### PR TITLE
Upgrade to arrow 40 which has stronger/better schema safety

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ authors = ["Zach Schuermann <zach@zvs.io>"]
 [dependencies]
 tracing = "0.1" # only for structured logging
 # todo depend only on the bits we need (arrow-schema, etc.)
-arrow = { version = "35.0", features = [ "json", "prettyprint" ]}
-parquet = "35.0" # need to generalize over arrow, arrow2 and diff parquet etc. (BYOP)
+arrow = { version = "^40.0", features = [ "json", "prettyprint" ]}
+parquet = "^40.0" # need to generalize over arrow, arrow2 and diff parquet etc. (BYOP)
 bytes = "1.4" # HACK only using this since ParquetRecordBatchReaderBuilder requires ChunkRead
 
 # required to deserialize DVs

--- a/src/scan/data_skipping.rs
+++ b/src/scan/data_skipping.rs
@@ -5,7 +5,7 @@ use tracing::debug;
 
 use arrow::datatypes::Field;
 use arrow::datatypes::Schema;
-use arrow::json::RawReaderBuilder;
+use arrow::json::ReaderBuilder;
 use std::io::BufReader;
 use std::sync::Arc;
 
@@ -46,12 +46,12 @@ pub(crate) fn data_skipping_filter(
     let stats_schema = Schema::new(vec![
         Field::new(
             "minValues",
-            arrow::datatypes::DataType::Struct(data_fields.clone()),
+            arrow::datatypes::DataType::Struct(data_fields.clone().into()),
             true,
         ),
         Field::new(
             "maxValues",
-            arrow::datatypes::DataType::Struct(data_fields),
+            arrow::datatypes::DataType::Struct(data_fields.into()),
             true,
         ),
     ]);
@@ -85,17 +85,17 @@ fn hack_parse(json_string: Option<&str>) -> RecordBatch {
     let stats_schema = Schema::new(vec![
         Field::new(
             "minValues",
-            arrow::datatypes::DataType::Struct(data_fields.clone()),
+            arrow::datatypes::DataType::Struct(data_fields.clone().into()),
             true,
         ),
         Field::new(
             "maxValues",
-            arrow::datatypes::DataType::Struct(data_fields.clone()),
+            arrow::datatypes::DataType::Struct(data_fields.clone().into()),
             true,
         ),
     ]);
     match json_string {
-        Some(s) => RawReaderBuilder::new(stats_schema.into())
+        Some(s) => ReaderBuilder::new(stats_schema.into())
             .build(BufReader::new(s.as_bytes()))
             .unwrap()
             .collect::<Vec<_>>()
@@ -107,11 +107,11 @@ fn hack_parse(json_string: Option<&str>) -> RecordBatch {
             stats_schema.into(),
             vec![
                 Arc::new(arrow::array::new_null_array(
-                    &arrow::datatypes::DataType::Struct(data_fields.clone()),
+                    &arrow::datatypes::DataType::Struct(data_fields.clone().into()),
                     1,
                 )),
                 Arc::new(arrow::array::new_null_array(
-                    &arrow::datatypes::DataType::Struct(data_fields),
+                    &arrow::datatypes::DataType::Struct(data_fields.into()),
                     1,
                 )),
             ],

--- a/tests/dv.rs
+++ b/tests/dv.rs
@@ -35,8 +35,8 @@ fn dv_table() -> Result<(), Box<dyn std::error::Error>> {
     {
         let batch = batch?;
         let rows = batch.num_rows();
-        assert_eq!(rows, 8);
         arrow::util::pretty::print_batches(&[batch]).unwrap();
+        assert_eq!(rows, 8);
     }
     Ok(())
 }


### PR DESCRIPTION
Upon upgrade to arrow 40, a schema mismatch error started to crop up to cause a failure in the dv_table test. The underlying problem is/was that the remove schema was incorrectly specifying that a non-null `stats` column which simply doesn't exist. This is likely just a copy/paste error from the `add` action since the Protocol[1] does not specify this column.

Older versions of arrow-rs do not properly validate schema conformance for fields masking this bug.

This change also manifests a :bug: with the API design of `LogFile.read`, which currently strives to return a Iterator of simply `Item = RecordBatch` while `ReaderBuilder` will yield an iterator of `Item = Result<RecordBatch, ArrowError>`. The erasure of the Result type in the `arrow::json::Reader::read` loop results in an infinite loop on _any_ `ArrowError yielded by the underlying Reader.

[1] <https://github.com/delta-io/delta/blob/master/PROTOCOL.md#add-file-and-remove-file>

Sponsored-by: Databricks Inc.