### PR TITLE
feat: add TableClient traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,9 @@ arrow-json = { version = "^42.0" }
 arrow-ord = { version = "^42.0" }
 arrow-schema = { version = "^42.0" }
 arrow-select = { version = "^42.0" }
+async-trait = "0.1"
 bytes = "1.4"
-futures = "*"
+futures = "0.3"
 # used for providing a storage abstraction layer
 object_store = "^0.6.0"
 # need to generalize over arrow, arrow2 and diff parquet etc. (BYOP)
@@ -30,8 +31,13 @@ roaring = "0.10.1"
 thiserror = "1"
 # only for structured logging
 tracing = "0.1"
+url = "2"
 uuid = "1.3.0"
 z85 = "3.0.5"
+
+[features]
+default = ["default-client"]
+default-client = []
 
 [build-dependencies]
 ureq = "2.2.0"
@@ -40,16 +46,17 @@ tar = "0.4.36"
 
 [dev-dependencies]
 arrow = { version = "^42.0", features = ["json", "prettyprint"] }
+datatest-stable = { version = "0.1.3" }
+serde = { version = "1.0.163", features = ["derive"] }
+serde_json = { version = "1.0.96" }
+test-log = { version = "0.2", default-features = false, features = ["trace"] }
+tempfile = "3"
+test-case = { version = "3.1.0" }
+tokio = { version = "1" }
 tracing-subscriber = { version = "0.3", default-features = false, features = [
   "env-filter",
   "fmt",
 ] }
-test-log = { version = "0.2", default-features = false, features = ["trace"] }
-test-case = { version = "3.1.0" }
-tokio = { version = "1" }
-serde = { version = "1.0.163", features = ["derive"] }
-serde_json = { version = "1.0.96" }
-datatest-stable = { version = "0.1.3" }
 
 [[test]]
 name = "dat_reader"

--- a/src/client/filesystem.rs
+++ b/src/client/filesystem.rs
@@ -1,0 +1,132 @@
+use std::sync::Arc;
+
+use bytes::Bytes;
+use futures::stream::{BoxStream, StreamExt, TryStreamExt};
+use object_store::path::Path;
+use object_store::DynObjectStore;
+use url::Url;
+
+use super::{FileMeta, FileSlice, FileSystemClient};
+use crate::{DeltaResult, Error};
+
+#[derive(Debug)]
+pub struct ObjectStoreFileSystemClient {
+    inner: Arc<DynObjectStore>,
+    prefix: Path,
+}
+
+impl ObjectStoreFileSystemClient {
+    pub fn new(store: Arc<DynObjectStore>, prefix: Path) -> Self {
+        Self {
+            inner: store,
+            prefix,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl FileSystemClient for ObjectStoreFileSystemClient {
+    async fn list_from(&self, path: &Url) -> DeltaResult<BoxStream<'_, DeltaResult<FileMeta>>> {
+        let url = path.clone();
+        let offset = Path::from(path.path());
+        Ok(self
+            .inner
+            .list_with_offset(Some(&self.prefix), &offset)
+            .await?
+            .map_err(Error::from)
+            .map_ok(move |meta| {
+                let mut location = url.clone();
+                location.set_path(&format!("/{}", meta.location.as_ref()));
+                FileMeta {
+                    location,
+                    last_modified: meta.last_modified.timestamp(),
+                    size: meta.size,
+                }
+            })
+            .boxed())
+    }
+
+    /// Read data specified by the start and end offset from the file.
+    async fn read_files(&self, files: Vec<FileSlice>) -> DeltaResult<Vec<Bytes>> {
+        let mut bytes = Vec::new();
+        for (url, range) in files {
+            let path = Path::from(url.path());
+            let data = self.inner.get_range(&path, range).await?;
+            bytes.push(data);
+        }
+        Ok(bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use object_store::{local::LocalFileSystem, ObjectStore};
+    use std::ops::Range;
+
+    #[tokio::test]
+    async fn test_list_from() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tmp_store = LocalFileSystem::new_with_prefix(tmp.path()).unwrap();
+
+        let data = Bytes::from("kernel-data");
+        tmp_store.put(&Path::from("a"), data.clone()).await.unwrap();
+        tmp_store.put(&Path::from("b"), data.clone()).await.unwrap();
+        tmp_store.put(&Path::from("c"), data.clone()).await.unwrap();
+
+        let mut url = Url::from_directory_path(tmp.path()).unwrap();
+
+        let store = Arc::new(LocalFileSystem::new());
+        let prefix = Path::from(url.path());
+        let client = ObjectStoreFileSystemClient::new(store, prefix);
+
+        url.set_path(&format!("{}/b", url.path().trim_end_matches('/')));
+
+        println!("{}", url.as_str());
+
+        let files = client
+            .list_from(&url)
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        assert_eq!(files.len(), 1);
+        assert!(files[0].location.as_ref().ends_with("/c"))
+    }
+
+    #[tokio::test]
+    async fn test_read_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tmp_store = LocalFileSystem::new_with_prefix(tmp.path()).unwrap();
+
+        let data = Bytes::from("kernel-data");
+        tmp_store.put(&Path::from("a"), data.clone()).await.unwrap();
+        tmp_store.put(&Path::from("b"), data.clone()).await.unwrap();
+        tmp_store.put(&Path::from("c"), data.clone()).await.unwrap();
+
+        let mut url = Url::from_directory_path(tmp.path()).unwrap();
+
+        let store = Arc::new(LocalFileSystem::new());
+        let prefix = Path::from(url.path());
+        let client = ObjectStoreFileSystemClient::new(store, prefix);
+
+        let mut slices: Vec<FileSlice> = Vec::new();
+
+        let mut url1 = url.clone();
+        url1.set_path(&format!("{}/b", url.path()));
+        slices.push((url1.clone(), Range { start: 0, end: 6 }));
+        slices.push((url1, Range { start: 7, end: 11 }));
+
+        url.set_path(&format!("{}/c", url.path()));
+        slices.push((url, Range { start: 4, end: 9 }));
+
+        let data = client.read_files(slices).await.unwrap();
+
+        assert_eq!(data.len(), 3);
+        assert_eq!(data[0], Bytes::from("kernel"));
+        assert_eq!(data[1], Bytes::from("data"));
+        assert_eq!(data[2], Bytes::from("el-da"));
+    }
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,0 +1,213 @@
+//! # TableClient interfaces
+//!
+//! The TableClient interfaces allow connectors to bring their own implementation of functionality
+//! such as reading parquet files, listing files in a file system, parsing a JSON string etc.
+//!
+//! The [`TableClient`] trait exposes methods to get sub-clients which expose the core
+//! functionalitites customizable by connectors.
+//!
+//! ## Expression handling
+//!
+//! Expression handling is done via the [`ExpressionHandler`], which in turn allows the creation
+//! of [`ExpressionEvaluator`]s. These evaluators are created for a specific predicate [`Expression`]
+//! and allow evaluation of that predicate for a specific batches of data.
+//!
+//! ## File system interactions
+//!
+//! Delta Kernel needs to perform some basic operations against file systems like listing and reading files.
+//! These interactions are encapsulated in the [`FileSystemClient`] trait. Implementors must take take
+//! care that all assumtions on the behavior if the functions - like sorted results - are respected.
+//!
+//! ## Reading log and data files
+//!
+//! Delta Kernel requires the capability to read json and parquet files, which is exposed via the
+//! [`JsonHandler`] and [`ParquetHandler`] respectively. When reading files, connectors are asked
+//! to provide the context imformation it requires to execute the actual read. This is done by
+//! invoking methods on the [`FileHandler`] trait. All specifc file handlers must also provide
+//! the contextualization APis.
+//!
+
+use std::ops::Range;
+use std::sync::Arc;
+
+use arrow_array::{RecordBatch, StringArray};
+use arrow_schema::SchemaRef;
+use bytes::Bytes;
+use futures::stream::BoxStream;
+use url::Url;
+
+use crate::{DeltaResult, Expression};
+
+#[cfg(feature = "default-client")]
+pub mod filesystem;
+#[cfg(feature = "default-client")]
+pub mod table;
+
+pub type FileSlice = (Url, Range<usize>);
+
+/// Data read from a Delta table file and the corresponding scan file information.
+pub type FileDataReadResult = (FileMeta, RecordBatch);
+
+/// The metadata that describes an object.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileMeta {
+    /// The fully qualified path to the object
+    pub location: Url,
+    /// The last modified time
+    pub last_modified: i64,
+    /// The size in bytes of the object
+    pub size: usize,
+}
+
+/// Interface for implementing an Expression evaluator.
+///
+/// It contains one Expression which can be evaluated on multiple ColumnarBatches.
+/// Connectors can implement this interface to optimize the evaluation using the
+/// connector specific capabilities.
+pub trait ExpressionEvaluator {
+    /// Evaluate the expression on given ColumnarBatch data.
+    ///
+    /// Contains one value for each row of the input.
+    /// The data type of the output is same as the type output of the expression this evaluator is using.
+    fn evaluate(&self, batch: &RecordBatch) -> DeltaResult<RecordBatch>;
+}
+
+/// Provides expression evaluation capability to Delta Kernel.
+///
+/// Delta Kernel can use this client to evaluate predicate on partition filters,
+/// fill up partition column values and any computation on data using Expressions.
+pub trait ExpressionHandler {
+    /// Create an [`ExpressionEvaluator`] that can evaluate the given [`Expression`]
+    /// on columnar batchs with the given [`Schema`].
+    ///
+    /// # Parameters
+    ///
+    /// - `schema`: Schema of the input data.
+    /// - `expression`: Expression to evaluate.
+    ///
+    /// [`Schema`]: arrow_schema::Schema
+    fn get_evaluator(
+        &self,
+        schema: SchemaRef,
+        expression: Expression,
+    ) -> Arc<dyn ExpressionEvaluator>;
+}
+
+/// Provides file system related functionalities to Delta Kernel.
+///
+/// Delta Kernel uses this client whenever it needs to access the underlying
+/// file system where the Delta table is present. Connector implementation of
+/// this interface can hide filesystem specific details from Delta Kernel.
+#[async_trait::async_trait]
+pub trait FileSystemClient {
+    /// List the paths in the same directory that are lexicographically greater or equal to
+    /// (UTF-8 sorting) the given `path`. The result should also be sorted by the file name.
+    async fn list_from(&self, path: &Url) -> DeltaResult<BoxStream<'_, DeltaResult<FileMeta>>>;
+
+    /// Read data specified by the start and end offset from the file.
+    async fn read_files(&self, files: Vec<FileSlice>) -> DeltaResult<Vec<Bytes>>;
+}
+
+/// Provides file handling functionality to Delta Kernel.
+///
+/// Connectors can implement this client to provide Delta Kernel
+/// their own custom implementation of file splitting, additional
+/// predicate pushdown or any other connector-specific capabilities.
+pub trait FileHandler {
+    /// Placeholder interface allowing connectors to attach their own custom implementation.
+    ///
+    /// Connectors can use this to pass additional context about a scan file through
+    /// Delta Kernel and back to the connector for interpretation.
+    type FileReadContext: Send;
+
+    /// Associates a connector specific FileReadContext for each scan file.
+    ///
+    /// Delta Kernel will supply the returned FileReadContexts back to
+    /// the connector when reading the file (for example, in ParquetHandler.readParquetFiles.
+    /// Delta Kernel does not interpret FileReadContext. For example, a connector can attach
+    /// split information in its own implementation of FileReadContext or attach any predicates.
+    ///
+    /// # Parameters
+    ///
+    /// - `files` - iterator of [`FileMeta`]
+    /// - `predicate` - Predicate to prune data. This is optional for the
+    ///   connector to use for further optimization. Filtering by this predicate is not required.
+    fn contextualize_file_reads(
+        &self,
+        files: Vec<FileMeta>,
+        predicate: Option<Expression>,
+    ) -> DeltaResult<Vec<Self::FileReadContext>>;
+}
+
+/// Provides JSON handling functionality to Delta Kernel.
+///
+/// Delta Kernel can use this client to parse JSON strings into Row or read content from JSON files.
+/// Connectors can leverage this interface to provide their best implementation of the JSON parsing
+/// capability to Delta Kernel.
+#[async_trait::async_trait]
+pub trait JsonHandler: FileHandler {
+    /// Parse the given json strings and return the fields requested by output schema as columns in a [`RecordBatch`].
+    fn parse_json(
+        &self,
+        json_strings: StringArray,
+        output_schema: SchemaRef,
+    ) -> DeltaResult<RecordBatch>;
+
+    /// Read and parse the JSON format file at given locations and return
+    /// the data as a RecordBatch with the columns requested by physical schema.
+    ///
+    /// # Parameters
+    ///
+    /// - `files` - Vec of FileReadContext objects to read data from.
+    /// - `physical_schema` - Select list of columns to read from the JSON file.
+    async fn read_json_files(
+        &self,
+        files: Vec<<Self as FileHandler>::FileReadContext>,
+        physical_schema: SchemaRef,
+    ) -> DeltaResult<Vec<FileDataReadResult>>;
+}
+
+/// Provides Parquet file related functionalities to Delta Kernel.
+///
+/// Connectors can leverage this interface to provide their own custom
+/// implementation of Parquet data file functionalities to Delta Kernel.
+#[async_trait::async_trait]
+pub trait ParquetHandler: FileHandler {
+    /// Read and parse the JSON format file at given locations and return
+    /// the data as a RecordBatch with the columns requested by physical schema.
+    ///
+    /// # Parameters
+    ///
+    /// - `files` - Vec of FileReadContext objects to read data from.
+    /// - `physical_schema` - Select list of columns to read from the JSON file.
+    async fn read_parquet_files(
+        &self,
+        files: Vec<<Self as FileHandler>::FileReadContext>,
+        physical_schema: SchemaRef,
+    ) -> DeltaResult<Vec<FileDataReadResult>>;
+}
+
+/// Interface encapsulating all clients needed by the Delta Kernel in order to read the Delta table.
+///
+/// Connectors are expected to pass an implementation of this interface when reading a Delta table.
+pub trait TableClient {
+    /// Read context when operating on json files
+    type JsonReadContext: Send;
+
+    /// Read context when operating on parquet files
+    type ParquetReadContext: Send;
+
+    /// Get the connector provided [`ExpressionHandler`].
+    fn get_expression_handler(&self) -> Arc<dyn ExpressionHandler>;
+
+    /// Get the connector provided [`FileSystemClient`]
+    fn get_file_system_client(&self) -> Arc<dyn FileSystemClient>;
+
+    /// Get the connector provided [`JsonHandler`].
+    fn get_json_handler(&self) -> Arc<dyn JsonHandler<FileReadContext = Self::JsonReadContext>>;
+
+    /// Get the connector provided [`ParquetHandler`].
+    fn get_parquet_handler(
+        &self,
+    ) -> Arc<dyn ParquetHandler<FileReadContext = Self::ParquetReadContext>>;
+}

--- a/src/client/table.rs
+++ b/src/client/table.rs
@@ -1,0 +1,52 @@
+use std::sync::Arc;
+
+use object_store::{parse_url_opts, ObjectMeta};
+use url::Url;
+
+use super::filesystem::ObjectStoreFileSystemClient;
+use super::{ExpressionHandler, FileSystemClient, JsonHandler, ParquetHandler, TableClient};
+use crate::DeltaResult;
+
+#[derive(Debug)]
+pub struct DefaultTableClient {
+    file_system: Arc<ObjectStoreFileSystemClient>,
+}
+
+impl DefaultTableClient {
+    /// Create a new [`DefaultTableClient`] instnance
+    pub fn try_new<I, K, V>(path: impl AsRef<Url>, options: I) -> DeltaResult<Self>
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: AsRef<str>,
+        V: Into<String>,
+    {
+        let (store, prefix) = parse_url_opts(path.as_ref(), options)?;
+        let client = ObjectStoreFileSystemClient::new(Arc::new(store), prefix);
+        Ok(Self {
+            file_system: Arc::new(client),
+        })
+    }
+}
+
+impl TableClient for DefaultTableClient {
+    type JsonReadContext = ObjectMeta;
+    type ParquetReadContext = ObjectMeta;
+
+    fn get_expression_handler(&self) -> Arc<dyn ExpressionHandler> {
+        todo!()
+    }
+
+    fn get_file_system_client(&self) -> Arc<dyn FileSystemClient> {
+        self.file_system.clone()
+    }
+
+    fn get_json_handler(&self) -> Arc<dyn JsonHandler<FileReadContext = Self::JsonReadContext>> {
+        todo!()
+    }
+
+    fn get_parquet_handler(
+        &self,
+    ) -> Arc<dyn ParquetHandler<FileReadContext = Self::ParquetReadContext>> {
+        todo!()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,9 +17,12 @@ use tracing::*;
 /// Includes top-level DeltaTable type which can construct Snapshots
 pub mod table;
 pub use table::Table;
+pub mod client;
+pub use client::*;
 
 /// defines a common expression language for use in data skipping predicates
 pub mod expressions;
+pub use expressions::Expression;
 
 /// generic parquet interface
 pub mod parquet_reader;


### PR DESCRIPTION
Had some time to kill on the plane and worked a bit on Kernel.

In this first PR we add Traits for the `TableClient` APIs closely following the java APIs. There are some smaller deviations in how the `FileReadContext` is defined. I thought that might be a bit more idiomatic, for Rust, but happy to heart feedback. In some follow ups (after cleaning a bit), I'll add some default implementations, which may still change these traits.

@schuermannator @rtyler @tdas @wjones127