### PR TITLE
Add visibility crate and use it a bit

### DIFF
--- a/acceptance/Cargo.toml
+++ b/acceptance/Cargo.toml
@@ -11,7 +11,7 @@ readme.workspace = true
 version.workspace = true
 
 [dependencies]
-deltakernel = { path = "../kernel" }
+deltakernel = { path = "../kernel", features = ["developer-visibility"] }
 futures = "0.3"
 object_store = "^0.7.0"
 serde = { version = "1", features = ["derive"] }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -33,6 +33,9 @@ url = "2"
 uuid = "1.3.0"
 z85 = "3.0.5"
 
+# used for developer-visibility
+visibility = "0.1.0"
+
 # Used in default client
 futures = { version = "0.3", optional = true }
 object_store = { version = "^0.7.0", optional = true }
@@ -44,6 +47,7 @@ tokio = { version = "1", optional = true, features=["rt-multi-thread"] }
 [features]
 default = ["default-client"]
 default-client = ["chrono", "futures", "object_store", "parquet"]
+developer-visibility = []
 
 [dev-dependencies]
 arrow = { version = "^46.0", features = ["json", "prettyprint"] }

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -22,7 +22,9 @@ use crate::{DeltaResult, Error, FileMeta, FileSystemClient, TableClient, Version
 const LAST_CHECKPOINT_FILE_NAME: &str = "_last_checkpoint";
 
 #[derive(Debug)]
-pub struct LogSegment {
+#[cfg_attr(feature = "developer-visibility", visibility::make(pub))]
+#[cfg_attr(not(feature = "developer-visibility"), visibility::make(pub(crate)))]
+struct LogSegment {
     log_root: Url,
     /// Reverse order sorted commit files in the log segment
     pub(crate) commit_files: Vec<FileMeta>,
@@ -39,7 +41,7 @@ impl LogSegment {
     /// to project the log files to a subset of the columns.
     ///
     /// `predicate` is an optional expression to filter the log files with.
-    pub fn replay<JRC: Send, PRC: Send>(
+    pub(crate) fn replay<JRC: Send, PRC: Send>(
         &self,
         table_client: &dyn TableClient<JsonReadContext = JRC, ParquetReadContext = PRC>,
         read_schema: Arc<ArrowSchema>,
@@ -193,7 +195,7 @@ impl<JRC: Send, PRC: Send + Sync> Snapshot<JRC, PRC> {
     }
 
     /// Create a new [`Snapshot`] instance.
-    pub fn new(
+    pub(crate) fn new(
         location: Url,
         client: Arc<dyn TableClient<JsonReadContext = JRC, ParquetReadContext = PRC>>,
         log_segment: LogSegment,
@@ -266,21 +268,24 @@ impl<JRC: Send, PRC: Send + Sync> Snapshot<JRC, PRC> {
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CheckpointMetadata {
+#[cfg_attr(feature = "developer-visibility", visibility::make(pub))]
+#[cfg_attr(not(feature = "developer-visibility"), visibility::make(pub(crate)))]
+struct CheckpointMetadata {
     /// The version of the table when the last checkpoint was made.
+    #[allow(unreachable_pub)] // used by acceptance tests (TODO make an fn accessor?)
     pub version: Version,
     /// The number of actions that are stored in the checkpoint.
-    pub size: i32,
+    pub(crate) size: i32,
     /// The number of fragments if the last checkpoint was written in multiple parts.
-    pub parts: Option<i32>,
+    pub(crate) parts: Option<i32>,
     /// The number of bytes of the checkpoint.
-    pub size_in_bytes: Option<i32>,
+    pub(crate) size_in_bytes: Option<i32>,
     /// The number of AddFile actions in the checkpoint.
-    pub num_of_add_files: Option<i32>,
+    pub(crate) num_of_add_files: Option<i32>,
     /// The schema of the checkpoint file.
-    pub checkpoint_schema: Option<Schema>,
+    pub(crate) checkpoint_schema: Option<Schema>,
     /// The checksum of the last checkpoint JSON.
-    pub checksum: Option<String>,
+    pub(crate) checksum: Option<String>,
 }
 
 /// Try reading the `_last_checkpoint` file.


### PR DESCRIPTION
We'd like to expose a few more internals (like `LogSegment` or `CheckpointMetadata`) to developer focused tools. For example, a program that wants to read and print each action might be useful (and is being developed in another soon to be pushed branch).

Likewise, the acceptance tests use `CheckpointMetadata` which required it to be `pub`, but it really shouldn't be in most use cases.

This PR adds a dependency on the [visibility](https://crates.io/crates/visibility) crate, which is basically just a proc-macro that lets us conditionally set the visibility of items, and applies it (for now) to `LogSegment` and `CheckpointMetadata`).

It also adds a "developer-visibility" feature that we use to set the visibility as specified.

The `visibility` crate is really simple, it's just a single macro (see [here](https://github.com/danielhenrymantilla/visibility.rs/blob/master/src/lib.rs)). We could implement it ourselves if we want to keep dependencies down, but since it's a proc macro it does have to be in its own crate, so we'd have to add another crate to our workspace for it.  `visibility` pulls in `quote`, `syn` and `proc-macro2`, but we already depend on those in  numerous other ways.