### PR TITLE
Protect Snapshot with Arc so Scan[Builder] can safely reference it

### DIFF
--- a/kernel/src/table.rs
+++ b/kernel/src/table.rs
@@ -41,7 +41,7 @@ impl<JRC: Send, PRC: Send + Sync> Table<JRC, PRC> {
     /// Create a [`Snapshot`] of the table corresponding to `version`.
     ///
     /// If no version is supplied, a snapshot for the latest version will be created.
-    pub fn snapshot(&self, version: Option<Version>) -> DeltaResult<Snapshot<JRC, PRC>> {
+    pub fn snapshot(&self, version: Option<Version>) -> DeltaResult<Arc<Snapshot<JRC, PRC>>> {
         Snapshot::try_new(self.location.clone(), self.table_client.clone(), version)
     }
 }

--- a/kernel/tests/dv.rs
+++ b/kernel/tests/dv.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use deltakernel::client::DefaultTableClient;
 use deltakernel::executor::tokio::TokioBackgroundExecutor;
+use deltakernel::scan::ScanBuilder;
 use deltakernel::Table;
 
 #[test]
@@ -19,7 +20,7 @@ fn dv_table() -> Result<(), Box<dyn std::error::Error>> {
 
     let table = Table::new(url, table_client);
     let snapshot = table.snapshot(None)?;
-    let scan = snapshot.scan()?.build();
+    let scan = ScanBuilder::try_new(snapshot)?.build();
 
     let stream = scan.execute()?;
     for batch in stream {
@@ -42,7 +43,7 @@ fn non_dv_table() -> Result<(), Box<dyn std::error::Error>> {
 
     let table = Table::new(url, table_client);
     let snapshot = table.snapshot(None)?;
-    let scan = snapshot.scan()?.build();
+    let scan = ScanBuilder::try_new(snapshot)?.build();
 
     let stream = scan.execute()?;
     for batch in stream {

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -6,6 +6,7 @@ use arrow::record_batch::RecordBatch;
 use deltakernel::client::DefaultTableClient;
 use deltakernel::executor::tokio::TokioBackgroundExecutor;
 use deltakernel::expressions::Expression;
+use deltakernel::scan::ScanBuilder;
 use deltakernel::Table;
 use object_store::{memory::InMemory, path::Path, ObjectStore};
 use parquet::arrow::arrow_writer::ArrowWriter;
@@ -97,7 +98,7 @@ async fn single_commit_two_add_files() -> Result<(), Box<dyn std::error::Error>>
     let expected_data = vec![batch.clone(), batch];
 
     let snapshot = table.snapshot(None)?;
-    let scan = snapshot.scan()?.build();
+    let scan = ScanBuilder::try_new(snapshot)?.build();
 
     let mut files = 0;
     let stream = scan.execute()?.into_iter().zip(expected_data);
@@ -147,7 +148,7 @@ async fn two_commits() -> Result<(), Box<dyn std::error::Error>> {
     let expected_data = vec![batch.clone(), batch];
 
     let snapshot = table.snapshot(None).unwrap();
-    let scan = snapshot.scan()?.build();
+    let scan = ScanBuilder::try_new(snapshot)?.build();
 
     let mut files = 0;
     let stream = scan.execute()?.into_iter().zip(expected_data);
@@ -201,7 +202,7 @@ async fn remove_action() -> Result<(), Box<dyn std::error::Error>> {
     let expected_data = vec![batch];
 
     let snapshot = table.snapshot(None)?;
-    let scan = snapshot.scan()?.build();
+    let scan = ScanBuilder::try_new(snapshot)?.build();
 
     let stream = scan.execute()?.into_iter().zip(expected_data);
 
@@ -263,7 +264,9 @@ async fn stats() -> Result<(), Box<dyn std::error::Error>> {
     let snapshot = table.snapshot(None)?;
 
     let predicate = Expression::column("ids").lt(Expression::literal(2));
-    let scan = snapshot.scan()?.with_predicate(predicate).build();
+    let scan = ScanBuilder::try_new(snapshot)?
+        .with_predicate(predicate)
+        .build();
 
     let mut files = 0;
     let stream = scan.execute()?.into_iter().zip(expected_data);


### PR DESCRIPTION
Today, creating a scan consumes the snapshot that produced it. That means scanning the "same" snapshot N times requires recreating the snapshot N times, which includes paying the protocol+metadata query each time. This happens because `Scan` (and the `ScanBuilder` that produced it) needs most of the snapshot's internal state, and we don't want to copy it.

To fix this, we now protect all `Snapshot` instances with `Arc` so that the Scan[Builder] can simply reference the Snapshot that produced it.