### PR TITLE
Remove file contextualization concept from kernel code

### DIFF
--- a/acceptance/src/meta.rs
+++ b/acceptance/src/meta.rs
@@ -96,10 +96,7 @@ impl TestCaseInfo {
         Ok(())
     }
 
-    pub async fn assert_metadata<JRC: Send, PRC: Send + Sync>(
-        &self,
-        table_client: Arc<dyn TableClient<JsonReadContext = JRC, ParquetReadContext = PRC>>,
-    ) -> TestResult<()> {
+    pub async fn assert_metadata(&self, table_client: Arc<dyn TableClient>) -> TestResult<()> {
         let table_client = table_client.as_ref();
         let table = Table::new(self.table_root()?);
 

--- a/kernel/src/client/mod.rs
+++ b/kernel/src/client/mod.rs
@@ -16,8 +16,8 @@ use url::Url;
 use self::executor::TaskExecutor;
 use self::expression::DefaultExpressionHandler;
 use self::filesystem::ObjectStoreFileSystemClient;
-use self::json::{DefaultJsonHandler, JsonReadContext};
-use self::parquet::{DefaultParquetHandler, ParquetReadContext};
+use self::json::DefaultJsonHandler;
+use self::parquet::DefaultParquetHandler;
 use crate::{
     DeltaResult, ExpressionHandler, FileSystemClient, JsonHandler, ParquetHandler, TableClient,
 };
@@ -94,9 +94,6 @@ impl<E: TaskExecutor> DefaultTableClient<E> {
 }
 
 impl<E: TaskExecutor> TableClient for DefaultTableClient<E> {
-    type JsonReadContext = JsonReadContext;
-    type ParquetReadContext = ParquetReadContext;
-
     fn get_expression_handler(&self) -> Arc<dyn ExpressionHandler> {
         self.expression.clone()
     }
@@ -105,13 +102,11 @@ impl<E: TaskExecutor> TableClient for DefaultTableClient<E> {
         self.file_system.clone()
     }
 
-    fn get_json_handler(&self) -> Arc<dyn JsonHandler<FileReadContext = Self::JsonReadContext>> {
+    fn get_json_handler(&self) -> Arc<dyn JsonHandler> {
         self.json.clone()
     }
 
-    fn get_parquet_handler(
-        &self,
-    ) -> Arc<dyn ParquetHandler<FileReadContext = Self::ParquetReadContext>> {
+    fn get_parquet_handler(&self) -> Arc<dyn ParquetHandler> {
         self.parquet.clone()
     }
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -137,43 +137,12 @@ pub trait FileSystemClient: Send + Sync {
     ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<Bytes>>>>;
 }
 
-/// Provides file handling functionality to Delta Kernel.
-///
-/// Connectors can implement this client to provide Delta Kernel
-/// their own custom implementation of file splitting, additional
-/// predicate pushdown or any other connector-specific capabilities.
-pub trait FileHandler {
-    /// Placeholder interface allowing connectors to attach their own custom implementation.
-    ///
-    /// Connectors can use this to pass additional context about a scan file through
-    /// Delta Kernel and back to the connector for interpretation.
-    type FileReadContext: Send;
-
-    /// Associates a connector specific FileReadContext for each scan file.
-    ///
-    /// Delta Kernel will supply the returned FileReadContexts back to
-    /// the connector when reading the file (for example, in ParquetHandler.readParquetFiles.
-    /// Delta Kernel does not interpret FileReadContext. For example, a connector can attach
-    /// split information in its own implementation of FileReadContext or attach any predicates.
-    ///
-    /// # Parameters
-    ///
-    /// - `files` - iterator of [`FileMeta`]
-    /// - `predicate` - Predicate to prune data. This is optional for the
-    ///   connector to use for further optimization. Filtering by this predicate is not required.
-    fn contextualize_file_reads(
-        &self,
-        files: &[FileMeta],
-        predicate: Option<Expression>,
-    ) -> DeltaResult<Vec<Self::FileReadContext>>;
-}
-
 /// Provides JSON handling functionality to Delta Kernel.
 ///
 /// Delta Kernel can use this client to parse JSON strings into Row or read content from JSON files.
 /// Connectors can leverage this interface to provide their best implementation of the JSON parsing
 /// capability to Delta Kernel.
-pub trait JsonHandler: FileHandler {
+pub trait JsonHandler {
     /// Parse the given json strings and return the fields requested by output schema as columns in a [`RecordBatch`].
     fn parse_json(
         &self,
@@ -186,12 +155,14 @@ pub trait JsonHandler: FileHandler {
     ///
     /// # Parameters
     ///
-    /// - `files` - Vec of FileReadContext objects to read data from.
+    /// - `files` - File metadata for files to be read.
     /// - `physical_schema` - Select list of columns to read from the JSON file.
+    /// - `predicate` - Optional push-down predicate hint (engine is free to ignore it).
     fn read_json_files(
         &self,
-        files: &[Self::FileReadContext],
+        files: &[FileMeta],
         physical_schema: SchemaRef,
+        predicate: Option<Expression>,
     ) -> DeltaResult<FileDataReadResultIterator>;
 }
 
@@ -199,18 +170,20 @@ pub trait JsonHandler: FileHandler {
 ///
 /// Connectors can leverage this interface to provide their own custom
 /// implementation of Parquet data file functionalities to Delta Kernel.
-pub trait ParquetHandler: FileHandler + Send + Sync {
+pub trait ParquetHandler: Send + Sync {
     /// Read and parse the JSON format file at given locations and return
     /// the data as a RecordBatch with the columns requested by physical schema.
     ///
     /// # Parameters
     ///
-    /// - `files` - Vec of FileReadContext objects to read data from.
+    /// - `files` - File metadata for files to be read.
     /// - `physical_schema` - Select list of columns to read from the JSON file.
+    /// - `predicate` - Optional push-down predicate hint (engine is free to ignore it).
     fn read_parquet_files(
         &self,
-        files: Vec<<Self as FileHandler>::FileReadContext>,
+        files: &[FileMeta],
         physical_schema: SchemaRef,
+        predicate: Option<Expression>,
     ) -> DeltaResult<FileDataReadResultIterator>;
 }
 
@@ -218,12 +191,6 @@ pub trait ParquetHandler: FileHandler + Send + Sync {
 ///
 /// Connectors are expected to pass an implementation of this interface when reading a Delta table.
 pub trait TableClient {
-    /// Read context when operating on json files
-    type JsonReadContext: Send;
-
-    /// Read context when operating on parquet files
-    type ParquetReadContext: Send;
-
     /// Get the connector provided [`ExpressionHandler`].
     fn get_expression_handler(&self) -> Arc<dyn ExpressionHandler>;
 
@@ -231,10 +198,8 @@ pub trait TableClient {
     fn get_file_system_client(&self) -> Arc<dyn FileSystemClient>;
 
     /// Get the connector provided [`JsonHandler`].
-    fn get_json_handler(&self) -> Arc<dyn JsonHandler<FileReadContext = Self::JsonReadContext>>;
+    fn get_json_handler(&self) -> Arc<dyn JsonHandler>;
 
     /// Get the connector provided [`ParquetHandler`].
-    fn get_parquet_handler(
-        &self,
-    ) -> Arc<dyn ParquetHandler<FileReadContext = Self::ParquetReadContext>>;
+    fn get_parquet_handler(&self) -> Arc<dyn ParquetHandler>;
 }

--- a/kernel/src/table.rs
+++ b/kernel/src/table.rs
@@ -34,9 +34,9 @@ impl Table {
     /// Create a [`Snapshot`] of the table corresponding to `version`.
     ///
     /// If no version is supplied, a snapshot for the latest version will be created.
-    pub fn snapshot<JRC: Send, PRC: Send + Sync>(
+    pub fn snapshot(
         &self,
-        table_client: &dyn TableClient<JsonReadContext = JRC, ParquetReadContext = PRC>,
+        table_client: &dyn TableClient,
         version: Option<Version>,
     ) -> DeltaResult<Arc<Snapshot>> {
         Snapshot::try_new(self.location.clone(), table_client, version)


### PR DESCRIPTION
Originally, we thought it would be a useful engine hook point for kernel to expose a notion of "file contextualization" -- a place where file splitting and distributed scheduling could potentially be applied. However, exploration on the kernel-jvm side showed that neither is true. The _engine_ may need to contextualize files internally, but _kernel_ doesn't need to know or care either way. Instead, the engine can directly consume the `FileMeta` and file splitting etc can be hidden behind the resulting iterator of data batches.

Also based on kernel-jvm explorations, we will eventually need to update the read API so that engine receives (and forwards back to kernel) some kernel-specific per-file state that is opaque to the engine. That way, kernel can easily identify the file each batch came from, in order to e.g. apply deletion vectors. But we'll leave that as future work: https://github.com/delta-incubator/delta-kernel-rs/issues/97