### PR TITLE
clean up dv parsing code

### DIFF
--- a/kernel/src/actions/deletion_vector.rs
+++ b/kernel/src/actions/deletion_vector.rs
@@ -142,7 +142,12 @@ impl DeletionVectorDescriptor {
                 // get the Bytes back out and limit it to dv_size
                 let position = cursor.position();
                 let mut bytes = cursor.into_inner();
-                bytes.truncate((position + dv_size as u64) as usize);
+                let truncate_pos = position + dv_size as u64;
+                assert!(
+                    truncate_pos <= usize::MAX as u64,
+                    "Can't truncate as truncate_pos is > usize::MAX"
+                );
+                bytes.truncate(truncate_pos as usize);
                 let mut cursor = Cursor::new(bytes);
                 cursor.set_position(position);
                 RoaringTreemap::deserialize_from(cursor)


### PR DESCRIPTION
This PR does a few things:

- ensure dv file version is 1
- properly get out the size from the file and ensure it matches what the add file says (this is also what spark does [here](https://github.com/delta-io/delta/blob/master/spark/src/main/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorStore.scala#L125))
- Don't copy the data into a new buffer before parsing the RoaringTreemap

Resolves #125 