### PR TITLE
Simplify and clean up data skipping logic a bit

### DIFF
--- a/kernel/src/engine/arrow_expression.rs
+++ b/kernel/src/engine/arrow_expression.rs
@@ -319,7 +319,8 @@ fn evaluate_expression(
                 Equal => |l, r| eq(l, r).map(wrap_comparison_result),
                 NotEqual => |l, r| neq(l, r).map(wrap_comparison_result),
                 Distinct => |l, r| distinct(l, r).map(wrap_comparison_result),
-                _ => return Err(Error::generic("Invalid expression given")),
+                // NOTE: [Not]In was already covered above
+                In | NotIn => return Err(Error::generic("Invalid expression given")),
             };
 
             eval(&left_arr, &right_arr).map_err(Error::generic_err)


### PR DESCRIPTION
Several cleanups to the data skipping logic (partly inspired by recently added parquet stats skipping logic):
* Reorder `Expression` match arms to match declaration order
* Add an `inverted` flag to the data skipping expression logic, which allows to more easily push NOT down
  * Remove `as_inverted_data_skipping_predicate` (no longer needed)
  * Collapse the four {tight, wide} x {null, not null} helper methods into just tight and wide helpers
* Add support for boolean literals and columns 
  * They don't necessarily have good skipping power, but defaulting them to NULL can disable skipping
  * i.e. `FALSE OR <expr>` and `<col> OR <expr>` no longer blocks data skipping on `<expr>`
* No longer create new expressions that need to be passed to `as_data_skipping_predicate` (e.g. `Equal` comparison)
* Make `NotEqual` data skipping logic a bit easier to grok