### PR TITLE
[chore] add macro tests

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -8,8 +8,10 @@ license.workspace = true
 repository.workspace = true
 readme.workspace = true
 version.workspace = true
-# exclude golden tests + golden test data since they push us over 10MB crate size limit
-exclude = ["tests/golden_tables.rs", "tests/golden_data/" ]
+# exclude 
+# - golden tests + golden test data since they push us over 10MB crate size limit
+# - macro tests as those are run via unittests
+exclude = ["tests/golden_tables.rs", "tests/golden_data/", "tests/macros/"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -121,3 +123,5 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
   "env-filter",
   "fmt",
 ] }
+trybuild = "1.0.25"
+syn = { version = "2.0", features = ["extra-traits"] }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -248,3 +248,20 @@ pub trait Engine: Send + Sync {
     /// Get the connector provided [`ParquetHandler`].
     fn get_parquet_handler(&self) -> Arc<dyn ParquetHandler>;
 }
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn test_derive_macros() {
+        use trybuild;
+
+        let t = trybuild::TestCases::new();
+        t.pass("tests/macros/schema_on_struct.rs");
+        t.pass("tests/macros/schema_with_attributed_field.rs");
+        t.pass("tests/macros/schema_with_angle_bracketed_path.rs");
+        t.compile_fail("tests/macros/schema_empty_struct.rs");
+        t.compile_fail("tests/macros/schema_with_invalid_attribute_target.rs");
+        t.compile_fail("tests/macros/schema_with_invalid_field_type.rs");
+    }
+}

--- a/kernel/tests/macros/actions.rs
+++ b/kernel/tests/macros/actions.rs
@@ -1,0 +1,66 @@
+pub mod schemas {
+    use crate::schema::DataType;
+    use crate::schema::MapType;
+    use crate::schema::StructField;
+    use std::collections::HashMap;
+
+    pub trait ToDataType {
+        fn to_data_type() -> DataType;
+    }
+
+    pub(crate) trait ToNullableContainerType {
+        fn to_nullable_container_type() -> DataType;
+    }
+
+    pub trait GetStructField {
+        fn get_struct_field(name: impl Into<String>) -> StructField;
+    }
+
+    pub trait GetNullableContainerStructField {
+        fn get_nullable_container_struct_field(name: impl Into<String>) -> StructField;
+    }
+
+    impl<T: ToNullableContainerType> GetNullableContainerStructField for T {
+        fn get_nullable_container_struct_field(name: impl Into<String>) -> StructField {
+            StructField::new(name, T::to_nullable_container_type(), false)
+        }
+    }
+
+    macro_rules! impl_to_data_type {
+        ( $(($rust_type: ty, $kernel_type: expr)), * ) => {
+            $(
+                impl ToDataType for $rust_type {
+                    fn to_data_type() -> DataType {
+                        $kernel_type
+                    }
+                }
+            )*
+        };
+    }
+
+    impl_to_data_type!((String, DataType::STRING));
+
+    impl<T: ToDataType> GetStructField for T {
+        fn get_struct_field(name: impl Into<String>) -> StructField {
+            StructField::new(name, T::to_data_type(), false)
+        }
+    }
+
+    impl<K: ToDataType, V: ToDataType> ToDataType for HashMap<K, V> {
+        fn to_data_type() -> DataType {
+            MapType::new(K::to_data_type(), V::to_data_type(), false).into()
+        }
+    }
+
+    impl<A: ToDataType, B: ToDataType, C: ToDataType> ToDataType for Box<dyn Fn(A, B) -> C> {
+        fn to_data_type() -> DataType {
+            MapType::new(A::to_data_type(), B::to_data_type(), false).into()
+        }
+    }
+
+    impl<K: ToDataType, V: ToDataType> ToNullableContainerType for HashMap<K, V> {
+        fn to_nullable_container_type() -> DataType {
+            MapType::new(K::to_data_type(), V::to_data_type(), true).into()
+        }
+    }
+}

--- a/kernel/tests/macros/schema.rs
+++ b/kernel/tests/macros/schema.rs
@@ -1,0 +1,81 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum PrimitiveType {
+    String,
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq, Clone, Eq)]
+pub struct StructType {
+    pub type_name: String,
+    pub fields: Vec<String>,
+}
+
+impl StructType {
+    pub fn new(fields: impl IntoIterator<Item = StructField>) -> Self {
+        Self {
+            type_name: "struct".into(),
+            fields: fields.into_iter().map(|f| f.name.clone()).collect(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct MapType {
+    #[serde(rename = "type")]
+    pub type_name: String,
+    pub key_type: DataType,
+    pub value_type: DataType,
+    pub value_contains_null: bool,
+}
+
+impl MapType {
+    pub fn new(key_type: DataType, value_type: DataType, value_contains_null: bool) -> Self {
+        Self {
+            type_name: "map".into(),
+            key_type,
+            value_type,
+            value_contains_null,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq)]
+#[serde(untagged, rename_all = "camelCase")]
+pub enum DataType {
+    Primitive(PrimitiveType),
+    Struct(Box<StructType>),
+    Map(Box<MapType>),
+}
+
+impl DataType {
+    pub const STRING: Self = DataType::Primitive(PrimitiveType::String);
+
+    pub fn struct_type(fields: impl IntoIterator<Item = StructField>) -> Self {
+        StructType::new(fields).into()
+    }
+}
+
+impl From<MapType> for DataType {
+    fn from(map_type: MapType) -> Self {
+        DataType::Map(Box::new(map_type))
+    }
+}
+
+impl From<StructType> for DataType {
+    fn from(struct_type: StructType) -> Self {
+        DataType::Struct(Box::new(struct_type))
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq)]
+pub struct StructField {
+    pub name: String,
+}
+impl StructField {
+    pub fn new(name: impl Into<String>, _data_type: impl Into<DataType>, _nullable: bool) -> Self {
+        Self { name: name.into() }
+    }
+}

--- a/kernel/tests/macros/schema_empty_struct.rs
+++ b/kernel/tests/macros/schema_empty_struct.rs
@@ -1,0 +1,10 @@
+extern crate delta_kernel_derive;
+use delta_kernel_derive::Schema;
+
+mod actions;
+mod schema;
+
+#[derive(Schema)]
+pub struct NoFields;
+
+fn main() {}

--- a/kernel/tests/macros/schema_empty_struct.stderr
+++ b/kernel/tests/macros/schema_empty_struct.stderr
@@ -1,0 +1,7 @@
+error: this derive macro only works on structs with named fields
+ --> tests/macros/schema_empty_struct.rs:7:10
+  |
+7 | #[derive(Schema)]
+  |          ^^^^^^
+  |
+  = note: this error originates in the derive macro `Schema` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/kernel/tests/macros/schema_on_struct.rs
+++ b/kernel/tests/macros/schema_on_struct.rs
@@ -1,0 +1,12 @@
+extern crate delta_kernel_derive;
+use delta_kernel_derive::Schema;
+
+mod actions;
+mod schema;
+
+#[derive(Schema)]
+pub struct WithFields {
+    some_long_name: String,
+}
+
+fn main() {}

--- a/kernel/tests/macros/schema_with_angle_bracketed_path.rs
+++ b/kernel/tests/macros/schema_with_angle_bracketed_path.rs
@@ -1,0 +1,13 @@
+extern crate delta_kernel_derive;
+use delta_kernel_derive::Schema;
+use std::collections::HashMap;
+
+mod actions;
+mod schema;
+
+#[derive(Schema)]
+pub struct WithAngleBracketPath {
+    map_field: HashMap<String, String>,
+}
+
+fn main() {}

--- a/kernel/tests/macros/schema_with_attributed_field.rs
+++ b/kernel/tests/macros/schema_with_attributed_field.rs
@@ -1,0 +1,14 @@
+extern crate delta_kernel_derive;
+use delta_kernel_derive::Schema;
+use std::collections::HashMap;
+
+mod actions;
+mod schema;
+
+#[derive(Schema)]
+pub struct WithAngleBracketPath {
+    #[drop_null_container_values]
+    map_field: HashMap<String, String>,
+}
+
+fn main() {}

--- a/kernel/tests/macros/schema_with_invalid_attribute_target.rs
+++ b/kernel/tests/macros/schema_with_invalid_attribute_target.rs
@@ -1,0 +1,13 @@
+extern crate delta_kernel_derive;
+use delta_kernel_derive::Schema;
+
+mod actions;
+mod schema;
+
+#[derive(Schema)]
+pub struct WithInvalidAttribute {
+    #[drop_null_container_values]
+    some_long_name: String,
+}
+
+fn main() {}

--- a/kernel/tests/macros/schema_with_invalid_attribute_target.stderr
+++ b/kernel/tests/macros/schema_with_invalid_attribute_target.stderr
@@ -1,0 +1,5 @@
+error: Can only use drop_null_container_values on HashMap fields, not String
+  --> tests/macros/schema_with_invalid_attribute_target.rs:10:21
+   |
+10 |     some_long_name: String,
+   |                     ^^^^^^

--- a/kernel/tests/macros/schema_with_invalid_field_type.rs
+++ b/kernel/tests/macros/schema_with_invalid_field_type.rs
@@ -1,0 +1,13 @@
+extern crate delta_kernel_derive;
+use delta_kernel_derive::Schema;
+use syn::Token;
+
+mod actions;
+mod schema;
+
+#[derive(Schema)]
+pub struct WithMacro {
+    token: Token![struct],
+}
+
+fn main() {}

--- a/kernel/tests/macros/schema_with_invalid_field_type.stderr
+++ b/kernel/tests/macros/schema_with_invalid_field_type.stderr
@@ -1,0 +1,5 @@
+error: Can't handle type: Type::Macro { mac: Macro { path: Path { leading_colon: None, segments: [PathSegment { ident: Ident { ident: "Token", span: #0 bytes(162..167) }, arguments: PathArguments::None }] }, bang_token: Not, delimiter: MacroDelimiter::Bracket(Bracket), tokens: TokenStream [Ident { ident: "struct", span: #0 bytes(169..175) }] } }
+  --> tests/macros/schema_with_invalid_field_type.rs:10:5
+   |
+10 |     token: Token![struct],
+   |     ^^^^^


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-incubator/delta-kernel-rs/blob/main/CONTRIBUTING.md
  2. Run `cargo t --all-features --all-targets` to get started testing, and run `cargo fmt`.
  3. Ensure you have added or run the appropriate tests for your PR.
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

## What changes are proposed in this pull request?

Implement tests for `Schema` macro  (#421). 

## Notes
- The `Schema` macro generates code referencing non-public types of the `kernel`, therefore test-local types were needed, as implemented in the `tests/macros/schema.rs` and `tests/macros/actions.rs`. I could not find other way to reference those internal types
- Tests are run as a unittest (in `src/lib.rs`) but use additional test files placed under `tests` (excluded them from direct execution in the `Cargo.toml`). I thought this should be acceptable but happy to change if a different approach is suggested. 
- I was unable to implement a test catching one of the match branches (which should throw compile error if `PathArguments::Parenthesized` is used as a field type). I am still doing my research on how/if this could be done. Asked for help [here](https://stackoverflow.com/questions/79123128/how-to-declare-synpatharguments-parenthesized-field-in-structure-in-rust)


## How was this change tested?

All tests pass, including the newly added