### PR TITLE
Add boundary test cases for UUID length and file extensions

### DIFF
--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -234,8 +234,25 @@ mod tests {
 
         // ignored - no extension
         let log_path = table_log_dir.join("00000000000000000010").unwrap();
-        let log_path = ParsedLogPath::try_from(log_path).unwrap();
-        assert!(log_path.is_none());
+        let result = ParsedLogPath::try_from(log_path);
+        assert!(
+            matches!(result, Ok(None)),
+            "Expected Ok(None) for missing file extension"
+        );
+
+        // empty extension - should be treated as unknown file type
+        let log_path = table_log_dir.join("00000000000000000011.").unwrap();
+        let result = ParsedLogPath::try_from(log_path);
+        assert!(
+            matches!(result, Ok(Some(_))),
+            "Expected Ok(Some) for empty extension"
+        );
+        if let Ok(Some(parsed)) = result {
+            assert!(
+                parsed.is_unknown(),
+                "Expected Unknown file type for empty extension"
+            );
+        }
 
         // ignored - version fails to parse
         let log_path = table_log_dir.join("abc.json").unwrap();
@@ -394,6 +411,20 @@ mod tests {
         assert!(!log_path.is_commit());
         assert!(!log_path.is_checkpoint());
         assert!(log_path.is_unknown());
+
+        // Boundary test - UUID with exactly 35 characters (one too short)
+        let log_path = table_log_dir
+            .join("00000000000000000010.checkpoint.3a0d65cd-4056-49b8-937b-95f9e3ee90e.parquet")
+            .unwrap();
+        let result = ParsedLogPath::try_from(log_path);
+        assert!(
+            result.is_err(),
+            "Expected an error for UUID with exactly 35 characters"
+        );
+        assert!(
+            matches!(result, Err(Error::InvalidLogPath(_))),
+            "Expected InvalidLogPath error for boundary UUID length"
+        );
     }
 
     #[test]

--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -244,15 +244,16 @@ mod tests {
         let log_path = table_log_dir.join("00000000000000000011.").unwrap();
         let result = ParsedLogPath::try_from(log_path);
         assert!(
-            matches!(result, Ok(Some(_))),
-            "Expected Ok(Some) for empty extension"
+            matches!(
+                result,
+                Ok(Some(ParsedLogPath {
+                    file_type: LogPathFileType::Unknown,
+                    ..
+                }))
+            ),
+            "Expected Unknown file type, got {:?}",
+            result
         );
-        if let Ok(Some(parsed)) = result {
-            assert!(
-                parsed.is_unknown(),
-                "Expected Unknown file type for empty extension"
-            );
-        }
 
         // ignored - version fails to parse
         let log_path = table_log_dir.join("abc.json").unwrap();
@@ -418,12 +419,8 @@ mod tests {
             .unwrap();
         let result = ParsedLogPath::try_from(log_path);
         assert!(
-            result.is_err(),
-            "Expected an error for UUID with exactly 35 characters"
-        );
-        assert!(
             matches!(result, Err(Error::InvalidLogPath(_))),
-            "Expected InvalidLogPath error for boundary UUID length"
+            "Expected an error for UUID with exactly 35 characters"
         );
     }
 


### PR DESCRIPTION
This PR adds explicit boundary test cases to existing tests:

1. In test_uuid_checkpoint_patterns:
   - Tests UUID with exactly 35 characters (one too short)
   - Uses realistic UUID format: "3a0d65cd-4056-49b8-937b-95f9e3ee90e"

2. In test_unknown_invalid_patterns:
   - Tests file with no extension (returns Ok(None))
   - Tests file with empty extension "." (returns Ok(Some) with Unknown type)

