### PR TITLE
skip ci for changelog changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,12 @@
 name: build
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'CHANGELOG.md'
+  pull_request:
+    paths-ignore:
+      - 'CHANGELOG.md'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/run_integration_test.yml
+++ b/.github/workflows/run_integration_test.yml
@@ -1,6 +1,15 @@
 name: Run tests to ensure we can compile across arrow versions
 
-on: [workflow_dispatch, push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'CHANGELOG.md'
+  pull_request:
+    paths-ignore:
+      - 'CHANGELOG.md'
+  workflow_dispatch:
+    paths-ignore:
+      - 'CHANGELOG.md'
 
 jobs:
   arrow_integration_test:

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -8,6 +8,8 @@ on:
       - edited
       - synchronize
       - reopened
+    paths-ignore:
+      - 'CHANGELOG.md'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -3,11 +3,9 @@ name: semver-checks
 # Trigger when a PR is opened or changed
 on:
   pull_request_target:
-    types:
-      - opened
-      - edited
-      - synchronize
-      - reopened
+    paths-ignore:
+      - 'CHANGELOG.md'
+  push:
     paths-ignore:
       - 'CHANGELOG.md'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
 
-test change revert me
-
 ## [v0.4.1](https://github.com/delta-incubator/delta-kernel-rs/tree/v0.4.1/) (2024-10-28)
 
 [Full Changelog](https://github.com/delta-incubator/delta-kernel-rs/compare/v0.4.0...v0.4.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+test change revert me
+
 ## [v0.4.1](https://github.com/delta-incubator/delta-kernel-rs/tree/v0.4.1/) (2024-10-28)
 
 [Full Changelog](https://github.com/delta-incubator/delta-kernel-rs/compare/v0.4.0...v0.4.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-
+test
 ## [v0.4.1](https://github.com/delta-io/delta-kernel-rs/tree/v0.4.1/) (2024-10-28)
 
 [Full Changelog](https://github.com/delta-io/delta-kernel-rs/compare/v0.4.0...v0.4.1)


### PR DESCRIPTION
skip running our CI for `CHANGELOG.md`. this will become more useful as we move to a new `unreleased` section in the changelog which PR authors will add to :)

and remove `edited` PR trigger for semver checks