### PR TITLE
move `ensure_read_supported` from `Scan` to `Snapshot`

### DIFF
--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -99,9 +99,6 @@ impl ScanBuilder {
         )?;
         let physical_schema = Arc::new(StructType::new(read_fields));
 
-        // important! before a read/write to the table we must check it is supported
-        self.snapshot.protocol().ensure_read_supported()?;
-
         Ok(Scan {
             snapshot: self.snapshot,
             logical_schema,


### PR DESCRIPTION
previously, we were only checking `protocol.ensure_read_supported()` when we create a `Scan`, instead we should move it up earlier to `Snapshot` creation. this is useful so that we can fail earlier and generally as soon as we get a `Protocol` we should ensure read is supported instead of waiting for `Scan` creation. note this is useful for CDF too (as it relies on snapshots but separate scans)