### PR TITLE
Enable relaying log events via FFI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,7 +145,7 @@ jobs:
           cargo build
           popd
           pushd ffi
-          cargo b --features default-engine,sync-engine,test-ffi
+          cargo b --features default-engine,sync-engine,test-ffi,tracing
           popd
       - name: build and run read-table test
         run: |

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
 tracing = "0.1"
+tracing-core = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", optional = true, features = [ "json" ] }
 url = "2"
 delta_kernel = { path = "../kernel", default-features = false, features = [
@@ -47,7 +48,7 @@ default-engine = [
   "arrow-data",
   "arrow-schema",
 ]
-tracing = [ "tracing-subscriber" ]
+tracing = [ "tracing-core", "tracing-subscriber" ]
 sync-engine = ["delta_kernel/sync-engine"]
 developer-visibility = []
 test-ffi = []

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", optional = false, features = [ "json" ] } # TODO Make optional
+tracing-subscriber = { version = "0.3", optional = true, features = [ "json" ] } # TODO Make optional
 url = "2"
 delta_kernel = { path = "../kernel", default-features = false, features = [
   "developer-visibility",
@@ -47,6 +47,7 @@ default-engine = [
   "arrow-data",
   "arrow-schema",
 ]
+tracing = [ "tracing-subscriber" ]
 sync-engine = ["delta_kernel/sync-engine"]
 developer-visibility = []
 test-ffi = []

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
 tracing = "0.1"
+tracing-subscriber = { version = "0.3", optional = false } # TODO Make optional
 url = "2"
 delta_kernel = { path = "../kernel", default-features = false, features = [
   "developer-visibility",

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", optional = true, features = [ "json" ] } # TODO Make optional
+tracing-subscriber = { version = "0.3", optional = true, features = [ "json" ] }
 url = "2"
 delta_kernel = { path = "../kernel", default-features = false, features = [
   "developer-visibility",

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", optional = false } # TODO Make optional
+tracing-subscriber = { version = "0.3", optional = false, features = [ "json" ] } # TODO Make optional
 url = "2"
 delta_kernel = { path = "../kernel", default-features = false, features = [
   "developer-visibility",

--- a/ffi/examples/read-table/README.md
+++ b/ffi/examples/read-table/README.md
@@ -10,9 +10,9 @@ This example is built with [cmake]. Instructions below assume you start in the d
 Note that prior to building these examples you must build `delta_kernel_ffi` (see [the FFI readme] for details). TLDR:
 ```bash
 # from repo root
-$ cargo build -p delta_kernel_ffi [--release] [--features default-engine]
+$ cargo build -p delta_kernel_ffi [--release] [--features default-engine, tracing]
 # from ffi/ dir
-$ cargo build [--release] [--features default-engine]
+$ cargo build [--release] [--features default-engine, tracing]
 ```
 
 There are two configurations that can currently be configured in cmake:

--- a/ffi/examples/read-table/read_table.c
+++ b/ffi/examples/read-table/read_table.c
@@ -166,10 +166,9 @@ void tracing_callback(struct Event event) {
   gettimeofday(&tv, NULL);
   struct tm *tm_info = gmtime(&tv.tv_sec);
   strftime(buffer, 26, "%Y-%m-%dT%H:%M:%S", tm_info);
-  char* message = allocate_string(event.message);
   char* level_color = event.level < 3 ? RED : BLUE;
   printf(
-    "%s%s.%06dZ%s [%sKernel %s%s]: %s\n",
+    "%s%s.%06dZ%s [%sKernel %s%s] %s%.*s%s: %.*s\n",
     DIM,
     buffer,
     (int)tv.tv_usec, // safe, microseconds are in int range
@@ -177,24 +176,25 @@ void tracing_callback(struct Event event) {
     level_color,
     LEVEL_STRING[event.level],
     RESET,
-    message);
+    DIM,
+    (int)event.target.len,
+    event.target.ptr,
+    RESET,
+    (int)event.message.len,
+    event.message.ptr);
   if (event.file.ptr) {
-    char* file = allocate_string(event.file);
     printf(
-      "  %sat%s %s:%i\n",
+      "  %sat%s %.*s:%i\n",
       DIM,
       RESET,
-      file,
+      (int)event.file.len,
+      event.file.ptr,
       event.line);
-    free(file);
   }
-  free(message);
 }
 
 void log_line_callback(KernelStringSlice line) {
-  char* message = allocate_string(line);
-  printf("%s", message);
-  free(message);
+  printf("%.*s", (int)line.len, line.ptr);
 }
 
 int main(int argc, char* argv[])

--- a/ffi/examples/read-table/read_table.c
+++ b/ffi/examples/read-table/read_table.c
@@ -191,6 +191,12 @@ void tracing_callback(struct Event event) {
   free(message);
 }
 
+void log_line_callback(KernelStringSlice line) {
+  char* message = allocate_string(line);
+  printf("%s", message);
+  free(message);
+}
+
 int main(int argc, char* argv[])
 {
   if (argc < 2) {
@@ -200,6 +206,8 @@ int main(int argc, char* argv[])
 
 #ifdef VERBOSE
   enable_event_tracing(tracing_callback, TRACE);
+  // we could also do something like this if we want less control over formatting
+  // enable_formatted_log_line_tracing(log_line_callback, TRACE, FULL, true, true, false, false);
 #else
   enable_event_tracing(tracing_callback, INFO);
 #endif

--- a/ffi/examples/read-table/read_table.c
+++ b/ffi/examples/read-table/read_table.c
@@ -155,6 +155,11 @@ static const char *LEVEL_STRING[] = {
   "ERROR", "WARN", "INFO", "DEBUG", "TRACE"
 };
 
+#define RED   "\x1b[31m"
+#define BLUE  "\x1b[34m"
+#define DIM   "\x1b[2m"
+#define RESET "\x1b[0m"
+
 void tracing_callback(struct Event event) {
   struct timeval tv;
   char buffer[32];
@@ -162,7 +167,27 @@ void tracing_callback(struct Event event) {
   struct tm *tm_info = gmtime(&tv.tv_sec);
   strftime(buffer, 26, "%Y-%m-%dT%H:%M:%S", tm_info);
   char* message = allocate_string(event.message);
-  printf("%s.%06ldZ [Kernel %s]: %s\n", buffer, tv.tv_usec, LEVEL_STRING[event.level], message);
+  char* level_color = event.level < 3 ? RED : BLUE;
+  printf(
+    "%s%s.%06ldZ%s [%sKernel %s%s]: %s\n",
+    DIM,
+    buffer,
+    tv.tv_usec,
+    RESET,
+    level_color,
+    LEVEL_STRING[event.level],
+    RESET,
+    message);
+  if (event.file.ptr) {
+    char* file = allocate_string(event.file);
+    printf(
+      "  %sat%s %s:%i\n",
+      DIM,
+      RESET,
+      file,
+      event.line);
+    free(file);
+  }
   free(message);
 }
 

--- a/ffi/examples/read-table/read_table.c
+++ b/ffi/examples/read-table/read_table.c
@@ -169,10 +169,10 @@ void tracing_callback(struct Event event) {
   char* message = allocate_string(event.message);
   char* level_color = event.level < 3 ? RED : BLUE;
   printf(
-    "%s%s.%06ldZ%s [%sKernel %s%s]: %s\n",
+    "%s%s.%06dZ%s [%sKernel %s%s]: %s\n",
     DIM,
     buffer,
-    tv.tv_usec,
+    (int)tv.tv_usec, // safe, microseconds are in int range
     RESET,
     level_color,
     LEVEL_STRING[event.level],

--- a/ffi/examples/read-table/read_table.c
+++ b/ffi/examples/read-table/read_table.c
@@ -155,6 +155,7 @@ static const char *LEVEL_STRING[] = {
   "ERROR", "WARN", "INFO", "DEBUG", "TRACE"
 };
 
+// define some ansi color escapes so we can have nice colored output in our logs
 #define RED   "\x1b[31m"
 #define BLUE  "\x1b[34m"
 #define DIM   "\x1b[2m"

--- a/ffi/src/ffi_tracing.rs
+++ b/ffi/src/ffi_tracing.rs
@@ -1,0 +1,172 @@
+//! FFI functions to allow engines to receive log and tracing events from kernel
+
+use core::fmt;
+
+use delta_kernel::{DeltaResult, Error};
+use tracing::{field::{Field as TracingField, Visit}, Event as TracingEvent, Subscriber};
+use tracing_subscriber::{filter::LevelFilter, layer::Context, registry::LookupSpan, Layer};
+
+use crate::{kernel_string_slice, KernelStringSlice};
+
+#[repr(C)]
+pub enum Level {
+    ERROR,
+    WARN,
+    INFO,
+    DEBUG,
+    TRACE,
+}
+
+impl From<&tracing::Level> for Level {
+    fn from(value: &tracing::Level) -> Self {
+        match *value {
+            tracing::Level::TRACE => Level::TRACE,
+            tracing::Level::DEBUG => Level::DEBUG,
+            tracing::Level::INFO => Level::INFO,
+            tracing::Level::WARN => Level::WARN,
+            tracing::Level::ERROR => Level::ERROR,
+        }
+    }
+}
+
+impl From<Level> for LevelFilter {
+    fn from(value: Level) -> Self {
+        match value {
+            Level::TRACE => LevelFilter::TRACE,
+            Level::DEBUG => LevelFilter::DEBUG,
+            Level::INFO => LevelFilter::INFO,
+            Level::WARN => LevelFilter::WARN,
+            Level::ERROR => LevelFilter::ERROR,
+        }
+    }
+}
+
+/// An `Event` can generally be thought of a "log message". It contains all the relevant bits such
+/// that an engine can generate a log message in its format
+#[repr(C)]
+pub struct Event {
+    message: KernelStringSlice,
+    level: Level,
+}
+
+impl TryFrom<&TracingEvent<'_>> for Event {
+    type Error = Error;
+
+    fn try_from(event: &TracingEvent<'_>) -> DeltaResult<Self> {
+        let metadata = event.metadata();
+        let level = metadata.level().into();
+        let mut message_visitor = MessageFieldVisitor { message: None };
+        event.record(&mut message_visitor);
+        let msg = message_visitor.message.ok_or_else(||
+            Error::missing_data("message field")
+        )?;
+        let msg = kernel_string_slice!(msg);
+        Ok(Self {
+            message: msg,
+            level,
+        })
+    }
+}
+
+pub type TracingEventFn = extern "C" fn(event: Event);
+
+/// Enable getting called back for tracing (logging) events in the kernel. `max_level` specifies
+/// that only events `<=` to the specified level should be reported.  More verbose Levels are "greater
+/// than" less verbose ones. So Level::ERROR is the lowest, and Level::TRACE the highest.
+#[no_mangle]
+pub unsafe extern "C" fn enable_event_tracing(callback: TracingEventFn, max_level: Level) {
+    setup_event_subscriber(callback, max_level);
+}
+
+
+// utility code below for setting up the tracing subscriber stuff
+
+
+struct MessageFieldVisitor {
+    message: Option<String>,
+}
+
+impl Visit for MessageFieldVisitor {
+    fn record_debug(&mut self, field: &TracingField, value: &dyn fmt::Debug) {
+        if field.name() == "message" {
+            self.message = Some(format!("{:?}", value));
+        }
+    }
+
+    fn record_str(&mut self, field: &TracingField, value: &str) {
+        if field.name() == "message" {
+            self.message = Some(value.to_string());
+        }
+    }
+}
+
+struct EventLayer {
+    callback: TracingEventFn,
+}
+
+impl<S> Layer<S> for EventLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_event(&self, event: &TracingEvent<'_>, _context: Context<'_, S>) {
+        if let Ok(event) = event.try_into() {
+            // ignore if event doesn't have a "message" field
+            (self.callback)(event);
+        }
+    }
+}
+
+fn setup_event_subscriber(callback: TracingEventFn, max_level: Level) {
+    use tracing_subscriber::{registry::Registry, layer::SubscriberExt};
+    let filter: LevelFilter = max_level.into();
+    let event_layer = EventLayer { callback }.with_filter(filter);
+    let subscriber = Registry::default().with(event_layer);
+    tracing::subscriber::set_global_default(subscriber)
+        .expect("Failed to set global subscriber");
+}
+
+
+// type SharedBuffer = Arc<Mutex<Vec<u8>>>;
+
+// struct TriggerLayer {
+//     buf: SharedBuffer,
+// }
+
+// impl<S> Layer<S> for TriggerLayer
+// where
+//     S: Subscriber + for<'a> LookupSpan<'a>,
+// {
+//     fn on_event(&self, event: &TracingEvent<'_>, _context: Context<'_, S>) {
+//         println!("EVENT");
+//         let mut buf = self.buf.lock().unwrap();
+//         let output = String::from_utf8_lossy(&buf);
+//         println!("Buf is:\n{output}");
+//         buf.clear();
+//     }
+// }
+
+// #[derive(Default)]
+// struct BufferedMessageWriter {
+//      current_buffer: SharedBuffer,
+// }
+
+// impl io::Write for BufferedMessageWriter {
+//     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+//         self.current_buffer.lock().unwrap().extend_from_slice(buf);
+//         Ok(buf.len())
+//     }
+
+//     fn flush(&mut self) -> io::Result<()> {
+//         Ok(())
+//     }
+// }
+
+// impl<'a> MakeWriter<'a> for BufferedMessageWriter {
+//     type Writer = Self;
+
+//     fn make_writer(&'a self) -> Self::Writer {
+//         BufferedMessageWriter {
+//             current_buffer: self.current_buffer.clone()
+//         }
+//     }
+// }

--- a/ffi/src/ffi_tracing.rs
+++ b/ffi/src/ffi_tracing.rs
@@ -217,7 +217,7 @@ pub unsafe extern "C" fn enable_formatted_log_line_tracing(
 
 // utility code below for setting up the tracing subscriber for events
 
-pub fn set_global_default(dispatch: tracing_core::Dispatch) -> DeltaResult<()> {
+fn set_global_default(dispatch: tracing_core::Dispatch) -> DeltaResult<()> {
     tracing_core::dispatcher::set_global_default(dispatch).map_err(|_| {
         Error::generic("Unable to set global default subscriber. Trying to set more than once?")
     })

--- a/ffi/src/ffi_tracing.rs
+++ b/ffi/src/ffi_tracing.rs
@@ -377,8 +377,8 @@ fn get_log_line_dispatch(
     // This repeats some code, but avoids some insane generic wrangling if we try to abstract the
     // type of `fmt_layer` over the formatter
     macro_rules! setup_subscriber {
-        ($($transform:ident($($arg:ident)?)).*) => {{
-            let fmt_layer = fmt_layer$(.$transform($($arg)?))*.with_filter(filter);
+        ($($transform:ident()).*) => {{
+            let fmt_layer = fmt_layer$(.$transform())*.with_filter(filter);
             let subscriber = Registry::default()
                 .with(fmt_layer)
                 .with(tracking_layer.with_filter(filter));

--- a/ffi/src/ffi_tracing.rs
+++ b/ffi/src/ffi_tracing.rs
@@ -577,7 +577,7 @@ mod tests {
 
         // file path will use \ on windows
         use std::path::MAIN_SEPARATOR;
-        let expected_file = format!("ffi{}src{}ffi_tracing.rs",MAIN_SEPARATOR,MAIN_SEPARATOR);
+        let expected_file = format!("ffi{}src{}ffi_tracing.rs", MAIN_SEPARATOR, MAIN_SEPARATOR);
 
         let ok = event.level == Level::INFO
             && target == "delta_kernel_ffi::ffi_tracing::tests"

--- a/ffi/src/ffi_tracing.rs
+++ b/ffi/src/ffi_tracing.rs
@@ -377,8 +377,8 @@ fn get_log_line_dispatch(
     // This repeats some code, but avoids some insane generic wrangling if we try to abstract the
     // type of `fmt_layer` over the formatter
     macro_rules! setup_subscriber {
-        ($($transform:ident($($arg:ident)?)).+) => {{
-            let fmt_layer = fmt_layer$(.$transform($($arg)?))+.with_filter(filter);
+        ($($transform:ident($($arg:ident)?)).*) => {{
+            let fmt_layer = fmt_layer$(.$transform($($arg)?))*.with_filter(filter);
             let subscriber = Registry::default()
                 .with(fmt_layer)
                 .with(tracking_layer.with_filter(filter));
@@ -387,9 +387,7 @@ fn get_log_line_dispatch(
     }
     use LogLineFormat::*;
     match (format, with_time) {
-        // NOTE: There is no `full()` method (it's the default), so just call `with_ansi`
-        // a second time instead (as a no-op) to keep the macro happy.
-        (FULL, true) => setup_subscriber!(with_ansi(ansi)),
+        (FULL, true) => setup_subscriber!(),
         (FULL, false) => setup_subscriber!(without_time()),
         (COMPACT, true) => setup_subscriber!(compact()),
         (COMPACT, false) => setup_subscriber!(compact().without_time()),

--- a/ffi/src/ffi_tracing.rs
+++ b/ffi/src/ffi_tracing.rs
@@ -1,8 +1,13 @@
 //! FFI functions to allow engines to receive log and tracing events from kernel
 
-use core::fmt;
+use std::sync::{Arc, Mutex};
+use std::{fmt, io};
 
-use tracing::{field::{Field as TracingField, Visit}, Event as TracingEvent, Subscriber};
+use tracing::{
+    field::{Field as TracingField, Visit},
+    Event as TracingEvent, Subscriber,
+};
+use tracing_subscriber::fmt::MakeWriter;
 use tracing_subscriber::{filter::LevelFilter, layer::Context, registry::LookupSpan, Layer};
 
 use crate::{kernel_string_slice, KernelStringSlice};
@@ -40,7 +45,6 @@ impl From<Level> for LevelFilter {
     }
 }
 
-
 /// An `Event` can generally be thought of a "log message". It contains all the relevant bits such
 /// that an engine can generate a log message in its format
 #[repr(C)]
@@ -62,14 +66,107 @@ pub type TracingEventFn = extern "C" fn(event: Event);
 /// Enable getting called back for tracing (logging) events in the kernel. `max_level` specifies
 /// that only events `<=` to the specified level should be reported.  More verbose Levels are "greater
 /// than" less verbose ones. So Level::ERROR is the lowest, and Level::TRACE the highest.
+///
+/// [`Event`] based tracing gives an engine maximal flexibility in formatting event log
+/// lines. Kernel can also format events for the engine. If this is desired call
+/// [`enable_log_line_tracing`] instead of this method.
 #[no_mangle]
 pub unsafe extern "C" fn enable_event_tracing(callback: TracingEventFn, max_level: Level) {
     setup_event_subscriber(callback, max_level);
 }
 
+pub type TracingLogLineFn = extern "C" fn(line: KernelStringSlice);
 
-// utility code below for setting up the tracing subscriber stuff
+/// Format to use for log lines. These correspond to the formats from [`tracing_subscriber`
+/// formats](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/index.html).
+#[repr(C)]
+pub enum LogLineFormat {
+    /// The default formatter. This emits human-readable, single-line logs for each event that
+    /// occurs, with the context displayed before the formatted representation of the event.
+    /// Example:
+    /// `2022-02-15T18:40:14.289898Z  INFO fmt: preparing to shave yaks number_of_yaks=3`
+    FULL,
+    /// A variant of the FULL formatter, optimized for short line lengths. Fields from the context
+    /// are appended to the fields of the formatted event, and targets are not shown; the verbosity
+    /// level is abbreviated to a single character.
+    /// Example:
+    COMPACT,
+    /// Emits excessively pretty, multi-line logs, optimized for human readability. This is
+    /// primarily intended to be used in local development and debugging, or for command-line
+    /// applications, where automated analysis and compact storage of logs is less of a priority
+    /// than readability and visual appeal.
+    /// Example:
+    /// ```
+    ///   2022-02-15T18:44:24.535324Z  INFO fmt_pretty: preparing to shave yaks, number_of_yaks: 3
+    ///   at examples/examples/fmt-pretty.rs:16 on main
+    /// ```
+    PRETTY,
+    /// Outputs newline-delimited JSON logs. This is intended for production use with systems where
+    /// structured logs are consumed as JSON by analysis and viewing tools. The JSON output is not
+    /// optimized for human readability.
+    /// Example:
+    /// `{"timestamp":"2022-02-15T18:47:10.821315Z","level":"INFO","fields":{"message":"preparing to shave yaks","number_of_yaks":3},"target":"fmt_json"}`
+    JSON,
+}
 
+/// Enable getting called back with log lines in the kernel using default settings:
+/// - FULL format
+/// - include ansi color
+/// - include timestamps
+/// - include level
+/// - include target
+/// `max_level` specifies that only logs `<=` to the specified level should be reported.  More
+/// verbose Levels are "greater than" less verbose ones. So Level::ERROR is the lowest, and
+/// Level::TRACE the highest.
+///
+/// Log lines passed to the callback will already have a newline at the end.
+///
+/// Log line based tracing is simple for an engine as it can just log the passed string, but does
+/// not provide flexibility for an engine to format events. If the engine wants to use a specific
+/// format for events it should call [`enable_event_tracing`] instead of this function.
+#[no_mangle]
+pub unsafe extern "C" fn enable_log_line_tracing(callback: TracingLogLineFn, max_level: Level) {
+    setup_log_line_subscriber(
+        callback,
+        max_level,
+        LogLineFormat::FULL,
+        true,
+        true,
+        true,
+        true,
+    );
+}
+
+/// Enable getting called back with log lines in the kernel. This variant allows specifying
+/// formatting options for the log lines. See [`enable_log_line_tracing`] for general info on
+/// getting called back for log lines. Options that can be set here:
+/// - `format`: see [`LogLineFormat`]
+/// - `ansi`: should the formatter use ansi escapes for color
+/// - `with_time`: should the formatter include a timestamp in the log message
+/// - `with_level`: should the formatter include the level in the log message
+/// - `with_target`: should the formatter include what part of the system the event occurred
+#[no_mangle]
+pub unsafe extern "C" fn enable_formatted_log_line_tracing(
+    callback: TracingLogLineFn,
+    max_level: Level,
+    format: LogLineFormat,
+    ansi: bool,
+    with_time: bool,
+    with_level: bool,
+    with_target: bool,
+) {
+    setup_log_line_subscriber(
+        callback,
+        max_level,
+        format,
+        ansi,
+        with_time,
+        with_level,
+        with_target,
+    );
+}
+
+// utility code below for setting up the tracing subscriber for events
 
 struct MessageFieldVisitor {
     message: Option<String>,
@@ -112,12 +209,10 @@ where
             let target = kernel_string_slice!(target);
             let file = match metadata.file() {
                 Some(file) => kernel_string_slice!(file),
-                None => {
-                    KernelStringSlice {
-                        ptr: std::ptr::null(),
-                        len: 0,
-                    }
-                }
+                None => KernelStringSlice {
+                    ptr: std::ptr::null(),
+                    len: 0,
+                },
             };
             let event = Event {
                 message: msg,
@@ -132,56 +227,126 @@ where
 }
 
 fn setup_event_subscriber(callback: TracingEventFn, max_level: Level) {
-    use tracing_subscriber::{registry::Registry, layer::SubscriberExt};
+    use tracing_subscriber::{layer::SubscriberExt, registry::Registry};
     let filter: LevelFilter = max_level.into();
     let event_layer = EventLayer { callback }.with_filter(filter);
     let subscriber = Registry::default().with(event_layer);
-    tracing::subscriber::set_global_default(subscriber)
-        .expect("Failed to set global subscriber");
+    tracing::subscriber::set_global_default(subscriber).expect("Failed to set global subscriber");
 }
 
+// utility code below for setting up the tracing subscriber for log lines
 
-// type SharedBuffer = Arc<Mutex<Vec<u8>>>;
+type SharedBuffer = Arc<Mutex<Vec<u8>>>;
 
-// struct TriggerLayer {
-//     buf: SharedBuffer,
-// }
+struct TriggerLayer {
+    buf: SharedBuffer,
+    callback: TracingLogLineFn,
+}
 
-// impl<S> Layer<S> for TriggerLayer
-// where
-//     S: Subscriber + for<'a> LookupSpan<'a>,
-// {
-//     fn on_event(&self, event: &TracingEvent<'_>, _context: Context<'_, S>) {
-//         println!("EVENT");
-//         let mut buf = self.buf.lock().unwrap();
-//         let output = String::from_utf8_lossy(&buf);
-//         println!("Buf is:\n{output}");
-//         buf.clear();
-//     }
-// }
+impl<S> Layer<S> for TriggerLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_event(&self, _: &TracingEvent<'_>, _context: Context<'_, S>) {
+        let mut buf = self.buf.lock().unwrap();
+        let output = String::from_utf8_lossy(&buf);
+        let message = kernel_string_slice!(output);
+        (self.callback)(message);
+        buf.clear();
+    }
+}
 
-// #[derive(Default)]
-// struct BufferedMessageWriter {
-//      current_buffer: SharedBuffer,
-// }
+#[derive(Default)]
+struct BufferedMessageWriter {
+    current_buffer: SharedBuffer,
+}
 
-// impl io::Write for BufferedMessageWriter {
-//     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-//         self.current_buffer.lock().unwrap().extend_from_slice(buf);
-//         Ok(buf.len())
-//     }
+impl io::Write for BufferedMessageWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.current_buffer.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
 
-//     fn flush(&mut self) -> io::Result<()> {
-//         Ok(())
-//     }
-// }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
 
-// impl<'a> MakeWriter<'a> for BufferedMessageWriter {
-//     type Writer = Self;
+impl<'a> MakeWriter<'a> for BufferedMessageWriter {
+    type Writer = Self;
 
-//     fn make_writer(&'a self) -> Self::Writer {
-//         BufferedMessageWriter {
-//             current_buffer: self.current_buffer.clone()
-//         }
-//     }
-// }
+    fn make_writer(&'a self) -> Self::Writer {
+        BufferedMessageWriter {
+            current_buffer: self.current_buffer.clone(),
+        }
+    }
+}
+
+fn setup_log_line_subscriber(
+    callback: TracingLogLineFn,
+    max_level: Level,
+    format: LogLineFormat,
+    ansi: bool,
+    with_time: bool,
+    with_level: bool,
+    with_target: bool,
+) {
+    use tracing_subscriber::{layer::SubscriberExt, registry::Registry};
+    let buffer = Arc::new(Mutex::new(vec![]));
+    let writer = BufferedMessageWriter {
+        current_buffer: buffer.clone(),
+    };
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .with_writer(writer)
+        .with_ansi(ansi)
+        .with_level(with_level)
+        .with_target(with_target);
+    let filter: LevelFilter = max_level.into();
+    let tracking_layer = TriggerLayer {
+        buf: buffer.clone(),
+        callback,
+    };
+
+    // This repeats some code, but avoids some insane generic wrangling if we try to abstract the
+    // type of `fmt_layer` over the formatter
+    macro_rules! setup_subscriber {
+        ( $format_fn:ident ) => {
+            if with_time {
+                let fmt_layer = fmt_layer.$format_fn().with_filter(filter);
+                let subscriber = Registry::default().with(fmt_layer).with(tracking_layer);
+                tracing::subscriber::set_global_default(subscriber)
+                    .expect("Failed to set global subscriber");
+            } else {
+                let fmt_layer = fmt_layer.without_time().$format_fn().with_filter(filter);
+                let subscriber = Registry::default().with(fmt_layer).with(tracking_layer);
+                tracing::subscriber::set_global_default(subscriber)
+                    .expect("Failed to set global subscriber");
+            }
+        };
+    }
+    match format {
+        LogLineFormat::FULL => {
+            // can't use macro as there's no `full()` function, it's just the default
+            if with_time {
+                let fmt_layer = fmt_layer.with_filter(filter);
+                let subscriber = Registry::default().with(fmt_layer).with(tracking_layer);
+                tracing::subscriber::set_global_default(subscriber)
+                    .expect("Failed to set global subscriber");
+            } else {
+                let fmt_layer = fmt_layer.without_time().with_filter(filter);
+                let subscriber = Registry::default().with(fmt_layer).with(tracking_layer);
+                tracing::subscriber::set_global_default(subscriber)
+                    .expect("Failed to set global subscriber");
+            }
+        }
+        LogLineFormat::COMPACT => {
+            setup_subscriber!(compact);
+        }
+        LogLineFormat::PRETTY => {
+            setup_subscriber!(pretty);
+        }
+        LogLineFormat::JSON => {
+            setup_subscriber!(json);
+        }
+    }
+}

--- a/ffi/src/ffi_tracing.rs
+++ b/ffi/src/ffi_tracing.rs
@@ -327,9 +327,10 @@ struct BufferedMessageWriter {
 
 impl io::Write for BufferedMessageWriter {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.current_buffer.lock().map_err(|_| {
-            io::Error::new(io::ErrorKind::Other, "Could not lock buffer")
-        })?.extend_from_slice(buf);
+        self.current_buffer
+            .lock()
+            .map_err(|_| io::Error::new(io::ErrorKind::Other, "Could not lock buffer"))?
+            .extend_from_slice(buf);
         Ok(buf.len())
     }
 
@@ -388,8 +389,8 @@ fn get_log_line_dispatch(
     match (format, with_time) {
         // NOTE: There is no `full()` method (it's the default), so just call `with_ansi`
         // a second time instead (as a no-op) to keep the macro happy.
-        (FULL, true) =>  setup_subscriber!(with_ansi(ansi)),
-        (FULL, false) =>  setup_subscriber!(without_time()),
+        (FULL, true) => setup_subscriber!(with_ansi(ansi)),
+        (FULL, false) => setup_subscriber!(without_time()),
         (COMPACT, true) => setup_subscriber!(compact()),
         (COMPACT, false) => setup_subscriber!(compact().without_time()),
         (PRETTY, true) => setup_subscriber!(pretty()),

--- a/ffi/src/ffi_tracing.rs
+++ b/ffi/src/ffi_tracing.rs
@@ -519,10 +519,10 @@ mod tests {
                 record_callback,
                 Level::TRACE,
                 LogLineFormat::FULL,
-                true,
-                true,
-                true,
-                true,
+                true, // ansi
+                true, // with_time
+                true, // with_level
+                true, // with_target
             )
         };
         assert!(!ok, "Should have not set up a second time")

--- a/ffi/src/ffi_tracing.rs
+++ b/ffi/src/ffi_tracing.rs
@@ -12,6 +12,8 @@ use tracing_subscriber::{filter::LevelFilter, layer::Context, registry::LookupSp
 
 use crate::{kernel_string_slice, KernelStringSlice};
 
+/// Definitions of level verbosity. Verbose Levels are "greater than" less verbose ones. So
+/// Level::ERROR is the lowest, and Level::TRACE the highest.
 #[repr(C)]
 pub enum Level {
     ERROR,
@@ -87,9 +89,9 @@ pub enum LogLineFormat {
     /// `2022-02-15T18:40:14.289898Z  INFO fmt: preparing to shave yaks number_of_yaks=3`
     FULL,
     /// A variant of the FULL formatter, optimized for short line lengths. Fields from the context
-    /// are appended to the fields of the formatted event, and targets are not shown; the verbosity
-    /// level is abbreviated to a single character.
+    /// are appended to the fields of the formatted event, and targets are not shown.
     /// Example:
+    /// `2022-02-17T19:51:05.809287Z  INFO fmt_compact: preparing to shave yaks number_of_yaks=3`
     COMPACT,
     /// Emits excessively pretty, multi-line logs, optimized for human readability. This is
     /// primarily intended to be used in local development and debugging, or for command-line

--- a/ffi/src/ffi_tracing.rs
+++ b/ffi/src/ffi_tracing.rs
@@ -304,8 +304,8 @@ where
     fn on_event(&self, _: &TracingEvent<'_>, _context: Context<'_, S>) {
         match self.buf.lock() {
             Ok(mut buf) => {
-                let output = String::from_utf8_lossy(&buf);
-                let message = kernel_string_slice!(output);
+                let message = String::from_utf8_lossy(&buf);
+                let message = kernel_string_slice!(message);
                 (self.callback)(message);
                 buf.clear();
             }

--- a/ffi/src/ffi_tracing.rs
+++ b/ffi/src/ffi_tracing.rs
@@ -574,6 +574,9 @@ mod tests {
         let msg: &str = unsafe { TryFromStringSlice::try_from_slice(&event.message).unwrap() };
         let target: &str = unsafe { TryFromStringSlice::try_from_slice(&event.target).unwrap() };
         let file: &str = unsafe { TryFromStringSlice::try_from_slice(&event.file).unwrap() };
+        println!("msg: {msg}");
+        println!("target: {target}");
+        println!("file: {file}");
         let ok = event.level == Level::INFO
             && target == "delta_kernel_ffi::ffi_tracing::tests"
             && file == "ffi/src/ffi_tracing.rs"

--- a/ffi/src/ffi_tracing.rs
+++ b/ffi/src/ffi_tracing.rs
@@ -98,7 +98,7 @@ pub enum LogLineFormat {
     /// applications, where automated analysis and compact storage of logs is less of a priority
     /// than readability and visual appeal.
     /// Example:
-    /// ```
+    /// ```ignore
     ///   2022-02-15T18:44:24.535324Z  INFO fmt_pretty: preparing to shave yaks, number_of_yaks: 3
     ///   at examples/examples/fmt-pretty.rs:16 on main
     /// ```

--- a/ffi/src/ffi_tracing.rs
+++ b/ffi/src/ffi_tracing.rs
@@ -574,12 +574,14 @@ mod tests {
         let msg: &str = unsafe { TryFromStringSlice::try_from_slice(&event.message).unwrap() };
         let target: &str = unsafe { TryFromStringSlice::try_from_slice(&event.target).unwrap() };
         let file: &str = unsafe { TryFromStringSlice::try_from_slice(&event.file).unwrap() };
-        println!("msg: {msg}");
-        println!("target: {target}");
-        println!("file: {file}");
+
+        // file path will use \ on windows
+        use std::path::MAIN_SEPARATOR;
+        let expected_file = format!("ffi{}src{}ffi_tracing.rs",MAIN_SEPARATOR,MAIN_SEPARATOR);
+
         let ok = event.level == Level::INFO
             && target == "delta_kernel_ffi::ffi_tracing::tests"
-            && file == "ffi/src/ffi_tracing.rs"
+            && file == expected_file
             && (msg == "Testing 1" || msg == "Another line");
         let mut lock = EVENTS_OK.lock().unwrap();
         if let Some(ref mut events) = *lock {

--- a/ffi/src/handle.rs
+++ b/ffi/src/handle.rs
@@ -176,7 +176,6 @@ mod private {
     {
         /// Obtains a mutable reference to the handle's underlying object. Unsafe equivalent to
         /// [`AsMut::as_mut`].
-
         ///
         /// # Safety
         ///

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -39,6 +39,8 @@ pub mod scan;
 pub mod schema;
 #[cfg(feature = "test-ffi")]
 pub mod test_ffi;
+// todo: feature flag
+pub mod ffi_tracing;
 
 pub(crate) type NullableCvoid = Option<NonNull<c_void>>;
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -121,6 +121,14 @@ impl KernelStringSlice {
             len: source.len(),
         }
     }
+
+    /// Create a new empty `KernelStringSlice`. `len` will be 0, and `ptr` will be `null`.
+    pub(crate) fn empty() -> Self {
+        Self {
+            ptr: std::ptr::null(),
+            len: 0,
+        }
+    }
 }
 
 /// Creates a new [`KernelStringSlice`] from a string reference (which must be an identifier, to

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -39,7 +39,7 @@ pub mod scan;
 pub mod schema;
 #[cfg(feature = "test-ffi")]
 pub mod test_ffi;
-// todo: feature flag
+#[cfg(feature = "tracing")]
 pub mod ffi_tracing;
 
 pub(crate) type NullableCvoid = Option<NonNull<c_void>>;

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -35,12 +35,12 @@ pub mod engine_funcs;
 pub mod error;
 use error::{AllocateError, AllocateErrorFn, ExternResult, IntoExternResult};
 pub mod expressions;
+#[cfg(feature = "tracing")]
+pub mod ffi_tracing;
 pub mod scan;
 pub mod schema;
 #[cfg(feature = "test-ffi")]
 pub mod test_ffi;
-#[cfg(feature = "tracing")]
-pub mod ffi_tracing;
 
 pub(crate) type NullableCvoid = Option<NonNull<c_void>>;
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -121,14 +121,6 @@ impl KernelStringSlice {
             len: source.len(),
         }
     }
-
-    /// Create a new empty `KernelStringSlice`. `len` will be 0, and `ptr` will be `null`.
-    pub(crate) fn empty() -> Self {
-        Self {
-            ptr: std::ptr::null(),
-            len: 0,
-        }
-    }
 }
 
 /// Creates a new [`KernelStringSlice`] from a string reference (which must be an identifier, to


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-incubator/delta-kernel-rs/blob/main/CONTRIBUTING.md
  2. Run `cargo t --all-features --all-targets` to get started testing, and run `cargo fmt`.
  3. Ensure you have added or run the appropriate tests for your PR.
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

## What changes are proposed in this pull request?
<!--
Please clarify what changes you are proposing and why the changes are needed.
The purpose of this section is to outline the changes, why they are needed, and how this PR fixes the issue.
If the reason for the change is already explained clearly in an issue, then it does not need to be restated here.
  1. If you propose a new API or feature, clarify the use case for a new API or feature.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This PR provides 3 ways for engines to hook into our logging:
1. getting a struct `Event` type with relevant information that they can format
2. A very simple call that will just pick some defaults and give them a string
3. A slightly more complex one that lets them control the string formatting a little, but still ultimately just hands over a string

Note that the `Compact` format seems a bit broken upstream. I've filled https://github.com/tokio-rs/tracing/issues/3157 for that.

<!--
Uncomment this section if there are any changes affecting public APIs:
### This PR affects the following public APIs

If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.

Note that _new_ public APIs are not considered breaking.
-->

Adds 3 new public ffi APIs

## How was this change tested?
<!--
Please make sure to add test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested, ideally via a reproducible test documented in the PR description.
-->

Running in `read_table`, and unit tests