### PR TITLE
Simplify column mapping mode handling

### DIFF
--- a/acceptance/src/data.rs
+++ b/acceptance/src/data.rs
@@ -61,9 +61,6 @@ pub fn sort_record_batch(batch: RecordBatch) -> DeltaResult<RecordBatch> {
     Ok(RecordBatch::try_new(batch.schema(), columns)?)
 }
 
-// TODO(zach): skip iceberg_compat_v1 test until DAT is fixed
-static SKIPPED_TESTS: &[&str; 1] = &["iceberg_compat_v1"];
-
 // Ensure that two schema have the same field names, and dict_id/ordering.
 // We ignore:
 //  - data type: This is checked already in `assert_columns_match`
@@ -114,13 +111,6 @@ fn assert_columns_match(actual: &[Arc<dyn Array>], expected: &[Arc<dyn Array>]) 
 }
 
 pub async fn assert_scan_data(engine: Arc<dyn Engine>, test_case: &TestCaseInfo) -> TestResult<()> {
-    let root_dir = test_case.root_dir();
-    for skipped in SKIPPED_TESTS {
-        if root_dir.ends_with(skipped) {
-            return Ok(());
-        }
-    }
-
     let engine = engine.as_ref();
     let table_root = test_case.table_root()?;
     let table = Table::new(table_root);

--- a/acceptance/tests/dat_reader.rs
+++ b/acceptance/tests/dat_reader.rs
@@ -5,12 +5,21 @@ use acceptance::read_dat_case;
 use delta_kernel::engine::default::executor::tokio::TokioBackgroundExecutor;
 use delta_kernel::engine::default::DefaultEngine;
 
+// TODO(zach): skip iceberg_compat_v1 test until DAT is fixed
+static SKIPPED_TESTS: &[&str; 1] = &["iceberg_compat_v1"];
+
 fn reader_test(path: &Path) -> datatest_stable::Result<()> {
     let root_dir = format!(
         "{}/{}",
         env!["CARGO_MANIFEST_DIR"],
         path.parent().unwrap().to_str().unwrap()
     );
+    for skipped in SKIPPED_TESTS {
+        if root_dir.ends_with(skipped) {
+            println!("Skipping test: {}", skipped);
+            return Ok(());
+        }
+    }
 
     tokio::runtime::Builder::new_current_thread()
         .enable_all()

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -128,7 +128,7 @@ impl Metadata {
         Ok(visitor.metadata)
     }
 
-    pub fn schema(&self) -> DeltaResult<StructType> {
+    pub fn parse_schema(&self) -> DeltaResult<StructType> {
         Ok(serde_json::from_str(&self.schema_string)?)
     }
 

--- a/kernel/src/actions/visitors.rs
+++ b/kernel/src/actions/visitors.rs
@@ -5,8 +5,7 @@ use std::collections::HashMap;
 use std::sync::LazyLock;
 
 use crate::engine_data::{GetData, RowVisitor, TypedGetData as _};
-use crate::expressions::{column_name, ColumnName};
-use crate::schema::{ColumnNamesAndTypes, DataType};
+use crate::schema::{column_name, ColumnName, ColumnNamesAndTypes, DataType};
 use crate::utils::require;
 use crate::{DeltaResult, Error};
 

--- a/kernel/src/engine/arrow_data.rs
+++ b/kernel/src/engine/arrow_data.rs
@@ -1,6 +1,5 @@
 use crate::engine_data::{EngineData, EngineList, EngineMap, GetData, RowVisitor};
-use crate::expressions::ColumnName;
-use crate::schema::{DataType};
+use crate::schema::{ColumnName, DataType};
 use crate::{DeltaResult, Error};
 
 use arrow_array::cast::AsArray;

--- a/kernel/src/engine_data.rs
+++ b/kernel/src/engine_data.rs
@@ -1,7 +1,6 @@
 //! Traits that engines need to implement in order to pass data between themselves and kernel.
 
-use crate::expressions::ColumnName;
-use crate::schema::DataType;
+use crate::schema::{ColumnName, DataType};
 use crate::{AsAny, DeltaResult, Error};
 
 use tracing::debug;

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -95,7 +95,6 @@ impl ScanBuilder {
         let (all_fields, read_fields, have_partition_cols) = get_state_info(
             logical_schema.as_ref(),
             &self.snapshot.metadata().partition_columns,
-            self.snapshot.column_mapping_mode,
         )?;
         let physical_schema = Arc::new(StructType::new(read_fields));
 
@@ -399,7 +398,6 @@ fn parse_partition_value(raw: Option<&String>, data_type: &DataType) -> DeltaRes
 fn get_state_info(
     logical_schema: &Schema,
     partition_columns: &[String],
-    column_mapping_mode: ColumnMappingMode,
 ) -> DeltaResult<(Vec<ColumnType>, Vec<StructField>, bool)> {
     let mut have_partition_cols = false;
     let mut read_fields = Vec::with_capacity(logical_schema.fields.len());
@@ -419,7 +417,7 @@ fn get_state_info(
             } else {
                 // Add to read schema, store field so we can build a `Column` expression later
                 // if needed (i.e. if we have partition columns)
-                let physical_field = logical_field.make_physical(column_mapping_mode)?;
+                let physical_field = logical_field.make_physical();
                 debug!("\n\n{logical_field:#?}\nAfter mapping: {physical_field:#?}\n\n");
                 let physical_name = physical_field.name.clone();
                 read_fields.push(physical_field);
@@ -451,7 +449,6 @@ pub fn transform_to_logical(
     let (all_fields, _read_fields, have_partition_cols) = get_state_info(
         &global_state.logical_schema,
         &global_state.partition_columns,
-        global_state.column_mapping_mode,
     )?;
     transform_to_logical_internal(
         engine,
@@ -488,7 +485,7 @@ fn transform_to_logical_internal(
                         "logical schema did not contain expected field, can't transform data",
                     ));
                 };
-                let name = field.physical_name(global_state.column_mapping_mode)?;
+                let name = field.physical_name();
                 let value_expression =
                     parse_partition_value(partition_values.get(name), field.data_type())?;
                 Ok(value_expression.into())

--- a/kernel/src/scan/state.rs
+++ b/kernel/src/scan/state.rs
@@ -3,7 +3,6 @@
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
-use crate::expressions::ColumnName;
 use crate::utils::require;
 use crate::{
     actions::{
@@ -11,7 +10,7 @@ use crate::{
         visitors::visit_deletion_vector_at,
     },
     engine_data::{GetData, RowVisitor, TypedGetData as _},
-    schema::{ColumnNamesAndTypes, DataType, SchemaRef},
+    schema::{ColumnName, ColumnNamesAndTypes, DataType, SchemaRef},
     table_features::ColumnMappingMode,
     DeltaResult, Engine, EngineData, Error,
 };

--- a/kernel/src/schema.rs
+++ b/kernel/src/schema.rs
@@ -188,9 +188,9 @@ impl StructField {
 
     /// Applies physical name mappings to this field
     ///
-    /// NOTE: Caller affirms that the schema was alreasdy validated by
-    /// [`crate::table_features::validate_schema_column_mapping`], to ensure that
-    /// annotations are always and only present when column mapping mode is enabled.
+    /// NOTE: Caller affirms that the schema was already validated by
+    /// [`crate::table_features::validate_schema_column_mapping`], to ensure that annotations are
+    /// always and only present when column mapping mode is enabled.
     pub fn make_physical(&self) -> Self {
         struct MakePhysical;
         impl<'a> SchemaTransform<'a> for MakePhysical {

--- a/kernel/src/schema.rs
+++ b/kernel/src/schema.rs
@@ -134,7 +134,7 @@ impl StructField {
     /// Get the physical name for this field as it should be read from parquet.
     ///
     /// NOTE: Caller affirms that the schema was already validated by
-    /// [`crate::table_features::validate_column_mapping_schema`], to ensure that
+    /// [`crate::table_features::validate_schema_column_mapping`], to ensure that
     /// annotations are always and only present when column mapping mode is enabled.
     pub fn physical_name(&self) -> &str {
         match self
@@ -189,7 +189,7 @@ impl StructField {
     /// Applies physical name mappings to this field
     ///
     /// NOTE: Caller affirms that the schema was alreasdy validated by
-    /// [`crate::table_features::validate_column_mapping_schema`], to ensure that
+    /// [`crate::table_features::validate_schema_column_mapping`], to ensure that
     /// annotations are always and only present when column mapping mode is enabled.
     pub fn make_physical(&self) -> Self {
         struct MakePhysical;

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -10,7 +10,9 @@ use crate::actions::{Metadata, Protocol};
 use crate::log_segment::LogSegment;
 use crate::scan::ScanBuilder;
 use crate::schema::Schema;
-use crate::table_features::{column_mapping_mode, ColumnMappingMode};
+use crate::table_features::{
+    column_mapping_mode, validate_schema_column_mapping, ColumnMappingMode,
+};
 use crate::table_properties::TableProperties;
 use crate::{DeltaResult, Engine, Error, FileSystemClient, Version};
 
@@ -82,9 +84,12 @@ impl Snapshot {
         // important! before a read/write to the table we must check it is supported
         protocol.ensure_read_supported()?;
 
+        // validate column mapping mode -- all schema fields should be correctly (un)annotated
         let schema = metadata.schema()?;
         let table_properties = metadata.parse_table_properties();
         let column_mapping_mode = column_mapping_mode(&protocol, &table_properties);
+        validate_schema_column_mapping(&schema, column_mapping_mode)?;
+
         Ok(Self {
             table_root: location,
             log_segment,

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -85,9 +85,9 @@ impl Snapshot {
         protocol.ensure_read_supported()?;
 
         // validate column mapping mode -- all schema fields should be correctly (un)annotated
-        let schema = metadata.schema()?;
+        let schema = metadata.parse_schema()?;
         let table_properties = metadata.parse_table_properties();
-        let column_mapping_mode = column_mapping_mode(&protocol, &table_properties);
+        let column_mapping_mode = column_mapping_mode(&protocol, &table_properties)?;
         validate_schema_column_mapping(&schema, column_mapping_mode)?;
 
         Ok(Self {

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -87,7 +87,7 @@ impl Snapshot {
         // validate column mapping mode -- all schema fields should be correctly (un)annotated
         let schema = metadata.parse_schema()?;
         let table_properties = metadata.parse_table_properties();
-        let column_mapping_mode = column_mapping_mode(&protocol, &table_properties)?;
+        let column_mapping_mode = column_mapping_mode(&protocol, &table_properties);
         validate_schema_column_mapping(&schema, column_mapping_mode)?;
 
         Ok(Self {

--- a/kernel/src/table_changes/mod.rs
+++ b/kernel/src/table_changes/mod.rs
@@ -8,7 +8,6 @@ use crate::log_segment::LogSegment;
 use crate::path::AsUrl;
 use crate::schema::{DataType, Schema, StructField, StructType};
 use crate::snapshot::Snapshot;
-use crate::table_features::ColumnMappingMode;
 use crate::{DeltaResult, Engine, Error, Version};
 
 pub mod scan;
@@ -163,11 +162,6 @@ impl TableChanges {
     #[allow(unused)]
     pub(crate) fn partition_columns(&self) -> &Vec<String> {
         &self.end_snapshot.metadata().partition_columns
-    }
-    /// The column mapping mode at the end schema.
-    #[allow(unused)]
-    pub(crate) fn column_mapping_mode(&self) -> &ColumnMappingMode {
-        &self.end_snapshot.column_mapping_mode
     }
 
     /// Create a [`TableChangesScanBuilder`] for an `Arc<TableChanges>`.

--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -139,8 +139,7 @@ impl TableChangesScanBuilder {
                 } else {
                     // Add to read schema, store field so we can build a `Column` expression later
                     // if needed (i.e. if we have partition columns)
-                    let physical_field =
-                        logical_field.make_physical(*self.table_changes.column_mapping_mode())?;
+                    let physical_field = logical_field.make_physical();
                     debug!("\n\n{logical_field:#?}\nAfter mapping: {physical_field:#?}\n\n");
                     let physical_name = physical_field.name.clone();
                     read_fields.push(physical_field);

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -28,18 +28,17 @@ pub enum ColumnMappingMode {
 pub(crate) fn column_mapping_mode(
     protocol: &Protocol,
     table_properties: &TableProperties,
-) -> DeltaResult<ColumnMappingMode> {
+) -> ColumnMappingMode {
     match (
         table_properties.column_mapping_mode,
         protocol.min_reader_version(),
     ) {
-        // NOTE: The table property is optional even when the feature is supported
-        (None, _) => Ok(ColumnMappingMode::None),
-        (Some(mode), 2) => Ok(mode),
-        (Some(mode), 3) if protocol.has_reader_feature(&ReaderFeatures::ColumnMapping) => Ok(mode),
-        (Some(_), _) => Err(Error::invalid_column_mapping_mode(
-            "Table does not support column mapping mode, but the table property is set",
-        )),
+        // NOTE: The table property is optional even when the feature is supported, and should be
+        // ignored when the feature is not supported. For details see
+        // https://github.com/delta-io/delta/blob/master/PROTOCOL.md#column-mapping
+        (Some(mode), 2) => mode,
+        (Some(mode), 3) if protocol.has_reader_feature(&ReaderFeatures::ColumnMapping) => mode,
+        _ => ColumnMappingMode::None,
     }
 }
 
@@ -174,20 +173,28 @@ mod tests {
         let empty_table_properties = TableProperties::from([] as [(String, String); 0]);
 
         let protocol = Protocol::try_new(2, 5, None::<Vec<String>>, None::<Vec<String>>).unwrap();
+
         assert_eq!(
-            column_mapping_mode(&protocol, &table_properties).unwrap(),
+            column_mapping_mode(&protocol, &table_properties),
             ColumnMappingMode::Id
+        );
+
+        assert_eq!(
+            column_mapping_mode(&protocol, &empty_table_properties),
+            ColumnMappingMode::None
         );
 
         let empty_features = Some::<[String; 0]>([]);
         let protocol =
             Protocol::try_new(3, 7, empty_features.clone(), empty_features.clone()).unwrap();
 
-        column_mapping_mode(&protocol, &table_properties)
-            .expect_err("table property set but feature not supported");
+        assert_eq!(
+            column_mapping_mode(&protocol, &table_properties),
+            ColumnMappingMode::None
+        );
 
         assert_eq!(
-            column_mapping_mode(&protocol, &empty_table_properties).unwrap(),
+            column_mapping_mode(&protocol, &empty_table_properties),
             ColumnMappingMode::None
         );
 
@@ -198,9 +205,15 @@ mod tests {
             empty_features.clone(),
         )
         .unwrap();
+
         assert_eq!(
-            column_mapping_mode(&protocol, &table_properties).unwrap(),
+            column_mapping_mode(&protocol, &table_properties),
             ColumnMappingMode::Id
+        );
+
+        assert_eq!(
+            column_mapping_mode(&protocol, &empty_table_properties),
+            ColumnMappingMode::None
         );
 
         let protocol = Protocol::try_new(
@@ -211,11 +224,13 @@ mod tests {
         )
         .unwrap();
 
-        column_mapping_mode(&protocol, &table_properties)
-            .expect_err("table property set but feature not supported");
+        assert_eq!(
+            column_mapping_mode(&protocol, &table_properties),
+            ColumnMappingMode::None
+        );
 
         assert_eq!(
-            column_mapping_mode(&protocol, &empty_table_properties).unwrap(),
+            column_mapping_mode(&protocol, &empty_table_properties),
             ColumnMappingMode::None
         );
 
@@ -229,9 +244,15 @@ mod tests {
             empty_features,
         )
         .unwrap();
+
         assert_eq!(
-            column_mapping_mode(&protocol, &table_properties).unwrap(),
+            column_mapping_mode(&protocol, &table_properties),
             ColumnMappingMode::Id
+        );
+
+        assert_eq!(
+            column_mapping_mode(&protocol, &empty_table_properties),
+            ColumnMappingMode::None
         );
     }
 }

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -258,7 +258,10 @@ mod tests {
     }
 
     // Creates optional schema field annotations for column mapping id and physical name, as a string.
-    fn create_annotations<'a>(id: impl Into<Option<&'a str>>, name: impl Into<Option<&'a str>>) -> String {
+    fn create_annotations<'a>(
+        id: impl Into<Option<&'a str>>,
+        name: impl Into<Option<&'a str>>,
+    ) -> String {
         let mut annotations = vec![];
         if let Some(id) = id.into() {
             annotations.push(format!("\"delta.columnMapping.id\": {id}"));
@@ -270,9 +273,14 @@ mod tests {
     }
 
     // Creates a generic schema with optional field annotations for column mapping id and physical name.
-    fn create_schema<'a>(inner_id: impl Into<Option<&'a str>>, inner_name: impl Into<Option<&'a str>>, outer_id: impl Into<Option<&'a str>>, outer_name: impl Into<Option<&'a str>>) -> StructType {
-
-        let schema = format!(r#"
+    fn create_schema<'a>(
+        inner_id: impl Into<Option<&'a str>>,
+        inner_name: impl Into<Option<&'a str>>,
+        outer_id: impl Into<Option<&'a str>>,
+        outer_name: impl Into<Option<&'a str>>,
+    ) -> StructType {
+        let schema = format!(
+            r#"
         {{
             "name": "e",
             "type": {{
@@ -293,7 +301,10 @@ mod tests {
             "nullable": true,
             "metadata": {{ {} }}
         }}
-        "#, create_annotations(inner_id, inner_name), create_annotations(outer_id, outer_name));
+        "#,
+            create_annotations(inner_id, inner_name),
+            create_annotations(outer_id, outer_name)
+        );
         println!("{}", schema);
         StructType::new([serde_json::from_str(&schema).unwrap()])
     }
@@ -306,25 +317,33 @@ mod tests {
 
         // missing annotation
         let schema = create_schema(None, "\"col-a7f4159c\"", "4", "\"col-5f422f40\"");
-        validate_schema_column_mapping(&schema, ColumnMappingMode::Name).expect_err("missing field id");
+        validate_schema_column_mapping(&schema, ColumnMappingMode::Name)
+            .expect_err("missing field id");
         let schema = create_schema("5", None, "4", "\"col-5f422f40\"");
-        validate_schema_column_mapping(&schema, ColumnMappingMode::Name).expect_err("missing field name");
+        validate_schema_column_mapping(&schema, ColumnMappingMode::Name)
+            .expect_err("missing field name");
         let schema = create_schema("5", "\"col-a7f4159c\"", None, "\"col-5f422f40\"");
-        validate_schema_column_mapping(&schema, ColumnMappingMode::Name).expect_err("missing field id");
+        validate_schema_column_mapping(&schema, ColumnMappingMode::Name)
+            .expect_err("missing field id");
         let schema = create_schema("5", "\"col-a7f4159c\"", "4", None);
-        validate_schema_column_mapping(&schema, ColumnMappingMode::Name).expect_err("missing field name");
+        validate_schema_column_mapping(&schema, ColumnMappingMode::Name)
+            .expect_err("missing field name");
 
         // wrong-type field id annotation (string instead of int)
         let schema = create_schema("\"5\"", "\"col-a7f4159c\"", "4", "\"col-5f422f40\"");
-        validate_schema_column_mapping(&schema, ColumnMappingMode::Name).expect_err("invalid field id");
+        validate_schema_column_mapping(&schema, ColumnMappingMode::Name)
+            .expect_err("invalid field id");
         let schema = create_schema("5", "\"col-a7f4159c\"", "\"4\"", "\"col-5f422f40\"");
-        validate_schema_column_mapping(&schema, ColumnMappingMode::Name).expect_err("invalid field id");
+        validate_schema_column_mapping(&schema, ColumnMappingMode::Name)
+            .expect_err("invalid field id");
 
         // wrong-type field name annotation (int instead of string)
         let schema = create_schema("5", "555", "4", "\"col-5f422f40\"");
-        validate_schema_column_mapping(&schema, ColumnMappingMode::Name).expect_err("invalid field name");
+        validate_schema_column_mapping(&schema, ColumnMappingMode::Name)
+            .expect_err("invalid field name");
         let schema = create_schema("5", "\"col-a7f4159c\"", "4", "444");
-        validate_schema_column_mapping(&schema, ColumnMappingMode::Name).expect_err("invalid field name");
+        validate_schema_column_mapping(&schema, ColumnMappingMode::Name)
+            .expect_err("invalid field name");
     }
 
     #[test]

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -33,8 +33,8 @@ pub(crate) fn column_mapping_mode(
         table_properties.column_mapping_mode,
         protocol.min_reader_version(),
     ) {
-        // NOTE: The table property is optional even when the feature is supported, and should be
-        // ignored when the feature is not supported. For details see
+        // NOTE: The table property is optional even when the feature is supported, and is allowed
+        // (but should be ignored) even when the feature is not supported. For details see
         // https://github.com/delta-io/delta/blob/master/PROTOCOL.md#column-mapping
         (Some(mode), 2) => mode,
         (Some(mode), 3) if protocol.has_reader_feature(&ReaderFeatures::ColumnMapping) => mode,

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -41,10 +41,7 @@ pub(crate) fn column_mapping_mode(
 
 /// When column mapping mode is enabled, verify that each field in the schema is annotated with a
 /// physical name and field_id; when not enabled, verify that no fields are annotated.
-pub(crate) fn validate_schema_column_mapping(
-    schema: &Schema,
-    mode: ColumnMappingMode,
-) -> DeltaResult<()> {
+pub fn validate_schema_column_mapping(schema: &Schema, mode: ColumnMappingMode) -> DeltaResult<()> {
     if mode == ColumnMappingMode::Id {
         // TODO: Support column mapping ID mode
         return Err(Error::unsupported("Column mapping ID mode not supported"));

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -1,7 +1,11 @@
 //! Code to handle column mapping, including modes and schema transforms
 use super::ReaderFeatures;
 use crate::actions::Protocol;
+use crate::schema::{ColumnName, DataType, MetadataValue, Schema, SchemaTransform, StructField};
 use crate::table_properties::TableProperties;
+use crate::{DeltaResult, Error};
+
+use std::borrow::Cow;
 
 use serde::{Deserialize, Serialize};
 use strum::EnumString;
@@ -25,15 +29,132 @@ pub(crate) fn column_mapping_mode(
     protocol: &Protocol,
     table_properties: &TableProperties,
 ) -> ColumnMappingMode {
-    match table_properties.column_mapping_mode {
-        Some(mode) if protocol.min_reader_version() == 2 => mode,
-        Some(mode)
-            if protocol.min_reader_version() == 3
-                && protocol.has_reader_feature(&ReaderFeatures::ColumnMapping) =>
-        {
-            mode
-        }
+    match (
+        table_properties.column_mapping_mode,
+        protocol.min_reader_version(),
+    ) {
+        (Some(mode), 2) => mode,
+        (Some(mode), 3) if protocol.has_reader_feature(&ReaderFeatures::ColumnMapping) => mode,
         _ => ColumnMappingMode::None,
+    }
+}
+
+/// When column mapping mode is enabled, verify that each field in the schema is annotated with a
+/// physical name and field_id; when not enabled, verify that no fields are annotated.
+pub(crate) fn validate_schema_column_mapping(
+    schema: &Schema,
+    mode: ColumnMappingMode,
+) -> DeltaResult<()> {
+    if mode == ColumnMappingMode::Id {
+        // TODO: Support column mapping ID mode
+        return Err(Error::unsupported("Column mapping ID mode not supported"));
+    }
+
+    let mut validator = ValidateColumnMappings {
+        mode,
+        path: vec![],
+        err: None,
+    };
+    let _ = validator.transform_struct(schema);
+    match validator.err {
+        Some(err) => Err(err),
+        None => Ok(()),
+    }
+}
+
+struct ValidateColumnMappings<'a> {
+    mode: ColumnMappingMode,
+    path: Vec<&'a str>,
+    err: Option<Error>,
+}
+
+impl<'a> ValidateColumnMappings<'a> {
+    fn transform_inner_type(
+        &mut self,
+        data_type: &'a DataType,
+        name: &'a str,
+    ) -> Option<Cow<'a, DataType>> {
+        if self.err.is_none() {
+            self.path.push(name);
+            let _ = self.transform(data_type);
+            self.path.pop();
+        }
+        None
+    }
+    fn check_annotations(&mut self, field: &StructField) {
+        // The iterator yields `&&str` but `ColumnName::new` needs `&str`
+        let column_name = || ColumnName::new(self.path.iter().copied());
+        let annotation = "delta.columnMapping.physicalName";
+        match (self.mode, field.metadata.get(annotation)) {
+            // Both Id and Name modes require a physical name annotation; None mode forbids it.
+            (ColumnMappingMode::None, None) => {}
+            (ColumnMappingMode::Name | ColumnMappingMode::Id, Some(MetadataValue::String(_))) => {}
+            (ColumnMappingMode::Name | ColumnMappingMode::Id, Some(_)) => {
+                self.err = Some(Error::invalid_column_mapping_mode(format!(
+                    "The {annotation} annotation on field '{}' must be a string",
+                    column_name()
+                )));
+            }
+            (ColumnMappingMode::None, Some(_)) => {
+                self.err = Some(Error::invalid_column_mapping_mode(format!(
+                    "Column mapping is not enabled but field '{annotation}' is annotated with {}",
+                    column_name()
+                )));
+            }
+            (ColumnMappingMode::Name | ColumnMappingMode::Id, None) => {
+                self.err = Some(Error::invalid_column_mapping_mode(format!(
+                    "Column mapping is enabled but field '{}' lacks the {annotation} annotation",
+                    column_name()
+                )));
+            }
+        }
+
+        let annotation = "delta.columnMapping.id";
+        match (self.mode, field.metadata.get(annotation)) {
+            // Both Id and Name modes require a field ID annotation; None mode forbids it.
+            (ColumnMappingMode::None, None) => {}
+            (ColumnMappingMode::Name | ColumnMappingMode::Id, Some(MetadataValue::Number(_))) => {}
+            (ColumnMappingMode::Name | ColumnMappingMode::Id, Some(_)) => {
+                self.err = Some(Error::invalid_column_mapping_mode(format!(
+                    "The {annotation} annotation on field '{}' must be a number",
+                    column_name()
+                )));
+            }
+            (ColumnMappingMode::None, Some(_)) => {
+                self.err = Some(Error::invalid_column_mapping_mode(format!(
+                    "Column mapping is not enabled but field '{}' is annotated with {annotation}",
+                    column_name()
+                )));
+            }
+            (ColumnMappingMode::Name | ColumnMappingMode::Id, None) => {
+                self.err = Some(Error::invalid_column_mapping_mode(format!(
+                    "Column mapping is enabled but field '{}' lacks the {annotation} annotation",
+                    column_name()
+                )));
+            }
+        }
+    }
+}
+
+impl<'a> SchemaTransform<'a> for ValidateColumnMappings<'a> {
+    // Override array element and map key/value for better error messages
+    fn transform_array_element(&mut self, etype: &'a DataType) -> Option<Cow<'a, DataType>> {
+        self.transform_inner_type(etype, "<array element>")
+    }
+    fn transform_map_key(&mut self, ktype: &'a DataType) -> Option<Cow<'a, DataType>> {
+        self.transform_inner_type(ktype, "<map key>")
+    }
+    fn transform_map_value(&mut self, vtype: &'a DataType) -> Option<Cow<'a, DataType>> {
+        self.transform_inner_type(vtype, "<map value>")
+    }
+    fn transform_struct_field(&mut self, field: &'a StructField) -> Option<Cow<'a, StructField>> {
+        if self.err.is_none() {
+            self.path.push(&field.name);
+            self.check_annotations(field);
+            let _ = self.recurse_into_struct_field(field);
+            self.path.pop();
+        }
+        None
     }
 }
 

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -4,8 +4,8 @@ use std::sync::LazyLock;
 use serde::{Deserialize, Serialize};
 use strum::{AsRefStr, Display as StrumDisplay, EnumString, VariantNames};
 
-pub(crate) use column_mapping::column_mapping_mode;
 pub use column_mapping::ColumnMappingMode;
+pub(crate) use column_mapping::{column_mapping_mode, validate_schema_column_mapping};
 mod column_mapping;
 
 /// Reader features communicate capabilities that must be implemented in order to correctly read a

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -4,8 +4,8 @@ use std::sync::LazyLock;
 use serde::{Deserialize, Serialize};
 use strum::{AsRefStr, Display as StrumDisplay, EnumString, VariantNames};
 
-pub use column_mapping::ColumnMappingMode;
-pub(crate) use column_mapping::{column_mapping_mode, validate_schema_column_mapping};
+pub(crate) use column_mapping::column_mapping_mode;
+pub use column_mapping::{validate_schema_column_mapping, ColumnMappingMode};
 mod column_mapping;
 
 /// Reader features communicate capabilities that must be implemented in order to correctly read a


### PR DESCRIPTION
## What changes are proposed in this pull request?

Today's code scatters column mapping validity checks around the various use sites which makes them complex and requires propagating the column mapping mode through various function calls.

We can simplify by validating the schema once, up front during snapshot load. In particular:
1. Ensure that (correct) column mapping annotations are present in the schema exactly and only when column mapping is actually enabled. This simplifies logical -> physical name translation because we should use the annotation if present and use the field's logical name otherwise.
2. Reject column mapping ID mode early. Most code only needs to care whether column mapping is enabled at all.

As a result, most column mapping operations become infallible and with simpler code. 

### This PR affects the following public APIs

`StructField::physical_name` no longer takes a `ColumnMapping` argument, because it is no longer needed for validation.

## How was this change tested?

Existing unit tests.