### PR TITLE
ScanFile expression and visitor for CDF

### DIFF
--- a/kernel/src/scan/state.rs
+++ b/kernel/src/scan/state.rs
@@ -112,11 +112,11 @@ pub type ScanCallback<T> = fn(
 /// ## Example
 /// ```ignore
 /// let mut context = [my context];
-/// for res in scan_data { // scan data from scan.get_scan_data()
+/// for res in scan_data { // scan data from scan.scan_data()
 ///     let (data, vector) = res?;
 ///     context = delta_kernel::scan::state::visit_scan_files(
 ///        data.as_ref(),
-///        vector,
+///        selection_vector,
 ///        context,
 ///        my_callback,
 ///     )?;

--- a/kernel/src/table_changes/log_replay.rs
+++ b/kernel/src/table_changes/log_replay.rs
@@ -21,6 +21,7 @@ use crate::table_changes::{check_cdf_table_properties, ensure_cdf_read_supported
 use crate::table_properties::TableProperties;
 use crate::utils::require;
 use crate::{DeltaResult, Engine, EngineData, Error, ExpressionRef, RowVisitor};
+
 use itertools::Itertools;
 
 #[cfg(test)]

--- a/kernel/src/table_changes/log_replay.rs
+++ b/kernel/src/table_changes/log_replay.rs
@@ -11,12 +11,12 @@ use crate::actions::{
     PROTOCOL_NAME, REMOVE_NAME,
 };
 use crate::engine_data::{GetData, TypedGetData};
-use crate::expressions::{column_expr, column_name, ColumnName, Expression};
+use crate::expressions::{column_name, ColumnName};
 use crate::path::ParsedLogPath;
 use crate::scan::data_skipping::DataSkippingFilter;
-use crate::scan::scan_row_schema;
 use crate::scan::state::DvInfo;
 use crate::schema::{ArrayType, ColumnNamesAndTypes, DataType, MapType, SchemaRef, StructType};
+use crate::table_changes::scan_file::{cdf_scan_row_expression, cdf_scan_row_schema};
 use crate::table_changes::{check_cdf_table_properties, ensure_cdf_read_supported};
 use crate::table_properties::TableProperties;
 use crate::utils::require;
@@ -64,21 +64,6 @@ pub(crate) fn table_changes_action_iter(
         .flatten_ok() // Iterator-Result-Result
         .map(|x| x?); // Iterator-Result
     Ok(result)
-}
-
-// Gets the expression for generating the engine data in [`TableChangesScanData`].
-//
-// TODO: This expression is temporary. In the future it will also select `cdc` and `remove` actions
-// fields.
-fn add_transform_expr() -> Expression {
-    Expression::Struct(vec![
-        column_expr!("add.path"),
-        column_expr!("add.size"),
-        column_expr!("add.modificationTime"),
-        column_expr!("add.stats"),
-        column_expr!("add.deletionVector"),
-        Expression::Struct(vec![column_expr!("add.partitionValues")]),
-    ])
 }
 
 /// Processes a single commit file from the log to generate an iterator of [`TableChangesScanData`].
@@ -238,7 +223,7 @@ impl LogReplayScanner {
             remove_dvs,
             commit_file,
             // TODO: Add the timestamp as a column with an expression
-            timestamp: _,
+            timestamp,
         } = self;
         let remove_dvs = Arc::new(remove_dvs);
 
@@ -248,10 +233,14 @@ impl LogReplayScanner {
             schema,
             None,
         )?;
+        let commit_version = commit_file
+            .version
+            .try_into()
+            .map_err(|_| Error::generic("Failed to convert commit version to i64"))?;
         let evaluator = engine.get_expression_handler().get_evaluator(
             get_log_add_schema().clone(),
-            add_transform_expr(),
-            scan_row_schema().into(),
+            cdf_scan_row_expression(timestamp, commit_version),
+            cdf_scan_row_schema().into(),
         );
 
         let result = action_iter.map(move |actions| -> DeltaResult<_> {

--- a/kernel/src/table_changes/log_replay.rs
+++ b/kernel/src/table_changes/log_replay.rs
@@ -37,7 +37,7 @@ pub(crate) struct TableChangesScanData {
     pub(crate) scan_data: Box<dyn EngineData>,
     /// The selection vector used to filter the `scan_data`.
     pub(crate) selection_vector: Vec<bool>,
-    /// An map from a remove action's path to its deletion vector
+    /// A map from a remove action's path to its deletion vector
     pub(crate) remove_dvs: Arc<HashMap<String, DvInfo>>,
 }
 

--- a/kernel/src/table_changes/mod.rs
+++ b/kernel/src/table_changes/mod.rs
@@ -17,6 +17,7 @@ use crate::{DeltaResult, Engine, Error, Version};
 
 mod log_replay;
 pub mod scan;
+mod scan_file;
 
 static CDF_FIELDS: LazyLock<[StructField; 3]> = LazyLock::new(|| {
     [

--- a/kernel/src/table_changes/scan_file.rs
+++ b/kernel/src/table_changes/scan_file.rs
@@ -108,7 +108,8 @@ pub(crate) fn visit_cdf_scan_files<T>(
     Ok(visitor.context)
 }
 
-// add some visitor magic for engines
+/// A visitor that extracts [`CdfScanFile`]s from engine data. Expects data to have the schema
+/// [`cdf_scan_row_schema`].
 #[allow(unused)]
 struct CdfScanFileVisitor<'a, T> {
     callback: CdfScanCallback<T>,

--- a/kernel/src/table_changes/scan_file.rs
+++ b/kernel/src/table_changes/scan_file.rs
@@ -35,7 +35,7 @@ pub(crate) struct CdfScanFile {
     /// A `&str` which is the path to the file
     pub path: String,
     /// A [`DvInfo`] struct with the path to the action's deletion vector
-    pub add_dv: DvInfo,
+    pub dv_info: DvInfo,
     /// An optional [`DvInfo`] struct. If present, this is deletion vector of a remove action with
     /// the same path as this [`CdfScanFile`]
     pub remove_dv: Option<DvInfo>,
@@ -159,7 +159,7 @@ impl<T> RowVisitor for CdfScanFileVisitor<'_, T> {
                 remove_dv: self.remove_dvs.get(&path).cloned(),
                 scan_type,
                 path,
-                add_dv: DvInfo { deletion_vector },
+                dv_info: DvInfo { deletion_vector },
                 partition_values,
                 commit_timestamp: getters[16].get(row_index, "scanFile.timestamp")?,
                 commit_version: getters[17].get(row_index, "scanFile.commit_version")?,
@@ -263,7 +263,7 @@ mod tests {
         let engine = SyncEngine::new();
         let mut mock_table = LocalMockTable::new();
 
-        let add_dv = DeletionVectorDescriptor {
+        let dv_info = DeletionVectorDescriptor {
             storage_type: "u".to_string(),
             path_or_inline_dv: "vBn[lx{q8@P<9BNH/isA".to_string(),
             offset: Some(1),
@@ -273,7 +273,7 @@ mod tests {
         let add_partition_values = HashMap::from([("a".to_string(), "b".to_string())]);
         let add_paired = Add {
             path: "fake_path_1".into(),
-            deletion_vector: Some(add_dv.clone()),
+            deletion_vector: Some(dv_info.clone()),
             partition_values: add_partition_values,
             data_change: true,
             ..Default::default()
@@ -365,7 +365,7 @@ mod tests {
             CdfScanFile {
                 scan_type: CdfScanFileType::Add,
                 path: add_paired.path,
-                add_dv: DvInfo {
+                dv_info: DvInfo {
                     deletion_vector: add_paired.deletion_vector,
                 },
                 partition_values: add_paired.partition_values,
@@ -376,7 +376,7 @@ mod tests {
             CdfScanFile {
                 scan_type: CdfScanFileType::Remove,
                 path: remove.path,
-                add_dv: DvInfo {
+                dv_info: DvInfo {
                     deletion_vector: remove.deletion_vector,
                 },
                 partition_values: remove.partition_values.unwrap(),
@@ -387,7 +387,7 @@ mod tests {
             CdfScanFile {
                 scan_type: CdfScanFileType::Cdc,
                 path: cdc.path,
-                add_dv: DvInfo {
+                dv_info: DvInfo {
                     deletion_vector: None,
                 },
                 partition_values: cdc.partition_values,
@@ -398,7 +398,7 @@ mod tests {
             CdfScanFile {
                 scan_type: CdfScanFileType::Remove,
                 path: remove_no_partition.path,
-                add_dv: DvInfo {
+                dv_info: DvInfo {
                     deletion_vector: None,
                 },
                 partition_values: HashMap::new(),

--- a/kernel/src/table_changes/scan_file.rs
+++ b/kernel/src/table_changes/scan_file.rs
@@ -1,0 +1,403 @@
+//! This module handles [`CDFScanFile`]s for [`TableChangeScan`]. A [`CDFScanFile`] consists of all the
+//! metadata required to generate a change data feed. [`CDFScanFile`] can be constructed using
+//! [`CDFScanFileVisitor`]. The visitor reads from engine data with the schema [`cdf_scan_row_schema`].
+//! You can convert engine data to this schema using the [`get_cdf_scan_row_expression`].
+use itertools::Itertools;
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock};
+
+use super::log_replay::TableChangesScanData;
+use crate::actions::visitors::visit_deletion_vector_at;
+use crate::engine_data::{GetData, TypedGetData};
+use crate::expressions::{column_expr, Expression};
+use crate::scan::state::DvInfo;
+use crate::schema::{
+    ColumnName, ColumnNamesAndTypes, DataType, MapType, SchemaRef, StructField, StructType,
+};
+use crate::utils::require;
+use crate::{DeltaResult, EngineData, Error, RowVisitor};
+
+#[allow(unused)]
+pub(crate) struct UnresolvedCDFScanFile {
+    pub scan_file: CDFScanFile,
+    pub remove_dvs: Arc<HashMap<String, DvInfo>>,
+}
+#[allow(unused)]
+#[derive(Debug)]
+pub(crate) struct ResolvedCDFScanFile {
+    pub scan_file: CDFScanFile,
+    pub selection_vector: Option<Vec<bool>>,
+}
+
+// The type of action associated with a [`CDFScanFile`].
+#[allow(unused)]
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum CDFScanFileType {
+    Add,
+    Remove,
+    Cdc,
+}
+
+/// Represents all the metadata needed to read a Change Data Feed.
+#[allow(unused)]
+#[derive(Debug, PartialEq, Clone)]
+pub(crate) struct CDFScanFile {
+    /// The type of action this file belongs to. This may be one of add, remove, or cdc.
+    pub scan_type: CDFScanFileType,
+    /// a `&str` which is the path to the file
+    pub path: String,
+    /// a [`DvInfo`] struct, which allows getting the selection vector for this file
+    pub dv_info: DvInfo,
+    /// a `HashMap<String, String>` which are partition values
+    pub partition_values: HashMap<String, String>,
+    /// the commit version that this action was performed in
+    pub commit_version: i64,
+    /// the timestamp of the commit that this action was performed in
+    pub commit_timestamp: i64,
+}
+
+pub(crate) type CDFScanCallback<T> = fn(context: &mut T, scan_file: CDFScanFile);
+
+/// Transforms an iterator of TableChangesScanData into an iterator  of
+/// `UnresolvedCDFScanFile` by visiting the engine data.
+#[allow(unused)]
+pub(crate) fn scan_data_to_scan_file(
+    scan_data: impl Iterator<Item = DeltaResult<TableChangesScanData>>,
+) -> impl Iterator<Item = DeltaResult<UnresolvedCDFScanFile>> {
+    scan_data
+        .map(|scan_data| -> DeltaResult<_> {
+            let scan_data = scan_data?;
+            let callback: CDFScanCallback<Vec<CDFScanFile>> =
+                |context, scan_file| context.push(scan_file);
+            let result = visit_cdf_scan_files(
+                scan_data.scan_data.as_ref(),
+                &scan_data.selection_vector,
+                vec![],
+                callback,
+            )?
+            .into_iter()
+            .map(move |scan_file| UnresolvedCDFScanFile {
+                scan_file,
+                remove_dvs: scan_data.remove_dvs.clone(),
+            });
+            Ok(result)
+        }) // Iterator-Result-Iterator
+        .flatten_ok() // Iterator-Result
+}
+
+/// Request that the kernel call a callback on each valid file that needs to be read for the
+/// scan.
+///
+/// The arguments to the callback are:
+/// * `context`: an `&mut context` argument. this can be anything that engine needs to pass through to each call
+/// * `CDFScanFile`: a [`CDFScanFile`] struct that holds all the metadata required to perform Change Data
+///   Feed
+///
+/// ## Context
+/// A note on the `context`. This can be any value the engine wants. This function takes ownership
+/// of the passed arg, but then returns it, so the engine can repeatedly call `visit_cdf_scan_files`
+/// with the same context.
+///
+/// ## Example
+/// ```ignore
+/// let mut context = [my context];
+/// for res in scan_data { // scan data table_changes_scan.scan_data()
+///     let (data, vector, remove_dv) = res?;
+///     context = delta_kernel::table_changes::scan_file::visit_cdf_scan_files(
+///        data.as_ref(),
+///        selection_vector,
+///        context,
+///        my_callback,
+///     )?;
+/// }
+/// ```
+#[allow(unused)]
+pub(crate) fn visit_cdf_scan_files<T>(
+    data: &dyn EngineData,
+    selection_vector: &[bool],
+    context: T,
+    callback: CDFScanCallback<T>,
+) -> DeltaResult<T> {
+    let mut visitor = CDFScanFileVisitor {
+        callback,
+        selection_vector,
+        context,
+    };
+
+    visitor.visit_rows_of(data)?;
+    Ok(visitor.context)
+}
+
+// add some visitor magic for engines
+#[allow(unused)]
+struct CDFScanFileVisitor<'a, T> {
+    callback: CDFScanCallback<T>,
+    selection_vector: &'a [bool],
+    context: T,
+}
+
+impl<T> RowVisitor for CDFScanFileVisitor<'_, T> {
+    fn visit<'a>(&mut self, row_count: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
+        require!(
+            getters.len() == 18,
+            Error::InternalError(format!(
+                "Wrong number of CDFScanFileVisitor getters: {}",
+                getters.len()
+            ))
+        );
+        for row_index in 0..row_count {
+            if !self.selection_vector[row_index] {
+                continue;
+            }
+
+            let (scan_type, path, deletion_vector, partition_values) =
+                if let Some(path) = getters[0].get_opt(row_index, "scanFile.add.path")? {
+                    let scan_type = CDFScanFileType::Add;
+                    let deletion_vector = visit_deletion_vector_at(row_index, &getters[1..=5])?;
+                    let partition_values = getters[6]
+                        .get(row_index, "scanFile.add.fileConstantValues.partitionValues")?;
+                    (scan_type, path, deletion_vector, partition_values)
+                } else if let Some(path) = getters[7].get_opt(row_index, "scanFile.remove.path")? {
+                    let scan_type = CDFScanFileType::Remove;
+                    let deletion_vector = visit_deletion_vector_at(row_index, &getters[8..=12])?;
+                    let partition_values = getters[13].get(
+                        row_index,
+                        "scanFile.remove.fileConstantValues.partitionValues",
+                    )?;
+                    (scan_type, path, deletion_vector, partition_values)
+                } else if let Some(path) = getters[14].get_opt(row_index, "scanFile.cdc.path")? {
+                    let scan_type = CDFScanFileType::Cdc;
+                    let partition_values = getters[15]
+                        .get(row_index, "scanFile.cdc.fileConstantValues.partitionValues")?;
+                    (scan_type, path, None, partition_values)
+                } else {
+                    continue;
+                };
+            let dv_info = DvInfo { deletion_vector };
+            let scan_file = CDFScanFile {
+                scan_type,
+                path,
+                dv_info,
+                partition_values,
+                commit_timestamp: getters[16].get(row_index, "scanFile.timestamp")?,
+                commit_version: getters[17].get(row_index, "scanFile.commit_version")?,
+            };
+            (self.callback)(&mut self.context, scan_file)
+        }
+        Ok(())
+    }
+
+    fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
+        static NAMES_AND_TYPES: LazyLock<ColumnNamesAndTypes> =
+            LazyLock::new(|| cdf_scan_row_schema().leaves(None));
+        NAMES_AND_TYPES.as_ref()
+    }
+}
+
+/// Get the schema that scan rows (from [`TableChanges::scan_data`]) will be returned with.
+pub(crate) fn cdf_scan_row_schema() -> SchemaRef {
+    static CDF_SCAN_ROW_SCHEMA: LazyLock<Arc<StructType>> = LazyLock::new(|| {
+        let deletion_vector = StructType::new([
+            StructField::new("storageType", DataType::STRING, true),
+            StructField::new("pathOrInlineDv", DataType::STRING, true),
+            StructField::new("offset", DataType::INTEGER, true),
+            StructField::new("sizeInBytes", DataType::INTEGER, true),
+            StructField::new("cardinality", DataType::LONG, true),
+        ]);
+        let partition_values = MapType::new(DataType::STRING, DataType::STRING, true);
+        let file_constant_values =
+            StructType::new([StructField::new("partitionValues", partition_values, true)]);
+
+        let add = StructType::new([
+            StructField::new("path", DataType::STRING, true),
+            StructField::new("deletionVector", deletion_vector.clone(), true),
+            StructField::new("fileConstantValues", file_constant_values.clone(), true),
+        ]);
+        let remove = StructType::new([
+            StructField::new("path", DataType::STRING, true),
+            StructField::new("deletionVector", deletion_vector, true),
+            StructField::new("fileConstantValues", file_constant_values.clone(), true),
+        ]);
+        let cdc = StructType::new([
+            StructField::new("path", DataType::STRING, true),
+            StructField::new("fileConstantValues", file_constant_values, true),
+        ]);
+
+        Arc::new(StructType::new([
+            StructField::new("add", add, true),
+            StructField::new("remove", remove, true),
+            StructField::new("cdc", cdc, true),
+            StructField::new("timestamp", DataType::LONG, true),
+            StructField::new("commit_version", DataType::LONG, true),
+        ]))
+    });
+    CDF_SCAN_ROW_SCHEMA.clone()
+}
+
+/// Expression to convert an action with `log_schema` into one with
+/// `TABLE_CHANGES_cdf_scan_row_schema`. This is the expression used to create `TableChangesScanData`.
+#[allow(unused)]
+pub(crate) fn get_cdf_scan_row_expression(commit_timestamp: i64, commit_number: i64) -> Expression {
+    Expression::struct_from([
+        Expression::struct_from([
+            column_expr!("add.path"),
+            column_expr!("add.deletionVector"),
+            Expression::struct_from([column_expr!("add.partitionValues")]),
+        ]),
+        Expression::struct_from([
+            column_expr!("remove.path"),
+            column_expr!("remove.deletionVector"),
+            Expression::struct_from([column_expr!("remove.partitionValues")]),
+        ]),
+        Expression::struct_from([
+            column_expr!("cdc.path"),
+            Expression::struct_from([column_expr!("cdc.partitionValues")]),
+        ]),
+        commit_timestamp.into(),
+        commit_number.into(),
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use itertools::Itertools;
+
+    use super::CDFScanFileType;
+    use super::{
+        cdf_scan_row_schema, get_cdf_scan_row_expression, visit_cdf_scan_files, CDFScanCallback,
+        CDFScanFile,
+    };
+    use crate::actions::deletion_vector::DeletionVectorDescriptor;
+    use crate::actions::{get_log_schema, Add, Cdc, Remove};
+    use crate::engine::sync::SyncEngine;
+    use crate::log_segment::LogSegment;
+    use crate::scan::state::DvInfo;
+    use crate::utils::test_utils::{Action, LocalMockTable};
+    use crate::{DeltaResult, Engine};
+
+    #[tokio::test]
+    async fn schema_transform_correct() {
+        let engine = SyncEngine::new();
+        let mut mock_table = LocalMockTable::new();
+
+        let add_dv = DeletionVectorDescriptor {
+            storage_type: "u".to_string(),
+            path_or_inline_dv: "vBn[lx{q8@P<9BNH/isA".to_string(),
+            offset: Some(1),
+            size_in_bytes: 36,
+            cardinality: 2,
+        };
+        let add_partition_values = HashMap::from([("a".to_string(), "b".to_string())]);
+        let add = Add {
+            path: "fake_path_1".into(),
+            deletion_vector: Some(add_dv.clone()),
+            partition_values: add_partition_values,
+            ..Default::default()
+        };
+
+        let rm_dv = DeletionVectorDescriptor {
+            storage_type: "u".to_string(),
+            path_or_inline_dv: "U5OWRz5k%CFT.Td}yCPW".to_string(),
+            offset: Some(1),
+            size_in_bytes: 38,
+            cardinality: 3,
+        };
+        let rm_partition_values = Some(HashMap::from([("c".to_string(), "d".to_string())]));
+        let remove = Remove {
+            path: "fake_path_2".into(),
+            deletion_vector: Some(rm_dv),
+            partition_values: rm_partition_values,
+            ..Default::default()
+        };
+
+        let cdc_partition_values = HashMap::from([("x".to_string(), "y".to_string())]);
+        let cdc = Cdc {
+            path: "fake_path_3".into(),
+            partition_values: cdc_partition_values,
+            ..Default::default()
+        };
+
+        mock_table
+            .commit([
+                Action::Add(add.clone()),
+                Action::Remove(remove.clone()),
+                Action::Cdc(cdc.clone()),
+            ])
+            .await;
+
+        let table_root = url::Url::from_directory_path(mock_table.table_root()).unwrap();
+        let log_root = table_root.join("_delta_log/").unwrap();
+        let log_segment =
+            LogSegment::for_table_changes(engine.get_file_system_client().as_ref(), log_root, 0, 0)
+                .unwrap();
+        let commit = log_segment.ascending_commit_files[0].clone();
+
+        let actions = engine
+            .get_json_handler()
+            .read_json_files(&[commit.location.clone()], get_log_schema().clone(), None)
+            .unwrap();
+
+        // Transform the engine data into the [`cdf_scan_row_schema`] and insert
+        // the following timestamp and commit version.
+        let commit_timestamp = 1234_i64;
+        let commit_version = 42_i64;
+        let scan_files: Vec<_> = actions
+            .map_ok(|actions| {
+                engine
+                    .get_expression_handler()
+                    .get_evaluator(
+                        get_log_schema().clone(),
+                        get_cdf_scan_row_expression(commit_timestamp, commit_version),
+                        cdf_scan_row_schema().into(),
+                    )
+                    .evaluate(actions.as_ref())
+                    .unwrap()
+            })
+            .map(|data| -> DeltaResult<_> {
+                let data = data?;
+                let selection_vector = vec![true; data.len()];
+                let callback: CDFScanCallback<Vec<CDFScanFile>> =
+                    |context, scan_file| context.push(scan_file);
+                visit_cdf_scan_files(data.as_ref(), &selection_vector, vec![], callback)
+            })
+            .flatten_ok()
+            .try_collect()
+            .unwrap();
+
+        let expected_scan_files = vec![
+            CDFScanFile {
+                scan_type: CDFScanFileType::Add,
+                path: add.path,
+                dv_info: DvInfo {
+                    deletion_vector: add.deletion_vector,
+                },
+                partition_values: add.partition_values,
+                commit_version,
+                commit_timestamp,
+            },
+            CDFScanFile {
+                scan_type: CDFScanFileType::Remove,
+                path: remove.path,
+                dv_info: DvInfo {
+                    deletion_vector: remove.deletion_vector,
+                },
+                partition_values: remove.partition_values.unwrap(),
+                commit_version,
+                commit_timestamp,
+            },
+            CDFScanFile {
+                scan_type: CDFScanFileType::Cdc,
+                path: cdc.path,
+                dv_info: DvInfo {
+                    deletion_vector: None,
+                },
+                partition_values: cdc.partition_values,
+                commit_version,
+                commit_timestamp,
+            },
+        ];
+        assert_eq!(expected_scan_files, scan_files);
+    }
+}

--- a/kernel/src/table_changes/scan_file.rs
+++ b/kernel/src/table_changes/scan_file.rs
@@ -1,4 +1,4 @@
-//! This module handles [`CdfScanFile`]s for [`TableChangeScan`]. A [`CdfScanFile`] consists of all the
+//! This module handles [`CdfScanFile`]s for [`TableChangesScan`]. A [`CdfScanFile`] consists of all the
 //! metadata required to generate a change data feed. [`CdfScanFile`] can be constructed using
 //! [`CdfScanFileVisitor`]. The visitor reads from engine data with the schema [`cdf_scan_row_schema`].
 //! You can convert engine data to this schema using the [`cdf_scan_row_expression`].
@@ -49,8 +49,8 @@ pub(crate) struct CdfScanFile {
 
 pub(crate) type CdfScanCallback<T> = fn(context: &mut T, scan_file: CdfScanFile);
 
-/// Transforms an iterator of TableChangesScanData into an iterator  of
-/// `UnresolvedCdfScanFile` by visiting the engine data.
+/// Transforms an iterator of [`TableChangesScanData`] into an iterator of
+/// [`CdfScanFile`] by visiting the engine data.
 #[allow(unused)]
 pub(crate) fn scan_data_to_scan_file(
     scan_data: impl Iterator<Item = DeltaResult<TableChangesScanData>>,
@@ -101,7 +101,7 @@ pub(crate) fn visit_cdf_scan_files<T>(
         callback,
         context,
         selection_vector: &scan_data.selection_vector,
-        remove_dvs: &scan_data.remove_dvs,
+        remove_dvs: scan_data.remove_dvs.as_ref(),
     };
 
     visitor.visit_rows_of(scan_data.scan_data.as_ref())?;
@@ -114,7 +114,7 @@ pub(crate) fn visit_cdf_scan_files<T>(
 struct CdfScanFileVisitor<'a, T> {
     callback: CdfScanCallback<T>,
     selection_vector: &'a [bool],
-    remove_dvs: &'a Arc<HashMap<String, DvInfo>>,
+    remove_dvs: &'a HashMap<String, DvInfo>,
     context: T,
 }
 
@@ -218,7 +218,7 @@ pub(crate) fn cdf_scan_row_schema() -> SchemaRef {
 }
 
 /// Expression to convert an action with `log_schema` into one with
-/// `TABLE_CHANGES_cdf_scan_row_schema`. This is the expression used to create `TableChangesScanData`.
+/// [`cdf_scan_row_schema`]. This is the expression used to create [`TableChangesScanData`].
 #[allow(unused)]
 pub(crate) fn cdf_scan_row_expression(commit_timestamp: i64, commit_number: i64) -> Expression {
     Expression::struct_from([

--- a/kernel/src/table_changes/scan_file.rs
+++ b/kernel/src/table_changes/scan_file.rs
@@ -188,11 +188,10 @@ impl<T> RowVisitor for CdfScanFileVisitor<'_, T> {
                 } else {
                     continue;
                 };
-            let dv_info = DvInfo { deletion_vector };
             let scan_file = CdfScanFile {
                 scan_type,
                 path,
-                dv_info,
+                dv_info: DvInfo { deletion_vector },
                 partition_values,
                 commit_timestamp: getters[16].get(row_index, "scanFile.timestamp")?,
                 commit_version: getters[17].get(row_index, "scanFile.commit_version")?,

--- a/kernel/src/table_changes/scan_file.rs
+++ b/kernel/src/table_changes/scan_file.rs
@@ -330,7 +330,6 @@ mod tests {
             .commit([Action::Remove(remove_no_partition.clone())])
             .await;
 
-        // Read the table and generate [`TableChangesScanData`]
         let table_root = url::Url::from_directory_path(mock_table.table_root()).unwrap();
         let log_root = table_root.join("_delta_log/").unwrap();
         let log_segment = LogSegment::for_table_changes(

--- a/kernel/src/table_changes/scan_file.rs
+++ b/kernel/src/table_changes/scan_file.rs
@@ -211,7 +211,7 @@ impl<T> RowVisitor for CdfScanFileVisitor<'_, T> {
 
 /// Get the schema that scan rows (from [`TableChanges::scan_data`]) will be returned with.
 pub(crate) fn cdf_scan_row_schema() -> SchemaRef {
-    static Cdf_SCAN_ROW_SCHEMA: LazyLock<Arc<StructType>> = LazyLock::new(|| {
+    static CDF_SCAN_ROW_SCHEMA: LazyLock<Arc<StructType>> = LazyLock::new(|| {
         let deletion_vector = StructType::new([
             StructField::new("storageType", DataType::STRING, true),
             StructField::new("pathOrInlineDv", DataType::STRING, true),
@@ -246,7 +246,7 @@ pub(crate) fn cdf_scan_row_schema() -> SchemaRef {
             StructField::new("commit_version", DataType::LONG, true),
         ]))
     });
-    Cdf_SCAN_ROW_SCHEMA.clone()
+    CDF_SCAN_ROW_SCHEMA.clone()
 }
 
 /// Expression to convert an action with `log_schema` into one with

--- a/kernel/src/table_changes/scan_file.rs
+++ b/kernel/src/table_changes/scan_file.rs
@@ -1,7 +1,7 @@
 //! This module handles [`CdfScanFile`]s for [`TableChangeScan`]. A [`CdfScanFile`] consists of all the
 //! metadata required to generate a change data feed. [`CdfScanFile`] can be constructed using
 //! [`CdfScanFileVisitor`]. The visitor reads from engine data with the schema [`cdf_scan_row_schema`].
-//! You can convert engine data to this schema using the [`get_cdf_scan_row_expression`].
+//! You can convert engine data to this schema using the [`cdf_scan_row_expression`].
 use itertools::Itertools;
 use std::collections::HashMap;
 use std::sync::{Arc, LazyLock};
@@ -251,7 +251,7 @@ pub(crate) fn cdf_scan_row_schema() -> SchemaRef {
 /// Expression to convert an action with `log_schema` into one with
 /// `TABLE_CHANGES_cdf_scan_row_schema`. This is the expression used to create `TableChangesScanData`.
 #[allow(unused)]
-pub(crate) fn get_cdf_scan_row_expression(commit_timestamp: i64, commit_number: i64) -> Expression {
+pub(crate) fn cdf_scan_row_expression(commit_timestamp: i64, commit_number: i64) -> Expression {
     Expression::struct_from([
         Expression::struct_from([
             column_expr!("add.path"),
@@ -280,7 +280,7 @@ mod tests {
 
     use super::CdfScanFileType;
     use super::{
-        cdf_scan_row_schema, get_cdf_scan_row_expression, visit_cdf_scan_files, CdfScanCallback,
+        cdf_scan_row_expression, cdf_scan_row_schema, visit_cdf_scan_files, CdfScanCallback,
         CdfScanFile,
     };
     use crate::actions::deletion_vector::DeletionVectorDescriptor;
@@ -363,7 +363,7 @@ mod tests {
                     .get_expression_handler()
                     .get_evaluator(
                         get_log_schema().clone(),
-                        get_cdf_scan_row_expression(commit_timestamp, commit_version),
+                        cdf_scan_row_expression(commit_timestamp, commit_version),
                         cdf_scan_row_schema().into(),
                     )
                     .evaluate(actions.as_ref())


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR introduces four concepts:
- `cdf_scan_row_schema`: This is the schema that engine data will be transformed into at the end of the log replay phase. This schema prunes the log schema down only to the fields necessary to produce CDF columns. 
- `cdf_scan_row_expression`: This is a function that generates an expression to transform an engine data into the `cdf_scan_row_schema`. The function takes timestamp and commit number as arguments because it inserts these as columns into the output engine data.
- `CDFScanFile`: This is a type that holds all the information needed to read a data file and generate its CDF rows. It holds path, deletion vector, the type of action, and the paired remove deletion vector. The action type is encoded as an enum `CDFScanFileType`
- `CDFScanFileVisitor`: This is a visitor that reads engine data with the `cdf_scan_row_schema` and constructs `CDFScanFile`s.

This PR is only for internal use, and is only expected to be used by `TableChangesScan::execute` when it is implemented. Engines must *not* use the visitor nor `CDFScanFile`.

### This PR affects the following public APIs
No public APIs are changed. 

## How was this change tested?
I generate a table with add, remove and cdc actions. Then:
- The table is read,
- The engine data is transformed using `table_changes_action_iter` which in transforms the engine data into the `cdf_scan_row_schema` using the `cdf_scan_row_expression`
- The transformed engine data is read again using the `CDFScanFileVisitor` and assert that the `CDFScanFile`s are as expected.

This test checks the following cases:
- A remove with `None` partition values. An empty hashmap for partition values should be used.
- A remove with partition values.
- An add/remove DV pair. This should place the correct remove dv into the add's CdfScanFile.
- The visitor extracts the correct timestamp and commit version for each file.