### PR TITLE
Introduce `TableChangesScan::execute` and `ScanFileReader`

### DIFF
--- a/ffi/src/error.rs
+++ b/ffi/src/error.rs
@@ -50,6 +50,7 @@ pub enum KernelError {
     UnsupportedError,
     ParseIntervalError,
     ChangeDataFeedUnsupported,
+    ChangeDataFeedIncompatibleSchema,
 }
 
 impl From<Error> for KernelError {
@@ -104,6 +105,9 @@ impl From<Error> for KernelError {
             Error::Unsupported(_) => KernelError::UnsupportedError,
             Error::ParseIntervalError(_) => KernelError::ParseIntervalError,
             Error::ChangeDataFeedUnsupported(_) => KernelError::ChangeDataFeedUnsupported,
+            Error::ChangeDataFeedIncompatibleSchema(_, _) => {
+                KernelError::ChangeDataFeedIncompatibleSchema
+            }
         }
     }
 }

--- a/kernel/examples/change_data_feed/Cargo.toml
+++ b/kernel/examples/change_data_feed/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "change_data_feed"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+arrow-array = { workspace = true }
+arrow-schema = { workspace = true }
+clap = { version = "4.5", features = ["derive"] }
+delta_kernel = { path = "../../../kernel", features = [
+  "cloud",
+  "default-engine",
+  "developer-visibility",
+  "sync-engine"
+] }
+env_logger = "0.11.3"
+url = "2"
+itertools = "0.13"
+arrow = { workspace = true, features = ["prettyprint"] }

--- a/kernel/examples/change_data_feed/src/main.rs
+++ b/kernel/examples/change_data_feed/src/main.rs
@@ -1,0 +1,52 @@
+use std::sync::Arc;
+
+use arrow::{compute::filter_record_batch, util::pretty::print_batches};
+use arrow_array::RecordBatch;
+use clap::Parser;
+use delta_kernel::{
+    engine::{arrow_data::ArrowEngineData, sync::SyncEngine},
+    DeltaResult, Table,
+};
+use itertools::Itertools;
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+#[command(propagate_version = true)]
+struct Cli {
+    /// Path to the table to inspect
+    path: String,
+
+    start_version: u64,
+
+    end_version: Option<u64>,
+}
+
+fn main() -> DeltaResult<()> {
+    let cli = Cli::parse();
+    let table = Table::try_from_uri(cli.path)?;
+    let engine = Arc::new(SyncEngine::new());
+    let table_changes = table.table_changes(engine.as_ref(), cli.start_version, cli.end_version)?;
+
+    let x = table_changes.into_scan_builder().build()?;
+    let batches: Vec<RecordBatch> = x
+        .execute(engine)?
+        .map(|scan_result| -> DeltaResult<_> {
+            let scan_result = scan_result?;
+            let mask = scan_result.full_mask();
+            let data = scan_result.raw_data?;
+            let record_batch: RecordBatch = data
+                .into_any()
+                .downcast::<ArrowEngineData>()
+                .map_err(|_| delta_kernel::Error::EngineDataType("ArrowEngineData".to_string()))?
+                .into();
+            if let Some(mask) = mask {
+                Ok(filter_record_batch(&record_batch, &mask.into())?)
+            } else {
+                Ok(record_batch)
+            }
+        })
+        .try_collect()?;
+    print_batches(&batches)?;
+
+    Ok(())
+}

--- a/kernel/src/actions/deletion_vector.rs
+++ b/kernel/src/actions/deletion_vector.rs
@@ -1,10 +1,9 @@
 //! Code relating to parsing and using deletion vectors
 
-use std::io::{Cursor, Read};
-use std::sync::Arc;
-
 use bytes::Bytes;
 use roaring::RoaringTreemap;
+use std::io::{Cursor, Read};
+use std::sync::Arc;
 use url::Url;
 
 use delta_kernel_derive::Schema;
@@ -13,6 +12,7 @@ use crate::utils::require;
 use crate::{DeltaResult, Error, FileSystemClient};
 
 #[derive(Debug, Clone, PartialEq, Eq, Schema)]
+#[cfg_attr(test, derive(serde::Serialize), serde(rename_all = "camelCase"))]
 pub struct DeletionVectorDescriptor {
     /// A single character to indicate how to access the DV. Legal options are: ['u', 'i', 'p'].
     pub storage_type: String,

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -85,6 +85,7 @@ pub(crate) fn get_log_commit_info_schema() -> &'static SchemaRef {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Schema)]
+#[cfg_attr(test, derive(Serialize), serde(rename_all = "camelCase"))]
 pub struct Format {
     /// Name of the encoding for files in this table
     pub provider: String,
@@ -102,6 +103,7 @@ impl Default for Format {
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Schema)]
+#[cfg_attr(test, derive(Serialize), serde(rename_all = "camelCase"))]
 pub struct Metadata {
     /// Unique identifier for this table
     pub id: String,
@@ -325,6 +327,7 @@ where
 #[derive(Debug, Clone, PartialEq, Eq, Schema)]
 #[cfg_attr(feature = "developer-visibility", visibility::make(pub))]
 #[cfg_attr(not(feature = "developer-visibility"), visibility::make(pub(crate)))]
+#[cfg_attr(test, derive(Serialize, Default), serde(rename_all = "camelCase"))]
 struct CommitInfo {
     /// The time this logical file was created, as milliseconds since the epoch.
     /// Read: optional, write: required (that is, kernel always writes).
@@ -346,6 +349,7 @@ struct CommitInfo {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Schema)]
+#[cfg_attr(test, derive(Serialize, Default), serde(rename_all = "camelCase"))]
 pub struct Add {
     /// A relative path to a data file from the root of the table or an absolute path to a file
     /// that should be added to the table. The path is a URI as specified by
@@ -374,23 +378,29 @@ pub struct Add {
     /// Contains [statistics] (e.g., count, min/max values for columns) about the data in this logical file.
     ///
     /// [statistics]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#Per-file-Statistics
+    #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
     pub stats: Option<String>,
 
     /// Map containing metadata about this logical file.
+    #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
     pub tags: Option<HashMap<String, String>>,
 
     /// Information about deletion vector (DV) associated with this add action
+    #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
     pub deletion_vector: Option<DeletionVectorDescriptor>,
 
     /// Default generated Row ID of the first row in the file. The default generated Row IDs
     /// of the other rows in the file can be reconstructed by adding the physical index of the
     /// row within the file to the base Row ID
+    #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
     pub base_row_id: Option<i64>,
 
     /// First commit version in which an add action with the same path was committed to the table.
+    #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
     pub default_row_commit_version: Option<i64>,
 
     /// The name of the clustering implementation
+    #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
     pub clustering_provider: Option<String>,
 }
 
@@ -403,6 +413,7 @@ impl Add {
 #[derive(Debug, Clone, PartialEq, Eq, Schema)]
 #[cfg_attr(feature = "developer-visibility", visibility::make(pub))]
 #[cfg_attr(not(feature = "developer-visibility"), visibility::make(pub(crate)))]
+#[cfg_attr(test, derive(Serialize, Default), serde(rename_all = "camelCase"))]
 struct Remove {
     /// A relative path to a data file from the root of the table or an absolute path to a file
     /// that should be added to the table. The path is a URI as specified by
@@ -412,6 +423,7 @@ struct Remove {
     pub(crate) path: String,
 
     /// The time this logical file was created, as milliseconds since the epoch.
+    #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
     pub(crate) deletion_timestamp: Option<i64>,
 
     /// When `false` the logical file must already be present in the table or the records
@@ -419,32 +431,40 @@ struct Remove {
     pub(crate) data_change: bool,
 
     /// When true the fields `partition_values`, `size`, and `tags` are present
+    #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
     pub(crate) extended_file_metadata: Option<bool>,
 
     /// A map from partition column to value for this logical file.
+    #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
     pub(crate) partition_values: Option<HashMap<String, String>>,
 
     /// The size of this data file in bytes
+    #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
     pub(crate) size: Option<i64>,
 
     /// Map containing metadata about this logical file.
+    #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
     pub(crate) tags: Option<HashMap<String, String>>,
 
     /// Information about deletion vector (DV) associated with this add action
+    #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
     pub(crate) deletion_vector: Option<DeletionVectorDescriptor>,
 
     /// Default generated Row ID of the first row in the file. The default generated Row IDs
     /// of the other rows in the file can be reconstructed by adding the physical index of the
     /// row within the file to the base Row ID
+    #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
     pub(crate) base_row_id: Option<i64>,
 
     /// First commit version in which an add action with the same path was committed to the table.
+    #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
     pub(crate) default_row_commit_version: Option<i64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Schema)]
 #[cfg_attr(feature = "developer-visibility", visibility::make(pub))]
 #[cfg_attr(not(feature = "developer-visibility"), visibility::make(pub(crate)))]
+#[cfg_attr(test, derive(Serialize, Default), serde(rename_all = "camelCase"))]
 struct Cdc {
     /// A relative path to a change data file from the root of the table or an absolute path to a
     /// change data file that should be added to the table. The path is a URI as specified by

--- a/kernel/src/actions/visitors.rs
+++ b/kernel/src/actions/visitors.rs
@@ -122,7 +122,7 @@ struct ProtocolVisitor {
 
 impl ProtocolVisitor {
     #[cfg_attr(feature = "developer-visibility", visibility::make(pub))]
-    fn visit_protocol<'a>(
+    pub(crate) fn visit_protocol<'a>(
         row_index: usize,
         min_reader_version: i32,
         getters: &[&'a dyn GetData<'a>],

--- a/kernel/src/engine/sync/mod.rs
+++ b/kernel/src/engine/sync/mod.rs
@@ -15,7 +15,7 @@ use tracing::debug;
 
 mod fs_client;
 pub(crate) mod json;
-mod parquet;
+pub(crate) mod parquet;
 
 /// This is a simple implementation of [`Engine`]. It only supports reading data from the local
 /// filesystem, and internally represents data using `Arrow`.

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -6,7 +6,7 @@ use std::{
     str::Utf8Error,
 };
 
-use crate::schema::DataType;
+use crate::schema::{DataType, StructType};
 use crate::table_properties::ParseIntervalError;
 use crate::Version;
 
@@ -188,6 +188,9 @@ pub enum Error {
 
     #[error("Change data feed is unsupported for the table at version {0}")]
     ChangeDataFeedUnsupported(Version),
+
+    #[error("Change data feed encountered incompatible schema. Expected {0}, got {1}")]
+    ChangeDataFeedIncompatibleSchema(String, String),
 }
 
 // Convenience constructors for Error types that take a String argument
@@ -253,6 +256,12 @@ impl Error {
     }
     pub fn change_data_feed_unsupported(version: impl Into<Version>) -> Self {
         Self::ChangeDataFeedUnsupported(version.into())
+    }
+    pub fn change_data_feed_incompatible_schema(
+        expected: &StructType,
+        actual: &StructType,
+    ) -> Self {
+        Self::ChangeDataFeedIncompatibleSchema(format!("{:?}", expected), format!("{:?}", actual))
     }
 
     // Capture a backtrace when the error is constructed.

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -151,6 +151,13 @@ impl Scalar {
     pub fn is_null(&self) -> bool {
         matches!(self, Self::Null(_))
     }
+
+    pub fn timestamp_from_millis(millis: i64) -> DeltaResult<Self> {
+        let Some(timestamp) = DateTime::from_timestamp_millis(millis) else {
+            return Err(Error::generic("Failed to convert timestamp"));
+        };
+        Ok(Self::Timestamp(timestamp.timestamp_micros()))
+    }
 }
 
 impl Display for Scalar {

--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -14,7 +14,7 @@ const MULTIPART_PART_LEN: usize = 10;
 /// The number of characters in the uuid part of a uuid checkpoint
 const UUID_PART_LEN: usize = 36;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "developer-visibility", visibility::make(pub))]
 #[cfg_attr(not(feature = "developer-visibility"), visibility::make(pub(crate)))]
 enum LogPathFileType {
@@ -37,7 +37,7 @@ enum LogPathFileType {
     Unknown,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "developer-visibility", visibility::make(pub))]
 #[cfg_attr(not(feature = "developer-visibility"), visibility::make(pub(crate)))]
 struct ParsedLogPath<Location: AsUrl = FileMeta> {

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -41,6 +41,7 @@ fn as_data_skipping_predicate(expr: &Expr, inverted: bool) -> Option<Expr> {
     DataSkippingPredicateCreator.eval_expr(expr, inverted)
 }
 
+#[derive(Clone)]
 pub(crate) struct DataSkippingFilter {
     stats_schema: SchemaRef,
     select_stats_evaluator: Arc<dyn ExpressionEvaluator>,

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -180,7 +180,7 @@ pub(crate) static SCAN_ROW_SCHEMA: LazyLock<Arc<StructType>> = LazyLock::new(|| 
     ]))
 });
 
-static SCAN_ROW_DATATYPE: LazyLock<DataType> = LazyLock::new(|| SCAN_ROW_SCHEMA.clone().into());
+pub static SCAN_ROW_DATATYPE: LazyLock<DataType> = LazyLock::new(|| SCAN_ROW_SCHEMA.clone().into());
 
 fn get_add_transform_expr() -> Expression {
     Expression::Struct(vec![

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -124,7 +124,7 @@ pub struct ScanResult {
     pub raw_data: DeltaResult<Box<dyn EngineData>>,
     /// Raw row mask.
     // TODO(nick) this should be allocated by the engine
-    raw_mask: Option<Vec<bool>>,
+    pub(crate) raw_mask: Option<Vec<bool>>,
 }
 
 impl ScanResult {
@@ -159,7 +159,7 @@ impl ScanResult {
 /// store the name of the column, as that's all that's needed during the actual query. For
 /// `Partition` we store an index into the logical schema for this query since later we need the
 /// data type as well to materialize the partition column.
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum ColumnType {
     // A column, selected from the data, as is
     Selected(String),

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -380,7 +380,7 @@ pub fn scan_row_schema() -> Schema {
     log_replay::SCAN_ROW_SCHEMA.as_ref().clone()
 }
 
-fn parse_partition_value(raw: Option<&String>, data_type: &DataType) -> DeltaResult<Scalar> {
+pub fn parse_partition_value(raw: Option<&String>, data_type: &DataType) -> DeltaResult<Scalar> {
     match (raw, data_type.as_primitive_opt()) {
         (Some(v), Some(primitive)) => primitive.parse_scalar(v),
         (Some(_), None) => Err(Error::generic(format!(

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -19,7 +19,7 @@ use crate::{DeltaResult, Engine, EngineData, Error, FileMeta};
 use self::log_replay::scan_action_iter;
 use self::state::GlobalScanState;
 
-mod data_skipping;
+pub mod data_skipping;
 pub mod log_replay;
 pub mod state;
 

--- a/kernel/src/scan/state.rs
+++ b/kernel/src/scan/state.rs
@@ -113,11 +113,11 @@ pub type ScanCallback<T> = fn(
 /// ## Example
 /// ```ignore
 /// let mut context = [my context];
-/// for res in scan_data { // scan data from scan.get_scan_data()
+/// for res in scan_data { // scan data from scan.scan_data()
 ///     let (data, vector) = res?;
 ///     context = delta_kernel::scan::state::visit_scan_files(
 ///        data.as_ref(),
-///        vector,
+///        selection_vector,
 ///        context,
 ///        my_callback,
 ///     )?;

--- a/kernel/src/table_changes/data_read.rs
+++ b/kernel/src/table_changes/data_read.rs
@@ -1,110 +1,316 @@
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
+use std::iter::once;
+use std::sync::Arc;
 
-use itertools::Itertools;
+use itertools::{Either, Itertools};
+use url::Url;
 
-use crate::{
-    expressions::{column_expr, ColumnName, Scalar},
-    scan::{parse_partition_value, state::GlobalScanState, ColumnType},
-    schema::StructType,
-    DeltaResult, Engine, EngineData, Error, Expression,
-};
+use crate::actions::deletion_vector::{split_vector, treemap_to_bools};
+use crate::expressions::{column_expr, ColumnName, Scalar};
+use crate::scan::state::DvInfo;
+use crate::scan::{parse_partition_value, ColumnType, ScanResult};
+use crate::schema::{DataType, SchemaRef, StructField, StructType};
+use crate::{DeltaResult, Engine, Error, Expression, FileMeta};
 
-use super::scan_file::ScanFileType;
+use super::scan::GlobalScanState;
+use super::scan_file::{ScanFile, ScanFileType};
+use super::CDF_FIELDS;
+type ResolvedScanFile = (ScanFile, Option<Vec<bool>>);
 
-// We have this function because `execute` can save `all_fields` and `have_partition_cols` in the
-// scan, and then reuse them for each batch transform
-#[allow(clippy::too_many_arguments)] // TEMPORARY
-pub(crate) fn transform_to_logical_internal(
-    engine: &dyn Engine,
-    data: Box<dyn EngineData>,
-    global_state: &GlobalScanState,
-    partition_values: &std::collections::HashMap<String, String>,
-    all_fields: &[ColumnType],
-    _have_partition_cols: bool,
-    generated_columns: &HashMap<String, Expression>,
-    read_schema: Arc<StructType>,
-) -> DeltaResult<Box<dyn EngineData>> {
-    // need to add back partition cols and/or fix-up mapped columns
-    let all_fields: Vec<Expression> = all_fields
-        .iter()
-        .map(|field| match field {
-            ColumnType::Partition(field_idx) => {
-                let field = global_state.logical_schema.fields.get_index(*field_idx);
-                let Some((_, field)) = field else {
-                    return Err(Error::generic(
-                        "logical schema did not contain expected field, can't transform data",
-                    ));
-                };
-                let name = field.physical_name(global_state.column_mapping_mode)?;
-                let value_expression =
-                    parse_partition_value(partition_values.get(name), field.data_type())?;
-                Ok(value_expression.into())
-            }
-            ColumnType::Selected(field_name) => Ok(ColumnName::new([field_name]).into()),
-            ColumnType::InsertedColumn(field_idx) => {
-                let field = global_state.logical_schema.fields.get_index(*field_idx);
-                let Some((_, field)) = field else {
-                    return Err(Error::generic(
-                        "logical schema did not contain expected field, can't transform data",
-                    ));
-                };
-                let Some(expr) = generated_columns.get(field.name()) else {
-                    return Err(Error::generic(
-                        "Got unexpected inserted field , can't transform data",
-                    ));
-                };
-                Ok(expr.clone())
-            }
-        })
-        .try_collect()?;
-    let read_expression = Expression::Struct(all_fields);
-
-    let result = engine
-        .get_expression_handler()
-        .get_evaluator(
-            read_schema,
-            read_expression,
-            global_state.logical_schema.clone().into(),
-        )
-        .evaluate(data.as_ref())?;
-    Ok(result)
+pub(crate) struct DataReader {
+    global_scan_state: GlobalScanState,
+    scan_file: ScanFile,
+    selection_vector: Option<Vec<bool>>,
 }
 
-pub(crate) fn get_generated_columns(
-    timestamp: i64,
-    tpe: ScanFileType,
-    commit_version: i64,
-) -> Result<Arc<HashMap<String, Expression>>, crate::Error> {
-    // Both in-commit timestamps and file metadata are in milliseconds
-    //
-    // See:
-    // [`FileMeta`]
-    // [In-Commit Timestamps] : https://github.com/delta-io/delta/blob/master/PROTOCOL.md#writer-requirements-for-in-commit-timestampsa
-    let timestamp = Scalar::timestamp_from_millis(timestamp)?;
-    let expressions = match tpe {
-        ScanFileType::Cdc => [
-            column_expr!("_change_type"),
-            Expression::literal(commit_version),
-            timestamp.into(),
-        ],
-        ScanFileType::Add => [
-            "insert".into(),
-            Expression::literal(commit_version),
-            timestamp.into(),
-        ],
+impl DataReader {
+    pub(crate) fn new(
+        global_scan_state: GlobalScanState,
+        scan_file: ScanFile,
+        selection_vector: Option<Vec<bool>>,
+    ) -> Self {
+        Self {
+            global_scan_state,
+            scan_file,
+            selection_vector,
+        }
+    }
 
-        ScanFileType::Remove => [
-            "delete".into(),
-            Expression::literal(commit_version),
-            timestamp.into(),
-        ],
-    };
-    let generated_columns: Arc<HashMap<String, Expression>> = Arc::new(
-        CDF_GENERATED_COLUMNS
+    pub(crate) fn get_generated_columns(&self) -> DeltaResult<HashMap<String, Expression>> {
+        // Both in-commit timestamps and file metadata are in milliseconds
+        //
+        // See:
+        // [`FileMeta`]
+        // [In-Commit Timestamps] : https://github.com/delta-io/delta/blob/master/PROTOCOL.md#writer-requirements-for-in-commit-timestampsa
+        let timestamp = Scalar::timestamp_from_millis(self.scan_file.timestamp)?;
+        let commit_version: i64 = self
+            .scan_file
+            .commit_version
+            .try_into()
+            .map_err(Error::generic)?;
+        let cols = ["_change_type", "_commit_version", "_commit_timestamp"];
+        let expressions = match self.scan_file.tpe {
+            ScanFileType::Cdc => [
+                column_expr!("_change_type"),
+                Expression::literal(commit_version),
+                timestamp.into(),
+            ],
+            ScanFileType::Add => [
+                "insert".into(),
+                Expression::literal(commit_version),
+                timestamp.into(),
+            ],
+
+            ScanFileType::Remove => [
+                "delete".into(),
+                Expression::literal(commit_version),
+                timestamp.into(),
+            ],
+        };
+        let generated_columns: HashMap<String, Expression> = cols
             .iter()
             .map(ToString::to_string)
             .zip(expressions)
-            .collect(),
-    );
-    Ok(generated_columns)
+            .collect();
+        Ok(generated_columns)
+    }
+    fn get_expression(&self, scan_file: &ScanFile) -> DeltaResult<Expression> {
+        let mut generated_columns = self.get_generated_columns()?;
+        let all_fields = self
+            .global_scan_state
+            .all_fields
+            .iter()
+            .map(|field| match field {
+                ColumnType::Partition(field_idx) => {
+                    let field = self
+                        .global_scan_state
+                        .logical_schema
+                        .fields
+                        .get_index(*field_idx);
+                    let Some((_, field)) = field else {
+                        return Err(Error::generic(
+                            "logical schema did not contain expected field, can't transform data",
+                        ));
+                    };
+                    let name = field.physical_name(self.global_scan_state.column_mapping_mode)?;
+                    let value_expression = parse_partition_value(
+                        scan_file.partition_values.get(name),
+                        field.data_type(),
+                    )?;
+                    Ok(value_expression.into())
+                }
+                ColumnType::Selected(field_name) =>
+                // We take the expression from the map
+                {
+                    Ok(generated_columns
+                        .remove(field_name)
+                        .unwrap_or_else(|| ColumnName::new([field_name]).into()))
+                }
+            })
+            .try_collect()?;
+        Ok(Expression::Struct(all_fields))
+    }
+    fn read_schema(&self) -> SchemaRef {
+        if self.scan_file.tpe == ScanFileType::Cdc {
+            let fields = self
+                .global_scan_state
+                .read_schema
+                .fields()
+                .cloned()
+                .chain(once(StructField::new(
+                    "_change_type",
+                    DataType::STRING,
+                    false,
+                )));
+            StructType::new(fields).into()
+        } else {
+            self.global_scan_state.read_schema.clone()
+        }
+    }
+    pub fn into_data(
+        mut self,
+        engine: &dyn Engine,
+    ) -> DeltaResult<impl Iterator<Item = DeltaResult<ScanResult>>> {
+        let table_root = Url::parse(&self.global_scan_state.table_root)?;
+
+        let expression = self.get_expression(&self.scan_file)?;
+        let schema = self.read_schema();
+        let evaluator = engine.get_expression_handler().get_evaluator(
+            schema.clone(),
+            expression,
+            self.global_scan_state.logical_schema.into(),
+        );
+
+        let mut selection_vector = self.selection_vector.take();
+
+        let location = table_root.join(&self.scan_file.path)?;
+        let file = FileMeta {
+            last_modified: 0,
+            size: 0,
+            location,
+        };
+        let read_result_iter = engine.get_parquet_handler().read_parquet_files(
+            &[file],
+            schema.clone(),
+            None, // TODO: Add back the predicate
+        )?;
+
+        Ok(read_result_iter.map(move |batch| -> DeltaResult<_> {
+            let batch = batch?;
+            // to transform the physical data into the correct logical form
+            let logical = evaluator.evaluate(batch.as_ref());
+            let len = logical.as_ref().map_or(0, |res| res.len());
+            // need to split the dv_mask. what's left in dv_mask covers this result, and rest
+            // will cover the following results. we `take()` out of `selection_vector` to avoid
+            // trying to return a captured variable. We're going to reassign `selection_vector`
+            // to `rest` in a moment anyway
+            let mut sv = selection_vector.take();
+            let rest = split_vector(sv.as_mut(), len, None); // TODO: Fill in len and extend
+                                                             // value
+            let result = ScanResult {
+                raw_data: logical,
+                raw_mask: sv,
+            };
+            selection_vector = rest;
+            Ok(result)
+        }))
+    }
 }
+pub(crate) fn resolve_scan_file_dv(
+    engine: &dyn Engine,
+    table_root: &Url,
+    scan_file: ScanFile,
+    remove_dv: Option<Arc<HashMap<String, DvInfo>>>,
+) -> DeltaResult<impl Iterator<Item = ResolvedScanFile>> {
+    let remove_dv = remove_dv.as_ref().and_then(|map| map.get(&scan_file.path));
+    match (&scan_file.tpe, remove_dv) {
+        (ScanFileType::Add, Some(rm_dv)) => {
+            let add_dv = scan_file
+                .dv_info
+                .get_treemap(engine, table_root)?
+                .unwrap_or(Default::default());
+            let rm_dv = rm_dv
+                .get_treemap(engine, table_root)?
+                .unwrap_or(Default::default());
+
+            let added_dv = treemap_to_bools(&rm_dv - &add_dv);
+            let added = once((scan_file.clone(), Some(added_dv)));
+
+            let removed_dv = treemap_to_bools(add_dv - rm_dv);
+            let rm_scanfile = ScanFile {
+                tpe: ScanFileType::Remove,
+                ..scan_file
+            };
+            let removed = once((rm_scanfile, Some(removed_dv)));
+
+            Ok(Either::Right(added.chain(removed)))
+        }
+        (_, Some(_)) => Err(Error::generic(
+            "Remove DV should only match to an add action!",
+        )),
+        (ScanFileType::Remove | ScanFileType::Add, None) => {
+            let selection_vector = scan_file.dv_info.get_selection_vector(engine, table_root)?;
+            Ok(Either::Left(once((scan_file, selection_vector))))
+        }
+        (ScanFileType::Cdc, None) => Ok(Either::Left(once((scan_file, None)))),
+    }
+}
+
+//
+//// We have this function because `execute` can save `all_fields` and `have_partition_cols` in the
+//// scan, and then reuse them for each batch transform
+//#[allow(clippy::too_many_arguments)] // TEMPORARY
+//pub(crate) fn transform_to_logical_internal(
+//    engine: &dyn Engine,
+//    data: Box<dyn EngineData>,
+//    global_state: &GlobalScanState,
+//    partition_values: &std::collections::HashMap<String, String>,
+//    all_fields: &[ColumnType],
+//    _have_partition_cols: bool,
+//    generated_columns: &HashMap<String, Expression>,
+//    read_schema: Arc<StructType>,
+//) -> DeltaResult<Box<dyn EngineData>> {
+//    // need to add back partition cols and/or fix-up mapped columns
+//    let all_fields: Vec<Expression> = all_fields
+//        .iter()
+//        .map(|field| match field {
+//            ColumnType::Partition(field_idx) => {
+//                let field = global_state.logical_schema.fields.get_index(*field_idx);
+//                let Some((_, field)) = field else {
+//                    return Err(Error::generic(
+//                        "logical schema did not contain expected field, can't transform data",
+//                    ));
+//                };
+//                let name = field.physical_name(global_state.column_mapping_mode)?;
+//                let value_expression =
+//                    parse_partition_value(partition_values.get(name), field.data_type())?;
+//                Ok(value_expression.into())
+//            }
+//            ColumnType::Selected(field_name) => Ok(ColumnName::new([field_name]).into()),
+//            ColumnType::InsertedColumn(field_idx) => {
+//                let field = global_state.logical_schema.fields.get_index(*field_idx);
+//                let Some((_, field)) = field else {
+//                    return Err(Error::generic(
+//                        "logical schema did not contain expected field, can't transform data",
+//                    ));
+//                };
+//                let Some(expr) = generated_columns.get(field.name()) else {
+//                    return Err(Error::generic(
+//                        "Got unexpected inserted field , can't transform data",
+//                    ));
+//                };
+//                Ok(expr.clone())
+//            }
+//        })
+//        .try_collect()?;
+//    let read_expression = Expression::Struct(all_fields);
+//
+//    let result = engine
+//        .get_expression_handler()
+//        .get_evaluator(
+//            read_schema,
+//            read_expression,
+//            global_state.logical_schema.clone().into(),
+//        )
+//        .evaluate(data.as_ref())?;
+//    Ok(result)
+//}
+//
+//pub(crate) fn get_generated_columns(
+//    timestamp: i64,
+//    tpe: ScanFileType,
+//    commit_version: i64,
+//) -> Result<Arc<HashMap<String, Expression>>, crate::Error> {
+//    // Both in-commit timestamps and file metadata are in milliseconds
+//    //
+//    // See:
+//    // [`FileMeta`]
+//    // [In-Commit Timestamps] : https://github.com/delta-io/delta/blob/master/PROTOCOL.md#writer-requirements-for-in-commit-timestampsa
+//    let timestamp = Scalar::timestamp_from_millis(timestamp)?;
+//    let expressions = match tpe {
+//        ScanFileType::Cdc => [
+//            column_expr!("_change_type"),
+//            Expression::literal(commit_version),
+//            timestamp.into(),
+//        ],
+//        ScanFileType::Add => [
+//            "insert".into(),
+//            Expression::literal(commit_version),
+//            timestamp.into(),
+//        ],
+//
+//        ScanFileType::Remove => [
+//            "delete".into(),
+//            Expression::literal(commit_version),
+//            timestamp.into(),
+//        ],
+//    };
+//    let generated_columns: Arc<HashMap<String, Expression>> = Arc::new(
+//        CDF_GENERATED_COLUMNS
+//            .iter()
+//            .map(ToString::to_string)
+//            .zip(expressions)
+//            .collect(),
+//    );
+//    Ok(generated_columns)
+//}

--- a/kernel/src/table_changes/data_read.rs
+++ b/kernel/src/table_changes/data_read.rs
@@ -1,0 +1,110 @@
+use std::{collections::HashMap, sync::Arc};
+
+use itertools::Itertools;
+
+use crate::{
+    expressions::{column_expr, ColumnName, Scalar},
+    scan::{parse_partition_value, state::GlobalScanState, ColumnType},
+    schema::StructType,
+    DeltaResult, Engine, EngineData, Error, Expression,
+};
+
+use super::scan_file::ScanFileType;
+
+// We have this function because `execute` can save `all_fields` and `have_partition_cols` in the
+// scan, and then reuse them for each batch transform
+#[allow(clippy::too_many_arguments)] // TEMPORARY
+pub(crate) fn transform_to_logical_internal(
+    engine: &dyn Engine,
+    data: Box<dyn EngineData>,
+    global_state: &GlobalScanState,
+    partition_values: &std::collections::HashMap<String, String>,
+    all_fields: &[ColumnType],
+    _have_partition_cols: bool,
+    generated_columns: &HashMap<String, Expression>,
+    read_schema: Arc<StructType>,
+) -> DeltaResult<Box<dyn EngineData>> {
+    // need to add back partition cols and/or fix-up mapped columns
+    let all_fields: Vec<Expression> = all_fields
+        .iter()
+        .map(|field| match field {
+            ColumnType::Partition(field_idx) => {
+                let field = global_state.logical_schema.fields.get_index(*field_idx);
+                let Some((_, field)) = field else {
+                    return Err(Error::generic(
+                        "logical schema did not contain expected field, can't transform data",
+                    ));
+                };
+                let name = field.physical_name(global_state.column_mapping_mode)?;
+                let value_expression =
+                    parse_partition_value(partition_values.get(name), field.data_type())?;
+                Ok(value_expression.into())
+            }
+            ColumnType::Selected(field_name) => Ok(ColumnName::new([field_name]).into()),
+            ColumnType::InsertedColumn(field_idx) => {
+                let field = global_state.logical_schema.fields.get_index(*field_idx);
+                let Some((_, field)) = field else {
+                    return Err(Error::generic(
+                        "logical schema did not contain expected field, can't transform data",
+                    ));
+                };
+                let Some(expr) = generated_columns.get(field.name()) else {
+                    return Err(Error::generic(
+                        "Got unexpected inserted field , can't transform data",
+                    ));
+                };
+                Ok(expr.clone())
+            }
+        })
+        .try_collect()?;
+    let read_expression = Expression::Struct(all_fields);
+
+    let result = engine
+        .get_expression_handler()
+        .get_evaluator(
+            read_schema,
+            read_expression,
+            global_state.logical_schema.clone().into(),
+        )
+        .evaluate(data.as_ref())?;
+    Ok(result)
+}
+
+pub(crate) fn get_generated_columns(
+    timestamp: i64,
+    tpe: ScanFileType,
+    commit_version: i64,
+) -> Result<Arc<HashMap<String, Expression>>, crate::Error> {
+    // Both in-commit timestamps and file metadata are in milliseconds
+    //
+    // See:
+    // [`FileMeta`]
+    // [In-Commit Timestamps] : https://github.com/delta-io/delta/blob/master/PROTOCOL.md#writer-requirements-for-in-commit-timestampsa
+    let timestamp = Scalar::timestamp_from_millis(timestamp)?;
+    let expressions = match tpe {
+        ScanFileType::Cdc => [
+            column_expr!("_change_type"),
+            Expression::literal(commit_version),
+            timestamp.into(),
+        ],
+        ScanFileType::Add => [
+            "insert".into(),
+            Expression::literal(commit_version),
+            timestamp.into(),
+        ],
+
+        ScanFileType::Remove => [
+            "delete".into(),
+            Expression::literal(commit_version),
+            timestamp.into(),
+        ],
+    };
+    let generated_columns: Arc<HashMap<String, Expression>> = Arc::new(
+        CDF_GENERATED_COLUMNS
+            .iter()
+            .map(ToString::to_string)
+            .zip(expressions)
+            .collect(),
+    );
+    Ok(generated_columns)
+}

--- a/kernel/src/table_changes/log_replay.rs
+++ b/kernel/src/table_changes/log_replay.rs
@@ -1,0 +1,847 @@
+//! Defines [`LogReplayScanner`] used by [`TableChangesScan`] to process commit files and extract
+//! the metadata needed to generate the Change Data Feed.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, LazyLock};
+
+use crate::actions::visitors::{visit_deletion_vector_at, ProtocolVisitor};
+use crate::actions::{
+    get_log_add_schema, get_log_schema, Protocol, ADD_NAME, CDC_NAME, COMMIT_INFO_NAME,
+    METADATA_NAME, PROTOCOL_NAME, REMOVE_NAME,
+};
+use crate::engine_data::TypedGetData;
+use crate::expressions::{column_expr, column_name, Expression};
+use crate::path::ParsedLogPath;
+use crate::scan::data_skipping::DataSkippingFilter;
+use crate::scan::scan_row_schema;
+use crate::scan::state::DvInfo;
+use crate::schema::{ArrayType, ColumnNamesAndTypes, DataType, MapType, SchemaRef, StructType};
+use crate::table_properties::TableProperties;
+use crate::utils::require;
+use crate::{
+    DeltaResult, Engine, EngineData, Error, ExpressionHandler, ExpressionRef, JsonHandler,
+    RowVisitor,
+};
+use itertools::Itertools;
+
+pub struct TableChangesScanData {
+    pub data: Box<dyn EngineData>,
+    pub selection_vector: Vec<bool>,
+    pub remove_dv: Option<Arc<HashMap<String, DvInfo>>>,
+}
+
+/// Given an iterator of ParsedLogPath and a predicate, returns an iterator of
+/// [`TableChangesScanData`]  Each row that is selected in the returned
+/// `engine_data` _must_ be processed to complete the scan. Non-selected rows
+/// _must_ be ignored.
+pub(crate) fn table_changes_action_iter(
+    engine: &dyn Engine,
+    commit_files: impl IntoIterator<Item = ParsedLogPath>,
+    table_schema: SchemaRef,
+    predicate: Option<ExpressionRef>,
+) -> DeltaResult<impl Iterator<Item = DeltaResult<TableChangesScanData>>> {
+    let json_handler = engine.get_json_handler();
+    let filter = DataSkippingFilter::new(engine, &table_schema, predicate);
+
+    let expression_handler = engine.get_expression_handler();
+    let result = commit_files
+        .into_iter()
+        .map(move |commit_file| -> DeltaResult<_> {
+            let mut scanner = LogReplayScanner::new(
+                commit_file,
+                json_handler.clone(),
+                filter.clone(),
+                expression_handler.clone(),
+                table_schema.clone(),
+            );
+            scanner.prepare_phase()?;
+            scanner.into_scan_batches()
+        })
+        .flatten_ok()
+        .map(|x| x?);
+    Ok(result)
+}
+
+// Gets the expression for generating the engine data in [`TableChangesScanData`].
+//
+// TODO: This expression is temporary. In the future it will also select `cdc` and `remove` actions
+// fields.
+fn get_add_transform_expr() -> Expression {
+    Expression::Struct(vec![
+        column_expr!("add.path"),
+        column_expr!("add.size"),
+        column_expr!("add.modificationTime"),
+        column_expr!("add.stats"),
+        column_expr!("add.deletionVector"),
+        Expression::Struct(vec![column_expr!("add.partitionValues")]),
+    ])
+}
+
+/// Processes a single commit file from the log to generate an iterator of [`TableChangesScanData`].
+/// The scanner operates in two phases that _must_ be performed in the following order:
+/// 1. Prepare phase [`LogReplayScanner::prepare_phase`]: This performs one iteration over every
+///    action in the commit. In this phase, we do the following:
+///     - Find the timestamp from a `CommitInfo` action if it exists. These are generated when
+///       In-commit timestamps is enabled.
+///     - Ensure that reading is supported on any protocol updates
+///     - Ensure that Change Data Feed is enabled for any metadata update. See  [`TableProperties`]
+///     - Ensure that any schema update is compatible with the provided `schema`. Currently, schema
+///       compatibility is checked through schema equality. This will be expanded in the future to
+///       allow limited schema evolution.
+///     - Determine if there exists any `cdc` actions.
+///     - Constructs the remove deletion vector map from paths belonging to `remove` actions to the
+///       action's corresponding [`DvInfo`]. This map will be filtered to only contain paths that
+///       exists in another `add` action _within the same commit_. This corresponds to `remove_dv`
+///       in [`TableChangesScanData`].
+/// 2. Scan file generation phase [`LogReplayScanner::into_scan_batches`]: This performs another
+///    iteration over every action in the commit, and generates [`TableChangesScanData`]. It does
+///    so by transforming the actions using [`get_add_transform_expr`], and generating selection
+///    vectors with the following rules:
+///     - If a `cdc` action was found in the prepare phase, only `cdc` actions are selected
+///     - Otherwise, select `add` and `remove` actions. Note that only `remove` actions that do not
+///       share a path with an `add` action are selected.
+///
+/// Note: As a consequence of the two phases, LogReplayScanner will iterate over each action in the
+/// commit twice. It also may use an unbounded amount of memory, proportional to the number of
+/// `add` and `remove` actions in the commit.
+struct LogReplayScanner {
+    // True if a `cdc` action was found after running [`LogReplayScanner::prepare_phase`]
+    has_cdc_action: bool,
+    // A map from path to the deletion vector from the remove action. It is guaranteed that there
+    // is an add action with the same path in this commit
+    remove_dvs: HashMap<String, DvInfo>,
+    // The commit file that this replay scanner will operate on.
+    commit_file: ParsedLogPath,
+    // The timestamp associated with this commit. By default this is the file modification time
+    // from the commit's [`FileMeta`]. If there is a [`CommitInfo`] with a timestamp generated by
+    // in-commit timestamps, that timestamp will be used instead.
+    timestamp: i64,
+    // The schema of the table
+    schema: SchemaRef,
+    json_handler: Arc<dyn JsonHandler>,
+    filter: Option<DataSkippingFilter>,
+    expression_handler: Arc<dyn ExpressionHandler>,
+}
+
+impl LogReplayScanner {
+    fn new(
+        commit_file: ParsedLogPath,
+        json_handler: Arc<dyn JsonHandler>,
+        filter: Option<DataSkippingFilter>,
+        expression_handler: Arc<dyn ExpressionHandler>,
+        schema: SchemaRef,
+    ) -> Self {
+        Self {
+            timestamp: commit_file.location.last_modified,
+            commit_file,
+            json_handler,
+            filter,
+            has_cdc_action: Default::default(),
+            remove_dvs: Default::default(),
+            expression_handler,
+            schema,
+        }
+    }
+    fn prepare_phase(&mut self) -> DeltaResult<()> {
+        let schema = PreparePhaseVisitor::schema()?;
+        let action_iter = self.json_handler.read_json_files(
+            &[self.commit_file.location.clone()],
+            schema,
+            None,
+        )?;
+
+        let mut add_paths = HashSet::new();
+        for actions in action_iter {
+            let actions = actions?;
+
+            // Apply data skipping to get back a selection vector for actions that passed skipping.
+            // We start our selection vector based on what was filtered. We will add to this vector
+            // below if a file has been removed. Note: None implies all files passed data skipping.
+            let selection_vector = match &self.filter {
+                Some(filter) => filter.apply(actions.as_ref())?,
+                None => vec![true; actions.len()],
+            };
+
+            let mut visitor = PreparePhaseVisitor::new(self, selection_vector, &mut add_paths);
+            visitor.visit_rows_of(actions.as_ref())?;
+
+            if let Some(protocol) = visitor.protocol {
+                protocol.ensure_read_supported()?;
+            }
+            if let Some((schema, configuration)) = visitor.metadata_info {
+                let schema: StructType = serde_json::from_str(&schema)?;
+                require!(
+                    self.schema.as_ref() == &schema,
+                    Error::change_data_feed_incompatible_schema(&self.schema, &schema)
+                );
+
+                let table_properties = TableProperties::from(configuration);
+                require!(
+                    table_properties.enable_change_data_feed.unwrap_or(false),
+                    Error::change_data_feed_unsupported(self.commit_file.version)
+                )
+            }
+        }
+
+        // We resolve the remove deletion vector map after visiting the entire commit.
+        if self.has_cdc_action {
+            self.remove_dvs.clear();
+        } else {
+            // The only (path, deletion_vector) pairs we must track are ones whose path is the
+            // same as an `add` action.
+            self.remove_dvs
+                .retain(|rm_path, _| add_paths.contains(rm_path));
+        }
+        Ok(())
+    }
+
+    fn into_scan_batches(
+        self,
+    ) -> DeltaResult<impl Iterator<Item = DeltaResult<TableChangesScanData>>> {
+        let Self {
+            has_cdc_action,
+            remove_dvs,
+            commit_file,
+            json_handler,
+            timestamp: _,
+            filter,
+            expression_handler,
+            schema: _,
+        } = self;
+        let remove_dvs = Arc::new(remove_dvs);
+
+        let schema = FileActionSelectionVisitor::schema()?;
+        let action_iter =
+            json_handler.read_json_files(&[commit_file.location.clone()], schema, None)?;
+
+        let result = action_iter.map(move |actions| -> DeltaResult<_> {
+            let actions = actions?;
+
+            // Apply data skipping to get back a selection vector for actions that passed skipping.
+            // We start our selection vector based on what was filtered. We will add to this vector
+            // below if a file has been removed. Note: None implies all files passed data skipping.
+            let selection_vector = match &filter {
+                Some(filter) => filter.apply(actions.as_ref())?,
+                None => vec![true; actions.len()],
+            };
+
+            let mut visitor =
+                FileActionSelectionVisitor::new(&remove_dvs, selection_vector, has_cdc_action);
+            visitor.visit_rows_of(actions.as_ref())?;
+
+            let data = expression_handler
+                .get_evaluator(
+                    get_log_add_schema().clone(),
+                    get_add_transform_expr(),
+                    scan_row_schema().into(),
+                )
+                .evaluate(actions.as_ref())?;
+            Ok(TableChangesScanData {
+                data,
+                selection_vector: visitor.selection_vector,
+                remove_dv: Some(remove_dvs.clone()),
+            })
+        });
+        Ok(result)
+    }
+}
+
+// This is a visitor used in the prepare phase of [`LogReplayScanner`]. See
+// [`LogReplayScanner::prepare_phase`] for details usage.
+struct PreparePhaseVisitor<'a> {
+    scanner: &'a mut LogReplayScanner,
+    selection_vector: Vec<bool>,
+    protocol: Option<Protocol>,
+    metadata_info: Option<(String, HashMap<String, String>)>,
+    add_paths: &'a mut HashSet<String>,
+}
+impl<'a> PreparePhaseVisitor<'a> {
+    fn new(
+        scanner: &'a mut LogReplayScanner,
+        selection_vector: Vec<bool>,
+        add_paths: &'a mut HashSet<String>,
+    ) -> Self {
+        PreparePhaseVisitor {
+            scanner,
+            selection_vector,
+            protocol: None,
+            metadata_info: None,
+            add_paths,
+        }
+    }
+    fn schema() -> DeltaResult<Arc<StructType>> {
+        get_log_schema().project(&[
+            ADD_NAME,
+            REMOVE_NAME,
+            CDC_NAME,
+            COMMIT_INFO_NAME,
+            METADATA_NAME,
+            PROTOCOL_NAME,
+        ])
+    }
+}
+
+impl<'a> RowVisitor for PreparePhaseVisitor<'a> {
+    fn selected_column_names_and_types(
+        &self,
+    ) -> (
+        &'static [crate::expressions::ColumnName],
+        &'static [crate::schema::DataType],
+    ) {
+        // NOTE: The order of the names and types is based on [`PreparePhaseVisitor::schema`]
+        static NAMES_AND_TYPES: LazyLock<ColumnNamesAndTypes> = LazyLock::new(|| {
+            const STRING: DataType = DataType::STRING;
+            const INTEGER: DataType = DataType::INTEGER;
+            const LONG: DataType = DataType::LONG;
+            let string_list: DataType = ArrayType::new(STRING, false).into();
+            let string_string_map = MapType::new(STRING, STRING, false).into();
+            let types_and_names = vec![
+                (STRING, column_name!("add.path")),
+                (STRING, column_name!("remove.path")),
+                (STRING, column_name!("remove.deletionVector.storageType")),
+                (STRING, column_name!("remove.deletionVector.pathOrInlineDv")),
+                (INTEGER, column_name!("remove.deletionVector.offset")),
+                (INTEGER, column_name!("remove.deletionVector.sizeInBytes")),
+                (LONG, column_name!("remove.deletionVector.cardinality")),
+                (STRING, column_name!("cdc.path")),
+                (LONG, column_name!("commitInfo.timestamp")),
+                (STRING, column_name!("metaData.schemaString")),
+                (string_string_map, column_name!("metaData.configuration")),
+                (INTEGER, column_name!("protocol.minReaderVersion")),
+                (INTEGER, column_name!("protocol.minWriterVersion")),
+                (string_list.clone(), column_name!("protocol.readerFeatures")),
+                (string_list, column_name!("protocol.writerFeatures")),
+            ];
+            let (types, names) = types_and_names.into_iter().unzip();
+            (names, types).into()
+        });
+        NAMES_AND_TYPES.as_ref()
+    }
+
+    fn visit<'b>(
+        &mut self,
+        row_count: usize,
+        getters: &[&'b dyn crate::engine_data::GetData<'b>],
+    ) -> DeltaResult<()> {
+        let expected_getters = 15;
+        require!(
+            getters.len() == expected_getters,
+            Error::InternalError(format!(
+                "Wrong number of PreparePhaseVisitor getters: {}",
+                getters.len()
+            ))
+        );
+
+        for i in 0..row_count {
+            if !self.selection_vector[i] {
+                continue;
+            }
+            if let Some(path) = getters[0].get_str(i, "add.path")? {
+                self.add_paths.insert(path.to_string());
+            } else if let Some(path) = getters[1].get_str(i, "remove.path")? {
+                let deletion_vector = visit_deletion_vector_at(i, &getters[2..=6])?;
+                self.scanner
+                    .remove_dvs
+                    .insert(path.to_string(), DvInfo { deletion_vector });
+            } else if getters[7].get_str(i, "cdc.path")?.is_some() {
+                self.scanner.has_cdc_action = true;
+            } else if let Some(timestamp) = getters[8].get_long(i, "commitInfo.timestamp")? {
+                self.scanner.timestamp = timestamp;
+            } else if let Some(schema) = getters[9].get_str(i, "metaData.schemaString")? {
+                let configuration_map_opt: Option<HashMap<_, _>> =
+                    getters[10].get_opt(i, "metadata.configuration")?;
+
+                // A null configuration here means that we found an empty configuration. This is
+                // different from not finding any metadata action, where self.configuration = None
+                let configuration = configuration_map_opt.unwrap_or_else(HashMap::new);
+
+                self.metadata_info = Some((schema.to_string(), configuration));
+            } else if let Some(min_reader_version) =
+                getters[11].get_int(i, "protocol.min_reader_version")?
+            {
+                let protocol =
+                    ProtocolVisitor::visit_protocol(i, min_reader_version, &getters[11..=14])?;
+                self.protocol = Some(protocol);
+            }
+        }
+        Ok(())
+    }
+}
+
+// This visitor generates selection vectors based on the rules specified in [`LogReplayScanner`].
+// See [`LogReplayScanner::into_scan_batches`] for usage.
+struct FileActionSelectionVisitor<'a> {
+    selection_vector: Vec<bool>,
+    has_cdc_action: bool,
+    remove_dvs: &'a HashMap<String, DvInfo>,
+}
+
+impl<'a> FileActionSelectionVisitor<'a> {
+    fn new(
+        remove_dvs: &'a HashMap<String, DvInfo>,
+        selection_vector: Vec<bool>,
+        has_cdc_action: bool,
+    ) -> Self {
+        FileActionSelectionVisitor {
+            selection_vector,
+            has_cdc_action,
+            remove_dvs,
+        }
+    }
+    fn schema() -> DeltaResult<Arc<StructType>> {
+        get_log_schema().project(&[ADD_NAME, REMOVE_NAME, CDC_NAME])
+    }
+}
+
+impl<'a> RowVisitor for FileActionSelectionVisitor<'a> {
+    fn selected_column_names_and_types(
+        &self,
+    ) -> (
+        &'static [crate::expressions::ColumnName],
+        &'static [crate::schema::DataType],
+    ) {
+        // NOTE: The order of the names and types is based on [`FileActionSelectionVisitor::schema`]
+        static NAMES_AND_TYPES: LazyLock<ColumnNamesAndTypes> = LazyLock::new(|| {
+            const STRING: DataType = DataType::STRING;
+            let types_and_names = vec![
+                (STRING, column_name!("add.path")),
+                (STRING, column_name!("remove.path")),
+                (STRING, column_name!("cdc.path")),
+            ];
+            let (types, names) = types_and_names.into_iter().unzip();
+            (names, types).into()
+        });
+        NAMES_AND_TYPES.as_ref()
+    }
+
+    fn visit<'b>(
+        &mut self,
+        row_count: usize,
+        getters: &[&'b dyn crate::engine_data::GetData<'b>],
+    ) -> DeltaResult<()> {
+        let expected_getters = 3;
+        require!(
+            getters.len() == expected_getters,
+            Error::InternalError(format!(
+                "Wrong number of AddRemoveDedupVisitor getters: {}",
+                getters.len()
+            ))
+        );
+
+        for i in 0..row_count {
+            if !self.selection_vector[i] {
+                continue;
+            }
+            if getters[0].get_str(i, "add.path")?.is_some() {
+                self.selection_vector[i] = !self.has_cdc_action;
+            } else if let Some(path) = getters[1].get_str(i, "remove.path")? {
+                self.selection_vector[i] =
+                    !self.has_cdc_action && !self.remove_dvs.contains_key(path)
+            } else {
+                self.selection_vector[i] = getters[2].get_str(i, "cdc.path")?.is_some()
+            };
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::{LogReplayScanner, TableChangesScanData};
+    use crate::actions::deletion_vector::DeletionVectorDescriptor;
+    use crate::actions::{Add, Cdc, CommitInfo, Metadata, Protocol, Remove};
+    use crate::engine::sync::SyncEngine;
+    use crate::log_segment::LogSegment;
+    use crate::path::ParsedLogPath;
+    use crate::scan::state::DvInfo;
+    use crate::schema::{DataType, StructField, StructType};
+    use crate::utils::test_utils::MockTable;
+    use crate::{DeltaResult, Engine, Error, Version};
+
+    use itertools::Itertools;
+    use std::collections::HashMap;
+    use std::path::Path;
+
+    fn get_schema() -> StructType {
+        StructType::new([
+            StructField::new("id", DataType::LONG, true),
+            StructField::new("value", DataType::STRING, true),
+        ])
+    }
+
+    fn get_segment(
+        engine: &dyn Engine,
+        path: &Path,
+        start_version: Version,
+        end_version: impl Into<Option<Version>>,
+    ) -> DeltaResult<Vec<ParsedLogPath>> {
+        let table_root = url::Url::from_directory_path(path).unwrap();
+        let log_root = table_root.join("_delta_log/")?;
+        let log_segment = LogSegment::for_table_changes(
+            engine.get_file_system_client().as_ref(),
+            log_root,
+            start_version,
+            end_version,
+        )?;
+        Ok(log_segment.ascending_commit_files)
+    }
+
+    fn get_commit_log_scanner(engine: &dyn Engine, commit: ParsedLogPath) -> LogReplayScanner {
+        let expression_handler = engine.get_expression_handler();
+        LogReplayScanner::new(
+            commit,
+            engine.get_json_handler(),
+            None,
+            expression_handler.clone(),
+            get_schema().into(),
+        )
+    }
+    fn result_to_sv(iter: impl Iterator<Item = DeltaResult<TableChangesScanData>>) -> Vec<bool> {
+        iter.map_ok(|scan_data| scan_data.selection_vector.into_iter())
+            .flatten_ok()
+            .try_collect()
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn metadata_protocol() {
+        let engine = SyncEngine::new();
+        let mut mock_table = MockTable::new();
+        let schema_string = serde_json::to_string(&get_schema()).unwrap();
+        mock_table
+            .commit(&[
+                Metadata {
+                    schema_string,
+                    configuration: HashMap::from([
+                        ("delta.enableChangeDataFeed".to_string(), "true".to_string()),
+                        (
+                            "delta.enableDeletionVectors".to_string(),
+                            "true".to_string(),
+                        ),
+                    ]),
+                    ..Default::default()
+                }
+                .into(),
+                Protocol::try_new(3, 7, Some(["deletionVectors"]), Some(["deletionVectors"]))
+                    .unwrap()
+                    .into(),
+            ])
+            .await;
+
+        let mut commits = get_segment(&engine, mock_table.table_root(), 0, None)
+            .unwrap()
+            .into_iter();
+
+        let mut scanner = get_commit_log_scanner(&engine, commits.next().unwrap());
+
+        scanner.prepare_phase().unwrap();
+        assert!(!scanner.has_cdc_action);
+        assert!(scanner.remove_dvs.is_empty());
+
+        assert_eq!(
+            result_to_sv(scanner.into_scan_batches().unwrap()),
+            &[false, false]
+        );
+    }
+    #[tokio::test]
+    async fn configuration_fails() {
+        let engine = SyncEngine::new();
+        let mut mock_table = MockTable::new();
+        let schema_string = serde_json::to_string(&get_schema()).unwrap();
+        mock_table
+            .commit(&[Metadata {
+                schema_string,
+                configuration: HashMap::from([(
+                    "delta.enableDeletionVectors".to_string(),
+                    "true".to_string(),
+                )]),
+                ..Default::default()
+            }
+            .into()])
+            .await;
+
+        let mut commits = get_segment(&engine, mock_table.table_root(), 0, None)
+            .unwrap()
+            .into_iter();
+
+        let mut scanner = get_commit_log_scanner(&engine, commits.next().unwrap());
+
+        assert!(matches!(
+            scanner.prepare_phase(),
+            Err(Error::ChangeDataFeedUnsupported(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn incompatible_schema() {
+        let engine = SyncEngine::new();
+        let mut mock_table = MockTable::new();
+
+        // The original schema has two fields: `id` and value.
+        let schema = get_schema().project(&["id"]).unwrap();
+        let schema_string = serde_json::to_string(&schema).unwrap();
+        mock_table
+            .commit(&[Metadata {
+                schema_string,
+                configuration: HashMap::from([
+                    ("delta.enableChangeDataFeed".to_string(), "true".to_string()),
+                    (
+                        "delta.enableDeletionVectors".to_string(),
+                        "true".to_string(),
+                    ),
+                ]),
+                ..Default::default()
+            }
+            .into()])
+            .await;
+
+        let mut commits = get_segment(&engine, mock_table.table_root(), 0, None)
+            .unwrap()
+            .into_iter();
+
+        let mut scanner = get_commit_log_scanner(&engine, commits.next().unwrap());
+
+        assert!(matches!(
+            scanner.prepare_phase(),
+            Err(Error::ChangeDataFeedIncompatibleSchema(_, _))
+        ));
+    }
+
+    #[tokio::test]
+    async fn add_remove() {
+        let engine = SyncEngine::new();
+        let mut mock_table = MockTable::new();
+        mock_table
+            .commit(&[
+                Add {
+                    path: "fake_path_1".into(),
+                    ..Default::default()
+                }
+                .into(),
+                Remove {
+                    path: "fake_path_2".into(),
+                    ..Default::default()
+                }
+                .into(),
+            ])
+            .await;
+
+        let mut commits = get_segment(&engine, mock_table.table_root(), 0, None)
+            .unwrap()
+            .into_iter();
+
+        let commit = commits.next().unwrap();
+        let mut scanner = get_commit_log_scanner(&engine, commit);
+
+        scanner.prepare_phase().unwrap();
+        assert!(!scanner.has_cdc_action);
+        assert_eq!(scanner.remove_dvs, HashMap::new());
+
+        assert_eq!(
+            result_to_sv(scanner.into_scan_batches().unwrap()),
+            &[true, true]
+        );
+    }
+
+    #[tokio::test]
+    async fn cdc_selection() {
+        let engine = SyncEngine::new();
+        let mut mock_table = MockTable::new();
+        mock_table
+            .commit(&[
+                Add {
+                    path: "fake_path_1".into(),
+                    ..Default::default()
+                }
+                .into(),
+                Remove {
+                    path: "fake_path_2".into(),
+                    ..Default::default()
+                }
+                .into(),
+                Cdc {
+                    path: "fake_path_3".into(),
+                    ..Default::default()
+                }
+                .into(),
+            ])
+            .await;
+
+        let mut commits = get_segment(&engine, mock_table.table_root(), 0, None)
+            .unwrap()
+            .into_iter();
+
+        let commit = commits.next().unwrap();
+        let mut scanner = get_commit_log_scanner(&engine, commit);
+
+        scanner.prepare_phase().unwrap();
+        assert!(scanner.has_cdc_action);
+        assert_eq!(scanner.remove_dvs, HashMap::new());
+
+        assert_eq!(
+            result_to_sv(scanner.into_scan_batches().unwrap()),
+            &[false, false, true]
+        );
+    }
+
+    #[tokio::test]
+    async fn dv() {
+        let engine = SyncEngine::new();
+        let mut mock_table = MockTable::new();
+
+        let deletion_vector1 = DeletionVectorDescriptor {
+            storage_type: "u".to_string(),
+            path_or_inline_dv: "vBn[lx{q8@P<9BNH/isA".to_string(),
+            offset: Some(1),
+            size_in_bytes: 36,
+            cardinality: 2,
+        };
+        let deletion_vector2 = DeletionVectorDescriptor {
+            storage_type: "u".to_string(),
+            path_or_inline_dv: "U5OWRz5k%CFT.Td}yCPW".to_string(),
+            offset: Some(1),
+            size_in_bytes: 38,
+            cardinality: 3,
+        };
+        mock_table
+            .commit(&[
+                Add {
+                    path: "fake_path_1".into(),
+                    ..Default::default()
+                }
+                .into(),
+                Remove {
+                    path: "fake_path_1".into(),
+                    deletion_vector: Some(deletion_vector1.clone()),
+                    ..Default::default()
+                }
+                .into(),
+                Remove {
+                    path: "fake_path_2".into(),
+                    deletion_vector: Some(deletion_vector2.clone()),
+                    ..Default::default()
+                }
+                .into(),
+            ])
+            .await;
+
+        let mut commits = get_segment(&engine, mock_table.table_root(), 0, None)
+            .unwrap()
+            .into_iter();
+
+        let commit = commits.next().unwrap();
+        let mut scanner = get_commit_log_scanner(&engine, commit);
+
+        scanner.prepare_phase().unwrap();
+        assert!(!scanner.has_cdc_action);
+        assert_eq!(
+            scanner.remove_dvs,
+            HashMap::from([(
+                "fake_path_1".to_string(),
+                DvInfo {
+                    deletion_vector: Some(deletion_vector1.clone())
+                }
+            )])
+        );
+
+        assert_eq!(
+            result_to_sv(scanner.into_scan_batches().unwrap()),
+            &[true, false, true]
+        );
+    }
+    #[tokio::test]
+    async fn failing_protocol() {
+        let engine = SyncEngine::new();
+        let mut mock_table = MockTable::new();
+
+        let protocol = Protocol::try_new(
+            3,
+            1,
+            ["fake_feature".to_string()].into(),
+            ["fake_feature".to_string()].into(),
+        )
+        .unwrap();
+
+        mock_table
+            .commit(&[
+                Add {
+                    path: "fake_path_1".into(),
+                    ..Default::default()
+                }
+                .into(),
+                Remove {
+                    path: "fake_path_2".into(),
+                    ..Default::default()
+                }
+                .into(),
+                protocol.into(),
+            ])
+            .await;
+
+        let mut commits = get_segment(&engine, mock_table.table_root(), 0, None)
+            .unwrap()
+            .into_iter();
+
+        let commit = commits.next().unwrap();
+        let mut scanner = get_commit_log_scanner(&engine, commit);
+
+        assert!(scanner.prepare_phase().is_err());
+    }
+    #[tokio::test]
+    async fn in_commit_timestamp() {
+        let engine = SyncEngine::new();
+        let mut mock_table = MockTable::new();
+
+        let timestamp = 123456;
+        mock_table
+            .commit(&[
+                Add {
+                    path: "fake_path_1".into(),
+                    ..Default::default()
+                }
+                .into(),
+                CommitInfo {
+                    timestamp: Some(timestamp),
+                    ..Default::default()
+                }
+                .into(),
+            ])
+            .await;
+
+        let mut commits = get_segment(&engine, mock_table.table_root(), 0, None)
+            .unwrap()
+            .into_iter();
+
+        let commit = commits.next().unwrap();
+        let mut scanner = get_commit_log_scanner(&engine, commit);
+
+        scanner.prepare_phase().unwrap();
+        assert_eq!(scanner.timestamp, timestamp);
+    }
+
+    #[tokio::test]
+    async fn file_meta_timestamp() {
+        let engine = SyncEngine::new();
+        let mut mock_table = MockTable::new();
+
+        mock_table
+            .commit(&[Add {
+                path: "fake_path_1".into(),
+                ..Default::default()
+            }
+            .into()])
+            .await;
+
+        let mut commits = get_segment(&engine, mock_table.table_root(), 0, None)
+            .unwrap()
+            .into_iter();
+
+        let commit = commits.next().unwrap();
+        let file_meta_ts = commit.location.last_modified;
+        let mut scanner = get_commit_log_scanner(&engine, commit);
+
+        scanner.prepare_phase().unwrap();
+        assert_eq!(scanner.timestamp, file_meta_ts);
+    }
+}

--- a/kernel/src/table_changes/mod.rs
+++ b/kernel/src/table_changes/mod.rs
@@ -12,6 +12,7 @@ use crate::table_features::ColumnMappingMode;
 use crate::{DeltaResult, Engine, Error, Version};
 
 pub mod scan;
+mod scan_file;
 
 static CDF_FIELDS: LazyLock<[StructField; 3]> = LazyLock::new(|| {
     [

--- a/kernel/src/table_changes/mod.rs
+++ b/kernel/src/table_changes/mod.rs
@@ -11,6 +11,7 @@ use crate::snapshot::Snapshot;
 use crate::table_features::ColumnMappingMode;
 use crate::{DeltaResult, Engine, Error, Version};
 
+mod data_read;
 mod log_replay;
 pub mod scan;
 mod scan_file;

--- a/kernel/src/table_changes/mod.rs
+++ b/kernel/src/table_changes/mod.rs
@@ -11,6 +11,7 @@ use crate::snapshot::Snapshot;
 use crate::table_features::ColumnMappingMode;
 use crate::{DeltaResult, Engine, Error, Version};
 
+mod log_replay;
 pub mod scan;
 mod scan_file;
 

--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -9,6 +9,7 @@ use crate::schema::{SchemaRef, StructType};
 use crate::{DeltaResult, Engine, ExpressionRef};
 
 use super::log_replay::{table_changes_action_iter, TableChangesScanData};
+use super::scan_file::scan_data_to_scan_file;
 use super::{TableChanges, CDF_FIELDS};
 
 /// The result of building a [`TableChanges`] scan over a table. This can be used to get a change
@@ -187,6 +188,116 @@ impl TableChangesScan {
         engine: Arc<dyn Engine>,
     ) -> DeltaResult<impl Iterator<Item = DeltaResult<ScanResult>>> {
         let scan_data = self.scan_data(engine.as_ref())?;
+        let scan_files = scan_data_to_scan_file(scan_data);
+
+        let result = scan_files
+            .into_iter()
+            .map(move |scan_res| -> DeltaResult<_> {
+                let (scan_file, dv_map) = scan_res?;
+                let ScanFile {
+                    tpe,
+                    path,
+                    dv_info,
+                    partition_values,
+                    size,
+                    commit_version,
+                    timestamp,
+                } = scan_file;
+                let file_path = self.table_changes.table_root.join(&path)?;
+                let file = FileMeta {
+                    last_modified: 0,
+                    size: size as usize,
+                    location: file_path,
+                };
+                match (&tpe, dv_map.get(&path)) {
+                    (state::ScanFileType::Add, Some(rm_dv)) => {
+                        let generated_columns =
+                            get_generated_columns(timestamp, tpe, commit_version)?;
+
+                        let add_dv = dv_info
+                            .get_treemap(engine, &self.table_changes.table_root)?
+                            .unwrap_or(Default::default());
+                        let rm_dv = rm_dv
+                            .get_treemap(engine, &self.table_changes.table_root)?
+                            .unwrap_or(Default::default());
+
+                        let added = treemap_to_bools(&rm_dv - &add_dv);
+                        let added_rows = self.generate_output_rows(
+                            engine,
+                            file.clone(),
+                            global_state.clone(),
+                            partition_values.clone(),
+                            Some(added),
+                            Some(false),
+                            generated_columns.clone(),
+                            self.global_scan_state().read_schema.clone(),
+                        )?;
+
+                        let removed = treemap_to_bools(add_dv - rm_dv);
+                        let removed_rows = self.generate_output_rows(
+                            engine,
+                            file,
+                            global_state.clone(),
+                            partition_values.clone(),
+                            Some(removed),
+                            Some(false),
+                            generated_columns.clone(),
+                            self.global_scan_state().read_schema.clone(),
+                        )?;
+
+                        Ok(Either::Left(added_rows.chain(removed_rows)))
+                    }
+                    (ScanFileType::Cdc, _) => {
+                        let selection_vector =
+                            dv_info.get_selection_vector(engine, &self.table_changes.table_root)?;
+
+                        let generated_columns =
+                            get_generated_columns(timestamp, tpe, commit_version)?;
+
+                        let fields = self
+                            .global_scan_state()
+                            .read_schema
+                            .fields()
+                            .cloned()
+                            .collect_vec();
+                        let read_schema = StructType::new(fields.into_iter().chain(once(
+                            StructField::new("_change_type", DataType::STRING, false),
+                        )));
+                        Ok(Either::Right(self.generate_output_rows(
+                            engine,
+                            file,
+                            global_state.clone(),
+                            partition_values,
+                            selection_vector,
+                            None,
+                            generated_columns,
+                            read_schema.into(),
+                        )?))
+                    }
+                    _ => {
+                        let selection_vector =
+                            dv_info.get_selection_vector(engine, &self.table_changes.table_root)?;
+
+                        let generated_columns =
+                            get_generated_columns(timestamp, tpe, commit_version)?;
+                        Ok(Either::Right(self.generate_output_rows(
+                            engine,
+                            file,
+                            global_state.clone(),
+                            partition_values,
+                            selection_vector,
+                            None,
+                            generated_columns,
+                            self.global_scan_state().read_schema.clone(),
+                        )?))
+                    }
+                }
+            })
+            // // Iterator<DeltaResult<Iterator<DeltaResult<ScanResult>>>> to Iterator<DeltaResult<DeltaResult<ScanResult>>>
+            .flatten_ok()
+            // // Iterator<DeltaResult<DeltaResult<ScanResult>>> to Iterator<DeltaResult<ScanResult>>
+            .map(|x| x?);
+        Ok(result)
         Ok(iter::empty())
     }
 }

--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -1,9 +1,10 @@
+use std::iter;
 use std::sync::Arc;
 
 use itertools::Itertools;
 use tracing::debug;
 
-use crate::scan::ColumnType;
+use crate::scan::{ColumnType, ScanResult};
 use crate::schema::{SchemaRef, StructType};
 use crate::{DeltaResult, Engine, ExpressionRef};
 
@@ -180,6 +181,13 @@ impl TableChangesScan {
             self.table_schema.clone(),
             self.predicate.clone(),
         )
+    }
+    pub fn execute(
+        &self,
+        engine: Arc<dyn Engine>,
+    ) -> DeltaResult<impl Iterator<Item = DeltaResult<ScanResult>>> {
+        let scan_data = self.scan_data(engine.as_ref())?;
+        Ok(iter::empty())
     }
 }
 

--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -4,9 +4,10 @@ use itertools::Itertools;
 use tracing::debug;
 
 use crate::scan::ColumnType;
-use crate::schema::SchemaRef;
-use crate::{DeltaResult, ExpressionRef};
+use crate::schema::{SchemaRef, StructType};
+use crate::{DeltaResult, Engine, ExpressionRef};
 
+use super::log_replay::{table_changes_action_iter, TableChangesScanData};
 use super::{TableChanges, CDF_FIELDS};
 
 /// The result of building a [`TableChanges`] scan over a table. This can be used to get a change
@@ -19,6 +20,8 @@ pub struct TableChangesScan {
     predicate: Option<ExpressionRef>,
     all_fields: Vec<ColumnType>,
     have_partition_cols: bool,
+    physical_schema: StructType,
+    table_schema: SchemaRef,
 }
 
 /// This builder constructs a [`TableChangesScan`] that can be used to read the [`TableChanges`]
@@ -148,15 +151,38 @@ impl TableChangesScanBuilder {
                 }
             })
             .try_collect()?;
+        let table_schema = self.table_changes.end_snapshot.schema().clone().into();
         Ok(TableChangesScan {
             table_changes: self.table_changes,
             logical_schema,
             predicate: self.predicate,
             all_fields,
             have_partition_cols,
+            physical_schema: StructType::new(read_fields),
+            table_schema,
         })
     }
 }
+
+impl TableChangesScan {
+    pub fn scan_data(
+        &self,
+        engine: &dyn Engine,
+    ) -> DeltaResult<impl Iterator<Item = DeltaResult<TableChangesScanData>>> {
+        let commits = self
+            .table_changes
+            .log_segment
+            .ascending_commit_files
+            .clone();
+        table_changes_action_iter(
+            engine,
+            commits,
+            self.table_schema.clone(),
+            self.predicate.clone(),
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -1,21 +1,16 @@
-use std::collections::HashMap;
-use std::iter::{self, empty, once};
 use std::sync::Arc;
 
 use itertools::Itertools;
-use serde::{Deserialize, Serialize};
 use tracing::debug;
 
-use crate::scan::state::DvInfo;
 use crate::scan::{ColumnType, ScanResult};
 use crate::schema::{SchemaRef, StructType};
-use crate::table_changes::scan_file::ScanFileType;
 use crate::table_features::ColumnMappingMode;
-use crate::{DeltaResult, Engine, Error, ExpressionRef};
+use crate::{DeltaResult, Engine, ExpressionRef};
 
-use super::data_read::{resolve_scan_file_dv, DataReader};
+use super::data_read::{resolve_scan_file_dv, ScanFileReader};
 use super::log_replay::{table_changes_action_iter, TableChangesScanData};
-use super::scan_file::{scan_data_to_scan_file, ScanFile};
+use super::scan_file::scan_data_to_scan_file;
 use super::{TableChanges, CDF_FIELDS};
 
 /// The result of building a [`TableChanges`] scan over a table. This can be used to get a change
@@ -239,7 +234,7 @@ impl TableChangesScan {
                 let (scan_file, selection_vector) = x?;
                 let engine = engine.clone();
                 let reader =
-                    DataReader::new(global_scan_state.clone(), scan_file, selection_vector);
+                    ScanFileReader::new(global_scan_state.clone(), scan_file, selection_vector);
                 reader.into_data(engine.as_ref())
             })
             .flatten_ok()

--- a/kernel/src/table_changes/scan_file.rs
+++ b/kernel/src/table_changes/scan_file.rs
@@ -23,21 +23,21 @@ pub(crate) enum ScanFileType {
 }
 
 /// Represents all the metadata needed to read a Change Data Feed. It has the following fields:
-/// * `tpe`: The type of action this file belongs to. This may be one of add, remove, or cdc.
-/// * `path`: a `&str` which is the path to the file
-/// * `size`: an `i64` which is the size of the file
-/// * `dv_info`: a [`DvInfo`] struct, which allows getting the selection vector for this file
-/// * `partition_values`: a `HashMap<String, String>` which are partition values
-/// * `commit_version`: the commit version that this action was performed in
-/// * `timestamp`: the timestamp of the commit that this action was performed in
 #[derive(Debug)]
 pub(crate) struct ScanFile {
+    /// The type of action this file belongs to. This may be one of add, remove, or cdc.
     pub tpe: ScanFileType,
+    /// a `&str` which is the path to the file
     pub path: String,
+    /// an `i64` which is the size of the file
     pub size: i64,
+    /// a [`DvInfo`] struct, which allows getting the selection vector for this file
     pub dv_info: DvInfo,
+    /// a `HashMap<String, String>` which are partition values
     pub partition_values: HashMap<String, String>,
+    /// the commit version that this action was performed in
     pub commit_version: u64,
+    /// the timestamp of the commit that this action was performed in
     pub timestamp: i64,
 }
 

--- a/kernel/src/table_changes/scan_file.rs
+++ b/kernel/src/table_changes/scan_file.rs
@@ -15,6 +15,7 @@ use crate::utils::require;
 use crate::{DeltaResult, EngineData, Error, RowVisitor};
 
 // The type of action associated with a [`ScanFile`]
+#[allow(unused)]
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum ScanFileType {
     Add,
@@ -23,6 +24,7 @@ pub(crate) enum ScanFileType {
 }
 
 /// Represents all the metadata needed to read a Change Data Feed. It has the following fields:
+#[allow(unused)]
 #[derive(Debug, PartialEq)]
 pub(crate) struct ScanFile {
     /// The type of action this file belongs to. This may be one of add, remove, or cdc.
@@ -67,6 +69,7 @@ pub(crate) type ScanCallback<T> = fn(context: &mut T, scan_file: ScanFile);
 ///     )?;
 /// }
 /// ```
+#[allow(unused)]
 pub(crate) fn visit_scan_files<T>(
     data: &dyn EngineData,
     selection_vector: &[bool],
@@ -84,6 +87,7 @@ pub(crate) fn visit_scan_files<T>(
 }
 
 // add some visitor magic for engines
+#[allow(unused)]
 struct ScanFileVisitor<'a, T> {
     callback: ScanCallback<T>,
     selection_vector: &'a [bool],
@@ -255,6 +259,7 @@ pub(crate) fn scan_row_schema() -> SchemaRef {
 
 /// Expression to convert an action with `log_schema` into one with
 /// `TABLE_CHANGES_SCAN_ROW_SCHEMA`. This is the expression used to create `TableChangesScanData`.
+#[allow(unused)]
 pub(crate) fn transform_to_scan_row_expression(timestamp: i64, commit_number: i64) -> Expression {
     Expression::struct_from([
         Expression::struct_from([
@@ -360,7 +365,7 @@ mod tests {
         let timestamp = 1234_i64;
         let commit_version = 42_u64;
 
-        let scan_file: Vec<_> = actions
+        let scan_files: Vec<_> = actions
             .map_ok(|actions| {
                 engine
                     .get_expression_handler()

--- a/kernel/src/table_changes/scan_file.rs
+++ b/kernel/src/table_changes/scan_file.rs
@@ -1,0 +1,292 @@
+//! This module handles [`ScanFile`]s for [`TableChangeScan`]. A [`ScanFile`] consists of all the
+//! metadata required to generate Change Data Feed. [`ScanFile`] can be read using
+//! [`ScanFileVisitor`]. The visitor may read from a log with the schema [`scan_row_schema`].
+//! You can convert a log to this schema using the [`transform_to_scan_row_expression`].
+
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock};
+
+use crate::actions::visitors::visit_deletion_vector_at;
+use crate::engine_data::{GetData, TypedGetData};
+use crate::expressions::{column_expr, Expression};
+use crate::scan::state::DvInfo;
+use crate::schema::{ColumnNamesAndTypes, DataType, MapType, SchemaRef, StructField, StructType};
+use crate::utils::require;
+use crate::{DeltaResult, EngineData, Error, RowVisitor};
+
+// The type of action associated with a [`ScanFile`]
+#[derive(Debug, Clone)]
+pub(crate) enum ScanFileType {
+    Add,
+    Remove,
+    Cdc,
+}
+
+/// Represents all the metadata needed to read a Change Data Feed. It has the following fields:
+/// * `tpe`: The type of action this file belongs to. This may be one of add, remove, or cdc.
+/// * `path`: a `&str` which is the path to the file
+/// * `size`: an `i64` which is the size of the file
+/// * `dv_info`: a [`DvInfo`] struct, which allows getting the selection vector for this file
+/// * `partition_values`: a `HashMap<String, String>` which are partition values
+/// * `commit_version`: the commit version that this action was performed in
+/// * `timestamp`: the timestamp of the commit that this action was performed in
+#[derive(Debug)]
+pub(crate) struct ScanFile {
+    pub tpe: ScanFileType,
+    pub path: String,
+    pub size: i64,
+    pub dv_info: DvInfo,
+    pub partition_values: HashMap<String, String>,
+    pub commit_version: u64,
+    pub timestamp: i64,
+}
+
+pub(crate) type ScanCallback<T> = fn(context: &mut T, scan_file: ScanFile);
+
+/// Request that the kernel call a callback on each valid file that needs to be read for the
+/// scan.
+///
+/// The arguments to the callback are:
+/// * `context`: an `&mut context` argument. this can be anything that engine needs to pass through to each call
+/// * `ScanFile`: a [`ScanFile`] struct that holds all the metadata required to perform Change Data
+///   Feed
+///
+/// ## Context
+/// A note on the `context`. This can be any value the engine wants. This function takes ownership
+/// of the passed arg, but then returns it, so the engine can repeatedly call `visit_scan_files`
+/// with the same context.
+///
+/// ## Example
+/// ```ignore
+/// let mut context = [my context];
+/// for res in scan_data { // scan data table_changes_scan.scan_data()
+///     let (data, vector, remove_dv) = res?;
+///     context = delta_kernel::table_changes::scan_file::visit_scan_files(
+///        data.as_ref(),
+///        selection_vector,
+///        context,
+///        my_callback,
+///     )?;
+/// }
+/// ```
+pub(crate) fn visit_scan_files<T>(
+    data: &dyn EngineData,
+    selection_vector: &[bool],
+    context: T,
+    callback: ScanCallback<T>,
+) -> DeltaResult<T> {
+    let mut visitor = ScanFileVisitor {
+        callback,
+        selection_vector,
+        context,
+    };
+
+    visitor.visit_rows_of(data)?;
+    Ok(visitor.context)
+}
+
+// add some visitor magic for engines
+struct ScanFileVisitor<'a, T> {
+    callback: ScanCallback<T>,
+    selection_vector: &'a [bool],
+    context: T,
+}
+
+impl<T> RowVisitor for ScanFileVisitor<'_, T> {
+    fn visit<'a>(&mut self, row_count: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
+        let expected_getters = 21;
+        require!(
+            getters.len() == expected_getters,
+            Error::InternalError(format!(
+                "Wrong number of ScanFileVisitor getters: {}",
+                getters.len()
+            ))
+        );
+        for row_index in 0..row_count {
+            if !self.selection_vector[row_index] {
+                // skip skipped rows
+                continue;
+            }
+            let timestamp = getters[19].get(row_index, "scanFile.timestamp")?;
+            let commit_version: i64 = getters[20].get(row_index, "scanFile.commit_version")?;
+            let commit_version: u64 = commit_version.try_into().map_err(Error::generic)?;
+
+            // Since path column is required, use it to detect presence of an Add action
+            if let Some(path) = getters[0].get_opt(row_index, "scanFile.add.path")? {
+                let size = getters[1].get(row_index, "scanFile.add.size")?;
+                let deletion_vector = visit_deletion_vector_at(row_index, &getters[2..=6])?;
+                let dv_info = DvInfo { deletion_vector };
+                let partition_values =
+                    getters[7].get(row_index, "scanFile.add.fileConstantValues.partitionValues")?;
+                let scan_file = ScanFile {
+                    tpe: ScanFileType::Add,
+                    path,
+                    size,
+                    dv_info,
+                    partition_values,
+                    commit_version,
+                    timestamp,
+                };
+                (self.callback)(&mut self.context, scan_file)
+            } else if let Some(path) = getters[8].get_opt(row_index, "scanFile.remove.path")? {
+                let size = getters[9].get(row_index, "scanFile.remove.size")?;
+                let deletion_vector = visit_deletion_vector_at(row_index, &getters[10..=14])?;
+                let dv_info = DvInfo { deletion_vector };
+                let partition_values = getters[15].get(
+                    row_index,
+                    "scanFile.remove.fileConstantValues.partitionValues",
+                )?;
+                let scan_file = ScanFile {
+                    tpe: ScanFileType::Remove,
+                    path,
+                    size,
+                    dv_info,
+                    partition_values,
+                    commit_version,
+                    timestamp,
+                };
+                (self.callback)(&mut self.context, scan_file)
+            } else if let Some(path) = getters[16].get_opt(row_index, "scanFile.cdc.path")? {
+                let size = getters[17].get(row_index, "scanFile.cdc.size")?;
+                let partition_values = getters[18]
+                    .get(row_index, "scanFile.cdc.fileConstantValues.partitionValues")?;
+                let scan_file = ScanFile {
+                    tpe: ScanFileType::Cdc,
+                    path,
+                    size,
+                    dv_info: DvInfo {
+                        deletion_vector: None,
+                    },
+                    partition_values,
+                    commit_version,
+                    timestamp,
+                };
+
+                (self.callback)(&mut self.context, scan_file)
+            }
+        }
+        Ok(())
+    }
+
+    fn selected_column_names_and_types(
+        &self,
+    ) -> (
+        &'static [crate::expressions::ColumnName],
+        &'static [DataType],
+    ) {
+        static NAMES_AND_TYPES: LazyLock<ColumnNamesAndTypes> =
+            LazyLock::new(|| scan_row_schema().leaves(None));
+        NAMES_AND_TYPES.as_ref()
+    }
+}
+
+/// Get the schema that scan rows (from [`TableChanges::scan_data`]) will be returned with.
+///
+/// It is:
+/// ```ignored
+/// {
+///   add: {
+///     path: string,
+///     size: long,
+///     deletionVector: {
+///       storageType: string,
+///       pathOrInlineDv: string,
+///       offset: int,
+///       sizeInBytes: int,
+///       cardinality: long,
+///     },
+///     fileConstantValues: {
+///       partitionValues: map<string, string>
+///     }
+///   }
+///   remove: {
+///     path: string,
+///     size: long,
+///     deletionVector: {
+///       storageType: string,
+///       pathOrInlineDv: string,
+///       offset: int,
+///       sizeInBytes: int,
+///       cardinality: long,
+///     },
+///     fileConstantValues: {
+///       partitionValues: map<string, string>
+///     },
+///   }
+///   cdc: {
+///     path: string,
+///     size: long,
+///     fileConstantValues: {
+///       partitionValues: map<string, string>
+///     }
+///   }
+///   commit_timestamp: long,
+///   commit_version: long
+///
+/// }
+/// ```
+pub(crate) fn scan_row_schema() -> SchemaRef {
+    static TABLE_CHANGES_SCAN_ROW_SCHEMA: LazyLock<Arc<StructType>> = LazyLock::new(|| {
+        let deletion_vector = StructType::new([
+            StructField::new("storageType", DataType::STRING, true),
+            StructField::new("pathOrInlineDv", DataType::STRING, true),
+            StructField::new("offset", DataType::INTEGER, true),
+            StructField::new("sizeInBytes", DataType::INTEGER, true),
+            StructField::new("cardinality", DataType::LONG, true),
+        ]);
+        let partition_values = MapType::new(DataType::STRING, DataType::STRING, true);
+        let file_constant_values =
+            StructType::new([StructField::new("partitionValues", partition_values, true)]);
+
+        let add = StructType::new([
+            StructField::new("path", DataType::STRING, true),
+            StructField::new("deletionVector", deletion_vector.clone(), true),
+            StructField::new("fileConstantValues", file_constant_values.clone(), true),
+        ]);
+        let remove = StructType::new([
+            StructField::new("path", DataType::STRING, true),
+            StructField::new("deletionVector", deletion_vector, true),
+            StructField::new("fileConstantValues", file_constant_values.clone(), true),
+        ]);
+        let cdc = StructType::new([
+            StructField::new("path", DataType::STRING, true),
+            StructField::new("fileConstantValues", file_constant_values, true),
+        ]);
+
+        Arc::new(StructType::new([
+            StructField::new("add", add, true),
+            StructField::new("remove", remove, true),
+            StructField::new("cdc", cdc, true),
+            StructField::new("timestamp", DataType::LONG, true),
+            StructField::new("commit_version", DataType::LONG, true),
+        ]))
+    });
+    TABLE_CHANGES_SCAN_ROW_SCHEMA.clone()
+}
+
+/// Expression to convert an action with `log_schema` into one with
+/// `TABLE_CHANGES_SCAN_ROW_SCHEMA`. This is the expression used to create `TableChangesScanData`.
+pub(crate) fn transform_to_scan_row_expression(timestamp: i64, commit_number: i64) -> Expression {
+    Expression::struct_from([
+        Expression::struct_from([
+            column_expr!("add.path"),
+            column_expr!("add.deletionVector"),
+            Expression::struct_from([column_expr!("add.partitionValues")]),
+        ]),
+        Expression::struct_from([
+            column_expr!("remove.path"),
+            column_expr!("remove.deletionVector"),
+            Expression::struct_from([column_expr!("remove.partitionValues")]),
+        ]),
+        Expression::struct_from([
+            column_expr!("cdc.path"),
+            column_expr!("cdc.size"),
+            Expression::struct_from([column_expr!("cdc.partitionValues")]),
+        ]),
+        timestamp.into(),
+        commit_number.into(),
+    ])
+}
+
+#[cfg(test)]
+mod tests {}

--- a/kernel/src/table_changes/scan_file.rs
+++ b/kernel/src/table_changes/scan_file.rs
@@ -50,7 +50,7 @@ pub(crate) enum ScanFileType {
 
 /// Represents all the metadata needed to read a Change Data Feed. It has the following fields:
 #[allow(unused)]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub(crate) struct ScanFile {
     /// The type of action this file belongs to. This may be one of add, remove, or cdc.
     pub tpe: ScanFileType,

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -10,3 +10,98 @@ macro_rules! require {
 }
 
 pub(crate) use require;
+
+#[cfg(test)]
+pub(crate) mod test_utils {
+    use itertools::Itertools;
+    use object_store::local::LocalFileSystem;
+    use object_store::ObjectStore;
+    use serde::Serialize;
+    use std::{path::Path, sync::Arc};
+    use tempfile::TempDir;
+    use test_utils::delta_path_for_version;
+
+    use crate::actions::{Add, Cdc, CommitInfo, Metadata, Protocol, Remove};
+
+    #[derive(Serialize)]
+    pub(crate) enum Action {
+        #[serde(rename = "add")]
+        Add(Add),
+        #[serde(rename = "remove")]
+        Remove(Remove),
+        #[serde(rename = "cdc")]
+        Cdc(Cdc),
+        #[serde(rename = "metaData")]
+        Metadata(Metadata),
+        #[serde(rename = "protocol")]
+        Protocol(Protocol),
+        #[serde(rename = "commitInfo")]
+        CommitInfo(CommitInfo),
+    }
+
+    impl From<Add> for Action {
+        fn from(value: Add) -> Self {
+            Self::Add(value)
+        }
+    }
+    impl From<Remove> for Action {
+        fn from(value: Remove) -> Self {
+            Self::Remove(value)
+        }
+    }
+    impl From<Cdc> for Action {
+        fn from(value: Cdc) -> Self {
+            Self::Cdc(value)
+        }
+    }
+    impl From<Metadata> for Action {
+        fn from(value: Metadata) -> Self {
+            Self::Metadata(value)
+        }
+    }
+    impl From<Protocol> for Action {
+        fn from(value: Protocol) -> Self {
+            Self::Protocol(value)
+        }
+    }
+    impl From<CommitInfo> for Action {
+        fn from(value: CommitInfo) -> Self {
+            Self::CommitInfo(value)
+        }
+    }
+
+    pub(crate) struct MockTable {
+        commit_num: u64,
+        store: Arc<LocalFileSystem>,
+        dir: TempDir,
+    }
+
+    impl MockTable {
+        pub(crate) fn new() -> Self {
+            let dir = tempfile::tempdir().unwrap();
+            let store = Arc::new(LocalFileSystem::new_with_prefix(dir.path()).unwrap());
+            Self {
+                commit_num: 0,
+                store,
+                dir,
+            }
+        }
+        pub(crate) async fn commit(&mut self, actions: &[Action]) {
+            let data = actions
+                .iter()
+                .map(|action| serde_json::to_string(&action).unwrap())
+                .join("\n");
+
+            let path = delta_path_for_version(self.commit_num, "json");
+            self.commit_num += 1;
+
+            self.store
+                .put(&path, data.into())
+                .await
+                .expect("put log file in store");
+        }
+        pub(crate) fn table_root(&self) -> &Path {
+            self.dir.path()
+        }
+    }
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR introduces `TableChangesScan::execute`, which reads the change data feed for a `TableChangesScan`. We do so by introducing a `ScanFileReader` which performs all the data file reading, batch iteration, and physical to logical transformation.

I introduce some helper methods for resolving the deletion vectors in `ScanFile` and the remove_dv.

Depends on #546 

## How was this change tested?
TODO: add tests