### PR TITLE
fix: remove column mapping default

### DIFF
--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use strum::EnumString;
 
 /// Modes of column mapping a table can be in
-#[derive(Debug, Default, EnumString, Serialize, Deserialize, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, EnumString, Serialize, Deserialize, Copy, Clone, PartialEq, Eq)]
 #[strum(serialize_all = "camelCase")]
 #[serde(rename_all = "camelCase")]
 pub enum ColumnMappingMode {
@@ -20,7 +20,6 @@ pub enum ColumnMappingMode {
     /// Columns are mapped by their field_id in parquet
     Id,
     /// Columns are mapped to a physical name
-    #[default]
     Name,
 }
 


### PR DESCRIPTION
previously I accidentally changed default from `None` to `Name`. Instead of simply reverting, this removes `Default` from column mapping entirely.