### PR TITLE
Engines now return FileMeta with correct millisecond timestamps

### DIFF
--- a/kernel/src/engine/default/filesystem.rs
+++ b/kernel/src/engine/default/filesystem.rs
@@ -223,8 +223,8 @@ mod tests {
         let store = Arc::new(InMemory::new());
 
         let begin_time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-        // The [`FileMeta`]s must be greater than 2 minute ago
-        let allowed_time = begin_time - Duration::from_secs(120);
+        // The [`FileMeta`]s must be greater than 1 minute ago
+        let allowed_time = begin_time - Duration::from_secs(60);
 
         let data = Bytes::from("kernel-data");
         let name = delta_path_for_version(1, "json");

--- a/kernel/src/engine/default/filesystem.rs
+++ b/kernel/src/engine/default/filesystem.rs
@@ -223,8 +223,6 @@ mod tests {
         let store = Arc::new(InMemory::new());
 
         let begin_time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-        // The [`FileMeta`]s must be greater than 1 minute ago
-        let allowed_begin_time = begin_time - Duration::from_secs(60);
 
         let data = Bytes::from("kernel-data");
         let name = delta_path_for_version(1, "json");
@@ -240,15 +238,10 @@ mod tests {
             .try_collect()
             .unwrap();
 
-        let end_time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-        // The [`FileMeta`]s must be less than one minute in the future
-        let allowed_end_time = end_time + Duration::from_secs(60);
-
         assert!(!files.is_empty());
         for meta in files.into_iter() {
             let meta_time = Duration::from_millis(meta.last_modified.try_into().unwrap());
-            assert!(allowed_begin_time < meta_time);
-            assert!(meta_time < allowed_end_time);
+            assert!(meta_time.abs_diff(begin_time) < Duration::from_secs(10));
         }
     }
     #[tokio::test]

--- a/kernel/src/engine/sync/fs_client.rs
+++ b/kernel/src/engine/sync/fs_client.rs
@@ -1,5 +1,3 @@
-use std::time::SystemTime;
-
 use bytes::Bytes;
 use itertools::Itertools;
 use url::Url;

--- a/kernel/src/engine/sync/fs_client.rs
+++ b/kernel/src/engine/sync/fs_client.rs
@@ -119,8 +119,8 @@ mod tests {
         let tmp_dir = tempfile::tempdir().unwrap();
 
         let begin_time = SystemTime::now().duration_since(UNIX_EPOCH)?;
-        // The [`FileMeta`]s must be greater than 2 minute ago
-        let allowed_time = begin_time - Duration::from_secs(120);
+        // The [`FileMeta`]s must be greater than 1 minute ago
+        let allowed_time = begin_time - Duration::from_secs(60);
 
         let path = tmp_dir.path().join(get_json_filename(1));
         let mut f = File::create(path)?;

--- a/kernel/src/engine/sync/fs_client.rs
+++ b/kernel/src/engine/sync/fs_client.rs
@@ -49,26 +49,7 @@ impl FileSystemClient for SyncFilesystemClient {
             let it = all_ents
                 .into_iter()
                 .sorted_by_key(|ent| ent.path())
-                .map(|ent| {
-                    ent.metadata().map_err(Error::IOError).and_then(|metadata| {
-                        let last_modified = metadata
-                            .modified()
-                            .ok()
-                            .and_then(|modified| {
-                                modified.duration_since(SystemTime::UNIX_EPOCH).ok()
-                            })
-                            .and_then(|modified| modified.as_millis().try_into().ok())
-                            .unwrap_or(0);
-
-                        Url::from_file_path(ent.path())
-                            .map(|location| FileMeta {
-                                location,
-                                last_modified,
-                                size: metadata.len() as usize,
-                            })
-                            .map_err(|_| Error::Generic(format!("Invalid path: {:?}", ent.path())))
-                    })
-                });
+                .map(TryFrom::try_from);
             Ok(Box::new(it))
         } else {
             Err(Error::generic("Can only read local filesystem"))

--- a/kernel/src/engine/sync/fs_client.rs
+++ b/kernel/src/engine/sync/fs_client.rs
@@ -99,7 +99,7 @@ mod tests {
 
         let begin_time = SystemTime::now().duration_since(UNIX_EPOCH)?;
         // The [`FileMeta`]s must be greater than 1 minute ago
-        let allowed_time = begin_time - Duration::from_secs(60);
+        let allowed_begin_time = begin_time - Duration::from_secs(60);
 
         let path = tmp_dir.path().join(get_json_filename(1));
         let mut f = File::create(path)?;
@@ -108,10 +108,17 @@ mod tests {
 
         let url_path = tmp_dir.path().join(get_json_filename(1));
         let url = Url::from_file_path(url_path).unwrap();
-        let list: Vec<_> = client.list_from(&url)?.try_collect()?;
-        for meta in list.iter() {
+        let files: Vec<_> = client.list_from(&url)?.try_collect()?;
+
+        let end_time = SystemTime::now().duration_since(UNIX_EPOCH)?;
+        // The [`FileMeta`]s must be less than one minute in the future
+        let allowed_end_time = end_time + Duration::from_secs(60);
+
+        assert!(!files.is_empty());
+        for meta in files.iter() {
             let meta_time = Duration::from_millis(meta.last_modified.try_into()?);
-            assert!(allowed_time < meta_time,);
+            assert!(allowed_begin_time < meta_time);
+            assert!(meta_time < allowed_end_time);
         }
         Ok(())
     }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -59,7 +59,9 @@
 )]
 
 use std::any::Any;
+use std::fs::DirEntry;
 use std::sync::Arc;
+use std::time::SystemTime;
 use std::{cmp::Ordering, ops::Range};
 
 use bytes::Bytes;
@@ -139,6 +141,31 @@ impl Ord for FileMeta {
 impl PartialOrd for FileMeta {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+impl TryFrom<DirEntry> for FileMeta {
+    type Error = Error;
+
+    fn try_from(ent: DirEntry) -> DeltaResult<FileMeta> {
+        let metadata = ent.metadata()?;
+        let last_modified = metadata
+            .modified()?
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map_err(|_| Error::generic("Failed to convert file timestamp to milliseconds"))?;
+        let location = Url::from_file_path(ent.path())
+            .map_err(|_| Error::generic(format!("Invalid path: {:?}", ent.path())))?;
+        let last_modified = last_modified.as_millis().try_into().map_err(|_| {
+            Error::generic(format!(
+                "Failed to convert file modification time {:?} into i64",
+                last_modified.as_millis()
+            ))
+        })?;
+        Ok(FileMeta {
+            location,
+            last_modified,
+            size: metadata.len() as usize,
+        })
     }
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR fixes the `list_from` method used by both the `DefaultEngine` and the `SyncEngine` to return the correct `FileMeta` struct. Previously, both the engines would return the timestamp in number of seconds from Unix Epoch. However, `FileMeta` specifies that we should expect the modification time to be in milliseconds since Unix Epoch:
```
pub struct FileMeta {
    /// The fully qualified path to the object
    pub location: Url,
    /// The last modified time as milliseconds since unix epoch
    pub last_modified: i64,
    /// The size in bytes of the object
    pub size: usize,
}
```
### This PR affects the following public APIs
This changes the behaviour of the following:
- `SyncFilesystemClient::list_from`
- `ObjectStoreFileSystemClient::list_from`
- any transitive users of these methods


## How was this change tested?
I compare the `FileMeta` returned by each of the engines to expected `FileMeta` within 10 seconds of creation time.