### PR TITLE
fix: handle unrecognized file types in Delta log

### DIFF
--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -290,8 +290,8 @@ fn list_log_files(
     Ok(fs_client
         .list_from(&start_from)?
         .map(|meta| meta.map(|m| ParsedLogPath::try_from(m).ok().and_then(identity)))
-        // TODO this filters out .crc files etc which start with "." - how do we want to use these kind of files?
         .filter_map_ok(identity)
+        .filter(|path_res| path_res.as_ref().map_or(true, |path| path.is_commit() || path.is_checkpoint()))
         .take_while(move |path_res| match path_res {
             Ok(path) => !end_version.is_some_and(|end_version| end_version < path.version),
             Err(_) => true,

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -289,7 +289,7 @@ fn list_log_files(
 
     Ok(fs_client
         .list_from(&start_from)?
-        .map(|meta| ParsedLogPath::try_from(meta?))
+        .map(|meta| meta.map(|m| ParsedLogPath::try_from(m).ok().and_then(identity)))
         // TODO this filters out .crc files etc which start with "." - how do we want to use these kind of files?
         .filter_map_ok(identity)
         .take_while(move |path_res| match path_res {

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -291,7 +291,11 @@ fn list_log_files(
         .list_from(&start_from)?
         .map(|meta| meta.map(|m| ParsedLogPath::try_from(m).ok().and_then(identity)))
         .filter_map_ok(identity)
-        .filter(|path_res| path_res.as_ref().map_or(true, |path| path.is_commit() || path.is_checkpoint()))
+        .filter(|path_res| {
+            path_res
+                .as_ref()
+                .map_or(true, |path| path.is_commit() || path.is_checkpoint())
+        })
         .take_while(move |path_res| match path_res {
             Ok(path) => !end_version.is_some_and(|end_version| end_version < path.version),
             Err(_) => true,

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -521,7 +521,9 @@ fn test_list_files_with_unusual_patterns() {
         // bogus part numbering
         Path::from("_delta_log/00000000000000000000.checkpoint.0000000010.0000000000.parquet"),
         // v2 checkpoint
-        Path::from("_delta_log/00000000000000000010.checkpoint.80a083e8-7026-4e79-81be-64bd76c43a11.json"),
+        Path::from(
+            "_delta_log/00000000000000000010.checkpoint.80a083e8-7026-4e79-81be-64bd76c43a11.json",
+        ),
         // compacted log file
         Path::from("_delta_log/00000000000000000004.00000000000000000006.compacted.json"),
         // CRC file
@@ -539,16 +541,13 @@ fn test_list_files_with_unusual_patterns() {
     // Collect the results and verify
     let paths: Vec<_> = result.unwrap().collect::<Result<Vec<_>, _>>().unwrap();
 
-    // We should find at least the valid commit file
-    assert!(!paths.is_empty(), "Should find at least one valid file");
+    // We should find exactly one file (the valid commit)
+    assert_eq!(paths.len(), 1, "Should find exactly one valid file");
 
     // Verify that the valid commit file is included
     let has_valid_commit = paths.iter().any(|p| p.version == 2 && p.is_commit());
     assert!(has_valid_commit, "Should find the valid commit file");
 
-    // Verify that none of the paths resulted in errors
-    // The invalid patterns should have been filtered out by ParsedLogPath::try_from
-    for path in paths {
-        assert!(!path.is_unknown(), "Found unexpected unknown file type");
-    }
+    // All other files should have been filtered out by ParsedLogPath::try_from
+    // and the filter_map_ok(identity) call
 }

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -511,3 +511,44 @@ fn table_changes_fails_with_larger_start_version_than_end() {
     let log_segment_res = LogSegment::for_table_changes(client.as_ref(), log_root, 1, Some(0));
     assert!(log_segment_res.is_err());
 }
+
+#[test]
+fn test_list_files_with_unusual_patterns() {
+    // Create paths for all the unusual patterns
+    let paths = vec![
+        // hex instead of decimal
+        Path::from("_delta_log/00000000deadbeef.commit.json"),
+        // bogus part numbering
+        Path::from("_delta_log/00000000000000000000.checkpoint.0000000010.0000000000.parquet"),
+        // v2 checkpoint
+        Path::from("_delta_log/00000000000000000010.checkpoint.80a083e8-7026-4e79-81be-64bd76c43a11.json"),
+        // compacted log file
+        Path::from("_delta_log/00000000000000000004.00000000000000000006.compacted.json"),
+        // CRC file
+        Path::from("_delta_log/00000000000000000001.crc"),
+        // Valid commit file for comparison
+        Path::from("_delta_log/00000000000000000002.json"),
+    ];
+
+    let (client, log_root) = build_log_with_paths_and_checkpoint(&paths, None);
+
+    // Test that list_log_files doesn't fail
+    let result = super::list_log_files(&*client, &log_root, None, None);
+    assert!(result.is_ok(), "list_log_files should not fail");
+
+    // Collect the results and verify
+    let paths: Vec<_> = result.unwrap().collect::<Result<Vec<_>, _>>().unwrap();
+
+    // We should find at least the valid commit file
+    assert!(!paths.is_empty(), "Should find at least one valid file");
+
+    // Verify that the valid commit file is included
+    let has_valid_commit = paths.iter().any(|p| p.version == 2 && p.is_commit());
+    assert!(has_valid_commit, "Should find the valid commit file");
+
+    // Verify that none of the paths resulted in errors
+    // The invalid patterns should have been filtered out by ParsedLogPath::try_from
+    for path in paths {
+        assert!(!path.is_unknown(), "Found unexpected unknown file type");
+    }
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR fixes #496 . 

Specifically, we made the following changes:

Modified list_log_files to properly handle unrecognized file types in the Delta log by filtering out unknown patterns while preserving valid commit and checkpoint files. This aligns with the Delta specification requirement to ignore unknown file types.

Changes:

Added explicit filtering for commit and checkpoint files
Improved error handling to silently skip unrecognized patterns
Added comprehensive tests for unusual file patterns including:
Hex-based commit files
Bogus checkpoint numbering
V2 checkpoints
Compacted log files
CRC files

## How was this change tested?
Ran `cargo test --all-features --all-targets -- --skip read_table_version_hdfs`. 

I had some issues getting `read_table_version_hdfs` to work due to a Java dependency and noticed there are a few places where we skipped it. It also seemed unrelated to this change.

## Additional Context
This PR was entirely written by [Devin](https://devin.ai/) with a little bit of review from me. Happy to address any feedback and get this over the finish line.

Original Run: https://preview.devin.ai/sessions/032b39d6100a4277a7441f0a1eed085c

