### PR TITLE
Add `TableChangesScan::schema` method to get logical schema

### DIFF
--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -213,7 +213,7 @@ impl TableChangesScan {
         }
     }
 
-    /// Get a shared reference to the [`Schema`] of the scan.
+    /// Get a shared reference to the [`Schema`] of the table changes scan.
     ///
     /// [`Schema`]: crate::schema::Schema
     pub fn schema(&self) -> &SchemaRef {

--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -221,7 +221,7 @@ impl TableChangesScan {
     }
 
     /// Get the predicate [`ExpressionRef`] of the scan.
-    pub fn physical_predicate(&self) -> Option<ExpressionRef> {
+    fn physical_predicate(&self) -> Option<ExpressionRef> {
         if let PhysicalPredicate::Some(ref predicate, _) = self.physical_predicate {
             Some(predicate.clone())
         } else {

--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -220,7 +220,7 @@ impl TableChangesScan {
         &self.logical_schema
     }
 
-    /// Get the predicate [`Expression`] of the scan.
+    /// Get the predicate [`ExpressionRef`] of the scan.
     pub fn physical_predicate(&self) -> Option<ExpressionRef> {
         if let PhysicalPredicate::Some(ref predicate, _) = self.physical_predicate {
             Some(predicate.clone())

--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -213,8 +213,15 @@ impl TableChangesScan {
         }
     }
 
+    /// Get a shared reference to the [`Schema`] of the scan.
+    ///
+    /// [`Schema`]: crate::schema::Schema
+    pub fn schema(&self) -> &SchemaRef {
+        &self.logical_schema
+    }
+
     /// Get the predicate [`Expression`] of the scan.
-    fn physical_predicate(&self) -> Option<ExpressionRef> {
+    pub fn physical_predicate(&self) -> Option<ExpressionRef> {
         if let PhysicalPredicate::Some(ref predicate, _) = self.physical_predicate {
             Some(predicate.clone())
         } else {


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR adds a pub method to fetch the logical schema of a `TableChangesScan`


## How was this change tested?
Everything compiles.