### PR TITLE
[chore] add CI step to build kernel with no-default-features

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: build docs
         run: cargo doc
-  build_and_clippy:
+  build:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: build docs
         run: cargo doc
-  build:
+  build_and_clippy:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -101,6 +101,8 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v2
+      - name: check kernel builds with no-default-features
+        run: cargo build -p delta_kernel --no-default-features
       - name: build and lint with clippy
         run: cargo clippy --benches --tests --all-features -- -D warnings
       - name: lint without default features


### PR DESCRIPTION
title. Introducing since this would have caught the 0.6.0 release blocker. (`engine` code used in `parquet_stats_skipping` module)