### PR TITLE
Fix msrv check by pinning `home` dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
           cargo install cargo-msrv --locked
       - name: verify-msrv
         run: |
-          cargo msrv --path kernel/ verify --all-features
+          cargo msrv --log-level trace --path kernel/ verify --all-features
           cargo msrv --path derive-macros/ verify --all-features
           cargo msrv --path ffi/ verify --all-features
           cargo msrv --path ffi-proc-macros/ verify --all-features

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,10 +34,10 @@ jobs:
       - name: Install cargo-msrv
         shell: bash
         run: |
-          cargo install cargo-msrv --locked --force
+          cargo install cargo-msrv --locked
       - name: verify-msrv
         run: |
-          cargo msrv --log-level trace --path kernel/ verify --all-features
+          cargo msrv --log-target stdout --log-level trace --path kernel/ verify --all-features
           cargo msrv --path derive-macros/ verify --all-features
           cargo msrv --path ffi/ verify --all-features
           cargo msrv --path ffi-proc-macros/ verify --all-features

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install cargo-msrv
         shell: bash
         run: |
-          cargo install cargo-msrv --locked
+          cargo install cargo-msrv --locked --force
       - name: verify-msrv
         run: |
           cargo msrv --log-level trace --path kernel/ verify --all-features

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
           cargo install cargo-msrv --locked
       - name: verify-msrv
         run: |
-          cargo msrv --log-target stdout --log-level trace --path kernel/ verify --all-features
+          cargo msrv --path kernel/ verify --all-features
           cargo msrv --path derive-macros/ verify --all-features
           cargo msrv --path ffi/ verify --all-features
           cargo msrv --path ffi-proc-macros/ verify --all-features

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -112,6 +112,9 @@ integration-test = [
   "walkdir",
 ]
 
+[dependencies.home]
+version = "=0.5.9"
+
 [build-dependencies]
 rustc_version = "0.4.1"
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-incubator/delta-kernel-rs/blob/main/CONTRIBUTING.md
  2. Run `cargo t --all-features --all-targets` to get started testing, and run `cargo fmt`.
  3. Ensure you have added or run the appropriate tests for your PR.
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

## What changes are proposed in this pull request?
<!--
Please clarify what changes you are proposing and why the changes are needed.
The purpose of this section is to outline the changes, why they are needed, and how this PR fixes the issue.
If the reason for the change is already explained clearly in an issue, then it does not need to be restated here.
  1. If you propose a new API or feature, clarify the use case for a new API or feature.
  2. If you fix a bug, you can clarify why it is a bug.
-->

`hdfs-native` depends on `which` which depends on `home`. `home` recently updated and bumped their msrv to 1.81. This pins us to the previous version.

<!--
Uncomment this section if there are any changes affecting public APIs:
### This PR affects the following public APIs

If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.

Note that _new_ public APIs are not considered breaking.
-->


## How was this change tested?
<!--
Please make sure to add test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested, ideally via a reproducible test documented in the PR description.
-->

Check that the msrv test now passes