### PR TITLE
[wip] feat: add `materialize_scan_results` arrow utility

### DIFF
--- a/acceptance/src/data.rs
+++ b/acceptance/src/data.rs
@@ -116,6 +116,7 @@ pub async fn assert_scan_data(engine: Arc<dyn Engine>, test_case: &TestCaseInfo)
     let snapshot = table.snapshot(engine.as_ref(), None)?;
     let scan = snapshot.into_scan_builder().build()?;
     let mut schema = None;
+    // TODO replace with new util
     let batches: Vec<RecordBatch> = scan
         .execute(engine)?
         .map(|scan_result| -> DeltaResult<_> {

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -56,6 +56,8 @@ parquet = { workspace = true, optional = true }
 # Used for fetching direct urls (like pre-signed urls)
 reqwest = { version = "0.12.7", optional = true }
 strum = { version = "0.26", features = ["derive"] }
+# used in arrow-compute feature for record batch filtering utility
+arrow = { workspace = true, optional = true }
 
 
 # optionally used with default engine (though not required)
@@ -66,6 +68,7 @@ hdfs-native = { workspace = true, optional = true }
 walkdir = { workspace = true, optional = true }
 
 [features]
+arrow-compute = ["arrow", "arrow-conversion"]
 arrow-conversion = ["arrow-schema"]
 arrow-expression = ["arrow-arith", "arrow-array", "arrow-buffer", "arrow-ord", "arrow-schema"]
 cloud = [

--- a/kernel/examples/read-table-multi-threaded/src/main.rs
+++ b/kernel/examples/read-table-multi-threaded/src/main.rs
@@ -290,6 +290,7 @@ fn do_work(
             .read_parquet_files(&[meta], physical_schema.clone(), None)
             .unwrap();
 
+        // replace with materialize_scan_results?
         for read_result in read_results {
             let read_result = read_result.unwrap();
             let len = read_result.len();

--- a/kernel/examples/read-table-single-threaded/src/main.rs
+++ b/kernel/examples/read-table-single-threaded/src/main.rs
@@ -2,10 +2,9 @@ use std::collections::HashMap;
 use std::process::ExitCode;
 use std::sync::Arc;
 
-use arrow::compute::filter_record_batch;
 use arrow::record_batch::RecordBatch;
 use arrow::util::pretty::print_batches;
-use delta_kernel::engine::arrow_data::ArrowEngineData;
+use delta_kernel::engine::arrow_compute::materialize_scan_results;
 use delta_kernel::engine::default::executor::tokio::TokioBackgroundExecutor;
 use delta_kernel::engine::default::DefaultEngine;
 use delta_kernel::engine::sync::SyncEngine;
@@ -119,24 +118,8 @@ fn try_main() -> DeltaResult<()> {
         .with_schema_opt(read_schema_opt)
         .build()?;
 
-    let batches: Vec<RecordBatch> = scan
-        .execute(engine)?
-        .map(|scan_result| -> DeltaResult<_> {
-            let scan_result = scan_result?;
-            let mask = scan_result.full_mask();
-            let data = scan_result.raw_data?;
-            let record_batch: RecordBatch = data
-                .into_any()
-                .downcast::<ArrowEngineData>()
-                .map_err(|_| delta_kernel::Error::EngineDataType("ArrowEngineData".to_string()))?
-                .into();
-            if let Some(mask) = mask {
-                Ok(filter_record_batch(&record_batch, &mask.into())?)
-            } else {
-                Ok(record_batch)
-            }
-        })
-        .try_collect()?;
+    let batches: Vec<RecordBatch> =
+        materialize_scan_results(scan.execute(engine)?).try_collect()?;
     print_batches(&batches)?;
     Ok(())
 }

--- a/kernel/src/engine/arrow_compute.rs
+++ b/kernel/src/engine/arrow_compute.rs
@@ -1,0 +1,28 @@
+use crate::engine::arrow_data::ArrowEngineData;
+use crate::error::DeltaResult;
+use crate::scan::ScanResult;
+
+use arrow::compute::filter_record_batch;
+use arrow_array::RecordBatch;
+
+/// Utility function that transforms an iterator of `ScanResult`s into an iterator of
+/// `RecordBatch`s containing the actual scan data by applying the scan result's mask to the data.
+///
+/// It uses arrow-compute's `filter_record_batch` function to apply the mask to the data.
+pub fn materialize_scan_results(
+    scan_results: impl Iterator<Item = DeltaResult<ScanResult>>,
+) -> impl Iterator<Item = DeltaResult<RecordBatch>> {
+    scan_results.map(|res| {
+        let scan_res = res.and_then(|res| Ok((res.full_mask(), res.raw_data?)));
+        let (mask, data) = scan_res?;
+        let record_batch: RecordBatch = data
+            .into_any()
+            .downcast::<ArrowEngineData>()
+            .map_err(|_| crate::Error::EngineDataType("ArrowEngineData".to_string()))?
+            .into();
+        Ok(match mask {
+            Some(mask) => filter_record_batch(&record_batch, &mask.into())?,
+            None => record_batch,
+        })
+    })
+}

--- a/kernel/src/engine/mod.rs
+++ b/kernel/src/engine/mod.rs
@@ -33,3 +33,6 @@ declare_modules!(
     (pub(crate), arrow_utils),
     (pub(crate), ensure_data_types)
 );
+
+#[cfg(feature = "arrow-compute")]
+pub mod arrow_compute;

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -394,6 +394,7 @@ fn read_with_scan_data(
             )
             .unwrap();
 
+        // TODO(zach): use materialize_scan_results?
         for read_result in read_results {
             let read_result = read_result.unwrap();
             let len = read_result.len();


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-incubator/delta-kernel-rs/blob/main/CONTRIBUTING.md
  2. Run `cargo t --all-features --all-targets` to get started testing, and run `cargo fmt`.
  3. Ensure you have added or run the appropriate tests for your PR.
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

## What changes are proposed in this pull request?
<!--
Please clarify what changes you are proposing and why the changes are needed.
The purpose of this section is to outline the changes, why they are needed, and how this PR fixes the issue.
If the reason for the change is already explained clearly in an issue, then it does not need to be restated here.
  1. If you propose a new API or feature, clarify the use case for a new API or feature.
  2. If you fix a bug, you can clarify why it is a bug.
-->

<!--
Uncomment this section if there are any changes affecting public APIs:
### This PR affects the following public APIs

If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.

Note that _new_ public APIs are not considered breaking.
-->

1. new feature flag `arrow-compute` that pulls in arrow (for arrow-compute) TODO rename?
2. new utility function in a new module to transform an iterator of `ScanResult`s into an iterator of `RecordBatch`s by using arrow-compute's `filter_record_batch`
3. updates to places this can be used


## How was this change tested?
<!--
Please make sure to add test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested, ideally via a reproducible test documented in the PR description.
-->
existing

resolves #592 