### PR TITLE
partition skipping filter

### DIFF
--- a/kernel/src/predicates/mod.rs
+++ b/kernel/src/predicates/mod.rs
@@ -534,8 +534,6 @@ impl ResolveColumnAsScalar for EmptyColumnResolver {
     }
 }
 
-// In testing, it is convenient to just build a hashmap of scalar values.
-#[cfg(test)]
 impl ResolveColumnAsScalar for std::collections::HashMap<ColumnName, Scalar> {
     fn resolve_column(&self, col: &ColumnName) -> Option<Scalar> {
         self.get(col).cloned()

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -424,6 +424,7 @@ mod tests {
             logical_schema,
             None,
             None,
+            &[]
         );
         for res in iter {
             let (_batch, _sel, transforms) = res.unwrap();
@@ -447,6 +448,7 @@ mod tests {
             schema,
             static_transform,
             None,
+            &[]
         );
 
         fn validate_transform(transform: Option<&ExpressionRef>, expected_date_offset: i32) {

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -284,7 +284,9 @@ impl LogReplayScanner {
             None => vec![true; actions.len()],
         };
         if data_selection_vector.len() != actions.len() {
-            return Err(crate::Error::internal_error("Data skipping filter returned incorrect number of rows"))
+            return Err(crate::Error::internal_error(
+                "Data skipping filter returned incorrect number of rows",
+            ));
         }
 
         let partition_selection_vector = match &self.partition_filter {
@@ -292,7 +294,9 @@ impl LogReplayScanner {
             None => vec![true; actions.len()],
         };
         if partition_selection_vector.len() != actions.len() {
-            return Err(crate::Error::internal_error("Partition skipping filter returned incorrect number of rows"))
+            return Err(crate::Error::internal_error(
+                "Partition skipping filter returned incorrect number of rows",
+            ));
         }
 
         let selection_vector = data_selection_vector

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -258,13 +258,10 @@ impl LogReplayScanner {
         physical_predicate: Option<(ExpressionRef, SchemaRef)>,
         partition_columns: &[String],
     ) -> Self {
-        let partition_predicate = physical_predicate
-            .as_ref()
-            .filter(|_| !partition_columns.is_empty());
         Self {
             partition_filter: PartitionSkippingFilter::new(
                 engine,
-                partition_predicate.cloned(),
+                physical_predicate.clone(),
                 partition_columns,
             ),
             data_filter: DataSkippingFilter::new(engine, physical_predicate),

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -277,7 +277,7 @@ impl LogReplayScanner {
         };
         assert_eq!(data_selection_vector.len(), actions.len());
 
-        let partition_selection_vector = match &mut self.partition_filter {
+        let partition_selection_vector = match &self.partition_filter {
             Some(filter) => filter.apply(actions)?,
             None => vec![true; actions.len()],
         };

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -6,8 +6,8 @@ use itertools::Itertools;
 use tracing::debug;
 
 use super::data_skipping::DataSkippingFilter;
-use super::{ScanData, Transform};
 use super::partition_skipping::PartitionSkippingFilter;
+use super::{ScanData, Transform};
 use crate::actions::get_log_add_schema;
 use crate::engine_data::{GetData, RowVisitor, TypedGetData as _};
 use crate::expressions::{column_expr, column_name, ColumnName, Expression, ExpressionRef};
@@ -424,7 +424,7 @@ mod tests {
             logical_schema,
             None,
             None,
-            &[]
+            &[],
         );
         for res in iter {
             let (_batch, _sel, transforms) = res.unwrap();
@@ -448,7 +448,7 @@ mod tests {
             schema,
             static_transform,
             None,
-            &[]
+            &[],
         );
 
         fn validate_transform(transform: Option<&ExpressionRef>, expected_date_offset: i32) {

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -283,13 +283,17 @@ impl LogReplayScanner {
             Some(filter) => filter.apply(actions)?,
             None => vec![true; actions.len()],
         };
-        assert_eq!(data_selection_vector.len(), actions.len());
+        if data_selection_vector.len() != actions.len() {
+            return Err(crate::Error::internal_error("Data skipping filter returned incorrect number of rows"))
+        }
 
         let partition_selection_vector = match &self.partition_filter {
             Some(filter) => filter.apply(actions)?,
             None => vec![true; actions.len()],
         };
-        assert_eq!(partition_selection_vector.len(), actions.len());
+        if partition_selection_vector.len() != actions.len() {
+            return Err(crate::Error::internal_error("Partition skipping filter returned incorrect number of rows"))
+        }
 
         let selection_vector = data_selection_vector
             .iter()

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -259,7 +259,9 @@ impl LogReplayScanner {
         partition_columns: &[String],
     ) -> Self {
         let partition_filter = match partition_columns.is_empty() {
-            false => PartitionSkippingFilter::new(engine, physical_predicate.clone(), partition_columns),
+            false => {
+                PartitionSkippingFilter::new(engine, physical_predicate.clone(), partition_columns)
+            }
             true => None,
         };
         Self {

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -258,14 +258,15 @@ impl LogReplayScanner {
         physical_predicate: Option<(ExpressionRef, SchemaRef)>,
         partition_columns: &[String],
     ) -> Self {
-        let partition_filter = match partition_columns.is_empty() {
-            false => {
-                PartitionSkippingFilter::new(engine, physical_predicate.clone(), partition_columns)
-            }
-            true => None,
-        };
+        let partition_predicate = physical_predicate
+            .as_ref()
+            .filter(|_| !partition_columns.is_empty());
         Self {
-            partition_filter,
+            partition_filter: PartitionSkippingFilter::new(
+                engine,
+                partition_predicate.cloned(),
+                partition_columns,
+            ),
             data_filter: DataSkippingFilter::new(engine, physical_predicate),
             seen: Default::default(),
         }

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -256,11 +256,11 @@ impl LogReplayScanner {
     fn new(
         engine: &dyn Engine,
         physical_predicate: Option<(ExpressionRef, SchemaRef)>,
-        have_partition_cols: bool,
+        partition_columns: &[String],
     ) -> Self {
-        let partition_filter = match have_partition_cols {
-            true => PartitionSkippingFilter::new(engine, physical_predicate.clone()),
-            false => None,
+        let partition_filter = match partition_columns.is_empty() {
+            false => PartitionSkippingFilter::new(engine, physical_predicate.clone(), partition_columns),
+            true => None,
         };
         Self {
             partition_filter,
@@ -324,9 +324,9 @@ pub(crate) fn scan_action_iter(
     logical_schema: SchemaRef,
     transform: Option<Arc<Transform>>,
     physical_predicate: Option<(ExpressionRef, SchemaRef)>,
-    have_partition_cols: bool,
+    partition_columns: &[String],
 ) -> impl Iterator<Item = DeltaResult<ScanData>> {
-    let mut log_scanner = LogReplayScanner::new(engine, physical_predicate, have_partition_cols);
+    let mut log_scanner = LogReplayScanner::new(engine, physical_predicate, partition_columns);
     let add_transform = engine.get_expression_handler().get_evaluator(
         get_log_add_schema().clone(),
         get_add_transform_expr(),

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -409,7 +409,7 @@ impl Scan {
             self.logical_schema.clone(),
             static_transform,
             physical_predicate,
-            self.have_partition_cols,
+            &self.snapshot.metadata().partition_columns,
         );
         Ok(Some(it).into_iter().flatten())
     }
@@ -815,7 +815,7 @@ pub(crate) mod test_utils {
             logical_schema,
             transform,
             None,
-            false,
+            &[],
         );
         let mut batch_count = 0;
         for res in iter {

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -28,6 +28,7 @@ use self::state::GlobalScanState;
 
 pub(crate) mod data_skipping;
 pub mod log_replay;
+pub(crate) mod partition_skipping;
 pub mod state;
 
 /// Builder to scan a snapshot of a table.

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -409,6 +409,7 @@ impl Scan {
             self.logical_schema.clone(),
             static_transform,
             physical_predicate,
+            self.have_partition_cols,
         );
         Ok(Some(it).into_iter().flatten())
     }
@@ -814,6 +815,7 @@ pub(crate) mod test_utils {
             logical_schema,
             transform,
             None,
+            false,
         );
         let mut batch_count = 0;
         for res in iter {

--- a/kernel/src/scan/partition_skipping.rs
+++ b/kernel/src/scan/partition_skipping.rs
@@ -32,7 +32,6 @@ impl PartitionSkippingFilter {
 
         let (predicate, schema) = physical_predicate?;
         debug!("Creating a partition skipping filter for {:#?}", predicate);
-        println!("reference schema\n{:#?}", schema);
 
         let partitions_map_type = MapType::new(DataType::STRING, DataType::STRING, true);
 

--- a/kernel/src/scan/partition_skipping.rs
+++ b/kernel/src/scan/partition_skipping.rs
@@ -42,9 +42,7 @@ impl PartitionSkippingFilter {
             .filter(|f| partition_columns.contains(f.name()))
             .cloned()
             .peekable();
-        if partition_fields.peek().is_none() {
-            return None
-        }
+        partition_fields.peek()?;
         let schema = Arc::new(StructType::new(partition_fields));
 
         let partitions_map_type = MapType::new(DataType::STRING, DataType::STRING, true);

--- a/kernel/src/scan/partition_skipping.rs
+++ b/kernel/src/scan/partition_skipping.rs
@@ -46,7 +46,7 @@ impl PartitionSkippingFilter {
         })
     }
 
-    pub(crate) fn apply(&mut self, actions: &dyn EngineData) -> DeltaResult<Vec<bool>> {
+    pub(crate) fn apply(&self, actions: &dyn EngineData) -> DeltaResult<Vec<bool>> {
         let partitions = self.evaluator.evaluate(actions)?;
         assert_eq!(partitions.len(), actions.len());
 

--- a/kernel/src/scan/partition_skipping.rs
+++ b/kernel/src/scan/partition_skipping.rs
@@ -5,7 +5,6 @@ use std::{
 
 use tracing::debug;
 
-use crate::{expressions::column_expr, schema::StructType};
 use crate::schema::column_name;
 use crate::{
     engine_data::GetData,
@@ -15,6 +14,7 @@ use crate::{
     schema::{ColumnName, DataType, MapType, SchemaRef},
     DeltaResult, Engine, EngineData, Expression, ExpressionEvaluator, ExpressionRef, RowVisitor,
 };
+use crate::{expressions::column_expr, schema::StructType};
 
 pub(crate) struct PartitionSkippingFilter {
     evaluator: Arc<dyn ExpressionEvaluator>,
@@ -37,7 +37,10 @@ impl PartitionSkippingFilter {
         // Limit the schema passed to the row visitor of only the fields that are included
         // in the predicate and are also partition columns. The data skipping columns will
         // be handled elsewhere.
-        let partition_fields = schema.fields().filter(|f| partition_columns.contains(f.name())).cloned();
+        let partition_fields = schema
+            .fields()
+            .filter(|f| partition_columns.contains(f.name()))
+            .cloned();
         let schema = Arc::new(StructType::new(partition_fields));
 
         let partitions_map_type = MapType::new(DataType::STRING, DataType::STRING, true);

--- a/kernel/src/scan/partition_skipping.rs
+++ b/kernel/src/scan/partition_skipping.rs
@@ -99,12 +99,11 @@ impl RowVisitor for PartitionVisitor {
                 let resolver = partition_values
                     .iter()
                     .map(|(k, v)| {
-                        let data_type = self.schema.field(k).map(|f| f.data_type());
+                        let data_type = self.schema.field(k).map(|f| f.data_type()).ok_or(crate::Error::missing_column(k))?;
 
-                        let Some(DataType::Primitive(primitive_type)) = data_type else {
-                            return Err(crate::Error::Generic(
-                                "partition filtering only supported for primitive types"
-                                    .to_string(),
+                        let DataType::Primitive(primitive_type) = data_type else {
+                            return Err(crate::Error::unsupported(
+                                format!("Partition filtering only supported for primitive types. Found type: {}", data_type)
                             ));
                         };
 

--- a/kernel/src/scan/partition_skipping.rs
+++ b/kernel/src/scan/partition_skipping.rs
@@ -37,10 +37,14 @@ impl PartitionSkippingFilter {
         // Limit the schema passed to the row visitor of only the fields that are included
         // in the predicate and are also partition columns. The data skipping columns will
         // be handled elsewhere.
-        let partition_fields = schema
+        let mut partition_fields = schema
             .fields()
             .filter(|f| partition_columns.contains(f.name()))
-            .cloned();
+            .cloned()
+            .peekable();
+        if partition_fields.peek().is_none() {
+            return None
+        }
         let schema = Arc::new(StructType::new(partition_fields));
 
         let partitions_map_type = MapType::new(DataType::STRING, DataType::STRING, true);

--- a/kernel/src/scan/partition_skipping.rs
+++ b/kernel/src/scan/partition_skipping.rs
@@ -131,3 +131,85 @@ impl RowVisitor for PartitionVisitor {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use arrow_array::{RecordBatch, StringArray};
+    use arrow_schema::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema};
+    use std::sync::Arc;
+
+    use crate::engine::{arrow_data::ArrowEngineData, sync::SyncEngine};
+    use crate::expressions::UnaryOperator;
+    use crate::scan::get_log_schema;
+    use crate::schema::{DataType, Schema, StructField};
+    use crate::DeltaResult;
+    use crate::{DeltaResult, Engine, EngineData, Expression};
+
+    use super::PartitionSkippingFilter;
+
+    // TODO(nick): Merge all copies of this into one "test utils" thing
+    fn string_array_to_engine_data(string_array: StringArray) -> Box<dyn EngineData> {
+        let string_field = Arc::new(ArrowField::new("a", ArrowDataType::Utf8, true));
+        let schema = Arc::new(ArrowSchema::new(vec![string_field]));
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(string_array)])
+            .expect("Can't convert to record batch");
+        Box::new(ArrowEngineData::new(batch))
+    }
+
+    #[test]
+    fn test_partition_skipping() -> DeltaResult<()> {
+        let engine = SyncEngine::new();
+        let json_handler = engine.get_json_handler();
+        let json_strings: StringArray = vec![
+            // All these values should be filtered due to c1 value
+            r#"{"add":{"path":"c1=4/c2=c/part-00003-f525f459-34f9-46f5-82d6-d42121d883fd.c000.snappy.parquet","partitionValues":{"c1":"1","c2":""},"size":452,"modificationTime":1670892998135,"dataChange":true,"stats":"{\"numRecords\":1,\"minValues\":{\"c3\":5},\"maxValues\":{\"c3\":5},\"nullCount\":{\"c3\":0}}"}}"#,
+            r#"{"add":{"path":"c1=4/c2=c/part-00003-f525f459-34f9-46f5-82d6-d42121d883fd.c000.snappy.parquet","partitionValues":{"c1":"2","c2":null},"size":452,"modificationTime":1670892998135,"dataChange":true,"stats":"{\"numRecords\":1,\"minValues\":{\"c3\":5},\"maxValues\":{\"c3\":5},\"nullCount\":{\"c3\":0}}"}}"#,
+            r#"{"add":{"path":"c1=4/c2=c/part-00003-f525f459-34f9-46f5-82d6-d42121d883fd.c000.snappy.parquet","partitionValues":{"c1":"3","c2":"a"},"size":452,"modificationTime":1670892998135,"dataChange":true,"stats":"{\"numRecords\":1,\"minValues\":{\"c3\":5},\"maxValues\":{\"c3\":5},\"nullCount\":{\"c3\":0}}"}}"#,
+
+            // Test both null and "" produce valid nulls
+            r#"{"add":{"path":"c1=4/c2=c/part-00003-f525f459-34f9-46f5-82d6-d42121d883fd.c000.snappy.parquet","partitionValues":{"c1":"4","c2":""},"size":452,"modificationTime":1670892998135,"dataChange":true,"stats":"{\"numRecords\":1,\"minValues\":{\"c3\":5},\"maxValues\":{\"c3\":5},\"nullCount\":{\"c3\":0}}"}}"#,
+            r#"{"add":{"path":"c1=5/c2=b/part-00007-4e73fa3b-2c88-424a-8051-f8b54328ffdb.c000.snappy.parquet","partitionValues":{"c1":"5","c2":null},"size":452,"modificationTime":1670892998136,"dataChange":true,"stats":"{\"numRecords\":1,\"minValues\":{\"c3\":6},\"maxValues\":{\"c3\":6},\"nullCount\":{\"c3\":0}}"}}"#,
+            r#"{"add":{"path":"c1=6/c2=a/part-00011-10619b10-b691-4fd0-acc4-2a9608499d7c.c000.snappy.parquet","partitionValues":{"c1":"6","c2":"b"},"size":452,"modificationTime":1670892998137,"dataChange":true,"stats":"{\"numRecords\":1,\"minValues\":{\"c3\":4},\"maxValues\":{\"c3\":4},\"nullCount\":{\"c3\":0}}"}}"#,
+
+            // Gracefully handle missing partition values as null
+            r#"{"add":{"path":"c1=4/c2=c/part-00003-f525f459-34f9-46f5-82d6-d42121d883fd.c000.snappy.parquet","partitionValues":{"c1":"1"},"size":452,"modificationTime":1670892998135,"dataChange":true,"stats":"{\"numRecords\":1,\"minValues\":{\"c3\":5},\"maxValues\":{\"c3\":5},\"nullCount\":{\"c3\":0}}"}}"#,
+            r#"{"add":{"path":"c1=5/c2=b/part-00007-4e73fa3b-2c88-424a-8051-f8b54328ffdb.c000.snappy.parquet","partitionValues":{"c1":"5"},"size":452,"modificationTime":1670892998136,"dataChange":true,"stats":"{\"numRecords\":1,\"minValues\":{\"c3\":6},\"maxValues\":{\"c3\":6},\"nullCount\":{\"c3\":0}}"}}"#,
+
+            ]
+        .into();
+
+        let log_schema = get_log_schema().clone();
+        let batch = json_handler
+            .parse_json(
+                string_array_to_engine_data(json_strings),
+                log_schema.clone(),
+            )
+            .unwrap();
+
+        let expr = Arc::new(Expression::and(
+            Expression::unary(UnaryOperator::IsNull, Expression::column(["c2"])),
+            Expression::ge(Expression::column(["c1"]), Expression::literal(4)),
+        ));
+
+        let schema = Arc::new(Schema::new(vec![
+            StructField::new("c1", DataType::INTEGER, true),
+            StructField::new("c2", DataType::STRING, true),
+            StructField::new("c3", DataType::INTEGER, true),
+        ]));
+
+        let physical_predicate = Some((expr, schema));
+        let filter = PartitionSkippingFilter::new(
+            &engine,
+            physical_predicate,
+            &["c1".to_string(), "c2".to_string()],
+        )
+        .expect("Unable to create Partition Skipping Filter");
+
+        let actual = filter.apply(batch.as_ref())?;
+
+        let expected = vec![false, false, false, true, true, false, false, true];
+
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+}

--- a/kernel/src/scan/partition_skipping.rs
+++ b/kernel/src/scan/partition_skipping.rs
@@ -117,7 +117,7 @@ impl RowVisitor for PartitionVisitor {
                     .collect::<DeltaResult<HashMap<ColumnName, Scalar>>>()?;
 
                 let filter = DefaultPredicateEvaluator::from(resolver);
-                Ok(filter.eval_expr(&self.predicate, false).unwrap_or(false))
+                Ok(filter.eval_expr(&self.predicate, false).unwrap_or(true))
             });
 
             let val = match val {

--- a/kernel/src/scan/partition_skipping.rs
+++ b/kernel/src/scan/partition_skipping.rs
@@ -120,7 +120,11 @@ impl RowVisitor for PartitionVisitor {
                             .get(field.name())
                             .map(|v| primitive_type.parse_scalar(v))
                             .transpose()?
-                            .unwrap_or(Scalar::Null(data_type.clone()));
+                            .unwrap_or(
+                                match field.nullable {
+                                    true => Ok(Scalar::Null(data_type.clone())),
+                                    false => Err(crate::Error::missing_data(format!("Missing partition values on a non-nullable field is not supported. Field {}", field.name)))
+                                }?);
 
                         Ok((ColumnName::new([field.name()]), scalar))
                     })

--- a/kernel/src/scan/partition_skipping.rs
+++ b/kernel/src/scan/partition_skipping.rs
@@ -142,7 +142,6 @@ mod tests {
     use crate::expressions::UnaryOperator;
     use crate::scan::get_log_schema;
     use crate::schema::{DataType, Schema, StructField};
-    use crate::DeltaResult;
     use crate::{DeltaResult, Engine, EngineData, Expression};
 
     use super::PartitionSkippingFilter;

--- a/kernel/src/scan/partition_skipping.rs
+++ b/kernel/src/scan/partition_skipping.rs
@@ -5,7 +5,6 @@ use std::{
 
 use tracing::debug;
 
-use crate::expressions::column_expr;
 use crate::schema::column_name;
 use crate::{
     engine_data::GetData,
@@ -15,10 +14,12 @@ use crate::{
     schema::{ColumnName, DataType, MapType, SchemaRef},
     DeltaResult, Engine, EngineData, Expression, ExpressionEvaluator, ExpressionRef, RowVisitor,
 };
+use crate::expressions::column_expr;
 
 pub(crate) struct PartitionSkippingFilter {
     evaluator: Arc<dyn ExpressionEvaluator>,
     predicate: Arc<Expression>,
+    schema: SchemaRef,
 }
 
 impl PartitionSkippingFilter {
@@ -29,8 +30,9 @@ impl PartitionSkippingFilter {
         static PARITIONS_EXPR: LazyLock<Expression> =
             LazyLock::new(|| column_expr!("add.partitionValues"));
 
-        let (predicate, _referenced_schema) = physical_predicate?;
+        let (predicate, schema) = physical_predicate?;
         debug!("Creating a partition skipping filter for {:#?}", predicate);
+        println!("reference schema\n{:#?}", schema);
 
         let partitions_map_type = MapType::new(DataType::STRING, DataType::STRING, true);
 
@@ -43,6 +45,7 @@ impl PartitionSkippingFilter {
         Some(Self {
             evaluator,
             predicate,
+            schema,
         })
     }
 
@@ -50,7 +53,7 @@ impl PartitionSkippingFilter {
         let partitions = self.evaluator.evaluate(actions)?;
         assert_eq!(partitions.len(), actions.len());
 
-        let mut visitor = PartitionVisitor::new(&self.predicate);
+        let mut visitor = PartitionVisitor::new(&self.predicate, &self.schema);
         visitor.visit_rows_of(partitions.as_ref())?;
         Ok(visitor.selection_vector.clone())
     }
@@ -59,13 +62,15 @@ impl PartitionSkippingFilter {
 struct PartitionVisitor {
     pub(crate) selection_vector: Vec<bool>,
     predicate: Arc<Expression>,
+    schema: SchemaRef,
 }
 
 impl PartitionVisitor {
-    pub(crate) fn new(predicate: &Arc<Expression>) -> Self {
+    pub(crate) fn new(predicate: &Arc<Expression>, schema: &SchemaRef) -> Self {
         Self {
             selection_vector: Vec::default(),
             predicate: Arc::clone(predicate),
+            schema: Arc::clone(schema),
         }
     }
 }
@@ -90,15 +95,30 @@ impl RowVisitor for PartitionVisitor {
     fn visit<'a>(&mut self, row_count: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
         let getter = getters[0];
         for i in 0..row_count {
-            let val = getter.get_map(i, "output")?.map(|m| {
+            let val = getter.get_map(i, "output")?.and_then(|m| {
                 let partition_values = m.materialize();
                 // TODO(tsaucer) instead of casting to Scalar::String we need to use the appropriate schema
-                let resolver: HashMap<ColumnName, Scalar> = partition_values
+                let resolver = partition_values
                     .iter()
-                    .map(|(k, v)| (ColumnName::new([k]), Scalar::String(v.to_owned())))
-                    .collect();
+                    .map(|(k, v)| {
+                        let data_type = self.schema.field(k).map(|f| f.data_type());
+                        let primitve_type = if let Some(DataType::Primitive(primitive)) = data_type
+                        {
+                            primitive.to_owned()
+                        } else {
+                            return Err(crate::Error::Generic(
+                                "partition filtering only supported for primitive types"
+                                    .to_string(),
+                            ));
+                        };
+
+                        let scalar = primitve_type.parse_scalar(v)?;
+                        Ok((ColumnName::new([k]), scalar))
+                    })
+                    .collect::<DeltaResult<HashMap<ColumnName, Scalar>>>()
+                    .ok()?;
                 let filter = DefaultPredicateEvaluator::from(resolver);
-                filter.eval_expr(&self.predicate, false).unwrap_or(true)
+                Some(filter.eval_expr(&self.predicate, false).unwrap_or(true))
             });
 
             self.selection_vector.push(val.unwrap_or(true));

--- a/kernel/src/scan/partition_skipping.rs
+++ b/kernel/src/scan/partition_skipping.rs
@@ -1,0 +1,108 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, LazyLock},
+};
+
+use tracing::debug;
+
+use crate::expressions::column_expr;
+use crate::schema::column_name;
+use crate::{
+    engine_data::GetData,
+    expressions::Scalar,
+    predicates::{DefaultPredicateEvaluator, PredicateEvaluator},
+    scan::get_log_add_schema,
+    schema::{ColumnName, DataType, MapType, SchemaRef},
+    DeltaResult, Engine, EngineData, Expression, ExpressionEvaluator, ExpressionRef, RowVisitor,
+};
+
+pub(crate) struct PartitionSkippingFilter {
+    evaluator: Arc<dyn ExpressionEvaluator>,
+    predicate: Arc<Expression>,
+}
+
+impl PartitionSkippingFilter {
+    pub(crate) fn new(
+        engine: &dyn Engine,
+        physical_predicate: Option<(ExpressionRef, SchemaRef)>,
+    ) -> Option<Self> {
+        static PARITIONS_EXPR: LazyLock<Expression> =
+            LazyLock::new(|| column_expr!("add.partitionValues"));
+
+        let (predicate, _referenced_schema) = physical_predicate?;
+        debug!("Creating a partition skipping filter for {:#?}", predicate);
+
+        let partitions_map_type = MapType::new(DataType::STRING, DataType::STRING, true);
+
+        let evaluator = engine.get_expression_handler().get_evaluator(
+            get_log_add_schema().clone(),
+            PARITIONS_EXPR.clone(),
+            partitions_map_type.into(),
+        );
+
+        Some(Self {
+            evaluator,
+            predicate,
+        })
+    }
+
+    pub(crate) fn apply(&mut self, actions: &dyn EngineData) -> DeltaResult<Vec<bool>> {
+        let partitions = self.evaluator.evaluate(actions)?;
+        assert_eq!(partitions.len(), actions.len());
+
+        let mut visitor = PartitionVisitor::new(&self.predicate);
+        visitor.visit_rows_of(partitions.as_ref())?;
+        Ok(visitor.selection_vector.clone())
+    }
+}
+
+struct PartitionVisitor {
+    pub(crate) selection_vector: Vec<bool>,
+    predicate: Arc<Expression>,
+}
+
+impl PartitionVisitor {
+    pub(crate) fn new(predicate: &Arc<Expression>) -> Self {
+        Self {
+            selection_vector: Vec::default(),
+            predicate: Arc::clone(predicate),
+        }
+    }
+}
+
+impl RowVisitor for PartitionVisitor {
+    fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
+        static NAMES_AND_TYPES: LazyLock<crate::schema::ColumnNamesAndTypes> =
+            LazyLock::new(|| {
+                (
+                    vec![column_name!("output")],
+                    vec![DataType::Map(Box::new(MapType::new(
+                        DataType::STRING,
+                        DataType::STRING,
+                        true,
+                    )))],
+                )
+                    .into()
+            });
+        NAMES_AND_TYPES.as_ref()
+    }
+
+    fn visit<'a>(&mut self, row_count: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
+        let getter = getters[0];
+        for i in 0..row_count {
+            let val = getter.get_map(i, "output")?.map(|m| {
+                let partition_values = m.materialize();
+                // TODO(tsaucer) instead of casting to Scalar::String we need to use the appropriate schema
+                let resolver: HashMap<ColumnName, Scalar> = partition_values
+                    .iter()
+                    .map(|(k, v)| (ColumnName::new([k]), Scalar::String(v.to_owned())))
+                    .collect();
+                let filter = DefaultPredicateEvaluator::from(resolver);
+                filter.eval_expr(&self.predicate, false).unwrap_or(true)
+            });
+
+            self.selection_vector.push(val.unwrap_or(true));
+        }
+        Ok(())
+    }
+}

--- a/kernel/src/scan/partition_skipping.rs
+++ b/kernel/src/scan/partition_skipping.rs
@@ -116,7 +116,11 @@ impl RowVisitor for PartitionVisitor {
                             ));
                         };
 
-                        let scalar = partition_values.get(field.name()).map(|v| primitive_type.parse_scalar(v)).transpose()?.unwrap_or(Scalar::Null(data_type.clone()));
+                        let scalar = partition_values
+                            .get(field.name())
+                            .map(|v| primitive_type.parse_scalar(v))
+                            .transpose()?
+                            .unwrap_or(Scalar::Null(data_type.clone()));
 
                         Ok((ColumnName::new([field.name()]), scalar))
                     })

--- a/kernel/src/scan/partition_skipping.rs
+++ b/kernel/src/scan/partition_skipping.rs
@@ -96,7 +96,6 @@ impl RowVisitor for PartitionVisitor {
         for i in 0..row_count {
             let val = getter.get_map(i, "output")?.and_then(|m| {
                 let partition_values = m.materialize();
-                // TODO(tsaucer) instead of casting to Scalar::String we need to use the appropriate schema
                 let resolver = partition_values
                     .iter()
                     .map(|(k, v)| {


### PR DESCRIPTION
## What changes are proposed in this pull request?

This supersedes #615 

This PR adds in a partition filter step that is similar to the data skipping. It adds in a row visitor that checks to see if any filters should be applied at a file level based on partition values. The approach here is based on the discussion in #607.

## How was this change tested?

Tested in datafusion against an existing partitioned dataset and also against the integration test datasets for both multi-partition and single partition. I have also tested that combinations of data skipping and partition skipping are returning the correct number of files in the scan.

Remaining TODO items before this is ready for review/merge:

- [x] Add in unit tests
- [x] Ensure data types are cast based on schema (currently just evaluating the string values)

