### PR TITLE
feat: read `partition_values` in `RemoveVisitor` and remove `break` in `RowVisitor` for `RemoveVisitor`

### DIFF
--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -442,6 +442,12 @@ struct Remove {
     #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
     pub(crate) size: Option<i64>,
 
+    /// Contains [statistics] (e.g., count, min/max values for columns) about the data in this logical file.
+    ///
+    /// [statistics]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#Per-file-Statistics
+    #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
+    pub(crate) stats: Option<String>,
+
     /// Map containing metadata about this logical file.
     #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
     pub(crate) tags: Option<HashMap<String, String>>,
@@ -637,6 +643,7 @@ mod tests {
                 deletion_vector_field(),
                 StructField::new("baseRowId", DataType::LONG, true),
                 StructField::new("defaultRowCommitVersion", DataType::LONG, true),
+                StructField::new("stats", DataType::STRING, true),
             ]),
             true,
         )]));

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -375,7 +375,7 @@ pub struct Add {
     /// in the added file must be contained in one or more remove actions in the same version.
     pub data_change: bool,
 
-    /// Contains [statistics] (e.g., count, min/max values for columns) about the data in this logical file.
+    /// Contains [statistics] (e.g., count, min/max values for columns) about the data in this logical file encoded as a JSON string.
     ///
     /// [statistics]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#Per-file-Statistics
     #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
@@ -442,7 +442,7 @@ struct Remove {
     #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
     pub(crate) size: Option<i64>,
 
-    /// Contains [statistics] (e.g., count, min/max values for columns) about the data in this logical file.
+    /// Contains [statistics] (e.g., count, min/max values for columns) about the data in this logical file encoded as a JSON string.
     ///
     /// [statistics]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#Per-file-Statistics
     #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
@@ -639,11 +639,11 @@ mod tests {
                 StructField::new("extendedFileMetadata", DataType::BOOLEAN, true),
                 partition_values_field(),
                 StructField::new("size", DataType::LONG, true),
+                StructField::new("stats", DataType::STRING, true),
                 tags_field(),
                 deletion_vector_field(),
                 StructField::new("baseRowId", DataType::LONG, true),
                 StructField::new("defaultRowCommitVersion", DataType::LONG, true),
-                StructField::new("stats", DataType::STRING, true),
             ]),
             true,
         )]));

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -442,12 +442,6 @@ struct Remove {
     #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
     pub(crate) size: Option<i64>,
 
-    /// Contains [statistics] (e.g., count, min/max values for columns) about the data in this logical file encoded as a JSON string.
-    ///
-    /// [statistics]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#Per-file-Statistics
-    #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
-    pub(crate) stats: Option<String>,
-
     /// Map containing metadata about this logical file.
     #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
     pub(crate) tags: Option<HashMap<String, String>>,
@@ -639,7 +633,6 @@ mod tests {
                 StructField::new("extendedFileMetadata", DataType::BOOLEAN, true),
                 partition_values_field(),
                 StructField::new("size", DataType::LONG, true),
-                StructField::new("stats", DataType::STRING, true),
                 tags_field(),
                 deletion_vector_field(),
                 StructField::new("baseRowId", DataType::LONG, true),

--- a/kernel/src/actions/visitors.rs
+++ b/kernel/src/actions/visitors.rs
@@ -255,7 +255,7 @@ impl RemoveVisitor {
         getters: &[&'a dyn GetData<'a>],
     ) -> DeltaResult<Remove> {
         require!(
-            getters.len() == 14,
+            getters.len() == 15,
             Error::InternalError(format!(
                 "Wrong number of RemoveVisitor getters: {}",
                 getters.len()
@@ -267,29 +267,33 @@ impl RemoveVisitor {
         let extended_file_metadata: Option<bool> =
             getters[3].get_opt(row_index, "remove.extendedFileMetadata")?;
 
-        // TODO(nick) handle partition values in getters[4]
+        let partition_values: Option<HashMap<_, _>> =
+            getters[4].get_opt(row_index, "add.partitionValues")?;
 
         let size: Option<i64> = getters[5].get_opt(row_index, "remove.size")?;
 
-        // TODO(nick) tags are skipped in getters[6]
+        let stats: Option<String> = getters[6].get_opt(row_index, "remove.stats")?;
 
-        let deletion_vector = visit_deletion_vector_at(row_index, &getters[7..])?;
+        // TODO(nick) tags are skipped in getters[7]
 
-        let base_row_id: Option<i64> = getters[12].get_opt(row_index, "remove.baseRowId")?;
+        let deletion_vector = visit_deletion_vector_at(row_index, &getters[8..])?;
+
+        let base_row_id: Option<i64> = getters[13].get_opt(row_index, "remove.baseRowId")?;
         let default_row_commit_version: Option<i64> =
-            getters[13].get_opt(row_index, "remove.defaultRowCommitVersion")?;
+            getters[14].get_opt(row_index, "remove.defaultRowCommitVersion")?;
 
         Ok(Remove {
             path,
             data_change,
             deletion_timestamp,
             extended_file_metadata,
-            partition_values: None,
+            partition_values,
             size,
             tags: None,
             deletion_vector,
             base_row_id,
             default_row_commit_version,
+            stats,
         })
     }
     pub(crate) fn names_and_types() -> (&'static [ColumnName], &'static [DataType]) {
@@ -305,10 +309,9 @@ impl RowVisitor for RemoveVisitor {
     }
     fn visit<'a>(&mut self, row_count: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
         for i in 0..row_count {
-            // Since path column is required, use it to detect presence of an Remove action
+            // Since path column is required, use it to detect presence of a Remove action
             if let Some(path) = getters[0].get_opt(i, "remove.path")? {
                 self.removes.push(Self::visit_remove(i, path, getters)?);
-                break;
             }
         }
         Ok(())
@@ -630,8 +633,71 @@ mod tests {
             ..add1.clone()
         };
         let expected = vec![add1, add2, add3];
+        assert!(add_visitor.adds.len() == expected.len());
         for (add, expected) in add_visitor.adds.into_iter().zip(expected.into_iter()) {
             assert_eq!(add, expected);
+        }
+    }
+
+    #[test]
+    fn test_parse_remove_partitioned() {
+        let engine = SyncEngine::new();
+        let json_handler = engine.get_json_handler();
+        let json_strings: StringArray = vec![
+            r#"{"commitInfo":{"timestamp":1670892998177,"operation":"DELETE","operationParameters":{"mode":"Append","partitionBy":"[\"c1\",\"c2\"]"},"isolationLevel":"Serializable","isBlindAppend":true,"operationMetrics":{"numFiles":"3","numOutputRows":"3","numOutputBytes":"1356"},"engineInfo":"Apache-Spark/3.3.1 Delta-Lake/2.2.0","txnId":"046a258f-45e3-4657-b0bf-abfb0f76681c"}}"#,
+            r#"{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}"#,
+            r#"{"metaData":{"id":"aff5cb91-8cd9-4195-aef9-446908507302","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"c1\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}},{\"name\":\"c2\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"c3\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":["c1","c2"],"configuration":{},"createdTime":1670892997849}}"#,
+            r#"{"remove":{"path":"c1=4/c2=c/part-00003-f525f459-34f9-46f5-82d6-d42121d883fd.c000.snappy.parquet","deletionTimestamp":1670892998135,"dataChange":true,"partitionValues":{"c1":"4","c2":"c"},"size":452,"stats":"{\"numRecords\":1,\"minValues\":{\"c3\":5},\"maxValues\":{\"c3\":5},\"nullCount\":{\"c3\":0}}"}}"#,
+            r#"{"remove":{"path":"c1=5/c2=b/part-00007-4e73fa3b-2c88-424a-8051-f8b54328ffdb.c000.snappy.parquet","deletionTimestamp":1670892998136,"dataChange":true,"partitionValues":{"c1":"5","c2":"b"},"size":452,"stats":"{\"numRecords\":1,\"minValues\":{\"c3\":6},\"maxValues\":{\"c3\":6},\"nullCount\":{\"c3\":0}}"}}"#,
+            r#"{"remove":{"path":"c1=6/c2=a/part-00011-10619b10-b691-4fd0-acc4-2a9608499d7c.c000.snappy.parquet","deletionTimestamp":1670892998137,"dataChange":true,"partitionValues":{"c1":"6","c2":"a"},"size":452,"stats":"{\"numRecords\":1,\"minValues\":{\"c3\":4},\"maxValues\":{\"c3\":4},\"nullCount\":{\"c3\":0}}"}}"#,
+        ]
+        .into();
+        let output_schema = get_log_schema().clone();
+        let batch = json_handler
+            .parse_json(string_array_to_engine_data(json_strings), output_schema)
+            .unwrap();
+        let mut remove_visitor = RemoveVisitor::default();
+        remove_visitor.visit_rows_of(batch.as_ref()).unwrap();
+        let remove1 = Remove {
+            path: "c1=4/c2=c/part-00003-f525f459-34f9-46f5-82d6-d42121d883fd.c000.snappy.parquet".into(),
+            deletion_timestamp: Some(1670892998135),
+            data_change: true,
+            extended_file_metadata: None,
+            partition_values: Some(HashMap::from([
+                ("c1".to_string(), "4".to_string()),
+                ("c2".to_string(), "c".to_string()),
+            ])),
+            size: Some(452),
+            stats: Some("{\"numRecords\":1,\"minValues\":{\"c3\":5},\"maxValues\":{\"c3\":5},\"nullCount\":{\"c3\":0}}".into()),
+            tags: None,
+            deletion_vector: None,
+            base_row_id: None,
+            default_row_commit_version: None,
+        };
+        let remove2 = Remove {
+            path: "c1=5/c2=b/part-00007-4e73fa3b-2c88-424a-8051-f8b54328ffdb.c000.snappy.parquet".into(),
+            deletion_timestamp: Some(1670892998136),
+            partition_values: Some(HashMap::from([
+                ("c1".to_string(), "5".to_string()),
+                ("c2".to_string(), "b".to_string()),
+            ])),
+            stats: Some("{\"numRecords\":1,\"minValues\":{\"c3\":6},\"maxValues\":{\"c3\":6},\"nullCount\":{\"c3\":0}}".into()),
+            ..remove1.clone()
+        };
+        let remove3 = Remove {
+            path: "c1=6/c2=a/part-00011-10619b10-b691-4fd0-acc4-2a9608499d7c.c000.snappy.parquet".into(),
+            deletion_timestamp: Some(1670892998137),
+            partition_values: Some(HashMap::from([
+                ("c1".to_string(), "6".to_string()),
+                ("c2".to_string(), "a".to_string()),
+            ])),
+            stats: Some("{\"numRecords\":1,\"minValues\":{\"c3\":4},\"maxValues\":{\"c3\":4},\"nullCount\":{\"c3\":0}}".into()),
+            ..remove1.clone()
+        };
+        let expected = vec![remove1, remove2, remove3];
+        assert!(remove_visitor.removes.len() == expected.len());
+        for (remove, expected) in remove_visitor.removes.into_iter().zip(expected.into_iter()) {
+            assert_eq!(remove, expected);
         }
     }
 

--- a/kernel/src/actions/visitors.rs
+++ b/kernel/src/actions/visitors.rs
@@ -661,11 +661,11 @@ mod tests {
         assert_eq!(
             remove_visitor.removes.len(),
             1,
-            "Unexpected number of removal actions"
+            "Unexpected number of remove actions"
         );
         assert_eq!(
             remove_visitor.removes[0], expected_remove,
-            "Unexpected removal action"
+            "Unexpected remove action"
         );
     }
 
@@ -700,11 +700,11 @@ mod tests {
         assert_eq!(
             remove_visitor.removes.len(),
             1,
-            "Unexpected number of removal actions"
+            "Unexpected number of remove actions"
         );
         assert_eq!(
             remove_visitor.removes[0], expected_remove,
-            "Unexpected removal action"
+            "Unexpected remove action"
         );
     }
 

--- a/kernel/src/actions/visitors.rs
+++ b/kernel/src/actions/visitors.rs
@@ -676,7 +676,7 @@ mod tests {
         let json_strings: StringArray = vec![
             r#"{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}"#,
             r#"{"metaData":{"id":"aff5cb91-8cd9-4195-aef9-446908507302","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"c1\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}},{\"name\":\"c2\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"c3\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":["c1","c2"],"configuration":{},"createdTime":1670892997849}}"#,
-            r#"{"remove":{"path":"c1=4/c2=c/part-00003-f525f459-34f9-46f5-82d6-d42121d883fd.c000.snappy.parquet","deletionTimestamp":1670892998135,"dataChange":true,"partitionValues":{"c1":"4","c2":"c"},"size":452,\"nullCount\":{\"c3\":0}}"}}"#,
+            r#"{"remove":{"path":"c1=4/c2=c/part-00003-f525f459-34f9-46f5-82d6-d42121d883fd.c000.snappy.parquet","deletionTimestamp":1670892998135,"dataChange":true,"partitionValues":{"c1":"4","c2":"c"},"size":452}}"#,
         ]
         .into();
         let output_schema = get_log_schema().clone();

--- a/kernel/src/actions/visitors.rs
+++ b/kernel/src/actions/visitors.rs
@@ -268,7 +268,7 @@ impl RemoveVisitor {
             getters[3].get_opt(row_index, "remove.extendedFileMetadata")?;
 
         let partition_values: Option<HashMap<_, _>> =
-            getters[4].get_opt(row_index, "add.partitionValues")?;
+            getters[4].get_opt(row_index, "remove.partitionValues")?;
 
         let size: Option<i64> = getters[5].get_opt(row_index, "remove.size")?;
 
@@ -606,11 +606,7 @@ mod tests {
             modification_time: 1670892998135,
             data_change: true,
             stats: Some("{\"numRecords\":1,\"minValues\":{\"c3\":5},\"maxValues\":{\"c3\":5},\"nullCount\":{\"c3\":0}}".into()),
-            tags: None,
-            deletion_vector: None,
-            base_row_id: None,
-            default_row_commit_version: None,
-            clustering_provider: None,
+            ..Default::default()
         };
         let add2 = Add {
             path: "c1=5/c2=b/part-00007-4e73fa3b-2c88-424a-8051-f8b54328ffdb.c000.snappy.parquet".into(),
@@ -633,7 +629,7 @@ mod tests {
             ..add1.clone()
         };
         let expected = vec![add1, add2, add3];
-        assert!(add_visitor.adds.len() == expected.len());
+        assert_eq!(add_visitor.adds.len(), expected.len());
         for (add, expected) in add_visitor.adds.into_iter().zip(expected.into_iter()) {
             assert_eq!(add, expected);
         }
@@ -669,10 +665,7 @@ mod tests {
             ])),
             size: Some(452),
             stats: Some("{\"numRecords\":1,\"minValues\":{\"c3\":5},\"maxValues\":{\"c3\":5},\"nullCount\":{\"c3\":0}}".into()),
-            tags: None,
-            deletion_vector: None,
-            base_row_id: None,
-            default_row_commit_version: None,
+            ..Default::default()
         };
         let remove2 = Remove {
             path: "c1=5/c2=b/part-00007-4e73fa3b-2c88-424a-8051-f8b54328ffdb.c000.snappy.parquet".into(),
@@ -695,7 +688,7 @@ mod tests {
             ..remove1.clone()
         };
         let expected = vec![remove1, remove2, remove3];
-        assert!(remove_visitor.removes.len() == expected.len());
+        assert_eq!(remove_visitor.removes.len(), expected.len());
         for (remove, expected) in remove_visitor.removes.into_iter().zip(expected.into_iter()) {
             assert_eq!(remove, expected);
         }

--- a/kernel/src/schema.rs
+++ b/kernel/src/schema.rs
@@ -223,7 +223,7 @@ pub struct StructType {
     pub type_name: String,
     /// The type of element stored in this array
     // We use indexmap to preserve the order of fields as they are defined in the schema
-    // while also allowing for fast lookup by name. The alternative to do a linear search
+    // while also allowing for fast lookup by name. The alternative is to do a linear search
     // for each field by name would be potentially quite expensive for large schemas.
     pub fields: IndexMap<String, StructField>,
 }

--- a/kernel/src/schema.rs
+++ b/kernel/src/schema.rs
@@ -223,7 +223,7 @@ pub struct StructType {
     pub type_name: String,
     /// The type of element stored in this array
     // We use indexmap to preserve the order of fields as they are defined in the schema
-    // while also allowing for fast lookup by name. The atlerative to do a liner search
+    // while also allowing for fast lookup by name. The alternative to do a linear search
     // for each field by name would be potentially quite expensive for large schemas.
     pub fields: IndexMap<String, StructField>,
 }

--- a/kernel/src/table_changes/log_replay/tests.rs
+++ b/kernel/src/table_changes/log_replay/tests.rs
@@ -469,7 +469,7 @@ async fn dv() {
     assert_eq!(sv, &[false, true, true]);
 }
 
-//Note: Data skipping does not work reliably on Remove actions.
+// Note: Data skipping does not work on Remove actions.
 #[tokio::test]
 async fn data_skipping_filter() {
     let engine = Arc::new(SyncEngine::new());

--- a/kernel/src/table_changes/log_replay/tests.rs
+++ b/kernel/src/table_changes/log_replay/tests.rs
@@ -469,6 +469,7 @@ async fn dv() {
     assert_eq!(sv, &[false, true, true]);
 }
 
+//Note: Data skipping does not work reliably on Remove actions.
 #[tokio::test]
 async fn data_skipping_filter() {
     let engine = Arc::new(SyncEngine::new());
@@ -498,7 +499,6 @@ async fn data_skipping_filter() {
             // Remove/Add pair with max value id = 4
             Action::Remove(Remove {
                 path: "fake_path_2".into(),
-                stats: Some("{\"numRecords\":4,\"minValues\":{\"id\":4},\"maxValues\":{\"id\":4},\"nullCount\":{\"id\":3}}".into()),
                 data_change: true,
                 ..Default::default()
             }),
@@ -512,13 +512,6 @@ async fn data_skipping_filter() {
             // Add action with max value id = 5
             Action::Add(Add {
                 path: "fake_path_3".into(),
-                stats: Some("{\"numRecords\":4,\"minValues\":{\"id\":4},\"maxValues\":{\"id\":5},\"nullCount\":{\"id\":3}}".into()),
-                data_change: true,
-                ..Default::default()
-            }),
-            // Remove action with max value id = 5
-            Action::Remove(Remove {
-                path: "fake_path_4".into(),
                 stats: Some("{\"numRecords\":4,\"minValues\":{\"id\":4},\"maxValues\":{\"id\":5},\"nullCount\":{\"id\":3}}".into()),
                 data_change: true,
                 ..Default::default()
@@ -550,7 +543,7 @@ async fn data_skipping_filter() {
         .collect_vec();
 
     // Note: since the first pair is a dv operation, remove action will always be filtered
-    assert_eq!(sv, &[false, true, false, false, true, true]);
+    assert_eq!(sv, &[false, true, false, false, true]);
 }
 
 #[tokio::test]

--- a/kernel/src/table_changes/log_replay/tests.rs
+++ b/kernel/src/table_changes/log_replay/tests.rs
@@ -498,6 +498,7 @@ async fn data_skipping_filter() {
             // Remove/Add pair with max value id = 4
             Action::Remove(Remove {
                 path: "fake_path_2".into(),
+                stats: Some("{\"numRecords\":4,\"minValues\":{\"id\":4},\"maxValues\":{\"id\":4},\"nullCount\":{\"id\":3}}".into()),
                 data_change: true,
                 ..Default::default()
             }),
@@ -511,6 +512,13 @@ async fn data_skipping_filter() {
             // Add action with max value id = 5
             Action::Add(Add {
                 path: "fake_path_3".into(),
+                stats: Some("{\"numRecords\":4,\"minValues\":{\"id\":4},\"maxValues\":{\"id\":5},\"nullCount\":{\"id\":3}}".into()),
+                data_change: true,
+                ..Default::default()
+            }),
+            // Remove action with max value id = 5
+            Action::Remove(Remove {
+                path: "fake_path_4".into(),
                 stats: Some("{\"numRecords\":4,\"minValues\":{\"id\":4},\"maxValues\":{\"id\":5},\"nullCount\":{\"id\":3}}".into()),
                 data_change: true,
                 ..Default::default()
@@ -542,7 +550,7 @@ async fn data_skipping_filter() {
         .collect_vec();
 
     // Note: since the first pair is a dv operation, remove action will always be filtered
-    assert_eq!(sv, &[false, true, false, false, true]);
+    assert_eq!(sv, &[false, true, false, false, true, true]);
 }
 
 #[tokio::test]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-incubator/delta-kernel-rs/blob/main/CONTRIBUTING.md
  2. Run `cargo t --all-features --all-targets` to get started testing, and run `cargo fmt`.
  3. Ensure you have added or run the appropriate tests for your PR.
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

## What changes are proposed in this pull request?
<!--
Please clarify what changes you are proposing and why the changes are needed.
The purpose of this section is to outline the changes, why they are needed, and how this PR fixes the issue.
If the reason for the change is already explained clearly in an issue, then it does not need to be restated here.
  1. If you propose a new API or feature, clarify the use case for a new API or feature.
  2. If you fix a bug, you can clarify why it is a bug.
-->
1. This PR updates `RemoveVisitor` to read `partition_values`
2. This PR removes the stray break in the implementation of `RowVisitor` for `RemoveVisitor` which prevented reading multiple `Remove` actions in a commit
<!--
Uncomment this section if there are any changes affecting public APIs:
### This PR affects the following public APIs

If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.

Note that _new_ public APIs are not considered breaking.
-->


## How was this change tested?
<!--
Please make sure to add test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested, ideally via a reproducible test documented in the PR description.
-->

- Introduced test to parse the `partition_values` field from `Remove` actions