### PR TITLE
feat: incremental Snapshot update

### DIFF
--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -166,14 +166,20 @@ impl LogSegment {
                 .filter_ok(|x| x.is_commit())
                 .try_collect()?;
 
+        // Return a FileNotFound error if there are no new commits.
+        // Callers can then decide how to handle this case.
+        require!(
+            !ascending_commit_files.is_empty(),
+            Error::file_not_found("No new commits.")
+        );
+
         // - Here check that the start version is correct.
         // - [`LogSegment::try_new`] will verify that the `end_version` is correct if present.
         // - [`LogSegment::try_new`] also checks that there are no gaps between commits.
         // If all three are satisfied, this implies that all the desired commits are present.
         require!(
-            ascending_commit_files
-                .first()
-                .is_some_and(|first_commit| first_commit.version == start_version),
+            // safety: we validated the list is not empty above
+            ascending_commit_files[0].version == start_version,
             Error::generic(format!(
                 "Expected the first commit to have version {}",
                 start_version

--- a/kernel/src/table_properties.rs
+++ b/kernel/src/table_properties.rs
@@ -137,6 +137,9 @@ pub struct TableProperties {
     /// whether to enable row tracking during writes.
     pub enable_row_tracking: Option<bool>,
 
+    /// whether to enable type widening
+    pub enable_type_widening: Option<bool>,
+
     /// any unrecognized properties are passed through and ignored by the parser
     pub unknown_properties: HashMap<String, String>,
 }
@@ -268,6 +271,7 @@ mod tests {
             ("delta.tuneFileSizesForRewrites", "true"),
             ("delta.checkpointPolicy", "v2"),
             ("delta.enableRowTracking", "true"),
+            ("delta.enableTypeWidening", "true"),
         ];
         let actual = TableProperties::from(properties.into_iter());
         let expected = TableProperties {
@@ -293,6 +297,7 @@ mod tests {
             tune_file_sizes_for_rewrites: Some(true),
             checkpoint_policy: Some(CheckpointPolicy::V2),
             enable_row_tracking: Some(true),
+            enable_type_widening: Some(true),
             unknown_properties: HashMap::new(),
         };
         assert_eq!(actual, expected);

--- a/kernel/src/table_properties/deserialize.rs
+++ b/kernel/src/table_properties/deserialize.rs
@@ -76,6 +76,7 @@ fn try_parse(props: &mut TableProperties, k: &str, v: &str) -> Option<()> {
         }
         "delta.checkpointPolicy" => props.checkpoint_policy = CheckpointPolicy::try_from(v).ok(),
         "delta.enableRowTracking" => props.enable_row_tracking = Some(parse_bool(v)?),
+        "delta.enableTypeWidening" => props.enable_type_widening = Some(parse_bool(v)?),
         _ => return None,
     }
     Some(())

--- a/kernel/tests/cdf.rs
+++ b/kernel/tests/cdf.rs
@@ -398,8 +398,7 @@ fn invalid_range_end_before_start() {
 #[test]
 fn invalid_range_start_after_last_version_of_table() {
     let res = read_cdf_for_table("cdf-table-simple", 3, 4, None);
-    let expected_msg = "Expected the first commit to have version 3";
-    assert!(matches!(res, Err(Error::Generic(msg)) if msg == expected_msg));
+    assert!(matches!(res, Err(Error::FileNotFound(_))));
 }
 
 #[test]


### PR DESCRIPTION
> [!NOTE]
> removed the breaking change label, since calling code should not require updates.

## What changes are proposed in this pull request?

This PR proposes a new api on `Snapshot` to handle updating a snapshot to a more recent version.

```rs
    /// Update the `Snapshot` to the target version.
    ///
    /// # Parameters
    /// - `target_version`: desired version of the `Snapshot` after update, defaults to latest.
    /// - `engine`: Implementation of [`Engine`] apis.
    ///
    /// # Returns
    /// - boolean flag indicating if the `Snapshot` was updated.
    pub fn update(
        &mut self,
        target_version: impl Into<Option<Version>>,
        engine: &dyn Engine,
    ) -> DeltaResult<bool>
```

This allows engines like duckdb or delta-rs to hold on to a `Snapshot` and avoid potentially expensive operations on the object store by only the new log entries.

### This PR affects the following public APIs

- adds a new `update` method to `Snapshot`.
- exposes `enable_type_widening` on `TableProperties` (this was useful to use the type widening table for testing)
- extends permissible inputs to `Snapshot::try_new`

## How was this change tested?

- added new tests for both `LogSegment` and `Snapshot::update`