### PR TITLE
feat: Add check for whether appendOnly table feature is supported or enabled 

### DIFF
--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -816,12 +816,13 @@ mod tests {
 
     #[test]
     fn test_ensure_write_supported() {
-        let protocol = Protocol {
-            min_reader_version: 3,
-            min_writer_version: 7,
-            reader_features: Some(vec![]),
-            writer_features: Some(vec![]),
-        };
+        let protocol = Protocol::try_new(
+            3,
+            7,
+            Some::<Vec<String>>(vec![]),
+            Some(vec![WriterFeatures::AppendOnly]),
+        )
+        .unwrap();
         assert!(protocol.ensure_write_supported().is_ok());
 
         let protocol = Protocol::try_new(

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -197,7 +197,6 @@ impl TableConfiguration {
     /// - The table must have a writer version between 2 and 7 (inclusive)
     /// - If the table is on writer version 7, it must have the [`WriterFeatures::AppendOnly`]
     ///   writer feature.
-    #[allow(unused)]
     #[cfg_attr(feature = "developer-visibility", visibility::make(pub))]
     pub(crate) fn is_append_only_supported(&self) -> bool {
         let protocol = &self.protocol;

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -197,7 +197,6 @@ impl TableConfiguration {
     /// - The table must have a writer version between 2 and 7 (inclusive)
     /// - If the table is on writer version 7, it must have the [`WriterFeatures::AppendOnly`]
     ///   writer feature.
-    #[cfg_attr(feature = "developer-visibility", visibility::make(pub))]
     pub(crate) fn is_append_only_supported(&self) -> bool {
         let protocol = &self.protocol;
         match protocol.min_writer_version() {
@@ -207,7 +206,6 @@ impl TableConfiguration {
     }
 
     #[allow(unused)]
-    #[cfg_attr(feature = "developer-visibility", visibility::make(pub))]
     pub(crate) fn is_append_only_enabled(&self) -> bool {
         self.is_append_only_supported() && self.table_properties.append_only.unwrap_or(false)
     }

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -292,4 +292,30 @@ mod test {
         assert!(!table_config.is_deletion_vector_supported());
         assert!(!table_config.is_deletion_vector_enabled());
     }
+
+    pub fn is_append_only_table(&self) -> DeltaResult<()> {
+        static APPEND_ONLY_WRITER_FEATURE: LazyLock<HashSet<WriterFeatures>> =
+            LazyLock::new(|| HashSet::from([WriterFeatures::AppendOnly]));
+        match self.protocol.reader_features() {
+            // if min_writer_version = 7 and the append only writer feature is enabled => OK
+            Some(reader_features) if self.protocol.min_writer_version() == 7 => {
+                ensure_supported_features(reader_features, &APPEND_ONLY_WRITER_FEATURE)?
+            }
+            // if min_writer_version is between 2 and 6 inclusive and there are no reader features => OK
+            None if 2 <= self.protocol.min_reader_version()
+                && self.protocol.min_writer_version() <= 6 => {}
+            // any other protocol is not supported
+            _ => {
+                return Err(Error::unsupported(
+                    "Change data feed not supported on this protocol",
+                ));
+            }
+        };
+        require!(
+            self.table_properties.append_only.unwrap_or(false),
+            Error::unsupported("Append only table is not enabled")
+        );
+
+        Ok(())
+    }
 }

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -192,18 +192,18 @@ impl TableConfiguration {
                 .enable_deletion_vectors
                 .unwrap_or(false)
     }
+
+    /// Returns `true` if the table supports the appendOnly table feature. To support this feature:
+    /// - The table must have a writer version between 2 and 7 (inclusive)
+    /// - If the table is on writer version 7, it must have the [`WriterFeatures::AppendOnly`]
+    ///   writer feature.
     #[allow(unused)]
     #[cfg_attr(feature = "developer-visibility", visibility::make(pub))]
     pub(crate) fn is_append_only_supported(&self) -> bool {
-        match self.protocol.min_writer_version() {
-            7 if self
-                .protocol
-                .has_writer_feature(&WriterFeatures::AppendOnly) =>
-            {
-                true
-            }
-            ver if (2..7).contains(&ver) => true,
-            _ => false,
+        let protocol = &self.protocol;
+        match protocol.min_writer_version() {
+            7 if protocol.has_writer_feature(&WriterFeatures::AppendOnly) => true,
+            version => (2..=6).contains(&version),
         }
     }
 

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -136,7 +136,7 @@ pub(crate) static SUPPORTED_READER_FEATURES: LazyLock<HashSet<ReaderFeatures>> =
         ])
     });
 
-// write support wip: no table features are supported yet
+// currently the only writer feature supported is `AppendOnly`
 pub(crate) static SUPPORTED_WRITER_FEATURES: LazyLock<HashSet<WriterFeatures>> =
     LazyLock::new(|| HashSet::from([WriterFeatures::AppendOnly]));
 

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -138,7 +138,7 @@ pub(crate) static SUPPORTED_READER_FEATURES: LazyLock<HashSet<ReaderFeatures>> =
 
 // write support wip: no table features are supported yet
 pub(crate) static SUPPORTED_WRITER_FEATURES: LazyLock<HashSet<WriterFeatures>> =
-    LazyLock::new(|| HashSet::from([]));
+    LazyLock::new(|| HashSet::from([WriterFeatures::AppendOnly]));
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR adds two functions to TableConfiguration: 
1) check whether appendOnly table feature is supported
2) check whether appendOnly table feature is enabled

It also enabled writes on tables with `AppendOnly` writer feature.

## How was this change tested?
I check that write is supported on Protocol with `WriterFeatures::AppendOnly`.