### PR TITLE
fix: consistent PartialEq for Scalar

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -71,6 +71,7 @@ tokio = { version = "1.40", optional = true, features = ["rt-multi-thread"] }
 # Used in integration tests
 hdfs-native = { workspace = true, optional = true }
 walkdir = { workspace = true, optional = true }
+bigdecimal = "0.4.7"
 
 [features]
 arrow-conversion = ["arrow-schema"]

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 readme.workspace = true
 version.workspace = true
 # exclude golden tests + golden test data since they push us over 10MB crate size limit
-exclude = ["tests/golden_tables.rs", "tests/golden_data/" ]
+exclude = ["tests/golden_tables.rs", "tests/golden_data/"]
 rust-version.workspace = true
 
 [package.metadata.docs.rs]
@@ -17,10 +17,22 @@ all-features = true
 
 [package.metadata.release]
 pre-release-replacements = [
-  {file="../README.md", search="delta_kernel = \"[a-z0-9\\.-]+\"", replace="delta_kernel = \"{{version}}\""},
-  {file="../README.md", search="version = \"[a-z0-9\\.-]+\"", replace="version = \"{{version}}\""},
+  { file = "../README.md", search = "delta_kernel = \"[a-z0-9\\.-]+\"", replace = "delta_kernel = \"{{version}}\"" },
+  { file = "../README.md", search = "version = \"[a-z0-9\\.-]+\"", replace = "version = \"{{version}}\"" },
 ]
-pre-release-hook = ["git", "cliff", "--repository", "../", "--config", "../cliff.toml", "--unreleased", "--prepend", "../CHANGELOG.md", "--tag", "{{version}}" ]
+pre-release-hook = [
+  "git",
+  "cliff",
+  "--repository",
+  "../",
+  "--config",
+  "../cliff.toml",
+  "--unreleased",
+  "--prepend",
+  "../CHANGELOG.md",
+  "--tag",
+  "{{version}}",
+]
 
 [dependencies]
 bytes = "1.7"
@@ -71,11 +83,16 @@ tokio = { version = "1.40", optional = true, features = ["rt-multi-thread"] }
 # Used in integration tests
 hdfs-native = { workspace = true, optional = true }
 walkdir = { workspace = true, optional = true }
-bigdecimal = "0.4.7"
 
 [features]
 arrow-conversion = ["arrow-schema"]
-arrow-expression = ["arrow-arith", "arrow-array", "arrow-buffer", "arrow-ord", "arrow-schema"]
+arrow-expression = [
+  "arrow-arith",
+  "arrow-array",
+  "arrow-buffer",
+  "arrow-ord",
+  "arrow-schema",
+]
 cloud = [
   "object_store/aws",
   "object_store/azure",
@@ -107,10 +124,7 @@ default-engine-base = [
 
 # the default-engine use the reqwest crate with default features which uses native-tls. if you want
 # to instead use rustls, use 'default-engine-rustls' which has no native-tls dependency
-default-engine = [
-  "default-engine-base",
-  "reqwest/default",
-]
+default-engine = ["default-engine-base", "reqwest/default"]
 
 default-engine-rustls = [
   "default-engine-base",

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -261,17 +261,9 @@ impl PartialOrd for Scalar {
             (Date(_), _) => None,
             (Binary(a), Binary(b)) => a.partial_cmp(b),
             (Binary(_), _) => None,
-            (Decimal(v1, p1, s1), Decimal(v2, p2, s2)) => {
-                use bigdecimal::{BigDecimal, FromPrimitive};
-
-                let lhs = BigDecimal::from_i128(*v1)?
-                    .with_prec(*p1 as u64)
-                    .with_scale(*s1 as i64);
-                let rhs = BigDecimal::from_i128(*v2)?
-                    .with_prec(*p2 as u64)
-                    .with_scale(*s2 as i64);
-                lhs.partial_cmp(&rhs)
-            }
+            (Decimal(v1, p1, s1), Decimal(v2, p2, s2)) => (s1.eq(s2) && p1.eq(p2))
+                .then(|| v1.partial_cmp(v2))
+                .flatten(),
             (Decimal(_, _, _), _) => None,
             (Null(_), _) => None, // NOTE: NULL values are incomparable by definition
             (Struct(_), _) => None, // TODO: Support Struct?

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -1,6 +1,7 @@
-use chrono::{DateTime, NaiveDate, NaiveDateTime, TimeZone, Utc};
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
+
+use chrono::{DateTime, NaiveDate, NaiveDateTime, TimeZone, Utc};
 
 use crate::schema::{ArrayType, DataType, PrimitiveType, StructField};
 use crate::utils::require;
@@ -89,7 +90,7 @@ impl StructData {
 
 /// A single value, which can be null. Used for representing literal values
 /// in [Expressions][crate::expressions::Expression].
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub enum Scalar {
     /// 32bit integer
     Integer(i32),
@@ -224,6 +225,12 @@ impl Display for Scalar {
     }
 }
 
+impl PartialEq for Scalar {
+    fn eq(&self, other: &Scalar) -> bool {
+        self.partial_cmp(other) == Some(Ordering::Equal)
+    }
+}
+
 impl PartialOrd for Scalar {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         use Scalar::*;
@@ -254,10 +261,21 @@ impl PartialOrd for Scalar {
             (Date(_), _) => None,
             (Binary(a), Binary(b)) => a.partial_cmp(b),
             (Binary(_), _) => None,
-            (Decimal(_, _, _), _) => None, // TODO: Support Decimal
-            (Null(_), _) => None,          // NOTE: NULL values are incomparable by definition
-            (Struct(_), _) => None,        // TODO: Support Struct?
-            (Array(_), _) => None,         // TODO: Support Array?
+            (Decimal(v1, p1, s1), Decimal(v2, p2, s2)) => {
+                use bigdecimal::{BigDecimal, FromPrimitive};
+
+                let lhs = BigDecimal::from_i128(*v1)?
+                    .with_prec(*p1 as u64)
+                    .with_scale(*s1 as i64);
+                let rhs = BigDecimal::from_i128(*v2)?
+                    .with_prec(*p2 as u64)
+                    .with_scale(*s2 as i64);
+                lhs.partial_cmp(&rhs)
+            }
+            (Decimal(_, _, _), _) => None,
+            (Null(_), _) => None, // NOTE: NULL values are incomparable by definition
+            (Struct(_), _) => None, // TODO: Support Struct?
+            (Array(_), _) => None, // TODO: Support Array?
         }
     }
 }
@@ -585,6 +603,7 @@ mod tests {
         assert_eq!(&format!("{}", column_op), "3.1415927 IN Column(item)");
         assert_eq!(&format!("{}", column_not_op), "'Cool' NOT IN Column(item)");
     }
+
     #[test]
     fn test_timestamp_parse() {
         let assert_timestamp_eq = |scalar_string, micros| {
@@ -599,6 +618,7 @@ mod tests {
         assert_timestamp_eq("2011-01-11 13:06:07.123456", 1294751167123456);
         assert_timestamp_eq("1970-01-01 00:00:00", 0);
     }
+
     #[test]
     fn test_timestamp_ntz_parse() {
         let assert_timestamp_eq = |scalar_string, micros| {
@@ -626,5 +646,37 @@ mod tests {
 
         let p_type = PrimitiveType::Timestamp;
         assert_timestamp_fails(&p_type, "1971-07-22");
+    }
+
+    #[test]
+    fn test_partial_cmp() {
+        let a = Scalar::Integer(1);
+        let b = Scalar::Integer(2);
+        let c = Scalar::Null(DataType::INTEGER);
+        assert_eq!(a.partial_cmp(&b), Some(Ordering::Less));
+        assert_eq!(b.partial_cmp(&a), Some(Ordering::Greater));
+        assert_eq!(a.partial_cmp(&a), Some(Ordering::Equal));
+        assert_eq!(b.partial_cmp(&b), Some(Ordering::Equal));
+        assert_eq!(a.partial_cmp(&c), None);
+        assert_eq!(c.partial_cmp(&a), None);
+
+        // assert that NULL values are incomparable
+        let null = Scalar::Null(DataType::INTEGER);
+        assert_eq!(null.partial_cmp(&null), None);
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let a = Scalar::Integer(1);
+        let b = Scalar::Integer(2);
+        let c = Scalar::Null(DataType::INTEGER);
+        assert!(!a.eq(&b));
+        assert!(a.eq(&a));
+        assert!(!a.eq(&c));
+        assert!(!c.eq(&a));
+
+        // assert that NULL values are incomparable
+        let null = Scalar::Null(DataType::INTEGER);
+        assert!(!null.eq(&null));
     }
 }

--- a/kernel/src/predicates/tests.rs
+++ b/kernel/src/predicates/tests.rs
@@ -117,7 +117,7 @@ fn test_default_partial_cmp_scalars() {
     }
 
     let expect_if_comparable_type = |s: &_, expect| match s {
-        Null(_) | Decimal(..) | Struct(_) | Array(_) => None,
+        Null(_) | Struct(_) | Array(_) => None,
         _ => Some(expect),
     };
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

We currently have a custom implementation for `Scalar::partial_cmp` whith correct NULL semantics. The current derived `PartialEq` implementation is inconsistent with that impl. This PR then introduces a custom implementation for `PartialEq` which uses the `PartialOrd` implementation.

We also extend the implementation of `PartialOrd` to cover decimals via the `bigdecimals` crate, which handles arbitrary precision decimals.

## How was this change tested?

added tests for null handling in `PartialEq` / `PartialOrd`. Decimal comparisons are well covered in predicate tests, where they were previously disabled.