### PR TITLE
test: introduce the new `MockJsonHandler` and `MockParquetHandler`

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -106,6 +106,9 @@ pub use error::{DeltaResult, Error};
 pub use expressions::{Expression, ExpressionRef};
 pub use table::Table;
 
+#[cfg(test)]
+use path::ParsedLogPath;
+
 #[cfg(any(
     feature = "default-engine",
     feature = "sync-engine",
@@ -182,6 +185,12 @@ impl FileMeta {
             last_modified,
             size,
         }
+    }
+
+    /// Create a ParsedLogPath from this FileMeta
+    #[cfg(test)]
+    fn to_parsed_log_path(&self) -> ParsedLogPath {
+        ParsedLogPath::try_from(self.clone()).unwrap().unwrap()
     }
 }
 

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -754,7 +754,7 @@ pub(crate) mod test_utils {
     use super::{state::ScanCallback, Transform};
 
     // TODO(nick): Merge all copies of this into one "test utils" thing
-    fn string_array_to_engine_data(string_array: StringArray) -> Box<dyn EngineData> {
+    pub(crate) fn string_array_to_engine_data(string_array: StringArray) -> Box<dyn EngineData> {
         let string_field = Arc::new(Field::new("a", DataType::Utf8, true));
         let schema = Arc::new(ArrowSchema::new(vec![string_field]));
         let batch = RecordBatch::try_new(schema, vec![Arc::new(string_array)])

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -754,7 +754,7 @@ pub(crate) mod test_utils {
     use super::{state::ScanCallback, Transform};
 
     // TODO(nick): Merge all copies of this into one "test utils" thing
-    pub(crate) fn string_array_to_engine_data(string_array: StringArray) -> Box<dyn EngineData> {
+    fn string_array_to_engine_data(string_array: StringArray) -> Box<dyn EngineData> {
         let string_field = Arc::new(Field::new("a", DataType::Utf8, true));
         let schema = Arc::new(ArrowSchema::new(vec![string_field]));
         let batch = RecordBatch::try_new(schema, vec![Arc::new(string_array)])

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -1,6 +1,3 @@
-//! Various utility functions/macros used throughout the kernel
-
-/// convenient way to return an error if a condition isn't true
 macro_rules! require {
     ( $cond:expr, $err:expr ) => {
         if !($cond) {
@@ -17,12 +14,17 @@ pub(crate) mod test_utils {
     use object_store::local::LocalFileSystem;
     use object_store::ObjectStore;
     use serde::Serialize;
-    use std::{path::Path, sync::Arc};
+    use std::sync::Mutex;
+    use std::{collections::VecDeque, path::Path, sync::Arc};
     use tempfile::TempDir;
     use test_utils::delta_path_for_version;
 
     use crate::actions::{Add, Cdc, CommitInfo, Metadata, Protocol, Remove};
-
+    use crate::{
+        schema::SchemaRef, DeltaResult, ExpressionRef, FileDataReadResultIterator, FileMeta,
+        ParquetHandler,
+    };
+    use crate::{Engine, ExpressionHandler, FileSystemClient, JsonHandler};
     #[derive(Serialize)]
     pub(crate) enum Action {
         #[serde(rename = "add")]
@@ -76,6 +78,251 @@ pub(crate) mod test_utils {
         /// Get the path to the root of the table.
         pub(crate) fn table_root(&self) -> &Path {
             self.dir.path()
+        }
+    }
+
+    /// A mock implementation of the `Engine` trait for unit testing purposes.
+    ///
+    /// This engine provides mock JSON and Parquet handlers that allow controlled
+    /// file read expectations and assertions, ensuring that expected behavior is met.
+    pub(crate) struct MockEngine {
+        json_handler: Arc<dyn JsonHandler>,
+        parquet_handler: Arc<dyn ParquetHandler>,
+    }
+
+    impl MockEngine {
+        /// Creates a new `MockEngine` instance with default mock handlers.
+        pub(crate) fn new() -> Self {
+            Self {
+                json_handler: Arc::new(MockJsonHandler::new()),
+                parquet_handler: Arc::new(MockParquetHandler::new()),
+            }
+        }
+    }
+
+    impl Engine for MockEngine {
+        fn get_expression_handler(&self) -> Arc<dyn ExpressionHandler> {
+            // TODO: Create a mock expression handler
+            unimplemented!()
+        }
+
+        fn get_file_system_client(&self) -> Arc<dyn FileSystemClient> {
+            // TODO: Create a mock file system cliient
+            unimplemented!()
+        }
+
+        fn get_parquet_handler(&self) -> Arc<dyn ParquetHandler> {
+            Arc::clone(&self.parquet_handler)
+        }
+
+        fn get_json_handler(&self) -> Arc<dyn JsonHandler> {
+            Arc::clone(&self.json_handler)
+        }
+    }
+
+    /// Represents the expected parameters for a file read operation,
+    /// along with a predefined result to be returned.
+    struct ExpectedFileReadParams {
+        // List of files expected to be read.
+        files: Vec<FileMeta>,
+
+        // Expected schema reference for the file read.
+        schema: SchemaRef,
+
+        // Expected predicate filter applied to the read.
+        predicate: Option<ExpressionRef>,
+
+        // Predefined result to return.
+        result: DeltaResult<FileDataReadResultIterator>,
+    }
+
+    /// Verifies that actual file read parameters match the expected parameters.
+    fn assert_parameters_match(
+        expected_params: &ExpectedFileReadParams,
+        files: &[FileMeta],
+        physical_schema: SchemaRef,
+        predicate: Option<ExpressionRef>,
+        file_type: &str,
+    ) {
+        assert_eq!(
+            expected_params.files, files,
+            "Mismatch in {} file read: expected {:?}, got {:?}.",
+            file_type, expected_params.files, files
+        );
+
+        assert_eq!(
+            expected_params.schema, physical_schema,
+            "Mismatch in {} file schema: expected {:?}, got {:?}.",
+            file_type, expected_params.schema, physical_schema
+        );
+
+        assert_eq!(
+            expected_params.predicate.is_some(),
+            predicate.is_some(),
+            "Mismatch in {} file predicate presence.",
+            file_type
+        );
+
+        if let (Some(expected_predicate), Some(actual_predicate)) =
+            (&expected_params.predicate, &predicate)
+        {
+            assert_eq!(
+                expected_predicate.as_ref(),
+                actual_predicate.as_ref(),
+                "Mismatch in {} file predicate expressions.",
+                file_type
+            );
+        }
+    }
+
+    /// A generic mock handler for testing file read operations.
+    ///
+    /// This handler maintains a queue of expected read calls and their results,
+    /// enforcing that calls occur in a defined order.
+    struct MockHandler {
+        expected_file_reads_params: Mutex<VecDeque<ExpectedFileReadParams>>,
+    }
+
+    impl MockHandler {
+        /// Creates a new `MockHandler` with an empty queue.
+        fn new() -> Self {
+            Self {
+                expected_file_reads_params: Mutex::new(VecDeque::new()),
+            }
+        }
+
+        /// Registers an expected file read operation with its expected result.
+        fn expect_read_files(
+            &self,
+            files: Vec<FileMeta>,
+            schema: SchemaRef,
+            predicate: Option<ExpressionRef>,
+            result: DeltaResult<FileDataReadResultIterator>,
+        ) {
+            self.expected_file_reads_params
+                .lock()
+                .unwrap()
+                .push_back(ExpectedFileReadParams {
+                    files,
+                    schema,
+                    predicate,
+                    result,
+                });
+        }
+
+        /// Retrieves and validates an expected file read operation, returning the associated result.
+        fn read_files(
+            &self,
+            files: &[FileMeta],
+            schema: SchemaRef,
+            predicate: Option<ExpressionRef>,
+            file_type: &str,
+        ) -> DeltaResult<FileDataReadResultIterator> {
+            let mut queue = self.expected_file_reads_params.lock().unwrap();
+            if let Some(expected_call) = queue.pop_front() {
+                assert_parameters_match(&expected_call, files, schema, predicate, file_type);
+                expected_call.result
+            } else {
+                panic!(
+                    "Unexpected call to read_{}_files! No expected read call found.",
+                    file_type
+                );
+            }
+        }
+    }
+
+    /// A mock handler for testing Parquet file reads.
+    pub(crate) struct MockParquetHandler {
+        handler: MockHandler,
+    }
+
+    impl MockParquetHandler {
+        /// Creates a new `MockParquetHandler`.
+        pub(crate) fn new() -> Self {
+            Self {
+                handler: MockHandler::new(),
+            }
+        }
+
+        /// Registers an expected call to `read_parquet_files`.
+        pub(crate) fn expect_read_parquet_files(
+            &self,
+            files: Vec<FileMeta>,
+            schema: SchemaRef,
+            predicate: Option<ExpressionRef>,
+            result: DeltaResult<FileDataReadResultIterator>,
+        ) {
+            self.handler
+                .expect_read_files(files, schema, predicate, result);
+        }
+    }
+
+    impl ParquetHandler for MockParquetHandler {
+        /// Matches parameters with expected values and returns the result.
+        fn read_parquet_files(
+            &self,
+            files: &[FileMeta],
+            schema: SchemaRef,
+            predicate: Option<ExpressionRef>,
+        ) -> DeltaResult<FileDataReadResultIterator> {
+            self.handler.read_files(files, schema, predicate, "parquet")
+        }
+    }
+
+    /// A mock handler for testing JSON file reads.
+    pub(crate) struct MockJsonHandler {
+        handler: MockHandler,
+    }
+
+    impl MockJsonHandler {
+        /// Creates a new `MockJsonHandler`.
+        pub(crate) fn new() -> Self {
+            Self {
+                handler: MockHandler::new(),
+            }
+        }
+
+        /// Registers an expected call to `read_json_files`.
+        pub(crate) fn expect_read_json_files(
+            &self,
+            files: Vec<FileMeta>,
+            schema: SchemaRef,
+            predicate: Option<ExpressionRef>,
+            result: DeltaResult<FileDataReadResultIterator>,
+        ) {
+            self.handler
+                .expect_read_files(files, schema, predicate, result);
+        }
+    }
+
+    impl JsonHandler for MockJsonHandler {
+        /// Matches parameters with expected values and returns the result.
+        fn read_json_files(
+            &self,
+            files: &[FileMeta],
+            schema: SchemaRef,
+            predicate: Option<ExpressionRef>,
+        ) -> DeltaResult<FileDataReadResultIterator> {
+            self.handler.read_files(files, schema, predicate, "json")
+        }
+
+        /// Placeholder implementation for JSON parsing.
+        fn parse_json(
+            &self,
+            _json_strings: Box<dyn crate::EngineData>,
+            _output_schema: SchemaRef,
+        ) -> DeltaResult<Box<dyn crate::EngineData>> {
+            unimplemented!()
+        }
+
+        /// Placeholder implementation for writing JSON data.
+        fn write_json_file(
+            &self,
+            _path: &url::Url,
+            _data: Box<dyn Iterator<Item = DeltaResult<Box<dyn crate::EngineData>>> + Send + '_>,
+            _overwrite: bool,
+        ) -> DeltaResult<()> {
+            unimplemented!()
         }
     }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-incubator/delta-kernel-rs/blob/main/CONTRIBUTING.md
  2. Run `cargo t --all-features --all-targets` to get started testing, and run `cargo fmt`.
  3. Ensure you have added or run the appropriate tests for your PR.
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

<!--
PR title formatting:
This project uses conventional commits: https://www.conventionalcommits.org/

Each PR corresponds to a commit on the `main` branch, with the title of the PR (typically) being
used for the commit message on main. In order to ensure proper formatting in the CHANGELOG please
ensure your PR title adheres to the conventional commit specification.

Examples:
- new feature PR: "feat: new API for snapshot.update()"
- bugfix PR: "fix: correctly apply DV in read-table example"
-->

## What changes are proposed in this pull request?
<!--
Please clarify what changes you are proposing and why the changes are needed.
The purpose of this section is to outline the changes, why they are needed, and how this PR fixes the issue.
If the reason for the change is already explained clearly in an issue, then it does not need to be restated here.
  1. If you propose a new API or feature, clarify the use case for a new API or feature.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This PR introduces the `MockEngine` which returns the new `MockJsonHandler`, and `MockParquetHandler`.

These mock handlers enable functional testing without relying on real implementations of the `Engine` trait that perform actual file I/O. Instead, they simulate file reads in a controlled manner, ensuring tests remain **isolated** and predictable.

Both handlers extend a generic `MockHandler`, which:
- Maintains an expected queue of file read operations (i.e., which files should be read, with what schema, and using which predicate).
- Enforces  order validation, ensuring that file reads occur as expected.
- Returns predefined results for each file read operation, eliminating reliance on actual files.

This addition aims to better our current testing utilities. Tests that leverage `LocalMockTable` are candidates for replacement as `LocalMockTable` relies on performing operations in a temporary directory, introducing unnecessary dependencies on file I/O.
<!--
Uncomment this section if there are any changes affecting public APIs:
### This PR affects the following public APIs

If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.

Note that _new_ public APIs are not considered breaking.
-->


## How was this change tested?
<!--
Please make sure to add test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested, ideally via a reproducible test documented in the PR description.
-->

Included in this PR is an example of the handlers usage for unit testing a core piece of functionality in kernel: `test_log_replay`

- asserts that the correct commit files are read in reversed order with the correct schema and predicate
- asserts that the correct checkpoint files are read with the correct schema and predicate
- asserts that the batches read from the files are mapped with the appropriate `is_log_batch` flag
- asserts that the batches read from the files are chained and returned