### PR TITLE
refactor!: adopt types for table features

### DIFF
--- a/kernel/src/actions/deletion_vector.rs
+++ b/kernel/src/actions/deletion_vector.rs
@@ -66,7 +66,7 @@ impl DeletionVectorDescriptor {
                 let path_len = self.path_or_inline_dv.len();
                 require!(
                     path_len >= 20,
-                    Error::deletion_vector("Invalid length {path_len}, must be >= 20")
+                    Error::DeletionVector(format!("Invalid length {path_len}, must be >= 20"))
                 );
                 let prefix_len = path_len - 20;
                 let decoded = z85::decode(&self.path_or_inline_dv[prefix_len..])

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -190,8 +190,8 @@ impl Protocol {
     pub(crate) fn try_new(
         min_reader_version: i32,
         min_writer_version: i32,
-        reader_features: Option<impl IntoIterator<Item = impl Into<String>>>,
-        writer_features: Option<impl IntoIterator<Item = impl Into<String>>>,
+        reader_features: Option<impl IntoIterator<Item = impl ToString>>,
+        writer_features: Option<impl IntoIterator<Item = impl ToString>>,
     ) -> DeltaResult<Self> {
         if min_reader_version == 3 {
             require!(
@@ -211,14 +211,18 @@ impl Protocol {
         }
 
         fn parse_features<T>(
-            features: Option<impl IntoIterator<Item = impl Into<String>>>,
+            features: Option<impl IntoIterator<Item = impl ToString>>,
         ) -> Result<Option<Vec<T>>, Error>
         where
             T: FromStr,
             T::Err: Display,
         {
             features
-                .map(|fs| fs.into_iter().map(|f| T::from_str(&f.into())).collect())
+                .map(|fs| {
+                    fs.into_iter()
+                        .map(|f| T::from_str(&f.to_string()))
+                        .collect()
+                })
                 .transpose()
                 .map_err(|e| {
                     Error::InvalidProtocol(format!("Failed to parse protocol features: {e}"))

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -1,7 +1,6 @@
 //! Provides parsing and manipulation of the various actions defined in the [Delta
 //! specification](https://github.com/delta-io/delta/blob/master/PROTOCOL.md)
 
-use std::any::type_name;
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
@@ -178,11 +177,11 @@ pub(crate) struct Protocol {
     /// A collection of features that a client must implement in order to correctly
     /// read this table (exist only when minReaderVersion is set to 3)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) reader_features: Option<Vec<String>>,
+    reader_features: Option<Vec<ReaderFeature>>,
     /// A collection of features that a client must implement in order to correctly
     /// write this table (exist only when minWriterVersion is set to 7)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) writer_features: Option<Vec<String>>,
+    writer_features: Option<Vec<WriterFeature>>,
 }
 
 impl Protocol {
@@ -210,8 +209,25 @@ impl Protocol {
                 )
             );
         }
-        let reader_features = reader_features.map(|f| f.into_iter().map(Into::into).collect());
-        let writer_features = writer_features.map(|f| f.into_iter().map(Into::into).collect());
+
+        fn parse_features<T>(
+            features: Option<impl IntoIterator<Item = impl Into<String>>>,
+        ) -> Result<Option<Vec<T>>, Error>
+        where
+            T: FromStr,
+            T::Err: Display,
+        {
+            features
+                .map(|fs| fs.into_iter().map(|f| T::from_str(&f.into())).collect())
+                .transpose()
+                .map_err(|e| {
+                    Error::InvalidProtocol(format!("Failed to parse protocol features: {e}"))
+                })
+        }
+
+        let reader_features = parse_features(reader_features)?;
+        let writer_features = parse_features(writer_features)?;
+
         Ok(Protocol {
             min_reader_version,
             min_writer_version,
@@ -241,25 +257,25 @@ impl Protocol {
     }
 
     /// Get the reader features for the protocol
-    pub(crate) fn reader_features(&self) -> Option<&[String]> {
+    pub(crate) fn reader_features(&self) -> Option<&[ReaderFeature]> {
         self.reader_features.as_deref()
     }
 
     /// Get the writer features for the protocol
-    pub(crate) fn writer_features(&self) -> Option<&[String]> {
+    pub(crate) fn writer_features(&self) -> Option<&[WriterFeature]> {
         self.writer_features.as_deref()
     }
 
     /// True if this protocol has the requested reader feature
     pub(crate) fn has_reader_feature(&self, feature: &ReaderFeature) -> bool {
         self.reader_features()
-            .is_some_and(|features| features.iter().any(|f| f == feature.as_ref()))
+            .is_some_and(|features| features.contains(feature))
     }
 
     /// True if this protocol has the requested writer feature
     pub(crate) fn has_writer_feature(&self, feature: &WriterFeature) -> bool {
         self.writer_features()
-            .is_some_and(|features| features.iter().any(|f| f == feature.as_ref()))
+            .is_some_and(|features| features.contains(feature))
     }
 
     /// Check if reading a table with this protocol is supported. That is: does the kernel support
@@ -321,42 +337,47 @@ impl Protocol {
     }
 }
 
-// given unparsed `table_features`, parse and check if they are subset of `supported_features`
+// given `table_features`, check if they are subset of `supported_features`
 pub(crate) fn ensure_supported_features<T>(
-    table_features: &[String],
+    table_features: &[T],
     supported_features: &HashSet<T>,
 ) -> DeltaResult<()>
 where
+    T: Display + FromStr + Hash + Eq,
     <T as FromStr>::Err: Display,
-    T: Debug + FromStr + Hash + Eq,
 {
-    let error = |unsupported, unsupported_or_unknown| {
-        let supported = supported_features.iter().collect::<Vec<_>>();
-        let features_type = type_name::<T>()
-            .rsplit("::")
-            .next()
-            .unwrap_or("table features");
-        Error::Unsupported(format!(
-            "{} {} {:?}. Supported {} are {:?}",
-            unsupported_or_unknown, features_type, unsupported, features_type, supported
-        ))
-    };
-    let parsed_features: HashSet<T> = table_features
+    // first check if all features are supported, else we proceed to craft an error message
+    if table_features
         .iter()
-        .map(|s| T::from_str(s).map_err(|_| error(vec![s.to_string()], "Unknown")))
-        .collect::<Result<_, Error>>()?;
+        .all(|feature| supported_features.contains(feature))
+    {
+        return Ok(());
+    }
 
-    // check that parsed features are a subset of supported features
-    parsed_features
-        .is_subset(supported_features)
-        .then_some(())
-        .ok_or_else(|| {
-            let unsupported = parsed_features
-                .difference(supported_features)
-                .map(|f| format!("{:?}", f))
-                .collect::<Vec<_>>();
-            error(unsupported, "Unsupported")
-        })
+    // we get the type name (ReaderFeature/WriterFeature) for better error messages
+    let features_type = std::any::type_name::<T>()
+        .rsplit("::")
+        .next()
+        .unwrap_or("table features");
+
+    // NB: we didn't do this above to avoid allocation in the common case
+    let unsupported: Vec<_> = table_features
+        .iter()
+        .filter(|feature| !supported_features.contains(*feature))
+        .map(|feature| feature.to_string())
+        .collect();
+    let supported: Vec<_> = supported_features
+        .iter()
+        .map(|feature| feature.to_string())
+        .collect();
+
+    Err(Error::Unsupported(format!(
+        "Unknown {} \"{}\". Supported {}s are \"{}\"",
+        features_type,
+        unsupported.join("\", \""),
+        features_type,
+        supported.join("\", \""),
+    )))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Schema)]
@@ -975,20 +996,23 @@ mod tests {
         let supported_features = [ReaderFeature::ColumnMapping, ReaderFeature::DeletionVectors]
             .into_iter()
             .collect();
-        let table_features = vec![ReaderFeature::ColumnMapping.to_string()];
+        let table_features = vec![ReaderFeature::ColumnMapping];
         ensure_supported_features(&table_features, &supported_features).unwrap();
 
         // test unknown features
-        let table_features = vec![ReaderFeature::ColumnMapping.to_string(), "idk".to_string()];
+        let table_features = vec![
+            ReaderFeature::ColumnMapping,
+            ReaderFeature::Unknown("idk".to_string()),
+        ];
         let error = ensure_supported_features(&table_features, &supported_features).unwrap_err();
         match error {
             Error::Unsupported(e) if e ==
-                "Unknown ReaderFeature [\"idk\"]. Supported ReaderFeature are [ColumnMapping, DeletionVectors]"
+                "Unknown ReaderFeature \"idk\". Supported ReaderFeatures are \"columnMapping\", \"deletionVectors\""
             => {},
             Error::Unsupported(e) if e ==
-                "Unknown ReaderFeature [\"idk\"]. Supported ReaderFeature are [DeletionVectors, ColumnMapping]"
+                "Unknown ReaderFeature \"idk\". Supported ReaderFeatures are \"deletionVectors\", \"columnMapping\""
             => {},
-            _ => panic!("Expected unsupported error"),
+            _ => panic!("Expected unsupported error, got: {error}"),
         }
     }
 }

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -20,6 +20,7 @@ use url::Url;
 use visitors::{MetadataVisitor, ProtocolVisitor};
 
 use delta_kernel_derive::Schema;
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
 pub mod deletion_vector;
@@ -366,21 +367,16 @@ where
         .filter(|feature| !supported_features.contains(*feature))
         .map(|feature| feature.to_string())
         .collect();
-    let mut supported: Vec<_> = supported_features
-        .iter()
-        .map(|feature| feature.to_string())
-        .collect();
 
-    // sort both vecs for consistent error messages
+    // sort for consistent error messages
     unsupported.sort();
-    supported.sort();
 
     Err(Error::Unsupported(format!(
         "Unknown {}s: \"{}\". Supported {}s: \"{}\"",
         features_type,
         unsupported.join("\", \""),
         features_type,
-        supported.join("\", \""),
+        supported_features.iter().join("\", \""),
     )))
 }
 

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -340,7 +340,7 @@ impl Protocol {
 // given `table_features`, check if they are subset of `supported_features`
 pub(crate) fn ensure_supported_features<T>(
     table_features: &[T],
-    supported_features: &Vec<T>,
+    supported_features: &[T],
 ) -> DeltaResult<()>
 where
     T: Display + FromStr + Hash + Eq,
@@ -997,9 +997,7 @@ mod tests {
 
     #[test]
     fn test_ensure_supported_features() {
-        let supported_features = [ReaderFeature::ColumnMapping, ReaderFeature::DeletionVectors]
-            .into_iter()
-            .collect();
+        let supported_features = [ReaderFeature::ColumnMapping, ReaderFeature::DeletionVectors];
         let table_features = vec![ReaderFeature::ColumnMapping];
         ensure_supported_features(&table_features, &supported_features).unwrap();
 
@@ -1008,7 +1006,7 @@ mod tests {
         let error = ensure_supported_features(&table_features, &supported_features).unwrap_err();
         match error {
             Error::Unsupported(e) if e ==
-                "Unknown ReaderFeature \"idk\". Supported ReaderFeatures are \"columnMapping\", \"deletionVectors\""
+                "Unknown ReaderFeatures: \"idk\". Supported ReaderFeatures: \"columnMapping\", \"deletionVectors\""
             => {},
             _ => panic!("Expected unsupported error, got: {error}"),
         }

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -362,14 +362,9 @@ where
         .unwrap_or("table feature");
 
     // NB: we didn't do this above to avoid allocation in the common case
-    let mut unsupported: Vec<_> = table_features
+    let mut unsupported = table_features
         .iter()
-        .filter(|feature| !supported_features.contains(*feature))
-        .map(|feature| feature.to_string())
-        .collect();
-
-    // sort for consistent error messages
-    unsupported.sort();
+        .filter(|feature| !supported_features.contains(*feature));
 
     Err(Error::Unsupported(format!(
         "Unknown {}s: \"{}\". Supported {}s: \"{}\"",
@@ -1011,22 +1006,16 @@ mod tests {
     #[test]
     fn test_parse_table_feature_never_fails() {
         // parse a non-str
-        let features = [5];
-        let expected = vec![ReaderFeature::unknown("5")];
-        assert_eq!(
-            parse_features::<ReaderFeature>(features.into()),
-            expected.into()
-        );
+        let features = Some([5]);
+        let expected = Some(vec![ReaderFeature::unknown("5")]);
+        assert_eq!(parse_features::<ReaderFeature>(features), expected);
 
         // weird strs
-        let features = ["", "absurD_)(+13%^⚙️"];
-        let expected = vec![
+        let features = Some(["", "absurD_)(+13%^⚙️"]);
+        let expected = Some(vec![
             ReaderFeature::unknown(""),
             ReaderFeature::unknown("absurD_)(+13%^⚙️"),
-        ];
-        assert_eq!(
-            parse_features::<ReaderFeature>(features.into()),
-            expected.into()
-        );
+        ]);
+        assert_eq!(parse_features::<ReaderFeature>(features), expected);
     }
 }

--- a/kernel/src/actions/visitors.rs
+++ b/kernel/src/actions/visitors.rs
@@ -513,8 +513,10 @@ pub(crate) fn visit_deletion_vector_at<'a>(
 mod tests {
     use super::*;
 
-    use crate::utils::test_utils::action_batch;
-    use crate::{arrow::array::StringArray, utils::test_utils::parse_json_batch};
+    use crate::arrow::array::StringArray;
+
+    use crate::table_features::{ReaderFeature, WriterFeature};
+    use crate::utils::test_utils::{action_batch, parse_json_batch};
 
     #[test]
     fn test_parse_protocol() -> DeltaResult<()> {
@@ -523,8 +525,8 @@ mod tests {
         let expected = Protocol {
             min_reader_version: 3,
             min_writer_version: 7,
-            reader_features: Some(vec!["deletionVectors".into()]),
-            writer_features: Some(vec!["deletionVectors".into()]),
+            reader_features: Some(vec![ReaderFeature::DeletionVectors]),
+            writer_features: Some(vec![WriterFeature::DeletionVectors]),
         };
         assert_eq!(parsed, expected);
         Ok(())

--- a/kernel/src/engine/arrow_data.rs
+++ b/kernel/src/engine/arrow_data.rs
@@ -296,6 +296,7 @@ impl ArrowEngineData {
 mod tests {
     use crate::arrow::array::StringArray;
 
+    use crate::table_features::{ReaderFeature, WriterFeature};
     use crate::utils::test_utils::string_array_to_engine_data;
     use crate::{
         actions::{get_log_schema, Metadata, Protocol},
@@ -337,10 +338,19 @@ mod tests {
         let protocol = Protocol::try_new_from_data(parsed.as_ref())?.unwrap();
         assert_eq!(protocol.min_reader_version(), 3);
         assert_eq!(protocol.min_writer_version(), 7);
-        assert_eq!(protocol.reader_features(), Some(["rw1".into()].as_slice()));
+        assert_eq!(
+            protocol.reader_features(),
+            Some([ReaderFeature::Unknown("rw1".to_string())].as_slice())
+        );
         assert_eq!(
             protocol.writer_features(),
-            Some(["rw1".into(), "w2".into()].as_slice())
+            Some(
+                [
+                    WriterFeature::Unknown("rw1".to_string()),
+                    WriterFeature::Unknown("w2".to_string())
+                ]
+                .as_slice()
+            )
         );
         Ok(())
     }

--- a/kernel/src/engine/arrow_data.rs
+++ b/kernel/src/engine/arrow_data.rs
@@ -340,17 +340,11 @@ mod tests {
         assert_eq!(protocol.min_writer_version(), 7);
         assert_eq!(
             protocol.reader_features(),
-            Some([ReaderFeature::Unknown("rw1".to_string())].as_slice())
+            Some([ReaderFeature::unknown("rw1")].as_slice())
         );
         assert_eq!(
             protocol.writer_features(),
-            Some(
-                [
-                    WriterFeature::Unknown("rw1".to_string()),
-                    WriterFeature::Unknown("w2".to_string())
-                ]
-                .as_slice()
-            )
+            Some([WriterFeature::unknown("rw1"), WriterFeature::unknown("w2")].as_slice())
         );
         Ok(())
     }

--- a/kernel/src/table_changes/mod.rs
+++ b/kernel/src/table_changes/mod.rs
@@ -31,7 +31,6 @@
 //! let table_change_batches = table_changes_scan.execute(engine.clone())?;
 //! # Ok::<(), Error>(())
 //! ```
-use std::collections::HashSet;
 use std::sync::{Arc, LazyLock};
 
 use scan::TableChangesScanBuilder;
@@ -255,8 +254,8 @@ fn check_cdf_table_properties(table_properties: &TableProperties) -> DeltaResult
 /// Ensures that Change Data Feed is supported for a table with this [`Protocol`] .
 /// See the documentation of [`TableChanges`] for more details.
 fn ensure_cdf_read_supported(protocol: &Protocol) -> DeltaResult<()> {
-    static CDF_SUPPORTED_READER_FEATURES: LazyLock<HashSet<ReaderFeature>> =
-        LazyLock::new(|| HashSet::from([ReaderFeature::DeletionVectors]));
+    static CDF_SUPPORTED_READER_FEATURES: LazyLock<Vec<ReaderFeature>> =
+        LazyLock::new(|| Vec::from([ReaderFeature::DeletionVectors]));
     match &protocol.reader_features() {
         // if min_reader_version = 3 and all reader features are subset of supported => OK
         Some(reader_features) if protocol.min_reader_version() == 3 => {

--- a/kernel/src/table_changes/mod.rs
+++ b/kernel/src/table_changes/mod.rs
@@ -255,7 +255,7 @@ fn check_cdf_table_properties(table_properties: &TableProperties) -> DeltaResult
 /// See the documentation of [`TableChanges`] for more details.
 fn ensure_cdf_read_supported(protocol: &Protocol) -> DeltaResult<()> {
     static CDF_SUPPORTED_READER_FEATURES: LazyLock<Vec<ReaderFeature>> =
-        LazyLock::new(|| Vec::from([ReaderFeature::DeletionVectors]));
+        LazyLock::new(|| vec![ReaderFeature::DeletionVectors]);
     match &protocol.reader_features() {
         // if min_reader_version = 3 and all reader features are subset of supported => OK
         Some(reader_features) if protocol.min_reader_version() == 3 => {

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -181,7 +181,7 @@ impl TableConfiguration {
     #[cfg_attr(feature = "developer-visibility", visibility::make(pub))]
     pub(crate) fn is_cdf_read_supported(&self) -> bool {
         static CDF_SUPPORTED_READER_FEATURES: LazyLock<Vec<ReaderFeature>> =
-            LazyLock::new(|| Vec::from([ReaderFeature::DeletionVectors]));
+            LazyLock::new(|| vec![ReaderFeature::DeletionVectors]);
         let protocol_supported = match self.protocol.reader_features() {
             // if min_reader_version = 3 and all reader features are subset of supported => OK
             Some(reader_features) if self.protocol.min_reader_version() == 3 => {

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -8,7 +8,6 @@
 //! [`TableProperties`].
 //!
 //! [`Schema`]: crate::schema::Schema
-use std::collections::HashSet;
 use std::sync::{Arc, LazyLock};
 
 use url::Url;
@@ -181,8 +180,8 @@ impl TableConfiguration {
     /// [`TableChanges`]: crate::table_changes::TableChanges
     #[cfg_attr(feature = "developer-visibility", visibility::make(pub))]
     pub(crate) fn is_cdf_read_supported(&self) -> bool {
-        static CDF_SUPPORTED_READER_FEATURES: LazyLock<HashSet<ReaderFeature>> =
-            LazyLock::new(|| HashSet::from([ReaderFeature::DeletionVectors]));
+        static CDF_SUPPORTED_READER_FEATURES: LazyLock<Vec<ReaderFeature>> =
+            LazyLock::new(|| Vec::from([ReaderFeature::DeletionVectors]));
         let protocol_supported = match self.protocol.reader_features() {
             // if min_reader_version = 3 and all reader features are subset of supported => OK
             Some(reader_features) if self.protocol.min_reader_version() == 3 => {

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -53,7 +53,6 @@ pub enum ReaderFeature {
     VacuumProtocolCheck,
     #[serde(untagged)]
     #[strum(default)]
-    #[strum(to_string = "{0}")]
     Unknown(String),
 }
 
@@ -118,7 +117,6 @@ pub enum WriterFeature {
     VacuumProtocolCheck,
     #[serde(untagged)]
     #[strum(default)]
-    #[strum(to_string = "{0}")]
     Unknown(String),
 }
 

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -146,7 +146,7 @@ impl WriterFeature {
 }
 
 pub(crate) static SUPPORTED_READER_FEATURES: LazyLock<Vec<ReaderFeature>> = LazyLock::new(|| {
-    Vec::from([
+    vec![
         ReaderFeature::ColumnMapping,
         ReaderFeature::DeletionVectors,
         ReaderFeature::TimestampWithoutTimezone,
@@ -154,18 +154,18 @@ pub(crate) static SUPPORTED_READER_FEATURES: LazyLock<Vec<ReaderFeature>> = Lazy
         ReaderFeature::TypeWideningPreview,
         ReaderFeature::VacuumProtocolCheck,
         ReaderFeature::V2Checkpoint,
-    ])
+    ]
 });
 
 // note: we 'support' Invariants, but only insofar as we check that they are not present.
 // we support writing to tables that have Invariants enabled but not used. similarly, we only
 // support DeletionVectors in that we never write them (no DML).
 pub(crate) static SUPPORTED_WRITER_FEATURES: LazyLock<Vec<WriterFeature>> = LazyLock::new(|| {
-    Vec::from([
+    vec![
         WriterFeature::AppendOnly,
         WriterFeature::DeletionVectors,
         WriterFeature::Invariants,
-    ])
+    ]
 });
 
 #[cfg(test)]

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -122,18 +122,6 @@ pub enum WriterFeature {
     Unknown(String),
 }
 
-impl From<ReaderFeature> for String {
-    fn from(feature: ReaderFeature) -> Self {
-        feature.to_string()
-    }
-}
-
-impl From<WriterFeature> for String {
-    fn from(feature: WriterFeature) -> Self {
-        feature.to_string()
-    }
-}
-
 impl ToDataType for ReaderFeature {
     fn to_data_type() -> DataType {
         DataType::STRING


### PR DESCRIPTION
## What changes are proposed in this pull request?
Instead of `Protocol` retaining a list of `Strings` representing lists of `ReaderFeature`/`WriterFeature`, we move to embed the fully parsed `ReaderFeature`s and `WriterFeature`s. This changes `Protocol.reader_features` and `Protocol.writer_features` fields from`Option<Vec<String>>` to Optional vecs of `ReaderFeatures` and `WriterFeatures` respectively. Critically, this includes a new `Unknown` variant which allows us to parse all possible strings in the protocol into `ReaderFeature`s and `WriterFeature`s but later detect if unknown features are present and fail when ensuring reader/writer features are supported. 

### This PR affects the following public APIs
Breaking: new `ReaderFeature::Unknown(String)` and `WriterFeature::Unknown(String)` variants

(note that `Protocol` and fields are `pub(crate)`)

## How was this change tested?
UT modification