### PR TITLE
feat!(ffi): Make get_partition_column* work on a snapshot.

### DIFF
--- a/ffi/examples/read-table/read_table.c
+++ b/ffi/examples/read-table/read_table.c
@@ -112,15 +112,15 @@ void visit_partition(void* context, const KernelStringSlice partition)
 }
 
 // Build a list of partition column names.
-PartitionList* get_partition_list(SharedSnapshot* state)
+PartitionList* get_partition_list(SharedSnapshot* snapshot)
 {
   print_diag("Building list of partition columns\n");
-  uintptr_t count = get_partition_column_count(state);
+  uintptr_t count = get_partition_column_count(snapshot);
   PartitionList* list = malloc(sizeof(PartitionList));
   // We set the `len` to 0 here and use it to track how many items we've added to the list
   list->len = 0;
   list->cols = malloc(sizeof(char*) * count);
-  StringSliceIterator* part_iter = get_partition_columns(state);
+  StringSliceIterator* part_iter = get_partition_columns(snapshot);
   for (;;) {
     bool has_next = string_slice_next(part_iter, list, visit_partition);
     if (!has_next) {

--- a/ffi/examples/read-table/read_table.c
+++ b/ffi/examples/read-table/read_table.c
@@ -112,7 +112,7 @@ void visit_partition(void* context, const KernelStringSlice partition)
 }
 
 // Build a list of partition column names.
-PartitionList* get_partition_list(SharedGlobalScanState* state)
+PartitionList* get_partition_list(SharedSnapshot* state)
 {
   print_diag("Building list of partition columns\n");
   uintptr_t count = get_partition_column_count(state);
@@ -263,6 +263,8 @@ int main(int argc, char* argv[])
   char* table_root = snapshot_table_root(snapshot, allocate_string);
   print_diag("Table root: %s\n", table_root);
 
+  PartitionList* partition_cols = get_partition_list(snapshot);
+
   print_diag("Starting table scan\n\n");
 
   ExternResultHandleSharedScan scan_res = scan(snapshot, engine, NULL);
@@ -274,7 +276,6 @@ int main(int argc, char* argv[])
   SharedScan* scan = scan_res.ok;
   SharedGlobalScanState* global_state = get_global_scan_state(scan);
   SharedSchema* read_schema = get_global_read_schema(global_state);
-  PartitionList* partition_cols = get_partition_list(global_state);
   struct EngineContext context = {
     global_state,
     read_schema,

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -612,7 +612,7 @@ pub unsafe extern "C" fn version(snapshot: Handle<SharedSnapshot>) -> u64 {
 ///
 /// # Safety
 ///
-/// Caller is responsible for passing a valid handle.
+/// Caller is responsible for passing a valid snapshot handle.
 #[no_mangle]
 pub unsafe extern "C" fn snapshot_table_root(
     snapshot: Handle<SharedSnapshot>,
@@ -633,10 +633,10 @@ pub unsafe extern "C" fn get_partition_column_count(snapshot: Handle<SharedSnaps
     snapshot.metadata().partition_columns.len()
 }
 
-/// Get an iterator of the list of partition columns for this scan.
+/// Get an iterator of the list of partition columns for this snapshot.
 ///
 /// # Safety
-/// Caller is responsible for passing a valid global scan pointer.
+/// Caller is responsible for passing a valid snapshot handle.
 #[no_mangle]
 pub unsafe extern "C" fn get_partition_columns(
     snapshot: Handle<SharedSnapshot>,

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -623,6 +623,29 @@ pub unsafe extern "C" fn snapshot_table_root(
     allocate_fn(kernel_string_slice!(table_root))
 }
 
+/// Get a count of the number of partition columns for this snapshot
+///
+/// # Safety
+/// Caller is responsible for passing a valid snapshot handle
+#[no_mangle]
+pub unsafe extern "C" fn get_partition_column_count(snapshot: Handle<SharedSnapshot>) -> usize {
+    let snapshot = unsafe { snapshot.as_ref() };
+    snapshot.metadata().partition_columns.len()
+}
+
+/// Get an iterator of the list of partition columns for this scan.
+///
+/// # Safety
+/// Caller is responsible for passing a valid global scan pointer.
+#[no_mangle]
+pub unsafe extern "C" fn get_partition_columns(
+    snapshot: Handle<SharedSnapshot>,
+) -> Handle<StringSliceIterator> {
+    let snapshot = unsafe { snapshot.as_ref() };
+    let iter: Box<StringIter> = Box::new(snapshot.metadata().partition_columns.clone().into_iter());
+    iter.into()
+}
+
 type StringIter = dyn Iterator<Item = String> + Send;
 
 #[handle_descriptor(target=StringIter, mutable=true, sized=false)]
@@ -719,7 +742,7 @@ impl<T> Default for ReferenceSet<T> {
 mod tests {
     use delta_kernel::engine::default::{executor::tokio::TokioBackgroundExecutor, DefaultEngine};
     use object_store::{memory::InMemory, path::Path};
-    use test_utils::{actions_to_string, add_commit, TestAction};
+    use test_utils::{actions_to_string, actions_to_string_partitioned, add_commit, TestAction};
 
     use super::*;
     use crate::error::{EngineError, KernelError};
@@ -811,6 +834,46 @@ mod tests {
         let s = recover_string(table_root.unwrap());
         assert_eq!(&s, path);
 
+        unsafe { free_snapshot(snapshot) }
+        unsafe { free_engine(engine) }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_snapshot_partition_cols() -> Result<(), Box<dyn std::error::Error>> {
+        let storage = Arc::new(InMemory::new());
+        add_commit(
+            storage.as_ref(),
+            0,
+            actions_to_string_partitioned(vec![TestAction::Metadata]),
+        )
+        .await?;
+        let engine = DefaultEngine::new(
+            storage.clone(),
+            Path::from("/"),
+            Arc::new(TokioBackgroundExecutor::new()),
+        );
+        let engine = engine_to_handle(Arc::new(engine), allocate_err);
+        let path = "memory:///";
+
+        let snapshot =
+            unsafe { ok_or_panic(snapshot(kernel_string_slice!(path), engine.shallow_copy())) };
+
+        let partition_count = unsafe { get_partition_column_count(snapshot.shallow_copy()) };
+        assert_eq!(partition_count, 1, "Should have one partition");
+
+        let partition_iter = unsafe { get_partition_columns(snapshot.shallow_copy()) };
+
+        #[no_mangle]
+        extern "C" fn visit_partition(_context: NullableCvoid, slice: KernelStringSlice) {
+            let s = unsafe { String::try_from_slice(&slice) }.unwrap();
+            assert_eq!(s.as_str(), "val", "Partition col should be 'val'");
+        }
+        while unsafe { string_slice_next(partition_iter.shallow_copy(), None, visit_partition) } {
+            // validate happens inside visit_partition
+        }
+
+        unsafe { free_string_slice_data(partition_iter) }
         unsafe { free_snapshot(snapshot) }
         unsafe { free_engine(engine) }
         Ok(())

--- a/ffi/src/scan.rs
+++ b/ffi/src/scan.rs
@@ -113,7 +113,9 @@ pub unsafe extern "C" fn free_global_read_schema(schema: Handle<SharedSchema>) {
 /// # Safety
 /// Caller is responsible for passing a valid global scan pointer.
 #[no_mangle]
-pub unsafe extern "C" fn get_partition_column_count(state: Handle<SharedGlobalScanState>) -> usize {
+pub unsafe extern "C" fn get_scan_partition_column_count(
+    state: Handle<SharedGlobalScanState>,
+) -> usize {
     let state = unsafe { state.as_ref() };
     state.partition_columns.len()
 }
@@ -123,7 +125,7 @@ pub unsafe extern "C" fn get_partition_column_count(state: Handle<SharedGlobalSc
 /// # Safety
 /// Caller is responsible for passing a valid global scan pointer.
 #[no_mangle]
-pub unsafe extern "C" fn get_partition_columns(
+pub unsafe extern "C" fn get_scan_partition_columns(
     state: Handle<SharedGlobalScanState>,
 ) -> Handle<StringSliceIterator> {
     let state = unsafe { state.as_ref() };

--- a/ffi/src/scan.rs
+++ b/ffi/src/scan.rs
@@ -18,7 +18,7 @@ use crate::expressions::engine::{
 use crate::{
     kernel_string_slice, AllocateStringFn, ExclusiveEngineData, ExternEngine, ExternResult,
     IntoExternResult, KernelBoolSlice, KernelRowIndexArray, KernelStringSlice, NullableCvoid,
-    SharedExternEngine, SharedSnapshot, StringIter, StringSliceIterator, TryFromStringSlice,
+    SharedExternEngine, SharedSnapshot, TryFromStringSlice,
 };
 
 use super::handle::Handle;
@@ -106,31 +106,6 @@ pub unsafe extern "C" fn get_global_read_schema(
 #[no_mangle]
 pub unsafe extern "C" fn free_global_read_schema(schema: Handle<SharedSchema>) {
     schema.drop_handle();
-}
-
-/// Get a count of the number of partition columns for this scan
-///
-/// # Safety
-/// Caller is responsible for passing a valid global scan pointer.
-#[no_mangle]
-pub unsafe extern "C" fn get_scan_partition_column_count(
-    state: Handle<SharedGlobalScanState>,
-) -> usize {
-    let state = unsafe { state.as_ref() };
-    state.partition_columns.len()
-}
-
-/// Get an iterator of the list of partition columns for this scan.
-///
-/// # Safety
-/// Caller is responsible for passing a valid global scan pointer.
-#[no_mangle]
-pub unsafe extern "C" fn get_scan_partition_columns(
-    state: Handle<SharedGlobalScanState>,
-) -> Handle<StringSliceIterator> {
-    let state = unsafe { state.as_ref() };
-    let iter: Box<StringIter> = Box::new(state.partition_columns.clone().into_iter());
-    iter.into()
 }
 
 /// # Safety

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -16,22 +16,38 @@ pub const METADATA: &str = r#"{"commitInfo":{"timestamp":1587968586154,"operatio
 {"protocol":{"minReaderVersion":1,"minWriterVersion":2}}
 {"metaData":{"id":"5fba94ed-9794-4965-ba6e-6ee3c0d22af9","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"id\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}},{\"name\":\"val\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{},"createdTime":1587968585495}}"#;
 
+/// A common useful initial metadata and protocol. Also includes a single commitInfo
+pub const METADATA_WITH_PARTITION_COLS: &str = r#"{"commitInfo":{"timestamp":1587968586154,"operation":"WRITE","operationParameters":{"mode":"ErrorIfExists","partitionBy":"[]"},"isBlindAppend":true}}
+{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}
+{"metaData":{"id":"5fba94ed-9794-4965-ba6e-6ee3c0d22af9","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"id\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}},{\"name\":\"val\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":["val"],"configuration":{},"createdTime":1587968585495}}"#;
+
 pub enum TestAction {
     Add(String),
     Remove(String),
     Metadata,
 }
 
-/// Convert a vector of actions into a newline delimited json string
+// TODO: We need a better way to mock tables :)
+
+/// Convert a vector of actions into a newline delimited json string, with standard metadata
 pub fn actions_to_string(actions: Vec<TestAction>) -> String {
+    actions_to_string_with_metadata(actions, METADATA)
+}
+
+/// Convert a vector of actions into a newline delimited json string, with metadata including a partition column
+pub fn actions_to_string_partitioned(actions: Vec<TestAction>) -> String {
+    actions_to_string_with_metadata(actions, METADATA_WITH_PARTITION_COLS)
+}
+
+fn actions_to_string_with_metadata(actions: Vec<TestAction>, metadata: &str) -> String {
     actions
-            .into_iter()
-            .map(|test_action| match test_action {
-                TestAction::Add(path) => format!(r#"{{"add":{{"path":"{path}","partitionValues":{{}},"size":262,"modificationTime":1587968586000,"dataChange":true, "stats":"{{\"numRecords\":2,\"nullCount\":{{\"id\":0}},\"minValues\":{{\"id\": 1}},\"maxValues\":{{\"id\":3}}}}"}}}}"#),
-                TestAction::Remove(path) => format!(r#"{{"remove":{{"path":"{path}","partitionValues":{{}},"size":262,"modificationTime":1587968586000,"dataChange":true}}}}"#),
-                TestAction::Metadata => METADATA.into(),
-            })
-            .join("\n")
+        .into_iter()
+        .map(|test_action| match test_action {
+            TestAction::Add(path) => format!(r#"{{"add":{{"path":"{path}","partitionValues":{{}},"size":262,"modificationTime":1587968586000,"dataChange":true, "stats":"{{\"numRecords\":2,\"nullCount\":{{\"id\":0}},\"minValues\":{{\"id\": 1}},\"maxValues\":{{\"id\":3}}}}"}}}}"#),
+            TestAction::Remove(path) => format!(r#"{{"remove":{{"path":"{path}","partitionValues":{{}},"size":262,"modificationTime":1587968586000,"dataChange":true}}}}"#),
+            TestAction::Metadata => metadata.into(),
+        })
+        .join("\n")
 }
 
 /// convert a RecordBatch into a vector of bytes. We can't use `From` since these are both foreign


### PR DESCRIPTION
## What changes are proposed in this pull request?

Make `get_partition_column_count` and `get_partition_columns` take a snapshot so engines can work this out at planning time without creating a scan.

The previous methods to get this info out of a scan have been removed.

### This PR affects the following public APIs

The old functions that took snapshots have been removed

## How was this change tested?

New unit test