### PR TITLE
Support --all-features again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
           cargo install cargo-msrv --locked
       - name: verify-msrv
         run: |
-          cargo msrv --path kernel/ verify --features $(cat .github/workflows/default-kernel-features)
+          cargo msrv --path kernel/ verify --all-features
           cargo msrv --path derive-macros/ verify --all-features
           cargo msrv --path ffi/ verify --all-features
           cargo msrv --path ffi-proc-macros/ verify --all-features
@@ -104,7 +104,7 @@ jobs:
       - name: check kernel builds with no-default-features
         run: cargo build -p delta_kernel --no-default-features
       - name: build and lint with clippy
-        run: cargo clippy --benches --tests --features $(cat .github/workflows/default-kernel-features) -- -D warnings
+        run: cargo clippy --benches --tests --all-features -- -D warnings
       - name: lint without default features
         run: cargo clippy --no-default-features -- -D warnings
       - name: check kernel builds with default-engine
@@ -129,7 +129,7 @@ jobs:
           override: true
       - uses: Swatinem/rust-cache@v2
       - name: test
-        run: cargo test --workspace --verbose --features $(cat .github/workflows/default-kernel-features) -- --skip read_table_version_hdfs
+        run: cargo test --workspace --verbose --all-features -- --skip read_table_version_hdfs
 
   ffi_test:
     runs-on: ${{ matrix.os }}
@@ -229,7 +229,7 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
       - uses: Swatinem/rust-cache@v2
       - name: Generate code coverage
-        run: cargo llvm-cov --features $(cat .github/workflows/default-kernel-features) --workspace --codecov --output-path codecov.json -- --skip read_table_version_hdfs
+        run: cargo llvm-cov --all-features --workspace --codecov --output-path codecov.json -- --skip read_table_version_hdfs
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/default-kernel-features
+++ b/.github/workflows/default-kernel-features
@@ -1,1 +1,0 @@
-integration-test,default-engine,default-engine-rustls,cloud,arrow,sync-engine

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -40,7 +40,7 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          cargo semver-checks --features $(cat .github/workflows/default-kernel-features) --baseline-rev ${{ github.event.pull_request.base.sha }}
+          cargo semver-checks --all-features --baseline-rev ${{ github.event.pull_request.base.sha }}
       - name: On Failure
         id: set_failure
         if: ${{ steps.check.outcome == 'failure' }}

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -40,7 +40,7 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          cargo semver-checks --all-features --baseline-rev ${{ github.event.pull_request.base.sha }}
+          cargo semver-checks --features $(cat .github/workflows/default-kernel-features) --baseline-rev ${{ github.event.pull_request.base.sha }}
       - name: On Failure
         id: set_failure
         if: ${{ steps.check.outcome == 'failure' }}

--- a/README.md
+++ b/README.md
@@ -74,32 +74,15 @@ quickly. To enable engines that already integrate arrow to also integrate kernel
 to track a specific version of arrow that kernel depends on, we take as broad dependency on arrow
 versions as we can.
 
-This means you can force kernel to rely on the specific arrow version that your engine already uses,
-as long as it falls in that range. You can see the range in the `Cargo.toml` in the same folder as
-this `README.md`.
+We allow selecting the version of arrow to use via feature flags. Currently we support the following
+flags:
 
-For example, although arrow 53.1.0 has been released, you can force kernel to compile on 53.0 by
-putting the following in your project's `Cargo.toml`:
+- `arrow_53`: Use arrow version 53
+- `arrow_54`: Use arrow version 54
 
-```toml
-[patch.crates-io]
-arrow = "53.0"
-arrow-arith = "53.0"
-arrow-array = "53.0"
-arrow-buffer = "53.0"
-arrow-cast = "53.0"
-arrow-data = "53.0"
-arrow-ord = "53.0"
-arrow-json = "53.0"
-arrow-select = "53.0"
-arrow-schema = "53.0"
-parquet = "53.0"
-```
-
-Note that unfortunately patching in `cargo` requires that _exactly one_ version matches your
-specification. If only arrow "53.0.0" had been released the above will work, but if "53.0.1" where
-to be released, the specification will break and you will need to provide a more restrictive
-specification like `"=53.0.0"`.
+Note that if more than one `arrow_x` feature is enabled, kernel will default to the _lowest_
+specified flag. This also means that if you use `--all-features` you will get the lowest version of
+arrow that kernel supports.
 
 ### Object Store
 You may also need to patch the `object_store` version used if the version of `parquet` you depend on

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ Note that if more than one `arrow_x` feature is enabled, kernel will default to 
 specified flag. This also means that if you use `--all-features` you will get the lowest version of
 arrow that kernel supports.
 
+If no arrow feature is enabled, but are least one of `default-engine`, `sync-engine`,
+`arrow-conversion` or, `arrow-expression` is enabled, the lowest supported arrow version will be
+enabled.
+
 ### Object Store
 You may also need to patch the `object_store` version used if the version of `parquet` you depend on
 depends on a different version of `object_store`. This can be done by including `object_store` in

--- a/integration-tests/test-all-arrow-versions.sh
+++ b/integration-tests/test-all-arrow-versions.sh
@@ -8,8 +8,16 @@ test_arrow_version() {
   cargo clean
   rm -f Cargo.lock
   cargo update
+  echo "Cargo.toml is:"
   cat Cargo.toml
-  cargo run --features ${ARROW_VERSION}
+  echo ""
+  if [ "$ARROW_VERSION" = "ALL_ENABLED" ]; then
+    echo "testing with --all-features"
+    cargo run --all-features
+  else
+    echo "testing with --features ${ARROW_VERSION}"
+    cargo run --features ${ARROW_VERSION}
+  fi
 }
 
 FEATURES=$(cat ../kernel/Cargo.toml | grep -e ^arrow_ | awk '{ print $1 }' | sort -u)
@@ -23,4 +31,7 @@ do
   test_arrow_version $ARROW_VERSION
 done
 
-git checkout Cargo.toml
+test_arrow_version "ALL_ENABLED"
+
+git checkout HEAD Cargo.toml
+

--- a/integration-tests/test-all-arrow-versions.sh
+++ b/integration-tests/test-all-arrow-versions.sh
@@ -2,6 +2,15 @@
 
 set -eu -o pipefail
 
+clean_up () {
+  CODE=$?
+  git checkout HEAD Cargo.toml
+  exit $CODE
+}
+
+# ensure we checkout the clean version of Cargo.toml no matter how we exit
+trap clean_up EXIT
+
 test_arrow_version() {
   ARROW_VERSION="$1"
   echo "== Testing version $ARROW_VERSION =="
@@ -32,6 +41,4 @@ do
 done
 
 test_arrow_version "ALL_ENABLED"
-
-git checkout HEAD Cargo.toml
 

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -94,8 +94,9 @@ arrow_53 = ["dep:arrow_53", "dep:parquet_53"]
 
 arrow_54 = ["dep:arrow_54", "dep:parquet_54"]
 
-arrow-conversion = []
-arrow-expression = []
+need_arrow = []
+arrow-conversion = ["need_arrow"]
+arrow-expression = ["need_arrow"]
 
 cloud = [
   "object_store/aws",
@@ -112,6 +113,7 @@ default-engine-base = [
   "arrow-conversion",
   "arrow-expression",
   "futures",
+  "need_arrow",
   "object_store",
   "tokio",
   "uuid/v4",
@@ -130,6 +132,7 @@ default-engine-rustls = [
 
 developer-visibility = []
 sync-engine = [
+  "need_arrow",
   "tempfile",
 ]
 integration-test = [

--- a/kernel/src/arrow.rs
+++ b/kernel/src/arrow.rs
@@ -2,10 +2,10 @@
 //! parts of kernel that need arrow
 
 #[cfg(all(feature = "arrow_53", feature = "arrow_54"))]
-compile_error!("Multiple versions of the arrow cannot be used at the same time!");
-
-#[cfg(feature = "arrow_53")]
 pub use arrow_53::*;
 
-#[cfg(feature = "arrow_54")]
+#[cfg(all(feature = "arrow_53", not(feature = "arrow_54")))]
+pub use arrow_53::*;
+
+#[cfg(all(feature = "arrow_54", not(feature = "arrow_53")))]
 pub use arrow_54::*;

--- a/kernel/src/arrow.rs
+++ b/kernel/src/arrow.rs
@@ -6,3 +6,12 @@ pub use arrow_53::*;
 
 #[cfg(all(feature = "arrow_54", not(feature = "arrow_53")))]
 pub use arrow_54::*;
+
+// if nothing is enabled but we need arrow because of some other feature flag, default to lowest
+// supported version
+#[cfg(all(
+    feature = "need_arrow",
+    not(feature = "arrow_53"),
+    not(feature = "arrow_54")
+))]
+pub use arrow_53::*;

--- a/kernel/src/arrow.rs
+++ b/kernel/src/arrow.rs
@@ -1,10 +1,7 @@
 //! This module exists to help re-export the version of arrow used by default-engine and other
 //! parts of kernel that need arrow
 
-#[cfg(all(feature = "arrow_53", feature = "arrow_54"))]
-pub use arrow_53::*;
-
-#[cfg(all(feature = "arrow_53", not(feature = "arrow_54")))]
+#[cfg(feature = "arrow_53")]
 pub use arrow_53::*;
 
 #[cfg(all(feature = "arrow_54", not(feature = "arrow_53")))]

--- a/kernel/src/parquet.rs
+++ b/kernel/src/parquet.rs
@@ -1,10 +1,7 @@
 //! This module exists to help re-export the version of arrow used by default-engine and other
 //! parts of kernel that need arrow
 
-#[cfg(all(feature = "arrow_53", feature = "arrow_54"))]
-pub use parquet_53::*;
-
-#[cfg(all(feature = "arrow_53", not(feature = "arrow_54")))]
+#[cfg(feature = "arrow_53")]
 pub use parquet_53::*;
 
 #[cfg(all(feature = "arrow_54", not(feature = "arrow_53")))]

--- a/kernel/src/parquet.rs
+++ b/kernel/src/parquet.rs
@@ -2,10 +2,10 @@
 //! parts of kernel that need arrow
 
 #[cfg(all(feature = "arrow_53", feature = "arrow_54"))]
-compile_error!("Multiple versions of the arrow cannot be used at the same time!");
-
-#[cfg(feature = "arrow_53")]
 pub use parquet_53::*;
 
-#[cfg(feature = "arrow_54")]
+#[cfg(all(feature = "arrow_53", not(feature = "arrow_54")))]
+pub use parquet_53::*;
+
+#[cfg(all(feature = "arrow_54", not(feature = "arrow_53")))]
 pub use parquet_54::*;

--- a/kernel/src/parquet.rs
+++ b/kernel/src/parquet.rs
@@ -6,3 +6,12 @@ pub use parquet_53::*;
 
 #[cfg(all(feature = "arrow_54", not(feature = "arrow_53")))]
 pub use parquet_54::*;
+
+// if nothing is enabled but we need arrow because of some other feature flag, default to lowest
+// supported version
+#[cfg(all(
+    feature = "need_arrow",
+    not(feature = "arrow_53"),
+    not(feature = "arrow_54")
+))]
+pub use parquet_53::*;


### PR DESCRIPTION
## What changes are proposed in this pull request?

If both arrow_53 and arrow_54 are specified, just use arrow_53

Also update the README for the new situation.

I'd like to emit a warning if more than one feature is enabled, but there is no `compiler_warning!`. See [here](https://internals.rust-lang.org/t/pre-rfc-add-compile-warning-macro/9370) for some discussion. If reviewers feel the `must_use` hack would be worth it, I can add it.