### PR TITLE
fix: Make having `need_arrow` + no arrow a compiler error

### DIFF
--- a/kernel/src/arrow.rs
+++ b/kernel/src/arrow.rs
@@ -14,4 +14,4 @@ pub use arrow_54::*;
     not(feature = "arrow_53"),
     not(feature = "arrow_54")
 ))]
-pub use arrow_53::*;
+compile_error!("Requested a feature that needs arrow without enabling arrow. Please enable the `arrow_53` or `arrow_54` feature");

--- a/kernel/src/parquet.rs
+++ b/kernel/src/parquet.rs
@@ -14,4 +14,4 @@ pub use parquet_54::*;
     not(feature = "arrow_53"),
     not(feature = "arrow_54")
 ))]
-pub use parquet_53::*;
+compile_error!("Requested a feature that needs arrow without enabling arrow. Please enable the `arrow_53` or `arrow_54` feature");

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -12,6 +12,6 @@ version.workspace = true
 release = false
 
 [dependencies]
-delta_kernel = { path = "../kernel", features = [  "default-engine" ] }
+delta_kernel = { path = "../kernel", features = [  "default-engine", "arrow" ] }
 itertools = "0.13.0"
 object_store = { workspace = true }


### PR DESCRIPTION
If we try and have a `need_arrow` flag we can make that include the code line: `pub use arrow_53::*` but we _cannot_ have it actually pull in the dependency. Pulling in the dependency is purely expressed in `Cargo.toml`, so the `use` just fails because we don't _have_ an arrow_53 dependency in that case.

We can do some gross stuff in `build.rs` to inject the dependency, but even that doesn't apply to crates that depend on us so it only works if just compiling `delta-kernel` but isn't actually helpful for the use case we want.

So I kept the `need-arrow` dep as a way for us to express that something needs arrow enabled, but rather than trying to do the import, it just issues a `compile_error` asking you to pick an arrow version.

Perhaps we can get something more clever in the future, but for now let's unblock things.

Also have test-utils depend on the arrow feature