### PR TITLE
pin chrono version to fix arrow compilation failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ keywords = ["deltalake", "delta", "datalake"]
 license = "Apache-2.0"
 repository = "https://github.com/delta-io/delta-kernel-rs"
 readme = "README.md"
-rust-version = "1.80"
+rust-version = "1.81"
 version = "0.7.0"
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ keywords = ["deltalake", "delta", "datalake"]
 license = "Apache-2.0"
 repository = "https://github.com/delta-io/delta-kernel-rs"
 readme = "README.md"
-rust-version = "1.81"
+rust-version = "1.80"
 version = "0.7.0"
 
 [workspace.dependencies]

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -36,7 +36,7 @@ pre-release-hook = [
 
 [dependencies]
 bytes = "1.7"
-chrono = { version = "0.4" }
+chrono = { version = "=0.4.39" }
 fix-hidden-lifetime-bug = "0.2"
 indexmap = "2.5.0"
 itertools = "0.13"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -36,7 +36,7 @@ pre-release-hook = [
 
 [dependencies]
 bytes = "1.7"
-chrono = { version = "=0.4.39" }
+chrono = "=0.4.39"
 fix-hidden-lifetime-bug = "0.2"
 indexmap = "2.5.0"
 itertools = "0.13"


### PR DESCRIPTION
## What changes are proposed in this pull request?
Current chrono 0.4.40 breaks building arrow, pin chrono to a prior version that does not break arrow.

## How was this change tested?
CI/CD