### PR TITLE
fix: MSRV fix by pinning idna_adapter version

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -47,6 +47,10 @@ thiserror = "1"
 # only for structured logging
 tracing = { version = "0.1", features = ["log"] }
 url = "2"
+# force URL to use unicode-rs instead of ICU4X otherwise we require MSRV 1.81
+# from docs: compared to ICU4X, this makes build times faster, MSRV lower, binary size larger, and
+# run-time performance slower.
+idna_adapter = "=1.1.0"
 uuid = "1.10.0"
 z85 = "3.0.5"
 

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -49,13 +49,6 @@ tracing = { version = "0.1", features = ["log"] }
 uuid = "1.10.0"
 z85 = "3.0.5"
 
-# force URL to use unicode-rs instead of ICU4X otherwise we require MSRV 1.81
-# from docs: compared to ICU4X, this makes build times faster, MSRV lower, binary size larger, and
-# run-time performance slower.
-[dependencies.url]
-version = "2"
-idna_adapter = "=1.1.0"
-
 # bring in our derive macros
 delta_kernel_derive = { path = "../derive-macros", version = "0.7.0" }
 
@@ -149,6 +142,13 @@ integration-test = [
 
 [dependencies.home]
 version = "=0.5.9"
+
+# force URL to use unicode-rs instead of ICU4X otherwise we require MSRV 1.81
+# from docs: compared to ICU4X, this makes build times faster, MSRV lower, binary size larger, and
+# run-time performance slower.
+[dependencies.url]
+version = "2"
+idna_adapter = "=1.1.0"
 
 [build-dependencies]
 rustc_version = "0.4.1"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -46,13 +46,15 @@ serde_json = "1"
 thiserror = "1"
 # only for structured logging
 tracing = { version = "0.1", features = ["log"] }
-url = "2"
+uuid = "1.10.0"
+z85 = "3.0.5"
+
 # force URL to use unicode-rs instead of ICU4X otherwise we require MSRV 1.81
 # from docs: compared to ICU4X, this makes build times faster, MSRV lower, binary size larger, and
 # run-time performance slower.
+[dependencies.url]
+version = "2"
 idna_adapter = "=1.1.0"
-uuid = "1.10.0"
-z85 = "3.0.5"
 
 # bring in our derive macros
 delta_kernel_derive = { path = "../derive-macros", version = "0.7.0" }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-incubator/delta-kernel-rs/blob/main/CONTRIBUTING.md
  2. Run `cargo t --all-features --all-targets` to get started testing, and run `cargo fmt`.
  3. Ensure you have added or run the appropriate tests for your PR.
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

<!--
PR title formatting:
This project uses conventional commits: https://www.conventionalcommits.org/

Each PR corresponds to a commit on the `main` branch, with the title of the PR (typically) being
used for the commit message on main. In order to ensure proper formatting in the CHANGELOG please
ensure your PR title adheres to the conventional commit specification.

Examples:
- new feature PR: "feat: new API for snapshot.update()"
- bugfix PR: "fix: correctly apply DV in read-table example"
-->

## What changes are proposed in this pull request?
<!--
Please clarify what changes you are proposing and why the changes are needed.
The purpose of this section is to outline the changes, why they are needed, and how this PR fixes the issue.
If the reason for the change is already explained clearly in an issue, then it does not need to be restated here.
  1. If you propose a new API or feature, clarify the use case for a new API or feature.
  2. If you fix a bug, you can clarify why it is a bug.
-->

TLDR: pin `idna_adapter` to version `1.1.0`.

problem: despite Url saying that MSRV is 1.63, it actually depends on the unicode backend you use. previously kernel took no opinion and was thus bumped to the newest releases of ICU4X which requires rust 1.81. for now, we will force the old unicode backend and then in 0.8.0 (or whenever we want to bump MSRV) upgrade/revert back to the ICU4X backend

from [Url docs](https://crates.io/crates/url):
> By default, idna uses [ICU4X](https://github.com/unicode-org/icu4x/) as its Unicode back end. If you wish to opt for different tradeoffs between correctness, run-time performance, binary size, compile time, and MSRV, please see the [README of the latest version of the idna_adapter crate](https://docs.rs/crate/idna_adapter/latest) for how to opt into a different Unicode back end.

<!--
Uncomment this section if there are any changes affecting public APIs:
### This PR affects the following public APIs

If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.

Note that _new_ public APIs are not considered breaking.
-->


## How was this change tested?
<!--
Please make sure to add test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested, ideally via a reproducible test documented in the PR description.
-->