### PR TITLE
fix!(ffi): Visit decimals as signed values

### DIFF
--- a/ffi/examples/visit-expression/expression.h
+++ b/ffi/examples/visit-expression/expression.h
@@ -87,7 +87,8 @@ struct BinaryData {
   uintptr_t len;
 };
 struct Decimal {
-  uint64_t value[2];
+  int64_t hi;
+  uint64_t lo;
   uint8_t precision;
   uint8_t scale;
 };
@@ -202,15 +203,15 @@ void visit_expr_string_literal(void* data, uintptr_t sibling_list_id, KernelStri
 }
 void visit_expr_decimal_literal(void* data,
                                 uintptr_t sibling_list_id,
-                                uint64_t value_ms,
+                                int64_t value_ms,
                                 uint64_t value_ls,
                                 uint8_t precision,
                                 uint8_t scale) {
   struct Literal* literal = malloc(sizeof(struct Literal));
   literal->type = Decimal;
   struct Decimal* dec = &literal->value.decimal;
-  dec->value[0] = value_ms;
-  dec->value[1] = value_ls;
+  dec->hi = value_ms;
+  dec->lo = value_ls;
   dec->precision = precision;
   dec->scale = scale;
   put_expr_item(data, sibling_list_id, literal, Literal);

--- a/ffi/examples/visit-expression/expression_print.h
+++ b/ffi/examples/visit-expression/expression_print.h
@@ -144,9 +144,9 @@ void print_tree_helper(ExpressionItem ref, int depth) {
         }
         case Decimal: {
           struct Decimal* dec = &lit->value.decimal;
-          printf("Decimal(%lld,%lld,%d,%d)\n",
-                 (long long)dec->value[0],
-                 (long long)dec->value[1],
+          printf("Decimal(%lld,%llu,%d,%d)\n",
+                 (long long)dec->hi,
+                 (unsigned long long)dec->ho,
                  dec->precision,
                  dec->scale);
           break;

--- a/ffi/examples/visit-expression/expression_print.h
+++ b/ffi/examples/visit-expression/expression_print.h
@@ -146,7 +146,7 @@ void print_tree_helper(ExpressionItem ref, int depth) {
           struct Decimal* dec = &lit->value.decimal;
           printf("Decimal(%lld,%llu,%d,%d)\n",
                  (long long)dec->hi,
-                 (unsigned long long)dec->ho,
+                 (unsigned long long)dec->lo,
                  dec->precision,
                  dec->scale);
           break;

--- a/ffi/src/expressions/kernel.rs
+++ b/ffi/src/expressions/kernel.rs
@@ -96,7 +96,7 @@ pub struct EngineExpressionVisitor {
     pub visit_literal_decimal: extern "C" fn(
         data: *mut c_void,
         sibling_list_id: usize,
-        value_ms: u64,
+        value_ms: i64,
         value_ls: u64,
         precision: u8,
         scale: u8,
@@ -318,14 +318,12 @@ pub fn visit_expression_internal(
                 buf.len()
             ),
             Scalar::Decimal(value, precision, scale) => {
-                let ms: u64 = (value >> 64) as u64;
-                let ls: u64 = *value as u64;
                 call!(
                     visitor,
                     visit_literal_decimal,
                     sibling_list_id,
-                    ms,
-                    ls,
+                    (value >> 64) as i64,
+                    *value as u64,
                     *precision,
                     *scale
                 )


### PR DESCRIPTION
## What changes are proposed in this pull request?

The FFI expression visitor code incorrectly passes a `(u64, u64)` pair to `visit_literal_decimal` callback, representing the upper and lower half of an `i128` decimal value. It should actually be `(i64, u64)` to preserve signedness.

### This PR affects the following public APIs

The expression visitor callback `visit_literal_decimal` now takes `i64` for the upper half of a 128-bit int value.


## How was this change tested?

Updated the example code.