### PR TITLE
fix!: bump MSRV to 1.81

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ keywords = ["deltalake", "delta", "datalake"]
 license = "Apache-2.0"
 repository = "https://github.com/delta-io/delta-kernel-rs"
 readme = "README.md"
-rust-version = "1.80"
+rust-version = "1.81"
 version = "0.7.0"
 
 [workspace.dependencies]


### PR DESCRIPTION

## What changes are proposed in this pull request?
`Url` crate now has MSRV with default unicode backend of rustc `1.81`. instead of fighting this, we will just bump up our MSRV from `1.80` to `1.81` seeing as (1) a large part of the ecosystem (datafusion, polars (though still states `1.80` in README), delta-rs, etc.) already is on `1.81` and (2) `Url` is a rather foundational crate so if they bump it seems reasonable to assume that many consumers will too

### This PR affects the following public APIs
bumping MSRV from `1.80` to `1.81`

## How was this change tested?
MSRV test