### PR TITLE
fix: allow for Null(DataType) equivalency comparison

### DIFF
--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -265,6 +265,13 @@ impl PartialOrd for Scalar {
                 .then(|| v1.partial_cmp(v2))
                 .flatten(),
             (Decimal(_, _, _), _) => None,
+            (Null(a), Null(b)) => {
+                if a == b {
+                    Some(Ordering::Equal)
+                } else {
+                    None
+                }
+            }
             (Null(_), _) => None, // NOTE: NULL values are incomparable by definition
             (Struct(_), _) => None, // TODO: Support Struct?
             (Array(_), _) => None, // TODO: Support Array?
@@ -652,9 +659,9 @@ mod tests {
         assert_eq!(a.partial_cmp(&c), None);
         assert_eq!(c.partial_cmp(&a), None);
 
-        // assert that NULL values are incomparable
-        let null = Scalar::Null(DataType::INTEGER);
-        assert_eq!(null.partial_cmp(&null), None);
+        let a = Scalar::Null(DataType::INTEGER);
+        let b = Scalar::Null(DataType::STRING);
+        assert_eq!(a.partial_cmp(&b), None);
     }
 
     #[test]
@@ -667,8 +674,13 @@ mod tests {
         assert!(!a.eq(&c));
         assert!(!c.eq(&a));
 
+        let a = Scalar::Null(DataType::STRING);
+        let b = Scalar::Null(DataType::STRING);
+        assert_eq!(a, b);
+
         // assert that NULL values are incomparable
-        let null = Scalar::Null(DataType::INTEGER);
-        assert!(!null.eq(&null));
+        let a = Scalar::Null(DataType::INTEGER);
+        let b = Scalar::Null(DataType::STRING);
+        assert_ne!(a, b);
     }
 }


### PR DESCRIPTION
The change made in `e2378a579790172800d91701c143f4522957a9de` modified the equivalency behaviors of Scalars in a way that mean Null(DataType::String) != Null(DataType::String) which I don't believe is correct since we can perform an equivalency on the DataType.

This changes re-introduces that support with a test case that passes on v0.6.1 and fails on v0.7.0, v0.8.0, and `main`.
