### PR TITLE
Change metadata values for column metadata to i64

### DIFF
--- a/acceptance/Cargo.toml
+++ b/acceptance/Cargo.toml
@@ -16,24 +16,24 @@ release = false
 [dependencies]
 delta_kernel = { path = "../kernel", features = [
   "default-engine",
-  "arrow_53",
+  "arrow_54",
   "developer-visibility",
 ] }
 futures = "0.3"
-itertools = "0.13"
+itertools = "0.14"
 object_store = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-thiserror = "1"
+thiserror = "2"
 url = "2"
 
 [build-dependencies]
-ureq = "2.10"
+ureq = "3"
 flate2 = "1.0"
 tar = "0.4"
 
 [dev-dependencies]
-datatest-stable = "0.2"
+datatest-stable = "0.3"
 test-log = { version = "0.2", default-features = false, features = ["trace"] }
 tempfile = "3"
 test-case = { version = "3.3.1" }

--- a/acceptance/build.rs
+++ b/acceptance/build.rs
@@ -2,7 +2,7 @@
 
 use std::env;
 use std::fs::File;
-use std::io::{BufReader, BufWriter, Write};
+use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::Path;
 
 use flate2::read::GzDecoder;
@@ -33,8 +33,9 @@ fn download_dat_files() -> Vec<u8> {
     );
 
     let response = if let Ok(proxy_url) = env::var("HTTPS_PROXY") {
-        let proxy = ureq::Proxy::new(proxy_url).unwrap();
-        let agent = ureq::AgentBuilder::new().proxy(proxy).build();
+        let proxy = ureq::Proxy::new(&proxy_url).unwrap();
+        let agent_cfg = ureq::Agent::config_builder().proxy(Some(proxy)).build();
+        let agent = ureq::Agent::new_with_config(agent_cfg);
         agent.get(&tarball_url).call().unwrap()
     } else {
         ureq::get(&tarball_url).call().unwrap()
@@ -42,6 +43,7 @@ fn download_dat_files() -> Vec<u8> {
 
     let mut tarball_data: Vec<u8> = Vec::new();
     response
+        .into_body()
         .into_reader()
         .read_to_end(&mut tarball_data)
         .unwrap();

--- a/acceptance/tests/dat_reader.rs
+++ b/acceptance/tests/dat_reader.rs
@@ -44,8 +44,6 @@ fn reader_test(path: &Path) -> datatest_stable::Result<()> {
     Ok(())
 }
 
-datatest_stable::harness!(
-    reader_test,
-    "tests/dat/out/reader_tests/generated/",
-    r"test_case_info\.json"
-);
+datatest_stable::harness! {
+    { test = reader_test, root = "tests/dat/out/reader_tests/generated/", pattern = r"test_case_info\.json" }
+}

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -41,11 +41,11 @@ bytes = "1.7"
 chrono = "=0.4.39"
 fix-hidden-lifetime-bug = "0.2"
 indexmap = "2.5.0"
-itertools = "0.13"
+itertools = "0.14"
 roaring = "0.10.6"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
-thiserror = "1"
+thiserror = "2"
 # only for structured logging
 tracing = { version = "0.1", features = ["log"] }
 url = "2"
@@ -78,7 +78,7 @@ object_store = { workspace = true, optional = true }
 hdfs-native-object-store = { workspace = true, optional = true }
 # Used for fetching direct urls (like pre-signed urls)
 reqwest = { version = "0.12.8", default-features = false, optional = true }
-strum = { version = "0.26", features = ["derive"] }
+strum = { version = "0.27", features = ["derive"] }
 
 
 # optionally used with default engine (though not required)

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -22,7 +22,7 @@ pub type SchemaRef = Arc<StructType>;
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq)]
 #[serde(untagged)]
 pub enum MetadataValue {
-    Number(i32),
+    Number(i64),
     String(String),
     Boolean(bool),
     // The [PROTOCOL](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#struct-field) states
@@ -32,8 +32,8 @@ pub enum MetadataValue {
     Other(serde_json::Value),
 }
 
-impl std::fmt::Display for MetadataValue {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for MetadataValue {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             MetadataValue::Number(n) => write!(f, "{n}"),
             MetadataValue::String(s) => write!(f, "{s}"),
@@ -61,8 +61,8 @@ impl From<&str> for MetadataValue {
     }
 }
 
-impl From<i32> for MetadataValue {
-    fn from(value: i32) -> Self {
+impl From<i64> for MetadataValue {
+    fn from(value: i64) -> Self {
         Self::Number(value)
     }
 }
@@ -145,7 +145,7 @@ impl StructField {
         self
     }
 
-    pub fn get_config_value(&self, key: &ColumnMetadataKey) -> Option<&MetadataValue> {
+    pub fn get_metadata_value(&self, key: &ColumnMetadataKey) -> Option<&MetadataValue> {
         self.metadata.get(key.as_ref())
     }
 
@@ -1039,16 +1039,20 @@ mod tests {
             "nullable": true,
             "metadata": {
                 "delta.columnMapping.id": 4,
-                "delta.columnMapping.physicalName": "col-5f422f40-de70-45b2-88ab-1d5c90e94db1"
+                "delta.columnMapping.physicalName": "col-5f422f40-de70-45b2-88ab-1d5c90e94db1",
+                "delta.identity.start": 2147483648 
             }
         }
         "#;
+        
         let field: StructField = serde_json::from_str(data).unwrap();
 
         let col_id = field
-            .get_config_value(&ColumnMetadataKey::ColumnMappingId)
+            .get_metadata_value(&ColumnMetadataKey::ColumnMappingId)
             .unwrap();
+        let id_start = field.get_metadata_value(&ColumnMetadataKey::IdentityStart).unwrap();
         assert!(matches!(col_id, MetadataValue::Number(num) if *num == 4));
+        assert!(matches!(id_start, MetadataValue::Number(num) if *num == 2147483648i64));
         assert_eq!(
             field.physical_name(),
             "col-5f422f40-de70-45b2-88ab-1d5c90e94db1"


### PR DESCRIPTION
Additionally, I updated some dependencies to their latest versions.

## What changes are proposed in this pull request?
`MetadataValue::Number(i32)` was the previous values for metadata values, but identity columns are only longs, so updated MetadataValue::Number to be `MetadataValue::Number(i64)` instead.


## How was this change tested?
I ran the tests, this doesn't change any existing functionality only the type. 