### PR TITLE
[WIP] feat: support multiple object stores in `DefaultEngine`

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -64,15 +64,32 @@ tempfile = { version = "3", optional = true }
 # Arrow supported versions
 ## 53
 # Used in default engine
-arrow_53 = { package = "arrow", version = "53", features = ["chrono-tz", "ffi", "json", "prettyprint"], optional = true }
+arrow_53 = { package = "arrow", version = "53", features = [
+  "chrono-tz",
+  "ffi",
+  "json",
+  "prettyprint",
+], optional = true }
 # Used in default and sync engine
-parquet_53 = { package = "parquet", version = "53", features = ["async", "object_store"] , optional = true }
+parquet_53 = { package = "parquet", version = "53", features = [
+  "async",
+  "object_store",
+], optional = true }
 ######
 ## 54
-arrow_54 = { package = "arrow", version = "54", features = ["chrono-tz", "ffi", "json", "prettyprint"], optional = true }
-parquet_54 = { package = "parquet", version = "54", features = ["async", "object_store"] , optional = true }
+arrow_54 = { package = "arrow", version = "54", features = [
+  "chrono-tz",
+  "ffi",
+  "json",
+  "prettyprint",
+], optional = true }
+parquet_54 = { package = "parquet", version = "54", features = [
+  "async",
+  "object_store",
+], optional = true }
 ######
 
+async-trait = { version = "0.1", optional = true }
 futures = { version = "0.3", optional = true }
 object_store = { workspace = true, optional = true }
 hdfs-native-object-store = { workspace = true, optional = true }
@@ -120,6 +137,7 @@ default-engine-base = [
   "tokio",
   "uuid/v4",
   "uuid/fast-rng",
+  "async-trait",
 ]
 
 # the default-engine use the reqwest crate with default features which uses native-tls. if you want
@@ -133,10 +151,7 @@ default-engine-rustls = [
 ]
 
 developer-visibility = []
-sync-engine = [
-  "need_arrow",
-  "tempfile",
-]
+sync-engine = ["need_arrow", "tempfile"]
 integration-test = [
   "hdfs-native-object-store/integration-test",
   "hdfs-native",
@@ -150,7 +165,11 @@ version = "=0.5.9"
 rustc_version = "0.4.1"
 
 [dev-dependencies]
-delta_kernel = { path = ".", features = ["arrow", "default-engine", "sync-engine"] }
+delta_kernel = { path = ".", features = [
+  "arrow",
+  "default-engine",
+  "sync-engine",
+] }
 test_utils = { path = "../test-utils" }
 async-trait = "0.1" # only used for our custom SlowGetStore ObjectStore implementation
 paste = "1.0"

--- a/kernel/src/engine/default/mod.rs
+++ b/kernel/src/engine/default/mod.rs
@@ -133,15 +133,13 @@ impl<E: TaskExecutor> Engine for DefaultEngine<E> {
     }
 }
 
-pub(self) trait UrlExt {
+trait UrlExt {
     fn is_presigned(&self) -> bool;
 }
 
 impl UrlExt for Url {
     fn is_presigned(&self) -> bool {
-        self.query_pairs()
-            .find(|(key, _)| key == "AWSAccessKeyId")
-            .is_some()
+        matches!(self.scheme(), "http" | "https") && self.query().is_some()
     }
 }
 

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -4,15 +4,16 @@ use std::collections::HashMap;
 use std::ops::Range;
 use std::sync::Arc;
 
+use crate::arrow::array::builder::{MapBuilder, MapFieldNames, StringBuilder};
+use crate::arrow::array::{BooleanArray, Int64Array, RecordBatch, StringArray};
+use crate::parquet::arrow::arrow_writer::ArrowWriter;
+use crate::parquet::arrow::async_reader::{ParquetObjectReader, ParquetRecordBatchStreamBuilder};
 use futures::StreamExt;
 use object_store::path::Path;
 use uuid::Uuid;
 
 use super::file_stream::{FileOpenFuture, FileOpener, FileStream};
-use super::ObjectStoreRegistry;
-use super::UrlExt;
-use crate::arrow::array::builder::{MapBuilder, MapFieldNames, StringBuilder};
-use crate::arrow::array::{BooleanArray, Int64Array, RecordBatch, StringArray};
+use super::{ObjectStoreRegistry, UrlExt};
 use crate::engine::arrow_data::ArrowEngineData;
 use crate::engine::arrow_utils::{fixup_parquet_read, generate_mask, get_requested_indices};
 use crate::engine::default::executor::TaskExecutor;
@@ -20,19 +21,6 @@ use crate::engine::parquet_row_group_skipping::ParquetRowGroupSkipping;
 use crate::parquet::arrow::arrow_reader::{
     ArrowReaderMetadata, ArrowReaderOptions, ParquetRecordBatchReaderBuilder,
 };
-use crate::parquet::arrow::arrow_writer::ArrowWriter;
-use crate::parquet::arrow::async_reader::{ParquetObjectReader, ParquetRecordBatchStreamBuilder};
-use futures::StreamExt;
-use object_store::path::Path;
-use object_store::DynObjectStore;
-use uuid::Uuid;
-
-use super::file_stream::{FileOpenFuture, FileOpener, FileStream};
-use super::UrlExt;
-use crate::engine::arrow_data::ArrowEngineData;
-use crate::engine::arrow_utils::{fixup_parquet_read, generate_mask, get_requested_indices};
-use crate::engine::default::executor::TaskExecutor;
-use crate::engine::parquet_row_group_skipping::ParquetRowGroupSkipping;
 use crate::schema::SchemaRef;
 use crate::{
     DeltaResult, EngineData, Error, ExpressionRef, FileDataReadResultIterator, FileMeta,

--- a/kernel/src/engine/default/registry.rs
+++ b/kernel/src/engine/default/registry.rs
@@ -23,12 +23,16 @@ impl std::fmt::Debug for DefaultObjectStoreRegistry {
             .field(
                 "schemes",
                 &self
-                    .object_stores
-                    .iter()
-                    .map(|(key, _)| key.clone())
+                    .object_stores.keys().cloned()
                     .collect::<Vec<_>>(),
             )
             .finish()
+    }
+}
+
+impl Default for DefaultObjectStoreRegistry {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/kernel/src/engine/default/registry.rs
+++ b/kernel/src/engine/default/registry.rs
@@ -1,0 +1,134 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use object_store::local::LocalFileSystem;
+use object_store::{DynObjectStore, ObjectStore};
+use url::Url;
+
+use crate::{DeltaResult, Error};
+
+pub trait ObjectStoreRegistry: Send + Sync + std::fmt::Debug + 'static {
+    fn get_store(&self, url: &Url) -> DeltaResult<(Arc<DynObjectStore>, bool)>;
+}
+
+/// The default [`ObjectStoreRegistry`]
+pub struct DefaultObjectStoreRegistry {
+    /// A map from scheme to object store that serve list / read operations for the store
+    object_stores: HashMap<String, (Arc<dyn ObjectStore>, bool)>,
+}
+
+impl std::fmt::Debug for DefaultObjectStoreRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DefaultObjectStoreRegistry")
+            .field(
+                "schemes",
+                &self
+                    .object_stores
+                    .iter()
+                    .map(|(key, _)| key.clone())
+                    .collect::<Vec<_>>(),
+            )
+            .finish()
+    }
+}
+
+impl DefaultObjectStoreRegistry {
+    /// This will register [`LocalFileSystem`] to handle `file://` paths
+    pub fn new() -> Self {
+        let mut object_stores: HashMap<String, (Arc<dyn ObjectStore>, bool)> = HashMap::new();
+        object_stores.insert(
+            "file://".to_string(),
+            (Arc::new(LocalFileSystem::new()), false),
+        );
+        Self { object_stores }
+    }
+
+    /// This will register [`LocalFileSystem`] to handle `file://` and `memory://` paths
+    #[cfg(test)]
+    pub fn new_test() -> Self {
+        use object_store::memory::InMemory;
+        let mut object_stores: HashMap<String, (Arc<dyn ObjectStore>, bool)> = HashMap::new();
+        object_stores.insert(
+            "file://".to_string(),
+            (Arc::new(LocalFileSystem::new()), false),
+        );
+        object_stores.insert("memory://".to_string(), (Arc::new(InMemory::new()), false));
+        Self { object_stores }
+    }
+
+    #[cfg(test)]
+    pub fn get_memory(&self) -> Arc<dyn ObjectStore> {
+        self.object_stores
+            .get("memory://")
+            .map(|(s, _flag)| Arc::clone(s))
+            .expect("memory store not found")
+    }
+
+    #[cfg(test)]
+    pub fn get_local(&self) -> Arc<dyn ObjectStore> {
+        self.object_stores
+            .get("file://")
+            .map(|(s, _flag)| Arc::clone(s))
+            .expect("file store not found")
+    }
+
+    pub fn register_store(
+        &mut self,
+        url: &Url,
+        store: Arc<dyn ObjectStore>,
+    ) -> Option<Arc<dyn ObjectStore>> {
+        let s = get_url_key(url);
+        // HACK to check if we're using a LocalFileSystem from ObjectStore. We need this because
+        // local filesystem doesn't return a sorted list by default. Although the `object_store`
+        // crate explicitly says it _does not_ return a sorted listing, in practice all the cloud
+        // implementations actually do:
+        // - AWS:
+        //   [`ListObjectsV2`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html)
+        //   states: "For general purpose buckets, ListObjectsV2 returns objects in lexicographical
+        //   order based on their key names." (Directory buckets are out of scope for now)
+        // - Azure: Docs state
+        //   [here](https://learn.microsoft.com/en-us/rest/api/storageservices/enumerating-blob-resources):
+        //   "A listing operation returns an XML response that contains all or part of the requested
+        //   list. The operation returns entities in alphabetical order."
+        // - GCP: The [main](https://cloud.google.com/storage/docs/xml-api/get-bucket-list) doc
+        //   doesn't indicate order, but [this
+        //   page](https://cloud.google.com/storage/docs/xml-api/get-bucket-list) does say: "This page
+        //   shows you how to list the [objects](https://cloud.google.com/storage/docs/objects) stored
+        //   in your Cloud Storage buckets, which are ordered in the list lexicographically by name."
+        // So we just need to know if we're local and then if so, we wrap the store in an OrderedObjectStore
+        let store_str = format!("{}", store);
+        let is_local = store_str.starts_with("LocalFileSystem");
+        self.object_stores
+            .insert(s, (store, !is_local))
+            .map(|(s, _)| s)
+    }
+}
+
+/// Stores are registered based on the scheme, host and port of the provided URL
+/// with a [`LocalFileSystem::new`] automatically registered for `file://` (if the
+/// target arch is not `wasm32`).
+///
+/// For example:
+///
+/// - `file:///my_path` will return the default LocalFS store
+/// - `s3://bucket/path` will return a store registered with `s3://bucket` if any
+/// - `hdfs://host:port/path` will return a store registered with `hdfs://host:port` if any
+impl ObjectStoreRegistry for DefaultObjectStoreRegistry {
+    fn get_store(&self, url: &Url) -> DeltaResult<(Arc<dyn ObjectStore>, bool)> {
+        let s = get_url_key(url);
+        self.object_stores
+            .get(&s)
+            .map(|(s, flag)| (Arc::clone(s), *flag))
+            .ok_or_else(|| Error::Generic(format!("No object store registered for {}", url)))
+    }
+}
+
+/// Get the key of a url for object store registration.
+/// The credential info will be removed
+fn get_url_key(url: &Url) -> String {
+    format!(
+        "{}://{}",
+        url.scheme(),
+        &url[url::Position::BeforeHost..url::Position::AfterPort],
+    )
+}

--- a/kernel/src/engine/mod.rs
+++ b/kernel/src/engine/mod.rs
@@ -54,12 +54,16 @@ mod tests {
             .map(|i| delta_path_for_version(i, "json"))
             .collect_vec();
 
+        dbg!(&expected_names);
+
         for i in expected_names.iter().rev() {
             let path = base_url.join(i.as_ref()).unwrap();
             json.write_json_file(&path, get_data(), false).unwrap();
         }
         let path = base_url.join("other").unwrap();
         json.write_json_file(&path, get_data(), false).unwrap();
+
+        dbg!("after json write");
 
         let fs = engine.get_file_system_client();
 
@@ -71,11 +75,15 @@ mod tests {
             assert_eq!(file.location, base_url.join(expected.as_ref()).unwrap());
         }
 
+        dbg!("after list");
+
         let test_url = base_url
             .join(delta_path_for_version(0, "json").as_ref())
             .unwrap();
         let files: Vec<_> = fs.list_from(&test_url).unwrap().try_collect().unwrap();
         assert_eq!(files.len(), expected_names.len());
+
+        dbg!("after list");
 
         // list files inside a directory / key prefix
         let test_url = base_url.join("_delta_log/").unwrap();

--- a/kernel/src/engine/mod.rs
+++ b/kernel/src/engine/mod.rs
@@ -54,16 +54,12 @@ mod tests {
             .map(|i| delta_path_for_version(i, "json"))
             .collect_vec();
 
-        dbg!(&expected_names);
-
         for i in expected_names.iter().rev() {
             let path = base_url.join(i.as_ref()).unwrap();
             json.write_json_file(&path, get_data(), false).unwrap();
         }
         let path = base_url.join("other").unwrap();
         json.write_json_file(&path, get_data(), false).unwrap();
-
-        dbg!("after json write");
 
         let fs = engine.get_file_system_client();
 
@@ -75,15 +71,11 @@ mod tests {
             assert_eq!(file.location, base_url.join(expected.as_ref()).unwrap());
         }
 
-        dbg!("after list");
-
         let test_url = base_url
             .join(delta_path_for_version(0, "json").as_ref())
             .unwrap();
         let files: Vec<_> = fs.list_from(&test_url).unwrap().try_collect().unwrap();
         assert_eq!(files.len(), expected_names.len());
-
-        dbg!("after list");
 
         // list files inside a directory / key prefix
         let test_url = base_url.join("_delta_log/").unwrap();

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -12,6 +12,7 @@ version.workspace = true
 release = false
 
 [dependencies]
-delta_kernel = { path = "../kernel", features = [  "default-engine", "arrow" ] }
+delta_kernel = { path = "../kernel", features = ["default-engine", "arrow"] }
 itertools = "0.13.0"
 object_store = { workspace = true }
+url = "2"

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -12,11 +12,7 @@ version.workspace = true
 release = false
 
 [dependencies]
-<<<<<<< HEAD
 delta_kernel = { path = "../kernel", features = ["default-engine", "arrow"] }
-=======
-delta_kernel = { path = "../kernel", features = [ "default-engine", "arrow" ] }
->>>>>>> upstream/main
 itertools = "0.13.0"
 object_store = { workspace = true }
 url = "2"


### PR DESCRIPTION
## What changes are proposed in this pull request?

Currently the default client is somewhat tied to a single table (or at least to tables that can be accessed by a single object-store instance) and also does not support tables where data files doe not reside in the same location as the delta log.

This PR replaces the single object store instance used in the default file system client with an `ObjectStoreRegistry`, such that engines can register a number of stores for multiple known storage locations.

### This PR affects the following public APIs

Constructing a new `DefaultEngine` now requires passing an instance of `ObjectStoreRegistry`. We provides a simple default implementation of a registry that internally tracks stores in a HashMap.

## How was this change tested?

TODO: Add test covering multiple stores.