### PR TITLE
refactor: rename `LogSegment::replay` to `LogSegment::read_actions`

### DIFF
--- a/kernel/examples/inspect-table/src/main.rs
+++ b/kernel/examples/inspect-table/src/main.rs
@@ -223,7 +223,7 @@ fn try_main() -> DeltaResult<()> {
         }
         Commands::Actions { oldest_first } => {
             let log_schema = get_log_schema();
-            let actions = snapshot.log_segment().replay(
+            let actions = snapshot.log_segment().read_actions(
                 &engine,
                 log_schema.clone(),
                 log_schema.clone(),

--- a/kernel/src/actions/set_transaction.rs
+++ b/kernel/src/actions/set_transaction.rs
@@ -59,9 +59,12 @@ impl SetTransactionScanner {
                 Expr::column([SET_TRANSACTION_NAME, "appId"]).is_not_null(),
             ))
         });
-        self.snapshot
-            .log_segment()
-            .replay(engine, schema.clone(), schema, META_PREDICATE.clone())
+        self.snapshot.log_segment().read_actions(
+            engine,
+            schema.clone(),
+            schema,
+            META_PREDICATE.clone(),
+        )
     }
 
     /// Scan the Delta Log for the latest transaction entry of an application

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -186,19 +186,21 @@ impl LogSegment {
         );
         LogSegment::try_new(ascending_commit_files, vec![], log_root, end_version)
     }
-    /// Read a stream of log data from this log segment.
+
+    /// Read a stream of actions from this log segment. This returns an iterator of (EngineData,
+    /// bool) pairs, where the boolean flag indicates whether the data was read from a commit file
+    /// (true) or a checkpoint file (false).
     ///
     /// The log files will be read from most recent to oldest.
-    /// The boolean flags indicates whether the data was read from
-    /// a commit file (true) or a checkpoint file (false).
     ///
-    /// `read_schema` is the schema to read the log files with. This can be used
-    /// to project the log files to a subset of the columns.
+    /// `commit_read_schema` is the (physical) schema to read the commit files with, and
+    /// `checkpoint_read_schema` is the (physical) schema to read checkpoint files with. This can be
+    /// used to project the log files to a subset of the columns.
     ///
     /// `meta_predicate` is an optional expression to filter the log files with. It is _NOT_ the
     /// query's predicate, but rather a predicate for filtering log files themselves.
     #[cfg_attr(feature = "developer-visibility", visibility::make(pub))]
-    pub(crate) fn replay(
+    pub(crate) fn read_actions(
         &self,
         engine: &dyn Engine,
         commit_read_schema: SchemaRef,
@@ -399,7 +401,7 @@ impl LogSegment {
             )))
         });
         // read the same protocol and metadata schema for both commits and checkpoints
-        self.replay(engine, schema.clone(), schema, META_PREDICATE.clone())
+        self.read_actions(engine, schema.clone(), schema, META_PREDICATE.clone())
     }
 }
 

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -430,9 +430,12 @@ impl Scan {
 
         // NOTE: We don't pass any meta-predicate because we expect no meaningful row group skipping
         // when ~every checkpoint file will contain the adds and removes we are looking for.
-        self.snapshot
-            .log_segment()
-            .replay(engine, commit_read_schema, checkpoint_read_schema, None)
+        self.snapshot.log_segment().read_actions(
+            engine,
+            commit_read_schema,
+            checkpoint_read_schema,
+            None,
+        )
     }
 
     /// Get global state that is valid for the entire scan. This is somewhat expensive so should


### PR DESCRIPTION
small change: `replay` generally refers to the work we do to resolve actions during log replay. I've renamed `LogSegment::replay` to `LogSegment::read_actions` since this method does just that: reads actions, but doesn't actually do tangible 'replay' work (Add/Remove matching, etc.).

just docs/rename. no material changes.