### PR TITLE
refactor!: make visit_expression_internal  private, and unwrap_kernel_expression pub(crate)

### DIFF
--- a/ffi/src/expressions/engine.rs
+++ b/ffi/src/expressions/engine.rs
@@ -47,7 +47,7 @@ fn wrap_expression(state: &mut KernelExpressionVisitorState, expr: impl Into<Exp
     state.inflight_expressions.insert(expr.into())
 }
 
-pub fn unwrap_kernel_expression(
+pub(crate) fn unwrap_kernel_expression(
     state: &mut KernelExpressionVisitorState,
     exprid: usize,
 ) -> Option<Expression> {

--- a/ffi/src/expressions/kernel.rs
+++ b/ffi/src/expressions/kernel.rs
@@ -209,7 +209,7 @@ pub unsafe extern "C" fn visit_expression_ref(
     visit_expression_internal(expression, visitor)
 }
 
-pub fn visit_expression_internal(
+fn visit_expression_internal(
     expression: &Expression,
     visitor: &mut EngineExpressionVisitor,
 ) -> usize {


### PR DESCRIPTION
## What changes are proposed in this pull request?

These were never intended to be public, so just fixing that.


### This PR affects the following public APIs
- `visit_expression_internal`: is private
- `unwrap_kernel_expression`: is `pub(crate)`

## How was this change tested?
Existing tests