### PR TITLE
misc: add .cargo/config.toml with native instruction codegen

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-C", "target-cpu=native"]

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 .zed
 
 # Rust
-.cargo/
 target/
 /Cargo.lock
 integration-tests/Cargo.lock


### PR DESCRIPTION
## What changes are proposed in this pull request?
According to [arrow docs] we should ensure that we have `-C target-cpu=native` for rustc to generate best available instructions (SIMD, etc.) for our architecture

[arrow docs]: https://crates.io/crates/arrow