### PR TITLE
feat: add classic and uuid parquet checkpoint path generation

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -49,7 +49,7 @@ thiserror = "1"
 # only for structured logging
 tracing = { version = "0.1", features = ["log"] }
 url = "2"
-uuid = "1.10.0"
+uuid = { version = "1.10.0", features = ["v4", "fast-rng"] }
 z85 = "3.0.5"
 
 # bring in our derive macros
@@ -118,8 +118,6 @@ default-engine-base = [
   "need_arrow",
   "object_store",
   "tokio",
-  "uuid/v4",
-  "uuid/fast-rng",
 ]
 
 # the default-engine use the reqwest crate with default features which uses native-tls. if you want

--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -181,7 +181,7 @@ impl<Location: AsUrl> ParsedLogPath<Location> {
 }
 
 impl ParsedLogPath<Url> {
-    const DELTA_LOG_DIR: &'static str = "_delta_log";
+    const DELTA_LOG_DIR: &'static str = "_delta_log/";
 
     /// Helper method to create a path with the given filename generator
     fn create_path(table_root: &Url, filename: String) -> DeltaResult<Self> {

--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -186,8 +186,9 @@ impl ParsedLogPath<Url> {
     /// Helper method to create a path with the given filename generator
     fn create_path(table_root: &Url, filename: String) -> DeltaResult<Self> {
         let location = table_root.join(Self::DELTA_LOG_DIR)?.join(&filename)?;
-        Self::try_from(location)?
-            .ok_or_else(|| Error::internal_error("attempted to create invalid path"))
+        Self::try_from(location)?.ok_or_else(|| {
+            Error::internal_error(format!("Attempted to create an invalid path: {}", filename))
+        })
     }
 
     /// Create a new ParsedCommitPath<Url> for a new json commit file
@@ -617,6 +618,14 @@ mod tests {
         } else {
             panic!("Expected UuidCheckpoint file type");
         }
+
+        let filename = log_path.filename.to_string();
+        let filename_parts: Vec<&str> = filename.split('.').collect();
+        assert_eq!(filename_parts.len(), 4);
+        assert_eq!(filename_parts[0], "00000000000000000010");
+        assert_eq!(filename_parts[1], "checkpoint");
+        assert_eq!(filename_parts[2].len(), UUID_PART_LEN);
+        assert_eq!(filename_parts[3], "parquet");
     }
 
     #[test]

--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -198,7 +198,7 @@ impl ParsedLogPath<Url> {
         Ok(path)
     }
 
-    /// Create a new ParsedCommitPath<Url> for a classic-named parquet checkpoint file at the specified version
+    /// Create a new ParsedCheckpointPath<Url> for a classic-named parquet checkpoint file at the specified version
     #[allow(unused)] // TODO: Remove once used
     pub(crate) fn new_classic_parquet_checkpoint(
         table_root: &Url,
@@ -216,7 +216,7 @@ impl ParsedLogPath<Url> {
         Ok(path)
     }
 
-    /// Create a new ParsedCommitPath<Url> for a uuid-named parquet checkpoint file at the specified version
+    /// Create a new ParsedCheckpointPath<Url> for a uuid-named parquet checkpoint file at the specified version
     #[allow(unused)] // TODO: Remove once used
     pub(crate) fn new_uuid_parquet_checkpoint(
         table_root: &Url,

--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -203,6 +203,7 @@ impl ParsedLogPath<Url> {
     }
 
     /// Create a new ParsedCheckpointPath<Url> for a classic parquet checkpoint file
+    #[allow(dead_code)] // TODO: Remove this once we have a use case for it
     pub(crate) fn new_classic_parquet_checkpoint(
         table_root: &Url,
         version: Version,
@@ -218,6 +219,7 @@ impl ParsedLogPath<Url> {
     }
 
     /// Create a new ParsedCheckpointPath<Url> for a UUID-based parquet checkpoint file
+    #[allow(dead_code)] // TODO: Remove this once we have a use case for it
     pub(crate) fn new_uuid_parquet_checkpoint(
         table_root: &Url,
         version: Version,

--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -2,6 +2,7 @@
 
 use std::str::FromStr;
 use url::Url;
+use uuid::Uuid;
 
 use crate::{DeltaResult, Error, FileMeta, Version};
 
@@ -192,6 +193,44 @@ impl ParsedLogPath<Url> {
         if !path.is_commit() {
             return Err(Error::internal_error(
                 "ParsedLogPath::new_commit created a non-commit path",
+            ));
+        }
+        Ok(path)
+    }
+
+    /// Create a new ParsedCommitPath<Url> for a classic-named parquet checkpoint file at the specified version
+    #[allow(unused)] // TODO: Remove once used
+    pub(crate) fn new_classic_parquet_checkpoint(
+        table_root: &Url,
+        version: Version,
+    ) -> DeltaResult<ParsedLogPath<Url>> {
+        let filename = format!("{:020}.checkpoint.parquet", version);
+        let location = table_root.join("_delta_log/")?.join(&filename)?;
+        let path = Self::try_from(location)?
+            .ok_or_else(|| Error::internal_error("attempted to create invalid checkpoint path"))?;
+        if !path.is_checkpoint() {
+            return Err(Error::internal_error(
+                "ParsedLogPath::new_classic_parquet_checkpoint created a non-checkpoint path",
+            ));
+        }
+        Ok(path)
+    }
+
+    /// Create a new ParsedCommitPath<Url> for a uuid-named parquet checkpoint file at the specified version
+    #[allow(unused)] // TODO: Remove once used
+    pub(crate) fn new_uuid_parquet_checkpoint(
+        table_root: &Url,
+        version: Version,
+    ) -> DeltaResult<ParsedLogPath<Url>> {
+        // Generate a random UUID v4
+        let uuid = Uuid::new_v4().to_string();
+        let filename = format!("{:020}.checkpoint.{}.parquet", version, uuid);
+        let location = table_root.join("_delta_log/")?.join(&filename)?;
+        let path = Self::try_from(location)?
+            .ok_or_else(|| Error::internal_error("attempted to create invalid checkpoint path"))?;
+        if !path.is_checkpoint() {
+            return Err(Error::internal_error(
+                "ParsedLogPath::new_uuid_parquet_checkpoint created a non-checkpoint path",
             ));
         }
         Ok(path)
@@ -565,5 +604,36 @@ mod tests {
         assert_eq!(log_path.extension, "json");
         assert!(matches!(log_path.file_type, LogPathFileType::Commit));
         assert_eq!(log_path.filename, "00000000000000000010.json");
+    }
+
+    #[test]
+    fn test_new_uuid_parquet_checkpoint() {
+        let table_log_dir = table_log_dir_url();
+        let log_path = ParsedLogPath::new_uuid_parquet_checkpoint(&table_log_dir, 10).unwrap();
+
+        assert_eq!(log_path.version, 10);
+        assert!(log_path.is_checkpoint());
+        assert_eq!(log_path.extension, "parquet");
+        if let LogPathFileType::UuidCheckpoint(uuid) = &log_path.file_type {
+            assert_eq!(uuid.len(), UUID_PART_LEN);
+        } else {
+            panic!("Expected UuidCheckpoint file type");
+        }
+    }
+
+    #[test]
+    fn test_new_classic_parquet_checkpoint() {
+        let table_log_dir = table_log_dir_url();
+        let log_path = ParsedLogPath::new_classic_parquet_checkpoint(&table_log_dir, 10).unwrap();
+
+        // Basic properties
+        assert_eq!(log_path.version, 10);
+        assert!(log_path.is_checkpoint());
+        assert_eq!(log_path.extension, "parquet");
+        assert!(matches!(
+            log_path.file_type,
+            LogPathFileType::SinglePartCheckpoint
+        ));
+        assert_eq!(log_path.filename, "00000000000000000010.checkpoint.parquet");
     }
 }

--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -181,7 +181,7 @@ impl<Location: AsUrl> ParsedLogPath<Location> {
 }
 
 impl ParsedLogPath<Url> {
-    const DELTA_LOG_DIR: &'static str = "_delta_log/";
+    const DELTA_LOG_DIR: &'static str = "_delta_log";
 
     /// Helper method to create a path with the given filename generator
     fn create_path(table_root: &Url, filename: String) -> DeltaResult<Self> {
@@ -224,8 +224,7 @@ impl ParsedLogPath<Url> {
         table_root: &Url,
         version: Version,
     ) -> DeltaResult<Self> {
-        let uuid = Uuid::new_v4().to_string();
-        let filename = format!("{:020}.checkpoint.{}.parquet", version, uuid);
+        let filename = format!("{:020}.checkpoint.{}.parquet", version, Uuid::new_v4());
         let path = Self::create_path(table_root, filename)?;
         if !path.is_checkpoint() {
             return Err(Error::internal_error(

--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -625,7 +625,6 @@ mod tests {
         let table_log_dir = table_log_dir_url();
         let log_path = ParsedLogPath::new_classic_parquet_checkpoint(&table_log_dir, 10).unwrap();
 
-        // Basic properties
         assert_eq!(log_path.version, 10);
         assert!(log_path.is_checkpoint());
         assert_eq!(log_path.extension, "parquet");


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-incubator/delta-kernel-rs/blob/main/CONTRIBUTING.md
  2. Run `cargo t --all-features --all-targets` to get started testing, and run `cargo fmt`.
  3. Ensure you have added or run the appropriate tests for your PR.
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

<!--
PR title formatting:
This project uses conventional commits: https://www.conventionalcommits.org/

Each PR corresponds to a commit on the `main` branch, with the title of the PR (typically) being
used for the commit message on main. In order to ensure proper formatting in the CHANGELOG please
ensure your PR title adheres to the conventional commit specification.

Examples:
- new feature PR: "feat: new API for snapshot.update()"
- bugfix PR: "fix: correctly apply DV in read-table example"
-->

## What changes are proposed in this pull request?
<!--
Please clarify what changes you are proposing and why the changes are needed.
The purpose of this section is to outline the changes, why they are needed, and how this PR fixes the issue.
If the reason for the change is already explained clearly in an issue, then it does not need to be restated here.
  1. If you propose a new API or feature, clarify the use case for a new API or feature.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This PR introduces the helper methods:
- `new_uuid_parquet_checkpoint` which creates a new `ParsedCheckpointPath<Url>` for a uuid-named parquet checkpoint file at the specified version. The UUID-naming scheme looks like: `n.checkpoint.u.parquet`, where u is a UUID and n is the snapshot version that this checkpoint represents.
- `new_classic_parquet_checkpoint` which creates a new `ParsedCheckpointPath<Url>` for a classic-named parquet checkpoint file at the specified version. The classic-naming scheme looks like: `n.checkpoint.parquet`, where n is the snapshot version that this checkpoint represents.
- **Updates the `uuid` dependency to always include `v4` and `fast-rng` features:**
     - This ensures that `uuid::new_v4()` is always available.
     - The `fast-rng` feature improves performance when generating UUIDs.




For more information on the two checkpoint naming-schemes:
https://github.com/delta-io/delta/blob/master/PROTOCOL.md#uuid-named-checkpoint
https://github.com/delta-io/delta/blob/master/PROTOCOL.md#classic-checkpoint

This PR is part of the on-going effort to implement single-file checkpoint write support. For reference, [[link to write API proposal]](https://github.com/delta-io/delta-kernel-rs/pull/779)

<!--
Uncomment this section if there are any changes affecting public APIs:
### This PR affects the following public APIs

If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.

Note that _new_ public APIs are not considered breaking.
-->


## How was this change tested?
<!--
Please make sure to add test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested, ideally via a reproducible test documented in the PR description.
-->

- `test_new_uuid_parquet_checkpoint` - verifies UUID-named Parquet checkpoint creation with proper attributes.
- `test_new_classic_parquet_checkpoint`  - verifies classic-named Parquet checkpoint creation with proper attributes.