### PR TITLE
chore: unpin chrono dependency

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -38,7 +38,7 @@ pre-release-hook = [
 
 [dependencies]
 bytes = "1.7"
-chrono = "=0.4.39"
+chrono = "0.4.40"
 fix-hidden-lifetime-bug = "0.2"
 indexmap = "2.5.0"
 itertools = "0.13"


### PR DESCRIPTION
## What changes are proposed in this pull request?
Previously (#719) we pinned chrono to `0.4.39` to avoid breaking arrow. Recently, arrow fixed the issue and bumped their own chrono dep to `0.4.40` (currently the latest) https://github.com/apache/arrow-rs/pull/7198. This PR unpins chrono so we are back on the latest `0.4`

EDIT: looks like the backport fix to arrow 53 only includes the pinning of the chrono version (that is, the PR which fixes/updates chrono isn't in arrow 53) https://github.com/apache/arrow-rs/pull/7231. We can either (1) stop supporting arrow 53 or (2) keep chrono pinned (or perhaps there's a way to pin only for arrow53?)

resolves #721 

## How was this change tested?
<!--
Please make sure to add test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested, ideally via a reproducible test documented in the PR description.
-->
existing