### PR TITLE
refactor: Rename `_last_checkpoint` from `CheckpointMetadata` to `LastCheckpointHint`

### DIFF
--- a/acceptance/tests/other.rs
+++ b/acceptance/tests/other.rs
@@ -3,7 +3,7 @@
 /// Since each new `.rs` file in this directory results in increased build and link time, it is
 /// important to only add new files if absolutely necessary for code readability or test
 /// performance.
-use delta_kernel::snapshot::CheckpointMetadata;
+use delta_kernel::snapshot::LastCheckpointHint;
 
 #[test]
 fn test_checkpoint_serde() {
@@ -11,7 +11,7 @@ fn test_checkpoint_serde() {
         "./tests/dat/out/reader_tests/generated/with_checkpoint/delta/_delta_log/_last_checkpoint",
     )
     .unwrap();
-    let cp: CheckpointMetadata = serde_json::from_reader(file).unwrap();
+    let cp: LastCheckpointHint = serde_json::from_reader(file).unwrap();
     assert_eq!(cp.version, 2)
 }
 

--- a/kernel/src/actions/schemas.rs
+++ b/kernel/src/actions/schemas.rs
@@ -8,15 +8,6 @@ pub(crate) trait ToSchema {
     fn to_schema() -> StructType;
 }
 
-/// Implement ToSchema for StructType to enable its use within Option<T> fields
-/// in schema-derived structs. This follows the system pattern where schema types
-/// implement ToSchema rather than directly implementing ToDataType.
-impl ToSchema for StructType {
-    fn to_schema() -> StructType {
-        StructType::new(vec![])
-    }
-}
-
 pub(crate) trait ToDataType {
     fn to_data_type() -> DataType;
 }

--- a/kernel/src/actions/schemas.rs
+++ b/kernel/src/actions/schemas.rs
@@ -8,6 +8,15 @@ pub(crate) trait ToSchema {
     fn to_schema() -> StructType;
 }
 
+/// Implement ToSchema for StructType to enable its use within Option<T> fields
+/// in schema-derived structs. This follows the system pattern where schema types
+/// implement ToSchema rather than directly implementing ToDataType.
+impl ToSchema for StructType {
+    fn to_schema() -> StructType {
+        StructType::new(vec![])
+    }
+}
+
 pub(crate) trait ToDataType {
     fn to_data_type() -> DataType;
 }

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -131,7 +131,7 @@ impl LogSegment {
                 // Else, we check if the checkpoint hint's version is less than or equal to the
                 // time travel version.
                 (Some(cp), Some(end_version))
-                    if i64::try_from(end_version).map_or(false, |v| cp.version <= v) =>
+                    if i64::try_from(end_version).is_ok_and(|v| cp.version <= v) =>
                 {
                     list_log_files_with_checkpoint(&cp, fs_client, &log_root, Some(end_version))?
                 }

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -8,7 +8,7 @@ use crate::actions::{
 };
 use crate::path::{LogPathFileType, ParsedLogPath};
 use crate::schema::SchemaRef;
-use crate::snapshot::CheckpointMetadata;
+use crate::snapshot::LastCheckpointHint;
 use crate::utils::require;
 use crate::{
     DeltaResult, Engine, EngineData, Error, Expression, ExpressionRef, FileSystemClient,
@@ -109,7 +109,7 @@ impl LogSegment {
     /// parts. All these parts will have the same checkpoint version.
     ///
     /// The options for constructing a LogSegment for Snapshot are as follows:
-    /// - `checkpoint_hint`: a `CheckpointMetadata` to start the log segment from (e.g. from reading the `last_checkpoint` file).
+    /// - `checkpoint_hint`: a `LastCheckpointHint` to start the log segment from (e.g. from reading the `last_checkpoint` file).
     /// - `time_travel_version`: The version of the log that the Snapshot will be at.
     ///
     /// [`Snapshot`]: crate::snapshot::Snapshot
@@ -117,7 +117,7 @@ impl LogSegment {
     pub(crate) fn for_snapshot(
         fs_client: &dyn FileSystemClient,
         log_root: Url,
-        checkpoint_hint: impl Into<Option<CheckpointMetadata>>,
+        checkpoint_hint: impl Into<Option<LastCheckpointHint>>,
         time_travel_version: impl Into<Option<Version>>,
     ) -> DeltaResult<Self> {
         let time_travel_version = time_travel_version.into();
@@ -127,7 +127,12 @@ impl LogSegment {
                 (Some(cp), None) => {
                     list_log_files_with_checkpoint(&cp, fs_client, &log_root, None)?
                 }
-                (Some(cp), Some(end_version)) if cp.version <= end_version => {
+                // If type conversion fails, we skip the checkpoint hint and list all log files.
+                // Else, we check if the checkpoint hint's version is less than or equal to the
+                // time travel version.
+                (Some(cp), Some(end_version))
+                    if i64::try_from(end_version).map_or(false, |v| cp.version <= v) =>
+                {
                     list_log_files_with_checkpoint(&cp, fs_client, &log_root, Some(end_version))?
                 }
                 _ => list_log_files_with_version(fs_client, &log_root, None, time_travel_version)?,
@@ -535,15 +540,26 @@ fn group_checkpoint_parts(parts: Vec<ParsedLogPath>) -> HashMap<u32, Vec<ParsedL
 /// the returned [`ParsedLogPath`]s will have a version less than or equal to the `end_version`.
 /// See [`list_log_files_with_version`] for details on the return type.
 fn list_log_files_with_checkpoint(
-    checkpoint_metadata: &CheckpointMetadata,
+    checkpoint_metadata: &LastCheckpointHint,
     fs_client: &dyn FileSystemClient,
     log_root: &Url,
     end_version: Option<Version>,
 ) -> DeltaResult<(Vec<ParsedLogPath>, Vec<ParsedLogPath>)> {
+    // Safely convert checkpoint_metadata.version (i64) to u64 for comparisons
+    let checkpoint_metadata_version = match u64::try_from(checkpoint_metadata.version) {
+        Ok(version) => version,
+        Err(e) => {
+            return Err(Error::InvalidCheckpoint(format!(
+                "Invalid checkpoint version (negative value): {}",
+                e
+            )));
+        }
+    };
+
     let (commit_files, checkpoint_parts) = list_log_files_with_version(
         fs_client,
         log_root,
-        Some(checkpoint_metadata.version),
+        Some(checkpoint_metadata_version),
         end_version,
     )?;
 
@@ -553,18 +569,31 @@ fn list_log_files_with_checkpoint(
             "Had a _last_checkpoint hint but didn't find any checkpoints",
         ));
     };
-    if latest_checkpoint.version != checkpoint_metadata.version {
+    if latest_checkpoint.version != checkpoint_metadata_version {
         warn!(
             "_last_checkpoint hint is out of date. _last_checkpoint version: {}. Using actual most recent: {}",
             checkpoint_metadata.version,
             latest_checkpoint.version
         );
-    } else if checkpoint_parts.len() != checkpoint_metadata.parts.unwrap_or(1) {
-        return Err(Error::InvalidCheckpoint(format!(
-            "_last_checkpoint indicated that checkpoint should have {} parts, but it has {}",
-            checkpoint_metadata.parts.unwrap_or(1),
-            checkpoint_parts.len()
-        )));
+    } else {
+        // Convert checkpoint_metadata.parts(i64) to usize for comparisons
+        let expected_parts = match usize::try_from(checkpoint_metadata.parts.unwrap_or(1)) {
+            Ok(parts) => parts,
+            Err(e) => {
+                return Err(Error::InvalidCheckpoint(format!(
+                    "Invalid number of checkpoint parts (negative or too large): {}",
+                    e
+                )));
+            }
+        };
+
+        if checkpoint_parts.len() != expected_parts {
+            return Err(Error::InvalidCheckpoint(format!(
+                "_last_checkpoint indicated that checkpoint should have {} parts, but it has {}",
+                expected_parts,
+                checkpoint_parts.len()
+            )));
+        }
     }
     Ok((commit_files, checkpoint_parts))
 }

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -22,7 +22,7 @@ use crate::path::ParsedLogPath;
 use crate::scan::test_utils::{
     add_batch_simple, add_batch_with_remove, sidecar_batch_with_given_paths,
 };
-use crate::snapshot::CheckpointMetadata;
+use crate::snapshot::LastCheckpointHint;
 use crate::utils::test_utils::{assert_batch_matches, Action};
 use crate::{
     DeltaResult, Engine, EngineData, Expression, ExpressionRef, FileMeta, FileSystemClient,
@@ -81,10 +81,10 @@ fn delta_path_for_multipart_checkpoint(version: u64, part_num: u32, num_parts: u
 }
 
 // Utility method to build a log using a list of log paths and an optional checkpoint hint. The
-// CheckpointMetadata is written to `_delta_log/_last_checkpoint`.
+// LastCheckpointHint is written to `_delta_log/_last_checkpoint`.
 fn build_log_with_paths_and_checkpoint(
     paths: &[Path],
-    checkpoint_metadata: Option<&CheckpointMetadata>,
+    checkpoint_metadata: Option<&LastCheckpointHint>,
 ) -> (Box<dyn FileSystemClient>, Url) {
     let store = Arc::new(InMemory::new());
 
@@ -269,7 +269,7 @@ fn build_snapshot_with_uuid_checkpoint_json() {
 
 #[test]
 fn build_snapshot_with_correct_last_uuid_checkpoint() {
-    let checkpoint_metadata = CheckpointMetadata {
+    let checkpoint_metadata = LastCheckpointHint {
         version: 5,
         size: 10,
         parts: Some(1),
@@ -347,7 +347,7 @@ fn build_snapshot_with_multiple_incomplete_multipart_checkpoints() {
 
 #[test]
 fn build_snapshot_with_out_of_date_last_checkpoint() {
-    let checkpoint_metadata = CheckpointMetadata {
+    let checkpoint_metadata = LastCheckpointHint {
         version: 3,
         size: 10,
         parts: None,
@@ -384,7 +384,7 @@ fn build_snapshot_with_out_of_date_last_checkpoint() {
 }
 #[test]
 fn build_snapshot_with_correct_last_multipart_checkpoint() {
-    let checkpoint_metadata = CheckpointMetadata {
+    let checkpoint_metadata = LastCheckpointHint {
         version: 5,
         size: 10,
         parts: Some(3),
@@ -427,7 +427,7 @@ fn build_snapshot_with_correct_last_multipart_checkpoint() {
 
 #[test]
 fn build_snapshot_with_missing_checkpoint_part_from_hint_fails() {
-    let checkpoint_metadata = CheckpointMetadata {
+    let checkpoint_metadata = LastCheckpointHint {
         version: 5,
         size: 10,
         parts: Some(3),
@@ -462,7 +462,7 @@ fn build_snapshot_with_missing_checkpoint_part_from_hint_fails() {
 }
 #[test]
 fn build_snapshot_with_bad_checkpoint_hint_fails() {
-    let checkpoint_metadata = CheckpointMetadata {
+    let checkpoint_metadata = LastCheckpointHint {
         version: 5,
         size: 10,
         parts: Some(1),
@@ -536,7 +536,7 @@ fn build_snapshot_with_out_of_date_last_checkpoint_and_incomplete_recent_checkpo
     // When the _last_checkpoint is out of date and the most recent checkpoint is incomplete, the
     // Snapshot should be made of the most recent complete checkpoint and the commit files that
     // follow it.
-    let checkpoint_metadata = CheckpointMetadata {
+    let checkpoint_metadata = LastCheckpointHint {
         version: 3,
         size: 10,
         parts: None,
@@ -625,7 +625,7 @@ fn build_snapshot_without_checkpoints() {
 
 #[test]
 fn build_snapshot_with_checkpoint_greater_than_time_travel_version() {
-    let checkpoint_metadata = CheckpointMetadata {
+    let checkpoint_metadata = LastCheckpointHint {
         version: 5,
         size: 10,
         parts: None,
@@ -665,7 +665,7 @@ fn build_snapshot_with_checkpoint_greater_than_time_travel_version() {
 
 #[test]
 fn build_snapshot_with_start_checkpoint_and_time_travel_version() {
-    let checkpoint_metadata = CheckpointMetadata {
+    let checkpoint_metadata = LastCheckpointHint {
         version: 3,
         size: 10,
         parts: None,

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -156,9 +156,9 @@ struct LastCheckpointHint {
     /// The number of fragments if the last checkpoint was written in multiple parts.
     pub(crate) parts: Option<usize>,
     /// The number of bytes of the checkpoint.
-    pub(crate) size_in_bytes: Option<i64>, // TODO: use u64 instead
+    pub(crate) size_in_bytes: Option<i64>,
     /// The number of AddFile actions in the checkpoint.
-    pub(crate) num_of_add_files: Option<i64>, // TODO: use u64 instead
+    pub(crate) num_of_add_files: Option<i64>,
     /// The schema of the checkpoint file.
     pub(crate) checkpoint_schema: Option<Schema>,
     /// The checksum of the last checkpoint JSON.

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -142,6 +142,7 @@ impl Snapshot {
     }
 }
 
+// Note: Schema can not be derived because the checkpoint schema is only known at runtime.
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "developer-visibility", visibility::make(pub))]

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -1,7 +1,6 @@
 //! In-memory representation of snapshots of tables (snapshot is a table at given point in time, it
 //! has schema etc.)
 
-use delta_kernel_derive::Schema;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::{debug, warn};
@@ -143,18 +142,18 @@ impl Snapshot {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Schema)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "developer-visibility", visibility::make(pub))]
 #[cfg_attr(not(feature = "developer-visibility"), visibility::make(pub(crate)))]
 struct LastCheckpointHint {
     /// The version of the table when the last checkpoint was made.
     #[allow(unreachable_pub)] // used by acceptance tests (TODO make an fn accessor?)
-    pub version: i64, // TODO: use Version type instead of i64
+    pub version: Version,
     /// The number of actions that are stored in the checkpoint.
     pub(crate) size: i64,
     /// The number of fragments if the last checkpoint was written in multiple parts.
-    pub(crate) parts: Option<i64>, // TODO: use usize instead
+    pub(crate) parts: Option<usize>,
     /// The number of bytes of the checkpoint.
     pub(crate) size_in_bytes: Option<i64>, // TODO: use u64 instead
     /// The number of AddFile actions in the checkpoint.

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -98,7 +98,7 @@ impl Snapshot {
         self.table_configuration().version()
     }
 
-    /// Table [`Schema`] at this `Snapshot`s version.
+    /// Table [`type@Schema`] at this `Snapshot`s version.
     pub fn schema(&self) -> SchemaRef {
         self.table_configuration.schema()
     }

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -1,6 +1,7 @@
 //! In-memory representation of snapshots of tables (snapshot is a table at given point in time, it
 //! has schema etc.)
 
+use delta_kernel_derive::Schema;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::{debug, warn};
@@ -142,22 +143,22 @@ impl Snapshot {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Schema)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "developer-visibility", visibility::make(pub))]
 #[cfg_attr(not(feature = "developer-visibility"), visibility::make(pub(crate)))]
-struct CheckpointMetadata {
+struct LastCheckpointHint {
     /// The version of the table when the last checkpoint was made.
     #[allow(unreachable_pub)] // used by acceptance tests (TODO make an fn accessor?)
-    pub version: Version,
+    pub version: i64, // TODO: use Version type instead of i64
     /// The number of actions that are stored in the checkpoint.
     pub(crate) size: i64,
     /// The number of fragments if the last checkpoint was written in multiple parts.
-    pub(crate) parts: Option<usize>,
+    pub(crate) parts: Option<i64>, // TODO: use u64 instead
     /// The number of bytes of the checkpoint.
-    pub(crate) size_in_bytes: Option<i64>,
+    pub(crate) size_in_bytes: Option<i64>, // TODO: use u64 instead
     /// The number of AddFile actions in the checkpoint.
-    pub(crate) num_of_add_files: Option<i64>,
+    pub(crate) num_of_add_files: Option<i64>, // TODO: use u64 instead
     /// The schema of the checkpoint file.
     pub(crate) checkpoint_schema: Option<Schema>,
     /// The checksum of the last checkpoint JSON.
@@ -175,7 +176,7 @@ struct CheckpointMetadata {
 fn read_last_checkpoint(
     fs_client: &dyn FileSystemClient,
     log_root: &Url,
-) -> DeltaResult<Option<CheckpointMetadata>> {
+) -> DeltaResult<Option<LastCheckpointHint>> {
     let file_path = log_root.join(LAST_CHECKPOINT_FILE_NAME)?;
     match fs_client
         .read_files(vec![(file_path, None)])

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -154,7 +154,7 @@ struct LastCheckpointHint {
     /// The number of actions that are stored in the checkpoint.
     pub(crate) size: i64,
     /// The number of fragments if the last checkpoint was written in multiple parts.
-    pub(crate) parts: Option<i64>, // TODO: use u64 instead
+    pub(crate) parts: Option<i64>, // TODO: use usize instead
     /// The number of bytes of the checkpoint.
     pub(crate) size_in_bytes: Option<i64>, // TODO: use u64 instead
     /// The number of AddFile actions in the checkpoint.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-incubator/delta-kernel-rs/blob/main/CONTRIBUTING.md
  2. Run `cargo t --all-features --all-targets` to get started testing, and run `cargo fmt`.
  3. Ensure you have added or run the appropriate tests for your PR.
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

<!--
PR title formatting:
This project uses conventional commits: https://www.conventionalcommits.org/

Each PR corresponds to a commit on the `main` branch, with the title of the PR (typically) being
used for the commit message on main. In order to ensure proper formatting in the CHANGELOG please
ensure your PR title adheres to the conventional commit specification.

Examples:
- new feature PR: "feat: new API for snapshot.update()"
- bugfix PR: "fix: correctly apply DV in read-table example"
-->

## What changes are proposed in this pull request?
<!--
Please clarify what changes you are proposing and why the changes are needed.
The purpose of this section is to outline the changes, why they are needed, and how this PR fixes the issue.
If the reason for the change is already explained clearly in an issue, then it does not need to be restated here.
  1. If you propose a new API or feature, clarify the use case for a new API or feature.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This PR renames `CheckpointMetadata` to `LastCheckpointHint` in order not to clash with the incoming `CheckpointMetadata` [[link to PR]](https://github.com/delta-io/delta-kernel-rs/pull/781). 


Moved to another PR
~~This PR also changes the types of fields in the `LastCheckpointHint`. This was done to unblock the in-flight work for single-file checkpoint write support, which includes the creation of the `_last_checkpoint` file. As `usize` and `u64` primitives are not supported, and we want to avoid a mismatch of field types we read v.s. write, we are updating the types to `i64`.  There is an overarching github issue for converting field types to unsigned integers (u64, usize) where semantically appropriate (such as for `LastCheckpointHint.version`... ) and adding proper support for these data type primitives throughout the codebase. https://github.com/delta-io/delta-kernel-rs/issues/786~~


<!--
Uncomment this section if there are any changes affecting public APIs:
### This PR affects the following public APIs

If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.

Note that _new_ public APIs are not considered breaking.
-->


## How was this change tested?
<!--
Please make sure to add test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested, ideally via a reproducible test documented in the PR description.
-->

No new behavioral changes. All current tests pass ✅ 