### PR TITLE
fix: update compilation error and clippy lints for rustc 1.86

### DIFF
--- a/ffi/src/scan.rs
+++ b/ffi/src/scan.rs
@@ -254,7 +254,7 @@ pub struct Stats {
 /// * `size`: an `i64` which is the size of the file
 /// * `dv_info`: a [`DvInfo`] struct, which allows getting the selection vector for this file
 /// * `transform`: An optional expression that, if not `NULL`, _must_ be applied to physical data to
-///                convert it to the correct logical format. If this is `NULL`, no transform is needed.
+///   convert it to the correct logical format. If this is `NULL`, no transform is needed.
 /// * `partition_values`: [DEPRECATED] a `HashMap<String, String>` which are partition values
 type CScanCallback = extern "C" fn(
     engine_context: NullableCvoid,

--- a/ffi/tests/invalid-handle-code/private-constructor.stderr
+++ b/ffi/tests/invalid-handle-code/private-constructor.stderr
@@ -2,4 +2,4 @@ error[E0451]: field `ptr` of struct `Handle` is private
   --> tests/invalid-handle-code/private-constructor.rs:10:41
    |
 10 |     let _: Handle<SharedFoo> = Handle { ptr: std::ptr::NonNull::dangling() };
-   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private field
+   |                                         ^^^ private field

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -510,7 +510,7 @@ mod tests {
             .try_into()
             .unwrap();
 
-        let filename = location.path().split('/').last().unwrap();
+        let filename = location.path().split('/').next_back().unwrap();
         assert_eq!(&expected_location.join(filename).unwrap(), location);
         assert_eq!(expected_size, size);
         assert!(now - last_modified < 10_000);

--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -88,7 +88,7 @@ impl<Location: AsUrl> ParsedLogPath<Location> {
         let filename = url
             .path_segments()
             .ok_or_else(|| Error::invalid_log_path(url))?
-            .last()
+            .next_back()
             .unwrap() // "the iterator always contains at least one string (which may be empty)"
             .to_string();
         if filename.is_empty() {

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -33,9 +33,9 @@ mod tests;
 ///
 /// The variadic operations are rewritten as follows:
 /// - `AND` is rewritten as a conjunction of the rewritten operands where we just skip operands that
-///         are not eligible for data skipping.
+///   are not eligible for data skipping.
 /// - `OR` is rewritten only if all operands are eligible for data skipping. Otherwise, the whole OR
-///        expression is dropped.
+///   expression is dropped.
 #[cfg(test)]
 fn as_data_skipping_predicate(expr: &Expr) -> Option<Expr> {
     DataSkippingPredicateCreator.eval(expr)

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -389,12 +389,12 @@ impl Scan {
     ///   `filter_record_batch`, you _need_ to extend this vector to the full length of the batch or
     ///   arrow will drop the extra rows.
     /// - `Vec<Option<Expression>>`: Transformation expressions that need to be applied. For each
-    ///    row at index `i` in the above data, if an expression exists at index `i` in the `Vec`,
-    ///    the associated expression _must_ be applied to the data read from the file specified by
-    ///    the row. The resultant schema for this expression is guaranteed to be `Scan.schema()`. If
-    ///    the item at index `i` in this `Vec` is `None`, or if the `Vec` contains fewer than `i`
-    ///    elements, no expression need be applied and the data read from disk is already in the
-    ///    correct logical state.
+    ///   row at index `i` in the above data, if an expression exists at index `i` in the `Vec`,
+    ///   the associated expression _must_ be applied to the data read from the file specified by
+    ///   the row. The resultant schema for this expression is guaranteed to be `Scan.schema()`. If
+    ///   the item at index `i` in this `Vec` is `None`, or if the `Vec` contains fewer than `i`
+    ///   elements, no expression need be applied and the data read from disk is already in the
+    ///   correct logical state.
     pub fn scan_data(
         &self,
         engine: &dyn Engine,

--- a/kernel/src/scan/state.rs
+++ b/kernel/src/scan/state.rs
@@ -135,12 +135,13 @@ pub type ScanCallback<T> = fn(
 /// scan.
 ///
 /// The arguments to the callback are:
-/// * `context`: an `&mut context` argument. this can be anything that engine needs to pass through to each call
+/// * `context`: an `&mut context` argument. this can be anything that engine needs to pass through
+///   to each call
 /// * `path`: a `&str` which is the path to the file
 /// * `size`: an `i64` which is the size of the file
 /// * `dv_info`: a [`DvInfo`] struct, which allows getting the selection vector for this file
-/// * `transform`: An optional expression that, if present, _must_ be applied to physical data to convert it to
-///                the correct logical format
+/// * `transform`: An optional expression that, if present, _must_ be applied to physical data to
+///   convert it to the correct logical format
 /// * `partition_values`: a `HashMap<String, String>` which are partition values
 ///
 /// ## Context


### PR DESCRIPTION
builds currently broken due to rustc 1.86 changing an error message + new clippy lints. this PR updates expected output to the new error and does two clippy lints:
1. `next_back()` instead of `last()` on iterators
2. docstring indentation updates