### PR TITLE
refactor!: Remove get_ prefix from engine getters

### DIFF
--- a/ffi/examples/read-table/arrow.c
+++ b/ffi/examples/read-table/arrow.c
@@ -117,7 +117,7 @@ static ExclusiveEngineData* apply_transform(
     return data;
   }
   print_diag("  Applying transform\n");
-  SharedExpressionEvaluator* evaluator = get_evaluator(
+  SharedExpressionEvaluator* evaluator = new_expression_evaluator(
     context->engine,
     context->read_schema, // input schema
     context->arrow_context->cur_transform,
@@ -127,7 +127,7 @@ static ExclusiveEngineData* apply_transform(
     &data,
     evaluator);
   free_engine_data(data);
-  free_evaluator(evaluator);
+  free_expression_evaluator(evaluator);
   if (transformed_res.tag != OkHandleExclusiveEngineData) {
     print_error("Failed to transform read data.", (Error*)transformed_res.err);
     free_error((Error*)transformed_res.err);

--- a/kernel/examples/read-table-multi-threaded/src/main.rs
+++ b/kernel/examples/read-table-multi-threaded/src/main.rs
@@ -286,7 +286,7 @@ fn do_work(
         // enough meta-data was passed to each thread to correctly apply the selection
         // vector
         let read_results = engine
-            .get_parquet_handler()
+            .parquet_handler()
             .read_parquet_files(&[meta], scan_state.physical_schema.clone(), None)
             .unwrap();
 

--- a/kernel/src/actions/deletion_vector.rs
+++ b/kernel/src/actions/deletion_vector.rs
@@ -363,7 +363,7 @@ mod tests {
     fn test_inline_read() {
         let inline = dv_inline();
         let sync_engine = SyncEngine::new();
-        let fs_client = sync_engine.get_file_system_client();
+        let fs_client = sync_engine.file_system_client();
         let parent = Url::parse("http://not.used").unwrap();
         let tree_map = inline.read(fs_client, &parent).unwrap();
         assert_eq!(tree_map.len(), 6);
@@ -381,7 +381,7 @@ mod tests {
             std::fs::canonicalize(PathBuf::from("./tests/data/table-with-dv-small/")).unwrap();
         let parent = url::Url::from_directory_path(path).unwrap();
         let sync_engine = SyncEngine::new();
-        let fs_client = sync_engine.get_file_system_client();
+        let fs_client = sync_engine.file_system_client();
 
         let example = dv_example();
         let tree_map = example.read(fs_client, &parent).unwrap();
@@ -441,7 +441,7 @@ mod tests {
     fn test_dv_row_indexes() {
         let example = dv_inline();
         let sync_engine = SyncEngine::new();
-        let fs_client = sync_engine.get_file_system_client();
+        let fs_client = sync_engine.file_system_client();
         let parent = Url::parse("http://not.used").unwrap();
         let row_idx = example.row_indexes(fs_client, &parent).unwrap();
 

--- a/kernel/src/engine/arrow_data.rs
+++ b/kernel/src/engine/arrow_data.rs
@@ -306,7 +306,7 @@ mod tests {
     #[test]
     fn test_md_extract() -> DeltaResult<()> {
         let engine = SyncEngine::new();
-        let handler = engine.get_json_handler();
+        let handler = engine.json_handler();
         let json_strings: StringArray = vec![
             r#"{"metaData":{"id":"aff5cb91-8cd9-4195-aef9-446908507302","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"c1\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}},{\"name\":\"c2\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"c3\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":["c1","c2"],"configuration":{},"createdTime":1670892997849}}"#,
         ]
@@ -325,7 +325,7 @@ mod tests {
     #[test]
     fn test_protocol_extract() -> DeltaResult<()> {
         let engine = SyncEngine::new();
-        let handler = engine.get_json_handler();
+        let handler = engine.json_handler();
         let json_strings: StringArray = vec![
             r#"{"protocol": {"minReaderVersion": 3, "minWriterVersion": 7, "readerFeatures": ["rw1"], "writerFeatures": ["rw1", "w2"]}}"#,
         ]

--- a/kernel/src/engine/arrow_expression/mod.rs
+++ b/kernel/src/engine/arrow_expression/mod.rs
@@ -17,7 +17,7 @@ use crate::engine::arrow_data::ArrowEngineData;
 use crate::error::{DeltaResult, Error};
 use crate::expressions::{Expression, Scalar};
 use crate::schema::{DataType, PrimitiveType, SchemaRef};
-use crate::{EngineData, ExpressionEvaluator, ExpressionHandler};
+use crate::{EngineData, EvaluationHandler, ExpressionEvaluator};
 
 use itertools::Itertools;
 use tracing::debug;
@@ -123,10 +123,10 @@ impl Scalar {
 }
 
 #[derive(Debug)]
-pub struct ArrowExpressionHandler;
+pub struct ArrowEvaluationHandler;
 
-impl ExpressionHandler for ArrowExpressionHandler {
-    fn get_evaluator(
+impl EvaluationHandler for ArrowEvaluationHandler {
+    fn new_expression_evaluator(
         &self,
         schema: SchemaRef,
         expression: Expression,

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -10,7 +10,7 @@ use super::*;
 use crate::expressions::*;
 use crate::schema::{ArrayType, StructField, StructType};
 use crate::DataType as DeltaDataTypes;
-use crate::ExpressionHandlerExtension as _;
+use crate::EvaluationHandlerExtension as _;
 
 #[test]
 fn test_array_column() {
@@ -312,7 +312,7 @@ fn test_null_row() {
         ),
         StructField::nullable("c", crate::schema::DataType::STRING),
     ]));
-    let handler = ArrowExpressionHandler;
+    let handler = ArrowEvaluationHandler;
     let result = handler.null_row(schema.clone()).unwrap();
     let expected = RecordBatch::try_new(
         Arc::new(schema.as_ref().try_into().unwrap()),
@@ -343,13 +343,13 @@ fn test_null_row_err() {
         "a",
         crate::schema::DataType::STRING,
     )]));
-    let handler = ArrowExpressionHandler;
+    let handler = ArrowEvaluationHandler;
     assert!(handler.null_row(not_null_schema).is_err());
 }
 
 // helper to take values/schema to pass to `create_one` and assert the result = expected
 fn assert_create_one(values: &[Scalar], schema: SchemaRef, expected: RecordBatch) {
-    let handler = ArrowExpressionHandler;
+    let handler = ArrowEvaluationHandler;
     let actual = handler.create_one(schema, values).unwrap();
     let actual_rb: RecordBatch = actual
         .into_any()
@@ -482,14 +482,14 @@ fn test_create_one_not_null_struct() {
             StructField::nullable("c", DeltaDataTypes::INTEGER),
         ]),
     )]));
-    let handler = ArrowExpressionHandler;
+    let handler = ArrowEvaluationHandler;
     assert!(handler.create_one(schema, values).is_err());
 }
 
 #[test]
 fn test_create_one_top_level_null() {
     let values = &[Scalar::Null(DeltaDataTypes::INTEGER)];
-    let handler = ArrowExpressionHandler;
+    let handler = ArrowEvaluationHandler;
 
     let schema = Arc::new(StructType::new([StructField::not_null(
         "col_1",

--- a/kernel/src/engine/default/filesystem.rs
+++ b/kernel/src/engine/default/filesystem.rs
@@ -234,7 +234,7 @@ mod tests {
         let table_root = Url::parse("memory:///").expect("valid url");
         let engine = DefaultEngine::new(store, Arc::new(TokioBackgroundExecutor::new()));
         let files: Vec<_> = engine
-            .get_file_system_client()
+            .file_system_client()
             .list_from(&table_root.join("_delta_log").unwrap().join("0").unwrap())
             .unwrap()
             .try_collect()
@@ -263,7 +263,7 @@ mod tests {
         let url = Url::from_directory_path(tmp.path()).unwrap();
         let store = Arc::new(LocalFileSystem::new());
         let engine = DefaultEngine::new(store, Arc::new(TokioBackgroundExecutor::new()));
-        let client = engine.get_file_system_client();
+        let client = engine.file_system_client();
 
         let files = client
             .list_from(&url.join("_delta_log").unwrap().join("0").unwrap())

--- a/kernel/src/engine/mod.rs
+++ b/kernel/src/engine/mod.rs
@@ -47,7 +47,7 @@ mod tests {
         base_url: &Url,
         engine_data: impl Fn() -> Box<dyn EngineData>,
     ) {
-        let json = engine.get_json_handler();
+        let json = engine.json_handler();
         let get_data = || Box::new(std::iter::once(Ok(engine_data())));
 
         let expected_names: Vec<Path> = (1..4)
@@ -61,7 +61,7 @@ mod tests {
         let path = base_url.join("other").unwrap();
         json.write_json_file(&path, get_data(), false).unwrap();
 
-        let fs = engine.get_file_system_client();
+        let fs = engine.file_system_client();
 
         // list files after an offset
         let test_url = base_url.join(expected_names[0].as_ref()).unwrap();

--- a/kernel/src/engine/sync/mod.rs
+++ b/kernel/src/engine/sync/mod.rs
@@ -1,9 +1,9 @@
 //! A simple, single threaded, [`Engine`] that can only read from the local filesystem
 
-use super::arrow_expression::ArrowExpressionHandler;
+use super::arrow_expression::ArrowEvaluationHandler;
 use crate::engine::arrow_data::ArrowEngineData;
 use crate::{
-    DeltaResult, Engine, Error, ExpressionHandler, ExpressionRef, FileDataReadResultIterator,
+    DeltaResult, Engine, Error, EvaluationHandler, ExpressionRef, FileDataReadResultIterator,
     FileMeta, FileSystemClient, JsonHandler, ParquetHandler, SchemaRef,
 };
 
@@ -23,7 +23,7 @@ pub struct SyncEngine {
     fs_client: Arc<fs_client::SyncFilesystemClient>,
     json_handler: Arc<json::SyncJsonHandler>,
     parquet_handler: Arc<parquet::SyncParquetHandler>,
-    expression_handler: Arc<ArrowExpressionHandler>,
+    evaluation_handler: Arc<ArrowEvaluationHandler>,
 }
 
 impl SyncEngine {
@@ -33,26 +33,26 @@ impl SyncEngine {
             fs_client: Arc::new(fs_client::SyncFilesystemClient {}),
             json_handler: Arc::new(json::SyncJsonHandler {}),
             parquet_handler: Arc::new(parquet::SyncParquetHandler {}),
-            expression_handler: Arc::new(ArrowExpressionHandler {}),
+            evaluation_handler: Arc::new(ArrowEvaluationHandler {}),
         }
     }
 }
 
 impl Engine for SyncEngine {
-    fn get_expression_handler(&self) -> Arc<dyn ExpressionHandler> {
-        self.expression_handler.clone()
+    fn evaluation_handler(&self) -> Arc<dyn EvaluationHandler> {
+        self.evaluation_handler.clone()
     }
 
-    fn get_file_system_client(&self) -> Arc<dyn FileSystemClient> {
+    fn file_system_client(&self) -> Arc<dyn FileSystemClient> {
         self.fs_client.clone()
     }
 
     /// Get the connector provided [`ParquetHandler`].
-    fn get_parquet_handler(&self) -> Arc<dyn ParquetHandler> {
+    fn parquet_handler(&self) -> Arc<dyn ParquetHandler> {
         self.parquet_handler.clone()
     }
 
-    fn get_json_handler(&self) -> Arc<dyn JsonHandler> {
+    fn json_handler(&self) -> Arc<dyn JsonHandler> {
         self.json_handler.clone()
     }
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -35,7 +35,7 @@
 //!
 //! ## Expression handling
 //!
-//! Expression handling is done via the [`ExpressionHandler`], which in turn allows the creation of
+//! Expression handling is done via the [`EvaluationHandler`], which in turn allows the creation of
 //! [`ExpressionEvaluator`]s. These evaluators are created for a specific predicate [`Expression`]
 //! and allow evaluation of that predicate for a specific batches of data.
 //!
@@ -327,7 +327,7 @@ pub trait ExpressionEvaluator: AsAny {
 ///
 /// Delta Kernel can use this handler to evaluate predicate on partition filters,
 /// fill up partition column values and any computation on data using Expressions.
-pub trait ExpressionHandler: AsAny {
+pub trait EvaluationHandler: AsAny {
     /// Create an [`ExpressionEvaluator`] that can evaluate the given [`Expression`]
     /// on columnar batches with the given [`Schema`] to produce data of [`DataType`].
     ///
@@ -339,7 +339,7 @@ pub trait ExpressionHandler: AsAny {
     ///
     /// [`Schema`]: crate::schema::StructType
     /// [`DataType`]: crate::schema::DataType
-    fn get_evaluator(
+    fn new_expression_evaluator(
         &self,
         schema: SchemaRef,
         expression: Expression,
@@ -354,10 +354,10 @@ pub trait ExpressionHandler: AsAny {
 }
 
 /// Internal trait to allow us to have a private `create_one` API that's implemented for all
-/// ExpressionHandlers.
+/// EvaluationHandlers.
 // For some reason rustc doesn't detect it's usage so we allow(dead_code) here...
 #[allow(dead_code)]
-trait ExpressionHandlerExtension: ExpressionHandler {
+trait EvaluationHandlerExtension: EvaluationHandler {
     /// Create a single-row [`EngineData`] by applying the given schema to the leaf-values given in
     /// `values`.
     // Note: we will stick with a Schema instead of DataType (more constrained can expand in
@@ -375,13 +375,13 @@ trait ExpressionHandlerExtension: ExpressionHandler {
         schema_transform.transform_struct(schema.as_ref());
         let row_expr = schema_transform.try_into_expr()?;
 
-        let eval = self.get_evaluator(null_row_schema, row_expr, schema.into());
+        let eval = self.new_expression_evaluator(null_row_schema, row_expr, schema.into());
         eval.evaluate(null_row.as_ref())
     }
 }
 
-// Auto-implement the extension trait for all ExpressionHandlers
-impl<T: ExpressionHandler> ExpressionHandlerExtension for T {}
+// Auto-implement the extension trait for all EvaluationHandlers
+impl<T: EvaluationHandler> EvaluationHandlerExtension for T {}
 
 /// Provides file system related functionalities to Delta Kernel.
 ///
@@ -503,17 +503,17 @@ pub trait ParquetHandler: AsAny {
 /// Engines/Connectors are expected to pass an implementation of this trait when reading a Delta
 /// table.
 pub trait Engine: AsAny {
-    /// Get the connector provided [`ExpressionHandler`].
-    fn get_expression_handler(&self) -> Arc<dyn ExpressionHandler>;
+    /// Get the connector provided [`EvaluationHandler`].
+    fn evaluation_handler(&self) -> Arc<dyn EvaluationHandler>;
 
     /// Get the connector provided [`FileSystemClient`]
-    fn get_file_system_client(&self) -> Arc<dyn FileSystemClient>;
+    fn file_system_client(&self) -> Arc<dyn FileSystemClient>;
 
     /// Get the connector provided [`JsonHandler`].
-    fn get_json_handler(&self) -> Arc<dyn JsonHandler>;
+    fn json_handler(&self) -> Arc<dyn JsonHandler>;
 
     /// Get the connector provided [`ParquetHandler`].
-    fn get_parquet_handler(&self) -> Arc<dyn ParquetHandler>;
+    fn parquet_handler(&self) -> Arc<dyn ParquetHandler>;
 }
 
 // we have an 'internal' feature flag: default-engine-base, which is actually just the shared

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -216,7 +216,7 @@ impl LogSegment {
             .map(|f| f.location.clone())
             .collect();
         let commit_stream = engine
-            .get_json_handler()
+            .json_handler()
             .read_json_files(&commit_files, commit_read_schema, meta_predicate.clone())?
             .map_ok(|batch| (batch, true));
 
@@ -258,7 +258,7 @@ impl LogSegment {
             .map(|f| f.location.clone())
             .collect();
 
-        let parquet_handler = engine.get_parquet_handler();
+        let parquet_handler = engine.parquet_handler();
 
         // Historically, we had a shared file reader trait for JSON and Parquet handlers,
         // but it was removed to avoid unnecessary coupling. This is a concrete case
@@ -266,7 +266,7 @@ impl LogSegment {
         // If similar patterns start appearing elsewhere, we should reconsider that decision.
         let actions = match self.checkpoint_parts.first() {
             Some(parsed_log_path) if parsed_log_path.extension == "json" => {
-                engine.get_json_handler().read_json_files(
+                engine.json_handler().read_json_files(
                     &checkpoint_file_meta,
                     checkpoint_read_schema.clone(),
                     meta_predicate.clone(),

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -835,7 +835,7 @@ fn test_checkpoint_batch_with_no_sidecars_returns_none() -> DeltaResult<()> {
     let checkpoint_batch = add_batch_simple(get_log_schema().clone());
 
     let mut iter = LogSegment::process_sidecars(
-        engine.get_parquet_handler(),
+        engine.parquet_handler(),
         log_root,
         checkpoint_batch.as_ref(),
         get_log_schema().project(&[ADD_NAME, REMOVE_NAME, SIDECAR_NAME])?,
@@ -873,7 +873,7 @@ fn test_checkpoint_batch_with_sidecars_returns_sidecar_batches() -> DeltaResult<
     );
 
     let mut iter = LogSegment::process_sidecars(
-        engine.get_parquet_handler(),
+        engine.parquet_handler(),
         log_root,
         checkpoint_batch.as_ref(),
         read_schema.clone(),
@@ -901,7 +901,7 @@ fn test_checkpoint_batch_with_sidecar_files_that_do_not_exist() -> DeltaResult<(
     );
 
     let mut iter = LogSegment::process_sidecars(
-        engine.get_parquet_handler(),
+        engine.parquet_handler(),
         log_root,
         checkpoint_batch.as_ref(),
         get_log_schema().project(&[ADD_NAME, REMOVE_NAME, SIDECAR_NAME])?,
@@ -941,7 +941,7 @@ fn test_reading_sidecar_files_with_predicate() -> DeltaResult<()> {
     });
 
     let mut iter = LogSegment::process_sidecars(
-        engine.get_parquet_handler(),
+        engine.parquet_handler(),
         log_root,
         checkpoint_batch.as_ref(),
         read_schema.clone(),

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -133,20 +133,20 @@ impl DataSkippingFilter {
         //
         // 3. The selection evaluator does DISTINCT(col(predicate), 'false') to produce true (= keep) when
         //    the predicate is true/null and false (= skip) when the predicate is false.
-        let select_stats_evaluator = engine.get_expression_handler().get_evaluator(
+        let select_stats_evaluator = engine.evaluation_handler().new_expression_evaluator(
             // safety: kernel is very broken if we don't have the schema for Add actions
             get_log_add_schema().clone(),
             STATS_EXPR.clone(),
             DataType::STRING,
         );
 
-        let skipping_evaluator = engine.get_expression_handler().get_evaluator(
+        let skipping_evaluator = engine.evaluation_handler().new_expression_evaluator(
             stats_schema.clone(),
             Expr::struct_from([as_sql_data_skipping_predicate(&predicate)?]),
             PREDICATE_SCHEMA.clone(),
         );
 
-        let filter_evaluator = engine.get_expression_handler().get_evaluator(
+        let filter_evaluator = engine.evaluation_handler().new_expression_evaluator(
             stats_schema.clone(),
             FILTER_EXPR.clone(),
             DataType::BOOLEAN,
@@ -157,7 +157,7 @@ impl DataSkippingFilter {
             select_stats_evaluator,
             skipping_evaluator,
             filter_evaluator,
-            json_handler: engine.get_json_handler(),
+            json_handler: engine.json_handler(),
         })
     }
 

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -349,7 +349,7 @@ pub(crate) fn scan_action_iter(
     physical_predicate: Option<(ExpressionRef, SchemaRef)>,
 ) -> impl Iterator<Item = DeltaResult<ScanData>> {
     let mut log_scanner = LogReplayScanner::new(engine, physical_predicate);
-    let add_transform = engine.get_expression_handler().get_evaluator(
+    let add_transform = engine.evaluation_handler().new_expression_evaluator(
         get_log_add_schema().clone(),
         get_add_transform_expr(),
         SCAN_ROW_DATATYPE.clone(),

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -526,7 +526,7 @@ impl Scan {
                 // partition columns, but the read schema we use here does _NOT_ include partition
                 // columns. So we cannot safely assume that all column references are valid. See
                 // https://github.com/delta-io/delta-kernel-rs/issues/434 for more details.
-                let read_result_iter = engine.get_parquet_handler().read_parquet_files(
+                let read_result_iter = engine.parquet_handler().read_parquet_files(
                     &[meta],
                     global_state.physical_schema.clone(),
                     physical_predicate.clone(),
@@ -656,7 +656,7 @@ pub fn selection_vector(
     descriptor: &DeletionVectorDescriptor,
     table_root: &Url,
 ) -> DeltaResult<Vec<bool>> {
-    let fs_client = engine.get_file_system_client();
+    let fs_client = engine.file_system_client();
     let dv_treemap = descriptor.read(fs_client, table_root)?;
     Ok(deletion_treemap_to_bools(dv_treemap))
 }

--- a/kernel/src/scan/state.rs
+++ b/kernel/src/scan/state.rs
@@ -68,7 +68,7 @@ impl DvInfo {
         self.deletion_vector
             .as_ref()
             .map(|dv_descriptor| {
-                let fs_client = engine.get_file_system_client();
+                let fs_client = engine.file_system_client();
                 dv_descriptor.read(fs_client, table_root)
             })
             .transpose()
@@ -92,7 +92,7 @@ impl DvInfo {
         self.deletion_vector
             .as_ref()
             .map(|dv| {
-                let fs_client = engine.get_file_system_client();
+                let fs_client = engine.file_system_client();
                 dv.row_indexes(fs_client, table_root)
             })
             .transpose()
@@ -110,8 +110,8 @@ pub fn transform_to_logical(
 ) -> DeltaResult<Box<dyn EngineData>> {
     match transform {
         Some(ref transform) => engine
-            .get_expression_handler()
-            .get_evaluator(
+            .evaluation_handler()
+            .new_expression_evaluator(
                 physical_schema.clone(),
                 transform.as_ref().clone(), // TODO: Maybe eval should take a ref
                 logical_schema.clone().into(),

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -55,7 +55,7 @@ impl Snapshot {
         engine: &dyn Engine,
         version: Option<Version>,
     ) -> DeltaResult<Self> {
-        let fs_client = engine.get_file_system_client();
+        let fs_client = engine.file_system_client();
         let log_root = table_root.join("_delta_log/")?;
 
         let checkpoint_hint = read_last_checkpoint(fs_client.as_ref(), &log_root)?;

--- a/kernel/src/table_changes/log_replay.rs
+++ b/kernel/src/table_changes/log_replay.rs
@@ -154,7 +154,7 @@ impl LogReplayScanner {
         // As a result, we would read the file path for the remove action, which is unnecessary because
         // all of the rows will be filtered by the predicate. Instead, we wait until deletion
         // vectors are resolved so that we can skip both actions in the pair.
-        let action_iter = engine.get_json_handler().read_json_files(
+        let action_iter = engine.json_handler().read_json_files(
             &[commit_file.location.clone()],
             visitor_schema,
             None, // not safe to apply data skipping yet
@@ -226,16 +226,15 @@ impl LogReplayScanner {
         let remove_dvs = Arc::new(remove_dvs);
 
         let schema = FileActionSelectionVisitor::schema();
-        let action_iter = engine.get_json_handler().read_json_files(
-            &[commit_file.location.clone()],
-            schema,
-            None,
-        )?;
+        let action_iter =
+            engine
+                .json_handler()
+                .read_json_files(&[commit_file.location.clone()], schema, None)?;
         let commit_version = commit_file
             .version
             .try_into()
             .map_err(|_| Error::generic("Failed to convert commit version to i64"))?;
-        let evaluator = engine.get_expression_handler().get_evaluator(
+        let evaluator = engine.evaluation_handler().new_expression_evaluator(
             get_log_add_schema().clone(),
             cdf_scan_row_expression(timestamp, commit_version),
             cdf_scan_row_schema().into(),

--- a/kernel/src/table_changes/log_replay/tests.rs
+++ b/kernel/src/table_changes/log_replay/tests.rs
@@ -37,7 +37,7 @@ fn get_segment(
     let table_root = url::Url::from_directory_path(path).unwrap();
     let log_root = table_root.join("_delta_log/")?;
     let log_segment = LogSegment::for_table_changes(
-        engine.get_file_system_client().as_ref(),
+        engine.file_system_client().as_ref(),
         log_root,
         start_version,
         end_version,

--- a/kernel/src/table_changes/mod.rs
+++ b/kernel/src/table_changes/mod.rs
@@ -140,7 +140,7 @@ impl TableChanges {
     ) -> DeltaResult<Self> {
         let log_root = table_root.join("_delta_log/")?;
         let log_segment = LogSegment::for_table_changes(
-            engine.get_file_system_client().as_ref(),
+            engine.file_system_client().as_ref(),
             log_root,
             start_version,
             end_version,

--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -286,7 +286,7 @@ fn read_scan_file(
         physical_to_logical_expr(&scan_file, global_state.logical_schema.as_ref(), all_fields)?;
     let physical_schema =
         scan_file_physical_schema(&scan_file, global_state.physical_schema.as_ref());
-    let phys_to_logical_eval = engine.get_expression_handler().get_evaluator(
+    let phys_to_logical_eval = engine.evaluation_handler().new_expression_evaluator(
         physical_schema.clone(),
         physical_to_logical_expr,
         global_state.logical_schema.clone().into(),
@@ -301,7 +301,7 @@ fn read_scan_file(
         size: 0,
         location,
     };
-    let read_result_iter = engine.get_parquet_handler().read_parquet_files(
+    let read_result_iter = engine.parquet_handler().read_parquet_files(
         &[file],
         physical_schema,
         physical_predicate,

--- a/kernel/src/table_changes/scan_file.rs
+++ b/kernel/src/table_changes/scan_file.rs
@@ -326,13 +326,9 @@ mod tests {
 
         let table_root = url::Url::from_directory_path(mock_table.table_root()).unwrap();
         let log_root = table_root.join("_delta_log/").unwrap();
-        let log_segment = LogSegment::for_table_changes(
-            engine.get_file_system_client().as_ref(),
-            log_root,
-            0,
-            None,
-        )
-        .unwrap();
+        let log_segment =
+            LogSegment::for_table_changes(engine.file_system_client().as_ref(), log_root, 0, None)
+                .unwrap();
         let table_schema = StructType::new([
             StructField::nullable("id", DataType::INTEGER),
             StructField::nullable("value", DataType::STRING),

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -113,7 +113,7 @@ pub(crate) mod test_utils {
 
     pub(crate) fn parse_json_batch(json_strings: StringArray) -> Box<dyn EngineData> {
         let engine = SyncEngine::new();
-        let json_handler = engine.get_json_handler();
+        let json_handler = engine.json_handler();
         let output_schema = get_log_schema().clone();
         json_handler
             .parse_json(string_array_to_engine_data(json_strings), output_schema)

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -384,7 +384,7 @@ fn read_with_scan_data(
             location: file_path,
         };
         let read_results = engine
-            .get_parquet_handler()
+            .parquet_handler()
             .read_parquet_files(
                 &[meta],
                 global_state.physical_schema.clone(),


### PR DESCRIPTION
## What changes are proposed in this pull request?

Rust doesn't encourage the `get_` prefix for getters because it's redundant and anyway a getter is allowed to have the same name as the field it exposes. Remove the prefix from the various engine interfaces. Additionally, rename `get_evaluator` as `new_expression_evaluator` to accurately reflect that it is _NOT_ a getter at all, but actually creates a new expression evaluator.

Finally, we also rename `ExpressionHandler` to `EvaluationHandler` because that trait is used to create expression _evaluators_, not expressions. Additionally, future work will differentiate generic "expressions" from "predicates" (boolean-valued expressions with special evaluation semantics), and that will likely necessitate defining a `EvaluationHandler::new_predicate_evaluator` method alongside the `new_expression_evaluator` method.

### This PR affects the following public APIs

All the methods and traits we change are public.

## How was this change tested?

Rename-only operation, no functional changes. Compilation suffices.