### PR TITLE
refactor!: Rename FileSystemClient to StorageHandler

### DIFF
--- a/acceptance/tests/other.rs
+++ b/acceptance/tests/other.rs
@@ -26,8 +26,8 @@ async fn test_read_last_checkpoint() {
 
     let store = Arc::new(LocalFileSystem::new());
     let prefix = Path::from(url.path());
-    let client = ObjectStoreFileSystemClient::new(store, prefix);
-    let cp = read_last_checkpoint(&client, &url).await.unwrap().unwrap();
+    let storage = ObjectStoreStorageHandler::new(store, prefix);
+    let cp = read_last_checkpoint(&storage, &url).await.unwrap().unwrap();
     assert_eq!(cp.version, 2);
 }
 

--- a/kernel/src/engine/mod.rs
+++ b/kernel/src/engine/mod.rs
@@ -61,11 +61,11 @@ mod tests {
         let path = base_url.join("other").unwrap();
         json.write_json_file(&path, get_data(), false).unwrap();
 
-        let fs = engine.file_system_client();
+        let storage = engine.storage_handler();
 
         // list files after an offset
         let test_url = base_url.join(expected_names[0].as_ref()).unwrap();
-        let files: Vec<_> = fs.list_from(&test_url).unwrap().try_collect().unwrap();
+        let files: Vec<_> = storage.list_from(&test_url).unwrap().try_collect().unwrap();
         assert_eq!(files.len(), expected_names.len() - 1);
         for (file, expected) in files.iter().zip(expected_names.iter().skip(1)) {
             assert_eq!(file.location, base_url.join(expected.as_ref()).unwrap());
@@ -74,12 +74,12 @@ mod tests {
         let test_url = base_url
             .join(delta_path_for_version(0, "json").as_ref())
             .unwrap();
-        let files: Vec<_> = fs.list_from(&test_url).unwrap().try_collect().unwrap();
+        let files: Vec<_> = storage.list_from(&test_url).unwrap().try_collect().unwrap();
         assert_eq!(files.len(), expected_names.len());
 
         // list files inside a directory / key prefix
         let test_url = base_url.join("_delta_log/").unwrap();
-        let files: Vec<_> = fs.list_from(&test_url).unwrap().try_collect().unwrap();
+        let files: Vec<_> = storage.list_from(&test_url).unwrap().try_collect().unwrap();
         assert_eq!(files.len(), expected_names.len());
         for (file, expected) in files.iter().zip(expected_names.iter()) {
             assert_eq!(file.location, base_url.join(expected.as_ref()).unwrap());

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -42,7 +42,7 @@
 //! ## File system interactions
 //!
 //! Delta Kernel needs to perform some basic operations against file systems like listing and
-//! reading files. These interactions are encapsulated in the [`FileSystemClient`] trait.
+//! reading files. These interactions are encapsulated in the [`StorageHandler`] trait.
 //! Implementers must take care that all assumptions on the behavior if the functions - like sorted
 //! results - are respected.
 //!
@@ -51,7 +51,7 @@
 //! Delta Kernel requires the capability to read and write json files and read parquet files, which
 //! is exposed via the [`JsonHandler`] and [`ParquetHandler`] respectively. When reading files,
 //! connectors are asked to provide the context information it requires to execute the actual
-//! operation. This is done by invoking methods on the [`FileSystemClient`] trait.
+//! operation. This is done by invoking methods on the [`StorageHandler`] trait.
 
 #![cfg_attr(all(doc, NIGHTLY_CHANNEL), feature(doc_auto_cfg))]
 #![warn(
@@ -389,10 +389,10 @@ impl<T: EvaluationHandler> EvaluationHandlerExtension for T {}
 
 /// Provides file system related functionalities to Delta Kernel.
 ///
-/// Delta Kernel uses this client whenever it needs to access the underlying
+/// Delta Kernel uses this handler whenever it needs to access the underlying
 /// file system where the Delta table is present. Connector implementation of
 /// this trait can hide filesystem specific details from Delta Kernel.
-pub trait FileSystemClient: AsAny {
+pub trait StorageHandler: AsAny {
     /// List the paths in the same directory that are lexicographically greater than
     /// (UTF-8 sorting) the given `path`. The result should also be sorted by the file name.
     ///
@@ -410,7 +410,7 @@ pub trait FileSystemClient: AsAny {
 
 /// Provides JSON handling functionality to Delta Kernel.
 ///
-/// Delta Kernel can use this client to parse JSON strings into Row or read content from JSON files.
+/// Delta Kernel can use this handler to parse JSON strings into Row or read content from JSON files.
 /// Connectors can leverage this trait to provide their best implementation of the JSON parsing
 /// capability to Delta Kernel.
 pub trait JsonHandler: AsAny {
@@ -510,8 +510,8 @@ pub trait Engine: AsAny {
     /// Get the connector provided [`EvaluationHandler`].
     fn evaluation_handler(&self) -> Arc<dyn EvaluationHandler>;
 
-    /// Get the connector provided [`FileSystemClient`]
-    fn file_system_client(&self) -> Arc<dyn FileSystemClient>;
+    /// Get the connector provided [`StorageHandler`]
+    fn storage_handler(&self) -> Arc<dyn StorageHandler>;
 
     /// Get the connector provided [`JsonHandler`].
     fn json_handler(&self) -> Arc<dyn JsonHandler>;

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -663,8 +663,8 @@ pub fn selection_vector(
     descriptor: &DeletionVectorDescriptor,
     table_root: &Url,
 ) -> DeltaResult<Vec<bool>> {
-    let fs_client = engine.file_system_client();
-    let dv_treemap = descriptor.read(fs_client, table_root)?;
+    let storage = engine.storage_handler();
+    let dv_treemap = descriptor.read(storage, table_root)?;
     Ok(deletion_treemap_to_bools(dv_treemap))
 }
 

--- a/kernel/src/scan/state.rs
+++ b/kernel/src/scan/state.rs
@@ -68,8 +68,8 @@ impl DvInfo {
         self.deletion_vector
             .as_ref()
             .map(|dv_descriptor| {
-                let fs_client = engine.file_system_client();
-                dv_descriptor.read(fs_client, table_root)
+                let storage = engine.storage_handler();
+                dv_descriptor.read(storage, table_root)
             })
             .transpose()
     }
@@ -92,8 +92,8 @@ impl DvInfo {
         self.deletion_vector
             .as_ref()
             .map(|dv| {
-                let fs_client = engine.file_system_client();
-                dv.row_indexes(fs_client, table_root)
+                let storage = engine.storage_handler();
+                dv.row_indexes(storage, table_root)
             })
             .transpose()
     }

--- a/kernel/src/table_changes/log_replay/tests.rs
+++ b/kernel/src/table_changes/log_replay/tests.rs
@@ -37,7 +37,7 @@ fn get_segment(
     let table_root = url::Url::from_directory_path(path).unwrap();
     let log_root = table_root.join("_delta_log/")?;
     let log_segment = LogSegment::for_table_changes(
-        engine.file_system_client().as_ref(),
+        engine.storage_handler().as_ref(),
         log_root,
         start_version,
         end_version,

--- a/kernel/src/table_changes/mod.rs
+++ b/kernel/src/table_changes/mod.rs
@@ -140,7 +140,7 @@ impl TableChanges {
     ) -> DeltaResult<Self> {
         let log_root = table_root.join("_delta_log/")?;
         let log_segment = LogSegment::for_table_changes(
-            engine.file_system_client().as_ref(),
+            engine.storage_handler().as_ref(),
             log_root,
             start_version,
             end_version,

--- a/kernel/src/table_changes/scan_file.rs
+++ b/kernel/src/table_changes/scan_file.rs
@@ -327,7 +327,7 @@ mod tests {
         let table_root = url::Url::from_directory_path(mock_table.table_root()).unwrap();
         let log_root = table_root.join("_delta_log/").unwrap();
         let log_segment =
-            LogSegment::for_table_changes(engine.file_system_client().as_ref(), log_root, 0, None)
+            LogSegment::for_table_changes(engine.storage_handler().as_ref(), log_root, 0, None)
                 .unwrap();
         let table_schema = StructType::new([
             StructField::nullable("id", DataType::INTEGER),

--- a/kernel/src/transaction.rs
+++ b/kernel/src/transaction.rs
@@ -336,7 +336,7 @@ mod tests {
     use crate::engine::arrow_data::ArrowEngineData;
     use crate::engine::arrow_expression::ArrowEvaluationHandler;
     use crate::schema::MapType;
-    use crate::{EvaluationHandler, FileSystemClient, JsonHandler, ParquetHandler};
+    use crate::{EvaluationHandler, JsonHandler, ParquetHandler, StorageHandler};
 
     use crate::arrow::array::{MapArray, MapBuilder, MapFieldNames, StringArray, StringBuilder};
     use crate::arrow::datatypes::{DataType as ArrowDataType, Field, Schema as ArrowSchema};
@@ -365,7 +365,7 @@ mod tests {
             unimplemented!()
         }
 
-        fn file_system_client(&self) -> Arc<dyn FileSystemClient> {
+        fn storage_handler(&self) -> Arc<dyn StorageHandler> {
             unimplemented!()
         }
     }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Continuing the cleanup started by https://github.com/delta-io/delta-kernel-rs/pull/804, rename the class to eliminate the last vestiges of (ancient) "client" nomenclature.

### This PR affects the following public APIs

The renamed class (and module) are public.

## How was this change tested?

Rename-only operation, no functional changes. Compilation suffices.