### PR TITLE
refactor: Rename predicates mod to kernel_predicates

### DIFF
--- a/kernel/src/engine/parquet_row_group_skipping.rs
+++ b/kernel/src/engine/parquet_row_group_skipping.rs
@@ -1,10 +1,10 @@
 //! An implementation of parquet row group skipping using data skipping predicates over footer stats.
 use crate::expressions::{ColumnName, Expression, Scalar};
+use crate::kernel_predicates::parquet_stats_skipping::ParquetStatsProvider;
 use crate::parquet::arrow::arrow_reader::ArrowReaderBuilder;
 use crate::parquet::file::metadata::RowGroupMetaData;
 use crate::parquet::file::statistics::Statistics;
 use crate::parquet::schema::types::ColumnDescPtr;
-use crate::predicates::parquet_stats_skipping::ParquetStatsProvider;
 use crate::schema::{DataType, PrimitiveType};
 use chrono::{DateTime, Days};
 use std::collections::HashMap;
@@ -55,7 +55,7 @@ impl<'a> RowGroupFilter<'a> {
 
     /// Applies a filtering predicate to a row group. Return value false means to skip it.
     fn apply(row_group: &'a RowGroupMetaData, predicate: &Expression) -> bool {
-        use crate::predicates::PredicateEvaluator as _;
+        use crate::kernel_predicates::KernelPredicateEvaluator as _;
         RowGroupFilter::new(row_group, predicate).eval_sql_where(predicate) != Some(false)
     }
 

--- a/kernel/src/engine/parquet_row_group_skipping/tests.rs
+++ b/kernel/src/engine/parquet_row_group_skipping/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::expressions::{column_expr, column_name};
+use crate::kernel_predicates::DataSkippingPredicateEvaluator as _;
 use crate::parquet::arrow::arrow_reader::ArrowReaderMetadata;
-use crate::predicates::DataSkippingPredicateEvaluator as _;
 use crate::Expression;
 use std::fs::File;
 

--- a/kernel/src/kernel_predicates/parquet_stats_skipping.rs
+++ b/kernel/src/kernel_predicates/parquet_stats_skipping.rs
@@ -1,6 +1,6 @@
 //! An implementation of data skipping that leverages parquet stats from the file footer.
 use crate::expressions::{BinaryOperator, ColumnName, Scalar, VariadicOperator};
-use crate::predicates::{DataSkippingPredicateEvaluator, PredicateEvaluatorDefaults};
+use crate::kernel_predicates::{DataSkippingPredicateEvaluator, KernelPredicateEvaluatorDefaults};
 use crate::schema::DataType;
 use std::cmp::Ordering;
 
@@ -57,15 +57,15 @@ impl<T: ParquetStatsProvider> DataSkippingPredicateEvaluator for T {
         val: &Scalar,
         inverted: bool,
     ) -> Option<bool> {
-        PredicateEvaluatorDefaults::partial_cmp_scalars(ord, &col, val, inverted)
+        KernelPredicateEvaluatorDefaults::partial_cmp_scalars(ord, &col, val, inverted)
     }
 
     fn eval_scalar_is_null(&self, val: &Scalar, inverted: bool) -> Option<bool> {
-        PredicateEvaluatorDefaults::eval_scalar_is_null(val, inverted)
+        KernelPredicateEvaluatorDefaults::eval_scalar_is_null(val, inverted)
     }
 
     fn eval_scalar(&self, val: &Scalar, inverted: bool) -> Option<bool> {
-        PredicateEvaluatorDefaults::eval_scalar(val, inverted)
+        KernelPredicateEvaluatorDefaults::eval_scalar(val, inverted)
     }
 
     fn eval_is_null(&self, col: &ColumnName, inverted: bool) -> Option<bool> {
@@ -83,7 +83,7 @@ impl<T: ParquetStatsProvider> DataSkippingPredicateEvaluator for T {
         right: &Scalar,
         inverted: bool,
     ) -> Option<bool> {
-        PredicateEvaluatorDefaults::eval_binary_scalars(op, left, right, inverted)
+        KernelPredicateEvaluatorDefaults::eval_binary_scalars(op, left, right, inverted)
     }
 
     fn finish_eval_variadic(
@@ -92,6 +92,6 @@ impl<T: ParquetStatsProvider> DataSkippingPredicateEvaluator for T {
         exprs: impl IntoIterator<Item = Option<bool>>,
         inverted: bool,
     ) -> Option<bool> {
-        PredicateEvaluatorDefaults::finish_eval_variadic(op, exprs, inverted)
+        KernelPredicateEvaluatorDefaults::finish_eval_variadic(op, exprs, inverted)
     }
 }

--- a/kernel/src/kernel_predicates/parquet_stats_skipping/tests.rs
+++ b/kernel/src/kernel_predicates/parquet_stats_skipping/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::expressions::{column_expr, Expression as Expr};
-use crate::predicates::PredicateEvaluator as _;
+use crate::kernel_predicates::KernelPredicateEvaluator as _;
 use crate::DataType;
 
 const TRUE: Option<bool> = Some(true);

--- a/kernel/src/kernel_predicates/tests.rs
+++ b/kernel/src/kernel_predicates/tests.rs
@@ -43,7 +43,7 @@ fn test_default_eval_scalar() {
     ];
     for (value, inverted, expect) in test_cases.into_iter() {
         assert_eq!(
-            PredicateEvaluatorDefaults::eval_scalar(&value, inverted),
+            KernelPredicateEvaluatorDefaults::eval_scalar(&value, inverted),
             expect,
             "value: {value:?} inverted: {inverted}"
         );
@@ -100,7 +100,7 @@ fn test_default_partial_cmp_scalars() {
     ];
 
     // scalars of different types are always incomparable
-    let compare = PredicateEvaluatorDefaults::partial_cmp_scalars;
+    let compare = KernelPredicateEvaluatorDefaults::partial_cmp_scalars;
     for (i, a) in smaller_values.iter().enumerate() {
         for b in smaller_values.iter().skip(i + 1) {
             for op in [Less, Equal, Greater] {
@@ -193,7 +193,7 @@ fn test_eval_binary_scalars() {
     let smaller_value = Scalar::Long(1);
     let larger_value = Scalar::Long(10);
     for inverted in [true, false] {
-        let compare = PredicateEvaluatorDefaults::eval_binary_scalars;
+        let compare = KernelPredicateEvaluatorDefaults::eval_binary_scalars;
         expect_eq!(
             compare(Equal, &smaller_value, &smaller_value, inverted),
             Some(!inverted),
@@ -269,7 +269,7 @@ fn test_eval_binary_columns() {
         (column_name!("x"), Scalar::from(1)),
         (column_name!("y"), Scalar::from(10)),
     ]);
-    let filter = DefaultPredicateEvaluator::from(columns);
+    let filter = DefaultKernelPredicateEvaluator::from(columns);
     let x = column_expr!("x");
     let y = column_expr!("y");
     for inverted in [true, false] {
@@ -307,7 +307,7 @@ fn test_eval_variadic() {
         (&[Some(false), Some(true), None], Some(false), Some(true)),
         (&[Some(true), Some(false), None], Some(false), Some(true)),
     ];
-    let filter = DefaultPredicateEvaluator::from(UnimplementedColumnResolver);
+    let filter = DefaultKernelPredicateEvaluator::from(UnimplementedColumnResolver);
     for (inputs, expect_and, expect_or) in test_cases.iter() {
         let inputs: Vec<_> = inputs
             .iter()
@@ -343,7 +343,7 @@ fn test_eval_column() {
     ];
     let col = &column_name!("x");
     for (input, expect) in &test_cases {
-        let filter = DefaultPredicateEvaluator::from(input.clone());
+        let filter = DefaultKernelPredicateEvaluator::from(input.clone());
         for inverted in [true, false] {
             expect_eq!(
                 filter.eval_column(col, inverted),
@@ -362,7 +362,7 @@ fn test_eval_not() {
         (Scalar::Null(DataType::BOOLEAN), None),
         (Scalar::Long(1), None),
     ];
-    let filter = DefaultPredicateEvaluator::from(UnimplementedColumnResolver);
+    let filter = DefaultKernelPredicateEvaluator::from(UnimplementedColumnResolver);
     for (input, expect) in test_cases {
         let input = input.into();
         for inverted in [true, false] {
@@ -378,7 +378,7 @@ fn test_eval_not() {
 #[test]
 fn test_eval_is_null() {
     let expr = column_expr!("x");
-    let filter = DefaultPredicateEvaluator::from(Scalar::from(1));
+    let filter = DefaultKernelPredicateEvaluator::from(Scalar::from(1));
     expect_eq!(
         filter.eval_unary(UnaryOperator::IsNull, &expr, true),
         Some(true),
@@ -408,7 +408,7 @@ fn test_eval_distinct() {
     let one = &Scalar::from(1);
     let two = &Scalar::from(2);
     let null = &Scalar::Null(DataType::INTEGER);
-    let filter = DefaultPredicateEvaluator::from(one.clone());
+    let filter = DefaultKernelPredicateEvaluator::from(one.clone());
     let col = &column_name!("x");
     expect_eq!(
         filter.eval_distinct(col, one, true),
@@ -441,7 +441,7 @@ fn test_eval_distinct() {
         "DISTINCT(x, NULL) (x = 1)"
     );
 
-    let filter = DefaultPredicateEvaluator::from(null.clone());
+    let filter = DefaultKernelPredicateEvaluator::from(null.clone());
     expect_eq!(
         filter.eval_distinct(col, one, true),
         Some(false),
@@ -470,7 +470,7 @@ fn test_eval_distinct() {
 fn eval_binary() {
     let col = column_expr!("x");
     let val = Expression::literal(10);
-    let filter = DefaultPredicateEvaluator::from(Scalar::from(1));
+    let filter = DefaultKernelPredicateEvaluator::from(Scalar::from(1));
 
     // unsupported
     expect_eq!(
@@ -585,8 +585,8 @@ fn test_sql_where() {
     const NULL: Expr = Expr::Literal(Scalar::Null(DataType::BOOLEAN));
     const FALSE: Expr = Expr::Literal(Scalar::Boolean(false));
     const TRUE: Expr = Expr::Literal(Scalar::Boolean(true));
-    let null_filter = DefaultPredicateEvaluator::from(NullColumnResolver);
-    let empty_filter = DefaultPredicateEvaluator::from(EmptyColumnResolver);
+    let null_filter = DefaultKernelPredicateEvaluator::from(NullColumnResolver);
+    let empty_filter = DefaultKernelPredicateEvaluator::from(EmptyColumnResolver);
 
     // Basic sanity check
     expect_eq!(null_filter.eval_sql_where(&VAL), None, "WHERE {VAL}");

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -88,8 +88,8 @@ pub mod table_properties;
 pub mod transaction;
 
 pub mod arrow;
+pub(crate) mod kernel_predicates;
 pub mod parquet;
-pub(crate) mod predicates;
 pub(crate) mod utils;
 
 #[cfg(feature = "developer-visibility")]

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -11,8 +11,8 @@ use crate::expressions::{
     column_expr, joined_column_expr, BinaryOperator, ColumnName, Expression as Expr, ExpressionRef,
     Scalar, VariadicOperator,
 };
-use crate::predicates::{
-    DataSkippingPredicateEvaluator, PredicateEvaluator, PredicateEvaluatorDefaults,
+use crate::kernel_predicates::{
+    DataSkippingPredicateEvaluator, KernelPredicateEvaluator, KernelPredicateEvaluatorDefaults,
 };
 use crate::schema::{DataType, PrimitiveType, SchemaRef, SchemaTransform, StructField, StructType};
 use crate::{Engine, EngineData, ExpressionEvaluator, JsonHandler, RowVisitor as _};
@@ -240,11 +240,11 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator {
     }
 
     fn eval_scalar_is_null(&self, val: &Scalar, inverted: bool) -> Option<Expr> {
-        PredicateEvaluatorDefaults::eval_scalar_is_null(val, inverted).map(Expr::literal)
+        KernelPredicateEvaluatorDefaults::eval_scalar_is_null(val, inverted).map(Expr::literal)
     }
 
     fn eval_scalar(&self, val: &Scalar, inverted: bool) -> Option<Expr> {
-        PredicateEvaluatorDefaults::eval_scalar(val, inverted).map(Expr::literal)
+        KernelPredicateEvaluatorDefaults::eval_scalar(val, inverted).map(Expr::literal)
     }
 
     fn eval_is_null(&self, col: &ColumnName, inverted: bool) -> Option<Expr> {
@@ -262,7 +262,7 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator {
         right: &Scalar,
         inverted: bool,
     ) -> Option<Expr> {
-        PredicateEvaluatorDefaults::eval_binary_scalars(op, left, right, inverted)
+        KernelPredicateEvaluatorDefaults::eval_binary_scalars(op, left, right, inverted)
             .map(Expr::literal)
     }
 

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 use crate::expressions::column_name;
-use crate::predicates::{DefaultPredicateEvaluator, UnimplementedColumnResolver};
+use crate::kernel_predicates::{DefaultKernelPredicateEvaluator, UnimplementedColumnResolver};
 use std::collections::HashMap;
 
 const TRUE: Option<bool> = Some(true);
@@ -32,7 +32,7 @@ fn test_eval_is_null() {
             (column_name!("numRecords"), Scalar::from(2i64)),
             (column_name!("nullCount.x"), Scalar::from(nullcount)),
         ]);
-        let filter = DefaultPredicateEvaluator::from(resolver);
+        let filter = DefaultKernelPredicateEvaluator::from(resolver);
         for (expr, expect) in expressions.iter().zip(expected) {
             let pred = as_data_skipping_predicate(expr).unwrap();
             expect_eq!(
@@ -75,7 +75,7 @@ fn test_eval_binary_comparisons() {
             (column_name!("minValues.x"), min.clone()),
             (column_name!("maxValues.x"), max.clone()),
         ]);
-        let filter = DefaultPredicateEvaluator::from(resolver);
+        let filter = DefaultKernelPredicateEvaluator::from(resolver);
         for (expr, expect) in expressions.iter().zip(expected.iter()) {
             let pred = as_data_skipping_predicate(expr).unwrap();
             expect_eq!(
@@ -149,7 +149,7 @@ fn test_eval_variadic() {
         (&[NULL, TRUE, FALSE], FALSE, TRUE),
         (&[NULL, FALSE, TRUE], FALSE, TRUE),
     ];
-    let filter = DefaultPredicateEvaluator::from(UnimplementedColumnResolver);
+    let filter = DefaultKernelPredicateEvaluator::from(UnimplementedColumnResolver);
     for (inputs, expect_and, expect_or) in test_cases {
         let inputs: Vec<_> = inputs
             .iter()
@@ -214,7 +214,7 @@ fn test_eval_distinct() {
             (column_name!("minValues.x"), min.clone()),
             (column_name!("maxValues.x"), max.clone()),
         ]);
-        let filter = DefaultPredicateEvaluator::from(resolver);
+        let filter = DefaultKernelPredicateEvaluator::from(resolver);
         for (expr, expect) in expressions.iter().zip(expected) {
             let pred = as_data_skipping_predicate(expr).unwrap();
             expect_eq!(
@@ -286,7 +286,7 @@ fn test_sql_where() {
                     (column_name!("maxValues.x"), max.clone()),
                 ])
             };
-            let filter = DefaultPredicateEvaluator::from(resolver);
+            let filter = DefaultKernelPredicateEvaluator::from(resolver);
             let pred = as_data_skipping_predicate(expr).unwrap();
             expect_eq!(
                 filter.eval_expr(&pred, false),

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -9,8 +9,8 @@ use super::{ScanMetadata, Transform};
 use crate::actions::get_log_add_schema;
 use crate::engine_data::{GetData, RowVisitor, TypedGetData as _};
 use crate::expressions::{column_expr, column_name, ColumnName, Expression, ExpressionRef};
+use crate::kernel_predicates::{DefaultKernelPredicateEvaluator, KernelPredicateEvaluator as _};
 use crate::log_replay::{FileActionDeduplicator, FileActionKey, LogReplayProcessor};
-use crate::predicates::{DefaultPredicateEvaluator, PredicateEvaluator as _};
 use crate::scan::{Scalar, TransformExpr};
 use crate::schema::{ColumnNamesAndTypes, DataType, MapType, SchemaRef, StructField, StructType};
 use crate::utils::require;
@@ -189,7 +189,7 @@ impl AddRemoveDedupVisitor<'_> {
             .values()
             .map(|(k, v)| (ColumnName::new([k]), v.clone()))
             .collect();
-        let evaluator = DefaultPredicateEvaluator::from(partition_values);
+        let evaluator = DefaultKernelPredicateEvaluator::from(partition_values);
         evaluator.eval_sql_where(partition_filter) == Some(false)
     }
 

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -14,8 +14,8 @@ use crate::actions::deletion_vector::{
 use crate::actions::{get_log_schema, ADD_NAME, REMOVE_NAME, SIDECAR_NAME};
 use crate::engine_data::FilteredEngineData;
 use crate::expressions::{ColumnName, Expression, ExpressionRef, ExpressionTransform, Scalar};
+use crate::kernel_predicates::{DefaultKernelPredicateEvaluator, EmptyColumnResolver};
 use crate::log_replay::HasSelectionVector;
-use crate::predicates::{DefaultPredicateEvaluator, EmptyColumnResolver};
 use crate::scan::state::{DvInfo, Stats};
 use crate::schema::{
     ArrayType, DataType, MapType, PrimitiveType, Schema, SchemaRef, SchemaTransform, StructField,
@@ -184,8 +184,9 @@ impl PhysicalPredicate {
 // the predicate allows to statically skip all files. Since this is direct evaluation (not an
 // expression rewrite), we use a `DefaultPredicateEvaluator` with an empty column resolver.
 fn can_statically_skip_all_files(predicate: &Expression) -> bool {
-    use crate::predicates::PredicateEvaluator as _;
-    DefaultPredicateEvaluator::from(EmptyColumnResolver).eval_sql_where(predicate) == Some(false)
+    use crate::kernel_predicates::KernelPredicateEvaluator as _;
+    DefaultKernelPredicateEvaluator::from(EmptyColumnResolver).eval_sql_where(predicate)
+        == Some(false)
 }
 
 // Build the stats read schema filtering the table schema to keep only skipping-eligible


### PR DESCRIPTION
## What changes are proposed in this pull request?

The `predicates` module has a confusing name because it sits alongside the `expressions` module but does not actually define predicates (= boolean-valued expressions) at all. Instead, it contains kernel's implementation of predicate evaluation, used for e.g. data skipping and partition pruning.

Rename the module to `kernel_predicates` and rename corresponding classes like `PredicateEvaluator` to `KernelPredicateEvaluator`, to make their purpose more clear. This also helps clear the way for us to split out predicates as a separate concept from normal expressions, see https://github.com/delta-io/delta-kernel-rs/issues/765.

## How was this change tested?

Module and class renames only. Compilation suffices.