### PR TITLE
feat: add `transaction.with_transaction_id()` API

### DIFF
--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -16,7 +16,7 @@ use crate::table_features::{
 use crate::table_properties::TableProperties;
 use crate::utils::require;
 use crate::EvaluationHandlerExtension;
-use crate::{DataType, DeltaResult, Engine, EngineData, Error, FileMeta, RowVisitor as _, Scalar};
+use crate::{DeltaResult, Engine, EngineData, Error, FileMeta, RowVisitor as _};
 
 use url::Url;
 use visitors::{MetadataVisitor, ProtocolVisitor};
@@ -589,7 +589,7 @@ impl SetTransaction {
         let values = [
             self.app_id.into(),
             self.version.into(),
-            Scalar::Null(DataType::LONG),
+            self.last_updated.into(),
         ];
         let evaluator = engine.evaluation_handler();
         evaluator.create_one(get_log_txn_schema().clone(), &values)

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -15,7 +15,9 @@ use crate::table_features::{
 };
 use crate::table_properties::TableProperties;
 use crate::utils::require;
-use crate::{DeltaResult, EngineData, Error, FileMeta, RowVisitor as _};
+use crate::EvaluationHandlerExtension;
+use crate::{DataType, DeltaResult, Engine, EngineData, Error, FileMeta, RowVisitor as _, Scalar};
+
 use url::Url;
 use visitors::{MetadataVisitor, ProtocolVisitor};
 
@@ -75,6 +77,13 @@ static LOG_COMMIT_INFO_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
     StructType::new([Option::<CommitInfo>::get_struct_field(COMMIT_INFO_NAME)]).into()
 });
 
+static LOG_TXN_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
+    StructType::new([Option::<SetTransaction>::get_struct_field(
+        SET_TRANSACTION_NAME,
+    )])
+    .into()
+});
+
 #[cfg_attr(feature = "developer-visibility", visibility::make(pub))]
 #[cfg_attr(not(feature = "developer-visibility"), visibility::make(pub(crate)))]
 fn get_log_schema() -> &'static SchemaRef {
@@ -89,6 +98,10 @@ fn get_log_add_schema() -> &'static SchemaRef {
 
 pub(crate) fn get_log_commit_info_schema() -> &'static SchemaRef {
     &LOG_COMMIT_INFO_SCHEMA
+}
+
+pub(crate) fn get_log_txn_schema() -> &'static SchemaRef {
+    &LOG_TXN_SCHEMA
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Schema)]
@@ -561,6 +574,26 @@ pub(crate) struct SetTransaction {
 
     /// The time when this transaction action was created in milliseconds since the Unix epoch.
     pub(crate) last_updated: Option<i64>,
+}
+
+impl SetTransaction {
+    pub(crate) fn new(app_id: String, version: i64, last_updated: Option<i64>) -> Self {
+        Self {
+            app_id,
+            version,
+            last_updated,
+        }
+    }
+
+    pub(crate) fn into_engine_data(self, engine: &dyn Engine) -> DeltaResult<Box<dyn EngineData>> {
+        let values = [
+            self.app_id.into(),
+            self.version.into(),
+            Scalar::Null(DataType::LONG),
+        ];
+        let evaluator = engine.evaluation_handler();
+        evaluator.create_one(get_log_txn_schema().clone(), &values)
+    }
 }
 
 /// The sidecar action references a sidecar file which provides some of the checkpoint's

--- a/kernel/src/actions/set_transaction.rs
+++ b/kernel/src/actions/set_transaction.rs
@@ -75,7 +75,6 @@ impl SetTransactionScanner {
     }
 
     /// Scan the Delta Log to obtain the latest transaction for all applications
-    #[allow(unused)]
     pub(crate) fn application_transactions(
         &self,
         engine: &dyn Engine,

--- a/kernel/src/actions/set_transaction.rs
+++ b/kernel/src/actions/set_transaction.rs
@@ -13,6 +13,7 @@ pub(crate) struct SetTransactionScanner {
 }
 
 impl SetTransactionScanner {
+    #[allow(unused)]
     pub(crate) fn new(snapshot: Arc<Snapshot>) -> Self {
         SetTransactionScanner { snapshot }
     }
@@ -75,6 +76,7 @@ impl SetTransactionScanner {
     }
 
     /// Scan the Delta Log to obtain the latest transaction for all applications
+    #[allow(unused)]
     pub(crate) fn application_transactions(
         &self,
         engine: &dyn Engine,

--- a/kernel/src/actions/set_transaction.rs
+++ b/kernel/src/actions/set_transaction.rs
@@ -58,8 +58,8 @@ impl SetTransactionScanner {
         });
         self.snapshot.log_segment().read_actions(
             engine,
-            txn_schema.clone(),
-            txn_schema.clone(),
+            txn_schema.clone(), // Arc clone
+            txn_schema.clone(), // Arc clone
             META_PREDICATE.clone(),
         )
     }

--- a/kernel/src/actions/set_transaction.rs
+++ b/kernel/src/actions/set_transaction.rs
@@ -12,8 +12,8 @@ pub(crate) struct SetTransactionScanner {
     snapshot: Arc<Snapshot>,
 }
 
+#[allow(dead_code)]
 impl SetTransactionScanner {
-    #[allow(unused)]
     pub(crate) fn new(snapshot: Arc<Snapshot>) -> Self {
         SetTransactionScanner { snapshot }
     }
@@ -64,7 +64,6 @@ impl SetTransactionScanner {
         )
     }
 
-    #[allow(unused)]
     /// Scan the Delta Log for the latest transaction entry of an application
     pub(crate) fn application_transaction(
         &self,

--- a/kernel/src/actions/set_transaction.rs
+++ b/kernel/src/actions/set_transaction.rs
@@ -1,36 +1,34 @@
 use std::sync::{Arc, LazyLock};
 
+use crate::actions::get_log_txn_schema;
 use crate::actions::visitors::SetTransactionVisitor;
-use crate::actions::{get_log_schema, SetTransaction, SET_TRANSACTION_NAME};
+use crate::actions::{SetTransaction, SET_TRANSACTION_NAME};
 use crate::snapshot::Snapshot;
-use crate::{
-    DeltaResult, Engine, EngineData, Expression as Expr, ExpressionRef, RowVisitor as _, SchemaRef,
-};
+use crate::{DeltaResult, Engine, EngineData, Expression as Expr, ExpressionRef, RowVisitor as _};
 
 pub(crate) use crate::actions::visitors::SetTransactionMap;
 
-#[allow(dead_code)]
 pub(crate) struct SetTransactionScanner {
     snapshot: Arc<Snapshot>,
 }
 
-#[allow(dead_code)]
 impl SetTransactionScanner {
     pub(crate) fn new(snapshot: Arc<Snapshot>) -> Self {
         SetTransactionScanner { snapshot }
     }
 
-    /// Scan the entire log for all application ids but terminate early if a specific application id is provided
+    /// Scan the entire log for all application ids but terminate early if a specific application id
+    /// is provided
+    // TODO: we could have this track _multiple_ application ids instead of only up to one.
     fn scan_application_transactions(
         &self,
         engine: &dyn Engine,
         application_id: Option<&str>,
     ) -> DeltaResult<SetTransactionMap> {
-        let schema = Self::get_txn_schema()?;
         let mut visitor = SetTransactionVisitor::new(application_id.map(|s| s.to_owned()));
         // If a specific id is requested then we can terminate log replay early as soon as it was
         // found. If all ids are requested then we are forced to replay the entire log.
-        for maybe_data in self.replay_for_app_ids(engine, schema.clone())? {
+        for maybe_data in self.replay_for_app_ids(engine)? {
             let (txns, _) = maybe_data?;
             visitor.visit_rows_of(txns.as_ref())?;
             // if a specific id is requested and a transaction was found, then return
@@ -43,16 +41,11 @@ impl SetTransactionScanner {
     }
 
     // Factored out to facilitate testing
-    fn get_txn_schema() -> DeltaResult<SchemaRef> {
-        get_log_schema().project(&[SET_TRANSACTION_NAME])
-    }
-
-    // Factored out to facilitate testing
     fn replay_for_app_ids(
         &self,
         engine: &dyn Engine,
-        schema: SchemaRef,
     ) -> DeltaResult<impl Iterator<Item = DeltaResult<(Box<dyn EngineData>, bool)>> + Send> {
+        let txn_schema = get_log_txn_schema();
         // This meta-predicate should be effective because all the app ids end up in a single
         // checkpoint part when patitioned by `add.path` like the Delta spec requires. There's no
         // point filtering by a particular app id, even if we have one, because app ids are all in
@@ -64,12 +57,13 @@ impl SetTransactionScanner {
         });
         self.snapshot.log_segment().read_actions(
             engine,
-            schema.clone(),
-            schema,
+            txn_schema.clone(),
+            txn_schema.clone(),
             META_PREDICATE.clone(),
         )
     }
 
+    #[allow(unused)]
     /// Scan the Delta Log for the latest transaction entry of an application
     pub(crate) fn application_transaction(
         &self,
@@ -160,11 +154,10 @@ mod tests {
         let table = Table::new(url);
         let snapshot = table.snapshot(&engine, None).unwrap();
         let txn = SetTransactionScanner::new(snapshot.into());
-        let txn_schema = SetTransactionScanner::get_txn_schema().unwrap();
 
         // The checkpoint has five parts, each containing one action. There are two app ids.
         let data: Vec<_> = txn
-            .replay_for_app_ids(&engine, txn_schema.clone())
+            .replay_for_app_ids(&engine)
             .unwrap()
             .try_collect()
             .unwrap();

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -3,6 +3,7 @@ use std::fmt::{Display, Formatter};
 
 use chrono::{DateTime, NaiveDate, NaiveDateTime, TimeZone, Utc};
 
+use crate::actions::schemas::ToDataType;
 use crate::schema::{ArrayType, DataType, PrimitiveType, StructField};
 use crate::utils::require;
 use crate::{DeltaResult, Error};
@@ -335,6 +336,15 @@ impl<T: Into<Scalar> + Copy> From<&T> for Scalar {
 impl From<&[u8]> for Scalar {
     fn from(b: &[u8]) -> Self {
         Self::Binary(b.into())
+    }
+}
+
+impl<T: Into<Scalar> + ToDataType> From<Option<T>> for Scalar {
+    fn from(t: Option<T>) -> Self {
+        match t {
+            Some(t) => t.into(),
+            None => Self::Null(T::to_data_type()),
+        }
     }
 }
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -386,7 +386,7 @@ trait EvaluationHandlerExtension: EvaluationHandler {
 }
 
 // Auto-implement the extension trait for all EvaluationHandlers
-impl<T: EvaluationHandler> EvaluationHandlerExtension for T {}
+impl<T: EvaluationHandler + ?Sized> EvaluationHandlerExtension for T {}
 
 /// Provides file system related functionalities to Delta Kernel.
 ///

--- a/kernel/src/transaction.rs
+++ b/kernel/src/transaction.rs
@@ -725,7 +725,4 @@ mod tests {
         ]);
         assert_eq!(*schema, expected.into());
     }
-
-    #[test]
-    fn test_idempotent_writes() {}
 }

--- a/kernel/src/transaction.rs
+++ b/kernel/src/transaction.rs
@@ -131,7 +131,6 @@ impl Transaction {
         );
         let add_actions = generate_adds(engine, self.write_metadata.iter().map(|a| a.as_ref()));
 
-        // TODO: should we chain before/after file actions?
         let actions = iter::once(commit_info_actions)
             .chain(add_actions)
             .chain(set_transaction_actions);

--- a/kernel/src/transaction.rs
+++ b/kernel/src/transaction.rs
@@ -4,6 +4,8 @@ use std::sync::{Arc, LazyLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::actions::schemas::{GetNullableContainerStructField, GetStructField};
+use crate::actions::set_transaction::SetTransactionScanner;
+use crate::actions::SetTransaction;
 use crate::actions::COMMIT_INFO_NAME;
 use crate::actions::{get_log_add_schema, get_log_commit_info_schema};
 use crate::error::Error;
@@ -13,7 +15,6 @@ use crate::schema::{SchemaRef, StructField, StructType};
 use crate::snapshot::Snapshot;
 use crate::{DataType, DeltaResult, Engine, EngineData, Expression, Version};
 
-use itertools::chain;
 use url::Url;
 
 const KERNEL_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -55,6 +56,11 @@ pub struct Transaction {
     operation: Option<String>,
     commit_info: Option<Arc<dyn EngineData>>,
     write_metadata: Vec<Box<dyn EngineData>>,
+    // NB: we could use HashMap<String, SetTransaction> for set_transactions but since the expected
+    // number is small, we will save an allocation and (likely) have better memory locality just
+    // with a Vec. (following rule-of-thumb that 10-100 linear search will do same/better than hash
+    // lookup)
+    set_transactions: Vec<SetTransaction>,
 }
 
 impl std::fmt::Debug for Transaction {
@@ -65,6 +71,11 @@ impl std::fmt::Debug for Transaction {
             self.commit_info.is_some()
         ))
     }
+}
+
+enum SetTransactionResult {
+    Valid,
+    Conflict(SetTransaction),
 }
 
 impl Transaction {
@@ -87,24 +98,53 @@ impl Transaction {
             operation: None,
             commit_info: None,
             write_metadata: vec![],
+            set_transactions: vec![],
         })
     }
 
     /// Consume the transaction and commit it to the table. The result is a [CommitResult] which
     /// will include the failed transaction in case of a conflict so the user can retry.
     pub fn commit(self, engine: &dyn Engine) -> DeltaResult<CommitResult> {
-        // step one: construct the iterator of actions we want to commit
+        // step 0: if there are SetTransaction(app_id, version) actions being committed, ensure
+        // that for every app_id, this commit's version is greater than any previous version. if
+        // so, we chain them to our actions iterator.
+        //
+        // TODO: we are currently doing set_transaction validation (another log replay) as a
+        // separate step but we could be smarter and merge this with the snapshot log replay above
+        // to produce a special snapshot with SetTransactions (but how do we know which ones to
+        // care about ahead of time?)
+        match self.validate_set_transactions(engine)? {
+            SetTransactionResult::Valid => {}
+            SetTransactionResult::Conflict(conflict_transaction) => {
+                return Ok(CommitResult::IdempotentWriteConflict(
+                    self,
+                    conflict_transaction.app_id.clone(),
+                    conflict_transaction.version,
+                ));
+            }
+        }
+        let set_transaction_actions = self
+            .set_transactions
+            .clone() // FIXME?
+            .into_iter()
+            .map(|txn| txn.into_engine_data(engine));
+
+        // step one: construct the iterator of commit info + file actions we want to commit
         let engine_commit_info = self
             .commit_info
             .as_ref()
             .ok_or_else(|| Error::MissingCommitInfo)?;
-        let commit_info = generate_commit_info(
+        let commit_info_actions = generate_commit_info(
             engine,
             self.operation.as_deref(),
             engine_commit_info.as_ref(),
         );
-        let adds = generate_adds(engine, self.write_metadata.iter().map(|a| a.as_ref()));
-        let actions = chain(iter::once(commit_info), adds);
+        let add_actions = generate_adds(engine, self.write_metadata.iter().map(|a| a.as_ref()));
+
+        // TODO: should we chain before/after file actions?
+        let actions = iter::once(commit_info_actions)
+            .chain(add_actions)
+            .chain(set_transaction_actions);
 
         // step two: set new commit version (current_version + 1) and path to write
         let commit_version = self.read_snapshot.version() + 1;
@@ -120,11 +160,56 @@ impl Transaction {
         }
     }
 
+    /// given an iterator of SetTransaction actions, validate by:
+    /// 1. replaying the log to find the latest version of each app_id
+    /// 2. explode if any app_id has a version that is greater or eq to the current app_id's version
+    ///    (in this transaction)
+    ///
+    /// note that (1) above can be improved in potentially a couple of ways:
+    /// - we could merge this with the snapshot log replay above to avoid a second log replay
+    /// - we could pass a list of app ids to the set transaction scanner so we don't do wasted work
+    fn validate_set_transactions(&self, engine: &dyn Engine) -> DeltaResult<SetTransactionResult> {
+        let scanner = SetTransactionScanner::new(self.read_snapshot.clone());
+        let latest_app_ids = scanner.application_transactions(engine)?;
+
+        for set_transaction in &self.set_transactions {
+            if let Some(existing) = latest_app_ids.get(&set_transaction.app_id) {
+                if existing.version >= set_transaction.version {
+                    return Ok(SetTransactionResult::Conflict(set_transaction.clone()));
+                }
+            }
+        }
+
+        Ok(SetTransactionResult::Valid)
+    }
+
     /// Set the operation that this transaction is performing. This string will be persisted in the
     /// commit and visible to anyone who describes the table history.
     pub fn with_operation(mut self, operation: String) -> Self {
         self.operation = Some(operation);
         self
+    }
+
+    /// Include a SetTransaction (app_id and version) action for this transaction.
+    /// Note that each app_id can only appear once per transaction. That is, multiple app_ids with
+    /// different versions are disallowed in a single transaction.
+    pub fn with_set_transaction(mut self, app_id: String, version: i64) -> DeltaResult<Self> {
+        // TODO: do we want to prohibit multiple app_ids in a single transaction? (like we are
+        // doing here) Or just simply overwrite?
+        let set_transaction = SetTransaction::new(app_id, version, None);
+        if self
+            .set_transactions
+            .iter()
+            .any(|txn| txn.app_id == set_transaction.app_id)
+        {
+            return Err(Error::generic(format!(
+                "app_id {} already exists in transaction",
+                set_transaction.app_id
+            )));
+        } else {
+            self.set_transactions.push(set_transaction);
+        }
+        Ok(self)
     }
 
     /// WARNING: This is an unstable API and will likely change in the future.
@@ -246,8 +331,13 @@ impl WriteContext {
 pub enum CommitResult {
     /// The transaction was successfully committed at the version.
     Committed(Version),
-    /// The transaction conflicted with an existing version (at the version given).
+    /// This transaction conflicted with an existing version (at the version given).
     Conflict(Transaction, Version),
+    /// This transaction conflicted with a previous transaction's app_id (existing app_id version >
+    /// this transaction's app_id version).
+    /// The tuple provides the transaction (for retry), along with the (app_id, version) conflict.
+    // TODO make these structs.
+    IdempotentWriteConflict(Transaction, String, i64),
 }
 
 // given the engine's commit info we want to create commitInfo action to commit (and append more actions to)
@@ -678,4 +768,7 @@ mod tests {
         ]);
         assert_eq!(*schema, expected.into());
     }
+
+    #[test]
+    fn test_idempotent_writes() {}
 }

--- a/kernel/src/transaction.rs
+++ b/kernel/src/transaction.rs
@@ -163,13 +163,15 @@ impl Transaction {
     /// Note that each app_id can only appear once per transaction. That is, multiple app_ids with
     /// different versions are disallowed in a single transaction. If a duplicate app_id is
     /// included, the `commit` will fail (that is, we don't eagerly check app_id validity here).
-    pub fn with_transaction_id(
-        mut self,
-        app_id: String,
-        version: i64,
-        last_updated: impl Into<Option<i64>>,
-    ) -> Self {
-        let set_transaction = SetTransaction::new(app_id, version, last_updated.into());
+    pub fn with_transaction_id(mut self, app_id: String, version: i64) -> Self {
+        let last_updated = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time went backwards")
+            .as_millis()
+            .try_into()
+            // we can fit billions of years in i64
+            .expect("milliseconds since unix_epoch exceeded i64 size");
+        let set_transaction = SetTransaction::new(app_id, version, Some(last_updated));
         self.set_transactions.push(set_transaction);
         self
     }

--- a/kernel/tests/write.rs
+++ b/kernel/tests/write.rs
@@ -724,8 +724,8 @@ async fn test_idempotent_writes() -> Result<(), Box<dyn std::error::Error>> {
         assert!(matches!(
             table
                 .new_transaction(&engine)?
-                .with_transaction_id("app_id1".to_string(), 0)
-                .with_transaction_id("app_id1".to_string(), 1)
+                .with_transaction_id("app_id1".to_string(), 0, None)
+                .with_transaction_id("app_id1".to_string(), 1, None)
                 .commit(&engine),
             Err(KernelError::Generic(msg)) if msg == "app_id app_id1 already exists in transaction"
         ));
@@ -733,8 +733,8 @@ async fn test_idempotent_writes() -> Result<(), Box<dyn std::error::Error>> {
         let txn = table
             .new_transaction(&engine)?
             .with_commit_info(commit_info)
-            .with_transaction_id("app_id1".to_string(), 1)
-            .with_transaction_id("app_id2".to_string(), 2);
+            .with_transaction_id("app_id1".to_string(), 1, None)
+            .with_transaction_id("app_id2".to_string(), 2, 123456789);
 
         // commit!
         txn.commit(&engine)?;
@@ -776,7 +776,8 @@ async fn test_idempotent_writes() -> Result<(), Box<dyn std::error::Error>> {
             json!({
                 "txn": {
                     "appId": "app_id2",
-                    "version": 2
+                    "version": 2,
+                    "lastUpdated": 123456789
                 }
             }),
         ];

--- a/kernel/tests/write.rs
+++ b/kernel/tests/write.rs
@@ -761,6 +761,19 @@ async fn test_write_txn_actions() -> Result<(), Box<dyn std::error::Error>> {
             .try_into()
             .unwrap();
 
+        // check that last_updated times are identical
+        let last_updated1 = parsed_commits[1]
+            .get("txn")
+            .unwrap()
+            .get("lastUpdated")
+            .unwrap();
+        let last_updated2 = parsed_commits[2]
+            .get("txn")
+            .unwrap()
+            .get("lastUpdated")
+            .unwrap();
+        assert_eq!(last_updated1, last_updated2);
+
         let last_updated = parsed_commits[1]
             .get_mut("txn")
             .unwrap()

--- a/kernel/tests/write.rs
+++ b/kernel/tests/write.rs
@@ -7,6 +7,7 @@ use delta_kernel::arrow::array::{
 use delta_kernel::arrow::datatypes::{DataType as ArrowDataType, Field, Schema as ArrowSchema};
 use delta_kernel::arrow::error::ArrowError;
 use delta_kernel::arrow::record_batch::RecordBatch;
+use delta_kernel::transaction::CommitResult;
 use itertools::Itertools;
 use object_store::local::LocalFileSystem;
 use object_store::memory::InMemory;
@@ -701,6 +702,95 @@ async fn test_append_invalid_schema() -> Result<(), Box<dyn std::error::Error>> 
                 true,
             _ => false,
         }));
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_idempotent_writes() -> Result<(), Box<dyn std::error::Error>> {
+    // setup tracing
+    let _ = tracing_subscriber::fmt::try_init();
+
+    // create a simple table: one int column named 'number'
+    let schema = Arc::new(StructType::new(vec![StructField::nullable(
+        "number",
+        DataType::INTEGER,
+    )]));
+
+    for (table, engine, store, table_name) in setup_tables(schema, &[]).await? {
+        let commit_info = new_commit_info()?;
+
+        // can't have duplicate app_id in same transaction
+        assert!(table
+            .new_transaction(&engine)?
+            .with_set_transaction("app_id1".to_string(), 0)?
+            .with_set_transaction("app_id1".to_string(), 1)
+            .is_err());
+
+        let txn = table
+            .new_transaction(&engine)?
+            .with_commit_info(commit_info)
+            .with_set_transaction("app_id1".to_string(), 1)?
+            .with_set_transaction("app_id2".to_string(), 2)?;
+
+        // commit!
+        txn.commit(&engine)?;
+
+        let commit1 = store
+            .get(&Path::from(format!(
+                "/{table_name}/_delta_log/00000000000000000001.json"
+            )))
+            .await?;
+
+        let mut parsed_commits: Vec<_> = Deserializer::from_slice(&commit1.bytes().await?)
+            .into_iter::<serde_json::Value>()
+            .try_collect()?;
+
+        *parsed_commits[0]
+            .get_mut("commitInfo")
+            .unwrap()
+            .get_mut("timestamp")
+            .unwrap() = serde_json::Value::Number(0.into());
+
+        let expected_commit = vec![
+            json!({
+                "commitInfo": {
+                    "timestamp": 0,
+                    "operation": "UNKNOWN",
+                    "kernelVersion": format!("v{}", env!("CARGO_PKG_VERSION")),
+                    "operationParameters": {},
+                    "engineCommitInfo": {
+                        "engineInfo": "default engine"
+                    }
+                }
+            }),
+            json!({
+                "txn": {
+                    "appId": "app_id1",
+                    "version": 1
+                }
+            }),
+            json!({
+                "txn": {
+                    "appId": "app_id2",
+                    "version": 2
+                }
+            }),
+        ];
+
+        assert_eq!(parsed_commits, expected_commit);
+
+        let commit_info = new_commit_info()?;
+        let txn = table
+            .new_transaction(&engine)?
+            .with_commit_info(commit_info)
+            .with_set_transaction("app_id1".to_string(), 1)?;
+
+        // commit should fail since we've already committed (app_id1, 1)
+        assert!(matches!(
+            txn.commit(&engine)?,
+            CommitResult::IdempotentWriteConflict(_, _, 1)
+        ));
     }
     Ok(())
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?
(part of idempotent writes support) this PR adds `transaction.with_transaction_id(app_id: String, version: i64, last_updated: Option<i64>)` API for commiting `txn` actions to the log. The only invariant imposed by kernel (as indicated by the [spec](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#transaction-identifiers)) is that each `app_id` in a commit is unique.
> The semantics of the application-specific version are left up to the external system. Delta only ensures that the latest version for a given appId is available in the table snapshot. The Delta transaction protocol does not, for example, assume monotonicity of the version and it would be valid for the version to decrease, possibly representing a "rollback" of an earlier transaction.

Note that in order to make this useful to engines we need to expose `SetTransactionScanner` appropriately (in follow-up)

### This PR affects the following public APIs
Add `Transaction::with_set_transaction(app_id, version, last_updated)`


## How was this change tested?
new tests in write.rs

resolves #845 