### PR TITLE
[POC] feat: create table API

### DIFF
--- a/derive-macros/src/lib.rs
+++ b/derive-macros/src/lib.rs
@@ -168,12 +168,15 @@ pub fn into_engine_data_derive(input: proc_macro::TokenStream) -> proc_macro::To
 
     let expanded = quote! {
         #[automatically_derived]
-        impl ToEngineData for #struct_name
+        impl ::delta_kernel::ToEngineData for #struct_name
         where
-            Self: ToDataType,
-            #(#field_types: Into<Scalar>),*
+            Self: ::delta_kernel::actions::schemas::ToDataType,
+            #(#field_types: Into<::delta_kernel::expressions::Scalar>),*
         {
-            fn into_engine_data(self, engine: &dyn Engine) -> DeltaResult<Box<dyn EngineData>> {
+            fn into_engine_data(
+                self,
+                engine: &dyn ::delta_kernel::Engine)
+            -> ::delta_kernel::DeltaResult<Box<dyn ::delta_kernel::EngineData>> {
                 let values = [
                     #(self.#field_idents.into()),*
                 ];

--- a/derive-macros/src/lib.rs
+++ b/derive-macros/src/lib.rs
@@ -136,7 +136,7 @@ fn gen_schema_fields(data: &Data) -> TokenStream {
 }
 
 /// Derive an IntoEngineData trait for a struct that implements ToDataType and has all fields
-/// implement Into<Scalar>.
+/// implement `Into<Scalar>`.
 #[proc_macro_derive(IntoEngineData)]
 pub fn into_engine_data_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/ffi/src/expressions/kernel.rs
+++ b/ffi/src/expressions/kernel.rs
@@ -333,6 +333,7 @@ fn visit_expression_internal(
                 visit_expression_struct_literal(visitor, struct_data, sibling_list_id)
             }
             Scalar::Array(array) => visit_expression_array(visitor, array, sibling_list_id),
+            Scalar::Map(_map_data) => todo!(),
         }
     }
     fn visit_expression_impl(

--- a/kernel/src/actions/schemas.rs
+++ b/kernel/src/actions/schemas.rs
@@ -4,6 +4,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::schema::{ArrayType, DataType, MapType, StructField, StructType};
 
+// TODO(zach): should this instead return something const? or Arc<StructType>?
 pub(crate) trait ToSchema {
     fn to_schema() -> StructType;
 }

--- a/kernel/src/engine/arrow_expression/mod.rs
+++ b/kernel/src/engine/arrow_expression/mod.rs
@@ -84,6 +84,7 @@ impl Scalar {
                     None,
                 ))
             }
+            Map(map_data) => todo!(),
             Null(DataType::BYTE) => Arc::new(Int8Array::new_null(num_rows)),
             Null(DataType::SHORT) => Arc::new(Int16Array::new_null(num_rows)),
             Null(DataType::INTEGER) => Arc::new(Int32Array::new_null(num_rows)),

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -3,6 +3,7 @@ use std::fmt::{Display, Formatter};
 
 use chrono::{DateTime, NaiveDate, NaiveDateTime, TimeZone, Utc};
 
+use crate::actions::schemas::ToDataType;
 use crate::schema::{ArrayType, DataType, PrimitiveType, StructField};
 use crate::utils::require;
 use crate::{DeltaResult, Error};
@@ -335,6 +336,15 @@ impl<T: Into<Scalar> + Copy> From<&T> for Scalar {
 impl From<&[u8]> for Scalar {
     fn from(b: &[u8]) -> Self {
         Self::Binary(b.into())
+    }
+}
+
+impl<T: Into<Scalar> + ToDataType> From<Option<T>> for Scalar {
+    fn from(val: Option<T>) -> Self {
+        match val {
+            Some(v) => v.into(),
+            None => Scalar::Null(T::to_data_type()),
+        }
     }
 }
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -388,6 +388,17 @@ trait EvaluationHandlerExtension: EvaluationHandler {
 // Auto-implement the extension trait for all EvaluationHandlers
 impl<T: EvaluationHandler> EvaluationHandlerExtension for T {}
 
+/// A trait that allows converting a type into EngineData
+///
+/// This is typically used with the `#[derive(IntoEngineData)]` macro
+/// which leverages the traits `ToDataType` and `Into<Scalar>` for struct fields
+/// to convert a struct into EngineData.
+#[allow(unused)]
+pub(crate) trait ToEngineData {
+    /// Convert this type into EngineData using the provided engine
+    fn into_engine_data(self, engine: &dyn Engine) -> DeltaResult<Box<dyn EngineData>>;
+}
+
 /// Provides file system related functionalities to Delta Kernel.
 ///
 /// Delta Kernel uses this handler whenever it needs to access the underlying

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -376,6 +376,7 @@ trait EvaluationHandlerExtension: EvaluationHandler {
         let null_row = self.null_row(null_row_schema.clone())?;
 
         // Convert schema and leaf values to an expression
+        println!("{:?}, {:?}", schema, values);
         let mut schema_transform = LiteralExpressionTransform::new(values);
         schema_transform.transform_struct(schema.as_ref());
         let row_expr = schema_transform.try_into_expr()?;

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -386,7 +386,7 @@ trait EvaluationHandlerExtension: EvaluationHandler {
 }
 
 // Auto-implement the extension trait for all EvaluationHandlers
-impl<T: EvaluationHandler> EvaluationHandlerExtension for T {}
+impl<T: EvaluationHandler + ?Sized> EvaluationHandlerExtension for T {}
 
 /// A trait that allows converting a type into EngineData
 ///
@@ -394,7 +394,7 @@ impl<T: EvaluationHandler> EvaluationHandlerExtension for T {}
 /// which leverages the traits `ToDataType` and `Into<Scalar>` for struct fields
 /// to convert a struct into EngineData.
 #[allow(unused)]
-pub(crate) trait ToEngineData {
+pub(crate) trait IntoEngineData {
     /// Convert this type into EngineData using the provided engine
     fn into_engine_data(self, engine: &dyn Engine) -> DeltaResult<Box<dyn EngineData>>;
 }

--- a/kernel/tests/create.rs
+++ b/kernel/tests/create.rs
@@ -1,0 +1,16 @@
+use delta_kernel::engine::sync::SyncEngine;
+use delta_kernel::schema::{DataType, Schema, StructField};
+use delta_kernel::Table;
+
+use url::Url;
+
+#[test]
+fn test_create_table() {
+    let engine = SyncEngine::new();
+    let schema = Schema::new([StructField::nullable("id", DataType::INTEGER)]);
+    let location = Url::parse("file:////Users/zach.schuermann/Desktop/test_table/").unwrap();
+    let table = Table::create("test_table", schema, location, &engine).unwrap();
+
+    let snapshot = table.snapshot(&engine, None).unwrap();
+    assert_eq!(snapshot.version(), 0);
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?
Playing with a POC for implementing a CREATE TABLE API.

- adds `Table::create()` API
- adds a new `Scalar::Map` type (previously just didn't support `Scalar` maps)
- adds map and array support to `LiteralExpressionTransform`
- adds a bunch of `impl From for Scalar`

Stacked on #830 

### This PR affects the following public APIs
- New `Table::create()` API

## How was this change tested?
new integration test + some UT

resolves #843 