### PR TITLE
refactor: new `#[internal_api]` macro instead of `visibility` crate

### DIFF
--- a/derive-macros/Cargo.toml
+++ b/derive-macros/Cargo.toml
@@ -15,5 +15,5 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = "1"
-syn = { version = "2.0", features = ["extra-traits"] }
+syn = { version = "2.0", features = ["full"] }
 quote = "1.0"

--- a/derive-macros/Cargo.toml
+++ b/derive-macros/Cargo.toml
@@ -15,5 +15,5 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = "1"
-syn = { version = "2.0", features = ["full"] }
+syn = { version = "2.0", features = ["extra-traits", "full"] }
 quote = "1.0"

--- a/derive-macros/src/lib.rs
+++ b/derive-macros/src/lib.rs
@@ -165,14 +165,13 @@ pub fn internal_api(
 fn make_public(mut item: Item) -> Item {
     fn set_pub(vis: &mut Visibility) -> Result<(), syn::Error> {
         if matches!(vis, Visibility::Public(_)) {
-            Err(Error::new(
+            return Err(Error::new(
                 vis.span(),
                 "ineligible for #[internal_api]: item is already public",
-            ))
-        } else {
-            *vis = syn::parse_quote!(pub);
-            Ok(())
+            ));
         }
+        *vis = syn::parse_quote!(pub);
+        Ok(())
     }
 
     let result = match &mut item {

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -24,7 +24,6 @@ url = "2"
 delta_kernel = { path = "../kernel", default-features = false, features = [
   "internal-api",
 ] }
-delta_kernel_derive = { path = "../derive-macros", version = "0.9.0" }
 delta_kernel_ffi_macros = { path = "../ffi-proc-macros", version = "0.9.0" }
 
 [build-dependencies]

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -24,6 +24,7 @@ url = "2"
 delta_kernel = { path = "../kernel", default-features = false, features = [
   "internal-api",
 ] }
+delta_kernel_derive = { path = "../derive-macros", version = "0.9.0" }
 delta_kernel_ffi_macros = { path = "../ffi-proc-macros", version = "0.9.0" }
 
 [build-dependencies]

--- a/ffi/src/handle.rs
+++ b/ffi/src/handle.rs
@@ -547,7 +547,7 @@ mod tests {
     pub struct MutNotSync;
 
     // Because tests compile as binaries against packages, this test can only run correctly if we
-    // use the `internal-api` feature to make mod handle public. Otherwise it's inaccessible for testing
+    // use the `unstable` feature to make mod handle public. Otherwise it's inaccessible for testing
     #[test]
     #[cfg(feature = "internal-api")]
     fn invalid_handle_code() {

--- a/ffi/src/handle.rs
+++ b/ffi/src/handle.rs
@@ -547,7 +547,8 @@ mod tests {
     pub struct MutNotSync;
 
     // Because tests compile as binaries against packages, this test can only run correctly if we
-    // use the `unstable` feature to make mod handle public. Otherwise it's inaccessible for testing
+    // use the `internal-api` feature to make mod handle public. Otherwise it's inaccessible for
+    // testing
     #[test]
     #[cfg(feature = "internal-api")]
     fn invalid_handle_code() {

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -137,7 +137,7 @@ macro_rules! kernel_string_slice {
         //
         // NOTE: The `do_it` wrapper avoids an "unnecessary `unsafe` block" clippy warning in case
         // the invocation site of this macro is already in an `unsafe` block. We can't just disable
-        // the warning with #[allow(unused_unsafe)] because expression annotation is internal-api rust.
+        // the warning with #[allow(unused_unsafe)] because expression annotation is unstable rust.
         fn do_it(s: &str) -> $crate::KernelStringSlice {
             unsafe { $crate::KernelStringSlice::new_unsafe(s) }
         }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -55,9 +55,6 @@ z85 = "3.0.6"
 # bring in our derive macros
 delta_kernel_derive = { path = "../derive-macros", version = "0.9.0" }
 
-# used for `internal-api` feature flag
-visibility = "0.1.1"
-
 # Used in the sync engine
 tempfile = { version = "3", optional = true }
 

--- a/kernel/src/actions/visitors.rs
+++ b/kernel/src/actions/visitors.rs
@@ -4,6 +4,8 @@
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
+use delta_kernel_derive::internal_api;
+
 use crate::engine_data::{GetData, RowVisitor, TypedGetData as _};
 use crate::schema::{column_name, ColumnName, ColumnNamesAndTypes, DataType};
 use crate::utils::require;
@@ -17,13 +19,13 @@ use super::{
 };
 
 #[derive(Default)]
-#[cfg_attr(feature = "internal-api", visibility::make(pub))]
+#[internal_api]
 pub(crate) struct MetadataVisitor {
     pub(crate) metadata: Option<Metadata>,
 }
 
 impl MetadataVisitor {
-    #[cfg_attr(feature = "internal-api", visibility::make(pub))]
+    #[internal_api]
     fn visit_metadata<'a>(
         row_index: usize,
         id: String,
@@ -112,13 +114,13 @@ impl RowVisitor for SelectionVectorVisitor {
 }
 
 #[derive(Default)]
-#[cfg_attr(feature = "internal-api", visibility::make(pub))]
+#[internal_api]
 pub(crate) struct ProtocolVisitor {
     pub(crate) protocol: Option<Protocol>,
 }
 
 impl ProtocolVisitor {
-    #[cfg_attr(feature = "internal-api", visibility::make(pub))]
+    #[internal_api]
     pub(crate) fn visit_protocol<'a>(
         row_index: usize,
         min_reader_version: i32,
@@ -166,14 +168,13 @@ impl RowVisitor for ProtocolVisitor {
 
 #[allow(unused)]
 #[derive(Default)]
-#[cfg_attr(feature = "internal-api", visibility::make(pub))]
+#[internal_api]
 pub(crate) struct AddVisitor {
     pub(crate) adds: Vec<Add>,
 }
 
 impl AddVisitor {
-    #[cfg_attr(feature = "internal-api", visibility::make(pub))]
-    #[cfg_attr(not(feature = "internal-api"), visibility::make(pub(crate)))]
+    #[internal_api]
     fn visit_add<'a>(
         row_index: usize,
         path: String,
@@ -240,13 +241,13 @@ impl RowVisitor for AddVisitor {
 
 #[allow(unused)]
 #[derive(Default)]
-#[cfg_attr(feature = "internal-api", visibility::make(pub))]
+#[internal_api]
 pub(crate) struct RemoveVisitor {
     pub(crate) removes: Vec<Remove>,
 }
 
 impl RemoveVisitor {
-    #[cfg_attr(feature = "internal-api", visibility::make(pub))]
+    #[internal_api]
     pub(crate) fn visit_remove<'a>(
         row_index: usize,
         path: String,
@@ -315,13 +316,13 @@ impl RowVisitor for RemoveVisitor {
 
 #[allow(unused)]
 #[derive(Default)]
-#[cfg_attr(feature = "internal-api", visibility::make(pub))]
+#[internal_api]
 pub(crate) struct CdcVisitor {
     pub(crate) cdcs: Vec<Cdc>,
 }
 
 impl CdcVisitor {
-    #[cfg_attr(feature = "internal-api", visibility::make(pub))]
+    #[internal_api]
     pub(crate) fn visit_cdc<'a>(
         row_index: usize,
         path: String,
@@ -372,7 +373,7 @@ pub(crate) type SetTransactionMap = HashMap<String, SetTransaction>;
 /// required.
 ///
 #[derive(Default, Debug)]
-#[cfg_attr(feature = "internal-api", visibility::make(pub))]
+#[internal_api]
 pub(crate) struct SetTransactionVisitor {
     pub(crate) set_transactions: SetTransactionMap,
     pub(crate) application_id: Option<String>,
@@ -387,7 +388,7 @@ impl SetTransactionVisitor {
         }
     }
 
-    #[cfg_attr(feature = "internal-api", visibility::make(pub))]
+    #[internal_api]
     pub(crate) fn visit_txn<'a>(
         row_index: usize,
         app_id: String,
@@ -439,7 +440,7 @@ impl RowVisitor for SetTransactionVisitor {
 }
 
 #[derive(Default)]
-#[cfg_attr(feature = "internal-api", visibility::make(pub))]
+#[internal_api]
 pub(crate) struct SidecarVisitor {
     pub(crate) sidecars: Vec<Sidecar>,
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -123,7 +123,7 @@ macro_rules! internal_mod {
         compile_error!("internal_mod!: module is already public");
     };
 
-    ($vis:vis mod $name:ident $(;)?) => {
+    ($vis:vis mod $name:ident) => {
         #[cfg(feature = "internal-api")]
         pub mod $name;
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -114,26 +114,21 @@ use schema::{SchemaTransform, StructField, StructType};
 ))]
 pub mod engine;
 
-// Macro for `unstable` modules. Note this can't be implemented alongside the `#[internal_api]`
-// macro since proc macro crates can't export macro_rules! macros.
+// Macro for `internal-api` modules. Note this can't be implemented alongside the `#[internal_api]`
+// macro because proc macro crates can't export macro_rules! macros.
 #[macro_export]
 macro_rules! internal_mod {
-    ($vis:vis mod $name:ident) => {
+    // error if item is already pub
+    (pub mod $name:ident) => {
+        compile_error!("internal_mod!: module is already public");
+    };
+
+    ($vis:vis mod $name:ident $(;)?) => {
         #[cfg(feature = "internal-api")]
         pub mod $name;
 
         #[cfg(not(feature = "internal-api"))]
         $vis mod $name;
-    };
-
-    // allow for a trailing semicolon
-    ($vis:vis mod $name:ident;) => {
-        internal_mod!($vis mod $name);
-    };
-
-    // error if item is already pub
-    (pub mod $name:ident) => {
-        compile_error!("internal_mod!: module is already public");
     };
 }
 

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -1,5 +1,8 @@
 //! Represents a segment of a delta log. [`LogSegment`] wraps a set of  checkpoint and commit
 //! files.
+use std::collections::HashMap;
+use std::convert::identity;
+use std::sync::{Arc, LazyLock};
 
 use crate::actions::visitors::SidecarVisitor;
 use crate::actions::{
@@ -14,10 +17,9 @@ use crate::{
     DeltaResult, Engine, EngineData, Error, Expression, ExpressionRef, ParquetHandler, RowVisitor,
     StorageHandler, Version,
 };
+use delta_kernel_derive::internal_api;
+
 use itertools::Itertools;
-use std::collections::HashMap;
-use std::convert::identity;
-use std::sync::{Arc, LazyLock};
 use tracing::warn;
 use url::Url;
 
@@ -38,7 +40,7 @@ mod tests;
 ///
 /// [`Snapshot`]: crate::snapshot::Snapshot
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "internal-api", visibility::make(pub))]
+#[internal_api]
 pub(crate) struct LogSegment {
     pub end_version: Version,
     pub checkpoint_version: Option<Version>,
@@ -122,7 +124,7 @@ impl LogSegment {
     /// - `time_travel_version`: The version of the log that the Snapshot will be at.
     ///
     /// [`Snapshot`]: crate::snapshot::Snapshot
-    #[cfg_attr(feature = "internal-api", visibility::make(pub))]
+    #[internal_api]
     pub(crate) fn for_snapshot(
         storage: &dyn StorageHandler,
         log_root: Url,
@@ -152,7 +154,7 @@ impl LogSegment {
     /// `start_version` and `end_version`: Its LogSegment is made of zero checkpoints and all commits
     /// between versions `start_version` (inclusive) and `end_version` (inclusive). If no `end_version`
     /// is specified it will be the most recent version by default.
-    #[cfg_attr(feature = "internal-api", visibility::make(pub))]
+    #[internal_api]
     pub(crate) fn for_table_changes(
         storage: &dyn StorageHandler,
         log_root: Url,
@@ -201,7 +203,7 @@ impl LogSegment {
     ///
     /// `meta_predicate` is an optional expression to filter the log files with. It is _NOT_ the
     /// query's predicate, but rather a predicate for filtering log files themselves.
-    #[cfg_attr(feature = "internal-api", visibility::make(pub))]
+    #[internal_api]
     pub(crate) fn read_actions(
         &self,
         engine: &dyn Engine,

--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -1,10 +1,12 @@
 //! Utilities to make working with directory and file paths easier
 
 use std::str::FromStr;
-use url::Url;
-use uuid::Uuid;
 
 use crate::{DeltaResult, Error, FileMeta, Version};
+use delta_kernel_derive::internal_api;
+
+use url::Url;
+use uuid::Uuid;
 
 /// How many characters a version tag has
 const VERSION_LEN: usize = 20;
@@ -16,7 +18,7 @@ const MULTIPART_PART_LEN: usize = 10;
 const UUID_PART_LEN: usize = 36;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "internal-api", visibility::make(pub))]
+#[internal_api]
 pub(crate) enum LogPathFileType {
     Commit,
     SinglePartCheckpoint,
@@ -38,7 +40,7 @@ pub(crate) enum LogPathFileType {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "internal-api", visibility::make(pub))]
+#[internal_api]
 pub(crate) struct ParsedLogPath<Location: AsUrl = FileMeta> {
     pub location: Location,
     #[allow(unused)]
@@ -60,7 +62,7 @@ fn parse_path_part<T: FromStr>(value: &str, expect_len: usize, location: &Url) -
 
 // We normally construct ParsedLogPath from FileMeta, but in testing it's convenient to use
 // a Url directly instead. This trait decouples the two.
-#[cfg_attr(feature = "internal-api", visibility::make(pub))]
+#[internal_api]
 pub(crate) trait AsUrl {
     fn as_url(&self) -> &Url;
 }
@@ -79,7 +81,7 @@ impl AsUrl for Url {
 
 impl<Location: AsUrl> ParsedLogPath<Location> {
     // NOTE: We can't actually impl TryFrom because Option<T> is a foreign struct even if T is local.
-    #[cfg_attr(feature = "internal-api", visibility::make(pub))]
+    #[internal_api]
     pub(crate) fn try_from(location: Location) -> DeltaResult<Option<ParsedLogPath<Location>>> {
         let url = location.as_url();
         let filename = url
@@ -151,12 +153,12 @@ impl<Location: AsUrl> ParsedLogPath<Location> {
         }))
     }
 
-    #[cfg_attr(feature = "internal-api", visibility::make(pub))]
+    #[internal_api]
     pub(crate) fn is_commit(&self) -> bool {
         matches!(self.file_type, LogPathFileType::Commit)
     }
 
-    #[cfg_attr(feature = "internal-api", visibility::make(pub))]
+    #[internal_api]
     pub(crate) fn is_checkpoint(&self) -> bool {
         matches!(
             self.file_type,
@@ -166,7 +168,7 @@ impl<Location: AsUrl> ParsedLogPath<Location> {
         )
     }
 
-    #[cfg_attr(feature = "internal-api", visibility::make(pub))]
+    #[internal_api]
     #[allow(dead_code)] // currently only used in tests, which don't "count"
     pub(crate) fn is_unknown(&self) -> bool {
         matches!(self.file_type, LogPathFileType::Unknown)

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 pub(crate) use crate::expressions::{column_name, ColumnName};
 use crate::utils::require;
 use crate::{DeltaResult, Error};
+use delta_kernel_derive::internal_api;
 
 pub(crate) mod compare;
 
@@ -307,7 +308,7 @@ impl StructType {
     ///
     /// NOTE: This method only traverses through `StructType` fields; `MapType` and `ArrayType`
     /// fields are considered leaves even if they contain `StructType` entries/elements.
-    #[cfg_attr(feature = "internal-api", visibility::make(pub))]
+    #[internal_api]
     pub(crate) fn leaves<'s>(&self, own_name: impl Into<Option<&'s str>>) -> ColumnNamesAndTypes {
         let mut get_leaves = GetSchemaLeaves::new(own_name.into());
         let _ = get_leaves.transform_struct(self);
@@ -344,11 +345,11 @@ impl InvariantChecker {
 }
 
 /// Helper for RowVisitor implementations
-#[cfg_attr(feature = "internal-api", visibility::make(pub))]
+#[internal_api]
 #[derive(Clone, Default)]
 pub(crate) struct ColumnNamesAndTypes(Vec<ColumnName>, Vec<DataType>);
 impl ColumnNamesAndTypes {
-    #[cfg_attr(feature = "internal-api", visibility::make(pub))]
+    #[internal_api]
     pub(crate) fn as_ref(&self) -> (&[ColumnName], &[DataType]) {
         (&self.0, &self.1)
     }

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -1,10 +1,7 @@
 //! In-memory representation of snapshots of tables (snapshot is a table at given point in time, it
 //! has schema etc.)
 
-use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use tracing::{debug, warn};
-use url::Url;
 
 use crate::actions::{Metadata, Protocol};
 use crate::log_segment::{self, LogSegment};
@@ -14,6 +11,11 @@ use crate::table_configuration::TableConfiguration;
 use crate::table_features::ColumnMappingMode;
 use crate::table_properties::TableProperties;
 use crate::{DeltaResult, Engine, Error, StorageHandler, Version};
+use delta_kernel_derive::internal_api;
+
+use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
+use url::Url;
 
 const LAST_CHECKPOINT_FILE_NAME: &str = "_last_checkpoint";
 // TODO expose methods for accessing the files of a table (with file pruning).
@@ -242,7 +244,7 @@ impl Snapshot {
     }
 
     /// Log segment this snapshot uses
-    #[cfg_attr(feature = "internal-api", visibility::make(pub))]
+    #[internal_api]
     pub(crate) fn log_segment(&self) -> &LogSegment {
         &self.log_segment
     }
@@ -262,14 +264,14 @@ impl Snapshot {
     }
 
     /// Table [`Metadata`] at this `Snapshot`s version.
-    #[cfg_attr(feature = "internal-api", visibility::make(pub))]
+    #[internal_api]
     pub(crate) fn metadata(&self) -> &Metadata {
         self.table_configuration.metadata()
     }
 
     /// Table [`Protocol`] at this `Snapshot`s version.
     #[allow(dead_code)]
-    #[cfg_attr(feature = "internal-api", visibility::make(pub))]
+    #[internal_api]
     pub(crate) fn protocol(&self) -> &Protocol {
         self.table_configuration.protocol()
     }
@@ -278,11 +280,13 @@ impl Snapshot {
     pub fn table_properties(&self) -> &TableProperties {
         self.table_configuration().table_properties()
     }
+
     /// Get the [`TableConfiguration`] for this [`Snapshot`].
-    #[cfg_attr(feature = "internal-api", visibility::make(pub))]
+    #[internal_api]
     pub(crate) fn table_configuration(&self) -> &TableConfiguration {
         &self.table_configuration
     }
+
     /// Get the [column mapping
     /// mode](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#column-mapping) at this
     /// `Snapshot`s version.
@@ -304,7 +308,7 @@ impl Snapshot {
 // Note: Schema can not be derived because the checkpoint schema is only known at runtime.
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "internal-api", visibility::make(pub))]
+#[internal_api]
 pub(crate) struct LastCheckpointHint {
     /// The version of the table when the last checkpoint was made.
     #[allow(unreachable_pub)] // used by acceptance tests (TODO make an fn accessor?)

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -20,6 +20,7 @@ use crate::table_features::{
 };
 use crate::table_properties::TableProperties;
 use crate::{DeltaResult, Error, Version};
+use delta_kernel_derive::internal_api;
 
 /// Holds all the configuration for a table at a specific version. This includes the supported
 /// reader and writer features, table properties, schema, version, and table root. This can be used
@@ -31,7 +32,7 @@ use crate::{DeltaResult, Error, Version};
 /// to validate that Metadata and Protocol are correctly formatted and mutually compatible. If
 /// `try_new` successfully returns `TableConfiguration`, it is also guaranteed that reading the
 /// table is supported.
-#[cfg_attr(feature = "internal-api", visibility::make(pub))]
+#[internal_api]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TableConfiguration {
     metadata: Metadata,
@@ -114,50 +115,50 @@ impl TableConfiguration {
     }
 
     /// The [`Metadata`] for this table at this version.
-    #[cfg_attr(feature = "internal-api", visibility::make(pub))]
+    #[internal_api]
     pub(crate) fn metadata(&self) -> &Metadata {
         &self.metadata
     }
 
     /// The [`Protocol`] of this table at this version.
-    #[cfg_attr(feature = "internal-api", visibility::make(pub))]
+    #[internal_api]
     pub(crate) fn protocol(&self) -> &Protocol {
         &self.protocol
     }
 
     /// The logical schema ([`SchemaRef`]) of this table at this version.
-    #[cfg_attr(feature = "internal-api", visibility::make(pub))]
+    #[internal_api]
     pub(crate) fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
 
     /// The [`TableProperties`] of this table at this version.
-    #[cfg_attr(feature = "internal-api", visibility::make(pub))]
+    #[internal_api]
     pub(crate) fn table_properties(&self) -> &TableProperties {
         &self.table_properties
     }
 
     /// The [`ColumnMappingMode`] for this table at this version.
-    #[cfg_attr(feature = "internal-api", visibility::make(pub))]
+    #[internal_api]
     pub(crate) fn column_mapping_mode(&self) -> ColumnMappingMode {
         self.column_mapping_mode
     }
 
     /// The [`Url`] of the table this [`TableConfiguration`] belongs to
-    #[cfg_attr(feature = "internal-api", visibility::make(pub))]
+    #[internal_api]
     pub(crate) fn table_root(&self) -> &Url {
         &self.table_root
     }
 
     /// The [`Version`] which this [`TableConfiguration`] belongs to.
-    #[cfg_attr(feature = "internal-api", visibility::make(pub))]
+    #[internal_api]
     pub(crate) fn version(&self) -> Version {
         self.version
     }
 
     /// Returns `true` if the kernel supports writing to this table. This checks that the
     /// protocol's writer features are all supported.
-    #[cfg_attr(feature = "internal-api", visibility::make(pub))]
+    #[internal_api]
     pub(crate) fn ensure_write_supported(&self) -> DeltaResult<()> {
         self.protocol.ensure_write_supported()?;
 
@@ -178,7 +179,7 @@ impl TableConfiguration {
     /// See the documentation of [`TableChanges`] for more details.
     ///
     /// [`TableChanges`]: crate::table_changes::TableChanges
-    #[cfg_attr(feature = "internal-api", visibility::make(pub))]
+    #[internal_api]
     pub(crate) fn is_cdf_read_supported(&self) -> bool {
         static CDF_SUPPORTED_READER_FEATURES: LazyLock<Vec<ReaderFeature>> =
             LazyLock::new(|| vec![ReaderFeature::DeletionVectors]);
@@ -208,7 +209,7 @@ impl TableConfiguration {
     /// both the protocol's readerFeatures and writerFeatures.
     ///
     /// See: <https://github.com/delta-io/delta/blob/master/PROTOCOL.md#deletion-vectors>
-    #[cfg_attr(feature = "internal-api", visibility::make(pub))]
+    #[internal_api]
     #[allow(unused)] // needed to compile w/o default features
     pub(crate) fn is_deletion_vector_supported(&self) -> bool {
         let read_supported = self
@@ -227,7 +228,7 @@ impl TableConfiguration {
     /// table property is set to `true`.
     ///
     /// See: <https://github.com/delta-io/delta/blob/master/PROTOCOL.md#deletion-vectors>
-    #[cfg_attr(feature = "internal-api", visibility::make(pub))]
+    #[internal_api]
     #[allow(unused)] // needed to compile w/o default features
     pub(crate) fn is_deletion_vector_enabled(&self) -> bool {
         self.is_deletion_vector_supported()


### PR DESCRIPTION
## What changes are proposed in this pull request?
In an effort to simplify our system of having an `internal_api` API this PR introduces an `#[internal_api]` attribute to annotate functions that are `pub(crate)` to make them `pub` when the `internal_api` feature flag is enabled. In this process, the PR removes our dependency on `visibility` crate (and hopefully makes it easier to introduce/track our 'internal' APIs). Note that there's also a small `internal_mod!` macro which is used to workaround the limitation of rustc disallowing attributes on non-inline modules.

~Stacked on #834~

## How was this change tested?
build