### PR TITLE
refactor!: Rename VariadicExpression to JunctionExpression

### DIFF
--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -237,11 +237,8 @@ pub(crate) fn evaluate_expression(
                     evaluate_expression(&Expression::literal(default), batch, result_type)
                 })
         }
-        (Junction(_), _) => {
-            // NOTE: Update this error message if we add support for junction operations on other types
-            Err(Error::Generic(format!(
-                "Junction {expression:?} is expected to return boolean results, got {result_type:?}"
-            )))
-        }
+        (Junction(_), _) => Err(Error::Generic(format!(
+            "Junction {expression:?} is expected to return boolean results, got {result_type:?}"
+        ))),
     }
 }

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -14,8 +14,8 @@ use crate::arrow::error::ArrowError;
 use crate::engine::arrow_utils::prim_array_cmp;
 use crate::error::{DeltaResult, Error};
 use crate::expressions::{
-    BinaryExpression, BinaryOperator, Expression, Scalar, UnaryExpression, UnaryOperator,
-    VariadicExpression, VariadicOperator,
+    BinaryExpression, BinaryOperator, Expression, JunctionExpression, JunctionOperator, Scalar,
+    UnaryExpression, UnaryOperator,
 };
 use crate::schema::DataType;
 use itertools::Itertools;
@@ -220,11 +220,11 @@ pub(crate) fn evaluate_expression(
 
             eval(&left_arr, &right_arr).map_err(Error::generic_err)
         }
-        (Variadic(VariadicExpression { op, exprs }), None | Some(&DataType::BOOLEAN)) => {
+        (Junction(JunctionExpression { op, exprs }), None | Some(&DataType::BOOLEAN)) => {
             type Operation = fn(&BooleanArray, &BooleanArray) -> Result<BooleanArray, ArrowError>;
             let (reducer, default): (Operation, _) = match op {
-                VariadicOperator::And => (and_kleene, true),
-                VariadicOperator::Or => (or_kleene, false),
+                JunctionOperator::And => (and_kleene, true),
+                JunctionOperator::Or => (or_kleene, false),
             };
             exprs
                 .iter()
@@ -237,10 +237,10 @@ pub(crate) fn evaluate_expression(
                     evaluate_expression(&Expression::literal(default), batch, result_type)
                 })
         }
-        (Variadic(_), _) => {
-            // NOTE: Update this error message if we add support for variadic operations on other types
+        (Junction(_), _) => {
+            // NOTE: Update this error message if we add support for junction operations on other types
             Err(Error::Generic(format!(
-                "Variadic {expression:?} is expected to return boolean results, got {result_type:?}"
+                "Junction {expression:?} is expected to return boolean results, got {result_type:?}"
             )))
         }
     }

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -75,14 +75,16 @@ impl BinaryOperator {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum VariadicOperator {
+pub enum JunctionOperator {
+    /// Conjunction
     And,
+    /// Disjunction
     Or,
 }
 
-impl VariadicOperator {
-    pub(crate) fn invert(&self) -> VariadicOperator {
-        use VariadicOperator::*;
+impl JunctionOperator {
+    pub(crate) fn invert(&self) -> JunctionOperator {
+        use JunctionOperator::*;
         match self {
             And => Or,
             Or => And,
@@ -156,14 +158,14 @@ impl BinaryExpression {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct VariadicExpression {
+pub struct JunctionExpression {
     /// The operator.
-    pub op: VariadicOperator,
+    pub op: JunctionOperator,
     /// The expressions.
     pub exprs: Vec<Expression>,
 }
-impl VariadicExpression {
-    fn new(op: VariadicOperator, exprs: Vec<Expression>) -> Self {
+impl JunctionExpression {
+    fn new(op: JunctionOperator, exprs: Vec<Expression>) -> Self {
         Self { op, exprs }
     }
 }
@@ -185,8 +187,8 @@ pub enum Expression {
     Unary(UnaryExpression),
     /// A binary operation.
     Binary(BinaryExpression),
-    /// A variadic operation.
-    Variadic(VariadicExpression),
+    /// A junction operation (AND/OR).
+    Junction(JunctionExpression),
     // TODO: support more expressions, such as IS IN, LIKE, etc.
 }
 
@@ -222,11 +224,11 @@ impl Display for Expression {
                 UnaryOperator::Not => write!(f, "NOT {expr}"),
                 UnaryOperator::IsNull => write!(f, "{expr} IS NULL"),
             },
-            Self::Variadic(VariadicExpression { op, exprs }) => {
+            Self::Junction(JunctionExpression { op, exprs }) => {
                 let exprs = &exprs.iter().map(|e| format!("{e}")).join(", ");
                 let op = match op {
-                    VariadicOperator::And => "AND",
-                    VariadicOperator::Or => "OR",
+                    JunctionOperator::And => "AND",
+                    JunctionOperator::Or => "OR",
                 };
                 write!(f, "{op}({exprs})")
             }
@@ -285,20 +287,20 @@ impl Expression {
         })
     }
 
-    /// Creates a new variadic expression OP(exprs...)
-    pub fn variadic(op: VariadicOperator, exprs: impl IntoIterator<Item = Self>) -> Self {
+    /// Creates a new junction expression OP(exprs...)
+    pub fn junction(op: JunctionOperator, exprs: impl IntoIterator<Item = Self>) -> Self {
         let exprs = exprs.into_iter().collect::<Vec<_>>();
-        Self::Variadic(VariadicExpression { op, exprs })
+        Self::Junction(JunctionExpression { op, exprs })
     }
 
     /// Creates a new expression AND(exprs...)
     pub fn and_from(exprs: impl IntoIterator<Item = Self>) -> Self {
-        Self::variadic(VariadicOperator::And, exprs)
+        Self::junction(JunctionOperator::And, exprs)
     }
 
     /// Creates a new expression OR(exprs...)
     pub fn or_from(exprs: impl IntoIterator<Item = Self>) -> Self {
-        Self::variadic(VariadicOperator::Or, exprs)
+        Self::junction(JunctionOperator::Or, exprs)
     }
 
     /// Create a new expression `self IS NULL`
@@ -420,13 +422,13 @@ pub trait ExpressionTransform<'a> {
         self.recurse_into_binary(expr)
     }
 
-    /// Called for each [`VariadicExpression`] encountered during the traversal. Implementations can
-    /// call [`Self::recurse_into_variadic`] if they wish to recursively transform the children.
-    fn transform_variadic(
+    /// Called for each [`JunctionExpression`] encountered during the traversal. Implementations can
+    /// call [`Self::recurse_into_junction`] if they wish to recursively transform the children.
+    fn transform_junction(
         &mut self,
-        expr: &'a VariadicExpression,
-    ) -> Option<Cow<'a, VariadicExpression>> {
-        self.recurse_into_variadic(expr)
+        expr: &'a JunctionExpression,
+    ) -> Option<Cow<'a, JunctionExpression>> {
+        self.recurse_into_junction(expr)
     }
 
     /// General entry point for transforming an expression. This method will dispatch to the
@@ -455,8 +457,8 @@ pub trait ExpressionTransform<'a> {
                 Owned(b) => Owned(Expression::Binary(b)),
                 Borrowed(_) => Borrowed(expr),
             },
-            Expression::Variadic(v) => match self.transform_variadic(v)? {
-                Owned(v) => Owned(Expression::Variadic(v)),
+            Expression::Junction(j) => match self.transform_junction(j)? {
+                Owned(j) => Owned(Expression::Junction(j)),
                 Borrowed(_) => Borrowed(expr),
             },
         };
@@ -524,19 +526,19 @@ pub trait ExpressionTransform<'a> {
         Some(b)
     }
 
-    /// Recursively transforms a variadic expression's children. Returns `None` if all children were
+    /// Recursively transforms a junction expression's children. Returns `None` if all children were
     /// removed, `Some(Cow::Owned)` if at least one child was changed or removed, and
     /// `Some(Cow::Borrowed)` otherwise.
-    fn recurse_into_variadic(
+    fn recurse_into_junction(
         &mut self,
-        v: &'a VariadicExpression,
-    ) -> Option<Cow<'a, VariadicExpression>> {
+        j: &'a JunctionExpression,
+    ) -> Option<Cow<'a, JunctionExpression>> {
         use Cow::*;
-        let v = match self.recurse_into_struct(&v.exprs)? {
-            Owned(exprs) => Owned(VariadicExpression::new(v.op, exprs)),
-            Borrowed(_) => Borrowed(v),
+        let j = match self.recurse_into_struct(&j.exprs)? {
+            Owned(exprs) => Owned(JunctionExpression::new(j.op, exprs)),
+            Borrowed(_) => Borrowed(j),
         };
-        Some(v)
+        Some(j)
     }
 }
 
@@ -671,11 +673,11 @@ impl<'a> ExpressionTransform<'a> for ExpressionDepthChecker {
         self.depth_limited(Self::recurse_into_binary, expr)
     }
 
-    fn transform_variadic(
+    fn transform_junction(
         &mut self,
-        expr: &'a VariadicExpression,
-    ) -> Option<Cow<'a, VariadicExpression>> {
-        self.depth_limited(Self::recurse_into_variadic, expr)
+        expr: &'a JunctionExpression,
+    ) -> Option<Cow<'a, JunctionExpression>> {
+        self.depth_limited(Self::recurse_into_junction, expr)
     }
 }
 

--- a/kernel/src/kernel_predicates/mod.rs
+++ b/kernel/src/kernel_predicates/mod.rs
@@ -1,6 +1,6 @@
 use crate::expressions::{
-    BinaryExpression, BinaryOperator, ColumnName, Expression as Expr, Scalar, UnaryExpression,
-    UnaryOperator, VariadicExpression, VariadicOperator,
+    BinaryExpression, BinaryOperator, ColumnName, Expression as Expr, JunctionExpression,
+    JunctionOperator, Scalar, UnaryExpression, UnaryOperator,
 };
 use crate::schema::DataType;
 
@@ -97,14 +97,14 @@ pub(crate) trait KernelPredicateEvaluator {
         inverted: bool,
     ) -> Option<Self::Output>;
 
-    /// Completes evaluation of a (possibly inverted) variadic expression.
+    /// Completes evaluation of a (possibly inverted) junction expression.
     ///
     /// AND and OR are implemented by first evaluating its (possibly inverted) inputs. This part is
-    /// always the same, provided by [`eval_variadic`]). The results are then combined to become the
+    /// always the same, provided by [`eval_junction`]). The results are then combined to become the
     /// expression's output in some implementation-defined way (this method).
-    fn finish_eval_variadic(
+    fn finish_eval_junction(
         &self,
-        op: VariadicOperator,
+        op: JunctionOperator,
         exprs: impl IntoIterator<Item = Option<Self::Output>>,
         inverted: bool,
     ) -> Option<Self::Output>;
@@ -156,7 +156,7 @@ pub(crate) trait KernelPredicateEvaluator {
                 self.eval_is_null(col, inverted),
                 self.eval_eq(col, val, !inverted),
             ];
-            self.finish_eval_variadic(VariadicOperator::Or, args, inverted)
+            self.finish_eval_junction(JunctionOperator::Or, args, inverted)
         }
     }
 
@@ -206,15 +206,15 @@ pub(crate) trait KernelPredicateEvaluator {
         }
     }
 
-    /// Dispatches a variadic operation, leveraging each implementation's [`finish_eval_variadic`].
-    fn eval_variadic(
+    /// Dispatches a junction operation, leveraging each implementation's [`finish_eval_junction`].
+    fn eval_junction(
         &self,
-        op: VariadicOperator,
+        op: JunctionOperator,
         exprs: &[Expr],
         inverted: bool,
     ) -> Option<Self::Output> {
         let exprs = exprs.iter().map(|expr| self.eval_expr(expr, inverted));
-        self.finish_eval_variadic(op, exprs, inverted)
+        self.finish_eval_junction(op, exprs, inverted)
     }
 
     /// Dispatches an expression to the specific implementation for each expression variant.
@@ -230,7 +230,7 @@ pub(crate) trait KernelPredicateEvaluator {
             Binary(BinaryExpression { op, left, right }) => {
                 self.eval_binary(*op, left, right, inverted)
             }
-            Variadic(VariadicExpression { op, exprs }) => self.eval_variadic(*op, exprs, inverted),
+            Junction(JunctionExpression { op, exprs }) => self.eval_junction(*op, exprs, inverted),
         }
     }
 
@@ -339,13 +339,12 @@ pub(crate) trait KernelPredicateEvaluator {
     fn eval_expr_sql_where(&self, filter: &Expr, inverted: bool) -> Option<Self::Output> {
         use Expr::*;
         match filter {
-            Variadic(v) => {
+            Junction(JunctionExpression { op, exprs }) => {
                 // Recursively invoke `eval_expr_sql_where` instead of the usual `eval_expr` for AND/OR.
-                let exprs = v
-                    .exprs
+                let exprs = exprs
                     .iter()
                     .map(|expr| self.eval_expr_sql_where(expr, inverted));
-                self.finish_eval_variadic(v.op, exprs, inverted)
+                self.finish_eval_junction(*op, exprs, inverted)
             }
             Binary(BinaryExpression { op, left, right }) if op.is_null_intolerant_comparison() => {
                 // Perform a nullsafe comparison instead of the usual `eval_binary`
@@ -354,7 +353,7 @@ pub(crate) trait KernelPredicateEvaluator {
                     self.eval_unary(UnaryOperator::IsNull, right, true),
                     self.eval_binary(*op, left, right, inverted),
                 ];
-                self.finish_eval_variadic(VariadicOperator::And, exprs, false)
+                self.finish_eval_junction(JunctionOperator::And, exprs, false)
             }
             Unary(UnaryExpression {
                 op: UnaryOperator::Not,
@@ -366,7 +365,7 @@ pub(crate) trait KernelPredicateEvaluator {
                     self.eval_unary(UnaryOperator::IsNull, filter, true),
                     self.eval_column(col, inverted),
                 ];
-                self.finish_eval_variadic(VariadicOperator::And, exprs, false)
+                self.finish_eval_junction(JunctionOperator::And, exprs, false)
             }
             Literal(val) if val.is_null() => {
                 // AND(NULL IS NOT NULL, NULL) = AND(FALSE, NULL) = FALSE
@@ -460,22 +459,22 @@ impl KernelPredicateEvaluatorDefaults {
         }
     }
 
-    /// Finishes evaluating a (possibly inverted) variadic operation. See
-    /// [`KernelPredicateEvaluator::finish_eval_variadic`].
+    /// Finishes evaluating a (possibly inverted) junction operation. See
+    /// [`KernelPredicateEvaluator::finish_eval_junction`].
     ///
     /// The inputs were already inverted by the caller, if needed.
     ///
     /// With AND (OR), any FALSE (TRUE) input dominates, forcing a FALSE (TRUE) output.  If there
     /// was no dominating input, then any NULL input forces NULL output.  Otherwise, return the
     /// non-dominant value. Inverting the operation also inverts the dominant value.
-    pub(crate) fn finish_eval_variadic(
-        op: VariadicOperator,
+    pub(crate) fn finish_eval_junction(
+        op: JunctionOperator,
         exprs: impl IntoIterator<Item = Option<bool>>,
         inverted: bool,
     ) -> Option<bool> {
         let dominator = match op {
-            VariadicOperator::And => inverted,
-            VariadicOperator::Or => !inverted,
+            JunctionOperator::And => inverted,
+            JunctionOperator::Or => !inverted,
         };
         let result = exprs.into_iter().try_fold(false, |found_null, val| {
             match val {
@@ -596,13 +595,13 @@ impl<R: ResolveColumnAsScalar> KernelPredicateEvaluator for DefaultKernelPredica
         self.eval_binary_scalars(op, &left, &right, inverted)
     }
 
-    fn finish_eval_variadic(
+    fn finish_eval_junction(
         &self,
-        op: VariadicOperator,
+        op: JunctionOperator,
         exprs: impl IntoIterator<Item = Option<bool>>,
         inverted: bool,
     ) -> Option<bool> {
-        KernelPredicateEvaluatorDefaults::finish_eval_variadic(op, exprs, inverted)
+        KernelPredicateEvaluatorDefaults::finish_eval_junction(op, exprs, inverted)
     }
 }
 
@@ -654,10 +653,10 @@ pub(crate) trait DataSkippingPredicateEvaluator {
         inverted: bool,
     ) -> Option<Self::Output>;
 
-    /// See [`KernelPredicateEvaluator::finish_eval_variadic`]
-    fn finish_eval_variadic(
+    /// See [`KernelPredicateEvaluator::finish_eval_junction`]
+    fn finish_eval_junction(
         &self,
-        op: VariadicOperator,
+        op: JunctionOperator,
         exprs: impl IntoIterator<Item = Option<Self::Output>>,
         inverted: bool,
     ) -> Option<Self::Output>;
@@ -750,16 +749,16 @@ pub(crate) trait DataSkippingPredicateEvaluator {
                 self.partial_cmp_min_stat(col, val, Ordering::Equal, true),
                 self.partial_cmp_max_stat(col, val, Ordering::Equal, true),
             ];
-            (VariadicOperator::Or, exprs)
+            (JunctionOperator::Or, exprs)
         } else {
             // Column could compare equal if its min/max values bracket the literal.
             let exprs = [
                 self.partial_cmp_min_stat(col, val, Ordering::Greater, true),
                 self.partial_cmp_max_stat(col, val, Ordering::Less, true),
             ];
-            (VariadicOperator::And, exprs)
+            (JunctionOperator::And, exprs)
         };
-        self.finish_eval_variadic(op, exprs, false)
+        self.finish_eval_junction(op, exprs, false)
     }
 }
 
@@ -810,12 +809,12 @@ impl<T: DataSkippingPredicateEvaluator> KernelPredicateEvaluator for T {
         None // Unsupported
     }
 
-    fn finish_eval_variadic(
+    fn finish_eval_junction(
         &self,
-        op: VariadicOperator,
+        op: JunctionOperator,
         exprs: impl IntoIterator<Item = Option<Self::Output>>,
         inverted: bool,
     ) -> Option<Self::Output> {
-        self.finish_eval_variadic(op, exprs, inverted)
+        self.finish_eval_junction(op, exprs, inverted)
     }
 }

--- a/kernel/src/kernel_predicates/parquet_stats_skipping.rs
+++ b/kernel/src/kernel_predicates/parquet_stats_skipping.rs
@@ -1,5 +1,5 @@
 //! An implementation of data skipping that leverages parquet stats from the file footer.
-use crate::expressions::{BinaryOperator, ColumnName, Scalar, VariadicOperator};
+use crate::expressions::{BinaryOperator, ColumnName, JunctionOperator, Scalar};
 use crate::kernel_predicates::{DataSkippingPredicateEvaluator, KernelPredicateEvaluatorDefaults};
 use crate::schema::DataType;
 use std::cmp::Ordering;
@@ -86,12 +86,12 @@ impl<T: ParquetStatsProvider> DataSkippingPredicateEvaluator for T {
         KernelPredicateEvaluatorDefaults::eval_binary_scalars(op, left, right, inverted)
     }
 
-    fn finish_eval_variadic(
+    fn finish_eval_junction(
         &self,
-        op: VariadicOperator,
+        op: JunctionOperator,
         exprs: impl IntoIterator<Item = Option<bool>>,
         inverted: bool,
     ) -> Option<bool> {
-        KernelPredicateEvaluatorDefaults::finish_eval_variadic(op, exprs, inverted)
+        KernelPredicateEvaluatorDefaults::finish_eval_junction(op, exprs, inverted)
     }
 }

--- a/kernel/src/kernel_predicates/parquet_stats_skipping/tests.rs
+++ b/kernel/src/kernel_predicates/parquet_stats_skipping/tests.rs
@@ -40,10 +40,10 @@ impl ParquetStatsProvider for UnimplementedTestFilter {
     }
 }
 
-/// Tests apply_variadic and apply_scalar
+/// Tests apply_junction and apply_scalar
 #[test]
 fn test_junctions() {
-    use VariadicOperator::*;
+    use JunctionOperator::*;
 
     let test_cases = &[
         // Every combo of 0, 1 and 2 inputs
@@ -99,22 +99,22 @@ fn test_junctions() {
             .collect();
 
         expect_eq!(
-            filter.eval_variadic(And, &inputs, false),
+            filter.eval_junction(And, &inputs, false),
             *expect_and,
             "AND({inputs:?})"
         );
         expect_eq!(
-            filter.eval_variadic(Or, &inputs, false),
+            filter.eval_junction(Or, &inputs, false),
             *expect_or,
             "OR({inputs:?})"
         );
         expect_eq!(
-            filter.eval_variadic(And, &inputs, true),
+            filter.eval_junction(And, &inputs, true),
             expect_and.map(|val| !val),
             "NOT(AND({inputs:?}))"
         );
         expect_eq!(
-            filter.eval_variadic(Or, &inputs, true),
+            filter.eval_junction(Or, &inputs, true),
             expect_or.map(|val| !val),
             "NOT(OR({inputs:?}))"
         );

--- a/kernel/src/kernel_predicates/tests.rs
+++ b/kernel/src/kernel_predicates/tests.rs
@@ -287,7 +287,7 @@ fn test_eval_binary_columns() {
 }
 
 #[test]
-fn test_eval_variadic() {
+fn test_eval_junction() {
     let test_cases: Vec<(&[_], _, _)> = vec![
         // input, AND expect, OR expect
         (&[], Some(true), Some(false)),
@@ -320,12 +320,12 @@ fn test_eval_variadic() {
         for inverted in [true, false] {
             let invert_if_needed = |v: &Option<_>| v.map(|v| v != inverted);
             expect_eq!(
-                filter.eval_variadic(VariadicOperator::And, &inputs, inverted),
+                filter.eval_junction(JunctionOperator::And, &inputs, inverted),
                 invert_if_needed(expect_and),
                 "AND({inputs:?}) (inverted: {inverted})"
             );
             expect_eq!(
-                filter.eval_variadic(VariadicOperator::Or, &inputs, inverted),
+                filter.eval_junction(JunctionOperator::Or, &inputs, inverted),
                 invert_if_needed(expect_or),
                 "OR({inputs:?}) (inverted: {inverted})"
             );

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -9,7 +9,7 @@ use crate::actions::visitors::SelectionVectorVisitor;
 use crate::error::DeltaResult;
 use crate::expressions::{
     column_expr, joined_column_expr, BinaryOperator, ColumnName, Expression as Expr, ExpressionRef,
-    Scalar, VariadicOperator,
+    JunctionOperator, Scalar,
 };
 use crate::kernel_predicates::{
     DataSkippingPredicateEvaluator, KernelPredicateEvaluator, KernelPredicateEvaluatorDefaults,
@@ -31,7 +31,7 @@ mod tests;
 ///
 /// Unary `IsNull` checks if the null counts indicate that the column could contain a null.
 ///
-/// The variadic operations are rewritten as follows:
+/// The junction operations are rewritten as follows:
 /// - `AND` is rewritten as a conjunction of the rewritten operands where we just skip operands that
 ///   are not eligible for data skipping.
 /// - `OR` is rewritten only if all operands are eligible for data skipping. Otherwise, the whole OR
@@ -266,9 +266,9 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator {
             .map(Expr::literal)
     }
 
-    fn finish_eval_variadic(
+    fn finish_eval_junction(
         &self,
-        mut op: VariadicOperator,
+        mut op: JunctionOperator,
         exprs: impl IntoIterator<Item = Option<Expr>>,
         inverted: bool,
     ) -> Option<Expr> {
@@ -292,6 +292,6 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator {
                 }),
             })
             .collect();
-        Some(Expr::variadic(op, exprs))
+        Some(Expr::junction(op, exprs))
     }
 }

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -107,7 +107,7 @@ fn test_eval_binary_comparisons() {
 }
 
 #[test]
-fn test_eval_variadic() {
+fn test_eval_junction() {
     let test_cases = &[
         (&[] as &[Option<bool>], TRUE, FALSE),
         (&[TRUE], TRUE, TRUE),


### PR DESCRIPTION
## What changes are proposed in this pull request?

Kernel only has two `VariadicExpression` variants: `AND` and `OR`. They are actually quite special because they hard-wire the assumption of short circuiting evaluation over boolean inputs. Those assumptions are incompatible with basically all future variadic expression types we might add, e.g. `XOR` does not short-circuit and `COALESCE` is not boolean-input. 

To avoid confusion, rename the "variant" operation to "junction" (AND = conjunction, OR = disjunction). 

NOTE: If we ever decide to support any true variadic expressions in the future (`XOR`, `COALESCE`, `SUM`, `MIN`, etc), it would mean (re-)introducing `VariadicOperation`, `VariadicExpression`, and `Expression::Variadic` alongside their `Junction`-related counterparts.

### This PR affects the following public APIs

`VariadicOperation`, `VariadicExpression` , and `Expression::Variadic` are all public.

## How was this change tested?

Renaming operation only. Compilation suffices.