### PR TITLE
refactor!: Tidy up AND/OR/NOT API and usage

### DIFF
--- a/ffi/src/test_ffi.rs
+++ b/ffi/src/test_ffi.rs
@@ -1,10 +1,10 @@
 //! Utility functions used for testing ffi code
 
-use std::{ops::Not, sync::Arc};
+use std::sync::Arc;
 
 use crate::{expressions::SharedExpression, handle::Handle};
 use delta_kernel::{
-    expressions::{column_expr, ArrayData, BinaryOperator, Expression, Scalar, StructData},
+    expressions::{column_expr, ArrayData, BinaryOperator, Expression as Expr, Scalar, StructData},
     schema::{ArrayType, DataType, StructField, StructType},
 };
 
@@ -16,8 +16,6 @@ use delta_kernel::{
 /// [`free_kernel_predicate`], or [`Handle::drop_handle`]
 #[no_mangle]
 pub unsafe extern "C" fn get_testing_kernel_expression() -> Handle<SharedExpression> {
-    use Expression as Expr;
-
     let array_type = ArrayType::new(
         DataType::Primitive(delta_kernel::schema::PrimitiveType::Short),
         false,
@@ -68,7 +66,7 @@ pub unsafe extern "C" fn get_testing_kernel_expression() -> Handle<SharedExpress
             Scalar::Integer(5).into(),
             Scalar::Long(20).into(),
         ])]),
-        Expr::not(Expr::is_null(column_expr!("col"))),
+        Expr::is_not_null(column_expr!("col")),
     ];
     sub_exprs.extend(
         [
@@ -86,8 +84,8 @@ pub unsafe extern "C" fn get_testing_kernel_expression() -> Handle<SharedExpress
             BinaryOperator::GreaterThanOrEqual,
             BinaryOperator::Distinct,
         ]
-        .iter()
-        .map(|op| Expr::binary(*op, Scalar::Integer(0), Scalar::Long(0))),
+        .into_iter()
+        .map(|op| Expr::binary(op, Scalar::Integer(0), Scalar::Long(0))),
     );
 
     Arc::new(Expr::and_from(sub_exprs)).into()

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -274,25 +274,25 @@ fn test_logical() {
     let column_a = column_expr!("a");
     let column_b = column_expr!("b");
 
-    let expression = column_a.clone().and(column_b.clone());
+    let expression = Expression::and(column_a.clone(), column_b.clone());
     let results =
         evaluate_expression(&expression, &batch, Some(&crate::schema::DataType::BOOLEAN)).unwrap();
     let expected = Arc::new(BooleanArray::from(vec![false, false]));
     assert_eq!(results.as_ref(), expected.as_ref());
 
-    let expression = column_a.clone().and(true);
+    let expression = Expression::and(column_a.clone(), true);
     let results =
         evaluate_expression(&expression, &batch, Some(&crate::schema::DataType::BOOLEAN)).unwrap();
     let expected = Arc::new(BooleanArray::from(vec![true, false]));
     assert_eq!(results.as_ref(), expected.as_ref());
 
-    let expression = column_a.clone().or(column_b);
+    let expression = Expression::or(column_a.clone(), column_b);
     let results =
         evaluate_expression(&expression, &batch, Some(&crate::schema::DataType::BOOLEAN)).unwrap();
     let expected = Arc::new(BooleanArray::from(vec![true, true]));
     assert_eq!(results.as_ref(), expected.as_ref());
 
-    let expression = column_a.clone().or(false);
+    let expression = Expression::or(column_a.clone(), false);
     let results =
         evaluate_expression(&expression, &batch, Some(&crate::schema::DataType::BOOLEAN)).unwrap();
     let expected = Arc::new(BooleanArray::from(vec![true, false]));

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -301,6 +301,11 @@ impl Expression {
         Self::variadic(VariadicOperator::Or, exprs)
     }
 
+    /// Logical NOT (boolean inversion)
+    pub fn not(expr: impl Into<Self>) -> Self {
+        Self::unary(UnaryOperator::Not, expr.into())
+    }
+
     /// Create a new expression `self IS NULL`
     pub fn is_null(self) -> Self {
         Self::unary(UnaryOperator::IsNull, self)
@@ -308,7 +313,7 @@ impl Expression {
 
     /// Create a new expression `self IS NOT NULL`
     pub fn is_not_null(self) -> Self {
-        !Self::is_null(self)
+        Self::not(Self::is_null(self))
     }
 
     /// Create a new expression `self == other`
@@ -352,13 +357,13 @@ impl Expression {
     }
 
     /// Create a new expression `self AND other`
-    pub fn and(self, other: impl Into<Self>) -> Self {
-        Self::and_from([self, other.into()])
+    pub fn and(a: impl Into<Self>, b: impl Into<Self>) -> Self {
+        Self::and_from([a.into(), b.into()])
     }
 
     /// Create a new expression `self OR other`
-    pub fn or(self, other: impl Into<Self>) -> Self {
-        Self::or_from([self, other.into()])
+    pub fn or(a: impl Into<Self>, b: impl Into<Self>) -> Self {
+        Self::or_from([a.into(), b.into()])
     }
 
     /// Create a new expression `DISTINCT(self, other)`
@@ -540,11 +545,12 @@ pub trait ExpressionTransform<'a> {
     }
 }
 
+#[cfg(test)]
 impl std::ops::Not for Expression {
     type Output = Self;
 
     fn not(self) -> Self {
-        Self::unary(UnaryOperator::Not, self)
+        Self::not(self)
     }
 }
 
@@ -682,7 +688,6 @@ impl<'a> ExpressionTransform<'a> for ExpressionDepthChecker {
 #[cfg(test)]
 mod tests {
     use super::{column_expr, Expression as Expr, ExpressionDepthChecker};
-    use std::ops::Not;
 
     #[test]
     fn test_expression_format() {
@@ -693,7 +698,7 @@ mod tests {
             ((col_ref.clone() - 4).lt(10), "Column(x) - 4 < 10"),
             ((col_ref.clone() + 4) / 10 * 42, "Column(x) + 4 / 10 * 42"),
             (
-                col_ref.clone().gt_eq(2).and(col_ref.clone().lt_eq(10)),
+                Expr::and(col_ref.clone().gt_eq(2), col_ref.clone().lt_eq(10)),
                 "AND(Column(x) >= 2, Column(x) <= 10)",
             ),
             (
@@ -705,7 +710,7 @@ mod tests {
                 "AND(Column(x) >= 2, Column(x) <= 10, Column(x) <= 100)",
             ),
             (
-                col_ref.clone().gt(2).or(col_ref.clone().lt(10)),
+                Expr::or(col_ref.clone().gt(2), col_ref.clone().lt(10)),
                 "OR(Column(x) > 2, Column(x) < 10)",
             ),
             (col_ref.eq("foo"), "Column(x) = 'foo'"),

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -545,15 +545,6 @@ pub trait ExpressionTransform<'a> {
     }
 }
 
-#[cfg(test)]
-impl std::ops::Not for Expression {
-    type Output = Self;
-
-    fn not(self) -> Self {
-        Self::not(self)
-    }
-}
-
 impl<R: Into<Expression>> std::ops::Add<R> for Expression {
     type Output = Self;
 

--- a/kernel/src/kernel_predicates/mod.rs
+++ b/kernel/src/kernel_predicates/mod.rs
@@ -118,10 +118,15 @@ pub(crate) trait KernelPredicateEvaluator {
         self.eval_eq(col, &Scalar::from(inverted), true)
     }
 
+    /// Dispatches a (possibly inverted) NOT expression
+    fn eval_not(&self, expr: &Expr, inverted: bool) -> Option<Self::Output> {
+        self.eval_expr(expr, !inverted)
+    }
+
     /// Dispatches a (possibly inverted) unary expression to each operator's specific implementation.
     fn eval_unary(&self, op: UnaryOperator, expr: &Expr, inverted: bool) -> Option<Self::Output> {
         match op {
-            UnaryOperator::Not => self.eval_expr(expr, !inverted),
+            UnaryOperator::Not => self.eval_not(expr, inverted),
             UnaryOperator::IsNull => match expr {
                 // WARNING: Only literals and columns can be safely null-checked. Attempting to
                 // null-check an expressions such as `a < 10` could wrongly produce FALSE in case

--- a/kernel/src/kernel_predicates/parquet_stats_skipping/tests.rs
+++ b/kernel/src/kernel_predicates/parquet_stats_skipping/tests.rs
@@ -230,7 +230,7 @@ impl ParquetStatsProvider for NullCountTestFilter {
 fn test_eval_is_null() {
     let expressions = [
         Expr::is_null(column_expr!("x")),
-        !Expr::is_null(column_expr!("x")),
+        Expr::is_not_null(column_expr!("x")),
     ];
 
     let do_test = |nullcount: i64, expected: &[Option<bool>]| {

--- a/kernel/src/kernel_predicates/tests.rs
+++ b/kernel/src/kernel_predicates/tests.rs
@@ -599,7 +599,7 @@ fn test_sql_where() {
     expect_eq!(null_filter.eval_sql_where(expr), Some(true), "{expr}");
 
     // NOT a gets skipped when NULL but not when missing
-    let expr = &!col.clone();
+    let expr = &Expr::not(col.clone());
     expect_eq!(null_filter.eval_sql_where(expr), Some(false), "{expr}");
     expect_eq!(empty_filter.eval_sql_where(expr), None, "{expr}");
 

--- a/kernel/src/kernel_predicates/tests.rs
+++ b/kernel/src/kernel_predicates/tests.rs
@@ -1,7 +1,5 @@
 use super::*;
-use crate::expressions::{
-    column_expr, column_name, ArrayData, Expression, StructData, UnaryOperator,
-};
+use crate::expressions::{column_expr, column_name, ArrayData, Expression, StructData};
 use crate::schema::ArrayType;
 use crate::DataType;
 
@@ -367,7 +365,7 @@ fn test_eval_not() {
         let input = input.into();
         for inverted in [true, false] {
             expect_eq!(
-                filter.eval_unary(UnaryOperator::Not, &input, inverted),
+                filter.eval_not(&input, inverted),
                 expect.map(|v| v != inverted),
                 "NOT({input:?}) (inverted: {inverted})"
             );
@@ -377,27 +375,28 @@ fn test_eval_not() {
 
 #[test]
 fn test_eval_is_null() {
+    use crate::expressions::UnaryOperator::IsNull;
     let expr = column_expr!("x");
     let filter = DefaultKernelPredicateEvaluator::from(Scalar::from(1));
     expect_eq!(
-        filter.eval_unary(UnaryOperator::IsNull, &expr, true),
+        filter.eval_unary(IsNull, &expr, true),
         Some(true),
         "x IS NOT NULL"
     );
     expect_eq!(
-        filter.eval_unary(UnaryOperator::IsNull, &expr, false),
+        filter.eval_unary(IsNull, &expr, false),
         Some(false),
         "x IS NULL"
     );
 
     let expr = Expression::literal(1);
     expect_eq!(
-        filter.eval_unary(UnaryOperator::IsNull, &expr, true),
+        filter.eval_unary(IsNull, &expr, true),
         Some(true),
         "1 IS NOT NULL"
     );
     expect_eq!(
-        filter.eval_unary(UnaryOperator::IsNull, &expr, false),
+        filter.eval_unary(IsNull, &expr, false),
         Some(false),
         "1 IS NULL"
     );

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -25,7 +25,7 @@ macro_rules! expect_eq {
 #[test]
 fn test_eval_is_null() {
     let col = &column_expr!("x");
-    let expressions = [Expr::is_null(col.clone()), !Expr::is_null(col.clone())];
+    let expressions = [Expr::is_null(col.clone()), Expr::is_not_null(col.clone())];
 
     let do_test = |nullcount: i64, expected: &[Option<bool>]| {
         let resolver = HashMap::from_iter([

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -171,7 +171,7 @@ fn test_eval_variadic() {
         let pred = as_data_skipping_predicate(&expr).unwrap();
         expect_eq!(filter.eval_expr(&pred, false), *expect_or, "OR({inputs:?})");
 
-        let expr = !Expr::and_from(inputs.clone());
+        let expr = Expr::not(Expr::and_from(inputs.clone()));
         let pred = as_data_skipping_predicate(&expr).unwrap();
         expect_eq!(
             filter.eval_expr(&pred, false),
@@ -179,7 +179,7 @@ fn test_eval_variadic() {
             "NOT AND({inputs:?})"
         );
 
-        let expr = !Expr::or_from(inputs.clone());
+        let expr = Expr::not(Expr::or_from(inputs.clone()));
         let pred = as_data_skipping_predicate(&expr).unwrap();
         expect_eq!(
             filter.eval_expr(&pred, false),
@@ -202,9 +202,9 @@ fn test_eval_distinct() {
 
     let expressions = [
         Expr::distinct(col.clone(), ten.clone()),
-        !Expr::distinct(col.clone(), ten.clone()),
+        Expr::not(Expr::distinct(col.clone(), ten.clone())),
         Expr::distinct(col.clone(), null.clone()),
-        !Expr::distinct(col.clone(), null.clone()),
+        Expr::not(Expr::distinct(col.clone(), null.clone())),
     ];
 
     let do_test = |min: &Scalar, max: &Scalar, nullcount: i64, expected: &[Option<bool>]| {

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::ops::Not;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -861,27 +860,31 @@ fn mixed_not_null() -> Result<(), Box<dyn std::error::Error>> {
 fn and_or_predicates() -> Result<(), Box<dyn std::error::Error>> {
     let cases = vec![
         (
-            column_expr!("number")
-                .gt(4i64)
-                .and(column_expr!("a_float").gt(5.5)),
+            Expression::and(
+                column_expr!("number").gt(4i64),
+                column_expr!("a_float").gt(5.5),
+            ),
             table_for_numbers(vec![6]),
         ),
         (
-            column_expr!("number")
-                .gt(4i64)
-                .and(Expression::not(column_expr!("a_float").gt(5.5))),
+            Expression::and(
+                column_expr!("number").gt(4i64),
+                Expression::not(column_expr!("a_float").gt(5.5)),
+            ),
             table_for_numbers(vec![5]),
         ),
         (
-            column_expr!("number")
-                .gt(4i64)
-                .or(column_expr!("a_float").gt(5.5)),
+            Expression::or(
+                column_expr!("number").gt(4i64),
+                column_expr!("a_float").gt(5.5),
+            ),
             table_for_numbers(vec![5, 6]),
         ),
         (
-            column_expr!("number")
-                .gt(4i64)
-                .or(Expression::not(column_expr!("a_float").gt(5.5))),
+            Expression::or(
+                column_expr!("number").gt(4i64),
+                Expression::not(column_expr!("a_float").gt(5.5)),
+            ),
             table_for_numbers(vec![1, 2, 3, 4, 5, 6]),
         ),
     ];
@@ -900,35 +903,31 @@ fn and_or_predicates() -> Result<(), Box<dyn std::error::Error>> {
 fn not_and_or_predicates() -> Result<(), Box<dyn std::error::Error>> {
     let cases = vec![
         (
-            Expression::not(
-                column_expr!("number")
-                    .gt(4i64)
-                    .and(column_expr!("a_float").gt(5.5)),
-            ),
+            Expression::not(Expression::and(
+                column_expr!("number").gt(4i64),
+                column_expr!("a_float").gt(5.5),
+            )),
             table_for_numbers(vec![1, 2, 3, 4, 5]),
         ),
         (
-            Expression::not(
-                column_expr!("number")
-                    .gt(4i64)
-                    .and(Expression::not(column_expr!("a_float").gt(5.5))),
-            ),
+            Expression::not(Expression::and(
+                column_expr!("number").gt(4i64),
+                Expression::not(column_expr!("a_float").gt(5.5)),
+            )),
             table_for_numbers(vec![1, 2, 3, 4, 6]),
         ),
         (
-            Expression::not(
-                column_expr!("number")
-                    .gt(4i64)
-                    .or(column_expr!("a_float").gt(5.5)),
-            ),
+            Expression::not(Expression::or(
+                column_expr!("number").gt(4i64),
+                column_expr!("a_float").gt(5.5),
+            )),
             table_for_numbers(vec![1, 2, 3, 4]),
         ),
         (
-            Expression::not(
-                column_expr!("number")
-                    .gt(4i64)
-                    .or(Expression::not(column_expr!("a_float").gt(5.5))),
-            ),
+            Expression::not(Expression::or(
+                column_expr!("number").gt(4i64),
+                Expression::not(column_expr!("a_float").gt(5.5)),
+            )),
             vec![],
         ),
     ];


### PR DESCRIPTION
## What changes are proposed in this pull request?

Get rid of `impl Not for Expression` because it's hard to use directly (have to import `std::ops::Not`) and is also forced to take `self` instead of `impl Into<Expression>` as an argument (which we use way more often than `!`). Further, NOT is the only logical operator we could meaningfully overload in rust. AND/OR cannot be overloaded at all, and comparisons (via `PartialEq` and `PartialOrd`) have hard-wired return types that don't work for expressions.

Meanwhile `Expression::and` and `Expression::or` are hard to read as infix operators:
```rust
(a.lt(10).and(b.gt(20)).or(c.eq(42).and(d.le(100)))
```
so make them associated methods taking `impl Into<Expression>` instead of taking `self`:
```rust
Expr::or(
    Expr::and(a.lt(10), b.gt(20)),
    Expr::and(c.eq(42), d.le(100)),
)
```

### This PR affects the following public APIs

Public interfaces and methods.

## How was this change tested?

Renaming refactor. Compilation suffices.