### PR TITLE
refactor: Grab bag of cosmetic tweaks and comment updates

### DIFF
--- a/ffi/src/expressions/engine.rs
+++ b/ffi/src/expressions/engine.rs
@@ -13,15 +13,7 @@ use delta_kernel::{
 
 #[derive(Default)]
 pub struct KernelExpressionVisitorState {
-    // TODO: ReferenceSet<Box<dyn MetadataFilterFn>> instead?
-    inflight_expressions: ReferenceSet<Expression>,
-}
-impl KernelExpressionVisitorState {
-    pub fn new() -> Self {
-        Self {
-            inflight_expressions: Default::default(),
-        }
-    }
+    inflight_ids: ReferenceSet<Expression>,
 }
 
 /// A predicate that can be used to skip data when scanning.
@@ -44,14 +36,14 @@ pub struct EnginePredicate {
 }
 
 fn wrap_expression(state: &mut KernelExpressionVisitorState, expr: impl Into<Expression>) -> usize {
-    state.inflight_expressions.insert(expr.into())
+    state.inflight_ids.insert(expr.into())
 }
 
 pub(crate) fn unwrap_kernel_expression(
     state: &mut KernelExpressionVisitorState,
     exprid: usize,
 ) -> Option<Expression> {
-    state.inflight_expressions.take(exprid)
+    state.inflight_ids.take(exprid)
 }
 
 fn visit_expression_binary(

--- a/ffi/src/expressions/kernel.rs
+++ b/ffi/src/expressions/kernel.rs
@@ -20,8 +20,7 @@ pub unsafe extern "C" fn free_kernel_predicate(data: Handle<SharedExpression>) {
 
 type VisitLiteralFn<T> = extern "C" fn(data: *mut c_void, sibling_list_id: usize, value: T);
 type VisitUnaryFn = extern "C" fn(data: *mut c_void, sibling_list_id: usize, child_list_id: usize);
-type VisitBinaryOpFn =
-    extern "C" fn(data: *mut c_void, sibling_list_id: usize, child_list_id: usize);
+type VisitBinaryFn = extern "C" fn(data: *mut c_void, sibling_list_id: usize, child_list_id: usize);
 type VisitJunctionFn =
     extern "C" fn(data: *mut c_void, sibling_list_id: usize, child_list_id: usize);
 
@@ -130,43 +129,43 @@ pub struct EngineExpressionVisitor {
     pub visit_is_null: VisitUnaryFn,
     /// Visits the `LessThan` binary operator belonging to the list identified by `sibling_list_id`.
     /// The operands will be in a _two_ item list identified by `child_list_id`
-    pub visit_lt: VisitBinaryOpFn,
+    pub visit_lt: VisitBinaryFn,
     /// Visits the `LessThanOrEqual` binary operator belonging to the list identified by `sibling_list_id`.
     /// The operands will be in a _two_ item list identified by `child_list_id`
-    pub visit_le: VisitBinaryOpFn,
+    pub visit_le: VisitBinaryFn,
     /// Visits the `GreaterThan` binary operator belonging to the list identified by `sibling_list_id`.
     /// The operands will be in a _two_ item list identified by `child_list_id`
-    pub visit_gt: VisitBinaryOpFn,
+    pub visit_gt: VisitBinaryFn,
     /// Visits the `GreaterThanOrEqual` binary operator belonging to the list identified by `sibling_list_id`.
     /// The operands will be in a _two_ item list identified by `child_list_id`
-    pub visit_ge: VisitBinaryOpFn,
+    pub visit_ge: VisitBinaryFn,
     /// Visits the `Equal` binary operator belonging to the list identified by `sibling_list_id`.
     /// The operands will be in a _two_ item list identified by `child_list_id`
-    pub visit_eq: VisitBinaryOpFn,
+    pub visit_eq: VisitBinaryFn,
     /// Visits the `NotEqual` binary operator belonging to the list identified by `sibling_list_id`.
     /// The operands will be in a _two_ item list identified by `child_list_id`
-    pub visit_ne: VisitBinaryOpFn,
+    pub visit_ne: VisitBinaryFn,
     /// Visits the `Distinct` binary operator belonging to the list identified by `sibling_list_id`.
     /// The operands will be in a _two_ item list identified by `child_list_id`
-    pub visit_distinct: VisitBinaryOpFn,
+    pub visit_distinct: VisitBinaryFn,
     /// Visits the `In` binary operator belonging to the list identified by `sibling_list_id`.
     /// The operands will be in a _two_ item list identified by `child_list_id`
-    pub visit_in: VisitBinaryOpFn,
+    pub visit_in: VisitBinaryFn,
     /// Visits the `NotIn` binary operator belonging to the list identified by `sibling_list_id`.
     /// The operands will be in a _two_ item list identified by `child_list_id`
-    pub visit_not_in: VisitBinaryOpFn,
+    pub visit_not_in: VisitBinaryFn,
     /// Visits the `Add` binary operator belonging to the list identified by `sibling_list_id`.
     /// The operands will be in a _two_ item list identified by `child_list_id`
-    pub visit_add: VisitBinaryOpFn,
+    pub visit_add: VisitBinaryFn,
     /// Visits the `Minus` binary operator belonging to the list identified by `sibling_list_id`.
     /// The operands will be in a _two_ item list identified by `child_list_id`
-    pub visit_minus: VisitBinaryOpFn,
+    pub visit_minus: VisitBinaryFn,
     /// Visits the `Multiply` binary operator belonging to the list identified by `sibling_list_id`.
     /// The operands will be in a _two_ item list identified by `child_list_id`
-    pub visit_multiply: VisitBinaryOpFn,
+    pub visit_multiply: VisitBinaryFn,
     /// Visits the `Divide` binary operator belonging to the list identified by `sibling_list_id`.
     /// The operands will be in a _two_ item list identified by `child_list_id`
-    pub visit_divide: VisitBinaryOpFn,
+    pub visit_divide: VisitBinaryFn,
     /// Visits the `column` belonging to the list identified by `sibling_list_id`.
     pub visit_column:
         extern "C" fn(data: *mut c_void, sibling_list_id: usize, name: KernelStringSlice),
@@ -255,7 +254,7 @@ fn visit_expression_struct_literal(
     )
 }
 
-fn visit_expression_struct_expr(
+fn visit_expression_struct(
     visitor: &mut EngineExpressionVisitor,
     exprs: &[Expression],
     sibling_list_id: usize,
@@ -347,9 +346,9 @@ fn visit_expression_impl(
         Expression::Column(name) => {
             let name = name.to_string();
             let name = kernel_string_slice!(name);
-            call!(visitor, visit_column, sibling_list_id, name)
+            call!(visitor, visit_column, sibling_list_id, name);
         }
-        Expression::Struct(exprs) => visit_expression_struct_expr(visitor, exprs, sibling_list_id),
+        Expression::Struct(exprs) => visit_expression_struct(visitor, exprs, sibling_list_id),
         Expression::Binary(BinaryExpression { op, left, right }) => {
             let child_list_id = call!(visitor, make_field_list, 2);
             visit_expression_impl(visitor, left, child_list_id);

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -732,10 +732,8 @@ impl<T> ReferenceSet<T> {
         Default::default()
     }
 
-    // Inserts a new value into the set. This always creates a new entry
-    // because the new value cannot have the same address as any existing value.
-    // Returns a raw pointer to the value. This pointer serves as a key that
-    // can be used later to take() from the set, and should NOT be dereferenced.
+    // Inserts a new value into the set, returning an identifier for the value that can be used
+    // later to take() from the set.
     pub fn insert(&mut self, value: T) -> usize {
         let id = self.next_id;
         self.next_id += 1;

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -49,8 +49,8 @@ pub(crate) type NullableCvoid = Option<NonNull<c_void>>;
 /// the engine functions. The engine retains ownership of the iterator.
 #[repr(C)]
 pub struct EngineIterator {
-    // Opaque data that will be iterated over. This data will be passed to the get_next function
-    // each time a next item is requested from the iterator
+    /// Opaque data that will be iterated over. This data will be passed to the get_next function
+    /// each time a next item is requested from the iterator
     data: NonNull<c_void>,
     /// A function that should advance the iterator and return the next time from the data
     /// If the iterator is complete, it should return null. It should be safe to
@@ -721,19 +721,20 @@ pub unsafe extern "C" fn free_string_slice_data(data: Handle<StringSliceIterator
     data.drop_handle();
 }
 
-// A set that can identify its contents by address
+/// A set that can identify its contents by address
 pub struct ReferenceSet<T> {
     map: std::collections::HashMap<usize, T>,
     next_id: usize,
 }
 
 impl<T> ReferenceSet<T> {
+    /// Creates a new empty set.
     pub fn new() -> Self {
         Default::default()
     }
 
-    // Inserts a new value into the set, returning an identifier for the value that can be used
-    // later to take() from the set.
+    /// Inserts a new value into the set, returning an identifier for the value that can be used
+    /// later to take() from the set.
     pub fn insert(&mut self, value: T) -> usize {
         let id = self.next_id;
         self.next_id += 1;
@@ -741,17 +742,17 @@ impl<T> ReferenceSet<T> {
         id
     }
 
-    // Attempts to remove a value from the set, if present.
+    /// Attempts to remove a value from the set, if present.
     pub fn take(&mut self, i: usize) -> Option<T> {
         self.map.remove(&i)
     }
 
-    // True if the set contains an object whose address matches the pointer.
+    /// True if the set contains an object whose address matches the pointer.
     pub fn contains(&self, id: usize) -> bool {
         self.map.contains_key(&id)
     }
 
-    // The current size of the set.
+    /// The current size of the set.
     pub fn len(&self) -> usize {
         self.map.len()
     }

--- a/ffi/src/scan.rs
+++ b/ffi/src/scan.rs
@@ -92,9 +92,9 @@ fn scan_impl(
 ) -> DeltaResult<Handle<SharedScan>> {
     let mut scan_builder = snapshot.scan_builder();
     if let Some(predicate) = predicate {
-        let mut visitor_state = KernelExpressionVisitorState::new();
-        let exprid = (predicate.visitor)(predicate.predicate, &mut visitor_state);
-        let predicate = unwrap_kernel_expression(&mut visitor_state, exprid);
+        let mut visitor_state = KernelExpressionVisitorState::default();
+        let predid = (predicate.visitor)(predicate.predicate, &mut visitor_state);
+        let predicate = unwrap_kernel_expression(&mut visitor_state, predid);
         debug!("Got predicate: {:#?}", predicate);
         scan_builder = scan_builder.with_predicate(predicate.map(Arc::new));
     }

--- a/ffi/src/scan.rs
+++ b/ffi/src/scan.rs
@@ -93,8 +93,8 @@ fn scan_impl(
     let mut scan_builder = snapshot.scan_builder();
     if let Some(predicate) = predicate {
         let mut visitor_state = KernelExpressionVisitorState::default();
-        let predid = (predicate.visitor)(predicate.predicate, &mut visitor_state);
-        let predicate = unwrap_kernel_expression(&mut visitor_state, predid);
+        let pred_id = (predicate.visitor)(predicate.predicate, &mut visitor_state);
+        let predicate = unwrap_kernel_expression(&mut visitor_state, pred_id);
         debug!("Got predicate: {:#?}", predicate);
         scan_builder = scan_builder.with_predicate(predicate.map(Arc::new));
     }

--- a/kernel/src/engine/arrow_data.rs
+++ b/kernel/src/engine/arrow_data.rs
@@ -294,15 +294,12 @@ impl ArrowEngineData {
 
 #[cfg(test)]
 mod tests {
+    use crate::actions::{get_log_schema, Metadata, Protocol};
     use crate::arrow::array::StringArray;
-
+    use crate::engine::sync::SyncEngine;
     use crate::table_features::{ReaderFeature, WriterFeature};
     use crate::utils::test_utils::string_array_to_engine_data;
-    use crate::{
-        actions::{get_log_schema, Metadata, Protocol},
-        engine::sync::SyncEngine,
-        DeltaResult, Engine,
-    };
+    use crate::{DeltaResult, Engine as _};
 
     #[test]
     fn test_md_extract() -> DeltaResult<()> {

--- a/kernel/src/engine/default/filesystem.rs
+++ b/kernel/src/engine/default/filesystem.rs
@@ -183,7 +183,7 @@ mod tests {
 
     use crate::engine::default::executor::tokio::TokioBackgroundExecutor;
     use crate::engine::default::DefaultEngine;
-    use crate::Engine;
+    use crate::Engine as _;
 
     use itertools::Itertools;
 

--- a/kernel/src/kernel_predicates/mod.rs
+++ b/kernel/src/kernel_predicates/mod.rs
@@ -12,9 +12,9 @@ pub(crate) mod parquet_stats_skipping;
 #[cfg(test)]
 mod tests;
 
-/// Evaluates a predicate expression tree against column names that resolve as scalars. Useful for
-/// testing/debugging but also serves as a reference implementation that documents the expression
-/// semantics that kernel relies on for data skipping.
+/// Uses kernel (not engine) logic to evaluate an expression tree against column names that resolve
+/// as scalars. Useful for testing/debugging but also serves as a reference implementation that
+/// documents the expression semantics that kernel relies on for data skipping.
 ///
 /// # Inverted expression semantics
 ///

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -25,7 +25,7 @@ use crate::scan::test_utils::{
 use crate::snapshot::LastCheckpointHint;
 use crate::utils::test_utils::{assert_batch_matches, Action};
 use crate::{
-    DeltaResult, Engine, EngineData, Expression, ExpressionRef, FileMeta, RowVisitor,
+    DeltaResult, Engine as _, EngineData, Expression, ExpressionRef, FileMeta, RowVisitor,
     StorageHandler, Table,
 };
 use test_utils::delta_path_for_version;

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -41,8 +41,8 @@ fn as_data_skipping_predicate(expr: &Expr) -> Option<Expr> {
     DataSkippingPredicateCreator.eval(expr)
 }
 
-/// Like `as_data_skipping_predicate`, but invokes [`PredicateEvaluator::eval_sql_where`] instead
-/// of [`PredicateEvaluator::eval_expr`].
+/// Like `as_data_skipping_predicate`, but invokes [`KernelPredicateEvaluator::eval_sql_where`]
+/// instead of [`KernelPredicateEvaluator::eval`].
 fn as_sql_data_skipping_predicate(expr: &Expr) -> Option<Expr> {
     DataSkippingPredicateCreator.eval_sql_where(expr)
 }

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -182,11 +182,11 @@ impl PhysicalPredicate {
 
 // Evaluates a static data skipping predicate, ignoring any column references, and returns true if
 // the predicate allows to statically skip all files. Since this is direct evaluation (not an
-// expression rewrite), we use a `DefaultPredicateEvaluator` with an empty column resolver.
+// expression rewrite), we use a `DefaultKernelPredicateEvaluator` with an empty column resolver.
 fn can_statically_skip_all_files(predicate: &Expression) -> bool {
     use crate::kernel_predicates::KernelPredicateEvaluator as _;
-    DefaultKernelPredicateEvaluator::from(EmptyColumnResolver).eval_sql_where(predicate)
-        == Some(false)
+    let evaluator = DefaultKernelPredicateEvaluator::from(EmptyColumnResolver);
+    evaluator.eval_sql_where(predicate) == Some(false)
 }
 
 // Build the stats read schema filtering the table schema to keep only skipping-eligible

--- a/kernel/src/table_changes/scan_file.rs
+++ b/kernel/src/table_changes/scan_file.rs
@@ -251,7 +251,7 @@ mod tests {
     use crate::schema::{DataType, StructField, StructType};
     use crate::table_changes::log_replay::table_changes_action_iter;
     use crate::utils::test_utils::{Action, LocalMockTable};
-    use crate::Engine;
+    use crate::Engine as _;
 
     #[tokio::test]
     async fn test_scan_file_visiting() {


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR applies various cosmetic improvements that I noticed while working on other changes, but did not want to merge for hygiene reasons. Instead, I collected them together into a single hygiene-only PR.

### This PR affects the following public APIs

Removing `KernelExpressionVisitorState::new` in favor of the already-existing `KernelExpressionVisitorState::default`.

## How was this change tested?

Refactoring and comments. Compilation suffices.