### PR TITLE
feat: overwrite logic in `write_json_file` for default & sync engine 

### DIFF
--- a/kernel/src/engine/default/json.rs
+++ b/kernel/src/engine/default/json.rs
@@ -757,7 +757,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_write_json_file_non_overwrite() -> DeltaResult<()> {
+    async fn test_write_json_file_without_overwrite() -> DeltaResult<()> {
         let store = Arc::new(InMemory::new());
         let executor = Arc::new(TokioBackgroundExecutor::new());
         let handler = DefaultJsonHandler::new(store.clone(), executor);

--- a/kernel/src/engine/default/json.rs
+++ b/kernel/src/engine/default/json.rs
@@ -761,12 +761,11 @@ mod tests {
         let store = Arc::new(InMemory::new());
         let executor = Arc::new(TokioBackgroundExecutor::new());
         let handler = DefaultJsonHandler::new(store.clone(), executor);
-        let path = Url::parse("memory:///test/data/00000000000000000001.json").unwrap();
+        let path = Url::parse("memory:///test/data/00000000000000000001.json")?;
         let object_path = Path::from("/test/data/00000000000000000001.json");
 
-        let data = create_test_data(vec!["remi", "wilson"])?;
-
         // First write with overwrite=false & no existing file
+        let data = create_test_data(vec!["remi", "wilson"])?;
         let result = handler.write_json_file(&path, Box::new(std::iter::once(Ok(data))), false);
 
         // Verify the first write is successful
@@ -774,9 +773,8 @@ mod tests {
         let json = read_json_file(&store, &object_path).await?;
         assert_eq!(json, vec![json!({"dog": "remi"}), json!({"dog": "wilson"})]);
 
-        let data = create_test_data(vec!["check", "error"])?;
-
         // Second write with overwrite=false & existing file
+        let data = create_test_data(vec!["check", "error"])?;
         let result = handler.write_json_file(&path, Box::new(std::iter::once(Ok(data))), false);
 
         // Verify the second write fails with FileAlreadyExists error
@@ -795,26 +793,23 @@ mod tests {
         let store = Arc::new(InMemory::new());
         let executor = Arc::new(TokioBackgroundExecutor::new());
         let handler = DefaultJsonHandler::new(store.clone(), executor);
-        let path = Url::parse("memory:///test/data/00000000000000000001.json").unwrap();
+        let path = Url::parse("memory:///test/data/00000000000000000001.json")?;
         let object_path = Path::from("/test/data/00000000000000000001.json");
 
-        let first_batch = create_test_data(vec!["remi", "wilson"])?;
-
         // First write with overwrite=true & no existing file
-        let result =
-            handler.write_json_file(&path, Box::new(std::iter::once(Ok(first_batch))), true);
-        assert!(result.is_ok());
+        let data = create_test_data(vec!["remi", "wilson"])?;
+        let result = handler.write_json_file(&path, Box::new(std::iter::once(Ok(data))), true);
 
         // Verify the first write is successful
+        assert!(result.is_ok());
         let json = read_json_file(&store, &object_path).await?;
         assert_eq!(json, vec![json!({"dog": "remi"}), json!({"dog": "wilson"})]);
 
         // Second write with overwrite=true & existing file
-        let second_batch = create_test_data(vec!["seb", "tia"])?;
+        let data = create_test_data(vec!["seb", "tia"])?;
+        let result = handler.write_json_file(&path, Box::new(std::iter::once(Ok(data))), true);
 
         // Verify the second write is successful
-        let result =
-            handler.write_json_file(&path, Box::new(std::iter::once(Ok(second_batch))), true);
         assert!(result.is_ok());
         let json = read_json_file(&store, &object_path).await?;
         assert_eq!(json, vec![json!({"dog": "seb"}), json!({"dog": "tia"})]);

--- a/kernel/src/engine/default/json.rs
+++ b/kernel/src/engine/default/json.rs
@@ -12,7 +12,7 @@ use bytes::{Buf, Bytes};
 use futures::stream::{self, BoxStream};
 use futures::{ready, StreamExt, TryStreamExt};
 use object_store::path::Path;
-use object_store::{DynObjectStore, GetResultPayload};
+use object_store::{DynObjectStore, GetResultPayload, PutMode};
 use tracing::warn;
 use url::Url;
 
@@ -137,19 +137,20 @@ impl<E: TaskExecutor> JsonHandler for DefaultJsonHandler<E> {
         &self,
         path: &Url,
         data: Box<dyn Iterator<Item = DeltaResult<Box<dyn EngineData>>> + Send + '_>,
-        _overwrite: bool,
+        overwrite: bool,
     ) -> DeltaResult<()> {
         let buffer = to_json_bytes(data)?;
-        // Put if absent
+        let put_mode = if overwrite {
+            PutMode::Overwrite
+        } else {
+            PutMode::Create
+        };
+
         let store = self.store.clone(); // cheap Arc
         let path = Path::from_url_path(path.path())?;
         let path_str = path.to_string();
         self.task_executor
-            .block_on(async move {
-                store
-                    .put_opts(&path, buffer.into(), object_store::PutMode::Create.into())
-                    .await
-            })
+            .block_on(async move { store.put_opts(&path, buffer.into(), put_mode.into()).await })
             .map_err(|e| match e {
                 object_store::Error::AlreadyExists { .. } => Error::FileAlreadyExists(path_str),
                 e => e.into(),
@@ -266,6 +267,7 @@ mod tests {
         GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
         PutMultipartOpts, PutOptions, PutPayload, PutResult, Result,
     };
+    use serde_json::json;
 
     // TODO: should just use the one from test_utils, but running into dependency issues
     fn into_record_batch(engine_data: Box<dyn EngineData>) -> RecordBatch {
@@ -721,5 +723,102 @@ mod tests {
                 .collect();
             assert_eq!(all_values, (0..1000).collect_vec());
         }
+    }
+
+    // Helper function to create test data
+    fn create_test_data(values: Vec<&str>) -> DeltaResult<Box<dyn EngineData>> {
+        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+            "dog",
+            DataType::Utf8,
+            true,
+        )]));
+        let batch =
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(StringArray::from(values))])?;
+        Ok(Box::new(ArrowEngineData::new(batch)))
+    }
+
+    // Helper function to read JSON file asynchronously
+    async fn read_json_file(
+        store: &Arc<InMemory>,
+        path: &Path,
+    ) -> DeltaResult<Vec<serde_json::Value>> {
+        let content = store.get(path).await?;
+        let file_bytes = content.bytes().await?;
+        let file_string =
+            String::from_utf8(file_bytes.to_vec()).map_err(|e| object_store::Error::Generic {
+                store: "memory",
+                source: Box::new(e),
+            })?;
+        let json: Vec<_> = serde_json::Deserializer::from_str(&file_string)
+            .into_iter::<serde_json::Value>()
+            .flatten()
+            .collect();
+        Ok(json)
+    }
+
+    #[tokio::test]
+    async fn test_write_json_file_non_overwrite() -> DeltaResult<()> {
+        let store = Arc::new(InMemory::new());
+        let executor = Arc::new(TokioBackgroundExecutor::new());
+        let handler = DefaultJsonHandler::new(store.clone(), executor);
+        let path = Url::parse("memory:///test/data/00000000000000000001.json").unwrap();
+        let object_path = Path::from("/test/data/00000000000000000001.json");
+
+        let data = create_test_data(vec!["remi", "wilson"])?;
+
+        // First write with overwrite=false & no existing file
+        let result = handler.write_json_file(&path, Box::new(std::iter::once(Ok(data))), false);
+
+        // Verify the first write is successful
+        assert!(result.is_ok());
+        let json = read_json_file(&store, &object_path).await?;
+        assert_eq!(json, vec![json!({"dog": "remi"}), json!({"dog": "wilson"})]);
+
+        let data = create_test_data(vec!["check", "error"])?;
+
+        // Second write with overwrite=false & existing file
+        let result = handler.write_json_file(&path, Box::new(std::iter::once(Ok(data))), false);
+
+        // Verify the second write fails with FileAlreadyExists error
+        match result {
+            Err(Error::FileAlreadyExists(err_path)) => {
+                assert_eq!(err_path, object_path.to_string());
+            }
+            _ => panic!("Expected FileAlreadyExists error, got: {:?}", result),
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_write_json_file_overwrite() -> DeltaResult<()> {
+        let store = Arc::new(InMemory::new());
+        let executor = Arc::new(TokioBackgroundExecutor::new());
+        let handler = DefaultJsonHandler::new(store.clone(), executor);
+        let path = Url::parse("memory:///test/data/00000000000000000001.json").unwrap();
+        let object_path = Path::from("/test/data/00000000000000000001.json");
+
+        let first_batch = create_test_data(vec!["remi", "wilson"])?;
+
+        // First write with overwrite=true & no existing file
+        let result =
+            handler.write_json_file(&path, Box::new(std::iter::once(Ok(first_batch))), true);
+        assert!(result.is_ok());
+
+        // Verify the first write is successful
+        let json = read_json_file(&store, &object_path).await?;
+        assert_eq!(json, vec![json!({"dog": "remi"}), json!({"dog": "wilson"})]);
+
+        // Second write with overwrite=true & existing file
+        let second_batch = create_test_data(vec!["seb", "tia"])?;
+
+        // Verify the second write is successful
+        let result =
+            handler.write_json_file(&path, Box::new(std::iter::once(Ok(second_batch))), true);
+        assert!(result.is_ok());
+        let json = read_json_file(&store, &object_path).await?;
+        assert_eq!(json, vec![json!({"dog": "seb"}), json!({"dog": "tia"})]);
+
+        Ok(())
     }
 }

--- a/kernel/src/engine/sync/json.rs
+++ b/kernel/src/engine/sync/json.rs
@@ -54,7 +54,7 @@ impl JsonHandler for SyncJsonHandler {
         &self,
         path: &Url,
         data: Box<dyn Iterator<Item = DeltaResult<Box<dyn EngineData>>> + Send + '_>,
-        _overwrite: bool,
+        overwrite: bool,
     ) -> DeltaResult<()> {
         let path = path
             .to_file_path()
@@ -76,69 +76,116 @@ impl JsonHandler for SyncJsonHandler {
         tmp_file.write_all(&buf)?;
         tmp_file.flush()?;
 
-        // use 'persist_noclobber' to atomically rename tmp file to final path
-        tmp_file
-            .persist_noclobber(path.clone())
-            .map_err(|e| match e {
-                tempfile::PersistError { error, .. }
-                    if error.kind() == std::io::ErrorKind::AlreadyExists =>
-                {
-                    Error::FileAlreadyExists(path.to_string_lossy().to_string())
-                }
-                e => Error::IOError(e.into()),
-            })?;
+        let persist_result = if overwrite {
+            tmp_file.persist(path.clone())
+        } else {
+            // use 'persist_noclobber' to atomically rename tmp file to final path
+            tmp_file.persist_noclobber(path.clone())
+        };
+
+        // Map errors (handling AlreadyExists only in non-overwrite mode).
+        persist_result.map_err(|e| {
+            if !overwrite && e.error.kind() == std::io::ErrorKind::AlreadyExists {
+                Error::FileAlreadyExists(path.to_string_lossy().to_string())
+            } else {
+                Error::IOError(e.into())
+            }
+        })?;
+
         Ok(())
     }
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    use std::sync::Arc;
-
     use crate::arrow::array::{RecordBatch, StringArray};
     use crate::arrow::datatypes::{DataType as ArrowDataType, Field, Schema as ArrowSchema};
     use serde_json::json;
+    use std::path::Path;
+    use std::sync::Arc;
+    use tempfile::TempDir;
     use url::Url;
 
-    #[test]
-    fn test_write_json_file() -> DeltaResult<()> {
-        let test_dir = tempfile::tempdir().unwrap();
-        let path = test_dir.path().join("00000000000000000001.json");
-        let handler = SyncJsonHandler;
-
+    // Helper function to create test data
+    fn create_test_data(values: Vec<&str>) -> DeltaResult<Box<dyn EngineData>> {
         let schema = Arc::new(ArrowSchema::new(vec![Field::new(
             "dog",
             ArrowDataType::Utf8,
             true,
         )]));
-        let data = RecordBatch::try_new(
-            schema.clone(),
-            vec![Arc::new(StringArray::from(vec!["remi", "wilson"]))],
-        )?;
-        let data: Box<dyn EngineData> = Box::new(ArrowEngineData::new(data));
-        let empty: Box<dyn EngineData> =
-            Box::new(ArrowEngineData::new(RecordBatch::new_empty(schema)));
+        let batch =
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(StringArray::from(values))])?;
+        Ok(Box::new(ArrowEngineData::new(batch)))
+    }
 
-        let url = Url::from_file_path(path.clone()).unwrap();
-        handler
-            .write_json_file(&url, Box::new(std::iter::once(Ok(data))), false)
-            .expect("write json file");
-        assert!(matches!(
-            handler.write_json_file(&url, Box::new(std::iter::once(Ok(empty))), false),
-            Err(Error::FileAlreadyExists(_))
-        ));
-
+    // Helper function to read and parse JSON file
+    fn read_json_file(path: &Path) -> DeltaResult<Vec<serde_json::Value>> {
         let file = std::fs::read_to_string(path)?;
         let json: Vec<_> = serde_json::Deserializer::from_str(&file)
             .into_iter::<serde_json::Value>()
             .flatten()
             .collect();
-        assert_eq!(
-            json,
-            vec![json!({"dog": "remi"}), json!({"dog": "wilson"}),]
-        );
+        Ok(json)
+    }
+
+    #[test]
+    fn test_write_json_file_non_overwrite() -> DeltaResult<()> {
+        let test_dir = TempDir::new().unwrap();
+        let path = test_dir.path().join("00000000000000000001.json");
+        let handler = SyncJsonHandler;
+        let url = Url::from_file_path(path.clone()).unwrap();
+        let data = create_test_data(vec!["remi", "wilson"])?;
+
+        // First write with overwrite=false & no existing file
+        let result = handler.write_json_file(&url, Box::new(std::iter::once(Ok(data))), false);
+
+        // Verify the first write is successful
+        assert!(result.is_ok());
+        let json = read_json_file(&path)?;
+        assert_eq!(json, vec![json!({"dog": "remi"}), json!({"dog": "wilson"})],);
+
+        let data = create_test_data(vec!["check", "error"])?;
+
+        // Second write with overwrite=false & existing file
+        let result = handler.write_json_file(&url, Box::new(std::iter::once(Ok(data))), false);
+
+        // Verify the second write fails with FileAlreadyExists error
+        match result {
+            Err(Error::FileAlreadyExists(err_path)) => {
+                assert_eq!(err_path, path.to_string_lossy().to_string());
+            }
+            _ => panic!("Expected FileAlreadyExists error, got: {:?}", result),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_write_json_file_overwrite() -> DeltaResult<()> {
+        let test_dir = TempDir::new().unwrap();
+        let path = test_dir.path().join("00000000000000000001.json");
+        let handler = SyncJsonHandler;
+        let url = Url::from_file_path(path.clone()).unwrap();
+        let first_batch = create_test_data(vec!["remi", "wilson"])?;
+
+        // First write with overwrite=true & no existing file
+        let result =
+            handler.write_json_file(&url, Box::new(std::iter::once(Ok(first_batch))), true);
+        assert!(result.is_ok());
+
+        // Verify the first write is successful
+        let json = read_json_file(&path)?;
+        assert_eq!(json, vec![json!({"dog": "remi"}), json!({"dog": "wilson"})]);
+
+        // Second write with overwrite=true & existing file
+        let second_batch = create_test_data(vec!["seb", "tia"])?;
+
+        // Verify the second write is successful
+        let result =
+            handler.write_json_file(&url, Box::new(std::iter::once(Ok(second_batch))), true);
+        assert!(result.is_ok());
+        let json = read_json_file(&path)?;
+        assert_eq!(json, vec![json!({"dog": "seb"}), json!({"dog": "tia"})]);
 
         Ok(())
     }

--- a/kernel/src/engine/sync/json.rs
+++ b/kernel/src/engine/sync/json.rs
@@ -134,9 +134,9 @@ mod tests {
         let path = test_dir.path().join("00000000000000000001.json");
         let handler = SyncJsonHandler;
         let url = Url::from_file_path(path.clone()).unwrap();
-        let data = create_test_data(vec!["remi", "wilson"])?;
 
         // First write with overwrite=false & no existing file
+        let data = create_test_data(vec!["remi", "wilson"])?;
         let result = handler.write_json_file(&url, Box::new(std::iter::once(Ok(data))), false);
 
         // Verify the first write is successful
@@ -144,9 +144,8 @@ mod tests {
         let json = read_json_file(&path)?;
         assert_eq!(json, vec![json!({"dog": "remi"}), json!({"dog": "wilson"})],);
 
-        let data = create_test_data(vec!["check", "error"])?;
-
         // Second write with overwrite=false & existing file
+        let data = create_test_data(vec!["check", "error"])?;
         let result = handler.write_json_file(&url, Box::new(std::iter::once(Ok(data))), false);
 
         // Verify the second write fails with FileAlreadyExists error
@@ -166,11 +165,10 @@ mod tests {
         let path = test_dir.path().join("00000000000000000001.json");
         let handler = SyncJsonHandler;
         let url = Url::from_file_path(path.clone()).unwrap();
-        let first_batch = create_test_data(vec!["remi", "wilson"])?;
+        let data = create_test_data(vec!["remi", "wilson"])?;
 
         // First write with overwrite=true & no existing file
-        let result =
-            handler.write_json_file(&url, Box::new(std::iter::once(Ok(first_batch))), true);
+        let result = handler.write_json_file(&url, Box::new(std::iter::once(Ok(data))), true);
         assert!(result.is_ok());
 
         // Verify the first write is successful
@@ -178,11 +176,10 @@ mod tests {
         assert_eq!(json, vec![json!({"dog": "remi"}), json!({"dog": "wilson"})]);
 
         // Second write with overwrite=true & existing file
-        let second_batch = create_test_data(vec!["seb", "tia"])?;
+        let data = create_test_data(vec!["seb", "tia"])?;
+        let result = handler.write_json_file(&url, Box::new(std::iter::once(Ok(data))), true);
 
         // Verify the second write is successful
-        let result =
-            handler.write_json_file(&url, Box::new(std::iter::once(Ok(second_batch))), true);
         assert!(result.is_ok());
         let json = read_json_file(&path)?;
         assert_eq!(json, vec![json!({"dog": "seb"}), json!({"dog": "tia"})]);

--- a/kernel/src/engine/sync/json.rs
+++ b/kernel/src/engine/sync/json.rs
@@ -129,7 +129,7 @@ mod tests {
     }
 
     #[test]
-    fn test_write_json_file_non_overwrite() -> DeltaResult<()> {
+    fn test_write_json_file_without_overwrite() -> DeltaResult<()> {
         let test_dir = TempDir::new().unwrap();
         let path = test_dir.path().join("00000000000000000001.json");
         let handler = SyncJsonHandler;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-incubator/delta-kernel-rs/blob/main/CONTRIBUTING.md
  2. Run `cargo t --all-features --all-targets` to get started testing, and run `cargo fmt`.
  3. Ensure you have added or run the appropriate tests for your PR.
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

<!--
PR title formatting:
This project uses conventional commits: https://www.conventionalcommits.org/

Each PR corresponds to a commit on the `main` branch, with the title of the PR (typically) being
used for the commit message on main. In order to ensure proper formatting in the CHANGELOG please
ensure your PR title adheres to the conventional commit specification.

Examples:
- new feature PR: "feat: new API for snapshot.update()"
- bugfix PR: "fix: correctly apply DV in read-table example"
-->

## What changes are proposed in this pull request?
<!--
Please clarify what changes you are proposing and why the changes are needed.
The purpose of this section is to outline the changes, why they are needed, and how this PR fixes the issue.
If the reason for the change is already explained clearly in an issue, then it does not need to be restated here.
  1. If you propose a new API or feature, clarify the use case for a new API or feature.
  2. If you fix a bug, you can clarify why it is a bug.
-->

<!--
Uncomment this section if there are any changes affecting public APIs:
### This PR affects the following public APIs

If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.

Note that _new_ public APIs are not considered breaking.
-->

This PR adds support for overwriting JSON files in both the `DefaultEngine` and `SyncEngine`.

Previously, the `write_json_file` implementations ignored the `overwrite` flag, as there was no use case requiring it. However, with the ongoing work in #851, engines are now expected to support overwriting in their `write_json_file` implementations- since the `_last_checkpoint` file will likely already exist at write time.

## How was this change tested?
<!--
Please make sure to add test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested, ideally via a reproducible test documented in the PR description.
-->

Both the `DefaultEngine` and the `SyncEngine` have the following new unit-test coverage:
- `test_write_json_file_without_overwrite`
- `test_write_json_file_overwrite`