### PR TITLE
fix: tiny change for `impl AllocateError for T: ExternEngine`

### DIFF
--- a/ffi/src/error.rs
+++ b/ffi/src/error.rs
@@ -178,7 +178,9 @@ impl AllocateError for AllocateErrorFn {
     }
 }
 
-impl AllocateError for &dyn ExternEngine {
+// We do this instead of `impl AllocateError for &dyn ExternEngine` since we can then directly use
+// this trait on type T instead of having to cast it to a trait object first.
+impl<T: ExternEngine + ?Sized> AllocateError for &T {
     /// # Safety
     ///
     /// In addition to the usual requirements, the engine handle must be valid.


### PR DESCRIPTION
ryan and I had a new learning (during exploration of `impl<T: EvaluationHandler + ?Sized> EvaluationHandlerExtension for T {}`) and just applying that approach to `impl<T: ExternEngine + ?Sized> AllocateError for &T {}` instead of  `impl AllocateError for &dyn ExternEngine {}`