### PR TITLE
fix!: Enforce precision/scale correctness of Decimal types and values

### DIFF
--- a/ffi/src/expressions/kernel.rs
+++ b/ffi/src/expressions/kernel.rs
@@ -318,15 +318,15 @@ fn visit_expression_scalar(
             buf.as_ptr(),
             buf.len()
         ),
-        Scalar::Decimal(value, precision, scale) => {
+        Scalar::Decimal(v) => {
             call!(
                 visitor,
                 visit_literal_decimal,
                 sibling_list_id,
-                (value >> 64) as i64,
-                *value as u64,
-                *precision,
-                *scale
+                (v.bits() >> 64) as i64,
+                v.bits() as u64,
+                v.precision(),
+                v.scale()
             )
         }
         Scalar::Null(_) => call!(visitor, visit_literal_null, sibling_list_id),

--- a/ffi/src/schema.rs
+++ b/ffi/src/schema.rs
@@ -303,8 +303,8 @@ fn visit_schema_impl(schema: &StructType, visitor: &mut EngineSchemaVisitor) -> 
             DataType::Array(at) => {
                 call!(visit_array, visit_array_item(visitor, at, at.contains_null))
             }
-            DataType::Primitive(PrimitiveType::Decimal(precision, scale)) => {
-                call!(visit_decimal, *precision, *scale)
+            DataType::Primitive(PrimitiveType::Decimal(d)) => {
+                call!(visit_decimal, d.precision(), d.scale())
             }
             &DataType::STRING => call!(visit_string),
             &DataType::LONG => call!(visit_long),

--- a/ffi/src/test_ffi.rs
+++ b/ffi/src/test_ffi.rs
@@ -58,7 +58,7 @@ pub unsafe extern "C" fn get_testing_kernel_expression() -> Handle<SharedExpress
         Scalar::Date(32).into(),
         Scalar::Binary(0x0000deadbeefcafeu64.to_be_bytes().to_vec()).into(),
         // Both the most and least significant u64 of the Decimal value will be 1
-        Scalar::Decimal((1 << 64) + 1, 5, 3).into(),
+        Scalar::decimal((1i128 << 64) + 1, 5, 3).unwrap().into(),
         Expr::null_literal(DataType::SHORT),
         Scalar::Struct(top_level_struct).into(),
         Scalar::Array(array_data).into(),

--- a/ffi/src/test_ffi.rs
+++ b/ffi/src/test_ffi.rs
@@ -58,7 +58,7 @@ pub unsafe extern "C" fn get_testing_kernel_expression() -> Handle<SharedExpress
         Scalar::Date(32).into(),
         Scalar::Binary(0x0000deadbeefcafeu64.to_be_bytes().to_vec()).into(),
         // Both the most and least significant u64 of the Decimal value will be 1
-        Scalar::decimal((1i128 << 64) + 1, 5, 3).unwrap().into(),
+        Scalar::decimal((1i128 << 64) + 1, 20, 3).unwrap().into(),
         Expr::null_literal(DataType::SHORT),
         Scalar::Struct(top_level_struct).into(),
         Scalar::Array(array_data).into(),

--- a/ffi/tests/test-expression-visitor/expected.txt
+++ b/ffi/tests/test-expression-visitor/expected.txt
@@ -16,7 +16,7 @@ And
   TimestampNtz(100)
   Date(32)
   Binary(0000deadbeefcafe)
-  Decimal(1,1,5,3)
+  Decimal(1,1,20,3)
   Null
   Struct
     Field: top

--- a/kernel/src/engine/arrow_conversion.rs
+++ b/kernel/src/engine/arrow_conversion.rs
@@ -107,11 +107,10 @@ impl TryFrom<&DataType> for ArrowDataType {
                     PrimitiveType::Double => Ok(ArrowDataType::Float64),
                     PrimitiveType::Boolean => Ok(ArrowDataType::Boolean),
                     PrimitiveType::Binary => Ok(ArrowDataType::Binary),
-                    PrimitiveType::Decimal(precision, scale) => {
-                        PrimitiveType::check_decimal(*precision, *scale)
-                            .map_err(|e| ArrowError::from_external_error(e.into()))?;
-                        Ok(ArrowDataType::Decimal128(*precision, *scale as i8))
-                    }
+                    PrimitiveType::Decimal(dtype) => Ok(ArrowDataType::Decimal128(
+                        dtype.precision(),
+                        dtype.scale() as i8,
+                    )),
                     PrimitiveType::Date => {
                         // A calendar date, represented as a year-month-day triple without a
                         // timezone. Stored as 4 bytes integer representing days since 1970-01-01

--- a/kernel/src/engine/arrow_conversion.rs
+++ b/kernel/src/engine/arrow_conversion.rs
@@ -109,7 +109,7 @@ impl TryFrom<&DataType> for ArrowDataType {
                     PrimitiveType::Binary => Ok(ArrowDataType::Binary),
                     PrimitiveType::Decimal(dtype) => Ok(ArrowDataType::Decimal128(
                         dtype.precision(),
-                        dtype.scale() as i8,
+                        dtype.scale() as i8, // 0..=38
                     )),
                     PrimitiveType::Date => {
                         // A calendar date, represented as a year-month-day triple without a

--- a/kernel/src/engine/arrow_expression/mod.rs
+++ b/kernel/src/engine/arrow_expression/mod.rs
@@ -54,7 +54,7 @@ impl Scalar {
             Binary(val) => Arc::new(BinaryArray::from(vec![val.as_slice(); num_rows])),
             Decimal(val) => Arc::new(
                 Decimal128Array::from_value(val.bits(), num_rows)
-                    .with_precision_and_scale(val.precision(), val.scale() as i8)?,
+                    .with_precision_and_scale(val.precision(), val.scale() as i8)?, // 0..=38
             ),
             Struct(data) => {
                 let arrays = data
@@ -102,7 +102,7 @@ impl Scalar {
             Null(DataType::BINARY) => Arc::new(BinaryArray::new_null(num_rows)),
             Null(DataType::Primitive(PrimitiveType::Decimal(dtype))) => Arc::new(
                 Decimal128Array::new_null(num_rows)
-                    .with_precision_and_scale(dtype.precision(), dtype.scale() as i8)?,
+                    .with_precision_and_scale(dtype.precision(), dtype.scale() as i8)?, // 0..=38
             ),
             Null(DataType::Struct(t)) => {
                 let fields: Fields = t.fields().map(ArrowField::try_from).try_collect()?;

--- a/kernel/src/engine/arrow_expression/mod.rs
+++ b/kernel/src/engine/arrow_expression/mod.rs
@@ -52,9 +52,9 @@ impl Scalar {
             TimestampNtz(val) => Arc::new(TimestampMicrosecondArray::from_value(*val, num_rows)),
             Date(val) => Arc::new(Date32Array::from_value(*val, num_rows)),
             Binary(val) => Arc::new(BinaryArray::from(vec![val.as_slice(); num_rows])),
-            Decimal(val, precision, scale) => Arc::new(
-                Decimal128Array::from_value(*val, num_rows)
-                    .with_precision_and_scale(*precision, *scale as i8)?,
+            Decimal(val) => Arc::new(
+                Decimal128Array::from_value(val.bits(), num_rows)
+                    .with_precision_and_scale(val.precision(), val.scale() as i8)?,
             ),
             Struct(data) => {
                 let arrays = data
@@ -100,9 +100,9 @@ impl Scalar {
             }
             Null(DataType::DATE) => Arc::new(Date32Array::new_null(num_rows)),
             Null(DataType::BINARY) => Arc::new(BinaryArray::new_null(num_rows)),
-            Null(DataType::Primitive(PrimitiveType::Decimal(precision, scale))) => Arc::new(
+            Null(DataType::Primitive(PrimitiveType::Decimal(dtype))) => Arc::new(
                 Decimal128Array::new_null(num_rows)
-                    .with_precision_and_scale(*precision, *scale as i8)?,
+                    .with_precision_and_scale(dtype.precision(), dtype.scale() as i8)?,
             ),
             Null(DataType::Struct(t)) => {
                 let fields: Fields = t.fields().map(ArrowField::try_from).try_collect()?;

--- a/kernel/src/engine/parquet_row_group_skipping.rs
+++ b/kernel/src/engine/parquet_row_group_skipping.rs
@@ -1,11 +1,11 @@
 //! An implementation of parquet row group skipping using data skipping predicates over footer stats.
-use crate::expressions::{ColumnName, Expression, Scalar};
+use crate::expressions::{ColumnName, DecimalValue, Expression, Scalar};
 use crate::kernel_predicates::parquet_stats_skipping::ParquetStatsProvider;
 use crate::parquet::arrow::arrow_reader::ArrowReaderBuilder;
 use crate::parquet::file::metadata::RowGroupMetaData;
 use crate::parquet::file::statistics::Statistics;
 use crate::parquet::schema::types::ColumnDescPtr;
-use crate::schema::{DataType, PrimitiveType};
+use crate::schema::{DataType, DecimalType, PrimitiveType};
 use chrono::{DateTime, Days};
 use std::collections::HashMap;
 use tracing::debug;
@@ -66,18 +66,15 @@ impl<'a> RowGroupFilter<'a> {
             .map(|&i| self.row_group.column(i).statistics())
     }
 
-    fn decimal_from_bytes(bytes: Option<&[u8]>, precision: u8, scale: u8) -> Option<Scalar> {
+    fn decimal_from_bytes(bytes: Option<&[u8]>, dtype: DecimalType) -> Option<Scalar> {
         // WARNING: The bytes are stored in big-endian order; reverse and then 0-pad to 16 bytes.
         let bytes = bytes.filter(|b| b.len() <= 16)?;
         let mut bytes = Vec::from(bytes);
         bytes.reverse();
         bytes.resize(16, 0u8);
         let bytes: [u8; 16] = bytes.try_into().ok()?;
-        Some(Scalar::Decimal(
-            i128::from_le_bytes(bytes),
-            precision,
-            scale,
-        ))
+        let value = DecimalValue::try_new(i128::from_le_bytes(bytes), dtype).ok()?;
+        Some(value.into())
     }
 
     fn timestamp_from_date(days: Option<&i32>) -> Option<Scalar> {
@@ -126,10 +123,14 @@ impl ParquetStatsProvider for RowGroupFilter<'_> {
             (TimestampNtz, Statistics::Int64(s)) => Scalar::TimestampNtz(*s.min_opt()?),
             (TimestampNtz, Statistics::Int32(s)) => Self::timestamp_from_date(s.min_opt())?,
             (TimestampNtz, _) => return None, // TODO: Int96 timestamps
-            (Decimal(p, s), Statistics::Int32(i)) => Scalar::Decimal(*i.min_opt()? as i128, *p, *s),
-            (Decimal(p, s), Statistics::Int64(i)) => Scalar::Decimal(*i.min_opt()? as i128, *p, *s),
-            (Decimal(p, s), Statistics::FixedLenByteArray(b)) => {
-                Self::decimal_from_bytes(b.min_bytes_opt(), *p, *s)?
+            (Decimal(d), Statistics::Int32(i)) => {
+                DecimalValue::try_new(*i.min_opt()?, *d).ok()?.into()
+            }
+            (Decimal(d), Statistics::Int64(i)) => {
+                DecimalValue::try_new(*i.min_opt()?, *d).ok()?.into()
+            }
+            (Decimal(d), Statistics::FixedLenByteArray(b)) => {
+                Self::decimal_from_bytes(b.min_bytes_opt(), *d)?
             }
             (Decimal(..), _) => return None,
         };
@@ -168,10 +169,14 @@ impl ParquetStatsProvider for RowGroupFilter<'_> {
             (TimestampNtz, Statistics::Int64(s)) => Scalar::TimestampNtz(*s.max_opt()?),
             (TimestampNtz, Statistics::Int32(s)) => Self::timestamp_from_date(s.max_opt())?,
             (TimestampNtz, _) => return None, // TODO: Int96 timestamps
-            (Decimal(p, s), Statistics::Int32(i)) => Scalar::Decimal(*i.max_opt()? as i128, *p, *s),
-            (Decimal(p, s), Statistics::Int64(i)) => Scalar::Decimal(*i.max_opt()? as i128, *p, *s),
-            (Decimal(p, s), Statistics::FixedLenByteArray(b)) => {
-                Self::decimal_from_bytes(b.max_bytes_opt(), *p, *s)?
+            (Decimal(d), Statistics::Int32(i)) => {
+                DecimalValue::try_new(*i.max_opt()?, *d).ok()?.into()
+            }
+            (Decimal(d), Statistics::Int64(i)) => {
+                DecimalValue::try_new(*i.max_opt()?, *d).ok()?.into()
+            }
+            (Decimal(d), Statistics::FixedLenByteArray(b)) => {
+                Self::decimal_from_bytes(b.max_bytes_opt(), *d)?
             }
             (Decimal(..), _) => return None,
         };

--- a/kernel/src/engine/parquet_row_group_skipping/tests.rs
+++ b/kernel/src/engine/parquet_row_group_skipping/tests.rs
@@ -152,7 +152,7 @@ fn test_get_stat_values() {
             &column_name!("numeric.decimals.decimal32"),
             &DataType::decimal(8, 3).unwrap()
         ),
-        Some(Scalar::Decimal(11032, 8, 3))
+        Some(Scalar::decimal(11032, 8, 3).unwrap())
     );
 
     assert_eq!(
@@ -160,7 +160,7 @@ fn test_get_stat_values() {
             &column_name!("numeric.decimals.decimal64"),
             &DataType::decimal(16, 3).unwrap()
         ),
-        Some(Scalar::Decimal(11064, 16, 3))
+        Some(Scalar::decimal(11064, 16, 3).unwrap())
     );
 
     // type widening!
@@ -169,7 +169,7 @@ fn test_get_stat_values() {
             &column_name!("numeric.decimals.decimal32"),
             &DataType::decimal(16, 3).unwrap()
         ),
-        Some(Scalar::Decimal(11032, 16, 3))
+        Some(Scalar::decimal(11032, 16, 3).unwrap())
     );
 
     assert_eq!(
@@ -177,7 +177,7 @@ fn test_get_stat_values() {
             &column_name!("numeric.decimals.decimal128"),
             &DataType::decimal(32, 3).unwrap()
         ),
-        Some(Scalar::Decimal(11128, 32, 3))
+        Some(Scalar::decimal(11128, 32, 3).unwrap())
     );
 
     // type widening!
@@ -186,7 +186,7 @@ fn test_get_stat_values() {
             &column_name!("numeric.decimals.decimal64"),
             &DataType::decimal(32, 3).unwrap()
         ),
-        Some(Scalar::Decimal(11064, 32, 3))
+        Some(Scalar::decimal(11064, 32, 3).unwrap())
     );
 
     // type widening!
@@ -195,7 +195,7 @@ fn test_get_stat_values() {
             &column_name!("numeric.decimals.decimal32"),
             &DataType::decimal(32, 3).unwrap()
         ),
-        Some(Scalar::Decimal(11032, 32, 3))
+        Some(Scalar::decimal(11032, 32, 3).unwrap())
     );
 
     assert_eq!(
@@ -324,7 +324,7 @@ fn test_get_stat_values() {
             &column_name!("numeric.decimals.decimal32"),
             &DataType::decimal(8, 3).unwrap()
         ),
-        Some(Scalar::Decimal(15032, 8, 3))
+        Some(Scalar::decimal(15032, 8, 3).unwrap())
     );
 
     assert_eq!(
@@ -332,7 +332,7 @@ fn test_get_stat_values() {
             &column_name!("numeric.decimals.decimal64"),
             &DataType::decimal(16, 3).unwrap()
         ),
-        Some(Scalar::Decimal(15064, 16, 3))
+        Some(Scalar::decimal(15064, 16, 3).unwrap())
     );
 
     // type widening!
@@ -341,7 +341,7 @@ fn test_get_stat_values() {
             &column_name!("numeric.decimals.decimal32"),
             &DataType::decimal(16, 3).unwrap()
         ),
-        Some(Scalar::Decimal(15032, 16, 3))
+        Some(Scalar::decimal(15032, 16, 3).unwrap())
     );
 
     assert_eq!(
@@ -349,7 +349,7 @@ fn test_get_stat_values() {
             &column_name!("numeric.decimals.decimal128"),
             &DataType::decimal(32, 3).unwrap()
         ),
-        Some(Scalar::Decimal(15128, 32, 3))
+        Some(Scalar::decimal(15128, 32, 3).unwrap())
     );
 
     // type widening!
@@ -358,7 +358,7 @@ fn test_get_stat_values() {
             &column_name!("numeric.decimals.decimal64"),
             &DataType::decimal(32, 3).unwrap()
         ),
-        Some(Scalar::Decimal(15064, 32, 3))
+        Some(Scalar::decimal(15064, 32, 3).unwrap())
     );
 
     // type widening!
@@ -367,7 +367,7 @@ fn test_get_stat_values() {
             &column_name!("numeric.decimals.decimal32"),
             &DataType::decimal(32, 3).unwrap()
         ),
-        Some(Scalar::Decimal(15032, 32, 3))
+        Some(Scalar::decimal(15032, 32, 3).unwrap())
     );
 
     assert_eq!(

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -9,7 +9,7 @@ use itertools::Itertools;
 pub use self::column_names::{
     column_expr, column_name, joined_column_expr, joined_column_name, ColumnName,
 };
-pub use self::scalars::{ArrayData, DecimalValue, Scalar, StructData};
+pub use self::scalars::{ArrayData, DecimalData, Scalar, StructData};
 use crate::DataType;
 
 mod column_names;

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -9,7 +9,7 @@ use itertools::Itertools;
 pub use self::column_names::{
     column_expr, column_name, joined_column_expr, joined_column_name, ColumnName,
 };
-pub use self::scalars::{ArrayData, Scalar, StructData};
+pub use self::scalars::{ArrayData, DecimalValue, Scalar, StructData};
 use crate::DataType;
 
 mod column_names;

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -9,12 +9,12 @@ use crate::utils::require;
 use crate::{DeltaResult, Error};
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct DecimalValue {
+pub struct DecimalData {
     bits: i128,
     ty: DecimalType,
 }
 
-impl DecimalValue {
+impl DecimalData {
     pub fn try_new(bits: impl Into<i128>, ty: DecimalType) -> DeltaResult<Self> {
         let bits = bits.into();
         require!(
@@ -194,7 +194,7 @@ pub enum Scalar {
     /// Binary data
     Binary(Vec<u8>),
     /// Decimal value with a given precision and scale.
-    Decimal(DecimalValue),
+    Decimal(DecimalData),
     /// Null value with a given data type.
     Null(DataType),
     /// Struct value
@@ -233,7 +233,7 @@ impl Scalar {
     /// Constructs a Decimal value from raw parts
     pub fn decimal(bits: impl Into<i128>, precision: u8, scale: u8) -> DeltaResult<Self> {
         let dtype = DecimalType::try_new(precision, scale)?;
-        let dval = DecimalValue::try_new(bits, dtype)?;
+        let dval = DecimalData::try_new(bits, dtype)?;
         Ok(Self::Decimal(dval))
     }
 
@@ -400,8 +400,8 @@ impl From<bool> for Scalar {
     }
 }
 
-impl From<DecimalValue> for Scalar {
-    fn from(d: DecimalValue) -> Self {
+impl From<DecimalData> for Scalar {
+    fn from(d: DecimalData) -> Self {
         Self::Decimal(d)
     }
 }
@@ -567,7 +567,7 @@ impl PrimitiveType {
             None => int_part.parse()?,
             Some(frac_part) => format!("{}{}", int_part, frac_part).parse()?,
         };
-        Ok(Scalar::Decimal(DecimalValue::try_new(int, dtype)?))
+        Ok(Scalar::Decimal(DecimalData::try_new(int, dtype)?))
     }
 }
 
@@ -583,7 +583,7 @@ mod tests {
     #[test]
     fn test_bad_decimal() {
         let dtype = DecimalType::try_new(3, 0).unwrap();
-        DecimalValue::try_new(123456789, dtype).expect_err("should have failed");
+        DecimalData::try_new(123456789, dtype).expect_err("should have failed");
         PrimitiveType::parse_decimal("0.12345", dtype).expect_err("should have failed");
         PrimitiveType::parse_decimal("12345", dtype).expect_err("should have failed");
     }

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -48,7 +48,7 @@ impl DecimalData {
 /// Computes the decimal precision of a 128-bit number. The largest possible magnitude is i128::MIN
 /// = -2**127 with 39 decimal digits.
 fn get_decimal_precision(value: i128) -> u8 {
-    // Not sure why checked_ilog10 returns u32 when log10(2**127) = 39 fits easily in u8??
+    // Not sure why checked_ilog10 returns u32 when log10(2**127) = 38 fits easily in u8??
     value.unsigned_abs().checked_ilog10().map_or(0, |p| p + 1) as _
 }
 

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -3,9 +3,85 @@ use std::fmt::{Display, Formatter};
 
 use chrono::{DateTime, NaiveDate, NaiveDateTime, TimeZone, Utc};
 
-use crate::schema::{ArrayType, DataType, PrimitiveType, StructField};
+use crate::schema::{ArrayType, DataType, DecimalType, PrimitiveType, StructField};
 use crate::utils::require;
 use crate::{DeltaResult, Error};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DecimalValue {
+    bits: i128,
+    ty: DecimalType,
+}
+
+impl DecimalValue {
+    pub fn try_new(bits: impl Into<i128>, ty: DecimalType) -> DeltaResult<Self> {
+        let bits = bits.into();
+        require!(
+            ty.precision() >= get_decimal_precision(bits),
+            Error::invalid_decimal(format!(
+                "Decimal value {} exceeds precision {}",
+                bits,
+                ty.precision()
+            ))
+        );
+        Ok(Self { bits, ty })
+    }
+
+    pub fn bits(&self) -> i128 {
+        self.bits
+    }
+
+    pub fn ty(&self) -> &DecimalType {
+        &self.ty
+    }
+
+    pub fn precision(&self) -> u8 {
+        self.ty.precision()
+    }
+
+    pub fn scale(&self) -> u8 {
+        self.ty.scale()
+    }
+}
+
+/// Computes the decimal precision of a 128-bit number. The largest possible magnitude is i128::MIN
+/// = -2**127 with 39 decimal digits.
+fn get_decimal_precision(value: i128) -> u8 {
+    let mut precision = 0;
+
+    let mut value = value.unsigned_abs();
+    if value >= 1000_0000_0000_0000_0000_0000 {
+        value /= 1_0000_0000_0000_0000_0000_0000;
+        precision += 24;
+        // at most 39-24 = 15 digits remain
+    } else if value >= 1000_0000_0000 {
+        value /= 1_0000_0000_0000;
+        precision += 12;
+        // at most 24-12 = 12 digits remain
+    }
+
+    if value >= 1000_0000 {
+        value /= 1_0000_0000;
+        precision += 8;
+        // at most 7 decimal digits remain
+    }
+    if value >= 1000 {
+        value /= 1_0000;
+        precision += 4;
+        // at most 3 decimal digits remain
+    }
+    if value >= 10 {
+        value /= 1_00;
+        precision += 2;
+        // at most 1 decimal digit remains
+    }
+    if value >= 1 {
+        precision += 1;
+        // no digits left
+    }
+
+    precision
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct StructData {
@@ -117,7 +193,7 @@ pub enum Scalar {
     /// Binary data
     Binary(Vec<u8>),
     /// Decimal value with a given precision and scale.
-    Decimal(i128, u8, u8),
+    Decimal(DecimalValue),
     /// Null value with a given data type.
     Null(DataType),
     /// Struct value
@@ -141,7 +217,7 @@ impl Scalar {
             Self::TimestampNtz(_) => DataType::TIMESTAMP_NTZ,
             Self::Date(_) => DataType::DATE,
             Self::Binary(_) => DataType::BINARY,
-            Self::Decimal(_, precision, scale) => DataType::decimal_unchecked(*precision, *scale),
+            Self::Decimal(d) => DataType::from(*d.ty()),
             Self::Null(data_type) => data_type.clone(),
             Self::Struct(data) => DataType::struct_type(data.fields.clone()),
             Self::Array(data) => data.tpe.clone().into(),
@@ -151,6 +227,13 @@ impl Scalar {
     /// Returns true if this scalar is null.
     pub fn is_null(&self) -> bool {
         matches!(self, Self::Null(_))
+    }
+
+    /// Constructs a Decimal value from raw parts
+    pub fn decimal(bits: impl Into<i128>, precision: u8, scale: u8) -> DeltaResult<Self> {
+        let dtype = DecimalType::try_new(precision, scale)?;
+        let dval = DecimalValue::try_new(bits, dtype)?;
+        Ok(Self::Decimal(dval))
     }
 
     /// Constructs a Scalar timestamp with no timezone from an `i64` millisecond since unix epoch
@@ -179,24 +262,26 @@ impl Display for Scalar {
             Self::TimestampNtz(ts) => write!(f, "{}", ts),
             Self::Date(d) => write!(f, "{}", d),
             Self::Binary(b) => write!(f, "{:?}", b),
-            Self::Decimal(value, _, scale) => match scale.cmp(&0) {
+            Self::Decimal(d) => match d.scale().cmp(&0) {
                 Ordering::Equal => {
-                    write!(f, "{}", value)
+                    write!(f, "{}", d.bits())
                 }
                 Ordering::Greater => {
-                    let scalar_multiple = 10_i128.pow(*scale as u32);
+                    let scale = d.scale();
+                    let scalar_multiple = 10_i128.pow(scale as u32);
+                    let value = d.bits();
                     write!(f, "{}", value / scalar_multiple)?;
                     write!(f, ".")?;
                     write!(
                         f,
                         "{:0>scale$}",
                         value % scalar_multiple,
-                        scale = *scale as usize
+                        scale = scale as usize
                     )
                 }
                 Ordering::Less => {
-                    write!(f, "{}", value)?;
-                    for _ in 0..*scale {
+                    write!(f, "{}", d.bits())?;
+                    for _ in 0..d.scale() {
                         write!(f, "0")?;
                     }
                     Ok(())
@@ -261,10 +346,10 @@ impl PartialOrd for Scalar {
             (Date(_), _) => None,
             (Binary(a), Binary(b)) => a.partial_cmp(b),
             (Binary(_), _) => None,
-            (Decimal(v1, p1, s1), Decimal(v2, p2, s2)) => (s1.eq(s2) && p1.eq(p2))
-                .then(|| v1.partial_cmp(v2))
+            (Decimal(d1), Decimal(d2)) => (d1.ty() == d2.ty())
+                .then(|| d1.bits().partial_cmp(&d2.bits()))
                 .flatten(),
-            (Decimal(_, _, _), _) => None,
+            (Decimal(_), _) => None,
             (Null(_), _) => None, // NOTE: NULL values are incomparable by definition
             (Struct(_), _) => None, // TODO: Support Struct?
             (Array(_), _) => None, // TODO: Support Array?
@@ -314,6 +399,12 @@ impl From<bool> for Scalar {
     }
 }
 
+impl From<DecimalValue> for Scalar {
+    fn from(d: DecimalValue) -> Self {
+        Self::Decimal(d)
+    }
+}
+
 impl From<&str> for Scalar {
     fn from(s: &str) -> Self {
         Self::String(s.into())
@@ -341,24 +432,6 @@ impl From<&[u8]> for Scalar {
 // TODO: add more From impls
 
 impl PrimitiveType {
-    /// Check if the given precision and scale are valid for a decimal type.
-    pub fn check_decimal(precision: u8, scale: u8) -> DeltaResult<()> {
-        require!(
-            0 < precision && precision <= 38,
-            Error::invalid_decimal(format!(
-                "precision must in range 1..38 inclusive, found: {}.",
-                precision
-            ))
-        );
-        require!(
-            scale <= precision,
-            Error::invalid_decimal(format!(
-                "scale must be in range 0..precision inclusive, found: {scale}."
-            ))
-        );
-        Ok(())
-    }
-
     fn data_type(&self) -> DataType {
         DataType::Primitive(self.clone())
     }
@@ -374,7 +447,7 @@ impl PrimitiveType {
             String => Ok(Scalar::String(raw.to_string())),
             Binary => Ok(Scalar::Binary(raw.to_string().into_bytes())),
             Byte => self.parse_str_as_scalar(raw, Scalar::Byte),
-            Decimal(precision, scale) => self.parse_decimal(raw, *precision, *scale),
+            Decimal(dtype) => Self::parse_decimal(raw, *dtype),
             Short => self.parse_str_as_scalar(raw, Scalar::Short),
             Integer => self.parse_str_as_scalar(raw, Scalar::Integer),
             Long => self.parse_str_as_scalar(raw, Scalar::Long),
@@ -447,7 +520,7 @@ impl PrimitiveType {
         }
     }
 
-    fn parse_decimal(&self, raw: &str, precision: u8, expected_scale: u8) -> Result<Scalar, Error> {
+    fn parse_decimal(raw: &str, dtype: DecimalType) -> Result<Scalar, Error> {
         let (base, exp): (&str, i128) = match raw.find(['e', 'E']) {
             None => (raw, 0), // no 'e' or 'E', so there's no exponent
             Some(pos) => {
@@ -456,7 +529,8 @@ impl PrimitiveType {
                 (base, exp[1..].parse()?)
             }
         };
-        require!(!base.is_empty(), self.parse_error(raw));
+        let parse_error = || PrimitiveType::from(dtype).parse_error(raw);
+        require!(!base.is_empty(), parse_error());
 
         // now split on any '.' and parse
         let (int_part, frac_part, frac_digits) = match base.find('.') {
@@ -477,15 +551,13 @@ impl PrimitiveType {
         // we can assume this won't underflow since `frac_digits` is at minimum 0, and exp is at
         // most i128::MAX, and 0-i128::MAX doesn't underflow
         let scale = frac_digits - exp;
-        let scale: u8 = scale.try_into().map_err(|_| self.parse_error(raw))?;
-        require!(scale == expected_scale, self.parse_error(raw));
-        Self::check_decimal(precision, scale)?;
-
+        let scale: u8 = scale.try_into().map_err(|_| parse_error())?;
+        require!(scale == dtype.scale(), parse_error());
         let int: i128 = match frac_part {
             None => int_part.parse()?,
             Some(frac_part) => format!("{}{}", int_part, frac_part).parse()?,
         };
-        Ok(Scalar::Decimal(int, precision, scale))
+        Ok(Scalar::Decimal(DecimalValue::try_new(int, dtype)?))
     }
 }
 
@@ -499,14 +571,21 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_bad_decimal() {
+        let dtype = DecimalType::try_new(3, 0).unwrap();
+        DecimalValue::try_new(123456789, dtype).expect_err("should have failed");
+        PrimitiveType::parse_decimal("0.12345", dtype).expect_err("should have failed");
+        PrimitiveType::parse_decimal("12345", dtype).expect_err("should have failed");
+    }
+    #[test]
     fn test_decimal_display() {
-        let s = Scalar::Decimal(123456789, 9, 2);
+        let s = Scalar::decimal(123456789, 9, 2).unwrap();
         assert_eq!(s.to_string(), "1234567.89");
 
-        let s = Scalar::Decimal(123456789, 9, 0);
+        let s = Scalar::decimal(123456789, 9, 0).unwrap();
         assert_eq!(s.to_string(), "123456789");
 
-        let s = Scalar::Decimal(123456789, 9, 9);
+        let s = Scalar::decimal(123456789, 9, 9).unwrap();
         assert_eq!(s.to_string(), "0.123456789");
     }
 
@@ -516,12 +595,12 @@ mod tests {
         expect_prec: u8,
         expect_scale: u8,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let s = PrimitiveType::Decimal(expect_prec, expect_scale);
+        let s = PrimitiveType::decimal(expect_prec, expect_scale)?;
         match s.parse_scalar(raw)? {
-            Scalar::Decimal(int, prec, scale) => {
-                assert_eq!(int, expect_int);
-                assert_eq!(prec, expect_prec);
-                assert_eq!(scale, expect_scale);
+            Scalar::Decimal(val) => {
+                assert_eq!(val.bits(), expect_int);
+                assert_eq!(val.precision(), expect_prec);
+                assert_eq!(val.scale(), expect_scale);
             }
             _ => panic!("Didn't parse as decimal"),
         };
@@ -529,7 +608,71 @@ mod tests {
     }
 
     #[test]
+    fn test_decimal_precision() {
+        // Test around 0, 1, 2, and 4 digit boundaries
+        assert_eq!(get_decimal_precision(0), 0);
+        assert_eq!(get_decimal_precision(1), 1);
+        assert_eq!(get_decimal_precision(9), 1);
+        assert_eq!(get_decimal_precision(10), 2);
+        assert_eq!(get_decimal_precision(99), 2);
+        assert_eq!(get_decimal_precision(100), 3);
+        assert_eq!(get_decimal_precision(999), 3);
+        assert_eq!(get_decimal_precision(1000), 4);
+        assert_eq!(get_decimal_precision(9999), 4);
+        assert_eq!(get_decimal_precision(10000), 5);
+
+        // Test around the 8 digit boundary
+        assert_eq!(get_decimal_precision(999_9999), 7);
+        assert_eq!(get_decimal_precision(1000_0000), 8);
+        assert_eq!(get_decimal_precision(9999_9999), 8);
+        assert_eq!(get_decimal_precision(1_0000_0000), 9);
+
+        // Test around the 16 digit boundary
+        assert_eq!(get_decimal_precision(999_9999_9999_9999), 15);
+        assert_eq!(get_decimal_precision(1000_0000_0000_0000), 16);
+        assert_eq!(get_decimal_precision(9999_9999_9999_9999), 16);
+        assert_eq!(get_decimal_precision(1_0000_0000_0000_0000), 17);
+
+        // Test around the 32 digit boundary
+        assert_eq!(
+            get_decimal_precision(999_9999_9999_9999_9999_9999_9999_9999),
+            31
+        );
+        assert_eq!(
+            get_decimal_precision(1000_0000_0000_0000_0000_0000_0000_0000),
+            32
+        );
+        assert_eq!(
+            get_decimal_precision(9999_9999_9999_9999_9999_9999_9999_9999),
+            32
+        );
+        assert_eq!(
+            get_decimal_precision(1_0000_0000_0000_0000_0000_0000_0000_0000),
+            33
+        );
+
+        // Test around the 38 digit boundary
+        assert_eq!(
+            get_decimal_precision(9_9999_9999_9999_9999_9999_9999_9999_9999_9999),
+            37
+        );
+        assert_eq!(
+            get_decimal_precision(10_0000_0000_0000_0000_0000_0000_0000_0000_0000),
+            38
+        );
+        assert_eq!(
+            get_decimal_precision(99_9999_9999_9999_9999_9999_9999_9999_9999_9999),
+            38
+        );
+        assert_eq!(
+            get_decimal_precision(100_0000_0000_0000_0000_0000_0000_0000_0000_0000),
+            39
+        );
+    }
+
+    #[test]
     fn test_parse_decimal() -> Result<(), Box<dyn std::error::Error>> {
+        assert_decimal("0.999", 999, 3, 3)?;
         assert_decimal("0", 0, 1, 0)?;
         assert_decimal("0.00", 0, 3, 2)?;
         assert_decimal("123", 123, 3, 0)?;
@@ -546,25 +689,26 @@ mod tests {
     }
 
     fn expect_fail_parse(raw: &str, prec: u8, scale: u8) {
-        let s = PrimitiveType::Decimal(prec, scale);
+        let s = PrimitiveType::decimal(prec, scale).unwrap();
         let res = s.parse_scalar(raw);
         assert!(res.is_err(), "Fail on {raw}");
     }
 
     #[test]
     fn test_parse_decimal_expect_fail() {
-        expect_fail_parse("iowjef", 0, 0);
-        expect_fail_parse("123Ef", 0, 0);
-        expect_fail_parse("1d2E3", 0, 0);
-        expect_fail_parse("a", 0, 0);
+        expect_fail_parse("1.000", 3, 3);
+        expect_fail_parse("iowjef", 1, 0);
+        expect_fail_parse("123Ef", 1, 0);
+        expect_fail_parse("1d2E3", 1, 0);
+        expect_fail_parse("a", 1, 0);
         expect_fail_parse("2.a", 1, 1);
-        expect_fail_parse("E45", 0, 0);
-        expect_fail_parse("1.2.3", 0, 0);
-        expect_fail_parse("1.2E1.3", 0, 0);
+        expect_fail_parse("E45", 1, 0);
+        expect_fail_parse("1.2.3", 1, 0);
+        expect_fail_parse("1.2E1.3", 1, 0);
         expect_fail_parse("123.45", 5, 1);
         expect_fail_parse(".45", 5, 1);
-        expect_fail_parse("+", 0, 0);
-        expect_fail_parse("-", 0, 0);
+        expect_fail_parse("+", 1, 0);
+        expect_fail_parse("-", 1, 0);
         expect_fail_parse("0.-0", 2, 1);
         expect_fail_parse("--1.0", 1, 1);
         expect_fail_parse("+-1.0", 1, 1);
@@ -572,9 +716,9 @@ mod tests {
         expect_fail_parse("++1.0", 1, 1);
         expect_fail_parse("1.0E1+", 1, 1);
         // overflow i8 for `scale`
-        expect_fail_parse("0.999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999", 0, 0);
+        expect_fail_parse("0.999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999", 1, 0);
         // scale will be too small to fit in i8
-        expect_fail_parse("0.E170141183460469231731687303715884105727", 0, 0);
+        expect_fail_parse("0.E170141183460469231731687303715884105727", 1, 0);
     }
 
     #[test]

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -48,40 +48,8 @@ impl DecimalData {
 /// Computes the decimal precision of a 128-bit number. The largest possible magnitude is i128::MIN
 /// = -2**127 with 39 decimal digits.
 fn get_decimal_precision(value: i128) -> u8 {
-    let mut precision = 0;
-
-    let mut value = value.unsigned_abs();
-    if value >= 1000_0000_0000_0000_0000_0000 {
-        value /= 1_0000_0000_0000_0000_0000_0000;
-        precision += 24;
-        // at most 39-24 = 15 digits remain
-    } else if value >= 1000_0000_0000 {
-        value /= 1_0000_0000_0000;
-        precision += 12;
-        // at most 24-12 = 12 digits remain
-    }
-
-    if value >= 1000_0000 {
-        value /= 1_0000_0000;
-        precision += 8;
-        // at most 7 decimal digits remain
-    }
-    if value >= 1000 {
-        value /= 1_0000;
-        precision += 4;
-        // at most 3 decimal digits remain
-    }
-    if value >= 10 {
-        value /= 1_00;
-        precision += 2;
-        // at most 1 decimal digit remains
-    }
-    if value >= 1 {
-        precision += 1;
-        // no digits left
-    }
-
-    precision
+    // Not sure why checked_ilog10 returns u32 when log10(2**127) = 39 fits easily in u8??
+    value.unsigned_abs().checked_ilog10().map_or(0, |p| p + 1) as _
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/kernel/src/kernel_predicates/tests.rs
+++ b/kernel/src/kernel_predicates/tests.rs
@@ -67,7 +67,7 @@ fn test_default_partial_cmp_scalars() {
         TimestampNtz(1),
         Date(1),
         Binary(vec![1]),
-        Decimal(1, 10, 10), // invalid value,
+        Scalar::decimal(1, 10, 10).unwrap(),
         Null(DataType::LONG),
         Struct(StructData::try_new(vec![], vec![]).unwrap()),
         Array(ArrayData::new(
@@ -88,7 +88,7 @@ fn test_default_partial_cmp_scalars() {
         TimestampNtz(10),
         Date(10),
         Binary(vec![10]),
-        Decimal(10, 10, 10), // invalid value
+        Scalar::decimal(10, 10, 10).unwrap(),
         Null(DataType::LONG),
         Struct(StructData::try_new(vec![], vec![]).unwrap()),
         Array(ArrayData::new(

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -486,6 +486,40 @@ fn default_true() -> bool {
     true
 }
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct DecimalType {
+    precision: u8,
+    scale: u8,
+}
+
+impl DecimalType {
+    /// Check if the given precision and scale are valid for a decimal type.
+    pub fn try_new(precision: u8, scale: u8) -> DeltaResult<Self> {
+        require!(
+            0 < precision && precision <= 38,
+            Error::invalid_decimal(format!(
+                "precision must be in range 1..38 inclusive, found: {}.",
+                precision
+            ))
+        );
+        require!(
+            scale <= precision,
+            Error::invalid_decimal(format!(
+                "scale must be in range 0..{precision} inclusive, found: {scale}."
+            ))
+        );
+        Ok(Self { precision, scale })
+    }
+
+    pub fn precision(&self) -> u8 {
+        self.precision
+    }
+
+    pub fn scale(&self) -> u8 {
+        self.scale
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum PrimitiveType {
@@ -516,18 +550,23 @@ pub enum PrimitiveType {
         deserialize_with = "deserialize_decimal",
         untagged
     )]
-    Decimal(u8, u8),
+    Decimal(DecimalType),
+}
+
+impl PrimitiveType {
+    pub fn decimal(precision: u8, scale: u8) -> DeltaResult<Self> {
+        Ok(DecimalType::try_new(precision, scale)?.into())
+    }
 }
 
 fn serialize_decimal<S: serde::Serializer>(
-    precision: &u8,
-    scale: &u8,
+    dtype: &DecimalType,
     serializer: S,
 ) -> Result<S::Ok, S::Error> {
-    serializer.serialize_str(&format!("decimal({},{})", precision, scale))
+    serializer.serialize_str(&format!("decimal({},{})", dtype.precision(), dtype.scale()))
 }
 
-fn deserialize_decimal<'de, D>(deserializer: D) -> Result<(u8, u8), D::Error>
+fn deserialize_decimal<'de, D>(deserializer: D) -> Result<DecimalType, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
@@ -550,8 +589,7 @@ where
         .ok_or_else(|| {
             serde::de::Error::custom(format!("Invalid scale in decimal: {}", str_value))
         })?;
-    PrimitiveType::check_decimal(precision, scale).map_err(serde::de::Error::custom)?;
-    Ok((precision, scale))
+    DecimalType::try_new(precision, scale).map_err(serde::de::Error::custom)
 }
 
 impl Display for PrimitiveType {
@@ -569,8 +607,8 @@ impl Display for PrimitiveType {
             PrimitiveType::Date => write!(f, "date"),
             PrimitiveType::Timestamp => write!(f, "timestamp"),
             PrimitiveType::TimestampNtz => write!(f, "timestamp_ntz"),
-            PrimitiveType::Decimal(precision, scale) => {
-                write!(f, "decimal({},{})", precision, scale)
+            PrimitiveType::Decimal(dtype) => {
+                write!(f, "decimal({},{})", dtype.precision(), dtype.scale())
             }
         }
     }
@@ -591,6 +629,16 @@ pub enum DataType {
     Map(Box<MapType>),
 }
 
+impl From<DecimalType> for PrimitiveType {
+    fn from(dtype: DecimalType) -> Self {
+        PrimitiveType::Decimal(dtype)
+    }
+}
+impl From<DecimalType> for DataType {
+    fn from(dtype: DecimalType) -> Self {
+        PrimitiveType::from(dtype).into()
+    }
+}
 impl From<PrimitiveType> for DataType {
     fn from(ptype: PrimitiveType) -> Self {
         DataType::Primitive(ptype)
@@ -636,10 +684,7 @@ impl DataType {
     pub const TIMESTAMP_NTZ: Self = DataType::Primitive(PrimitiveType::TimestampNtz);
 
     pub fn decimal(precision: u8, scale: u8) -> DeltaResult<Self> {
-        PrimitiveType::check_decimal(precision, scale)?;
-        Ok(DataType::Primitive(PrimitiveType::Decimal(
-            precision, scale,
-        )))
+        Ok(PrimitiveType::decimal(precision, scale)?.into())
     }
 
     // This function assumes that the caller has already checked the precision and scale
@@ -1039,10 +1084,7 @@ mod tests {
         }
         "#;
         let field: StructField = serde_json::from_str(data).unwrap();
-        assert!(matches!(
-            field.data_type,
-            DataType::Primitive(PrimitiveType::Decimal(10, 2))
-        ));
+        assert_eq!(field.data_type, DataType::decimal(10, 2).unwrap());
 
         let json_str = serde_json::to_string(&field).unwrap();
         assert_eq!(


### PR DESCRIPTION
## What changes are proposed in this pull request?

128-bit decimal precision is constrained to `1..=38` and scale is constrained to `0..=precision`. So far, the code only enforced that constraint for `PrimitiveType::Decimal` on an opt-in basis, with little or no enforcement on `Scalar::Decimal` values. In particular, there was not code in place at all to enforce that the decimal's i128 value actually fit within the specified precision.

Fix both problems by introducing new `DecimalType` and `DecimalValue` structs, which respectively replace unnamed tuple args as the payload of `PrimitiveType::Decimal` and `Scalar::Decimal`. This, in turn, allows us to make the struct members private, forcing all instances through a constructor that can validate its inputs.

Fixes https://github.com/delta-io/delta-kernel-rs/issues/853

### This PR affects the following public APIs

The signatures of `PrimitiveType::Decimal` and `Scalar::Decimal` both changed.

## How was this change tested?

Added new unit tests. Also fixed a bunch of existing unit tests that broke due to their using invalid decimal values.