### PR TITLE
docs: remove `acceptance` from `rust-analyzer.cargo.features` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Some design principles which should be considered:
 ```json
 {
   "editor.formatOnSave": true,
-  "rust-analyzer.cargo.features": ["default-engine", "acceptance"]
+  "rust-analyzer.cargo.features": ["default-engine"]
 }
 ```
 


### PR DESCRIPTION
The `rust-analyzer.cargo.features` setting only controls feature flags. Since acceptance is its now it's own crate, we should drop it from that list, otherwise rust-analyzer will try to pass `--features acceptance` at the workspace root (which Cargo will reject).