### PR TITLE
fix: disable predicate pushdown in `Scan::execute`

### DIFF
--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -533,7 +533,6 @@ impl Scan {
 
         let global_state = Arc::new(self.global_scan_state());
         let table_root = self.snapshot.table_root().clone();
-        let physical_predicate = self.physical_predicate();
 
         let scan_metadata_iter = self.scan_metadata(engine.as_ref())?;
         let scan_files_iter = scan_metadata_iter
@@ -562,10 +561,12 @@ impl Scan {
                 // partition columns, but the read schema we use here does _NOT_ include partition
                 // columns. So we cannot safely assume that all column references are valid. See
                 // https://github.com/delta-io/delta-kernel-rs/issues/434 for more details.
+                //
+                // TODO(#860): we disable predicate pushdown until we support row indexes.
                 let read_result_iter = engine.parquet_handler().read_parquet_files(
                     &[meta],
                     global_state.physical_schema.clone(),
-                    physical_predicate.clone(),
+                    None,
                 )?;
 
                 // Arc clones

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -1163,7 +1163,11 @@ mod tests {
         let data: Vec<_> = scan.execute(engine.clone()).unwrap().try_collect().unwrap();
         assert_eq!(data.len(), 1);
 
-        // Effective predicate pushdown, so no data files should be returned.
+        // TODO(#860): we disable predicate pushdown until we support row indexes. Update this test
+        // accordingly after support is reintroduced.
+        //
+        // Effective predicate pushdown, so no data files should be returned. BUT since we disabled
+        // predicate pushdown, the one data file is still returned.
         let predicate = Arc::new(int_col.lt(value));
         let scan = snapshot
             .scan_builder()
@@ -1171,7 +1175,7 @@ mod tests {
             .build()
             .unwrap();
         let data: Vec<_> = scan.execute(engine).unwrap().try_collect().unwrap();
-        assert_eq!(data.len(), 0);
+        assert_eq!(data.len(), 1);
     }
 
     #[test]

--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -276,7 +276,7 @@ fn read_scan_file(
     resolved_scan_file: ResolvedCdfScanFile,
     global_state: &GlobalScanState,
     all_fields: &[ColumnType],
-    physical_predicate: Option<ExpressionRef>,
+    _physical_predicate: Option<ExpressionRef>,
 ) -> DeltaResult<impl Iterator<Item = DeltaResult<ScanResult>>> {
     let ResolvedCdfScanFile {
         scan_file,
@@ -302,11 +302,11 @@ fn read_scan_file(
         size: 0,
         location,
     };
-    let read_result_iter = engine.parquet_handler().read_parquet_files(
-        &[file],
-        physical_schema,
-        physical_predicate,
-    )?;
+    // TODO(#860): we disable predicate pushdown until we support row indexes.
+    let read_result_iter =
+        engine
+            .parquet_handler()
+            .read_parquet_files(&[file], physical_schema, None)?;
 
     let result = read_result_iter.map(move |batch| -> DeltaResult<_> {
         let batch = batch?;


### PR DESCRIPTION
## What changes are proposed in this pull request?
TLDR: Disable predicate pushdown in `Scan::execute` API (and CDF API too) since it currently breaks DV application.

The `Scan::execute` function currently combines the `Scan::scan_metadata()` (and the needed visiting, etc.) to get the `ScanFiles`, then for each scan file, performs the corresponding DV and parquet read before applying transforms/schemas and eventually handing back 'final data' to the user (in the form of a `ScanResult` which is just filtered engine data).

The problem lies in the application of the DV to the data in the presence of predicates. currently everything is positional, that is, if we read a DV that indicates rows 1, 5, and 10 are deleted from a record batch, then `Scan::execute` will simply apply those positional deletions after reading the parquet file. This may seem okay at first glance but if a predicate 'reshuffles' data from the parquet file then the positions referenced in the aforementioned DV are no longer valid. This should instead be handled by row indexes. future work: #860 

## How was this change tested?
Updated existing `test_data_row_group_skipping` UT to assert there is _no_ predicate pushdown when using `scan.execute`