### PR TITLE
feat: add `snapshot.get_app_id_version(app_id, engine)`

### DIFF
--- a/kernel/src/actions/set_transaction.rs
+++ b/kernel/src/actions/set_transaction.rs
@@ -3,90 +3,94 @@ use std::sync::{Arc, LazyLock};
 use crate::actions::get_log_txn_schema;
 use crate::actions::visitors::SetTransactionVisitor;
 use crate::actions::{SetTransaction, SET_TRANSACTION_NAME};
-use crate::snapshot::Snapshot;
+use crate::log_segment::LogSegment;
 use crate::{DeltaResult, Engine, EngineData, Expression as Expr, ExpressionRef, RowVisitor as _};
 
 pub(crate) use crate::actions::visitors::SetTransactionMap;
 
-pub(crate) struct SetTransactionScanner {
-    snapshot: Arc<Snapshot>,
-}
+pub(crate) struct SetTransactionScanner {}
 
 impl SetTransactionScanner {
-    pub(crate) fn new(snapshot: Arc<Snapshot>) -> Self {
-        SetTransactionScanner { snapshot }
-    }
-
-    /// Scan the entire log for all application ids but terminate early if a specific application id
-    /// is provided
-    // TODO: we could have this track _multiple_ application ids instead of only up to one.
-    fn scan_application_transactions(
-        &self,
-        engine: &dyn Engine,
-        application_id: Option<&str>,
-    ) -> DeltaResult<SetTransactionMap> {
-        let mut visitor = SetTransactionVisitor::new(application_id.map(|s| s.to_owned()));
-        // If a specific id is requested then we can terminate log replay early as soon as it was
-        // found. If all ids are requested then we are forced to replay the entire log.
-        for maybe_data in self.replay_for_app_ids(engine)? {
-            let (txns, _) = maybe_data?;
-            visitor.visit_rows_of(txns.as_ref())?;
-            // if a specific id is requested and a transaction was found, then return
-            if application_id.is_some() && !visitor.set_transactions.is_empty() {
-                break;
-            }
-        }
-
-        Ok(visitor.set_transactions)
-    }
-
-    // Factored out to facilitate testing
-    fn replay_for_app_ids(
-        &self,
-        engine: &dyn Engine,
-    ) -> DeltaResult<impl Iterator<Item = DeltaResult<(Box<dyn EngineData>, bool)>> + Send> {
-        let txn_schema = get_log_txn_schema();
-        // This meta-predicate should be effective because all the app ids end up in a single
-        // checkpoint part when patitioned by `add.path` like the Delta spec requires. There's no
-        // point filtering by a particular app id, even if we have one, because app ids are all in
-        // the a single checkpoint part having large min/max range (because they're usually uuids).
-        static META_PREDICATE: LazyLock<Option<ExpressionRef>> = LazyLock::new(|| {
-            Some(Arc::new(
-                Expr::column([SET_TRANSACTION_NAME, "appId"]).is_not_null(),
-            ))
-        });
-        self.snapshot.log_segment().read_actions(
-            engine,
-            txn_schema.clone(), // Arc clone
-            txn_schema.clone(), // Arc clone
-            META_PREDICATE.clone(),
-        )
-    }
-
-    /// Scan the Delta Log for the latest `txn` action for an application id
-    pub(crate) fn latest_txn(
-        &self,
-        engine: &dyn Engine,
+    /// Scan the Delta Log for the latest `txn` action for an application id.
+    ///
+    /// Note that each call to this function repeats log replay. Thus, if callers are interested
+    /// in multiple app ids, use `get_all` (once) instead and probe the map returned.
+    pub(crate) fn get_one(
+        log_segment: &LogSegment,
         application_id: &str,
+        engine: &dyn Engine,
     ) -> DeltaResult<Option<SetTransaction>> {
-        let mut transactions = self.scan_application_transactions(engine, Some(application_id))?;
+        let mut transactions =
+            scan_application_transactions(log_segment, Some(application_id), engine)?;
         Ok(transactions.remove(application_id))
     }
 
-    /// Scan the Delta Log to obtain the all of the latest `txn` actions
+    /// Scan the Delta Log to obtain the all of the latest `txn` actions.
+    ///
+    /// This performs log replay and populates the `SetTransactionMap` with the latest `txn` action
+    /// found for each app_id.
     #[allow(unused)]
-    pub(crate) fn latest_txn_map(&self, engine: &dyn Engine) -> DeltaResult<SetTransactionMap> {
-        self.scan_application_transactions(engine, None)
+    pub(crate) fn get_all(
+        log_segment: &LogSegment,
+        engine: &dyn Engine,
+    ) -> DeltaResult<SetTransactionMap> {
+        scan_application_transactions(log_segment, None, engine)
     }
 }
 
-#[cfg(all(test, feature = "sync-engine"))]
+/// Scan the entire log for all application ids but terminate early if a specific application id
+/// is provided
+fn scan_application_transactions(
+    log_segment: &LogSegment,
+    application_id: Option<&str>,
+    engine: &dyn Engine,
+) -> DeltaResult<SetTransactionMap> {
+    let mut visitor = SetTransactionVisitor::new(application_id.map(|s| s.to_owned()));
+    // If a specific id is requested then we can terminate log replay early as soon as it was
+    // found. If all ids are requested then we are forced to replay the entire log.
+    for maybe_data in replay_for_app_ids(log_segment, engine)? {
+        let (txns, _) = maybe_data?;
+        visitor.visit_rows_of(txns.as_ref())?;
+        // if a specific id is requested and a transaction was found, then return
+        if application_id.is_some() && !visitor.set_transactions.is_empty() {
+            break;
+        }
+    }
+
+    Ok(visitor.set_transactions)
+}
+
+// Factored out to facilitate testing
+fn replay_for_app_ids(
+    log_segment: &LogSegment,
+    engine: &dyn Engine,
+) -> DeltaResult<impl Iterator<Item = DeltaResult<(Box<dyn EngineData>, bool)>> + Send> {
+    let txn_schema = get_log_txn_schema();
+    // This meta-predicate should be effective because all the app ids end up in a single
+    // checkpoint part when patitioned by `add.path` like the Delta spec requires. There's no
+    // point filtering by a particular app id, even if we have one, because app ids are all in
+    // the a single checkpoint part having large min/max range (because they're usually uuids).
+    static META_PREDICATE: LazyLock<Option<ExpressionRef>> = LazyLock::new(|| {
+        Some(Arc::new(
+            Expr::column([SET_TRANSACTION_NAME, "appId"]).is_not_null(),
+        ))
+    });
+    log_segment.read_actions(
+        engine,
+        txn_schema.clone(), // Arc clone
+        txn_schema.clone(), // Arc clone
+        META_PREDICATE.clone(),
+    )
+}
+
+#[cfg(test)]
 mod tests {
     use std::path::PathBuf;
 
     use super::*;
     use crate::engine::sync::SyncEngine;
     use crate::Table;
+
     use itertools::Itertools;
 
     fn get_latest_transactions(
@@ -99,11 +103,11 @@ mod tests {
 
         let table = Table::new(url);
         let snapshot = table.snapshot(&engine, None).unwrap();
-        let txn_scan = SetTransactionScanner::new(snapshot.into());
+        let log_segment = snapshot.log_segment();
 
         (
-            txn_scan.latest_txn_map(&engine).unwrap(),
-            txn_scan.latest_txn(&engine, app_id).unwrap(),
+            SetTransactionScanner::get_all(log_segment, &engine).unwrap(),
+            SetTransactionScanner::get_one(log_segment, app_id, &engine).unwrap(),
         )
     }
 
@@ -150,11 +154,10 @@ mod tests {
 
         let table = Table::new(url);
         let snapshot = table.snapshot(&engine, None).unwrap();
-        let txn = SetTransactionScanner::new(snapshot.into());
+        let log_segment = snapshot.log_segment();
 
         // The checkpoint has five parts, each containing one action. There are two app ids.
-        let data: Vec<_> = txn
-            .replay_for_app_ids(&engine)
+        let data: Vec<_> = replay_for_app_ids(log_segment, &engine)
             .unwrap()
             .try_collect()
             .unwrap();

--- a/kernel/src/actions/set_transaction.rs
+++ b/kernel/src/actions/set_transaction.rs
@@ -12,7 +12,6 @@ pub(crate) struct SetTransactionScanner {
     snapshot: Arc<Snapshot>,
 }
 
-#[allow(dead_code)]
 impl SetTransactionScanner {
     pub(crate) fn new(snapshot: Arc<Snapshot>) -> Self {
         SetTransactionScanner { snapshot }
@@ -64,8 +63,8 @@ impl SetTransactionScanner {
         )
     }
 
-    /// Scan the Delta Log for the latest transaction entry of an application
-    pub(crate) fn application_transaction(
+    /// Scan the Delta Log for the latest `txn` action for an application id
+    pub(crate) fn latest_txn(
         &self,
         engine: &dyn Engine,
         application_id: &str,
@@ -74,11 +73,9 @@ impl SetTransactionScanner {
         Ok(transactions.remove(application_id))
     }
 
-    /// Scan the Delta Log to obtain the latest transaction for all applications
-    pub(crate) fn application_transactions(
-        &self,
-        engine: &dyn Engine,
-    ) -> DeltaResult<SetTransactionMap> {
+    /// Scan the Delta Log to obtain the all of the latest `txn` actions
+    #[allow(unused)]
+    pub(crate) fn latest_txn_map(&self, engine: &dyn Engine) -> DeltaResult<SetTransactionMap> {
         self.scan_application_transactions(engine, None)
     }
 }
@@ -105,8 +102,8 @@ mod tests {
         let txn_scan = SetTransactionScanner::new(snapshot.into());
 
         (
-            txn_scan.application_transactions(&engine).unwrap(),
-            txn_scan.application_transaction(&engine, app_id).unwrap(),
+            txn_scan.latest_txn_map(&engine).unwrap(),
+            txn_scan.latest_txn(&engine, app_id).unwrap(),
         )
     }
 

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -3,6 +3,7 @@
 
 use std::sync::Arc;
 
+use crate::actions::set_transaction::SetTransactionScanner;
 use crate::actions::{Metadata, Protocol};
 use crate::log_segment::{self, LogSegment};
 use crate::scan::ScanBuilder;
@@ -302,6 +303,17 @@ impl Snapshot {
     /// Consume this `Snapshot` to create a [`ScanBuilder`]
     pub fn into_scan_builder(self) -> ScanBuilder {
         ScanBuilder::new(self)
+    }
+
+    /// Fetch the latest version of the provided `application_id` for this snapshot.
+    pub fn latest_application_id_version(
+        self: Arc<Self>,
+        application_id: &str,
+        engine: &dyn Engine,
+    ) -> DeltaResult<Option<i64>> {
+        let txn_scanner = SetTransactionScanner::new(self);
+        let txn = txn_scanner.latest_txn(engine, application_id)?;
+        Ok(txn.map(|t| t.version))
     }
 }
 

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -306,13 +306,15 @@ impl Snapshot {
     }
 
     /// Fetch the latest version of the provided `application_id` for this snapshot.
-    pub fn latest_application_id_version(
+    ///
+    /// Note that this method performs log replay (fetches and processes metadata from storage).
+    // TODO: add a get_app_id_versions to fetch all at once using SetTransactionScanner::get_all
+    pub fn get_app_id_version(
         self: Arc<Self>,
         application_id: &str,
         engine: &dyn Engine,
     ) -> DeltaResult<Option<i64>> {
-        let txn_scanner = SetTransactionScanner::new(self);
-        let txn = txn_scanner.latest_txn(engine, application_id)?;
+        let txn = SetTransactionScanner::get_one(self.log_segment(), application_id, engine)?;
         Ok(txn.map(|t| t.version))
     }
 }

--- a/kernel/tests/write.rs
+++ b/kernel/tests/write.rs
@@ -741,21 +741,14 @@ async fn test_write_txn_actions() -> Result<(), Box<dyn std::error::Error>> {
 
         let snapshot = Arc::new(table.snapshot(&engine, None)?);
         assert_eq!(
-            snapshot
-                .clone()
-                .latest_application_id_version("app_id1", &engine)?,
+            snapshot.clone().get_app_id_version("app_id1", &engine)?,
             Some(1)
         );
         assert_eq!(
-            snapshot
-                .clone()
-                .latest_application_id_version("app_id2", &engine)?,
+            snapshot.clone().get_app_id_version("app_id2", &engine)?,
             Some(2)
         );
-        assert_eq!(
-            snapshot.latest_application_id_version("app_id3", &engine)?,
-            None
-        );
+        assert_eq!(snapshot.get_app_id_version("app_id3", &engine)?, None);
 
         let commit1 = store
             .get(&Path::from(format!(

--- a/kernel/tests/write.rs
+++ b/kernel/tests/write.rs
@@ -739,6 +739,24 @@ async fn test_write_txn_actions() -> Result<(), Box<dyn std::error::Error>> {
         // commit!
         txn.commit(&engine)?;
 
+        let snapshot = Arc::new(table.snapshot(&engine, None)?);
+        assert_eq!(
+            snapshot
+                .clone()
+                .latest_application_id_version("app_id1", &engine)?,
+            Some(1)
+        );
+        assert_eq!(
+            snapshot
+                .clone()
+                .latest_application_id_version("app_id2", &engine)?,
+            Some(2)
+        );
+        assert_eq!(
+            snapshot.latest_application_id_version("app_id3", &engine)?,
+            None
+        );
+
         let commit1 = store
             .get(&Path::from(format!(
                 "/{table_name}/_delta_log/00000000000000000001.json"


### PR DESCRIPTION
## What changes are proposed in this pull request?
In an effort to support idempotent writes: adds a new API on `Snapshot` to fetch the latest version (latest `txn` action version) for a specific application id.

Future work: expose an api for fetching _all_ `txn` actions.

### This PR affects the following public APIs
New `Snapshot:: get_app_id_version(self: Arc<Self>, app_id: &str, engine: &dyn Engine)` API for fetching the latest application id of a `txn` action.


## How was this change tested?
added to `write.rs`

resolves #846 