### PR TITLE
chore: remove unused dependencies

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -35,11 +35,6 @@ delta-rs
 https://github.com/delta-io/delta-rs/
 Licence: Apache-2.0
 
-fix-hidden-lifetime-bug
-https://github.com/danielhenrymantilla/fix-hidden-lifetime-bug.rs
-Licence: Zlib OR MIT OR Apache-2.0
-Copyright 2021 Daniel Henry-Mantilla
-
 flate2
 https://github.com/rust-lang/flate2-rs
 Licence: MIT OR Apache-2.0
@@ -137,10 +132,6 @@ Licence: MIT OR Apache-2.0
 uuid
 https://github.com/uuid-rs/uuid
 Licence: Apache-2.0 OR MIT
-
-visibility
-https://github.com/danielhenrymantilla/visibility.rs
-Licence: Zlib OR MIT OR Apache-2.0
 
 z85
 https://github.com/decafbad/z85

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -39,7 +39,6 @@ pre-release-hook = [
 [dependencies]
 bytes = "1.10"
 chrono = "=0.4.39"
-fix-hidden-lifetime-bug = "0.2"
 indexmap = "2.9.0"
 itertools = "0.14"
 roaring = "0.10.12"
@@ -137,9 +136,6 @@ integration-test = [
   "hdfs-native",
   "walkdir",
 ]
-
-[dependencies.home]
-version = "=0.5.9"
 
 [build-dependencies]
 rustc_version = "0.4.1"

--- a/kernel/examples/inspect-table/Cargo.toml
+++ b/kernel/examples/inspect-table/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 publish = false
 
 [dependencies]
-arrow = "54"
 clap = { version = "4.5", features = ["derive"] }
 delta_kernel = { path = "../../../kernel", features = [
   "cloud",

--- a/kernel/examples/read-table-changes/Cargo.toml
+++ b/kernel/examples/read-table-changes/Cargo.toml
@@ -14,6 +14,5 @@ delta_kernel = { path = "../../../kernel", features = [
   "arrow",
   "default-engine",
 ] }
-env_logger = "0.11.8"
 url = "2"
 itertools = "0.14"


### PR DESCRIPTION
noticed we had a few unused dependencies - ran across a handy tool [`cargo-udeps`](https://github.com/est31/cargo-udeps) to help out