### PR TITLE
docs: add RFC process documentation and template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
 # How to contribute to Delta Kernel Rust
 
-Welcome!  We'd love to have you contribute to Delta Kernel Rust!
+Welcome! We’d love to have you contribute to Delta Kernel Rust!
 
 ## Did you find a bug?
 
-Create an issue with a reproducible example.  Please specify the Rust version, delta-kernel-rs version, the code executed, and the error message.
+Create an issue with a reproducible example. Please specify the Rust version, delta-kernel-rs version, the code executed, and the error message.
 
 ## Did you create a PR to fix a bug?
 
@@ -14,12 +14,33 @@ We appreciate bug fixes - thank you in advance!
 
 ## Would you like to add a new feature or change existing code?
 
-If you would like to add a feature or change existing behavior, please make sure to create an issue and get the planned work approved by the core team first!
+**Let’s chat first!**  
+If you would like to add a feature or change existing behavior, please create an issue describing your idea. The core team will help discuss the design, explore alternatives, and align on the direction before any code is written.
 
-Always better to get aligned with the core devs before writing any code.
+For **substantial features or major changes**, we may ask you to draft a brief design proposal (an RFC) before implementation starts. This helps us:
+
+- Avoid duplicate or misaligned work
+- Explore the design space together
+- Document key decisions for the future
+- Build a shared understanding in the community
+
+Don’t worry—RFCs don’t need to be formal or long! Just outline the motivation, your approach, and any alternatives you considered. We’ll guide you through the process.
+
+👉 **WIP: See our [RFC template](../protocol_rfcs/000-template.md) for guidance.**
+
+For **small enhancements and bug fixes**, feel free to open a PR directly (but opening an issue first is always welcome if you’re unsure).
 
 ## Do you have questions about the source code?
 
-Feel free to create an issue or join the [Delta Lake Slack](https://go.delta.io/slack) with questions!  We chat in the `#delta-kernel` channel.
+Feel free to create an issue or join the [Delta Lake Slack](https://go.delta.io/slack) with questions! We chat in the `#delta-kernel` channel.
 
 Thanks for reading! :heart: :crab:
+
+---
+
+**Summary of our contribution process:**
+- **Bugs and small fixes:** PRs welcome!
+- **New features/major changes:** Start with an issue and discussion. For bigger ideas, we’ll work together on a lightweight RFC before coding.
+- **Questions?** Issues and Slack are open to all.
+
+We’re excited to build Delta Kernel Rust together!

--- a/protocol_rfcs/000-template.md
+++ b/protocol_rfcs/000-template.md
@@ -1,0 +1,44 @@
+# RFC: [Descriptive Title]
+
+- **Author(s):** [Your Name(s)]
+- **Created:** [YYYY-MM-DD]
+- **Discussion:** [Link to related issue or discussion]
+- **Status:** Draft | In Review | Accepted | Rejected | Implemented
+
+---
+
+## Summary
+
+Briefly describe the proposed change or feature. What problem does it solve? Why is it important?
+
+## Motivation
+
+Explain why this change is needed. What use cases or requirements does it address? Who will benefit?
+
+## Detailed Proposal
+
+Describe the proposed solution in detail. Include:
+- API changes (if any)
+- Data model changes (if any)
+- Example usage
+- Implementation plan (optional)
+
+## Alternatives Considered
+
+List other approaches you considered and explain why you chose this one.
+
+## Drawbacks
+
+What are the potential downsides or risks of this proposal?
+
+## Prior Art
+
+Are there similar features or designs in other projects or ecosystems?
+
+## Unresolved Questions
+
+List any open questions or areas that need further discussion.
+
+## Future Possibilities
+
+Are there follow-up ideas or extensions that could build on this RFC?

--- a/protocol_rfcs/README.md
+++ b/protocol_rfcs/README.md
@@ -1,0 +1,51 @@
+# Delta Kernel Rust RFCs
+
+Welcome to the Delta Kernel Rust RFC (Request for Comments) process!
+
+The RFC process helps us:
+- Collaboratively design and discuss substantial changes before implementation
+- Explore alternatives and document decisions
+- Ensure new features align with the project’s goals
+
+## When should I write an RFC?
+
+- For **substantial features** or **major design changes**
+- When you want feedback on a big idea before starting implementation
+- If a maintainer asks you to draft an RFC after an initial discussion
+
+For **small bug fixes** or **minor enhancements**, you usually don’t need an RFC—just open a PR!
+
+## How do I submit an RFC?
+
+1. **Start a discussion:**  
+   Open an issue or join a conversation in [Delta Lake Slack](https://go.delta.io/slack) (`#delta-kernel`) to share your idea and get early feedback.
+
+2. **Write your RFC:**  
+   Copy [`000-template.md`](./000-template.md) to a new file named `NNN-descriptive-title.md` (where NNN is the next available number).
+
+3. **Open a Pull Request:**  
+   Submit your RFC as a pull request to the `protocol_rfcs` directory. Link to any related issues or discussions.
+
+4. **Collaborate:**  
+   The community and maintainers will discuss, suggest changes, and iterate on the RFC.
+
+5. **Decision:**  
+   Once consensus is reached, the RFC will be marked as **Accepted** (or **Rejected**). Accepted RFCs can then be implemented via standard PRs.
+
+## RFC Status
+
+- **Draft:** Initial proposal, open for discussion
+- **In Review:** Under active review by maintainers/community
+- **Accepted:** Approved and ready for implementation
+- **Rejected:** Not moving forward (with rationale)
+- **Implemented:** Feature has been merged
+
+## Tips for writing a great RFC
+
+- Be concise but thorough—focus on motivation, design, and alternatives.
+- Link to related issues, discussions, or prior art.
+- Don’t worry about perfection—the process is collaborative!
+
+---
+
+We’re excited to hear your ideas and work together to make Delta Kernel Rust even better!


### PR DESCRIPTION
This PR introduces a formal RFC (Request for Comments) process to Delta Kernel Rust to help us collaboratively design and discuss substantial features or major changes before implementation. 

**Summary of changes:**
- **`protocol_rfcs/README.md`**: Explains the RFC process, when to use it, and how RFCs are reviewed and accepted.
- **`protocol_rfcs/000-template.md`**: Provides a template for contributors to draft new RFCs.
- **Update to `CONTRIBUTING.md`**: Adds a link to the RFC process and template, making it easy for contributors to discover and use.

I’m selfishly introducing this because I’d like to contribute some larger features and want to make sure there’s a clear, collaborative process for doing so. We may not want to introduce this process just yet, I'm putting it here as a reference and to start a discussion. Feedback and suggestions are very welcome!
