### PR TITLE
chore: Test code uses Expr shorthand for Expression

### DIFF
--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -12,6 +12,8 @@ use crate::schema::{ArrayType, StructField, StructType};
 use crate::DataType as DeltaDataTypes;
 use crate::EvaluationHandlerExtension as _;
 
+use Expression as Expr;
+
 #[test]
 fn test_array_column() {
     let values = Int32Array::from(vec![0, 1, 2, 3, 4, 5, 6, 7, 8]);
@@ -24,9 +26,9 @@ fn test_array_column() {
     let array = ListArray::new(field.clone(), offsets, Arc::new(values), None);
     let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array.clone())]).unwrap();
 
-    let not_op = Expression::binary(BinaryOperator::NotIn, 5, column_expr!("item"));
+    let not_op = Expr::binary(BinaryOperator::NotIn, 5, column_expr!("item"));
 
-    let in_op = Expression::binary(BinaryOperator::In, 5, column_expr!("item"));
+    let in_op = Expr::binary(BinaryOperator::In, 5, column_expr!("item"));
 
     let result = evaluate_expression(&not_op, &batch, None).unwrap();
     let expected = BooleanArray::from(vec![true, false, true]);
@@ -44,7 +46,7 @@ fn test_bad_right_type_array() {
     let schema = Schema::new([field.clone()]);
     let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(values.clone())]).unwrap();
 
-    let in_op = Expression::binary(BinaryOperator::NotIn, 5, column_expr!("item"));
+    let in_op = Expr::binary(BinaryOperator::NotIn, 5, column_expr!("item"));
 
     let in_result = evaluate_expression(&in_op, &batch, None);
 
@@ -61,7 +63,7 @@ fn test_literal_type_array() {
     let schema = Schema::new([field.clone()]);
     let batch = RecordBatch::new_empty(Arc::new(schema));
 
-    let in_op = Expression::binary(
+    let in_op = Expr::binary(
         BinaryOperator::NotIn,
         5,
         Scalar::Array(ArrayData::new(
@@ -87,7 +89,7 @@ fn test_invalid_array_sides() {
     let array = ListArray::new(field.clone(), offsets, Arc::new(values), None);
     let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array.clone())]).unwrap();
 
-    let in_op = Expression::binary(
+    let in_op = Expr::binary(
         BinaryOperator::NotIn,
         column_expr!("item"),
         column_expr!("item"),
@@ -114,9 +116,9 @@ fn test_str_arrays() {
     let array = ListArray::new(field.clone(), offsets, Arc::new(values), None);
     let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array.clone())]).unwrap();
 
-    let str_not_op = Expression::binary(BinaryOperator::NotIn, "bye", column_expr!("item"));
+    let str_not_op = Expr::binary(BinaryOperator::NotIn, "bye", column_expr!("item"));
 
-    let str_in_op = Expression::binary(BinaryOperator::In, "hi", column_expr!("item"));
+    let str_in_op = Expr::binary(BinaryOperator::In, "hi", column_expr!("item"));
 
     let result = evaluate_expression(&str_in_op, &batch, None).unwrap();
     let expected = BooleanArray::from(vec![true, true, true]);
@@ -274,25 +276,25 @@ fn test_logical() {
     let column_a = column_expr!("a");
     let column_b = column_expr!("b");
 
-    let expression = Expression::and(column_a.clone(), column_b.clone());
+    let expression = Expr::and(column_a.clone(), column_b.clone());
     let results =
         evaluate_expression(&expression, &batch, Some(&crate::schema::DataType::BOOLEAN)).unwrap();
     let expected = Arc::new(BooleanArray::from(vec![false, false]));
     assert_eq!(results.as_ref(), expected.as_ref());
 
-    let expression = Expression::and(column_a.clone(), true);
+    let expression = Expr::and(column_a.clone(), true);
     let results =
         evaluate_expression(&expression, &batch, Some(&crate::schema::DataType::BOOLEAN)).unwrap();
     let expected = Arc::new(BooleanArray::from(vec![true, false]));
     assert_eq!(results.as_ref(), expected.as_ref());
 
-    let expression = Expression::or(column_a.clone(), column_b);
+    let expression = Expr::or(column_a.clone(), column_b);
     let results =
         evaluate_expression(&expression, &batch, Some(&crate::schema::DataType::BOOLEAN)).unwrap();
     let expected = Arc::new(BooleanArray::from(vec![true, true]));
     assert_eq!(results.as_ref(), expected.as_ref());
 
-    let expression = Expression::or(column_a.clone(), false);
+    let expression = Expr::or(column_a.clone(), false);
     let results =
         evaluate_expression(&expression, &batch, Some(&crate::schema::DataType::BOOLEAN)).unwrap();
     let expected = Arc::new(BooleanArray::from(vec![true, false]));

--- a/kernel/src/expressions/literal_expression_transform.rs
+++ b/kernel/src/expressions/literal_expression_transform.rs
@@ -191,11 +191,13 @@ mod tests {
 
     use paste::paste;
 
+    use Expression as Expr;
+
     // helper to take values/schema to pass to `create_one` and assert the result = expected
     fn assert_single_row_transform(
         values: &[Scalar],
         schema: SchemaRef,
-        expected: Result<Expression, ()>,
+        expected: Result<Expr, ()>,
     ) {
         let mut schema_transform = LiteralExpressionTransform::new(values);
         let datatype = schema.into();
@@ -221,15 +223,14 @@ mod tests {
             "col_1",
             DeltaDataTypes::INTEGER,
         )]));
-        let expected = Expression::null_literal(schema.clone().into());
+        let expected = Expr::null_literal(schema.clone().into());
         assert_single_row_transform(values, schema, Ok(expected));
 
         let schema = Arc::new(StructType::new([StructField::nullable(
             "col_1",
             DeltaDataTypes::INTEGER,
         )]));
-        let expected =
-            Expression::struct_from(vec![Expression::null_literal(DeltaDataTypes::INTEGER)]);
+        let expected = Expr::struct_from(vec![Expr::null_literal(DeltaDataTypes::INTEGER)]);
         assert_single_row_transform(values, schema, Ok(expected));
     }
 
@@ -283,9 +284,9 @@ mod tests {
                 ]),
             ),
         ]));
-        let expected = Expression::struct_from(vec![
-            Expression::struct_from(vec![Expression::literal(1), Expression::literal(2)]),
-            Expression::struct_from(vec![Expression::literal(3), Expression::literal(4)]),
+        let expected = Expr::struct_from(vec![
+            Expr::struct_from(vec![Expr::literal(1), Expr::literal(2)]),
+            Expr::struct_from(vec![Expr::literal(3), Expr::literal(4)]),
         ]);
         assert_single_row_transform(values, schema, Ok(expected));
     }
@@ -327,16 +328,16 @@ mod tests {
 
         let expected_result = match expected {
             Expected::Noop => {
-                let nested_struct = Expression::struct_from(vec![
-                    Expression::literal(values[0].clone()),
-                    Expression::literal(values[1].clone()),
+                let nested_struct = Expr::struct_from(vec![
+                    Expr::literal(values[0].clone()),
+                    Expr::literal(values[1].clone()),
                 ]);
-                Ok(Expression::struct_from([nested_struct]))
+                Ok(Expr::struct_from([nested_struct]))
             }
-            Expected::Null => Ok(Expression::null_literal(schema.clone().into())),
+            Expected::Null => Ok(Expr::null_literal(schema.clone().into())),
             Expected::NullStruct => {
-                let nested_null = Expression::null_literal(field_x.data_type().clone());
-                Ok(Expression::struct_from([nested_null]))
+                let nested_null = Expr::null_literal(field_x.data_type().clone());
+                Ok(Expr::struct_from([nested_null]))
             }
             Expected::Error => Err(()),
         };

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -504,7 +504,7 @@ mod tests {
     use std::f32::consts::PI;
 
     use crate::expressions::{column_expr, BinaryOperator};
-    use crate::Expression;
+    use crate::Expression as Expr;
 
     use super::*;
 
@@ -596,10 +596,10 @@ mod tests {
         });
 
         let column = column_expr!("item");
-        let array_op = Expression::binary(BinaryOperator::In, 10, array.clone());
-        let array_not_op = Expression::binary(BinaryOperator::NotIn, 10, array);
-        let column_op = Expression::binary(BinaryOperator::In, PI, column.clone());
-        let column_not_op = Expression::binary(BinaryOperator::NotIn, "Cool", column);
+        let array_op = Expr::binary(BinaryOperator::In, 10, array.clone());
+        let array_not_op = Expr::binary(BinaryOperator::NotIn, 10, array);
+        let column_op = Expr::binary(BinaryOperator::In, PI, column.clone());
+        let column_not_op = Expr::binary(BinaryOperator::NotIn, "Cool", column);
         assert_eq!(&format!("{}", array_op), "10 IN (1, 2, 3)");
         assert_eq!(&format!("{}", array_not_op), "10 NOT IN (1, 2, 3)");
         assert_eq!(&format!("{}", column_op), "3.1415927 IN Column(item)");

--- a/kernel/src/kernel_predicates/tests.rs
+++ b/kernel/src/kernel_predicates/tests.rs
@@ -311,8 +311,8 @@ fn test_eval_junction() {
             .iter()
             .cloned()
             .map(|v| match v {
-                Some(v) => Expression::literal(v),
-                None => Expression::null_literal(DataType::BOOLEAN),
+                Some(v) => Expr::literal(v),
+                None => Expr::null_literal(DataType::BOOLEAN),
             })
             .collect();
         for inverted in [true, false] {
@@ -389,7 +389,7 @@ fn test_eval_is_null() {
         "x IS NULL"
     );
 
-    let expr = Expression::literal(1);
+    let expr = Expr::literal(1);
     expect_eq!(
         filter.eval_unary(IsNull, &expr, true),
         Some(true),
@@ -468,7 +468,7 @@ fn test_eval_distinct() {
 #[test]
 fn eval_binary() {
     let col = column_expr!("x");
-    let val = Expression::literal(10);
+    let val = Expr::literal(10);
     let filter = DefaultKernelPredicateEvaluator::from(Scalar::from(1));
 
     // unsupported

--- a/kernel/src/kernel_predicates/tests.rs
+++ b/kernel/src/kernel_predicates/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::expressions::{column_expr, column_name, ArrayData, Expression, StructData};
+use crate::expressions::{column_expr, column_name, ArrayData, StructData};
 use crate::schema::ArrayType;
 use crate::DataType;
 

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -407,7 +407,7 @@ mod tests {
         run_with_validate_callback,
     };
     use crate::scan::{get_state_info, Scan};
-    use crate::Expression;
+    use crate::Expression as Expr;
     use crate::{
         engine::sync::SyncEngine,
         schema::{DataType, SchemaRef, StructField, StructType},
@@ -502,17 +502,17 @@ mod tests {
 
         fn validate_transform(transform: Option<&ExpressionRef>, expected_date_offset: i32) {
             assert!(transform.is_some());
-            let Expression::Struct(inner) = transform.unwrap().as_ref() else {
+            let Expr::Struct(inner) = transform.unwrap().as_ref() else {
                 panic!("Transform should always be a struct expr");
             };
             assert_eq!(inner.len(), 2, "expected two items in transform struct");
 
-            let Expression::Column(ref name) = inner[0] else {
+            let Expr::Column(ref name) = inner[0] else {
                 panic!("Expected first expression to be a column");
             };
             assert_eq!(name, &column_name!("value"), "First col should be 'value'");
 
-            let Expression::Literal(ref scalar) = inner[1] else {
+            let Expr::Literal(ref scalar) = inner[1] else {
                 panic!("Expected second expression to be a literal");
             };
             assert_eq!(

--- a/kernel/src/table_changes/physical_to_logical.rs
+++ b/kernel/src/table_changes/physical_to_logical.rs
@@ -81,7 +81,7 @@ pub(crate) fn scan_file_physical_schema(
 mod tests {
     use std::collections::HashMap;
 
-    use crate::expressions::{column_expr, Expression, Scalar};
+    use crate::expressions::{column_expr, Expression as Expr, Scalar};
     use crate::scan::ColumnType;
     use crate::schema::{DataType, StructField, StructType};
     use crate::table_changes::physical_to_logical::physical_to_logical_expr;
@@ -119,18 +119,18 @@ mod tests {
             ];
             let phys_to_logical_expr =
                 physical_to_logical_expr(&scan_file, &logical_schema, &all_fields).unwrap();
-            let expected_expr = Expression::struct_from([
+            let expected_expr = Expr::struct_from([
                 column_expr!("id"),
                 Scalar::Long(20).into(),
                 expected_expr,
-                Expression::literal(42i64),
+                Expr::literal(42i64),
                 Scalar::TimestampNtz(1234000).into(), // Microsecond is 1000x millisecond
             ]);
 
             assert_eq!(phys_to_logical_expr, expected_expr)
         };
 
-        let cdc_change_type = Expression::column([CHANGE_TYPE_COL_NAME]);
+        let cdc_change_type = Expr::column([CHANGE_TYPE_COL_NAME]);
         test(CdfScanFileType::Add, ADD_CHANGE_TYPE.into());
         test(CdfScanFileType::Remove, REMOVE_CHANGE_TYPE.into());
         test(CdfScanFileType::Cdc, cdc_change_type);

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -8,7 +8,7 @@ use delta_kernel::arrow::datatypes::SchemaRef as ArrowSchemaRef;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::engine::default::executor::tokio::TokioBackgroundExecutor;
 use delta_kernel::engine::default::DefaultEngine;
-use delta_kernel::expressions::{column_expr, BinaryOperator, Expression, ExpressionRef};
+use delta_kernel::expressions::{column_expr, BinaryOperator, Expression as Expr, ExpressionRef};
 use delta_kernel::parquet::file::properties::{EnabledStatistics, WriterProperties};
 use delta_kernel::scan::state::{transform_to_logical, DvInfo, Stats};
 use delta_kernel::scan::Scan;
@@ -287,7 +287,7 @@ async fn stats() -> Result<(), Box<dyn std::error::Error>> {
         (NotEqual, 8, vec![&batch2, &batch1]),
     ];
     for (op, value, expected_batches) in test_cases {
-        let predicate = Expression::binary(op, column_expr!("id"), value);
+        let predicate = Expr::binary(op, column_expr!("id"), value);
         let scan = snapshot
             .clone()
             .scan_builder()
@@ -691,7 +691,7 @@ fn predicate_on_letter_and_number() -> Result<(), Box<dyn std::error::Error>> {
 
     let cases = vec![
         (
-            Expression::or(
+            Expr::or(
                 // No pruning power
                 column_expr!("letter").gt("a"),
                 column_expr!("number").gt(3i64),
@@ -699,16 +699,16 @@ fn predicate_on_letter_and_number() -> Result<(), Box<dyn std::error::Error>> {
             full_table,
         ),
         (
-            Expression::and(
+            Expr::and(
                 column_expr!("letter").gt("a"),  // numbers 2, 3, 5
                 column_expr!("number").gt(3i64), // letters a, e
             ),
             table_for_letters(&['e']),
         ),
         (
-            Expression::and(
+            Expr::and(
                 column_expr!("letter").gt("a"), // numbers 2, 3, 5
-                Expression::or(
+                Expr::or(
                     // No pruning power
                     column_expr!("letter").eq("c"),
                     column_expr!("number").eq(3i64),
@@ -733,27 +733,27 @@ fn predicate_on_letter_and_number() -> Result<(), Box<dyn std::error::Error>> {
 fn predicate_on_number_not() -> Result<(), Box<dyn std::error::Error>> {
     let cases = vec![
         (
-            Expression::not(column_expr!("number").lt(4i64)),
+            Expr::not(column_expr!("number").lt(4i64)),
             table_for_numbers(vec![4, 5, 6]),
         ),
         (
-            Expression::not(column_expr!("number").le(4i64)),
+            Expr::not(column_expr!("number").le(4i64)),
             table_for_numbers(vec![5, 6]),
         ),
         (
-            Expression::not(column_expr!("number").gt(4i64)),
+            Expr::not(column_expr!("number").gt(4i64)),
             table_for_numbers(vec![1, 2, 3, 4]),
         ),
         (
-            Expression::not(column_expr!("number").ge(4i64)),
+            Expr::not(column_expr!("number").ge(4i64)),
             table_for_numbers(vec![1, 2, 3]),
         ),
         (
-            Expression::not(column_expr!("number").eq(4i64)),
+            Expr::not(column_expr!("number").eq(4i64)),
             table_for_numbers(vec![1, 2, 3, 5, 6]),
         ),
         (
-            Expression::not(column_expr!("number").ne(4i64)),
+            Expr::not(column_expr!("number").ne(4i64)),
             table_for_numbers(vec![4]),
         ),
     ];
@@ -781,9 +781,9 @@ fn predicate_on_number_with_not_null() -> Result<(), Box<dyn std::error::Error>>
     read_table_data_str(
         "./tests/data/basic_partitioned",
         Some(&["a_float", "number"]),
-        Some(Expression::and(
+        Some(Expr::and(
             column_expr!("number").is_not_null(),
-            column_expr!("number").lt(Expression::literal(3i64)),
+            column_expr!("number").lt(Expr::literal(3i64)),
         )),
         expected,
     )?;
@@ -860,30 +860,30 @@ fn mixed_not_null() -> Result<(), Box<dyn std::error::Error>> {
 fn and_or_predicates() -> Result<(), Box<dyn std::error::Error>> {
     let cases = vec![
         (
-            Expression::and(
+            Expr::and(
                 column_expr!("number").gt(4i64),
                 column_expr!("a_float").gt(5.5),
             ),
             table_for_numbers(vec![6]),
         ),
         (
-            Expression::and(
+            Expr::and(
                 column_expr!("number").gt(4i64),
-                Expression::not(column_expr!("a_float").gt(5.5)),
+                Expr::not(column_expr!("a_float").gt(5.5)),
             ),
             table_for_numbers(vec![5]),
         ),
         (
-            Expression::or(
+            Expr::or(
                 column_expr!("number").gt(4i64),
                 column_expr!("a_float").gt(5.5),
             ),
             table_for_numbers(vec![5, 6]),
         ),
         (
-            Expression::or(
+            Expr::or(
                 column_expr!("number").gt(4i64),
-                Expression::not(column_expr!("a_float").gt(5.5)),
+                Expr::not(column_expr!("a_float").gt(5.5)),
             ),
             table_for_numbers(vec![1, 2, 3, 4, 5, 6]),
         ),
@@ -903,30 +903,30 @@ fn and_or_predicates() -> Result<(), Box<dyn std::error::Error>> {
 fn not_and_or_predicates() -> Result<(), Box<dyn std::error::Error>> {
     let cases = vec![
         (
-            Expression::not(Expression::and(
+            Expr::not(Expr::and(
                 column_expr!("number").gt(4i64),
                 column_expr!("a_float").gt(5.5),
             )),
             table_for_numbers(vec![1, 2, 3, 4, 5]),
         ),
         (
-            Expression::not(Expression::and(
+            Expr::not(Expr::and(
                 column_expr!("number").gt(4i64),
-                Expression::not(column_expr!("a_float").gt(5.5)),
+                Expr::not(column_expr!("a_float").gt(5.5)),
             )),
             table_for_numbers(vec![1, 2, 3, 4, 6]),
         ),
         (
-            Expression::not(Expression::or(
+            Expr::not(Expr::or(
                 column_expr!("number").gt(4i64),
                 column_expr!("a_float").gt(5.5),
             )),
             table_for_numbers(vec![1, 2, 3, 4]),
         ),
         (
-            Expression::not(Expression::or(
+            Expr::not(Expr::or(
                 column_expr!("number").gt(4i64),
-                Expression::not(column_expr!("a_float").gt(5.5)),
+                Expr::not(column_expr!("a_float").gt(5.5)),
             )),
             vec![],
         ),
@@ -944,19 +944,19 @@ fn not_and_or_predicates() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn invalid_skips_none_predicates() -> Result<(), Box<dyn std::error::Error>> {
-    let empty_struct = Expression::struct_from(vec![]);
+    let empty_struct = Expr::struct_from(vec![]);
     let cases = vec![
-        (Expression::literal(false), table_for_numbers(vec![])),
+        (Expr::literal(false), table_for_numbers(vec![])),
         (
-            Expression::and(column_expr!("number"), false),
+            Expr::and(column_expr!("number"), false),
             table_for_numbers(vec![]),
         ),
         (
-            Expression::literal(true),
+            Expr::literal(true),
             table_for_numbers(vec![1, 2, 3, 4, 5, 6]),
         ),
         (
-            Expression::literal(3i64),
+            Expr::literal(3i64),
             table_for_numbers(vec![1, 2, 3, 4, 5, 6]),
         ),
         (
@@ -964,17 +964,15 @@ fn invalid_skips_none_predicates() -> Result<(), Box<dyn std::error::Error>> {
             table_for_numbers(vec![1, 2, 4, 5, 6]),
         ),
         (
-            column_expr!("number").distinct(Expression::null_literal(DataType::LONG)),
+            column_expr!("number").distinct(Expr::null_literal(DataType::LONG)),
             table_for_numbers(vec![1, 2, 3, 4, 5, 6]),
         ),
         (
-            Expression::not(column_expr!("number").distinct(3i64)),
+            Expr::not(column_expr!("number").distinct(3i64)),
             table_for_numbers(vec![3]),
         ),
         (
-            Expression::not(
-                column_expr!("number").distinct(Expression::null_literal(DataType::LONG)),
-            ),
+            Expr::not(column_expr!("number").distinct(Expr::null_literal(DataType::LONG))),
             table_for_numbers(vec![]),
         ),
         (
@@ -982,7 +980,7 @@ fn invalid_skips_none_predicates() -> Result<(), Box<dyn std::error::Error>> {
             table_for_numbers(vec![1, 2, 3, 4, 5, 6]),
         ),
         (
-            Expression::not(column_expr!("number").gt(empty_struct.clone())),
+            Expr::not(column_expr!("number").gt(empty_struct.clone())),
             table_for_numbers(vec![1, 2, 3, 4, 5, 6]),
         ),
     ];
@@ -1016,7 +1014,7 @@ fn with_predicate_and_removes() -> Result<(), Box<dyn std::error::Error>> {
     read_table_data_str(
         "./tests/data/table-with-dv-small/",
         None,
-        Some(Expression::gt(column_expr!("value"), 3)),
+        Some(Expr::gt(column_expr!("value"), 3)),
         expected,
     )?;
     Ok(())
@@ -1059,7 +1057,7 @@ async fn predicate_on_non_nullable_partition_column() -> Result<(), Box<dyn std:
     ));
     let snapshot = Arc::new(table.snapshot(engine.as_ref(), None)?);
 
-    let predicate = Expression::eq(column_expr!("id"), 2);
+    let predicate = Expr::eq(column_expr!("id"), 2);
     let scan = snapshot
         .scan_builder()
         .with_predicate(Arc::new(predicate))
@@ -1122,7 +1120,7 @@ async fn predicate_on_non_nullable_column_missing_stats() -> Result<(), Box<dyn 
     ));
     let snapshot = Arc::new(table.snapshot(engine.as_ref(), None)?);
 
-    let predicate = Expression::eq(column_expr!("val"), "g");
+    let predicate = Expr::eq(column_expr!("val"), "g");
     let scan = snapshot
         .scan_builder()
         .with_predicate(Arc::new(predicate))

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -422,7 +422,7 @@ fn read_with_scan_metadata(
 fn read_table_data(
     path: &str,
     select_cols: Option<&[&str]>,
-    predicate: Option<Expression>,
+    predicate: Option<Expr>,
     mut expected: Vec<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let path = std::fs::canonicalize(PathBuf::from(path))?;
@@ -465,7 +465,7 @@ fn read_table_data(
 fn read_table_data_str(
     path: &str,
     select_cols: Option<&[&str]>,
-    predicate: Option<Expression>,
+    predicate: Option<Expr>,
     expected: Vec<&str>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     read_table_data(


### PR DESCRIPTION
## What changes are proposed in this pull request?

Improve readability of some test code by using `Expr` instead of `Expression`. Most tests already did this.

## How was this change tested?

Symbol name change, compilation suffices.