### PR TITLE
refactor!: Make literal expressions more strict

### DIFF
--- a/ffi/src/expressions/engine.rs
+++ b/ffi/src/expressions/engine.rs
@@ -178,7 +178,7 @@ fn visit_expression_literal_string_impl(
     state: &mut KernelExpressionVisitorState,
     value: DeltaResult<String>,
 ) -> DeltaResult<usize> {
-    Ok(wrap_expression(state, value?))
+    Ok(wrap_expression(state, Expression::literal(value?)))
 }
 
 // We need to get parse.expand working to be able to macro everything below, see issue #255
@@ -188,7 +188,7 @@ pub extern "C" fn visit_expression_literal_int(
     state: &mut KernelExpressionVisitorState,
     value: i32,
 ) -> usize {
-    wrap_expression(state, value)
+    wrap_expression(state, Expression::literal(value))
 }
 
 #[no_mangle]
@@ -196,7 +196,7 @@ pub extern "C" fn visit_expression_literal_long(
     state: &mut KernelExpressionVisitorState,
     value: i64,
 ) -> usize {
-    wrap_expression(state, value)
+    wrap_expression(state, Expression::literal(value))
 }
 
 #[no_mangle]
@@ -204,7 +204,7 @@ pub extern "C" fn visit_expression_literal_short(
     state: &mut KernelExpressionVisitorState,
     value: i16,
 ) -> usize {
-    wrap_expression(state, value)
+    wrap_expression(state, Expression::literal(value))
 }
 
 #[no_mangle]
@@ -212,7 +212,7 @@ pub extern "C" fn visit_expression_literal_byte(
     state: &mut KernelExpressionVisitorState,
     value: i8,
 ) -> usize {
-    wrap_expression(state, value)
+    wrap_expression(state, Expression::literal(value))
 }
 
 #[no_mangle]
@@ -220,7 +220,7 @@ pub extern "C" fn visit_expression_literal_float(
     state: &mut KernelExpressionVisitorState,
     value: f32,
 ) -> usize {
-    wrap_expression(state, value)
+    wrap_expression(state, Expression::literal(value))
 }
 
 #[no_mangle]
@@ -228,7 +228,7 @@ pub extern "C" fn visit_expression_literal_double(
     state: &mut KernelExpressionVisitorState,
     value: f64,
 ) -> usize {
-    wrap_expression(state, value)
+    wrap_expression(state, Expression::literal(value))
 }
 
 #[no_mangle]
@@ -236,5 +236,5 @@ pub extern "C" fn visit_expression_literal_bool(
     state: &mut KernelExpressionVisitorState,
     value: bool,
 ) -> usize {
-    wrap_expression(state, value)
+    wrap_expression(state, Expression::literal(value))
 }

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -26,9 +26,13 @@ fn test_array_column() {
     let array = ListArray::new(field.clone(), offsets, Arc::new(values), None);
     let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array.clone())]).unwrap();
 
-    let not_op = Expr::binary(BinaryOperator::NotIn, 5, column_expr!("item"));
+    let not_op = Expr::binary(
+        BinaryOperator::NotIn,
+        Expr::literal(5),
+        column_expr!("item"),
+    );
 
-    let in_op = Expr::binary(BinaryOperator::In, 5, column_expr!("item"));
+    let in_op = Expr::binary(BinaryOperator::In, Expr::literal(5), column_expr!("item"));
 
     let result = evaluate_expression(&not_op, &batch, None).unwrap();
     let expected = BooleanArray::from(vec![true, false, true]);
@@ -46,7 +50,11 @@ fn test_bad_right_type_array() {
     let schema = Schema::new([field.clone()]);
     let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(values.clone())]).unwrap();
 
-    let in_op = Expr::binary(BinaryOperator::NotIn, 5, column_expr!("item"));
+    let in_op = Expr::binary(
+        BinaryOperator::NotIn,
+        Expr::literal(5),
+        column_expr!("item"),
+    );
 
     let in_result = evaluate_expression(&in_op, &batch, None);
 
@@ -65,7 +73,7 @@ fn test_literal_type_array() {
 
     let in_op = Expr::binary(
         BinaryOperator::NotIn,
-        5,
+        Expr::literal(5),
         Scalar::Array(ArrayData::new(
             ArrayType::new(DeltaDataTypes::INTEGER, false),
             vec![Scalar::Integer(1), Scalar::Integer(2)],
@@ -116,9 +124,17 @@ fn test_str_arrays() {
     let array = ListArray::new(field.clone(), offsets, Arc::new(values), None);
     let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array.clone())]).unwrap();
 
-    let str_not_op = Expr::binary(BinaryOperator::NotIn, "bye", column_expr!("item"));
+    let str_not_op = Expr::binary(
+        BinaryOperator::NotIn,
+        Expr::literal("bye"),
+        column_expr!("item"),
+    );
 
-    let str_in_op = Expr::binary(BinaryOperator::In, "hi", column_expr!("item"));
+    let str_in_op = Expr::binary(
+        BinaryOperator::In,
+        Expr::literal("hi"),
+        column_expr!("item"),
+    );
 
     let result = evaluate_expression(&str_in_op, &batch, None).unwrap();
     let expected = BooleanArray::from(vec![true, true, true]);
@@ -168,23 +184,23 @@ fn test_binary_op_scalar() {
     let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(values)]).unwrap();
     let column = column_expr!("a");
 
-    let expression = column.clone().add(1);
+    let expression = column.clone().add(Expr::literal(1));
     let results = evaluate_expression(&expression, &batch, None).unwrap();
     let expected = Arc::new(Int32Array::from(vec![2, 3, 4]));
     assert_eq!(results.as_ref(), expected.as_ref());
 
-    let expression = column.clone().sub(1);
+    let expression = column.clone().sub(Expr::literal(1));
     let results = evaluate_expression(&expression, &batch, None).unwrap();
     let expected = Arc::new(Int32Array::from(vec![0, 1, 2]));
     assert_eq!(results.as_ref(), expected.as_ref());
 
-    let expression = column.clone().mul(2);
+    let expression = column.clone().mul(Expr::literal(2));
     let results = evaluate_expression(&expression, &batch, None).unwrap();
     let expected = Arc::new(Int32Array::from(vec![2, 4, 6]));
     assert_eq!(results.as_ref(), expected.as_ref());
 
     // TODO handle type casting
-    let expression = column.div(1);
+    let expression = column.div(Expr::literal(1));
     let results = evaluate_expression(&expression, &batch, None).unwrap();
     let expected = Arc::new(Int32Array::from(vec![1, 2, 3]));
     assert_eq!(results.as_ref(), expected.as_ref())
@@ -228,32 +244,32 @@ fn test_binary_cmp() {
     let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(values)]).unwrap();
     let column = column_expr!("a");
 
-    let expression = column.clone().lt(2);
+    let expression = column.clone().lt(Expr::literal(2));
     let results = evaluate_expression(&expression, &batch, None).unwrap();
     let expected = Arc::new(BooleanArray::from(vec![true, false, false]));
     assert_eq!(results.as_ref(), expected.as_ref());
 
-    let expression = column.clone().lt_eq(2);
+    let expression = column.clone().lt_eq(Expr::literal(2));
     let results = evaluate_expression(&expression, &batch, None).unwrap();
     let expected = Arc::new(BooleanArray::from(vec![true, true, false]));
     assert_eq!(results.as_ref(), expected.as_ref());
 
-    let expression = column.clone().gt(2);
+    let expression = column.clone().gt(Expr::literal(2));
     let results = evaluate_expression(&expression, &batch, None).unwrap();
     let expected = Arc::new(BooleanArray::from(vec![false, false, true]));
     assert_eq!(results.as_ref(), expected.as_ref());
 
-    let expression = column.clone().gt_eq(2);
+    let expression = column.clone().gt_eq(Expr::literal(2));
     let results = evaluate_expression(&expression, &batch, None).unwrap();
     let expected = Arc::new(BooleanArray::from(vec![false, true, true]));
     assert_eq!(results.as_ref(), expected.as_ref());
 
-    let expression = column.clone().eq(2);
+    let expression = column.clone().eq(Expr::literal(2));
     let results = evaluate_expression(&expression, &batch, None).unwrap();
     let expected = Arc::new(BooleanArray::from(vec![false, true, false]));
     assert_eq!(results.as_ref(), expected.as_ref());
 
-    let expression = column.clone().ne(2);
+    let expression = column.clone().ne(Expr::literal(2));
     let results = evaluate_expression(&expression, &batch, None).unwrap();
     let expected = Arc::new(BooleanArray::from(vec![true, false, true]));
     assert_eq!(results.as_ref(), expected.as_ref());
@@ -282,7 +298,7 @@ fn test_logical() {
     let expected = Arc::new(BooleanArray::from(vec![false, false]));
     assert_eq!(results.as_ref(), expected.as_ref());
 
-    let expression = Expr::and(column_a.clone(), true);
+    let expression = Expr::and(column_a.clone(), Expr::literal(true));
     let results =
         evaluate_expression(&expression, &batch, Some(&crate::schema::DataType::BOOLEAN)).unwrap();
     let expected = Arc::new(BooleanArray::from(vec![true, false]));
@@ -294,7 +310,7 @@ fn test_logical() {
     let expected = Arc::new(BooleanArray::from(vec![true, true]));
     assert_eq!(results.as_ref(), expected.as_ref());
 
-    let expression = Expr::or(column_a.clone(), false);
+    let expression = Expr::or(column_a.clone(), Expr::literal(false));
     let results =
         evaluate_expression(&expression, &batch, Some(&crate::schema::DataType::BOOLEAN)).unwrap();
     let expected = Arc::new(BooleanArray::from(vec![true, false]));

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -193,8 +193,8 @@ pub enum Expression {
     // TODO: support more expressions, such as IS IN, LIKE, etc.
 }
 
-impl<T: Into<Scalar>> From<T> for Expression {
-    fn from(value: T) -> Self {
+impl From<Scalar> for Expression {
+    fn from(value: Scalar) -> Self {
         Self::literal(value)
     }
 }
@@ -688,26 +688,38 @@ mod tests {
         let col_ref = column_expr!("x");
         let cases = [
             (col_ref.clone(), "Column(x)"),
-            (col_ref.clone().eq(2), "Column(x) = 2"),
-            ((col_ref.clone() - 4).lt(10), "Column(x) - 4 < 10"),
-            ((col_ref.clone() + 4) / 10 * 42, "Column(x) + 4 / 10 * 42"),
+            (col_ref.clone().eq(Expr::literal(2)), "Column(x) = 2"),
             (
-                Expr::and(col_ref.clone().gt_eq(2), col_ref.clone().lt_eq(10)),
+                (col_ref.clone() - Expr::literal(4)).lt(Expr::literal(10)),
+                "Column(x) - 4 < 10",
+            ),
+            (
+                (col_ref.clone() + Expr::literal(4)) / Expr::literal(10) * Expr::literal(42),
+                "Column(x) + 4 / 10 * 42",
+            ),
+            (
+                Expr::and(
+                    col_ref.clone().gt_eq(Expr::literal(2)),
+                    col_ref.clone().lt_eq(Expr::literal(10)),
+                ),
                 "AND(Column(x) >= 2, Column(x) <= 10)",
             ),
             (
                 Expr::and_from([
-                    col_ref.clone().gt_eq(2),
-                    col_ref.clone().lt_eq(10),
-                    col_ref.clone().lt_eq(100),
+                    col_ref.clone().gt_eq(Expr::literal(2)),
+                    col_ref.clone().lt_eq(Expr::literal(10)),
+                    col_ref.clone().lt_eq(Expr::literal(100)),
                 ]),
                 "AND(Column(x) >= 2, Column(x) <= 10, Column(x) <= 100)",
             ),
             (
-                Expr::or(col_ref.clone().gt(2), col_ref.clone().lt(10)),
+                Expr::or(
+                    col_ref.clone().gt(Expr::literal(2)),
+                    col_ref.clone().lt(Expr::literal(10)),
+                ),
                 "OR(Column(x) > 2, Column(x) < 10)",
             ),
-            (col_ref.eq("foo"), "Column(x) = 'foo'"),
+            (col_ref.eq(Expr::literal("foo")), "Column(x) = 'foo'"),
         ];
 
         for (expr, expected) in cases {

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -596,10 +596,10 @@ mod tests {
         });
 
         let column = column_expr!("item");
-        let array_op = Expr::binary(BinaryOperator::In, 10, array.clone());
-        let array_not_op = Expr::binary(BinaryOperator::NotIn, 10, array);
-        let column_op = Expr::binary(BinaryOperator::In, PI, column.clone());
-        let column_not_op = Expr::binary(BinaryOperator::NotIn, "Cool", column);
+        let array_op = Expr::binary(BinaryOperator::In, Expr::literal(10), array.clone());
+        let array_not_op = Expr::binary(BinaryOperator::NotIn, Expr::literal(10), array);
+        let column_op = Expr::binary(BinaryOperator::In, Expr::literal(PI), column.clone());
+        let column_not_op = Expr::binary(BinaryOperator::NotIn, Expr::literal("Cool"), column);
         assert_eq!(&format!("{}", array_op), "10 IN (1, 2, 3)");
         assert_eq!(&format!("{}", array_not_op), "10 NOT IN (1, 2, 3)");
         assert_eq!(&format!("{}", column_op), "3.1415927 IN Column(item)");

--- a/kernel/src/kernel_predicates/parquet_stats_skipping/tests.rs
+++ b/kernel/src/kernel_predicates/parquet_stats_skipping/tests.rs
@@ -161,12 +161,12 @@ fn test_eval_binary_comparisons() {
     const NULL_VAL: Scalar = Scalar::Null(DataType::INTEGER);
 
     let expressions = [
-        Expr::lt(column_expr!("x"), 10),
-        Expr::le(column_expr!("x"), 10),
-        Expr::eq(column_expr!("x"), 10),
-        Expr::ne(column_expr!("x"), 10),
-        Expr::gt(column_expr!("x"), 10),
-        Expr::ge(column_expr!("x"), 10),
+        Expr::lt(column_expr!("x"), Expr::literal(10)),
+        Expr::le(column_expr!("x"), Expr::literal(10)),
+        Expr::eq(column_expr!("x"), Expr::literal(10)),
+        Expr::ne(column_expr!("x"), Expr::literal(10)),
+        Expr::gt(column_expr!("x"), Expr::literal(10)),
+        Expr::ge(column_expr!("x"), Expr::literal(10)),
     ];
 
     let do_test = |min: Scalar, max: Scalar, expected: &[Option<bool>]| {

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -70,7 +70,7 @@ impl DataSkippingFilter {
         });
         static STATS_EXPR: LazyLock<Expr> = LazyLock::new(|| column_expr!("add.stats"));
         static FILTER_EXPR: LazyLock<Expr> =
-            LazyLock::new(|| column_expr!("predicate").distinct(false));
+            LazyLock::new(|| column_expr!("predicate").distinct(Expr::literal(false)));
 
         let (predicate, referenced_schema) = physical_predicate?;
         debug!("Creating a data skipping filter for {:#?}", predicate);

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -849,12 +849,12 @@ mod tests {
             (true, Expr::literal(false)),
             (false, Expr::literal(true)),
             (true, NULL),
-            (true, Expr::and(column_expr!("a"), false)),
-            (false, Expr::or(column_expr!("a"), true)),
-            (false, Expr::or(column_expr!("a"), false)),
-            (false, Expr::lt(column_expr!("a"), 10)),
-            (false, Expr::lt(Expr::literal(10), 100)),
-            (true, Expr::gt(Expr::literal(10), 100)),
+            (true, Expr::and(column_expr!("a"), Expr::literal(false))),
+            (false, Expr::or(column_expr!("a"), Expr::literal(true))),
+            (false, Expr::or(column_expr!("a"), Expr::literal(false))),
+            (false, Expr::lt(column_expr!("a"), Expr::literal(10))),
+            (false, Expr::lt(Expr::literal(10), Expr::literal(100))),
+            (true, Expr::gt(Expr::literal(10), Expr::literal(100))),
             (true, Expr::and(NULL, column_expr!("a"))),
         ];
         for (should_skip, predicate) in test_cases {
@@ -974,9 +974,9 @@ mod tests {
                 )),
             ),
             (
-                Expr::and(column_expr!("mapped.n"), true),
+                Expr::and(column_expr!("mapped.n"), Expr::literal(true)),
                 Some(PhysicalPredicate::Some(
-                    Expr::and(column_expr!("phys_mapped.phys_n"), true).into(),
+                    Expr::and(column_expr!("phys_mapped.phys_n"), Expr::literal(true)).into(),
                     StructType::new(vec![StructField::nullable(
                         "phys_mapped",
                         StructType::new(vec![StructField::nullable("phys_n", DataType::LONG)
@@ -993,7 +993,7 @@ mod tests {
                 )),
             ),
             (
-                Expr::and(column_expr!("mapped.n"), false),
+                Expr::and(column_expr!("mapped.n"), Expr::literal(false)),
                 Some(PhysicalPredicate::StaticSkipAll),
             ),
         ];
@@ -1184,7 +1184,7 @@ mod tests {
         //
         // WARNING: https://github.com/delta-io/delta-kernel-rs/issues/434 - This
         // optimization is currently disabled, so the one data file is still returned.
-        let predicate = Arc::new(column_expr!("missing").lt(1000i64));
+        let predicate = Arc::new(column_expr!("missing").lt(Expr::literal(1000i64)));
         let scan = snapshot
             .clone()
             .scan_builder()
@@ -1195,7 +1195,7 @@ mod tests {
         assert_eq!(data.len(), 1);
 
         // Predicate over a logically missing column fails the scan
-        let predicate = Arc::new(column_expr!("numeric.ints.invalid").lt(1000));
+        let predicate = Arc::new(column_expr!("numeric.ints.invalid").lt(Expr::literal(1000)));
         snapshot
             .scan_builder()
             .with_predicate(predicate)

--- a/kernel/src/table_changes/physical_to_logical.rs
+++ b/kernel/src/table_changes/physical_to_logical.rs
@@ -19,8 +19,8 @@ fn get_cdf_columns(scan_file: &CdfScanFile) -> DeltaResult<HashMap<&str, Express
     let version = scan_file.commit_version;
     let change_type: Expression = match scan_file.scan_type {
         CdfScanFileType::Cdc => Expression::column([CHANGE_TYPE_COL_NAME]),
-        CdfScanFileType::Add => ADD_CHANGE_TYPE.into(),
-        CdfScanFileType::Remove => REMOVE_CHANGE_TYPE.into(),
+        CdfScanFileType::Add => Expression::literal(ADD_CHANGE_TYPE),
+        CdfScanFileType::Remove => Expression::literal(REMOVE_CHANGE_TYPE),
     };
     let expressions = [
         (CHANGE_TYPE_COL_NAME, change_type),
@@ -131,8 +131,8 @@ mod tests {
         };
 
         let cdc_change_type = Expr::column([CHANGE_TYPE_COL_NAME]);
-        test(CdfScanFileType::Add, ADD_CHANGE_TYPE.into());
-        test(CdfScanFileType::Remove, REMOVE_CHANGE_TYPE.into());
+        test(CdfScanFileType::Add, Expr::literal(ADD_CHANGE_TYPE));
+        test(CdfScanFileType::Remove, Expr::literal(REMOVE_CHANGE_TYPE));
         test(CdfScanFileType::Cdc, cdc_change_type);
     }
 }

--- a/kernel/src/table_changes/scan_file.rs
+++ b/kernel/src/table_changes/scan_file.rs
@@ -230,8 +230,8 @@ pub(crate) fn cdf_scan_row_expression(commit_timestamp: i64, commit_number: i64)
             column_expr!("cdc.path"),
             Expression::struct_from([column_expr!("cdc.partitionValues")]),
         ]),
-        commit_timestamp.into(),
-        commit_number.into(),
+        Expression::literal(commit_timestamp),
+        Expression::literal(commit_number),
     ])
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

The existing `impl<T: Into<Scalar>> From<T> for Expression` was too liberal and implicit, making code harder to read and making it harder to determine where ordinary values like `10` or `"hi"` were treated as expression literals. Replace that with `impl From<Scalar> for Expression` instead, and update call sites to use `Expression::literal` as needed.

### This PR affects the following public APIs

Removed a trait impl for pub type `Expression`. 

## How was this change tested?

Existing unit tests