### PR TITLE
chore: Arrow DefaultExpressionEvaluator need not box its inner expression

### DIFF
--- a/kernel/src/engine/arrow_expression/mod.rs
+++ b/kernel/src/engine/arrow_expression/mod.rs
@@ -134,7 +134,7 @@ impl EvaluationHandler for ArrowEvaluationHandler {
     ) -> Arc<dyn ExpressionEvaluator> {
         Arc::new(DefaultExpressionEvaluator {
             input_schema: schema,
-            expression: Box::new(expression),
+            expression,
             output_type,
         })
     }
@@ -156,16 +156,13 @@ impl EvaluationHandler for ArrowEvaluationHandler {
 #[derive(Debug)]
 pub struct DefaultExpressionEvaluator {
     input_schema: SchemaRef,
-    expression: Box<Expression>,
+    expression: Expression,
     output_type: DataType,
 }
 
 impl ExpressionEvaluator for DefaultExpressionEvaluator {
     fn evaluate(&self, batch: &dyn EngineData) -> DeltaResult<Box<dyn EngineData>> {
-        debug!(
-            "Arrow evaluator evaluating: {:#?}",
-            self.expression.as_ref()
-        );
+        debug!("Arrow evaluator evaluating: {:#?}", self.expression);
         let batch = batch
             .any_ref()
             .downcast_ref::<ArrowEngineData>()

--- a/kernel/src/engine/default/mod.rs
+++ b/kernel/src/engine/default/mod.rs
@@ -38,7 +38,7 @@ pub struct DefaultEngine<E: TaskExecutor> {
     storage: Arc<ObjectStoreStorageHandler<E>>,
     json: Arc<DefaultJsonHandler<E>>,
     parquet: Arc<DefaultParquetHandler<E>>,
-    expression: Arc<ArrowEvaluationHandler>,
+    evaluation: Arc<ArrowEvaluationHandler>,
 }
 
 impl<E: TaskExecutor> DefaultEngine<E> {
@@ -84,7 +84,7 @@ impl<E: TaskExecutor> DefaultEngine<E> {
                 task_executor,
             )),
             object_store,
-            expression: Arc::new(ArrowEvaluationHandler {}),
+            evaluation: Arc::new(ArrowEvaluationHandler {}),
         }
     }
 
@@ -121,7 +121,7 @@ impl<E: TaskExecutor> DefaultEngine<E> {
 
 impl<E: TaskExecutor> Engine for DefaultEngine<E> {
     fn evaluation_handler(&self) -> Arc<dyn EvaluationHandler> {
-        self.expression.clone()
+        self.evaluation.clone()
     }
 
     fn storage_handler(&self) -> Arc<dyn StorageHandler> {


### PR DESCRIPTION
## What changes are proposed in this pull request?

See title.

## How was this change tested?

Compilation suffices.