### PR TITLE
refactor!: Remove nearly-unused expression lt_eq/gt_eq overloads

### DIFF
--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -249,7 +249,7 @@ fn test_binary_cmp() {
     let expected = Arc::new(BooleanArray::from(vec![true, false, false]));
     assert_eq!(results.as_ref(), expected.as_ref());
 
-    let expression = column.clone().lt_eq(Expr::literal(2));
+    let expression = column.clone().le(Expr::literal(2));
     let results = evaluate_expression(&expression, &batch, None).unwrap();
     let expected = Arc::new(BooleanArray::from(vec![true, true, false]));
     assert_eq!(results.as_ref(), expected.as_ref());
@@ -259,7 +259,7 @@ fn test_binary_cmp() {
     let expected = Arc::new(BooleanArray::from(vec![false, false, true]));
     assert_eq!(results.as_ref(), expected.as_ref());
 
-    let expression = column.clone().gt_eq(Expr::literal(2));
+    let expression = column.clone().ge(Expr::literal(2));
     let results = evaluate_expression(&expression, &batch, None).unwrap();
     let expected = Arc::new(BooleanArray::from(vec![false, true, true]));
     assert_eq!(results.as_ref(), expected.as_ref());

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -349,16 +349,6 @@ impl Expression {
         Self::binary(BinaryOperator::GreaterThan, self, other)
     }
 
-    /// Create a new expression `self >= other`
-    pub fn gt_eq(self, other: impl Into<Self>) -> Self {
-        Self::binary(BinaryOperator::GreaterThanOrEqual, self, other)
-    }
-
-    /// Create a new expression `self <= other`
-    pub fn lt_eq(self, other: impl Into<Self>) -> Self {
-        Self::binary(BinaryOperator::LessThanOrEqual, self, other)
-    }
-
     /// Create a new expression `self AND other`
     pub fn and(a: impl Into<Self>, b: impl Into<Self>) -> Self {
         Self::and_from([a.into(), b.into()])
@@ -699,16 +689,16 @@ mod tests {
             ),
             (
                 Expr::and(
-                    col_ref.clone().gt_eq(Expr::literal(2)),
-                    col_ref.clone().lt_eq(Expr::literal(10)),
+                    col_ref.clone().ge(Expr::literal(2)),
+                    col_ref.clone().le(Expr::literal(10)),
                 ),
                 "AND(Column(x) >= 2, Column(x) <= 10)",
             ),
             (
                 Expr::and_from([
-                    col_ref.clone().gt_eq(Expr::literal(2)),
-                    col_ref.clone().lt_eq(Expr::literal(10)),
-                    col_ref.clone().lt_eq(Expr::literal(100)),
+                    col_ref.clone().ge(Expr::literal(2)),
+                    col_ref.clone().le(Expr::literal(10)),
+                    col_ref.clone().le(Expr::literal(100)),
                 ]),
                 "AND(Column(x) >= 2, Column(x) <= 10, Column(x) <= 100)",
             ),


### PR DESCRIPTION
## What changes are proposed in this pull request?

The `lt_eq` and `gt_eq` methods of `Expression` are nearly-unused, with just a few call sites in test code. Remove them in favor of the more rustic [`le`](https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html#method.le) and [`ge`](https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html#method.ge) methods that they alias.

### This PR affects the following public APIs

Removed public methods from `impl Expression`

## How was this change tested?

Compilation suffices.