### PR TITLE
refactor!: Code movement in expression-related code

### DIFF
--- a/kernel/src/kernel_predicates/parquet_stats_skipping.rs
+++ b/kernel/src/kernel_predicates/parquet_stats_skipping.rs
@@ -60,12 +60,12 @@ impl<T: ParquetStatsProvider> DataSkippingPredicateEvaluator for T {
         KernelPredicateEvaluatorDefaults::partial_cmp_scalars(ord, &col, val, inverted)
     }
 
-    fn eval_scalar_is_null(&self, val: &Scalar, inverted: bool) -> Option<bool> {
-        KernelPredicateEvaluatorDefaults::eval_scalar_is_null(val, inverted)
-    }
-
     fn eval_scalar(&self, val: &Scalar, inverted: bool) -> Option<bool> {
         KernelPredicateEvaluatorDefaults::eval_scalar(val, inverted)
+    }
+
+    fn eval_scalar_is_null(&self, val: &Scalar, inverted: bool) -> Option<bool> {
+        KernelPredicateEvaluatorDefaults::eval_scalar_is_null(val, inverted)
     }
 
     fn eval_is_null(&self, col: &ColumnName, inverted: bool) -> Option<bool> {

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -239,12 +239,12 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator {
         Some(Expr::binary(op, col, val.clone()))
     }
 
-    fn eval_scalar_is_null(&self, val: &Scalar, inverted: bool) -> Option<Expr> {
-        KernelPredicateEvaluatorDefaults::eval_scalar_is_null(val, inverted).map(Expr::literal)
-    }
-
     fn eval_scalar(&self, val: &Scalar, inverted: bool) -> Option<Expr> {
         KernelPredicateEvaluatorDefaults::eval_scalar(val, inverted).map(Expr::literal)
+    }
+
+    fn eval_scalar_is_null(&self, val: &Scalar, inverted: bool) -> Option<Expr> {
+        KernelPredicateEvaluatorDefaults::eval_scalar_is_null(val, inverted).map(Expr::literal)
     }
 
     fn eval_is_null(&self, col: &ColumnName, inverted: bool) -> Option<Expr> {


### PR DESCRIPTION
## What changes are proposed in this pull request?

The expressions module is pretty big, shuffling some code around to organize it better.

## This PR affects the following public APIs

Reordered variants of the `BinaryExpressionOp` enum. Code that casts the variants `as isize` could notice.

## How was this change tested?

Pure code movement, compilation suffices.
