### PR TITLE
feat: support maps and arrays in literal_expression_transform

### DIFF
--- a/kernel/src/expressions/literal_expression_transform.rs
+++ b/kernel/src/expressions/literal_expression_transform.rs
@@ -88,7 +88,7 @@ macro_rules! transform_leaf {
             return None;
         };
 
-        // NOTE: Grab a reference here so code below can leverage the blanket Deref impl for &T
+        // NOTE: Grab a reference here so code below can leverage the blanket impl<T> Deref for &T
         let $type_variant(ref scalar_type) = scalar.data_type() else {
             $self.set_error(Error::Schema(format!(
                 "Mismatched scalar type while creating Expression: expected {}({:?}), got {:?}",
@@ -99,7 +99,7 @@ macro_rules! transform_leaf {
             return None;
         };
 
-        // NOTE: &T and &Box<T> both deref-coerce to &T
+        // NOTE: &T and &Box<T> both deref to &T
         if scalar_type.deref() != $type {
             $self.set_error(Error::Schema(format!(
                 "Mismatched scalar type while creating Expression: expected {:?}, got {:?}",

--- a/kernel/src/expressions/literal_expression_transform.rs
+++ b/kernel/src/expressions/literal_expression_transform.rs
@@ -228,11 +228,13 @@ mod tests {
 
     use paste::paste;
 
+    use Expression as Expr;
+
     // helper to take values/schema to pass to `create_one` and assert the result = expected
     fn assert_single_row_transform(
         values: &[Scalar],
         schema: SchemaRef,
-        expected: Result<Expression, ()>,
+        expected: Result<Expr, ()>,
     ) {
         let mut schema_transform = LiteralExpressionTransform::new(values);
         let datatype = schema.into();
@@ -258,15 +260,14 @@ mod tests {
             "col_1",
             DeltaDataTypes::INTEGER,
         )]));
-        let expected = Expression::null_literal(schema.clone().into());
+        let expected = Expr::null_literal(schema.clone().into());
         assert_single_row_transform(values, schema, Ok(expected));
 
         let schema = Arc::new(StructType::new([StructField::nullable(
             "col_1",
             DeltaDataTypes::INTEGER,
         )]));
-        let expected =
-            Expression::struct_from(vec![Expression::null_literal(DeltaDataTypes::INTEGER)]);
+        let expected = Expr::struct_from(vec![Expr::null_literal(DeltaDataTypes::INTEGER)]);
         assert_single_row_transform(values, schema, Ok(expected));
     }
 
@@ -320,9 +321,9 @@ mod tests {
                 ]),
             ),
         ]));
-        let expected = Expression::struct_from(vec![
-            Expression::struct_from(vec![Expression::literal(1), Expression::literal(2)]),
-            Expression::struct_from(vec![Expression::literal(3), Expression::literal(4)]),
+        let expected = Expr::struct_from(vec![
+            Expr::struct_from(vec![Expr::literal(1), Expr::literal(2)]),
+            Expr::struct_from(vec![Expr::literal(3), Expr::literal(4)]),
         ]);
         assert_single_row_transform(values, schema, Ok(expected));
     }
@@ -341,9 +342,9 @@ mod tests {
             StructField::nullable("map", DeltaDataTypes::Map(Box::new(map_type))),
             StructField::nullable("array", DeltaDataTypes::Array(Box::new(array_type))),
         ]));
-        let expected = Expression::struct_from(vec![
-            Expression::literal(Scalar::Map(map_data)),
-            Expression::literal(Scalar::Array(array_data)),
+        let expected = Expr::struct_from(vec![
+            Expr::literal(Scalar::Map(map_data)),
+            Expr::literal(Scalar::Array(array_data)),
         ]);
         assert_single_row_transform(values, schema, Ok(expected));
     }
@@ -385,16 +386,16 @@ mod tests {
 
         let expected_result = match expected {
             Expected::Noop => {
-                let nested_struct = Expression::struct_from(vec![
-                    Expression::literal(values[0].clone()),
-                    Expression::literal(values[1].clone()),
+                let nested_struct = Expr::struct_from(vec![
+                    Expr::literal(values[0].clone()),
+                    Expr::literal(values[1].clone()),
                 ]);
-                Ok(Expression::struct_from([nested_struct]))
+                Ok(Expr::struct_from([nested_struct]))
             }
-            Expected::Null => Ok(Expression::null_literal(schema.clone().into())),
+            Expected::Null => Ok(Expr::null_literal(schema.clone().into())),
             Expected::NullStruct => {
-                let nested_null = Expression::null_literal(field_x.data_type().clone());
-                Ok(Expression::struct_from([nested_null]))
+                let nested_null = Expr::null_literal(field_x.data_type().clone());
+                Ok(Expr::struct_from([nested_null]))
             }
             Expected::Error => Err(()),
         };


### PR DESCRIPTION
## What changes are proposed in this pull request?
~stacked on #881~

Adds support for maps and arrays (just treated as leaves) in literal_expression_transform.


## How was this change tested?
new UT