### PR TITLE
feat!: Add in-commit timestamp table feature

### DIFF
--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -90,6 +90,8 @@ pub enum WriterFeature {
     ColumnMapping,
     /// ID Columns
     IdentityColumns,
+    /// Monotonically increasing timestamps in the CommitInfo
+    InCommitTimestamp,
     /// Deletion vectors for merge, update, delete
     DeletionVectors,
     /// Row tracking on tables
@@ -244,6 +246,7 @@ mod tests {
             (WriterFeature::GeneratedColumns, "generatedColumns"),
             (WriterFeature::ColumnMapping, "columnMapping"),
             (WriterFeature::IdentityColumns, "identityColumns"),
+            (WriterFeature::InCommitTimestamp, "inCommitTimestamp"),
             (WriterFeature::DeletionVectors, "deletionVectors"),
             (WriterFeature::RowTracking, "rowTracking"),
             (WriterFeature::TimestampWithoutTimezone, "timestampNtz"),


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds checks to TableConfiguration for in-commit timestamps. The following are introduced: 
- `in_commit_timestamps_supported`: true if ICT is supported
- `in_commit_timestamps_enabled`: true if ICT is enabled
- `in_commit_timestamp_enablement`: Gets enablement version and timestamp

## Breaking changes
This adds a WriterFeature, making it a breaking change.

## How was this change tested?
Check the following cases:
- Supported but not enabled
- Supported and enabled, but is missing the enablement timestamp
- Fully supported and Enabled.