### PR TITLE
feat: Add high level api for timestamp conversion

### DIFF
--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -225,6 +225,10 @@ pub enum Error {
     /// Validation error for file statistics (e.g., missing required clustering column stats)
     #[error("Stats validation error: {0}")]
     StatsValidation(String),
+
+    /// Error during log history operations (timestamp queries, version lookups)
+    #[error(transparent)]
+    LogHistory(#[from] Box<crate::history_manager::error::LogHistoryError>),
 }
 
 // Convenience constructors for Error types that take a String argument

--- a/kernel/src/history_manager/error.rs
+++ b/kernel/src/history_manager/error.rs
@@ -1,3 +1,6 @@
+// Low-level timestamp conversion internals. Made public in a later PR.
+#![allow(unused)]
+
 //! Error types for the history manager module.
 
 use super::Timestamp;

--- a/kernel/src/history_manager/error.rs
+++ b/kernel/src/history_manager/error.rs
@@ -62,7 +62,6 @@ impl LogHistoryError {
     }
 
     /// Creates an internal error with just a context message.
-    #[allow(unused)]
     pub(crate) fn internal_message(context: &'static str) -> Self {
         Self::Internal {
             context,

--- a/kernel/src/history_manager/error.rs
+++ b/kernel/src/history_manager/error.rs
@@ -55,6 +55,7 @@ pub enum LogHistoryError {
 
 impl LogHistoryError {
     /// Creates an internal error with context describing the failed operation.
+    #[allow(unused)]
     pub(crate) fn internal(context: &'static str, source: crate::Error) -> Self {
         Self::Internal {
             context,

--- a/kernel/src/history_manager/error.rs
+++ b/kernel/src/history_manager/error.rs
@@ -1,6 +1,3 @@
-// Low-level timestamp conversion internals. Made public in a later PR.
-#![allow(unused)]
-
 //! Error types for the history manager module.
 
 use super::Timestamp;

--- a/kernel/src/history_manager/error.rs
+++ b/kernel/src/history_manager/error.rs
@@ -1,0 +1,70 @@
+//! Error types for the history manager module.
+
+use super::search::Bound;
+use super::Timestamp;
+use crate::Version;
+
+/// Represents errors that can occur when converting commit timestamps to versions.
+#[derive(Debug, thiserror::Error)]
+pub enum LogHistoryError {
+    /// The provided timestamp range is invalid (start > end).
+    #[error("Invalid timestamp range: ({start_timestamp}, {end_timestamp})")]
+    InvalidTimestampRange {
+        /// The start timestamp that was greater than the end timestamp.
+        start_timestamp: Timestamp,
+        /// The end timestamp that was less than the start timestamp.
+        end_timestamp: Timestamp,
+    },
+    /// The timestamp range contains no commits - the entire range falls between two adjacent
+    /// versions.
+    #[error(
+        "There are no commits in the timestamp range ({start_timestamp}, {end_timestamp}). \
+         The entire timestamp range falls between versions {between_version} and {}.",
+        .between_version + 1
+    )]
+    EmptyTimestampRange {
+        /// The start of the empty timestamp range.
+        start_timestamp: Timestamp,
+        /// The end of the empty timestamp range.
+        end_timestamp: Timestamp,
+        /// The version immediately before the timestamp range (the next version is
+        /// `between_version + 1`).
+        between_version: Version,
+    },
+    /// The timestamp is outside the range of available commits.
+    #[error("Timestamp {timestamp} is out of range: {}", match .bound {
+        Bound::LeastUpper => "no version exists at or after this timestamp",
+        Bound::GreatestLower => "no version exists at or before this timestamp",
+    })]
+    TimestampOutOfRange {
+        /// The timestamp that was out of range.
+        timestamp: Timestamp,
+        /// The type of bound search that failed.
+        bound: Bound,
+    },
+    /// An internal error occurred during timestamp conversion.
+    #[error("{context}: {source}")]
+    Internal {
+        /// Description of the operation that failed.
+        context: &'static str,
+        /// The underlying error.
+        #[source]
+        source: Box<crate::Error>,
+    },
+}
+
+impl LogHistoryError {
+    /// Creates an internal error with context describing the failed operation.
+    pub(crate) fn internal(context: &'static str, source: crate::Error) -> Self {
+        Self::Internal {
+            context,
+            source: Box::new(source),
+        }
+    }
+}
+
+impl From<LogHistoryError> for crate::Error {
+    fn from(e: LogHistoryError) -> Self {
+        crate::Error::LogHistory(Box::new(e))
+    }
+}

--- a/kernel/src/history_manager/error.rs
+++ b/kernel/src/history_manager/error.rs
@@ -39,23 +39,31 @@ pub enum LogHistoryError {
         reason: &'static str,
     },
     /// An internal error occurred during timestamp conversion.
-    #[error("{context}: {source}")]
+    #[error("{context}{}", source.as_ref().map(|e| format!(": {e}")).unwrap_or_default())]
     Internal {
         /// Description of the operation that failed.
         context: &'static str,
-        /// The underlying error.
+        /// The underlying error, if any.
         #[source]
-        source: Box<crate::Error>,
+        source: Option<Box<crate::Error>>,
     },
 }
 
 impl LogHistoryError {
-    /// Creates an internal error with context describing the failed operation.
-    #[allow(unused)]
+    /// Creates an internal error with context and an underlying cause.
     pub(crate) fn internal(context: &'static str, source: crate::Error) -> Self {
         Self::Internal {
             context,
-            source: Box::new(source),
+            source: Some(Box::new(source)),
+        }
+    }
+
+    /// Creates an internal error with just a context message.
+    #[allow(unused)]
+    pub(crate) fn internal_message(context: &'static str) -> Self {
+        Self::Internal {
+            context,
+            source: None,
         }
     }
 }

--- a/kernel/src/history_manager/error.rs
+++ b/kernel/src/history_manager/error.rs
@@ -1,6 +1,5 @@
 //! Error types for the history manager module.
 
-use super::search::Bound;
 use super::Timestamp;
 use crate::Version;
 
@@ -32,15 +31,12 @@ pub enum LogHistoryError {
         between_version: Version,
     },
     /// The timestamp is outside the range of available commits.
-    #[error("Timestamp {timestamp} is out of range: {}", match .bound {
-        Bound::LeastUpper => "no version exists at or after this timestamp",
-        Bound::GreatestLower => "no version exists at or before this timestamp",
-    })]
+    #[error("Timestamp {timestamp} is out of range: {reason}")]
     TimestampOutOfRange {
         /// The timestamp that was out of range.
         timestamp: Timestamp,
-        /// The type of bound search that failed.
-        bound: Bound,
+        /// Description of why the timestamp is out of range.
+        reason: &'static str,
     },
     /// An internal error occurred during timestamp conversion.
     #[error("{context}: {source}")]

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -146,7 +146,10 @@ fn linear_search_file_mod_timestamps(
     bound: Bound,
 ) -> Result<Version, LogHistoryError> {
     if commits.is_empty() {
-        return Err(LogHistoryError::TimestampOutOfRange { timestamp, bound });
+        return Err(LogHistoryError::TimestampOutOfRange {
+            timestamp,
+            reason: bound.out_of_range_reason(),
+        });
     }
 
     let lo_version = commits[0].version;
@@ -179,7 +182,10 @@ fn linear_search_file_mod_timestamps(
         prev_monotonic_ts = monotonic_ts;
     }
 
-    result.ok_or(LogHistoryError::TimestampOutOfRange { timestamp, bound })
+    result.ok_or(LogHistoryError::TimestampOutOfRange {
+        timestamp,
+        reason: bound.out_of_range_reason(),
+    })
 }
 
 /// Converts a timestamp to a version based on the specified bound type.
@@ -247,7 +253,10 @@ pub(crate) fn timestamp_to_version(
         TimestampSearchBounds::ICTSearchStartingFrom(lo) => {
             let commit_range = &log_segment.listed.ascending_commit_files[lo..];
             if commit_range.is_empty() {
-                return Err(LogHistoryError::TimestampOutOfRange { timestamp, bound });
+                return Err(LogHistoryError::TimestampOutOfRange {
+                    timestamp,
+                    reason: bound.out_of_range_reason(),
+                });
             }
 
             let lo_version = commit_range.first().map(|c| c.version).unwrap_or(0);
@@ -273,9 +282,10 @@ pub(crate) fn timestamp_to_version(
                     Ok(log_segment.listed.ascending_commit_files[idx].version)
                 }
                 Err(SearchError::KeyFunctionError(error)) => Err(error),
-                Err(SearchError::OutOfRange) => {
-                    Err(LogHistoryError::TimestampOutOfRange { timestamp, bound })
-                }
+                Err(SearchError::OutOfRange) => Err(LogHistoryError::TimestampOutOfRange {
+                    timestamp,
+                    reason: bound.out_of_range_reason(),
+                }),
             }
         }
 

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -1,1 +1,616 @@
+//! This module provides functions for performing timestamp queries over the Delta Log, translating
+//! between timestamps and Delta versions.
+
+use std::cmp::Ordering;
+
+use error::LogHistoryError;
+use search::{binary_search_by_key_with_bounds, Bound, SearchError};
+use tracing::info;
+
+use crate::log_segment::LogSegment;
+use crate::path::ParsedLogPath;
+use crate::snapshot::Snapshot;
+use crate::table_configuration::InCommitTimestampEnablement;
+use crate::utils::require;
+use crate::{Engine, Error as DeltaError, Version};
+
 pub(crate) mod search;
+
+#[cfg(feature = "internal-api")]
+pub mod error;
+#[cfg(not(feature = "internal-api"))]
+pub(crate) mod error;
+
+type Timestamp = i64;
+
+#[allow(unused)]
+#[derive(Debug)]
+enum TimestampSearchBounds {
+    ExactMatch(Version),
+    ICTSearchStartingFrom(usize),
+    FileModificationSearch,
+    FileModificationSearchUntil {
+        index: usize,
+        ict_enablement_version: Version,
+    },
+}
+
+/// Given a timestamp, this function determines the commit range that timestamp conversion
+/// should search. A timestamp search may be conducted over one of two version ranges:
+///     1) A range of commits whose timestamp is the file modification timestamp
+///     2) A range of commits whose timestamp is an in-commit timestamp.
+#[allow(unused)]
+fn get_timestamp_search_bounds(
+    snapshot: &Snapshot,
+    log_segment: &LogSegment,
+    timestamp: Timestamp,
+) -> Result<TimestampSearchBounds, LogHistoryError> {
+    debug_assert!(log_segment.end_version == snapshot.version());
+    let table_config = snapshot.table_configuration();
+
+    // Get the In-commit timestamp (ICT) enablement version and timestamp. If ICT is not
+    // supported or enabled, we perform a regular file modification search.
+    let ict_enablement = table_config
+        .in_commit_timestamp_enablement()
+        .map_err(|e| LogHistoryError::internal("failed to read table configuration", e))?;
+
+    let (ict_enablement_version, ict_timestamp) = match ict_enablement {
+        InCommitTimestampEnablement::NotEnabled => {
+            return Ok(TimestampSearchBounds::FileModificationSearch)
+        }
+        InCommitTimestampEnablement::Enabled {
+            enablement: Some((v, t)),
+        } => (v, t),
+        InCommitTimestampEnablement::Enabled { enablement: None } => {
+            // ICT was enabled from table creation - all commits have ICT
+            return Ok(TimestampSearchBounds::ICTSearchStartingFrom(0));
+        }
+    };
+
+    // Get the index of the ICT enablement version in the log segment. If the version is not
+    // present, binary_search returns the insertion point (first commit at or after).
+    let commit_count = log_segment.listed.ascending_commit_files.len();
+    let ict_enablement_idx = log_segment
+        .listed
+        .ascending_commit_files
+        .binary_search_by(|x| x.version.cmp(&ict_enablement_version))
+        .unwrap_or_else(|idx| idx);
+
+    // The ICT enablement index must be within the log segment. If it equals commit_count,
+    // the ICT enablement version is beyond all commits in the segment.
+    require!(
+        ict_enablement_idx < commit_count,
+        LogHistoryError::internal(
+            "ICT enablement version beyond log segment",
+            DeltaError::generic(format!(
+                "ICT enablement version {} not in log segment (index {} >= count {})",
+                ict_enablement_version, ict_enablement_idx, commit_count
+            ))
+        )
+    );
+
+    // Based on the in-commit timestamp enablement, determine the search bounds. If the
+    // desired timestamp is in the ICT range, we must _only_ search over commits with ICT
+    // enabled. Otherwise, the timestamp range must only consist of commits that use file
+    // modification time as the timestamp.
+    let result = match timestamp.cmp(&ict_timestamp) {
+        Ordering::Equal => TimestampSearchBounds::ExactMatch(ict_enablement_version),
+        Ordering::Less => TimestampSearchBounds::FileModificationSearchUntil {
+            index: ict_enablement_idx,
+            ict_enablement_version,
+        },
+        Ordering::Greater => TimestampSearchBounds::ICTSearchStartingFrom(ict_enablement_idx),
+    };
+    Ok(result)
+}
+
+/// Converts a timestamp to a version based on the specified bound type.
+///
+/// This function finds the appropriate commit version that corresponds to the given timestamp
+/// according to the bound parameter:
+///
+/// - `Bound::GreatestLower`: Returns the version with the greatest timestamp that is less than or
+///   equal to the given timestamp (the version immediately before or at the timestamp).
+/// - `Bound::LeastUpper`: Returns the version with the smallest timestamp that is greater than or
+///   equal to the given timestamp (the version immediately at or after the timestamp).
+///
+/// # Visual Example:
+/// ```ignore
+/// versions:    v0                    v1                    v2
+///              |----------|----------|----------|----------|
+/// timestamp:              t1                    t2
+/// ```
+///
+/// # Results Table:
+/// | Timestamp | GreatestLower | LeastUpper |
+/// |-----------|---------------|------------|
+/// | t1        | v0            | v1         |
+/// | t2        | v1            | v2         |
+///
+/// # Errors
+/// Returns [`LogHistoryError::TimestampOutOfRange`] if the timestamp is out of range. This can
+/// happen in the following cases based on the bound:
+/// - `Bound::GreatestLower`: There is no commit whose timestamp is lower than the given
+///   `timestamp`.
+/// - `Bound::LeastUpper`: There is no commit whose timestamp is greater than the given `timestamp`.
+#[allow(unused)]
+pub(crate) fn timestamp_to_version(
+    snapshot: &Snapshot,
+    engine: &dyn Engine,
+    timestamp: Timestamp,
+    bound: Bound,
+) -> Result<Version, LogHistoryError> {
+    // Get log segment for timestamp conversion
+    let log_segment = LogSegment::for_timestamp_conversion(
+        engine.storage_handler().as_ref(),
+        snapshot.log_segment().log_root.clone(),
+        snapshot.version(),
+        None,
+    )
+    .map_err(|e| {
+        LogHistoryError::internal("failed to build log segment for timestamp conversion", e)
+    })?;
+    debug_assert!(
+        !log_segment.listed.ascending_commit_files.is_empty(),
+        "LogSegment should ensure that a segment is non-empty"
+    );
+    debug_assert!(log_segment.end_version == snapshot.log_segment().end_version);
+
+    let len = log_segment.listed.ascending_commit_files.len();
+
+    // Determine the type of timestamp search. The search may either be over file modification
+    // timestamps or over In-Commit Timestamps.
+    let search_bounds = get_timestamp_search_bounds(snapshot, &log_segment, timestamp)?;
+    let (lo, hi, read_ict) = match search_bounds {
+        TimestampSearchBounds::ExactMatch(version) => return Ok(version),
+        TimestampSearchBounds::ICTSearchStartingFrom(lo) => (lo, len, true),
+        TimestampSearchBounds::FileModificationSearch => (0, len, false),
+        TimestampSearchBounds::FileModificationSearchUntil { index: hi, .. } => (0, hi, false),
+    };
+
+    // If the search range is empty (lo >= hi), the timestamp is out of range. This can happen
+    // when the log has been trimmed and the query timestamp falls before the available commits.
+    if lo >= hi {
+        return Err(LogHistoryError::TimestampOutOfRange { timestamp, bound });
+    }
+
+    let lo_version = log_segment.listed.ascending_commit_files[lo].version;
+    let hi_version = log_segment.listed.ascending_commit_files[hi - 1].version;
+    info!(
+        ?search_bounds,
+        lo_version, hi_version, "Timestamp search bounds"
+    );
+
+    // We only search in the range [lo..hi).
+    let commit_range = &log_segment.listed.ascending_commit_files[lo..hi];
+
+    // Key function that extracts the timestamp from a commit.
+    let commit_to_ts = |commit: &ParsedLogPath| -> Result<Timestamp, LogHistoryError> {
+        if read_ict {
+            info!(version = commit.version, "Reading in-commit timestamp");
+            commit
+                .read_in_commit_timestamp(engine)
+                .map_err(|e| LogHistoryError::internal("failed to read in-commit timestamp", e))
+        } else {
+            Ok(commit.location.last_modified)
+        }
+    };
+
+    let search_result =
+        binary_search_by_key_with_bounds(commit_range, timestamp, commit_to_ts, bound);
+
+    match search_result {
+        Ok(relative_idx) => {
+            // `relative_idx` is for range [lo..hi]. Add back `lo` to get absolute index.
+            let idx = lo + relative_idx;
+            debug_assert!(idx < len, "Relative index should become a valid index");
+            Ok(log_segment.listed.ascending_commit_files[idx].version)
+        }
+        Err(SearchError::KeyFunctionError(error)) => Err(error),
+        // Special case: For LeastUpper search over file modification timestamps, the ICT
+        // enablement version serves as the upper bound when no version was found in range.
+        Err(SearchError::OutOfRange) => match (&search_bounds, bound) {
+            (
+                TimestampSearchBounds::FileModificationSearchUntil {
+                    ict_enablement_version,
+                    ..
+                },
+                Bound::LeastUpper,
+            ) => Ok(*ict_enablement_version),
+            _ => Err(LogHistoryError::TimestampOutOfRange { timestamp, bound }),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::fs::OpenOptions;
+    use std::sync::Arc;
+    use std::time::{Duration, SystemTime};
+
+    use test_utils::delta_path_for_version;
+    use url::Url;
+
+    use super::*;
+    use crate::actions::{CommitInfo, Metadata, Protocol};
+    use crate::engine::sync::SyncEngine;
+    use crate::schema::{DataType, SchemaRef, StructField, StructType};
+    use crate::snapshot::Snapshot;
+    use crate::table_features::TableFeature;
+    use crate::utils::test_utils::{Action, LocalMockTable};
+    use crate::Version;
+
+    // Helper to create test schema
+    fn get_test_schema() -> SchemaRef {
+        Arc::new(StructType::new_unchecked([StructField::nullable(
+            "value",
+            DataType::INTEGER,
+        )]))
+    }
+
+    // Helper to set the file modification timestamp of a file
+    fn set_mod_time(mock_table: &LocalMockTable, commit_version: Version, timestamp: Timestamp) {
+        let file_name = delta_path_for_version(commit_version, "json")
+            .filename()
+            .unwrap()
+            .to_string();
+        let path = mock_table.table_root().join("_delta_log/").join(file_name);
+        let file = OpenOptions::new().write(true).open(path).unwrap();
+
+        let time = SystemTime::UNIX_EPOCH + Duration::from_millis(timestamp.try_into().unwrap());
+        file.set_modified(time).unwrap();
+    }
+
+    async fn mock_table() -> LocalMockTable {
+        let mut mock_table = LocalMockTable::new();
+
+        // 0: Has file modification timestamp 50
+        mock_table
+            .commit([
+                Action::Metadata(
+                    Metadata::try_new(None, None, get_test_schema(), vec![], 0, HashMap::new())
+                        .unwrap(),
+                ),
+                Action::Protocol(
+                    Protocol::try_new(
+                        3,
+                        7,
+                        Some(Vec::<String>::new()),
+                        Some(vec![TableFeature::InCommitTimestamp]),
+                    )
+                    .unwrap(),
+                ),
+            ])
+            .await;
+        set_mod_time(&mock_table, 0, 50);
+
+        // 1: Has file modification timestamp 150
+        mock_table
+            .commit([Action::CommitInfo(CommitInfo {
+                ..Default::default()
+            })])
+            .await;
+        set_mod_time(&mock_table, 1, 150);
+
+        // 2: Has file modification timestamp 250
+        mock_table
+            .commit([Action::CommitInfo(CommitInfo {
+                ..Default::default()
+            })])
+            .await;
+        set_mod_time(&mock_table, 2, 250);
+
+        // 3: Has in-commit timestamp 300, file modification timestamp 350
+        mock_table
+            .commit([
+                Action::CommitInfo(CommitInfo {
+                    in_commit_timestamp: Some(300),
+                    ..Default::default()
+                }),
+                Action::Metadata(
+                    Metadata::try_new(
+                        None,
+                        None,
+                        get_test_schema(),
+                        vec![],
+                        0,
+                        HashMap::from_iter([
+                            (
+                                "delta.enableInCommitTimestamps".to_string(),
+                                "true".to_string(),
+                            ),
+                            (
+                                "delta.inCommitTimestampEnablementVersion".to_string(),
+                                "3".to_string(),
+                            ),
+                            (
+                                "delta.inCommitTimestampEnablementTimestamp".to_string(),
+                                "300".to_string(),
+                            ),
+                        ]),
+                    )
+                    .unwrap(),
+                ),
+                Action::Protocol(
+                    Protocol::try_new(
+                        3,
+                        7,
+                        Some(Vec::<String>::new()),
+                        Some(vec![TableFeature::InCommitTimestamp]),
+                    )
+                    .unwrap(),
+                ),
+            ])
+            .await;
+        set_mod_time(&mock_table, 3, 350);
+
+        // 4: Has in-commit timestamp 400, file modification timestamp 450
+        mock_table
+            .commit([Action::CommitInfo(CommitInfo {
+                in_commit_timestamp: Some(400),
+                ..Default::default()
+            })])
+            .await;
+        set_mod_time(&mock_table, 4, 450);
+
+        mock_table
+    }
+
+    #[tokio::test]
+    async fn test_timestamp_search_bounds_no_ict() {
+        let mock_table = mock_table().await;
+        let engine = SyncEngine::new();
+        let path = Url::from_directory_path(mock_table.table_root()).unwrap();
+
+        // Set the end version to a time before In-commit timestamps were enabled
+        let snapshot = Snapshot::builder_for(path)
+            .at_version(2)
+            .build(&engine)
+            .unwrap();
+        let log_segment = LogSegment::for_timestamp_conversion(
+            engine.storage_handler().as_ref(),
+            snapshot.log_segment().log_root.clone(),
+            snapshot.version(),
+            None,
+        )
+        .unwrap();
+
+        // Before all commits
+        let mut res = get_timestamp_search_bounds(&snapshot, &log_segment, 0);
+        assert!(matches!(
+            res,
+            Ok(TimestampSearchBounds::FileModificationSearch)
+        ));
+
+        // Within the timestamp range
+        res = get_timestamp_search_bounds(&snapshot, &log_segment, 100);
+        assert!(matches!(
+            res,
+            Ok(TimestampSearchBounds::FileModificationSearch)
+        ));
+
+        // After all commits
+        res = get_timestamp_search_bounds(&snapshot, &log_segment, 1000);
+        assert!(matches!(
+            res,
+            Ok(TimestampSearchBounds::FileModificationSearch)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_timestamp_search_bounds_with_ict_range() {
+        let mock_table = mock_table().await;
+        let engine = SyncEngine::new();
+        let path = Url::from_directory_path(mock_table.table_root()).unwrap();
+        let snapshot = Snapshot::builder_for(path).build(&engine).unwrap();
+        let log_segment = LogSegment::for_timestamp_conversion(
+            engine.storage_handler().as_ref(),
+            snapshot.log_segment().log_root.clone(),
+            snapshot.version(),
+            None,
+        )
+        .unwrap();
+
+        // Exact match only applies to in-commit timestamp enablement version
+        let mut res = get_timestamp_search_bounds(&snapshot, &log_segment, 50);
+        assert!(
+            matches!(
+                res,
+                Ok(TimestampSearchBounds::FileModificationSearchUntil {
+                    index: 3,
+                    ict_enablement_version: 3
+                })
+            ),
+            "{res:?}"
+        );
+
+        // Not exact match, file modification time range
+        res = get_timestamp_search_bounds(&snapshot, &log_segment, 60);
+        assert!(
+            matches!(
+                res,
+                Ok(TimestampSearchBounds::FileModificationSearchUntil {
+                    index: 3,
+                    ict_enablement_version: 3
+                })
+            ),
+            "{res:?}"
+        );
+
+        // Edge case: The last timestamp that is file modification time
+        res = get_timestamp_search_bounds(&snapshot, &log_segment, 299);
+        assert!(
+            matches!(
+                res,
+                Ok(TimestampSearchBounds::FileModificationSearchUntil {
+                    index: 3,
+                    ict_enablement_version: 3
+                })
+            ),
+            "{res:?}"
+        );
+
+        // Edge case: Timestamp is the enablement timestamp
+        res = get_timestamp_search_bounds(&snapshot, &log_segment, 300);
+        assert!(
+            matches!(res, Ok(TimestampSearchBounds::ExactMatch(3))),
+            "{res:?}"
+        );
+
+        // Edge case: The timestamp is 1 + enablement_timestamp. This returns the beginning of the
+        // in-commit timestamp index range.
+        res = get_timestamp_search_bounds(&snapshot, &log_segment, 301);
+        assert!(
+            matches!(res, Ok(TimestampSearchBounds::ICTSearchStartingFrom(3))),
+            "{res:?}"
+        );
+
+        // Timestamp is much larger than the last in-commit timestamp
+        res = get_timestamp_search_bounds(&snapshot, &log_segment, 1000);
+        assert!(
+            matches!(res, Ok(TimestampSearchBounds::ICTSearchStartingFrom(3))),
+            "{res:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_reading_in_commit_timestamp() {
+        let mock_table = mock_table().await;
+        let engine = SyncEngine::new();
+        let path = Url::from_directory_path(mock_table.table_root()).unwrap();
+        let snapshot = Snapshot::builder_for(path).build(&engine).unwrap();
+        let log_segment = LogSegment::for_timestamp_conversion(
+            engine.storage_handler().as_ref(),
+            snapshot.log_segment().log_root.clone(),
+            snapshot.version(),
+            None,
+        )
+        .unwrap();
+        let commits = log_segment.listed.ascending_commit_files;
+
+        // File that has no In-commit timestamps
+        let mut res = commits[0].read_in_commit_timestamp(&engine);
+        assert!(res.is_err(), "Expected error for file without ICT: {res:?}");
+
+        // File that doesn't exist
+        let mut fake_log_path = commits[0].clone();
+
+        let failing_path = if cfg!(windows) {
+            "C:\\phony\\path"
+        } else {
+            "/phony/path"
+        };
+
+        fake_log_path.location.location = Url::from_file_path(failing_path).unwrap();
+        res = fake_log_path.read_in_commit_timestamp(&engine);
+        assert!(
+            res.is_err(),
+            "Expected error for non-existent file: {res:?}"
+        );
+
+        // Files with In-commit timestamps
+        res = commits[3].read_in_commit_timestamp(&engine);
+        assert!(matches!(res, Ok(300)), "{res:?}");
+        res = commits[4].read_in_commit_timestamp(&engine);
+        assert!(matches!(res, Ok(400)), "{res:?}");
+    }
+
+    #[tokio::test]
+    async fn test_file_modification_conversion() {
+        let mock_table = mock_table().await;
+        let engine = SyncEngine::new();
+        let path = Url::from_directory_path(mock_table.table_root()).unwrap();
+        let snapshot = Snapshot::builder_for(path).build(&engine).unwrap();
+        let log_segment = LogSegment::for_timestamp_conversion(
+            engine.storage_handler().as_ref(),
+            snapshot.log_segment().log_root.clone(),
+            snapshot.version(),
+            None,
+        )
+        .unwrap();
+        let commits = log_segment.listed.ascending_commit_files;
+
+        // Read the file modification timestamps
+        let ts: Result<Timestamp, LogHistoryError> = Ok(commits[0].location.last_modified);
+        assert!(matches!(ts, Ok(50)));
+
+        let ts: Result<Timestamp, LogHistoryError> = Ok(commits[1].location.last_modified);
+        assert!(matches!(ts, Ok(150)));
+
+        let ts: Result<Timestamp, LogHistoryError> = Ok(commits[2].location.last_modified);
+        assert!(matches!(ts, Ok(250)));
+
+        // Read the in-commit timestamps
+        let ts = commits[3].read_in_commit_timestamp(&engine);
+        assert!(matches!(ts, Ok(300)));
+        let ts = commits[4].read_in_commit_timestamp(&engine);
+        assert!(matches!(ts, Ok(400)));
+    }
+
+    #[tokio::test]
+    async fn test_convert_timestamp_to_version() {
+        let mock_table = mock_table().await;
+        let engine = SyncEngine::new();
+        let path = Url::from_directory_path(mock_table.table_root()).unwrap();
+        let snapshot = Snapshot::builder_for(path).build(&engine).unwrap();
+
+        // Less than the lowest ICT
+        let mut res = timestamp_to_version(&snapshot, &engine, 0, Bound::LeastUpper);
+        assert!(matches!(res, Ok(0)), "{res:?}");
+
+        // Negative timestamps are allowed:
+        res = timestamp_to_version(&snapshot, &engine, -1, Bound::LeastUpper);
+        assert!(matches!(res, Ok(0)), "{res:?}");
+
+        // GreatestLower Bound on timestamp that is less than all commits fails
+        res = timestamp_to_version(&snapshot, &engine, 0, Bound::GreatestLower);
+        assert!(
+            matches!(
+                res,
+                Err(LogHistoryError::TimestampOutOfRange {
+                    timestamp: 0,
+                    bound: Bound::GreatestLower,
+                })
+            ),
+            "{res:?}"
+        );
+
+        // GreatestLower bound on timestamp that is greater than all commits succeeds
+        res = timestamp_to_version(&snapshot, &engine, 1000, Bound::GreatestLower);
+        assert!(matches!(res, Ok(4)), "{res:?}");
+
+        // LeastUpper Bound on timestamp that is greater than all commits fails
+        res = timestamp_to_version(&snapshot, &engine, 1000, Bound::LeastUpper);
+        assert!(
+            matches!(
+                res,
+                Err(LogHistoryError::TimestampOutOfRange {
+                    timestamp: 1000,
+                    bound: Bound::LeastUpper,
+                })
+            ),
+            "{res:?}"
+        );
+
+        // Edge cases: timestamp is between file modification time and in-commit timestamp
+
+        // Right after last file modification timestamp
+        res = timestamp_to_version(&snapshot, &engine, 251, Bound::LeastUpper);
+        assert!(matches!(res, Ok(3)), "{res:?}");
+        res = timestamp_to_version(&snapshot, &engine, 251, Bound::GreatestLower);
+        assert!(matches!(res, Ok(2)), "{res:?}");
+
+        // Right before first in-commit timestamp
+        res = timestamp_to_version(&snapshot, &engine, 299, Bound::LeastUpper);
+        assert!(matches!(res, Ok(3)), "{res:?}");
+        res = timestamp_to_version(&snapshot, &engine, 299, Bound::GreatestLower);
+        assert!(matches!(res, Ok(2)), "{res:?}");
+
+        // Right after first in-commit timestamp
+        res = timestamp_to_version(&snapshot, &engine, 301, Bound::GreatestLower);
+        assert!(matches!(res, Ok(3)), "{res:?}");
+        res = timestamp_to_version(&snapshot, &engine, 301, Bound::LeastUpper);
+        assert!(matches!(res, Ok(4)), "{res:?}");
+    }
+}

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -5,7 +5,7 @@ use std::cmp::Ordering;
 
 use error::LogHistoryError;
 use search::{binary_search_by_key_with_bounds, Bound, SearchError};
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::log_segment::LogSegment;
 use crate::path::ParsedLogPath;
@@ -23,14 +23,21 @@ pub(crate) mod error;
 
 type Timestamp = i64;
 
+/// Determines the search strategy for timestamp-to-version conversion based on ICT enablement.
 #[allow(unused)]
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 enum TimestampSearchBounds {
+    /// The timestamp exactly matches the ICT enablement timestamp.
     ExactMatch(Version),
+    /// Search over In-Commit Timestamps starting from the given index.
     ICTSearchStartingFrom(usize),
+    /// Search over file modification timestamps (ICT not enabled).
     FileModificationSearch,
+    /// Search over file modification timestamps up to the ICT enablement point.
     FileModificationSearchUntil {
+        /// The index in the commit list where ICT begins.
         index: usize,
+        /// The version at which ICT was enabled.
         ict_enablement_version: Version,
     },
 }
@@ -105,6 +112,63 @@ fn get_timestamp_search_bounds(
     Ok(result)
 }
 
+/// Performs a linear search over file modification timestamps with monotonization.
+///
+/// File modification timestamps are not guaranteed to be monotonically increasing due to clock
+/// skew or filesystem limitations. This function ensures correctness by monotonizing timestamps
+/// as it scans: if a commit's timestamp is less than or equal to the previous commit's timestamp,
+/// it is adjusted to `previous_timestamp + 1`.
+///
+/// # Arguments
+/// * `commits` - Slice of commits to search, ordered by version (ascending)
+/// * `timestamp` - The target timestamp to search for
+/// * `bound` - The type of bound to find (GreatestLower or LeastUpper)
+///
+/// # Returns
+/// The version matching the bound criteria, or an error if no match exists.
+#[allow(unused)]
+fn linear_search_file_mod_timestamps(
+    commits: &[ParsedLogPath],
+    timestamp: Timestamp,
+    bound: Bound,
+) -> Result<Version, LogHistoryError> {
+    if commits.is_empty() {
+        return Err(LogHistoryError::TimestampOutOfRange { timestamp, bound });
+    }
+
+    let lo_version = commits[0].version;
+    let hi_version = commits[commits.len() - 1].version;
+    info!(lo_version, hi_version, "File modification linear search");
+
+    let mut result: Option<Version> = None;
+    let mut prev_monotonic_ts = i64::MIN;
+
+    for commit in commits {
+        let raw_ts = commit.location.last_modified;
+        // Monotonize: ensure each timestamp is strictly greater than the previous
+        let monotonic_ts = raw_ts.max(prev_monotonic_ts + 1);
+        if monotonic_ts != raw_ts {
+            warn!(
+                version = commit.version,
+                raw_ts, monotonic_ts, "Adjusted non-monotonic timestamp"
+            );
+        }
+
+        match bound {
+            // GreatestLower: update result until we surpass `timestamp`
+            Bound::GreatestLower if monotonic_ts <= timestamp => result = Some(commit.version),
+            Bound::GreatestLower => break,
+            // LeastUpper: return version upon first match
+            Bound::LeastUpper if monotonic_ts >= timestamp => return Ok(commit.version),
+            Bound::LeastUpper => {}
+        }
+
+        prev_monotonic_ts = monotonic_ts;
+    }
+
+    result.ok_or(LogHistoryError::TimestampOutOfRange { timestamp, bound })
+}
+
 /// Converts a timestamp to a version based on the specified bound type.
 ///
 /// This function finds the appropriate commit version that corresponds to the given timestamp
@@ -162,63 +226,68 @@ pub(crate) fn timestamp_to_version(
     // Determine the type of timestamp search. The search may either be over file modification
     // timestamps or over In-Commit Timestamps.
     let search_bounds = get_timestamp_search_bounds(snapshot, &log_segment, timestamp)?;
-    let (lo, hi, read_ict) = match search_bounds {
-        TimestampSearchBounds::ExactMatch(version) => return Ok(version),
-        TimestampSearchBounds::ICTSearchStartingFrom(lo) => (lo, len, true),
-        TimestampSearchBounds::FileModificationSearch => (0, len, false),
-        TimestampSearchBounds::FileModificationSearchUntil { index: hi, .. } => (0, hi, false),
-    };
 
-    // If the search range is empty (lo >= hi), the timestamp is out of range. This can happen
-    // when the log has been trimmed and the query timestamp falls before the available commits.
-    if lo >= hi {
-        return Err(LogHistoryError::TimestampOutOfRange { timestamp, bound });
-    }
-    debug_assert!(lo < len, "lo index {} should be less than len {}", lo, len);
-    debug_assert!(hi <= len, "hi index {} should be at most len {}", hi, len);
+    match search_bounds {
+        TimestampSearchBounds::ExactMatch(version) => Ok(version),
 
-    let lo_version = log_segment.listed.ascending_commit_files[lo].version;
-    let hi_version = log_segment.listed.ascending_commit_files[hi - 1].version;
-    info!(lo_version, hi_version, "Searching version range");
+        // ICT search: use binary search (ICT timestamps are guaranteed monotonic by protocol)
+        TimestampSearchBounds::ICTSearchStartingFrom(lo) => {
+            let commit_range = &log_segment.listed.ascending_commit_files[lo..];
+            if commit_range.is_empty() {
+                return Err(LogHistoryError::TimestampOutOfRange { timestamp, bound });
+            }
 
-    // We only search in the range [lo..hi).
-    let commit_range = &log_segment.listed.ascending_commit_files[lo..hi];
+            let lo_version = commit_range.first().map(|c| c.version).unwrap_or(0);
+            let hi_version = commit_range.last().map(|c| c.version).unwrap_or(0);
+            info!(
+                lo_version,
+                hi_version, "ICT binary search over version range"
+            );
 
-    // Key function that extracts the timestamp from a commit.
-    let commit_to_ts = |commit: &ParsedLogPath| -> Result<Timestamp, LogHistoryError> {
-        if read_ict {
-            info!(version = commit.version, "Reading in-commit timestamp");
-            commit
-                .read_in_commit_timestamp(engine)
-                .map_err(|e| LogHistoryError::internal("failed to read in-commit timestamp", e))
-        } else {
-            Ok(commit.location.last_modified)
+            let commit_to_ict = |commit: &ParsedLogPath| -> Result<Timestamp, LogHistoryError> {
+                commit
+                    .read_in_commit_timestamp(engine)
+                    .map_err(|e| LogHistoryError::internal("failed to read in-commit timestamp", e))
+            };
+
+            let search_result =
+                binary_search_by_key_with_bounds(commit_range, timestamp, commit_to_ict, bound);
+
+            match search_result {
+                Ok(relative_idx) => {
+                    let idx = lo + relative_idx;
+                    debug_assert!(idx < len, "Index should be valid");
+                    Ok(log_segment.listed.ascending_commit_files[idx].version)
+                }
+                Err(SearchError::KeyFunctionError(error)) => Err(error),
+                Err(SearchError::OutOfRange) => {
+                    Err(LogHistoryError::TimestampOutOfRange { timestamp, bound })
+                }
+            }
         }
-    };
 
-    let search_result =
-        binary_search_by_key_with_bounds(commit_range, timestamp, commit_to_ts, bound);
-
-    match search_result {
-        Ok(relative_idx) => {
-            // `relative_idx` is for range [lo..hi]. Add back `lo` to get absolute index.
-            let idx = lo + relative_idx;
-            debug_assert!(idx < len, "Relative index should become a valid index");
-            Ok(log_segment.listed.ascending_commit_files[idx].version)
+        // File modification search: use linear scan with monotonization
+        // (file mod timestamps are NOT guaranteed monotonic due to clock skew)
+        TimestampSearchBounds::FileModificationSearch => {
+            let commits = &log_segment.listed.ascending_commit_files[..];
+            linear_search_file_mod_timestamps(commits, timestamp, bound)
         }
-        Err(SearchError::KeyFunctionError(error)) => Err(error),
-        // Special case: For LeastUpper search over file modification timestamps, the ICT
-        // enablement version serves as the upper bound when no version was found in range.
-        Err(SearchError::OutOfRange) => match (&search_bounds, bound) {
-            (
-                TimestampSearchBounds::FileModificationSearchUntil {
-                    ict_enablement_version,
-                    ..
-                },
-                Bound::LeastUpper,
-            ) => Ok(*ict_enablement_version),
-            _ => Err(LogHistoryError::TimestampOutOfRange { timestamp, bound }),
-        },
+
+        // File modification search up to ICT enablement point
+        TimestampSearchBounds::FileModificationSearchUntil {
+            index,
+            ict_enablement_version,
+        } => {
+            let commits = &log_segment.listed.ascending_commit_files[..index];
+            linear_search_file_mod_timestamps(commits, timestamp, bound).or_else(|e| {
+                // For LeastUpper, if no version found, the ICT enablement version is the answer
+                if bound == Bound::LeastUpper {
+                    Ok(ict_enablement_version)
+                } else {
+                    Err(e)
+                }
+            })
+        }
     }
 }
 
@@ -241,7 +310,6 @@ mod tests {
     use crate::utils::test_utils::{Action, LocalMockTable};
     use crate::Version;
 
-    // Helper to create test schema
     fn get_test_schema() -> SchemaRef {
         Arc::new(StructType::new_unchecked([StructField::nullable(
             "value",
@@ -249,125 +317,118 @@ mod tests {
         )]))
     }
 
-    // Helper to set the file modification timestamp of a file
-    fn set_mod_time(mock_table: &LocalMockTable, commit_version: Version, timestamp: Timestamp) {
-        let file_name = delta_path_for_version(commit_version, "json")
+    fn set_mod_time(mock_table: &LocalMockTable, version: Version, timestamp: Timestamp) {
+        let file_name = delta_path_for_version(version, "json")
             .filename()
             .unwrap()
             .to_string();
         let path = mock_table.table_root().join("_delta_log/").join(file_name);
         let file = OpenOptions::new().write(true).open(path).unwrap();
-
         let time = SystemTime::UNIX_EPOCH + Duration::from_millis(timestamp.try_into().unwrap());
         file.set_modified(time).unwrap();
     }
 
-    async fn mock_table() -> LocalMockTable {
+    /// Creates a test table with specified timestamps.
+    ///
+    /// # Arguments
+    /// * `timestamps` - List of `(file_mod_ts, Option<ict_ts>)` for each version
+    /// * `ict_enablement_version` - Version where ICT is enabled:
+    ///   - `None`: ICT never enabled (file mod only)
+    ///   - `Some(0)`: ICT enabled from creation
+    ///   - `Some(n)`: ICT enabled at version n
+    async fn mock_table_with_timestamps(
+        timestamps: &[(Timestamp, Option<Timestamp>)],
+        ict_enablement_version: Option<Version>,
+    ) -> LocalMockTable {
         let mut mock_table = LocalMockTable::new();
 
-        // 0: Has file modification timestamp 50
-        mock_table
-            .commit([
-                Action::Metadata(
-                    Metadata::try_new(None, None, get_test_schema(), vec![], 0, HashMap::new())
-                        .unwrap(),
-                ),
-                Action::Protocol(
-                    Protocol::try_new(
-                        3,
-                        7,
-                        Some(Vec::<String>::new()),
-                        Some(vec![TableFeature::InCommitTimestamp]),
-                    )
-                    .unwrap(),
-                ),
-            ])
-            .await;
-        set_mod_time(&mock_table, 0, 50);
+        for (version, (file_mod_ts, ict_ts)) in timestamps.iter().enumerate() {
+            let version = version as Version;
+            let is_first = version == 0;
+            let is_ict_enablement = ict_enablement_version == Some(version);
+            let ict_from_creation = ict_enablement_version == Some(0) && is_first;
 
-        // 1: Has file modification timestamp 150
-        mock_table
-            .commit([Action::CommitInfo(CommitInfo {
-                ..Default::default()
-            })])
-            .await;
-        set_mod_time(&mock_table, 1, 150);
+            let mut actions: Vec<Action> = vec![];
 
-        // 2: Has file modification timestamp 250
-        mock_table
-            .commit([Action::CommitInfo(CommitInfo {
-                ..Default::default()
-            })])
-            .await;
-        set_mod_time(&mock_table, 2, 250);
-
-        // 3: Has in-commit timestamp 300, file modification timestamp 350
-        mock_table
-            .commit([
-                Action::CommitInfo(CommitInfo {
-                    in_commit_timestamp: Some(300),
+            // CommitInfo with optional ICT (must be first when ICT is present)
+            if ict_ts.is_some() {
+                actions.push(Action::CommitInfo(CommitInfo {
+                    in_commit_timestamp: *ict_ts,
                     ..Default::default()
-                }),
-                Action::Metadata(
-                    Metadata::try_new(
-                        None,
-                        None,
-                        get_test_schema(),
-                        vec![],
-                        0,
-                        HashMap::from_iter([
-                            (
-                                "delta.enableInCommitTimestamps".to_string(),
-                                "true".to_string(),
-                            ),
-                            (
-                                "delta.inCommitTimestampEnablementVersion".to_string(),
-                                "3".to_string(),
-                            ),
-                            (
-                                "delta.inCommitTimestampEnablementTimestamp".to_string(),
-                                "300".to_string(),
-                            ),
-                        ]),
-                    )
-                    .unwrap(),
-                ),
-                Action::Protocol(
-                    Protocol::try_new(
-                        3,
-                        7,
-                        Some(Vec::<String>::new()),
-                        Some(vec![TableFeature::InCommitTimestamp]),
-                    )
-                    .unwrap(),
-                ),
-            ])
-            .await;
-        set_mod_time(&mock_table, 3, 350);
+                }));
+            }
 
-        // 4: Has in-commit timestamp 400, file modification timestamp 450
+            // Metadata: on first commit, or when enabling ICT
+            if is_first || is_ict_enablement {
+                let config = if ict_from_creation {
+                    // ICT enabled from creation: no enablement version/timestamp
+                    HashMap::from_iter([(
+                        "delta.enableInCommitTimestamps".to_string(),
+                        "true".to_string(),
+                    )])
+                } else if is_ict_enablement {
+                    // ICT enabled at this version
+                    HashMap::from_iter([
+                        (
+                            "delta.enableInCommitTimestamps".to_string(),
+                            "true".to_string(),
+                        ),
+                        (
+                            "delta.inCommitTimestampEnablementVersion".to_string(),
+                            version.to_string(),
+                        ),
+                        (
+                            "delta.inCommitTimestampEnablementTimestamp".to_string(),
+                            ict_ts.unwrap().to_string(),
+                        ),
+                    ])
+                } else {
+                    HashMap::new()
+                };
+                actions.push(Action::Metadata(
+                    Metadata::try_new(None, None, get_test_schema(), vec![], 0, config).unwrap(),
+                ));
+            }
+
+            // Protocol on first commit
+            if is_first {
+                let writer_features: Option<Vec<TableFeature>> = if ict_enablement_version.is_some()
+                {
+                    Some(vec![TableFeature::InCommitTimestamp])
+                } else {
+                    Some(vec![])
+                };
+                actions.push(Action::Protocol(
+                    Protocol::try_new(3, 7, Some(Vec::<String>::new()), writer_features).unwrap(),
+                ));
+            }
+
+            // If no actions yet (non-first commit without ICT), add empty CommitInfo
+            if actions.is_empty() {
+                actions.push(Action::CommitInfo(CommitInfo::default()));
+            }
+
+            mock_table.commit(actions).await;
+            set_mod_time(&mock_table, version, *file_mod_ts);
+        }
+
         mock_table
-            .commit([Action::CommitInfo(CommitInfo {
-                in_commit_timestamp: Some(400),
-                ..Default::default()
-            })])
-            .await;
-        set_mod_time(&mock_table, 4, 450);
-
-        mock_table
     }
 
-    #[tokio::test]
-    async fn test_timestamp_search_bounds_no_ict() {
-        let mock_table = mock_table().await;
+    /// Helper to build snapshot and log segment
+    async fn build_test_snapshot(
+        timestamps: &[(Timestamp, Option<Timestamp>)],
+        ict_enablement: Option<Version>,
+        at_version: Option<Version>,
+    ) -> (LocalMockTable, SyncEngine, Arc<Snapshot>, LogSegment) {
+        let table = mock_table_with_timestamps(timestamps, ict_enablement).await;
         let engine = SyncEngine::new();
-        let path = Url::from_directory_path(mock_table.table_root()).unwrap();
-
-        // Set the end version to a time before In-commit timestamps were enabled
-        let snapshot = Snapshot::builder_for(path)
-            .at_version(2)
-            .build(&engine)
-            .unwrap();
+        let path = Url::from_directory_path(table.table_root()).unwrap();
+        let mut builder = Snapshot::builder_for(path);
+        if let Some(v) = at_version {
+            builder = builder.at_version(v);
+        }
+        let snapshot = builder.build(&engine).unwrap();
         let log_segment = LogSegment::for_timestamp_conversion(
             engine.storage_handler().as_ref(),
             snapshot.log_segment().log_root.clone(),
@@ -375,242 +436,298 @@ mod tests {
             None,
         )
         .unwrap();
-
-        // Before all commits
-        let mut res = get_timestamp_search_bounds(&snapshot, &log_segment, 0);
-        assert!(matches!(
-            res,
-            Ok(TimestampSearchBounds::FileModificationSearch)
-        ));
-
-        // Within the timestamp range
-        res = get_timestamp_search_bounds(&snapshot, &log_segment, 100);
-        assert!(matches!(
-            res,
-            Ok(TimestampSearchBounds::FileModificationSearch)
-        ));
-
-        // After all commits
-        res = get_timestamp_search_bounds(&snapshot, &log_segment, 1000);
-        assert!(matches!(
-            res,
-            Ok(TimestampSearchBounds::FileModificationSearch)
-        ));
+        (table, engine, snapshot, log_segment)
     }
 
+    // Table: v0=50, v1=150, v2=250 (file mod only), snapshot at v2 (no ICT)
+    #[rstest::rstest]
+    #[case::before_all(0)]
+    #[case::within_range(100)]
+    #[case::after_all(1000)]
     #[tokio::test]
-    async fn test_timestamp_search_bounds_with_ict_range() {
-        let mock_table = mock_table().await;
-        let engine = SyncEngine::new();
-        let path = Url::from_directory_path(mock_table.table_root()).unwrap();
-        let snapshot = Snapshot::builder_for(path).build(&engine).unwrap();
-        let log_segment = LogSegment::for_timestamp_conversion(
-            engine.storage_handler().as_ref(),
-            snapshot.log_segment().log_root.clone(),
-            snapshot.version(),
-            None,
-        )
-        .unwrap();
+    async fn test_search_bounds_no_ict(#[case] timestamp: Timestamp) {
+        let timestamps = [
+            (50, None),
+            (150, None),
+            (250, None),
+            (350, Some(300)),
+            (450, Some(400)),
+        ];
+        let (_table, _engine, snapshot, log_segment) =
+            build_test_snapshot(&timestamps, Some(3), Some(2)).await;
 
-        // Exact match only applies to in-commit timestamp enablement version
-        let mut res = get_timestamp_search_bounds(&snapshot, &log_segment, 50);
+        let res = get_timestamp_search_bounds(&snapshot, &log_segment, timestamp).unwrap();
         assert!(
-            matches!(
-                res,
-                Ok(TimestampSearchBounds::FileModificationSearchUntil {
-                    index: 3,
-                    ict_enablement_version: 3
-                })
-            ),
-            "{res:?}"
-        );
-
-        // Not exact match, file modification time range
-        res = get_timestamp_search_bounds(&snapshot, &log_segment, 60);
-        assert!(
-            matches!(
-                res,
-                Ok(TimestampSearchBounds::FileModificationSearchUntil {
-                    index: 3,
-                    ict_enablement_version: 3
-                })
-            ),
-            "{res:?}"
-        );
-
-        // Edge case: The last timestamp that is file modification time
-        res = get_timestamp_search_bounds(&snapshot, &log_segment, 299);
-        assert!(
-            matches!(
-                res,
-                Ok(TimestampSearchBounds::FileModificationSearchUntil {
-                    index: 3,
-                    ict_enablement_version: 3
-                })
-            ),
-            "{res:?}"
-        );
-
-        // Edge case: Timestamp is the enablement timestamp
-        res = get_timestamp_search_bounds(&snapshot, &log_segment, 300);
-        assert!(
-            matches!(res, Ok(TimestampSearchBounds::ExactMatch(3))),
-            "{res:?}"
-        );
-
-        // Edge case: The timestamp is 1 + enablement_timestamp. This returns the beginning of the
-        // in-commit timestamp index range.
-        res = get_timestamp_search_bounds(&snapshot, &log_segment, 301);
-        assert!(
-            matches!(res, Ok(TimestampSearchBounds::ICTSearchStartingFrom(3))),
-            "{res:?}"
-        );
-
-        // Timestamp is much larger than the last in-commit timestamp
-        res = get_timestamp_search_bounds(&snapshot, &log_segment, 1000);
-        assert!(
-            matches!(res, Ok(TimestampSearchBounds::ICTSearchStartingFrom(3))),
+            matches!(res, TimestampSearchBounds::FileModificationSearch),
             "{res:?}"
         );
     }
 
+    // Table: v0=50, v1=150, v2=250 (file mod), v3=300, v4=400 (ICT enabled at v3)
+    #[rstest::rstest]
+    #[case::file_mod_region(50, TimestampSearchBounds::FileModificationSearchUntil { index: 3, ict_enablement_version: 3 })]
+    #[case::file_mod_between(60, TimestampSearchBounds::FileModificationSearchUntil { index: 3, ict_enablement_version: 3 })]
+    #[case::file_mod_last(299, TimestampSearchBounds::FileModificationSearchUntil { index: 3, ict_enablement_version: 3 })]
+    #[case::exact_enablement(300, TimestampSearchBounds::ExactMatch(3))]
+    #[case::ict_after_enablement(301, TimestampSearchBounds::ICTSearchStartingFrom(3))]
+    #[case::ict_far_future(1000, TimestampSearchBounds::ICTSearchStartingFrom(3))]
     #[tokio::test]
-    async fn test_reading_in_commit_timestamp() {
-        let mock_table = mock_table().await;
-        let engine = SyncEngine::new();
-        let path = Url::from_directory_path(mock_table.table_root()).unwrap();
-        let snapshot = Snapshot::builder_for(path).build(&engine).unwrap();
-        let log_segment = LogSegment::for_timestamp_conversion(
-            engine.storage_handler().as_ref(),
-            snapshot.log_segment().log_root.clone(),
-            snapshot.version(),
-            None,
-        )
-        .unwrap();
-        let commits = log_segment.listed.ascending_commit_files;
+    async fn test_search_bounds_with_ict(
+        #[case] timestamp: Timestamp,
+        #[case] expected: TimestampSearchBounds,
+    ) {
+        let timestamps = [
+            (50, None),
+            (150, None),
+            (250, None),
+            (350, Some(300)),
+            (450, Some(400)),
+        ];
+        let (_table, _engine, snapshot, log_segment) =
+            build_test_snapshot(&timestamps, Some(3), None).await;
 
-        // File that has no In-commit timestamps
-        let mut res = commits[0].read_in_commit_timestamp(&engine);
+        let res = get_timestamp_search_bounds(&snapshot, &log_segment, timestamp).unwrap();
+        assert_eq!(res, expected);
+    }
+
+    // Table: v0=100, v1=200, v2=300 (ICT from creation)
+    #[rstest::rstest]
+    #[case::before_all(50)]
+    #[case::at_v0(100)]
+    #[case::between_v0_v1(150)]
+    #[case::after_all(1000)]
+    #[tokio::test]
+    async fn test_search_bounds_ict_from_creation(#[case] timestamp: Timestamp) {
+        let timestamps = [(0, Some(100)), (0, Some(200)), (0, Some(300))];
+        let (_table, _engine, snapshot, log_segment) =
+            build_test_snapshot(&timestamps, Some(0), None).await;
+
+        let res = get_timestamp_search_bounds(&snapshot, &log_segment, timestamp).unwrap();
+        assert!(
+            matches!(res, TimestampSearchBounds::ICTSearchStartingFrom(0)),
+            "{res:?}"
+        );
+    }
+
+    /// Tests reading timestamps from commits - both file modification and ICT.
+    #[tokio::test]
+    async fn test_reading_commit_timestamps() {
+        // Table: v0=50, v1=150, v2=250 (file mod), v3=300, v4=400 (ICT at v3)
+        let timestamps = [
+            (50, None),
+            (150, None),
+            (250, None),
+            (350, Some(300)),
+            (450, Some(400)),
+        ];
+        let (_table, engine, _snapshot, log_segment) =
+            build_test_snapshot(&timestamps, Some(3), None).await;
+        let commits = &log_segment.listed.ascending_commit_files;
+
+        // File modification timestamps are set correctly
+        assert_eq!(commits[0].location.last_modified, 50);
+        assert_eq!(commits[1].location.last_modified, 150);
+        assert_eq!(commits[2].location.last_modified, 250);
+
+        // Reading ICT from file without ICT returns error
+        let res = commits[0].read_in_commit_timestamp(&engine);
         assert!(res.is_err(), "Expected error for file without ICT: {res:?}");
 
-        // File that doesn't exist
+        // Reading ICT from non-existent file returns error
         let mut fake_log_path = commits[0].clone();
-
         let failing_path = if cfg!(windows) {
             "C:\\phony\\path"
         } else {
             "/phony/path"
         };
-
         fake_log_path.location.location = Url::from_file_path(failing_path).unwrap();
-        res = fake_log_path.read_in_commit_timestamp(&engine);
+        let res = fake_log_path.read_in_commit_timestamp(&engine);
         assert!(
             res.is_err(),
             "Expected error for non-existent file: {res:?}"
         );
 
-        // Files with In-commit timestamps
-        res = commits[3].read_in_commit_timestamp(&engine);
-        assert!(matches!(res, Ok(300)), "{res:?}");
-        res = commits[4].read_in_commit_timestamp(&engine);
-        assert!(matches!(res, Ok(400)), "{res:?}");
+        // In-commit timestamps read correctly
+        assert_eq!(commits[3].read_in_commit_timestamp(&engine).unwrap(), 300);
+        assert_eq!(commits[4].read_in_commit_timestamp(&engine).unwrap(), 400);
     }
 
+    // Table: v0=50, v1=150, v2=250 (file mod), v3=300, v4=400 (ICT at v3)
+    #[rstest::rstest]
+    #[case::before_all_lub(0, Bound::LeastUpper, Some(0))]
+    #[case::before_all_glb(0, Bound::GreatestLower, None)]
+    #[case::negative_lub(-1, Bound::LeastUpper, Some(0))]
+    #[case::after_all_lub(1000, Bound::LeastUpper, None)]
+    #[case::after_all_glb(1000, Bound::GreatestLower, Some(4))]
+    #[case::exact_v0_lub(50, Bound::LeastUpper, Some(0))]
+    #[case::exact_v0_glb(50, Bound::GreatestLower, Some(0))]
+    #[case::exact_v1_lub(150, Bound::LeastUpper, Some(1))]
+    #[case::exact_v1_glb(150, Bound::GreatestLower, Some(1))]
+    #[case::exact_v3_ict_lub(300, Bound::LeastUpper, Some(3))]
+    #[case::exact_v3_ict_glb(300, Bound::GreatestLower, Some(3))]
+    #[case::between_v0_v1_lub(100, Bound::LeastUpper, Some(1))]
+    #[case::between_v0_v1_glb(100, Bound::GreatestLower, Some(0))]
+    #[case::just_after_last_file_mod_lub(251, Bound::LeastUpper, Some(3))]
+    #[case::just_after_last_file_mod_glb(251, Bound::GreatestLower, Some(2))]
+    #[case::just_before_ict_lub(299, Bound::LeastUpper, Some(3))]
+    #[case::just_before_ict_glb(299, Bound::GreatestLower, Some(2))]
+    #[case::just_after_ict_glb(301, Bound::GreatestLower, Some(3))]
+    #[case::just_after_ict_lub(301, Bound::LeastUpper, Some(4))]
     #[tokio::test]
-    async fn test_file_modification_conversion() {
-        let mock_table = mock_table().await;
+    async fn test_timestamp_to_version_standard_table(
+        #[case] timestamp: Timestamp,
+        #[case] bound: Bound,
+        #[case] expected: Option<Version>,
+    ) {
+        let timestamps = [
+            (50, None),
+            (150, None),
+            (250, None),
+            (350, Some(300)),
+            (450, Some(400)),
+        ];
+        let (_table, engine, snapshot, _log_segment) =
+            build_test_snapshot(&timestamps, Some(3), None).await;
+
+        let res = timestamp_to_version(&snapshot, &engine, timestamp, bound);
+        match expected {
+            Some(v) => assert_eq!(res.unwrap(), v),
+            None => assert!(
+                matches!(res, Err(LogHistoryError::TimestampOutOfRange { .. })),
+                "{res:?}"
+            ),
+        }
+    }
+
+    // Table: v0=100, v1=200, v2=300 (ICT from creation)
+    #[rstest::rstest]
+    #[case::exact_v0_glb(100, Bound::GreatestLower, Some(0))]
+    #[case::exact_v0_lub(100, Bound::LeastUpper, Some(0))]
+    #[case::between_v0_v1_glb(150, Bound::GreatestLower, Some(0))]
+    #[case::between_v0_v1_lub(150, Bound::LeastUpper, Some(1))]
+    #[case::between_v1_v2_glb(250, Bound::GreatestLower, Some(1))]
+    #[case::between_v1_v2_lub(250, Bound::LeastUpper, Some(2))]
+    #[case::before_all_glb(50, Bound::GreatestLower, None)]
+    #[case::before_all_lub(50, Bound::LeastUpper, Some(0))]
+    #[tokio::test]
+    async fn test_ict_from_creation(
+        #[case] timestamp: Timestamp,
+        #[case] bound: Bound,
+        #[case] expected: Option<Version>,
+    ) {
+        let mock_table =
+            mock_table_with_timestamps(&[(0, Some(100)), (0, Some(200)), (0, Some(300))], Some(0))
+                .await;
         let engine = SyncEngine::new();
         let path = Url::from_directory_path(mock_table.table_root()).unwrap();
         let snapshot = Snapshot::builder_for(path).build(&engine).unwrap();
-        let log_segment = LogSegment::for_timestamp_conversion(
-            engine.storage_handler().as_ref(),
-            snapshot.log_segment().log_root.clone(),
-            snapshot.version(),
+
+        let res = timestamp_to_version(&snapshot, &engine, timestamp, bound);
+        match expected {
+            Some(v) => assert_eq!(res.unwrap(), v),
+            None => assert!(
+                matches!(res, Err(LogHistoryError::TimestampOutOfRange { .. })),
+                "{res:?}"
+            ),
+        }
+    }
+
+    /// Single commit table: v0=100 (file mod only)
+    #[rstest::rstest]
+    #[case::exact_glb(100, Bound::GreatestLower, Some(0))]
+    #[case::exact_lub(100, Bound::LeastUpper, Some(0))]
+    #[case::before_glb(50, Bound::GreatestLower, None)]
+    #[case::before_lub(50, Bound::LeastUpper, Some(0))]
+    #[case::after_glb(150, Bound::GreatestLower, Some(0))]
+    #[case::after_lub(150, Bound::LeastUpper, None)]
+    #[tokio::test]
+    async fn test_single_commit(
+        #[case] timestamp: Timestamp,
+        #[case] bound: Bound,
+        #[case] expected: Option<Version>,
+    ) {
+        let mock_table = mock_table_with_timestamps(&[(100, None)], None).await;
+        let engine = SyncEngine::new();
+        let path = Url::from_directory_path(mock_table.table_root()).unwrap();
+        let snapshot = Snapshot::builder_for(path).build(&engine).unwrap();
+
+        let res = timestamp_to_version(&snapshot, &engine, timestamp, bound);
+        match expected {
+            Some(v) => assert_eq!(res.unwrap(), v),
+            None => assert!(
+                matches!(res, Err(LogHistoryError::TimestampOutOfRange { .. })),
+                "{res:?}"
+            ),
+        }
+    }
+
+    /// Non-monotonic file mod timestamps (clock skew):
+    /// Raw: v0=100, v1=200, v2=150, v3=180, v4=300
+    /// Monotonized: v0=100, v1=200, v2=201, v3=202, v4=300
+    #[rstest::rstest]
+    #[case::exact_v0_glb(100, Bound::GreatestLower, Some(0))]
+    #[case::exact_v1_glb(200, Bound::GreatestLower, Some(1))]
+    #[case::monotonized_v2_glb(201, Bound::GreatestLower, Some(2))]
+    #[case::monotonized_v3_glb(202, Bound::GreatestLower, Some(3))]
+    #[case::between_v3_v4_glb(250, Bound::GreatestLower, Some(3))]
+    #[case::exact_v4_glb(300, Bound::GreatestLower, Some(4))]
+    #[case::raw_v2_maps_to_v1_lub(150, Bound::LeastUpper, Some(1))]
+    #[case::monotonized_v2_lub(201, Bound::LeastUpper, Some(2))]
+    #[case::after_v3_monotonized_lub(203, Bound::LeastUpper, Some(4))]
+    #[tokio::test]
+    async fn test_non_monotonic_timestamps(
+        #[case] timestamp: Timestamp,
+        #[case] bound: Bound,
+        #[case] expected: Option<Version>,
+    ) {
+        let mock_table = mock_table_with_timestamps(
+            &[
+                (100, None),
+                (200, None),
+                (150, None),
+                (180, None),
+                (300, None),
+            ],
             None,
         )
-        .unwrap();
-        let commits = log_segment.listed.ascending_commit_files;
-
-        // Read the file modification timestamps
-        let ts: Result<Timestamp, LogHistoryError> = Ok(commits[0].location.last_modified);
-        assert!(matches!(ts, Ok(50)));
-
-        let ts: Result<Timestamp, LogHistoryError> = Ok(commits[1].location.last_modified);
-        assert!(matches!(ts, Ok(150)));
-
-        let ts: Result<Timestamp, LogHistoryError> = Ok(commits[2].location.last_modified);
-        assert!(matches!(ts, Ok(250)));
-
-        // Read the in-commit timestamps
-        let ts = commits[3].read_in_commit_timestamp(&engine);
-        assert!(matches!(ts, Ok(300)));
-        let ts = commits[4].read_in_commit_timestamp(&engine);
-        assert!(matches!(ts, Ok(400)));
-    }
-
-    #[tokio::test]
-    async fn test_convert_timestamp_to_version() {
-        let mock_table = mock_table().await;
+        .await;
         let engine = SyncEngine::new();
         let path = Url::from_directory_path(mock_table.table_root()).unwrap();
         let snapshot = Snapshot::builder_for(path).build(&engine).unwrap();
 
-        // Less than the lowest ICT
-        let mut res = timestamp_to_version(&snapshot, &engine, 0, Bound::LeastUpper);
-        assert!(matches!(res, Ok(0)), "{res:?}");
-
-        // Negative timestamps are allowed:
-        res = timestamp_to_version(&snapshot, &engine, -1, Bound::LeastUpper);
-        assert!(matches!(res, Ok(0)), "{res:?}");
-
-        // GreatestLower Bound on timestamp that is less than all commits fails
-        res = timestamp_to_version(&snapshot, &engine, 0, Bound::GreatestLower);
-        assert!(
-            matches!(
-                res,
-                Err(LogHistoryError::TimestampOutOfRange {
-                    timestamp: 0,
-                    bound: Bound::GreatestLower,
-                })
+        let res = timestamp_to_version(&snapshot, &engine, timestamp, bound);
+        match expected {
+            Some(v) => assert_eq!(res.unwrap(), v),
+            None => assert!(
+                matches!(res, Err(LogHistoryError::TimestampOutOfRange { .. })),
+                "{res:?}"
             ),
-            "{res:?}"
-        );
+        }
+    }
 
-        // GreatestLower bound on timestamp that is greater than all commits succeeds
-        res = timestamp_to_version(&snapshot, &engine, 1000, Bound::GreatestLower);
-        assert!(matches!(res, Ok(4)), "{res:?}");
+    /// ICT enabled at v3 but v4 is missing its ICT timestamp (error case).
+    /// Table: v0=50, v1=150, v2=250 (file mod), v3=300 (ICT), v4=450 (missing ICT)
+    #[tokio::test]
+    async fn test_missing_ict_after_enablement() {
+        // Create table where v4 is after ICT enablement but doesn't have an ICT
+        let timestamps = [
+            (50, None),
+            (150, None),
+            (250, None),
+            (350, Some(300)), // ICT enabled at v3
+            (450, None),      // v4 missing ICT (bug in writer!)
+        ];
+        let table = mock_table_with_timestamps(&timestamps, Some(3)).await;
+        let engine = SyncEngine::new();
+        let path = Url::from_directory_path(table.table_root()).unwrap();
+        let snapshot = Snapshot::builder_for(path).build(&engine).unwrap();
 
-        // LeastUpper Bound on timestamp that is greater than all commits fails
-        res = timestamp_to_version(&snapshot, &engine, 1000, Bound::LeastUpper);
+        // Search for timestamp 350 which would need to search in ICT range (v3+)
+        // The search will try to read ICT from v4 which is missing
+        let res = timestamp_to_version(&snapshot, &engine, 350, Bound::LeastUpper);
         assert!(
-            matches!(
-                res,
-                Err(LogHistoryError::TimestampOutOfRange {
-                    timestamp: 1000,
-                    bound: Bound::LeastUpper,
-                })
-            ),
-            "{res:?}"
+            matches!(res, Err(LogHistoryError::Internal { .. })),
+            "Expected internal error for missing ICT: {res:?}"
         );
-
-        // Edge cases: timestamp is between file modification time and in-commit timestamp
-
-        // Right after last file modification timestamp
-        res = timestamp_to_version(&snapshot, &engine, 251, Bound::LeastUpper);
-        assert!(matches!(res, Ok(3)), "{res:?}");
-        res = timestamp_to_version(&snapshot, &engine, 251, Bound::GreatestLower);
-        assert!(matches!(res, Ok(2)), "{res:?}");
-
-        // Right before first in-commit timestamp
-        res = timestamp_to_version(&snapshot, &engine, 299, Bound::LeastUpper);
-        assert!(matches!(res, Ok(3)), "{res:?}");
-        res = timestamp_to_version(&snapshot, &engine, 299, Bound::GreatestLower);
-        assert!(matches!(res, Ok(2)), "{res:?}");
-
-        // Right after first in-commit timestamp
-        res = timestamp_to_version(&snapshot, &engine, 301, Bound::GreatestLower);
-        assert!(matches!(res, Ok(3)), "{res:?}");
-        res = timestamp_to_version(&snapshot, &engine, 301, Bound::LeastUpper);
-        assert!(matches!(res, Ok(4)), "{res:?}");
     }
 }

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -269,6 +269,27 @@ pub(crate) fn timestamp_to_version(
     timestamp: Timestamp,
     bound: Bound,
 ) -> Result<Version, LogHistoryError> {
+    // Short-circuit: compare against snapshot's timestamp to avoid log segment rebuild.
+    // This optimization mirrors Delta Spark and Java Kernel behavior.
+    let snap_ts = snapshot
+        .get_timestamp(engine)
+        .map_err(|e| LogHistoryError::internal("failed to get snapshot timestamp", e))?;
+    match (timestamp.cmp(&snap_ts), bound) {
+        // Exact match: snapshot version satisfies both bounds
+        (Ordering::Equal, _) => return Ok(snapshot.version()),
+        // Timestamp after snapshot: for GreatestLower, snapshot is the answer
+        (Ordering::Greater, Bound::GreatestLower) => return Ok(snapshot.version()),
+        // Timestamp after snapshot: for LeastUpper, no version exists
+        (Ordering::Greater, Bound::LeastUpper) => {
+            return Err(LogHistoryError::TimestampOutOfRange {
+                timestamp,
+                reason: bound.out_of_range_reason(),
+            });
+        }
+        // Timestamp before snapshot: need to search the log
+        _ => {}
+    }
+
     // TODO(#2443): Support staged commits (catalog-managed tables). Staged commits have ICT
     // (required by catalog-managed), so timestamps are available. However, we currently
     // rebuild the log segment from storage which doesn't include staged commits. To support

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -511,6 +511,11 @@ pub fn timestamp_range_to_versions(
         );
     }
 
+    // TODO(#2449): Optimize by reusing the log segment between the two timestamp conversions.
+    // Currently, both first_version_after and latest_version_as_of each build their own
+    // log segment via listing. We could build the segment once and pass it to a shared
+    // helper (e.g., timestamp_to_version_in_segment) to cut listing time in half.
+
     // Convert the start timestamp to version
     let start_version = first_version_after(snapshot, engine, start_timestamp)?;
 

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -3,6 +3,24 @@
 
 //! This module provides functions for performing timestamp queries over the Delta Log, translating
 //! between timestamps and Delta versions.
+//!
+//! # Usage
+//!
+//! Use this module to:
+//! - Convert timestamps or timestamp ranges into Delta versions or version ranges
+//! - Perform time travel queries
+//! - Execute timestamp-based change data feed queries
+//!
+//! The history_manager module works with tables regardless of whether they have In-Commit
+//! Timestamps (ICT) enabled. ICT is a Delta table feature that stores precise commit timestamps
+//! in the commit metadata rather than relying on file modification times, which can be affected
+//! by clock skew or filesystem limitations.
+//!
+//! # Limitations
+//!
+//! All timestamp queries are limited to the state captured in the [`Snapshot`] provided during
+//! construction. For tables without ICT enabled, timestamp queries rely on file modification
+//! timestamps, which are not guaranteed to be monotonically increasing across commits.
 
 use std::cmp::Ordering;
 
@@ -15,16 +33,16 @@ use crate::path::ParsedLogPath;
 use crate::snapshot::Snapshot;
 use crate::table_configuration::InCommitTimestampEnablement;
 use crate::utils::require;
-use crate::{Engine, Error as DeltaError, Version};
+use crate::{DeltaResult, Engine, Error as DeltaError, Version};
 
 pub(crate) mod search;
 
 pub(crate) mod error;
 
-type Timestamp = i64;
+/// A timestamp representing milliseconds since the Unix epoch (1970-01-01 00:00:00 UTC).
+pub(crate) type Timestamp = i64;
 
 /// Determines the search strategy for timestamp-to-version conversion based on ICT enablement.
-#[allow(unused)]
 #[derive(Debug, PartialEq, Eq)]
 enum TimestampSearchBounds {
     /// The timestamp exactly matches the ICT enablement timestamp.
@@ -42,11 +60,29 @@ enum TimestampSearchBounds {
     },
 }
 
-/// Given a timestamp, this function determines the commit range that timestamp conversion
-/// should search. A timestamp search may be conducted over one of two version ranges:
-///     1) A range of commits whose timestamp is the file modification timestamp
-///     2) A range of commits whose timestamp is an in-commit timestamp.
-#[allow(unused)]
+/// Determines the search strategy for timestamp-to-version conversion based on ICT enablement.
+///
+/// Given a timestamp, this function determines which commit range to search and what timestamp
+/// source to use (file modification time vs in-commit timestamp). A timestamp search may be
+/// conducted over one of two version ranges:
+///   1) A range of commits whose timestamp is the file modification timestamp
+///   2) A range of commits whose timestamp is an in-commit timestamp
+///
+/// # Returns
+///
+/// - [`TimestampSearchBounds::FileModificationSearch`]: ICT not enabled; search all commits using
+///   file modification timestamps.
+/// - [`TimestampSearchBounds::ICTSearchStartingFrom`]: Search commits with ICT enabled using
+///   in-commit timestamps (binary search).
+/// - [`TimestampSearchBounds::FileModificationSearchUntil`]: Timestamp is before ICT enablement;
+///   search pre-ICT commits using file modification timestamps.
+/// - [`TimestampSearchBounds::ExactMatch`]: Timestamp exactly matches the ICT enablement timestamp.
+///
+/// # Errors
+///
+/// Returns [`LogHistoryError::Internal`] if:
+/// - Failed to read table configuration
+/// - ICT enablement version is beyond the log segment (indicates corrupted metadata)
 #[tracing::instrument(skip(snapshot, log_segment), ret)]
 fn get_timestamp_search_bounds(
     snapshot: &Snapshot,
@@ -75,6 +111,13 @@ fn get_timestamp_search_bounds(
         }
     };
 
+    // Fast path: if the first commit is at or after ICT enablement (e.g., old commits cleaned
+    // up), all commits in the segment have ICT - skip binary search.
+    let first_version = log_segment.listed.ascending_commit_files[0].version;
+    if first_version >= ict_enablement_version {
+        return Ok(TimestampSearchBounds::ICTSearchStartingFrom(0));
+    }
+
     // Get the index of the ICT enablement version in the log segment. If the version is not
     // present, binary_search returns the insertion point (first commit at or after).
     let commit_count = log_segment.listed.ascending_commit_files.len();
@@ -84,16 +127,12 @@ fn get_timestamp_search_bounds(
         .binary_search_by(|x| x.version.cmp(&ict_enablement_version))
         .unwrap_or_else(|idx| idx);
 
-    // The ICT enablement index must be within the log segment. If it equals commit_count,
-    // the ICT enablement version is beyond all commits in the segment.
+    // Invariant: ICT enablement version must be within the log segment. If it equals
+    // commit_count, the enablement version is beyond the table's latest version.
     require!(
         ict_enablement_idx < commit_count,
-        LogHistoryError::internal(
-            "ICT enablement version beyond log segment",
-            DeltaError::generic(format!(
-                "ICT enablement version {} not in log segment (index {} >= count {})",
-                ict_enablement_version, ict_enablement_idx, commit_count
-            ))
+        LogHistoryError::internal_message(
+            "ICT enablement version is beyond the table's latest version"
         )
     );
 
@@ -144,7 +183,6 @@ fn get_timestamp_search_bounds(
 // TODO: Today we read full commit history for timestamp conversion, which is expensive.
 // A future backwards-listing optimization would avoid reading full history - at that
 // point, monotonizing over full history becomes a bad trade-off and should be revisited.
-#[allow(unused)]
 fn linear_search_file_mod_timestamps(
     commits: &[ParsedLogPath],
     timestamp: Timestamp,
@@ -167,7 +205,7 @@ fn linear_search_file_mod_timestamps(
     for commit in commits {
         let raw_ts = commit.location.last_modified;
         // Monotonize: ensure each timestamp is strictly greater than the previous
-        let monotonic_ts = raw_ts.max(prev_monotonic_ts + 1);
+        let monotonic_ts = raw_ts.max(prev_monotonic_ts.saturating_add(1));
         if monotonic_ts != raw_ts {
             trace!(
                 version = commit.version,
@@ -221,17 +259,36 @@ fn linear_search_file_mod_timestamps(
 /// # Errors
 /// Returns [`LogHistoryError::TimestampOutOfRange`] if the timestamp is out of range. This can
 /// happen in the following cases based on the bound:
-/// - `Bound::GreatestLower`: There is no commit whose timestamp is lower than the given
+/// - `Bound::GreatestLower`: There is no commit whose timestamp is less than or equal to the given
 ///   `timestamp`.
-/// - `Bound::LeastUpper`: There is no commit whose timestamp is greater than the given `timestamp`.
-#[allow(unused)]
+/// - `Bound::LeastUpper`: There is no commit whose timestamp is greater than or equal to the given
+///   `timestamp`.
 pub(crate) fn timestamp_to_version(
     snapshot: &Snapshot,
     engine: &dyn Engine,
     timestamp: Timestamp,
     bound: Bound,
 ) -> Result<Version, LogHistoryError> {
-    // Get log segment for timestamp conversion
+    // TODO(#2443): Support staged commits (catalog-managed tables). Staged commits have ICT
+    // (required by catalog-managed), so timestamps are available. However, we currently
+    // rebuild the log segment from storage which doesn't include staged commits. To support
+    // this, we'd need to pass the snapshot's log_tail into the log segment construction.
+    let has_staged_commits = snapshot
+        .log_segment()
+        .listed
+        .ascending_commit_files
+        .last() // Use last since a log segment always ends with staged commits from `log_tail`
+        .is_some_and(|c| c.file_type == crate::path::LogPathFileType::StagedCommit);
+    if has_staged_commits {
+        return Err(LogHistoryError::internal_message(
+            "timestamp conversion not yet supported for snapshots with staged commits",
+        ));
+    }
+
+    // Build a dedicated log segment for timestamp conversion. We cannot reuse
+    // snapshot.log_segment() because it may include a checkpoint prefix with gaps in
+    // the commit sequence. for_timestamp_conversion returns only contiguous commits,
+    // which is required for correct timestamp-to-version mapping.
     let log_segment = LogSegment::for_timestamp_conversion(
         engine.storage_handler().as_ref(),
         snapshot.log_segment().log_root.clone(),
@@ -266,8 +323,8 @@ pub(crate) fn timestamp_to_version(
                 });
             }
 
-            let lo_version = commit_range.first().map(|c| c.version).unwrap_or(0);
-            let hi_version = commit_range.last().map(|c| c.version).unwrap_or(0);
+            let lo_version = commit_range[0].version;
+            let hi_version = commit_range[commit_range.len() - 1].version;
             info!(
                 lo_version,
                 hi_version, "ICT binary search over version range"
@@ -310,15 +367,169 @@ pub(crate) fn timestamp_to_version(
         } => {
             let commits = &log_segment.listed.ascending_commit_files[..index];
             linear_search_file_mod_timestamps(commits, timestamp, bound).or_else(|e| {
-                // For LeastUpper, if no version found, the ICT enablement version is the answer
-                if bound == Bound::LeastUpper {
-                    Ok(ict_enablement_version)
-                } else {
-                    Err(e)
+                // For LeastUpper, if no version found in pre-ICT region, the ICT enablement
+                // version is the answer (protocol guarantees enablementTs > prev_mod_time)
+                match (&e, bound) {
+                    (LogHistoryError::TimestampOutOfRange { .. }, Bound::LeastUpper) => {
+                        Ok(ict_enablement_version)
+                    }
+                    _ => Err(e),
                 }
             })
         }
     }
+}
+
+/// Gets the latest version that occurs before or at the given `timestamp`.
+///
+/// This finds the version whose timestamp is less than or equal to `timestamp`.
+/// If no such version exists, returns [`LogHistoryError::TimestampOutOfRange`].
+///
+/// # Examples
+/// ```ignore
+/// use delta_kernel::snapshot::Snapshot;
+/// use delta_kernel::engine::default::DefaultEngine;
+/// use delta_kernel::history_manager::latest_version_as_of;
+///
+/// let engine = DefaultEngine::try_new(...)?;
+/// let snapshot = Snapshot::builder_for(table_uri).build(&engine)?;
+///
+/// // Get the latest version as of January 1, 2023
+/// let timestamp = 1672531200000; // Milliseconds since epoch for 2023-01-01
+/// let version = latest_version_as_of(&snapshot, &engine, timestamp)?;
+/// ```
+#[allow(unused)]
+#[tracing::instrument(skip(snapshot, engine), fields(latest_version = snapshot.version(), table_root = %snapshot.table_root()))]
+pub(crate) fn latest_version_as_of(
+    snapshot: &Snapshot,
+    engine: &dyn Engine,
+    timestamp: Timestamp,
+) -> DeltaResult<Version> {
+    timestamp_to_version(snapshot, engine, timestamp, Bound::GreatestLower).map_err(Into::into)
+}
+
+/// Gets the first version that occurs at or after the given `timestamp`.
+///
+/// This finds the version whose timestamp is greater than or equal to `timestamp`.
+/// If no such version exists, returns [`LogHistoryError::TimestampOutOfRange`].
+///
+/// # Examples
+/// ```ignore
+/// use delta_kernel::snapshot::Snapshot;
+/// use delta_kernel::engine::default::DefaultEngine;
+/// use delta_kernel::history_manager::first_version_after;
+///
+/// let engine = DefaultEngine::try_new(...)?;
+/// let snapshot = Snapshot::builder_for(table_uri).build(&engine)?;
+///
+/// // Find the first version that occurred after January 1, 2023
+/// let timestamp = 1672531200000; // Milliseconds since epoch for 2023-01-01
+/// let version = first_version_after(&snapshot, &engine, timestamp)?;
+/// ```
+#[allow(unused)]
+#[tracing::instrument(skip(snapshot, engine), fields(latest_version = snapshot.version(), table_root = %snapshot.table_root()))]
+pub(crate) fn first_version_after(
+    snapshot: &Snapshot,
+    engine: &dyn Engine,
+    timestamp: Timestamp,
+) -> DeltaResult<Version> {
+    timestamp_to_version(snapshot, engine, timestamp, Bound::LeastUpper).map_err(Into::into)
+}
+
+/// Converts a timestamp range to a corresponding version range.
+///
+/// This function finds the version range that corresponds to the given timestamp range.
+/// The returned tuple contains:
+/// - The first (earliest) version with a timestamp greater than or equal to `start_timestamp`
+/// - If `end_timestamp` is provided, the version with a timestamp less than or equal to
+///   `end_timestamp`.
+///
+/// # Arguments
+/// * `snapshot` - The snapshot that defines the searchable version range
+/// * `engine` - The engine used to access version history
+/// * `start_timestamp` - The lower bound timestamp (inclusive), in milliseconds since Unix epoch
+/// * `end_timestamp` - The optional upper bound timestamp (inclusive), or `None` to indicate no
+///   upper bound
+///
+/// # Returns
+/// A tuple containing the start version and optional end version (inclusive)
+///
+/// # Errors
+/// Returns [`LogHistoryError::InvalidTimestampRange`] if `start_timestamp > end_timestamp`.
+///
+/// Returns [`LogHistoryError::TimestampOutOfRange`] if:
+/// - No version exists at or after `start_timestamp`
+/// - `end_timestamp` is provided and no version exists at or before it
+///
+/// Returns [`LogHistoryError::EmptyTimestampRange`] if the entire range falls between two commits.
+///
+/// # Examples
+/// ```ignore
+/// use delta_kernel::snapshot::Snapshot;
+/// use delta_kernel::engine::default::DefaultEngine;
+/// use delta_kernel::history_manager::timestamp_range_to_versions;
+///
+/// let engine = DefaultEngine::try_new(...)?;
+/// let snapshot = Snapshot::builder_for(table_uri).build(&engine)?;
+///
+/// // Find versions between January 1, 2023 and March 1, 2023
+/// let start_timestamp = 1672531200000; // Jan 1, 2023 (milliseconds since epoch)
+/// let end_timestamp = 1677628800000;   // Mar 1, 2023 (milliseconds since epoch)
+///
+/// let (start_version, end_version) =
+///     timestamp_range_to_versions(&snapshot, &engine, start_timestamp, Some(end_timestamp))?;
+/// ```
+#[allow(unused)]
+#[tracing::instrument(skip(snapshot, engine), fields(latest_version = snapshot.version(), table_root = %snapshot.table_root()))]
+pub(crate) fn timestamp_range_to_versions(
+    snapshot: &Snapshot,
+    engine: &dyn Engine,
+    start_timestamp: Timestamp,
+    end_timestamp: Option<Timestamp>,
+) -> DeltaResult<(Version, Option<Version>)> {
+    if let Some(end_timestamp) = end_timestamp {
+        // The `start_timestamp` must be no greater than the `end_timestamp`.
+        require!(
+            start_timestamp <= end_timestamp,
+            LogHistoryError::InvalidTimestampRange {
+                start_timestamp,
+                end_timestamp
+            }
+            .into()
+        );
+    }
+
+    // Convert the start timestamp to version
+    let start_version = first_version_after(snapshot, engine, start_timestamp)?;
+
+    // If the end timestamp is present, convert it to an end version
+    let end_version = end_timestamp
+        .map(|end| {
+            let end_version = latest_version_as_of(snapshot, engine, end)?;
+
+            // Verify that the start version is no greater than the end version. This can
+            // happen in the case that the entire timestamp range falls between two commits.
+            // Consider the following history:
+            // |-------------|--------------------|---------------|
+            // v4       start_timestamp      end_timestamp       v5
+            //
+            // The latest version as of the end_timestamp is 4. The first version after the
+            // start_timestamp is 5. Thus in the case where end_version < start_version, we
+            // return an [`LogHistoryError::EmptyTimestampRange`].
+            require!(
+                start_version <= end_version,
+                DeltaError::from(LogHistoryError::EmptyTimestampRange {
+                    start_timestamp,
+                    end_timestamp: end,
+                    between_version: end_version,
+                })
+            );
+
+            Ok(end_version)
+        })
+        .transpose()?;
+
+    Ok((start_version, end_version))
 }
 
 #[cfg(test)]
@@ -469,6 +680,11 @@ mod tests {
         (table, engine, snapshot, log_segment)
     }
 
+    // ====================================================================================
+    // Tests for low-level internal functions: get_timestamp_search_bounds,
+    // timestamp_to_version, linear_search_file_mod_timestamps
+    // ====================================================================================
+
     // Table: v0=50, v1=150, v2=250 (file mod only), snapshot at v2 (no ICT)
     #[rstest::rstest]
     #[case::before_all(0)]
@@ -603,6 +819,8 @@ mod tests {
     #[case::just_before_ict_glb(299, Bound::GreatestLower, Some(2))]
     #[case::just_after_ict_glb(301, Bound::GreatestLower, Some(3))]
     #[case::just_after_ict_lub(301, Bound::LeastUpper, Some(4))]
+    #[case::between_ict_commits(350, Bound::GreatestLower, Some(3))]
+    #[case::between_ict_commits_lub(350, Bound::LeastUpper, Some(4))]
     #[tokio::test]
     async fn test_timestamp_to_version_standard_table(
         #[case] timestamp: Timestamp,
@@ -759,5 +977,420 @@ mod tests {
             matches!(res, Err(LogHistoryError::Internal { .. })),
             "Expected internal error for missing ICT: {res:?}"
         );
+    }
+
+    // ====================================================================================
+    // Tests for high-level public APIs: latest_version_as_of, first_version_after,
+    // timestamp_range_to_versions
+    // ====================================================================================
+
+    // Table: v0=50, v1=150, v2=250 (file mod), v3=300, v4=400 (ICT at v3)
+    // Matches test_timestamp_to_version_standard_table cases for GreatestLower bound
+    #[rstest::rstest]
+    #[case::before_all(0, None)]
+    #[case::exact_v0(50, Some(0))]
+    #[case::between_v0_v1(100, Some(0))]
+    #[case::exact_v1(150, Some(1))]
+    #[case::just_after_last_file_mod(251, Some(2))]
+    #[case::just_before_ict(299, Some(2))]
+    #[case::exact_ict_enablement(300, Some(3))]
+    #[case::just_after_ict(301, Some(3))]
+    #[case::between_ict_commits(350, Some(3))]
+    #[case::after_all(1000, Some(4))]
+    #[tokio::test]
+    async fn test_latest_version_as_of(
+        #[case] timestamp: Timestamp,
+        #[case] expected: Option<Version>,
+    ) {
+        let timestamps = [
+            (50, None),
+            (150, None),
+            (250, None),
+            (350, Some(300)),
+            (450, Some(400)),
+        ];
+        let table = mock_table_with_timestamps(&timestamps, Some(3)).await;
+        let engine = SyncEngine::new();
+        let path = Url::from_directory_path(table.table_root()).unwrap();
+        let snapshot = Snapshot::builder_for(path).build(&engine).unwrap();
+
+        let res = latest_version_as_of(&snapshot, &engine, timestamp);
+        match expected {
+            Some(v) => assert_eq!(res.unwrap(), v),
+            None => assert!(res.is_err(), "{res:?}"),
+        }
+    }
+
+    // Table: v0=50, v1=150, v2=250 (file mod), v3=300, v4=400 (ICT at v3)
+    // Matches test_timestamp_to_version_standard_table cases for LeastUpper bound
+    #[rstest::rstest]
+    #[case::before_all(0, Some(0))]
+    #[case::exact_v0(50, Some(0))]
+    #[case::between_v0_v1(100, Some(1))]
+    #[case::exact_v1(150, Some(1))]
+    #[case::just_after_last_file_mod(251, Some(3))]
+    #[case::just_before_ict(299, Some(3))]
+    #[case::exact_ict_enablement(300, Some(3))]
+    #[case::just_after_ict(301, Some(4))]
+    #[case::between_ict_commits(350, Some(4))]
+    #[case::after_all(1000, None)]
+    #[tokio::test]
+    async fn test_first_version_after(
+        #[case] timestamp: Timestamp,
+        #[case] expected: Option<Version>,
+    ) {
+        let timestamps = [
+            (50, None),
+            (150, None),
+            (250, None),
+            (350, Some(300)),
+            (450, Some(400)),
+        ];
+        let table = mock_table_with_timestamps(&timestamps, Some(3)).await;
+        let engine = SyncEngine::new();
+        let path = Url::from_directory_path(table.table_root()).unwrap();
+        let snapshot = Snapshot::builder_for(path).build(&engine).unwrap();
+
+        let res = first_version_after(&snapshot, &engine, timestamp);
+        match expected {
+            Some(v) => assert_eq!(res.unwrap(), v),
+            None => assert!(res.is_err(), "{res:?}"),
+        }
+    }
+
+    // Table: v0=50, v1=150, v2=250 (file mod), v3=300, v4=400 (ICT at v3)
+    // Comprehensive boundary test cases matching test_latest_version_as_of and
+    // test_first_version_after
+    #[rstest::rstest]
+    // Basic range tests
+    #[case::basic_range(50, Some(300), Ok((0, Some(3))))]
+    #[case::no_end(100, None, Ok((1, None)))]
+    #[case::start_equals_end(150, Some(150), Ok((1, Some(1))))]
+    #[case::spanning_ict_boundary(100, Some(350), Ok((1, Some(3))))]
+    #[case::entire_table(0, Some(1000), Ok((0, Some(4))))]
+    // Exact timestamp boundaries
+    #[case::exact_v0_to_v1(50, Some(150), Ok((0, Some(1))))]
+    #[case::exact_v1_to_v2(150, Some(250), Ok((1, Some(2))))]
+    #[case::exact_v3_ict_to_v4(300, Some(400), Ok((3, Some(4))))]
+    // File mod region boundaries
+    #[case::between_v0_v1_to_exact_v2(100, Some(250), Ok((1, Some(2))))]
+    #[case::just_after_last_file_mod_no_end(251, None, Ok((3, None)))]
+    #[case::just_before_ict_to_just_after(299, Some(301), Ok((3, Some(3))))]
+    // ICT region boundaries
+    #[case::exact_ict_to_after_all(300, Some(1000), Ok((3, Some(4))))]
+    #[case::between_ict_commits(350, Some(400), Ok((4, Some(4))))]
+    #[case::just_after_ict_to_end(301, Some(1000), Ok((4, Some(4))))]
+    // Error cases embedded as rstest cases
+    #[case::end_before_all_fails(0, Some(40), Err(()))] // No version at or before end_timestamp=40
+    #[case::start_after_all_fails(500, Some(1000), Err(()))] // No version at or after start_timestamp=500
+    #[tokio::test]
+    async fn test_timestamp_range_to_versions(
+        #[case] start: Timestamp,
+        #[case] end: Option<Timestamp>,
+        #[case] expected: Result<(Version, Option<Version>), ()>,
+    ) {
+        let timestamps = [
+            (50, None),
+            (150, None),
+            (250, None),
+            (350, Some(300)),
+            (450, Some(400)),
+        ];
+        let table = mock_table_with_timestamps(&timestamps, Some(3)).await;
+        let engine = SyncEngine::new();
+        let path = Url::from_directory_path(table.table_root()).unwrap();
+        let snapshot = Snapshot::builder_for(path).build(&engine).unwrap();
+
+        let res = timestamp_range_to_versions(&snapshot, &engine, start, end);
+        match expected {
+            Ok(v) => assert_eq!(res.unwrap(), v),
+            Err(()) => assert!(res.is_err(), "{res:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_timestamp_range_invalid_range() {
+        // Table: v0=50, v1=150, v2=250 (file mod), v3=300, v4=400 (ICT at v3)
+        let timestamps = [
+            (50, None),
+            (150, None),
+            (250, None),
+            (350, Some(300)),
+            (450, Some(400)),
+        ];
+        let table = mock_table_with_timestamps(&timestamps, Some(3)).await;
+        let engine = SyncEngine::new();
+        let path = Url::from_directory_path(table.table_root()).unwrap();
+        let snapshot = Snapshot::builder_for(path).build(&engine).unwrap();
+
+        let res = timestamp_range_to_versions(&snapshot, &engine, 300, Some(100));
+        assert!(
+            matches!(
+                res,
+                Err(crate::Error::LogHistory(ref e))
+                    if matches!(**e, LogHistoryError::InvalidTimestampRange { .. })
+            ),
+            "{res:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_timestamp_range_empty_range() {
+        // Table: v0=50, v1=150, v2=250 (file mod), v3=300, v4=400 (ICT at v3)
+        let timestamps = [
+            (50, None),
+            (150, None),
+            (250, None),
+            (350, Some(300)),
+            (450, Some(400)),
+        ];
+        let table = mock_table_with_timestamps(&timestamps, Some(3)).await;
+        let engine = SyncEngine::new();
+        let path = Url::from_directory_path(table.table_root()).unwrap();
+        let snapshot = Snapshot::builder_for(path).build(&engine).unwrap();
+
+        // Timestamps 51-149 fall between v0 (ts=50) and v1 (ts=150)
+        let res = timestamp_range_to_versions(&snapshot, &engine, 51, Some(149));
+        assert!(
+            matches!(
+                res,
+                Err(crate::Error::LogHistory(ref e))
+                    if matches!(**e, LogHistoryError::EmptyTimestampRange { between_version: 0, .. })
+            ),
+            "{res:?}"
+        );
+    }
+
+    // ====================================================================================
+    // High-level API tests for additional table configurations
+    // ====================================================================================
+
+    /// File-mod-only table (no ICT): v0=100, v1=200, v2=300
+    #[rstest::rstest]
+    #[case::exact_match(200, Some(1))]
+    #[case::between_commits(150, Some(0))]
+    #[case::after_all(500, Some(2))]
+    #[case::before_all(50, None)]
+    #[tokio::test]
+    async fn test_latest_version_as_of_file_mod_only(
+        #[case] timestamp: Timestamp,
+        #[case] expected: Option<Version>,
+    ) {
+        let table =
+            mock_table_with_timestamps(&[(100, None), (200, None), (300, None)], None).await;
+        let engine = SyncEngine::new();
+        let path = Url::from_directory_path(table.table_root()).unwrap();
+        let snapshot = Snapshot::builder_for(path).build(&engine).unwrap();
+
+        let res = latest_version_as_of(&snapshot, &engine, timestamp);
+        match expected {
+            Some(v) => assert_eq!(res.unwrap(), v),
+            None => assert!(res.is_err(), "{res:?}"),
+        }
+    }
+
+    /// File-mod-only table (no ICT): v0=100, v1=200, v2=300
+    #[rstest::rstest]
+    #[case::exact_match(200, Some(1))]
+    #[case::between_commits(150, Some(1))]
+    #[case::before_all(50, Some(0))]
+    #[case::after_all(500, None)]
+    #[tokio::test]
+    async fn test_first_version_after_file_mod_only(
+        #[case] timestamp: Timestamp,
+        #[case] expected: Option<Version>,
+    ) {
+        let table =
+            mock_table_with_timestamps(&[(100, None), (200, None), (300, None)], None).await;
+        let engine = SyncEngine::new();
+        let path = Url::from_directory_path(table.table_root()).unwrap();
+        let snapshot = Snapshot::builder_for(path).build(&engine).unwrap();
+
+        let res = first_version_after(&snapshot, &engine, timestamp);
+        match expected {
+            Some(v) => assert_eq!(res.unwrap(), v),
+            None => assert!(res.is_err(), "{res:?}"),
+        }
+    }
+
+    /// ICT from creation: v0=100, v1=200, v2=300 (all ICT)
+    #[rstest::rstest]
+    #[case::exact_match(200, Some(1))]
+    #[case::between_commits(150, Some(0))]
+    #[case::after_all(500, Some(2))]
+    #[case::before_all(50, None)]
+    #[tokio::test]
+    async fn test_latest_version_as_of_ict_from_creation(
+        #[case] timestamp: Timestamp,
+        #[case] expected: Option<Version>,
+    ) {
+        let table =
+            mock_table_with_timestamps(&[(0, Some(100)), (0, Some(200)), (0, Some(300))], Some(0))
+                .await;
+        let engine = SyncEngine::new();
+        let path = Url::from_directory_path(table.table_root()).unwrap();
+        let snapshot = Snapshot::builder_for(path).build(&engine).unwrap();
+
+        let res = latest_version_as_of(&snapshot, &engine, timestamp);
+        match expected {
+            Some(v) => assert_eq!(res.unwrap(), v),
+            None => assert!(res.is_err(), "{res:?}"),
+        }
+    }
+
+    /// ICT from creation: v0=100, v1=200, v2=300 (all ICT)
+    #[rstest::rstest]
+    #[case::exact_match(200, Some(1))]
+    #[case::between_commits(150, Some(1))]
+    #[case::before_all(50, Some(0))]
+    #[case::after_all(500, None)]
+    #[tokio::test]
+    async fn test_first_version_after_ict_from_creation(
+        #[case] timestamp: Timestamp,
+        #[case] expected: Option<Version>,
+    ) {
+        let table =
+            mock_table_with_timestamps(&[(0, Some(100)), (0, Some(200)), (0, Some(300))], Some(0))
+                .await;
+        let engine = SyncEngine::new();
+        let path = Url::from_directory_path(table.table_root()).unwrap();
+        let snapshot = Snapshot::builder_for(path).build(&engine).unwrap();
+
+        let res = first_version_after(&snapshot, &engine, timestamp);
+        match expected {
+            Some(v) => assert_eq!(res.unwrap(), v),
+            None => assert!(res.is_err(), "{res:?}"),
+        }
+    }
+
+    /// Non-monotonic file mod timestamps (clock skew):
+    /// Raw: v0=100, v1=200, v2=150, v3=180, v4=300
+    /// Monotonized: v0=100, v1=200, v2=201, v3=202, v4=300
+    #[rstest::rstest]
+    #[case::exact_v1(200, Some(1))]
+    #[case::monotonized_v2(201, Some(2))]
+    #[case::monotonized_v3(202, Some(3))]
+    #[case::between_v3_v4(250, Some(3))]
+    #[case::raw_v2_between_v0_v1(150, Some(0))]
+    #[tokio::test]
+    async fn test_latest_version_as_of_non_monotonic(
+        #[case] timestamp: Timestamp,
+        #[case] expected: Option<Version>,
+    ) {
+        let table = mock_table_with_timestamps(
+            &[
+                (100, None),
+                (200, None),
+                (150, None), // Clock skew - earlier than v1
+                (180, None), // Clock skew - earlier than v1
+                (300, None),
+            ],
+            None,
+        )
+        .await;
+        let engine = SyncEngine::new();
+        let path = Url::from_directory_path(table.table_root()).unwrap();
+        let snapshot = Snapshot::builder_for(path).build(&engine).unwrap();
+
+        let res = latest_version_as_of(&snapshot, &engine, timestamp);
+        match expected {
+            Some(v) => assert_eq!(res.unwrap(), v),
+            None => assert!(res.is_err(), "{res:?}"),
+        }
+    }
+
+    /// Non-monotonic file mod timestamps (clock skew):
+    /// Raw: v0=100, v1=200, v2=150, v3=180, v4=300
+    /// Monotonized: v0=100, v1=200, v2=201, v3=202, v4=300
+    #[rstest::rstest]
+    #[case::exact_v1(200, Some(1))]
+    #[case::monotonized_v2(201, Some(2))]
+    #[case::monotonized_v3(202, Some(3))]
+    #[case::after_v3_monotonized(203, Some(4))]
+    #[case::raw_v2_maps_to_v1(150, Some(1))]
+    #[tokio::test]
+    async fn test_first_version_after_non_monotonic(
+        #[case] timestamp: Timestamp,
+        #[case] expected: Option<Version>,
+    ) {
+        let table = mock_table_with_timestamps(
+            &[
+                (100, None),
+                (200, None),
+                (150, None), // Clock skew - earlier than v1
+                (180, None), // Clock skew - earlier than v1
+                (300, None),
+            ],
+            None,
+        )
+        .await;
+        let engine = SyncEngine::new();
+        let path = Url::from_directory_path(table.table_root()).unwrap();
+        let snapshot = Snapshot::builder_for(path).build(&engine).unwrap();
+
+        let res = first_version_after(&snapshot, &engine, timestamp);
+        match expected {
+            Some(v) => assert_eq!(res.unwrap(), v),
+            None => assert!(res.is_err(), "{res:?}"),
+        }
+    }
+
+    /// timestamp_range_to_versions with file-mod-only table (v0=100, v1=200, v2=300)
+    #[rstest::rstest]
+    #[case::basic_range(100, Some(200), Ok((0, Some(1))))]
+    #[case::entire_table(50, Some(500), Ok((0, Some(2))))]
+    #[case::no_end(150, None, Ok((1, None)))]
+    #[case::exact_v0_to_v2(100, Some(300), Ok((0, Some(2))))]
+    #[case::between_commits(150, Some(250), Ok((1, Some(1))))]
+    #[case::start_equals_end_exact(200, Some(200), Ok((1, Some(1))))]
+    #[case::end_before_all_fails(50, Some(80), Err(()))] // No version at or before end_timestamp=80
+    #[case::start_after_all_fails(400, Some(500), Err(()))] // No version at or after start_timestamp=400
+    #[tokio::test]
+    async fn test_timestamp_range_file_mod_only(
+        #[case] start: Timestamp,
+        #[case] end: Option<Timestamp>,
+        #[case] expected: Result<(Version, Option<Version>), ()>,
+    ) {
+        let table =
+            mock_table_with_timestamps(&[(100, None), (200, None), (300, None)], None).await;
+        let engine = SyncEngine::new();
+        let path = Url::from_directory_path(table.table_root()).unwrap();
+        let snapshot = Snapshot::builder_for(path).build(&engine).unwrap();
+
+        let res = timestamp_range_to_versions(&snapshot, &engine, start, end);
+        match expected {
+            Ok(v) => assert_eq!(res.unwrap(), v),
+            Err(()) => assert!(res.is_err(), "{res:?}"),
+        }
+    }
+
+    /// timestamp_range_to_versions with ICT from creation (v0=100, v1=200, v2=300)
+    #[rstest::rstest]
+    #[case::basic_range(100, Some(200), Ok((0, Some(1))))]
+    #[case::entire_table(50, Some(500), Ok((0, Some(2))))]
+    #[case::no_end(150, None, Ok((1, None)))]
+    #[case::exact_v0_to_v2(100, Some(300), Ok((0, Some(2))))]
+    #[case::between_commits(150, Some(250), Ok((1, Some(1))))]
+    #[case::start_equals_end_exact(200, Some(200), Ok((1, Some(1))))]
+    #[case::end_before_all_fails(50, Some(80), Err(()))] // No version at or before end_timestamp=80
+    #[case::start_after_all_fails(400, Some(500), Err(()))] // No version at or after start_timestamp=400
+    #[tokio::test]
+    async fn test_timestamp_range_ict_from_creation(
+        #[case] start: Timestamp,
+        #[case] end: Option<Timestamp>,
+        #[case] expected: Result<(Version, Option<Version>), ()>,
+    ) {
+        let table =
+            mock_table_with_timestamps(&[(0, Some(100)), (0, Some(200)), (0, Some(300))], Some(0))
+                .await;
+        let engine = SyncEngine::new();
+        let path = Url::from_directory_path(table.table_root()).unwrap();
+        let snapshot = Snapshot::builder_for(path).build(&engine).unwrap();
+
+        let res = timestamp_range_to_versions(&snapshot, &engine, start, end);
+        match expected {
+            Ok(v) => assert_eq!(res.unwrap(), v),
+            Err(()) => assert!(res.is_err(), "{res:?}"),
+        }
     }
 }

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -126,6 +126,19 @@ fn get_timestamp_search_bounds(
 ///
 /// # Returns
 /// The version matching the bound criteria, or an error if no match exists.
+//
+// NOTE: Monotonization trade-offs
+//
+// File modification timestamps can have clock skew. We monotonize over visible history
+// only, which may produce incorrect results for commits near the retention boundary if
+// metadata cleanup removed skewed commits that affected monotonization.
+//
+// Since ICT is the correct long-term solution for timestamps, we avoid over-investing
+// in file modification timestamp handling.
+//
+// TODO: Today we read full commit history for timestamp conversion, which is expensive.
+// A future backwards-listing optimization would avoid reading full history - at that
+// point, monotonizing over full history becomes a bad trade-off and should be revisited.
 #[allow(unused)]
 fn linear_search_file_mod_timestamps(
     commits: &[ParsedLogPath],

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -97,16 +97,21 @@ fn get_timestamp_search_bounds(
         )
     );
 
-    // Based on the in-commit timestamp enablement, determine the search bounds. If the
-    // desired timestamp is in the ICT range, we must _only_ search over commits with ICT
-    // enabled. Otherwise, the timestamp range must only consist of commits that use file
-    // modification time as the timestamp.
+    // Per PROTOCOL.md section on In-Commit Timestamps:
+    //   - ts >= enablementTs => consider only versions >= enablementVersion (ICT region)
+    //   - ts <  enablementTs => consider only versions <  enablementVersion (file mod region)
     let result = match timestamp.cmp(&ict_timestamp) {
+        // Equal: enablementTs IS the ICT of enablementVersion, so this version is the exact
+        // answer for both bounds (GreatestLower and LeastUpper).
         Ordering::Equal => TimestampSearchBounds::ExactMatch(ict_enablement_version),
+        // Less: Restrict search to the pre-ICT region via FileModificationSearchUntil. The
+        // protocol guarantees enablementTs > prev_mod_time, so when the pre-ICT linear scan
+        // fails for LeastUpper, enablementVersion is the true least upper bound.
         Ordering::Less => TimestampSearchBounds::FileModificationSearchUntil {
             index: ict_enablement_idx,
             ict_enablement_version,
         },
+        // Greater: Restrict search to ICT commits only via ICTSearchStartingFrom.
         Ordering::Greater => TimestampSearchBounds::ICTSearchStartingFrom(ict_enablement_idx),
     };
     Ok(result)

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -1,6 +1,3 @@
-// Low-level timestamp conversion internals. Made public in a later PR.
-#![allow(unused)]
-
 //! This module provides functions for performing timestamp queries over the Delta Log, translating
 //! between timestamps and Delta versions.
 //!
@@ -37,7 +34,7 @@ use crate::{DeltaResult, Engine, Error as DeltaError, Version};
 
 pub(crate) mod search;
 
-pub(crate) mod error;
+pub mod error;
 
 /// A timestamp representing milliseconds since the Unix epoch (1970-01-01 00:00:00 UTC).
 ///

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -40,6 +40,7 @@ enum TimestampSearchBounds {
 ///     1) A range of commits whose timestamp is the file modification timestamp
 ///     2) A range of commits whose timestamp is an in-commit timestamp.
 #[allow(unused)]
+#[tracing::instrument(skip(snapshot, log_segment), ret)]
 fn get_timestamp_search_bounds(
     snapshot: &Snapshot,
     log_segment: &LogSegment,
@@ -173,13 +174,12 @@ pub(crate) fn timestamp_to_version(
     if lo >= hi {
         return Err(LogHistoryError::TimestampOutOfRange { timestamp, bound });
     }
+    debug_assert!(lo < len, "lo index {} should be less than len {}", lo, len);
+    debug_assert!(hi <= len, "hi index {} should be at most len {}", hi, len);
 
     let lo_version = log_segment.listed.ascending_commit_files[lo].version;
     let hi_version = log_segment.listed.ascending_commit_files[hi - 1].version;
-    info!(
-        ?search_bounds,
-        lo_version, hi_version, "Timestamp search bounds"
-    );
+    info!(lo_version, hi_version, "Searching version range");
 
     // We only search in the range [lo..hi).
     let commit_range = &log_segment.listed.ascending_commit_files[lo..hi];

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -398,9 +398,8 @@ pub(crate) fn timestamp_to_version(
 /// let timestamp = 1672531200000; // Milliseconds since epoch for 2023-01-01
 /// let version = latest_version_as_of(&snapshot, &engine, timestamp)?;
 /// ```
-#[allow(unused)]
-#[tracing::instrument(skip(snapshot, engine), fields(latest_version = snapshot.version(), table_root = %snapshot.table_root()))]
-pub(crate) fn latest_version_as_of(
+#[tracing::instrument(skip(snapshot, engine), ret, fields(latest_version = snapshot.version(), table_root = %snapshot.table_root()))]
+pub fn latest_version_as_of(
     snapshot: &Snapshot,
     engine: &dyn Engine,
     timestamp: Timestamp,
@@ -426,9 +425,8 @@ pub(crate) fn latest_version_as_of(
 /// let timestamp = 1672531200000; // Milliseconds since epoch for 2023-01-01
 /// let version = first_version_after(&snapshot, &engine, timestamp)?;
 /// ```
-#[allow(unused)]
-#[tracing::instrument(skip(snapshot, engine), fields(latest_version = snapshot.version(), table_root = %snapshot.table_root()))]
-pub(crate) fn first_version_after(
+#[tracing::instrument(skip(snapshot, engine), ret, fields(latest_version = snapshot.version(), table_root = %snapshot.table_root()))]
+pub fn first_version_after(
     snapshot: &Snapshot,
     engine: &dyn Engine,
     timestamp: Timestamp,
@@ -479,9 +477,8 @@ pub(crate) fn first_version_after(
 /// let (start_version, end_version) =
 ///     timestamp_range_to_versions(&snapshot, &engine, start_timestamp, Some(end_timestamp))?;
 /// ```
-#[allow(unused)]
-#[tracing::instrument(skip(snapshot, engine), fields(latest_version = snapshot.version(), table_root = %snapshot.table_root()))]
-pub(crate) fn timestamp_range_to_versions(
+#[tracing::instrument(skip(snapshot, engine), ret, fields(latest_version = snapshot.version(), table_root = %snapshot.table_root()))]
+pub fn timestamp_range_to_versions(
     snapshot: &Snapshot,
     engine: &dyn Engine,
     start_timestamp: Timestamp,
@@ -1058,31 +1055,24 @@ mod tests {
         }
     }
 
-    // Table: v0=50, v1=150, v2=250 (file mod), v3=300, v4=400 (ICT at v3)
-    // Comprehensive boundary test cases matching test_latest_version_as_of and
-    // test_first_version_after
+    /// Table: v0=50, v1=150, v2=250 (file mod), v3=300, v4=400 (ICT at v3)
     #[rstest::rstest]
-    // Basic range tests
     #[case::basic_range(50, Some(300), Ok((0, Some(3))))]
     #[case::no_end(100, None, Ok((1, None)))]
     #[case::start_equals_end(150, Some(150), Ok((1, Some(1))))]
     #[case::spanning_ict_boundary(100, Some(350), Ok((1, Some(3))))]
     #[case::entire_table(0, Some(1000), Ok((0, Some(4))))]
-    // Exact timestamp boundaries
     #[case::exact_v0_to_v1(50, Some(150), Ok((0, Some(1))))]
     #[case::exact_v1_to_v2(150, Some(250), Ok((1, Some(2))))]
     #[case::exact_v3_ict_to_v4(300, Some(400), Ok((3, Some(4))))]
-    // File mod region boundaries
     #[case::between_v0_v1_to_exact_v2(100, Some(250), Ok((1, Some(2))))]
     #[case::just_after_last_file_mod_no_end(251, None, Ok((3, None)))]
     #[case::just_before_ict_to_just_after(299, Some(301), Ok((3, Some(3))))]
-    // ICT region boundaries
     #[case::exact_ict_to_after_all(300, Some(1000), Ok((3, Some(4))))]
     #[case::between_ict_commits(350, Some(400), Ok((4, Some(4))))]
     #[case::just_after_ict_to_end(301, Some(1000), Ok((4, Some(4))))]
-    // Error cases embedded as rstest cases
-    #[case::end_before_all_fails(0, Some(40), Err(()))] // No version at or before end_timestamp=40
-    #[case::start_after_all_fails(500, Some(1000), Err(()))] // No version at or after start_timestamp=500
+    #[case::end_before_all_fails(0, Some(40), Err(()))]
+    #[case::start_after_all_fails(500, Some(1000), Err(()))]
     #[tokio::test]
     async fn test_timestamp_range_to_versions(
         #[case] start: Timestamp,
@@ -1343,8 +1333,8 @@ mod tests {
     #[case::exact_v0_to_v2(100, Some(300), Ok((0, Some(2))))]
     #[case::between_commits(150, Some(250), Ok((1, Some(1))))]
     #[case::start_equals_end_exact(200, Some(200), Ok((1, Some(1))))]
-    #[case::end_before_all_fails(50, Some(80), Err(()))] // No version at or before end_timestamp=80
-    #[case::start_after_all_fails(400, Some(500), Err(()))] // No version at or after start_timestamp=400
+    #[case::end_before_all_fails(50, Some(80), Err(()))]
+    #[case::start_after_all_fails(400, Some(500), Err(()))]
     #[tokio::test]
     async fn test_timestamp_range_file_mod_only(
         #[case] start: Timestamp,
@@ -1372,8 +1362,8 @@ mod tests {
     #[case::exact_v0_to_v2(100, Some(300), Ok((0, Some(2))))]
     #[case::between_commits(150, Some(250), Ok((1, Some(1))))]
     #[case::start_equals_end_exact(200, Some(200), Ok((1, Some(1))))]
-    #[case::end_before_all_fails(50, Some(80), Err(()))] // No version at or before end_timestamp=80
-    #[case::start_after_all_fails(400, Some(500), Err(()))] // No version at or after start_timestamp=400
+    #[case::end_before_all_fails(50, Some(80), Err(()))]
+    #[case::start_after_all_fails(400, Some(500), Err(()))]
     #[tokio::test]
     async fn test_timestamp_range_ict_from_creation(
         #[case] start: Timestamp,

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -233,6 +233,45 @@ fn linear_search_file_mod_timestamps(
     })
 }
 
+/// Binary search over commits with In-Commit Timestamps (ICT).
+///
+/// ICT timestamps are guaranteed monotonic by protocol, so binary search is safe.
+fn binary_search_ict_timestamps(
+    commits: &[ParsedLogPath],
+    timestamp: Timestamp,
+    bound: Bound,
+    engine: &dyn Engine,
+) -> Result<Version, LogHistoryError> {
+    if commits.is_empty() {
+        return Err(LogHistoryError::TimestampOutOfRange {
+            timestamp,
+            reason: bound.out_of_range_reason(),
+        });
+    }
+
+    let lo_version = commits[0].version;
+    let hi_version = commits[commits.len() - 1].version;
+    info!(
+        lo_version,
+        hi_version, "ICT binary search over version range"
+    );
+
+    let commit_to_ict = |commit: &ParsedLogPath| -> Result<Timestamp, LogHistoryError> {
+        commit
+            .read_in_commit_timestamp(engine)
+            .map_err(|e| LogHistoryError::internal("failed to read in-commit timestamp", e))
+    };
+
+    match binary_search_by_key_with_bounds(commits, timestamp, commit_to_ict, bound) {
+        Ok(idx) => Ok(commits[idx].version),
+        Err(SearchError::KeyFunctionError(error)) => Err(error),
+        Err(SearchError::OutOfRange) => Err(LogHistoryError::TimestampOutOfRange {
+            timestamp,
+            reason: bound.out_of_range_reason(),
+        }),
+    }
+}
+
 /// Converts a timestamp to a version based on the specified bound type.
 ///
 /// This function finds the appropriate commit version that corresponds to the given timestamp
@@ -325,69 +364,24 @@ pub(crate) fn timestamp_to_version(
     );
     debug_assert!(log_segment.end_version == snapshot.log_segment().end_version);
 
-    let len = log_segment.listed.ascending_commit_files.len();
-
     // Determine the type of timestamp search. The search may either be over file modification
     // timestamps or over In-Commit Timestamps.
+    let commits = &log_segment.listed.ascending_commit_files;
     let search_bounds = get_timestamp_search_bounds(snapshot, &log_segment, timestamp)?;
 
     match search_bounds {
         TimestampSearchBounds::ExactMatch(version) => Ok(version),
-
-        // ICT search: use binary search (ICT timestamps are guaranteed monotonic by protocol)
         TimestampSearchBounds::ICTSearchStartingFrom(lo) => {
-            let commit_range = &log_segment.listed.ascending_commit_files[lo..];
-            if commit_range.is_empty() {
-                return Err(LogHistoryError::TimestampOutOfRange {
-                    timestamp,
-                    reason: bound.out_of_range_reason(),
-                });
-            }
-
-            let lo_version = commit_range[0].version;
-            let hi_version = commit_range[commit_range.len() - 1].version;
-            info!(
-                lo_version,
-                hi_version, "ICT binary search over version range"
-            );
-
-            let commit_to_ict = |commit: &ParsedLogPath| -> Result<Timestamp, LogHistoryError> {
-                commit
-                    .read_in_commit_timestamp(engine)
-                    .map_err(|e| LogHistoryError::internal("failed to read in-commit timestamp", e))
-            };
-
-            let search_result =
-                binary_search_by_key_with_bounds(commit_range, timestamp, commit_to_ict, bound);
-
-            match search_result {
-                Ok(relative_idx) => {
-                    let idx = lo + relative_idx;
-                    debug_assert!(idx < len, "Index should be valid");
-                    Ok(log_segment.listed.ascending_commit_files[idx].version)
-                }
-                Err(SearchError::KeyFunctionError(error)) => Err(error),
-                Err(SearchError::OutOfRange) => Err(LogHistoryError::TimestampOutOfRange {
-                    timestamp,
-                    reason: bound.out_of_range_reason(),
-                }),
-            }
+            binary_search_ict_timestamps(&commits[lo..], timestamp, bound, engine)
         }
-
-        // File modification search: use linear scan with monotonization
-        // (file mod timestamps are NOT guaranteed monotonic due to clock skew)
         TimestampSearchBounds::FileModificationSearch => {
-            let commits = &log_segment.listed.ascending_commit_files[..];
             linear_search_file_mod_timestamps(commits, timestamp, bound)
         }
-
-        // File modification search up to ICT enablement point
         TimestampSearchBounds::FileModificationSearchUntil {
             index,
             ict_enablement_version,
         } => {
-            let commits = &log_segment.listed.ascending_commit_files[..index];
-            linear_search_file_mod_timestamps(commits, timestamp, bound).or_else(|e| {
+            linear_search_file_mod_timestamps(&commits[..index], timestamp, bound).or_else(|e| {
                 // For LeastUpper, if no version found in pre-ICT region, the ICT enablement
                 // version is the answer (protocol guarantees enablementTs > prev_mod_time)
                 match (&e, bound) {

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -8,7 +8,7 @@ use std::cmp::Ordering;
 
 use error::LogHistoryError;
 use search::{binary_search_by_key_with_bounds, Bound, SearchError};
-use tracing::{info, warn};
+use tracing::{info, trace};
 
 use crate::log_segment::LogSegment;
 use crate::path::ParsedLogPath;
@@ -169,9 +169,11 @@ fn linear_search_file_mod_timestamps(
         // Monotonize: ensure each timestamp is strictly greater than the previous
         let monotonic_ts = raw_ts.max(prev_monotonic_ts + 1);
         if monotonic_ts != raw_ts {
-            warn!(
+            trace!(
                 version = commit.version,
-                raw_ts, monotonic_ts, "Adjusted non-monotonic timestamp"
+                raw_ts,
+                monotonic_ts,
+                "Adjusted non-monotonic timestamp"
             );
         }
 

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -1,3 +1,6 @@
+// Low-level timestamp conversion internals. Made public in a later PR.
+#![allow(unused)]
+
 //! This module provides functions for performing timestamp queries over the Delta Log, translating
 //! between timestamps and Delta versions.
 
@@ -16,9 +19,6 @@ use crate::{Engine, Error as DeltaError, Version};
 
 pub(crate) mod search;
 
-#[cfg(feature = "internal-api")]
-pub mod error;
-#[cfg(not(feature = "internal-api"))]
 pub(crate) mod error;
 
 type Timestamp = i64;

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -18,9 +18,9 @@
 //!
 //! # Limitations
 //!
-//! All timestamp queries are limited to the state captured in the [`Snapshot`] provided during
-//! construction. For tables without ICT enabled, timestamp queries rely on file modification
-//! timestamps, which are not guaranteed to be monotonically increasing across commits.
+//! All timestamp queries are limited to the state captured in the provided [`Snapshot`]. For
+//! tables without ICT enabled, timestamp queries rely on file modification timestamps, which are
+//! not guaranteed to be monotonically increasing across commits.
 
 use std::cmp::Ordering;
 
@@ -40,7 +40,10 @@ pub(crate) mod search;
 pub(crate) mod error;
 
 /// A timestamp representing milliseconds since the Unix epoch (1970-01-01 00:00:00 UTC).
-pub(crate) type Timestamp = i64;
+///
+/// This type is used throughout the history_manager module for timestamp-to-version conversion.
+/// All timestamp values should be specified in milliseconds, not seconds or nanoseconds.
+pub type Timestamp = i64;
 
 /// Determines the search strategy for timestamp-to-version conversion based on ICT enablement.
 #[derive(Debug, PartialEq, Eq)]
@@ -380,10 +383,10 @@ pub(crate) fn timestamp_to_version(
     }
 }
 
-/// Gets the latest version that occurs before or at the given `timestamp`.
+/// Gets the latest version with a timestamp at or before `timestamp`.
 ///
-/// This finds the version whose timestamp is less than or equal to `timestamp`.
-/// If no such version exists, returns [`LogHistoryError::TimestampOutOfRange`].
+/// Returns [`LogHistoryError::TimestampOutOfRange`] if no version exists at or before
+/// the given timestamp.
 ///
 /// # Examples
 /// ```ignore
@@ -407,10 +410,10 @@ pub fn latest_version_as_of(
     timestamp_to_version(snapshot, engine, timestamp, Bound::GreatestLower).map_err(Into::into)
 }
 
-/// Gets the first version that occurs at or after the given `timestamp`.
+/// Gets the first version with a timestamp at or after `timestamp`.
 ///
-/// This finds the version whose timestamp is greater than or equal to `timestamp`.
-/// If no such version exists, returns [`LogHistoryError::TimestampOutOfRange`].
+/// Returns [`LogHistoryError::TimestampOutOfRange`] if no version exists at or after
+/// the given timestamp.
 ///
 /// # Examples
 /// ```ignore
@@ -421,7 +424,7 @@ pub fn latest_version_as_of(
 /// let engine = DefaultEngine::try_new(...)?;
 /// let snapshot = Snapshot::builder_for(table_uri).build(&engine)?;
 ///
-/// // Find the first version that occurred after January 1, 2023
+/// // Find the first version that occurred at or after January 1, 2023
 /// let timestamp = 1672531200000; // Milliseconds since epoch for 2023-01-01
 /// let version = first_version_after(&snapshot, &engine, timestamp)?;
 /// ```
@@ -749,6 +752,57 @@ mod tests {
         assert!(
             matches!(res, TimestampSearchBounds::ICTSearchStartingFrom(0)),
             "{res:?}"
+        );
+    }
+
+    /// Tests the fast path: when pre-ICT commits are cleaned up (e.g., via VACUUM), the first
+    /// commit in the log segment is at or after ICT enablement. All visible commits have ICT,
+    /// so we return ICTSearchStartingFrom(0) directly without binary search.
+    #[rstest::rstest]
+    #[case::before_all(50)]
+    #[case::at_ict_enablement(300)]
+    #[case::after_ict_enablement(350)]
+    #[case::after_all(1000)]
+    #[tokio::test]
+    async fn test_search_bounds_fast_path_pre_ict_commits_cleaned_up(#[case] timestamp: Timestamp) {
+        // Table: ICT enabled at v3 with ts=300, but only v3+ remain after cleanup
+        let timestamps = [
+            (50, None),
+            (150, None),
+            (250, None),
+            (350, Some(300)),
+            (450, Some(400)),
+        ];
+        let (table, engine, snapshot, _log_segment) =
+            build_test_snapshot(&timestamps, Some(3), None).await;
+
+        // Simulate cleanup: delete pre-ICT commit files (v0, v1, v2)
+        let log_dir = table.table_root().join("_delta_log");
+        for version in 0..3 {
+            let file_name = format!("{:020}.json", version);
+            std::fs::remove_file(log_dir.join(&file_name)).unwrap();
+        }
+
+        // Build a new log segment that only sees v3+ (simulating post-cleanup state)
+        let cleaned_log_segment = LogSegment::for_timestamp_conversion(
+            engine.storage_handler().as_ref(),
+            snapshot.log_segment().log_root.clone(),
+            snapshot.version(),
+            None,
+        )
+        .unwrap();
+
+        // Verify the log segment only contains v3+ (first_version=3 >= ict_enablement_version=3)
+        assert_eq!(
+            cleaned_log_segment.listed.ascending_commit_files[0].version,
+            3
+        );
+
+        // The fast path should trigger: returns ICTSearchStartingFrom(0) for any timestamp
+        let res = get_timestamp_search_bounds(&snapshot, &cleaned_log_segment, timestamp).unwrap();
+        assert!(
+            matches!(res, TimestampSearchBounds::ICTSearchStartingFrom(0)),
+            "Expected fast path ICTSearchStartingFrom(0), got {res:?}"
         );
     }
 

--- a/kernel/src/history_manager/search.rs
+++ b/kernel/src/history_manager/search.rs
@@ -12,16 +12,16 @@ use std::fmt::Debug;
 ///
 /// * [`Bound::GreatestLower`] - Finds the largest index `i` such that `values[i] <= key`. This
 ///   represents the last element less than or equal to the search key.
-#[allow(unused)]
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum Bound {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Bound {
+    /// Find the smallest index with value >= key (first element at or after).
     LeastUpper,
+    /// Find the largest index with value <= key (last element at or before).
     GreatestLower,
 }
 
 /// Represents the errors that can occur when performing binary search using
 /// [`binary_search_by_key_with_bounds`].
-#[allow(unused)]
 #[derive(Debug)]
 pub(crate) enum SearchError<T: Error> {
     /// Error that occurs when a search goes out of range. The meaning of "out of range" depends on
@@ -129,7 +129,6 @@ pub(crate) enum SearchError<T: Error> {
 /// );
 /// assert!(matches!(result, Err(SearchError::KeyFunctionError(_))));
 /// ```
-#[allow(unused)]
 pub(crate) fn binary_search_by_key_with_bounds<'a, T, K: Ord + Debug, E: Error>(
     values: &'a [T],
     key: K,

--- a/kernel/src/history_manager/search.rs
+++ b/kernel/src/history_manager/search.rs
@@ -1,3 +1,6 @@
+// Low-level timestamp conversion internals. Made public in a later PR.
+#![allow(unused)]
+
 //! This module defines the [`binary_search_by_key_with_bounds`] utility method. This can be used to
 //! search over sorted slices of values to find the greatest lower or least upper bounds.
 use std::cmp::Ordering;

--- a/kernel/src/history_manager/search.rs
+++ b/kernel/src/history_manager/search.rs
@@ -1,6 +1,3 @@
-// Low-level timestamp conversion internals. Made public in a later PR.
-#![allow(unused)]
-
 //! This module defines the [`binary_search_by_key_with_bounds`] utility method. This can be used to
 //! search over sorted slices of values to find the greatest lower or least upper bounds.
 use std::cmp::Ordering;

--- a/kernel/src/history_manager/search.rs
+++ b/kernel/src/history_manager/search.rs
@@ -15,7 +15,6 @@ use std::fmt::Debug;
 ///
 /// * [`Bound::GreatestLower`] - Finds the largest index `i` such that `values[i] <= key`. This
 ///   represents the last element less than or equal to the search key.
-#[allow(unused)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Bound {
     /// Find the smallest index with value >= key (first element at or after).
@@ -36,7 +35,6 @@ impl Bound {
 
 /// Represents the errors that can occur when performing binary search using
 /// [`binary_search_by_key_with_bounds`].
-#[allow(unused)]
 #[derive(Debug)]
 pub(crate) enum SearchError<T: Error> {
     /// Error that occurs when a search goes out of range. The meaning of "out of range" depends on
@@ -144,7 +142,6 @@ pub(crate) enum SearchError<T: Error> {
 /// );
 /// assert!(matches!(result, Err(SearchError::KeyFunctionError(_))));
 /// ```
-#[allow(unused)]
 pub(crate) fn binary_search_by_key_with_bounds<'a, T, K: Ord + Debug, E: Error>(
     values: &'a [T],
     key: K,

--- a/kernel/src/history_manager/search.rs
+++ b/kernel/src/history_manager/search.rs
@@ -22,6 +22,7 @@ pub enum Bound {
 
 /// Represents the errors that can occur when performing binary search using
 /// [`binary_search_by_key_with_bounds`].
+#[allow(unused)]
 #[derive(Debug)]
 pub(crate) enum SearchError<T: Error> {
     /// Error that occurs when a search goes out of range. The meaning of "out of range" depends on
@@ -129,6 +130,7 @@ pub(crate) enum SearchError<T: Error> {
 /// );
 /// assert!(matches!(result, Err(SearchError::KeyFunctionError(_))));
 /// ```
+#[allow(unused)]
 pub(crate) fn binary_search_by_key_with_bounds<'a, T, K: Ord + Debug, E: Error>(
     values: &'a [T],
     key: K,

--- a/kernel/src/history_manager/search.rs
+++ b/kernel/src/history_manager/search.rs
@@ -12,12 +12,23 @@ use std::fmt::Debug;
 ///
 /// * [`Bound::GreatestLower`] - Finds the largest index `i` such that `values[i] <= key`. This
 ///   represents the last element less than or equal to the search key.
+#[allow(unused)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Bound {
+pub(crate) enum Bound {
     /// Find the smallest index with value >= key (first element at or after).
     LeastUpper,
     /// Find the largest index with value <= key (last element at or before).
     GreatestLower,
+}
+
+impl Bound {
+    /// Returns the error message for when a timestamp search is out of range.
+    pub(crate) fn out_of_range_reason(&self) -> &'static str {
+        match self {
+            Bound::LeastUpper => "no version exists at or after this timestamp",
+            Bound::GreatestLower => "no version exists at or before this timestamp",
+        }
+    }
 }
 
 /// Represents the errors that can occur when performing binary search using

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -164,7 +164,7 @@ pub(crate) mod last_checkpoint_hint;
 
 pub(crate) mod log_segment_files;
 
-pub(crate) mod history_manager;
+pub mod history_manager;
 
 #[cfg(feature = "internal-api")]
 pub mod parallel;

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -164,9 +164,6 @@ pub(crate) mod last_checkpoint_hint;
 
 pub(crate) mod log_segment_files;
 
-#[cfg(feature = "internal-api")]
-pub mod history_manager;
-#[cfg(not(feature = "internal-api"))]
 pub(crate) mod history_manager;
 
 #[cfg(feature = "internal-api")]

--- a/kernel/src/parallel/sequential_phase.rs
+++ b/kernel/src/parallel/sequential_phase.rs
@@ -340,7 +340,7 @@ mod tests {
         verify_sequential_processing(
             "with_checkpoint_no_last_checkpoint",
             &["part-00000-70b1dcdf-0236-4f63-a072-124cdbafd8a0-c000.snappy.parquet"], /* Add from commit 3 */
-            &[], // No sidecars
+            &[],                                                                      // No sidecars
         )
     }
 }

--- a/kernel/src/parallel/sequential_phase.rs
+++ b/kernel/src/parallel/sequential_phase.rs
@@ -340,7 +340,7 @@ mod tests {
         verify_sequential_processing(
             "with_checkpoint_no_last_checkpoint",
             &["part-00000-70b1dcdf-0236-4f63-a072-124cdbafd8a0-c000.snappy.parquet"], /* Add from commit 3 */
-            &[],                                                                      // No sidecars
+            &[], // No sidecars
         )
     }
 }

--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -285,6 +285,7 @@ impl ParsedLogPath<FileMeta> {
     ///
     /// Returns the inCommitTimestamp value, or an error if ICT is not found or cannot be read.
     /// Callers should handle enablement version checks before calling this method.
+    #[tracing::instrument(skip(engine), ret, fields(version = self.version))]
     pub(crate) fn read_in_commit_timestamp(&self, engine: &dyn Engine) -> DeltaResult<i64> {
         // Only works on commit files
         if !self.is_commit() {

--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -285,7 +285,7 @@ impl ParsedLogPath<FileMeta> {
     ///
     /// Returns the inCommitTimestamp value, or an error if ICT is not found or cannot be read.
     /// Callers should handle enablement version checks before calling this method.
-    #[tracing::instrument(skip(engine), ret, fields(version = self.version))]
+    #[tracing::instrument(skip(engine), ret, fields(version = self.version, path = %self.location.as_url()))]
     pub(crate) fn read_in_commit_timestamp(&self, engine: &dyn Engine) -> DeltaResult<i64> {
         // Only works on commit files
         if !self.is_commit() {


### PR DESCRIPTION
## What changes are proposed in this pull request?

NOTE: Only look at the latest PR

This PR introduces high-level timestamp conversion APIs for Delta tables, allowing conversion between timestamps and table versions.
 - Add `latest_version_as_of(snapshot, engine, timestamp)` - returns the latest version at or before a
  timestamp
  - Add `first_version_after(snapshot, engine, timestamp)` - returns the first version at or after a
  timestamp
  - Add `timestamp_range_to_versions(snapshot, engine, start, end)` - converts a timestamp range to a
  version range

  These APIs enable timestamp-based time travel queries and are the public interface for the
  history_manager module.



**Stack:**
- PR #899
- PR #900 

## How was this change tested?
Unit tests verify timestamp to version conversion functionality with both file modification timestamps and in-commit timestamps. Tests cover edge cases including exact matches, out-of-range timestamps, and transitions between timestamp types.