### PR TITLE
chore: remove abs_diff since we have rust 1.81

### DIFF
--- a/kernel/src/engine/default/filesystem.rs
+++ b/kernel/src/engine/default/filesystem.rs
@@ -192,7 +192,7 @@ mod tests {
     use crate::object_store::memory::InMemory;
     use crate::object_store::{local::LocalFileSystem, ObjectStore};
 
-    use test_utils::{abs_diff, delta_path_for_version};
+    use test_utils::delta_path_for_version;
 
     use crate::engine::default::executor::tokio::TokioBackgroundExecutor;
     use crate::engine::default::DefaultEngine;
@@ -267,7 +267,7 @@ mod tests {
         assert!(!files.is_empty());
         for meta in files.into_iter() {
             let meta_time = Duration::from_millis(meta.last_modified.try_into().unwrap());
-            assert!(abs_diff(meta_time, begin_time) < Duration::from_secs(10));
+            assert!(meta_time.abs_diff(begin_time) < Duration::from_secs(10));
         }
     }
     #[tokio::test]

--- a/kernel/src/engine/sync/storage.rs
+++ b/kernel/src/engine/sync/storage.rs
@@ -84,8 +84,6 @@ mod tests {
     use itertools::Itertools;
     use url::Url;
 
-    use test_utils::abs_diff;
-
     use super::SyncStorageHandler;
     use crate::StorageHandler;
 
@@ -113,7 +111,7 @@ mod tests {
         assert!(!files.is_empty());
         for meta in files.iter() {
             let meta_time = Duration::from_millis(meta.last_modified.try_into()?);
-            assert!(abs_diff(meta_time, begin_time) < Duration::from_secs(10));
+            assert!(meta_time.abs_diff(begin_time) < Duration::from_secs(10));
         }
         Ok(())
     }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -130,13 +130,3 @@ pub fn into_record_batch(engine_data: Box<dyn EngineData>) -> RecordBatch {
         .unwrap()
         .into()
 }
-
-/// We implement abs_diff here so we don't have to bump our msrv.
-/// TODO: Remove and use std version when msrv >= 1.81.0
-pub fn abs_diff(self_dur: std::time::Duration, other: std::time::Duration) -> std::time::Duration {
-    if let Some(res) = self_dur.checked_sub(other) {
-        res
-    } else {
-        other.checked_sub(self_dur).unwrap()
-    }
-}


### PR DESCRIPTION
## What changes are proposed in this pull request?
remove `abs_diff` - it's in rust 1.81

## How was this change tested?
existing