### PR TITLE
feat: Log replay tracks commit file versions

### DIFF
--- a/kernel/src/actions/set_transaction.rs
+++ b/kernel/src/actions/set_transaction.rs
@@ -4,7 +4,9 @@ use crate::actions::get_log_txn_schema;
 use crate::actions::visitors::SetTransactionVisitor;
 use crate::actions::{SetTransaction, SET_TRANSACTION_NAME};
 use crate::log_segment::LogSegment;
-use crate::{DeltaResult, Engine, EngineData, Expression as Expr, ExpressionRef, RowVisitor as _};
+use crate::{
+    DeltaResult, Engine, Expression as Expr, ExpressionRef, LogReplayBatch, RowVisitor as _,
+};
 
 pub(crate) use crate::actions::visitors::SetTransactionMap;
 
@@ -64,7 +66,7 @@ fn scan_application_transactions(
 fn replay_for_app_ids(
     log_segment: &LogSegment,
     engine: &dyn Engine,
-) -> DeltaResult<impl Iterator<Item = DeltaResult<(Box<dyn EngineData>, bool)>> + Send> {
+) -> DeltaResult<impl Iterator<Item = DeltaResult<LogReplayBatch>> + Send> {
     let txn_schema = get_log_txn_schema();
     // This meta-predicate should be effective because all the app ids end up in a single
     // checkpoint part when patitioned by `add.path` like the Delta spec requires. There's no

--- a/kernel/src/checkpoint/log_replay.rs
+++ b/kernel/src/checkpoint/log_replay.rs
@@ -466,17 +466,18 @@ mod tests {
     use super::*;
     use crate::arrow::array::StringArray;
     use crate::utils::test_utils::{action_batch, parse_json_batch};
+    use crate::LogReplayBatch;
     use std::collections::HashSet;
 
     /// Helper function to create test batches from JSON strings
-    fn create_batch(json_strings: Vec<&str>) -> DeltaResult<(Box<dyn EngineData>, bool)> {
+    fn create_batch(json_strings: Vec<&str>) -> DeltaResult<LogReplayBatch> {
         Ok((parse_json_batch(StringArray::from(json_strings)), true))
     }
 
     /// Helper function which applies the [`CheckpointLogReplayProcessor`] to a set of
     /// input batches and returns the results.
     fn run_checkpoint_test(
-        input_batches: Vec<(Box<dyn EngineData>, bool)>,
+        input_batches: Vec<LogReplayBatch>,
     ) -> DeltaResult<(Vec<FilteredEngineData>, i64, i64)> {
         let actions_count = Arc::new(AtomicI64::new(0));
         let add_actions_count = Arc::new(AtomicI64::new(0));

--- a/kernel/src/checkpoint/log_replay.rs
+++ b/kernel/src/checkpoint/log_replay.rs
@@ -35,7 +35,7 @@ use crate::log_replay::{FileActionDeduplicator, FileActionKey, LogReplayProcesso
 use crate::scan::data_skipping::DataSkippingFilter;
 use crate::schema::{column_name, ColumnName, ColumnNamesAndTypes, DataType};
 use crate::utils::require;
-use crate::{DeltaResult, EngineData, Error};
+use crate::{DeltaResult, EngineData, Error, Version};
 
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicI64, Ordering};
@@ -84,14 +84,14 @@ impl LogReplayProcessor for CheckpointLogReplayProcessor {
     fn process_actions_batch(
         &mut self,
         batch: Box<dyn EngineData>,
-        is_log_batch: bool,
+        log_file_version: Option<Version>,
     ) -> DeltaResult<Self::Output> {
         let selection_vector = vec![true; batch.len()];
 
         // Create the checkpoint visitor to process actions and update selection vector
         let mut visitor = CheckpointVisitor::new(
             &mut self.seen_file_keys,
-            is_log_batch,
+            log_file_version,
             selection_vector,
             self.minimum_file_retention_timestamp,
             self.seen_protocol,
@@ -228,7 +228,7 @@ impl CheckpointVisitor<'_> {
 
     pub(crate) fn new<'seen>(
         seen_file_keys: &'seen mut HashSet<FileActionKey>,
-        is_log_batch: bool,
+        log_file_version: Option<Version>,
         selection_vector: Vec<bool>,
         minimum_file_retention_timestamp: i64,
         seen_protocol: bool,
@@ -238,7 +238,7 @@ impl CheckpointVisitor<'_> {
         CheckpointVisitor {
             deduplicator: FileActionDeduplicator::new(
                 seen_file_keys,
-                is_log_batch,
+                log_file_version,
                 Self::ADD_PATH_INDEX,
                 Self::REMOVE_PATH_INDEX,
                 Self::ADD_DV_START_INDEX,
@@ -470,8 +470,9 @@ mod tests {
     use std::collections::HashSet;
 
     /// Helper function to create test batches from JSON strings
-    fn create_batch(json_strings: Vec<&str>) -> DeltaResult<LogReplayBatch> {
-        Ok((parse_json_batch(StringArray::from(json_strings)), true))
+    fn create_batch(json_strings: Vec<&str>, version: Version) -> DeltaResult<LogReplayBatch> {
+        let batch = parse_json_batch(StringArray::from(json_strings));
+        Ok((batch, Some(version)))
     }
 
     /// Helper function which applies the [`CheckpointLogReplayProcessor`] to a set of
@@ -503,7 +504,7 @@ mod tests {
         let mut seen_txns = HashSet::new();
         let mut visitor = CheckpointVisitor::new(
             &mut seen_file_keys,
-            true,
+            Some(1),
             vec![true; 9],
             0, // minimum_file_retention_timestamp (no expired tombstones)
             false,
@@ -558,7 +559,7 @@ mod tests {
         let mut seen_txns = HashSet::new();
         let mut visitor = CheckpointVisitor::new(
             &mut seen_file_keys,
-            true,
+            Some(1), // log_file_version
             vec![true; 4],
             100, // minimum_file_retention_timestamp (threshold set to 100)
             false,
@@ -589,7 +590,7 @@ mod tests {
         let mut seen_txns = HashSet::new();
         let mut visitor = CheckpointVisitor::new(
             &mut seen_file_keys,
-            false, // is_log_batch = false (checkpoint batch)
+            None, // log_file_version
             vec![true; 1],
             0,
             false,
@@ -628,7 +629,7 @@ mod tests {
         let mut seen_txns = HashSet::new();
         let mut visitor = CheckpointVisitor::new(
             &mut seen_file_keys,
-            true,
+            Some(1), // log_file_version
             vec![true; 3],
             0,
             false,
@@ -663,7 +664,7 @@ mod tests {
 
         let mut visitor = CheckpointVisitor::new(
             &mut seen_file_keys,
-            true,
+            Some(1), // log_file_version
             vec![true; 3],
             0,
             true,           // The visior has already seen a protocol action
@@ -701,7 +702,7 @@ mod tests {
         let mut seen_txns = HashSet::new();
         let mut visitor = CheckpointVisitor::new(
             &mut seen_file_keys,
-            true, // is_log_batch
+            Some(1), // log_file_version
             vec![true; 7],
             0, // minimum_file_retention_timestamp
             false,
@@ -725,8 +726,8 @@ mod tests {
     /// non-file actions (metadata, protocol, txn) across multiple batches.
     #[test]
     fn test_checkpoint_actions_iter_non_file_actions() -> DeltaResult<()> {
-        // Batch 1: protocol, metadata, and txn actions
-        let batch1 = vec![
+        // Batch 3 (latest): protocol, metadata, and txn actions
+        let batch3 = vec![
             r#"{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}"#,
             r#"{"metaData":{"id":"test1","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"c1\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}},{\"name\":\"c2\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"c3\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":["c1","c2"],"configuration":{},"createdTime":1670892997849}}"#,
             r#"{"txn":{"appId":"app1","version":1,"lastUpdated":123456789}}"#,
@@ -742,13 +743,13 @@ mod tests {
             r#"{"txn":{"appId":"app2","version":1,"lastUpdated":123456789}}"#,
         ];
 
-        // Batch 3: a duplicate action (entire batch should be skipped)
-        let batch3 = vec![r#"{"protocol":{"minReaderVersion":2,"minWriterVersion":3}}"#];
+        // Batch 1 (earliest): a duplicate action (entire batch should be skipped)
+        let batch1 = vec![r#"{"protocol":{"minReaderVersion":2,"minWriterVersion":3}}"#];
 
         let input_batches = vec![
-            create_batch(batch1)?,
-            create_batch(batch2)?,
-            create_batch(batch3)?,
+            create_batch(batch3, 3)?,
+            create_batch(batch2, 2)?,
+            create_batch(batch1, 1)?,
         ];
         let (results, actions_count, add_actions) = run_checkpoint_test(input_batches)?;
 
@@ -766,8 +767,8 @@ mod tests {
     /// file actions (add, remove) across multiple batches.
     #[test]
     fn test_checkpoint_actions_iter_file_actions() -> DeltaResult<()> {
-        // Batch 1: add action (file1) - new, should be included
-        let batch1 = vec![
+        // Batch 3 (newest): add action (file1) - new, should be included
+        let batch3 = vec![
             r#"{"add":{"path":"file1","partitionValues":{"c1":"6","c2":"a"},"size":452,"modificationTime":1670892998137,"dataChange":true}}"#,
         ];
 
@@ -779,15 +780,15 @@ mod tests {
             r#"{"remove":{"path":"file2","deletionTimestamp":100,"dataChange":true,"partitionValues":{}}}"#,
         ];
 
-        // Batch 3: add action (file2) - already seen, should be excluded
-        let batch3 = vec![
+        // Batch 1 (oldest): add action (file2) - already seen, should be excluded
+        let batch1 = vec![
             r#"{"add":{"path":"file2","partitionValues":{"c1":"6","c2":"a"},"size":452,"modificationTime":1670892998137,"dataChange":true}}"#,
         ];
 
         let input_batches = vec![
-            create_batch(batch1)?,
-            create_batch(batch2)?,
-            create_batch(batch3)?,
+            create_batch(batch3, 3)?,
+            create_batch(batch2, 2)?,
+            create_batch(batch1, 1)?,
         ];
         let (results, actions_count, add_actions) = run_checkpoint_test(input_batches)?;
 
@@ -805,16 +806,16 @@ mod tests {
     /// file actions (add, remove) with deletion vectors across multiple batches.
     #[test]
     fn test_checkpoint_actions_iter_file_actions_with_deletion_vectors() -> DeltaResult<()> {
-        // Batch 1: add actions with deletion vectors
-        let batch1 = vec![
+        // Batch 2 (newer): add actions with deletion vectors
+        let batch2 = vec![
             // (file1, DV_ONE) New, should be included
             r#"{"add":{"path":"file1","partitionValues":{},"size":635,"modificationTime":100,"dataChange":true,"deletionVector":{"storageType":"ONE","pathOrInlineDv":"dv1","offset":1,"sizeInBytes":36,"cardinality":2}}}"#,
             // (file1, DV_TWO) New, should be included
             r#"{"add":{"path":"file1","partitionValues":{},"size":635,"modificationTime":100,"dataChange":true,"deletionVector":{"storageType":"TWO","pathOrInlineDv":"dv2","offset":1,"sizeInBytes":36,"cardinality":2}}}"#,
         ];
 
-        // Batch 2: mixed actions with duplicate and new entries
-        let batch2 = vec![
+        // Batch 1 (older): mixed actions with duplicate and new entries
+        let batch1 = vec![
             // (file1, DV_ONE): Already seen, should be excluded
             r#"{"remove":{"path":"file1","deletionTimestamp":100,"dataChange":true,"deletionVector":{"storageType":"ONE","pathOrInlineDv":"dv1","offset":1,"sizeInBytes":36,"cardinality":2}}}"#,
             // (file1, DV_TWO): Already seen, should be excluded
@@ -823,7 +824,7 @@ mod tests {
             r#"{"remove":{"path":"file2","deletionTimestamp":100,"dataChange":true,"partitionValues":{}}}"#,
         ];
 
-        let input_batches = vec![create_batch(batch1)?, create_batch(batch2)?];
+        let input_batches = vec![create_batch(batch2, 2)?, create_batch(batch1, 1)?];
         let (results, actions_count, add_actions) = run_checkpoint_test(input_batches)?;
 
         // Verify results

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -100,6 +100,7 @@ internal_mod!(pub(crate) mod log_replay);
 internal_mod!(pub(crate) mod log_segment);
 
 pub use delta_kernel_derive;
+use delta_kernel_derive::internal_api;
 pub use engine_data::{EngineData, RowVisitor};
 pub use error::{DeltaResult, Error};
 pub use expressions::{Expression, ExpressionRef};
@@ -148,6 +149,11 @@ pub type FileDataReadResult = (FileMeta, Box<dyn EngineData>);
 /// An iterator of data read from specified files
 pub type FileDataReadResultIterator =
     Box<dyn Iterator<Item = DeltaResult<Box<dyn EngineData>>> + Send>;
+
+/// A batch of data produced by log replay. The boolean flag indicates whether the data came from a
+/// log file (true) or checkpoint false).
+#[internal_api]
+pub(crate) type LogReplayBatch = (Box<dyn EngineData>, bool);
 
 /// The metadata that describes an object.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -150,10 +150,10 @@ pub type FileDataReadResult = (FileMeta, Box<dyn EngineData>);
 pub type FileDataReadResultIterator =
     Box<dyn Iterator<Item = DeltaResult<Box<dyn EngineData>>> + Send>;
 
-/// A batch of data produced by log replay. The boolean flag indicates whether the data came from a
-/// log file (true) or checkpoint false).
+/// A batch of data produced by log replay. Batches produced from commit files include Some
+/// associated commit version, while checkpoint files have None.
 #[internal_api]
-pub(crate) type LogReplayBatch = (Box<dyn EngineData>, bool);
+pub(crate) type LogReplayBatch = (Box<dyn EngineData>, Option<Version>);
 
 /// The metadata that describes an object.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/kernel/src/log_replay.rs
+++ b/kernel/src/log_replay.rs
@@ -20,7 +20,7 @@
 use crate::actions::deletion_vector::DeletionVectorDescriptor;
 use crate::engine_data::{GetData, TypedGetData};
 use crate::scan::data_skipping::DataSkippingFilter;
-use crate::{DeltaResult, EngineData};
+use crate::{DeltaResult, EngineData, LogReplayBatch};
 
 use std::collections::HashSet;
 
@@ -282,7 +282,7 @@ pub(crate) trait LogReplayProcessor: Sized {
     /// (batches where at least one row was selected).
     fn process_actions_iter(
         mut self,
-        action_iter: impl Iterator<Item = DeltaResult<(Box<dyn EngineData>, bool)>>,
+        action_iter: impl Iterator<Item = DeltaResult<LogReplayBatch>>,
     ) -> impl Iterator<Item = DeltaResult<Self::Output>> {
         action_iter
             .map(move |action_res| {

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -1028,8 +1028,8 @@ fn test_create_checkpoint_stream_returns_checkpoint_batches_as_is_if_schema_has_
         log_segment.create_checkpoint_stream(&engine, v2_checkpoint_read_schema.clone(), None)?;
 
     // Assert that the first batch returned is from reading checkpoint file 1
-    let (first_batch, is_log_batch) = iter.next().unwrap()?;
-    assert!(!is_log_batch);
+    let (first_batch, log_file_version) = iter.next().unwrap()?;
+    assert!(log_file_version.is_none());
     assert_batch_matches(
         first_batch,
         sidecar_batch_with_given_paths(vec!["sidecar1.parquet"], v2_checkpoint_read_schema),
@@ -1084,8 +1084,8 @@ fn test_create_checkpoint_stream_returns_checkpoint_batches_if_checkpoint_is_mul
 
     // Assert the correctness of batches returned
     for expected_sidecar in ["sidecar1.parquet", "sidecar2.parquet"].iter() {
-        let (batch, is_log_batch) = iter.next().unwrap()?;
-        assert!(!is_log_batch);
+        let (batch, log_file_version) = iter.next().unwrap()?;
+        assert!(log_file_version.is_none());
         assert_batch_matches(
             batch,
             sidecar_batch_with_given_paths(
@@ -1127,8 +1127,8 @@ fn test_create_checkpoint_stream_reads_parquet_checkpoint_batch_without_sidecars
         log_segment.create_checkpoint_stream(&engine, v2_checkpoint_read_schema.clone(), None)?;
 
     // Assert that the first batch returned is from reading checkpoint file 1
-    let (first_batch, is_log_batch) = iter.next().unwrap()?;
-    assert!(!is_log_batch);
+    let (first_batch, log_file_version) = iter.next().unwrap()?;
+    assert!(log_file_version.is_none());
     assert_batch_matches(first_batch, add_batch_simple(v2_checkpoint_read_schema));
     assert!(iter.next().is_none());
 
@@ -1166,8 +1166,8 @@ fn test_create_checkpoint_stream_reads_json_checkpoint_batch_without_sidecars() 
         log_segment.create_checkpoint_stream(&engine, v2_checkpoint_read_schema, None)?;
 
     // Assert that the first batch returned is from reading checkpoint file 1
-    let (first_batch, is_log_batch) = iter.next().unwrap()?;
-    assert!(!is_log_batch);
+    let (first_batch, log_file_version) = iter.next().unwrap()?;
+    assert!(log_file_version.is_none());
     let mut visitor = AddVisitor::default();
     visitor.visit_rows_of(&*first_batch)?;
     assert!(visitor.adds.len() == 1);
@@ -1226,8 +1226,8 @@ fn test_create_checkpoint_stream_reads_checkpoint_file_and_returns_sidecar_batch
         log_segment.create_checkpoint_stream(&engine, v2_checkpoint_read_schema.clone(), None)?;
 
     // Assert that the first batch returned is from reading checkpoint file 1
-    let (first_batch, is_log_batch) = iter.next().unwrap()?;
-    assert!(!is_log_batch);
+    let (first_batch, log_file_version) = iter.next().unwrap()?;
+    assert!(log_file_version.is_none());
     assert_batch_matches(
         first_batch,
         sidecar_batch_with_given_paths(
@@ -1236,16 +1236,16 @@ fn test_create_checkpoint_stream_reads_checkpoint_file_and_returns_sidecar_batch
         ),
     );
     // Assert that the second batch returned is from reading sidecarfile1
-    let (second_batch, is_log_batch) = iter.next().unwrap()?;
-    assert!(!is_log_batch);
+    let (second_batch, log_file_version) = iter.next().unwrap()?;
+    assert!(log_file_version.is_none());
     assert_batch_matches(
         second_batch,
         add_batch_simple(v2_checkpoint_read_schema.clone()),
     );
 
     // Assert that the second batch returned is from reading sidecarfile2
-    let (third_batch, is_log_batch) = iter.next().unwrap()?;
-    assert!(!is_log_batch);
+    let (third_batch, log_file_version) = iter.next().unwrap()?;
+    assert!(log_file_version.is_none());
     assert_batch_matches(
         third_batch,
         add_batch_with_remove(v2_checkpoint_read_schema),

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -14,7 +14,7 @@ use crate::log_replay::{FileActionDeduplicator, FileActionKey, LogReplayProcesso
 use crate::scan::{Scalar, TransformExpr};
 use crate::schema::{ColumnNamesAndTypes, DataType, MapType, SchemaRef, StructField, StructType};
 use crate::utils::require;
-use crate::{DeltaResult, Engine, EngineData, Error, ExpressionEvaluator};
+use crate::{DeltaResult, Engine, EngineData, Error, ExpressionEvaluator, LogReplayBatch};
 
 /// [`ScanLogReplayProcessor`] performs log replay (processes actions) specifically for doing a table scan.
 ///
@@ -386,7 +386,7 @@ impl LogReplayProcessor for ScanLogReplayProcessor {
 /// order of the actions in the log from most recent to least recent.
 pub(crate) fn scan_action_iter(
     engine: &dyn Engine,
-    action_iter: impl Iterator<Item = DeltaResult<(Box<dyn EngineData>, bool)>>,
+    action_iter: impl Iterator<Item = DeltaResult<LogReplayBatch>>,
     logical_schema: SchemaRef,
     transform: Option<Arc<Transform>>,
     physical_predicate: Option<(ExpressionRef, SchemaRef)>,

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -24,7 +24,7 @@ use crate::schema::{
 };
 use crate::snapshot::Snapshot;
 use crate::table_features::ColumnMappingMode;
-use crate::{DeltaResult, Engine, EngineData, Error, FileMeta};
+use crate::{DeltaResult, Engine, EngineData, Error, FileMeta, LogReplayBatch};
 
 use self::log_replay::scan_action_iter;
 use self::state::GlobalScanState;
@@ -467,7 +467,7 @@ impl Scan {
     fn replay_for_scan_metadata(
         &self,
         engine: &dyn Engine,
-    ) -> DeltaResult<impl Iterator<Item = DeltaResult<(Box<dyn EngineData>, bool)>> + Send> {
+    ) -> DeltaResult<impl Iterator<Item = DeltaResult<LogReplayBatch>> + Send> {
         let commit_read_schema = get_log_schema().project(&[ADD_NAME, REMOVE_NAME])?;
         let checkpoint_read_schema = get_log_schema().project(&[ADD_NAME, SIDECAR_NAME])?;
 

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -816,7 +816,7 @@ pub(crate) mod test_utils {
             logical_schema.unwrap_or_else(|| Arc::new(crate::schema::StructType::new(vec![])));
         let iter = scan_action_iter(
             &SyncEngine::new(),
-            batch.into_iter().map(|batch| Ok((batch as _, true))),
+            batch.into_iter().map(|batch| Ok((batch as _, Some(1)))),
             logical_schema,
             transform,
             None,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Historically, there's no way to tell what commit version a given log replay batch came from. This has not caused any problems so far, but upcoming support for features like [row commit versions](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#row-commit-versions) will need version info. 

<!--
Uncomment this section if there are any changes affecting public APIs:
### This PR affects the following public APIs

If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.

Note that _new_ public APIs are not considered breaking.
-->


## How was this change tested?

Updated existing unit tests.