### PR TITLE
feat!: make `Error` non_exhaustive

### DIFF
--- a/ffi/src/error.rs
+++ b/ffi/src/error.rs
@@ -4,6 +4,7 @@ use crate::{kernel_string_slice, ExternEngine, KernelStringSlice};
 
 #[repr(C)]
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum KernelError {
     UnknownError, // catch-all for unrecognized kernel Error types
     FFIError,     // errors encountered in the code layer that supports FFI
@@ -116,6 +117,7 @@ impl From<Error> for KernelError {
             Error::LiteralExpressionTransformError(_) => {
                 KernelError::LiteralExpressionTransformError
             }
+            _ => KernelError::UnknownError,
         }
     }
 }

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -19,6 +19,7 @@ use crate::object_store;
 pub type DeltaResult<T, E = Error> = std::result::Result<T, E>;
 
 /// All the types of errors that the kernel can run into
+#[non_exhaustive]
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     /// This is an error that includes a backtrace. To have a particular type of error include such


### PR DESCRIPTION
## What changes are proposed in this pull request?
Every time we add an `Error` variant, we require a breaking change. In the long-term we would like to have a non-exhaustive `Error` class with easily-consumable error codes + messages. _For now_ this PR takes a small step and makes our `Error` (and corresponding FFI `KernelError`) `#[non_exhaustive]` which will mean we can introduce new errors without tons of breaking changes. Further error refactor left as future work

### This PR affects the following public APIs
both `delta_kernel::Error` and `delta_kernel_ffi::KernelError` are now `non_exhaustive` (calling code must handle wildcard case)

## How was this change tested?
existing