### PR TITLE
feat: Add row index support to the default parquet reader

### DIFF
--- a/kernel/src/engine/arrow_utils.rs
+++ b/kernel/src/engine/arrow_utils.rs
@@ -69,6 +69,7 @@ pub(crate) fn make_arrow_error(s: impl Into<String>) -> Error {
     .with_backtrace()
 }
 
+/// Prepares to enumerate row indexes of rows in a parquet file, accounting for row group skipping.
 pub(crate) struct RowIndexBuilder {
     row_group_starting_row_offsets: Vec<Range<i64>>,
     row_group_ordinals: Option<Vec<usize>>,

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -485,9 +485,13 @@ mod tests {
             .try_collect()
             .unwrap();
         assert_eq!(data.len(), 4);
-        let data: Vec<_> = data.into_iter().map(|batch| {
-            batch.column_by_name("row_index").unwrap().as_primitive::<Int64Type>().values().to_vec()
-        }).collect();
+        let data: Vec<_> = data
+            .into_iter()
+            .map(|batch| {
+                let column = batch.column_by_name("row_index").unwrap();
+                column.as_primitive::<Int64Type>().values().to_vec()
+            })
+            .collect();
         assert_eq!(data[0], &[0, 1, 2]);
         assert_eq!(data[1], &[0]);
         assert_eq!(data[2], &[0, 1]);

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -468,7 +468,7 @@ mod tests {
             metas.push(FileMeta {
                 location: url.clone(),
                 last_modified: meta.last_modified.timestamp(),
-                size: meta.size.try_into().unwrap(),
+                size: meta.size,
             });
         }
 

--- a/kernel/src/engine/parquet_row_group_skipping.rs
+++ b/kernel/src/engine/parquet_row_group_skipping.rs
@@ -1,4 +1,5 @@
 //! An implementation of parquet row group skipping using data skipping predicates over footer stats.
+use crate::engine::arrow_utils::RowIndexBuilder;
 use crate::expressions::{ColumnName, DecimalData, Predicate, Scalar};
 use crate::kernel_predicates::parquet_stats_skipping::ParquetStatsProvider;
 use crate::parquet::arrow::arrow_reader::ArrowReaderBuilder;
@@ -17,22 +18,31 @@ mod tests;
 pub(crate) trait ParquetRowGroupSkipping {
     /// Instructs the parquet reader to perform row group skipping, eliminating any row group whose
     /// stats prove that none of the group's rows can satisfy the given `predicate`.
-    fn with_row_group_filter(self, predicate: &Predicate) -> Self;
+    fn with_row_group_filter(
+        self,
+        predicate: &Predicate,
+        row_indexes: &mut RowIndexBuilder,
+    ) -> Self;
 }
 impl<T> ParquetRowGroupSkipping for ArrowReaderBuilder<T> {
-    fn with_row_group_filter(self, predicate: &Predicate) -> Self {
-        let indices = self
+    fn with_row_group_filter(
+        self,
+        predicate: &Predicate,
+        row_indexes: &mut RowIndexBuilder,
+    ) -> Self {
+        let ordinals: Vec<_> = self
             .metadata()
             .row_groups()
             .iter()
             .enumerate()
-            .filter_map(|(index, row_group)| {
-                // If the group survives the filter, return Some(index) so filter_map keeps it.
-                RowGroupFilter::apply(row_group, predicate).then_some(index)
+            .filter_map(|(ordinal, row_group)| {
+                // If the group survives the filter, return Some(ordinal) so filter_map keeps it.
+                RowGroupFilter::apply(row_group, predicate).then_some(ordinal)
             })
             .collect();
-        debug!("with_row_group_filter({predicate:#?}) = {indices:?})");
-        self.with_row_groups(indices)
+        debug!("with_row_group_filter({predicate:#?}) = {ordinals:?})");
+        row_indexes.select_row_groups(&ordinals);
+        self.with_row_groups(ordinals)
     }
 }
 

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -109,7 +109,7 @@ pub(crate) enum InternalMetadataColumn {
 }
 
 impl InternalMetadataColumn {
-    #[cfg(test)] // TODO: Actually use this in prod code
+    #[cfg(test)]
     pub(crate) fn as_struct_field(&self, name: impl Into<String>) -> StructField {
         let (data_type, nullable) = match self {
             Self::RowIndex => (DataType::LONG, false),


### PR DESCRIPTION
## What changes are proposed in this pull request?

Deletion vectors (and row tracking, eventually) rely on accurate file-level row indexes. But they're not implemented in the kernel's default parquet reader. That means we must rely on the position of rows in data batches returned by each read, and we cannot apply optimizations such as stats-based row group skipping (see https://github.com/delta-io/delta-kernel-rs/issues/860).

Add row index support to the default parquet reader, in the form of a new `RowIndex` variant of `ReorderIndexTransform`. Also start stubbing in a framework for internal metadata columns, in the form of `InternalMetadataColumn` that can be converted to a specially annotated `StructField`. Readers can add a row index column to their schema by passing the column name of their choosing to `InternalMetadataColumn::RowIndex.as_struct_field`. The default parquet reader recognizes that column and injects a transform to generate row indexes (with appropriate adjustments for any row group skipping that might occur).

Fixes https://github.com/delta-io/delta-kernel-rs/issues/919

NOTE: If/when arrow-rs parquet reader gains native support for row indexes, e.g. https://github.com/apache/arrow-rs/pull/7307, we should switch to using that. Our solution here is not robust to advanced parquet reader features like page-level skipping. row-level predicate pushdown, etc. 

## How was this change tested?

TODO: I couldn't find any parquet files in our test set that have multiple row groups, so there is incomplete coverage of the code that adjusts for row group skipping. Ideally, we would have a test that skips the middle of three row groups, to verify that the sequence of row indexes correctly skips the row group as well.

New unit tests.

