### PR TITLE
fix: Use object_store::Path::from_url_path when appropriate

### DIFF
--- a/acceptance/tests/other.rs
+++ b/acceptance/tests/other.rs
@@ -25,7 +25,7 @@ async fn test_read_last_checkpoint() {
     let url = url::Url::from_directory_path(path).unwrap();
 
     let store = Arc::new(LocalFileSystem::new());
-    let prefix = Path::from(url.path());
+    let prefix = Path::from_url_path(url.path()).unwrap();
     let storage = ObjectStoreStorageHandler::new(store, prefix);
     let cp = read_last_checkpoint(&storage, &url).await.unwrap().unwrap();
     assert_eq!(cp.version, 2);

--- a/kernel/src/engine/default/json.rs
+++ b/kernel/src/engine/default/json.rs
@@ -528,7 +528,7 @@ mod tests {
         ))
         .unwrap();
         let url = Url::from_file_path(path).unwrap();
-        let location = Path::from(url.path());
+        let location = Path::from_url_path(url.path()).unwrap();
         let meta = store.head(&location).await.unwrap();
 
         // TODO: remove after arrow 54 support is dropped

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -145,10 +145,10 @@ impl<E: TaskExecutor> DefaultParquetHandler<E> {
         let path = path.join(&name)?;
 
         self.store
-            .put(&Path::from(path.path()), buffer.into())
+            .put(&Path::from_url_path(path.path())?, buffer.into())
             .await?;
 
-        let metadata = self.store.head(&Path::from(path.path())).await?;
+        let metadata = self.store.head(&Path::from_url_path(path.path())?).await?;
         let modification_time = metadata.last_modified.timestamp_millis();
         // TODO: remove after dropping arrow 54 support
         #[allow(clippy::useless_conversion)]
@@ -408,7 +408,7 @@ mod tests {
             "./tests/data/table-with-dv-small/part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c000.snappy.parquet"
         )).unwrap();
         let url = url::Url::from_file_path(path).unwrap();
-        let location = Path::from(url.path());
+        let location = Path::from_url_path(url.path()).unwrap();
         let meta = store.head(&location).await.unwrap();
 
         let reader = ParquetObjectReader::new(store.clone(), location);
@@ -518,7 +518,10 @@ mod tests {
         let expected_location = Url::parse("memory:///data/").unwrap();
 
         // head the object to get metadata
-        let meta = store.head(&Path::from(location.path())).await.unwrap();
+        let meta = store
+            .head(&Path::from_url_path(location.path()).unwrap())
+            .await
+            .unwrap();
         let expected_size = meta.size;
 
         // check that last_modified is within 10s of now
@@ -535,7 +538,7 @@ mod tests {
         assert!(now - last_modified < 10_000);
 
         // check we can read back
-        let path = Path::from(location.path());
+        let path = Path::from_url_path(location.path()).unwrap();
         let reader = ParquetObjectReader::new(store.clone(), path);
         let physical_schema = ParquetRecordBatchStreamBuilder::new(reader)
             .await

--- a/kernel/tests/write.rs
+++ b/kernel/tests/write.rs
@@ -105,9 +105,10 @@ async fn create_table(
     .concat();
 
     // put 0.json with protocol + metadata
-    let path = table_path.path();
-    let path = format!("{path}_delta_log/00000000000000000000.json");
-    store.put(&Path::from(path), data.into()).await?;
+    let path = table_path.join("_delta_log/00000000000000000000.json")?;
+    store
+        .put(&Path::from_url_path(path.path())?, data.into())
+        .await?;
     Ok(Table::new(table_path))
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Several parts of the code (fortunately mostly in tests) incorrectly use `object_store::Path::from(url.path())`. `Url::path` returns a URI-encoded string, and `Path::from` applies URI encoding as well, resulting in double-encoded strings. 

Fortunately, `object_store::Path::from_url_path` exists for just this scenario. Use it.

Related to https://github.com/delta-io/delta-kernel-rs/issues/918

## How was this change tested?

Existing unit tests continue to pass. A larger change would be needed to categorically rule out this kind of issue.