### PR TITLE
fix: Don't include modules via a macro

### DIFF
--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -9,7 +9,6 @@ use std::sync::LazyLock;
 
 use self::deletion_vector::DeletionVectorDescriptor;
 use crate::actions::schemas::GetStructField;
-use crate::internal_mod;
 use crate::schema::{SchemaRef, StructType};
 use crate::table_features::{
     ReaderFeature, WriterFeature, SUPPORTED_READER_FEATURES, SUPPORTED_WRITER_FEATURES,
@@ -31,7 +30,12 @@ pub mod set_transaction;
 
 pub(crate) mod domain_metadata;
 pub(crate) mod schemas;
-internal_mod!(pub(crate) mod visitors);
+
+// see comment in ../lib.rs for the path module for why we include this way
+#[cfg(feature = "internal-api")]
+pub mod visitors;
+#[cfg(not(feature = "internal-api"))]
+pub(crate) mod visitors;
 
 #[internal_api]
 pub(crate) const ADD_NAME: &str = "add";


### PR DESCRIPTION
## What changes are proposed in this pull request?

Turns out `rustfmt` won't format module files that are included via a macro. See [here](https://github.com/rust-lang/rustfmt/issues/3253). 

This meant things like `log_segment.rs` that were included via `internal_mod!` were not getting formatted.

This removes that macro and just uses the "double include" gated by feature flags, which `rustfmt` can handle.

## How was this change tested?
Making sure that miss-formatted code in the effected modules is now formatted when running `cargo fmt`.