### PR TITLE
feat: Store compacted log files in LogSegment

### DIFF
--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -47,17 +47,20 @@ pub(crate) struct LogSegment {
     pub log_root: Url,
     /// Sorted commit files in the log segment (ascending)
     pub ascending_commit_files: Vec<ParsedLogPath>,
+    /// Sorted (by end version) compaction files in the log segment (ascending)
+    pub ascending_compaction_files: Vec<ParsedLogPath>,
     /// Checkpoint files in the log segment.
     pub checkpoint_parts: Vec<ParsedLogPath>,
 }
 
 impl LogSegment {
     pub(crate) fn try_new(
-        mut ascending_commit_files: Vec<ParsedLogPath>,
-        checkpoint_parts: Vec<ParsedLogPath>,
+        listed_files: ListedLogFiles,
         log_root: Url,
         end_version: Option<Version>,
     ) -> DeltaResult<Self> {
+        let ListedLogFiles { mut ascending_commit_files, ascending_compaction_files, checkpoint_parts } = listed_files;
+
         // Commit file versions must be greater than the most recent checkpoint version if it exists
         let checkpoint_version = checkpoint_parts.first().map(|checkpoint_file| {
             ascending_commit_files.retain(|log_path| checkpoint_file.version < log_path.version);
@@ -110,6 +113,7 @@ impl LogSegment {
             checkpoint_version,
             log_root,
             ascending_commit_files,
+            ascending_compaction_files,
             checkpoint_parts,
         })
     }
@@ -133,7 +137,7 @@ impl LogSegment {
     ) -> DeltaResult<Self> {
         let time_travel_version = time_travel_version.into();
 
-        let (ascending_commit_files, checkpoint_parts) =
+        let listed_files =
             match (checkpoint_hint.into(), time_travel_version) {
                 (Some(cp), None) => list_log_files_with_checkpoint(&cp, storage, &log_root, None)?,
                 (Some(cp), Some(end_version)) if cp.version <= end_version => {
@@ -142,9 +146,10 @@ impl LogSegment {
                 _ => list_log_files_with_version(storage, &log_root, None, time_travel_version)?,
             };
 
+        println!("Listed files here: {listed_files:#?}");
+
         LogSegment::try_new(
-            ascending_commit_files,
-            checkpoint_parts,
+            listed_files,
             log_root,
             time_travel_version,
         )
@@ -170,6 +175,7 @@ impl LogSegment {
             }
         }
 
+        // todo: compactions?
         let ascending_commit_files: Vec<_> =
             list_log_files(storage, &log_root, start_version, end_version)?
                 .filter_ok(|x| x.is_commit())
@@ -188,7 +194,12 @@ impl LogSegment {
                 start_version
             ))
         );
-        LogSegment::try_new(ascending_commit_files, vec![], log_root, end_version)
+        let listed_files = ListedLogFiles {
+            ascending_commit_files,
+            ascending_compaction_files: vec![],
+            checkpoint_parts: vec![],
+        };
+        LogSegment::try_new(listed_files, log_root, end_version)
     }
 
     /// Read a stream of actions from this log segment. This returns an iterator of (EngineData,
@@ -446,11 +457,19 @@ fn list_log_files(
         }))
 }
 
+/// A struct to hold the result of listing log files. The commit and compaction files are guaranteed
+/// to be sorted in ascending order by version. The elements of `checkpoint_parts` are all the parts
+/// of the same checkpoint. Checkpoint parts share the same version.
+// TODO: debug asserts in a `new` method to enforce the above?
+#[derive(Debug)]
+pub(crate) struct ListedLogFiles {
+    pub ascending_commit_files: Vec<ParsedLogPath>,
+    pub ascending_compaction_files: Vec<ParsedLogPath>,
+    pub checkpoint_parts: Vec<ParsedLogPath>,
+}
+
 /// List all commit and checkpoint files with versions above the provided `start_version` (inclusive).
-/// If successful, this returns a tuple `(ascending_commit_files, checkpoint_parts)` of type
-/// `(Vec<ParsedLogPath>, Vec<ParsedLogPath>)`. The commit files are guaranteed to be sorted in
-/// ascending order by version. The elements of `checkpoint_parts` are all the parts of the same
-/// checkpoint. Checkpoint parts share the same version.
+/// If successful, this returns a `ListedLogFiles`.
 // TODO: encode some of these guarantees in the output types. e.g. we could have:
 // - SortedCommitFiles: Vec<ParsedLogPath>, is_ascending: bool, end_version: Version
 // - CheckpointParts: Vec<ParsedLogPath>, checkpoint_version: Version (guarantee all same version)
@@ -459,14 +478,18 @@ pub(crate) fn list_log_files_with_version(
     log_root: &Url,
     start_version: Option<Version>,
     end_version: Option<Version>,
-) -> DeltaResult<(Vec<ParsedLogPath>, Vec<ParsedLogPath>)> {
+) -> DeltaResult<ListedLogFiles> {
     // We expect 10 commit files per checkpoint, so start with that size. We could adjust this based
     // on config at some point
+
+    println!("start version: {:?}", start_version);
+    println!("end version: {:?}", end_version);
 
     let log_files = list_log_files(storage, log_root, start_version, end_version)?;
 
     log_files.process_results(|iter| {
         let mut commit_files = Vec::with_capacity(10);
+        let mut compaction_files = Vec::with_capacity(2);
         let mut checkpoint_parts = vec![];
 
         // Group log files by version
@@ -477,12 +500,27 @@ pub(crate) fn list_log_files_with_version(
             for file in files {
                 if file.is_commit() {
                     commit_files.push(file);
+                } else if file.is_compaction() {
+                    let include = if let Some(end_version) = end_version {
+                        // validate this compaction doesn't extend too far
+                        if let LogPathFileType::CompactedCommit{ hi } = file.file_type {
+                            hi <= end_version
+                        } else {
+                            warn!("Found compaction file with type != CompactedCommit");
+                            false // don't include wonky file
+                        }
+                    } else {
+                        true
+                    };
+                    if include {
+                           compaction_files.push(file);
+                    }
                 } else if file.is_checkpoint() {
                     new_checkpoint_parts.push(file);
                 } else {
                     warn!(
-                        "Found a file with unknown file type {:?} at version {}",
-                        file.file_type, version
+                        "Found file {} with unknown file type {:?} at version {}",
+                        file.filename, file.file_type, version
                     );
                 }
             }
@@ -495,10 +533,17 @@ pub(crate) fn list_log_files_with_version(
                 .find(|(num_parts, part_files)| part_files.len() == *num_parts as usize)
             {
                 checkpoint_parts = complete_checkpoint;
-                commit_files.clear(); // Log replay only uses commits after a complete checkpoint
+                // Log replay only uses commits/compactions after a complete checkpoint
+                commit_files.clear();
+                compaction_files.clear();
             }
         }
-        (commit_files, checkpoint_parts)
+
+        ListedLogFiles {
+            ascending_commit_files: commit_files,
+            ascending_compaction_files: compaction_files,
+            checkpoint_parts,
+        }
     })
 }
 
@@ -556,15 +601,15 @@ fn list_log_files_with_checkpoint(
     storage: &dyn StorageHandler,
     log_root: &Url,
     end_version: Option<Version>,
-) -> DeltaResult<(Vec<ParsedLogPath>, Vec<ParsedLogPath>)> {
-    let (commit_files, checkpoint_parts) = list_log_files_with_version(
+) -> DeltaResult<ListedLogFiles> {
+    let listed_files = list_log_files_with_version(
         storage,
         log_root,
         Some(checkpoint_metadata.version),
         end_version,
     )?;
 
-    let Some(latest_checkpoint) = checkpoint_parts.last() else {
+    let Some(latest_checkpoint) = listed_files.checkpoint_parts.last() else {
         // TODO: We could potentially recover here
         return Err(Error::invalid_checkpoint(
             "Had a _last_checkpoint hint but didn't find any checkpoints",
@@ -576,12 +621,12 @@ fn list_log_files_with_checkpoint(
             checkpoint_metadata.version,
             latest_checkpoint.version
         );
-    } else if checkpoint_parts.len() != checkpoint_metadata.parts.unwrap_or(1) {
+    } else if listed_files.checkpoint_parts.len() != checkpoint_metadata.parts.unwrap_or(1) {
         return Err(Error::InvalidCheckpoint(format!(
             "_last_checkpoint indicated that checkpoint should have {} parts, but it has {}",
             checkpoint_metadata.parts.unwrap_or(1),
-            checkpoint_parts.len()
+            listed_files.checkpoint_parts.len()
         )));
     }
-    Ok((commit_files, checkpoint_parts))
+    Ok(listed_files)
 }

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -482,8 +482,8 @@ pub(crate) fn list_log_files_with_version(
     let log_files = list_log_files(storage, log_root, start_version, end_version)?;
 
     log_files.process_results(|iter| {
-        let mut commit_files = Vec::with_capacity(10);
-        let mut compaction_files = Vec::with_capacity(2);
+        let mut ascending_commit_files = Vec::with_capacity(10);
+        let mut ascending_compaction_files = Vec::with_capacity(2);
         let mut checkpoint_parts = vec![];
 
         // Group log files by version
@@ -493,7 +493,7 @@ pub(crate) fn list_log_files_with_version(
             let mut new_checkpoint_parts = vec![];
             for file in files {
                 if file.is_commit() {
-                    commit_files.push(file);
+                    ascending_commit_files.push(file);
                 } else if file.is_compaction() {
                     let include = if let Some(end_version) = end_version {
                         // validate this compaction doesn't extend too far
@@ -507,7 +507,7 @@ pub(crate) fn list_log_files_with_version(
                         true
                     };
                     if include {
-                        compaction_files.push(file);
+                        ascending_compaction_files.push(file);
                     }
                 } else if file.is_checkpoint() {
                     new_checkpoint_parts.push(file);
@@ -528,14 +528,14 @@ pub(crate) fn list_log_files_with_version(
             {
                 checkpoint_parts = complete_checkpoint;
                 // Log replay only uses commits/compactions after a complete checkpoint
-                commit_files.clear();
-                compaction_files.clear();
+                ascending_commit_files.clear();
+                ascending_compaction_files.clear();
             }
         }
 
         ListedLogFiles {
-            ascending_commit_files: commit_files,
-            ascending_compaction_files: compaction_files,
+            ascending_commit_files,
+            ascending_compaction_files,
             checkpoint_parts,
         }
     })

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -1336,7 +1336,10 @@ fn test_compaction_listing(
         .iter()
         .zip(expected_compaction_versions.iter())
     {
-        assert!(compaction_file.is_compaction());
+        assert!(matches!(
+            compaction_file.file_type,
+            LogPathFileType::CompactedCommit { .. }
+        ));
         assert_eq!(compaction_file.version, *expected_start);
         if let LogPathFileType::CompactedCommit { hi } = compaction_file.file_type {
             assert_eq!(hi, *expected_end);

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -16,9 +16,9 @@ use crate::engine::default::executor::tokio::TokioBackgroundExecutor;
 use crate::engine::default::filesystem::ObjectStoreStorageHandler;
 use crate::engine::default::DefaultEngine;
 use crate::engine::sync::SyncEngine;
-use crate::log_segment::LogSegment;
+use crate::log_segment::{ListedLogFiles, LogSegment};
 use crate::parquet::arrow::ArrowWriter;
-use crate::path::ParsedLogPath;
+use crate::path::{LogPathFileType, ParsedLogPath};
 use crate::scan::test_utils::{
     add_batch_simple, add_batch_with_remove, sidecar_batch_with_given_paths,
 };
@@ -28,7 +28,23 @@ use crate::{
     DeltaResult, Engine as _, EngineData, Expression, FileMeta, PredicateRef, RowVisitor,
     StorageHandler, Table,
 };
-use test_utils::delta_path_for_version;
+use test_utils::{compacted_log_path_for_versions, delta_path_for_version};
+
+// utility to easily create ListedLogFiles
+impl ListedLogFiles {
+    fn new(
+        ascending_commit_files: Vec<ParsedLogPath>,
+        ascending_compaction_files: Vec<ParsedLogPath>,
+        checkpoint_parts: Vec<ParsedLogPath>,
+    ) -> Self {
+        ListedLogFiles {
+            ascending_commit_files,
+            ascending_compaction_files,
+            checkpoint_parts,
+        }
+    }
+}
+
 
 // NOTE: In addition to testing the meta-predicate for metadata replay, this test also verifies
 // that the parquet reader properly infers nullcount = rowcount for missing columns. The two
@@ -962,8 +978,11 @@ fn test_create_checkpoint_stream_errors_when_schema_has_remove_but_no_sidecar_ac
 
     // Create the stream over checkpoint batches.
     let log_segment = LogSegment::try_new(
-        vec![],
-        vec![create_log_path("file:///00000000000000000001.parquet")],
+        ListedLogFiles::new(
+            vec![],
+            vec![],
+            vec![create_log_path("file:///00000000000000000001.parquet")],
+        ),
         log_root,
         None,
     )?;
@@ -987,8 +1006,11 @@ fn test_create_checkpoint_stream_errors_when_schema_has_add_but_no_sidecar_actio
 
     // Create the stream over checkpoint batches.
     let log_segment = LogSegment::try_new(
-        vec![],
-        vec![create_log_path("file:///00000000000000000001.parquet")],
+        ListedLogFiles::new(
+            vec![],
+            vec![],
+            vec![create_log_path("file:///00000000000000000001.parquet")],
+        ),
         log_root,
         None,
     )?;
@@ -1019,8 +1041,11 @@ fn test_create_checkpoint_stream_returns_checkpoint_batches_as_is_if_schema_has_
     let v2_checkpoint_read_schema = get_log_schema().project(&[METADATA_NAME])?;
 
     let log_segment = LogSegment::try_new(
-        vec![],
-        vec![create_log_path(&checkpoint_one_file)],
+        ListedLogFiles::new(
+            vec![],
+            vec![],
+            vec![create_log_path(&checkpoint_one_file)],
+        ),
         log_root,
         None,
     )?;
@@ -1071,11 +1096,14 @@ fn test_create_checkpoint_stream_returns_checkpoint_batches_if_checkpoint_is_mul
     let v2_checkpoint_read_schema = get_log_schema().project(&[ADD_NAME, SIDECAR_NAME])?;
 
     let log_segment = LogSegment::try_new(
-        vec![],
-        vec![
-            create_log_path(&checkpoint_one_file),
-            create_log_path(&checkpoint_two_file),
-        ],
+        ListedLogFiles::new(
+            vec![],
+            vec![],
+            vec![
+                create_log_path(&checkpoint_one_file),
+                create_log_path(&checkpoint_two_file),
+            ],
+        ),
         log_root,
         None,
     )?;
@@ -1118,8 +1146,11 @@ fn test_create_checkpoint_stream_reads_parquet_checkpoint_batch_without_sidecars
     let v2_checkpoint_read_schema = get_log_schema().project(&[ADD_NAME, SIDECAR_NAME])?;
 
     let log_segment = LogSegment::try_new(
-        vec![],
-        vec![create_log_path(&checkpoint_one_file)],
+        ListedLogFiles::new(
+            vec![],
+            vec![],
+            vec![create_log_path(&checkpoint_one_file)],
+        ),
         log_root,
         None,
     )?;
@@ -1157,8 +1188,11 @@ fn test_create_checkpoint_stream_reads_json_checkpoint_batch_without_sidecars() 
     let v2_checkpoint_read_schema = get_log_schema().project(&[ADD_NAME, SIDECAR_NAME])?;
 
     let log_segment = LogSegment::try_new(
-        vec![],
-        vec![create_log_path(&checkpoint_one_file)],
+        ListedLogFiles::new(
+            vec![],
+            vec![],
+            vec![create_log_path(&checkpoint_one_file)],
+        ),
         log_root,
         None,
     )?;
@@ -1217,8 +1251,11 @@ fn test_create_checkpoint_stream_reads_checkpoint_file_and_returns_sidecar_batch
     let v2_checkpoint_read_schema = get_log_schema().project(&[ADD_NAME, SIDECAR_NAME])?;
 
     let log_segment = LogSegment::try_new(
-        vec![],
-        vec![create_log_path(&checkpoint_file_path)],
+        ListedLogFiles::new(
+            vec![],
+            vec![],
+            vec![create_log_path(&checkpoint_file_path)],
+        ),
         log_root,
         None,
     )?;
@@ -1254,4 +1291,133 @@ fn test_create_checkpoint_stream_reads_checkpoint_file_and_returns_sidecar_batch
     assert!(iter.next().is_none());
 
     Ok(())
+}
+
+fn test_compaction_listing(
+    commit_versions: &[u64],
+    compaction_versions: &[(u64, u64)],
+    checkpoint_version: Option<u64>,
+    version_to_load: Option<u64>,
+) {
+    let mut paths: Vec<Path> = commit_versions.iter().map(|version| delta_path_for_version(*version, "json")).chain(
+        compaction_versions.iter().map(|(start, end)| compacted_log_path_for_versions(*start, *end, "json"))).collect();
+    if let Some(version) = checkpoint_version {
+        paths.push(delta_path_for_version(version, "checkpoint.3a0d65cd-4056-49b8-937b-95f9e3ee90e5.json"));
+    }
+    let (storage, log_root) = build_log_with_paths_and_checkpoint(
+        &paths,
+        None,
+    );
+    let log_segment = LogSegment::for_snapshot(storage.as_ref(), log_root.clone(), None, version_to_load).unwrap();
+
+    let version_to_load = version_to_load.unwrap_or(u64::MAX);
+    let checkpoint_cuttoff = checkpoint_version.map(|v| v as i64).unwrap_or(-1);
+    let expected_commit_versions: Vec<&u64> = commit_versions.iter().filter(|v| {
+        **v as i64 > checkpoint_cuttoff && **v <= version_to_load
+    }).collect();
+    let expected_compaction_versions: Vec<&(u64, u64)> = compaction_versions.iter().filter(|(start, end)| {
+        *start as i64 > checkpoint_cuttoff && *end <= version_to_load
+    }).collect();
+
+    assert_eq!(log_segment.ascending_commit_files.len(), expected_commit_versions.len());
+    assert_eq!(log_segment.ascending_compaction_files.len(), expected_compaction_versions.len());
+
+    for (commit_file, expected_version) in log_segment.ascending_commit_files.iter().zip(expected_commit_versions.iter()) {
+        assert!(commit_file.is_commit());
+        assert_eq!(commit_file.version, **expected_version);
+    }
+
+    for (compaction_file, (expected_start, expected_end)) in log_segment.ascending_compaction_files.iter().zip(expected_compaction_versions.iter()) {
+        assert!(compaction_file.is_compaction());
+        assert_eq!(compaction_file.version, *expected_start);
+        if let LogPathFileType::CompactedCommit { hi } = compaction_file.file_type {
+            assert_eq!(hi, *expected_end);
+        } else {
+            panic!("File was compaction but type was not CompactedCommit");
+        }
+    }
+}
+
+#[test]
+fn test_compaction_simple() {
+    test_compaction_listing(
+        &[0, 1, 2],
+        &[(1, 2)],
+        None, // checkpoint version
+        None, // version to load
+    );
+}
+
+#[test]
+fn test_compaction_in_version_range() {
+    test_compaction_listing(
+        &[0, 1, 2, 3],
+        &[(1, 2)],
+        None, // checkpoint version
+        Some(2) // version to load
+    );
+}
+
+#[test]
+fn test_compaction_out_of_version_range() {
+    test_compaction_listing(
+        &[0, 1, 2, 3, 4],
+        &[(1, 3)],
+        None, // checkpoint version
+        Some(2), // version to load
+    );
+}
+
+#[test]
+fn test_multi_compaction() {
+    test_compaction_listing(
+        &[0, 1, 2, 3, 4, 5],
+        &[(1, 2), (3, 5)],
+        None, // checkpoint version
+        None, //version to load
+    );
+}
+
+
+#[test]
+fn test_multi_compaction_one_out_of_range() {
+    test_compaction_listing(
+        &[0, 1, 2, 3, 4, 5],
+        &[(1, 2), (3, 5)],
+        None, // checkpoint version
+        Some(4), // version to load
+    );
+}
+
+
+#[test]
+fn test_compaction_with_checkpoint() {
+    test_compaction_listing(
+        &[0, 1, 2, 4, 5],
+        &[(1, 2), (4, 5)],
+        Some(3), // checkpoint version
+        None, // version to load
+    );
+}
+
+
+
+#[test]
+fn test_compaction_to_early_with_checkpoint() {
+    test_compaction_listing(
+        &[0, 1, 2, 4, 5],
+        &[(1, 2)],
+        Some(3), // checkpoint version
+        None, // version to load
+    );
+}
+
+#[test]
+fn test_compaction_starts_at_checkpoint() {
+    test_compaction_listing(
+        &[0, 1, 2, 4, 5],
+        &[(3, 5)],
+        Some(3), // checkpoint version
+        None, // version to load
+    );
 }

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -45,7 +45,6 @@ impl ListedLogFiles {
     }
 }
 
-
 // NOTE: In addition to testing the meta-predicate for metadata replay, this test also verifies
 // that the parquet reader properly infers nullcount = rowcount for missing columns. The two
 // checkpoint part files that contain transaction app ids have truncated schemas that would
@@ -1041,11 +1040,7 @@ fn test_create_checkpoint_stream_returns_checkpoint_batches_as_is_if_schema_has_
     let v2_checkpoint_read_schema = get_log_schema().project(&[METADATA_NAME])?;
 
     let log_segment = LogSegment::try_new(
-        ListedLogFiles::new(
-            vec![],
-            vec![],
-            vec![create_log_path(&checkpoint_one_file)],
-        ),
+        ListedLogFiles::new(vec![], vec![], vec![create_log_path(&checkpoint_one_file)]),
         log_root,
         None,
     )?;
@@ -1146,11 +1141,7 @@ fn test_create_checkpoint_stream_reads_parquet_checkpoint_batch_without_sidecars
     let v2_checkpoint_read_schema = get_log_schema().project(&[ADD_NAME, SIDECAR_NAME])?;
 
     let log_segment = LogSegment::try_new(
-        ListedLogFiles::new(
-            vec![],
-            vec![],
-            vec![create_log_path(&checkpoint_one_file)],
-        ),
+        ListedLogFiles::new(vec![], vec![], vec![create_log_path(&checkpoint_one_file)]),
         log_root,
         None,
     )?;
@@ -1188,11 +1179,7 @@ fn test_create_checkpoint_stream_reads_json_checkpoint_batch_without_sidecars() 
     let v2_checkpoint_read_schema = get_log_schema().project(&[ADD_NAME, SIDECAR_NAME])?;
 
     let log_segment = LogSegment::try_new(
-        ListedLogFiles::new(
-            vec![],
-            vec![],
-            vec![create_log_path(&checkpoint_one_file)],
-        ),
+        ListedLogFiles::new(vec![], vec![], vec![create_log_path(&checkpoint_one_file)]),
         log_root,
         None,
     )?;
@@ -1251,11 +1238,7 @@ fn test_create_checkpoint_stream_reads_checkpoint_file_and_returns_sidecar_batch
     let v2_checkpoint_read_schema = get_log_schema().project(&[ADD_NAME, SIDECAR_NAME])?;
 
     let log_segment = LogSegment::try_new(
-        ListedLogFiles::new(
-            vec![],
-            vec![],
-            vec![create_log_path(&checkpoint_file_path)],
-        ),
+        ListedLogFiles::new(vec![], vec![], vec![create_log_path(&checkpoint_file_path)]),
         log_root,
         None,
     )?;
@@ -1299,35 +1282,60 @@ fn test_compaction_listing(
     checkpoint_version: Option<u64>,
     version_to_load: Option<u64>,
 ) {
-    let mut paths: Vec<Path> = commit_versions.iter().map(|version| delta_path_for_version(*version, "json")).chain(
-        compaction_versions.iter().map(|(start, end)| compacted_log_path_for_versions(*start, *end, "json"))).collect();
+    let mut paths: Vec<Path> = commit_versions
+        .iter()
+        .map(|version| delta_path_for_version(*version, "json"))
+        .chain(
+            compaction_versions
+                .iter()
+                .map(|(start, end)| compacted_log_path_for_versions(*start, *end, "json")),
+        )
+        .collect();
     if let Some(version) = checkpoint_version {
-        paths.push(delta_path_for_version(version, "checkpoint.3a0d65cd-4056-49b8-937b-95f9e3ee90e5.json"));
+        paths.push(delta_path_for_version(
+            version,
+            "checkpoint.3a0d65cd-4056-49b8-937b-95f9e3ee90e5.json",
+        ));
     }
-    let (storage, log_root) = build_log_with_paths_and_checkpoint(
-        &paths,
-        None,
-    );
-    let log_segment = LogSegment::for_snapshot(storage.as_ref(), log_root.clone(), None, version_to_load).unwrap();
+    let (storage, log_root) = build_log_with_paths_and_checkpoint(&paths, None);
+    let log_segment =
+        LogSegment::for_snapshot(storage.as_ref(), log_root.clone(), None, version_to_load)
+            .unwrap();
 
     let version_to_load = version_to_load.unwrap_or(u64::MAX);
     let checkpoint_cuttoff = checkpoint_version.map(|v| v as i64).unwrap_or(-1);
-    let expected_commit_versions: Vec<&u64> = commit_versions.iter().filter(|v| {
-        **v as i64 > checkpoint_cuttoff && **v <= version_to_load
-    }).collect();
-    let expected_compaction_versions: Vec<&(u64, u64)> = compaction_versions.iter().filter(|(start, end)| {
-        *start as i64 > checkpoint_cuttoff && *end <= version_to_load
-    }).collect();
+    let expected_commit_versions: Vec<&u64> = commit_versions
+        .iter()
+        .filter(|v| **v as i64 > checkpoint_cuttoff && **v <= version_to_load)
+        .collect();
+    let expected_compaction_versions: Vec<&(u64, u64)> = compaction_versions
+        .iter()
+        .filter(|(start, end)| *start as i64 > checkpoint_cuttoff && *end <= version_to_load)
+        .collect();
 
-    assert_eq!(log_segment.ascending_commit_files.len(), expected_commit_versions.len());
-    assert_eq!(log_segment.ascending_compaction_files.len(), expected_compaction_versions.len());
+    assert_eq!(
+        log_segment.ascending_commit_files.len(),
+        expected_commit_versions.len()
+    );
+    assert_eq!(
+        log_segment.ascending_compaction_files.len(),
+        expected_compaction_versions.len()
+    );
 
-    for (commit_file, expected_version) in log_segment.ascending_commit_files.iter().zip(expected_commit_versions.iter()) {
+    for (commit_file, expected_version) in log_segment
+        .ascending_commit_files
+        .iter()
+        .zip(expected_commit_versions.iter())
+    {
         assert!(commit_file.is_commit());
         assert_eq!(commit_file.version, **expected_version);
     }
 
-    for (compaction_file, (expected_start, expected_end)) in log_segment.ascending_compaction_files.iter().zip(expected_compaction_versions.iter()) {
+    for (compaction_file, (expected_start, expected_end)) in log_segment
+        .ascending_compaction_files
+        .iter()
+        .zip(expected_compaction_versions.iter())
+    {
         assert!(compaction_file.is_compaction());
         assert_eq!(compaction_file.version, *expected_start);
         if let LogPathFileType::CompactedCommit { hi } = compaction_file.file_type {
@@ -1353,8 +1361,8 @@ fn test_compaction_in_version_range() {
     test_compaction_listing(
         &[0, 1, 2, 3],
         &[(1, 2)],
-        None, // checkpoint version
-        Some(2) // version to load
+        None,    // checkpoint version
+        Some(2), // version to load
     );
 }
 
@@ -1363,7 +1371,7 @@ fn test_compaction_out_of_version_range() {
     test_compaction_listing(
         &[0, 1, 2, 3, 4],
         &[(1, 3)],
-        None, // checkpoint version
+        None,    // checkpoint version
         Some(2), // version to load
     );
 }
@@ -1378,17 +1386,15 @@ fn test_multi_compaction() {
     );
 }
 
-
 #[test]
 fn test_multi_compaction_one_out_of_range() {
     test_compaction_listing(
         &[0, 1, 2, 3, 4, 5],
         &[(1, 2), (3, 5)],
-        None, // checkpoint version
+        None,    // checkpoint version
         Some(4), // version to load
     );
 }
-
 
 #[test]
 fn test_compaction_with_checkpoint() {
@@ -1396,11 +1402,9 @@ fn test_compaction_with_checkpoint() {
         &[0, 1, 2, 4, 5],
         &[(1, 2), (4, 5)],
         Some(3), // checkpoint version
-        None, // version to load
+        None,    // version to load
     );
 }
-
-
 
 #[test]
 fn test_compaction_to_early_with_checkpoint() {
@@ -1408,7 +1412,7 @@ fn test_compaction_to_early_with_checkpoint() {
         &[0, 1, 2, 4, 5],
         &[(1, 2)],
         Some(3), // checkpoint version
-        None, // version to load
+        None,    // version to load
     );
 }
 
@@ -1418,6 +1422,6 @@ fn test_compaction_starts_at_checkpoint() {
         &[0, 1, 2, 4, 5],
         &[(3, 5)],
         Some(3), // checkpoint version
-        None, // version to load
+        None,    // version to load
     );
 }

--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -161,11 +161,6 @@ impl<Location: AsUrl> ParsedLogPath<Location> {
     }
 
     #[internal_api]
-    pub(crate) fn is_compaction(&self) -> bool {
-        matches!(self.file_type, LogPathFileType::CompactedCommit { .. })
-    }
-
-    #[internal_api]
     pub(crate) fn is_checkpoint(&self) -> bool {
         matches!(
             self.file_type,

--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -162,7 +162,7 @@ impl<Location: AsUrl> ParsedLogPath<Location> {
 
     #[internal_api]
     pub(crate) fn is_compaction(&self) -> bool {
-        matches!(self.file_type, LogPathFileType::CompactedCommit{ .. })
+        matches!(self.file_type, LogPathFileType::CompactedCommit { .. })
     }
 
     #[internal_api]

--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -161,6 +161,11 @@ impl<Location: AsUrl> ParsedLogPath<Location> {
     }
 
     #[internal_api]
+    pub(crate) fn is_compaction(&self) -> bool {
+        matches!(self.file_type, LogPathFileType::CompactedCommit{ .. })
+    }
+
+    #[internal_api]
     pub(crate) fn is_checkpoint(&self) -> bool {
         matches!(
             self.file_type,

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -112,6 +112,12 @@ pub fn delta_path_for_version(version: u64, suffix: &str) -> Path {
     Path::from(path.as_str())
 }
 
+/// get an ObjectStore path for a compressed log file, based on the start/end versions
+pub fn compacted_log_path_for_versions(start_version: u64, end_version: u64, suffix: &str) -> Path {
+    let path = format!("_delta_log/{start_version:020}.{end_version:020}.compacted.{suffix}");
+    Path::from(path.as_str())
+}
+
 /// put a commit file into the specified object store.
 pub async fn add_commit(
     store: &dyn ObjectStore,


### PR DESCRIPTION
## What changes are proposed in this pull request?

This is a "pre-factor" pr. It makes our listing code aware of [compacted log files](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#log-compaction-files), and stores them in the log segment. It handles filtering out compactions that are outside the range of what has been requested or that are not useful due to a checkpoint.

A follow-on PR will handle actually using these files in place of the underlying commits.

This PR introduces a new struct: `ListedLogFiles` which allows our listing to more easily return multiple types of files. This replaces the old tuple of `(commit_files, checkpoint_files)`, as extending that to `(commit_files, compaction_files, checkpoint_files)` felt unwieldy. There will be more types as we add crc support (and potentially others) as well. This necessitated some more code change, but should keep things cleaner in the future.

## How was this change tested?
Lots of unit tests