### PR TITLE
refactor!: Make DataSkippingPredicate dyn compatible

### DIFF
--- a/kernel/src/engine/parquet_row_group_skipping/tests.rs
+++ b/kernel/src/engine/parquet_row_group_skipping/tests.rs
@@ -59,16 +59,16 @@ fn test_get_stat_values() {
     ]);
     let filter = RowGroupFilter::new(metadata.metadata().row_group(0), &columns);
 
-    assert_eq!(filter.get_rowcount_stat(), Some(Scalar::from(5)));
+    assert_eq!(filter.get_rowcount_stat(), Some(5i64.into()));
 
     // Only the BOOL column has any nulls
     assert_eq!(
         filter.get_nullcount_stat(&column_name!("bool")),
-        Some(Scalar::from(3))
+        Some(3i64.into())
     );
     assert_eq!(
         filter.get_nullcount_stat(&column_name!("varlen.utf8")),
-        Some(Scalar::from(0))
+        Some(0i64.into())
     );
 
     assert_eq!(

--- a/kernel/src/engine/parquet_row_group_skipping/tests.rs
+++ b/kernel/src/engine/parquet_row_group_skipping/tests.rs
@@ -59,13 +59,16 @@ fn test_get_stat_values() {
     ]);
     let filter = RowGroupFilter::new(metadata.metadata().row_group(0), &columns);
 
-    assert_eq!(filter.get_rowcount_stat(), Some(5));
+    assert_eq!(filter.get_rowcount_stat(), Some(Scalar::from(5)));
 
     // Only the BOOL column has any nulls
-    assert_eq!(filter.get_nullcount_stat(&column_name!("bool")), Some(3));
+    assert_eq!(
+        filter.get_nullcount_stat(&column_name!("bool")),
+        Some(Scalar::from(3))
+    );
     assert_eq!(
         filter.get_nullcount_stat(&column_name!("varlen.utf8")),
-        Some(0)
+        Some(Scalar::from(0))
     );
 
     assert_eq!(

--- a/kernel/src/kernel_predicates/mod.rs
+++ b/kernel/src/kernel_predicates/mod.rs
@@ -639,7 +639,7 @@ impl<R: ResolveColumnAsScalar> KernelPredicateEvaluator for DefaultKernelPredica
 pub(crate) trait DataSkippingPredicateEvaluator {
     /// The output type produced by this predicate evaluator
     type Output;
-    /// The type of min column stats
+    /// The type for column stats consumed by this predicate evaluator
     type ColumnStat;
 
     /// Retrieves the minimum value of a column, if it exists and has the requested type.
@@ -844,10 +844,8 @@ impl<T: DataSkippingPredicateEvaluator + ?Sized> KernelPredicateEvaluator for T 
     }
 }
 
+// Statically verify that both forms of the trait are dyn compatible
 #[cfg(test)]
-// Statically verify the trait is dyn compatible
 const _: Option<&dyn DataSkippingPredicateEvaluator<Output = Pred, ColumnStat = Expr>> = None;
-
 #[cfg(test)]
-// Statically verify the trait is dyn compatible
 const _: Option<&dyn DataSkippingPredicateEvaluator<Output = bool, ColumnStat = Scalar>> = None;

--- a/kernel/src/kernel_predicates/mod.rs
+++ b/kernel/src/kernel_predicates/mod.rs
@@ -639,22 +639,20 @@ impl<R: ResolveColumnAsScalar> KernelPredicateEvaluator for DefaultKernelPredica
 pub(crate) trait DataSkippingPredicateEvaluator {
     /// The output type produced by this predicate evaluator
     type Output;
-    /// The type of min and max column stats
-    type TypedStat;
-    /// The type of nullcount and rowcount column stats
-    type IntStat;
+    /// The type of min column stats
+    type ColumnStat;
 
     /// Retrieves the minimum value of a column, if it exists and has the requested type.
-    fn get_min_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Self::TypedStat>;
+    fn get_min_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Self::ColumnStat>;
 
     /// Retrieves the maximum value of a column, if it exists and has the requested type.
-    fn get_max_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Self::TypedStat>;
+    fn get_max_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Self::ColumnStat>;
 
     /// Retrieves the null count of a column, if it exists.
-    fn get_nullcount_stat(&self, col: &ColumnName) -> Option<Self::IntStat>;
+    fn get_nullcount_stat(&self, col: &ColumnName) -> Option<Self::ColumnStat>;
 
     /// Retrieves the row count of a column (parquet footers always include this stat).
-    fn get_rowcount_stat(&self) -> Option<Self::IntStat>;
+    fn get_rowcount_stat(&self) -> Option<Self::ColumnStat>;
 
     /// See [`KernelPredicateEvaluator::eval_pred_scalar`]
     fn eval_pred_scalar(&self, val: &Scalar, inverted: bool) -> Option<Self::Output>;
@@ -684,7 +682,7 @@ pub(crate) trait DataSkippingPredicateEvaluator {
     fn finish_eval_pred_junction(
         &self,
         op: JunctionPredicateOp,
-        preds: impl IntoIterator<Item = Option<Self::Output>>,
+        preds: &mut dyn Iterator<Item = Option<Self::Output>>,
         inverted: bool,
     ) -> Option<Self::Output>;
 
@@ -693,7 +691,7 @@ pub(crate) trait DataSkippingPredicateEvaluator {
     fn eval_partial_cmp(
         &self,
         ord: Ordering,
-        col: Self::TypedStat,
+        col: Self::ColumnStat,
         val: &Scalar,
         inverted: bool,
     ) -> Option<Self::Output>;
@@ -785,11 +783,11 @@ pub(crate) trait DataSkippingPredicateEvaluator {
             ];
             (JunctionPredicateOp::And, preds)
         };
-        self.finish_eval_pred_junction(op, preds, false)
+        self.finish_eval_pred_junction(op, &mut preds.into_iter(), false)
     }
 }
 
-impl<T: DataSkippingPredicateEvaluator> KernelPredicateEvaluator for T {
+impl<T: DataSkippingPredicateEvaluator + ?Sized> KernelPredicateEvaluator for T {
     type Output = T::Output;
 
     fn eval_pred_scalar(&self, val: &Scalar, inverted: bool) -> Option<Self::Output> {
@@ -842,6 +840,14 @@ impl<T: DataSkippingPredicateEvaluator> KernelPredicateEvaluator for T {
         preds: impl IntoIterator<Item = Option<Self::Output>>,
         inverted: bool,
     ) -> Option<Self::Output> {
-        self.finish_eval_pred_junction(op, preds, inverted)
+        self.finish_eval_pred_junction(op, &mut preds.into_iter(), inverted)
     }
 }
+
+#[cfg(test)]
+// Statically verify the trait is dyn compatible
+const _: Option<&dyn DataSkippingPredicateEvaluator<Output = Pred, ColumnStat = Expr>> = None;
+
+#[cfg(test)]
+// Statically verify the trait is dyn compatible
+const _: Option<&dyn DataSkippingPredicateEvaluator<Output = bool, ColumnStat = Scalar>> = None;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Upcoming support for opaque engine expressions (see https://github.com/delta-io/delta-kernel-rs/issues/764) will require passing `&dyn DataSkippingPredicate` to opaque expression operations, so they can correctly evaluate their child expressions.

The trait was already almost dyn-compatible, except that `finish_eval_pred_junction` took an `impl IntoIterator` (now changed to `&dyn Iterator`). 

While we're at it, simplify the trait's type signature by combining associated types `TypedStat` and `IntStat` to just one `ColumnStat` type:
```rust
// Before
&dyn DataSkippingPredicateEvaluator<Output = Pred, TypedStat = Expr, IntStat = Expr>
&dyn DataSkippingPredicateEvaluator<Output = bool, TypedStat = Scalar, IntStat = i64>

// After
&dyn DataSkippingPredicateEvaluator<Output = Pred, ColumnStat = Expr>
&dyn DataSkippingPredicateEvaluator<Output = bool, ColumnStat = Scalar>
```

The previous complexity was an attempt to optimize for the fact that parquet rowcount stats are always `i64` -- but the rest of the data skipping framework couldn't actually take advantage of that optimization.

### This PR affects the following public APIs

Type signature of the public `DataSkippingPredicate` changed.

## How was this change tested?

Compilation suffices. New static assertion verifies dyn compatibility.