### PR TITLE
refactor!: Code movement in FFI crate

### DIFF
--- a/ffi/src/expressions/engine_visitor.rs
+++ b/ffi/src/expressions/engine_visitor.rs
@@ -1,32 +1,15 @@
 //! Defines [`EngineExpressionVisitor`]. This is a visitor that can be used to convert the kernel's
-//! [`Expression`] to an engine's expression format.
-use crate::expressions::{SharedExpression, SharedPredicate};
+//! [`Expression`] or [`Predicate`] to an engine's native expression format.
 use std::ffi::c_void;
 
-use crate::{handle::Handle, kernel_string_slice, KernelStringSlice};
 use delta_kernel::expressions::{
     ArrayData, BinaryExpression, BinaryExpressionOp, BinaryPredicate, BinaryPredicateOp,
     Expression, JunctionPredicate, JunctionPredicateOp, MapData, Predicate, Scalar, StructData,
     UnaryPredicate, UnaryPredicateOp,
 };
 
-/// Free the memory the passed SharedExpression
-///
-/// # Safety
-/// Engine is responsible for passing a valid SharedExpression
-#[no_mangle]
-pub unsafe extern "C" fn free_kernel_expression(data: Handle<SharedExpression>) {
-    data.drop_handle();
-}
-
-/// Free the memory the passed SharedPredicate
-///
-/// # Safety
-/// Engine is responsible for passing a valid SharedPredicate
-#[no_mangle]
-pub unsafe extern "C" fn free_kernel_predicate(data: Handle<SharedPredicate>) {
-    data.drop_handle();
-}
+use crate::expressions::{SharedExpression, SharedPredicate};
+use crate::{handle::Handle, kernel_string_slice, KernelStringSlice};
 
 type VisitLiteralFn<T> = extern "C" fn(data: *mut c_void, sibling_list_id: usize, value: T);
 type VisitUnaryFn = extern "C" fn(data: *mut c_void, sibling_list_id: usize, child_list_id: usize);

--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -1,7 +1,5 @@
-//! Defines [`KernelExpressionVisitorState`]. This is a visitor  that can be used by an [`EnginePredicate`]
-//! to convert engine expressions into kernel expressions.
-use std::ffi::c_void;
-
+//! Defines [`KernelExpressionVisitorState`]. This is a visitor that can be used to convert an
+//! engine's native expressions into kernel's [`Expression`] and [`Predicate`] types.
 use crate::{
     AllocateErrorFn, EngineIterator, ExternResult, IntoExternResult, KernelStringSlice,
     ReferenceSet, TryFromStringSlice,
@@ -19,25 +17,6 @@ pub(crate) enum ExpressionOrPredicate {
 #[derive(Default)]
 pub struct KernelExpressionVisitorState {
     inflight_ids: ReferenceSet<ExpressionOrPredicate>,
-}
-
-/// A predicate that can be used to skip data when scanning.
-///
-/// When invoking [`scan::scan`], The engine provides a pointer to the (engine's native) predicate,
-/// along with a visitor function that can be invoked to recursively visit the predicate. This
-/// engine state must be valid until the call to [`scan::scan`] returns. Inside that method, the
-/// kernel allocates visitor state, which becomes the second argument to the predicate visitor
-/// invocation along with the engine-provided predicate pointer. The visitor state is valid for the
-/// lifetime of the predicate visitor invocation. Thanks to this double indirection, engine and
-/// kernel each retain ownership of their respective objects, with no need to coordinate memory
-/// lifetimes with the other.
-///
-/// [`scan::scan`]: crate::scan::scan
-#[repr(C)]
-pub struct EnginePredicate {
-    pub predicate: *mut c_void,
-    pub visitor:
-        extern "C" fn(predicate: *mut c_void, state: &mut KernelExpressionVisitorState) -> usize,
 }
 
 fn wrap_expression(state: &mut KernelExpressionVisitorState, expr: impl Into<Expression>) -> usize {

--- a/ffi/src/expressions/mod.rs
+++ b/ffi/src/expressions/mod.rs
@@ -3,11 +3,31 @@
 use delta_kernel::{Expression, Predicate};
 use delta_kernel_ffi_macros::handle_descriptor;
 
-pub mod engine;
-pub mod kernel;
+use crate::handle::Handle;
+
+pub mod engine_visitor;
+pub mod kernel_visitor;
 
 #[handle_descriptor(target=Expression, mutable=false, sized=true)]
 pub struct SharedExpression;
 
 #[handle_descriptor(target=Predicate, mutable=false, sized=true)]
 pub struct SharedPredicate;
+
+/// Free the memory the passed SharedExpression
+///
+/// # Safety
+/// Engine is responsible for passing a valid SharedExpression
+#[no_mangle]
+pub unsafe extern "C" fn free_kernel_expression(data: Handle<SharedExpression>) {
+    data.drop_handle();
+}
+
+/// Free the memory the passed SharedPredicate
+///
+/// # Safety
+/// Engine is responsible for passing a valid SharedPredicate
+#[no_mangle]
+pub unsafe extern "C" fn free_kernel_predicate(data: Handle<SharedPredicate>) {
+    data.drop_handle();
+}

--- a/ffi/src/scan.rs
+++ b/ffi/src/scan.rs
@@ -1,6 +1,7 @@
 //! Scan related ffi code
 
 use std::collections::HashMap;
+use std::ffi::c_void;
 use std::sync::{Arc, Mutex};
 
 use delta_kernel::scan::state::{DvInfo, GlobalScanState};
@@ -11,9 +12,7 @@ use delta_kernel_ffi_macros::handle_descriptor;
 use tracing::debug;
 use url::Url;
 
-use crate::expressions::engine::{
-    unwrap_kernel_predicate, EnginePredicate, KernelExpressionVisitorState,
-};
+use crate::expressions::kernel_visitor::{unwrap_kernel_predicate, KernelExpressionVisitorState};
 use crate::expressions::SharedExpression;
 use crate::{
     kernel_string_slice, AllocateStringFn, ExternEngine, ExternResult, IntoExternResult,
@@ -31,6 +30,23 @@ pub struct SharedScan;
 
 #[handle_descriptor(target=ScanMetadata, mutable=false, sized=true)]
 pub struct SharedScanMetadata;
+
+/// A predicate that can be used to skip data when scanning.
+///
+/// When invoking [`scan`], The engine provides a pointer to the (engine's native) predicate,
+/// along with a visitor function that can be invoked to recursively visit the predicate. This
+/// engine state must be valid until the call to [`scan::scan`] returns. Inside that method, the
+/// kernel allocates visitor state, which becomes the second argument to the predicate visitor
+/// invocation along with the engine-provided predicate pointer. The visitor state is valid for the
+/// lifetime of the predicate visitor invocation. Thanks to this double indirection, engine and
+/// kernel each retain ownership of their respective objects, with no need to coordinate memory
+/// lifetimes with the other.
+#[repr(C)]
+pub struct EnginePredicate {
+    pub predicate: *mut c_void,
+    pub visitor:
+        extern "C" fn(predicate: *mut c_void, state: &mut KernelExpressionVisitorState) -> usize,
+}
 
 /// Drop a `SharedScanMetadata`.
 ///

--- a/ffi/src/scan.rs
+++ b/ffi/src/scan.rs
@@ -33,14 +33,14 @@ pub struct SharedScanMetadata;
 
 /// A predicate that can be used to skip data when scanning.
 ///
-/// When invoking [`scan`], The engine provides a pointer to the (engine's native) predicate,
-/// along with a visitor function that can be invoked to recursively visit the predicate. This
-/// engine state must be valid until the call to [`scan::scan`] returns. Inside that method, the
-/// kernel allocates visitor state, which becomes the second argument to the predicate visitor
-/// invocation along with the engine-provided predicate pointer. The visitor state is valid for the
-/// lifetime of the predicate visitor invocation. Thanks to this double indirection, engine and
-/// kernel each retain ownership of their respective objects, with no need to coordinate memory
-/// lifetimes with the other.
+/// When invoking [`scan`], The engine provides a pointer to the (engine's native) predicate, along
+/// with a visitor function that can be invoked to recursively visit the predicate. This engine
+/// state must be valid until the call to [`scan`] returns. Inside that method, the kernel allocates
+/// visitor state, which becomes the second argument to the predicate visitor invocation along with
+/// the engine-provided predicate pointer. The visitor state is valid for the lifetime of the
+/// predicate visitor invocation. Thanks to this double indirection, engine and kernel each retain
+/// ownership of their respective objects, with no need to coordinate memory lifetimes with the
+/// other.
 #[repr(C)]
 pub struct EnginePredicate {
     pub predicate: *mut c_void,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Reorganize the FFI code so its two visitor modules contain only visitor code, and their names reflect it.

### This PR affects the following public APIs

Code movement in the FFI crate:
1. Rename `ffi::expressions::engine` mod as `kernel_visitor` to more accurately reflect the module's existing doc comment: "Defines [`KernelExpressionVisitorState`]".
2. Rename `ffi::expressions::kernel` mod as `engine_visitor` to more accurately reflect the module's existing doc comment: "Defines [`EngineExpressionVisitor`]".
3. Move the `free_kernel_[expression|predicate]` functions to the expressions mod, which already defines the corresponding shared handle types those functions work with. 
4. Move the `EnginePredicate` struct to the `ffi::scan` module, which is currently the type's only consumer.

## How was this change tested?

Code movement. Compilation suffices.