### PR TITLE
chore!: bump msrv 1.82

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,5 @@ keywords = ["deltalake", "delta", "datalake"]
 license = "Apache-2.0"
 repository = "https://github.com/delta-io/delta-kernel-rs"
 readme = "README.md"
-rust-version = "1.81"
+rust-version = "1.82"
 version = "0.10.0"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Delta Kernel (rust) &emsp; [![build-status]][actions] [![latest-version]][crates.io] [![docs]][docs.rs] [![rustc-version-1.81+]][rustc]
+# Delta Kernel (rust) &emsp; [![build-status]][actions] [![latest-version]][crates.io] [![docs]][docs.rs] [![rustc-version-1.82+]][rustc]
 
 [build-status]: https://img.shields.io/github/actions/workflow/status/delta-io/delta-kernel-rs/build.yml?branch=main
 [actions]: https://github.com/delta-io/delta-kernel-rs/actions/workflows/build.yml?query=branch%3Amain
 [latest-version]: https://img.shields.io/crates/v/delta_kernel.svg
 [crates.io]: https://crates.io/crates/delta\_kernel
-[rustc-version-1.81+]: https://img.shields.io/badge/rustc-1.81+-lightgray.svg
-[rustc]: https://blog.rust-lang.org/2024/09/05/Rust-1.81.0/
+[rustc-version-1.82+]: https://img.shields.io/badge/rustc-1.82+-lightgray.svg
+[rustc]: https://blog.rust-lang.org/2024/10/17/Rust-1.82.0/
 [docs]: https://img.shields.io/docsrs/delta_kernel
 [docs.rs]: https://docs.rs/delta_kernel/latest/delta_kernel/
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
bump MSRV 1.81 to 1.82 (due to `Url` transitive deps bumping)
```
error: rustc 1.81.0 is not supported by the following packages:      
  │   icu_collections@2.0.0 requires rustc 1.82                            │
  │   icu_locale_core@2.0.0 requires rustc 1.82                            │
  │   icu_normalizer@2.0.0 requires rustc 1.82                             │
  │   icu_normalizer_data@2.0.0 requires rustc 1.82                        │
  │   icu_normalizer_data@2.0.0 requires rustc 1.82                        │
  │   icu_normalizer_data@2.0.0 requires rustc 1.82                        │
  │   icu_properties@2.0.0 requires rustc 1.82                             │
  │   icu_properties_data@2.0.0 requires rustc 1.82                        │
  │   icu_properties_data@2.0.0 requires rustc 1.82                        │
  │   icu_properties_data@2.0.0 requires rustc 1.82                        │
  │   icu_provider@2.0.0 requires rustc 1.82                               │
  │   idna_adapter@1.2.1 requires rustc 1.82                               │
  │   litemap@0.8.0 requires rustc 1.82                                    │
  │   zerotrie@0.2.2 requires rustc 1.82                                   │
  │   zerovec@0.11.2 requires rustc 1.82            
```

### This PR affects the following public APIs
MSRV increase to rustc 1.82


## How was this change tested?
MSRV tests