### PR TITLE
chore: Conditional compilation instead of suppressing clippy warnings

### DIFF
--- a/ffi/src/engine_funcs.rs
+++ b/ffi/src/engine_funcs.rs
@@ -122,8 +122,6 @@ fn read_parquet_file_impl(
     let engine = extern_engine.engine();
     let parquet_handler = engine.parquet_handler();
     let location = Url::parse(path?)?;
-    // TODO: remove after arrow 54 is dropped
-    #[allow(clippy::useless_conversion)]
     let delta_fm = delta_kernel::FileMeta {
         location,
         last_modified: file.last_modified,

--- a/kernel/src/engine/default/json.rs
+++ b/kernel/src/engine/default/json.rs
@@ -530,12 +530,13 @@ mod tests {
         let location = Path::from_url_path(url.path()).unwrap();
         let meta = store.head(&location).await.unwrap();
 
-        // TODO: remove after arrow 54 support is dropped
-        #[allow(clippy::useless_conversion)]
+        let meta_size = meta.size;
+        #[cfg(not(feature = "arrow-55"))]
+        let meta_size = meta_size.try_into().unwrap();
         let files = &[FileMeta {
             location: url.clone(),
             last_modified: meta.last_modified.timestamp_millis(),
-            size: meta.size.try_into().unwrap(),
+            size: meta_size,
         }];
 
         let handler = DefaultJsonHandler::new(store, Arc::new(TokioBackgroundExecutor::new()));
@@ -681,12 +682,13 @@ mod tests {
                         let url = Url::parse(&format!("memory:/{}", path)).unwrap();
                         let location = Path::from(path.as_ref());
                         let meta = store.head(&location).await.unwrap();
-                        // TODO: remove after dropping support for arrow 54
-                        #[allow(clippy::useless_conversion)]
+                        let meta_size = meta.size;
+                        #[cfg(not(feature = "arrow-55"))]
+                        let meta_size = meta_size.try_into().unwrap();
                         FileMeta {
                             location: url,
                             last_modified: meta.last_modified.timestamp_millis(),
-                            size: meta.size.try_into().unwrap(),
+                            size: meta_size,
                         }
                     }
                 })

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -128,8 +128,6 @@ impl<E: TaskExecutor> DefaultParquetHandler<E> {
         writer.write(record_batch)?;
         writer.close()?; // writer must be closed to write footer
 
-        // TODO: remove after dropping arrow 54 support
-        #[allow(clippy::useless_conversion)]
         let size: u64 = buffer
             .len()
             .try_into()
@@ -150,10 +148,9 @@ impl<E: TaskExecutor> DefaultParquetHandler<E> {
 
         let metadata = self.store.head(&Path::from_url_path(path.path())?).await?;
         let modification_time = metadata.last_modified.timestamp_millis();
-        // TODO: remove after dropping arrow 54 support
-        #[allow(clippy::useless_conversion)]
-        let metadata_size: u64 = metadata
-            .size
+        let metadata_size = metadata.size;
+        #[cfg(not(feature = "arrow-55"))]
+        let metadata_size = metadata_size
             .try_into()
             .map_err(|_| Error::generic("Failed to convert parquet metadata 'size' to u64"))?;
         if size != metadata_size {
@@ -418,12 +415,13 @@ mod tests {
             .schema()
             .clone();
 
-        // TODO: remove after dropping arrow 54 support
-        #[allow(clippy::useless_conversion)]
+        let meta_size = meta.size;
+        #[cfg(not(feature = "arrow-55"))]
+        let meta_size = meta_size.try_into().unwrap();
         let files = &[FileMeta {
             location: url.clone(),
             last_modified: meta.last_modified.timestamp(),
-            size: meta.size.try_into().unwrap(),
+            size: meta_size,
         }];
 
         let handler = DefaultParquetHandler::new(store, Arc::new(TokioBackgroundExecutor::new()));

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -150,7 +150,7 @@ impl<E: TaskExecutor> DefaultParquetHandler<E> {
         let modification_time = metadata.last_modified.timestamp_millis();
         let metadata_size = metadata.size;
         #[cfg(not(feature = "arrow-55"))]
-        let metadata_size = metadata_size
+        let metadata_size: u64 = metadata_size
             .try_into()
             .map_err(|_| Error::generic("Failed to convert parquet metadata 'size' to u64"))?;
         if size != metadata_size {

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -187,7 +187,7 @@ impl TryFrom<DirEntry> for FileMeta {
             ))
         })?;
         let metadata_len = metadata.len();
-        #[cfg(not(feature = "arrow-55"))]
+        #[cfg(all(feature = "arrow-54", not(feature = "arrow-55")))]
         let metadata_len = metadata_len
             .try_into()
             .map_err(|_| Error::generic("unable to convert DirEntry metadata to file size"))?;

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -186,15 +186,15 @@ impl TryFrom<DirEntry> for FileMeta {
                 last_modified.as_millis()
             ))
         })?;
-        // TODO: remove after arrow 54 is dropped
-        #[allow(clippy::useless_conversion)]
+        let metadata_len = metadata.len();
+        #[cfg(not(feature = "arrow-55"))]
+        let metadata_len = metadata_len
+            .try_into()
+            .map_err(|_| Error::generic("unable to convert DirEntry metadata to file size"))?;
         Ok(FileMeta {
             location,
             last_modified,
-            size: metadata
-                .len()
-                .try_into()
-                .map_err(|_| Error::generic("unable to convert DirEntry metadata to file size"))?,
+            size: metadata_len,
         })
     }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Between arrow-54 and arrow-55, some uses of `usize` changed to `u64` which causes compilation errors if not converted. Previously, we just added a `try_into` call, which always compiles thanks to a blanket `impl<T> TryInto<T> for T`, but generates a clippy warning on arrow-55 where it's redundant. 

Unfortunately, the annotations added to ignore those clippy warnings come with undesirable side effects:
1. There is no compiler help to encourage removing the redundant code, once it's no longer needed.
2. Some annotated sites always need the conversion, regardless of which arrow version is used

Replace the clippy annotations with a separate conditionally compiled `let` that only does the `try_into` when compiling against arrow-54, and fix the sites that were already incorrect. Once arrow-54 support is dropped, the remaining sites will trigger compilation errors because the corresponding feature no longer exists.

## How was this change tested?

Compilation suffices.