### PR TITLE
fix!: Fix timestamp ntz in physical to logical cdf

### DIFF
--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -290,7 +290,7 @@ impl Scalar {
         Ok(Self::Decimal(dval))
     }
 
-    /// Constructs a Scalar timestamp from an `i64` millisecond since unix epoch
+    /// Constructs a Scalar timestamp (in UTC) from an `i64` millisecond since unix epoch
     pub(crate) fn timestamp_from_millis(millis: i64) -> DeltaResult<Self> {
         let Some(timestamp) = DateTime::from_timestamp_millis(millis) else {
             return Err(Error::generic(format!(

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -290,14 +290,14 @@ impl Scalar {
         Ok(Self::Decimal(dval))
     }
 
-    /// Constructs a Scalar timestamp with no timezone from an `i64` millisecond since unix epoch
-    pub(crate) fn timestamp_ntz_from_millis(millis: i64) -> DeltaResult<Self> {
+    /// Constructs a Scalar from an `i64` millisecond since unix epoch
+    pub(crate) fn timestamp_from_millis(millis: i64) -> DeltaResult<Self> {
         let Some(timestamp) = DateTime::from_timestamp_millis(millis) else {
             return Err(Error::generic(format!(
                 "Failed to create millisecond timestamp from {millis}"
             )));
         };
-        Ok(Self::TimestampNtz(timestamp.timestamp_micros()))
+        Ok(Self::Timestamp(timestamp.timestamp_micros()))
     }
 }
 

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -290,7 +290,7 @@ impl Scalar {
         Ok(Self::Decimal(dval))
     }
 
-    /// Constructs a Scalar from an `i64` millisecond since unix epoch
+    /// Constructs a Scalar timestamp from an `i64` millisecond since unix epoch
     pub(crate) fn timestamp_from_millis(millis: i64) -> DeltaResult<Self> {
         let Some(timestamp) = DateTime::from_timestamp_millis(millis) else {
             return Err(Error::generic(format!(

--- a/kernel/src/table_changes/physical_to_logical.rs
+++ b/kernel/src/table_changes/physical_to_logical.rs
@@ -15,7 +15,7 @@ use super::{
 
 /// Returns a map from change data feed column name to an expression that generates the row data.
 fn get_cdf_columns(scan_file: &CdfScanFile) -> DeltaResult<HashMap<&str, Expression>> {
-    let timestamp = Scalar::timestamp_ntz_from_millis(scan_file.commit_timestamp)?;
+    let timestamp = Scalar::timestamp_from_millis(scan_file.commit_timestamp)?;
     let version = scan_file.commit_version;
     let change_type: Expression = match scan_file.scan_type {
         CdfScanFileType::Cdc => Expression::column([CHANGE_TYPE_COL_NAME]),
@@ -124,7 +124,7 @@ mod tests {
                 Scalar::Long(20).into(),
                 expected_expr,
                 Expr::literal(42i64),
-                Scalar::TimestampNtz(1234000).into(), // Microsecond is 1000x millisecond
+                Scalar::Timestamp(1234000).into(), // Microsecond is 1000x millisecond
             ]);
 
             assert_eq!(phys_to_logical_expr, expected_expr)


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR changes the record batches produced by `TableChangesScan::execute` to return `timestamp` column instead of `timestamp_ntz`. Previously, the TableChanges schema stated that the batches would have timestamp type, but the record batches returned did not match that.

The reference implementation of change data feed returns timestamp columns, so that is what we will use.

## How was this change tested?
The physical to logical translation test is updated to ensure `Timestamp` type is returned.r

The cdf integration test ensures that the returned arrow batches match the table's schema.