### PR TITLE
refactor: Make arrow predicate eval directly invertible

### DIFF
--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -3,10 +3,10 @@ use crate::arrow::array::types::*;
 use crate::arrow::array::{
     Array, ArrayRef, AsArray, BooleanArray, Datum, RecordBatch, StructArray,
 };
-use crate::arrow::compute::kernels::cmp::{distinct, eq, gt, lt};
+use crate::arrow::compute::kernels::cmp::{distinct, eq, gt, gt_eq, lt, lt_eq, neq, not_distinct};
 use crate::arrow::compute::kernels::comparison::in_list_utf8;
 use crate::arrow::compute::kernels::numeric::{add, div, mul, sub};
-use crate::arrow::compute::{and_kleene, is_null, not, or_kleene};
+use crate::arrow::compute::{and_kleene, is_not_null, is_null, not, or_kleene};
 use crate::arrow::datatypes::{
     DataType as ArrowDataType, Field as ArrowField, IntervalUnit, TimeUnit,
 };
@@ -19,6 +19,7 @@ use crate::expressions::{
 };
 use crate::schema::DataType;
 use itertools::Itertools;
+use std::borrow::Cow;
 use std::sync::Arc;
 
 trait ProvidesColumnByName {
@@ -106,7 +107,7 @@ pub(crate) fn evaluate_expression(
             "Data type is required to evaluate struct expressions",
         )),
         (Predicate(pred), None | Some(&DataType::BOOLEAN)) => {
-            let result = evaluate_predicate(pred, batch)?;
+            let result = evaluate_predicate(pred, batch, false)?;
             Ok(Arc::new(result))
         }
         (Predicate(_), Some(data_type)) => Err(Error::generic(format!(
@@ -129,12 +130,21 @@ pub(crate) fn evaluate_expression(
     }
 }
 
+/// Evaluates a (possibly inverted) kernel predicate over a record batch
 pub(crate) fn evaluate_predicate(
     predicate: &Predicate,
     batch: &RecordBatch,
+    inverted: bool,
 ) -> DeltaResult<BooleanArray> {
     use BinaryPredicateOp::*;
     use Predicate::*;
+
+    // Helper to conditionally invert results of arrow operations we couldn't push NOT down into.
+    let maybe_inverted = |result: Cow<'_, BooleanArray>| match inverted {
+        true => not(&result),
+        false => Ok(result.into_owned()),
+    };
+
     match predicate {
         BooleanExpression(expr) => {
             // Grr -- there's no way to cast an `Arc<dyn Array>` back to its native type, so we
@@ -142,17 +152,18 @@ pub(crate) fn evaluate_predicate(
             // instances are still cheaply clonable.
             let arr = evaluate_expression(expr, batch, Some(&DataType::BOOLEAN))?;
             match arr.as_any().downcast_ref::<BooleanArray>() {
-                Some(arr) => Ok(arr.clone()),
+                Some(arr) => Ok(maybe_inverted(Cow::Borrowed(arr))?),
                 None => Err(Error::generic("expected boolean array")),
             }
         }
-        Not(pred) => Ok(not(&evaluate_predicate(pred, batch)?)?),
+        Not(pred) => evaluate_predicate(pred, batch, !inverted),
         Unary(UnaryPredicate { op, expr }) => {
             let arr = evaluate_expression(expr.as_ref(), batch, None)?;
-            let result = match op {
-                UnaryPredicateOp::IsNull => is_null(&arr)?,
+            let eval_op_fn = match (op, inverted) {
+                (UnaryPredicateOp::IsNull, false) => is_null,
+                (UnaryPredicateOp::IsNull, true) => is_not_null,
             };
-            Ok(result)
+            Ok(eval_op_fn(&arr)?)
         }
         Binary(BinaryPredicate { op, left, right }) => {
             let (left, right) = (left.as_ref(), right.as_ref());
@@ -216,12 +227,16 @@ pub(crate) fn evaluate_predicate(
                 ))),
             };
 
-            let eval_fn = match op {
-                LessThan => lt,
-                GreaterThan => gt,
-                Equal => eq,
-                Distinct => distinct,
-                In => return eval_in(),
+            let eval_fn = match (op, inverted) {
+                (LessThan, false) => lt,
+                (LessThan, true) => gt_eq,
+                (GreaterThan, false) => gt,
+                (GreaterThan, true) => lt_eq,
+                (Equal, false) => eq,
+                (Equal, true) => neq,
+                (Distinct, false) => distinct,
+                (Distinct, true) => not_distinct,
+                (In, _) => return Ok(maybe_inverted(Cow::Owned(eval_in()?))?),
             };
 
             let left = evaluate_expression(left, batch, None)?;
@@ -229,14 +244,21 @@ pub(crate) fn evaluate_predicate(
             Ok(eval_fn(&left, &right)?)
         }
         Junction(JunctionPredicate { op, preds }) => {
+            // Leverage de Morgan's laws (invert the children and swap the operator):
+            // NOT(AND(A, B)) = OR(NOT(A), NOT(B))
+            // NOT(OR(A, B)) = AND(NOT(A), NOT(B))
+            //
+            // In case of an empty junction, we return a default value of TRUE (FALSE) for AND (OR),
+            // as a "hidden" extra child: AND(TRUE, ...) = AND(...) and OR(FALSE, ...) = OR(...).
+            use JunctionPredicateOp::*;
             type Operation = fn(&BooleanArray, &BooleanArray) -> Result<BooleanArray, ArrowError>;
-            let (reducer, default): (Operation, _) = match op {
-                JunctionPredicateOp::And => (and_kleene, true),
-                JunctionPredicateOp::Or => (or_kleene, false),
+            let (reducer, default): (Operation, _) = match (op, inverted) {
+                (And, false) | (Or, true) => (and_kleene, true),
+                (Or, false) | (And, true) => (or_kleene, false),
             };
             preds
                 .iter()
-                .map(|pred| evaluate_predicate(pred, batch))
+                .map(|pred| evaluate_predicate(pred, batch, inverted))
                 .reduce(|l, r| Ok(reducer(&l?, &r?)?))
                 .unwrap_or_else(|| Ok(BooleanArray::from(vec![default; batch.num_rows()])))
         }

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -139,7 +139,7 @@ pub(crate) fn evaluate_predicate(
     use BinaryPredicateOp::*;
     use Predicate::*;
 
-    // Helper to conditionally invert results of arrow operations we couldn't push NOT down into.
+    // Helper to conditionally invert results of arrow operations if we couldn't push down the NOT.
     let maybe_inverted = |result: Cow<'_, BooleanArray>| match inverted {
         true => not(&result),
         false => Ok(result.into_owned()),

--- a/kernel/src/engine/arrow_expression/mod.rs
+++ b/kernel/src/engine/arrow_expression/mod.rs
@@ -366,7 +366,7 @@ impl PredicateEvaluator for DefaultPredicateEvaluator {
         //         batch.schema()
         //     )));
         // };
-        let array = evaluate_predicate(&self.predicate, batch)?;
+        let array = evaluate_predicate(&self.predicate, batch, false)?;
         let schema = ArrowSchema::new(vec![ArrowField::new(
             "output",
             ArrowDataType::Boolean,

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -41,12 +41,19 @@ fn test_array_column() {
     );
 
     let result = evaluate_predicate(&not_op, &batch, false).unwrap();
-    let expected = BooleanArray::from(vec![true, false, true]);
-    assert_eq!(result, expected);
+    let expected_not_in = BooleanArray::from(vec![true, false, true]);
+    assert_eq!(result, expected_not_in);
 
     let result = evaluate_predicate(&in_op, &batch, false).unwrap();
-    let expected = BooleanArray::from(vec![false, true, false]);
-    assert_eq!(result, expected);
+    let expected_in = BooleanArray::from(vec![false, true, false]);
+    assert_eq!(result, expected_in);
+
+    // Test inversion as well
+    let result = evaluate_predicate(&not_op, &batch, true).unwrap();
+    assert_eq!(result, expected_in);
+
+    let result = evaluate_predicate(&in_op, &batch, true).unwrap();
+    assert_eq!(result, expected_not_in);
 }
 
 #[test]
@@ -77,7 +84,7 @@ fn test_literal_type_array() {
     let schema = Schema::new([field.clone()]);
     let batch = RecordBatch::new_empty(Arc::new(schema));
 
-    let in_op = Pred::not(Pred::binary(
+    let not_in_op = Pred::not(Pred::binary(
         BinaryPredicateOp::In,
         Expr::literal(5),
         Scalar::Array(
@@ -89,9 +96,14 @@ fn test_literal_type_array() {
         ),
     ));
 
-    let in_result = evaluate_predicate(&in_op, &batch, false).unwrap();
-    let in_expected = BooleanArray::from(vec![true]);
-    assert_eq!(in_result, in_expected);
+    let result = evaluate_predicate(&not_in_op, &batch, false).unwrap();
+    let not_in_expected = BooleanArray::from(vec![true]);
+    assert_eq!(result, not_in_expected);
+
+    // Test inversion
+    let result = evaluate_predicate(&not_in_op, &batch, true).unwrap();
+    let in_expected = BooleanArray::from(vec![false]);
+    assert_eq!(result, in_expected);
 }
 
 #[test]
@@ -272,12 +284,19 @@ fn test_str_arrays() {
     );
 
     let result = evaluate_predicate(&str_in_op, &batch, false).unwrap();
-    let expected = BooleanArray::from(vec![true, true, true]);
-    assert_eq!(result, expected);
+    let in_expected = BooleanArray::from(vec![true, true, true]);
+    assert_eq!(result, in_expected);
 
     let result = evaluate_predicate(&str_not_op, &batch, false).unwrap();
-    let expected = BooleanArray::from(vec![false, false, false]);
-    assert_eq!(result, expected);
+    let not_in_expected = BooleanArray::from(vec![false, false, false]);
+    assert_eq!(result, not_in_expected);
+
+    // Test inversion
+    let result = evaluate_predicate(&str_in_op, &batch, true).unwrap();
+    assert_eq!(result, not_in_expected);
+
+    let result = evaluate_predicate(&str_not_op, &batch, true).unwrap();
+    assert_eq!(result, in_expected);
 }
 
 #[test]
@@ -379,72 +398,112 @@ fn test_binary_cmp() {
     let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(values)]).unwrap();
     let column = column_expr!("a");
 
-    let predicate = column.clone().lt(Expr::literal(2));
-    let results = evaluate_predicate(&predicate, &batch, false).unwrap();
-    let expected = BooleanArray::from(vec![true, false, false]);
-    assert_eq!(results, expected);
+    let predicate_lt = column.clone().lt(Expr::literal(2));
+    let results = evaluate_predicate(&predicate_lt, &batch, false).unwrap();
+    let expected_lt = BooleanArray::from(vec![true, false, false]);
+    assert_eq!(results, expected_lt);
 
-    let predicate = column.clone().le(Expr::literal(2));
-    let results = evaluate_predicate(&predicate, &batch, false).unwrap();
-    let expected = BooleanArray::from(vec![true, true, false]);
-    assert_eq!(results, expected);
+    let predicate_le = column.clone().le(Expr::literal(2));
+    let results = evaluate_predicate(&predicate_le, &batch, false).unwrap();
+    let expected_le = BooleanArray::from(vec![true, true, false]);
+    assert_eq!(results, expected_le);
 
-    let predicate = column.clone().gt(Expr::literal(2));
-    let results = evaluate_predicate(&predicate, &batch, false).unwrap();
-    let expected = BooleanArray::from(vec![false, false, true]);
-    assert_eq!(results, expected);
+    let predicate_gt = column.clone().gt(Expr::literal(2));
+    let results = evaluate_predicate(&predicate_gt, &batch, false).unwrap();
+    let expected_gt = BooleanArray::from(vec![false, false, true]);
+    assert_eq!(results, expected_gt);
 
-    let predicate = column.clone().ge(Expr::literal(2));
-    let results = evaluate_predicate(&predicate, &batch, false).unwrap();
-    let expected = BooleanArray::from(vec![false, true, true]);
-    assert_eq!(results, expected);
+    let predicate_ge = column.clone().ge(Expr::literal(2));
+    let results = evaluate_predicate(&predicate_ge, &batch, false).unwrap();
+    let expected_ge = BooleanArray::from(vec![false, true, true]);
+    assert_eq!(results, expected_ge);
 
-    let predicate = column.clone().eq(Expr::literal(2));
-    let results = evaluate_predicate(&predicate, &batch, false).unwrap();
-    let expected = BooleanArray::from(vec![false, true, false]);
-    assert_eq!(results, expected);
+    let predicate_eq = column.clone().eq(Expr::literal(2));
+    let results = evaluate_predicate(&predicate_eq, &batch, false).unwrap();
+    let expected_eq = BooleanArray::from(vec![false, true, false]);
+    assert_eq!(results, expected_eq);
 
-    let predicate = column.clone().ne(Expr::literal(2));
-    let results = evaluate_predicate(&predicate, &batch, false).unwrap();
-    let expected = BooleanArray::from(vec![true, false, true]);
-    assert_eq!(results, expected);
+    let predicate_ne = column.clone().ne(Expr::literal(2));
+    let results = evaluate_predicate(&predicate_ne, &batch, false).unwrap();
+    let expected_ne = BooleanArray::from(vec![true, false, true]);
+    assert_eq!(results, expected_ne);
+
+    // Test inversion
+    let results = evaluate_predicate(&predicate_lt, &batch, true).unwrap();
+    assert_eq!(results, expected_ge);
+
+    let results = evaluate_predicate(&predicate_le, &batch, true).unwrap();
+    assert_eq!(results, expected_gt);
+
+    let results = evaluate_predicate(&predicate_gt, &batch, true).unwrap();
+    assert_eq!(results, expected_le);
+
+    let results = evaluate_predicate(&predicate_ge, &batch, true).unwrap();
+    assert_eq!(results, expected_lt);
+
+    let results = evaluate_predicate(&predicate_eq, &batch, true).unwrap();
+    assert_eq!(results, expected_ne);
+
+    let results = evaluate_predicate(&predicate_ne, &batch, true).unwrap();
+    assert_eq!(results, expected_eq);
 }
 
 #[test]
 fn test_logical() {
+    let t = Some(true);
+    let f = Some(false);
+    let n = None;
+
     let schema = Schema::new(vec![
         Field::new("a", DataType::Boolean, false),
-        Field::new("b", DataType::Boolean, false),
+        Field::new("b", DataType::Boolean, true),
     ]);
     let batch = RecordBatch::try_new(
         Arc::new(schema.clone()),
         vec![
-            Arc::new(BooleanArray::from(vec![true, false])),
-            Arc::new(BooleanArray::from(vec![false, true])),
+            Arc::new(BooleanArray::from(vec![t, t, f, f, t, f])),
+            Arc::new(BooleanArray::from(vec![t, f, t, f, n, n])),
         ],
     )
     .unwrap();
     let column_a = column_pred!("a");
     let column_b = column_pred!("b");
 
-    let pred = Pred::and(column_a.clone(), column_b.clone());
-    let results = evaluate_predicate(&pred, &batch, false).unwrap();
-    let expected = BooleanArray::from(vec![false, false]);
+    let pred_and_col = Pred::and(column_a.clone(), column_b.clone());
+    let results = evaluate_predicate(&pred_and_col, &batch, false).unwrap();
+    let expected = BooleanArray::from(vec![t, f, f, f, n, f]);
     assert_eq!(results, expected);
 
-    let pred = Pred::and(column_a.clone(), Pred::literal(true));
-    let results = evaluate_predicate(&pred, &batch, false).unwrap();
-    let expected = BooleanArray::from(vec![true, false]);
+    let pred_and_lit = Pred::and(column_a.clone(), Pred::literal(true));
+    let results = evaluate_predicate(&pred_and_lit, &batch, false).unwrap();
+    let expected = BooleanArray::from(vec![t, t, f, f, t, f]);
     assert_eq!(results, expected);
 
-    let pred = Pred::or(column_a.clone(), column_b);
-    let results = evaluate_predicate(&pred, &batch, false).unwrap();
-    let expected = BooleanArray::from(vec![true, true]);
+    let pred_or_col = Pred::or(column_a.clone(), column_b);
+    let results = evaluate_predicate(&pred_or_col, &batch, false).unwrap();
+    let expected = BooleanArray::from(vec![t, t, t, f, t, n]);
     assert_eq!(results, expected);
 
-    let pred = Pred::or(column_a.clone(), Pred::literal(false));
-    let results = evaluate_predicate(&pred, &batch, false).unwrap();
-    let expected = BooleanArray::from(vec![true, false]);
+    let pred_or_lit = Pred::or(column_a.clone(), Pred::literal(false));
+    let results = evaluate_predicate(&pred_or_lit, &batch, false).unwrap();
+    let expected = BooleanArray::from(vec![t, t, f, f, t, f]);
+    assert_eq!(results, expected);
+
+    // Test inversion
+    let results = evaluate_predicate(&pred_and_col, &batch, true).unwrap();
+    let expected = BooleanArray::from(vec![f, t, t, t, n, t]);
+    assert_eq!(results, expected);
+
+    let results = evaluate_predicate(&pred_and_lit, &batch, true).unwrap();
+    let expected = BooleanArray::from(vec![f, f, t, t, f, t]);
+    assert_eq!(results, expected);
+
+    let results = evaluate_predicate(&pred_or_col, &batch, true).unwrap();
+    let expected = BooleanArray::from(vec![f, f, f, t, f, n]);
+    assert_eq!(results, expected);
+
+    let results = evaluate_predicate(&pred_or_lit, &batch, true).unwrap();
+    let expected = BooleanArray::from(vec![f, f, t, t, f, t]);
     assert_eq!(results, expected);
 }
 

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -40,11 +40,11 @@ fn test_array_column() {
         column_expr!("item"),
     );
 
-    let result = evaluate_predicate(&not_op, &batch).unwrap();
+    let result = evaluate_predicate(&not_op, &batch, false).unwrap();
     let expected = BooleanArray::from(vec![true, false, true]);
     assert_eq!(result, expected);
 
-    let result = evaluate_predicate(&in_op, &batch).unwrap();
+    let result = evaluate_predicate(&in_op, &batch, false).unwrap();
     let expected = BooleanArray::from(vec![false, true, false]);
     assert_eq!(result, expected);
 }
@@ -62,7 +62,7 @@ fn test_bad_right_type_array() {
         column_expr!("item"),
     ));
 
-    let in_result = evaluate_predicate(&in_op, &batch);
+    let in_result = evaluate_predicate(&in_op, &batch, false);
 
     assert!(in_result.is_err());
     assert_eq!(
@@ -89,7 +89,7 @@ fn test_literal_type_array() {
         ),
     ));
 
-    let in_result = evaluate_predicate(&in_op, &batch).unwrap();
+    let in_result = evaluate_predicate(&in_op, &batch, false).unwrap();
     let in_expected = BooleanArray::from(vec![true]);
     assert_eq!(in_result, in_expected);
 }
@@ -238,7 +238,7 @@ fn test_invalid_array_sides() {
         column_expr!("item"),
     ));
 
-    let in_result = evaluate_predicate(&in_op, &batch);
+    let in_result = evaluate_predicate(&in_op, &batch, false);
 
     assert!(in_result.is_err());
     assert_eq!(
@@ -271,11 +271,11 @@ fn test_str_arrays() {
         column_expr!("item"),
     );
 
-    let result = evaluate_predicate(&str_in_op, &batch).unwrap();
+    let result = evaluate_predicate(&str_in_op, &batch, false).unwrap();
     let expected = BooleanArray::from(vec![true, true, true]);
     assert_eq!(result, expected);
 
-    let result = evaluate_predicate(&str_not_op, &batch).unwrap();
+    let result = evaluate_predicate(&str_not_op, &batch, false).unwrap();
     let expected = BooleanArray::from(vec![false, false, false]);
     assert_eq!(result, expected);
 }
@@ -380,32 +380,32 @@ fn test_binary_cmp() {
     let column = column_expr!("a");
 
     let predicate = column.clone().lt(Expr::literal(2));
-    let results = evaluate_predicate(&predicate, &batch).unwrap();
+    let results = evaluate_predicate(&predicate, &batch, false).unwrap();
     let expected = BooleanArray::from(vec![true, false, false]);
     assert_eq!(results, expected);
 
     let predicate = column.clone().le(Expr::literal(2));
-    let results = evaluate_predicate(&predicate, &batch).unwrap();
+    let results = evaluate_predicate(&predicate, &batch, false).unwrap();
     let expected = BooleanArray::from(vec![true, true, false]);
     assert_eq!(results, expected);
 
     let predicate = column.clone().gt(Expr::literal(2));
-    let results = evaluate_predicate(&predicate, &batch).unwrap();
+    let results = evaluate_predicate(&predicate, &batch, false).unwrap();
     let expected = BooleanArray::from(vec![false, false, true]);
     assert_eq!(results, expected);
 
     let predicate = column.clone().ge(Expr::literal(2));
-    let results = evaluate_predicate(&predicate, &batch).unwrap();
+    let results = evaluate_predicate(&predicate, &batch, false).unwrap();
     let expected = BooleanArray::from(vec![false, true, true]);
     assert_eq!(results, expected);
 
     let predicate = column.clone().eq(Expr::literal(2));
-    let results = evaluate_predicate(&predicate, &batch).unwrap();
+    let results = evaluate_predicate(&predicate, &batch, false).unwrap();
     let expected = BooleanArray::from(vec![false, true, false]);
     assert_eq!(results, expected);
 
     let predicate = column.clone().ne(Expr::literal(2));
-    let results = evaluate_predicate(&predicate, &batch).unwrap();
+    let results = evaluate_predicate(&predicate, &batch, false).unwrap();
     let expected = BooleanArray::from(vec![true, false, true]);
     assert_eq!(results, expected);
 }
@@ -428,22 +428,22 @@ fn test_logical() {
     let column_b = column_pred!("b");
 
     let pred = Pred::and(column_a.clone(), column_b.clone());
-    let results = evaluate_predicate(&pred, &batch).unwrap();
+    let results = evaluate_predicate(&pred, &batch, false).unwrap();
     let expected = BooleanArray::from(vec![false, false]);
     assert_eq!(results, expected);
 
     let pred = Pred::and(column_a.clone(), Pred::literal(true));
-    let results = evaluate_predicate(&pred, &batch).unwrap();
+    let results = evaluate_predicate(&pred, &batch, false).unwrap();
     let expected = BooleanArray::from(vec![true, false]);
     assert_eq!(results, expected);
 
     let pred = Pred::or(column_a.clone(), column_b);
-    let results = evaluate_predicate(&pred, &batch).unwrap();
+    let results = evaluate_predicate(&pred, &batch, false).unwrap();
     let expected = BooleanArray::from(vec![true, true]);
     assert_eq!(results, expected);
 
     let pred = Pred::or(column_a.clone(), Pred::literal(false));
-    let results = evaluate_predicate(&pred, &batch).unwrap();
+    let results = evaluate_predicate(&pred, &batch, false).unwrap();
     let expected = BooleanArray::from(vec![true, false]);
     assert_eq!(results, expected);
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Make arrow predicate evaluation directly invertible, similar to how kernel predicate evaluation already does it. This is a necessary precursor to supporting opaque predicates, because we don't know the best way to handle inputs of an inverted opaque predicate (should we invert the output, like NOT? Or invert the inputs, like XOR? Or do something clever like AND, which is inverts inputs and OR the results?). By factoring out an `inverted` flag, we can delegate the implementation of `NOT(<opaque pred>)` to the opaque predicate.

## How was this change tested?

Expanded existing unit tests to cover inversion