### PR TITLE
fix: remove `target-cpu=native` rustflags

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["-C", "target-cpu=native"]


### PR DESCRIPTION
## What changes are proposed in this pull request?
`target-cpu=native` rustflags instructs rustc to optimize code specifically for the CPU architecture of the machine that's compiling the code. this is a problem for cross compilation (see #959)

instead, we can just have local `~/.cargo/config.toml` with our own specific RUSTFLAGS.

## How was this change tested?
compile: `cargo build --package delta_kernel_ffi --workspace --target x86_64-apple-darwin` from an aarch64 mac

resolves #959 