### PR TITLE
fix: allow CheckpointDataIterator to be used across await

### DIFF
--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -163,7 +163,7 @@ static CHECKPOINT_METADATA_ACTION_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(||
 /// [`CheckpointWriter::finalize`]. Failing to do so may result in data loss or corruption.
 pub struct CheckpointDataIterator {
     /// The nested iterator that yields checkpoint batches with action counts
-    checkpoint_batch_iterator: Box<dyn Iterator<Item = DeltaResult<CheckpointBatch>>>,
+    checkpoint_batch_iterator: Box<dyn Iterator<Item = DeltaResult<CheckpointBatch>> + Send>,
     /// Running total of actions included in the checkpoint
     actions_count: i64,
     /// Running total of add actions included in the checkpoint


### PR DESCRIPTION
## What changes are proposed in this pull request?

Writing data is mostly an async operation in Rust. Since the `CheckpointDataIterator` needs to be handed back to kernel on `finalize`, we need to be able to use it across `awaits`. As such we require the internal boxed iterator to also be `Send`.

## How was this change tested?

This came up when integrating checkpoint writing in `delta-rs`. With the proposed change, it works.