### PR TITLE
fix: Rename `drop_null_container_values` to `allow_null_container_values`

### DIFF
--- a/derive-macros/src/lib.rs
+++ b/derive-macros/src/lib.rs
@@ -34,11 +34,11 @@ pub fn parse_column_name(input: proc_macro::TokenStream) -> proc_macro::TokenStr
 /// action (this macro allows the use of standard rust snake_case, and will convert to the correct
 /// delta schema camelCase version).
 ///
-/// If a field sets `drop_null_container_values`, it means the underlying data can contain null in
+/// If a field sets `allow_null_container_values`, it means the underlying data can contain null in
 /// the values of the container (i.e. a `key` -> `null` in a `HashMap`). Therefore the schema should
 /// mark the value field as nullable, but those mappings will be dropped when converting to an
 /// actual rust `HashMap`. Currently this can _only_ be set on `HashMap` fields.
-#[proc_macro_derive(Schema, attributes(drop_null_container_values))]
+#[proc_macro_derive(Schema, attributes(allow_null_container_values))]
 pub fn derive_schema(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let struct_ident = input.ident;
@@ -99,9 +99,9 @@ fn gen_schema_fields(data: &Data) -> TokenStream {
         let name = field.ident.as_ref().unwrap(); // we know these are named fields
         let name = get_schema_name(name);
         let have_schema_null = field.attrs.iter().any(|attr| {
-            // check if we have drop_null_container_values attr
+            // check if we have allow_null_container_values attr
             match &attr.meta {
-                Meta::Path(path) => path.get_ident().is_some_and(|ident| ident == "drop_null_container_values"),
+                Meta::Path(path) => path.get_ident().is_some_and(|ident| ident == "allow_null_container_values"),
                 _ => false,
             }
         });
@@ -121,7 +121,7 @@ fn gen_schema_fields(data: &Data) -> TokenStream {
                         if first_ident != "HashMap" {
                            return Error::new(
                                 first_ident.span(),
-                                format!("Can only use drop_null_container_values on HashMap fields, not {first_ident}")
+                                format!("Can only use allow_null_container_values on HashMap fields, not {first_ident}")
                             ).to_compile_error()
                         }
                     }

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -445,9 +445,10 @@ pub(crate) struct Add {
 
     /// A map from partition column to value for this logical file. This map can contain null in the
     /// values meaning a partition is null. We drop those values from this map, due to the
-    /// `drop_null_container_values` annotation. This means an engine can assume that if a partition
-    /// is found in [`Metadata`] `partition_columns`, but not in this map, its value is null.
-    #[drop_null_container_values]
+    /// `allow_null_container_values` annotation allowing them and because `materialize` drops null
+    /// values. This means an engine can assume that if a partition is found in [`Metadata`]
+    /// `partition_columns`, but not in this map, its value is null.
+    #[allow_null_container_values]
     pub(crate) partition_values: HashMap<String, String>,
 
     /// The size of this data file in bytes
@@ -560,9 +561,10 @@ pub(crate) struct Cdc {
 
     /// A map from partition column to value for this logical file. This map can contain null in the
     /// values meaning a partition is null. We drop those values from this map, due to the
-    /// `drop_null_container_values` annotation. This means an engine can assume that if a partition
-    /// is found in [`Metadata`] `partition_columns`, but not in this map, its value is null.
-    #[drop_null_container_values]
+    /// `allow_null_container_values` annotation allowing them and because `materialize` drops null
+    /// values. This means an engine can assume that if a partition is found in [`Metadata`]
+    /// `partition_columns`, but not in this map, its value is null.
+    #[allow_null_container_values]
     pub partition_values: HashMap<String, String>,
 
     /// The size of this cdc file in bytes

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -445,9 +445,11 @@ pub(crate) struct Add {
 
     /// A map from partition column to value for this logical file. This map can contain null in the
     /// values meaning a partition is null. We drop those values from this map, due to the
-    /// `allow_null_container_values` annotation allowing them and because `materialize` drops null
-    /// values. This means an engine can assume that if a partition is found in [`Metadata`]
-    /// `partition_columns`, but not in this map, its value is null.
+    /// `allow_null_container_values` annotation allowing them and because [`materialize`] drops
+    /// null values. This means an engine can assume that if a partition is found in
+    /// [`Metadata::partition_columns`] but not in this map, its value is null.
+    ///
+    /// [`materialize`]: crate::engine_data::EngineMap::materialize
     #[allow_null_container_values]
     pub(crate) partition_values: HashMap<String, String>,
 
@@ -561,9 +563,11 @@ pub(crate) struct Cdc {
 
     /// A map from partition column to value for this logical file. This map can contain null in the
     /// values meaning a partition is null. We drop those values from this map, due to the
-    /// `allow_null_container_values` annotation allowing them and because `materialize` drops null
-    /// values. This means an engine can assume that if a partition is found in [`Metadata`]
-    /// `partition_columns`, but not in this map, its value is null.
+    /// `allow_null_container_values` annotation allowing them and because [`materialize`] drops
+    /// null values. This means an engine can assume that if a partition is found in
+    /// [`Metadata::partition_columns`] but not in this map, its value is null.
+    ///
+    /// [`materialize`]: crate::engine_data::EngineMap::materialize
     #[allow_null_container_values]
     pub partition_values: HashMap<String, String>,
 

--- a/kernel/src/engine_data.rs
+++ b/kernel/src/engine_data.rs
@@ -75,7 +75,7 @@ pub trait EngineMap {
     /// conjunction with the `allow_null_container_values` attribute, `materialize` _drops_ any
     /// (key, value) pairs where the underlying value was `null`. If preserving `null` values is
     /// important, use the `allow_null_container_values` attribute, and manually materialize the map
-    /// using [`get`].
+    /// using [`Self::get`].
     fn materialize(&self, row_index: usize) -> HashMap<String, String>;
 }
 

--- a/kernel/src/engine_data.rs
+++ b/kernel/src/engine_data.rs
@@ -71,7 +71,11 @@ impl<'a> ListItem<'a> {
 pub trait EngineMap {
     /// Get the item with the specified key from the map at `row_index` in the raw data, and return it as an `Option<&'a str>`
     fn get<'a>(&'a self, row_index: usize, key: &str) -> Option<&'a str>;
-    /// Materialize the entire map at `row_index` in the raw data into a `HashMap`
+    /// Materialize the entire map at `row_index` in the raw data into a `HashMap`. Note that in
+    /// conjunction with the `allow_null_container_values` attribute, `materialize` _drops_ any
+    /// (key, value) pairs where the underlying value was `null`. If preserving `null` values is
+    /// important, use the `allow_null_container_values` attribute, and manually materialize the map
+    /// using [`get`].
     fn materialize(&self, row_index: usize) -> HashMap<String, String>;
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
Rename `drop_null_container_values` to `allow_null_container_values`.

`#[drop_null_container_values]` is a bad name for the annotation.  It really means `#[allow_null_container_values]`, since it just sets the `nullable` flag on the `StructField`. The actual dropping is a contract of GetData (specifically `materialize`).

If we had an action that wanted to keep nulls, they could (misleadingly) put `#[drop_null_container_values]` and then not use `materialize`, and just build their own `HashMap<String, Option<String>>` using `MapItem::get`.

This PR also updates a few comments to make the above more clear when reading the code.

### This PR affects the following public APIs
Not really public API, but the attribute is public in a sense.

## How was this change tested?
Existing unit tests