### PR TITLE
chore: bump object_store to 0.12.1

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -91,7 +91,7 @@ features = ["async", "object_store"]
 optional = true
 [dependencies.object_store_55]
 package = "object_store"
-version = "0.12"
+version = "0.12.1"
 features = ["aws", "azure", "gcp", "http"]
 optional = true
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
object_store 0.12.0 seems to be causing some issue with range GETs on azure


## How was this change tested?
existing