### PR TITLE
refactor: Add `ActionsBatch`

### DIFF
--- a/kernel/examples/inspect-table/src/main.rs
+++ b/kernel/examples/inspect-table/src/main.rs
@@ -226,7 +226,7 @@ fn try_main() -> DeltaResult<()> {
 
             let mut visitor = LogVisitor::new();
             for action in actions {
-                visitor.visit_rows_of(action?.0.as_ref())?;
+                visitor.visit_rows_of(action?.actions())?;
             }
 
             if oldest_first {

--- a/kernel/src/checkpoint/log_replay.rs
+++ b/kernel/src/checkpoint/log_replay.rs
@@ -32,12 +32,12 @@
 //! [`CheckpointMetadata`]: crate::actions::CheckpointMetadata
 use crate::engine_data::{FilteredEngineData, GetData, RowVisitor, TypedGetData as _};
 use crate::log_replay::{
-    FileActionDeduplicator, FileActionKey, HasSelectionVector, LogReplayProcessor,
+    ActionsBatch, FileActionDeduplicator, FileActionKey, HasSelectionVector, LogReplayProcessor,
 };
 use crate::scan::data_skipping::DataSkippingFilter;
 use crate::schema::{column_name, ColumnName, ColumnNamesAndTypes, DataType};
 use crate::utils::require;
-use crate::{DeltaResult, EngineData, Error};
+use crate::{DeltaResult, Error};
 
 use std::collections::HashSet;
 use std::sync::LazyLock;
@@ -90,12 +90,12 @@ impl LogReplayProcessor for CheckpointLogReplayProcessor {
     /// the deduplication rules described in the module documentation. The method tracks
     /// statistics about processed actions (total count, add actions count) and maintains
     /// state for cross-batch deduplication.
-    fn process_actions_batch(
-        &mut self,
-        batch: Box<dyn EngineData>,
-        is_log_batch: bool,
-    ) -> DeltaResult<Self::Output> {
-        let selection_vector = vec![true; batch.len()];
+    fn process_actions_batch(&mut self, actions_batch: ActionsBatch) -> DeltaResult<Self::Output> {
+        let ActionsBatch {
+            actions,
+            is_log_batch,
+        } = actions_batch;
+        let selection_vector = vec![true; actions.len()];
 
         // Create the checkpoint visitor to process actions and update selection vector
         let mut visitor = CheckpointVisitor::new(
@@ -107,14 +107,14 @@ impl LogReplayProcessor for CheckpointLogReplayProcessor {
             self.seen_metadata,
             &mut self.seen_txns,
         );
-        visitor.visit_rows_of(batch.as_ref())?;
+        visitor.visit_rows_of(actions.as_ref())?;
 
         // Update protocol and metadata seen flags
         self.seen_protocol = visitor.seen_protocol;
         self.seen_metadata = visitor.seen_metadata;
 
         let filtered_data = FilteredEngineData {
-            data: batch,
+            data: actions,
             selection_vector: visitor.selection_vector,
         };
 
@@ -469,14 +469,17 @@ mod tests {
     use itertools::Itertools;
 
     /// Helper function to create test batches from JSON strings
-    fn create_batch(json_strings: Vec<&str>) -> DeltaResult<(Box<dyn EngineData>, bool)> {
-        Ok((parse_json_batch(StringArray::from(json_strings)), true))
+    fn create_batch(json_strings: Vec<&str>) -> DeltaResult<ActionsBatch> {
+        Ok(ActionsBatch::new(
+            parse_json_batch(StringArray::from(json_strings)),
+            true,
+        ))
     }
 
     /// Helper function which applies the [`CheckpointLogReplayProcessor`] to a set of
     /// input batches and returns the results.
     fn run_checkpoint_test(
-        input_batches: Vec<(Box<dyn EngineData>, bool)>,
+        input_batches: Vec<ActionsBatch>,
     ) -> DeltaResult<(Vec<FilteredEngineData>, i64, i64)> {
         let processed_batches: Vec<_> = CheckpointLogReplayProcessor::new(0)
             .process_actions_iter(input_batches.into_iter().map(Ok))

--- a/kernel/src/checkpoint/log_replay.rs
+++ b/kernel/src/checkpoint/log_replay.rs
@@ -470,10 +470,8 @@ mod tests {
 
     /// Helper function to create test batches from JSON strings
     fn create_batch(json_strings: Vec<&str>) -> DeltaResult<ActionsBatch> {
-        Ok(ActionsBatch::new(
-            parse_json_batch(StringArray::from(json_strings)),
-            true,
-        ))
+        let actions = parse_json_batch(StringArray::from(json_strings));
+        Ok(ActionsBatch::new(actions, true))
     }
 
     /// Helper function which applies the [`CheckpointLogReplayProcessor`] to a set of

--- a/kernel/src/log_replay.rs
+++ b/kernel/src/log_replay.rs
@@ -219,6 +219,7 @@ impl ActionsBatch {
 
     /// HACK: a duplication of the pub(crate) field `actions` to allow us to export as
     /// 'internal-api' and let inspect-table example use it.
+    #[allow(unused)]
     #[internal_api]
     pub(crate) fn actions(&self) -> &dyn EngineData {
         self.actions.as_ref()

--- a/kernel/src/log_replay.rs
+++ b/kernel/src/log_replay.rs
@@ -204,7 +204,8 @@ pub(crate) struct ActionsBatch {
 }
 
 impl ActionsBatch {
-    /// Creates a new `ActionsBatch` instance.
+    /// Creates a new `ActionsBatch` instance. See [`LogReplayProcessor::process_actions_batch`] for
+    /// usage.
     ///
     /// # Parameters
     /// - `actions`: A boxed [`EngineData`] instance representing the actions batch.
@@ -282,10 +283,10 @@ pub(crate) trait LogReplayProcessor: Sized {
     type Output: HasSelectionVector;
 
     /// Processes a batch of actions and returns the filtered results.
-    /// FIXME
     /// # Parameters
-    /// - `actions_batch` - A boxed [`EngineData`] instance representing a batch of actions.
-    /// - `is_log_batch` - `true` if the batch originates from a commit log, `false` if from a checkpoint.
+    /// - `actions_batch` - An [`ActionsBatch`] which includes a boxed [`EngineData`] instance
+    ///   representing a batch of actions and a boolean flag indicating whether the batch originates
+    ///   from a commit log, `false` if from a checkpoint.
     ///
     /// Returns a [`DeltaResult`] containing the processor’s output, which includes only selected actions.
     ///
@@ -300,9 +301,9 @@ pub(crate) trait LogReplayProcessor: Sized {
     /// 3. Automatically filters out batches with no selected rows
     ///
     /// # Parameters
-    /// - `action_iter`: Iterator of (batch, is_commit_batch) tuples, where each batch contains actions
-    ///   and the boolean flag indicates whether the batch came from a commit log (`true`) or checkpoint
-    ///   (`false`). Actions must be provided in reverse chronological order.
+    /// - `action_iter`: Iterator of [`ActionsBatch`], where each batch contains actions and the
+    ///   boolean flag indicates whether the batch came from a commit log (`true`) or checkpoint
+    ///   (`false`). Actions _must_ be provided in reverse chronological order.
     ///
     /// # Returns
     /// An iterator that yields the output type of the processor, containing only non-empty results

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -200,9 +200,9 @@ impl LogSegment {
         LogSegment::try_new(listed_files, log_root, end_version)
     }
 
-    /// Read a stream of actions from this log segment. This returns an iterator of (EngineData,
-    /// bool) pairs, where the boolean flag indicates whether the data was read from a commit file
-    /// (true) or a checkpoint file (false).
+    /// Read a stream of actions from this log segment. This returns an iterator of
+    /// [`ActionsBatch`]s which includes EngineData of actions + a boolean flag indicating whether
+    /// the data was read from a commit file (true) or a checkpoint file (false).
     ///
     /// The log files will be read from most recent to oldest.
     ///

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -9,6 +9,7 @@ use crate::actions::{
     get_log_schema, Metadata, Protocol, ADD_NAME, METADATA_NAME, PROTOCOL_NAME, REMOVE_NAME,
     SIDECAR_NAME,
 };
+use crate::log_replay::ActionsBatch;
 use crate::path::{LogPathFileType, ParsedLogPath};
 use crate::schema::SchemaRef;
 use crate::snapshot::LastCheckpointHint;
@@ -218,7 +219,7 @@ impl LogSegment {
         commit_read_schema: SchemaRef,
         checkpoint_read_schema: SchemaRef,
         meta_predicate: Option<PredicateRef>,
-    ) -> DeltaResult<impl Iterator<Item = DeltaResult<(Box<dyn EngineData>, bool)>> + Send> {
+    ) -> DeltaResult<impl Iterator<Item = DeltaResult<ActionsBatch>> + Send> {
         // `replay` expects commit files to be sorted in descending order, so we reverse the sorted
         // commit files
         let commit_files: Vec<_> = self
@@ -230,7 +231,7 @@ impl LogSegment {
         let commit_stream = engine
             .json_handler()
             .read_json_files(&commit_files, commit_read_schema, meta_predicate.clone())?
-            .map_ok(|batch| (batch, true));
+            .map_ok(|batch| ActionsBatch::new(batch, true));
 
         let checkpoint_stream =
             self.create_checkpoint_stream(engine, checkpoint_read_schema, meta_predicate)?;
@@ -254,7 +255,7 @@ impl LogSegment {
         engine: &dyn Engine,
         checkpoint_read_schema: SchemaRef,
         meta_predicate: Option<PredicateRef>,
-    ) -> DeltaResult<impl Iterator<Item = DeltaResult<(Box<dyn EngineData>, bool)>> + Send> {
+    ) -> DeltaResult<impl Iterator<Item = DeltaResult<ActionsBatch>> + Send> {
         let need_file_actions = checkpoint_read_schema.contains(ADD_NAME)
             || checkpoint_read_schema.contains(REMOVE_NAME);
         require!(
@@ -330,7 +331,7 @@ impl LogSegment {
                     .chain(sidecar_content.into_iter().flatten())
                     // The boolean flag indicates whether the batch originated from a commit file
                     // (true) or a checkpoint file (false).
-                    .map_ok(|sidecar_batch| (sidecar_batch, false));
+                    .map_ok(|sidecar_batch| ActionsBatch::new(sidecar_batch, false));
 
                 Ok(combined_batches)
             })
@@ -380,15 +381,15 @@ impl LogSegment {
         &self,
         engine: &dyn Engine,
     ) -> DeltaResult<(Option<Metadata>, Option<Protocol>)> {
-        let data_batches = self.replay_for_metadata(engine)?;
+        let actions_batches = self.replay_for_metadata(engine)?;
         let (mut metadata_opt, mut protocol_opt) = (None, None);
-        for batch in data_batches {
-            let (batch, _) = batch?;
+        for actions_batch in actions_batches {
+            let actions = actions_batch?.actions;
             if metadata_opt.is_none() {
-                metadata_opt = Metadata::try_new_from_data(batch.as_ref())?;
+                metadata_opt = Metadata::try_new_from_data(actions.as_ref())?;
             }
             if protocol_opt.is_none() {
-                protocol_opt = Protocol::try_new_from_data(batch.as_ref())?;
+                protocol_opt = Protocol::try_new_from_data(actions.as_ref())?;
             }
             if metadata_opt.is_some() && protocol_opt.is_some() {
                 // we've found both, we can stop
@@ -412,7 +413,7 @@ impl LogSegment {
     fn replay_for_metadata(
         &self,
         engine: &dyn Engine,
-    ) -> DeltaResult<impl Iterator<Item = DeltaResult<(Box<dyn EngineData>, bool)>> + Send> {
+    ) -> DeltaResult<impl Iterator<Item = DeltaResult<ActionsBatch>> + Send> {
         let schema = get_log_schema().project(&[PROTOCOL_NAME, METADATA_NAME])?;
         // filter out log files that do not contain metadata or protocol information
         static META_PREDICATE: LazyLock<Option<PredicateRef>> = LazyLock::new(|| {

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -16,6 +16,7 @@ use crate::engine::default::executor::tokio::TokioBackgroundExecutor;
 use crate::engine::default::filesystem::ObjectStoreStorageHandler;
 use crate::engine::default::DefaultEngine;
 use crate::engine::sync::SyncEngine;
+use crate::log_replay::ActionsBatch;
 use crate::log_segment::{ListedLogFiles, LogSegment};
 use crate::parquet::arrow::ArrowWriter;
 use crate::path::{LogPathFileType, ParsedLogPath};
@@ -1048,7 +1049,10 @@ fn test_create_checkpoint_stream_returns_checkpoint_batches_as_is_if_schema_has_
         log_segment.create_checkpoint_stream(&engine, v2_checkpoint_read_schema.clone(), None)?;
 
     // Assert that the first batch returned is from reading checkpoint file 1
-    let (first_batch, is_log_batch) = iter.next().unwrap()?;
+    let ActionsBatch {
+        actions: first_batch,
+        is_log_batch,
+    } = iter.next().unwrap()?;
     assert!(!is_log_batch);
     assert_batch_matches(
         first_batch,
@@ -1107,7 +1111,10 @@ fn test_create_checkpoint_stream_returns_checkpoint_batches_if_checkpoint_is_mul
 
     // Assert the correctness of batches returned
     for expected_sidecar in ["sidecar1.parquet", "sidecar2.parquet"].iter() {
-        let (batch, is_log_batch) = iter.next().unwrap()?;
+        let ActionsBatch {
+            actions: batch,
+            is_log_batch,
+        } = iter.next().unwrap()?;
         assert!(!is_log_batch);
         assert_batch_matches(
             batch,
@@ -1149,7 +1156,10 @@ fn test_create_checkpoint_stream_reads_parquet_checkpoint_batch_without_sidecars
         log_segment.create_checkpoint_stream(&engine, v2_checkpoint_read_schema.clone(), None)?;
 
     // Assert that the first batch returned is from reading checkpoint file 1
-    let (first_batch, is_log_batch) = iter.next().unwrap()?;
+    let ActionsBatch {
+        actions: first_batch,
+        is_log_batch,
+    } = iter.next().unwrap()?;
     assert!(!is_log_batch);
     assert_batch_matches(first_batch, add_batch_simple(v2_checkpoint_read_schema));
     assert!(iter.next().is_none());
@@ -1187,7 +1197,10 @@ fn test_create_checkpoint_stream_reads_json_checkpoint_batch_without_sidecars() 
         log_segment.create_checkpoint_stream(&engine, v2_checkpoint_read_schema, None)?;
 
     // Assert that the first batch returned is from reading checkpoint file 1
-    let (first_batch, is_log_batch) = iter.next().unwrap()?;
+    let ActionsBatch {
+        actions: first_batch,
+        is_log_batch,
+    } = iter.next().unwrap()?;
     assert!(!is_log_batch);
     let mut visitor = AddVisitor::default();
     visitor.visit_rows_of(&*first_batch)?;
@@ -1246,7 +1259,10 @@ fn test_create_checkpoint_stream_reads_checkpoint_file_and_returns_sidecar_batch
         log_segment.create_checkpoint_stream(&engine, v2_checkpoint_read_schema.clone(), None)?;
 
     // Assert that the first batch returned is from reading checkpoint file 1
-    let (first_batch, is_log_batch) = iter.next().unwrap()?;
+    let ActionsBatch {
+        actions: first_batch,
+        is_log_batch,
+    } = iter.next().unwrap()?;
     assert!(!is_log_batch);
     assert_batch_matches(
         first_batch,
@@ -1256,7 +1272,10 @@ fn test_create_checkpoint_stream_reads_checkpoint_file_and_returns_sidecar_batch
         ),
     );
     // Assert that the second batch returned is from reading sidecarfile1
-    let (second_batch, is_log_batch) = iter.next().unwrap()?;
+    let ActionsBatch {
+        actions: second_batch,
+        is_log_batch,
+    } = iter.next().unwrap()?;
     assert!(!is_log_batch);
     assert_batch_matches(
         second_batch,
@@ -1264,7 +1283,10 @@ fn test_create_checkpoint_stream_reads_checkpoint_file_and_returns_sidecar_batch
     );
 
     // Assert that the second batch returned is from reading sidecarfile2
-    let (third_batch, is_log_batch) = iter.next().unwrap()?;
+    let ActionsBatch {
+        actions: third_batch,
+        is_log_batch,
+    } = iter.next().unwrap()?;
     assert!(!is_log_batch);
     assert_batch_matches(
         third_batch,

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -387,13 +387,14 @@ impl LogReplayProcessor for ScanLogReplayProcessor {
     }
 }
 
-/// Given an iterator of (engine_data, bool) tuples and a predicate, returns an iterator of
-/// `(engine_data, selection_vec)`. Each row that is selected in the returned `engine_data` _must_
-/// be processed to complete the scan. Non-selected rows _must_ be ignored. The boolean flag
-/// indicates whether the record batch is a log or checkpoint batch.
+/// Given an iterator of [`ActionsBatch`]s (batches of actions read from the log) and a predicate,
+/// returns an iterator of [`ScanMetadata`]s (which includes the files to be scanned as
+/// [`FilteredEngineData`] and transforms that must be applied to correctly read the data). Each row
+/// that is selected in the returned `engine_data` _must_ be processed to complete the scan.
+/// Non-selected rows _must_ be ignored.
 ///
-/// Note: The iterator of (engine_data, bool) tuples 'action_iter' parameter must be sorted by the
-/// order of the actions in the log from most recent to least recent.
+/// Note: The iterator of [`ActionsBatch`]s ('action_iter' parameter) must be sorted by the order of
+/// the actions in the log from most recent to least recent.
 pub(crate) fn scan_action_iter(
     engine: &dyn Engine,
     action_iter: impl Iterator<Item = DeltaResult<ActionsBatch>>,

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -18,7 +18,7 @@ use crate::engine_data::FilteredEngineData;
 use crate::expressions::transforms::ExpressionTransform;
 use crate::expressions::{ColumnName, Expression, ExpressionRef, Predicate, PredicateRef, Scalar};
 use crate::kernel_predicates::{DefaultKernelPredicateEvaluator, EmptyColumnResolver};
-use crate::log_replay::HasSelectionVector;
+use crate::log_replay::{ActionsBatch, HasSelectionVector};
 use crate::log_segment::{ListedLogFiles, LogSegment};
 use crate::scan::state::{DvInfo, Stats};
 use crate::schema::ToSchema as _;
@@ -537,8 +537,9 @@ impl Scan {
             get_scan_metadata_transform_expr(),
             RESTORED_ADD_SCHEMA.clone(),
         );
-        let apply_transform =
-            move |data: Box<dyn EngineData>| Ok((transform.evaluate(data.as_ref())?, false));
+        let apply_transform = move |data: Box<dyn EngineData>| {
+            Ok(ActionsBatch::new(transform.evaluate(data.as_ref())?, false))
+        };
 
         // If the snapshot version corresponds to the hint version, we process the existing data
         // to apply file skipping and provide the required transformations.
@@ -587,7 +588,7 @@ impl Scan {
     fn scan_metadata_inner(
         &self,
         engine: &dyn Engine,
-        action_iter: impl Iterator<Item = DeltaResult<(Box<dyn EngineData>, bool)>>,
+        action_batch_iter: impl Iterator<Item = DeltaResult<ActionsBatch>>,
     ) -> DeltaResult<impl Iterator<Item = DeltaResult<ScanMetadata>>> {
         // Compute the static part of the transformation. This is `None` if no transformation is
         // needed (currently just means no partition cols AND no column mapping but will be extended
@@ -602,7 +603,7 @@ impl Scan {
         };
         let it = scan_action_iter(
             engine,
-            action_iter,
+            action_batch_iter,
             self.logical_schema.clone(),
             static_transform,
             physical_predicate,
@@ -614,7 +615,7 @@ impl Scan {
     fn replay_for_scan_metadata(
         &self,
         engine: &dyn Engine,
-    ) -> DeltaResult<impl Iterator<Item = DeltaResult<(Box<dyn EngineData>, bool)>> + Send> {
+    ) -> DeltaResult<impl Iterator<Item = DeltaResult<ActionsBatch>> + Send> {
         // NOTE: We don't pass any meta-predicate because we expect no meaningful row group skipping
         // when ~every checkpoint file will contain the adds and removes we are looking for.
         self.snapshot.log_segment().read_actions(
@@ -853,6 +854,7 @@ pub(crate) mod test_utils {
     use itertools::Itertools;
     use std::sync::Arc;
 
+    use crate::log_replay::ActionsBatch;
     use crate::{
         actions::get_log_schema,
         engine::{
@@ -960,7 +962,9 @@ pub(crate) mod test_utils {
             logical_schema.unwrap_or_else(|| Arc::new(crate::schema::StructType::new(vec![])));
         let iter = scan_action_iter(
             &SyncEngine::new(),
-            batch.into_iter().map(|batch| Ok((batch as _, true))),
+            batch
+                .into_iter()
+                .map(|batch| Ok(ActionsBatch::new(batch as _, true))),
             logical_schema,
             transform,
             None,


### PR DESCRIPTION
## What changes are proposed in this pull request?
We have many places which pass around the following tuple which contains a batch of EngineData of actions and a boolean to indicate whether or not it came from a commit file or a checkpoint or something else: `(Box<dyn EngineData>, bool)`. Inspired by #910 this encapsulates "actions batches" into a struct.

In order to easy the interpretation of these tuples this PR replaces the tuple with a simple pub(crate)-fields struct named `ActionsBatch`:
```rust
struct ActionsBatch {
    actions: Box<dyn EngineData>,
    is_log_batch: bool,
}
```


## How was this change tested?
refactor. existing tests suffice