### PR TITLE
chore!: Make several types/function pub and fix their doc comments

### DIFF
--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -35,7 +35,7 @@ pub(crate) fn unwrap_kernel_expression(
 ) -> Option<Expression> {
     match state.inflight_ids.take(exprid)? {
         ExpressionOrPredicate::Expression(expr) => Some(expr),
-        ExpressionOrPredicate::Predicate(pred) => Some(Expression::predicate(pred)),
+        ExpressionOrPredicate::Predicate(pred) => Some(Expression::from_pred(pred)),
     }
 }
 

--- a/ffi/src/ffi_tracing.rs
+++ b/ffi/src/ffi_tracing.rs
@@ -85,7 +85,7 @@ pub type TracingEventFn = extern "C" fn(event: Event);
 /// Returns `true` if the callback was setup successfully, false on failure (i.e. if called a second
 /// time)
 ///
-/// [`event`] based tracing gives an engine maximal flexibility in formatting event log
+/// Event-based tracing gives an engine maximal flexibility in formatting event log
 /// lines. Kernel can also format events for the engine. If this is desired call
 /// [`enable_log_line_tracing`] instead of this method.
 ///

--- a/ffi/src/test_ffi.rs
+++ b/ffi/src/test_ffi.rs
@@ -15,7 +15,7 @@ use delta_kernel::schema::{ArrayType, DataType, MapType, StructField, StructType
 ///
 /// # Safety
 /// The caller is responsible for freeing the returned memory, either by calling
-/// [`crate::expressions::free_kernel_expression`], or [`crate::handles::Handle::drop_handle`].
+/// [`crate::expressions::free_kernel_expression`], or [`crate::handle::Handle::drop_handle`].
 #[no_mangle]
 pub unsafe extern "C" fn get_testing_kernel_expression() -> Handle<SharedExpression> {
     let array_type = ArrayType::new(
@@ -98,7 +98,7 @@ pub unsafe extern "C" fn get_testing_kernel_expression() -> Handle<SharedExpress
 ///
 /// # Safety
 /// The caller is responsible for freeing the returned memory, either by calling
-/// [`crate::expressions::free_kernel_predicate`], or [`crate::handles::Handle::drop_handle`].
+/// [`crate::expressions::free_kernel_predicate`], or [`crate::handle::Handle::drop_handle`].
 #[no_mangle]
 pub unsafe extern "C" fn get_testing_kernel_predicate() -> Handle<SharedPredicate> {
     let array_type = ArrayType::new(

--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -298,7 +298,7 @@ impl CheckpointWriter {
     /// - `metadata`: The metadata of the written checkpoint file
     /// - `checkpoint_data`: The exhausted checkpoint data iterator
     ///
-    /// # Returns: [`variant@Ok`] if the checkpoint was successfully finalized
+    /// # Returns: `Ok` if the checkpoint was successfully finalized
     // Internally, this method:
     // 1. Validates that the checkpoint data iterator is fully exhausted
     // 2. Creates the `_last_checkpoint` data with `create_last_checkpoint_data`

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -73,7 +73,8 @@ fn extract_column(mut parent: &dyn ProvidesColumnByName, col: &[String]) -> Delt
     }
 }
 
-pub(crate) fn evaluate_expression(
+/// Evaluates a kernel expression over a record batch
+pub fn evaluate_expression(
     expression: &Expression,
     batch: &RecordBatch,
     result_type: Option<&DataType>,
@@ -131,7 +132,7 @@ pub(crate) fn evaluate_expression(
 }
 
 /// Evaluates a (possibly inverted) kernel predicate over a record batch
-pub(crate) fn evaluate_predicate(
+pub fn evaluate_predicate(
     predicate: &Predicate,
     batch: &RecordBatch,
     inverted: bool,

--- a/kernel/src/engine/arrow_expression/mod.rs
+++ b/kernel/src/engine/arrow_expression/mod.rs
@@ -21,7 +21,7 @@ use apply_schema::{apply_schema, apply_schema_to};
 use evaluate_expression::{evaluate_expression, evaluate_predicate};
 
 mod apply_schema;
-mod evaluate_expression;
+pub mod evaluate_expression;
 
 #[cfg(test)]
 mod tests;

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -240,7 +240,7 @@ impl Expression {
     }
 
     /// Wraps a predicate as a boolean-valued expression
-    pub fn predicate(value: Predicate) -> Self {
+    pub fn from_pred(value: Predicate) -> Self {
         match value {
             Predicate::BooleanExpression(expr) => expr,
             _ => Self::Predicate(Box::new(value)),
@@ -531,7 +531,7 @@ impl From<ColumnName> for Expression {
 
 impl From<Predicate> for Expression {
     fn from(value: Predicate) -> Self {
-        Self::predicate(value)
+        Self::from_pred(value)
     }
 }
 

--- a/kernel/src/kernel_predicates/mod.rs
+++ b/kernel/src/kernel_predicates/mod.rs
@@ -17,6 +17,22 @@ pub(crate) mod parquet_stats_skipping;
 #[cfg(test)]
 mod tests;
 
+/// A data skipping predicate evaluator that directly applies data skipping, resolving column
+/// references to scalar stats values such as those provided by parquet footer stats.
+//
+// NOTE: We need a generic lifetime here to inform the compiler that this typedef only needs to live
+// as long as whatever is using it. Otherwise the compiler infers the static lifetime, which is too
+// long for any concrete implementation that has a lifetime parameter of its own (such as the
+// `RowGroupFilter` used by parquet data skipping). Downside is a `<'_>` at every use site.
+pub type DirectDataSkippingPredicateEvaluator<'a> =
+    dyn DataSkippingPredicateEvaluator<Output = bool, ColumnStat = Scalar> + 'a;
+
+/// A data skipping predicate evaluator that rewrites the input to a predicate that performs data
+/// skipping over column stats for all referenced columns. The resulting predicate can be evaluated
+/// against batches of column stats at some future point.
+pub type IndirectDataSkippingPredicateEvaluator<'a> =
+    dyn DataSkippingPredicateEvaluator<Output = Pred, ColumnStat = Expr> + 'a;
+
 /// Uses kernel (not engine) logic to evaluate a predicate tree against column names that resolve as
 /// scalars. Useful for testing/debugging but also serves as a reference implementation that
 /// documents the expression semantics that kernel relies on for data skipping.
@@ -24,21 +40,21 @@ mod tests;
 /// # Inverted expression semantics
 ///
 /// Because inversion (`NOT` operator) has special semantics and can often be optimized away by
-/// pushing it down, most methods take an `inverted` flag. That allows operations like
-/// [`UnaryPredicateOp::Not`] to simply evaluate their operand with a flipped `inverted` flag, and
-/// greatly simplifies the implementations of most operators (other than those which have to
-/// directly implement NOT semantics, which are unavoidably complex in that regard).
+/// pushing it down, most methods take an `inverted` flag. That allows operations like [`Pred::Not`]
+/// to simply evaluate their operand with a flipped `inverted` flag, and greatly simplifies the
+/// implementations of most operators (other than those which have to directly implement NOT
+/// semantics, which are unavoidably complex in that regard).
 ///
 /// # Parameterized output type
 ///
 /// The types involved in predicate evaluation are parameterized and implementation-specific. For
-/// example, [`crate::engine::parquet_stats_skipping::ParquetStatsProvider`] directly evaluates the
-/// predicate over parquet footer stats and returns boolean results, while
-/// [`crate::scan::data_skipping::DataSkippingPredicateCreator`] instead transforms the input
-/// predicate to a data skipping predicate that the engine can evaluated directly against Delta data
-/// skipping stats during log replay. Although this approach is harder to read and reason about at
-/// first, the majority of predicates can be implemented generically, which greatly reduces
-/// redundancy and ensures that all flavors of predicate evaluation have the same semantics.
+/// example, a [`DirectDataSkippingPredicateEvaluator`] directly evaluates the predicate (e.g. using
+/// parquet footer stats) and returns boolean results, while
+/// [`IndirectDataSkippingPredicateEvaluator`] instead transforms the input predicate to a data
+/// skipping predicate that the engine can evaluated directly against Delta data skipping stats
+/// during log replay. Although this approach is harder to read and reason about at first, the
+/// majority of predicates can be implemented generically, which greatly reduces redundancy and
+/// ensures that all flavors of predicate evaluation have the same semantics.
 ///
 /// # NULL and error semantics
 ///
@@ -59,7 +75,7 @@ mod tests;
 /// NOTE: The error-handling semantics of this trait's scalar-based predicate evaluation may differ
 /// from those of the engine's predicate evaluation, because kernel predicates don't include the
 /// necessary type information to reliably detect all type errors.
-pub(crate) trait KernelPredicateEvaluator {
+pub trait KernelPredicateEvaluator {
     type Output;
 
     /// A (possibly inverted) boolean scalar value, e.g. `[NOT] <value>`.
@@ -104,8 +120,8 @@ pub(crate) trait KernelPredicateEvaluator {
     /// Completes evaluation of a (possibly inverted) junction predicate.
     ///
     /// AND and OR are implemented by first evaluating its (possibly inverted) inputs. This part is
-    /// always the same, provided by [`eval_pred_junction`]). The results are then combined to become the
-    /// predicate's output in some implementation-defined way (this method).
+    /// always the same, provided by [`Self::eval_pred_junction`]). The results are then combined to
+    /// become the predicate's output in some implementation-defined way (this method).
     fn finish_eval_pred_junction(
         &self,
         op: JunctionPredicateOp,
@@ -166,8 +182,8 @@ pub(crate) trait KernelPredicateEvaluator {
     /// A (possibly inverted) DISTINCT test, e.g. `[NOT] DISTINCT(<col>, false)`. DISTINCT can be
     /// seen as one of two operations, depending on the input:
     ///
-    /// 1. DISTINCT(<col>, NULL) is equivalent to `<col> IS NOT NULL`
-    /// 2. DISTINCT(<col>, <value>) is equivalent to `OR(<col> IS NULL, <col> != <value>)`
+    /// 1. `DISTINCT(<col>, NULL)` is equivalent to `<col> IS NOT NULL`
+    /// 2. `DISTINCT(<col>, <value>)` is equivalent to `OR(<col> IS NULL, <col> != <value>)`
     fn eval_pred_distinct(
         &self,
         col: &ColumnName,
@@ -236,7 +252,7 @@ pub(crate) trait KernelPredicateEvaluator {
     }
 
     /// Dispatches a predicate junction operation (AND or OR), leveraging each implementation's
-    /// [`finish_eval_junction`].
+    /// [`Self::finish_eval_pred_junction`].
     fn eval_pred_junction(
         &self,
         op: JunctionPredicateOp,
@@ -265,9 +281,9 @@ pub(crate) trait KernelPredicateEvaluator {
 
     /// Evaluates a (possibly inverted) predicate with SQL WHERE semantics.
     ///
-    /// By default, [`eval_pred`] behaves badly for comparisons involving NULL columns (e.g. `a <
-    /// 10` when `a` is NULL), because the comparison correctly evaluates to NULL, but NULL
-    /// values are interpreted as "stats missing" (= cannot skip). This ambiguity can "poison"
+    /// By default, [`Self::eval_pred`] behaves badly for comparisons involving NULL columns
+    /// (e.g. `a < 10` when `a` is NULL), because the comparison correctly evaluates to NULL, but
+    /// NULL values are interpreted as "stats missing" (= cannot skip). This ambiguity can "poison"
     /// the entire predicate, causing it to return NULL instead of FALSE that would allow skipping:
     ///
     /// ```text
@@ -422,13 +438,13 @@ pub(crate) trait KernelPredicateEvaluator {
         }
     }
 
-    /// A convenient non-inverted wrapper for [`eval_pred`]
-    #[cfg(test)]
+    /// A convenient non-inverted wrapper for [`Self::eval_pred`]
+    #[allow(unused)]
     fn eval(&self, pred: &Pred) -> Option<Self::Output> {
         self.eval_pred(pred, false)
     }
 
-    /// A convenient non-inverted wrapper for [`eval_pred_sql_where`].
+    /// A convenient non-inverted wrapper for [`Self::eval_pred_sql_where`].
     fn eval_sql_where(&self, pred: &Pred) -> Option<Self::Output> {
         self.eval_pred_sql_where(pred, false)
     }
@@ -436,10 +452,10 @@ pub(crate) trait KernelPredicateEvaluator {
 
 /// A collection of provided methods from the [`KernelPredicateEvaluator`] trait, factored out to allow
 /// reuse by multiple bool-output predicate evaluator implementations.
-pub(crate) struct KernelPredicateEvaluatorDefaults;
+pub struct KernelPredicateEvaluatorDefaults;
 impl KernelPredicateEvaluatorDefaults {
     /// Directly evaluates a boolean scalar. See [`KernelPredicateEvaluator::eval_pred_scalar`].
-    pub(crate) fn eval_pred_scalar(val: &Scalar, inverted: bool) -> Option<bool> {
+    pub fn eval_pred_scalar(val: &Scalar, inverted: bool) -> Option<bool> {
         match val {
             Scalar::Boolean(val) => Some(*val != inverted),
             _ => None,
@@ -447,13 +463,13 @@ impl KernelPredicateEvaluatorDefaults {
     }
 
     /// Directly null-tests a scalar. See [`KernelPredicateEvaluator::eval_pred_scalar_is_null`].
-    pub(crate) fn eval_pred_scalar_is_null(val: &Scalar, inverted: bool) -> Option<bool> {
+    pub fn eval_pred_scalar_is_null(val: &Scalar, inverted: bool) -> Option<bool> {
         Some(val.is_null() != inverted)
     }
 
     /// A (possibly inverted) partial comparison of two scalars, leveraging the [`PartialOrd`]
     /// trait.
-    pub(crate) fn partial_cmp_scalars(
+    pub fn partial_cmp_scalars(
         ord: Ordering,
         a: &Scalar,
         b: &Scalar,
@@ -465,7 +481,7 @@ impl KernelPredicateEvaluatorDefaults {
     }
 
     /// Directly evaluates a boolean comparison. See [`KernelPredicateEvaluator::eval_pred_binary_scalars`].
-    pub(crate) fn eval_pred_binary_scalars(
+    pub fn eval_pred_binary_scalars(
         op: BinaryPredicateOp,
         left: &Scalar,
         right: &Scalar,
@@ -491,7 +507,7 @@ impl KernelPredicateEvaluatorDefaults {
     /// With AND (OR), any FALSE (TRUE) input dominates, forcing a FALSE (TRUE) output.  If there
     /// was no dominating input, then any NULL input forces NULL output.  Otherwise, return the
     /// non-dominant value. Inverting the operation also inverts the dominant value.
-    pub(crate) fn finish_eval_pred_junction(
+    pub fn finish_eval_pred_junction(
         op: JunctionPredicateOp,
         preds: impl IntoIterator<Item = Option<bool>>,
         inverted: bool,
@@ -633,7 +649,7 @@ impl<R: ResolveColumnAsScalar> KernelPredicateEvaluator for DefaultKernelPredica
 /// example, comparisons involving a column are converted into comparisons over that column's
 /// min/max stats, and NULL checks are converted into comparisons involving the column's nullcount
 /// and rowcount stats.
-pub(crate) trait DataSkippingPredicateEvaluator {
+pub trait DataSkippingPredicateEvaluator {
     /// The output type produced by this predicate evaluator
     type Output;
     /// The type for column stats consumed by this predicate evaluator
@@ -763,7 +779,7 @@ pub(crate) trait DataSkippingPredicateEvaluator {
         }
     }
 
-    /// See [`KernelPredicateEvaluator::eval_pred_ge`]
+    /// See [`KernelPredicateEvaluator::eval_pred_eq`]
     fn eval_pred_eq(&self, col: &ColumnName, val: &Scalar, inverted: bool) -> Option<Self::Output> {
         let (op, preds) = if inverted {
             // Column could compare not-equal if min or max value differs from the literal.

--- a/kernel/src/kernel_predicates/parquet_stats_skipping.rs
+++ b/kernel/src/kernel_predicates/parquet_stats_skipping.rs
@@ -27,8 +27,7 @@ pub(crate) trait ParquetStatsProvider {
     fn get_parquet_rowcount_stat(&self) -> i64;
 }
 
-/// Blanket implementation that converts a [`ParquetStatsProvider`] into a
-/// [`DataSkippingPredicateEvaluator`].
+// Blanket implementation for all types that impl ParquetStatsProvider.
 impl<T: ParquetStatsProvider> DataSkippingPredicateEvaluator for T {
     type Output = bool;
     type ColumnStat = Scalar;

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -92,7 +92,7 @@ mod arrow_compat;
 #[cfg(any(feature = "arrow-54", feature = "arrow-55"))]
 pub use arrow_compat::*;
 
-pub(crate) mod kernel_predicates;
+pub mod kernel_predicates;
 pub(crate) mod utils;
 
 // for the below modules, we cannot introduce a macro to clean this up. rustfmt doesn't follow into

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -39,7 +39,7 @@ mod tests;
 /// - `OR` is rewritten only if all operands are eligible for data skipping. Otherwise, the whole OR
 ///   predicate is dropped.
 #[cfg(test)]
-fn as_data_skipping_predicate(pred: &Pred) -> Option<Pred> {
+pub(crate) fn as_data_skipping_predicate(pred: &Pred) -> Option<Pred> {
     DataSkippingPredicateCreator.eval(pred)
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Pathfinding on https://github.com/delta-io/delta-kernel-rs/pull/686 exposed the fact that an engine implementing custom (opaque) expressions needs access to several kernel API that are currently private. Make them public and fix their doc comments. 

Also fix some broken doc comments for already-pub code, exposed by the following command (CI test gap?)
```
cargo doc --workspace --all-features
```

While we're at it, rename `Expression::predicate` to `Expression::from_pred` to be consistent with `Predicate::from_expr` (the old name was confusing to read at call sites).

### This PR affects the following public APIs

`KernelPredicateEvaluator` and `KernelPredicateEvaluatorDefaults` are now pub.

Make `DataSkippingPredicateEvaluator` pub; add new type aliases `DirectDataSkippingPredicateEvaluator` and `IndirectDataSkippingPredicateEvaluator` to improve readability of code using those types.

Arrow engine `evaluate_expression` and `evaluate_predicate` are now pub.

`Expression::predicate` renamed to `Expression::from_pred`

## How was this change tested?

Doc tests pass on the newly pub code.