### PR TITLE
feat: Add default engine support for arrow eval of opaque expressions

### DIFF
--- a/kernel/src/engine/arrow_expression/mod.rs
+++ b/kernel/src/engine/arrow_expression/mod.rs
@@ -22,6 +22,7 @@ use evaluate_expression::{evaluate_expression, evaluate_predicate};
 
 mod apply_schema;
 pub mod evaluate_expression;
+pub mod opaque;
 
 #[cfg(test)]
 mod tests;

--- a/kernel/src/engine/arrow_expression/opaque.rs
+++ b/kernel/src/engine/arrow_expression/opaque.rs
@@ -1,0 +1,231 @@
+use crate::arrow::array::{ArrayRef, BooleanArray, RecordBatch};
+use crate::expressions::{
+    Expression, OpaqueExpressionOp, OpaquePredicateOp, Predicate, Scalar, ScalarExpressionEvaluator,
+};
+use crate::kernel_predicates::{
+    DirectDataSkippingPredicateEvaluator, DirectPredicateEvaluator,
+    IndirectDataSkippingPredicateEvaluator,
+};
+use crate::schema::DataType;
+use crate::{DeltaResult, DynPartialEq};
+
+/// An arrow-enhanced opaque expression op that supports full expression evaluation over arrow data.
+///
+/// NOTE: This trait includes all methods of [`OpaqueExpressionOp`], but intentionally does not
+/// implement it. This is to prevent accidentally creating an [`Expression`] directly from an object
+/// that implements this trait. Doing so would "clip" it [`&dyn OpaqueExpressionOp`], and we would
+/// not be able to recover a [`&dyn ArrowOpaqueExpressionOp`] from it later. Instead, we use
+/// [`ArrowOpaqueExpression::arrow_opaque`] to safely convert it to an [`OpaqueExpressionOp`].
+pub trait ArrowOpaqueExpressionOp: DynPartialEq + std::fmt::Debug {
+    /// Evaluates this expression over the provided input expressions, returning `Err` in case of an
+    /// incorrect or unsupported invocation (e.g. wrong number and/or types of arguments.
+    fn eval_expr(
+        &self,
+        args: &[Expression],
+        batch: &RecordBatch,
+        result_type: Option<&DataType>,
+    ) -> DeltaResult<ArrayRef>;
+
+    /// See [`OpaqueExpressionOp::name`].
+    fn name(&self) -> &str;
+
+    /// See [`OpaqueExpressionOp::eval_expr_scalar`].
+    fn eval_expr_scalar(
+        &self,
+        eval_expr: &ScalarExpressionEvaluator<'_>,
+        exprs: &[Expression],
+    ) -> DeltaResult<Scalar>;
+}
+
+/// An arrow-enhanced opaque predicate op that supports full predicate evaluation over arrow data.
+///
+/// NOTE: This trait includes all methods of [`OpaquePredicateOp`], but intentionally does not
+/// implement it. This is to prevent accidentally creating an [`Predicate`] directly from an object
+/// that implements this trait. Doing so would "clip" it [`&dyn OpaquePredicateOp`], and we would
+/// not be able to recover a [`&dyn ArrowOpaquePredicateOp`] from it later. Instead, we use
+/// [`ArrowOpaquePredicate::arrow_opaque`] to safely convert it to an [`OpaquePredicateOp`].
+pub trait ArrowOpaquePredicateOp: DynPartialEq + std::fmt::Debug {
+    /// Evaluates this (possibly inverted) predicate over the provided input args, returning `Err`
+    /// in case of an incorrect or unsupported invocation (e.g. wrong number and/or types of
+    /// arguments.
+    fn eval_pred(
+        &self,
+        args: &[Expression],
+        batch: &RecordBatch,
+        inverted: bool,
+    ) -> DeltaResult<BooleanArray>;
+
+    /// See [`OpaquePredicateOp::name`].
+    fn name(&self) -> &str;
+
+    /// See [`OpaquePredicateOp::eval_pred_scalar`].
+    fn eval_pred_scalar(
+        &self,
+        eval_expr: &ScalarExpressionEvaluator<'_>,
+        eval_pred: &DirectPredicateEvaluator<'_>,
+        exprs: &[Expression],
+        inverted: bool,
+    ) -> DeltaResult<Option<bool>>;
+
+    /// See [`OpaquePredicateOp::eval_as_data_skipping_predicate`].
+    fn eval_as_data_skipping_predicate(
+        &self,
+        predicate_evaluator: &DirectDataSkippingPredicateEvaluator<'_>,
+        exprs: &[Expression],
+        inverted: bool,
+    ) -> Option<bool>;
+
+    /// See [`OpaquePredicateOp::as_data_skipping_predicate`].
+    fn as_data_skipping_predicate(
+        &self,
+        predicate_evaluator: &IndirectDataSkippingPredicateEvaluator<'_>,
+        exprs: &[Expression],
+        inverted: bool,
+    ) -> Option<Predicate>;
+}
+
+/// Extension trait for turning [`ArrowOpaqueExpressionOp`] into an [`Expression`].
+pub trait ArrowOpaqueExpression {
+    /// Creates a new opaque expression. See also [`Expression::opaque`].
+    fn arrow_opaque(
+        op: impl ArrowOpaqueExpressionOp,
+        exprs: impl IntoIterator<Item = Expression>,
+    ) -> Expression;
+}
+
+impl ArrowOpaqueExpression for Expression {
+    fn arrow_opaque(
+        op: impl ArrowOpaqueExpressionOp,
+        exprs: impl IntoIterator<Item = Expression>,
+    ) -> Expression {
+        Expression::opaque(ArrowOpaqueExpressionOpAdaptor(Box::new(op)), exprs)
+    }
+}
+
+/// Extension trait for safely turning [`ArrowOpaquePredicateOp`] into an opaque [`Predicate`].
+pub trait ArrowOpaquePredicate {
+    /// Creates a new opaque predicate. See also [`Predicate::opaque`].
+    fn arrow_opaque<T: ArrowOpaquePredicateOp>(
+        op: T,
+        exprs: impl IntoIterator<Item = Expression>,
+    ) -> Predicate;
+}
+
+impl ArrowOpaquePredicate for Predicate {
+    fn arrow_opaque<T: ArrowOpaquePredicateOp>(
+        op: T,
+        exprs: impl IntoIterator<Item = Expression>,
+    ) -> Predicate {
+        Predicate::opaque(ArrowOpaquePredicateOpAdaptor(Box::new(op)), exprs)
+    }
+}
+
+/// Adaptor that implements [`OpaquePredicateOp`] on behalf of all [`ArrowOpaqueExpressionOp`], and
+/// also acts as an intermediary for downcasting so that arrow evaluation can actually use it.
+///
+/// This extra layer of indirection is needed because Rust does not support trait downcasting: If we
+/// allowed `ArrowOpaqueExpressionOp: OpaqueExpressionOp`, to decay to `&dyn OpaqueExpressionOp`,
+/// there would be no way to recover a &dyn ArrowOpaqueExpressionOp` from it. Instead, we must
+/// downcast from `&dyn OpaqueExpressionOp` to the concrete `ArrowOpaqueExpressionOpAdaptor` type
+/// that implements both traits, and extract its inner `dyn ArrowOpaqueExpressionOp`.
+pub(crate) struct ArrowOpaqueExpressionOpAdaptor(Box<dyn ArrowOpaqueExpressionOp>);
+
+impl std::ops::Deref for ArrowOpaqueExpressionOpAdaptor {
+    type Target = dyn ArrowOpaqueExpressionOp;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+impl std::fmt::Debug for ArrowOpaqueExpressionOpAdaptor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        std::fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl PartialEq for ArrowOpaqueExpressionOpAdaptor {
+    fn eq(&self, other: &Self) -> bool {
+        (**self).dyn_eq(other.any_ref())
+    }
+}
+
+// Forward the op's trait methods so kernel can use them
+impl OpaqueExpressionOp for ArrowOpaqueExpressionOpAdaptor {
+    fn name(&self) -> &str {
+        (**self).name()
+    }
+
+    fn eval_expr_scalar(
+        &self,
+        eval_expr: &ScalarExpressionEvaluator<'_>,
+        exprs: &[Expression],
+    ) -> DeltaResult<Scalar> {
+        (**self).eval_expr_scalar(eval_expr, exprs)
+    }
+}
+
+/// Adaptor that implements [`OpaquePredicateOp`] on behalf of all [`ArrowOpaquePredicateOp`], and
+/// also acts as an intermediary for downcasting so that arrow evaluation can actually use it.
+///
+/// This extra layer of indirection is needed because Rust does not support trait downcasting: If we
+/// allowed `ArrowOpaquePredicateOp: OpaquePredicateOp`, to decay to `&dyn OpaquePredicateOp`, there
+/// would be no way to recover a &dyn ArrowOpaquePredicateOp` from it. Instead, we must downcast
+/// from `&dyn OpaquePredicateOp` to the concrete `ArrowOpaquePredicateOpAdaptor` type that
+/// implements both traits, and extract its inner `dyn ArrowOpaquePredicateOp`.
+pub(crate) struct ArrowOpaquePredicateOpAdaptor(Box<dyn ArrowOpaquePredicateOp>);
+
+impl std::ops::Deref for ArrowOpaquePredicateOpAdaptor {
+    type Target = dyn ArrowOpaquePredicateOp;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+impl std::fmt::Debug for ArrowOpaquePredicateOpAdaptor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        std::fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl PartialEq for ArrowOpaquePredicateOpAdaptor {
+    fn eq(&self, other: &Self) -> bool {
+        (**self).dyn_eq(other.any_ref())
+    }
+}
+
+// Forward the op's trait methods so kernel can use them
+impl OpaquePredicateOp for ArrowOpaquePredicateOpAdaptor {
+    fn name(&self) -> &str {
+        (**self).name()
+    }
+
+    fn eval_pred_scalar(
+        &self,
+        eval_expr: &ScalarExpressionEvaluator<'_>,
+        eval_pred: &DirectPredicateEvaluator<'_>,
+        exprs: &[Expression],
+        inverted: bool,
+    ) -> DeltaResult<Option<bool>> {
+        (**self).eval_pred_scalar(eval_expr, eval_pred, exprs, inverted)
+    }
+
+    fn eval_as_data_skipping_predicate(
+        &self,
+        predicate_evaluator: &DirectDataSkippingPredicateEvaluator<'_>,
+        exprs: &[Expression],
+        inverted: bool,
+    ) -> Option<bool> {
+        (**self).eval_as_data_skipping_predicate(predicate_evaluator, exprs, inverted)
+    }
+
+    fn as_data_skipping_predicate(
+        &self,
+        predicate_evaluator: &IndirectDataSkippingPredicateEvaluator<'_>,
+        exprs: &[Expression],
+        inverted: bool,
+    ) -> Option<Predicate> {
+        (**self).as_data_skipping_predicate(predicate_evaluator, exprs, inverted)
+    }
+}

--- a/kernel/src/engine/arrow_expression/opaque.rs
+++ b/kernel/src/engine/arrow_expression/opaque.rs
@@ -128,6 +128,7 @@ impl ArrowOpaquePredicate for Predicate {
 /// there would be no way to recover a &dyn ArrowOpaqueExpressionOp` from it. Instead, we must
 /// downcast from `&dyn OpaqueExpressionOp` to the concrete `ArrowOpaqueExpressionOpAdaptor` type
 /// that implements both traits, and extract its inner `dyn ArrowOpaqueExpressionOp`.
+#[derive(Debug)]
 pub(crate) struct ArrowOpaqueExpressionOpAdaptor(Box<dyn ArrowOpaqueExpressionOp>);
 
 impl std::ops::Deref for ArrowOpaqueExpressionOpAdaptor {
@@ -135,12 +136,6 @@ impl std::ops::Deref for ArrowOpaqueExpressionOpAdaptor {
 
     fn deref(&self) -> &Self::Target {
         self.0.deref()
-    }
-}
-
-impl std::fmt::Debug for ArrowOpaqueExpressionOpAdaptor {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        std::fmt::Debug::fmt(&**self, f)
     }
 }
 
@@ -173,6 +168,7 @@ impl OpaqueExpressionOp for ArrowOpaqueExpressionOpAdaptor {
 /// would be no way to recover a &dyn ArrowOpaquePredicateOp` from it. Instead, we must downcast
 /// from `&dyn OpaquePredicateOp` to the concrete `ArrowOpaquePredicateOpAdaptor` type that
 /// implements both traits, and extract its inner `dyn ArrowOpaquePredicateOp`.
+#[derive(Debug)]
 pub(crate) struct ArrowOpaquePredicateOpAdaptor(Box<dyn ArrowOpaquePredicateOp>);
 
 impl std::ops::Deref for ArrowOpaquePredicateOpAdaptor {
@@ -180,12 +176,6 @@ impl std::ops::Deref for ArrowOpaquePredicateOpAdaptor {
 
     fn deref(&self) -> &Self::Target {
         self.0.deref()
-    }
-}
-
-impl std::fmt::Debug for ArrowOpaquePredicateOpAdaptor {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        std::fmt::Debug::fmt(&**self, f)
     }
 }
 

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -618,11 +618,11 @@ fn test_opaque() {
 
     assert_eq!(
         format!("{expr:?}"),
-        "Opaque(OpaqueExpression { op: OpaqueLessThanOp, exprs: [Column(ColumnName { path: [\"x\"] }), Literal(Integer(10))] })"
+        "Opaque(OpaqueExpression { op: ArrowOpaqueExpressionOpAdaptor(OpaqueLessThanOp), exprs: [Column(ColumnName { path: [\"x\"] }), Literal(Integer(10))] })"
     );
     assert_eq!(
         format!("{pred:?}"),
-        "Opaque(OpaquePredicate { op: OpaqueLessThanOp, exprs: [Column(ColumnName { path: [\"x\"] }), Literal(Integer(10))] })"
+        "Opaque(OpaquePredicate { op: ArrowOpaquePredicateOpAdaptor(OpaqueLessThanOp), exprs: [Column(ColumnName { path: [\"x\"] }), Literal(Integer(10))] })"
     );
 
     assert_eq!(expr, expr);

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -5,12 +5,20 @@ use crate::arrow::array::{
     ListArray, MapArray, MapBuilder, MapFieldNames, StringBuilder, StructArray,
 };
 use crate::arrow::buffer::{OffsetBuffer, ScalarBuffer};
+use crate::arrow::compute::kernels::cmp::{gt_eq, lt};
 use crate::arrow::datatypes::{DataType, Field, Fields, Schema};
 
 use super::*;
+use crate::engine::arrow_expression::opaque::{
+    ArrowOpaqueExpression as _, ArrowOpaqueExpressionOp, ArrowOpaquePredicate as _,
+    ArrowOpaquePredicateOp,
+};
 use crate::expressions::*;
-use crate::schema::{ArrayType, MapType, StructField, StructType};
-use crate::DataType as KernelDataType;
+use crate::kernel_predicates::{
+    DirectDataSkippingPredicateEvaluator, DirectPredicateEvaluator,
+    IndirectDataSkippingPredicateEvaluator,
+};
+use crate::schema::{ArrayType, DataType as KernelDataType, MapType, StructField, StructType};
 use crate::EvaluationHandlerExtension as _;
 
 use Expression as Expr;
@@ -505,6 +513,137 @@ fn test_logical() {
     let results = evaluate_predicate(&pred_or_lit, &batch, true).unwrap();
     let expected = BooleanArray::from(vec![f, f, t, t, f, t]);
     assert_eq!(results, expected);
+}
+
+#[derive(Debug, PartialEq)]
+struct OpaqueLessThanOp;
+
+impl OpaqueLessThanOp {
+    fn name(&self) -> &str {
+        "less_than"
+    }
+
+    fn eval_pred(
+        &self,
+        args: &[Expression],
+        batch: &RecordBatch,
+        inverted: bool,
+    ) -> DeltaResult<BooleanArray> {
+        let op_fn = match inverted {
+            true => gt_eq,
+            false => lt,
+        };
+
+        let [left, right] = args else {
+            panic!("Invalid arg count: {}", args.len());
+        };
+
+        let eval = |arg| evaluate_expression(arg, batch, Some(&KernelDataType::BOOLEAN));
+        Ok(op_fn(&eval(left)?, &eval(right)?)?)
+    }
+}
+
+impl ArrowOpaqueExpressionOp for OpaqueLessThanOp {
+    fn name(&self) -> &str {
+        self.name()
+    }
+
+    fn eval_expr_scalar(
+        &self,
+        _eval_expr: &ScalarExpressionEvaluator<'_>,
+        _exprs: &[Expression],
+    ) -> DeltaResult<Scalar> {
+        unimplemented!() // OpaqueExpressionOp is already tested
+    }
+
+    fn eval_expr(
+        &self,
+        args: &[Expression],
+        batch: &RecordBatch,
+        result_type: Option<&KernelDataType>,
+    ) -> DeltaResult<ArrayRef> {
+        assert!(matches!(result_type, None | Some(&KernelDataType::BOOLEAN)));
+        let result = self.eval_pred(args, batch, false)?;
+        Ok(Arc::new(result))
+    }
+}
+
+impl ArrowOpaquePredicateOp for OpaqueLessThanOp {
+    fn name(&self) -> &str {
+        self.name()
+    }
+
+    fn eval_pred(
+        &self,
+        args: &[Expression],
+        batch: &RecordBatch,
+        inverted: bool,
+    ) -> DeltaResult<BooleanArray> {
+        self.eval_pred(args, batch, inverted)
+    }
+
+    fn eval_pred_scalar(
+        &self,
+        _eval_expr: &ScalarExpressionEvaluator<'_>,
+        _eval_pred: &DirectPredicateEvaluator<'_>,
+        _exprs: &[Expression],
+        _inverted: bool,
+    ) -> DeltaResult<Option<bool>> {
+        unimplemented!() // OpaquePredicateOp is already tested
+    }
+
+    fn eval_as_data_skipping_predicate(
+        &self,
+        _predicate_evaluator: &DirectDataSkippingPredicateEvaluator<'_>,
+        _exprs: &[Expr],
+        _inverted: bool,
+    ) -> Option<bool> {
+        unimplemented!() // OpaquePredicateOp is already tested
+    }
+
+    fn as_data_skipping_predicate(
+        &self,
+        _predicate_evaluator: &IndirectDataSkippingPredicateEvaluator<'_>,
+        _exprs: &[Expr],
+        _inverted: bool,
+    ) -> Option<Pred> {
+        unimplemented!() // OpaquePredicateOp is already tested
+    }
+}
+
+#[test]
+fn test_opaque() {
+    let expr = Expr::arrow_opaque(OpaqueLessThanOp, [column_expr!("x"), Expr::literal(10)]);
+    let pred = Pred::arrow_opaque(OpaqueLessThanOp, [column_expr!("x"), Expr::literal(10)]);
+
+    assert_eq!(
+        format!("{expr:?}"),
+        "Opaque(OpaqueExpression { op: OpaqueLessThanOp, exprs: [Column(ColumnName { path: [\"x\"] }), Literal(Integer(10))] })"
+    );
+    assert_eq!(
+        format!("{pred:?}"),
+        "Opaque(OpaquePredicate { op: OpaqueLessThanOp, exprs: [Column(ColumnName { path: [\"x\"] }), Literal(Integer(10))] })"
+    );
+
+    assert_eq!(expr, expr);
+    assert_eq!(pred, pred);
+
+    let data = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![Field::new("x", DataType::Int32, false)])),
+        vec![Arc::new(Int32Array::from(vec![1, 10, 100]))],
+    )
+    .unwrap();
+
+    let lt_result = evaluate_predicate(&pred, &data, false).unwrap();
+    let lt_expected = BooleanArray::from(vec![true, false, false]);
+    assert_eq!(lt_result, lt_expected);
+
+    let not_lt_result = evaluate_predicate(&pred, &data, true).unwrap();
+    let not_lt_expected = BooleanArray::from(vec![false, true, true]);
+    assert_eq!(not_lt_result, not_lt_expected);
+
+    let lt_result = evaluate_expression(&expr, &data, Some(&KernelDataType::BOOLEAN)).unwrap();
+    assert_eq!(lt_result.as_ref(), &lt_expected);
 }
 
 #[test]


### PR DESCRIPTION
## What changes are proposed in this pull request?

Follow-up to 
* https://github.com/delta-io/delta-kernel-rs/pull/686

Add support for arrow evaluation of opaque expressions in the default engine. The new API allows engines to define their own expressions that operate on arrow record batches and which seamlessly fit into the arrow evaluation framework alongside normal kernel expressions.

Once this support lands, we can remove the existing `BinaryPredicateOp::In` predicate from the core kernel, and make it part of the default engine instead.

### This PR affects the following public APIs

Add a new API for evaluating opaque expressions and predicates in the default engine.

## How was this change tested?

New unit tests.