### PR TITLE
ci: cargo doc workspace + all-features

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install minimal stable
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: build docs
-        run: cargo doc
+        run: cargo doc --workspace --all-features
 
 
   # When we run cargo { build, clippy } --no-default-features, we want to build/lint the kernel to


### PR DESCRIPTION
## What changes are proposed in this pull request?
title: modify our CI docs builds to be `cargo doc --workspace --all-features`
