### PR TITLE
fix: make `ActionsBatch` fields pub for `internal-api`

### DIFF
--- a/kernel/src/log_replay.rs
+++ b/kernel/src/log_replay.rs
@@ -198,9 +198,9 @@ impl<'seen> FileActionDeduplicator<'seen> {
 #[internal_api]
 pub(crate) struct ActionsBatch {
     /// The batch of actions to be processed: each row is an action from the log.
-    pub(crate) actions: Box<dyn EngineData>,
+    pub actions: Box<dyn EngineData>,
     /// Whether the batch is from a commit log (=true) or a checkpoint/CRC/elsewhere (=false).
-    pub(crate) is_log_batch: bool,
+    pub is_log_batch: bool,
 }
 
 impl ActionsBatch {


### PR DESCRIPTION
## What changes are proposed in this pull request?
Previously, for actions batches represented as tuples: `(Box<dyn EngineData>, bool)` you could access the actual `Box<dyn EngineData>` (delta-rs used it) but when the `ActionsBatch` was introduced, fields were `pub(crate)` and only exposed actions via `actions()` method which returned a ref. This PR makes fields pub (for `internal-api`) to reinstate the old behavior.

## How was this change tested?
N/A