### PR TITLE
feat: Add `debug_assert` to the constructor of `struct ListedLogFiles`

### DIFF
--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -75,7 +75,7 @@ impl LogSegment {
             checkpoint_file.version
         });
 
-        // TODO: consider unifying this with debug_asserts in the ListedLogFiles::new()
+        // TODO: consider unifying this with debug_asserts in the ListedLogFiles::new(); issue#995
         // We require that commits that are contiguous. In other words, there must be no gap between commit versions.
         require!(
             ascending_commit_files

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -502,7 +502,7 @@ fn list_log_files(
 }
 
 /// A struct to hold the result of listing log files. The commit and compaction files are guaranteed
-/// to be contiguous and sorted in ascending order by version. The elements of `checkpoint_parts` are all the parts
+/// to be sorted in ascending order by version. The elements of `checkpoint_parts` are all the parts
 /// of the same checkpoint. Checkpoint parts share the same version. The `latest_crc_file` includes
 /// the latest (highest version) CRC file, if any, which may not correspond to the latest commit.
 #[derive(Debug)]

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -536,11 +536,9 @@ impl ListedLogFiles {
         debug_assert!(checkpoint_parts
             .windows(2)
             .all(|p| p[0].version == p[1].version));
-        debug_assert!(if checkpoint_parts
-            .iter()
-            .any(|p| matches!(p.file_type, LogPathFileType::MultiPartCheckpoint { .. }))
-        {
-            checkpoint_parts
+        debug_assert!(
+            checkpoint_parts.len() <= 1
+            || checkpoint_parts
                 .iter()
                 .all(|p| matches!(p.file_type, LogPathFileType::MultiPartCheckpoint { .. }))
                 && matches!(
@@ -548,18 +546,7 @@ impl ListedLogFiles {
                     LogPathFileType::MultiPartCheckpoint { num_parts, .. }
                     if checkpoint_parts.len() == num_parts as usize
                 )
-        } else if checkpoint_parts
-            .iter()
-            .any(|p| matches!(p.file_type, LogPathFileType::CompactedCommit { .. }))
-        {
-            checkpoint_parts
-                .iter()
-                .all(|p| matches!(p.file_type, LogPathFileType::CompactedCommit { .. }))
-        } else {
-            checkpoint_parts
-                .windows(2)
-                .all(|p| p[0].file_type == p[1].file_type)
-        });
+        );
 
         ListedLogFiles {
             ascending_commit_files,

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -530,7 +530,7 @@ impl ListedLogFiles {
             ascending_compaction_files
                 .windows(2)
                 .all(|f| match (&f[0].file_type, &f[1]) {
-                    (LogPathFileType::CompactedCommit { hi }, next) => *hi == next.version - 1,
+                    (LogPathFileType::CompactedCommit { hi }, next) => *hi <= next.version - 1,
                     _ => true,
                 })
         } else {

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -529,9 +529,9 @@ impl ListedLogFiles {
         {
             ascending_compaction_files
                 .windows(2)
-                .all(|f| match (&f[0].file_type, &f[1]) {
-                    (LogPathFileType::CompactedCommit { hi }, next) => *hi <= next.version - 1,
-                    _ => true,
+                .all(|f| match (&f[0].file_type, &f[1].file_type) {
+                    (LogPathFileType::CompactedCommit { hi }, ..) => *hi <= f[1].version - 1,
+                    _ => f[0].version == f[1].version - 1,
                 })
         } else {
             ascending_compaction_files

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -524,7 +524,7 @@ impl ListedLogFiles {
             .windows(2)
             .all(|f| f[0].version + 1 == f[1].version));
         debug_assert!(ascending_compaction_files.windows(2).all(|pair| {
-            let (first, second) = (&pair[0], &pair[1]);
+            let [first, second] = pair else { unreachable!() };
             match (&first.file_type, &second.file_type) {
                 (
                     LogPathFileType::CompactedCommit { hi: hi0 },

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -528,7 +528,10 @@ impl ListedLogFiles {
                 (
                     LogPathFileType::CompactedCommit { hi: hi0 },
                     LogPathFileType::CompactedCommit { hi: hi1 },
-                ) => first.version < second.version || (first.version == second.version && *hi0 <= *hi1),
+                ) => {
+                    first.version < second.version
+                        || (first.version == second.version && *hi0 <= *hi1)
+                }
                 _ => false,
             }
         }));

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -75,6 +75,7 @@ impl LogSegment {
             checkpoint_file.version
         });
 
+        // TODO: consider unifying this with debug_asserts in the ListedLogFiles::new()
         // We require that commits that are contiguous. In other words, there must be no gap between commit versions.
         require!(
             ascending_commit_files
@@ -520,9 +521,7 @@ impl ListedLogFiles {
         checkpoint_parts: Vec<ParsedLogPath>,
         latest_crc_file: Option<ParsedLogPath>,
     ) -> Self {
-        debug_assert!(ascending_commit_files
-            .windows(2)
-            .all(|f| f[0].version + 1 == f[1].version));
+        // We are adding debug_asserts here, so they don't impact the runtime performance of the released binaries
         debug_assert!(ascending_compaction_files.windows(2).all(|pair| {
             let [first, second] = pair else { unreachable!() };
             match (&first.file_type, &second.file_type) {

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -528,7 +528,7 @@ impl ListedLogFiles {
                 (
                     LogPathFileType::CompactedCommit { hi: hi0 },
                     LogPathFileType::CompactedCommit { hi: hi1 },
-                ) => first.version <= second.version && *hi0 <= *hi1,
+                ) => first.version < second.version || (first.version == second.version && *hi0 <= *hi1),
                 _ => false,
             }
         }));

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -196,12 +196,12 @@ impl LogSegment {
                 start_version
             ))
         );
-        let listed_files = ListedLogFiles {
+        let listed_files = ListedLogFiles::new (
             ascending_commit_files,
-            ascending_compaction_files: vec![],
-            checkpoint_parts: vec![],
-            latest_crc_file: None, // TODO: use CRC files for table changes?
-        };
+            vec![],
+            vec![],
+            None, // TODO: use CRC files for table changes?
+        );
         LogSegment::try_new(listed_files, log_root, end_version)
     }
 
@@ -505,13 +505,33 @@ fn list_log_files(
 /// to be sorted in ascending order by version. The elements of `checkpoint_parts` are all the parts
 /// of the same checkpoint. Checkpoint parts share the same version. The `latest_crc_file` includes
 /// the latest (highest version) CRC file, if any, which may not correspond to the latest commit.
-// TODO: debug asserts in a `new` method to enforce the above?
 #[derive(Debug)]
 pub(crate) struct ListedLogFiles {
     pub ascending_commit_files: Vec<ParsedLogPath>,
     pub ascending_compaction_files: Vec<ParsedLogPath>,
     pub checkpoint_parts: Vec<ParsedLogPath>,
     pub latest_crc_file: Option<ParsedLogPath>,
+}
+
+impl ListedLogFiles {
+    fn new(
+        ascending_commit_files: Vec<ParsedLogPath>,
+        ascending_compaction_files: Vec<ParsedLogPath>,
+        checkpoint_parts: Vec<ParsedLogPath>,
+        latest_crc_file: Option<ParsedLogPath>,
+    ) -> Self {
+        debug_assert!(ascending_commit_files.is_sorted_by_key(|f| f.version));
+        debug_assert!(ascending_compaction_files.is_sorted_by_key(|f| f.version));
+        // Debug assert for checking that checkpoint_parts are from the same checkpoint.
+        debug_assert!(checkpoint_parts.windows(2).all(|f| f[0].version == f[1].version));
+
+        ListedLogFiles {
+            ascending_commit_files,
+            ascending_compaction_files,
+            checkpoint_parts,
+            latest_crc_file,
+        }
+    }
 }
 
 /// List all commit and checkpoint files with versions above the provided `start_version` (inclusive).
@@ -580,12 +600,12 @@ pub(crate) fn list_log_files_with_version(
             }
         }
 
-        ListedLogFiles {
+        ListedLogFiles::new (
             ascending_commit_files,
             ascending_compaction_files,
             checkpoint_parts,
             latest_crc_file,
-        }
+        )
     })
 }
 

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -527,12 +527,12 @@ impl ListedLogFiles {
             .iter()
             .any(|f| matches!(f.file_type, LogPathFileType::CompactedCommit { .. }))
         {
-            ascending_compaction_files
-                .windows(2)
-                .all(|f| match (&f[0].file_type, &f[1].file_type) {
-                    (LogPathFileType::CompactedCommit { hi }, ..) => *hi <= f[1].version - 1,
+            ascending_compaction_files.windows(2).all(|f| {
+                match (&f[0].file_type, &f[1].file_type) {
+                    (LogPathFileType::CompactedCommit { hi }, ..) => *hi >= f[1].version - 1,
                     _ => f[0].version == f[1].version - 1,
-                })
+                }
+            })
         } else {
             ascending_compaction_files
                 .windows(2)

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -523,7 +523,9 @@ impl ListedLogFiles {
     ) -> Self {
         // We are adding debug_asserts here, so they don't impact the runtime performance of the released binaries
         debug_assert!(ascending_compaction_files.windows(2).all(|pair| {
-            let [first, second] = pair else { unreachable!() };
+            let [first, second] = pair else {
+                unreachable!()
+            };
             match (&first.file_type, &second.file_type) {
                 (
                     LogPathFileType::CompactedCommit { hi: hi0 },
@@ -538,14 +540,14 @@ impl ListedLogFiles {
             .all(|p| p[0].version == p[1].version));
         debug_assert!(
             checkpoint_parts.len() <= 1
-            || checkpoint_parts
-                .iter()
-                .all(|p| matches!(p.file_type, LogPathFileType::MultiPartCheckpoint { .. }))
-                && matches!(
-                    checkpoint_parts[0].file_type,
-                    LogPathFileType::MultiPartCheckpoint { num_parts, .. }
-                    if checkpoint_parts.len() == num_parts as usize
-                )
+                || checkpoint_parts
+                    .iter()
+                    .all(|p| matches!(p.file_type, LogPathFileType::MultiPartCheckpoint { .. }))
+                    && matches!(
+                        checkpoint_parts[0].file_type,
+                        LogPathFileType::MultiPartCheckpoint { num_parts, .. }
+                        if checkpoint_parts.len() == num_parts as usize
+                    )
         );
 
         ListedLogFiles {

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -521,7 +521,7 @@ impl ListedLogFiles {
         checkpoint_parts: Vec<ParsedLogPath>,
         latest_crc_file: Option<ParsedLogPath>,
     ) -> Self {
-        // We are adding debug_asserts here, so they don't impact the runtime performance of the released binaries
+        // We are adding debug_asserts here since we want to validate invariants that are (relatively) expensive to compute
         debug_assert!(ascending_compaction_files.windows(2).all(|pair| {
             let [first, second] = pair else {
                 unreachable!()

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -1,6 +1,5 @@
 //! Represents a segment of a delta log. [`LogSegment`] wraps a set of  checkpoint and commit
 //! files.
-use core::f64;
 use std::collections::HashMap;
 use std::convert::identity;
 use std::sync::{Arc, LazyLock};

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -502,7 +502,7 @@ fn list_log_files(
 }
 
 /// A struct to hold the result of listing log files. The commit and compaction files are guaranteed
-/// to be contiguously sorted in ascending order by version. The elements of `checkpoint_parts` are all the parts
+/// to be contiguous and sorted in ascending order by version. The elements of `checkpoint_parts` are all the parts
 /// of the same checkpoint. Checkpoint parts share the same version. The `latest_crc_file` includes
 /// the latest (highest version) CRC file, if any, which may not correspond to the latest commit.
 #[derive(Debug)]

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -538,6 +538,8 @@ impl ListedLogFiles {
         debug_assert!(checkpoint_parts
             .windows(2)
             .all(|p| p[0].version == p[1].version));
+        // check that only one of the following exists: (1) a singular `SinglePartCheckpoint` or
+        // `UUID` checkpoint or (2) a multi-part, and all parts are there and nothing else
         debug_assert!(
             checkpoint_parts.len() <= 1
                 || checkpoint_parts

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -522,18 +522,17 @@ impl ListedLogFiles {
         latest_crc_file: Option<ParsedLogPath>,
     ) -> Self {
         // We are adding debug_asserts here since we want to validate invariants that are (relatively) expensive to compute
-        debug_assert!(ascending_compaction_files.windows(2).all(|f| {
-            let (first, second) = (&f[0], &f[1]);
-            match (&first.file_type, &second.file_type) {
-                (
-                    LogPathFileType::CompactedCommit { hi: hi0 },
-                    LogPathFileType::CompactedCommit { hi: hi1 },
-                ) => {
-                    first.version < second.version
-                        || (first.version == second.version && *hi0 <= *hi1)
-                }
-                _ => false,
-            }
+        debug_assert!(ascending_compaction_files.windows(2).all(|f| match f {
+            [ParsedLogPath {
+                version: version0,
+                file_type: LogPathFileType::CompactedCommit { hi: hi0 },
+                ..
+            }, ParsedLogPath {
+                version: version1,
+                file_type: LogPathFileType::CompactedCommit { hi: hi1 },
+                ..
+            }] => version0 < version1 || (version0 == version1 && hi0 <= hi1),
+            _ => false,
         }));
         debug_assert!(checkpoint_parts.iter().all(|p| p.is_checkpoint()));
         debug_assert!(checkpoint_parts

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -1,5 +1,6 @@
 //! Represents a segment of a delta log. [`LogSegment`] wraps a set of  checkpoint and commit
 //! files.
+use core::f64;
 use std::collections::HashMap;
 use std::convert::identity;
 use std::sync::{Arc, LazyLock};
@@ -522,10 +523,8 @@ impl ListedLogFiles {
         latest_crc_file: Option<ParsedLogPath>,
     ) -> Self {
         // We are adding debug_asserts here since we want to validate invariants that are (relatively) expensive to compute
-        debug_assert!(ascending_compaction_files.windows(2).all(|pair| {
-            let [first, second] = pair else {
-                unreachable!()
-            };
+        debug_assert!(ascending_compaction_files.windows(2).all(|f| {
+            let (first, second) = (&f[0], &f[1]);
             match (&first.file_type, &second.file_type) {
                 (
                     LogPathFileType::CompactedCommit { hi: hi0 },

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -1687,3 +1687,56 @@ fn test_commit_cover_minimal_overlap() {
         ],
     );
 }
+
+#[test]
+#[should_panic]
+#[cfg(debug_assertions)]
+fn test_debug_assert_listed_log_file_non_contiguous_compaction_files() {
+    let _listed_log_file = ListedLogFiles::new(
+        vec![],
+        vec![
+            create_log_path(
+                "file:///00000000000000000000.00000000000000000004.compacted.json",
+            ), create_log_path(
+                "file:///00000000000000000000.00000000000000000003.compacted.json",
+            )],
+        vec![],
+        None,
+    );
+}
+
+#[test]
+#[should_panic]
+#[cfg(debug_assertions)]
+fn test_debug_assert_listed_log_file_different_checkpoint_versions() {
+    let _listed_log_file = ListedLogFiles::new(
+        vec![],
+        vec![],
+        vec![
+            create_log_path(
+                "00000000000000000010.checkpoint.0000000001.0000000002.parquet",
+            ), create_log_path(
+                "00000000000000000011.checkpoint.0000000002.0000000002.parquet",
+            )    
+        ],
+        None,
+    );
+}
+
+#[test]
+#[should_panic]
+#[cfg(debug_assertions)]
+fn test_debug_assert_listed_log_file_invalid_multipart_checkpoint() {
+    let _listed_log_file = ListedLogFiles::new(
+        vec![],
+        vec![],
+        vec![
+            create_log_path(
+                "00000000000000000010.checkpoint.0000000001.0000000003.parquet",
+            ), create_log_path(
+                "00000000000000000011.checkpoint.0000000002.0000000003.parquet",
+            )  
+        ],
+        None,
+    );
+}

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -34,23 +34,6 @@ use test_utils::{compacted_log_path_for_versions, delta_path_for_version};
 
 use super::*;
 
-// utility to easily create ListedLogFiles
-impl ListedLogFiles {
-    fn new(
-        ascending_commit_files: Vec<ParsedLogPath>,
-        ascending_compaction_files: Vec<ParsedLogPath>,
-        checkpoint_parts: Vec<ParsedLogPath>,
-        latest_crc_file: Option<ParsedLogPath>,
-    ) -> Self {
-        ListedLogFiles {
-            ascending_commit_files,
-            ascending_compaction_files,
-            checkpoint_parts,
-            latest_crc_file,
-        }
-    }
-}
-
 // NOTE: In addition to testing the meta-predicate for metadata replay, this test also verifies
 // that the parquet reader properly infers nullcount = rowcount for missing columns. The two
 // checkpoint part files that contain transaction app ids have truncated schemas that would

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -1689,9 +1689,23 @@ fn test_commit_cover_minimal_overlap() {
 }
 
 #[test]
+#[cfg(debug_assertions)]
+fn test_debug_assert_listed_log_file_in_order_compaction_files() {
+    let _ = ListedLogFiles::new(
+        vec![],
+        vec![
+            create_log_path("file:///00000000000000000000.00000000000000000004.compacted.json"),
+            create_log_path("file:///00000000000000000001.00000000000000000002.compacted.json"),
+        ],
+        vec![],
+        None,
+    );
+}
+
+#[test]
 #[should_panic]
 #[cfg(debug_assertions)]
-fn test_debug_assert_listed_log_file_non_contiguous_compaction_files() {
+fn test_debug_assert_listed_log_file_out_of_order_compaction_files() {
     let _ = ListedLogFiles::new(
         vec![],
         vec![
@@ -1706,7 +1720,7 @@ fn test_debug_assert_listed_log_file_non_contiguous_compaction_files() {
 #[test]
 #[should_panic]
 #[cfg(debug_assertions)]
-fn test_debug_assert_listed_log_file_different_checkpoint_versions() {
+fn test_debug_assert_listed_log_file_different_multipart_checkpoint_versions() {
     let _ = ListedLogFiles::new(
         vec![],
         vec![],

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -1692,7 +1692,7 @@ fn test_commit_cover_minimal_overlap() {
 #[should_panic]
 #[cfg(debug_assertions)]
 fn test_debug_assert_listed_log_file_non_contiguous_compaction_files() {
-    let _listed_log_file = ListedLogFiles::new(
+    let _ = ListedLogFiles::new(
         vec![],
         vec![
             create_log_path("file:///00000000000000000000.00000000000000000004.compacted.json"),
@@ -1707,7 +1707,7 @@ fn test_debug_assert_listed_log_file_non_contiguous_compaction_files() {
 #[should_panic]
 #[cfg(debug_assertions)]
 fn test_debug_assert_listed_log_file_different_checkpoint_versions() {
-    let _listed_log_file = ListedLogFiles::new(
+    let _ = ListedLogFiles::new(
         vec![],
         vec![],
         vec![
@@ -1722,7 +1722,7 @@ fn test_debug_assert_listed_log_file_different_checkpoint_versions() {
 #[should_panic]
 #[cfg(debug_assertions)]
 fn test_debug_assert_listed_log_file_invalid_multipart_checkpoint() {
-    let _listed_log_file = ListedLogFiles::new(
+    let _ = ListedLogFiles::new(
         vec![],
         vec![],
         vec![

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -758,24 +758,7 @@ fn build_table_changes_with_commit_versions() {
 }
 
 #[test]
-#[should_panic]
-#[cfg(debug_assertions)]
-fn test_non_contiguous_log_debug_panic() {
-    // In debug builds, this should panic due to debug_assert
-    let (storage, log_root) = build_log_with_paths_and_checkpoint(
-        &[
-            delta_path_for_version(0, "json"),
-            delta_path_for_version(2, "json"),
-        ],
-        None,
-    );
-
-    let _log_segment_res = LogSegment::for_table_changes(storage.as_ref(), log_root, 0, None);
-}
-
-#[test]
-#[cfg(not(debug_assertions))]
-fn test_non_contiguous_log_release() {
+fn test_non_contiguous_log() {
     // Commit with version 1 is missing
     let (storage, log_root) = build_log_with_paths_and_checkpoint(
         &[

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -1695,11 +1695,9 @@ fn test_debug_assert_listed_log_file_non_contiguous_compaction_files() {
     let _listed_log_file = ListedLogFiles::new(
         vec![],
         vec![
-            create_log_path(
-                "file:///00000000000000000000.00000000000000000004.compacted.json",
-            ), create_log_path(
-                "file:///00000000000000000000.00000000000000000003.compacted.json",
-            )],
+            create_log_path("file:///00000000000000000000.00000000000000000004.compacted.json"),
+            create_log_path("file:///00000000000000000000.00000000000000000003.compacted.json"),
+        ],
         vec![],
         None,
     );
@@ -1713,11 +1711,8 @@ fn test_debug_assert_listed_log_file_different_checkpoint_versions() {
         vec![],
         vec![],
         vec![
-            create_log_path(
-                "00000000000000000010.checkpoint.0000000001.0000000002.parquet",
-            ), create_log_path(
-                "00000000000000000011.checkpoint.0000000002.0000000002.parquet",
-            )    
+            create_log_path("00000000000000000010.checkpoint.0000000001.0000000002.parquet"),
+            create_log_path("00000000000000000011.checkpoint.0000000002.0000000002.parquet"),
         ],
         None,
     );
@@ -1731,11 +1726,8 @@ fn test_debug_assert_listed_log_file_invalid_multipart_checkpoint() {
         vec![],
         vec![],
         vec![
-            create_log_path(
-                "00000000000000000010.checkpoint.0000000001.0000000003.parquet",
-            ), create_log_path(
-                "00000000000000000011.checkpoint.0000000002.0000000003.parquet",
-            )  
+            create_log_path("00000000000000000010.checkpoint.0000000001.0000000003.parquet"),
+            create_log_path("00000000000000000011.checkpoint.0000000002.0000000003.parquet"),
         ],
         None,
     );


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes #954

Specifically, I've added assert statements to check that:
- `ascending_commit_files` are contiguously sorted, from lowest to highest version
- `ascending_compaction_files` are sorted
- all elements within `checkpoint_parts` is a checkpoint
- all elements within `checkpoint_parts` share the same `version` and `file_type`
- if an element within `checkpoint_parts` is `LogPathFileType::MultiPartCheckpoint`, check that the length of vector equals to the `num_parts`

## How was this change tested?

I ran `cargo nextest run` and passed all tests