### PR TITLE
feat: enable "TimestampWithoutTimezone" table feature and add protocol validation for it

### DIFF
--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -167,6 +167,7 @@ pub(crate) static SUPPORTED_WRITER_FEATURES: LazyLock<Vec<WriterFeature>> = Lazy
         WriterFeature::AppendOnly,
         WriterFeature::DeletionVectors,
         WriterFeature::Invariants,
+        WriterFeature::TimestampWithoutTimezone,
     ]
 });
 

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -8,7 +8,7 @@ use crate::schema::DataType;
 
 pub(crate) use column_mapping::column_mapping_mode;
 pub use column_mapping::{validate_schema_column_mapping, ColumnMappingMode};
-pub use timestamp_ntz::validate_timestamp_ntz_feature_support;
+pub(crate) use timestamp_ntz::validate_timestamp_ntz_feature_support;
 mod column_mapping;
 mod timestamp_ntz;
 

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -8,7 +8,9 @@ use crate::schema::DataType;
 
 pub(crate) use column_mapping::column_mapping_mode;
 pub use column_mapping::{validate_schema_column_mapping, ColumnMappingMode};
+pub use timestamp_ntz::validate_timestamp_ntz_feature_support;
 mod column_mapping;
+mod timestamp_ntz;
 
 /// Reader features communicate capabilities that must be implemented in order to correctly read a
 /// given table. That is, readers must implement and respect all features listed in a table's

--- a/kernel/src/table_features/timestamp_ntz.rs
+++ b/kernel/src/table_features/timestamp_ntz.rs
@@ -10,7 +10,7 @@ use std::borrow::Cow;
 
 /// Validates that if a table schema contains TIMESTAMP_NTZ columns, the table must have the
 /// TimestampWithoutTimezone feature in both reader and writer features.
-pub fn validate_timestamp_ntz_feature_support(
+pub(crate) fn validate_timestamp_ntz_feature_support(
     schema: &Schema,
     protocol: &Protocol,
 ) -> DeltaResult<()> {

--- a/kernel/src/table_features/timestamp_ntz.rs
+++ b/kernel/src/table_features/timestamp_ntz.rs
@@ -1,0 +1,133 @@
+//! Validation for TIMESTAMP_NTZ feature support
+
+use super::{ReaderFeature, WriterFeature};
+use crate::actions::Protocol;
+use crate::schema::{PrimitiveType, Schema, SchemaTransform};
+use crate::utils::require;
+use crate::{DeltaResult, Error};
+
+use std::borrow::Cow;
+
+/// Validates that if a table schema contains TIMESTAMP_NTZ columns, the table must have the
+/// TimestampWithoutTimezone feature in both reader and writer features.
+pub fn validate_timestamp_ntz_feature_support(
+    schema: &Schema,
+    protocol: &Protocol,
+) -> DeltaResult<()> {
+    if !protocol.has_reader_feature(&ReaderFeature::TimestampWithoutTimezone)
+        || !protocol.has_writer_feature(&WriterFeature::TimestampWithoutTimezone)
+    {
+        let mut uses_timestamp_ntz = UsesTimestampNtz(false);
+        let _ = uses_timestamp_ntz.transform_struct(schema);
+        require!(
+            !uses_timestamp_ntz.0,
+            Error::unsupported(
+                "Table contains TIMESTAMP_NTZ columns but does not have the required 'timestampNtz' feature in reader and writer features"
+            )
+        );
+    }
+    Ok(())
+}
+
+/// Schema visitor that checks if any column in the schema uses TIMESTAMP_NTZ type
+struct UsesTimestampNtz(bool);
+
+impl<'a> SchemaTransform<'a> for UsesTimestampNtz {
+    fn transform_primitive(&mut self, ptype: &'a PrimitiveType) -> Option<Cow<'a, PrimitiveType>> {
+        if *ptype == PrimitiveType::TimestampNtz {
+            self.0 = true;
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::actions::Protocol;
+    use crate::schema::{DataType, PrimitiveType, StructField, StructType};
+    use crate::table_features::{ReaderFeature, WriterFeature};
+
+    #[test]
+    fn test_timestamp_ntz_feature_validation() {
+        let schema_with_timestamp_ntz = StructType::new([
+            StructField::new("id", DataType::INTEGER, false),
+            StructField::new("ts", DataType::Primitive(PrimitiveType::TimestampNtz), true),
+        ]);
+
+        let schema_without_timestamp_ntz = StructType::new([
+            StructField::new("id", DataType::INTEGER, false),
+            StructField::new("name", DataType::STRING, true),
+        ]);
+
+        // Protocol with TimestampWithoutTimezone features
+        let protocol_with_features = Protocol::try_new(
+            3,
+            7,
+            Some([ReaderFeature::TimestampWithoutTimezone]),
+            Some([WriterFeature::TimestampWithoutTimezone]),
+        )
+        .unwrap();
+
+        // Protocol without TimestampWithoutTimezone features
+        let protocol_without_features = Protocol::try_new(
+            3,
+            7,
+            Some::<Vec<String>>(vec![]),
+            Some::<Vec<String>>(vec![]),
+        )
+        .unwrap();
+
+        // Schema with TIMESTAMP_NTZ + Protocol with features = OK
+        validate_timestamp_ntz_feature_support(&schema_with_timestamp_ntz, &protocol_with_features)
+            .expect("Should succeed when features are present");
+
+        // Schema without TIMESTAMP_NTZ + Protocol without features = OK
+        validate_timestamp_ntz_feature_support(
+            &schema_without_timestamp_ntz,
+            &protocol_without_features,
+        )
+        .expect("Should succeed when no TIMESTAMP_NTZ columns are present");
+
+        // Schema without TIMESTAMP_NTZ + Protocol with features = OK
+        validate_timestamp_ntz_feature_support(
+            &schema_without_timestamp_ntz,
+            &protocol_with_features,
+        )
+        .expect("Should succeed when no TIMESTAMP_NTZ columns are present, even with features");
+
+        // Schema with TIMESTAMP_NTZ + Protocol without features = ERROR
+        let result = validate_timestamp_ntz_feature_support(
+            &schema_with_timestamp_ntz,
+            &protocol_without_features,
+        );
+        assert!(
+            result.is_err(),
+            "Should fail when TIMESTAMP_NTZ columns are present but features are missing"
+        );
+        assert!(result.unwrap_err().to_string().contains("timestampNtz"));
+
+        // Nested schema with TIMESTAMP_NTZ
+        let nested_schema_with_timestamp_ntz = StructType::new([
+            StructField::new("id", DataType::INTEGER, false),
+            StructField::new(
+                "nested",
+                DataType::Struct(Box::new(StructType::new([StructField::new(
+                    "inner_ts",
+                    DataType::Primitive(PrimitiveType::TimestampNtz),
+                    true,
+                )]))),
+                true,
+            ),
+        ]);
+
+        let result = validate_timestamp_ntz_feature_support(
+            &nested_schema_with_timestamp_ntz,
+            &protocol_without_features,
+        );
+        assert!(
+            result.is_err(),
+            "Should fail for nested TIMESTAMP_NTZ columns when features are missing"
+        );
+    }
+}


### PR DESCRIPTION
Resolves #987.

And adds protocol validation: if the provided table has "TIMESTAMP_NTZ" column, it should have "timestampNtz" reader/writer features.

## What changes are proposed in this pull request?
Support `TIMESTAMP_NTZ` column type for writes.

## How was this change tested?
* Added test to `kernel/tests/write.rs`
* Added test to new `kernel/src/table_features/timestamp_ntz.rs`