### PR TITLE
[WIP] Lazy opaque expressions

### DIFF
--- a/ffi/src/expressions/engine_visitor.rs
+++ b/ffi/src/expressions/engine_visitor.rs
@@ -4,11 +4,14 @@ use std::ffi::c_void;
 
 use delta_kernel::expressions::{
     ArrayData, BinaryExpression, BinaryExpressionOp, BinaryPredicate, BinaryPredicateOp,
-    Expression, JunctionPredicate, JunctionPredicateOp, MapData, Predicate, Scalar, StructData,
+    Expression, JunctionPredicate, JunctionPredicateOp, MapData, OpaqueExpression,
+    OpaqueExpressionOpRef, OpaquePredicate, OpaquePredicateOpRef, Predicate, Scalar, StructData,
     UnaryPredicate, UnaryPredicateOp,
 };
 
-use crate::expressions::{SharedExpression, SharedPredicate};
+use crate::expressions::{
+    SharedExpression, SharedOpaqueExpressionOp, SharedOpaquePredicateOp, SharedPredicate,
+};
 use crate::{handle::Handle, kernel_string_slice, KernelStringSlice};
 
 type VisitLiteralFn<T> = extern "C" fn(data: *mut c_void, sibling_list_id: usize, value: T);
@@ -163,6 +166,26 @@ pub struct EngineExpressionVisitor {
     /// The sub-expressions of the `StructExpression` are in a list identified by `child_list_id`
     pub visit_struct_expr:
         extern "C" fn(data: *mut c_void, sibling_list_id: usize, child_list_id: usize),
+    /// Visits the operator (`op`) and children (`child_list_id`) of an opaque expression belonging
+    /// to the list identified by `sibling_list_id`.
+    pub visit_opaque_expr: extern "C" fn(
+        data: *mut c_void,
+        sibling_list_id: usize,
+        op: Handle<SharedOpaqueExpressionOp>,
+        child_list_id: usize,
+    ),
+    /// Visits the operator (`op`) and children (`child_list_id`) of an opaque predicate belonging
+    /// to the list identified by `sibling_list_id`.
+    pub visit_opaque_pred: extern "C" fn(
+        data: *mut c_void,
+        sibling_list_id: usize,
+        op: Handle<SharedOpaquePredicateOp>,
+        child_list_id: usize,
+    ),
+    /// Visits the name of an `Expression::Unknown` or `Predicate::Unknown` belonging to the
+    /// list identified by `sibling_list_id`.
+    pub visit_unknown:
+        extern "C" fn(data: *mut c_void, sibling_list_id: usize, name: KernelStringSlice),
 }
 
 /// Visit the expression of the passed [`SharedExpression`] Handle using the provided `visitor`.
@@ -310,6 +333,26 @@ fn visit_expression_struct(
     call!(visitor, visit_struct_expr, sibling_list_id, child_list_id)
 }
 
+fn visit_expression_opaque(
+    visitor: &mut EngineExpressionVisitor,
+    op: &OpaqueExpressionOpRef,
+    exprs: &[Expression],
+    sibling_list_id: usize,
+) {
+    let child_list_id = call!(visitor, make_field_list, exprs.len());
+    for expr in exprs {
+        visit_expression_impl(visitor, expr, child_list_id);
+    }
+    let op = Handle::from(op.clone());
+    call!(
+        visitor,
+        visit_opaque_expr,
+        sibling_list_id,
+        op,
+        child_list_id
+    );
+}
+
 fn visit_predicate_junction(
     visitor: &mut EngineExpressionVisitor,
     op: &JunctionPredicateOp,
@@ -326,6 +369,35 @@ fn visit_predicate_junction(
         JunctionPredicateOp::Or => &visitor.visit_or,
     };
     visit_fn(visitor.data, sibling_list_id, child_list_id);
+}
+
+fn visit_predicate_opaque(
+    visitor: &mut EngineExpressionVisitor,
+    op: &OpaquePredicateOpRef,
+    exprs: &[Expression],
+    sibling_list_id: usize,
+) {
+    let child_list_id = call!(visitor, make_field_list, exprs.len());
+    for expr in exprs {
+        visit_expression_impl(visitor, expr, child_list_id);
+    }
+    let op = Handle::from(op.clone());
+    call!(
+        visitor,
+        visit_opaque_pred,
+        sibling_list_id,
+        op,
+        child_list_id
+    );
+}
+
+fn visit_unknown(visitor: &mut EngineExpressionVisitor, sibling_list_id: usize, name: &str) {
+    call!(
+        visitor,
+        visit_unknown,
+        sibling_list_id,
+        kernel_string_slice!(name)
+    );
 }
 
 fn visit_expression_scalar(
@@ -407,7 +479,10 @@ fn visit_expression_impl(
             };
             visit_fn(visitor.data, sibling_list_id, child_list_id);
         }
-        Expression::Opaque(_) | Expression::Unknown(_) => todo!(),
+        Expression::Opaque(OpaqueExpression { op, exprs }) => {
+            visit_expression_opaque(visitor, op, exprs, sibling_list_id)
+        }
+        Expression::Unknown(name) => visit_unknown(visitor, sibling_list_id, name),
     }
 }
 
@@ -447,7 +522,10 @@ fn visit_predicate_impl(
         Predicate::Junction(JunctionPredicate { op, preds }) => {
             visit_predicate_junction(visitor, op, preds, sibling_list_id)
         }
-        Predicate::Opaque(_) | Predicate::Unknown(_) => todo!(),
+        Predicate::Opaque(OpaquePredicate { op, exprs }) => {
+            visit_predicate_opaque(visitor, op, exprs, sibling_list_id)
+        }
+        Predicate::Unknown(name) => visit_unknown(visitor, sibling_list_id, name),
     }
 }
 

--- a/ffi/src/expressions/engine_visitor.rs
+++ b/ffi/src/expressions/engine_visitor.rs
@@ -407,6 +407,7 @@ fn visit_expression_impl(
             };
             visit_fn(visitor.data, sibling_list_id, child_list_id);
         }
+        Expression::Opaque(_) | Expression::Unknown(_) => todo!(),
     }
 }
 
@@ -446,6 +447,7 @@ fn visit_predicate_impl(
         Predicate::Junction(JunctionPredicate { op, preds }) => {
             visit_predicate_junction(visitor, op, preds, sibling_list_id)
         }
+        Predicate::Opaque(_) | Predicate::Unknown(_) => todo!(),
     }
 }
 

--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -191,6 +191,24 @@ pub extern "C" fn visit_predicate_ne(
     visit_predicate_not(state, p)
 }
 
+#[no_mangle]
+pub extern "C" fn visit_predicate_unknown(
+    state: &mut KernelExpressionVisitorState,
+    name: KernelStringSlice,
+) -> usize {
+    let name = unsafe { TryFromStringSlice::try_from_slice(&name) };
+    name.map_or(0, |name| wrap_predicate(state, Predicate::Unknown(name)))
+}
+
+#[no_mangle]
+pub extern "C" fn visit_expression_unknown(
+    state: &mut KernelExpressionVisitorState,
+    name: KernelStringSlice,
+) -> usize {
+    let name = unsafe { TryFromStringSlice::try_from_slice(&name) };
+    name.map_or(0, |name| wrap_expression(state, Expression::Unknown(name)))
+}
+
 /// # Safety
 /// The string slice must be valid
 #[no_mangle]

--- a/ffi/src/expressions/mod.rs
+++ b/ffi/src/expressions/mod.rs
@@ -1,9 +1,12 @@
 //! This module holds functionality for moving expressions across the FFI boundary, both from
 //! engine to kernel, and from kernel to engine.
+use std::ffi::c_void;
+
+use delta_kernel::expressions::{OpaqueExpressionOp, OpaquePredicateOp};
 use delta_kernel::{Expression, Predicate};
 use delta_kernel_ffi_macros::handle_descriptor;
 
-use crate::handle::Handle;
+use crate::{handle::Handle, kernel_string_slice, KernelStringSlice};
 
 pub mod engine_visitor;
 pub mod kernel_visitor;
@@ -13,6 +16,12 @@ pub struct SharedExpression;
 
 #[handle_descriptor(target=Predicate, mutable=false, sized=true)]
 pub struct SharedPredicate;
+
+#[handle_descriptor(target=dyn OpaquePredicateOp, mutable=false, sized=false)]
+pub struct SharedOpaquePredicateOp;
+
+#[handle_descriptor(target=dyn OpaqueExpressionOp, mutable=false, sized=false)]
+pub struct SharedOpaqueExpressionOp;
 
 /// Free the memory the passed SharedExpression
 ///
@@ -30,4 +39,52 @@ pub unsafe extern "C" fn free_kernel_expression(data: Handle<SharedExpression>) 
 #[no_mangle]
 pub unsafe extern "C" fn free_kernel_predicate(data: Handle<SharedPredicate>) {
     data.drop_handle();
+}
+
+/// Free the passed SharedOpaqueExpressionOp
+///
+/// # Safety
+/// Engine is responsible for passing a valid SharedOpaqueExpressionOp
+#[no_mangle]
+pub unsafe extern "C" fn free_kernel_opaque_expression_op(data: Handle<SharedOpaqueExpressionOp>) {
+    data.drop_handle();
+}
+
+/// Free the passed SharedOpaquePredicateOp
+///
+/// # Safety
+/// Engine is responsible for passing a valid SharedOpaquePredicateOp
+#[no_mangle]
+pub unsafe extern "C" fn free_kernel_opaque_predicate_op(data: Handle<SharedOpaquePredicateOp>) {
+    data.drop_handle();
+}
+
+/// Visits the name of a SharedOpaqueExpressionOp
+///
+/// # Safety
+/// Engine is responsible for passing a valid SharedOpaqueExpressionOp
+#[no_mangle]
+pub unsafe extern "C" fn visit_kernel_opaque_expression_op_name(
+    op: Handle<SharedOpaqueExpressionOp>,
+    data: *mut c_void,
+    visit: extern "C" fn(data: *mut c_void, name: KernelStringSlice),
+) {
+    let op = unsafe { op.as_ref() };
+    let name = op.name();
+    visit(data, kernel_string_slice!(name));
+}
+
+/// Visits the name of a SharedOpaquePredicateOp
+///
+/// # Safety
+/// Engine is responsible for passing a valid SharedOpaquePredicateOp
+#[no_mangle]
+pub unsafe extern "C" fn visit_kernel_opaque_predicate_op_name(
+    op: Handle<SharedOpaquePredicateOp>,
+    data: *mut c_void,
+    visit: extern "C" fn(data: *mut c_void, name: KernelStringSlice),
+) {
+    let op = unsafe { op.as_ref() };
+    let name = op.name();
+    visit(data, kernel_string_slice!(name));
 }

--- a/ffi/src/test_ffi.rs
+++ b/ffi/src/test_ffi.rs
@@ -6,10 +6,12 @@ use crate::expressions::{SharedExpression, SharedPredicate};
 use crate::handle::Handle;
 use delta_kernel::expressions::{
     column_expr, column_pred, ArrayData, BinaryExpressionOp, BinaryPredicateOp, Expression as Expr,
-    MapData, OpaqueExpressionOp, OpaquePredicateOp, Predicate as Pred, Scalar, StructData,
+    MapData, OpaqueExpressionOp, OpaquePredicateOp, Predicate as Pred, Scalar,
+    ScalarExpressionEvaluator, StructData,
 };
 use delta_kernel::kernel_predicates::{
-    DirectDataSkippingPredicateEvaluator, IndirectDataSkippingPredicateEvaluator,
+    DirectDataSkippingPredicateEvaluator, DirectPredicateEvaluator,
+    IndirectDataSkippingPredicateEvaluator,
 };
 use delta_kernel::schema::{ArrayType, DataType, MapType, StructField, StructType};
 use delta_kernel::DeltaResult;
@@ -21,7 +23,11 @@ impl OpaqueExpressionOp for OpaqueTestOp {
     fn name(&self) -> &str {
         &self.0
     }
-    fn eval_expr_scalar(&self, _values: &[Option<Scalar>]) -> DeltaResult<Scalar> {
+    fn eval_expr_scalar(
+        &self,
+        _eval_expr: &ScalarExpressionEvaluator<'_>,
+        _exprs: &[Expr],
+    ) -> DeltaResult<Scalar> {
         unimplemented!()
     }
 }
@@ -33,7 +39,9 @@ impl OpaquePredicateOp for OpaqueTestOp {
 
     fn eval_pred_scalar(
         &self,
-        _values: &[Option<Scalar>],
+        _eval_expr: &ScalarExpressionEvaluator<'_>,
+        _evaluator: &DirectPredicateEvaluator<'_>,
+        _exprs: &[Expr],
         _inverted: bool,
     ) -> DeltaResult<Option<bool>> {
         unimplemented!()
@@ -41,7 +49,7 @@ impl OpaquePredicateOp for OpaqueTestOp {
 
     fn eval_as_data_skipping_predicate(
         &self,
-        _predicate_evaluator: &DirectDataSkippingPredicateEvaluator<'_>,
+        _evaluator: &DirectDataSkippingPredicateEvaluator<'_>,
         _exprs: &[Expr],
         _inverted: bool,
     ) -> Option<bool> {
@@ -50,7 +58,7 @@ impl OpaquePredicateOp for OpaqueTestOp {
 
     fn as_data_skipping_predicate(
         &self,
-        _predicate_evaluator: &IndirectDataSkippingPredicateEvaluator<'_>,
+        _evaluator: &IndirectDataSkippingPredicateEvaluator<'_>,
         _exprs: &[Expr],
         _inverted: bool,
     ) -> Option<Pred> {

--- a/ffi/src/test_ffi.rs
+++ b/ffi/src/test_ffi.rs
@@ -6,9 +6,57 @@ use crate::expressions::{SharedExpression, SharedPredicate};
 use crate::handle::Handle;
 use delta_kernel::expressions::{
     column_expr, column_pred, ArrayData, BinaryExpressionOp, BinaryPredicateOp, Expression as Expr,
-    MapData, Predicate as Pred, Scalar, StructData,
+    MapData, OpaqueExpressionOp, OpaquePredicateOp, Predicate as Pred, Scalar, StructData,
+};
+use delta_kernel::kernel_predicates::{
+    DirectDataSkippingPredicateEvaluator, IndirectDataSkippingPredicateEvaluator,
 };
 use delta_kernel::schema::{ArrayType, DataType, MapType, StructField, StructType};
+use delta_kernel::DeltaResult;
+
+#[derive(Debug, PartialEq)]
+struct OpaqueTestOp(String);
+
+impl OpaqueExpressionOp for OpaqueTestOp {
+    fn name(&self) -> &str {
+        &self.0
+    }
+    fn eval_expr_scalar(&self, _values: &[Option<Scalar>]) -> DeltaResult<Scalar> {
+        unimplemented!()
+    }
+}
+
+impl OpaquePredicateOp for OpaqueTestOp {
+    fn name(&self) -> &str {
+        &self.0
+    }
+
+    fn eval_pred_scalar(
+        &self,
+        _values: &[Option<Scalar>],
+        _inverted: bool,
+    ) -> DeltaResult<Option<bool>> {
+        unimplemented!()
+    }
+
+    fn eval_as_data_skipping_predicate(
+        &self,
+        _predicate_evaluator: &DirectDataSkippingPredicateEvaluator<'_>,
+        _exprs: &[Expr],
+        _inverted: bool,
+    ) -> Option<bool> {
+        unimplemented!()
+    }
+
+    fn as_data_skipping_predicate(
+        &self,
+        _predicate_evaluator: &IndirectDataSkippingPredicateEvaluator<'_>,
+        _exprs: &[Expr],
+        _inverted: bool,
+    ) -> Option<Pred> {
+        unimplemented!()
+    }
+}
 
 /// Constructs a kernel expression that is passed back as a [`SharedExpression`] handle. The expected
 /// output expression can be found in `ffi/tests/test_expression_visitor/expected.txt`.
@@ -78,6 +126,11 @@ pub unsafe extern "C" fn get_testing_kernel_expression() -> Handle<SharedExpress
         Scalar::Array(array_data).into(),
         Scalar::Map(map_data).into(),
         Expr::struct_from([Expr::literal(5_i32), Expr::literal(20_i64)]),
+        Expr::opaque(
+            OpaqueTestOp("foo".to_string()),
+            vec![Expr::literal(42), Expr::literal(1.111)],
+        ),
+        Expr::unknown("mystery"),
     ];
     sub_exprs.extend(
         [
@@ -127,6 +180,11 @@ pub unsafe extern "C" fn get_testing_kernel_predicate() -> Handle<SharedPredicat
             Pred::ne(Expr::literal(20), Expr::literal(10)),
         ]),
         Pred::is_not_null(column_expr!("col")),
+        Pred::opaque(
+            OpaqueTestOp("bar".to_string()),
+            vec![Expr::literal(42), Expr::literal(1.111)],
+        ),
+        Pred::unknown("intrigue"),
     ];
     sub_exprs.extend(
         [

--- a/ffi/tests/test-expression-visitor/expected.txt
+++ b/ffi/tests/test-expression-visitor/expected.txt
@@ -37,6 +37,10 @@ StructExpression
   StructExpression
     Integer(5)
     Long(20)
+  OpaqueExpression(foo)
+    Integer(42)
+    Double(1.111000)
+  Unknown(mystery)
   Divide
     Integer(0)
     Integer(0)
@@ -75,6 +79,10 @@ And
   Not
     IsNull
       Column(col)
+  OpaquePredicate(bar)
+    Integer(42)
+    Double(1.111000)
+  Unknown(intrigue)
   Equal
     Integer(0)
     Integer(0)

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -128,7 +128,8 @@ pub fn evaluate_expression(
 
             Ok(eval(&left_arr, &right_arr)?)
         }
-        (Opaque(_) | Unknown(_), _) => todo!(),
+        (Opaque(_), _) => Err(Error::unsupported("Cannot evaluate opaque expressions")),
+        (Unknown(name), _) => Err(Error::unsupported(format!("Unknown expression: {name:?}"))),
     }
 }
 

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -128,6 +128,7 @@ pub fn evaluate_expression(
 
             Ok(eval(&left_arr, &right_arr)?)
         }
+        (Opaque(_) | Unknown(_), _) => todo!(),
     }
 }
 
@@ -263,5 +264,6 @@ pub fn evaluate_predicate(
                 .reduce(|l, r| Ok(reducer(&l?, &r?)?))
                 .unwrap_or_else(|| Ok(BooleanArray::from(vec![default; batch.num_rows()])))
         }
+        Opaque(_) | Unknown(_) => todo!(),
     }
 }

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -88,7 +88,7 @@ pub trait OpaqueExpressionOp: DynPartialEq + std::fmt::Debug {
     /// etc); the operation is disqualified from participating in partition pruning.
     ///
     /// `Ok(Scalar::Null)` means the operation actually produced a legitimately NULL result.
-    fn eval_expr_scalar(&self, _values: &[Option<Scalar>]) -> DeltaResult<Scalar>;
+    fn eval_expr_scalar(&self, values: &[Option<Scalar>]) -> DeltaResult<Scalar>;
 }
 
 /// An opaque predicate operation (ie defined and implemented by the engine).

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -299,6 +299,58 @@ impl Scalar {
         };
         Ok(Self::Timestamp(timestamp.timestamp_micros()))
     }
+
+    /// Attempts to add two scalars, returning None if they were incompatible.
+    pub fn try_add(&self, other: &Scalar) -> Option<Scalar> {
+        use Scalar::*;
+        let result = match (self, other) {
+            (Integer(a), Integer(b)) => Integer(a.checked_add(*b)?),
+            (Long(a), Long(b)) => Long(a.checked_add(*b)?),
+            (Short(a), Short(b)) => Short(a.checked_add(*b)?),
+            (Byte(a), Byte(b)) => Byte(a.checked_add(*b)?),
+            _ => return None,
+        };
+        Some(result)
+    }
+
+    /// Attempts to subtract two scalars, returning None if they were incompatible.
+    pub fn try_sub(&self, other: &Scalar) -> Option<Scalar> {
+        use Scalar::*;
+        let result = match (self, other) {
+            (Integer(a), Integer(b)) => Integer(a.checked_sub(*b)?),
+            (Long(a), Long(b)) => Long(a.checked_sub(*b)?),
+            (Short(a), Short(b)) => Short(a.checked_sub(*b)?),
+            (Byte(a), Byte(b)) => Byte(a.checked_sub(*b)?),
+            _ => return None,
+        };
+        Some(result)
+    }
+
+    /// Attempts to multiply two scalars, returning None if they were incompatible.
+    pub fn try_mul(&self, other: &Scalar) -> Option<Scalar> {
+        use Scalar::*;
+        let result = match (self, other) {
+            (Integer(a), Integer(b)) => Integer(a.checked_mul(*b)?),
+            (Long(a), Long(b)) => Long(a.checked_mul(*b)?),
+            (Short(a), Short(b)) => Short(a.checked_mul(*b)?),
+            (Byte(a), Byte(b)) => Byte(a.checked_mul(*b)?),
+            _ => return None,
+        };
+        Some(result)
+    }
+
+    /// Attempts to divide two scalars, returning None if they were incompatible.
+    pub fn try_div(&self, other: &Scalar) -> Option<Scalar> {
+        use Scalar::*;
+        let result = match (self, other) {
+            (Integer(a), Integer(b)) => Integer(a.checked_div(*b)?),
+            (Long(a), Long(b)) => Long(a.checked_div(*b)?),
+            (Short(a), Short(b)) => Short(a.checked_div(*b)?),
+            (Byte(a), Byte(b)) => Byte(a.checked_div(*b)?),
+            _ => return None,
+        };
+        Some(result)
+    }
 }
 
 impl Display for Scalar {

--- a/kernel/src/expressions/transforms.rs
+++ b/kernel/src/expressions/transforms.rs
@@ -507,10 +507,11 @@ mod tests {
     use super::*;
     use crate::expressions::{
         column_expr, column_pred, Expression as Expr, OpaqueExpressionOp, OpaquePredicateOp,
-        Predicate as Pred,
+        Predicate as Pred, ScalarExpressionEvaluator,
     };
     use crate::kernel_predicates::{
-        DirectDataSkippingPredicateEvaluator, IndirectDataSkippingPredicateEvaluator,
+        DirectDataSkippingPredicateEvaluator, DirectPredicateEvaluator,
+        IndirectDataSkippingPredicateEvaluator,
     };
     use crate::DeltaResult;
 
@@ -521,7 +522,11 @@ mod tests {
         fn name(&self) -> &str {
             &self.0
         }
-        fn eval_expr_scalar(&self, _values: &[Option<Scalar>]) -> DeltaResult<Scalar> {
+        fn eval_expr_scalar(
+            &self,
+            _eval_expr: &ScalarExpressionEvaluator<'_>,
+            _exprs: &[Expression],
+        ) -> DeltaResult<Scalar> {
             unimplemented!()
         }
     }
@@ -533,7 +538,9 @@ mod tests {
 
         fn eval_pred_scalar(
             &self,
-            _values: &[Option<Scalar>],
+            _eval_expr: &ScalarExpressionEvaluator<'_>,
+            _evaluator: &DirectPredicateEvaluator<'_>,
+            _exprs: &[Expr],
             _inverted: bool,
         ) -> DeltaResult<Option<bool>> {
             unimplemented!()

--- a/kernel/src/kernel_predicates/mod.rs
+++ b/kernel/src/kernel_predicates/mod.rs
@@ -143,7 +143,7 @@ pub trait KernelPredicateEvaluator {
     fn finish_eval_pred_junction(
         &self,
         op: JunctionPredicateOp,
-        preds: impl IntoIterator<Item = Option<Self::Output>>,
+        preds: &mut dyn Iterator<Item = Option<Self::Output>>,
         inverted: bool,
     ) -> Option<Self::Output>;
 
@@ -218,11 +218,12 @@ pub trait KernelPredicateEvaluator {
         if let Scalar::Null(_) = val {
             self.eval_pred_is_null(col, !inverted)
         } else {
-            let args = [
+            let mut args = [
                 self.eval_pred_is_null(col, inverted),
                 self.eval_pred_eq(col, val, !inverted),
-            ];
-            self.finish_eval_pred_junction(JunctionPredicateOp::Or, args, inverted)
+            ]
+            .into_iter();
+            self.finish_eval_pred_junction(JunctionPredicateOp::Or, &mut args, inverted)
         }
     }
 
@@ -284,8 +285,8 @@ pub trait KernelPredicateEvaluator {
         preds: &[Pred],
         inverted: bool,
     ) -> Option<Self::Output> {
-        let preds = preds.iter().map(|pred| self.eval_pred(pred, inverted));
-        self.finish_eval_pred_junction(op, preds, inverted)
+        let mut preds = preds.iter().map(|pred| self.eval_pred(pred, inverted));
+        self.finish_eval_pred_junction(op, &mut preds, inverted)
     }
 
     /// Dispatches a predicate to the specific implementation for each predicate variant.
@@ -413,28 +414,30 @@ pub trait KernelPredicateEvaluator {
         match pred {
             Junction(JunctionPredicate { op, preds }) => {
                 // Recursively invoke `eval_pred_sql_where` instead of the usual `eval_pred` for AND/OR.
-                let preds = preds
+                let mut preds = preds
                     .iter()
                     .map(|pred| self.eval_pred_sql_where(pred, inverted));
-                self.finish_eval_pred_junction(*op, preds, inverted)
+                self.finish_eval_pred_junction(*op, &mut preds, inverted)
             }
             Binary(BinaryPredicate { op, left, right }) if op.is_null_intolerant() => {
                 // Perform a nullsafe comparison instead of the usual `eval_pred_binary`
-                let preds = [
+                let mut preds = [
                     self.eval_pred_unary(UnaryPredicateOp::IsNull, left, true),
                     self.eval_pred_unary(UnaryPredicateOp::IsNull, right, true),
                     self.eval_pred_binary(*op, left, right, inverted),
-                ];
-                self.finish_eval_pred_junction(JunctionPredicateOp::And, preds, false)
+                ]
+                .into_iter();
+                self.finish_eval_pred_junction(JunctionPredicateOp::And, &mut preds, false)
             }
             Not(pred) => self.eval_pred_sql_where(pred, !inverted),
             BooleanExpression(Expr::Column(col)) => {
                 // Perform a nullsafe comparison instead of the usual `eval_pred_column`
-                let preds = [
+                let mut preds = [
                     self.eval_pred_is_null(col, true),
                     self.eval_pred_column(col, inverted),
-                ];
-                self.finish_eval_pred_junction(JunctionPredicateOp::And, preds, false)
+                ]
+                .into_iter();
+                self.finish_eval_pred_junction(JunctionPredicateOp::And, &mut preds, false)
             }
             BooleanExpression(Expr::Literal(val)) if val.is_null() => {
                 // AND(NULL IS NOT NULL, NULL) = AND(FALSE, NULL) = FALSE
@@ -536,26 +539,22 @@ impl KernelPredicateEvaluatorDefaults {
     /// non-dominant value. Inverting the operation also inverts the dominant value.
     pub fn finish_eval_pred_junction(
         op: JunctionPredicateOp,
-        preds: impl IntoIterator<Item = Option<bool>>,
+        preds: &mut dyn Iterator<Item = Option<bool>>,
         inverted: bool,
     ) -> Option<bool> {
         let dominator = match op {
             JunctionPredicateOp::And => inverted,
             JunctionPredicateOp::Or => !inverted,
         };
-        let result = preds.into_iter().try_fold(false, |found_null, val| {
+        let mut found_null = false;
+        for val in preds {
             match val {
-                Some(val) if val == dominator => None, // (1) short circuit, dominant found
-                Some(_) => Some(found_null),
-                None => Some(true), // (2) null found (but keep looking for a dominant value)
+                Some(val) if val == dominator => return Some(dominator), // short circuit!
+                None => found_null = true,
+                Some(_) => (), // ignore non-dominant values
             }
-        });
-
-        match result {
-            None => Some(dominator), // (1) short circuit, dominant found
-            Some(false) => Some(!dominator),
-            Some(true) => None, // (2) null found, dominant not found
         }
+        (!found_null).then_some(!dominator)
     }
 }
 
@@ -731,7 +730,7 @@ impl<R: ResolveColumnAsScalar> KernelPredicateEvaluator for DefaultKernelPredica
     fn finish_eval_pred_junction(
         &self,
         op: JunctionPredicateOp,
-        preds: impl IntoIterator<Item = Option<bool>>,
+        preds: &mut dyn Iterator<Item = Option<bool>>,
         inverted: bool,
     ) -> Option<bool> {
         KernelPredicateEvaluatorDefaults::finish_eval_pred_junction(op, preds, inverted)
@@ -971,9 +970,9 @@ impl<T: DataSkippingPredicateEvaluator + ?Sized> KernelPredicateEvaluator for T 
     fn finish_eval_pred_junction(
         &self,
         op: JunctionPredicateOp,
-        preds: impl IntoIterator<Item = Option<Self::Output>>,
+        preds: &mut dyn Iterator<Item = Option<Self::Output>>,
         inverted: bool,
     ) -> Option<Self::Output> {
-        self.finish_eval_pred_junction(op, &mut preds.into_iter(), inverted)
+        self.finish_eval_pred_junction(op, preds, inverted)
     }
 }

--- a/kernel/src/kernel_predicates/parquet_stats_skipping.rs
+++ b/kernel/src/kernel_predicates/parquet_stats_skipping.rs
@@ -1,7 +1,10 @@
 //! An implementation of data skipping that leverages parquet stats from the file footer.
-use crate::expressions::{BinaryPredicateOp, ColumnName, JunctionPredicateOp, Scalar};
+use crate::expressions::{
+    BinaryPredicateOp, ColumnName, Expression, JunctionPredicateOp, OpaquePredicateOpRef, Scalar,
+};
 use crate::kernel_predicates::{DataSkippingPredicateEvaluator, KernelPredicateEvaluatorDefaults};
 use crate::schema::DataType;
+
 use std::cmp::Ordering;
 
 #[cfg(test)]
@@ -84,6 +87,15 @@ impl<T: ParquetStatsProvider> DataSkippingPredicateEvaluator for T {
         inverted: bool,
     ) -> Option<bool> {
         KernelPredicateEvaluatorDefaults::eval_pred_binary_scalars(op, left, right, inverted)
+    }
+
+    fn eval_pred_opaque(
+        &self,
+        op: &OpaquePredicateOpRef,
+        exprs: &[Expression],
+        inverted: bool,
+    ) -> Option<bool> {
+        op.eval_as_data_skipping_predicate(self, exprs, inverted)
     }
 
     fn finish_eval_pred_junction(

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -324,6 +324,21 @@ impl<T: Any + Send + Sync> AsAny for T {
     }
 }
 
+/// Extension trait that facilitates object-safe implementations of `PartialEq`.
+pub trait DynPartialEq: AsAny {
+    fn dyn_eq(&self, other: &dyn Any) -> bool;
+}
+
+// Blanket implementation for all eligible types
+impl<T: PartialEq + AsAny> DynPartialEq for T {
+    fn dyn_eq(&self, other: &dyn Any) -> bool {
+        match other.downcast_ref::<T>() {
+            Some(other) => self == other,
+            None => false,
+        }
+    }
+}
+
 /// Trait for implementing an Expression evaluator.
 ///
 /// It contains one Expression which can be evaluated on multiple ColumnarBatches.

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -9,7 +9,7 @@ use crate::actions::visitors::SelectionVectorVisitor;
 use crate::error::DeltaResult;
 use crate::expressions::{
     column_expr, joined_column_expr, BinaryPredicateOp, ColumnName, Expression as Expr,
-    JunctionPredicateOp, Predicate as Pred, PredicateRef, Scalar,
+    JunctionPredicateOp, OpaquePredicateOpRef, Predicate as Pred, PredicateRef, Scalar,
 };
 use crate::kernel_predicates::{
     DataSkippingPredicateEvaluator, KernelPredicateEvaluator, KernelPredicateEvaluatorDefaults,
@@ -261,6 +261,15 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator {
     ) -> Option<Pred> {
         KernelPredicateEvaluatorDefaults::eval_pred_binary_scalars(op, left, right, inverted)
             .map(Pred::literal)
+    }
+
+    fn eval_pred_opaque(
+        &self,
+        op: &OpaquePredicateOpRef,
+        exprs: &[Expr],
+        inverted: bool,
+    ) -> Option<Pred> {
+        op.as_data_skipping_predicate(self, exprs, inverted)
     }
 
     fn finish_eval_pred_junction(


### PR DESCRIPTION
## What changes are proposed in this pull request?

NOTE: Stacked on https://github.com/delta-io/delta-kernel-rs/pull/686, ignore the first four commits.

Pathfinding that allows opaque expressions and predicates to do lazy scalar evaluation of their inputs (data skipping evaluation already supported this). This requires making `KernelPredicateEvaluator` dyn-compatible (in the same was we already made the data skipping predicate evaluators dyn-compatible), and also requires passing an additional function pointer to handle "normal" (non-boolean) expression evaluation. 

If we like this change, we can either fold it into the main PR or merge them separately -- whichever is better for reviewer sanity.
 
<!--
Uncomment this section if there are any changes affecting public APIs:
### This PR affects the following public APIs

If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.

Note that _new_ public APIs are not considered breaking.
-->


## How was this change tested?

Implement an opaque version of the AND operator as a demonstration of the new capability.