### PR TITLE
feat: Replace `with_commit_info()` API with multiple APIs to provide `CommitInfo` data and materialize it during `commit()`

### DIFF
--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -415,9 +415,9 @@ where
     )))
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ToSchema)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, ToSchema)]
 #[internal_api]
-#[cfg_attr(test, derive(Serialize, Default), serde(rename_all = "camelCase"))]
+#[cfg_attr(test, derive(Serialize), serde(rename_all = "camelCase"))]
 pub(crate) struct CommitInfo {
     /// The time this logical file was created, as milliseconds since the epoch.
     /// Read: optional, write: required (that is, kernel always writes).

--- a/kernel/src/transaction.rs
+++ b/kernel/src/transaction.rs
@@ -1,17 +1,18 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::iter;
 use std::sync::{Arc, LazyLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::actions::SetTransaction;
-use crate::actions::COMMIT_INFO_NAME;
-use crate::actions::{get_log_add_schema, get_log_commit_info_schema, get_log_txn_schema};
+use crate::actions::{get_log_add_schema, get_log_commit_info_schema};
+use crate::actions::{CommitInfo, SetTransaction};
 use crate::error::Error;
-use crate::expressions::{column_expr, Scalar, StructData};
+use crate::expressions::{MapData, Scalar};
 use crate::path::ParsedLogPath;
 use crate::schema::{MapType, SchemaRef, StructField, StructType};
 use crate::snapshot::Snapshot;
-use crate::{DataType, DeltaResult, Engine, EngineData, Expression, IntoEngineData, Version};
+use crate::{
+    DataType, DeltaResult, Engine, EngineData, EvaluationHandlerExtension, Expression, Version,
+};
 
 use url::Url;
 
@@ -54,8 +55,7 @@ pub fn get_write_metadata_schema() -> &'static SchemaRef {
 /// ```
 pub struct Transaction {
     read_snapshot: Arc<Snapshot>,
-    operation: Option<String>,
-    commit_info: Option<Arc<dyn EngineData>>,
+    commit_info: Option<CommitInfo>,
     write_metadata: Vec<Box<dyn EngineData>>,
     // NB: hashmap would require either duplicating the appid or splitting SetTransaction
     // key/payload. HashSet requires Borrow<&str> with matching Eq, Ord, and Hash. Plus,
@@ -71,9 +71,9 @@ pub struct Transaction {
 impl std::fmt::Debug for Transaction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&format!(
-            "Transaction {{ read_snapshot version: {}, commit_info: {} }}",
+            "Transaction {{ read_snapshot version: {}, commit_info: {:#?} }}",
             self.read_snapshot.version(),
-            self.commit_info.is_some()
+            self.commit_info
         ))
     }
 }
@@ -102,7 +102,6 @@ impl Transaction {
 
         Ok(Transaction {
             read_snapshot,
-            operation: None,
             commit_info: None,
             write_metadata: vec![],
             set_transactions: vec![],
@@ -135,16 +134,13 @@ impl Transaction {
             .map(|txn| txn.into_engine_data(get_log_txn_schema().clone(), engine));
 
         // step one: construct the iterator of commit info + file actions we want to commit
-        let engine_commit_info = self
+        let commit_info = self
             .commit_info
-            .as_ref()
+            .clone()
             .ok_or_else(|| Error::MissingCommitInfo)?;
-        let commit_info_actions = generate_commit_info(
-            engine,
-            self.operation.as_deref(),
-            self.commit_timestamp,
-            engine_commit_info.as_ref(),
-        );
+
+        let commit_info_actions = generate_commit_info(engine, &commit_info, self.commit_timestamp);
+
         let add_actions = generate_adds(engine, self.write_metadata.iter().map(|a| a.as_ref()));
 
         let actions = iter::once(commit_info_actions)
@@ -165,10 +161,53 @@ impl Transaction {
         }
     }
 
+    // Set the timestmap of this transaction.
+    pub fn with_timestamp(mut self, timestamp: i64) -> Self {
+        self.commit_info.get_or_insert_default().timestamp = Some(timestamp);
+        self
+    }
+
+    /// Set the in-commit timestamp for this transaction. This is used for In-Commit Timestamps (ICT) feature.
+    /// When ICT is enabled, this timestamp must be monotonically increasing across commits.
+    ///
+    /// Note: For full ICT compliance, the caller should ensure this timestamp is greater than
+    /// the previous commit's inCommitTimestamp.
+    pub fn with_in_commit_timestamp(mut self, in_commit_timestamp: i64) -> Self {
+        self.commit_info.get_or_insert_default().in_commit_timestamp = Some(in_commit_timestamp);
+        self
+    }
+
     /// Set the operation that this transaction is performing. This string will be persisted in the
     /// commit and visible to anyone who describes the table history.
     pub fn with_operation(mut self, operation: String) -> Self {
-        self.operation = Some(operation);
+        self.commit_info.get_or_insert_default().operation = Some(operation);
+        self
+    }
+
+    // Set the operation parameters for the operation that this transaction is performing.
+    pub fn with_operation_parameters(
+        mut self,
+        operation_parameters: HashMap<String, String>,
+    ) -> Self {
+        self.commit_info
+            .get_or_insert_default()
+            .operation_parameters = Some(operation_parameters);
+        self
+    }
+
+    // Set the version of the delta_kernel crate used to write this transaction.
+    pub fn with_kernel_version(mut self, kernel_version: String) -> Self {
+        self.commit_info.get_or_insert_default().kernel_version = Some(kernel_version);
+        self
+    }
+
+    // Set the engine commit info of this transaction.
+    //
+    // Note: The engine data passed here must have exactly one row, and we
+    /// only read one column: `engineCommitInfo` which must be a map<string, string> encoding the
+    /// metadata.
+    pub fn with_engine_commit_info(mut self, engine_commit_info: HashMap<String, String>) -> Self {
+        self.commit_info.get_or_insert_default().engine_commit_info = Some(engine_commit_info);
         self
     }
 
@@ -180,24 +219,6 @@ impl Transaction {
     pub fn with_transaction_id(mut self, app_id: String, version: i64) -> Self {
         let set_transaction = SetTransaction::new(app_id, version, Some(self.commit_timestamp));
         self.set_transactions.push(set_transaction);
-        self
-    }
-
-    /// WARNING: This is an unstable API and will likely change in the future.
-    ///
-    /// Add commit info to the transaction. This is commit-wide metadata that is written as the
-    /// first action in the commit. The engine data passed here must have exactly one row, and we
-    /// only read one column: `engineCommitInfo` which must be a map<string, string> encoding the
-    /// metadata.
-    ///
-    /// The engine is required to provide commit info before committing the transaction. If the
-    /// engine would like to omit engine-specific commit info, it can do so by passing pass a
-    /// commit_info engine data chunk with one row and one column of type `Map<string, string>`
-    /// that can either be `null` or contain an empty map.
-    ///
-    /// Any other columns in the data chunk are ignored.
-    pub fn with_commit_info(mut self, commit_info: Box<dyn EngineData>) -> Self {
-        self.commit_info = Some(commit_info.into());
         self
     }
 
@@ -306,77 +327,72 @@ pub enum CommitResult {
     Conflict(Transaction, Version),
 }
 
-// given the engine's commit info we want to create commitInfo action to commit (and append more actions to)
+// given the CommitInfo struct we want to materialize it into a commitInfo action to commit (and append more actions to)
 fn generate_commit_info(
     engine: &dyn Engine,
-    operation: Option<&str>,
-    timestamp: i64,
-    engine_commit_info: &dyn EngineData,
+    commit_info: &CommitInfo,
+    commit_timestamp: i64,
 ) -> DeltaResult<Box<dyn EngineData>> {
-    if engine_commit_info.len() != 1 {
-        return Err(Error::InvalidCommitInfo(format!(
-            "Engine commit info should have exactly one row, found {}",
-            engine_commit_info.len()
-        )));
+    if let Some(engine_commit_info) = &commit_info.engine_commit_info {
+        if engine_commit_info.len() != 1 {
+            return Err(Error::InvalidCommitInfo(format!(
+                "Engine commit info should have exactly one row, found {}",
+                engine_commit_info.len()
+            )));
+        }
     }
 
-    let commit_info_exprs = [
-        Expression::literal(timestamp),
-        Expression::literal(operation.unwrap_or(UNKNOWN_OPERATION)),
-        // HACK (part 1/2): since we don't have proper map support, we create a literal struct with
-        // one null field to create data that serializes as "operationParameters": {}
-        Expression::literal(Scalar::Struct(StructData::try_new(
-            vec![StructField::nullable(
-                "operation_parameter_int",
-                DataType::INTEGER,
-            )],
-            vec![Scalar::Null(DataType::INTEGER)],
-        )?)),
-        Expression::literal(format!("v{}", KERNEL_VERSION)),
-        column_expr!("engineCommitInfo"),
-    ];
-    let commit_info_expr = Expression::struct_from([Expression::struct_from(commit_info_exprs)]);
-    let commit_info_schema = get_log_commit_info_schema().as_ref();
-
-    // HACK (part 2/2): we need to modify the commit info schema to match the expression above (a
-    // struct with a single null int field).
-    let mut commit_info_empty_struct_schema = commit_info_schema.clone();
-    let commit_info_field = commit_info_empty_struct_schema
-        .fields
-        .get_mut(COMMIT_INFO_NAME)
-        .ok_or_else(|| Error::missing_column(COMMIT_INFO_NAME))?;
-    let DataType::Struct(mut commit_info_data_type) = commit_info_field.data_type().clone() else {
-        return Err(Error::internal_error(
-            "commit_info_field should be a struct",
-        ));
+    // Helper function to convert HashMap to Scalar for commit_info
+    let hashmap_to_scalar = |hm: &Option<HashMap<String, String>>| -> DeltaResult<Scalar> {
+        match hm {
+            Some(map) => {
+                let pairs = map.iter().map(|(k, v)| (k.clone(), v.clone()));
+                let map_data = MapData::try_new(
+                    MapType::new(DataType::STRING, DataType::STRING, false),
+                    pairs,
+                )?;
+                Ok(Scalar::Map(map_data))
+            }
+            None => {
+                let map_data = MapData::try_new(
+                    MapType::new(DataType::STRING, DataType::STRING, false),
+                    std::iter::empty::<(String, String)>(),
+                )?;
+                Ok(Scalar::Map(map_data))
+            }
+        }
     };
-    let engine_commit_info_schema =
-        commit_info_data_type.project_as_struct(&["engineCommitInfo"])?;
-    let hack_data_type = DataType::Struct(Box::new(StructType::new(vec![StructField::nullable(
-        "hack_operation_parameter_int",
-        DataType::INTEGER,
-    )])));
 
-    commit_info_data_type
-        .fields
-        .get_mut("operationParameters")
-        .ok_or_else(|| Error::missing_column("operationParameters"))?
-        .data_type = hack_data_type;
+    let commit_info_schema = get_log_commit_info_schema();
 
-    // Since writing in-commit timestamps is not supported, we remove the field so it is not
-    // written to the log
-    commit_info_data_type
-        .fields
-        .shift_remove("inCommitTimestamp");
-    commit_info_field.data_type = DataType::Struct(commit_info_data_type);
+    let commit_info_values = vec![
+        // timestamp
+        Scalar::Long(commit_info.timestamp.unwrap_or(commit_timestamp)),
+        // in_commit_timestamp
+        Scalar::Long(commit_info.in_commit_timestamp.unwrap_or(commit_timestamp)),
+        //operation
+        Scalar::String(
+            commit_info
+                .operation
+                .clone()
+                .unwrap_or(UNKNOWN_OPERATION.to_string()),
+        ),
+        // operation parameters
+        hashmap_to_scalar(&commit_info.operation_parameters)?,
+        // kernel_version
+        Scalar::String(
+            commit_info
+                .kernel_version
+                .clone()
+                .unwrap_or(format!("v{}", KERNEL_VERSION)),
+        ),
+        // engine_commit_info
+        hashmap_to_scalar(&commit_info.engine_commit_info)?,
+    ];
 
-    let commit_info_evaluator = engine.evaluation_handler().new_expression_evaluator(
-        engine_commit_info_schema.into(),
-        commit_info_expr,
-        commit_info_empty_struct_schema.into(),
-    );
-
-    commit_info_evaluator.evaluate(engine_commit_info)
+    engine
+        .evaluation_handler()
+        .create_one(commit_info_schema.clone(), &commit_info_values)
 }
 
 #[cfg(test)]
@@ -388,9 +404,6 @@ mod tests {
     use crate::schema::MapType;
     use crate::{EvaluationHandler, JsonHandler, ParquetHandler, StorageHandler};
 
-    use crate::arrow::array::{MapArray, MapBuilder, MapFieldNames, StringArray, StringBuilder};
-    use crate::arrow::datatypes::{DataType as ArrowDataType, Field, Schema as ArrowSchema};
-    use crate::arrow::error::ArrowError;
     use crate::arrow::json::writer::LineDelimitedWriter;
     use crate::arrow::record_batch::RecordBatch;
 
@@ -420,23 +433,6 @@ mod tests {
         }
     }
 
-    fn build_map(entries: Vec<(&str, &str)>) -> MapArray {
-        let key_builder = StringBuilder::new();
-        let val_builder = StringBuilder::new();
-        let names = MapFieldNames {
-            entry: "entries".to_string(),
-            key: "key".to_string(),
-            value: "value".to_string(),
-        };
-        let mut builder = MapBuilder::new(Some(names), key_builder, val_builder);
-        for (key, val) in entries {
-            builder.keys().append_value(key);
-            builder.values().append_value(val);
-            builder.append(true).unwrap();
-        }
-        builder.finish()
-    }
-
     // convert it to JSON just for ease of comparison (and since we ultimately persist as JSON)
     fn as_json(data: Box<dyn EngineData>) -> serde_json::Value {
         let record_batch: RecordBatch = data
@@ -457,260 +453,86 @@ mod tests {
     #[test]
     fn test_generate_commit_info() -> DeltaResult<()> {
         let engine = ExprEngine::new();
-        let engine_commit_info_schema = Arc::new(ArrowSchema::new(vec![Field::new(
-            "engineCommitInfo",
-            ArrowDataType::Map(
-                Arc::new(Field::new(
-                    "entries",
-                    ArrowDataType::Struct(
-                        vec![
-                            Field::new("key", ArrowDataType::Utf8, false),
-                            Field::new("value", ArrowDataType::Utf8, true),
-                        ]
-                        .into(),
-                    ),
-                    false,
-                )),
-                false,
+
+        let commit_info = CommitInfo {
+            timestamp: None,
+            in_commit_timestamp: Some(123),
+            operation: Some("test operation".to_string()),
+            kernel_version: Some(format!("v{}", env!("CARGO_PKG_VERSION"))),
+            operation_parameters: Some(HashMap::new()),
+            engine_commit_info: Some(
+                vec![("engineInfo".to_string(), "default engine".to_string())]
+                    .into_iter()
+                    .collect(),
             ),
-            false,
-        )]));
-
-        let map_array = build_map(vec![("engineInfo", "default engine")]);
-        let commit_info_batch =
-            RecordBatch::try_new(engine_commit_info_schema, vec![Arc::new(map_array)])?;
-
-        let actions = generate_commit_info(
-            &engine,
-            Some("test operation"),
-            123456789,
-            &ArrowEngineData::new(commit_info_batch),
-        )?;
-
-        let expected = serde_json::json!({
-            "commitInfo": {
-                "timestamp": 123456789,
-                "operation": "test operation",
-                "kernelVersion": format!("v{}", env!("CARGO_PKG_VERSION")),
-                "operationParameters": {},
-                "engineCommitInfo": {
-                    "engineInfo": "default engine"
-                }
-            }
-        });
-
-        assert_eq!(actions.len(), 1);
-        let result = as_json(actions);
-        assert_eq!(result, expected);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_commit_info_with_multiple_columns() -> DeltaResult<()> {
-        let engine = ExprEngine::new();
-        let engine_commit_info_schema = Arc::new(ArrowSchema::new(vec![
-            Field::new(
-                "engineCommitInfo",
-                ArrowDataType::Map(
-                    Arc::new(Field::new(
-                        "entries",
-                        ArrowDataType::Struct(
-                            vec![
-                                Field::new("key", ArrowDataType::Utf8, false),
-                                Field::new("value", ArrowDataType::Utf8, true),
-                            ]
-                            .into(),
-                        ),
-                        false,
-                    )),
-                    false,
-                ),
-                false,
-            ),
-            Field::new("operation", ArrowDataType::Utf8, true),
-        ]));
-
-        let map_array = build_map(vec![("engineInfo", "default engine")]);
-
-        let commit_info_batch = RecordBatch::try_new(
-            engine_commit_info_schema,
-            vec![
-                Arc::new(map_array),
-                Arc::new(StringArray::from(vec!["some_string"])),
-            ],
-        )?;
-
-        let actions = generate_commit_info(
-            &engine,
-            Some("test operation"),
-            123456789,
-            &ArrowEngineData::new(commit_info_batch),
-        )?;
-
-        let expected = serde_json::json!({
-            "commitInfo": {
-                "timestamp": 123456789,
-                "operation": "test operation",
-                "kernelVersion": format!("v{}", env!("CARGO_PKG_VERSION")),
-                "operationParameters": {},
-                "engineCommitInfo": {
-                    "engineInfo": "default engine"
-                }
-            }
-        });
-
-        assert_eq!(actions.len(), 1);
-        let result = as_json(actions);
-        assert_eq!(result, expected);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_invalid_commit_info_missing_column() -> DeltaResult<()> {
-        let engine = ExprEngine::new();
-        let engine_commit_info_schema = Arc::new(ArrowSchema::new(vec![Field::new(
-            "some_column_name",
-            ArrowDataType::Utf8,
-            true,
-        )]));
-        let commit_info_batch = RecordBatch::try_new(
-            engine_commit_info_schema,
-            vec![Arc::new(StringArray::new_null(1))],
-        )?;
-
-        let _ = generate_commit_info(
-            &engine,
-            Some("test operation"),
-            123456789,
-            &ArrowEngineData::new(commit_info_batch),
-        )
-        .map_err(|e| match e {
-            Error::Arrow(ArrowError::SchemaError(_)) => (),
-            Error::Backtraced { source, .. }
-                if matches!(&*source, Error::Arrow(ArrowError::SchemaError(_))) => {}
-            _ => panic!("expected arrow schema error error, got {:?}", e),
-        });
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_invalid_commit_info_invalid_column_type() -> DeltaResult<()> {
-        let engine = ExprEngine::new();
-        let engine_commit_info_schema = Arc::new(ArrowSchema::new(vec![Field::new(
-            "engineCommitInfo",
-            ArrowDataType::Utf8,
-            true,
-        )]));
-        let commit_info_batch = RecordBatch::try_new(
-            engine_commit_info_schema,
-            vec![Arc::new(StringArray::new_null(1))],
-        )?;
-
-        let _ = generate_commit_info(
-            &engine,
-            Some("test operation"),
-            123456789,
-            &ArrowEngineData::new(commit_info_batch),
-        )
-        .map_err(|e| match e {
-            Error::Arrow(ArrowError::InvalidArgumentError(_)) => (),
-            Error::Backtraced { source, .. }
-                if matches!(&*source, Error::Arrow(ArrowError::InvalidArgumentError(_))) => {}
-            _ => panic!("expected arrow invalid arg error, got {:?}", e),
-        });
-
-        Ok(())
-    }
-
-    fn assert_empty_commit_info(
-        data: Box<dyn EngineData>,
-        write_engine_commit_info: bool,
-        timestamp: i64,
-    ) -> DeltaResult<()> {
-        assert_eq!(data.len(), 1);
-        let expected = if write_engine_commit_info {
-            serde_json::json!({
-                "commitInfo": {
-                    "timestamp": timestamp,
-                    "operation": "test operation",
-                    "kernelVersion": format!("v{}", env!("CARGO_PKG_VERSION")),
-                    "operationParameters": {},
-                    "engineCommitInfo": {}
-                }
-            })
-        } else {
-            serde_json::json!({
-                "commitInfo": {
-                    "timestamp": timestamp,
-                    "operation": "test operation",
-                    "kernelVersion": format!("v{}", env!("CARGO_PKG_VERSION")),
-                    "operationParameters": {},
-                }
-            })
         };
-        let result = as_json(data);
+
+        let actions = generate_commit_info(&engine, &commit_info, 123456789)?;
+
+        let expected = serde_json::json!({
+            "commitInfo": {
+                "timestamp": 123456789,
+                "inCommitTimestamp": 123,
+                "operation": "test operation",
+                "kernelVersion": format!("v{}", env!("CARGO_PKG_VERSION")),
+                "operationParameters": {},
+                "engineCommitInfo": {
+                    "engineInfo": "default engine"
+                }
+            }
+        });
+
+        assert_eq!(actions.len(), 1);
+        let result = as_json(actions);
         assert_eq!(result, expected);
+
         Ok(())
     }
 
-    // Three cases for empty commit info:
-    // 1. `engineCommitInfo` column with an empty Map<string, string>
-    // 2. `engineCommitInfo` null column of type Map<string, string>
-    // 3. a column that has a name other than `engineCommitInfo`; Delta can detect that the column
-    //    is missing and substitute a null literal in its place. The type of that column doesn't
-    //    matter, Delta will ignore it.
     #[test]
-    fn test_empty_commit_info() -> DeltaResult<()> {
-        // test with null map and empty map
-        for is_null in [true, false] {
-            let engine = ExprEngine::new();
-            let engine_commit_info_schema = Arc::new(ArrowSchema::new(vec![Field::new(
-                "engineCommitInfo",
-                ArrowDataType::Map(
-                    Arc::new(Field::new(
-                        "entries",
-                        ArrowDataType::Struct(
-                            vec![
-                                Field::new("key", ArrowDataType::Utf8, false),
-                                Field::new("value", ArrowDataType::Utf8, true),
-                            ]
-                            .into(),
-                        ),
-                        false,
-                    )),
-                    false,
-                ),
-                true,
-            )]));
+    fn test_generate_commit_info_invalid_engine_commit_info() -> DeltaResult<()> {
+        let engine = ExprEngine::new();
 
-            let key_builder = StringBuilder::new();
-            let val_builder = StringBuilder::new();
-            let names = crate::arrow::array::MapFieldNames {
-                entry: "entries".to_string(),
-                key: "key".to_string(),
-                value: "value".to_string(),
-            };
-            let mut builder =
-                crate::arrow::array::MapBuilder::new(Some(names), key_builder, val_builder);
-            builder.append(is_null).unwrap();
-            let array = builder.finish();
+        let mut commit_info = CommitInfo {
+            timestamp: Some(123456789),
+            in_commit_timestamp: Some(123),
+            operation: Some("test operation".to_string()),
+            kernel_version: Some(format!("v{}", env!("CARGO_PKG_VERSION"))),
+            operation_parameters: Some(HashMap::new()),
+            engine_commit_info: Some(HashMap::new()),
+        };
 
-            let commit_info_batch =
-                RecordBatch::try_new(engine_commit_info_schema, vec![Arc::new(array)])?;
-
-            let timestamp = 123456;
-            let actions = generate_commit_info(
-                &engine,
-                Some("test operation"),
-                timestamp,
-                &ArrowEngineData::new(commit_info_batch),
-            )?;
-
-            assert_empty_commit_info(actions, is_null, timestamp)?;
+        match generate_commit_info(&engine, &commit_info, 0) {
+            Err(Error::InvalidCommitInfo(msg)) => {
+                assert_eq!(
+                    msg,
+                    "Engine commit info should have exactly one row, found 0"
+                );
+            }
+            _ => panic!("Expected InvalidCommitInfo error"),
         }
+
+        commit_info
+            .engine_commit_info
+            .as_mut()
+            .unwrap()
+            .insert("row1".to_string(), "default engine".to_string());
+        commit_info
+            .engine_commit_info
+            .as_mut()
+            .unwrap()
+            .insert("row2".to_string(), "default engine".to_string());
+
+        match generate_commit_info(&engine, &commit_info, 0) {
+            Err(Error::InvalidCommitInfo(msg)) => {
+                assert_eq!(
+                    msg,
+                    "Engine commit info should have exactly one row, found 2"
+                );
+            }
+            _ => panic!("Expected InvalidCommitInfo error"),
+        }
+
         Ok(())
     }
 

--- a/kernel/src/transaction.rs
+++ b/kernel/src/transaction.rs
@@ -74,7 +74,7 @@ impl std::fmt::Debug for Transaction {
         f.write_str(&format!(
             "Transaction {{ read_snapshot version: {}, commit_info: {:#?} }}",
             self.read_snapshot.version(),
-            self.commit_info
+            self.commit_info.is_some()
         ))
     }
 }
@@ -137,10 +137,10 @@ impl Transaction {
         // step one: construct the iterator of commit info + file actions we want to commit
         let commit_info = self
             .commit_info
-            .clone()
+            .as_ref()
             .ok_or_else(|| Error::MissingCommitInfo)?;
 
-        let commit_info_actions = generate_commit_info(engine, &commit_info, self.commit_timestamp);
+        let commit_info_actions = generate_commit_info(engine, commit_info, self.commit_timestamp);
 
         let add_actions = generate_adds(engine, self.write_metadata.iter().map(|a| a.as_ref()));
 
@@ -203,10 +203,6 @@ impl Transaction {
     }
 
     // Set the engine commit info of this transaction.
-    //
-    // Note: The engine data passed here must have exactly one row, and we
-    /// only read one column: `engineCommitInfo` which must be a map<string, string> encoding the
-    /// metadata.
     pub fn with_engine_commit_info(mut self, engine_commit_info: HashMap<String, String>) -> Self {
         self.commit_info.get_or_insert_default().engine_commit_info = Some(engine_commit_info);
         self
@@ -334,15 +330,6 @@ fn generate_commit_info(
     commit_info: &CommitInfo,
     commit_timestamp: i64,
 ) -> DeltaResult<Box<dyn EngineData>> {
-    if let Some(engine_commit_info) = &commit_info.engine_commit_info {
-        if engine_commit_info.len() != 1 {
-            return Err(Error::InvalidCommitInfo(format!(
-                "Engine commit info should have exactly one row, found {}",
-                engine_commit_info.len()
-            )));
-        }
-    }
-
     // Helper function to convert HashMap to Scalar for commit_info
     let hashmap_to_scalar = |hm: &Option<HashMap<String, String>>| -> DeltaResult<Scalar> {
         match hm {
@@ -486,53 +473,6 @@ mod tests {
         assert_eq!(actions.len(), 1);
         let result = as_json(actions);
         assert_eq!(result, expected);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_generate_commit_info_invalid_engine_commit_info() -> DeltaResult<()> {
-        let engine = ExprEngine::new();
-
-        let mut commit_info = CommitInfo {
-            timestamp: Some(123456789),
-            in_commit_timestamp: Some(123),
-            operation: Some("test operation".to_string()),
-            kernel_version: Some(format!("v{}", env!("CARGO_PKG_VERSION"))),
-            operation_parameters: Some(HashMap::new()),
-            engine_commit_info: Some(HashMap::new()),
-        };
-
-        match generate_commit_info(&engine, &commit_info, 0) {
-            Err(Error::InvalidCommitInfo(msg)) => {
-                assert_eq!(
-                    msg,
-                    "Engine commit info should have exactly one row, found 0"
-                );
-            }
-            _ => panic!("Expected InvalidCommitInfo error"),
-        }
-
-        commit_info
-            .engine_commit_info
-            .as_mut()
-            .unwrap()
-            .insert("row1".to_string(), "default engine".to_string());
-        commit_info
-            .engine_commit_info
-            .as_mut()
-            .unwrap()
-            .insert("row2".to_string(), "default engine".to_string());
-
-        match generate_commit_info(&engine, &commit_info, 0) {
-            Err(Error::InvalidCommitInfo(msg)) => {
-                assert_eq!(
-                    msg,
-                    "Engine commit info should have exactly one row, found 2"
-                );
-            }
-            _ => panic!("Expected InvalidCommitInfo error"),
-        }
 
         Ok(())
     }

--- a/kernel/src/transaction.rs
+++ b/kernel/src/transaction.rs
@@ -3,7 +3,7 @@ use std::iter;
 use std::sync::{Arc, LazyLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::actions::{get_log_add_schema, get_log_commit_info_schema};
+use crate::actions::{get_log_add_schema, get_log_commit_info_schema, get_log_txn_schema};
 use crate::actions::{CommitInfo, SetTransaction};
 use crate::error::Error;
 use crate::expressions::{MapData, Scalar};
@@ -11,7 +11,8 @@ use crate::path::ParsedLogPath;
 use crate::schema::{MapType, SchemaRef, StructField, StructType};
 use crate::snapshot::Snapshot;
 use crate::{
-    DataType, DeltaResult, Engine, EngineData, EvaluationHandlerExtension, Expression, Version,
+    DataType, DeltaResult, Engine, EngineData, EvaluationHandlerExtension, Expression,
+    IntoEngineData, Version,
 };
 
 use url::Url;

--- a/kernel/tests/write.rs
+++ b/kernel/tests/write.rs
@@ -245,47 +245,6 @@ async fn test_empty_commit() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[tokio::test]
-async fn test_invalid_commit_info() -> Result<(), Box<dyn std::error::Error>> {
-    // setup tracing
-    let _ = tracing_subscriber::fmt::try_init();
-
-    // create a simple table: one int column named 'number'
-    let schema = Arc::new(StructType::new(vec![StructField::nullable(
-        "number",
-        DataType::INTEGER,
-    )]));
-    for (table, engine, _store, _table_name) in setup_tables(schema, &[]).await? {
-        // empty commit info test
-        let txn = table
-            .new_transaction(&engine)?
-            .with_engine_commit_info(HashMap::new());
-
-        // commit!
-        assert!(matches!(
-            txn.commit(&engine),
-            Err(KernelError::InvalidCommitInfo(_))
-        ));
-
-        // two-row commit info test
-        let txn = table.new_transaction(&engine)?.with_engine_commit_info(
-            vec![
-                ("row1".to_string(), "default engine".to_string()),
-                ("row2".to_string(), "default engine".to_string()),
-            ]
-            .into_iter()
-            .collect(),
-        );
-
-        // commit!
-        assert!(matches!(
-            txn.commit(&engine),
-            Err(KernelError::InvalidCommitInfo(_))
-        ));
-    }
-    Ok(())
-}
-
 // check that the timestamps in commit_info and add actions are within 10s of SystemTime::now()
 fn check_action_timestamps<'a>(
     parsed_commits: impl Iterator<Item = &'a serde_json::Value>,

--- a/kernel/tests/write.rs
+++ b/kernel/tests/write.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use delta_kernel::arrow::array::{Int32Array, StringArray};
+use delta_kernel::arrow::array::{Int32Array, StringArray, TimestampMicrosecondArray};
 use delta_kernel::arrow::error::ArrowError;
 use delta_kernel::arrow::record_batch::RecordBatch;
 
@@ -912,11 +912,11 @@ async fn test_append_timestamp_ntz() -> Result<(), Box<dyn std::error::Error>> {
     )
     .await?;
 
-    let commit_info = new_commit_info()?;
-
-    let mut txn = table
-        .new_transaction(&engine)?
-        .with_commit_info(commit_info);
+    let mut txn = table.new_transaction(&engine)?.with_engine_commit_info(
+        vec![("engineInfo".to_string(), "default engine".to_string())]
+            .into_iter()
+            .collect(),
+    );
 
     // Create Arrow data with TIMESTAMP_NTZ values including edge cases
     // These are microseconds since Unix epoch

--- a/kernel/tests/write.rs
+++ b/kernel/tests/write.rs
@@ -1,10 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use delta_kernel::arrow::array::{
-    Int32Array, MapBuilder, MapFieldNames, StringArray, StringBuilder, TimestampMicrosecondArray,
-};
-use delta_kernel::arrow::datatypes::{DataType as ArrowDataType, Field, Schema as ArrowSchema};
+use delta_kernel::arrow::array::{Int32Array, StringArray};
 use delta_kernel::arrow::error::ArrowError;
 use delta_kernel::arrow::record_batch::RecordBatch;
 
@@ -124,46 +121,6 @@ async fn create_table(
     Ok(Table::new(table_path))
 }
 
-// create commit info in arrow of the form {engineInfo: "default engine"}
-fn new_commit_info() -> DeltaResult<Box<ArrowEngineData>> {
-    // create commit info of the form {engineCommitInfo: Map { "engineInfo": "default engine" } }
-    let commit_info_schema = Arc::new(ArrowSchema::new(vec![Field::new(
-        "engineCommitInfo",
-        ArrowDataType::Map(
-            Arc::new(Field::new(
-                "entries",
-                ArrowDataType::Struct(
-                    vec![
-                        Field::new("key", ArrowDataType::Utf8, false),
-                        Field::new("value", ArrowDataType::Utf8, true),
-                    ]
-                    .into(),
-                ),
-                false,
-            )),
-            false,
-        ),
-        false,
-    )]));
-
-    let key_builder = StringBuilder::new();
-    let val_builder = StringBuilder::new();
-    let names = MapFieldNames {
-        entry: "entries".to_string(),
-        key: "key".to_string(),
-        value: "value".to_string(),
-    };
-    let mut builder = MapBuilder::new(Some(names), key_builder, val_builder);
-    builder.keys().append_value("engineInfo");
-    builder.values().append_value("default engine");
-    builder.append(true).unwrap();
-    let array = builder.finish();
-
-    let commit_info_batch =
-        RecordBatch::try_new(commit_info_schema.clone(), vec![Arc::new(array)])?;
-    Ok(Box::new(ArrowEngineData::new(commit_info_batch)))
-}
-
 async fn setup_tables(
     schema: SchemaRef,
     partition_columns: &[&str],
@@ -222,12 +179,12 @@ async fn test_commit_info() -> Result<(), Box<dyn std::error::Error>> {
     )]));
 
     for (table, engine, store, table_name) in setup_tables(schema, &[]).await? {
-        let commit_info = new_commit_info()?;
-
         // create a transaction
-        let txn = table
-            .new_transaction(&engine)?
-            .with_commit_info(commit_info);
+        let txn = table.new_transaction(&engine)?.with_engine_commit_info(
+            vec![("engineInfo".to_string(), "default engine".to_string())]
+                .into_iter()
+                .collect(),
+        );
 
         // commit!
         txn.commit(&engine)?;
@@ -245,9 +202,16 @@ async fn test_commit_info() -> Result<(), Box<dyn std::error::Error>> {
             .get_mut("timestamp")
             .unwrap() = serde_json::Value::Number(0.into());
 
+        *parsed_commit
+            .get_mut("commitInfo")
+            .unwrap()
+            .get_mut("inCommitTimestamp")
+            .unwrap() = serde_json::Value::Number(0.into());
+
         let expected_commit = json!({
             "commitInfo": {
                 "timestamp": 0,
+                "inCommitTimestamp": 0,
                 "operation": "UNKNOWN",
                 "kernelVersion": format!("v{}", env!("CARGO_PKG_VERSION")),
                 "operationParameters": {},
@@ -293,12 +257,9 @@ async fn test_invalid_commit_info() -> Result<(), Box<dyn std::error::Error>> {
     )]));
     for (table, engine, _store, _table_name) in setup_tables(schema, &[]).await? {
         // empty commit info test
-        let commit_info_schema = Arc::new(ArrowSchema::empty());
-        let commit_info_batch = RecordBatch::new_empty(commit_info_schema.clone());
-        assert!(commit_info_batch.num_rows() == 0);
         let txn = table
             .new_transaction(&engine)?
-            .with_commit_info(Box::new(ArrowEngineData::new(commit_info_batch)));
+            .with_engine_commit_info(HashMap::new());
 
         // commit!
         assert!(matches!(
@@ -307,22 +268,14 @@ async fn test_invalid_commit_info() -> Result<(), Box<dyn std::error::Error>> {
         ));
 
         // two-row commit info test
-        let commit_info_schema = Arc::new(ArrowSchema::new(vec![Field::new(
-            "engineInfo",
-            ArrowDataType::Utf8,
-            true,
-        )]));
-        let commit_info_batch = RecordBatch::try_new(
-            commit_info_schema.clone(),
-            vec![Arc::new(StringArray::from(vec![
-                "row1: default engine",
-                "row2: default engine",
-            ]))],
-        )?;
-
-        let txn = table
-            .new_transaction(&engine)?
-            .with_commit_info(Box::new(ArrowEngineData::new(commit_info_batch)));
+        let txn = table.new_transaction(&engine)?.with_engine_commit_info(
+            vec![
+                ("row1".to_string(), "default engine".to_string()),
+                ("row2".to_string(), "default engine".to_string()),
+            ]
+            .into_iter()
+            .collect(),
+        );
 
         // commit!
         assert!(matches!(
@@ -391,6 +344,71 @@ async fn get_and_check_all_parquet_sizes(store: Arc<dyn ObjectStore>, path: &str
 }
 
 #[tokio::test]
+async fn test_comit_info_action() -> Result<(), Box<dyn std::error::Error>> {
+    // setup tracing
+    let _ = tracing_subscriber::fmt::try_init();
+    // create a simple table: one int column named 'number'
+    let schema = Arc::new(StructType::new(vec![StructField::nullable(
+        "number",
+        DataType::INTEGER,
+    )]));
+
+    for (table, engine, store, table_name) in setup_tables(schema.clone(), &[]).await? {
+        let txn = table
+            .new_transaction(&engine)?
+            .with_timestamp(1)
+            .with_in_commit_timestamp(2)
+            .with_operation("INSERT".to_string())
+            .with_operation_parameters(
+                vec![
+                    ("mode".to_string(), "Append".to_string()),
+                    ("partitionBy".to_string(), "[]".to_string()),
+                ]
+                .into_iter()
+                .collect(),
+            )
+            .with_kernel_version("v0.11.0".to_string())
+            .with_engine_commit_info(
+                vec![("engineInfo".to_string(), "default engine".to_string())]
+                    .into_iter()
+                    .collect(),
+            );
+
+        txn.commit(&engine)?;
+
+        let commit = store
+            .get(&Path::from(format!(
+                "/{table_name}/_delta_log/00000000000000000001.json"
+            )))
+            .await?;
+
+        let parsed_commits: Vec<_> = Deserializer::from_slice(&commit.bytes().await?)
+            .into_iter::<serde_json::Value>()
+            .try_collect()?;
+
+        let expected_commit = vec![json!({
+            "commitInfo": {
+                "timestamp": 1,
+                "inCommitTimestamp": 2,
+                "operation": "INSERT",
+                "kernelVersion": "v0.11.0",
+                "operationParameters": {
+                    "mode": "Append",
+                    "partitionBy": "[]"
+                },
+                "engineCommitInfo": {
+                    "engineInfo": "default engine"
+                }
+            }
+        })];
+
+        assert_eq!(parsed_commits, expected_commit);
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_append() -> Result<(), Box<dyn std::error::Error>> {
     // setup tracing
     let _ = tracing_subscriber::fmt::try_init();
@@ -401,11 +419,11 @@ async fn test_append() -> Result<(), Box<dyn std::error::Error>> {
     )]));
 
     for (table, engine, store, table_name) in setup_tables(schema.clone(), &[]).await? {
-        let commit_info = new_commit_info()?;
-
-        let mut txn = table
-            .new_transaction(&engine)?
-            .with_commit_info(commit_info);
+        let mut txn = table.new_transaction(&engine)?.with_engine_commit_info(
+            vec![("engineInfo".to_string(), "default engine".to_string())]
+                .into_iter()
+                .collect(),
+        );
 
         // create two new arrow record batches to append
         let append_data = [[1, 2, 3], [4, 5, 6]].map(|data| -> DeltaResult<_> {
@@ -463,6 +481,11 @@ async fn test_append() -> Result<(), Box<dyn std::error::Error>> {
         // set timestamps to 0 and paths to known string values for comparison
         // (otherwise timestamps are non-deterministic and paths are random UUIDs)
         set_value(&mut parsed_commits[0], "commitInfo.timestamp", json!(0))?;
+        set_value(
+            &mut parsed_commits[0],
+            "commitInfo.inCommitTimestamp",
+            json!(0),
+        )?;
         set_value(&mut parsed_commits[1], "add.modificationTime", json!(0))?;
         set_value(&mut parsed_commits[1], "add.path", json!("first.parquet"))?;
         set_value(&mut parsed_commits[2], "add.modificationTime", json!(0))?;
@@ -472,6 +495,7 @@ async fn test_append() -> Result<(), Box<dyn std::error::Error>> {
             json!({
                 "commitInfo": {
                     "timestamp": 0,
+                    "inCommitTimestamp": 0,
                     "operation": "UNKNOWN",
                     "kernelVersion": format!("v{}", env!("CARGO_PKG_VERSION")),
                     "operationParameters": {},
@@ -535,11 +559,11 @@ async fn test_append_partitioned() -> Result<(), Box<dyn std::error::Error>> {
     for (table, engine, store, table_name) in
         setup_tables(table_schema.clone(), &[partition_col]).await?
     {
-        let commit_info = new_commit_info()?;
-
-        let mut txn = table
-            .new_transaction(&engine)?
-            .with_commit_info(commit_info);
+        let mut txn = table.new_transaction(&engine)?.with_engine_commit_info(
+            vec![("engineInfo".to_string(), "default engine".to_string())]
+                .into_iter()
+                .collect(),
+        );
 
         // create two new arrow record batches to append
         let append_data = [[1, 2, 3], [4, 5, 6]].map(|data| -> DeltaResult<_> {
@@ -601,6 +625,11 @@ async fn test_append_partitioned() -> Result<(), Box<dyn std::error::Error>> {
         // set timestamps to 0 and paths to known string values for comparison
         // (otherwise timestamps are non-deterministic and paths are random UUIDs)
         set_value(&mut parsed_commits[0], "commitInfo.timestamp", json!(0))?;
+        set_value(
+            &mut parsed_commits[0],
+            "commitInfo.inCommitTimestamp",
+            json!(0),
+        )?;
         set_value(&mut parsed_commits[1], "add.modificationTime", json!(0))?;
         set_value(&mut parsed_commits[1], "add.path", json!("first.parquet"))?;
         set_value(&mut parsed_commits[2], "add.modificationTime", json!(0))?;
@@ -610,6 +639,7 @@ async fn test_append_partitioned() -> Result<(), Box<dyn std::error::Error>> {
             json!({
                 "commitInfo": {
                     "timestamp": 0,
+                    "inCommitTimestamp": 0,
                     "operation": "UNKNOWN",
                     "kernelVersion": format!("v{}", env!("CARGO_PKG_VERSION")),
                     "operationParameters": {},
@@ -675,11 +705,11 @@ async fn test_append_invalid_schema() -> Result<(), Box<dyn std::error::Error>> 
     )]));
 
     for (table, engine, _store, _table_name) in setup_tables(table_schema, &[]).await? {
-        let commit_info = new_commit_info()?;
-
-        let txn = table
-            .new_transaction(&engine)?
-            .with_commit_info(commit_info);
+        let txn = table.new_transaction(&engine)?.with_engine_commit_info(
+            vec![("engineInfo".to_string(), "default engine".to_string())]
+                .into_iter()
+                .collect(),
+        );
 
         // create two new arrow record batches to append
         let append_data = [["a", "b"], ["c", "d"]].map(|data| -> DeltaResult<_> {
@@ -733,8 +763,6 @@ async fn test_write_txn_actions() -> Result<(), Box<dyn std::error::Error>> {
     )]));
 
     for (table, engine, store, table_name) in setup_tables(schema, &[]).await? {
-        let commit_info = new_commit_info()?;
-
         // can't have duplicate app_id in same transaction
         assert!(matches!(
             table
@@ -747,7 +775,11 @@ async fn test_write_txn_actions() -> Result<(), Box<dyn std::error::Error>> {
 
         let txn = table
             .new_transaction(&engine)?
-            .with_commit_info(commit_info)
+            .with_engine_commit_info(
+                vec![("engineInfo".to_string(), "default engine".to_string())]
+                    .into_iter()
+                    .collect(),
+            )
             .with_transaction_id("app_id1".to_string(), 1)
             .with_transaction_id("app_id2".to_string(), 2);
 
@@ -779,6 +811,12 @@ async fn test_write_txn_actions() -> Result<(), Box<dyn std::error::Error>> {
             .get_mut("commitInfo")
             .unwrap()
             .get_mut("timestamp")
+            .unwrap() = serde_json::Value::Number(0.into());
+
+        *parsed_commits[0]
+            .get_mut("commitInfo")
+            .unwrap()
+            .get_mut("inCommitTimestamp")
             .unwrap() = serde_json::Value::Number(0.into());
 
         let time_ms: i64 = std::time::SystemTime::now()
@@ -822,6 +860,7 @@ async fn test_write_txn_actions() -> Result<(), Box<dyn std::error::Error>> {
             json!({
                 "commitInfo": {
                     "timestamp": 0,
+                    "inCommitTimestamp": 0,
                     "operation": "UNKNOWN",
                     "kernelVersion": format!("v{}", env!("CARGO_PKG_VERSION")),
                     "operationParameters": {},


### PR DESCRIPTION
Fixes #762 

## What changes are proposed in this pull request?

To append [Commit Provenance Information](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#commit-provenance-information) to a transaction, the current implementation provides an API called `with_commit_info()` that takes in the data for`engine_commit_info` in the form of `EngineData`. Instead, this PR proposes to add new sets of APIs to take in data (not in the form of `EngineData`) and materialize it into `EngineData` inside `commit()`.

More specifically, this PR introduces the following new APIs:
`with_timestamp(timestamp: i64)`
`with_in_commit_timestamp(in_commit_timestamp: i64)`
`with_operation(operation: String)`
`with_operation_parameters(operation_parameters: HashMap<String, String>`
`with_kernel_version(kernel_version: String)`
`with_engine_commit_info(engine_commit_info: HashMap<String, String>)`

Additionally, I've removed test cases that validate the schema of engine_commit_info.

### This PR affects the following public APIs

removal of `with_commit_info()` in transactions.rs

## How was this change tested?

I ran `cargo nextest run` and passed all tests