### PR TITLE
fix: disable timestamp column for data skipping

### DIFF
--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -197,13 +197,23 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator {
     type ColumnStat = Expr;
 
     /// Retrieves the minimum value of a column, if it exists and has the requested type.
-    fn get_min_stat(&self, col: &ColumnName, _data_type: &DataType) -> Option<Expr> {
-        Some(joined_column_expr!("minValues", col))
+    // TODO(#1002): we currently don't support file skipping on timestamp columns since they are
+    // truncated to milliseconds in add.stats.
+    fn get_min_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
+        match data_type {
+            DataType::Primitive(PrimitiveType::Timestamp | PrimitiveType::TimestampNtz) => None,
+            _ => Some(joined_column_expr!("minValues", col)),
+        }
     }
 
     /// Retrieves the maximum value of a column, if it exists and has the requested type.
-    fn get_max_stat(&self, col: &ColumnName, _data_type: &DataType) -> Option<Expr> {
-        Some(joined_column_expr!("maxValues", col))
+    // TODO(#1002): we currently don't support file skipping on timestamp columns since they are
+    // truncated to milliseconds in add.stats.
+    fn get_max_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
+        match data_type {
+            DataType::Primitive(PrimitiveType::Timestamp | PrimitiveType::TimestampNtz) => None,
+            _ => Some(joined_column_expr!("maxValues", col)),
+        }
     }
 
     /// Retrieves the null count of a column, if it exists.

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -197,21 +197,16 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator {
     type ColumnStat = Expr;
 
     /// Retrieves the minimum value of a column, if it exists and has the requested type.
-    // TODO(#1002): we currently don't support file skipping on timestamp columns since they are
-    // truncated to milliseconds in add.stats.
-    fn get_min_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
-        match data_type {
-            DataType::Primitive(PrimitiveType::Timestamp | PrimitiveType::TimestampNtz) => None,
-            _ => Some(joined_column_expr!("minValues", col)),
-        }
+    fn get_min_stat(&self, col: &ColumnName, _data_type: &DataType) -> Option<Expr> {
+        Some(joined_column_expr!("minValues", col))
     }
 
     /// Retrieves the maximum value of a column, if it exists and has the requested type.
-    // TODO(#1002): we currently don't support file skipping on timestamp columns since they are
-    // truncated to milliseconds in add.stats.
+    // TODO(#1002): we currently don't support file skipping on timestamp columns' max stat since
+    // they are truncated to milliseconds in add.stats.
     fn get_max_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
         match data_type {
-            DataType::Primitive(PrimitiveType::Timestamp | PrimitiveType::TimestampNtz) => None,
+            &DataType::TIMESTAMP | &DataType::TIMESTAMP_NTZ => None,
             _ => Some(joined_column_expr!("maxValues", col)),
         }
     }

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -347,38 +347,32 @@ fn test_timestamp_skipping_disabled() {
     let creator = DataSkippingPredicateCreator;
     let col = &column_name!("timestamp_col");
 
-    // Test that get_min_stat returns None for timestamp types
     assert_eq!(
         creator.get_min_stat(col, &DataType::TIMESTAMP),
         None,
         "get_min_stat should return None: no data skipping on timestamp columns"
     );
-
     assert_eq!(
         creator.get_max_stat(col, &DataType::TIMESTAMP),
         None,
         "get_max_stat should return None: no data skipping on timestamp columns"
     );
-
-    // Test that get_min_stat returns None for timestamp_ntz types
     assert_eq!(
         creator.get_min_stat(col, &DataType::TIMESTAMP_NTZ),
         None,
         "get_min_stat should return None: no data skipping on timestamp_ntz columns"
     );
-
     assert_eq!(
         creator.get_max_stat(col, &DataType::TIMESTAMP_NTZ),
         None,
         "get_max_stat should return None: no data skipping on timestamp_ntz columns"
     );
 
-    // Test that non-timestamp types still work
+    // non-timestamp still work
     assert!(
         creator.get_min_stat(col, &DataType::INTEGER).is_some(),
         "get_min_stat should still work for non-timestamp columns"
     );
-
     assert!(
         creator.get_max_stat(col, &DataType::INTEGER).is_some(),
         "get_max_stat should still work for non-timestamp columns"


### PR DESCRIPTION
## What changes are proposed in this pull request?
delta-kernel-rs assumes stats to be accurate as microseconds (like the timestamp type they are represented), but delta spec states that `add.stats` min/max values truncate strings/timestamps to milliseconds:
> String columns are cut off at a fixed prefix length. Timestamp columns are truncated down to milliseconds

While that's okay for min-stats, it's incorrect for max-stats: the file's _actual_ max-value is anywhere from 0-999µs larger than the recorded stats max-value.

In the short-term we disable timestamp-based file skipping, and long term will explore a solution like adding 999us to our max stat (in follow-up issue).

## How was this change tested?
New UT

follow-up in #1002 