### PR TITLE
fix: remove azure suffix range request

### DIFF
--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -266,12 +266,12 @@ impl FileOpener for ParquetOpener {
         Ok(Box::pin(async move {
             #[cfg(feature = "arrow-55")]
             use crate::object_store::azure::MicrosoftAzure;
-            use std::any::Any;
+            use crate::AsAny;
             // HACK: unfortunately, `ParquetObjectReader` under the hood does a suffix GET which
             // isn't supported by Azure. For now we just detect if the store is backed by Azure and
             // if so, do a HEAD request so we can pass in file size to the reader which will cause
             // the reader to avoid a suffix GET.
-            let mut reader = if (&store.clone() as &dyn Any).is::<MicrosoftAzure>() {
+            let mut reader = if store.any_ref().is::<MicrosoftAzure>() {
                 let meta = store.head(&path).await?;
                 ParquetObjectReader::new(store, path).with_file_size(meta.size)
             } else {

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -266,14 +266,15 @@ impl FileOpener for ParquetOpener {
         Ok(Box::pin(async move {
             #[cfg(feature = "arrow-55")]
             let mut reader = {
-                use crate::object_store::azure::MicrosoftAzure;
-                use crate::AsAny;
+                use crate::object_store::ObjectStoreScheme;
                 // HACK: unfortunately, `ParquetObjectReader` under the hood does a suffix range
-                // request which isn't supported by Azure. For now we just detect if the store is backed
-                // by Azure and if so, do a HEAD request so we can pass in file size to the reader which
-                // will cause the reader to avoid a suffix range request.
+                // request which isn't supported by Azure. For now we just detect if the URL is
+                // pointing to azure and if so, do a HEAD request so we can pass in file size to the
+                // reader which will cause the reader to avoid a suffix range request.
                 // see also: https://github.com/delta-io/delta-kernel-rs/issues/968
-                if store.any_ref().is::<MicrosoftAzure>() {
+                if let Ok((ObjectStoreScheme::MicrosoftAzure, _)) =
+                    ObjectStoreScheme::parse(&file_meta.location)
+                {
                     let meta = store.head(&path).await?;
                     ParquetObjectReader::new(store, path).with_file_size(meta.size)
                 } else {

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -267,10 +267,11 @@ impl FileOpener for ParquetOpener {
             #[cfg(feature = "arrow-55")]
             use crate::object_store::azure::MicrosoftAzure;
             use crate::AsAny;
-            // HACK: unfortunately, `ParquetObjectReader` under the hood does a suffix GET which
-            // isn't supported by Azure. For now we just detect if the store is backed by Azure and
-            // if so, do a HEAD request so we can pass in file size to the reader which will cause
-            // the reader to avoid a suffix GET.
+            // HACK: unfortunately, `ParquetObjectReader` under the hood does a suffix range
+            // request which isn't supported by Azure. For now we just detect if the store is backed
+            // by Azure and if so, do a HEAD request so we can pass in file size to the reader which
+            // will cause the reader to avoid a suffix range request.
+            // see also: https://github.com/delta-io/delta-kernel-rs/issues/968
             let mut reader = if store.any_ref().is::<MicrosoftAzure>() {
                 let meta = store.head(&path).await?;
                 ParquetObjectReader::new(store, path).with_file_size(meta.size)

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -265,18 +265,20 @@ impl FileOpener for ParquetOpener {
 
         Ok(Box::pin(async move {
             #[cfg(feature = "arrow-55")]
-            use crate::object_store::azure::MicrosoftAzure;
-            use crate::AsAny;
-            // HACK: unfortunately, `ParquetObjectReader` under the hood does a suffix range
-            // request which isn't supported by Azure. For now we just detect if the store is backed
-            // by Azure and if so, do a HEAD request so we can pass in file size to the reader which
-            // will cause the reader to avoid a suffix range request.
-            // see also: https://github.com/delta-io/delta-kernel-rs/issues/968
-            let mut reader = if store.any_ref().is::<MicrosoftAzure>() {
-                let meta = store.head(&path).await?;
-                ParquetObjectReader::new(store, path).with_file_size(meta.size)
-            } else {
-                ParquetObjectReader::new(store, path)
+            let mut reader = {
+                use crate::object_store::azure::MicrosoftAzure;
+                use crate::AsAny;
+                // HACK: unfortunately, `ParquetObjectReader` under the hood does a suffix range
+                // request which isn't supported by Azure. For now we just detect if the store is backed
+                // by Azure and if so, do a HEAD request so we can pass in file size to the reader which
+                // will cause the reader to avoid a suffix range request.
+                // see also: https://github.com/delta-io/delta-kernel-rs/issues/968
+                if store.any_ref().is::<MicrosoftAzure>() {
+                    let meta = store.head(&path).await?;
+                    ParquetObjectReader::new(store, path).with_file_size(meta.size)
+                } else {
+                    ParquetObjectReader::new(store, path)
+                }
             };
             #[cfg(all(feature = "arrow-54", not(feature = "arrow-55")))]
             let mut reader = {

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -272,9 +272,15 @@ impl FileOpener for ParquetOpener {
                 // pointing to azure and if so, do a HEAD request so we can pass in file size to the
                 // reader which will cause the reader to avoid a suffix range request.
                 // see also: https://github.com/delta-io/delta-kernel-rs/issues/968
+                //
+                // TODO(#1010): Note that we don't need this at all and can actually just _always_
+                // do the `with_file_size` but need to (1) update our unit tests which often
+                // hardcode size=0 and (2) update CDF execute which also hardcodes size=0.
                 if let Ok((ObjectStoreScheme::MicrosoftAzure, _)) =
                     ObjectStoreScheme::parse(&file_meta.location)
                 {
+                    // also note doing HEAD then actual GET isn't atomic, and leaves us vulnerable
+                    // to file changing between the two calls.
                     let meta = store.head(&path).await?;
                     ParquetObjectReader::new(store, path).with_file_size(meta.size)
                 } else {


### PR DESCRIPTION
resolves #968 (I hope)

## What changes are proposed in this pull request?
TLDR: Fixes kernel (default-engine) error when trying to read on azure.

`arrow-55` introduced [support for reading parquet metadata via suffix range requests](https://github.com/apache/arrow-rs/pull/7334) but since azure [doesn't support suffix range requests](https://github.com/apache/arrow-rs-object-store/blob/9c43521d3c8e86fdfc4df788a5a63e45e23093b7/src/azure/client.rs#L912-L918) whenever anyone tried reading an azure table with default-engine based on arrow-55 it [blew up](https://github.com/delta-io/delta-kernel-rs/issues/968).

This PR mitigates by re-adding the original `head` request so that we can pass the `file_size` to the `ParquetObjectReader::with_file_size` which states that when this API is used, the reader will ensure only bounded range requests are used:
```rust
/// Provide the byte size of this file.
///
/// If provided, the file size will ensure that only bounded range requests are used. If file
/// size is not provided, the reader will use suffix range requests to fetch the metadata.
///
/// Providing this size up front is an important optimization to avoid extra calls when the
/// underlying store does not support suffix range requests.
///
/// The file size can be obtained using [`ObjectStore::list`] or [`ObjectStore::head`].
pub fn with_file_size(self, file_size: usize) -> Self { ... }
```

## How was this change tested?
tested manually.. painfully manually. spun up a public azure container thing and pointed our example code at it. was able to repro the following error without my changes and observe it going away after changes here applied.
```
Parquet(
    External(
        NotSupported {
            source: "Azure does not support suffix range requests",
        },
    ),
)
```

obviously highlights our test gap. working on setting up some environments to test against S3/ADLS/GCS/etc.