### PR TITLE
[WIP] fix: plumb through correct file_size for all reads

### DIFF
--- a/kernel/src/engine/default/filesystem.rs
+++ b/kernel/src/engine/default/filesystem.rs
@@ -85,9 +85,27 @@ impl<E: TaskExecutor> StorageHandler for ObjectStoreStorageHandler<E> {
         let (sender, receiver) = std::sync::mpsc::sync_channel(4_000);
         let url = path.clone();
         self.task_executor.spawn(async move {
+            // remove prefix "kerneltest/" from prefix
+            println!("old offset: {offset}");
+            println!("old prefix: {prefix}");
+            // let prefix = Path::from_iter(prefix.parts().skip(1));
+            // let offset = Path::from_iter(offset.parts().skip(1));
             let mut stream = store.list_with_offset(Some(&prefix), &offset);
+            println!(
+                "GET {:?}",
+                store
+                    .get(&Path::from(
+                        "checkpoint_table/_delta_log/00000000000000000000.json"
+                    ))
+                    .await
+            );
+
+            println!("Listing files from: {url}");
+            println!("new offset: {offset}");
+            println!("new prefix: {prefix}");
 
             while let Some(meta) = stream.next().await {
+                println!("Listed {meta:?}");
                 match meta {
                     Ok(meta) => {
                         let mut location = url.clone();

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -266,12 +266,12 @@ impl FileOpener for ParquetOpener {
         Ok(Box::pin(async move {
             #[cfg(feature = "arrow-55")]
             use crate::object_store::azure::MicrosoftAzure;
-            use std::any::Any;
+            use crate::AsAny;
             // HACK: unfortunately, `ParquetObjectReader` under the hood does a suffix GET which
             // isn't supported by Azure. For now we just detect if the store is backed by Azure and
             // if so, do a HEAD request so we can pass in file size to the reader which will cause
             // the reader to avoid a suffix GET.
-            let mut reader = if (&store.clone() as &dyn Any).is::<MicrosoftAzure>() {
+            let mut reader = if store.any_ref().is::<MicrosoftAzure>() {
                 let meta = store.head(&path).await?;
                 ParquetObjectReader::new(store, path).with_file_size(meta.size)
             } else {

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -266,14 +266,15 @@ impl FileOpener for ParquetOpener {
         Ok(Box::pin(async move {
             #[cfg(feature = "arrow-55")]
             let mut reader = {
-                use crate::object_store::azure::MicrosoftAzure;
-                use crate::AsAny;
+                use crate::object_store::ObjectStoreScheme;
                 // HACK: unfortunately, `ParquetObjectReader` under the hood does a suffix range
-                // request which isn't supported by Azure. For now we just detect if the store is backed
-                // by Azure and if so, do a HEAD request so we can pass in file size to the reader which
-                // will cause the reader to avoid a suffix range request.
+                // request which isn't supported by Azure. For now we just detect if the URL is
+                // pointing to azure and if so, do a HEAD request so we can pass in file size to the
+                // reader which will cause the reader to avoid a suffix range request.
                 // see also: https://github.com/delta-io/delta-kernel-rs/issues/968
-                if store.any_ref().is::<MicrosoftAzure>() {
+                if let Ok((ObjectStoreScheme::MicrosoftAzure, _)) =
+                    ObjectStoreScheme::parse(&file_meta.location)
+                {
                     let meta = store.head(&path).await?;
                     ParquetObjectReader::new(store, path).with_file_size(meta.size)
                 } else {

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -267,10 +267,11 @@ impl FileOpener for ParquetOpener {
             #[cfg(feature = "arrow-55")]
             use crate::object_store::azure::MicrosoftAzure;
             use crate::AsAny;
-            // HACK: unfortunately, `ParquetObjectReader` under the hood does a suffix GET which
-            // isn't supported by Azure. For now we just detect if the store is backed by Azure and
-            // if so, do a HEAD request so we can pass in file size to the reader which will cause
-            // the reader to avoid a suffix GET.
+            // HACK: unfortunately, `ParquetObjectReader` under the hood does a suffix range
+            // request which isn't supported by Azure. For now we just detect if the store is backed
+            // by Azure and if so, do a HEAD request so we can pass in file size to the reader which
+            // will cause the reader to avoid a suffix range request.
+            // see also: https://github.com/delta-io/delta-kernel-rs/issues/968
             let mut reader = if store.any_ref().is::<MicrosoftAzure>() {
                 let meta = store.head(&path).await?;
                 ParquetObjectReader::new(store, path).with_file_size(meta.size)

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -266,26 +266,11 @@ impl FileOpener for ParquetOpener {
         Ok(Box::pin(async move {
             #[cfg(feature = "arrow-55")]
             let mut reader = {
-                use crate::object_store::ObjectStoreScheme;
-                // HACK: unfortunately, `ParquetObjectReader` under the hood does a suffix range
-                // request which isn't supported by Azure. For now we just detect if the URL is
-                // pointing to azure and if so, do a HEAD request so we can pass in file size to the
-                // reader which will cause the reader to avoid a suffix range request.
-                // see also: https://github.com/delta-io/delta-kernel-rs/issues/968
-                //
-                // TODO(#1010): Note that we don't need this at all and can actually just _always_
-                // do the `with_file_size` but need to (1) update our unit tests which often
-                // hardcode size=0 and (2) update CDF execute which also hardcodes size=0.
-                if let Ok((ObjectStoreScheme::MicrosoftAzure, _)) =
-                    ObjectStoreScheme::parse(&file_meta.location)
-                {
-                    // also note doing HEAD then actual GET isn't atomic, and leaves us vulnerable
-                    // to file changing between the two calls.
-                    let meta = store.head(&path).await?;
-                    ParquetObjectReader::new(store, path).with_file_size(meta.size)
-                } else {
-                    ParquetObjectReader::new(store, path)
-                }
+                println!("Opening parquet file: {}", path);
+                let meta = store.head(&path).await?;
+                println!("File size: {}", file_meta.size);
+                println!("actual file size: {}", meta.size);
+                ParquetObjectReader::new(store, path).with_file_size(file_meta.size)
             };
             #[cfg(all(feature = "arrow-54", not(feature = "arrow-55")))]
             let mut reader = {

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -265,18 +265,20 @@ impl FileOpener for ParquetOpener {
 
         Ok(Box::pin(async move {
             #[cfg(feature = "arrow-55")]
-            use crate::object_store::azure::MicrosoftAzure;
-            use crate::AsAny;
-            // HACK: unfortunately, `ParquetObjectReader` under the hood does a suffix range
-            // request which isn't supported by Azure. For now we just detect if the store is backed
-            // by Azure and if so, do a HEAD request so we can pass in file size to the reader which
-            // will cause the reader to avoid a suffix range request.
-            // see also: https://github.com/delta-io/delta-kernel-rs/issues/968
-            let mut reader = if store.any_ref().is::<MicrosoftAzure>() {
-                let meta = store.head(&path).await?;
-                ParquetObjectReader::new(store, path).with_file_size(meta.size)
-            } else {
-                ParquetObjectReader::new(store, path)
+            let mut reader = {
+                use crate::object_store::azure::MicrosoftAzure;
+                use crate::AsAny;
+                // HACK: unfortunately, `ParquetObjectReader` under the hood does a suffix range
+                // request which isn't supported by Azure. For now we just detect if the store is backed
+                // by Azure and if so, do a HEAD request so we can pass in file size to the reader which
+                // will cause the reader to avoid a suffix range request.
+                // see also: https://github.com/delta-io/delta-kernel-rs/issues/968
+                if store.any_ref().is::<MicrosoftAzure>() {
+                    let meta = store.head(&path).await?;
+                    ParquetObjectReader::new(store, path).with_file_size(meta.size)
+                } else {
+                    ParquetObjectReader::new(store, path)
+                }
             };
             #[cfg(all(feature = "arrow-54", not(feature = "arrow-55")))]
             let mut reader = {

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -272,9 +272,15 @@ impl FileOpener for ParquetOpener {
                 // pointing to azure and if so, do a HEAD request so we can pass in file size to the
                 // reader which will cause the reader to avoid a suffix range request.
                 // see also: https://github.com/delta-io/delta-kernel-rs/issues/968
+                //
+                // TODO(#1010): Note that we don't need this at all and can actually just _always_
+                // do the `with_file_size` but need to (1) update our unit tests which often
+                // hardcode size=0 and (2) update CDF execute which also hardcodes size=0.
                 if let Ok((ObjectStoreScheme::MicrosoftAzure, _)) =
                     ObjectStoreScheme::parse(&file_meta.location)
                 {
+                    // also note doing HEAD then actual GET isn't atomic, and leaves us vulnerable
+                    // to file changing between the two calls.
                     let meta = store.head(&path).await?;
                     ParquetObjectReader::new(store, path).with_file_size(meta.size)
                 } else {

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -1,7 +1,7 @@
 use std::sync::LazyLock;
 use std::{path::PathBuf, sync::Arc};
 
-use crate::object_store::{memory::InMemory, path::Path, ObjectStore};
+use crate::object_store::{memory::InMemory, path::Path, ObjectStore, PutPayload};
 use futures::executor::block_on;
 use itertools::Itertools;
 use test_log::test;
@@ -133,12 +133,13 @@ fn new_in_memory_store() -> (Arc<InMemory>, Url) {
     )
 }
 
-// Writes a record batch obtained from engine data to the in-memory store at a given path.
+// Writes a record batch obtained from engine data to the in-memory store at a given path and
+// returns the size of the written data in bytes.
 fn write_parquet_to_store(
     store: &Arc<InMemory>,
     path: String,
     data: Box<dyn EngineData>,
-) -> DeltaResult<()> {
+) -> DeltaResult<u64> {
     let batch = ArrowEngineData::try_from_engine_data(data)?;
     let record_batch = batch.record_batch();
 
@@ -147,9 +148,10 @@ fn write_parquet_to_store(
     writer.write(record_batch)?;
     writer.close()?;
 
+    let size = buffer.len();
     block_on(async { store.put(&Path::from(path), buffer.into()).await })?;
 
-    Ok(())
+    Ok(size.try_into().unwrap())
 }
 
 /// Writes all actions to a _delta_log parquet checkpoint file in the store.
@@ -158,7 +160,7 @@ pub(crate) fn add_checkpoint_to_store(
     store: &Arc<InMemory>,
     data: Box<dyn EngineData>,
     filename: &str,
-) -> DeltaResult<()> {
+) -> DeltaResult<u64> {
     let path = format!("_delta_log/{}", filename);
     write_parquet_to_store(store, path, data)
 }
@@ -169,18 +171,19 @@ fn add_sidecar_to_store(
     store: &Arc<InMemory>,
     data: Box<dyn EngineData>,
     filename: &str,
-) -> DeltaResult<()> {
+) -> DeltaResult<u64> {
     let path = format!("_delta_log/_sidecars/{}", filename);
     write_parquet_to_store(store, path, data)
 }
 
 /// Writes all actions to a _delta_log json checkpoint file in the store.
 /// This function formats the provided filename into the _delta_log directory.
+/// Returns number of bytes written.
 fn write_json_to_store(
     store: &Arc<InMemory>,
     actions: Vec<Action>,
     filename: &str,
-) -> DeltaResult<()> {
+) -> DeltaResult<u64> {
     let json_lines: Vec<String> = actions
         .into_iter()
         .map(|action| serde_json::to_string(&action).expect("action to string"))
@@ -188,22 +191,20 @@ fn write_json_to_store(
     let content = json_lines.join("\n");
     let checkpoint_path = format!("_delta_log/{}", filename);
 
+    let content: PutPayload = content.into();
+    let len = content.content_length();
     tokio::runtime::Runtime::new()
         .expect("create tokio runtime")
-        .block_on(async {
-            store
-                .put(&Path::from(checkpoint_path), content.into())
-                .await
-        })?;
+        .block_on(async { store.put(&Path::from(checkpoint_path), content).await })?;
 
-    Ok(())
+    Ok(len.try_into().unwrap())
 }
 
-fn create_log_path(path: &str) -> ParsedLogPath<FileMeta> {
+fn create_log_path(path: &str, size: u64) -> ParsedLogPath<FileMeta> {
     ParsedLogPath::try_from(FileMeta {
         location: Url::parse(path).expect("Invalid file URL"),
         last_modified: 0,
-        size: 0,
+        size,
     })
     .unwrap()
     .unwrap()
@@ -858,19 +859,22 @@ fn test_checkpoint_batch_with_sidecars_returns_sidecar_batches() -> DeltaResult<
     let engine = DefaultEngine::new(store.clone(), Arc::new(TokioBackgroundExecutor::new()));
     let read_schema = get_log_schema().project(&[ADD_NAME, REMOVE_NAME, SIDECAR_NAME])?;
 
-    add_sidecar_to_store(
+    let size1 = add_sidecar_to_store(
         &store,
         add_batch_simple(read_schema.clone()),
         "sidecarfile1.parquet",
     )?;
-    add_sidecar_to_store(
+    let size2 = add_sidecar_to_store(
         &store,
         add_batch_with_remove(read_schema.clone()),
         "sidecarfile2.parquet",
     )?;
 
     let checkpoint_batch = sidecar_batch_with_given_paths(
-        vec!["sidecarfile1.parquet", "sidecarfile2.parquet"],
+        vec![
+            ("sidecarfile1.parquet", size1),
+            ("sidecarfile2.parquet", size2),
+        ],
         read_schema.clone(),
     );
 
@@ -898,7 +902,7 @@ fn test_checkpoint_batch_with_sidecar_files_that_do_not_exist() -> DeltaResult<(
     let engine = DefaultEngine::new(store.clone(), Arc::new(TokioBackgroundExecutor::new()));
 
     let checkpoint_batch = sidecar_batch_with_given_paths(
-        vec!["sidecarfile1.parquet", "sidecarfile2.parquet"],
+        vec![("sidecarfile1.parquet", 1), ("sidecarfile2.parquet", 2)],
         get_log_schema().clone(),
     );
 
@@ -925,15 +929,14 @@ fn test_reading_sidecar_files_with_predicate() -> DeltaResult<()> {
     let engine = DefaultEngine::new(store.clone(), Arc::new(TokioBackgroundExecutor::new()));
     let read_schema = get_log_schema().project(&[ADD_NAME, REMOVE_NAME, SIDECAR_NAME])?;
 
-    let checkpoint_batch =
-        sidecar_batch_with_given_paths(vec!["sidecarfile1.parquet"], read_schema.clone());
-
     // Add a sidecar file with only add actions
-    add_sidecar_to_store(
+    let size = add_sidecar_to_store(
         &store,
         add_batch_simple(read_schema.clone()),
         "sidecarfile1.parquet",
     )?;
+    let checkpoint_batch =
+        sidecar_batch_with_given_paths(vec![("sidecarfile1.parquet", size)], read_schema.clone());
 
     // Filter out sidecar files that do not contain remove actions
     let remove_predicate: LazyLock<Option<PredicateRef>> = LazyLock::new(|| {
@@ -971,6 +974,7 @@ fn test_create_checkpoint_stream_errors_when_schema_has_remove_but_no_sidecar_ac
             vec![],
             vec![create_log_path(
                 "file:///00000000000000000001.checkpoint.parquet",
+                100,
             )],
             None,
         ),
@@ -1002,6 +1006,7 @@ fn test_create_checkpoint_stream_errors_when_schema_has_add_but_no_sidecar_actio
             vec![],
             vec![create_log_path(
                 "file:///00000000000000000001.checkpoint.parquet",
+                100,
             )],
             None,
         ),
@@ -1021,10 +1026,10 @@ fn test_create_checkpoint_stream_returns_checkpoint_batches_as_is_if_schema_has_
 ) -> DeltaResult<()> {
     let (store, log_root) = new_in_memory_store();
     let engine = DefaultEngine::new(store.clone(), Arc::new(TokioBackgroundExecutor::new()));
-    add_checkpoint_to_store(
+    let checkpoint_size = add_checkpoint_to_store(
         &store,
         // Create a checkpoint batch with sidecar actions to verify that the sidecar actions are not read.
-        sidecar_batch_with_given_paths(vec!["sidecar1.parquet"], get_log_schema().clone()),
+        sidecar_batch_with_given_paths(vec![("sidecar1.parquet", 1)], get_log_schema().clone()),
         "00000000000000000001.checkpoint.parquet",
     )?;
 
@@ -1038,7 +1043,7 @@ fn test_create_checkpoint_stream_returns_checkpoint_batches_as_is_if_schema_has_
         ListedLogFiles::new(
             vec![],
             vec![],
-            vec![create_log_path(&checkpoint_one_file)],
+            vec![create_log_path(&checkpoint_one_file, checkpoint_size)],
             None,
         ),
         log_root,
@@ -1055,7 +1060,7 @@ fn test_create_checkpoint_stream_returns_checkpoint_batches_as_is_if_schema_has_
     assert!(!is_log_batch);
     assert_batch_matches(
         first_batch,
-        sidecar_batch_with_given_paths(vec!["sidecar1.parquet"], v2_checkpoint_read_schema),
+        sidecar_batch_with_given_paths(vec![("sidecar1.parquet", 1)], v2_checkpoint_read_schema),
     );
     assert!(iter.next().is_none());
 
@@ -1077,14 +1082,14 @@ fn test_create_checkpoint_stream_returns_checkpoint_batches_if_checkpoint_is_mul
     let checkpoint_part_1 = "00000000000000000001.checkpoint.0000000001.0000000002.parquet";
     let checkpoint_part_2 = "00000000000000000001.checkpoint.0000000002.0000000002.parquet";
 
-    add_checkpoint_to_store(
+    let checkpoint1_size = add_checkpoint_to_store(
         &store,
-        sidecar_batch_with_given_paths(vec!["sidecar1.parquet"], get_log_schema().clone()),
+        sidecar_batch_with_given_paths(vec![("sidecar1.parquet", 1)], get_log_schema().clone()),
         checkpoint_part_1,
     )?;
-    add_checkpoint_to_store(
+    let checkpoint2_size = add_checkpoint_to_store(
         &store,
-        sidecar_batch_with_given_paths(vec!["sidecar2.parquet"], get_log_schema().clone()),
+        sidecar_batch_with_given_paths(vec![("sidecar2.parquet", 1)], get_log_schema().clone()),
         checkpoint_part_2,
     )?;
 
@@ -1098,8 +1103,8 @@ fn test_create_checkpoint_stream_returns_checkpoint_batches_if_checkpoint_is_mul
             vec![],
             vec![],
             vec![
-                create_log_path(&checkpoint_one_file),
-                create_log_path(&checkpoint_two_file),
+                create_log_path(&checkpoint_one_file, checkpoint1_size),
+                create_log_path(&checkpoint_two_file, checkpoint2_size),
             ],
             None,
         ),
@@ -1119,7 +1124,7 @@ fn test_create_checkpoint_stream_returns_checkpoint_batches_if_checkpoint_is_mul
         assert_batch_matches(
             batch,
             sidecar_batch_with_given_paths(
-                vec![expected_sidecar],
+                vec![(expected_sidecar, 1)],
                 v2_checkpoint_read_schema.clone(),
             ),
         );
@@ -1135,7 +1140,7 @@ fn test_create_checkpoint_stream_reads_parquet_checkpoint_batch_without_sidecars
     let (store, log_root) = new_in_memory_store();
     let engine = DefaultEngine::new(store.clone(), Arc::new(TokioBackgroundExecutor::new()));
 
-    add_checkpoint_to_store(
+    let checkpoint1_size = add_checkpoint_to_store(
         &store,
         add_batch_simple(get_log_schema().clone()),
         "00000000000000000001.checkpoint.parquet",
@@ -1151,7 +1156,7 @@ fn test_create_checkpoint_stream_reads_parquet_checkpoint_batch_without_sidecars
         ListedLogFiles::new(
             vec![],
             vec![],
-            vec![create_log_path(&checkpoint_one_file)],
+            vec![create_log_path(&checkpoint_one_file, checkpoint1_size)],
             None,
         ),
         log_root,
@@ -1179,7 +1184,7 @@ fn test_create_checkpoint_stream_reads_json_checkpoint_batch_without_sidecars() 
 
     let filename = "00000000000000000010.checkpoint.80a083e8-7026-4e79-81be-64bd76c43a11.json";
 
-    write_json_to_store(
+    let checkpoint_size = write_json_to_store(
         &store,
         vec![Action::Add(Add {
             path: "fake_path_1".into(),
@@ -1197,7 +1202,7 @@ fn test_create_checkpoint_stream_reads_json_checkpoint_batch_without_sidecars() 
         ListedLogFiles::new(
             vec![],
             vec![],
-            vec![create_log_path(&checkpoint_one_file)],
+            vec![create_log_path(&checkpoint_one_file, checkpoint_size)],
             None,
         ),
         log_root,
@@ -1234,24 +1239,27 @@ fn test_create_checkpoint_stream_reads_checkpoint_file_and_returns_sidecar_batch
     let (store, log_root) = new_in_memory_store();
     let engine = DefaultEngine::new(store.clone(), Arc::new(TokioBackgroundExecutor::new()));
 
-    add_checkpoint_to_store(
-        &store,
-        sidecar_batch_with_given_paths(
-            vec!["sidecarfile1.parquet", "sidecarfile2.parquet"],
-            get_log_schema().clone(),
-        ),
-        "00000000000000000001.checkpoint.parquet",
-    )?;
-
-    add_sidecar_to_store(
+    let size1 = add_sidecar_to_store(
         &store,
         add_batch_simple(get_log_schema().project(&[ADD_NAME, REMOVE_NAME])?),
         "sidecarfile1.parquet",
     )?;
-    add_sidecar_to_store(
+    let size2 = add_sidecar_to_store(
         &store,
         add_batch_with_remove(get_log_schema().project(&[ADD_NAME, REMOVE_NAME])?),
         "sidecarfile2.parquet",
+    )?;
+
+    let checkpoint_size = add_checkpoint_to_store(
+        &store,
+        sidecar_batch_with_given_paths(
+            vec![
+                ("sidecarfile1.parquet", size1),
+                ("sidecarfile2.parquet", size2),
+            ],
+            get_log_schema().clone(),
+        ),
+        "00000000000000000001.checkpoint.parquet",
     )?;
 
     let checkpoint_file_path = log_root
@@ -1264,7 +1272,7 @@ fn test_create_checkpoint_stream_reads_checkpoint_file_and_returns_sidecar_batch
         ListedLogFiles::new(
             vec![],
             vec![],
-            vec![create_log_path(&checkpoint_file_path)],
+            vec![create_log_path(&checkpoint_file_path, checkpoint_size)],
             None,
         ),
         log_root,
@@ -1282,7 +1290,10 @@ fn test_create_checkpoint_stream_reads_checkpoint_file_and_returns_sidecar_batch
     assert_batch_matches(
         first_batch,
         sidecar_batch_with_given_paths(
-            vec!["sidecarfile1.parquet", "sidecarfile2.parquet"],
+            vec![
+                ("sidecarfile1.parquet", size1),
+                ("sidecarfile2.parquet", size2),
+            ],
             get_log_schema().project(&[ADD_NAME, SIDECAR_NAME])?,
         ),
     );
@@ -1694,8 +1705,14 @@ fn test_debug_assert_listed_log_file_in_order_compaction_files() {
     let _ = ListedLogFiles::new(
         vec![],
         vec![
-            create_log_path("file:///00000000000000000000.00000000000000000004.compacted.json"),
-            create_log_path("file:///00000000000000000001.00000000000000000002.compacted.json"),
+            create_log_path(
+                "file:///00000000000000000000.00000000000000000004.compacted.json",
+                1,
+            ),
+            create_log_path(
+                "file:///00000000000000000001.00000000000000000002.compacted.json",
+                1,
+            ),
         ],
         vec![],
         None,
@@ -1709,8 +1726,14 @@ fn test_debug_assert_listed_log_file_out_of_order_compaction_files() {
     let _ = ListedLogFiles::new(
         vec![],
         vec![
-            create_log_path("file:///00000000000000000000.00000000000000000004.compacted.json"),
-            create_log_path("file:///00000000000000000000.00000000000000000003.compacted.json"),
+            create_log_path(
+                "file:///00000000000000000000.00000000000000000004.compacted.json",
+                1,
+            ),
+            create_log_path(
+                "file:///00000000000000000000.00000000000000000003.compacted.json",
+                1,
+            ),
         ],
         vec![],
         None,
@@ -1725,8 +1748,14 @@ fn test_debug_assert_listed_log_file_different_multipart_checkpoint_versions() {
         vec![],
         vec![],
         vec![
-            create_log_path("00000000000000000010.checkpoint.0000000001.0000000002.parquet"),
-            create_log_path("00000000000000000011.checkpoint.0000000002.0000000002.parquet"),
+            create_log_path(
+                "00000000000000000010.checkpoint.0000000001.0000000002.parquet",
+                1,
+            ),
+            create_log_path(
+                "00000000000000000011.checkpoint.0000000002.0000000002.parquet",
+                1,
+            ),
         ],
         None,
     );
@@ -1740,8 +1769,14 @@ fn test_debug_assert_listed_log_file_invalid_multipart_checkpoint() {
         vec![],
         vec![],
         vec![
-            create_log_path("00000000000000000010.checkpoint.0000000001.0000000003.parquet"),
-            create_log_path("00000000000000000011.checkpoint.0000000002.0000000003.parquet"),
+            create_log_path(
+                "00000000000000000010.checkpoint.0000000001.0000000003.parquet",
+                1,
+            ),
+            create_log_path(
+                "00000000000000000011.checkpoint.0000000002.0000000003.parquet",
+                1,
+            ),
         ],
         None,
     );

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -884,16 +884,16 @@ pub(crate) mod test_utils {
     // Generates a batch of sidecar actions with the given paths.
     // The schema is provided as null columns affect equality checks.
     pub(crate) fn sidecar_batch_with_given_paths(
-        paths: Vec<&str>,
+        path_sizes: Vec<(&str, u64)>,
         output_schema: SchemaRef,
     ) -> Box<ArrowEngineData> {
         let handler = SyncJsonHandler {};
 
-        let mut json_strings: Vec<String> = paths
+        let mut json_strings: Vec<String> = path_sizes
         .iter()
-        .map(|path| {
+        .map(|(path, size)| {
             format!(
-                r#"{{"sidecar":{{"path":"{path}","sizeInBytes":9268,"modificationTime":1714496113961,"tags":{{"tag_foo":"tag_bar"}}}}}}"#
+                r#"{{"sidecar":{{"path":"{path}","sizeInBytes":{size},"modificationTime":1714496113961,"tags":{{"tag_foo":"tag_bar"}}}}}}"#
             )
         })
         .collect();

--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -297,9 +297,10 @@ fn read_scan_file(
     let is_dv_resolved_pair = scan_file.remove_dv.is_some();
 
     let location = table_root.join(&scan_file.path)?;
+    let size = scan_file.size;
     let file = FileMeta {
         last_modified: 0,
-        size: 0,
+        size,
         location,
     };
     // TODO(#860): we disable predicate pushdown until we support row indexes.

--- a/kernel/src/table_changes/scan_file.rs
+++ b/kernel/src/table_changes/scan_file.rs
@@ -32,6 +32,8 @@ pub(crate) struct CdfScanFile {
     pub scan_type: CdfScanFileType,
     /// A `&str` which is the path to the file
     pub path: String,
+    /// The size of the file
+    pub size: i64,
     /// A [`DvInfo`] struct with the path to the action's deletion vector
     pub dv_info: DvInfo,
     /// An optional [`DvInfo`] struct. If present, this is deletion vector of a remove action with
@@ -155,6 +157,7 @@ impl<T> RowVisitor for CdfScanFileVisitor<'_, T> {
                 remove_dv: self.remove_dvs.get(&path).cloned(),
                 scan_type,
                 path,
+                size,
                 dv_info: DvInfo { deletion_vector },
                 partition_values,
                 commit_timestamp: getters[16].get(row_index, "scanFile.timestamp")?,
@@ -188,6 +191,7 @@ pub(crate) fn cdf_scan_row_schema() -> SchemaRef {
 
         let add = StructType::new([
             StructField::nullable("path", DataType::STRING),
+            StructField::nullable("size", DataType::LONG),
             StructField::nullable("deletionVector", deletion_vector.clone()),
             StructField::nullable("fileConstantValues", file_constant_values.clone()),
         ]);


### PR DESCRIPTION
resolves #1010 

## What changes are proposed in this pull request?
wip: plumb through file_size for all our reads


### This PR affects the following public APIs
CDF scan metadata schema


## How was this change tested?
modified UT