### PR TITLE
refactor!: txn-specific write_metadata_schema

### DIFF
--- a/kernel/src/engine/default/mod.rs
+++ b/kernel/src/engine/default/mod.rs
@@ -113,6 +113,7 @@ impl<E: TaskExecutor> DefaultEngine<E> {
             .write_parquet_file(
                 write_context.target_dir(),
                 physical_data,
+                write_context.write_metadata_schema().clone(),
                 partition_values,
                 data_change,
             )

--- a/kernel/src/transaction.rs
+++ b/kernel/src/transaction.rs
@@ -230,7 +230,7 @@ impl Transaction {
     /// Add write metadata about files to include in the transaction. This API can be called
     /// multiple times to add multiple batches.
     ///
-    /// The expected schema for `write_metadata` is given by [`get_write_metadata_schema`].
+    /// The expected schema for `write_metadata` is given by [`WriteContext::write_metadata_schema`].
     pub fn add_write_metadata(&mut self, write_metadata: Box<dyn EngineData>) {
         self.write_metadata.push(write_metadata);
     }


### PR DESCRIPTION
## What changes are proposed in this pull request?
On the way to supporting `stats` in writes, we must allow for the `write_metadata_schema` to be specified per-txn/table instead of globally since the schema for write_metadata_schema will eventually include a stats column which is a function of the table schema.

Concretely, this PR
1. removes the global `transaction::get_write_metadata_schema()`
2. adds `write_metadata_schema()` to `WriteContext` (and plumbs the schema through)

Note that the actual naming will change in https://github.com/delta-io/delta-kernel-rs/pull/1019
 
### This PR affects the following public APIs

The (static) `transaction::get_write_metadata_schema()` is now a method: `WriteContext::write_metadata_schema()` (and the `WriteContext` is derived from a specific `Transaction`.

## How was this change tested?
minor modifications to existing UT