### PR TITLE
fix: support arrow views in ensure_data_types

### DIFF
--- a/kernel/src/engine/ensure_data_types.rs
+++ b/kernel/src/engine/ensure_data_types.rs
@@ -44,6 +44,7 @@ struct EnsureDataTypes {
 }
 
 /// Capture the compatibility between two data-types, as passed to [`ensure_data_types`]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum DataTypeCompat {
     /// The two types are the same
     Identical,
@@ -68,8 +69,13 @@ impl EnsureDataTypes {
             // strings, bools, and binary  aren't primitive in arrow
             (&DataType::BOOLEAN, ArrowDataType::Boolean)
             | (&DataType::STRING, ArrowDataType::Utf8)
+            | (&DataType::STRING, ArrowDataType::Utf8View)
+            | (&DataType::BINARY, ArrowDataType::BinaryView)
             | (&DataType::BINARY, ArrowDataType::Binary) => Ok(DataTypeCompat::Identical),
-            (DataType::Array(inner_type), ArrowDataType::List(arrow_list_field)) => {
+            (DataType::Array(inner_type), ArrowDataType::List(arrow_list_field))
+            | (DataType::Array(inner_type), ArrowDataType::LargeList(arrow_list_field))
+            | (DataType::Array(inner_type), ArrowDataType::ListView(arrow_list_field))
+            | (DataType::Array(inner_type), ArrowDataType::LargeListView(arrow_list_field)) => {
                 self.ensure_nullability(
                     "List",
                     inner_type.contains_null,
@@ -257,6 +263,8 @@ fn metadata_eq(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use crate::arrow::datatypes::{DataType as ArrowDataType, Field as ArrowField, Fields};
 
     use crate::engine::arrow_conversion::TryFromKernel as _;
@@ -386,6 +394,12 @@ mod tests {
         )
         .is_ok());
         assert!(ensure_data_types(
+            &DataType::Array(Box::new(ArrayType::new(DataType::LONG, true))),
+            &ArrowDataType::new_large_list(ArrowDataType::Int64, true),
+            false
+        )
+        .is_ok());
+        assert!(ensure_data_types(
             &DataType::Array(Box::new(ArrayType::new(DataType::STRING, true))),
             &ArrowDataType::new_list(ArrowDataType::Int64, true),
             false
@@ -461,5 +475,41 @@ mod tests {
             true
         )
         .is_err());
+    }
+
+    #[test]
+    fn ensure_views() {
+        assert_eq!(
+            ensure_data_types(&DataType::STRING, &ArrowDataType::Utf8View, true).unwrap(),
+            DataTypeCompat::Identical
+        );
+        assert_eq!(
+            ensure_data_types(&DataType::BINARY, &ArrowDataType::BinaryView, true).unwrap(),
+            DataTypeCompat::Identical
+        );
+        assert_eq!(
+            ensure_data_types(
+                &DataType::Array(Box::new(ArrayType::new(DataType::LONG, true))),
+                &ArrowDataType::ListView(Arc::new(ArrowField::new_list_field(
+                    ArrowDataType::Int64,
+                    true
+                ))),
+                true
+            )
+            .unwrap(),
+            DataTypeCompat::Identical
+        );
+        assert_eq!(
+            ensure_data_types(
+                &DataType::Array(Box::new(ArrayType::new(DataType::LONG, true))),
+                &ArrowDataType::LargeListView(Arc::new(ArrowField::new_list_field(
+                    ArrowDataType::Int64,
+                    true
+                ))),
+                true
+            )
+            .unwrap(),
+            DataTypeCompat::Identical
+        );
     }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?
We landed support for Arrow view types in #533 but didn't make modifications to `ensure_data_types`, meaning users would hit `Incorrect datatype. Expected string, got Utf8View`

This adds:
kernel's `BINARY` = `BinaryView`
kernel's `STRING` = `Utf8View`
kernel's `Array` = `ListView`
kernel's `Array` = `LargeListView`
(and ran across a missing `LargeList` equivalence, so added:)
kernel's `Array` = `LargeList`

While we're at it, I derive `Debug`, `Clone`, `PartialEq`, `Eq` on our internal `DataTypeCompat` for ease of use (needed `PartialEq` in tests)

## How was this change tested?
new UT

resolves #1027