### PR TITLE
fix: Clippy fmt cleanup

### DIFF
--- a/acceptance/build.rs
+++ b/acceptance/build.rs
@@ -29,8 +29,7 @@ fn dat_exists() -> bool {
 
 fn download_dat_files() -> Vec<u8> {
     let tarball_url = format!(
-        "https://github.com/delta-incubator/dat/releases/download/v{version}/deltalake-dat-v{version}.tar.gz",
-        version = VERSION
+        "https://github.com/delta-incubator/dat/releases/download/v{VERSION}/deltalake-dat-v{VERSION}.tar.gz"
     );
 
     let response = if let Ok(proxy_url) = env::var("HTTPS_PROXY") {

--- a/acceptance/src/meta.rs
+++ b/acceptance/src/meta.rs
@@ -147,6 +147,6 @@ mod tests {
         let path = PathBuf::from("./tests/dat/out/reader_tests/generated/with_schema_change");
         let case = read_dat_case(path).unwrap();
         let versions = case.versions().await.unwrap();
-        println!("{:?}", versions)
+        println!("{versions:?}")
     }
 }

--- a/acceptance/tests/dat_reader.rs
+++ b/acceptance/tests/dat_reader.rs
@@ -16,7 +16,7 @@ fn reader_test(path: &Path) -> datatest_stable::Result<()> {
     );
     for skipped in SKIPPED_TESTS {
         if root_dir.ends_with(skipped) {
-            println!("Skipping test: {}", skipped);
+            println!("Skipping test: {skipped}");
             return Ok(());
         }
     }

--- a/derive-macros/src/lib.rs
+++ b/derive-macros/src/lib.rs
@@ -241,7 +241,7 @@ fn make_public(mut item: Item) -> Item {
         // foreign mod, impl block, and all others not handled
         _ => Err(Error::new(
             item.span(),
-            format!("unsupported item type for #[internal_api]: {:?}", item),
+            format!("unsupported item type for #[internal_api]: {item:?}"),
         )),
     };
 

--- a/ffi-proc-macros/src/lib.rs
+++ b/ffi-proc-macros/src/lib.rs
@@ -56,7 +56,7 @@ impl Parse for HandleDescriptorParams {
                 field => {
                     return Err(Error::new(
                         ident.span(),
-                        format!("unknown or duplicated field `{}`", field),
+                        format!("unknown or duplicated field `{field}`"),
                     ));
                 }
             }

--- a/ffi/build.rs
+++ b/ffi/build.rs
@@ -26,7 +26,7 @@ fn main() {
 
     // generate cxx bindings
     let output_file_hpp = target_dir
-        .join(format!("{}.hpp", package_name))
+        .join(format!("{package_name}.hpp"))
         .display()
         .to_string();
     let mut config_hpp = config.clone();
@@ -37,7 +37,7 @@ fn main() {
 
     // generate c bindings
     let output_file_h = target_dir
-        .join(format!("{}.h", package_name))
+        .join(format!("{package_name}.h"))
         .display()
         .to_string();
     config.language = Language::C;

--- a/ffi/src/error.rs
+++ b/ffi/src/error.rs
@@ -214,7 +214,7 @@ impl<T> IntoExternResult<T> for DeltaResult<T> {
         match self {
             Ok(ok) => ExternResult::Ok(ok),
             Err(err) => {
-                let msg = format!("{}", err);
+                let msg = format!("{err}");
                 let err = unsafe { alloc.allocate_error(err.into(), kernel_string_slice!(msg)) };
                 ExternResult::Err(err)
             }

--- a/ffi/src/ffi_tracing.rs
+++ b/ffi/src/ffi_tracing.rs
@@ -230,7 +230,7 @@ struct MessageFieldVisitor {
 impl Visit for MessageFieldVisitor {
     fn record_debug(&mut self, field: &TracingField, value: &dyn fmt::Debug) {
         if field.name() == "message" {
-            self.message = Some(format!("{:?}", value));
+            self.message = Some(format!("{value:?}"));
         }
     }
 
@@ -577,7 +577,7 @@ mod tests {
 
         // file path will use \ on windows
         use std::path::MAIN_SEPARATOR;
-        let expected_file = format!("ffi{}src{}ffi_tracing.rs", MAIN_SEPARATOR, MAIN_SEPARATOR);
+        let expected_file = format!("ffi{MAIN_SEPARATOR}src{MAIN_SEPARATOR}ffi_tracing.rs");
 
         let ok = event.level == Level::INFO
             && target == "delta_kernel_ffi::ffi_tracing::tests"

--- a/kernel/examples/inspect-table/src/main.rs
+++ b/kernel/examples/inspect-table/src/main.rs
@@ -230,12 +230,12 @@ fn try_main() -> DeltaResult<()> {
             }
             for (action, row) in visitor.actions.iter() {
                 match action {
-                    Action::Metadata(md) => println!("\nAction {row}:\n{:#?}", md),
-                    Action::Protocol(p) => println!("\nAction {row}:\n{:#?}", p),
-                    Action::Remove(r) => println!("\nAction {row}:\n{:#?}", r),
-                    Action::Add(a) => println!("\nAction {row}:\n{:#?}", a),
-                    Action::SetTransaction(t) => println!("\nAction {row}:\n{:#?}", t),
-                    Action::Cdc(c) => println!("\nAction {row}:\n{:#?}", c),
+                    Action::Metadata(md) => println!("\nAction {row}:\n{md:#?}"),
+                    Action::Protocol(p) => println!("\nAction {row}:\n{p:#?}"),
+                    Action::Remove(r) => println!("\nAction {row}:\n{r:#?}"),
+                    Action::Add(a) => println!("\nAction {row}:\n{a:#?}"),
+                    Action::SetTransaction(t) => println!("\nAction {row}:\n{t:#?}"),
+                    Action::Cdc(c) => println!("\nAction {row}:\n{c:#?}"),
                 }
             }
         }

--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -414,7 +414,7 @@ impl CheckpointWriter {
             retention_duration,
             SystemTime::now()
                 .duration_since(UNIX_EPOCH)
-                .map_err(|e| Error::generic(format!("Failed to calculate system time: {}", e)))?,
+                .map_err(|e| Error::generic(format!("Failed to calculate system time: {e}")))?,
         )
     }
 }

--- a/kernel/src/engine/default/json.rs
+++ b/kernel/src/engine/default/json.rs
@@ -310,7 +310,7 @@ mod tests {
             let mut seen = HashSet::new();
             for key in ordered_keys.iter() {
                 if !seen.insert(key) {
-                    panic!("Duplicate key in OrderedGetStore: {}", key);
+                    panic!("Duplicate key in OrderedGetStore: {key}");
                 }
             }
 
@@ -571,7 +571,7 @@ mod tests {
         // note we don't want to go over 1000 since we only buffer 1000 requests at a time
         let num_paths = 1000;
         let ordered_paths: Vec<Path> = (0..num_paths)
-            .map(|i| Path::from(format!("/test/path{}", i)))
+            .map(|i| Path::from(format!("/test/path{i}")))
             .collect();
         let jumbled_paths: Vec<_> = ordered_paths[100..400]
             .iter()
@@ -583,7 +583,7 @@ mod tests {
         let memory_store = InMemory::new();
         for (i, path) in ordered_paths.iter().enumerate() {
             memory_store
-                .put(path, Bytes::from(format!("content_{}", i)).into())
+                .put(path, Bytes::from(format!("content_{i}")).into())
                 .await
                 .unwrap();
         }
@@ -632,7 +632,7 @@ mod tests {
         // 2. we then set up an ObjectStore to resolves those paths in a jumbled order
         // 3. then call read_json_files and check that the results are in order
         let ordered_paths: Vec<Path> = (0..1000)
-            .map(|i| Path::from(format!("test/path{}", i)))
+            .map(|i| Path::from(format!("test/path{i}")))
             .collect();
 
         let test_list: &[(usize, Vec<Path>)] = &[
@@ -680,7 +680,7 @@ mod tests {
                 .map(|path| {
                     let store = store.clone();
                     async move {
-                        let url = Url::parse(&format!("memory:/{}", path)).unwrap();
+                        let url = Url::parse(&format!("memory:/{path}")).unwrap();
                         let location = Path::from(path.as_ref());
                         let meta = store.head(&location).await.unwrap();
                         let meta_size = meta.size;
@@ -801,7 +801,7 @@ mod tests {
                 Err(Error::FileAlreadyExists(err_path)) => {
                     assert_eq!(err_path, object_path.to_string());
                 }
-                _ => panic!("Expected FileAlreadyExists error, got: {:?}", result),
+                _ => panic!("Expected FileAlreadyExists error, got: {result:?}"),
             }
         }
 

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -137,8 +137,7 @@ impl<E: TaskExecutor> DefaultParquetHandler<E> {
         // fail if path does not end with a trailing slash
         if !path.path().ends_with('/') {
             return Err(Error::generic(format!(
-                "Path must end with a trailing slash: {}",
-                path
+                "Path must end with a trailing slash: {path}"
             )));
         }
         let path = path.join(&name)?;

--- a/kernel/src/engine/ensure_data_types.rs
+++ b/kernel/src/engine/ensure_data_types.rs
@@ -121,15 +121,13 @@ impl EnsureDataTypes {
                         .take(5)
                         .join(", ");
                     make_arrow_error(format!(
-                        "Missing Struct fields {} (Up to five missing fields shown)",
-                        missing_field_names
+                        "Missing Struct fields {missing_field_names} (Up to five missing fields shown)"
                     ))
                 });
                 Ok(DataTypeCompat::Nested)
             }
             _ => Err(make_arrow_error(format!(
-                "Incorrect datatype. Expected {}, got {}",
-                kernel_type, arrow_type
+                "Incorrect datatype. Expected {kernel_type}, got {arrow_type}"
             ))),
         }
     }
@@ -144,8 +142,7 @@ impl EnsureDataTypes {
             && kernel_field_is_nullable != arrow_field_is_nullable
         {
             Err(Error::Generic(format!(
-                "{desc} has nullablily {} in kernel and {} in arrow",
-                kernel_field_is_nullable, arrow_field_is_nullable,
+                "{desc} has nullablily {kernel_field_is_nullable} in kernel and {arrow_field_is_nullable} in arrow",
             )))
         } else {
             Ok(())
@@ -200,8 +197,7 @@ fn check_cast_compat(
         }
         (Date32, Timestamp(_, None)) => Ok(DataTypeCompat::NeedsCast(target_type)),
         _ => Err(make_arrow_error(format!(
-            "Incorrect datatype. Expected {}, got {}",
-            target_type, source_type
+            "Incorrect datatype. Expected {target_type}, got {source_type}"
         ))),
     }
 }

--- a/kernel/src/engine/sync/json.rs
+++ b/kernel/src/engine/sync/json.rs
@@ -60,8 +60,7 @@ impl JsonHandler for SyncJsonHandler {
             .map_err(|_| crate::Error::generic("sync client can only read local files"))?;
         let Some(parent) = path.parent() else {
             return Err(crate::Error::generic(format!(
-                "no parent found for {:?}",
-                path
+                "no parent found for {path:?}"
             )));
         };
 
@@ -167,7 +166,7 @@ mod tests {
                 Err(Error::FileAlreadyExists(err_path)) => {
                     assert_eq!(err_path, path.to_string_lossy().to_string());
                 }
-                _ => panic!("Expected FileAlreadyExists error, got: {:?}", result),
+                _ => panic!("Expected FileAlreadyExists error, got: {result:?}"),
             }
         }
 

--- a/kernel/src/engine/sync/storage.rs
+++ b/kernel/src/engine/sync/storage.rs
@@ -15,7 +15,7 @@ impl StorageHandler for SyncStorageHandler {
     ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<FileMeta>>>> {
         if url_path.scheme() == "file" {
             let path = url_path.to_file_path().map_err(|_| {
-                Error::Generic(format!("Invalid path for list_from: {:?}", url_path))
+                Error::Generic(format!("Invalid path for list_from: {url_path:?}"))
             })?;
 
             let (path_to_read, min_file_name) = if path.is_dir() {
@@ -27,11 +27,11 @@ impl StorageHandler for SyncStorageHandler {
                 let parent = path
                     .parent()
                     .ok_or_else(|| {
-                        Error::Generic(format!("Invalid path for list_from: {:?}", path))
+                        Error::Generic(format!("Invalid path for list_from: {path:?}"))
                     })?
                     .to_path_buf();
                 let file_name = path.file_name().ok_or_else(|| {
-                    Error::Generic(format!("Invalid path for list_from: {:?}", path))
+                    Error::Generic(format!("Invalid path for list_from: {path:?}"))
                 })?;
                 (parent, Some(file_name))
             };

--- a/kernel/src/engine/sync/storage.rs
+++ b/kernel/src/engine/sync/storage.rs
@@ -14,9 +14,9 @@ impl StorageHandler for SyncStorageHandler {
         url_path: &Url,
     ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<FileMeta>>>> {
         if url_path.scheme() == "file" {
-            let path = url_path.to_file_path().map_err(|_| {
-                Error::Generic(format!("Invalid path for list_from: {url_path:?}"))
-            })?;
+            let path = url_path
+                .to_file_path()
+                .map_err(|_| Error::Generic(format!("Invalid path for list_from: {url_path:?}")))?;
 
             let (path_to_read, min_file_name) = if path.is_dir() {
                 // passed path is an existing dir, don't strip anything and don't filter the results
@@ -26,9 +26,7 @@ impl StorageHandler for SyncStorageHandler {
                 // that and use it as the min_file_name to return
                 let parent = path
                     .parent()
-                    .ok_or_else(|| {
-                        Error::Generic(format!("Invalid path for list_from: {path:?}"))
-                    })?
+                    .ok_or_else(|| Error::Generic(format!("Invalid path for list_from: {path:?}")))?
                     .to_path_buf();
                 let file_name = path.file_name().ok_or_else(|| {
                     Error::Generic(format!("Invalid path for list_from: {path:?}"))

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -592,7 +592,7 @@ mod tests {
         ];
 
         for (expr, expected) in cases {
-            let result = format!("{}", expr);
+            let result = format!("{expr}");
             assert_eq!(result, expected);
         }
     }
@@ -635,7 +635,7 @@ mod tests {
         ];
 
         for (pred, expected) in cases {
-            let result = format!("{}", pred);
+            let result = format!("{pred}");
             assert_eq!(result, expected);
         }
     }

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -356,18 +356,18 @@ impl Scalar {
 impl Display for Scalar {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Integer(i) => write!(f, "{}", i),
-            Self::Long(i) => write!(f, "{}", i),
-            Self::Short(i) => write!(f, "{}", i),
-            Self::Byte(i) => write!(f, "{}", i),
-            Self::Float(fl) => write!(f, "{}", fl),
-            Self::Double(fl) => write!(f, "{}", fl),
-            Self::String(s) => write!(f, "'{}'", s),
-            Self::Boolean(b) => write!(f, "{}", b),
-            Self::Timestamp(ts) => write!(f, "{}", ts),
-            Self::TimestampNtz(ts) => write!(f, "{}", ts),
-            Self::Date(d) => write!(f, "{}", d),
-            Self::Binary(b) => write!(f, "{:?}", b),
+            Self::Integer(i) => write!(f, "{i}"),
+            Self::Long(i) => write!(f, "{i}"),
+            Self::Short(i) => write!(f, "{i}"),
+            Self::Byte(i) => write!(f, "{i}"),
+            Self::Float(fl) => write!(f, "{fl}"),
+            Self::Double(fl) => write!(f, "{fl}"),
+            Self::String(s) => write!(f, "'{s}'"),
+            Self::Boolean(b) => write!(f, "{b}"),
+            Self::Timestamp(ts) => write!(f, "{ts}"),
+            Self::TimestampNtz(ts) => write!(f, "{ts}"),
+            Self::Date(d) => write!(f, "{d}"),
+            Self::Binary(b) => write!(f, "{b:?}"),
             Self::Decimal(d) => match d.scale().cmp(&0) {
                 Ordering::Equal => {
                     write!(f, "{}", d.bits())
@@ -681,7 +681,7 @@ impl PrimitiveType {
         require!(scale == dtype.scale(), parse_error());
         let int: i128 = match frac_part {
             None => int_part.parse()?,
-            Some(frac_part) => format!("{}{}", int_part, frac_part).parse()?,
+            Some(frac_part) => format!("{int_part}{frac_part}").parse()?,
         };
         Ok(Scalar::Decimal(DecimalData::try_new(int, dtype)?))
     }
@@ -868,10 +868,10 @@ mod tests {
             Expr::literal("Cool"),
             column,
         ));
-        assert_eq!(&format!("{}", array_op), "10 IN (1, 2, 3)");
-        assert_eq!(&format!("{}", array_not_op), "NOT(10 IN (1, 2, 3))");
-        assert_eq!(&format!("{}", column_op), "3.1415927 IN Column(item)");
-        assert_eq!(&format!("{}", column_not_op), "NOT('Cool' IN Column(item))");
+        assert_eq!(&format!("{array_op}"), "10 IN (1, 2, 3)");
+        assert_eq!(&format!("{array_not_op}"), "NOT(10 IN (1, 2, 3))");
+        assert_eq!(&format!("{column_op}"), "3.1415927 IN Column(item)");
+        assert_eq!(&format!("{column_not_op}"), "NOT('Cool' IN Column(item))");
     }
 
     #[test]

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -82,8 +82,7 @@ impl LogSegment {
                 .windows(2)
                 .all(|cfs| cfs[0].version + 1 == cfs[1].version),
             Error::generic(format!(
-                "Expected ordered contiguous commit files {:?}",
-                ascending_commit_files
+                "Expected ordered contiguous commit files {ascending_commit_files:?}"
             ))
         );
 
@@ -111,8 +110,7 @@ impl LogSegment {
             require!(
                 effective_version == end_version,
                 Error::generic(format!(
-                    "LogSegment end version {} not the same as the specified end version {}",
-                    effective_version, end_version
+                    "LogSegment end version {effective_version} not the same as the specified end version {end_version}"
                 ))
             );
         }
@@ -193,8 +191,7 @@ impl LogSegment {
                 .first()
                 .is_some_and(|first_commit| first_commit.version == start_version),
             Error::generic(format!(
-                "Expected the first commit to have version {}",
-                start_version
+                "Expected the first commit to have version {start_version}"
             ))
         );
         let listed_files = ListedLogFiles::new(
@@ -488,7 +485,7 @@ fn list_log_files(
 ) -> DeltaResult<impl Iterator<Item = DeltaResult<ParsedLogPath>>> {
     let start_version = start_version.into().unwrap_or(0);
     let end_version = end_version.into();
-    let version_prefix = format!("{:020}", start_version);
+    let version_prefix = format!("{start_version:020}");
     let start_from = log_root.join(&version_prefix)?;
 
     Ok(storage

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -159,7 +159,7 @@ pub(crate) fn add_checkpoint_to_store(
     data: Box<dyn EngineData>,
     filename: &str,
 ) -> DeltaResult<()> {
-    let path = format!("_delta_log/{}", filename);
+    let path = format!("_delta_log/{filename}");
     write_parquet_to_store(store, path, data)
 }
 
@@ -170,7 +170,7 @@ fn add_sidecar_to_store(
     data: Box<dyn EngineData>,
     filename: &str,
 ) -> DeltaResult<()> {
-    let path = format!("_delta_log/_sidecars/{}", filename);
+    let path = format!("_delta_log/_sidecars/{filename}");
     write_parquet_to_store(store, path, data)
 }
 
@@ -186,7 +186,7 @@ fn write_json_to_store(
         .map(|action| serde_json::to_string(&action).expect("action to string"))
         .collect();
     let content = json_lines.join("\n");
-    let checkpoint_path = format!("_delta_log/{}", filename);
+    let checkpoint_path = format!("_delta_log/{filename}");
 
     tokio::runtime::Runtime::new()
         .expect("create tokio runtime")
@@ -823,8 +823,7 @@ fn test_sidecar_to_filemeta_valid_paths() -> DeltaResult<()> {
         assert_eq!(
             filemeta.location.as_str(),
             expected_url,
-            "Mismatch for input path: {}",
-            input_path
+            "Mismatch for input path: {input_path}"
         );
     }
     Ok(())

--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -184,13 +184,13 @@ impl ParsedLogPath<Url> {
     fn create_path(table_root: &Url, filename: String) -> DeltaResult<Self> {
         let location = table_root.join(Self::DELTA_LOG_DIR)?.join(&filename)?;
         Self::try_from(location)?.ok_or_else(|| {
-            Error::internal_error(format!("Attempted to create an invalid path: {}", filename))
+            Error::internal_error(format!("Attempted to create an invalid path: {filename}"))
         })
     }
 
     /// Create a new ParsedCommitPath<Url> for a new json commit file
     pub(crate) fn new_commit(table_root: &Url, version: Version) -> DeltaResult<Self> {
-        let filename = format!("{:020}.json", version);
+        let filename = format!("{version:020}.json");
         let path = Self::create_path(table_root, filename)?;
         if !path.is_commit() {
             return Err(Error::internal_error(
@@ -206,7 +206,7 @@ impl ParsedLogPath<Url> {
         table_root: &Url,
         version: Version,
     ) -> DeltaResult<Self> {
-        let filename = format!("{:020}.checkpoint.parquet", version);
+        let filename = format!("{version:020}.checkpoint.parquet");
         let path = Self::create_path(table_root, filename)?;
         if !path.is_checkpoint() {
             return Err(Error::internal_error(
@@ -236,7 +236,7 @@ impl ParsedLogPath<Url> {
     #[allow(unused)]
     /// Create a new ParsedCommitPath<Url> for a new CRC file
     pub(crate) fn new_crc(table_root: &Url, version: Version) -> DeltaResult<Self> {
-        let filename = format!("{:020}.crc", version);
+        let filename = format!("{version:020}.crc");
         let path = Self::create_path(table_root, filename)?;
         if path.file_type != LogPathFileType::Crc {
             return Err(Error::internal_error(
@@ -297,8 +297,7 @@ mod tests {
                     ..
                 }))
             ),
-            "Expected Unknown file type, got {:?}",
-            result
+            "Expected Unknown file type, got {result:?}"
         );
 
         // ignored - version fails to parse

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -1030,8 +1030,7 @@ mod tests {
             assert_eq!(
                 can_statically_skip_all_files(&predicate),
                 should_skip,
-                "Failed for predicate: {:#?}",
-                predicate
+                "Failed for predicate: {predicate:#?}"
             );
         }
     }
@@ -1171,8 +1170,7 @@ mod tests {
             let result = PhysicalPredicate::try_new(&predicate, &logical_schema).ok();
             assert_eq!(
                 result, expected,
-                "Failed for predicate: {:#?}, expected {:#?}, got {:#?}",
-                predicate, expected, result
+                "Failed for predicate: {predicate:#?}, expected {expected:#?}, got {result:#?}"
             );
         }
     }

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -511,8 +511,7 @@ impl DecimalType {
         require!(
             0 < precision && precision <= 38,
             Error::invalid_decimal(format!(
-                "precision must be in range 1..38 inclusive, found: {}.",
-                precision
+                "precision must be in range 1..38 inclusive, found: {precision}."
             ))
         );
         require!(
@@ -586,7 +585,7 @@ where
     let str_value = String::deserialize(deserializer)?;
     require!(
         str_value.starts_with("decimal(") && str_value.ends_with(')'),
-        serde::de::Error::custom(format!("Invalid decimal: {}", str_value))
+        serde::de::Error::custom(format!("Invalid decimal: {str_value}"))
     );
 
     let mut parts = str_value[8..str_value.len() - 1].split(',');
@@ -594,13 +593,13 @@ where
         .next()
         .and_then(|part| part.trim().parse::<u8>().ok())
         .ok_or_else(|| {
-            serde::de::Error::custom(format!("Invalid precision in decimal: {}", str_value))
+            serde::de::Error::custom(format!("Invalid precision in decimal: {str_value}"))
         })?;
     let scale = parts
         .next()
         .and_then(|part| part.trim().parse::<u8>().ok())
         .ok_or_else(|| {
-            serde::de::Error::custom(format!("Invalid scale in decimal: {}", str_value))
+            serde::de::Error::custom(format!("Invalid scale in decimal: {str_value}"))
         })?;
     DecimalType::try_new(precision, scale).map_err(serde::de::Error::custom)
 }
@@ -726,7 +725,7 @@ impl DataType {
 impl Display for DataType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            DataType::Primitive(p) => write!(f, "{}", p),
+            DataType::Primitive(p) => write!(f, "{p}"),
             DataType::Array(a) => write!(f, "array<{}>", a.element_type),
             DataType::Struct(s) => {
                 write!(f, "struct<")?;

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -122,8 +122,7 @@ impl Snapshot {
             if new_version < old_version {
                 // Hint is too new: error since this is effectively an incorrect optimization
                 return Err(Error::Generic(format!(
-                    "Requested snapshot version {} is older than snapshot hint version {}",
-                    new_version, old_version
+                    "Requested snapshot version {new_version} is older than snapshot hint version {old_version}"
                 )));
             }
         }
@@ -152,8 +151,7 @@ impl Snapshot {
                 Some(new_version) if new_version != old_version => {
                     // No new commits, but we are looking for a new version
                     return Err(Error::Generic(format!(
-                        "Requested snapshot version {} is newer than the latest version {}",
-                        new_version, old_version
+                        "Requested snapshot version {new_version} is newer than the latest version {old_version}"
                     )));
                 }
                 _ => {
@@ -173,8 +171,7 @@ impl Snapshot {
             // we should never see a new log segment with a version < the existing snapshot
             // version, that would mean a commit was incorrectly deleted from the log
             return Err(Error::Generic(format!(
-                "Unexpected state: The newest version in the log {} is older than the old version {}",
-                new_end_version, old_version)));
+                "Unexpected state: The newest version in the log {new_end_version} is older than the old version {old_version}")));
         }
         if new_end_version == old_version {
             // No new commits, just return the same snapshot

--- a/kernel/src/table.rs
+++ b/kernel/src/table.rs
@@ -54,14 +54,13 @@ impl Table {
                     )));
                 }
                 let path = std::fs::canonicalize(path).map_err(|err| {
-                    let msg = format!("Invalid table location: {} Error: {:?}", uri, err);
+                    let msg = format!("Invalid table location: {uri} Error: {err:?}");
                     Error::InvalidTableLocation(msg)
                 })?;
                 Url::from_directory_path(path.clone()).map_err(|_| {
                     let msg = format!(
-                        "Could not construct a URL from canonicalized path: {:?}.\n\
-                         Something must be very wrong with the table path.",
-                        path
+                        "Could not construct a URL from canonicalized path: {path:?}.\n\
+                         Something must be very wrong with the table path."
                     );
                     Error::InvalidTableLocation(msg)
                 })?

--- a/kernel/src/table_changes/log_replay/tests.rs
+++ b/kernel/src/table_changes/log_replay/tests.rs
@@ -524,7 +524,7 @@ async fn data_skipping_filter() {
     let logical_schema = get_schema();
     let predicate = match PhysicalPredicate::try_new(&predicate, &logical_schema) {
         Ok(PhysicalPredicate::Some(p, s)) => Some((p, s)),
-        other => panic!("Unexpected result: {:?}", other),
+        other => panic!("Unexpected result: {other:?}"),
     };
     let commits = get_segment(engine.as_ref(), mock_table.table_root(), 0, None)
         .unwrap()

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -301,7 +301,7 @@ mod tests {
             create_annotations(inner_id, inner_name),
             create_annotations(outer_id, outer_name)
         );
-        println!("{}", schema);
+        println!("{schema}");
         StructType::new([serde_json::from_str(&schema).unwrap()])
     }
 

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -242,7 +242,7 @@ mod tests {
         for (feature, expected) in cases {
             assert_eq!(feature.to_string(), expected);
             let serialized = serde_json::to_string(&feature).unwrap();
-            assert_eq!(serialized, format!("\"{}\"", expected));
+            assert_eq!(serialized, format!("\"{expected}\""));
 
             let deserialized: ReaderFeature = serde_json::from_str(&serialized).unwrap();
             assert_eq!(deserialized, feature);
@@ -283,7 +283,7 @@ mod tests {
         for (feature, expected) in cases {
             assert_eq!(feature.to_string(), expected);
             let serialized = serde_json::to_string(&feature).unwrap();
-            assert_eq!(serialized, format!("\"{}\"", expected));
+            assert_eq!(serialized, format!("\"{expected}\""));
 
             let deserialized: WriterFeature = serde_json::from_str(&serialized).unwrap();
             assert_eq!(deserialized, feature);

--- a/kernel/src/transaction.rs
+++ b/kernel/src/transaction.rs
@@ -332,7 +332,7 @@ fn generate_commit_info(
             )],
             vec![Scalar::Null(DataType::INTEGER)],
         )?)),
-        Expression::literal(format!("v{}", KERNEL_VERSION)),
+        Expression::literal(format!("v{KERNEL_VERSION}")),
         column_expr!("engineCommitInfo"),
     ];
     let commit_info_expr = Expression::struct_from([Expression::struct_from(commit_info_exprs)]);
@@ -590,7 +590,7 @@ mod tests {
             Error::Arrow(ArrowError::SchemaError(_)) => (),
             Error::Backtraced { source, .. }
                 if matches!(&*source, Error::Arrow(ArrowError::SchemaError(_))) => {}
-            _ => panic!("expected arrow schema error error, got {:?}", e),
+            _ => panic!("expected arrow schema error error, got {e:?}"),
         });
 
         Ok(())
@@ -619,7 +619,7 @@ mod tests {
             Error::Arrow(ArrowError::InvalidArgumentError(_)) => (),
             Error::Backtraced { source, .. }
                 if matches!(&*source, Error::Arrow(ArrowError::InvalidArgumentError(_))) => {}
-            _ => panic!("expected arrow invalid arg error, got {:?}", e),
+            _ => panic!("expected arrow invalid arg error, got {e:?}"),
         });
 
         Ok(())

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -24,7 +24,7 @@ pub(crate) fn calculate_transaction_expiration_timestamp(
         .map(|duration| -> DeltaResult<i64> {
             let now = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
-                .map_err(|e| Error::generic(format!("Failed to get current time: {}", e)))?;
+                .map_err(|e| Error::generic(format!("Failed to get current time: {e}")))?;
 
             let now_ms = i64::try_from(now.as_millis())
                 .map_err(|_| Error::generic("Current timestamp exceeds i64 millisecond range"))?;


### PR DESCRIPTION
## What changes are proposed in this pull request?
All the fixes needed now that clippy complains about `println!("{}", foo)`.

## How was this change tested?
Existing tests