### PR TITLE
feat: Introduce a crate for args that are common between examples

### DIFF
--- a/kernel/examples/common/Cargo.toml
+++ b/kernel/examples/common/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "common"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4.5", features = ["derive"] }
+delta_kernel = { path = "../../../kernel", features = [
+  "arrow-55",
+  "default-engine",
+  "internal-api",
+] }

--- a/kernel/examples/common/src/lib.rs
+++ b/kernel/examples/common/src/lib.rs
@@ -1,5 +1,5 @@
-/// Common code to be shared between all examples. Mostly argument parsing, and a few other
-/// utilities
+//! Common code to be shared between all examples. Mostly argument parsing, and a few other
+//! utilities
 use std::{collections::HashMap, sync::Arc};
 
 use clap::Args;

--- a/kernel/examples/common/src/lib.rs
+++ b/kernel/examples/common/src/lib.rs
@@ -13,7 +13,7 @@ use delta_kernel::{
 
 #[derive(Args)]
 pub struct LocationArgs {
-    /// Path to the table to inspect
+    /// Path to the table
     pub path: String,
 
     /// Region to specify to the cloud access store (only applies to S3)

--- a/kernel/examples/common/src/lib.rs
+++ b/kernel/examples/common/src/lib.rs
@@ -16,7 +16,7 @@ pub struct LocationArgs {
     /// Path to the table to inspect
     pub path: String,
 
-    /// Region to specify to the cloud access store (only applies if using the default engine)
+    /// Region to specify to the cloud access store (only applies to S3)
     #[arg(long)]
     pub region: Option<String>,
 

--- a/kernel/examples/common/src/lib.rs
+++ b/kernel/examples/common/src/lib.rs
@@ -42,10 +42,12 @@ pub struct ScanArgs {
     pub columns: Option<Vec<String>>,
 }
 
+/// Get a [`Table`] from the specified location args
 pub fn get_table(args: &LocationArgs) -> DeltaResult<Table> {
     Table::try_from_uri(&args.path)
 }
 
+/// Get an engine configured to read table specified by `table` and `LocationArgs`
 pub fn get_engine(
     table: &Table,
     args: &LocationArgs,
@@ -65,8 +67,8 @@ pub fn get_engine(
     )
 }
 
-/// Utility function to take in the specified `CommonArgs` and configure a scan as
-/// specified. Returns the constructed engine and scan
+/// Construct a scan at the latest snapshot. This is over the specified table and using the passed
+/// engine. Parameters of the scan are controlled by the specified `ScanArgs`
 pub fn get_scan(
     table: &Table,
     engine: &DefaultEngine<TokioBackgroundExecutor>,

--- a/kernel/examples/common/src/lib.rs
+++ b/kernel/examples/common/src/lib.rs
@@ -50,9 +50,6 @@ pub fn get_engine(
     table: &Table,
     args: &LocationArgs,
 ) -> DeltaResult<DefaultEngine<TokioBackgroundExecutor>> {
-    // build a table and get the latest snapshot from it
-    println!("Reading {}", table.location());
-
     let mut options = if let Some(ref region) = args.region {
         HashMap::from([("region", region.clone())])
     } else {

--- a/kernel/examples/common/src/lib.rs
+++ b/kernel/examples/common/src/lib.rs
@@ -1,0 +1,95 @@
+use std::{collections::HashMap, sync::Arc};
+
+use clap::Args;
+use delta_kernel::{
+    engine::default::{executor::tokio::TokioBackgroundExecutor, DefaultEngine},
+    scan::Scan,
+    schema::Schema,
+    DeltaResult, Table,
+};
+
+#[derive(Args)]
+pub struct CommonArgs {
+    /// Path to the table to inspect
+    pub path: String,
+
+    // /// how many threads to read with (1 - 2048)
+    // #[arg(short, long, default_value_t = 2, value_parser = 1..=2048)]
+    // thread_count: i64,
+    /// Comma separated list of columns to select
+    #[arg(long, value_delimiter=',', num_args(0..))]
+    pub columns: Option<Vec<String>>,
+
+    /// Region to specify to the cloud access store (only applies if using the default engine)
+    #[arg(long)]
+    pub region: Option<String>,
+
+    /// Specify that the table is "public" (i.e. no cloud credentials are needed). This is required
+    /// for things like s3 public buckets, otherwise the kernel will try and authenticate by talking
+    /// to the aws metadata server, which will fail unless you're on an ec2 instance.
+    #[arg(long)]
+    pub public: bool,
+
+    /// Limit to printing only LIMIT rows.
+    #[arg(short, long)]
+    pub limit: Option<usize>,
+
+    /// Only print the schema of the table
+    #[arg(long)]
+    pub schema_only: bool,
+}
+
+/// Utility function to take in the specified `CommonArgs` and configure a scan as
+/// specified. Returns the constructed engine and scan
+pub fn get_scan(
+    args: &CommonArgs,
+) -> DeltaResult<Option<(Scan, DefaultEngine<TokioBackgroundExecutor>)>> {
+    // build a table and get the latest snapshot from it
+    let table = Table::try_from_uri(&args.path)?;
+    println!("Reading {}", table.location());
+
+    let mut options = if let Some(ref region) = args.region {
+        HashMap::from([("region", region.clone())])
+    } else {
+        HashMap::new()
+    };
+    if args.public {
+        options.insert("skip_signature", "true".to_string());
+    }
+    let engine = DefaultEngine::try_new(
+        table.location(),
+        options,
+        Arc::new(TokioBackgroundExecutor::new()),
+    )?;
+
+    let snapshot = table.snapshot(&engine, None)?;
+
+    if args.schema_only {
+        println!("{:#?}", snapshot.schema());
+        return Ok(None);
+    }
+
+    let read_schema_opt = args
+        .columns
+        .clone()
+        .map(|cols| -> DeltaResult<_> {
+            let table_schema = snapshot.schema();
+            let selected_fields = cols.iter().map(|col| {
+                table_schema
+                    .field(col)
+                    .cloned()
+                    .ok_or(delta_kernel::Error::Generic(format!(
+                        "Table has no such column: {col}"
+                    )))
+            });
+            Schema::try_new(selected_fields).map(Arc::new)
+        })
+        .transpose()?;
+    Ok(Some((
+        snapshot
+            .into_scan_builder()
+            .with_schema_opt(read_schema_opt)
+            .build()?,
+        engine,
+    )))
+}

--- a/kernel/examples/inspect-table/Cargo.toml
+++ b/kernel/examples/inspect-table/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
+common = { path = "../common" }
 delta_kernel = { path = "../../../kernel", features = [
   "arrow",
   "default-engine",

--- a/kernel/examples/read-table-changes/Cargo.toml
+++ b/kernel/examples/read-table-changes/Cargo.toml
@@ -9,6 +9,7 @@ release = false
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
+common = { path = "../common" }
 delta_kernel = { path = "../../../kernel", features = [
   "arrow",
   "default-engine",

--- a/kernel/examples/read-table-multi-threaded/Cargo.toml
+++ b/kernel/examples/read-table-multi-threaded/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 arrow = { version = "55", features = ["prettyprint", "chrono-tz"] }
 clap = { version = "4.5", features = ["derive"] }
+common = { path = "../common" }
 delta_kernel = { path = "../../../kernel", features = [
   "arrow-55",
   "default-engine",

--- a/kernel/examples/read-table-multi-threaded/src/main.rs
+++ b/kernel/examples/read-table-multi-threaded/src/main.rs
@@ -94,9 +94,8 @@ fn try_main() -> DeltaResult<()> {
     let table = common::get_table(&cli.location_args)?;
     println!("Reading {}", table.location());
     let engine = common::get_engine(&table, &cli.location_args)?;
-    let scan = match common::get_scan(&table, &engine, &cli.scan_args)? {
-        Some(scan) => scan,
-        None => return Ok(()),
+    let Some(scan) = common::get_scan(&table, &engine, &cli.scan_args)? else {
+        return Ok(());
     };
 
     // this gives us an iterator of (our engine data, selection vector). our engine data is just

--- a/kernel/examples/read-table-multi-threaded/src/main.rs
+++ b/kernel/examples/read-table-multi-threaded/src/main.rs
@@ -92,6 +92,7 @@ struct ScanState {
 fn try_main() -> DeltaResult<()> {
     let cli = Cli::parse();
     let table = common::get_table(&cli.location_args)?;
+    println!("Reading {}", table.location());
     let engine = common::get_engine(&table, &cli.location_args)?;
     let scan = match common::get_scan(&table, &engine, &cli.scan_args)? {
         Some(scan) => scan,

--- a/kernel/examples/read-table-multi-threaded/src/main.rs
+++ b/kernel/examples/read-table-multi-threaded/src/main.rs
@@ -7,13 +7,12 @@ use std::thread;
 use arrow::compute::filter_record_batch;
 use arrow::record_batch::RecordBatch;
 use arrow::util::pretty::print_batches;
+use common::CommonArgs;
 use delta_kernel::actions::deletion_vector::split_vector;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
-use delta_kernel::engine::default::executor::tokio::TokioBackgroundExecutor;
-use delta_kernel::engine::default::DefaultEngine;
 use delta_kernel::scan::state::{transform_to_logical, DvInfo, Stats};
-use delta_kernel::schema::{Schema, SchemaRef};
-use delta_kernel::{DeltaResult, Engine, EngineData, ExpressionRef, FileMeta, Table};
+use delta_kernel::schema::SchemaRef;
+use delta_kernel::{DeltaResult, Engine, EngineData, ExpressionRef, FileMeta};
 
 use clap::Parser;
 use url::Url;
@@ -25,30 +24,12 @@ use url::Url;
 #[command(author, version, about, long_about = None)]
 #[command(propagate_version = true)]
 struct Cli {
-    /// Path to the table to inspect
-    path: String,
+    #[command(flatten)]
+    common_args: CommonArgs,
 
     /// how many threads to read with (1 - 2048)
     #[arg(short, long, default_value_t = 2, value_parser = 1..=2048)]
     thread_count: i64,
-
-    /// Comma separated list of columns to select
-    #[arg(long, value_delimiter=',', num_args(0..))]
-    columns: Option<Vec<String>>,
-
-    /// Region to specify to the cloud access store (only applies if using the default engine)
-    #[arg(long)]
-    region: Option<String>,
-
-    /// Specify that the table is "public" (i.e. no cloud credentials are needed). This is required
-    /// for things like s3 public buckets, otherwise the kernel will try and authenticate by talking
-    /// to the aws metadata server, which will fail unless you're on an ec2 instance.
-    #[arg(long)]
-    public: bool,
-
-    /// Limit to printing only LIMIT rows.
-    #[arg(short, long)]
-    limit: Option<usize>,
 }
 
 fn main() -> ExitCode {
@@ -118,48 +99,10 @@ struct ScanState {
 fn try_main() -> DeltaResult<()> {
     let cli = Cli::parse();
 
-    // build a table and get the latest snapshot from it
-    let table = Table::try_from_uri(&cli.path)?;
-    println!("Reading {}", table.location());
-
-    let mut options = if let Some(region) = cli.region {
-        HashMap::from([("region", region)])
-    } else {
-        HashMap::new()
+    let (scan, engine) = match common::get_scan(&cli.common_args)? {
+        Some((scan, engine)) => (scan, engine),
+        None => return Ok(()),
     };
-    if cli.public {
-        options.insert("skip_signature", "true".to_string());
-    }
-    let engine = DefaultEngine::try_new(
-        table.location(),
-        options,
-        Arc::new(TokioBackgroundExecutor::new()),
-    )?;
-
-    let snapshot = table.snapshot(&engine, None)?;
-
-    // process the columns requested and build a schema from them
-    let read_schema_opt = cli
-        .columns
-        .map(|cols| -> DeltaResult<_> {
-            let table_schema = snapshot.schema();
-            let selected_fields = cols.iter().map(|col| {
-                table_schema
-                    .field(col)
-                    .cloned()
-                    .ok_or(delta_kernel::Error::Generic(format!(
-                        "Table has no such column: {col}"
-                    )))
-            });
-            Schema::try_new(selected_fields).map(Arc::new)
-        })
-        .transpose()?;
-
-    // build a scan with the specified schema
-    let scan = snapshot
-        .into_scan_builder()
-        .with_schema_opt(read_schema_opt)
-        .build()?;
 
     // this gives us an iterator of (our engine data, selection vector). our engine data is just
     // arrow data. The schema can be obtained by calling
@@ -199,10 +142,9 @@ fn try_main() -> DeltaResult<()> {
             scan_file_tx = scan_metadata.visit_scan_files(scan_file_tx, send_scan_file)?;
         }
 
-        // have sent all scan files, drop this so threads will exit when there's no more work
         drop(scan_file_tx);
 
-        let batches = if let Some(limit) = cli.limit {
+        let batches = if let Some(limit) = cli.common_args.limit {
             // gather batches while we need
             let mut batches = vec![];
             let mut rows_so_far = 0;

--- a/kernel/examples/read-table-single-threaded/Cargo.toml
+++ b/kernel/examples/read-table-single-threaded/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 arrow = { version = "55", features = ["prettyprint", "chrono-tz"] }
 clap = { version = "4.5", features = ["derive"] }
+common = { path = "../common" }
 delta_kernel = { path = "../../../kernel", features = [
   "arrow-55",
   "default-engine",

--- a/kernel/examples/read-table-single-threaded/src/main.rs
+++ b/kernel/examples/read-table-single-threaded/src/main.rs
@@ -1,15 +1,12 @@
-use std::collections::HashMap;
 use std::process::ExitCode;
 use std::sync::Arc;
 
 use arrow::compute::filter_record_batch;
 use arrow::record_batch::RecordBatch;
 use arrow::util::pretty::print_batches;
+use common::CommonArgs;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
-use delta_kernel::engine::default::executor::tokio::TokioBackgroundExecutor;
-use delta_kernel::engine::default::DefaultEngine;
-use delta_kernel::schema::Schema;
-use delta_kernel::{DeltaResult, Table};
+use delta_kernel::DeltaResult;
 
 use clap::Parser;
 use itertools::Itertools;
@@ -20,26 +17,11 @@ use itertools::Itertools;
 #[command(author, version, about, long_about = None)]
 #[command(propagate_version = true)]
 struct Cli {
-    /// Path to the table to inspect
-    path: String,
-
-    /// Comma separated list of columns to select
-    #[arg(long, value_delimiter=',', num_args(0..))]
-    columns: Option<Vec<String>>,
-
-    /// Region to specify to the cloud access store (only applies if using the default engine)
-    #[arg(long)]
-    region: Option<String>,
-
-    /// Specify that the table is "public" (i.e. no cloud credentials are needed). This is required
-    /// for things like s3 public buckets, otherwise the kernel will try and authenticate by talking
-    /// to the aws metadata server, which will fail unless you're on an ec2 instance.
-    #[arg(long)]
-    public: bool,
-
-    /// Only print the schema of the table
-    #[arg(long)]
-    schema_only: bool,
+    // today we don't have any args unique to this version, but we keep this as flattened this way
+    // for consistency with the multi-threaded version and to make it easy to add unique options in
+    // the future
+    #[command(flatten)]
+    common_args: CommonArgs,
 }
 
 fn main() -> ExitCode {
@@ -56,50 +38,10 @@ fn main() -> ExitCode {
 fn try_main() -> DeltaResult<()> {
     let cli = Cli::parse();
 
-    // build a table and get the latest snapshot from it
-    let table = Table::try_from_uri(&cli.path)?;
-    println!("Reading {}", table.location());
-
-    let mut options = if let Some(region) = cli.region {
-        HashMap::from([("region", region)])
-    } else {
-        HashMap::new()
+    let (scan, engine) = match common::get_scan(&cli.common_args)? {
+        Some((scan, engine)) => (scan, Arc::new(engine)),
+        None => return Ok(()),
     };
-    if cli.public {
-        options.insert("skip_signature", "true".to_string());
-    }
-    let engine = Arc::new(DefaultEngine::try_new(
-        table.location(),
-        options,
-        Arc::new(TokioBackgroundExecutor::new()),
-    )?);
-
-    let snapshot = table.snapshot(engine.as_ref(), None)?;
-
-    if cli.schema_only {
-        println!("{:#?}", snapshot.schema());
-        return Ok(());
-    }
-
-    let read_schema_opt = cli
-        .columns
-        .map(|cols| -> DeltaResult<_> {
-            let table_schema = snapshot.schema();
-            let selected_fields = cols.iter().map(|col| {
-                table_schema
-                    .field(col)
-                    .cloned()
-                    .ok_or(delta_kernel::Error::Generic(format!(
-                        "Table has no such column: {col}"
-                    )))
-            });
-            Schema::try_new(selected_fields).map(Arc::new)
-        })
-        .transpose()?;
-    let scan = snapshot
-        .into_scan_builder()
-        .with_schema_opt(read_schema_opt)
-        .build()?;
 
     let batches: Vec<RecordBatch> = scan
         .execute(engine)?

--- a/kernel/examples/read-table-single-threaded/src/main.rs
+++ b/kernel/examples/read-table-single-threaded/src/main.rs
@@ -43,9 +43,8 @@ fn try_main() -> DeltaResult<()> {
     let table = common::get_table(&cli.location_args)?;
     println!("Reading {}", table.location());
     let engine = common::get_engine(&table, &cli.location_args)?;
-    let scan = match common::get_scan(&table, &engine, &cli.scan_args)? {
-        Some(scan) => scan,
-        None => return Ok(()),
+    let Some(scan) = common::get_scan(&table, &engine, &cli.scan_args)? else {
+        return Ok(());
     };
 
     let mut rows_so_far = 0;

--- a/kernel/examples/read-table-single-threaded/src/main.rs
+++ b/kernel/examples/read-table-single-threaded/src/main.rs
@@ -41,6 +41,7 @@ fn main() -> ExitCode {
 fn try_main() -> DeltaResult<()> {
     let cli = Cli::parse();
     let table = common::get_table(&cli.location_args)?;
+    println!("Reading {}", table.location());
     let engine = common::get_engine(&table, &cli.location_args)?;
     let scan = match common::get_scan(&table, &engine, &cli.scan_args)? {
         Some(scan) => scan,


### PR DESCRIPTION
## What changes are proposed in this pull request?
Our examples have a lot of common code to get an engine, snapshot, table, etc. We want to add support for more options (like reading from different cloud providers), and we shouldn't have to add that code in multiple places.

This introduces a new `common` crate with all the shared options, and then each example can just `flatten` the set of args they need into their `Cli` struct.

Note that all the code in `common/src/lib.rs` is just copied from the existing examples.

## How was this change tested?
Running all the examples