### PR TITLE
fix: always write `_last_checkpoint` with parts = None

### DIFF
--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -468,6 +468,7 @@ fn deleted_file_retention_timestamp_with_time(
 ///
 /// TODO(#838): Add `checksum` field to `_last_checkpoint` file
 /// TODO(#839): Add `checkpoint_schema` field to `_last_checkpoint` file
+/// TODO(#1054): Add `tags` field to `_last_checkpoint` file
 /// TODO(#1052): Add `v2Checkpoint` field to `_last_checkpoint` file
 pub(crate) fn create_last_checkpoint_data(
     engine: &dyn Engine,

--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -462,12 +462,13 @@ fn deleted_file_retention_timestamp_with_time(
 /// A new [`EngineData`] batch with the `_last_checkpoint` fields:
 /// - `version` (i64, required): Table version number
 /// - `size` (i64, required): Total actions count
-/// - `parts` (i64, optional): Always 1 for single-file checkpoints
+/// - `parts` (i64, optional): Always None for single-file checkpoints
 /// - `sizeInBytes` (i64, optional): Size of checkpoint file in bytes
 /// - `numOfAddFiles` (i64, optional): Number of Add actions
 ///
-/// TODO(#838) Add `checksum` field to `_last_checkpoint` file
-/// TODO(#839) Add `checkpoint_schema` field to `_last_checkpoint` file
+/// TODO(#838): Add `checksum` field to `_last_checkpoint` file
+/// TODO(#839): Add `checkpoint_schema` field to `_last_checkpoint` file
+/// TODO(#1052): Add `v2Checkpoint` field to `_last_checkpoint` file
 pub(crate) fn create_last_checkpoint_data(
     engine: &dyn Engine,
     version: i64,
@@ -480,7 +481,7 @@ pub(crate) fn create_last_checkpoint_data(
         &[
             version.into(),
             actions_counter.into(),
-            1i64.into(), // parts = 1 since we only support single-part checkpoint here
+            None::<i64>.into(), // parts = None since we only support single-part checkpoints
             size_in_bytes.into(),
             add_actions_counter.into(),
         ],

--- a/kernel/src/checkpoint/tests.rs
+++ b/kernel/src/checkpoint/tests.rs
@@ -144,7 +144,7 @@ fn test_create_last_checkpoint_data() -> DeltaResult<()> {
         vec![
             create_array!(Int64, [version]),
             create_array!(Int64, [total_actions_counter]),
-            create_array!(Int64, [1]),
+            create_array!(Int64, [None]),
             create_array!(Int64, [size_in_bytes]),
             create_array!(Int64, [add_actions_counter]),
         ],
@@ -247,7 +247,6 @@ fn assert_last_checkpoint_contents(
     let expected_data = json!({
         "version": expected_version,
         "size": expected_size,
-        "parts": 1,
         "sizeInBytes": expected_size_in_bytes,
         "numOfAddFiles": expected_num_add_files,
     });


### PR DESCRIPTION
## What changes are proposed in this pull request?
previously, kernel always wrote `parts: 1` in the `_last_checkpoint` file since the kernel only supports single-file checkpoints and v2 checkpoints, NOT muti-part checkpoints (which are considered unsafe and will never be written by kernel). This was incorrect. The [protocol states](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#last-checkpoint-file-schema) that the 'parts' field in `_last_checkpoint` is:
> The number of fragments if the last checkpoint was written in multiple parts. This field is optional.

Thus, we actually _must_ write `None` for single-part/v2 checkpoints in order to comply with the protocol. `Some(x)` implies a multi-part checkpoint with `x` parts.

## How was this change tested?
modified UT

resolves #1043 