### PR TITLE
feat: Support reordering structs that are inside maps in default parquet reader

### DIFF
--- a/kernel/src/engine/arrow_utils.rs
+++ b/kernel/src/engine/arrow_utils.rs
@@ -142,6 +142,9 @@ where
 *      - `Nested` and the data is a `List<StructArray>`: get the inner struct array out of the list,
 *         reorder it recursively as above, rebuild the list, and the put the column at the correct
 *         location
+*      - `Nested` and the data is a `Map`. We expect the child order to contain two elements. The
+*         first specifies any needed reordering in the keys (i.e. if the key contains a struct),
+*         and the second any reordering needed in the values.
 *
 * Example:
 * The parquet crate `ProjectionMask::leaves` method only considers leaf columns -- a "flat" schema --

--- a/kernel/src/engine/arrow_utils.rs
+++ b/kernel/src/engine/arrow_utils.rs
@@ -1545,7 +1545,6 @@ mod tests {
             .next()
             .unwrap()
             .unwrap();
-        println!("Batch 1: {batch1:?}");
 
         macro_rules! assert_nulls {
             ( $column: expr, $nulls: expr ) => {
@@ -1584,7 +1583,6 @@ mod tests {
             .next()
             .unwrap()
             .unwrap();
-        println!("Batch 2 before: {batch2:?}");
 
         // Starting from arrow-53.3, the parquet reader started returning broken nested NULL masks.
         let batch2 = RecordBatch::from(fix_nested_null_masks(batch2.into()));


### PR DESCRIPTION
## What changes are proposed in this pull request?
Previously we didn't reorder things that were inside a map. We actually already did compute the required reordering, but then just threw it away.

This uses that computed reordering and returns it in the mask/reorder phase, and then uses it in `reorder_struct_array` to properly recurse into maps and reorder elements.

We model a map reorder as a `ReorderIndex::Nested` variant. The index of the top level nested item says where the map itself should end up in the output. Then there are two nested `ReorderIndex`s, which specify how any inner things should be reordered. The code does  handle the case that a struct might be in a map but not need to be reordered. It checks if the computed nested reorder for keys or values doesn't actually require any work and will replace it with an `Identity` transform if none is needed.

## How was this change tested?
Unit tests. One for computing the reorder, one for applying it.