### PR TITLE
fix: don't release `common` crate

### DIFF
--- a/kernel/examples/common/Cargo.toml
+++ b/kernel/examples/common/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
 name = "common"
-version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+readme.workspace = true
+version.workspace = true
+
+[package.metadata.release]
+release = false
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }


### PR DESCRIPTION
## What changes are proposed in this pull request?
1. add `release = false` to `common` crate `Cargo.toml` so we don't attempt releases by release script
2. replace version/edition with workspace version/edition (as we do for most all other crates)

## How was this change tested?
existing (and manual check running release script)