### PR TITLE
refactor: exclude `tests/data` from release

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -9,7 +9,8 @@ repository.workspace = true
 readme.workspace = true
 version.workspace = true
 # exclude golden tests + golden test data since they push us over 10MB crate size limit
-exclude = ["tests/golden_tables.rs", "tests/golden_data/"]
+# also exlude tests/data since similarly this has large test tables we don't need to ship
+exclude = ["tests/golden_tables.rs", "tests/golden_data/", "tests/data/"]
 rust-version.workspace = true
 
 [package.metadata.docs.rs]

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -67,6 +67,7 @@
 /// cannot invoke the macro because `delta_kernel` is an unknown crate identifier (you have to use
 /// `crate` instead). We could make the macro use `crate::schema::DataType` instead, but then the
 /// macro is useless outside the `delta_kernel` crate.
+#[allow(unused_extern_crates)]
 extern crate self as delta_kernel;
 
 use std::any::Any;


### PR DESCRIPTION
## What changes are proposed in this pull request?
1. exclude `tests/data` from kernel binary to not bloat our size
2. quick fix from warning noticed in `cargo package`

## How was this change tested?
`cargo package -p delta_kernel`