### PR TITLE
[WIP] feat: `VariantType` to represent VARIANT in schema

### DIFF
--- a/kernel/src/schema/variant_utils.rs
+++ b/kernel/src/schema/variant_utils.rs
@@ -1,7 +1,7 @@
 //! Utility functions for the variant type and variant-related table features.
 
 use crate::actions::Protocol;
-use crate::schema::{DataType, Schema, SchemaTransform};
+use crate::schema::{Schema, SchemaTransform, VariantType};
 use crate::table_features::{ReaderFeature, WriterFeature};
 use crate::utils::require;
 use crate::{DeltaResult, Error};
@@ -12,7 +12,7 @@ use std::borrow::Cow;
 pub(crate) struct UsesVariant(pub(crate) bool);
 
 impl<'a> SchemaTransform<'a> for UsesVariant {
-    fn transform_variant(&mut self, _: &'a DataType) -> Option<Cow<'a, DataType>> {
+    fn transform_variant(&mut self, _: &'a VariantType) -> Option<Cow<'a, VariantType>> {
         self.0 = true;
         None
     }

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -1,7 +1,9 @@
 //! Code to handle column mapping, including modes and schema transforms
 use super::ReaderFeature;
 use crate::actions::Protocol;
-use crate::schema::{ColumnName, DataType, MetadataValue, Schema, SchemaTransform, StructField};
+use crate::schema::{
+    ColumnName, DataType, MetadataValue, Schema, SchemaTransform, StructField, VariantType,
+};
 use crate::table_properties::TableProperties;
 use crate::{DeltaResult, Error};
 
@@ -153,6 +155,12 @@ impl<'a> SchemaTransform<'a> for ValidateColumnMappings<'a> {
             let _ = self.recurse_into_struct_field(field);
             self.path.pop();
         }
+        None
+    }
+    fn transform_variant(&mut self, _: &'a VariantType) -> Option<Cow<'a, VariantType>> {
+        // don't recurse into variant's fields, as they are not expected to have column mapping
+        // annotations
+        // TODO: this changes with icebergcompat right?
         None
     }
 }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -248,6 +248,10 @@ pub async fn create_table(
         }
         if enable_column_mapping {
             reader_features.push("columnMapping");
+            // TODO: we don't actually support column mapping writes yet, but have some tests that
+            // do column mapping on writes. for now omit the writer feature to let tests run, but
+            // after actual support this should be enabled.
+            // writer_features.push("columnMapping");
         }
         (reader_features, writer_features)
     };
@@ -357,7 +361,6 @@ pub fn to_arrow(data: Box<dyn EngineData>) -> DeltaResult<RecordBatch> {
         .into())
 }
 
-// TODO (zach): this is listed as unused for acceptance crate
 pub fn read_scan(scan: &Scan, engine: Arc<dyn Engine>) -> DeltaResult<Vec<RecordBatch>> {
     let scan_results = scan.execute(engine)?;
     scan_results
@@ -375,7 +378,6 @@ pub fn read_scan(scan: &Scan, engine: Arc<dyn Engine>) -> DeltaResult<Vec<Record
         .try_collect()
 }
 
-// TODO (zach): this is listed as unused for acceptance crate
 pub fn test_read(
     expected: &ArrowEngineData,
     url: &Url,


### PR DESCRIPTION
## What changes are proposed in this pull request?
Originally prompted as follow-up from #1015, this serves as an exploration of introducing a new `VariantType` struct (similar to `MapType`/`ArrayType`/etc.) which just wraps `StructType`.

The original question pertaining to `SchemaTransform` was basically: can we implement `transform_variant` to take+return a `StructType` instead of `DataType`? This loses the information that says the thing is a variant and not a normal struct. This prompted the exploration of how we actually want to represent Variant in our schemas. In general we need a way of distinguishing variants from plain structs 

I think we have two options: we either rely on `DataType` which communicates `DataType::Variant(struct_type)` OR we introduce a new `StructType` much like MapType/ArrayType/etc.

This PR serves as exploration of the former - though i'm realizing if we _do_ take `DataType` as the thing that 'tags' a struct as variant then it's probably also okay? And would just have the schema transform still retain taking/returning DataType? (or perhaps could consume a StructType but just always return a DataType)

I remember @nicklan had even more/better thoughts around this - please comment and we can discuss :)

## How was this change tested?
Existing UT