### PR TITLE
refactor: Contiguous commit file checking inside `ListedLogFiles::try_new()`

### DIFF
--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -239,12 +239,7 @@ impl LogSegment {
             contiguous_commits.push(commit);
         }
 
-        let listed_files = ListedLogFiles::try_new (
-            contiguous_commits,
-            vec![],
-            vec![],
-            None,
-        )?;
+        let listed_files = ListedLogFiles::try_new(contiguous_commits, vec![], vec![], None)?;
 
         LogSegment::try_new(listed_files, log_root, Some(end_version))
     }

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -587,6 +587,7 @@ pub(crate) struct ListedLogFiles {
 }
 
 impl ListedLogFiles {
+    // TODO: enforce the usage of this construct to enforce the assertion (issue#1143)
     #[internal_api]
     pub(crate) fn try_new(
         ascending_commit_files: Vec<ParsedLogPath>,

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -77,17 +77,6 @@ impl LogSegment {
             checkpoint_file.version
         });
 
-        // TODO: consider unifying this with debug_asserts in the ListedLogFiles::new(); issue#995
-        // We require that commits that are contiguous. In other words, there must be no gap between commit versions.
-        require!(
-            ascending_commit_files
-                .windows(2)
-                .all(|cfs| cfs[0].version + 1 == cfs[1].version),
-            Error::generic(format!(
-                "Expected ordered contiguous commit files {ascending_commit_files:?}"
-            ))
-        );
-
         // There must be no gap between a checkpoint and the first commit version. Note that
         // that all checkpoint parts share the same version.
         if let (Some(checkpoint_version), Some(commit_file)) =
@@ -186,7 +175,7 @@ impl LogSegment {
 
         // - Here check that the start version is correct.
         // - [`LogSegment::try_new`] will verify that the `end_version` is correct if present.
-        // - [`LogSegment::try_new`] also checks that there are no gaps between commits.
+        // - [`ListedLogFiles::try_new`] also checks that there are no gaps between commits.
         // If all three are satisfied, this implies that all the desired commits are present.
         require!(
             ascending_commit_files
@@ -196,12 +185,12 @@ impl LogSegment {
                 "Expected the first commit to have version {start_version}"
             ))
         );
-        let listed_files = ListedLogFiles::new(
+        let listed_files = ListedLogFiles::try_new(
             ascending_commit_files,
             vec![],
             vec![],
             None, // TODO: use CRC files for table changes?
-        );
+        )?;
         LogSegment::try_new(listed_files, log_root, end_version)
     }
 
@@ -250,12 +239,12 @@ impl LogSegment {
             contiguous_commits.push(commit);
         }
 
-        let listed_files = ListedLogFiles {
-            ascending_commit_files: contiguous_commits,
-            ascending_compaction_files: vec![],
-            checkpoint_parts: vec![],
-            latest_crc_file: None,
-        };
+        let listed_files = ListedLogFiles::try_new (
+            contiguous_commits,
+            vec![],
+            vec![],
+            None,
+        )?;
 
         LogSegment::try_new(listed_files, log_root, Some(end_version))
     }
@@ -604,12 +593,22 @@ pub(crate) struct ListedLogFiles {
 
 impl ListedLogFiles {
     #[internal_api]
-    pub(crate) fn new(
+    pub(crate) fn try_new(
         ascending_commit_files: Vec<ParsedLogPath>,
         ascending_compaction_files: Vec<ParsedLogPath>,
         checkpoint_parts: Vec<ParsedLogPath>,
         latest_crc_file: Option<ParsedLogPath>,
-    ) -> Self {
+    ) -> DeltaResult<Self> {
+        // Ensure commit file versions are contiguous
+        require!(
+            ascending_commit_files
+                .windows(2)
+                .all(|cfs| cfs[0].version + 1 == cfs[1].version),
+            Error::generic(format!(
+                "Expected ordered contiguous commit files {ascending_commit_files:?}"
+            ))
+        );
+
         // We are adding debug_assertions here since we want to validate invariants that are (relatively) expensive to compute
         #[cfg(debug_assertions)]
         {
@@ -644,12 +643,12 @@ impl ListedLogFiles {
             }
         }
 
-        ListedLogFiles {
+        Ok(ListedLogFiles {
             ascending_commit_files,
             ascending_compaction_files,
             checkpoint_parts,
             latest_crc_file,
-        }
+        })
     }
 }
 
@@ -719,13 +718,13 @@ pub(crate) fn list_log_files_with_version(
             }
         }
 
-        ListedLogFiles::new(
+        ListedLogFiles::try_new(
             ascending_commit_files,
             ascending_compaction_files,
             checkpoint_parts,
             latest_crc_file,
         )
-    })
+    })?
 }
 
 /// Groups all checkpoint parts according to the checkpoint they belong to.

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -2006,3 +2006,30 @@ fn for_timestamp_conversion_no_commit_files() {
     let res = LogSegment::for_timestamp_conversion(storage.as_ref(), log_root.clone(), 0, None);
     assert_result_error_with_message(res, "Generic delta kernel error: No files in log segment");
 }
+
+#[test]
+fn test_listed_log_files_contiguous_commit_files() {
+    let res = ListedLogFiles::try_new(
+        vec![
+            create_log_path("file:///00000000000000000001.json"),
+            create_log_path("file:///00000000000000000002.json"),
+            create_log_path("file:///00000000000000000003.json"),
+        ],
+        vec![],
+        vec![],
+        None,
+    );
+    assert!(res.is_ok());
+
+    let res = ListedLogFiles::try_new(
+        vec![
+            create_log_path("file:///00000000000000000001.json"),
+            create_log_path("file:///00000000000000000003.json"),
+        ],
+        vec![],
+        vec![],
+        None,
+    );
+
+    assert!(res.is_err());
+}

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -2031,5 +2031,17 @@ fn test_listed_log_files_contiguous_commit_files() {
         None,
     );
 
-    assert!(res.is_err());
+    assert_result_error_with_message(
+        res,
+        "Generic delta kernel error: Expected ordered \
+        contiguous commit files [ParsedLogPath { location: FileMeta { location: Url { scheme: \
+        \"file\", cannot_be_a_base: false, username: \"\", password: None, host: None, port: \
+        None, path: \"/00000000000000000001.json\", query: None, fragment: None }, last_modified: \
+        0, size: 0 }, filename: \"00000000000000000001.json\", extension: \"json\", version: 1, \
+        file_type: Commit }, ParsedLogPath { location: FileMeta { location: Url { scheme: \
+        \"file\", cannot_be_a_base: false, username: \"\", password: None, host: None, port: \
+        None, path: \"/00000000000000000003.json\", query: None, fragment: None }, last_modified: \
+        0, size: 0 }, filename: \"00000000000000000003.json\", extension: \"json\", version: 3, \
+        file_type: Commit }]",
+    );
 }

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -983,14 +983,14 @@ fn test_create_checkpoint_stream_errors_when_schema_has_remove_but_no_sidecar_ac
 
     // Create the stream over checkpoint batches.
     let log_segment = LogSegment::try_new(
-        ListedLogFiles::new(
+        ListedLogFiles::try_new(
             vec![],
             vec![],
             vec![create_log_path(
                 "file:///00000000000000000001.checkpoint.parquet",
             )],
             None,
-        ),
+        )?,
         log_root,
         None,
     )?;
@@ -1014,14 +1014,14 @@ fn test_create_checkpoint_stream_errors_when_schema_has_add_but_no_sidecar_actio
 
     // Create the stream over checkpoint batches.
     let log_segment = LogSegment::try_new(
-        ListedLogFiles::new(
+        ListedLogFiles::try_new(
             vec![],
             vec![],
             vec![create_log_path(
                 "file:///00000000000000000001.checkpoint.parquet",
             )],
             None,
-        ),
+        )?,
         log_root,
         None,
     )?;
@@ -1052,12 +1052,12 @@ fn test_create_checkpoint_stream_returns_checkpoint_batches_as_is_if_schema_has_
     let v2_checkpoint_read_schema = get_log_schema().project(&[METADATA_NAME])?;
 
     let log_segment = LogSegment::try_new(
-        ListedLogFiles::new(
+        ListedLogFiles::try_new(
             vec![],
             vec![],
             vec![create_log_path(&checkpoint_one_file)],
             None,
-        ),
+        )?,
         log_root,
         None,
     )?;
@@ -1111,7 +1111,7 @@ fn test_create_checkpoint_stream_returns_checkpoint_batches_if_checkpoint_is_mul
     let v2_checkpoint_read_schema = get_log_schema().project(&[ADD_NAME, SIDECAR_NAME])?;
 
     let log_segment = LogSegment::try_new(
-        ListedLogFiles::new(
+        ListedLogFiles::try_new(
             vec![],
             vec![],
             vec![
@@ -1119,7 +1119,7 @@ fn test_create_checkpoint_stream_returns_checkpoint_batches_if_checkpoint_is_mul
                 create_log_path(&checkpoint_two_file),
             ],
             None,
-        ),
+        )?,
         log_root,
         None,
     )?;
@@ -1165,12 +1165,12 @@ fn test_create_checkpoint_stream_reads_parquet_checkpoint_batch_without_sidecars
     let v2_checkpoint_read_schema = get_log_schema().project(&[ADD_NAME, SIDECAR_NAME])?;
 
     let log_segment = LogSegment::try_new(
-        ListedLogFiles::new(
+        ListedLogFiles::try_new(
             vec![],
             vec![],
             vec![create_log_path(&checkpoint_one_file)],
             None,
-        ),
+        )?,
         log_root,
         None,
     )?;
@@ -1211,12 +1211,12 @@ fn test_create_checkpoint_stream_reads_json_checkpoint_batch_without_sidecars() 
     let v2_checkpoint_read_schema = get_log_schema().project(&[ADD_NAME, SIDECAR_NAME])?;
 
     let log_segment = LogSegment::try_new(
-        ListedLogFiles::new(
+        ListedLogFiles::try_new(
             vec![],
             vec![],
             vec![create_log_path(&checkpoint_one_file)],
             None,
-        ),
+        )?,
         log_root,
         None,
     )?;
@@ -1278,12 +1278,12 @@ fn test_create_checkpoint_stream_reads_checkpoint_file_and_returns_sidecar_batch
     let v2_checkpoint_read_schema = get_log_schema().project(&[ADD_NAME, SIDECAR_NAME])?;
 
     let log_segment = LogSegment::try_new(
-        ListedLogFiles::new(
+        ListedLogFiles::try_new(
             vec![],
             vec![],
             vec![create_log_path(&checkpoint_file_path)],
             None,
-        ),
+        )?,
         log_root,
         None,
     )?;
@@ -1708,7 +1708,7 @@ fn test_commit_cover_minimal_overlap() {
 #[test]
 #[cfg(debug_assertions)]
 fn test_debug_assert_listed_log_file_in_order_compaction_files() {
-    let _ = ListedLogFiles::new(
+    let _ = ListedLogFiles::try_new(
         vec![],
         vec![
             create_log_path("file:///00000000000000000000.00000000000000000004.compacted.json"),
@@ -1723,7 +1723,7 @@ fn test_debug_assert_listed_log_file_in_order_compaction_files() {
 #[should_panic]
 #[cfg(debug_assertions)]
 fn test_debug_assert_listed_log_file_out_of_order_compaction_files() {
-    let _ = ListedLogFiles::new(
+    let _ = ListedLogFiles::try_new(
         vec![],
         vec![
             create_log_path("file:///00000000000000000000.00000000000000000004.compacted.json"),
@@ -1738,7 +1738,7 @@ fn test_debug_assert_listed_log_file_out_of_order_compaction_files() {
 #[should_panic]
 #[cfg(debug_assertions)]
 fn test_debug_assert_listed_log_file_different_multipart_checkpoint_versions() {
-    let _ = ListedLogFiles::new(
+    let _ = ListedLogFiles::try_new(
         vec![],
         vec![],
         vec![
@@ -1753,7 +1753,7 @@ fn test_debug_assert_listed_log_file_different_multipart_checkpoint_versions() {
 #[should_panic]
 #[cfg(debug_assertions)]
 fn test_debug_assert_listed_log_file_invalid_multipart_checkpoint() {
-    let _ = ListedLogFiles::new(
+    let _ = ListedLogFiles::try_new(
         vec![],
         vec![],
         vec![


### PR DESCRIPTION
fixes #995 

## What changes are proposed in this pull request?

This PR moves the `require!()` check from `LogSegment::try_new()` —> `ListedLogFiles::try_new()`

Originally, this issue was meant to explore if we could add this check inside the `debug_asserts` of #986 . However, I don't think this is an invariant specified by the [Protocol.md](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#delta-log-entries-1), so I think we should keep this as a runtime check.

+1 [Java kernel also has a runtime check](https://github.com/delta-io/delta/blob/5893f5c2bbccb9eea3b6d1b7c74bb72395269860/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/LogSegment.java#L184)

Also, this was labeled as a "breaking change" because the name changes of an internal API. I've removed the tag.

## How was this change tested?

I added test cases for testing the `ListedLogFiles::try_new()` and also passed `cargo nextest run`