### PR TITLE
refactor: deny panics in prod code

### DIFF
--- a/kernel/src/actions/deletion_vector.rs
+++ b/kernel/src/actions/deletion_vector.rs
@@ -271,6 +271,8 @@ pub fn split_vector(
         Some(vector) if split_index < vector.len() => Some(vector.split_off(split_index)),
         Some(vector) if extend.is_some() => {
             vector.extend(std::iter::repeat_n(
+                // safety: we just checked `is_some` above
+                #[allow(clippy::unwrap_used)]
                 extend.unwrap(),
                 split_index - vector.len(),
             ));

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -271,7 +271,7 @@ where
                 .collect()
         })
         .transpose()
-        .expect("Parsing FromStr should never fail with strum 'default'")
+        .ok()?
 }
 
 impl Protocol {

--- a/kernel/src/engine/arrow_conversion.rs
+++ b/kernel/src/engine/arrow_conversion.rs
@@ -280,7 +280,7 @@ impl TryFromArrow<&ArrowDataType> for DataType {
                     let value_type_nullable = struct_fields[1].is_nullable();
                     Ok(MapType::new(key_type, value_type, value_type_nullable).into())
                 } else {
-                    panic!("DataType::Map should contain a struct field child");
+                    unreachable!("DataType::Map should contain a struct field child");
                 }
             }
             // Dictionary types are just an optimized in-memory representation of an array.

--- a/kernel/src/engine/default/executor.rs
+++ b/kernel/src/engine/default/executor.rs
@@ -1,4 +1,4 @@
-// TODO: (make issue) remove panics in this file
+// TODO: (#1112) remove panics in this file
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::expect_used)]
 #![allow(clippy::panic)]

--- a/kernel/src/engine/default/executor.rs
+++ b/kernel/src/engine/default/executor.rs
@@ -1,3 +1,8 @@
+// TODO: (make issue) remove panics in this file
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::expect_used)]
+#![allow(clippy::panic)]
+
 //! The default engine uses Async IO to read files, but the kernel APIs are all
 //! synchronous. Therefore, we need an executor to run the async IO on in the
 //! background.

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -78,7 +78,7 @@ impl DataFileMetadata {
             builder.keys().append_value(k);
             builder.values().append_value(v);
         }
-        builder.append(true).unwrap();
+        builder.append(true)?;
         let partitions = Arc::new(builder.finish());
         // this means max size we can write is i64::MAX (~8EB)
         let size: i64 = (*size)

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -59,8 +59,13 @@
     trivial_numeric_casts,
     unused_extern_crates,
     rust_2018_idioms,
-    rust_2021_compatibility
+    rust_2021_compatibility,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic
 )]
+// we re-allow panics in tests
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
 
 /// This `extern crate` declaration allows the macro to reliably refer to
 /// `delta_kernel::schema::DataType` no matter which crate invokes it. Without that, `delta_kernel`

--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -85,6 +85,7 @@ impl<Location: AsUrl> ParsedLogPath<Location> {
     #[internal_api]
     pub(crate) fn try_from(location: Location) -> DeltaResult<Option<ParsedLogPath<Location>>> {
         let url = location.as_url();
+        #[allow(clippy::unwrap_used)]
         let filename = url
             .path_segments()
             .ok_or_else(|| Error::invalid_log_path(url))?
@@ -98,6 +99,7 @@ impl<Location: AsUrl> ParsedLogPath<Location> {
         let mut split = filename.split('.');
 
         // NOTE: str::split always returns at least one item, even for the empty string.
+        #[allow(clippy::unwrap_used)]
         let version = split.next().unwrap();
 
         // Every valid log path starts with a numeric version part. If version parsing fails, it

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -36,8 +36,12 @@ pub(crate) mod data_skipping;
 pub mod log_replay;
 pub mod state;
 
+// safety: we define get_log_schema() and _know_ it contains ADD_NAME and REMOVE_NAME
+#[allow(clippy::unwrap_used)]
 static COMMIT_READ_SCHEMA: LazyLock<SchemaRef> =
     LazyLock::new(|| get_log_schema().project(&[ADD_NAME, REMOVE_NAME]).unwrap());
+// safety: we define get_log_schema() and _know_ it contains ADD_NAME and SIDECAR_NAME
+#[allow(clippy::unwrap_used)]
 static CHECKPOINT_READ_SCHEMA: LazyLock<SchemaRef> =
     LazyLock::new(|| get_log_schema().project(&[ADD_NAME, SIDECAR_NAME]).unwrap());
 

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -246,6 +246,7 @@ impl StructField {
             }
         }
         // NOTE: unwrap is safe because the transformer is incapable of returning None
+        #[allow(clippy::unwrap_used)]
         MakePhysical
             .transform_struct_field(self)
             .unwrap()


### PR DESCRIPTION
## What changes are proposed in this pull request?
changes TLDR:
1. add clippy lints to deny panic in non-test code
2. fix most of them
3. make follow ups for (1) kernel/src/engine/default/executor.rs #1112, (2) do the same lints + fixes in FFI crate #1114 

details:
after running across many PR reviews which rely on humans to catch panics, this PR attempts to automate much of this by introducing the following clippy lints to warn (=deny for us) on panics in prod code. note that we still allow it in test code.
```
clippy::unwrap_used,
clippy::expect_used,
clippy::panic
```

## How was this change tested?
ran clippy