### PR TITLE
fix: use object_store >= 0.12.3 for arrow 55 feature

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -92,7 +92,7 @@ features = ["async", "object_store"]
 optional = true
 [dependencies.object_store_55]
 package = "object_store"
-version = "0.12"
+version = "0.12.3"
 features = ["aws", "azure", "gcp", "http"]
 optional = true
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
in #1071 we made a rename based on a change that landed in `object_store` 0.12.3 - need to make sure cargo doesn't select an object_store before 0.12.3, else we get the following error since the rename only occurred in 0.12.3+
```
error[E0432]: unresolved import `crate::object_store::PutMultipartOptions`
   --> kernel/src/engine/default/json.rs:264:9
    |
264 |     use crate::object_store::PutMultipartOptions;
    |         ^^^^^^^^^^^^^^^^^^^^^-------------------
    |         |                    |
    |         |                    help: a similar name exists in the module: `PutMultipartOpts`
    |         no `PutMultipartOptions` in the root

```

## How was this change tested?
manually