### PR TITLE
Fix failing test and improve indentation test error message

### DIFF
--- a/kernel/src/engine/ensure_data_types.rs
+++ b/kernel/src/engine/ensure_data_types.rs
@@ -343,7 +343,7 @@ mod tests {
                 &incorrect_variant_arrow_type(),
                 true,
             ),
-            "Invalid argument error: Incorrect datatype. Expected Struct(metadata Binary, value Binary), got Struct(field_1 Binary, field_2 Binary)",
+            r#"Invalid argument error: Incorrect datatype. Expected Struct([Field { name: "metadata", data_type: Binary, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: "value", data_type: Binary, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }]), got Struct([Field { name: "field_1", data_type: Binary, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: "field_2", data_type: Binary, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }])"#,
         )
     }
 

--- a/kernel/src/engine/ensure_data_types.rs
+++ b/kernel/src/engine/ensure_data_types.rs
@@ -343,7 +343,8 @@ mod tests {
                 &incorrect_variant_arrow_type(),
                 true,
             ),
-            r#"Invalid argument error: Incorrect datatype. Expected Struct([Field { name: "metadata", data_type: Binary, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: "value", data_type: Binary, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }]), got Struct([Field { name: "field_1", data_type: Binary, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }, Field { name: "field_2", data_type: Binary, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }])"#,
+            // Arrow has different printing for different versions. We use the common prefix
+            "Invalid argument error: Incorrect datatype. Expected Struct",
         )
     }
 

--- a/kernel/src/engine/ensure_data_types.rs
+++ b/kernel/src/engine/ensure_data_types.rs
@@ -343,7 +343,9 @@ mod tests {
                 &incorrect_variant_arrow_type(),
                 true,
             ),
-            // Arrow has different printing for different versions. We use the common prefix
+            // TODO(#1140): Arrow has different printing for different versions. We use the
+            // common prefix to check the error. Once the minimum version of arrow is greater
+            // than 55.1, assert the full message
             "Invalid argument error: Incorrect datatype. Expected Struct",
         )
     }

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -283,7 +283,7 @@ pub(crate) mod test_utils {
                 let error_str = error.to_string();
                 assert!(
                     error_str.contains(message),
-                    "Error message does not contain the expected message.\nExpected message: {message}\nActual message: {error_str}"
+                    "Error message does not contain the expected message.\nExpected message:\t{message}\nActual message:\t\t{error_str}"
                 );
             }
         }


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR fixes a test that fails on an error message to work across all arrow versions.  the error message depends on the Debug print of arrow type. Due to this [commit](https://github.com/apache/arrow-rs/pull/7469), the debug print result differs between arrow versions. 

 
## How was this change tested?
existing unit tests.

Indentation was tested by breaking a test and checking that the error message is easy to read.