### PR TITLE
feat: add CreateTableBuilder

### DIFF
--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -19,7 +19,7 @@ use crate::table_properties::TableProperties;
 use crate::utils::require;
 use crate::{
     DeltaResult, Engine, EngineData, Error, EvaluationHandlerExtension as _, FileMeta,
-    IntoEngineData, RowVisitor as _,
+    IntoEngineData, RowVisitor as _, KERNEL_VERSION,
 };
 
 use url::Url;
@@ -29,7 +29,6 @@ use delta_kernel_derive::{internal_api, IntoEngineData, ToSchema};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
-const KERNEL_VERSION: &str = env!("CARGO_PKG_VERSION");
 const UNKNOWN_OPERATION: &str = "UNKNOWN";
 
 pub mod deletion_vector;
@@ -96,6 +95,20 @@ static LOG_COMMIT_INFO_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
     )]))
 });
 
+static LOG_PROTOCOL_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
+    Arc::new(StructType::new([StructField::nullable(
+        PROTOCOL_NAME,
+        Protocol::to_schema(),
+    )]))
+});
+
+static LOG_METADATA_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
+    Arc::new(StructType::new([StructField::nullable(
+        METADATA_NAME,
+        Metadata::to_schema(),
+    )]))
+});
+
 static LOG_TXN_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
     Arc::new(StructType::new([StructField::nullable(
         SET_TRANSACTION_NAME,
@@ -122,6 +135,14 @@ pub(crate) fn get_log_add_schema() -> &'static SchemaRef {
 
 pub(crate) fn get_log_commit_info_schema() -> &'static SchemaRef {
     &LOG_COMMIT_INFO_SCHEMA
+}
+
+pub(crate) fn get_log_protocol_schema() -> &'static SchemaRef {
+    &LOG_PROTOCOL_SCHEMA
+}
+
+pub(crate) fn get_log_metadata_schema() -> &'static SchemaRef {
+    &LOG_METADATA_SCHEMA
 }
 
 pub(crate) fn get_log_txn_schema() -> &'static SchemaRef {

--- a/kernel/src/create_table.rs
+++ b/kernel/src/create_table.rs
@@ -1,0 +1,247 @@
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+use chrono::Utc;
+use url::Url;
+
+use crate::actions::{
+    get_log_commit_info_schema, get_log_metadata_schema, get_log_protocol_schema, CommitInfo,
+    Metadata, Protocol,
+};
+use crate::path::ParsedLogPath;
+use crate::schema::StructType;
+use crate::table_features::{ReaderFeature, WriterFeature};
+use crate::{DeltaResult, Engine, IntoEngineData};
+
+#[cfg(test)]
+mod tests;
+
+// default to 3, 7 with all our supported table features
+const DEFAULT_MIN_READER_VERSION: i32 = 3;
+const DEFAULT_MIN_WRITER_VERSION: i32 = 7;
+
+const DEFAULT_CREATE_TABLE_OPERATION: &str = "CREATE";
+
+// default to all features except catalog-managed
+static DEFAULT_READER_FEATURES: LazyLock<Vec<ReaderFeature>> = LazyLock::new(|| {
+    vec![
+        ReaderFeature::ColumnMapping,
+        ReaderFeature::DeletionVectors,
+        ReaderFeature::TimestampWithoutTimezone,
+        ReaderFeature::TypeWidening,
+        ReaderFeature::TypeWideningPreview,
+        ReaderFeature::VacuumProtocolCheck,
+        ReaderFeature::V2Checkpoint,
+        ReaderFeature::VariantType,
+        ReaderFeature::VariantTypePreview,
+        ReaderFeature::VariantShreddingPreview,
+    ]
+});
+
+// default to all features except invaiants (and catalog-managed after it lands)
+static DEFAULT_WRITER_FEATURES: LazyLock<Vec<WriterFeature>> = LazyLock::new(|| {
+    vec![
+        WriterFeature::AppendOnly,
+        WriterFeature::DeletionVectors,
+        WriterFeature::TimestampWithoutTimezone,
+        WriterFeature::VariantType,
+        WriterFeature::VariantTypePreview,
+        WriterFeature::VariantShreddingPreview,
+    ]
+});
+
+/// Builder to create a delta table. Pragmatically, this will just create a new table with all the
+/// specified configuration, schema, features at the specified root URL.
+///
+/// If only the minimal configuration (schema and table root) is provided, it will create a table
+/// with the default minimum reader version of 3, minimum writer version of 7, and all table
+/// features that kernel supports enabled.
+///
+/// Note that this builder does not create the table directory or the `_delta_log` directory if
+/// they do not already exist. It only writes the initial commit to the `_delta_log` directory at
+/// the time of calling `create()`.
+///
+/// Additionally note: this lazily validates configuration (that is, validates on `create()` call).
+///
+/// Currently, only CREATE is supported. In the future, REPLACE or CREATE OR REPLACE may be
+/// introduced. As a workaround for the REPLACE use cases, users can delete the entire table
+/// directory then call CREATE.
+#[derive(Debug)]
+pub struct CreateTableBuilder {
+    table_root: Url,
+    schema: StructType,
+    min_reader_version: i32,
+    min_writer_version: i32,
+    reader_features: Option<Vec<ReaderFeature>>,
+    writer_features: Option<Vec<WriterFeature>>,
+    partition_columns: Vec<String>,
+    timestamp: Option<i64>,
+    table_name: Option<String>,
+    description: Option<String>,
+    configuration: Option<HashMap<String, String>>,
+    operation: String,
+    engine_info: Option<String>,
+}
+
+impl CreateTableBuilder {
+    /// Create a new `CreateTable` builder for a table root and schema.
+    pub fn new(table_root: Url, schema: StructType) -> Self {
+        Self {
+            table_root,
+            schema,
+            min_reader_version: DEFAULT_MIN_READER_VERSION,
+            min_writer_version: DEFAULT_MIN_WRITER_VERSION,
+            reader_features: Some(DEFAULT_READER_FEATURES.to_vec()),
+            writer_features: Some(DEFAULT_WRITER_FEATURES.to_vec()),
+            partition_columns: vec![],
+            timestamp: None,
+            table_name: None,
+            description: None,
+            configuration: None,
+            operation: DEFAULT_CREATE_TABLE_OPERATION.to_string(),
+            engine_info: None,
+        }
+    }
+
+    /// Create an 'empty' table (i.e., a table with no columns in schema) with the given root URL.
+    pub fn empty(table_root: Url) -> Self {
+        Self::new(table_root, StructType::new([]))
+    }
+
+    /// Set the commit timestamp (in ms since unix epoch) for the table creation commit. If not set,
+    /// the current UTC time in ms since unix epoch is used.
+    pub fn with_timestamp(mut self, timestamp: i64) -> Self {
+        self.timestamp = Some(timestamp);
+        self
+    }
+
+    /// Set minimum reader version. Note that if the version is less than 3, reader features must
+    /// be empty (reader features are not supported in versions < 3).
+    pub fn with_min_reader_version(mut self, version: i32) -> Self {
+        self.min_reader_version = version;
+        self
+    }
+
+    /// Set minimum writer version. Note that if the version is less than 7, writer features must
+    /// be empty (writer features are not supported in versions < 7).
+    pub fn with_min_writer_version(mut self, version: i32) -> Self {
+        self.min_writer_version = version;
+        self
+    }
+
+    /// Set reader features. Note that the min_reader_version must be at least 3 in order to
+    /// support table features.
+    // TODO: should we eagerly check?
+    pub fn with_reader_features(mut self, features: impl Into<Vec<ReaderFeature>>) -> Self {
+        self.reader_features = Some(features.into());
+        self
+    }
+
+    /// Set writer features. Note that the min_writer_version must be at least 7 in order to
+    /// support table features.
+    // TODO: should we eagerly check?
+    pub fn with_writer_features(mut self, features: impl Into<Vec<WriterFeature>>) -> Self {
+        self.writer_features = Some(features.into());
+        self
+    }
+
+    /// Set partition columns for this table.
+    pub fn with_partition_columns(mut self, columns: impl Into<Vec<String>>) -> Self {
+        self.partition_columns = columns.into();
+        self
+    }
+
+    /// Set the table name.
+    pub fn with_table_name(mut self, name: impl Into<String>) -> Self {
+        self.table_name = Some(name.into());
+        self
+    }
+
+    /// Set the table description.
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Set the table configuration.
+    // TODO: what sort of API do we want for configuration and/or feature enablement? This allows a
+    // lot of flexibility, but if user just wants to e.g. enable ICT or append-only, they have to
+    // set the table features then additionally enable those features in the configuration
+    // manually.
+    pub fn with_configuration(mut self, config: HashMap<String, String>) -> Self {
+        self.configuration = Some(config);
+        self
+    }
+
+    /// Set the `commitInfo.operation` field. This is used to indicate the operation that was
+    /// occurring when the commit was made. The default is "CREATE".
+    pub fn with_operation(mut self, operation: impl Into<String>) -> Self {
+        self.operation = operation.into();
+        self
+    }
+
+    /// Set the `commitInfo.engineInfo` field. This is used to identify the engine that was used to
+    /// make the commit. The default is `None`, which means no engine information is recorded.
+    pub fn with_engine_commit_info(mut self, engine_info: impl Into<String>) -> Self {
+        self.engine_info = Some(engine_info.into());
+        self
+    }
+
+    /// Create the table. This will write the initial commit to the `_delta_log` directory at the
+    /// root of the table. Note that this does not create the table directory nor the `_delta_log`
+    /// directory if they do not already exist.
+    pub fn create(self, engine: &dyn Engine) -> DeltaResult<()> {
+        // creating a table requires the following steps:
+        // 1. create Metadata/Protocol actions to commit (ensure protocol is supported)
+        // 2. create CommitInfo action
+        // 3. write out <table_root>/_delta_log/00000000000000000000.json with the actions
+        //
+        // For now, we take two shortcuts:
+        // 1. we don't allow any other metadata/data operations during this commit (0.json only has
+        //    Protocol and Metadata and CommitInfo actions)
+        // 2. we don't return a snapshot of the table we just created. Note that we could just do
+        //    duplicate work to construct a snapshot to hand back, but that would just be the same
+        //    as the user calling `Snapshot::try_new` themselves.
+        let log_root = self.table_root.join("_delta_log")?;
+        let timestamp = self
+            .timestamp
+            .unwrap_or_else(|| Utc::now().timestamp_millis());
+        let metadata = Metadata::try_new(
+            self.table_name,
+            self.description,
+            self.schema,
+            self.partition_columns,
+            timestamp,
+            self.configuration.unwrap_or_default(),
+        )?;
+        let protocol = Protocol::try_new(
+            self.min_reader_version,
+            self.min_writer_version,
+            self.reader_features,
+            self.writer_features,
+        )?;
+
+        protocol.ensure_read_supported()?;
+        protocol.ensure_write_supported()?;
+
+        // The only dependency that CommitInfo has on other metadata is ICT configuration. Since we
+        // don't yet support ICT we can just create CommitInfo in isolation.
+        let commit_info = CommitInfo::new(timestamp, Some(self.operation), self.engine_info);
+
+        let actions = vec![
+            commit_info.into_engine_data(get_log_commit_info_schema().clone(), engine),
+            protocol.into_engine_data(get_log_protocol_schema().clone(), engine),
+            metadata.into_engine_data(get_log_metadata_schema().clone(), engine),
+        ];
+
+        let json_handler = engine.json_handler();
+        let commit_path = ParsedLogPath::new_commit(&log_root, 0)?;
+        json_handler.write_json_file(
+            &commit_path.location,
+            Box::new(actions.into_iter()),
+            false,
+        )?;
+
+        Ok(())
+    }
+}

--- a/kernel/src/create_table/tests.rs
+++ b/kernel/src/create_table/tests.rs
@@ -1,0 +1,109 @@
+use std::sync::Arc;
+
+use object_store::memory::InMemory;
+use object_store::{path::Path, ObjectStore};
+use serde_json::json;
+use url::Url;
+
+use crate::engine::default::{executor::tokio::TokioBackgroundExecutor, DefaultEngine};
+use crate::schema::{DataType, StructField, StructType};
+use crate::KERNEL_VERSION;
+
+use super::CreateTableBuilder;
+
+#[tokio::test]
+async fn create_table_simple() {
+    let store = Arc::new(InMemory::new());
+    let engine = DefaultEngine::new(store.clone(), Arc::new(TokioBackgroundExecutor::new()));
+    let table_root = Url::parse("memory:///test_table").unwrap();
+
+    let schema = StructType::new(vec![
+        StructField::new("id", DataType::LONG, false),
+        StructField::new("name", DataType::STRING, true),
+    ]);
+
+    CreateTableBuilder::new(table_root.clone(), schema)
+        .with_table_name("test_table")
+        .with_description("A test table")
+        .with_timestamp(1234567890)
+        .create(&engine)
+        .unwrap();
+
+    let commit_path = Path::from("_delta_log/00000000000000000000.json");
+    let data = store.get(&commit_path).await.unwrap();
+    let content = String::from_utf8(data.bytes().await.unwrap().to_vec()).unwrap();
+
+    let mut lines: Vec<serde_json::Value> = content
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+
+    lines.sort_by_key(|v| {
+        if v.get("commitInfo").is_some() {
+            0
+        } else if v.get("protocol").is_some() {
+            1
+        } else if v.get("metaData").is_some() {
+            2
+        } else {
+            3
+        }
+    });
+
+    let expected_commit_info = json!({
+        "commitInfo": {
+            "timestamp": 1234567890,
+            "operation": "CREATE",
+            "kernelVersion": format!("v{KERNEL_VERSION}"),
+            "operationParameters": {}
+        }
+    });
+
+    let expected_protocol = json!({
+        "protocol": {
+            "minReaderVersion": 3,
+            "minWriterVersion": 7,
+            "readerFeatures": [
+                "columnMapping",
+                "deletionVectors",
+                "timestampNtz",
+                "typeWidening",
+                "typeWidening-preview",
+                "vacuumProtocolCheck",
+                "v2Checkpoint",
+                "variantType",
+                "variantType-preview",
+                "variantShredding-preview"
+            ],
+            "writerFeatures": [
+                "appendOnly",
+                "deletionVectors",
+                "timestampNtz",
+                "variantType",
+                "variantType-preview",
+                "variantShredding-preview"
+            ]
+        }
+    });
+
+    let expected_metadata = json!({
+        "metaData": {
+            "id": lines[2]["metaData"]["id"].clone(),
+            "name": "test_table",
+            "description": "A test table",
+            "format": {
+                "provider": "parquet",
+                "options": {}
+            },
+            "schemaString": r#"{"type":"struct","fields":[{"name":"id","type":"long","nullable":false,"metadata":{}},{"name":"name","type":"string","nullable":true,"metadata":{}}]}"#,
+            "partitionColumns": [],
+            "configuration": {},
+            "createdTime": 1234567890
+        }
+    });
+
+    assert_eq!(lines[0], expected_commit_info);
+    assert_eq!(lines[1], expected_protocol);
+    assert_eq!(lines[2], expected_metadata);
+    assert_eq!(lines.len(), 3);
+}

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -98,6 +98,10 @@ pub mod table_features;
 pub mod table_properties;
 pub mod transaction;
 
+mod create_table;
+#[cfg(feature = "internal-api")]
+pub use create_table::CreateTableBuilder;
+
 mod arrow_compat;
 #[cfg(any(feature = "arrow-55", feature = "arrow-56"))]
 pub use arrow_compat::*;
@@ -155,6 +159,8 @@ use schema::{SchemaTransform, StructField, StructType};
     feature = "arrow-conversion"
 ))]
 pub mod engine;
+
+pub(crate) const KERNEL_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Delta table version is 8 byte unsigned int
 pub type Version = u64;


### PR DESCRIPTION
## What changes are proposed in this pull request?
Add a simple `CreateTableBuilder` which allows for creation of delta tables in a simple API which will effectively just PUT the 0.json commit in the table_root/_delta_log.

Example:
```rust
// for now, just returns `Result<()>`
CreateTableBuilder::new(table_root, schema)
    .with_table_name("test_table")
    .with_description("A test table")
    .with_timestamp(1234567890)
    .create(&engine)?;
```

For now, this is all only exposed as `internal-api`.

In the future this may graduate to being unified with our `Transaction` machinery.

Immediate follow-ups to consider:
- example for CREATE TABLE
- consider returning the snapshot we just created
- create issue for follow-ups and future inclusion in `Transaction` to unblock CTAS, etc.

## How was this change tested?
New UT