### PR TITLE
chore: bump MSRV to 1.84

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,5 @@ keywords = ["deltalake", "delta", "datalake"]
 license = "Apache-2.0"
 repository = "https://github.com/delta-io/delta-kernel-rs"
 readme = "README.md"
-rust-version = "1.82"
+rust-version = "1.84"
 version = "0.14.0"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Delta Kernel (rust) &emsp; [![build-status]][actions] [![latest-version]][crates.io] [![docs]][docs.rs] [![rustc-version-1.82+]][rustc]
+# Delta Kernel (rust) &emsp; [![build-status]][actions] [![latest-version]][crates.io] [![docs]][docs.rs] [![rustc-version-1.84+]][rustc]
 
 [build-status]: https://img.shields.io/github/actions/workflow/status/delta-io/delta-kernel-rs/build.yml?branch=main
 [actions]: https://github.com/delta-io/delta-kernel-rs/actions/workflows/build.yml?query=branch%3Amain
 [latest-version]: https://img.shields.io/crates/v/delta_kernel.svg
 [crates.io]: https://crates.io/crates/delta\_kernel
-[rustc-version-1.82+]: https://img.shields.io/badge/rustc-1.82+-lightgray.svg
-[rustc]: https://blog.rust-lang.org/2024/10/17/Rust-1.82.0/
+[rustc-version-1.84+]: https://img.shields.io/badge/rustc-1.84+-lightgray.svg
+[rustc]: https://blog.rust-lang.org/2025/01/09/Rust-1.84.0/
 [docs]: https://img.shields.io/docsrs/delta_kernel
 [docs.rs]: https://docs.rs/delta_kernel/latest/delta_kernel/
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
Bump our MSRV from rustc 1.82 to 1.84. It looks like arrow 56 has MSRV 1.84 so we will follow.

### This PR affects the following public APIs
MSRV 1.82 -> 1.84

## How was this change tested?
Existing