### PR TITLE
refactor(catalog-managed): LogSegmentBuilder

### DIFF
--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -225,7 +225,9 @@ fn build_snapshot_with_uuid_checkpoint_parquet() {
         None,
     );
 
-    let log_segment = LogSegment::for_snapshot(storage.as_ref(), log_root, None, None).unwrap();
+    let log_segment = LogSegment::build(log_root)
+        .build_complete(storage.as_ref())
+        .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -254,7 +256,9 @@ fn build_snapshot_with_uuid_checkpoint_json() {
         None,
     );
 
-    let log_segment = LogSegment::for_snapshot(storage.as_ref(), log_root, None, None).unwrap();
+    let log_segment = LogSegment::build(log_root)
+        .build_complete(storage.as_ref())
+        .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -295,8 +299,9 @@ fn build_snapshot_with_correct_last_uuid_checkpoint() {
         Some(&checkpoint_metadata),
     );
 
-    let log_segment =
-        LogSegment::for_snapshot(storage.as_ref(), log_root, checkpoint_metadata, None).unwrap();
+    let log_segment = LogSegment::build(log_root)
+        .build_complete_impl(storage.as_ref(), Some(checkpoint_metadata))
+        .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -332,7 +337,9 @@ fn build_snapshot_with_multiple_incomplete_multipart_checkpoints() {
         None,
     );
 
-    let log_segment = LogSegment::for_snapshot(storage.as_ref(), log_root, None, None).unwrap();
+    let log_segment = LogSegment::build(log_root)
+        .build_complete(storage.as_ref())
+        .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -370,8 +377,9 @@ fn build_snapshot_with_out_of_date_last_checkpoint() {
         Some(&checkpoint_metadata),
     );
 
-    let log_segment =
-        LogSegment::for_snapshot(storage.as_ref(), log_root, checkpoint_metadata, None).unwrap();
+    let log_segment = LogSegment::build(log_root)
+        .build_complete_impl(storage.as_ref(), Some(checkpoint_metadata))
+        .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -412,8 +420,9 @@ fn build_snapshot_with_correct_last_multipart_checkpoint() {
         Some(&checkpoint_metadata),
     );
 
-    let log_segment =
-        LogSegment::for_snapshot(storage.as_ref(), log_root, checkpoint_metadata, None).unwrap();
+    let log_segment = LogSegment::build(log_root)
+        .build_complete_impl(storage.as_ref(), Some(checkpoint_metadata))
+        .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -455,8 +464,8 @@ fn build_snapshot_with_missing_checkpoint_part_from_hint_fails() {
         Some(&checkpoint_metadata),
     );
 
-    let log_segment =
-        LogSegment::for_snapshot(storage.as_ref(), log_root, checkpoint_metadata, None);
+    let log_segment = LogSegment::build(log_root)
+        .build_complete_impl(storage.as_ref(), Some(checkpoint_metadata));
     assert_result_error_with_message(
         log_segment,
         "Invalid Checkpoint: Had a _last_checkpoint hint but didn't find any checkpoints",
@@ -492,8 +501,8 @@ fn build_snapshot_with_bad_checkpoint_hint_fails() {
         Some(&checkpoint_metadata),
     );
 
-    let log_segment =
-        LogSegment::for_snapshot(storage.as_ref(), log_root, checkpoint_metadata, None);
+    let log_segment = LogSegment::build(log_root)
+        .build_complete_impl(storage.as_ref(), Some(checkpoint_metadata));
     assert_result_error_with_message(
         log_segment,
         "Invalid Checkpoint: _last_checkpoint indicated that checkpoint should have 1 parts, but \
@@ -524,7 +533,9 @@ fn build_snapshot_with_missing_checkpoint_part_no_hint() {
         None,
     );
 
-    let log_segment = LogSegment::for_snapshot(storage.as_ref(), log_root, None, None).unwrap();
+    let log_segment = LogSegment::build(log_root)
+        .build_complete(storage.as_ref())
+        .unwrap();
 
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
@@ -569,8 +580,9 @@ fn build_snapshot_with_out_of_date_last_checkpoint_and_incomplete_recent_checkpo
         Some(&checkpoint_metadata),
     );
 
-    let log_segment =
-        LogSegment::for_snapshot(storage.as_ref(), log_root, checkpoint_metadata, None).unwrap();
+    let log_segment = LogSegment::build(log_root)
+        .build_complete_impl(storage.as_ref(), Some(checkpoint_metadata))
+        .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -602,8 +614,9 @@ fn build_snapshot_without_checkpoints() {
     );
 
     ///////// Specify no checkpoint or end version /////////
-    let log_segment =
-        LogSegment::for_snapshot(storage.as_ref(), log_root.clone(), None, None).unwrap();
+    let log_segment = LogSegment::build(log_root.clone())
+        .build_complete(storage.as_ref())
+        .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -616,7 +629,10 @@ fn build_snapshot_without_checkpoints() {
     assert_eq!(versions, expected_versions);
 
     ///////// Specify  only end version /////////
-    let log_segment = LogSegment::for_snapshot(storage.as_ref(), log_root, None, Some(2)).unwrap();
+    let log_segment = LogSegment::build(log_root)
+        .with_end_version_opt(Some(2))
+        .build_complete(storage.as_ref())
+        .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -657,8 +673,10 @@ fn build_snapshot_with_checkpoint_greater_than_time_travel_version() {
         None,
     );
 
-    let log_segment =
-        LogSegment::for_snapshot(storage.as_ref(), log_root, checkpoint_metadata, Some(4)).unwrap();
+    let log_segment = LogSegment::build(log_root)
+        .with_end_version_opt(Some(4))
+        .build_complete_impl(storage.as_ref(), Some(checkpoint_metadata))
+        .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -695,8 +713,10 @@ fn build_snapshot_with_start_checkpoint_and_time_travel_version() {
         Some(&checkpoint_metadata),
     );
 
-    let log_segment =
-        LogSegment::for_snapshot(storage.as_ref(), log_root, checkpoint_metadata, Some(4)).unwrap();
+    let log_segment = LogSegment::build(log_root)
+        .with_end_version_opt(Some(4))
+        .build_complete_impl(storage.as_ref(), Some(checkpoint_metadata))
+        .unwrap();
 
     assert_eq!(log_segment.checkpoint_parts[0].version, 3);
     assert_eq!(log_segment.ascending_commit_files.len(), 1);
@@ -723,8 +743,10 @@ fn build_table_changes_with_commit_versions() {
 
     ///////// Specify start version and end version /////////
 
-    let log_segment =
-        LogSegment::for_table_changes(storage.as_ref(), log_root.clone(), 2, 5).unwrap();
+    let log_segment = LogSegment::build(log_root.clone())
+        .with_end_version_opt(Some(5))
+        .build_incremental(2, storage.as_ref())
+        .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -737,8 +759,10 @@ fn build_table_changes_with_commit_versions() {
     assert_eq!(versions, expected_versions);
 
     ///////// Start version and end version are the same /////////
-    let log_segment =
-        LogSegment::for_table_changes(storage.as_ref(), log_root.clone(), 0, Some(0)).unwrap();
+    let log_segment = LogSegment::build(log_root.clone())
+        .with_end_version_opt(Some(0))
+        .build_incremental(0, storage.as_ref())
+        .unwrap();
 
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
@@ -750,7 +774,9 @@ fn build_table_changes_with_commit_versions() {
     assert_eq!(commit_files[0].version, 0);
 
     ///////// Specify no start or end version /////////
-    let log_segment = LogSegment::for_table_changes(storage.as_ref(), log_root, 0, None).unwrap();
+    let log_segment = LogSegment::build(log_root)
+        .build_incremental(0, storage.as_ref())
+        .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -775,7 +801,7 @@ fn test_non_contiguous_log() {
     );
 
     let log_segment_res =
-        LogSegment::for_table_changes(storage.as_ref(), log_root.clone(), 0, None);
+        LogSegment::build(log_root.clone()).build_incremental(0, storage.as_ref());
     // check the error message up to the timestamp
     let expected_error_pattern = "Generic delta kernel error: Expected ordered contiguous \
         commit files [ParsedLogPath { location: FileMeta { location: Url { scheme: \"memory\", \
@@ -784,13 +810,15 @@ fn test_non_contiguous_log() {
     assert_result_error_with_message(log_segment_res, expected_error_pattern);
 
     let log_segment_res =
-        LogSegment::for_table_changes(storage.as_ref(), log_root.clone(), 1, None);
+        LogSegment::build(log_root.clone()).build_incremental(1, storage.as_ref());
     assert_result_error_with_message(
         log_segment_res,
         "Generic delta kernel error: Expected the first commit to have version 1",
     );
 
-    let log_segment_res = LogSegment::for_table_changes(storage.as_ref(), log_root, 0, Some(1));
+    let log_segment_res = LogSegment::build(log_root)
+        .with_end_version_opt(Some(1))
+        .build_incremental(0, storage.as_ref());
     assert_result_error_with_message(
         log_segment_res,
         "Generic delta kernel error: LogSegment end version 0 not the same as the specified end \
@@ -808,7 +836,9 @@ fn table_changes_fails_with_larger_start_version_than_end() {
         ],
         None,
     );
-    let log_segment_res = LogSegment::for_table_changes(storage.as_ref(), log_root, 1, Some(0));
+    let log_segment_res = LogSegment::build(log_root)
+        .with_end_version_opt(Some(0))
+        .build_incremental(1, storage.as_ref());
     assert_result_error_with_message(log_segment_res, "Generic delta kernel error: Failed to build LogSegment: start_version cannot be greater than end_version");
 }
 #[test]
@@ -1352,7 +1382,10 @@ fn create_segment_for(
         ));
     }
     let (storage, log_root) = build_log_with_paths_and_checkpoint(&paths, None);
-    LogSegment::for_snapshot(storage.as_ref(), log_root.clone(), None, version_to_load).unwrap()
+    LogSegment::build(log_root.clone())
+        .with_end_version_opt(version_to_load)
+        .build_complete(storage.as_ref())
+        .unwrap()
 }
 
 #[test]
@@ -1856,8 +1889,10 @@ fn for_timestamp_conversion_gets_commit_range() {
         None,
     );
 
-    let log_segment =
-        LogSegment::for_timestamp_conversion(storage.as_ref(), log_root.clone(), 7, None).unwrap();
+    let log_segment = LogSegment::build(log_root.clone())
+        .with_end_version_opt(Some(7))
+        .build_for_timestamp_conversion(storage.as_ref(), None)
+        .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -1886,8 +1921,10 @@ fn for_timestamp_conversion_with_old_end_version() {
         None,
     );
 
-    let log_segment =
-        LogSegment::for_timestamp_conversion(storage.as_ref(), log_root.clone(), 5, None).unwrap();
+    let log_segment = LogSegment::build(log_root.clone())
+        .with_end_version_opt(Some(5))
+        .build_for_timestamp_conversion(storage.as_ref(), None)
+        .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -1916,8 +1953,10 @@ fn for_timestamp_conversion_only_contiguous_ranges() {
         None,
     );
 
-    let log_segment =
-        LogSegment::for_timestamp_conversion(storage.as_ref(), log_root.clone(), 7, None).unwrap();
+    let log_segment = LogSegment::build(log_root.clone())
+        .with_end_version_opt(Some(7))
+        .build_for_timestamp_conversion(storage.as_ref(), None)
+        .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -1946,13 +1985,10 @@ fn for_timestamp_conversion_with_limit() {
         None,
     );
 
-    let log_segment = LogSegment::for_timestamp_conversion(
-        storage.as_ref(),
-        log_root.clone(),
-        7,
-        Some(NonZero::new(3).unwrap()),
-    )
-    .unwrap();
+    let log_segment = LogSegment::build(log_root.clone())
+        .with_end_version_opt(Some(7))
+        .build_for_timestamp_conversion(storage.as_ref(), Some(NonZero::new(3).unwrap()))
+        .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -1980,13 +2016,10 @@ fn for_timestamp_conversion_with_large_limit() {
         None,
     );
 
-    let log_segment = LogSegment::for_timestamp_conversion(
-        storage.as_ref(),
-        log_root.clone(),
-        7,
-        Some(NonZero::new(20).unwrap()),
-    )
-    .unwrap();
+    let log_segment = LogSegment::build(log_root.clone())
+        .with_end_version_opt(Some(7))
+        .build_for_timestamp_conversion(storage.as_ref(), Some(NonZero::new(20).unwrap()))
+        .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -2003,7 +2036,9 @@ fn for_timestamp_conversion_no_commit_files() {
         None,
     );
 
-    let res = LogSegment::for_timestamp_conversion(storage.as_ref(), log_root.clone(), 0, None);
+    let res = LogSegment::build(log_root.clone())
+        .with_end_version_opt(Some(0))
+        .build_for_timestamp_conversion(storage.as_ref(), None);
     assert_result_error_with_message(res, "Generic delta kernel error: No files in log segment");
 }
 

--- a/kernel/src/table_changes/log_replay/tests.rs
+++ b/kernel/src/table_changes/log_replay/tests.rs
@@ -35,12 +35,9 @@ fn get_segment(
 ) -> DeltaResult<Vec<ParsedLogPath>> {
     let table_root = url::Url::from_directory_path(path).unwrap();
     let log_root = table_root.join("_delta_log/")?;
-    let log_segment = LogSegment::for_table_changes(
-        engine.storage_handler().as_ref(),
-        log_root,
-        start_version,
-        end_version,
-    )?;
+    let log_segment = LogSegment::build(log_root)
+        .with_end_version_opt(end_version.into())
+        .build_incremental(start_version, engine.storage_handler().as_ref())?;
     Ok(log_segment.ascending_commit_files)
 }
 

--- a/kernel/src/table_changes/mod.rs
+++ b/kernel/src/table_changes/mod.rs
@@ -140,12 +140,9 @@ impl TableChanges {
         end_version: Option<Version>,
     ) -> DeltaResult<Self> {
         let log_root = table_root.join("_delta_log/")?;
-        let log_segment = LogSegment::for_table_changes(
-            engine.storage_handler().as_ref(),
-            log_root,
-            start_version,
-            end_version,
-        )?;
+        let log_segment = LogSegment::build(log_root)
+            .with_end_version_opt(end_version)
+            .build_incremental(start_version, engine.storage_handler().as_ref())?;
 
         // Both snapshots ensure that reading is supported at the start and end version using
         // `ensure_read_supported`. Note that we must still verify that reading is

--- a/kernel/src/table_changes/scan_file.rs
+++ b/kernel/src/table_changes/scan_file.rs
@@ -326,9 +326,9 @@ mod tests {
 
         let table_root = url::Url::from_directory_path(mock_table.table_root()).unwrap();
         let log_root = table_root.join("_delta_log/").unwrap();
-        let log_segment =
-            LogSegment::for_table_changes(engine.storage_handler().as_ref(), log_root, 0, None)
-                .unwrap();
+        let log_segment = LogSegment::build(log_root)
+            .build_incremental(0, engine.storage_handler().as_ref())
+            .unwrap();
         let table_schema = StructType::new([
             StructField::nullable("id", DataType::INTEGER),
             StructField::nullable("value", DataType::STRING),


### PR DESCRIPTION
## What changes are proposed in this pull request?
Adds a new `LogSegmentBuilder` which encapsulates the 3 constructors we previously had for `LogSegment`. Now, `LogSegmentBuilder` can be created with start/end versions and then call `build_incremental`/`build_complete` to construct a `LogSegment`:

Ideally, trying to normalize around 2 main kinds of log segments: (1) complete - all actions in table appear exactly once, (2) incremental - subset of actions appear exactly once.
- `LogSegment::for_snapshot()` -> `LogSegment::build().with_end_version_opt().build_complete()`
- `LogSegment::for_table_changes()` -> `LogSegment::build().with_end_version_opt().build_incremental()`

There is a third constructor which includes addition logic specific to timestamp conversion which should likely be unified with incremental log segment but left as future work.
- `LogSegment::for_timestamp_conversion()` -> `LogSegment::build().with_end_version_opt().build_for_timestamp_conversion()`

The changes here pave the way for a new `with_log_tail` API (and `with_protocol_metadata` etc. in the future) to use for catalog managed tables.

Lastly, there are two major places where `LogSegment`s are manually modified and could probably also be either unified with builder API or include more methods on `LogSegment` to encapsulate the logic to incrementally update and trim the segment: (1) `Snapshot::try_new_from` and (2) `Scan::scan_metadata_from`.

## How was this change tested?
refactor: existing