### PR TITLE
feat(catalog-managed): experimental uc client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "kernel/examples/*",
     "test-utils",
     "feature-tests",
+    "uc-client", # WIP: this is an experimental UC client for catalog-managed table work
 ]
 # note that in addition to the members above, the workspace includes examples:
 # - inspect-table

--- a/uc-client/Cargo.toml
+++ b/uc-client/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "uc-client"
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+readme.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+# for cargo-release
+[package.metadata.release]
+release = false
+
+[dependencies]
+reqwest = { version = "0.12", features = ["json"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tokio = { version = "1", features = ["time"] }
+thiserror = "2.0"
+tracing = "0.1"
+url = "2.5"
+chrono = { version = "0.4", features = ["serde"] }
+
+[dev-dependencies]
+wiremock = "0.6"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+clap = { version = "4.5", features = ["derive", "env"] }

--- a/uc-client/README.md
+++ b/uc-client/README.md
@@ -1,0 +1,37 @@
+# uc-client
+
+An experimental/under-construction rust client for Unity Catalog. This crate is not intended for
+production use.
+
+## Example CLI
+This crate provides a command-line interface (CLI) to interact with Unity Catalog APIs, see
+`uc-client/examples/uc-cli.rs`.
+
+```bash
+# set environment variables for UC url/token
+UC_WORKSPACE_URL=https://some.uc.org
+UC_TOKEN=your-token
+
+# or set them in each command like
+cargo run --example uc-cli -- --workspace-url <url> --token <token> table catalog.schema.table
+
+# there are 3 operations:
+# 1. get table metadata
+cargo run --example uc-cli -- table catalog.schema.table
+
+# 2. get commits for a table (automatically resolves table id and storage location)
+cargo run --example uc-cli -- commits catalog.schema.table
+
+# or get commits with version range
+cargo run --example uc-cli -- commits catalog.schema.table \
+  --start-version 0 \
+  --end-version 10
+
+# 3. get temporary credentials
+cargo run --example uc-cli -- credentials \
+  --table-id "table-uuid" \
+  --operation READ
+
+# also can enable verbose logging
+cargo run --example uc-cli -- --verbose table catalog.schema.table
+```

--- a/uc-client/examples/uc-cli.rs
+++ b/uc-client/examples/uc-cli.rs
@@ -87,8 +87,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create client
     let client = UCClient::builder(&cli.workspace_url, &cli.token)
-        .timeout(Duration::from_secs(60))
-        .max_retries(3)
+        .with_timeout(Duration::from_secs(60))
+        .with_max_retries(3)
         .build()?;
 
     // Execute command

--- a/uc-client/examples/uc-cli.rs
+++ b/uc-client/examples/uc-cli.rs
@@ -1,0 +1,278 @@
+use clap::{Parser, Subcommand};
+use std::time::Duration;
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+use uc_client::{
+    models::{credentials::Operation, CommitsRequest},
+    UCClient,
+};
+
+#[derive(Parser)]
+#[command(name = "uc-client")]
+#[command(about = "Unity Catalog CLI client", long_about = None)]
+struct Cli {
+    /// Unity Catalog URL
+    #[arg(short, long, env = "UC_WORKSPACE_URL")]
+    workspace_url: String,
+
+    /// Authentication token
+    #[arg(short, long, env = "UC_TOKEN", hide_env_values = true)]
+    token: String,
+
+    /// Enable verbose logging
+    #[arg(short, long, default_value_t = false)]
+    verbose: bool,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Get table metadata
+    Table {
+        /// Full table name (catalog.schema.table)
+        #[arg(value_name = "TABLE")]
+        name: String,
+    },
+
+    /// Get commits for a table
+    Commits {
+        /// Full table name (catalog.schema.table)
+        #[arg(value_name = "TABLE")]
+        name: String,
+
+        /// Start version (optional)
+        #[arg(short, long)]
+        start_version: Option<i64>,
+
+        /// End version (optional)
+        #[arg(short, long)]
+        end_version: Option<i64>,
+    },
+
+    /// Get temporary credentials for a table
+    Credentials {
+        /// Table ID
+        #[arg(short, long)]
+        table_id: String,
+
+        /// Operation type (READ, WRITE, or READ_WRITE)
+        #[arg(short, long, value_parser = parse_operation, default_value = "READ")]
+        operation: Operation,
+    },
+}
+
+fn parse_operation(s: &str) -> Result<Operation, String> {
+    match s.to_uppercase().as_str() {
+        "READ" => Ok(Operation::Read),
+        "WRITE" => Ok(Operation::Write),
+        "READ_WRITE" | "READWRITE" => Ok(Operation::ReadWrite),
+        _ => Err(format!(
+            "Invalid operation '{}'. Must be READ, WRITE, or READ_WRITE",
+            s
+        )),
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = Cli::parse();
+
+    // Setup logging
+    let filter_level = if cli.verbose { "debug" } else { "info" };
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(filter_level)))
+        .init();
+
+    // Create client
+    let client = UCClient::builder(&cli.workspace_url, &cli.token)
+        .timeout(Duration::from_secs(60))
+        .max_retries(3)
+        .build()?;
+
+    // Execute command
+    match cli.command {
+        Commands::Table { name } => {
+            println!("Fetching table metadata for: {}", name);
+
+            match client.get_table(&name).await {
+                Ok(table) => {
+                    println!("\n✓ Table metadata retrieved successfully\n");
+                    println!("Full Name:        {}", table.full_name());
+                    println!("Catalog:          {}", table.catalog_name);
+                    println!("Schema:           {}", table.schema_name);
+                    println!("Table Name:       {}", table.name);
+                    println!("Type:             {}", table.table_type);
+                    println!("Format:           {}", table.data_source_format);
+                    println!("Storage Location: {}", table.storage_location);
+                    println!("Owner:            {}", table.owner);
+                    println!("Table ID:         {}", table.table_id);
+                    println!("Is Delta Table:   {}", table.is_delta_table());
+                    println!("Is Managed:       {}", table.is_managed_table());
+
+                    if !table.properties.is_empty() {
+                        println!("\nProperties:");
+                        for (key, value) in &table.properties {
+                            println!("  {}: {}", key, value);
+                        }
+                    }
+                }
+                Err(e) => {
+                    eprintln!("✗ Failed to get table: {}", e);
+                    std::process::exit(1);
+                }
+            }
+        }
+
+        Commands::Commits {
+            name,
+            start_version,
+            end_version,
+        } => {
+            println!("Resolving table: {}", name);
+
+            // First, get the table metadata to obtain table_id and storage_location
+            let table = match client.get_table(&name).await {
+                Ok(table) => {
+                    println!(
+                        "✓ Table resolved: {} (ID: {})",
+                        table.full_name(),
+                        table.table_id
+                    );
+                    table
+                }
+                Err(e) => {
+                    eprintln!("✗ Failed to resolve table: {}", e);
+                    std::process::exit(1);
+                }
+            };
+
+            println!("Fetching commits for table...");
+
+            let mut request = CommitsRequest::new(&table.table_id, &table.storage_location);
+
+            // Set start_version - default to 0 if not provided
+            let start = start_version.unwrap_or(0);
+            request = request.with_start_version(start);
+
+            if let Some(end) = end_version {
+                request = request.with_end_version(end);
+            }
+
+            match client.get_commits(request).await {
+                Ok(response) => {
+                    println!("\n✓ Commits retrieved successfully\n");
+                    println!("Table:           {}", table.full_name());
+                    println!("Latest Version:  {}", response.latest_table_version);
+
+                    if let Some(commits) = response.commits {
+                        println!("\nCommits ({} total):", commits.len());
+                        println!(
+                            "{:<8} {:<20} {:<40} {:<15}",
+                            "Version", "Timestamp", "File Name", "Size"
+                        );
+                        println!("{}", "-".repeat(85));
+
+                        for commit in commits {
+                            let timestamp_str = commit
+                                .timestamp_as_datetime()
+                                .map(|dt| dt.format("%Y-%m-%d %H:%M:%S").to_string())
+                                .unwrap_or_else(|| {
+                                    format!("Invalid timestamp: {}", commit.timestamp)
+                                });
+
+                            println!(
+                                "{:<8} {:<20} {:<40} {:<15}",
+                                commit.version,
+                                timestamp_str,
+                                if commit.file_name.len() > 40 {
+                                    format!("{}...", &commit.file_name[..37])
+                                } else {
+                                    commit.file_name.clone()
+                                },
+                                format_bytes(commit.file_size)
+                            );
+                        }
+                    } else {
+                        println!("No commits found in the specified range");
+                    }
+                }
+                Err(e) => {
+                    eprintln!("✗ Failed to get commits: {}", e);
+                    std::process::exit(1);
+                }
+            }
+        }
+
+        Commands::Credentials {
+            table_id,
+            operation,
+        } => {
+            println!(
+                "Getting {} credentials for table_id: {}",
+                operation, table_id
+            );
+
+            match client.get_credentials(&table_id, operation).await {
+                Ok(creds) => {
+                    println!("\n✓ Credentials retrieved successfully\n");
+                    println!("URL:              {}", creds.url);
+                    let expires_str = creds
+                        .expiration_as_datetime()
+                        .map(|dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
+                        .unwrap_or_else(|| format!("Invalid timestamp: {}", creds.expiration_time));
+                    println!("Expires at:       {}", expires_str);
+
+                    if let Some(time_left) = creds.time_until_expiry() {
+                        let hours = time_left.num_hours();
+                        let minutes = time_left.num_minutes() % 60;
+                        println!("Time until expiry: {} hours {} minutes", hours, minutes);
+                    } else {
+                        println!("Time until expiry: Unable to calculate");
+                    }
+
+                    if creds.is_expired() {
+                        println!("⚠ WARNING: Credentials are already expired!");
+                    }
+
+                    if let Some(aws_creds) = &creds.aws_temp_credentials {
+                        println!("\nAWS Credentials:");
+                        println!(
+                            "  Access Key ID:     {}...",
+                            &aws_creds.access_key_id[..10.min(aws_creds.access_key_id.len())]
+                        );
+                        println!("  Secret Access Key: ***hidden***");
+                        println!(
+                            "  Session Token:     {}...",
+                            &aws_creds.session_token[..10.min(aws_creds.session_token.len())]
+                        );
+                    }
+                }
+                Err(e) => {
+                    eprintln!("✗ Failed to get credentials: {}", e);
+                    std::process::exit(1);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn format_bytes(bytes: i64) -> String {
+    const UNITS: &[&str] = &["B", "KB", "MB", "GB", "TB"];
+    let mut size = bytes as f64;
+    let mut unit_index = 0;
+
+    while size >= 1024.0 && unit_index < UNITS.len() - 1 {
+        size /= 1024.0;
+        unit_index += 1;
+    }
+
+    if unit_index == 0 {
+        format!("{} {}", size as i64, UNITS[unit_index])
+    } else {
+        format!("{:.2} {}", size, UNITS[unit_index])
+    }
+}

--- a/uc-client/src/client.rs
+++ b/uc-client/src/client.rs
@@ -1,0 +1,200 @@
+use std::future::Future;
+use std::time::Duration;
+
+use reqwest::{header, Client, Response, StatusCode};
+use tracing::{instrument, warn};
+use url::Url;
+
+use crate::config::{ClientConfig, ClientConfigBuilder};
+use crate::error::{Error, Result};
+use crate::models::commits::{CommitsRequest, CommitsResponse};
+use crate::models::credentials::{CredentialsRequest, Operation, TemporaryTableCredentials};
+use crate::models::tables::TablesResponse;
+
+#[derive(Debug, Clone)]
+pub struct UCClient {
+    client: Client,
+    config: ClientConfig,
+    base_url: Url,
+}
+
+impl UCClient {
+    pub fn new(config: ClientConfig) -> Result<Self> {
+        // default headers with authorization and content type
+        let mut headers = header::HeaderMap::new();
+        headers.insert(
+            header::AUTHORIZATION,
+            header::HeaderValue::from_str(&format!("Bearer {}", config.token))?,
+        );
+        headers.insert(
+            header::CONTENT_TYPE,
+            header::HeaderValue::from_static("application/json"),
+        );
+
+        let client = Client::builder()
+            .default_headers(headers)
+            .timeout(config.timeout)
+            .connect_timeout(config.connect_timeout)
+            .build()?;
+
+        Ok(Self {
+            client,
+            base_url: config.workspace_url.clone(),
+            config,
+        })
+    }
+
+    pub fn builder(workspace: impl Into<String>, token: impl Into<String>) -> UCClientBuilder {
+        UCClientBuilder::new(workspace, token)
+    }
+
+    #[instrument(skip(self))]
+    pub async fn get_commits(&self, request: CommitsRequest) -> Result<CommitsResponse> {
+        let url = self.base_url.join("delta/preview/commits")?;
+
+        let response = self
+            .execute_with_retry(|| {
+                self.client
+                    .request(reqwest::Method::GET, url.clone())
+                    .json(&request)
+                    .send()
+            })
+            .await?;
+
+        self.handle_response(response).await
+    }
+
+    #[instrument(skip(self))]
+    pub async fn get_table(&self, table_name: &str) -> Result<TablesResponse> {
+        let url = self.base_url.join(&format!("tables/{}", table_name))?;
+
+        let response = self
+            .execute_with_retry(|| self.client.get(url.clone()).send())
+            .await?;
+
+        match response.status() {
+            StatusCode::NOT_FOUND => Err(Error::TableNotFound(table_name.to_string())),
+            _ => self.handle_response(response).await,
+        }
+    }
+
+    #[instrument(skip(self))]
+    pub async fn get_credentials(
+        &self,
+        table_id: &str,
+        operation: Operation,
+    ) -> Result<TemporaryTableCredentials> {
+        let url = self.base_url.join("temporary-table-credentials")?;
+
+        let request_body = CredentialsRequest::new(table_id, operation);
+        let response = self
+            .execute_with_retry(|| self.client.post(url.clone()).json(&request_body).send())
+            .await?;
+
+        self.handle_response(response).await
+    }
+
+    async fn execute_with_retry<F, Fut>(&self, f: F) -> Result<Response>
+    where
+        F: Fn() -> Fut,
+        Fut: Future<Output = std::result::Result<Response, reqwest::Error>>,
+    {
+        let mut retries = 0;
+        let max_retries = self.config.max_retries;
+
+        loop {
+            match f().await {
+                Ok(response) => {
+                    if response.status().is_server_error() && retries < max_retries {
+                        retries += 1;
+                        warn!(
+                            "Server error {}, retrying (attempt {}/{})",
+                            response.status(),
+                            retries,
+                            max_retries
+                        );
+                        tokio::time::sleep(self.config.retry_base_delay * retries).await;
+                        continue;
+                    }
+                    return Ok(response);
+                }
+                Err(e) => {
+                    if retries >= max_retries {
+                        return Err(Error::from(e));
+                    }
+                    retries += 1;
+                    warn!(
+                        "Request failed, retrying (attempt {}/{}): {}",
+                        retries, max_retries, e
+                    );
+                    tokio::time::sleep(self.config.retry_base_delay * retries).await;
+                }
+            }
+        }
+    }
+
+    async fn handle_response<T>(&self, response: Response) -> Result<T>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        let status = response.status();
+
+        if status.is_success() {
+            response.json::<T>().await.map_err(Error::from)
+        } else {
+            let error_body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+
+            match status {
+                StatusCode::UNAUTHORIZED => Err(Error::AuthenticationFailed),
+                StatusCode::NOT_FOUND => Err(Error::ApiError {
+                    status: status.as_u16(),
+                    message: format!("Resource not found: {}", error_body),
+                }),
+                _ => Err(Error::ApiError {
+                    status: status.as_u16(),
+                    message: error_body,
+                }),
+            }
+        }
+    }
+}
+
+pub struct UCClientBuilder {
+    config_builder: ClientConfigBuilder,
+}
+
+impl UCClientBuilder {
+    pub fn new(workspace: impl Into<String>, token: impl Into<String>) -> Self {
+        Self {
+            config_builder: ClientConfig::builder(workspace, token),
+        }
+    }
+
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.config_builder = self.config_builder.timeout(timeout);
+        self
+    }
+
+    pub fn connect_timeout(mut self, timeout: Duration) -> Self {
+        self.config_builder = self.config_builder.connect_timeout(timeout);
+        self
+    }
+
+    pub fn max_retries(mut self, retries: u32) -> Self {
+        self.config_builder = self.config_builder.max_retries(retries);
+        self
+    }
+
+    pub fn retry_delays(mut self, base: Duration, max: Duration) -> Self {
+        self.config_builder = self.config_builder.retry_delays(base, max);
+        self
+    }
+
+    pub fn build(self) -> Result<UCClient> {
+        let config = self.config_builder.build()?;
+        UCClient::new(config)
+    }
+}

--- a/uc-client/src/config.rs
+++ b/uc-client/src/config.rs
@@ -1,0 +1,103 @@
+use std::time::Duration;
+
+use url::Url;
+
+use crate::error::Result;
+
+#[derive(Debug, Clone)]
+pub struct ClientConfig {
+    pub workspace_url: Url,
+    pub token: String,
+    pub timeout: Duration,
+    pub connect_timeout: Duration,
+    pub max_retries: u32,
+    pub retry_base_delay: Duration,
+    pub retry_max_delay: Duration,
+}
+
+impl ClientConfig {
+    pub fn new(workspace: impl Into<String>, token: impl Into<String>) -> Result<Self> {
+        let workspace_str = workspace.into();
+        let base_url =
+            if workspace_str.starts_with("http://") || workspace_str.starts_with("https://") {
+                workspace_str
+            } else {
+                format!("https://{}", workspace_str)
+            };
+
+        let mut workspace_url = Url::parse(&base_url)?;
+        if !workspace_url.path().ends_with('/') {
+            workspace_url.set_path(&format!("{}/", workspace_url.path()));
+        }
+        workspace_url.set_path(&format!("{}api/2.1/unity-catalog/", workspace_url.path()));
+
+        Ok(Self {
+            workspace_url,
+            token: token.into(),
+            timeout: Duration::from_secs(30),
+            connect_timeout: Duration::from_secs(10),
+            max_retries: 3,
+            retry_base_delay: Duration::from_millis(500),
+            retry_max_delay: Duration::from_secs(10),
+        })
+    }
+
+    pub fn builder(workspace: impl Into<String>, token: impl Into<String>) -> ClientConfigBuilder {
+        ClientConfigBuilder::new(workspace, token)
+    }
+}
+
+pub struct ClientConfigBuilder {
+    workspace: String,
+    token: String,
+    timeout: Duration,
+    connect_timeout: Duration,
+    max_retries: u32,
+    retry_base_delay: Duration,
+    retry_max_delay: Duration,
+}
+
+impl ClientConfigBuilder {
+    pub fn new(workspace: impl Into<String>, token: impl Into<String>) -> Self {
+        Self {
+            workspace: workspace.into(),
+            token: token.into(),
+            timeout: Duration::from_secs(30),
+            connect_timeout: Duration::from_secs(10),
+            max_retries: 3,
+            retry_base_delay: Duration::from_millis(500),
+            retry_max_delay: Duration::from_secs(10),
+        }
+    }
+
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    pub fn connect_timeout(mut self, timeout: Duration) -> Self {
+        self.connect_timeout = timeout;
+        self
+    }
+
+    pub fn max_retries(mut self, retries: u32) -> Self {
+        self.max_retries = retries;
+        self
+    }
+
+    pub fn retry_delays(mut self, base: Duration, max: Duration) -> Self {
+        self.retry_base_delay = base;
+        self.retry_max_delay = max;
+        self
+    }
+
+    pub fn build(self) -> Result<ClientConfig> {
+        let mut config = ClientConfig::new(self.workspace, self.token)?;
+        config.timeout = self.timeout;
+        config.connect_timeout = self.connect_timeout;
+        config.max_retries = self.max_retries;
+        config.retry_base_delay = self.retry_base_delay;
+        config.retry_max_delay = self.retry_max_delay;
+        Ok(config)
+    }
+}

--- a/uc-client/src/error.rs
+++ b/uc-client/src/error.rs
@@ -1,0 +1,33 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+
+    #[error("Invalid header value: {0}")]
+    InvalidHeaderValue(#[from] reqwest::header::InvalidHeaderValue),
+
+    #[error("URL parse error: {0}")]
+    UrlParse(#[from] url::ParseError),
+
+    #[error("Serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+
+    #[error("API error (status {status}): {message}")]
+    ApiError { status: u16, message: String },
+
+    #[error("Table not found: {0}")]
+    TableNotFound(String),
+
+    #[error("Invalid configuration: {0}")]
+    InvalidConfiguration(String),
+
+    #[error("Authentication failed")]
+    AuthenticationFailed,
+
+    #[error("Operation not supported: {0}")]
+    UnsupportedOperation(String),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/uc-client/src/error.rs
+++ b/uc-client/src/error.rs
@@ -28,6 +28,9 @@ pub enum Error {
 
     #[error("Operation not supported: {0}")]
     UnsupportedOperation(String),
+
+    #[error("Max retries exceeded")]
+    MaxRetriesExceeded,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/uc-client/src/lib.rs
+++ b/uc-client/src/lib.rs
@@ -1,0 +1,43 @@
+//! Unity Catalog Client for Rust
+//!
+//! This crate provides a Rust client for interacting with Unity Catalog APIs.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use uc_client::{UCClient, models::CommitsRequest};
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let client = UCClient::builder("uc.awesome.org", "your-token")
+//!         .build()?;
+//!
+//!     let request = CommitsRequest::new("table-id", "table-uri");
+//!     let commits = client.get_commits(request).await?;
+//!
+//!     Ok(())
+//! }
+//! ```
+
+pub mod client;
+pub mod config;
+pub mod error;
+pub mod models;
+
+#[cfg(test)]
+mod tests;
+
+pub use client::{UCClient, UCClientBuilder};
+pub use config::{ClientConfig, ClientConfigBuilder};
+pub use error::{Error, Result};
+
+#[doc(hidden)]
+pub mod prelude {
+    pub use crate::client::UCClient;
+    pub use crate::error::Result;
+    pub use crate::models::{
+        commits::{Commit, CommitsRequest, CommitsResponse},
+        credentials::{Operation, TemporaryTableCredentials},
+        tables::TablesResponse,
+    };
+}

--- a/uc-client/src/models/commits.rs
+++ b/uc-client/src/models/commits.rs
@@ -1,0 +1,60 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommitsRequest {
+    pub table_id: String,
+    pub table_uri: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_version: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_version: Option<i64>,
+}
+
+impl CommitsRequest {
+    pub fn new(table_id: impl Into<String>, table_uri: impl Into<String>) -> Self {
+        Self {
+            table_id: table_id.into(),
+            table_uri: table_uri.into(),
+            start_version: None,
+            end_version: None,
+        }
+    }
+
+    pub fn with_start_version(mut self, version: i64) -> Self {
+        self.start_version = Some(version);
+        self
+    }
+
+    pub fn with_end_version(mut self, version: i64) -> Self {
+        self.end_version = Some(version);
+        self
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommitsResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commits: Option<Vec<Commit>>,
+    pub latest_table_version: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Commit {
+    pub version: i64,
+    pub timestamp: i64,
+    pub file_name: String,
+    pub file_size: i64,
+    pub file_modification_timestamp: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_disown_commit: Option<bool>,
+}
+
+impl Commit {
+    pub fn timestamp_as_datetime(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+        chrono::DateTime::from_timestamp_millis(self.timestamp)
+    }
+
+    pub fn file_modification_as_datetime(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+        chrono::DateTime::from_timestamp_millis(self.file_modification_timestamp)
+    }
+}

--- a/uc-client/src/models/credentials.rs
+++ b/uc-client/src/models/credentials.rs
@@ -14,9 +14,9 @@ impl TemporaryTableCredentials {
     }
 
     pub fn is_expired(&self) -> bool {
+        // If we can't parse the timestamp, consider it expired for safety
         self.expiration_as_datetime()
-            .map(|exp| exp < chrono::Utc::now())
-            .unwrap_or(true) // If we can't parse the timestamp, consider it expired for safety
+            .is_none_or(|exp| exp < chrono::Utc::now())
     }
 
     pub fn time_until_expiry(&self) -> Option<chrono::Duration> {

--- a/uc-client/src/models/credentials.rs
+++ b/uc-client/src/models/credentials.rs
@@ -1,0 +1,67 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TemporaryTableCredentials {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub aws_temp_credentials: Option<AwsTempCredentials>,
+    pub expiration_time: i64,
+    pub url: String,
+}
+
+impl TemporaryTableCredentials {
+    pub fn expiration_as_datetime(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+        chrono::DateTime::from_timestamp_millis(self.expiration_time)
+    }
+
+    pub fn is_expired(&self) -> bool {
+        self.expiration_as_datetime()
+            .map(|exp| exp < chrono::Utc::now())
+            .unwrap_or(true) // If we can't parse the timestamp, consider it expired for safety
+    }
+
+    pub fn time_until_expiry(&self) -> Option<chrono::Duration> {
+        self.expiration_as_datetime()
+            .map(|exp| exp - chrono::Utc::now())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AwsTempCredentials {
+    pub access_key_id: String,
+    pub secret_access_key: String,
+    pub session_token: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum Operation {
+    Read,
+    Write,
+    #[serde(rename = "READ_WRITE")]
+    ReadWrite,
+}
+
+impl std::fmt::Display for Operation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Operation::Read => write!(f, "READ"),
+            Operation::Write => write!(f, "WRITE"),
+            Operation::ReadWrite => write!(f, "READ_WRITE"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CredentialsRequest {
+    pub table_id: String,
+    pub operation: Operation,
+}
+
+impl CredentialsRequest {
+    pub fn new(table_id: impl Into<String>, operation: Operation) -> Self {
+        Self {
+            table_id: table_id.into(),
+            operation,
+        }
+    }
+}

--- a/uc-client/src/models/mod.rs
+++ b/uc-client/src/models/mod.rs
@@ -1,0 +1,7 @@
+pub mod commits;
+pub mod credentials;
+pub mod tables;
+
+pub use commits::{Commit, CommitsRequest, CommitsResponse};
+pub use credentials::{AwsTempCredentials, TemporaryTableCredentials};
+pub use tables::TablesResponse;

--- a/uc-client/src/models/tables.rs
+++ b/uc-client/src/models/tables.rs
@@ -1,0 +1,39 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+// note this is a subset of actual get tables response
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TablesResponse {
+    pub name: String,
+    pub catalog_name: String,
+    pub schema_name: String,
+    pub table_type: String,
+    pub data_source_format: String,
+    pub storage_location: String,
+    pub owner: String,
+    #[serde(default)]
+    pub properties: HashMap<String, String>,
+    pub securable_kind: String,
+    pub metastore_id: String,
+    pub table_id: String,
+    pub schema_id: String,
+    pub catalog_id: String,
+}
+
+impl TablesResponse {
+    pub fn full_name(&self) -> String {
+        format!("{}.{}.{}", self.catalog_name, self.schema_name, self.name)
+    }
+
+    pub fn is_delta_table(&self) -> bool {
+        self.data_source_format.eq_ignore_ascii_case("delta")
+    }
+
+    pub fn is_managed_table(&self) -> bool {
+        self.table_type.eq_ignore_ascii_case("managed")
+    }
+
+    pub fn is_external_table(&self) -> bool {
+        self.table_type.eq_ignore_ascii_case("external")
+    }
+}

--- a/uc-client/src/models/tables.rs
+++ b/uc-client/src/models/tables.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::fmt::{self, Display};
 
 // note this is a subset of actual get tables response
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -35,5 +36,31 @@ impl TablesResponse {
 
     pub fn is_external_table(&self) -> bool {
         self.table_type.eq_ignore_ascii_case("external")
+    }
+}
+
+impl Display for TablesResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Full Name:        {}", self.full_name())?;
+        writeln!(f, "Catalog:          {}", self.catalog_name)?;
+        writeln!(f, "Schema:           {}", self.schema_name)?;
+        writeln!(f, "Table Name:       {}", self.name)?;
+        writeln!(f, "Type:             {}", self.table_type)?;
+        writeln!(f, "Format:           {}", self.data_source_format)?;
+        writeln!(f, "Storage Location: {}", self.storage_location)?;
+        writeln!(f, "Owner:            {}", self.owner)?;
+        writeln!(f, "Table ID:         {}", self.table_id)?;
+        writeln!(f, "Is Delta Table:   {}", self.is_delta_table())?;
+        writeln!(f, "Is Managed:       {}", self.is_managed_table())?;
+
+        if !self.properties.is_empty() {
+            writeln!(f)?;
+            writeln!(f, "Properties:")?;
+            for (key, value) in &self.properties {
+                writeln!(f, "  {}: {}", key, value)?;
+            }
+        }
+
+        Ok(())
     }
 }

--- a/uc-client/src/tests.rs
+++ b/uc-client/src/tests.rs
@@ -1,4 +1,3 @@
-use crate::config::ClientConfig;
 use crate::models::commits::CommitsRequest;
 use crate::models::credentials::Operation;
 
@@ -19,30 +18,6 @@ fn test_operation_display() {
     assert_eq!(Operation::Read.to_string(), "READ");
     assert_eq!(Operation::Write.to_string(), "WRITE");
     assert_eq!(Operation::ReadWrite.to_string(), "READ_WRITE");
-}
-
-#[test]
-fn test_client_config() {
-    let config = ClientConfig::new("some-workspace.something.com", "token").unwrap();
-    assert!(config
-        .workspace_url
-        .as_str()
-        .contains("api/2.1/unity-catalog"));
-    assert_eq!(config.token, "token");
-}
-
-#[test]
-fn test_client_config_builder() {
-    use std::time::Duration;
-
-    let config = ClientConfig::builder("some-workspace.something.com", "token")
-        .timeout(Duration::from_secs(60))
-        .max_retries(5)
-        .build()
-        .unwrap();
-
-    assert_eq!(config.timeout, Duration::from_secs(60));
-    assert_eq!(config.max_retries, 5);
 }
 
 #[test]

--- a/uc-client/src/tests.rs
+++ b/uc-client/src/tests.rs
@@ -1,0 +1,73 @@
+use crate::config::ClientConfig;
+use crate::models::commits::CommitsRequest;
+use crate::models::credentials::Operation;
+
+#[test]
+fn test_commits_request_builder() {
+    let request = CommitsRequest::new("test-id", "test-uri")
+        .with_start_version(1)
+        .with_end_version(10);
+
+    assert_eq!(request.table_id, "test-id");
+    assert_eq!(request.table_uri, "test-uri");
+    assert_eq!(request.start_version, Some(1));
+    assert_eq!(request.end_version, Some(10));
+}
+
+#[test]
+fn test_operation_display() {
+    assert_eq!(Operation::Read.to_string(), "READ");
+    assert_eq!(Operation::Write.to_string(), "WRITE");
+    assert_eq!(Operation::ReadWrite.to_string(), "READ_WRITE");
+}
+
+#[test]
+fn test_client_config() {
+    let config = ClientConfig::new("some-workspace.something.com", "token").unwrap();
+    assert!(config
+        .workspace_url
+        .as_str()
+        .contains("api/2.1/unity-catalog"));
+    assert_eq!(config.token, "token");
+}
+
+#[test]
+fn test_client_config_builder() {
+    use std::time::Duration;
+
+    let config = ClientConfig::builder("some-workspace.something.com", "token")
+        .timeout(Duration::from_secs(60))
+        .max_retries(5)
+        .build()
+        .unwrap();
+
+    assert_eq!(config.timeout, Duration::from_secs(60));
+    assert_eq!(config.max_retries, 5);
+}
+
+#[test]
+fn test_table_response_helpers() {
+    use crate::models::tables::TablesResponse;
+    use std::collections::HashMap;
+
+    let table = TablesResponse {
+        name: "my_table".to_string(),
+        catalog_name: "catalog".to_string(),
+        schema_name: "schema".to_string(),
+        table_type: "MANAGED".to_string(),
+        data_source_format: "DELTA".to_string(),
+        storage_location: "/path/to/table".to_string(),
+        owner: "user".to_string(),
+        properties: HashMap::new(),
+        securable_kind: "TABLE".to_string(),
+        metastore_id: "metastore-id".to_string(),
+        table_id: "table-id".to_string(),
+        schema_id: "schema-id".to_string(),
+        catalog_id: "catalog-id".to_string(),
+    };
+
+    assert_eq!(table.full_name(), "catalog.schema.my_table");
+    assert!(table.is_delta_table());
+    assert!(table.is_managed_table());
+    assert!(!table.is_external_table());
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?
Add `uc-client` crate: experimental, minimal UC rust client. It implements the handful of APIs needed to interact with UC for catalog-managed tables. This create _will not be released_ in its current form and exists only to unblock future catalog-managed tables work.

## How was this change tested?
Ran CLI example against existing UC deployment