### PR TITLE
feat!(catalog-managed): add catalog-managed table features + feature flag

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -105,6 +105,10 @@ arrow-56 = ["dep:arrow_56", "dep:parquet_56", "object_store"]
 arrow-conversion = ["need-arrow"]
 arrow-expression = ["need-arrow"]
 
+# WARNING: experimental feature, still under active development
+# enables new experimental catalog-managed tables support
+catalog-managed = []
+
 # this is an 'internal' feature flag which has all the shared bits from default-engine and
 # default-engine-rustls
 default-engine-base = [
@@ -127,7 +131,7 @@ default-engine-rustls = [
 rustc_version = "0.4.1"
 
 [dev-dependencies]
-delta_kernel = { path = ".", features = ["arrow", "default-engine-rustls", "internal-api"] }
+delta_kernel = { path = ".", features = ["arrow", "catalog-managed", "default-engine-rustls", "internal-api"] }
 test_utils = { path = "../test-utils" }
 # Used for testing parse_url_opts extensibility
 hdfs-native-object-store = { version = "0.14.0" }

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -37,6 +37,11 @@ mod timestamp_ntz;
 #[serde(rename_all = "camelCase")]
 #[internal_api]
 pub(crate) enum ReaderFeature {
+    /// CatalogManaged tables: https://github.com/delta-io/delta/blob/master/protocol_rfcs/catalog-managed.md
+    CatalogManaged,
+    #[strum(serialize = "catalogOwned-preview")]
+    #[serde(rename = "catalogOwned-preview")]
+    CatalogOwnedPreview,
     /// Mapping of one column to another
     ColumnMapping,
     /// Deletion vectors for merge, update, delete
@@ -90,6 +95,11 @@ pub(crate) enum ReaderFeature {
 #[serde(rename_all = "camelCase")]
 #[internal_api]
 pub(crate) enum WriterFeature {
+    /// CatalogManaged tables: https://github.com/delta-io/delta/blob/master/protocol_rfcs/catalog-managed.md
+    CatalogManaged,
+    #[strum(serialize = "catalogOwned-preview")]
+    #[serde(rename = "catalogOwned-preview")]
+    CatalogOwnedPreview,
     /// Append Only Tables
     AppendOnly,
     /// Table invariants
@@ -188,6 +198,10 @@ impl WriterFeature {
 
 pub(crate) static SUPPORTED_READER_FEATURES: LazyLock<Vec<ReaderFeature>> = LazyLock::new(|| {
     vec![
+        #[cfg(feature = "catalog-managed")]
+        ReaderFeature::CatalogManaged,
+        #[cfg(feature = "catalog-managed")]
+        ReaderFeature::CatalogOwnedPreview,
         ReaderFeature::ColumnMapping,
         ReaderFeature::DeletionVectors,
         ReaderFeature::TimestampWithoutTimezone,
@@ -262,6 +276,8 @@ mod tests {
     #[test]
     fn test_roundtrip_reader_features() {
         let cases = [
+            (ReaderFeature::CatalogManaged, "catalogManaged"),
+            (ReaderFeature::CatalogOwnedPreview, "catalogOwned-preview"),
             (ReaderFeature::ColumnMapping, "columnMapping"),
             (ReaderFeature::DeletionVectors, "deletionVectors"),
             (ReaderFeature::TimestampWithoutTimezone, "timestampNtz"),
@@ -297,6 +313,8 @@ mod tests {
     fn test_roundtrip_writer_features() {
         let cases = [
             (WriterFeature::AppendOnly, "appendOnly"),
+            (WriterFeature::CatalogManaged, "catalogManaged"),
+            (WriterFeature::CatalogOwnedPreview, "catalogOwned-preview"),
             (WriterFeature::Invariants, "invariants"),
             (WriterFeature::CheckConstraints, "checkConstraints"),
             (WriterFeature::ChangeDataFeed, "changeDataFeed"),


### PR DESCRIPTION
## What changes are proposed in this pull request?
Adds `catalogManaged` and `catalogOwned-preview` reader/writer features. Additionally, adds 'support' for them behind a new `catalog-managed` cargo feature. Many of the new APIs will be merged behind this flag to gate usage while it is under development.

### This PR affects the following public APIs



## How was this change tested?
existing