### PR TITLE
fix: match arrow versions in examples

### DIFF
--- a/kernel/examples/common/Cargo.toml
+++ b/kernel/examples/common/Cargo.toml
@@ -13,7 +13,7 @@ release = false
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 delta_kernel = { path = "../../../kernel", features = [
-  "arrow-55",
+  "arrow",
   "default-engine-rustls",
   "internal-api",
 ] }

--- a/kernel/examples/read-table-multi-threaded/Cargo.toml
+++ b/kernel/examples/read-table-multi-threaded/Cargo.toml
@@ -9,7 +9,7 @@ arrow = { version = "56", features = ["prettyprint", "chrono-tz"] }
 clap = { version = "4.5", features = ["derive"] }
 common = { path = "../common" }
 delta_kernel = { path = "../../../kernel", features = [
-  "arrow-55",
+  "arrow-56",
   "default-engine-rustls",
   "internal-api",
 ] }

--- a/kernel/examples/read-table-single-threaded/Cargo.toml
+++ b/kernel/examples/read-table-single-threaded/Cargo.toml
@@ -9,7 +9,7 @@ arrow = { version = "56", features = ["prettyprint", "chrono-tz"] }
 clap = { version = "4.5", features = ["derive"] }
 common = { path = "../common" }
 delta_kernel = { path = "../../../kernel", features = [
-  "arrow-55",
+  "arrow-56",
   "default-engine-rustls",
   "internal-api",
 ] }


### PR DESCRIPTION
## What changes are proposed in this pull request?
examples were broken since they pulled in arrow 55/56, only do 56

## How was this change tested?
ran examples