### PR TITLE
feat: Implement `IntoEngineData` for `DomainMetadata`

### DIFF
--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -894,15 +894,13 @@ impl DomainMetadata {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::arrow::array::ListBuilder;
-    use crate::arrow::json::ReaderBuilder;
     use crate::{
         arrow::array::{
-            Array, BooleanArray, Int32Array, Int64Array, MapBuilder, MapFieldNames, StringArray,
-            StringBuilder, StructArray,
+            Array, BooleanArray, Int32Array, Int64Array, ListArray, ListBuilder, MapBuilder,
+            MapFieldNames, RecordBatch, StringArray, StringBuilder, StructArray,
         },
         arrow::datatypes::{DataType as ArrowDataType, Field, Schema},
-        arrow::record_batch::RecordBatch,
+        arrow::json::ReaderBuilder,
         engine::arrow_data::ArrowEngineData,
         engine::arrow_expression::ArrowEvaluationHandler,
         schema::{ArrayType, DataType, MapType, StructField},
@@ -1364,7 +1362,7 @@ mod tests {
         let engine_data =
             set_transaction.into_engine_data(SetTransaction::to_schema().into(), &engine);
 
-        let record_batch: crate::arrow::array::RecordBatch = engine_data
+        let record_batch: RecordBatch = engine_data
             .unwrap()
             .into_any()
             .downcast::<ArrowEngineData>()
@@ -1398,7 +1396,7 @@ mod tests {
 
         let engine_data = commit_info.into_engine_data(CommitInfo::to_schema().into(), &engine);
 
-        let record_batch: crate::arrow::array::RecordBatch = engine_data
+        let record_batch: RecordBatch = engine_data
             .unwrap()
             .into_any()
             .downcast::<ArrowEngineData>()
@@ -1439,7 +1437,7 @@ mod tests {
         let engine_data =
             domain_metadata.into_engine_data(DomainMetadata::to_schema().into(), &engine);
 
-        let record_batch: crate::arrow::array::RecordBatch = engine_data
+        let record_batch: RecordBatch = engine_data
             .unwrap()
             .into_any()
             .downcast::<ArrowEngineData>()
@@ -1819,14 +1817,14 @@ mod tests {
         let reader_features_col = record_batch
             .column(2)
             .as_any()
-            .downcast_ref::<crate::arrow::array::ListArray>()
+            .downcast_ref::<ListArray>()
             .unwrap();
         assert_eq!(reader_features_col.len(), 1);
         assert_eq!(reader_features_col.value(0).len(), 0); // empty list
         let writer_features_col = record_batch
             .column(3)
             .as_any()
-            .downcast_ref::<crate::arrow::array::ListArray>()
+            .downcast_ref::<ListArray>()
             .unwrap();
         assert_eq!(writer_features_col.len(), 1);
         assert_eq!(writer_features_col.value(0).len(), 0); // empty list

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -553,12 +553,9 @@ where
     type Error = Error;
 
     fn try_from(vec: Vec<T>) -> Result<Self, Self::Error> {
-        let element_type = T::to_data_type();
-        let array_type = ArrayType::new(element_type, false);
-
+        let array_type = ArrayType::new(T::to_data_type(), false);
         let array_data = ArrayData::try_new(array_type, vec)?;
-
-        Ok(Self::Array(array_data))
+        Ok(array_data.into())
     }
 }
 
@@ -569,12 +566,9 @@ where
     type Error = Error;
 
     fn try_from(vec: Vec<Option<T>>) -> Result<Self, Self::Error> {
-        let element_type = T::to_data_type();
-        let array_type = ArrayType::new(element_type, true);
-
+        let array_type = ArrayType::new(T::to_data_type(), true);
         let array_data = ArrayData::try_new(array_type, vec)?;
-
-        Ok(Self::Array(array_data))
+        Ok(array_data.into())
     }
 }
 
@@ -586,13 +580,9 @@ where
     type Error = Error;
 
     fn try_from(map: HashMap<K, V>) -> Result<Self, Self::Error> {
-        let key_type = K::to_data_type();
-        let value_type = V::to_data_type();
-        let map_type = MapType::new(key_type, value_type, false);
-
+        let map_type = MapType::new(K::to_data_type(), V::to_data_type(), false);
         let map_data = MapData::try_new(map_type, map)?;
-
-        Ok(Self::Map(map_data))
+        Ok(map_data.into())
     }
 }
 
@@ -604,13 +594,9 @@ where
     type Error = Error;
 
     fn try_from(map: HashMap<K, Option<V>>) -> Result<Self, Self::Error> {
-        let key_type = K::to_data_type();
-        let value_type = V::to_data_type();
-        let map_type = MapType::new(key_type, value_type, true);
-
+        let map_type = MapType::new(K::to_data_type(), V::to_data_type(), true);
         let map_data = MapData::try_new(map_type, map)?;
-
-        Ok(Self::Map(map_data))
+        Ok(map_data.into())
     }
 }
 
@@ -621,6 +607,18 @@ impl<T: Into<Scalar> + ToDataType> From<Option<T>> for Scalar {
             Some(t) => t.into(),
             None => Self::Null(T::to_data_type()),
         }
+    }
+}
+
+impl From<ArrayData> for Scalar {
+    fn from(array_data: ArrayData) -> Self {
+        Self::Array(array_data)
+    }
+}
+
+impl From<MapData> for Scalar {
+    fn from(map_data: MapData) -> Self {
+        Self::Map(map_data)
     }
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR implements the `IntoEngineData` trait for `DomainMetadata` actions, which is a prerequisite for implementing the row tracking write path.

This PR also adds `Scalar::try_from` implementations for `HashMap` and `Vec` and consequently simplifies existing implementations of `IntoEngineData`.

## How was this change tested?

New UT