### PR TITLE
perf!: ExpressionRef instead of owned for transforms

### DIFF
--- a/ffi/src/expressions/engine_visitor.rs
+++ b/ffi/src/expressions/engine_visitor.rs
@@ -327,7 +327,7 @@ fn visit_expression_struct(
     sibling_list_id: usize,
 ) {
     let child_list_id = call!(visitor, make_field_list, exprs.len());
-    for expr in exprs.iter() {
+    for expr in exprs {
         visit_expression_impl(visitor, expr, child_list_id);
     }
     call!(visitor, visit_struct_expr, sibling_list_id, child_list_id)

--- a/ffi/src/expressions/engine_visitor.rs
+++ b/ffi/src/expressions/engine_visitor.rs
@@ -4,7 +4,7 @@ use std::ffi::c_void;
 
 use delta_kernel::expressions::{
     ArrayData, BinaryExpression, BinaryExpressionOp, BinaryPredicate, BinaryPredicateOp,
-    Expression, JunctionPredicate, JunctionPredicateOp, MapData, OpaqueExpression,
+    Expression, ExpressionRef, JunctionPredicate, JunctionPredicateOp, MapData, OpaqueExpression,
     OpaqueExpressionOpRef, OpaquePredicate, OpaquePredicateOpRef, Predicate, Scalar, StructData,
     UnaryPredicate, UnaryPredicateOp,
 };
@@ -323,11 +323,11 @@ fn visit_expression_struct_literal(
 
 fn visit_expression_struct(
     visitor: &mut EngineExpressionVisitor,
-    exprs: &[Expression],
+    exprs: &[ExpressionRef],
     sibling_list_id: usize,
 ) {
     let child_list_id = call!(visitor, make_field_list, exprs.len());
-    for expr in exprs {
+    for expr in exprs.iter() {
         visit_expression_impl(visitor, expr, child_list_id);
     }
     call!(visitor, visit_struct_expr, sibling_list_id, child_list_id)

--- a/kernel/examples/read-table-multi-threaded/src/main.rs
+++ b/kernel/examples/read-table-multi-threaded/src/main.rs
@@ -33,6 +33,10 @@ struct Cli {
     /// how many threads to read with (1 - 2048)
     #[arg(short, long, default_value_t = 2, value_parser = 1..=2048)]
     thread_count: i64,
+
+    /// run metadata-only
+    #[arg(short, long, default_value_t = false)]
+    metadata: bool,
 }
 
 fn main() -> ExitCode {
@@ -106,6 +110,14 @@ fn try_main() -> DeltaResult<()> {
     // this data directly, and can just call [`visit_scan_files`] to get pre-parsed data back from
     // the kernel.
     let scan_metadata = scan.scan_metadata(&engine)?;
+
+    if cli.metadata {
+        let (scan_metadata_batches, scan_metadata_rows) = scan_metadata
+            .map(|res| res.unwrap().scan_files.data.len())
+            .fold((0, 0), |(batches, rows), len| (batches + 1, rows + len));
+        println!("Scan metadata: {scan_metadata_batches} chunks, {scan_metadata_rows} files",);
+        return Ok(());
+    }
 
     // create the channels we'll use. record_batch_[t/r]x are used for the threads to send back the
     // processed RecordBatches to themain thread

--- a/kernel/src/actions/visitors.rs
+++ b/kernel/src/actions/visitors.rs
@@ -1085,7 +1085,10 @@ mod tests {
                 get_log_schema().clone(),
                 Expression::Struct(vec![Expression::Struct(vec![column_expr!(
                     "commitInfo.inCommitTimestamp"
-                )])]),
+                )
+                .into()])
+                .into()])
+                .into(),
                 InCommitTimestampVisitor::schema().into(),
             )
             .evaluate(batch.as_ref())

--- a/kernel/src/actions/visitors.rs
+++ b/kernel/src/actions/visitors.rs
@@ -684,7 +684,7 @@ mod tests {
     use crate::arrow::array::StringArray;
 
     use crate::engine::sync::SyncEngine;
-    use crate::expressions::{column_expr, Expression};
+    use crate::expressions::{column_expr_ref, Expression};
     use crate::table_features::{ReaderFeature, WriterFeature};
     use crate::utils::test_utils::{action_batch, parse_json_batch};
     use crate::Engine;
@@ -1083,12 +1083,9 @@ mod tests {
             .evaluation_handler()
             .new_expression_evaluator(
                 get_log_schema().clone(),
-                Expression::Struct(vec![Expression::Struct(vec![column_expr!(
+                Expression::Struct(vec![Arc::new(Expression::Struct(vec![column_expr_ref!(
                     "commitInfo.inCommitTimestamp"
-                )
-                .into()])
-                .into()])
-                .into(),
+                )]))]),
                 InCommitTimestampVisitor::schema().into(),
             )
             .evaluate(batch.as_ref())

--- a/kernel/src/expressions/column_names.rs
+++ b/kernel/src/expressions/column_names.rs
@@ -422,6 +422,16 @@ pub use __column_expr as column_expr;
 
 #[macro_export]
 #[doc(hidden)]
+macro_rules! __column_expr_ref {
+    ( $($name:tt)* ) => {
+        std::sync::Arc::new($crate::expressions::Expression::from($crate::__column_name!($($name)*)))
+    };
+}
+#[doc(inline)]
+pub use __column_expr_ref as column_expr_ref;
+
+#[macro_export]
+#[doc(hidden)]
 macro_rules! __column_pred {
     ( $($name:tt)* ) => {
         $crate::expressions::Predicate::from($crate::__column_name!($($name)*))

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use itertools::Itertools;
 
 pub use self::column_names::{
-    column_expr, column_name, column_pred, joined_column_expr, joined_column_name, ColumnName,
+    column_expr, column_expr_ref, column_name, column_pred, joined_column_expr, joined_column_name, ColumnName,
 };
 pub use self::scalars::{ArrayData, DecimalData, MapData, Scalar, StructData};
 use self::transforms::{ExpressionTransform as _, GetColumnReferences};
@@ -255,7 +255,7 @@ pub enum Expression {
     /// A column reference by name.
     Column(ColumnName),
     /// A predicate treated as a boolean expression
-    Predicate(Box<Predicate>),
+    Predicate(Box<Predicate>), // should this be Arc?
     /// A struct computed from a Vec of expressions
     Struct(Vec<Expression>),
     /// An expression that takes two expressions as input.
@@ -408,7 +408,7 @@ impl Expression {
 
     /// Create a new struct expression
     pub fn struct_from(exprs: impl IntoIterator<Item = Self>) -> Self {
-        Self::Struct(exprs.into_iter().collect())
+        Self::Struct(exprs.into_iter().map(Arc::new).collect())
     }
 
     /// Create a new predicate `self IS NULL`

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -408,8 +408,8 @@ impl Expression {
     }
 
     /// Create a new struct expression
-    pub fn struct_from(exprs: impl IntoIterator<Item = Self>) -> Self {
-        Self::Struct(exprs.into_iter().map(Arc::new).collect())
+    pub fn struct_from(exprs: impl IntoIterator<Item = impl Into<Arc<Self>>>) -> Self {
+        Self::Struct(exprs.into_iter().map(Into::into).collect())
     }
 
     /// Create a new predicate `self IS NULL`

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -7,7 +7,8 @@ use std::sync::Arc;
 use itertools::Itertools;
 
 pub use self::column_names::{
-    column_expr, column_expr_ref, column_name, column_pred, joined_column_expr, joined_column_name, ColumnName,
+    column_expr, column_expr_ref, column_name, column_pred, joined_column_expr, joined_column_name,
+    ColumnName,
 };
 pub use self::scalars::{ArrayData, DecimalData, MapData, Scalar, StructData};
 use self::transforms::{ExpressionTransform as _, GetColumnReferences};
@@ -257,7 +258,7 @@ pub enum Expression {
     /// A predicate treated as a boolean expression
     Predicate(Box<Predicate>), // should this be Arc?
     /// A struct computed from a Vec of expressions
-    Struct(Vec<Expression>),
+    Struct(Vec<ExpressionRef>),
     /// An expression that takes two expressions as input.
     Binary(BinaryExpression),
     /// An expression that the engine defines and implements. Kernel interacts with the expression

--- a/kernel/src/expressions/transforms.rs
+++ b/kernel/src/expressions/transforms.rs
@@ -1,8 +1,9 @@
 use std::borrow::{Cow, ToOwned};
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use crate::expressions::{
-    BinaryExpression, BinaryPredicate, ColumnName, Expression, JunctionPredicate, OpaqueExpression,
+    BinaryExpression, BinaryPredicate, ColumnName, Expression, ExpressionRef, JunctionPredicate, OpaqueExpression,
     OpaquePredicate, Predicate, Scalar, UnaryPredicate,
 };
 use crate::utils::CowExt as _;
@@ -39,7 +40,7 @@ pub trait ExpressionTransform<'a> {
     /// Called for the expression list of each [`Expression::Struct`] encountered during the
     /// traversal. Implementations can call [`Self::recurse_into_expr_struct`] if they wish to
     /// recursively transform the child expressions.
-    fn transform_expr_struct(&mut self, fields: &'a [Expression]) -> Option<Cow<'a, [Expression]>> {
+    fn transform_expr_struct(&mut self, fields: &'a [ExpressionRef]) -> Option<Cow<'a, [ExpressionRef]>> {
         self.recurse_into_expr_struct(fields)
     }
 
@@ -184,9 +185,17 @@ pub trait ExpressionTransform<'a> {
     /// `Some(Cow::Borrowed)` otherwise.
     fn recurse_into_expr_struct(
         &mut self,
-        fields: &'a [Expression],
-    ) -> Option<Cow<'a, [Expression]>> {
-        recurse_into_children(fields, |f| self.transform_expr(f))
+        fields: &'a [ExpressionRef],
+    ) -> Option<Cow<'a, [ExpressionRef]>> {
+        recurse_into_children(fields, |f| {
+            // Transform the Arc<Expression> by dereferencing it first
+            self.transform_expr(f).map(|cow| {
+                match cow {
+                    Cow::Borrowed(_) => Cow::Borrowed(f),
+                    Cow::Owned(expr) => Cow::Owned(Arc::new(expr)),
+                }
+            })
+        })
     }
 
     /// Recursively transforms the children of an [`OpaqueExpression`]. Returns `None` if all
@@ -393,7 +402,7 @@ impl ExpressionDepthChecker {
 }
 
 impl<'a> ExpressionTransform<'a> for ExpressionDepthChecker {
-    fn transform_expr_struct(&mut self, fields: &'a [Expression]) -> Option<Cow<'a, [Expression]>> {
+    fn transform_expr_struct(&mut self, fields: &'a [ExpressionRef]) -> Option<Cow<'a, [ExpressionRef]>> {
         self.depth_limited(Self::recurse_into_expr_struct, fields)
     }
 

--- a/kernel/src/expressions/transforms.rs
+++ b/kernel/src/expressions/transforms.rs
@@ -3,8 +3,8 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use crate::expressions::{
-    BinaryExpression, BinaryPredicate, ColumnName, Expression, ExpressionRef, JunctionPredicate, OpaqueExpression,
-    OpaquePredicate, Predicate, Scalar, UnaryPredicate,
+    BinaryExpression, BinaryPredicate, ColumnName, Expression, ExpressionRef, JunctionPredicate,
+    OpaqueExpression, OpaquePredicate, Predicate, Scalar, UnaryPredicate,
 };
 use crate::utils::CowExt as _;
 
@@ -40,7 +40,10 @@ pub trait ExpressionTransform<'a> {
     /// Called for the expression list of each [`Expression::Struct`] encountered during the
     /// traversal. Implementations can call [`Self::recurse_into_expr_struct`] if they wish to
     /// recursively transform the child expressions.
-    fn transform_expr_struct(&mut self, fields: &'a [ExpressionRef]) -> Option<Cow<'a, [ExpressionRef]>> {
+    fn transform_expr_struct(
+        &mut self,
+        fields: &'a [ExpressionRef],
+    ) -> Option<Cow<'a, [ExpressionRef]>> {
         self.recurse_into_expr_struct(fields)
     }
 
@@ -189,11 +192,9 @@ pub trait ExpressionTransform<'a> {
     ) -> Option<Cow<'a, [ExpressionRef]>> {
         recurse_into_children(fields, |f| {
             // Transform the Arc<Expression> by dereferencing it first
-            self.transform_expr(f).map(|cow| {
-                match cow {
-                    Cow::Borrowed(_) => Cow::Borrowed(f),
-                    Cow::Owned(expr) => Cow::Owned(Arc::new(expr)),
-                }
+            self.transform_expr(f).map(|cow| match cow {
+                Cow::Borrowed(_) => Cow::Borrowed(f),
+                Cow::Owned(expr) => Cow::Owned(Arc::new(expr)),
             })
         })
     }
@@ -402,7 +403,10 @@ impl ExpressionDepthChecker {
 }
 
 impl<'a> ExpressionTransform<'a> for ExpressionDepthChecker {
-    fn transform_expr_struct(&mut self, fields: &'a [ExpressionRef]) -> Option<Cow<'a, [ExpressionRef]>> {
+    fn transform_expr_struct(
+        &mut self,
+        fields: &'a [ExpressionRef],
+    ) -> Option<Cow<'a, [ExpressionRef]>> {
         self.depth_limited(Self::recurse_into_expr_struct, fields)
     }
 

--- a/kernel/src/expressions/transforms.rs
+++ b/kernel/src/expressions/transforms.rs
@@ -191,11 +191,8 @@ pub trait ExpressionTransform<'a> {
         fields: &'a [ExpressionRef],
     ) -> Option<Cow<'a, [ExpressionRef]>> {
         recurse_into_children(fields, |f| {
-            // Transform the Arc<Expression> by dereferencing it first
-            self.transform_expr(f).map(|cow| match cow {
-                Cow::Borrowed(_) => Cow::Borrowed(f),
-                Cow::Owned(expr) => Cow::Owned(Arc::new(expr)),
-            })
+            self.transform_expr(f)
+                .map(|cow| cow.map_owned_or_else(f, Arc::new))
         })
     }
 

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -10,7 +10,7 @@ use crate::actions::deletion_vector::DeletionVectorDescriptor;
 use crate::actions::get_log_add_schema;
 use crate::engine_data::{GetData, RowVisitor, TypedGetData as _};
 use crate::expressions::{
-    column_expr, column_name, ColumnName, Expression, ExpressionRef, PredicateRef,
+    column_name, ColumnName, Expression, ExpressionRef, PredicateRef,
 };
 use crate::kernel_predicates::{DefaultKernelPredicateEvaluator, KernelPredicateEvaluator as _};
 use crate::log_replay::{ActionsBatch, FileActionDeduplicator, FileActionKey, LogReplayProcessor};
@@ -326,27 +326,29 @@ pub(crate) static SCAN_ROW_DATATYPE: LazyLock<DataType> =
     LazyLock::new(|| SCAN_ROW_SCHEMA.clone().into());
 
 fn get_add_transform_expr() -> Expression {
+    use crate::expressions::column_expr_ref;
     Expression::Struct(vec![
-        column_expr!("add.path"),
-        column_expr!("add.size"),
-        column_expr!("add.modificationTime"),
-        column_expr!("add.stats"),
-        column_expr!("add.deletionVector"),
-        Expression::Struct(vec![column_expr!("add.partitionValues")]),
+        column_expr_ref!("add.path"),
+        column_expr_ref!("add.size"),
+        column_expr_ref!("add.modificationTime"),
+        column_expr_ref!("add.stats"),
+        column_expr_ref!("add.deletionVector"),
+        std::sync::Arc::new(Expression::Struct(vec![column_expr_ref!("add.partitionValues")])),
     ])
 }
 
 // TODO: remove once `scan_metadata_from` is pub.
 #[allow(unused)]
 pub(crate) fn get_scan_metadata_transform_expr() -> Expression {
-    Expression::Struct(vec![Expression::Struct(vec![
-        column_expr!("path"),
-        column_expr!("fileConstantValues.partitionValues"),
-        column_expr!("size"),
-        column_expr!("modificationTime"),
-        column_expr!("stats"),
-        column_expr!("deletionVector"),
-    ])])
+    use crate::expressions::column_expr_ref;
+    Expression::Struct(vec![std::sync::Arc::new(Expression::Struct(vec![
+        column_expr_ref!("path"),
+        column_expr_ref!("fileConstantValues.partitionValues"),
+        column_expr_ref!("size"),
+        column_expr_ref!("modificationTime"),
+        column_expr_ref!("stats"),
+        column_expr_ref!("deletionVector"),
+    ]))])
 }
 
 impl LogReplayProcessor for ScanLogReplayProcessor {

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -331,7 +331,7 @@ fn get_add_transform_expr() -> Expression {
         column_expr_ref!("add.modificationTime"),
         column_expr_ref!("add.stats"),
         column_expr_ref!("add.deletionVector"),
-        std::sync::Arc::new(Expression::Struct(vec![column_expr_ref!(
+        Arc::new(Expression::Struct(vec![column_expr_ref!(
             "add.partitionValues"
         )])),
     ])
@@ -341,7 +341,7 @@ fn get_add_transform_expr() -> Expression {
 #[allow(unused)]
 pub(crate) fn get_scan_metadata_transform_expr() -> Expression {
     use crate::expressions::column_expr_ref;
-    Expression::Struct(vec![std::sync::Arc::new(Expression::Struct(vec![
+    Expression::Struct(vec![Arc::new(Expression::Struct(vec![
         column_expr_ref!("path"),
         column_expr_ref!("fileConstantValues.partitionValues"),
         column_expr_ref!("size"),

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -435,7 +435,7 @@ impl Scan {
         &self.physical_schema
     }
 
-    /// Get the predicate [`Expression`] of the scan.
+    /// Get the predicate [`PredicateRef`] of the scan.
     pub fn physical_predicate(&self) -> Option<PredicateRef> {
         if let PhysicalPredicate::Some(ref predicate, _) = self.physical_predicate {
             Some(predicate.clone())

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -16,7 +16,7 @@ use crate::actions::deletion_vector::{
 use crate::actions::{get_log_schema, ADD_NAME, REMOVE_NAME, SIDECAR_NAME};
 use crate::engine_data::FilteredEngineData;
 use crate::expressions::transforms::ExpressionTransform;
-use crate::expressions::{ColumnName, Expression, ExpressionRef, Predicate, PredicateRef, Scalar};
+use crate::expressions::{ColumnName, ExpressionRef, Predicate, PredicateRef, Scalar};
 use crate::kernel_predicates::{DefaultKernelPredicateEvaluator, EmptyColumnResolver};
 use crate::listed_log_files::ListedLogFiles;
 use crate::log_replay::{ActionsBatch, HasSelectionVector};

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -334,7 +334,7 @@ pub fn get_transform_for_row(
 /// things like partition columns need to filled in. This enum holds an expression that's part of a
 /// `Transform`.
 pub(crate) enum TransformExpr {
-    Static(Expression),
+    Static(ExpressionRef),
     Partition(usize),
 }
 
@@ -452,7 +452,7 @@ impl Scan {
             .iter()
             .map(|field| match field {
                 ColumnType::Selected(col_name) => {
-                    TransformExpr::Static(ColumnName::new([col_name]).into())
+                    TransformExpr::Static(Arc::new(ColumnName::new([col_name]).into()))
                 }
                 ColumnType::Partition(idx) => TransformExpr::Partition(*idx),
             })

--- a/kernel/src/table_changes/physical_to_logical.rs
+++ b/kernel/src/table_changes/physical_to_logical.rs
@@ -59,6 +59,7 @@ pub(crate) fn physical_to_logical_expr(
                 Ok(generated_column.unwrap_or_else(|| ColumnName::new([field_name]).into()))
             }
         })
+        .map(|expr| expr.map(std::sync::Arc::new))
         .try_collect()?;
     Ok(Expression::Struct(all_fields))
 }

--- a/kernel/src/table_changes/physical_to_logical.rs
+++ b/kernel/src/table_changes/physical_to_logical.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use itertools::Itertools;
 
@@ -59,7 +60,7 @@ pub(crate) fn physical_to_logical_expr(
                 Ok(generated_column.unwrap_or_else(|| ColumnName::new([field_name]).into()))
             }
         })
-        .map(|expr| expr.map(std::sync::Arc::new))
+        .map(|expr| expr.map(Arc::new))
         .try_collect()?;
     Ok(Expression::Struct(all_fields))
 }

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -947,7 +947,7 @@ fn not_and_or_predicates() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn invalid_skips_none_predicates() -> Result<(), Box<dyn std::error::Error>> {
-    let empty_struct = Expr::struct_from(vec![]);
+    let empty_struct = Expr::struct_from(Vec::<ExpressionRef>::new());
     let cases = vec![
         (Pred::literal(false), table_for_numbers(vec![])),
         (


### PR DESCRIPTION
## What changes are proposed in this pull request?
use `ExpressionRef` (`Arc<Expression>`) instead of owned `Expressions` in `Struct` and `Transform`

main changes:
- new `column_expr_ref!` macro
- Expression::Struct now takes a `Vec<ExpressionRef>` instead of `Vec<Expression>`
- expression transform changed accordingly


### This PR affects the following public APIs

Expression::Struct now takes a `Vec<ExpressionRef>` instead of `Vec<Expression>`


## How was this change tested?
correctness: existing UT
performance: manual (below) - seeing significant (~2x) speedups on wide/large scan_metadata
```
cargo b -r -p read-table-multi-threaded && \
time target/release/read-table-multi-threaded --metadata <table_path>
```