### PR TITLE
chore: remove unused deps from examples

### DIFF
--- a/kernel/examples/inspect-table/Cargo.toml
+++ b/kernel/examples/inspect-table/Cargo.toml
@@ -13,7 +13,6 @@ delta_kernel = { path = "../../../kernel", features = [
   "internal-api",
 ] }
 env_logger = "0.11.8"
-url = "2"
 
 # for cargo-release
 [package.metadata.release]

--- a/kernel/examples/read-table-changes/Cargo.toml
+++ b/kernel/examples/read-table-changes/Cargo.toml
@@ -16,5 +16,4 @@ delta_kernel = { path = "../../../kernel", features = [
   "default-engine-rustls",
   "internal-api",
 ] }
-url = "2"
 itertools = "0.14"

--- a/kernel/examples/read-table-multi-threaded/Cargo.toml
+++ b/kernel/examples/read-table-multi-threaded/Cargo.toml
@@ -14,7 +14,6 @@ delta_kernel = { path = "../../../kernel", features = [
   "internal-api",
 ] }
 env_logger = "0.11.8"
-itertools = "0.14"
 spmc = "0.3.0"
 url = "2"
 

--- a/kernel/examples/read-table-single-threaded/Cargo.toml
+++ b/kernel/examples/read-table-single-threaded/Cargo.toml
@@ -15,7 +15,6 @@ delta_kernel = { path = "../../../kernel", features = [
 ] }
 env_logger = "0.11.8"
 itertools = "0.14"
-url = "2"
 
 # for cargo-release
 [package.metadata.release]


### PR DESCRIPTION
## What changes are proposed in this pull request?
remove unused deps from examples

## How was this change tested?
`cargo b` all targets