### PR TITLE
refactor!: Make `StructField.physical_name` internal

### DIFF
--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -183,7 +183,8 @@ impl StructField {
     /// NOTE: Caller affirms that the schema was already validated by
     /// [`crate::table_features::validate_schema_column_mapping`], to ensure that annotations are
     /// always and only present when column mapping mode is enabled.
-    pub fn physical_name(&self) -> &str {
+    #[internal_api]
+    pub(crate) fn physical_name(&self) -> &str {
         match self
             .metadata
             .get(ColumnMetadataKey::ColumnMappingPhysicalName.as_ref())


### PR DESCRIPTION

## What changes are proposed in this pull request?

Closes: https://github.com/delta-io/delta-kernel-rs/issues/1121 
StructField.physical_name is made into an internal API. 

### This PR affects the following public APIs
`StructField.physical_name` is now private (`internal-api`)

## How was this change tested?
existing