### PR TITLE
[WIP] !feat: Add columnar_concat and into_engine_data to EvaluationHandler

### DIFF
--- a/kernel/src/engine/arrow_expression/mod.rs
+++ b/kernel/src/engine/arrow_expression/mod.rs
@@ -9,7 +9,7 @@ use crate::arrow::datatypes::{
 use super::arrow_conversion::{TryFromKernel as _, TryIntoArrow as _};
 use crate::engine::arrow_data::ArrowEngineData;
 use crate::error::{DeltaResult, Error};
-use crate::expressions::{Expression, Predicate, Scalar};
+use crate::expressions::{ArrayData, Expression, Predicate, Scalar};
 use crate::schema::{DataType, PrimitiveType, SchemaRef};
 use crate::utils::require;
 use crate::{EngineData, EvaluationHandler, ExpressionEvaluator, PredicateEvaluator};
@@ -251,6 +251,70 @@ impl EvaluationHandler for ArrowEvaluationHandler {
             .try_collect()?;
         let record_batch =
             RecordBatch::try_new(Arc::new(output_schema.as_ref().try_into_arrow()?), arrays)?;
+        Ok(Box::new(ArrowEngineData::new(record_batch)))
+    }
+
+    fn columnar_concat(
+        &self,
+        left: &dyn EngineData,
+        right: &dyn EngineData,
+    ) -> DeltaResult<Box<dyn EngineData>> {
+        let left = left
+            .any_ref()
+            .downcast_ref::<ArrowEngineData>()
+            .ok_or_else(|| Error::engine_data_type("ArrowEngineData"))?
+            .record_batch();
+        let right = right
+            .any_ref()
+            .downcast_ref::<ArrowEngineData>()
+            .ok_or_else(|| Error::engine_data_type("ArrowEngineData"))?
+            .record_batch();
+
+        // Verify both batches have the same number of rows
+        if left.num_rows() != right.num_rows() {
+            return Err(Error::generic(format!(
+                "Cannot concatenate batches with different row counts: {} vs {}",
+                left.num_rows(),
+                right.num_rows()
+            )));
+        }
+
+        // Combine the schemas by merging fields from both batches
+        let mut combined_fields = Vec::new();
+        combined_fields.extend_from_slice(left.schema().fields());
+        combined_fields.extend_from_slice(right.schema().fields());
+        let combined_schema = Arc::new(ArrowSchema::new(combined_fields));
+
+        // Combine the columns by concatenating arrays from both batches
+        let mut combined_columns = Vec::new();
+        combined_columns.extend_from_slice(left.columns());
+        combined_columns.extend_from_slice(right.columns());
+
+        // Create the new RecordBatch with combined schema and columns
+        let record_batch = RecordBatch::try_new(combined_schema, combined_columns)?;
+        Ok(Box::new(ArrowEngineData::new(record_batch)))
+    }
+
+    fn into_engine_data(
+        &self,
+        schema: SchemaRef,
+        columns: Vec<ArrayData>,
+    ) -> DeltaResult<Box<dyn EngineData>> {
+        let arrow_columns: Vec<ArrayRef> = columns
+            .into_iter()
+            .map(|col| {
+                // Convert kernel ArrayData to Scalar::Array and then to Arrow ArrayRef
+                #[allow(deprecated)]
+                let num_rows = col.array_elements().len();
+                let scalar = Scalar::Array(col);
+                scalar.to_array(num_rows)
+            })
+            .try_collect()
+            .unwrap();
+        let record_batch = RecordBatch::try_new(
+            Arc::new(schema.as_ref().try_into_arrow().unwrap()),
+            arrow_columns,
+        )?;
         Ok(Box::new(ArrowEngineData::new(record_batch)))
     }
 }

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -1,8 +1,9 @@
 use std::ops::{Add, Div, Mul, Sub};
 
 use crate::arrow::array::{
-    create_array, Array, ArrayRef, BooleanArray, GenericStringArray, Int32Array, Int32Builder,
-    ListArray, MapArray, MapBuilder, MapFieldNames, StringBuilder, StructArray,
+    create_array, Array, ArrayRef, BinaryArray, BooleanArray, Float32Array, Float64Array,
+    GenericStringArray, Int16Array, Int32Array, Int32Builder, Int64Array, Int8Array, ListArray,
+    MapArray, MapBuilder, MapFieldNames, StringArray, StringBuilder, StructArray,
 };
 use crate::arrow::buffer::{OffsetBuffer, ScalarBuffer};
 use crate::arrow::compute::kernels::cmp::{gt_eq, lt};
@@ -899,4 +900,441 @@ fn test_null_scalar_map() -> DeltaResult<()> {
     assert!(map_array.is_null(0));
 
     Ok(())
+}
+
+#[test]
+fn test_columnar_concat() {
+    let handler = ArrowEvaluationHandler;
+
+    // Create left batch with 2 columns (id, name)
+    let left_schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("name", DataType::Utf8, true),
+    ]));
+    let left_batch = RecordBatch::try_new(
+        left_schema,
+        vec![
+            create_array!(Int32, [1, 2, 3]),
+            create_array!(Utf8, ["Alice", "Bob", "Charlie"]),
+        ],
+    )
+    .unwrap();
+    let left_data = ArrowEngineData::new(left_batch);
+
+    // Create right batch with 2 columns (age, active)
+    let right_schema = Arc::new(Schema::new(vec![
+        Field::new("age", DataType::Int32, true),
+        Field::new("active", DataType::Boolean, false),
+    ]));
+    let right_batch = RecordBatch::try_new(
+        right_schema,
+        vec![
+            create_array!(Int32, [25, 30, 35]),
+            create_array!(Boolean, [true, false, true]),
+        ],
+    )
+    .unwrap();
+    let right_data = ArrowEngineData::new(right_batch);
+
+    // Test concatenation
+    let result = handler.columnar_concat(&left_data, &right_data).unwrap();
+    let result_batch: RecordBatch = result
+        .into_any()
+        .downcast::<ArrowEngineData>()
+        .unwrap()
+        .into();
+
+    // Verify the result has all 4 columns in the correct order
+    assert_eq!(result_batch.num_columns(), 4);
+    assert_eq!(result_batch.num_rows(), 3);
+
+    let schema = result_batch.schema();
+    assert_eq!(schema.field(0).name(), "id");
+    assert_eq!(schema.field(1).name(), "name");
+    assert_eq!(schema.field(2).name(), "age");
+    assert_eq!(schema.field(3).name(), "active");
+
+    // Verify the data is correct
+    let id_column = result_batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .unwrap();
+    assert_eq!(id_column.values(), &[1, 2, 3]);
+
+    let name_column = result_batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<GenericStringArray<i32>>()
+        .unwrap();
+    assert_eq!(name_column.value(0), "Alice");
+    assert_eq!(name_column.value(1), "Bob");
+    assert_eq!(name_column.value(2), "Charlie");
+
+    let age_column = result_batch
+        .column(2)
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .unwrap();
+    assert_eq!(age_column.values(), &[25, 30, 35]);
+
+    let active_column = result_batch
+        .column(3)
+        .as_any()
+        .downcast_ref::<BooleanArray>()
+        .unwrap();
+    assert_eq!(active_column.value(0), true);
+    assert_eq!(active_column.value(1), false);
+    assert_eq!(active_column.value(2), true);
+}
+
+#[test]
+fn test_columnar_concat_mismatched_rows() {
+    let handler = ArrowEvaluationHandler;
+
+    // Create left batch with 3 rows
+    let left_schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+    let left_batch =
+        RecordBatch::try_new(left_schema, vec![create_array!(Int32, [1, 2, 3])]).unwrap();
+    let left_data = ArrowEngineData::new(left_batch);
+
+    // Create right batch with 2 rows (different count)
+    let right_schema = Arc::new(Schema::new(vec![Field::new("name", DataType::Utf8, true)]));
+    let right_batch =
+        RecordBatch::try_new(right_schema, vec![create_array!(Utf8, ["Alice", "Bob"])]).unwrap();
+    let right_data = ArrowEngineData::new(right_batch);
+
+    // Test that concatenation fails with mismatched row counts
+    let result = handler.columnar_concat(&left_data, &right_data);
+    assert!(result.is_err());
+    if let Err(err) = result {
+        assert!(err.to_string().contains("different row counts"));
+    }
+}
+
+#[test]
+fn test_columnar_concat_empty_batches() {
+    let handler = ArrowEvaluationHandler;
+
+    // Create left batch with 0 rows
+    let left_schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+    let left_batch = RecordBatch::try_new(
+        left_schema,
+        vec![Arc::new(Int32Array::from(vec![] as Vec<i32>))],
+    )
+    .unwrap();
+    let left_data = ArrowEngineData::new(left_batch);
+
+    // Create right batch with 0 rows
+    let right_schema = Arc::new(Schema::new(vec![Field::new("name", DataType::Utf8, true)]));
+    let right_batch = RecordBatch::try_new(
+        right_schema,
+        vec![Arc::new(StringArray::from(vec![] as Vec<&str>))],
+    )
+    .unwrap();
+    let right_data = ArrowEngineData::new(right_batch);
+
+    // Test concatenation of empty batches
+    let result = handler.columnar_concat(&left_data, &right_data).unwrap();
+    let result_batch: RecordBatch = result
+        .into_any()
+        .downcast::<ArrowEngineData>()
+        .unwrap()
+        .into();
+
+    assert_eq!(result_batch.num_columns(), 2);
+    assert_eq!(result_batch.num_rows(), 0);
+    assert_eq!(result_batch.schema().field(0).name(), "id");
+    assert_eq!(result_batch.schema().field(1).name(), "name");
+}
+
+// let values = Int32Array::from(vec![0, 1, 2, 3, 4, 5, 6, 7, 8]);
+// let offsets = OffsetBuffer::new(ScalarBuffer::from(vec![0, 3, 6, 9]));
+// let field = Arc::new(Field::new("item", DataType::Int32, true));
+// let arr_field = Arc::new(Field::new("item", DataType::List(field.clone()), true));
+
+// let schema = Schema::new([arr_field.clone()]);
+
+// let array = ListArray::new(field.clone(), offsets, Arc::new(values), None);
+// let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array.clone())]).unwrap();
+
+#[test]
+fn test_into_engine_data() {
+    let handler = ArrowEvaluationHandler;
+
+    // Test with simple integer array
+    let int_values = vec![1, 2, 3];
+    let int_array_data =
+        ArrayData::try_new(ArrayType::new(KernelDataType::INTEGER, false), int_values).unwrap();
+
+    let schema = Arc::new(StructType::new(vec![StructField::new(
+        "col1",
+        KernelDataType::INTEGER,
+        false,
+    )]));
+
+    let result = handler
+        .into_engine_data(schema.clone(), vec![int_array_data])
+        .unwrap();
+    let arrow_data = result.any_ref().downcast_ref::<ArrowEngineData>().unwrap();
+    let batch = arrow_data.record_batch();
+
+    assert_eq!(batch.num_columns(), 1);
+    assert_eq!(batch.num_rows(), 3);
+    assert_eq!(batch.column(0).len(), 3);
+
+    // Verify the values
+    let int_array = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .unwrap();
+    assert_eq!(int_array.value(0), 1);
+    assert_eq!(int_array.value(1), 2);
+    assert_eq!(int_array.value(2), 3);
+}
+
+#[test]
+fn test_into_engine_data_multiple_columns() {
+    let handler = ArrowEvaluationHandler;
+
+    // Create multiple columns with different types
+    let int_values = vec![10, 20];
+    let int_array_data =
+        ArrayData::try_new(ArrayType::new(KernelDataType::INTEGER, true), int_values).unwrap();
+
+    let string_values = vec!["hello".to_string(), "world".to_string()];
+    let string_array_data =
+        ArrayData::try_new(ArrayType::new(KernelDataType::STRING, true), string_values).unwrap();
+
+    let bool_values = vec![true, false];
+    let bool_array_data =
+        ArrayData::try_new(ArrayType::new(KernelDataType::BOOLEAN, true), bool_values).unwrap();
+
+    let schema = Arc::new(StructType::new(vec![
+        StructField::new("int_col", KernelDataType::INTEGER, true),
+        StructField::new("str_col", KernelDataType::STRING, true),
+        StructField::new("bool_col", KernelDataType::BOOLEAN, true),
+    ]));
+
+    let result = handler
+        .into_engine_data(
+            schema.clone(),
+            vec![int_array_data, string_array_data, bool_array_data],
+        )
+        .unwrap();
+
+    let arrow_data = result.any_ref().downcast_ref::<ArrowEngineData>().unwrap();
+    let batch = arrow_data.record_batch();
+
+    assert_eq!(batch.num_columns(), 3);
+    assert_eq!(batch.num_rows(), 2);
+
+    // Verify integer column
+    let int_array = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .unwrap();
+    assert_eq!(int_array.value(0), 10);
+    assert_eq!(int_array.value(1), 20);
+
+    // Verify string column
+    let string_array = batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(string_array.value(0), "hello");
+    assert_eq!(string_array.value(1), "world");
+
+    // Verify boolean column
+    let bool_array = batch
+        .column(2)
+        .as_any()
+        .downcast_ref::<BooleanArray>()
+        .unwrap();
+    assert_eq!(bool_array.value(0), true);
+    assert_eq!(bool_array.value(1), false);
+}
+
+#[test]
+fn test_into_engine_data_empty_array() {
+    let handler = ArrowEvaluationHandler;
+
+    // Test with empty array
+    let empty_values: Vec<Scalar> = vec![];
+    let empty_array_data =
+        ArrayData::try_new(ArrayType::new(KernelDataType::INTEGER, true), empty_values).unwrap();
+
+    let schema = Arc::new(StructType::new(vec![StructField::new(
+        "col1",
+        KernelDataType::INTEGER,
+        true,
+    )]));
+
+    let result = handler
+        .into_engine_data(schema.clone(), vec![empty_array_data])
+        .unwrap();
+    let arrow_data = result.any_ref().downcast_ref::<ArrowEngineData>().unwrap();
+    let batch = arrow_data.record_batch();
+
+    assert_eq!(batch.num_columns(), 1);
+    assert_eq!(batch.num_rows(), 0);
+    assert_eq!(batch.column(0).len(), 0);
+}
+
+#[test]
+fn test_into_engine_data_with_nulls() {
+    let handler = ArrowEvaluationHandler;
+
+    // Test with array containing null values
+    let values_with_nulls = vec![Some(42), None::<i32>, Some(84)];
+    let array_data = ArrayData::try_new(
+        ArrayType::new(KernelDataType::INTEGER, true),
+        values_with_nulls,
+    )
+    .unwrap();
+
+    let schema = Arc::new(StructType::new(vec![StructField::new(
+        "col1",
+        KernelDataType::INTEGER,
+        true,
+    )]));
+
+    let result = handler
+        .into_engine_data(schema.clone(), vec![array_data])
+        .unwrap();
+    let arrow_data = result.any_ref().downcast_ref::<ArrowEngineData>().unwrap();
+    let batch = arrow_data.record_batch();
+
+    assert_eq!(batch.num_columns(), 1);
+    assert_eq!(batch.num_rows(), 3);
+
+    let int_array = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .unwrap();
+
+    assert_eq!(int_array.value(0), 42);
+    assert!(int_array.is_null(1));
+    assert_eq!(int_array.value(2), 84);
+}
+
+#[test]
+fn test_into_engine_data_various_types() {
+    let handler = ArrowEvaluationHandler;
+
+    // Test with various primitive types
+    let long_values = vec![Scalar::Long(9223372036854775807)];
+    let float_values = vec![Scalar::Float(3.14)];
+    let double_values = vec![Scalar::Double(2.718281828)];
+    let byte_values = vec![Scalar::Byte(127)];
+    let short_values = vec![Scalar::Short(32767)];
+    let binary_values = vec![Scalar::Binary(vec![0x42, 0x43, 0x44])];
+
+    let schema = Arc::new(StructType::new(vec![
+        StructField::new("long_col", KernelDataType::LONG, true),
+        StructField::new("float_col", KernelDataType::FLOAT, true),
+        StructField::new("double_col", KernelDataType::DOUBLE, true),
+        StructField::new("byte_col", KernelDataType::BYTE, true),
+        StructField::new("short_col", KernelDataType::SHORT, true),
+        StructField::new("binary_col", KernelDataType::BINARY, true),
+    ]));
+
+    let result = handler
+        .into_engine_data(
+            schema.clone(),
+            vec![
+                ArrayData::try_new(ArrayType::new(KernelDataType::LONG, true), long_values)
+                    .unwrap(),
+                ArrayData::try_new(ArrayType::new(KernelDataType::FLOAT, true), float_values)
+                    .unwrap(),
+                ArrayData::try_new(ArrayType::new(KernelDataType::DOUBLE, true), double_values)
+                    .unwrap(),
+                ArrayData::try_new(ArrayType::new(KernelDataType::BYTE, true), byte_values)
+                    .unwrap(),
+                ArrayData::try_new(ArrayType::new(KernelDataType::SHORT, true), short_values)
+                    .unwrap(),
+                ArrayData::try_new(ArrayType::new(KernelDataType::BINARY, true), binary_values)
+                    .unwrap(),
+            ],
+        )
+        .unwrap();
+
+    let arrow_data = result.any_ref().downcast_ref::<ArrowEngineData>().unwrap();
+    let batch = arrow_data.record_batch();
+
+    assert_eq!(batch.num_columns(), 6);
+    assert_eq!(batch.num_rows(), 1);
+
+    // Verify each column type and value
+    let long_array = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap();
+    assert_eq!(long_array.value(0), 9223372036854775807);
+
+    let float_array = batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<Float32Array>()
+        .unwrap();
+    assert!((float_array.value(0) - 3.14).abs() < f32::EPSILON);
+
+    let double_array = batch
+        .column(2)
+        .as_any()
+        .downcast_ref::<Float64Array>()
+        .unwrap();
+    assert!((double_array.value(0) - 2.718281828).abs() < f64::EPSILON);
+
+    let byte_array = batch
+        .column(3)
+        .as_any()
+        .downcast_ref::<Int8Array>()
+        .unwrap();
+    assert_eq!(byte_array.value(0), 127);
+
+    let short_array = batch
+        .column(4)
+        .as_any()
+        .downcast_ref::<Int16Array>()
+        .unwrap();
+    assert_eq!(short_array.value(0), 32767);
+
+    let binary_array = batch
+        .column(5)
+        .as_any()
+        .downcast_ref::<BinaryArray>()
+        .unwrap();
+    assert_eq!(binary_array.value(0), &[0x42, 0x43, 0x44]);
+}
+
+#[test]
+fn test_into_engine_data_schema_mismatch() {
+    let handler = ArrowEvaluationHandler;
+
+    // Create data with 2 columns but schema with 1 column
+    let int_values = vec![1, 2];
+    let string_values = vec!["test".to_string(), "data".to_string()];
+
+    let schema = Arc::new(StructType::new(vec![
+        StructField::new("col1", KernelDataType::INTEGER, true),
+        // Missing second column in schema
+    ]));
+
+    let result = handler.into_engine_data(
+        schema.clone(),
+        vec![
+            ArrayData::try_new(ArrayType::new(KernelDataType::INTEGER, true), int_values).unwrap(),
+            ArrayData::try_new(ArrayType::new(KernelDataType::STRING, true), string_values)
+                .unwrap(),
+        ],
+    );
+
+    // This should fail because we have 2 columns but schema only defines 1
+    assert!(result.is_err());
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -85,6 +85,8 @@ use std::{cmp::Ordering, ops::Range};
 use bytes::Bytes;
 use url::Url;
 
+use crate::expressions::ArrayData;
+
 use self::schema::{DataType, SchemaRef};
 
 pub mod actions;
@@ -441,6 +443,20 @@ pub trait EvaluationHandler: AsAny {
     // NOTE: we should probably allow DataType instead of SchemaRef, but can expand that in the
     // future.
     fn null_row(&self, output_schema: SchemaRef) -> DeltaResult<Box<dyn EngineData>>;
+
+    /// Concatenate two [`EngineData`] column-wise into a single one.
+    fn columnar_concat(
+        &self,
+        left: &dyn EngineData,
+        right: &dyn EngineData,
+    ) -> DeltaResult<Box<dyn EngineData>>;
+
+    // Convert StructData created by Kernel into EngineData
+    fn into_engine_data(
+        &self,
+        schema: SchemaRef,
+        columns: Vec<ArrayData>,
+    ) -> DeltaResult<Box<dyn EngineData>>;
 }
 
 /// Internal trait to allow us to have a private `create_one` API that's implemented for all


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-incubator/delta-kernel-rs/blob/main/CONTRIBUTING.md
  2. Run `cargo t --all-features --all-targets` to get started testing, and run `cargo fmt`.
  3. Ensure you have added or run the appropriate tests for your PR.
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

<!--
PR title formatting:
This project uses conventional commits: https://www.conventionalcommits.org/

Each PR corresponds to a commit on the `main` branch, with the title of the PR (typically) being
used for the commit message on main. In order to ensure proper formatting in the CHANGELOG please
ensure your PR title adheres to the conventional commit specification.

Examples:
- new feature PR: "feat: new API for snapshot.update()"
- bugfix PR: "fix: correctly apply DV in read-table example"
-->

## What changes are proposed in this pull request?
<!--
Please clarify what changes you are proposing and why the changes are needed.
The purpose of this section is to outline the changes, why they are needed, and how this PR fixes the issue.
If the reason for the change is already explained clearly in an issue, then it does not need to be restated here.
  1. If you propose a new API or feature, clarify the use case for a new API or feature.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This PR adds two new `EvaluationHandler` functions:
- `columnar_concat` allows column-wise concatenation of two existing `EngineData` into a single one. 
- `into_engine_data` allows kernel to convert data it generated into `EngineData`.

The two functions are necessary for row tracking support, where kernel needs to perform the following steps:
1. Compute base row IDs (and default commit versions) from a set of AddFile actions, resulting in two `Vec<i64>`
2. Convert the vector data into `EngineData` -> `into_engine_data()`
3. Combine that `EngineData` with the existing `EngineData` containing other AddFile metadata -> `columnar_concat`


### This PR affects the following public APIs

This PR adds two new public APIs to the `EvaluationHandler` trait (see above).


## How was this change tested?
<!--
Please make sure to add test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested, ideally via a reproducible test documented in the PR description.
-->

New UTs in the default engine.