### PR TITLE
feat!: Add `UnaryExpression` and `ToJson` expression

### DIFF
--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -1,7 +1,7 @@
 //! Expression handling based on arrow-rs compute kernels.
 use crate::arrow::array::types::*;
 use crate::arrow::array::{
-    Array, ArrayRef, AsArray, BooleanArray, Datum, RecordBatch, StructArray,
+    Array, ArrayRef, AsArray, BooleanArray, Datum, RecordBatch, StringArray, StructArray,
 };
 use crate::arrow::compute::kernels::cmp::{distinct, eq, gt, gt_eq, lt, lt_eq, neq, not_distinct};
 use crate::arrow::compute::kernels::comparison::in_list_utf8;
@@ -11,6 +11,7 @@ use crate::arrow::datatypes::{
     DataType as ArrowDataType, Field as ArrowField, IntervalUnit, TimeUnit,
 };
 use crate::arrow::error::ArrowError;
+use crate::arrow::json::LineDelimitedWriter;
 use crate::engine::arrow_expression::opaque::{
     ArrowOpaqueExpressionOpAdaptor, ArrowOpaquePredicateOpAdaptor,
 };
@@ -19,7 +20,7 @@ use crate::error::{DeltaResult, Error};
 use crate::expressions::{
     BinaryExpression, BinaryExpressionOp, BinaryPredicate, BinaryPredicateOp, Expression,
     JunctionPredicate, JunctionPredicateOp, OpaqueExpression, OpaquePredicate, Predicate, Scalar,
-    UnaryPredicate, UnaryPredicateOp,
+    UnaryExpression, UnaryExpressionOp, UnaryPredicate, UnaryPredicateOp,
 };
 use crate::schema::DataType;
 use itertools::Itertools;
@@ -85,6 +86,7 @@ pub fn evaluate_expression(
 ) -> DeltaResult<ArrayRef> {
     use BinaryExpressionOp::*;
     use Expression::*;
+    use UnaryExpressionOp::*;
     match (expression, result_type) {
         (Literal(scalar), _) => Ok(scalar.to_array(batch.num_rows())?),
         (Column(name), _) => extract_column(batch, name),
@@ -118,6 +120,28 @@ pub fn evaluate_expression(
         (Predicate(_), Some(data_type)) => Err(Error::generic(format!(
             "Predicate evaluation produces boolean output, but caller expects {data_type:?}"
         ))),
+        (Unary(UnaryExpression { op, expr }), data_type) => {
+            match op {
+                ToJson => {
+                    if let Some(data_type) = data_type {
+                        if data_type != &DataType::STRING {
+                            return Err(Error::generic(format!(
+                                "ToJson operator requires STRING output, but got {data_type:?}"
+                            )));
+                        }
+                    }
+                }
+            };
+
+            let input_arr = evaluate_expression(expr, batch, None)?;
+
+            type Operation = fn(&dyn Datum) -> Result<ArrayRef, ArrowError>;
+            let eval: Operation = match op {
+                ToJson => to_json,
+            };
+
+            Ok(eval(&input_arr)?)
+        }
         (Binary(BinaryExpression { op, left, right }), _) => {
             let left_arr = evaluate_expression(left.as_ref(), batch, None)?;
             let right_arr = evaluate_expression(right.as_ref(), batch, None)?;
@@ -288,5 +312,61 @@ pub fn evaluate_predicate(
             }
         }
         Unknown(name) => Err(Error::unsupported(format!("Unknown predicate: {name:?}"))),
+    }
+}
+
+/// Converts a StructArray to JSON-encoded strings
+pub fn to_json(input: &dyn Datum) -> Result<ArrayRef, ArrowError> {
+    let (array_ref, _is_scalar) = input.get();
+    match array_ref.data_type() {
+        ArrowDataType::Struct(_) => {
+            let struct_array = array_ref.as_struct_opt().ok_or_else(|| {
+                ArrowError::InvalidArgumentError(
+                    "Expected struct array but got different type".to_string(),
+                )
+            })?;
+            let num_rows = struct_array.len();
+
+            // Convert each struct row to JSON
+            let mut json_strings = Vec::with_capacity(num_rows);
+
+            for i in 0..num_rows {
+                if struct_array.is_null(i) {
+                    json_strings.push(None);
+                } else {
+                    // Create a single-row RecordBatch from the struct row
+                    let row_batch = RecordBatch::try_new(
+                        std::sync::Arc::new(crate::arrow::datatypes::Schema::new(
+                            struct_array.fields().iter().cloned().collect::<Vec<_>>(),
+                        )),
+                        struct_array
+                            .columns()
+                            .iter()
+                            .map(|col| col.slice(i, 1))
+                            .collect(),
+                    )?;
+
+                    // Use LineDelimitedWriter to convert to JSON
+                    let mut writer = LineDelimitedWriter::new(Vec::new());
+                    writer.write(&row_batch)?;
+                    writer.finish()?;
+                    let json_bytes = writer.into_inner();
+
+                    // Convert bytes to string, removing the trailing newline
+                    let json_string = String::from_utf8(json_bytes).map_err(|e| {
+                        ArrowError::InvalidArgumentError(format!("Invalid UTF-8: {e}"))
+                    })?;
+                    let json_string = json_string.trim_end().to_string();
+
+                    json_strings.push(Some(json_string));
+                }
+            }
+
+            Ok(Arc::new(StringArray::from(json_strings)))
+        }
+        _ => Err(ArrowError::InvalidArgumentError(format!(
+            "TO_JSON can only be applied to struct arrays, got {:?}",
+            array_ref.data_type()
+        ))),
     }
 }

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -2,13 +2,14 @@ use std::ops::{Add, Div, Mul, Sub};
 
 use crate::arrow::array::{
     create_array, Array, ArrayRef, BooleanArray, GenericStringArray, Int32Array, Int32Builder,
-    ListArray, MapArray, MapBuilder, MapFieldNames, StringBuilder, StructArray,
+    ListArray, MapArray, MapBuilder, MapFieldNames, StringArray, StringBuilder, StructArray,
 };
 use crate::arrow::buffer::{OffsetBuffer, ScalarBuffer};
 use crate::arrow::compute::kernels::cmp::{gt_eq, lt};
 use crate::arrow::datatypes::{DataType, Field, Fields, Schema};
 
 use super::*;
+use crate::engine::arrow_expression::evaluate_expression::to_json;
 use crate::engine::arrow_expression::opaque::{
     ArrowOpaqueExpression as _, ArrowOpaqueExpressionOp, ArrowOpaquePredicate as _,
     ArrowOpaquePredicateOp,
@@ -899,4 +900,147 @@ fn test_null_scalar_map() -> DeltaResult<()> {
     assert!(map_array.is_null(0));
 
     Ok(())
+}
+
+#[test]
+fn test_to_json_with_struct_array() {
+    // Create a test struct array
+    let boolean_field = Arc::new(Field::new("bool_field", ArrowDataType::Boolean, true));
+    let int_field = Arc::new(Field::new("int_field", ArrowDataType::Int32, true));
+    let string_field = Arc::new(Field::new("string_field", ArrowDataType::Utf8, true));
+
+    let boolean_array = Arc::new(BooleanArray::from(vec![Some(true), Some(false), None]));
+    let int_array = Arc::new(Int32Array::from(vec![Some(42), None, Some(84)]));
+    let string_array = Arc::new(StringArray::from(vec![
+        Some("hello"),
+        Some("world"),
+        Some("test"),
+    ]));
+
+    let struct_array = StructArray::new(
+        vec![boolean_field, int_field, string_field].into(),
+        vec![boolean_array, int_array, string_array],
+        None,
+    );
+
+    // Test the to_json function
+    let result = to_json(&struct_array).unwrap();
+    let json_array = result.as_any().downcast_ref::<StringArray>().unwrap();
+
+    assert_eq!(json_array.len(), 3);
+    assert_eq!(
+        json_array.value(0),
+        r#"{"bool_field":true,"int_field":42,"string_field":"hello"}"#
+    );
+    assert_eq!(
+        json_array.value(1),
+        r#"{"bool_field":false,"string_field":"world"}"#
+    );
+    assert_eq!(
+        json_array.value(2),
+        r#"{"int_field":84,"string_field":"test"}"#
+    );
+}
+
+#[test]
+fn test_to_json_with_null_struct() {
+    // Create a test struct array with a NullBuffer
+    let int_field = Arc::new(Field::new("int_field", ArrowDataType::Int32, true));
+    let int_array = Arc::new(Int32Array::from(vec![Some(42), Some(24)]));
+
+    let struct_array = StructArray::new(
+        vec![int_field].into(),
+        vec![int_array],
+        Some(crate::arrow::buffer::NullBuffer::new(
+            crate::arrow::buffer::BooleanBuffer::from(vec![true, false]),
+        )),
+    );
+
+    // Test the to_json function
+    let result = to_json(&struct_array).unwrap();
+    let json_array = result.as_any().downcast_ref::<StringArray>().unwrap();
+
+    assert_eq!(json_array.len(), 2);
+    assert!(!json_array.is_null(0));
+    assert!(json_array.is_null(1));
+    assert_eq!(json_array.value(0), r#"{"int_field":42}"#);
+}
+
+#[test]
+fn test_to_json_with_non_struct_array() {
+    // Test that to_json fails when input is not a StructArray
+    let int_array = Int32Array::from(vec![1, 2, 3]);
+    let result = to_json(&int_array);
+    assert!(result.is_err());
+
+    let string_array = StringArray::from(vec!["hello", "world"]);
+    let result = to_json(&string_array);
+    assert!(result.is_err());
+
+    let boolean_array = BooleanArray::from(vec![true, false]);
+    let result = to_json(&boolean_array);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_to_json_with_empty_struct_array() {
+    // Test to_json with an empty struct array
+    let int_field = Arc::new(Field::new("int_field", ArrowDataType::Int32, true));
+    let int_array = Arc::new(Int32Array::from(Vec::<Option<i32>>::new()));
+
+    let struct_array = StructArray::new(vec![int_field].into(), vec![int_array], None);
+
+    let result = to_json(&struct_array).unwrap();
+    let json_array = result.as_any().downcast_ref::<StringArray>().unwrap();
+    assert_eq!(json_array.len(), 0);
+}
+
+#[test]
+fn test_to_json_with_nested_struct() {
+    // Test to_json with nested struct fields
+    let inner_int_field = Arc::new(Field::new("inner_int", ArrowDataType::Int32, true));
+    let inner_string_field = Arc::new(Field::new("inner_string", ArrowDataType::Utf8, true));
+
+    let inner_int_array = Arc::new(Int32Array::from(vec![Some(10), None]));
+    let inner_string_array = Arc::new(StringArray::from(vec![Some("nested"), Some("value")]));
+
+    let inner_struct_array = Arc::new(StructArray::new(
+        vec![inner_int_field, inner_string_field].into(),
+        vec![inner_int_array, inner_string_array],
+        None,
+    ));
+
+    let outer_field = Arc::new(Field::new("outer_int", ArrowDataType::Int32, true));
+    let nested_field = Arc::new(Field::new(
+        "nested_struct",
+        ArrowDataType::Struct(
+            vec![
+                Field::new("inner_int", ArrowDataType::Int32, true),
+                Field::new("inner_string", ArrowDataType::Utf8, true),
+            ]
+            .into(),
+        ),
+        true,
+    ));
+
+    let outer_array = Arc::new(Int32Array::from(vec![Some(100), Some(200)]));
+
+    let struct_array = StructArray::new(
+        vec![outer_field, nested_field].into(),
+        vec![outer_array, inner_struct_array],
+        None,
+    );
+
+    let result = to_json(&struct_array).unwrap();
+    let json_array = result.as_any().downcast_ref::<StringArray>().unwrap();
+
+    assert_eq!(json_array.len(), 2);
+    assert_eq!(
+        json_array.value(0),
+        r#"{"outer_int":100,"nested_struct":{"inner_int":10,"inner_string":"nested"}}"#
+    );
+    assert_eq!(
+        json_array.value(1),
+        r#"{"outer_int":200,"nested_struct":{"inner_string":"value"}}"#
+    );
 }

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -52,6 +52,13 @@ pub enum BinaryPredicateOp {
     In,
 }
 
+/// A unary expression operator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UnaryExpressionOp {
+    /// Convert struct data to JSON-encoded strings
+    ToJson,
+}
+
 /// A binary expression operator.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BinaryExpressionOp {
@@ -195,6 +202,14 @@ pub struct BinaryPredicate {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub struct UnaryExpression {
+    /// The operator.
+    pub op: UnaryExpressionOp,
+    /// The input expression.
+    pub expr: Box<Expression>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct BinaryExpression {
     /// The operator.
     pub op: BinaryExpressionOp,
@@ -259,6 +274,8 @@ pub enum Expression {
     Predicate(Box<Predicate>), // should this be Arc?
     /// A struct computed from a Vec of expressions
     Struct(Vec<ExpressionRef>),
+    /// An expression that takes one expression as input.
+    Unary(UnaryExpression),
     /// An expression that takes two expressions as input.
     Binary(BinaryExpression),
     /// An expression that the engine defines and implements. Kernel interacts with the expression
@@ -333,6 +350,13 @@ impl JunctionPredicateOp {
             And => Or,
             Or => And,
         }
+    }
+}
+
+impl UnaryExpression {
+    fn new(op: UnaryExpressionOp, expr: impl Into<Expression>) -> Self {
+        let expr = Box::new(expr.into());
+        Self { op, expr }
     }
 }
 
@@ -455,6 +479,14 @@ impl Expression {
     /// Create a new predicate `DISTINCT(self, other)`
     pub fn distinct(self, other: impl Into<Self>) -> Predicate {
         Predicate::distinct(self, other)
+    }
+
+    /// Creates a new unary expression
+    pub fn unary(op: UnaryExpressionOp, expr: impl Into<Expression>) -> Self {
+        Self::Unary(UnaryExpression {
+            op,
+            expr: Box::new(expr.into()),
+        })
     }
 
     /// Creates a new binary expression lhs OP rhs
@@ -640,6 +672,15 @@ impl PartialEq for OpaqueExpression {
     }
 }
 
+impl Display for UnaryExpressionOp {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        use UnaryExpressionOp::*;
+        match self {
+            ToJson => write!(f, "TO_JSON"),
+        }
+    }
+}
+
 impl Display for BinaryExpressionOp {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         use BinaryExpressionOp::*;
@@ -681,6 +722,7 @@ impl Display for Expression {
             Column(name) => write!(f, "Column({name})"),
             Predicate(p) => write!(f, "{p}"),
             Struct(exprs) => write!(f, "Struct({})", format_child_list(exprs)),
+            Unary(UnaryExpression { op, expr }) => write!(f, "{op}({expr})"),
             Binary(BinaryExpression { op, left, right }) => write!(f, "{left} {op} {right}"),
             Opaque(OpaqueExpression { op, exprs }) => {
                 write!(f, "{op:?}({})", format_child_list(exprs))

--- a/kernel/src/expressions/transforms.rs
+++ b/kernel/src/expressions/transforms.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::expressions::{
     BinaryExpression, BinaryPredicate, ColumnName, Expression, ExpressionRef, JunctionPredicate,
-    OpaqueExpression, OpaquePredicate, Predicate, Scalar, UnaryPredicate,
+    OpaqueExpression, OpaquePredicate, Predicate, Scalar, UnaryExpression, UnaryPredicate,
 };
 use crate::utils::CowExt as _;
 
@@ -75,6 +75,15 @@ pub trait ExpressionTransform<'a> {
         self.recurse_into_pred_not(pred)
     }
 
+    /// Called for each [`UnaryExpression`] encountered during the traversal. Implementations can
+    /// call [`Self::recurse_into_expr_unary`] if they wish to recursively transform the child.
+    fn transform_expr_unary(
+        &mut self,
+        expr: &'a UnaryExpression,
+    ) -> Option<Cow<'a, UnaryExpression>> {
+        self.recurse_into_expr_unary(expr)
+    }
+
     /// Called for each [`UnaryPredicate`] encountered during the traversal. Implementations can
     /// call [`Self::recurse_into_pred_unary`] if they wish to recursively transform the child.
     fn transform_pred_unary(
@@ -142,6 +151,9 @@ pub trait ExpressionTransform<'a> {
             Expression::Struct(s) => self
                 .transform_expr_struct(s)?
                 .map_owned_or_else(expr, Expression::Struct),
+            Expression::Unary(u) => self
+                .transform_expr_unary(u)?
+                .map_owned_or_else(expr, Expression::Unary),
             Expression::Binary(b) => self
                 .transform_expr_binary(b)?
                 .map_owned_or_else(expr, Expression::Binary),
@@ -242,6 +254,16 @@ pub trait ExpressionTransform<'a> {
         let right = self.transform_expr(&b.right)?;
         let f = |(left, right)| BinaryPredicate::new(b.op, left, right);
         Some((left, right).map_owned_or_else(b, f))
+    }
+
+    /// Recursively transforms a unary expression's child. Returns `None` if the child was removed,
+    /// `Some(Cow::Owned)` if the child was changed, and `Some(Cow::Borrowed)` otherwise.
+    fn recurse_into_expr_unary(
+        &mut self,
+        u: &'a UnaryExpression,
+    ) -> Option<Cow<'a, UnaryExpression>> {
+        let nested_result = self.transform_expr(&u.expr)?;
+        Some(nested_result.map_owned_or_else(u, |expr| UnaryExpression::new(u.op, expr)))
     }
 
     /// Recursively transforms a binary expression's children. Returns `None` if at least one child

--- a/kernel/src/kernel_predicates/mod.rs
+++ b/kernel/src/kernel_predicates/mod.rs
@@ -7,7 +7,7 @@ use crate::expressions::{
     BinaryExpression, BinaryExpressionOp, BinaryPredicate, BinaryPredicateOp, ColumnName,
     Expression as Expr, JunctionPredicate, JunctionPredicateOp, OpaqueExpression,
     OpaqueExpressionOpRef, OpaquePredicate, OpaquePredicateOpRef, Predicate as Pred, Scalar,
-    UnaryPredicate, UnaryPredicateOp,
+    UnaryExpression, UnaryExpressionOp, UnaryPredicate, UnaryPredicateOp,
 };
 use crate::schema::DataType;
 
@@ -177,7 +177,7 @@ pub trait KernelPredicateEvaluator {
             Expr::Opaque(OpaqueExpression { op, exprs }) => {
                 self.eval_pred_expr_opaque(op, exprs, inverted)
             }
-            Expr::Struct(_) | Expr::Binary(_) | Expr::Unknown(_) => None,
+            Expr::Struct(_) | Expr::Unary(_) | Expr::Binary(_) | Expr::Unknown(_) => None,
         }
     }
 
@@ -199,6 +199,7 @@ pub trait KernelPredicateEvaluator {
                 Expr::Column(col) => self.eval_pred_is_null(col, inverted),
                 Expr::Predicate(_)
                 | Expr::Struct(_)
+                | Expr::Unary(_)
                 | Expr::Binary(_)
                 | Expr::Opaque(_)
                 | Expr::Unknown(_) => {
@@ -609,6 +610,9 @@ impl<R: ResolveColumnAsScalar> DefaultKernelPredicateEvaluator<R> {
             Expr::Column(name) => self.resolve_column(name),
             Expr::Predicate(pred) => self.eval_pred(pred, false).map(Scalar::from),
             Expr::Struct(_) => None, // TODO
+            Expr::Unary(UnaryExpression { op, expr: _ }) => match op {
+                UnaryExpressionOp::ToJson => None, // TODO
+            },
             Expr::Binary(BinaryExpression { op, left, right }) => {
                 let op_fn = match op {
                     BinaryExpressionOp::Plus => Scalar::try_add,


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR introduces `UnaryExpression` as a new kind of expression that takes one expression as input and performs an operation on it. Different from `UnaryPredicate`, its output is not Boolean.

This change is necessary to support the `ToJson` expression, which is also introduced in this PR. We will need a `ToJson` operation once we let the Parquet handler report stats back to kernel. These stats should be strongly typed as a Struct to not perform unnecessary SerDe. However, this means that we need to serialize the stats into a JSON string before writing them to the Delta log.

### This PR affects the following public APIs

This PR extends the expression framework and thus requires all implementing engines to adopt the new expression.

## How was this change tested?

New UT for `to_json()`.