### PR TITLE
feat!: Add support for sparse transform expressions

### DIFF
--- a/ffi/src/expressions/engine_visitor.rs
+++ b/ffi/src/expressions/engine_visitor.rs
@@ -482,6 +482,11 @@ fn visit_expression_impl(
         Expression::Opaque(OpaqueExpression { op, exprs }) => {
             visit_expression_opaque(visitor, op, exprs, sibling_list_id)
         }
+        Expression::Transform(_) => {
+            // Minimal FFI support: Transform expressions are treated as unknown
+            // TODO: Implement full Transform FFI support in future version
+            visit_unknown(visitor, sibling_list_id, "Transform")
+        }
         Expression::Unknown(name) => visit_unknown(visitor, sibling_list_id, name),
     }
 }

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -117,7 +117,7 @@ fn evaluate_transform_expression(
     
     // Handle prepends (insertions before any field)
     if let Some(prepend_exprs) = transform.field_insertions.get(&None) {
-        expressions.extend(prepend_exprs.iter().cloned()); // TODO: Use Cow<Expression> instead of cloning
+        expressions.extend(prepend_exprs.iter().cloned()); // cheap Arc clone 
         used_insertion_keys.insert(None);
     }
     
@@ -129,7 +129,7 @@ fn evaluate_transform_expression(
         match transform.field_replacements.get(field_name) {
             Some(Some(replacement_expr)) => {
                 // Field is replaced
-                expressions.push(replacement_expr.clone()); // TODO: Use Cow<Expression> instead of cloning
+                expressions.push(replacement_expr.clone()); // cheap Arc clone
             }
             Some(None) => {
                 // Field is dropped - skip it entirely
@@ -142,7 +142,7 @@ fn evaluate_transform_expression(
         
         // Handle insertions after this input field
         if let Some(insertion_exprs) = transform.field_insertions.get(&Some(field_name.to_string())) {
-            expressions.extend(insertion_exprs.iter().cloned()); // TODO: Use Cow<Expression> instead of cloning
+            expressions.extend(insertion_exprs.iter().cloned()); // cheap Arc clone
             used_insertion_keys.insert(Some(field_name.to_string()));
         }
     }
@@ -153,11 +153,11 @@ fn evaluate_transform_expression(
     }
     
     // Validate expression count matches output schema
-    if expressions.len() != output_schema.fields().len() {
+    if expressions.len() != output_schema.fields_len() {
         return Err(Error::generic(format!(
             "Expression count ({}) doesn't match output schema field count ({})",
             expressions.len(), 
-            output_schema.fields().len()
+            output_schema.fields_len()
         )));
     }
     

--- a/kernel/src/engine/arrow_expression/mod.rs
+++ b/kernel/src/engine/arrow_expression/mod.rs
@@ -1,7 +1,7 @@
 //! Expression handling based on arrow-rs compute kernels.
 use std::sync::Arc;
 
-use crate::arrow::array::{self, ArrayBuilder, ArrayRef, RecordBatch};
+use crate::arrow::array::{self, ArrayBuilder, ArrayRef, RecordBatch, StructArray};
 use crate::arrow::datatypes::{
     DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
 };
@@ -279,14 +279,29 @@ impl ExpressionEvaluator for DefaultExpressionEvaluator {
         //         batch.schema()
         //     )));
         // };
-        let array_ref = evaluate_expression(&self.expression, batch, Some(&self.output_type))?;
-        let batch: RecordBatch = if let DataType::Struct(_) = self.output_type {
-            apply_schema(&array_ref, &self.output_type)?
+        // Short-circuit optimization: if this is an empty Transform (only column mapping, no actual transformations),
+        // skip expression evaluation and directly apply the output schema to the input RecordBatch
+        let batch: RecordBatch = if let (Expression::Transform(transform), DataType::Struct(_)) = (&self.expression, &self.output_type) {
+            if transform.field_replacements.is_empty() && transform.field_insertions.is_empty() {
+                // Empty transform - just apply schema directly to input RecordBatch
+                let struct_array = StructArray::from(batch.clone());
+                apply_schema(&struct_array, &self.output_type)?
+            } else {
+                // Non-empty transform - use normal evaluation path
+                let array_ref = evaluate_expression(&self.expression, batch, Some(&self.output_type))?;
+                apply_schema(&array_ref, &self.output_type)?
+            }
         } else {
-            let array_ref = apply_schema_to(&array_ref, &self.output_type)?;
-            let arrow_type = ArrowDataType::try_from_kernel(&self.output_type)?;
-            let schema = ArrowSchema::new(vec![ArrowField::new("output", arrow_type, true)]);
-            RecordBatch::try_new(Arc::new(schema), vec![array_ref])?
+            // Non-transform expression - use normal evaluation path
+            let array_ref = evaluate_expression(&self.expression, batch, Some(&self.output_type))?;
+            if let DataType::Struct(_) = self.output_type {
+                apply_schema(&array_ref, &self.output_type)?
+            } else {
+                let array_ref = apply_schema_to(&array_ref, &self.output_type)?;
+                let arrow_type = ArrowDataType::try_from_kernel(&self.output_type)?;
+                let schema = ArrowSchema::new(vec![ArrowField::new("output", arrow_type, true)]);
+                RecordBatch::try_new(Arc::new(schema), vec![array_ref])?
+            }
         };
         Ok(Box::new(ArrowEngineData::new(batch)))
     }

--- a/kernel/src/engine/arrow_expression/mod.rs
+++ b/kernel/src/engine/arrow_expression/mod.rs
@@ -281,14 +281,17 @@ impl ExpressionEvaluator for DefaultExpressionEvaluator {
         // };
         // Short-circuit optimization: if this is an empty Transform (only column mapping, no actual transformations),
         // skip expression evaluation and directly apply the output schema to the input RecordBatch
-        let batch: RecordBatch = if let (Expression::Transform(transform), DataType::Struct(_)) = (&self.expression, &self.output_type) {
+        let batch: RecordBatch = if let (Expression::Transform(transform), DataType::Struct(_)) =
+            (&self.expression, &self.output_type)
+        {
             if transform.field_replacements.is_empty() && transform.field_insertions.is_empty() {
                 // Empty transform - just apply schema directly to input RecordBatch
                 let struct_array = StructArray::from(batch.clone());
                 apply_schema(&struct_array, &self.output_type)?
             } else {
                 // Non-empty transform - use normal evaluation path
-                let array_ref = evaluate_expression(&self.expression, batch, Some(&self.output_type))?;
+                let array_ref =
+                    evaluate_expression(&self.expression, batch, Some(&self.output_type))?;
                 apply_schema(&array_ref, &self.output_type)?
             }
         } else {

--- a/kernel/src/expressions/literal_expression_transform.rs
+++ b/kernel/src/expressions/literal_expression_transform.rs
@@ -131,14 +131,14 @@ impl<'a, T: Iterator<Item = &'a Scalar>> SchemaTransform<'a> for LiteralExpressi
         self.recurse_into_struct(struct_type)?;
         let field_exprs = self.stack.split_off(mark);
 
-        if field_exprs.len() != struct_type.fields_len() {
+        let fields = struct_type.fields();
+        if field_exprs.len() != fields.len() {
             self.set_error(Error::InsufficientScalars);
             return None;
         }
 
         let mut found_non_nullable_null = false;
         let mut all_null = true;
-        let fields = struct_type.fields();
         for (field, expr) in fields.zip(&field_exprs) {
             if !matches!(expr, Expression::Literal(Scalar::Null(_))) {
                 all_null = false;

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -256,11 +256,11 @@ pub struct Transform {
     /// - `Some(expression)`: Replace the field with this expression
     /// - `None`: Drop the field from output
     /// - Absent key: Pass through field unchanged
-    pub field_replacements: HashMap<String, Option<Expression>>,
+    pub field_replacements: HashMap<String, Option<ExpressionRef>>,
     /// New fields to insert at various positions. The key determines insertion point:
-    /// - `Some(field_name)`: Insert before the named field  
-    /// - `None`: Append at the end of the struct
-    pub field_insertions: HashMap<Option<String>, Vec<Expression>>,
+    /// - `Some(field_name)`: Insert after the named field  
+    /// - `None`: Prepend at the start of the struct
+    pub field_insertions: HashMap<Option<String>, Vec<ExpressionRef>>,
 }
 
 impl Transform {
@@ -276,13 +276,13 @@ impl Transform {
     }
 
     /// Create a transform with a replaced field
-    pub fn with_replaced_field(mut self, name: impl Into<String>, expr: Expression) -> Self {
+    pub fn with_replaced_field(mut self, name: impl Into<String>, expr: ExpressionRef) -> Self {
         self.field_replacements.insert(name.into(), Some(expr));
         self
     }
 
     /// Create a transform with an insertion
-    pub fn with_insertion(mut self, after: Option<String>, exprs: Vec<Expression>) -> Self {
+    pub fn with_insertion(mut self, after: Option<String>, exprs: Vec<ExpressionRef>) -> Self {
         self.field_insertions.insert(after, exprs);
         self
     }

--- a/kernel/src/expressions/transforms.rs
+++ b/kernel/src/expressions/transforms.rs
@@ -243,7 +243,8 @@ pub trait ExpressionTransform<'a> {
         let mut new_field_insertions = Vec::new();
         for (key, exprs) in &t.field_insertions {
             let new_exprs = recurse_into_children(exprs, |e| {
-                self.transform_expr(e).map(|cow| cow.map_owned_or_else(e, Arc::new))
+                self.transform_expr(e)
+                    .map(|cow| cow.map_owned_or_else(e, Arc::new))
             });
             if !matches!(new_exprs, Some(Cow::Borrowed(_))) {
                 any_field_changed = true;
@@ -256,7 +257,12 @@ pub trait ExpressionTransform<'a> {
         if any_field_changed {
             let field_replacements = new_field_replacements
                 .into_iter()
-                .map(|(name, replacement)| (name.to_owned(), replacement.map(Cow::into_owned).map(Arc::new)))
+                .map(|(name, replacement)| {
+                    (
+                        name.to_owned(),
+                        replacement.map(Cow::into_owned).map(Arc::new),
+                    )
+                })
                 .collect();
             let field_insertions = new_field_insertions
                 .into_iter()

--- a/kernel/src/kernel_predicates/mod.rs
+++ b/kernel/src/kernel_predicates/mod.rs
@@ -177,7 +177,7 @@ pub trait KernelPredicateEvaluator {
             Expr::Opaque(OpaqueExpression { op, exprs }) => {
                 self.eval_pred_expr_opaque(op, exprs, inverted)
             }
-            Expr::Struct(_) | Expr::Binary(_) | Expr::Unknown(_) => None,
+            Expr::Struct(_) | Expr::Transform(_) | Expr::Binary(_) | Expr::Unknown(_) => None,
         }
     }
 
@@ -199,6 +199,7 @@ pub trait KernelPredicateEvaluator {
                 Expr::Column(col) => self.eval_pred_is_null(col, inverted),
                 Expr::Predicate(_)
                 | Expr::Struct(_)
+                | Expr::Transform(_)
                 | Expr::Binary(_)
                 | Expr::Opaque(_)
                 | Expr::Unknown(_) => {
@@ -608,7 +609,7 @@ impl<R: ResolveColumnAsScalar> DefaultKernelPredicateEvaluator<R> {
             Expr::Literal(value) => Some(value.clone()),
             Expr::Column(name) => self.resolve_column(name),
             Expr::Predicate(pred) => self.eval_pred(pred, false).map(Scalar::from),
-            Expr::Struct(_) => None, // TODO
+            Expr::Struct(_) | Expr::Transform(_) => None, // TODO?
             Expr::Binary(BinaryExpression { op, left, right }) => {
                 let op_fn = match op {
                     BinaryExpressionOp::Plus => Scalar::try_add,

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -156,18 +156,15 @@ impl AddRemoveDedupVisitor<'_> {
     }
 
     /// Compute an expression that will transform from physical to logical for a given Add file action
+    ///
+    /// An empty `transform_spec` is valid and represents the case where only column mapping is needed
+    /// (e.g., no partition columns to inject). The resulting empty `Expression::Transform` will
+    /// pass all input fields through unchanged while applying the output schema for name mapping.
     fn get_transform_expr(
         &self,
         transform_spec: &Transform,
         mut partition_values: HashMap<usize, (String, Scalar)>,
     ) -> DeltaResult<ExpressionRef> {
-        if transform_spec.is_empty() {
-            // No transformations needed - this shouldn't happen with current logic
-            return Err(Error::InternalError(
-                "get_transform_expr called with empty transform_spec".to_string(),
-            ));
-        }
-
         let mut transform_expr = crate::expressions::Transform::new();
 
         for transform in transform_spec {

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -161,6 +161,11 @@ impl AddRemoveDedupVisitor<'_> {
         transform: &Transform,
         mut partition_values: HashMap<usize, (String, Scalar)>,
     ) -> DeltaResult<ExpressionRef> {
+        // TODO: Optimize with Expression::Transform for sparse transformations
+        // Current challenge: mapping between output schema positions (Transform/TransformExpr)
+        // and input schema field names (needed for Expression::Transform insertion positioning)
+        // This optimization would provide O(partition_count) vs O(schema_width) complexity
+
         let transforms = transform
             .iter()
             .map(|transform_expr| match transform_expr {

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -411,7 +411,7 @@ impl StructType {
         self.fields.get_index_of(name.as_ref())
     }
 
-    pub fn fields(&self) -> impl Iterator<Item = &StructField> {
+    pub fn fields(&self) -> impl ExactSizeIterator<Item = &StructField> {
         self.fields.values()
     }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Log replay needs to define per-file transforms for row of metadata that survives data skipping. Unfortunately, `Expression::Struct` is "dense" (mentions _every_ output field) and this produces excessive overhead when injecting the (usually very few) partition columns for tables with wide schemas (hundreds or thousands of columns). Column mapping tables are even worse, because they don't _change_ the columns at all -- they just need to apply the output schema to the input data.

Solution: Define a new `Expression::Transform` that is a "sparse" representation of the _changes_ to be made to a given top-level schema or nested struct. Input columns can be dropped or replaced, and new output columns can be injected after an input column of choice (or prepended to the output schema). 

Update log replay to use the new transform capability, so that the cost is `O(partition_columns)` instead of `O(schema_width)`. In the `metadata_bench` benchmark, scan times are nearly cut in half:
```
Benchmarking scan_metadata/scan_metadata: Warming up for 3.0000 s
Warning: Unable to complete 20 samples in 5.0s. You may wish to increase target time to 5.1s, or reduce sample count to 10.
scan_metadata/scan_metadata
                        time:   [250.51 ms 253.72 ms 257.45 ms]
                        change: [-45.173% -44.306% -43.415%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) high mild
```

### This PR affects the following public APIs

Added a new `Expression::Transform` enum variant.

## How was this change tested?

New and existing unit tests, existing benchmarks.