### PR TITLE
perf: make checkpoint visitor more efficient using short circuiting

### DIFF
--- a/kernel/src/checkpoint/log_replay.rs
+++ b/kernel/src/checkpoint/log_replay.rs
@@ -987,37 +987,6 @@ mod tests {
                     Ok(None)
                 }
             }
-
-            fn get_long(&'a self, _: usize, field_name: &str) -> DeltaResult<Option<i64>> {
-                if field_name == self.error_on_field && self.error_type == "long" {
-                    Err(
-                        Error::UnexpectedColumnType(format!("{field_name} is not of type i64"))
-                            .with_backtrace(),
-                    )
-                } else {
-                    Ok(None)
-                }
-            }
-
-            // Unused methods - required by trait but not covered by tests
-            // Note: These one-liner methods may show as uncovered but are just trait boilerplate
-            fn get_bool(&'a self, _: usize, _: &str) -> DeltaResult<Option<bool>> {
-                Ok(None)
-            }
-            fn get_list(
-                &'a self,
-                _: usize,
-                _: &str,
-            ) -> DeltaResult<Option<crate::engine_data::ListItem<'a>>> {
-                Ok(None)
-            }
-            fn get_map(
-                &'a self,
-                _: usize,
-                _: &str,
-            ) -> DeltaResult<Option<crate::engine_data::MapItem<'a>>> {
-                Ok(None)
-            }
         }
 
         /// Flexible mock for complex field error scenarios
@@ -1050,29 +1019,6 @@ mod tests {
                 } else {
                     Ok(None)
                 }
-            }
-
-            // Unused methods - required by trait but not covered by tests
-            // Note: These one-liner methods may show as uncovered but are just trait boilerplate
-            fn get_int(&'a self, _: usize, _: &str) -> DeltaResult<Option<i32>> {
-                Ok(None)
-            }
-            fn get_bool(&'a self, _: usize, _: &str) -> DeltaResult<Option<bool>> {
-                Ok(None)
-            }
-            fn get_list(
-                &'a self,
-                _: usize,
-                _: &str,
-            ) -> DeltaResult<Option<crate::engine_data::ListItem<'a>>> {
-                Ok(None)
-            }
-            fn get_map(
-                &'a self,
-                _: usize,
-                _: &str,
-            ) -> DeltaResult<Option<crate::engine_data::MapItem<'a>>> {
-                Ok(None)
             }
         }
     }

--- a/kernel/src/checkpoint/log_replay.rs
+++ b/kernel/src/checkpoint/log_replay.rs
@@ -1000,11 +1000,6 @@ mod tests {
                     Ok(Some("test_app"))
                 } else if field_name == "remove.path" {
                     Ok(Some("test_path"))
-                } else if field_name.contains(self.error_field) {
-                    Err(
-                        Error::UnexpectedColumnType(format!("{field_name} is not of type str"))
-                            .with_backtrace(),
-                    )
                 } else {
                     Ok(None)
                 }

--- a/kernel/src/checkpoint/log_replay.rs
+++ b/kernel/src/checkpoint/log_replay.rs
@@ -999,6 +999,8 @@ mod tests {
                 }
             }
 
+            // Unused methods - required by trait but not covered by tests
+            // Note: These one-liner methods may show as uncovered but are just trait boilerplate
             fn get_bool(&'a self, _: usize, _: &str) -> DeltaResult<Option<bool>> {
                 Ok(None)
             }
@@ -1050,6 +1052,8 @@ mod tests {
                 }
             }
 
+            // Unused methods - required by trait but not covered by tests
+            // Note: These one-liner methods may show as uncovered but are just trait boilerplate
             fn get_int(&'a self, _: usize, _: &str) -> DeltaResult<Option<i32>> {
                 Ok(None)
             }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-incubator/delta-kernel-rs/blob/main/CONTRIBUTING.md
  2. Run `cargo t --all-features --all-targets` to get started testing, and run `cargo fmt`.
  3. Ensure you have added or run the appropriate tests for your PR.
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

<!--
PR title formatting:
This project uses conventional commits: https://www.conventionalcommits.org/

Each PR corresponds to a commit on the `main` branch, with the title of the PR (typically) being
used for the commit message on main. In order to ensure proper formatting in the CHANGELOG please
ensure your PR title adheres to the conventional commit specification.

Examples:
- new feature PR: "feat: new API for snapshot.update()"
- bugfix PR: "fix: correctly apply DV in read-table example"
-->

## What changes are proposed in this pull request?
<!--
Please clarify what changes you are proposing and why the changes are needed.
The purpose of this section is to outline the changes, why they are needed, and how this PR fixes the issue.
If the reason for the change is already explained clearly in an issue, then it does not need to be restated here.
  1. If you propose a new API or feature, clarify the use case for a new API or feature.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Addressing https://github.com/delta-io/delta-kernel-rs/issues/1014, and implementing fix as suggested in issue.

This PR implements a short-circuit optimization for the checkpoint visitor code to improve performance when processing Delta Lake transaction logs during checkpoint creation.

Today, when a duplicate action is found, the system would still unnecessarily evaluate following action checks, even though the row was already determined to be excluded. 

To fix, we introduce a 4 states in the return with Option<DeltaResult<bool>>.

* Some(Ok(true)): Valid action found → include row, stop checking other types
* Some(Ok(false)): Action found but suppressed (duplicate/expired) → exclude row, stop checking other types
* None: No action of this type found → continue checking other action types
* Some(Err(...)): Error occurred → stop checking, propagate error

<!--
Uncomment this section if there are any changes affecting public APIs:
### This PR affects the following public APIs

If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.

Note that _new_ public APIs are not considered breaking.
-->


## How was this change tested?
<!--
Please make sure to add test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested, ideally via a reproducible test documented in the PR description.
-->

Existing tests