### PR TITLE
refactor(catalog-managed): push down _last_checkpoint read into LogSegment

### DIFF
--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -149,7 +149,7 @@ impl LogSegment {
     }
 
     // factored out for testing
-    fn for_snapshot_impl(
+    pub(crate) fn for_snapshot_impl(
         storage: &dyn StorageHandler,
         log_root: Url,
         checkpoint_hint: impl Into<Option<LastCheckpointHint>>,

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -152,12 +152,10 @@ impl LogSegment {
     pub(crate) fn for_snapshot_impl(
         storage: &dyn StorageHandler,
         log_root: Url,
-        checkpoint_hint: impl Into<Option<LastCheckpointHint>>,
-        time_travel_version: impl Into<Option<Version>>,
+        checkpoint_hint: Option<LastCheckpointHint>,
+        time_travel_version: Option<Version>,
     ) -> DeltaResult<Self> {
-        let time_travel_version = time_travel_version.into();
-
-        let listed_files = match (checkpoint_hint.into(), time_travel_version) {
+        let listed_files = match (checkpoint_hint, time_travel_version) {
             (Some(cp), None) => {
                 ListedLogFiles::list_with_checkpoint_hint(&cp, storage, &log_root, None)?
             }

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -141,6 +141,17 @@ impl LogSegment {
     pub(crate) fn for_snapshot(
         storage: &dyn StorageHandler,
         log_root: Url,
+        time_travel_version: impl Into<Option<Version>>,
+    ) -> DeltaResult<Self> {
+        let time_travel_version = time_travel_version.into();
+        let checkpoint_hint = LastCheckpointHint::try_read(storage, &log_root)?;
+        Self::for_snapshot_impl(storage, log_root, checkpoint_hint, time_travel_version)
+    }
+
+    // factored out for testing
+    fn for_snapshot_impl(
+        storage: &dyn StorageHandler,
+        log_root: Url,
         checkpoint_hint: impl Into<Option<LastCheckpointHint>>,
         time_travel_version: impl Into<Option<Version>>,
     ) -> DeltaResult<Self> {

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -298,7 +298,7 @@ fn build_snapshot_with_correct_last_uuid_checkpoint() {
     );
 
     let log_segment =
-        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, checkpoint_metadata, None)
+        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, Some(checkpoint_metadata), None)
             .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
@@ -375,7 +375,7 @@ fn build_snapshot_with_out_of_date_last_checkpoint() {
     );
 
     let log_segment =
-        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, checkpoint_metadata, None)
+        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, Some(checkpoint_metadata), None)
             .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
@@ -418,7 +418,7 @@ fn build_snapshot_with_correct_last_multipart_checkpoint() {
     );
 
     let log_segment =
-        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, checkpoint_metadata, None)
+        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, Some(checkpoint_metadata), None)
             .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
@@ -462,7 +462,7 @@ fn build_snapshot_with_missing_checkpoint_part_from_hint_fails() {
     );
 
     let log_segment =
-        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, checkpoint_metadata, None);
+        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, Some(checkpoint_metadata), None);
     assert_result_error_with_message(
         log_segment,
         "Invalid Checkpoint: Had a _last_checkpoint hint but didn't find any checkpoints",
@@ -499,7 +499,7 @@ fn build_snapshot_with_bad_checkpoint_hint_fails() {
     );
 
     let log_segment =
-        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, checkpoint_metadata, None);
+        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, Some(checkpoint_metadata), None);
     assert_result_error_with_message(
         log_segment,
         "Invalid Checkpoint: _last_checkpoint indicated that checkpoint should have 1 parts, but \
@@ -577,7 +577,7 @@ fn build_snapshot_with_out_of_date_last_checkpoint_and_incomplete_recent_checkpo
     );
 
     let log_segment =
-        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, checkpoint_metadata, None)
+        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, Some(checkpoint_metadata), None)
             .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
@@ -666,9 +666,13 @@ fn build_snapshot_with_checkpoint_greater_than_time_travel_version() {
         None,
     );
 
-    let log_segment =
-        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, checkpoint_metadata, Some(4))
-            .unwrap();
+    let log_segment = LogSegment::for_snapshot_impl(
+        storage.as_ref(),
+        log_root,
+        Some(checkpoint_metadata),
+        Some(4),
+    )
+    .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -705,9 +709,13 @@ fn build_snapshot_with_start_checkpoint_and_time_travel_version() {
         Some(&checkpoint_metadata),
     );
 
-    let log_segment =
-        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, checkpoint_metadata, Some(4))
-            .unwrap();
+    let log_segment = LogSegment::for_snapshot_impl(
+        storage.as_ref(),
+        log_root,
+        Some(checkpoint_metadata),
+        Some(4),
+    )
+    .unwrap();
 
     assert_eq!(log_segment.checkpoint_parts[0].version, 3);
     assert_eq!(log_segment.ascending_commit_files.len(), 1);

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -225,7 +225,8 @@ fn build_snapshot_with_uuid_checkpoint_parquet() {
         None,
     );
 
-    let log_segment = LogSegment::for_snapshot(storage.as_ref(), log_root, None, None).unwrap();
+    let log_segment =
+        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, None, None).unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -254,7 +255,8 @@ fn build_snapshot_with_uuid_checkpoint_json() {
         None,
     );
 
-    let log_segment = LogSegment::for_snapshot(storage.as_ref(), log_root, None, None).unwrap();
+    let log_segment =
+        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, None, None).unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -296,7 +298,8 @@ fn build_snapshot_with_correct_last_uuid_checkpoint() {
     );
 
     let log_segment =
-        LogSegment::for_snapshot(storage.as_ref(), log_root, checkpoint_metadata, None).unwrap();
+        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, checkpoint_metadata, None)
+            .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -332,7 +335,8 @@ fn build_snapshot_with_multiple_incomplete_multipart_checkpoints() {
         None,
     );
 
-    let log_segment = LogSegment::for_snapshot(storage.as_ref(), log_root, None, None).unwrap();
+    let log_segment =
+        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, None, None).unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -371,7 +375,8 @@ fn build_snapshot_with_out_of_date_last_checkpoint() {
     );
 
     let log_segment =
-        LogSegment::for_snapshot(storage.as_ref(), log_root, checkpoint_metadata, None).unwrap();
+        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, checkpoint_metadata, None)
+            .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -413,7 +418,8 @@ fn build_snapshot_with_correct_last_multipart_checkpoint() {
     );
 
     let log_segment =
-        LogSegment::for_snapshot(storage.as_ref(), log_root, checkpoint_metadata, None).unwrap();
+        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, checkpoint_metadata, None)
+            .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -456,7 +462,7 @@ fn build_snapshot_with_missing_checkpoint_part_from_hint_fails() {
     );
 
     let log_segment =
-        LogSegment::for_snapshot(storage.as_ref(), log_root, checkpoint_metadata, None);
+        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, checkpoint_metadata, None);
     assert_result_error_with_message(
         log_segment,
         "Invalid Checkpoint: Had a _last_checkpoint hint but didn't find any checkpoints",
@@ -493,7 +499,7 @@ fn build_snapshot_with_bad_checkpoint_hint_fails() {
     );
 
     let log_segment =
-        LogSegment::for_snapshot(storage.as_ref(), log_root, checkpoint_metadata, None);
+        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, checkpoint_metadata, None);
     assert_result_error_with_message(
         log_segment,
         "Invalid Checkpoint: _last_checkpoint indicated that checkpoint should have 1 parts, but \
@@ -524,7 +530,8 @@ fn build_snapshot_with_missing_checkpoint_part_no_hint() {
         None,
     );
 
-    let log_segment = LogSegment::for_snapshot(storage.as_ref(), log_root, None, None).unwrap();
+    let log_segment =
+        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, None, None).unwrap();
 
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
@@ -570,7 +577,8 @@ fn build_snapshot_with_out_of_date_last_checkpoint_and_incomplete_recent_checkpo
     );
 
     let log_segment =
-        LogSegment::for_snapshot(storage.as_ref(), log_root, checkpoint_metadata, None).unwrap();
+        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, checkpoint_metadata, None)
+            .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -603,7 +611,7 @@ fn build_snapshot_without_checkpoints() {
 
     ///////// Specify no checkpoint or end version /////////
     let log_segment =
-        LogSegment::for_snapshot(storage.as_ref(), log_root.clone(), None, None).unwrap();
+        LogSegment::for_snapshot_impl(storage.as_ref(), log_root.clone(), None, None).unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -616,7 +624,8 @@ fn build_snapshot_without_checkpoints() {
     assert_eq!(versions, expected_versions);
 
     ///////// Specify  only end version /////////
-    let log_segment = LogSegment::for_snapshot(storage.as_ref(), log_root, None, Some(2)).unwrap();
+    let log_segment =
+        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, None, Some(2)).unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -658,7 +667,8 @@ fn build_snapshot_with_checkpoint_greater_than_time_travel_version() {
     );
 
     let log_segment =
-        LogSegment::for_snapshot(storage.as_ref(), log_root, checkpoint_metadata, Some(4)).unwrap();
+        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, checkpoint_metadata, Some(4))
+            .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -696,7 +706,8 @@ fn build_snapshot_with_start_checkpoint_and_time_travel_version() {
     );
 
     let log_segment =
-        LogSegment::for_snapshot(storage.as_ref(), log_root, checkpoint_metadata, Some(4)).unwrap();
+        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, checkpoint_metadata, Some(4))
+            .unwrap();
 
     assert_eq!(log_segment.checkpoint_parts[0].version, 3);
     assert_eq!(log_segment.ascending_commit_files.len(), 1);
@@ -1352,7 +1363,8 @@ fn create_segment_for(
         ));
     }
     let (storage, log_root) = build_log_with_paths_and_checkpoint(&paths, None);
-    LogSegment::for_snapshot(storage.as_ref(), log_root.clone(), None, version_to_load).unwrap()
+    LogSegment::for_snapshot_impl(storage.as_ref(), log_root.clone(), None, version_to_load)
+        .unwrap()
 }
 
 #[test]

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -410,6 +410,7 @@ mod tests {
     use crate::engine::default::filesystem::ObjectStoreStorageHandler;
     use crate::engine::default::DefaultEngine;
     use crate::engine::sync::SyncEngine;
+    use crate::last_checkpoint_hint::LastCheckpointHint;
     use crate::path::ParsedLogPath;
     use crate::utils::test_utils::string_array_to_engine_data;
     use test_utils::{add_commit, delta_path_for_version};

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -7,7 +7,6 @@ use crate::actions::domain_metadata::domain_metadata_configuration;
 use crate::actions::set_transaction::SetTransactionScanner;
 use crate::actions::{Metadata, Protocol, INTERNAL_DOMAIN_PREFIX};
 use crate::checkpoint::CheckpointWriter;
-use crate::last_checkpoint_hint::LastCheckpointHint;
 use crate::listed_log_files::ListedLogFiles;
 use crate::log_segment::LogSegment;
 use crate::scan::ScanBuilder;
@@ -92,11 +91,7 @@ impl Snapshot {
     ) -> DeltaResult<Self> {
         let storage = engine.storage_handler();
         let log_root = table_root.join("_delta_log/")?;
-
-        let checkpoint_hint = LastCheckpointHint::try_read(storage.as_ref(), &log_root)?;
-
-        let log_segment =
-            LogSegment::for_snapshot(storage.as_ref(), log_root, checkpoint_hint, version)?;
+        let log_segment = LogSegment::for_snapshot(storage.as_ref(), log_root, version)?;
 
         // try_new_from_log_segment will ensure the protocol is supported
         Self::try_new_from_log_segment(table_root, log_segment, engine)
@@ -415,7 +410,6 @@ mod tests {
     use crate::engine::default::filesystem::ObjectStoreStorageHandler;
     use crate::engine::default::DefaultEngine;
     use crate::engine::sync::SyncEngine;
-    use crate::last_checkpoint_hint::LastCheckpointHint;
     use crate::path::ParsedLogPath;
     use crate::utils::test_utils::string_array_to_engine_data;
     use test_utils::{add_commit, delta_path_for_version};


### PR DESCRIPTION
## What changes are proposed in this pull request?
Push down reading `LastCheckpointHint` into (one of) `LogSegment` constructor. This is needed so that the LogSegment constructor can 'decide' if it needs to list - in the presence of a `log_tail` in CCv2 we may not need to list at all. Furthermore, even in the absence of CCv2, this should change is probably still useful in that the LogSegment::for_snapshot is called after the only place we read the `LastCheckpointHint` = reasonable to directly embed it. Note that to keep our existing unit tests i've refactored the `for_snapshot_impl` with the same signature as the old one.

For reviewers: i've split into two commits, first does material change, second updates callsites.

## How was this change tested?
refactor: existing