### PR TITLE
feat!: Expression evaluators take ExpressionRef as input

### DIFF
--- a/ffi/src/engine_funcs.rs
+++ b/ffi/src/engine_funcs.rs
@@ -4,7 +4,8 @@ use std::sync::Arc;
 
 use delta_kernel::schema::{DataType, Schema, SchemaRef};
 use delta_kernel::{
-    DeltaResult, EngineData, Error, Expression, ExpressionEvaluator, FileDataReadResultIterator,
+    DeltaResult, EngineData, Error, Expression, ExpressionEvaluator, ExpressionRef,
+    FileDataReadResultIterator,
 };
 use delta_kernel_ffi_macros::handle_descriptor;
 use tracing::debug;
@@ -159,21 +160,21 @@ pub unsafe extern "C" fn new_expression_evaluator(
     let engine = unsafe { engine.clone_as_arc() };
     let input_schema = unsafe { input_schema.clone_as_arc() };
     let output_type: DataType = output_type.as_ref().clone().into();
+    let expression = expression.clone().into();
     new_expression_evaluator_impl(engine, input_schema, expression, output_type)
 }
 
 fn new_expression_evaluator_impl(
     extern_engine: Arc<dyn ExternEngine>,
     input_schema: SchemaRef,
-    expression: &Expression,
+    expression: ExpressionRef,
     output_type: DataType,
 ) -> Handle<SharedExpressionEvaluator> {
     let engine = extern_engine.engine();
-    let evaluator = engine.evaluation_handler().new_expression_evaluator(
-        input_schema,
-        expression.clone(),
-        output_type,
-    );
+    let evaluator =
+        engine
+            .evaluation_handler()
+            .new_expression_evaluator(input_schema, expression, output_type);
     evaluator.into()
 }
 

--- a/ffi/src/engine_funcs.rs
+++ b/ffi/src/engine_funcs.rs
@@ -160,7 +160,7 @@ pub unsafe extern "C" fn new_expression_evaluator(
     let engine = unsafe { engine.clone_as_arc() };
     let input_schema = unsafe { input_schema.clone_as_arc() };
     let output_type: DataType = output_type.as_ref().clone().into();
-    let expression = expression.clone().into();
+    let expression = Arc::new(expression.clone());
     new_expression_evaluator_impl(engine, input_schema, expression, output_type)
 }
 

--- a/kernel/examples/read-table-multi-threaded/src/main.rs
+++ b/kernel/examples/read-table-multi-threaded/src/main.rs
@@ -227,7 +227,7 @@ fn do_work(
                 read_result,
                 &scan_state.physical_schema,
                 &scan_state.logical_schema,
-                &scan_file.transform,
+                scan_file.transform.clone(),
             )
             .unwrap();
 

--- a/kernel/src/actions/visitors.rs
+++ b/kernel/src/actions/visitors.rs
@@ -1079,13 +1079,15 @@ mod tests {
 
     fn transform_batch(batch: Box<dyn EngineData>) -> Box<dyn EngineData> {
         let engine = SyncEngine::new();
+        let expression =
+            Expression::Struct(vec![Arc::new(Expression::Struct(vec![column_expr_ref!(
+                "commitInfo.inCommitTimestamp"
+            )]))]);
         engine
             .evaluation_handler()
             .new_expression_evaluator(
                 get_log_schema().clone(),
-                Expression::Struct(vec![Arc::new(Expression::Struct(vec![column_expr_ref!(
-                    "commitInfo.inCommitTimestamp"
-                )]))]),
+                expression.into(),
                 InCommitTimestampVisitor::schema().into(),
             )
             .evaluate(batch.as_ref())

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -412,7 +412,7 @@ pub trait EvaluationHandler: AsAny {
     fn new_expression_evaluator(
         &self,
         input_schema: SchemaRef,
-        expression: Expression,
+        expression: ExpressionRef,
         output_type: DataType,
     ) -> Arc<dyn ExpressionEvaluator>;
 
@@ -430,7 +430,7 @@ pub trait EvaluationHandler: AsAny {
     fn new_predicate_evaluator(
         &self,
         input_schema: SchemaRef,
-        predicate: Predicate,
+        predicate: PredicateRef,
     ) -> Arc<dyn PredicateEvaluator>;
 
     /// Create a single-row all-null-value [`EngineData`] with the schema specified by
@@ -462,7 +462,7 @@ trait EvaluationHandlerExtension: EvaluationHandler {
         schema_transform.transform_struct(schema.as_ref());
         let row_expr = schema_transform.try_into_expr()?;
 
-        let eval = self.new_expression_evaluator(null_row_schema, row_expr, schema.into());
+        let eval = self.new_expression_evaluator(null_row_schema, row_expr.into(), schema.into());
         eval.evaluate(null_row.as_ref())
     }
 }

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -143,7 +143,7 @@ impl DataSkippingFilter {
 
         let skipping_evaluator = engine.evaluation_handler().new_predicate_evaluator(
             stats_schema.clone(),
-            as_sql_data_skipping_predicate(&predicate)?.into(),
+            Arc::new(as_sql_data_skipping_predicate(&predicate)?),
         );
 
         let filter_evaluator = engine

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -9,7 +9,8 @@ use crate::actions::visitors::SelectionVectorVisitor;
 use crate::error::DeltaResult;
 use crate::expressions::{
     column_expr, joined_column_expr, BinaryPredicateOp, ColumnName, Expression as Expr,
-    JunctionPredicateOp, OpaquePredicateOpRef, Predicate as Pred, PredicateRef, Scalar,
+    ExpressionRef, JunctionPredicateOp, OpaquePredicateOpRef, Predicate as Pred, PredicateRef,
+    Scalar,
 };
 use crate::kernel_predicates::{
     DataSkippingPredicateEvaluator, KernelPredicateEvaluator, KernelPredicateEvaluatorDefaults,
@@ -67,9 +68,10 @@ impl DataSkippingFilter {
         engine: &dyn Engine,
         physical_predicate: Option<(PredicateRef, SchemaRef)>,
     ) -> Option<Self> {
-        static STATS_EXPR: LazyLock<Expr> = LazyLock::new(|| column_expr!("add.stats"));
-        static FILTER_PRED: LazyLock<Pred> =
-            LazyLock::new(|| column_expr!("output").distinct(Expr::literal(false)));
+        static STATS_EXPR: LazyLock<ExpressionRef> =
+            LazyLock::new(|| Arc::new(column_expr!("add.stats")));
+        static FILTER_PRED: LazyLock<PredicateRef> =
+            LazyLock::new(|| Arc::new(column_expr!("output").distinct(Expr::literal(false))));
 
         let (predicate, referenced_schema) = physical_predicate?;
         debug!("Creating a data skipping filter for {:#?}", predicate);
@@ -141,7 +143,7 @@ impl DataSkippingFilter {
 
         let skipping_evaluator = engine.evaluation_handler().new_predicate_evaluator(
             stats_schema.clone(),
-            as_sql_data_skipping_predicate(&predicate)?,
+            as_sql_data_skipping_predicate(&predicate)?.into(),
         );
 
         let filter_evaluator = engine

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -343,32 +343,40 @@ pub(crate) static SCAN_ROW_SCHEMA: LazyLock<Arc<StructType>> = LazyLock::new(|| 
 pub(crate) static SCAN_ROW_DATATYPE: LazyLock<DataType> =
     LazyLock::new(|| SCAN_ROW_SCHEMA.clone().into());
 
-fn get_add_transform_expr() -> Expression {
+fn get_add_transform_expr() -> ExpressionRef {
     use crate::expressions::column_expr_ref;
-    Expression::Struct(vec![
-        column_expr_ref!("add.path"),
-        column_expr_ref!("add.size"),
-        column_expr_ref!("add.modificationTime"),
-        column_expr_ref!("add.stats"),
-        column_expr_ref!("add.deletionVector"),
-        Arc::new(Expression::Struct(vec![column_expr_ref!(
-            "add.partitionValues"
-        )])),
-    ])
+    static EXPR: LazyLock<ExpressionRef> = LazyLock::new(|| {
+        Arc::new(Expression::Struct(vec![
+            column_expr_ref!("add.path"),
+            column_expr_ref!("add.size"),
+            column_expr_ref!("add.modificationTime"),
+            column_expr_ref!("add.stats"),
+            column_expr_ref!("add.deletionVector"),
+            Arc::new(Expression::Struct(vec![column_expr_ref!(
+                "add.partitionValues"
+            )])),
+        ]))
+    });
+    EXPR.clone()
 }
 
 // TODO: remove once `scan_metadata_from` is pub.
 #[allow(unused)]
-pub(crate) fn get_scan_metadata_transform_expr() -> Expression {
+pub(crate) fn get_scan_metadata_transform_expr() -> ExpressionRef {
     use crate::expressions::column_expr_ref;
-    Expression::Struct(vec![Arc::new(Expression::Struct(vec![
-        column_expr_ref!("path"),
-        column_expr_ref!("fileConstantValues.partitionValues"),
-        column_expr_ref!("size"),
-        column_expr_ref!("modificationTime"),
-        column_expr_ref!("stats"),
-        column_expr_ref!("deletionVector"),
-    ]))])
+    static EXPR: LazyLock<ExpressionRef> = LazyLock::new(|| {
+        Arc::new(Expression::Struct(vec![Arc::new(Expression::Struct(
+            vec![
+                column_expr_ref!("path"),
+                column_expr_ref!("fileConstantValues.partitionValues"),
+                column_expr_ref!("size"),
+                column_expr_ref!("modificationTime"),
+                column_expr_ref!("stats"),
+                column_expr_ref!("deletionVector"),
+            ],
+        ))]))
+    });
+    EXPR.clone()
 }
 
 impl LogReplayProcessor for ScanLogReplayProcessor {

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -788,7 +788,7 @@ impl Scan {
                         read_result,
                         self.physical_schema(),
                         self.logical_schema(),
-                        &scan_file.transform,
+                        scan_file.transform.clone(),
                     );
                     let len = logical.as_ref().map_or(0, |res| res.len());
                     // need to split the dv_mask. what's left in dv_mask covers this result, and rest

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -778,8 +778,7 @@ impl Scan {
                     None,
                 )?;
 
-                // Arc clones
-                let engine = engine.clone();
+                let engine = engine.clone(); // Arc clone
                 Ok(read_result_iter.map(move |read_result| -> DeltaResult<_> {
                     let read_result = read_result?;
                     // transform the physical data into the correct logical form
@@ -788,7 +787,7 @@ impl Scan {
                         read_result,
                         self.physical_schema(),
                         self.logical_schema(),
-                        scan_file.transform.clone(),
+                        scan_file.transform.clone(), // Arc clone
                     );
                     let len = logical.as_ref().map_or(0, |res| res.len());
                     // need to split the dv_mask. what's left in dv_mask covers this result, and rest

--- a/kernel/src/scan/state.rs
+++ b/kernel/src/scan/state.rs
@@ -98,15 +98,15 @@ pub fn transform_to_logical(
     physical_data: Box<dyn EngineData>,
     physical_schema: &SchemaRef,
     logical_schema: &Schema,
-    transform: &Option<ExpressionRef>,
+    transform: Option<ExpressionRef>,
 ) -> DeltaResult<Box<dyn EngineData>> {
     match transform {
-        Some(ref transform) => engine
+        Some(transform) => engine
             .evaluation_handler()
             .new_expression_evaluator(
                 physical_schema.clone(),
-                transform.as_ref().clone(), // TODO: Maybe eval should take a ref
-                logical_schema.clone().into(),
+                transform,
+                logical_schema.clone().into(), // TODO: expensive deep clone!
             )
             .evaluate(physical_data.as_ref()),
         None => Ok(physical_data),

--- a/kernel/src/table_changes/log_replay.rs
+++ b/kernel/src/table_changes/log_replay.rs
@@ -241,7 +241,7 @@ impl LogReplayScanner {
             .map_err(|_| Error::generic("Failed to convert commit version to i64"))?;
         let evaluator = engine.evaluation_handler().new_expression_evaluator(
             get_log_add_schema().clone(),
-            cdf_scan_row_expression(timestamp, commit_version).into(),
+            Arc::new(cdf_scan_row_expression(timestamp, commit_version)),
             cdf_scan_row_schema().into(),
         );
 

--- a/kernel/src/table_changes/log_replay.rs
+++ b/kernel/src/table_changes/log_replay.rs
@@ -241,7 +241,7 @@ impl LogReplayScanner {
             .map_err(|_| Error::generic("Failed to convert commit version to i64"))?;
         let evaluator = engine.evaluation_handler().new_expression_evaluator(
             get_log_add_schema().clone(),
-            cdf_scan_row_expression(timestamp, commit_version),
+            cdf_scan_row_expression(timestamp, commit_version).into(),
             cdf_scan_row_schema().into(),
         );
 

--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -292,7 +292,7 @@ fn read_scan_file(
     let physical_schema = scan_file_physical_schema(&scan_file, physical_schema.as_ref());
     let phys_to_logical_eval = engine.evaluation_handler().new_expression_evaluator(
         physical_schema.clone(),
-        physical_to_logical_expr.into(),
+        Arc::new(physical_to_logical_expr),
         logical_schema.clone().into(),
     );
     // Determine if the scan file was derived from a deletion vector pair

--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -292,7 +292,7 @@ fn read_scan_file(
     let physical_schema = scan_file_physical_schema(&scan_file, physical_schema.as_ref());
     let phys_to_logical_eval = engine.evaluation_handler().new_expression_evaluator(
         physical_schema.clone(),
-        physical_to_logical_expr,
+        physical_to_logical_expr.into(),
         logical_schema.clone().into(),
     );
     // Determine if the scan file was derived from a deletion vector pair

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -228,7 +228,7 @@ impl Transaction {
         WriteContext::new(
             target_dir.clone(),
             snapshot_schema,
-            logical_to_physical.into(),
+            Arc::new(logical_to_physical),
         )
     }
 
@@ -260,7 +260,7 @@ fn generate_adds<'a>(
         )]);
         let adds_evaluator = evaluation_handler.new_expression_evaluator(
             add_files_schema.clone(),
-            adds_expr.into(),
+            Arc::new(adds_expr),
             log_schema.clone().into(),
         );
         adds_evaluator.evaluate(add_files_batch)

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -9,7 +9,9 @@ use crate::error::Error;
 use crate::path::ParsedLogPath;
 use crate::schema::{MapType, SchemaRef, StructField, StructType};
 use crate::snapshot::Snapshot;
-use crate::{DataType, DeltaResult, Engine, EngineData, Expression, IntoEngineData, Version};
+use crate::{
+    DataType, DeltaResult, Engine, EngineData, Expression, ExpressionRef, IntoEngineData, Version,
+};
 
 use url::Url;
 
@@ -223,7 +225,11 @@ impl Transaction {
         let target_dir = self.read_snapshot.table_root();
         let snapshot_schema = self.read_snapshot.schema();
         let logical_to_physical = self.generate_logical_to_physical();
-        WriteContext::new(target_dir.clone(), snapshot_schema, logical_to_physical)
+        WriteContext::new(
+            target_dir.clone(),
+            snapshot_schema,
+            logical_to_physical.into(),
+        )
     }
 
     /// Add files to include in this transaction. This API generally enables the engine to
@@ -254,7 +260,7 @@ fn generate_adds<'a>(
         )]);
         let adds_evaluator = evaluation_handler.new_expression_evaluator(
             add_files_schema.clone(),
-            adds_expr,
+            adds_expr.into(),
             log_schema.clone().into(),
         );
         adds_evaluator.evaluate(add_files_batch)
@@ -268,11 +274,11 @@ fn generate_adds<'a>(
 pub struct WriteContext {
     target_dir: Url,
     schema: SchemaRef,
-    logical_to_physical: Expression,
+    logical_to_physical: ExpressionRef,
 }
 
 impl WriteContext {
-    fn new(target_dir: Url, schema: SchemaRef, logical_to_physical: Expression) -> Self {
+    fn new(target_dir: Url, schema: SchemaRef, logical_to_physical: ExpressionRef) -> Self {
         WriteContext {
             target_dir,
             schema,
@@ -288,8 +294,8 @@ impl WriteContext {
         &self.schema
     }
 
-    pub fn logical_to_physical(&self) -> &Expression {
-        &self.logical_to_physical
+    pub fn logical_to_physical(&self) -> ExpressionRef {
+        self.logical_to_physical.clone()
     }
 }
 

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -393,7 +393,7 @@ fn read_with_scan_metadata(
                 read_result,
                 scan.physical_schema(),
                 scan.logical_schema(),
-                &scan_file.transform,
+                scan_file.transform.clone(),
             )
             .unwrap();
             let record_batch = to_arrow(logical).unwrap();


### PR DESCRIPTION
## What changes are proposed in this pull request?

Today, `EvaluationHandler::new_expression_evaluator` takes an owned `Expression` (`Predicate`) as input. 
This requires making expensive deep clones even when the caller already has an `ExpressionRef`.

(exactly the same analysis applies to `EvaluationHandler::new_predicate_evaluator`, `Predicate`, and `PredicateRef`)

Change the method signatures to take Arc instead. For single-use expressions, the additional heap allocation cost is minimal (measurable with only the tiniest expressions), and for frequently-used expressions it saves a lot of copying. 

NOTE: 
* The FFI `new_expression_evaluator` still takes an `&Expression`; we should consider whether it should take an `ExpressionRef` as well. 
   * PRO: would allow expression reuse across the FFI boundary as well
   * CON: requires introducing a new `SharedExpressionHandle` type

### This PR affects the following public APIs

Signature changes for `EvaluationHandler::new_expression_evaluator` and `EvaluationHandler::new_predicate_evaluator`, to take Arc instead of owned expression/predicate.

Signature change for `scan::state::transform_to_logical`, to take owned `Option<ExpressionRef>` instead of a borrowed reference.

Signature change for `transaction::WriteContext::logical_to_physical` to return an Arc instead of a borrowed reference.

## How was this change tested?

Simple refactor, compilation suffices.