### PR TITLE
fix: make ListedLogFiles::try_new internal-api (again)

### DIFF
--- a/kernel/src/listed_log_files.rs
+++ b/kernel/src/listed_log_files.rs
@@ -118,6 +118,7 @@ impl ListedLogFiles {
     // Note: for now we expose the constructor as pub(crate) to allow for use in testing. Ideally,
     // we should explore entirely encapsulating ListedLogFiles within LogSegment - currently
     // LogSegment constructor requires a ListedLogFiles.
+    #[internal_api]
     pub(crate) fn try_new(
         ascending_commit_files: Vec<ParsedLogPath>,
         ascending_compaction_files: Vec<ParsedLogPath>,


### PR DESCRIPTION
## What changes are proposed in this pull request?
prior PR made it private. this reverts back to being `internal-api`


## How was this change tested?
visibility. compilation suffices.