### PR TITLE
feat!: Add FFI support for Expr::Transform

### DIFF
--- a/ffi/examples/visit-expression/expression.h
+++ b/ffi/examples/visit-expression/expression.h
@@ -560,12 +560,14 @@ void free_expression_item(ExpressionItem ref) {
       struct TransformExpression* transform = ref.ref;
       free_expression_list(transform->input_path);
       free_expression_list(transform->ops);
+      free(transform);
       break;
     }
     case TransformOp: {
       struct TransformOp* op = ref.ref;
       free(op->field_name);
       free_expression_list(op->expr);
+      free(op);
       break;
     }
     case OpaqueExpression: {

--- a/ffi/examples/visit-expression/expression_print.h
+++ b/ffi/examples/visit-expression/expression_print.h
@@ -88,25 +88,21 @@ void print_tree_helper(ExpressionItem ref, int depth) {
       struct TransformExpression* transform = ref.ref;
       printf("Transform\n");
       print_expression_item_list(transform->input_path, depth + 1);
-      print_expression_item_list(transform-> ops, depth + 1);
+      print_expression_item_list(transform->field_transforms, depth + 1);
       break;
     }
-    case TransformOp: {
-      struct TransformOp* transform_op = ref.ref;
-      if (transform_op->is_insert) {
-        if (transform_op->field_name) {
-          printf("Insert(%s)\n", transform_op->field_name);
-        } else {
-          printf("Prepend\n");
-        }
+    case FieldTransform: {
+      struct FieldTransform* field_transform = ref.ref;
+      if (!field_transform->field_name) {
+        printf("Prepend\n");
+      } else if (!field_transform->exprs.len) {
+        printf("Drop(%s)\n", field_transform->field_name);
+      } else if (field_transform->is_replace) {
+        printf("Replace(%s)\n", field_transform->field_name);
       } else {
-        if (transform_op->expr.len > 0) {
-          printf("Replace(%s)\n", transform_op->field_name);
-        } else {
-          printf("Drop(%s)\n", transform_op->field_name);
-        }
+        printf("Insert(%s)\n", field_transform->field_name);
       }
-      print_expression_item_list(transform_op->expr, depth + 1);
+      print_expression_item_list(field_transform->exprs, depth + 1);
       break;
     }
     case OpaqueExpression: {

--- a/ffi/examples/visit-expression/expression_print.h
+++ b/ffi/examples/visit-expression/expression_print.h
@@ -84,6 +84,31 @@ void print_tree_helper(ExpressionItem ref, int depth) {
       print_expression_item_list(var->exprs, depth + 1);
       break;
     }
+    case Transform: {
+      struct TransformExpression* transform = ref.ref;
+      printf("Transform\n");
+      print_expression_item_list(transform->input_path, depth + 1);
+      print_expression_item_list(transform-> ops, depth + 1);
+      break;
+    }
+    case TransformOp: {
+      struct TransformOp* transform_op = ref.ref;
+      if (transform_op->is_insert) {
+        if (transform_op->field_name) {
+          printf("Insert(%s)\n", transform_op->field_name);
+        } else {
+          printf("Prepend\n");
+        }
+      } else {
+        if (transform_op->expr.len > 0) {
+          printf("Replace(%s)\n", transform_op->field_name);
+        } else {
+          printf("Drop(%s)\n", transform_op->field_name);
+        }
+      }
+      print_expression_item_list(transform_op->expr, depth + 1);
+      break;
+    }
     case OpaqueExpression: {
       struct OpaqueExpression* opaque = ref.ref;
       visit_kernel_opaque_expression_op_name(opaque->op, "OpaqueExpression", print_opaque_op_name);

--- a/ffi/src/test_ffi.rs
+++ b/ffi/src/test_ffi.rs
@@ -5,9 +5,9 @@ use std::sync::Arc;
 use crate::expressions::{SharedExpression, SharedPredicate};
 use crate::handle::Handle;
 use delta_kernel::expressions::{
-    column_expr, column_pred, ArrayData, BinaryExpressionOp, BinaryPredicateOp, Expression as Expr,
-    MapData, OpaqueExpressionOp, OpaquePredicateOp, Predicate as Pred, Scalar,
-    ScalarExpressionEvaluator, StructData,
+    column_expr, column_name, column_pred, ArrayData, BinaryExpressionOp, BinaryPredicateOp,
+    Expression as Expr, MapData, OpaqueExpressionOp, OpaquePredicateOp, Predicate as Pred, Scalar,
+    ScalarExpressionEvaluator, StructData, Transform,
 };
 use delta_kernel::kernel_predicates::{
     DirectDataSkippingPredicateEvaluator, DirectPredicateEvaluator,
@@ -108,6 +108,23 @@ pub unsafe extern "C" fn get_testing_kernel_expression() -> Handle<SharedExpress
     )
     .unwrap();
 
+    let nested_transform = Transform::new()
+        .with_dropped_field("gone")
+        .with_replaced_field("stub", Expr::literal("replaced").into())
+        .with_inserted_field(Some("x".to_string()), Expr::literal(true).into())
+        .with_inserted_field(Some("y".to_string()), Expr::literal(false).into());
+    let top_level_transform = Transform::new()
+        .with_input_path(column_name!("foo.bar.baz"))
+        .with_dropped_field("dropme")
+        .with_replaced_field("replaceme", Expr::literal(42).into())
+        .with_inserted_field(None, Expr::literal("prepended").into())
+        .with_inserted_field(Some("a".to_string()), Expr::literal("first").into())
+        .with_inserted_field(
+            Some("a".to_string()),
+            Expr::transform(nested_transform).into(),
+        )
+        .with_inserted_field(Some("a".to_string()), Expr::literal("third").into());
+
     let mut sub_exprs = vec![
         column_expr!("col"),
         Expr::literal(i8::MAX),
@@ -131,6 +148,7 @@ pub unsafe extern "C" fn get_testing_kernel_expression() -> Handle<SharedExpress
         Scalar::decimal((1i128 << 64) + 1, 20, 3).unwrap().into(),
         Expr::null_literal(DataType::SHORT),
         Scalar::Struct(top_level_struct).into(),
+        Expr::Transform(top_level_transform),
         Scalar::Array(array_data).into(),
         Scalar::Map(map_data).into(),
         Expr::struct_from([Expr::literal(5_i32), Expr::literal(20_i64)]),

--- a/ffi/tests/test-expression-visitor/expected.txt
+++ b/ffi/tests/test-expression-visitor/expected.txt
@@ -34,7 +34,6 @@ StructExpression
       String(prepended)
     Insert(a)
       String(first)
-    Insert(a)
       Transform
         Drop(gone)
         Replace(stub)
@@ -43,7 +42,6 @@ StructExpression
           Boolean(1)
         Insert(y)
           Boolean(0)
-    Insert(a)
       String(third)
     Drop(dropme)
     Replace(replaceme)

--- a/ffi/tests/test-expression-visitor/expected.txt
+++ b/ffi/tests/test-expression-visitor/expected.txt
@@ -28,6 +28,26 @@ StructExpression
           Array
             Short(5)
             Short(0)
+  Transform
+    Column(foo.bar.baz)
+    Prepend
+      String(prepended)
+    Insert(a)
+      String(first)
+    Insert(a)
+      Transform
+        Drop(gone)
+        Replace(stub)
+          String(replaced)
+        Insert(x)
+          Boolean(1)
+        Insert(y)
+          Boolean(0)
+    Insert(a)
+      String(third)
+    Drop(dropme)
+    Replace(replaceme)
+      Integer(42)
   Array
     Short(5)
     Short(0)

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -63,6 +63,7 @@ reqwest = { version = "0.12.23", default-features = false, optional = true }
 tokio = { version = "1.47", optional = true, features = ["rt-multi-thread"] }
 # both arrow versions below are optional and require object_store
 object_store = { version = "0.12.3", optional = true, features = ["aws", "azure", "gcp", "http"] }
+comfy-table = "=7.1.4" # TODO: Remove this once https://github.com/apache/arrow-rs/pull/8244 ships"
 
 # arrow 55
 [dependencies.arrow_55]

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -63,7 +63,6 @@ reqwest = { version = "0.12.23", default-features = false, optional = true }
 tokio = { version = "1.47", optional = true, features = ["rt-multi-thread"] }
 # both arrow versions below are optional and require object_store
 object_store = { version = "0.12.3", optional = true, features = ["aws", "azure", "gcp", "http"] }
-comfy-table = "=7.1.4" # TODO: Remove this once https://github.com/apache/arrow-rs/pull/8244 ships"
 
 # arrow 55
 [dependencies.arrow_55]


### PR DESCRIPTION
## What changes are proposed in this pull request?

A new `Expr::Transform` expression type was added, but lacked FFI support that made it impossible for external engines to use it. Which is bad, because log replay already started using expression transforms. 

Add the FFI missing support and expand the unit test to exercise it.

In order to fit the existing infrastructure, the FFI models expression transforms as three levels:
* The transform itself has two members:
   * An optional input path expression (always an `Expr::Column`, if present)
   * A list of "field transforms", where each field transform represents the changes made to an individual input field
* A field transform has three members:
   * An optional input field name (string), which is missing for an insert that prepends before the first input field
   * An optional list of expressions to insert as new fields, which is missing/empty if the input field is being dropped
   * A boolean flag indicating whether the inserted fields replace the input field or merely insert after it

That way, the transform references a variable-length list of field transform "expressions" and each field transform "expression" describes the changes associated with one input field.

### This PR affects the following public APIs

Added two new members to the FFI `EngineExpressionVisitor` struct -- `visit_transform_expression` and `visit_field_transform`, which also changes the ordering of existing fields.

## How was this change tested?

The FFI expression visitor test was expanded to create transforms with all types of changes.