### PR TITLE
chore: Add test for empty commits and clean up test error types

### DIFF
--- a/kernel/tests/write.rs
+++ b/kernel/tests/write.rs
@@ -348,10 +348,10 @@ async fn test_no_add_actions() -> Result<(), Box<dyn std::error::Error>> {
     // setup tracing
     let _ = tracing_subscriber::fmt::try_init();
     // create a simple table: one int column named 'number'
-    let schema = Arc::new(StructType::new(vec![StructField::nullable(
+    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
         "number",
         DataType::INTEGER,
-    )]));
+    )])?);
 
     for (table_url, engine, store, table_name) in
         setup_test_tables(schema.clone(), &[], None, "test_table").await?


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds a test for empty commits to our test infrastructure to verify that:
- Commits without add actions do not fail
- We do not write anything but a commit info action for such a commit

## How was this change tested?

New write integration test.