### PR TITLE
fix!: make ColumnType pub(crate)

### DIFF
--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -310,7 +310,7 @@ impl ScanResult {
 /// `Partition` we store an index into the logical schema for this query since later we need the
 /// data type as well to materialize the partition column.
 #[derive(PartialEq, Debug)]
-pub enum ColumnType {
+pub(crate) enum ColumnType {
     // A column, selected from the data, as is
     Selected(String),
     // A partition column that needs to be added back in


### PR DESCRIPTION
## What changes are proposed in this pull request?
make `ColumnType` `pub(crate)` instead of `pub` - must have accidentally slipped through


### This PR affects the following public APIs
Makes `ColumnType` private now.

## How was this change tested?
pure visibility change. existing tests suffice.