### PR TITLE
refactor: retention calculation into a new trait

### DIFF
--- a/kernel/src/action_reconciliation/mod.rs
+++ b/kernel/src/action_reconciliation/mod.rs
@@ -7,8 +7,8 @@
 //! This module provides utilities for calculating retention timestamps used during action reconciliation:
 //!
 //! - **Deleted File Retention**: Determines when `remove` actions can be excluded from checkpoints
-//! - **Transaction Retention**: Calculates when expired transactions can be cleaned up
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+//! - **Transaction Retention**: Calculates when expired app ids can be cleaned up
+use std::time::Duration;
 
 use crate::table_properties::TableProperties;
 use crate::{DeltaResult, Error};
@@ -47,9 +47,7 @@ pub(crate) trait RetentionCalculator {
 
         deleted_file_retention_timestamp_with_time(
             retention_duration,
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .map_err(|e| Error::generic(format!("Failed to calculate system time: {e}")))?,
+            crate::utils::current_time_duration()?,
         )
     }
 
@@ -108,12 +106,7 @@ pub(crate) fn calculate_transaction_expiration_timestamp(
     table_properties
         .set_transaction_retention_duration
         .map(|duration| -> DeltaResult<i64> {
-            let now = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .map_err(|e| Error::generic(format!("Failed to get current time: {e}")))?;
-
-            let now_ms = i64::try_from(now.as_millis())
-                .map_err(|_| Error::generic("Current timestamp exceeds i64 millisecond range"))?;
+            let now_ms = crate::utils::current_time_ms()?;
 
             let expiration_ms = i64::try_from(duration.as_millis())
                 .map_err(|_| Error::generic("Retention duration exceeds i64 millisecond range"))?;
@@ -196,10 +189,7 @@ mod tests {
         // The result should be current time minus 1 hour (approximately)
         // We can't test exact value due to timing, but we can verify it's reasonable
         let timestamp = result.unwrap();
-        let now_ms = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as i64;
+        let now_ms = crate::utils::current_time_ms().unwrap();
         let one_hour_ms = 3600 * 1000;
 
         // Should be within a reasonable range (allowing for test execution time)
@@ -249,10 +239,7 @@ mod tests {
         let result = calculator.deleted_file_retention_timestamp()?;
 
         // Should be current time minus 7 days (approximately)
-        let now_ms = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as i64;
+        let now_ms = crate::utils::current_time_ms().unwrap();
         let seven_days_ms = 7 * 24 * 60 * 60 * 1000;
 
         assert!(result < now_ms);
@@ -291,10 +278,7 @@ mod tests {
         assert!(result.is_some());
 
         let timestamp = result.unwrap();
-        let now_ms = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as i64;
+        let now_ms = crate::utils::current_time_ms().unwrap();
         let two_hours_ms = 2 * 60 * 60 * 1000;
 
         assert!(timestamp < now_ms);

--- a/kernel/src/action_reconciliation/mod.rs
+++ b/kernel/src/action_reconciliation/mod.rs
@@ -1,3 +1,13 @@
+//! # This module implements APIs related to action reconciliation.
+//! Please see the [Delta Lake Protocol](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#action-reconciliation)
+//! for more details about action reconciliation.
+//!
+//! ## Retention and Cleanup
+//!
+//! This module provides utilities for calculating retention timestamps used during action reconciliation:
+//!
+//! - **Deleted File Retention**: Determines when `remove` actions can be excluded from checkpoints
+//! - **Transaction Retention**: Calculates when expired transactions can be cleaned up
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::table_properties::TableProperties;

--- a/kernel/src/action_reconciliation/mod.rs
+++ b/kernel/src/action_reconciliation/mod.rs
@@ -1,4 +1,5 @@
-//! # This module implements APIs related to action reconciliation.
+//! # Action Reconciliation
+//! This module implements APIs related to action reconciliation.
 //! Please see the [Delta Lake Protocol](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#action-reconciliation)
 //! for more details about action reconciliation.
 //!
@@ -41,7 +42,7 @@ pub(crate) trait RetentionCalculator {
     /// The cutoff timestamp in milliseconds since epoch, matching the remove action's
     /// `deletion_timestamp` field format for comparison.
     ///
-    /// # Note: The default retention period is 7 days, matching delta-spark's behavior.
+    /// Note: The default retention period is 7 days, matching delta-spark's behavior.
     fn deleted_file_retention_timestamp(&self) -> DeltaResult<i64> {
         let retention_duration = self.table_properties().deleted_file_retention_duration;
 

--- a/kernel/src/action_reconciliation/mod.rs
+++ b/kernel/src/action_reconciliation/mod.rs
@@ -176,8 +176,10 @@ mod tests {
         assert_eq!(result, None);
 
         // Test with set_transaction_retention_duration
-        let mut properties = TableProperties::default();
-        properties.set_transaction_retention_duration = Some(Duration::from_secs(3600)); // 1 hour
+        let properties = TableProperties {
+            set_transaction_retention_duration: Some(Duration::from_secs(3600)), // 1 hour
+            ..Default::default()
+        };
         let result = calculate_transaction_expiration_timestamp(&properties)?;
         assert!(result.is_some());
 
@@ -200,8 +202,10 @@ mod tests {
     #[test]
     fn test_calculate_transaction_expiration_timestamp_edge_cases() {
         // Test with very large retention duration that would overflow
-        let mut properties = TableProperties::default();
-        properties.set_transaction_retention_duration = Some(Duration::from_secs(u64::MAX));
+        let properties = TableProperties {
+            set_transaction_retention_duration: Some(Duration::from_secs(u64::MAX)),
+            ..Default::default()
+        };
         let result = calculate_transaction_expiration_timestamp(&properties);
         assert!(result.is_err());
         assert!(result
@@ -245,8 +249,10 @@ mod tests {
         assert!(result > now_ms - seven_days_ms - 1000); // Allow a small 1 second buffer
 
         // Test with custom retention
-        let mut properties = TableProperties::default();
-        properties.deleted_file_retention_duration = Some(Duration::from_secs(1800)); // 30 minutes
+        let properties = TableProperties {
+            deleted_file_retention_duration: Some(Duration::from_secs(1800)), // 30 minutes
+            ..Default::default()
+        };
         let calculator = MockRetentionCalculator::new(properties);
         let result = calculator.deleted_file_retention_timestamp()?;
 
@@ -266,8 +272,10 @@ mod tests {
         assert_eq!(result, None);
 
         // Test with transaction retention
-        let mut properties = TableProperties::default();
-        properties.set_transaction_retention_duration = Some(Duration::from_secs(7200)); // 2 hours
+        let properties = TableProperties {
+            set_transaction_retention_duration: Some(Duration::from_secs(7200)), // 2 hours
+            ..Default::default()
+        };
         let calculator = MockRetentionCalculator::new(properties);
         let result = calculator.get_transaction_expiration_timestamp()?;
         assert!(result.is_some());

--- a/kernel/src/action_reconciliation/mod.rs
+++ b/kernel/src/action_reconciliation/mod.rs
@@ -1,0 +1,138 @@
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use crate::snapshot::Snapshot;
+use crate::utils::calculate_transaction_expiration_timestamp;
+use crate::{DeltaResult, Error};
+
+const SECONDS_PER_MINUTE: u64 = 60;
+const MINUTES_PER_HOUR: u64 = 60;
+const HOURS_PER_DAY: u64 = 24;
+
+/// The default retention period for deleted files in seconds.
+/// This is set to 7 days, which is the default in delta-spark.
+pub(crate) const DEFAULT_RETENTION_SECS: u64 =
+    7 * HOURS_PER_DAY * MINUTES_PER_HOUR * SECONDS_PER_MINUTE;
+
+/// Provides common functionality for calculating file retention timestamps
+/// and transaction expiration timestamps.
+pub(crate) trait RetentionCalculator {
+    /// Get the snapshot reference for accessing table properties
+    fn snapshot(&self) -> &Snapshot;
+
+    /// Determines the minimum timestamp before which deleted files
+    /// are eligible for permanent removal during VACUUM operations. It is used
+    /// during checkpointing to decide whether to include `remove` actions.
+    ///
+    /// If a deleted file's timestamp is older than this threshold (based on the
+    /// table's `deleted_file_retention_duration`), the corresponding `remove` action
+    /// is included in the checkpoint, allowing VACUUM operations to later identify
+    /// and clean up those files.
+    ///
+    /// # Returns:
+    /// The cutoff timestamp in milliseconds since epoch, matching the remove action's
+    /// `deletion_timestamp` field format for comparison.
+    ///
+    /// # Note: The default retention period is 7 days, matching delta-spark's behavior.
+    fn deleted_file_retention_timestamp(&self) -> DeltaResult<i64> {
+        let retention_duration = self
+            .snapshot()
+            .table_properties()
+            .deleted_file_retention_duration;
+
+        deleted_file_retention_timestamp_with_time(
+            retention_duration,
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map_err(|e| Error::generic(format!("Failed to calculate system time: {e}")))?,
+        )
+    }
+
+    /// Calculate the transaction expiration timestamp
+    ///
+    /// Calculates the timestamp threshold for transaction expiration based on
+    /// the table's `set_transaction_retention_duration` property. Transactions that expired
+    /// before this timestamp can be cleaned up.
+    ///
+    /// # Returns
+    /// The timestamp in milliseconds since epoch before which transactions are considered expired,
+    /// or `None` if transaction retention is not configured.
+    ///
+    /// # Errors
+    /// Returns an error if the current system time cannot be obtained or if the retention
+    /// duration exceeds the maximum representable value for i64.
+    fn get_transaction_expiration_timestamp(&self) -> DeltaResult<Option<i64>> {
+        calculate_transaction_expiration_timestamp(self.snapshot().table_properties())
+    }
+}
+
+/// Calculates the timestamp threshold for deleted file retention based on the provided duration.
+/// This is factored out to allow testing with an injectable time and duration parameter.
+///
+/// # Parameters
+/// - `retention_duration`: The duration to retain deleted files. The table property
+///   `deleted_file_retention_duration` is passed here. If `None`, defaults to 7 days.
+/// - `now_duration`: The current time as a [`Duration`]. This allows for testing with
+///   a specific time instead of using `SystemTime::now()`.
+///
+/// # Returns: The timestamp in milliseconds since epoch
+pub(crate) fn deleted_file_retention_timestamp_with_time(
+    retention_duration: Option<Duration>,
+    now_duration: Duration,
+) -> DeltaResult<i64> {
+    // Use provided retention duration or default (7 days)
+    let retention_duration =
+        retention_duration.unwrap_or_else(|| Duration::from_secs(DEFAULT_RETENTION_SECS));
+
+    // Convert to milliseconds for remove action deletion_timestamp comparison
+    let now_ms = i64::try_from(now_duration.as_millis())
+        .map_err(|_| Error::checkpoint_write("Current timestamp exceeds i64 millisecond range"))?;
+
+    let retention_ms = i64::try_from(retention_duration.as_millis())
+        .map_err(|_| Error::checkpoint_write("Retention duration exceeds i64 millisecond range"))?;
+
+    // Simple subtraction - will produce negative values if retention > now
+    Ok(now_ms - retention_ms)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn test_deleted_file_retention_timestamp_with_time() -> DeltaResult<()> {
+        // Test with default retention (7 days)
+        let reference_time = Duration::from_secs(1_000_000_000); // Some reference time
+        let result = deleted_file_retention_timestamp_with_time(None, reference_time)?;
+        let expected = 1_000_000_000_000 - (7 * 24 * 60 * 60 * 1000); // 7 days in milliseconds
+        assert_eq!(result, expected);
+
+        // Test with custom retention (1 day)
+        let retention = Duration::from_secs(24 * 60 * 60); // 1 day
+        let result = deleted_file_retention_timestamp_with_time(Some(retention), reference_time)?;
+        let expected = 1_000_000_000_000 - (24 * 60 * 60 * 1000); // 1 day in milliseconds
+        assert_eq!(result, expected);
+
+        // Test with zero retention
+        let retention = Duration::from_secs(0);
+        let result = deleted_file_retention_timestamp_with_time(Some(retention), reference_time)?;
+        let expected = 1_000_000_000_000; // Same as reference time
+        assert_eq!(result, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_deleted_file_retention_timestamp_edge_cases() {
+        // Test with very large retention duration
+        let reference_time = Duration::from_secs(1_000_000_000);
+        let large_retention = Duration::from_secs(u64::MAX);
+        let result =
+            deleted_file_retention_timestamp_with_time(Some(large_retention), reference_time);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Retention duration exceeds i64 millisecond range"));
+    }
+}

--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -83,8 +83,8 @@
 // - TODO(#837): Multi-file V2 checkpoints are not supported yet. The API is designed to be extensible for future
 //   multi-file support, but the current implementation only supports single-file checkpoints.
 use std::sync::{Arc, LazyLock};
-use std::time::Duration;
 
+use crate::action_reconciliation::RetentionCalculator;
 use crate::actions::{
     Add, Metadata, Protocol, Remove, SetTransaction, Sidecar, ADD_NAME, CHECKPOINT_METADATA_NAME,
     METADATA_NAME, PROTOCOL_NAME, REMOVE_NAME, SET_TRANSACTION_NAME, SIDECAR_NAME,
@@ -96,7 +96,6 @@ use crate::log_replay::LogReplayProcessor;
 use crate::path::ParsedLogPath;
 use crate::schema::{DataType, SchemaRef, StructField, StructType, ToSchema as _};
 use crate::snapshot::Snapshot;
-use crate::utils::{calculate_transaction_expiration_timestamp, current_time_duration};
 use crate::{DeltaResult, Engine, EngineData, Error, EvaluationHandlerExtension, FileMeta};
 use log_replay::{CheckpointBatch, CheckpointLogReplayProcessor};
 
@@ -105,13 +104,6 @@ use url::Url;
 mod log_replay;
 #[cfg(test)]
 mod tests;
-
-const SECONDS_PER_MINUTE: u64 = 60;
-const MINUTES_PER_HOUR: u64 = 60;
-const HOURS_PER_DAY: u64 = 24;
-/// The default retention period for deleted files in seconds.
-/// This is set to 7 days, which is the default in delta-spark.
-const DEFAULT_RETENTION_SECS: u64 = 7 * HOURS_PER_DAY * MINUTES_PER_HOUR * SECONDS_PER_MINUTE;
 
 /// Schema of the `_last_checkpoint` file
 /// We cannot use `LastCheckpointInfo::to_schema()` as it would include the 'checkpoint_schema'
@@ -207,6 +199,12 @@ pub struct CheckpointWriter {
     version: i64,
 }
 
+impl RetentionCalculator for CheckpointWriter {
+    fn table_properties(&self) -> &crate::table_properties::TableProperties {
+        self.snapshot.table_properties()
+    }
+}
+
 impl CheckpointWriter {
     /// Creates a new [`CheckpointWriter`] for the given snapshot.
     pub(crate) fn try_new(snapshot: Arc<Snapshot>) -> DeltaResult<Self> {
@@ -219,10 +217,6 @@ impl CheckpointWriter {
         })?;
 
         Ok(Self { snapshot, version })
-    }
-
-    fn get_transaction_expiration_timestamp(&self) -> DeltaResult<Option<i64>> {
-        calculate_transaction_expiration_timestamp(self.snapshot.table_properties())
     }
     /// Returns the URL where the checkpoint file should be written.
     ///
@@ -382,58 +376,6 @@ impl CheckpointWriter {
             add_actions_count: 0,
         })
     }
-
-    /// This function determines the minimum timestamp before which deleted files
-    /// are eligible for permanent removal during VACUUM operations. It is used
-    /// during checkpointing to decide whether to include `remove` actions.
-    ///
-    /// If a deleted file's timestamp is older than this threshold (based on the
-    /// table's `deleted_file_retention_duration`), the corresponding `remove` action
-    /// is included in the checkpoint, allowing VACUUM operations to later identify
-    /// and clean up those files.
-    ///
-    /// # Returns:
-    /// The cutoff timestamp in milliseconds since epoch, matching the remove action's
-    /// `deletion_timestamp` field format for comparison.
-    ///
-    /// # Note: The default retention period is 7 days, matching delta-spark's behavior.
-    fn deleted_file_retention_timestamp(&self) -> DeltaResult<i64> {
-        let retention_duration = self
-            .snapshot
-            .table_properties()
-            .deleted_file_retention_duration;
-
-        deleted_file_retention_timestamp_with_time(retention_duration, current_time_duration()?)
-    }
-}
-
-/// Calculates the timestamp threshold for deleted file retention based on the provided duration.
-/// This is factored out to allow testing with an injectable time and duration parameter.
-///
-/// # Parameters
-/// - `retention_duration`: The duration to retain deleted files. The table property
-///   `deleted_file_retention_duration` is passed here. If `None`, defaults to 7 days.
-/// - `now_duration`: The current time as a [`Duration`]. This allows for testing with
-///   a specific time instead of using `SystemTime::now()`.
-///
-/// # Returns: The timestamp in milliseconds since epoch
-fn deleted_file_retention_timestamp_with_time(
-    retention_duration: Option<Duration>,
-    now_duration: Duration,
-) -> DeltaResult<i64> {
-    // Use provided retention duration or default (7 days)
-    let retention_duration =
-        retention_duration.unwrap_or_else(|| Duration::from_secs(DEFAULT_RETENTION_SECS));
-
-    // Convert to milliseconds for remove action deletion_timestamp comparison
-    let now_ms = i64::try_from(now_duration.as_millis())
-        .map_err(|_| Error::checkpoint_write("Current timestamp exceeds i64 millisecond range"))?;
-
-    let retention_ms = i64::try_from(retention_duration.as_millis())
-        .map_err(|_| Error::checkpoint_write("Retention duration exceeds i64 millisecond range"))?;
-
-    // Simple subtraction - will produce negative values if retention > now
-    Ok(now_ms - retention_ms)
 }
 
 /// Creates the data for the _last_checkpoint file containing checkpoint

--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -201,11 +201,7 @@ pub struct CheckpointWriter {
 }
 
 impl RetentionCalculator for CheckpointWriter {
-<<<<<<< HEAD
-    fn table_properties(&self) -> &crate::table_properties::TableProperties {
-=======
     fn table_properties(&self) -> &TableProperties {
->>>>>>> 1127ce9 (Incorporate PR feedback from Zach)
         self.snapshot.table_properties()
     }
 }

--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -96,6 +96,7 @@ use crate::log_replay::LogReplayProcessor;
 use crate::path::ParsedLogPath;
 use crate::schema::{DataType, SchemaRef, StructField, StructType, ToSchema as _};
 use crate::snapshot::Snapshot;
+use crate::table_properties::TableProperties;
 use crate::{DeltaResult, Engine, EngineData, Error, EvaluationHandlerExtension, FileMeta};
 use log_replay::{CheckpointBatch, CheckpointLogReplayProcessor};
 
@@ -200,7 +201,11 @@ pub struct CheckpointWriter {
 }
 
 impl RetentionCalculator for CheckpointWriter {
+<<<<<<< HEAD
     fn table_properties(&self) -> &crate::table_properties::TableProperties {
+=======
+    fn table_properties(&self) -> &TableProperties {
+>>>>>>> 1127ce9 (Incorporate PR feedback from Zach)
         self.snapshot.table_properties()
     }
 }

--- a/kernel/src/checkpoint/tests.rs
+++ b/kernel/src/checkpoint/tests.rs
@@ -1,10 +1,12 @@
 use std::{sync::Arc, time::Duration};
 
-use super::DEFAULT_RETENTION_SECS;
+use crate::action_reconciliation::{
+    deleted_file_retention_timestamp_with_time, DEFAULT_RETENTION_SECS,
+};
 use crate::actions::{Add, Metadata, Protocol, Remove};
 use crate::arrow::array::{ArrayRef, StructArray};
 use crate::arrow::datatypes::{DataType, Schema};
-use crate::checkpoint::{create_last_checkpoint_data, deleted_file_retention_timestamp_with_time};
+use crate::checkpoint::create_last_checkpoint_data;
 use crate::engine::arrow_data::ArrowEngineData;
 use crate::engine::default::{executor::tokio::TokioBackgroundExecutor, DefaultEngine};
 use crate::utils::test_utils::Action;

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -84,6 +84,7 @@ use url::Url;
 
 use self::schema::{DataType, SchemaRef};
 
+mod action_reconciliation;
 pub mod actions;
 pub mod checkpoint;
 pub mod engine_data;

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -3,6 +3,7 @@
 
 use std::sync::Arc;
 
+use crate::action_reconciliation::calculate_transaction_expiration_timestamp;
 use crate::actions::domain_metadata::domain_metadata_configuration;
 use crate::actions::set_transaction::SetTransactionScanner;
 use crate::actions::{Metadata, Protocol, INTERNAL_DOMAIN_PREFIX};
@@ -15,7 +16,6 @@ use crate::table_configuration::TableConfiguration;
 use crate::table_features::ColumnMappingMode;
 use crate::table_properties::TableProperties;
 use crate::transaction::Transaction;
-use crate::utils::calculate_transaction_expiration_timestamp;
 use crate::{DeltaResult, Engine, Error, Version};
 use delta_kernel_derive::internal_api;
 

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -1,12 +1,9 @@
 //! Various utility functions/macros used throughout the kernel
+use crate::{DeltaResult, Error};
+use delta_kernel_derive::internal_api;
 use std::borrow::Cow;
 use std::ops::Deref;
 use std::path::PathBuf;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
-
-use crate::table_properties::TableProperties;
-use crate::{DeltaResult, Error};
-use delta_kernel_derive::internal_api;
 
 use url::Url;
 
@@ -96,37 +93,6 @@ fn resolve_uri_type(table_uri: impl AsRef<str>) -> DeltaResult<UriType> {
     }
 }
 
-/// Calculates the transaction expiration timestamp based on table properties.
-/// Returns None if set_transaction_retention_duration is not set.
-pub(crate) fn calculate_transaction_expiration_timestamp(
-    table_properties: &TableProperties,
-) -> DeltaResult<Option<i64>> {
-    table_properties
-        .set_transaction_retention_duration
-        .map(|duration| -> DeltaResult<i64> {
-            let now_ms = current_time_ms()?;
-
-            let expiration_ms = i64::try_from(duration.as_millis())
-                .map_err(|_| Error::generic("Retention duration exceeds i64 millisecond range"))?;
-
-            Ok(now_ms - expiration_ms)
-        })
-        .transpose()
-}
-
-/// Returns the current time as a Duration since Unix epoch.
-pub(crate) fn current_time_duration() -> DeltaResult<Duration> {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|e| Error::generic(format!("System time before Unix epoch: {}", e)))
-}
-
-/// Returns the current time in milliseconds since Unix epoch.
-pub(crate) fn current_time_ms() -> DeltaResult<i64> {
-    let duration = current_time_duration()?;
-    i64::try_from(duration.as_millis())
-        .map_err(|_| Error::generic("Current timestamp exceeds i64 millisecond range"))
-}
 // Extension trait for Cow<'_, T>
 pub(crate) trait CowExt<T: ToOwned + ?Sized> {
     /// The owned type that corresopnds to Self

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -1,12 +1,13 @@
 //! Various utility functions/macros used throughout the kernel
-use crate::{DeltaResult, Error};
-use delta_kernel_derive::internal_api;
 use std::borrow::Cow;
 use std::ops::Deref;
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use url::Url;
+
+use delta_kernel_derive::internal_api;
+use crate::{DeltaResult, Error};
 
 /// convenient way to return an error if a condition isn't true
 macro_rules! require {

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -6,8 +6,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use url::Url;
 
-use delta_kernel_derive::internal_api;
 use crate::{DeltaResult, Error};
+use delta_kernel_derive::internal_api;
 
 /// convenient way to return an error if a condition isn't true
 macro_rules! require {

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -4,6 +4,7 @@ use delta_kernel_derive::internal_api;
 use std::borrow::Cow;
 use std::ops::Deref;
 use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use url::Url;
 
@@ -91,6 +92,20 @@ fn resolve_uri_type(table_uri: impl AsRef<str>) -> DeltaResult<UriType> {
     } else {
         Ok(UriType::LocalPath(table_uri.deref().into()))
     }
+}
+
+/// Returns the current time as a Duration since Unix epoch.
+pub(crate) fn current_time_duration() -> DeltaResult<Duration> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| Error::generic(format!("System time before Unix epoch: {}", e)))
+}
+
+/// Returns the current time in milliseconds since Unix epoch.
+pub(crate) fn current_time_ms() -> DeltaResult<i64> {
+    let duration = current_time_duration()?;
+    i64::try_from(duration.as_millis())
+        .map_err(|_| Error::generic("Current timestamp exceeds i64 millisecond range"))
 }
 
 // Extension trait for Cow<'_, T>


### PR DESCRIPTION
This is a pure refactoring change to:

- Extract retention calculation logic into new module with a RetentionCalculator trait
- Update CheckpointWriter to use RetentionCalculator trait

The trait will be reused in the upcoming log compaction writer.

## How was this change tested?

New tests, ran existing tests