### PR TITLE
feat!: Introduce row index metadata column

### DIFF
--- a/kernel/src/engine/sync/parquet.rs
+++ b/kernel/src/engine/sync/parquet.rs
@@ -5,7 +5,10 @@ use crate::parquet::arrow::arrow_reader::{ArrowReaderMetadata, ParquetRecordBatc
 
 use super::read_files;
 use crate::engine::arrow_data::ArrowEngineData;
-use crate::engine::arrow_utils::{fixup_parquet_read, generate_mask, get_requested_indices};
+use crate::engine::arrow_utils::{
+    fixup_parquet_read, generate_mask, get_requested_indices, ordering_needs_row_indexes,
+    RowIndexBuilder,
+};
 use crate::engine::parquet_row_group_skipping::ParquetRowGroupSkipping;
 use crate::schema::SchemaRef;
 use crate::{DeltaResult, FileDataReadResultIterator, FileMeta, ParquetHandler, PredicateRef};
@@ -25,11 +28,19 @@ fn try_create_from_parquet(
     if let Some(mask) = generate_mask(&schema, parquet_schema, builder.parquet_schema(), &indices) {
         builder = builder.with_projection(mask);
     }
+
+    // Only create RowIndexBuilder if row indexes are actually needed
+    let mut row_indexes = ordering_needs_row_indexes(&requested_ordering)
+        .then(|| RowIndexBuilder::new(builder.metadata().row_groups()));
+
+    // Filter row groups and row indexes if a predicate is provided
     if let Some(predicate) = predicate {
-        builder = builder.with_row_group_filter(predicate.as_ref());
+        builder = builder.with_row_group_filter(predicate.as_ref(), row_indexes.as_mut());
     }
+
+    let mut row_indexes = row_indexes.map(|rb| rb.into_iter());
     let stream = builder.build()?;
-    Ok(stream.map(move |rbr| fixup_parquet_read(rbr?, &requested_ordering)))
+    Ok(stream.map(move |rbr| fixup_parquet_read(rbr?, &requested_ordering, row_indexes.as_mut())))
 }
 
 impl ParquetHandler for SyncParquetHandler {


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR follows up on #1266 and adds support for reading the row index metadata column to the default engine. The implementation directly follows the approach proposed in #920 and slightly modifies it to match the new metadata column API.

Quoting from #920 

> Deletion vectors (and row tracking, eventually) rely on accurate file-level row indexes. But they're not implemented in the kernel's default parquet reader. That means we must rely on the position of rows in data batches returned by each read, and we cannot apply optimizations such as stats-based row group skipping (see https://github.com/delta-io/delta-kernel-rs/issues/860).
>
> Add row index support to the default Parquet reader, in the form of a new RowIndex variant of ReorderIndexTransform. [...] The default parquet reader recognizes (the RowIndex metadata) column and injects a transform to generate row indexes (with appropriate adjustments for any row group skipping that might occur).
>
> Fixes https://github.com/delta-io/delta-kernel-rs/issues/919
>
> NOTE: If/when arrow-rs parquet reader gains native support for row indexes, e.g. https://github.com/apache/arrow-rs/pull/7307, we should switch to using that. Our solution here is not robust to advanced parquet reader features like page-level skipping. row-level predicate pushdown, etc.

### This PR affects the following public APIs

None - the breaking changes were introduced in #1266.

## How was this change tested?

New UT.