### PR TITLE
feat!: new StructType constructors

### DIFF
--- a/derive-macros/src/lib.rs
+++ b/derive-macros/src/lib.rs
@@ -51,7 +51,7 @@ pub fn derive_to_schema(input: proc_macro::TokenStream) -> proc_macro::TokenStre
                 use delta_kernel::schema::derive_macro_utils::{
                     ToDataType as _, GetStructField as _, GetNullableContainerStructField as _,
                 };
-                delta_kernel::schema::StructType::new([
+                delta_kernel::schema::StructType::new_unchecked([
                     #schema_fields
                 ])
             }

--- a/ffi/src/engine_funcs.rs
+++ b/ffi/src/engine_funcs.rs
@@ -225,11 +225,9 @@ mod tests {
     #[test]
     fn test_new_expression_evaluator() {
         let engine = get_default_engine("memory:///doesntmatter/foo");
-        let in_schema = Arc::new(StructType::new(vec![StructField::new(
-            "a",
-            DataType::LONG,
-            true,
-        )]));
+        let in_schema = Arc::new(
+            StructType::try_new(vec![StructField::new("a", DataType::LONG, true)]).unwrap(),
+        );
         let expr = Expression::literal(1);
         let output_type: Handle<SharedSchema> = in_schema.clone().into();
         let in_schema_handle: Handle<SharedSchema> = in_schema.into();

--- a/ffi/src/test_ffi.rs
+++ b/ffi/src/test_ffi.rs
@@ -97,7 +97,7 @@ pub unsafe extern "C" fn get_testing_kernel_expression() -> Handle<SharedExpress
     ];
     let nested_values = vec![Scalar::Integer(500), Scalar::Array(array_data.clone())];
     let nested_struct = StructData::try_new(nested_fields.clone(), nested_values).unwrap();
-    let nested_struct_type = StructType::new(nested_fields);
+    let nested_struct_type = StructType::try_new(nested_fields).unwrap();
 
     let top_level_struct = StructData::try_new(
         vec![StructField::nullable(

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -229,10 +229,10 @@ mod tests {
     #[tokio::test]
     #[cfg_attr(miri, ignore)] // FIXME: re-enable miri (can't call foreign function `linkat` on OS `linux`)
     async fn test_basic_append() -> Result<(), Box<dyn std::error::Error>> {
-        let schema = Arc::new(StructType::new(vec![
+        let schema = Arc::new(StructType::try_new(vec![
             StructField::nullable("number", DataType::INTEGER),
             StructField::nullable("string", DataType::STRING),
-        ]));
+        ])?);
 
         // Create a temporary local directory for use during this test
         let tmp_test_dir = tempdir()?;

--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -11,7 +11,7 @@ fn create_kernel_schema() -> delta_kernel::schema::Schema {
     use delta_kernel::schema::{DataType, StructField};
     let field_a = StructField::not_null("a", DataType::LONG);
     let field_b = StructField::not_null("b", DataType::BOOLEAN);
-    delta_kernel::schema::Schema::new(vec![field_a, field_b])
+    delta_kernel::schema::Schema::try_new(vec![field_a, field_b]).unwrap()
 }
 
 fn main() {

--- a/kernel/examples/common/src/lib.rs
+++ b/kernel/examples/common/src/lib.rs
@@ -81,7 +81,7 @@ pub fn get_scan(snapshot: SnapshotRef, args: &ScanArgs) -> DeltaResult<Option<Sc
                         "Table has no such column: {col}"
                     )))
             });
-            Schema::try_new(selected_fields).map(Arc::new)
+            Schema::try_from_results(selected_fields).map(Arc::new)
         })
         .transpose()?;
     Ok(Some(

--- a/kernel/examples/write-table/src/main.rs
+++ b/kernel/examples/write-table/src/main.rs
@@ -171,7 +171,7 @@ fn parse_schema(schema_str: &str) -> DeltaResult<SchemaRef> {
         })
         .collect::<DeltaResult<Vec<_>>>()?;
 
-    Ok(Arc::new(StructType::new(fields)))
+    Ok(Arc::new(StructType::try_new(fields)?))
 }
 
 /// Create a new Delta table with the given schema.

--- a/kernel/src/actions/crc.rs
+++ b/kernel/src/actions/crc.rs
@@ -157,7 +157,7 @@ mod tests {
     #[test]
     fn test_file_size_histogram_schema() {
         let schema = FileSizeHistogram::to_schema();
-        let expected = StructType::new([
+        let expected = StructType::new_unchecked([
             StructField::not_null("sortedBinBoundaries", ArrayType::new(DataType::LONG, false)),
             StructField::not_null("fileCounts", ArrayType::new(DataType::LONG, false)),
             StructField::not_null("totalBytes", ArrayType::new(DataType::LONG, false)),
@@ -168,7 +168,7 @@ mod tests {
     #[test]
     fn test_deleted_record_counts_histogram_schema() {
         let schema = DeletedRecordCountsHistogram::to_schema();
-        let expected = StructType::new([StructField::not_null(
+        let expected = StructType::new_unchecked([StructField::not_null(
             "deletedRecordCounts",
             ArrayType::new(DataType::LONG, false),
         )]);
@@ -178,7 +178,7 @@ mod tests {
     #[test]
     fn test_crc_schema() {
         let schema = Crc::to_schema();
-        let expected = StructType::new([
+        let expected = StructType::new_unchecked([
             StructField::nullable("txnId", DataType::STRING),
             StructField::not_null("tableSizeBytes", DataType::LONG),
             StructField::not_null("numFiles", DataType::LONG),

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -68,7 +68,7 @@ pub(crate) const DOMAIN_METADATA_NAME: &str = "domainMetadata";
 pub(crate) const INTERNAL_DOMAIN_PREFIX: &str = "delta.";
 
 static LOG_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    Arc::new(StructType::new([
+    Arc::new(StructType::new_unchecked([
         StructField::nullable(ADD_NAME, Add::to_schema()),
         StructField::nullable(REMOVE_NAME, Remove::to_schema()),
         StructField::nullable(METADATA_NAME, Metadata::to_schema()),
@@ -83,28 +83,28 @@ static LOG_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
 });
 
 static LOG_ADD_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    Arc::new(StructType::new([StructField::nullable(
+    Arc::new(StructType::new_unchecked([StructField::nullable(
         ADD_NAME,
         Add::to_schema(),
     )]))
 });
 
 static LOG_COMMIT_INFO_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    Arc::new(StructType::new([StructField::nullable(
+    Arc::new(StructType::new_unchecked([StructField::nullable(
         COMMIT_INFO_NAME,
         CommitInfo::to_schema(),
     )]))
 });
 
 static LOG_TXN_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    Arc::new(StructType::new([StructField::nullable(
+    Arc::new(StructType::new_unchecked([StructField::nullable(
         SET_TRANSACTION_NAME,
         SetTransaction::to_schema(),
     )]))
 });
 
 static LOG_DOMAIN_METADATA_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    Arc::new(StructType::new([StructField::nullable(
+    Arc::new(StructType::new_unchecked([StructField::nullable(
         DOMAIN_METADATA_NAME,
         DomainMetadata::to_schema(),
     )]))
@@ -137,7 +137,9 @@ pub(crate) fn get_log_domain_metadata_schema() -> &'static SchemaRef {
 /// This is useful for JSON conversion, as it allows us to wrap a dynamically maintained add action
 /// schema in a top-level "add" struct.
 pub(crate) fn as_log_add_schema(schema: SchemaRef) -> SchemaRef {
-    Arc::new(StructType::new([StructField::nullable(ADD_NAME, schema)]))
+    Arc::new(StructType::new_unchecked([StructField::nullable(
+        ADD_NAME, schema,
+    )]))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ToSchema)]
@@ -991,15 +993,15 @@ mod tests {
             .project(&[METADATA_NAME])
             .expect("Couldn't get metaData field");
 
-        let expected = Arc::new(StructType::new([StructField::nullable(
+        let expected = Arc::new(StructType::new_unchecked([StructField::nullable(
             "metaData",
-            StructType::new([
+            StructType::new_unchecked([
                 StructField::not_null("id", DataType::STRING),
                 StructField::nullable("name", DataType::STRING),
                 StructField::nullable("description", DataType::STRING),
                 StructField::not_null(
                     "format",
-                    StructType::new([
+                    StructType::new_unchecked([
                         StructField::not_null("provider", DataType::STRING),
                         StructField::not_null(
                             "options",
@@ -1025,9 +1027,9 @@ mod tests {
             .project(&[ADD_NAME])
             .expect("Couldn't get add field");
 
-        let expected = Arc::new(StructType::new([StructField::nullable(
+        let expected = Arc::new(StructType::new_unchecked([StructField::nullable(
             "add",
-            StructType::new([
+            StructType::new_unchecked([
                 StructField::not_null("path", DataType::STRING),
                 StructField::not_null(
                     "partitionValues",
@@ -1067,7 +1069,7 @@ mod tests {
     fn deletion_vector_field() -> StructField {
         StructField::nullable(
             "deletionVector",
-            DataType::struct_type([
+            DataType::struct_type_unchecked([
                 StructField::not_null("storageType", DataType::STRING),
                 StructField::not_null("pathOrInlineDv", DataType::STRING),
                 StructField::nullable("offset", DataType::INTEGER),
@@ -1082,9 +1084,9 @@ mod tests {
         let schema = get_log_schema()
             .project(&[REMOVE_NAME])
             .expect("Couldn't get remove field");
-        let expected = Arc::new(StructType::new([StructField::nullable(
+        let expected = Arc::new(StructType::new_unchecked([StructField::nullable(
             "remove",
-            StructType::new([
+            StructType::new_unchecked([
                 StructField::not_null("path", DataType::STRING),
                 StructField::nullable("deletionTimestamp", DataType::LONG),
                 StructField::not_null("dataChange", DataType::BOOLEAN),
@@ -1105,9 +1107,9 @@ mod tests {
         let schema = get_log_schema()
             .project(&[CDC_NAME])
             .expect("Couldn't get cdc field");
-        let expected = Arc::new(StructType::new([StructField::nullable(
+        let expected = Arc::new(StructType::new_unchecked([StructField::nullable(
             "cdc",
-            StructType::new([
+            StructType::new_unchecked([
                 StructField::not_null("path", DataType::STRING),
                 StructField::not_null(
                     "partitionValues",
@@ -1126,9 +1128,9 @@ mod tests {
         let schema = get_log_schema()
             .project(&[SIDECAR_NAME])
             .expect("Couldn't get sidecar field");
-        let expected = Arc::new(StructType::new([StructField::nullable(
+        let expected = Arc::new(StructType::new_unchecked([StructField::nullable(
             "sidecar",
-            StructType::new([
+            StructType::new_unchecked([
                 StructField::not_null("path", DataType::STRING),
                 StructField::not_null("sizeInBytes", DataType::LONG),
                 StructField::not_null("modificationTime", DataType::LONG),
@@ -1143,9 +1145,9 @@ mod tests {
         let schema = get_log_schema()
             .project(&[CHECKPOINT_METADATA_NAME])
             .expect("Couldn't get checkpointMetadata field");
-        let expected = Arc::new(StructType::new([StructField::nullable(
+        let expected = Arc::new(StructType::new_unchecked([StructField::nullable(
             "checkpointMetadata",
-            StructType::new([
+            StructType::new_unchecked([
                 StructField::not_null("version", DataType::LONG),
                 tags_field(),
             ]),
@@ -1159,9 +1161,9 @@ mod tests {
             .project(&["txn"])
             .expect("Couldn't get transaction field");
 
-        let expected = Arc::new(StructType::new([StructField::nullable(
+        let expected = Arc::new(StructType::new_unchecked([StructField::nullable(
             "txn",
-            StructType::new([
+            StructType::new_unchecked([
                 StructField::not_null("appId", DataType::STRING),
                 StructField::not_null("version", DataType::LONG),
                 StructField::nullable("lastUpdated", DataType::LONG),
@@ -1176,9 +1178,9 @@ mod tests {
             .project(&["commitInfo"])
             .expect("Couldn't get commitInfo field");
 
-        let expected = Arc::new(StructType::new(vec![StructField::nullable(
+        let expected = Arc::new(StructType::new_unchecked(vec![StructField::nullable(
             "commitInfo",
-            StructType::new(vec![
+            StructType::new_unchecked(vec![
                 StructField::nullable("timestamp", DataType::LONG),
                 StructField::nullable("inCommitTimestamp", DataType::LONG),
                 StructField::nullable("operation", DataType::STRING),
@@ -1199,9 +1201,9 @@ mod tests {
         let schema = get_log_schema()
             .project(&[DOMAIN_METADATA_NAME])
             .expect("Couldn't get domainMetadata field");
-        let expected = Arc::new(StructType::new([StructField::nullable(
+        let expected = Arc::new(StructType::new_unchecked([StructField::nullable(
             "domainMetadata",
-            StructType::new([
+            StructType::new_unchecked([
                 StructField::not_null("domain", DataType::STRING),
                 StructField::not_null("configuration", DataType::STRING),
                 StructField::not_null("removed", DataType::BOOLEAN),
@@ -1526,7 +1528,7 @@ mod tests {
 
     #[test]
     fn test_metadata_try_new() {
-        let schema = StructType::new([StructField::not_null("id", DataType::INTEGER)]);
+        let schema = StructType::new_unchecked([StructField::not_null("id", DataType::INTEGER)]);
         let config = HashMap::from([("key1".to_string(), "value1".to_string())]);
 
         let metadata = Metadata::try_new(
@@ -1551,7 +1553,7 @@ mod tests {
 
     #[test]
     fn test_metadata_try_new_default() {
-        let schema = StructType::new([StructField::not_null("id", DataType::INTEGER)]);
+        let schema = StructType::new_unchecked([StructField::not_null("id", DataType::INTEGER)]);
         let metadata = Metadata::try_new(None, None, schema, vec![], 0, HashMap::new()).unwrap();
 
         assert!(!metadata.id.is_empty());
@@ -1561,7 +1563,7 @@ mod tests {
 
     #[test]
     fn test_metadata_unique_ids() {
-        let schema = StructType::new([StructField::not_null("id", DataType::INTEGER)]);
+        let schema = StructType::new_unchecked([StructField::not_null("id", DataType::INTEGER)]);
         let m1 = Metadata::try_new(None, None, schema.clone(), vec![], 0, HashMap::new()).unwrap();
         let m2 = Metadata::try_new(None, None, schema, vec![], 0, HashMap::new()).unwrap();
         assert_ne!(m1.id, m2.id);
@@ -1648,7 +1650,7 @@ mod tests {
     #[test]
     fn test_metadata_into_engine_data() {
         let engine = ExprEngine::new();
-        let schema = StructType::new([StructField::not_null("id", DataType::INTEGER)]);
+        let schema = StructType::new_unchecked([StructField::not_null("id", DataType::INTEGER)]);
 
         let test_metadata = Metadata::try_new(
             Some("test".to_string()),
@@ -1699,7 +1701,7 @@ mod tests {
     #[test]
     fn test_metadata_with_log_schema() {
         let engine = ExprEngine::new();
-        let schema = StructType::new([StructField::not_null("id", DataType::INTEGER)]);
+        let schema = StructType::new_unchecked([StructField::not_null("id", DataType::INTEGER)]);
 
         let metadata = Metadata::try_new(
             Some("table".to_string()),

--- a/kernel/src/actions/visitors.rs
+++ b/kernel/src/actions/visitors.rs
@@ -630,9 +630,9 @@ impl InCommitTimestampVisitor {
     pub(crate) fn schema() -> Arc<Schema> {
         static SCHEMA: LazyLock<Arc<Schema>> = LazyLock::new(|| {
             let ict_type = StructField::new("inCommitTimestamp", DataType::LONG, true);
-            Arc::new(StructType::new(vec![StructField::new(
+            Arc::new(StructType::new_unchecked(vec![StructField::new(
                 COMMIT_INFO_NAME,
-                StructType::new([ict_type]),
+                StructType::new_unchecked([ict_type]),
                 true,
             )]))
         });

--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -113,7 +113,7 @@ mod tests;
 /// We cannot use `LastCheckpointInfo::to_schema()` as it would include the 'checkpoint_schema'
 /// field, which is only known at runtime.
 static LAST_CHECKPOINT_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    StructType::new([
+    StructType::new_unchecked([
         StructField::not_null("version", DataType::LONG),
         StructField::not_null("size", DataType::LONG),
         StructField::nullable("parts", DataType::LONG),
@@ -125,7 +125,7 @@ static LAST_CHECKPOINT_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
 
 /// Schema for extracting relevant actions from log files for checkpoint creation
 static CHECKPOINT_ACTIONS_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    Arc::new(StructType::new([
+    Arc::new(StructType::new_unchecked([
         StructField::nullable(ADD_NAME, Add::to_schema()),
         StructField::nullable(REMOVE_NAME, Remove::to_schema()),
         StructField::nullable(METADATA_NAME, Metadata::to_schema()),
@@ -139,9 +139,9 @@ static CHECKPOINT_ACTIONS_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
 // We cannot use `CheckpointMetadata::to_schema()` as it would include the 'tags' field which
 // we're not supporting yet due to the lack of map support TODO(#880).
 static CHECKPOINT_METADATA_ACTION_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    Arc::new(StructType::new([StructField::nullable(
+    Arc::new(StructType::new_unchecked([StructField::nullable(
         CHECKPOINT_METADATA_NAME,
-        DataType::struct_type([StructField::not_null("version", DataType::LONG)]),
+        DataType::struct_type_unchecked([StructField::not_null("version", DataType::LONG)]),
     )]))
 });
 

--- a/kernel/src/engine/arrow_data.rs
+++ b/kernel/src/engine/arrow_data.rs
@@ -429,7 +429,7 @@ mod tests {
         ];
 
         // Create schema for the new columns
-        let new_schema = Arc::new(StructType::new([
+        let new_schema = Arc::new(StructType::new_unchecked([
             StructField::new("age", DataType::INTEGER, true),
             StructField::new("active", DataType::BOOLEAN, false),
         ]));
@@ -487,7 +487,7 @@ mod tests {
             vec![25, 30, 35],
         )?];
 
-        let new_schema = Arc::new(StructType::new([StructField::new(
+        let new_schema = Arc::new(StructType::new_unchecked([StructField::new(
             "age",
             DataType::INTEGER,
             true,
@@ -519,7 +519,7 @@ mod tests {
             vec![Some("Alice".to_string()), Some("Bob".to_string())],
         )?];
 
-        let new_schema = Arc::new(StructType::new([
+        let new_schema = Arc::new(StructType::new_unchecked([
             StructField::new("name", DataType::STRING, true),
             StructField::new("email", DataType::STRING, true), // Extra field in schema
         ]));
@@ -552,7 +552,7 @@ mod tests {
             ArrayType::new(DataType::STRING, true),
             Vec::<Option<String>>::new(),
         )?];
-        let new_schema = Arc::new(StructType::new([StructField::new(
+        let new_schema = Arc::new(StructType::new_unchecked([StructField::new(
             "name",
             DataType::STRING,
             true,
@@ -583,7 +583,7 @@ mod tests {
 
         // Create empty schema and columns
         let new_columns = vec![];
-        let new_schema = Arc::new(StructType::new([]));
+        let new_schema = Arc::new(StructType::new_unchecked([]));
 
         let result_data = arrow_data.append_columns(new_schema, new_columns)?;
         let result_batch = extract_record_batch(result_data.as_ref())?;
@@ -620,7 +620,7 @@ mod tests {
             )?,
         ];
 
-        let new_schema = Arc::new(StructType::new([
+        let new_schema = Arc::new(StructType::new_unchecked([
             StructField::new("name", DataType::STRING, true),
             StructField::new("age", DataType::INTEGER, true),
         ]));
@@ -662,7 +662,7 @@ mod tests {
             ArrayData::try_new(ArrayType::new(DataType::BOOLEAN, false), vec![true, false])?,
         ];
 
-        let new_schema = Arc::new(StructType::new([
+        let new_schema = Arc::new(StructType::new_unchecked([
             StructField::new("big_number", DataType::LONG, false),
             StructField::new("pi", DataType::DOUBLE, true),
             StructField::new("flag", DataType::BOOLEAN, false),
@@ -709,7 +709,7 @@ mod tests {
             vec![true, false, true],
         )?];
 
-        let new_schema = Arc::new(StructType::new([StructField::new(
+        let new_schema = Arc::new(StructType::new_unchecked([StructField::new(
             "active",
             DataType::BOOLEAN,
             false,

--- a/kernel/src/engine/arrow_expression/apply_schema.rs
+++ b/kernel/src/engine/arrow_expression/apply_schema.rs
@@ -233,7 +233,7 @@ mod apply_schema_validation_tests {
     }
 
     fn create_target_schema_2_fields() -> StructType {
-        StructType::new([
+        StructType::new_unchecked([
             StructField::new("a", DataType::INTEGER, false),
             StructField::new("b", DataType::INTEGER, false),
         ])

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -649,7 +649,7 @@ mod tests {
 
         // Test 1: Empty transform (identity) - should be exactly equal to input
         let transform = Transform::new_top_level();
-        let output_schema = StructType::new(vec![
+        let output_schema = StructType::new_unchecked(vec![
             StructField::new("a", DataType::INTEGER, false),
             StructField::new("b", DataType::INTEGER, false),
             StructField::new("c", DataType::INTEGER, false),
@@ -675,7 +675,7 @@ mod tests {
         let nested_batch = create_nested_test_batch();
         let transform_nested = Transform::new_nested(["nested"]);
 
-        let nested_output_schema = StructType::new(vec![
+        let nested_output_schema = StructType::new_unchecked(vec![
             StructField::new("x", DataType::INTEGER, false),
             StructField::new("y", DataType::INTEGER, false),
         ]);
@@ -723,7 +723,7 @@ mod tests {
             .with_inserted_field(Some("c"), column_expr_ref!("a"))
             .with_inserted_field(Some("c"), Expr::literal(99).into());
 
-        let output_schema = StructType::new(vec![
+        let output_schema = StructType::new_unchecked(vec![
             StructField::new("pre1", DataType::INTEGER, false), // prepend 1
             StructField::new("pre2", DataType::INTEGER, false), // prepend 2
             StructField::new("pre3", DataType::INTEGER, false), // prepend 3 (column c)
@@ -770,7 +770,7 @@ mod tests {
         // Test 1: Simple struct relocation (copy nested struct to top level unchanged)
         let transform_copy = Transform::new_nested(["nested"]);
 
-        let copy_output_schema = StructType::new(vec![
+        let copy_output_schema = StructType::new_unchecked(vec![
             StructField::new("x", DataType::INTEGER, false),
             StructField::new("y", DataType::INTEGER, false),
         ]);
@@ -804,7 +804,7 @@ mod tests {
             .with_replaced_field("x".to_string(), Expr::literal(777).into())
             .with_inserted_field(Some("y"), Expr::literal(555).into());
 
-        let modify_output_schema = StructType::new(vec![
+        let modify_output_schema = StructType::new_unchecked(vec![
             StructField::new("x", DataType::INTEGER, false), // replaced with literal 777
             StructField::new("y", DataType::INTEGER, false), // passed through
             StructField::new("new_field", DataType::INTEGER, false), // inserted after y
@@ -842,7 +842,8 @@ mod tests {
         // Test unused replacement keys
         let transform =
             Transform::new_top_level().with_replaced_field("missing", Expr::literal(1).into());
-        let output_schema = StructType::new(vec![StructField::new("a", DataType::INTEGER, false)]);
+        let output_schema =
+            StructType::new_unchecked(vec![StructField::new("a", DataType::INTEGER, false)]);
 
         let expr = Expr::Transform(transform);
         let result = evaluate_expression(
@@ -874,7 +875,7 @@ mod tests {
         // Test column count mismatch
         let transform3 = Transform::new_top_level().with_dropped_field("a");
 
-        let wrong_output_schema = StructType::new(vec![
+        let wrong_output_schema = StructType::new_unchecked(vec![
             StructField::new("a", DataType::INTEGER, false), // expects a field that was dropped
             StructField::new("b", DataType::INTEGER, false),
             StructField::new("c", DataType::INTEGER, false),

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -158,7 +158,7 @@ fn test_literal_complex_type_array() {
         StructField::nullable("map", map_type.clone()),
         StructField::nullable("null_map", map_type.clone()),
     ];
-    let struct_type = StructType::new(struct_fields.clone());
+    let struct_type = StructType::new_unchecked(struct_fields.clone());
     let struct_value = Scalar::Struct(
         crate::expressions::StructData::try_new(
             struct_fields.clone(),
@@ -646,10 +646,10 @@ fn test_opaque() {
 #[test]
 fn test_null_row() {
     // note that we _allow_ nested nulls, since the top-level struct can be NULL
-    let schema = Arc::new(StructType::new(vec![
+    let schema = Arc::new(StructType::new_unchecked(vec![
         StructField::nullable(
             "x",
-            StructType::new([
+            StructType::new_unchecked([
                 StructField::nullable("a", KernelDataType::INTEGER),
                 StructField::not_null("b", KernelDataType::STRING),
             ]),
@@ -683,7 +683,7 @@ fn test_null_row() {
 
 #[test]
 fn test_null_row_err() {
-    let not_null_schema = Arc::new(StructType::new(vec![StructField::not_null(
+    let not_null_schema = Arc::new(StructType::new_unchecked(vec![StructField::not_null(
         "a",
         KernelDataType::STRING,
     )]));
@@ -714,7 +714,7 @@ fn test_create_one() {
         3.into(),
         Scalar::Null(KernelDataType::INTEGER),
     ];
-    let schema = Arc::new(StructType::new([
+    let schema = Arc::new(StructType::new_unchecked([
         StructField::nullable("a", KernelDataType::INTEGER),
         StructField::nullable("b", KernelDataType::STRING),
         StructField::not_null("c", KernelDataType::INTEGER),
@@ -743,9 +743,9 @@ fn test_create_one() {
 #[test]
 fn test_create_one_nested() {
     let values: &[Scalar] = &[1.into(), 2.into()];
-    let schema = Arc::new(StructType::new([StructField::not_null(
+    let schema = Arc::new(StructType::new_unchecked([StructField::not_null(
         "a",
-        KernelDataType::struct_type([
+        KernelDataType::struct_type_unchecked([
             StructField::nullable("b", KernelDataType::INTEGER),
             StructField::not_null("c", KernelDataType::INTEGER),
         ]),
@@ -781,9 +781,9 @@ fn test_create_one_nested() {
 #[test]
 fn test_create_one_nested_null() {
     let values: &[Scalar] = &[Scalar::Null(KernelDataType::INTEGER), 1.into()];
-    let schema = Arc::new(StructType::new([StructField::not_null(
+    let schema = Arc::new(StructType::new_unchecked([StructField::not_null(
         "a",
-        KernelDataType::struct_type([
+        KernelDataType::struct_type_unchecked([
             StructField::nullable("b", KernelDataType::INTEGER),
             StructField::not_null("c", KernelDataType::INTEGER),
         ]),
@@ -820,7 +820,7 @@ fn test_create_one_nested_null() {
 fn test_create_one_mismatching_scalar_types() {
     // Scalar is a LONG but schema specifies INTEGER
     let values: &[Scalar] = &[Scalar::Long(10)];
-    let schema = Arc::new(StructType::new([StructField::not_null(
+    let schema = Arc::new(StructType::new_unchecked([StructField::not_null(
         "version",
         KernelDataType::INTEGER,
     )]));
@@ -837,9 +837,9 @@ fn test_create_one_not_null_struct() {
         Scalar::Null(KernelDataType::INTEGER),
         Scalar::Null(KernelDataType::INTEGER),
     ];
-    let schema = Arc::new(StructType::new([StructField::not_null(
+    let schema = Arc::new(StructType::new_unchecked([StructField::not_null(
         "a",
-        KernelDataType::struct_type([
+        KernelDataType::struct_type_unchecked([
             StructField::not_null("b", KernelDataType::INTEGER),
             StructField::nullable("c", KernelDataType::INTEGER),
         ]),
@@ -856,7 +856,7 @@ fn test_create_one_top_level_null() {
     let values = &[Scalar::Null(KernelDataType::INTEGER)];
     let handler = ArrowEvaluationHandler;
 
-    let schema = Arc::new(StructType::new([StructField::not_null(
+    let schema = Arc::new(StructType::new_unchecked([StructField::not_null(
         "col_1",
         KernelDataType::INTEGER,
     )]));
@@ -939,7 +939,7 @@ fn test_apply_schema_column_count_mismatch() {
     ]);
 
     // Create a schema with only 2 fields (mismatch)
-    let schema = KernelDataType::Struct(Box::new(StructType::new([
+    let schema = KernelDataType::Struct(Box::new(StructType::new_unchecked([
         StructField::not_null("a", KernelDataType::INTEGER),
         StructField::not_null("b", KernelDataType::INTEGER),
     ])));

--- a/kernel/src/engine/arrow_utils.rs
+++ b/kernel/src/engine/arrow_utils.rs
@@ -387,7 +387,7 @@ fn get_indices(
                     // we just want to transparently recurse into lists, need to transform the kernel
                     // list data type into a schema
                     if let DataType::Array(array_type) = requested_field.data_type() {
-                        let requested_schema = StructType::new([StructField::new(
+                        let requested_schema = StructType::new_unchecked([StructField::new(
                             list_field.name().clone(), // so we find it in the inner call
                             array_type.element_type.clone(),
                             array_type.contains_null,
@@ -1111,7 +1111,7 @@ mod tests {
     #[test]
     fn simple_mask_indices() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new([
+            let requested_schema = StructType::new_unchecked([
                 StructField::not_null(logical_name(0), DataType::INTEGER)
                     .with_metadata(column_mapping_metadata(0)),
                 StructField::nullable(logical_name(1), DataType::STRING)
@@ -1188,7 +1188,7 @@ mod tests {
             ArrowField::new("v", ArrowDataType::Int16, true)
         }
         // Top level variant
-        let requested_schema = Arc::new(StructType::new([StructField::nullable(
+        let requested_schema = Arc::new(StructType::new_unchecked([StructField::nullable(
             "v",
             DataType::unshredded_variant(),
         )]));
@@ -1214,9 +1214,9 @@ mod tests {
             Err(e) if e.to_string().contains("The default engine does not support shredded reads")));
 
         // Struct of Variant
-        let requested_schema = Arc::new(StructType::new([StructField::nullable(
+        let requested_schema = Arc::new(StructType::new_unchecked([StructField::nullable(
             "struct_v",
-            StructType::new([StructField::nullable("v", DataType::unshredded_variant())]),
+            StructType::new_unchecked([StructField::nullable("v", DataType::unshredded_variant())]),
         )]));
         let unshredded_parquet_schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
             "struct_v",
@@ -1235,7 +1235,7 @@ mod tests {
         assert!(matches!(result_shredded,
             Err(e) if e.to_string().contains("The default engine does not support shredded reads")));
         // Array of Variant
-        let requested_schema = Arc::new(StructType::new([StructField::nullable(
+        let requested_schema = Arc::new(StructType::new_unchecked([StructField::nullable(
             "array_v",
             ArrayType::new(DataType::unshredded_variant(), true),
         )]));
@@ -1257,7 +1257,7 @@ mod tests {
             Err(e) if e.to_string().contains("The default engine does not support shredded reads")));
 
         // Map of Variant
-        let requested_schema = Arc::new(StructType::new([StructField::nullable(
+        let requested_schema = Arc::new(StructType::new_unchecked([StructField::nullable(
             "map_v",
             MapType::new(DataType::STRING, DataType::unshredded_variant(), true),
         )]));
@@ -1288,7 +1288,7 @@ mod tests {
     #[test]
     fn ensure_data_types_fails_correctly() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new([
+            let requested_schema = StructType::new_unchecked([
                 StructField::not_null(logical_name(0), DataType::INTEGER)
                     .with_metadata(column_mapping_metadata(0)),
                 StructField::nullable(logical_name(1), DataType::INTEGER)
@@ -1308,7 +1308,7 @@ mod tests {
                 "Invalid argument error: Incorrect datatype. Expected integer, got Utf8",
             );
 
-            let requested_schema = StructType::new([
+            let requested_schema = StructType::new_unchecked([
                 StructField::not_null(logical_name(0), DataType::INTEGER)
                     .with_metadata(column_mapping_metadata(0)),
                 StructField::nullable(logical_name(1), DataType::STRING)
@@ -1331,7 +1331,7 @@ mod tests {
     #[test]
     fn mask_with_map() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new([StructField::not_null(
+            let requested_schema = StructType::new_unchecked([StructField::not_null(
                 logical_name(0),
                 MapType::new(DataType::INTEGER, DataType::STRING, false),
             )
@@ -1361,7 +1361,7 @@ mod tests {
     #[test]
     fn simple_reorder_indices() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new([
+            let requested_schema = StructType::new_unchecked([
                 StructField::not_null(logical_name(0), DataType::INTEGER)
                     .with_metadata(column_mapping_metadata(0)),
                 StructField::nullable(logical_name(1), DataType::STRING)
@@ -1395,7 +1395,7 @@ mod tests {
     #[test]
     fn simple_nullable_field_missing() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new([
+            let requested_schema = StructType::new_unchecked([
                 StructField::not_null(logical_name(0), DataType::INTEGER)
                     .with_metadata(column_mapping_metadata(0)),
                 StructField::nullable(logical_name(1), DataType::STRING)
@@ -1436,7 +1436,7 @@ mod tests {
 
     #[test]
     fn get_requested_indices_by_id_only() {
-        let requested_schema = StructType::new([
+        let requested_schema = StructType::new_unchecked([
             StructField::not_null("i_logical", DataType::INTEGER)
                 .with_metadata(kernel_fid_and_name(1, "i_physical")),
             StructField::nullable("s_logical", DataType::STRING)
@@ -1474,7 +1474,7 @@ mod tests {
 
     #[test]
     fn get_requested_indices_by_id_falls_back_to_name() {
-        let requested_schema = StructType::new([
+        let requested_schema = StructType::new_unchecked([
             StructField::not_null("i_logical", DataType::INTEGER)
                 .with_metadata(kernel_fid_and_name(1, "i_physical")),
             StructField::nullable("s_logical", DataType::STRING)
@@ -1536,12 +1536,12 @@ mod tests {
     #[test]
     fn nested_indices() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new([
+            let requested_schema = StructType::new_unchecked([
                 StructField::not_null(logical_name(1), DataType::INTEGER)
                     .with_metadata(column_mapping_metadata(1)),
                 StructField::not_null(
                     logical_name(3),
-                    StructType::new([
+                    StructType::new_unchecked([
                         StructField::not_null(logical_name(4), DataType::INTEGER)
                             .with_metadata(column_mapping_metadata(4)),
                         StructField::not_null(logical_name(5), DataType::STRING)
@@ -1573,10 +1573,10 @@ mod tests {
     #[test]
     fn nested_indices_reorder() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new([
+            let requested_schema = StructType::new_unchecked([
                 StructField::not_null(
                     logical_name(3),
-                    StructType::new([
+                    StructType::new_unchecked([
                         StructField::not_null(logical_name(5), DataType::STRING)
                             .with_metadata(column_mapping_metadata(5)),
                         StructField::not_null(logical_name(4), DataType::INTEGER)
@@ -1611,13 +1611,16 @@ mod tests {
     #[test]
     fn nested_indices_mask_inner() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new([
+            let requested_schema = StructType::new_unchecked([
                 StructField::not_null(logical_name(1), DataType::INTEGER)
                     .with_metadata(column_mapping_metadata(1)),
                 StructField::not_null(
                     logical_name(3),
-                    StructType::new([StructField::not_null(logical_name(4), DataType::INTEGER)
-                        .with_metadata(column_mapping_metadata(4))]),
+                    StructType::new_unchecked([StructField::not_null(
+                        logical_name(4),
+                        DataType::INTEGER,
+                    )
+                    .with_metadata(column_mapping_metadata(4))]),
                 )
                 .with_metadata(column_mapping_metadata(3)),
                 StructField::not_null(logical_name(2), DataType::INTEGER)
@@ -1642,7 +1645,7 @@ mod tests {
     #[test]
     fn simple_list_mask() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new([
+            let requested_schema = StructType::new_unchecked([
                 StructField::not_null(logical_name(1), DataType::INTEGER)
                     .with_metadata(column_mapping_metadata(1)),
                 StructField::not_null(logical_name(2), ArrayType::new(DataType::INTEGER, false))
@@ -1684,7 +1687,7 @@ mod tests {
     #[test]
     fn list_skip_earlier_element() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new([StructField::not_null(
+            let requested_schema = StructType::new_unchecked([StructField::not_null(
                 logical_name(1),
                 ArrayType::new(DataType::INTEGER, false),
             )
@@ -1716,13 +1719,13 @@ mod tests {
     #[test]
     fn nested_indices_list() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new([
+            let requested_schema = StructType::new_unchecked([
                 StructField::not_null(logical_name(0), DataType::INTEGER)
                     .with_metadata(column_mapping_metadata(0)),
                 StructField::not_null(
                     logical_name(1),
                     ArrayType::new(
-                        StructType::new([
+                        StructType::new_unchecked([
                             StructField::not_null(logical_name(3), DataType::INTEGER)
                                 .with_metadata(column_mapping_metadata(3)),
                             StructField::not_null(logical_name(4), DataType::STRING)
@@ -1781,7 +1784,7 @@ mod tests {
     #[test]
     fn nested_indices_unselected_list() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new([
+            let requested_schema = StructType::new_unchecked([
                 StructField::not_null(logical_name(1), DataType::INTEGER)
                     .with_metadata(column_mapping_metadata(1)),
                 StructField::not_null(logical_name(3), DataType::INTEGER)
@@ -1825,13 +1828,13 @@ mod tests {
     #[test]
     fn nested_indices_list_mask_inner() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new([
+            let requested_schema = StructType::new_unchecked([
                 StructField::not_null(logical_name(1), DataType::INTEGER)
                     .with_metadata(column_mapping_metadata(1)),
                 StructField::not_null(
                     logical_name(2),
                     ArrayType::new(
-                        StructType::new([StructField::not_null(
+                        StructType::new_unchecked([StructField::not_null(
                             logical_name(4),
                             DataType::INTEGER,
                         )
@@ -1886,13 +1889,13 @@ mod tests {
     #[test]
     fn nested_indices_list_mask_inner_reorder() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new([
+            let requested_schema = StructType::new_unchecked([
                 StructField::not_null(logical_name(1), DataType::INTEGER)
                     .with_metadata(column_mapping_metadata(1)),
                 StructField::not_null(
                     logical_name(2),
                     ArrayType::new(
-                        StructType::new([
+                        StructType::new_unchecked([
                             StructField::not_null(logical_name(6), DataType::STRING)
                                 .with_metadata(column_mapping_metadata(6)),
                             StructField::not_null(logical_name(5), DataType::INTEGER)
@@ -1953,12 +1956,12 @@ mod tests {
     #[test]
     fn skipped_struct() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new([
+            let requested_schema = StructType::new_unchecked([
                 StructField::not_null(logical_name(1), DataType::INTEGER)
                     .with_metadata(column_mapping_metadata(1)),
                 StructField::not_null(
                     logical_name(2),
-                    StructType::new([
+                    StructType::new_unchecked([
                         StructField::not_null(logical_name(4), DataType::INTEGER)
                             .with_metadata(column_mapping_metadata(4)),
                         StructField::not_null(logical_name(5), DataType::STRING)
@@ -2023,16 +2026,16 @@ mod tests {
 
     #[test]
     fn reorder_map_with_structs() {
-        let requested_schema = Arc::new(StructType::new([
+        let requested_schema = Arc::new(StructType::new_unchecked([
             StructField::not_null("i", DataType::INTEGER),
             StructField::not_null(
                 "map",
                 MapType::new(
-                    StructType::new([
+                    StructType::new_unchecked([
                         StructField::not_null("k1", DataType::STRING),
                         StructField::not_null("k2", DataType::STRING),
                     ]),
-                    StructType::new([
+                    StructType::new_unchecked([
                         StructField::not_null("v2", DataType::STRING),
                         StructField::not_null("v1", DataType::STRING),
                     ]),
@@ -2297,7 +2300,7 @@ mod tests {
     #[test]
     fn no_matches() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new([
+            let requested_schema = StructType::new_unchecked([
                 StructField::nullable(logical_name(1), DataType::STRING)
                     .with_metadata(column_mapping_metadata(1)),
                 StructField::nullable(logical_name(2), DataType::INTEGER)
@@ -2340,7 +2343,7 @@ mod tests {
 
     #[test]
     fn empty_requested_schema() {
-        let requested_schema = Arc::new(StructType::new([]));
+        let requested_schema = Arc::new(StructType::new_unchecked([]));
         let parquet_schema = Arc::new(ArrowSchema::new(vec![
             ArrowField::new("i", ArrowDataType::Int32, false),
             ArrowField::new("s", ArrowDataType::Utf8, true),

--- a/kernel/src/engine/default/json.rs
+++ b/kernel/src/engine/default/json.rs
@@ -701,7 +701,7 @@ mod tests {
                 )),
             );
             let handler = handler.with_buffer_size(*buffer_size);
-            let physical_schema = Arc::new(Schema::new(vec![StructField::nullable(
+            let physical_schema = Arc::new(Schema::new_unchecked(vec![StructField::nullable(
                 "val",
                 DeltaDataType::INTEGER,
             )]));

--- a/kernel/src/engine/ensure_data_types.rs
+++ b/kernel/src/engine/ensure_data_types.rs
@@ -452,10 +452,10 @@ mod tests {
 
     #[test]
     fn ensure_struct() {
-        let schema = DataType::struct_type([StructField::nullable(
+        let schema = DataType::struct_type_unchecked([StructField::nullable(
             "a",
             ArrayType::new(
-                DataType::struct_type([
+                DataType::struct_type_unchecked([
                     StructField::nullable("w", DataType::LONG),
                     StructField::nullable("x", ArrayType::new(DataType::LONG, true)),
                     StructField::nullable(
@@ -464,7 +464,7 @@ mod tests {
                     ),
                     StructField::nullable(
                         "z",
-                        DataType::struct_type([
+                        DataType::struct_type_unchecked([
                             StructField::nullable("n", DataType::LONG),
                             StructField::nullable("m", DataType::STRING),
                         ]),
@@ -476,7 +476,7 @@ mod tests {
         let arrow_struct = ArrowDataType::try_from_kernel(&schema).unwrap();
         assert!(ensure_data_types(&schema, &arrow_struct, true).is_ok());
 
-        let kernel_simple = DataType::struct_type([
+        let kernel_simple = DataType::struct_type_unchecked([
             StructField::nullable("w", DataType::LONG),
             StructField::nullable("x", DataType::LONG),
         ]);

--- a/kernel/src/expressions/literal_expression_transform.rs
+++ b/kernel/src/expressions/literal_expression_transform.rs
@@ -228,14 +228,14 @@ mod tests {
     fn test_create_one_top_level_null() {
         let values = &[Scalar::Null(DeltaDataTypes::INTEGER)];
 
-        let schema = Arc::new(StructType::new([StructField::not_null(
+        let schema = Arc::new(StructType::new_unchecked([StructField::not_null(
             "col_1",
             DeltaDataTypes::INTEGER,
         )]));
         let expected = Expr::null_literal(schema.clone().into());
         assert_single_row_transform(values, schema, Ok(expected));
 
-        let schema = Arc::new(StructType::new([StructField::nullable(
+        let schema = Arc::new(StructType::new_unchecked([StructField::nullable(
             "col_1",
             DeltaDataTypes::INTEGER,
         )]));
@@ -246,7 +246,7 @@ mod tests {
     #[test]
     fn test_create_one_missing_values() {
         let values = &[1.into()];
-        let schema = Arc::new(StructType::new([
+        let schema = Arc::new(StructType::new_unchecked([
             StructField::nullable("col_1", DeltaDataTypes::INTEGER),
             StructField::nullable("col_2", DeltaDataTypes::INTEGER),
         ]));
@@ -256,7 +256,7 @@ mod tests {
     #[test]
     fn test_create_one_extra_values() {
         let values = &[1.into(), 2.into(), 3.into()];
-        let schema = Arc::new(StructType::new([
+        let schema = Arc::new(StructType::new_unchecked([
             StructField::nullable("col_1", DeltaDataTypes::INTEGER),
             StructField::nullable("col_2", DeltaDataTypes::INTEGER),
         ]));
@@ -266,7 +266,7 @@ mod tests {
     #[test]
     fn test_create_one_incorrect_schema() {
         let values = &["a".into()];
-        let schema = Arc::new(StructType::new([StructField::nullable(
+        let schema = Arc::new(StructType::new_unchecked([StructField::nullable(
             "col_1",
             DeltaDataTypes::INTEGER,
         )]));
@@ -277,17 +277,17 @@ mod tests {
     #[test]
     fn test_many_structs() {
         let values: &[Scalar] = &[1.into(), 2.into(), 3.into(), 4.into()];
-        let schema = Arc::new(StructType::new([
+        let schema = Arc::new(StructType::new_unchecked([
             StructField::nullable(
                 "x",
-                DeltaDataTypes::struct_type([
+                DeltaDataTypes::struct_type_unchecked([
                     StructField::not_null("a", DeltaDataTypes::INTEGER),
                     StructField::nullable("b", DeltaDataTypes::INTEGER),
                 ]),
             ),
             StructField::nullable(
                 "y",
-                DeltaDataTypes::struct_type([
+                DeltaDataTypes::struct_type_unchecked([
                     StructField::not_null("c", DeltaDataTypes::INTEGER),
                     StructField::nullable("d", DeltaDataTypes::INTEGER),
                 ]),
@@ -310,7 +310,7 @@ mod tests {
             Scalar::Map(map_data.clone()),
             Scalar::Array(array_data.clone()),
         ];
-        let schema = Arc::new(StructType::new([
+        let schema = Arc::new(StructType::new_unchecked([
             StructField::nullable("map", DeltaDataTypes::Map(Box::new(map_type))),
             StructField::nullable("array", DeltaDataTypes::Array(Box::new(array_type))),
         ]));
@@ -351,10 +351,10 @@ mod tests {
         let field_b = StructField::new("b", DeltaDataTypes::INTEGER, test_schema.b_nullable);
         let field_x = StructField::new(
             "x",
-            StructType::new([field_a.clone(), field_b.clone()]),
+            StructType::new_unchecked([field_a.clone(), field_b.clone()]),
             test_schema.x_nullable,
         );
-        let schema = Arc::new(StructType::new([field_x.clone()]));
+        let schema = Arc::new(StructType::new_unchecked([field_x.clone()]));
 
         let expected_result = match expected {
             Expected::Noop => {

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -273,7 +273,7 @@ impl Scalar {
             Self::Binary(_) => DataType::BINARY,
             Self::Decimal(d) => DataType::from(*d.ty()),
             Self::Null(data_type) => data_type.clone(),
-            Self::Struct(data) => DataType::struct_type(data.fields.clone()),
+            Self::Struct(data) => DataType::struct_type_unchecked(data.fields.clone()),
             Self::Array(data) => data.tpe.clone().into(),
             Self::Map(data) => data.data_type.clone().into(),
         }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -457,7 +457,7 @@ trait EvaluationHandlerExtension: EvaluationHandler {
     // future)
     fn create_one(&self, schema: SchemaRef, values: &[Scalar]) -> DeltaResult<Box<dyn EngineData>> {
         // just get a single int column (arbitrary)
-        let null_row_schema = Arc::new(StructType::new(vec![StructField::nullable(
+        let null_row_schema = Arc::new(StructType::new_unchecked(vec![StructField::nullable(
             "null_col",
             DataType::INTEGER,
         )]));

--- a/kernel/src/log_compaction/mod.rs
+++ b/kernel/src/log_compaction/mod.rs
@@ -92,7 +92,7 @@ mod tests;
 /// Schema for extracting relevant actions from log files for compaction.
 /// CommitInfo is excluded as it's not needed in compaction files.
 static COMPACTION_ACTIONS_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    Arc::new(StructType::new([
+    Arc::new(StructType::new_unchecked([
         StructField::nullable(ADD_NAME, Add::to_schema()),
         StructField::nullable(REMOVE_NAME, Remove::to_schema()),
         StructField::nullable(METADATA_NAME, Metadata::to_schema()),

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -116,7 +116,7 @@ impl DataSkippingFilter {
         let nullcount_schema = NullCountStatsTransform
             .transform_struct(&stats_schema)?
             .into_owned();
-        let stats_schema = Arc::new(StructType::new([
+        let stats_schema = Arc::new(StructType::new_unchecked([
             StructField::nullable("numRecords", DataType::LONG),
             StructField::nullable("nullCount", nullcount_schema),
             StructField::nullable("minValues", stats_schema.clone()),

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -329,8 +329,8 @@ pub(crate) static SCAN_ROW_SCHEMA: LazyLock<Arc<StructType>> = LazyLock::new(|| 
     // Note that fields projected out of a nullable struct must be nullable
     let partition_values = MapType::new(DataType::STRING, DataType::STRING, true);
     let file_constant_values =
-        StructType::new([StructField::nullable("partitionValues", partition_values)]);
-    Arc::new(StructType::new([
+        StructType::new_unchecked([StructField::nullable("partitionValues", partition_values)]);
+    Arc::new(StructType::new_unchecked([
         StructField::nullable("path", DataType::STRING),
         StructField::nullable("size", DataType::LONG),
         StructField::nullable("modificationTime", DataType::LONG),
@@ -508,7 +508,7 @@ mod tests {
     #[test]
     fn test_no_transforms() {
         let batch = vec![add_batch_simple(get_log_schema().clone())];
-        let logical_schema = Arc::new(crate::schema::StructType::new(vec![]));
+        let logical_schema = Arc::new(crate::schema::StructType::new_unchecked(vec![]));
         let iter = scan_action_iter(
             &SyncEngine::new(),
             batch
@@ -529,7 +529,7 @@ mod tests {
 
     #[test]
     fn test_simple_transform() {
-        let schema: SchemaRef = Arc::new(StructType::new([
+        let schema: SchemaRef = Arc::new(StructType::new_unchecked([
             StructField::new("value", DataType::INTEGER, true),
             StructField::new("date", DataType::DATE, true),
         ]));

--- a/kernel/src/schema/compare.rs
+++ b/kernel/src/schema/compare.rs
@@ -6,15 +6,15 @@
 //!  # use delta_kernel::schema::StructType;
 //!  # use delta_kernel::schema::StructField;
 //!  # use delta_kernel::schema::DataType;
-//!  let schema = StructType::new([
+//!  let schema = StructType::try_new([
 //!     StructField::new("id", DataType::LONG, false),
 //!     StructField::new("value", DataType::STRING, true),
-//!  ]);
-//!  let read_schema = StructType::new([
+//!  ])?;
+//!  let read_schema = StructType::try_new([
 //!     StructField::new("id", DataType::LONG, true),
 //!     StructField::new("value", DataType::STRING, true),
 //!     StructField::new("year", DataType::INTEGER, true),
-//!  ]);
+//!  ])?;
 //!  // Schemas are compatible since the `read_schema` adds a nullable column `year`
 //!  assert!(schema.can_read_as(&read_schema).is_ok());
 //!  ````
@@ -181,18 +181,19 @@ mod tests {
 
     #[test]
     fn can_read_is_reflexive() {
-        let map_key = StructType::new([
+        let map_key = StructType::new_unchecked([
             StructField::new("id", DataType::LONG, false),
             StructField::new("name", DataType::STRING, false),
         ]);
-        let map_value = StructType::new([StructField::new("age", DataType::INTEGER, true)]);
+        let map_value =
+            StructType::new_unchecked([StructField::new("age", DataType::INTEGER, true)]);
         let map_type = MapType::new(map_key, map_value, true);
         let array_type = ArrayType::new(DataType::TIMESTAMP, false);
-        let nested_struct = StructType::new([
+        let nested_struct = StructType::new_unchecked([
             StructField::new("name", DataType::STRING, false),
             StructField::new("age", DataType::INTEGER, true),
         ]);
-        let schema = StructType::new([
+        let schema = StructType::new_unchecked([
             StructField::new("id", DataType::LONG, false),
             StructField::new("map", map_type, false),
             StructField::new("array", array_type, false),
@@ -203,28 +204,28 @@ mod tests {
     }
     #[test]
     fn add_nullable_column_to_map_key_and_value() {
-        let existing_map_key = StructType::new([
+        let existing_map_key = StructType::new_unchecked([
             StructField::new("id", DataType::LONG, false),
             StructField::new("name", DataType::STRING, true),
         ]);
         let existing_map_value =
-            StructType::new([StructField::new("age", DataType::INTEGER, false)]);
-        let existing_schema = StructType::new([StructField::new(
+            StructType::new_unchecked([StructField::new("age", DataType::INTEGER, false)]);
+        let existing_schema = StructType::new_unchecked([StructField::new(
             "map",
             MapType::new(existing_map_key, existing_map_value, false),
             false,
         )]);
 
-        let read_map_key = StructType::new([
+        let read_map_key = StructType::new_unchecked([
             StructField::new("id", DataType::LONG, false),
             StructField::new("name", DataType::STRING, true),
             StructField::new("location", DataType::STRING, true),
         ]);
-        let read_map_value = StructType::new([
+        let read_map_value = StructType::new_unchecked([
             StructField::new("age", DataType::INTEGER, true),
             StructField::new("years_of_experience", DataType::INTEGER, true),
         ]);
-        let read_schema = StructType::new([StructField::new(
+        let read_schema = StructType::new_unchecked([StructField::new(
             "map",
             MapType::new(read_map_key, read_map_value, false),
             false,
@@ -234,23 +235,25 @@ mod tests {
     }
     #[test]
     fn map_value_becomes_non_nullable_fails() {
-        let map_key = StructType::new([
+        let map_key = StructType::new_unchecked([
             StructField::new("id", DataType::LONG, false),
             StructField::new("name", DataType::STRING, false),
         ]);
-        let map_value = StructType::new([StructField::new("age", DataType::INTEGER, true)]);
-        let existing_schema = StructType::new([StructField::new(
+        let map_value =
+            StructType::new_unchecked([StructField::new("age", DataType::INTEGER, true)]);
+        let existing_schema = StructType::new_unchecked([StructField::new(
             "map",
             MapType::new(map_key, map_value, false),
             false,
         )]);
 
-        let map_key = StructType::new([
+        let map_key = StructType::new_unchecked([
             StructField::new("id", DataType::LONG, false),
             StructField::new("name", DataType::STRING, false),
         ]);
-        let map_value = StructType::new([StructField::new("age", DataType::INTEGER, false)]);
-        let read_schema = StructType::new([StructField::new(
+        let map_value =
+            StructType::new_unchecked([StructField::new("age", DataType::INTEGER, false)]);
+        let read_schema = StructType::new_unchecked([StructField::new(
             "map",
             MapType::new(map_key, map_value, false),
             false,
@@ -264,12 +267,12 @@ mod tests {
     #[test]
     fn different_field_name_case_fails() {
         // names differing only in case are not the same
-        let existing_schema = StructType::new([
+        let existing_schema = StructType::new_unchecked([
             StructField::new("id", DataType::LONG, false),
             StructField::new("name", DataType::STRING, false),
             StructField::new("age", DataType::INTEGER, true),
         ]);
-        let read_schema = StructType::new([
+        let read_schema = StructType::new_unchecked([
             StructField::new("Id", DataType::LONG, false),
             StructField::new("name", DataType::STRING, false),
             StructField::new("age", DataType::INTEGER, true),
@@ -281,12 +284,12 @@ mod tests {
     }
     #[test]
     fn different_type_fails() {
-        let existing_schema = StructType::new([
+        let existing_schema = StructType::new_unchecked([
             StructField::new("id", DataType::LONG, false),
             StructField::new("name", DataType::STRING, false),
             StructField::new("age", DataType::INTEGER, true),
         ]);
-        let read_schema = StructType::new([
+        let read_schema = StructType::new_unchecked([
             StructField::new("id", DataType::INTEGER, false),
             StructField::new("name", DataType::STRING, false),
             StructField::new("age", DataType::INTEGER, true),
@@ -298,12 +301,12 @@ mod tests {
     }
     #[test]
     fn set_nullable_to_true() {
-        let existing_schema = StructType::new([
+        let existing_schema = StructType::new_unchecked([
             StructField::new("id", DataType::LONG, false),
             StructField::new("name", DataType::STRING, false),
             StructField::new("age", DataType::INTEGER, true),
         ]);
-        let read_schema = StructType::new([
+        let read_schema = StructType::new_unchecked([
             StructField::new("id", DataType::LONG, false),
             StructField::new("name", DataType::STRING, true),
             StructField::new("age", DataType::INTEGER, true),
@@ -312,12 +315,12 @@ mod tests {
     }
     #[test]
     fn set_nullable_to_false_fails() {
-        let existing_schema = StructType::new([
+        let existing_schema = StructType::new_unchecked([
             StructField::new("id", DataType::LONG, false),
             StructField::new("name", DataType::STRING, false),
             StructField::new("age", DataType::INTEGER, true),
         ]);
-        let read_schema = StructType::new([
+        let read_schema = StructType::new_unchecked([
             StructField::new("id", DataType::LONG, false),
             StructField::new("name", DataType::STRING, false),
             StructField::new("age", DataType::INTEGER, false),
@@ -329,13 +332,13 @@ mod tests {
     }
     #[test]
     fn differ_by_nullable_column() {
-        let a = StructType::new([
+        let a = StructType::new_unchecked([
             StructField::new("id", DataType::LONG, false),
             StructField::new("name", DataType::STRING, false),
             StructField::new("age", DataType::INTEGER, true),
         ]);
 
-        let b = StructType::new([
+        let b = StructType::new_unchecked([
             StructField::new("id", DataType::LONG, false),
             StructField::new("name", DataType::STRING, false),
             StructField::new("age", DataType::INTEGER, true),
@@ -350,13 +353,13 @@ mod tests {
     }
     #[test]
     fn differ_by_non_nullable_column() {
-        let a = StructType::new([
+        let a = StructType::new_unchecked([
             StructField::new("id", DataType::LONG, false),
             StructField::new("name", DataType::STRING, false),
             StructField::new("age", DataType::INTEGER, true),
         ]);
 
-        let b = StructType::new([
+        let b = StructType::new_unchecked([
             StructField::new("id", DataType::LONG, false),
             StructField::new("name", DataType::STRING, false),
             StructField::new("age", DataType::INTEGER, true),
@@ -375,14 +378,14 @@ mod tests {
 
     #[test]
     fn duplicate_field_modulo_case() {
-        let existing_schema = StructType::new([
+        let existing_schema = StructType::new_unchecked([
             StructField::new("id", DataType::LONG, false),
             StructField::new("Id", DataType::LONG, false),
             StructField::new("name", DataType::STRING, false),
             StructField::new("age", DataType::INTEGER, true),
         ]);
 
-        let read_schema = StructType::new([
+        let read_schema = StructType::new_unchecked([
             StructField::new("id", DataType::LONG, false),
             StructField::new("Id", DataType::LONG, false),
             StructField::new("name", DataType::STRING, false),

--- a/kernel/src/schema/variant_utils.rs
+++ b/kernel/src/schema/variant_utils.rs
@@ -54,15 +54,21 @@ mod tests {
         fn is_unshredded_variant(s: &DataType) -> bool {
             s == &DataType::unshredded_variant()
         }
-        assert!(!is_unshredded_variant(&DataType::variant_type([
-            StructField::not_null("metadata", DataType::BINARY),
-            StructField::nullable("value", DataType::BINARY),
-            StructField::nullable("another_field", DataType::BINARY),
-        ])));
-        assert!(is_unshredded_variant(&DataType::variant_type([
-            StructField::not_null("metadata", DataType::BINARY),
-            StructField::not_null("value", DataType::BINARY),
-        ])));
+        assert!(!is_unshredded_variant(
+            &DataType::variant_type([
+                StructField::not_null("metadata", DataType::BINARY),
+                StructField::nullable("value", DataType::BINARY),
+                StructField::nullable("another_field", DataType::BINARY),
+            ])
+            .unwrap()
+        ));
+        assert!(is_unshredded_variant(
+            &DataType::variant_type([
+                StructField::not_null("metadata", DataType::BINARY),
+                StructField::not_null("value", DataType::BINARY),
+            ])
+            .unwrap()
+        ));
     }
 
     #[test]
@@ -74,22 +80,22 @@ mod tests {
                 WriterFeature::VariantTypePreview,
             ),
         ];
-        let schema_with_variant = StructType::new([
+        let schema_with_variant = StructType::new_unchecked([
             StructField::new("id", DataType::INTEGER, false),
             StructField::new("v", DataType::unshredded_variant(), true),
         ]);
 
-        let schema_without_variant = StructType::new([
+        let schema_without_variant = StructType::new_unchecked([
             StructField::new("id", DataType::INTEGER, false),
             StructField::new("name", DataType::STRING, true),
         ]);
 
         // Nested schema with VARIANT
-        let nested_schema_with_variant = StructType::new([
+        let nested_schema_with_variant = StructType::new_unchecked([
             StructField::new("id", DataType::INTEGER, false),
             StructField::new(
                 "nested",
-                DataType::Struct(Box::new(StructType::new([StructField::new(
+                DataType::Struct(Box::new(StructType::new_unchecked([StructField::new(
                     "inner_v",
                     DataType::unshredded_variant(),
                     true,

--- a/kernel/src/table_changes/log_replay.rs
+++ b/kernel/src/table_changes/log_replay.rs
@@ -281,7 +281,7 @@ struct PreparePhaseVisitor<'a> {
 }
 impl PreparePhaseVisitor<'_> {
     fn schema() -> Arc<StructType> {
-        Arc::new(StructType::new(vec![
+        Arc::new(StructType::new_unchecked(vec![
             StructField::nullable(ADD_NAME, Add::to_schema()),
             StructField::nullable(REMOVE_NAME, Remove::to_schema()),
             StructField::nullable(CDC_NAME, Cdc::to_schema()),
@@ -381,7 +381,7 @@ impl<'a> FileActionSelectionVisitor<'a> {
         }
     }
     fn schema() -> Arc<StructType> {
-        Arc::new(StructType::new(vec![
+        Arc::new(StructType::new_unchecked(vec![
             StructField::nullable(CDC_NAME, Cdc::to_schema()),
             StructField::nullable(ADD_NAME, Add::to_schema()),
             StructField::nullable(REMOVE_NAME, Remove::to_schema()),

--- a/kernel/src/table_changes/log_replay/tests.rs
+++ b/kernel/src/table_changes/log_replay/tests.rs
@@ -21,7 +21,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 fn get_schema() -> StructType {
-    StructType::new([
+    StructType::new_unchecked([
         StructField::nullable("id", DataType::INTEGER),
         StructField::nullable("value", DataType::STRING),
     ])
@@ -214,7 +214,7 @@ async fn incompatible_schemas_fail() {
 
     // The CDF schema has fields: `id: int` and `value: string`.
     // This commit has schema with fields: `id: long`, `value: string` and `year: int` (nullable).
-    let schema = StructType::new([
+    let schema = StructType::new_unchecked([
         StructField::nullable("id", DataType::LONG),
         StructField::nullable("value", DataType::STRING),
         StructField::nullable("year", DataType::INTEGER),
@@ -223,7 +223,7 @@ async fn incompatible_schemas_fail() {
 
     // The CDF schema has fields: `id: int` and `value: string`.
     // This commit has schema with fields: `id: long` and `value: string`.
-    let schema = StructType::new([
+    let schema = StructType::new_unchecked([
         StructField::nullable("id", DataType::LONG),
         StructField::nullable("value", DataType::STRING),
     ]);
@@ -233,11 +233,11 @@ async fn incompatible_schemas_fail() {
     //
     // The CDF schema has fields: `id: long` and `value: string`.
     // This commit has schema with fields: `id: int` and `value: string`.
-    let cdf_schema = StructType::new([
+    let cdf_schema = StructType::new_unchecked([
         StructField::nullable("id", DataType::LONG),
         StructField::nullable("value", DataType::STRING),
     ]);
-    let commit_schema = StructType::new([
+    let commit_schema = StructType::new_unchecked([
         StructField::nullable("id", DataType::INTEGER),
         StructField::nullable("value", DataType::STRING),
     ]);
@@ -247,7 +247,7 @@ async fn incompatible_schemas_fail() {
     //
     // The CDF schema has fields: nullable `id`  and nullable `value`.
     // This commit has schema with fields: non-nullable `id` and nullable `value`.
-    let schema = StructType::new([
+    let schema = StructType::new_unchecked([
         StructField::not_null("id", DataType::LONG),
         StructField::nullable("value", DataType::STRING),
     ]);
@@ -255,7 +255,7 @@ async fn incompatible_schemas_fail() {
 
     // The CDF schema has fields: `id: int` and `value: string`.
     // This commit has schema with fields:`id: string` and `value: string`.
-    let schema = StructType::new([
+    let schema = StructType::new_unchecked([
         StructField::nullable("id", DataType::STRING),
         StructField::nullable("value", DataType::STRING),
     ]);

--- a/kernel/src/table_changes/mod.rs
+++ b/kernel/src/table_changes/mod.rs
@@ -188,13 +188,13 @@ impl TableChanges {
             )));
         }
 
-        let schema = StructType::new(
+        let schema = StructType::try_new(
             end_snapshot
                 .schema()
                 .fields()
                 .cloned()
                 .chain(CDF_FIELDS.clone()),
-        );
+        )?;
 
         Ok(TableChanges {
             table_root,

--- a/kernel/src/table_changes/physical_to_logical.rs
+++ b/kernel/src/table_changes/physical_to_logical.rs
@@ -73,7 +73,8 @@ pub(crate) fn scan_file_physical_schema(
     if scan_file.scan_type == CdfScanFileType::Cdc {
         let change_type = StructField::not_null(CHANGE_TYPE_COL_NAME, DataType::STRING);
         let fields = physical_schema.fields().cloned().chain(Some(change_type));
-        StructType::new(fields).into()
+        // NOTE: We don't validate the fields again because CHANGE_TYPE_COL_NAME should never be used anywhere else
+        StructType::new_unchecked(fields).into()
     } else {
         physical_schema.clone().into()
     }
@@ -105,7 +106,7 @@ mod tests {
                 commit_version: 42,
                 commit_timestamp: 1234,
             };
-            let logical_schema = StructType::new([
+            let logical_schema = StructType::new_unchecked([
                 StructField::nullable("id", DataType::STRING),
                 StructField::not_null("age", DataType::LONG),
                 StructField::not_null(CHANGE_TYPE_COL_NAME, DataType::STRING),

--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -173,7 +173,7 @@ impl TableChangesScanBuilder {
             logical_schema,
             physical_predicate,
             all_fields: Arc::new(all_fields),
-            physical_schema: StructType::new(read_fields).into(),
+            physical_schema: StructType::try_new(read_fields)?.into(),
         })
     }
 }
@@ -422,7 +422,7 @@ mod tests {
         );
         assert_eq!(
             scan.logical_schema,
-            StructType::new([
+            StructType::new_unchecked([
                 StructField::nullable("id", DataType::INTEGER),
                 StructField::not_null("_commit_version", DataType::LONG),
             ])
@@ -432,7 +432,7 @@ mod tests {
             scan.physical_predicate,
             PhysicalPredicate::Some(
                 predicate,
-                StructType::new([StructField::nullable("id", DataType::INTEGER),]).into()
+                StructType::new_unchecked([StructField::nullable("id", DataType::INTEGER),]).into()
             )
         );
     }

--- a/kernel/src/table_changes/scan_file.rs
+++ b/kernel/src/table_changes/scan_file.rs
@@ -175,7 +175,7 @@ impl<T> RowVisitor for CdfScanFileVisitor<'_, T> {
 /// Get the schema that scan rows (from [`TableChanges::scan_metadata`]) will be returned with.
 pub(crate) fn cdf_scan_row_schema() -> SchemaRef {
     static CDF_SCAN_ROW_SCHEMA: LazyLock<Arc<StructType>> = LazyLock::new(|| {
-        let deletion_vector = StructType::new([
+        let deletion_vector = StructType::new_unchecked([
             StructField::nullable("storageType", DataType::STRING),
             StructField::nullable("pathOrInlineDv", DataType::STRING),
             StructField::nullable("offset", DataType::INTEGER),
@@ -184,24 +184,24 @@ pub(crate) fn cdf_scan_row_schema() -> SchemaRef {
         ]);
         let partition_values = MapType::new(DataType::STRING, DataType::STRING, true);
         let file_constant_values =
-            StructType::new([StructField::nullable("partitionValues", partition_values)]);
+            StructType::new_unchecked([StructField::nullable("partitionValues", partition_values)]);
 
-        let add = StructType::new([
+        let add = StructType::new_unchecked([
             StructField::nullable("path", DataType::STRING),
             StructField::nullable("deletionVector", deletion_vector.clone()),
             StructField::nullable("fileConstantValues", file_constant_values.clone()),
         ]);
-        let remove = StructType::new([
+        let remove = StructType::new_unchecked([
             StructField::nullable("path", DataType::STRING),
             StructField::nullable("deletionVector", deletion_vector),
             StructField::nullable("fileConstantValues", file_constant_values.clone()),
         ]);
-        let cdc = StructType::new([
+        let cdc = StructType::new_unchecked([
             StructField::nullable("path", DataType::STRING),
             StructField::nullable("fileConstantValues", file_constant_values),
         ]);
 
-        Arc::new(StructType::new([
+        Arc::new(StructType::new_unchecked([
             StructField::nullable("add", add),
             StructField::nullable("remove", remove),
             StructField::nullable("cdc", cdc),
@@ -329,7 +329,7 @@ mod tests {
         let log_segment =
             LogSegment::for_table_changes(engine.storage_handler().as_ref(), log_root, 0, None)
                 .unwrap();
-        let table_schema = StructType::new([
+        let table_schema = StructType::new_unchecked([
             StructField::nullable("id", DataType::INTEGER),
             StructField::nullable("value", DataType::STRING),
         ]);

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -305,7 +305,7 @@ mod tests {
             create_annotations(outer_id, outer_name)
         );
         println!("{schema}");
-        StructType::new([serde_json::from_str(&schema).unwrap()])
+        StructType::new_unchecked([serde_json::from_str(&schema).unwrap()])
     }
 
     #[test]

--- a/kernel/src/table_features/timestamp_ntz.rs
+++ b/kernel/src/table_features/timestamp_ntz.rs
@@ -51,12 +51,12 @@ mod tests {
 
     #[test]
     fn test_timestamp_ntz_feature_validation() {
-        let schema_with_timestamp_ntz = StructType::new([
+        let schema_with_timestamp_ntz = StructType::new_unchecked([
             StructField::new("id", DataType::INTEGER, false),
             StructField::new("ts", DataType::Primitive(PrimitiveType::TimestampNtz), true),
         ]);
 
-        let schema_without_timestamp_ntz = StructType::new([
+        let schema_without_timestamp_ntz = StructType::new_unchecked([
             StructField::new("id", DataType::INTEGER, false),
             StructField::new("name", DataType::STRING, true),
         ]);
@@ -105,11 +105,11 @@ mod tests {
         assert_result_error_with_message(result, "Unsupported: Table contains TIMESTAMP_NTZ columns but does not have the required 'timestampNtz' feature in reader and writer features");
 
         // Nested schema with TIMESTAMP_NTZ
-        let nested_schema_with_timestamp_ntz = StructType::new([
+        let nested_schema_with_timestamp_ntz = StructType::new_unchecked([
             StructField::new("id", DataType::INTEGER, false),
             StructField::new(
                 "nested",
-                DataType::Struct(Box::new(StructType::new([StructField::new(
+                DataType::Struct(Box::new(StructType::new_unchecked([StructField::new(
                     "inner_ts",
                     DataType::Primitive(PrimitiveType::TimestampNtz),
                     true,

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -27,7 +27,7 @@ type EngineDataResultIterator<'a> =
 
 /// The minimal (i.e., mandatory) fields in an add action.
 pub(crate) static MANDATORY_ADD_FILE_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    Arc::new(StructType::new(vec![
+    Arc::new(StructType::new_unchecked(vec![
         StructField::not_null("path", DataType::STRING),
         StructField::not_null(
             "partitionValues",
@@ -48,10 +48,10 @@ pub(crate) fn mandatory_add_file_schema() -> &'static SchemaRef {
 pub(crate) static ADD_FILES_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
     let stats = StructField::nullable(
         "stats",
-        DataType::struct_type(vec![StructField::nullable("numRecords", DataType::LONG)]),
+        DataType::struct_type_unchecked(vec![StructField::nullable("numRecords", DataType::LONG)]),
     );
 
-    Arc::new(StructType::new(
+    Arc::new(StructType::new_unchecked(
         mandatory_add_file_schema().fields().cloned().chain([stats]),
     ))
 });
@@ -85,7 +85,7 @@ fn with_stats_col(schema: &SchemaRef) -> SchemaRef {
         .fields()
         .cloned()
         .chain([StructField::nullable("stats", DataType::STRING)]);
-    Arc::new(StructType::new(fields))
+    Arc::new(StructType::new_unchecked(fields))
 }
 
 /// Extend a schema with row tracking columns and return a new SchemaRef.
@@ -96,7 +96,7 @@ fn with_row_tracking_cols(schema: &SchemaRef) -> SchemaRef {
         StructField::nullable("baseRowId", DataType::LONG),
         StructField::nullable("defaultRowCommitVersion", DataType::LONG),
     ]);
-    Arc::new(StructType::new(fields))
+    Arc::new(StructType::new_unchecked(fields))
 }
 
 /// A transaction represents an in-progress write to a table. After creating a transaction, changes
@@ -385,7 +385,7 @@ impl Transaction {
                         ArrayData::try_new(ArrayType::new(DataType::LONG, true), commit_versions)?;
 
                     add_files_batch.append_columns(
-                        with_row_tracking_cols(&Arc::new(StructType::new(vec![]))),
+                        with_row_tracking_cols(&Arc::new(StructType::new_unchecked(vec![]))),
                         vec![base_row_ids, row_commit_versions],
                     )
                 },
@@ -481,7 +481,7 @@ mod tests {
     #[test]
     fn test_add_files_schema() {
         let schema = add_files_schema();
-        let expected = StructType::new(vec![
+        let expected = StructType::new_unchecked(vec![
             StructField::not_null("path", DataType::STRING),
             StructField::not_null(
                 "partitionValues",
@@ -492,7 +492,10 @@ mod tests {
             StructField::not_null("dataChange", DataType::BOOLEAN),
             StructField::nullable(
                 "stats",
-                DataType::struct_type(vec![StructField::nullable("numRecords", DataType::LONG)]),
+                DataType::struct_type_unchecked(vec![StructField::nullable(
+                    "numRecords",
+                    DataType::LONG,
+                )]),
             ),
         ]);
         assert_eq!(*schema, expected.into());

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -440,7 +440,7 @@ fn read_table_data(
         let selected_fields = select_cols
             .iter()
             .map(|col| table_schema.field(col).cloned().unwrap());
-        Arc::new(Schema::new(selected_fields))
+        Arc::new(Schema::new_unchecked(selected_fields))
     });
     println!("Read {url:?} with schema {read_schema:#?} and predicate {predicate:#?}");
     let scan = snapshot

--- a/kernel/tests/row_tracking.rs
+++ b/kernel/tests/row_tracking.rs
@@ -201,10 +201,10 @@ async fn test_row_tracking_append() -> DeltaResult<()> {
     // Setup
     let _ = tracing_subscriber::fmt::try_init();
     let tmp_test_dir = tempdir()?;
-    let schema = Arc::new(StructType::new(vec![StructField::nullable(
+    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
         "number",
         DataType::INTEGER,
-    )]));
+    )])?);
 
     let (table_url, engine, store) =
         create_row_tracking_table(&tmp_test_dir, "test_append", schema.clone()).await?;
@@ -247,10 +247,10 @@ async fn test_row_tracking_single_record_batches() -> DeltaResult<()> {
     // Setup
     let _ = tracing_subscriber::fmt::try_init();
     let tmp_test_dir = tempdir()?;
-    let schema = Arc::new(StructType::new(vec![StructField::nullable(
+    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
         "number",
         DataType::INTEGER,
-    )]));
+    )])?);
 
     let (table_url, engine, store) =
         create_row_tracking_table(&tmp_test_dir, "test_single_records", schema.clone()).await?;
@@ -284,10 +284,10 @@ async fn test_row_tracking_large_batch() -> DeltaResult<()> {
     // Setup
     let _ = tracing_subscriber::fmt::try_init();
     let tmp_test_dir = tempdir()?;
-    let schema = Arc::new(StructType::new(vec![StructField::nullable(
+    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
         "number",
         DataType::INTEGER,
-    )]));
+    )])?);
 
     let (table_url, engine, store) =
         create_row_tracking_table(&tmp_test_dir, "test_large_batch", schema.clone()).await?;
@@ -325,10 +325,10 @@ async fn test_row_tracking_consecutive_transactions() -> DeltaResult<()> {
     // Setup
     let _ = tracing_subscriber::fmt::try_init();
     let tmp_test_dir = tempdir()?;
-    let schema = Arc::new(StructType::new(vec![StructField::nullable(
+    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
         "number",
         DataType::INTEGER,
-    )]));
+    )])?);
 
     let (table_url, engine, store) =
         create_row_tracking_table(&tmp_test_dir, "test_consecutive_commits", schema.clone())
@@ -387,10 +387,10 @@ async fn test_row_tracking_three_consecutive_transactions() -> DeltaResult<()> {
     // Setup
     let _ = tracing_subscriber::fmt::try_init();
     let tmp_test_dir = tempdir()?;
-    let schema = Arc::new(StructType::new(vec![
+    let schema = Arc::new(StructType::try_new(vec![
         StructField::nullable("id", DataType::LONG),
         StructField::nullable("name", DataType::STRING),
-    ]));
+    ])?);
 
     let (table_url, engine, store) =
         create_row_tracking_table(&tmp_test_dir, "test_three_transactions", schema.clone()).await?;
@@ -473,10 +473,10 @@ async fn test_row_tracking_with_regular_and_empty_adds() -> DeltaResult<()> {
     // Setup
     let _ = tracing_subscriber::fmt::try_init();
     let tmp_test_dir = tempdir()?;
-    let schema = Arc::new(StructType::new(vec![StructField::nullable(
+    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
         "number",
         DataType::INTEGER,
-    )]));
+    )])?);
 
     let (table_url, engine, store) =
         create_row_tracking_table(&tmp_test_dir, "test_append", schema.clone()).await?;
@@ -520,10 +520,10 @@ async fn test_row_tracking_with_empty_adds() -> DeltaResult<()> {
     // Setup
     let _ = tracing_subscriber::fmt::try_init();
     let tmp_test_dir = tempdir()?;
-    let schema = Arc::new(StructType::new(vec![StructField::nullable(
+    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
         "number",
         DataType::INTEGER,
-    )]));
+    )])?);
 
     let (table_url, engine, store) =
         create_row_tracking_table(&tmp_test_dir, "test_append", schema.clone()).await?;
@@ -567,10 +567,10 @@ async fn test_row_tracking_without_adds() -> DeltaResult<()> {
     // Setup
     let _ = tracing_subscriber::fmt::try_init();
     let tmp_test_dir = tempdir()?;
-    let schema = Arc::new(StructType::new(vec![StructField::nullable(
+    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
         "number",
         DataType::INTEGER,
-    )]));
+    )])?);
 
     let (table_url, engine, store) =
         create_row_tracking_table(&tmp_test_dir, "test_consecutive_commits", schema.clone())
@@ -602,10 +602,10 @@ async fn test_row_tracking_parallel_transactions_conflict() -> DeltaResult<()> {
     // Setup
     let _ = tracing_subscriber::fmt::try_init();
     let tmp_test_dir = tempdir()?;
-    let schema = Arc::new(StructType::new(vec![StructField::nullable(
+    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
         "number",
         DataType::INTEGER,
-    )]));
+    )])?);
 
     let (table_url, engine, store) =
         create_row_tracking_table(&tmp_test_dir, "test_parallel_row_tracking", schema.clone())
@@ -710,10 +710,10 @@ async fn test_no_row_tracking_fields_without_feature() -> DeltaResult<()> {
     // Setup
     let _ = tracing_subscriber::fmt::try_init();
     let tmp_test_dir = tempdir()?;
-    let schema = Arc::new(StructType::new(vec![StructField::nullable(
+    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
         "number",
         DataType::INTEGER,
-    )]));
+    )])?);
 
     // Create a table without row tracking
     let tmp_test_dir_url = Url::from_directory_path(tmp_test_dir.path())

--- a/kernel/tests/write.rs
+++ b/kernel/tests/write.rs
@@ -51,10 +51,10 @@ async fn test_commit_info() -> Result<(), Box<dyn std::error::Error>> {
     let _ = tracing_subscriber::fmt::try_init();
 
     // create a simple table: one int column named 'number'
-    let schema = Arc::new(StructType::new(vec![StructField::nullable(
+    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
         "number",
         DataType::INTEGER,
-    )]));
+    )])?);
 
     for (table_url, engine, store, table_name) in
         setup_test_tables(schema, &[], None, "test_table").await?
@@ -205,10 +205,10 @@ async fn test_commit_info_action() -> Result<(), Box<dyn std::error::Error>> {
     // setup tracing
     let _ = tracing_subscriber::fmt::try_init();
     // create a simple table: one int column named 'number'
-    let schema = Arc::new(StructType::new(vec![StructField::nullable(
+    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
         "number",
         DataType::INTEGER,
-    )]));
+    )])?);
 
     for (table_url, engine, store, table_name) in
         setup_test_tables(schema.clone(), &[], None, "test_table").await?
@@ -256,10 +256,10 @@ async fn test_append() -> Result<(), Box<dyn std::error::Error>> {
     // setup tracing
     let _ = tracing_subscriber::fmt::try_init();
     // create a simple table: one int column named 'number'
-    let schema = Arc::new(StructType::new(vec![StructField::nullable(
+    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
         "number",
         DataType::INTEGER,
-    )]));
+    )])?);
 
     for (table_url, engine, store, table_name) in
         setup_test_tables(schema.clone(), &[], None, "test_table").await?
@@ -348,10 +348,10 @@ async fn test_append_twice() -> Result<(), Box<dyn std::error::Error>> {
     // setup tracing
     let _ = tracing_subscriber::fmt::try_init();
     // create a simple table: one int column named 'number'
-    let schema = Arc::new(StructType::new(vec![StructField::nullable(
+    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
         "number",
         DataType::INTEGER,
-    )]));
+    )])?);
 
     for (table_url, engine, _, _) in
         setup_test_tables(schema.clone(), &[], None, "test_table").await?
@@ -385,14 +385,14 @@ async fn test_append_partitioned() -> Result<(), Box<dyn std::error::Error>> {
 
     // create a simple partitioned table: one int column named 'number', partitioned by string
     // column named 'partition'
-    let table_schema = Arc::new(StructType::new(vec![
+    let table_schema = Arc::new(StructType::try_new(vec![
         StructField::nullable("number", DataType::INTEGER),
         StructField::nullable("partition", DataType::STRING),
-    ]));
-    let data_schema = Arc::new(StructType::new(vec![StructField::nullable(
+    ])?);
+    let data_schema = Arc::new(StructType::try_new(vec![StructField::nullable(
         "number",
         DataType::INTEGER,
-    )]));
+    )])?);
 
     for (table_url, engine, store, table_name) in
         setup_test_tables(table_schema.clone(), &[partition_col], None, "test_table").await?
@@ -527,15 +527,15 @@ async fn test_append_invalid_schema() -> Result<(), Box<dyn std::error::Error>> 
     // setup tracing
     let _ = tracing_subscriber::fmt::try_init();
     // create a simple table: one int column named 'number'
-    let table_schema = Arc::new(StructType::new(vec![StructField::nullable(
+    let table_schema = Arc::new(StructType::try_new(vec![StructField::nullable(
         "number",
         DataType::INTEGER,
-    )]));
+    )])?);
     // incompatible data schema: one string column named 'string'
-    let data_schema = Arc::new(StructType::new(vec![StructField::nullable(
+    let data_schema = Arc::new(StructType::try_new(vec![StructField::nullable(
         "string",
         DataType::STRING,
-    )]));
+    )])?);
 
     for (table_url, engine, _store, _table_name) in
         setup_test_tables(table_schema, &[], None, "test_table").await?
@@ -589,10 +589,10 @@ async fn test_write_txn_actions() -> Result<(), Box<dyn std::error::Error>> {
     let _ = tracing_subscriber::fmt::try_init();
 
     // create a simple table: one int column named 'number'
-    let schema = Arc::new(StructType::new(vec![StructField::nullable(
+    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
         "number",
         DataType::INTEGER,
-    )]));
+    )])?);
 
     for (table_url, engine, store, table_name) in
         setup_test_tables(schema, &[], None, "test_table").await?
@@ -725,10 +725,10 @@ async fn test_append_timestamp_ntz() -> Result<(), Box<dyn std::error::Error>> {
     let _ = tracing_subscriber::fmt::try_init();
 
     // create a table with TIMESTAMP_NTZ column
-    let schema = Arc::new(StructType::new(vec![StructField::nullable(
+    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
         "ts_ntz",
         DataType::TIMESTAMP_NTZ,
-    )]));
+    )])?);
 
     let (store, engine, table_location) = engine_store_setup("test_table_timestamp_ntz", None);
     let table_url = create_table(
@@ -811,6 +811,7 @@ async fn test_append_variant() -> Result<(), Box<dyn std::error::Error>> {
             StructField::not_null("value", DataType::BINARY),
             StructField::not_null("metadata", DataType::BINARY),
         ])
+        .unwrap()
     }
     fn variant_arrow_type_flipped() -> ArrowDataType {
         let metadata_field = Field::new("metadata", ArrowDataType::Binary, false);
@@ -820,7 +821,7 @@ async fn test_append_variant() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // create a table with VARIANT column
-    let table_schema = Arc::new(StructType::new(vec![
+    let table_schema = Arc::new(StructType::try_new(vec![
         StructField::nullable("v", DataType::unshredded_variant())
             .with_metadata([("delta.columnMapping.physicalName", "col1")])
             .add_metadata([("delta.columnMapping.id", 1)]),
@@ -830,28 +831,28 @@ async fn test_append_variant() -> Result<(), Box<dyn std::error::Error>> {
         StructField::nullable(
             "nested",
             // We flip the value and metadata fields in the actual parquet file for the test
-            StructType::new(vec![StructField::nullable(
+            StructType::try_new(vec![StructField::nullable(
                 "nested_v",
                 unshredded_variant_schema_flipped(),
             )
             .with_metadata([("delta.columnMapping.physicalName", "col21")])
-            .add_metadata([("delta.columnMapping.id", 3)])]),
+            .add_metadata([("delta.columnMapping.id", 3)])])?,
         )
         .with_metadata([("delta.columnMapping.physicalName", "col3")])
         .add_metadata([("delta.columnMapping.id", 4)]),
-    ]));
+    ])?);
 
-    let write_schema = Arc::new(StructType::new(vec![
+    let write_schema = Arc::new(StructType::try_new(vec![
         StructField::nullable("col1", DataType::unshredded_variant()),
         StructField::nullable("col2", DataType::INTEGER),
         StructField::nullable(
             "col3",
-            StructType::new(vec![StructField::nullable(
+            StructType::try_new(vec![StructField::nullable(
                 "col21",
                 unshredded_variant_schema_flipped(),
-            )]),
+            )])?,
         ),
-    ]));
+    ])?);
 
     let tmp_test_dir = tempdir()?;
     let tmp_test_dir_url = Url::from_directory_path(tmp_test_dir.path()).unwrap();
@@ -1004,17 +1005,18 @@ async fn test_append_variant() -> Result<(), Box<dyn std::error::Error>> {
     assert!(parsed_commits[1].get("add").is_some());
 
     // The scanned data will match the logical schema, not the physical one
-    let expected_schema = Arc::new(StructType::new(vec![
+    let expected_schema = Arc::new(StructType::try_new(vec![
         StructField::nullable("v", DataType::unshredded_variant()),
         StructField::nullable("i", DataType::INTEGER),
         StructField::nullable(
             "nested",
-            StructType::new(vec![StructField::nullable(
+            StructType::try_new(vec![StructField::nullable(
                 "nested_v",
                 DataType::unshredded_variant(),
-            )]),
+            )])
+            .unwrap(),
         ),
-    ]));
+    ])?);
 
     // During the read, the flipped fields should be reordered into metadata, value.
     let variant_nested_v_array_expected = Arc::new(StructArray::try_new(
@@ -1052,22 +1054,22 @@ async fn test_shredded_variant_read_rejection() -> Result<(), Box<dyn std::error
 
     // setup tracing
     let _ = tracing_subscriber::fmt::try_init();
-    let table_schema = Arc::new(StructType::new(vec![StructField::nullable(
+    let table_schema = Arc::new(StructType::try_new(vec![StructField::nullable(
         "v",
         DataType::unshredded_variant(),
-    )]));
+    )])?);
 
     // The table will be attempted to be written in this form but be read into
     // STRUCT<metadata: BINARY, value: BINARY>. The read should fail because the default engine
     // currently does not support shredded reads.
-    let shredded_write_schema = Arc::new(StructType::new(vec![StructField::nullable(
+    let shredded_write_schema = Arc::new(StructType::try_new(vec![StructField::nullable(
         "v",
-        DataType::struct_type([
+        DataType::try_struct_type([
             StructField::new("metadata", DataType::BINARY, true),
             StructField::new("value", DataType::BINARY, true),
             StructField::new("typed_value", DataType::INTEGER, true),
-        ]),
-    )]));
+        ])?,
+    )])?);
 
     let tmp_test_dir = tempdir()?;
     let tmp_test_dir_url = Url::from_directory_path(tmp_test_dir.path()).unwrap();


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR refactors the constructors of `StructType` to clearly distinguish between fallible and infallible operations. Creating a schema/StructType is a fallible operation in general, since we, for example, do not allow duplicate column names. Once we introduce metadata columns to kernel-rs, we will have more failure scenarios. 

Consequently, this PR updates `StructType` to have the following three constructors:
- `pub fn try_new(fields: impl IntoIterator<Item = StructField>) -> DeltaResult<Self>`: This should be the default method for callers.
- `pub fn try_from_results(fields: impl IntoIterator<Item = DeltaResult<StructField>>) -> DeltaResult<Self>;`: A convenience method for callers if they have an iterator of results.
- `pub(crate) fn new_unchecked(fields: impl IntoIterator<Item = StructField>) -> Self`: A shortcut method that does not perform validation if the caller ensures themselves that their schema is valid.

### This PR affects the following public APIs

This PR changes the `StructType` API as described above.

## How was this change tested?

This is a pure refactoring. Existing tests verify correctness.