### PR TITLE
prefactor!: optional table root in SnapshotBuilder

### DIFF
--- a/acceptance/src/data.rs
+++ b/acceptance/src/data.rs
@@ -115,7 +115,9 @@ pub async fn assert_scan_metadata(
     test_case: &TestCaseInfo,
 ) -> TestResult<()> {
     let table_root = test_case.table_root()?;
-    let snapshot = Snapshot::builder(table_root).build(engine.as_ref())?;
+    let snapshot = Snapshot::builder()
+        .with_table_root(table_root)
+        .build(engine.as_ref())?;
     let scan = snapshot.into_scan_builder().build()?;
     let mut schema = None;
     let batches: Vec<RecordBatch> = scan

--- a/acceptance/src/meta.rs
+++ b/acceptance/src/meta.rs
@@ -103,11 +103,14 @@ impl TestCaseInfo {
         let engine = engine.as_ref();
         let (latest, versions) = self.versions().await?;
 
-        let snapshot = Snapshot::builder(self.table_root()?).build(engine)?;
+        let snapshot = Snapshot::builder()
+            .with_table_root(self.table_root()?)
+            .build(engine)?;
         self.assert_snapshot_meta(&latest, &snapshot)?;
 
         for table_version in versions {
-            let snapshot = Snapshot::builder(self.table_root()?)
+            let snapshot = Snapshot::builder()
+                .with_table_root(self.table_root()?)
                 .at_version(table_version.version)
                 .build(engine)?;
             self.assert_snapshot_meta(&table_version, &snapshot)?;

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -601,7 +601,7 @@ fn snapshot_impl(
     extern_engine: &dyn ExternEngine,
     version: Option<Version>,
 ) -> DeltaResult<Handle<SharedSnapshot>> {
-    let builder = Snapshot::builder(url?);
+    let builder = Snapshot::builder().with_table_root(url?);
     let builder = if let Some(v) = version {
         // TODO: should we include a `with_version_opt` method for the builder?
         builder.at_version(v)

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -38,7 +38,11 @@ fn transaction_impl(
     url: DeltaResult<Url>,
     extern_engine: &dyn ExternEngine,
 ) -> DeltaResult<Handle<ExclusiveTransaction>> {
-    let snapshot = Arc::new(Snapshot::builder(url?).build(extern_engine.engine().as_ref())?);
+    let snapshot = Arc::new(
+        Snapshot::builder()
+            .with_table_root(url?)
+            .build(extern_engine.engine().as_ref())?,
+    );
     let transaction = snapshot.transaction();
     Ok(Box::new(transaction?).into())
 }

--- a/kernel/benches/metadata_bench.rs
+++ b/kernel/benches/metadata_bench.rs
@@ -53,7 +53,8 @@ fn create_snapshot_benchmark(c: &mut Criterion) {
 
     c.bench_function("create_snapshot", |b| {
         b.iter(|| {
-            Snapshot::builder(url.clone())
+            Snapshot::builder()
+                .with_table_root(url.clone())
                 .build(engine.as_ref())
                 .expect("Failed to create snapshot")
         })
@@ -64,7 +65,8 @@ fn scan_metadata_benchmark(c: &mut Criterion) {
     let (_tempdir, url, engine) = setup();
 
     let snapshot = Arc::new(
-        Snapshot::builder(url.clone())
+        Snapshot::builder()
+            .with_table_root(url.clone())
             .build(engine.as_ref())
             .expect("Failed to create snapshot"),
     );

--- a/kernel/examples/inspect-table/src/main.rs
+++ b/kernel/examples/inspect-table/src/main.rs
@@ -182,7 +182,7 @@ fn try_main() -> DeltaResult<()> {
 
     let url = delta_kernel::try_parse_uri(&cli.location_args.path)?;
     let engine = common::get_engine(&url, &cli.location_args)?;
-    let snapshot = Snapshot::builder(url).build(&engine)?;
+    let snapshot = Snapshot::builder().with_table_root(url).build(&engine)?;
 
     match cli.command {
         Commands::TableVersion => {

--- a/kernel/examples/read-table-multi-threaded/src/main.rs
+++ b/kernel/examples/read-table-multi-threaded/src/main.rs
@@ -99,7 +99,7 @@ fn try_main() -> DeltaResult<()> {
     let url = delta_kernel::try_parse_uri(&cli.location_args.path)?;
     println!("Reading {url}");
     let engine = common::get_engine(&url, &cli.location_args)?;
-    let snapshot = Snapshot::builder(url).build(&engine)?;
+    let snapshot = Snapshot::builder().with_table_root(url).build(&engine)?;
     let Some(scan) = common::get_scan(snapshot, &cli.scan_args)? else {
         return Ok(());
     };

--- a/kernel/examples/read-table-single-threaded/src/main.rs
+++ b/kernel/examples/read-table-single-threaded/src/main.rs
@@ -43,7 +43,7 @@ fn try_main() -> DeltaResult<()> {
     let url = delta_kernel::try_parse_uri(&cli.location_args.path)?;
     println!("Reading {url}");
     let engine = common::get_engine(&url, &cli.location_args)?;
-    let snapshot = Snapshot::builder(url).build(&engine)?;
+    let snapshot = Snapshot::builder().with_table_root(url).build(&engine)?;
     let Some(scan) = common::get_scan(snapshot, &cli.scan_args)? else {
         return Ok(());
     };

--- a/kernel/examples/write-table/src/main.rs
+++ b/kernel/examples/write-table/src/main.rs
@@ -125,7 +125,10 @@ async fn create_or_get_base_snapshot(
     schema_str: &str,
 ) -> DeltaResult<Snapshot> {
     // Check if table already exists
-    match Snapshot::builder(url.clone()).build(engine) {
+    match Snapshot::builder()
+        .with_table_root(url.clone())
+        .build(engine)
+    {
         Ok(snapshot) => {
             println!("✓ Found existing table at version {}", snapshot.version());
             Ok(snapshot)
@@ -135,7 +138,9 @@ async fn create_or_get_base_snapshot(
             println!("Creating new Delta table...");
             let schema = parse_schema(schema_str)?;
             create_table(url, &schema).await?;
-            Snapshot::builder(url.clone()).build(engine)
+            Snapshot::builder()
+                .with_table_root(url.clone())
+                .build(engine)
         }
     }
 }
@@ -294,7 +299,9 @@ async fn read_and_display_data(
     table_url: &Url,
     engine: DefaultEngine<TokioBackgroundExecutor>,
 ) -> DeltaResult<()> {
-    let snapshot = Snapshot::builder(table_url.clone()).build(&engine)?;
+    let snapshot = Snapshot::builder()
+        .with_table_root(table_url.clone())
+        .build(&engine)?;
     let scan = snapshot.into_scan_builder().build()?;
 
     let batches: Vec<RecordBatch> = scan

--- a/kernel/src/actions/set_transaction.rs
+++ b/kernel/src/actions/set_transaction.rs
@@ -113,7 +113,10 @@ mod tests {
         let url = url::Url::from_directory_path(path).unwrap();
         let engine = SyncEngine::new();
 
-        let snapshot = Snapshot::builder(url).build(&engine).unwrap();
+        let snapshot = Snapshot::builder()
+            .with_table_root(url)
+            .build(&engine)
+            .unwrap();
         let log_segment = snapshot.log_segment();
 
         (
@@ -163,7 +166,10 @@ mod tests {
         let url = url::Url::from_directory_path(path.unwrap()).unwrap();
         let engine = SyncEngine::new();
 
-        let snapshot = Snapshot::builder(url).build(&engine).unwrap();
+        let snapshot = Snapshot::builder()
+            .with_table_root(url)
+            .build(&engine)
+            .unwrap();
         let log_segment = snapshot.log_segment();
 
         // The checkpoint has five parts, each containing one action. There are two app ids.
@@ -180,7 +186,10 @@ mod tests {
         let url = url::Url::from_directory_path(path.unwrap()).unwrap();
         let engine = SyncEngine::new();
 
-        let snapshot = Snapshot::builder(url).build(&engine).unwrap();
+        let snapshot = Snapshot::builder()
+            .with_table_root(url)
+            .build(&engine)
+            .unwrap();
         let log_segment = snapshot.log_segment();
 
         // Test with no retention (should get all transactions)

--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -47,7 +47,7 @@
 //!
 //! // Create a snapshot for the table at the version you want to checkpoint
 //! let url = delta_kernel::try_parse_uri("./tests/data/app-txn-no-checkpoint")?;
-//! let snapshot = Arc::new(Snapshot::builder(url).build(engine)?);
+//! let snapshot = Arc::new(Snapshot::builder().with_table_root(url).build(engine)?);
 //!
 //! // Create a checkpoint writer from the snapshot
 //! let mut writer = snapshot.checkpoint()?;

--- a/kernel/src/checkpoint/tests.rs
+++ b/kernel/src/checkpoint/tests.rs
@@ -72,7 +72,9 @@ fn test_create_checkpoint_metadata_batch() -> DeltaResult<()> {
     )?;
 
     let table_root = Url::parse("memory:///")?;
-    let snapshot = Snapshot::builder(table_root).build(&engine)?;
+    let snapshot = Snapshot::builder()
+        .with_table_root(table_root)
+        .build(&engine)?;
     let writer = Arc::new(snapshot).checkpoint()?;
 
     let checkpoint_batch = writer.create_checkpoint_metadata_batch(&engine)?;
@@ -295,7 +297,11 @@ fn test_v1_checkpoint_latest_version_by_default() -> DeltaResult<()> {
     )?;
 
     let table_root = Url::parse("memory:///")?;
-    let snapshot = Arc::new(Snapshot::builder(table_root).build(&engine)?);
+    let snapshot = Arc::new(
+        Snapshot::builder()
+            .with_table_root(table_root)
+            .build(&engine)?,
+    );
     let writer = snapshot.checkpoint()?;
 
     // Verify the checkpoint file path is the latest version by default.
@@ -363,7 +369,12 @@ fn test_v1_checkpoint_specific_version() -> DeltaResult<()> {
 
     let table_root = Url::parse("memory:///")?;
     // Specify version 0 for checkpoint
-    let snapshot = Arc::new(Snapshot::builder(table_root).at_version(0).build(&engine)?);
+    let snapshot = Arc::new(
+        Snapshot::builder()
+            .with_table_root(table_root)
+            .at_version(0)
+            .build(&engine)?,
+    );
     let writer = snapshot.checkpoint()?;
 
     // Verify the checkpoint file path is the specified version.
@@ -411,7 +422,12 @@ fn test_finalize_errors_if_checkpoint_data_iterator_is_not_exhausted() -> DeltaR
     )?;
 
     let table_root = Url::parse("memory:///")?;
-    let snapshot = Arc::new(Snapshot::builder(table_root).at_version(0).build(&engine)?);
+    let snapshot = Arc::new(
+        Snapshot::builder()
+            .with_table_root(table_root)
+            .at_version(0)
+            .build(&engine)?,
+    );
     let writer = snapshot.checkpoint()?;
     let data_iter = writer.checkpoint_data(&engine)?;
 
@@ -465,7 +481,11 @@ fn test_v2_checkpoint_supported_table() -> DeltaResult<()> {
     )?;
 
     let table_root = Url::parse("memory:///")?;
-    let snapshot = Arc::new(Snapshot::builder(table_root).build(&engine)?);
+    let snapshot = Arc::new(
+        Snapshot::builder()
+            .with_table_root(table_root)
+            .build(&engine)?,
+    );
     let writer = snapshot.checkpoint()?;
 
     // Verify the checkpoint file path is the latest version by default.

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -50,7 +50,10 @@ fn test_replay_for_metadata() {
     let url = url::Url::from_directory_path(path.unwrap()).unwrap();
     let engine = SyncEngine::new();
 
-    let snapshot = Snapshot::builder(url).build(&engine).unwrap();
+    let snapshot = Snapshot::builder()
+        .with_table_root(url)
+        .build(&engine)
+        .unwrap();
     let data: Vec<_> = snapshot
         .log_segment()
         .replay_for_metadata(&engine)

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -1256,7 +1256,10 @@ mod tests {
         let url = url::Url::from_directory_path(path).unwrap();
         let engine = SyncEngine::new();
 
-        let snapshot = Snapshot::builder(url).build(&engine).unwrap();
+        let snapshot = Snapshot::builder()
+            .with_table_root(url)
+            .build(&engine)
+            .unwrap();
         let scan = snapshot.into_scan_builder().build().unwrap();
         let files = get_files_for_scan(scan, &engine).unwrap();
         assert_eq!(files.len(), 1);
@@ -1273,7 +1276,10 @@ mod tests {
         let url = url::Url::from_directory_path(path).unwrap();
         let engine = Arc::new(SyncEngine::new());
 
-        let snapshot = Snapshot::builder(url).build(engine.as_ref()).unwrap();
+        let snapshot = Snapshot::builder()
+            .with_table_root(url)
+            .build(engine.as_ref())
+            .unwrap();
         let scan = snapshot.into_scan_builder().build().unwrap();
         let files: Vec<ScanResult> = scan.execute(engine).unwrap().try_collect().unwrap();
 
@@ -1289,7 +1295,10 @@ mod tests {
         let url = url::Url::from_directory_path(path).unwrap();
         let engine = Arc::new(SyncEngine::new());
 
-        let snapshot = Snapshot::builder(url).build(engine.as_ref()).unwrap();
+        let snapshot = Snapshot::builder()
+            .with_table_root(url)
+            .build(engine.as_ref())
+            .unwrap();
         let version = snapshot.version();
         let scan = snapshot.into_scan_builder().build().unwrap();
         let files: Vec<_> = scan
@@ -1323,7 +1332,8 @@ mod tests {
         let url = url::Url::from_directory_path(path).unwrap();
         let engine = Arc::new(SyncEngine::new());
 
-        let snapshot = Snapshot::builder(url.clone())
+        let snapshot = Snapshot::builder()
+            .with_table_root(url.clone())
             .at_version(0)
             .build(engine.as_ref())
             .unwrap();
@@ -1347,7 +1357,8 @@ mod tests {
             .into_iter()
             .map(|b| Box::new(ArrowEngineData::from(b)) as Box<dyn EngineData>)
             .collect();
-        let snapshot = Snapshot::builder(url)
+        let snapshot = Snapshot::builder()
+            .with_table_root(url)
             .at_version(1)
             .build(engine.as_ref())
             .unwrap();
@@ -1419,7 +1430,10 @@ mod tests {
         let url = url::Url::from_directory_path(path.unwrap()).unwrap();
         let engine = SyncEngine::new();
 
-        let snapshot = Snapshot::builder(url).build(&engine).unwrap();
+        let snapshot = Snapshot::builder()
+            .with_table_root(url)
+            .build(&engine)
+            .unwrap();
         let scan = snapshot.into_scan_builder().build().unwrap();
         let data: Vec<_> = scan
             .replay_for_scan_metadata(&engine)
@@ -1439,7 +1453,12 @@ mod tests {
         let url = url::Url::from_directory_path(path.unwrap()).unwrap();
         let engine = Arc::new(SyncEngine::new());
 
-        let snapshot = Arc::new(Snapshot::builder(url).build(engine.as_ref()).unwrap());
+        let snapshot = Arc::new(
+            Snapshot::builder()
+                .with_table_root(url)
+                .build(engine.as_ref())
+                .unwrap(),
+        );
 
         // No predicate pushdown attempted, so the one data file should be returned.
         //
@@ -1482,7 +1501,12 @@ mod tests {
         let url = url::Url::from_directory_path(path.unwrap()).unwrap();
         let engine = Arc::new(SyncEngine::new());
 
-        let snapshot = Arc::new(Snapshot::builder(url).build(engine.as_ref()).unwrap());
+        let snapshot = Arc::new(
+            Snapshot::builder()
+                .with_table_root(url)
+                .build(engine.as_ref())
+                .unwrap(),
+        );
 
         // Predicate over a logically valid but physically missing column. No data files should be
         // returned because the column is inferred to be all-null.
@@ -1517,7 +1541,10 @@ mod tests {
         let url = url::Url::from_directory_path(path).unwrap();
         let engine = SyncEngine::new();
 
-        let snapshot = Snapshot::builder(url).build(&engine).unwrap();
+        let snapshot = Snapshot::builder()
+            .with_table_root(url)
+            .build(&engine)
+            .unwrap();
         let scan = snapshot.into_scan_builder().build()?;
         let files = get_files_for_scan(scan, &engine)?;
         // test case:

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -391,7 +391,11 @@ mod tests {
         let url = url::Url::from_directory_path(path).unwrap();
 
         let engine = SyncEngine::new();
-        let snapshot = Snapshot::builder(url).at_version(1).build(&engine).unwrap();
+        let snapshot = Snapshot::builder()
+            .with_table_root(url)
+            .at_version(1)
+            .build(&engine)
+            .unwrap();
 
         let expected =
             Protocol::try_new(3, 7, Some(["deletionVectors"]), Some(["deletionVectors"])).unwrap();
@@ -409,7 +413,10 @@ mod tests {
         let url = url::Url::from_directory_path(path).unwrap();
 
         let engine = SyncEngine::new();
-        let snapshot = Snapshot::builder(url).build(&engine).unwrap();
+        let snapshot = Snapshot::builder()
+            .with_table_root(url)
+            .build(&engine)
+            .unwrap();
 
         let expected =
             Protocol::try_new(3, 7, Some(["deletionVectors"]), Some(["deletionVectors"])).unwrap();
@@ -449,7 +456,8 @@ mod tests {
 
         let engine = SyncEngine::new();
         let old_snapshot = Arc::new(
-            Snapshot::builder(url.clone())
+            Snapshot::builder()
+                .with_table_root(url.clone())
                 .at_version(1)
                 .build(&engine)
                 .unwrap(),
@@ -479,12 +487,14 @@ mod tests {
             let url = Url::parse("memory:///")?;
             let engine = DefaultEngine::new(store, Arc::new(TokioBackgroundExecutor::new()));
             let base_snapshot = Arc::new(
-                Snapshot::builder(url.clone())
+                Snapshot::builder()
+                    .with_table_root(url.clone())
                     .at_version(0)
                     .build(&engine)?,
             );
             let snapshot = Snapshot::try_new_from(base_snapshot.clone(), &engine, Some(1))?;
-            let expected = Snapshot::builder(url.clone())
+            let expected = Snapshot::builder()
+                .with_table_root(url.clone())
                 .at_version(1)
                 .build(&engine)?;
             assert_eq!(snapshot, expected.into());
@@ -532,12 +542,14 @@ mod tests {
             Arc::new(TokioBackgroundExecutor::new()),
         );
         let base_snapshot = Arc::new(
-            Snapshot::builder(url.clone())
+            Snapshot::builder()
+                .with_table_root(url.clone())
                 .at_version(0)
                 .build(&engine)?,
         );
         let snapshot = Snapshot::try_new_from(base_snapshot.clone(), &engine, None)?;
-        let expected = Snapshot::builder(url.clone())
+        let expected = Snapshot::builder()
+            .with_table_root(url.clone())
             .at_version(0)
             .build(&engine)?;
         assert_eq!(snapshot, expected.into());
@@ -607,7 +619,8 @@ mod tests {
         let url = Url::parse("memory:///")?;
         let engine = DefaultEngine::new(store_3c_i, Arc::new(TokioBackgroundExecutor::new()));
         let base_snapshot = Arc::new(
-            Snapshot::builder(url.clone())
+            Snapshot::builder()
+                .with_table_root(url.clone())
                 .at_version(0)
                 .build(&engine)?,
         );
@@ -718,14 +731,16 @@ mod tests {
 
         // base snapshot is at version 0
         let base_snapshot = Arc::new(
-            Snapshot::builder(url.clone())
+            Snapshot::builder()
+                .with_table_root(url.clone())
                 .at_version(0)
                 .build(&engine)?,
         );
 
         // first test: no new crc
         let snapshot = Snapshot::try_new_from(base_snapshot.clone(), &engine, Some(1))?;
-        let expected = Snapshot::builder(url.clone())
+        let expected = Snapshot::builder()
+            .with_table_root(url.clone())
             .at_version(1)
             .build(&engine)?;
         assert_eq!(snapshot, expected.into());
@@ -752,7 +767,8 @@ mod tests {
         });
         store.put(&path, crc.to_string().into()).await?;
         let snapshot = Snapshot::try_new_from(base_snapshot.clone(), &engine, Some(1))?;
-        let expected = Snapshot::builder(url.clone())
+        let expected = Snapshot::builder()
+            .with_table_root(url.clone())
             .at_version(1)
             .build(&engine)?;
         assert_eq!(snapshot, expected.into());
@@ -865,7 +881,10 @@ mod tests {
         .unwrap();
         let location = url::Url::from_directory_path(path).unwrap();
         let engine = SyncEngine::new();
-        let snapshot = Snapshot::builder(location).build(&engine).unwrap();
+        let snapshot = Snapshot::builder()
+            .with_table_root(location)
+            .build(&engine)
+            .unwrap();
 
         assert_eq!(snapshot.log_segment.checkpoint_parts.len(), 1);
         assert_eq!(
@@ -972,7 +991,11 @@ mod tests {
         .join("\n");
         add_commit(store.as_ref(), 1, commit).await.unwrap();
 
-        let snapshot = Arc::new(Snapshot::builder(url.clone()).build(&engine)?);
+        let snapshot = Arc::new(
+            Snapshot::builder()
+                .with_table_root(url.clone())
+                .build(&engine)?,
+        );
 
         assert_eq!(snapshot.get_domain_metadata("domain1", &engine)?, None);
         assert_eq!(

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -16,7 +16,7 @@ use url::Url;
 /// let table_root = Url::parse("file:///path/to/table")?;
 ///
 /// // Build a snapshot
-/// let snapshot = Snapshot::builder(table_root.clone())
+/// let snapshot = Snapshot::builder().with_table_root(table_root.clone())
 ///     .at_version(5) // Optional: specify a time-travel version (default is latest version)
 ///     .build(engine)?;
 ///
@@ -161,10 +161,13 @@ mod tests {
         let engine = engine.as_ref();
         create_table(&store, &table_root)?;
 
-        let snapshot = SnapshotBuilder::new(table_root.clone()).build(engine)?;
+        let snapshot = SnapshotBuilder::default()
+            .with_table_root(table_root.clone())
+            .build(engine)?;
         assert_eq!(snapshot.version(), 1);
 
-        let snapshot = SnapshotBuilder::new(table_root.clone())
+        let snapshot = SnapshotBuilder::default()
+            .with_table_root(table_root.clone())
             .at_version(0)
             .build(engine)?;
         assert_eq!(snapshot.version(), 0);

--- a/kernel/src/table_changes/mod.rs
+++ b/kernel/src/table_changes/mod.rs
@@ -151,7 +151,8 @@ impl TableChanges {
         // `ensure_read_supported`. Note that we must still verify that reading is
         // supported for every protocol action in the CDF range.
         let start_snapshot = Arc::new(
-            Snapshot::builder(table_root.as_url().clone())
+            Snapshot::builder()
+                .with_table_root(table_root.as_url().clone())
                 .at_version(start_version)
                 .build(engine)?,
         );

--- a/kernel/tests/dv.rs
+++ b/kernel/tests/dv.rs
@@ -32,7 +32,9 @@ fn dv_table() -> Result<(), Box<dyn std::error::Error>> {
     let url = url::Url::from_directory_path(path).unwrap();
     let engine = DefaultEngine::new_local();
 
-    let snapshot = Snapshot::builder(url).build(engine.as_ref())?;
+    let snapshot = Snapshot::builder()
+        .with_table_root(url)
+        .build(engine.as_ref())?;
     let scan = snapshot.into_scan_builder().build()?;
 
     let stream = scan.execute(engine)?;
@@ -47,7 +49,9 @@ fn non_dv_table() -> Result<(), Box<dyn std::error::Error>> {
     let url = url::Url::from_directory_path(path).unwrap();
     let engine = DefaultEngine::new_local();
 
-    let snapshot = Snapshot::builder(url).build(engine.as_ref())?;
+    let snapshot = Snapshot::builder()
+        .with_table_root(url)
+        .build(engine.as_ref())?;
     let scan = snapshot.into_scan_builder().build()?;
 
     let stream = scan.execute(engine)?;

--- a/kernel/tests/golden_tables.rs
+++ b/kernel/tests/golden_tables.rs
@@ -168,7 +168,7 @@ async fn latest_snapshot_test(
     url: Url,
     expected_path: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let snapshot = Snapshot::builder(url).build(&engine)?;
+    let snapshot = Snapshot::builder().with_table_root(url).build(&engine)?;
     let scan = snapshot.into_scan_builder().build()?;
     let scan_res = scan.execute(Arc::new(engine))?;
     let batches: Vec<RecordBatch> = scan_res
@@ -271,7 +271,10 @@ async fn canonicalized_paths_test(
     _expected: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // assert latest version is 1 and there are no files in the snapshot (add is removed)
-    let snapshot = Snapshot::builder(table_root).build(&engine).unwrap();
+    let snapshot = Snapshot::builder()
+        .with_table_root(table_root)
+        .build(&engine)
+        .unwrap();
     assert_eq!(snapshot.version(), 1);
     let scan = snapshot
         .into_scan_builder()
@@ -287,7 +290,10 @@ async fn checkpoint_test(
     table_root: Url,
     _expected: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let snapshot = Snapshot::builder(table_root).build(&engine).unwrap();
+    let snapshot = Snapshot::builder()
+        .with_table_root(table_root)
+        .build(&engine)
+        .unwrap();
     let version = snapshot.version();
     let scan = snapshot
         .into_scan_builder()

--- a/kernel/tests/hdfs.rs
+++ b/kernel/tests/hdfs.rs
@@ -73,7 +73,7 @@ async fn read_table_version_hdfs() -> Result<(), Box<dyn std::error::Error>> {
         Arc::new(TokioBackgroundExecutor::new()),
     )?;
 
-    let snapshot = Snapshot::builder(url).build(&engine)?;
+    let snapshot = Snapshot::builder().with_table_root(url).build(&engine)?;
     assert_eq!(snapshot.version(), 1);
 
     Ok(())

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -66,7 +66,9 @@ async fn single_commit_two_add_files() -> Result<(), Box<dyn std::error::Error>>
 
     let expected_data = vec![batch.clone(), batch];
 
-    let snapshot = Snapshot::builder(location).build(engine.as_ref())?;
+    let snapshot = Snapshot::builder()
+        .with_table_root(location)
+        .build(engine.as_ref())?;
     let scan = snapshot.into_scan_builder().build()?;
 
     let mut files = 0;
@@ -118,7 +120,9 @@ async fn two_commits() -> Result<(), Box<dyn std::error::Error>> {
 
     let expected_data = vec![batch.clone(), batch];
 
-    let snapshot = Snapshot::builder(location).build(&engine)?;
+    let snapshot = Snapshot::builder()
+        .with_table_root(location)
+        .build(&engine)?;
     let scan = snapshot.into_scan_builder().build()?;
 
     let mut files = 0;
@@ -171,7 +175,9 @@ async fn remove_action() -> Result<(), Box<dyn std::error::Error>> {
 
     let expected_data = vec![batch];
 
-    let snapshot = Snapshot::builder(location).build(&engine)?;
+    let snapshot = Snapshot::builder()
+        .with_table_root(location)
+        .build(&engine)?;
     let scan = snapshot.into_scan_builder().build()?;
 
     let stream = scan.execute(Arc::new(engine))?.zip(expected_data);
@@ -242,7 +248,11 @@ async fn stats() -> Result<(), Box<dyn std::error::Error>> {
         storage.clone(),
         Arc::new(TokioBackgroundExecutor::new()),
     ));
-    let snapshot = Arc::new(Snapshot::builder(location).build(engine.as_ref())?);
+    let snapshot = Arc::new(
+        Snapshot::builder()
+            .with_table_root(location)
+            .build(engine.as_ref())?,
+    );
 
     // The first file has id between 1 and 3; the second has id between 5 and 7. For each operator,
     // we validate the boundary values where we expect the set of matched files to change.
@@ -433,7 +443,9 @@ fn read_table_data(
         Arc::new(TokioBackgroundExecutor::new()),
     )?);
 
-    let snapshot = Snapshot::builder(url.clone()).build(engine.as_ref())?;
+    let snapshot = Snapshot::builder()
+        .with_table_root(url.clone())
+        .build(engine.as_ref())?;
 
     let read_schema = select_cols.map(|select_cols| {
         let table_schema = snapshot.schema();
@@ -1057,7 +1069,11 @@ async fn predicate_on_non_nullable_partition_column() -> Result<(), Box<dyn std:
         storage.clone(),
         Arc::new(TokioBackgroundExecutor::new()),
     ));
-    let snapshot = Arc::new(Snapshot::builder(location).build(engine.as_ref())?);
+    let snapshot = Arc::new(
+        Snapshot::builder()
+            .with_table_root(location)
+            .build(engine.as_ref())?,
+    );
 
     let predicate = Pred::eq(column_expr!("id"), Expr::literal(2));
     let scan = snapshot
@@ -1119,7 +1135,11 @@ async fn predicate_on_non_nullable_column_missing_stats() -> Result<(), Box<dyn 
         storage.clone(),
         Arc::new(TokioBackgroundExecutor::new()),
     ));
-    let snapshot = Arc::new(Snapshot::builder(location).build(engine.as_ref())?);
+    let snapshot = Arc::new(
+        Snapshot::builder()
+            .with_table_root(location)
+            .build(engine.as_ref())?,
+    );
 
     let predicate = Pred::eq(column_expr!("val"), Expr::literal("g"));
     let scan = snapshot

--- a/kernel/tests/v2_checkpoints.rs
+++ b/kernel/tests/v2_checkpoints.rs
@@ -17,7 +17,10 @@ fn read_v2_checkpoint_table(test_name: impl AsRef<str>) -> DeltaResult<Vec<Recor
     let engine = DefaultEngine::new_local();
     let url =
         delta_kernel::try_parse_uri(test_path.to_str().expect("table path to string")).unwrap();
-    let snapshot = Snapshot::builder(url).build(engine.as_ref()).unwrap();
+    let snapshot = Snapshot::builder()
+        .with_table_root(url)
+        .build(engine.as_ref())
+        .unwrap();
     let scan = snapshot.into_scan_builder().build()?;
     let batches = read_scan(&scan, engine)?;
 

--- a/kernel/tests/write.rs
+++ b/kernel/tests/write.rs
@@ -60,7 +60,11 @@ async fn test_commit_info() -> Result<(), Box<dyn std::error::Error>> {
         setup_test_tables(schema, &[], None, "test_table").await?
     {
         // create a transaction
-        let snapshot = Arc::new(Snapshot::builder(table_url.clone()).build(&engine)?);
+        let snapshot = Arc::new(
+            Snapshot::builder()
+                .with_table_root(table_url.clone())
+                .build(&engine)?,
+        );
         let txn = snapshot.transaction()?.with_engine_info("default engine");
 
         // commit!
@@ -143,7 +147,11 @@ async fn write_data_and_check_result_and_stats(
     engine: Arc<DefaultEngine<TokioBackgroundExecutor>>,
     expected_since_commit: u64,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let snapshot = Arc::new(Snapshot::builder(table_url.clone()).build(engine.as_ref())?);
+    let snapshot = Arc::new(
+        Snapshot::builder()
+            .with_table_root(table_url.clone())
+            .build(engine.as_ref())?,
+    );
     let mut txn = snapshot.transaction()?;
 
     // create two new arrow record batches to append
@@ -213,7 +221,11 @@ async fn test_commit_info_action() -> Result<(), Box<dyn std::error::Error>> {
     for (table_url, engine, store, table_name) in
         setup_test_tables(schema.clone(), &[], None, "test_table").await?
     {
-        let snapshot = Arc::new(Snapshot::builder(table_url.clone()).build(&engine)?);
+        let snapshot = Arc::new(
+            Snapshot::builder()
+                .with_table_root(table_url.clone())
+                .build(&engine)?,
+        );
         let txn = snapshot.transaction()?.with_engine_info("default engine");
 
         txn.commit(&engine)?;
@@ -397,7 +409,11 @@ async fn test_append_partitioned() -> Result<(), Box<dyn std::error::Error>> {
     for (table_url, engine, store, table_name) in
         setup_test_tables(table_schema.clone(), &[partition_col], None, "test_table").await?
     {
-        let snapshot = Arc::new(Snapshot::builder(table_url.clone()).build(&engine)?);
+        let snapshot = Arc::new(
+            Snapshot::builder()
+                .with_table_root(table_url.clone())
+                .build(&engine)?,
+        );
         let mut txn = snapshot.transaction()?.with_engine_info("default engine");
 
         // create two new arrow record batches to append
@@ -540,7 +556,11 @@ async fn test_append_invalid_schema() -> Result<(), Box<dyn std::error::Error>> 
     for (table_url, engine, _store, _table_name) in
         setup_test_tables(table_schema, &[], None, "test_table").await?
     {
-        let snapshot = Arc::new(Snapshot::builder(table_url.clone()).build(&engine)?);
+        let snapshot = Arc::new(
+            Snapshot::builder()
+                .with_table_root(table_url.clone())
+                .build(&engine)?,
+        );
         let txn = snapshot.transaction()?.with_engine_info("default engine");
 
         // create two new arrow record batches to append
@@ -598,7 +618,11 @@ async fn test_write_txn_actions() -> Result<(), Box<dyn std::error::Error>> {
         setup_test_tables(schema, &[], None, "test_table").await?
     {
         // can't have duplicate app_id in same transaction
-        let snapshot = Arc::new(Snapshot::builder(table_url.clone()).build(&engine)?);
+        let snapshot = Arc::new(
+            Snapshot::builder()
+                .with_table_root(table_url.clone())
+                .build(&engine)?,
+        );
         assert!(matches!(
             snapshot
                 .transaction()?
@@ -608,7 +632,11 @@ async fn test_write_txn_actions() -> Result<(), Box<dyn std::error::Error>> {
             Err(KernelError::Generic(msg)) if msg == "app_id app_id1 already exists in transaction"
         ));
 
-        let snapshot = Arc::new(Snapshot::builder(table_url.clone()).build(&engine)?);
+        let snapshot = Arc::new(
+            Snapshot::builder()
+                .with_table_root(table_url.clone())
+                .build(&engine)?,
+        );
         let txn = snapshot
             .transaction()?
             .with_engine_info("default engine")
@@ -619,7 +647,8 @@ async fn test_write_txn_actions() -> Result<(), Box<dyn std::error::Error>> {
         txn.commit(&engine)?;
 
         let snapshot = Arc::new(
-            Snapshot::builder(table_url.clone())
+            Snapshot::builder()
+                .with_table_root(table_url.clone())
                 .at_version(1)
                 .build(&engine)?,
         );
@@ -742,7 +771,11 @@ async fn test_append_timestamp_ntz() -> Result<(), Box<dyn std::error::Error>> {
     )
     .await?;
 
-    let snapshot = Arc::new(Snapshot::builder(table_url.clone()).build(&engine)?);
+    let snapshot = Arc::new(
+        Snapshot::builder()
+            .with_table_root(table_url.clone())
+            .build(&engine)?,
+    );
     let mut txn = snapshot.transaction()?.with_engine_info("default engine");
 
     // Create Arrow data with TIMESTAMP_NTZ values including edge cases
@@ -871,7 +904,11 @@ async fn test_append_variant() -> Result<(), Box<dyn std::error::Error>> {
     )
     .await?;
 
-    let snapshot = Arc::new(Snapshot::builder(table_url.clone()).build(&engine)?);
+    let snapshot = Arc::new(
+        Snapshot::builder()
+            .with_table_root(table_url.clone())
+            .build(&engine)?,
+    );
     let mut txn = snapshot.transaction()?;
 
     // First value corresponds to the variant value "1". Third value corresponds to the variant
@@ -1081,7 +1118,11 @@ async fn test_shredded_variant_read_rejection() -> Result<(), Box<dyn std::error
     )
     .await?;
 
-    let snapshot = Arc::new(Snapshot::builder(table_url.clone()).build(&engine)?);
+    let snapshot = Arc::new(
+        Snapshot::builder()
+            .with_table_root(table_url.clone())
+            .build(&engine)?,
+    );
     let mut txn = snapshot.transaction()?;
 
     // First value corresponds to the variant value "1". Third value corresponds to the variant

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -404,7 +404,9 @@ pub fn test_read(
     url: &Url,
     engine: Arc<dyn Engine>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let snapshot = Snapshot::builder(url.clone()).build(engine.as_ref())?;
+    let snapshot = Snapshot::builder()
+        .with_table_root(url.clone())
+        .build(engine.as_ref())?;
     let scan = snapshot.into_scan_builder().build()?;
     let batches = read_scan(&scan, engine)?;
     let formatted = pretty_format_batches(&batches).unwrap().to_string();


### PR DESCRIPTION
> [!NOTE]
> For reviewers: I see two plausible alternatives, either:
> 1. (this PR) `Snapshot::builder().with_table_root(url)`
> 2. OR `Snapshot::builder(table_root)` and `Snapshot::builder_from(existing_snapshot)`
> 
> The former is simpler from a user perspective, but we have to do runtime checks for making sure you _do_ specify a table_root (or an existing snapshot in the future, or if you specify both they must match).

> [!IMPORTANT]
> This PR is split into two commits: first does material changes, second does callsite updates.

## What changes are proposed in this pull request?
Make `Snapshot::builder()` take no params and instead specify `table_root` in new method `SnapshotBuilder::with_table_root`.

This paves the way for integrating `Snapshot::try_new_from` since we no longer need a table_root if we have access to existing snapshot.

### This PR affects the following public APIs
Migrate `Snapshot::builder(table_root)` to `Snapshot::builder().with_table_root(table_root)`

## How was this change tested?
refactor, existing.