### PR TITLE
refactor!: migrate Snapshot::try_new_from into SnapshotBuilder

### DIFF
--- a/acceptance/src/data.rs
+++ b/acceptance/src/data.rs
@@ -115,8 +115,8 @@ pub async fn assert_scan_metadata(
     test_case: &TestCaseInfo,
 ) -> TestResult<()> {
     let table_root = test_case.table_root()?;
-    let snapshot = Snapshot::builder(table_root).build(engine.as_ref())?;
-    let scan = snapshot.into_scan_builder().build()?;
+    let snapshot = Snapshot::builder_for(table_root).build(engine.as_ref())?;
+    let scan = snapshot.scan_builder().build()?;
     let mut schema = None;
     let batches: Vec<RecordBatch> = scan
         .execute(engine)?

--- a/acceptance/src/meta.rs
+++ b/acceptance/src/meta.rs
@@ -103,11 +103,11 @@ impl TestCaseInfo {
         let engine = engine.as_ref();
         let (latest, versions) = self.versions().await?;
 
-        let snapshot = Snapshot::builder(self.table_root()?).build(engine)?;
+        let snapshot = Snapshot::builder_for(self.table_root()?).build(engine)?;
         self.assert_snapshot_meta(&latest, &snapshot)?;
 
         for table_version in versions {
-            let snapshot = Snapshot::builder(self.table_root()?)
+            let snapshot = Snapshot::builder_for(self.table_root()?)
                 .at_version(table_version.version)
                 .build(engine)?;
             self.assert_snapshot_meta(&table_version, &snapshot)?;

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -601,7 +601,7 @@ fn snapshot_impl(
     extern_engine: &dyn ExternEngine,
     version: Option<Version>,
 ) -> DeltaResult<Handle<SharedSnapshot>> {
-    let builder = Snapshot::builder(url?);
+    let builder = Snapshot::builder_for(url?);
     let builder = if let Some(v) = version {
         // TODO: should we include a `with_version_opt` method for the builder?
         builder.at_version(v)
@@ -609,7 +609,7 @@ fn snapshot_impl(
         builder
     };
     let snapshot = builder.build(extern_engine.engine().as_ref())?;
-    Ok(Arc::new(snapshot).into())
+    Ok(snapshot.into())
 }
 
 /// # Safety

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -9,7 +9,6 @@ use crate::{DeltaResult, ExternEngine, Snapshot, Url};
 use crate::{ExclusiveEngineData, SharedExternEngine};
 use delta_kernel::transaction::{CommitResult, Transaction};
 use delta_kernel_ffi_macros::handle_descriptor;
-use std::sync::Arc;
 
 /// A handle representing an exclusive transaction on a Delta table. (Similar to a Box<_>)
 ///
@@ -38,7 +37,7 @@ fn transaction_impl(
     url: DeltaResult<Url>,
     extern_engine: &dyn ExternEngine,
 ) -> DeltaResult<Handle<ExclusiveTransaction>> {
-    let snapshot = Arc::new(Snapshot::builder(url?).build(extern_engine.engine().as_ref())?);
+    let snapshot = Snapshot::builder_for(url?).build(extern_engine.engine().as_ref())?;
     let transaction = snapshot.transaction();
     Ok(Box::new(transaction?).into())
 }

--- a/kernel/benches/metadata_bench.rs
+++ b/kernel/benches/metadata_bench.rs
@@ -53,7 +53,7 @@ fn create_snapshot_benchmark(c: &mut Criterion) {
 
     c.bench_function("create_snapshot", |b| {
         b.iter(|| {
-            Snapshot::builder(url.clone())
+            Snapshot::builder_for(url.clone())
                 .build(engine.as_ref())
                 .expect("Failed to create snapshot")
         })
@@ -63,11 +63,9 @@ fn create_snapshot_benchmark(c: &mut Criterion) {
 fn scan_metadata_benchmark(c: &mut Criterion) {
     let (_tempdir, url, engine) = setup();
 
-    let snapshot = Arc::new(
-        Snapshot::builder(url.clone())
-            .build(engine.as_ref())
-            .expect("Failed to create snapshot"),
-    );
+    let snapshot = Snapshot::builder_for(url.clone())
+        .build(engine.as_ref())
+        .expect("Failed to create snapshot");
 
     let mut group = c.benchmark_group("scan_metadata");
     group.sample_size(SCAN_METADATA_BENCH_SAMPLE_SIZE);

--- a/kernel/examples/common/src/lib.rs
+++ b/kernel/examples/common/src/lib.rs
@@ -62,7 +62,7 @@ pub fn get_engine(
 
 /// Construct a scan at the latest snapshot. This is over the specified table and using the passed
 /// engine. Parameters of the scan are controlled by the specified `ScanArgs`
-pub fn get_scan(snapshot: Snapshot, args: &ScanArgs) -> DeltaResult<Option<Scan>> {
+pub fn get_scan(snapshot: Arc<Snapshot>, args: &ScanArgs) -> DeltaResult<Option<Scan>> {
     if args.schema_only {
         println!("{:#?}", snapshot.schema());
         return Ok(None);
@@ -86,7 +86,7 @@ pub fn get_scan(snapshot: Snapshot, args: &ScanArgs) -> DeltaResult<Option<Scan>
         .transpose()?;
     Ok(Some(
         snapshot
-            .into_scan_builder()
+            .scan_builder()
             .with_schema_opt(read_schema_opt)
             .build()?,
     ))

--- a/kernel/examples/inspect-table/src/main.rs
+++ b/kernel/examples/inspect-table/src/main.rs
@@ -182,7 +182,7 @@ fn try_main() -> DeltaResult<()> {
 
     let url = delta_kernel::try_parse_uri(&cli.location_args.path)?;
     let engine = common::get_engine(&url, &cli.location_args)?;
-    let snapshot = Snapshot::builder(url).build(&engine)?;
+    let snapshot = Snapshot::builder_for(url).build(&engine)?;
 
     match cli.command {
         Commands::TableVersion => {

--- a/kernel/examples/read-table-multi-threaded/src/main.rs
+++ b/kernel/examples/read-table-multi-threaded/src/main.rs
@@ -99,7 +99,7 @@ fn try_main() -> DeltaResult<()> {
     let url = delta_kernel::try_parse_uri(&cli.location_args.path)?;
     println!("Reading {url}");
     let engine = common::get_engine(&url, &cli.location_args)?;
-    let snapshot = Snapshot::builder(url).build(&engine)?;
+    let snapshot = Snapshot::builder_for(url).build(&engine)?;
     let Some(scan) = common::get_scan(snapshot, &cli.scan_args)? else {
         return Ok(());
     };

--- a/kernel/examples/read-table-single-threaded/src/main.rs
+++ b/kernel/examples/read-table-single-threaded/src/main.rs
@@ -43,7 +43,7 @@ fn try_main() -> DeltaResult<()> {
     let url = delta_kernel::try_parse_uri(&cli.location_args.path)?;
     println!("Reading {url}");
     let engine = common::get_engine(&url, &cli.location_args)?;
-    let snapshot = Snapshot::builder(url).build(&engine)?;
+    let snapshot = Snapshot::builder_for(url).build(&engine)?;
     let Some(scan) = common::get_scan(snapshot, &cli.scan_args)? else {
         return Ok(());
     };

--- a/kernel/src/actions/set_transaction.rs
+++ b/kernel/src/actions/set_transaction.rs
@@ -113,7 +113,7 @@ mod tests {
         let url = url::Url::from_directory_path(path).unwrap();
         let engine = SyncEngine::new();
 
-        let snapshot = Snapshot::builder(url).build(&engine).unwrap();
+        let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
         let log_segment = snapshot.log_segment();
 
         (
@@ -163,7 +163,7 @@ mod tests {
         let url = url::Url::from_directory_path(path.unwrap()).unwrap();
         let engine = SyncEngine::new();
 
-        let snapshot = Snapshot::builder(url).build(&engine).unwrap();
+        let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
         let log_segment = snapshot.log_segment();
 
         // The checkpoint has five parts, each containing one action. There are two app ids.
@@ -180,7 +180,7 @@ mod tests {
         let url = url::Url::from_directory_path(path.unwrap()).unwrap();
         let engine = SyncEngine::new();
 
-        let snapshot = Snapshot::builder(url).build(&engine).unwrap();
+        let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
         let log_segment = snapshot.log_segment();
 
         // Test with no retention (should get all transactions)

--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -47,7 +47,7 @@
 //!
 //! // Create a snapshot for the table at the version you want to checkpoint
 //! let url = delta_kernel::try_parse_uri("./tests/data/app-txn-no-checkpoint")?;
-//! let snapshot = Arc::new(Snapshot::builder(url).build(engine)?);
+//! let snapshot = Snapshot::builder_for(url).build(engine)?;
 //!
 //! // Create a checkpoint writer from the snapshot
 //! let mut writer = snapshot.checkpoint()?;

--- a/kernel/src/checkpoint/tests.rs
+++ b/kernel/src/checkpoint/tests.rs
@@ -72,8 +72,8 @@ fn test_create_checkpoint_metadata_batch() -> DeltaResult<()> {
     )?;
 
     let table_root = Url::parse("memory:///")?;
-    let snapshot = Snapshot::builder(table_root).build(&engine)?;
-    let writer = Arc::new(snapshot).checkpoint()?;
+    let snapshot = Snapshot::builder_for(table_root).build(&engine)?;
+    let writer = snapshot.checkpoint()?;
 
     let checkpoint_batch = writer.create_checkpoint_metadata_batch(&engine)?;
 
@@ -295,7 +295,7 @@ fn test_v1_checkpoint_latest_version_by_default() -> DeltaResult<()> {
     )?;
 
     let table_root = Url::parse("memory:///")?;
-    let snapshot = Arc::new(Snapshot::builder(table_root).build(&engine)?);
+    let snapshot = Snapshot::builder_for(table_root).build(&engine)?;
     let writer = snapshot.checkpoint()?;
 
     // Verify the checkpoint file path is the latest version by default.
@@ -363,7 +363,9 @@ fn test_v1_checkpoint_specific_version() -> DeltaResult<()> {
 
     let table_root = Url::parse("memory:///")?;
     // Specify version 0 for checkpoint
-    let snapshot = Arc::new(Snapshot::builder(table_root).at_version(0).build(&engine)?);
+    let snapshot = Snapshot::builder_for(table_root)
+        .at_version(0)
+        .build(&engine)?;
     let writer = snapshot.checkpoint()?;
 
     // Verify the checkpoint file path is the specified version.
@@ -411,7 +413,9 @@ fn test_finalize_errors_if_checkpoint_data_iterator_is_not_exhausted() -> DeltaR
     )?;
 
     let table_root = Url::parse("memory:///")?;
-    let snapshot = Arc::new(Snapshot::builder(table_root).at_version(0).build(&engine)?);
+    let snapshot = Snapshot::builder_for(table_root)
+        .at_version(0)
+        .build(&engine)?;
     let writer = snapshot.checkpoint()?;
     let data_iter = writer.checkpoint_data(&engine)?;
 
@@ -465,7 +469,7 @@ fn test_v2_checkpoint_supported_table() -> DeltaResult<()> {
     )?;
 
     let table_root = Url::parse("memory:///")?;
-    let snapshot = Arc::new(Snapshot::builder(table_root).build(&engine)?);
+    let snapshot = Snapshot::builder_for(table_root).build(&engine)?;
     let writer = snapshot.checkpoint()?;
 
     // Verify the checkpoint file path is the latest version by default.

--- a/kernel/src/log_compaction/mod.rs
+++ b/kernel/src/log_compaction/mod.rs
@@ -39,7 +39,7 @@
 //! # fn example(engine: &dyn Engine) -> DeltaResult<()> {
 //! // Create a snapshot for the table
 //! let table_root = Url::parse("file:///path/to/table")?;
-//! let snapshot = Arc::new(Snapshot::builder(table_root).build(engine)?);
+//! let snapshot = Snapshot::builder_for(table_root).build(engine)?;
 //!
 //! // Create a log compaction writer for versions 10-20
 //! let mut writer = snapshot.get_log_compaction_writer(10, 20)?;

--- a/kernel/src/log_compaction/tests.rs
+++ b/kernel/src/log_compaction/tests.rs
@@ -12,7 +12,7 @@ fn create_mock_snapshot() -> Arc<Snapshot> {
     .unwrap();
     let url = url::Url::from_directory_path(path).unwrap();
     let engine = SyncEngine::new();
-    Arc::new(Snapshot::builder(url).build(&engine).unwrap())
+    Snapshot::builder_for(url).build(&engine).unwrap()
 }
 
 fn create_multi_version_snapshot() -> Arc<Snapshot> {
@@ -20,7 +20,7 @@ fn create_multi_version_snapshot() -> Arc<Snapshot> {
         std::fs::canonicalize(std::path::PathBuf::from("./tests/data/basic_partitioned/")).unwrap();
     let url = url::Url::from_directory_path(path).unwrap();
     let engine = SyncEngine::new();
-    Arc::new(Snapshot::builder(url).build(&engine).unwrap())
+    Snapshot::builder_for(url).build(&engine).unwrap()
 }
 
 #[test]

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -50,7 +50,7 @@ fn test_replay_for_metadata() {
     let url = url::Url::from_directory_path(path.unwrap()).unwrap();
     let engine = SyncEngine::new();
 
-    let snapshot = Snapshot::builder(url).build(&engine).unwrap();
+    let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
     let data: Vec<_> = snapshot
         .log_segment()
         .replay_for_metadata(&engine)

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -1256,8 +1256,8 @@ mod tests {
         let url = url::Url::from_directory_path(path).unwrap();
         let engine = SyncEngine::new();
 
-        let snapshot = Snapshot::builder(url).build(&engine).unwrap();
-        let scan = snapshot.into_scan_builder().build().unwrap();
+        let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
+        let scan = snapshot.scan_builder().build().unwrap();
         let files = get_files_for_scan(scan, &engine).unwrap();
         assert_eq!(files.len(), 1);
         assert_eq!(
@@ -1273,8 +1273,8 @@ mod tests {
         let url = url::Url::from_directory_path(path).unwrap();
         let engine = Arc::new(SyncEngine::new());
 
-        let snapshot = Snapshot::builder(url).build(engine.as_ref()).unwrap();
-        let scan = snapshot.into_scan_builder().build().unwrap();
+        let snapshot = Snapshot::builder_for(url).build(engine.as_ref()).unwrap();
+        let scan = snapshot.scan_builder().build().unwrap();
         let files: Vec<ScanResult> = scan.execute(engine).unwrap().try_collect().unwrap();
 
         assert_eq!(files.len(), 1);
@@ -1289,9 +1289,9 @@ mod tests {
         let url = url::Url::from_directory_path(path).unwrap();
         let engine = Arc::new(SyncEngine::new());
 
-        let snapshot = Snapshot::builder(url).build(engine.as_ref()).unwrap();
+        let snapshot = Snapshot::builder_for(url).build(engine.as_ref()).unwrap();
         let version = snapshot.version();
-        let scan = snapshot.into_scan_builder().build().unwrap();
+        let scan = snapshot.scan_builder().build().unwrap();
         let files: Vec<_> = scan
             .scan_metadata(engine.as_ref())
             .unwrap()
@@ -1323,11 +1323,11 @@ mod tests {
         let url = url::Url::from_directory_path(path).unwrap();
         let engine = Arc::new(SyncEngine::new());
 
-        let snapshot = Snapshot::builder(url.clone())
+        let snapshot = Snapshot::builder_for(url.clone())
             .at_version(0)
             .build(engine.as_ref())
             .unwrap();
-        let scan = snapshot.into_scan_builder().build().unwrap();
+        let scan = snapshot.scan_builder().build().unwrap();
         let files: Vec<_> = scan
             .scan_metadata(engine.as_ref())
             .unwrap()
@@ -1347,11 +1347,11 @@ mod tests {
             .into_iter()
             .map(|b| Box::new(ArrowEngineData::from(b)) as Box<dyn EngineData>)
             .collect();
-        let snapshot = Snapshot::builder(url)
+        let snapshot = Snapshot::builder_for(url)
             .at_version(1)
             .build(engine.as_ref())
             .unwrap();
-        let scan = snapshot.into_scan_builder().build().unwrap();
+        let scan = snapshot.scan_builder().build().unwrap();
         let new_files: Vec<_> = scan
             .scan_metadata_from(engine.as_ref(), 0, files, None)
             .unwrap()
@@ -1419,8 +1419,8 @@ mod tests {
         let url = url::Url::from_directory_path(path.unwrap()).unwrap();
         let engine = SyncEngine::new();
 
-        let snapshot = Snapshot::builder(url).build(&engine).unwrap();
-        let scan = snapshot.into_scan_builder().build().unwrap();
+        let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
+        let scan = snapshot.scan_builder().build().unwrap();
         let data: Vec<_> = scan
             .replay_for_scan_metadata(&engine)
             .unwrap()
@@ -1439,7 +1439,7 @@ mod tests {
         let url = url::Url::from_directory_path(path.unwrap()).unwrap();
         let engine = Arc::new(SyncEngine::new());
 
-        let snapshot = Arc::new(Snapshot::builder(url).build(engine.as_ref()).unwrap());
+        let snapshot = Snapshot::builder_for(url).build(engine.as_ref()).unwrap();
 
         // No predicate pushdown attempted, so the one data file should be returned.
         //
@@ -1482,7 +1482,7 @@ mod tests {
         let url = url::Url::from_directory_path(path.unwrap()).unwrap();
         let engine = Arc::new(SyncEngine::new());
 
-        let snapshot = Arc::new(Snapshot::builder(url).build(engine.as_ref()).unwrap());
+        let snapshot = Snapshot::builder_for(url).build(engine.as_ref()).unwrap();
 
         // Predicate over a logically valid but physically missing column. No data files should be
         // returned because the column is inferred to be all-null.
@@ -1517,8 +1517,8 @@ mod tests {
         let url = url::Url::from_directory_path(path).unwrap();
         let engine = SyncEngine::new();
 
-        let snapshot = Snapshot::builder(url).build(&engine).unwrap();
-        let scan = snapshot.into_scan_builder().build()?;
+        let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
+        let scan = snapshot.scan_builder().build()?;
         let files = get_files_for_scan(scan, &engine)?;
         // test case:
         //

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -1032,7 +1032,7 @@ mod tests {
         let url = url::Url::from_directory_path(path).unwrap();
 
         let engine = SyncEngine::new();
-        let snapshot = Arc::new(Snapshot::builder(url).build(&engine).unwrap());
+        let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
 
         // Test creating a log compaction writer
         let writer = snapshot.clone().get_log_compaction_writer(0, 1).unwrap();

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -1,7 +1,9 @@
 //! Builder for creating [`Snapshot`] instances.
+use std::sync::Arc;
 
 use crate::log_segment::LogSegment;
-use crate::{DeltaResult, Engine, Snapshot, Version};
+use crate::snapshot::SnapshotRef;
+use crate::{DeltaResult, Engine, Error, Snapshot, Version};
 
 use url::Url;
 
@@ -23,15 +25,30 @@ use url::Url;
 /// # Ok(())
 /// # }
 /// ```
+//
+// Note the SnapshotBuilder must have either a table_root or an existing_snapshot (but not both).
+// We enforce this in the constructors. We could improve this in the future with different
+// types/add type state.
+#[derive(Debug)]
 pub struct SnapshotBuilder {
-    table_root: Url,
+    table_root: Option<Url>,
+    existing_snapshot: Option<SnapshotRef>,
     version: Option<Version>,
 }
 
 impl SnapshotBuilder {
     pub(crate) fn new(table_root: Url) -> Self {
         Self {
-            table_root,
+            table_root: Some(table_root),
+            existing_snapshot: None,
+            version: None,
+        }
+    }
+
+    pub(crate) fn new_from(existing_snapshot: Arc<Snapshot>) -> Self {
+        Self {
+            table_root: None,
+            existing_snapshot: Some(existing_snapshot),
             version: None,
         }
     }
@@ -43,18 +60,29 @@ impl SnapshotBuilder {
         self
     }
 
-    /// Create a new [`Snapshot`] instance.
+    /// Create a new [`Snapshot`]. This returns a [`SnapshotRef`] (`Arc<Snapshot>`), perhaps
+    /// returning a reference to an existing snapshot if the request to build a new snapshot
+    /// matches the version of an existing snapshot.
     ///
     /// # Parameters
     ///
     /// - `engine`: Implementation of [`Engine`] apis.
-    pub fn build(self, engine: &dyn Engine) -> DeltaResult<Snapshot> {
-        let log_segment = LogSegment::for_snapshot(
-            engine.storage_handler().as_ref(),
-            self.table_root.join("_delta_log/")?,
-            self.version,
-        )?;
-        Snapshot::try_new_from_log_segment(self.table_root, log_segment, engine)
+    pub fn build(self, engine: &dyn Engine) -> DeltaResult<Arc<Snapshot>> {
+        if let Some(table_root) = self.table_root {
+            let log_segment = LogSegment::for_snapshot(
+                engine.storage_handler().as_ref(),
+                table_root.join("_delta_log/")?,
+                self.version,
+            )?;
+            Ok(Snapshot::try_new_from_log_segment(table_root, log_segment, engine)?.into())
+        } else {
+            let existing_snapshot = self.existing_snapshot.ok_or_else(|| {
+                Error::internal_error(
+                    "SnapshotBuilder should have either table_root or existing_snapshot",
+                )
+            })?;
+            Snapshot::try_new_from(existing_snapshot, engine, self.version)
+        }
     }
 }
 

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -18,7 +18,7 @@ use url::Url;
 /// let table_root = Url::parse("file:///path/to/table")?;
 ///
 /// // Build a snapshot
-/// let snapshot = Snapshot::builder(table_root.clone())
+/// let snapshot = Snapshot::builder_for(table_root.clone())
 ///     .at_version(5) // Optional: specify a time-travel version (default is latest version)
 ///     .build(engine)?;
 ///

--- a/kernel/src/table_changes/mod.rs
+++ b/kernel/src/table_changes/mod.rs
@@ -150,12 +150,15 @@ impl TableChanges {
         // Both snapshots ensure that reading is supported at the start and end version using
         // `ensure_read_supported`. Note that we must still verify that reading is
         // supported for every protocol action in the CDF range.
-        let start_snapshot = Arc::new(
-            Snapshot::builder(table_root.as_url().clone())
-                .at_version(start_version)
+        let start_snapshot = Snapshot::builder_for(table_root.as_url().clone())
+            .at_version(start_version)
+            .build(engine)?;
+        let end_snapshot = match end_version {
+            Some(version) => Snapshot::builder_from(start_snapshot.clone())
+                .at_version(version)
                 .build(engine)?,
-        );
-        let end_snapshot = Snapshot::try_new_from(start_snapshot.clone(), engine, end_version)?;
+            None => Snapshot::builder_from(start_snapshot.clone()).build(engine)?,
+        };
 
         // Verify CDF is enabled at the beginning and end of the interval using
         // [`check_cdf_table_properties`] to fail early. This also ensures that column mapping is

--- a/kernel/tests/dv.rs
+++ b/kernel/tests/dv.rs
@@ -32,8 +32,8 @@ fn dv_table() -> Result<(), Box<dyn std::error::Error>> {
     let url = url::Url::from_directory_path(path).unwrap();
     let engine = DefaultEngine::new_local();
 
-    let snapshot = Snapshot::builder(url).build(engine.as_ref())?;
-    let scan = snapshot.into_scan_builder().build()?;
+    let snapshot = Snapshot::builder_for(url).build(engine.as_ref())?;
+    let scan = snapshot.scan_builder().build()?;
 
     let stream = scan.execute(engine)?;
     let total_rows = count_total_scan_rows(stream)?;
@@ -47,8 +47,8 @@ fn non_dv_table() -> Result<(), Box<dyn std::error::Error>> {
     let url = url::Url::from_directory_path(path).unwrap();
     let engine = DefaultEngine::new_local();
 
-    let snapshot = Snapshot::builder(url).build(engine.as_ref())?;
-    let scan = snapshot.into_scan_builder().build()?;
+    let snapshot = Snapshot::builder_for(url).build(engine.as_ref())?;
+    let scan = snapshot.scan_builder().build()?;
 
     let stream = scan.execute(engine)?;
     let total_rows = count_total_scan_rows(stream)?;

--- a/kernel/tests/golden_tables.rs
+++ b/kernel/tests/golden_tables.rs
@@ -168,8 +168,8 @@ async fn latest_snapshot_test(
     url: Url,
     expected_path: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let snapshot = Snapshot::builder(url).build(&engine)?;
-    let scan = snapshot.into_scan_builder().build()?;
+    let snapshot = Snapshot::builder_for(url).build(&engine)?;
+    let scan = snapshot.scan_builder().build()?;
     let scan_res = scan.execute(Arc::new(engine))?;
     let batches: Vec<RecordBatch> = scan_res
         .map(|scan_result| -> DeltaResult<_> {
@@ -271,12 +271,9 @@ async fn canonicalized_paths_test(
     _expected: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // assert latest version is 1 and there are no files in the snapshot (add is removed)
-    let snapshot = Snapshot::builder(table_root).build(&engine).unwrap();
+    let snapshot = Snapshot::builder_for(table_root).build(&engine).unwrap();
     assert_eq!(snapshot.version(), 1);
-    let scan = snapshot
-        .into_scan_builder()
-        .build()
-        .expect("build the scan");
+    let scan = snapshot.scan_builder().build().expect("build the scan");
     let mut scan_metadata = scan.scan_metadata(&engine).expect("scan metadata");
     assert!(scan_metadata.next().is_none());
     Ok(())
@@ -287,12 +284,9 @@ async fn checkpoint_test(
     table_root: Url,
     _expected: Option<PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let snapshot = Snapshot::builder(table_root).build(&engine).unwrap();
+    let snapshot = Snapshot::builder_for(table_root).build(&engine).unwrap();
     let version = snapshot.version();
-    let scan = snapshot
-        .into_scan_builder()
-        .build()
-        .expect("build the scan");
+    let scan = snapshot.scan_builder().build().expect("build the scan");
     let scan_metadata: Vec<_> = scan
         .scan_metadata(&engine)
         .expect("scan metadata")

--- a/kernel/tests/hdfs.rs
+++ b/kernel/tests/hdfs.rs
@@ -73,7 +73,7 @@ async fn read_table_version_hdfs() -> Result<(), Box<dyn std::error::Error>> {
         Arc::new(TokioBackgroundExecutor::new()),
     )?;
 
-    let snapshot = Snapshot::builder(url).build(&engine)?;
+    let snapshot = Snapshot::builder_for(url).build(&engine)?;
     assert_eq!(snapshot.version(), 1);
 
     Ok(())

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -66,8 +66,8 @@ async fn single_commit_two_add_files() -> Result<(), Box<dyn std::error::Error>>
 
     let expected_data = vec![batch.clone(), batch];
 
-    let snapshot = Snapshot::builder(location).build(engine.as_ref())?;
-    let scan = snapshot.into_scan_builder().build()?;
+    let snapshot = Snapshot::builder_for(location).build(engine.as_ref())?;
+    let scan = snapshot.scan_builder().build()?;
 
     let mut files = 0;
     let stream = scan.execute(engine)?.zip(expected_data);
@@ -118,8 +118,8 @@ async fn two_commits() -> Result<(), Box<dyn std::error::Error>> {
 
     let expected_data = vec![batch.clone(), batch];
 
-    let snapshot = Snapshot::builder(location).build(&engine)?;
-    let scan = snapshot.into_scan_builder().build()?;
+    let snapshot = Snapshot::builder_for(location).build(&engine)?;
+    let scan = snapshot.scan_builder().build()?;
 
     let mut files = 0;
     let stream = scan.execute(Arc::new(engine))?.zip(expected_data);
@@ -171,8 +171,8 @@ async fn remove_action() -> Result<(), Box<dyn std::error::Error>> {
 
     let expected_data = vec![batch];
 
-    let snapshot = Snapshot::builder(location).build(&engine)?;
-    let scan = snapshot.into_scan_builder().build()?;
+    let snapshot = Snapshot::builder_for(location).build(&engine)?;
+    let scan = snapshot.scan_builder().build()?;
 
     let stream = scan.execute(Arc::new(engine))?.zip(expected_data);
 
@@ -242,7 +242,7 @@ async fn stats() -> Result<(), Box<dyn std::error::Error>> {
         storage.clone(),
         Arc::new(TokioBackgroundExecutor::new()),
     ));
-    let snapshot = Arc::new(Snapshot::builder(location).build(engine.as_ref())?);
+    let snapshot = Snapshot::builder_for(location).build(engine.as_ref())?;
 
     // The first file has id between 1 and 3; the second has id between 5 and 7. For each operator,
     // we validate the boundary values where we expect the set of matched files to change.
@@ -433,7 +433,7 @@ fn read_table_data(
         Arc::new(TokioBackgroundExecutor::new()),
     )?);
 
-    let snapshot = Snapshot::builder(url.clone()).build(engine.as_ref())?;
+    let snapshot = Snapshot::builder_for(url.clone()).build(engine.as_ref())?;
 
     let read_schema = select_cols.map(|select_cols| {
         let table_schema = snapshot.schema();
@@ -444,7 +444,7 @@ fn read_table_data(
     });
     println!("Read {url:?} with schema {read_schema:#?} and predicate {predicate:#?}");
     let scan = snapshot
-        .into_scan_builder()
+        .scan_builder()
         .with_schema_opt(read_schema)
         .with_predicate(predicate.clone())
         .build()?;
@@ -1057,7 +1057,7 @@ async fn predicate_on_non_nullable_partition_column() -> Result<(), Box<dyn std:
         storage.clone(),
         Arc::new(TokioBackgroundExecutor::new()),
     ));
-    let snapshot = Arc::new(Snapshot::builder(location).build(engine.as_ref())?);
+    let snapshot = Snapshot::builder_for(location).build(engine.as_ref())?;
 
     let predicate = Pred::eq(column_expr!("id"), Expr::literal(2));
     let scan = snapshot
@@ -1119,7 +1119,7 @@ async fn predicate_on_non_nullable_column_missing_stats() -> Result<(), Box<dyn 
         storage.clone(),
         Arc::new(TokioBackgroundExecutor::new()),
     ));
-    let snapshot = Arc::new(Snapshot::builder(location).build(engine.as_ref())?);
+    let snapshot = Snapshot::builder_for(location).build(engine.as_ref())?;
 
     let predicate = Pred::eq(column_expr!("val"), Expr::literal("g"));
     let scan = snapshot

--- a/kernel/tests/row_tracking.rs
+++ b/kernel/tests/row_tracking.rs
@@ -56,7 +56,7 @@ async fn write_data_to_table(
     engine: Arc<DefaultEngine<TokioBackgroundExecutor>>,
     data: Vec<ArrowEngineData>,
 ) -> DeltaResult<CommitResult> {
-    let snapshot = Arc::new(Snapshot::builder(table_url.clone()).build(engine.as_ref())?);
+    let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
     let mut txn = snapshot.transaction()?;
 
     // Write data out by spawning async tasks to simulate executors
@@ -553,8 +553,8 @@ async fn test_row_tracking_with_empty_adds() -> DeltaResult<()> {
     .await?;
 
     // Verify that the table is empty
-    let snapshot = Snapshot::builder(table_url).build(engine.as_ref())?;
-    let scan = snapshot.into_scan_builder().build()?;
+    let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+    let scan = snapshot.scan_builder().build()?;
     let batches = read_scan(&scan, engine)?;
 
     assert!(batches.is_empty(), "Table should be empty");
@@ -575,7 +575,7 @@ async fn test_row_tracking_without_adds() -> DeltaResult<()> {
     let (table_url, engine, store) =
         create_row_tracking_table(&tmp_test_dir, "test_consecutive_commits", schema.clone())
             .await?;
-    let snapshot = Arc::new(Snapshot::builder(table_url.clone()).build(engine.as_ref())?);
+    let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
     let txn = snapshot.transaction()?;
 
     // Commit without adding any add files
@@ -615,8 +615,8 @@ async fn test_row_tracking_parallel_transactions_conflict() -> DeltaResult<()> {
     let engine2 = engine;
 
     // Create two snapshots from the same initial state
-    let snapshot1 = Arc::new(Snapshot::builder(table_url.clone()).build(engine1.as_ref())?);
-    let snapshot2 = Arc::new(Snapshot::builder(table_url.clone()).build(engine2.as_ref())?);
+    let snapshot1 = Snapshot::builder_for(table_url.clone()).build(engine1.as_ref())?;
+    let snapshot2 = Snapshot::builder_for(table_url.clone()).build(engine2.as_ref())?;
 
     // Create two transactions from the same snapshot (simulating parallel transactions)
     let mut txn1 = snapshot1.transaction()?.with_engine_info("transaction 1");

--- a/kernel/tests/v2_checkpoints.rs
+++ b/kernel/tests/v2_checkpoints.rs
@@ -17,8 +17,8 @@ fn read_v2_checkpoint_table(test_name: impl AsRef<str>) -> DeltaResult<Vec<Recor
     let engine = DefaultEngine::new_local();
     let url =
         delta_kernel::try_parse_uri(test_path.to_str().expect("table path to string")).unwrap();
-    let snapshot = Snapshot::builder(url).build(engine.as_ref()).unwrap();
-    let scan = snapshot.into_scan_builder().build()?;
+    let snapshot = Snapshot::builder_for(url).build(engine.as_ref()).unwrap();
+    let scan = snapshot.scan_builder().build()?;
     let batches = read_scan(&scan, engine)?;
 
     Ok(batches)

--- a/kernel/tests/write.rs
+++ b/kernel/tests/write.rs
@@ -60,7 +60,7 @@ async fn test_commit_info() -> Result<(), Box<dyn std::error::Error>> {
         setup_test_tables(schema, &[], None, "test_table").await?
     {
         // create a transaction
-        let snapshot = Arc::new(Snapshot::builder(table_url.clone()).build(&engine)?);
+        let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
         let txn = snapshot.transaction()?.with_engine_info("default engine");
 
         // commit!
@@ -143,7 +143,7 @@ async fn write_data_and_check_result_and_stats(
     engine: Arc<DefaultEngine<TokioBackgroundExecutor>>,
     expected_since_commit: u64,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let snapshot = Arc::new(Snapshot::builder(table_url.clone()).build(engine.as_ref())?);
+    let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
     let mut txn = snapshot.transaction()?;
 
     // create two new arrow record batches to append
@@ -213,7 +213,7 @@ async fn test_commit_info_action() -> Result<(), Box<dyn std::error::Error>> {
     for (table_url, engine, store, table_name) in
         setup_test_tables(schema.clone(), &[], None, "test_table").await?
     {
-        let snapshot = Arc::new(Snapshot::builder(table_url.clone()).build(&engine)?);
+        let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
         let txn = snapshot.transaction()?.with_engine_info("default engine");
 
         txn.commit(&engine)?;
@@ -397,7 +397,7 @@ async fn test_append_partitioned() -> Result<(), Box<dyn std::error::Error>> {
     for (table_url, engine, store, table_name) in
         setup_test_tables(table_schema.clone(), &[partition_col], None, "test_table").await?
     {
-        let snapshot = Arc::new(Snapshot::builder(table_url.clone()).build(&engine)?);
+        let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
         let mut txn = snapshot.transaction()?.with_engine_info("default engine");
 
         // create two new arrow record batches to append
@@ -540,7 +540,7 @@ async fn test_append_invalid_schema() -> Result<(), Box<dyn std::error::Error>> 
     for (table_url, engine, _store, _table_name) in
         setup_test_tables(table_schema, &[], None, "test_table").await?
     {
-        let snapshot = Arc::new(Snapshot::builder(table_url.clone()).build(&engine)?);
+        let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
         let txn = snapshot.transaction()?.with_engine_info("default engine");
 
         // create two new arrow record batches to append
@@ -598,7 +598,7 @@ async fn test_write_txn_actions() -> Result<(), Box<dyn std::error::Error>> {
         setup_test_tables(schema, &[], None, "test_table").await?
     {
         // can't have duplicate app_id in same transaction
-        let snapshot = Arc::new(Snapshot::builder(table_url.clone()).build(&engine)?);
+        let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
         assert!(matches!(
             snapshot
                 .transaction()?
@@ -608,7 +608,7 @@ async fn test_write_txn_actions() -> Result<(), Box<dyn std::error::Error>> {
             Err(KernelError::Generic(msg)) if msg == "app_id app_id1 already exists in transaction"
         ));
 
-        let snapshot = Arc::new(Snapshot::builder(table_url.clone()).build(&engine)?);
+        let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
         let txn = snapshot
             .transaction()?
             .with_engine_info("default engine")
@@ -618,11 +618,9 @@ async fn test_write_txn_actions() -> Result<(), Box<dyn std::error::Error>> {
         // commit!
         txn.commit(&engine)?;
 
-        let snapshot = Arc::new(
-            Snapshot::builder(table_url.clone())
-                .at_version(1)
-                .build(&engine)?,
-        );
+        let snapshot = Snapshot::builder_for(table_url.clone())
+            .at_version(1)
+            .build(&engine)?;
         assert_eq!(
             snapshot.clone().get_app_id_version("app_id1", &engine)?,
             Some(1)
@@ -631,7 +629,10 @@ async fn test_write_txn_actions() -> Result<(), Box<dyn std::error::Error>> {
             snapshot.clone().get_app_id_version("app_id2", &engine)?,
             Some(2)
         );
-        assert_eq!(snapshot.get_app_id_version("app_id3", &engine)?, None);
+        assert_eq!(
+            snapshot.clone().get_app_id_version("app_id3", &engine)?,
+            None
+        );
 
         let commit1 = store
             .get(&Path::from(format!(
@@ -741,7 +742,7 @@ async fn test_append_timestamp_ntz() -> Result<(), Box<dyn std::error::Error>> {
     )
     .await?;
 
-    let snapshot = Arc::new(Snapshot::builder(table_url.clone()).build(&engine)?);
+    let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
     let mut txn = snapshot.transaction()?.with_engine_info("default engine");
 
     // Create Arrow data with TIMESTAMP_NTZ values including edge cases
@@ -875,7 +876,7 @@ async fn test_append_variant() -> Result<(), Box<dyn std::error::Error>> {
     )
     .await?;
 
-    let snapshot = Arc::new(Snapshot::builder(table_url.clone()).build(&engine)?);
+    let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
     let mut txn = snapshot.transaction()?;
 
     // First value corresponds to the variant value "1". Third value corresponds to the variant
@@ -1084,7 +1085,7 @@ async fn test_shredded_variant_read_rejection() -> Result<(), Box<dyn std::error
     )
     .await?;
 
-    let snapshot = Arc::new(Snapshot::builder(table_url.clone()).build(&engine)?);
+    let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
     let mut txn = snapshot.transaction()?;
 
     // First value corresponds to the variant value "1". Third value corresponds to the variant

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -396,8 +396,8 @@ pub fn test_read(
     url: &Url,
     engine: Arc<dyn Engine>,
 ) -> DeltaResult<()> {
-    let snapshot = Snapshot::builder(url.clone()).build(engine.as_ref())?;
-    let scan = snapshot.into_scan_builder().build()?;
+    let snapshot = Snapshot::builder_for(url.clone()).build(engine.as_ref())?;
+    let scan = snapshot.scan_builder().build()?;
     let batches = read_scan(&scan, engine)?;
     let formatted = pretty_format_batches(&batches).unwrap().to_string();
 


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is split into two commits: (1) material changes, and (2) callsite updates

## What changes are proposed in this pull request?
This PR integrates `Snapshot::try_new_from` into `SnapshotBuilder`. We move `Snapshot::try_new_from` into `Snapshot::builder_from` and modify `SnapshotBuilder` to return an `Arc<Snapshot>` instead of a `Snapshot`.

Also, `Snapshot::builder(table_root)` is renamed to `Snapshot::builder_for(table_root)`

### This PR affects the following public APIs
1. Replaces `Snapshot::try_new_from(existing)` with `Snapshot::build_from(existing).build()`
2. `SnapshotBuilder::build()` now returns an `Arc<Snapshot>` instead of a `Snapshot`
3. Renames `Snapshot::builder` to `Snapshot::builder_for`


## How was this change tested?
refactor, updated tests