### PR TITLE
feat!(catalog-managed): add `log_tail` to `SnapshotBuilder`

### DIFF
--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -1443,6 +1443,26 @@ mod tests {
     }
 
     #[test]
+    fn test_no_catalog_managed_writes() {
+        let protocol = Protocol::try_new(
+            3,
+            7,
+            Some([ReaderFeature::CatalogManaged]),
+            Some([WriterFeature::CatalogManaged]),
+        )
+        .unwrap();
+        assert!(protocol.ensure_write_supported().is_err());
+        let protocol = Protocol::try_new(
+            3,
+            7,
+            Some([ReaderFeature::CatalogOwnedPreview]),
+            Some([WriterFeature::CatalogOwnedPreview]),
+        )
+        .unwrap();
+        assert!(protocol.ensure_write_supported().is_err());
+    }
+
+    #[test]
     fn test_into_engine_data() {
         let engine = ExprEngine::new();
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -82,6 +82,8 @@ use std::{cmp::Ordering, ops::Range};
 use bytes::Bytes;
 use url::Url;
 
+use crate::path::ParsedLogPath;
+
 use self::schema::{DataType, SchemaRef};
 
 mod action_reconciliation;
@@ -91,6 +93,7 @@ pub mod engine_data;
 pub mod error;
 pub mod expressions;
 mod log_compaction;
+mod log_path;
 pub mod scan;
 pub mod schema;
 pub mod snapshot;
@@ -100,6 +103,8 @@ pub mod table_features;
 pub mod table_properties;
 pub mod transaction;
 pub(crate) mod transforms;
+
+pub use log_path::LogPath;
 
 mod row_tracking;
 

--- a/kernel/src/listed_log_files.rs
+++ b/kernel/src/listed_log_files.rs
@@ -245,11 +245,10 @@ impl ListedLogFiles {
     pub(crate) fn list(
         storage: &dyn StorageHandler,
         log_root: &Url,
+        log_tail: Vec<ParsedLogPath>,
         start_version: Option<Version>,
         end_version: Option<Version>,
     ) -> DeltaResult<Self> {
-        // TODO: plumb through a log_tail provided by our caller
-        let log_tail = vec![];
         let log_files = list_log_files(storage, log_root, log_tail, start_version, end_version)?;
 
         log_files.process_results(|iter| {
@@ -318,11 +317,13 @@ impl ListedLogFiles {
         checkpoint_metadata: &LastCheckpointHint,
         storage: &dyn StorageHandler,
         log_root: &Url,
+        log_tail: Vec<ParsedLogPath>,
         end_version: Option<Version>,
     ) -> DeltaResult<Self> {
         let listed_files = Self::list(
             storage,
             log_root,
+            log_tail,
             Some(checkpoint_metadata.version),
             end_version,
         )?;

--- a/kernel/src/log_path.rs
+++ b/kernel/src/log_path.rs
@@ -1,0 +1,119 @@
+//! Public-facing [`LogPath`] type for representing paths to delta log files.
+
+use crate::path::ParsedLogPath;
+use crate::utils::require;
+use crate::{DeltaResult, Error, FileMeta, FileSize};
+
+use url::Url;
+
+/// A path to a valid delta log file. You can parse a given `FileMeta` into a `LogPath` using
+/// [`LogPath::try_new`].
+///
+/// Today, a `LogPath` is a file in the `_delta_log` directory of a Delta table; in the future,
+/// this will expand to support providing inline data in the log path itself.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LogPath(ParsedLogPath);
+
+impl From<LogPath> for ParsedLogPath {
+    fn from(p: LogPath) -> Self {
+        p.0
+    }
+}
+
+impl LogPath {
+    /// Attempt to create a `LogPath` from `FileMeta`. This returns an error if the path isn't a
+    /// valid log path.
+    pub fn try_new(file_meta: FileMeta) -> DeltaResult<Self> {
+        // TODO: we should avoid the clone
+        let parsed = ParsedLogPath::try_from(file_meta.clone())?
+            .ok_or_else(|| Error::invalid_log_path(&file_meta.location))?;
+
+        require!(
+            !parsed.is_unknown(),
+            Error::invalid_log_path(&file_meta.location)
+        );
+
+        Ok(Self(parsed))
+    }
+
+    /// Create a new staged commit log path given the table root and filename and metadata.
+    pub fn staged_commit(
+        table_root: Url,
+        filename: &str,
+        last_modified: i64,
+        size: FileSize,
+    ) -> DeltaResult<LogPath> {
+        // TODO: we should introduce TablePath/LogPath types which enforce checks like ending '/'
+
+        // require table_root ends with '/'
+        require!(
+            table_root.path().ends_with('/'),
+            Error::generic("table root must be a directory-like URL ending with '/'")
+        );
+        let location = table_root
+            .join("_delta_log/")?
+            .join("_staged_commits/")?
+            .join(filename)?;
+        let file_meta = FileMeta {
+            location,
+            last_modified,
+            size,
+        };
+        LogPath::try_new(file_meta)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use std::str::FromStr;
+
+    #[test]
+    fn test_staged_commit_path_creation() {
+        let table_root = Url::from_str("s3://my-bucket/my-table/").unwrap();
+        let filename = "00000000000000000010.3a0d65cd-4a56-49a8-937b-95f9e3ee90e5.json";
+        let last_modified = 1234567890i64;
+        let size = 1024u64;
+
+        let log_path = LogPath::staged_commit(table_root.clone(), filename, last_modified, size)
+            .expect("Failed to create staged commit log path");
+
+        let expected_path =
+            Url::from_str("s3://my-bucket/my-table/_delta_log/_staged_commits/00000000000000000010.3a0d65cd-4a56-49a8-937b-95f9e3ee90e5.json")
+                .unwrap();
+        let expected = FileMeta {
+            location: expected_path,
+            last_modified,
+            size,
+        };
+
+        let path = log_path.0;
+        assert_eq!(path.location, expected);
+    }
+
+    #[test]
+    fn test_staged_commit_path_creation_failures() {
+        let last_modified = 1234567890i64;
+        let size = 1024u64;
+
+        // table root not ending with '/'
+        let table_root = Url::from_str("s3://my-bucket/my-table").unwrap();
+        let filename = "00000000000000000010.3a0d65cd-4a56-49a8-937b-95f9e3ee90e5.json";
+        LogPath::staged_commit(table_root.clone(), filename, last_modified, size).unwrap_err();
+
+        // filename with path separators
+        let table_root = Url::from_str("s3://my-bucket/my-table/").unwrap();
+        let filename = "subdir/00000000000000000010.3a0d65cd-4a56-49a8-937b-95f9e3ee90e5.json";
+        LogPath::staged_commit(table_root.clone(), filename, last_modified, size).unwrap_err();
+
+        // incorrect filenames
+        let table_root = Url::from_str("s3://my-bucket/my-table/").unwrap();
+        let filename = "00000000000000000010.not-a-uuid.json";
+        LogPath::staged_commit(table_root.clone(), filename, last_modified, size).unwrap_err();
+        let filename = "000000000000000000aa.3a0d65cd-4a56-49a8-937b-95f9e3ee90e5.json";
+        LogPath::staged_commit(table_root.clone(), filename, last_modified, size).unwrap_err();
+        let filename = "00000000000000000010.3a0d65cd-4a56-49a8-937b-95f9e3ee90e5.parquet";
+        LogPath::staged_commit(table_root.clone(), filename, last_modified, size).unwrap_err();
+    }
+}

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -225,8 +225,14 @@ fn build_snapshot_with_uuid_checkpoint_parquet() {
         None,
     );
 
-    let log_segment =
-        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, None, None).unwrap();
+    let log_segment = LogSegment::for_snapshot_impl(
+        storage.as_ref(),
+        log_root,
+        vec![], // log_tail
+        None,
+        None,
+    )
+    .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -255,8 +261,14 @@ fn build_snapshot_with_uuid_checkpoint_json() {
         None,
     );
 
-    let log_segment =
-        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, None, None).unwrap();
+    let log_segment = LogSegment::for_snapshot_impl(
+        storage.as_ref(),
+        log_root,
+        vec![], // log_tail
+        None,
+        None,
+    )
+    .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -297,9 +309,14 @@ fn build_snapshot_with_correct_last_uuid_checkpoint() {
         Some(&checkpoint_metadata),
     );
 
-    let log_segment =
-        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, Some(checkpoint_metadata), None)
-            .unwrap();
+    let log_segment = LogSegment::for_snapshot_impl(
+        storage.as_ref(),
+        log_root,
+        vec![], // log_tail
+        Some(checkpoint_metadata),
+        None,
+    )
+    .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -335,8 +352,14 @@ fn build_snapshot_with_multiple_incomplete_multipart_checkpoints() {
         None,
     );
 
-    let log_segment =
-        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, None, None).unwrap();
+    let log_segment = LogSegment::for_snapshot_impl(
+        storage.as_ref(),
+        log_root,
+        vec![], // log_tail
+        None,
+        None,
+    )
+    .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -374,9 +397,14 @@ fn build_snapshot_with_out_of_date_last_checkpoint() {
         Some(&checkpoint_metadata),
     );
 
-    let log_segment =
-        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, Some(checkpoint_metadata), None)
-            .unwrap();
+    let log_segment = LogSegment::for_snapshot_impl(
+        storage.as_ref(),
+        log_root,
+        vec![], // log_tail
+        Some(checkpoint_metadata),
+        None,
+    )
+    .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -417,9 +445,14 @@ fn build_snapshot_with_correct_last_multipart_checkpoint() {
         Some(&checkpoint_metadata),
     );
 
-    let log_segment =
-        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, Some(checkpoint_metadata), None)
-            .unwrap();
+    let log_segment = LogSegment::for_snapshot_impl(
+        storage.as_ref(),
+        log_root,
+        vec![], // log_tail
+        Some(checkpoint_metadata),
+        None,
+    )
+    .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -461,8 +494,13 @@ fn build_snapshot_with_missing_checkpoint_part_from_hint_fails() {
         Some(&checkpoint_metadata),
     );
 
-    let log_segment =
-        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, Some(checkpoint_metadata), None);
+    let log_segment = LogSegment::for_snapshot_impl(
+        storage.as_ref(),
+        log_root,
+        vec![], // log_tail
+        Some(checkpoint_metadata),
+        None,
+    );
     assert_result_error_with_message(
         log_segment,
         "Invalid Checkpoint: Had a _last_checkpoint hint but didn't find any checkpoints",
@@ -498,8 +536,13 @@ fn build_snapshot_with_bad_checkpoint_hint_fails() {
         Some(&checkpoint_metadata),
     );
 
-    let log_segment =
-        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, Some(checkpoint_metadata), None);
+    let log_segment = LogSegment::for_snapshot_impl(
+        storage.as_ref(),
+        log_root,
+        vec![], // log_tail
+        Some(checkpoint_metadata),
+        None,
+    );
     assert_result_error_with_message(
         log_segment,
         "Invalid Checkpoint: _last_checkpoint indicated that checkpoint should have 1 parts, but \
@@ -530,8 +573,14 @@ fn build_snapshot_with_missing_checkpoint_part_no_hint() {
         None,
     );
 
-    let log_segment =
-        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, None, None).unwrap();
+    let log_segment = LogSegment::for_snapshot_impl(
+        storage.as_ref(),
+        log_root,
+        vec![], // log_tail
+        None,
+        None,
+    )
+    .unwrap();
 
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
@@ -576,9 +625,14 @@ fn build_snapshot_with_out_of_date_last_checkpoint_and_incomplete_recent_checkpo
         Some(&checkpoint_metadata),
     );
 
-    let log_segment =
-        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, Some(checkpoint_metadata), None)
-            .unwrap();
+    let log_segment = LogSegment::for_snapshot_impl(
+        storage.as_ref(),
+        log_root,
+        vec![], // log_tail
+        Some(checkpoint_metadata),
+        None,
+    )
+    .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -610,8 +664,14 @@ fn build_snapshot_without_checkpoints() {
     );
 
     ///////// Specify no checkpoint or end version /////////
-    let log_segment =
-        LogSegment::for_snapshot_impl(storage.as_ref(), log_root.clone(), None, None).unwrap();
+    let log_segment = LogSegment::for_snapshot_impl(
+        storage.as_ref(),
+        log_root.clone(),
+        vec![], // log_tail
+        None,
+        None,
+    )
+    .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -624,8 +684,14 @@ fn build_snapshot_without_checkpoints() {
     assert_eq!(versions, expected_versions);
 
     ///////// Specify  only end version /////////
-    let log_segment =
-        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, None, Some(2)).unwrap();
+    let log_segment = LogSegment::for_snapshot_impl(
+        storage.as_ref(),
+        log_root,
+        vec![], // log_tail
+        None,
+        Some(2),
+    )
+    .unwrap();
     let commit_files = log_segment.ascending_commit_files;
     let checkpoint_parts = log_segment.checkpoint_parts;
 
@@ -669,6 +735,7 @@ fn build_snapshot_with_checkpoint_greater_than_time_travel_version() {
     let log_segment = LogSegment::for_snapshot_impl(
         storage.as_ref(),
         log_root,
+        vec![], // log_tail
         Some(checkpoint_metadata),
         Some(4),
     )
@@ -712,6 +779,7 @@ fn build_snapshot_with_start_checkpoint_and_time_travel_version() {
     let log_segment = LogSegment::for_snapshot_impl(
         storage.as_ref(),
         log_root,
+        vec![], // log_tail
         Some(checkpoint_metadata),
         Some(4),
     )
@@ -1371,8 +1439,14 @@ fn create_segment_for(
         ));
     }
     let (storage, log_root) = build_log_with_paths_and_checkpoint(&paths, None);
-    LogSegment::for_snapshot_impl(storage.as_ref(), log_root.clone(), None, version_to_load)
-        .unwrap()
+    LogSegment::for_snapshot_impl(
+        storage.as_ref(),
+        log_root.clone(),
+        vec![], // log_tail
+        None,
+        version_to_load,
+    )
+    .unwrap()
 }
 
 #[test]
@@ -1387,7 +1461,13 @@ fn test_list_log_files_with_version() -> DeltaResult<()> {
         ],
         None,
     );
-    let result = ListedLogFiles::list(storage.as_ref(), &log_root, Some(0), None)?;
+    let result = ListedLogFiles::list(
+        storage.as_ref(),
+        &log_root,
+        vec![], // log_tail
+        Some(0),
+        None,
+    )?;
     let latest_crc = result.latest_crc_file.unwrap();
     assert_eq!(
         latest_crc.location.location.path(),

--- a/kernel/src/table_changes/mod.rs
+++ b/kernel/src/table_changes/mod.rs
@@ -160,6 +160,17 @@ impl TableChanges {
             None => Snapshot::builder_from(start_snapshot.clone()).build(engine)?,
         };
 
+        // we block reading catalog-managed tables with CDF for now. note this is best-effort just
+        // checking that start/end snapshots are not catalog-managed.
+        //
+        // TODO: link issue
+        #[cfg(feature = "catalog-managed")]
+        require!(
+            !start_snapshot.protocol().is_catalog_managed()
+                && !end_snapshot.protocol().is_catalog_managed(),
+            Error::unsupported("Change data feed is not supported for catalog-managed tables")
+        );
+
         // Verify CDF is enabled at the beginning and end of the interval using
         // [`check_cdf_table_properties`] to fail early. This also ensures that column mapping is
         // disabled.

--- a/kernel/tests/log_tail.rs
+++ b/kernel/tests/log_tail.rs
@@ -1,0 +1,329 @@
+use std::sync::Arc;
+
+use object_store::memory::InMemory;
+use object_store::path::Path;
+use url::Url;
+
+use delta_kernel::engine::default::executor::tokio::TokioBackgroundExecutor;
+use delta_kernel::engine::default::DefaultEngine;
+use delta_kernel::{FileMeta, LogPath, Snapshot};
+
+use test_utils::{
+    actions_to_string, add_commit, add_staged_commit, delta_path_for_version, TestAction,
+};
+
+/// Helper function to create a LogPath for a commit at the given version
+fn create_log_path(table_root: &Url, commit_path: Path) -> LogPath {
+    let file_meta = create_file_meta(table_root, commit_path);
+    LogPath::try_new(file_meta).expect("Failed to create LogPath")
+}
+
+fn create_file_meta(table_root: &Url, commit_path: Path) -> FileMeta {
+    let commit_url = table_root.join(commit_path.as_ref()).unwrap();
+    FileMeta {
+        location: commit_url,
+        last_modified: 123,
+        size: 100, // arbitrary size
+    }
+}
+
+fn setup_test() -> (
+    Arc<InMemory>,
+    Arc<DefaultEngine<TokioBackgroundExecutor>>,
+    Url,
+) {
+    let storage = Arc::new(InMemory::new());
+    let table_root = Url::parse("memory:///").unwrap();
+    let engine = Arc::new(DefaultEngine::new(
+        storage.clone(),
+        Arc::new(TokioBackgroundExecutor::new()),
+    ));
+    (storage, engine, table_root)
+}
+
+#[tokio::test]
+async fn basic_snapshot_with_log_tail_staged_commits() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_root) = setup_test();
+
+    // with staged commits:
+    // _delta_log/0.json (PM in here)
+    // _delta_log/_staged_commits/1.uuid.json
+    // _delta_log/_staged_commits/1.uuid.json // add an unused staged commit at version 1
+    // _delta_log/_staged_commits/2.uuid.json
+    let actions = vec![TestAction::Metadata];
+    add_commit(storage.as_ref(), 0, actions_to_string(actions)).await?;
+    let path1 = add_staged_commit(storage.as_ref(), 1, String::from("{}")).await?;
+    let _ = add_staged_commit(storage.as_ref(), 1, String::from("{}")).await?;
+    let path2 = add_staged_commit(storage.as_ref(), 2, String::from("{}")).await?;
+
+    // 1. Create log_tail for commits 1, 2
+    let log_tail = vec![
+        create_log_path(&table_root, path1.clone()),
+        create_log_path(&table_root, path2.clone()),
+    ];
+    let snapshot = Snapshot::builder_for(table_root.clone())
+        .with_log_tail(log_tail.clone())
+        .build(engine.as_ref())?;
+    assert_eq!(snapshot.version(), 2);
+    let log_segment = snapshot.log_segment();
+    assert_eq!(log_segment.ascending_commit_files.len(), 3);
+    // version 0 is commit
+    assert_eq!(
+        log_segment.ascending_commit_files[0].location.location,
+        table_root.join(delta_path_for_version(0, "json").as_ref())?
+    );
+    // version 1 is (the right) staged commit
+    assert_eq!(
+        log_segment.ascending_commit_files[1].location.location,
+        table_root.join(path1.as_ref())?
+    );
+    // version 2 is staged commit
+    assert_eq!(
+        log_segment.ascending_commit_files[2].location.location,
+        table_root.join(path2.as_ref())?
+    );
+
+    // 2. Now check for time-travel to 1
+    let snapshot = Snapshot::builder_for(table_root.clone())
+        .with_log_tail(log_tail)
+        .at_version(1)
+        .build(engine.as_ref())?;
+    assert_eq!(snapshot.version(), 1);
+    let log_segment = snapshot.log_segment();
+    assert_eq!(log_segment.ascending_commit_files.len(), 2);
+    // version 0 is commit
+    assert_eq!(
+        log_segment.ascending_commit_files[0].location.location,
+        table_root.join(delta_path_for_version(0, "json").as_ref())?
+    );
+    // version 1 is (the right) staged commit
+    assert_eq!(
+        log_segment.ascending_commit_files[1].location.location,
+        table_root.join(path1.as_ref())?
+    );
+
+    // 3. Check case for log_tail is only 1 staged commit
+    let log_tail = vec![create_log_path(&table_root, path1.clone())];
+    let snapshot = Snapshot::builder_for(table_root.clone())
+        .with_log_tail(log_tail)
+        .build(engine.as_ref())?;
+    assert_eq!(snapshot.version(), 1);
+    let log_segment = snapshot.log_segment();
+    assert_eq!(log_segment.ascending_commit_files.len(), 2);
+    // version 0 is commit
+    assert_eq!(
+        log_segment.ascending_commit_files[0].location.location,
+        table_root.join(delta_path_for_version(0, "json").as_ref())?
+    );
+    // version 1 is (the right) staged commit
+    assert_eq!(
+        log_segment.ascending_commit_files[1].location.location,
+        table_root.join(path1.as_ref())?
+    );
+
+    // 4. Check if we don't pass log tail
+    let snapshot = Snapshot::builder_for(table_root.clone()).build(engine.as_ref())?;
+    assert_eq!(snapshot.version(), 0);
+    let log_segment = snapshot.log_segment();
+    assert_eq!(log_segment.ascending_commit_files.len(), 1);
+    // version 0 is commit
+    assert_eq!(
+        log_segment.ascending_commit_files[0].location.location,
+        table_root.join(delta_path_for_version(0, "json").as_ref())?
+    );
+
+    // 5. Check duplicating log_tail with normal listed commit
+    let log_tail = vec![create_log_path(
+        &table_root,
+        delta_path_for_version(0, "json"),
+    )];
+    let snapshot = Snapshot::builder_for(table_root.clone())
+        .with_log_tail(log_tail)
+        .build(engine.as_ref())?;
+
+    assert_eq!(snapshot.version(), 0);
+    let log_segment = snapshot.log_segment();
+    assert_eq!(log_segment.ascending_commit_files.len(), 1);
+    // version 0 is commit
+    assert_eq!(
+        log_segment.ascending_commit_files[0].location.location,
+        table_root.join(delta_path_for_version(0, "json").as_ref())?
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn basic_snapshot_with_log_tail() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_root) = setup_test();
+
+    // with normal commits:
+    // _delta_log/0.json
+    // _delta_log/1.json
+    // _delta_log/2.json
+    let actions = vec![TestAction::Metadata];
+    add_commit(storage.as_ref(), 0, actions_to_string(actions)).await?;
+    let actions = vec![TestAction::Add("file_1.parquet".to_string())];
+    add_commit(storage.as_ref(), 1, actions_to_string(actions)).await?;
+    let actions = vec![TestAction::Add("file_2.parquet".to_string())];
+    add_commit(storage.as_ref(), 2, actions_to_string(actions)).await?;
+
+    // Create log_tail for commits 1, 2
+    let log_tail = vec![
+        create_log_path(&table_root, delta_path_for_version(1, "json")),
+        create_log_path(&table_root, delta_path_for_version(2, "json")),
+    ];
+
+    let snapshot = Snapshot::builder_for(table_root.clone())
+        .with_log_tail(log_tail)
+        .build(engine.as_ref())?;
+
+    assert_eq!(snapshot.version(), 2);
+    Ok(())
+}
+
+#[tokio::test]
+async fn log_tail_behind_filesystem() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_root) = setup_test();
+
+    // Create commits 0, 1, 2 in storage
+    let actions = vec![TestAction::Metadata];
+    add_commit(storage.as_ref(), 0, actions_to_string(actions)).await?;
+    let actions = vec![TestAction::Add("file_1.parquet".to_string())];
+    add_commit(storage.as_ref(), 1, actions_to_string(actions)).await?;
+    let actions = vec![TestAction::Add("file_2.parquet".to_string())];
+    add_commit(storage.as_ref(), 2, actions_to_string(actions)).await?;
+
+    // log_tail BEHIND file system => must respect log_tail
+    let log_tail = vec![
+        create_log_path(&table_root, delta_path_for_version(0, "json")),
+        create_log_path(&table_root, delta_path_for_version(1, "json")),
+    ];
+
+    let snapshot = Snapshot::builder_for(table_root.clone())
+        .with_log_tail(log_tail)
+        .build(engine.as_ref())?;
+
+    // snapshot stops at version 1, not 2
+    assert_eq!(
+        snapshot.version(),
+        1,
+        "Log tail should define the latest version"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn incremental_snapshot_with_log_tail() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_root) = setup_test();
+
+    // commits 0, 1, 2 in storage
+    let actions = vec![TestAction::Metadata];
+    add_commit(storage.as_ref(), 0, actions_to_string(actions)).await?;
+    let actions = vec![TestAction::Add("file_1.parquet".to_string())];
+    add_commit(storage.as_ref(), 1, actions_to_string(actions)).await?;
+    let actions = vec![TestAction::Add("file_2.parquet".to_string())];
+    add_commit(storage.as_ref(), 2, actions_to_string(actions)).await?;
+
+    // initial snapshot at version 1
+    let initial_snapshot = Snapshot::builder_for(table_root.clone())
+        .at_version(1)
+        .build(engine.as_ref())?;
+    assert_eq!(initial_snapshot.version(), 1);
+
+    // add commit 3, 4
+    let actions = vec![TestAction::Add("file_3.parquet".to_string())];
+    let path3 = add_staged_commit(storage.as_ref(), 3, actions_to_string(actions)).await?;
+    let actions = vec![TestAction::Add("file_4.parquet".to_string())];
+    let path4 = add_staged_commit(storage.as_ref(), 4, actions_to_string(actions)).await?;
+
+    // log_tail with commits 2, 3, 4
+    let log_tail = vec![
+        create_log_path(&table_root, delta_path_for_version(2, "json")),
+        create_log_path(&table_root, path3),
+        create_log_path(&table_root, path4),
+    ];
+
+    // Build incremental snapshot with log_tail
+    let new_snapshot = Snapshot::builder_from(initial_snapshot)
+        .with_log_tail(log_tail)
+        .build(engine.as_ref())?;
+
+    // Verify we advanced to version 4
+    assert_eq!(new_snapshot.version(), 4);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn log_tail_exceeds_requested_version() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_root) = setup_test();
+
+    // commits 0, 1, 2, 3, 4 in storage
+    let actions = vec![TestAction::Metadata];
+    add_commit(storage.as_ref(), 0, actions_to_string(actions)).await?;
+    let actions = vec![TestAction::Add("file_1.parquet".to_string())];
+    add_commit(storage.as_ref(), 1, actions_to_string(actions)).await?;
+    let actions = vec![TestAction::Add("file_2.parquet".to_string())];
+    add_commit(storage.as_ref(), 2, actions_to_string(actions)).await?;
+    let actions = vec![TestAction::Add("file_3.parquet".to_string())];
+    add_commit(storage.as_ref(), 3, actions_to_string(actions)).await?;
+    let actions = vec![TestAction::Add("file_4.parquet".to_string())];
+    add_commit(storage.as_ref(), 4, actions_to_string(actions)).await?;
+
+    // log tail goes up to version 4
+    let log_tail = vec![
+        create_log_path(&table_root, delta_path_for_version(1, "json")),
+        create_log_path(&table_root, delta_path_for_version(2, "json")),
+        create_log_path(&table_root, delta_path_for_version(3, "json")),
+        create_log_path(&table_root, delta_path_for_version(4, "json")),
+    ];
+
+    // user asks for version 3 (or catalog says latest is 3)
+    let snapshot = Snapshot::builder_for(table_root.clone())
+        .at_version(3)
+        .with_log_tail(log_tail)
+        .build(engine.as_ref())?;
+
+    // Should stop at version 3 even though log tail has version 4
+    assert_eq!(snapshot.version(), 3);
+    Ok(())
+}
+
+#[tokio::test]
+async fn log_tail_behind_requested_version() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_root) = setup_test();
+
+    // create commits 0, 1, 2, 3, 4 in storage
+    let actions = vec![TestAction::Metadata];
+    add_commit(storage.as_ref(), 0, actions_to_string(actions)).await?;
+    let actions = vec![TestAction::Add("file_1.parquet".to_string())];
+    add_commit(storage.as_ref(), 1, actions_to_string(actions)).await?;
+    let actions = vec![TestAction::Add("file_2.parquet".to_string())];
+    add_commit(storage.as_ref(), 2, actions_to_string(actions)).await?;
+    let actions = vec![TestAction::Add("file_3.parquet".to_string())];
+    add_commit(storage.as_ref(), 3, actions_to_string(actions)).await?;
+    let actions = vec![TestAction::Add("file_4.parquet".to_string())];
+    add_commit(storage.as_ref(), 4, actions_to_string(actions)).await?;
+
+    // Log tail only goes up to version 3
+    let log_tail = vec![
+        create_log_path(&table_root, delta_path_for_version(1, "json")),
+        create_log_path(&table_root, delta_path_for_version(2, "json")),
+        create_log_path(&table_root, delta_path_for_version(3, "json")),
+    ];
+
+    // User asks for version 4, but log tail only has up to version 3
+    // This should fail with an error
+    let result = Snapshot::builder_for(table_root.clone())
+        .at_version(4)
+        .with_log_tail(log_tail)
+        .build(engine.as_ref());
+
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("LogSegment end version 3 not the same as the specified end version 4"));
+
+    Ok(())
+}

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -20,4 +20,5 @@ serde_json = "1.0.142"
 tar = "0.4"
 tempfile = "3"
 url = "2.5.4"
+uuid = { version = "1", features = ["v4"] }
 zstd = "0.13"

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -153,6 +153,12 @@ pub fn delta_path_for_version(version: u64, suffix: &str) -> Path {
     Path::from(path.as_str())
 }
 
+pub fn staged_commit_path_for_version(version: u64) -> Path {
+    let uuid = uuid::Uuid::new_v4();
+    let path = format!("_delta_log/_staged_commits/{version:020}.{uuid}.json");
+    Path::from(path.as_str())
+}
+
 /// get an ObjectStore path for a compressed log file, based on the start/end versions
 pub fn compacted_log_path_for_versions(start_version: u64, end_version: u64, suffix: &str) -> Path {
     let path = format!("_delta_log/{start_version:020}.{end_version:020}.compacted.{suffix}");
@@ -168,6 +174,16 @@ pub async fn add_commit(
     let path = delta_path_for_version(version, "json");
     store.put(&path, data.into()).await?;
     Ok(())
+}
+
+pub async fn add_staged_commit(
+    store: &dyn ObjectStore,
+    version: u64,
+    data: String,
+) -> Result<Path, Box<dyn std::error::Error>> {
+    let path = staged_commit_path_for_version(version);
+    store.put(&path, data.into()).await?;
+    Ok(path)
 }
 
 /// Try to convert an `EngineData` into a `RecordBatch`. Panics if not using `ArrowEngineData` from


### PR DESCRIPTION
> [!NOTE]
> split into three commits (1 - material changes, 2 - callsites, 3 - test)

## What changes are proposed in this pull request?
Two main things: (1) Adds `with_log_tail` API for to `SnapshotBuilder` (only for feature = `catalog-managed`) and (2) new `LogPath` type (and in a new module) to expose a public API for communicating delta log paths to kernel (currently leveraged in the new `with_log_tail` API).

This allows users (catalogs) to pass in a recent log_tail during snapshot construction. Note that our other high-level read API, `TableChanges` is not yet integrated for CCv2 (with log_tail during reads) and now explicitly checks that start/end snapshot are _not_ catalog-managed. Will track a follow up for CDF read support.

### This PR affects the following public APIs
Removes the unnecessary `Snapshot::into_scan_builder` API - instead use `Snapshot::scan_builder`

## How was this change tested?
New UT