### PR TITLE
feat: Allow LargeUTF8 -> String and LargeBinary -> Binary in arrow conversion

### DIFF
--- a/kernel/src/engine/ensure_data_types.rs
+++ b/kernel/src/engine/ensure_data_types.rs
@@ -71,8 +71,10 @@ impl EnsureDataTypes {
             }
             // strings, bools, and binary  aren't primitive in arrow
             (&DataType::BOOLEAN, ArrowDataType::Boolean)
+            | (&DataType::STRING, ArrowDataType::LargeUtf8)
             | (&DataType::STRING, ArrowDataType::Utf8)
             | (&DataType::STRING, ArrowDataType::Utf8View)
+            | (&DataType::BINARY, ArrowDataType::LargeBinary)
             | (&DataType::BINARY, ArrowDataType::BinaryView)
             | (&DataType::BINARY, ArrowDataType::Binary) => Ok(DataTypeCompat::Identical),
             (DataType::Array(inner_type), ArrowDataType::List(arrow_list_field))
@@ -549,6 +551,18 @@ mod tests {
                 true
             )
             .unwrap(),
+            DataTypeCompat::Identical
+        );
+    }
+
+    #[test]
+    fn ensure_large_strings_and_binary() {
+        assert_eq!(
+            ensure_data_types(&DataType::STRING, &ArrowDataType::LargeUtf8, true).unwrap(),
+            DataTypeCompat::Identical
+        );
+        assert_eq!(
+            ensure_data_types(&DataType::BINARY, &ArrowDataType::LargeBinary, true).unwrap(),
             DataTypeCompat::Identical
         );
     }


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR relaxes type-checking rules to allow `LargeUtf8` conversion to `STRING` and `LargeBinary` conversion to `BINARY`. With this PR Delta kernel will allow committing arrow record batches that use `LargeUtf8` or that are built using `LargeStringBuilder` or corresponding types for building `LargeBinary`.

The main limitation that non-large variations of string and binary types impose is that they can hold up to 2 GBs of data, which makes it impossible to do kernel commits if there is a string or binary column larger than 2 GB. With this PR clients can just pass `RecordBatch` that uses `LargeUtf8` or `LargeBinary` as column types.

## How was this change tested?
New UT