### PR TITLE
don't need a whole engine when converting into `ArrowEngineData`

### DIFF
--- a/ffi/src/engine_data.rs
+++ b/ffi/src/engine_data.rs
@@ -14,6 +14,7 @@ use delta_kernel::DeltaResult;
 use delta_kernel::EngineData;
 use std::ffi::c_void;
 
+use crate::error::AllocateErrorFn;
 use crate::ExclusiveEngineData;
 #[cfg(feature = "default-engine-base")]
 use crate::{ExternResult, IntoExternResult, SharedExternEngine};
@@ -113,9 +114,9 @@ fn get_raw_arrow_data_impl(data: Box<dyn EngineData>) -> DeltaResult<*mut ArrowF
 pub unsafe extern "C" fn get_engine_data(
     array: FFI_ArrowArray,
     schema: &FFI_ArrowSchema,
-    engine: Handle<SharedExternEngine>,
+    allocate_error: AllocateErrorFn,
 ) -> ExternResult<Handle<ExclusiveEngineData>> {
-    get_engine_data_impl(array, schema).into_extern_result(&engine.as_ref())
+    get_engine_data_impl(array, schema).into_extern_result(&allocate_error)
 }
 
 #[cfg(feature = "default-engine-base")]

--- a/ffi/src/engine_data.rs
+++ b/ffi/src/engine_data.rs
@@ -14,6 +14,7 @@ use delta_kernel::DeltaResult;
 use delta_kernel::EngineData;
 use std::ffi::c_void;
 
+#[cfg(feature = "default-engine-base")]
 use crate::error::AllocateErrorFn;
 use crate::ExclusiveEngineData;
 #[cfg(feature = "default-engine-base")]

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -314,7 +314,11 @@ mod tests {
             let file_info = write_parquet_file(table_path_str, "my_file.parquet", &batch)?;
 
             let file_info_engine_data = ok_or_panic(unsafe {
-                get_engine_data(file_info.array, &file_info.schema, engine.shallow_copy())
+                get_engine_data(
+                    file_info.array,
+                    &file_info.schema,
+                    crate::ffi_test_utils::allocate_err,
+                )
             });
 
             unsafe { add_files(txn_with_engine_info.shallow_copy(), file_info_engine_data) };


### PR DESCRIPTION
## What changes are proposed in this pull request?
We were asking for a whole engine over ffi just to be able to convert the error. Let's just take an `AllocateErrorFn` instead.

### This PR affects the following public APIs
in the ffi crate: `engine_data::get_engine_data` now takes an `AllocateErrorFn` instead of an engine.

## How was this change tested?
Existing tests