### PR TITLE
chore!: Make StructType::into_fields return type consistent

### DIFF
--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -674,7 +674,9 @@ impl StructType {
     }
 
     /// Gets an iterator over all the fields in this struct type.
-    pub fn into_fields(self) -> impl ExactSizeIterator<Item = StructField> {
+    pub fn into_fields(
+        self,
+    ) -> impl ExactSizeIterator<Item = StructField> + DoubleEndedIterator + FusedIterator {
         self.fields.into_values()
     }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

#1287 extended the return type of `StructType::fields` with new traits that #1266 did not pick up for the newly introduced `StructType::into_fields`. This PR fixes that.

### This PR affects the following public APIs

This PR extends the return type of the public API `StructType::into_fields`. Since we are only adding additional traits to the return type, all existing use cases should continue to work.

## How was this change tested?

Refactoring only - existing tests verify correctness.