### PR TITLE
[wip] feat(catalog-managed): introduce Committer (with FileSystemCommitter)

### DIFF
--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -112,13 +112,13 @@ pub unsafe extern "C" fn commit(
     // TODO: for now this removes the enum, which prevents doing any conflict resolution. We should fix
     //       this by making the commit function return the enum somehow.
     match txn.commit(engine.as_ref()) {
-        Ok(CommitResult::Committed {
-            version: v,
-            post_commit_stats: _,
-        }) => Ok(v),
-        Ok(CommitResult::Conflict(_, v)) => Err(delta_kernel::Error::Generic(format!(
-            "commit conflict at version {v}"
-        ))),
+        Ok(CommitResult::CommittedTransaction(committed)) => Ok(committed.version()),
+        Ok(CommitResult::ConflictedTransaction(conflicted)) => {
+            Err(delta_kernel::Error::Generic(format!(
+                "commit conflict at version {}",
+                conflicted.conflict_version
+            )))
+        }
         Err(e) => Err(e),
     }
     .into_extern_result(&extern_engine)

--- a/kernel/examples/write-table/src/main.rs
+++ b/kernel/examples/write-table/src/main.rs
@@ -101,7 +101,8 @@ async fn try_main() -> DeltaResult<()> {
 
     // Commit the transaction
     match txn.commit(&engine)? {
-        CommitResult::Committed { version, .. } => {
+        CommitResult::CommittedTransaction(committed) => {
+            let version = committed.version();
             println!("✓ Committed transaction at version {version}");
             println!("✓ Successfully wrote {} rows to the table", cli.num_rows);
 
@@ -111,7 +112,8 @@ async fn try_main() -> DeltaResult<()> {
 
             Ok(())
         }
-        CommitResult::Conflict(_, conflicting_version) => {
+        CommitResult::ConflictedTransaction(conflicted) => {
+            let conflicting_version = conflicted.conflict_version;
             println!("✗ Failed to write data, transaction conflicted with version: {conflicting_version}");
             Err(Error::generic("Commit failed"))
         }

--- a/kernel/src/committer.rs
+++ b/kernel/src/committer.rs
@@ -1,0 +1,69 @@
+use std::sync::Arc;
+
+use crate::path::ParsedLogPath;
+use crate::{DeltaResult, Engine, EngineDataResultIterator, Error, Version};
+
+use url::Url;
+
+#[derive(Debug)]
+pub struct CommitMetadata {
+    pub(crate) commit_path: ParsedLogPath<Url>,
+    pub(crate) version: Version,
+}
+
+impl CommitMetadata {
+    pub(crate) fn new(commit_path: ParsedLogPath<Url>, version: Version) -> Self {
+        Self {
+            commit_path,
+            version,
+        }
+    }
+}
+
+#[derive(Debug)]
+/// Result of committing a transaction.
+pub enum CommitResponse {
+    Committed { version: Version },
+    Conflict { version: Version },
+}
+
+pub trait Committer: Send + Sync {
+    fn commit(
+        &self,
+        engine: &dyn Engine,
+        actions: EngineDataResultIterator<'_>,
+        commit_metadata: CommitMetadata,
+    ) -> DeltaResult<CommitResponse>;
+}
+
+pub(crate) struct FileSystemCommitter;
+
+impl FileSystemCommitter {
+    pub(crate) fn new() -> Arc<Self> {
+        Arc::new(Self {})
+    }
+}
+
+impl Committer for FileSystemCommitter {
+    fn commit(
+        &self,
+        engine: &dyn Engine,
+        actions: EngineDataResultIterator<'_>,
+        commit_metadata: CommitMetadata,
+    ) -> DeltaResult<CommitResponse> {
+        let json_handler = engine.json_handler();
+        match json_handler.write_json_file(
+            &commit_metadata.commit_path.location,
+            Box::new(actions),
+            false,
+        ) {
+            Ok(()) => Ok(CommitResponse::Committed {
+                version: commit_metadata.version,
+            }),
+            Err(Error::FileAlreadyExists(_)) => Ok(CommitResponse::Conflict {
+                version: commit_metadata.version,
+            }),
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -89,6 +89,7 @@ use self::schema::{DataType, SchemaRef};
 mod action_reconciliation;
 pub mod actions;
 pub mod checkpoint;
+mod committer;
 pub mod engine_data;
 pub mod error;
 pub mod expressions;
@@ -182,6 +183,10 @@ pub type FileDataReadResult = (FileMeta, Box<dyn EngineData>);
 /// An iterator of data read from specified files
 pub type FileDataReadResultIterator =
     Box<dyn Iterator<Item = DeltaResult<Box<dyn EngineData>>> + Send>;
+
+/// Type alias for an iterator of [`EngineData`] results.
+pub(crate) type EngineDataResultIterator<'a> =
+    Box<dyn Iterator<Item = DeltaResult<Box<dyn EngineData>>> + Send + 'a>;
 
 /// The metadata that describes an object.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -1,7 +1,7 @@
 //! Builder for creating [`Snapshot`] instances.
 use crate::log_segment::LogSegment;
 use crate::snapshot::SnapshotRef;
-use crate::LogPath;
+use crate::log_path::LogPath;
 use crate::{DeltaResult, Engine, Error, Snapshot, Version};
 
 use url::Url;

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -9,21 +9,18 @@ use crate::actions::{
     as_log_add_schema, get_log_commit_info_schema, get_log_domain_metadata_schema,
     get_log_txn_schema, CommitInfo, DomainMetadata, SetTransaction,
 };
+use crate::committer::{CommitMetadata, CommitResponse, Committer, FileSystemCommitter};
 use crate::error::Error;
 use crate::expressions::{ArrayData, Transform, UnaryExpressionOp::ToJson};
 use crate::path::ParsedLogPath;
 use crate::row_tracking::{RowTrackingDomainMetadata, RowTrackingVisitor};
 use crate::schema::{ArrayType, MapType, SchemaRef, StructField, StructType};
 use crate::snapshot::SnapshotRef;
-use crate::utils::current_time_ms;
+use crate::utils::{current_time_ms, require};
 use crate::{
-    DataType, DeltaResult, Engine, EngineData, Expression, ExpressionRef, IntoEngineData,
-    RowVisitor, Snapshot, Version,
+    DataType, DeltaResult, Engine, EngineData, EngineDataResultIterator, Expression,
+    ExpressionRef, IntoEngineData, RowVisitor, Snapshot, Version,
 };
-
-/// Type alias for an iterator of [`EngineData`] results.
-type EngineDataResultIterator<'a> =
-    Box<dyn Iterator<Item = DeltaResult<Box<dyn EngineData>>> + Send + 'a>;
 
 /// The minimal (i.e., mandatory) fields in an add action.
 pub(crate) static MANDATORY_ADD_FILE_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
@@ -115,6 +112,7 @@ fn with_row_tracking_cols(schema: &SchemaRef) -> SchemaRef {
 /// ```
 pub struct Transaction {
     read_snapshot: SnapshotRef,
+    committer: Option<Arc<dyn Committer>>,
     operation: Option<String>,
     engine_info: Option<String>,
     add_files_metadata: Vec<Box<dyn EngineData>>,
@@ -159,6 +157,7 @@ impl Transaction {
 
         Ok(Transaction {
             read_snapshot,
+            committer: None,
             operation: None,
             engine_info: None,
             add_files_metadata: vec![],
@@ -168,9 +167,32 @@ impl Transaction {
         })
     }
 
+    /// Set the committer that will be used to commit this transaction. If not set, the default
+    /// filesystem-based committer will be used. Note that the default committer is only allowed
+    /// for non-catalog-managed tables.
+    #[cfg(feature = "catalog-managed")]
+    pub fn with_committer(mut self, committer: impl Into<Arc<dyn Committer>>) -> Self {
+        self.committer = Some(committer.into());
+        self
+    }
+
     /// Consume the transaction and commit it to the table. The result is a [CommitResult] which
     /// will include the failed transaction in case of a conflict so the user can retry.
-    pub fn commit(self, engine: &dyn Engine) -> DeltaResult<CommitResult> {
+    pub fn commit(mut self, engine: &dyn Engine) -> DeltaResult<CommitResult> {
+        // Step 0: Determine the committer to use
+        #[cfg(feature = "catalog-managed")]
+        if self.committer.is_none() {
+            require!(
+                !self.read_snapshot.table_configuration().protocol().is_catalog_managed(),
+                Error::generic("Cannot use the default committer for a catalog-managed table. Please provide a committer via Transaction::with_committer.")
+            );
+        }
+
+        let committer = self
+            .committer
+            .take()
+            .unwrap_or_else(|| FileSystemCommitter::new());
+
         // Step 1: Check for duplicate app_ids and generate set transactions (`txn`)
         // Note: The commit info must always be the first action in the commit but we generate it in
         // step 2 to fail early on duplicate transaction appIds
@@ -219,15 +241,14 @@ impl Transaction {
             .chain(set_transaction_actions)
             .chain(domain_metadata_actions);
 
-        let json_handler = engine.json_handler();
-        match json_handler.write_json_file(&commit_path.location, Box::new(actions), false) {
-            Ok(()) => Ok(CommitResult::CommittedTransaction(
-                self.into_committed(commit_version),
+        let commit_metadata = CommitMetadata::new(commit_path, commit_version);
+        match committer.commit(engine, Box::new(actions), commit_metadata)? {
+            CommitResponse::Committed { version } => Ok(CommitResult::CommittedTransaction(
+                self.into_committed(version),
             )),
-            Err(Error::FileAlreadyExists(_)) => Ok(CommitResult::ConflictedTransaction(
-                self.into_conflicted(commit_version),
+            CommitResponse::Conflict { version } => Ok(CommitResult::ConflictedTransaction(
+                self.into_conflicted(version),
             )),
-            Err(e) => Err(e),
         }
     }
 

--- a/kernel/tests/write.rs
+++ b/kernel/tests/write.rs
@@ -183,17 +183,14 @@ async fn write_data_and_check_result_and_stats(
 
     // commit!
     match txn.commit(engine.as_ref())? {
-        CommitResult::Committed {
-            version,
-            post_commit_stats,
-        } => {
-            assert_eq!(version, expected_since_commit as Version);
+        CommitResult::CommittedTransaction(committed) => {
+            assert_eq!(committed.version(), expected_since_commit as Version);
             assert_eq!(
-                post_commit_stats.commits_since_checkpoint,
+                committed.post_commit_stats().commits_since_checkpoint,
                 expected_since_commit
             );
             assert_eq!(
-                post_commit_stats.commits_since_log_compaction,
+                committed.post_commit_stats().commits_since_log_compaction,
                 expected_since_commit
             );
         }


### PR DESCRIPTION
## What changes are proposed in this pull request?
add new `Committer` trait for catalog-managed tables to provide their own catalog-based committer. when not provided we (1) ensure it's not catalog-managed (which requires a committer) and (2) fall back to the "old" way of atomically writing a JSON file, now encapsulated in a `FileSystemCommitter`

## How was this change tested?
existing