### PR TITLE
feat: Arc instead of Box<dyn EngineData> for add_files API

### DIFF
--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -343,6 +343,9 @@ pub unsafe extern "C" fn free_row_indexes(slice: KernelRowIndexArray) {
 #[handle_descriptor(target=dyn EngineData, mutable=true)]
 pub struct ExclusiveEngineData;
 
+#[handle_descriptor(target=dyn EngineData, mutable=false)]
+pub struct SharedEngineData;
+
 /// Drop an `ExclusiveEngineData`.
 ///
 /// # Safety

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -6,7 +6,7 @@ use crate::handle::Handle;
 use crate::KernelStringSlice;
 use crate::{unwrap_and_parse_path_as_url, TryFromStringSlice};
 use crate::{DeltaResult, ExternEngine, Snapshot, Url};
-use crate::{ExclusiveEngineData, SharedExternEngine};
+use crate::{SharedEngineData, SharedExternEngine};
 use delta_kernel::transaction::{CommitResult, Transaction};
 use delta_kernel_ffi_macros::handle_descriptor;
 
@@ -87,7 +87,7 @@ fn with_engine_info_impl(
 #[no_mangle]
 pub unsafe extern "C" fn add_files(
     mut txn: Handle<ExclusiveTransaction>,
-    write_metadata: Handle<ExclusiveEngineData>,
+    write_metadata: Handle<SharedEngineData>,
 ) {
     let txn = unsafe { txn.as_mut() };
     let write_metadata = unsafe { write_metadata.into_inner() };

--- a/kernel/src/engine/default/mod.rs
+++ b/kernel/src/engine/default/mod.rs
@@ -99,7 +99,7 @@ impl<E: TaskExecutor> DefaultEngine<E> {
         write_context: &WriteContext,
         partition_values: HashMap<String, String>,
         data_change: bool,
-    ) -> DeltaResult<Box<dyn EngineData>> {
+    ) -> DeltaResult<Arc<dyn EngineData>> {
         let transform = write_context.logical_to_physical();
         let input_schema = Schema::try_from_arrow(data.record_batch().schema())?;
         let output_schema = write_context.schema();

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -117,7 +117,7 @@ pub struct Transaction {
     read_snapshot: SnapshotRef,
     operation: Option<String>,
     engine_info: Option<String>,
-    add_files_metadata: Vec<Box<dyn EngineData>>,
+    add_files_metadata: Vec<Arc<dyn EngineData>>,
     // NB: hashmap would require either duplicating the appid or splitting SetTransaction
     // key/payload. HashSet requires Borrow<&str> with matching Eq, Ord, and Hash. Plus,
     // HashSet::insert drops the to-be-inserted value without returning the existing one, which
@@ -360,7 +360,7 @@ impl Transaction {
     /// to add multiple batches.
     ///
     /// The expected schema for `add_metadata` is given by [`add_files_schema`].
-    pub fn add_files(&mut self, add_metadata: Box<dyn EngineData>) {
+    pub fn add_files(&mut self, add_metadata: Arc<dyn EngineData>) {
         self.add_files_metadata.push(add_metadata);
     }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
Opening for some discussion: do we want to take a Box or an Arc for `transaction.add_files`?

Currently we take a `Box<dyn EngineData>` - this means engine can't use it again after handing to our transaction. I'm raising this to consider Arc since none of our APIs actually _require_ ownership - we can just take a shared Arc and everything basically "just works".

Though this brings up whether or not we want to allow this flexibility, as the add_files_metadata is not very useful outside of a transaction and in the future a `Transaction` should be able to just rebase itself?

### This PR affects the following public APIs
`transaction.add_files` takes an `Arc<dyn EngineData>` instead of `Box<dyn EngineData>`

## How was this change tested?
existing