### PR TITLE
fix: Change InCommitTimestamp enablement getter function 

### DIFF
--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -351,17 +351,15 @@ impl TableConfiguration {
 
         match (enablement_version, enablement_timestamp) {
             (Some(version), Some(timestamp)) => Ok(InCommitTimestampEnablement::Enabled {
-                enablement: Some((version, timestamp))
+                enablement: Some((version, timestamp)),
             }),
             (Some(_), None) => Err(Error::generic(
-                "In-commit timestamp enabled, but enablement timestamp is missing while enablement version is present"
+                "In-commit timestamp enabled, but enablement timestamp is missing",
             )),
             (None, Some(_)) => Err(Error::generic(
-                "In-commit timestamp enabled, but enablement version is missing while enablement timestamp is present"
+                "In-commit timestamp enabled, but enablement version is missing",
             )),
-            (None, None) => Ok(InCommitTimestampEnablement::Enabled {
-                enablement: None
-            }),
+            (None, None) => Ok(InCommitTimestampEnablement::Enabled { enablement: None }),
         }
     }
 

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -29,10 +29,10 @@ pub(crate) enum InCommitTimestampEnablement {
     /// In-commit timestamps is not enabled
     NotEnabled,
     /// In-commit timestamps is enabled
-    Enabled { 
+    Enabled {
         /// Enablement information, if available. `None` indicates the table was created
         /// with ICT enabled from the beginning (no enablement properties needed).
-        enablement: Option<(Version, i64)> 
+        enablement: Option<(Version, i64)>,
     },
 }
 
@@ -330,17 +330,18 @@ impl TableConfiguration {
                 .unwrap_or(false)
     }
 
-
     /// Returns information about in-commit timestamp enablement state.
     ///
     /// Returns an error if only one of the enablement properties is present, as this indicates
     /// an inconsistent state.
     #[allow(unused)]
-    pub(crate) fn in_commit_timestamp_enablement(&self) -> DeltaResult<InCommitTimestampEnablement> {
+    pub(crate) fn in_commit_timestamp_enablement(
+        &self,
+    ) -> DeltaResult<InCommitTimestampEnablement> {
         if !self.is_in_commit_timestamps_enabled() {
             return Ok(InCommitTimestampEnablement::NotEnabled);
         }
-        
+
         let enablement_version = self
             .table_properties()
             .in_commit_timestamp_enablement_version;
@@ -349,8 +350,8 @@ impl TableConfiguration {
             .in_commit_timestamp_enablement_timestamp;
 
         match (enablement_version, enablement_timestamp) {
-            (Some(version), Some(timestamp)) => Ok(InCommitTimestampEnablement::Enabled { 
-                enablement: Some((version, timestamp)) 
+            (Some(version), Some(timestamp)) => Ok(InCommitTimestampEnablement::Enabled {
+                enablement: Some((version, timestamp))
             }),
             (Some(_), None) => Err(Error::generic(
                 "In-commit timestamp enabled, but enablement timestamp is missing while enablement version is present"
@@ -358,8 +359,8 @@ impl TableConfiguration {
             (None, Some(_)) => Err(Error::generic(
                 "In-commit timestamp enabled, but enablement version is missing while enablement timestamp is present"
             )),
-            (None, None) => Ok(InCommitTimestampEnablement::Enabled { 
-                enablement: None 
+            (None, None) => Ok(InCommitTimestampEnablement::Enabled {
+                enablement: None
             }),
         }
     }
@@ -437,7 +438,7 @@ mod test {
     use crate::utils::test_utils::assert_result_error_with_message;
     use crate::Error;
 
-    use super::{TableConfiguration, InCommitTimestampEnablement};
+    use super::{InCommitTimestampEnablement, TableConfiguration};
 
     #[test]
     fn dv_supported_not_enabled() {
@@ -522,7 +523,10 @@ mod test {
         // When ICT is enabled from table creation (version 0), it's perfectly normal
         // for enablement properties to be missing
         let info = table_config.in_commit_timestamp_enablement().unwrap();
-        assert_eq!(info, InCommitTimestampEnablement::Enabled { enablement: None });
+        assert_eq!(
+            info,
+            InCommitTimestampEnablement::Enabled { enablement: None }
+        );
     }
     #[test]
     fn ict_supported_and_enabled() {
@@ -561,7 +565,12 @@ mod test {
         assert!(table_config.is_in_commit_timestamps_supported());
         assert!(table_config.is_in_commit_timestamps_enabled());
         let info = table_config.in_commit_timestamp_enablement().unwrap();
-        assert_eq!(info, InCommitTimestampEnablement::Enabled { enablement: Some((5, 100)) })
+        assert_eq!(
+            info,
+            InCommitTimestampEnablement::Enabled {
+                enablement: Some((5, 100))
+            }
+        )
     }
     #[test]
     fn ict_enabled_with_partial_enablement_info() {

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -564,24 +564,6 @@ mod test {
         assert_eq!(info, InCommitTimestampEnablement::Enabled { enablement: Some((5, 100)) })
     }
     #[test]
-    fn ict_supported_and_not_enabled() {
-        let schema = StructType::new_unchecked([StructField::nullable("value", DataType::INTEGER)]);
-        let metadata = Metadata::try_new(None, None, schema, vec![], 0, HashMap::new()).unwrap();
-        let protocol = Protocol::try_new(
-            3,
-            7,
-            Some::<Vec<String>>(vec![]),
-            Some([WriterFeature::InCommitTimestamp]),
-        )
-        .unwrap();
-        let table_root = Url::try_from("file:///").unwrap();
-        let table_config = TableConfiguration::try_new(metadata, protocol, table_root, 0).unwrap();
-        assert!(table_config.is_in_commit_timestamps_supported());
-        assert!(!table_config.is_in_commit_timestamps_enabled());
-        let info = table_config.in_commit_timestamp_enablement().unwrap();
-        assert_eq!(info, InCommitTimestampEnablement::NotEnabled);
-    }
-    #[test]
     fn ict_enabled_with_partial_enablement_info() {
         let schema = StructType::new_unchecked([StructField::nullable("value", DataType::INTEGER)]);
         let metadata = Metadata::try_new(
@@ -618,6 +600,24 @@ mod test {
             table_config.in_commit_timestamp_enablement(),
             Err(Error::Generic(msg)) if msg.contains("enablement timestamp is missing while enablement version is present")
         ));
+    }
+    #[test]
+    fn ict_supported_and_not_enabled() {
+        let schema = StructType::new_unchecked([StructField::nullable("value", DataType::INTEGER)]);
+        let metadata = Metadata::try_new(None, None, schema, vec![], 0, HashMap::new()).unwrap();
+        let protocol = Protocol::try_new(
+            3,
+            7,
+            Some::<Vec<String>>(vec![]),
+            Some([WriterFeature::InCommitTimestamp]),
+        )
+        .unwrap();
+        let table_root = Url::try_from("file:///").unwrap();
+        let table_config = TableConfiguration::try_new(metadata, protocol, table_root, 0).unwrap();
+        assert!(table_config.is_in_commit_timestamps_supported());
+        assert!(!table_config.is_in_commit_timestamps_enabled());
+        let info = table_config.in_commit_timestamp_enablement().unwrap();
+        assert_eq!(info, InCommitTimestampEnablement::NotEnabled);
     }
     #[test]
     fn fails_on_unsupported_feature() {

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -359,6 +359,8 @@ impl TableConfiguration {
             (None, Some(_)) => Err(Error::generic(
                 "In-commit timestamp enabled, but enablement version is missing",
             )),
+            // If InCommitTimestamps was enabled at the beginning of the table's history,
+            // it may have an empty enablement version and timestamp
             (None, None) => Ok(InCommitTimestampEnablement::Enabled { enablement: None }),
         }
     }
@@ -605,7 +607,7 @@ mod test {
         assert!(table_config.is_in_commit_timestamps_enabled());
         assert!(matches!(
             table_config.in_commit_timestamp_enablement(),
-            Err(Error::Generic(msg)) if msg.contains("enablement timestamp is missing while enablement version is present")
+            Err(Error::Generic(msg)) if msg.contains("In-commit timestamp enabled, but enablement timestamp is missing")
         ));
     }
     #[test]


### PR DESCRIPTION
## What changes are proposed in this pull request?
https://github.com/delta-io/delta-kernel-rs/issues/1356

The in_commit_timestamp_enablement() method returns errors when ICT is enabled but enablement properties are missing, violating the Delta protocol. When table is created with ICT enablement info, the enablement properties will stay empty.

This change introduces a new enum to capture ICT enablement. 


## How was this change tested?

New and edited unit tests
