### PR TITLE
feat: Add latest_commit_file field to LogSegment

### DIFF
--- a/kernel/src/listed_log_files.rs
+++ b/kernel/src/listed_log_files.rs
@@ -302,10 +302,9 @@ impl ListedLogFiles {
                     .find(|(num_parts, part_files)| part_files.len() == *num_parts as usize)
                 {
                     checkpoint_parts = complete_checkpoint;
-                    // Log replay only uses commits/compactions after a complete checkpoint
-                    // Note: we preserve latest_commit_file even when clearing ascending_commit_files
-                    // Save the latest commit file before clearing
+                    // Save the latest commit file before clearing ascending_commit_files
                     latest_commit_file = ascending_commit_files.last().cloned();
+                    // Log replay only uses commits/compactions after a complete checkpoint
                     ascending_commit_files.clear();
                     ascending_compaction_files.clear();
                 }

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -60,7 +60,7 @@ pub(crate) struct LogSegment {
     pub latest_crc_file: Option<ParsedLogPath>,
     /// The latest commit file found during listing, which may not be part of the
     /// contiguous segment but is needed for ICT timestamp reading
-    pub latest_commit_file: ParsedLogPath,
+    pub latest_commit_file: Option<ParsedLogPath>,
 }
 
 impl LogSegment {
@@ -122,10 +122,6 @@ impl LogSegment {
                 ))
             );
         }
-
-        // LogSegment requires a latest_commit_file
-        let latest_commit_file = latest_commit_file
-            .ok_or_else(|| Error::generic("LogSegment requires at least one commit"))?;
 
         Ok(LogSegment {
             end_version: effective_version,

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -60,7 +60,7 @@ pub(crate) struct LogSegment {
     pub latest_crc_file: Option<ParsedLogPath>,
     /// The latest commit file found during listing, which may not be part of the
     /// contiguous segment but is needed for ICT timestamp reading
-    pub latest_commit: ParsedLogPath,
+    pub latest_commit_file: ParsedLogPath,
 }
 
 impl LogSegment {
@@ -75,7 +75,7 @@ impl LogSegment {
             ascending_compaction_files,
             checkpoint_parts,
             latest_crc_file,
-            latest_commit,
+            latest_commit_file,
         } = listed_files;
 
         // Ensure commit file versions are contiguous
@@ -123,8 +123,8 @@ impl LogSegment {
             );
         }
 
-        // LogSegment requires a latest_commit
-        let latest_commit = latest_commit
+        // LogSegment requires a latest_commit_file
+        let latest_commit_file = latest_commit_file
             .ok_or_else(|| Error::generic("LogSegment requires at least one commit"))?;
 
         Ok(LogSegment {
@@ -135,7 +135,7 @@ impl LogSegment {
             ascending_compaction_files,
             checkpoint_parts,
             latest_crc_file,
-            latest_commit,
+            latest_commit_file,
         })
     }
 

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -58,6 +58,9 @@ pub(crate) struct LogSegment {
     pub checkpoint_parts: Vec<ParsedLogPath>,
     /// Latest CRC (checksum) file
     pub latest_crc_file: Option<ParsedLogPath>,
+    /// The latest commit file found during listing, which may not be part of the
+    /// contiguous segment but is needed for ICT timestamp reading
+    pub latest_commit: ParsedLogPath,
 }
 
 impl LogSegment {
@@ -72,6 +75,7 @@ impl LogSegment {
             ascending_compaction_files,
             checkpoint_parts,
             latest_crc_file,
+            latest_commit,
         } = listed_files;
 
         // Ensure commit file versions are contiguous
@@ -119,6 +123,10 @@ impl LogSegment {
             );
         }
 
+        // LogSegment requires a latest_commit
+        let latest_commit = latest_commit
+            .ok_or_else(|| Error::generic("LogSegment requires at least one commit"))?;
+
         Ok(LogSegment {
             end_version: effective_version,
             checkpoint_version,
@@ -127,6 +135,7 @@ impl LogSegment {
             ascending_compaction_files,
             checkpoint_parts,
             latest_crc_file,
+            latest_commit,
         })
     }
 

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -1077,6 +1077,7 @@ fn test_create_checkpoint_stream_errors_when_schema_has_remove_but_no_sidecar_ac
                 "file:///00000000000000000001.checkpoint.parquet",
             )],
             None,
+            Some(create_log_path("file:///00000000000000000001.json")),
         )?,
         log_root,
         None,
@@ -1108,6 +1109,7 @@ fn test_create_checkpoint_stream_errors_when_schema_has_add_but_no_sidecar_actio
                 "file:///00000000000000000001.checkpoint.parquet",
             )],
             None,
+            Some(create_log_path("file:///00000000000000000001.json")),
         )?,
         log_root,
         None,
@@ -1144,6 +1146,7 @@ fn test_create_checkpoint_stream_returns_checkpoint_batches_as_is_if_schema_has_
             vec![],
             vec![create_log_path(&checkpoint_one_file)],
             None,
+            Some(create_log_path("file:///00000000000000000001.json")),
         )?,
         log_root,
         None,
@@ -1206,6 +1209,7 @@ fn test_create_checkpoint_stream_returns_checkpoint_batches_if_checkpoint_is_mul
                 create_log_path(&checkpoint_two_file),
             ],
             None,
+            Some(create_log_path("file:///00000000000000000001.json")),
         )?,
         log_root,
         None,
@@ -1257,6 +1261,7 @@ fn test_create_checkpoint_stream_reads_parquet_checkpoint_batch_without_sidecars
             vec![],
             vec![create_log_path(&checkpoint_one_file)],
             None,
+            Some(create_log_path("file:///00000000000000000001.json")),
         )?,
         log_root,
         None,
@@ -1303,6 +1308,7 @@ fn test_create_checkpoint_stream_reads_json_checkpoint_batch_without_sidecars() 
             vec![],
             vec![create_log_path(&checkpoint_one_file)],
             None,
+            Some(create_log_path("file:///00000000000000000001.json")),
         )?,
         log_root,
         None,
@@ -1370,6 +1376,7 @@ fn test_create_checkpoint_stream_reads_checkpoint_file_and_returns_sidecar_batch
             vec![],
             vec![create_log_path(&checkpoint_file_path)],
             None,
+            Some(create_log_path("file:///00000000000000000001.json")),
         )?,
         log_root,
         None,
@@ -1816,6 +1823,7 @@ fn test_debug_assert_listed_log_file_in_order_compaction_files() {
         ],
         vec![],
         None,
+        Some(create_log_path("file:///00000000000000000001.json")),
     );
 }
 
@@ -1831,6 +1839,7 @@ fn test_debug_assert_listed_log_file_out_of_order_compaction_files() {
         ],
         vec![],
         None,
+        Some(create_log_path("file:///00000000000000000001.json")),
     );
 }
 
@@ -1846,6 +1855,7 @@ fn test_debug_assert_listed_log_file_different_multipart_checkpoint_versions() {
             create_log_path("00000000000000000011.checkpoint.0000000002.0000000002.parquet"),
         ],
         None,
+        Some(create_log_path("file:///00000000000000000001.json")),
     );
 }
 
@@ -1861,6 +1871,7 @@ fn test_debug_assert_listed_log_file_invalid_multipart_checkpoint() {
             create_log_path("00000000000000000011.checkpoint.0000000002.0000000003.parquet"),
         ],
         None,
+        Some(create_log_path("file:///00000000000000000001.json")),
     );
 }
 
@@ -2108,6 +2119,100 @@ fn for_timestamp_conversion_no_commit_files() {
 }
 
 #[test]
+fn test_latest_commit_field_is_captured() {
+    // Test that the latest commit is preserved even after checkpoint filtering
+    let (storage, log_root) = build_log_with_paths_and_checkpoint(
+        &[
+            delta_path_for_version(0, "json"),
+            delta_path_for_version(1, "json"),
+            delta_path_for_version(2, "json"),
+            delta_path_for_version(2, "checkpoint.parquet"),
+            delta_path_for_version(3, "json"),
+            delta_path_for_version(4, "json"),
+            delta_path_for_version(5, "json"),
+        ],
+        None,
+    );
+
+    let log_segment =
+        LogSegment::for_snapshot(storage.as_ref(), log_root.clone(), vec![], None).unwrap();
+
+    // The latest commit should be version 5
+    assert_eq!(log_segment.latest_commit.version, 5);
+
+    // The log segment should only contain commits 3, 4, 5 (after checkpoint 2)
+    assert_eq!(log_segment.ascending_commit_files.len(), 3);
+    assert_eq!(log_segment.ascending_commit_files[0].version, 3);
+    assert_eq!(log_segment.ascending_commit_files[2].version, 5);
+}
+
+#[test]
+fn test_latest_commit_with_checkpoint_filtering() {
+    // Test when commits get filtered by checkpoint
+    let (storage, log_root) = build_log_with_paths_and_checkpoint(
+        &[
+            delta_path_for_version(0, "json"),
+            delta_path_for_version(1, "json"),
+            delta_path_for_version(2, "json"),
+            delta_path_for_version(3, "checkpoint.parquet"),
+            delta_path_for_version(4, "json"),
+        ],
+        None,
+    );
+
+    let log_segment =
+        LogSegment::for_snapshot(storage.as_ref(), log_root.clone(), vec![], None).unwrap();
+
+    // The latest commit should be version 4
+    assert_eq!(log_segment.latest_commit.version, 4);
+
+    // The log segment should have only commit 4 (after checkpoint 3)
+    assert_eq!(log_segment.ascending_commit_files.len(), 1);
+    assert_eq!(log_segment.ascending_commit_files[0].version, 4);
+}
+
+#[test]
+fn test_latest_commit_with_no_commits() {
+    // Test when there are only checkpoints and no commits at all
+    // This should fail because a log segment requires at least one commit
+    let (storage, log_root) = build_log_with_paths_and_checkpoint(
+        &[delta_path_for_version(2, "checkpoint.parquet")],
+        None,
+    );
+
+    let result = LogSegment::for_snapshot(storage.as_ref(), log_root.clone(), vec![], None);
+
+    // Should error because there are no commits
+    assert_result_error_with_message(result, "LogSegment requires at least one commit");
+}
+
+#[test]
+fn test_latest_commit_with_checkpoint_at_same_version() {
+    // Test when checkpoint is at the same version as the latest commit
+    // This tests: 0.json, 1.json, 1.checkpoint.parquet
+    let (storage, log_root) = build_log_with_paths_and_checkpoint(
+        &[
+            delta_path_for_version(0, "json"),
+            delta_path_for_version(1, "json"),
+            delta_path_for_version(1, "checkpoint.parquet"),
+        ],
+        None,
+    );
+
+    let log_segment =
+        LogSegment::for_snapshot(storage.as_ref(), log_root.clone(), vec![], None).unwrap();
+
+    // The latest commit should be version 1 (saved before filtering)
+    assert_eq!(log_segment.latest_commit.version, 1);
+
+    // The log segment should have no commit files (all filtered by checkpoint at version 1)
+    assert_eq!(log_segment.ascending_commit_files.len(), 0);
+
+    // The checkpoint should be at version 1
+    assert_eq!(log_segment.checkpoint_version, Some(1));
+}
+
+#[test]
 fn test_log_segment_contiguous_commit_files() {
     let res = ListedLogFiles::try_new(
         vec![
@@ -2118,6 +2223,7 @@ fn test_log_segment_contiguous_commit_files() {
         vec![],
         vec![],
         None,
+        Some(create_log_path("file:///00000000000000000001.json")),
     );
     assert!(res.is_ok());
 
@@ -2130,6 +2236,7 @@ fn test_log_segment_contiguous_commit_files() {
         vec![],
         vec![],
         None,
+        Some(create_log_path("file:///00000000000000000001.json")),
     );
 
     // disallow gaps in LogSegment

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -2119,7 +2119,7 @@ fn for_timestamp_conversion_no_commit_files() {
 }
 
 #[test]
-fn test_latest_commit_field_is_captured() {
+fn test_latest_commit_file_field_is_captured() {
     // Test that the latest commit is preserved even after checkpoint filtering
     let (storage, log_root) = build_log_with_paths_and_checkpoint(
         &[
@@ -2138,7 +2138,7 @@ fn test_latest_commit_field_is_captured() {
         LogSegment::for_snapshot(storage.as_ref(), log_root.clone(), vec![], None).unwrap();
 
     // The latest commit should be version 5
-    assert_eq!(log_segment.latest_commit.version, 5);
+    assert_eq!(log_segment.latest_commit_file.version, 5);
 
     // The log segment should only contain commits 3, 4, 5 (after checkpoint 2)
     assert_eq!(log_segment.ascending_commit_files.len(), 3);
@@ -2147,7 +2147,7 @@ fn test_latest_commit_field_is_captured() {
 }
 
 #[test]
-fn test_latest_commit_with_checkpoint_filtering() {
+fn test_latest_commit_file_with_checkpoint_filtering() {
     // Test when commits get filtered by checkpoint
     let (storage, log_root) = build_log_with_paths_and_checkpoint(
         &[
@@ -2164,7 +2164,7 @@ fn test_latest_commit_with_checkpoint_filtering() {
         LogSegment::for_snapshot(storage.as_ref(), log_root.clone(), vec![], None).unwrap();
 
     // The latest commit should be version 4
-    assert_eq!(log_segment.latest_commit.version, 4);
+    assert_eq!(log_segment.latest_commit_file.version, 4);
 
     // The log segment should have only commit 4 (after checkpoint 3)
     assert_eq!(log_segment.ascending_commit_files.len(), 1);
@@ -2172,7 +2172,7 @@ fn test_latest_commit_with_checkpoint_filtering() {
 }
 
 #[test]
-fn test_latest_commit_with_no_commits() {
+fn test_latest_commit_file_with_no_commits() {
     // Test when there are only checkpoints and no commits at all
     // This should fail because a log segment requires at least one commit
     let (storage, log_root) = build_log_with_paths_and_checkpoint(
@@ -2187,7 +2187,7 @@ fn test_latest_commit_with_no_commits() {
 }
 
 #[test]
-fn test_latest_commit_with_checkpoint_at_same_version() {
+fn test_latest_commit_file_with_checkpoint_at_same_version() {
     // Test when checkpoint is at the same version as the latest commit
     // This tests: 0.json, 1.json, 1.checkpoint.parquet
     let (storage, log_root) = build_log_with_paths_and_checkpoint(
@@ -2203,7 +2203,7 @@ fn test_latest_commit_with_checkpoint_at_same_version() {
         LogSegment::for_snapshot(storage.as_ref(), log_root.clone(), vec![], None).unwrap();
 
     // The latest commit should be version 1 (saved before filtering)
-    assert_eq!(log_segment.latest_commit.version, 1);
+    assert_eq!(log_segment.latest_commit_file.version, 1);
 
     // The log segment should have no commit files (all filtered by checkpoint at version 1)
     assert_eq!(log_segment.ascending_commit_files.len(), 0);

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -562,7 +562,7 @@ impl Scan {
             ascending_compaction_files: vec![],
             checkpoint_parts: vec![],
             latest_crc_file: None,
-            latest_commit_file: Some(log_segment.latest_commit_file.clone()),
+            latest_commit_file: log_segment.latest_commit_file.clone(),
         };
         let new_log_segment = LogSegment::try_new(
             listed_log_files,

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -562,6 +562,7 @@ impl Scan {
             ascending_compaction_files: vec![],
             checkpoint_parts: vec![],
             latest_crc_file: None,
+            latest_commit: Some(log_segment.latest_commit.clone()),
         };
         let new_log_segment = LogSegment::try_new(
             listed_log_files,

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -562,7 +562,7 @@ impl Scan {
             ascending_compaction_files: vec![],
             checkpoint_parts: vec![],
             latest_crc_file: None,
-            latest_commit: Some(log_segment.latest_commit.clone()),
+            latest_commit_file: Some(log_segment.latest_commit_file.clone()),
         };
         let new_log_segment = LogSegment::try_new(
             listed_log_files,

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -156,6 +156,8 @@ impl Snapshot {
 
         // create a log segment just from existing_checkpoint.version -> new_version
         // OR could be from 1 -> new_version
+        // Save the latest_commit before moving new_listed_files
+        let new_latest_commit = new_listed_files.latest_commit.clone();
         let mut new_log_segment =
             LogSegment::try_new(new_listed_files, log_root.clone(), new_version)?;
 
@@ -222,6 +224,11 @@ impl Snapshot {
             .latest_crc_file
             .or_else(|| old_log_segment.latest_crc_file.clone());
 
+        // Use the new latest_commit if available, otherwise use the old one
+        // This handles the case where the new listing returned no commits
+        let latest_commit =
+            new_latest_commit.unwrap_or_else(|| old_log_segment.latest_commit.clone());
+
         // we can pass in just the old checkpoint parts since by the time we reach this line, we
         // know there are no checkpoints in the new log segment.
         let combined_log_segment = LogSegment::try_new(
@@ -230,6 +237,7 @@ impl Snapshot {
                 ascending_compaction_files,
                 checkpoint_parts: old_log_segment.checkpoint_parts.clone(),
                 latest_crc_file,
+                latest_commit: Some(latest_commit),
             },
             log_root,
             new_version,
@@ -611,7 +619,7 @@ mod tests {
         writer.write(&checkpoint)?;
         writer.close()?;
 
-        store
+        store_3a
             .put(
                 &delta_path_for_version(1, "checkpoint.parquet"),
                 buffer.into(),

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -227,7 +227,7 @@ impl Snapshot {
         // Use the new latest_commit if available, otherwise use the old one
         // This handles the case where the new listing returned no commits
         let latest_commit_file =
-            new_latest_commit_file.unwrap_or_else(|| old_log_segment.latest_commit_file.clone());
+            new_latest_commit_file.or_else(|| old_log_segment.latest_commit_file.clone());
         // we can pass in just the old checkpoint parts since by the time we reach this line, we
         // know there are no checkpoints in the new log segment.
         let combined_log_segment = LogSegment::try_new(
@@ -236,7 +236,7 @@ impl Snapshot {
                 ascending_compaction_files,
                 checkpoint_parts: old_log_segment.checkpoint_parts.clone(),
                 latest_crc_file,
-                latest_commit_file: Some(latest_commit_file),
+                latest_commit_file,
             },
             log_root,
             new_version,

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -157,7 +157,7 @@ impl Snapshot {
         // create a log segment just from existing_checkpoint.version -> new_version
         // OR could be from 1 -> new_version
         // Save the latest_commit before moving new_listed_files
-        let new_latest_commit = new_listed_files.latest_commit.clone();
+        let new_latest_commit_file = new_listed_files.latest_commit_file.clone();
         let mut new_log_segment =
             LogSegment::try_new(new_listed_files, log_root.clone(), new_version)?;
 
@@ -226,9 +226,8 @@ impl Snapshot {
 
         // Use the new latest_commit if available, otherwise use the old one
         // This handles the case where the new listing returned no commits
-        let latest_commit =
-            new_latest_commit.unwrap_or_else(|| old_log_segment.latest_commit.clone());
-
+        let latest_commit_file =
+            new_latest_commit_file.unwrap_or_else(|| old_log_segment.latest_commit_file.clone());
         // we can pass in just the old checkpoint parts since by the time we reach this line, we
         // know there are no checkpoints in the new log segment.
         let combined_log_segment = LogSegment::try_new(
@@ -237,7 +236,7 @@ impl Snapshot {
                 ascending_compaction_files,
                 checkpoint_parts: old_log_segment.checkpoint_parts.clone(),
                 latest_crc_file,
-                latest_commit: Some(latest_commit),
+                latest_commit_file: Some(latest_commit_file),
             },
             log_root,
             new_version,


### PR DESCRIPTION
## What changes are proposed in this pull request?
Add `latest_commit` field to `LogSegment` to prepare for in-commit timestamp (ICT) support. When ICT is enabled, we need access to the latest commit file to read timestamp information. We cannot depend on ascending commits because commits will be filtered out by checkpoint processing when checkpoint version equals commit version.

  #### Changes

  - Add `latest_commit_file: Option<ParsedLogPath>` field to `LogSegment` (optional)
  - Add `latest_commit_file: Option<ParsedLogPath>` field to `ListedLogFiles` (optional)
  - Track latest commit during listing, before any checkpoint filtering occurs
  - Handle incremental snapshot updates by inheriting `latest_commit` from existing snapshot when new listing is empty


## How was this change tested?

Added and changed tests to verify latest commit is passed through
