### PR TITLE
fix: be adaptive to the log schema changing in inspect-table

### DIFF
--- a/kernel/examples/inspect-table/src/main.rs
+++ b/kernel/examples/inspect-table/src/main.rs
@@ -86,6 +86,7 @@ impl LogVisitor {
         let mut it = NAMES_AND_TYPES.as_ref().0.iter().enumerate().peekable();
         while let Some((start, col)) = it.next() {
             let mut end = start + 1;
+            // move forward while the top level struct has the same name
             while it.next_if(|(_, other)| col[0] == other[0]).is_some() {
                 end += 1;
             }
@@ -104,9 +105,10 @@ impl RowVisitor for LogVisitor {
         NAMES_AND_TYPES.as_ref()
     }
     fn visit<'a>(&mut self, row_count: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
-        if getters.len() != 55 {
+        let expected = NAMES_AND_TYPES.as_ref().0.len();
+        if getters.len() != expected {
             return Err(Error::InternalError(format!(
-                "Wrong number of LogVisitor getters: {}",
+                "Wrong number of LogVisitor getters: {}, expected {expected}",
                 getters.len()
             )));
         }


### PR DESCRIPTION
## What changes are proposed in this pull request?
We were hard coding the number of expected leaf fields we would get when visiting log data. This meant any changes to the log schema would silently break this example. We already have code to extract the offsets of the getters within the schema, so we should just adapt to changes (although reordering the schema would be bad).

This PR just computes the expected number of getters from the number of leaves in the schema, and ensures that's what we get back from the visitor, instead of hard-coding the number.

## How was this change tested?
Run example on existing tables