### PR TITLE
feat: Inspect table fixes

### DIFF
--- a/kernel/src/actions/visitors.rs
+++ b/kernel/src/actions/visitors.rs
@@ -430,6 +430,7 @@ impl RowVisitor for SidecarVisitor {
 /// included to only retain the domain metadata for a specific domain (in order to bound memory
 /// requirements).
 #[derive(Debug, Default)]
+#[internal_api]
 pub(crate) struct DomainMetadataVisitor {
     domain_metadatas: DomainMetadataMap,
     domain_filter: Option<String>,
@@ -444,6 +445,7 @@ impl DomainMetadataVisitor {
         }
     }
 
+    #[internal_api]
     pub(crate) fn visit_domain_metadata<'a>(
         row_index: usize,
         domain: String,

--- a/kernel/src/engine/arrow_conversion.rs
+++ b/kernel/src/engine/arrow_conversion.rs
@@ -12,6 +12,7 @@ use itertools::Itertools;
 use crate::error::Error;
 use crate::schema::{
     ArrayType, DataType, MapType, MetadataValue, PrimitiveType, StructField, StructType,
+    UNSHREDDED_VARIANT_SCHEMA,
 };
 
 pub(crate) const LIST_ARRAY_ROOT: &str = "element";
@@ -162,7 +163,7 @@ impl TryFromKernel<&DataType> for ArrowDataType {
                 false,
             )),
             DataType::Variant(s) => {
-                if *t == DataType::unshredded_variant() {
+                if *t == *UNSHREDDED_VARIANT_SCHEMA {
                     Ok(ArrowDataType::Struct(
                         s.fields()
                             .map(TryIntoArrow::try_into_arrow)
@@ -326,11 +327,10 @@ mod tests {
 
     #[test]
     fn test_variant_shredded_type_fail() -> DeltaResult<()> {
-        let unshredded_variant = DataType::unshredded_variant();
-        let unshredded_variant_arrow = ArrowDataType::try_from_kernel(&unshredded_variant)?;
+        let unshredded_variant_arrow = ArrowDataType::try_from_kernel(&UNSHREDDED_VARIANT_SCHEMA)?;
         assert!(unshredded_variant_arrow == unshredded_variant_arrow_type());
         let shredded_variant = DataType::variant_type([
-            StructField::nullable("metadata", DataType::BINARY),
+            StructField::not_null("metadata", DataType::BINARY),
             StructField::nullable("value", DataType::BINARY),
             StructField::nullable("typed_value", DataType::INTEGER),
         ])?;

--- a/kernel/src/engine/arrow_utils.rs
+++ b/kernel/src/engine/arrow_utils.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, OnceLock};
 
 use crate::engine::arrow_conversion::{TryFromKernel as _, TryIntoArrow as _};
 use crate::engine::ensure_data_types::DataTypeCompat;
-use crate::schema::{ColumnMetadataKey, MetadataValue};
+use crate::schema::{ColumnMetadataKey, MetadataValue, UNSHREDDED_VARIANT_SCHEMA};
 use crate::{
     engine::arrow_data::ArrowEngineData,
     schema::{DataType, MetadataColumnSpec, Schema, SchemaRef, StructField, StructType},
@@ -429,7 +429,7 @@ fn get_indices(
         {
             // If the field is a variant, make sure the parquet schema matches the unshredded variant
             // representation. This is to ensure that shredded reads are not performed.
-            if requested_field.data_type == DataType::unshredded_variant() {
+            if requested_field.data_type == *UNSHREDDED_VARIANT_SCHEMA {
                 validate_parquet_variant(field)?;
             }
             match field.data_type() {

--- a/kernel/src/engine/ensure_data_types.rs
+++ b/kernel/src/engine/ensure_data_types.rs
@@ -269,7 +269,7 @@ mod tests {
 
     use crate::engine::arrow_conversion::TryFromKernel as _;
     use crate::engine::arrow_data::unshredded_variant_arrow_type;
-    use crate::schema::{ArrayType, DataType, MapType, StructField};
+    use crate::schema::{ArrayType, DataType, MapType, StructField, UNSHREDDED_VARIANT_SCHEMA};
     use crate::utils::test_utils::assert_result_error_with_message;
 
     use super::*;
@@ -341,14 +341,14 @@ mod tests {
         }
 
         assert!(ensure_data_types(
-            &DataType::unshredded_variant(),
+            &UNSHREDDED_VARIANT_SCHEMA,
             &unshredded_variant_arrow_type(),
             true
         )
         .is_ok());
         assert_result_error_with_message(
             ensure_data_types(
-                &DataType::unshredded_variant(),
+                &UNSHREDDED_VARIANT_SCHEMA,
                 &incorrect_variant_arrow_type(),
                 true,
             ),

--- a/kernel/src/engine/parquet_row_group_skipping/tests.rs
+++ b/kernel/src/engine/parquet_row_group_skipping/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::expressions::{column_name, column_pred};
 use crate::kernel_predicates::DataSkippingPredicateEvaluator as _;
 use crate::parquet::arrow::arrow_reader::ArrowReaderMetadata;
+use crate::schema::UNSHREDDED_VARIANT_SCHEMA;
 use crate::Predicate;
 use std::fs::File;
 
@@ -216,7 +217,7 @@ fn test_get_stat_values() {
     assert_eq!(
         filter.get_min_stat(
             &column_name!("chrono.date32"),
-            &DataType::unshredded_variant()
+            &UNSHREDDED_VARIANT_SCHEMA,
         ),
         None
     );
@@ -398,7 +399,7 @@ fn test_get_stat_values() {
     assert_eq!(
         filter.get_max_stat(
             &column_name!("chrono.date32"),
-            &DataType::unshredded_variant()
+            &UNSHREDDED_VARIANT_SCHEMA,
         ),
         None
     );

--- a/kernel/src/schema/variant_utils.rs
+++ b/kernel/src/schema/variant_utils.rs
@@ -45,14 +45,14 @@ pub(crate) fn validate_variant_type_feature_support(
 mod tests {
     use super::*;
     use crate::actions::Protocol;
-    use crate::schema::{DataType, StructField, StructType};
+    use crate::schema::{DataType, StructField, StructType, UNSHREDDED_VARIANT_SCHEMA};
     use crate::table_features::{ReaderFeature, WriterFeature};
     use crate::utils::test_utils::assert_result_error_with_message;
 
     #[test]
     fn test_is_unshredded_variant() {
         fn is_unshredded_variant(s: &DataType) -> bool {
-            s == &DataType::unshredded_variant()
+            *s == *UNSHREDDED_VARIANT_SCHEMA
         }
         assert!(!is_unshredded_variant(
             &DataType::variant_type([

--- a/kernel/tests/write.rs
+++ b/kernel/tests/write.rs
@@ -29,7 +29,7 @@ use serde_json::json;
 use serde_json::Deserializer;
 use tempfile::tempdir;
 
-use delta_kernel::schema::{DataType, SchemaRef, StructField, StructType};
+use delta_kernel::schema::{DataType, SchemaRef, StructField, StructType, UNSHREDDED_VARIANT_SCHEMA};
 
 use test_utils::{
     assert_result_error_with_message, create_table, engine_store_setup, setup_test_tables,
@@ -951,7 +951,7 @@ async fn test_append_variant() -> Result<(), Box<dyn std::error::Error>> {
     let value_nested_v_array = Arc::new(BinaryArray::from(value_nested_v)) as ArrayRef;
     let metadata_nested_v_array = Arc::new(BinaryArray::from(metadata_nested_v)) as ArrayRef;
 
-    let variant_arrow = ArrowDataType::try_from_kernel(&DataType::unshredded_variant()).unwrap();
+    let variant_arrow = ArrowDataType::try_from_kernel(&UNSHREDDED_VARIANT_SCHEMA).unwrap();
     let variant_arrow_flipped = variant_arrow_type_flipped();
 
     let i_values = vec![31, 32, 33];
@@ -1064,7 +1064,7 @@ async fn test_append_variant() -> Result<(), Box<dyn std::error::Error>> {
         Some(null_bitmap),
     )?);
     let variant_arrow_type: ArrowDataType =
-        ArrowDataType::try_from_kernel(&DataType::unshredded_variant()).unwrap();
+        ArrowDataType::try_from_kernel(&UNSHREDDED_VARIANT_SCHEMA).unwrap();
     let expected_data = RecordBatch::try_new(
         Arc::new(expected_schema.as_ref().try_into_arrow()?),
         vec![


### PR DESCRIPTION
## What changes are proposed in this pull request?

The `inspect-table` example had rotted and was not runnable. It also lacked domain metadata support. 

Additionally, upgrade the example's `actions` command with a `--stats-only` flag that avoids materializing file actions. 

The command now unconditionally emits stats such as the following:
```
Found 479908 'add' actions
Found 1 'protocol' actions
Found 1 'metadata' actions
```

If `--stats-only` was _not_ supplied, the stats are followed by a complete printout of log actions, as before.

## How was this change tested?

Example code now runs nicely.