### PR TITLE
Allow converting `bytes::Bytes` into a Binary Scalar

### DIFF
--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -546,6 +546,12 @@ impl From<&[u8]> for Scalar {
     }
 }
 
+impl From<bytes::Bytes> for Scalar {
+    fn from(b: bytes::Bytes) -> Self {
+        Self::Binary(b.to_vec())
+    }
+}
+
 impl<T> TryFrom<Vec<T>> for Scalar
 where
     T: Into<Scalar> + ToDataType,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Allow converting `bytes::Bytes` into a Binary Scalar.

<!--
Please clarify what changes you are proposing and why the changes are needed.
The purpose of this section is to outline the changes, why they are needed, and how this PR fixes the issue.
If the reason for the change is already explained clearly in an issue, then it does not need to be restated here.
  1. If you propose a new API or feature, clarify the use case for a new API or feature.
  2. If you fix a bug, you can clarify why it is a bug.
-->

<!--
Uncomment this section if there are any changes affecting public APIs:
### This PR affects the following public APIs

If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.

Note that _new_ public APIs are not considered breaking.
-->


## How was this change tested?
<!--
Please make sure to add test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested, ideally via a reproducible test documented in the PR description.
-->