### PR TITLE
feat: Set "isBlindAppend" to true always in write Transactions

### DIFF
--- a/kernel/tests/write.rs
+++ b/kernel/tests/write.rs
@@ -90,6 +90,7 @@ async fn test_commit_info() -> Result<(), Box<dyn std::error::Error>> {
                 "operationParameters": {},
                 "engineInfo": "default engine",
                 "txnId": ZERO_UUID,
+                "isBlindAppend": true,
             }
         });
 
@@ -245,7 +246,8 @@ async fn test_commit_info_action() -> Result<(), Box<dyn std::error::Error>> {
                 "kernelVersion": format!("v{}", env!("CARGO_PKG_VERSION")),
                 "operationParameters": {},
                 "engineInfo": "default engine",
-                "txnId": ZERO_UUID
+                "txnId": ZERO_UUID,
+                "isBlindAppend": true,
             }
         })];
 
@@ -307,7 +309,8 @@ async fn test_append() -> Result<(), Box<dyn std::error::Error>> {
                     "operation": "UNKNOWN",
                     "kernelVersion": format!("v{}", env!("CARGO_PKG_VERSION")),
                     "operationParameters": {},
-                    "txnId": ZERO_UUID
+                    "txnId": ZERO_UUID,
+                    "isBlindAppend": true,
                 }
             }),
             json!({
@@ -515,7 +518,8 @@ async fn test_append_partitioned() -> Result<(), Box<dyn std::error::Error>> {
                     "kernelVersion": format!("v{}", env!("CARGO_PKG_VERSION")),
                     "operationParameters": {},
                     "engineInfo": "default engine",
-                    "txnId": ZERO_UUID
+                    "txnId": ZERO_UUID,
+                    "isBlindAppend": true,
                 }
             }),
             json!({
@@ -734,7 +738,8 @@ async fn test_write_txn_actions() -> Result<(), Box<dyn std::error::Error>> {
                     "kernelVersion": format!("v{}", env!("CARGO_PKG_VERSION")),
                     "operationParameters": {},
                     "engineInfo": "default engine",
-                    "txnId": ZERO_UUID
+                    "txnId": ZERO_UUID,
+                    "isBlindAppend": true,
                 }
             }),
             json!({


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-incubator/delta-kernel-rs/blob/main/CONTRIBUTING.md
  2. Run `cargo t --all-features --all-targets` to get started testing, and run `cargo fmt`.
  3. Ensure you have added or run the appropriate tests for your PR.
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

<!--
PR title formatting:
This project uses conventional commits: https://www.conventionalcommits.org/

Each PR corresponds to a commit on the `main` branch, with the title of the PR (typically) being
used for the commit message on main. In order to ensure proper formatting in the CHANGELOG please
ensure your PR title adheres to the conventional commit specification.

Examples:
- new feature PR: "feat: new API for snapshot.update()"
- bugfix PR: "fix: correctly apply DV in read-table example"
-->

## What changes are proposed in this pull request?
<!--
Please clarify what changes you are proposing and why the changes are needed.
The purpose of this section is to outline the changes, why they are needed, and how this PR fixes the issue.
If the reason for the change is already explained clearly in an issue, then it does not need to be restated here.
  1. If you propose a new API or feature, clarify the use case for a new API or feature.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Add "isBlindAppend" property to CommitInfo in the same way as it's done in Java's Delta implementation.

This is how kernel-java calculates blind append: https://github.com/delta-io/delta/blob/master/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala#L1453-L1458
The logic is:
  1. `isBlindAppend` is `true` when:
    - All file actions in the transaction are AddFile (no removes/updates)
    - AND the transaction doesn't depend on reading existing files (readPredicates is empty AND readFiles is empty)
  2. `isBlindAppend` is `false` when:
    - There are non-AddFile actions (like RemoveFile)
    - OR the transaction read from existing files (has read predicates or read files)

Currently, kernel-rs doesn't support any RemoveFile actions and doesn't read existing files in write transactions; that's why **isBlindAppend should always be true**.

Open question: How can we ensure that the `isBlindAppend` calculation is updated when someone adds `RemoveFile` actions?
We could make the `Transaction.add_files_metadata` field type an enum that includes `AddFile` and `RemoveFile`. However, from previous PRs, I noticed that this enum was removed, and the field became just `add_files_metadata`. So, is it most likely that removing will be another field like `remove_files_metadata`?

<!--
Uncomment this section if there are any changes affecting public APIs:
### This PR affects the following public APIs

If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.

Note that _new_ public APIs are not considered breaking.
-->


## How was this change tested?
<!--
Please make sure to add test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested, ideally via a reproducible test documented in the PR description.
-->

Updated existing tests that write to the table by adding the expected "isBlindAppend: true".