### PR TITLE
refactor: Avoid overly complex itertools methods in log listing code

### DIFF
--- a/kernel/src/listed_log_files.rs
+++ b/kernel/src/listed_log_files.rs
@@ -307,7 +307,7 @@ impl ListedLogFiles {
             //
             // If this version has a complete checkpoint, we can drop the existing commit and
             // compaction files we collected so far -- except we must keep the latest commit.
-            fn flush_group(&mut self, version: Version) {
+            fn flush_checkpoint_group(&mut self, version: Version) {
                 let new_checkpoint_parts = std::mem::take(&mut self.new_checkpoint_parts);
                 if let Some((_, complete_checkpoint)) = group_checkpoint_parts(new_checkpoint_parts)
                     .into_iter()
@@ -345,14 +345,14 @@ impl ListedLogFiles {
             // Process remaining files, flushing the previous groups first if the version changed
             while let Some(file) = log_files.next().transpose()? {
                 if file.version != group_version {
-                    builder.flush_group(group_version);
+                    builder.flush_checkpoint_group(group_version);
                     group_version = file.version;
                 }
                 builder.process_file(file);
             }
 
             // Flush the final group, which must always contain at least one file
-            builder.flush_group(group_version);
+            builder.flush_checkpoint_group(group_version);
         }
 
         // Since ascending_commit_files is cleared at each checkpoint, if it's non-empty here


### PR DESCRIPTION
## What changes are proposed in this pull request?

`Itertools::process_results` and `chunk_by` methods have very complex semantics without any significant code size reduction to compensate. Eliminate them from log listing logic to make the control flow easier to understand and maintain.

## How was this change tested?

Existing log listing unit tests are quite extensive.