### PR TITLE
fix: post-process scale-0 decimals in JSON stats with regex

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -54,6 +54,7 @@ tracing = { version = "0.1", features = ["log"] }
 url = "2"
 uuid = { version = "1.18.0", features = ["v4", "fast-rng"] }
 z85 = "3.0.6"
+regex = "1"
 
 # optional deps
 futures = { version = "0.3", optional = true }


### PR DESCRIPTION

## What changes are proposed in this pull request?
<!--
Please clarify what changes you are proposing and why the changes are needed.
The purpose of this section is to outline the changes, why they are needed, and how this PR fixes the issue.
If the reason for the change is already explained clearly in an issue, then it does not need to be restated here.
  1. If you propose a new API or feature, clarify the use case for a new API or feature.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Fixes https://github.com/delta-io/delta-kernel-rs/issues/1431 by post-processing JSON output to strip ".0" suffix from Decimal columns with scale=0.


## How was this change tested?
<!--
Please make sure to add test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested, ideally via a reproducible test documented in the PR description.
-->

new unit test