### PR TITLE
fix: Use EncoderFactory for Decimal Scale-Zero JSON Encoding

### DIFF
--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -496,7 +496,8 @@ impl EncoderFactory for DecimalScaleZeroEncoderFactory {
                     .downcast_ref::<Decimal128Array>()
                     .ok_or_else(|| {
                         ArrowError::InvalidArgumentError(format!(
-                            "Field type is Decimal128 but array type is {}. This is a bug.",
+                            "Field {} has type Decimal128 but array has type {}. This is a bug.",
+                            field.name(),
                             array.data_type()
                         ))
                     })?;
@@ -514,7 +515,8 @@ impl EncoderFactory for DecimalScaleZeroEncoderFactory {
                     .downcast_ref::<Decimal256Array>()
                     .ok_or_else(|| {
                         ArrowError::InvalidArgumentError(format!(
-                            "Field type is Decimal256 but array type is {}. This is a bug.",
+                            "Field {} has type Decimal256 but array has type {}. This is a bug.",
+                            field.name(),
                             array.data_type()
                         ))
                     })?;
@@ -1427,4 +1429,5 @@ mod tests {
             json2
         );
     }
+
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?
<!--
Please clarify what changes you are proposing and why the changes are needed.
The purpose of this section is to outline the changes, why they are needed, and how this PR fixes the issue.
If the reason for the change is already explained clearly in an issue, then it does not need to be restated here.
  1. If you propose a new API or feature, clarify the use case for a new API or feature.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fixes https://github.com/delta-io/delta-kernel-rs/issues/1431 with Arrow's EncoderFactory pattern for encoding Decimal(*, 0) types as integers in JSON output 


## How was this change tested?
<!--
Please make sure to add test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested, ideally via a reproducible test documented in the PR description.
-->

New test cases