### PR TITLE
feat: add tags field to LastCheckpointHint

### DIFF
--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -267,6 +267,9 @@ fn visit_expression_literal_string_impl(
 
 // We need to get parse.expand working to be able to macro everything below, see issue #255
 
+// This is a function called by the engine to transform the engine expression into a kernel expression
+// The engine visitor calls this function with the argument (predicate, kernel_expression_visitor) where
+// kernel_expression_visitor is a pointer to the KernelExpressionVisitorState struct.
 #[no_mangle]
 pub extern "C" fn visit_expression_literal_int(
     state: &mut KernelExpressionVisitorState,

--- a/kernel/src/last_checkpoint_hint.rs
+++ b/kernel/src/last_checkpoint_hint.rs
@@ -1,6 +1,8 @@
 //! Utities for reading the `_last_checkpoint` file. Maybe this file should instead go under
 //! log_segment module since it should only really be used there? as hint for listing?
 
+use std::collections::HashMap;
+
 use crate::schema::Schema;
 use crate::{DeltaResult, Error, StorageHandler, Version};
 use delta_kernel_derive::internal_api;
@@ -34,6 +36,8 @@ pub(crate) struct LastCheckpointHint {
     pub(crate) checkpoint_schema: Option<Schema>,
     /// The checksum of the last checkpoint JSON.
     pub(crate) checksum: Option<String>,
+    /// Additional metadata about the last checkpoint.
+    pub(crate) tags: Option<HashMap<String, String>>,
 }
 
 impl LastCheckpointHint {
@@ -66,5 +70,11 @@ impl LastCheckpointHint {
                 Ok(None)
             }
         }
+    }
+
+    /// Convert the LastCheckpointHint to JSON bytes
+    #[cfg(test)]
+    pub(crate) fn to_json_bytes(&self) -> Vec<u8> {
+        serde_json::to_vec(self).expect("Failed to convert LastCheckpointHint to JSON bytes")
     }
 }

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -290,6 +290,7 @@ fn build_snapshot_with_correct_last_uuid_checkpoint() {
         num_of_add_files: None,
         checkpoint_schema: None,
         checksum: None,
+        tags: None,
     };
 
     let (storage, log_root) = build_log_with_paths_and_checkpoint(
@@ -381,6 +382,7 @@ fn build_snapshot_with_out_of_date_last_checkpoint() {
         num_of_add_files: None,
         checkpoint_schema: None,
         checksum: None,
+        tags: None,
     };
 
     let (storage, log_root) = build_log_with_paths_and_checkpoint(
@@ -424,6 +426,7 @@ fn build_snapshot_with_correct_last_multipart_checkpoint() {
         num_of_add_files: None,
         checkpoint_schema: None,
         checksum: None,
+        tags: None,
     };
 
     let (storage, log_root) = build_log_with_paths_and_checkpoint(
@@ -473,6 +476,7 @@ fn build_snapshot_with_missing_checkpoint_part_from_hint_fails() {
         num_of_add_files: None,
         checkpoint_schema: None,
         checksum: None,
+        tags: None,
     };
 
     let (storage, log_root) = build_log_with_paths_and_checkpoint(
@@ -516,6 +520,7 @@ fn build_snapshot_with_bad_checkpoint_hint_fails() {
         num_of_add_files: None,
         checkpoint_schema: None,
         checksum: None,
+        tags: None,
     };
 
     let (storage, log_root) = build_log_with_paths_and_checkpoint(
@@ -606,6 +611,7 @@ fn build_snapshot_with_out_of_date_last_checkpoint_and_incomplete_recent_checkpo
         num_of_add_files: None,
         checkpoint_schema: None,
         checksum: None,
+        tags: None,
     };
 
     let (storage, log_root) = build_log_with_paths_and_checkpoint(
@@ -714,6 +720,7 @@ fn build_snapshot_with_checkpoint_greater_than_time_travel_version() {
         num_of_add_files: None,
         checkpoint_schema: None,
         checksum: None,
+        tags: None,
     };
     let (storage, log_root) = build_log_with_paths_and_checkpoint(
         &[
@@ -760,6 +767,7 @@ fn build_snapshot_with_start_checkpoint_and_time_travel_version() {
         num_of_add_files: None,
         checkpoint_schema: None,
         checksum: None,
+        tags: None,
     };
 
     let (storage, log_root) = build_log_with_paths_and_checkpoint(

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -137,7 +137,6 @@ impl DataSkippingFilter {
         let select_stats_evaluator = engine
             .evaluation_handler()
             .new_expression_evaluator(
-                // safety: kernel is very broken if we don't have the schema for Add actions
                 get_log_add_schema().clone(),
                 STATS_EXPR.clone(),
                 DataType::STRING,

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -933,8 +933,41 @@ mod tests {
         assert!(cp.is_none());
     }
 
-    fn valid_last_checkpoint() -> Vec<u8> {
-        r#"{"size":8,"sizeInBytes":21857,"version":1}"#.as_bytes().to_vec()
+    fn valid_last_checkpoint() -> (Vec<u8>, LastCheckpointHint) {
+        let checkpoint = LastCheckpointHint {
+            version: 1,
+            size: 8,
+            parts: None,
+            size_in_bytes: Some(21857),
+            num_of_add_files: None,
+            checkpoint_schema: None,
+            checksum: None,
+            tags: None,
+        };
+        let data = checkpoint.to_json_bytes();
+        (data, checkpoint)
+    }
+
+    fn valid_last_checkpoint_with_tags() -> (Vec<u8>, LastCheckpointHint) {
+        use std::collections::HashMap;
+
+        let (_, base_checkpoint) = valid_last_checkpoint();
+
+        let mut tags = HashMap::new();
+        tags.insert(
+            "author".to_string(),
+            "test_read_table_with_last_checkpoint".to_string(),
+        );
+        tags.insert("environment".to_string(), "snapshot_tests".to_string());
+        tags.insert("created_by".to_string(), "delta-kernel-rs".to_string());
+
+        let checkpoint = LastCheckpointHint {
+            tags: Some(tags),
+            ..base_checkpoint
+        };
+
+        let data = checkpoint.to_json_bytes();
+        (data, checkpoint)
     }
 
     #[test]
@@ -967,42 +1000,39 @@ mod tests {
         // in memory file system
         let store = Arc::new(InMemory::new());
 
-        // put a valid/invalid _last_checkpoint file
-        let data = valid_last_checkpoint();
-        let invalid_data = "invalid".as_bytes().to_vec();
-        let path = Path::from("valid/_last_checkpoint");
-        let invalid_path = Path::from("invalid/_last_checkpoint");
+        // Define test cases: (path, data, expected_result)
+        let (data, expected) = valid_last_checkpoint();
+        let (data_with_tags, expected_with_tags) = valid_last_checkpoint_with_tags();
+        let test_cases = vec![
+            ("valid", data, Some(expected)),
+            ("invalid", "invalid".as_bytes().to_vec(), None),
+            ("valid_with_tags", data_with_tags, Some(expected_with_tags)),
+        ];
 
+        // Write all test files to the in memory file system
         tokio::runtime::Runtime::new()
             .expect("create tokio runtime")
             .block_on(async {
-                store
-                    .put(&path, data.into())
-                    .await
-                    .expect("put _last_checkpoint");
-                store
-                    .put(&invalid_path, invalid_data.into())
-                    .await
-                    .expect("put _last_checkpoint");
+                for (path_prefix, data, _) in &test_cases {
+                    let path = Path::from(format!("{}/_last_checkpoint", path_prefix));
+                    store
+                        .put(&path, data.clone().into())
+                        .await
+                        .expect("put _last_checkpoint");
+                }
             });
 
         let executor = Arc::new(TokioBackgroundExecutor::new());
         let storage = ObjectStoreStorageHandler::new(store, executor);
-        let url = Url::parse("memory:///valid/").expect("valid url");
-        let valid = LastCheckpointHint::try_read(&storage, &url).expect("read last checkpoint");
-        let url = Url::parse("memory:///invalid/").expect("valid url");
-        let invalid = LastCheckpointHint::try_read(&storage, &url).expect("read last checkpoint");
-        let expected = LastCheckpointHint {
-            version: 1,
-            size: 8,
-            parts: None,
-            size_in_bytes: Some(21857),
-            num_of_add_files: None,
-            checkpoint_schema: None,
-            checksum: None,
-        };
-        assert_eq!(valid.unwrap(), expected);
-        assert!(invalid.is_none());
+
+        // Test reading all checkpoints from the in memory file system for cases where the data is valid, invalid and
+        // valid with tags.
+        for (path_prefix, _, expected_result) in test_cases {
+            let url = Url::parse(&format!("memory:///{}/", path_prefix)).expect("valid url");
+            let result =
+                LastCheckpointHint::try_read(&storage, &url).expect("read last checkpoint");
+            assert_eq!(result, expected_result);
+        }
     }
 
     #[test_log::test]


### PR DESCRIPTION
## What changes are proposed in this pull request?
Add optional tags field to LastCheckpointHint struct to support additional metadata about the last checkpoint as specified in Delta Lake protocol. (#1054)


- Add tags: Option<HashMap<String, String>> field to LastCheckpointHint
- Update all test cases to include tags: None
- Maintain backward compatibility through optional field

The tags field enables storing arbitrary string key-value pairs for checkpoint metadata while maintaining full backward compatibility with existing checkpoint files.

### This PR affects the following public APIs
None

## How was this change tested?
Test instances updated: 9 test functions that construct LastCheckpointHint passing in the default value None for the tags