### PR TITLE
chore: Remove a stray comment in the kernel visitor

### DIFF
--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -266,10 +266,6 @@ fn visit_expression_literal_string_impl(
 }
 
 // We need to get parse.expand working to be able to macro everything below, see issue #255
-
-// This is a function called by the engine to transform the engine expression into a kernel expression
-// The engine visitor calls this function with the argument (predicate, kernel_expression_visitor) where
-// kernel_expression_visitor is a pointer to the KernelExpressionVisitorState struct.
 #[no_mangle]
 pub extern "C" fn visit_expression_literal_int(
     state: &mut KernelExpressionVisitorState,


### PR DESCRIPTION
## What changes are proposed in this pull request?
Removes a stray comment which got added in the the kernel visitor.

## How was this change tested?
Comment removal. Cargo build.