### PR TITLE
Revert: feat!: error on surplus columns in output schema

### DIFF
--- a/ffi/src/transaction/write_context.rs
+++ b/ffi/src/transaction/write_context.rs
@@ -43,7 +43,7 @@ pub unsafe extern "C" fn get_write_schema(
     write_context: Handle<SharedWriteContext>,
 ) -> Handle<SharedSchema> {
     let write_context = unsafe { write_context.as_ref() };
-    write_context.logical_schema().clone().into()
+    write_context.schema().clone().into()
 }
 
 /// Get write path from WriteContext handle.

--- a/kernel/src/engine/default/mod.rs
+++ b/kernel/src/engine/default/mod.rs
@@ -99,7 +99,7 @@ impl<E: TaskExecutor> DefaultEngine<E> {
     ) -> DeltaResult<Box<dyn EngineData>> {
         let transform = write_context.logical_to_physical();
         let input_schema = Schema::try_from_arrow(data.record_batch().schema())?;
-        let output_schema = write_context.physical_schema();
+        let output_schema = write_context.schema();
         let logical_to_physical_expr = self.evaluation_handler().new_expression_evaluator(
             input_schema.into(),
             transform.clone(),

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -555,23 +555,9 @@ impl Transaction {
         let target_dir = self.read_snapshot.table_root();
         let snapshot_schema = self.read_snapshot.schema();
         let logical_to_physical = self.generate_logical_to_physical();
-
-        // Compute physical schema: exclude partition columns since they're stored in the path
-        let partition_columns = self
-            .read_snapshot
-            .table_configuration()
-            .metadata()
-            .partition_columns();
-        let physical_fields = snapshot_schema
-            .fields()
-            .filter(|f| !partition_columns.contains(f.name()))
-            .cloned();
-        let physical_schema = Arc::new(StructType::new_unchecked(physical_fields));
-
         WriteContext::new(
             target_dir.clone(),
             snapshot_schema,
-            physical_schema,
             Arc::new(logical_to_physical),
         )
     }
@@ -886,22 +872,15 @@ impl Transaction {
 /// [`Transaction`]: struct.Transaction.html
 pub struct WriteContext {
     target_dir: Url,
-    logical_schema: SchemaRef,
-    physical_schema: SchemaRef,
+    schema: SchemaRef,
     logical_to_physical: ExpressionRef,
 }
 
 impl WriteContext {
-    fn new(
-        target_dir: Url,
-        logical_schema: SchemaRef,
-        physical_schema: SchemaRef,
-        logical_to_physical: ExpressionRef,
-    ) -> Self {
+    fn new(target_dir: Url, schema: SchemaRef, logical_to_physical: ExpressionRef) -> Self {
         WriteContext {
             target_dir,
-            logical_schema,
-            physical_schema,
+            schema,
             logical_to_physical,
         }
     }
@@ -910,12 +889,8 @@ impl WriteContext {
         &self.target_dir
     }
 
-    pub fn logical_schema(&self) -> &SchemaRef {
-        &self.logical_schema
-    }
-
-    pub fn physical_schema(&self) -> &SchemaRef {
-        &self.physical_schema
+    pub fn schema(&self) -> &SchemaRef {
+        &self.schema
     }
 
     pub fn logical_to_physical(&self) -> ExpressionRef {
@@ -1129,46 +1104,6 @@ mod tests {
         let dv_path3 = write_context.new_deletion_vector_path(prefix.clone());
         let abs_path3 = dv_path3.absolute_path()?;
         assert_ne!(abs_path2, abs_path3);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_physical_schema_excludes_partition_columns() -> Result<(), Box<dyn std::error::Error>> {
-        let engine = SyncEngine::new();
-        let path = std::fs::canonicalize(PathBuf::from("./tests/data/basic_partitioned/")).unwrap();
-        let url = url::Url::from_directory_path(path).unwrap();
-        let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
-        let txn = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()))?
-            .with_engine_info("default engine");
-
-        let write_context = txn.get_write_context();
-        let logical_schema = write_context.logical_schema();
-        let physical_schema = write_context.physical_schema();
-
-        // Logical schema should include the partition column
-        assert!(
-            logical_schema.contains("letter"),
-            "Logical schema should contain partition column 'letter'"
-        );
-
-        // Physical schema should exclude the partition column
-        assert!(
-            !physical_schema.contains("letter"),
-            "Physical schema should not contain partition column 'letter' (stored in path)"
-        );
-
-        // Both should contain the non-partition columns
-        assert!(
-            logical_schema.contains("number"),
-            "Logical schema should contain data column 'number'"
-        );
-
-        assert!(
-            physical_schema.contains("number"),
-            "Physical schema should contain data column 'number'"
-        );
 
         Ok(())
     }


### PR DESCRIPTION
This _temporarily_ reverts commit def7919d929ff7a2963a4f1bceeee1cd3afd7397 (PR #1488) so we can have a linear commit history on `main` for 0.18.1 release. I'll un-revert soon as we release.