### PR TITLE
fix: improve parse_json performance by removing line-by-line parsing

### DIFF
--- a/kernel/src/engine/arrow_utils.rs
+++ b/kernel/src/engine/arrow_utils.rs
@@ -1075,19 +1075,19 @@ fn parse_json_impl(json_strings: &StringArray, schema: ArrowSchemaRef) -> DeltaR
         .with_batch_size(json_strings.len())
         .build_decoder()?;
 
-    for (idx, json) in json_strings.iter().enumerate() {
+    for (json, row_number) in json_strings.iter().zip(1..) {
         let line = json.unwrap_or("{}");
         let consumed = decoder.decode(line.as_bytes())?;
         // did we fail to decode the whole line, or was the line partial
         if consumed != line.len() || decoder.has_partial_record() {
             return Err(Error::Generic(format!(
-                "Malformed JSON: Multiple, partial, or 0 JSON objects on row {idx}"
+                "Malformed JSON: Multiple, partial, or 0 JSON objects on row {row_number}"
             )));
         }
         // did we decode exactly one record
-        if decoder.len() - idx != 1 {
+        if decoder.len() != row_number {
             return Err(Error::Generic(format!(
-                "Malformed JSON: Multiple, partial, or 0 JSON objects on row {idx}"
+                "Malformed JSON: Multiple, partial, or 0 JSON objects on row {row_number}"
             )));
         }
     }


### PR DESCRIPTION
This change removes some previous code which was written to work around arrow behaviors which have since been remediated. This rlies now far more on the arrow-json decoder and therefore will allocate less and execute faster.


Using a proprietary table with billions of actions I was running a simple `deltalake::open_table()` on a local file system of the transaction log. The big thing to note is that there about 400k fewer allocations and much less throw-away memory usage (yellow)

## Before

### Allocations

<img width="2496" height="1139" alt="allocated-0 18 2-unmodified" src="https://github.com/user-attachments/assets/2795db2c-aec6-4dce-80ae-958868cccff6" />


### Memory Consumption

<img width="2496" height="1139" alt="consumed-0 18 2-unmodified" src="https://github.com/user-attachments/assets/8b518310-cd98-4432-b272-3c66b41a8e68" />



## With this change

### Allocations


<img width="2496" height="1139" alt="allocated-modified" src="https://github.com/user-attachments/assets/4937f7d8-61cb-4fac-b529-b956ece49289" />

### Memory Consumption

<img width="2496" height="1139" alt="consumed-modified" src="https://github.com/user-attachments/assets/37ff4f53-95c5-4705-86bc-1162c1e6c341" />
