### PR TITLE
fix: work on exposing the required dataChange field upwards to engines

### DIFF
--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -288,7 +288,7 @@ pub(crate) static SCAN_ROW_SCHEMA: LazyLock<Arc<StructType>> = LazyLock::new(|| 
         StructField::nullable(BASE_ROW_ID_NAME, DataType::LONG),
         StructField::nullable(DEFAULT_ROW_COMMIT_VERSION_NAME, DataType::LONG),
         StructField::nullable(
-            "tags",
+            TAGS_NAME,
             MapType::new(
                 DataType::STRING,
                 DataType::STRING,
@@ -300,6 +300,7 @@ pub(crate) static SCAN_ROW_SCHEMA: LazyLock<Arc<StructType>> = LazyLock::new(|| 
         StructField::nullable("path", DataType::STRING),
         StructField::nullable("size", DataType::LONG),
         StructField::nullable("modificationTime", DataType::LONG),
+        StructField::nullable("dataChange", DataType::BOOLEAN),
         StructField::nullable("stats", DataType::STRING),
         StructField::nullable("deletionVector", DeletionVectorDescriptor::to_schema()),
         StructField::nullable(FILE_CONSTANT_VALUES_NAME, file_constant_values),
@@ -316,6 +317,7 @@ fn get_add_transform_expr() -> ExpressionRef {
             column_expr_ref!("add.path"),
             column_expr_ref!("add.size"),
             column_expr_ref!("add.modificationTime"),
+            column_expr_ref!("add.dataChange"),
             column_expr_ref!("add.stats"),
             column_expr_ref!("add.deletionVector"),
             Arc::new(Expression::Struct(vec![
@@ -340,6 +342,7 @@ pub(crate) fn get_scan_metadata_transform_expr() -> ExpressionRef {
                 column_expr_ref!("fileConstantValues.partitionValues"),
                 column_expr_ref!("size"),
                 column_expr_ref!("modificationTime"),
+                column_expr_ref!("dataChange"),
                 column_expr_ref!("stats"),
                 column_expr_ref!("fileConstantValues.tags"),
                 column_expr_ref!("deletionVector"),

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -470,6 +470,7 @@ impl Scan {
                     StructField::not_null("partitionValues", partition_values),
                     StructField::not_null("size", DataType::LONG),
                     StructField::nullable("modificationTime", DataType::LONG),
+                    StructField::nullable("dataChange", DataType::BOOLEAN),
                     StructField::nullable("stats", DataType::STRING),
                     StructField::nullable(
                         "tags",
@@ -683,6 +684,7 @@ impl Scan {
 ///    path: string,
 ///    size: long,
 ///    modificationTime: long,
+///    dataChange: bool,
 ///    stats: string,
 ///    deletionVector: {
 ///      storageType: string,

--- a/kernel/src/scan/state.rs
+++ b/kernel/src/scan/state.rs
@@ -186,7 +186,7 @@ impl<T> RowVisitor for ScanFileVisitor<'_, T> {
     }
     fn visit<'a>(&mut self, row_count: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
         require!(
-            getters.len() == 13,
+            getters.len() == 14,
             Error::InternalError(format!(
                 "Wrong number of ScanFileVisitor getters: {}",
                 getters.len()
@@ -201,7 +201,7 @@ impl<T> RowVisitor for ScanFileVisitor<'_, T> {
             if let Some(path) = getters[0].get_opt(row_index, "scanFile.path")? {
                 let size = getters[1].get(row_index, "scanFile.size")?;
                 let modification_time: i64 = getters[2].get(row_index, "add.modificationTime")?;
-                let stats: Option<String> = getters[3].get_opt(row_index, "scanFile.stats")?;
+                let stats: Option<String> = getters[4].get_opt(row_index, "scanFile.stats")?;
                 let stats: Option<Stats> =
                     stats.and_then(|json| match serde_json::from_str(json.as_str()) {
                         Ok(stats) => Some(stats),
@@ -217,7 +217,7 @@ impl<T> RowVisitor for ScanFileVisitor<'_, T> {
                 let deletion_vector = visit_deletion_vector_at(row_index, &getters[dv_index..])?;
                 let dv_info = DvInfo { deletion_vector };
                 let partition_values =
-                    getters[9].get(row_index, "scanFile.fileConstantValues.partitionValues")?;
+                    getters[10].get(row_index, "scanFile.fileConstantValues.partitionValues")?;
                 let scan_file = ScanFile {
                     path,
                     size,

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -526,7 +526,7 @@ impl Transaction {
     /// [`add_files`]: crate::transaction::Transaction::add_files
     /// [`ParquetHandler`]: crate::ParquetHandler
     pub fn add_files_schema(&self) -> &'static SchemaRef {
-        &BASE_ADD_FILES_SCHEMA
+        &ADD_FILES_SCHEMA_WITH_DATA_CHANGE
     }
 
     // Generate the logical-to-physical transform expression which must be evaluated on every data
@@ -1094,6 +1094,7 @@ mod tests {
             ),
             StructField::not_null("size", DataType::LONG),
             StructField::not_null("modificationTime", DataType::LONG),
+            StructField::not_null("dataChange", DataType::BOOLEAN),
             StructField::nullable(
                 "stats",
                 DataType::struct_type_unchecked(vec![StructField::nullable(


### PR DESCRIPTION
Right now this is not working because there is far too much gnarly hard-coding of array offsets here.
