### PR TITLE
Refactor `ListedLogFiles::try_new` to be more extensible and with default values by using builder pattern

### DIFF
--- a/kernel/src/listed_log_files.rs
+++ b/kernel/src/listed_log_files.rs
@@ -31,18 +31,81 @@ use url::Url;
 /// - `checkpoint_parts`: All parts of the most recent complete checkpoint (all same version). Empty if no checkpoint found.
 /// - `latest_crc_file`: The CRC file with the highest version, if any.
 /// - `latest_commit_file`: The commit file with the highest version, or `None` if no commits were found.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 #[internal_api]
 pub(crate) struct ListedLogFiles {
-    pub(crate) ascending_commit_files: Vec<ParsedLogPath>,
-    pub(crate) ascending_compaction_files: Vec<ParsedLogPath>,
-    pub(crate) checkpoint_parts: Vec<ParsedLogPath>,
-    pub(crate) latest_crc_file: Option<ParsedLogPath>,
-    pub(crate) latest_commit_file: Option<ParsedLogPath>,
+    ascending_commit_files: Vec<ParsedLogPath>,
+    ascending_compaction_files: Vec<ParsedLogPath>,
+    checkpoint_parts: Vec<ParsedLogPath>,
+    latest_crc_file: Option<ParsedLogPath>,
+    latest_commit_file: Option<ParsedLogPath>,
 }
 
-/// Type alias that allows us to cleanly construct a [`ListedLogFiles`] with validation via [`ListedLogFiles::try_new`].
-pub(crate) type UnvalidatedListedLogFiles = ListedLogFiles;
+/// Builder for constructing a validated [`ListedLogFiles`].
+///
+/// Use struct literal syntax with `..Default::default()` to set only the fields you need,
+/// then call `.build()` to validate and produce a `ListedLogFiles`.
+#[derive(Debug, Default)]
+pub(crate) struct ListedLogFilesBuilder {
+    pub ascending_commit_files: Vec<ParsedLogPath>,
+    pub ascending_compaction_files: Vec<ParsedLogPath>,
+    pub checkpoint_parts: Vec<ParsedLogPath>,
+    pub latest_crc_file: Option<ParsedLogPath>,
+    pub latest_commit_file: Option<ParsedLogPath>,
+}
+
+impl ListedLogFilesBuilder {
+    /// Validates the builder contents and produces a [`ListedLogFiles`].
+    pub(crate) fn build(self) -> DeltaResult<ListedLogFiles> {
+        // We are adding debug_assertions here since we want to validate invariants that are
+        // (relatively) expensive to compute
+        #[cfg(debug_assertions)]
+        {
+            assert!(self
+                .ascending_compaction_files
+                .windows(2)
+                .all(|pair| match pair {
+                    [ParsedLogPath {
+                        version: version0,
+                        file_type: LogPathFileType::CompactedCommit { hi: hi0 },
+                        ..
+                    }, ParsedLogPath {
+                        version: version1,
+                        file_type: LogPathFileType::CompactedCommit { hi: hi1 },
+                        ..
+                    }] => version0 < version1 || (version0 == version1 && hi0 <= hi1),
+                    _ => false,
+                }));
+
+            assert!(self
+                .checkpoint_parts
+                .iter()
+                .all(|part| part.is_checkpoint()));
+
+            // for a multi-part checkpoint, check that they are all same version and all the parts are there
+            if self.checkpoint_parts.len() > 1 {
+                assert!(self
+                    .checkpoint_parts
+                    .windows(2)
+                    .all(|pair| pair[0].version == pair[1].version));
+
+                assert!(self.checkpoint_parts.iter().all(|part| matches!(
+                    part.file_type,
+                    LogPathFileType::MultiPartCheckpoint { num_parts, .. }
+                    if self.checkpoint_parts.len() == num_parts as usize
+                )));
+            }
+        }
+
+        Ok(ListedLogFiles {
+            ascending_commit_files: self.ascending_commit_files,
+            ascending_compaction_files: self.ascending_compaction_files,
+            checkpoint_parts: self.checkpoint_parts,
+            latest_crc_file: self.latest_crc_file,
+            latest_commit_file: self.latest_commit_file,
+        })
+    }
+}
 
 /// Returns a fallible iterator of [`ParsedLogPath`] over versions `start_version..=end_version`
 /// taking into account the `log_tail` which was (ostentibly) returned from the catalog. If there
@@ -169,51 +232,6 @@ fn group_checkpoint_parts(parts: Vec<ParsedLogPath>) -> HashMap<u32, Vec<ParsedL
 }
 
 impl ListedLogFiles {
-    // Note: for now we expose the constructor as pub(crate) to allow for use in testing. Ideally,
-    // we should explore entirely encapsulating ListedLogFiles within LogSegment - currently
-    // LogSegment constructor requires a ListedLogFiles.
-    #[internal_api]
-    pub(crate) fn try_new(raw: UnvalidatedListedLogFiles) -> DeltaResult<Self> {
-        // We are adding debug_assertions here since we want to validate invariants that are
-        // (relatively) expensive to compute
-        #[cfg(debug_assertions)]
-        {
-            assert!(raw
-                .ascending_compaction_files
-                .windows(2)
-                .all(|pair| match pair {
-                    [ParsedLogPath {
-                        version: version0,
-                        file_type: LogPathFileType::CompactedCommit { hi: hi0 },
-                        ..
-                    }, ParsedLogPath {
-                        version: version1,
-                        file_type: LogPathFileType::CompactedCommit { hi: hi1 },
-                        ..
-                    }] => version0 < version1 || (version0 == version1 && hi0 <= hi1),
-                    _ => false,
-                }));
-
-            assert!(raw.checkpoint_parts.iter().all(|part| part.is_checkpoint()));
-
-            // for a multi-part checkpoint, check that they are all same version and all the parts are there
-            if raw.checkpoint_parts.len() > 1 {
-                assert!(raw
-                    .checkpoint_parts
-                    .windows(2)
-                    .all(|pair| pair[0].version == pair[1].version));
-
-                assert!(raw.checkpoint_parts.iter().all(|part| matches!(
-                    part.file_type,
-                    LogPathFileType::MultiPartCheckpoint { num_parts, .. }
-                    if raw.checkpoint_parts.len() == num_parts as usize
-                )));
-            }
-        }
-
-        Ok(raw)
-    }
-
     #[allow(clippy::type_complexity)] // It's the most readable way to destructure
     pub(crate) fn into_parts(
         self,
@@ -265,11 +283,12 @@ impl ListedLogFiles {
                 .try_collect()?;
         // .last() on a slice is an O(1) operation
         let latest_commit_file = listed_commits.last().cloned();
-        ListedLogFiles::try_new(UnvalidatedListedLogFiles {
+        ListedLogFilesBuilder {
             ascending_commit_files: listed_commits,
             latest_commit_file,
             ..Default::default()
-        })
+        }
+        .build()
     }
 
     /// List all commit and checkpoint files with versions above the provided `start_version` (inclusive).
@@ -396,13 +415,14 @@ impl ListedLogFiles {
             builder.latest_commit_file = Some(commit_file.clone());
         }
 
-        ListedLogFiles::try_new(UnvalidatedListedLogFiles {
+        ListedLogFilesBuilder {
             ascending_commit_files: builder.ascending_commit_files,
             ascending_compaction_files: builder.ascending_compaction_files,
             checkpoint_parts: builder.checkpoint_parts,
             latest_crc_file: builder.latest_crc_file,
             latest_commit_file: builder.latest_commit_file,
-        })
+        }
+        .build()
     }
 
     /// List all commit and checkpoint files after the provided checkpoint. It is guaranteed that all

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -17,7 +17,7 @@ use crate::engine::default::filesystem::ObjectStoreStorageHandler;
 use crate::engine::default::DefaultEngine;
 use crate::engine::sync::SyncEngine;
 use crate::last_checkpoint_hint::LastCheckpointHint;
-use crate::listed_log_files::UnvalidatedListedLogFiles;
+use crate::listed_log_files::ListedLogFilesBuilder;
 use crate::log_replay::ActionsBatch;
 use crate::log_segment::{ListedLogFiles, LogSegment};
 use crate::parquet::arrow::ArrowWriter;
@@ -1109,11 +1109,12 @@ async fn test_create_checkpoint_stream_returns_checkpoint_batches_as_is_if_schem
     let v2_checkpoint_read_schema = get_commit_schema().project(&[METADATA_NAME])?;
 
     let log_segment = LogSegment::try_new(
-        ListedLogFiles::try_new(UnvalidatedListedLogFiles {
+        ListedLogFilesBuilder {
             checkpoint_parts: vec![create_log_path(&checkpoint_one_file)],
             latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
             ..Default::default()
-        })?,
+        }
+        .build()?,
         log_root,
         None,
     )?;
@@ -1169,14 +1170,15 @@ async fn test_create_checkpoint_stream_returns_checkpoint_batches_if_checkpoint_
     let v2_checkpoint_read_schema = get_commit_schema().project(&[ADD_NAME])?;
 
     let log_segment = LogSegment::try_new(
-        ListedLogFiles::try_new(UnvalidatedListedLogFiles {
+        ListedLogFilesBuilder {
             checkpoint_parts: vec![
                 create_log_path(&checkpoint_one_file),
                 create_log_path(&checkpoint_two_file),
             ],
             latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
             ..Default::default()
-        })?,
+        }
+        .build()?,
         log_root,
         None,
     )?;
@@ -1223,11 +1225,12 @@ async fn test_create_checkpoint_stream_reads_parquet_checkpoint_batch_without_si
     let v2_checkpoint_read_schema = get_all_actions_schema().project(&[ADD_NAME, SIDECAR_NAME])?;
 
     let log_segment = LogSegment::try_new(
-        ListedLogFiles::try_new(UnvalidatedListedLogFiles {
+        ListedLogFilesBuilder {
             checkpoint_parts: vec![create_log_path(&checkpoint_one_file)],
             latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
             ..Default::default()
-        })?,
+        }
+        .build()?,
         log_root,
         None,
     )?;
@@ -1270,11 +1273,12 @@ async fn test_create_checkpoint_stream_reads_json_checkpoint_batch_without_sidec
     let v2_checkpoint_read_schema = get_all_actions_schema().project(&[ADD_NAME, SIDECAR_NAME])?;
 
     let log_segment = LogSegment::try_new(
-        ListedLogFiles::try_new(UnvalidatedListedLogFiles {
+        ListedLogFilesBuilder {
             checkpoint_parts: vec![create_log_path(&checkpoint_one_file)],
             latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
             ..Default::default()
-        })?,
+        }
+        .build()?,
         log_root,
         None,
     )?;
@@ -1339,11 +1343,12 @@ async fn test_create_checkpoint_stream_reads_checkpoint_file_and_returns_sidecar
     let v2_checkpoint_read_schema = get_all_actions_schema().project(&[ADD_NAME])?;
 
     let log_segment = LogSegment::try_new(
-        ListedLogFiles::try_new(UnvalidatedListedLogFiles {
+        ListedLogFilesBuilder {
             checkpoint_parts: vec![create_log_path(&checkpoint_file_path)],
             latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
             ..Default::default()
-        })?,
+        }
+        .build()?,
         log_root,
         None,
     )?;
@@ -1810,7 +1815,7 @@ async fn test_commit_cover_minimal_overlap() {
 #[test]
 #[cfg(debug_assertions)]
 fn test_debug_assert_listed_log_file_in_order_compaction_files() {
-    let _ = ListedLogFiles::try_new(UnvalidatedListedLogFiles {
+    let _ = ListedLogFilesBuilder {
         ascending_compaction_files: vec![
             create_log_path(
                 "file:///_delta_log/00000000000000000000.00000000000000000004.compacted.json",
@@ -1823,14 +1828,15 @@ fn test_debug_assert_listed_log_file_in_order_compaction_files() {
             "file:///_delta_log/00000000000000000001.json",
         )),
         ..Default::default()
-    });
+    }
+    .build();
 }
 
 #[test]
 #[should_panic]
 #[cfg(debug_assertions)]
 fn test_debug_assert_listed_log_file_out_of_order_compaction_files() {
-    let _ = ListedLogFiles::try_new(UnvalidatedListedLogFiles {
+    let _ = ListedLogFilesBuilder {
         ascending_compaction_files: vec![
             create_log_path(
                 "file:///_delta_log/00000000000000000000.00000000000000000004.compacted.json",
@@ -1843,14 +1849,15 @@ fn test_debug_assert_listed_log_file_out_of_order_compaction_files() {
             "file:///_delta_log/00000000000000000001.json",
         )),
         ..Default::default()
-    });
+    }
+    .build();
 }
 
 #[test]
 #[should_panic]
 #[cfg(debug_assertions)]
 fn test_debug_assert_listed_log_file_different_multipart_checkpoint_versions() {
-    let _ = ListedLogFiles::try_new(UnvalidatedListedLogFiles {
+    let _ = ListedLogFilesBuilder {
         checkpoint_parts: vec![
             create_log_path(
                 "file:///_delta_log/00000000000000000010.checkpoint.0000000001.0000000002.parquet",
@@ -1863,14 +1870,15 @@ fn test_debug_assert_listed_log_file_different_multipart_checkpoint_versions() {
             "file:///_delta_log/00000000000000000001.json",
         )),
         ..Default::default()
-    });
+    }
+    .build();
 }
 
 #[test]
 #[should_panic]
 #[cfg(debug_assertions)]
 fn test_debug_assert_listed_log_file_invalid_multipart_checkpoint() {
-    let _ = ListedLogFiles::try_new(UnvalidatedListedLogFiles {
+    let _ = ListedLogFilesBuilder {
         checkpoint_parts: vec![
             create_log_path(
                 "file:///_delta_log/00000000000000000010.checkpoint.0000000001.0000000003.parquet",
@@ -1883,7 +1891,8 @@ fn test_debug_assert_listed_log_file_invalid_multipart_checkpoint() {
             "file:///_delta_log/00000000000000000001.json",
         )),
         ..Default::default()
-    });
+    }
+    .build();
 }
 
 #[tokio::test]
@@ -2272,7 +2281,7 @@ async fn test_latest_commit_file_edge_case_commit_before_checkpoint() {
 
 #[test]
 fn test_log_segment_contiguous_commit_files() {
-    let res = ListedLogFiles::try_new(UnvalidatedListedLogFiles {
+    let res = ListedLogFilesBuilder {
         ascending_commit_files: vec![
             create_log_path("file:///_delta_log/00000000000000000001.json"),
             create_log_path("file:///_delta_log/00000000000000000002.json"),
@@ -2282,11 +2291,12 @@ fn test_log_segment_contiguous_commit_files() {
             "file:///_delta_log/00000000000000000001.json",
         )),
         ..Default::default()
-    });
+    }
+    .build();
     assert!(res.is_ok());
 
     // allow gaps in ListedLogFiles
-    let listed = ListedLogFiles::try_new(UnvalidatedListedLogFiles {
+    let listed = ListedLogFilesBuilder {
         ascending_commit_files: vec![
             create_log_path("file:///_delta_log/00000000000000000001.json"),
             create_log_path("file:///_delta_log/00000000000000000003.json"),
@@ -2295,7 +2305,8 @@ fn test_log_segment_contiguous_commit_files() {
             "file:///_delta_log/00000000000000000001.json",
         )),
         ..Default::default()
-    });
+    }
+    .build();
 
     // disallow gaps in LogSegment
     let log_segment = LogSegment::try_new(listed.unwrap(), Url::parse("file:///").unwrap(), None);

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -18,7 +18,7 @@ use crate::engine_data::FilteredEngineData;
 use crate::expressions::transforms::ExpressionTransform;
 use crate::expressions::{ColumnName, ExpressionRef, Predicate, PredicateRef, Scalar};
 use crate::kernel_predicates::{DefaultKernelPredicateEvaluator, EmptyColumnResolver};
-use crate::listed_log_files::{ListedLogFiles, UnvalidatedListedLogFiles};
+use crate::listed_log_files::ListedLogFilesBuilder;
 use crate::log_replay::{ActionsBatch, HasSelectionVector};
 use crate::log_segment::LogSegment;
 use crate::scan::log_replay::BASE_ROW_ID_NAME;
@@ -525,11 +525,12 @@ impl Scan {
         // create a new log segment containing only the commits added after the version hint.
         let mut ascending_commit_files = log_segment.ascending_commit_files.clone();
         ascending_commit_files.retain(|f| f.version > existing_version);
-        let listed_log_files = ListedLogFiles::try_new(UnvalidatedListedLogFiles {
+        let listed_log_files = ListedLogFilesBuilder {
             ascending_commit_files,
             latest_commit_file: log_segment.latest_commit_file.clone(),
             ..Default::default()
-        })?;
+        }
+        .build()?;
         let new_log_segment = LogSegment::try_new(
             listed_log_files,
             log_segment.log_root.clone(),

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -12,7 +12,7 @@ use crate::actions::set_transaction::SetTransactionScanner;
 use crate::actions::INTERNAL_DOMAIN_PREFIX;
 use crate::checkpoint::CheckpointWriter;
 use crate::committer::Committer;
-use crate::listed_log_files::{ListedLogFiles, UnvalidatedListedLogFiles};
+use crate::listed_log_files::{ListedLogFiles, ListedLogFilesBuilder};
 use crate::log_segment::LogSegment;
 use crate::metrics::{MetricEvent, MetricId};
 use crate::path::ParsedLogPath;
@@ -237,13 +237,14 @@ impl Snapshot {
         // we can pass in just the old checkpoint parts since by the time we reach this line, we
         // know there are no checkpoints in the new log segment.
         let combined_log_segment = LogSegment::try_new(
-            ListedLogFiles::try_new(UnvalidatedListedLogFiles {
+            ListedLogFilesBuilder {
                 ascending_commit_files,
                 ascending_compaction_files,
                 checkpoint_parts: old_log_segment.checkpoint_parts.clone(),
                 latest_crc_file,
                 latest_commit_file,
-            })?,
+            }
+            .build()?,
             log_root,
             new_version,
         )?;
@@ -555,7 +556,7 @@ mod tests {
     use crate::engine::default::DefaultEngine;
     use crate::engine::sync::SyncEngine;
     use crate::last_checkpoint_hint::LastCheckpointHint;
-    use crate::listed_log_files::{ListedLogFiles, UnvalidatedListedLogFiles};
+    use crate::listed_log_files::ListedLogFilesBuilder;
     use crate::log_segment::LogSegment;
     use crate::parquet::arrow::ArrowWriter;
     use crate::path::ParsedLogPath;
@@ -1491,10 +1492,11 @@ mod tests {
         })?
         .unwrap()];
 
-        let listed_files = ListedLogFiles::try_new(UnvalidatedListedLogFiles {
+        let listed_files = ListedLogFilesBuilder {
             checkpoint_parts,
             ..Default::default()
-        })?;
+        }
+        .build()?;
 
         let log_segment = LogSegment::try_new(listed_files, url.join("_delta_log/")?, Some(0))?;
         let table_config = snapshot.table_configuration().clone();


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/1585/files) to review incremental changes.
- [**stack/listed_log_files_refactor**](https://github.com/delta-io/delta-kernel-rs/pull/1585) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1585/files)]

---------
This PR refactors `ListedLogFiles::try_new` to instead be `ListedLogFilesBuilder::build()`. 

This allows using default values in the `ListedLogFilesBuilder`, which will make creating `ListedLogFiles` easier in the future (e.g. when we add `max_known_published_commit_version`).
