### PR TITLE
feat: Include max known published commit version inside of `LogSegment`

### DIFF
--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -72,7 +72,7 @@ pub(crate) struct LogSegment {
     /// Note that this published commit file maybe not be included in
     /// [LogSegment::ascending_commit_files] if there is a catalog commit present for the same
     /// version that took priority over it.
-    pub max_known_published_commit_version: Option<Version>,
+    pub max_published_version: Option<Version>,
 }
 
 impl LogSegment {
@@ -89,7 +89,7 @@ impl LogSegment {
             checkpoint_parts,
             latest_crc_file,
             latest_commit_file,
-            max_known_published_commit_version,
+            max_published_version,
         ) = listed_files.into_parts();
 
         // Ensure commit file versions are contiguous
@@ -147,7 +147,7 @@ impl LogSegment {
             latest_crc_file,
             latest_commit_file,
             checkpoint_schema,
-            max_known_published_commit_version,
+            max_published_version,
         })
     }
 

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -2446,7 +2446,7 @@ fn test_publish_validation() {
         latest_crc_file: None,
         latest_commit_file: None,
         checkpoint_schema: None,
-        max_known_published_commit_version: None,
+        max_published_version: None,
     };
 
     assert!(log_segment.validate_no_staged_commits().is_ok());
@@ -2468,7 +2468,7 @@ fn test_publish_validation() {
         latest_crc_file: None,
         latest_commit_file: None,
         checkpoint_schema: None,
-        max_known_published_commit_version: None,
+        max_published_version: None,
     };
 
     // Should fail with staged commits
@@ -2582,61 +2582,61 @@ async fn test_get_file_actions_schema_v1_parquet_with_hint() -> DeltaResult<()> 
 }
 
 #[tokio::test]
-async fn test_max_known_published_commit_version_only_published_commits() {
+async fn test_max_published_version_only_published_commits() {
     let log_segment = create_segment_for(LogSegmentConfig {
         published_commit_versions: &[0, 1, 2, 3, 4],
         ..Default::default()
     })
     .await;
-    assert_eq!(log_segment.max_known_published_commit_version.unwrap(), 4);
+    assert_eq!(log_segment.max_published_version.unwrap(), 4);
 }
 
 #[tokio::test]
-async fn test_max_known_published_commit_version_checkpoint_followed_by_published_commits() {
+async fn test_max_published_version_checkpoint_followed_by_published_commits() {
     let log_segment = create_segment_for(LogSegmentConfig {
         published_commit_versions: &[5, 6, 7, 8],
         checkpoint_version: Some(5),
         ..Default::default()
     })
     .await;
-    assert_eq!(log_segment.max_known_published_commit_version.unwrap(), 8);
+    assert_eq!(log_segment.max_published_version.unwrap(), 8);
 }
 
 #[tokio::test]
-async fn test_max_known_published_commit_version_only_staged_commits() {
+async fn test_max_published_version_only_staged_commits() {
     let log_segment = create_segment_for(LogSegmentConfig {
         staged_commit_versions: &[0, 1, 2, 3, 4],
         ..Default::default()
     })
     .await;
-    assert_eq!(log_segment.max_known_published_commit_version, None);
+    assert_eq!(log_segment.max_published_version, None);
 }
 
 #[tokio::test]
-async fn test_max_known_published_commit_version_checkpoint_followed_by_staged_commits() {
+async fn test_max_published_version_checkpoint_followed_by_staged_commits() {
     let log_segment = create_segment_for(LogSegmentConfig {
         staged_commit_versions: &[5, 6, 7, 8],
         checkpoint_version: Some(5),
         ..Default::default()
     })
     .await;
-    assert_eq!(log_segment.max_known_published_commit_version, None);
+    assert_eq!(log_segment.max_published_version, None);
 }
 
 #[tokio::test]
-async fn test_max_known_published_commit_version_published_and_staged_commits_no_overlap() {
+async fn test_max_published_version_published_and_staged_commits_no_overlap() {
     let log_segment = create_segment_for(LogSegmentConfig {
         published_commit_versions: &[0, 1, 2],
         staged_commit_versions: &[3, 4],
         ..Default::default()
     })
     .await;
-    assert_eq!(log_segment.max_known_published_commit_version.unwrap(), 2);
+    assert_eq!(log_segment.max_published_version.unwrap(), 2);
 }
 
 #[tokio::test]
-async fn test_max_known_published_commit_version_checkpoint_followed_by_published_and_staged_commits_no_overlap(
-) {
+async fn test_max_published_version_checkpoint_followed_by_published_and_staged_commits_no_overlap()
+{
     let log_segment = create_segment_for(LogSegmentConfig {
         published_commit_versions: &[5, 6, 7],
         staged_commit_versions: &[8, 9, 10],
@@ -2644,22 +2644,22 @@ async fn test_max_known_published_commit_version_checkpoint_followed_by_publishe
         ..Default::default()
     })
     .await;
-    assert_eq!(log_segment.max_known_published_commit_version.unwrap(), 7);
+    assert_eq!(log_segment.max_published_version.unwrap(), 7);
 }
 
 #[tokio::test]
-async fn test_max_known_published_commit_version_published_and_staged_commits_with_overlap() {
+async fn test_max_published_version_published_and_staged_commits_with_overlap() {
     let log_segment = create_segment_for(LogSegmentConfig {
         published_commit_versions: &[0, 1, 2],
         staged_commit_versions: &[2, 3, 4],
         ..Default::default()
     })
     .await;
-    assert_eq!(log_segment.max_known_published_commit_version.unwrap(), 2);
+    assert_eq!(log_segment.max_published_version.unwrap(), 2);
 }
 
 #[tokio::test]
-async fn test_max_known_published_commit_version_checkpoint_followed_by_published_and_staged_commits_with_overlap(
+async fn test_max_published_version_checkpoint_followed_by_published_and_staged_commits_with_overlap(
 ) {
     let log_segment = create_segment_for(LogSegmentConfig {
         published_commit_versions: &[5, 6, 7, 8, 9],
@@ -2668,15 +2668,15 @@ async fn test_max_known_published_commit_version_checkpoint_followed_by_publishe
         ..Default::default()
     })
     .await;
-    assert_eq!(log_segment.max_known_published_commit_version.unwrap(), 9);
+    assert_eq!(log_segment.max_published_version.unwrap(), 9);
 }
 
 #[tokio::test]
-async fn test_max_known_published_commit_version_checkpoint_only() {
+async fn test_max_published_version_checkpoint_only() {
     let log_segment = create_segment_for(LogSegmentConfig {
         checkpoint_version: Some(5),
         ..Default::default()
     })
     .await;
-    assert_eq!(log_segment.max_known_published_commit_version, None);
+    assert_eq!(log_segment.max_published_version, None);
 }

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -246,9 +246,9 @@ impl Snapshot {
                 checkpoint_parts: old_log_segment.checkpoint_parts.clone(),
                 latest_crc_file,
                 latest_commit_file,
-                max_known_published_commit_version: new_log_segment
-                    .max_known_published_commit_version
-                    .max(old_log_segment.max_known_published_commit_version),
+                max_published_version: new_log_segment
+                    .max_published_version
+                    .max(old_log_segment.max_published_version),
             }
             .build()?,
             log_root,


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/1587/files) to review incremental changes.
- [**stack/max_known_published_commit_version**](https://github.com/delta-io/delta-kernel-rs/pull/1587) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1587/files)]
  - stack/commit_metadata_max_known_published_commit_version

---------
## What changes are proposed in this pull request?

This PR updates our `LogSegment` and `ListedLogFiles` construction logic to find the `max_known_published_commit_version` while listing + parsing the `_delta_log`.

This will be needed for catalog-managed commits for UnityCatalog. That is, Kernel must provide to the injected Committer the sufficient CommitMetadata that includes this max_known_published_commit_version.

Note that previously we would _stop_ our list iteration once we had found a commit file equal to the start of our `log_tail`.

(1) That seems wrong to me -- what if there are later CRC files?
(2) Now, we continue to parse our listing to indeed find the max known published commit version, even if we won't be including it as a commit-file-to-read inside of our LogSegment.

## How was this change tested?

New UTs.
