### PR TITLE
feat: Change CommitResponse::Committed to return a FileMeta

### DIFF
--- a/uc-catalog/Cargo.toml
+++ b/uc-catalog/Cargo.toml
@@ -14,7 +14,7 @@ version.workspace = true
 release = false
 
 [dependencies]
-delta_kernel = { path = "../kernel", features = ["catalog-managed", "internal-api"] }
+delta_kernel = { path = "../kernel", features = ["catalog-managed"] }
 uc-client = { path = "../uc-client" }
 itertools = "0.14"
 object_store = "0.12.3"

--- a/uc-catalog/src/committer.rs
+++ b/uc-catalog/src/committer.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use delta_kernel::committer::{CommitMetadata, CommitResponse, Committer};
-use delta_kernel::path::ParsedLogPath;
 use delta_kernel::{DeltaResult, Engine, Error as DeltaError, FilteredEngineData};
 use uc_client::models::commits::{Commit, CommitRequest};
 use uc_client::UCCommitsClient;
@@ -86,9 +85,8 @@ impl<C: UCCommitsClient + 'static> Committer for UCCommitter<C> {
                     .map_err(|e| DeltaError::Generic(format!("UC commit error: {e}")))
             })
         })?;
-        let parsed_log_path = ParsedLogPath::try_parse_staged_commit(committed)?;
         Ok(CommitResponse::Committed {
-            data: parsed_log_path,
+            file_meta: committed,
         })
     }
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/1599/files) to review incremental changes.
- [**stack/commit_response_file_meta**](https://github.com/delta-io/delta-kernel-rs/pull/1599) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1599/files)]

---------
## What changes are proposed in this pull request?

This is PR 1 in the effort to create a Post-Commit Snapshot.

This PR changes the `Committer::commit --> CommitResponse` return type for successful commits to return a `FileMeta`

This will be helpful in future PR(s) where we want to create a post-commit-Snapshot.

That is, we (1) commit, (2) get back the written file path (FileMeta), (3) we can append that to our LogSegment.

## How was this change tested?

Pretty trivial change. Added a unit test to delta-kernel module. For the uc-catalog module, unit testing would require UC-Client being a trait, which is WIP.
