### PR TITLE
feat: Propagate top-level struct nulls to child columns in apply_schema

### DIFF
--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -827,6 +827,8 @@ fn test_create_one_mismatching_scalar_types() {
 
 #[test]
 fn test_create_one_not_null_struct() {
+    // Creating a NOT NULL struct field with null values should error.
+    // The error comes from Arrow's RecordBatch validation (non-nullable column has nulls).
     let values: &[Scalar] = &[
         Scalar::Null(KernelDataType::INTEGER),
         Scalar::Null(KernelDataType::INTEGER),
@@ -841,12 +843,14 @@ fn test_create_one_not_null_struct() {
     let handler = ArrowEvaluationHandler;
     assert_result_error_with_message(
         handler.create_one(schema, values),
-        "Invalid struct data: Top-level nulls in struct are not supported",
+        "Column 'a' is declared as non-nullable but contains null values",
     );
 }
 
 #[test]
 fn test_create_one_top_level_null() {
+    // Creating a NOT NULL field with null value should error.
+    // The error comes from Arrow's RecordBatch validation.
     let values = &[Scalar::Null(KernelDataType::INTEGER)];
     let handler = ArrowEvaluationHandler;
 
@@ -854,10 +858,10 @@ fn test_create_one_top_level_null() {
         "col_1",
         KernelDataType::INTEGER,
     )]));
-    assert!(matches!(
+    assert_result_error_with_message(
         handler.create_one(schema, values),
-        Err(Error::InvalidStructData(_))
-    ));
+        "Column 'col_1' is declared as non-nullable but contains null values",
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What changes are proposed in this pull request?
Change `apply_schema` to propagate top-level struct nulls to child columns instead of erroring

When reading Delta logs, each row represents one action type (add, remove, cdc, etc.). Expressions like `add.stats_parsed` need to return null for rows where `add` is null (e.g., remove actions), rather than erroring with "Top-level nulls in struct are not supported".

Arrow stores:
  1. Struct null buffer - indicates which struct rows are null
  2. Child column null buffers - indicate which values within each child are null

These are stored separately. When we call into_parts(), we get:
  - The child columns (with their original null buffers)
  - The struct's null buffer (separate)

  When converting to RecordBatch (which has no concept of "struct-level" nulls since it IS the top-level struct), we need to explicitly propagate the nulls.

## How was this change tested?
Edited unit tests

Added unit test to show new behavior