### PR TITLE
fix: remove `breaking-change` tag after semver passes

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -66,13 +66,14 @@ jobs:
         uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: breaking-change
+      - name: Remove breaking-change label
+        if: needs.check_if_pr_breaks_semver.outputs.check_status == 'success' && contains(github.event.pull_request.labels.*.name, 'breaking-change')
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: breaking-change
       - name: On Success
         if: needs.check_if_pr_breaks_semver.outputs.check_status == 'success'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
         run: |
-          gh pr edit ${{ github.event.pull_request.number }} --remove-label breaking-change 2>/dev/null || true
           echo "Checks succeed"
       - name: Fail On Incorrect Previous Output
         if: needs.check_if_pr_breaks_semver.outputs.check_status != 'success' && needs.check_if_pr_breaks_semver.outputs.check_status != 'failure'


### PR DESCRIPTION
## What changes are proposed in this pull request?
In the past, we automatically run `cargo-semver-checks` to add `breaking-change` tag for PRs. However, the label never been removed after the semver passes. This leads to some PRs incorrectly marked as breaking.(e.g. This PR is marked as breaking since I didnt rebase to main and lack of some pub APIs in main. The tag will not be removed after I rebase).
<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

## How was this change tested?
Tested in my fork repo. For the `no-breaking` PR https://github.com/dengsh12/delta-kernel-rs/pull/3, label was not added. For the `breaking` PR https://github.com/dengsh12/delta-kernel-rs/pull/2, at first it is breaking, after that I restored the breaked API. We can see the robot add the `breaking-change` label first, and then removed it.