### PR TITLE
[DRAFT] perf: Use `old_version + 1` instead of `old_checkpoint.version + 1` when rebuild Snapshot from existing one

### DIFF
--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -76,8 +76,7 @@ impl Snapshot {
     /// We implement a simple heuristic:
     /// 1. if the new version == existing version, just return the existing snapshot
     /// 2. if the new version < existing version, error: there is no optimization to do here
-    /// 3. list from (existing checkpoint version + 1) onward (or just existing snapshot version if
-    ///    no checkpoint)
+    /// 3. list from (existing snapshot version + 1) onward
     /// 4. a. if new checkpoint is found: just create a new snapshot from that checkpoint (and
     ///    commits after it)
     ///    b. if no new checkpoint is found: do lightweight P+M replay on the latest commits (after
@@ -128,8 +127,7 @@ impl Snapshot {
         let log_root = old_log_segment.log_root.clone();
         let storage = engine.storage_handler();
 
-        // Start listing just after the previous segment's checkpoint, if any
-        let listing_start = old_log_segment.checkpoint_version.unwrap_or(0) + 1;
+        let listing_start = old_version + 1;
 
         // Check for new commits (and CRC)
         let new_listed_files = ListedLogFiles::list(


### PR DESCRIPTION
## What changes are proposed in this pull request?

<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

Optimize `Snapshot::build_from`.
We noticed that each call to `Snapshot::build_from` makes, on average, ~100 GET calls. We also found that we're repeatedly reading version.json files we already read. We create checkpoints every 200 iterations, which is why we read from 0 to 200 version.json files each time (~100 is the average).
Then I realized there is an easy way to make it faster by stopping reading the files we already read, because we anyway skip all the version.json files where version is less than the "existing_version" of the provided Snapshot (=hint).

## How was this change tested?

There is already a test that covers all cases for `Snapshot::build_from` named `test_snapshot_new_from`: https://github.com/delta-io/delta-kernel-rs/blob/bc9a5d8574aca5c88fd74bf1ef5942a6fb879deb/kernel/src/snapshot.rs#L719
