### PR TITLE
refactor: add Expression::coalesce helper method

### DIFF
--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -1185,13 +1185,10 @@ mod tests {
         // Create coalesce expression with column that has no nulls, followed by
         // a reference to a non-existent column. If short-circuit works, the
         // non-existent column is never evaluated and no error occurs.
-        let expr = Expression::variadic(
-            VariadicExpressionOp::Coalesce,
-            vec![
-                Expression::column(["a"]),
-                Expression::column(["nonexistent"]), // Would fail if evaluated
-            ],
-        );
+        let expr = Expression::coalesce([
+            Expression::column(["a"]),
+            Expression::column(["nonexistent"]), // Would fail if evaluated
+        ]);
 
         // Should return column "a" directly (short-circuit skips evaluating "nonexistent")
         let result = evaluate_expression(&expr, &batch, Some(&DataType::INTEGER)).unwrap();
@@ -1216,14 +1213,11 @@ mod tests {
 
         // Create coalesce expression: a has nulls, b has none, c doesn't exist.
         // Short-circuit should stop after evaluating b.
-        let expr = Expression::variadic(
-            VariadicExpressionOp::Coalesce,
-            vec![
-                Expression::column(["a"]),
-                Expression::column(["b"]),
-                Expression::column(["nonexistent"]), // Would fail if evaluated
-            ],
-        );
+        let expr = Expression::coalesce([
+            Expression::column(["a"]),
+            Expression::column(["b"]),
+            Expression::column(["nonexistent"]), // Would fail if evaluated
+        ]);
 
         // Should coalesce a and b, never evaluate "nonexistent"
         let result = evaluate_expression(&expr, &batch, Some(&DataType::INTEGER)).unwrap();
@@ -1242,10 +1236,7 @@ mod tests {
         let a_values = Int32Array::from(vec![1, 2, 3]); // No nulls - would short-circuit
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a_values)]).unwrap();
 
-        let expr = Expression::variadic(
-            VariadicExpressionOp::Coalesce,
-            vec![Expression::column(["a"])],
-        );
+        let expr = Expression::coalesce([Expression::column(["a"])]);
 
         // Request STRING type but array is INT32 - should fail even with short-circuit
         let result = evaluate_expression(&expr, &batch, Some(&DataType::STRING));

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -560,7 +560,7 @@ mod tests {
 
     use crate::actions::get_commit_schema;
     use crate::engine::sync::SyncEngine;
-    use crate::expressions::{BinaryExpressionOp, Scalar, VariadicExpressionOp};
+    use crate::expressions::{BinaryExpressionOp, Scalar};
     use crate::log_replay::ActionsBatch;
     use crate::scan::state::ScanFile;
     use crate::scan::state_info::tests::{
@@ -761,17 +761,14 @@ mod tests {
                 assert!(row_id_transform.is_replace);
                 assert_eq!(row_id_transform.exprs.len(), 1);
                 let expr = &row_id_transform.exprs[0];
-                let expeceted_expr = Arc::new(Expr::variadic(
-                    VariadicExpressionOp::Coalesce,
-                    vec![
-                        Expr::column(["row_id_col"]),
-                        Expr::binary(
-                            BinaryExpressionOp::Plus,
-                            Expr::literal(42i64),
-                            Expr::column(["row_indexes_for_row_id_0"]),
-                        ),
-                    ],
-                ));
+                let expeceted_expr = Arc::new(Expr::coalesce([
+                    Expr::column(["row_id_col"]),
+                    Expr::binary(
+                        BinaryExpressionOp::Plus,
+                        Expr::literal(42i64),
+                        Expr::column(["row_indexes_for_row_id_0"]),
+                    ),
+                ]));
                 assert_eq!(expr, &expeceted_expr);
             } else {
                 panic!("Should have been a transform expression");


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/1648/files) to review incremental changes.
- [**stack/coalesce**](https://github.com/delta-io/delta-kernel-rs/pull/1648) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1648/files)]
  - [stack/checkpoint-transforms](https://github.com/delta-io/delta-kernel-rs/pull/1646) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1646/files/e9f2b41a60de195f9dcc585d8320b59528da4d7a..4775644b59a8c195ca95143bb16267d33c844660)]
    - [stack/write-stats](https://github.com/delta-io/delta-kernel-rs/pull/1643) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1643/files/4775644b59a8c195ca95143bb16267d33c844660..3290656716c864826256d8772bf7aa09e95eb3eb)]

---------
## What changes are proposed in this pull request?

This PR adds an `Expression::coalesce` helper method to simplify creating COALESCE expressions, and updates all existing call sites to use the new helper.


## How was this change tested?
Existing tests