### PR TITLE
feat: Introduce TransformationPipeline infra to transform Delta protocol and metadata

### DIFF
--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -349,6 +349,14 @@ impl Metadata {
     pub(crate) fn parse_table_properties(&self) -> TableProperties {
         TableProperties::from(self.configuration.iter())
     }
+
+    /// Return a new Metadata with updated configuration.
+    #[internal_api]
+    #[allow(dead_code)] // Used by table_transformation module
+    pub(crate) fn with_configuration(mut self, configuration: HashMap<String, String>) -> Self {
+        self.configuration = configuration;
+        self
+    }
 }
 
 // NOTE: We can't derive IntoEngineData for Metadata because it has a nested Format struct,
@@ -475,6 +483,79 @@ impl Protocol {
         // Since each reader features is a subset of writer features, we only check writer feature
         self.writer_features()
             .is_some_and(|features| features.contains(feature))
+    }
+
+    /// Create a new Protocol with the given feature added.
+    ///
+    /// If the feature is already present, returns the protocol unchanged.
+    /// If the feature is a ReaderWriter feature, it will be added to both
+    /// reader and writer feature lists.
+    ///
+    /// # Arguments
+    ///
+    /// * `feature` - The feature to add to the protocol
+    ///
+    /// # Returns
+    ///
+    /// A new Protocol with the feature added, or an error if the resulting
+    /// protocol would be invalid.
+    #[allow(dead_code)]
+    pub(crate) fn with_feature(self, feature: TableFeature) -> DeltaResult<Self> {
+        use crate::table_features::{
+            TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION,
+        };
+
+        // Get current features as mutable vecs
+        let mut reader_features: Vec<_> =
+            self.reader_features.map(|f| f.to_vec()).unwrap_or_default();
+        let mut writer_features: Vec<_> =
+            self.writer_features.map(|f| f.to_vec()).unwrap_or_default();
+
+        // Add feature to writer features if not already present
+        if !writer_features.contains(&feature) {
+            writer_features.push(feature.clone());
+        }
+
+        // If it's a ReaderWriter feature, also add to reader features
+        if feature.is_reader_writer() && !reader_features.contains(&feature) {
+            reader_features.push(feature);
+        }
+
+        // Create new protocol with updated features
+        Protocol::try_new(
+            TABLE_FEATURES_MIN_READER_VERSION,
+            TABLE_FEATURES_MIN_WRITER_VERSION,
+            Some(reader_features.iter()),
+            Some(writer_features.iter()),
+        )
+    }
+
+    /// Create a new Protocol with specified versions, preserving existing features.
+    ///
+    /// This is used during table creation when the protocol version is determined
+    /// from user-specified properties.
+    ///
+    /// # Arguments
+    ///
+    /// * `min_reader_version` - The minimum reader version
+    /// * `min_writer_version` - The minimum writer version
+    ///
+    /// # Returns
+    ///
+    /// A new Protocol with the specified versions, or an error if the resulting
+    /// protocol would be invalid.
+    #[allow(dead_code)]
+    pub(crate) fn with_versions(
+        self,
+        min_reader_version: i32,
+        min_writer_version: i32,
+    ) -> DeltaResult<Self> {
+        Protocol::try_new(
+            min_reader_version,
+            min_writer_version,
+            self.reader_features.as_ref().map(|f| f.iter()),
+            self.writer_features.as_ref().map(|f| f.iter()),
+        )
     }
 
     /// Validates the relationship between reader features and writer features in the protocol.

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -102,6 +102,7 @@ pub mod table_changes;
 pub mod table_configuration;
 pub mod table_features;
 pub mod table_properties;
+mod table_protocol_metadata_config;
 pub mod transaction;
 pub(crate) mod transforms;
 

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -1,3 +1,5 @@
+//! Configuration for reading existing Delta tables.
+//!
 //! This module defines [`TableConfiguration`], a high level api to check feature support and
 //! feature enablement for a table at a given version. This encapsulates [`Protocol`], [`Metadata`],
 //! [`Schema`], [`TableProperties`], and [`ColumnMappingMode`]. These structs in isolation should

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -1,4 +1,6 @@
 use itertools::Itertools;
+use std::str::FromStr;
+
 use serde::{Deserialize, Serialize};
 use strum::{AsRefStr, Display as StrumDisplay, EnumCount, EnumString};
 
@@ -679,6 +681,22 @@ impl TableFeature {
             TableFeature::Unknown(_) => None,
         }
     }
+
+    /// Parse a feature name string into a TableFeature.
+    ///
+    /// Known feature names are parsed into their corresponding variants.
+    /// Unknown feature names are wrapped in `TableFeature::Unknown`.
+    #[allow(dead_code)] // Used by table_transformation module
+    pub(crate) fn from_name(name: &str) -> Self {
+        TableFeature::from_str(name).unwrap_or_else(|_| TableFeature::Unknown(name.to_string()))
+    }
+
+    /// Returns true if this is a ReaderWriter feature (appears in both reader and writer feature lists).
+    /// Returns false for Writer-only features and Unknown features.
+    #[allow(dead_code)] // Used by Protocol::with_feature
+    pub(crate) fn is_reader_writer(&self) -> bool {
+        matches!(self.feature_type(), FeatureType::ReaderWriter)
+    }
 }
 
 impl ToDataType for TableFeature {
@@ -828,5 +846,50 @@ mod tests {
             let from_str: TableFeature = expected.parse().unwrap();
             assert_eq!(from_str, feature);
         }
+    }
+
+    #[test]
+    fn test_from_name() {
+        // Known features
+        assert_eq!(
+            TableFeature::from_name("deletionVectors"),
+            TableFeature::DeletionVectors
+        );
+        assert_eq!(
+            TableFeature::from_name("changeDataFeed"),
+            TableFeature::ChangeDataFeed
+        );
+        assert_eq!(
+            TableFeature::from_name("columnMapping"),
+            TableFeature::ColumnMapping
+        );
+        assert_eq!(
+            TableFeature::from_name("timestampNtz"),
+            TableFeature::TimestampWithoutTimezone
+        );
+
+        // Unknown features
+        assert_eq!(
+            TableFeature::from_name("unknownFeature"),
+            TableFeature::Unknown("unknownFeature".to_string())
+        );
+    }
+
+    #[test]
+    fn test_is_reader_writer() {
+        // ReaderWriter features
+        assert!(TableFeature::DeletionVectors.is_reader_writer());
+        assert!(TableFeature::ColumnMapping.is_reader_writer());
+        assert!(TableFeature::TimestampWithoutTimezone.is_reader_writer());
+        assert!(TableFeature::V2Checkpoint.is_reader_writer());
+
+        // Writer-only features
+        assert!(!TableFeature::ChangeDataFeed.is_reader_writer());
+        assert!(!TableFeature::AppendOnly.is_reader_writer());
+        assert!(!TableFeature::DomainMetadata.is_reader_writer());
+        assert!(!TableFeature::RowTracking.is_reader_writer());
+
+        // Unknown features
+        assert!(!TableFeature::unknown("something").is_reader_writer());
     }
 }

--- a/kernel/src/table_properties.rs
+++ b/kernel/src/table_properties.rs
@@ -26,6 +26,14 @@ pub use deserialize::ParseIntervalError;
 /// Prefix for delta table properties (e.g., `delta.enableChangeDataFeed`, `delta.appendOnly`).
 pub const DELTA_PROPERTY_PREFIX: &str = "delta.";
 
+/// Table property key for specifying the minimum reader protocol version.
+/// This is a signal flag property - it affects protocol creation but is not stored in metadata.
+pub const MIN_READER_VERSION_PROP: &str = "delta.minReaderVersion";
+
+/// Table property key for specifying the minimum writer protocol version.
+/// This is a signal flag property - it affects protocol creation but is not stored in metadata.
+pub const MIN_WRITER_VERSION_PROP: &str = "delta.minWriterVersion";
+
 /// Delta table properties. These are parsed from the 'configuration' map in the most recent
 /// 'Metadata' action of a table.
 ///

--- a/kernel/src/table_protocol_metadata_config.rs
+++ b/kernel/src/table_protocol_metadata_config.rs
@@ -1,0 +1,249 @@
+//! Configuration for table property-based protocol and metadata modifications.
+//!
+//! This module provides [`TableProtocolMetadataConfig`], which creates Protocol and Metadata
+//! from user-provided table properties during table creation or modification operations.
+//!
+//! # Architecture
+//!
+//! The configuration flows through a transform pipeline:
+//!
+//! 1. `TableProtocolMetadataConfig::new()` - Creates initial config with bare protocol
+//!    and all properties passed through to metadata
+//! 2. `TransformationPipeline::apply_transforms()` - Applies registered transforms based on
+//!    the raw properties (enables features, validates properties, etc.)
+//!
+//! See [`crate::table_transformation`] for the transform pipeline implementation.
+//!
+//! # Difference from [`TableConfiguration`](crate::table_configuration::TableConfiguration)
+//!
+//! - **[`TableConfiguration`](crate::table_configuration::TableConfiguration)**: Reads the
+//!   configuration of an *existing* table from a snapshot.
+//!
+//! - **[`TableProtocolMetadataConfig`]**: Creates Protocol and Metadata from *user-provided*
+//!   properties during table creation or modification operations.
+
+use std::collections::HashMap;
+
+use crate::actions::{Metadata, Protocol};
+use crate::schema::StructType;
+use crate::table_features::{
+    TableFeature, SET_TABLE_FEATURE_SUPPORTED_PREFIX, TABLE_FEATURES_MIN_READER_VERSION,
+    TABLE_FEATURES_MIN_WRITER_VERSION,
+};
+use crate::table_properties::{MIN_READER_VERSION_PROP, MIN_WRITER_VERSION_PROP};
+use crate::utils::current_time_ms;
+use crate::DeltaResult;
+
+/// Protocol and Metadata state that flows through transforms.
+///
+/// This struct is the initial state created from user-provided table properties
+/// and schema during table creation. It flows through the transform pipeline
+/// which may:
+/// - Add features to the protocol based on properties or schema
+/// - Validate and process delta.* properties
+/// - Add column mapping metadata to the schema (future)
+///
+/// # Example
+/// ```ignore
+/// use delta_kernel::schema::StructType;
+/// use delta_kernel::table_transformation::TransformationPipeline;
+/// use std::collections::HashMap;
+///
+/// let schema = StructType::new_unchecked(vec![/* fields */]);
+/// let props = HashMap::from([
+///     ("myapp.version".to_string(), "1.0".to_string()),
+/// ]);
+///
+/// // Create initial config
+/// let config = TableProtocolMetadataConfig::new(schema, vec![], props.clone())?;
+///
+/// // Apply transforms
+/// let final_config = TransformationPipeline::apply_transforms(config, &props)?;
+/// ```
+#[derive(Debug)]
+#[allow(dead_code)] // Used by table_transformation module
+pub(crate) struct TableProtocolMetadataConfig {
+    /// The protocol (starts as bare v3/v7, transforms add features).
+    pub(crate) protocol: Protocol,
+    /// The metadata containing schema, partition columns, and all table properties.
+    pub(crate) metadata: Metadata,
+}
+
+#[allow(dead_code)] // Used by table_transformation module
+impl TableProtocolMetadataConfig {
+    /// Create initial config from schema, partition columns, and properties.
+    ///
+    /// This creates a "bare" configuration:
+    /// - Protocol: v3/v7 with empty feature lists
+    /// - Metadata: schema + partition columns + ALL properties (no filtering)
+    ///
+    /// Signal processing (delta.feature.*, version props) happens in transforms.
+    /// See [`crate::table_transformation::TransformationPipeline`].
+    ///
+    /// # Arguments
+    ///
+    /// * `schema` - The table schema
+    /// * `partition_columns` - Column names for partitioning
+    /// * `properties` - All user-provided table properties (pass-through)
+    pub(crate) fn new(
+        schema: StructType,
+        partition_columns: Vec<String>,
+        properties: HashMap<String, String>,
+    ) -> DeltaResult<Self> {
+        // Create bare protocol - v3/v7 with empty features
+        // Transforms will add features based on properties
+        let empty_features: [TableFeature; 0] = [];
+        let protocol = Protocol::try_new(
+            TABLE_FEATURES_MIN_READER_VERSION,
+            TABLE_FEATURES_MIN_WRITER_VERSION,
+            Some(empty_features.iter()),
+            Some(empty_features.iter()),
+        )?;
+
+        // Create Metadata with ALL properties - no filtering here
+        // Transforms will validate and process delta.* properties
+        let metadata = Metadata::try_new(
+            None, // name
+            None, // description
+            schema,
+            partition_columns,
+            current_time_ms()?,
+            properties,
+        )?;
+
+        Ok(Self { protocol, metadata })
+    }
+
+    /// Check if a table feature is allowed during CREATE TABLE.
+    pub(crate) fn is_delta_feature_allowed(feature: &TableFeature) -> bool {
+        Self::ALLOWED_DELTA_FEATURES.contains(feature)
+    }
+
+    /// Check if a property is allowed during CREATE TABLE.
+    ///
+    /// Returns `true` if the property is:
+    /// - Not a delta.* property (user properties like `myapp.version` are always allowed)
+    /// - A signal flag (`delta.feature.*`, `delta.minReaderVersion`, `delta.minWriterVersion`)
+    /// - An explicitly allowed delta property
+    pub(crate) fn is_delta_property_allowed(key: &str) -> bool {
+        // Non-delta properties are always allowed (user properties)
+        if !key.starts_with("delta.") {
+            return true;
+        }
+
+        // Signal flags are always allowed (they're processed and stripped)
+        if key.starts_with(SET_TABLE_FEATURE_SUPPORTED_PREFIX) {
+            return true;
+        }
+        if key == MIN_READER_VERSION_PROP || key == MIN_WRITER_VERSION_PROP {
+            return true;
+        }
+
+        // Check against explicitly allowed delta properties
+        Self::ALLOWED_DELTA_PROPERTIES.contains(&key)
+    }
+
+    /// Table features allowed during CREATE TABLE.
+    const ALLOWED_DELTA_FEATURES: [TableFeature; 0] = [
+        // Currently empty - no features allowed yet
+        // As transforms are added, their features go here:
+        // TableFeature::DeletionVectors,
+        // TableFeature::ColumnMapping,
+        // TableFeature::TimestampWithoutTimezone,
+    ];
+
+    /// Delta properties allowed during CREATE TABLE.
+    /// Signal flags (delta.feature.*, delta.minReaderVersion, delta.minWriterVersion)
+    /// are always allowed and handled separately.
+    const ALLOWED_DELTA_PROPERTIES: [&'static str; 0] = [
+        // Currently empty - no delta.* properties allowed yet
+        // As property transforms are added, their properties go here:
+        // "delta.enableDeletionVectors",
+        // "delta.columnMapping.mode",
+        // "delta.enableChangeDataFeed",
+    ];
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::{DataType, StructField};
+
+    /// Helper to construct a HashMap<String, String> from string slice pairs.
+    fn props<const N: usize>(pairs: [(&str, &str); N]) -> HashMap<String, String> {
+        pairs
+            .into_iter()
+            .map(|(k, v)| (k.into(), v.into()))
+            .collect()
+    }
+
+    /// Helper to create a simple test schema.
+    fn test_schema() -> StructType {
+        StructType::new_unchecked(vec![StructField::new("id", DataType::INTEGER, false)])
+    }
+
+    // =========================================================================
+    // try_from Tests - Initial Config Creation
+    // =========================================================================
+
+    #[test]
+    fn test_try_from_creates_bare_protocol() {
+        let properties = props([("myapp.version", "1.0"), ("custom.property", "value")]);
+        let config = TableProtocolMetadataConfig::new(test_schema(), vec![], properties).unwrap();
+
+        // Protocol should be bare v3/v7 with empty features
+        assert_eq!(config.protocol.min_reader_version(), 3);
+        assert_eq!(config.protocol.min_writer_version(), 7);
+        assert!(config.protocol.reader_features().unwrap().is_empty());
+        assert!(config.protocol.writer_features().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_try_from_passes_all_properties_through() {
+        let properties = props([
+            ("myapp.version", "1.0"),
+            ("delta.feature.deletionVectors", "supported"),
+            ("delta.minReaderVersion", "3"),
+            ("custom.property", "value"),
+        ]);
+        let config = TableProtocolMetadataConfig::new(test_schema(), vec![], properties).unwrap();
+
+        // ALL properties should be in metadata - no filtering in try_from
+        assert_eq!(config.metadata.configuration().len(), 4);
+        assert_eq!(
+            config.metadata.configuration().get("myapp.version"),
+            Some(&"1.0".to_string())
+        );
+        assert_eq!(
+            config
+                .metadata
+                .configuration()
+                .get("delta.feature.deletionVectors"),
+            Some(&"supported".to_string())
+        );
+        assert_eq!(
+            config
+                .metadata
+                .configuration()
+                .get("delta.minReaderVersion"),
+            Some(&"3".to_string())
+        );
+    }
+
+    #[test]
+    fn test_try_from_with_partition_columns() {
+        let schema = StructType::new_unchecked(vec![
+            StructField::new("id", DataType::INTEGER, false),
+            StructField::new("region", DataType::STRING, false),
+        ]);
+        let config =
+            TableProtocolMetadataConfig::new(schema, vec!["region".to_string()], HashMap::new())
+                .unwrap();
+
+        assert_eq!(config.metadata.partition_columns(), &["region".to_string()]);
+    }
+
+    // =========================================================================
+    // Pipeline Integration Tests (added after TransformationPipeline is available)
+    // =========================================================================
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/1655/files) to review incremental changes.
- [**stack/create_table_3**](https://github.com/delta-io/delta-kernel-rs/pull/1655) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1655/files)]
  - [stack/create_table_3_transform_foundation](https://github.com/delta-io/delta-kernel-rs/pull/1735) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1735/files/f47a69c07281ffe16c5c8d8ffc65b4f1355de846..ac9e583790848bd1c6f57921d9ffbe3829f22223)]
    - [stack/create_table_3_transform_pipeline](https://github.com/delta-io/delta-kernel-rs/pull/1736) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1736/files/ac9e583790848bd1c6f57921d9ffbe3829f22223..3434fea652c5d10c279b16b04d7de1dc946fbc5a)]
      - [stack/create_table_3_transform_integration](https://github.com/delta-io/delta-kernel-rs/pull/1737) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1737/files/3434fea652c5d10c279b16b04d7de1dc946fbc5a..4291ec6e7cfe21243b262979453852942037b8aa)]
        - [stack/create_table_4](https://github.com/delta-io/delta-kernel-rs/pull/1724) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1724/files/4291ec6e7cfe21243b262979453852942037b8aa..9d0ca999517db6be68ab9141b695fdc1541b5a57)]
          - [stack/create_table_5](https://github.com/delta-io/delta-kernel-rs/pull/1725) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1725/files/9d0ca999517db6be68ab9141b695fdc1541b5a57..12d62e61096deb4b0f3324401554879a0f10c0dd)]
            - [stack/create_table_6_domain_metadata_transform](https://github.com/delta-io/delta-kernel-rs/pull/1742) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1742/files/12d62e61096deb4b0f3324401554879a0f10c0dd..c311424f054bdf723c6be70bd6d602342e2d2f4f)]
              - [stack/create_table_6_partitioning](https://github.com/delta-io/delta-kernel-rs/pull/1743) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1743/files/c311424f054bdf723c6be70bd6d602342e2d2f4f..e2fc12991b8548609f57b209aab5389259f91cd9)]
                - [stack/create_table_6_clustering](https://github.com/delta-io/delta-kernel-rs/pull/1744) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1744/files/e2fc12991b8548609f57b209aab5389259f91cd9..6ba29952c249004bee09f35e5a0b8b5267508cc7)]
                  - [stack/create_table_7_column_mapping](https://github.com/delta-io/delta-kernel-rs/pull/1747) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1747/files/6ba29952c249004bee09f35e5a0b8b5267508cc7..5bb078f9e438fac69dde154491fd0dc9c2bbca96)]
                    - [stack/create_table_integration_tests](https://github.com/delta-io/delta-kernel-rs/pull/1757) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1757/files/5bb078f9e438fac69dde154491fd0dc9c2bbca96..bfe49e7afc7ef3ad6a61369f5ebbba8c9c42e52b)]

---------
## What changes are proposed in this pull request?
This PR introduces a transformation pipeline infrastructure for table creation that provides an extensible, well-structured approach to processing user properties and configuring Protocol/Metadata during CREATE TABLE operations. This architecture can be reused for operations such as replace and alter.

    Pipeline Architecture:
    - `table_transformation/mod.rs`: Core types, traits, and pipeline
      - TransformId: Canonical identifiers for transforms
      - TransformDependency: Hard/soft ordering constraints
      - ProtocolMetadataTransform trait: Interface for transforms
      - TransformationPipeline: Orchestrates transform execution

    - `table_transformation/registry.rs`: Transform registry
      - TransformRegistry: Selects applicable transforms
      - TRANSFORM_REGISTRY: Global singleton

    - `table_transformation/transforms.rs`: Transforms
      - DeltaPropertyValidationTransform
      - ProtocolVersionTransform
      - FeatureSignalTransform

    Supporting Changes:
    - TableProtocolMetadataConfig: Holds Protocol + Metadata during transformation
    - Protocol.with_versions(): Functional update for protocol version
    - Metadata.with_configuration(): Functional update for configuration

    Key Design:
    - Transforms are selected by registry based on properties
    - Pipeline handles topological sort for dependency ordering
    - Extensible for future features (clustering, column mapping, etc.)

Usage:
```rust
    pub fn build(
        self,
        engine: &dyn Engine,
        committer: Box<dyn Committer>,
    ) -> DeltaResult<Transaction> {
        // Validate path
        let table_url = try_parse_uri(&self.path)?;
        // Check if table already exists by looking for _delta_log directory
        let delta_log_url = table_url.join("_delta_log/")?;
        let storage = engine.storage_handler();
        ensure_table_does_not_exist(storage.as_ref(), &delta_log_url, &self.path)?;

        // Validate schema is non-empty
        if self.schema.fields().len() == 0 {
            return Err(Error::generic("Schema cannot be empty"));
        }

        // Create initial config with bare protocol and all properties
        let config = TableProtocolMetadataConfig::new(
            (*self.schema).clone(),
            Vec::new(), // partition_columns - added with data layout support
            self.table_properties.clone(),
        )?;

        // Apply transforms based on properties (enables features, validates, etc.)
        let final_config =
            TransformationPipeline::apply_transforms(config, &self.table_properties)?;

        // Extract protocol and metadata from final config
        let protocol = final_config.protocol;
        let metadata = final_config.metadata;

        // Create pre-commit snapshot from protocol/metadata
        let log_root = table_url.join("_delta_log/")?;
        let log_segment = LogSegment::for_pre_commit(log_root);
        let table_configuration =
            TableConfiguration::try_new(metadata, protocol, table_url, PRE_COMMIT_VERSION)?;

        // Create Transaction with pre-commit snapshot
        Transaction::try_new_create_table(
            Arc::new(Snapshot::new(log_segment, table_configuration)),
            self.engine_info,
            committer,
            vec![], // system_domain_metadata - not supported in base API
        )
    }
```
The delta.feature.* properties are consumed during build() and not stored
in the final Metadata configuration, matching Java Kernel behavior.

## How was this change tested?
Rust module unit tests