### PR TITLE
ci: add Rust caching to build and test jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
+      - uses: Swatinem/rust-cache@v2
       - name: build and lint with clippy
         run: cargo clippy --benches --tests --all-features -- -D warnings
       - name: lint without default features - packages which depend on kernel with features enabled
@@ -127,6 +128,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install minimal stable with clippy and rustfmt
         uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: Swatinem/rust-cache@v2
       - name: test
         run: cargo test --workspace --verbose --all-features -- --skip read_table_version_hdfs
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/1672/files) to review incremental changes.
- [**stack/ci-add-rust-cache**](https://github.com/delta-io/delta-kernel-rs/pull/1672) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1672/files)]

---------
## What changes are proposed in this pull request?

Adds `Swatinem/rust-cache@v2` to the `build` and `test` CI jobs in `build.yml`.

Currently these jobs recompile all dependencies from scratch on every run. The rust-cache action caches:
- `~/.cargo/registry/` (crate metadata and sources)
- `~/.cargo/git/db` (git dependencies)
- `./target` (compiled artifacts)

The cache key is derived from `Cargo.lock`, toolchain version, and OS, so it invalidates automatically when dependencies change.

This pattern is already used by the `msrv-run-tests` job in the same workflow.

## Impact

| Job | First Run | Second Run | Δ (Second − First) |
|---|---:|---:|---:|
| Auto-assign PR / assign-author | 6s | 6s | 0s |
| build (macOS-latest) | 5m | 2m | −3m |
| build (ubuntu-latest) | 3m | 1m | −2m |
| build (windows-latest) | 6m | 6m | 0m |
| coverage | 5m | 4m | −1m |
| docs | 6m | 5m | −1m |
| ffi_test (macOS-latest) | 6m | 6m | 0m |
| ffi_test (ubuntu-latest) | 1m | 1m | 0m |
| format | 18s | 21s | +3s |
| Miri | 7m | 7m | 0m |
| msrv | 5m | 56s | −4m+ |
| msrv-run-tests | 7m | 1m | −6m |
| test (macOS-latest) | 10m | 2m | −8m |
| test (ubuntu-latest) | 4m | 1m | −3m |
| test (windows-latest) | 9m | 3m | −6m |

## How was this change tested?

CI will validate the workflow syntax. Cache effectiveness will be visible on subsequent runs (look for "Cache restored" in the rust-cache step output).