### PR TITLE
ci: use cargo-nextest for parallel test execution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,8 +129,9 @@ jobs:
       - name: Install minimal stable with clippy and rustfmt
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@nextest
       - name: test
-        run: cargo test --workspace --verbose --all-features -- --skip read_table_version_hdfs
+        run: cargo nextest run --workspace --all-features -E 'not test(read_table_version_hdfs)'
 
   ffi_test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/1673/files) to review incremental changes.
- [**stack/ci-use-nextest**](https://github.com/delta-io/delta-kernel-rs/pull/1673) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1673/files)]

---------
## What changes are proposed in this pull request?

Replaces `cargo test` with `cargo nextest run` in the CI test job.

### Benchmark results (local, 16-core machine)

| Command | Wall clock time | CPU utilization |
|---------|-----------------|-----------------|
| `cargo test` | **1m 21.9s** | 429% |
| `cargo nextest` | **4.2s** | 1283% |

**~19x faster with nextest**

### Why nextest?

`cargo test` runs tests as threads within a single process per test binary. With 824 unit tests in the `delta_kernel` lib alone, this limits parallelism due to thread contention.

`cargo nextest` runs each test as a **separate process**, providing:
- **True parallelism**: Tests run in separate processes across all CPU cores (1283% CPU utilization vs 429%)
- **Test isolation**: No shared global state between tests
- **Better output**: stdout/stderr captured per-test, shown only on failure
- **Faster CI**: Better utilization of multi-core runners

### Filter syntax change

- Before: `cargo test -- --skip read_table_version_hdfs`
- After: `cargo nextest run -E 'not test(read_table_version_hdfs)'`

Nextest uses a filter expression syntax instead of `--skip`.

### Note on doc-tests

Nextest doesn't run doc-tests by default. If doc-test coverage is needed, they can be run separately with `cargo test --doc`. Currently the workspace has minimal doc-tests (just 1 in uc-client).

## How was this change tested?

Benchmarked locally (results above). CI will validate the workflow runs successfully.