### PR TITLE
ci: add caching and optimize tool installation across all jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install minimal stable and cargo msrv
         uses: actions-rust-lang/setup-rust-toolchain@v1
-      - name: Install cargo-msrv
-        shell: bash
-        run: |
-          cargo install cargo-msrv --locked
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-msrv
       - name: verify-msrv
         run: |
           cargo msrv --path kernel/ verify --all-features
@@ -41,23 +41,22 @@ jobs:
       - name: Install minimal stable and cargo msrv
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: Swatinem/rust-cache@v2
-      - name: Install cargo-msrv
-        shell: bash
-        run: |
-          cargo install cargo-msrv --locked
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-msrv
+      - uses: taiki-e/install-action@nextest
       - name: Get rust-version from Cargo.toml
         id: rust-version
         run: echo "RUST_VERSION=$(cargo msrv show --path kernel/ --output-format minimal)" >> $GITHUB_ENV
       - name: Install specified rust version
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
-          profile: minimal
       - name: run tests
         run: |
           pushd kernel
           echo "Testing with $(cargo msrv show --output-format minimal)"
-          cargo +$(cargo msrv show --output-format minimal) test
+          cargo +$(cargo msrv show --output-format minimal) nextest run
   docs:
     runs-on: ubuntu-latest
     env:
@@ -66,6 +65,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install minimal stable
         uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: Swatinem/rust-cache@v2
       - name: build docs
         run: cargo doc --workspace --all-features
 
@@ -206,6 +206,7 @@ jobs:
           rustup toolchain install nightly --component miri
           rustup override set nightly
           cargo miri setup
+      - uses: Swatinem/rust-cache@v2
       - name: Test with Miri
         run: |
           pushd ffi
@@ -219,6 +220,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: Swatinem/rust-cache@v2
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add caching and optimize tool installation across CI jobs:

- **msrv**: Add `Swatinem/rust-cache@v2`, use pre-built `cargo-msrv` binary
- **msrv-run-tests**: Use pre-built `cargo-msrv`, add nextest for parallel tests, fix deprecated toolchain action
- **docs**: Add `Swatinem/rust-cache@v2`
- **miri**: Add `Swatinem/rust-cache@v2`
- **coverage**: Add `Swatinem/rust-cache@v2`

### Why pre-built binaries?

`cargo install cargo-msrv --locked` compiles from source (~4 min). `taiki-e/install-action` downloads a pre-built binary (~5 sec).

## How was this change tested?

CI validates the workflow runs successfully.

Part of #1696