### PR TITLE
feat: include clustering columns in stats schema

### DIFF
--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -288,7 +288,9 @@ mod tests {
                 ))
             };
 
-            let write_context = unsafe { get_write_context(txn_with_engine_info.shallow_copy()) };
+            let write_context = ok_or_panic(unsafe {
+                get_write_context(txn_with_engine_info.shallow_copy(), engine.shallow_copy())
+            });
 
             // Ensure we get the correct schema
             let write_schema = unsafe { get_write_schema(write_context.shallow_copy()) };

--- a/kernel/examples/write-table/src/main.rs
+++ b/kernel/examples/write-table/src/main.rs
@@ -93,7 +93,7 @@ async fn try_main() -> DeltaResult<()> {
         .with_data_change(true);
 
     // Write the data using the engine
-    let write_context = Arc::new(txn.get_write_context());
+    let write_context = Arc::new(txn.get_write_context(&engine)?);
     let file_metadata = engine
         .write_parquet(&sample_data, write_context.as_ref(), HashMap::new())
         .await?;

--- a/kernel/src/clustering.rs
+++ b/kernel/src/clustering.rs
@@ -1,0 +1,84 @@
+//! Clustering domain metadata parsing for clustered Delta tables.
+//!
+//! This module provides functionality to parse clustering column information from
+//! Delta table domain metadata. Clustering columns are stored as physical column IDs
+//! when column mapping is enabled.
+
+use serde::Deserialize;
+
+use crate::actions::domain_metadata::domain_metadata_configuration;
+use crate::expressions::ColumnName;
+use crate::log_segment::LogSegment;
+use crate::{DeltaResult, Engine};
+
+/// Domain metadata for clustered tables.
+///
+/// The clustering domain metadata is stored as JSON in the format:
+/// `{"clusteringColumns": ["col-uuid1", "col-uuid2"]}`
+///
+/// Note: Column names are physical column IDs when column mapping is enabled.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ClusteringDomainMetadata {
+    clustering_columns: Vec<String>,
+}
+
+impl ClusteringDomainMetadata {
+    /// Domain name for clustering metadata.
+    /// This is an internal domain (delta.*) so it uses the internal API to access it.
+    pub(crate) const DOMAIN_NAME: &'static str = "delta.clustering";
+
+    /// Parse clustering columns from the log segment's domain metadata.
+    ///
+    /// Returns physical column names/IDs as stored in the domain metadata.
+    /// Returns `None` if the table is not clustered (no clustering domain metadata).
+    pub(crate) fn get_clustering_columns(
+        log_segment: &LogSegment,
+        engine: &dyn Engine,
+    ) -> DeltaResult<Option<Vec<ColumnName>>> {
+        let config = domain_metadata_configuration(log_segment, Self::DOMAIN_NAME, engine)?;
+
+        match config {
+            Some(json_str) => {
+                let metadata: ClusteringDomainMetadata = serde_json::from_str(&json_str)?;
+                let columns = metadata
+                    .clustering_columns
+                    .into_iter()
+                    .map(|name| ColumnName::new([name]))
+                    .collect();
+                Ok(Some(columns))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_clustering_metadata() {
+        let json = r#"{"clusteringColumns": ["col1", "col2", "col3"]}"#;
+        let metadata: ClusteringDomainMetadata = serde_json::from_str(json).unwrap();
+        assert_eq!(metadata.clustering_columns, vec!["col1", "col2", "col3"]);
+    }
+
+    #[test]
+    fn test_parse_clustering_metadata_empty() {
+        let json = r#"{"clusteringColumns": []}"#;
+        let metadata: ClusteringDomainMetadata = serde_json::from_str(json).unwrap();
+        assert!(metadata.clustering_columns.is_empty());
+    }
+
+    #[test]
+    fn test_parse_clustering_metadata_with_uuid_columns() {
+        // Physical column IDs when column mapping is enabled
+        let json = r#"{"clusteringColumns": ["col-abc123", "col-def456"]}"#;
+        let metadata: ClusteringDomainMetadata = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            metadata.clustering_columns,
+            vec!["col-abc123", "col-def456"]
+        );
+    }
+}

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -87,6 +87,7 @@ use self::schema::{DataType, SchemaRef};
 mod action_reconciliation;
 pub mod actions;
 pub mod checkpoint;
+pub(crate) mod clustering;
 pub mod committer;
 pub mod engine_data;
 pub mod error;

--- a/kernel/src/scan/data_skipping/stats_schema/column_filter.rs
+++ b/kernel/src/scan/data_skipping/stats_schema/column_filter.rs
@@ -14,6 +14,10 @@ use crate::{
 /// Filters columns according to:
 /// * `dataSkippingStatsColumns` - explicit list of columns to include (takes precedence)
 /// * `dataSkippingNumIndexedCols` - number of leaf columns to include (default 32)
+/// * Clustering columns - always included per Delta protocol requirements
+///
+/// Per the Delta protocol, writers MUST write per-file statistics for clustering columns,
+/// regardless of table property settings.
 ///
 /// The lifetime `'col` ties this filter to the column names it was built from when
 /// using `dataSkippingStatsColumns`.
@@ -26,19 +30,47 @@ pub(crate) struct StatsColumnFilter<'col> {
     /// Trie built from user-specified columns for O(path_length) prefix matching.
     /// `None` when using `n_columns` limit instead of explicit column list.
     column_trie: Option<ColumnTrie<'col>>,
+    /// Trie built from clustering columns that must always be included.
+    /// `None` when the table has no clustering columns.
+    clustering_trie: Option<ColumnTrie<'col>>,
     /// Current path during schema traversal. Pushed on field entry, popped on exit.
     path: Vec<String>,
 }
 
 impl<'col> StatsColumnFilter<'col> {
-    pub(crate) fn new(props: &'col TableProperties) -> Self {
+    /// Creates a new StatsColumnFilter with optional clustering columns.
+    ///
+    /// Clustering columns are always included in statistics, even when `dataSkippingStatsColumns`
+    /// or `dataSkippingNumIndexedCols` would otherwise exclude them.
+    pub(crate) fn new(
+        props: &'col TableProperties,
+        clustering_columns: Option<&'col [ColumnName]>,
+    ) -> Self {
+        let clustering_trie = clustering_columns.map(ColumnTrie::from_columns);
+
         // If data_skipping_stats_columns is specified, it takes precedence
         // over data_skipping_num_indexed_cols, even if that is also specified.
         if let Some(column_names) = &props.data_skipping_stats_columns {
+            let mut combined_trie = ColumnTrie::from_columns(column_names);
+
+            // Warn about missing clustering columns, then add them
+            if let Some(clustering_cols) = clustering_columns {
+                for col in clustering_cols {
+                    if !combined_trie.contains_prefix_of(col) {
+                        tracing::warn!(
+                            "Clustering column '{}' not in dataSkippingStatsColumns; adding anyway",
+                            col
+                        );
+                    }
+                    combined_trie.insert(col);
+                }
+            }
+
             Self {
                 n_columns: None,
                 added_columns: 0,
-                column_trie: Some(ColumnTrie::from_columns(column_names)),
+                column_trie: Some(combined_trie),
+                clustering_trie,
                 path: Vec::new(),
             }
         } else {
@@ -47,6 +79,7 @@ impl<'col> StatsColumnFilter<'col> {
                 n_columns: Some(n_cols),
                 added_columns: 0,
                 column_trie: None,
+                clustering_trie,
                 path: Vec::new(),
             }
         }
@@ -73,8 +106,27 @@ impl<'col> StatsColumnFilter<'col> {
         )
     }
 
+    /// Returns true if the current path is a clustering column.
+    fn is_clustering_column(&self) -> bool {
+        self.clustering_trie
+            .as_ref()
+            .is_some_and(|trie| trie.contains_prefix_of(&self.path))
+    }
+
     /// Returns true if the current path should be included based on column_trie config.
     pub(crate) fn should_include_current(&self) -> bool {
+        if self.at_column_limit() {
+            // Clustering columns are always included
+            if self.is_clustering_column() {
+                tracing::warn!(
+                    "Clustering column '{}' exceeds dataSkippingNumIndexedCols limit; adding anyway",
+                    self.path.join(".")
+                );
+                return true;
+            }
+            return false;
+        }
+
         self.column_trie
             .as_ref()
             .map(|trie| trie.contains_prefix_of(&self.path))
@@ -100,7 +152,10 @@ impl<'col> StatsColumnFilter<'col> {
     // These methods are private to this module.
 
     fn collect_field(&mut self, field: &StructField, result: &mut Vec<ColumnName>) {
-        if self.at_column_limit() {
+        // When at the column limit and no clustering columns, we can skip entirely.
+        // When clustering columns exist, we must continue traversing in case
+        // nested clustering columns need to be included.
+        if self.at_column_limit() && self.clustering_trie.is_none() {
             return;
         }
 
@@ -124,5 +179,142 @@ impl<'col> StatsColumnFilter<'col> {
         }
 
         self.path.pop();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_props_with_num_cols(n: u64) -> TableProperties {
+        [(
+            "delta.dataSkippingNumIndexedCols".to_string(),
+            n.to_string(),
+        )]
+        .into()
+    }
+
+    fn make_props_with_stats_cols(cols: &str) -> TableProperties {
+        [(
+            "delta.dataSkippingStatsColumns".to_string(),
+            cols.to_string(),
+        )]
+        .into()
+    }
+
+    #[test]
+    fn test_clustering_columns_override_num_indexed_cols() {
+        // With limit of 1, normally only the first column would be included
+        let props = make_props_with_num_cols(1);
+        let clustering_cols = vec![ColumnName::new(["c"])]; // Third column
+
+        let schema = crate::schema::StructType::new_unchecked([
+            crate::schema::StructField::nullable("a", DataType::LONG),
+            crate::schema::StructField::nullable("b", DataType::STRING),
+            crate::schema::StructField::nullable("c", DataType::INTEGER),
+        ]);
+
+        let mut filter = StatsColumnFilter::new(&props, Some(&clustering_cols));
+        let mut columns = Vec::new();
+        filter.collect_columns(&schema, &mut columns);
+
+        // Should include both "a" (first column within limit) and "c" (clustering column)
+        assert_eq!(
+            columns,
+            vec![ColumnName::new(["a"]), ColumnName::new(["c"])]
+        );
+    }
+
+    #[test]
+    fn test_clustering_columns_added_to_stats_columns() {
+        // Only "a" is in stats columns, but "c" is a clustering column
+        let props = make_props_with_stats_cols("a");
+        let clustering_cols = vec![ColumnName::new(["c"])];
+
+        let schema = crate::schema::StructType::new_unchecked([
+            crate::schema::StructField::nullable("a", DataType::LONG),
+            crate::schema::StructField::nullable("b", DataType::STRING),
+            crate::schema::StructField::nullable("c", DataType::INTEGER),
+        ]);
+
+        let mut filter = StatsColumnFilter::new(&props, Some(&clustering_cols));
+        let mut columns = Vec::new();
+        filter.collect_columns(&schema, &mut columns);
+
+        // Should include both "a" (explicit stats column) and "c" (clustering column)
+        assert_eq!(
+            columns,
+            vec![ColumnName::new(["a"]), ColumnName::new(["c"])]
+        );
+    }
+
+    #[test]
+    fn test_clustering_columns_already_included() {
+        // "a" is both in stats columns and is a clustering column
+        let props = make_props_with_stats_cols("a,b");
+        let clustering_cols = vec![ColumnName::new(["a"])];
+
+        let schema = crate::schema::StructType::new_unchecked([
+            crate::schema::StructField::nullable("a", DataType::LONG),
+            crate::schema::StructField::nullable("b", DataType::STRING),
+            crate::schema::StructField::nullable("c", DataType::INTEGER),
+        ]);
+
+        let mut filter = StatsColumnFilter::new(&props, Some(&clustering_cols));
+        let mut columns = Vec::new();
+        filter.collect_columns(&schema, &mut columns);
+
+        // Should include "a" and "b" (both explicit stats columns), "a" is also clustering
+        assert_eq!(
+            columns,
+            vec![ColumnName::new(["a"]), ColumnName::new(["b"])]
+        );
+    }
+
+    #[test]
+    fn test_no_clustering_columns() {
+        // No clustering columns specified - should work as before
+        let props = make_props_with_num_cols(2);
+
+        let schema = crate::schema::StructType::new_unchecked([
+            crate::schema::StructField::nullable("a", DataType::LONG),
+            crate::schema::StructField::nullable("b", DataType::STRING),
+            crate::schema::StructField::nullable("c", DataType::INTEGER),
+        ]);
+
+        let mut filter = StatsColumnFilter::new(&props, None);
+        let mut columns = Vec::new();
+        filter.collect_columns(&schema, &mut columns);
+
+        // Should include first 2 columns within the limit
+        assert_eq!(
+            columns,
+            vec![ColumnName::new(["a"]), ColumnName::new(["b"])]
+        );
+    }
+
+    #[test]
+    fn test_clustering_column_non_eligible_type() {
+        // Array/Map clustering columns should be excluded as they're not eligible for stats
+        let props = make_props_with_num_cols(32);
+        let clustering_cols = vec![ColumnName::new(["arr"])];
+
+        let schema = crate::schema::StructType::new_unchecked([
+            crate::schema::StructField::nullable("a", DataType::LONG),
+            crate::schema::StructField::nullable(
+                "arr",
+                DataType::Array(Box::new(crate::schema::ArrayType::new(
+                    DataType::STRING,
+                    false,
+                ))),
+            ),
+        ]);
+
+        let mut filter = StatsColumnFilter::new(&props, Some(&clustering_cols));
+        let mut columns = Vec::new();
+        filter.collect_columns(&schema, &mut columns);
+
+        // Should only include "a" - arrays are not eligible for statistics
+        assert_eq!(columns, vec![ColumnName::new(["a"])]);
     }
 }

--- a/kernel/tests/dv.rs
+++ b/kernel/tests/dv.rs
@@ -103,7 +103,7 @@ fn get_write_context(
 ) -> Result<delta_kernel::transaction::WriteContext, Box<dyn std::error::Error>> {
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine)?;
     let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()))?;
-    Ok(txn.get_write_context())
+    Ok(txn.get_write_context(engine)?)
 }
 
 /// Helper to write a deletion vector to object store and return its descriptor.

--- a/kernel/tests/row_tracking.rs
+++ b/kernel/tests/row_tracking.rs
@@ -62,7 +62,7 @@ async fn write_data_to_table(
     let mut txn = snapshot.transaction(committer)?.with_data_change(true);
 
     // Write data out by spawning async tasks to simulate executors
-    let write_context = Arc::new(txn.get_write_context());
+    let write_context = Arc::new(txn.get_write_context(engine.as_ref())?);
     let tasks = data.into_iter().map(|data| {
         let engine = engine.clone();
         let write_context = write_context.clone();
@@ -661,8 +661,8 @@ async fn test_row_tracking_parallel_transactions_conflict() -> DeltaResult<()> {
     )?;
 
     // Write data for both transactions
-    let write_context1 = Arc::new(txn1.get_write_context());
-    let write_context2 = Arc::new(txn2.get_write_context());
+    let write_context1 = Arc::new(txn1.get_write_context(engine1.as_ref())?);
+    let write_context2 = Arc::new(txn2.get_write_context(engine2.as_ref())?);
 
     let metadata1 = engine1
         .write_parquet(

--- a/kernel/tests/write.rs
+++ b/kernel/tests/write.rs
@@ -244,7 +244,7 @@ async fn write_data_and_check_result_and_stats(
     });
 
     // write data out by spawning async tasks to simulate executors
-    let write_context = Arc::new(txn.get_write_context());
+    let write_context = Arc::new(txn.get_write_context(engine.as_ref())?);
     let tasks = append_data.into_iter().map(|data| {
         // arc clones
         let engine = engine.clone();
@@ -527,7 +527,7 @@ async fn test_append_partitioned() -> Result<(), Box<dyn std::error::Error>> {
 
         // write data out by spawning async tasks to simulate executors
         let engine = Arc::new(engine);
-        let write_context = Arc::new(txn.get_write_context());
+        let write_context = Arc::new(txn.get_write_context(engine.as_ref())?);
         let tasks = append_data
             .into_iter()
             .zip(partition_vals)
@@ -670,7 +670,7 @@ async fn test_append_invalid_schema() -> Result<(), Box<dyn std::error::Error>> 
 
         // write data out by spawning async tasks to simulate executors
         let engine = Arc::new(engine);
-        let write_context = Arc::new(txn.get_write_context());
+        let write_context = Arc::new(txn.get_write_context(engine.as_ref())?);
         let tasks = append_data.into_iter().map(|data| {
             // arc clones
             let engine = engine.clone();
@@ -877,7 +877,7 @@ async fn test_append_timestamp_ntz() -> Result<(), Box<dyn std::error::Error>> {
 
     // Write data
     let engine = Arc::new(engine);
-    let write_context = Arc::new(txn.get_write_context());
+    let write_context = Arc::new(txn.get_write_context(engine.as_ref())?);
 
     let add_files_metadata = engine
         .write_parquet(
@@ -1068,7 +1068,7 @@ async fn test_append_variant() -> Result<(), Box<dyn std::error::Error>> {
 
     // Write data
     let engine = Arc::new(engine);
-    let write_context = Arc::new(txn.get_write_context());
+    let write_context = Arc::new(txn.get_write_context(engine.as_ref())?);
 
     let add_files_metadata = (*engine)
         .parquet_handler()
@@ -1242,7 +1242,7 @@ async fn test_shredded_variant_read_rejection() -> Result<(), Box<dyn std::error
     .unwrap();
 
     let engine = Arc::new(engine);
-    let write_context = Arc::new(txn.get_write_context());
+    let write_context = Arc::new(txn.get_write_context(engine.as_ref())?);
 
     let add_files_metadata = (*engine)
         .parquet_handler()
@@ -1312,7 +1312,7 @@ async fn test_set_domain_metadata_basic() -> Result<(), Box<dyn std::error::Erro
     let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()))?;
 
     // write context does not conflict with domain metadata
-    let _write_context = txn.get_write_context();
+    let _write_context = txn.get_write_context(&engine)?;
 
     // set multiple domain metadata
     let domain1 = "app.config";
@@ -1724,7 +1724,7 @@ async fn generate_and_add_data_file(
         vec![Arc::new(Int32Array::from(values))],
     )?;
 
-    let write_context = Arc::new(txn.get_write_context());
+    let write_context = Arc::new(txn.get_write_context(engine)?);
     let file_meta = engine
         .write_parquet(
             &ArrowEngineData::new(data),
@@ -2763,7 +2763,7 @@ async fn add_files_to_transaction(
         vec![Arc::new(Int32Array::from(values))],
     )?;
 
-    let write_context = Arc::new(txn.get_write_context());
+    let write_context = Arc::new(txn.get_write_context(engine.as_ref())?);
     let add_files_metadata = engine
         .write_parquet(
             &ArrowEngineData::new(data),

--- a/kernel/tests/write_row_tracking.rs
+++ b/kernel/tests/write_row_tracking.rs
@@ -75,7 +75,7 @@ async fn test_row_tracking_fields_in_add_and_remove_actions(
     )?;
 
     let engine_arc = Arc::new(engine);
-    let write_context = Arc::new(txn.get_write_context());
+    let write_context = Arc::new(txn.get_write_context(engine_arc.as_ref())?);
     let add_files_metadata = engine_arc
         .write_parquet(
             &ArrowEngineData::new(data),

--- a/uc-catalog/src/lib.rs
+++ b/uc-catalog/src/lib.rs
@@ -260,7 +260,7 @@ mod tests {
             .await?;
         println!("latest snapshot version: {:?}", snapshot.version());
         let txn = snapshot.clone().transaction(committer)?;
-        let _write_context = txn.get_write_context();
+        let _write_context = txn.get_write_context(&engine)?;
 
         match txn.commit(&engine)? {
             CommitResult::CommittedTransaction(t) => {


### PR DESCRIPTION
## What changes are proposed in this pull request?
  - Clustering columns are always included in file statistics, even when `dataSkippingStatsColumns` or `dataSkippingNumIndexedCols` would otherwise exclude them
  - Adds `clustering.rs` module to parse clustering domain metadata (`delta.clustering`)
  - Updates `stats_schema()` and `stats_columns()` Transaction APIs to accept `&dyn Engine` parameter (breaking change)

## This PR affects the following public APIs

  The following `Transaction` methods now require an `&dyn Engine` parameter to fetch clustering columns from domain metadata:

  | Method | Old Signature | New Signature |
  |--------|---------------|---------------|
  | `stats_schema` | `fn stats_schema(&self) -> DeltaResult<SchemaRef>` | `fn stats_schema(&self, engine: &dyn Engine) -> DeltaResult<SchemaRef>` |
  | `stats_columns` | `fn stats_columns(&self) -> Vec<ColumnName>` | `fn stats_columns(&self, engine: &dyn Engine) -> DeltaResult<Vec<ColumnName>>` |
  | `get_write_context` | `fn get_write_context(&self) -> WriteContext` | `fn get_write_context(&self, engine: &dyn Engine) -> DeltaResult<WriteContext>` |

  This is required because clustering columns must be fetched from domain metadata in the transaction log, which requires engine access.

## How was this change tested?
New and existing tests