### PR TITLE
feat: support using stats_columns and predicate together in scans

### DIFF
--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -146,12 +146,11 @@ impl ScanBuilder {
     /// NOTE: The filtering is best-effort and can produce false positives (rows that should should
     /// have been filtered out but were kept).
     ///
-    /// NOTE: This method cannot currently be used together with [`include_stats_columns`].
-    /// Using both will result in an error when calling [`build`]. See [#1751] for tracking.
+    /// This method can be combined with [`include_stats_columns`]. When both are used, the kernel
+    /// performs data skipping internally using the predicate AND outputs parsed statistics to the
+    /// engine via the `stats_parsed` column in scan metadata.
     ///
     /// [`include_stats_columns`]: ScanBuilder::include_stats_columns
-    /// [`build`]: ScanBuilder::build
-    /// [#1751]: https://github.com/delta-io/delta-kernel-rs/issues/1751
     pub fn with_predicate(mut self, predicate: impl Into<Option<PredicateRef>>) -> Self {
         self.predicate = predicate.into();
         self
@@ -166,12 +165,11 @@ impl ScanBuilder {
     /// The statistics schema is determined by the table's configuration
     /// (`delta.dataSkippingStatsColumns` or `delta.dataSkippingNumIndexedCols`).
     ///
-    /// NOTE: This method cannot currently be used together with [`with_predicate`]. Using both
-    /// will result in an error when calling [`build`]. See [#1751] for tracking.
+    /// This method can be combined with [`with_predicate`]. When both are used, the kernel
+    /// performs data skipping internally using the predicate AND outputs parsed statistics to the
+    /// engine via the `stats_parsed` column in scan metadata.
     ///
     /// [`with_predicate`]: ScanBuilder::with_predicate
-    /// [`build`]: ScanBuilder::build
-    /// [#1751]: https://github.com/delta-io/delta-kernel-rs/issues/1751
     pub fn include_stats_columns(mut self) -> Self {
         self.stats_columns = Some(Vec::new());
         self

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -674,35 +674,77 @@ fn test_data_skipping_with_parsed_stats() {
     );
 }
 
-/// Test that `with_stats_columns` cannot be used with `with_predicate`.
-/// See [#1751] for tracking.
-/// [#1751]: https://github.com/delta-io/delta-kernel-rs/issues/1751
+/// Test that `include_stats_columns` and `with_predicate` can be used together.
+/// The scan should output stats_parsed AND perform data skipping via the predicate.
 #[test]
-fn test_scan_metadata_stats_columns_with_predicate_errors() {
-    // Use the parsed-stats table
+fn test_scan_metadata_stats_columns_with_predicate() {
+    const STATS_PARSED_COL: &str = "stats_parsed";
+
     let path = std::fs::canonicalize(PathBuf::from("./tests/data/parsed-stats/")).unwrap();
     let url = url::Url::from_directory_path(path).unwrap();
     let engine = Arc::new(SyncEngine::new());
 
     let snapshot = Snapshot::builder_for(url).build(engine.as_ref()).unwrap();
 
-    // Build scan with both predicate (that references a column) and stats_columns should error
-    // Note: Pred::literal(true) has no column references, so it becomes PhysicalPredicate::None
-    let predicate = Arc::new(column_pred!("id")); // References 'id' column
-    let result = snapshot
+    // Build scan with both a predicate and stats_columns
+    let predicate = Arc::new(column_expr!("id").gt(Expr::literal(0i64)));
+    let scan = snapshot
         .scan_builder()
         .with_predicate(predicate)
         .include_stats_columns()
-        .build();
+        .build()
+        .expect("Should succeed when using both predicate and stats_columns");
+
+    // Verify the scan has a physical predicate (data skipping is active)
+    assert!(
+        scan.physical_predicate().is_some(),
+        "Scan should have a physical predicate for data skipping"
+    );
+
+    // Run scan_metadata and verify stats_parsed is present in the output
+    let scan_metadata_results: Vec<_> = scan
+        .scan_metadata(engine.as_ref())
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
 
     assert!(
-        result.is_err(),
-        "Should error when using both predicate and stats_columns"
+        !scan_metadata_results.is_empty(),
+        "Should have scan metadata results"
     );
-    let err = result.unwrap_err();
+
+    let mut file_count = 0;
+    for scan_metadata in scan_metadata_results {
+        let (underlying_data, selection_vector) = scan_metadata.scan_files.into_parts();
+        let batch: RecordBatch = ArrowEngineData::try_from_engine_data(underlying_data)
+            .unwrap()
+            .into();
+        let filtered_batch =
+            filter_record_batch(&batch, &BooleanArray::from(selection_vector)).unwrap();
+
+        // Verify stats_parsed column exists and is a struct type
+        let schema = filtered_batch.schema();
+        let field = schema
+            .field_with_name(STATS_PARSED_COL)
+            .expect("Schema should contain stats_parsed column");
+        assert!(
+            matches!(field.data_type(), ArrowDataType::Struct(_)),
+            "stats_parsed should be a struct type"
+        );
+
+        // Verify stats_parsed has data
+        let stats_parsed = get_column!(filtered_batch, STATS_PARSED_COL, StructArray);
+        let num_records = get_column!(stats_parsed, "numRecords", Int64Array);
+        for i in 0..filtered_batch.num_rows() {
+            if !stats_parsed.is_null(i) {
+                assert!(num_records.value(i) > 0, "numRecords should be positive");
+                file_count += 1;
+            }
+        }
+    }
+
     assert!(
-        err.to_string().contains("predicate") || err.to_string().contains("stats_columns"),
-        "Error message should mention predicate or stats_columns: {}",
-        err
+        file_count > 0,
+        "Should have processed at least one file with stats"
     );
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/1691/files) to review incremental changes.
- [**stack/output_parsed_stats**](https://github.com/delta-io/delta-kernel-rs/pull/1691) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1691/files)]
  - [stack/specify-stats-columns](https://github.com/delta-io/delta-kernel-rs/pull/1730) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1730/files/f031b05d8bea17f6e15fd77f5d6df1dfbd3ff810..f581c7a6ee4a8daaf46608f9af9204d021261423)]

---------
## What changes are proposed in this pull request?

Remove the mutual exclusivity error between stats_columns and predicate in StateInfo::try_new. When both are provided, expected_stats_schema (a superset of the predicate-derived schema) is used, enabling both stats output to the engine and kernel-level data skipping.


## How was this change tested?
New unit tests + existing tests