### PR TITLE
feat: Add write support for clustered tables behind feature flag

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -116,6 +116,10 @@ catalog-managed = []
 # Schema diffing functionality (experimental)
 schema-diff = []
 
+# WARNING: experimental feature, still under active development
+# enables write support for clustered tables
+clustered-table = []
+
 # this is an 'internal' feature flag which has all the shared bits from default-engine and
 # default-engine-rustls
 default-engine-base = [

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -1645,4 +1645,32 @@ mod test {
         assert!(!column_names.contains(&ColumnName::new(["phys_col_a"])));
         assert!(!column_names.contains(&ColumnName::new(["phys_col_b"])));
     }
+
+    #[cfg(feature = "clustered-table")]
+    #[test]
+    fn test_clustered_table_writes() {
+        // ClusteredTable requires DomainMetadata to be supported
+        let config = create_mock_table_config(
+            &[],
+            &[TableFeature::ClusteredTable, TableFeature::DomainMetadata],
+        );
+        assert!(
+            config.ensure_operation_supported(Operation::Write).is_ok(),
+            "ClusteredTable with DomainMetadata should be supported for writes"
+        );
+    }
+
+    #[cfg(not(feature = "clustered-table"))]
+    #[test]
+    fn test_clustered_table_writes_not_supported() {
+        // Without the clustered-table feature, writes to clustered tables should fail
+        let config = create_mock_table_config(
+            &[],
+            &[TableFeature::ClusteredTable, TableFeature::DomainMetadata],
+        );
+        assert!(
+            config.ensure_operation_supported(Operation::Write).is_err(),
+            "ClusteredTable should not be supported for writes without feature flag"
+        );
+    }
 }

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -420,13 +420,15 @@ static ICEBERG_COMPAT_V2_INFO: FeatureInfo = FeatureInfo {
     }),
 };
 
-#[allow(dead_code)]
 static CLUSTERED_TABLE_INFO: FeatureInfo = FeatureInfo {
     name: "clustering",
     min_reader_version: 1,
     min_writer_version: 7,
     feature_type: FeatureType::Writer,
     feature_requirements: &[FeatureRequirement::Supported(TableFeature::DomainMetadata)],
+    #[cfg(feature = "clustered-table")]
+    kernel_support: KernelSupport::Supported,
+    #[cfg(not(feature = "clustered-table"))]
     kernel_support: KernelSupport::NotSupported,
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };


### PR DESCRIPTION
This commit enables writes to clustered tables when the `clustered-table` feature flag is enabled. Without the feature flag, writes to tables with the `clustering` writer feature will fail with "Feature 'clustering' is not supported".

## Usage

To enable writes to clustered tables, add the feature flag to your Cargo.toml:

```toml
[dependencies]
delta_kernel = { version = "0.x", features = ["clustered-table"] }
```

Or build with:

```bash
cargo build --features clustered-table
```

## Protocol Requirements
When writing to clustered tables, ensure that:
The client provides per-file statistics including min/max for clustering columns in the add file metadata

## Changes
- Add `clustered-table` feature flag to kernel/Cargo.toml
- Update CLUSTERED_TABLE_INFO to conditionally set kernel_support based on feature flag
- Add tests for both enabled and disabled states