### PR TITLE
ci: add sccache for file-level compilation caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,21 @@ on: [push, pull_request]
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # Two-layer caching strategy for Rust builds:
+  #
+  # 1. Swatinem/rust-cache (crate-level):
+  #    - Caches ~/.cargo/registry, ~/.cargo/git, and ./target/
+  #    - Avoids re-downloading dependencies (tokio, serde, etc.)
+  #    - Restores pre-built dependency artifacts
+  #
+  # 2. sccache (file-level):
+  #    - Wraps rustc and caches individual compilation units
+  #    - When you change one file, only that file recompiles
+  #    - Shares compilation results across jobs and branches
+  #
+  # Why both? rust-cache handles dependency artifacts efficiently, while sccache
+  # provides incremental compilation benefits for the project's own code. Together
+  # they minimize both download time and compilation time.
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
 


### PR DESCRIPTION
## Summary

Add [sccache](https://github.com/mozilla/sccache) for **file-level compilation caching** to complement the existing `Swatinem/rust-cache` which only caches at the crate level.

Closes #1698

## Why sccache?

### The Problem with Crate-Level Caching Only

Currently, `Swatinem/rust-cache` caches:
- `~/.cargo/registry/` - Downloaded crate source code
- `~/.cargo/git/` - Git dependencies  
- `./target/` - Compiled artifacts

But this operates at the **crate level**. If you change one line in `kernel/src/snapshot.rs`:

```
Before: cargo build → uses cached dependencies ✓ → rebuilds ALL of delta_kernel ✗
Result: 30-60 seconds of compilation even for a one-line change
```

### How sccache Helps

sccache wraps `rustc` and caches at the **compilation unit level** (individual `.rs` files):

```
Normal compilation:
  rustc src/lib.rs → compile → lib.rlib (30 seconds)

With sccache (first run - cold):
  rustc src/lib.rs → sccache miss → compile → lib.rlib → cache result

With sccache (subsequent runs - warm):
  rustc src/lib.rs → sccache checks hash → HIT for unchanged files → skip compilation
  rustc src/changed.rs → sccache miss → compile only this file
```

## Implementation

### Jobs with sccache enabled
- `build` (macOS, ubuntu, windows) - Heavy compilation
- `test` (macOS, ubuntu, windows) - Heavy compilation  
- `ffi_test` (macOS, ubuntu) - Heavy compilation
- `msrv-run-tests` - Runs full test suite
- `coverage` - Full compilation + instrumentation

### Jobs excluded
- `format` - No compilation (just `cargo fmt --check`)
- `msrv` - Only runs `cargo msrv verify`, minimal compilation
- `docs` - Doc generation has different caching characteristics
- `miri` - Incompatible (miri wraps rustc itself)

## Test Results

Compared two CI runs to measure caching effectiveness:
- **Run 1**: [21461823910](https://github.com/delta-io/delta-kernel-rs/actions/runs/21461823910) - Cold cache (first run)
- **Run 2**: [21461991639](https://github.com/delta-io/delta-kernel-rs/actions/runs/21461991639) - Warm cache (second run)

### Job Duration Comparison

| Job | Run 1 (Cold) | Run 2 (Warm) | Improvement |
|-----|--------------|--------------|-------------|
| ffi_test (ubuntu) | 3m 49s | 1m 45s | **54% faster** |
| ffi_test (macOS) | 8m 52s | 4m 42s | **47% faster** |
| build (macOS) | 7m 23s | 2m 38s | **64% faster** |
| build (windows) | 7m 53s | 3m 9s | **60% faster** |
| test (ubuntu) | 5m 48s | 1m 32s | **73% faster** |
| coverage | 4m 56s | 1m 36s | **68% faster** |
| msrv-run-tests | 3m 53s | 1m 28s | **62% faster** |

### sccache Statistics (Run 2 - build ubuntu)
```
Compile requests                   1339
Cache hits (Assembler)               69 (57.98%)
Cache hits (C/C++)                  123 (35.14%)
Cache misses (Rust)                 679
```

**Note**: The Rust cache hit rate is low because this was the first run to populate the sccache cache for Rust artifacts. The C/C++ hits are from building `aws-lc-sys` which was already cached. Future incremental builds (changing a few files) will see higher Rust cache hit rates.

### Key Insight

The improvements above come from **both** caching layers working together:
1. **rust-cache**: Restores pre-built dependencies → dramatic speedup
2. **sccache**: Will provide additional speedup on incremental code changes (not fully demonstrated here since there were no code changes between runs)

## References

- [sccache GitHub](https://github.com/mozilla/sccache)
- [mozilla-actions/sccache-action](https://github.com/mozilla-actions/sccache-action)
- [Issue #1698](https://github.com/delta-io/delta-kernel-rs/issues/1698)
- Used by: [delta-rs](https://github.com/delta-io/delta-rs), [arrow-rs](https://github.com/apache/arrow-rs), and many other Rust projects