### PR TITLE
feat: pass engine to Snapshot::transaction() for domain metadata access

### DIFF
--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -39,9 +39,10 @@ fn transaction_impl(
     url: DeltaResult<Url>,
     extern_engine: &dyn ExternEngine,
 ) -> DeltaResult<Handle<ExclusiveTransaction>> {
-    let snapshot = Snapshot::builder_for(url?).build(extern_engine.engine().as_ref())?;
+    let engine = extern_engine.engine();
+    let snapshot = Snapshot::builder_for(url?).build(engine.as_ref())?;
     let committer = Box::new(FileSystemCommitter::new());
-    let transaction = snapshot.transaction(committer);
+    let transaction = snapshot.transaction(committer, engine.as_ref());
     Ok(Box::new(transaction?).into())
 }
 

--- a/kernel/examples/write-table/src/main.rs
+++ b/kernel/examples/write-table/src/main.rs
@@ -87,7 +87,7 @@ async fn try_main() -> DeltaResult<()> {
     // Write sample data to the table
     let committer = Box::new(FileSystemCommitter::new());
     let mut txn = snapshot
-        .transaction(committer)?
+        .transaction(committer, &engine)?
         .with_operation("INSERT".to_string())
         .with_engine_info("default_engine/write-table-example")
         .with_data_change(true);

--- a/kernel/src/committer/filesystem.rs
+++ b/kernel/src/committer/filesystem.rs
@@ -102,7 +102,7 @@ mod tests {
         // Try to commit a transaction with FileSystemCommitter
         let committer = Box::new(FileSystemCommitter::new());
         let err = snapshot
-            .transaction(committer)
+            .transaction(committer, &engine)
             .unwrap()
             .commit(&engine)
             .unwrap_err();

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -317,6 +317,7 @@ impl Snapshot {
     ) -> DeltaResult<Self> {
         let reporter = engine.get_metrics_reporter();
 
+        // Read protocol and metadata
         let start = Instant::now();
         let (metadata, protocol) = log_segment.read_metadata(engine)?;
         let read_metadata_duration = start.elapsed();
@@ -509,8 +510,12 @@ impl Snapshot {
     }
 
     /// Create a [`Transaction`] for this `SnapshotRef`. With the specified [`Committer`].
-    pub fn transaction(self: Arc<Self>, committer: Box<dyn Committer>) -> DeltaResult<Transaction> {
-        Transaction::try_new_existing_table(self, committer)
+    pub fn transaction(
+        self: Arc<Self>,
+        committer: Box<dyn Committer>,
+        engine: &dyn Engine,
+    ) -> DeltaResult<Transaction> {
+        Transaction::try_new_existing_table(self, committer, engine)
     }
 
     /// Fetch the latest version of the provided `application_id` for this snapshot. Filters the txn based on the SetTransactionRetentionDuration property and lastUpdated

--- a/kernel/tests/dv.rs
+++ b/kernel/tests/dv.rs
@@ -102,7 +102,7 @@ fn get_write_context(
     engine: &dyn delta_kernel::Engine,
 ) -> Result<delta_kernel::transaction::WriteContext, Box<dyn std::error::Error>> {
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine)?;
-    let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()))?;
+    let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), engine)?;
     Ok(txn.get_write_context())
 }
 
@@ -139,7 +139,7 @@ fn create_dv_update_transaction(
 ) -> Result<delta_kernel::transaction::Transaction, Box<dyn std::error::Error>> {
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine)?;
     Ok(snapshot
-        .transaction(Box::new(FileSystemCommitter::new()))?
+        .transaction(Box::new(FileSystemCommitter::new()), engine)?
         .with_engine_info("test engine")
         .with_operation("DELETE".to_string()))
 }
@@ -261,7 +261,7 @@ async fn test_write_deletion_vectors_end_to_end() -> Result<(), Box<dyn std::err
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
     let mut txn = snapshot
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()))?
+        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_engine_info("test engine")
         .with_operation("WRITE".to_string());
 

--- a/kernel/tests/write_row_tracking.rs
+++ b/kernel/tests/write_row_tracking.rs
@@ -65,7 +65,7 @@ async fn test_row_tracking_fields_in_add_and_remove_actions(
     // ===== FIRST COMMIT: Add files with row tracking =====
     let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
     let mut txn = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()))?
+        .transaction(Box::new(FileSystemCommitter::new()), &engine)?
         .with_engine_info("row tracking test")
         .with_data_change(true);
 
@@ -137,7 +137,7 @@ async fn test_row_tracking_fields_in_add_and_remove_actions(
     let snapshot2 = Snapshot::builder_for(table_url.clone()).build(engine_arc.as_ref())?;
     let mut txn2 = snapshot2
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()))?
+        .transaction(Box::new(FileSystemCommitter::new()), engine_arc.as_ref())?
         .with_engine_info("row tracking remove test")
         .with_data_change(true);
 

--- a/uc-catalog/src/lib.rs
+++ b/uc-catalog/src/lib.rs
@@ -259,7 +259,7 @@ mod tests {
             .load_snapshot(&table_id, &table_uri, &engine)
             .await?;
         println!("latest snapshot version: {:?}", snapshot.version());
-        let txn = snapshot.clone().transaction(committer)?;
+        let txn = snapshot.clone().transaction(committer, &engine)?;
         let _write_context = txn.get_write_context();
 
         match txn.commit(&engine)? {

--- a/uc-catalog/tests/e2e_in_memory.rs
+++ b/uc-catalog/tests/e2e_in_memory.rs
@@ -103,7 +103,11 @@ fn commit(
     engine: &DefaultEngine<TokioMultiThreadExecutor>,
 ) -> Result<Arc<Snapshot>, TestError> {
     let committer = Box::new(UCCommitter::new(commits_client.clone(), TABLE_ID));
-    match snapshot.clone().transaction(committer)?.commit(engine)? {
+    match snapshot
+        .clone()
+        .transaction(committer, engine)?
+        .commit(engine)?
+    {
         CommitResult::CommittedTransaction(t) => Ok(t
             .post_commit_snapshot()
             .ok_or("no post commit snapshot")?
@@ -161,7 +165,7 @@ async fn test_insert_without_publish_hits_limit() -> Result<(), TestError> {
     let committer = Box::new(UCCommitter::new(commits_client.clone(), TABLE_ID));
     let err = snapshot
         .clone()
-        .transaction(committer)?
+        .transaction(committer, &engine)?
         .commit(&engine)
         .unwrap_err();
     assert!(


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Add `engine: &dyn Engine` parameter to `Snapshot::transaction()`
- Update all call sites to pass the engine

### This PR affects the following public APIs

  **Breaking change:** `Snapshot::transaction()` now requires an `engine: &dyn Engine` parameter.

  ```rust
  // Before
  pub fn transaction(self: Arc<Self>, committer: Box<dyn Committer>) -> DeltaResult<Transaction>

  // After
  pub fn transaction(self: Arc<Self>, committer: Box<dyn Committer>, engine: &dyn Engine) -> DeltaResult<Transaction>
  ```

  This change is needed to allow Transaction to read domain metadata (e.g., clustering columns) from the log segment when required. The engine provides the necessary I/O capabilities to read from storage.


## How was this change tested?
Tests pass