### PR TITLE
feat: add conflict detection API for protocol/metadata changes

### DIFF
--- a/kernel/src/conflict_detection.rs
+++ b/kernel/src/conflict_detection.rs
@@ -1,0 +1,189 @@
+//! Conflict detection utilities for transaction retry scenarios.
+//!
+//! When a connector's transaction conflicts (e.g., read at v10, but other writers committed v11,
+//! v12, v13), it may want to retry. This module provides utilities to check if previously computed
+//! data (like add_files_meta) can be safely reused.
+
+use std::sync::LazyLock;
+
+use url::Url;
+
+use crate::actions::{get_commit_schema, METADATA_NAME, PROTOCOL_NAME};
+use crate::engine_data::{GetData, RowVisitor, TypedGetData};
+use crate::log_segment::LogSegment;
+use crate::schema::{column_name, ColumnName, ColumnNamesAndTypes, DataType};
+use crate::{DeltaResult, Engine, Error, Version};
+
+/// Visitor that detects presence of protocol or metadata actions.
+#[derive(Default)]
+struct DetectProtocolMetadataChangeVisitor {
+    found_protocol: bool,
+    found_metadata: bool,
+}
+
+impl RowVisitor for DetectProtocolMetadataChangeVisitor {
+    fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
+        static NAMES_AND_TYPES: LazyLock<ColumnNamesAndTypes> = LazyLock::new(|| {
+            // Select required sub-fields: if non-null, the action exists
+            let names = vec![
+                column_name!("protocol.minReaderVersion"),
+                column_name!("metaData.id"),
+            ];
+            let types = vec![DataType::INTEGER, DataType::STRING];
+            (names, types).into()
+        });
+        NAMES_AND_TYPES.as_ref()
+    }
+
+    fn visit<'a>(&mut self, row_count: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
+        for i in 0..row_count {
+            let protocol_val: Option<i32> = getters[0].get_opt(i, "protocol.minReaderVersion")?;
+            if protocol_val.is_some() {
+                self.found_protocol = true;
+            }
+            let metadata_val: Option<&str> = getters[1].get_opt(i, "metaData.id")?;
+            if metadata_val.is_some() {
+                self.found_metadata = true;
+            }
+            if self.found_protocol && self.found_metadata {
+                return Ok(());
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Checks that no protocol or metadata action was committed in the given version range.
+///
+/// This is useful for transaction retry scenarios: when a connector's transaction conflicts,
+/// it can check if protocol/metadata changed. If not, previously computed add_files_meta
+/// can be safely reused.
+///
+/// # Arguments
+/// * `engine` - The engine for reading log files
+/// * `table_root` - The root URL of the delta table
+/// * `start_version_exclusive` - Check commits after this version
+/// * `end_version_inclusive` - Check commits up to and including this version
+///
+/// # Returns
+/// * `Ok(())` - No protocol/metadata changes found in the version range
+/// * `Err(ProtocolChanged)` - Protocol action detected in the version range
+/// * `Err(MetadataChanged)` - Metadata action detected in the version range
+pub fn check_no_protocol_or_metadata_changes(
+    engine: &dyn Engine,
+    table_root: &Url,
+    start_version_exclusive: Version,
+    end_version_inclusive: Version,
+) -> DeltaResult<()> {
+    // Nothing to check if versions are adjacent or reversed
+    if start_version_exclusive >= end_version_inclusive {
+        return Ok(());
+    }
+
+    let log_root = table_root.join("_delta_log/")?;
+    let check_start = start_version_exclusive.saturating_add(1);
+
+    let log_segment = LogSegment::for_table_changes(
+        engine.storage_handler().as_ref(),
+        log_root,
+        check_start,
+        Some(end_version_inclusive),
+    )?;
+
+    let schema = get_commit_schema().project(&[PROTOCOL_NAME, METADATA_NAME])?;
+    let actions_iter = log_segment.read_actions(engine, schema, None)?;
+
+    let mut visitor = DetectProtocolMetadataChangeVisitor::default();
+
+    for actions_result in actions_iter {
+        let batch = actions_result?;
+        visitor.visit_rows_of(batch.actions.as_ref())?;
+
+        // Check for protocol change first
+        if visitor.found_protocol {
+            return Err(Error::protocol_changed(format!(
+                "protocol changed between versions {} and {}",
+                start_version_exclusive, end_version_inclusive
+            )));
+        }
+
+        // Check for metadata change
+        if visitor.found_metadata {
+            return Err(Error::metadata_changed(format!(
+                "metadata changed between versions {} and {}",
+                start_version_exclusive, end_version_inclusive
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::sync::SyncEngine;
+    use std::path::PathBuf;
+
+    fn get_test_engine_and_url(table_name: &str) -> (SyncEngine, Url) {
+        let engine = SyncEngine::new();
+        let path = std::fs::canonicalize(PathBuf::from(format!("./tests/data/{}/", table_name)))
+            .expect("Failed to canonicalize path");
+        let url = Url::from_directory_path(path).expect("Failed to create URL");
+        (engine, url)
+    }
+
+    #[test]
+    fn test_adjacent_versions_succeeds() {
+        let (engine, url) = get_test_engine_and_url("basic_partitioned");
+
+        // start >= end should succeed immediately without reading any files
+        let result = check_no_protocol_or_metadata_changes(&engine, &url, 0, 0);
+        assert!(result.is_ok());
+
+        let result = check_no_protocol_or_metadata_changes(&engine, &url, 5, 3);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_no_changes_between_add_only_commits() {
+        // basic_partitioned: v0 has P+M, v1 has only add actions
+        let (engine, url) = get_test_engine_and_url("basic_partitioned");
+
+        // Check between v0 and v1 - should succeed since v1 only has add actions
+        let result = check_no_protocol_or_metadata_changes(&engine, &url, 0, 1);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_detects_protocol_change() {
+        // type-widening: v1 has protocol change (adding typeWidening-preview feature)
+        let (engine, url) = get_test_engine_and_url("type-widening");
+
+        // v0 -> v1 should detect the protocol change
+        let result = check_no_protocol_or_metadata_changes(&engine, &url, 0, 1);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, Error::ProtocolChanged(_)),
+            "Expected ProtocolChanged, got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_detects_metadata_change() {
+        // type-widening: v2 has metadata change (schema widening) but no protocol change
+        let (engine, url) = get_test_engine_and_url("type-widening");
+
+        // v1 -> v2 should detect the metadata change
+        let result = check_no_protocol_or_metadata_changes(&engine, &url, 1, 2);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, Error::MetadataChanged(_)),
+            "Expected MetadataChanged, got {:?}",
+            err
+        );
+    }
+}

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -211,6 +211,14 @@ pub enum Error {
     /// Schema mismatch has occurred or invalid schema used somewhere
     #[error("Schema error: {0}")]
     Schema(String),
+
+    /// Protocol changed concurrently during a transaction
+    #[error("Concurrent protocol change detected: {0}")]
+    ProtocolChanged(String),
+
+    /// Metadata changed concurrently during a transaction
+    #[error("Concurrent metadata change detected: {0}")]
+    MetadataChanged(String),
 }
 
 // Convenience constructors for Error types that take a String argument
@@ -294,6 +302,14 @@ impl Error {
 
     pub fn schema(msg: impl ToString) -> Self {
         Self::Schema(msg.to_string())
+    }
+
+    pub fn protocol_changed(msg: impl ToString) -> Self {
+        Self::ProtocolChanged(msg.to_string())
+    }
+
+    pub fn metadata_changed(msg: impl ToString) -> Self {
+        Self::MetadataChanged(msg.to_string())
     }
 
     // Capture a backtrace when the error is constructed.

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -88,6 +88,7 @@ mod action_reconciliation;
 pub mod actions;
 pub mod checkpoint;
 pub mod committer;
+pub mod conflict_detection;
 pub mod engine_data;
 pub mod error;
 pub mod expressions;
@@ -153,6 +154,7 @@ pub mod history_manager;
 pub(crate) mod history_manager;
 
 pub use action_reconciliation::{ActionReconciliationIterator, ActionReconciliationIteratorState};
+pub use conflict_detection::check_no_protocol_or_metadata_changes;
 pub use delta_kernel_derive;
 use delta_kernel_derive::internal_api;
 pub use engine_data::{EngineData, FilteredEngineData, RowVisitor};


### PR DESCRIPTION
## Summary

Add a conflict detection API for transaction retry scenarios. When a connector's transaction conflicts (e.g., read at v10, but other writers committed v11, v12, v13), it may want to retry. This API helps determine if previously computed data (like add_files_meta) can be safely reused.

### Changes

1. **New error variants** (`kernel/src/error.rs`):
   - `ProtocolChanged(String)` - Protocol changed concurrently during a transaction
   - `MetadataChanged(String)` - Metadata changed concurrently during a transaction

2. **New module** (`kernel/src/conflict_detection.rs`):
   - `check_no_protocol_or_metadata_changes()` - Scans commits between two versions and returns:
     - `Ok(())` if no protocol/metadata changes found
     - `Err(ProtocolChanged)` if a protocol action was detected
     - `Err(MetadataChanged)` if a metadata action was detected

3. **Public export** in `kernel/src/lib.rs`

### Usage

```rust
use delta_kernel::check_no_protocol_or_metadata_changes;

// Check if protocol/metadata changed between versions 10 and 13
let result = check_no_protocol_or_metadata_changes(
    &engine,
    &table_root,
    10,  // start_version_exclusive
    13,  // end_version_inclusive
);

match result {
    Ok(()) => {
        // Safe to reuse previously computed add_files_meta
    }
    Err(Error::ProtocolChanged(_)) => {
        // Protocol changed, need to recompute
    }
    Err(Error::MetadataChanged(_)) => {
        // Metadata changed, need to recompute
    }
    Err(e) => {
        // Other error
    }
}
```

## Test plan

- [x] Unit tests for adjacent/reversed versions
- [x] Unit tests for detecting protocol changes
- [x] Unit tests for detecting metadata changes
- [x] Unit tests for no changes between add-only commits
- [x] All existing kernel tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)