### PR TITLE
feat: support owned runtime in `TokioMultiThreadExecutor`

### DIFF
--- a/kernel/src/engine/default/executor.rs
+++ b/kernel/src/engine/default/executor.rs
@@ -409,14 +409,14 @@ pub mod tokio {
 
         #[test]
         fn test_block_on_works_outside_tokio_runtime() {
+            let executor = TokioMultiThreadExecutor::new_owned_runtime(None, None)
+                .expect("Failed to create executor");
+
             // Verify we're not inside a Tokio runtime
             assert!(
                 tokio::runtime::Handle::try_current().is_err(),
                 "Test must run outside of a Tokio runtime"
             );
-
-            let executor = TokioMultiThreadExecutor::new_owned_runtime(None, None)
-                .expect("Failed to create executor");
 
             // block_on should work even though we're not inside a Tokio runtime
             let result = executor.block_on(async {


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/1719/files) to review incremental changes.
- [**stack/executor-refactor**](https://github.com/delta-io/delta-kernel-rs/pull/1719) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1719/files)]
  - [stack/ffi-multi](https://github.com/delta-io/delta-kernel-rs/pull/1755) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1755/files/f96f1b80ebf652eb86d2593a7d2d6d3f0ce7f67c..5178df4eefd158914c42e12af4af225ac1937146)]

---------
## What changes are proposed in this pull request?
Adds `TokioMultiThreadExecutor::new_owned_runtime(worker_threads, max_blocking_threads)` constructor that creates and owns a Tokio multi-thread runtime.

With it, users can create `TokioMultiThreadExecutor` without pre-existing tokio runtime.
<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->
## How was this change tested?
Added
