### PR TITLE
docs: simplify checkpoint-table example to use Snapshot::checkpoint() API

### DIFF
--- a/kernel/examples/checkpoint-table/Cargo.toml
+++ b/kernel/examples/checkpoint-table/Cargo.toml
@@ -5,23 +5,13 @@ edition = "2021"
 publish = false
 
 [dependencies]
-arrow = { version = "57", features = ["prettyprint", "chrono-tz"] }
 clap = { version = "4.5", features = ["derive"] }
-chrono = { version = "0.4", features = ["serde"] }
-# NB: common depends on 'arrow' (latest) so have to match here
 common = { path = "../common" }
 delta_kernel = { path = "../../../kernel", features = [
-  "arrow",
   "default-engine-rustls",
-  "internal-api",
 ] }
 env_logger = "0.11.8"
-object_store = { version = "0.12.3", features = ["aws", "azure", "gcp", "http"] }
-parquet = { version = "57" }
 tokio = { version = "1.0", features = ["full"] }
-url = "2"
-bytes = "1.11.0"
-futures = "0.3.31"
 
 # for cargo-release
 [package.metadata.release]

--- a/kernel/examples/checkpoint-table/src/main.rs
+++ b/kernel/examples/checkpoint-table/src/main.rs
@@ -1,15 +1,12 @@
 use std::process::ExitCode;
+use std::sync::Arc;
 
-use arrow::array::RecordBatch;
 use clap::Parser;
 use common::{LocationArgs, ParseWithExamples};
-use futures::future::{BoxFuture, FutureExt};
-use parquet::arrow::async_writer::{AsyncFileWriter, ParquetObjectWriter};
-use parquet::arrow::AsyncArrowWriter;
 
-use delta_kernel::engine::arrow_data::EngineDataArrowExt;
+use delta_kernel::engine::default::executor::tokio::TokioMultiThreadExecutor;
 use delta_kernel::engine::default::DefaultEngineBuilder;
-use delta_kernel::{ActionReconciliationIterator, DeltaResult, Error, FileMeta, Snapshot};
+use delta_kernel::{DeltaResult, Snapshot};
 
 /// An example program that checkpoints a table.
 /// !!!WARNING!!!: This doesn't use put-if-absent, or a catalog based commit, so it is UNSAFE.
@@ -42,20 +39,6 @@ async fn main() -> ExitCode {
     }
 }
 
-async fn write_data<W: AsyncFileWriter>(
-    first_batch: &RecordBatch,
-    batch_iter: &mut ActionReconciliationIterator,
-    parquet_writer: &mut AsyncArrowWriter<W>,
-) -> DeltaResult<()> {
-    parquet_writer.write(first_batch).await?;
-    for data_res in batch_iter {
-        let data = data_res?.apply_selection_vector()?;
-        let batch = data.try_into_record_batch()?;
-        parquet_writer.write(&batch).await?;
-    }
-    Ok(())
-}
-
 async fn try_main() -> DeltaResult<()> {
     let cli = Cli::parse_with_examples(env!("CARGO_PKG_NAME"), "Write", "write", "");
 
@@ -64,84 +47,46 @@ async fn try_main() -> DeltaResult<()> {
 
     use delta_kernel::engine::default::storage::store_from_url;
     let store = store_from_url(&url)?;
-    let engine = DefaultEngineBuilder::new(store.clone()).build();
+
+    // Use TokioMultiThreadExecutor to avoid deadlock when calling snapshot.checkpoint()
+    let executor = Arc::new(TokioMultiThreadExecutor::new(
+        tokio::runtime::Handle::current(),
+    ));
+    let engine = DefaultEngineBuilder::new(store)
+        .with_task_executor(executor)
+        .build();
+
     let snapshot = Snapshot::builder_for(url).build(&engine)?;
 
-    // first we create a checkpoint writer
-    let writer = snapshot.create_checkpoint_writer()?;
-
-    // this tells us the path where we should write the checkpoint file
-    let checkpoint_path = writer.checkpoint_path()?;
-    // this gives us a iterator of `FilteredEngineData` that needs to be written to the file
-    let mut data_iter = writer.checkpoint_data(&engine)?;
-    let state = data_iter.state();
-
-    let batch_iter = data_iter.by_ref();
-    // we'll use the first batch to determine the schema
-    let first = batch_iter.next();
-
-    let Some(first) = first else {
-        return Err(Error::generic("No batches in checkpoint data"));
-    };
-    // Note that with `FilteredEngineData` it's important to `apply_selection_vector` to remove any
-    // filtered out rows. It's also possible to use `into_parts` to get the unfiltered batch and the
-    // selection vector individually, such that an engine could write only the selected rows out
-    // without having to allocate a new engine data.
-    // NB: Unselected rows MUST NOT be written to the checkpoint! Doing so will create an invalid
-    // checkpoint
-    let first_data = first?.apply_selection_vector()?;
-    let first_batch = first_data.try_into_record_batch()?;
-
     if cli.unsafe_i_know_what_im_doing {
-        // this block uses the arrow writer to write the data out
-        let path = object_store::path::Path::from_url_path(checkpoint_path.path())?;
-        let object_writer = ParquetObjectWriter::new(store.clone(), path.clone());
-        let mut parquet_writer =
-            AsyncArrowWriter::try_new(object_writer, first_batch.schema(), None)?;
-        write_data(&first_batch, batch_iter, &mut parquet_writer).await?;
-        parquet_writer.close().await?;
-        let metadata = store.head(&path).await?;
-        let file_meta = FileMeta {
-            location: checkpoint_path.clone(),
-            last_modified: metadata.last_modified.timestamp() * 1000,
-            size: metadata.size,
-        };
-        // It's important to call `finalize` on the writer, which will create a `_last_checkpoint`
-        // file
-        writer.finalize(&engine, &file_meta, &state)?;
+        // Use the simplified all-in-one checkpoint API
+        snapshot.checkpoint(&engine)?;
         println!("Table checkpointed");
     } else {
+        // For dry-run mode, we still need to manually iterate through the data
+        // to show what would be written without actually writing it
         println!("--unsafe-i-know-what-im-doing not specified, just doing a dry run");
-        // this block just writes the checkpoint to a blackhole
-        let mut parquet_writer =
-            AsyncArrowWriter::try_new(BlackholeWriter::default(), first_batch.schema(), None)?;
-        write_data(&first_batch, batch_iter, &mut parquet_writer).await?;
-        parquet_writer.finish().await?;
-        let blackhole_writer = parquet_writer.into_inner();
-        println!(
-            "Would have written a checkpoint as:\n\tpath: {checkpoint_path}\n\tsize: {}",
-            blackhole_writer.len
-        );
-        // in this example we don't call `finalize` because we don't want to actually write
-        // anything, but if really checkpointing, it's important to call finalize as we do above
+        dry_run_checkpoint(snapshot, &engine)?;
     }
     Ok(())
 }
 
-/// Simple struct to allow us to go through the motions of writing the data without actually writing
-/// it anywhere. Verifies that the actual flow of data does work.
-#[derive(Default)]
-pub struct BlackholeWriter {
-    len: u64,
-}
+fn dry_run_checkpoint(
+    snapshot: Arc<Snapshot>,
+    engine: &impl delta_kernel::Engine,
+) -> DeltaResult<()> {
+    let writer = snapshot.create_checkpoint_writer()?;
+    let checkpoint_path = writer.checkpoint_path()?;
+    let data_iter = writer.checkpoint_data(engine)?;
 
-impl AsyncFileWriter for BlackholeWriter {
-    fn write(&mut self, bs: bytes::Bytes) -> BoxFuture<'_, parquet::errors::Result<()>> {
-        self.len += bs.len() as u64;
-        async move { Ok(()) }.boxed()
+    let mut total_rows = 0usize;
+    for data_res in data_iter {
+        let data = data_res?.apply_selection_vector()?;
+        total_rows += data.len();
     }
 
-    fn complete(&mut self) -> BoxFuture<'_, parquet::errors::Result<()>> {
-        async move { Ok(()) }.boxed()
-    }
+    println!(
+        "Would have written a checkpoint as:\n\tpath: {checkpoint_path}\n\ttotal rows: {total_rows}"
+    );
+    Ok(())
 }


### PR DESCRIPTION
## Summary
Simplify the checkpoint-table example by replacing the manual checkpoint workflow with the new `Snapshot::checkpoint()` API.

## Changes
- Use `TokioMultiThreadExecutor` to avoid deadlock when calling `snapshot.checkpoint()`
- Replace manual `CheckpointWriter` + `AsyncArrowWriter` workflow with single `snapshot.checkpoint()` call
- Keep dry-run mode using manual iteration to display stats without writing
- Remove unused dependencies from Cargo.toml (arrow, parquet, object_store, bytes, futures, chrono)

## Before (117 lines)
- Manually create CheckpointWriter
- Get checkpoint path and data iterator  
- Write parquet data using AsyncArrowWriter
- Call store.head() for file metadata
- Call writer.finalize()

## After (31 lines)
```rust
snapshot.checkpoint(&engine)?;
```

## Note
The dry-run mode still uses manual logic to iterate through checkpoint data and display stats without actually writing.

Fixes #1727