### PR TITLE
feat: Add DomainMetadata transform and TransformOutput infrastructure

### DIFF
--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -349,6 +349,14 @@ impl Metadata {
     pub(crate) fn parse_table_properties(&self) -> TableProperties {
         TableProperties::from(self.configuration.iter())
     }
+
+    /// Return a new Metadata with updated configuration.
+    #[internal_api]
+    #[allow(dead_code)] // Used by table_transformation module
+    pub(crate) fn with_configuration(mut self, configuration: HashMap<String, String>) -> Self {
+        self.configuration = configuration;
+        self
+    }
 }
 
 // NOTE: We can't derive IntoEngineData for Metadata because it has a nested Format struct,
@@ -475,6 +483,79 @@ impl Protocol {
         // Since each reader features is a subset of writer features, we only check writer feature
         self.writer_features()
             .is_some_and(|features| features.contains(feature))
+    }
+
+    /// Create a new Protocol with the given feature added.
+    ///
+    /// If the feature is already present, returns the protocol unchanged.
+    /// If the feature is a ReaderWriter feature, it will be added to both
+    /// reader and writer feature lists.
+    ///
+    /// # Arguments
+    ///
+    /// * `feature` - The feature to add to the protocol
+    ///
+    /// # Returns
+    ///
+    /// A new Protocol with the feature added, or an error if the resulting
+    /// protocol would be invalid.
+    #[allow(dead_code)]
+    pub(crate) fn with_feature(self, feature: TableFeature) -> DeltaResult<Self> {
+        use crate::table_features::{
+            TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION,
+        };
+
+        // Get current features as mutable vecs
+        let mut reader_features: Vec<_> =
+            self.reader_features.map(|f| f.to_vec()).unwrap_or_default();
+        let mut writer_features: Vec<_> =
+            self.writer_features.map(|f| f.to_vec()).unwrap_or_default();
+
+        // Add feature to writer features if not already present
+        if !writer_features.contains(&feature) {
+            writer_features.push(feature.clone());
+        }
+
+        // If it's a ReaderWriter feature, also add to reader features
+        if feature.is_reader_writer() && !reader_features.contains(&feature) {
+            reader_features.push(feature);
+        }
+
+        // Create new protocol with updated features
+        Protocol::try_new(
+            TABLE_FEATURES_MIN_READER_VERSION,
+            TABLE_FEATURES_MIN_WRITER_VERSION,
+            Some(reader_features.iter()),
+            Some(writer_features.iter()),
+        )
+    }
+
+    /// Create a new Protocol with specified versions, preserving existing features.
+    ///
+    /// This is used during table creation when the protocol version is determined
+    /// from user-specified properties.
+    ///
+    /// # Arguments
+    ///
+    /// * `min_reader_version` - The minimum reader version
+    /// * `min_writer_version` - The minimum writer version
+    ///
+    /// # Returns
+    ///
+    /// A new Protocol with the specified versions, or an error if the resulting
+    /// protocol would be invalid.
+    #[allow(dead_code)]
+    pub(crate) fn with_versions(
+        self,
+        min_reader_version: i32,
+        min_writer_version: i32,
+    ) -> DeltaResult<Self> {
+        Protocol::try_new(
+            min_reader_version,
+            min_writer_version,
+            self.reader_features.as_ref().map(|f| f.iter()),
+            self.writer_features.as_ref().map(|f| f.iter()),
+        )
     }
 
     /// Validates the relationship between reader features and writer features in the protocol.

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -103,6 +103,7 @@ pub mod table_configuration;
 pub mod table_features;
 pub mod table_properties;
 mod table_protocol_metadata_config;
+mod table_transformation;
 pub mod transaction;
 pub(crate) mod transforms;
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -102,6 +102,7 @@ pub mod table_changes;
 pub mod table_configuration;
 pub mod table_features;
 pub mod table_properties;
+mod table_protocol_metadata_config;
 pub mod transaction;
 pub(crate) mod transforms;
 

--- a/kernel/src/row_tracking.rs
+++ b/kernel/src/row_tracking.rs
@@ -16,9 +16,10 @@ pub(crate) struct RowTrackingDomainMetadata {
     row_id_high_water_mark: i64,
 }
 
-impl RowTrackingDomainMetadata {
-    const ROW_TRACKING_DOMAIN_NAME: &str = "delta.rowTracking";
+/// The domain name for row tracking metadata.
+pub(crate) const ROW_TRACKING_DOMAIN_NAME: &str = "delta.rowTracking";
 
+impl RowTrackingDomainMetadata {
     pub(crate) fn new(row_id_high_water_mark: i64) -> Self {
         RowTrackingDomainMetadata {
             row_id_high_water_mark,
@@ -45,14 +46,16 @@ impl RowTrackingDomainMetadata {
         snapshot: &Snapshot,
         engine: &dyn Engine,
     ) -> DeltaResult<Option<i64>> {
-        Ok(domain_metadata_configuration(
-            snapshot.log_segment(),
-            Self::ROW_TRACKING_DOMAIN_NAME,
-            engine,
-        )?
-        .map(|domain_metadata| serde_json::from_str::<Self>(&domain_metadata))
-        .transpose()?
-        .map(|metadata| metadata.row_id_high_water_mark))
+        Ok(
+            domain_metadata_configuration(
+                snapshot.log_segment(),
+                ROW_TRACKING_DOMAIN_NAME,
+                engine,
+            )?
+            .map(|domain_metadata| serde_json::from_str::<Self>(&domain_metadata))
+            .transpose()?
+            .map(|metadata| metadata.row_id_high_water_mark),
+        )
     }
 }
 
@@ -61,7 +64,7 @@ impl TryFrom<RowTrackingDomainMetadata> for DomainMetadata {
 
     fn try_from(metadata: RowTrackingDomainMetadata) -> DeltaResult<Self> {
         Ok(DomainMetadata::new(
-            RowTrackingDomainMetadata::ROW_TRACKING_DOMAIN_NAME.to_string(),
+            ROW_TRACKING_DOMAIN_NAME.to_string(),
             serde_json::to_string(&metadata)?,
         ))
     }

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -1,3 +1,5 @@
+//! Configuration for reading existing Delta tables.
+//!
 //! This module defines [`TableConfiguration`], a high level api to check feature support and
 //! feature enablement for a table at a given version. This encapsulates [`Protocol`], [`Metadata`],
 //! [`Schema`], [`TableProperties`], and [`ColumnMappingMode`]. These structs in isolation should

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -1,4 +1,6 @@
 use itertools::Itertools;
+use std::str::FromStr;
+
 use serde::{Deserialize, Serialize};
 use strum::{AsRefStr, Display as StrumDisplay, EnumCount, EnumString};
 
@@ -679,6 +681,22 @@ impl TableFeature {
             TableFeature::Unknown(_) => None,
         }
     }
+
+    /// Parse a feature name string into a TableFeature.
+    ///
+    /// Known feature names are parsed into their corresponding variants.
+    /// Unknown feature names are wrapped in `TableFeature::Unknown`.
+    #[allow(dead_code)] // Used by table_transformation module
+    pub(crate) fn from_name(name: &str) -> Self {
+        TableFeature::from_str(name).unwrap_or_else(|_| TableFeature::Unknown(name.to_string()))
+    }
+
+    /// Returns true if this is a ReaderWriter feature (appears in both reader and writer feature lists).
+    /// Returns false for Writer-only features and Unknown features.
+    #[allow(dead_code)] // Used by Protocol::with_feature
+    pub(crate) fn is_reader_writer(&self) -> bool {
+        matches!(self.feature_type(), FeatureType::ReaderWriter)
+    }
 }
 
 impl ToDataType for TableFeature {
@@ -828,5 +846,50 @@ mod tests {
             let from_str: TableFeature = expected.parse().unwrap();
             assert_eq!(from_str, feature);
         }
+    }
+
+    #[test]
+    fn test_from_name() {
+        // Known features
+        assert_eq!(
+            TableFeature::from_name("deletionVectors"),
+            TableFeature::DeletionVectors
+        );
+        assert_eq!(
+            TableFeature::from_name("changeDataFeed"),
+            TableFeature::ChangeDataFeed
+        );
+        assert_eq!(
+            TableFeature::from_name("columnMapping"),
+            TableFeature::ColumnMapping
+        );
+        assert_eq!(
+            TableFeature::from_name("timestampNtz"),
+            TableFeature::TimestampWithoutTimezone
+        );
+
+        // Unknown features
+        assert_eq!(
+            TableFeature::from_name("unknownFeature"),
+            TableFeature::Unknown("unknownFeature".to_string())
+        );
+    }
+
+    #[test]
+    fn test_is_reader_writer() {
+        // ReaderWriter features
+        assert!(TableFeature::DeletionVectors.is_reader_writer());
+        assert!(TableFeature::ColumnMapping.is_reader_writer());
+        assert!(TableFeature::TimestampWithoutTimezone.is_reader_writer());
+        assert!(TableFeature::V2Checkpoint.is_reader_writer());
+
+        // Writer-only features
+        assert!(!TableFeature::ChangeDataFeed.is_reader_writer());
+        assert!(!TableFeature::AppendOnly.is_reader_writer());
+        assert!(!TableFeature::DomainMetadata.is_reader_writer());
+        assert!(!TableFeature::RowTracking.is_reader_writer());
+
+        // Unknown features
+        assert!(!TableFeature::unknown("something").is_reader_writer());
     }
 }

--- a/kernel/src/table_properties.rs
+++ b/kernel/src/table_properties.rs
@@ -26,6 +26,14 @@ pub use deserialize::ParseIntervalError;
 /// Prefix for delta table properties (e.g., `delta.enableChangeDataFeed`, `delta.appendOnly`).
 pub const DELTA_PROPERTY_PREFIX: &str = "delta.";
 
+/// Table property key for specifying the minimum reader protocol version.
+/// This is a signal flag property - it affects protocol creation but is not stored in metadata.
+pub const MIN_READER_VERSION_PROP: &str = "delta.minReaderVersion";
+
+/// Table property key for specifying the minimum writer protocol version.
+/// This is a signal flag property - it affects protocol creation but is not stored in metadata.
+pub const MIN_WRITER_VERSION_PROP: &str = "delta.minWriterVersion";
+
 /// Delta table properties. These are parsed from the 'configuration' map in the most recent
 /// 'Metadata' action of a table.
 ///

--- a/kernel/src/table_protocol_metadata_config.rs
+++ b/kernel/src/table_protocol_metadata_config.rs
@@ -1,0 +1,249 @@
+//! Configuration for table property-based protocol and metadata modifications.
+//!
+//! This module provides [`TableProtocolMetadataConfig`], which creates Protocol and Metadata
+//! from user-provided table properties during table creation or modification operations.
+//!
+//! # Architecture
+//!
+//! The configuration flows through a transform pipeline:
+//!
+//! 1. `TableProtocolMetadataConfig::new()` - Creates initial config with bare protocol
+//!    and all properties passed through to metadata
+//! 2. `TransformationPipeline::apply_transforms()` - Applies registered transforms based on
+//!    the raw properties (enables features, validates properties, etc.)
+//!
+//! See [`crate::table_transformation`] for the transform pipeline implementation.
+//!
+//! # Difference from [`TableConfiguration`](crate::table_configuration::TableConfiguration)
+//!
+//! - **[`TableConfiguration`](crate::table_configuration::TableConfiguration)**: Reads the
+//!   configuration of an *existing* table from a snapshot.
+//!
+//! - **[`TableProtocolMetadataConfig`]**: Creates Protocol and Metadata from *user-provided*
+//!   properties during table creation or modification operations.
+
+use std::collections::HashMap;
+
+use crate::actions::{Metadata, Protocol};
+use crate::schema::StructType;
+use crate::table_features::{
+    TableFeature, SET_TABLE_FEATURE_SUPPORTED_PREFIX, TABLE_FEATURES_MIN_READER_VERSION,
+    TABLE_FEATURES_MIN_WRITER_VERSION,
+};
+use crate::table_properties::{MIN_READER_VERSION_PROP, MIN_WRITER_VERSION_PROP};
+use crate::utils::current_time_ms;
+use crate::DeltaResult;
+
+/// Protocol and Metadata state that flows through transforms.
+///
+/// This struct is the initial state created from user-provided table properties
+/// and schema during table creation. It flows through the transform pipeline
+/// which may:
+/// - Add features to the protocol based on properties or schema
+/// - Validate and process delta.* properties
+/// - Add column mapping metadata to the schema (future)
+///
+/// # Example
+/// ```ignore
+/// use delta_kernel::schema::StructType;
+/// use delta_kernel::table_transformation::TransformationPipeline;
+/// use std::collections::HashMap;
+///
+/// let schema = StructType::new_unchecked(vec![/* fields */]);
+/// let props = HashMap::from([
+///     ("myapp.version".to_string(), "1.0".to_string()),
+/// ]);
+///
+/// // Create initial config
+/// let config = TableProtocolMetadataConfig::new(schema, vec![], props.clone())?;
+///
+/// // Apply transforms
+/// let final_config = TransformationPipeline::apply_transforms(config, &props)?;
+/// ```
+#[derive(Debug)]
+#[allow(dead_code)] // Used by table_transformation module
+pub(crate) struct TableProtocolMetadataConfig {
+    /// The protocol (starts as bare v3/v7, transforms add features).
+    pub(crate) protocol: Protocol,
+    /// The metadata containing schema, partition columns, and all table properties.
+    pub(crate) metadata: Metadata,
+}
+
+#[allow(dead_code)] // Used by table_transformation module
+impl TableProtocolMetadataConfig {
+    /// Create initial config from schema, partition columns, and properties.
+    ///
+    /// This creates a "bare" configuration:
+    /// - Protocol: v3/v7 with empty feature lists
+    /// - Metadata: schema + partition columns + ALL properties (no filtering)
+    ///
+    /// Signal processing (delta.feature.*, version props) happens in transforms.
+    /// See [`crate::table_transformation::TransformationPipeline`].
+    ///
+    /// # Arguments
+    ///
+    /// * `schema` - The table schema
+    /// * `partition_columns` - Column names for partitioning
+    /// * `properties` - All user-provided table properties (pass-through)
+    pub(crate) fn new(
+        schema: StructType,
+        partition_columns: Vec<String>,
+        properties: HashMap<String, String>,
+    ) -> DeltaResult<Self> {
+        // Create bare protocol - v3/v7 with empty features
+        // Transforms will add features based on properties
+        let empty_features: [TableFeature; 0] = [];
+        let protocol = Protocol::try_new(
+            TABLE_FEATURES_MIN_READER_VERSION,
+            TABLE_FEATURES_MIN_WRITER_VERSION,
+            Some(empty_features.iter()),
+            Some(empty_features.iter()),
+        )?;
+
+        // Create Metadata with ALL properties - no filtering here
+        // Transforms will validate and process delta.* properties
+        let metadata = Metadata::try_new(
+            None, // name
+            None, // description
+            schema,
+            partition_columns,
+            current_time_ms()?,
+            properties,
+        )?;
+
+        Ok(Self { protocol, metadata })
+    }
+
+    /// Check if a table feature is allowed during CREATE TABLE.
+    pub(crate) fn is_delta_feature_allowed(feature: &TableFeature) -> bool {
+        Self::ALLOWED_DELTA_FEATURES.contains(feature)
+    }
+
+    /// Check if a property is allowed during CREATE TABLE.
+    ///
+    /// Returns `true` if the property is:
+    /// - Not a delta.* property (user properties like `myapp.version` are always allowed)
+    /// - A signal flag (`delta.feature.*`, `delta.minReaderVersion`, `delta.minWriterVersion`)
+    /// - An explicitly allowed delta property
+    pub(crate) fn is_delta_property_allowed(key: &str) -> bool {
+        // Non-delta properties are always allowed (user properties)
+        if !key.starts_with("delta.") {
+            return true;
+        }
+
+        // Signal flags are always allowed (they're processed and stripped)
+        if key.starts_with(SET_TABLE_FEATURE_SUPPORTED_PREFIX) {
+            return true;
+        }
+        if key == MIN_READER_VERSION_PROP || key == MIN_WRITER_VERSION_PROP {
+            return true;
+        }
+
+        // Check against explicitly allowed delta properties
+        Self::ALLOWED_DELTA_PROPERTIES.contains(&key)
+    }
+
+    /// Table features allowed during CREATE TABLE.
+    const ALLOWED_DELTA_FEATURES: [TableFeature; 0] = [
+        // Currently empty - no features allowed yet
+        // As transforms are added, their features go here:
+        // TableFeature::DeletionVectors,
+        // TableFeature::ColumnMapping,
+        // TableFeature::TimestampWithoutTimezone,
+    ];
+
+    /// Delta properties allowed during CREATE TABLE.
+    /// Signal flags (delta.feature.*, delta.minReaderVersion, delta.minWriterVersion)
+    /// are always allowed and handled separately.
+    const ALLOWED_DELTA_PROPERTIES: [&'static str; 0] = [
+        // Currently empty - no delta.* properties allowed yet
+        // As property transforms are added, their properties go here:
+        // "delta.enableDeletionVectors",
+        // "delta.columnMapping.mode",
+        // "delta.enableChangeDataFeed",
+    ];
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::{DataType, StructField};
+
+    /// Helper to construct a HashMap<String, String> from string slice pairs.
+    fn props<const N: usize>(pairs: [(&str, &str); N]) -> HashMap<String, String> {
+        pairs
+            .into_iter()
+            .map(|(k, v)| (k.into(), v.into()))
+            .collect()
+    }
+
+    /// Helper to create a simple test schema.
+    fn test_schema() -> StructType {
+        StructType::new_unchecked(vec![StructField::new("id", DataType::INTEGER, false)])
+    }
+
+    // =========================================================================
+    // try_from Tests - Initial Config Creation
+    // =========================================================================
+
+    #[test]
+    fn test_try_from_creates_bare_protocol() {
+        let properties = props([("myapp.version", "1.0"), ("custom.property", "value")]);
+        let config = TableProtocolMetadataConfig::new(test_schema(), vec![], properties).unwrap();
+
+        // Protocol should be bare v3/v7 with empty features
+        assert_eq!(config.protocol.min_reader_version(), 3);
+        assert_eq!(config.protocol.min_writer_version(), 7);
+        assert!(config.protocol.reader_features().unwrap().is_empty());
+        assert!(config.protocol.writer_features().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_try_from_passes_all_properties_through() {
+        let properties = props([
+            ("myapp.version", "1.0"),
+            ("delta.feature.deletionVectors", "supported"),
+            ("delta.minReaderVersion", "3"),
+            ("custom.property", "value"),
+        ]);
+        let config = TableProtocolMetadataConfig::new(test_schema(), vec![], properties).unwrap();
+
+        // ALL properties should be in metadata - no filtering in try_from
+        assert_eq!(config.metadata.configuration().len(), 4);
+        assert_eq!(
+            config.metadata.configuration().get("myapp.version"),
+            Some(&"1.0".to_string())
+        );
+        assert_eq!(
+            config
+                .metadata
+                .configuration()
+                .get("delta.feature.deletionVectors"),
+            Some(&"supported".to_string())
+        );
+        assert_eq!(
+            config
+                .metadata
+                .configuration()
+                .get("delta.minReaderVersion"),
+            Some(&"3".to_string())
+        );
+    }
+
+    #[test]
+    fn test_try_from_with_partition_columns() {
+        let schema = StructType::new_unchecked(vec![
+            StructField::new("id", DataType::INTEGER, false),
+            StructField::new("region", DataType::STRING, false),
+        ]);
+        let config =
+            TableProtocolMetadataConfig::new(schema, vec!["region".to_string()], HashMap::new())
+                .unwrap();
+
+        assert_eq!(config.metadata.partition_columns(), &["region".to_string()]);
+    }
+
+    // =========================================================================
+    // Pipeline Integration Tests (added after TransformationPipeline is available)
+    // =========================================================================
+}

--- a/kernel/src/table_protocol_metadata_config.rs
+++ b/kernel/src/table_protocol_metadata_config.rs
@@ -61,7 +61,6 @@ use crate::DeltaResult;
 /// let final_config = TransformationPipeline::apply_transforms(config, &props)?;
 /// ```
 #[derive(Debug)]
-#[allow(dead_code)] // Used by table_transformation module
 pub(crate) struct TableProtocolMetadataConfig {
     /// The protocol (starts as bare v3/v7, transforms add features).
     pub(crate) protocol: Protocol,
@@ -69,7 +68,6 @@ pub(crate) struct TableProtocolMetadataConfig {
     pub(crate) metadata: Metadata,
 }
 
-#[allow(dead_code)] // Used by table_transformation module
 impl TableProtocolMetadataConfig {
     /// Create base config for CREATE TABLE with only user properties.
     ///
@@ -158,8 +156,9 @@ impl TableProtocolMetadataConfig {
     }
 
     /// Table features allowed during CREATE TABLE.
-    const ALLOWED_DELTA_FEATURES: [TableFeature; 0] = [
-        // Currently empty - no features allowed yet
+    const ALLOWED_DELTA_FEATURES: [TableFeature; 1] = [
+        // DomainMetadata: required for clustering, can also be enabled explicitly
+        TableFeature::DomainMetadata,
         // As transforms are added, their features go here:
         // TableFeature::DeletionVectors,
         // TableFeature::ColumnMapping,
@@ -280,12 +279,12 @@ mod tests {
         )
         .unwrap();
 
-        let final_config = TransformationPipeline::apply_transforms(config, &properties).unwrap();
+        let output = TransformationPipeline::apply_transforms(config, &properties).unwrap();
 
         // Protocol still bare, properties still there
-        assert!(final_config.protocol.writer_features().unwrap().is_empty());
+        assert!(output.config.protocol.writer_features().unwrap().is_empty());
         assert_eq!(
-            final_config.metadata.configuration().get("myapp.version"),
+            output.config.metadata.configuration().get("myapp.version"),
             Some(&"1.0".to_string())
         );
     }

--- a/kernel/src/table_protocol_metadata_config.rs
+++ b/kernel/src/table_protocol_metadata_config.rs
@@ -244,6 +244,25 @@ mod tests {
     }
 
     // =========================================================================
-    // Pipeline Integration Tests (added after TransformationPipeline is available)
+    // Pipeline Integration Tests
     // =========================================================================
+
+    #[test]
+    fn test_apply_transforms_with_no_signals() {
+        use crate::table_transformation::TransformationPipeline;
+
+        // With no signal flags, config passes through with empty features
+        let properties = props([("myapp.version", "1.0")]);
+        let config =
+            TableProtocolMetadataConfig::new(test_schema(), vec![], properties.clone()).unwrap();
+
+        let final_config = TransformationPipeline::apply_transforms(config, &properties).unwrap();
+
+        // Protocol still bare, properties still there
+        assert!(final_config.protocol.writer_features().unwrap().is_empty());
+        assert_eq!(
+            final_config.metadata.configuration().get("myapp.version"),
+            Some(&"1.0".to_string())
+        );
+    }
 }

--- a/kernel/src/table_transformation/mod.rs
+++ b/kernel/src/table_transformation/mod.rs
@@ -1,0 +1,115 @@
+//! Transform pipeline for table creation and modification.
+//!
+//! This module provides the infrastructure for applying transformations to
+//! [`TableProtocolMetadataConfig`] during table creation. Transforms can:
+//!
+//! - Add features to the protocol based on properties or schema
+//! - Validate and process delta.* properties
+//! - Strip signal flags from metadata
+//!
+//! See [`TransformationPipeline::apply_transforms`] for the main entry point.
+
+mod registry;
+mod transforms;
+
+use crate::DeltaResult;
+
+use crate::table_protocol_metadata_config::TableProtocolMetadataConfig;
+
+// Re-export for use by the pipeline
+#[allow(unused_imports)]
+pub(crate) use registry::TransformContext;
+#[allow(unused_imports)]
+pub(crate) use registry::TRANSFORM_REGISTRY;
+
+// ============================================================================
+// Transform Types
+// ============================================================================
+
+/// Canonical identifier for each transform type.
+///
+/// Used for:
+/// - Dependency declarations (compile-time safe)
+/// - Tracking completed transforms
+/// - Topological sort ordering
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[allow(dead_code)] // Used by TransformationPipeline
+pub(crate) enum TransformId {
+    /// Validates delta.* properties are allowed
+    DeltaPropertyValidation,
+    /// Sets protocol version from properties or defaults
+    ProtocolVersion,
+    /// Processes delta.feature.X=supported signals
+    FeatureSignals,
+}
+
+/// Dependencies that must be satisfied before a transform can run.
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // Used by TransformationPipeline
+pub(crate) enum TransformDependency {
+    /// Hard ordering: This transform MUST be in the pipeline and run before me.
+    #[allow(dead_code)]
+    TransformRequired(TransformId),
+
+    /// Soft ordering: If this transform is in the pipeline, run it before me.
+    #[allow(dead_code)]
+    TransformCompletedIfPresent(TransformId),
+}
+
+// ============================================================================
+// Transform Trait
+// ============================================================================
+
+/// A transformation step that modifies protocol and/or metadata.
+///
+/// Transforms are registered in a central registry and applied by the
+/// [`TransformationPipeline`]. Each transform declares its dependencies
+/// and validation logic.
+#[allow(dead_code)] // Trait methods used by TransformationPipeline
+pub(crate) trait ProtocolMetadataTransform: std::fmt::Debug {
+    /// Canonical identifier for this transform type.
+    fn id(&self) -> TransformId;
+
+    /// Human-readable description of this transform.
+    fn name(&self) -> &'static str;
+
+    /// Dependencies that must be satisfied before this transform can run.
+    fn dependencies(&self) -> &'static [TransformDependency] {
+        &[]
+    }
+
+    /// Pre-validate the configuration before applying this transform.
+    fn validate_preconditions(
+        &self,
+        _config: &TableProtocolMetadataConfig,
+        _context: &TransformContext<'_>,
+    ) -> DeltaResult<()> {
+        Ok(())
+    }
+
+    /// Apply the transformation to protocol and metadata.
+    fn apply(
+        &self,
+        config: TableProtocolMetadataConfig,
+        context: &TransformContext<'_>,
+    ) -> DeltaResult<TableProtocolMetadataConfig>;
+
+    /// Validate the config AFTER this transform has been applied.
+    fn validate_postconditions(&self, _config: &TableProtocolMetadataConfig) -> DeltaResult<()> {
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Transformation Pipeline (stub - full implementation in follow-up commit)
+// ============================================================================
+
+/// Pipeline that applies transforms in dependency order.
+#[allow(dead_code)]
+pub(crate) struct TransformationPipeline;
+
+#[cfg(test)]
+mod tests {
+    #[allow(unused_imports)]
+    use super::*;
+}

--- a/kernel/src/table_transformation/mod.rs
+++ b/kernel/src/table_transformation/mod.rs
@@ -52,6 +52,7 @@ mod transforms;
 
 use std::collections::{HashMap, HashSet};
 
+use crate::actions::DomainMetadata;
 use crate::schema::variant_utils::validate_variant_type_feature_support;
 use crate::table_features::{
     column_mapping_mode, validate_schema_column_mapping, validate_timestamp_ntz_feature_support,
@@ -87,9 +88,10 @@ pub(crate) enum TransformId {
     DeltaPropertyValidation,
     /// Sets protocol version from properties or defaults
     ProtocolVersion,
+    /// Enables DomainMetadata writer feature
+    DomainMetadata,
     // Future transforms:
     // ColumnMapping,
-    // DomainMetadata,
     // Clustering,
     // DeletionVectors,
     // etc.
@@ -102,7 +104,7 @@ pub(crate) enum TransformDependency {
     ///
     /// Example: ClusteringTransform requires DomainMetadataTransform to have run,
     /// because Clustering needs to write domain metadata.
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Used when ClusteringTransform is added
     TransformRequired(TransformId),
 
     /// Soft ordering: If this transform is in the pipeline, run it before me.
@@ -111,8 +113,45 @@ pub(crate) enum TransformDependency {
     /// Example: If ColumnMappingTransform is in the pipeline, it should run before
     /// ClusteringTransform (to transform schema first), but Clustering doesn't
     /// require ColumnMapping to be enabled.
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Used when soft dependencies are needed
     TransformCompletedIfPresent(TransformId),
+}
+
+// ============================================================================
+// Transform Output
+// ============================================================================
+
+/// Output from a transform's `apply()` method.
+///
+/// Contains the updated config and any domain metadata actions produced by the transform.
+/// Domain metadata is collected by the pipeline and returned alongside the final config.
+#[derive(Debug)]
+pub(crate) struct TransformOutput {
+    /// The updated protocol/metadata configuration
+    pub config: TableProtocolMetadataConfig,
+    /// Domain metadata actions to be written to the commit (e.g., delta.clustering)
+    pub domain_metadata: Vec<DomainMetadata>,
+}
+
+impl TransformOutput {
+    /// Create output with just the config (no domain metadata)
+    pub(crate) fn new(config: TableProtocolMetadataConfig) -> Self {
+        Self {
+            config,
+            domain_metadata: vec![],
+        }
+    }
+
+    /// Create output with config and domain metadata
+    pub(crate) fn with_domain_metadata(
+        config: TableProtocolMetadataConfig,
+        domain_metadata: Vec<DomainMetadata>,
+    ) -> Self {
+        Self {
+            config,
+            domain_metadata,
+        }
+    }
 }
 
 // ============================================================================
@@ -147,9 +186,9 @@ pub(crate) enum TransformDependency {
 ///         "MyFeature: enables feature when delta.enableMyFeature is set"
 ///     }
 ///     
-///     fn apply(&self, mut config: TableProtocolMetadataConfig) -> DeltaResult<TableProtocolMetadataConfig> {
+///     fn apply(&self, mut config: TableProtocolMetadataConfig) -> DeltaResult<TransformOutput> {
 ///         config.protocol = config.protocol.with_feature(TableFeature::MyFeature)?;
-///         Ok(config)
+///         Ok(TransformOutput::new(config))
 ///     }
 /// }
 /// ```
@@ -170,9 +209,9 @@ pub(crate) trait ProtocolMetadataTransform: std::fmt::Debug {
     fn name(&self) -> &'static str;
 
     /// Dependencies that must be satisfied before this transform can run.
-    /// Returns empty slice if no dependencies.
-    fn dependencies(&self) -> &'static [TransformDependency] {
-        &[]
+    /// Returns empty vec if no dependencies.
+    fn dependencies(&self) -> Vec<TransformDependency> {
+        vec![]
     }
 
     /// Pre-validate the configuration before applying this transform.
@@ -198,12 +237,14 @@ pub(crate) trait ProtocolMetadataTransform: std::fmt::Debug {
     }
 
     /// Apply the transformation to protocol and metadata.
-    /// May: add features, set properties, transform schema, add domain metadata.
+    ///
+    /// Returns a [`TransformOutput`] containing the updated config and any domain
+    /// metadata actions produced by this transform.
     fn apply(
         &self,
         config: TableProtocolMetadataConfig,
         context: &TransformContext<'_>,
-    ) -> DeltaResult<TableProtocolMetadataConfig>;
+    ) -> DeltaResult<TransformOutput>;
 
     /// Validate the config AFTER this transform has been applied.
     /// Called immediately after apply() succeeds.
@@ -224,13 +265,11 @@ pub(crate) trait ProtocolMetadataTransform: std::fmt::Debug {
 /// - Dependency validation
 /// - Sequential execution with validation
 /// - Final protocol/metadata compatibility validation
-#[allow(dead_code)] // Used by create_table transaction
 pub(crate) struct TransformationPipeline {
     transforms: Vec<Box<dyn ProtocolMetadataTransform>>,
     completed: HashSet<TransformId>,
 }
 
-#[allow(dead_code)] // Used by create_table transaction
 impl TransformationPipeline {
     /// Create a new pipeline with the given transforms.
     pub(crate) fn new(transforms: Vec<Box<dyn ProtocolMetadataTransform>>) -> Self {
@@ -251,19 +290,20 @@ impl TransformationPipeline {
     ///
     /// # Steps
     ///
-    /// 1. Get applicable transforms from registry based on properties and schema
+    /// 1. Get applicable transforms from registry based on properties
     /// 2. Topological sort by dependencies
     /// 3. Apply each transform (with validation)
     /// 4. Run final validation
+    ///
+    /// Returns a [`TransformOutput`] containing the final config and any domain metadata
+    /// collected from all transforms.
     pub(crate) fn apply_transforms(
         config: TableProtocolMetadataConfig,
         properties: &HashMap<String, String>,
-    ) -> DeltaResult<TableProtocolMetadataConfig> {
-        // Parse schema for registry to check schema-triggered transforms
-        let schema = config.metadata.parse_schema()?;
-
-        // Get transforms from registry using raw properties and schema
-        let transforms = TRANSFORM_REGISTRY.select_transforms_to_trigger(properties, &schema)?;
+    ) -> DeltaResult<TransformOutput> {
+        // Get transforms from registry using raw properties
+        // The registry auto-resolves dependencies (e.g., ClusteringTransform -> DomainMetadataTransform)
+        let transforms = TRANSFORM_REGISTRY.select_transforms_to_trigger(properties)?;
 
         // Create context for transforms
         let context = TransformContext::new(properties);
@@ -277,13 +317,19 @@ impl TransformationPipeline {
     ///
     /// Transforms are selected by the registry based on properties, so the pipeline
     /// simply executes them in dependency order without re-checking triggers.
+    ///
+    /// Returns a [`TransformOutput`] containing the final config and collected
+    /// domain metadata from all transforms.
     pub(crate) fn apply_all(
         &mut self,
         mut config: TableProtocolMetadataConfig,
         context: &TransformContext<'_>,
-    ) -> DeltaResult<TableProtocolMetadataConfig> {
+    ) -> DeltaResult<TransformOutput> {
         // 1. Topological sort
         let ordered_indices = self.order_transform_dependencies()?;
+
+        // Collect domain metadata from all transforms
+        let mut all_domain_metadata = Vec::new();
 
         // 2. Apply each transform
         for idx in ordered_indices {
@@ -293,13 +339,12 @@ impl TransformationPipeline {
             self.check_transform_dependencies(transform.as_ref())?;
 
             // Validate no conflicting configurations and feature requirements
-            // TODO: When per-feature transforms are implemented (e.g., ColumnMappingTransform,
-            // DomainMetadataTransform), their validate_preconditions() should check
-            // FeatureInfo.feature_requirements to ensure dependent features are enabled.
             transform.validate_preconditions(&config, context)?;
 
             // Apply
-            config = transform.apply(config, context)?;
+            let output = transform.apply(config, context)?;
+            config = output.config;
+            all_domain_metadata.extend(output.domain_metadata);
 
             // Post-apply validation
             transform.validate_postconditions(&config)?;
@@ -311,7 +356,10 @@ impl TransformationPipeline {
         // 3. Final validation
         self.validate_final(&config)?;
 
-        Ok(config)
+        Ok(TransformOutput::with_domain_metadata(
+            config,
+            all_domain_metadata,
+        ))
     }
 
     /// Performs a topological sort of transforms based on their dependencies.
@@ -380,7 +428,7 @@ impl TransformationPipeline {
 
         // Visit dependencies first
         for dep in self.transforms[idx].dependencies() {
-            let dep_id = match dep {
+            let dep_id = match &dep {
                 TransformDependency::TransformRequired(id) => id,
                 TransformDependency::TransformCompletedIfPresent(id) => id,
             };
@@ -418,7 +466,7 @@ impl TransformationPipeline {
         transform: &dyn ProtocolMetadataTransform,
     ) -> DeltaResult<()> {
         for dep in transform.dependencies() {
-            match dep {
+            match &dep {
                 TransformDependency::TransformRequired(id) => {
                     // Hard dependency: transform MUST be in pipeline and completed
                     if !self.completed.contains(id) {
@@ -510,8 +558,8 @@ mod tests {
         let result = transform.apply(config, &context).unwrap();
 
         // Default to v3/v7 for table features support
-        assert_eq!(result.protocol.min_reader_version(), 3);
-        assert_eq!(result.protocol.min_writer_version(), 7);
+        assert_eq!(result.config.protocol.min_reader_version(), 3);
+        assert_eq!(result.config.protocol.min_writer_version(), 7);
     }
 
     #[test]
@@ -533,8 +581,8 @@ mod tests {
         let transform = ProtocolVersionTransform;
         let result = transform.apply(config, &context).unwrap();
 
-        assert_eq!(result.protocol.min_reader_version(), 3);
-        assert_eq!(result.protocol.min_writer_version(), 7);
+        assert_eq!(result.config.protocol.min_reader_version(), 3);
+        assert_eq!(result.config.protocol.min_writer_version(), 7);
     }
 
     #[test]
@@ -612,15 +660,18 @@ mod tests {
 
         // Version signals should NOT be in metadata (filtered in new_base_for_create)
         assert!(!result
+            .config
             .metadata
             .configuration()
             .contains_key("delta.minReaderVersion"));
         assert!(!result
+            .config
             .metadata
             .configuration()
             .contains_key("delta.minWriterVersion"));
         // User property should remain
         assert!(result
+            .config
             .metadata
             .configuration()
             .contains_key("myapp.version"));
@@ -740,7 +791,7 @@ mod tests {
         let result = TransformationPipeline::apply_transforms(config, &properties);
 
         assert!(result.is_ok());
-        let final_config = result.unwrap();
-        assert!(final_config.protocol.writer_features().unwrap().is_empty());
+        let output = result.unwrap();
+        assert!(output.config.protocol.writer_features().unwrap().is_empty());
     }
 }

--- a/kernel/src/table_transformation/mod.rs
+++ b/kernel/src/table_transformation/mod.rs
@@ -7,19 +7,62 @@
 //! - Validate and process delta.* properties
 //! - Strip signal flags from metadata
 //!
-//! See [`TransformationPipeline::apply_transforms`] for the main entry point.
+//! # Architecture
+//!
+//! ```text
+//!  ┌──────────────────────────────────────────────────────────────┐
+//!  │                      Table Operations                        │
+//!  │  ┌──────────────┐  ┌──────────────┐  ┌───────────────────┐   │
+//!  │  │ CREATE TABLE │  │ALTER TABLE(*)│  │ REPLACE TABLE (*) │   │
+//!  │  └──────┬───────┘  └──────┬───────┘  └─────────┬─────────┘   │
+//!  │         │                 │                    │             │
+//!  │         └─────────────────┼────────────────────┘             │
+//!  │                           ▼                                  │
+//!  │             User Properties + Schema                         │
+//!  └──────────────────────────────────────────────────────────────┘
+//!                              │
+//!                              ▼
+//!                TransformRegistry.select_transforms()
+//!                              │
+//!                              ▼
+//!                ┌─────────────────────────────┐
+//!                │   TransformationPipeline    │
+//!                │  1. Topological sort        │
+//!                │  2. Apply each transform    │
+//!                │  3. Final validation        │
+//!                └─────────────────────────────┘
+//!                              │
+//!                              ▼
+//!                 Final Config (Protocol + Metadata)
+//!
+//! (*) Future operations - not yet implemented
+//! ```
+//!
+//! # Example
+//!
+//! ```ignore
+//! use delta_kernel::table_transformation::TransformationPipeline;
+//!
+//! let config = TableProtocolMetadataConfig::new(schema, vec![], props.clone())?;
+//! let final_config = TransformationPipeline::apply_transforms(config, &props)?;
+//! ```
 
 mod registry;
 mod transforms;
 
-use crate::DeltaResult;
+use std::collections::{HashMap, HashSet};
+
+use crate::schema::variant_utils::validate_variant_type_feature_support;
+use crate::table_features::{
+    column_mapping_mode, validate_schema_column_mapping, validate_timestamp_ntz_feature_support,
+};
+use crate::{DeltaResult, Error};
 
 use crate::table_protocol_metadata_config::TableProtocolMetadataConfig;
 
 // Re-export for use by the pipeline
 #[allow(unused_imports)]
 pub(crate) use registry::TransformContext;
-#[allow(unused_imports)]
 pub(crate) use registry::TRANSFORM_REGISTRY;
 
 // ============================================================================
@@ -32,26 +75,38 @@ pub(crate) use registry::TRANSFORM_REGISTRY;
 /// - Dependency declarations (compile-time safe)
 /// - Tracking completed transforms
 /// - Topological sort ordering
+///
+/// Each transform returns its ID via `ProtocolMetadataTransform::id()`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[allow(dead_code)] // Used by TransformationPipeline
 pub(crate) enum TransformId {
     /// Validates delta.* properties are allowed
     DeltaPropertyValidation,
     /// Sets protocol version from properties or defaults
     ProtocolVersion,
-    /// Processes delta.feature.X=supported signals
-    FeatureSignals,
+    // Future transforms:
+    // ColumnMapping,
+    // DomainMetadata,
+    // Clustering,
+    // DeletionVectors,
+    // etc.
 }
 
-/// Dependencies that must be satisfied before a transform can run.
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // Used by TransformationPipeline
 pub(crate) enum TransformDependency {
     /// Hard ordering: This transform MUST be in the pipeline and run before me.
+    /// If the transform is not in the pipeline, execution will fail.
+    ///
+    /// Example: ClusteringTransform requires DomainMetadataTransform to have run,
+    /// because Clustering needs to write domain metadata.
     #[allow(dead_code)]
     TransformRequired(TransformId),
 
     /// Soft ordering: If this transform is in the pipeline, run it before me.
+    /// If the transform is not in the pipeline, that's fine - no error.
+    ///
+    /// Example: If ColumnMappingTransform is in the pipeline, it should run before
+    /// ClusteringTransform (to transform schema first), but Clustering doesn't
+    /// require ColumnMapping to be enabled.
     #[allow(dead_code)]
     TransformCompletedIfPresent(TransformId),
 }
@@ -65,20 +120,71 @@ pub(crate) enum TransformDependency {
 /// Transforms are registered in a central registry and applied by the
 /// [`TransformationPipeline`]. Each transform declares its dependencies
 /// and validation logic.
-#[allow(dead_code)] // Trait methods used by TransformationPipeline
+///
+/// # Lifecycle
+///
+/// 1. Registry selects transforms based on properties
+/// 2. Pipeline sorts transforms by dependencies
+/// 3. `validate_preconditions()` checks for incompatible configurations
+/// 4. `apply()` performs the transformation
+/// 5. `validate_postconditions()` verifies the result
+///
+/// # Example
+///
+/// ```ignore
+/// struct MyFeatureTransform;
+///
+/// impl ProtocolMetadataTransform for MyFeatureTransform {
+///     fn id(&self) -> TransformId {
+///         TransformId::MyFeature
+///     }
+///
+///     fn name(&self) -> &'static str {
+///         "MyFeature: enables feature when delta.enableMyFeature is set"
+///     }
+///     
+///     fn apply(&self, mut config: TableProtocolMetadataConfig) -> DeltaResult<TableProtocolMetadataConfig> {
+///         config.protocol = config.protocol.with_feature(TableFeature::MyFeature)?;
+///         Ok(config)
+///     }
+/// }
+/// ```
 pub(crate) trait ProtocolMetadataTransform: std::fmt::Debug {
     /// Canonical identifier for this transform type.
+    ///
+    /// Used for:
+    /// - Dependency declarations (compile-time safe)
+    /// - Tracking completed transforms
+    /// - Topological sort ordering
     fn id(&self) -> TransformId;
 
     /// Human-readable description of this transform.
+    ///
+    /// Format: "TransformName: reason" (e.g., "ProtocolVersion: sets version from properties")
+    ///
+    /// Used for logging, debugging, and error messages.
     fn name(&self) -> &'static str;
 
     /// Dependencies that must be satisfied before this transform can run.
+    /// Returns empty slice if no dependencies.
     fn dependencies(&self) -> &'static [TransformDependency] {
         &[]
     }
 
     /// Pre-validate the configuration before applying this transform.
+    ///
+    /// Called BEFORE `apply()`. Return Err if the transform cannot be applied.
+    ///
+    /// Use this for checking:
+    /// - Incompatible property combinations (e.g., conflicting settings)
+    /// - Missing required companion properties
+    /// - Invalid configurations that span multiple properties
+    ///
+    /// # Examples
+    ///
+    /// - Clustering columns not included in `dataSkippingStatsColumns`
+    /// - Clustering enabled but `dataSkippingNumIndexedCols` set to 0
+    /// - Both partitioning and clustering set on the same columns
     fn validate_preconditions(
         &self,
         _config: &TableProtocolMetadataConfig,
@@ -88,6 +194,7 @@ pub(crate) trait ProtocolMetadataTransform: std::fmt::Debug {
     }
 
     /// Apply the transformation to protocol and metadata.
+    /// May: add features, set properties, transform schema, add domain metadata.
     fn apply(
         &self,
         config: TableProtocolMetadataConfig,
@@ -95,21 +202,288 @@ pub(crate) trait ProtocolMetadataTransform: std::fmt::Debug {
     ) -> DeltaResult<TableProtocolMetadataConfig>;
 
     /// Validate the config AFTER this transform has been applied.
+    /// Called immediately after apply() succeeds.
     fn validate_postconditions(&self, _config: &TableProtocolMetadataConfig) -> DeltaResult<()> {
         Ok(())
     }
 }
 
 // ============================================================================
-// Transformation Pipeline (stub - full implementation in follow-up commit)
+// Transformation Pipeline
 // ============================================================================
 
 /// Pipeline that applies transforms in dependency order.
-#[allow(dead_code)]
-pub(crate) struct TransformationPipeline;
+///
+/// Responsibilities:
+/// - Topological sort of transforms by dependencies
+/// - Trigger detection (which transforms should run)
+/// - Dependency validation
+/// - Sequential execution with validation
+/// - Final protocol/metadata compatibility validation
+#[allow(dead_code)] // Used by create_table transaction
+pub(crate) struct TransformationPipeline {
+    transforms: Vec<Box<dyn ProtocolMetadataTransform>>,
+    completed: HashSet<TransformId>,
+}
+
+#[allow(dead_code)] // Used by create_table transaction
+impl TransformationPipeline {
+    /// Create a new pipeline with the given transforms.
+    pub(crate) fn new(transforms: Vec<Box<dyn ProtocolMetadataTransform>>) -> Self {
+        Self {
+            transforms,
+            completed: HashSet::new(),
+        }
+    }
+
+    /// Main entry point: apply transforms to config based on properties and schema.
+    ///
+    /// This is called from the builder after creating initial config via `try_from`.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - Initial config from `TableProtocolMetadataConfig::new()`
+    /// * `properties` - Raw properties map (for transform lookup)
+    ///
+    /// # Steps
+    ///
+    /// 1. Get applicable transforms from registry based on properties and schema
+    /// 2. Topological sort by dependencies
+    /// 3. Apply each transform (with validation)
+    /// 4. Run final validation
+    pub(crate) fn apply_transforms(
+        config: TableProtocolMetadataConfig,
+        properties: &HashMap<String, String>,
+    ) -> DeltaResult<TableProtocolMetadataConfig> {
+        // Parse schema for registry to check schema-triggered transforms
+        let schema = config.metadata.parse_schema()?;
+
+        // Get transforms from registry using raw properties and schema
+        let transforms = TRANSFORM_REGISTRY.select_transforms_to_trigger(properties, &schema)?;
+
+        // Create context for transforms
+        let context = TransformContext::new(properties);
+
+        // Apply via pipeline
+        let mut pipeline = Self::new(transforms);
+        pipeline.apply_all(config, &context)
+    }
+
+    /// Apply all transforms to the config.
+    ///
+    /// Transforms are selected by the registry based on properties, so the pipeline
+    /// simply executes them in dependency order without re-checking triggers.
+    pub(crate) fn apply_all(
+        &mut self,
+        mut config: TableProtocolMetadataConfig,
+        context: &TransformContext<'_>,
+    ) -> DeltaResult<TableProtocolMetadataConfig> {
+        // 1. Topological sort
+        let ordered_indices = self.order_transform_dependencies()?;
+
+        // 2. Apply each transform
+        for idx in ordered_indices {
+            let transform = &self.transforms[idx];
+
+            // Check transform ordering dependencies are satisfied
+            self.check_transform_dependencies(transform.as_ref())?;
+
+            // Validate no conflicting configurations and feature requirements
+            // TODO: When per-feature transforms are implemented (e.g., ColumnMappingTransform,
+            // DomainMetadataTransform), their validate_preconditions() should check
+            // FeatureInfo.feature_requirements to ensure dependent features are enabled.
+            transform.validate_preconditions(&config, context)?;
+
+            // Apply
+            config = transform.apply(config, context)?;
+
+            // Post-apply validation
+            transform.validate_postconditions(&config)?;
+
+            // Mark completed
+            self.completed.insert(transform.id());
+        }
+
+        // 3. Final validation
+        self.validate_final(&config)?;
+
+        Ok(config)
+    }
+
+    /// Performs a topological sort of transforms based on their dependencies.
+    ///
+    /// Uses depth-first search (DFS) to produce an ordering where each transform
+    /// appears after all transforms it depends on. This ensures that when we execute
+    /// transforms in the returned order, all dependencies are satisfied.
+    ///
+    /// # Algorithm
+    /// 1. Build a lookup map from transform name -> index for O(1) dependency resolution
+    /// 2. For each transform, recursively visit its dependencies first (DFS)
+    /// 3. After visiting all dependencies, add the transform to the ordered list
+    /// 4. Track "in progress" nodes to detect circular dependencies
+    ///
+    /// # Returns
+    /// A vector of indices into `self.transforms` in the order they should execute.
+    ///
+    /// # Errors
+    /// - Circular dependency detected (transform A depends on B, B depends on A)
+    fn order_transform_dependencies(&self) -> DeltaResult<Vec<usize>> {
+        // Build name -> index lookup for O(1) dependency resolution
+        let id_to_idx: HashMap<TransformId, usize> = self
+            .transforms
+            .iter()
+            .enumerate()
+            .map(|(idx, t)| (t.id(), idx))
+            .collect();
+
+        let mut ordered = Vec::with_capacity(self.transforms.len());
+        let mut visited = HashSet::new();
+        let mut in_progress = HashSet::new();
+
+        for idx in 0..self.transforms.len() {
+            self.visit(
+                idx,
+                &id_to_idx,
+                &mut visited,
+                &mut in_progress,
+                &mut ordered,
+            )?;
+        }
+
+        Ok(ordered)
+    }
+
+    /// DFS helper for topological sort.
+    fn visit(
+        &self,
+        idx: usize,
+        id_to_idx: &HashMap<TransformId, usize>,
+        visited: &mut HashSet<usize>,
+        in_progress: &mut HashSet<usize>,
+        ordered: &mut Vec<usize>,
+    ) -> DeltaResult<()> {
+        if visited.contains(&idx) {
+            return Ok(());
+        }
+        if in_progress.contains(&idx) {
+            return Err(Error::generic(format!(
+                "Circular dependency detected involving transform '{}'",
+                self.transforms[idx].name()
+            )));
+        }
+
+        in_progress.insert(idx);
+
+        // Visit dependencies first
+        for dep in self.transforms[idx].dependencies() {
+            let dep_id = match dep {
+                TransformDependency::TransformRequired(id) => id,
+                TransformDependency::TransformCompletedIfPresent(id) => id,
+            };
+
+            if let Some(&dep_idx) = id_to_idx.get(dep_id) {
+                self.visit(dep_idx, id_to_idx, visited, in_progress, ordered)?;
+            }
+        }
+
+        in_progress.remove(&idx);
+        visited.insert(idx);
+        ordered.push(idx);
+
+        Ok(())
+    }
+
+    /// Validates that all dependencies declared by a transform have been satisfied.
+    ///
+    /// Called before applying each transform to ensure execution order is correct.
+    ///
+    /// Two types of dependencies:
+    /// - `TransformRequired(name)`: Hard dependency - the named transform MUST have run.
+    ///   Fails if the transform is not in the pipeline or hasn't completed.
+    /// - `TransformCompletedIfPresent(name)`: Soft dependency - if the named transform
+    ///   is in the pipeline, it must have run. No error if it's not in the pipeline.
+    ///
+    /// # Note on Feature Requirements
+    /// Feature-level requirements (e.g., "Clustering requires DomainMetadata feature")
+    /// should be validated in `validate_preconditions()` using `FeatureInfo.feature_requirements`.
+    /// TODO: Implement this when per-feature transforms (ColumnMapping, DomainMetadata, etc.)
+    /// are added. By that point, the topological sort has ensured dependent transforms have
+    /// already run.
+    fn check_transform_dependencies(
+        &self,
+        transform: &dyn ProtocolMetadataTransform,
+    ) -> DeltaResult<()> {
+        for dep in transform.dependencies() {
+            match dep {
+                TransformDependency::TransformRequired(id) => {
+                    // Hard dependency: transform MUST be in pipeline and completed
+                    if !self.completed.contains(id) {
+                        return Err(Error::generic(format!(
+                            "Transform '{}' requires {:?} to complete first, but it is not in the pipeline",
+                            transform.name(),
+                            id
+                        )));
+                    }
+                }
+                TransformDependency::TransformCompletedIfPresent(id) => {
+                    // Soft dependency: if the transform is in the pipeline, it must have completed.
+                    // If it's not in the pipeline, that's fine (soft = optional).
+                    let is_in_pipeline = self.transforms.iter().any(|t| t.id() == *id);
+                    if is_in_pipeline && !self.completed.contains(id) {
+                        // Transform is in pipeline but hasn't completed - this is a bug
+                        // in the topological sort or execution order
+                        return Err(Error::generic(format!(
+                            "Transform '{}' should run after {:?}, but {:?} has not completed yet",
+                            transform.name(),
+                            id,
+                            id
+                        )));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Final validation of protocol + metadata compatibility.
+    fn validate_final(&self, config: &TableProtocolMetadataConfig) -> DeltaResult<()> {
+        // Validate protocol + metadata compatibility
+        let schema = config.metadata.parse_schema()?;
+        let table_properties = config.metadata.parse_table_properties();
+        let col_mapping_mode = column_mapping_mode(&config.protocol, &table_properties);
+
+        validate_schema_column_mapping(&schema, col_mapping_mode)?;
+        validate_timestamp_ntz_feature_support(&schema, &config.protocol)?;
+        validate_variant_type_feature_support(&schema, &config.protocol)?;
+
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
 
 #[cfg(test)]
 mod tests {
     #[allow(unused_imports)]
     use super::*;
+    use crate::schema::{DataType, StructField, StructType};
+
+    /// Helper to construct a HashMap<String, String> from string slice pairs.
+    #[allow(dead_code)]
+    fn props<const N: usize>(pairs: [(&str, &str); N]) -> HashMap<String, String> {
+        pairs
+            .into_iter()
+            .map(|(k, v)| (k.into(), v.into()))
+            .collect()
+    }
+
+    /// Helper to create a simple test schema.
+    #[allow(dead_code)]
+    fn test_schema() -> StructType {
+        StructType::new_unchecked(vec![StructField::new("id", DataType::INTEGER, false)])
+    }
 }
+
+// Note: Transform-specific tests are added with the implementations in a follow-up commit.

--- a/kernel/src/table_transformation/registry.rs
+++ b/kernel/src/table_transformation/registry.rs
@@ -1,14 +1,32 @@
 //! Transform registry for selecting applicable transforms.
 //!
-//! The [`TransformRegistry`] manages transform registrations. Each registration
-//! associates a trigger condition with a factory function to create the transform.
+//! The [`TransformRegistry`] is a singleton that manages transform registrations.
+//! Each registration associates a [`TableFeature`] (optional) with a trigger condition
+//! and a factory function to create the transform.
 //!
-//! See [`TRANSFORM_REGISTRY`] for the singleton instance.
+//! # Design
+//!
+//! Transforms are registered declaratively with trigger conditions:
+//!
+//! ```ignore
+//! registry.register_feature(
+//!     TableFeature::DeletionVectors,
+//!     TransformTrigger::Property("delta.enableDeletionVectors"),
+//!     || Box::new(DeletionVectorsTransform),
+//! );
+//! ```
+//!
+//! The `select_transforms()` method automatically selects transforms whose triggers match.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
 
-use super::ProtocolMetadataTransform;
+use crate::schema::{DataType, StructType};
+use crate::table_features::TableFeature;
+use crate::DeltaResult;
+
+use super::transforms::{DeltaPropertyValidationTransform, ProtocolVersionTransform};
+use super::{ProtocolMetadataTransform, TransformId};
 
 // ============================================================================
 // Transform Context
@@ -34,28 +52,383 @@ impl<'a> TransformContext<'a> {
 }
 
 /// Factory function to create a transform instance.
-#[allow(dead_code)]
 type TransformFactory = fn() -> Box<dyn ProtocolMetadataTransform>;
 
 // ============================================================================
-// Registry (stub - full implementation in follow-up commit)
+// Trigger Types
 // ============================================================================
 
-/// The global transform registry singleton.
+/// How to check schema for type presence.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub(crate) enum SchemaTypeCheck {
+    /// Schema contains this data type at any level (including nested).
+    ContainsType(DataType),
+}
+
+/// Which data layout triggers the transform.
 ///
-/// Contains all registered transforms that can be triggered during table creation.
+/// Used when DataLayout support is added to trigger transforms based on
+/// whether the table is partitioned or clustered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(crate) enum DataLayoutKind {
+    Partitioned,
+    Clustered,
+}
+
+/// Trigger condition for when a transform should be selected.
+///
+/// The registry checks each registration's trigger against the current context
+/// (properties, schema, data layout) to determine which transforms to include.
+#[derive(Debug, Clone)]
+pub(crate) enum TransformTrigger {
+    /// Always runs (for core transforms like validation, protocol version).
+    Always,
+
+    /// Triggered by `delta.feature.X=supported` signal.
+    ///
+    /// Example: `TransformTrigger::FeatureSignal(TableFeature::DeletionVectors)`
+    /// triggers when `delta.feature.deletionVectors=supported` is present.
+    #[allow(dead_code)]
+    FeatureSignal(TableFeature),
+
+    /// Triggered by presence of a property.
+    ///
+    /// Example: `TransformTrigger::Property("delta.columnMapping.mode")`
+    /// triggers when the property key exists in the properties map.
+    #[allow(dead_code)]
+    Property(&'static str),
+
+    /// Triggered by schema containing a specific type.
+    ///
+    /// Example: `TransformTrigger::SchemaType(SchemaTypeCheck::ContainsType(DataType::TIMESTAMP_NTZ))`
+    /// triggers when the schema contains a TIMESTAMP_NTZ field.
+    #[allow(dead_code)]
+    SchemaType(SchemaTypeCheck),
+
+    /// Triggered by data layout (partitioned or clustered).
+    ///
+    /// Example: `TransformTrigger::DataLayout(DataLayoutKind::Clustered)`
+    /// triggers when the table uses clustered data layout.
+    #[allow(dead_code)]
+    DataLayout(DataLayoutKind),
+}
+
+// ============================================================================
+// Registration
+// ============================================================================
+
+/// Registration entry for a transform.
+///
+/// Associates an optional feature with a trigger condition and factory.
+#[allow(dead_code)]
+pub(crate) struct FeatureTransformRegistration {
+    /// The table feature this transform handles (None for core transforms).
+    pub feature: Option<TableFeature>,
+    /// When to trigger this transform.
+    pub trigger: TransformTrigger,
+    /// Factory to create the transform instance.
+    pub factory: TransformFactory,
+}
+
+// ============================================================================
+// Registry
+// ============================================================================
+
+/// Central registry of all available transforms.
+///
+/// Transforms are selected based on trigger conditions matching the current context.
+/// The registry is a singleton - all builders share the same registry.
 #[allow(dead_code)] // Used by TransformationPipeline
-pub(crate) static TRANSFORM_REGISTRY: LazyLock<TransformRegistry> =
-    LazyLock::new(TransformRegistry::new);
+pub(crate) struct TransformRegistry {
+    /// All registered transforms.
+    registrations: Vec<FeatureTransformRegistration>,
+}
 
-/// Registry for transform registrations.
-#[derive(Debug)]
-#[allow(dead_code)] // Constructed by LazyLock
-pub(crate) struct TransformRegistry;
-
-#[allow(dead_code)] // Methods used by pipeline
+#[allow(dead_code)] // Methods used by TransformationPipeline
 impl TransformRegistry {
     fn new() -> Self {
-        Self
+        Self {
+            registrations: Vec::new(),
+        }
+    }
+
+    /// Register a feature-associated transform.
+    fn register_feature(
+        &mut self,
+        feature: TableFeature,
+        trigger: TransformTrigger,
+        factory: TransformFactory,
+    ) {
+        self.registrations.push(FeatureTransformRegistration {
+            feature: Some(feature),
+            trigger,
+            factory,
+        });
+    }
+
+    /// Register an operation transform (not tied to a specific feature).
+    ///
+    /// These are transforms triggered by the operation (e.g., validation, protocol version)
+    /// rather than by enabling a specific table feature.
+    fn register_operation_transform(
+        &mut self,
+        trigger: TransformTrigger,
+        factory: TransformFactory,
+    ) {
+        self.registrations.push(FeatureTransformRegistration {
+            feature: None,
+            trigger,
+            factory,
+        });
+    }
+
+    /// Select all transforms to trigger based on the current context.
+    ///
+    /// # Arguments
+    ///
+    /// * `properties` - Raw properties map (for property and signal triggers)
+    /// * `schema` - Table schema (for schema type triggers)
+    ///
+    /// # Returns
+    ///
+    /// A vector of transform instances. The caller (pipeline) is responsible for
+    /// ordering them by dependencies via topological sort.
+    pub(crate) fn select_transforms_to_trigger(
+        &self,
+        properties: &HashMap<String, String>,
+        schema: &StructType,
+    ) -> DeltaResult<Vec<Box<dyn ProtocolMetadataTransform>>> {
+        let mut transforms: Vec<Box<dyn ProtocolMetadataTransform>> = Vec::new();
+        let mut included_ids: HashSet<TransformId> = HashSet::new();
+
+        for registration in &self.registrations {
+            let should_include = match &registration.trigger {
+                // Core transforms that always run
+                TransformTrigger::Always => true,
+
+                // Feature signal: delta.feature.X=supported
+                TransformTrigger::FeatureSignal(feature) => {
+                    let key = format!("delta.feature.{}", feature.as_ref());
+                    properties
+                        .get(&key)
+                        .map(|v| v == "supported")
+                        .unwrap_or(false)
+                }
+
+                // Property presence
+                TransformTrigger::Property(prop_name) => properties.contains_key(*prop_name),
+
+                // Schema type detection
+                TransformTrigger::SchemaType(check) => match check {
+                    SchemaTypeCheck::ContainsType(dtype) => schema_contains_type(schema, dtype),
+                },
+
+                // Data layout (placeholder - always false until DataLayout is added)
+                TransformTrigger::DataLayout(_kind) => {
+                    // TODO: When DataLayout is added, check:
+                    // match (kind, data_layout) {
+                    //     (DataLayoutKind::Partitioned, DataLayout::Partitioned { .. }) => true,
+                    //     (DataLayoutKind::Clustered, DataLayout::Clustered { .. }) => true,
+                    //     _ => false,
+                    // }
+                    false
+                }
+            };
+
+            if should_include {
+                // Create the transform and check for duplicates
+                let transform = (registration.factory)();
+                let id = transform.id();
+
+                // Deduplicate: same transform may be triggered multiple ways
+                if !included_ids.contains(&id) {
+                    included_ids.insert(id);
+                    transforms.push(transform);
+                }
+            }
+        }
+
+        Ok(transforms)
+    }
+}
+
+/// Recursively check if schema contains a data type.
+#[allow(dead_code)] // Used by select_transforms_to_trigger
+fn schema_contains_type(schema: &StructType, target: &DataType) -> bool {
+    for field in schema.fields() {
+        if field.data_type() == target {
+            return true;
+        }
+        // Recurse into nested types
+        match field.data_type() {
+            DataType::Struct(inner) => {
+                if schema_contains_type(inner, target) {
+                    return true;
+                }
+            }
+            DataType::Array(arr) => {
+                if arr.element_type() == target {
+                    return true;
+                }
+                // Check nested struct in array
+                if let DataType::Struct(inner) = arr.element_type() {
+                    if schema_contains_type(inner, target) {
+                        return true;
+                    }
+                }
+            }
+            DataType::Map(map) => {
+                if map.key_type() == target || map.value_type() == target {
+                    return true;
+                }
+                // Check nested structs in map
+                if let DataType::Struct(inner) = map.key_type() {
+                    if schema_contains_type(inner, target) {
+                        return true;
+                    }
+                }
+                if let DataType::Struct(inner) = map.value_type() {
+                    if schema_contains_type(inner, target) {
+                        return true;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+// ============================================================================
+// Global Singleton
+// ============================================================================
+
+/// Global singleton registry initialized with all supported transforms.
+///
+/// # Future: Composable Registries for Different Operations
+///
+/// For operations like ALTER TABLE that share some transforms with CREATE TABLE,
+/// consider a composable approach:
+///
+/// ```ignore
+/// fn base_registry() -> TransformRegistry {
+///     // Shared transforms (validation, protocol version, etc.)
+/// }
+///
+/// fn create_table_registry() -> TransformRegistry {
+///     let mut registry = base_registry();
+///     registry.register_feature(...);  // CREATE-specific transforms
+///     registry
+/// }
+///
+/// fn alter_table_registry() -> TransformRegistry {
+///     let mut registry = base_registry();
+///     registry.register_feature(...);  // ALTER-specific transforms
+///     registry
+/// }
+/// ```
+#[allow(dead_code)] // Used by TransformationPipeline
+pub(crate) static TRANSFORM_REGISTRY: LazyLock<TransformRegistry> = LazyLock::new(|| {
+    let mut registry = TransformRegistry::new();
+
+    // =========================================================================
+    // Operation transforms (triggered by the operation, not specific features)
+    // =========================================================================
+
+    // First: validate all delta.* properties are allowed
+    registry.register_operation_transform(TransformTrigger::Always, || {
+        Box::new(DeltaPropertyValidationTransform)
+    });
+
+    // Set protocol version from properties or defaults
+    registry.register_operation_transform(TransformTrigger::Always, || {
+        Box::new(ProtocolVersionTransform)
+    });
+
+    // =========================================================================
+    // Future: Feature-specific transforms
+    // =========================================================================
+    //
+    // When implementing new features, register them here. Examples:
+    //
+    // registry.register_feature(
+    //     TableFeature::DeletionVectors,
+    //     TransformTrigger::Property("delta.enableDeletionVectors"),
+    //     || Box::new(DeletionVectorsTransform),
+    // );
+    //
+    // registry.register_feature(
+    //     TableFeature::ColumnMapping,
+    //     TransformTrigger::Property("delta.columnMapping.mode"),
+    //     || Box::new(ColumnMappingTransform),
+    // );
+    //
+    // registry.register_feature(
+    //     TableFeature::TimestampWithoutTimezone,
+    //     TransformTrigger::SchemaType(SchemaTypeCheck::ContainsType(DataType::TIMESTAMP_NTZ)),
+    //     || Box::new(TimestampNtzTransform),
+    // );
+
+    registry
+});
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::{DataType, StructField, StructType};
+
+    fn test_schema() -> StructType {
+        StructType::new_unchecked(vec![StructField::new("id", DataType::INTEGER, false)])
+    }
+
+    #[test]
+    fn test_always_triggers_select_core_transforms() {
+        let props = HashMap::new();
+        let schema = test_schema();
+
+        let transforms = TRANSFORM_REGISTRY
+            .select_transforms_to_trigger(&props, &schema)
+            .unwrap();
+
+        // Should have validation and protocol version transforms
+        assert_eq!(transforms.len(), 2);
+        assert!(transforms
+            .iter()
+            .any(|t| t.id() == TransformId::DeltaPropertyValidation));
+        assert!(transforms
+            .iter()
+            .any(|t| t.id() == TransformId::ProtocolVersion));
+    }
+
+    #[test]
+    fn test_schema_contains_type_simple() {
+        let schema = StructType::new_unchecked(vec![
+            StructField::new("id", DataType::INTEGER, false),
+            StructField::new("name", DataType::STRING, true),
+        ]);
+
+        assert!(schema_contains_type(&schema, &DataType::INTEGER));
+        assert!(schema_contains_type(&schema, &DataType::STRING));
+        assert!(!schema_contains_type(&schema, &DataType::BOOLEAN));
+    }
+
+    #[test]
+    fn test_schema_contains_type_nested() {
+        let inner =
+            StructType::new_unchecked(vec![StructField::new("value", DataType::DOUBLE, false)]);
+        let schema = StructType::new_unchecked(vec![
+            StructField::new("id", DataType::INTEGER, false),
+            StructField::new("nested", DataType::Struct(Box::new(inner)), true),
+        ]);
+
+        assert!(schema_contains_type(&schema, &DataType::INTEGER));
+        assert!(schema_contains_type(&schema, &DataType::DOUBLE));
+        assert!(!schema_contains_type(&schema, &DataType::STRING));
     }
 }

--- a/kernel/src/table_transformation/registry.rs
+++ b/kernel/src/table_transformation/registry.rs
@@ -1,0 +1,61 @@
+//! Transform registry for selecting applicable transforms.
+//!
+//! The [`TransformRegistry`] manages transform registrations. Each registration
+//! associates a trigger condition with a factory function to create the transform.
+//!
+//! See [`TRANSFORM_REGISTRY`] for the singleton instance.
+
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+use super::ProtocolMetadataTransform;
+
+// ============================================================================
+// Transform Context
+// ============================================================================
+
+/// Runtime context passed to transforms.
+///
+/// Contains all user-provided properties including delta.* signals.
+/// Transforms should read properties from this context rather than from
+/// the metadata configuration.
+#[derive(Debug)]
+#[allow(dead_code)] // Fields accessed by transforms
+pub(crate) struct TransformContext<'a> {
+    /// Raw properties from the user (includes delta.* signals)
+    pub properties: &'a HashMap<String, String>,
+}
+
+impl<'a> TransformContext<'a> {
+    #[allow(dead_code)] // Used by TransformationPipeline in later commits
+    pub(crate) fn new(properties: &'a HashMap<String, String>) -> Self {
+        Self { properties }
+    }
+}
+
+/// Factory function to create a transform instance.
+#[allow(dead_code)]
+type TransformFactory = fn() -> Box<dyn ProtocolMetadataTransform>;
+
+// ============================================================================
+// Registry (stub - full implementation in follow-up commit)
+// ============================================================================
+
+/// The global transform registry singleton.
+///
+/// Contains all registered transforms that can be triggered during table creation.
+#[allow(dead_code)] // Used by TransformationPipeline
+pub(crate) static TRANSFORM_REGISTRY: LazyLock<TransformRegistry> =
+    LazyLock::new(TransformRegistry::new);
+
+/// Registry for transform registrations.
+#[derive(Debug)]
+#[allow(dead_code)] // Constructed by LazyLock
+pub(crate) struct TransformRegistry;
+
+#[allow(dead_code)] // Methods used by pipeline
+impl TransformRegistry {
+    fn new() -> Self {
+        Self
+    }
+}

--- a/kernel/src/table_transformation/transforms.rs
+++ b/kernel/src/table_transformation/transforms.rs
@@ -4,26 +4,33 @@
 //!
 //! - [`ProtocolVersionTransform`]: Sets protocol version from properties or defaults
 //! - [`DeltaPropertyValidationTransform`]: Validates `delta.*` properties are allowed
-//!
-//! NOTE: This is the stub implementation. Full implementations are in a follow-up commit.
 
-use crate::DeltaResult;
+use crate::table_features::{TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION};
+use crate::table_properties::{MIN_READER_VERSION_PROP, MIN_WRITER_VERSION_PROP};
+use crate::{DeltaResult, Error};
 
 use crate::table_protocol_metadata_config::TableProtocolMetadataConfig;
 
 use super::{ProtocolMetadataTransform, TransformContext, TransformId};
 
 // ============================================================================
-// ProtocolVersionTransform (Stub)
+// ProtocolVersionTransform
 // ============================================================================
 
 /// Determines and sets the protocol version from user properties.
 ///
 /// This transform:
-/// 1. Parses version properties (defaults to 3/7 if not specified)
-/// 2. Validates they are supported (only 3/7 currently)
-/// 3. Sets the protocol version
-/// 4. Strips the version properties from metadata (transient signals)
+/// 1. Reads version properties from TransformContext (raw user properties)
+/// 2. Parses version properties (defaults to 3/7 if not specified)
+/// 3. Validates they are supported (only 3/7 currently)
+/// 4. Sets the protocol version
+///
+/// Note: Version properties are NOT stored in metadata - they are filtered out
+/// in `TableProtocolMetadataConfig::new_base_for_create()`. This transform reads
+/// them from `TransformContext.properties` which contains all raw user properties.
+///
+/// The transform always runs, whether or not version properties are specified,
+/// because protocol needs a version set. If no properties, defaults to 3/7.
 #[derive(Debug)]
 #[allow(dead_code)] // Constructed by registry
 pub(crate) struct ProtocolVersionTransform;
@@ -39,22 +46,84 @@ impl ProtocolMetadataTransform for ProtocolVersionTransform {
 
     fn apply(
         &self,
-        config: TableProtocolMetadataConfig,
-        _context: &TransformContext<'_>,
+        mut config: TableProtocolMetadataConfig,
+        context: &TransformContext<'_>,
     ) -> DeltaResult<TableProtocolMetadataConfig> {
-        // Stub: pass through unchanged (version already set in Protocol::new())
+        // Read version properties from context (raw user properties)
+        // not from config.metadata which only has user properties (delta.* filtered)
+
+        // Parse reader version (default to 3 for table features support)
+        let reader_version = context
+            .properties
+            .get(MIN_READER_VERSION_PROP)
+            .map(|v| {
+                v.parse::<u8>().map_err(|_| {
+                    Error::generic(format!(
+                        "Invalid value '{}' for {}. Must be an integer.",
+                        v, MIN_READER_VERSION_PROP
+                    ))
+                })
+            })
+            .transpose()?
+            .unwrap_or(TABLE_FEATURES_MIN_READER_VERSION as u8);
+
+        // Parse writer version (default to 7 for table features support)
+        let writer_version = context
+            .properties
+            .get(MIN_WRITER_VERSION_PROP)
+            .map(|v| {
+                v.parse::<u8>().map_err(|_| {
+                    Error::generic(format!(
+                        "Invalid value '{}' for {}. Must be an integer.",
+                        v, MIN_WRITER_VERSION_PROP
+                    ))
+                })
+            })
+            .transpose()?
+            .unwrap_or(TABLE_FEATURES_MIN_WRITER_VERSION as u8);
+
+        // Validate versions: currently only support 3/7 (table features protocol)
+        // Supporting older protocol versions would require different handling for features
+        if reader_version != TABLE_FEATURES_MIN_READER_VERSION as u8 {
+            return Err(Error::generic(format!(
+                "Invalid value '{}' for {}. Only '{}' is supported for CREATE TABLE.",
+                reader_version, MIN_READER_VERSION_PROP, TABLE_FEATURES_MIN_READER_VERSION
+            )));
+        }
+        if writer_version != TABLE_FEATURES_MIN_WRITER_VERSION as u8 {
+            return Err(Error::generic(format!(
+                "Invalid value '{}' for {}. Only '{}' is supported for CREATE TABLE.",
+                writer_version, MIN_WRITER_VERSION_PROP, TABLE_FEATURES_MIN_WRITER_VERSION
+            )));
+        }
+
+        // Update the protocol with the validated versions
+        config.protocol = config
+            .protocol
+            .with_versions(reader_version.into(), writer_version.into())?;
+
+        // No need to strip version properties from metadata - they were already
+        // filtered out in new_base_for_create()
+
         Ok(config)
     }
 }
 
 // ============================================================================
-// DeltaPropertyValidationTransform (Stub)
+// DeltaPropertyValidationTransform
 // ============================================================================
 
 /// Validates that all delta.* properties are supported.
 ///
 /// This transform runs first to reject unsupported properties early, before
-/// any other transforms process the configuration.
+/// any other transforms process the configuration. It ensures users don't
+/// accidentally think a property is being used when it's actually ignored.
+///
+/// Allowed property patterns:
+/// - `delta.feature.*` - Feature signal flags
+/// - `delta.minReaderVersion` - Protocol version (processed by ProtocolVersionTransform)
+/// - `delta.minWriterVersion` - Protocol version (processed by ProtocolVersionTransform)
+/// - Non-delta properties (e.g., `myapp.version`) - passed through unmodified
 #[derive(Debug)]
 #[allow(dead_code)] // Constructed by registry
 pub(crate) struct DeltaPropertyValidationTransform;
@@ -68,12 +137,64 @@ impl ProtocolMetadataTransform for DeltaPropertyValidationTransform {
         "DeltaPropertyValidation: validates delta.* properties"
     }
 
+    fn validate_preconditions(
+        &self,
+        _config: &TableProtocolMetadataConfig,
+        context: &TransformContext<'_>,
+    ) -> DeltaResult<()> {
+        use crate::table_features::{
+            TableFeature, SET_TABLE_FEATURE_SUPPORTED_PREFIX, SET_TABLE_FEATURE_SUPPORTED_VALUE,
+        };
+
+        // Validate against raw user properties from context
+        // (config.metadata only has user properties with delta.* filtered out)
+        for (key, value) in context.properties.iter() {
+            // Check feature signals specially for better error messages
+            if let Some(feature_name) = key.strip_prefix(SET_TABLE_FEATURE_SUPPORTED_PREFIX) {
+                // First validate the value is "supported"
+                if value != SET_TABLE_FEATURE_SUPPORTED_VALUE {
+                    return Err(Error::generic(format!(
+                        "Invalid value '{}' for {}. Only '{}' is allowed.",
+                        value, key, SET_TABLE_FEATURE_SUPPORTED_VALUE
+                    )));
+                }
+
+                // Then check if the feature is allowed
+                if let Ok(feature) = feature_name.parse::<TableFeature>() {
+                    if !TableProtocolMetadataConfig::is_delta_feature_allowed(&feature) {
+                        return Err(Error::generic(format!(
+                            "Enabling feature '{}' is not supported during CREATE TABLE",
+                            feature_name
+                        )));
+                    }
+                } else {
+                    // Unknown feature name
+                    return Err(Error::generic(format!(
+                        "Unknown feature '{}' in property '{}'",
+                        feature_name, key
+                    )));
+                }
+                continue;
+            }
+
+            // For other properties, use the general validation
+            if !TableProtocolMetadataConfig::is_delta_property_allowed(key) {
+                return Err(Error::generic(format!(
+                    "Property '{}' is not supported during CREATE TABLE. \
+                     Only delta.feature.* signals and delta.minReaderVersion/delta.minWriterVersion are allowed.",
+                    key
+                )));
+            }
+        }
+        Ok(())
+    }
+
     fn apply(
         &self,
         config: TableProtocolMetadataConfig,
         _context: &TransformContext<'_>,
     ) -> DeltaResult<TableProtocolMetadataConfig> {
-        // Stub: pass through unchanged
+        // Validation-only transform - no modifications
         Ok(config)
     }
 }

--- a/kernel/src/table_transformation/transforms.rs
+++ b/kernel/src/table_transformation/transforms.rs
@@ -1,0 +1,99 @@
+//! Built-in transforms for table creation.
+//!
+//! This module contains the standard transforms that are applied during table creation:
+//!
+//! - [`FeatureSignalTransform`]: Processes `delta.feature.X=supported` signals
+//! - [`ProtocolVersionTransform`]: Sets protocol version from properties or defaults
+//! - [`DeltaPropertyValidationTransform`]: Validates `delta.*` properties are allowed
+//!
+//! NOTE: This is the stub implementation. Full implementations are in a follow-up commit.
+
+use crate::DeltaResult;
+
+use crate::table_protocol_metadata_config::TableProtocolMetadataConfig;
+
+use super::{ProtocolMetadataTransform, TransformContext, TransformId};
+
+// ============================================================================
+// FeatureSignalTransform (Stub)
+// ============================================================================
+
+/// Processes delta.feature.X=supported signals.
+#[derive(Debug)]
+#[allow(dead_code)] // Constructed by registry
+pub(crate) struct FeatureSignalTransform;
+
+impl ProtocolMetadataTransform for FeatureSignalTransform {
+    fn id(&self) -> TransformId {
+        TransformId::FeatureSignals
+    }
+
+    fn name(&self) -> &'static str {
+        "FeatureSignals: processes delta.feature.* signals"
+    }
+
+    fn apply(
+        &self,
+        config: TableProtocolMetadataConfig,
+        _context: &TransformContext<'_>,
+    ) -> DeltaResult<TableProtocolMetadataConfig> {
+        // Stub: pass through unchanged
+        Ok(config)
+    }
+}
+
+// ============================================================================
+// ProtocolVersionTransform (Stub)
+// ============================================================================
+
+/// Determines and sets the protocol version from user properties.
+#[derive(Debug)]
+#[allow(dead_code)] // Constructed by registry
+pub(crate) struct ProtocolVersionTransform;
+
+impl ProtocolMetadataTransform for ProtocolVersionTransform {
+    fn id(&self) -> TransformId {
+        TransformId::ProtocolVersion
+    }
+
+    fn name(&self) -> &'static str {
+        "ProtocolVersion: sets version from properties or defaults"
+    }
+
+    fn apply(
+        &self,
+        config: TableProtocolMetadataConfig,
+        _context: &TransformContext<'_>,
+    ) -> DeltaResult<TableProtocolMetadataConfig> {
+        // Stub: pass through unchanged
+        Ok(config)
+    }
+}
+
+// ============================================================================
+// DeltaPropertyValidationTransform (Stub)
+// ============================================================================
+
+/// Validates that delta.* properties are allowed for table creation.
+#[derive(Debug)]
+#[allow(dead_code)] // Constructed by registry
+pub(crate) struct DeltaPropertyValidationTransform;
+
+impl ProtocolMetadataTransform for DeltaPropertyValidationTransform {
+    fn id(&self) -> TransformId {
+        TransformId::DeltaPropertyValidation
+    }
+
+    fn name(&self) -> &'static str {
+        "DeltaPropertyValidation: validates delta.* properties are allowed"
+    }
+
+    fn apply(
+        &self,
+        config: TableProtocolMetadataConfig,
+        _context: &TransformContext<'_>,
+    ) -> DeltaResult<TableProtocolMetadataConfig> {
+        // Stub: pass through unchanged (no validation yet)
+        Ok(config)
+    }
+}

--- a/kernel/src/table_transformation/transforms.rs
+++ b/kernel/src/table_transformation/transforms.rs
@@ -2,7 +2,6 @@
 //!
 //! This module contains the standard transforms that are applied during table creation:
 //!
-//! - [`FeatureSignalTransform`]: Processes `delta.feature.X=supported` signals
 //! - [`ProtocolVersionTransform`]: Sets protocol version from properties or defaults
 //! - [`DeltaPropertyValidationTransform`]: Validates `delta.*` properties are allowed
 //!
@@ -15,38 +14,16 @@ use crate::table_protocol_metadata_config::TableProtocolMetadataConfig;
 use super::{ProtocolMetadataTransform, TransformContext, TransformId};
 
 // ============================================================================
-// FeatureSignalTransform (Stub)
-// ============================================================================
-
-/// Processes delta.feature.X=supported signals.
-#[derive(Debug)]
-#[allow(dead_code)] // Constructed by registry
-pub(crate) struct FeatureSignalTransform;
-
-impl ProtocolMetadataTransform for FeatureSignalTransform {
-    fn id(&self) -> TransformId {
-        TransformId::FeatureSignals
-    }
-
-    fn name(&self) -> &'static str {
-        "FeatureSignals: processes delta.feature.* signals"
-    }
-
-    fn apply(
-        &self,
-        config: TableProtocolMetadataConfig,
-        _context: &TransformContext<'_>,
-    ) -> DeltaResult<TableProtocolMetadataConfig> {
-        // Stub: pass through unchanged
-        Ok(config)
-    }
-}
-
-// ============================================================================
 // ProtocolVersionTransform (Stub)
 // ============================================================================
 
 /// Determines and sets the protocol version from user properties.
+///
+/// This transform:
+/// 1. Parses version properties (defaults to 3/7 if not specified)
+/// 2. Validates they are supported (only 3/7 currently)
+/// 3. Sets the protocol version
+/// 4. Strips the version properties from metadata (transient signals)
 #[derive(Debug)]
 #[allow(dead_code)] // Constructed by registry
 pub(crate) struct ProtocolVersionTransform;
@@ -65,7 +42,7 @@ impl ProtocolMetadataTransform for ProtocolVersionTransform {
         config: TableProtocolMetadataConfig,
         _context: &TransformContext<'_>,
     ) -> DeltaResult<TableProtocolMetadataConfig> {
-        // Stub: pass through unchanged
+        // Stub: pass through unchanged (version already set in Protocol::new())
         Ok(config)
     }
 }
@@ -74,7 +51,10 @@ impl ProtocolMetadataTransform for ProtocolVersionTransform {
 // DeltaPropertyValidationTransform (Stub)
 // ============================================================================
 
-/// Validates that delta.* properties are allowed for table creation.
+/// Validates that all delta.* properties are supported.
+///
+/// This transform runs first to reject unsupported properties early, before
+/// any other transforms process the configuration.
 #[derive(Debug)]
 #[allow(dead_code)] // Constructed by registry
 pub(crate) struct DeltaPropertyValidationTransform;
@@ -85,7 +65,7 @@ impl ProtocolMetadataTransform for DeltaPropertyValidationTransform {
     }
 
     fn name(&self) -> &'static str {
-        "DeltaPropertyValidation: validates delta.* properties are allowed"
+        "DeltaPropertyValidation: validates delta.* properties"
     }
 
     fn apply(
@@ -93,7 +73,7 @@ impl ProtocolMetadataTransform for DeltaPropertyValidationTransform {
         config: TableProtocolMetadataConfig,
         _context: &TransformContext<'_>,
     ) -> DeltaResult<TableProtocolMetadataConfig> {
-        // Stub: pass through unchanged (no validation yet)
+        // Stub: pass through unchanged
         Ok(config)
     }
 }

--- a/kernel/src/transaction/create_table.rs
+++ b/kernel/src/transaction/create_table.rs
@@ -36,30 +36,16 @@ use std::sync::Arc;
 
 use url::Url;
 
-use crate::actions::{Metadata, Protocol};
 use crate::committer::Committer;
 use crate::log_segment::LogSegment;
 use crate::schema::SchemaRef;
 use crate::snapshot::Snapshot;
 use crate::table_configuration::TableConfiguration;
-use crate::table_features::{
-    SET_TABLE_FEATURE_SUPPORTED_PREFIX, TABLE_FEATURES_MIN_READER_VERSION,
-    TABLE_FEATURES_MIN_WRITER_VERSION,
-};
-use crate::table_properties::DELTA_PROPERTY_PREFIX;
+use crate::table_protocol_metadata_config::TableProtocolMetadataConfig;
+use crate::table_transformation::TransformationPipeline;
 use crate::transaction::Transaction;
-use crate::utils::{current_time_ms, try_parse_uri};
+use crate::utils::try_parse_uri;
 use crate::{DeltaResult, Engine, Error, StorageHandler, PRE_COMMIT_VERSION};
-
-/// Properties that are allowed to be set during create table.
-/// This list will expand as more features are supported (e.g., column mapping, clustering).
-/// The allow list will be deprecated once auto feature enablement is implemented
-/// like the Java Kernel.
-const ALLOWED_DELTA_PROPERTIES: &[&str] = &[
-    // Empty for now - will add properties as features are implemented:
-    // - "delta.columnMapping.mode" (for column mapping)
-    // - etc.
-];
 
 /// Ensures that no Delta table exists at the given path.
 ///
@@ -112,35 +98,6 @@ fn ensure_table_does_not_exist(
             Err(e)
         }
     }
-}
-
-/// Validates that table properties are allowed during CREATE TABLE.
-///
-/// This function enforces an allow list for delta properties:
-/// - Feature override properties (`delta.feature.*`) are never allowed
-/// - Delta properties (`delta.*`) must be on the allow list
-/// - Non-delta properties (user/application properties) are always allowed
-fn validate_table_properties(properties: &HashMap<String, String>) -> DeltaResult<()> {
-    for key in properties.keys() {
-        // Block all delta.feature.* properties (feature override properties)
-        if key.starts_with(SET_TABLE_FEATURE_SUPPORTED_PREFIX) {
-            return Err(Error::generic(format!(
-                "Setting feature override property '{}' is not supported during CREATE TABLE",
-                key
-            )));
-        }
-        // For delta.* properties, check against allow list
-        if key.starts_with(DELTA_PROPERTY_PREFIX)
-            && !ALLOWED_DELTA_PROPERTIES.contains(&key.as_str())
-        {
-            return Err(Error::generic(format!(
-                "Setting delta property '{}' is not supported during CREATE TABLE",
-                key
-            )));
-        }
-        // Non-delta properties (user/application properties) are always allowed
-    }
-    Ok(())
 }
 
 /// Creates a builder for creating a new Delta table.
@@ -284,37 +241,30 @@ impl CreateTableTransactionBuilder {
     ) -> DeltaResult<Transaction> {
         // Validate path
         let table_url = try_parse_uri(&self.path)?;
+        // Check if table already exists by looking for _delta_log directory
+        let delta_log_url = table_url.join("_delta_log/")?;
+        let storage = engine.storage_handler();
+        ensure_table_does_not_exist(storage.as_ref(), &delta_log_url, &self.path)?;
 
         // Validate schema is non-empty
         if self.schema.fields().len() == 0 {
             return Err(Error::generic("Schema cannot be empty"));
         }
 
-        // Validate table properties against allow list
-        validate_table_properties(&self.table_properties)?;
-
-        // Check if table already exists by looking for _delta_log directory
-        let delta_log_url = table_url.join("_delta_log/")?;
-        let storage = engine.storage_handler();
-        ensure_table_does_not_exist(storage.as_ref(), &delta_log_url, &self.path)?;
-
-        // Create Protocol action with table features support
-        let protocol = Protocol::try_new(
-            TABLE_FEATURES_MIN_READER_VERSION,
-            TABLE_FEATURES_MIN_WRITER_VERSION,
-            Some(Vec::<String>::new()), // readerFeatures (empty for now)
-            Some(Vec::<String>::new()), // writerFeatures (empty for now)
-        )?;
-
-        // Create Metadata action
-        let metadata = Metadata::try_new(
-            None, // name
-            None, // description
+        // Create initial config with bare protocol and all properties
+        let config = TableProtocolMetadataConfig::new(
             (*self.schema).clone(),
             Vec::new(), // partition_columns - added with data layout support
-            current_time_ms()?,
-            self.table_properties,
+            self.table_properties.clone(),
         )?;
+
+        // Apply transforms based on properties (enables features, validates, etc.)
+        let final_config =
+            TransformationPipeline::apply_transforms(config, &self.table_properties)?;
+
+        // Extract protocol and metadata from final config
+        let protocol = final_config.protocol;
+        let metadata = final_config.metadata;
 
         // Create pre-commit snapshot from protocol/metadata
         let log_root = table_url.join("_delta_log/")?;
@@ -336,7 +286,7 @@ impl CreateTableTransactionBuilder {
 mod tests {
     use super::*;
     use crate::schema::{DataType, StructField, StructType};
-    use crate::utils::test_utils::assert_result_error_with_message;
+    use crate::table_properties::{MIN_READER_VERSION_PROP, MIN_WRITER_VERSION_PROP};
     use std::sync::Arc;
 
     fn test_schema() -> SchemaRef {
@@ -402,46 +352,64 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_supported_properties() {
-        // Empty properties are allowed
+    fn test_table_creation_config_parsing() {
+        let schema =
+            StructType::new_unchecked(vec![StructField::new("id", DataType::INTEGER, false)]);
+
+        // Empty properties are allowed - protocol is created with default features
         let properties = HashMap::new();
-        assert!(validate_table_properties(&properties).is_ok());
+        let config = TableProtocolMetadataConfig::new(schema.clone(), vec![], properties).unwrap();
+        assert!(config.metadata.configuration().is_empty());
+        // Protocol always has features (even if empty) at version 3/7
+        assert_eq!(config.protocol.min_reader_version(), 3);
+        assert_eq!(config.protocol.min_writer_version(), 7);
+        assert!(config.protocol.reader_features().unwrap().is_empty());
+        assert!(config.protocol.writer_features().unwrap().is_empty());
 
-        // User/application properties are allowed
-        let mut properties = HashMap::new();
-        properties.insert("myapp.version".to_string(), "1.0".to_string());
-        properties.insert("custom.setting".to_string(), "value".to_string());
-        assert!(validate_table_properties(&properties).is_ok());
+        // User/application properties are passed through
+        let properties = HashMap::from([
+            ("myapp.version".to_string(), "1.0".to_string()),
+            ("custom.setting".to_string(), "value".to_string()),
+        ]);
+        let config = TableProtocolMetadataConfig::new(schema.clone(), vec![], properties).unwrap();
+        assert_eq!(
+            config.metadata.configuration().get("myapp.version"),
+            Some(&"1.0".to_string())
+        );
+        assert_eq!(
+            config.metadata.configuration().get("custom.setting"),
+            Some(&"value".to_string())
+        );
+
+        // try_from creates bare protocol and passes all properties through
+        let properties = HashMap::from([
+            (MIN_READER_VERSION_PROP.to_string(), "3".to_string()),
+            (MIN_WRITER_VERSION_PROP.to_string(), "7".to_string()),
+            ("myapp.version".to_string(), "1.0".to_string()),
+        ]);
+        let config = TableProtocolMetadataConfig::new(schema, vec![], properties).unwrap();
+        // Protocol is bare v3/v7 (transforms would process version signals)
+        assert_eq!(config.protocol.min_reader_version(), 3);
+        assert_eq!(config.protocol.min_writer_version(), 7);
+        // All properties pass through in try_from (including version props)
+        assert!(config
+            .metadata
+            .configuration()
+            .contains_key(MIN_READER_VERSION_PROP));
+        assert!(config
+            .metadata
+            .configuration()
+            .contains_key(MIN_WRITER_VERSION_PROP));
+        assert_eq!(
+            config.metadata.configuration().get("myapp.version"),
+            Some(&"1.0".to_string())
+        );
     }
 
-    #[test]
-    fn test_validate_unsupported_properties() {
-        // Delta properties not on allow list are rejected
-        let mut properties = HashMap::new();
-        properties.insert("delta.enableChangeDataFeed".to_string(), "true".to_string());
-        assert_result_error_with_message(
-            validate_table_properties(&properties),
-            "Setting delta property 'delta.enableChangeDataFeed' is not supported",
-        );
-
-        // Feature override properties are rejected
-        let mut properties = HashMap::new();
-        properties.insert(
-            "delta.feature.domainMetadata".to_string(),
-            "supported".to_string(),
-        );
-        assert_result_error_with_message(
-            validate_table_properties(&properties),
-            "Setting feature override property 'delta.feature.domainMetadata' is not supported",
-        );
-
-        // Mixed properties with unsupported delta property are rejected
-        let mut properties = HashMap::new();
-        properties.insert("myapp.version".to_string(), "1.0".to_string());
-        properties.insert("delta.appendOnly".to_string(), "true".to_string());
-        assert_result_error_with_message(
-            validate_table_properties(&properties),
-            "Setting delta property 'delta.appendOnly' is not supported",
-        );
-    }
+    // Note: Protocol version validation tests are pending implementation of
+    // ProtocolVersionTransform. Once implemented, add tests here for:
+    // - Valid versions (3, 7) succeed
+    // - Invalid reader version (not 3) fails
+    // - Invalid writer version (not 7) fails
+    // - Non-integer versions fail
 }

--- a/kernel/src/transaction/create_table.rs
+++ b/kernel/src/transaction/create_table.rs
@@ -260,12 +260,12 @@ impl CreateTableTransactionBuilder {
         )?;
 
         // Apply transforms based on properties (enables features, validates, etc.)
-        let final_config =
+        let output =
             TransformationPipeline::apply_transforms(config, &self.table_properties)?;
 
         // Extract protocol and metadata from final config
-        let protocol = final_config.protocol;
-        let metadata = final_config.metadata;
+        let protocol = output.config.protocol;
+        let metadata = output.config.metadata;
 
         // Create pre-commit snapshot from protocol/metadata
         let log_root = table_url.join("_delta_log/")?;
@@ -274,11 +274,12 @@ impl CreateTableTransactionBuilder {
             TableConfiguration::try_new(metadata, protocol, table_url, PRE_COMMIT_VERSION)?;
 
         // Create Transaction with pre-commit snapshot
+        // Domain metadata from transforms is passed as system domain metadata
         Transaction::try_new_create_table(
             Arc::new(Snapshot::new(log_segment, table_configuration)),
             self.engine_info,
             committer,
-            vec![], // system_domain_metadata - not supported in base API
+            output.domain_metadata,
         )
     }
 }

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -20,7 +20,9 @@ use crate::error::Error;
 use crate::expressions::{column_name, ColumnName};
 use crate::expressions::{ArrayData, Scalar, StructData, Transform, UnaryExpressionOp::ToJson};
 use crate::path::{LogRoot, ParsedLogPath};
-use crate::row_tracking::{RowTrackingDomainMetadata, RowTrackingVisitor};
+use crate::row_tracking::{
+    RowTrackingDomainMetadata, RowTrackingVisitor, ROW_TRACKING_DOMAIN_NAME,
+};
 use crate::scan::data_skipping::stats_schema::NullableStatsTransform;
 use crate::scan::log_replay::{
     get_scan_metadata_transform_expr, BASE_ROW_ID_NAME, DEFAULT_ROW_COMMIT_VERSION_NAME,
@@ -659,19 +661,49 @@ impl Transaction {
         // PRE_COMMIT_VERSION (u64::MAX) + 1 wraps to 0, which is the correct first version
         self.read_snapshot.version().wrapping_add(1)
     }
-    /// Validate that user domains don't conflict with system domains or each other.
-    fn validate_user_domain_operations(&self) -> DeltaResult<()> {
+    /// Validate domain metadata operations for both create-table and existing-table transactions.
+    ///
+    /// Enforces the following rules:
+    /// - DomainMetadata feature must be supported if any domain operations are present
+    /// - System domains (delta.*) can only be added in create-table transactions
+    /// - System domains must correspond to a known feature (e.g., rowTracking) and that feature must be enabled
+    /// - User domains can be added in both create-table and existing-table transactions
+    /// - Domain removals are not allowed in create-table transactions
+    /// - No duplicate domains within a single transaction
+    fn validate_domain_metadata_operations(&self) -> DeltaResult<()> {
+        // Feature validation (applies to all transactions with domain operations)
+        if (!self.domain_metadata_additions.is_empty() || !self.domain_removals.is_empty())
+            && !self
+                .read_snapshot
+                .table_configuration()
+                .is_feature_supported(&TableFeature::DomainMetadata)
+        {
+            return Err(Error::unsupported(
+                "Domain metadata operations require writer version 7 and the 'domainMetadata' writer feature",
+            ));
+        }
+
+        let is_create = self.is_create_table();
         let mut seen_domains = HashSet::new();
 
         // Validate domain additions
         for dm in &self.domain_metadata_additions {
             let domain = dm.domain();
-            if domain.starts_with(INTERNAL_DOMAIN_PREFIX) {
+            let is_system_domain = domain.starts_with(INTERNAL_DOMAIN_PREFIX);
+
+            // System domains (delta.*) only allowed in create-table
+            if is_system_domain && !is_create {
                 return Err(Error::generic(
                     "Cannot modify domains that start with 'delta.' as those are system controlled",
                 ));
             }
 
+            // For create-table, validate system domains against their required features
+            if is_system_domain && is_create {
+                self.validate_system_domain_feature(domain)?;
+            }
+
+            // Check for duplicates
             if !seen_domains.insert(domain) {
                 return Err(Error::generic(format!(
                     "Metadata for domain {} already specified in this transaction",
@@ -680,7 +712,14 @@ impl Transaction {
             }
         }
 
-        // Validate domain removals
+        // No removals allowed for create-table
+        if is_create && !self.domain_removals.is_empty() {
+            return Err(Error::unsupported(
+                "Domain metadata removals are not supported in create-table transactions",
+            ));
+        }
+
+        // Validate domain removals (for non-create-table)
         for domain in &self.domain_removals {
             if domain.starts_with(INTERNAL_DOMAIN_PREFIX) {
                 return Err(Error::generic(
@@ -692,6 +731,39 @@ impl Transaction {
                 return Err(Error::generic(format!(
                     "Metadata for domain {} already specified in this transaction",
                     domain
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Validate that a system domain corresponds to a known feature and that the feature is supported.
+    ///
+    /// This prevents arbitrary `delta.*` domains from being added during table creation.
+    /// Each known system domain must have its corresponding feature enabled in the protocol.
+    fn validate_system_domain_feature(&self, domain: &str) -> DeltaResult<()> {
+        let table_config = self.read_snapshot.table_configuration();
+
+        // Map domain to its required feature
+        let required_feature = match domain {
+            ROW_TRACKING_DOMAIN_NAME => Some(TableFeature::RowTracking),
+            // Will be changed to a constant in a follow up clustering create table feature PR
+            "delta.clustering" => Some(TableFeature::ClusteredTable),
+            _ => {
+                return Err(Error::generic(format!(
+                    "Unknown system domain '{}'. Only known system domains are allowed.",
+                    domain
+                )));
+            }
+        };
+
+        // If the domain requires a feature, validate it's supported
+        if let Some(feature) = required_feature {
+            if !table_config.is_feature_supported(&feature) {
+                return Err(Error::generic(format!(
+                    "System domain '{}' requires the '{}' feature to be enabled",
+                    domain, feature
                 )));
             }
         }
@@ -837,6 +909,36 @@ impl Transaction {
         Ok(())
     }
 
+    /// Generate removal actions for user domain metadata by scanning the log.
+    ///
+    /// This performs an expensive log replay operation to fetch the previous configuration
+    /// value for each domain being removed, as required by the Delta spec for tombstones.
+    /// Returns an empty vector if there are no domain removals.
+    fn generate_user_domain_removal_actions(
+        &self,
+        engine: &dyn Engine,
+    ) -> DeltaResult<Vec<DomainMetadata>> {
+        if self.domain_removals.is_empty() {
+            return Ok(vec![]);
+        }
+
+        // Scan log to fetch existing configurations for tombstones
+        let existing_domains =
+            scan_domain_metadatas(self.read_snapshot.log_segment(), None, engine)?;
+
+        // Create removal tombstones with pre-image configurations
+        Ok(self
+            .domain_removals
+            .iter()
+            .filter_map(|domain| {
+                // If domain doesn't exist in the log, this is a no-op (filter it out)
+                existing_domains.get(domain).map(|existing| {
+                    DomainMetadata::remove(domain.clone(), existing.configuration().to_owned())
+                })
+            })
+            .collect())
+    }
+
     /// Generate domain metadata actions with validation. Handle both user and system domains.
     ///
     /// This function may perform an expensive log replay operation if there are any domain removals.
@@ -847,55 +949,28 @@ impl Transaction {
         engine: &'a dyn Engine,
         row_tracking_high_watermark: Option<RowTrackingDomainMetadata>,
     ) -> DeltaResult<EngineDataResultIterator<'a>> {
-        // For create-table transactions, domain metadata will be added in
-        // a subsequent code commit
-        if self.is_create_table() {
-            if !self.domain_metadata_additions.is_empty() || !self.domain_removals.is_empty() {
-                return Err(Error::unsupported(
-                    "Domain metadata operations are not supported in create-table transactions",
+        let is_create = self.is_create_table();
+
+        // Validate domain operations (includes feature validation)
+        self.validate_domain_metadata_operations()?;
+
+        // TODO(sanuj) Create-table must not have row tracking or removals
+        // Defensive. Needs to be updated when row tracking support is added.
+        if is_create {
+            if row_tracking_high_watermark.is_some() {
+                return Err(Error::internal_error(
+                    "CREATE TABLE cannot have row tracking domain metadata",
                 ));
             }
-            return Ok(Box::new(iter::empty()));
+            // domain_removals already validated above, but be explicit
+            debug_assert!(self.domain_removals.is_empty());
         }
 
-        // Validate feature support for user domain operations
-        if (!self.domain_metadata_additions.is_empty() || !self.domain_removals.is_empty())
-            && !self
-                .read_snapshot
-                .table_configuration()
-                .is_feature_supported(&TableFeature::DomainMetadata)
-        {
-            return Err(Error::unsupported("Domain metadata operations require writer version 7 and the 'domainMetadata' writer feature"));
-        }
+        // Generate removal actions (empty for create-table due to validation above)
+        let removal_actions = self.generate_user_domain_removal_actions(engine)?;
 
-        // Validate user domain operations
-        self.validate_user_domain_operations()?;
-
-        // Generate user domain removals via log replay (expensive if non-empty)
-        let removal_actions = if !self.domain_removals.is_empty() {
-            // Scan log to fetch existing configurations for tombstones
-            let existing_domains =
-                scan_domain_metadatas(self.read_snapshot.log_segment(), None, engine)?;
-
-            // Create removal tombstones with pre-image configurations
-            let removals: Vec<_> = self
-                .domain_removals
-                .iter()
-                .filter_map(|domain| {
-                    // If domain doesn't exist in the log, this is a no-op (filter it out)
-                    existing_domains.get(domain).map(|existing| {
-                        DomainMetadata::remove(domain.clone(), existing.configuration().to_owned())
-                    })
-                })
-                .collect();
-
-            removals
-        } else {
-            vec![]
-        };
-
-        // Generate system domain actions (row tracking)
-        let system_domain_actions = row_tracking_high_watermark
+        // Generate row tracking domain action (None for create-table)
+        let row_tracking_domain_action = row_tracking_high_watermark
             .map(DomainMetadata::try_from)
             .transpose()?
             .into_iter();
@@ -906,7 +981,7 @@ impl Transaction {
                 .clone()
                 .into_iter()
                 .chain(removal_actions)
-                .chain(system_domain_actions)
+                .chain(row_tracking_domain_action)
                 .map(|dm| dm.into_engine_data(get_log_domain_metadata_schema().clone(), engine)),
         ))
     }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/1742/files/12d62e61096deb4b0f3324401554879a0f10c0dd..c311424f054bdf723c6be70bd6d602342e2d2f4f) to review incremental changes.
- [stack/create_table_3](https://github.com/delta-io/delta-kernel-rs/pull/1655) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1655/files)]
  - [stack/create_table_3_transform_foundation](https://github.com/delta-io/delta-kernel-rs/pull/1735) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1735/files/f47a69c07281ffe16c5c8d8ffc65b4f1355de846..ac9e583790848bd1c6f57921d9ffbe3829f22223)]
    - [stack/create_table_3_transform_pipeline](https://github.com/delta-io/delta-kernel-rs/pull/1736) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1736/files/ac9e583790848bd1c6f57921d9ffbe3829f22223..3434fea652c5d10c279b16b04d7de1dc946fbc5a)]
      - [stack/create_table_3_transform_integration](https://github.com/delta-io/delta-kernel-rs/pull/1737) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1737/files/3434fea652c5d10c279b16b04d7de1dc946fbc5a..4291ec6e7cfe21243b262979453852942037b8aa)]
        - [stack/create_table_4](https://github.com/delta-io/delta-kernel-rs/pull/1724) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1724/files/4291ec6e7cfe21243b262979453852942037b8aa..9d0ca999517db6be68ab9141b695fdc1541b5a57)]
          - [stack/create_table_5](https://github.com/delta-io/delta-kernel-rs/pull/1725) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1725/files/9d0ca999517db6be68ab9141b695fdc1541b5a57..12d62e61096deb4b0f3324401554879a0f10c0dd)]
            - [**stack/create_table_6_domain_metadata_transform**](https://github.com/delta-io/delta-kernel-rs/pull/1742) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1742/files/12d62e61096deb4b0f3324401554879a0f10c0dd..c311424f054bdf723c6be70bd6d602342e2d2f4f)]
              - [stack/create_table_6_partitioning](https://github.com/delta-io/delta-kernel-rs/pull/1743) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1743/files/c311424f054bdf723c6be70bd6d602342e2d2f4f..e2fc12991b8548609f57b209aab5389259f91cd9)]
                - [stack/create_table_6_clustering](https://github.com/delta-io/delta-kernel-rs/pull/1744) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1744/files/e2fc12991b8548609f57b209aab5389259f91cd9..6ba29952c249004bee09f35e5a0b8b5267508cc7)]
                  - [stack/create_table_7_column_mapping](https://github.com/delta-io/delta-kernel-rs/pull/1747) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1747/files/6ba29952c249004bee09f35e5a0b8b5267508cc7..5bb078f9e438fac69dde154491fd0dc9c2bbca96)]
                    - [stack/create_table_integration_tests](https://github.com/delta-io/delta-kernel-rs/pull/1757) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1757/files/5bb078f9e438fac69dde154491fd0dc9c2bbca96..bfe49e7afc7ef3ad6a61369f5ebbba8c9c42e52b)]

---------
This commit introduces the infrastructure for transforms to return domain
metadata alongside configuration changes:

Infrastructure changes:
- `TransformOutput` struct to return both config and domain metadata from transforms
- Updated `apply()` to return `TransformOutput` instead of `TableProtocolMetadataConfig`
- Updated `dependencies()` to return `Vec<TransformDependency>` for flexibility
- Pipeline now collects domain metadata from all transforms and returns in output

New transform:
- `DomainMetadataTransform`: Enables the DomainMetadata writer feature when
  triggered via `delta.feature.domainMetadata=supported`

Feature enablement:
- Added `DomainMetadata` to `ALLOWED_DELTA_FEATURES` in `TableProtocolMetadataConfig`

The domain metadata from transforms is now passed through to the Transaction
via `try_new_create_table()`.

## What changes are proposed in this pull request?

<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

## How was this change tested?
