### PR TITLE
refactor: refactor out stats_schema table properties

### DIFF
--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -187,10 +187,12 @@ impl TableConfiguration {
         &self,
         clustering_columns: Option<&[ColumnName]>,
     ) -> DeltaResult<SchemaRef> {
-        let physical_schema = self.physical_data_schema();
         Ok(Arc::new(expected_stats_schema(
-            &physical_schema,
-            self.table_properties(),
+            &self.physical_data_schema(),
+            self.table_properties()
+                .data_skipping_stats_columns
+                .as_deref(),
+            self.table_properties().data_skipping_num_indexed_cols,
             clustering_columns,
         )?))
     }
@@ -209,10 +211,12 @@ impl TableConfiguration {
         &self,
         clustering_columns: Option<&[ColumnName]>,
     ) -> Vec<ColumnName> {
-        let physical_schema = self.physical_data_schema();
         stats_column_names(
-            &physical_schema,
-            self.table_properties(),
+            &self.physical_data_schema(),
+            self.table_properties()
+                .data_skipping_stats_columns
+                .as_deref(),
+            self.table_properties().data_skipping_num_indexed_cols,
             clustering_columns,
         )
     }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/1746/files) to review incremental changes.
- [**stack/rename-stats-schema-params**](https://github.com/delta-io/delta-kernel-rs/pull/1746) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1746/files)]
  - [stack/stats-schema-column-mapping](https://github.com/delta-io/delta-kernel-rs/pull/1739) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1739/files/ffbcabc4c5422bfe77ed2b2a81097bc7dbf3ccd1..fe13b5e0c06ef65aba9e9d0b827ea394fd840434)]
    - [stack/stats-columns-api](https://github.com/delta-io/delta-kernel-rs/pull/1728) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1728/files/fe13b5e0c06ef65aba9e9d0b827ea394fd840434..594a02f9d7f5e9ad01c07347e5fd48c46022f7a1)]
      - [stack/output-stat-columns-all](https://github.com/delta-io/delta-kernel-rs/pull/1720) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1720/files/594a02f9d7f5e9ad01c07347e5fd48c46022f7a1..096790bb3e3091502f65c28518f9746a1c340f20)]
        - [stack/specify-stats-columns](https://github.com/delta-io/delta-kernel-rs/pull/1730) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1730/files/096790bb3e3091502f65c28518f9746a1c340f20..e4713c549a2ae90b2b8a794c42ca1ea473c70351)]

---------
## What changes are proposed in this pull request?

Refactor stats_schema functions to take column names and num_cols directly instead of reading from table properties. This way TableConfiguration can handle column mapping conversion.

## How was this change tested?
Existing unit tests