### PR TITLE
feat: Support creation of `DefaultEngine` with `TokioMultiThreadExecutor` in FFI

### DIFF
--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -547,7 +547,7 @@ pub unsafe extern "C" fn set_builder_with_multithreaded_executor(
 ) {
     let worker_threads = (worker_threads != 0).then_some(worker_threads);
     let max_blocking_threads = (max_blocking_threads != 0).then_some(max_blocking_threads);
-    
+
     builder.multithreaded_executor_config = Some(MultithreadedExecutorConfig {
         worker_threads,
         max_blocking_threads,


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/1755/files) to review incremental changes.
- [**stack/ffi-multi**](https://github.com/delta-io/delta-kernel-rs/pull/1755) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1755/files)]

---------
## What changes are proposed in this pull request?
Added a new API `set_builder_with_multithreaded_executor` allowing FFI to create `DefaultEngine` with `TokioMultiThreadExecutor`.
<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

## How was this change tested?
Added