### PR TITLE
feat: create table builder and domain metadata handling

### DIFF
--- a/kernel/src/row_tracking.rs
+++ b/kernel/src/row_tracking.rs
@@ -16,9 +16,10 @@ pub(crate) struct RowTrackingDomainMetadata {
     row_id_high_water_mark: i64,
 }
 
-impl RowTrackingDomainMetadata {
-    const ROW_TRACKING_DOMAIN_NAME: &str = "delta.rowTracking";
+/// The domain name for row tracking metadata.
+pub(crate) const ROW_TRACKING_DOMAIN_NAME: &str = "delta.rowTracking";
 
+impl RowTrackingDomainMetadata {
     pub(crate) fn new(row_id_high_water_mark: i64) -> Self {
         RowTrackingDomainMetadata {
             row_id_high_water_mark,
@@ -45,14 +46,16 @@ impl RowTrackingDomainMetadata {
         snapshot: &Snapshot,
         engine: &dyn Engine,
     ) -> DeltaResult<Option<i64>> {
-        Ok(domain_metadata_configuration(
-            snapshot.log_segment(),
-            Self::ROW_TRACKING_DOMAIN_NAME,
-            engine,
-        )?
-        .map(|domain_metadata| serde_json::from_str::<Self>(&domain_metadata))
-        .transpose()?
-        .map(|metadata| metadata.row_id_high_water_mark))
+        Ok(
+            domain_metadata_configuration(
+                snapshot.log_segment(),
+                ROW_TRACKING_DOMAIN_NAME,
+                engine,
+            )?
+            .map(|domain_metadata| serde_json::from_str::<Self>(&domain_metadata))
+            .transpose()?
+            .map(|metadata| metadata.row_id_high_water_mark),
+        )
     }
 }
 
@@ -61,7 +64,7 @@ impl TryFrom<RowTrackingDomainMetadata> for DomainMetadata {
 
     fn try_from(metadata: RowTrackingDomainMetadata) -> DeltaResult<Self> {
         Ok(DomainMetadata::new(
-            RowTrackingDomainMetadata::ROW_TRACKING_DOMAIN_NAME.to_string(),
+            ROW_TRACKING_DOMAIN_NAME.to_string(),
             serde_json::to_string(&metadata)?,
         ))
     }

--- a/kernel/src/transaction/create_table.rs
+++ b/kernel/src/transaction/create_table.rs
@@ -43,15 +43,29 @@ use crate::schema::SchemaRef;
 use crate::snapshot::Snapshot;
 use crate::table_configuration::TableConfiguration;
 use crate::table_features::{
-    SET_TABLE_FEATURE_SUPPORTED_PREFIX, TABLE_FEATURES_MIN_READER_VERSION,
-    TABLE_FEATURES_MIN_WRITER_VERSION,
+    TableFeature, SET_TABLE_FEATURE_SUPPORTED_PREFIX, SET_TABLE_FEATURE_SUPPORTED_VALUE,
+    TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION,
 };
 use crate::table_properties::DELTA_PROPERTY_PREFIX;
 use crate::transaction::Transaction;
 use crate::utils::{current_time_ms, try_parse_uri};
 use crate::{DeltaResult, Engine, Error, StorageHandler, PRE_COMMIT_VERSION};
 
-/// Properties that are allowed to be set during create table.
+/// Table features allowed to be enabled via `delta.feature.*=supported` during CREATE TABLE.
+///
+/// Feature signals (`delta.feature.X=supported`) are validated against this list.
+/// Only features in this list can be enabled via feature signals.
+///
+/// This list will expand as more features are supported (e.g., column mapping, clustering).
+const ALLOWED_DELTA_FEATURES: &[TableFeature] = &[
+    // Currently empty - no features allowed yet
+    // As features are supported, add them here:
+    // TableFeature::ColumnMapping,
+    // TableFeature::DeletionVectors,
+];
+
+/// Delta properties allowed to be set during CREATE TABLE.
+///
 /// This list will expand as more features are supported (e.g., column mapping, clustering).
 /// The allow list will be deprecated once auto feature enablement is implemented
 /// like the Java Kernel.
@@ -114,22 +128,81 @@ fn ensure_table_does_not_exist(
     }
 }
 
-/// Validates that table properties are allowed during CREATE TABLE.
+/// Result of validating and transforming table properties.
+struct ValidatedTableProperties {
+    /// Table properties with feature signals removed (to be stored in metadata)
+    properties: HashMap<String, String>,
+    /// Reader features extracted from feature signals (for ReaderWriter features)
+    reader_features: Vec<TableFeature>,
+    /// Writer features extracted from feature signals (for all features)
+    writer_features: Vec<TableFeature>,
+}
+
+/// Validates and transforms table properties for CREATE TABLE.
 ///
-/// This function enforces an allow list for delta properties:
-/// - Feature override properties (`delta.feature.*`) are never allowed
-/// - Delta properties (`delta.*`) must be on the allow list
-/// - Non-delta properties (user/application properties) are always allowed
-fn validate_table_properties(properties: &HashMap<String, String>) -> DeltaResult<()> {
-    for key in properties.keys() {
-        // Block all delta.feature.* properties (feature override properties)
-        if key.starts_with(SET_TABLE_FEATURE_SUPPORTED_PREFIX) {
+/// This function:
+/// 1. Validates feature signals (`delta.feature.*`) against `ALLOWED_DELTA_FEATURES`
+/// 2. Validates delta properties (`delta.*`) against `ALLOWED_DELTA_PROPERTIES`
+/// 3. Removes feature signals from properties (they shouldn't be stored in metadata)
+/// 4. Extracts reader/writer features from validated feature signals
+///
+/// Non-delta properties (user/application properties) are always allowed.
+fn validate_extract_table_features_and_properties(
+    properties: HashMap<String, String>,
+) -> DeltaResult<ValidatedTableProperties> {
+    use crate::table_features::FeatureType;
+
+    let mut reader_features = Vec::new();
+    let mut writer_features = Vec::new();
+
+    // Partition properties into feature signals and regular properties
+    // Feature signals (delta.feature.X=supported) are processed but not stored in metadata
+    // Feature signals are removed from the properties map.
+    let (feature_signals, properties): (HashMap<_, _>, HashMap<_, _>) = properties
+        .into_iter()
+        .partition(|(k, _)| k.starts_with(SET_TABLE_FEATURE_SUPPORTED_PREFIX));
+
+    // Process and validate feature signals
+    for (key, value) in &feature_signals {
+        // Safe: we partitioned for keys starting with this prefix above
+        let Some(feature_name) = key.strip_prefix(SET_TABLE_FEATURE_SUPPORTED_PREFIX) else {
+            continue;
+        };
+
+        // Validate that the value is "supported"
+        if value != SET_TABLE_FEATURE_SUPPORTED_VALUE {
             return Err(Error::generic(format!(
-                "Setting feature override property '{}' is not supported during CREATE TABLE",
-                key
+                "Invalid value '{}' for '{}'. Only '{}' is allowed.",
+                value, key, SET_TABLE_FEATURE_SUPPORTED_VALUE
             )));
         }
-        // For delta.* properties, check against allow list
+
+        // Parse feature name to TableFeature (unknown features become TableFeature::Unknown)
+        let feature: TableFeature = feature_name
+            .parse()
+            .unwrap_or_else(|_| TableFeature::Unknown(feature_name.to_string()));
+
+        if !ALLOWED_DELTA_FEATURES.contains(&feature) {
+            return Err(Error::generic(format!(
+                "Enabling feature '{}' via '{}' is not supported during CREATE TABLE",
+                feature_name, key
+            )));
+        }
+
+        // Add to appropriate feature lists based on feature type
+        match feature.feature_type() {
+            FeatureType::ReaderWriter => {
+                reader_features.push(feature.clone());
+                writer_features.push(feature);
+            }
+            FeatureType::Writer | FeatureType::Unknown => {
+                writer_features.push(feature);
+            }
+        }
+    }
+
+    // Validate remaining delta.* properties against allow list
+    for key in properties.keys() {
         if key.starts_with(DELTA_PROPERTY_PREFIX)
             && !ALLOWED_DELTA_PROPERTIES.contains(&key.as_str())
         {
@@ -138,9 +211,13 @@ fn validate_table_properties(properties: &HashMap<String, String>) -> DeltaResul
                 key
             )));
         }
-        // Non-delta properties (user/application properties) are always allowed
     }
-    Ok(())
+
+    Ok(ValidatedTableProperties {
+        properties,
+        reader_features,
+        writer_features,
+    })
 }
 
 /// Creates a builder for creating a new Delta table.
@@ -289,31 +366,33 @@ impl CreateTableTransactionBuilder {
         if self.schema.fields().len() == 0 {
             return Err(Error::generic("Schema cannot be empty"));
         }
-
-        // Validate table properties against allow list
-        validate_table_properties(&self.table_properties)?;
-
         // Check if table already exists by looking for _delta_log directory
         let delta_log_url = table_url.join("_delta_log/")?;
         let storage = engine.storage_handler();
         ensure_table_does_not_exist(storage.as_ref(), &delta_log_url, &self.path)?;
 
+        // Validate and transform table properties
+        // - Extracts and validates feature signals
+        // - Removes feature signals from properties (they shouldn't be stored in metadata)
+        // - Returns reader/writer features to add to protocol
+        let validated = validate_extract_table_features_and_properties(self.table_properties)?;
+
         // Create Protocol action with table features support
         let protocol = Protocol::try_new(
             TABLE_FEATURES_MIN_READER_VERSION,
             TABLE_FEATURES_MIN_WRITER_VERSION,
-            Some(Vec::<String>::new()), // readerFeatures (empty for now)
-            Some(Vec::<String>::new()), // writerFeatures (empty for now)
+            Some(validated.reader_features),
+            Some(validated.writer_features),
         )?;
 
-        // Create Metadata action
+        // Create Metadata action with filtered properties (feature signals removed)
         let metadata = Metadata::try_new(
             None, // name
             None, // description
             (*self.schema).clone(),
             Vec::new(), // partition_columns - added with data layout support
             current_time_ms()?,
-            self.table_properties,
+            validated.properties,
         )?;
 
         // Create pre-commit snapshot from protocol/metadata
@@ -405,13 +484,29 @@ mod tests {
     fn test_validate_supported_properties() {
         // Empty properties are allowed
         let properties = HashMap::new();
-        assert!(validate_table_properties(&properties).is_ok());
+        let result = validate_extract_table_features_and_properties(properties);
+        assert!(result.is_ok());
+        let validated = result.unwrap();
+        assert!(validated.properties.is_empty());
+        assert!(validated.reader_features.is_empty());
+        assert!(validated.writer_features.is_empty());
 
-        // User/application properties are allowed
+        // User/application properties are allowed and preserved
         let mut properties = HashMap::new();
         properties.insert("myapp.version".to_string(), "1.0".to_string());
         properties.insert("custom.setting".to_string(), "value".to_string());
-        assert!(validate_table_properties(&properties).is_ok());
+        let result = validate_extract_table_features_and_properties(properties);
+        assert!(result.is_ok());
+        let validated = result.unwrap();
+        assert_eq!(validated.properties.len(), 2);
+        assert_eq!(
+            validated.properties.get("myapp.version"),
+            Some(&"1.0".to_string())
+        );
+        assert_eq!(
+            validated.properties.get("custom.setting"),
+            Some(&"value".to_string())
+        );
     }
 
     #[test]
@@ -420,19 +515,19 @@ mod tests {
         let mut properties = HashMap::new();
         properties.insert("delta.enableChangeDataFeed".to_string(), "true".to_string());
         assert_result_error_with_message(
-            validate_table_properties(&properties),
+            validate_extract_table_features_and_properties(properties),
             "Setting delta property 'delta.enableChangeDataFeed' is not supported",
         );
 
-        // Feature override properties are rejected
+        // Feature signals for features not in ALLOWED_DELTA_FEATURES are rejected
         let mut properties = HashMap::new();
         properties.insert(
             "delta.feature.domainMetadata".to_string(),
             "supported".to_string(),
         );
         assert_result_error_with_message(
-            validate_table_properties(&properties),
-            "Setting feature override property 'delta.feature.domainMetadata' is not supported",
+            validate_extract_table_features_and_properties(properties),
+            "Enabling feature 'domainMetadata' via 'delta.feature.domainMetadata' is not supported",
         );
 
         // Mixed properties with unsupported delta property are rejected
@@ -440,7 +535,7 @@ mod tests {
         properties.insert("myapp.version".to_string(), "1.0".to_string());
         properties.insert("delta.appendOnly".to_string(), "true".to_string());
         assert_result_error_with_message(
-            validate_table_properties(&properties),
+            validate_extract_table_features_and_properties(properties),
             "Setting delta property 'delta.appendOnly' is not supported",
         );
     }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/1762/files) to review incremental changes.
- [**stack/create_table_simple_base**](https://github.com/delta-io/delta-kernel-rs/pull/1762) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1762/files)]
  - [stack/create_table_simple_clustering](https://github.com/delta-io/delta-kernel-rs/pull/1763) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1763/files/5b3bf6eda7e3c1b142d5192a8bf35bd6315e8f59..de75c8d04b9a0ec131f74dbde025ce30f8fb05a0)]
    - [stack/create_table_simple_cm](https://github.com/delta-io/delta-kernel-rs/pull/1764) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1764/files/de75c8d04b9a0ec131f74dbde025ce30f8fb05a0..8e51d4747acbda5803b875912f7940e5ce3bda16)]

---------
## What changes are proposed in this pull request?

- Rename validate_table_properties to validate_and_transform_table_properties
- Add ValidatedTableProperties struct to return filtered properties and features
- Remove feature signals from properties (they shouldn't be stored in metadata)
- Extract reader/writer features from validated feature signals:
  - ReaderWriter features added to both reader_features and writer_features
  - Writer-only features added to writer_features only
- Add ALLOWED_DELTA_FEATURES constant to validate feature signals
- Update build() to pass extracted features to Protocol::try_new()
- Update tests to verify new return type and behavior
- Refactors generate_domain_metadata_actions to consume domain metadata
  actions passed down by the create table builder.
- Refactors validate_user_domain_operations() to
  validate_domain_metadata_operations() which enforces a myriad of
  domain metadata invariants.
- Adds validate_system_domain_feature to make sure relevant features
  are supported when row tracking and clustering domain metadata are
  pushed down.

This enables feature enablement via delta.feature.X=supported signals
while ensuring signals are not persisted in table metadata. Currently
no signals are supported.

## How was this change tested?
========
1/ Unit tests

2/ Integration tests to be added in  kernel/tests/create_table.rs once
clustered table creation support is implement since validation testing
requires feature allow listing.


