### PR TITLE
feat: Add clustering support for CREATE TABLE

### DIFF
--- a/kernel/src/clustering.rs
+++ b/kernel/src/clustering.rs
@@ -1,18 +1,22 @@
 //! Clustering column support for Delta tables.
 //!
-//! This module provides functionality for reading clustering columns from domain metadata.
-//! Per the Delta protocol, writers MUST write per-file statistics for clustering columns.
+//! This module provides functionality for reading and writing clustering columns
+//! via domain metadata. Per the Delta protocol, writers MUST write per-file statistics
+//! for clustering columns.
 //!
 //! Clustering columns are stored in domain metadata under the `delta.clustering` domain
 //! as a JSON object with a `clusteringColumns` field containing an array of column paths,
 //! where each path is an array of field names (to handle nested columns).
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::actions::domain_metadata::domain_metadata_configuration;
+use crate::actions::DomainMetadata;
 use crate::expressions::ColumnName;
 use crate::log_segment::LogSegment;
-use crate::{DeltaResult, Engine};
+use crate::scan::data_skipping::stats_schema::is_skipping_eligible_datatype;
+use crate::schema::{DataType, StructType};
+use crate::{DeltaResult, Engine, Error};
 
 /// Domain metadata structure for clustering columns.
 ///
@@ -27,14 +31,132 @@ use crate::{DeltaResult, Engine};
 /// ```json
 /// {"clusteringColumns": [["col1"], ["user", "address", "city"]]}
 /// ```
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct ClusteringDomainMetadata {
     clustering_columns: Vec<Vec<String>>,
 }
 
 /// The domain name for clustering metadata.
-const CLUSTERING_DOMAIN_NAME: &str = "delta.clustering";
+pub(crate) const CLUSTERING_DOMAIN_NAME: &str = "delta.clustering";
+
+/// Maximum number of columns that can be used for clustering.
+///
+/// TODO(#1794): This limit is a Delta-Spark connector configuration, not a protocol requirement.
+/// Consider removing or making this configurable.
+pub(crate) const MAX_CLUSTERING_COLUMNS: usize = 4;
+
+/// Validates clustering columns against the table schema.
+///
+/// This function performs comprehensive validation of clustering columns:
+///
+/// **Structural validations:**
+/// 1. At least one column must be specified
+/// 2. At most [`MAX_CLUSTERING_COLUMNS`] columns allowed (currently 4)
+/// 3. No duplicate columns
+///
+/// **Schema validations:**
+/// 4. Columns must be top-level (not nested paths)
+/// 5. Columns must exist in the schema
+/// 6. Columns must have data types eligible for statistics collection
+///
+/// # Errors
+///
+/// Returns an error if any validation fails.
+pub(crate) fn validate_clustering_columns(
+    schema: &StructType,
+    columns: &[ColumnName],
+) -> DeltaResult<()> {
+    use std::collections::HashSet;
+
+    // Structural validation: at least one column required
+    if columns.is_empty() {
+        return Err(Error::generic("Clustering requires at least one column"));
+    }
+
+    // Structural validation: max columns check
+    // TODO(#1794): This limit is a Delta-Spark connector configuration, not a protocol
+    // requirement. Consider removing or making this configurable.
+    if columns.len() > MAX_CLUSTERING_COLUMNS {
+        return Err(Error::generic(format!(
+            "Clustering supports at most {} columns, got {}",
+            MAX_CLUSTERING_COLUMNS,
+            columns.len()
+        )));
+    }
+
+    // Validate each column and check for duplicates
+    let mut seen = HashSet::new();
+    for col in columns {
+        // TODO(#1794): The Delta protocol doesn't explicitly require clustering columns to be
+        // top-level. Consider allowing nested columns.
+        if col.path().is_empty() {
+            return Err(Error::generic("Clustering column name cannot be empty"));
+        }
+        if col.path().len() != 1 {
+            return Err(Error::generic(format!(
+                "Clustering column '{}' must be a top-level column, not a nested path",
+                col
+            )));
+        }
+
+        // Safe to access path()[0] now that we've validated it's a single-element path
+        let col_name = &col.path()[0];
+
+        // Check for duplicates
+        if !seen.insert(col_name) {
+            return Err(Error::generic(format!(
+                "Duplicate clustering column: '{}'",
+                col_name
+            )));
+        }
+
+        // Validate column exists in schema
+        let field = schema.field(col_name).ok_or_else(|| {
+            Error::generic(format!(
+                "Clustering column '{}' not found in schema",
+                col_name
+            ))
+        })?;
+
+        // Clustering requires per-file statistics, so only stats-eligible types are allowed
+        match field.data_type() {
+            DataType::Primitive(ptype) if is_skipping_eligible_datatype(ptype) => {}
+            dt => {
+                return Err(Error::generic(format!(
+                    "Clustering column '{}' has unsupported type '{}'. \
+                     Supported types: Byte, Short, Integer, Long, Float, Double, \
+                     Decimal, Date, Timestamp, TimestampNtz, String",
+                    col_name, dt
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Creates domain metadata for clustering configuration.
+///
+/// Converts the given clustering columns into the JSON format required by the Delta protocol
+/// and wraps it in a `DomainMetadata` action.
+///
+/// # Format
+///
+/// The JSON format is: `{"clusteringColumns": [["col1"], ["col2"]]}`
+/// Each column is represented as an array of path components to support nested columns.
+pub(crate) fn create_clustering_domain_metadata(columns: &[ColumnName]) -> DomainMetadata {
+    let metadata = ClusteringDomainMetadata {
+        clustering_columns: columns
+            .iter()
+            .map(|c| c.path().iter().map(|s| s.to_string()).collect())
+            .collect(),
+    };
+    // ClusteringDomainMetadata serialization cannot fail (only contains Vec<Vec<String>>)
+    #[allow(clippy::unwrap_used)]
+    let config = serde_json::to_string(&metadata).unwrap();
+
+    DomainMetadata::new(CLUSTERING_DOMAIN_NAME.to_string(), config)
+}
 
 /// Parses clustering columns from a JSON configuration string.
 ///
@@ -74,6 +196,7 @@ pub(crate) fn get_clustering_columns(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::schema::{DataType, StructField};
 
     #[rstest::rstest]
     #[case::simple(
@@ -100,5 +223,216 @@ mod tests {
         let columns = parse_clustering_columns(json).unwrap();
         let expected_cols: Vec<ColumnName> = expected.into_iter().map(ColumnName::new).collect();
         assert_eq!(columns, expected_cols);
+    }
+
+    #[test]
+    fn test_validate_clustering_columns_valid() {
+        let schema = StructType::new_unchecked(vec![
+            StructField::new("id", DataType::INTEGER, false),
+            StructField::new("name", DataType::STRING, true),
+        ]);
+        let columns = vec![ColumnName::new(["id"])];
+        assert!(validate_clustering_columns(&schema, &columns).is_ok());
+    }
+
+    #[test]
+    fn test_validate_clustering_columns_not_found() {
+        let schema =
+            StructType::new_unchecked(vec![StructField::new("id", DataType::INTEGER, false)]);
+        let columns = vec![ColumnName::new(["nonexistent"])];
+        let result = validate_clustering_columns(&schema, &columns);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("not found in schema"));
+    }
+
+    #[test]
+    fn test_validate_clustering_columns_nested_rejected() {
+        let schema =
+            StructType::new_unchecked(vec![StructField::new("nested", DataType::STRING, true)]);
+        let columns = vec![ColumnName::new(["nested", "field"])];
+        let result = validate_clustering_columns(&schema, &columns);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("must be a top-level column"));
+    }
+
+    #[test]
+    fn test_create_clustering_domain_metadata() {
+        let columns = vec![ColumnName::new(["col1"]), ColumnName::new(["col2"])];
+        let dm = create_clustering_domain_metadata(&columns);
+
+        assert_eq!(dm.domain(), CLUSTERING_DOMAIN_NAME);
+
+        // Verify roundtrip: the JSON we create should be parseable back
+        let parsed = parse_clustering_columns(dm.configuration()).unwrap();
+        assert_eq!(parsed, columns);
+    }
+
+    #[test]
+    fn test_create_and_parse_roundtrip() {
+        // Test that create and parse are inverses
+        let original = vec![
+            ColumnName::new(["id"]),
+            ColumnName::new(["timestamp"]),
+            ColumnName::new(["region"]),
+        ];
+        let dm = create_clustering_domain_metadata(&original);
+        let parsed = parse_clustering_columns(dm.configuration()).unwrap();
+        assert_eq!(original, parsed);
+    }
+
+    #[test]
+    fn test_validate_clustering_columns_supported_types() {
+        // All supported primitive types
+        let schema = StructType::new_unchecked(vec![
+            StructField::new("byte_col", DataType::BYTE, false),
+            StructField::new("short_col", DataType::SHORT, false),
+            StructField::new("int_col", DataType::INTEGER, false),
+            StructField::new("long_col", DataType::LONG, false),
+            StructField::new("float_col", DataType::FLOAT, false),
+            StructField::new("double_col", DataType::DOUBLE, false),
+            StructField::new("date_col", DataType::DATE, false),
+            StructField::new("timestamp_col", DataType::TIMESTAMP, false),
+            StructField::new("timestamp_ntz_col", DataType::TIMESTAMP_NTZ, false),
+            StructField::new("string_col", DataType::STRING, false),
+            StructField::new("decimal_col", DataType::decimal(10, 2).unwrap(), false),
+        ]);
+
+        // Each supported type should be valid for clustering
+        for field in schema.fields() {
+            let columns = vec![ColumnName::new([field.name()])];
+            assert!(
+                validate_clustering_columns(&schema, &columns).is_ok(),
+                "Type {} should be supported for clustering",
+                field.data_type()
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_clustering_columns_unsupported_primitive_types() {
+        // Boolean and Binary are primitives but not supported for clustering
+        let schema = StructType::new_unchecked(vec![
+            StructField::new("bool_col", DataType::BOOLEAN, false),
+            StructField::new("binary_col", DataType::BINARY, false),
+        ]);
+
+        for field in schema.fields() {
+            let columns = vec![ColumnName::new([field.name()])];
+            let result = validate_clustering_columns(&schema, &columns);
+            assert!(
+                result.is_err(),
+                "Type {} should NOT be supported for clustering",
+                field.data_type()
+            );
+            assert!(result.unwrap_err().to_string().contains("unsupported type"));
+        }
+    }
+
+    #[test]
+    fn test_validate_clustering_columns_complex_types_rejected() {
+        use crate::schema::{ArrayType, MapType};
+
+        let inner_struct =
+            StructType::new_unchecked(vec![StructField::new("inner", DataType::STRING, false)]);
+
+        let schema = StructType::new_unchecked(vec![
+            StructField::new(
+                "struct_col",
+                DataType::Struct(Box::new(inner_struct)),
+                false,
+            ),
+            StructField::new(
+                "array_col",
+                DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, false))),
+                false,
+            ),
+            StructField::new(
+                "map_col",
+                DataType::Map(Box::new(MapType::new(
+                    DataType::STRING,
+                    DataType::INTEGER,
+                    false,
+                ))),
+                false,
+            ),
+        ]);
+
+        for field in schema.fields() {
+            let columns = vec![ColumnName::new([field.name()])];
+            let result = validate_clustering_columns(&schema, &columns);
+            assert!(
+                result.is_err(),
+                "Complex type {} should NOT be supported for clustering",
+                field.data_type()
+            );
+            assert!(result.unwrap_err().to_string().contains("unsupported type"));
+        }
+    }
+
+    // Structural validation tests - parameterized with rstest
+
+    /// Test that the correct number of clustering columns is allowed.
+    #[rstest::rstest]
+    #[case::max_allowed(4, true)]
+    #[case::too_many(5, false)]
+    fn test_validate_clustering_column_count(
+        #[case] num_columns: usize,
+        #[case] should_succeed: bool,
+    ) {
+        let fields: Vec<StructField> = (0..num_columns)
+            .map(|i| StructField::new(format!("col{}", i), DataType::INTEGER, false))
+            .collect();
+        let schema = StructType::new_unchecked(fields);
+
+        let columns: Vec<ColumnName> = (0..num_columns)
+            .map(|i| ColumnName::new([format!("col{}", i)]))
+            .collect();
+
+        let result = validate_clustering_columns(&schema, &columns);
+        assert_eq!(result.is_ok(), should_succeed);
+        if !should_succeed {
+            assert!(result.unwrap_err().to_string().contains("at most"));
+        }
+    }
+
+    /// Test various structural validation error cases.
+    #[rstest::rstest]
+    #[case::empty_columns(vec![], "at least one column")]
+    #[case::duplicate_columns(vec!["id", "id"], "Duplicate clustering column")]
+    fn test_validate_clustering_structural_errors(
+        #[case] column_names: Vec<&str>,
+        #[case] expected_error: &str,
+    ) {
+        let schema =
+            StructType::new_unchecked(vec![StructField::new("id", DataType::INTEGER, false)]);
+        let columns: Vec<ColumnName> = column_names
+            .into_iter()
+            .map(|s| ColumnName::new([s]))
+            .collect();
+
+        let result = validate_clustering_columns(&schema, &columns);
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().to_string().contains(expected_error),
+            "Expected error containing '{}'",
+            expected_error
+        );
+    }
+
+    #[test]
+    fn test_validate_clustering_columns_empty_name_rejected() {
+        let schema =
+            StructType::new_unchecked(vec![StructField::new("id", DataType::INTEGER, false)]);
+        // Create a ColumnName with empty path (can't easily express in rstest case)
+        let columns: Vec<ColumnName> = vec![ColumnName::new(Vec::<String>::new())];
+        let result = validate_clustering_columns(&schema, &columns);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("cannot be empty"));
     }
 }

--- a/kernel/src/scan/data_skipping/stats_schema/mod.rs
+++ b/kernel/src/scan/data_skipping/stats_schema/mod.rs
@@ -329,12 +329,14 @@ impl<'a> SchemaTransform<'a> for MinMaxStatsTransform {
 
 /// Checks if a data type is eligible for min/max file skipping.
 ///
+/// This is also used to validate clustering column types, since clustering requires
+/// per-file statistics on clustering columns.
+///
 /// Note: Boolean and Binary are intentionally excluded as min/max statistics provide minimal
 /// skipping benefit for low-cardinality or opaque data types.
 ///
 /// See: <https://github.com/delta-io/delta/blob/143ab3337121248d2ca6a7d5bc31deae7c8fe4be/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java#L61>
-#[allow(unused)]
-fn is_skipping_eligible_datatype(data_type: &PrimitiveType) -> bool {
+pub(crate) fn is_skipping_eligible_datatype(data_type: &PrimitiveType) -> bool {
     matches!(
         data_type,
         &PrimitiveType::Byte

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -584,6 +584,7 @@ impl Snapshot {
     /// clustering metadata is malformed.
     ///
     /// Note that this method performs log replay (fetches and processes metadata from storage).
+    #[internal_api]
     pub(crate) fn get_clustering_columns(
         &self,
         engine: &dyn Engine,

--- a/kernel/src/transaction/data_layout.rs
+++ b/kernel/src/transaction/data_layout.rs
@@ -1,0 +1,96 @@
+//! Data layout configuration for Delta tables.
+//!
+//! This module defines [`DataLayout`] which specifies how data files are organized
+//! within a Delta table. Supported layouts are:
+//!
+//! - **None**: No special organization (default)
+//! - **Clustered**: Data files optimized for queries on clustering columns
+
+// Allow unreachable_pub because this module is pub when internal-api is enabled
+// but pub(crate) otherwise. The items need to be pub for the public API.
+#![allow(unreachable_pub)]
+#![allow(dead_code)]
+
+use crate::expressions::ColumnName;
+
+/// Data layout configuration for a Delta table.
+///
+/// Determines how data files are organized within the table:
+///
+/// - [`DataLayout::None`]: No special organization (default)
+/// - [`DataLayout::Clustered`]: Data files optimized for queries on clustering columns
+///
+/// TODO(#1795): Add `Partitioned` variant for partition column support.
+#[derive(Debug, Clone, Default)]
+pub enum DataLayout {
+    /// No special data organization (default).
+    #[default]
+    None,
+
+    /// Data files optimized for queries on clustering columns.
+    ///
+    /// Clustering columns must be top-level columns in the schema.
+    /// Maximum of 4 columns allowed.
+    Clustered {
+        /// Columns to cluster by (in order).
+        columns: Vec<ColumnName>,
+    },
+}
+
+impl DataLayout {
+    /// Create a clustered layout with the given columns.
+    ///
+    /// This method constructs the layout without validation. Full validation
+    /// (column count, duplicates, schema compatibility, data types) is performed
+    /// during `CreateTableTransactionBuilder::build()` via `validate_clustering_columns()`.
+    ///
+    /// # Arguments
+    ///
+    /// * `columns` - Column names to cluster by.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let layout = DataLayout::clustered(["id", "timestamp"]);
+    /// ```
+    pub fn clustered<I, S>(columns: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let columns: Vec<ColumnName> = columns
+            .into_iter()
+            .map(|s| ColumnName::new([s.as_ref()]))
+            .collect();
+
+        DataLayout::Clustered { columns }
+    }
+
+    /// Returns true if this layout specifies clustering.
+    pub fn is_clustered(&self) -> bool {
+        matches!(self, DataLayout::Clustered { .. })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_clustered_layout_construction() {
+        let layout = DataLayout::clustered(["col1", "col2"]);
+        assert!(layout.is_clustered());
+        if let DataLayout::Clustered { columns } = layout {
+            assert_eq!(columns.len(), 2);
+        }
+    }
+
+    #[test]
+    fn test_default_layout() {
+        let layout = DataLayout::default();
+        assert!(!layout.is_clustered());
+    }
+
+    // Note: Validation tests (empty, too many, duplicates) are in clustering.rs
+    // since validate_clustering_columns() performs all validation at build time.
+}

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -48,6 +48,11 @@ pub mod create_table;
 #[cfg(not(feature = "internal-api"))]
 pub(crate) mod create_table;
 
+#[cfg(feature = "internal-api")]
+pub mod data_layout;
+#[cfg(not(feature = "internal-api"))]
+pub(crate) mod data_layout;
+
 /// Type alias for an iterator of [`EngineData`] results.
 pub(crate) type EngineDataResultIterator<'a> =
     Box<dyn Iterator<Item = DeltaResult<Box<dyn EngineData>>> + Send + 'a>;
@@ -363,6 +368,7 @@ impl Transaction {
         engine_info: String,
         committer: Box<dyn Committer>,
         system_domain_metadata: Vec<DomainMetadata>,
+        clustering_columns: Option<Vec<ColumnName>>,
     ) -> DeltaResult<Self> {
         // TODO(sanuj) Today transactions expect a read snapshot to be passed in and we pass
         // in the pre_commit_snapshot for CREATE. To support other operations such as ALTERs
@@ -389,10 +395,7 @@ impl Transaction {
             user_domain_removals: vec![],
             data_change: true,
             dv_matched_files: vec![],
-            // TODO: For CREATE TABLE with clustering, clustering columns should be passed in here
-            // (e.g., from CreateTableTransactionBuilder) so that stats_schema() and stats_columns()
-            // return the correct columns for the new table.
-            clustering_columns: None,
+            clustering_columns,
         })
     }
 

--- a/kernel/tests/create_table.rs
+++ b/kernel/tests/create_table.rs
@@ -11,17 +11,19 @@ use delta_kernel::table_features::{
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::DeltaResult;
 use serde_json::Value;
-use tempfile::tempdir;
-use test_utils::{assert_result_error_with_message, create_default_engine};
+use test_utils::{assert_result_error_with_message, test_table_setup};
+
+/// Helper to create a simple two-column schema for tests.
+fn simple_schema() -> DeltaResult<Arc<StructType>> {
+    Ok(Arc::new(StructType::try_new(vec![
+        StructField::new("id", DataType::INTEGER, false),
+        StructField::new("value", DataType::STRING, true),
+    ])?))
+}
 
 #[tokio::test]
 async fn test_create_simple_table() -> DeltaResult<()> {
-    // Setup
-    let temp_dir = tempdir().expect("Failed to create temp dir");
-    let table_path = temp_dir.path().to_str().expect("Invalid path").to_string();
-
-    let engine =
-        create_default_engine(&url::Url::from_directory_path(&table_path).expect("Invalid URL"))?;
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
 
     // Create schema for an events table
     let schema = Arc::new(StructType::try_new(vec![
@@ -33,7 +35,7 @@ async fn test_create_simple_table() -> DeltaResult<()> {
     ])?);
 
     // Create table using new API
-    let _result = create_table(&table_path, schema.clone(), "DeltaKernel-RS/0.17.0")
+    let _ = create_table(&table_path, schema.clone(), "DeltaKernel-RS/0.17.0")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
@@ -44,30 +46,19 @@ async fn test_create_simple_table() -> DeltaResult<()> {
     assert_eq!(snapshot.version(), 0);
     assert_eq!(snapshot.schema().fields().len(), 5);
 
-    // Verify protocol versions are (3, 7) by reading the log file
-    let log_file_path = format!("{}/_delta_log/00000000000000000000.json", table_path);
-    let log_contents = std::fs::read_to_string(&log_file_path).expect("Failed to read log file");
-    let actions: Vec<Value> = log_contents
-        .lines()
-        .map(|line| serde_json::from_str(line).expect("Failed to parse JSON"))
-        .collect();
-
-    let protocol_action = actions
-        .iter()
-        .find(|a| a.get("protocol").is_some())
-        .expect("Protocol action not found");
-    let protocol = protocol_action.get("protocol").unwrap();
+    // Verify protocol versions via snapshot
+    let protocol = snapshot.table_configuration().protocol();
     assert_eq!(
-        protocol["minReaderVersion"],
+        protocol.min_reader_version(),
         TABLE_FEATURES_MIN_READER_VERSION
     );
     assert_eq!(
-        protocol["minWriterVersion"],
+        protocol.min_writer_version(),
         TABLE_FEATURES_MIN_WRITER_VERSION
     );
-    // Verify no reader/writer features are set (empty arrays for table features mode)
-    assert_eq!(protocol["readerFeatures"], Value::Array(vec![]));
-    assert_eq!(protocol["writerFeatures"], Value::Array(vec![]));
+    // Verify no reader/writer features are set (empty for table features mode)
+    assert!(protocol.reader_features().is_some_and(|f| f.is_empty()));
+    assert!(protocol.writer_features().is_some_and(|f| f.is_empty()));
 
     // Verify no table properties are set via public API
     use delta_kernel::table_properties::TableProperties;
@@ -89,13 +80,60 @@ async fn test_create_simple_table() -> DeltaResult<()> {
 }
 
 #[tokio::test]
-async fn test_create_table_already_exists() -> DeltaResult<()> {
-    // Setup
-    let temp_dir = tempdir().expect("Failed to create temp dir");
-    let table_path = temp_dir.path().to_str().expect("Invalid path").to_string();
+async fn test_create_table_with_user_domain_metadata() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
 
-    let engine =
-        create_default_engine(&url::Url::from_directory_path(&table_path).expect("Invalid URL"))?;
+    let schema = simple_schema()?;
+
+    // Create table with domainMetadata feature enabled
+    let txn = create_table(&table_path, schema, "Test/1.0")
+        .with_table_properties([("delta.feature.domainMetadata", "supported")])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
+
+    // Add user domain metadata during table creation
+    let domain = "app.settings";
+    let config = r#"{"version": 1, "enabled": true}"#;
+
+    let _ = txn
+        .with_domain_metadata(domain.to_string(), config.to_string())
+        .commit(engine.as_ref())?;
+
+    // Load snapshot and verify domain metadata was persisted
+    let table_url = delta_kernel::try_parse_uri(&table_path)?;
+    let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+
+    // Verify domainMetadata feature is enabled in protocol
+    use delta_kernel::table_features::TableFeature;
+    assert!(
+        snapshot
+            .table_configuration()
+            .is_feature_supported(&TableFeature::DomainMetadata),
+        "DomainMetadata feature should be enabled"
+    );
+
+    // Verify domain metadata string was persisted correctly
+    let retrieved_config = snapshot.get_domain_metadata(domain, engine.as_ref())?;
+    assert_eq!(
+        retrieved_config,
+        Some(config.to_string()),
+        "Domain metadata should be persisted and retrievable"
+    );
+
+    // Parse and verify the JSON contents
+    let parsed: Value = serde_json::from_str(retrieved_config.as_ref().unwrap())?;
+    assert_eq!(parsed["version"], 1);
+    assert_eq!(parsed["enabled"], true);
+
+    // Verify non-existent domain returns None
+    let missing = snapshot.get_domain_metadata("nonexistent.domain", engine.as_ref())?;
+    assert!(missing.is_none(), "Non-existent domain should return None");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_create_table_already_exists() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
 
     // Create schema for a user profiles table
     let schema = Arc::new(StructType::try_new(vec![
@@ -107,7 +145,7 @@ async fn test_create_table_already_exists() -> DeltaResult<()> {
     ])?);
 
     // Create table first time
-    let _result = create_table(&table_path, schema.clone(), "UserManagementService/1.2.0")
+    let _ = create_table(&table_path, schema.clone(), "UserManagementService/1.2.0")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
@@ -122,12 +160,7 @@ async fn test_create_table_already_exists() -> DeltaResult<()> {
 
 #[tokio::test]
 async fn test_create_table_empty_schema_not_supported() -> DeltaResult<()> {
-    // Setup
-    let temp_dir = tempdir().expect("Failed to create temp dir");
-    let table_path = temp_dir.path().to_str().expect("Invalid path").to_string();
-
-    let engine =
-        create_default_engine(&url::Url::from_directory_path(&table_path).expect("Invalid URL"))?;
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
 
     // Create empty schema
     let schema = Arc::new(StructType::try_new(vec![])?);
@@ -143,12 +176,7 @@ async fn test_create_table_empty_schema_not_supported() -> DeltaResult<()> {
 
 #[tokio::test]
 async fn test_create_table_log_actions() -> DeltaResult<()> {
-    // Setup
-    let temp_dir = tempdir().expect("Failed to create temp dir");
-    let table_path = temp_dir.path().to_str().expect("Invalid path").to_string();
-
-    let engine =
-        create_default_engine(&url::Url::from_directory_path(&table_path).expect("Invalid URL"))?;
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
 
     // Create schema
     let schema = Arc::new(StructType::try_new(vec![
@@ -259,6 +287,189 @@ async fn test_create_table_log_actions() -> DeltaResult<()> {
     assert!(
         kernel_version.unwrap().as_str().unwrap().starts_with("v"),
         "Kernel version should start with 'v'"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_create_clustered_table() -> DeltaResult<()> {
+    use delta_kernel::expressions::ColumnName;
+    use delta_kernel::table_features::TableFeature;
+    use delta_kernel::transaction::data_layout::DataLayout;
+
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    // Create schema for a clustered table
+    let schema = Arc::new(StructType::try_new(vec![
+        StructField::new("id", DataType::INTEGER, false),
+        StructField::new("name", DataType::STRING, true),
+        StructField::new("timestamp", DataType::TIMESTAMP, false),
+    ])?);
+
+    // Create clustered table on "id" column
+    let txn = create_table(&table_path, schema.clone(), "DeltaKernel-RS/Test")
+        .with_data_layout(DataLayout::clustered(["id"]))
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
+
+    // Verify stats_columns includes the clustering column
+    let stats_cols = txn.stats_columns();
+    assert!(
+        stats_cols.iter().any(|c| c.to_string() == "id"),
+        "Clustering column 'id' should be in stats columns"
+    );
+
+    // Commit the table
+    let _ = txn.commit(engine.as_ref())?;
+
+    // Verify clustering columns via snapshot read path
+    let table_url = delta_kernel::try_parse_uri(&table_path)?;
+    let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+
+    let clustering_columns = snapshot.get_clustering_columns(engine.as_ref())?;
+    assert_eq!(clustering_columns, Some(vec![ColumnName::new(["id"])]));
+
+    // Verify protocol has required features
+    let table_configuration = snapshot.table_configuration();
+    assert!(
+        table_configuration.is_feature_supported(&TableFeature::DomainMetadata),
+        "Protocol should support domainMetadata feature"
+    );
+    assert!(
+        table_configuration.is_feature_supported(&TableFeature::ClusteredTable),
+        "Protocol should support clustering feature"
+    );
+
+    Ok(())
+}
+
+/// Test that combining explicit feature signals with auto-enabled features doesn't create duplicates.
+///
+/// This tests the edge case where a user provides `delta.feature.domainMetadata=supported`
+/// AND uses `DataLayout::Clustered`. Both would try to add DomainMetadata, but we should
+/// only have it once in the feature lists.
+#[tokio::test]
+async fn test_clustering_with_explicit_feature_signal_no_duplicates() -> DeltaResult<()> {
+    use delta_kernel::expressions::ColumnName;
+    use delta_kernel::table_features::TableFeature;
+    use delta_kernel::transaction::data_layout::DataLayout;
+
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    let schema = simple_schema()?;
+
+    // Combine BOTH: explicit feature signal AND clustering (which auto-adds domainMetadata)
+    let _ = create_table(&table_path, schema, "Test/1.0")
+        .with_table_properties([("delta.feature.domainMetadata", "supported")])
+        .with_data_layout(DataLayout::clustered(["id"]))
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?;
+
+    // Read back using kernel APIs and verify no duplicate features
+    let table_url = delta_kernel::try_parse_uri(&table_path)?;
+    let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+    let protocol = snapshot.table_configuration().protocol();
+    let writer_features = protocol
+        .writer_features()
+        .expect("Writer features should exist");
+
+    // Count occurrences of DomainMetadata - should be exactly 1, not 2
+    let domain_metadata_count = writer_features
+        .iter()
+        .filter(|f| **f == TableFeature::DomainMetadata)
+        .count();
+
+    assert_eq!(
+        domain_metadata_count, 1,
+        "domainMetadata should appear exactly once, not {} times (duplicate detected!)",
+        domain_metadata_count
+    );
+
+    // Verify clustering columns via snapshot read path
+    let clustering_columns = snapshot.get_clustering_columns(engine.as_ref())?;
+    assert_eq!(clustering_columns, Some(vec![ColumnName::new(["id"])]));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_clustering_stats_columns_within_limit() -> DeltaResult<()> {
+    use delta_kernel::transaction::data_layout::DataLayout;
+
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    // Build schema with 10 columns (cluster on column 5, within default 32 limit)
+    let fields: Vec<StructField> = (0..10)
+        .map(|i| StructField::new(format!("col{}", i), DataType::INTEGER, true))
+        .collect();
+    let schema = Arc::new(StructType::try_new(fields)?);
+
+    // Create clustered table on col5
+    let txn = create_table(&table_path, schema, "Test/1.0")
+        .with_data_layout(DataLayout::clustered(["col5"]))
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
+
+    // Verify stats_columns includes the clustering column
+    let stats_cols = txn.stats_columns();
+    assert!(
+        stats_cols.iter().any(|c| c.to_string() == "col5"),
+        "Clustering column col5 should be in stats columns"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_clustering_stats_columns_beyond_limit() -> DeltaResult<()> {
+    use delta_kernel::transaction::data_layout::DataLayout;
+
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    // Build schema with 40 columns (cluster on column 35, beyond default 32 limit)
+    let fields: Vec<StructField> = (0..40)
+        .map(|i| StructField::new(format!("col{}", i), DataType::INTEGER, true))
+        .collect();
+    let schema = Arc::new(StructType::try_new(fields)?);
+
+    // Create clustered table on col35 (position > 32)
+    let txn = create_table(&table_path, schema, "Test/1.0")
+        .with_data_layout(DataLayout::clustered(["col35"]))
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
+
+    // Verify stats_columns includes the clustering column even beyond limit
+    let stats_cols = txn.stats_columns();
+    assert!(
+        stats_cols.iter().any(|c| c.to_string() == "col35"),
+        "Clustering column col35 should be in stats columns even beyond DEFAULT_NUM_INDEXED_COLS"
+    );
+
+    // Verify we have exactly 33 stats columns: first 32 + col35
+    // (col35 is added in Pass 2 of collect_columns)
+    assert_eq!(
+        stats_cols.len(),
+        33,
+        "Should have 32 indexed cols + 1 clustering col"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_clustering_column_not_in_schema() -> DeltaResult<()> {
+    use delta_kernel::transaction::data_layout::DataLayout;
+
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    let schema = simple_schema()?;
+
+    // Try to create clustered table on non-existent column
+    let result = create_table(&table_path, schema, "Test/1.0")
+        .with_data_layout(DataLayout::clustered(["nonexistent"]))
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()));
+
+    assert_result_error_with_message(
+        result,
+        "Clustering column 'nonexistent' not found in schema",
     );
 
     Ok(())


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/1763/files) to review incremental changes.
- [**stack/create_table_simple_clustering**](https://github.com/delta-io/delta-kernel-rs/pull/1763) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1763/files)]
  - [stack/create_table_simple_cm](https://github.com/delta-io/delta-kernel-rs/pull/1764) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1764/files/a374a1a02ec34996e4f629a807966ed2f0a6065a..417bf953ee0d53d6396e838363b4248edec86054)]

---------
## What changes are proposed in this pull request?

This adds the ability to create clustered Delta tables using the
`with_data_layout(DataLayout::Clustered { columns })` API.

Key changes:
- Add DataLayout enum with None and Clustered variants
- Add with_data_layout() method to CreateTableTransactionBuilder
- Implement support_clustering_for_table_create() for validation and
  domain metadata creation
- Update Transaction::try_new_create_table() to accept clustering columns
- Allowlist TableFeature::DomainMetadata for CREATE TABLE
- Add unit tests for clustering validation
- Add integration tests for clustered table creation and stats columns

Clustering columns are validated to:
- Exist in the schema
- Be top-level (not nested)
- Have at most 4 columns (MAX_CLUSTERING_COLUMNS)
- The clustering columns are passed to Transaction so stats_columns()
correctly includes them regardless of schema position.

## How was this change tested?
Unit and integration tests

