### PR TITLE
feat: Add column mapping support for CREATE TABLE

### DIFF
--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -777,6 +777,30 @@ impl StructType {
         self.fields.len()
     }
 
+    /// Recursively counts all [`StructField`] nodes in this schema tree.
+    ///
+    /// This includes nested struct fields (inside Struct, Array, and Map types) but does not
+    /// count Array/Map containers themselves. This matches the traversal pattern used by
+    /// `assign_column_mapping_metadata` when assigning column IDs, so the result equals the
+    /// expected `delta.columnMapping.maxColumnId` for a newly created table.
+    #[allow(unused)] // Only used by integration tests (create_table/column_mapping.rs)
+    #[internal_api]
+    pub(crate) fn total_struct_fields(&self) -> usize {
+        fn count_data_type(dt: &DataType) -> usize {
+            match dt {
+                DataType::Struct(inner) => inner.total_struct_fields(),
+                DataType::Array(array) => count_data_type(array.element_type()),
+                DataType::Map(map) => {
+                    count_data_type(map.key_type()) + count_data_type(map.value_type())
+                }
+                _ => 0,
+            }
+        }
+        self.fields()
+            .map(|field| 1 + count_data_type(field.data_type()))
+            .sum()
+    }
+
     /// Gets a reference to the metadata column with the given spec.
     pub fn metadata_column(&self, spec: &MetadataColumnSpec) -> Option<&StructField> {
         self.metadata_columns

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -1,16 +1,23 @@
 //! Code to handle column mapping, including modes and schema transforms
+//!
+//! This module provides:
+//! - Read-side: Mode detection and schema validation
+//! - Write-side: Schema transformation for assigning IDs and physical names
 use super::TableFeature;
 use crate::actions::Protocol;
 use crate::schema::{
-    ColumnName, DataType, MetadataValue, Schema, SchemaTransform, StructField, StructType,
+    ArrayType, ColumnMetadataKey, ColumnName, DataType, MapType, MetadataValue, Schema,
+    SchemaTransform, StructField, StructType,
 };
-use crate::table_properties::TableProperties;
+use crate::table_properties::{TableProperties, COLUMN_MAPPING_MODE};
 use crate::{DeltaResult, Error};
 
 use std::borrow::Cow;
+use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 use strum::EnumString;
+use uuid::Uuid;
 
 /// Modes of column mapping a table can be in
 #[derive(Debug, EnumString, Serialize, Deserialize, Copy, Clone, PartialEq, Eq)]
@@ -160,11 +167,161 @@ impl<'a> SchemaTransform<'a> for ValidateColumnMappings<'a> {
     }
 }
 
+// ============================================================================
+// Write-side column mapping functions
+// ============================================================================
+
+/// Get the column mapping mode from a table properties map.
+///
+/// This is used during table creation when we have raw properties from the builder,
+/// not yet converted to [`TableProperties`].
+///
+/// Returns `ColumnMappingMode::None` if the property is not set.
+pub(crate) fn get_column_mapping_mode_from_properties(
+    properties: &HashMap<String, String>,
+) -> DeltaResult<ColumnMappingMode> {
+    match properties.get(COLUMN_MAPPING_MODE) {
+        Some(mode_str) => mode_str.parse::<ColumnMappingMode>().map_err(|_| {
+            Error::generic(format!(
+                "Invalid column mapping mode '{}'. Must be one of: none, name, id",
+                mode_str
+            ))
+        }),
+        None => Ok(ColumnMappingMode::None),
+    }
+}
+
+/// Assigns column mapping metadata (id and physicalName) to all fields in a schema.
+///
+/// This function recursively processes all fields in the schema, including nested structs,
+/// arrays, and maps. Each field is assigned a new unique ID and physical name.
+///
+/// Fields with pre-existing column mapping metadata (id or physicalName) are rejected
+/// to avoid conflicts. ALTER TABLE will need different handling in the future.
+///
+/// # Arguments
+///
+/// * `schema` - The schema to transform
+/// * `max_id` - Tracks the highest column ID assigned. Updated in place. Should be initialized
+///   to 0 for a new table.
+///
+/// # Returns
+///
+/// A new schema with column mapping metadata on all fields.
+pub(crate) fn assign_column_mapping_metadata(
+    schema: &StructType,
+    max_id: &mut i64,
+) -> DeltaResult<StructType> {
+    let new_fields: Vec<StructField> = schema
+        .fields()
+        .map(|field| assign_field_column_mapping(field, max_id))
+        .collect::<DeltaResult<Vec<_>>>()?;
+
+    StructType::try_new(new_fields)
+}
+
+/// Assigns column mapping metadata to a single field, recursively processing nested types.
+///
+/// Rejects fields with pre-existing column mapping metadata. Otherwise, assigns a new
+/// unique ID and physical name (incrementing `max_id`).
+fn assign_field_column_mapping(field: &StructField, max_id: &mut i64) -> DeltaResult<StructField> {
+    let has_id = field
+        .get_config_value(&ColumnMetadataKey::ColumnMappingId)
+        .is_some();
+    let has_physical_name = field
+        .get_config_value(&ColumnMetadataKey::ColumnMappingPhysicalName)
+        .is_some();
+
+    // For CREATE TABLE, reject any pre-existing column mapping metadata.
+    // This avoids conflicts between user-provided IDs/physical names and the ones we assign.
+    // ALTER TABLE (adding columns) will need different handling in the future.
+    // TODO: Also check for nested column IDs (`delta.columnMapping.nested.ids`) once
+    // Iceberg compatibility (IcebergCompatV2+) is supported. See issue #1125.
+    if has_id || has_physical_name {
+        return Err(Error::generic(format!(
+            "Field '{}' already has column mapping metadata. \
+             Pre-existing column mapping metadata is not supported for CREATE TABLE.",
+            field.name
+        )));
+    }
+
+    // Start with the existing field and assign new ID
+    let mut new_field = field.clone();
+    *max_id += 1;
+    new_field.metadata.insert(
+        ColumnMetadataKey::ColumnMappingId.as_ref().to_string(),
+        MetadataValue::Number(*max_id),
+    );
+
+    // Assign physical name
+    let physical_name = format!("col-{}", Uuid::new_v4());
+    new_field.metadata.insert(
+        ColumnMetadataKey::ColumnMappingPhysicalName
+            .as_ref()
+            .to_string(),
+        MetadataValue::String(physical_name),
+    );
+
+    // Recursively process nested types
+    new_field.data_type = process_nested_data_type(&field.data_type, max_id)?;
+
+    Ok(new_field)
+}
+
+/// Process nested data types to assign column mapping metadata to any nested struct fields.
+fn process_nested_data_type(data_type: &DataType, max_id: &mut i64) -> DeltaResult<DataType> {
+    match data_type {
+        DataType::Struct(inner) => {
+            let new_inner = assign_column_mapping_metadata(inner, max_id)?;
+            Ok(DataType::Struct(Box::new(new_inner)))
+        }
+        DataType::Array(array_type) => {
+            let new_element_type = process_nested_data_type(array_type.element_type(), max_id)?;
+            Ok(DataType::Array(Box::new(ArrayType::new(
+                new_element_type,
+                array_type.contains_null(),
+            ))))
+        }
+        DataType::Map(map_type) => {
+            let new_key_type = process_nested_data_type(map_type.key_type(), max_id)?;
+            let new_value_type = process_nested_data_type(map_type.value_type(), max_id)?;
+            Ok(DataType::Map(Box::new(MapType::new(
+                new_key_type,
+                new_value_type,
+                map_type.value_contains_null(),
+            ))))
+        }
+        // Primitive and Variant types don't contain nested struct fields - return as-is
+        DataType::Primitive(_) | DataType::Variant(_) => Ok(data_type.clone()),
+    }
+}
+
+/// Resolves a clustering column's logical name to its physical name using column mapping metadata.
+///
+/// Uses [`StructField::physical_name`] to resolve the name based on the column mapping mode.
+/// When column mapping is disabled (mode = None), returns the logical name. When enabled,
+/// returns the physical name from the field's metadata.
+///
+/// This function only handles top-level columns. Note: the top-level restriction for
+/// clustering columns is an opinionated choice (matching delta-spark behavior), not a
+/// requirement of the Delta protocol itself.
+pub(crate) fn get_top_level_column_physical_name(
+    logical_name: &str,
+    schema: &StructType,
+    mode: ColumnMappingMode,
+) -> DeltaResult<String> {
+    let field = schema
+        .field(logical_name)
+        .ok_or_else(|| Error::generic(format!("Column '{}' not found in schema", logical_name)))?;
+
+    Ok(field.physical_name(mode).to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::schema::StructType;
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
 
     #[test]
     fn test_column_mapping_mode() {
@@ -353,5 +510,474 @@ mod tests {
         validate_schema_column_mapping(&schema, ColumnMappingMode::None).expect_err("field id");
         let schema = create_schema(None, None, None, "\"col-5f422f40\"");
         validate_schema_column_mapping(&schema, ColumnMappingMode::None).expect_err("field name");
+    }
+
+    // =========================================================================
+    // Tests for write-side column mapping functions
+    // =========================================================================
+
+    #[rstest::rstest]
+    #[case::no_property(None, Some(ColumnMappingMode::None))]
+    #[case::mode_name(Some("name"), Some(ColumnMappingMode::Name))]
+    #[case::mode_id(Some("id"), Some(ColumnMappingMode::Id))]
+    #[case::mode_none_explicit(Some("none"), Some(ColumnMappingMode::None))]
+    #[case::invalid_mode(Some("invalid"), None)]
+    fn test_get_column_mapping_mode_from_properties(
+        #[case] mode_str: Option<&str>,
+        #[case] expected: Option<ColumnMappingMode>,
+    ) {
+        let mut properties = HashMap::new();
+        if let Some(mode) = mode_str {
+            properties.insert(COLUMN_MAPPING_MODE.to_string(), mode.to_string());
+        }
+        match expected {
+            Some(mode) => assert_eq!(
+                get_column_mapping_mode_from_properties(&properties).unwrap(),
+                mode
+            ),
+            None => assert!(get_column_mapping_mode_from_properties(&properties).is_err()),
+        }
+    }
+
+    #[test]
+    fn test_assign_column_mapping_metadata_simple() {
+        use crate::schema::DataType;
+
+        let schema = StructType::new_unchecked([
+            StructField::new("a", DataType::INTEGER, false),
+            StructField::new("b", DataType::STRING, true),
+        ]);
+
+        let mut max_id = 0;
+        let result = assign_column_mapping_metadata(&schema, &mut max_id).unwrap();
+
+        // Should have assigned IDs 1 and 2
+        assert_eq!(max_id, 2);
+        assert_eq!(result.fields().count(), 2);
+
+        // Check both fields have metadata
+        for (i, field) in result.fields().enumerate() {
+            let expected_id = (i + 1) as i64;
+            assert_eq!(
+                field.get_config_value(&ColumnMetadataKey::ColumnMappingId),
+                Some(&MetadataValue::Number(expected_id))
+            );
+            assert!(field
+                .get_config_value(&ColumnMetadataKey::ColumnMappingPhysicalName)
+                .is_some());
+
+            // Verify physical name format (col-{uuid})
+            if let Some(MetadataValue::String(name)) =
+                field.get_config_value(&ColumnMetadataKey::ColumnMappingPhysicalName)
+            {
+                assert!(
+                    name.starts_with("col-"),
+                    "Physical name should start with 'col-'"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_assign_column_mapping_metadata_rejects_existing_id() {
+        use crate::schema::DataType;
+
+        // Schema with pre-existing column mapping metadata should be rejected
+        let schema = StructType::new_unchecked([
+            StructField::new("a", DataType::INTEGER, false).add_metadata([
+                (
+                    ColumnMetadataKey::ColumnMappingId.as_ref(),
+                    MetadataValue::Number(100),
+                ),
+                (
+                    ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
+                    MetadataValue::String("existing-physical".to_string()),
+                ),
+            ]),
+            StructField::new("b", DataType::STRING, true),
+        ]);
+
+        let mut max_id = 0;
+        let result = assign_column_mapping_metadata(&schema, &mut max_id);
+
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("already has column mapping metadata"),
+            "Expected error about existing column mapping metadata, got: {}",
+            err_msg
+        );
+    }
+
+    #[test]
+    fn test_assign_column_mapping_metadata_nested_struct() {
+        use crate::schema::DataType;
+
+        let inner = StructType::new_unchecked([
+            StructField::new("x", DataType::INTEGER, false),
+            StructField::new("y", DataType::STRING, true),
+        ]);
+
+        let schema = StructType::new_unchecked([
+            StructField::new("a", DataType::INTEGER, false),
+            StructField::new("nested", DataType::Struct(Box::new(inner)), true),
+        ]);
+
+        let mut max_id = 0;
+        let result = assign_column_mapping_metadata(&schema, &mut max_id).unwrap();
+
+        // Should have assigned IDs to all 4 fields
+        assert_eq!(max_id, 4);
+
+        let mut seen_ids = HashSet::new();
+        let mut seen_physical_names = HashSet::new();
+
+        // Check outer field 'a'
+        let field_a = result.field("a").unwrap();
+        assert_has_column_mapping_metadata(field_a, &mut seen_ids, &mut seen_physical_names);
+
+        // Check outer field 'nested'
+        let field_nested = result.field("nested").unwrap();
+        assert_has_column_mapping_metadata(field_nested, &mut seen_ids, &mut seen_physical_names);
+
+        // Check nested fields
+        let inner = unwrap_struct(&field_nested.data_type, "nested");
+        let field_x = inner.field("x").unwrap();
+        assert_has_column_mapping_metadata(field_x, &mut seen_ids, &mut seen_physical_names);
+        let field_y = inner.field("y").unwrap();
+        assert_has_column_mapping_metadata(field_y, &mut seen_ids, &mut seen_physical_names);
+
+        // All 4 fields should have unique IDs and physical names
+        assert_eq!(seen_ids.len(), 4);
+        assert_eq!(seen_physical_names.len(), 4);
+    }
+
+    // ========================================================================
+    // "Cursed" nested type tests - verify column mapping metadata is assigned
+    // correctly for complex nested structures (arrays, maps, deeply nested)
+    // ========================================================================
+
+    /// Helper to verify a struct field has column mapping metadata (id and physical name).
+    /// Also collects the id and physical name into the provided sets for uniqueness checking.
+    fn assert_has_column_mapping_metadata(
+        field: &StructField,
+        seen_ids: &mut HashSet<i64>,
+        seen_physical_names: &mut HashSet<String>,
+    ) {
+        let id = field
+            .get_config_value(&ColumnMetadataKey::ColumnMappingId)
+            .unwrap_or_else(|| panic!("Field '{}' should have column mapping ID", field.name));
+        let MetadataValue::Number(id_val) = id else {
+            panic!(
+                "Field '{}' column mapping ID should be a number",
+                field.name
+            );
+        };
+        assert!(
+            seen_ids.insert(*id_val),
+            "Duplicate column mapping ID {} on field '{}'",
+            id_val,
+            field.name
+        );
+
+        let physical = field
+            .get_config_value(&ColumnMetadataKey::ColumnMappingPhysicalName)
+            .unwrap_or_else(|| panic!("Field '{}' should have physical name", field.name));
+        let MetadataValue::String(physical_name) = physical else {
+            panic!("Field '{}' physical name should be a string", field.name);
+        };
+        assert!(
+            seen_physical_names.insert(physical_name.clone()),
+            "Duplicate physical name '{}' on field '{}'",
+            physical_name,
+            field.name
+        );
+    }
+
+    /// Helper to extract struct from a DataType, panicking with context if not a struct
+    fn unwrap_struct<'a>(data_type: &'a DataType, context: &str) -> &'a StructType {
+        match data_type {
+            DataType::Struct(s) => s,
+            _ => panic!("Expected Struct for {}, got {:?}", context, data_type),
+        }
+    }
+
+    #[test]
+    fn test_assign_column_mapping_metadata_map_with_struct_key_and_value() {
+        // Test: map<struct<k: int>, struct<v: int>>
+        // Both key and value are structs that need column mapping metadata
+        use crate::schema::DataType;
+
+        let key_struct =
+            StructType::new_unchecked([StructField::new("k", DataType::INTEGER, false)]);
+        let value_struct =
+            StructType::new_unchecked([StructField::new("v", DataType::INTEGER, false)]);
+
+        let map_type = MapType::new(
+            DataType::Struct(Box::new(key_struct)),
+            DataType::Struct(Box::new(value_struct)),
+            true,
+        );
+
+        let schema = StructType::new_unchecked([StructField::new(
+            "my_map",
+            DataType::Map(Box::new(map_type)),
+            true,
+        )]);
+
+        let mut max_id = 0;
+        let result = assign_column_mapping_metadata(&schema, &mut max_id).unwrap();
+
+        // Should assign IDs to: my_map (1), k (2), v (3)
+        assert_eq!(max_id, 3);
+
+        let mut seen_ids = HashSet::new();
+        let mut seen_physical_names = HashSet::new();
+
+        // Check top-level map field
+        let map_field = result.field("my_map").unwrap();
+        assert_has_column_mapping_metadata(map_field, &mut seen_ids, &mut seen_physical_names);
+
+        // Check key struct field
+        if let DataType::Map(inner_map) = &map_field.data_type {
+            let key_struct = unwrap_struct(inner_map.key_type(), "map key");
+            let field_k = key_struct.field("k").unwrap();
+            assert_has_column_mapping_metadata(field_k, &mut seen_ids, &mut seen_physical_names);
+
+            // Check value struct field
+            let value_struct = unwrap_struct(inner_map.value_type(), "map value");
+            let field_v = value_struct.field("v").unwrap();
+            assert_has_column_mapping_metadata(field_v, &mut seen_ids, &mut seen_physical_names);
+        } else {
+            panic!("Expected map type");
+        }
+
+        assert_eq!(seen_ids.len(), 3);
+        assert_eq!(seen_physical_names.len(), 3);
+    }
+
+    #[test]
+    fn test_assign_column_mapping_metadata_array_with_struct_element() {
+        // Test: array<struct<elem: int>>
+        use crate::schema::DataType;
+
+        let elem_struct =
+            StructType::new_unchecked([StructField::new("elem", DataType::INTEGER, false)]);
+
+        let array_type = ArrayType::new(DataType::Struct(Box::new(elem_struct)), true);
+
+        let schema = StructType::new_unchecked([StructField::new(
+            "my_array",
+            DataType::Array(Box::new(array_type)),
+            true,
+        )]);
+
+        let mut max_id = 0;
+        let result = assign_column_mapping_metadata(&schema, &mut max_id).unwrap();
+
+        // Should assign IDs to: my_array (1), elem (2)
+        assert_eq!(max_id, 2);
+
+        let mut seen_ids = HashSet::new();
+        let mut seen_physical_names = HashSet::new();
+
+        // Check top-level array field
+        let array_field = result.field("my_array").unwrap();
+        assert_has_column_mapping_metadata(array_field, &mut seen_ids, &mut seen_physical_names);
+
+        // Check element struct field
+        if let DataType::Array(inner_array) = &array_field.data_type {
+            let elem_struct = unwrap_struct(inner_array.element_type(), "array element");
+            let field_elem = elem_struct.field("elem").unwrap();
+            assert_has_column_mapping_metadata(field_elem, &mut seen_ids, &mut seen_physical_names);
+        } else {
+            panic!("Expected array type");
+        }
+
+        assert_eq!(seen_ids.len(), 2);
+        assert_eq!(seen_physical_names.len(), 2);
+    }
+
+    #[test]
+    fn test_assign_column_mapping_metadata_double_nested_array() {
+        // Test: array<array<struct<deep: int>>>
+        use crate::schema::DataType;
+
+        let deep_struct =
+            StructType::new_unchecked([StructField::new("deep", DataType::INTEGER, false)]);
+
+        let inner_array = ArrayType::new(DataType::Struct(Box::new(deep_struct)), true);
+        let outer_array = ArrayType::new(DataType::Array(Box::new(inner_array)), true);
+
+        let schema = StructType::new_unchecked([StructField::new(
+            "nested_arrays",
+            DataType::Array(Box::new(outer_array)),
+            true,
+        )]);
+
+        let mut max_id = 0;
+        let result = assign_column_mapping_metadata(&schema, &mut max_id).unwrap();
+
+        // Should assign IDs to: nested_arrays (1), deep (2)
+        assert_eq!(max_id, 2);
+
+        let mut seen_ids = HashSet::new();
+        let mut seen_physical_names = HashSet::new();
+
+        // Check top-level field
+        let outer_field = result.field("nested_arrays").unwrap();
+        assert_has_column_mapping_metadata(outer_field, &mut seen_ids, &mut seen_physical_names);
+
+        // Navigate: array -> array -> struct -> field
+        let DataType::Array(outer) = &outer_field.data_type else {
+            panic!("Expected outer array type");
+        };
+        let DataType::Array(inner) = outer.element_type() else {
+            panic!("Expected inner array type");
+        };
+        let deep_struct = unwrap_struct(inner.element_type(), "inner array element");
+        let field_deep = deep_struct.field("deep").unwrap();
+        assert_has_column_mapping_metadata(field_deep, &mut seen_ids, &mut seen_physical_names);
+
+        assert_eq!(seen_ids.len(), 2);
+        assert_eq!(seen_physical_names.len(), 2);
+    }
+
+    #[test]
+    fn test_assign_column_mapping_metadata_array_map_array_struct_nesting() {
+        // Test: array<map<array<struct<k: int>>, array<struct<v: int>>>>
+        // Deeply nested array-map-array-struct combination
+        use crate::schema::DataType;
+
+        let key_struct =
+            StructType::new_unchecked([StructField::new("k", DataType::INTEGER, false)]);
+        let value_struct =
+            StructType::new_unchecked([StructField::new("v", DataType::INTEGER, false)]);
+
+        let key_array = ArrayType::new(DataType::Struct(Box::new(key_struct)), true);
+        let value_array = ArrayType::new(DataType::Struct(Box::new(value_struct)), true);
+
+        let inner_map = MapType::new(
+            DataType::Array(Box::new(key_array)),
+            DataType::Array(Box::new(value_array)),
+            true,
+        );
+
+        let outer_array = ArrayType::new(DataType::Map(Box::new(inner_map)), true);
+
+        let schema = StructType::new_unchecked([StructField::new(
+            "cursed",
+            DataType::Array(Box::new(outer_array)),
+            true,
+        )]);
+
+        let mut max_id = 0;
+        let result = assign_column_mapping_metadata(&schema, &mut max_id).unwrap();
+
+        // Should assign IDs to: cursed (1), k (2), v (3)
+        assert_eq!(max_id, 3);
+
+        let mut seen_ids = HashSet::new();
+        let mut seen_physical_names = HashSet::new();
+
+        // Check top-level field
+        let cursed_field = result.field("cursed").unwrap();
+        assert_has_column_mapping_metadata(cursed_field, &mut seen_ids, &mut seen_physical_names);
+
+        // Navigate: array -> map -> key array -> struct -> field
+        //                        -> value array -> struct -> field
+        let DataType::Array(outer) = &cursed_field.data_type else {
+            panic!("Expected outer array type");
+        };
+        let DataType::Map(inner_map) = outer.element_type() else {
+            panic!("Expected map inside outer array");
+        };
+
+        // Check key path: array<struct<k>>
+        let DataType::Array(key_arr) = inner_map.key_type() else {
+            panic!("Expected array for map key");
+        };
+        let key_struct = unwrap_struct(key_arr.element_type(), "key array element");
+        let field_k = key_struct.field("k").unwrap();
+        assert_has_column_mapping_metadata(field_k, &mut seen_ids, &mut seen_physical_names);
+
+        // Check value path: array<struct<v>>
+        let DataType::Array(val_arr) = inner_map.value_type() else {
+            panic!("Expected array for map value");
+        };
+        let val_struct = unwrap_struct(val_arr.element_type(), "value array element");
+        let field_v = val_struct.field("v").unwrap();
+        assert_has_column_mapping_metadata(field_v, &mut seen_ids, &mut seen_physical_names);
+
+        assert_eq!(seen_ids.len(), 3);
+        assert_eq!(seen_physical_names.len(), 3);
+    }
+
+    #[test]
+    fn test_get_top_level_column_physical_name_no_mapping() {
+        use crate::schema::DataType;
+
+        let schema = StructType::new_unchecked([
+            StructField::new("a", DataType::INTEGER, false),
+            StructField::new("b", DataType::STRING, true),
+        ]);
+
+        let result =
+            get_top_level_column_physical_name("a", &schema, ColumnMappingMode::None).unwrap();
+
+        // Should return logical name as-is when column mapping is disabled
+        assert_eq!(result, "a");
+    }
+
+    #[test]
+    fn test_get_top_level_column_physical_name_with_mapping() {
+        use crate::schema::DataType;
+
+        let schema = StructType::new_unchecked([
+            StructField::new("a", DataType::INTEGER, false).add_metadata([
+                (
+                    ColumnMetadataKey::ColumnMappingId.as_ref(),
+                    MetadataValue::Number(1),
+                ),
+                (
+                    ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
+                    MetadataValue::String("col-abc123".to_string()),
+                ),
+            ]),
+            StructField::new("b", DataType::STRING, true).add_metadata([
+                (
+                    ColumnMetadataKey::ColumnMappingId.as_ref(),
+                    MetadataValue::Number(2),
+                ),
+                (
+                    ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
+                    MetadataValue::String("col-def456".to_string()),
+                ),
+            ]),
+        ]);
+
+        let result =
+            get_top_level_column_physical_name("a", &schema, ColumnMappingMode::Name).unwrap();
+
+        // Should return physical name
+        assert_eq!(result, "col-abc123");
+    }
+
+    #[test]
+    fn test_get_top_level_column_physical_name_not_found() {
+        use crate::schema::DataType;
+
+        let schema = StructType::new_unchecked([StructField::new("a", DataType::INTEGER, false)]);
+
+        let result =
+            get_top_level_column_physical_name("nonexistent", &schema, ColumnMappingMode::Name);
+
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("not found in schema"),
+            "Expected 'not found in schema' error, got: {}",
+            err_msg
+        );
     }
 }

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -10,7 +10,10 @@ use crate::table_properties::TableProperties;
 use crate::{DeltaResult, Error};
 use delta_kernel_derive::internal_api;
 
-pub(crate) use column_mapping::column_mapping_mode;
+pub(crate) use column_mapping::{
+    assign_column_mapping_metadata, column_mapping_mode, get_column_mapping_mode_from_properties,
+    get_top_level_column_physical_name,
+};
 pub use column_mapping::{validate_schema_column_mapping, ColumnMappingMode};
 pub(crate) use timestamp_ntz::validate_timestamp_ntz_feature_support;
 mod column_mapping;

--- a/kernel/src/table_properties.rs
+++ b/kernel/src/table_properties.rs
@@ -34,6 +34,7 @@ pub(crate) const CHECKPOINT_INTERVAL: &str = "delta.checkpointInterval";
 pub(crate) const CHECKPOINT_WRITE_STATS_AS_JSON: &str = "delta.checkpoint.writeStatsAsJson";
 pub(crate) const CHECKPOINT_WRITE_STATS_AS_STRUCT: &str = "delta.checkpoint.writeStatsAsStruct";
 pub(crate) const COLUMN_MAPPING_MODE: &str = "delta.columnMapping.mode";
+pub(crate) const COLUMN_MAPPING_MAX_COLUMN_ID: &str = "delta.columnMapping.maxColumnId";
 pub(crate) const DATA_SKIPPING_NUM_INDEXED_COLS: &str = "delta.dataSkippingNumIndexedCols";
 pub(crate) const DATA_SKIPPING_STATS_COLUMNS: &str = "delta.dataSkippingStatsColumns";
 pub(crate) const DELETED_FILE_RETENTION_DURATION: &str = "delta.deletedFileRetentionDuration";

--- a/kernel/tests/create_table/column_mapping.rs
+++ b/kernel/tests/create_table/column_mapping.rs
@@ -1,0 +1,472 @@
+//! Column Mapping integration tests for the CreateTable API.
+//!
+//! These tests use kernel's snapshot API to read back the table, which exercises
+//! the full column mapping validation path (via TableConfiguration::try_new ->
+//! validate_schema_column_mapping). This ensures the written schema is valid and
+//! readable by kernel.
+
+use std::sync::Arc;
+
+use delta_kernel::committer::FileSystemCommitter;
+use delta_kernel::schema::{
+    ArrayType, ColumnMetadataKey, DataType, MapType, StructField, StructType,
+};
+use delta_kernel::snapshot::Snapshot;
+use delta_kernel::table_features::{ColumnMappingMode, TableFeature};
+use delta_kernel::transaction::create_table::create_table;
+use delta_kernel::transaction::data_layout::DataLayout;
+use delta_kernel::DeltaResult;
+use test_utils::test_table_setup;
+
+use super::simple_schema;
+
+/// Helper to strip column mapping metadata (IDs and physical names) from all StructFields recursively.
+fn strip_column_mapping_metadata(schema: &StructType) -> StructType {
+    let cm_id = ColumnMetadataKey::ColumnMappingId.as_ref();
+    let cm_name = ColumnMetadataKey::ColumnMappingPhysicalName.as_ref();
+
+    fn strip_field(field: &StructField, cm_id: &str, cm_name: &str) -> StructField {
+        let mut metadata = field.metadata().clone();
+        metadata.remove(cm_id);
+        metadata.remove(cm_name);
+
+        let data_type = strip_data_type(field.data_type(), cm_id, cm_name);
+        StructField::new(field.name(), data_type, field.is_nullable()).with_metadata(metadata)
+    }
+
+    fn strip_data_type(dt: &DataType, cm_id: &str, cm_name: &str) -> DataType {
+        match dt {
+            DataType::Struct(s) => {
+                let fields: Vec<_> = s.fields().map(|f| strip_field(f, cm_id, cm_name)).collect();
+                DataType::Struct(Box::new(StructType::new_unchecked(fields)))
+            }
+            DataType::Array(a) => DataType::from(ArrayType::new(
+                strip_data_type(a.element_type(), cm_id, cm_name),
+                a.contains_null(),
+            )),
+            DataType::Map(m) => DataType::from(MapType::new(
+                strip_data_type(m.key_type(), cm_id, cm_name),
+                strip_data_type(m.value_type(), cm_id, cm_name),
+                m.value_contains_null(),
+            )),
+            other => other.clone(),
+        }
+    }
+
+    let fields: Vec<_> = schema
+        .fields()
+        .map(|f| strip_field(f, cm_id, cm_name))
+        .collect();
+    StructType::new_unchecked(fields)
+}
+
+/// Helper to create a table, load its snapshot, and return it for verification.
+fn create_table_and_load_snapshot(
+    table_path: &str,
+    schema: Arc<StructType>,
+    engine: &dyn delta_kernel::Engine,
+    properties: &[(&str, &str)],
+) -> DeltaResult<Arc<Snapshot>> {
+    let _ = create_table(table_path, schema, "Test/1.0")
+        .with_table_properties(properties.to_vec())
+        .build(engine, Box::new(FileSystemCommitter::new()))?
+        .commit(engine)?;
+
+    let table_url = delta_kernel::try_parse_uri(table_path)?;
+    Snapshot::builder_for(table_url).build(engine)
+}
+
+/// Assert column mapping configuration on a snapshot.
+///
+/// For `Name` / `Id`: feature supported & enabled, mode matches, `maxColumnId` equals
+/// the recursive field count.
+///
+/// For `None`: mode is `None`, no `maxColumnId`, and no column mapping metadata (IDs or
+/// physical names) on any field. Note: whether `ColumnMapping` appears in the protocol
+/// depends on whether the feature flag was explicitly set, so that check is left to the
+/// caller.
+fn assert_column_mapping_config(snapshot: &Snapshot, expected_mode: ColumnMappingMode) {
+    let table_config = snapshot.table_configuration();
+
+    assert_eq!(
+        table_config.column_mapping_mode(),
+        expected_mode,
+        "Column mapping mode mismatch"
+    );
+
+    match expected_mode {
+        ColumnMappingMode::Name | ColumnMappingMode::Id => {
+            assert!(
+                table_config.is_feature_supported(&TableFeature::ColumnMapping),
+                "Protocol should support columnMapping feature"
+            );
+            assert!(
+                table_config.is_feature_enabled(&TableFeature::ColumnMapping),
+                "ColumnMapping feature should be enabled"
+            );
+
+            let expected_max_id = snapshot.schema().total_struct_fields();
+            let max_id_str = expected_max_id.to_string();
+            let config = table_config.metadata().configuration();
+            assert_eq!(
+                config
+                    .get("delta.columnMapping.maxColumnId")
+                    .map(|s| s.as_str()),
+                Some(max_id_str.as_str()),
+                "maxColumnId should equal the total number of struct fields ({expected_max_id})"
+            );
+        }
+        ColumnMappingMode::None => {
+            // No maxColumnId property
+            let config = table_config.metadata().configuration();
+            assert!(
+                config.get("delta.columnMapping.maxColumnId").is_none(),
+                "maxColumnId should not be present when column mapping mode is None"
+            );
+
+            // No column mapping metadata on any field
+            for field in snapshot.schema().fields() {
+                assert!(
+                    field
+                        .get_config_value(&ColumnMetadataKey::ColumnMappingId)
+                        .is_none(),
+                    "Field '{}' should not have a column mapping ID when mode is None",
+                    field.name()
+                );
+                assert!(
+                    field
+                        .get_config_value(&ColumnMetadataKey::ColumnMappingPhysicalName)
+                        .is_none(),
+                    "Field '{}' should not have a physical name when mode is None",
+                    field.name()
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn test_create_table_with_column_mapping_name_mode() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    let schema = simple_schema()?;
+
+    // Create table and load snapshot (this validates column mapping annotations on read)
+    let snapshot = create_table_and_load_snapshot(
+        &table_path,
+        schema,
+        engine.as_ref(),
+        &[("delta.columnMapping.mode", "name")],
+    )?;
+
+    assert_column_mapping_config(&snapshot, ColumnMappingMode::Name);
+
+    // Verify schema preserves field names, types, and nullability
+    let read_schema = snapshot.schema();
+    assert_eq!(read_schema.fields().count(), 2);
+
+    let id_field = read_schema.field("id").expect("id field should exist");
+    assert_eq!(id_field.data_type(), &DataType::INTEGER);
+    assert!(!id_field.is_nullable());
+
+    let value_field = read_schema
+        .field("value")
+        .expect("value field should exist");
+    assert_eq!(value_field.data_type(), &DataType::STRING);
+    assert!(value_field.is_nullable());
+
+    Ok(())
+}
+
+#[test]
+fn test_create_table_with_column_mapping_id_mode() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    let schema = Arc::new(StructType::try_new(vec![StructField::new(
+        "id",
+        DataType::INTEGER,
+        false,
+    )])?);
+
+    // Create table and load snapshot (validates column mapping on read)
+    let snapshot = create_table_and_load_snapshot(
+        &table_path,
+        schema,
+        engine.as_ref(),
+        &[("delta.columnMapping.mode", "id")],
+    )?;
+
+    assert_column_mapping_config(&snapshot, ColumnMappingMode::Id);
+
+    // Verify schema
+    let read_schema = snapshot.schema();
+    assert_eq!(read_schema.fields().count(), 1);
+    let id_field = read_schema.field("id").expect("id field should exist");
+    assert_eq!(id_field.data_type(), &DataType::INTEGER);
+    assert!(!id_field.is_nullable());
+
+    Ok(())
+}
+
+#[test]
+fn test_column_mapping_mode_none_no_annotations() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    let schema = simple_schema()?;
+
+    // Create table WITHOUT column mapping and load snapshot
+    let snapshot = create_table_and_load_snapshot(&table_path, schema, engine.as_ref(), &[])?;
+
+    // Verify protocol does NOT have columnMapping feature
+    assert!(
+        !snapshot
+            .table_configuration()
+            .is_feature_supported(&TableFeature::ColumnMapping),
+        "Protocol should NOT have columnMapping feature when mode is not set"
+    );
+
+    // Verify no column mapping config (mode=None, no maxColumnId, no field metadata)
+    assert_column_mapping_config(&snapshot, ColumnMappingMode::None);
+
+    // Verify schema preserves fields
+    let read_schema = snapshot.schema();
+    assert_eq!(read_schema.fields().count(), 2);
+    assert!(read_schema.field("id").is_some());
+    assert!(read_schema.field("value").is_some());
+
+    Ok(())
+}
+
+/// Test: setting `delta.feature.columnMapping=supported` without a mode means the feature
+/// is in the protocol but column mapping is not active (mode resolves to `None`).
+/// The schema should NOT have column mapping IDs or physical names.
+#[test]
+fn test_column_mapping_feature_only_without_mode() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    let schema = simple_schema()?;
+
+    // Create table with ONLY the feature flag, no delta.columnMapping.mode
+    let _ = create_table(&table_path, schema, "Test/1.0")
+        .with_table_properties([("delta.feature.columnMapping", "supported")])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?;
+
+    let table_url = delta_kernel::try_parse_uri(&table_path)?;
+    let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+
+    // Feature IS in the protocol (the feature signal put it there)
+    assert!(
+        snapshot
+            .table_configuration()
+            .is_feature_supported(&TableFeature::ColumnMapping),
+        "Protocol should list columnMapping as a supported feature"
+    );
+
+    // But mode is None, no maxColumnId, no field metadata
+    assert_column_mapping_config(&snapshot, ColumnMappingMode::None);
+
+    Ok(())
+}
+
+#[test]
+fn test_column_mapping_invalid_mode_rejected() {
+    let (_temp_dir, table_path, engine) = test_table_setup().unwrap();
+
+    let schema = Arc::new(
+        StructType::try_new(vec![StructField::new("id", DataType::INTEGER, false)]).unwrap(),
+    );
+
+    // Try to create table with invalid column mapping mode
+    let result = create_table(&table_path, schema, "Test/1.0")
+        .with_table_properties([("delta.columnMapping.mode", "invalid")])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()));
+
+    assert!(result.is_err());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("Invalid column mapping mode"));
+}
+
+/// Test cases for clustering columns with column mapping enabled.
+/// Each case specifies: (logical_column_names, description)
+#[rstest::rstest]
+#[case::single_column(&["id"], "single clustering column")]
+#[case::multiple_columns(&["id", "value"], "multiple clustering columns")]
+#[test]
+fn test_create_clustered_table_with_column_mapping(
+    #[case] clustering_cols: &[&str],
+    #[case] description: &str,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    let schema = simple_schema()?;
+
+    // Create clustered table with column mapping enabled
+    let _ = create_table(&table_path, schema, "Test/1.0")
+        .with_table_properties([("delta.columnMapping.mode", "name")])
+        .with_data_layout(DataLayout::clustered(clustering_cols.iter().copied()))
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?;
+
+    // Load snapshot (validates column mapping annotations on read)
+    let table_url = delta_kernel::try_parse_uri(&table_path)?;
+    let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+
+    // Verify column mapping configuration
+    assert_column_mapping_config(&snapshot, ColumnMappingMode::Name);
+
+    // Verify clustering-specific features
+    let table_config = snapshot.table_configuration();
+    assert!(table_config.is_feature_supported(&TableFeature::ClusteredTable));
+    assert!(table_config.is_feature_supported(&TableFeature::DomainMetadata));
+
+    // Verify clustering domain metadata exists and uses physical column names
+    let clustering_columns = snapshot.get_clustering_columns(engine.as_ref())?;
+    let columns = clustering_columns.expect("Clustering columns should be present");
+    assert_eq!(
+        columns.len(),
+        clustering_cols.len(),
+        "{}: expected {} clustering columns, got {}",
+        description,
+        clustering_cols.len(),
+        columns.len()
+    );
+
+    // With column mapping enabled, clustering domain metadata stores physical names
+    for (i, col) in columns.iter().enumerate() {
+        let physical_name: &str = col.path()[0].as_ref();
+        let logical_name = clustering_cols[i];
+        assert!(
+            physical_name.starts_with("col-"),
+            "{}: clustering column {} should use physical name '{}', not logical name '{}'",
+            description,
+            i,
+            physical_name,
+            logical_name
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_column_mapping_nested_schema() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    // Create nested schema
+    let address_type = StructType::try_new(vec![
+        StructField::new("street", DataType::STRING, true),
+        StructField::new("city", DataType::STRING, true),
+    ])?;
+
+    let schema = Arc::new(StructType::try_new(vec![
+        StructField::new("id", DataType::INTEGER, false),
+        StructField::new("address", DataType::Struct(Box::new(address_type)), true),
+    ])?);
+
+    // Create table and load snapshot (validates column mapping for nested schema on read)
+    let snapshot = create_table_and_load_snapshot(
+        &table_path,
+        schema,
+        engine.as_ref(),
+        &[("delta.columnMapping.mode", "name")],
+    )?;
+
+    // Verify column mapping config (maxColumnId = 4: id, address, street, city)
+    assert_column_mapping_config(&snapshot, ColumnMappingMode::Name);
+
+    // Verify schema preserves the full nested structure
+    let read_schema = snapshot.schema();
+    assert_eq!(read_schema.fields().count(), 2);
+
+    // Verify top-level fields
+    let id_field = read_schema.field("id").expect("id field should exist");
+    assert_eq!(id_field.data_type(), &DataType::INTEGER);
+    assert!(!id_field.is_nullable());
+
+    let address_field = read_schema
+        .field("address")
+        .expect("address field should exist");
+    assert!(address_field.is_nullable());
+
+    // Verify nested struct fields are preserved
+    match address_field.data_type() {
+        DataType::Struct(nested) => {
+            assert_eq!(nested.fields().count(), 2);
+
+            let street = nested.field("street").expect("street field should exist");
+            assert_eq!(street.data_type(), &DataType::STRING);
+            assert!(street.is_nullable());
+
+            let city = nested.field("city").expect("city field should exist");
+            assert_eq!(city.data_type(), &DataType::STRING);
+            assert!(city.is_nullable());
+        }
+        other => panic!("Expected Struct type for address, got {:?}", other),
+    }
+
+    Ok(())
+}
+
+/// E2E test: create a table with column mapping on a schema containing map and array types,
+/// then read it back via snapshot and verify column mapping metadata survives the roundtrip.
+#[test]
+fn test_column_mapping_schema_with_maps_and_arrays() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    // Schema:
+    //   id: int (not null)
+    //   tags: map<string, string>
+    //   scores: array<int>
+    //   metadata: struct<
+    //     labels: map<string, array<int>>
+    //   >
+    let labels_type = MapType::new(
+        DataType::STRING,
+        ArrayType::new(DataType::INTEGER, true),
+        true,
+    );
+
+    let metadata_type = StructType::try_new(vec![StructField::new(
+        "labels",
+        DataType::from(labels_type),
+        true,
+    )])?;
+
+    let schema = Arc::new(StructType::try_new(vec![
+        StructField::new("id", DataType::INTEGER, false),
+        StructField::new(
+            "tags",
+            DataType::from(MapType::new(DataType::STRING, DataType::STRING, true)),
+            true,
+        ),
+        StructField::new(
+            "scores",
+            DataType::from(ArrayType::new(DataType::INTEGER, true)),
+            true,
+        ),
+        StructField::new("metadata", DataType::Struct(Box::new(metadata_type)), true),
+    ])?);
+
+    // Create table with column mapping and read back the snapshot.
+    // The snapshot read exercises validate_schema_column_mapping, which verifies
+    // that all fields (including map key/value, array element, and nested structs)
+    // have valid column mapping metadata.
+    let snapshot = create_table_and_load_snapshot(
+        &table_path,
+        schema.clone(),
+        engine.as_ref(),
+        &[("delta.columnMapping.mode", "name")],
+    )?;
+
+    // First verify column mapping annotations (IDs, physical names, maxColumnId, feature flags)
+    assert_column_mapping_config(&snapshot, ColumnMappingMode::Name);
+
+    // Then strip column mapping metadata and verify the schema structure matches the input.
+    let read_schema = strip_column_mapping_metadata(&snapshot.schema());
+    assert_eq!(&read_schema, schema.as_ref(), "Schema roundtrip mismatch");
+
+    Ok(())
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/1764/files) to review incremental changes.
- [**stack/create_table_simple_cm**](https://github.com/delta-io/delta-kernel-rs/pull/1764) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1764/files)]
  - [stack/ct_clustering_split](https://github.com/delta-io/delta-kernel-rs/pull/1828) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1828/files/e66edbcfbecf1726d67c5905b51899c9ccaf3038..1bf279276d7b11132679b5f746b41332e5934ee9)]

---------
## What changes are proposed in this pull request?

Implement column mapping support for table creation. When
`delta.columnMapping.mode` is set to "name" or "id", the schema is
transformed to add field annotations (id and physicalName), and
clustering uses physical column names in domain metadata.

Changes:
- Add write-side column mapping functions to column_mapping.rs:
  - get_column_mapping_mode_from_properties(): parse mode from properties
  - assign_column_mapping_metadata(): recursively assign IDs and physical
    names to all fields (including nested structs, arrays, maps)
  - resolve_logical_to_physical_path(): convert logical to physical names
- Add ColumnMapping to ALLOWED_DELTA_FEATURES and delta.columnMapping.mode
  to ALLOWED_DELTA_PROPERTIES
- Add maybe_apply_column_mapping_for_table_create() to conditionally
  transform schema and set maxColumnId
- Refactor clustering to maybe_enable_clustering() for cleaner build()
- When both column mapping and clustering are enabled, clustering domain
  metadata stores physical column names (survives column renames)

## How was this change tested?
- Unit tests for mode parsing, metadata assignment, path resolution
- Integration tests for column mapping with name/id modes
- Integration test for column mapping + clustering interaction
- Test for nested schema handling with column mapping