### PR TITLE
Fix get_app_id_version to take &self

### DIFF
--- a/ffi/src/transaction/transaction_id.rs
+++ b/ffi/src/transaction/transaction_id.rs
@@ -142,18 +142,9 @@ mod tests {
                 .build(&engine)?;
 
             // Check versions
-            assert_eq!(
-                snapshot.clone().get_app_id_version("app_id1", &engine)?,
-                Some(1)
-            );
-            assert_eq!(
-                snapshot.clone().get_app_id_version("app_id2", &engine)?,
-                Some(2)
-            );
-            assert_eq!(
-                snapshot.clone().get_app_id_version("app_id3", &engine)?,
-                None
-            );
+            assert_eq!(snapshot.get_app_id_version("app_id1", &engine)?, Some(1));
+            assert_eq!(snapshot.get_app_id_version("app_id2", &engine)?, Some(2));
+            assert_eq!(snapshot.get_app_id_version("app_id3", &engine)?, None);
 
             // Check versions through ffi handles
             let version1 = ok_or_panic(unsafe {

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -544,7 +544,7 @@ impl Snapshot {
     // TODO: add a get_app_id_versions to fetch all at once using SetTransactionScanner::get_all
     #[instrument(parent = &self.span, name = "snap.get_app_id_version", skip_all, err)]
     pub fn get_app_id_version(
-        self: Arc<Self>,
+        &self,
         application_id: &str,
         engine: &dyn Engine,
     ) -> DeltaResult<Option<i64>> {

--- a/kernel/tests/write.rs
+++ b/kernel/tests/write.rs
@@ -735,18 +735,9 @@ async fn test_write_txn_actions() -> Result<(), Box<dyn std::error::Error>> {
         let snapshot = Snapshot::builder_for(table_url.clone())
             .at_version(1)
             .build(&engine)?;
-        assert_eq!(
-            snapshot.clone().get_app_id_version("app_id1", &engine)?,
-            Some(1)
-        );
-        assert_eq!(
-            snapshot.clone().get_app_id_version("app_id2", &engine)?,
-            Some(2)
-        );
-        assert_eq!(
-            snapshot.clone().get_app_id_version("app_id3", &engine)?,
-            None
-        );
+        assert_eq!(snapshot.get_app_id_version("app_id1", &engine)?, Some(1));
+        assert_eq!(snapshot.get_app_id_version("app_id2", &engine)?, Some(2));
+        assert_eq!(snapshot.get_app_id_version("app_id3", &engine)?, None);
 
         let commit1 = store
             .get(&Path::from(format!(


### PR DESCRIPTION
Fixes delta-io/delta-kernel-rs#1677.

- Change `Snapshot::get_app_id_version` receiver from `self: Arc<Self>` to `&self`.
- Update call sites to avoid unnecessary `Arc::clone()`.

Tests:
- `cargo test -p delta_kernel --test write test_write_txn_actions`
- `cargo test -p delta_kernel_ffi`
