### PR TITLE
fix: Snapshot builder change URI validation

### DIFF
--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -96,7 +96,7 @@ impl Snapshot {
     /// Create a new [`SnapshotBuilder`] to build a new [`Snapshot`] for a given table root. If you
     /// instead have an existing [`Snapshot`] you would like to do minimal work to update, consider
     /// using
-    pub fn builder_for(table_root: Url) -> SnapshotBuilder {
+    pub fn builder_for(table_root: impl AsRef<str>) -> SnapshotBuilder {
         SnapshotBuilder::new_for(table_root)
     }
 

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -966,7 +966,8 @@ mod tests {
         assert_eq!(snapshot.schema(), expected);
     }
 
-    // TODO: unify this and lots of stuff in LogSegment tests and test_utils
+    // TODO: unify this and lots of stuff in LogSegment tests and test_utils.
+    // Also make this function take in the path of the delta table (currently only can commit to tables at the root directory).
     async fn commit(store: &InMemory, version: Version, commit: Vec<serde_json::Value>) {
         let commit_data = commit
             .iter()
@@ -1666,7 +1667,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_timestamp_enablement_version_in_future() -> DeltaResult<()> {
         // Test invalid state where snapshot has enablement version in the future - should error
-        let url = Url::parse("memory:///table2")?;
+        let url = Url::parse("memory:///")?;
         let store = Arc::new(InMemory::new());
         let engine = DefaultEngineBuilder::new(store.clone()).build();
 
@@ -1715,7 +1716,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_timestamp_missing_ict_when_enabled() -> DeltaResult<()> {
         // Test missing ICT when it should be present - should error
-        let url = Url::parse("memory:///table3")?;
+        let url = Url::parse("memory:///")?;
         let store = Arc::new(InMemory::new());
         let engine = DefaultEngineBuilder::new(store.clone()).build();
 
@@ -1747,7 +1748,7 @@ mod tests {
         // When ICT is enabled but commit file is not found in log segment,
         // get_in_commit_timestamp should return an error
 
-        let url = Url::parse("memory:///missing_commit_test")?;
+        let url = Url::parse("memory:///")?;
         let store = Arc::new(InMemory::new());
         let engine = DefaultEngineBuilder::new(store.clone()).build();
 
@@ -1802,7 +1803,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_timestamp_with_checkpoint_and_commit_same_version() -> DeltaResult<()> {
         // Test the scenario where both checkpoint and commit exist at the same version with ICT enabled.
-        let url = Url::parse("memory:///checkpoint_commit_test")?;
+        let url = Url::parse("memory:///")?;
         let store = Arc::new(InMemory::new());
         let engine = DefaultEngineBuilder::new(store.clone()).build();
 

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -181,6 +181,7 @@ mod tests {
         (engine, store, table_root)
     }
 
+    // TODO: update this function to properly store the table at table_root
     async fn create_table(store: &Arc<dyn ObjectStore>, _table_root: String) -> DeltaResult<()> {
         let protocol = json!({
             "minReaderVersion": 3,

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -181,7 +181,7 @@ mod tests {
         (engine, store, table_root)
     }
 
-    // TODO: update this function to properly store the table at table_root
+    // TODO (#1990): update this function to properly store the table at table_root
     async fn create_table(store: &Arc<dyn ObjectStore>, _table_root: String) -> DeltaResult<()> {
         let protocol = json!({
             "minReaderVersion": 3,

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -3,7 +3,8 @@ use crate::log_path::LogPath;
 use crate::log_segment::LogSegment;
 use crate::metrics::MetricId;
 use crate::snapshot::SnapshotRef;
-use crate::{try_parse_uri, DeltaResult, Engine, Error, Snapshot, Version};
+use crate::utils::try_parse_uri;
+use crate::{DeltaResult, Engine, Error, Snapshot, Version};
 
 use tracing::{info, instrument};
 

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -138,8 +138,7 @@ impl SnapshotBuilder {
 
     fn table_path(&self) -> &str {
         self.table_root
-            .as_ref()
-            .map(|u| u.as_str())
+            .as_deref()
             .or_else(|| {
                 self.existing_snapshot
                     .as_ref()
@@ -175,7 +174,7 @@ mod tests {
         Arc<dyn ObjectStore>,
         String,
     ) {
-        let table_root = String::from("memory:///test_table");
+        let table_root = String::from("memory:///");
         let store = Arc::new(InMemory::new());
         let engine = Arc::new(DefaultEngineBuilder::new(store.clone()).build());
         (engine, store, table_root)

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -215,7 +215,7 @@ pub fn compacted_log_path_for_versions(start_version: u64, end_version: u64, suf
     Path::from(path.as_str())
 }
 
-// TODO: make this function take in the path of the delta table (currently only can commit to tables at the root directory).
+// TODO (#1990): make this function take in the path of the delta table (currently only can commit to tables at the root directory).
 /// put a commit file into the specified object store.
 pub async fn add_commit(
     store: &dyn ObjectStore,

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -215,6 +215,7 @@ pub fn compacted_log_path_for_versions(start_version: u64, end_version: u64, suf
     Path::from(path.as_str())
 }
 
+// TODO: make this function take in the path of the delta table (currently only can commit to tables at the root directory).
 /// put a commit file into the specified object store.
 pub async fn add_commit(
     store: &dyn ObjectStore,


### PR DESCRIPTION
## What changes are proposed in this pull request?
This change addresses issue #1765 by changing the SnapshotBuilder to take any struct implementing AsRef<str> and verifying / parsing the passed in argument to ensure it is a valid table / directory rather than assuming the passed URL is a valid folder. This verification is done using the already defined utility function [try_parse_uri](https://github.com/delta-io/delta-kernel-rs/blob/main/kernel/src/utils.rs#L27).

### This PR affects the following public APIs
While this will change the exact type that can be passed into `SnapshotBuilder::new_from` and `Snapshot::builder_for` users can still pass in a URL as it implements [AsRef<str>](https://docs.rs/url/latest/url/struct.Url.html#impl-AsRef%3Cstr%3E-for-Url); however, now there will be verification on the URL that they pass in is a directory.

## How was this change tested?
This was ran against all previously written snapshot tests and passes all of the same tests as the previous implementation.