### PR TITLE
refactor: extract protocol & metadata replay into log_segment submodule

### DIFF
--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -6,10 +6,7 @@ use std::sync::{Arc, LazyLock};
 use std::time::Instant;
 
 use crate::actions::visitors::SidecarVisitor;
-use crate::actions::{
-    get_commit_schema, schema_contains_file_actions, Metadata, Protocol, Sidecar, METADATA_NAME,
-    PROTOCOL_NAME, SIDECAR_NAME,
-};
+use crate::actions::{schema_contains_file_actions, Sidecar, SIDECAR_NAME};
 use crate::committer::CatalogCommit;
 use crate::last_checkpoint_hint::LastCheckpointHint;
 use crate::log_reader::commit::CommitReader;
@@ -19,8 +16,8 @@ use crate::path::{LogPathFileType, ParsedLogPath};
 use crate::schema::{DataType, SchemaRef, StructField, StructType, ToSchema as _};
 use crate::utils::require;
 use crate::{
-    DeltaResult, Engine, Error, Expression, FileMeta, Predicate, PredicateRef, RowVisitor,
-    StorageHandler, Version, PRE_COMMIT_VERSION,
+    DeltaResult, Engine, Error, FileMeta, PredicateRef, RowVisitor, StorageHandler, Version,
+    PRE_COMMIT_VERSION,
 };
 use delta_kernel_derive::internal_api;
 
@@ -33,6 +30,8 @@ use crate::schema::compare::SchemaComparison;
 use itertools::Itertools;
 use tracing::{debug, info, instrument, warn};
 use url::Url;
+
+mod protocol_metadata_replay;
 
 #[cfg(test)]
 mod tests;
@@ -851,58 +850,6 @@ impl LogSegment {
             .iter()
             .map(|sidecar| sidecar.to_filemeta(&self.log_root))
             .try_collect()
-    }
-
-    /// Do a lightweight protocol+metadata log replay to find the latest Protocol and Metadata in
-    /// the LogSegment.
-    #[instrument(name = "log_seg.load_p_m", skip_all, err)]
-    pub(crate) fn protocol_and_metadata(
-        &self,
-        engine: &dyn Engine,
-    ) -> DeltaResult<(Option<Metadata>, Option<Protocol>)> {
-        let actions_batches = self.replay_for_metadata(engine)?;
-        let (mut metadata_opt, mut protocol_opt) = (None, None);
-        for actions_batch in actions_batches {
-            let actions = actions_batch?.actions;
-            if metadata_opt.is_none() {
-                metadata_opt = Metadata::try_new_from_data(actions.as_ref())?;
-            }
-            if protocol_opt.is_none() {
-                protocol_opt = Protocol::try_new_from_data(actions.as_ref())?;
-            }
-            if metadata_opt.is_some() && protocol_opt.is_some() {
-                // we've found both, we can stop
-                break;
-            }
-        }
-        Ok((metadata_opt, protocol_opt))
-    }
-
-    // Get the most up-to-date Protocol and Metadata actions
-    pub(crate) fn read_metadata(&self, engine: &dyn Engine) -> DeltaResult<(Metadata, Protocol)> {
-        match self.protocol_and_metadata(engine)? {
-            (Some(m), Some(p)) => Ok((m, p)),
-            (None, Some(_)) => Err(Error::MissingMetadata),
-            (Some(_), None) => Err(Error::MissingProtocol),
-            (None, None) => Err(Error::MissingMetadataAndProtocol),
-        }
-    }
-
-    // Replay the commit log, projecting rows to only contain Protocol and Metadata action columns.
-    fn replay_for_metadata(
-        &self,
-        engine: &dyn Engine,
-    ) -> DeltaResult<impl Iterator<Item = DeltaResult<ActionsBatch>> + Send> {
-        let schema = get_commit_schema().project(&[PROTOCOL_NAME, METADATA_NAME])?;
-        // filter out log files that do not contain metadata or protocol information
-        static META_PREDICATE: LazyLock<Option<PredicateRef>> = LazyLock::new(|| {
-            Some(Arc::new(Predicate::or(
-                Expression::column([METADATA_NAME, "id"]).is_not_null(),
-                Expression::column([PROTOCOL_NAME, "minReaderVersion"]).is_not_null(),
-            )))
-        });
-        // read the same protocol and metadata schema for both commits and checkpoints
-        self.read_actions(engine, schema, META_PREDICATE.clone())
     }
 
     /// How many commits since a checkpoint, according to this log segment.

--- a/kernel/src/log_segment/protocol_metadata_replay.rs
+++ b/kernel/src/log_segment/protocol_metadata_replay.rs
@@ -1,0 +1,121 @@
+//! Protocol and Metadata replay logic for [`LogSegment`].
+//!
+//! This module contains the methods that perform a lightweight log replay to extract the latest
+//! Protocol and Metadata actions from a [`LogSegment`].
+
+use std::sync::{Arc, LazyLock};
+
+use crate::actions::{get_commit_schema, Metadata, Protocol, METADATA_NAME, PROTOCOL_NAME};
+use crate::log_replay::ActionsBatch;
+use crate::{DeltaResult, Engine, Error, Expression, Predicate, PredicateRef};
+
+use tracing::instrument;
+
+use super::LogSegment;
+
+impl LogSegment {
+    /// Do a lightweight protocol+metadata log replay to find the latest Protocol and Metadata in
+    /// the LogSegment.
+    #[instrument(name = "log_seg.load_p_m", skip_all, err)]
+    pub(crate) fn protocol_and_metadata(
+        &self,
+        engine: &dyn Engine,
+    ) -> DeltaResult<(Option<Metadata>, Option<Protocol>)> {
+        let actions_batches = self.replay_for_metadata(engine)?;
+        let (mut metadata_opt, mut protocol_opt) = (None, None);
+        for actions_batch in actions_batches {
+            let actions = actions_batch?.actions;
+            if metadata_opt.is_none() {
+                metadata_opt = Metadata::try_new_from_data(actions.as_ref())?;
+            }
+            if protocol_opt.is_none() {
+                protocol_opt = Protocol::try_new_from_data(actions.as_ref())?;
+            }
+            if metadata_opt.is_some() && protocol_opt.is_some() {
+                // we've found both, we can stop
+                break;
+            }
+        }
+        Ok((metadata_opt, protocol_opt))
+    }
+
+    // Get the most up-to-date Protocol and Metadata actions
+    pub(crate) fn read_metadata(&self, engine: &dyn Engine) -> DeltaResult<(Metadata, Protocol)> {
+        match self.protocol_and_metadata(engine)? {
+            (Some(m), Some(p)) => Ok((m, p)),
+            (None, Some(_)) => Err(Error::MissingMetadata),
+            (Some(_), None) => Err(Error::MissingProtocol),
+            (None, None) => Err(Error::MissingMetadataAndProtocol),
+        }
+    }
+
+    // Replay the commit log, projecting rows to only contain Protocol and Metadata action columns.
+    fn replay_for_metadata(
+        &self,
+        engine: &dyn Engine,
+    ) -> DeltaResult<impl Iterator<Item = DeltaResult<ActionsBatch>> + Send> {
+        let schema = get_commit_schema().project(&[PROTOCOL_NAME, METADATA_NAME])?;
+        // filter out log files that do not contain metadata or protocol information
+        static META_PREDICATE: LazyLock<Option<PredicateRef>> = LazyLock::new(|| {
+            Some(Arc::new(Predicate::or(
+                Expression::column([METADATA_NAME, "id"]).is_not_null(),
+                Expression::column([PROTOCOL_NAME, "minReaderVersion"]).is_not_null(),
+            )))
+        });
+        // read the same protocol and metadata schema for both commits and checkpoints
+        self.read_actions(engine, schema, META_PREDICATE.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use itertools::Itertools;
+    use test_log::test;
+
+    use crate::engine::sync::SyncEngine;
+    use crate::Snapshot;
+
+    // NOTE: In addition to testing the meta-predicate for metadata replay, this test also verifies
+    // that the parquet reader properly infers nullcount = rowcount for missing columns. The two
+    // checkpoint part files that contain transaction app ids have truncated schemas that would
+    // otherwise fail skipping due to their missing nullcount stat:
+    //
+    // Row group 0:  count: 1  total(compressed): 111 B total(uncompressed):107 B
+    // --------------------------------------------------------------------------------
+    //              type    nulls  min / max
+    // txn.appId    BINARY  0      "3ae45b72-24e1-865a-a211-3..." / "3ae45b72-24e1-865a-a211-3..."
+    // txn.version  INT64   0      "4390" / "4390"
+    #[test]
+    fn test_replay_for_metadata() {
+        let path = std::fs::canonicalize(PathBuf::from("./tests/data/parquet_row_group_skipping/"));
+        let url = url::Url::from_directory_path(path.unwrap()).unwrap();
+        let engine = SyncEngine::new();
+
+        let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
+        let data: Vec<_> = snapshot
+            .log_segment()
+            .replay_for_metadata(&engine)
+            .unwrap()
+            .try_collect()
+            .unwrap();
+
+        // The checkpoint has five parts, each containing one action:
+        // 1. txn (physically missing P&M columns)
+        // 2. metaData
+        // 3. protocol
+        // 4. add
+        // 5. txn (physically missing P&M columns)
+        //
+        // The parquet reader should skip parts 1, 3, and 5. Note that the actual `read_metadata`
+        // always skips parts 4 and 5 because it terminates the iteration after finding both P&M.
+        //
+        // NOTE: Each checkpoint part is a single-row file -- guaranteed to produce one row group.
+        //
+        // WARNING: https://github.com/delta-io/delta-kernel-rs/issues/434 -- We currently
+        // read parts 1 and 5 (4 in all instead of 2) because row group skipping is disabled for
+        // missing columns, but can still skip part 3 because has valid nullcount stats for P&M.
+        assert_eq!(data.len(), 4);
+    }
+}

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -1,5 +1,5 @@
+use std::sync::Arc;
 use std::sync::LazyLock;
-use std::{path::PathBuf, sync::Arc};
 
 use itertools::Itertools;
 use object_store::{memory::InMemory, path::Path, ObjectStore};
@@ -28,7 +28,7 @@ use crate::scan::test_utils::{
 use crate::schema::{DataType, StructType};
 use crate::utils::test_utils::{assert_batch_matches, assert_result_error_with_message, Action};
 use crate::{
-    DeltaResult, Engine as _, EngineData, Expression, FileMeta, PredicateRef, RowVisitor, Snapshot,
+    DeltaResult, Engine as _, EngineData, Expression, FileMeta, PredicateRef, RowVisitor,
     StorageHandler,
 };
 use test_utils::{
@@ -72,48 +72,6 @@ fn process_sidecars(
         checkpoint_read_schema,
         meta_predicate,
     )?))
-}
-
-// NOTE: In addition to testing the meta-predicate for metadata replay, this test also verifies
-// that the parquet reader properly infers nullcount = rowcount for missing columns. The two
-// checkpoint part files that contain transaction app ids have truncated schemas that would
-// otherwise fail skipping due to their missing nullcount stat:
-//
-// Row group 0:  count: 1  total(compressed): 111 B total(uncompressed):107 B
-// --------------------------------------------------------------------------------
-//              type    nulls  min / max
-// txn.appId    BINARY  0      "3ae45b72-24e1-865a-a211-3..." / "3ae45b72-24e1-865a-a211-3..."
-// txn.version  INT64   0      "4390" / "4390"
-#[test]
-fn test_replay_for_metadata() {
-    let path = std::fs::canonicalize(PathBuf::from("./tests/data/parquet_row_group_skipping/"));
-    let url = url::Url::from_directory_path(path.unwrap()).unwrap();
-    let engine = SyncEngine::new();
-
-    let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
-    let data: Vec<_> = snapshot
-        .log_segment()
-        .replay_for_metadata(&engine)
-        .unwrap()
-        .try_collect()
-        .unwrap();
-
-    // The checkpoint has five parts, each containing one action:
-    // 1. txn (physically missing P&M columns)
-    // 2. metaData
-    // 3. protocol
-    // 4. add
-    // 5. txn (physically missing P&M columns)
-    //
-    // The parquet reader should skip parts 1, 3, and 5. Note that the actual `read_metadata`
-    // always skips parts 4 and 5 because it terminates the iteration after finding both P&M.
-    //
-    // NOTE: Each checkpoint part is a single-row file -- guaranteed to produce one row group.
-    //
-    // WARNING: https://github.com/delta-io/delta-kernel-rs/issues/434 -- We currently
-    // read parts 1 and 5 (4 in all instead of 2) because row group skipping is disabled for
-    // missing columns, but can still skip part 3 because has valid nullcount stats for P&M.
-    assert_eq!(data.len(), 4);
 }
 
 // get an ObjectStore path for a checkpoint file, based on version, part number, and total number of parts


### PR DESCRIPTION
## Summary

- Extract `protocol_and_metadata()`, `read_metadata()`, and `replay_for_metadata()` from `log_segment.rs` into a new `log_segment/protocol_metadata_replay.rs` submodule
- Move the `test_replay_for_metadata` test alongside the extracted code
- All methods remain on `impl LogSegment` with no visibility or API changes — callers are unaffected

Part of #1781.