### PR TITLE
refactor(schema): unify nested column type lookup

### DIFF
--- a/kernel/src/scan/data_skipping/stats_schema/column_filter.rs
+++ b/kernel/src/scan/data_skipping/stats_schema/column_filter.rs
@@ -3,9 +3,11 @@
 //! This module contains [`StatsColumnFilter`], which determines which columns
 //! should have statistics collected based on table configuration.
 
+#[cfg(test)]
+use crate::schema::StructType;
 use crate::{
     column_trie::ColumnTrie,
-    schema::{ColumnName, DataType, Schema, StructField, StructType},
+    schema::{ColumnName, DataType, Schema, StructField},
     table_properties::{DataSkippingNumIndexedCols, TableProperties},
 };
 
@@ -111,7 +113,7 @@ impl<'col> StatsColumnFilter<'col> {
                     continue;
                 }
                 // Verify the clustering column exists in schema before adding
-                if lookup_column_type(schema, col).is_some() {
+                if schema.lookup_column_type(col).is_some() {
                     tracing::warn!(
                         "Clustering column '{}' exceeds dataSkippingNumIndexedCols limit; \
                          adding anyway",
@@ -202,34 +204,6 @@ impl<'col> StatsColumnFilter<'col> {
 
         self.path.pop();
     }
-}
-
-/// Looks up a column by path in the schema, returning its data type if found.
-///
-/// Navigates through nested structs following the path components.
-/// For example, `lookup_column_type(schema, "user.address.city")` will:
-/// 1. Find field "user" in schema
-/// 2. Find field "address" in user's struct type
-/// 3. Find field "city" in address's struct type
-/// 4. Return city's data type
-fn lookup_column_type<'a>(schema: &'a StructType, column: &ColumnName) -> Option<&'a DataType> {
-    let mut parts = column.iter();
-
-    // Get the first part to start navigation
-    let first = parts.next()?;
-    let mut current_field = schema.field(first)?;
-
-    // Navigate through remaining parts
-    for part in parts {
-        match current_field.data_type() {
-            DataType::Struct(struct_type) => {
-                current_field = struct_type.field(part)?;
-            }
-            _ => return None, // Path continues but current field is not a struct
-        }
-    }
-
-    Some(current_field.data_type())
 }
 
 #[cfg(test)]

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -752,6 +752,27 @@ impl StructType {
         self.fields.get_index(index).map(|(_, field)| field)
     }
 
+    /// Looks up the data type of a column by path.
+    ///
+    /// The path is resolved through nested struct fields only. If any segment is missing, or a
+    /// non-struct field is traversed before the final segment, this returns `None`.
+    pub(crate) fn lookup_column_type(&self, column: &ColumnName) -> Option<&DataType> {
+        let mut parts = column.iter();
+        let first = parts.next()?;
+        let mut current_field = self.field(first)?;
+
+        for part in parts {
+            match current_field.data_type() {
+                DataType::Struct(struct_type) => {
+                    current_field = struct_type.field(part)?;
+                }
+                _ => return None,
+            }
+        }
+
+        Some(current_field.data_type())
+    }
+
     /// Gets a reference to all the fields in this struct type.
     pub fn fields(
         &self,
@@ -3293,5 +3314,47 @@ mod tests {
         assert_eq!(extended_schema.num_fields(), 2);
         assert_eq!(extended_schema.field_at_index(0).unwrap().name(), "id");
         assert_eq!(extended_schema.field_at_index(1).unwrap().name(), "name");
+    }
+
+    #[test]
+    fn test_lookup_column_type() {
+        let schema = StructType::new_unchecked([
+            StructField::nullable("id", DataType::LONG),
+            StructField::nullable(
+                "user",
+                StructType::new_unchecked([
+                    StructField::nullable(
+                        "address",
+                        StructType::new_unchecked([
+                            StructField::nullable("city", DataType::STRING),
+                            StructField::nullable("zip", DataType::INTEGER),
+                        ]),
+                    ),
+                    StructField::nullable("name", DataType::STRING),
+                ]),
+            ),
+        ]);
+
+        assert_eq!(
+            schema.lookup_column_type(&ColumnName::new(["id"])),
+            Some(&DataType::LONG)
+        );
+        assert_eq!(
+            schema.lookup_column_type(&ColumnName::new(["user", "name"])),
+            Some(&DataType::STRING)
+        );
+        assert_eq!(
+            schema.lookup_column_type(&ColumnName::new(["user", "address", "zip"])),
+            Some(&DataType::INTEGER)
+        );
+
+        assert_eq!(
+            schema.lookup_column_type(&ColumnName::new(["user", "missing"])),
+            None
+        );
+        assert_eq!(
+            schema.lookup_column_type(&ColumnName::new(["id", "extra"])),
+            None
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add a shared `StructType::lookup_column_type` helper for nested field-path lookup
- replace local lookup logic in stats column filtering with the shared utility
- add schema-level tests for valid and invalid lookup paths

## Why
Issue #1729 calls out duplicated schema traversal patterns. This starts centralizing path-based struct traversal in the schema module and removes one duplicate implementation.

## Changes
- `kernel/src/schema/mod.rs`
  - add `StructType::lookup_column_type(&ColumnName) -> Option<&DataType>`
  - add `test_lookup_column_type` coverage for:
    - top-level field lookup
    - nested struct lookup
    - missing path handling
    - traversal through non-struct handling
- `kernel/src/scan/data_skipping/stats_schema/column_filter.rs`
  - switch pass-2 clustering column existence check to `schema.lookup_column_type(...)`
  - remove the now-duplicated local `lookup_column_type` function

Fixes #1729

## Validation
- `cargo fmt --all`
- `cargo test -p delta_kernel test_lookup_column_type`
- `cargo test -p delta_kernel test_clustering_with_num_indexed_cols`
