### PR TITLE
feat(uc-committer): add tracing instrumentation for commit and publish

### DIFF
--- a/uc-catalog/src/committer.rs
+++ b/uc-catalog/src/committer.rs
@@ -56,7 +56,8 @@ impl<C: UCCommitsClient + 'static> Committer for UCCommitter<C> {
 
         let committed = engine.storage_handler().head(&staged_commit_path)?;
         info!(
-            staged_file = ?committed,
+            staged_file_size = committed.size,
+            staged_file_last_modified = ?committed.last_modified,
             "Wrote staged commit file"
         );
         let max_published_version =


### PR DESCRIPTION
## Summary

Adds span-based tracing for Unity Catalog committer operations to improve observability for staged commits, UC ratification calls, and publish idempotency.

## Changes

### `UCCommitter::commit`

- Added span:
  - `#[instrument(name = "uc_committer.commit", skip_all, fields(version = commit_metadata.version(), table_id = %self.table_id), err)]`
- Added `info!` after staged commit write/head with staged file size.
- Added `debug!` for `max_published_version` sent to UC.
- Added `info!` after UC API commit call succeeds.

### `UCCommitter::publish`

- Added span:
  - `#[instrument(name = "uc_committer.publish", skip_all, fields(num_commits = publish_metadata.commits_to_publish().len()), err)]`
- Added per-file `debug!` with source and destination paths.
- Added `info!` when `FileAlreadyExists` is encountered (publish skip / idempotent case).

## Validation

- `cargo fmt --all`
- `cargo test -p uc-catalog test_publish`
- `cargo test -p uc-catalog`

Closes #1787
