### PR TITLE
refactor(table_properties): centralize resolved default accessors

### DIFF
--- a/kernel/src/scan/data_skipping/stats_schema/column_filter.rs
+++ b/kernel/src/scan/data_skipping/stats_schema/column_filter.rs
@@ -77,7 +77,7 @@ impl<'col> StatsColumnFilter<'col> {
                 path: Vec::new(),
             }
         } else {
-            let n_cols = props.data_skipping_num_indexed_cols.unwrap_or_default();
+            let n_cols = props.data_skipping_num_indexed_cols();
             let clustering_trie = clustering_columns.map(ColumnTrie::from_columns);
             Self {
                 n_columns: Some(n_cols),

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -545,9 +545,7 @@ impl TableConfiguration {
     /// - Row tracking can be _supported_ and _suspended_ at the same time.
     /// - Row tracking cannot be _enabled_ while _suspended_.
     pub(crate) fn is_row_tracking_suspended(&self) -> bool {
-        self.table_properties()
-            .row_tracking_suspended
-            .unwrap_or(false)
+        self.table_properties().is_row_tracking_suspended()
     }
 
     /// Returns `true` if row tracking information should be written for this table.

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -286,9 +286,7 @@ static CHANGE_DATA_FEED_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::Writer,
     feature_requirements: &[],
     kernel_support: KernelSupport::Supported,
-    enablement_check: EnablementCheck::EnabledIf(|props| {
-        props.enable_change_data_feed == Some(true)
-    }),
+    enablement_check: EnablementCheck::EnabledIf(|props| props.is_change_data_feed_enabled()),
 };
 
 #[allow(dead_code)]
@@ -337,7 +335,7 @@ static ROW_TRACKING_INFO: FeatureInfo = FeatureInfo {
     feature_requirements: &[FeatureRequirement::Supported(TableFeature::DomainMetadata)],
     kernel_support: KernelSupport::Supported,
     enablement_check: EnablementCheck::EnabledIf(|props| {
-        props.enable_row_tracking == Some(true) && props.row_tracking_suspended != Some(true)
+        props.is_row_tracking_enabled() && !props.is_row_tracking_suspended()
     }),
 };
 

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -470,8 +470,7 @@ impl Transaction {
                 .read_snapshot
                 .table_configuration()
                 .table_properties()
-                .enable_change_data_feed
-                .unwrap_or(false);
+                .is_change_data_feed_enabled();
             require!(
                 !cdf_enabled,
                 Error::generic(


### PR DESCRIPTION
## Summary
Centralize table-property default resolution in `TableProperties` accessor methods, then migrate call sites away from ad-hoc `unwrap_or` / `unwrap_or_default` logic.

## Changes
- Added resolved-value accessors on `TableProperties`:
  - `data_skipping_num_indexed_cols()`
  - `is_change_data_feed_enabled()`
  - `is_row_tracking_enabled()`
  - `is_row_tracking_suspended()`
- Added unit tests for default behavior and override behavior of these accessors.
- Migrated current call sites to accessor-based usage:
  - `scan/data_skipping/stats_schema/column_filter.rs`
  - `table_configuration.rs`
  - `transaction/mod.rs`
  - `table_features/mod.rs`

## Why this approach
Used centralized accessors as the single API for resolved values so consumers no longer need to know protocol defaults at each usage site.

## Validation
- `cargo fmt --all`
- `cargo test -p delta_kernel`

Closes #1821
