### PR TITLE
fix: Fix Miri CI failure by pinning version of `nightly`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,7 +209,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Test with Miri
         run: |
-          cargo miri clean
           pushd ffi
           MIRIFLAGS=-Zmiri-disable-isolation cargo miri test --features default-engine-rustls
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
The Miri CI job [fails](https://github.com/delta-io/delta-kernel-rs/actions/runs/21959578067/job/63433093206?pr=1842) because of an issue after `nightly` update https://github.com/rust-lang/miri/issues/4855, thanks to @DrakeLin for discovering that issue! This PR pins the version of `nightly` to fix and keep stable.
<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

## How was this change tested?

Ran the commands locally

```
    steps:
      - uses: actions/checkout@v4
      - name: Install Miri
        run: |
          rustup toolchain install nightly --component miri
          rustup override set nightly
          cargo miri setup
      - uses: Swatinem/rust-cache@v2
      - name: Test with Miri
        run: |
          cargo miri clean
          pushd ffi
          MIRIFLAGS=-Zmiri-disable-isolation cargo miri test --features default-engine-rustls
```