### PR TITLE
feat!: add CheckpointRowGroupFilter for checkpoint data skipping

### DIFF
--- a/kernel/src/engine/parquet_row_group_skipping.rs
+++ b/kernel/src/engine/parquet_row_group_skipping.rs
@@ -467,7 +467,7 @@ fn adjust_stats_for_truncation(val: Scalar) -> Scalar {
 fn extract_max_i64(stats: &Statistics) -> Option<i64> {
     match stats {
         Statistics::Int64(s) => Some(*s.max_opt()?),
-        Statistics::Int32(s) => Some(*s.max_opt()? as i64),
+        Statistics::Int32(s) => Some(i64::from(*s.max_opt()?)),
         _ => None,
     }
 }
@@ -526,8 +526,8 @@ fn compute_checkpoint_field_indices(
 
         // Match add.partitionValues_parsed.<col>
         // Delta partition columns are always top-level (no nested partition columns).
-        if parts.len() >= 3 && parts[0] == "add" && parts[1] == "partitionValues_parsed" {
-            let col_name = ColumnName::new(&parts[2..]);
+        if parts.len() == 3 && parts[0] == "add" && parts[1] == "partitionValues_parsed" {
+            let col_name = ColumnName::new([&parts[2]]);
             if referenced_columns.contains(&col_name)
                 && is_partition_column(&col_name, partition_columns)
             {

--- a/kernel/src/engine/parquet_row_group_skipping.rs
+++ b/kernel/src/engine/parquet_row_group_skipping.rs
@@ -37,10 +37,12 @@ pub(crate) trait ParquetRowGroupSkipping {
     /// under `add.partitionValues_parsed.*`.
     ///
     /// The `predicate` uses physical column names (e.g. `x > 10`, or `col-abc-123 > 10` under
-    /// column mapping), and the filter internally maps them to the checkpoint's nested layout.
+    /// column mapping), and the filter internally maps them to the checkpoint's nested stats
+    /// schema layout.
     /// Statistics for data columns are null-guarded: if a stat column contains any null values
     /// in the row group (indicating some files lack that statistic), the stat is treated as
     /// unavailable to prevent false pruning.
+    // TODO: remove #[allow(dead_code)] once production callers land
     #[allow(dead_code)]
     fn with_checkpoint_row_group_filter(
         self,
@@ -366,8 +368,7 @@ impl<'a> CheckpointRowGroupFilter<'a> {
 
     /// Returns `true` if the column is a partition column.
     fn is_partition_column(&self, col: &ColumnName) -> bool {
-        let path = col.path();
-        path.len() == 1 && self.partition_columns.contains(path[0].as_str())
+        is_partition_column(col, self.partition_columns)
     }
 
     /// Returns the footer statistics for a parquet column at the given index.
@@ -447,6 +448,10 @@ impl ParquetStatsProvider for CheckpointRowGroupFilter<'_> {
 /// `stored_max <= actual_max <= stored_max + 999us`. Adding 999us ensures we never falsely
 /// prune files whose actual max exceeds the truncated value. Non-timestamp values pass through
 /// unchanged.
+///
+/// See also [`DataSkippingPredicateCreator::adjust_scalar_for_max_stat_truncation`] in
+/// `scan/data_skipping.rs`, which handles the same truncation issue from the predicate side
+/// (subtracting 999us from the comparison value instead of adding to the stat).
 #[allow(dead_code)]
 fn adjust_stats_for_truncation(val: Scalar) -> Scalar {
     match val {
@@ -491,9 +496,18 @@ pub(crate) fn compute_field_indices(
         .collect()
 }
 
+/// Returns `true` if the column is a top-level partition column.
+/// Delta partition columns are always top-level (no nested partition columns).
+#[allow(dead_code)]
+fn is_partition_column(col: &ColumnName, partition_columns: &HashSet<String>) -> bool {
+    let path = col.path();
+    path.len() == 1 && partition_columns.contains(path[0].as_str())
+}
+
 /// Builds column index mappings for checkpoint row group skipping. Maps each predicate column to
-/// its corresponding stats column indices (`add.stats_parsed.{minValues,maxValues,nullCount}.<col>`)
-/// or partition column index (`add.partitionValues_parsed.<col>`).
+/// its corresponding stats column indices
+/// (`add.stats_parsed.{minValues,maxValues,nullCount}.<col>`) or partition column index
+/// (`add.partitionValues_parsed.<col>`).
 #[allow(dead_code)]
 fn compute_checkpoint_field_indices(
     fields: &[ColumnDescPtr],
@@ -515,8 +529,7 @@ fn compute_checkpoint_field_indices(
         if parts.len() >= 3 && parts[0] == "add" && parts[1] == "partitionValues_parsed" {
             let col_name = ColumnName::new(&parts[2..]);
             if referenced_columns.contains(&col_name)
-                && col_name.path().len() == 1
-                && partition_columns.contains(col_name.path()[0].as_str())
+                && is_partition_column(&col_name, partition_columns)
             {
                 partition_indices.insert(col_name, i);
             }
@@ -529,8 +542,7 @@ fn compute_checkpoint_field_indices(
             let col_name = ColumnName::new(&parts[3..]);
             // Skip partition columns (they use partitionValues_parsed, not stats_parsed)
             if !referenced_columns.contains(&col_name)
-                || (col_name.path().len() == 1
-                    && partition_columns.contains(col_name.path()[0].as_str()))
+                || is_partition_column(&col_name, partition_columns)
             {
                 continue;
             }

--- a/kernel/src/engine/parquet_row_group_skipping.rs
+++ b/kernel/src/engine/parquet_row_group_skipping.rs
@@ -1,6 +1,6 @@
 //! An implementation of parquet row group skipping using data skipping predicates over footer
 //! stats.
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use chrono::{DateTime, Days};
 use delta_kernel_derive::internal_api;
@@ -31,6 +31,23 @@ pub(crate) trait ParquetRowGroupSkipping {
         predicate: &Predicate,
         row_indexes: Option<&mut RowIndexBuilder>,
     ) -> Self;
+
+    /// Like [`with_row_group_filter`](Self::with_row_group_filter), but for checkpoint and sidecar
+    /// parquet files where statistics are nested under `add.stats_parsed.*` and partition values
+    /// under `add.partitionValues_parsed.*`.
+    ///
+    /// The `predicate` uses physical column names (e.g. `x > 10`, or `col-abc-123 > 10` under
+    /// column mapping), and the filter internally maps them to the checkpoint's nested layout.
+    /// Statistics for data columns are null-guarded: if a stat column contains any null values
+    /// in the row group (indicating some files lack that statistic), the stat is treated as
+    /// unavailable to prevent false pruning.
+    #[allow(dead_code)]
+    fn with_checkpoint_row_group_filter(
+        self,
+        predicate: &Predicate,
+        partition_columns: &HashSet<String>,
+        row_indexes: Option<&mut RowIndexBuilder>,
+    ) -> Self;
 }
 impl<T> ParquetRowGroupSkipping for ArrowReaderBuilder<T> {
     fn with_row_group_filter(
@@ -49,6 +66,29 @@ impl<T> ParquetRowGroupSkipping for ArrowReaderBuilder<T> {
             })
             .collect();
         debug!("with_row_group_filter({predicate:#?}) = {ordinals:?})");
+        if let Some(row_indexes) = row_indexes {
+            row_indexes.select_row_groups(&ordinals);
+        }
+        self.with_row_groups(ordinals)
+    }
+
+    fn with_checkpoint_row_group_filter(
+        self,
+        predicate: &Predicate,
+        partition_columns: &HashSet<String>,
+        row_indexes: Option<&mut RowIndexBuilder>,
+    ) -> Self {
+        let ordinals: Vec<_> = self
+            .metadata()
+            .row_groups()
+            .iter()
+            .enumerate()
+            .filter_map(|(ordinal, row_group)| {
+                CheckpointRowGroupFilter::apply(row_group, predicate, partition_columns)
+                    .then_some(ordinal)
+            })
+            .collect();
+        debug!("with_checkpoint_row_group_filter({predicate:#?}) = {ordinals:?})");
         if let Some(row_indexes) = row_indexes {
             row_indexes.select_row_groups(&ordinals);
         }
@@ -236,6 +276,197 @@ fn timestamp_from_date(days: Option<&i32>) -> Option<Scalar> {
     Some(Scalar::TimestampNtz(timestamp.num_microseconds()?))
 }
 
+/// Checks whether a parquet column has any null values in a row group, based on its footer stats.
+/// Returns `true` if the column has nulls, or if nullcount stats are unavailable (conservative).
+#[allow(dead_code)]
+fn column_has_nulls(row_group: &RowGroupMetaData, col_index: usize) -> bool {
+    row_group
+        .column(col_index)
+        .statistics()
+        .and_then(|s| s.null_count_opt())
+        .is_none_or(|n| n > 0)
+}
+
+/// Parquet field indices for a single column's Delta statistics within a checkpoint file.
+/// Each index points to a leaf column in the checkpoint parquet schema.
+#[derive(Default)]
+#[allow(dead_code)]
+struct StatsColumnIndices {
+    /// Index of `add.stats_parsed.minValues.<col>` in the parquet schema.
+    min_index: Option<usize>,
+    /// Index of `add.stats_parsed.maxValues.<col>` in the parquet schema.
+    max_index: Option<usize>,
+    /// Index of `add.stats_parsed.nullCount.<col>` in the parquet schema.
+    nullcount_index: Option<usize>,
+}
+
+/// A [`ParquetStatsProvider`] for row group skipping in checkpoint and sidecar parquet files.
+///
+/// Unlike [`RowGroupFilter`] which evaluates a predicate whose column references directly match
+/// the parquet schema, this filter evaluates a predicate with physical column names (e.g.
+/// `x > 10`, or `col-abc-123 > 10` under column mapping) against
+/// a checkpoint file where statistics are nested under `add.stats_parsed.{minValues,maxValues,
+/// nullCount}.<col>` and partition values under `add.partitionValues_parsed.<col>`.
+///
+/// Because checkpoint statistics are aggregates _of_ per-file statistics, a null value in a stat
+/// column means the corresponding file was missing that statistic. The parquet footer min/max
+/// ignores nulls, which can produce misleading aggregates. To prevent false pruning, this filter
+/// returns `None` for any stat whose column contains null values in the row group (checked via
+/// the column's own null count in the parquet footer).
+///
+/// Partition columns are handled separately: their footer min/max of
+/// `add.partitionValues_parsed.<col>` can be used directly without null guarding, because parquet
+/// footer stats ignore null values (which may appear for non-add action rows).
+#[allow(dead_code)]
+pub(crate) struct CheckpointRowGroupFilter<'a> {
+    row_group: &'a RowGroupMetaData,
+    /// Maps each predicate data column to its stats column indices in the checkpoint parquet file.
+    stats_column_indices: HashMap<ColumnName, StatsColumnIndices>,
+    /// Maps each predicate partition column to its `add.partitionValues_parsed.<col>` field index.
+    partition_column_indices: HashMap<ColumnName, usize>,
+    /// Physical names of table partition columns.
+    partition_columns: &'a HashSet<String>,
+}
+
+#[allow(dead_code)]
+impl<'a> CheckpointRowGroupFilter<'a> {
+    /// Creates a new checkpoint row group filter. The `predicate` uses physical column names
+    /// (e.g. `x > 10`, or `col-abc-123 > 10` under column mapping), and `partition_columns`
+    /// are the physical names of the table's partition columns.
+    pub(crate) fn new(
+        row_group: &'a RowGroupMetaData,
+        predicate: &Predicate,
+        partition_columns: &'a HashSet<String>,
+    ) -> Self {
+        let (stats_column_indices, partition_column_indices) = compute_checkpoint_field_indices(
+            row_group.schema_descr().columns(),
+            predicate,
+            partition_columns,
+        );
+        Self {
+            row_group,
+            stats_column_indices,
+            partition_column_indices,
+            partition_columns,
+        }
+    }
+
+    /// Applies the predicate to a checkpoint row group. Returns `false` if the row group can be
+    /// safely skipped (none of its add file rows can match the predicate).
+    pub(crate) fn apply(
+        row_group: &'a RowGroupMetaData,
+        predicate: &Predicate,
+        partition_columns: &'a HashSet<String>,
+    ) -> bool {
+        use crate::kernel_predicates::KernelPredicateEvaluator as _;
+        CheckpointRowGroupFilter::new(row_group, predicate, partition_columns)
+            .eval_sql_where(predicate)
+            != Some(false)
+    }
+
+    /// Returns `true` if the column is a partition column.
+    fn is_partition_column(&self, col: &ColumnName) -> bool {
+        let path = col.path();
+        path.len() == 1 && self.partition_columns.contains(path[0].as_str())
+    }
+
+    /// Returns the footer statistics for a parquet column at the given index.
+    fn get_stats_at(&self, index: usize) -> Option<&Statistics> {
+        self.row_group.column(index).statistics()
+    }
+
+    /// Retrieves a stat value for a data column, but only if the stat column has no null values
+    /// in this row group. A null in the stat column means some file is missing that statistic,
+    /// making the footer aggregate unreliable.
+    fn get_guarded_stat(
+        &self,
+        col: &ColumnName,
+        data_type: &DataType,
+        get_index: impl FnOnce(&StatsColumnIndices) -> Option<usize>,
+        extract: impl FnOnce(&DataType, &Statistics) -> Option<Scalar>,
+    ) -> Option<Scalar> {
+        let indices = self.stats_column_indices.get(col)?;
+        let stat_index = get_index(indices)?;
+        // If the stat column has any nulls, some files are missing this stat and the footer
+        // aggregate is unreliable.
+        if column_has_nulls(self.row_group, stat_index) {
+            return None;
+        }
+        extract(data_type, self.get_stats_at(stat_index)?)
+    }
+}
+
+impl ParquetStatsProvider for CheckpointRowGroupFilter<'_> {
+    fn get_parquet_min_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Scalar> {
+        if self.is_partition_column(col) {
+            let &idx = self.partition_column_indices.get(col)?;
+            return extract_min_scalar(data_type, self.get_stats_at(idx)?);
+        }
+        self.get_guarded_stat(col, data_type, |i| i.min_index, extract_min_scalar)
+    }
+
+    fn get_parquet_max_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Scalar> {
+        if self.is_partition_column(col) {
+            let &idx = self.partition_column_indices.get(col)?;
+            return extract_max_scalar(data_type, self.get_stats_at(idx)?);
+        }
+        let max = self.get_guarded_stat(col, data_type, |i| i.max_index, extract_max_scalar)?;
+        Some(adjust_stats_for_truncation(max))
+    }
+
+    fn get_parquet_nullcount_stat(&self, col: &ColumnName) -> Option<i64> {
+        if self.is_partition_column(col) {
+            let &idx = self.partition_column_indices.get(col)?;
+            return extract_nullcount(self.get_stats_at(idx));
+        }
+        let indices = self.stats_column_indices.get(col)?;
+        let nullcount_index = indices.nullcount_index?;
+        // If the nullCount stat column itself has nulls, some files are missing nullCount
+        // stats, making the aggregate unreliable.
+        if column_has_nulls(self.row_group, nullcount_index) {
+            return None;
+        }
+        // Return the MAX of the nullCount column from the footer. If any file has null values,
+        // max(nullCount) > 0, so IS NULL predicates won't falsely prune the row group.
+        let stats = self.get_stats_at(nullcount_index)?;
+        extract_max_i64(stats)
+    }
+
+    fn get_parquet_rowcount_stat(&self) -> Option<i64> {
+        // The footer row count is the number of add file _rows_ in this row group, not the
+        // sum of data file row counts. Returning `None` makes IS NOT NULL evaluate to `None`
+        // (can't decide), which prevents it from ever pruning checkpoint row groups. This also
+        // allows the IS NOT NULL guard in `eval_pred_sql_where` to pass through for
+        // null-intolerant binary comparisons, letting the actual comparison decide.
+        None
+    }
+}
+
+/// Adjusts a max stat value to account for millisecond truncation in JSON-serialized stats.
+/// `stats_parsed` inherits from JSON stats which truncate timestamps to millisecond precision:
+/// `stored_max <= actual_max <= stored_max + 999us`. Adding 999us ensures we never falsely
+/// prune files whose actual max exceeds the truncated value. Non-timestamp values pass through
+/// unchanged.
+#[allow(dead_code)]
+fn adjust_stats_for_truncation(val: Scalar) -> Scalar {
+    match val {
+        Scalar::Timestamp(us) => Scalar::Timestamp(us.saturating_add(999)),
+        Scalar::TimestampNtz(us) => Scalar::TimestampNtz(us.saturating_add(999)),
+        other => other,
+    }
+}
+
+/// Extracts the maximum value as i64 from parquet statistics. Used for reading checkpoint
+/// nullCount stats where the footer max represents the largest per-file null count.
+#[allow(dead_code)]
+fn extract_max_i64(stats: &Statistics) -> Option<i64> {
+    match stats {
+        Statistics::Int64(s) => Some(*s.max_opt()?),
+        Statistics::Int32(s) => Some(*s.max_opt()? as i64),
+        _ => None,
+    }
+}
+
 /// Given a predicate of interest and a set of parquet column descriptors, build a column ->
 /// index mapping for columns the predicate references. This ensures O(1) lookup times, for an
 /// overall O(n) cost to evaluate a predicate tree with n nodes.
@@ -258,4 +489,60 @@ pub(crate) fn compute_field_indices(
                 .map(|path| (path.clone(), i))
         })
         .collect()
+}
+
+/// Builds column index mappings for checkpoint row group skipping. Maps each predicate column to
+/// its corresponding stats column indices (`add.stats_parsed.{minValues,maxValues,nullCount}.<col>`)
+/// or partition column index (`add.partitionValues_parsed.<col>`).
+#[allow(dead_code)]
+fn compute_checkpoint_field_indices(
+    fields: &[ColumnDescPtr],
+    predicate: &Predicate,
+    partition_columns: &HashSet<String>,
+) -> (
+    HashMap<ColumnName, StatsColumnIndices>,
+    HashMap<ColumnName, usize>,
+) {
+    let referenced_columns = predicate.references();
+    let mut stats_indices: HashMap<ColumnName, StatsColumnIndices> = HashMap::new();
+    let mut partition_indices: HashMap<ColumnName, usize> = HashMap::new();
+
+    for (i, field) in fields.iter().enumerate() {
+        let parts = field.path().parts();
+
+        // Match add.partitionValues_parsed.<col>
+        // Delta partition columns are always top-level (no nested partition columns).
+        if parts.len() >= 3 && parts[0] == "add" && parts[1] == "partitionValues_parsed" {
+            let col_name = ColumnName::new(&parts[2..]);
+            if referenced_columns.contains(&col_name)
+                && col_name.path().len() == 1
+                && partition_columns.contains(col_name.path()[0].as_str())
+            {
+                partition_indices.insert(col_name, i);
+            }
+            continue;
+        }
+
+        // Match add.stats_parsed.{minValues,maxValues,nullCount}.<col_path...>
+        if parts.len() >= 4 && parts[0] == "add" && parts[1] == "stats_parsed" {
+            let stat_type = parts[2].as_str();
+            let col_name = ColumnName::new(&parts[3..]);
+            // Skip partition columns (they use partitionValues_parsed, not stats_parsed)
+            if !referenced_columns.contains(&col_name)
+                || (col_name.path().len() == 1
+                    && partition_columns.contains(col_name.path()[0].as_str()))
+            {
+                continue;
+            }
+            let entry = stats_indices.entry(col_name).or_default();
+            match stat_type {
+                "minValues" => entry.min_index = Some(i),
+                "maxValues" => entry.max_index = Some(i),
+                "nullCount" => entry.nullcount_index = Some(i),
+                _ => {}
+            }
+        }
+    }
+
+    (stats_indices, partition_indices)
 }

--- a/kernel/src/engine/parquet_row_group_skipping/tests.rs
+++ b/kernel/src/engine/parquet_row_group_skipping/tests.rs
@@ -1008,54 +1008,6 @@ fn checkpoint_filter_opaque_predicate_with_missing_stats() {
 }
 
 #[test]
-fn checkpoint_filter_physical_column_names_for_column_mapping() {
-    // Simulate column mapping: the physical column name in the checkpoint parquet file is
-    // "col-abc-123" (a UUID-style name), not the logical "x". The predicate is already in
-    // physical form by the time it reaches CheckpointRowGroupFilter.
-    let physical_name = "col-abc-123";
-    let tmp = write_checkpoint_parquet(
-        &[Some(10), Some(20)],
-        &[Some(100), Some(200)],
-        &[Some(0), Some(0)],
-        &[physical_name],
-        None,
-    );
-    let metadata = checkpoint_row_group_metadata(&tmp);
-    let row_group = metadata.row_group(0);
-
-    let col = ColumnName::new([physical_name]);
-
-    // Predicate uses the physical column name, matching the checkpoint parquet schema.
-    // physical_col > 500: max = 200 < 500 -> can prune.
-    let predicate = Predicate::gt(col.clone(), Scalar::from(500i64));
-    assert!(!CheckpointRowGroupFilter::apply(
-        row_group,
-        &predicate,
-        &NO_PARTITIONS
-    ));
-
-    // physical_col > 50: max = 200 > 50 -> keep.
-    let predicate = Predicate::gt(col.clone(), Scalar::from(50i64));
-    assert!(CheckpointRowGroupFilter::apply(
-        row_group,
-        &predicate,
-        &NO_PARTITIONS
-    ));
-
-    // Verify stats are accessible via the physical name.
-    let predicate = Predicate::gt(col.clone(), Scalar::from(0i64));
-    let filter = CheckpointRowGroupFilter::new(row_group, &predicate, &NO_PARTITIONS);
-    assert_eq!(
-        filter.get_min_stat(&col, &DataType::LONG),
-        Some(10i64.into())
-    );
-    assert_eq!(
-        filter.get_max_stat(&col, &DataType::LONG),
-        Some(200i64.into())
-    );
-}
-
-#[test]
 fn checkpoint_filter_partition_nullcount_is_null() {
     // All partition values are non-null, so footer nullcount for partitionValues_parsed.part_col
     // is 0. extract_nullcount suppresses Some(0) due to the arrow-rs#9451 workaround, so

--- a/kernel/src/engine/parquet_row_group_skipping/tests.rs
+++ b/kernel/src/engine/parquet_row_group_skipping/tests.rs
@@ -1,4 +1,7 @@
+use std::cmp::Ordering;
+use std::collections::HashSet;
 use std::fs::File;
+use std::sync::{Arc, LazyLock};
 
 use super::*;
 use crate::arrow::array::{Int64Array, RecordBatch, StringArray, StructArray};
@@ -17,9 +20,6 @@ use crate::parquet::file::properties::WriterProperties;
 use crate::parquet::file::reader::FileReader;
 use crate::parquet::file::serialized_reader::SerializedFileReader;
 use crate::{DeltaResult, Predicate};
-use std::cmp::Ordering;
-use std::collections::HashSet;
-use std::sync::{Arc, LazyLock};
 
 /// Empty partition column set for tests that don't need partition columns.
 static NO_PARTITIONS: LazyLock<HashSet<String>> = LazyLock::new(HashSet::new);
@@ -457,62 +457,95 @@ fn test_get_stat_values() {
     );
 }
 
+/// Wraps an Int64 leaf array in nested StructArrays matching the given column path.
+///
+/// For `col_path = &["a", "b"]` and a leaf array `[10, 20]`, produces the Arrow structure:
+///   `a: Struct { b: Int64 }` with values `[{b: 10}, {b: 20}]`.
+///
+/// Returns the outermost `(field, array)` pair for embedding in a parent struct.
+fn wrap_in_nested_struct(
+    col_path: &[&str],
+    values: Arc<Int64Array>,
+) -> (Arc<Field>, Arc<dyn crate::arrow::array::Array>) {
+    assert!(!col_path.is_empty());
+    let mut field = Arc::new(Field::new(
+        *col_path.last().unwrap(),
+        ArrowDataType::Int64,
+        true,
+    ));
+    let mut array: Arc<dyn crate::arrow::array::Array> = values;
+    for &name in col_path[..col_path.len() - 1].iter().rev() {
+        let struct_array = StructArray::from(vec![(field.clone(), array)]);
+        field = Arc::new(Field::new(
+            name,
+            ArrowDataType::Struct(Fields::from(vec![field])),
+            true,
+        ));
+        array = Arc::new(struct_array);
+    }
+    (field, array)
+}
+
+/// Builds a `(field, array)` pair for a single stat type (e.g. `minValues.<col_path>`).
+fn build_stat_column(
+    stat_name: &str,
+    col_path: &[&str],
+    values: Arc<Int64Array>,
+) -> (Arc<Field>, Arc<dyn crate::arrow::array::Array>) {
+    let (col_field, col_array) = wrap_in_nested_struct(col_path, values);
+    let stat_struct = StructArray::from(vec![(col_field.clone(), col_array)]);
+    let stat_field = Arc::new(Field::new(
+        stat_name,
+        ArrowDataType::Struct(Fields::from(vec![col_field])),
+        true,
+    ));
+    (stat_field, Arc::new(stat_struct))
+}
+
 /// Writes a checkpoint-like parquet file with the given per-file statistics.
 ///
-/// Schema: `add.stats_parsed.{minValues,maxValues,nullCount}.<col_name>` (INT64)
+/// Schema: `add.stats_parsed.{minValues,maxValues,nullCount}.<col_path>` (INT64)
 ///         + optionally `add.partitionValues_parsed.part_col` (STRING)
 ///
+/// `col_path` supports nested columns (e.g. `&["a", "b"]` produces `...minValues.a.b`).
 /// Each array index represents one data file row. Use `None` to simulate missing statistics.
 /// When `part_values` is `Some`, a `partitionValues_parsed.part_col` column is included.
 fn write_checkpoint_parquet(
     min_values: &[Option<i64>],
     max_values: &[Option<i64>],
     null_counts: &[Option<i64>],
-    col_name: &str,
+    col_path: &[&str],
     part_values: Option<&[Option<&str>]>,
 ) -> tempfile::NamedTempFile {
-    let col_field = Arc::new(Field::new(col_name, ArrowDataType::Int64, true));
-    let min_values_field = Arc::new(Field::new(
+    let (min_f, min_a) = build_stat_column(
         "minValues",
-        ArrowDataType::Struct(Fields::from(vec![col_field.clone()])),
-        true,
-    ));
-    let max_values_field = Arc::new(Field::new(
+        col_path,
+        Arc::new(Int64Array::from(min_values.to_vec())),
+    );
+    let (max_f, max_a) = build_stat_column(
         "maxValues",
-        ArrowDataType::Struct(Fields::from(vec![col_field.clone()])),
-        true,
-    ));
-    let null_count_field = Arc::new(Field::new(
+        col_path,
+        Arc::new(Int64Array::from(max_values.to_vec())),
+    );
+    let (nc_f, nc_a) = build_stat_column(
         "nullCount",
-        ArrowDataType::Struct(Fields::from(vec![col_field.clone()])),
-        true,
-    ));
+        col_path,
+        Arc::new(Int64Array::from(null_counts.to_vec())),
+    );
+
+    let stats_struct = StructArray::from(vec![
+        (min_f.clone(), min_a),
+        (max_f.clone(), max_a),
+        (nc_f.clone(), nc_a),
+    ]);
     let stats_parsed_field = Arc::new(Field::new(
         "stats_parsed",
-        ArrowDataType::Struct(Fields::from(vec![
-            min_values_field.clone(),
-            max_values_field.clone(),
-            null_count_field.clone(),
-        ])),
+        ArrowDataType::Struct(Fields::from(vec![min_f, max_f, nc_f])),
         true,
     ));
 
-    // Build the add struct fields: always include stats_parsed, optionally partitionValues_parsed.
-    let mut add_children: Vec<(Arc<Field>, Arc<dyn crate::arrow::array::Array>)> = vec![];
-
-    let min_x = Arc::new(Int64Array::from(min_values.to_vec()));
-    let max_x = Arc::new(Int64Array::from(max_values.to_vec()));
-    let null_count_x = Arc::new(Int64Array::from(null_counts.to_vec()));
-
-    let min_struct = StructArray::from(vec![(col_field.clone(), min_x as _)]);
-    let max_struct = StructArray::from(vec![(col_field.clone(), max_x as _)]);
-    let nc_struct = StructArray::from(vec![(col_field.clone(), null_count_x as _)]);
-    let stats_struct = StructArray::from(vec![
-        (min_values_field.clone(), Arc::new(min_struct) as _),
-        (max_values_field.clone(), Arc::new(max_struct) as _),
-        (null_count_field.clone(), Arc::new(nc_struct) as _),
-    ]);
-    add_children.push((stats_parsed_field.clone(), Arc::new(stats_struct) as _));
+    let mut add_children: Vec<(Arc<Field>, Arc<dyn crate::arrow::array::Array>)> =
+        vec![(stats_parsed_field, Arc::new(stats_struct))];
 
     if let Some(part_values) = part_values {
         let part_col_field = Arc::new(Field::new("part_col", ArrowDataType::Utf8, true));
@@ -523,7 +556,7 @@ fn write_checkpoint_parquet(
         ));
         let part_col = Arc::new(StringArray::from(part_values.to_vec()));
         let pv_struct = StructArray::from(vec![(part_col_field.clone(), part_col as _)]);
-        add_children.push((pv_parsed_field.clone(), Arc::new(pv_struct) as _));
+        add_children.push((pv_parsed_field, Arc::new(pv_struct)));
     }
 
     let add_struct = StructArray::from(add_children.clone());
@@ -555,7 +588,7 @@ fn checkpoint_filter_returns_stats_when_no_nulls_in_stat_columns() {
         &[Some(10), Some(20)],
         &[Some(100), Some(200)],
         &[Some(2), Some(0)],
-        "x",
+        &["x"],
         Some(&[Some("a"), Some("b")]),
     );
     let metadata = checkpoint_row_group_metadata(&tmp);
@@ -590,7 +623,7 @@ fn checkpoint_filter_returns_none_when_stat_column_has_nulls() {
         &[Some(10), None, Some(20)],
         &[Some(100), None, Some(200)],
         &[Some(2), None, Some(0)],
-        "x",
+        &["x"],
         Some(&[Some("a"), Some("b"), Some("b")]),
     );
     let metadata = checkpoint_row_group_metadata(&tmp);
@@ -618,7 +651,7 @@ fn checkpoint_filter_partition_columns_always_available() {
         &[Some(10), None],
         &[Some(100), None],
         &[Some(2), None],
-        "x",
+        &["x"],
         Some(&[Some("a"), Some("b")]),
     );
     let metadata = checkpoint_row_group_metadata(&tmp);
@@ -656,7 +689,7 @@ fn checkpoint_filter_apply_keeps_row_group_with_missing_stats() {
         &[Some(10), None],
         &[Some(100), None],
         &[Some(0), None],
-        "x",
+        &["x"],
         Some(&[Some("a"), Some("b")]),
     );
     let metadata = checkpoint_row_group_metadata(&tmp);
@@ -678,7 +711,7 @@ fn checkpoint_filter_apply_prunes_row_group_with_all_stats_present() {
         &[Some(10), Some(20)],
         &[Some(100), Some(200)],
         &[Some(0), Some(0)],
-        "x",
+        &["x"],
         Some(&[Some("a"), Some("b")]),
     );
     let metadata = checkpoint_row_group_metadata(&tmp);
@@ -699,7 +732,7 @@ fn checkpoint_filter_is_null_with_all_stats_present() {
         &[Some(10), Some(20)],
         &[Some(100), Some(200)],
         &[Some(5), Some(0)],
-        "x",
+        &["x"],
         Some(&[Some("a"), Some("b")]),
     );
     let metadata = checkpoint_row_group_metadata(&tmp);
@@ -722,7 +755,7 @@ fn checkpoint_filter_is_null_all_zero_nullcounts() {
         &[Some(10), Some(20)],
         &[Some(100), Some(200)],
         &[Some(0), Some(0)],
-        "x",
+        &["x"],
         Some(&[Some("a"), Some("b")]),
     );
     let metadata = checkpoint_row_group_metadata(&tmp);
@@ -747,7 +780,7 @@ fn checkpoint_filter_is_not_null_never_prunes() {
         &[Some(10), Some(20)],
         &[Some(100), Some(200)],
         &[Some(5), Some(3)],
-        "x",
+        &["x"],
         Some(&[Some("a"), Some("b")]),
     );
     let metadata = checkpoint_row_group_metadata(&tmp);
@@ -770,7 +803,7 @@ fn checkpoint_filter_timestamp_max_widened() {
         &[Some(10), Some(20)],
         &[Some(100), Some(200)],
         &[Some(0), Some(0)],
-        "x",
+        &["x"],
         Some(&[Some("a"), Some("b")]),
     );
     let metadata = checkpoint_row_group_metadata(&tmp);
@@ -802,7 +835,7 @@ fn checkpoint_filter_unknown_column_returns_none() {
         &[Some(10)],
         &[Some(100)],
         &[Some(0)],
-        "x",
+        &["x"],
         Some(&[Some("a")]),
     );
     let metadata = checkpoint_row_group_metadata(&tmp);
@@ -832,7 +865,7 @@ fn checkpoint_filter_mixed_partition_and_data_predicate() {
         &[Some(10), None],
         &[Some(100), None],
         &[Some(0), None],
-        "x",
+        &["x"],
         Some(&[Some("a"), Some("b")]),
     );
     let metadata = checkpoint_row_group_metadata(&tmp);
@@ -917,7 +950,7 @@ fn checkpoint_filter_opaque_predicate_with_null_guarded_stats() {
         &[Some(10), Some(20)],
         &[Some(100), Some(200)],
         &[Some(0), Some(0)],
-        "x",
+        &["x"],
         Some(&[Some("a"), Some("b")]),
     );
     let metadata = checkpoint_row_group_metadata(&tmp);
@@ -954,7 +987,7 @@ fn checkpoint_filter_opaque_predicate_with_missing_stats() {
         &[Some(10), None],
         &[Some(100), None],
         &[Some(0), None],
-        "x",
+        &["x"],
         Some(&[Some("a"), Some("b")]),
     );
     let metadata = checkpoint_row_group_metadata(&tmp);
@@ -984,7 +1017,7 @@ fn checkpoint_filter_physical_column_names_for_column_mapping() {
         &[Some(10), Some(20)],
         &[Some(100), Some(200)],
         &[Some(0), Some(0)],
-        physical_name,
+        &[physical_name],
         None,
     );
     let metadata = checkpoint_row_group_metadata(&tmp);
@@ -1031,7 +1064,7 @@ fn checkpoint_filter_partition_nullcount_is_null() {
         &[Some(10), Some(20)],
         &[Some(100), Some(200)],
         &[Some(0), Some(0)],
-        "x",
+        &["x"],
         Some(&[Some("a"), Some("b")]),
     );
     let metadata = checkpoint_row_group_metadata(&tmp);
@@ -1133,69 +1166,16 @@ fn checkpoint_filter_multi_row_group_skipping() {
 
 #[test]
 fn checkpoint_filter_nested_struct_column_stats() {
-    // Build schema: add.stats_parsed.{minValues,maxValues,nullCount}.a.b (INT64)
-    // This simulates a nested struct column `a` with field `b`.
-    let b_field = Arc::new(Field::new("b", ArrowDataType::Int64, true));
-    let a_field = Arc::new(Field::new(
-        "a",
-        ArrowDataType::Struct(Fields::from(vec![b_field.clone()])),
-        true,
-    ));
-    let min_field = Arc::new(Field::new(
-        "minValues",
-        ArrowDataType::Struct(Fields::from(vec![a_field.clone()])),
-        true,
-    ));
-    let max_field = Arc::new(Field::new(
-        "maxValues",
-        ArrowDataType::Struct(Fields::from(vec![a_field.clone()])),
-        true,
-    ));
-    let nc_field = Arc::new(Field::new(
-        "nullCount",
-        ArrowDataType::Struct(Fields::from(vec![a_field.clone()])),
-        true,
-    ));
-    let stats_field = Arc::new(Field::new(
-        "stats_parsed",
-        ArrowDataType::Struct(Fields::from(vec![
-            min_field.clone(),
-            max_field.clone(),
-            nc_field.clone(),
-        ])),
-        true,
-    ));
-    let add_field = Arc::new(Field::new(
-        "add",
-        ArrowDataType::Struct(Fields::from(vec![stats_field.clone()])),
-        true,
-    ));
-    let schema = Arc::new(ArrowSchema::new(vec![add_field]));
-
-    let min_b = Arc::new(Int64Array::from(vec![Some(10), Some(20)]));
-    let max_b = Arc::new(Int64Array::from(vec![Some(100), Some(200)]));
-    let nc_b = Arc::new(Int64Array::from(vec![Some(0), Some(0)]));
-
-    let min_a = StructArray::from(vec![(b_field.clone(), min_b as _)]);
-    let max_a = StructArray::from(vec![(b_field.clone(), max_b as _)]);
-    let nc_a = StructArray::from(vec![(b_field.clone(), nc_b as _)]);
-    let min_s = StructArray::from(vec![(a_field.clone(), Arc::new(min_a) as _)]);
-    let max_s = StructArray::from(vec![(a_field.clone(), Arc::new(max_a) as _)]);
-    let nc_s = StructArray::from(vec![(a_field.clone(), Arc::new(nc_a) as _)]);
-    let stats_s = StructArray::from(vec![
-        (min_field.clone(), Arc::new(min_s) as _),
-        (max_field.clone(), Arc::new(max_s) as _),
-        (nc_field.clone(), Arc::new(nc_s) as _),
-    ]);
-    let add_s = StructArray::from(vec![(stats_field.clone(), Arc::new(stats_s) as _)]);
-    let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(add_s)]).unwrap();
-
-    let tmp = tempfile::NamedTempFile::new().unwrap();
-    let file = tmp.as_file().try_clone().unwrap();
-    let mut writer = ArrowWriter::try_new(file, schema, None).unwrap();
-    writer.write(&batch).unwrap();
-    writer.close().unwrap();
-
+    // Per-file statistics mirror the data schema structure (Delta protocol spec, "Per-file
+    // Statistics" section). For a nested column `a.b`, stats are stored as:
+    //   add.stats_parsed.{minValues,maxValues,nullCount}.a.b (INT64)
+    let tmp = write_checkpoint_parquet(
+        &[Some(10), Some(20)],
+        &[Some(100), Some(200)],
+        &[Some(0), Some(0)],
+        &["a", "b"],
+        None,
+    );
     let metadata = checkpoint_row_group_metadata(&tmp);
     let row_group = metadata.row_group(0);
 

--- a/kernel/src/engine/parquet_row_group_skipping/tests.rs
+++ b/kernel/src/engine/parquet_row_group_skipping/tests.rs
@@ -1,10 +1,28 @@
 use std::fs::File;
 
 use super::*;
-use crate::expressions::{column_name, column_pred};
-use crate::kernel_predicates::DataSkippingPredicateEvaluator as _;
+use crate::arrow::array::{Int64Array, RecordBatch, StringArray, StructArray};
+use crate::arrow::datatypes::{DataType as ArrowDataType, Field, Fields, Schema as ArrowSchema};
+use crate::expressions::{
+    column_expr, column_name, column_pred, Expression, OpaquePredicateOp, ScalarExpressionEvaluator,
+};
+use crate::kernel_predicates::{
+    DataSkippingPredicateEvaluator as _, DirectDataSkippingPredicateEvaluator,
+    DirectPredicateEvaluator, IndirectDataSkippingPredicateEvaluator,
+    KernelPredicateEvaluator as _,
+};
 use crate::parquet::arrow::arrow_reader::ArrowReaderMetadata;
-use crate::Predicate;
+use crate::parquet::arrow::ArrowWriter;
+use crate::parquet::file::properties::WriterProperties;
+use crate::parquet::file::reader::FileReader;
+use crate::parquet::file::serialized_reader::SerializedFileReader;
+use crate::{DeltaResult, Predicate};
+use std::cmp::Ordering;
+use std::collections::HashSet;
+use std::sync::{Arc, LazyLock};
+
+/// Empty partition column set for tests that don't need partition columns.
+static NO_PARTITIONS: LazyLock<HashSet<String>> = LazyLock::new(HashSet::new);
 
 /// Performs an exhaustive set of reads against a specially crafted parquet file.
 ///
@@ -437,4 +455,766 @@ fn test_get_stat_values() {
                 .unwrap()
         )
     );
+}
+
+/// Writes a checkpoint-like parquet file with the given per-file statistics.
+///
+/// Schema: `add.stats_parsed.{minValues,maxValues,nullCount}.<col_name>` (INT64)
+///         + optionally `add.partitionValues_parsed.part_col` (STRING)
+///
+/// Each array index represents one data file row. Use `None` to simulate missing statistics.
+/// When `part_values` is `Some`, a `partitionValues_parsed.part_col` column is included.
+fn write_checkpoint_parquet(
+    min_values: &[Option<i64>],
+    max_values: &[Option<i64>],
+    null_counts: &[Option<i64>],
+    col_name: &str,
+    part_values: Option<&[Option<&str>]>,
+) -> tempfile::NamedTempFile {
+    let col_field = Arc::new(Field::new(col_name, ArrowDataType::Int64, true));
+    let min_values_field = Arc::new(Field::new(
+        "minValues",
+        ArrowDataType::Struct(Fields::from(vec![col_field.clone()])),
+        true,
+    ));
+    let max_values_field = Arc::new(Field::new(
+        "maxValues",
+        ArrowDataType::Struct(Fields::from(vec![col_field.clone()])),
+        true,
+    ));
+    let null_count_field = Arc::new(Field::new(
+        "nullCount",
+        ArrowDataType::Struct(Fields::from(vec![col_field.clone()])),
+        true,
+    ));
+    let stats_parsed_field = Arc::new(Field::new(
+        "stats_parsed",
+        ArrowDataType::Struct(Fields::from(vec![
+            min_values_field.clone(),
+            max_values_field.clone(),
+            null_count_field.clone(),
+        ])),
+        true,
+    ));
+
+    // Build the add struct fields: always include stats_parsed, optionally partitionValues_parsed.
+    let mut add_children: Vec<(Arc<Field>, Arc<dyn crate::arrow::array::Array>)> = vec![];
+
+    let min_x = Arc::new(Int64Array::from(min_values.to_vec()));
+    let max_x = Arc::new(Int64Array::from(max_values.to_vec()));
+    let null_count_x = Arc::new(Int64Array::from(null_counts.to_vec()));
+
+    let min_struct = StructArray::from(vec![(col_field.clone(), min_x as _)]);
+    let max_struct = StructArray::from(vec![(col_field.clone(), max_x as _)]);
+    let nc_struct = StructArray::from(vec![(col_field.clone(), null_count_x as _)]);
+    let stats_struct = StructArray::from(vec![
+        (min_values_field.clone(), Arc::new(min_struct) as _),
+        (max_values_field.clone(), Arc::new(max_struct) as _),
+        (null_count_field.clone(), Arc::new(nc_struct) as _),
+    ]);
+    add_children.push((stats_parsed_field.clone(), Arc::new(stats_struct) as _));
+
+    if let Some(part_values) = part_values {
+        let part_col_field = Arc::new(Field::new("part_col", ArrowDataType::Utf8, true));
+        let pv_parsed_field = Arc::new(Field::new(
+            "partitionValues_parsed",
+            ArrowDataType::Struct(Fields::from(vec![part_col_field.clone()])),
+            true,
+        ));
+        let part_col = Arc::new(StringArray::from(part_values.to_vec()));
+        let pv_struct = StructArray::from(vec![(part_col_field.clone(), part_col as _)]);
+        add_children.push((pv_parsed_field.clone(), Arc::new(pv_struct) as _));
+    }
+
+    let add_struct = StructArray::from(add_children.clone());
+    let add_fields: Fields = add_children.iter().map(|(f, _)| f.clone()).collect();
+    let add_field = Arc::new(Field::new("add", ArrowDataType::Struct(add_fields), true));
+    let schema = Arc::new(ArrowSchema::new(vec![add_field]));
+
+    let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(add_struct)]).unwrap();
+
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let file = tmp.as_file().try_clone().unwrap();
+    let mut writer = ArrowWriter::try_new(file, schema, None).unwrap();
+    writer.write(&batch).unwrap();
+    writer.close().unwrap();
+    tmp
+}
+
+fn checkpoint_row_group_metadata(
+    tmp: &tempfile::NamedTempFile,
+) -> crate::parquet::file::metadata::ParquetMetaData {
+    let file = File::open(tmp.path()).unwrap();
+    let reader = SerializedFileReader::new(file).unwrap();
+    reader.metadata().clone()
+}
+
+#[test]
+fn checkpoint_filter_returns_stats_when_no_nulls_in_stat_columns() {
+    let tmp = write_checkpoint_parquet(
+        &[Some(10), Some(20)],
+        &[Some(100), Some(200)],
+        &[Some(2), Some(0)],
+        "x",
+        Some(&[Some("a"), Some("b")]),
+    );
+    let metadata = checkpoint_row_group_metadata(&tmp);
+    let row_group = metadata.row_group(0);
+
+    let predicate = Predicate::gt(column_name!("x"), Scalar::from(50i64));
+    let filter = CheckpointRowGroupFilter::new(row_group, &predicate, &NO_PARTITIONS);
+
+    // All stat columns are non-null, so stats should be available.
+    // min(minValues.x) across rows = 10, max(maxValues.x) = 200
+    assert_eq!(
+        filter.get_min_stat(&column_name!("x"), &DataType::LONG),
+        Some(10i64.into())
+    );
+    assert_eq!(
+        filter.get_max_stat(&column_name!("x"), &DataType::LONG),
+        Some(200i64.into())
+    );
+    // max(nullCount.x) = 2 (conservative: at least one file has nulls)
+    assert_eq!(
+        filter.get_nullcount_stat(&column_name!("x")),
+        Some(2i64.into())
+    );
+    // Row count is None for checkpoint files (footer rowcount is not meaningful)
+    assert_eq!(filter.get_rowcount_stat(), None);
+}
+
+#[test]
+fn checkpoint_filter_returns_none_when_stat_column_has_nulls() {
+    // Row 1 has null stats (file missing statistics)
+    let tmp = write_checkpoint_parquet(
+        &[Some(10), None, Some(20)],
+        &[Some(100), None, Some(200)],
+        &[Some(2), None, Some(0)],
+        "x",
+        Some(&[Some("a"), Some("b"), Some("b")]),
+    );
+    let metadata = checkpoint_row_group_metadata(&tmp);
+    let row_group = metadata.row_group(0);
+
+    let predicate = Predicate::gt(column_name!("x"), Scalar::from(50i64));
+    let filter = CheckpointRowGroupFilter::new(row_group, &predicate, &NO_PARTITIONS);
+
+    // Stat columns have nulls (row 1), so footer aggregates are unreliable.
+    assert_eq!(
+        filter.get_min_stat(&column_name!("x"), &DataType::LONG),
+        None
+    );
+    assert_eq!(
+        filter.get_max_stat(&column_name!("x"), &DataType::LONG),
+        None
+    );
+    assert_eq!(filter.get_nullcount_stat(&column_name!("x")), None);
+}
+
+#[test]
+fn checkpoint_filter_partition_columns_always_available() {
+    // Row 1 has null stats, but partition values are always present.
+    let tmp = write_checkpoint_parquet(
+        &[Some(10), None],
+        &[Some(100), None],
+        &[Some(2), None],
+        "x",
+        Some(&[Some("a"), Some("b")]),
+    );
+    let metadata = checkpoint_row_group_metadata(&tmp);
+    let row_group = metadata.row_group(0);
+
+    let partition_columns: HashSet<String> = ["part_col".to_string()].into();
+    let predicate = Predicate::and(
+        Predicate::gt(column_name!("x"), Scalar::from(50i64)),
+        Predicate::eq(column_name!("part_col"), Scalar::from("a")),
+    );
+    let filter = CheckpointRowGroupFilter::new(row_group, &predicate, &partition_columns);
+
+    // Partition column stats should always be available (not null-guarded).
+    assert_eq!(
+        filter.get_min_stat(&column_name!("part_col"), &DataType::STRING),
+        Some("a".into())
+    );
+    assert_eq!(
+        filter.get_max_stat(&column_name!("part_col"), &DataType::STRING),
+        Some("b".into())
+    );
+
+    // Data column stats should still be None (stat columns have nulls).
+    assert_eq!(
+        filter.get_min_stat(&column_name!("x"), &DataType::LONG),
+        None
+    );
+}
+
+#[test]
+fn checkpoint_filter_apply_keeps_row_group_with_missing_stats() {
+    // Row 1 has null stats -- row group must NOT be pruned even though
+    // the non-null footer max is 100 < 500.
+    let tmp = write_checkpoint_parquet(
+        &[Some(10), None],
+        &[Some(100), None],
+        &[Some(0), None],
+        "x",
+        Some(&[Some("a"), Some("b")]),
+    );
+    let metadata = checkpoint_row_group_metadata(&tmp);
+    let row_group = metadata.row_group(0);
+
+    let predicate = Predicate::gt(column_name!("x"), Scalar::from(500i64));
+    // Without null guarding, footer max=100 < 500 would falsely prune this row group.
+    assert!(CheckpointRowGroupFilter::apply(
+        row_group,
+        &predicate,
+        &NO_PARTITIONS
+    ));
+}
+
+#[test]
+fn checkpoint_filter_apply_prunes_row_group_with_all_stats_present() {
+    // All stats present, max=200 < 500, so row group can be pruned.
+    let tmp = write_checkpoint_parquet(
+        &[Some(10), Some(20)],
+        &[Some(100), Some(200)],
+        &[Some(0), Some(0)],
+        "x",
+        Some(&[Some("a"), Some("b")]),
+    );
+    let metadata = checkpoint_row_group_metadata(&tmp);
+    let row_group = metadata.row_group(0);
+
+    let predicate = Predicate::gt(column_name!("x"), Scalar::from(500i64));
+    assert!(!CheckpointRowGroupFilter::apply(
+        row_group,
+        &predicate,
+        &NO_PARTITIONS
+    ));
+}
+
+#[test]
+fn checkpoint_filter_is_null_with_all_stats_present() {
+    // All nullCount values present. max(nullCount.x) = 5 > 0, so IS NULL should keep.
+    let tmp = write_checkpoint_parquet(
+        &[Some(10), Some(20)],
+        &[Some(100), Some(200)],
+        &[Some(5), Some(0)],
+        "x",
+        Some(&[Some("a"), Some("b")]),
+    );
+    let metadata = checkpoint_row_group_metadata(&tmp);
+    let row_group = metadata.row_group(0);
+
+    // IS NULL(x): at least one file has nullCount > 0, so keep the row group.
+    let predicate = Predicate::is_null(column_name!("x"));
+    assert!(CheckpointRowGroupFilter::apply(
+        row_group,
+        &predicate,
+        &NO_PARTITIONS
+    ));
+}
+
+#[test]
+fn checkpoint_filter_is_null_all_zero_nullcounts() {
+    // All nullCount values are 0, so max(nullCount) = 0. The data skipping evaluator checks
+    // nullcount != 0 for IS NULL. Since nullcount == 0, no files have nulls and IS NULL prunes.
+    let tmp = write_checkpoint_parquet(
+        &[Some(10), Some(20)],
+        &[Some(100), Some(200)],
+        &[Some(0), Some(0)],
+        "x",
+        Some(&[Some("a"), Some("b")]),
+    );
+    let metadata = checkpoint_row_group_metadata(&tmp);
+    let row_group = metadata.row_group(0);
+
+    let predicate = Predicate::is_null(column_name!("x"));
+    let filter = CheckpointRowGroupFilter::new(row_group, &predicate, &NO_PARTITIONS);
+
+    // All nullCount entries are present (no nulls in the stat column), so the null guard
+    // passes. max(nullCount.x) = 0, meaning no files have nulls for x.
+    // The data skipping evaluator checks nullcount != 0 for IS NULL. Since nullcount == 0,
+    // it means no files have nulls, so IS NULL can prune.
+    let result = filter.eval_sql_where(&predicate);
+    // eval_sql_where returns Some(false) -> can skip. Semantics: no file has null values for x.
+    assert_eq!(result, Some(false));
+}
+
+#[test]
+fn checkpoint_filter_is_not_null_never_prunes() {
+    // IS NOT NULL can never prune checkpoint row groups because get_rowcount_stat() returns None.
+    let tmp = write_checkpoint_parquet(
+        &[Some(10), Some(20)],
+        &[Some(100), Some(200)],
+        &[Some(5), Some(3)],
+        "x",
+        Some(&[Some("a"), Some("b")]),
+    );
+    let metadata = checkpoint_row_group_metadata(&tmp);
+    let row_group = metadata.row_group(0);
+
+    let predicate = Predicate::is_not_null(column_name!("x"));
+    let filter = CheckpointRowGroupFilter::new(row_group, &predicate, &NO_PARTITIONS);
+
+    // IS NOT NULL checks nullcount != rowcount. Since rowcount is None, the evaluator
+    // short-circuits and returns None (can't decide), which always keeps the row group.
+    let result = filter.eval_sql_where(&predicate);
+    assert_eq!(result, None);
+}
+
+#[test]
+fn checkpoint_filter_timestamp_max_widened() {
+    // Timestamp max stats are widened by 999us to account for millisecond truncation
+    // in JSON-serialized stats (which stats_parsed inherits).
+    let tmp = write_checkpoint_parquet(
+        &[Some(10), Some(20)],
+        &[Some(100), Some(200)],
+        &[Some(0), Some(0)],
+        "x",
+        Some(&[Some("a"), Some("b")]),
+    );
+    let metadata = checkpoint_row_group_metadata(&tmp);
+    let row_group = metadata.row_group(0);
+
+    let predicate = column_pred!("x");
+    let filter = CheckpointRowGroupFilter::new(row_group, &predicate, &NO_PARTITIONS);
+
+    // max(maxValues.x) = 200, widened to 200 + 999 = 1199
+    assert_eq!(
+        filter.get_max_stat(&column_name!("x"), &DataType::TIMESTAMP),
+        Some(Scalar::Timestamp(1199))
+    );
+    assert_eq!(
+        filter.get_max_stat(&column_name!("x"), &DataType::TIMESTAMP_NTZ),
+        Some(Scalar::TimestampNtz(1199))
+    );
+
+    // Non-timestamp types are not widened.
+    assert_eq!(
+        filter.get_max_stat(&column_name!("x"), &DataType::LONG),
+        Some(200i64.into())
+    );
+}
+
+#[test]
+fn checkpoint_filter_unknown_column_returns_none() {
+    let tmp = write_checkpoint_parquet(
+        &[Some(10)],
+        &[Some(100)],
+        &[Some(0)],
+        "x",
+        Some(&[Some("a")]),
+    );
+    let metadata = checkpoint_row_group_metadata(&tmp);
+    let row_group = metadata.row_group(0);
+
+    // Predicate references column "y" which doesn't exist in the checkpoint.
+    let predicate = Predicate::gt(column_name!("y"), Scalar::from(50i64));
+    let filter = CheckpointRowGroupFilter::new(row_group, &predicate, &NO_PARTITIONS);
+
+    assert_eq!(
+        filter.get_min_stat(&column_name!("y"), &DataType::LONG),
+        None
+    );
+    assert_eq!(
+        filter.get_max_stat(&column_name!("y"), &DataType::LONG),
+        None
+    );
+    assert_eq!(filter.get_nullcount_stat(&column_name!("y")), None);
+}
+
+#[test]
+fn checkpoint_filter_mixed_partition_and_data_predicate() {
+    // Row 1 has null data stats but valid partition values.
+    // Predicate: part_col = "a" AND x > 500
+    // The partition predicate should still work, but the data predicate can't prune.
+    let tmp = write_checkpoint_parquet(
+        &[Some(10), None],
+        &[Some(100), None],
+        &[Some(0), None],
+        "x",
+        Some(&[Some("a"), Some("b")]),
+    );
+    let metadata = checkpoint_row_group_metadata(&tmp);
+    let row_group = metadata.row_group(0);
+
+    let partition_columns: HashSet<String> = ["part_col".to_string()].into();
+
+    // x > 500: data stats have nulls, can't prune. Overall AND can't prune.
+    let predicate = Predicate::and(
+        Predicate::eq(column_name!("part_col"), Scalar::from("a")),
+        Predicate::gt(column_name!("x"), Scalar::from(500i64)),
+    );
+    assert!(CheckpointRowGroupFilter::apply(
+        row_group,
+        &predicate,
+        &partition_columns
+    ));
+
+    // part_col = "c": partition stats show min="a", max="b", so "c" is out of range.
+    // But x stats are unreliable. AND("c" not in [a,b], x unknown) -- the partition arm
+    // is false, so the AND is false -> can prune!
+    let predicate = Predicate::and(
+        Predicate::eq(column_name!("part_col"), Scalar::from("c")),
+        Predicate::gt(column_name!("x"), Scalar::from(5i64)),
+    );
+    assert!(!CheckpointRowGroupFilter::apply(
+        row_group,
+        &predicate,
+        &partition_columns,
+    ));
+}
+
+/// An opaque "less than" predicate op that supports data skipping. Used to verify that
+/// `CheckpointRowGroupFilter` correctly delegates opaque predicates through the
+/// `ParquetStatsProvider` trait, where null guarding is applied by the provider.
+#[derive(Debug, PartialEq)]
+struct OpaqueLessThanOp;
+
+impl OpaquePredicateOp for OpaqueLessThanOp {
+    fn name(&self) -> &str {
+        "less_than"
+    }
+
+    fn eval_pred_scalar(
+        &self,
+        _eval_expr: &ScalarExpressionEvaluator<'_>,
+        _evaluator: &DirectPredicateEvaluator<'_>,
+        _exprs: &[Expression],
+        _inverted: bool,
+    ) -> DeltaResult<Option<bool>> {
+        unimplemented!("not needed for data skipping tests")
+    }
+
+    fn eval_as_data_skipping_predicate(
+        &self,
+        evaluator: &DirectDataSkippingPredicateEvaluator<'_>,
+        exprs: &[Expression],
+        inverted: bool,
+    ) -> Option<bool> {
+        let (col, val, ord) = match exprs {
+            [Expression::Column(col), Expression::Literal(val)] => (col, val, Ordering::Less),
+            [Expression::Literal(val), Expression::Column(col)] => (col, val, Ordering::Greater),
+            _ => return None,
+        };
+        evaluator.partial_cmp_min_stat(col, val, ord, inverted)
+    }
+
+    fn as_data_skipping_predicate(
+        &self,
+        _evaluator: &IndirectDataSkippingPredicateEvaluator<'_>,
+        _exprs: &[Expression],
+        _inverted: bool,
+    ) -> Option<Predicate> {
+        unimplemented!("not needed for data skipping tests")
+    }
+}
+
+#[test]
+fn checkpoint_filter_opaque_predicate_with_null_guarded_stats() {
+    // All stats present: opaque predicate should participate in skipping.
+    let tmp = write_checkpoint_parquet(
+        &[Some(10), Some(20)],
+        &[Some(100), Some(200)],
+        &[Some(0), Some(0)],
+        "x",
+        Some(&[Some("a"), Some("b")]),
+    );
+    let metadata = checkpoint_row_group_metadata(&tmp);
+    let row_group = metadata.row_group(0);
+
+    // OpaqueLessThanOp(x, 5) -> "x < 5". Data skipping checks min(x) < 5.
+    // min(x) = 10, so 10 < 5 is false -> can skip the row group.
+    let predicate = Predicate::opaque(
+        OpaqueLessThanOp,
+        vec![column_expr!("x"), Expression::literal(5i64)],
+    );
+    assert!(!CheckpointRowGroupFilter::apply(
+        row_group,
+        &predicate,
+        &NO_PARTITIONS
+    ));
+
+    // OpaqueLessThanOp(x, 50) -> "x < 50". min(x) = 10, so 10 < 50 is true -> keep.
+    let predicate = Predicate::opaque(
+        OpaqueLessThanOp,
+        vec![column_expr!("x"), Expression::literal(50i64)],
+    );
+    assert!(CheckpointRowGroupFilter::apply(
+        row_group,
+        &predicate,
+        &NO_PARTITIONS
+    ));
+}
+
+#[test]
+fn checkpoint_filter_opaque_predicate_with_missing_stats() {
+    // Row 1 has null stats: opaque predicate must not cause false pruning.
+    let tmp = write_checkpoint_parquet(
+        &[Some(10), None],
+        &[Some(100), None],
+        &[Some(0), None],
+        "x",
+        Some(&[Some("a"), Some("b")]),
+    );
+    let metadata = checkpoint_row_group_metadata(&tmp);
+    let row_group = metadata.row_group(0);
+
+    // OpaqueLessThanOp(x, 5) -> "x < 5". The stat column has nulls, so the null-guarded
+    // provider returns None for min(x). The opaque op gets None and returns None,
+    // which means the row group cannot be pruned. This is the safe behavior.
+    let predicate = Predicate::opaque(
+        OpaqueLessThanOp,
+        vec![column_expr!("x"), Expression::literal(5i64)],
+    );
+    assert!(CheckpointRowGroupFilter::apply(
+        row_group,
+        &predicate,
+        &NO_PARTITIONS
+    ));
+}
+
+#[test]
+fn checkpoint_filter_physical_column_names_for_column_mapping() {
+    // Simulate column mapping: the physical column name in the checkpoint parquet file is
+    // "col-abc-123" (a UUID-style name), not the logical "x". The predicate is already in
+    // physical form by the time it reaches CheckpointRowGroupFilter.
+    let physical_name = "col-abc-123";
+    let tmp = write_checkpoint_parquet(
+        &[Some(10), Some(20)],
+        &[Some(100), Some(200)],
+        &[Some(0), Some(0)],
+        physical_name,
+        None,
+    );
+    let metadata = checkpoint_row_group_metadata(&tmp);
+    let row_group = metadata.row_group(0);
+
+    let col = ColumnName::new([physical_name]);
+
+    // Predicate uses the physical column name, matching the checkpoint parquet schema.
+    // physical_col > 500: max = 200 < 500 -> can prune.
+    let predicate = Predicate::gt(col.clone(), Scalar::from(500i64));
+    assert!(!CheckpointRowGroupFilter::apply(
+        row_group,
+        &predicate,
+        &NO_PARTITIONS
+    ));
+
+    // physical_col > 50: max = 200 > 50 -> keep.
+    let predicate = Predicate::gt(col.clone(), Scalar::from(50i64));
+    assert!(CheckpointRowGroupFilter::apply(
+        row_group,
+        &predicate,
+        &NO_PARTITIONS
+    ));
+
+    // Verify stats are accessible via the physical name.
+    let predicate = Predicate::gt(col.clone(), Scalar::from(0i64));
+    let filter = CheckpointRowGroupFilter::new(row_group, &predicate, &NO_PARTITIONS);
+    assert_eq!(
+        filter.get_min_stat(&col, &DataType::LONG),
+        Some(10i64.into())
+    );
+    assert_eq!(
+        filter.get_max_stat(&col, &DataType::LONG),
+        Some(200i64.into())
+    );
+}
+
+#[test]
+fn checkpoint_filter_partition_nullcount_is_null() {
+    // All partition values are non-null, so footer nullcount for partitionValues_parsed.part_col
+    // is 0. extract_nullcount suppresses Some(0) due to the arrow-rs#9451 workaround, so
+    // get_nullcount_stat returns None. IS NULL on the partition column can't prune.
+    let tmp = write_checkpoint_parquet(
+        &[Some(10), Some(20)],
+        &[Some(100), Some(200)],
+        &[Some(0), Some(0)],
+        "x",
+        Some(&[Some("a"), Some("b")]),
+    );
+    let metadata = checkpoint_row_group_metadata(&tmp);
+    let row_group = metadata.row_group(0);
+
+    let partition_columns: HashSet<String> = ["part_col".to_string()].into();
+    let predicate = Predicate::is_null(column_name!("part_col"));
+    let filter = CheckpointRowGroupFilter::new(row_group, &predicate, &partition_columns);
+
+    // extract_nullcount never returns Some(0), so nullcount stat is None (can't decide).
+    assert_eq!(filter.get_nullcount_stat(&column_name!("part_col")), None);
+    // IS NULL evaluates to None (can't decide) -> row group is kept.
+    assert_eq!(filter.eval_sql_where(&predicate), None);
+}
+
+#[test]
+fn checkpoint_filter_multi_row_group_skipping() {
+    // Build schema: add.stats_parsed.{minValues,maxValues,nullCount}.x (INT64)
+    let col_field = Arc::new(Field::new("x", ArrowDataType::Int64, true));
+    let min_field = Arc::new(Field::new(
+        "minValues",
+        ArrowDataType::Struct(Fields::from(vec![col_field.clone()])),
+        true,
+    ));
+    let max_field = Arc::new(Field::new(
+        "maxValues",
+        ArrowDataType::Struct(Fields::from(vec![col_field.clone()])),
+        true,
+    ));
+    let nc_field = Arc::new(Field::new(
+        "nullCount",
+        ArrowDataType::Struct(Fields::from(vec![col_field.clone()])),
+        true,
+    ));
+    let stats_field = Arc::new(Field::new(
+        "stats_parsed",
+        ArrowDataType::Struct(Fields::from(vec![
+            min_field.clone(),
+            max_field.clone(),
+            nc_field.clone(),
+        ])),
+        true,
+    ));
+    let add_field = Arc::new(Field::new(
+        "add",
+        ArrowDataType::Struct(Fields::from(vec![stats_field.clone()])),
+        true,
+    ));
+    let schema = Arc::new(ArrowSchema::new(vec![add_field]));
+
+    let make_batch = |mins: &[i64], maxs: &[i64], ncs: &[i64]| {
+        let min_arr = Arc::new(Int64Array::from(mins.to_vec()));
+        let max_arr = Arc::new(Int64Array::from(maxs.to_vec()));
+        let nc_arr = Arc::new(Int64Array::from(ncs.to_vec()));
+        let min_s = StructArray::from(vec![(col_field.clone(), min_arr as _)]);
+        let max_s = StructArray::from(vec![(col_field.clone(), max_arr as _)]);
+        let nc_s = StructArray::from(vec![(col_field.clone(), nc_arr as _)]);
+        let stats_s = StructArray::from(vec![
+            (min_field.clone(), Arc::new(min_s) as _),
+            (max_field.clone(), Arc::new(max_s) as _),
+            (nc_field.clone(), Arc::new(nc_s) as _),
+        ]);
+        let add_s = StructArray::from(vec![(stats_field.clone(), Arc::new(stats_s) as _)]);
+        RecordBatch::try_new(schema.clone(), vec![Arc::new(add_s)]).unwrap()
+    };
+
+    // RG0: x in [10, 100] -> pruned by "x > 500"
+    // RG1: x in [400, 600] -> kept by "x > 500"
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let file = tmp.as_file().try_clone().unwrap();
+    #[allow(deprecated)] // renamed to set_max_row_group_row_count in newer parquet versions
+    let props = WriterProperties::builder()
+        .set_max_row_group_size(2)
+        .build();
+    let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props)).unwrap();
+    writer
+        .write(&make_batch(&[10, 20], &[50, 100], &[0, 0]))
+        .unwrap();
+    writer
+        .write(&make_batch(&[400, 450], &[500, 600], &[0, 0]))
+        .unwrap();
+    writer.close().unwrap();
+
+    let file = File::open(tmp.path()).unwrap();
+    let builder =
+        crate::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(file)
+            .unwrap();
+    assert_eq!(builder.metadata().num_row_groups(), 2);
+
+    let predicate = Predicate::gt(column_name!("x"), Scalar::from(500i64));
+    let builder = builder.with_checkpoint_row_group_filter(&predicate, &NO_PARTITIONS, None);
+
+    // Only RG1 (x in [400, 600]) survives: max(x) = 600 > 500.
+    let reader = builder.build().unwrap();
+    let batches: Vec<_> = reader.into_iter().collect::<Result<_, _>>().unwrap();
+    assert_eq!(batches.len(), 1);
+    assert_eq!(batches[0].num_rows(), 2);
+}
+
+#[test]
+fn checkpoint_filter_nested_struct_column_stats() {
+    // Build schema: add.stats_parsed.{minValues,maxValues,nullCount}.a.b (INT64)
+    // This simulates a nested struct column `a` with field `b`.
+    let b_field = Arc::new(Field::new("b", ArrowDataType::Int64, true));
+    let a_field = Arc::new(Field::new(
+        "a",
+        ArrowDataType::Struct(Fields::from(vec![b_field.clone()])),
+        true,
+    ));
+    let min_field = Arc::new(Field::new(
+        "minValues",
+        ArrowDataType::Struct(Fields::from(vec![a_field.clone()])),
+        true,
+    ));
+    let max_field = Arc::new(Field::new(
+        "maxValues",
+        ArrowDataType::Struct(Fields::from(vec![a_field.clone()])),
+        true,
+    ));
+    let nc_field = Arc::new(Field::new(
+        "nullCount",
+        ArrowDataType::Struct(Fields::from(vec![a_field.clone()])),
+        true,
+    ));
+    let stats_field = Arc::new(Field::new(
+        "stats_parsed",
+        ArrowDataType::Struct(Fields::from(vec![
+            min_field.clone(),
+            max_field.clone(),
+            nc_field.clone(),
+        ])),
+        true,
+    ));
+    let add_field = Arc::new(Field::new(
+        "add",
+        ArrowDataType::Struct(Fields::from(vec![stats_field.clone()])),
+        true,
+    ));
+    let schema = Arc::new(ArrowSchema::new(vec![add_field]));
+
+    let min_b = Arc::new(Int64Array::from(vec![Some(10), Some(20)]));
+    let max_b = Arc::new(Int64Array::from(vec![Some(100), Some(200)]));
+    let nc_b = Arc::new(Int64Array::from(vec![Some(0), Some(0)]));
+
+    let min_a = StructArray::from(vec![(b_field.clone(), min_b as _)]);
+    let max_a = StructArray::from(vec![(b_field.clone(), max_b as _)]);
+    let nc_a = StructArray::from(vec![(b_field.clone(), nc_b as _)]);
+    let min_s = StructArray::from(vec![(a_field.clone(), Arc::new(min_a) as _)]);
+    let max_s = StructArray::from(vec![(a_field.clone(), Arc::new(max_a) as _)]);
+    let nc_s = StructArray::from(vec![(a_field.clone(), Arc::new(nc_a) as _)]);
+    let stats_s = StructArray::from(vec![
+        (min_field.clone(), Arc::new(min_s) as _),
+        (max_field.clone(), Arc::new(max_s) as _),
+        (nc_field.clone(), Arc::new(nc_s) as _),
+    ]);
+    let add_s = StructArray::from(vec![(stats_field.clone(), Arc::new(stats_s) as _)]);
+    let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(add_s)]).unwrap();
+
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let file = tmp.as_file().try_clone().unwrap();
+    let mut writer = ArrowWriter::try_new(file, schema, None).unwrap();
+    writer.write(&batch).unwrap();
+    writer.close().unwrap();
+
+    let metadata = checkpoint_row_group_metadata(&tmp);
+    let row_group = metadata.row_group(0);
+
+    let col = ColumnName::new(["a", "b"]);
+    let predicate = Predicate::gt(col.clone(), Scalar::from(500i64));
+    let filter = CheckpointRowGroupFilter::new(row_group, &predicate, &NO_PARTITIONS);
+
+    assert_eq!(
+        filter.get_min_stat(&col, &DataType::LONG),
+        Some(10i64.into())
+    );
+    assert_eq!(
+        filter.get_max_stat(&col, &DataType::LONG),
+        Some(200i64.into())
+    );
+    // max(x) = 200 < 500 -> can prune.
+    assert!(!CheckpointRowGroupFilter::apply(
+        row_group,
+        &predicate,
+        &NO_PARTITIONS
+    ));
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds CheckpointRowGroupFilter, a new ParquetStatsProvider implementation for row group skipping in checkpoint parquet files.

Unlike data file row group skipping where footer stats directly correspond to data columns, checkpoint files store per-file statistics as nested columns (`add.stats_parsed.maxValues.x`). Because these stat columns can contain nulls (when files lack statistics for a column), the parquet footer min/max silently ignores those nulls and produces aggregates that don't reflect all files. Without null guarding, the filter could falsely prune row groups containing files whose actual values fall outside the reported range. 

To prevent this, the filter null-guards each stat: if a stat column contains any nulls in the row group, that stat is treated as unavailable. Partition columns (`add.partitionValues_parsed.<col>`) skip null guarding since partition values are always present in checkpoint metadata.

### This PR affects the following public APIs                                                                                  
                                                    
`ParquetStatsProvider::get_parquet_rowcount_stat` return type changed from i64 to Option<i64>.              

Checkpoint parquet files don't have a meaningful footer row count for data skipping purposes. The footer counts add action rows, not data file rows. Returning `Option<i64>` lets checkpoint filters return `None` (can't decide), while data file filters continue to return the actual row count via `Some(num_rows)`. Engines implementing ParquetStatsProvider must update  their `get_parquet_rowcount_stat` implementation to return `Some(num_rows)` instead of `num_rows`

## How was this change tested?

New unit tests