### PR TITLE
feat: Relax clustering column constraints to align with Delta protocol

### DIFF
--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -12,7 +12,6 @@ use crate::schema::{
 use crate::table_properties::{TableProperties, COLUMN_MAPPING_MODE};
 use crate::{DeltaResult, Error};
 
-use itertools::Itertools;
 use std::borrow::Cow;
 use std::collections::HashMap;
 
@@ -297,28 +296,10 @@ fn process_nested_data_type(data_type: &DataType, max_id: &mut i64) -> DeltaResu
     }
 }
 
-/// Resolves a clustering column's logical name to its physical name using column mapping metadata.
-///
-/// Uses [`StructField::physical_name`] to resolve the name based on the column mapping mode.
-/// When column mapping is disabled (mode = None), returns the logical name. When enabled,
-/// returns the physical name from the field's metadata.
-///
-/// This function only handles top-level columns. Note: the top-level restriction for
-/// clustering columns is an opinionated choice (matching delta-spark behavior), not a
-/// requirement of the Delta protocol itself.
-pub(crate) fn get_top_level_column_physical_name(
-    logical_name: &str,
-    schema: &StructType,
-    mode: ColumnMappingMode,
-) -> DeltaResult<String> {
-    let field = schema
-        .field(logical_name)
-        .ok_or_else(|| Error::generic(format!("Column '{}' not found in schema", logical_name)))?;
-
-    Ok(field.physical_name(mode).to_string())
-}
-
 /// Translates a logical [`ColumnName`] to physical. It can be top level or nested.
+///
+/// Uses `StructType::walk_column_fields` to walk the column path through nested structs,
+/// then maps each field to its physical name based on the column mapping mode.
 ///
 /// Returns an error if the column name cannot be resolved in the schema.
 #[delta_kernel_derive::internal_api]
@@ -327,26 +308,11 @@ pub(crate) fn get_any_level_column_physical_name(
     col_name: &ColumnName,
     column_mapping_mode: ColumnMappingMode,
 ) -> DeltaResult<ColumnName> {
-    let mut current_struct: Option<&StructType> = Some(schema);
-    let physical_path: Vec<String> = col_name
-        .path()
+    let fields = schema.walk_column_fields(col_name)?;
+    let physical_path: Vec<String> = fields
         .iter()
-        .map(|segment| -> DeltaResult<String> {
-            let field = current_struct
-                .and_then(|s| s.field(segment))
-                .ok_or_else(|| {
-                    Error::generic(format!(
-                        "Could not resolve column {col_name} in schema {schema}"
-                    ))
-                })?;
-            current_struct = if let DataType::Struct(s) = field.data_type() {
-                Some(s)
-            } else {
-                None
-            };
-            Ok(field.physical_name(column_mapping_mode).to_string())
-        })
-        .try_collect()?;
+        .map(|f| f.physical_name(column_mapping_mode).to_string())
+        .collect();
     Ok(ColumnName::new(physical_path))
 }
 
@@ -993,67 +959,5 @@ mod tests {
             ColumnMappingMode::None,
         );
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_get_top_level_column_physical_name_no_mapping() {
-        let schema = StructType::new_unchecked([
-            StructField::new("a", DataType::INTEGER, false),
-            StructField::new("b", DataType::STRING, true),
-        ]);
-
-        let result =
-            get_top_level_column_physical_name("a", &schema, ColumnMappingMode::None).unwrap();
-
-        // Should return logical name as-is when column mapping is disabled
-        assert_eq!(result, "a");
-    }
-
-    #[test]
-    fn test_get_top_level_column_physical_name_with_mapping() {
-        let schema = StructType::new_unchecked([
-            StructField::new("a", DataType::INTEGER, false).add_metadata([
-                (
-                    ColumnMetadataKey::ColumnMappingId.as_ref(),
-                    MetadataValue::Number(1),
-                ),
-                (
-                    ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
-                    MetadataValue::String("col-abc123".to_string()),
-                ),
-            ]),
-            StructField::new("b", DataType::STRING, true).add_metadata([
-                (
-                    ColumnMetadataKey::ColumnMappingId.as_ref(),
-                    MetadataValue::Number(2),
-                ),
-                (
-                    ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
-                    MetadataValue::String("col-def456".to_string()),
-                ),
-            ]),
-        ]);
-
-        let result =
-            get_top_level_column_physical_name("a", &schema, ColumnMappingMode::Name).unwrap();
-
-        // Should return physical name
-        assert_eq!(result, "col-abc123");
-    }
-
-    #[test]
-    fn test_get_top_level_column_physical_name_not_found() {
-        let schema = StructType::new_unchecked([StructField::new("a", DataType::INTEGER, false)]);
-
-        let result =
-            get_top_level_column_physical_name("nonexistent", &schema, ColumnMappingMode::Name);
-
-        assert!(result.is_err());
-        let err_msg = result.unwrap_err().to_string();
-        assert!(
-            err_msg.contains("not found in schema"),
-            "Expected 'not found in schema' error, got: {}",
-            err_msg
-        );
     }
 }

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -16,7 +16,6 @@ pub use column_mapping::get_any_level_column_physical_name;
 pub(crate) use column_mapping::get_any_level_column_physical_name;
 pub(crate) use column_mapping::{
     assign_column_mapping_metadata, column_mapping_mode, get_column_mapping_mode_from_properties,
-    get_top_level_column_physical_name,
 };
 pub use column_mapping::{validate_schema_column_mapping, ColumnMappingMode};
 pub(crate) use timestamp_ntz::validate_timestamp_ntz_feature_support;

--- a/kernel/tests/create_table/column_mapping.rs
+++ b/kernel/tests/create_table/column_mapping.rs
@@ -454,3 +454,112 @@ fn test_column_mapping_schema_with_maps_and_arrays() -> DeltaResult<()> {
 
     Ok(())
 }
+
+/// Builds a schema that supports clustering at depths 1, 2, and 5:
+///   { id: int, name: string, address: { city: string, zip: string },
+///     l1: { l2: { l3: { l4: { value: double } } } } }
+fn clustering_cm_test_schema() -> DeltaResult<Arc<StructType>> {
+    let address = StructType::try_new(vec![
+        StructField::new("city", DataType::STRING, true),
+        StructField::new("zip", DataType::STRING, true),
+    ])?;
+    let l4 = StructType::try_new(vec![StructField::new("value", DataType::DOUBLE, true)])?;
+    let l3 = StructType::try_new(vec![StructField::new(
+        "l4",
+        DataType::Struct(Box::new(l4)),
+        true,
+    )])?;
+    let l2 = StructType::try_new(vec![StructField::new(
+        "l3",
+        DataType::Struct(Box::new(l3)),
+        true,
+    )])?;
+    let l1 = StructType::try_new(vec![StructField::new(
+        "l2",
+        DataType::Struct(Box::new(l2)),
+        true,
+    )])?;
+    Ok(Arc::new(StructType::try_new(vec![
+        StructField::new("id", DataType::INTEGER, false),
+        StructField::new("name", DataType::STRING, true),
+        StructField::new("address", DataType::Struct(Box::new(address)), true),
+        StructField::new("l1", DataType::Struct(Box::new(l1)), true),
+    ])?))
+}
+
+#[rstest::rstest]
+#[case::top_level_cm_none(vec![vec!["id"]], "none")]
+#[case::top_level_cm_name(vec![vec!["id"]], "name")]
+#[case::top_level_cm_id(vec![vec!["id"]], "id")]
+#[case::nested_2_cm_none(vec![vec!["address", "city"]], "none")]
+#[case::nested_2_cm_name(vec![vec!["address", "city"]], "name")]
+#[case::nested_2_cm_id(vec![vec!["address", "city"]], "id")]
+#[case::mixed_cm_none(vec![vec!["id"], vec!["name"], vec!["address", "city"], vec!["address", "zip"], vec!["l1", "l2", "l3", "l4", "value"]], "none")]
+#[case::mixed_cm_name(vec![vec!["id"], vec!["name"], vec!["address", "city"], vec!["address", "zip"], vec!["l1", "l2", "l3", "l4", "value"]], "name")]
+#[case::mixed_cm_id(vec![vec!["id"], vec!["name"], vec!["address", "city"], vec!["address", "zip"], vec!["l1", "l2", "l3", "l4", "value"]], "id")]
+#[test]
+fn test_create_clustered_table_nested_with_column_mapping(
+    #[case] col_paths: Vec<Vec<&str>>,
+    #[case] cm_mode: &str,
+) -> DeltaResult<()> {
+    use delta_kernel::expressions::ColumnName;
+
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let schema = clustering_cm_test_schema()?;
+    let expected_cols: Vec<ColumnName> = col_paths
+        .iter()
+        .map(|p| ColumnName::new(p.iter().copied()))
+        .collect();
+
+    let _ = create_table(&table_path, schema, "Test/1.0")
+        .with_table_properties([("delta.columnMapping.mode", cm_mode)])
+        .with_data_layout(DataLayout::Clustered {
+            columns: expected_cols.clone(),
+        })
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?;
+
+    let table_url = delta_kernel::try_parse_uri(&table_path)?;
+    let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+
+    let table_configuration = snapshot.table_configuration();
+    assert!(
+        table_configuration.is_feature_supported(&TableFeature::DomainMetadata),
+        "Protocol should support domainMetadata feature"
+    );
+    assert!(
+        table_configuration.is_feature_supported(&TableFeature::ClusteredTable),
+        "Protocol should support clustering feature"
+    );
+
+    let expected_cm_mode = match cm_mode {
+        "name" => ColumnMappingMode::Name,
+        "id" => ColumnMappingMode::Id,
+        _ => ColumnMappingMode::None,
+    };
+    assert_column_mapping_config(&snapshot, expected_cm_mode);
+
+    let clustering_columns = snapshot.get_clustering_columns(engine.as_ref())?;
+    let columns = clustering_columns.expect("Clustering columns should be present");
+    assert_eq!(columns.len(), expected_cols.len());
+
+    for (col, expected_path) in columns.iter().zip(col_paths.iter()) {
+        assert_eq!(col.path().len(), expected_path.len());
+        match expected_cm_mode {
+            ColumnMappingMode::Name | ColumnMappingMode::Id => {
+                for field_name in col.path() {
+                    assert!(
+                        field_name.starts_with("col-"),
+                        "Clustering path field '{field_name}' should use physical name"
+                    );
+                }
+            }
+            ColumnMappingMode::None => {
+                let expected_col = ColumnName::new(expected_path.iter().copied());
+                assert_eq!(*col, expected_col);
+            }
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Resolves #1794

## What changes are proposed in this pull request?
Remove the MAX_CLUSTERING_COLUMNS=4 limit and the top-level-only requirement from clustering column validation. Neither constraint is specified by the Delta protocol; the column limit originated from the Delta-Spark connector configuration and the top-level restriction was an opinionated choice.

Changes:
- Add StructType::resolve_column() unified helper for walking column paths through nested structs
- Refactor validate_clustering_columns to use resolve_column, supporting nested columns with stats-eligible leaf types
- Refactor get_any_level_column_physical_name to use resolve_column and removes get_top_level_column_physical_name.
- Update maybe_enable_clustering to use get_any_level_column_physical_name for both top-level and nested columns
- Update DataLayout docs to reflect nested column support

## How was this change tested?
- Adds unit and integration tests for nested clustering columns (with and without column mapping)