### PR TITLE
fix!: Parquet footer skipping cannot trust nullcount=0 stat

### DIFF
--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -61,7 +61,7 @@
 //! let state = checkpoint_data.state();
 //!
 //! // Write the checkpoint data to the object store and collect metadata
-//! let metadata: FileMeta = write_checkpoint_file(checkpoint_path, &checkpoint_data)?;
+//! let metadata: FileMeta = write_checkpoint_file(checkpoint_path, &mut checkpoint_data)?;
 //!
 //! /* IMPORTANT: All data must be written before finalizing the checkpoint */
 //!

--- a/kernel/src/engine/parquet_row_group_skipping/tests.rs
+++ b/kernel/src/engine/parquet_row_group_skipping/tests.rs
@@ -66,9 +66,11 @@ fn test_get_stat_values() {
         filter.get_nullcount_stat(&column_name!("bool")),
         Some(3i64.into())
     );
+
+    // Should be Some(0), but https://github.com/apache/arrow-rs/issues/9451
     assert_eq!(
         filter.get_nullcount_stat(&column_name!("varlen.utf8")),
-        Some(0i64.into())
+        None // Some(0i64.into())
     );
 
     assert_eq!(

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -999,12 +999,14 @@ fn apply_row_group_filter(parquet_bytes: Bytes, meta_predicate: &Pred) -> usize 
 #[rstest]
 #[case::comparison(
     Pred::gt(column_expr!("id"), Expr::literal(200i64)),
-    Some(3),
+    // Should skip RG2 and RG3, but https://github.com/apache/arrow-rs/issues/9451
+    Some(6), // Some(3),
     "keep RG 0 (null stats) + RG 1 (max>200), skip RG 2 + RG 3 (max<200)"
 )]
 #[case::is_null(
     Pred::is_null(column_expr!("id")),
-    Some(5),
+    // Should skip RG 1 (nullCount=0), but https://github.com/apache/arrow-rs/issues/9451
+    Some(6), // Some(5),
     "keep RG 0 (nullCount>0) + RG 2 (nullCount>0) + RG 3 (null nullCount), skip RG 1 (nullCount=0)"
 )]
 #[case::is_not_null(


### PR DESCRIPTION
## What changes are proposed in this pull request?

It turns out that arrow-rs parquet reader interprets missing nullcount stats as nullcount=0
* https://github.com/apache/arrow-rs/issues/9451

That means row group skipping cannot safely rely on nullcount=0 when pruning files. 

Forcibly filter out `Some(0)` nullcount stats for safety, without disabling pruning altogether.

## Behavior change

No API changed, but row group pruning that used to succeed could start failing now.

## How was this change tested?

Several unit tests broke, they're fixed now.