### PR TITLE
Revert "chore: pin native-tls to 0.2.16 due to upstream breakage"

### DIFF
--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -22,9 +22,6 @@ tracing = "0.1"
 tracing-core = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", optional = true, features = [ "json" ] }
 url = "2"
-# Pin native-tls due to 0.2.17 regression:
-# https://github.com/rust-native-tls/rust-native-tls/issues/370
-native-tls = { version = "<0.2.17", optional = true }
 delta_kernel = { path = "../kernel", default-features = false, features = [
   "internal-api",
 ] }
@@ -48,7 +45,7 @@ object_store = "0.12.3"
 
 [features]
 default = ["default-engine-rustls"]
-default-engine-native-tls = ["delta_kernel/default-engine-native-tls", "default-engine-base", "dep:native-tls"]
+default-engine-native-tls = ["delta_kernel/default-engine-native-tls", "default-engine-base"]
 default-engine-rustls = ["delta_kernel/default-engine-rustls", "default-engine-base"]
 catalog-managed = ["delta_kernel/catalog-managed"]
 

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -60,9 +60,6 @@ z85 = "3.0.6"
 futures = { version = "0.3", optional = true }
 # Used for fetching direct urls (like pre-signed urls)
 reqwest = { version = "0.13", optional = true }
-# Pin native-tls due to 0.2.17 regression:
-# https://github.com/rust-native-tls/rust-native-tls/issues/370
-native-tls = { version = "<0.2.17", optional = true }
 # optionally used with default engine (though not required)
 tokio = { version = "1.47", optional = true, features = ["rt-multi-thread"] }
 # both arrow versions below are optional and require object_store
@@ -134,7 +131,7 @@ default-engine-base = [
 ]
 # the default-engine-native-tls use the reqwest crate with default features which uses native-tls. if you want
 # to instead use rustls, use 'default-engine-rustls' which has no native-tls dependency
-default-engine-native-tls = ["default-engine-base", "reqwest/native-tls", "dep:native-tls"]
+default-engine-native-tls = ["default-engine-base", "reqwest/native-tls"]
 default-engine-rustls = [
   "default-engine-base",
   "reqwest/http2",

--- a/uc-client/Cargo.toml
+++ b/uc-client/Cargo.toml
@@ -15,9 +15,6 @@ release = false
 
 [dependencies]
 reqwest = { version = "0.13", features = ["http2", "json"] }
-# Pin native-tls due to 0.2.17 regression:
-# https://github.com/rust-native-tls/rust-native-tls/issues/370
-native-tls = "<0.2.17"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
* Revert delta-io/delta-kernel-rs#1880 because https://github.com/rust-native-tls/rust-native-tls/issues/370 was fixed by 0.2.18 release.
