### PR TITLE
chore: incorporate arrow 58 and drop arrow 56 into default engine

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 # - read-table-multi-threaded
 # - read-table-single-threaded
 # - write-table
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
 edition = "2021"
@@ -27,5 +27,5 @@ keywords = ["deltalake", "delta", "datalake"]
 license = "Apache-2.0"
 repository = "https://github.com/delta-io/delta-kernel-rs"
 readme = "README.md"
-rust-version = "1.85"
+rust-version = "1.88"
 version = "0.20.0"

--- a/acceptance/Cargo.toml
+++ b/acceptance/Cargo.toml
@@ -22,7 +22,7 @@ delta_kernel = { path = "../kernel", features = [
 ] }
 futures = "0.3"
 itertools = "0.14"
-object_store = "0.12.3" # must 'match' arrow version above
+object_store = "0.13.1" # must 'match' arrow version above
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -11,7 +11,7 @@ rust-version.workspace = true
 [dependencies]
 delta_kernel = { path = "../kernel", features = ["arrow", "default-engine-rustls", "internal-api"] }
 flate2 = "1"
-object_store = "0.12.3"
+object_store = "0.13.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tar = "0.4"

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -43,7 +43,7 @@ tokio = { version = "1.47" }
 trybuild = "1.0"
 tempfile = "3.20.0"
 itertools = "0.14.0"
-object_store = "0.12.3"
+object_store = "0.13.1"
 
 [features]
 default = ["default-engine-rustls"]

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1006,7 +1006,7 @@ mod tests {
     use delta_kernel::engine::default::DefaultEngineBuilder;
     use object_store::memory::InMemory;
     use object_store::path::Path;
-    use object_store::ObjectStore;
+    use object_store::ObjectStoreExt;
     use serde_json::Value;
     use test_utils::{
         actions_to_string, actions_to_string_partitioned, add_commit, TestAction, METADATA,

--- a/ffi/src/table_changes.rs
+++ b/ffi/src/table_changes.rs
@@ -348,7 +348,7 @@ mod tests {
     use delta_kernel::Engine;
     use delta_kernel_ffi::engine_data::get_engine_data;
     use itertools::Itertools;
-    use object_store::{memory::InMemory, path::Path, ObjectStore};
+    use object_store::{memory::InMemory, path::Path, ObjectStore, ObjectStoreExt};
     use std::sync::Arc;
     use test_utils::{
         actions_to_string_with_metadata, add_commit, generate_batch, record_batch_to_bytes,

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -205,7 +205,7 @@ mod tests {
 
     use itertools::Itertools;
     use object_store::path::Path;
-    use object_store::ObjectStore;
+    use object_store::ObjectStoreExt;
     use serde_json::json;
     use serde_json::Deserializer;
 

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -63,29 +63,25 @@ reqwest = { version = "0.13", optional = true }
 # optionally used with default engine (though not required)
 tokio = { version = "1.47", optional = true, features = ["rt-multi-thread"] }
 # both arrow versions below are optional and require object_store
-object_store = { version = "0.12.3", optional = true, features = ["aws", "azure", "gcp", "http"] }
+object_store = { version = "0.13.1", optional = true, features = ["aws", "azure", "gcp", "http"] }
+# This is required to be pinned for some MSRV violations with 7.2.2.
+# see <https://github.com/apache/arrow-rs/pull/9501>
+comfy-table = { version = "=7.2.1", optional = true }
 
-# arrow 56
-[dependencies.arrow_56]
-package = "arrow"
-version = "56"
-features = ["chrono-tz", "ffi", "json", "prettyprint"]
-optional = true
-[dependencies.parquet_56]
-package = "parquet"
-version = "56"
-features = ["async", "object_store"]
-optional = true
+# At the moment arrow 57 and 58 have different majorish versions of
+# object_store with a lot of incompatibilities
+#
+# Once arrow 59 has been released then the default arrow engine can resume supporting multiple arrow versions
 
-# arrow 57
-[dependencies.arrow_57]
+# arrow 58
+[dependencies.arrow_58]
 package = "arrow"
-version = "57"
-features = ["chrono-tz", "ffi", "json", "prettyprint"]
+version = "58"
+features = ["chrono-tz", "ffi", "json"]
 optional = true
-[dependencies.parquet_57]
+[dependencies.parquet_58]
 package = "parquet"
-version = "57"
+version = "58"
 features = ["async", "object_store"]
 optional = true
 
@@ -95,16 +91,17 @@ default = []
 # internal-api will make everything marked #[internal_api] public
 internal-api = []
 # test-utils exposes test-only constructors for downstream crate tests
-test-utils = []
+# The `prettyprint` dependency is only needed when testing, and can bring in
+# some other unwanted dependencies for most arrow use
+test-utils = ["dep:comfy-table", "arrow_58/prettyprint"]
 # integration-test turns on a particularly heavy test for hdfs-object-store
 integration-test = ["hdfs-native-object-store/integration-test"]
 
 # The default versions for arrow/parquet/object_store
-arrow = ["arrow-57"] # latest arrow version
+arrow = ["arrow-58"] # latest arrow version
 need-arrow = [] # need-arrow is a marker that the feature needs arrow dep
 
-arrow-56 = ["dep:arrow_56", "dep:parquet_56", "object_store"]
-arrow-57 = ["dep:arrow_57", "dep:parquet_57", "object_store"]
+arrow-58 = ["dep:arrow_58", "dep:parquet_58", "dep:object_store"]
 arrow-conversion = ["need-arrow"]
 arrow-expression = ["need-arrow"]
 
@@ -140,8 +137,8 @@ delta_kernel = { path = ".", features = ["arrow", "catalog-managed", "default-en
 test_utils = { path = "../test-utils" }
 criterion = "0.5"
 # Used for testing parse_url_opts extensibility
-hdfs-native-object-store = { version = "0.15.0" }
-hdfs-native = "0.12.2"
+hdfs-native-object-store = { version = "0.16.0" }
+hdfs-native = "0.13"
 walkdir = { version = "2.5.0" }
 async-trait = "0.1" # only used for our custom SlowGetStore ObjectStore implementation
 paste = "1.0"

--- a/kernel/examples/checkpoint-table/Cargo.toml
+++ b/kernel/examples/checkpoint-table/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-arrow = { version = "57", features = ["prettyprint", "chrono-tz"] }
+arrow = { version = "58", features = ["prettyprint", "chrono-tz"] }
 clap = { version = "4.5", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
 # NB: common depends on 'arrow' (latest) so have to match here
@@ -16,8 +16,8 @@ delta_kernel = { path = "../../../kernel", features = [
   "internal-api",
 ] }
 env_logger = "0.11.8"
-object_store = { version = "0.12.3", features = ["aws", "azure", "gcp", "http"] }
-parquet = { version = "57" }
+object_store = { version = "0.13.1", features = ["aws", "azure", "gcp", "http"] }
+parquet = { version = "58", features = ["async"] }
 tokio = { version = "1.0", features = ["full"] }
 url = "2"
 bytes = "1.11.0"

--- a/kernel/examples/common/Cargo.toml
+++ b/kernel/examples/common/Cargo.toml
@@ -17,5 +17,5 @@ delta_kernel = { path = "../../../kernel", features = [
   "default-engine-rustls",
   "internal-api",
 ] }
-object_store = { version = "0.12.3", features = ["aws", "azure", "gcp", "http"] }
+object_store = { version = "0.13.1", features = ["aws", "azure", "gcp", "http"] }
 url = "2"

--- a/kernel/examples/read-table-changes/Cargo.toml
+++ b/kernel/examples/read-table-changes/Cargo.toml
@@ -15,5 +15,6 @@ delta_kernel = { path = "../../../kernel", features = [
   "arrow",
   "default-engine-rustls",
   "internal-api",
+  "test-utils",
 ] }
 itertools = "0.14"

--- a/kernel/examples/read-table-multi-threaded/Cargo.toml
+++ b/kernel/examples/read-table-multi-threaded/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-arrow = { version = "57", features = ["prettyprint", "chrono-tz"] }
+arrow = { version = "58", features = ["prettyprint", "chrono-tz"] }
 clap = { version = "4.5", features = ["derive"] }
 # common pulls in arrow latest so we have to keep all these in sync here
 common = { path = "../common" }

--- a/kernel/examples/read-table-single-threaded/Cargo.toml
+++ b/kernel/examples/read-table-single-threaded/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-arrow = { version = "57", features = ["prettyprint", "chrono-tz"] }
+arrow = { version = "58", features = ["prettyprint", "chrono-tz"] }
 clap = { version = "4.5", features = ["derive"] }
 common = { path = "../common" }
 delta_kernel = { path = "../../../kernel", features = [

--- a/kernel/examples/write-table/Cargo.toml
+++ b/kernel/examples/write-table/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-arrow = { version = "57", features = ["prettyprint", "chrono-tz"] }
+arrow = { version = "58", features = ["prettyprint", "chrono-tz"] }
 clap = { version = "4.5", features = ["derive"] }
 # NB: common depends on 'arrow' (latest) so have to match here
 common = { path = "../common" }

--- a/kernel/src/arrow_compat.rs
+++ b/kernel/src/arrow_compat.rs
@@ -1,25 +1,15 @@
 //! This module re-exports the different versions of arrow, parquet, and object_store we support.
 
-#[cfg(feature = "arrow-57")]
+#[cfg(feature = "arrow-58")]
 mod arrow_compat_shims {
-    pub use arrow_57 as arrow;
-    pub use parquet_57 as parquet;
-}
-
-#[cfg(all(feature = "arrow-56", not(feature = "arrow-57"),))]
-mod arrow_compat_shims {
-    pub use arrow_56 as arrow;
-    pub use parquet_56 as parquet;
+    pub use arrow_58 as arrow;
+    pub use parquet_58 as parquet;
 }
 
 // if nothing is enabled but we need arrow because of some other feature flag, throw compile-time
 // error
-#[cfg(all(
-    feature = "need-arrow",
-    not(feature = "arrow-56"),
-    not(feature = "arrow-57")
-))]
-compile_error!("Requested a feature that needs arrow without enabling arrow. Please enable the `arrow-56`, or `arrow-57` feature");
+#[cfg(all(feature = "need-arrow", not(feature = "arrow-58"),))]
+compile_error!("Requested a feature that needs arrow without enabling arrow. Please enable the `arrow-58`, or `arrow-57` feature");
 
-#[cfg(any(feature = "arrow-56", feature = "arrow-57"))]
+#[cfg(feature = "arrow-58")]
 pub use arrow_compat_shims::*;

--- a/kernel/src/checkpoint/tests.rs
+++ b/kernel/src/checkpoint/tests.rs
@@ -21,7 +21,7 @@ use crate::utils::test_utils::Action;
 use crate::{DeltaResult, FileMeta, LogPath, Snapshot};
 
 use object_store::local::LocalFileSystem;
-use object_store::{memory::InMemory, path::Path, ObjectStore};
+use object_store::{memory::InMemory, path::Path, ObjectStoreExt};
 use serde_json::{from_slice, json, Value};
 use tempfile::tempdir;
 use test_utils::delta_path_for_version;

--- a/kernel/src/committer/filesystem.rs
+++ b/kernel/src/committer/filesystem.rs
@@ -93,7 +93,7 @@ mod tests {
     use crate::path::LogRoot;
 
     use object_store::memory::InMemory;
-    use object_store::ObjectStore as _;
+    use object_store::ObjectStoreExt;
     use url::Url;
 
     #[cfg(feature = "catalog-managed")]

--- a/kernel/src/engine/default/filesystem.rs
+++ b/kernel/src/engine/default/filesystem.rs
@@ -8,7 +8,7 @@ use delta_kernel_derive::internal_api;
 use futures::stream::{self, BoxStream, Stream, StreamExt, TryStreamExt};
 use itertools::Itertools;
 use object_store::path::Path;
-use object_store::{DynObjectStore, ObjectStore, PutMode};
+use object_store::{self, DynObjectStore, ObjectStoreExt, PutMode};
 use url::Url;
 
 use super::UrlExt;
@@ -407,8 +407,8 @@ mod tests {
     use std::time::Duration;
 
     use itertools::Itertools;
+    use object_store::local::LocalFileSystem;
     use object_store::memory::InMemory;
-    use object_store::{local::LocalFileSystem, ObjectStore};
 
     use test_utils::delta_path_for_version;
 

--- a/kernel/src/engine/default/json.rs
+++ b/kernel/src/engine/default/json.rs
@@ -11,7 +11,7 @@ use bytes::{Buf, Bytes};
 use futures::stream::{self, BoxStream};
 use futures::{ready, StreamExt, TryStreamExt};
 use object_store::path::Path;
-use object_store::{self, DynObjectStore, GetResultPayload, PutMode};
+use object_store::{self, DynObjectStore, GetResultPayload, ObjectStoreExt, PutMode};
 use url::Url;
 
 use super::executor::TaskExecutor;
@@ -260,7 +260,6 @@ async fn open_json_file(
 #[cfg(test)]
 mod tests {
     use std::collections::{HashMap, HashSet, VecDeque};
-    use std::ops::Range;
     use std::path::PathBuf;
     use std::sync::{mpsc, Arc, Mutex};
     use std::task::Waker;
@@ -280,8 +279,8 @@ mod tests {
     use object_store::memory::InMemory;
     use object_store::PutMultipartOptions;
     use object_store::{
-        GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore, PutOptions,
-        PutPayload, PutResult, Result,
+        GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+        ObjectStoreExt, PutOptions, PutPayload, PutResult, Result,
     };
     use serde_json::json;
     use tracing::info;
@@ -351,8 +350,13 @@ mod tests {
 
     #[async_trait::async_trait]
     impl<T: ObjectStore> ObjectStore for OrderedGetStore<T> {
-        async fn put(&self, location: &Path, payload: PutPayload) -> Result<PutResult> {
-            self.inner.put(location, payload).await
+        async fn copy_opts(
+            &self,
+            from: &Path,
+            to: &Path,
+            opts: object_store::CopyOptions,
+        ) -> Result<()> {
+            self.inner.copy_opts(from, to, opts).await
         }
 
         async fn put_opts(
@@ -362,10 +366,6 @@ mod tests {
             opts: PutOptions,
         ) -> Result<PutResult> {
             self.inner.put_opts(location, payload, opts).await
-        }
-
-        async fn put_multipart(&self, location: &Path) -> Result<Box<dyn MultipartUpload>> {
-            self.inner.put_multipart(location).await
         }
 
         async fn put_multipart_opts(
@@ -380,9 +380,15 @@ mod tests {
         // - if yes, remove the path from the queue and proceed with the GET request, then wake the
         //   next path in order
         // - if no, register the waker and wait
-        async fn get(&self, location: &Path) -> Result<GetResult> {
+        async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
             // Do the actual GET request first, then introduce any artificial ordering delays as needed
-            let result = self.inner.get(location).await;
+            let result = self.inner.get_opts(location, options.clone()).await;
+
+            // As of object_store 0.13 an ObjectStore.head() call _actually_ routes through to
+            // get_opts which can cause some unxpected behavior in our ordering tests
+            if options.head {
+                return result;
+            }
 
             // we implement a future which only resolves once the requested path is next in order
             future::poll_fn(move |cx| {
@@ -438,56 +444,19 @@ mod tests {
             result
         }
 
-        async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
-            self.inner.get_opts(location, options).await
-        }
-
-        async fn get_range(&self, location: &Path, range: Range<u64>) -> Result<Bytes> {
-            self.inner.get_range(location, range).await
-        }
-
-        async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> Result<Vec<Bytes>> {
-            self.inner.get_ranges(location, ranges).await
-        }
-
-        async fn head(&self, location: &Path) -> Result<ObjectMeta> {
-            self.inner.head(location).await
-        }
-
-        async fn delete(&self, location: &Path) -> Result<()> {
-            self.inner.delete(location).await
-        }
-
         fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, Result<ObjectMeta>> {
             self.inner.list(prefix)
-        }
-
-        fn list_with_offset(
-            &self,
-            prefix: Option<&Path>,
-            offset: &Path,
-        ) -> BoxStream<'static, Result<ObjectMeta>> {
-            self.inner.list_with_offset(prefix, offset)
         }
 
         async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {
             self.inner.list_with_delimiter(prefix).await
         }
 
-        async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
-            self.inner.copy(from, to).await
-        }
-
-        async fn rename(&self, from: &Path, to: &Path) -> Result<()> {
-            self.inner.rename(from, to).await
-        }
-
-        async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
-            self.inner.copy_if_not_exists(from, to).await
-        }
-
-        async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
-            self.inner.rename_if_not_exists(from, to).await
+        fn delete_stream(
+            &self,
+            locations: BoxStream<'static, Result<Path>>,
+        ) -> BoxStream<'static, Result<Path>> {
+            self.inner.delete_stream(locations)
         }
     }
 

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -19,7 +19,7 @@ use crate::parquet::arrow::async_writer::ParquetObjectWriter;
 use futures::stream::{self, BoxStream};
 use futures::{StreamExt, TryStreamExt};
 use object_store::path::Path;
-use object_store::{DynObjectStore, ObjectStore};
+use object_store::{self, DynObjectStore, ObjectStoreExt};
 use uuid::Uuid;
 
 use super::file_stream::{FileOpenFuture, FileOpener, FileStream};
@@ -578,7 +578,7 @@ mod tests {
     use crate::EngineData;
 
     use itertools::Itertools;
-    use object_store::{local::LocalFileSystem, memory::InMemory, ObjectStore};
+    use object_store::{local::LocalFileSystem, memory::InMemory};
     use url::Url;
 
     use crate::utils::current_time_ms;

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -117,7 +117,7 @@ mod row_tracking;
 pub(crate) mod clustering;
 
 mod arrow_compat;
-#[cfg(any(feature = "arrow-56", feature = "arrow-57"))]
+#[cfg(feature = "arrow-58")]
 pub use arrow_compat::*;
 
 pub(crate) mod column_trie;

--- a/kernel/src/log_compaction/tests.rs
+++ b/kernel/src/log_compaction/tests.rs
@@ -236,7 +236,7 @@ async fn test_no_compaction_staged_commits() {
     use crate::actions::Add;
     use crate::engine::default::DefaultEngineBuilder;
     use crate::table_features::TableFeature;
-    use object_store::{memory::InMemory, path::Path, ObjectStore};
+    use object_store::{memory::InMemory, path::Path, ObjectStoreExt};
     use std::sync::Arc;
 
     // Set up in-memory store

--- a/kernel/src/log_compaction/writer.rs
+++ b/kernel/src/log_compaction/writer.rs
@@ -15,7 +15,7 @@ pub fn should_compact(commit_version: Version, compaction_interval: Version) -> 
     // Commits start at 0, so we add one to the commit version to check if we've hit the interval
     compaction_interval > 0
         && commit_version > 0
-        && ((commit_version + 1) % compaction_interval) == 0
+        && (commit_version + 1).is_multiple_of(compaction_interval)
 }
 
 /// Writer for log compaction files

--- a/kernel/src/log_segment/crc_tests.rs
+++ b/kernel/src/log_segment/crc_tests.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use object_store::memory::InMemory;
-use object_store::ObjectStore;
+use object_store::ObjectStoreExt;
 use serde_json::json;
 use url::Url;
 

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::sync::LazyLock;
 
 use itertools::Itertools;
-use object_store::{memory::InMemory, path::Path, ObjectStore};
+use object_store::{memory::InMemory, path::Path, ObjectStoreExt};
 use url::Url;
 
 use crate::actions::visitors::AddVisitor;

--- a/kernel/src/log_segment_files.rs
+++ b/kernel/src/log_segment_files.rs
@@ -424,7 +424,7 @@ impl LogSegmentFiles {
 mod list_log_files_with_log_tail_tests {
     use std::sync::Arc;
 
-    use object_store::{memory::InMemory, path::Path as ObjectPath, ObjectStore};
+    use object_store::{memory::InMemory, path::Path as ObjectPath, ObjectStoreExt};
     use url::Url;
 
     use crate::engine::default::executor::tokio::TokioBackgroundExecutor;

--- a/kernel/src/parallel/parallel_phase.rs
+++ b/kernel/src/parallel/parallel_phase.rs
@@ -141,7 +141,7 @@ mod tests {
     use crate::{PredicateRef, SnapshotRef};
     use object_store::memory::InMemory;
     use object_store::path::Path;
-    use object_store::ObjectStore;
+    use object_store::{ObjectStore, ObjectStoreExt};
     use std::collections::HashSet;
     use std::sync::Arc;
     use std::thread;

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -854,7 +854,7 @@ mod tests {
     use object_store::local::LocalFileSystem;
     use object_store::memory::InMemory;
     use object_store::path::Path;
-    use object_store::ObjectStore;
+    use object_store::ObjectStoreExt;
     use serde_json::json;
     use test_utils::{add_commit, delta_path_for_version};
 

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -165,7 +165,7 @@ mod tests {
 
     use itertools::Itertools;
     use object_store::memory::InMemory;
-    use object_store::ObjectStore;
+    use object_store::{ObjectStore, ObjectStoreExt};
     use serde_json::json;
 
     use super::*;

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -151,7 +151,7 @@ pub(crate) mod test_utils {
 
     use itertools::Itertools;
     use object_store::local::LocalFileSystem;
-    use object_store::ObjectStore;
+    use object_store::ObjectStoreExt;
     use serde::Serialize;
     use tempfile::TempDir;
     use test_utils::{delta_path_for_version, load_test_data};

--- a/kernel/tests/checkpoint_transform.rs
+++ b/kernel/tests/checkpoint_transform.rs
@@ -23,7 +23,7 @@ use delta_kernel::Snapshot;
 
 use object_store::memory::InMemory;
 use object_store::path::Path;
-use object_store::ObjectStore;
+use object_store::ObjectStoreExt;
 use serde_json::json;
 use test_utils::{insert_data, read_scan, write_batch_to_table};
 use url::Url;

--- a/kernel/tests/create_table/ctas.rs
+++ b/kernel/tests/create_table/ctas.rs
@@ -22,7 +22,7 @@ use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::transaction::CommitResult;
 use delta_kernel::{Engine, FileMeta};
 use object_store::path::Path;
-use object_store::ObjectStore;
+use object_store::{ObjectStore, ObjectStoreExt};
 use url::Url;
 
 use test_utils::{

--- a/kernel/tests/dv.rs
+++ b/kernel/tests/dv.rs
@@ -13,6 +13,7 @@ use delta_kernel::engine_data::FilteredEngineData;
 use delta_kernel::schema::{DataType, StructField, StructType};
 use delta_kernel::transaction::CommitResult;
 use delta_kernel::{DeltaResult, EngineData, Snapshot};
+use object_store::ObjectStoreExt;
 use tempfile::tempdir;
 use test_utils::{
     create_add_files_metadata, create_table, engine_store_setup, generate_batch, into_record_batch,

--- a/kernel/tests/log_compaction.rs
+++ b/kernel/tests/log_compaction.rs
@@ -7,7 +7,7 @@ use delta_kernel::Snapshot;
 use test_utils::{create_table, engine_store_setup};
 
 use object_store::path::Path;
-use object_store::ObjectStore;
+use object_store::ObjectStoreExt;
 use url::Url;
 
 /// Convert a URL to an object_store::Path

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -20,7 +20,7 @@ use delta_kernel::schema::{DataType, MetadataColumnSpec, Schema, StructField, St
 use delta_kernel::{Engine, FileMeta, Snapshot};
 
 use itertools::Itertools;
-use object_store::{memory::InMemory, path::Path, ObjectStore};
+use object_store::{memory::InMemory, path::Path, ObjectStoreExt};
 use test_utils::{
     actions_to_string, add_commit, generate_batch, generate_simple_batch, into_record_batch,
     load_test_data, read_scan, record_batch_to_bytes, record_batch_to_bytes_with_props, IntoArray,

--- a/kernel/tests/row_tracking.rs
+++ b/kernel/tests/row_tracking.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use itertools::Itertools;
-use object_store::{path::Path, ObjectStore};
+use object_store::{path::Path, ObjectStore, ObjectStoreExt};
 use serde_json::{Deserializer, Value};
 use tempfile::{tempdir, TempDir};
 use url::Url;

--- a/kernel/tests/write.rs
+++ b/kernel/tests/write.rs
@@ -32,7 +32,7 @@ use test_utils::set_json_value;
 
 use itertools::Itertools;
 use object_store::path::Path;
-use object_store::ObjectStore;
+use object_store::{ObjectStore, ObjectStoreExt};
 use serde_json::json;
 use serde_json::Deserializer;
 use tempfile::tempdir;

--- a/kernel/tests/write_row_tracking.rs
+++ b/kernel/tests/write_row_tracking.rs
@@ -15,7 +15,7 @@ use delta_kernel::transaction::CommitResult;
 
 use itertools::Itertools;
 use object_store::path::Path;
-use object_store::ObjectStore;
+use object_store::ObjectStoreExt;
 use serde_json::Deserializer;
 use tempfile::tempdir;
 

--- a/mem-test/Cargo.toml
+++ b/mem-test/Cargo.toml
@@ -16,7 +16,7 @@ release = false
 [dependencies]
 delta_kernel = { path = "../kernel", features = ["arrow", "default-engine-rustls"] }
 dhat = "0.3"
-object_store = "0.12.3"
+object_store = "0.13.1"
 rayon = "1.10"
 serde_json = "1"
 tempfile = "3"

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -13,8 +13,8 @@ version.workspace = true
 release = false
 
 [dependencies]
-delta_kernel = { path = "../kernel", features = [ "default-engine-rustls", "arrow" ] }
-object_store = "0.12.3"
+delta_kernel = { path = "../kernel", features = [ "default-engine-rustls", "arrow", "test-utils"] }
+object_store = "0.13.1"
 itertools = "0.14.0"
 serde_json = "1.0.142"
 tar = "0.4"

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -31,7 +31,7 @@ use delta_kernel::{DeltaResult, Engine, EngineData, Snapshot};
 use itertools::Itertools;
 use object_store::local::LocalFileSystem;
 use object_store::memory::InMemory;
-use object_store::{path::Path, ObjectStore};
+use object_store::{path::Path, ObjectStore, ObjectStoreExt};
 use serde_json::{json, to_vec, Deserializer};
 use std::sync::Mutex;
 use tracing::subscriber::DefaultGuard;

--- a/uc-catalog/Cargo.toml
+++ b/uc-catalog/Cargo.toml
@@ -17,7 +17,7 @@ release = false
 delta_kernel = { path = "../kernel", features = ["catalog-managed"] }
 uc-client = { path = "../uc-client" }
 itertools = "0.14"
-object_store = "0.12.3"
+object_store = "0.13.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }
@@ -26,7 +26,6 @@ url = "2"
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
-delta_kernel = { path = "../kernel", features = ["arrow-56", "default-engine-rustls", "catalog-managed", "test-utils", "internal-api"] }
+delta_kernel = { path = "../kernel", features = ["arrow", "default-engine-rustls", "catalog-managed", "test-utils", "internal-api"] }
 uc-client = { path = "../uc-client", features = ["test-utils"] }
-object_store = "0.12"
 tempfile = "3"


### PR DESCRIPTION
Regrettably there are a host of of MSRV issues and incompatibilities that pop out of the woodwork with 0.13.  There's transitive dependencies down the stack that require 1.88 :melting_face: 