### PR TITLE
refactor: Clean up table feature parsing with strum-0.28

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -48,7 +48,7 @@ itertools = "0.14"
 roaring = "0.11.2"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
-strum = { version = "0.27", features = ["derive"] }
+strum = { version = "0.28", features = ["derive"] }
 thiserror = "2"
 # only for structured logging
 tracing = { version = "0.1", features = ["log"] }

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -8,8 +8,7 @@ use self::deletion_vector::DeletionVectorDescriptor;
 use crate::expressions::{MapData, Scalar, StructData};
 use crate::schema::{DataType, MapType, SchemaRef, StructField, StructType, ToSchema as _};
 use crate::table_features::{
-    FeatureType, TableFeature, TABLE_FEATURES_MIN_READER_VERSION,
-    TABLE_FEATURES_MIN_WRITER_VERSION,
+    FeatureType, TableFeature, TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION,
 };
 use crate::table_properties::TableProperties;
 use crate::utils::require;

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, LazyLock};
 use self::deletion_vector::DeletionVectorDescriptor;
 use crate::expressions::{MapData, Scalar, StructData};
 use crate::schema::{DataType, MapType, SchemaRef, StructField, StructType, ToSchema as _};
-use crate::table_features::{FeatureType, IntoTableFeature, TableFeature};
+use crate::table_features::{FeatureType, TableFeature};
 use crate::table_properties::TableProperties;
 use crate::utils::require;
 use crate::{
@@ -423,9 +423,9 @@ pub(crate) struct Protocol {
 /// Parse a list of feature identifiers into TableFeatures. Returns `None` for `None` input;
 /// otherwise infallible (unrecognized names become `TableFeature::Unknown`).
 fn parse_features(
-    features: Option<impl IntoIterator<Item = impl IntoTableFeature>>,
+    features: Option<impl IntoIterator<Item = impl Into<TableFeature>>>,
 ) -> Option<Vec<TableFeature>> {
-    let features = features?.into_iter().map(|f| f.into_table_feature());
+    let features = features?.into_iter().map(Into::into);
     Some(features.collect())
 }
 
@@ -456,8 +456,8 @@ impl Protocol {
     pub(crate) fn try_new(
         min_reader_version: i32,
         min_writer_version: i32,
-        reader_features: Option<impl IntoIterator<Item = impl IntoTableFeature>>,
-        writer_features: Option<impl IntoIterator<Item = impl IntoTableFeature>>,
+        reader_features: Option<impl IntoIterator<Item = impl Into<TableFeature>>>,
+        writer_features: Option<impl IntoIterator<Item = impl Into<TableFeature>>>,
     ) -> DeltaResult<Self> {
         let reader_features = parse_features(reader_features);
         let writer_features = parse_features(writer_features);

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -65,9 +65,7 @@ pub const SET_TABLE_FEATURE_SUPPORTED_VALUE: &str = "supported";
     EnumCount,
     Hash,
 )]
-#[strum(
-    serialize_all = "camelCase"
-)]
+#[strum(serialize_all = "camelCase")]
 #[serde(rename_all = "camelCase")]
 #[internal_api]
 #[derive(EnumIter)]


### PR DESCRIPTION
## What changes are proposed in this pull request?

Now that https://github.com/Peternator7/strum/pull/476 merged, we can use From/Into instead of the bespoke `IntoTableFeature` trait.

## How was this change tested?

Existing unit tests.