### PR TITLE
feat: auto-enable variantType feature during CREATE TABLE (#1922)

### DIFF
--- a/kernel/src/schema/variant_utils.rs
+++ b/kernel/src/schema/variant_utils.rs
@@ -9,7 +9,13 @@ use std::borrow::Cow;
 
 /// Schema visitor that checks if any column in the schema uses VARIANT type
 #[derive(Debug, Default)]
-pub(crate) struct UsesVariant(pub(crate) bool);
+pub(crate) struct UsesVariant(bool);
+
+impl UsesVariant {
+    pub(crate) fn found(&self) -> bool {
+        self.0
+    }
+}
 
 impl<'a> SchemaTransform<'a> for UsesVariant {
     fn transform_variant(&mut self, _: &'a StructType) -> Option<Cow<'a, StructType>> {
@@ -28,7 +34,7 @@ pub(crate) fn validate_variant_type_feature_support(tc: &TableConfiguration) -> 
         let mut uses_variant = UsesVariant::default();
         let _ = uses_variant.transform_struct(&tc.schema());
         require!(
-            !uses_variant.0,
+            !uses_variant.found(),
             Error::unsupported(
                 "Table contains VARIANT columns but does not have the required 'variantType' feature in reader and writer features"
             )

--- a/kernel/tests/create_table.rs
+++ b/kernel/tests/create_table.rs
@@ -4,6 +4,8 @@
 mod clustering;
 #[path = "create_table/column_mapping.rs"]
 mod column_mapping;
+#[path = "create_table/variant.rs"]
+mod variant;
 
 use std::sync::Arc;
 

--- a/kernel/tests/create_table/column_mapping.rs
+++ b/kernel/tests/create_table/column_mapping.rs
@@ -21,7 +21,7 @@ use test_utils::{create_table_and_load_snapshot, test_table_setup};
 use super::simple_schema;
 
 /// Helper to strip column mapping metadata (IDs and physical names) from all StructFields recursively.
-fn strip_column_mapping_metadata(schema: &StructType) -> StructType {
+pub(super) fn strip_column_mapping_metadata(schema: &StructType) -> StructType {
     let cm_id = ColumnMetadataKey::ColumnMappingId.as_ref();
     let cm_name = ColumnMetadataKey::ColumnMappingPhysicalName.as_ref();
 

--- a/kernel/tests/create_table/variant.rs
+++ b/kernel/tests/create_table/variant.rs
@@ -1,0 +1,181 @@
+//! Variant type integration tests for the CreateTable API.
+//!
+//! Tests that creating a table with Variant columns in the schema automatically adds the
+//! `variantType` feature to the protocol, and that Variant columns interact correctly
+//! with other features (column mapping, clustering rejection).
+
+use std::sync::Arc;
+
+use delta_kernel::committer::FileSystemCommitter;
+use delta_kernel::schema::{DataType, StructField, StructType};
+use delta_kernel::snapshot::Snapshot;
+use delta_kernel::table_features::{
+    ColumnMappingMode, TableFeature, TABLE_FEATURES_MIN_READER_VERSION,
+    TABLE_FEATURES_MIN_WRITER_VERSION,
+};
+use delta_kernel::transaction::create_table::create_table;
+use delta_kernel::transaction::data_layout::DataLayout;
+use delta_kernel::DeltaResult;
+use test_utils::{assert_result_error_with_message, test_table_setup};
+
+/// Schema with a top-level variant column: (id INT, v VARIANT)
+fn top_level_variant_schema() -> Arc<StructType> {
+    Arc::new(StructType::new_unchecked(vec![
+        StructField::new("id", DataType::INTEGER, false),
+        StructField::new("v", DataType::unshredded_variant(), true),
+    ]))
+}
+
+/// Schema with a variant nested inside a struct: (id INT, nested STRUCT<inner_v VARIANT>)
+fn nested_variant_schema() -> Arc<StructType> {
+    Arc::new(StructType::new_unchecked(vec![
+        StructField::new("id", DataType::INTEGER, false),
+        StructField::new(
+            "nested",
+            DataType::Struct(Box::new(StructType::new_unchecked(vec![StructField::new(
+                "inner_v",
+                DataType::unshredded_variant(),
+                true,
+            )]))),
+            true,
+        ),
+    ]))
+}
+
+/// Schema with multiple top-level variant columns: (id INT, v1 VARIANT, v2 VARIANT)
+fn multiple_variant_schema() -> Arc<StructType> {
+    Arc::new(StructType::new_unchecked(vec![
+        StructField::new("id", DataType::INTEGER, false),
+        StructField::new("v1", DataType::unshredded_variant(), true),
+        StructField::new("v2", DataType::unshredded_variant(), true),
+    ]))
+}
+
+/// Returns column mapping table properties for the given mode, or empty for "none".
+fn cm_properties(mode: &str) -> Vec<(&str, &str)> {
+    if mode == "none" {
+        vec![]
+    } else {
+        vec![("delta.columnMapping.mode", mode)]
+    }
+}
+
+/// Asserts the snapshot's protocol includes variantType with correct reader/writer versions.
+fn assert_variant_protocol(snapshot: &Snapshot) {
+    let table_config = snapshot.table_configuration();
+    assert!(
+        table_config.is_feature_supported(&TableFeature::VariantType),
+        "variantType feature should be supported"
+    );
+    let protocol = table_config.protocol();
+    assert!(
+        protocol.min_reader_version() >= TABLE_FEATURES_MIN_READER_VERSION,
+        "Reader version should be at least {}",
+        TABLE_FEATURES_MIN_READER_VERSION
+    );
+    assert!(
+        protocol.min_writer_version() >= TABLE_FEATURES_MIN_WRITER_VERSION,
+        "Writer version should be at least {}",
+        TABLE_FEATURES_MIN_WRITER_VERSION
+    );
+}
+
+/// Variant schema auto-enables variantType across schema shapes and column mapping modes.
+#[rstest::rstest]
+#[case::top_level_no_cm(top_level_variant_schema(), "none")]
+#[case::top_level_cm_name(top_level_variant_schema(), "name")]
+#[case::top_level_cm_id(top_level_variant_schema(), "id")]
+#[case::nested_no_cm(nested_variant_schema(), "none")]
+#[case::nested_cm_name(nested_variant_schema(), "name")]
+#[case::nested_cm_id(nested_variant_schema(), "id")]
+#[case::multiple_no_cm(multiple_variant_schema(), "none")]
+#[case::multiple_cm_name(multiple_variant_schema(), "name")]
+#[case::multiple_cm_id(multiple_variant_schema(), "id")]
+#[test]
+fn test_create_table_with_variant(
+    #[case] schema: Arc<StructType>,
+    #[case] cm_mode: &str,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    let _ = create_table(&table_path, schema.clone(), "Test/1.0")
+        .with_table_properties(cm_properties(cm_mode))
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?;
+
+    let table_url = delta_kernel::try_parse_uri(&table_path)?;
+    let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+
+    assert_variant_protocol(&snapshot);
+
+    if cm_mode != "none" {
+        let table_config = snapshot.table_configuration();
+        assert!(
+            table_config.is_feature_supported(&TableFeature::ColumnMapping),
+            "columnMapping feature should be supported when cm_mode={cm_mode}"
+        );
+        let expected_mode = match cm_mode {
+            "name" => ColumnMappingMode::Name,
+            "id" => ColumnMappingMode::Id,
+            _ => unreachable!(),
+        };
+        assert_eq!(table_config.column_mapping_mode(), expected_mode);
+    }
+
+    // Verify the schema round-trips correctly (strip CM metadata before comparing,
+    // since the read-back schema has physical names/IDs that the original doesn't).
+    let read_schema = snapshot.schema();
+    let stripped = super::column_mapping::strip_column_mapping_metadata(&read_schema);
+    assert_eq!(
+        &stripped,
+        schema.as_ref(),
+        "Schema should round-trip through create table"
+    );
+
+    Ok(())
+}
+
+/// A schema without variant columns should not add the variantType feature.
+#[test]
+fn test_create_table_no_variant_no_feature() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    let schema = Arc::new(StructType::try_new(vec![
+        StructField::new("id", DataType::INTEGER, false),
+        StructField::new("name", DataType::STRING, true),
+    ])?);
+
+    let _ = create_table(&table_path, schema, "Test/1.0")
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?;
+
+    let table_url = delta_kernel::try_parse_uri(&table_path)?;
+    let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+
+    let table_config = snapshot.table_configuration();
+    assert!(
+        !table_config.is_feature_supported(&TableFeature::VariantType),
+        "variantType feature should NOT be in protocol for non-variant schema"
+    );
+
+    Ok(())
+}
+
+/// Clustering on a variant column is rejected per the Delta spec.
+#[test]
+fn test_create_table_variant_clustering_rejected() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    let schema = Arc::new(StructType::new_unchecked(vec![
+        StructField::new("id", DataType::INTEGER, false),
+        StructField::new("v", DataType::unshredded_variant(), true),
+    ]));
+
+    let result = create_table(&table_path, schema, "Test/1.0")
+        .with_data_layout(DataLayout::clustered(["v"]))
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()));
+
+    assert_result_error_with_message(result, "unsupported type");
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #1922 

## What changes are proposed in this pull request?
Detect Variant columns in the schema during table creation and automatically add the variantType reader/writer feature to the protocol, matching the schema-driven enablement pattern used by columnMapping and clustering.

Changes:
- Add `maybe_enable_variant_type()` in the create-table builder to scan the schema with `UsesVariant` and conditionally add `VariantType`.
- Add `found()` accessor to `UsesVariant` for readability; update existing call site in `validate_variant_type_feature_support`.
- Make `strip_column_mapping_metadata` pub(super) so sibling test modules can reuse it.

## How was this change tested?
- Add parameterized integration tests (rstest) covering top-level, nested, and multiple variant schemas across column mapping modes, plus negative tests for no-variant and clustering rejection.


### This PR affects the following public APIs
Enhances create table without changing the method signature.
