### PR TITLE
fix: gracefully handle corrupt stats in JSON parsing

### DIFF
--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -4,12 +4,13 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use itertools::Itertools;
+use tracing::warn;
 
 use crate::arrow::array::types::*;
 use crate::arrow::array::{
-    self as arrow_array, make_array, Array, ArrayBuilder, ArrayData, ArrayRef, AsArray,
-    BooleanArray, Datum, MapArray, MutableArrayData, NullBufferBuilder, RecordBatch, StringArray,
-    StructArray,
+    self as arrow_array, make_array, new_null_array, Array, ArrayBuilder, ArrayData, ArrayRef,
+    AsArray, BooleanArray, Datum, MapArray, MutableArrayData, NullBufferBuilder, RecordBatch,
+    StringArray, StructArray,
 };
 use crate::arrow::buffer::OffsetBuffer;
 use crate::arrow::compute::kernels::cmp::{distinct, eq, gt, gt_eq, lt, lt_eq, neq, not_distinct};
@@ -338,10 +339,19 @@ pub fn evaluate_expression(
 
             // Convert kernel schema to Arrow schema and parse
             let arrow_schema = Arc::new(ArrowSchema::try_from_kernel(p.output_schema.as_ref())?);
-            let result = parse_json_impl(json_strings, arrow_schema)?;
-
-            // Return as StructArray
-            Ok(Arc::new(StructArray::from(result)) as ArrayRef)
+            match parse_json_impl(json_strings, arrow_schema.clone()) {
+                Ok(batch) => Ok(Arc::new(StructArray::from(batch)) as ArrayRef),
+                Err(e) => {
+                    warn!(
+                        "Failed to parse JSON stats as {}: {e}. Using null stats.",
+                        p.output_schema,
+                    );
+                    Ok(new_null_array(
+                        &ArrowDataType::Struct(arrow_schema.fields().clone()),
+                        json_strings.len(),
+                    ))
+                }
+            }
         }
         (MapToStruct(m), Some(DataType::Struct(output_schema))) => {
             let map_arr = evaluate_expression(&m.map_expr, batch, None)?;
@@ -1763,25 +1773,47 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_json_type_mismatch_error() {
-        // Schema expects LONG but JSON has a string value - should error
-        let schema = ArrowSchema::new(vec![ArrowField::new("json_col", ArrowDataType::Utf8, true)]);
-        let json_strings = StringArray::from(vec![
-            Some(r#"{"a": "not_a_number"}"#), // string instead of number
-        ]);
-        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(json_strings)]).unwrap();
+    fn test_parse_json_errors_return_nulls() {
+        // ParseJson is used for stats parsing. Corrupt or unparseable values should produce
+        // null output rather than failing the query -- files with null stats simply skip data
+        // skipping and are always included in scan results.
 
-        let output_schema = Arc::new(StructType::new_unchecked(vec![StructField::new(
-            "a",
-            DataType::LONG,
-            true,
-        )]));
+        fn assert_parse_json_result_all_nulls(
+            json_strings: Vec<Option<&str>>,
+            output_schema: Arc<StructType>,
+        ) {
+            let schema =
+                ArrowSchema::new(vec![ArrowField::new("json_col", ArrowDataType::Utf8, true)]);
+            let len = json_strings.len();
+            let json_arr = StringArray::from(json_strings);
+            let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(json_arr)]).unwrap();
 
-        let expr = Expr::parse_json(column_expr!("json_col"), output_schema);
-        let result = evaluate_expression(&expr, &batch, None);
+            let expr = Expr::parse_json(column_expr!("json_col"), output_schema);
+            let result = evaluate_expression(&expr, &batch, None).unwrap();
 
-        // Type mismatch should produce an error
-        assert!(result.is_err());
+            assert_eq!(result.len(), len);
+            assert_eq!(result.null_count(), len);
+        }
+
+        // Type mismatch: string value where integer is expected
+        assert_parse_json_result_all_nulls(
+            vec![Some(r#"{"a": "not_a_number"}"#)],
+            Arc::new(StructType::new_unchecked(vec![StructField::new(
+                "a",
+                DataType::LONG,
+                true,
+            )])),
+        );
+
+        // Value overflow: 99999 doesn't fit in decimal(4,2) (max 99.99)
+        assert_parse_json_result_all_nulls(
+            vec![Some(r#"{"a": 99999}"#)],
+            Arc::new(StructType::new_unchecked(vec![StructField::new(
+                "a",
+                DataType::decimal(4, 2).unwrap(),
+                true,
+            )])),
+        );
     }
 
     // ==================== MapToStruct Tests ====================

--- a/kernel/src/engine/arrow_utils.rs
+++ b/kernel/src/engine/arrow_utils.rs
@@ -1631,6 +1631,30 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_json_impl_propagates_type_errors() {
+        // Verify that parse_json_impl surfaces errors for values that don't match the schema,
+        // so the expression-level caller can catch them and return nulls.
+
+        // Value overflow: 99999 doesn't fit in decimal(4,2) (max 99.99)
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "a",
+            ArrowDataType::Decimal128(4, 2),
+            true,
+        )]));
+        let input: Vec<Option<&str>> = vec![Some(r#"{"a": 99999}"#)];
+        assert!(parse_json_impl(&input.into(), schema).is_err());
+
+        // Type mismatch: string where integer expected
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "a",
+            ArrowDataType::Int64,
+            true,
+        )]));
+        let input: Vec<Option<&str>> = vec![Some(r#"{"a": "not_a_number"}"#)];
+        assert!(parse_json_impl(&input.into(), schema).is_err());
+    }
+
+    #[test]
     fn simple_mask_indices() {
         column_mapping_cases().into_iter().for_each(|mode| {
             let requested_schema = StructType::new_unchecked([


### PR DESCRIPTION
## What changes are proposed in this pull request?

  - When ParseJson expression evaluation fails (e.g. wrong type), return an all-null struct instead of propagating the error
  - Files with corrupt stats lose data skipping but are still included in scan results, which is correct behavior
  
## How was this change tested?

new unit test