### PR TITLE
refactor: bundle commit path and ICT into TxnChangesContext

### DIFF
--- a/kernel/src/transaction/txn_changes.rs
+++ b/kernel/src/transaction/txn_changes.rs
@@ -1,0 +1,17 @@
+//! Transaction changes context for post-commit snapshot construction.
+//!
+//! Captures changes introduced by a committed transaction so the post-commit snapshot and CRC
+//! can be constructed without re-reading from storage.
+//!
+//! TODO: Add fields for protocol, metadata, domain metadata, set transactions, and file stats.
+
+use crate::path::ParsedLogPath;
+
+/// See [module-level documentation](self) for details.
+#[derive(Debug, Clone)]
+pub(crate) struct TxnChangesContext {
+    /// The parsed commit path for the committed transaction.
+    pub(crate) parsed_commit: ParsedLogPath,
+    /// The in-commit timestamp of this transaction, if ICT is enabled.
+    pub(crate) in_commit_timestamp: Option<i64>,
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Introduce `TxnChangesContext` to bundle the parsed commit path and in-commit timestamp from a committed transaction. Store it on the post-commit `Snapshot` so `get_in_commit_timestamp` can return the pre-computed ICT without engine I/O.

Prefactor for CRC writes, which will add `FileStatsChanges` to `TxnChangesContext`.

## How was this change tested?

- `test_new_post_commit_simple` -- existing test updated to use `TxnChangesContext`
- `test_new_post_commit_preserves_ict` -- new test verifying ICT round-trips through `TxnChangesContext`
- All existing ICT tests pass (CRC/fallback paths unaffected)