### PR TITLE
refactor: store CRC domain_metadata as HashMap instead of Vec

### DIFF
--- a/kernel/src/crc/mod.rs
+++ b/kernel/src/crc/mod.rs
@@ -14,6 +14,10 @@ pub(crate) use reader::try_read_crc_file;
 #[allow(unused)]
 pub(crate) use writer::try_write_crc_file;
 
+use std::collections::HashMap;
+
+use serde::de::Deserializer;
+use serde::ser::Serializer;
 use serde::{Deserialize, Serialize};
 
 use crate::actions::{Add, DomainMetadata, Metadata, Protocol, SetTransaction};
@@ -52,8 +56,17 @@ pub(crate) struct Crc {
     /// Live transaction identifier ([`SetTransaction`]) actions at this version.
     #[serde(skip)]
     pub(crate) set_transactions: Option<Vec<SetTransaction>>,
-    /// Live [`DomainMetadata`] actions at this version, excluding tombstones.
-    pub(crate) domain_metadata: Option<Vec<DomainMetadata>>,
+    /// Active (non-removed) [`DomainMetadata`] actions at this version. Tombstones
+    /// (`removed=true`) are never stored.
+    ///
+    /// Stored as a HashMap keyed by domain name for efficient lookup. The CRC JSON format uses
+    /// a Vec, which is converted via custom serde deserialization.
+    #[serde(
+        default,
+        deserialize_with = "de_opt_vec_to_opt_map",
+        serialize_with = "ser_opt_map_to_opt_vec"
+    )]
+    pub(crate) domain_metadata: Option<HashMap<String, DomainMetadata>>,
     /// Size distribution information of files remaining after action reconciliation.
     #[serde(skip)]
     pub(crate) file_size_histogram: Option<FileSizeHistogram>,
@@ -69,6 +82,36 @@ pub(crate) struct Crc {
     /// Distribution of deleted record counts across files. See this section for more details.
     #[serde(skip)]
     pub(crate) deleted_record_counts_histogram_opt: Option<DeletedRecordCountsHistogram>,
+}
+
+/// Deserialize `Option<Vec<DomainMetadata>>` from JSON into `Option<HashMap<String, DomainMetadata>>`.
+fn de_opt_vec_to_opt_map<'de, D>(
+    deserializer: D,
+) -> Result<Option<HashMap<String, DomainMetadata>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let opt_vec: Option<Vec<DomainMetadata>> = Option::deserialize(deserializer)?;
+    Ok(opt_vec.map(|vec| {
+        vec.into_iter()
+            .map(|dm| (dm.domain().to_string(), dm))
+            .collect()
+    }))
+}
+
+/// Serialize `Option<HashMap<String, DomainMetadata>>` back to `Option<Vec<DomainMetadata>>` so
+/// the CRC JSON format uses an array (matching the Delta protocol spec).
+fn ser_opt_map_to_opt_vec<S>(
+    map: &Option<HashMap<String, DomainMetadata>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match map {
+        None => serializer.serialize_none(),
+        Some(m) => m.values().collect::<Vec<_>>().serialize(serializer),
+    }
 }
 
 /// The [FileSizeHistogram] object represents a histogram tracking file counts and total bytes

--- a/kernel/src/crc/reader.rs
+++ b/kernel/src/crc/reader.rs
@@ -107,14 +107,13 @@ mod tests {
         let dms = crc.domain_metadata.unwrap();
         assert_eq!(dms.len(), 3);
 
-        assert_eq!(dms[0].domain(), "delta.clustering");
-        assert!(dms[0].configuration().contains("clusteringColumns"));
-
-        assert_eq!(dms[1].domain(), "delta.rowTracking");
-        assert!(dms[1].configuration().contains("rowIdHighWaterMark"));
-
-        assert_eq!(dms[2].domain(), "myApp.metadata");
-        assert!(dms[2].configuration().contains("key"));
+        assert!(dms["delta.clustering"]
+            .configuration()
+            .contains("clusteringColumns"));
+        assert!(dms["delta.rowTracking"]
+            .configuration()
+            .contains("rowIdHighWaterMark"));
+        assert!(dms["myApp.metadata"].configuration().contains("key"));
 
         // Skipped fields are always None (pending serde support on their types)
         assert!(crc.txn_id.is_none());

--- a/kernel/src/crc/writer.rs
+++ b/kernel/src/crc/writer.rs
@@ -26,6 +26,8 @@ mod tests {
 
     use object_store::memory::InMemory;
 
+    use std::collections::HashMap;
+
     use super::*;
     use crate::actions::{DomainMetadata, Metadata, Protocol};
     use crate::crc::reader::try_read_crc_file;
@@ -44,10 +46,17 @@ mod tests {
             ],
         )
         .unwrap();
-        let domain_metadata = vec![DomainMetadata::new(
+        // NOTE: Adding more entries here will break test_crc_serialized_json_content because
+        // domain_metadata is backed by an unsorted HashMap -- the serialized array order is
+        // non-deterministic. If you need multiple entries, either make the test order-independent
+        // (e.g. sort both sides by domain name) or switch to a BTreeMap.
+        let domain_metadata = HashMap::from([(
             "delta.rowTracking".to_string(),
-            r#"{"rowIdHighWaterMark":1048576}"#.to_string(),
-        )];
+            DomainMetadata::new(
+                "delta.rowTracking".to_string(),
+                r#"{"rowIdHighWaterMark":1048576}"#.to_string(),
+            ),
+        )]);
         Crc {
             table_size_bytes: 1024,
             num_files: 5,
@@ -65,31 +74,6 @@ mod tests {
             num_deletion_vectors_opt: None,
             deleted_record_counts_histogram_opt: None,
         }
-    }
-
-    /// Strip common leading whitespace from a multi-line string, trim leading/trailing blank
-    /// lines, and return the dedented result.
-    fn dedent(s: &str) -> String {
-        let lines: Vec<&str> = s.lines().collect();
-        let min_indent = lines
-            .iter()
-            .filter(|l| !l.trim().is_empty())
-            .map(|l| l.len() - l.trim_start().len())
-            .min()
-            .unwrap_or(0);
-        lines
-            .iter()
-            .map(|l| {
-                if l.len() >= min_indent {
-                    &l[min_indent..]
-                } else {
-                    l.trim()
-                }
-            })
-            .collect::<Vec<_>>()
-            .join("\n")
-            .trim()
-            .to_string()
     }
 
     #[test]
@@ -116,60 +100,50 @@ mod tests {
         assert_eq!(read_back, crc);
     }
 
-    /// Verify the exact JSON bytes produced by CRC serialization, including protocol table
-    /// features and row tracking domain metadata. The expected JSON is indented for readability;
-    /// we dedent it and compare directly against `serde_json::to_string_pretty` output.
+    /// Verify JSON content produced by CRC serialization via serde_json::Value comparison.
     #[test]
     fn test_crc_serialized_json_content() {
         let crc = test_crc();
-        let actual = serde_json::to_string_pretty(&crc).unwrap();
+        let actual: serde_json::Value = serde_json::to_value(&crc).unwrap();
 
-        // Expected output of serde_json::to_string_pretty (2-space indent, struct field order).
-        // dedent() strips the common leading whitespace so this stays readable in source.
-        let expected = dedent(
-            r#"
-            {
-              "tableSizeBytes": 1024,
-              "numFiles": 5,
-              "numMetadata": 1,
-              "numProtocol": 1,
-              "metadata": {
+        let expected = serde_json::json!({
+            "tableSizeBytes": 1024,
+            "numFiles": 5,
+            "numMetadata": 1,
+            "numProtocol": 1,
+            "metadata": {
                 "id": "",
                 "name": null,
                 "description": null,
                 "format": {
-                  "provider": "parquet",
-                  "options": {}
+                    "provider": "parquet",
+                    "options": {}
                 },
                 "schemaString": "",
                 "partitionColumns": [],
                 "createdTime": null,
                 "configuration": {}
-              },
-              "protocol": {
+            },
+            "protocol": {
                 "minReaderVersion": 3,
                 "minWriterVersion": 7,
-                "readerFeatures": [
-                  "columnMapping"
-                ],
+                "readerFeatures": ["columnMapping"],
                 "writerFeatures": [
-                  "columnMapping",
-                  "rowTracking",
-                  "domainMetadata",
-                  "inCommitTimestamp"
+                    "columnMapping",
+                    "rowTracking",
+                    "domainMetadata",
+                    "inCommitTimestamp"
                 ]
-              },
-              "inCommitTimestampOpt": 1234567890,
-              "domainMetadata": [
+            },
+            "inCommitTimestampOpt": 1234567890,
+            "domainMetadata": [
                 {
-                  "domain": "delta.rowTracking",
-                  "configuration": "{\"rowIdHighWaterMark\":1048576}",
-                  "removed": false
+                    "domain": "delta.rowTracking",
+                    "configuration": "{\"rowIdHighWaterMark\":1048576}",
+                    "removed": false
                 }
-              ]
-            }
-        "#,
-        );
+            ]
+        });
 
         assert_eq!(actual, expected);
     }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Changes `Crc::domain_metadata` from `Option<Vec<DomainMetadata>>` to `Option<HashMap<String, DomainMetadata>>` for efficient key-based lookup by domain name. Custom serde handles the conversion: JSON arrays deserialize into HashMaps and serialize back to arrays, preserving the Delta protocol CRC file format.

## How was this change tested?

Existing CRC read/write/round-trip tests updated and passing. The exact JSON content test (`test_crc_serialized_json_content`) validates the serialized format matches the protocol spec.