### PR TITLE
fix: remove LazyCrc from Snapshot::new internal-api signature

### DIFF
--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -123,8 +123,18 @@ impl Snapshot {
         SnapshotBuilder::new_from(existing_snapshot)
     }
 
+    /// Create a new [`Snapshot`] from a [`LogSegment`] and [`TableConfiguration`].
     #[internal_api]
-    pub(crate) fn new(
+    pub(crate) fn new(log_segment: LogSegment, table_configuration: TableConfiguration) -> Self {
+        Self::new_with_crc(
+            log_segment,
+            table_configuration,
+            Arc::new(LazyCrc::new(None)),
+        )
+    }
+
+    /// Internal constructor that accepts an explicit [`LazyCrc`].
+    pub(crate) fn new_with_crc(
         log_segment: LogSegment,
         table_configuration: TableConfiguration,
         lazy_crc: Arc<LazyCrc>,
@@ -311,7 +321,7 @@ impl Snapshot {
         )?;
 
         let lazy_crc = Arc::new(LazyCrc::new(combined_log_segment.latest_crc_file.clone()));
-        Ok(Arc::new(Snapshot::new(
+        Ok(Arc::new(Snapshot::new_with_crc(
             combined_log_segment,
             table_configuration,
             lazy_crc,
@@ -390,7 +400,11 @@ impl Snapshot {
         let table_configuration =
             TableConfiguration::try_new(metadata, protocol, location, log_segment.end_version)?;
 
-        Ok(Self::new(log_segment, table_configuration, lazy_crc))
+        Ok(Self::new_with_crc(
+            log_segment,
+            table_configuration,
+            lazy_crc,
+        ))
     }
 
     /// Create a new [`Snapshot`] instance.
@@ -468,7 +482,7 @@ impl Snapshot {
 
         let new_log_segment = self.log_segment.new_with_commit_appended(commit)?;
 
-        Ok(Snapshot::new(
+        Ok(Snapshot::new_with_crc(
             new_log_segment,
             new_table_configuration,
             self.lazy_crc.clone(),
@@ -717,7 +731,7 @@ impl Snapshot {
 
         committer.publish(engine, publish_metadata)?;
 
-        Ok(Arc::new(Snapshot::new(
+        Ok(Arc::new(Snapshot::new_with_crc(
             self.log_segment().new_as_published()?,
             self.table_configuration().clone(),
             self.lazy_crc.clone(),
@@ -1790,8 +1804,7 @@ mod tests {
         let table_config = snapshot.table_configuration().clone();
 
         // Create snapshot without commit file in log segment
-        let snapshot_no_commit =
-            Snapshot::new(log_segment, table_config, Arc::new(LazyCrc::new(None)));
+        let snapshot_no_commit = Snapshot::new(log_segment, table_config);
 
         // Should return an error when commit file is missing
         let result = snapshot_no_commit.get_in_commit_timestamp(&engine);

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -15,7 +15,6 @@ use url::Url;
 use crate::actions::{DomainMetadata, Metadata, Protocol};
 use crate::clustering::{create_clustering_domain_metadata, validate_clustering_columns};
 use crate::committer::Committer;
-use crate::crc::LazyCrc;
 use crate::expressions::ColumnName;
 use crate::log_segment::LogSegment;
 use crate::schema::variant_utils::UsesVariant;
@@ -568,11 +567,7 @@ impl CreateTableTransactionBuilder {
 
         // Create Transaction<CreateTable> with pre-commit snapshot
         Transaction::try_new_create_table(
-            Arc::new(Snapshot::new(
-                log_segment,
-                table_configuration,
-                Arc::new(LazyCrc::new(None)),
-            )),
+            Arc::new(Snapshot::new(log_segment, table_configuration)),
             self.engine_info,
             committer,
             system_domain_metadata,


### PR DESCRIPTION
## What changes are proposed in this pull request?

`Snapshot::new` is `#[internal_api]` (promoted to `pub` with the feature flag), but its `Arc<LazyCrc>` parameter is `pub(crate)` -- making it visible but uncallable from outside the crate.

Split into `Snapshot::new` (no CRC param, defaults to empty) and `Snapshot::new_with_crc` (`pub(crate)`, for internal callers).

## How was this change tested?

Existing tests.