### PR TITLE
prefactor: expose CRC getter behind `test-utils` feature flag

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -136,7 +136,7 @@ default-engine-rustls = [
 rustc_version = "0.4.1"
 
 [dev-dependencies]
-delta_kernel = { path = ".", features = ["arrow", "catalog-managed", "default-engine-rustls", "internal-api"] }
+delta_kernel = { path = ".", features = ["arrow", "catalog-managed", "default-engine-rustls", "internal-api", "test-utils"] }
 test_utils = { path = "../test-utils" }
 criterion = "0.5"
 # Used for testing parse_url_opts extensibility

--- a/kernel/src/crc/lazy.rs
+++ b/kernel/src/crc/lazy.rs
@@ -44,7 +44,7 @@ pub(crate) struct LazyCrc {
     /// The CRC file path, if one exists in the log segment.
     crc_file: Option<ParsedLogPath>,
     /// Cached load result (loaded lazily, at most once).
-    cached: OnceLock<CrcLoadResult>,
+    pub(crate) cached: OnceLock<CrcLoadResult>,
 }
 
 impl LazyCrc {

--- a/kernel/src/crc/mod.rs
+++ b/kernel/src/crc/mod.rs
@@ -5,6 +5,10 @@
 //!
 //! [CRC file]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#version-checksum-file
 
+// Allow unreachable_pub because this module is pub when test-utils is enabled
+// but pub(crate) otherwise. The items need to be pub for integration tests.
+#![allow(unreachable_pub)]
+
 mod delta;
 mod file_stats;
 mod lazy;
@@ -32,7 +36,7 @@ use crate::actions::{Add, DomainMetadata, Metadata, Protocol, SetTransaction};
 /// from disk (a CRC file's stats are correct by definition).
 #[allow(dead_code)] // Variants used in follow-up PRs (forward replay, transaction delta).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub(crate) enum FileStatsValidity {
+pub enum FileStatsValidity {
     /// File stats are known-correct absolute totals. This is the case when seeded from a CRC
     /// file (which contains `num_files` and `table_size_bytes`) or when replay starts from
     /// version zero (where the initial state is trivially zero).
@@ -61,40 +65,43 @@ pub(crate) enum FileStatsValidity {
 /// 1. Be named `{version}.crc` with version zero-padded to 20 digits: `00000000000000000001.crc`
 /// 2. Be stored directly in the _delta_log directory alongside Delta log files
 /// 3. Contain exactly one JSON object with the schema of this struct.
+///
+/// This struct and its fields are marked `pub`, but the `crc` module is only re-exported as `pub`
+/// when the `test-utils` feature is enabled (otherwise `pub(crate)`). See `kernel/src/lib.rs`.
 // Deserialized directly from JSON via serde. See `reader::try_read_crc_file`.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub(crate) struct Crc {
+pub struct Crc {
     // ===== Required fields =====
     /// Total size of the table in bytes, calculated as the sum of the `size` field of all live
     /// [`Add`] actions.
-    pub(crate) table_size_bytes: i64,
+    pub table_size_bytes: i64,
     /// Number of live [`Add`] actions in this table version after action reconciliation.
-    pub(crate) num_files: i64,
+    pub num_files: i64,
     /// Number of [`Metadata`] actions. Must be 1.
-    pub(crate) num_metadata: i64,
+    pub num_metadata: i64,
     /// Number of [`Protocol`] actions. Must be 1.
-    pub(crate) num_protocol: i64,
+    pub num_protocol: i64,
     /// The table [`Metadata`] at this version.
-    pub(crate) metadata: Metadata,
+    pub metadata: Metadata,
     /// The table [`Protocol`] at this version.
-    pub(crate) protocol: Protocol,
+    pub protocol: Protocol,
     /// Whether the file stats (`num_files`, `table_size_bytes`) in this CRC are trustworthy.
     /// Not serialized -- this is an in-memory replay concern only. When deserialized from a CRC
     /// file on disk, defaults to [`FileStatsValidity::Valid`] (a CRC file's stats are correct
     /// by definition).
     #[serde(skip)]
-    pub(crate) validity: FileStatsValidity,
+    pub validity: FileStatsValidity,
 
     // ===== Optional fields =====
     /// A unique identifier for the transaction that produced this commit.
     #[serde(skip)]
-    pub(crate) txn_id: Option<String>,
+    pub txn_id: Option<String>,
     /// The in-commit timestamp of this version. Present iff In-Commit Timestamps are enabled.
-    pub(crate) in_commit_timestamp_opt: Option<i64>,
+    pub in_commit_timestamp_opt: Option<i64>,
     /// Live transaction identifier ([`SetTransaction`]) actions at this version.
     #[serde(skip)]
-    pub(crate) set_transactions: Option<Vec<SetTransaction>>,
+    pub set_transactions: Option<Vec<SetTransaction>>,
     /// Active (non-removed) [`DomainMetadata`] actions at this version. Tombstones
     /// (`removed=true`) are never stored.
     ///
@@ -105,22 +112,22 @@ pub(crate) struct Crc {
         deserialize_with = "de_opt_vec_to_opt_map",
         serialize_with = "ser_opt_map_to_opt_vec"
     )]
-    pub(crate) domain_metadata: Option<HashMap<String, DomainMetadata>>,
+    pub domain_metadata: Option<HashMap<String, DomainMetadata>>,
     /// Size distribution information of files remaining after action reconciliation.
     #[serde(skip)]
-    pub(crate) file_size_histogram: Option<FileSizeHistogram>,
+    pub file_size_histogram: Option<FileSizeHistogram>,
     /// All live [`Add`] file actions at this version.
     #[serde(skip)]
-    pub(crate) all_files: Option<Vec<Add>>,
+    pub all_files: Option<Vec<Add>>,
     /// Number of records deleted through Deletion Vectors in this table version.
     #[serde(skip)]
-    pub(crate) num_deleted_records_opt: Option<i64>,
+    pub num_deleted_records_opt: Option<i64>,
     /// Number of Deletion Vectors active in this table version.
     #[serde(skip)]
-    pub(crate) num_deletion_vectors_opt: Option<i64>,
+    pub num_deletion_vectors_opt: Option<i64>,
     /// Distribution of deleted record counts across files. See this section for more details.
     #[serde(skip)]
-    pub(crate) deleted_record_counts_histogram_opt: Option<DeletedRecordCountsHistogram>,
+    pub deleted_record_counts_histogram_opt: Option<DeletedRecordCountsHistogram>,
 }
 
 /// Deserialize `Option<Vec<DomainMetadata>>` from JSON into `Option<HashMap<String, DomainMetadata>>`.
@@ -158,7 +165,7 @@ where
 ///
 /// [FileSizeHistogram]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#file-size-histogram-schema
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct FileSizeHistogram {
+pub struct FileSizeHistogram {
     /// A sorted array of bin boundaries where each element represents the start of a bin
     /// (inclusive) and the next element represents the end of the bin (exclusive). The first
     /// element must be 0.
@@ -187,7 +194,7 @@ pub(crate) struct FileSizeHistogram {
 ///
 /// [DeletedRecordCountsHistogram]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#deleted-record-counts-histogram-schema
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct DeletedRecordCountsHistogram {
+pub struct DeletedRecordCountsHistogram {
     /// Array of size 10 where each element represents the count of files falling into a specific
     /// deletion count range.
     pub(crate) deleted_record_counts: Vec<i64>,

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -88,6 +88,10 @@ mod action_reconciliation;
 pub mod actions;
 pub mod checkpoint;
 pub mod committer;
+// Public under test-utils so integration tests can inspect CRC state via Snapshot::get_current_crc_if_loaded_for_testing.
+#[cfg(feature = "test-utils")]
+pub mod crc;
+#[cfg(not(feature = "test-utils"))]
 pub(crate) mod crc;
 pub mod engine_data;
 pub mod error;

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -677,6 +677,17 @@ impl Snapshot {
         })
     }
 
+    /// Returns the CRC if one has been loaded at this snapshot's version (no I/O).
+    ///
+    /// This is a test-only helper for integration tests to inspect the CRC state.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn get_current_crc_if_loaded_for_testing(&self) -> Option<&crate::crc::Crc> {
+        if self.lazy_crc.crc_version() != Some(self.version()) {
+            return None;
+        }
+        self.lazy_crc.cached.get()?.get().map(|arc| arc.as_ref())
+    }
+
     /// Publishes all catalog commits at this table version. Applicable only to catalog-managed
     /// tables. This method is a no-op for filesystem-managed tables or if there are no catalog
     /// commits to publish.

--- a/kernel/tests/crc.rs
+++ b/kernel/tests/crc.rs
@@ -89,3 +89,65 @@ async fn test_get_file_stats_crc_not_at_snapshot_version() -> DeltaResult<()> {
 
     Ok(())
 }
+
+// ============================================================================
+// CRC test visibility: get_current_crc_if_loaded_for_testing
+// ============================================================================
+
+#[tokio::test]
+async fn test_get_current_crc_if_loaded_returns_loaded_crc() -> DeltaResult<()> {
+    // ===== GIVEN =====
+    let path = std::fs::canonicalize(PathBuf::from("./tests/data/crc-full/")).unwrap();
+    let table_root = url::Url::from_directory_path(path).unwrap();
+
+    let store = Arc::new(LocalFileSystem::new());
+    let engine = DefaultEngineBuilder::new(store).build();
+
+    let snapshot = Snapshot::builder_for(table_root).build(&engine)?;
+    assert_eq!(snapshot.version(), 0);
+
+    // ===== WHEN =====
+    let crc = snapshot.get_current_crc_if_loaded_for_testing().unwrap();
+
+    // ===== THEN =====
+    assert_eq!(crc.table_size_bytes, 5259);
+    assert_eq!(crc.num_files, 10);
+    assert_eq!(crc.num_metadata, 1);
+    assert_eq!(crc.num_protocol, 1);
+
+    // Protocol and metadata should match the snapshot's table configuration
+    assert_eq!(crc.protocol, *snapshot.table_configuration().protocol());
+    assert_eq!(crc.metadata, *snapshot.table_configuration().metadata());
+
+    // Domain metadata
+    let dms = crc.domain_metadata.as_ref().unwrap();
+    assert_eq!(dms.len(), 3);
+    assert!(dms.contains_key("delta.clustering"));
+    assert!(dms.contains_key("delta.rowTracking"));
+    assert!(dms.contains_key("myApp.metadata"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_current_crc_if_loaded_returns_none_when_no_crc() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
+        "id",
+        DataType::INTEGER,
+    )])?);
+
+    let _ = create_table(&table_path, schema, "Test/1.0")
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?;
+
+    let table_url = delta_kernel::try_parse_uri(&table_path)?;
+    let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+    assert_eq!(snapshot.version(), 0);
+
+    // No CRC file exists, so get_current_crc_if_loaded_for_testing should return None
+    assert!(snapshot.get_current_crc_if_loaded_for_testing().is_none());
+
+    Ok(())
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds `Snapshot::get_current_crc_if_loaded_for_testing` behind the `test-utils` feature flag.

This PR also updates the CRC struct visibility to be public behind the `test-utils` feature flag.

This will let our future CRC integration tests poke at the value of of CRC struct.

## How was this change tested?

Two simple tests.
