### PR TITLE
refactor: make CRC file stats private with safe accessor

### DIFF
--- a/kernel/src/crc/file_stats.rs
+++ b/kernel/src/crc/file_stats.rs
@@ -1,6 +1,9 @@
-// No consumers yet -- will be integrated in a follow-up PR.
+// FileStatsDelta is not yet consumed outside this module.
 #![allow(dead_code)]
-//! File statistics delta: the file count and size changes from a single commit.
+//! File statistics and deltas for CRC tracking.
+//!
+//! [`FileStats`] represents absolute file-level statistics (count and size) for a table version.
+//! [`FileStatsDelta`] captures the net changes from a single commit.
 //!
 //! [`FileStatsDelta`] captures how many files were added/removed and their total sizes. It can be
 //! produced from either:
@@ -13,6 +16,19 @@ use crate::engine_data::{FilteredEngineData, GetData, TypedGetData as _};
 use crate::schema::{ColumnName, ColumnNamesAndTypes, DataType};
 use crate::utils::require;
 use crate::{DeltaResult, EngineData, Error, RowVisitor};
+
+/// File-level statistics for a table version: total file count and size.
+///
+/// Obtained via [`Crc::file_stats()`](super::Crc::file_stats), which returns `None` when
+/// the stats are not known to be valid.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileStats {
+    /// Number of active [`Add`](crate::actions::Add) file actions in this table version.
+    pub num_files: i64,
+    /// Total size of the table in bytes (sum of all active
+    /// [`Add`](crate::actions::Add) file sizes).
+    pub table_size_bytes: i64,
+}
 
 /// Net file count and size changes from a single commit.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/kernel/src/crc/mod.rs
+++ b/kernel/src/crc/mod.rs
@@ -17,6 +17,7 @@ mod writer;
 
 #[allow(unused)]
 pub(crate) use delta::CrcDelta;
+pub(crate) use file_stats::FileStats;
 pub(crate) use lazy::{CrcLoadResult, LazyCrc};
 pub(crate) use reader::try_read_crc_file;
 #[allow(unused)]
@@ -74,10 +75,11 @@ pub enum FileStatsValidity {
 pub struct Crc {
     // ===== Required fields =====
     /// Total size of the table in bytes, calculated as the sum of the `size` field of all live
-    /// [`Add`] actions.
-    pub table_size_bytes: i64,
+    /// [`Add`] actions. Private -- use [`Crc::file_stats()`] to access safely.
+    table_size_bytes: i64,
     /// Number of live [`Add`] actions in this table version after action reconciliation.
-    pub num_files: i64,
+    /// Private -- use [`Crc::file_stats()`] to access safely.
+    num_files: i64,
     /// Number of [`Metadata`] actions. Must be 1.
     pub num_metadata: i64,
     /// Number of [`Protocol`] actions. Must be 1.
@@ -135,6 +137,23 @@ pub struct Crc {
     /// Distribution of deleted record counts across files. See this section for more details.
     #[serde(skip)]
     pub deleted_record_counts_histogram_opt: Option<DeletedRecordCountsHistogram>,
+}
+
+impl Crc {
+    /// Returns file-level statistics only if they are known to be valid.
+    ///
+    /// Returns `None` when file stats cannot be trusted -- for example, when the CRC was
+    /// built from incremental replay that encountered a non-incremental operation or a
+    /// missing file size.
+    pub fn file_stats(&self) -> Option<FileStats> {
+        match self.validity {
+            FileStatsValidity::Valid => Some(FileStats {
+                num_files: self.num_files,
+                table_size_bytes: self.table_size_bytes,
+            }),
+            _ => None,
+        }
+    }
 }
 
 /// Trait for types that can be stored in a HashMap keyed by a string identifier.

--- a/kernel/src/crc/writer.rs
+++ b/kernel/src/crc/writer.rs
@@ -2,13 +2,15 @@
 
 use url::Url;
 
-use super::Crc;
-use crate::{DeltaResult, Engine};
+use super::{Crc, FileStatsValidity};
+use crate::utils::require;
+use crate::{DeltaResult, Engine, Error};
 
 /// Serialize and write a CRC file to storage.
 ///
 /// Serializes the [`Crc`] struct to JSON via serde and writes the raw bytes using the storage
-/// handler. If `overwrite` is false and the file already exists, returns
+/// handler. Returns an error if file stats are not valid (a CRC file on disk must have correct
+/// stats). If `overwrite` is false and the file already exists, returns
 /// `Err(Error::FileAlreadyExists)`.
 pub(crate) fn try_write_crc_file(
     engine: &dyn Engine,
@@ -16,6 +18,10 @@ pub(crate) fn try_write_crc_file(
     crc: &Crc,
     overwrite: bool,
 ) -> DeltaResult<()> {
+    require!(
+        crc.validity == FileStatsValidity::Valid,
+        Error::internal_error("Cannot write CRC file with invalid file stats")
+    );
     let data = serde_json::to_vec(crc)?;
     engine.storage_handler().put(path, data.into(), overwrite)
 }
@@ -170,5 +176,26 @@ mod tests {
 
         // Second write with overwrite=true should succeed
         try_write_crc_file(&engine, crc_path.location.as_url(), &crc, true).unwrap();
+    }
+
+    #[test]
+    fn test_write_rejects_invalid_file_stats() {
+        use crate::crc::FileStatsValidity;
+
+        let store = Arc::new(InMemory::new());
+        let engine = DefaultEngineBuilder::new(store).build();
+        let table_root = url::Url::parse("memory:///test_table/").unwrap();
+        let crc_path = ParsedLogPath::create_parsed_crc(&table_root, 0);
+
+        for invalid_validity in [
+            FileStatsValidity::RequiresCheckpointRead,
+            FileStatsValidity::Indeterminate,
+            FileStatsValidity::Untrackable,
+        ] {
+            let mut crc = test_crc();
+            crc.validity = invalid_validity;
+            let result = try_write_crc_file(&engine, crc_path.location.as_url(), &crc, false);
+            assert!(result.is_err(), "should reject {:?}", invalid_validity);
+        }
     }
 }

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -41,18 +41,12 @@ use url::Url;
 
 pub type SnapshotRef = Arc<Snapshot>;
 
-/// File-level statistics for a table snapshot.
+/// File-level statistics for a table version.
 ///
 /// NOTE: This is an unstable API expected to change in future releases.
 #[allow(unused)]
-#[derive(Debug, Clone, PartialEq, Eq)]
 #[internal_api]
-pub(crate) struct FileStats {
-    /// Total size of the table in bytes (sum of all active AddFile sizes).
-    pub table_size_bytes: i64,
-    /// Number of active AddFile actions in this table version.
-    pub num_files: i64,
-}
+pub(crate) type FileStats = crate::crc::FileStats;
 
 // TODO expose methods for accessing the files of a table (with file pruning).
 /// In-memory representation of a specific snapshot of a Delta table. While a `DeltaTable` exists
@@ -661,7 +655,7 @@ impl Snapshot {
         }
     }
 
-    /// Returns file-level statistics from the CRC file, or `None` if no CRC exists at this
+    /// Returns file-level statistics, or `None` if no CRC with valid stats exists at this
     /// snapshot's version.
     ///
     /// NOTE: This is an unstable API expected to change in future releases.
@@ -671,10 +665,7 @@ impl Snapshot {
         let crc = self
             .lazy_crc
             .get_or_load_if_at_version(engine, self.version())?;
-        Some(FileStats {
-            table_size_bytes: crc.table_size_bytes,
-            num_files: crc.num_files,
-        })
+        crc.file_stats()
     }
 
     /// Returns the CRC if one has been loaded at this snapshot's version (no I/O).

--- a/kernel/tests/crc.rs
+++ b/kernel/tests/crc.rs
@@ -110,8 +110,11 @@ async fn test_get_current_crc_if_loaded_returns_loaded_crc() -> DeltaResult<()> 
     let crc = snapshot.get_current_crc_if_loaded_for_testing().unwrap();
 
     // ===== THEN =====
-    assert_eq!(crc.table_size_bytes, 5259);
-    assert_eq!(crc.num_files, 10);
+    let file_stats = crc
+        .file_stats()
+        .expect("CRC from disk should have valid file stats");
+    assert_eq!(file_stats.table_size_bytes, 5259);
+    assert_eq!(file_stats.num_files, 10);
     assert_eq!(crc.num_metadata, 1);
     assert_eq!(crc.num_protocol, 1);
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Makes `Crc.num_files` and `Crc.table_size_bytes` private. Adds `Crc::file_stats() -> Option<FileStats>` that returns `None` unless validity is `Valid`, preventing callers from reading garbage stats from in-memory CRCs with degraded validity.

Also guards `try_write_crc_file` against writing CRC files with invalid stats.

## How was this change tested?

Existing CRC tests pass. Added test for writer validity guard.