### PR TITLE
fix: case-insensitive column matching in PhysicalPredicate

### DIFF
--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -277,18 +277,20 @@ impl PhysicalPredicate {
             return Ok(PhysicalPredicate::StaticSkipAll);
         }
         let unresolved_references = predicate.references();
-        let folded_references: HashMap<Vec<String>, &ColumnName> = unresolved_references
-            .iter()
-            .map(|r| {
-                let folded: Vec<String> = r.iter().map(|s| s.to_ascii_lowercase()).collect();
-                (folded, *r)
-            })
-            .collect();
+        // Group predicate references by case-folded path so that multiple references to the
+        // same column with different casings (e.g., `col > 5 AND COL < 10`) all resolve
+        // correctly instead of one being silently dropped.
+        let mut folded_references: HashMap<Vec<String>, Vec<&ColumnName>> = HashMap::new();
+        for r in &unresolved_references {
+            let folded: Vec<String> = r.iter().map(|s| s.to_lowercase()).collect();
+            folded_references.entry(folded).or_default().push(r);
+        }
         let mut get_referenced_fields = GetReferencedFields {
             unresolved_references,
             folded_references,
             column_mappings: HashMap::new(),
             logical_path: vec![],
+            folded_logical_path: vec![],
             physical_path: vec![],
             column_mapping_mode,
         };
@@ -338,12 +340,15 @@ fn can_statically_skip_all_files(predicate: &Predicate) -> bool {
 // mappings so we can access the correct physical stats column for each logical column.
 struct GetReferencedFields<'a> {
     unresolved_references: HashSet<&'a ColumnName>,
-    /// Case-folded (lowercased) column path -> original predicate column name, for O(1)
-    /// case-insensitive matching. Delta column names are case-insensitive, so we case-fold
-    /// both predicate references and schema paths to find matches.
-    folded_references: HashMap<Vec<String>, &'a ColumnName>,
+    /// Case-folded (lowercased) column path -> all predicate column names that fold to it,
+    /// for O(1) case-insensitive matching. Grouped as a `Vec` so that multiple references to
+    /// the same column with different casings all resolve correctly.
+    folded_references: HashMap<Vec<String>, Vec<&'a ColumnName>>,
     column_mappings: HashMap<ColumnName, ColumnName>,
     logical_path: Vec<String>,
+    /// Case-folded version of `logical_path`, maintained incrementally via push/pop to avoid
+    /// re-folding the entire path at every leaf field.
+    folded_logical_path: Vec<String>,
     physical_path: Vec<String>,
     column_mapping_mode: ColumnMappingMode,
 }
@@ -352,17 +357,17 @@ impl<'a> SchemaTransform<'a> for GetReferencedFields<'a> {
     fn transform_primitive(&mut self, ptype: &'a PrimitiveType) -> Option<Cow<'a, PrimitiveType>> {
         // Record the physical name mappings for all referenced leaf columns. Delta column names
         // are case-insensitive, so we probe the case-folded lookup map for O(1) matching.
-        let folded_path: Vec<String> = self
-            .logical_path
-            .iter()
-            .map(|s| s.to_ascii_lowercase())
-            .collect();
-        let predicate_col = self.folded_references.remove(folded_path.as_slice())?;
-        self.unresolved_references.remove(predicate_col);
-        // Use the predicate's column name as key so ApplyColumnMappings can look it up
-        // by the exact name used in the predicate expression.
-        self.column_mappings
-            .insert(predicate_col.clone(), ColumnName::new(&self.physical_path));
+        let pred_cols = self
+            .folded_references
+            .remove(self.folded_logical_path.as_slice())?;
+        let physical = ColumnName::new(&self.physical_path);
+        for pred_col in pred_cols {
+            self.unresolved_references.remove(pred_col);
+            // Use the predicate's column name as key so ApplyColumnMappings can look it up
+            // by the exact name used in the predicate expression.
+            self.column_mappings
+                .insert(pred_col.clone(), physical.clone());
+        }
         Some(Cow::Borrowed(ptype))
     }
 
@@ -377,9 +382,11 @@ impl<'a> SchemaTransform<'a> for GetReferencedFields<'a> {
     fn transform_struct_field(&mut self, field: &'a StructField) -> Option<Cow<'a, StructField>> {
         let physical_name = field.physical_name(self.column_mapping_mode);
         self.logical_path.push(field.name.clone());
+        self.folded_logical_path.push(field.name.to_lowercase());
         self.physical_path.push(physical_name.to_string());
         let field = self.recurse_into_struct_field(field);
         self.logical_path.pop();
+        self.folded_logical_path.pop();
         self.physical_path.pop();
         Some(Cow::Owned(field?.with_name(physical_name)))
     }

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -216,57 +216,34 @@ fn test_physical_predicate() {
 }
 
 /// Delta column names are case-insensitive, so predicates with differently-cased column names
-/// (e.g., engines that lowercase all predicate columns) must still resolve against the schema.
-#[test]
-fn test_physical_predicate_case_insensitive_without_column_mapping() {
-    // Without column mapping, physical names equal logical names. The predicate is rewritten
-    // to use the schema's casing:
-    //   predicate: createdat > 500 AND value < 100
-    //   schema:    createdAt, Value
-    //   result:    createdAt > 500 AND Value < 100
-    let logical_schema = StructType::new_unchecked(vec![
+/// must still resolve against the schema. The predicate is rewritten to use the schema's casing
+/// (or physical names when column mapping is enabled).
+#[rstest]
+#[case::without_column_mapping(
+    // predicate: createdat > 500 AND value < 100, schema: createdAt, Value
+    StructType::new_unchecked(vec![
         StructField::nullable("createdAt", DataType::LONG),
         StructField::nullable("Value", DataType::LONG),
-    ]);
-    let predicate = Pred::and(
+    ]),
+    Pred::and(
         Pred::gt(column_expr!("createdat"), Expr::literal(500i64)),
         Pred::lt(column_expr!("value"), Expr::literal(100i64)),
-    );
-    let result = PhysicalPredicate::try_new(&predicate, &logical_schema, ColumnMappingMode::None);
-    assert_eq!(
-        result.unwrap(),
-        PhysicalPredicate::Some(
-            Arc::new(Pred::and(
-                Pred::gt(column_expr!("createdAt"), Expr::literal(500i64)),
-                Pred::lt(column_expr!("Value"), Expr::literal(100i64)),
-            )),
-            StructType::new_unchecked(vec![
-                StructField::nullable("createdAt", DataType::LONG),
-                StructField::nullable("Value", DataType::LONG),
-            ])
-            .into(),
-        )
-    );
-
-    // Unknown column still fails even with case-insensitive matching
-    let result = PhysicalPredicate::try_new(
-        &column_pred!("nonexistent"),
-        &logical_schema,
-        ColumnMappingMode::None,
-    );
-    assert!(result.is_err());
-}
-
-/// With column mapping, the predicate is rewritten to use physical names from metadata.
-/// Case-insensitive matching resolves the logical name first, then applies the mapping.
-#[test]
-fn test_physical_predicate_case_insensitive_with_column_mapping() {
-    // With column mapping, physical names come from field metadata. The predicate is rewritten
-    // to use the physical names after case-insensitive logical name resolution:
-    //   predicate: createdat > 500 AND value < 100
-    //   schema:    createdAt (physical: phys_created), Value (physical: phys_value)
-    //   result:    phys_created > 500 AND phys_value < 100
-    let logical_schema = StructType::new_unchecked(vec![
+    ),
+    ColumnMappingMode::None,
+    PhysicalPredicate::Some(
+        Arc::new(Pred::and(
+            Pred::gt(column_expr!("createdAt"), Expr::literal(500i64)),
+            Pred::lt(column_expr!("Value"), Expr::literal(100i64)),
+        )),
+        StructType::new_unchecked(vec![
+            StructField::nullable("createdAt", DataType::LONG),
+            StructField::nullable("Value", DataType::LONG),
+        ]).into(),
+    ),
+)]
+#[case::with_column_mapping(
+    // predicate: createdat > 500 AND value < 100, schema has physical name metadata
+    StructType::new_unchecked(vec![
         StructField::nullable("createdAt", DataType::LONG).with_metadata([(
             ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
             "phys_created",
@@ -275,59 +252,88 @@ fn test_physical_predicate_case_insensitive_with_column_mapping() {
             ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
             "phys_value",
         )]),
-    ]);
-    let predicate = Pred::and(
+    ]),
+    Pred::and(
         Pred::gt(column_expr!("createdat"), Expr::literal(500i64)),
         Pred::lt(column_expr!("value"), Expr::literal(100i64)),
-    );
-    let result = PhysicalPredicate::try_new(&predicate, &logical_schema, ColumnMappingMode::Name);
-    assert_eq!(
-        result.unwrap(),
-        PhysicalPredicate::Some(
-            Arc::new(Pred::and(
-                Pred::gt(column_expr!("phys_created"), Expr::literal(500i64)),
-                Pred::lt(column_expr!("phys_value"), Expr::literal(100i64)),
-            )),
-            StructType::new_unchecked(vec![
-                StructField::nullable("phys_created", DataType::LONG).with_metadata([(
-                    ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
-                    "phys_created",
-                )]),
-                StructField::nullable("phys_value", DataType::LONG).with_metadata([(
-                    ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
-                    "phys_value",
-                )]),
-            ])
+    ),
+    ColumnMappingMode::Name,
+    PhysicalPredicate::Some(
+        Arc::new(Pred::and(
+            Pred::gt(column_expr!("phys_created"), Expr::literal(500i64)),
+            Pred::lt(column_expr!("phys_value"), Expr::literal(100i64)),
+        )),
+        StructType::new_unchecked(vec![
+            StructField::nullable("phys_created", DataType::LONG).with_metadata([(
+                ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
+                "phys_created",
+            )]),
+            StructField::nullable("phys_value", DataType::LONG).with_metadata([(
+                ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
+                "phys_value",
+            )]),
+        ]).into(),
+    ),
+)]
+#[case::duplicate_column_different_casing(
+    // predicate references same column with different casings: value > 5 AND VALUE < 10
+    StructType::new_unchecked(vec![
+        StructField::nullable("Value", DataType::LONG),
+    ]),
+    Pred::and(
+        Pred::gt(column_expr!("value"), Expr::literal(5i64)),
+        Pred::lt(column_expr!("VALUE"), Expr::literal(10i64)),
+    ),
+    ColumnMappingMode::None,
+    PhysicalPredicate::Some(
+        Arc::new(Pred::and(
+            Pred::gt(column_expr!("Value"), Expr::literal(5i64)),
+            Pred::lt(column_expr!("Value"), Expr::literal(10i64)),
+        )),
+        StructType::new_unchecked(vec![StructField::nullable("Value", DataType::LONG)])
             .into(),
-        )
-    );
-}
-
-/// Case-insensitive matching also works for nested struct fields, where casing can differ at
-/// each level of the path (e.g., predicate references `nested.fieldname` but schema has
-/// `Nested.FieldName`).
-#[test]
-fn test_physical_predicate_case_insensitive_nested_fields() {
-    let logical_schema = StructType::new_unchecked(vec![StructField::nullable(
+    ),
+)]
+#[case::nested_fields(
+    // predicate references nested.fieldname but schema has Nested.FieldName
+    StructType::new_unchecked(vec![StructField::nullable(
         "Nested",
         StructType::new_unchecked(vec![StructField::nullable("FieldName", DataType::LONG)]),
-    )]);
-    let predicate = column_pred!("nested.fieldname");
+    )]),
+    column_pred!("nested.fieldname"),
+    ColumnMappingMode::None,
+    PhysicalPredicate::Some(
+        column_pred!("Nested.FieldName").into(),
+        StructType::new_unchecked(vec![StructField::nullable(
+            "Nested",
+            StructType::new_unchecked(vec![
+                StructField::nullable("FieldName", DataType::LONG)
+            ]),
+        )]).into(),
+    ),
+)]
+fn test_physical_predicate_case_insensitive(
+    #[case] logical_schema: StructType,
+    #[case] predicate: Predicate,
+    #[case] column_mapping_mode: ColumnMappingMode,
+    #[case] expected: PhysicalPredicate,
+) {
     let result =
-        PhysicalPredicate::try_new(&predicate, &logical_schema, ColumnMappingMode::None).unwrap();
-    assert_eq!(
-        result,
-        PhysicalPredicate::Some(
-            column_pred!("Nested.FieldName").into(),
-            StructType::new_unchecked(vec![StructField::nullable(
-                "Nested",
-                StructType::new_unchecked(vec![
-                    StructField::nullable("FieldName", DataType::LONG,)
-                ]),
-            )])
-            .into(),
-        )
+        PhysicalPredicate::try_new(&predicate, &logical_schema, column_mapping_mode).unwrap();
+    assert_eq!(result, expected);
+}
+
+/// Unknown column still fails even with case-insensitive matching.
+#[test]
+fn test_physical_predicate_case_insensitive_unknown_column() {
+    let logical_schema =
+        StructType::new_unchecked(vec![StructField::nullable("createdAt", DataType::LONG)]);
+    let result = PhysicalPredicate::try_new(
+        &column_pred!("nonexistent"),
+        &logical_schema,
+        ColumnMappingMode::None,
     );
+    assert!(result.is_err());
 }
 
 fn get_files_for_scan(scan: Scan, engine: &dyn Engine) -> DeltaResult<Vec<String>> {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Delta column names are case-insensitive by spec, so we should match predicate column references against schema field names in a case-insensitive manner.

When a match is identified, the predicate is rewritten to use the physical column names

## How was this change tested?
Unit tests