### PR TITLE
feat: ensure CRC domain metadata never updates from None -> Some

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,12 +29,15 @@ cargo nextest run -p delta_kernel --lib --all-features test_name_here
 # Run a test by name, searching all crates (slow -- compiles everything)
 cargo nextest run --workspace --all-features test_name_here
 
-# Format and lint (always run after code changes)
-cargo fmt && cargo clippy --workspace --benches --tests --all-features -- -D warnings
+# Format, lint, and doc check (always run after code changes)
+cargo fmt \
+  && cargo clippy --workspace --benches --tests --all-features -- -D warnings \
+  && cargo doc --workspace --all-features --no-deps
 
 # Quick pre-push check (mimics CI)
 cargo fmt \
   && cargo clippy --workspace --benches --tests --all-features -- -D warnings \
+  && cargo doc --workspace --all-features --no-deps \
   && cargo nextest run --workspace --all-features
 ```
 

--- a/kernel/src/crc/delta.rs
+++ b/kernel/src/crc/delta.rs
@@ -15,8 +15,6 @@
 //!   Once validity degrades (e.g. a non-incremental operation like ANALYZE STATS, or a
 //!   missing file size), file stats stop updating for the lifetime of that CRC.
 
-use std::collections::HashMap;
-
 use crate::actions::{DomainMetadata, Metadata, Protocol};
 
 use super::file_stats::FileStatsDelta;
@@ -32,11 +30,13 @@ pub(crate) struct CrcDelta {
     pub(crate) protocol: Option<Protocol>,
     /// New metadata action, if this commit changed it.
     pub(crate) metadata: Option<Metadata>,
-    /// Domain metadata additions and removals in this commit.
+    /// All DM actions in this commit (additions and removals). `apply()` only processes these
+    /// when the base CRC's `domain_metadata` is `Some` (tracked).
     pub(crate) domain_metadata_changes: Vec<DomainMetadata>,
     /// In-commit timestamp, if present in this commit.
     pub(crate) in_commit_timestamp: Option<i64>,
-    /// The operation that produced this commit (e.g. "WRITE", "MERGE").
+    /// Must be `Some` with an incremental-safe value for file stats to update. `None` or
+    /// unrecognized values transition validity to `Indeterminate`.
     pub(crate) operation: Option<String>,
     /// A file action in this commit had a missing `size` field, making byte-level file stats
     /// impossible to compute.
@@ -61,15 +61,18 @@ impl Crc {
             self.metadata = m;
         }
 
-        // Domain metadata: insert or remove by domain name.
+        // Domain metadata: insert or remove by domain name. Only update if the base CRC
+        // tracks domain metadata (Some). If None ("not tracked"), leave it as None --
+        // applying partial changes would create an incomplete map.
         if !delta.domain_metadata_changes.is_empty() {
-            let map = self.domain_metadata.get_or_insert_with(HashMap::new);
-            for dm in delta.domain_metadata_changes {
-                if dm.is_removed() {
-                    map.remove(dm.domain());
-                } else {
-                    let domain = dm.domain().to_string();
-                    map.insert(domain, dm);
+            if let Some(map) = &mut self.domain_metadata {
+                for dm in delta.domain_metadata_changes {
+                    if dm.is_removed() {
+                        map.remove(dm.domain());
+                    } else {
+                        let domain = dm.domain().to_string();
+                        map.insert(domain, dm);
+                    }
                 }
             }
         }
@@ -111,6 +114,8 @@ impl Crc {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
     use crate::actions::{DomainMetadata, Metadata, Protocol};
 
@@ -309,8 +314,9 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_adds_domain_metadata() {
+    fn test_apply_adds_domain_metadata_to_tracked_map() {
         let mut crc = base_crc();
+        crc.domain_metadata = Some(HashMap::new());
         let dm = DomainMetadata::new("my.domain".to_string(), "config1".to_string());
         let delta = CrcDelta {
             domain_metadata_changes: vec![dm],
@@ -321,6 +327,21 @@ mod tests {
         let map = crc.domain_metadata.as_ref().unwrap();
         assert_eq!(map.len(), 1);
         assert_eq!(map["my.domain"].configuration(), "config1");
+    }
+
+    #[test]
+    fn test_apply_with_untracked_domain_metadata_skips_changes() {
+        let mut crc = base_crc();
+        assert!(crc.domain_metadata.is_none()); // Not tracked (default)
+        let dm = DomainMetadata::new("my.domain".to_string(), "config1".to_string());
+        let delta = CrcDelta {
+            domain_metadata_changes: vec![dm],
+            ..write_delta(0, 0)
+        };
+        crc.apply(delta);
+
+        // domain_metadata stays None -- apply() must not create a partial map.
+        assert!(crc.domain_metadata.is_none());
     }
 
     #[test]

--- a/kernel/src/crc/mod.rs
+++ b/kernel/src/crc/mod.rs
@@ -40,27 +40,30 @@ use crate::actions::{Add, DomainMetadata, Metadata, Protocol, SetTransaction};
 pub enum FileStatsValidity {
     /// File stats are known-correct absolute totals. This is the case when seeded from a CRC
     /// file (which contains `num_files` and `table_size_bytes`) or when replay starts from
-    /// version zero (where the initial state is trivially zero).
+    /// version zero (where the initial state is trivially zero). Safe to write to disk.
     #[default]
     Valid,
     /// File stats are relative deltas, not absolute totals. This happens when seeding from a
     /// checkpoint: we extract metadata fields but not file counts (reading all add actions from
     /// a checkpoint just for counts is too expensive). The accumulated deltas are correct, but
-    /// without a baseline they cannot produce final totals.
+    /// without a baseline they cannot produce final totals. Not safe to write to disk.
     RequiresCheckpointRead,
     /// A non-incremental operation was seen: file stats cannot be determined incrementally.
     /// For example, ANALYZE STATS re-adds existing files with updated statistics but no
     /// corresponding removes, so naively counting adds would double-count.
-    /// A full log replay from scratch could recover correct file stats.
+    /// A full log replay from scratch could recover correct file stats. Not safe to write to disk.
     Indeterminate,
     /// A file action had a missing size field: correct file stats are impossible to compute.
     /// For example, the Delta protocol allows `remove.size` to be null -- when encountered,
     /// we can no longer track byte totals. Unlike [`Indeterminate`](Self::Indeterminate), no
-    /// amount of replay can recover the missing data.
+    /// amount of replay can recover the missing data. Not safe to write to disk.
     Untrackable,
 }
 
 /// Parsed content of a CRC (version checksum) file.
+///
+/// A `Crc` is either (a) loaded from disk (deserialized from a `.crc` JSON file) or (b) computed
+/// in memory (built incrementally via `Crc::apply`).
 ///
 /// A CRC file must:
 /// 1. Be named `{version}.crc` with version zero-padded to 20 digits: `00000000000000000001.crc`
@@ -91,7 +94,7 @@ pub struct Crc {
     /// Whether the file stats (`num_files`, `table_size_bytes`) in this CRC are trustworthy.
     /// Not serialized -- this is an in-memory replay concern only. When deserialized from a CRC
     /// file on disk, defaults to [`FileStatsValidity::Valid`] (a CRC file's stats are correct
-    /// by definition).
+    /// by definition). A CRC is only safe to write to disk when validity is `Valid`.
     #[serde(skip)]
     pub validity: FileStatsValidity,
 
@@ -112,7 +115,9 @@ pub struct Crc {
     )]
     pub(crate) set_transactions: Option<HashMap<String, SetTransaction>>,
     /// Active (non-removed) [`DomainMetadata`] actions at this version. Tombstones
-    /// (`removed=true`) are never stored.
+    /// (`removed=true`) are never stored. `None` = not tracked (field absent in CRC JSON or not
+    /// computed). `Some(empty_map)` = tracked, no active domain metadata. `apply()` skips
+    /// updates when `None`.
     ///
     /// Stored as a HashMap keyed by domain name for efficient lookup. The CRC JSON format uses
     /// a Vec, which is converted via custom serde deserialization.


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds a minor (though important) logic fix and comment updates to the ongoing CRC effort.

This PR ensures that a CRC's domainMetadata field can never go from None -> Some.

That is: if you have a CRC at 10.crc, and it has NO domainMetadata (deserialized to None), then if we apply a CrcDelta from 11.json to it that has a domainMetadata change, then this CRC still ends up with a None value for domainMetadata. Else, we would be saying that "we know *all* of the DMs at version 11 in this CRC" which is false.

## How was this change tested?

Simple UT.
