### PR TITLE
feat: support column mapping on writes (#1863)

### DIFF
--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -702,7 +702,7 @@ pub unsafe extern "C" fn snapshot(
 ) -> ExternResult<Handle<SharedSnapshot>> {
     let url = unsafe { unwrap_and_parse_path_as_url(path) };
     let engine = unsafe { engine.as_ref() };
-    snapshot_impl(url, engine, None, Vec::new()).into_extern_result(&engine)
+    snapshot_impl(url, engine, None, Vec::new(), None).into_extern_result(&engine)
 }
 
 /// Get the latest snapshot from the specified table with optional log tail
@@ -717,6 +717,7 @@ pub unsafe extern "C" fn snapshot_with_log_tail(
     path: KernelStringSlice,
     engine: Handle<SharedExternEngine>,
     log_paths: log_path::LogPathArray,
+    max_catalog_version: Version,
 ) -> ExternResult<Handle<SharedSnapshot>> {
     let url = unsafe { unwrap_and_parse_path_as_url(path) };
     let engine_ref = unsafe { engine.as_ref() };
@@ -727,7 +728,8 @@ pub unsafe extern "C" fn snapshot_with_log_tail(
         Err(err) => return Err(err).into_extern_result(&engine_ref),
     };
 
-    snapshot_impl(url, engine_ref, None, log_tail).into_extern_result(&engine_ref)
+    snapshot_impl(url, engine_ref, None, log_tail, Some(max_catalog_version))
+        .into_extern_result(&engine_ref)
 }
 
 /// Get the snapshot from the specified table at a specific version. Note this is only safe for
@@ -744,7 +746,7 @@ pub unsafe extern "C" fn snapshot_at_version(
 ) -> ExternResult<Handle<SharedSnapshot>> {
     let url = unsafe { unwrap_and_parse_path_as_url(path) };
     let engine = unsafe { engine.as_ref() };
-    snapshot_impl(url, engine, version.into(), Vec::new()).into_extern_result(&engine)
+    snapshot_impl(url, engine, version.into(), Vec::new(), None).into_extern_result(&engine)
 }
 
 /// Get the snapshot from the specified table at a specific version with log tail.
@@ -760,6 +762,7 @@ pub unsafe extern "C" fn snapshot_at_version_with_log_tail(
     engine: Handle<SharedExternEngine>,
     version: Version,
     log_tail: log_path::LogPathArray,
+    max_catalog_version: Version,
 ) -> ExternResult<Handle<SharedSnapshot>> {
     let url = unsafe { unwrap_and_parse_path_as_url(path) };
     let engine_ref = unsafe { engine.as_ref() };
@@ -770,7 +773,14 @@ pub unsafe extern "C" fn snapshot_at_version_with_log_tail(
         Err(err) => return Err(err).into_extern_result(&engine_ref),
     };
 
-    snapshot_impl(url, engine_ref, version.into(), log_tail).into_extern_result(&engine_ref)
+    snapshot_impl(
+        url,
+        engine_ref,
+        version.into(),
+        log_tail,
+        Some(max_catalog_version),
+    )
+    .into_extern_result(&engine_ref)
 }
 
 fn snapshot_impl(
@@ -778,6 +788,7 @@ fn snapshot_impl(
     extern_engine: &dyn ExternEngine,
     version: Option<Version>,
     #[allow(unused_variables)] log_tail: Vec<LogPath>,
+    #[allow(unused_variables)] max_catalog_version: Option<Version>,
 ) -> DeltaResult<Handle<SharedSnapshot>> {
     let mut builder = Snapshot::builder_for(url?);
 
@@ -786,8 +797,13 @@ fn snapshot_impl(
     }
 
     #[cfg(feature = "catalog-managed")]
-    if !log_tail.is_empty() {
-        builder = builder.with_log_tail(log_tail);
+    {
+        if !log_tail.is_empty() {
+            builder = builder.with_log_tail(log_tail);
+        }
+        if let Some(mcv) = max_catalog_version {
+            builder = builder.with_max_catalog_version(mcv);
+        }
     }
 
     let snapshot = builder.build(extern_engine.engine().as_ref())?;
@@ -1300,12 +1316,12 @@ mod tests {
     #[cfg(feature = "catalog-managed")]
     #[tokio::test]
     async fn test_snapshot_log_tail() -> Result<(), Box<dyn std::error::Error>> {
-        use test_utils::add_staged_commit;
+        use test_utils::{actions_to_string_catalog_managed, add_staged_commit};
         let storage = Arc::new(InMemory::new());
         add_commit(
             storage.as_ref(),
             0,
-            actions_to_string(vec![TestAction::Metadata]),
+            actions_to_string_catalog_managed(vec![TestAction::Metadata]),
         )
         .await?;
         let commit1 = add_staged_commit(
@@ -1335,6 +1351,7 @@ mod tests {
                 kernel_string_slice!(path),
                 engine.shallow_copy(),
                 log_tail.clone(),
+                1, // max_catalog_version
             ))
         };
         let snapshot_version = unsafe { version(snapshot.shallow_copy()) };
@@ -1347,6 +1364,7 @@ mod tests {
                 engine.shallow_copy(),
                 1,
                 log_tail,
+                1, // max_catalog_version
             ))
         };
         let snapshot_version = unsafe { version(snapshot.shallow_copy()) };

--- a/kernel/src/checkpoint/tests.rs
+++ b/kernel/src/checkpoint/tests.rs
@@ -186,6 +186,11 @@ fn create_basic_protocol_action() -> Action {
     )
 }
 
+/// Create a Protocol action with catalogManaged feature support
+fn create_catalog_managed_protocol_action() -> Action {
+    Action::Protocol(Protocol::try_new_modern(["catalogManaged"], ["catalogManaged"]).unwrap())
+}
+
 /// Create a Protocol action with v2Checkpoint feature support
 fn create_v2_checkpoint_protocol_action() -> Action {
     Action::Protocol(Protocol::try_new_modern(vec!["v2Checkpoint"], vec!["v2Checkpoint"]).unwrap())
@@ -527,10 +532,13 @@ async fn test_no_checkpoint_on_unpublished_snapshot() -> DeltaResult<()> {
     let (store, _) = new_in_memory_store();
     let engine = DefaultEngineBuilder::new(store.clone()).build();
 
-    // normal commit
+    // normal commit with catalog-managed protocol
     write_commit_to_store(
         &store,
-        vec![create_metadata_action(), create_basic_protocol_action()],
+        vec![
+            create_metadata_action(),
+            create_catalog_managed_protocol_action(),
+        ],
         0,
     )
     .await?;
@@ -556,6 +564,7 @@ async fn test_no_checkpoint_on_unpublished_snapshot() -> DeltaResult<()> {
     };
     let snapshot = Snapshot::builder_for(table_root.clone())
         .with_log_tail(vec![LogPath::try_new(staged_commit).unwrap()])
+        .with_max_catalog_version(1)
         .build(&engine)?;
 
     assert!(matches!(

--- a/kernel/src/committer/filesystem.rs
+++ b/kernel/src/committer/filesystem.rs
@@ -113,6 +113,7 @@ mod tests {
         storage.put(&commit_path, actions.into()).await.unwrap();
 
         let snapshot = crate::snapshot::SnapshotBuilder::new_for(table_root)
+            .with_max_catalog_version(0)
             .build(&engine)
             .unwrap();
         // Try to commit a transaction with FileSystemCommitter

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -36,6 +36,7 @@ pub struct SnapshotBuilder {
     existing_snapshot: Option<SnapshotRef>,
     version: Option<Version>,
     log_tail: Vec<LogPath>,
+    max_catalog_version: Option<Version>,
 }
 
 impl SnapshotBuilder {
@@ -45,6 +46,7 @@ impl SnapshotBuilder {
             existing_snapshot: None,
             version: None,
             log_tail: Vec::new(),
+            max_catalog_version: None,
         }
     }
 
@@ -54,6 +56,7 @@ impl SnapshotBuilder {
             existing_snapshot: Some(existing_snapshot),
             version: None,
             log_tail: Vec::new(),
+            max_catalog_version: None,
         }
     }
 
@@ -75,6 +78,20 @@ impl SnapshotBuilder {
         self
     }
 
+    /// Set the maximum catalog-ratified version. When set, the snapshot will not load versions
+    /// beyond this limit, even if later commits exist on the filesystem. This ensures the
+    /// catalog remains the source of truth for catalog-managed tables.
+    ///
+    /// When no explicit time-travel version is set via [`at_version`], the `max_catalog_version`
+    /// is used as the effective target version.
+    ///
+    /// [`at_version`]: Self::at_version
+    #[cfg(feature = "catalog-managed")]
+    pub fn with_max_catalog_version(mut self, max_catalog_version: Version) -> Self {
+        self.max_catalog_version = Some(max_catalog_version);
+        self
+    }
+
     /// Create a new [`Snapshot`]. This returns a [`SnapshotRef`] (`Arc<Snapshot>`), perhaps
     /// returning a reference to an existing snapshot if the request to build a new snapshot
     /// matches the version of an existing snapshot.
@@ -93,33 +110,45 @@ impl SnapshotBuilder {
             target = self.target_version_str(),
             from_version = ?self.existing_snapshot.as_ref().map(|s| s.version()),
             log_tail_len = self.log_tail.len(),
+            max_catalog_version = ?self.max_catalog_version,
             "building snapshot"
         );
 
-        let log_tail = self.log_tail.into_iter().map(Into::into).collect();
+        // Destructure self so fields can be moved independently
+        let Self {
+            table_root,
+            existing_snapshot,
+            version,
+            log_tail,
+            max_catalog_version,
+        } = self;
+
+        let log_tail: Vec<_> = log_tail.into_iter().map(Into::into).collect();
         let operation_id = MetricId::new();
         let reporter = engine.get_metrics_reporter();
 
-        if let Some(table_root) = self.table_root {
+        // Pre-build validations for catalog-managed tables
+        #[cfg(feature = "catalog-managed")]
+        Self::validate_catalog_version_static(version, max_catalog_version, &log_tail)?;
+
+        // Compute effective version: use time-travel version, or fall back to max_catalog_version
+        let effective_version = version.or(max_catalog_version);
+
+        let snapshot = if let Some(table_root) = table_root {
             let table_url = try_parse_uri(table_root)?;
             let log_segment = LogSegment::for_snapshot(
                 engine.storage_handler().as_ref(),
                 table_url.join("_delta_log/")?,
                 log_tail,
-                self.version,
+                effective_version,
                 reporter.as_ref(),
                 Some(operation_id),
             )?;
 
-            Ok(Snapshot::try_new_from_log_segment(
-                table_url,
-                log_segment,
-                engine,
-                Some(operation_id),
-            )?
-            .into())
+            Snapshot::try_new_from_log_segment(table_url, log_segment, engine, Some(operation_id))?
+                .into()
         } else {
-            let existing_snapshot = self.existing_snapshot.ok_or_else(|| {
+            let existing_snapshot = existing_snapshot.ok_or_else(|| {
                 Error::internal_error(
                     "SnapshotBuilder should have either table_root or existing_snapshot",
                 )
@@ -129,10 +158,108 @@ impl SnapshotBuilder {
                 existing_snapshot,
                 log_tail,
                 engine,
-                self.version,
+                effective_version,
                 Some(operation_id),
+            )?
+        };
+
+        // Post-build validations for catalog-managed tables
+        #[cfg(feature = "catalog-managed")]
+        Self::validate_catalog_managed_consistency(&snapshot, max_catalog_version)?;
+
+        Ok(snapshot)
+    }
+
+    // ===== Catalog-managed Validations =====
+
+    /// Pre-build validations for catalog-managed table invariants.
+    #[cfg(feature = "catalog-managed")]
+    fn validate_catalog_version_static(
+        version: Option<Version>,
+        max_catalog_version: Option<Version>,
+        log_tail: &[crate::path::ParsedLogPath],
+    ) -> DeltaResult<()> {
+        use crate::path::LogPathFileType;
+        use crate::utils::require;
+
+        // TODO: If inline commits (or any other catalog commits) are
+        // ever supported, change this method to check if there are any
+        // catalog commits
+        let has_catalog_commits = log_tail
+            .iter()
+            .any(|p| p.file_type == LogPathFileType::StagedCommit);
+
+        // Staged commits require max_catalog_version
+        require!(
+            !has_catalog_commits || max_catalog_version.is_some(),
+            Error::generic(
+                "Staged commits in log_tail require max_catalog_version to be set. \
+                 Use with_max_catalog_version() when providing staged commits."
             )
+        );
+
+        // Time-travel version must not exceed max_catalog_version
+        if let (Some(ver), Some(max_cv)) = (version, max_catalog_version) {
+            require!(
+                ver <= max_cv,
+                Error::generic(format!(
+                    "Time-travel version {ver} exceeds max_catalog_version {max_cv}"
+                ))
+            );
         }
+
+        // Log tail end version validation when max_catalog_version is set
+        if let Some(max_cv) = max_catalog_version {
+            if let Some(last) = log_tail.last() {
+                if let Some(ver) = version {
+                    // With time-travel: last log_tail entry must be >= requested version
+                    require!(
+                        last.version >= ver,
+                        Error::generic(format!(
+                            "Log tail last version {} is less than requested version {ver}",
+                            last.version
+                        ))
+                    );
+                } else {
+                    // Without time-travel: last log_tail entry must == max_catalog_version
+                    require!(
+                        last.version == max_cv,
+                        Error::generic(format!(
+                            "Log tail last version {} does not match max_catalog_version {max_cv}",
+                            last.version
+                        ))
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Post-build validation: catalog-managed tables must have max_catalog_version, and
+    /// non-catalog-managed tables must not.
+    #[cfg(feature = "catalog-managed")]
+    fn validate_catalog_managed_consistency(
+        snapshot: &SnapshotRef,
+        max_catalog_version: Option<Version>,
+    ) -> DeltaResult<()> {
+        use crate::utils::require;
+
+        let is_catalog_managed = snapshot.table_configuration().is_catalog_managed();
+
+        require!(
+            !is_catalog_managed || max_catalog_version.is_some(),
+            Error::generic(
+                "Catalog-managed table requires max_catalog_version to be set. \
+                 Use with_max_catalog_version() when loading a catalog-managed table."
+            )
+        );
+        require!(
+            is_catalog_managed || max_catalog_version.is_none(),
+            Error::generic("max_catalog_version must not be set for non-catalog-managed tables.")
+        );
+
+        Ok(())
     }
 
     // ===== Instrumentation Helpers =====
@@ -149,9 +276,17 @@ impl SnapshotBuilder {
     }
 
     fn target_version_str(&self) -> String {
-        self.version
+        let version_str = self
+            .version
             .map(|v| v.to_string())
-            .unwrap_or_else(|| "LATEST".into())
+            .unwrap_or_else(|| "LATEST".into());
+
+        #[cfg(feature = "catalog-managed")]
+        if let Some(mcv) = self.max_catalog_version {
+            return format!("{version_str} (max_catalog_version={mcv})");
+        }
+
+        version_str
     }
 }
 
@@ -254,14 +389,228 @@ mod tests {
         let engine = engine.as_ref();
         create_table(&store, table_root.clone()).await?;
 
-        let snapshot = SnapshotBuilder::new_for(table_root.clone()).build(engine)?;
+        let snapshot = SnapshotBuilder::new_for(table_root.clone())
+            .with_max_catalog_version(1)
+            .build(engine)?;
         assert_eq!(snapshot.version(), 1);
 
         let snapshot = SnapshotBuilder::new_for(table_root.clone())
             .at_version(0)
+            .with_max_catalog_version(1)
             .build(engine)?;
         assert_eq!(snapshot.version(), 0);
 
         Ok(())
+    }
+
+    #[cfg(feature = "catalog-managed")]
+    mod catalog_managed_tests {
+        use super::*;
+
+        use test_utils::{
+            actions_to_string, actions_to_string_catalog_managed, add_commit, add_staged_commit,
+            TestAction,
+        };
+
+        use crate::log_path::LogPath;
+        use crate::utils::try_parse_uri;
+        use crate::FileMeta;
+
+        fn create_log_path(table_root: &str, commit_path: object_store::path::Path) -> LogPath {
+            let table_url = try_parse_uri(table_root).expect("Failed to parse table root");
+            let commit_url = table_url.join(commit_path.as_ref()).unwrap();
+            let file_meta = FileMeta {
+                location: commit_url,
+                last_modified: 123,
+                size: 100,
+            };
+            LogPath::try_new(file_meta).expect("Failed to create LogPath")
+        }
+
+        #[test_log::test(tokio::test)]
+        async fn test_staged_commits_without_max_catalog_version_errors(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            let (engine, store, table_root) = setup_test();
+
+            let actions = vec![TestAction::Metadata];
+            add_commit(
+                store.as_ref(),
+                0,
+                actions_to_string_catalog_managed(actions),
+            )
+            .await?;
+            let path1 = add_staged_commit(store.as_ref(), 1, String::from("{}")).await?;
+
+            let log_tail = vec![create_log_path(&table_root, path1)];
+
+            let result = SnapshotBuilder::new_for(table_root)
+                .with_log_tail(log_tail)
+                .build(engine.as_ref());
+
+            assert!(result
+                .unwrap_err()
+                .to_string()
+                .contains("Staged commits in log_tail require max_catalog_version"));
+
+            Ok(())
+        }
+
+        #[test_log::test(tokio::test)]
+        async fn test_version_exceeds_max_catalog_version_errors(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            let (engine, store, table_root) = setup_test();
+
+            let actions = vec![TestAction::Metadata];
+            add_commit(
+                store.as_ref(),
+                0,
+                actions_to_string_catalog_managed(actions),
+            )
+            .await?;
+
+            let result = SnapshotBuilder::new_for(table_root)
+                .at_version(5)
+                .with_max_catalog_version(3)
+                .build(engine.as_ref());
+
+            assert!(result
+                .unwrap_err()
+                .to_string()
+                .contains("Time-travel version 5 exceeds max_catalog_version 3"));
+
+            Ok(())
+        }
+
+        #[test_log::test(tokio::test)]
+        async fn test_log_tail_last_version_mismatch_errors(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            let (engine, store, table_root) = setup_test();
+
+            let actions = vec![TestAction::Metadata];
+            add_commit(
+                store.as_ref(),
+                0,
+                actions_to_string_catalog_managed(actions),
+            )
+            .await?;
+            let actions = vec![TestAction::Add("file_1.parquet".to_string())];
+            add_commit(store.as_ref(), 1, actions_to_string(actions)).await?;
+            let actions = vec![TestAction::Add("file_2.parquet".to_string())];
+            add_commit(store.as_ref(), 2, actions_to_string(actions)).await?;
+
+            let log_tail = vec![
+                create_log_path(&table_root, test_utils::delta_path_for_version(1, "json")),
+                create_log_path(&table_root, test_utils::delta_path_for_version(2, "json")),
+            ];
+
+            // log_tail ends at v2, max_catalog_version=3, no time-travel -> error
+            let result = SnapshotBuilder::new_for(table_root)
+                .with_log_tail(log_tail)
+                .with_max_catalog_version(3)
+                .build(engine.as_ref());
+
+            assert!(result
+                .unwrap_err()
+                .to_string()
+                .contains("Log tail last version 2 does not match max_catalog_version 3"));
+
+            Ok(())
+        }
+
+        #[test_log::test(tokio::test)]
+        async fn test_catalog_managed_table_without_max_catalog_version_errors(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            let (engine, store, table_root) = setup_test();
+
+            let actions = vec![TestAction::Metadata];
+            add_commit(
+                store.as_ref(),
+                0,
+                actions_to_string_catalog_managed(actions),
+            )
+            .await?;
+
+            let result = SnapshotBuilder::new_for(table_root).build(engine.as_ref());
+
+            assert!(result
+                .unwrap_err()
+                .to_string()
+                .contains("Catalog-managed table requires max_catalog_version"));
+
+            Ok(())
+        }
+
+        #[test_log::test(tokio::test)]
+        async fn test_non_catalog_managed_table_with_max_catalog_version_errors(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            let (engine, store, table_root) = setup_test();
+
+            let actions = vec![TestAction::Metadata];
+            add_commit(store.as_ref(), 0, actions_to_string(actions)).await?;
+
+            let result = SnapshotBuilder::new_for(table_root)
+                .with_max_catalog_version(0)
+                .build(engine.as_ref());
+
+            assert!(result
+                .unwrap_err()
+                .to_string()
+                .contains("max_catalog_version must not be set for non-catalog-managed tables"));
+
+            Ok(())
+        }
+
+        #[test_log::test(tokio::test)]
+        async fn test_max_catalog_version_as_effective_version(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            let (engine, store, table_root) = setup_test();
+
+            // Create catalog-managed table with commits 0, 1, 2
+            let actions = vec![TestAction::Metadata];
+            add_commit(
+                store.as_ref(),
+                0,
+                actions_to_string_catalog_managed(actions),
+            )
+            .await?;
+            let actions = vec![TestAction::Add("file_1.parquet".to_string())];
+            add_commit(store.as_ref(), 1, actions_to_string(actions)).await?;
+            let actions = vec![TestAction::Add("file_2.parquet".to_string())];
+            add_commit(store.as_ref(), 2, actions_to_string(actions)).await?;
+
+            // max_catalog_version=1, no time-travel -> snapshot at v1
+            let snapshot = SnapshotBuilder::new_for(table_root)
+                .with_max_catalog_version(1)
+                .build(engine.as_ref())?;
+            assert_eq!(snapshot.version(), 1);
+
+            Ok(())
+        }
+
+        #[test_log::test(tokio::test)]
+        async fn test_time_travel_with_max_catalog_version(
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            let (engine, store, table_root) = setup_test();
+
+            // Create catalog-managed table with commits 0, 1
+            let actions = vec![TestAction::Metadata];
+            add_commit(
+                store.as_ref(),
+                0,
+                actions_to_string_catalog_managed(actions),
+            )
+            .await?;
+            let actions = vec![TestAction::Add("file_1.parquet".to_string())];
+            add_commit(store.as_ref(), 1, actions_to_string(actions)).await?;
+
+            // at_version(0) + max_catalog_version=1 -> snapshot at v0
+            let snapshot = SnapshotBuilder::new_for(table_root)
+                .at_version(0)
+                .with_max_catalog_version(1)
+                .build(engine.as_ref())?;
+            assert_eq!(snapshot.version(), 0);
+
+            Ok(())
+        }
     }
 }

--- a/kernel/tests/log_tail.rs
+++ b/kernel/tests/log_tail.rs
@@ -9,7 +9,8 @@ use delta_kernel::engine::default::{DefaultEngine, DefaultEngineBuilder};
 use delta_kernel::{FileMeta, LogPath, Snapshot};
 
 use test_utils::{
-    actions_to_string, add_commit, add_staged_commit, delta_path_for_version, TestAction,
+    actions_to_string, actions_to_string_catalog_managed, add_commit, add_staged_commit,
+    delta_path_for_version, TestAction,
 };
 
 /// Helper function to create a LogPath for a commit at the given version
@@ -48,7 +49,12 @@ async fn basic_snapshot_with_log_tail_staged_commits() -> Result<(), Box<dyn std
     // _delta_log/_staged_commits/1.uuid.json // add an unused staged commit at version 1
     // _delta_log/_staged_commits/2.uuid.json
     let actions = vec![TestAction::Metadata];
-    add_commit(storage.as_ref(), 0, actions_to_string(actions)).await?;
+    add_commit(
+        storage.as_ref(),
+        0,
+        actions_to_string_catalog_managed(actions),
+    )
+    .await?;
     let path1 = add_staged_commit(storage.as_ref(), 1, String::from("{}")).await?;
     let _ = add_staged_commit(storage.as_ref(), 1, String::from("{}")).await?;
     let path2 = add_staged_commit(storage.as_ref(), 2, String::from("{}")).await?;
@@ -60,6 +66,7 @@ async fn basic_snapshot_with_log_tail_staged_commits() -> Result<(), Box<dyn std
     ];
     let snapshot = Snapshot::builder_for(table_root.clone())
         .with_log_tail(log_tail.clone())
+        .with_max_catalog_version(2)
         .build(engine.as_ref())?;
     assert_eq!(snapshot.version(), 2);
     let log_segment = snapshot.log_segment();
@@ -90,6 +97,7 @@ async fn basic_snapshot_with_log_tail_staged_commits() -> Result<(), Box<dyn std
     let snapshot = Snapshot::builder_for(table_root.clone())
         .with_log_tail(log_tail)
         .at_version(1)
+        .with_max_catalog_version(2)
         .build(engine.as_ref())?;
     assert_eq!(snapshot.version(), 1);
     let log_segment = snapshot.log_segment();
@@ -113,6 +121,7 @@ async fn basic_snapshot_with_log_tail_staged_commits() -> Result<(), Box<dyn std
     let log_tail = vec![create_log_path(&table_root, path1.clone())];
     let snapshot = Snapshot::builder_for(table_root.clone())
         .with_log_tail(log_tail)
+        .with_max_catalog_version(1)
         .build(engine.as_ref())?;
     assert_eq!(snapshot.version(), 1);
     let log_segment = snapshot.log_segment();
@@ -133,7 +142,9 @@ async fn basic_snapshot_with_log_tail_staged_commits() -> Result<(), Box<dyn std
     );
 
     // 4. Check if we don't pass log tail
-    let snapshot = Snapshot::builder_for(table_root.clone()).build(engine.as_ref())?;
+    let snapshot = Snapshot::builder_for(table_root.clone())
+        .with_max_catalog_version(0)
+        .build(engine.as_ref())?;
     assert_eq!(snapshot.version(), 0);
     let log_segment = snapshot.log_segment();
     assert_eq!(log_segment.listed.ascending_commit_files.len(), 1);
@@ -152,6 +163,7 @@ async fn basic_snapshot_with_log_tail_staged_commits() -> Result<(), Box<dyn std
     )];
     let snapshot = Snapshot::builder_for(table_root.clone())
         .with_log_tail(log_tail)
+        .with_max_catalog_version(0)
         .build(engine.as_ref())?;
 
     assert_eq!(snapshot.version(), 0);
@@ -234,7 +246,12 @@ async fn incremental_snapshot_with_log_tail() -> Result<(), Box<dyn std::error::
 
     // commits 0, 1, 2 in storage
     let actions = vec![TestAction::Metadata];
-    add_commit(storage.as_ref(), 0, actions_to_string(actions)).await?;
+    add_commit(
+        storage.as_ref(),
+        0,
+        actions_to_string_catalog_managed(actions),
+    )
+    .await?;
     let actions = vec![TestAction::Add("file_1.parquet".to_string())];
     add_commit(storage.as_ref(), 1, actions_to_string(actions)).await?;
     let actions = vec![TestAction::Add("file_2.parquet".to_string())];
@@ -243,6 +260,7 @@ async fn incremental_snapshot_with_log_tail() -> Result<(), Box<dyn std::error::
     // initial snapshot at version 1
     let initial_snapshot = Snapshot::builder_for(table_root.clone())
         .at_version(1)
+        .with_max_catalog_version(2)
         .build(engine.as_ref())?;
     assert_eq!(initial_snapshot.version(), 1);
 
@@ -262,6 +280,7 @@ async fn incremental_snapshot_with_log_tail() -> Result<(), Box<dyn std::error::
     // Build incremental snapshot with log_tail
     let new_snapshot = Snapshot::builder_from(initial_snapshot)
         .with_log_tail(log_tail)
+        .with_max_catalog_version(4)
         .build(engine.as_ref())?;
 
     // Verify we advanced to version 4

--- a/kernel/tests/max_catalog_version.rs
+++ b/kernel/tests/max_catalog_version.rs
@@ -1,0 +1,147 @@
+use std::sync::Arc;
+
+use delta_kernel::engine::default::executor::tokio::TokioBackgroundExecutor;
+use delta_kernel::engine::default::{DefaultEngine, DefaultEngineBuilder};
+use delta_kernel::Snapshot;
+use object_store::memory::InMemory;
+use url::Url;
+
+use test_utils::{
+    actions_to_string, actions_to_string_catalog_managed, add_commit, add_staged_commit, TestAction,
+};
+
+fn setup_test() -> (
+    Arc<InMemory>,
+    Arc<DefaultEngine<TokioBackgroundExecutor>>,
+    Url,
+) {
+    let storage = Arc::new(InMemory::new());
+    let table_root = Url::parse("memory:///").unwrap();
+    let engine = Arc::new(DefaultEngineBuilder::new(storage.clone()).build());
+    (storage, engine, table_root)
+}
+
+#[tokio::test]
+async fn test_max_catalog_version_latest_query() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, _table_root) = setup_test();
+
+    // Create catalog-managed table with commits 0, 1
+    let actions = vec![TestAction::Metadata];
+    add_commit(
+        storage.as_ref(),
+        0,
+        actions_to_string_catalog_managed(actions),
+    )
+    .await?;
+    let actions = vec![TestAction::Add("file_1.parquet".to_string())];
+    add_commit(storage.as_ref(), 1, actions_to_string(actions)).await?;
+
+    // max_catalog_version=0 -> snapshot at v0 (even though v1 exists)
+    let snapshot = Snapshot::builder_for(_table_root.clone())
+        .with_max_catalog_version(0)
+        .build(engine.as_ref())?;
+    assert_eq!(snapshot.version(), 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_max_catalog_version_time_travel_within_range(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, _table_root) = setup_test();
+
+    // Create catalog-managed table with commits 0, 1
+    let actions = vec![TestAction::Metadata];
+    add_commit(
+        storage.as_ref(),
+        0,
+        actions_to_string_catalog_managed(actions),
+    )
+    .await?;
+    let actions = vec![TestAction::Add("file_1.parquet".to_string())];
+    add_commit(storage.as_ref(), 1, actions_to_string(actions)).await?;
+
+    // at_version(0) + max_catalog_version=1 -> snapshot at v0
+    let snapshot = Snapshot::builder_for(_table_root.clone())
+        .at_version(0)
+        .with_max_catalog_version(1)
+        .build(engine.as_ref())?;
+    assert_eq!(snapshot.version(), 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_ccv2_table_requires_max_version() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_root) = setup_test();
+
+    // Create catalog-managed table
+    let actions = vec![TestAction::Metadata];
+    add_commit(
+        storage.as_ref(),
+        0,
+        actions_to_string_catalog_managed(actions),
+    )
+    .await?;
+
+    // No max_catalog_version -> error
+    let result = Snapshot::builder_for(table_root.clone()).build(engine.as_ref());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("Catalog-managed table requires max_catalog_version"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_non_ccv2_table_rejects_max_version() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_root) = setup_test();
+
+    // Create non-catalog-managed table
+    let actions = vec![TestAction::Metadata];
+    add_commit(storage.as_ref(), 0, actions_to_string(actions)).await?;
+
+    // max_catalog_version set -> error
+    let result = Snapshot::builder_for(table_root.clone())
+        .with_max_catalog_version(0)
+        .build(engine.as_ref());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("max_catalog_version must not be set for non-catalog-managed tables"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_staged_commits_with_max_catalog_version() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_root) = setup_test();
+
+    // Create catalog-managed table with staged commits
+    let actions = vec![TestAction::Metadata];
+    add_commit(
+        storage.as_ref(),
+        0,
+        actions_to_string_catalog_managed(actions),
+    )
+    .await?;
+    let path1 = add_staged_commit(storage.as_ref(), 1, String::from("{}")).await?;
+
+    let commit_url = table_root.join(path1.as_ref()).unwrap();
+    let file_meta = delta_kernel::FileMeta {
+        location: commit_url,
+        last_modified: 123,
+        size: 100,
+    };
+    let log_path = delta_kernel::LogPath::try_new(file_meta)?;
+
+    // With max_catalog_version -> succeeds
+    let snapshot = Snapshot::builder_for(table_root.clone())
+        .with_log_tail(vec![log_path])
+        .with_max_catalog_version(1)
+        .build(engine.as_ref())?;
+    assert_eq!(snapshot.version(), 1);
+
+    Ok(())
+}

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -100,6 +100,11 @@ pub const METADATA_WITH_PARTITION_COLS: &str = r#"{"commitInfo":{"timestamp":158
 {"protocol":{"minReaderVersion":1,"minWriterVersion":2}}
 {"metaData":{"id":"5fba94ed-9794-4965-ba6e-6ee3c0d22af9","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"id\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}},{\"name\":\"val\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":["val"],"configuration":{},"createdTime":1587968585495}}"#;
 
+/// Like [`METADATA`] but with protocol v3/7 and the `catalogManaged` table feature enabled.
+pub const CATALOG_MANAGED_METADATA: &str = r#"{"commitInfo":{"timestamp":1587968586154,"operation":"WRITE","operationParameters":{"mode":"ErrorIfExists","partitionBy":"[]"},"isBlindAppend":true}}
+{"protocol":{"minReaderVersion":3,"minWriterVersion":7,"readerFeatures":["catalogManaged"],"writerFeatures":["catalogManaged"]}}
+{"metaData":{"id":"5fba94ed-9794-4965-ba6e-6ee3c0d22af9","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"id\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}},{\"name\":\"val\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{},"createdTime":1587968585495}}"#;
+
 pub enum TestAction {
     Add(String),
     Remove(String),
@@ -115,6 +120,11 @@ pub enum TestAction {
 /// Convert a vector of actions into a newline delimited json string, with standard metadata
 pub fn actions_to_string(actions: Vec<TestAction>) -> String {
     actions_to_string_with_metadata(actions, METADATA)
+}
+
+/// Convert a vector of actions into a newline delimited json string, with catalog-managed metadata
+pub fn actions_to_string_catalog_managed(actions: Vec<TestAction>) -> String {
+    actions_to_string_with_metadata(actions, CATALOG_MANAGED_METADATA)
 }
 
 /// Convert a vector of actions into a newline delimited json string, with metadata including a partition column

--- a/uc-catalog/src/lib.rs
+++ b/uc-catalog/src/lib.rs
@@ -123,6 +123,7 @@ impl<'a, C: UCGetCommitsClient> UCCatalog<'a, C> {
 
         Snapshot::builder_for(table_url)
             .at_version(version)
+            .with_max_catalog_version(version)
             .with_log_tail(commits)
             .build(engine)
             .map_err(|e| e.into())

--- a/uc-catalog/tests/e2e_in_memory.rs
+++ b/uc-catalog/tests/e2e_in_memory.rs
@@ -191,7 +191,9 @@ async fn test_checkpoint_after_publish() -> Result<(), TestError> {
         .checkpoint(&engine)?;
 
     // Load a fresh snapshot and verify checkpoint was written
-    let snapshot = Snapshot::builder_for(table_uri).build(&engine)?;
+    let snapshot = Snapshot::builder_for(table_uri)
+        .with_max_catalog_version(3)
+        .build(&engine)?;
     assert_eq!(snapshot.log_segment().checkpoint_version, Some(3));
 
     Ok(())


### PR DESCRIPTION
## What changes are proposed in this pull request?
Officially support writes to tables with column mapping enabled and add
e2e tests to validate.
<!--
**Uncomment** this section if there are any changes affecting public
APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes`
label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

## How was this change tested?
Added test for all 3 CM modes `none,id,name` to
1. Creates a table with the given column mapping mode
2. Writes two batches of data
3. Checkpoints and verifies add.stats uses physical column names in the
checkpoint
4. Reads a parquet footer to verify physical names/IDs (verification of
ID is pending, as it depends on
https://github.com/delta-io/delta-kernel-rs/pull/1850, will add once it
got merged)
5. Reads data back to verify correctness
6. Remove added files and verify remove.stats are using physical column
names

And for table with partition columns, validate if `partitionValues` in
`add` and `remove` action use physical column name.

## Note(for DefaultEngine users only)
We are merging this PR before
https://github.com/delta-io/delta-kernel-rs/pull/1850, so for CM table,
field_id field of the SchemaElement struct in the [Parquet Thrift
specification](https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift)
will not be correctly written until
https://github.com/delta-io/delta-kernel-rs/pull/1850 gets merged

## What changes are proposed in this pull request?

<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

## How was this change tested?
