### PR TITLE
ci: only run invalid_handle_code test when there is change in ffi/*

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,7 +139,7 @@ jobs:
       - name: test
         run: cargo nextest run --workspace --all-features -E 'not test(read_table_version_hdfs) and not test(invalid_handle_code)'
       - name: trybuild tests
-        if: steps.filter.outputs.ffi == 'false'
+        if: steps.filter.outputs.ffi == 'true'
         run: cargo test --package delta_kernel_ffi --features --internal-api invalid_handle_code
 
   ffi_test:


### PR DESCRIPTION
## What changes are proposed in this pull request?
close #1687 

Currently, the test job in CI run the `invalid_handle_code`, ensured the Handle type's safety guarantees at compile time for FFI code. However, the `invalid_handle_code` can take long time to run on CI pipeline (more than 2 mins), making the `test` pipeline is the slowest job. Some prototyped optimization was made to reduce the `invalid_handle_code` e.g: parallel the `invalid_handle_code`, moving the `invalid_handle_code` to another job, but there is no efficient gain from that.

This PR split the `invalid_handle_code` to another run, and only run it there is a changed in the `ffi/` source code. Given that, the CI can skip running the heavy weight `invalid_handle_code`.


## How was this change tested?

- Manual test: added a small change in the handle.rs, making sure it trigger the trybuild run. 
- CI pipeline should be succeeded.