### PR TITLE
feat: extend DataSkippingFilter to support partition columns

### DIFF
--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -42,13 +42,13 @@ use delta_kernel_derive::internal_api;
 ///   predicate is dropped.
 #[cfg(test)]
 pub(crate) fn as_data_skipping_predicate(pred: &Pred) -> Option<Pred> {
-    DataSkippingPredicateCreator::new(Default::default()).eval(pred)
+    DataSkippingPredicateCreator::new(&Default::default()).eval(pred)
 }
 
 #[cfg(test)]
 pub(crate) fn as_data_skipping_predicate_with_partitions(
     pred: &Pred,
-    partition_columns: HashSet<String>,
+    partition_columns: &HashSet<String>,
 ) -> Option<Pred> {
     DataSkippingPredicateCreator::new(partition_columns).eval(pred)
 }
@@ -59,7 +59,7 @@ fn as_sql_data_skipping_predicate(
     pred: &Pred,
     partition_columns: &HashSet<String>,
 ) -> Option<Pred> {
-    DataSkippingPredicateCreator::new(partition_columns.clone()).eval_sql_where(pred)
+    DataSkippingPredicateCreator::new(partition_columns).eval_sql_where(pred)
 }
 
 #[internal_api]
@@ -182,19 +182,12 @@ impl DataSkippingFilter {
     /// `DataSkippingPredicateCreator`. Partition values are similarly wrapped under
     /// `partitionValues_parsed` when present.
     fn build_unified_schema_and_expr(
-        stats_schema: Option<&SchemaRef>,
+        physical_stats_schema: Option<&SchemaRef>,
         stats_expr: ExpressionRef,
-        partition_schema: Option<&SchemaRef>,
+        physical_partition_schema: Option<&SchemaRef>,
         partition_expr: ExpressionRef,
     ) -> Option<(SchemaRef, ExpressionRef, HashSet<String>)> {
-        let has_stats = stats_schema.is_some();
-        let has_partitions = partition_schema.is_some();
-
-        if !has_stats && !has_partitions {
-            return None;
-        }
-
-        let partition_columns: HashSet<String> = partition_schema
+        let partition_columns: HashSet<String> = physical_partition_schema
             .map(|s| s.fields().map(|f| f.name().to_string()).collect())
             .unwrap_or_default();
 
@@ -211,21 +204,24 @@ impl DataSkippingFilter {
             )
         };
 
-        let unified_schema = match (stats_schema, partition_schema) {
+        let unified_schema = match (physical_stats_schema, physical_partition_schema) {
             (Some(stats), Some(ps)) => Arc::new(StructType::new_unchecked([
                 stats_field(stats),
                 partition_field(ps),
             ])),
             (Some(stats), None) => Arc::new(StructType::new_unchecked([stats_field(stats)])),
             (None, Some(ps)) => Arc::new(StructType::new_unchecked([partition_field(ps)])),
-            (None, None) => unreachable!("checked above"),
+            (None, None) => return None,
         };
 
-        let unified_expr = match (has_stats, has_partitions) {
+        let unified_expr = match (
+            physical_stats_schema.is_some(),
+            physical_partition_schema.is_some(),
+        ) {
             (true, true) => Arc::new(Expr::struct_from([stats_expr, partition_expr])),
             (true, false) => Arc::new(Expr::struct_from([stats_expr])),
             (false, true) => Arc::new(Expr::struct_from([partition_expr])),
-            (false, false) => unreachable!("checked above"),
+            (false, false) => return None,
         };
 
         Some((unified_schema, unified_expr, partition_columns))
@@ -350,14 +346,14 @@ fn collect_junction_preds(
 /// `stats_parsed.nullCount.*`.
 /// For partition columns, rewrites to `partitionValues_parsed.*` since the partition value is
 /// the exact value for every row in the file (serving as both min and max).
-struct DataSkippingPredicateCreator {
+struct DataSkippingPredicateCreator<'a> {
     /// Physical names of partition columns. For these columns, stats come from
     /// `partitionValues.<col>` (exact values) instead of min/max ranges.
-    partition_columns: HashSet<String>,
+    partition_columns: &'a HashSet<String>,
 }
 
-impl DataSkippingPredicateCreator {
-    fn new(partition_columns: HashSet<String>) -> Self {
+impl<'a> DataSkippingPredicateCreator<'a> {
+    fn new(partition_columns: &'a HashSet<String>) -> Self {
         Self { partition_columns }
     }
 
@@ -367,7 +363,7 @@ impl DataSkippingPredicateCreator {
     }
 }
 
-impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator {
+impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
     type Output = Pred;
     type ColumnStat = Expr;
 

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -7,14 +7,14 @@ use tracing::{debug, error, info};
 use crate::actions::visitors::SelectionVectorVisitor;
 use crate::error::DeltaResult;
 use crate::expressions::{
-    column_expr, joined_column_expr, BinaryPredicateOp, ColumnName, Expression as Expr,
-    ExpressionRef, JunctionPredicateOp, OpaquePredicateOpRef, Predicate as Pred, PredicateRef,
-    Scalar,
+    column_expr, column_name, joined_column_expr, BinaryPredicateOp, ColumnName,
+    Expression as Expr, ExpressionRef, JunctionPredicateOp, OpaquePredicateOpRef,
+    Predicate as Pred, PredicateRef, Scalar,
 };
 use crate::kernel_predicates::{
     DataSkippingPredicateEvaluator, KernelPredicateEvaluator, KernelPredicateEvaluatorDefaults,
 };
-use crate::schema::{DataType, SchemaRef};
+use crate::schema::{DataType, SchemaRef, StructField, StructType};
 use crate::utils::require;
 use crate::{Engine, EngineData, Error, ExpressionEvaluator, PredicateEvaluator, RowVisitor as _};
 
@@ -42,13 +42,24 @@ use delta_kernel_derive::internal_api;
 ///   predicate is dropped.
 #[cfg(test)]
 pub(crate) fn as_data_skipping_predicate(pred: &Pred) -> Option<Pred> {
-    DataSkippingPredicateCreator.eval(pred)
+    DataSkippingPredicateCreator::new(Default::default()).eval(pred)
+}
+
+#[cfg(test)]
+pub(crate) fn as_data_skipping_predicate_with_partitions(
+    pred: &Pred,
+    partition_columns: HashSet<String>,
+) -> Option<Pred> {
+    DataSkippingPredicateCreator::new(partition_columns).eval(pred)
 }
 
 /// Like `as_data_skipping_predicate`, but invokes [`KernelPredicateEvaluator::eval_sql_where`]
 /// instead of [`KernelPredicateEvaluator::eval`].
-fn as_sql_data_skipping_predicate(pred: &Pred) -> Option<Pred> {
-    DataSkippingPredicateCreator.eval_sql_where(pred)
+fn as_sql_data_skipping_predicate(
+    pred: &Pred,
+    partition_columns: &HashSet<String>,
+) -> Option<Pred> {
+    DataSkippingPredicateCreator::new(partition_columns.clone()).eval_sql_where(pred)
 }
 
 #[internal_api]
@@ -74,17 +85,26 @@ impl DataSkippingFilter {
     /// # Parameters
     /// - `engine`: Engine for creating evaluators
     /// - `predicate`: Optional predicate for data skipping
-    /// - `stats_schema`: The stats schema (numRecords, nullCount, minValues, maxValues)
-    /// - `input_schema`: Schema of the batch that will be passed to [`apply()`](Self::apply)
-    /// - `stats_expr`: Expression to extract stats from the batch, producing output matching
+    /// - `stats_schema`: The data stats schema (numRecords, nullCount, minValues, maxValues).
+    ///   Pass `None` if no data stats are available.
+    /// - `stats_expr`: Expression to extract data stats from the batch, producing output matching
     ///   `stats_schema`. For example, `column_expr!("stats_parsed")` for pre-parsed stats, or
     ///   `Expression::parse_json(column_expr!("add.stats"), stats_schema)` for JSON parsing.
+    /// - `partition_schema`: Schema of typed partition columns referenced by the predicate
+    ///   (physical names). Pass `None` if no partition columns are referenced.
+    /// - `partition_expr`: Expression to extract partition values from the batch, producing output
+    ///   matching `partition_schema`. Typically a `MapToStruct` expression that converts the
+    ///   `partitionValues` string map into a typed struct. Only used when `partition_schema` is
+    ///   `Some`.
+    /// - `input_schema`: Schema of the batch that will be passed to [`apply()`](Self::apply)
     pub(crate) fn new(
         engine: &dyn Engine,
         predicate: Option<PredicateRef>,
-        stats_schema: SchemaRef,
-        input_schema: SchemaRef,
+        stats_schema: Option<&SchemaRef>,
         stats_expr: ExpressionRef,
+        partition_schema: Option<&SchemaRef>,
+        partition_expr: ExpressionRef,
+        input_schema: SchemaRef,
     ) -> Option<Self> {
         static FILTER_PRED: LazyLock<PredicateRef> =
             LazyLock::new(|| Arc::new(column_expr!("output").distinct(Expr::literal(false))));
@@ -92,12 +112,22 @@ impl DataSkippingFilter {
         let predicate = predicate?;
         debug!("Creating a data skipping filter for {:#?}", predicate);
 
+        // Build the unified evaluation schema and extraction expression. Data stats and partition
+        // values are conceptually separate, but the evaluator needs a single schema/expression.
+        let (unified_schema, unified_expr, partition_columns) =
+            Self::build_unified_schema_and_expr(
+                stats_schema,
+                stats_expr,
+                partition_schema,
+                partition_expr,
+            )?;
+
         let stats_evaluator = engine
             .evaluation_handler()
             .new_expression_evaluator(
                 input_schema,
-                stats_expr,
-                stats_schema.as_ref().clone().into(),
+                unified_expr,
+                unified_schema.as_ref().clone().into(),
             )
             .inspect_err(|e| error!("Failed to create stats evaluator: {e}"))
             .ok()?;
@@ -118,15 +148,18 @@ impl DataSkippingFilter {
         let skipping_evaluator = engine
             .evaluation_handler()
             .new_predicate_evaluator(
-                stats_schema.clone(),
-                Arc::new(as_sql_data_skipping_predicate(&predicate)?),
+                unified_schema.clone(),
+                Arc::new(as_sql_data_skipping_predicate(
+                    &predicate,
+                    &partition_columns,
+                )?),
             )
             .inspect_err(|e| error!("Failed to create skipping evaluator: {e}"))
             .ok()?;
 
         let filter_evaluator = engine
             .evaluation_handler()
-            .new_predicate_evaluator(stats_schema, FILTER_PRED.clone())
+            .new_predicate_evaluator(unified_schema, FILTER_PRED.clone())
             .inspect_err(|e| error!("Failed to create filter evaluator: {e}"))
             .ok()?;
 
@@ -135,6 +168,68 @@ impl DataSkippingFilter {
             skipping_evaluator,
             filter_evaluator,
         })
+    }
+
+    /// Builds the unified schema and extraction expression from separate data stats and partition
+    /// value inputs. Returns `None` if neither stats nor partition values are available.
+    ///
+    /// The caller provides a flat stats schema (e.g. `{ numRecords, minValues: { x } }`) and an
+    /// expression to extract it from the input batch. This function wraps both under a
+    /// `stats_parsed` struct field, producing a nested schema like
+    /// `{ stats_parsed: { numRecords, minValues: { x } } }` and a corresponding
+    /// `struct_from([stats_expr])` extraction expression. This ensures the unified schema aligns
+    /// with the `stats_parsed.*` prefixed column references emitted by
+    /// `DataSkippingPredicateCreator`. Partition values are similarly wrapped under
+    /// `partitionValues_parsed` when present.
+    fn build_unified_schema_and_expr(
+        stats_schema: Option<&SchemaRef>,
+        stats_expr: ExpressionRef,
+        partition_schema: Option<&SchemaRef>,
+        partition_expr: ExpressionRef,
+    ) -> Option<(SchemaRef, ExpressionRef, HashSet<String>)> {
+        let has_stats = stats_schema.is_some();
+        let pv_schema = partition_schema;
+        let has_partitions = pv_schema.is_some();
+
+        if !has_stats && !has_partitions {
+            return None;
+        }
+
+        let partition_columns: HashSet<String> = pv_schema
+            .map(|s| s.fields().map(|f| f.name().to_string()).collect())
+            .unwrap_or_default();
+
+        let stats_field = |stats: &SchemaRef| {
+            StructField::nullable(
+                "stats_parsed",
+                DataType::Struct(Box::new(stats.as_ref().clone())),
+            )
+        };
+        let pv_field = |pv: &SchemaRef| {
+            StructField::nullable(
+                "partitionValues_parsed",
+                DataType::Struct(Box::new(pv.as_ref().clone())),
+            )
+        };
+
+        let unified_schema = match (stats_schema, pv_schema) {
+            (Some(stats), Some(pv)) => Arc::new(StructType::new_unchecked([
+                stats_field(stats),
+                pv_field(pv),
+            ])),
+            (Some(stats), None) => Arc::new(StructType::new_unchecked([stats_field(stats)])),
+            (None, Some(pv)) => Arc::new(StructType::new_unchecked([pv_field(pv)])),
+            (None, None) => unreachable!("checked above"),
+        };
+
+        let unified_expr = match (has_stats, has_partitions) {
+            (true, true) => Arc::new(Expr::struct_from([stats_expr, partition_expr])),
+            (true, false) => Arc::new(Expr::struct_from([stats_expr])),
+            (false, true) => Arc::new(Expr::struct_from([partition_expr])),
+            (false, false) => unreachable!("checked above"),
+        };
+
+        Some((unified_schema, unified_expr, partition_columns))
     }
 
     /// Apply the DataSkippingFilter to an EngineData batch. Returns a selection vector
@@ -250,35 +345,70 @@ fn collect_junction_preds(
     Pred::junction(op, preds)
 }
 
-struct DataSkippingPredicateCreator;
+/// Rewrites user predicates into stats-based predicates for data skipping.
+///
+/// For data columns, rewrites to `stats_parsed.minValues.*`/`stats_parsed.maxValues.*`/
+/// `stats_parsed.nullCount.*`.
+/// For partition columns, rewrites to `partitionValues_parsed.*` since the partition value is
+/// the exact value for every row in the file (serving as both min and max).
+struct DataSkippingPredicateCreator {
+    /// Physical names of partition columns. For these columns, stats come from
+    /// `partitionValues.<col>` (exact values) instead of min/max ranges.
+    partition_columns: HashSet<String>,
+}
+
+impl DataSkippingPredicateCreator {
+    fn new(partition_columns: HashSet<String>) -> Self {
+        Self { partition_columns }
+    }
+
+    fn is_partition_column(&self, col: &ColumnName) -> bool {
+        let path = col.path();
+        path.len() == 1 && self.partition_columns.contains(path[0].as_str())
+    }
+}
 
 impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator {
     type Output = Pred;
     type ColumnStat = Expr;
 
-    /// Retrieves the minimum value of a column, if it exists and has the requested type.
+    /// Retrieves the minimum value of a column. For partition columns, returns the exact
+    /// partition value (which serves as both min and max).
     fn get_min_stat(&self, col: &ColumnName, _data_type: &DataType) -> Option<Expr> {
-        Some(joined_column_expr!("minValues", col))
-    }
-
-    /// Retrieves the maximum value of a column, if it exists and has the requested type.
-    // TODO(#1002): we currently don't support file skipping on timestamp columns' max stat since
-    // they are truncated to milliseconds in add.stats.
-    fn get_max_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
-        match data_type {
-            &DataType::TIMESTAMP | &DataType::TIMESTAMP_NTZ => None,
-            _ => Some(joined_column_expr!("maxValues", col)),
+        if self.is_partition_column(col) {
+            Some(joined_column_expr!("partitionValues_parsed", col))
+        } else {
+            Some(Expr::from(column_name!("stats_parsed.minValues").join(col)))
         }
     }
 
-    /// Retrieves the null count of a column, if it exists.
-    fn get_nullcount_stat(&self, col: &ColumnName) -> Option<Expr> {
-        Some(joined_column_expr!("nullCount", col))
+    /// Retrieves the maximum value of a column. For partition columns, returns the exact
+    /// partition value. For data columns, excludes timestamps due to millisecond truncation.
+    // TODO(#1002): we currently don't support file skipping on timestamp columns' max stat since
+    // they are truncated to milliseconds in add.stats.
+    fn get_max_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
+        if self.is_partition_column(col) {
+            Some(joined_column_expr!("partitionValues_parsed", col))
+        } else {
+            match data_type {
+                &DataType::TIMESTAMP | &DataType::TIMESTAMP_NTZ => None,
+                _ => Some(Expr::from(column_name!("stats_parsed.maxValues").join(col))),
+            }
+        }
     }
 
-    /// Retrieves the row count of a column (parquet footers always include this stat).
+    /// Retrieves the null count of a column. Partition columns don't have nullCount stats.
+    fn get_nullcount_stat(&self, col: &ColumnName) -> Option<Expr> {
+        if self.is_partition_column(col) {
+            None
+        } else {
+            Some(Expr::from(column_name!("stats_parsed.nullCount").join(col)))
+        }
+    }
+
+    /// Retrieves the row count statistic.
     fn get_rowcount_stat(&self) -> Option<Expr> {
-        Some(column_expr!("numRecords"))
+        Some(column_expr!("stats_parsed.numRecords"))
     }
 
     fn eval_partial_cmp(
@@ -299,14 +429,23 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator {
         KernelPredicateEvaluatorDefaults::eval_pred_scalar_is_null(val, inverted).map(Pred::literal)
     }
 
-    // NOTE: This is nearly identical to the impl for ParquetStatsProvider in
-    // parquet_stats_skipping.rs, except it uses `Expression` and `Predicate` instead of `Scalar`.
+    /// For partition columns, checks `partitionValues_parsed.<col> IS [NOT] NULL` directly.
+    /// For data columns, uses nullCount stats.
     fn eval_pred_is_null(&self, col: &ColumnName, inverted: bool) -> Option<Pred> {
-        let safe_to_skip = match inverted {
-            true => self.get_rowcount_stat()?, // all-null
-            false => Expr::literal(0i64),      // no-null
-        };
-        Some(Pred::ne(self.get_nullcount_stat(col)?, safe_to_skip))
+        if self.is_partition_column(col) {
+            let pv_expr = joined_column_expr!("partitionValues_parsed", col);
+            if inverted {
+                Some(Pred::is_not_null(pv_expr))
+            } else {
+                Some(Pred::is_null(pv_expr))
+            }
+        } else {
+            let safe_to_skip = match inverted {
+                true => self.get_rowcount_stat()?, // all-null
+                false => Expr::literal(0i64),      // no-null
+            };
+            Some(Pred::ne(self.get_nullcount_stat(col)?, safe_to_skip))
+        }
     }
 
     fn eval_pred_binary_scalars(
@@ -340,8 +479,8 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator {
 }
 
 /// Like [`DataSkippingPredicateCreator`] but adds IS NULL guards on stat column references
-/// for safe parquet row group filtering. Partition columns are excluded (no stats in
-/// `stats_parsed`).
+/// for safe parquet row group filtering. Partition columns are excluded since their values
+/// live in `add.partitionValues_parsed`, not `add.stats_parsed`.
 struct NullGuardedDataSkippingPredicateCreator<'a> {
     partition_columns: HashSet<&'a str>,
 }
@@ -358,32 +497,36 @@ impl DataSkippingPredicateEvaluator for NullGuardedDataSkippingPredicateCreator<
     type Output = Pred;
     type ColumnStat = Expr;
 
-    // The get_*_stat methods delegate to DataSkippingPredicateCreator but return None for
-    // partition columns, which don't have stats in stats_parsed.
+    // These stat methods produce unprefixed column references (e.g. `minValues.col`) because
+    // the checkpoint skipping path applies its own `add.stats_parsed` prefix afterward.
+    // Partition columns return None since their values live in `add.partitionValues_parsed`.
 
-    fn get_min_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
+    fn get_min_stat(&self, col: &ColumnName, _data_type: &DataType) -> Option<Expr> {
         if self.is_partition_column(col) {
             return None;
         }
-        DataSkippingPredicateCreator.get_min_stat(col, data_type)
+        Some(joined_column_expr!("minValues", col))
     }
 
     fn get_max_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
         if self.is_partition_column(col) {
             return None;
         }
-        DataSkippingPredicateCreator.get_max_stat(col, data_type)
+        match data_type {
+            &DataType::TIMESTAMP | &DataType::TIMESTAMP_NTZ => None,
+            _ => Some(joined_column_expr!("maxValues", col)),
+        }
     }
 
     fn get_nullcount_stat(&self, col: &ColumnName) -> Option<Expr> {
         if self.is_partition_column(col) {
             return None;
         }
-        DataSkippingPredicateCreator.get_nullcount_stat(col)
+        Some(joined_column_expr!("nullCount", col))
     }
 
     fn get_rowcount_stat(&self) -> Option<Expr> {
-        DataSkippingPredicateCreator.get_rowcount_stat()
+        Some(column_expr!("numRecords"))
     }
 
     /// Wraps a stat column comparison with an IS NULL guard.

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -188,14 +188,13 @@ impl DataSkippingFilter {
         partition_expr: ExpressionRef,
     ) -> Option<(SchemaRef, ExpressionRef, HashSet<String>)> {
         let has_stats = stats_schema.is_some();
-        let pv_schema = partition_schema;
-        let has_partitions = pv_schema.is_some();
+        let has_partitions = partition_schema.is_some();
 
         if !has_stats && !has_partitions {
             return None;
         }
 
-        let partition_columns: HashSet<String> = pv_schema
+        let partition_columns: HashSet<String> = partition_schema
             .map(|s| s.fields().map(|f| f.name().to_string()).collect())
             .unwrap_or_default();
 
@@ -205,20 +204,20 @@ impl DataSkippingFilter {
                 DataType::Struct(Box::new(stats.as_ref().clone())),
             )
         };
-        let pv_field = |pv: &SchemaRef| {
+        let partition_field = |ps: &SchemaRef| {
             StructField::nullable(
                 "partitionValues_parsed",
-                DataType::Struct(Box::new(pv.as_ref().clone())),
+                DataType::Struct(Box::new(ps.as_ref().clone())),
             )
         };
 
-        let unified_schema = match (stats_schema, pv_schema) {
-            (Some(stats), Some(pv)) => Arc::new(StructType::new_unchecked([
+        let unified_schema = match (stats_schema, partition_schema) {
+            (Some(stats), Some(ps)) => Arc::new(StructType::new_unchecked([
                 stats_field(stats),
-                pv_field(pv),
+                partition_field(ps),
             ])),
             (Some(stats), None) => Arc::new(StructType::new_unchecked([stats_field(stats)])),
-            (None, Some(pv)) => Arc::new(StructType::new_unchecked([pv_field(pv)])),
+            (None, Some(ps)) => Arc::new(StructType::new_unchecked([partition_field(ps)])),
             (None, None) => unreachable!("checked above"),
         };
 

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -358,8 +358,9 @@ fn test_sql_where() {
 // are truncated to milliseconds in add.stats.
 #[test]
 fn test_timestamp_skipping_disabled() {
+    let empty = HashSet::new();
     let creator = DataSkippingPredicateCreator {
-        partition_columns: Default::default(),
+        partition_columns: &empty,
     };
     let col = &column_name!("timestamp_col");
 
@@ -561,8 +562,7 @@ fn test_partition_column_rewrite() {
 
     // Partition column equality rewrites to partitionValues (not minValues/maxValues)
     let pred = Pred::eq(column_expr!("part_col"), Scalar::from("2025-01-01"));
-    let skipping_pred =
-        as_data_skipping_predicate_with_partitions(&pred, partition_columns.clone());
+    let skipping_pred = as_data_skipping_predicate_with_partitions(&pred, &partition_columns);
     let pred_str = skipping_pred.as_ref().map(|p| p.to_string());
     assert!(
         pred_str
@@ -579,8 +579,7 @@ fn test_partition_column_rewrite() {
 
     // Data column still rewrites to stats_parsed.minValues/maxValues
     let pred = Pred::gt(column_expr!("data_col"), Scalar::from(100));
-    let skipping_pred =
-        as_data_skipping_predicate_with_partitions(&pred, partition_columns.clone());
+    let skipping_pred = as_data_skipping_predicate_with_partitions(&pred, &partition_columns);
     let pred_str = skipping_pred.as_ref().map(|p| p.to_string());
     assert!(
         pred_str
@@ -601,8 +600,7 @@ fn test_partition_column_rewrite() {
 )]
 fn test_partition_column_is_null(#[case] pred: Pred, #[case] expected: &str) {
     let partition_columns = test_partition_columns();
-    let skipping_pred =
-        as_data_skipping_predicate_with_partitions(&pred, partition_columns.clone());
+    let skipping_pred = as_data_skipping_predicate_with_partitions(&pred, &partition_columns);
     assert_eq!(
         skipping_pred.as_ref().map(|p| p.to_string()).as_deref(),
         Some(expected),
@@ -620,8 +618,7 @@ fn test_mixed_partition_and_data_or_predicate() {
         Pred::eq(column_expr!("part_col"), Scalar::from("X")),
         Pred::gt(column_expr!("data_col"), Scalar::from(100)),
     );
-    let skipping_pred =
-        as_data_skipping_predicate_with_partitions(&pred, partition_columns.clone());
+    let skipping_pred = as_data_skipping_predicate_with_partitions(&pred, &partition_columns);
     assert!(
         skipping_pred.is_some(),
         "Mixed partition+data OR should produce a valid skipping predicate"
@@ -657,8 +654,8 @@ fn test_mixed_partition_and_data_or_evaluation(
         Pred::eq(column_expr!("part_col"), Scalar::from("X")),
         Pred::gt(column_expr!("data_col"), Scalar::from(100)),
     );
-    let skipping_pred =
-        as_data_skipping_predicate_with_partitions(&pred, partition_columns).expect("should exist");
+    let skipping_pred = as_data_skipping_predicate_with_partitions(&pred, &partition_columns)
+        .expect("should exist");
 
     let filter = mixed_resolver(part_val, max_data);
     assert_eq!(
@@ -685,8 +682,8 @@ fn test_mixed_partition_and_data_and_evaluation(
         Pred::eq(column_expr!("part_col"), Scalar::from("X")),
         Pred::gt(column_expr!("data_col"), Scalar::from(100)),
     );
-    let skipping_pred =
-        as_data_skipping_predicate_with_partitions(&pred, partition_columns).expect("should exist");
+    let skipping_pred = as_data_skipping_predicate_with_partitions(&pred, &partition_columns)
+        .expect("should exist");
 
     let filter = mixed_resolver(part_val, max_data);
     assert_eq!(
@@ -702,8 +699,8 @@ fn test_partition_column_comparison_uses_exact_value() {
 
     // part_col > 'B' rewrites both min and max to partitionValues_parsed.part_col
     let pred = Pred::gt(column_expr!("part_col"), Scalar::from("B"));
-    let skipping_pred =
-        as_data_skipping_predicate_with_partitions(&pred, partition_columns).expect("should exist");
+    let skipping_pred = as_data_skipping_predicate_with_partitions(&pred, &partition_columns)
+        .expect("should exist");
 
     // part_col='A': 'A' > 'B' is false -> skip
     let resolver = DefaultKernelPredicateEvaluator::from(HashMap::from_iter([(
@@ -726,8 +723,8 @@ fn test_partition_only_predicate() {
 
     // Partition-only: no data columns involved
     let pred = Pred::eq(column_expr!("part_col"), Scalar::from("X"));
-    let skipping_pred =
-        as_data_skipping_predicate_with_partitions(&pred, partition_columns).expect("should exist");
+    let skipping_pred = as_data_skipping_predicate_with_partitions(&pred, &partition_columns)
+        .expect("should exist");
     let pred_str = skipping_pred.to_string();
     assert!(
         pred_str.contains("partitionValues_parsed.part_col"),
@@ -736,5 +733,63 @@ fn test_partition_only_predicate() {
     assert!(
         !pred_str.contains("stats_parsed"),
         "Partition-only predicate should not reference stats_parsed"
+    );
+}
+
+#[test]
+fn test_sql_where_partition_rewrite() {
+    let partition_columns = test_partition_columns();
+
+    // Partition column equality: SQL WHERE should rewrite to partitionValues_parsed
+    let pred = Pred::eq(column_expr!("part_col"), Scalar::from("X"));
+    let sql_pred = as_sql_data_skipping_predicate(&pred, &partition_columns)
+        .expect("partition eq should produce SQL skipping pred");
+    let pred_str = sql_pred.to_string();
+    assert!(
+        pred_str.contains("partitionValues_parsed.part_col"),
+        "SQL WHERE should reference partitionValues_parsed, got {pred_str}"
+    );
+}
+
+#[rstest]
+#[case::partition_match_data_above("X", 200, TRUE)]
+#[case::partition_miss_data_above("Y", 200, FALSE)]
+#[case::partition_match_data_below("X", 50, FALSE)]
+#[case::both_miss("Y", 50, FALSE)]
+fn test_sql_where_mixed_partition_and_data_evaluation(
+    #[case] part_val: &str,
+    #[case] max_data: i32,
+    #[case] expected: Option<bool>,
+) {
+    let partition_columns = test_partition_columns();
+
+    // WHERE part_col = 'X' AND data_col > 100
+    let pred = Pred::and(
+        Pred::eq(column_expr!("part_col"), Scalar::from("X")),
+        Pred::gt(column_expr!("data_col"), Scalar::from(100)),
+    );
+    let sql_pred = as_sql_data_skipping_predicate(&pred, &partition_columns)
+        .expect("mixed AND should produce SQL skipping pred");
+
+    let resolver = HashMap::from_iter([
+        (
+            column_name!("partitionValues_parsed.part_col"),
+            Scalar::from(part_val),
+        ),
+        (column_name!("stats_parsed.numRecords"), Scalar::from(2i64)),
+        (
+            column_name!("stats_parsed.nullCount.data_col"),
+            Scalar::from(0i64),
+        ),
+        (
+            column_name!("stats_parsed.maxValues.data_col"),
+            Scalar::from(max_data),
+        ),
+    ]);
+    let filter = DefaultKernelPredicateEvaluator::from(resolver);
+    assert_eq!(
+        filter.eval(&sql_pred),
+        expected,
+        "part_col='{part_val}' max(data_col)={max_data}"
     );
 }

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -30,8 +30,11 @@ fn test_eval_is_null() {
 
     let do_test = |nullcount: i64, expected: &[Option<bool>]| {
         let resolver = HashMap::from_iter([
-            (column_name!("numRecords"), Scalar::from(2i64)),
-            (column_name!("nullCount.x"), Scalar::from(nullcount)),
+            (column_name!("stats_parsed.numRecords"), Scalar::from(2i64)),
+            (
+                column_name!("stats_parsed.nullCount.x"),
+                Scalar::from(nullcount),
+            ),
         ]);
         let filter = DefaultKernelPredicateEvaluator::from(resolver);
         for (pred, expect) in predicates.iter().zip(expected) {
@@ -73,8 +76,8 @@ fn test_eval_binary_comparisons() {
 
     let do_test = |min: &Scalar, max: &Scalar, expected: &[Option<bool>]| {
         let resolver = HashMap::from_iter([
-            (column_name!("minValues.x"), min.clone()),
-            (column_name!("maxValues.x"), max.clone()),
+            (column_name!("stats_parsed.minValues.x"), min.clone()),
+            (column_name!("stats_parsed.maxValues.x"), max.clone()),
         ]);
         let filter = DefaultKernelPredicateEvaluator::from(resolver);
         for (pred, expect) in predicates.iter().zip(expected.iter()) {
@@ -206,10 +209,13 @@ fn test_eval_distinct() {
 
     let do_test = |min: &Scalar, max: &Scalar, nullcount: i64, expected: &[Option<bool>]| {
         let resolver = HashMap::from_iter([
-            (column_name!("numRecords"), Scalar::from(2i64)),
-            (column_name!("nullCount.x"), Scalar::from(nullcount)),
-            (column_name!("minValues.x"), min.clone()),
-            (column_name!("maxValues.x"), max.clone()),
+            (column_name!("stats_parsed.numRecords"), Scalar::from(2i64)),
+            (
+                column_name!("stats_parsed.nullCount.x"),
+                Scalar::from(nullcount),
+            ),
+            (column_name!("stats_parsed.minValues.x"), min.clone()),
+            (column_name!("stats_parsed.maxValues.x"), max.clone()),
         ]);
         let filter = DefaultKernelPredicateEvaluator::from(resolver);
         for (pred, expect) in predicates.iter().zip(expected) {
@@ -277,10 +283,16 @@ fn test_sql_where() {
                 HashMap::new()
             } else {
                 HashMap::from_iter([
-                    (column_name!("numRecords"), Scalar::from(ROWCOUNT)),
-                    (column_name!("nullCount.x"), Scalar::from(nulls)),
-                    (column_name!("minValues.x"), min.clone()),
-                    (column_name!("maxValues.x"), max.clone()),
+                    (
+                        column_name!("stats_parsed.numRecords"),
+                        Scalar::from(ROWCOUNT),
+                    ),
+                    (
+                        column_name!("stats_parsed.nullCount.x"),
+                        Scalar::from(nulls),
+                    ),
+                    (column_name!("stats_parsed.minValues.x"), min.clone()),
+                    (column_name!("stats_parsed.maxValues.x"), max.clone()),
                 ])
             };
             let filter = DefaultKernelPredicateEvaluator::from(resolver);
@@ -290,7 +302,8 @@ fn test_sql_where() {
                 expect,
                 "{pred:#?} became {skipping_pred:#?} ({min}..{max}, {nulls} nulls)"
             );
-            let skipping_sql_pred = as_sql_data_skipping_predicate(pred).unwrap();
+            let skipping_sql_pred =
+                as_sql_data_skipping_predicate(pred, &Default::default()).unwrap();
             expect_eq!(
                 filter.eval(&skipping_sql_pred),
                 expect_sql,
@@ -345,7 +358,9 @@ fn test_sql_where() {
 // are truncated to milliseconds in add.stats.
 #[test]
 fn test_timestamp_skipping_disabled() {
-    let creator = DataSkippingPredicateCreator;
+    let creator = DataSkippingPredicateCreator {
+        partition_columns: Default::default(),
+    };
     let col = &column_name!("timestamp_col");
 
     assert!(
@@ -489,7 +504,7 @@ fn test_timestamp_predicates_dont_data_skip() {
         let skipping_pred = as_data_skipping_predicate(&pred);
         assert_eq!(
             skipping_pred.unwrap().to_string(),
-            "Column(minValues.ts_col) < 1000000"
+            "Column(stats_parsed.minValues.ts_col) < 1000000"
         );
 
         // GT will do maxValues -> BLOCKED
@@ -504,14 +519,222 @@ fn test_timestamp_predicates_dont_data_skip() {
         let skipping_pred = as_data_skipping_predicate(&pred);
         assert_eq!(
             skipping_pred.unwrap().to_string(),
-            "AND(NOT(Column(minValues.ts_col) > 1000000), null)"
+            "AND(NOT(Column(stats_parsed.minValues.ts_col) > 1000000), null)"
         );
 
         let pred = Pred::ne(col.clone(), timestamp.clone());
         let skipping_pred = as_data_skipping_predicate(&pred);
         assert_eq!(
             skipping_pred.unwrap().to_string(),
-            "OR(NOT(Column(minValues.ts_col) = 1000000), null)"
+            "OR(NOT(Column(stats_parsed.minValues.ts_col) = 1000000), null)"
         );
     }
+}
+
+// Tests for partition-aware data skipping
+
+/// Helper to build a partition columns set with a single "part_col" entry.
+fn test_partition_columns() -> HashSet<String> {
+    ["part_col".to_string()].into()
+}
+
+/// Helper to build a resolver for mixed partition + data stats evaluation.
+fn mixed_resolver(
+    part_val: &str,
+    max_data: i32,
+) -> DefaultKernelPredicateEvaluator<HashMap<ColumnName, Scalar>> {
+    DefaultKernelPredicateEvaluator::from(HashMap::from_iter([
+        (
+            column_name!("partitionValues_parsed.part_col"),
+            Scalar::from(part_val),
+        ),
+        (
+            column_name!("stats_parsed.maxValues.data_col"),
+            Scalar::from(max_data),
+        ),
+    ]))
+}
+
+#[test]
+fn test_partition_column_rewrite() {
+    let partition_columns = test_partition_columns();
+
+    // Partition column equality rewrites to partitionValues (not minValues/maxValues)
+    let pred = Pred::eq(column_expr!("part_col"), Scalar::from("2025-01-01"));
+    let skipping_pred =
+        as_data_skipping_predicate_with_partitions(&pred, partition_columns.clone());
+    let pred_str = skipping_pred.as_ref().map(|p| p.to_string());
+    assert!(
+        pred_str
+            .as_ref()
+            .is_some_and(|s| s.contains("partitionValues_parsed.part_col")),
+        "Expected partitionValues_parsed.part_col, got {pred_str:?}"
+    );
+    assert!(
+        pred_str
+            .as_ref()
+            .is_some_and(|s| !s.contains("minValues") && !s.contains("maxValues")),
+        "Should not contain minValues/maxValues for partition columns"
+    );
+
+    // Data column still rewrites to stats_parsed.minValues/maxValues
+    let pred = Pred::gt(column_expr!("data_col"), Scalar::from(100));
+    let skipping_pred =
+        as_data_skipping_predicate_with_partitions(&pred, partition_columns.clone());
+    let pred_str = skipping_pred.as_ref().map(|p| p.to_string());
+    assert!(
+        pred_str
+            .as_ref()
+            .is_some_and(|s| s.contains("stats_parsed.maxValues.data_col")),
+        "Expected stats_parsed.maxValues.data_col for data column, got {pred_str:?}"
+    );
+}
+
+#[rstest]
+#[case::is_null(
+    Pred::is_null(column_expr!("part_col")),
+    "Column(partitionValues_parsed.part_col) IS NULL"
+)]
+#[case::is_not_null(
+    Pred::is_not_null(column_expr!("part_col")),
+    "NOT(Column(partitionValues_parsed.part_col) IS NULL)"
+)]
+fn test_partition_column_is_null(#[case] pred: Pred, #[case] expected: &str) {
+    let partition_columns = test_partition_columns();
+    let skipping_pred =
+        as_data_skipping_predicate_with_partitions(&pred, partition_columns.clone());
+    assert_eq!(
+        skipping_pred.as_ref().map(|p| p.to_string()).as_deref(),
+        Some(expected),
+    );
+}
+
+#[test]
+fn test_mixed_partition_and_data_or_predicate() {
+    let partition_columns = test_partition_columns();
+
+    // Mixed OR: partition_col = 'X' OR data_col > 100
+    // This should produce a valid skipping predicate (not None) because both
+    // operands are now eligible for data skipping.
+    let pred = Pred::or(
+        Pred::eq(column_expr!("part_col"), Scalar::from("X")),
+        Pred::gt(column_expr!("data_col"), Scalar::from(100)),
+    );
+    let skipping_pred =
+        as_data_skipping_predicate_with_partitions(&pred, partition_columns.clone());
+    assert!(
+        skipping_pred.is_some(),
+        "Mixed partition+data OR should produce a valid skipping predicate"
+    );
+    let pred_str = skipping_pred.as_ref().map(|p| p.to_string());
+    assert!(
+        pred_str
+            .as_ref()
+            .is_some_and(|s| s.contains("partitionValues_parsed.part_col")),
+        "Should reference partitionValues for partition column"
+    );
+    assert!(
+        pred_str
+            .as_ref()
+            .is_some_and(|s| s.contains("stats_parsed.maxValues.data_col")),
+        "Should reference stats_parsed.maxValues for data column"
+    );
+}
+
+#[rstest]
+#[case::both_miss("Y", 50, FALSE)]
+#[case::partition_match("X", 50, TRUE)]
+#[case::data_match("Y", 200, TRUE)]
+fn test_mixed_partition_and_data_or_evaluation(
+    #[case] part_val: &str,
+    #[case] max_data: i32,
+    #[case] expected: Option<bool>,
+) {
+    let partition_columns = test_partition_columns();
+
+    // WHERE part_col = 'X' OR data_col > 100
+    let pred = Pred::or(
+        Pred::eq(column_expr!("part_col"), Scalar::from("X")),
+        Pred::gt(column_expr!("data_col"), Scalar::from(100)),
+    );
+    let skipping_pred =
+        as_data_skipping_predicate_with_partitions(&pred, partition_columns).expect("should exist");
+
+    let filter = mixed_resolver(part_val, max_data);
+    assert_eq!(
+        filter.eval(&skipping_pred),
+        expected,
+        "part_col='{part_val}' max(data_col)={max_data}"
+    );
+}
+
+#[rstest]
+#[case::both_match("X", 200, TRUE)]
+#[case::partition_miss("Y", 200, FALSE)]
+#[case::data_miss("X", 50, FALSE)]
+#[case::both_miss("Y", 50, FALSE)]
+fn test_mixed_partition_and_data_and_evaluation(
+    #[case] part_val: &str,
+    #[case] max_data: i32,
+    #[case] expected: Option<bool>,
+) {
+    let partition_columns = test_partition_columns();
+
+    // WHERE part_col = 'X' AND data_col > 100
+    let pred = Pred::and(
+        Pred::eq(column_expr!("part_col"), Scalar::from("X")),
+        Pred::gt(column_expr!("data_col"), Scalar::from(100)),
+    );
+    let skipping_pred =
+        as_data_skipping_predicate_with_partitions(&pred, partition_columns).expect("should exist");
+
+    let filter = mixed_resolver(part_val, max_data);
+    assert_eq!(
+        filter.eval(&skipping_pred),
+        expected,
+        "part_col='{part_val}' max(data_col)={max_data}"
+    );
+}
+
+#[test]
+fn test_partition_column_comparison_uses_exact_value() {
+    let partition_columns = test_partition_columns();
+
+    // part_col > 'B' rewrites both min and max to partitionValues_parsed.part_col
+    let pred = Pred::gt(column_expr!("part_col"), Scalar::from("B"));
+    let skipping_pred =
+        as_data_skipping_predicate_with_partitions(&pred, partition_columns).expect("should exist");
+
+    // part_col='A': 'A' > 'B' is false -> skip
+    let resolver = DefaultKernelPredicateEvaluator::from(HashMap::from_iter([(
+        column_name!("partitionValues_parsed.part_col"),
+        Scalar::from("A"),
+    )]));
+    assert_eq!(resolver.eval(&skipping_pred), FALSE);
+
+    // part_col='C': 'C' > 'B' is true -> keep
+    let resolver = DefaultKernelPredicateEvaluator::from(HashMap::from_iter([(
+        column_name!("partitionValues_parsed.part_col"),
+        Scalar::from("C"),
+    )]));
+    assert_eq!(resolver.eval(&skipping_pred), TRUE);
+}
+
+#[test]
+fn test_partition_only_predicate() {
+    let partition_columns = test_partition_columns();
+
+    // Partition-only: no data columns involved
+    let pred = Pred::eq(column_expr!("part_col"), Scalar::from("X"));
+    let skipping_pred =
+        as_data_skipping_predicate_with_partitions(&pred, partition_columns).expect("should exist");
+    let pred_str = skipping_pred.to_string();
+    assert!(
+        pred_str.contains("partitionValues_parsed.part_col"),
+        "Should reference partitionValues_parsed"
+    );
+    assert!(
+        !pred_str.contains("stats_parsed"),
+        "Partition-only predicate should not reference stats_parsed"
+    );
 }

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -205,9 +205,11 @@ impl ScanLogReplayProcessor {
                         engine,
                         // these are all cheap arc clones
                         physical_predicate.as_ref().map(|(p, _)| p.clone()),
-                        physical_stats_schema.clone(),
-                        output_schema.clone(),
+                        Some(physical_stats_schema),
                         column_expr_ref!("stats_parsed"),
+                        None, // no partition schema yet
+                        column_expr_ref!("partitionValues_parsed"),
+                        output_schema.clone(),
                     )
                 })
         };

--- a/kernel/src/table_changes/log_replay.rs
+++ b/kernel/src/table_changes/log_replay.rs
@@ -12,7 +12,7 @@ use crate::actions::{
     METADATA_NAME, PROTOCOL_NAME, REMOVE_NAME,
 };
 use crate::engine_data::{GetData, TypedGetData};
-use crate::expressions::{column_expr, column_name, ColumnName, Expression};
+use crate::expressions::{column_expr, column_expr_ref, column_name, ColumnName, Expression};
 use crate::path::{AsUrl, ParsedLogPath};
 use crate::scan::data_skipping::stats_schema::build_stats_schema;
 use crate::scan::data_skipping::DataSkippingFilter;
@@ -73,9 +73,11 @@ pub(crate) fn table_changes_action_iter(
             DataSkippingFilter::new(
                 engine.as_ref(),
                 Some(predicate),
-                stats_schema,
-                get_log_add_schema().clone(),
+                Some(&stats_schema),
                 stats_expr,
+                None, // no partition columns for table changes (partition_expr unused)
+                column_expr_ref!("partitionValues_parsed"),
+                get_log_add_schema().clone(),
             )
         })
         .map(Arc::new);


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2076/files) to review incremental changes.
- [**stack/data-skipping-partition-api**](https://github.com/delta-io/delta-kernel-rs/pull/2076) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2076/files)]
  - [stack/unify-data-skipping-stats-partition](https://github.com/delta-io/delta-kernel-rs/pull/1948) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1948/files/45f4f6d348349c0ff91de628ef44a5b25b9b0997..5cbd6815b56f526a3f0fa9f30773709006a8b314)]

---------
## What changes are proposed in this pull request?

Today, partition pruning and stats-based data skipping are separate mechanisms. Data skipping rewrote user predicates into file-level predicates against minValues/maxValues/nullCount stats, while partition pruning evaluated partition values per-row in `AddRemoveDedupVisitor`. Because they operated independently, mixed OR predicates like `part_col = X OR data_col > 100` couldn't skip files.

This PR extends DataSkippingFilter and DataSkippingPredicateCreator to transform both partition and data column predicates into a single file-level predicate. For data columns, the user predicate `data_col > 100` becomes `stats_parsed.maxValues.data_col > 100`. For partition columns, part_col = 'X' becomes `partitionValues_parsed.part_col = X` (checking the file's exact partition value). 

build_unified_schema_and_expr wraps the flat stats schema and partition schema into a single nested schema `({ stats_parsed: { ... }, partitionValues_parsed: { ... } })` that aligns with these prefixed column references.

## How was this change tested?
New and existing unit tests