### PR TITLE
ci: fix breaking changes check in title validator

### DIFF
--- a/.github/workflows/comment-on-title-failure.yml
+++ b/.github/workflows/comment-on-title-failure.yml
@@ -33,8 +33,7 @@ jobs:
           body: |
             PR title does not match the required pattern. Please ensure you follow the [conventional commits](https://www.conventionalcommits.org/) spec.
 
-            Your title should start with `feat:`, `fix:`, `chore:`, `docs:`, `perf:`, `refactor:`, `test:`, or `ci:`, and if it's a breaking change that should be suffixed
-            with a `!` (like `feat!:`), and then a 1-72 character brief description of your change.
+            Your title should start with `feat:`, `fix:`, `chore:`, `docs:`, `perf:`, `refactor:`, `test:`, or `ci:`, and if it's a breaking change that should be suffixed with a `!` (like `feat!:`), and then a 1-72 character brief description of your change.
 
             **Title:** `${{ env.PR_TITLE }}`
 

--- a/.github/workflows/pr-validator.yml
+++ b/.github/workflows/pr-validator.yml
@@ -25,7 +25,7 @@ jobs:
           else
             echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
             echo "title=${{ github.event.pull_request.title }}" >> "$GITHUB_OUTPUT"
-            echo "labels=$(echo '${{ toJson(github.event.pull_request.labels.*.name) }}')" >> "$GITHUB_OUTPUT"
+            echo "labels=$(echo '${{ toJson(github.event.pull_request.labels.*.name) }}' | jq -c '.')" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What changes are proposed in this pull request?

We need to force the labels onto one line

## How was this change tested?
running test [here](https://github.com/delta-io/delta-kernel-rs/actions/runs/22931182755/job/66552881246?pr=2083) that it works with the label (seems to appear on one line)

I did also have the bot add and remove a comment, so validated that workflow actually works