### PR TITLE
chore: fix format-related clippy warnings

### DIFF
--- a/benchmarks/benches/workload_bench.rs
+++ b/benchmarks/benches/workload_bench.rs
@@ -29,7 +29,7 @@ fn workload_benchmarks(c: &mut Criterion) {
     let workloads = match load_all_workloads() {
         Ok(workloads) if !workloads.is_empty() => workloads,
         Ok(_) => panic!("No workloads found"),
-        Err(e) => panic!("Failed to load workloads: {}", e),
+        Err(e) => panic!("Failed to load workloads: {e}"),
     };
 
     let engine = setup_engine();

--- a/benchmarks/src/utils.rs
+++ b/benchmarks/src/utils.rs
@@ -50,7 +50,7 @@ fn extract_workload_specs() -> Result<(), Box<dyn std::error::Error>> {
     let tar_path = Path::new(WORKLOAD_TAR);
 
     if !tar_path.exists() {
-        return Err(format!("Workload tarball not found at {}", WORKLOAD_TAR).into());
+        return Err(format!("Workload tarball not found at {WORKLOAD_TAR}").into());
     }
 
     extract_tarball(tar_path)?;
@@ -67,11 +67,11 @@ fn extract_tarball(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let mut archive = Archive::new(tarball);
 
     std::fs::create_dir_all(OUTPUT_FOLDER)
-        .map_err(|e| format!("Failed to create output directory: {}", e))?;
+        .map_err(|e| format!("Failed to create output directory: {e}"))?;
 
     archive
         .unpack(OUTPUT_FOLDER)
-        .map_err(|e| format!("Failed to unpack tarball: {}", e))?;
+        .map_err(|e| format!("Failed to unpack tarball: {e}"))?;
 
     Ok(())
 }
@@ -80,9 +80,9 @@ fn extract_tarball(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
 /// See TODO(#1939) for `workload_specs_exist` above; this file must be manually deleted to force re-extraction
 fn write_done_file() -> Result<(), Box<dyn std::error::Error>> {
     let mut done_file = std::fs::File::create(DONE_FILE)
-        .map_err(|e| format!("Failed to create .done file: {}", e))?;
+        .map_err(|e| format!("Failed to create .done file: {e}"))?;
 
-    write!(done_file, "done").map_err(|e| format!("Failed to write .done file: {}", e))?;
+    write!(done_file, "done").map_err(|e| format!("Failed to write .done file: {e}"))?;
 
     Ok(())
 }

--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -492,8 +492,7 @@ fn visit_engine_expression_impl(
 
     let expr = unwrap_kernel_expression(&mut visitor_state, expr_id).ok_or_else(|| {
         delta_kernel::Error::generic(format!(
-            "Invalid expression ID {} returned from engine visitor",
-            expr_id
+            "Invalid expression ID {expr_id} returned from engine visitor"
         ))
     })?;
 
@@ -523,8 +522,7 @@ fn visit_engine_predicate_impl(
 
     let pred = unwrap_kernel_predicate(&mut visitor_state, pred_id).ok_or_else(|| {
         delta_kernel::Error::generic(format!(
-            "Invalid predicate ID {} returned from engine visitor",
-            pred_id
+            "Invalid predicate ID {pred_id} returned from engine visitor"
         ))
     })?;
 

--- a/ffi/src/ffi_test_utils.rs
+++ b/ffi/src/ffi_test_utils.rs
@@ -107,18 +107,15 @@ mod tests {
 
         assert!(
             panic_str.contains("Got engine error with type"),
-            "Panic message should contain 'Got engine error with type', got: {}",
-            panic_str
+            "Panic message should contain 'Got engine error with type', got: {panic_str}"
         );
         assert!(
             panic_str.contains("GenericError"),
-            "Panic message should contain error type 'GenericError', got: {}",
-            panic_str
+            "Panic message should contain error type 'GenericError', got: {panic_str}"
         );
         assert!(
             panic_str.contains(message),
-            "Panic message should contain error message 'Test error message', got: {}",
-            panic_str
+            "Panic message should contain error message 'Test error message', got: {panic_str}"
         );
     }
 

--- a/ffi/src/ffi_tracing.rs
+++ b/ffi/src/ffi_tracing.rs
@@ -744,7 +744,7 @@ mod tests {
     fn events_to_string(events: Vec<(String, tracing::Level)>) -> String {
         let events_str = events
             .iter()
-            .map(|(s, lvl)| format!("{}:{}", s, lvl))
+            .map(|(s, lvl)| format!("{s}:{lvl}"))
             .collect::<Vec<_>>()
             .join(", ");
         events_str
@@ -767,7 +767,7 @@ mod tests {
 
         // file path will use \ on windows
         use std::path::MAIN_SEPARATOR;
-        let expected_file = format!("ffi{}src{}ffi_tracing.rs", MAIN_SEPARATOR, MAIN_SEPARATOR);
+        let expected_file = format!("ffi{MAIN_SEPARATOR}src{MAIN_SEPARATOR}ffi_tracing.rs");
 
         let ok = target == "delta_kernel_ffi::ffi_tracing::tests"
             && file == expected_file

--- a/ffi/src/schema_visitor.rs
+++ b/ffi/src/schema_visitor.rs
@@ -543,8 +543,7 @@ fn create_variant_data_type(
         state.elements.take(struct_type_id).map(|f| f.data_type)
     else {
         return Err(Error::generic(format!(
-            "Invalid variant struct ID {} - must be DataType::Struct",
-            struct_type_id
+            "Invalid variant struct ID {struct_type_id} - must be DataType::Struct"
         )));
     };
     Ok(DataType::Variant(variant_struct))

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -611,7 +611,7 @@ mod tests {
 
             // Read the staged commit
             let staged_commit_url = table_url
-                .join(&format!("_delta_log/_staged_commits/{}", staged_file_name))
+                .join(&format!("_delta_log/_staged_commits/{staged_file_name}"))
                 .unwrap();
             let staged_commit = store
                 .get(&Path::from_url_path(staged_commit_url.path()).unwrap())

--- a/kernel/examples/common/src/lib.rs
+++ b/kernel/examples/common/src/lib.rs
@@ -129,7 +129,7 @@ pub fn get_engine(
 ) -> DeltaResult<DefaultEngine<TokioBackgroundExecutor>> {
     if args.env_creds {
         let (scheme, _path) = ObjectStoreScheme::parse(url).map_err(|e| {
-            delta_kernel::Error::Generic(format!("Object store could not parse url: {}", e))
+            delta_kernel::Error::Generic(format!("Object store could not parse url: {e}"))
         })?;
         use ObjectStoreScheme::*;
         let url_str = url.to_string();

--- a/kernel/src/actions/deletion_vector.rs
+++ b/kernel/src/actions/deletion_vector.rs
@@ -46,8 +46,7 @@ impl FromStr for DeletionVectorStorageType {
             "i" => Ok(Self::Inline),
             "p" => Ok(Self::PersistedAbsolute),
             _ => Err(Error::internal_error(format!(
-                "Unsupported deletion vector format option: {}",
-                s
+                "Unsupported deletion vector format option: {s}"
             ))),
         }
     }

--- a/kernel/src/actions/deletion_vector_writer.rs
+++ b/kernel/src/actions/deletion_vector_writer.rs
@@ -59,7 +59,7 @@ pub trait DeletionVector: Sized {
         let mut serialized = Vec::new();
         treemap
             .serialize_into(&mut serialized)
-            .map_err(|e| Error::generic(format!("Failed to serialize deletion vector: {}", e)))?;
+            .map_err(|e| Error::generic(format!("Failed to serialize deletion vector: {e}")))?;
         Ok(Bytes::from(serialized))
     }
 }
@@ -162,7 +162,7 @@ impl DeletionVector for KernelDeletionVector {
         let mut serialized = Vec::new();
         self.dv
             .serialize_into(&mut serialized)
-            .map_err(|e| Error::generic(format!("Failed to serialize deletion vector: {}", e)))?;
+            .map_err(|e| Error::generic(format!("Failed to serialize deletion vector: {e}")))?;
         Ok(Bytes::from(serialized))
     }
 
@@ -267,7 +267,7 @@ impl<'a, W: Write> StreamingDeletionVectorWriter<'a, W> {
             // Write header.
             self.writer
                 .write_all(&[1u8])
-                .map_err(|e| Error::generic(format!("Failed to write version byte: {}", e)))?;
+                .map_err(|e| Error::generic(format!("Failed to write version byte: {e}")))?;
             self.current_offset = 1;
         }
 
@@ -299,19 +299,19 @@ impl<'a, W: Write> StreamingDeletionVectorWriter<'a, W> {
         let size_bytes = (dv_size as u32).to_be_bytes();
         self.writer
             .write_all(&size_bytes)
-            .map_err(|e| Error::generic(format!("Failed to write size: {}", e)))?;
+            .map_err(|e| Error::generic(format!("Failed to write size: {e}")))?;
 
         // Write magic number (little-endian)
         // This is the RoaringBitmapArray format magic
         let magic: u32 = 1681511377;
         self.writer
             .write_all(&magic.to_le_bytes())
-            .map_err(|e| Error::generic(format!("Failed to write magic: {}", e)))?;
+            .map_err(|e| Error::generic(format!("Failed to write magic: {e}")))?;
 
         // Write the serialized treemap
         self.writer
             .write_all(&serialized)
-            .map_err(|e| Error::generic(format!("Failed to write deletion vector data: {}", e)))?;
+            .map_err(|e| Error::generic(format!("Failed to write deletion vector data: {e}")))?;
 
         // Calculate and write CRC32 checksum (big-endian)
         // The CRC must include both the magic and the serialized data
@@ -322,7 +322,7 @@ impl<'a, W: Write> StreamingDeletionVectorWriter<'a, W> {
         let checksum = digest.finalize();
         self.writer
             .write_all(&checksum.to_be_bytes())
-            .map_err(|e| Error::generic(format!("Failed to write CRC32 checksum: {}", e)))?;
+            .map_err(|e| Error::generic(format!("Failed to write CRC32 checksum: {e}")))?;
 
         // Update offset for next write (size_prefix + magic + data + crc)
         let bytes_written = 4 + dv_size + 4; // size + (magic + data) + crc
@@ -361,7 +361,7 @@ impl<'a, W: Write> StreamingDeletionVectorWriter<'a, W> {
 
         self.writer
             .flush()
-            .map_err(|e| Error::generic(format!("Failed to flush writer: {}", e)))
+            .map_err(|e| Error::generic(format!("Failed to flush writer: {e}")))
     }
 }
 
@@ -781,9 +781,7 @@ mod tests {
             assert_eq!(
                 treemap,
                 expected_indexes.iter().collect::<RoaringTreemap>(),
-                "read {:?} != expected {:?}",
-                treemap,
-                expected_indexes
+                "read {treemap:?} != expected {expected_indexes:?}"
             );
         }
     }

--- a/kernel/src/checkpoint/tests.rs
+++ b/kernel/src/checkpoint/tests.rs
@@ -568,8 +568,7 @@ async fn test_no_checkpoint_on_unpublished_snapshot() -> DeltaResult<()> {
 /// Create an Add action with JSON stats
 fn create_add_action_with_stats(path: &str, num_records: i64) -> Action {
     let stats = format!(
-        r#"{{"numRecords":{},"minValues":{{"id":1,"name":"alice"}},"maxValues":{{"id":100,"name":"zoe"}},"nullCount":{{"id":0,"name":5}}}}"#,
-        num_records
+        r#"{{"numRecords":{num_records},"minValues":{{"id":1,"name":"alice"}},"maxValues":{{"id":100,"name":"zoe"}},"nullCount":{{"id":0,"name":5}}}}"#
     );
     Action::Add(Add {
         path: path.into(),
@@ -838,18 +837,15 @@ fn verify_checkpoint_schema_with_partitions(
 
         assert_eq!(
             has_stats, expect_stats,
-            "stats field: expected={}, actual={}",
-            expect_stats, has_stats
+            "stats field: expected={expect_stats}, actual={has_stats}"
         );
         assert_eq!(
             has_stats_parsed, expect_stats_parsed,
-            "stats_parsed field: expected={}, actual={}",
-            expect_stats_parsed, has_stats_parsed
+            "stats_parsed field: expected={expect_stats_parsed}, actual={has_stats_parsed}"
         );
         assert_eq!(
             has_pv_parsed, expect_partition_values_parsed,
-            "partitionValues_parsed field: expected={}, actual={}",
-            expect_partition_values_parsed, has_pv_parsed
+            "partitionValues_parsed field: expected={expect_partition_values_parsed}, actual={has_pv_parsed}"
         );
     } else {
         panic!("add field should be a struct");

--- a/kernel/src/clustering.rs
+++ b/kernel/src/clustering.rs
@@ -74,8 +74,7 @@ pub(crate) fn validate_clustering_columns(
     for col in columns {
         if !seen.insert(col) {
             return Err(Error::generic(format!(
-                "Duplicate clustering column: '{}'",
-                col
+                "Duplicate clustering column: '{col}'"
             )));
         }
 
@@ -90,10 +89,9 @@ pub(crate) fn validate_clustering_columns(
             DataType::Primitive(ptype) if is_skipping_eligible_datatype(ptype) => {}
             dt => {
                 return Err(Error::generic(format!(
-                    "Clustering column '{}' has unsupported type '{}'. \
+                    "Clustering column '{col}' has unsupported type '{dt}'. \
                      Supported types: Byte, Short, Integer, Long, Float, Double, \
-                     Decimal, Date, Timestamp, TimestampNtz, String",
-                    col, dt
+                     Decimal, Date, Timestamp, TimestampNtz, String"
                 )));
             }
         }
@@ -411,12 +409,12 @@ mod tests {
     #[case::ten(10)]
     fn test_validate_clustering_column_count(#[case] num_columns: usize) {
         let fields: Vec<StructField> = (0..num_columns)
-            .map(|i| StructField::new(format!("col{}", i), DataType::INTEGER, false))
+            .map(|i| StructField::new(format!("col{i}"), DataType::INTEGER, false))
             .collect();
         let schema = StructType::new_unchecked(fields);
 
         let columns: Vec<ColumnName> = (0..num_columns)
-            .map(|i| ColumnName::new([format!("col{}", i)]))
+            .map(|i| ColumnName::new([format!("col{i}")]))
             .collect();
 
         assert!(validate_clustering_columns(&schema, &columns).is_ok());
@@ -441,8 +439,7 @@ mod tests {
         assert!(result.is_err());
         assert!(
             result.unwrap_err().to_string().contains(expected_error),
-            "Expected error containing '{}'",
-            expected_error
+            "Expected error containing '{expected_error}'"
         );
     }
 

--- a/kernel/src/committer/commit_types.rs
+++ b/kernel/src/committer/commit_types.rs
@@ -132,13 +132,11 @@ mod tests {
             staged_path_str.starts_with(
                 "s3://my-bucket/path/to/table/_delta_log/_staged_commits/00000000000000000042."
             ),
-            "Staged path should start with the correct prefix, got: {}",
-            staged_path_str
+            "Staged path should start with the correct prefix, got: {staged_path_str}"
         );
         assert!(
             staged_path_str.ends_with(".json"),
-            "Staged path should end with .json, got: {}",
-            staged_path_str
+            "Staged path should end with .json, got: {staged_path_str}"
         );
         let uuid_str = staged_path_str
             .strip_prefix(

--- a/kernel/src/crc/writer.rs
+++ b/kernel/src/crc/writer.rs
@@ -195,7 +195,7 @@ mod tests {
             let mut crc = test_crc();
             crc.file_stats_validity = invalid_validity;
             let result = try_write_crc_file(&engine, crc_path.location.as_url(), &crc, false);
-            assert!(result.is_err(), "should reject {:?}", invalid_validity);
+            assert!(result.is_err(), "should reject {invalid_validity:?}");
         }
     }
 }

--- a/kernel/src/engine/arrow_data.rs
+++ b/kernel/src/engine/arrow_data.rs
@@ -248,8 +248,7 @@ impl EngineData for ArrowEngineData {
                 Some(ColumnState::HasGetter(getter)) => getters.push(*getter),
                 _ => {
                     return Err(Error::MissingColumn(format!(
-                        "Column {} not found in the data",
-                        column
+                        "Column {column} not found in the data"
                     )));
                 }
             }

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -1236,14 +1236,13 @@ mod tests {
         for (name, expr, schema) in test_cases {
             let result =
                 evaluate_expression(&expr, &batch, Some(&DataType::Struct(Box::new(schema))));
-            assert!(result.is_err(), "Test case '{}' should fail", name);
+            assert!(result.is_err(), "Test case '{name}' should fail");
             assert!(
                 result
                     .unwrap_err()
                     .to_string()
                     .contains("field count mismatch"),
-                "Test case '{}' should contain 'field count mismatch' error",
-                name
+                "Test case '{name}' should contain 'field count mismatch' error"
             );
         }
     }

--- a/kernel/src/engine/arrow_get_data.rs
+++ b/kernel/src/engine/arrow_get_data.rs
@@ -189,8 +189,7 @@ fn validate_and_get_physical_index(
 ) -> DeltaResult<usize> {
     if row_index >= run_array.len() {
         return Err(Error::generic(format!(
-            "Row index {} out of bounds for field '{}'",
-            row_index, field_name
+            "Row index {row_index} out of bounds for field '{field_name}'"
         )));
     }
 

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -390,12 +390,12 @@ impl<E: TaskExecutor> ParquetHandler for DefaultParquetHandler<E> {
                 let client = reqwest::Client::new();
                 let response =
                     client.get(location.as_str()).send().await.map_err(|e| {
-                        Error::generic(format!("Failed to fetch presigned URL: {}", e))
+                        Error::generic(format!("Failed to fetch presigned URL: {e}"))
                     })?;
                 let bytes = response
                     .bytes()
                     .await
-                    .map_err(|e| Error::generic(format!("Failed to read response bytes: {}", e)))?;
+                    .map_err(|e| Error::generic(format!("Failed to read response bytes: {e}")))?;
                 ArrowReaderMetadata::load(&bytes, reader_options())?
             } else {
                 let path = Path::from_url_path(location.path())?;
@@ -1310,7 +1310,7 @@ mod tests {
         match field_id {
             crate::schema::MetadataValue::String(id) => assert_eq!(id, "42"),
             crate::schema::MetadataValue::Number(id) => assert_eq!(*id, 42),
-            other => panic!("Expected String or Number, got {:?}", other),
+            other => panic!("Expected String or Number, got {other:?}"),
         }
     }
 

--- a/kernel/src/engine/default/stats.rs
+++ b/kernel/src/engine/default/stats.rs
@@ -118,7 +118,7 @@ fn truncate_max_string(s: &str) -> Option<Cow<'_, str>> {
             UTF8_MAX_CHAR
         };
 
-        return Some(Cow::Owned(format!("{}{}", truncated, tie_breaker)));
+        return Some(Cow::Owned(format!("{truncated}{tie_breaker}")));
     }
 
     // Could not find a valid truncation point within expansion limit

--- a/kernel/src/engine/sync/parquet.rs
+++ b/kernel/src/engine/sync/parquet.rs
@@ -93,7 +93,7 @@ impl ParquetHandler for SyncParquetHandler {
         // Convert URL to file path
         let path = location
             .to_file_path()
-            .map_err(|_| crate::Error::generic(format!("Invalid file URL: {}", location)))?;
+            .map_err(|_| crate::Error::generic(format!("Invalid file URL: {location}")))?;
 
         let mut file = File::create(&path)?;
 

--- a/kernel/src/log_compaction/tests.rs
+++ b/kernel/src/log_compaction/tests.rs
@@ -91,7 +91,7 @@ fn test_writer_debug_impl() {
     let snapshot = create_mock_snapshot();
     let writer = LogCompactionWriter::try_new(snapshot, 1, 5).unwrap();
 
-    let debug_str = format!("{:?}", writer);
+    let debug_str = format!("{writer:?}");
     assert!(debug_str.contains("LogCompactionWriter"));
 }
 
@@ -112,7 +112,7 @@ fn test_compaction_data() {
     assert_eq!(state.add_actions_count(), 0);
 
     // Test debug implementation
-    let debug_str = format!("{:?}", iterator);
+    let debug_str = format!("{iterator:?}");
     assert!(debug_str.contains("ActionReconciliationIterator"));
     assert!(debug_str.contains("actions_count"));
     assert!(debug_str.contains("add_actions_count"));
@@ -201,9 +201,7 @@ fn test_compaction_paths() {
         let path = writer.compaction_path();
         assert!(
             path.to_string().ends_with(expected_suffix),
-            "Path {} doesn't end with {}",
-            path,
-            expected_suffix
+            "Path {path} doesn't end with {expected_suffix}"
         );
     }
 }
@@ -274,7 +272,7 @@ async fn test_no_compaction_staged_commits() {
     store
         .put(
             &commit_0_path,
-            format!("{}\n{}", metadata_action, protocol_action).into(),
+            format!("{metadata_action}\n{protocol_action}").into(),
         )
         .await
         .unwrap();

--- a/kernel/src/log_segment_files.rs
+++ b/kernel/src/log_segment_files.rs
@@ -477,7 +477,7 @@ mod list_log_files_with_log_tail_tests {
                     format!("_delta_log/{version:020}.{hi:020}.compacted.json")
                 }
                 LogPathFileType::UuidCheckpoint | LogPathFileType::Unknown => {
-                    panic!("Unsupported file type in test: {:?}", file_type)
+                    panic!("Unsupported file type in test: {file_type:?}")
                 }
             };
             let data = match source {

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -91,16 +91,14 @@ impl fmt::Display for MetricEvent {
                 num_compaction_files,
             } => write!(
                 f,
-                "LogSegmentLoaded(id={}, duration={:?}, commits={}, checkpoints={}, compactions={})",
-                operation_id, duration, num_commit_files, num_checkpoint_files, num_compaction_files
+                "LogSegmentLoaded(id={operation_id}, duration={duration:?}, commits={num_commit_files}, checkpoints={num_checkpoint_files}, compactions={num_compaction_files})"
             ),
             MetricEvent::ProtocolMetadataLoaded {
                 operation_id,
                 duration,
             } => write!(
                 f,
-                "ProtocolMetadataLoaded(id={}, duration={:?})",
-                operation_id, duration
+                "ProtocolMetadataLoaded(id={operation_id}, duration={duration:?})"
             ),
             MetricEvent::SnapshotCompleted {
                 operation_id,
@@ -108,24 +106,21 @@ impl fmt::Display for MetricEvent {
                 total_duration,
             } => write!(
                 f,
-                "SnapshotCompleted(id={}, version={}, duration={:?})",
-                operation_id, version, total_duration
+                "SnapshotCompleted(id={operation_id}, version={version}, duration={total_duration:?})"
             ),
             MetricEvent::SnapshotFailed {
                 operation_id,
                 duration,
             } => write!(
                 f,
-                "SnapshotFailed(id={}, duration={:?})",
-                operation_id, duration
+                "SnapshotFailed(id={operation_id}, duration={duration:?})"
             ),
             MetricEvent::StorageListCompleted {
                 duration,
                 num_files,
             } => write!(
                 f,
-                "StorageListCompleted(duration={:?}, files={})",
-                duration, num_files
+                "StorageListCompleted(duration={duration:?}, files={num_files})"
             ),
             MetricEvent::StorageReadCompleted {
                 duration,
@@ -133,13 +128,11 @@ impl fmt::Display for MetricEvent {
                 bytes_read,
             } => write!(
                 f,
-                "StorageReadCompleted(duration={:?}, files={}, bytes={})",
-                duration, num_files, bytes_read
+                "StorageReadCompleted(duration={duration:?}, files={num_files}, bytes={bytes_read})"
             ),
             MetricEvent::StorageCopyCompleted { duration } => write!(
                 f,
-                "StorageCopyCompleted(duration={:?})",
-                duration
+                "StorageCopyCompleted(duration={duration:?})"
             ),
         }
     }

--- a/kernel/src/parallel/parallel_phase.rs
+++ b/kernel/src/parallel/parallel_phase.rs
@@ -474,8 +474,7 @@ mod tests {
         all_paths.sort();
         assert_eq!(
             all_paths, expected_paths,
-            "Parallel workflow paths don't match scan_metadata paths for table '{}'",
-            table_name
+            "Parallel workflow paths don't match scan_metadata paths for table '{table_name}'"
         );
 
         Ok(())

--- a/kernel/src/parallel/parallel_scan_metadata.rs
+++ b/kernel/src/parallel/parallel_scan_metadata.rs
@@ -123,9 +123,8 @@ impl ParallelState {
     #[allow(unused)]
     pub fn into_bytes(self) -> DeltaResult<Vec<u8>> {
         let state = self.into_serializable_state()?;
-        serde_json::to_vec(&state).map_err(|e| {
-            Error::generic(format!("Failed to serialize ParallelState to bytes: {}", e))
-        })
+        serde_json::to_vec(&state)
+            .map_err(|e| Error::generic(format!("Failed to serialize ParallelState to bytes: {e}")))
     }
 
     /// Reconstruct a ParallelState from bytes.

--- a/kernel/src/parallel/sequential_phase.rs
+++ b/kernel/src/parallel/sequential_phase.rs
@@ -243,8 +243,7 @@ mod tests {
             (sidecars, AfterSequentialScanMetadata::Done) => {
                 assert!(
                     sidecars.is_empty(),
-                    "Expected Done but got sidecars {:?}",
-                    sidecars
+                    "Expected Done but got sidecars {sidecars:?}"
                 );
             }
             (expected_sidecars, AfterSequentialScanMetadata::Parallel { files, .. }) => {

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -286,7 +286,7 @@ impl ScanLogReplayProcessor {
             physical_partition_schema,
         };
         let internal_state_blob = serde_json::to_vec(&internal_state)
-            .map_err(|e| Error::generic(format!("Failed to serialize internal state: {}", e)))?;
+            .map_err(|e| Error::generic(format!("Failed to serialize internal state: {e}")))?;
 
         Ok(SerializableScanState {
             predicate,

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -157,7 +157,7 @@ impl StateInfo {
 
                                 // ensure we have a column name that isn't already in our schema
                                 let index_column_name = (0..)
-                                    .map(|i| format!("row_indexes_for_row_id_{}", i))
+                                    .map(|i| format!("row_indexes_for_row_id_{i}"))
                                     .find(|name| logical_schema.field(name).is_none())
                                     .ok_or(Error::generic(
                                         "Couldn't generate row index column name",

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -653,10 +653,7 @@ fn assert_stats_struct_matches_json(
             assert_eq!(
                 json_val.as_i64().unwrap(),
                 int_col.value(row_idx),
-                "{}.{} mismatch at row {}",
-                field_name,
-                col_name,
-                row_idx
+                "{field_name}.{col_name} mismatch at row {row_idx}"
             );
         }
     }

--- a/kernel/src/scan/transform_spec.rs
+++ b/kernel/src/scan/transform_spec.rs
@@ -180,8 +180,7 @@ pub(crate) fn get_transform_expr(
                     // Column doesn't exist physically - treat as partition column
                     let Some((_, partition_value)) = metadata_values.remove(field_index) else {
                         return Err(Error::MissingData(format!(
-                            "missing partition value for dynamic column '{}' at index {}",
-                            physical_name, field_index
+                            "missing partition value for dynamic column '{physical_name}' at index {field_index}"
                         )));
                     };
 

--- a/kernel/src/schema/diff.rs
+++ b/kernel/src/schema/diff.rs
@@ -742,7 +742,7 @@ mod tests {
             ("delta.columnMapping.id", MetadataValue::Number(id)),
             (
                 "delta.columnMapping.physicalName",
-                MetadataValue::String(format!("col_{}", id)),
+                MetadataValue::String(format!("col_{id}")),
             ),
         ])
     }

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -568,7 +568,7 @@ impl Display for StructField {
                 metadata_str.push_str(", ");
             }
             first = false;
-            metadata_str.push_str(&format!("{}: {:?}", k, v));
+            metadata_str.push_str(&format!("{k}: {v:?}"));
         }
         metadata_str.push('}');
         write!(
@@ -981,7 +981,7 @@ impl StructType {
                 self.fields
                     .get_index_of(after)
                     .map(|index| index + 1)
-                    .ok_or_else(|| Error::generic(format!("Field {} not found", after)))
+                    .ok_or_else(|| Error::generic(format!("Field {after} not found")))
             })
             .unwrap_or_else(|| Ok(self.fields.len()))?;
 
@@ -1010,7 +1010,7 @@ impl StructType {
             .map(|before| {
                 self.fields
                     .get_index_of(before)
-                    .ok_or_else(|| Error::generic(format!("Field {} not found", before)))
+                    .ok_or_else(|| Error::generic(format!("Field {before} not found")))
             })
             .unwrap_or_else(|| Ok(0))?;
 
@@ -1045,7 +1045,7 @@ impl StructType {
         let replace_field = self
             .fields
             .get_mut(name)
-            .ok_or_else(|| Error::generic(format!("Field {} not found", name)))?;
+            .ok_or_else(|| Error::generic(format!("Field {name} not found")))?;
 
         *replace_field = new_field;
         Ok(self)
@@ -1081,7 +1081,7 @@ fn write_struct_type(
         levels.push(is_last);
 
         write_indent(f, levels)?;
-        writeln!(f, "{}", field)?;
+        writeln!(f, "{field}")?;
 
         field.data_type.fmt_recursive(f, levels)?;
 
@@ -2772,7 +2772,7 @@ mod tests {
                 1 => assert_eq!(field.name, "required_int"),
                 2 => assert_eq!(field.name, "nullable_bool"),
                 3 => assert_eq!(field.name, "required_long"),
-                _ => panic!("Unexpected field index: {}", index),
+                _ => panic!("Unexpected field index: {index}"),
             }
         }
     }

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -482,9 +482,8 @@ impl Snapshot {
         require!(
             new_version == read_version.wrapping_add(1),
             Error::internal_error(format!(
-                "Cannot create post-commit Snapshot. Log file version ({}) does not \
-                equal Snapshot version ({}) + 1.",
-                new_version, read_version
+                "Cannot create post-commit Snapshot. Log file version ({new_version}) does not \
+                equal Snapshot version ({read_version}) + 1."
             ))
         );
 
@@ -985,7 +984,7 @@ mod tests {
     fn create_basic_commit(ict_enabled: bool, ict_config: Option<(String, String)>) -> String {
         let protocol = create_protocol(ict_enabled, None);
         let metadata = create_metadata(None, None, None, ict_config, false);
-        format!("{}\n{}", protocol, metadata)
+        format!("{protocol}\n{metadata}")
     }
 
     #[test]
@@ -1465,7 +1464,7 @@ mod tests {
 
         // Write all test files to the in memory file system
         for (path_prefix, data, _) in &test_cases {
-            let path = Path::from(format!("{}/_last_checkpoint", path_prefix));
+            let path = Path::from(format!("{path_prefix}/_last_checkpoint"));
             store
                 .put(&path, data.clone().into())
                 .await
@@ -1478,7 +1477,7 @@ mod tests {
         // Test reading all checkpoints from the in memory file system for cases where the data is valid, invalid and
         // valid with tags.
         for (path_prefix, _, expected_result) in test_cases {
-            let url = Url::parse(&format!("memory:///{}/", path_prefix)).expect("valid url");
+            let url = Url::parse(&format!("memory:///{path_prefix}/")).expect("valid url");
             let result =
                 LastCheckpointHint::try_read(&storage, &url).expect("read last checkpoint");
             assert_eq!(result, expected_result);

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -201,8 +201,7 @@ pub(crate) fn get_column_mapping_mode_from_properties(
     match properties.get(COLUMN_MAPPING_MODE) {
         Some(mode_str) => mode_str.parse::<ColumnMappingMode>().map_err(|_| {
             Error::generic(format!(
-                "Invalid column mapping mode '{}'. Must be one of: none, name, id",
-                mode_str
+                "Invalid column mapping mode '{mode_str}'. Must be one of: none, name, id"
             ))
         }),
         None => Ok(ColumnMappingMode::None),
@@ -797,8 +796,7 @@ mod tests {
         let err_msg = result.unwrap_err().to_string();
         assert!(
             err_msg.contains("already has column mapping metadata"),
-            "Expected error about existing column mapping metadata, got: {}",
-            err_msg
+            "Expected error about existing column mapping metadata, got: {err_msg}"
         );
     }
 
@@ -889,7 +887,7 @@ mod tests {
     fn unwrap_struct<'a>(data_type: &'a DataType, context: &str) -> &'a StructType {
         match data_type {
             DataType::Struct(s) => s,
-            _ => panic!("Expected Struct for {}, got {:?}", context, data_type),
+            _ => panic!("Expected Struct for {context}, got {data_type:?}"),
         }
     }
 

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -91,8 +91,7 @@ fn ensure_table_does_not_exist(
             // - None means empty iterator -> OK for new table
             match files.next() {
                 Some(Ok(_)) => Err(Error::generic(format!(
-                    "Table already exists at path: {}",
-                    table_path
+                    "Table already exists at path: {table_path}"
                 ))),
                 Some(Err(Error::FileNotFound(_))) | None => {
                     // Path doesn't exist or empty - OK for new table
@@ -341,8 +340,7 @@ fn validate_extract_table_features_and_properties(
         // Validate that the value is "supported"
         if value != SET_TABLE_FEATURE_SUPPORTED_VALUE {
             return Err(Error::generic(format!(
-                "Invalid value '{}' for '{}'. Only '{}' is allowed.",
-                value, key, SET_TABLE_FEATURE_SUPPORTED_VALUE
+                "Invalid value '{value}' for '{key}'. Only '{SET_TABLE_FEATURE_SUPPORTED_VALUE}' is allowed."
             )));
         }
 
@@ -353,8 +351,7 @@ fn validate_extract_table_features_and_properties(
 
         if !ALLOWED_DELTA_FEATURES.contains(&feature) {
             return Err(Error::generic(format!(
-                "Enabling feature '{}' via '{}' is not supported during CREATE TABLE",
-                feature_name, key
+                "Enabling feature '{feature_name}' via '{key}' is not supported during CREATE TABLE"
             )));
         }
 
@@ -368,8 +365,7 @@ fn validate_extract_table_features_and_properties(
             && !ALLOWED_DELTA_PROPERTIES.contains(&key.as_str())
         {
             return Err(Error::generic(format!(
-                "Setting delta property '{}' is not supported during CREATE TABLE",
-                key
+                "Setting delta property '{key}' is not supported during CREATE TABLE"
             )));
         }
     }

--- a/kernel/src/transaction/domain_metadata.rs
+++ b/kernel/src/transaction/domain_metadata.rs
@@ -56,8 +56,7 @@ impl<S> Transaction<S> {
             // Check for duplicates
             if !seen_domains.insert(domain) {
                 return Err(Error::generic(format!(
-                    "Metadata for domain {} already specified in this transaction",
-                    domain
+                    "Metadata for domain {domain} already specified in this transaction"
                 )));
             }
         }
@@ -76,8 +75,7 @@ impl<S> Transaction<S> {
             // Check for duplicates (spans both system and user domains)
             if !seen_domains.insert(domain) {
                 return Err(Error::generic(format!(
-                    "Metadata for domain {} already specified in this transaction",
-                    domain
+                    "Metadata for domain {domain} already specified in this transaction"
                 )));
             }
         }
@@ -103,8 +101,7 @@ impl<S> Transaction<S> {
             // Check for duplicates
             if !seen_domains.insert(domain.as_str()) {
                 return Err(Error::generic(format!(
-                    "Metadata for domain {} already specified in this transaction",
-                    domain
+                    "Metadata for domain {domain} already specified in this transaction"
                 )));
             }
         }
@@ -126,8 +123,7 @@ impl<S> Transaction<S> {
             "delta.clustering" => Some(TableFeature::ClusteredTable),
             _ => {
                 return Err(Error::generic(format!(
-                    "Unknown system domain '{}'. Only known system domains are allowed.",
-                    domain
+                    "Unknown system domain '{domain}'. Only known system domains are allowed."
                 )));
             }
         };
@@ -136,8 +132,7 @@ impl<S> Transaction<S> {
         if let Some(feature) = required_feature {
             if !table_config.is_feature_supported(&feature) {
                 return Err(Error::generic(format!(
-                    "System domain '{}' requires the '{}' feature to be enabled",
-                    domain, feature
+                    "System domain '{domain}' requires the '{feature}' feature to be enabled"
                 )));
             }
         }

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -1370,7 +1370,7 @@ mod tests {
         };
         DeletionVectorDescriptor {
             storage_type: DeletionVectorStorageType::PersistedRelative,
-            path_or_inline_dv: format!("dv_{}", path_suffix),
+            path_or_inline_dv: format!("dv_{path_suffix}"),
             offset: Some(0),
             size_in_bytes: 100,
             cardinality: 1,
@@ -1556,8 +1556,7 @@ mod tests {
         let expr_str = format!("{}", wc_without.logical_to_physical());
         assert!(
             expr_str.contains("drop letter"),
-            "Partition column 'letter' should be dropped. Expression: {}",
-            expr_str
+            "Partition column 'letter' should be dropped. Expression: {expr_str}"
         );
 
         // With materializePartitionColumns, no columns should be dropped (identity transform)
@@ -1576,8 +1575,7 @@ mod tests {
         let expr_str = format!("{}", wc_with.logical_to_physical());
         assert!(
             !expr_str.contains("drop"),
-            "No columns should be dropped with materializePartitionColumns. Expression: {}",
-            expr_str
+            "No columns should be dropped with materializePartitionColumns. Expression: {expr_str}"
         );
 
         Ok(())
@@ -1625,8 +1623,7 @@ mod tests {
         assert!(
             err_msg.contains("Deletion vector")
                 && (err_msg.contains("require") || err_msg.contains("version")),
-            "Expected protocol error about DV requirements, got: {}",
-            err_msg
+            "Expected protocol error about DV requirements, got: {err_msg}"
         );
         Ok(())
     }
@@ -1651,8 +1648,7 @@ mod tests {
         let err_msg = result.unwrap_err().to_string();
         assert!(
             err_msg.contains("matched") && err_msg.contains("does not match"),
-            "Expected error about mismatched count (expected 1 descriptor, 0 matched files), got: {}",
-            err_msg);
+            "Expected error about mismatched count (expected 1 descriptor, 0 matched files), got: {err_msg}");
         Ok(())
     }
 
@@ -1668,8 +1664,7 @@ mod tests {
 
         assert!(
             result.is_ok(),
-            "Empty DV updates should succeed as no-op, got error: {:?}",
-            result
+            "Empty DV updates should succeed as no-op, got error: {result:?}"
         );
 
         Ok(())
@@ -1844,7 +1839,7 @@ mod tests {
     #[test]
     fn test_existing_table_txn_debug() -> DeltaResult<()> {
         let (_engine, txn, _tempdir) = create_existing_table_txn()?;
-        let debug_str = format!("{:?}", txn);
+        let debug_str = format!("{txn:?}");
         // Existing-table transactions should include the snapshot version number
         assert!(
             debug_str.contains("Transaction") && debug_str.contains("read_snapshot version"),
@@ -2214,8 +2209,7 @@ mod tests {
         let err_msg = result.unwrap_err().to_string();
         assert!(
             err_msg.contains("Stats validation error") || err_msg.contains("no stats"),
-            "Expected stats validation error, got: {}",
-            err_msg
+            "Expected stats validation error, got: {err_msg}"
         );
     }
 
@@ -2237,8 +2231,7 @@ mod tests {
 
         assert!(
             result.is_ok(),
-            "Stats validation should pass when stats are present, got: {:?}",
-            result
+            "Stats validation should pass when stats are present, got: {result:?}"
         );
     }
 
@@ -2259,8 +2252,7 @@ mod tests {
 
         assert!(
             result.is_ok(),
-            "Stats validation should be skipped without clustering, got: {:?}",
-            result
+            "Stats validation should be skipped without clustering, got: {result:?}"
         );
     }
 }

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -100,7 +100,7 @@ fn resolve_uri_type(table_uri: impl AsRef<str>) -> DeltaResult<UriType> {
 pub(crate) fn current_time_duration() -> DeltaResult<Duration> {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map_err(|e| Error::generic(format!("System time before Unix epoch: {}", e)))
+        .map_err(|e| Error::generic(format!("System time before Unix epoch: {e}")))
 }
 
 /// Returns the current time in milliseconds since Unix epoch.
@@ -387,7 +387,7 @@ pub(crate) mod test_utils {
         struct_type
             .fields()
             .find(|f| f.name() == name)
-            .unwrap_or_else(|| panic!("Field '{}' not found", name))
+            .unwrap_or_else(|| panic!("Field '{name}' not found"))
             .clone()
     }
 
@@ -400,8 +400,7 @@ pub(crate) mod test_utils {
             let field = get_schema_field(schema, field_name);
             assert!(
                 matches!(field.data_type(), KernelDataType::Struct(_)),
-                "Field '{}' should be a struct type",
-                field_name
+                "Field '{field_name}' should be a struct type"
             );
         }
 
@@ -791,7 +790,7 @@ pub(crate) mod test_utils {
                 path.push("tests/data");
                 path.push(table_name);
                 let path = std::fs::canonicalize(path)
-                    .map_err(|e| Error::Generic(format!("Failed to canonicalize path: {}", e)))?;
+                    .map_err(|e| Error::Generic(format!("Failed to canonicalize path: {e}")))?;
                 (path, None)
             }
         };

--- a/kernel/tests/checkpoint_transform.rs
+++ b/kernel/tests/checkpoint_transform.rs
@@ -35,7 +35,7 @@ fn new_in_memory_store() -> (Arc<InMemory>, Url) {
 
 /// Writes a JSON commit file to the store.
 async fn write_commit(store: &Arc<InMemory>, content: &str, version: u64) -> DeltaResult<()> {
-    let path = Path::from(format!("_delta_log/{version:020}.json", version = version));
+    let path = Path::from(format!("_delta_log/{version:020}.json"));
     store.put(&path, content.to_string().into()).await?;
     Ok(())
 }
@@ -75,7 +75,7 @@ fn build_commit(
                 "writerFeatures": []
             }
         });
-        format!("{}\n{}", protocol, metadata)
+        format!("{protocol}\n{metadata}")
     } else {
         metadata.to_string()
     }
@@ -454,7 +454,7 @@ async fn test_checkpoint_partition_values_parsed_with_column_mapping(
             "createdTime": 1587968585495i64
         }
     });
-    write_commit(&store, &format!("{}\n{}", protocol, metadata), 0).await?;
+    write_commit(&store, &format!("{protocol}\n{metadata}"), 0).await?;
 
     // Version 1: write data for partition category=books
     let snapshot = Snapshot::builder_for(table_root.clone()).build(engine.as_ref())?;

--- a/kernel/tests/create_table.rs
+++ b/kernel/tests/create_table.rs
@@ -201,7 +201,7 @@ async fn test_create_table_log_actions() -> DeltaResult<()> {
         .commit(engine.as_ref())?;
 
     // Read the actual Delta log file
-    let log_file_path = format!("{}/_delta_log/00000000000000000000.json", table_path);
+    let log_file_path = format!("{table_path}/_delta_log/00000000000000000000.json");
     let log_contents = std::fs::read_to_string(&log_file_path).expect("Failed to read log file");
 
     // Parse each line (each line is a separate JSON action)
@@ -323,7 +323,7 @@ fn create_test_create_table_txn() -> DeltaResult<(
 #[tokio::test]
 async fn test_create_table_txn_debug() -> DeltaResult<()> {
     let (_engine, txn, _tempdir) = create_test_create_table_txn()?;
-    let debug_str = format!("{:?}", txn);
+    let debug_str = format!("{txn:?}");
     assert!(
         debug_str.contains("Transaction") && debug_str.contains("create_table"),
         "Debug output should contain Transaction info: {debug_str}"

--- a/kernel/tests/create_table/clustering.rs
+++ b/kernel/tests/create_table/clustering.rs
@@ -129,8 +129,7 @@ async fn test_clustering_with_explicit_feature_signal_no_duplicates() -> DeltaRe
 
     assert_eq!(
         domain_metadata_count, 1,
-        "domainMetadata should appear exactly once, not {} times (duplicate detected!)",
-        domain_metadata_count
+        "domainMetadata should appear exactly once, not {domain_metadata_count} times (duplicate detected!)"
     );
 
     // Verify clustering columns via snapshot read path
@@ -146,7 +145,7 @@ async fn test_clustering_stats_columns_within_limit() -> DeltaResult<()> {
 
     // Build schema with 10 columns (cluster on column 5, within default 32 limit)
     let fields: Vec<StructField> = (0..10)
-        .map(|i| StructField::new(format!("col{}", i), DataType::INTEGER, true))
+        .map(|i| StructField::new(format!("col{i}"), DataType::INTEGER, true))
         .collect();
     let schema = Arc::new(StructType::try_new(fields)?);
 
@@ -171,7 +170,7 @@ async fn test_clustering_stats_columns_beyond_limit() -> DeltaResult<()> {
 
     // Build schema with 40 columns (cluster on column 35, beyond default 32 limit)
     let fields: Vec<StructField> = (0..40)
-        .map(|i| StructField::new(format!("col{}", i), DataType::INTEGER, true))
+        .map(|i| StructField::new(format!("col{i}"), DataType::INTEGER, true))
         .collect();
     let schema = Arc::new(StructType::try_new(fields)?);
 

--- a/kernel/tests/create_table/column_mapping.rs
+++ b/kernel/tests/create_table/column_mapping.rs
@@ -324,11 +324,7 @@ fn test_create_clustered_table_with_column_mapping(
         let logical_name = clustering_cols[i];
         assert!(
             physical_name.starts_with("col-"),
-            "{}: clustering column {} should use physical name '{}', not logical name '{}'",
-            description,
-            i,
-            physical_name,
-            logical_name
+            "{description}: clustering column {i} should use physical name '{physical_name}', not logical name '{logical_name}'"
         );
     }
 
@@ -388,7 +384,7 @@ fn test_column_mapping_nested_schema() -> DeltaResult<()> {
             assert_eq!(city.data_type(), &DataType::STRING);
             assert!(city.is_nullable());
         }
-        other => panic!("Expected Struct type for address, got {:?}", other),
+        other => panic!("Expected Struct type for address, got {other:?}"),
     }
 
     Ok(())

--- a/kernel/tests/create_table/variant.rs
+++ b/kernel/tests/create_table/variant.rs
@@ -70,13 +70,11 @@ fn assert_variant_protocol(snapshot: &Snapshot) {
     let protocol = table_config.protocol();
     assert!(
         protocol.min_reader_version() >= TABLE_FEATURES_MIN_READER_VERSION,
-        "Reader version should be at least {}",
-        TABLE_FEATURES_MIN_READER_VERSION
+        "Reader version should be at least {TABLE_FEATURES_MIN_READER_VERSION}"
     );
     assert!(
         protocol.min_writer_version() >= TABLE_FEATURES_MIN_WRITER_VERSION,
-        "Writer version should be at least {}",
-        TABLE_FEATURES_MIN_WRITER_VERSION
+        "Writer version should be at least {TABLE_FEATURES_MIN_WRITER_VERSION}"
     );
 }
 

--- a/kernel/tests/dv.rs
+++ b/kernel/tests/dv.rs
@@ -33,7 +33,7 @@ async fn write_parquet_file(
 
     let parquet_data = record_batch_to_bytes(data);
     let parquet_data_len = parquet_data.len();
-    let data_file_path = format!("data_file_{}.parquet", file_suffix);
+    let data_file_path = format!("data_file_{file_suffix}.parquet");
 
     // Construct the full object store path for the parquet file
     let data_url = table_url.join(&data_file_path)?;

--- a/kernel/tests/log_compaction.rs
+++ b/kernel/tests/log_compaction.rs
@@ -14,7 +14,7 @@ use url::Url;
 fn url_to_object_store_path(url: &Url) -> Result<Path, Box<dyn std::error::Error>> {
     let path_segments = url
         .path_segments()
-        .ok_or_else(|| format!("URL has no path segments: {}", url))?;
+        .ok_or_else(|| format!("URL has no path segments: {url}"))?;
 
     let path_string = path_segments.skip(1).collect::<Vec<_>>().join("/");
 
@@ -64,10 +64,9 @@ async fn action_reconciliation_round_trip() -> Result<(), Box<dyn std::error::Er
         .unwrap()
         .as_millis() as i64;
     let commit2_content = format!(
-        r#"{{"commitInfo":{{"timestamp":{},"operation":"DELETE","operationParameters":{{"predicate":"id <= 10"}},"isBlindAppend":false}}}}
-{{"remove":{{"path":"part-00000-file1.parquet","partitionValues":{{}},"size":1024,"modificationTime":1587968586000,"dataChange":true,"deletionTimestamp":{}}}}}
-"#,
-        current_timestamp_millis, current_timestamp_millis
+        r#"{{"commitInfo":{{"timestamp":{current_timestamp_millis},"operation":"DELETE","operationParameters":{{"predicate":"id <= 10"}},"isBlindAppend":false}}}}
+{{"remove":{{"path":"part-00000-file1.parquet","partitionValues":{{}},"size":1024,"modificationTime":1587968586000,"dataChange":true,"deletionTimestamp":{current_timestamp_millis}}}}}
+"#
     );
     store
         .put(
@@ -187,10 +186,7 @@ async fn action_reconciliation_round_trip() -> Result<(), Box<dyn std::error::Er
     let actual_deletion_timestamp = parsed_remove["remove"]["deletionTimestamp"]
         .as_i64()
         .ok_or_else(|| {
-            format!(
-                "deletionTimestamp should be present in remove action: {}",
-                remove_line
-            )
+            format!("deletionTimestamp should be present in remove action: {remove_line}")
         })?;
     assert_eq!(actual_deletion_timestamp, current_timestamp_millis);
 
@@ -390,8 +386,7 @@ async fn expired_tombstone_exclusion() -> Result<(), Box<dyn std::error::Error>>
         .as_i64()
         .ok_or_else(|| {
             format!(
-                "deletionTimestamp should be present in recent remove action: {}",
-                recent_remove_line
+                "deletionTimestamp should be present in recent remove action: {recent_remove_line}"
             )
         })?;
     assert_eq!(actual_deletion_timestamp, recent_timestamp);
@@ -402,8 +397,7 @@ async fn expired_tombstone_exclusion() -> Result<(), Box<dyn std::error::Error>>
         .count();
     assert!(
         total_actions >= 4,
-        "Should have at least 4 actions: protocol, metadata, 1 add, 1 remove (recent). Found {}",
-        total_actions
+        "Should have at least 4 actions: protocol, metadata, 1 add, 1 remove (recent). Found {total_actions}"
     );
     Ok(())
 }

--- a/kernel/tests/read.rs
+++ b/kernel/tests/read.rs
@@ -1520,7 +1520,7 @@ async fn test_file_path_metadata_column() -> Result<(), Box<dyn std::error::Erro
         // Verify the file path column contains the expected file name
         let file_path_array = batch.column(1);
         let expected_file_name = expected_files[file_count];
-        let expected_path = format!("{}{}", location, expected_file_name);
+        let expected_path = format!("{location}{expected_file_name}");
 
         // The file path array should be a plain StringArray with the path repeated for each row.
         let string_array = file_path_array
@@ -1539,8 +1539,7 @@ async fn test_file_path_metadata_column() -> Result<(), Box<dyn std::error::Erro
             string_array
                 .iter()
                 .all(|v| v == Some(expected_path.as_str())),
-            "All rows should contain file path '{}'",
-            expected_path
+            "All rows should contain file path '{expected_path}'"
         );
 
         file_count += 1;

--- a/kernel/tests/row_tracking.rs
+++ b/kernel/tests/row_tracking.rs
@@ -124,7 +124,7 @@ async fn verify_row_tracking_in_commit(
     expected_base_row_ids: Vec<i64>,
     expected_row_id_high_water_mark: i64,
 ) -> DeltaResult<()> {
-    let commit_url = table_url.join(&format!("_delta_log/{:020}.json", commit_version))?;
+    let commit_url = table_url.join(&format!("_delta_log/{commit_version:020}.json"))?;
     let commit = store.get(&Path::from_url_path(commit_url.path())?).await?;
 
     let parsed_actions: Vec<_> = Deserializer::from_slice(&commit.bytes().await?)

--- a/kernel/tests/write.rs
+++ b/kernel/tests/write.rs
@@ -1481,7 +1481,7 @@ async fn test_set_domain_metadata_basic() -> Result<(), Box<dyn std::error::Erro
         match domain {
             d if d == domain1 => assert_eq!(config, config1),
             d if d == domain2 => assert_eq!(config, config2),
-            _ => panic!("Unexpected domain: {}", domain),
+            _ => panic!("Unexpected domain: {domain}"),
         }
     }
 
@@ -1812,7 +1812,7 @@ async fn get_ict_at_version(
     table_url: &Url,
     version: u64,
 ) -> Result<i64, Box<dyn std::error::Error>> {
-    let commit_path = table_url.join(&format!("_delta_log/{:020}.json", version))?;
+    let commit_path = table_url.join(&format!("_delta_log/{version:020}.json"))?;
     let commit = store.get(&Path::from_url_path(commit_path.path())?).await?;
     let commit_content = String::from_utf8(commit.bytes().await?.to_vec())?;
 
@@ -1824,8 +1824,7 @@ async fn get_ict_at_version(
         .collect();
     assert!(
         !lines.is_empty(),
-        "Commit log at version {} should not be empty",
-        version
+        "Commit log at version {version} should not be empty"
     );
 
     // First line should contain commitInfo with inCommitTimestamp
@@ -1932,8 +1931,7 @@ async fn test_ict_commit_e2e() -> Result<(), Box<dyn std::error::Error>> {
 
     assert!(
         first_ict > 1612345678,
-        "First commit ICT ({}) should be greater than enablement timestamp (1612345678)",
-        first_ict
+        "First commit ICT ({first_ict}) should be greater than enablement timestamp (1612345678)"
     );
 
     // Second commit
@@ -1978,9 +1976,7 @@ async fn test_ict_commit_e2e() -> Result<(), Box<dyn std::error::Error>> {
     // Verify monotonic property: second_ict > first_ict
     assert!(
         second_ict > first_ict,
-        "Second ICT ({}) should be greater than first ICT ({})",
-        second_ict,
-        first_ict
+        "Second ICT ({second_ict}) should be greater than first ICT ({first_ict})"
     );
 
     Ok(())
@@ -2033,8 +2029,7 @@ async fn test_remove_files_adds_expected_entries() -> Result<(), Box<dyn std::er
             let commit_version = committed.commit_version();
 
             // Read the commit log directly to verify remove actions
-            let commit_path =
-                tmp_table_path.join(format!("_delta_log/{:020}.json", commit_version));
+            let commit_path = tmp_table_path.join(format!("_delta_log/{commit_version:020}.json"));
             let commit_content = std::fs::read_to_string(commit_path)?;
 
             let parsed_commits: Vec<_> = Deserializer::from_str(&commit_content)
@@ -2271,8 +2266,7 @@ async fn test_update_deletion_vectors_adds_expected_entries(
             let original_stats = original_add.get("stats");
 
             // Read the commit log directly
-            let commit_path =
-                tmp_table_path.join(format!("_delta_log/{:020}.json", commit_version));
+            let commit_path = tmp_table_path.join(format!("_delta_log/{commit_version:020}.json"));
             let commit_content = std::fs::read_to_string(commit_path)?;
 
             let parsed_commits: Vec<_> = Deserializer::from_str(&commit_content)
@@ -2509,7 +2503,7 @@ async fn test_update_deletion_vectors_multiple_files() -> Result<(), Box<dyn std
     for (idx, file_path) in file_paths.iter().enumerate() {
         let descriptor = DeletionVectorDescriptor {
             storage_type: DeletionVectorStorageType::PersistedRelative,
-            path_or_inline_dv: format!("dv_file_{}.bin", idx),
+            path_or_inline_dv: format!("dv_file_{idx}.bin"),
             offset: Some(idx as i32 * 10),
             size_in_bytes: 40 + idx as i32,
             cardinality: idx as i64 + 1,
@@ -2528,7 +2522,7 @@ async fn test_update_deletion_vectors_multiple_files() -> Result<(), Box<dyn std
 
             // Read the commit log directly from object store
             let final_commit_path =
-                table_url.join(&format!("_delta_log/{:020}.json", commit_version))?;
+                table_url.join(&format!("_delta_log/{commit_version:020}.json"))?;
             let commit_content = store
                 .get(&Path::from_url_path(final_commit_path.path())?)
                 .await?
@@ -2564,13 +2558,13 @@ async fn test_update_deletion_vectors_multiple_files() -> Result<(), Box<dyn std
                 let remove_action = remove_actions
                     .iter()
                     .find(|action| action["remove"]["path"].as_str() == Some(file_path.as_str()))
-                    .unwrap_or_else(|| panic!("Should find remove action for {}", file_path));
+                    .unwrap_or_else(|| panic!("Should find remove action for {file_path}"));
 
                 // Find the add action for this file
                 let add_action = add_actions
                     .iter()
                     .find(|action| action["add"]["path"].as_str() == Some(file_path.as_str()))
-                    .unwrap_or_else(|| panic!("Should find add action for {}", file_path));
+                    .unwrap_or_else(|| panic!("Should find add action for {file_path}"));
 
                 // Verify remove action does NOT have a DV (since these were newly written files)
                 assert!(
@@ -2583,30 +2577,26 @@ async fn test_update_deletion_vectors_multiple_files() -> Result<(), Box<dyn std
                     .as_object()
                     .expect("Add action should have deletionVector");
 
-                let expected_path = format!("dv_file_{}.bin", idx);
+                let expected_path = format!("dv_file_{idx}.bin");
                 assert_eq!(
                     add_dv.get("pathOrInlineDv").and_then(|v| v.as_str()),
                     Some(expected_path.as_str()),
-                    "DV path should match for file {}",
-                    file_path
+                    "DV path should match for file {file_path}"
                 );
                 assert_eq!(
                     add_dv.get("offset").and_then(|v| v.as_i64()),
                     Some(idx as i64 * 10),
-                    "DV offset should match for file {}",
-                    file_path
+                    "DV offset should match for file {file_path}"
                 );
                 assert_eq!(
                     add_dv.get("sizeInBytes").and_then(|v| v.as_i64()),
                     Some(40 + idx as i64),
-                    "DV size should match for file {}",
-                    file_path
+                    "DV size should match for file {file_path}"
                 );
                 assert_eq!(
                     add_dv.get("cardinality").and_then(|v| v.as_i64()),
                     Some(idx as i64 + 1),
-                    "DV cardinality should match for file {}",
-                    file_path
+                    "DV cardinality should match for file {file_path}"
                 );
             }
         }
@@ -2737,8 +2727,7 @@ async fn test_remove_files_with_modified_selection_vector() -> Result<(), Box<dy
 
         assert!(
             initial_file_count >= 3,
-            "Need at least 3 files for this test, got {}",
-            initial_file_count
+            "Need at least 3 files for this test, got {initial_file_count}"
         );
 
         // Create a transaction to remove files in two batches
@@ -3093,7 +3082,7 @@ async fn test_post_commit_snapshot_create_then_insert() -> DeltaResult<()> {
 
                 current_snapshot = post_snapshot.clone();
             }
-            _ => panic!("Commit {} should succeed", i),
+            _ => panic!("Commit {i} should succeed"),
         }
     }
 

--- a/mem-test/tests/dhat_large_table_data.rs
+++ b/mem-test/tests/dhat_large_table_data.rs
@@ -48,11 +48,8 @@ fn write_large_parquet_to(path: &Path) -> Result<(), Box<dyn std::error::Error>>
         .iter()
         .map(|rg| rg.total_byte_size())
         .sum();
-    println!("File size (compressed file size):    {} bytes", file_size);
-    println!(
-        "Total size (uncompressed file size): {} bytes",
-        total_row_group_size
-    );
+    println!("File size (compressed file size):    {file_size} bytes");
+    println!("Total size (uncompressed file size): {total_row_group_size} bytes");
 
     Ok(())
 }
@@ -93,7 +90,7 @@ fn create_commit(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     ];
 
     for action in actions {
-        writeln!(file, "{}", action)?;
+        writeln!(file, "{action}")?;
     }
 
     Ok(())
@@ -109,7 +106,7 @@ fn test_dhat_large_table_data() -> Result<(), Box<dyn std::error::Error>> {
     // Step 1: Write the large parquet file
     write_large_parquet_to(table_path)?;
     let stats = dhat::HeapStats::get();
-    println!("Heap stats after writing parquet:\n{:?}", stats);
+    println!("Heap stats after writing parquet:\n{stats:?}");
 
     // Step 2: Create the Delta log
     create_commit(table_path)?;
@@ -124,7 +121,7 @@ fn test_dhat_large_table_data() -> Result<(), Box<dyn std::error::Error>> {
         .expect("Failed to create snapshot");
 
     let stats = dhat::HeapStats::get();
-    println!("Heap stats after creating snapshot:\n{:?}", stats);
+    println!("Heap stats after creating snapshot:\n{stats:?}");
 
     // Step 4: Build and execute scan
     let scan = snapshot
@@ -133,7 +130,7 @@ fn test_dhat_large_table_data() -> Result<(), Box<dyn std::error::Error>> {
         .expect("Failed to build scan");
 
     let stats = dhat::HeapStats::get();
-    println!("Heap stats after building scan:\n{:?}", stats);
+    println!("Heap stats after building scan:\n{stats:?}");
 
     // Step 5: Execute the scan and read data
     let mut row_count = 0;
@@ -143,8 +140,8 @@ fn test_dhat_large_table_data() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let stats = dhat::HeapStats::get();
-    println!("Heap stats after scan execution:\n{:?}", stats);
-    println!("Total rows read: {}", row_count);
+    println!("Heap stats after scan execution:\n{stats:?}");
+    println!("Total rows read: {row_count}");
 
     Ok(())
 }

--- a/mem-test/tests/dhat_large_table_log.rs
+++ b/mem-test/tests/dhat_large_table_log.rs
@@ -30,7 +30,7 @@ fn generate_delta_log(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let mut current_file_id = 0u64;
 
     for commit_id in 0..NUM_COMMITS {
-        let commit_filename = format!("{:020}.json", commit_id);
+        let commit_filename = format!("{commit_id:020}.json");
         let commit_path = delta_log_path.join(&commit_filename);
         let mut file = File::create(&commit_path)?;
 
@@ -84,7 +84,7 @@ fn generate_delta_log(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
 
         // Write actions to file
         for action in actions {
-            writeln!(file, "{}", action)?;
+            writeln!(file, "{action}")?;
         }
     }
 
@@ -117,7 +117,7 @@ fn test_dhat_large_table_log() -> Result<(), Box<dyn std::error::Error>> {
         .expect("Failed to get latest snapshot");
 
     let stats = dhat::HeapStats::get();
-    println!("Heap stats after PM replay:\n{:?}", stats);
+    println!("Heap stats after PM replay:\n{stats:?}");
 
     let scan = snapshot
         .scan_builder()
@@ -131,7 +131,7 @@ fn test_dhat_large_table_log() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let stats = dhat::HeapStats::get();
-    println!("Heap stats after Scan replay:\n{:?}", stats);
+    println!("Heap stats after Scan replay:\n{stats:?}");
 
     Ok(())
 }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -1009,7 +1009,7 @@ pub fn read_actions_from_commit(
     action_type: &str,
 ) -> Result<Vec<serde_json::Value>, Box<dyn std::error::Error>> {
     let table_path = table_url.to_file_path().expect("should be a file URL");
-    let commit_path = table_path.join(format!("_delta_log/{:020}.json", version));
+    let commit_path = table_path.join(format!("_delta_log/{version:020}.json"));
     let content = std::fs::read_to_string(commit_path)?;
     let parsed: Vec<serde_json::Value> = Deserializer::from_str(&content)
         .into_iter::<serde_json::Value>()

--- a/uc-catalog/src/committer.rs
+++ b/uc-catalog/src/committer.rs
@@ -141,15 +141,14 @@ mod tests {
     fn staged_commit_url(table_root: &url::Url, version: Version) -> url::Url {
         table_root
             .join(&format!(
-                "_delta_log/_staged_commits/{:020}.uuid.json",
-                version
+                "_delta_log/_staged_commits/{version:020}.uuid.json"
             ))
             .unwrap()
     }
 
     fn published_commit_url(table_root: &url::Url, version: Version) -> url::Url {
         table_root
-            .join(&format!("_delta_log/{:020}.json", version))
+            .join(&format!("_delta_log/{version:020}.json"))
             .unwrap()
     }
 
@@ -197,10 +196,7 @@ mod tests {
         for v in versions {
             let path = published_commit_url(&table_root, v).to_file_path().unwrap();
             assert!(path.exists());
-            assert_eq!(
-                fs::read_to_string(&path).unwrap(),
-                format!("version: {}", v)
-            );
+            assert_eq!(fs::read_to_string(&path).unwrap(), format!("version: {v}"));
         }
     }
 }

--- a/uc-catalog/src/lib.rs
+++ b/uc-catalog/src/lib.rs
@@ -178,7 +178,7 @@ mod tests {
         let creds = uc_client
             .get_credentials(&table_id, Operation::Read)
             .await
-            .map_err(|e| format!("Failed to get credentials: {}", e))?;
+            .map_err(|e| format!("Failed to get credentials: {e}"))?;
 
         let catalog = UCCatalog::new(&uc_commits_client);
 
@@ -233,7 +233,7 @@ mod tests {
         let creds = client
             .get_credentials(&table_id, Operation::ReadWrite)
             .await
-            .map_err(|e| format!("Failed to get credentials: {}", e))?;
+            .map_err(|e| format!("Failed to get credentials: {e}"))?;
 
         let catalog = UCCatalog::new(commits_client.as_ref());
 

--- a/uc-client/examples/uc-cli.rs
+++ b/uc-client/examples/uc-cli.rs
@@ -68,8 +68,7 @@ fn parse_operation(s: &str) -> Result<Operation, String> {
         "WRITE" => Ok(Operation::Write),
         "READ_WRITE" | "READWRITE" => Ok(Operation::ReadWrite),
         _ => Err(format!(
-            "Invalid operation '{}'. Must be READ, WRITE, or READ_WRITE",
-            s
+            "Invalid operation '{s}'. Must be READ, WRITE, or READ_WRITE"
         )),
     }
 }
@@ -99,15 +98,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Execute command
     match cli.command {
         Commands::Table { name } => {
-            println!("Fetching table metadata for: {}", name);
+            println!("Fetching table metadata for: {name}");
 
             match uc_client.get_table(&name).await {
                 Ok(table) => {
                     println!("\n✓ Table metadata retrieved successfully\n");
-                    println!("{}", table);
+                    println!("{table}");
                 }
                 Err(e) => {
-                    eprintln!("✗ Failed to get table: {}", e);
+                    eprintln!("✗ Failed to get table: {e}");
                     std::process::exit(1);
                 }
             }
@@ -118,7 +117,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             start_version,
             end_version,
         } => {
-            println!("Resolving table: {}", name);
+            println!("Resolving table: {name}");
 
             // First, get the table metadata to obtain table_id and storage_location
             let table = match uc_client.get_table(&name).await {
@@ -131,7 +130,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     table
                 }
                 Err(e) => {
-                    eprintln!("✗ Failed to resolve table: {}", e);
+                    eprintln!("✗ Failed to resolve table: {e}");
                     std::process::exit(1);
                 }
             };
@@ -162,7 +161,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
                 Err(e) => {
-                    eprintln!("✗ Failed to get commits: {}", e);
+                    eprintln!("✗ Failed to get commits: {e}");
                     std::process::exit(1);
                 }
             }
@@ -172,10 +171,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             table_id,
             operation,
         } => {
-            println!(
-                "Getting {} credentials for table_id: {}",
-                operation, table_id
-            );
+            println!("Getting {operation} credentials for table_id: {table_id}");
 
             match uc_client.get_credentials(&table_id, operation).await {
                 Ok(creds) => {
@@ -185,12 +181,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         .expiration_as_datetime()
                         .map(|dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
                         .unwrap_or_else(|| format!("Invalid timestamp: {}", creds.expiration_time));
-                    println!("Expires at:       {}", expires_str);
+                    println!("Expires at:       {expires_str}");
 
                     if let Some(time_left) = creds.time_until_expiry() {
                         let hours = time_left.num_hours();
                         let minutes = time_left.num_minutes() % 60;
-                        println!("Time until expiry: {} hours {} minutes", hours, minutes);
+                        println!("Time until expiry: {hours} hours {minutes} minutes");
                     } else {
                         println!("Time until expiry: Unable to calculate");
                     }
@@ -213,7 +209,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
                 Err(e) => {
-                    eprintln!("✗ Failed to get credentials: {}", e);
+                    eprintln!("✗ Failed to get credentials: {e}");
                     std::process::exit(1);
                 }
             }

--- a/uc-client/src/client.rs
+++ b/uc-client/src/client.rs
@@ -38,7 +38,7 @@ impl UCClient {
     /// Resolve the table by name.
     #[instrument(skip(self))]
     pub async fn get_table(&self, table_name: &str) -> Result<TablesResponse> {
-        let url = self.base_url.join(&format!("tables/{}", table_name))?;
+        let url = self.base_url.join(&format!("tables/{table_name}"))?;
 
         let response =
             execute_with_retry(&self.config, || self.http_client.get(url.clone()).send()).await?;

--- a/uc-client/src/commits_client/in_memory.rs
+++ b/uc-client/src/commits_client/in_memory.rs
@@ -172,7 +172,7 @@ mod tests {
         Commit::new(
             version,
             version * 1000,
-            format!("{:020}.json", version),
+            format!("{version:020}.json"),
             100,
             version * 1000,
         )

--- a/uc-client/src/http.rs
+++ b/uc-client/src/http.rs
@@ -89,7 +89,7 @@ where
             StatusCode::UNAUTHORIZED => Err(Error::AuthenticationFailed),
             StatusCode::NOT_FOUND => Err(Error::ApiError {
                 status: status.as_u16(),
-                message: format!("Resource not found: {}", error_body),
+                message: format!("Resource not found: {error_body}"),
             }),
             _ => Err(Error::ApiError {
                 status: status.as_u16(),

--- a/uc-client/src/models/tables.rs
+++ b/uc-client/src/models/tables.rs
@@ -57,7 +57,7 @@ impl Display for TablesResponse {
             writeln!(f)?;
             writeln!(f, "Properties:")?;
             for (key, value) in &self.properties {
-                writeln!(f, "  {}: {}", key, value)?;
+                writeln!(f, "  {key}: {value}")?;
             }
         }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

arrow-58 bumps the MSRV to 1.88, which brings additional clippy warnings with it. Fix them pre-emptively.

## How was this change tested?

Fixed automatically by clippy, existing tests suffice.