### PR TITLE
refactor: move create_table tests to directory-based module structure

### DIFF
--- a/kernel/tests/create_table/main.rs
+++ b/kernel/tests/create_table/main.rs
@@ -1,14 +1,9 @@
 //! Integration tests for the CreateTable API
 
-#[path = "create_table/clustering.rs"]
 mod clustering;
-#[path = "create_table/column_mapping.rs"]
 mod column_mapping;
-#[path = "create_table/ctas.rs"]
 mod ctas;
-#[path = "create_table/timestamp_ntz.rs"]
 mod timestamp_ntz;
-#[path = "create_table/variant.rs"]
 mod variant;
 
 use std::sync::Arc;


### PR DESCRIPTION
## What changes are proposed in this pull request?
Remove ugly explicit #[path] attributes by restructuring tests/create_table.rs into tests/create_table/main.rs, letting Rust resolve submodules naturally.

## How was this change tested?
Test plan: all 100 create_table integration tests pass (`cargo test -p delta_kernel --test create_table --all-features`).

