### PR TITLE
chore: fix more clippy string format warnings

### DIFF
--- a/kernel/src/crc/writer.rs
+++ b/kernel/src/crc/writer.rs
@@ -194,8 +194,7 @@ mod tests {
             let result = try_write_crc_file(&engine, crc_path.location.as_url(), &crc);
             assert!(
                 matches!(result, Err(Error::ChecksumWriteUnsupported(_))),
-                "should reject {:?} with ChecksumWriteUnsupported",
-                invalid_validity
+                "should reject {invalid_validity:?} with ChecksumWriteUnsupported"
             );
         }
     }

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -2207,8 +2207,7 @@ mod tests {
 
         assert!(
             result.is_ok(),
-            "Stats validation should pass for all-null clustering columns, got: {:?}",
-            result
+            "Stats validation should pass for all-null clustering columns, got: {result:?}",
         );
     }
 

--- a/kernel/tests/create_table/timestamp_ntz.rs
+++ b/kernel/tests/create_table/timestamp_ntz.rs
@@ -29,13 +29,11 @@ fn assert_timestamp_ntz_protocol(snapshot: &Snapshot) {
     let protocol = table_config.protocol();
     assert!(
         protocol.min_reader_version() >= TABLE_FEATURES_MIN_READER_VERSION,
-        "Reader version should be at least {}",
-        TABLE_FEATURES_MIN_READER_VERSION
+        "Reader version should be at least {TABLE_FEATURES_MIN_READER_VERSION}"
     );
     assert!(
         protocol.min_writer_version() >= TABLE_FEATURES_MIN_WRITER_VERSION,
-        "Writer version should be at least {}",
-        TABLE_FEATURES_MIN_WRITER_VERSION
+        "Writer version should be at least {TABLE_FEATURES_MIN_WRITER_VERSION}"
     );
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Clean up a few more clippy warnings from rust-1.88

## How was this change tested?

Compilation suffices.