### PR TITLE
fix: update TokioBackgroundExecutor to join thread instead of detaching

### DIFF
--- a/kernel/src/engine/default/executor.rs
+++ b/kernel/src/engine/default/executor.rs
@@ -69,12 +69,15 @@ pub mod tokio {
     pub struct TokioBackgroundExecutor {
         sender: ManuallyDrop<tokio::sync::mpsc::Sender<BoxFuture<'static, ()>>>,
         handle: Handle,
+        /// `Option` because `join` takes ownership; we `take` it in `Drop` to move the
+        /// handle out. Never `None` outside of `Drop`.
         thread: Option<std::thread::JoinHandle<()>>,
     }
 
     impl Drop for TokioBackgroundExecutor {
         fn drop(&mut self) {
-            // SAFETY: The inner `Sender` has not been dropped yet because this is the only drop site and `Drop::drop` runs exactly once.
+            // SAFETY: The inner `Sender` has not been dropped yet because this is
+            // the only drop site and `Drop::drop` runs exactly once.
             // Drop sender first to close the channel, signaling the background
             // thread to exit its recv loop.
             unsafe { ManuallyDrop::drop(&mut self.sender) };


### PR DESCRIPTION
## What changes are proposed in this pull request?
The `TokioBackgroundExecutor` detaches its background thread on drop, which can cause a race condition with process exit. We hit this in a Postgres extension where the detached thread would conflict with Postgres backend exit.

This udpates `JoiningBackgroundExecutor` to join its thread instead of deatching it, ensuring all runtime cleanup completes before the executor is destroyed. We have currenlty implemented this locally but would like to upstream it.

## How was this change tested?
- Existing executor tests