### PR TITLE
ci: restrict rust-cache writes to main to prevent PR cache eviction

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,7 +11,12 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
+      # See build.yml top-level comment for why save-if is restricted to main.
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - uses: boa-dev/criterion-compare-action@v3
         env:
           BENCH_TAGS: base

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,29 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
+# Swatinem/rust-cache caches the cargo registry and target directory (~450MB per job).
+# save-if restricts cache writes to main pushes only. PRs read from main's cache but
+# never write their own entries.
+#
+# The key insight: Cargo.lock changes infrequently, so main's cache key almost always
+# matches. PRs download and compile zero dependencies on cache hit. By only writing on
+# main, we keep main's cache entries alive (no LRU eviction from PR churn), and every
+# PR benefits from them.
+#
+# Without this, GHA's ref-scoped caching works against us: each PR writes ~6.3GB of
+# cache entries (14 jobs x ~450MB) that only that PR can read. A handful of active PRs
+# fills the 10GB cache budget, LRU evicts main's shared entries, and every subsequent
+# PR compiles from scratch.
+#
+# The save-if condition checks both event_name == 'push' and ref == main because
+# pull_request_target events (used by benchmark.yml, semver-checks.yml) set github.ref
+# to the base branch (main), not the PR branch. Without the event_name check, those
+# workflows would write cache entries on every PR.
+#
+# Note: actions-rust-lang/setup-rust-toolchain has built-in Swatinem/rust-cache that
+# writes on every run with no save-if support. We disable it with cache: false and
+# manage caching explicitly via the Swatinem/rust-cache steps below.
+
 jobs:
   format:
     runs-on: ubuntu-latest
@@ -14,6 +37,7 @@ jobs:
       - name: Install minimal stable with rustfmt
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          cache: false
           components: rustfmt
       - name: format
         run: cargo fmt -- --check
@@ -24,7 +48,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install minimal stable and cargo msrv
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-msrv
@@ -40,7 +68,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install minimal stable and cargo msrv
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-msrv
@@ -51,6 +83,7 @@ jobs:
       - name: Install specified rust version
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          cache: false
           toolchain: ${{ env.RUST_VERSION }}
       - name: run tests
         run: |
@@ -65,7 +98,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install minimal stable
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: build docs
         run: cargo doc --workspace --all-features --no-deps
 
@@ -103,8 +140,11 @@ jobs:
       - name: Install minimal stable with clippy
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          cache: false
           components: clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: build and lint with clippy
         run: cargo clippy --benches --tests --all-features -- -D warnings
       - name: lint without default features - packages which depend on kernel with features enabled
@@ -134,7 +174,11 @@ jobs:
               - 'ffi-proc-macros/**'
       - name: Install minimal stable with clippy and rustfmt
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@nextest
       - name: test
         run: cargo nextest run --workspace --all-features -E 'not test(read_table_version_hdfs) and not test(invalid_handle_code)'
@@ -176,7 +220,11 @@ jobs:
           tools: "apache-arrow apache-arrow-glib"
       - name: Install minimal stable
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: Set output on fail
         run: echo "CTEST_OUTPUT_ON_FAILURE=1" >> "$GITHUB_ENV"
       - name: Build kernel
@@ -225,6 +273,8 @@ jobs:
           rustup override set nightly
           cargo miri setup
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@nextest
       - name: Test with Miri
         run: |
@@ -239,7 +289,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -13,7 +13,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install minimal stable
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
+      # See build.yml top-level comment for why save-if is restricted to main.
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Run all examples
         run: |

--- a/.github/workflows/run_integration_test.yml
+++ b/.github/workflows/run_integration_test.yml
@@ -23,6 +23,13 @@ jobs:
       - name: Setup rust toolchain
         if: ${{ !matrix.skip }}
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
+      # See build.yml top-level comment for why save-if is restricted to main.
+      - uses: Swatinem/rust-cache@v2
+        if: ${{ !matrix.skip }}
+        with:
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: Run integration tests
         if: ${{ !matrix.skip }}
         shell: bash

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -30,6 +30,12 @@ jobs:
                 || github.event.pull_request.head.sha }}
       - name: Install minimal stable
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
+      # See build.yml top-level comment for why save-if is restricted to main.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: Install cargo-semver-checks
         shell: bash
         run: |


### PR DESCRIPTION
## What changes are proposed in this pull request?

CI builds on PRs were taking ~5 minutes compiling dependencies from scratch ([example](https://github.com/delta-io/delta-kernel-rs/actions/runs/22980782326/job/66719888441?pr=2050)),
even though `Cargo.lock` rarely changes and Swatinem/rust-cache should have been providing
warm caches.

**Root cause:** GitHub Actions caches are scoped by git ref. A PR's cache can only be read
by that same PR, never by sibling PRs. Every PR was writing ~6.3GB of cache entries
(14 jobs x ~450MB each) that no other PR could use. This filled the 10GB cache budget,
LRU-evicted main's shared entries, and forced every PR to compile from scratch.

**Fix:** Add `save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}`
to all Swatinem/rust-cache invocations. PRs still read from main's cache (exact key hit
when `Cargo.lock` matches), but no longer write their own entries. Main's cache stays
alive, and every PR benefits from it.

The condition checks both `event_name == 'push'` and `ref == main` because
`pull_request_target` events (used by benchmark.yml, semver-checks.yml) set `github.ref`
to the base branch (main), not the PR branch. Without the `event_name` guard, those
workflows would incorrectly write cache entries on every PR.

Additionally, `actions-rust-lang/setup-rust-toolchain` bundles its own Swatinem/rust-cache
that writes on every run with no `save-if` support. We disable it with `cache: false` on
all instances and manage caching explicitly via standalone Swatinem/rust-cache steps.

## How was this change tested?

This change can only be validated after merging, since the fix restricts cache writes to
main. The test plan:
1. Merge this PR
2. Observe main's CI run writes caches (`"Saving cache..."` in Swatinem post-action logs)
3. Open a new PR and verify it hits main's cache (`"Found cache"` in logs) and does NOT
   write its own (`"save-if evaluates to false"`)
4. Compare compile times on new PRs against pre-merge baseline (~5 min on PR #2050)