### PR TITLE
ci: disable built-in cache in setup-rust-toolchain

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,6 +11,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
       # See build.yml top-level comment for why save-if is restricted to main.
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,10 @@ env:
 # 100GB with enough concurrent PRs). LRU then evicts main's shared entries, and all
 # subsequent PRs compile from scratch. More storage only delays the problem. Eliminating
 # PR writes removes it: main's ~6.3GB is the only cache that every PR benefits from.
+#
+# Note: actions-rust-lang/setup-rust-toolchain has built-in Swatinem/rust-cache that
+# writes on every run with no save-if support. We disable it with cache: false and
+# manage caching explicitly via the Swatinem/rust-cache steps below.
 
 jobs:
   format:
@@ -26,6 +30,7 @@ jobs:
       - name: Install minimal stable with rustfmt
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          cache: false
           components: rustfmt
       - name: format
         run: cargo fmt -- --check
@@ -36,6 +41,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install minimal stable and cargo msrv
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -54,6 +61,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install minimal stable and cargo msrv
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -67,6 +76,7 @@ jobs:
       - name: Install specified rust version
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          cache: false
           toolchain: ${{ env.RUST_VERSION }}
       - name: run tests
         run: |
@@ -81,6 +91,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install minimal stable
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -121,6 +133,7 @@ jobs:
       - name: Install minimal stable with clippy
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          cache: false
           components: clippy
       - uses: Swatinem/rust-cache@v2
         with:
@@ -154,6 +167,8 @@ jobs:
               - 'ffi-proc-macros/**'
       - name: Install minimal stable with clippy and rustfmt
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -198,6 +213,8 @@ jobs:
           tools: "apache-arrow apache-arrow-glib"
       - name: Install minimal stable
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -265,6 +282,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -13,6 +13,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install minimal stable
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
       # See build.yml top-level comment for why save-if is restricted to main.
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/run_integration_test.yml
+++ b/.github/workflows/run_integration_test.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Setup rust toolchain
         if: ${{ !matrix.skip }}
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
       - name: Run integration tests
         if: ${{ !matrix.skip }}
         shell: bash

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -30,6 +30,8 @@ jobs:
                 || github.event.pull_request.head.sha }}
       - name: Install minimal stable
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
       - name: Install cargo-semver-checks
         shell: bash
         run: |


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2132/files/d726e789f424fdaa50d74c4b15f36a6bd3721cde..4496c867f2d616e121ddda8b2abb07b0baa5febe) to review incremental changes.
- [stack/ci_cache_save_if](https://github.com/delta-io/delta-kernel-rs/pull/2130) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2130/files)]
  - [**stack/ci_cache_save_if_2**](https://github.com/delta-io/delta-kernel-rs/pull/2132) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2132/files/d726e789f424fdaa50d74c4b15f36a6bd3721cde..4496c867f2d616e121ddda8b2abb07b0baa5febe)]

---------
actions-rust-lang/setup-rust-toolchain@v1 has built-in Swatinem/rust-cache
that writes on every run with no save-if support. This bypasses our explicit
save-if restriction, causing PR and merge queue runs to write cache entries.
Disable it with cache: false so all caching goes through our explicit
Swatinem/rust-cache steps that have save-if: main-only.

Co-authored-by: Isaac

## What changes are proposed in this pull request?

<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

## How was this change tested?
