### PR TITLE
ci: share rust-cache between build and test jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,15 +142,8 @@ jobs:
         with:
           cache: false
           components: clippy
-      # The build and test jobs compile the same dependency tree with --all-features on the
-      # same OS matrix. shared-key replaces the job name component in the cache key,
-      # collapsing two cache entries per OS into one. The full key format is:
-      #   {prefix-key}-{shared-key}-{os.type()}-{os.arch()}-{envHash}-{lockHash}
-      # e.g. v0-rust-all-features-Linux-x64-a1b2c3d4-e5f6g7h8
-      # OS and arch are always appended by rust-cache, so cross-OS separation is automatic.
-      # On main pushes, whichever job finishes first saves the cache; the other's save is a
-      # no-op (GitHub caches are immutable per exact key). Both jobs benefit from cached
-      # dependency compilation on subsequent runs.
+      # Shared with the test job below. Both compile --all-features on the same OS matrix,
+      # so shared-key collapses two cache entries per OS into one (~1.3GB saved).
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: all-features

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,6 +155,10 @@ jobs:
         with:
           shared-key: all-features
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      # IMPORTANT: --all-features must stay in sync with the test job below. Both jobs share
+      # a rust-cache entry via shared-key. If the feature flags diverge, one job's artifacts
+      # evict the other's on each main push. If you need different features, remove shared-key
+      # from both jobs and let them cache independently.
       - name: build and lint with clippy
         run: cargo clippy --benches --tests --all-features -- -D warnings
       - name: lint without default features - packages which depend on kernel with features enabled
@@ -192,6 +196,8 @@ jobs:
           shared-key: all-features
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@nextest
+      # IMPORTANT: --all-features must stay in sync with the build job above. Both jobs share
+      # a rust-cache entry via shared-key. See the build job's clippy step for details.
       - name: test
         run: cargo nextest run --workspace --all-features -E 'not test(read_table_version_hdfs) and not test(invalid_handle_code)'
       - name: trybuild tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,8 +142,18 @@ jobs:
         with:
           cache: false
           components: clippy
+      # The build and test jobs compile the same dependency tree with --all-features on the
+      # same OS matrix. shared-key replaces the job name component in the cache key,
+      # collapsing two cache entries per OS into one. The full key format is:
+      #   {prefix-key}-{shared-key}-{os.type()}-{os.arch()}-{envHash}-{lockHash}
+      # e.g. v0-rust-all-features-Linux-x64-a1b2c3d4-e5f6g7h8
+      # OS and arch are always appended by rust-cache, so cross-OS separation is automatic.
+      # On main pushes, whichever job finishes first saves the cache; the other's save is a
+      # no-op (GitHub caches are immutable per exact key). Both jobs benefit from cached
+      # dependency compilation on subsequent runs.
       - uses: Swatinem/rust-cache@v2
         with:
+          shared-key: all-features
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: build and lint with clippy
         run: cargo clippy --benches --tests --all-features -- -D warnings
@@ -176,8 +186,10 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache: false
+      # Shares cache with the build job. See the build job's rust-cache step for details.
       - uses: Swatinem/rust-cache@v2
         with:
+          shared-key: all-features
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@nextest
       - name: test


### PR DESCRIPTION
## What changes are proposed in this pull request?

The `build` and `test` jobs compile the same `--all-features` dependency tree on the same 3-OS matrix but cache separately because `Swatinem/rust-cache` keys on job name by default. Adding `shared-key: all-features` to both jobs makes them share a single cache entry per OS, saving ~1.3GB of the 10GB cache budget.

**Before** (6 entries, ~2.7GB):
```
v0-rust-build-Linux-x64-9dc3db00-22f2e17d     (469MB)
v0-rust-test-Linux-x64-9dc3db00-22f2e17d      (455MB)
v0-rust-build-Darwin-arm64-30c8a630-22f2e17d   (490MB)
v0-rust-test-Darwin-arm64-30c8a630-22f2e17d    (442MB)
v0-rust-build-Windows_NT-x64-bcaa2ef8-22f2e17d (453MB)
v0-rust-test-Windows_NT-x64-bcaa2ef8-22f2e17d  (452MB)
```

**After** (3 entries, ~1.4GB):
```
v0-rust-all-features-Linux-x64-9dc3db00-22f2e17d
v0-rust-all-features-Darwin-arm64-{hash}-{hash}
v0-rust-all-features-Windows_NT-x64-{hash}-{hash}
```

Verified from the [CI run logs](https://github.com/delta-io/delta-kernel-rs/actions/runs/23121460634) that both jobs produce the same cache key on the same OS:
```
build (ubuntu-latest) Cache Key: v0-rust-all-features-Linux-x64-9dc3db00-22f2e17d
test  (ubuntu-latest) Cache Key: v0-rust-all-features-Linux-x64-9dc3db00-22f2e17d
```

**Important:** both jobs must continue using `--all-features` for the shared cache to be effective. If the feature flags diverge, the shared cache becomes a pessimization (one job's artifacts evict the other's on each main push).

## How was this change tested?

Verified from the [CI run](https://github.com/delta-io/delta-kernel-rs/actions/runs/23121460634) that `build` and `test` on the same OS produce identical cache keys. After merge, the [cache list](https://github.com/delta-io/delta-kernel-rs/actions/caches) should show 3 `all-features-*` entries instead of 6 `build-*`/`test-*` entries.