### PR TITLE
refactor: Centralize computation for physical schema without partition columns

### DIFF
--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -73,7 +73,7 @@ fn strip_metadata(schema: SchemaRef) -> SchemaRef {
 ///
 /// - `full`: physical representations of all columns from [`TableConfiguration::logical_schema`].
 /// - `without_partition`: lazily computed variant that excludes partition columns.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq)]
 struct PhysicalSchemas {
     full: SchemaRef,
     without_partition: OnceLock<SchemaRef>,
@@ -97,8 +97,6 @@ impl PartialEq for PhysicalSchemas {
         self.full == other.full
     }
 }
-
-impl Eq for PhysicalSchemas {}
 
 /// Holds all the configuration for a table at a specific version. This includes the supported
 /// reader and writer features, table properties, schema, version, and table root. This can be used
@@ -412,6 +410,21 @@ impl TableConfiguration {
     #[internal_api]
     pub(crate) fn physical_schema(&self) -> SchemaRef {
         self.physical_schemas.full.clone()
+    }
+
+    /// The physical schema for writing data files.
+    ///
+    /// When [`MaterializePartitionColumns`] is enabled, returns the full physical schema
+    /// (partition columns are materialized in data files). Otherwise, returns the physical
+    /// schema with partition columns excluded.
+    ///
+    /// [`MaterializePartitionColumns`]: crate::table_features::TableFeature::MaterializePartitionColumns
+    pub(crate) fn physical_write_schema(&self) -> SchemaRef {
+        if self.is_feature_enabled(&TableFeature::MaterializePartitionColumns) {
+            self.physical_schema()
+        } else {
+            self.physical_data_schema_without_partition_columns()
+        }
     }
 
     /// The [`TableProperties`] of this table at this version.

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -700,12 +700,7 @@ impl<S> Transaction<S> {
         let table_config = self.read_snapshot.table_configuration();
         let column_mapping_mode = table_config.column_mapping_mode();
 
-        let physical_schema =
-            if table_config.is_feature_enabled(&TableFeature::MaterializePartitionColumns) {
-                table_config.physical_schema()
-            } else {
-                table_config.physical_data_schema_without_partition_columns()
-            };
+        let physical_schema = table_config.physical_write_schema();
 
         // Get stats columns from table configuration
         let stats_columns = self.stats_columns();


### PR DESCRIPTION
## What changes are proposed in this pull request?
In the past, we compute physical schema without partition columns repeatedly. The PR is to centralize them to `TableConfiguration`
<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

## How was this change tested?
Existing