### PR TITLE
refactor: Restructured list log files function

### DIFF
--- a/kernel/src/log_segment_files.rs
+++ b/kernel/src/log_segment_files.rs
@@ -230,19 +230,8 @@ enum LogTailLowerBound {
 }
 
 impl LogSegmentFiles {
-    /// Assembles a [`LogSegmentFiles`] from two sources: `fs_files` (an iterator of files
-    /// listed from storage) and `log_tail` (catalog-provided commits). The two sources are
-    /// processed in three phases:
-    ///
-    /// 1. Stream `fs_files` in ascending version order, grouping files by version.
-    ///    At each version boundary, flush the group: if a complete checkpoint is found,
-    ///    discard all earlier commits and compaction files (they are superseded by the
-    ///    checkpoint). Filesystem commits at versions covered by `log_tail` are skipped
-    ///    because `log_tail` is authoritative for those commits; non-commit files (CRC,
-    ///    checkpoints, compactions) are always taken from the filesystem.
-    /// 2. Resolve the `log_tail` lower-bound version from `lower_bound`.
-    /// 3. Stream the filtered `log_tail` commits in ascending version order, applying the
-    ///    same checkpoint-grouping logic, then flush the final group.
+    /// Assembles a `LogSegmentFiles` from `fs_files` (an iterator of files
+    /// listed from storage) and `log_tail` (catalog-provided commits)
     ///
     /// `lower_bound` controls how the log_tail is filtered:
     /// - [`LogTailLowerBound::Explicit`]: include entries at version >= v


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2144/files) to review incremental changes.
- [**stack/refactor-list**](https://github.com/delta-io/delta-kernel-rs/pull/2144) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2144/files)]
  - [stack/backward-listing](https://github.com/delta-io/delta-kernel-rs/pull/2146) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2146/files/867162af108f73fa6ef7982fae431411a0906fec..b296c6cafadb9520941fade40205eaf6955f572b)]
    - [stack/fallback-list-w-checkpoint-hint](https://github.com/delta-io/delta-kernel-rs/pull/2149) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2149/files/b296c6cafadb9520941fade40205eaf6955f572b..82a62710bcd5a0f59d2af6889d2d11332a2af2d9)]

---------
## What changes are proposed in this pull request?

We need to move ListingAccumulator out of the scope of the list() function because we want to use it for both list() and for a list_with_backward_checkpoint_scan() function (in the later stacked PRs). 

This PR makes the following changes:
- Moves ListingAccumulator to be a top-level struct in the log_segment_files module
- Introduces build_log_segment_files which includes most of the logic previously in list(); list() delegates to this function (the goal is for list_with_backward_checkpoint_scan() to also delegate to this function in future PRs)
- LogTailLowerBound enum indicates whether we're listing from the start version (as done in list()), or we're deriving the start version from ListingAccumulator checkpoint parts (this would be the case for list_with_backward_checkpoint_scan())

## How was this change tested?
Existing tests that call list() were run
