### PR TITLE
fallback when checkpoint hint is wrong

### DIFF
--- a/kernel/src/log_segment_files.rs
+++ b/kernel/src/log_segment_files.rs
@@ -462,6 +462,7 @@ impl LogSegmentFiles {
         log_tail: Vec<ParsedLogPath>,
         end_version: Option<Version>,
     ) -> DeltaResult<Self> {
+        let log_tail_fallback = log_tail.clone();
         let listed_files = Self::list(
             storage,
             log_root,
@@ -471,10 +472,21 @@ impl LogSegmentFiles {
         )?;
 
         let Some(latest_checkpoint) = listed_files.checkpoint_parts.last() else {
-            // TODO: We could potentially recover here
-            return Err(Error::invalid_checkpoint(
-                "Had a _last_checkpoint hint but didn't find any checkpoints",
-            ));
+            // The checkpoint hint was stale or the checkpoint files were removed. Recover by
+            // falling back to a backward scan from the upper bound
+            let upper = end_version
+                .or_else(|| listed_files.latest_commit_file.as_ref().map(|f| f.version))
+                .ok_or_else(|| {
+                    Error::invalid_checkpoint(
+                        "Had a _last_checkpoint hint but found no checkpoints or commits",
+                    )
+                })?;
+            return Self::list_with_backward_checkpoint_scan(
+                storage,
+                log_root,
+                log_tail_fallback,
+                upper,
+            );
         };
         if latest_checkpoint.version != checkpoint_metadata.version {
             info!(


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2149/files/b296c6cafadb9520941fade40205eaf6955f572b..82a62710bcd5a0f59d2af6889d2d11332a2af2d9) to review incremental changes.
- [stack/refactor-list](https://github.com/delta-io/delta-kernel-rs/pull/2144) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2144/files)]
  - [stack/backward-listing](https://github.com/delta-io/delta-kernel-rs/pull/2146) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2146/files/867162af108f73fa6ef7982fae431411a0906fec..b296c6cafadb9520941fade40205eaf6955f572b)]
    - [**stack/fallback-list-w-checkpoint-hint**](https://github.com/delta-io/delta-kernel-rs/pull/2149) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2149/files/b296c6cafadb9520941fade40205eaf6955f572b..82a62710bcd5a0f59d2af6889d2d11332a2af2d9)]

---------
## What changes are proposed in this pull request?

<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

## How was this change tested?
