### PR TITLE
refactor!: New transform helpers for unary and binary children

### DIFF
--- a/kernel/src/transforms/expression.rs
+++ b/kernel/src/transforms/expression.rs
@@ -6,7 +6,7 @@ use crate::expressions::{
     MapToStructExpression, OpaqueExpression, OpaquePredicate, ParseJsonExpression, Predicate,
     Scalar, Transform, UnaryExpression, UnaryPredicate, VariadicExpression,
 };
-use crate::transforms::{map_owned_children_or_else, CowExt as _};
+use crate::transforms::{map_owned_children_or_else, map_owned_or_else, map_owned_pair_or_else};
 
 /// Generic framework for recursive bottom-up transforms of expressions and
 /// predicates. Transformations return `Option<Cow>` with the following semantics:
@@ -185,78 +185,97 @@ pub trait ExpressionTransform<'a> {
 
     /// General entry point for transforming an expression. This method will dispatch to the
     /// specific transform for each expression variant. Also invoked internally in order to recurse
-    /// on the child(ren) of non-leaf variants.
+    /// on the child(ren) of non-leaf expressions.
     fn transform_expr(&mut self, expr: &'a Expression) -> Option<Cow<'a, Expression>> {
-        let expr = match expr {
-            Expression::Literal(s) => self
-                .transform_expr_literal(s)?
-                .map_owned_or_else(expr, Expression::Literal),
-            Expression::Column(c) => self
-                .transform_expr_column(c)?
-                .map_owned_or_else(expr, Expression::Column),
-            Expression::Predicate(p) => self
-                .transform_expr_pred(p)?
-                .map_owned_or_else(expr, Expression::from),
-            Expression::Struct(s, nullability) => self
-                .transform_expr_struct(s)?
-                .map_owned_or_else(expr, |exprs| Expression::Struct(exprs, nullability.clone())),
-            Expression::Transform(t) => self
-                .transform_expr_transform(t)?
-                .map_owned_or_else(expr, Expression::Transform),
-            Expression::Unary(u) => self
-                .transform_expr_unary(u)?
-                .map_owned_or_else(expr, Expression::Unary),
-            Expression::Binary(b) => self
-                .transform_expr_binary(b)?
-                .map_owned_or_else(expr, Expression::Binary),
-            Expression::Variadic(v) => self
-                .transform_expr_variadic(v)?
-                .map_owned_or_else(expr, Expression::Variadic),
-            Expression::Opaque(o) => self
-                .transform_expr_opaque(o)?
-                .map_owned_or_else(expr, Expression::Opaque),
-            Expression::ParseJson(p) => self
-                .transform_expr_parse_json(p)?
-                .map_owned_or_else(expr, Expression::ParseJson),
-            Expression::MapToStruct(m) => self
-                .transform_expr_map_to_struct(m)?
-                .map_owned_or_else(expr, Expression::MapToStruct),
-            Expression::Unknown(u) => self
-                .transform_expr_unknown(u)?
-                .map_owned_or_else(expr, Expression::Unknown),
-        };
-        Some(expr)
+        match expr {
+            Expression::Literal(s) => {
+                let child = self.transform_expr_literal(s);
+                map_owned_or_else(expr, child, Expression::Literal)
+            }
+            Expression::Column(c) => {
+                let child = self.transform_expr_column(c);
+                map_owned_or_else(expr, child, Expression::Column)
+            }
+            Expression::Predicate(p) => {
+                let child = self.transform_expr_pred(p);
+                map_owned_or_else(expr, child, Expression::from)
+            }
+            Expression::Struct(s, nullability) => {
+                let map_owned = |exprs| Expression::Struct(exprs, nullability.clone());
+                map_owned_or_else(expr, self.transform_expr_struct(s), map_owned)
+            }
+            Expression::Transform(t) => {
+                let child = self.transform_expr_transform(t);
+                map_owned_or_else(expr, child, Expression::Transform)
+            }
+            Expression::Unary(u) => {
+                let child = self.transform_expr_unary(u);
+                map_owned_or_else(expr, child, Expression::Unary)
+            }
+            Expression::Binary(b) => {
+                let child = self.transform_expr_binary(b);
+                map_owned_or_else(expr, child, Expression::Binary)
+            }
+            Expression::Variadic(v) => {
+                let child = self.transform_expr_variadic(v);
+                map_owned_or_else(expr, child, Expression::Variadic)
+            }
+            Expression::Opaque(o) => {
+                let child = self.transform_expr_opaque(o);
+                map_owned_or_else(expr, child, Expression::Opaque)
+            }
+            Expression::ParseJson(p) => {
+                let child = self.transform_expr_parse_json(p);
+                map_owned_or_else(expr, child, Expression::ParseJson)
+            }
+            Expression::MapToStruct(m) => {
+                let child = self.transform_expr_map_to_struct(m);
+                map_owned_or_else(expr, child, Expression::MapToStruct)
+            }
+            Expression::Unknown(u) => {
+                let child = self.transform_expr_unknown(u);
+                map_owned_or_else(expr, child, Expression::Unknown)
+            }
+        }
     }
 
     /// General entry point for transforming a predicate. This method will dispatch to the specific
     /// transform for each predicate variant. Also invoked internally in order to recurse on the
     /// child(ren) of non-leaf variants.
     fn transform_pred(&mut self, pred: &'a Predicate) -> Option<Cow<'a, Predicate>> {
-        let pred = match pred {
-            Predicate::BooleanExpression(e) => self
-                .transform_expr(e)?
-                .map_owned_or_else(pred, Predicate::BooleanExpression),
-            Predicate::Not(p) => self.transform_pred_not(p)?.map_owned_or_else(pred, |p| p),
-            Predicate::Unary(u) => self
-                .transform_pred_unary(u)?
-                .map_owned_or_else(pred, Predicate::Unary),
-            Predicate::Binary(b) => self
-                .transform_pred_binary(b)?
-                .map_owned_or_else(pred, Predicate::Binary),
+        match pred {
+            Predicate::BooleanExpression(e) => {
+                let child = self.transform_expr(e);
+                map_owned_or_else(pred, child, Predicate::BooleanExpression)
+            }
+            Predicate::Not(p) => {
+                let child = self.transform_pred_not(p);
+                map_owned_or_else(pred, child, |p| p)
+            }
+            Predicate::Unary(u) => {
+                let child = self.transform_pred_unary(u);
+                map_owned_or_else(pred, child, Predicate::Unary)
+            }
+            Predicate::Binary(b) => {
+                let child = self.transform_pred_binary(b);
+                map_owned_or_else(pred, child, Predicate::Binary)
+            }
             // Route through the constructor to normalize in case the transform removed children.
             // When `transform_pred` returns `None` for a child, it is filtered out, which may
             // reduce the junction to one or zero elements. The constructor normalizes these.
-            Predicate::Junction(j) => self
-                .transform_pred_junction(j)?
-                .map_owned_or_else(pred, |j| Predicate::junction(j.op, j.preds)),
-            Predicate::Opaque(o) => self
-                .transform_pred_opaque(o)?
-                .map_owned_or_else(pred, Predicate::Opaque),
-            Predicate::Unknown(u) => self
-                .transform_pred_unknown(u)?
-                .map_owned_or_else(pred, Predicate::Unknown),
-        };
-        Some(pred)
+            Predicate::Junction(j) => {
+                let child = self.transform_pred_junction(j);
+                map_owned_or_else(pred, child, |j| Predicate::junction(j.op, j.preds))
+            }
+            Predicate::Opaque(o) => {
+                let child = self.transform_pred_opaque(o);
+                map_owned_or_else(pred, child, Predicate::Opaque)
+            }
+            Predicate::Unknown(u) => {
+                let child = self.transform_pred_unknown(u);
+                map_owned_or_else(pred, child, Predicate::Unknown)
+            }
+        }
     }
 
     /// Recursively transforms a struct's child expressions (variadic).
@@ -264,11 +283,10 @@ pub trait ExpressionTransform<'a> {
         &mut self,
         fields: &'a [ExpressionRef],
     ) -> Option<Cow<'a, [ExpressionRef]>> {
-        let transformed_children = fields.iter().map(|f| {
-            let transformed = self.transform_expr(f)?;
-            Some(transformed.map_owned_or_else(f, Arc::new))
+        let children = fields.iter().map(|f| -> Option<Cow<'a, ExpressionRef>> {
+            map_owned_or_else(f, self.transform_expr(f), Arc::new)
         });
-        map_owned_children_or_else(fields, transformed_children, |fields| fields)
+        map_owned_children_or_else(fields, children, |fields| fields)
     }
 
     /// Recursively transforms the child expression of a parse-json expression (unary).
@@ -276,10 +294,8 @@ pub trait ExpressionTransform<'a> {
         &mut self,
         expr: &'a ParseJsonExpression,
     ) -> Option<Cow<'a, ParseJsonExpression>> {
-        let nested = self.transform_expr(&expr.json_expr)?;
-        Some(nested.map_owned_or_else(expr, |json_expr| {
-            ParseJsonExpression::new(json_expr, expr.output_schema.clone())
-        }))
+        let f = |json_expr| ParseJsonExpression::new(json_expr, expr.output_schema.clone());
+        map_owned_or_else(expr, self.transform_expr(&expr.json_expr), f)
     }
 
     /// Recursively transforms the child expression of a map-to-struct expression (unary).
@@ -287,8 +303,8 @@ pub trait ExpressionTransform<'a> {
         &mut self,
         expr: &'a MapToStructExpression,
     ) -> Option<Cow<'a, MapToStructExpression>> {
-        let nested = self.transform_expr(&expr.map_expr)?;
-        Some(nested.map_owned_or_else(expr, MapToStructExpression::new))
+        let nested = self.transform_expr(&expr.map_expr);
+        map_owned_or_else(expr, nested, MapToStructExpression::new)
     }
 
     /// Recursively transforms the children of an opaque expression (variadic).
@@ -308,7 +324,7 @@ pub trait ExpressionTransform<'a> {
 
     /// Recursively transforms the child of a not predicate expression (unary).
     fn recurse_into_pred_not(&mut self, p: &'a Predicate) -> Option<Cow<'a, Predicate>> {
-        Some(self.transform_pred(p)?.map_owned_or_else(p, Predicate::not))
+        map_owned_or_else(p, self.transform_pred(p), Predicate::not)
     }
 
     /// Recursively transforms a unary predicate's child (unary).
@@ -316,8 +332,8 @@ pub trait ExpressionTransform<'a> {
         &mut self,
         u: &'a UnaryPredicate,
     ) -> Option<Cow<'a, UnaryPredicate>> {
-        let nested_result = self.transform_expr(&u.expr)?;
-        Some(nested_result.map_owned_or_else(u, |expr| UnaryPredicate::new(u.op, expr)))
+        let nested = self.transform_expr(&u.expr);
+        map_owned_or_else(u, nested, |expr| UnaryPredicate::new(u.op, expr))
     }
 
     /// Recursively transforms a binary predicate's children (binary).
@@ -325,10 +341,10 @@ pub trait ExpressionTransform<'a> {
         &mut self,
         b: &'a BinaryPredicate,
     ) -> Option<Cow<'a, BinaryPredicate>> {
-        let left = self.transform_expr(&b.left)?;
-        let right = self.transform_expr(&b.right)?;
+        let left = self.transform_expr(&b.left);
+        let right = self.transform_expr(&b.right);
         let f = |(left, right)| BinaryPredicate::new(b.op, left, right);
-        Some((left, right).map_owned_or_else(b, f))
+        map_owned_pair_or_else(b, left, right, f)
     }
 
     /// Recursively transforms a unary expression's child (unary).
@@ -336,8 +352,8 @@ pub trait ExpressionTransform<'a> {
         &mut self,
         u: &'a UnaryExpression,
     ) -> Option<Cow<'a, UnaryExpression>> {
-        let nested_result = self.transform_expr(&u.expr)?;
-        Some(nested_result.map_owned_or_else(u, |expr| UnaryExpression::new(u.op, expr)))
+        let nested = self.transform_expr(&u.expr);
+        map_owned_or_else(u, nested, |expr| UnaryExpression::new(u.op, expr))
     }
 
     /// Recursively transforms a binary expression's children (binary).
@@ -345,10 +361,10 @@ pub trait ExpressionTransform<'a> {
         &mut self,
         b: &'a BinaryExpression,
     ) -> Option<Cow<'a, BinaryExpression>> {
-        let left = self.transform_expr(&b.left)?;
-        let right = self.transform_expr(&b.right)?;
+        let left = self.transform_expr(&b.left);
+        let right = self.transform_expr(&b.right);
         let f = |(left, right)| BinaryExpression::new(b.op, left, right);
-        Some((left, right).map_owned_or_else(b, f))
+        map_owned_pair_or_else(b, left, right, f)
     }
 
     /// Recursively transforms a variadic expression's children (variadic).
@@ -356,9 +372,8 @@ pub trait ExpressionTransform<'a> {
         &mut self,
         v: &'a VariadicExpression,
     ) -> Option<Cow<'a, VariadicExpression>> {
-        let transformed_children = v.exprs.iter().map(|e| self.transform_expr(e));
-        let map_owned = |exprs| VariadicExpression::new(v.op, exprs);
-        map_owned_children_or_else(v, transformed_children, map_owned)
+        let children = v.exprs.iter().map(|e| self.transform_expr(e));
+        map_owned_children_or_else(v, children, |exprs| VariadicExpression::new(v.op, exprs))
     }
 
     /// Recursively transforms a junction predicate's children (variadic).
@@ -366,9 +381,8 @@ pub trait ExpressionTransform<'a> {
         &mut self,
         j: &'a JunctionPredicate,
     ) -> Option<Cow<'a, JunctionPredicate>> {
-        let transformed_children = j.preds.iter().map(|p| self.transform_pred(p));
-        let map_owned = |preds| JunctionPredicate::new(j.op, preds);
-        map_owned_children_or_else(j, transformed_children, map_owned)
+        let children = j.preds.iter().map(|p| self.transform_pred(p));
+        map_owned_children_or_else(j, children, |preds| JunctionPredicate::new(j.op, preds))
     }
 
     /// Recursively transforms an opaque predicate's children (variadic).
@@ -376,9 +390,9 @@ pub trait ExpressionTransform<'a> {
         &mut self,
         o: &'a OpaquePredicate,
     ) -> Option<Cow<'a, OpaquePredicate>> {
-        let transformed_children = o.exprs.iter().map(|e| self.transform_expr(e));
+        let children = o.exprs.iter().map(|e| self.transform_expr(e));
         let map_owned = |exprs| OpaquePredicate::new(o.op.clone(), exprs);
-        map_owned_children_or_else(o, transformed_children, map_owned)
+        map_owned_children_or_else(o, children, map_owned)
     }
 }
 

--- a/kernel/src/transforms/mod.rs
+++ b/kernel/src/transforms/mod.rs
@@ -5,41 +5,6 @@ mod schema;
 pub use self::expression::{ExpressionDepthChecker, ExpressionTransform};
 pub use self::schema::{SchemaDepthChecker, SchemaTransform};
 
-// Extension trait for Cow<'_, T>
-pub(crate) trait CowExt<T: ToOwned + ?Sized> {
-    /// The owned type that corresponds to Self
-    type Owned;
-
-    /// Propagate the results of nested transforms. If the nested transform made no change (borrowed
-    /// `self`), then return a borrowed result `s` as well. Otherwise, invoke the provided mapping
-    /// function `f` to convert the owned nested result into an owned result.
-    fn map_owned_or_else<S: Clone>(self, s: &S, f: impl FnOnce(Self::Owned) -> S) -> Cow<'_, S>;
-}
-
-// Basic implementation for a single Cow value
-impl<T: ToOwned + ?Sized> CowExt<T> for Cow<'_, T> {
-    type Owned = T::Owned;
-
-    fn map_owned_or_else<S: Clone>(self, s: &S, f: impl FnOnce(T::Owned) -> S) -> Cow<'_, S> {
-        match self {
-            Cow::Owned(v) => Cow::Owned(f(v)),
-            Cow::Borrowed(_) => Cow::Borrowed(s),
-        }
-    }
-}
-
-// Additional implementation for a pair of Cow values
-impl<'a, T: ToOwned + ?Sized> CowExt<(Cow<'a, T>, Cow<'a, T>)> for (Cow<'a, T>, Cow<'a, T>) {
-    type Owned = (T::Owned, T::Owned);
-
-    fn map_owned_or_else<S: Clone>(self, s: &S, f: impl FnOnce(Self::Owned) -> S) -> Cow<'_, S> {
-        match self {
-            (Cow::Borrowed(_), Cow::Borrowed(_)) => Cow::Borrowed(s),
-            (left, right) => Cow::Owned(f((left.into_owned(), right.into_owned()))),
-        }
-    }
-}
-
 /// Rebuilds a parent from transformed children only when needed.
 ///
 /// Child transforms may filter nodes by returning `None`. If all children are filtered out, this
@@ -72,4 +37,48 @@ where
     } else {
         Some(Cow::Borrowed(parent))
     }
+}
+
+/// Rebuilds a two-child parent from transformed children only when needed.
+///
+/// If either child is filtered out (`None`), filter out the parent by returning `None`. If both children survive as
+/// borrowed values, this returns a borrowed parent. Otherwise, it uses the provided `map_owned` function to rebuild and return an owned
+/// parent.
+pub(crate) fn map_owned_pair_or_else<'a, Parent, Child>(
+    parent: &'a Parent,
+    left: Option<Cow<'a, Child>>,
+    right: Option<Cow<'a, Child>>,
+    map_owned: impl FnOnce((Child::Owned, Child::Owned)) -> Parent,
+) -> Option<Cow<'a, Parent>>
+where
+    Parent: Clone,
+    Child: ToOwned + ?Sized + 'a,
+{
+    let (Some(left), Some(right)) = (left, right) else {
+        return None;
+    };
+    Some(match (left, right) {
+        (Cow::Borrowed(_), Cow::Borrowed(_)) => Cow::Borrowed(parent),
+        (left, right) => Cow::Owned(map_owned((left.into_owned(), right.into_owned()))),
+    })
+}
+
+/// Rebuilds a single-child parent from a transformed child only when needed.
+///
+/// If the child is filtered out (`None`), filter out the parent by returning `None`. If the child
+/// survives as a borrowed value, this returns a borrowed parent. Otherwise, it uses the provided
+/// `map_owned` function to rebuild and return an owned parent.
+pub(crate) fn map_owned_or_else<'a, Parent, Child>(
+    parent: &'a Parent,
+    child: Option<Cow<'a, Child>>,
+    map_owned: impl FnOnce(Child::Owned) -> Parent,
+) -> Option<Cow<'a, Parent>>
+where
+    Parent: Clone,
+    Child: ToOwned + ?Sized + 'a,
+{
+    Some(match child? {
+        Cow::Owned(v) => Cow::Owned(map_owned(v)),
+        Cow::Borrowed(_) => Cow::Borrowed(parent),
+    })
 }

--- a/kernel/src/transforms/schema.rs
+++ b/kernel/src/transforms/schema.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use crate::schema::{ArrayType, DataType, MapType, PrimitiveType, StructField, StructType};
-use crate::transforms::{map_owned_children_or_else, CowExt as _};
+use crate::transforms::{map_owned_children_or_else, map_owned_or_else, map_owned_pair_or_else};
 
 /// Generic framework for describing recursive bottom-up schema transforms. Transformations return
 /// `Option<Cow>` with the following semantics:
@@ -94,25 +94,28 @@ pub trait SchemaTransform<'a> {
     /// General entry point for a recursive traversal over any data type. Also invoked internally to
     /// dispatch on nested data types encountered during the traversal.
     fn transform(&mut self, data_type: &'a DataType) -> Option<Cow<'a, DataType>> {
-        use DataType::*;
-        let result = match data_type {
-            Primitive(ptype) => self
-                .transform_primitive(ptype)?
-                .map_owned_or_else(data_type, DataType::from),
-            Array(atype) => self
-                .transform_array(atype)?
-                .map_owned_or_else(data_type, DataType::from),
-            Struct(stype) => self
-                .transform_struct(stype)?
-                .map_owned_or_else(data_type, DataType::from),
-            Map(mtype) => self
-                .transform_map(mtype)?
-                .map_owned_or_else(data_type, DataType::from),
-            Variant(stype) => self
-                .transform_variant(stype)?
-                .map_owned_or_else(data_type, |s| DataType::Variant(Box::new(s))),
-        };
-        Some(result)
+        match data_type {
+            DataType::Primitive(ptype) => {
+                let child = self.transform_primitive(ptype);
+                map_owned_or_else(data_type, child, DataType::from)
+            }
+            DataType::Array(atype) => {
+                let child = self.transform_array(atype);
+                map_owned_or_else(data_type, child, DataType::from)
+            }
+            DataType::Struct(stype) => {
+                let child = self.transform_struct(stype);
+                map_owned_or_else(data_type, child, DataType::from)
+            }
+            DataType::Map(mtype) => {
+                let child = self.transform_map(mtype);
+                map_owned_or_else(data_type, child, DataType::from)
+            }
+            DataType::Variant(stype) => {
+                let child = self.transform_variant(stype);
+                map_owned_or_else(data_type, child, |s| DataType::Variant(Box::new(s)))
+            }
+        }
     }
 
     /// Recursively transforms a struct field's data type (unary).
@@ -120,44 +123,42 @@ pub trait SchemaTransform<'a> {
         &mut self,
         field: &'a StructField,
     ) -> Option<Cow<'a, StructField>> {
-        let result = self.transform(&field.data_type)?;
-        let f = |new_data_type| StructField {
+        let child = self.transform(&field.data_type);
+        map_owned_or_else(field, child, |new_data_type| StructField {
             name: field.name.clone(),
             data_type: new_data_type,
             nullable: field.nullable,
             metadata: field.metadata.clone(),
-        };
-        Some(result.map_owned_or_else(field, f))
+        })
     }
 
     /// Recursively transforms a struct's fields (variadic).
     fn recurse_into_struct(&mut self, stype: &'a StructType) -> Option<Cow<'a, StructType>> {
-        let transformed_children = stype.fields().map(|f| self.transform_struct_field(f));
-        map_owned_children_or_else(stype, transformed_children, StructType::new_unchecked)
+        let children = stype.fields().map(|f| self.transform_struct_field(f));
+        map_owned_children_or_else(stype, children, StructType::new_unchecked)
     }
 
     /// Recursively transforms an array's element type (unary).
     fn recurse_into_array(&mut self, atype: &'a ArrayType) -> Option<Cow<'a, ArrayType>> {
-        let result = self.transform_array_element(&atype.element_type)?;
-        let f = |element_type| ArrayType {
+        let child = self.transform_array_element(&atype.element_type);
+        map_owned_or_else(atype, child, |element_type| ArrayType {
             type_name: atype.type_name.clone(),
             element_type,
             contains_null: atype.contains_null,
-        };
-        Some(result.map_owned_or_else(atype, f))
+        })
     }
 
     /// Recursively transforms a map's key and value types (binary).
     fn recurse_into_map(&mut self, mtype: &'a MapType) -> Option<Cow<'a, MapType>> {
-        let key_type = self.transform_map_key(&mtype.key_type)?;
-        let value_type = self.transform_map_value(&mtype.value_type)?;
+        let key_type = self.transform_map_key(&mtype.key_type);
+        let value_type = self.transform_map_value(&mtype.value_type);
         let f = |(key_type, value_type)| MapType {
             type_name: mtype.type_name.clone(),
             key_type,
             value_type,
             value_contains_null: mtype.value_contains_null,
         };
-        Some((key_type, value_type).map_owned_or_else(mtype, f))
+        map_owned_pair_or_else(mtype, key_type, value_type, f)
     }
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

It turns out that `CowExt`, and its `map_owned_children` method, was an incomplete mechanism for eliminating boilerplate in transform traits. Previous changes already switched variadic transform methods to use the `map_owned_children_or_else` helper function instead. This PR completes the transition by introducing and using `map_owned_pair_or_else` for binary child transforms and `map_owned_or_else` for unary child transforms. After that change, the `CowExt` trait is unused and can be removed.

### This PR affects the following public APIs

The pub `CowExt` trait has been removed.

## How was this change tested?

Existing transform unit tests.