### PR TITLE
fix: validate column mapping uniqueness on commit path

### DIFF
--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -174,9 +174,9 @@ pub(crate) fn get_field_column_mapping_info<'a>(
 struct ValidateColumnMappings<'a> {
     mode: ColumnMappingMode,
     path: Vec<&'a str>,
-    physical_path: Vec<String>,
+    physical_path: Vec<String>, // physical names of ancestor fields; used to build full paths
     seen: HashMap<i64, &'a str>, // column mapping id -> first field name that claimed it
-    seen_physical_names: HashSet<String>, // full physical path -> duplicate detection
+    seen_physical_names: HashSet<String>, // full physical path (ancestors + field) -> seen
     err: Option<Error>,
 }
 
@@ -220,7 +220,10 @@ impl<'a> SchemaTransform<'a> for ValidateColumnMappings<'a> {
                 } else {
                     format!("{}.{}", this.physical_path.join("."), physical_name)
                 };
-                if !this.seen_physical_names.insert(full_physical_path.clone()) {
+                if this
+                    .seen_physical_names
+                    .contains(full_physical_path.as_str())
+                {
                     this.err = Some(Error::schema(format!(
                         "Duplicate physical name '{}' assigned to field '{}'",
                         physical_name,
@@ -228,6 +231,7 @@ impl<'a> SchemaTransform<'a> for ValidateColumnMappings<'a> {
                     )));
                     return None;
                 }
+                this.seen_physical_names.insert(full_physical_path);
                 this.physical_path.push(physical_name.to_owned());
                 this.recurse_into_struct_field(field);
                 this.physical_path.pop();
@@ -704,7 +708,6 @@ mod tests {
         );
     }
 
-    /// Build a field with a specific physical name, independent of the logical name.
     fn make_cm_field_with_phys(
         name: &str,
         id: i64,
@@ -723,21 +726,25 @@ mod tests {
         ])
     }
 
-    #[test]
-    fn duplicate_physical_names_at_same_level_rejected() {
+    #[rstest::rstest]
+    #[case::name_mode(ColumnMappingMode::Name)]
+    #[case::id_mode(ColumnMappingMode::Id)]
+    fn duplicate_physical_names_at_same_level_rejected(#[case] mode: ColumnMappingMode) {
         // Two sibling fields share the same physical name; column IDs are distinct.
         let schema = StructType::new_unchecked([
             make_cm_field_with_phys("a", 1, "shared-phys", DataType::INTEGER),
             make_cm_field_with_phys("b", 2, "shared-phys", DataType::INTEGER),
         ]);
         crate::utils::test_utils::assert_result_error_with_message(
-            validate_schema_column_mapping(&schema, ColumnMappingMode::Name),
+            validate_schema_column_mapping(&schema, mode),
             "Duplicate physical name",
         );
     }
 
-    #[test]
-    fn duplicate_physical_names_in_nested_struct_rejected() {
+    #[rstest::rstest]
+    #[case::name_mode(ColumnMappingMode::Name)]
+    #[case::id_mode(ColumnMappingMode::Id)]
+    fn duplicate_physical_names_in_nested_struct_rejected(#[case] mode: ColumnMappingMode) {
         // Sibling fields inside a nested struct share a physical name.
         let inner = StructType::new_unchecked([
             make_cm_field_with_phys("x", 2, "dup-phys", DataType::INTEGER),
@@ -750,14 +757,13 @@ mod tests {
             DataType::Struct(Box::new(inner)),
         )]);
         crate::utils::test_utils::assert_result_error_with_message(
-            validate_schema_column_mapping(&schema, ColumnMappingMode::Name),
+            validate_schema_column_mapping(&schema, mode),
             "Duplicate physical name",
         );
     }
 
     #[test]
     fn unique_physical_names_accepted() {
-        // Distinct physical names at the same level must not be rejected.
         let schema = StructType::new_unchecked([
             make_cm_field_with_phys("a", 1, "phys-a", DataType::INTEGER),
             make_cm_field_with_phys("b", 2, "phys-b", DataType::INTEGER),

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -15,7 +15,7 @@ use crate::transforms::SchemaTransform;
 use crate::{DeltaResult, Error};
 
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 use strum::EnumString;
@@ -59,7 +59,9 @@ pub fn validate_schema_column_mapping(schema: &Schema, mode: ColumnMappingMode) 
     let mut validator = ValidateColumnMappings {
         mode,
         path: vec![],
+        physical_path: vec![],
         seen: HashMap::new(),
+        seen_physical_names: HashSet::new(),
         err: None,
     };
     let _ = validator.transform_struct(schema);
@@ -172,7 +174,9 @@ pub(crate) fn get_field_column_mapping_info<'a>(
 struct ValidateColumnMappings<'a> {
     mode: ColumnMappingMode,
     path: Vec<&'a str>,
+    physical_path: Vec<String>,
     seen: HashMap<i64, &'a str>, // column mapping id -> first field name that claimed it
+    seen_physical_names: HashSet<String>, // full physical path -> duplicate detection
     err: Option<Error>,
 }
 
@@ -202,10 +206,36 @@ impl<'a> SchemaTransform<'a> for ValidateColumnMappings<'a> {
     }
     fn transform_struct_field(&mut self, field: &'a StructField) -> Option<Cow<'a, StructField>> {
         self.transform_inner(field.name(), |this| {
-            get_field_column_mapping_info(field, this.mode, &this.path, Some(&mut this.seen))
-                .map_err(|e| this.err = Some(e))
-                .ok()?;
-            this.recurse_into_struct_field(field)
+            let (physical_name, _) =
+                get_field_column_mapping_info(field, this.mode, &this.path, Some(&mut this.seen))
+                    .map_err(|e| this.err = Some(e))
+                    .ok()?;
+
+            // Check physical name uniqueness when column mapping is enabled. Two fields at the
+            // same nesting level must not share a physical name, since the full physical path
+            // (parent physical names joined by '.') would collide, corrupting Parquet reads.
+            if this.mode != ColumnMappingMode::None {
+                let full_physical_path = if this.physical_path.is_empty() {
+                    physical_name.to_owned()
+                } else {
+                    format!("{}.{}", this.physical_path.join("."), physical_name)
+                };
+                if !this.seen_physical_names.insert(full_physical_path.clone()) {
+                    this.err = Some(Error::schema(format!(
+                        "Duplicate physical name '{}' assigned to field '{}'",
+                        physical_name,
+                        this.path.join(".")
+                    )));
+                    return None;
+                }
+                this.physical_path.push(physical_name.to_owned());
+                this.recurse_into_struct_field(field);
+                this.physical_path.pop();
+            } else {
+                this.recurse_into_struct_field(field);
+            }
+
+            Some(())
         });
         None
     }
@@ -672,6 +702,67 @@ mod tests {
             ),
             "Duplicate column mapping ID",
         );
+    }
+
+    /// Build a field with a specific physical name, independent of the logical name.
+    fn make_cm_field_with_phys(
+        name: &str,
+        id: i64,
+        phys: &str,
+        data_type: impl Into<DataType>,
+    ) -> StructField {
+        StructField::new(name, data_type, false).with_metadata([
+            (
+                ColumnMetadataKey::ColumnMappingId.as_ref(),
+                MetadataValue::Number(id),
+            ),
+            (
+                ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
+                MetadataValue::String(phys.to_owned()),
+            ),
+        ])
+    }
+
+    #[test]
+    fn duplicate_physical_names_at_same_level_rejected() {
+        // Two sibling fields share the same physical name; column IDs are distinct.
+        let schema = StructType::new_unchecked([
+            make_cm_field_with_phys("a", 1, "shared-phys", DataType::INTEGER),
+            make_cm_field_with_phys("b", 2, "shared-phys", DataType::INTEGER),
+        ]);
+        crate::utils::test_utils::assert_result_error_with_message(
+            validate_schema_column_mapping(&schema, ColumnMappingMode::Name),
+            "Duplicate physical name",
+        );
+    }
+
+    #[test]
+    fn duplicate_physical_names_in_nested_struct_rejected() {
+        // Sibling fields inside a nested struct share a physical name.
+        let inner = StructType::new_unchecked([
+            make_cm_field_with_phys("x", 2, "dup-phys", DataType::INTEGER),
+            make_cm_field_with_phys("y", 3, "dup-phys", DataType::INTEGER),
+        ]);
+        let schema = StructType::new_unchecked([make_cm_field_with_phys(
+            "outer",
+            1,
+            "col-outer",
+            DataType::Struct(Box::new(inner)),
+        )]);
+        crate::utils::test_utils::assert_result_error_with_message(
+            validate_schema_column_mapping(&schema, ColumnMappingMode::Name),
+            "Duplicate physical name",
+        );
+    }
+
+    #[test]
+    fn unique_physical_names_accepted() {
+        // Distinct physical names at the same level must not be rejected.
+        let schema = StructType::new_unchecked([
+            make_cm_field_with_phys("a", 1, "phys-a", DataType::INTEGER),
+            make_cm_field_with_phys("b", 2, "phys-b", DataType::INTEGER),
+        ]);
+        assert!(validate_schema_column_mapping(&schema, ColumnMappingMode::Name).is_ok());
     }
 
     // =========================================================================

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -52,9 +52,15 @@ pub(crate) fn column_mapping_mode(
     }
 }
 
-/// When column mapping mode is enabled, verify that each field in the schema is annotated with a
-/// physical name and field_id, and that no two fields share the same `delta.columnMapping.id`
-/// value. When not enabled, verifies that no fields are annotated.
+/// Verify that column mapping annotations in `schema` are consistent with `mode`.
+///
+/// When column mapping is enabled (`Name` or `Id` mode), checks that:
+/// - Every field has a `delta.columnMapping.physicalName` annotation
+/// - Every field has a `delta.columnMapping.id` annotation
+/// - No two fields share the same column mapping ID
+/// - No two fields share the same full physical path (parent physical names + field physical name)
+///
+/// When column mapping is disabled (`None` mode), checks that no fields carry those annotations.
 pub fn validate_schema_column_mapping(schema: &Schema, mode: ColumnMappingMode) -> DeltaResult<()> {
     let mut validator = ValidateColumnMappings {
         mode,

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -27,7 +27,7 @@ use crate::scan::log_replay::{
 use crate::scan::scan_row_schema;
 use crate::schema::{ArrayType, MapType, SchemaRef, StructField, StructType, StructTypeBuilder};
 use crate::snapshot::SnapshotRef;
-use crate::table_features::{ColumnMappingMode, TableFeature};
+use crate::table_features::{validate_schema_column_mapping, ColumnMappingMode, TableFeature};
 use crate::utils::require;
 use crate::FileMeta;
 use crate::{
@@ -342,6 +342,17 @@ impl<S> Transaction<S> {
         // Step 3: Generate Protocol and Metadata actions for create-table
         let (protocol_action, metadata_action) = if self.is_create_table() {
             let table_config = self.read_snapshot.table_configuration();
+
+            // Validate column mapping metadata integrity before committing: ensures no duplicate
+            // column IDs or physical names were introduced during schema construction.
+            let column_mapping_mode = table_config.column_mapping_mode();
+            if column_mapping_mode != ColumnMappingMode::None {
+                validate_schema_column_mapping(
+                    &table_config.logical_schema(),
+                    column_mapping_mode,
+                )?;
+            }
+
             let protocol = table_config.protocol().clone();
             let metadata = table_config.metadata().clone();
 

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -343,8 +343,9 @@ impl<S> Transaction<S> {
         let (protocol_action, metadata_action) = if self.is_create_table() {
             let table_config = self.read_snapshot.table_configuration();
 
-            // Validate column mapping metadata integrity before committing: ensures no duplicate
-            // column IDs or physical names were introduced during schema construction.
+            // Guard against duplicate column IDs or physical names reaching the transaction log.
+            // Without this, an invalid schema committed here would cause Parquet read failures or
+            // be rejected later by Spark's equivalent commit-time check.
             let column_mapping_mode = table_config.column_mapping_mode();
             if column_mapping_mode != ColumnMappingMode::None {
                 validate_schema_column_mapping(


### PR DESCRIPTION
## What changes are proposed in this pull request?

Two related gaps in column mapping validation:

**1. Physical name uniqueness was not checked**

`ValidateColumnMappings` tracked column ID duplicates via `HashMap<i64, &str>` but had no equivalent check for physical names. The protocol requires every column to have a unique physical name (L889); two sibling fields sharing a physical name produce an unreadable Parquet file. Added a `physical_path: Vec<String>` stack and `seen_physical_names: HashSet<String>` to detect duplicates during traversal.

**2. `validate_schema_column_mapping` was not called on the write path**

The function existed and was tested in isolation but was never wired into `Transaction::commit`. An invalid schema could be committed without detection. Spark runs an equivalent check on every commit; this adds the same guard to the kernel CREATE TABLE path.

## How was this change tested?

Five new tests in `column_mapping.rs`, parameterized with `rstest` over both `Name` and `Id` modes:
- `duplicate_physical_names_at_same_level_rejected` — two siblings share a physical name
- `duplicate_physical_names_in_nested_struct_rejected` — duplicates inside a nested struct
- `unique_physical_names_accepted` — valid schema is not rejected

`cargo clippy --workspace --benches --tests --all-features -- -D warnings` clean; `cargo test -p delta_kernel --all-features --lib` passes (1488 tests).