### PR TITLE
fix: rebase snapshot onto newer checkpoint even when version is unchanged

### DIFF
--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -2519,7 +2519,10 @@ mod tests {
             .listed
             .ascending_commit_files
             .len();
-        assert!(num_commits_before > 0, "should have accumulated commit files");
+        assert!(
+            num_commits_before > 0,
+            "should have accumulated commit files"
+        );
 
         // Write a checkpoint at version 4 (not the latest). This validates that the rebase
         // picks up the checkpoint AND preserves the commit file for version 5 on top of it.
@@ -2532,21 +2535,12 @@ mod tests {
         assert_eq!(rebased.log_segment().checkpoint_version, Some(4));
         // Only commit 5 should remain (on top of the checkpoint at 4), trimming commits 0-4.
         assert_eq!(
-            rebased
-                .log_segment()
-                .listed
-                .ascending_commit_files
-                .len(),
+            rebased.log_segment().listed.ascending_commit_files.len(),
             1,
             "only the commit after the checkpoint should remain"
         );
         assert!(
-            rebased
-                .log_segment()
-                .listed
-                .ascending_commit_files
-                .len()
-                < num_commits_before,
+            rebased.log_segment().listed.ascending_commit_files.len() < num_commits_before,
             "commit files should be trimmed after rebasing onto the checkpoint"
         );
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Swap the checkpoint rebase check and version equality check in `try_new_from_impl`.
Previously, `builder_from(snapshot).build()` short-circuited when `new_end_version == old_version`, skipping a newly written checkpoint.
This caused `ascending_commit_files` to grow unboundedly for sole-writer workloads, where we're a single writer to the table, and we use post-commit snapshots.

The checkpoint check now runs first, so a checkpoint written at the current version is picked up and the log segment is trimmed.

## How was this change tested?

New unit test `test_builder_from_rebases_onto_checkpoint_at_same_version`: creates a table with commits 0-5, builds a snapshot at v5, writes a checkpoint at v4, then verifies that `builder_from` rebases onto the checkpoint and trims commit files. All existing snapshot tests pass.