### PR TITLE
feat: add IO profiling to workload benchmarks via CountingReporter

### DIFF
--- a/ffi/src/ffi_tracing.rs
+++ b/ffi/src/ffi_tracing.rs
@@ -603,9 +603,6 @@ mod tests {
         *MESSAGES.lock().unwrap() = Some(vec![]);
     }
 
-    // get the string that we should ensure is in log messages for the time. If current time seconds
-    // is >= 50, return None because the minute might roll over before we actually log which would
-    // invalidate this check
     /// Format the current time as a string using the same formatter that tracing uses, trimmed
     /// to hours, minutes, and seconds (e.g. `"2026-03-10T14:32:45"`). This is used by tests to
     /// verify that log output contains a reasonable timestamp.
@@ -663,14 +660,18 @@ mod tests {
 
     /// Assert that the log line contains a timestamp within [time_before, time_after].
     ///
-    /// Log lines may contain ANSI escape codes before the timestamp, so we search for the
-    /// timestamp by looking for a 4-digit year prefix. ISO 8601 timestamps are fixed-width
-    /// and sort lexicographically, so a simple string comparison works as a range check.
+    /// Log lines may contain ANSI escape codes before the timestamp, so we locate the
+    /// timestamp by searching for the `time_before` prefix (up to the seconds). Once found,
+    /// we extract the full timestamp and do a lexicographic range check. ISO 8601 timestamps
+    /// are fixed-width and sort lexicographically.
     fn assert_timestamp_in_range(log_line: &str, time_before: &str, time_after: &str) {
         let len = time_before.len();
-        // Find the timestamp start by searching for a 4-digit year (e.g., "202")
+        // Search for the date+hour+minute prefix (first 16 chars, e.g. "2026-03-10T14:32")
+        // to locate the timestamp start. We use 16 chars (excluding seconds) because the
+        // seconds may differ between time_before and the log line.
+        let prefix = &time_before[..16];
         let ts_start = log_line
-            .find(&time_before[..3])
+            .find(prefix)
             .unwrap_or_else(|| panic!("No timestamp found in log line: {log_line:?}"));
         let log_time = &log_line[ts_start..ts_start + len];
         assert!(


### PR DESCRIPTION
  Body:
  ## What changes are proposed in this pull request?

  Two changes:

  **Bug fix** (`kernel/src/engine/default/mod.rs`): `DefaultEngine::new_with_opts`
  was constructing `ObjectStoreStorageHandler` with `None` for the reporter,
  silently discarding any reporter passed via
  `DefaultEngineBuilder::with_metrics_reporter`. `StorageListCompleted` and
  `StorageReadCompleted` events were therefore never emitted to a configured reporter.

  **Benchmark IO profiling** (`benchmarks/`): Adds `CountingReporter`, a
  `MetricsReporter` implementation that accumulates storage-level and log-replay
  metrics via atomic counters:
  - Storage layer: list calls, files seen, read calls, files read, bytes read
  - Log replay layer: segment loads, commit/checkpoint/compaction file counts

  `CountingReporter` is wired into the benchmark engine and prints per-call IO stats
  after each Criterion timing pass. IO profiling is skipped for benchmarks filtered
  out by Criterion. Also enables `debug = true` in `[profile.bench]` so samply and
  flamegraph produce readable stack traces.

  Example output:
  workload_benchmarks/10k_single_part_checkpoint/snapshot_latest/snapshot_construction
                  time:   [552 µs 558 µs 563 µs]
    [io] 10k_single_part_checkpoint/snapshot_latest/snapshot_construction
          storage  : 1 list (4 files seen)  2 read (2 files, 5 KiB)
          log replay: 1 segment load(s) -- 0 commits  1 checkpoints  0 compactions

  ## How was this change tested?

  - Ran `cargo test -p delta_kernel --all-features` and `cargo test -p delta_kernel_benchmarks` -- all pass
  - Ran `cargo bench -p delta_kernel_benchmarks --bench workload_bench "snapshot_latest"`
    and verified IO stats appear inline after each benchmark's timing output, and are
    absent for filtered-out benchmarks