### PR TITLE
refactor: Restructured list log files function

### DIFF
--- a/kernel/src/log_segment_files.rs
+++ b/kernel/src/log_segment_files.rs
@@ -225,7 +225,9 @@ impl ListingAccumulator {
 
 impl LogSegmentFiles {
     /// Assembles a `LogSegmentFiles` from `fs_files` (an iterator of files
-    /// listed from storage) and `log_tail` (catalog-provided commits)
+    /// listed from storage) and `log_tail` (catalog-provided commits).
+    // This logic is identical to the old `list()` implementation; it was extracted so that
+    // callers with different listing strategies can share the same core logic.
     fn build_log_segment_files(
         fs_files: impl Iterator<Item = DeltaResult<ParsedLogPath>>,
         log_tail: Vec<ParsedLogPath>,


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2173/files) to review incremental changes.
- [**stack/refactor-list-new**](https://github.com/delta-io/delta-kernel-rs/pull/2173) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2173/files)]
  - [stack/backward-listing-new](https://github.com/delta-io/delta-kernel-rs/pull/2174) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2174/files/40e67460b8634221ccd6ff49d93c513eded0042b..6ec5fbcbe54710675de1a30b9879e6d729fd9ee5)]
    - [stack/fallback-list-w-checkpoint-hint-new](https://github.com/delta-io/delta-kernel-rs/pull/2175) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2175/files/03bdf905e37284d3b1748f2d13b06a3e48ddc68e..bf38addb24bbfecf270582038d4d8bc576f90451)]

---------
## What changes are proposed in this pull request?

We need to move ListingAccumulator out of the scope of the list() function because we want to use it for both list() and for a list_with_backward_checkpoint_scan() function (in the later stacked PRs). 

This PR makes the following changes:
- Moves ListingAccumulator to be a top-level struct in the log_segment_files module
- Introduces build_log_segment_files which includes most of the logic previously in list(); list() delegates to this function (the goal is for list_with_backward_checkpoint_scan() to also delegate to this function in future PRs)

Note that this copies over the logic of list() and changes only two things (everything else is essentially a copy):
- group_version is tracked as a field of ListingAccumulator
- start and end are still resolved in list() so that they can be passed to list_from_storage, but start and end_version are what's passed to build_log_segment_files; end_version is passed into ListingAccumulator directly (as Option<Version>), so build_log_segment_files resolves it to Version::MAX independently from the resolution already done in list for the storage listing call (identical functionality, just mentioned because it may look like a change)

## How was this change tested?
Existing tests that call list() were run
