### PR TITLE
perf: remove dead schema conversions in expression evaluators

### DIFF
--- a/kernel/src/engine/arrow_expression/mod.rs
+++ b/kernel/src/engine/arrow_expression/mod.rs
@@ -241,12 +241,11 @@ pub struct ArrowEvaluationHandler;
 impl EvaluationHandler for ArrowEvaluationHandler {
     fn new_expression_evaluator(
         &self,
-        schema: SchemaRef,
+        _schema: SchemaRef,
         expression: ExpressionRef,
         output_type: DataType,
     ) -> DeltaResult<Arc<dyn ExpressionEvaluator>> {
         Ok(Arc::new(DefaultExpressionEvaluator {
-            input_schema: schema,
             expression,
             output_type,
         }))
@@ -254,13 +253,10 @@ impl EvaluationHandler for ArrowEvaluationHandler {
 
     fn new_predicate_evaluator(
         &self,
-        schema: SchemaRef,
+        _schema: SchemaRef,
         predicate: PredicateRef,
     ) -> DeltaResult<Arc<dyn PredicateEvaluator>> {
-        Ok(Arc::new(DefaultPredicateEvaluator {
-            input_schema: schema,
-            predicate,
-        }))
+        Ok(Arc::new(DefaultPredicateEvaluator { predicate }))
     }
 
     /// Create a single-row array with all-null leaf values. Note that if a nested struct is
@@ -279,7 +275,6 @@ impl EvaluationHandler for ArrowEvaluationHandler {
 
 #[derive(Debug)]
 pub struct DefaultExpressionEvaluator {
-    input_schema: SchemaRef,
     expression: ExpressionRef,
     output_type: DataType,
 }
@@ -288,16 +283,6 @@ impl ExpressionEvaluator for DefaultExpressionEvaluator {
     fn evaluate(&self, batch: &dyn EngineData) -> DeltaResult<Box<dyn EngineData>> {
         debug!("Arrow evaluator evaluating: {:#?}", self.expression);
         let batch = extract_record_batch(batch)?;
-        let _input_schema: ArrowSchema = self.input_schema.as_ref().try_into_arrow()?;
-        // TODO: make sure we have matching schemas for validation
-        // if batch.schema().as_ref() != &input_schema {
-        //     return Err(Error::Generic(format!(
-        //         "input schema does not match batch schema: {:?} != {:?}",
-        //         input_schema,
-        //         batch.schema()
-        //     )));
-        // };
-
         let batch = match (self.expression.as_ref(), &self.output_type) {
             (Expression::Transform(transform), DataType::Struct(_)) if transform.is_identity() => {
                 // Empty transform optimization: Skip expression evaluation and directly apply the
@@ -328,7 +313,6 @@ impl ExpressionEvaluator for DefaultExpressionEvaluator {
 
 #[derive(Debug)]
 pub struct DefaultPredicateEvaluator {
-    input_schema: SchemaRef,
     predicate: PredicateRef,
 }
 
@@ -336,15 +320,6 @@ impl PredicateEvaluator for DefaultPredicateEvaluator {
     fn evaluate(&self, batch: &dyn EngineData) -> DeltaResult<Box<dyn EngineData>> {
         debug!("Arrow evaluator evaluating: {:#?}", self.predicate);
         let batch = extract_record_batch(batch)?;
-        let _input_schema: ArrowSchema = self.input_schema.as_ref().try_into_arrow()?;
-        // TODO: make sure we have matching schemas for validation
-        // if batch.schema().as_ref() != &input_schema {
-        //     return Err(Error::Generic(format!(
-        //         "input schema does not match batch schema: {:?} != {:?}",
-        //         input_schema,
-        //         batch.schema()
-        //     )));
-        // };
         let array = evaluate_predicate(&self.predicate, batch, false)?;
         let schema = ArrowSchema::new(vec![ArrowField::new(
             "output",

--- a/kernel/src/parallel/parallel_scan_metadata.rs
+++ b/kernel/src/parallel/parallel_scan_metadata.rs
@@ -102,6 +102,8 @@ impl ParallelState {
     /// # Example
     ///
     /// ```no_run
+    /// # use std::sync::Arc;
+    /// # use delta_kernel::scan::ParallelState;
     /// # use tracing::instrument;
     /// #[instrument(skip_all, name = "parallel_scan")]
     /// async fn process(state: Arc<ParallelState>) {


### PR DESCRIPTION
The input_schema field on DefaultExpressionEvaluator and
DefaultPredicateEvaluator was only used in a commented-out TODO
validation block. Removing it eliminates one full kernel->Arrow schema
conversion per batch throughout all log replay -- pure waste on every
iteration.

Also fixes a doctest in parallel_scan_metadata.rs that was missing
hidden imports for Arc and ParallelState.

## What changes are proposed in this pull request?

<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

## How was this change tested?
