### PR TITLE
perf: pre-size HashMap in ArrowEngineData::visit_rows

### DIFF
--- a/kernel/src/engine/arrow_data.rs
+++ b/kernel/src/engine/arrow_data.rs
@@ -221,7 +221,7 @@ impl EngineData for ArrowEngineData {
         // This is used to guide our depth-first extraction. If the list contains any non-leaf,
         // duplicate, or missing column references, the extracted column list will be too
         // short (error out below).
-        let mut column_map = HashMap::new();
+        let mut column_map = HashMap::with_capacity(leaf_columns.len() * 2);
 
         for (column, data_type) in leaf_columns.iter().zip(leaf_types.iter()) {
             column_map.insert(column.clone(), ColumnState::AwaitingGetter(data_type));

--- a/kernel/src/parallel/parallel_scan_metadata.rs
+++ b/kernel/src/parallel/parallel_scan_metadata.rs
@@ -102,6 +102,8 @@ impl ParallelState {
     /// # Example
     ///
     /// ```no_run
+    /// # use std::sync::Arc;
+    /// # use delta_kernel::scan::ParallelState;
     /// # use tracing::instrument;
     /// #[instrument(skip_all, name = "parallel_scan")]
     /// async fn process(state: Arc<ParallelState>) {


### PR DESCRIPTION
visit_rows is called once per batch during log replay and builds a fresh
column map with zero pre-sizing, causing repeated hashmap growth
allocations. Pre-sizing with leaf_columns.len() * 2 (leaf entries plus
one parent slot per nesting level) eliminates rehash allocations inside
the hot path.

Follows the existing with_capacity pattern already used for the getters
Vec at the call site and throughout the codebase.

## What changes are proposed in this pull request?

<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

## How was this change tested?
