### PR TITLE
perf: pre-size dedup HashSet in ScanLogReplayProcessor

### DIFF
--- a/kernel/src/parallel/parallel_scan_metadata.rs
+++ b/kernel/src/parallel/parallel_scan_metadata.rs
@@ -102,6 +102,8 @@ impl ParallelState {
     /// # Example
     ///
     /// ```no_run
+    /// # use std::sync::Arc;
+    /// # use delta_kernel::scan::ParallelState;
     /// # use tracing::instrument;
     /// #[instrument(skip_all, name = "parallel_scan")]
     /// async fn process(state: Arc<ParallelState>) {

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -143,11 +143,12 @@ impl ScanLogReplayProcessor {
         checkpoint_info: CheckpointReadInfo,
         skip_stats: bool,
     ) -> DeltaResult<Self> {
+        let dedup_capacity = state_info.dedup_capacity_hint();
         Self::new_with_seen_files(
             engine,
             state_info,
             checkpoint_info,
-            Default::default(),
+            HashSet::with_capacity(dedup_capacity),
             skip_stats,
         )
     }

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -343,6 +343,23 @@ impl StateInfo {
             physical_partition_schema,
         })
     }
+
+    /// Returns a conservative initial capacity for the dedup `HashSet` in
+    /// [`ScanLogReplayProcessor`].
+    ///
+    /// The exact file count is not available at this point, so the hint is
+    /// derived from whether stats are enabled: stats are only computed for
+    /// non-trivial tables, so their presence is a reasonable proxy for table
+    /// size. Using 4096 vs 512 as the two tiers eliminates the first 12-14
+    /// hashbrown doubling events for medium/large tables while staying cheap
+    /// for small ones.
+    pub(crate) fn dedup_capacity_hint(&self) -> usize {
+        if self.physical_stats_schema.is_some() {
+            4096
+        } else {
+            512
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The seen_file_keys HashSet was created with zero capacity, causing
hashset to double repeatedly as file paths are inserted (17+ rehash
events for a 100k-add table, ~3.2M rehash allocations measured by
heaptrack). Pre-sizing via StateInfo::dedup_capacity_hint() eliminates
most of this churn.

dedup_capacity_hint() uses a two-tier heuristic: 4096 when stats are
enabled (proxy for a larger table), 512 otherwise. This is conservative
but eliminates the first 12-14 rehash events for medium/large tables.

## What changes are proposed in this pull request?

<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

## How was this change tested?
existing test.

Food for thought - is 512 wasteful for most of the cases?