### PR TITLE
perf: use jemalloc allocator in benchmarks

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -27,6 +27,7 @@ url = { version = "2", features = ["serde"] }
 [dev-dependencies]
 criterion = "0.5"
 rstest = "0.23"
+tikv-jemallocator = "0.6"
 
 [[bench]]
 name = "workload_bench"

--- a/benchmarks/benches/workload_bench.rs
+++ b/benchmarks/benches/workload_bench.rs
@@ -1,3 +1,6 @@
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 use std::sync::Arc;
 
 use criterion::{criterion_group, criterion_main, Criterion};


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2193/files) to review incremental changes.
- [**stack/benchmark-jemalloc**](https://github.com/delta-io/delta-kernel-rs/pull/2193) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2193/files)]

---------
Switch from the system allocator to jemalloc (tikv-jemallocator) for the benchmark harness. Profiling showed 5-6% of scan_metadata time spent in allocation, and A/B testing shows jemalloc provides a consistent 10-15% improvement across all benchmark tables.

## What changes are proposed in this pull request?

<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

## How was this change tested?
