### PR TITLE
fix: filter evaluator input schema

### DIFF
--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -115,6 +115,12 @@ impl DataSkippingFilter {
     ) -> Option<Self> {
         static FILTER_PRED: LazyLock<PredicateRef> =
             LazyLock::new(|| Arc::new(column_expr!("output").distinct(Expr::literal(false))));
+        static FILTER_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
+            Arc::new(StructType::new_unchecked([StructField::nullable(
+                "output",
+                DataType::BOOLEAN,
+            )]))
+        });
 
         let predicate = predicate?;
         debug!("Creating a data skipping filter for {:#?}", predicate);
@@ -166,14 +172,9 @@ impl DataSkippingFilter {
 
         // The filter evaluator operates on the skipping evaluator's output, which is a single
         // boolean column named "output" (not the unified stats schema).
-        let filter_schema: SchemaRef =
-            Arc::new(StructType::new_unchecked([StructField::nullable(
-                "output",
-                DataType::BOOLEAN,
-            )]));
         let filter_evaluator = engine
             .evaluation_handler()
-            .new_predicate_evaluator(filter_schema, FILTER_PRED.clone())
+            .new_predicate_evaluator(FILTER_SCHEMA.clone(), FILTER_PRED.clone())
             .inspect_err(|e| error!("Failed to create filter evaluator: {e}"))
             .ok()?;
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2195/files) to review incremental changes.
- [**stack/fix-filter-evaluator-schema**](https://github.com/delta-io/delta-kernel-rs/pull/2195) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2195/files)]

---------
## What changes are proposed in this pull request?

 The `filter_evaluator` in `DataSkippingFilter` was constructed with `unified_schema` but at runtime it receives the `skipping_evaluator`'s output 

Use the correct input schema

## How was this change tested?
