### PR TITLE
fix: Avoid creating empty stats schemas

### DIFF
--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -126,16 +126,14 @@ fn build_data_skipping_schemas(
         (Some(tps), PhysicalPredicate::Some(_, ref_schema)) => {
             // Partition values extracted from the string map via MapToStruct are always
             // nullable (map lookup can return null), so we force all partition fields nullable.
-            let fields: Vec<StructField> = ref_schema
-                .fields()
-                .filter(|f| tps.field(f.name()).is_some())
-                .map(|f| StructField::nullable(f.name(), f.data_type().clone()))
-                .collect();
-            if fields.is_empty() {
-                None
-            } else {
-                Some(Arc::new(StructType::new_unchecked(fields)))
-            }
+            ref_schema
+                .with_fields_filtered_nonempty(|f| tps.field(f.name()).is_some())?
+                .map(|partition_schema| {
+                    let nullable_fields = partition_schema
+                        .fields()
+                        .map(|f| StructField::nullable(f.name(), f.data_type().clone()));
+                    Arc::new(StructType::new_unchecked(nullable_fields))
+                })
         }
         _ => None,
     };
@@ -190,18 +188,14 @@ fn build_data_skipping_schemas(
         // Split referenced columns into data columns and partition columns.
         // Data columns get min/max/nullCount stats; partition columns get exact values.
         (_, PhysicalPredicate::Some(_, schema)) => {
-            let data_fields: Vec<StructField> = schema
-                .fields()
-                .filter(|f| {
+            let data_stats = schema
+                .with_fields_filtered_nonempty(|f| {
                     predicate_partition_schema
                         .as_ref()
-                        .is_none_or(|ps| ps.field(f.name()).is_none())
-                })
-                .cloned()
-                .collect();
-
-            let data_schema = StructType::new_unchecked(data_fields);
-            let data_stats = build_stats_schema(&data_schema);
+                        .is_none_or(|partition_schema| partition_schema.field(f.name()).is_none())
+                })?
+                .as_ref()
+                .and_then(build_stats_schema);
             Ok((data_stats, predicate_partition_schema))
         }
         // No stats output and no predicate

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -1007,6 +1007,23 @@ impl StructType {
         Self::try_new(self.fields().filter(|f| predicate(f)).cloned())
     }
 
+    /// Returns an optional [`StructType`] containing only the top-level fields for which
+    /// `predicate` returns `true`.
+    ///
+    /// This is a convenience wrapper around [`StructType::with_fields_filtered`] for callers
+    /// that treat an empty top-level struct as "no schema".
+    pub fn with_fields_filtered_nonempty(
+        &self,
+        predicate: impl Fn(&StructField) -> bool,
+    ) -> DeltaResult<Option<Self>> {
+        let filtered = self.with_fields_filtered(predicate)?;
+        if filtered.num_fields() == 0 {
+            Ok(None)
+        } else {
+            Ok(Some(filtered))
+        }
+    }
+
     /// Returns a StructType with the named field replaced.
     /// Returns an error if field doesn't exist.
     pub fn with_field_replaced(


### PR DESCRIPTION
## What changes are proposed in this pull request?

Today, it's possible to produce a stats schema with no columns (if the intersection of eligible and referenced cols is empty). Arrow code in the default engine blows up if it encounters such a schema. It all happens to work by accident today because `build_stats_schema` leverages several schema transforms, and even "non-filtering" transforms are in fact able to filter out empty structs. Once https://github.com/delta-io/delta-kernel-rs/pull/2151 introduces non-filtering transforms, the gap is exposed and unit tests start failing.

Solution: Fix the call site that was filtering out partition columns from the stats schema to return None immediately if all fields are pruned away, instead of relying implicitly on `build_stats_schema` to do it.  

## How was this change tested?

Existing unit tests confirm that the change does not break any existing code.
Meanwhile, https://github.com/delta-io/delta-kernel-rs/pull/2151 fails several unit tests without this fix.