### PR TITLE
fix: preserve loaded LazyCrc during incremental snapshot updates

### DIFF
--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -705,6 +705,14 @@ impl Snapshot {
         self.lazy_crc.cached.get()?.get().map(|arc| arc.as_ref())
     }
 
+    /// Returns the CRC version tracked by this snapshot's LazyCrc, if any.
+    ///
+    /// This is a test-only helper for integration tests to inspect the CRC version.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn crc_version_for_testing(&self) -> Option<Version> {
+        self.lazy_crc.crc_version()
+    }
+
     /// Writes a version checksum (CRC) file for this snapshot. Writers should call this after
     /// every commit because checksums enable faster snapshot loading and table state validation.
     ///

--- a/kernel/tests/crc.rs
+++ b/kernel/tests/crc.rs
@@ -533,12 +533,13 @@ async fn test_incremental_snapshot_preserves_loaded_crc() -> DeltaResult<()> {
     let incremental_v1 = Snapshot::builder_from(fresh_v0).build(engine.as_ref())?;
     assert_eq!(incremental_v1.version(), 1);
 
-    // The CRC should be loaded from the incremental update (not discarded)
+    // The CRC at v1 should be loaded from the incremental update (not discarded)
+    assert_eq!(incremental_v1.crc_version_for_testing(), Some(1));
     assert!(
         incremental_v1
             .get_current_crc_if_loaded_for_testing()
             .is_some(),
-        "CRC should be loaded after incremental snapshot update with CRC file at target version"
+        "CRC should be loaded at v1 after incremental snapshot update"
     );
 
     // Committing from this snapshot should produce a post-commit CRC (proves


### PR DESCRIPTION
## What changes are proposed in this pull request?

Incremental snapshot updates (`try_new_from_impl`) created two `LazyCrc` instances from the same CRC file — one for P&M reading and a second LazyCRC for the final snapshot. The loaded CRC data was discarded, so `compute_post_commit_crc` could not find it. This broke CRC chaining for non-clustered tables after an incremental snapshot update.

The fix determines the CRC file upfront (preferring the new segment's, falling back to the old segment's), reuses the old snapshot's `LazyCrc` when the version matches, and uses a single `LazyCrc` for both P&M reading and the final snapshot.

## How was this change tested?
1. test_incremental_snapshot_preserves_loaded_crc`: CRC survives incremental update and chains through a subsequent commit
2. `test_incremental_snapshot_old_crc_no_new_crc`: old CRC is preserved but not reported as loaded at new version (version mismatch)
3. `test_snapshot_new_from_crc`: updated to verify old CRC falls back correctly when new segment has no CRC
4. existing tests pass