### PR TITLE
fix: downgrade per-batch data skipping log from info to debug

### DIFF
--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use std::sync::{Arc, LazyLock};
 use std::time::Instant;
 
-use tracing::{debug, error, info};
+use tracing::{debug, error};
 
 use crate::actions::visitors::SelectionVectorVisitor;
 use crate::error::DeltaResult;
@@ -297,13 +297,11 @@ impl DataSkippingFilter {
         let mut visitor = SelectionVectorVisitor::default();
         visitor.visit_rows_of(selection_vector.as_ref())?;
 
-        let skipped = visitor
-            .selection_vector
-            .iter()
-            .filter(|&&kept| !kept)
-            .count();
-        if skipped > 0 {
-            info!("data skipping filtered {skipped}/{batch_len} rows from batch",);
+        if visitor.num_filtered > 0 {
+            debug!(
+                "data skipping filtered {}/{batch_len} rows from batch",
+                visitor.num_filtered
+            );
         }
 
         if let Some(metrics) = self.metrics.as_ref() {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Downgrade the per-batch "data skipping filtered X/Y rows from batch" log message from `info!` to `debug!`. This message fires once per arrow batch (O(NumFiles)), which is too noisy for info level. The same filtered count is already captured in `ScanMetrics` (`num_predicate_filtered`) and reported at info level in the scan-wide summary.

Also removes the redundant `skipped` variable -- `visitor.num_filtered` already tracks the same count.

## How was this change tested?

Existing test suite -- no behavior change, only log verbosity.