### PR TITLE
docs: Add documentation for current tags

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -71,7 +71,7 @@ Set the `BENCH_TAGS` environment variable to a comma-separated list of tags to r
 BENCH_TAGS=base cargo bench -p delta_kernel_benchmarks
 ```
 
-Built-in tags (with current table assignments - for the most up-to-date table assignments, run benchmarks locally and inspect `benchmarks/workloads/benchmarks/<table-name>/tableInfo.json` to learn about the existing tables):
+Built-in tags (with current table assignments - for the most up-to-date table assignments, run benchmarks locally and inspect `benchmarks/workloads/benchmarks/<any-existing-table-name>/tableInfo.json` to learn about the existing tables):
 - **`base`** — a base set of tables run in CI
   - Tables: `101kAdds1kCommitsSinceChkpt1Chkpt`
 - **`commit-size-scaling`** — tables for comparing how log replay time scales with the number of actions in the log; all are single-commit tables with varying action counts (100, 1k, 10k, 100k, 1M)


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds documentation for new tags added to the workloads tarball.

Current plan:
- If users want to fully understand the tables that exist and/or test their features with new tables quickly, they should run benchmarking locally
- We've added more tags for CI to be more useful in the short-term; the README explains generally what each tag is used for (along with the names of the tables that currently have those tags) and the user can decide themselves which tags they think are relevant for their PRs. After initially running benchmarking with these new tags, if the user wanted more detail on which tables were ran they can run benchmarking locally to inspect the tables more closely
- I opted to not add any more detail in the README about the specific tables that the tags correspond to (beyond the table names) because at that point, that would be just reiterating the table info. This can also get out of date from the tarball quickly.

When these new tags are approved, the tarball will be updated.

## How was this change tested?
Tarball sent to @OussamaSaoudi, can also be sent to anyone else if they want to inspect the tables (but the README changes describe which tables have the updated tags)