### PR TITLE
refactor: prepare kernel internals for default engine crate split

### DIFF
--- a/kernel/src/column_trie.rs
+++ b/kernel/src/column_trie.rs
@@ -6,6 +6,8 @@
 
 use std::collections::HashMap;
 
+use delta_kernel_derive::internal_api;
+
 use crate::expressions::ColumnName;
 
 /// A trie (prefix tree) for efficient column path matching.
@@ -17,6 +19,7 @@ use crate::expressions::ColumnName;
 /// `is_terminal = false`. This is used both for creating a new root trie and for
 /// creating intermediate nodes during insertion (via `or_default()`).
 #[derive(Debug, Default)]
+#[internal_api]
 pub(crate) struct ColumnTrie<'col> {
     children: HashMap<&'col str, ColumnTrie<'col>>,
     /// True if this node represents the end of a specified column path.
@@ -27,6 +30,7 @@ pub(crate) struct ColumnTrie<'col> {
 
 impl<'col> ColumnTrie<'col> {
     /// Creates an empty trie.
+    #[internal_api]
     pub(crate) fn new() -> Self {
         Self::default()
     }
@@ -40,6 +44,7 @@ impl<'col> ColumnTrie<'col> {
     ///     ├── "b" (is_terminal=true)
     ///     └── "c" (is_terminal=true)
     /// ```
+    #[internal_api]
     pub(crate) fn from_columns(columns: &'col [ColumnName]) -> Self {
         let mut trie = Self::new();
         for column in columns {
@@ -61,6 +66,7 @@ impl<'col> ColumnTrie<'col> {
     ///     └── "b" (is_terminal=false)
     ///         └── "c" (is_terminal=true)
     /// ```
+    #[internal_api]
     pub(crate) fn insert(&mut self, column: &'col ColumnName) {
         let mut node = self;
         for part in column.iter() {
@@ -76,6 +82,7 @@ impl<'col> ColumnTrie<'col> {
     /// - `["a", "b", "c"]` → true (descendant)
     /// - `["a"]` → false (ancestor, not descendant)
     /// - `["a", "x"]` → false (divergent path)
+    #[internal_api]
     pub(crate) fn contains_prefix_of(&self, path: &[String]) -> bool {
         let mut node = self;
         for part in path {

--- a/kernel/src/engine/arrow_utils.rs
+++ b/kernel/src/engine/arrow_utils.rs
@@ -90,9 +90,8 @@ struct MatchedParquetField<'p, 'k> {
     kernel_field_info: Option<KernelFieldInfo<'k>>,
 }
 
-/// Get the indices in `parquet_schema` of the specified columns in `requested_schema`. This
-/// returns a tuples of (mask_indices: Vec<parquet_schema_index>, reorder_indices:
-/// Vec<requested_index>). `mask_indices` is used for generating the mask for reading from the
+/// Create an [`Error::Arrow`] with a backtrace from the given message.
+#[internal_api]
 pub(crate) fn make_arrow_error(s: impl Into<String>) -> Error {
     Error::Arrow(crate::arrow::error::ArrowError::InvalidArgumentError(
         s.into(),
@@ -101,12 +100,14 @@ pub(crate) fn make_arrow_error(s: impl Into<String>) -> Error {
 }
 
 /// Prepares to enumerate row indexes of rows in a parquet file, accounting for row group skipping.
+#[internal_api]
 pub(crate) struct RowIndexBuilder {
     row_group_row_index_ranges: Vec<Range<i64>>,
     row_group_ordinals: Option<Vec<usize>>,
 }
 
 impl RowIndexBuilder {
+    #[internal_api]
     pub(crate) fn new(row_groups: &[RowGroupMetaData]) -> Self {
         let mut row_group_row_index_ranges = Vec::with_capacity(row_groups.len());
         let mut offset = 0;
@@ -123,6 +124,7 @@ impl RowIndexBuilder {
 
     /// Only produce row indexes for the row groups specified by the ordinals that survived row
     /// group skipping. The ordinals must be in 0..num_row_groups.
+    #[internal_api]
     pub(crate) fn select_row_groups(&mut self, ordinals: &[usize]) {
         // NOTE: Don't apply the filtering until we actually build the iterator, because the
         // filtering is not idempotent and `with_row_groups` could be called more than once.
@@ -134,6 +136,7 @@ impl RowIndexBuilder {
     /// # Errors
     ///
     /// Returns an error if there are duplicate or out of bounds row group ordinals.
+    #[internal_api]
     pub(crate) fn build(self) -> DeltaResult<FlattenedRangeIterator<i64>> {
         let starting_offsets = match self.row_group_ordinals {
             Some(ordinals) => {
@@ -167,6 +170,7 @@ impl RowIndexBuilder {
 /// `row_indexes` are passed through to `reorder_struct_array`.
 /// `file_location` is used to populate file metadata columns if requested.
 /// If `target_schema` is provided, coerces the batch's field nullability to match it.
+#[internal_api]
 pub(crate) fn fixup_parquet_read(
     batch: RecordBatch,
     requested_ordering: &[ReorderIndex],
@@ -539,12 +543,14 @@ pub(crate) fn coerce_batch_nullability(
 /// output. The `transform` indicates what, if any, transforms are needed. See the docs for
 /// [`ReorderIndexTransform`] for the meaning.
 #[derive(Debug, PartialEq)]
+#[internal_api]
 pub(crate) struct ReorderIndex {
-    pub(crate) index: usize,
+    pub index: usize,
     transform: ReorderIndexTransform,
 }
 
 #[derive(Debug, PartialEq)]
+#[internal_api]
 pub(crate) enum ReorderIndexTransform {
     /// For a non-nested type, indicates that we need to cast to the contained type
     Cast(ArrowDataType),
@@ -996,6 +1002,7 @@ fn match_parquet_fields<'k, 'p>(
 /// file set to the index of the requested column in the parquet. `reorder_indices` is used for
 /// re-ordering. See the documentation for [`ReorderIndex`] to understand what each element in the
 /// returned array means.
+#[internal_api]
 pub(crate) fn get_requested_indices(
     requested_schema: &SchemaRef,
     parquet_schema: &ArrowSchemaRef,
@@ -1012,6 +1019,7 @@ pub(crate) fn get_requested_indices(
 
 /// Create a mask that will only select the specified indices from the parquet. `indices` can be
 /// computed from a [`Schema`] using [`get_requested_indices`]
+#[internal_api]
 pub(crate) fn generate_mask(
     _requested_schema: &SchemaRef,
     _parquet_schema: &ArrowSchemaRef,
@@ -1050,6 +1058,7 @@ fn ordering_needs_transform(requested_ordering: &[ReorderIndex]) -> bool {
 ///
 /// The function only checks if a RowIndex transform is present at the top-level, since metadata
 /// columns are not allowed to be nested.
+#[internal_api]
 pub(crate) fn ordering_needs_row_indexes(requested_ordering: &[ReorderIndex]) -> bool {
     requested_ordering
         .iter()
@@ -1485,6 +1494,7 @@ pub(crate) fn to_json_bytes(
 ///
 /// `reorder_indices` should be built once per schema via [`build_json_reorder_indices`] and
 /// reused for every batch from the same file.
+#[internal_api]
 pub(crate) fn fixup_json_read(
     batch: RecordBatch,
     reorder_indices: &[ReorderIndex],
@@ -1498,16 +1508,17 @@ pub(crate) fn fixup_json_read(
 ///
 /// The JSON reader is given a schema with metadata columns stripped (see [`json_arrow_schema`]).
 /// Its output therefore has non-metadata columns at contiguous indices 0..N in schema order.
-/// This function maps those source indices — and any metadata column specs — into a
-/// `Vec<ReorderIndex>` that [`reorder_struct_array`] can use to produce the final batch with
+/// This function maps those source indices -- and any metadata column specs -- into a
+/// `Vec<ReorderIndex>` that `reorder_struct_array` can use to produce the final batch with
 /// every column at its correct position.
 ///
 /// Build the index vec once per schema (e.g. once per file); apply it to every batch produced
-/// by the reader via [`reorder_struct_array`].
+/// by the reader via `reorder_struct_array`.
 ///
 /// # Companion function
 /// - Use [`json_arrow_schema`] to strip metadata columns before passing the schema to the JSON
 ///   reader.
+#[internal_api]
 pub(crate) fn build_json_reorder_indices(schema: &StructType) -> DeltaResult<Vec<ReorderIndex>> {
     // Real columns: position in reorder_indices IS the source column index (0..N in schema
     // order), and reorder_index.index carries the output position.
@@ -1541,8 +1552,9 @@ pub(crate) fn build_json_reorder_indices(schema: &StructType) -> DeltaResult<Vec
 /// omitting any fields annotated with [`MetadataColumnSpec`].
 ///
 /// Pass the returned schema to Arrow's JSON reader; then call [`build_json_reorder_indices`]
-/// once on the same schema and apply [`reorder_struct_array`] to each resulting batch to
+/// once on the same schema and apply `reorder_struct_array` to each resulting batch to
 /// insert the synthesized metadata columns at their correct positions.
+#[internal_api]
 pub(crate) fn json_arrow_schema(schema: &StructType) -> DeltaResult<ArrowSchema> {
     let json_fields = schema.with_fields_filtered(|f| f.get_metadata_column_spec().is_none())?;
     Ok(ArrowSchema::try_from_kernel(&json_fields)?)

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -11,10 +11,8 @@ use crate::arrow::array::{Array, Int64Array, RecordBatch, StringArray, StructArr
 use crate::arrow::datatypes::{DataType, Field, Schema};
 use crate::object_store::path::Path;
 use crate::object_store::{DynObjectStore, ObjectStoreExt as _};
-use crate::parquet::arrow::arrow_reader::{
-    ArrowReaderMetadata, ArrowReaderOptions, ParquetRecordBatchReaderBuilder,
-};
-use crate::parquet::arrow::arrow_writer::{ArrowWriter, ArrowWriterOptions};
+use crate::parquet::arrow::arrow_reader::{ArrowReaderMetadata, ParquetRecordBatchReaderBuilder};
+use crate::parquet::arrow::arrow_writer::ArrowWriter;
 use crate::parquet::arrow::async_reader::{ParquetObjectReader, ParquetRecordBatchStreamBuilder};
 use crate::parquet::arrow::async_writer::AsyncArrowWriter;
 use crate::parquet::arrow::async_writer::ParquetObjectWriter;
@@ -41,21 +39,7 @@ use crate::{
     ParquetHandler, PredicateRef,
 };
 
-/// Returns the standard [`ArrowReaderOptions`] for all kernel parquet reads.
-///
-/// Skipping the embedded Arrow IPC schema avoids dependence on Arrow-specific metadata and
-/// ensures that type resolution is driven by the kernel schema rather than the file's schema.
-pub(in crate::engine) fn reader_options() -> ArrowReaderOptions {
-    ArrowReaderOptions::new().with_skip_arrow_metadata(true)
-}
-
-/// Returns the standard [`ArrowWriterOptions`] for all kernel parquet writes.
-///
-/// Omitting the Arrow IPC schema from the file metadata keeps Delta files interoperable with
-/// non-Arrow readers and avoids encoding Arrow-specific type information.
-pub(in crate::engine) fn writer_options() -> ArrowWriterOptions {
-    ArrowWriterOptions::new().with_skip_arrow_metadata(true)
-}
+use crate::engine::{reader_options, writer_options};
 
 #[derive(Debug)]
 pub struct DefaultParquetHandler<E: TaskExecutor> {

--- a/kernel/src/engine/ensure_data_types.rs
+++ b/kernel/src/engine/ensure_data_types.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use crate::arrow::datatypes::{DataType as ArrowDataType, Field as ArrowField, TimeUnit};
+use delta_kernel_derive::internal_api;
 use itertools::Itertools;
 
 use super::arrow_conversion::TryIntoArrow as _;
@@ -18,6 +19,7 @@ use crate::{
 
 /// Controls how `ensure_data_types` validates struct fields and metadata.
 #[derive(Clone, Copy)]
+#[internal_api]
 pub(crate) enum ValidationMode {
     /// Check types only. Struct fields are matched by ordinal position, not by name.
     /// Nullability and metadata are not checked. Used by the expression evaluator where
@@ -42,6 +44,7 @@ pub(crate) enum ValidationMode {
 /// there is a `struct` type included and the mode uses name-based matching, we only ensure that
 /// the named fields that the kernel is asking for exist, and that for those fields the types
 /// match. Un-selected fields are ignored.
+#[internal_api]
 pub(crate) fn ensure_data_types(
     kernel_type: &DataType,
     arrow_type: &ArrowDataType,
@@ -57,6 +60,7 @@ struct EnsureDataTypes {
 
 /// Capture the compatibility between two data-types, as passed to [`ensure_data_types`]
 #[cfg_attr(test, derive(Debug, PartialEq))]
+#[internal_api]
 pub(crate) enum DataTypeCompat {
     /// The two types are the same
     Identical,

--- a/kernel/src/engine/mod.rs
+++ b/kernel/src/engine/mod.rs
@@ -2,12 +2,37 @@
 //! be built into the kernel by setting the `default-engine` feature flag. See the related module
 //! for more information.
 
+#[cfg(feature = "arrow-expression")]
+use crate::parquet::arrow::arrow_reader::ArrowReaderOptions;
+#[cfg(feature = "arrow-expression")]
+use crate::parquet::arrow::arrow_writer::ArrowWriterOptions;
+
+/// Returns the standard [`ArrowReaderOptions`] for all default engine parquet reads.
+///
+/// Skipping the embedded Arrow IPC schema avoids dependence on Arrow-specific metadata and
+/// ensures that type resolution is driven by the kernel schema rather than the file's schema.
+#[cfg(feature = "arrow-expression")]
+pub(crate) fn reader_options() -> ArrowReaderOptions {
+    ArrowReaderOptions::new().with_skip_arrow_metadata(true)
+}
+
+/// Returns the standard [`ArrowWriterOptions`] for all kernel parquet writes.
+///
+/// Omitting the Arrow IPC schema from the file metadata keeps Delta files interoperable with
+/// non-Arrow readers and avoids encoding Arrow-specific type information.
+#[cfg(feature = "arrow-expression")]
+pub(crate) fn writer_options() -> ArrowWriterOptions {
+    ArrowWriterOptions::new().with_skip_arrow_metadata(true)
+}
+
 #[cfg(feature = "arrow-conversion")]
 pub mod arrow_conversion;
 
 #[cfg(all(feature = "arrow-expression", feature = "default-engine-base"))]
 pub mod arrow_expression;
-#[cfg(feature = "arrow-expression")]
+#[cfg(all(feature = "arrow-expression", feature = "internal-api"))]
+pub mod arrow_utils;
+#[cfg(all(feature = "arrow-expression", not(feature = "internal-api")))]
 pub(crate) mod arrow_utils;
 #[cfg(feature = "internal-api")]
 pub use self::arrow_utils::{parse_json, to_json_bytes};
@@ -22,9 +47,12 @@ pub(crate) mod sync;
 pub mod arrow_data;
 #[cfg(feature = "default-engine-base")]
 pub(crate) mod arrow_get_data;
-#[cfg(feature = "default-engine-base")]
+#[cfg(all(feature = "default-engine-base", feature = "internal-api"))]
+pub mod ensure_data_types;
+#[cfg(all(feature = "default-engine-base", not(feature = "internal-api")))]
 pub(crate) mod ensure_data_types;
 #[cfg(feature = "default-engine-base")]
+// module is always pub; trait inside is gated by #[internal_api]
 pub mod parquet_row_group_skipping;
 
 #[cfg(test)]

--- a/kernel/src/engine/parquet_row_group_skipping.rs
+++ b/kernel/src/engine/parquet_row_group_skipping.rs
@@ -1,4 +1,6 @@
 //! An implementation of parquet row group skipping using data skipping predicates over footer stats.
+use delta_kernel_derive::internal_api;
+
 use crate::engine::arrow_utils::RowIndexBuilder;
 use crate::expressions::{ColumnName, DecimalData, Predicate, Scalar};
 use crate::kernel_predicates::parquet_stats_skipping::ParquetStatsProvider;
@@ -15,6 +17,7 @@ use tracing::debug;
 mod tests;
 
 /// An extension trait for [`ArrowReaderBuilder`] that injects row group skipping capability.
+#[internal_api]
 pub(crate) trait ParquetRowGroupSkipping {
     /// Instructs the parquet reader to perform row group skipping, eliminating any row group whose
     /// stats prove that none of the group's rows can satisfy the given `predicate`.

--- a/kernel/src/engine/sync/parquet.rs
+++ b/kernel/src/engine/sync/parquet.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 use std::sync::Arc;
 
-use crate::engine::default::parquet::{reader_options, writer_options};
+use crate::engine::{reader_options, writer_options};
 use crate::parquet::arrow::arrow_reader::{ArrowReaderMetadata, ParquetRecordBatchReaderBuilder};
 
 use super::read_files;

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -120,6 +120,9 @@ mod arrow_compat;
 #[cfg(any(feature = "arrow-57", feature = "arrow-58"))]
 pub use arrow_compat::*;
 
+#[cfg(feature = "internal-api")]
+pub mod column_trie;
+#[cfg(not(feature = "internal-api"))]
 pub(crate) mod column_trie;
 pub mod kernel_predicates;
 pub(crate) mod utils;


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2226/files) to review incremental changes.
- [**stack/expand-core-visibility**](https://github.com/delta-io/delta-kernel-rs/pull/2226) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2226/files)]
  - [stack/extract-default-engine](https://github.com/delta-io/delta-kernel-rs/pull/2227) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2227/files/b5bef727e8053863fd1d75b33b10efe0b01638db..7537f151b840d45d69c783afd2a8531ef1bbb985)]
    - [stack/migrate-dependents](https://github.com/delta-io/delta-kernel-rs/pull/2228) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2228/files/7537f151b840d45d69c783afd2a8531ef1bbb985..86a5343f2e37c3fd8c9f8e6a0f7ad788ab8dcfff)]
      - [stack/remove-old-default-engine](https://github.com/delta-io/delta-kernel-rs/pull/2229) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2229/files/86a5343f2e37c3fd8c9f8e6a0f7ad788ab8dcfff..b3afbd18e7d2253ca46d375dd7eadb5b800bc591)]
        - [stack/enhance-sync-engine](https://github.com/delta-io/delta-kernel-rs/pull/2230) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2230/files/b3afbd18e7d2253ca46d375dd7eadb5b800bc591..ec13153437f55a7c253f93ec69f50d4e142f23d0)]
          - [stack/migrate-tests-to-sync-engine](https://github.com/delta-io/delta-kernel-rs/pull/2231) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2231/files/ec13153437f55a7c253f93ec69f50d4e142f23d0..565183f402b0c9d0617707e93f487961e34aefb0)]
            - [stack/crate-split-cleanup](https://github.com/delta-io/delta-kernel-rs/pull/2232) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2232/files/565183f402b0c9d0617707e93f487961e34aefb0..6db3ac418597a48e2536a89bbb70e2bbf8660658)]

---------
## What changes are proposed in this pull request?

First PR in a stack that extracts `DefaultEngine` into its own crate. See #847.

Moves `reader_options()`/`writer_options()` to `engine/mod.rs` and adds `#[internal_api]` to ~15 items the new crate will need across the boundary (`arrow_utils`, `column_trie`, `ensure_data_types`, `parquet_row_group_skipping`, etc). Uses dual `#[cfg]` for module visibility since `#[internal_api]` doesn't work on `mod` declarations.

No functional changes.

## How was this change tested?

`cargo nextest run -p delta_kernel --all-features`