### PR TITLE
feat: extract default engine into separate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1327,6 +1327,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "delta_kernel_default_engine"
+version = "0.20.0"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "delta_kernel",
+ "futures",
+ "hdfs-native-object-store",
+ "itertools 0.14.0",
+ "reqwest 0.13.2",
+ "rstest",
+ "serde_json",
+ "tempfile",
+ "test_utils",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "delta_kernel_derive"
 version = "0.21.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "acceptance",
     "benchmarks",
+    "default-engine",
     "derive-macros",
     "ffi",
     "kernel",

--- a/default-engine/Cargo.toml
+++ b/default-engine/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "delta_kernel_default_engine"
+description = "Default Arrow/Tokio-based engine implementation for delta_kernel."
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+readme.workspace = true
+version.workspace = true
+rust-version.workspace = true
+
+# for cargo-release
+[package.metadata.release]
+release = false
+
+[dependencies]
+delta_kernel = { path = "../kernel", features = [
+  "arrow-conversion",
+  "arrow-expression",
+  "internal-api",
+] }
+bytes = "1.10"
+futures = "0.3"
+itertools = "0.14"
+reqwest = { version = "0.13", default-features = false, features = ["charset", "http2", "system-proxy"] }
+tokio = { version = "1.47", features = ["rt-multi-thread"] }
+url = "2"
+uuid = { version = "1.18.0", features = ["v4"] }
+
+[features]
+default = []
+arrow = ["arrow-58"]
+arrow-58 = ["delta_kernel/arrow-58"]
+arrow-57 = ["delta_kernel/arrow-57"]
+native-tls = ["reqwest/native-tls"]
+rustls = ["reqwest/rustls"]
+
+[dev-dependencies]
+async-trait = "0.1"
+rstest = "0.23"
+serde_json = "1"
+tempfile = "3"
+test_utils = { path = "../test-utils", default-features = false }
+tokio = { version = "1.47", features = ["rt-multi-thread", "macros"] }
+tracing = { version = "0.1", features = ["log"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
+hdfs-native-object-store = { version = "0.16.0" }

--- a/default-engine/src/executor.rs
+++ b/default-engine/src/executor.rs
@@ -1,0 +1,501 @@
+// TODO: (#1112) remove panics in this file
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::expect_used)]
+#![allow(clippy::panic)]
+
+//! The default engine uses Async IO to read files, but the kernel APIs are all
+//! synchronous. Therefore, we need an executor to run the async IO on in the
+//! background.
+//!
+//! A generic trait [TaskExecutor] can be implemented with your preferred async
+//! runtime. Behind the `tokio` feature flag, we provide a both a single-threaded
+//! and multi-threaded executor based on Tokio.
+use futures::{future::BoxFuture, Future};
+
+use delta_kernel::DeltaResult;
+
+/// An executor that can be used to run async tasks. This is used by IO functions
+/// within the `DefaultEngine`.
+///
+/// This must be capable of running within an async context and running futures
+/// on another thread. This could be a multi-threaded runtime, like Tokio's or
+/// could be a single-threaded runtime on a background thread.
+pub trait TaskExecutor: Send + Sync + 'static {
+    /// The type of guard returned for `enter`
+    type Guard<'a>
+    where
+        Self: 'a;
+
+    /// Block on the given future, returning its output.
+    ///
+    /// This should NOT panic if called within an async context. Thus it can't
+    /// be implemented by `tokio::runtime::Runtime::block_on`.
+    fn block_on<T>(&self, task: T) -> T::Output
+    where
+        T: Future + Send + 'static,
+        T::Output: Send + 'static;
+
+    /// Run the future in the background.
+    fn spawn<F>(&self, task: F)
+    where
+        F: Future<Output = ()> + Send + 'static;
+
+    fn spawn_blocking<T, R>(&self, task: T) -> BoxFuture<'_, DeltaResult<R>>
+    where
+        T: FnOnce() -> R + Send + 'static,
+        R: Send + 'static;
+
+    /// Enter the runtime context of this executor.
+    fn enter(&self) -> Self::Guard<'_>;
+}
+
+pub mod tokio {
+    use super::TaskExecutor;
+    use futures::TryFutureExt;
+    use futures::{future::BoxFuture, Future};
+    use std::mem::ManuallyDrop;
+    use std::sync::mpsc::channel;
+    use tokio::runtime::{EnterGuard, Handle, RuntimeFlavor};
+
+    use delta_kernel::{DeltaResult, Error};
+
+    /// A [`TaskExecutor`] that uses the tokio single-threaded runtime in a
+    /// background thread to service tasks.
+    ///
+    /// On drop, the background thread is joined to ensure the runtime is fully
+    /// shut down before the executor is destroyed.
+    #[derive(Debug)]
+    pub struct TokioBackgroundExecutor {
+        sender: ManuallyDrop<tokio::sync::mpsc::Sender<BoxFuture<'static, ()>>>,
+        handle: Handle,
+        /// `Option` because `join` takes ownership; we `take` it in `Drop` to move the
+        /// handle out. Never `None` outside of `Drop`.
+        thread: Option<std::thread::JoinHandle<()>>,
+    }
+
+    impl Drop for TokioBackgroundExecutor {
+        fn drop(&mut self) {
+            // SAFETY: The inner `Sender` has not been dropped yet because this is
+            // the only drop site and `Drop::drop` runs exactly once.
+            // Drop sender first to close the channel, signaling the background
+            // thread to exit its recv loop.
+            unsafe { ManuallyDrop::drop(&mut self.sender) };
+            // Join the thread so that runtime shutdown completes before we return.
+            if let Some(thread) = self.thread.take() {
+                let _ = thread.join();
+            }
+        }
+    }
+
+    impl Default for TokioBackgroundExecutor {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl TokioBackgroundExecutor {
+        pub fn new() -> Self {
+            let (handle_sender, handle_receiver) = std::sync::mpsc::channel::<Handle>();
+            let (sender, mut receiver) = tokio::sync::mpsc::channel::<BoxFuture<'_, ()>>(50);
+            let thread = std::thread::spawn(move || {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                let handle = rt.handle().clone();
+                handle_sender.send(handle).unwrap();
+                rt.block_on(async move {
+                    while let Some(task) = receiver.recv().await {
+                        tokio::task::spawn(task);
+                    }
+                });
+            });
+            let handle = handle_receiver.recv().unwrap();
+            Self {
+                sender: ManuallyDrop::new(sender),
+                handle,
+                thread: Some(thread),
+            }
+        }
+    }
+
+    impl TokioBackgroundExecutor {
+        fn send_future(&self, fut: BoxFuture<'static, ()>) {
+            // We cannot call `blocking_send()` because that calls `block_on`
+            // internally and panics if called within an async context. 🤦
+            let mut fut = Some(fut);
+            loop {
+                match self.sender.try_send(fut.take().unwrap()) {
+                    Ok(()) => break,
+                    Err(tokio::sync::mpsc::error::TrySendError::Full(original)) => {
+                        std::thread::yield_now();
+                        fut.replace(original);
+                    }
+                    Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                        panic!("TokioBackgroundExecutor channel closed")
+                    }
+                };
+            }
+        }
+    }
+
+    impl TaskExecutor for TokioBackgroundExecutor {
+        type Guard<'a> = EnterGuard<'a>;
+
+        fn block_on<T>(&self, task: T) -> T::Output
+        where
+            T: Future + Send + 'static,
+            T::Output: Send + 'static,
+        {
+            // We cannot call `tokio::runtime::Runtime::block_on` here because
+            // it panics if called within an async context. So instead we spawn
+            // the future on the runtime and send the result back using a channel.
+            let (sender, receiver) = channel::<T::Output>();
+
+            let fut = Box::pin(async move {
+                let task_output = task.await;
+                tokio::task::spawn_blocking(move || {
+                    sender.send(task_output).ok();
+                })
+                .await
+                .unwrap();
+            });
+
+            self.send_future(fut);
+
+            receiver
+                .recv()
+                .expect("TokioBackgroundExecutor has crashed")
+        }
+
+        fn spawn<F>(&self, task: F)
+        where
+            F: Future<Output = ()> + Send + 'static,
+        {
+            self.send_future(Box::pin(task));
+        }
+
+        fn spawn_blocking<T, R>(&self, task: T) -> BoxFuture<'_, DeltaResult<R>>
+        where
+            T: FnOnce() -> R + Send + 'static,
+            R: Send + 'static,
+        {
+            Box::pin(tokio::task::spawn_blocking(task).map_err(Error::join_failure))
+        }
+
+        fn enter(&self) -> EnterGuard<'_> {
+            self.handle.enter()
+        }
+    }
+
+    /// A [`TaskExecutor`] that uses the tokio multi-threaded runtime.
+    ///
+    /// You can create one based on a handle to an existing runtime (to share
+    /// the runtime with other parts of your application), or create one that
+    /// owns its own runtime.
+    #[derive(Debug)]
+    pub struct TokioMultiThreadExecutor {
+        handle: tokio::runtime::Handle,
+        /// If Some, this executor owns the runtime and will keep it alive.
+        /// If None, the executor borrows an external runtime via `handle`.
+        _runtime: Option<tokio::runtime::Runtime>,
+    }
+
+    impl TokioMultiThreadExecutor {
+        /// Create a new executor that uses an existing runtime's handle.
+        pub fn new(handle: tokio::runtime::Handle) -> Self {
+            assert_eq!(
+                handle.runtime_flavor(),
+                RuntimeFlavor::MultiThread,
+                "TokioExecutor must be created with a multi-threaded runtime"
+            );
+            Self {
+                handle,
+                _runtime: None,
+            }
+        }
+
+        /// Create a new executor that owns its own multi-threaded Tokio runtime.
+        ///
+        /// # Parameters
+        /// - `worker_threads`: Number of worker threads. If `None`, uses Tokio's default.
+        ///   See [`tokio::runtime::Builder::worker_threads`].
+        /// - `max_blocking_threads`: Maximum number of threads for blocking operations.
+        ///   If `None`, uses Tokio's default. See [`tokio::runtime::Builder::max_blocking_threads`].
+        ///
+        /// # Errors
+        /// Returns an error if the runtime cannot be created.
+        pub fn new_owned_runtime(
+            worker_threads: Option<usize>,
+            max_blocking_threads: Option<usize>,
+        ) -> DeltaResult<Self> {
+            let mut builder = tokio::runtime::Builder::new_multi_thread();
+            builder.enable_all();
+
+            if let Some(threads) = worker_threads {
+                builder.worker_threads(threads);
+            }
+            if let Some(max_blocking) = max_blocking_threads {
+                builder.max_blocking_threads(max_blocking);
+            }
+
+            let runtime = builder
+                .build()
+                .map_err(|e| Error::generic(format!("Failed to create Tokio runtime: {e}")))?;
+
+            let handle = runtime.handle().clone();
+            Ok(Self {
+                handle,
+                _runtime: Some(runtime),
+            })
+        }
+    }
+
+    impl TaskExecutor for TokioMultiThreadExecutor {
+        type Guard<'a> = EnterGuard<'a>;
+
+        // `block_on` uses `block_in_place`; If concurrent `block_on` calls exceed Tokio's `max_blocking_threads`, this can deadlock
+        // See:
+        // https://docs.rs/tokio/latest/tokio/runtime/struct.Builder.html#method.max_blocking_threads
+        fn block_on<T>(&self, task: T) -> T::Output
+        where
+            T: Future + Send + 'static,
+            T::Output: Send + 'static,
+        {
+            // We cannot call `tokio::runtime::Runtime::block_on` here because
+            // it panics if called within an async context. So instead we spawn
+            // the future on the runtime and send the result back using a channel.
+            let (sender, receiver) = channel::<T::Output>();
+
+            let fut = Box::pin(async move {
+                let task_output = task.await;
+                tokio::task::spawn_blocking(move || {
+                    sender.send(task_output).ok();
+                })
+                .await
+                .unwrap();
+            });
+
+            // We throw away the handle, but it should continue on.
+            self.handle.spawn(fut);
+
+            let recv = || {
+                receiver
+                    .recv()
+                    .expect("TokioMultiThreadExecutor has crashed")
+            };
+
+            if tokio::runtime::Handle::try_current().is_ok() {
+                // Use block_in_place to tell Tokio we're about to block - this allows
+                // the runtime to move tasks off this worker's local queue so they can
+                // be stolen by other workers. Only use block_in_place if we're inside
+                // a Tokio runtime.
+                tokio::task::block_in_place(recv)
+            } else {
+                // If we're not inside a Tokio runtime, we can't use block_in_place,
+                // so we just block on the receiver.
+                recv()
+            }
+        }
+
+        fn spawn<F>(&self, task: F)
+        where
+            F: Future<Output = ()> + Send + 'static,
+        {
+            self.handle.spawn(task);
+        }
+
+        fn spawn_blocking<T, R>(&self, task: T) -> BoxFuture<'_, DeltaResult<R>>
+        where
+            T: FnOnce() -> R + Send + 'static,
+            R: Send + 'static,
+        {
+            Box::pin(tokio::task::spawn_blocking(task).map_err(Error::join_failure))
+        }
+
+        fn enter(&self) -> EnterGuard<'_> {
+            self.handle.enter()
+        }
+    }
+
+    #[cfg(test)]
+    mod test {
+        use super::*;
+
+        async fn test_executor(executor: impl TaskExecutor) {
+            // Can run a task
+            let task = async {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                2 + 2
+            };
+            let result = executor.block_on(task);
+            assert_eq!(result, 4);
+
+            // Can spawn a task
+            let (sender, receiver) = channel::<i32>();
+            executor.spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                sender.send(2 + 2).unwrap();
+            });
+            let result = receiver.recv().unwrap();
+            assert_eq!(result, 4);
+        }
+
+        #[tokio::test]
+        async fn test_tokio_background_executor() {
+            let executor = TokioBackgroundExecutor::new();
+            test_executor(executor).await;
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+        async fn test_tokio_multi_thread_executor() {
+            let executor = TokioMultiThreadExecutor::new(tokio::runtime::Handle::current());
+            test_executor(executor).await;
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn test_nested_block_on_does_not_deadlock() {
+            use std::sync::Arc;
+            use std::time::Duration;
+
+            let executor = Arc::new(TokioMultiThreadExecutor::new(
+                tokio::runtime::Handle::current(),
+            ));
+            let executor_clone = executor.clone();
+
+            let (tx, rx) = channel::<i32>();
+
+            let handle = std::thread::spawn(move || {
+                // Outer block_on
+                let result = executor.block_on(async move {
+                    // Inner block_on
+                    let inner_result = executor_clone.block_on(async {
+                        tokio::time::sleep(Duration::from_millis(1)).await;
+                        42
+                    });
+                    inner_result + 1
+                });
+                tx.send(result).ok();
+            });
+
+            // Wait with timeout - if this times out, we have a deadlock
+            let timeout = Duration::from_secs(5);
+            let result = rx
+                .recv_timeout(timeout)
+                .expect("Timeout - likely deadlock in TokioMultiThreadExecutor::block_on");
+            assert_eq!(result, 43);
+            handle.join().expect("thread panicked");
+        }
+
+        #[test]
+        fn test_tokio_multi_thread_executor_owned_runtime() {
+            let executor = TokioMultiThreadExecutor::new_owned_runtime(None, None)
+                .expect("Failed to create executor");
+
+            // Test block_on works
+            let result = executor.block_on(async {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                2 + 2
+            });
+            assert_eq!(result, 4, "block_on should return the correct result");
+
+            // Test spawn works
+            let (sender, receiver) = channel::<i32>();
+            executor.spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                sender.send(2 + 2).unwrap();
+            });
+            let result = receiver.recv().expect("spawn task should send result");
+            assert_eq!(result, 4, "spawned task should compute correct result");
+        }
+
+        #[test]
+        fn test_owned_runtime_small_pool_nested_block_on_deadlocks() {
+            use std::sync::Arc;
+            use std::time::Duration;
+
+            // Create a small pool
+            let executor = Arc::new(
+                TokioMultiThreadExecutor::new_owned_runtime(Some(1), Some(1))
+                    .expect("Failed to create executor"),
+            );
+            let e1 = executor.clone();
+            let e2 = executor.clone();
+            let e3 = executor.clone();
+
+            let (tx, rx) = channel::<i32>();
+
+            // Spawn a thread to do deeply nested block_on calls
+            std::thread::spawn(move || {
+                let result = executor.block_on(async move {
+                    e1.block_on(async move {
+                        e2.block_on(async move {
+                            e3.block_on(async {
+                                tokio::time::sleep(Duration::from_millis(1)).await;
+                                42
+                            })
+                        })
+                    })
+                });
+                tx.send(result).ok();
+            });
+
+            // With 1 worker thread, 1 blocking thread and 4 nested block_on calls, this should deadlock
+            let timeout = Duration::from_millis(500);
+            let result = rx.recv_timeout(timeout);
+
+            // Test passes if we got a timeout (deadlock occurred as expected)
+            // Test fails if we got a result (no deadlock - unexpected)
+            assert!(
+                result.is_err(),
+                "Expected deadlock with 1 worker thread, 1 blocking thread and 4 nested block_on calls",
+            );
+        }
+
+        #[test]
+        fn test_block_on_works_outside_tokio_runtime() {
+            let executor = TokioMultiThreadExecutor::new_owned_runtime(None, None)
+                .expect("Failed to create executor");
+
+            // Verify we're not inside a Tokio runtime
+            assert!(
+                tokio::runtime::Handle::try_current().is_err(),
+                "Test must run outside of a Tokio runtime"
+            );
+
+            // block_on should work even though we're not inside a Tokio runtime
+            let result = executor.block_on(async {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                42
+            });
+            assert_eq!(result, 42);
+        }
+
+        #[rstest::rstest]
+        #[case::multithreaded(
+            TokioMultiThreadExecutor::new_owned_runtime(None, None).expect("Couldn't create multithreaded executor")
+        )]
+        #[case::background(TokioBackgroundExecutor::new())]
+        fn can_enter_a_runtime<T: TaskExecutor>(#[case] executor: T) {
+            // Verify we're not inside a Tokio runtime
+            assert!(
+                tokio::runtime::Handle::try_current().is_err(),
+                "Test must run outside of a Tokio runtime"
+            );
+
+            let guard = executor.enter();
+
+            assert!(
+                tokio::runtime::Handle::try_current().is_ok(),
+                "Should have entered runtime"
+            );
+
+            drop(guard);
+
+            assert!(
+                tokio::runtime::Handle::try_current().is_err(),
+                "Should have exited runtime"
+            );
+        }
+    }
+}

--- a/default-engine/src/file_stream.rs
+++ b/default-engine/src/file_stream.rs
@@ -1,0 +1,229 @@
+use std::collections::VecDeque;
+use std::mem;
+use std::ops::Range;
+use std::pin::Pin;
+use std::task::{ready, Context, Poll};
+
+use delta_kernel::arrow::array::RecordBatch;
+use delta_kernel::arrow::datatypes::SchemaRef as ArrowSchemaRef;
+use futures::future::BoxFuture;
+use futures::stream::{BoxStream, Stream, StreamExt};
+use futures::FutureExt;
+
+use delta_kernel::{DeltaResult, FileMeta};
+
+/// A fallible future that resolves to a stream of [`RecordBatch`]
+/// cbindgen:ignore
+pub type FileOpenFuture =
+    BoxFuture<'static, DeltaResult<BoxStream<'static, DeltaResult<RecordBatch>>>>;
+
+/// Generic API for opening a file using an [`ObjectStore`] and resolving to a
+/// stream of [`RecordBatch`]
+///
+/// [`ObjectStore`]: delta_kernel::object_store::ObjectStore
+pub trait FileOpener: Send + Unpin {
+    /// Asynchronously open the specified file and return a stream
+    /// of [`RecordBatch`]
+    fn open(&self, file_meta: FileMeta, range: Option<Range<i64>>) -> DeltaResult<FileOpenFuture>;
+}
+
+/// Describes the behavior of the `FileStream` if file opening or scanning fails
+#[allow(missing_debug_implementations)]
+#[derive(Default)]
+pub enum OnError {
+    /// Fail the entire stream and return the underlying error
+    #[default]
+    Fail,
+    /// Continue scanning, ignoring the failed file
+    Skip,
+}
+
+/// Represents the state of the next `FileOpenFuture`. Since we need to poll
+/// this future while scanning the current file, we need to store the result if it
+/// is ready
+enum NextOpen {
+    Pending(FileOpenFuture),
+    Ready(DeltaResult<BoxStream<'static, DeltaResult<RecordBatch>>>),
+}
+
+enum FileStreamState {
+    /// The idle state, no file is currently being read
+    Idle,
+    /// Currently performing asynchronous IO to obtain a stream of RecordBatch
+    /// for a given parquet file
+    Open {
+        /// A [`FileOpenFuture`] returned by [`FileOpener::open`]
+        future: FileOpenFuture,
+    },
+    /// Scanning the [`BoxStream`] returned by the completion of a [`FileOpenFuture`]
+    /// returned by [`FileOpener::open`]
+    Scan {
+        /// The reader instance
+        reader: BoxStream<'static, DeltaResult<RecordBatch>>,
+        /// A [`FileOpenFuture`] for the next file to be processed,
+        /// and its corresponding partition column values, if any.
+        /// This allows the next file to be opened in parallel while the
+        /// current file is read.
+        next: Option<NextOpen>,
+    },
+    /// Encountered an error
+    Error,
+}
+
+/// A stream that iterates record batch by record batch, file over file.
+#[allow(missing_debug_implementations)]
+pub struct FileStream {
+    /// An iterator over input files.
+    file_iter: VecDeque<FileMeta>,
+    /// The stream schema (file schema including partition columns and after
+    /// projection).
+    #[allow(unused)]
+    projected_schema: ArrowSchemaRef,
+    /// A closure that takes a reader and an optional remaining number of lines
+    /// (before reaching the limit) and returns a batch iterator. If the file reader
+    /// is not capable of limiting the number of records in the last batch, the file
+    /// stream will take care of truncating it.
+    file_opener: Box<dyn FileOpener>,
+    /// The stream state
+    state: FileStreamState,
+    /// Describes the behavior of the `FileStream` if file opening or scanning fails
+    on_error: OnError,
+}
+
+impl FileStream {
+    /// Create a new `FileStream` using the given `FileOpener` to scan underlying files
+    pub fn new(
+        files: impl IntoIterator<Item = FileMeta>,
+        schema: ArrowSchemaRef,
+        file_opener: Box<dyn FileOpener>,
+    ) -> DeltaResult<Self> {
+        Ok(Self {
+            file_iter: files.into_iter().collect(),
+            projected_schema: schema,
+            file_opener,
+            state: FileStreamState::Idle,
+            on_error: OnError::Fail,
+        })
+    }
+
+    /// Specify the behavior when an error occurs opening or scanning a file
+    ///
+    /// If `OnError::Skip` the stream will skip files which encounter an error and continue
+    /// If `OnError:Fail` (default) the stream will fail and stop processing when an error occurs
+    pub fn with_on_error(mut self, on_error: OnError) -> Self {
+        self.on_error = on_error;
+        self
+    }
+
+    /// Begin opening the next file in parallel while decoding the current file in FileStream.
+    ///
+    /// Since file opening is mostly IO (and may involve a
+    /// bunch of sequential IO), it can be parallelized with decoding.
+    fn start_next_file(&mut self) -> Option<DeltaResult<FileOpenFuture>> {
+        let file_meta = self.file_iter.pop_front()?;
+        Some(self.file_opener.open(file_meta, None))
+    }
+
+    fn poll_inner(&mut self, cx: &mut Context<'_>) -> Poll<Option<DeltaResult<RecordBatch>>> {
+        loop {
+            match &mut self.state {
+                FileStreamState::Idle => match self.start_next_file().transpose() {
+                    Ok(Some(future)) => self.state = FileStreamState::Open { future },
+                    Ok(None) => return Poll::Ready(None),
+                    Err(e) => {
+                        self.state = FileStreamState::Error;
+                        return Poll::Ready(Some(Err(e)));
+                    }
+                },
+                FileStreamState::Open { future } => match ready!(future.poll_unpin(cx)) {
+                    Ok(reader) => {
+                        // include time needed to start opening in `start_next_file`
+                        let next = self.start_next_file().transpose();
+
+                        match next {
+                            Ok(Some(next_future)) => {
+                                self.state = FileStreamState::Scan {
+                                    reader,
+                                    next: Some(NextOpen::Pending(next_future)),
+                                };
+                            }
+                            Ok(None) => {
+                                self.state = FileStreamState::Scan { reader, next: None };
+                            }
+                            Err(e) => {
+                                self.state = FileStreamState::Error;
+                                return Poll::Ready(Some(Err(e)));
+                            }
+                        }
+                    }
+                    Err(e) => match self.on_error {
+                        OnError::Skip => self.state = FileStreamState::Idle,
+                        OnError::Fail => {
+                            self.state = FileStreamState::Error;
+                            return Poll::Ready(Some(Err(e)));
+                        }
+                    },
+                },
+                FileStreamState::Scan { reader, next } => {
+                    // We need to poll the next `FileOpenFuture` here to drive it forward
+                    if let Some(next_open_future) = next {
+                        if let NextOpen::Pending(f) = next_open_future {
+                            if let Poll::Ready(reader) = f.as_mut().poll(cx) {
+                                *next_open_future = NextOpen::Ready(reader);
+                            }
+                        }
+                    }
+                    match ready!(reader.poll_next_unpin(cx)) {
+                        Some(Ok(batch)) => {
+                            return Poll::Ready(Some(Ok(batch)));
+                        }
+                        Some(Err(err)) => {
+                            match self.on_error {
+                                // If `OnError::Skip` we skip the file as soon as we hit the first error
+                                OnError::Skip => match mem::take(next) {
+                                    Some(future) => match future {
+                                        NextOpen::Pending(future) => {
+                                            self.state = FileStreamState::Open { future }
+                                        }
+                                        NextOpen::Ready(reader) => {
+                                            self.state = FileStreamState::Open {
+                                                future: Box::pin(std::future::ready(reader)),
+                                            }
+                                        }
+                                    },
+                                    None => return Poll::Ready(None),
+                                },
+                                OnError::Fail => {
+                                    self.state = FileStreamState::Error;
+                                    return Poll::Ready(Some(Err(err)));
+                                }
+                            }
+                        }
+                        None => match mem::take(next) {
+                            Some(future) => match future {
+                                NextOpen::Pending(future) => {
+                                    self.state = FileStreamState::Open { future }
+                                }
+                                NextOpen::Ready(reader) => {
+                                    self.state = FileStreamState::Open {
+                                        future: Box::pin(std::future::ready(reader)),
+                                    }
+                                }
+                            },
+                            None => return Poll::Ready(None),
+                        },
+                    }
+                }
+                FileStreamState::Error => return Poll::Ready(None),
+            }
+        }
+    }
+}
+
+impl Stream for FileStream {
+    type Item = DeltaResult<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.poll_inner(cx)
+    }
+}

--- a/default-engine/src/filesystem.rs
+++ b/default-engine/src/filesystem.rs
@@ -1,0 +1,668 @@
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use futures::stream::{self, BoxStream, Stream, StreamExt, TryStreamExt};
+use itertools::Itertools;
+use url::Url;
+
+use crate::executor::TaskExecutor;
+use crate::UrlExt;
+use delta_kernel::metrics::{MetricEvent, MetricsReporter};
+use delta_kernel::object_store::path::Path;
+use delta_kernel::object_store::{self, DynObjectStore, ObjectStore, ObjectStoreExt as _, PutMode};
+use delta_kernel::{DeltaResult, Error, FileMeta, FileSlice, StorageHandler};
+
+/// Iterator wrapper that emits metrics when exhausted
+///
+/// Generic over the inner iterator type and item type.
+/// The `event_fn` receives (duration, num_files, bytes_read) to construct the appropriate MetricEvent.
+/// Metrics are emitted either when the iterator is exhausted or when dropped.
+struct MetricsIterator<I, T> {
+    inner: I,
+    reporter: Option<Arc<dyn MetricsReporter>>,
+    start: Instant,
+    num_files: u64,
+    bytes_read: u64,
+    event_fn: fn(Duration, u64, u64) -> MetricEvent,
+    _phantom: std::marker::PhantomData<T>,
+}
+
+impl<I, T> MetricsIterator<I, T> {
+    fn new(
+        inner: I,
+        reporter: Option<Arc<dyn MetricsReporter>>,
+        start: Instant,
+        event_fn: fn(Duration, u64, u64) -> MetricEvent,
+    ) -> Self {
+        Self {
+            inner,
+            reporter,
+            start,
+            num_files: 0,
+            bytes_read: 0,
+            event_fn,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    fn emit_metrics_once(&mut self) {
+        if let Some(r) = self.reporter.take() {
+            r.report((self.event_fn)(
+                self.start.elapsed(),
+                self.num_files,
+                self.bytes_read,
+            ));
+        }
+    }
+}
+
+impl<I, T> Drop for MetricsIterator<I, T> {
+    fn drop(&mut self) {
+        self.emit_metrics_once();
+    }
+}
+
+impl<I> Stream for MetricsIterator<I, FileMeta>
+where
+    I: Stream<Item = DeltaResult<FileMeta>> + Unpin,
+{
+    type Item = I::Item;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match futures::ready!(Pin::new(&mut self.inner).poll_next(cx)) {
+            Some(item) => {
+                if item.is_ok() {
+                    self.num_files += 1;
+                }
+                Poll::Ready(Some(item))
+            }
+            None => {
+                self.emit_metrics_once();
+                Poll::Ready(None)
+            }
+        }
+    }
+}
+
+impl<I> Stream for MetricsIterator<I, Bytes>
+where
+    I: Stream<Item = DeltaResult<Bytes>> + Unpin,
+{
+    type Item = I::Item;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match futures::ready!(Pin::new(&mut self.inner).poll_next(cx)) {
+            Some(item) => {
+                if let Ok(ref bytes) = item {
+                    self.num_files += 1;
+                    self.bytes_read += bytes.len() as u64;
+                }
+                Poll::Ready(Some(item))
+            }
+            None => {
+                self.emit_metrics_once();
+                Poll::Ready(None)
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ObjectStoreStorageHandler<E: TaskExecutor> {
+    inner: Arc<DynObjectStore>,
+    task_executor: Arc<E>,
+    reporter: Option<Arc<dyn MetricsReporter>>,
+    readahead: usize,
+}
+
+impl<E: TaskExecutor> ObjectStoreStorageHandler<E> {
+    pub(crate) fn new(
+        store: Arc<DynObjectStore>,
+        task_executor: Arc<E>,
+        reporter: Option<Arc<dyn MetricsReporter>>,
+    ) -> Self {
+        Self {
+            inner: store,
+            task_executor,
+            reporter,
+            readahead: 10,
+        }
+    }
+
+    /// Set the maximum number of files to read in parallel.
+    pub fn with_readahead(mut self, readahead: usize) -> Self {
+        self.readahead = readahead;
+        self
+    }
+}
+
+/// Native async implementation for list_from
+async fn list_from_impl(
+    store: Arc<DynObjectStore>,
+    path: Url,
+    reporter: Option<Arc<dyn MetricsReporter>>,
+) -> DeltaResult<BoxStream<'static, DeltaResult<FileMeta>>> {
+    let start = Instant::now();
+
+    // The offset is used for list-after; the prefix is used to restrict the listing to a specific directory.
+    // Unfortunately, `Path` provides no easy way to check whether a name is directory-like,
+    // because it strips trailing /, so we're reduced to manually checking the original URL.
+    let offset = Path::from_url_path(path.path())?;
+    let prefix = if path.path().ends_with('/') {
+        offset.clone()
+    } else {
+        let mut parts = offset.parts().collect_vec();
+        if parts.pop().is_none() {
+            return Err(Error::Generic(format!(
+                "Offset path must not be a root directory. Got: '{path}'",
+            )));
+        }
+        Path::from_iter(parts)
+    };
+
+    let has_ordered_listing = supports_ordered_listing(&path);
+
+    let stream = store
+        .list_with_offset(Some(&prefix), &offset)
+        .map(move |meta| {
+            let meta = meta?;
+            let mut location = path.clone();
+            location.set_path(&format!("/{}", meta.location.as_ref()));
+            Ok(FileMeta {
+                location,
+                last_modified: meta.last_modified.timestamp_millis(),
+                size: meta.size,
+            })
+        });
+
+    if !has_ordered_listing {
+        // Local filesystem doesn't return sorted list - need to collect and sort
+        let mut items: Vec<_> = stream.try_collect().await?;
+        items.sort_unstable();
+
+        if let Some(r) = reporter {
+            r.report(MetricEvent::StorageListCompleted {
+                duration: start.elapsed(),
+                num_files: items.len() as u64,
+            });
+        }
+        Ok(Box::pin(stream::iter(items.into_iter().map(Ok))))
+    } else {
+        let stream = MetricsIterator::new(
+            stream,
+            reporter,
+            start,
+            |duration, num_files, _bytes_read| MetricEvent::StorageListCompleted {
+                duration,
+                num_files,
+            },
+        );
+        Ok(Box::pin(stream))
+    }
+}
+
+/// Native async implementation for read_files
+async fn read_files_impl(
+    store: Arc<DynObjectStore>,
+    files: Vec<FileSlice>,
+    readahead: usize,
+    reporter: Option<Arc<dyn MetricsReporter>>,
+) -> DeltaResult<BoxStream<'static, DeltaResult<Bytes>>> {
+    let start = Instant::now();
+    let files = stream::iter(files).map(move |(url, range)| {
+        let store = store.clone();
+        async move {
+            // Wasn't checking the scheme before calling to_file_path causing the url path to
+            // be eaten in a strange way. Now, if not a file scheme, just blindly convert to a path.
+            // https://docs.rs/url/latest/url/struct.Url.html#method.to_file_path has more
+            // details about why this check is necessary
+            let path = if url.scheme() == "file" {
+                let file_path = url
+                    .to_file_path()
+                    .map_err(|_| Error::InvalidTableLocation(format!("Invalid file URL: {url}")))?;
+                Path::from_absolute_path(file_path)
+                    .map_err(|e| Error::InvalidTableLocation(format!("Invalid file path: {e}")))?
+            } else {
+                Path::from(url.path())
+            };
+            if url.is_presigned() {
+                // have to annotate type here or rustc can't figure it out
+                let resp = reqwest::get(url).await.map_err(Error::generic_err)?;
+                Ok::<bytes::Bytes, Error>(resp.bytes().await.map_err(Error::generic_err)?)
+            } else if let Some(rng) = range {
+                Ok(store.get_range(&path, rng).await?)
+            } else {
+                let result = store.get(&path).await?;
+                Ok(result.bytes().await?)
+            }
+        }
+    });
+
+    // We allow executing up to `readahead` futures concurrently and
+    // buffer the results. This allows us to achieve async concurrency.
+    Ok(Box::pin(MetricsIterator::new(
+        files.buffered(readahead),
+        reporter,
+        start,
+        |duration, num_files, bytes_read| MetricEvent::StorageReadCompleted {
+            duration,
+            num_files,
+            bytes_read,
+        },
+    )))
+}
+
+/// Native async implementation for copy_atomic
+async fn copy_atomic_impl(
+    store: Arc<DynObjectStore>,
+    src_path: Path,
+    dest_path: Path,
+    reporter: Option<Arc<dyn MetricsReporter>>,
+) -> DeltaResult<()> {
+    let start = Instant::now();
+
+    // Read source file then write atomically with PutMode::Create. Note that a GET/PUT is not
+    // necessarily atomic, but since the source file is immutable, we aren't exposed to the
+    // possibility of source file changing while we do the PUT.
+    let data = store.get(&src_path).await?.bytes().await?;
+    let result = store
+        .put_opts(&dest_path, data.into(), PutMode::Create.into())
+        .await;
+
+    if let Some(r) = reporter {
+        r.report(MetricEvent::StorageCopyCompleted {
+            duration: start.elapsed(),
+        });
+    }
+
+    result.map_err(|e| match e {
+        object_store::Error::AlreadyExists { .. } => Error::FileAlreadyExists(dest_path.into()),
+        e => e.into(),
+    })?;
+    Ok(())
+}
+
+/// Native async implementation for put
+async fn put_impl(
+    store: Arc<DynObjectStore>,
+    path: Path,
+    data: Bytes,
+    overwrite: bool,
+) -> DeltaResult<()> {
+    let put_mode = if overwrite {
+        PutMode::Overwrite
+    } else {
+        PutMode::Create
+    };
+    let result = store.put_opts(&path, data.into(), put_mode.into()).await;
+    result.map_err(|e| match e {
+        object_store::Error::AlreadyExists { .. } => Error::FileAlreadyExists(path.into()),
+        e => e.into(),
+    })?;
+    Ok(())
+}
+
+/// Native async implementation for head
+async fn head_impl(store: Arc<DynObjectStore>, url: Url) -> DeltaResult<FileMeta> {
+    let meta = store.head(&Path::from_url_path(url.path())?).await?;
+    Ok(FileMeta {
+        location: url,
+        last_modified: meta.last_modified.timestamp_millis(),
+        size: meta.size,
+    })
+}
+
+impl<E: TaskExecutor> StorageHandler for ObjectStoreStorageHandler<E> {
+    fn list_from(
+        &self,
+        path: &Url,
+    ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<FileMeta>>>> {
+        let future = list_from_impl(self.inner.clone(), path.clone(), self.reporter.clone());
+        let iter = crate::stream_future_to_iter(self.task_executor.clone(), future)?;
+        Ok(iter) // type coercion drops the unneeded Send bound
+    }
+
+    /// Read data specified by the start and end offset from the file.
+    ///
+    /// This will return the data in the same order as the provided file slices.
+    ///
+    /// Multiple reads may occur in parallel, depending on the configured readahead.
+    /// See [`Self::with_readahead`].
+    fn read_files(
+        &self,
+        files: Vec<FileSlice>,
+    ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<Bytes>>>> {
+        let future = read_files_impl(
+            self.inner.clone(),
+            files,
+            self.readahead,
+            self.reporter.clone(),
+        );
+        let iter = crate::stream_future_to_iter(self.task_executor.clone(), future)?;
+        Ok(iter) // type coercion drops the unneeded Send bound
+    }
+
+    fn put(&self, path: &Url, data: Bytes, overwrite: bool) -> DeltaResult<()> {
+        let path = Path::from_url_path(path.path())?;
+        self.task_executor
+            .block_on(put_impl(self.inner.clone(), path, data, overwrite))
+    }
+
+    fn copy_atomic(&self, src: &Url, dest: &Url) -> DeltaResult<()> {
+        let src_path = Path::from_url_path(src.path())?;
+        let dest_path = Path::from_url_path(dest.path())?;
+        let future = copy_atomic_impl(
+            self.inner.clone(),
+            src_path,
+            dest_path,
+            self.reporter.clone(),
+        );
+        self.task_executor.block_on(future)
+    }
+
+    fn head(&self, path: &Url) -> DeltaResult<FileMeta> {
+        let future = head_impl(self.inner.clone(), path.clone());
+        self.task_executor.block_on(future)
+    }
+}
+
+/// Returns whether or not the [Url] can support ordered listing.
+///
+/// When this returns false the default engine will need to collect a stream before returning,
+/// which has a performance impact
+///
+/// The current known situations where there are unordered listings are with filesystems and AWS S3
+/// Express One Zone directory buckets
+///
+/// Although the `object_store` crate explicitly says it _does not_ return a sorted listing, in
+/// practice many implementations actually do:
+/// - AWS:
+///   [`ListObjectsV2`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html)
+///   states: "For general purpose buckets, ListObjectsV2 returns objects in lexicographical
+///   order based on their key names."
+/// - Azure: Docs state
+///   [here](https://learn.microsoft.com/en-us/rest/api/storageservices/enumerating-blob-resources):
+///   "A listing operation returns an XML response that contains all or part of the requested
+///   list. The operation returns entities in alphabetical order."
+/// - GCP: The [main](https://cloud.google.com/storage/docs/xml-api/get-bucket-list) doc
+///   doesn't indicate order, but [this
+///   page](https://cloud.google.com/storage/docs/xml-api/get-bucket-list) does say: "This page
+///   shows you how to list the [objects](https://cloud.google.com/storage/docs/objects) stored
+///   in your Cloud Storage buckets, which are ordered in the list lexicographically by name."
+fn supports_ordered_listing(url: &Url) -> bool {
+    !((url.scheme() == "file")
+        // S3 Directory Buckets
+        || url.domain().map(|d| d.contains("--x-s3")).unwrap_or(false)
+        // S3 Directory Bucket Access Points
+        || url.domain().map(|d| d.contains("-xa-s3")).unwrap_or(false))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Range;
+    use std::time::Duration;
+
+    use itertools::Itertools;
+
+    use test_utils::delta_path_for_version;
+
+    use crate::executor::tokio::TokioBackgroundExecutor;
+    use crate::DefaultEngineBuilder;
+    use delta_kernel::object_store::local::LocalFileSystem;
+    use delta_kernel::object_store::memory::InMemory;
+    use delta_kernel::utils::current_time_duration;
+    use delta_kernel::Engine as _;
+
+    use super::*;
+
+    fn setup_test() -> (
+        tempfile::TempDir,
+        Arc<LocalFileSystem>,
+        ObjectStoreStorageHandler<TokioBackgroundExecutor>,
+    ) {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Arc::new(LocalFileSystem::new());
+        let executor = Arc::new(TokioBackgroundExecutor::new());
+        let handler = ObjectStoreStorageHandler::new(store.clone(), executor, None);
+        (tmp, store, handler)
+    }
+
+    #[test]
+    fn test_ordered_listing_for_url() {
+        for (u, expected) in &[
+            (Url::parse("file:///dev/null").unwrap(), false),
+            (Url::parse("s3://robbert").unwrap(), true),
+            (Url::parse("s3://robbert/likes/paths").unwrap(), true),
+            (Url::parse("s3://robbie-one-zone--x-s3").unwrap(), false),
+            (
+                Url::parse("https://robbie-one-zone-xa-s3.us-east-2.amazonaws.biz").unwrap(),
+                false,
+            ),
+        ] {
+            assert_eq!(
+                *expected,
+                supports_ordered_listing(u),
+                "expected {expected} on {u:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_read_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tmp_store = LocalFileSystem::new_with_prefix(tmp.path()).unwrap();
+
+        let data = Bytes::from("kernel-data");
+        tmp_store
+            .put(&Path::from("a"), data.clone().into())
+            .await
+            .unwrap();
+        tmp_store
+            .put(&Path::from("b"), data.clone().into())
+            .await
+            .unwrap();
+        tmp_store
+            .put(&Path::from("c"), data.clone().into())
+            .await
+            .unwrap();
+
+        let mut url = Url::from_directory_path(tmp.path()).unwrap();
+
+        let store = Arc::new(LocalFileSystem::new());
+        let executor = Arc::new(TokioBackgroundExecutor::new());
+        let storage = ObjectStoreStorageHandler::new(store, executor, None);
+
+        let mut slices: Vec<FileSlice> = Vec::new();
+
+        let mut url1 = url.clone();
+        url1.set_path(&format!("{}/b", url.path()));
+        slices.push((url1.clone(), Some(Range { start: 0, end: 6 })));
+        slices.push((url1, Some(Range { start: 7, end: 11 })));
+
+        url.set_path(&format!("{}/c", url.path()));
+        slices.push((url, Some(Range { start: 4, end: 9 })));
+        dbg!("Slices are: {}", &slices);
+        let data: Vec<Bytes> = storage.read_files(slices).unwrap().try_collect().unwrap();
+
+        assert_eq!(data.len(), 3);
+        assert_eq!(data[0], Bytes::from("kernel"));
+        assert_eq!(data[1], Bytes::from("data"));
+        assert_eq!(data[2], Bytes::from("el-da"));
+    }
+
+    #[tokio::test]
+    async fn test_file_meta_is_correct() {
+        let store = Arc::new(InMemory::new());
+
+        let begin_time = current_time_duration().unwrap();
+
+        let data = Bytes::from("kernel-data");
+        let name = delta_path_for_version(1, "json");
+        store.put(&name, data.clone().into()).await.unwrap();
+
+        let table_root = Url::parse("memory:///").expect("valid url");
+        let engine = DefaultEngineBuilder::new(store).build();
+        let files: Vec<_> = engine
+            .storage_handler()
+            .list_from(&table_root.join("_delta_log").unwrap().join("0").unwrap())
+            .unwrap()
+            .try_collect()
+            .unwrap();
+
+        assert!(!files.is_empty());
+        for meta in files.into_iter() {
+            let meta_time = Duration::from_millis(meta.last_modified.try_into().unwrap());
+            assert!(meta_time.abs_diff(begin_time) < Duration::from_secs(10));
+        }
+    }
+    #[tokio::test]
+    async fn test_default_engine_listing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tmp_store = LocalFileSystem::new_with_prefix(tmp.path()).unwrap();
+        let data = Bytes::from("kernel-data");
+
+        let expected_names: Vec<Path> =
+            (0..10).map(|i| delta_path_for_version(i, "json")).collect();
+
+        // put them in in reverse order
+        for name in expected_names.iter().rev() {
+            tmp_store.put(name, data.clone().into()).await.unwrap();
+        }
+
+        let url = Url::from_directory_path(tmp.path()).unwrap();
+        let store = Arc::new(LocalFileSystem::new());
+        let engine = DefaultEngineBuilder::new(store).build();
+        let files = engine
+            .storage_handler()
+            .list_from(&url.join("_delta_log").unwrap().join("0").unwrap())
+            .unwrap();
+        let mut len = 0;
+        for (file, expected) in files.zip(expected_names.iter()) {
+            assert!(
+                file.as_ref()
+                    .unwrap()
+                    .location
+                    .path()
+                    .ends_with(expected.as_ref()),
+                "{} does not end with {}",
+                file.unwrap().location.path(),
+                expected
+            );
+            len += 1;
+        }
+        assert_eq!(len, 10, "list_from should have returned 10 files");
+    }
+
+    #[tokio::test]
+    async fn test_copy() {
+        let (tmp, store, handler) = setup_test();
+
+        // basic
+        let data = Bytes::from("test-data");
+        let src_path = Path::from_absolute_path(tmp.path().join("src.txt")).unwrap();
+        store.put(&src_path, data.clone().into()).await.unwrap();
+        let src_url = Url::from_file_path(tmp.path().join("src.txt")).unwrap();
+        let dest_url = Url::from_file_path(tmp.path().join("dest.txt")).unwrap();
+        assert!(handler.copy_atomic(&src_url, &dest_url).is_ok());
+        let dest_path = Path::from_absolute_path(tmp.path().join("dest.txt")).unwrap();
+        assert_eq!(
+            store.get(&dest_path).await.unwrap().bytes().await.unwrap(),
+            data
+        );
+
+        // copy to existing fails
+        assert!(matches!(
+            handler.copy_atomic(&src_url, &dest_url),
+            Err(Error::FileAlreadyExists(_))
+        ));
+
+        // copy from non-existing fails
+        let missing_url = Url::from_file_path(tmp.path().join("missing.txt")).unwrap();
+        let new_dest_url = Url::from_file_path(tmp.path().join("new_dest.txt")).unwrap();
+        assert!(handler.copy_atomic(&missing_url, &new_dest_url).is_err());
+    }
+
+    #[tokio::test]
+    async fn test_head() {
+        let (tmp, store, handler) = setup_test();
+
+        let data = Bytes::from("test-content");
+        let file_path = Path::from_absolute_path(tmp.path().join("test.txt")).unwrap();
+        let write_time = current_time_duration().unwrap();
+        store.put(&file_path, data.clone().into()).await.unwrap();
+
+        let file_url = Url::from_file_path(tmp.path().join("test.txt")).unwrap();
+        let file_meta = handler.head(&file_url).unwrap();
+
+        assert_eq!(file_meta.location, file_url);
+        assert_eq!(file_meta.size, data.len() as u64);
+
+        // Verify timestamp is within the expected range
+        let meta_time = Duration::from_millis(file_meta.last_modified as u64);
+        assert!(
+            meta_time.abs_diff(write_time) < Duration::from_millis(100),
+            "last_modified timestamp should be around {} ms, but was {} ms",
+            write_time.as_millis(),
+            meta_time.as_millis()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_head_non_existent() {
+        let (tmp, _store, handler) = setup_test();
+
+        let missing_url = Url::from_file_path(tmp.path().join("missing.txt")).unwrap();
+        let result = handler.head(&missing_url);
+
+        assert!(matches!(result, Err(Error::FileNotFound(_))));
+    }
+
+    #[test]
+    fn test_put() {
+        let (tmp, _store, handler) = setup_test();
+
+        let data = Bytes::from("put-test-data");
+        let file_url = Url::from_file_path(tmp.path().join("put.txt")).unwrap();
+        handler.put(&file_url, data.clone(), false).unwrap();
+
+        // Read back via read_files and verify content
+        let read_back: Vec<Bytes> = handler
+            .read_files(vec![(file_url, None)])
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        assert_eq!(read_back.len(), 1);
+        assert_eq!(read_back[0], data);
+    }
+
+    #[test]
+    fn test_put_already_exists() {
+        let (tmp, _store, handler) = setup_test();
+
+        let data = Bytes::from("original");
+        let file_url = Url::from_file_path(tmp.path().join("put.txt")).unwrap();
+        handler.put(&file_url, data, false).unwrap();
+
+        // Second put with overwrite=false should fail
+        let new_data = Bytes::from("updated");
+        assert!(matches!(
+            handler.put(&file_url, new_data.clone(), false),
+            Err(Error::FileAlreadyExists(_))
+        ));
+
+        // Put with overwrite=true should succeed
+        handler.put(&file_url, new_data.clone(), true).unwrap();
+
+        // Verify the content was overwritten
+        let read_back: Vec<Bytes> = handler
+            .read_files(vec![(file_url, None)])
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        assert_eq!(read_back.len(), 1);
+        assert_eq!(read_back[0], new_data);
+    }
+}

--- a/default-engine/src/json.rs
+++ b/default-engine/src/json.rs
@@ -1,0 +1,947 @@
+//! Default Json handler implementation
+
+use std::io::BufReader;
+use std::sync::Arc;
+use std::task::Poll;
+
+use bytes::{Buf, Bytes};
+use delta_kernel::arrow::datatypes::SchemaRef as ArrowSchemaRef;
+use delta_kernel::arrow::json::ReaderBuilder;
+use delta_kernel::arrow::record_batch::RecordBatch;
+use delta_kernel::object_store::path::Path;
+use delta_kernel::object_store::{
+    self, DynObjectStore, GetResultPayload, ObjectStoreExt as _, PutMode,
+};
+use futures::stream::{self, BoxStream};
+use futures::{ready, StreamExt, TryStreamExt};
+use url::Url;
+
+use crate::executor::TaskExecutor;
+use delta_kernel::engine::arrow_utils::{
+    build_json_reorder_indices, fixup_json_read, json_arrow_schema, parse_json as arrow_parse_json,
+    to_json_bytes,
+};
+use delta_kernel::engine_data::FilteredEngineData;
+use delta_kernel::schema::SchemaRef;
+use delta_kernel::{
+    DeltaResult, EngineData, Error, FileDataReadResultIterator, FileMeta, JsonHandler, PredicateRef,
+};
+
+#[derive(Debug)]
+pub struct DefaultJsonHandler<E: TaskExecutor> {
+    /// The object store to read files from
+    store: Arc<DynObjectStore>,
+    /// The executor to run async tasks on
+    task_executor: Arc<E>,
+    /// The maximum number of read requests to buffer in memory at once. Note that this actually
+    /// controls two things: the number of concurrent requests (done by `buffered`) and the size of
+    /// the buffer (via our `sync_channel`).
+    buffer_size: usize,
+    /// Limit the number of rows per batch. That is, for batch_size = N, then each RecordBatch
+    /// yielded by the stream will have at most N rows.
+    batch_size: usize,
+}
+
+impl<E: TaskExecutor> DefaultJsonHandler<E> {
+    pub fn new(store: Arc<DynObjectStore>, task_executor: Arc<E>) -> Self {
+        Self {
+            store,
+            task_executor,
+            buffer_size: crate::DEFAULT_BUFFER_SIZE,
+            batch_size: crate::DEFAULT_BATCH_SIZE,
+        }
+    }
+
+    /// Set the maximum number read requests to buffer in memory at once in
+    /// [Self::read_json_files()].
+    ///
+    /// Defaults to 1000.
+    ///
+    /// Memory constraints can be imposed by constraining the buffer size and batch size. Note that
+    /// overall memory usage is proportional to the product of these two values.
+    /// 1. Batch size governs the size of RecordBatches yielded in each iteration of the stream
+    /// 2. Buffer size governs the number of concurrent tasks (which equals the size of the buffer
+    pub fn with_buffer_size(mut self, buffer_size: usize) -> Self {
+        self.buffer_size = buffer_size;
+        self
+    }
+
+    /// Limit the number of rows per batch. That is, for batch_size = N, then each RecordBatch
+    /// yielded by the stream will have at most N rows.
+    ///
+    /// Defaults to 1000 rows (json objects).
+    ///
+    /// See [Decoder::with_buffer_size] for details on constraining memory usage with buffer size
+    /// and batch size.
+    ///
+    /// [Decoder::with_buffer_size]: delta_kernel::arrow::json::reader::Decoder
+    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = batch_size;
+        self
+    }
+}
+
+/// Internal async implementation of read_json_files
+async fn read_json_files_impl(
+    store: Arc<DynObjectStore>,
+    files: Vec<FileMeta>,
+    physical_schema: SchemaRef,
+    _predicate: Option<PredicateRef>,
+    batch_size: usize,
+    buffer_size: usize,
+) -> DeltaResult<BoxStream<'static, DeltaResult<Box<dyn EngineData>>>> {
+    if files.is_empty() {
+        return Ok(Box::pin(stream::empty()));
+    }
+
+    // Build Arrow schema from only the real JSON columns, omitting any metadata columns
+    // (e.g. FilePath) that the JSON reader cannot populate from the file content.
+    let json_arrow_schema = Arc::new(json_arrow_schema(&physical_schema)?);
+    // Build the reorder index vec once; apply it to every batch via reorder_struct_array.
+    let reorder_indices: Arc<[_]> = build_json_reorder_indices(&physical_schema)?.into();
+
+    // An iterator of futures that open each file and post-process each resulting batch.
+    let file_futures = files.into_iter().map(move |file| {
+        let store = store.clone();
+        let json_arrow_schema = json_arrow_schema.clone();
+        let reorder_indices = reorder_indices.clone();
+        async move {
+            let file_path = file.location.to_string();
+            let batch_stream = open_json_file(store, json_arrow_schema, batch_size, file).await?;
+            // Re-insert synthesized metadata columns (e.g. file path) at their schema positions.
+            let tagged = batch_stream
+                .map(move |result| fixup_json_read(result?, &reorder_indices, &file_path))
+                .boxed();
+            Ok::<_, Error>(tagged)
+        }
+    });
+
+    // Create a stream from that iterator which buffers up to `buffer_size` futures at a time.
+    let result_stream = stream::iter(file_futures)
+        .buffered(buffer_size)
+        .try_flatten()
+        .map_ok(|e| -> Box<dyn EngineData> { Box::new(e) });
+
+    Ok(Box::pin(result_stream))
+}
+
+/// Internal async implementation of write_json_file
+/// Note: for now we just buffer all the data and write it out all at once
+async fn write_json_file_impl(
+    store: Arc<DynObjectStore>,
+    path: Url,
+    buffer: Vec<u8>,
+    overwrite: bool,
+) -> DeltaResult<()> {
+    let put_mode = if overwrite {
+        PutMode::Overwrite
+    } else {
+        PutMode::Create
+    };
+
+    let path = Path::from_url_path(path.path())?;
+    let result = store.put_opts(&path, buffer.into(), put_mode.into()).await;
+    result.map_err(|e| match e {
+        object_store::Error::AlreadyExists { .. } => Error::FileAlreadyExists(path.to_string()),
+        e => e.into(),
+    })?;
+    Ok(())
+}
+
+impl<E: TaskExecutor> JsonHandler for DefaultJsonHandler<E> {
+    fn parse_json(
+        &self,
+        json_strings: Box<dyn EngineData>,
+        output_schema: SchemaRef,
+    ) -> DeltaResult<Box<dyn EngineData>> {
+        arrow_parse_json(json_strings, output_schema)
+    }
+
+    fn read_json_files(
+        &self,
+        files: &[FileMeta],
+        physical_schema: SchemaRef,
+        predicate: Option<PredicateRef>,
+    ) -> DeltaResult<FileDataReadResultIterator> {
+        let future = read_json_files_impl(
+            self.store.clone(),
+            files.to_vec(),
+            physical_schema,
+            predicate,
+            self.batch_size,
+            self.buffer_size,
+        );
+        crate::stream_future_to_iter(self.task_executor.clone(), future)
+    }
+
+    // note: for now we just buffer all the data and write it out all at once
+    fn write_json_file(
+        &self,
+        path: &Url,
+        data: Box<dyn Iterator<Item = DeltaResult<FilteredEngineData>> + Send + '_>,
+        overwrite: bool,
+    ) -> DeltaResult<()> {
+        self.task_executor.block_on(write_json_file_impl(
+            self.store.clone(),
+            path.clone(),
+            to_json_bytes(data)?,
+            overwrite,
+        ))
+    }
+}
+
+/// Opens a JSON file and returns a stream of record batches
+async fn open_json_file(
+    store: Arc<DynObjectStore>,
+    schema: ArrowSchemaRef,
+    batch_size: usize,
+    file_meta: FileMeta,
+) -> DeltaResult<BoxStream<'static, DeltaResult<RecordBatch>>> {
+    let path = Path::from_url_path(file_meta.location.path())?;
+    let result = store.get(&path).await?;
+    let builder = ReaderBuilder::new(schema)
+        .with_batch_size(batch_size)
+        .with_coerce_primitive(true);
+    match result.payload {
+        GetResultPayload::File(file, _) => {
+            let reader = builder.build(BufReader::new(file))?;
+            let reader = futures::stream::iter(reader).map_err(Error::from);
+
+            // Emit exactly one error, then stop the stream. We check seen_error BEFORE
+            // updating it so the first error passes through, but subsequent items don't.
+            // This is necessary because Arrow's Reader loops the same error indefinitely.
+            let mut seen_error = false;
+            let reader = reader.take_while(move |result| {
+                let return_this = !seen_error;
+                if result.is_err() {
+                    seen_error = true;
+                }
+                futures::future::ready(return_this)
+            });
+            Ok(reader.boxed())
+        }
+        GetResultPayload::Stream(s) => {
+            let mut decoder = builder.build_decoder()?;
+            let mut input = s.map_err(Error::from);
+            let mut buffered = Bytes::new();
+            let s = futures::stream::poll_fn(move |cx| {
+                loop {
+                    if buffered.is_empty() {
+                        buffered = match ready!(input.poll_next_unpin(cx)) {
+                            Some(Ok(b)) => b,
+                            Some(Err(e)) => return Poll::Ready(Some(Err(e))),
+                            None => break,
+                        };
+                    }
+
+                    // NB (from Decoder::decode docs):
+                    // Read JSON objects from `buf` (param), returning the number of bytes read
+                    //
+                    // This method returns once `batch_size` objects have been parsed since the
+                    // last call to [`Self::flush`], or `buf` is exhausted. Any remaining bytes
+                    // should be included in the next call to [`Self::decode`]
+                    let decoded = match decoder.decode(buffered.as_ref()) {
+                        Ok(decoded) => decoded,
+                        Err(e) => return Poll::Ready(Some(Err(e.into()))),
+                    };
+
+                    let read = buffered.len();
+                    buffered.advance(decoded);
+                    if decoded != read {
+                        break;
+                    }
+                }
+
+                Poll::Ready(decoder.flush().map_err(Error::from).transpose())
+            });
+            Ok(s.boxed())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet, VecDeque};
+    use std::ops::Range;
+    use std::path::PathBuf;
+    use std::sync::{mpsc, Arc, Mutex};
+    use std::task::Waker;
+
+    use crate::executor::tokio::{TokioBackgroundExecutor, TokioMultiThreadExecutor};
+    use delta_kernel::actions::get_commit_schema;
+    use delta_kernel::arrow::array::{Array, AsArray, Int32Array, RecordBatch, StringArray};
+    use delta_kernel::arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
+    use delta_kernel::engine::arrow_data::{ArrowEngineData, EngineDataArrowExt as _};
+    use delta_kernel::object_store::local::LocalFileSystem;
+    use delta_kernel::object_store::memory::InMemory;
+    use delta_kernel::object_store::PutMultipartOptions;
+    #[cfg(any(not(feature = "arrow-57"), feature = "arrow-58"))]
+    use delta_kernel::object_store::{CopyOptions, ObjectStore};
+    use delta_kernel::object_store::{
+        GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, PutOptions, PutPayload,
+        PutResult, Result,
+    };
+    use delta_kernel::schema::{DataType as DeltaDataType, Schema, StructField};
+    use futures::future;
+    use itertools::Itertools;
+    use serde_json::json;
+    use tracing::info;
+
+    fn into_record_batch(engine_data: Box<dyn EngineData>) -> RecordBatch {
+        ArrowEngineData::try_from_engine_data(engine_data)
+            .unwrap()
+            .into()
+    }
+
+    fn string_array_to_engine_data(string_array: StringArray) -> Box<dyn EngineData> {
+        let schema = delta_kernel::arrow::datatypes::Schema::new(vec![
+            delta_kernel::arrow::datatypes::Field::new("output", DataType::Utf8, true),
+        ]);
+        let batch = RecordBatch::try_new(
+            std::sync::Arc::new(schema),
+            vec![std::sync::Arc::new(string_array)],
+        )
+        .unwrap();
+        Box::new(ArrowEngineData::new(batch))
+    }
+
+    use super::*;
+
+    // A wrapper trait that allows us to work with the ObjectStore trait, without directly importing
+    // it and the ambiguous method errors it would bring.
+    #[cfg(all(feature = "arrow-57", not(feature = "arrow-58")))]
+    trait ObjectStore: delta_kernel::object_store::ObjectStore {}
+
+    #[cfg(all(feature = "arrow-57", not(feature = "arrow-58")))]
+    impl<T: delta_kernel::object_store::ObjectStore + ?Sized> ObjectStore for T {}
+
+    /// Store wrapper that wraps an inner store to guarantee the ordering of GET requests. Note
+    /// that since the keys are resolved in order, requests to subsequent keys in the order will
+    /// block until the earlier keys are requested.
+    ///
+    /// WARN: Does not handle duplicate keys, and will fail on duplicate requests of the same key.
+    ///
+    // TODO(zach): we can handle duplicate requests if we retain the ordering of the keys track
+    // that all of the keys prior to the one requested have been resolved.
+    #[derive(Debug)]
+    struct OrderedGetStore<T: ObjectStore> {
+        // The ObjectStore we are wrapping
+        inner: T,
+        // Combined state: queue and wakers, protected by a single mutex
+        state: Mutex<KeysAndWakers>,
+    }
+
+    #[derive(Debug)]
+    struct KeysAndWakers {
+        // Queue of paths in order which they will resolve
+        ordered_keys: VecDeque<Path>,
+        // Map of paths to wakers for pending get requests
+        wakers: HashMap<Path, Waker>,
+    }
+
+    impl<T: ObjectStore> OrderedGetStore<T> {
+        fn new(inner: T, ordered_keys: &[Path]) -> Self {
+            let ordered_keys = ordered_keys.to_vec();
+            // Check for duplicates
+            let mut seen = HashSet::new();
+            for key in ordered_keys.iter() {
+                if !seen.insert(key) {
+                    panic!("Duplicate key in OrderedGetStore: {key}");
+                }
+            }
+
+            let state = KeysAndWakers {
+                ordered_keys: ordered_keys.into(),
+                wakers: HashMap::new(),
+            };
+
+            Self {
+                inner,
+                state: Mutex::new(state),
+            }
+        }
+    }
+
+    impl<T: ObjectStore> std::fmt::Display for OrderedGetStore<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let state = self.state.lock().unwrap();
+            write!(f, "OrderedGetStore({:?})", state.ordered_keys)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl<T: ObjectStore> delta_kernel::object_store::ObjectStore for OrderedGetStore<T> {
+        async fn put_opts(
+            &self,
+            location: &Path,
+            payload: PutPayload,
+            opts: PutOptions,
+        ) -> Result<PutResult> {
+            self.inner.put_opts(location, payload, opts).await
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &Path,
+            opts: PutMultipartOptions,
+        ) -> Result<Box<dyn MultipartUpload>> {
+            self.inner.put_multipart_opts(location, opts).await
+        }
+
+        // A GET request is fulfilled by checking if the requested path is next in order:
+        // - if yes, remove the path from the queue and proceed with the GET request, then wake the
+        //   next path in order
+        // - if no, register the waker and wait
+        async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
+            // object_store 0.13 implements `head()` via `get_opts(..., head = true)`.
+            // The ordering queue is only meant to serialize content reads for the test, so
+            // skip queue accounting for HEAD probes used while constructing FileMeta.
+            if options.head {
+                return self.inner.get_opts(location, options).await;
+            }
+
+            // Do the actual GET request first, then introduce any artificial ordering delays as needed
+            let result = self.inner.get_opts(location, options).await;
+
+            // we implement a future which only resolves once the requested path is next in order
+            future::poll_fn(move |cx| {
+                let mut state = self.state.lock().unwrap();
+                let Some(next_key) = state.ordered_keys.front() else {
+                    panic!("Ran out of keys before {location}");
+                };
+                if next_key == location {
+                    // We are next in line. Nobody else can remove our key, and our successor
+                    // cannot race with us to register itself because we hold the lock.
+                    //
+                    // first, remove our key from the queue.
+                    //
+                    // note: safe to unwrap because we just checked that the front key exists (and
+                    // is the same as our requested location)
+                    state.ordered_keys.pop_front().unwrap();
+
+                    // there are three possible cases, either:
+                    // 1. the key has already been requested, hence there is a waker waiting, and we
+                    //    need to wake it up
+                    // 2. the next key has no waker registered, in which case we do nothing, and
+                    //    whenever the request for said key is made, it will either be next in line
+                    //    or a waker will be registered - either case ensuring that the request is
+                    //    completed
+                    // 3. the next key is the last key in the queue, in which case there is nothing
+                    //    left to do (no need to wake anyone)
+                    if let Some(next_key) = state.ordered_keys.front().cloned() {
+                        if let Some(waker) = state.wakers.remove(&next_key) {
+                            waker.wake(); // NOTE: Not async, returns instantly.
+                        }
+                    }
+                    Poll::Ready(())
+                } else {
+                    // We are not next in line, so wait on our key. Nobody can race to remove it
+                    // because we own it; nobody can race to wake us because we hold the lock.
+                    if state
+                        .wakers
+                        .insert(location.clone(), cx.waker().clone())
+                        .is_some()
+                    {
+                        panic!("Somebody else is already waiting on {location}");
+                    }
+                    Poll::Pending
+                }
+            })
+            .await;
+
+            // When we return this result, the future succeeds instantly. Any pending wake() call
+            // will not be processed before the next time we yield -- unless our executor is
+            // multi-threaded and happens to have another thread available. In that case, the
+            // serialization point is the moment our next-key poll_fn issues the wake call (or
+            // proves no wake is needed).
+            result
+        }
+
+        async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> Result<Vec<Bytes>> {
+            self.inner.get_ranges(location, ranges).await
+        }
+
+        #[cfg(all(feature = "arrow-57", not(feature = "arrow-58")))]
+        async fn delete(&self, location: &Path) -> Result<()> {
+            self.inner.delete(location).await
+        }
+
+        #[cfg(any(not(feature = "arrow-57"), feature = "arrow-58"))]
+        fn delete_stream(
+            &self,
+            locations: BoxStream<'static, Result<Path>>,
+        ) -> BoxStream<'static, Result<Path>> {
+            self.inner.delete_stream(locations)
+        }
+
+        fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, Result<ObjectMeta>> {
+            self.inner.list(prefix)
+        }
+
+        fn list_with_offset(
+            &self,
+            prefix: Option<&Path>,
+            offset: &Path,
+        ) -> BoxStream<'static, Result<ObjectMeta>> {
+            self.inner.list_with_offset(prefix, offset)
+        }
+
+        async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        #[cfg(all(feature = "arrow-57", not(feature = "arrow-58")))]
+        async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
+            self.inner.copy(from, to).await
+        }
+
+        #[cfg(any(not(feature = "arrow-57"), feature = "arrow-58"))]
+        async fn copy_opts(&self, from: &Path, to: &Path, options: CopyOptions) -> Result<()> {
+            self.inner.copy_opts(from, to, options).await
+        }
+
+        #[cfg(all(feature = "arrow-57", not(feature = "arrow-58")))]
+        async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
+            self.inner.copy_if_not_exists(from, to).await
+        }
+    }
+
+    #[test]
+    fn test_parse_json() {
+        let store = Arc::new(LocalFileSystem::new());
+        let handler = DefaultJsonHandler::new(store, Arc::new(TokioBackgroundExecutor::new()));
+
+        let json_strings = StringArray::from(vec![
+            r#"{"add":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c000.snappy.parquet","partitionValues":{},"size":635,"modificationTime":1677811178336,"dataChange":true,"stats":"{\"numRecords\":10,\"minValues\":{\"value\":0},\"maxValues\":{\"value\":9},\"nullCount\":{\"value\":0},\"tightBounds\":true}","tags":{"INSERTION_TIME":"1677811178336000","MIN_INSERTION_TIME":"1677811178336000","MAX_INSERTION_TIME":"1677811178336000","OPTIMIZE_TARGET_SIZE":"268435456"}}}"#,
+            r#"{"commitInfo":{"timestamp":1677811178585,"operation":"WRITE","operationParameters":{"mode":"ErrorIfExists","partitionBy":"[]"},"isolationLevel":"WriteSerializable","isBlindAppend":true,"operationMetrics":{"numFiles":"1","numOutputRows":"10","numOutputBytes":"635"},"engineInfo":"Runtime/<unknown>","txnId":"a6a94671-55ef-450e-9546-b8465b9147de"}}"#,
+            r#"{"protocol":{"minReaderVersion":3,"minWriterVersion":7,"readerFeatures":["deletionVectors"],"writerFeatures":["deletionVectors"]}}"#,
+            r#"{"metaData":{"id":"testId","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"value\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{"delta.enableDeletionVectors":"true","delta.columnMapping.mode":"none"},"createdTime":1677811175819}}"#,
+        ]);
+        let output_schema = get_commit_schema().clone();
+
+        let batch = handler
+            .parse_json(string_array_to_engine_data(json_strings), output_schema)
+            .unwrap();
+        assert_eq!(batch.len(), 4);
+    }
+
+    // Test that operationParameters with boolean/numeric primitives are coerced to strings.
+    // Some delta logs contain values like `"statsOnLoad": false` instead of `"statsOnLoad": "false"`.
+    // Without `with_coerce_primitive(true)`, this would fail with:
+    // "whilst decoding field 'commitInfo': whilst decoding field 'operationParameters': expected string got false"
+    #[test]
+    fn test_parse_json_coerce_operation_parameters() {
+        let store = Arc::new(LocalFileSystem::new());
+        let handler = DefaultJsonHandler::new(store, Arc::new(TokioBackgroundExecutor::new()));
+
+        // JSON with operationParameters containing boolean and numeric primitives (not strings)
+        let json_strings = StringArray::from(vec![
+            r#"{"commitInfo":{"timestamp":1677811178585,"operation":"WRITE","operationParameters":{"mode":"ErrorIfExists","statsOnLoad":false,"numRetries":5},"isolationLevel":"WriteSerializable","isBlindAppend":true,"operationMetrics":{"numFiles":"1","numOutputRows":"10","numOutputBytes":"635"},"engineInfo":"Runtime/<unknown>","txnId":"a6a94671-55ef-450e-9546-b8465b9147de"}}"#,
+        ]);
+        let output_schema = get_commit_schema().clone();
+
+        let batch: RecordBatch = handler
+            .parse_json(string_array_to_engine_data(json_strings), output_schema)
+            .unwrap()
+            .try_into_record_batch()
+            .unwrap();
+
+        assert_eq!(batch.num_rows(), 1);
+
+        // Verify the operationParameters were parsed correctly with primitives coerced to strings
+        let commit_info = batch.column_by_name("commitInfo").unwrap().as_struct();
+        let op_params = commit_info
+            .column_by_name("operationParameters")
+            .unwrap()
+            .as_map();
+
+        // The map should have 3 entries: mode, statsOnLoad, numRetries
+        let map_entries = op_params.value(0);
+        assert_eq!(map_entries.len(), 3);
+
+        // Extract keys and values from the map
+        let keys = map_entries.column(0).as_string::<i32>();
+        let values = map_entries.column(1).as_string::<i32>();
+
+        // Build a HashMap for easier lookup
+        let params: std::collections::HashMap<_, _> = (0..keys.len())
+            .map(|i| (keys.value(i), values.value(i)))
+            .collect();
+
+        // Verify coerced primitive values: boolean false -> "false", integer 5 -> "5"
+        assert_eq!(params.get("statsOnLoad"), Some(&"false"));
+        assert_eq!(params.get("numRetries"), Some(&"5"));
+        assert_eq!(params.get("mode"), Some(&"ErrorIfExists"));
+    }
+
+    #[test]
+    fn test_parse_json_drop_field() {
+        let store = Arc::new(LocalFileSystem::new());
+        let handler = DefaultJsonHandler::new(store, Arc::new(TokioBackgroundExecutor::new()));
+        let json_strings = StringArray::from(vec![
+            r#"{"add":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c000.snappy.parquet","partitionValues":{},"size":635,"modificationTime":1677811178336,"dataChange":true,"stats":"{\"numRecords\":10,\"minValues\":{\"value\":0},\"maxValues\":{\"value\":9},\"nullCount\":{\"value\":0},\"tightBounds\":false}","tags":{"INSERTION_TIME":"1677811178336000","MIN_INSERTION_TIME":"1677811178336000","MAX_INSERTION_TIME":"1677811178336000","OPTIMIZE_TARGET_SIZE":"268435456"},"deletionVector":{"storageType":"u","pathOrInlineDv":"vBn[lx{q8@P<9BNH/isA","offset":1,"sizeInBytes":36,"cardinality":2, "maxRowId": 3}}}"#,
+        ]);
+        let output_schema = get_commit_schema().clone();
+
+        let batch: RecordBatch = handler
+            .parse_json(string_array_to_engine_data(json_strings), output_schema)
+            .unwrap()
+            .try_into_record_batch()
+            .unwrap();
+        assert_eq!(batch.column(0).len(), 1);
+        let add_array = batch.column_by_name("add").unwrap().as_struct();
+        let dv_col = add_array
+            .column_by_name("deletionVector")
+            .unwrap()
+            .as_struct();
+        assert!(dv_col.column_by_name("storageType").is_some());
+        assert!(dv_col.column_by_name("maxRowId").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_read_json_files() {
+        let store = Arc::new(LocalFileSystem::new());
+
+        let path = std::fs::canonicalize(PathBuf::from(
+            "../kernel/tests/data/table-with-dv-small/_delta_log/00000000000000000000.json",
+        ))
+        .unwrap();
+        let url = Url::from_file_path(path).unwrap();
+        let location = Path::from_url_path(url.path()).unwrap();
+        let meta = store.head(&location).await.unwrap();
+
+        let files = &[FileMeta {
+            location: url.clone(),
+            last_modified: meta.last_modified.timestamp_millis(),
+            size: meta.size,
+        }];
+
+        let handler = DefaultJsonHandler::new(store, Arc::new(TokioBackgroundExecutor::new()));
+        let data: Vec<RecordBatch> = handler
+            .read_json_files(files, get_commit_schema().clone(), None)
+            .unwrap()
+            .map_ok(into_record_batch)
+            .try_collect()
+            .unwrap();
+
+        assert_eq!(data.len(), 1);
+        assert_eq!(data[0].num_rows(), 4);
+
+        // limit batch size
+        let handler = handler.with_batch_size(2);
+        let data: Vec<RecordBatch> = handler
+            .read_json_files(files, get_commit_schema().clone(), None)
+            .unwrap()
+            .map_ok(into_record_batch)
+            .try_collect()
+            .unwrap();
+
+        assert_eq!(data.len(), 2);
+        assert_eq!(data[0].num_rows(), 2);
+        assert_eq!(data[1].num_rows(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_ordered_get_store() {
+        // note we don't want to go over 1000 since we only buffer 1000 requests at a time
+        let num_paths = 1000;
+        let ordered_paths: Vec<Path> = (0..num_paths)
+            .map(|i| Path::from(format!("/test/path{i}")))
+            .collect();
+        let jumbled_paths: Vec<_> = ordered_paths[100..400]
+            .iter()
+            .chain(ordered_paths[400..].iter().rev())
+            .chain(ordered_paths[..100].iter())
+            .cloned()
+            .collect();
+
+        let memory_store = InMemory::new();
+        for (i, path) in ordered_paths.iter().enumerate() {
+            memory_store
+                .put(path, Bytes::from(format!("content_{i}")).into())
+                .await
+                .unwrap();
+        }
+
+        // Create ordered store with natural order (0, 1, 2, ...)
+        let ordered_store = Arc::new(OrderedGetStore::new(memory_store, &ordered_paths));
+
+        let (tx, rx) = mpsc::channel();
+
+        // Spawn tasks to GET each path in our somewhat jumbled order
+        // They should complete in order (0, 1, 2, ...) due to OrderedGetStore
+        let handles = jumbled_paths.into_iter().map(|path| {
+            let store = ordered_store.clone();
+            let tx = tx.clone();
+            tokio::spawn(async move {
+                let _ = store.get(&path).await.unwrap();
+                tx.send(path).unwrap();
+            })
+        });
+
+        // TODO(zach): we need to join all the handles otherwise none of the tasks run? despite the
+        // docs?
+        future::join_all(handles).await;
+        drop(tx);
+
+        // NB (from mpsc::Receiver::recv): This function will always block the current thread if
+        // there is no data available and it's possible for more data to be sent (at least one
+        // sender still exists).
+        let mut completed = Vec::new();
+        while let Ok(path) = rx.recv() {
+            completed.push(path);
+        }
+
+        assert_eq!(
+            completed,
+            ordered_paths.into_iter().collect_vec(),
+            "Expected paths to complete in order"
+        );
+    }
+
+    use crate::DefaultEngineBuilder;
+    use delta_kernel::schema::StructType;
+    use delta_kernel::Engine;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn make_invalid_named_temp() -> (NamedTempFile, Url) {
+        let mut temp_file = NamedTempFile::new().expect("Failed to create temp file");
+        write!(temp_file, r#"this is not valid json"#).expect("Failed to write to temp file");
+        let path = temp_file.path();
+        let file_url = Url::from_file_path(path).expect("Failed to create file URL");
+
+        info!("Created temporary malformed file at: {file_url}");
+        (temp_file, file_url)
+    }
+
+    #[test]
+    fn test_read_invalid_json() -> Result<(), Box<dyn std::error::Error>> {
+        let _ = tracing_subscriber::fmt().try_init();
+        let (_temp_file1, file_url1) = make_invalid_named_temp();
+        let (_temp_file2, file_url2) = make_invalid_named_temp();
+        let field = StructField::nullable("name", DeltaDataType::BOOLEAN);
+        let schema = Arc::new(StructType::try_new(vec![field]).unwrap());
+        let default_engine = DefaultEngineBuilder::new(Arc::new(LocalFileSystem::new())).build();
+
+        // Helper to check that we get expected number of errors then stream ends
+        let check_errors = |file_urls: Vec<_>, expected_errors: usize| {
+            let file_vec: Vec<_> = file_urls
+                .into_iter()
+                .map(|url| FileMeta::new(url, 1, 1))
+                .collect();
+
+            let mut iter = default_engine
+                .json_handler()
+                .read_json_files(&file_vec, schema.clone(), None)
+                .unwrap();
+
+            for _ in 0..expected_errors {
+                assert!(
+                    iter.next().unwrap().is_err(),
+                    "Read succeeded unexpectedly. The JSON should have been invalid."
+                );
+            }
+
+            assert!(
+                iter.next().is_none(),
+                "The stream should end once the read result fails"
+            );
+        };
+
+        // CASE 1: Single failing file
+        info!("\nAttempting to read single malformed JSON file...");
+        check_errors(vec![file_url1.clone()], 1);
+
+        // CASE 2: Two failing files
+        info!("\nAttempting to read two malformed JSON files...");
+        check_errors(vec![file_url1, file_url2], 2);
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+    async fn test_read_json_files_ordering() {
+        // this test checks that the read_json_files method returns the files in order in the
+        // presence of an ObjectStore (OrderedGetStore) that resolves paths in a jumbled order:
+        // 1. we set up a list of FileMetas (and some random JSON content) in order
+        // 2. we then set up an ObjectStore to resolves those paths in a jumbled order
+        // 3. then call read_json_files and check that the results are in order
+        let ordered_paths: Vec<Path> = (0..1000)
+            .map(|i| Path::from(format!("test/path{i}")))
+            .collect();
+
+        let test_list: &[(usize, Vec<Path>)] = &[
+            // test 1: buffer_size = 1000, just 1000 jumbled paths
+            (
+                1000, // buffer_size
+                ordered_paths[100..400]
+                    .iter()
+                    .chain(ordered_paths[400..].iter().rev())
+                    .chain(ordered_paths[..100].iter())
+                    .cloned()
+                    .collect(),
+            ),
+            // test 2: buffer_size = 4, jumbled paths in groups of 4
+            (
+                4, // buffer_size
+                (0..250)
+                    .flat_map(|i| {
+                        [
+                            ordered_paths[1 + 4 * i].clone(),
+                            ordered_paths[4 * i].clone(),
+                            ordered_paths[3 + 4 * i].clone(),
+                            ordered_paths[2 + 4 * i].clone(),
+                        ]
+                    })
+                    .collect_vec(),
+            ),
+        ];
+
+        let memory_store = InMemory::new();
+        for (i, path) in ordered_paths.iter().enumerate() {
+            memory_store
+                .put(path, Bytes::from(format!("{{\"val\": {i}}}")).into())
+                .await
+                .unwrap();
+        }
+
+        for (buffer_size, jumbled_paths) in test_list {
+            // set up our ObjectStore to resolve paths in a jumbled order
+            let store = Arc::new(OrderedGetStore::new(memory_store.fork(), jumbled_paths));
+
+            // convert the paths to FileMeta
+            let ordered_file_meta: Vec<_> = ordered_paths
+                .iter()
+                .map(|path| {
+                    let store = store.clone();
+                    async move {
+                        let url = Url::parse(&format!("memory:/{path}")).unwrap();
+                        let location = Path::from(path.as_ref());
+                        let meta = store.head(&location).await.unwrap();
+                        FileMeta {
+                            location: url,
+                            last_modified: meta.last_modified.timestamp_millis(),
+                            size: meta.size,
+                        }
+                    }
+                })
+                .collect();
+
+            // note: join_all is ordered
+            let files = future::join_all(ordered_file_meta).await;
+
+            // fire off the read_json_files call (for all the files in order)
+            let handler = DefaultJsonHandler::new(
+                store,
+                Arc::new(TokioMultiThreadExecutor::new(
+                    tokio::runtime::Handle::current(),
+                )),
+            );
+            let handler = handler.with_buffer_size(*buffer_size);
+            let physical_schema = Arc::new(Schema::new_unchecked(vec![StructField::nullable(
+                "val",
+                DeltaDataType::INTEGER,
+            )]));
+            let data: Vec<RecordBatch> = handler
+                .read_json_files(&files, physical_schema, None)
+                .unwrap()
+                .map_ok(into_record_batch)
+                .try_collect()
+                .unwrap();
+
+            // check the order
+            let all_values: Vec<i32> = data
+                .iter()
+                .flat_map(|batch| {
+                    let val_col: &Int32Array = batch.column(0).as_primitive();
+                    (0..val_col.len()).map(|i| val_col.value(i)).collect_vec()
+                })
+                .collect();
+            assert_eq!(all_values, (0..1000).collect_vec());
+        }
+    }
+
+    // Helper function to create test data
+    fn create_test_data(values: Vec<&str>) -> DeltaResult<Box<dyn EngineData>> {
+        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+            "dog",
+            DataType::Utf8,
+            true,
+        )]));
+        let batch =
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(StringArray::from(values))])?;
+        Ok(Box::new(ArrowEngineData::new(batch)))
+    }
+
+    // Helper function to read JSON file asynchronously
+    async fn read_json_file(
+        store: &Arc<InMemory>,
+        path: &Path,
+    ) -> DeltaResult<Vec<serde_json::Value>> {
+        let content = store.get(path).await?;
+        let file_bytes = content.bytes().await?;
+        let file_string =
+            String::from_utf8(file_bytes.to_vec()).map_err(|e| object_store::Error::Generic {
+                store: "memory",
+                source: Box::new(e),
+            })?;
+        let json: Vec<_> = serde_json::Deserializer::from_str(&file_string)
+            .into_iter::<serde_json::Value>()
+            .flatten()
+            .collect();
+        Ok(json)
+    }
+
+    #[tokio::test]
+    async fn test_write_json_file_without_overwrite() -> DeltaResult<()> {
+        do_test_write_json_file(false).await
+    }
+
+    #[tokio::test]
+    async fn test_write_json_file_overwrite() -> DeltaResult<()> {
+        do_test_write_json_file(true).await
+    }
+
+    async fn do_test_write_json_file(overwrite: bool) -> DeltaResult<()> {
+        let store = Arc::new(InMemory::new());
+        let executor = Arc::new(TokioBackgroundExecutor::new());
+        let handler = DefaultJsonHandler::new(store.clone(), executor);
+        let path = Url::parse("memory:///test/data/00000000000000000001.json")?;
+        let object_path = Path::from("/test/data/00000000000000000001.json");
+
+        // First write with no existing file
+        let data = create_test_data(vec!["remi", "wilson"])?;
+        let filtered_data = Ok(FilteredEngineData::with_all_rows_selected(data));
+        let result =
+            handler.write_json_file(&path, Box::new(std::iter::once(filtered_data)), overwrite);
+
+        // Verify the first write is successful
+        assert!(result.is_ok());
+        let json = read_json_file(&store, &object_path).await?;
+        assert_eq!(json, vec![json!({"dog": "remi"}), json!({"dog": "wilson"})]);
+
+        // Second write with existing file
+        let data = create_test_data(vec!["seb", "tia"])?;
+        let filtered_data = Ok(FilteredEngineData::with_all_rows_selected(data));
+        let result =
+            handler.write_json_file(&path, Box::new(std::iter::once(filtered_data)), overwrite);
+
+        if overwrite {
+            // Verify the second write is successful
+            assert!(result.is_ok());
+            let json = read_json_file(&store, &object_path).await?;
+            assert_eq!(json, vec![json!({"dog": "seb"}), json!({"dog": "tia"})]);
+        } else {
+            // Verify the second write fails with FileAlreadyExists error
+            match result {
+                Err(Error::FileAlreadyExists(err_path)) => {
+                    assert_eq!(err_path, object_path.to_string());
+                }
+                _ => panic!("Expected FileAlreadyExists error, got: {result:?}"),
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/default-engine/src/lib.rs
+++ b/default-engine/src/lib.rs
@@ -1,0 +1,493 @@
+//! # The Default Engine
+//!
+//! The default implementation of [`Engine`] is [`DefaultEngine`].
+//!
+//! The underlying implementations use asynchronous IO. Async tasks are run on
+//! a separate thread pool, provided by the [`TaskExecutor`] trait. Read more in
+//! the [executor] module.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::sync::Arc;
+
+use futures::stream::{BoxStream, StreamExt as _};
+use itertools::Itertools as _;
+use url::Url;
+
+use self::executor::TaskExecutor;
+use self::filesystem::ObjectStoreStorageHandler;
+use self::json::DefaultJsonHandler;
+use self::parquet::DefaultParquetHandler;
+use delta_kernel::engine::arrow_conversion::TryFromArrow as _;
+use delta_kernel::engine::arrow_data::ArrowEngineData;
+use delta_kernel::engine::arrow_expression::ArrowEvaluationHandler;
+use delta_kernel::metrics::MetricsReporter;
+use delta_kernel::object_store::DynObjectStore;
+use delta_kernel::schema::Schema;
+use delta_kernel::transaction::WriteContext;
+use delta_kernel::{
+    DeltaResult, Engine, EngineData, Error, EvaluationHandler, JsonHandler, ParquetHandler,
+    StorageHandler,
+};
+
+pub mod executor;
+pub mod file_stream;
+pub mod filesystem;
+pub mod json;
+pub mod parquet;
+pub mod stats;
+pub mod storage;
+
+/// Converts a Stream-producing future to a synchronous iterator.
+///
+/// This method performs the initial blocking call to extract the stream from the future, and each
+/// subsequent call to `next` on the iterator translates to a blocking `stream.next()` call, using
+/// the provided `task_executor`. Buffered streams allow concurrency in the form of prefetching,
+/// because that initial call will attempt to populate the N buffer slots; every call to
+/// `stream.next()` leaves an empty slot (out of N buffer slots) that the stream immediately
+/// attempts to fill by launching another future that can make progress in the background while we
+/// block on and consume each of the N-1 entries that precede it.
+///
+/// This is an internal utility for bridging object_store's async API to
+/// Delta Kernel's synchronous handler traits.
+pub(crate) fn stream_future_to_iter<T: Send + 'static, E: executor::TaskExecutor>(
+    task_executor: Arc<E>,
+    stream_future: impl Future<Output = DeltaResult<BoxStream<'static, T>>> + Send + 'static,
+) -> DeltaResult<Box<dyn Iterator<Item = T> + Send>> {
+    Ok(Box::new(BlockingStreamIterator {
+        stream: Some(task_executor.block_on(stream_future)?),
+        task_executor,
+    }))
+}
+
+struct BlockingStreamIterator<T: Send + 'static, E: executor::TaskExecutor> {
+    stream: Option<BoxStream<'static, T>>,
+    task_executor: Arc<E>,
+}
+
+impl<T: Send + 'static, E: executor::TaskExecutor> Iterator for BlockingStreamIterator<T, E> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Move the stream into the future so we can block on it.
+        let mut stream = self.stream.take()?;
+        let (item, stream) = self
+            .task_executor
+            .block_on(async move { (stream.next().await, stream) });
+
+        // We must not poll an exhausted stream after it returned None.
+        if item.is_some() {
+            self.stream = Some(stream);
+        }
+
+        item
+    }
+}
+
+const DEFAULT_BUFFER_SIZE: usize = 1000;
+const DEFAULT_BATCH_SIZE: usize = 1000;
+
+#[derive(Debug)]
+pub struct DefaultEngine<E: TaskExecutor> {
+    object_store: Arc<DynObjectStore>,
+    task_executor: Arc<E>,
+    storage: Arc<ObjectStoreStorageHandler<E>>,
+    json: Arc<DefaultJsonHandler<E>>,
+    parquet: Arc<DefaultParquetHandler<E>>,
+    evaluation: Arc<ArrowEvaluationHandler>,
+    metrics_reporter: Option<Arc<dyn MetricsReporter>>,
+}
+
+/// Builder for creating [`DefaultEngine`] instances.
+///
+/// # Example
+///
+/// ```no_run
+/// # use std::sync::Arc;
+/// # use delta_kernel_default_engine::DefaultEngineBuilder;
+/// # use delta_kernel_default_engine::executor::tokio::TokioBackgroundExecutor;
+/// # use delta_kernel::object_store::local::LocalFileSystem;
+/// // Build a DefaultEngine with default executor
+/// let engine = DefaultEngineBuilder::new(Arc::new(LocalFileSystem::new()))
+///     .build();
+///
+/// // Build with a custom executor
+/// let engine = DefaultEngineBuilder::new(Arc::new(LocalFileSystem::new()))
+///     .with_task_executor(Arc::new(TokioBackgroundExecutor::new()))
+///     .build();
+/// ```
+#[derive(Debug)]
+pub struct DefaultEngineBuilder<E: TaskExecutor> {
+    object_store: Arc<DynObjectStore>,
+    task_executor: Arc<E>,
+    metrics_reporter: Option<Arc<dyn MetricsReporter>>,
+}
+
+impl DefaultEngineBuilder<executor::tokio::TokioBackgroundExecutor> {
+    /// Create a new [`DefaultEngineBuilder`] instance with the default executor.
+    pub fn new(object_store: Arc<DynObjectStore>) -> Self {
+        Self {
+            object_store,
+            task_executor: Arc::new(executor::tokio::TokioBackgroundExecutor::new()),
+            metrics_reporter: None,
+        }
+    }
+}
+
+impl<E: TaskExecutor> DefaultEngineBuilder<E> {
+    /// Set the metrics reporter for the engine.
+    pub fn with_metrics_reporter(mut self, reporter: Arc<dyn MetricsReporter>) -> Self {
+        self.metrics_reporter = Some(reporter);
+        self
+    }
+
+    /// Set a custom task executor for the engine.
+    ///
+    /// See [`executor::TaskExecutor`] for more details.
+    pub fn with_task_executor<F: TaskExecutor>(
+        self,
+        task_executor: Arc<F>,
+    ) -> DefaultEngineBuilder<F> {
+        DefaultEngineBuilder {
+            object_store: self.object_store,
+            task_executor,
+            metrics_reporter: self.metrics_reporter,
+        }
+    }
+
+    /// Build the [`DefaultEngine`] instance.
+    pub fn build(self) -> DefaultEngine<E> {
+        DefaultEngine::new_with_opts(self.object_store, self.task_executor, self.metrics_reporter)
+    }
+}
+
+impl DefaultEngine<executor::tokio::TokioBackgroundExecutor> {
+    /// Create a [`DefaultEngineBuilder`] for constructing a [`DefaultEngine`] with custom options.
+    ///
+    /// # Parameters
+    ///
+    /// - `object_store`: The object store to use.
+    pub fn builder(
+        object_store: Arc<DynObjectStore>,
+    ) -> DefaultEngineBuilder<executor::tokio::TokioBackgroundExecutor> {
+        DefaultEngineBuilder::new(object_store)
+    }
+}
+
+impl<E: TaskExecutor> DefaultEngine<E> {
+    fn new_with_opts(
+        object_store: Arc<DynObjectStore>,
+        task_executor: Arc<E>,
+        metrics_reporter: Option<Arc<dyn MetricsReporter>>,
+    ) -> Self {
+        Self {
+            storage: Arc::new(ObjectStoreStorageHandler::new(
+                object_store.clone(),
+                task_executor.clone(),
+                None,
+            )),
+            json: Arc::new(DefaultJsonHandler::new(
+                object_store.clone(),
+                task_executor.clone(),
+            )),
+            parquet: Arc::new(DefaultParquetHandler::new(
+                object_store.clone(),
+                task_executor.clone(),
+            )),
+            object_store,
+            task_executor,
+            evaluation: Arc::new(ArrowEvaluationHandler {}),
+            metrics_reporter,
+        }
+    }
+
+    /// Enter the runtime context of the executor associated with this engine.
+    ///
+    /// # Panics
+    ///
+    /// When calling `enter` multiple times, the returned guards **must** be dropped in the reverse
+    /// order that they were acquired.  Failure to do so will result in a panic and possible memory
+    /// leaks.
+    pub fn enter(&self) -> <E as TaskExecutor>::Guard<'_> {
+        self.task_executor.enter()
+    }
+
+    pub fn get_object_store_for_url(&self, _url: &Url) -> Option<Arc<DynObjectStore>> {
+        Some(self.object_store.clone())
+    }
+
+    /// Write `data` as a parquet file using the provided `write_context`.
+    ///
+    /// The `partition_values` keys should use **logical** column names. They will be
+    /// automatically translated to physical names using the column mapping mode from
+    /// `write_context`.
+    pub async fn write_parquet(
+        &self,
+        data: &ArrowEngineData,
+        write_context: &WriteContext,
+        partition_values: HashMap<String, String>,
+    ) -> DeltaResult<Box<dyn EngineData>> {
+        // Validate partition columns exist in the schema and translate logical names to physical names.
+        let physical_partition_values: HashMap<String, String> = partition_values
+            .into_iter()
+            .map(|(logical_name, value)| -> DeltaResult<(String, String)> {
+                let field = write_context
+                    .logical_schema()
+                    .field(&logical_name)
+                    .ok_or_else(|| {
+                        Error::generic(format!(
+                            "Partition column '{logical_name}' not found in table schema"
+                        ))
+                    })?;
+                let physical_name = field
+                    .physical_name(write_context.column_mapping_mode())
+                    .to_string();
+                Ok((physical_name, value))
+            })
+            .try_collect()?;
+
+        let transform = write_context.logical_to_physical();
+        let input_schema = Schema::try_from_arrow(data.record_batch().schema())?;
+        let output_schema = write_context.physical_schema();
+        let logical_to_physical_expr = self.evaluation_handler().new_expression_evaluator(
+            input_schema.into(),
+            transform.clone(),
+            output_schema.clone().into(),
+        )?;
+        let physical_data = logical_to_physical_expr.evaluate(data)?;
+        self.parquet
+            .write_parquet_file(
+                write_context.target_dir(),
+                physical_data,
+                physical_partition_values,
+                Some(write_context.stats_columns()),
+            )
+            .await
+    }
+}
+
+impl<E: TaskExecutor> Engine for DefaultEngine<E> {
+    fn evaluation_handler(&self) -> Arc<dyn EvaluationHandler> {
+        self.evaluation.clone()
+    }
+
+    fn storage_handler(&self) -> Arc<dyn StorageHandler> {
+        self.storage.clone()
+    }
+
+    fn json_handler(&self) -> Arc<dyn JsonHandler> {
+        self.json.clone()
+    }
+
+    fn parquet_handler(&self) -> Arc<dyn ParquetHandler> {
+        self.parquet.clone()
+    }
+
+    fn get_metrics_reporter(&self) -> Option<Arc<dyn MetricsReporter>> {
+        self.metrics_reporter.clone()
+    }
+}
+
+trait UrlExt {
+    // Check if a given url is a presigned url and can be used
+    // to access the object store via simple http requests
+    fn is_presigned(&self) -> bool;
+}
+
+impl UrlExt for Url {
+    fn is_presigned(&self) -> bool {
+        matches!(self.scheme(), "http" | "https")
+            && (
+                // https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
+                // https://developers.cloudflare.com/r2/api/s3/presigned-urls/
+                self
+                .query_pairs()
+                .any(|(k, _)| k.eq_ignore_ascii_case("X-Amz-Signature")) ||
+                // https://learn.microsoft.com/en-us/rest/api/storageservices/create-user-delegation-sas#version-2020-12-06-and-later
+                // note signed permission (sp) must always be present
+                self
+                .query_pairs().any(|(k, _)| k.eq_ignore_ascii_case("sp")) ||
+                // https://cloud.google.com/storage/docs/authentication/signatures
+                self
+                .query_pairs().any(|(k, _)| k.eq_ignore_ascii_case("X-Goog-Credential")) ||
+                // https://www.alibabacloud.com/help/en/oss/user-guide/upload-files-using-presigned-urls
+                self
+                .query_pairs().any(|(k, _)| k.eq_ignore_ascii_case("X-OSS-Credential"))
+            )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use delta_kernel::arrow::array::StringArray;
+    use delta_kernel::arrow::datatypes::{DataType as ArrowDataType, Field, Schema as ArrowSchema};
+    use delta_kernel::engine::arrow_data::ArrowEngineData;
+    use delta_kernel::engine_data::FilteredEngineData;
+    use delta_kernel::metrics::MetricEvent;
+    use delta_kernel::object_store::local::LocalFileSystem;
+    use delta_kernel::object_store::path::Path;
+    use itertools::Itertools;
+    use test_utils::delta_path_for_version;
+
+    fn test_arrow_engine(engine: &dyn delta_kernel::Engine, base_url: &Url) {
+        let get_data = || -> Box<dyn delta_kernel::EngineData> {
+            let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+                "dog",
+                ArrowDataType::Utf8,
+                true,
+            )]));
+            let data = delta_kernel::arrow::array::RecordBatch::try_new(
+                schema.clone(),
+                vec![Arc::new(StringArray::from(vec!["remi", "wilson"]))],
+            )
+            .unwrap();
+            Box::new(ArrowEngineData::new(data))
+        };
+
+        let json = engine.json_handler();
+        let get_filtered = || {
+            let data = get_data();
+            let filtered_data = FilteredEngineData::with_all_rows_selected(data);
+            Box::new(std::iter::once(Ok(filtered_data)))
+        };
+
+        let expected_names: Vec<Path> = (1..4)
+            .map(|i| delta_path_for_version(i, "json"))
+            .collect_vec();
+
+        for i in expected_names.iter().rev() {
+            let path = base_url.join(i.as_ref()).unwrap();
+            json.write_json_file(&path, get_filtered(), false).unwrap();
+        }
+        let path = base_url.join("other").unwrap();
+        json.write_json_file(&path, get_filtered(), false).unwrap();
+
+        let storage = engine.storage_handler();
+
+        let test_url = base_url.join(expected_names[0].as_ref()).unwrap();
+        let files: Vec<_> = storage.list_from(&test_url).unwrap().try_collect().unwrap();
+        assert_eq!(files.len(), expected_names.len() - 1);
+        for (file, expected) in files.iter().zip(expected_names.iter().skip(1)) {
+            assert_eq!(file.location, base_url.join(expected.as_ref()).unwrap());
+        }
+
+        let test_url = base_url
+            .join(delta_path_for_version(0, "json").as_ref())
+            .unwrap();
+        let files: Vec<_> = storage.list_from(&test_url).unwrap().try_collect().unwrap();
+        assert_eq!(files.len(), expected_names.len());
+
+        let test_url = base_url.join("_delta_log/").unwrap();
+        let files: Vec<_> = storage.list_from(&test_url).unwrap().try_collect().unwrap();
+        assert_eq!(files.len(), expected_names.len());
+        for (file, expected) in files.iter().zip(expected_names.iter()) {
+            assert_eq!(file.location, base_url.join(expected.as_ref()).unwrap());
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestMetricsReporter;
+
+    impl MetricsReporter for TestMetricsReporter {
+        fn report(&self, _event: MetricEvent) {}
+    }
+
+    #[test]
+    fn test_default_engine() {
+        let tmp = tempfile::tempdir().unwrap();
+        let url = Url::from_directory_path(tmp.path()).unwrap();
+        let object_store = Arc::new(LocalFileSystem::new());
+        let engine = DefaultEngineBuilder::new(object_store).build();
+        test_arrow_engine(&engine, &url);
+    }
+
+    #[test]
+    fn test_default_engine_builder_new_and_build() {
+        let tmp = tempfile::tempdir().unwrap();
+        let url = Url::from_directory_path(tmp.path()).unwrap();
+        let object_store = Arc::new(LocalFileSystem::new());
+        let engine = DefaultEngineBuilder::new(object_store).build();
+        test_arrow_engine(&engine, &url);
+    }
+
+    #[test]
+    fn test_default_engine_builder_with_metrics_reporter() {
+        let tmp = tempfile::tempdir().unwrap();
+        let url = Url::from_directory_path(tmp.path()).unwrap();
+        let object_store = Arc::new(LocalFileSystem::new());
+        let reporter = Arc::new(TestMetricsReporter);
+        let engine = DefaultEngineBuilder::new(object_store)
+            .with_metrics_reporter(reporter)
+            .build();
+        assert!(engine.get_metrics_reporter().is_some());
+        test_arrow_engine(&engine, &url);
+    }
+
+    #[test]
+    fn test_default_engine_builder_with_custom_executor() {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let url = Url::from_directory_path(tmp.path()).unwrap();
+        let object_store = Arc::new(LocalFileSystem::new());
+        let executor = Arc::new(executor::tokio::TokioMultiThreadExecutor::new(
+            rt.handle().clone(),
+        ));
+        let engine = DefaultEngineBuilder::new(object_store)
+            .with_task_executor(executor)
+            .build();
+        test_arrow_engine(&engine, &url);
+    }
+
+    #[test]
+    fn test_default_engine_builder_method() {
+        let tmp = tempfile::tempdir().unwrap();
+        let url = Url::from_directory_path(tmp.path()).unwrap();
+        let object_store = Arc::new(LocalFileSystem::new());
+        let engine = DefaultEngine::builder(object_store).build();
+        test_arrow_engine(&engine, &url);
+    }
+
+    #[test]
+    fn test_default_engine_builder_all_options() {
+        let tmp = tempfile::tempdir().unwrap();
+        let url = Url::from_directory_path(tmp.path()).unwrap();
+        let object_store = Arc::new(LocalFileSystem::new());
+        let reporter = Arc::new(TestMetricsReporter);
+        let executor = Arc::new(executor::tokio::TokioBackgroundExecutor::new());
+        let engine = DefaultEngineBuilder::new(object_store)
+            .with_metrics_reporter(reporter)
+            .with_task_executor(executor)
+            .build();
+        assert!(engine.get_metrics_reporter().is_some());
+        test_arrow_engine(&engine, &url);
+    }
+
+    #[test]
+    fn test_pre_signed_url() {
+        let url = Url::parse("https://example.com?X-Amz-Signature=foo").unwrap();
+        assert!(url.is_presigned());
+
+        let url = Url::parse("https://example.com?sp=foo").unwrap();
+        assert!(url.is_presigned());
+
+        let url = Url::parse("https://example.com?X-Goog-Credential=foo").unwrap();
+        assert!(url.is_presigned());
+
+        let url = Url::parse("https://example.com?X-OSS-Credential=foo").unwrap();
+        assert!(url.is_presigned());
+
+        // assert that query keys are case insensitive
+        let url = Url::parse("https://example.com?x-gooG-credenTIAL=foo").unwrap();
+        assert!(url.is_presigned());
+
+        let url = Url::parse("https://example.com?x-oss-CREDENTIAL=foo").unwrap();
+        assert!(url.is_presigned());
+
+        let url = Url::parse("https://example.com").unwrap();
+        assert!(!url.is_presigned());
+    }
+}

--- a/default-engine/src/parquet.rs
+++ b/default-engine/src/parquet.rs
@@ -1,0 +1,1438 @@
+//! Default Parquet handler implementation
+
+use std::collections::HashMap;
+use std::ops::Range;
+use std::sync::Arc;
+
+use delta_kernel::arrow::array::builder::{MapBuilder, MapFieldNames, StringBuilder};
+use delta_kernel::arrow::array::{Array, Int64Array, RecordBatch, StringArray, StructArray};
+use delta_kernel::arrow::datatypes::{DataType, Field, Schema};
+use delta_kernel::object_store::path::Path;
+use delta_kernel::object_store::{DynObjectStore, ObjectStoreExt as _};
+use delta_kernel::parquet::arrow::arrow_reader::{
+    ArrowReaderMetadata, ParquetRecordBatchReaderBuilder,
+};
+use delta_kernel::parquet::arrow::arrow_writer::ArrowWriter;
+use delta_kernel::parquet::arrow::async_reader::{
+    ParquetObjectReader, ParquetRecordBatchStreamBuilder,
+};
+use delta_kernel::parquet::arrow::async_writer::AsyncArrowWriter;
+use delta_kernel::parquet::arrow::async_writer::ParquetObjectWriter;
+use futures::stream::{self, BoxStream};
+use futures::{StreamExt, TryStreamExt};
+use uuid::Uuid;
+
+use crate::executor::TaskExecutor;
+use crate::file_stream::{FileOpenFuture, FileOpener, FileStream};
+use crate::stats::collect_stats;
+use crate::UrlExt;
+use delta_kernel::engine::arrow_conversion::{TryFromArrow as _, TryIntoArrow as _};
+use delta_kernel::engine::arrow_data::ArrowEngineData;
+use delta_kernel::engine::arrow_utils::{
+    fixup_parquet_read, generate_mask, get_requested_indices, ordering_needs_row_indexes,
+    RowIndexBuilder,
+};
+use delta_kernel::engine::parquet_row_group_skipping::ParquetRowGroupSkipping;
+use delta_kernel::expressions::ColumnName;
+use delta_kernel::schema::{SchemaRef, StructType};
+use delta_kernel::{
+    DeltaResult, EngineData, Error, FileDataReadResultIterator, FileMeta, ParquetFooter,
+    ParquetHandler, PredicateRef,
+};
+
+use delta_kernel::engine::{reader_options, writer_options};
+
+#[derive(Debug)]
+pub struct DefaultParquetHandler<E: TaskExecutor> {
+    store: Arc<DynObjectStore>,
+    task_executor: Arc<E>,
+    readahead: usize,
+}
+
+/// Metadata of a data file (typically a parquet file).
+#[derive(Debug)]
+pub struct DataFileMetadata {
+    file_meta: FileMeta,
+    /// Collected statistics for this file (includes numRecords, tightBounds, etc.).
+    stats: StructArray,
+}
+
+impl DataFileMetadata {
+    pub fn new(file_meta: FileMeta, stats: StructArray) -> Self {
+        Self { file_meta, stats }
+    }
+
+    /// Convert DataFileMetadata into a record batch which matches the schema returned by
+    /// [`add_files_schema`].
+    ///
+    /// [`add_files_schema`]: delta_kernel::transaction::Transaction::add_files_schema
+    pub(crate) fn as_record_batch(
+        &self,
+        partition_values: &HashMap<String, String>,
+    ) -> DeltaResult<Box<dyn EngineData>> {
+        let DataFileMetadata {
+            file_meta:
+                FileMeta {
+                    location,
+                    last_modified,
+                    size,
+                },
+            stats,
+            ..
+        } = self;
+        // create the record batch of the write metadata
+        let path = Arc::new(StringArray::from(vec![location.to_string()]));
+        let key_builder = StringBuilder::new();
+        let val_builder = StringBuilder::new();
+        let names = MapFieldNames {
+            entry: "key_value".to_string(),
+            key: "key".to_string(),
+            value: "value".to_string(),
+        };
+        let mut builder = MapBuilder::new(Some(names), key_builder, val_builder);
+        for (k, v) in partition_values {
+            builder.keys().append_value(k);
+            if v.is_empty() {
+                // convert empty string to null as per the Delta Spec
+                builder.values().append_null();
+            } else {
+                builder.values().append_value(v);
+            }
+        }
+        builder.append(true)?;
+        let partitions = Arc::new(builder.finish());
+        // this means max size we can write is i64::MAX (~8EB)
+        let size: i64 = (*size)
+            .try_into()
+            .map_err(|_| Error::generic("Failed to convert parquet metadata 'size' to i64"))?;
+        let size = Arc::new(Int64Array::from(vec![size]));
+        let modification_time = Arc::new(Int64Array::from(vec![*last_modified]));
+
+        let stats_array = Arc::new(stats.clone());
+
+        // Build schema dynamically based on stats (stats schema varies based on collected statistics)
+        let key_value_struct = DataType::Struct(
+            vec![
+                Field::new("key", DataType::Utf8, false),
+                Field::new("value", DataType::Utf8, true),
+            ]
+            .into(),
+        );
+        let schema = Schema::new(vec![
+            Field::new("path", DataType::Utf8, false),
+            Field::new(
+                "partitionValues",
+                DataType::Map(
+                    Arc::new(Field::new("key_value", key_value_struct, false)),
+                    false,
+                ),
+                false,
+            ),
+            Field::new("size", DataType::Int64, false),
+            Field::new("modificationTime", DataType::Int64, false),
+            Field::new("stats", stats_array.data_type().clone(), true),
+        ]);
+
+        Ok(Box::new(ArrowEngineData::new(RecordBatch::try_new(
+            Arc::new(schema),
+            vec![path, partitions, size, modification_time, stats_array],
+        )?)))
+    }
+}
+
+impl<E: TaskExecutor> DefaultParquetHandler<E> {
+    pub fn new(store: Arc<DynObjectStore>, task_executor: Arc<E>) -> Self {
+        Self {
+            store,
+            task_executor,
+            readahead: 10,
+        }
+    }
+
+    /// Max number of batches to read ahead while executing [Self::read_parquet_files()].
+    ///
+    /// Defaults to 10.
+    pub fn with_readahead(mut self, readahead: usize) -> Self {
+        self.readahead = readahead;
+        self
+    }
+
+    // Write `data` to `{path}/<uuid>.parquet` as parquet using ArrowWriter and return the parquet
+    // metadata (where `<uuid>` is a generated UUIDv4).
+    //
+    // Note: after encoding the data as parquet, this issues a PUT followed by a HEAD to storage in
+    // order to obtain metadata about the object just written.
+    async fn write_parquet(
+        &self,
+        path: &url::Url,
+        data: Box<dyn EngineData>,
+        stats_columns: &[ColumnName],
+    ) -> DeltaResult<DataFileMetadata> {
+        let batch: Box<_> = ArrowEngineData::try_from_engine_data(data)?;
+        let record_batch = batch.record_batch();
+
+        // Collect statistics before writing (includes numRecords)
+        let stats = collect_stats(record_batch, stats_columns)?;
+
+        let mut buffer = vec![];
+        let mut writer = ArrowWriter::try_new_with_options(
+            &mut buffer,
+            record_batch.schema(),
+            writer_options(),
+        )?;
+        writer.write(record_batch)?;
+        writer.close()?; // writer must be closed to write footer
+
+        let size: u64 = buffer
+            .len()
+            .try_into()
+            .map_err(|_| Error::generic("unable to convert usize to u64"))?;
+        let name: String = format!("{}.parquet", Uuid::new_v4());
+        // fail if path does not end with a trailing slash
+        if !path.path().ends_with('/') {
+            return Err(Error::generic(format!(
+                "Path must end with a trailing slash: {path}"
+            )));
+        }
+        let path = path.join(&name)?;
+
+        self.store
+            .put(&Path::from_url_path(path.path())?, buffer.into())
+            .await?;
+
+        let metadata = self.store.head(&Path::from_url_path(path.path())?).await?;
+        let modification_time = metadata.last_modified.timestamp_millis();
+        if size != metadata.size {
+            return Err(Error::generic(format!(
+                "Size mismatch after writing parquet file: expected {}, got {}",
+                size, metadata.size
+            )));
+        }
+
+        let file_meta = FileMeta::new(path, modification_time, size);
+        Ok(DataFileMetadata::new(file_meta, stats))
+    }
+
+    /// Write `data` to `{path}/<uuid>.parquet` as parquet using ArrowWriter and return the parquet
+    /// metadata as an EngineData batch which matches the [add file metadata] schema (where `<uuid>`
+    /// is a generated UUIDv4).
+    ///
+    /// Note that the schema does not contain the dataChange column. In order to set `data_change` flag,
+    /// use [`delta_kernel::transaction::Transaction::with_data_change`].
+    ///
+    /// [add file metadata]: delta_kernel::transaction::Transaction::add_files_schema
+    pub async fn write_parquet_file(
+        &self,
+        path: &url::Url,
+        data: Box<dyn EngineData>,
+        partition_values: HashMap<String, String>,
+        stats_columns: Option<&[ColumnName]>,
+    ) -> DeltaResult<Box<dyn EngineData>> {
+        let parquet_metadata = self
+            .write_parquet(path, data, stats_columns.unwrap_or(&[]))
+            .await?;
+        parquet_metadata.as_record_batch(&partition_values)
+    }
+}
+
+/// Internal async implementation of read_parquet_files
+async fn read_parquet_files_impl(
+    store: Arc<DynObjectStore>,
+    files: Vec<FileMeta>,
+    physical_schema: SchemaRef,
+    predicate: Option<PredicateRef>,
+) -> DeltaResult<BoxStream<'static, DeltaResult<Box<dyn EngineData>>>> {
+    if files.is_empty() {
+        return Ok(Box::pin(stream::empty()));
+    }
+
+    let arrow_schema = Arc::new(physical_schema.as_ref().try_into_arrow()?);
+
+    // get the first FileMeta to decide how to fetch the file.
+    // NB: This means that every file in `FileMeta` _must_ have the same scheme or things will break
+    // s3://    -> aws   (ParquetOpener)
+    // nothing  -> local (ParquetOpener)
+    // https:// -> assume presigned URL (and fetch without object_store)
+    //   -> reqwest to get data
+    //   -> parse to parquet
+    // SAFETY: we did is_empty check above, this is ok.
+    if files[0].location.is_presigned() {
+        let file_opener = Box::new(PresignedUrlOpener::new(
+            1024,
+            physical_schema.clone(),
+            predicate,
+        ));
+        let stream = FileStream::new(files, arrow_schema, file_opener)?.map_ok(
+            |record_batch| -> Box<dyn EngineData> { Box::new(ArrowEngineData::new(record_batch)) },
+        );
+        return Ok(Box::pin(stream));
+    }
+
+    // an iterator of futures that open each file
+    let file_futures = files.into_iter().map(move |file| {
+        let store = store.clone();
+        let schema = physical_schema.clone();
+        let predicate = predicate.clone();
+        async move {
+            open_parquet_file(
+                store,
+                schema,
+                predicate,
+                None,
+                crate::DEFAULT_BATCH_SIZE,
+                file,
+            )
+            .await
+        }
+    });
+    // create a stream from that iterator which buffers up to `buffer_size` futures at a time
+    let result_stream = stream::iter(file_futures)
+        .buffered(crate::DEFAULT_BUFFER_SIZE)
+        .try_flatten()
+        .map_ok(|record_batch| -> Box<dyn EngineData> {
+            Box::new(ArrowEngineData::new(record_batch))
+        });
+
+    Ok(Box::pin(result_stream))
+}
+
+impl<E: TaskExecutor> ParquetHandler for DefaultParquetHandler<E> {
+    fn read_parquet_files(
+        &self,
+        files: &[FileMeta],
+        physical_schema: SchemaRef,
+        predicate: Option<PredicateRef>,
+    ) -> DeltaResult<FileDataReadResultIterator> {
+        let future = read_parquet_files_impl(
+            self.store.clone(),
+            files.to_vec(),
+            physical_schema,
+            predicate,
+        );
+        crate::stream_future_to_iter(self.task_executor.clone(), future)
+    }
+
+    /// Writes engine data to a Parquet file at the specified location.
+    ///
+    /// This implementation uses asynchronous file I/O with object_store to write the Parquet file.
+    /// If a file already exists at the given location, it will be overwritten.
+    ///
+    /// # Parameters
+    ///
+    /// - `location` - The full URL path where the Parquet file should be written
+    ///   (e.g., `s3://bucket/path/file.parquet`, `file:///path/to/file.parquet`).
+    /// - `data` - An iterator of engine data to be written to the Parquet file.
+    ///
+    /// # Returns
+    ///
+    /// A [`DeltaResult`] indicating success or failure.
+    fn write_parquet_file(
+        &self,
+        location: url::Url,
+        mut data: Box<dyn Iterator<Item = DeltaResult<Box<dyn EngineData>>> + Send>,
+    ) -> DeltaResult<()> {
+        let store = self.store.clone();
+
+        self.task_executor.block_on(async move {
+            let path = Path::from_url_path(location.path())?;
+
+            // Get first batch to initialize writer with schema
+            let first_batch = data.next().ok_or_else(|| {
+                Error::generic("Cannot write parquet file with empty data iterator")
+            })??;
+            let first_arrow = ArrowEngineData::try_from_engine_data(first_batch)?;
+            let first_record_batch: RecordBatch = (*first_arrow).into();
+
+            let object_writer = ParquetObjectWriter::new(store, path);
+            let schema = first_record_batch.schema();
+            let mut writer =
+                AsyncArrowWriter::try_new_with_options(object_writer, schema, writer_options())?;
+
+            // Write the first batch
+            writer.write(&first_record_batch).await?;
+
+            // Write remaining batches
+            for result in data {
+                let engine_data = result?;
+                let arrow_data = ArrowEngineData::try_from_engine_data(engine_data)?;
+                let batch: RecordBatch = (*arrow_data).into();
+                writer.write(&batch).await?;
+            }
+
+            writer.finish().await?;
+
+            Ok(())
+        })
+    }
+
+    fn read_parquet_footer(&self, file: &FileMeta) -> DeltaResult<ParquetFooter> {
+        let store = self.store.clone();
+        let location = file.location.clone();
+        let file_size = file.size;
+
+        self.task_executor.block_on(async move {
+            let metadata = if location.is_presigned() {
+                let client = reqwest::Client::new();
+                let response =
+                    client.get(location.as_str()).send().await.map_err(|e| {
+                        Error::generic(format!("Failed to fetch presigned URL: {e}"))
+                    })?;
+                let bytes = response
+                    .bytes()
+                    .await
+                    .map_err(|e| Error::generic(format!("Failed to read response bytes: {e}")))?;
+                ArrowReaderMetadata::load(&bytes, reader_options())?
+            } else {
+                let path = Path::from_url_path(location.path())?;
+                let mut reader = ParquetObjectReader::new(store, path).with_file_size(file_size);
+                ArrowReaderMetadata::load_async(&mut reader, reader_options()).await?
+            };
+
+            let schema = StructType::try_from_arrow(metadata.schema().as_ref())
+                .map(Arc::new)
+                .map_err(Error::Arrow)?;
+            Ok(ParquetFooter { schema })
+        })
+    }
+}
+
+/// Opens a Parquet file and returns a stream of record batches
+async fn open_parquet_file(
+    store: Arc<DynObjectStore>,
+    table_schema: SchemaRef,
+    predicate: Option<PredicateRef>,
+    limit: Option<usize>,
+    batch_size: usize,
+    file_meta: FileMeta,
+) -> DeltaResult<BoxStream<'static, DeltaResult<RecordBatch>>> {
+    let file_location = file_meta.location.to_string();
+    let path = Path::from_url_path(file_meta.location.path())?;
+
+    let mut reader = {
+        use delta_kernel::object_store::ObjectStoreScheme;
+        // HACK: unfortunately, `ParquetObjectReader` under the hood does a suffix range
+        // request which isn't supported by Azure. For now we just detect if the URL is
+        // pointing to azure and if so, do a HEAD request so we can pass in file size to the
+        // reader which will cause the reader to avoid a suffix range request.
+        // see also: https://github.com/delta-io/delta-kernel-rs/issues/968
+
+        // Since the `Remove` action's size value is optional as specified in the delta protocol
+        // https://github.com/delta-io/delta/blob/master/PROTOCOL.md#add-file-and-remove-file,
+        // the extracted size will be zero in this case. Thus, this function
+        // need to handle the case of zero file_meta.size.
+        if file_meta.size != 0 {
+            ParquetObjectReader::new(store, path).with_file_size(file_meta.size)
+        } else if let Ok((ObjectStoreScheme::MicrosoftAzure, _)) =
+            ObjectStoreScheme::parse(&file_meta.location)
+        {
+            // also note doing HEAD then actual GET isn't atomic, and leaves us vulnerable
+            // to file changing between the two calls.
+            let meta = store.head(&path).await?;
+            ParquetObjectReader::new(store, path).with_file_size(meta.size)
+        } else {
+            ParquetObjectReader::new(store, path)
+        }
+    };
+
+    let reader_options = reader_options();
+    let metadata = ArrowReaderMetadata::load_async(&mut reader, reader_options.clone()).await?;
+    let parquet_schema = metadata.schema();
+    let (indices, requested_ordering) = get_requested_indices(&table_schema, parquet_schema)?;
+    let mut builder =
+        ParquetRecordBatchStreamBuilder::new_with_options(reader, reader_options).await?;
+    if let Some(mask) = generate_mask(
+        &table_schema,
+        parquet_schema,
+        builder.parquet_schema(),
+        &indices,
+    ) {
+        builder = builder.with_projection(mask)
+    }
+
+    // Only create RowIndexBuilder if row indexes are actually needed
+    let mut row_indexes = ordering_needs_row_indexes(&requested_ordering)
+        .then(|| RowIndexBuilder::new(builder.metadata().row_groups()));
+
+    // Filter row groups and row indexes if a predicate is provided
+    if let Some(ref predicate) = predicate {
+        builder = builder.with_row_group_filter(predicate, row_indexes.as_mut());
+    }
+    if let Some(limit) = limit {
+        builder = builder.with_limit(limit)
+    }
+
+    let mut row_indexes = row_indexes.map(|rb| rb.build()).transpose()?;
+    let stream = builder.with_batch_size(batch_size).build()?;
+
+    let arrow_schema: Arc<Schema> = Arc::new(table_schema.as_ref().try_into_arrow()?);
+    let stream = stream.map(move |rbr| {
+        fixup_parquet_read(
+            rbr?,
+            &requested_ordering,
+            row_indexes.as_mut(),
+            Some(&file_location),
+            Some(&arrow_schema),
+        )
+        .map(Into::into)
+    });
+    Ok(stream.boxed())
+}
+
+/// Implements [`FileOpener`] for a opening a parquet file from a presigned URL
+struct PresignedUrlOpener {
+    batch_size: usize,
+    predicate: Option<PredicateRef>,
+    limit: Option<usize>,
+    table_schema: SchemaRef,
+    client: reqwest::Client,
+}
+
+impl PresignedUrlOpener {
+    pub(crate) fn new(
+        batch_size: usize,
+        schema: SchemaRef,
+        predicate: Option<PredicateRef>,
+    ) -> Self {
+        Self {
+            batch_size,
+            table_schema: schema,
+            predicate,
+            limit: None,
+            client: reqwest::Client::new(),
+        }
+    }
+}
+
+impl FileOpener for PresignedUrlOpener {
+    fn open(&self, file_meta: FileMeta, _range: Option<Range<i64>>) -> DeltaResult<FileOpenFuture> {
+        let batch_size = self.batch_size;
+        let table_schema = self.table_schema.clone();
+        let predicate = self.predicate.clone();
+        let limit = self.limit;
+        let client = self.client.clone(); // uses Arc internally according to reqwest docs
+        let file_location = file_meta.location.to_string();
+
+        Ok(Box::pin(async move {
+            // fetch the file from the interweb
+            let reader = client
+                .get(&file_location)
+                .send()
+                .await
+                .map_err(Error::generic_err)?
+                .bytes()
+                .await
+                .map_err(Error::generic_err)?;
+            let reader_options = reader_options();
+            let metadata = ArrowReaderMetadata::load(&reader, reader_options.clone())?;
+            let parquet_schema = metadata.schema();
+            let (indices, requested_ordering) =
+                get_requested_indices(&table_schema, parquet_schema)?;
+
+            let mut builder =
+                ParquetRecordBatchReaderBuilder::try_new_with_options(reader, reader_options)?;
+            if let Some(mask) = generate_mask(
+                &table_schema,
+                parquet_schema,
+                builder.parquet_schema(),
+                &indices,
+            ) {
+                builder = builder.with_projection(mask)
+            }
+
+            // Only create RowIndexBuilder if row indexes are actually needed
+            let mut row_indexes = ordering_needs_row_indexes(&requested_ordering)
+                .then(|| RowIndexBuilder::new(builder.metadata().row_groups()));
+
+            // Filter row groups and row indexes if a predicate is provided
+            if let Some(ref predicate) = predicate {
+                builder = builder.with_row_group_filter(predicate, row_indexes.as_mut());
+            }
+            if let Some(limit) = limit {
+                builder = builder.with_limit(limit)
+            }
+
+            let reader = builder.with_batch_size(batch_size).build()?;
+
+            let mut row_indexes = row_indexes.map(|rb| rb.build()).transpose()?;
+            let arrow_schema: Arc<Schema> = Arc::new(table_schema.as_ref().try_into_arrow()?);
+            let stream = futures::stream::iter(reader);
+            let stream = stream.map(move |rbr| {
+                fixup_parquet_read(
+                    rbr?,
+                    &requested_ordering,
+                    row_indexes.as_mut(),
+                    Some(&file_location),
+                    Some(&arrow_schema),
+                )
+                .map(Into::into)
+            });
+            Ok(stream.boxed())
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+    use std::slice;
+
+    use crate::executor::tokio::TokioBackgroundExecutor;
+    use crate::DEFAULT_BATCH_SIZE;
+    use delta_kernel::arrow::array::{
+        Array, BinaryArray, BooleanArray, Date32Array, Decimal128Array, Float32Array, Float64Array,
+        Int16Array, Int32Array, Int64Array, Int8Array, RecordBatch, StringArray,
+        TimestampMicrosecondArray,
+    };
+    use delta_kernel::arrow::datatypes::{DataType as ArrowDataType, Field, Schema as ArrowSchema};
+    use delta_kernel::engine::arrow_conversion::TryIntoKernel as _;
+    use delta_kernel::engine::arrow_data::ArrowEngineData;
+    use delta_kernel::object_store::{
+        local::LocalFileSystem, memory::InMemory, ObjectStoreExt as _,
+    };
+    use delta_kernel::parquet::arrow::{ARROW_SCHEMA_META_KEY, PARQUET_FIELD_ID_META_KEY};
+    use delta_kernel::schema::ColumnMetadataKey;
+    use delta_kernel::EngineData;
+
+    use itertools::Itertools;
+    use url::Url;
+
+    use delta_kernel::utils::current_time_ms;
+    use test_utils::assert_result_error_with_message;
+
+    use super::*;
+
+    fn into_record_batch(
+        engine_data: DeltaResult<Box<dyn EngineData>>,
+    ) -> DeltaResult<RecordBatch> {
+        engine_data
+            .and_then(ArrowEngineData::try_from_engine_data)
+            .map(Into::into)
+    }
+
+    async fn read_all_rows_helper(file_meta: FileMeta) -> DeltaResult<Vec<RecordBatch>> {
+        let store = Arc::new(LocalFileSystem::new());
+        let path = Path::from_url_path(file_meta.location.path()).unwrap();
+        let reader = ParquetObjectReader::new(store.clone(), path);
+        let physical_schema = ParquetRecordBatchStreamBuilder::new(reader)
+            .await
+            .unwrap()
+            .schema()
+            .clone();
+        let stream = open_parquet_file(
+            store,
+            Arc::new(physical_schema.try_into_kernel().unwrap()),
+            None,
+            None,
+            DEFAULT_BATCH_SIZE,
+            file_meta,
+        )
+        .await
+        .unwrap();
+
+        let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
+        Ok(batches)
+    }
+
+    #[tokio::test]
+    async fn test_open_parquet_file_with_size() {
+        let path = std::fs::canonicalize(PathBuf::from(
+            "../kernel/tests/data/table-with-dv-small/part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c000.snappy.parquet"
+        )).unwrap();
+        let file_size = std::fs::metadata(&path).unwrap().len();
+        let url = Url::from_file_path(path).unwrap();
+        let file_meta = FileMeta {
+            location: url,
+            last_modified: 0,
+            size: file_size,
+        };
+        let data = read_all_rows_helper(file_meta).await.unwrap();
+
+        assert_eq!(data.len(), 1);
+        assert_eq!(data[0].num_rows(), 10);
+    }
+
+    #[tokio::test]
+    async fn test_open_parquet_file_without_size() {
+        let path = std::fs::canonicalize(PathBuf::from(
+            "../kernel/tests/data/table-with-dv-small/part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c000.snappy.parquet"
+        )).unwrap();
+        let url = Url::from_file_path(path).unwrap();
+        let file_meta = FileMeta {
+            location: url,
+            last_modified: 0,
+            size: 0,
+        };
+        let data = read_all_rows_helper(file_meta).await.unwrap();
+
+        assert_eq!(data.len(), 1);
+        assert_eq!(data[0].num_rows(), 10);
+    }
+
+    #[tokio::test]
+    async fn test_read_parquet_files() {
+        let store = Arc::new(LocalFileSystem::new());
+
+        let path = std::fs::canonicalize(PathBuf::from(
+            "../kernel/tests/data/table-with-dv-small/part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c000.snappy.parquet"
+        )).unwrap();
+        let url = url::Url::from_file_path(path).unwrap();
+        let location = Path::from_url_path(url.path()).unwrap();
+        let meta = store.head(&location).await.unwrap();
+
+        let reader = ParquetObjectReader::new(store.clone(), location);
+        let physical_schema = ParquetRecordBatchStreamBuilder::new(reader)
+            .await
+            .unwrap()
+            .schema()
+            .clone();
+
+        let files = &[FileMeta {
+            location: url.clone(),
+            last_modified: meta.last_modified.timestamp(),
+            size: meta.size,
+        }];
+
+        let handler = DefaultParquetHandler::new(store, Arc::new(TokioBackgroundExecutor::new()));
+        let data: Vec<RecordBatch> = handler
+            .read_parquet_files(
+                files,
+                Arc::new(physical_schema.try_into_kernel().unwrap()),
+                None,
+            )
+            .unwrap()
+            .map(into_record_batch)
+            .try_collect()
+            .unwrap();
+
+        assert_eq!(data.len(), 1);
+        assert_eq!(data[0].num_rows(), 10);
+    }
+
+    #[rstest::rstest]
+    fn test_as_record_batch(#[values(true, false)] test_empty_str: bool) {
+        let location = Url::parse("file:///test_url").unwrap();
+        let size = 1_000_000;
+        let last_modified = 10000000000;
+        let num_records = 10;
+        let file_metadata = FileMeta::new(location.clone(), last_modified, size);
+        let stats = StructArray::try_new(
+            vec![
+                Field::new("numRecords", ArrowDataType::Int64, true),
+                Field::new("tightBounds", ArrowDataType::Boolean, true),
+            ]
+            .into(),
+            vec![
+                Arc::new(Int64Array::from(vec![num_records as i64])),
+                Arc::new(BooleanArray::from(vec![true])),
+            ],
+            None,
+        )
+        .unwrap();
+        let data_file_metadata = DataFileMetadata::new(file_metadata, stats.clone());
+        let partition_value = if test_empty_str {
+            "".to_string()
+        } else {
+            "a".to_string()
+        };
+        let partition_values = HashMap::from([("partition1".to_string(), partition_value)]);
+        let actual = data_file_metadata
+            .as_record_batch(&partition_values)
+            .unwrap();
+        let actual = ArrowEngineData::try_from_engine_data(actual).unwrap();
+
+        let mut partition_values_builder = MapBuilder::new(
+            Some(MapFieldNames {
+                entry: "key_value".to_string(),
+                key: "key".to_string(),
+                value: "value".to_string(),
+            }),
+            StringBuilder::new(),
+            StringBuilder::new(),
+        );
+
+        partition_values_builder.keys().append_value("partition1");
+        if test_empty_str {
+            partition_values_builder.values().append_null(); // empty string should go to null
+        } else {
+            partition_values_builder.values().append_value("a");
+        }
+        partition_values_builder.append(true).unwrap();
+        let partition_values = partition_values_builder.finish();
+
+        // Build expected schema dynamically based on stats
+        let stats_field = Field::new("stats", stats.data_type().clone(), true);
+        let schema = Arc::new(delta_kernel::arrow::datatypes::Schema::new(vec![
+            Field::new("path", ArrowDataType::Utf8, false),
+            Field::new(
+                "partitionValues",
+                ArrowDataType::Map(
+                    Arc::new(Field::new(
+                        "key_value",
+                        ArrowDataType::Struct(
+                            vec![
+                                Field::new("key", ArrowDataType::Utf8, false),
+                                Field::new("value", ArrowDataType::Utf8, true),
+                            ]
+                            .into(),
+                        ),
+                        false,
+                    )),
+                    false,
+                ),
+                false,
+            ),
+            Field::new("size", ArrowDataType::Int64, false),
+            Field::new("modificationTime", ArrowDataType::Int64, false),
+            stats_field,
+        ]));
+
+        let expected = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![location.to_string()])),
+                Arc::new(partition_values),
+                Arc::new(Int64Array::from(vec![size as i64])),
+                Arc::new(Int64Array::from(vec![last_modified])),
+                Arc::new(stats),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(actual.record_batch(), &expected);
+    }
+
+    #[tokio::test]
+    async fn test_write_parquet() {
+        let store = Arc::new(InMemory::new());
+        let parquet_handler =
+            DefaultParquetHandler::new(store.clone(), Arc::new(TokioBackgroundExecutor::new()));
+
+        let data = Box::new(ArrowEngineData::new(
+            RecordBatch::try_from_iter(vec![(
+                "a",
+                Arc::new(Int64Array::from(vec![1, 2, 3])) as Arc<dyn Array>,
+            )])
+            .unwrap(),
+        ));
+
+        let write_metadata = parquet_handler
+            .write_parquet(&Url::parse("memory:///data/").unwrap(), data, &[])
+            .await
+            .unwrap();
+
+        let DataFileMetadata {
+            file_meta:
+                ref parquet_file @ FileMeta {
+                    ref location,
+                    last_modified,
+                    size,
+                },
+            ref stats,
+        } = write_metadata;
+        let expected_location = Url::parse("memory:///data/").unwrap();
+
+        // head the object to get metadata
+        let meta = store
+            .head(&Path::from_url_path(location.path()).unwrap())
+            .await
+            .unwrap();
+        let expected_size = meta.size;
+
+        // check that last_modified is within 10s of now
+        let now: i64 = current_time_ms().unwrap();
+
+        let filename = location.path().split('/').next_back().unwrap();
+        assert_eq!(&expected_location.join(filename).unwrap(), location);
+        assert_eq!(expected_size, size);
+        assert!(now - last_modified < 10_000);
+
+        // Check numRecords from stats
+        let num_records = stats
+            .column_by_name("numRecords")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap()
+            .value(0);
+        assert_eq!(num_records, 3);
+
+        // check we can read back
+        let path = Path::from_url_path(location.path()).unwrap();
+        let reader = ParquetObjectReader::new(store.clone(), path);
+        let physical_schema = ParquetRecordBatchStreamBuilder::new(reader)
+            .await
+            .unwrap()
+            .schema()
+            .clone();
+
+        let data: Vec<RecordBatch> = parquet_handler
+            .read_parquet_files(
+                slice::from_ref(parquet_file),
+                Arc::new(physical_schema.try_into_kernel().unwrap()),
+                None,
+            )
+            .unwrap()
+            .map(into_record_batch)
+            .try_collect()
+            .unwrap();
+
+        assert_eq!(data.len(), 1);
+        assert_eq!(data[0].num_rows(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_disallow_non_trailing_slash() {
+        let store = Arc::new(InMemory::new());
+        let parquet_handler =
+            DefaultParquetHandler::new(store.clone(), Arc::new(TokioBackgroundExecutor::new()));
+
+        let data = Box::new(ArrowEngineData::new(
+            RecordBatch::try_from_iter(vec![(
+                "a",
+                Arc::new(Int64Array::from(vec![1, 2, 3])) as Arc<dyn Array>,
+            )])
+            .unwrap(),
+        ));
+
+        assert_result_error_with_message(
+            parquet_handler
+                .write_parquet(&Url::parse("memory:///data").unwrap(), data, &[])
+                .await,
+            "Generic delta kernel error: Path must end with a trailing slash: memory:///data",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_parquet_handler_trait_write() {
+        let store = Arc::new(InMemory::new());
+        let parquet_handler: Arc<dyn ParquetHandler> = Arc::new(DefaultParquetHandler::new(
+            store.clone(),
+            Arc::new(TokioBackgroundExecutor::new()),
+        ));
+
+        let engine_data: Box<dyn EngineData> = Box::new(ArrowEngineData::new(
+            RecordBatch::try_from_iter(vec![
+                (
+                    "x",
+                    Arc::new(Int64Array::from(vec![10, 20, 30])) as Arc<dyn Array>,
+                ),
+                (
+                    "y",
+                    Arc::new(Int64Array::from(vec![100, 200, 300])) as Arc<dyn Array>,
+                ),
+            ])
+            .unwrap(),
+        ));
+
+        // Create iterator with single batch
+        let data_iter: Box<dyn Iterator<Item = DeltaResult<Box<dyn EngineData>>> + Send> =
+            Box::new(std::iter::once(Ok(engine_data)));
+
+        // Test writing through the trait method
+        let file_url = Url::parse("memory:///test/data.parquet").unwrap();
+        parquet_handler
+            .write_parquet_file(file_url.clone(), data_iter)
+            .unwrap();
+
+        // Verify we can read the file back
+        let path = Path::from_url_path(file_url.path()).unwrap();
+        let metadata = store.head(&path).await.unwrap();
+        let reader = ParquetObjectReader::new(store.clone(), path);
+        let physical_schema = ParquetRecordBatchStreamBuilder::new(reader)
+            .await
+            .unwrap()
+            .schema()
+            .clone();
+
+        let file_meta = FileMeta {
+            location: file_url,
+            last_modified: 0,
+            size: metadata.size,
+        };
+
+        let data: Vec<RecordBatch> = parquet_handler
+            .read_parquet_files(
+                slice::from_ref(&file_meta),
+                Arc::new(physical_schema.try_into_kernel().unwrap()),
+                None,
+            )
+            .unwrap()
+            .map(into_record_batch)
+            .try_collect()
+            .unwrap();
+
+        assert_eq!(data.len(), 1);
+        assert_eq!(data[0].num_rows(), 3);
+        assert_eq!(data[0].num_columns(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_parquet_handler_trait_write_and_read_roundtrip() {
+        let store = Arc::new(InMemory::new());
+        let parquet_handler: Arc<dyn ParquetHandler> = Arc::new(DefaultParquetHandler::new(
+            store.clone(),
+            Arc::new(TokioBackgroundExecutor::new()),
+        ));
+
+        // Create test data with all Delta-supported primitive types
+        let engine_data: Box<dyn EngineData> = Box::new(ArrowEngineData::new(
+            RecordBatch::try_from_iter(vec![
+                // Byte (i8)
+                (
+                    "byte_col",
+                    Arc::new(Int8Array::from(vec![1i8, 2, 3, 4, 5])) as Arc<dyn Array>,
+                ),
+                // Short (i16)
+                (
+                    "short_col",
+                    Arc::new(Int16Array::from(vec![100i16, 200, 300, 400, 500])) as Arc<dyn Array>,
+                ),
+                // Integer (i32)
+                (
+                    "int_col",
+                    Arc::new(Int32Array::from(vec![1000i32, 2000, 3000, 4000, 5000]))
+                        as Arc<dyn Array>,
+                ),
+                // Long (i64)
+                (
+                    "long_col",
+                    Arc::new(Int64Array::from(vec![10000i64, 20000, 30000, 40000, 50000]))
+                        as Arc<dyn Array>,
+                ),
+                // Float (f32)
+                (
+                    "float_col",
+                    Arc::new(Float32Array::from(vec![1.1f32, 2.2, 3.3, 4.4, 5.5]))
+                        as Arc<dyn Array>,
+                ),
+                // Double (f64)
+                (
+                    "double_col",
+                    Arc::new(Float64Array::from(vec![1.11f64, 2.22, 3.33, 4.44, 5.55]))
+                        as Arc<dyn Array>,
+                ),
+                // Boolean
+                (
+                    "bool_col",
+                    Arc::new(BooleanArray::from(vec![true, false, true, false, true]))
+                        as Arc<dyn Array>,
+                ),
+                // String
+                (
+                    "string_col",
+                    Arc::new(StringArray::from(vec!["a", "b", "c", "d", "e"])) as Arc<dyn Array>,
+                ),
+                // Binary
+                (
+                    "binary_col",
+                    Arc::new(BinaryArray::from_vec(vec![
+                        b"bin1", b"bin2", b"bin3", b"bin4", b"bin5",
+                    ])) as Arc<dyn Array>,
+                ),
+                // Date
+                (
+                    "date_col",
+                    Arc::new(Date32Array::from(vec![18262, 18263, 18264, 18265, 18266]))
+                        as Arc<dyn Array>, // Days since epoch (2020-01-01 onwards)
+                ),
+                // Timestamp (with UTC timezone)
+                (
+                    "timestamp_col",
+                    Arc::new(
+                        TimestampMicrosecondArray::from(vec![
+                            1609459200000000i64, // 2021-01-01 00:00:00 UTC
+                            1609545600000000i64,
+                            1609632000000000i64,
+                            1609718400000000i64,
+                            1609804800000000i64,
+                        ])
+                        .with_timezone("UTC"),
+                    ) as Arc<dyn Array>,
+                ),
+                // TimestampNtz (without timezone)
+                (
+                    "timestamp_ntz_col",
+                    Arc::new(TimestampMicrosecondArray::from(vec![
+                        1609459200000000i64, // 2021-01-01 00:00:00
+                        1609545600000000i64,
+                        1609632000000000i64,
+                        1609718400000000i64,
+                        1609804800000000i64,
+                    ])) as Arc<dyn Array>,
+                ),
+                // Decimal (precision 10, scale 2)
+                (
+                    "decimal_col",
+                    Arc::new(
+                        Decimal128Array::from(vec![12345i128, 23456, 34567, 45678, 56789])
+                            .with_precision_and_scale(10, 2)
+                            .unwrap(),
+                    ) as Arc<dyn Array>,
+                ),
+            ])
+            .unwrap(),
+        ));
+
+        // Create iterator with single batch
+        let data_iter: Box<dyn Iterator<Item = DeltaResult<Box<dyn EngineData>>> + Send> =
+            Box::new(std::iter::once(Ok(engine_data)));
+
+        // Write the data
+        let file_url = Url::parse("memory:///roundtrip/test.parquet").unwrap();
+        parquet_handler
+            .write_parquet_file(file_url.clone(), data_iter)
+            .unwrap();
+
+        // Read it back
+        let path = Path::from_url_path(file_url.path()).unwrap();
+        let metadata = store.head(&path).await.unwrap();
+        let reader = ParquetObjectReader::new(store.clone(), path);
+        let physical_schema = ParquetRecordBatchStreamBuilder::new(reader)
+            .await
+            .unwrap()
+            .schema()
+            .clone();
+
+        let file_meta = FileMeta {
+            location: file_url.clone(),
+            last_modified: 0,
+            size: metadata.size,
+        };
+
+        let data: Vec<RecordBatch> = parquet_handler
+            .read_parquet_files(
+                slice::from_ref(&file_meta),
+                Arc::new(physical_schema.try_into_kernel().unwrap()),
+                None,
+            )
+            .unwrap()
+            .map(into_record_batch)
+            .try_collect()
+            .unwrap();
+
+        // Verify the data
+        assert_eq!(data.len(), 1);
+        assert_eq!(data[0].num_rows(), 5);
+        assert_eq!(data[0].num_columns(), 13);
+
+        let mut col_idx = 0;
+
+        // Verify byte column
+        let byte_col = data[0]
+            .column(col_idx)
+            .as_any()
+            .downcast_ref::<Int8Array>()
+            .unwrap();
+        assert_eq!(byte_col.values(), &[1i8, 2, 3, 4, 5]);
+        col_idx += 1;
+
+        // Verify short column
+        let short_col = data[0]
+            .column(col_idx)
+            .as_any()
+            .downcast_ref::<Int16Array>()
+            .unwrap();
+        assert_eq!(short_col.values(), &[100i16, 200, 300, 400, 500]);
+        col_idx += 1;
+
+        // Verify int column
+        let int_col = data[0]
+            .column(col_idx)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!(int_col.values(), &[1000i32, 2000, 3000, 4000, 5000]);
+        col_idx += 1;
+
+        // Verify long column
+        let long_col = data[0]
+            .column(col_idx)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(long_col.values(), &[10000i64, 20000, 30000, 40000, 50000]);
+        col_idx += 1;
+
+        // Verify float column
+        let float_col = data[0]
+            .column(col_idx)
+            .as_any()
+            .downcast_ref::<Float32Array>()
+            .unwrap();
+        assert_eq!(float_col.values(), &[1.1f32, 2.2, 3.3, 4.4, 5.5]);
+        col_idx += 1;
+
+        // Verify double column
+        let double_col = data[0]
+            .column(col_idx)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        assert_eq!(double_col.values(), &[1.11f64, 2.22, 3.33, 4.44, 5.55]);
+        col_idx += 1;
+
+        // Verify bool column
+        let bool_col = data[0]
+            .column(col_idx)
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .unwrap();
+        assert!(bool_col.value(0));
+        assert!(!bool_col.value(1));
+        col_idx += 1;
+
+        // Verify string column
+        let string_col = data[0]
+            .column(col_idx)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(string_col.value(0), "a");
+        assert_eq!(string_col.value(4), "e");
+        col_idx += 1;
+
+        // Verify binary column
+        let binary_col = data[0]
+            .column(col_idx)
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .unwrap();
+        assert_eq!(binary_col.value(0), b"bin1");
+        assert_eq!(binary_col.value(4), b"bin5");
+        col_idx += 1;
+
+        // Verify date column
+        let date_col = data[0]
+            .column(col_idx)
+            .as_any()
+            .downcast_ref::<Date32Array>()
+            .unwrap();
+        assert_eq!(date_col.values(), &[18262, 18263, 18264, 18265, 18266]);
+        col_idx += 1;
+
+        // Verify timestamp column (with UTC timezone)
+        let timestamp_col = data[0]
+            .column(col_idx)
+            .as_any()
+            .downcast_ref::<TimestampMicrosecondArray>()
+            .unwrap();
+        assert_eq!(timestamp_col.value(0), 1609459200000000i64);
+        assert_eq!(timestamp_col.value(4), 1609804800000000i64);
+        assert!(timestamp_col
+            .timezone()
+            .is_some_and(|tz| tz.eq_ignore_ascii_case("utc")));
+        col_idx += 1;
+
+        // Verify timestamp_ntz column (without timezone)
+        let timestamp_ntz_col = data[0]
+            .column(col_idx)
+            .as_any()
+            .downcast_ref::<TimestampMicrosecondArray>()
+            .unwrap();
+        assert_eq!(timestamp_ntz_col.value(0), 1609459200000000i64);
+        assert_eq!(timestamp_ntz_col.value(4), 1609804800000000i64);
+        assert!(timestamp_ntz_col.timezone().is_none());
+        col_idx += 1;
+
+        // Verify decimal column
+        let decimal_col = data[0]
+            .column(col_idx)
+            .as_any()
+            .downcast_ref::<Decimal128Array>()
+            .unwrap();
+        assert_eq!(decimal_col.value(0), 12345i128);
+        assert_eq!(decimal_col.value(4), 56789i128);
+        assert_eq!(decimal_col.precision(), 10);
+        assert_eq!(decimal_col.scale(), 2);
+    }
+
+    /// Test that field IDs are accessible via ColumnMetadataKey::ParquetFieldId as documented.
+    ///
+    /// Per trait definitions in lib.rs, field IDs should be accessible via StructField::get_config_value
+    /// with ColumnMetadataKey::ParquetFieldId.
+    #[test]
+    fn test_parquet_footer_read_with_field_id() {
+        // Write parquet file with field ID
+        let field = Field::new("value", ArrowDataType::Int64, false).with_metadata(HashMap::from(
+            [(PARQUET_FIELD_ID_META_KEY.to_string(), "42".to_string())],
+        ));
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![field]));
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file_path = temp_dir.path().join("field_id_test.parquet");
+        let batch = RecordBatch::try_new(
+            arrow_schema.clone(),
+            vec![Arc::new(Int64Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
+
+        let file = std::fs::File::create(&file_path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, arrow_schema, None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        // Read footer and verify field ID accessibility
+        let store = Arc::new(LocalFileSystem::new());
+        let handler = DefaultParquetHandler::new(store, Arc::new(TokioBackgroundExecutor::new()));
+        let file_size = std::fs::metadata(&file_path).unwrap().len();
+        let file_meta = FileMeta {
+            location: Url::from_file_path(&file_path).unwrap(),
+            last_modified: 0,
+            size: file_size,
+        };
+
+        let footer = handler.read_parquet_footer(&file_meta).unwrap();
+        let field = footer
+            .schema
+            .fields()
+            .find(|f| f.name() == "value")
+            .unwrap();
+
+        // Field ID is transformed to kernel key when reading
+        assert_eq!(
+            field
+                .metadata()
+                .get(ColumnMetadataKey::ParquetFieldId.as_ref()),
+            Some(&"42".into())
+        );
+
+        // Field ID should be accessible via documented API
+        let field_id = field.get_config_value(&ColumnMetadataKey::ParquetFieldId)
+            .expect("Field ID should be accessible via ColumnMetadataKey::ParquetFieldId per lib.rs:836-837");
+
+        match field_id {
+            delta_kernel::schema::MetadataValue::String(id) => assert_eq!(id, "42"),
+            delta_kernel::schema::MetadataValue::Number(id) => assert_eq!(*id, 42),
+            other => panic!("Expected String or Number, got {other:?}"),
+        }
+    }
+
+    /// Test that columns are matched by field ID when column names differ.
+    ///
+    /// Per lib.rs:676-680, field IDs (via [`ColumnMetadataKey::ParquetFieldId`]) should take
+    /// precedence over field names for column matching.
+    ///
+    /// [`ColumnMetadataKey::ParquetFieldId`]: delta_kernel::schema::ColumnMetadataKey::ParquetFieldId
+    #[test]
+    fn test_read_parquet_with_field_id_matching() {
+        use delta_kernel::schema::{ColumnMetadataKey, MetadataValue, StructField, StructType};
+
+        // Write parquet with field IDs using PARQUET_FIELD_ID_META_KEY (Parquet's native key)
+        // The kernel will transform these to parquet.field.id when reading
+        let fields = vec![
+            Field::new("id", ArrowDataType::Int64, false).with_metadata(HashMap::from([(
+                PARQUET_FIELD_ID_META_KEY.to_string(),
+                "1".to_string(),
+            )])),
+            Field::new("name", ArrowDataType::Utf8, false).with_metadata(HashMap::from([(
+                PARQUET_FIELD_ID_META_KEY.to_string(),
+                "2".to_string(),
+            )])),
+        ];
+        let arrow_schema = Arc::new(ArrowSchema::new(fields));
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file_path = temp_dir.path().join("field_id_matching.parquet");
+        let batch = RecordBatch::try_new(
+            arrow_schema.clone(),
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+                Arc::new(StringArray::from(vec!["alice", "bob", "charlie"])),
+            ],
+        )
+        .unwrap();
+
+        let file = std::fs::File::create(&file_path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, arrow_schema, None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        // Create kernel schema with DIFFERENT names but SAME field IDs
+        let kernel_schema = Arc::new(
+            StructType::try_new(vec![
+                StructField::new("user_id", delta_kernel::schema::DataType::LONG, false)
+                    .with_metadata([(
+                        ColumnMetadataKey::ParquetFieldId.as_ref(),
+                        MetadataValue::Number(1),
+                    )]),
+                StructField::new("user_name", delta_kernel::schema::DataType::STRING, false)
+                    .with_metadata([(
+                        ColumnMetadataKey::ParquetFieldId.as_ref(),
+                        MetadataValue::Number(2),
+                    )]),
+            ])
+            .unwrap(),
+        );
+
+        // Read using kernel schema with different column names
+        let store = Arc::new(LocalFileSystem::new());
+        let handler = DefaultParquetHandler::new(store, Arc::new(TokioBackgroundExecutor::new()));
+        let file_meta = FileMeta {
+            location: Url::from_file_path(&file_path).unwrap(),
+            last_modified: 0,
+            size: std::fs::metadata(&file_path).unwrap().len(),
+        };
+
+        // Should successfully match by field ID despite different names
+        let data: Vec<RecordBatch> = handler
+            .read_parquet_files(slice::from_ref(&file_meta), kernel_schema, None)
+            .unwrap()
+            .map(into_record_batch)
+            .try_collect()
+            .unwrap();
+
+        // Verify data was correctly matched by field ID
+        assert_eq!(data.len(), 1);
+        let batch = &data[0];
+
+        let id_col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(id_col.values(), &[1, 2, 3], "Should match by field ID 1");
+
+        let name_col = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(name_col.value(0), "alice", "Should match by field ID 2");
+        assert_eq!(name_col.value(1), "bob");
+        assert_eq!(name_col.value(2), "charlie");
+    }
+
+    // Verifies that write_parquet (the internal stats-collecting path) does not embed the Arrow
+    // IPC schema in the Parquet file metadata.
+    #[tokio::test]
+    async fn write_parquet_omits_arrow_schema_metadata() {
+        let store = Arc::new(InMemory::new());
+        let parquet_handler =
+            DefaultParquetHandler::new(store.clone(), Arc::new(TokioBackgroundExecutor::new()));
+
+        let data = Box::new(ArrowEngineData::new(
+            RecordBatch::try_from_iter(vec![(
+                "a",
+                Arc::new(Int64Array::from(vec![1, 2, 3])) as Arc<dyn Array>,
+            )])
+            .unwrap(),
+        ));
+        let metadata = parquet_handler
+            .write_parquet(&Url::parse("memory:///data/").unwrap(), data, &[])
+            .await
+            .unwrap();
+
+        let path = Path::from_url_path(metadata.file_meta.location.path()).unwrap();
+        let reader = ParquetObjectReader::new(store, path);
+        let builder = ParquetRecordBatchStreamBuilder::new(reader).await.unwrap();
+        let kv = builder.metadata().file_metadata().key_value_metadata();
+        let has = kv
+            .map(|kv| kv.iter().any(|e| e.key == ARROW_SCHEMA_META_KEY))
+            .unwrap_or(false);
+        assert!(
+            !has,
+            "Parquet file should not contain embedded Arrow schema metadata"
+        );
+    }
+}

--- a/default-engine/src/stats.rs
+++ b/default-engine/src/stats.rs
@@ -1,0 +1,1535 @@
+//! Statistics collection for Delta Lake file writes.
+//!
+//! Provides `collect_stats` to compute min, max, and null count statistics
+//! for a single RecordBatch during file writes.
+
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use delta_kernel::arrow::array::{
+    new_null_array, Array, ArrayRef, AsArray, BooleanArray, Decimal128Array, Int64Array,
+    LargeStringArray, PrimitiveArray, RecordBatch, StringArray, StringViewArray, StructArray,
+};
+use delta_kernel::arrow::compute::kernels::aggregate::{max, max_string, min, min_string};
+use delta_kernel::arrow::datatypes::{
+    ArrowPrimitiveType, DataType, Date32Type, Date64Type, Decimal128Type, Field, Float32Type,
+    Float64Type, Int16Type, Int32Type, Int64Type, Int8Type, TimeUnit, TimestampMicrosecondType,
+    TimestampMillisecondType, TimestampNanosecondType, TimestampSecondType, UInt16Type, UInt32Type,
+    UInt64Type, UInt8Type,
+};
+use delta_kernel::column_trie::ColumnTrie;
+use delta_kernel::engine::arrow_utils::fix_nested_null_masks;
+use delta_kernel::expressions::ColumnName;
+use delta_kernel::{DeltaResult, Error};
+
+/// Maximum prefix length for string statistics (Delta protocol requirement).
+const STRING_PREFIX_LENGTH: usize = 32;
+
+/// Maximum expansion when searching for a valid max truncation point.
+const STRING_EXPANSION_LIMIT: usize = STRING_PREFIX_LENGTH * 2;
+
+/// ASCII DEL character (0x7F) - used as tie-breaker for max values when truncated char is ASCII.
+const ASCII_MAX_CHAR: char = '\x7F';
+
+/// Maximum Unicode code point - used as tie-breaker for max values when truncated char is non-ASCII.
+const UTF8_MAX_CHAR: char = '\u{10FFFF}';
+
+// ============================================================================
+// String truncation for Delta statistics
+// ============================================================================
+
+/// Truncate a string for min statistics.
+///
+/// For min values, we simply truncate at the prefix length. The truncated value will always
+/// be <= the original, which is correct for min statistics.
+///
+/// Returns the original string if it's already within the limit.
+fn truncate_min_string(s: &str) -> &str {
+    if s.len() <= STRING_PREFIX_LENGTH {
+        return s;
+    }
+    // Find char boundary at or before STRING_PREFIX_LENGTH
+    let end = s
+        .char_indices()
+        .take(STRING_PREFIX_LENGTH + 1)
+        .last()
+        .map(|(i, _)| i)
+        .unwrap_or(s.len());
+
+    // Take exactly STRING_PREFIX_LENGTH chars
+    let truncated_end = s
+        .char_indices()
+        .nth(STRING_PREFIX_LENGTH)
+        .map(|(i, _)| i)
+        .unwrap_or(end);
+
+    &s[..truncated_end]
+}
+
+/// Truncate a string for max statistics.
+///
+/// For max values, we need to ensure the truncated value is >= all actual values in the column.
+/// We do this by appending a "tie-breaker" character after truncation:
+/// - ASCII_MAX_CHAR (0x7F) if the character at the truncation point is ASCII (< 0x7F)
+/// - UTF8_MAX_CHAR (U+10FFFF) otherwise
+///
+/// This ensures correct data skipping behavior: any string starting with the truncated prefix
+/// will compare <= the truncated max + tie-breaker.
+///
+/// Returns `Cow::Borrowed` if no truncation needed (avoiding allocation), `Cow::Owned` when
+/// truncation is performed, or `None` if the string is too long to truncate safely.
+fn truncate_max_string(s: &str) -> Option<Cow<'_, str>> {
+    if s.len() <= STRING_PREFIX_LENGTH {
+        return Some(Cow::Borrowed(s));
+    }
+
+    // Start at STRING_PREFIX_LENGTH chars
+    let char_indices: Vec<(usize, char)> = s.char_indices().collect();
+
+    // We can expand up to STRING_EXPANSION_LIMIT chars looking for a valid truncation point
+    let max_chars = char_indices.len().min(STRING_EXPANSION_LIMIT);
+
+    // Start from STRING_PREFIX_LENGTH and look for a valid truncation point
+    for len in STRING_PREFIX_LENGTH..=max_chars {
+        if len >= char_indices.len() {
+            // Reached end of string - return original
+            return Some(Cow::Borrowed(s));
+        }
+
+        let (_, next_char) = char_indices[len];
+
+        // If the character being truncated is U+10FFFF (max Unicode code point), we cannot
+        // use this position. The tie-breaker must be >= the truncated char, but nothing is
+        // greater than U+10FFFF. Include it in the prefix and check the next character.
+        // (In Scala/Java this is a surrogate pair requiring substring check; in Rust it's one char)
+        if next_char == UTF8_MAX_CHAR {
+            continue;
+        }
+
+        let truncation_byte_idx = char_indices[len].0;
+        let truncated = &s[..truncation_byte_idx];
+
+        // Choose tie-breaker based on the character being truncated
+        let tie_breaker = if next_char < ASCII_MAX_CHAR {
+            ASCII_MAX_CHAR
+        } else {
+            UTF8_MAX_CHAR
+        };
+
+        return Some(Cow::Owned(format!("{truncated}{tie_breaker}")));
+    }
+
+    // Could not find a valid truncation point within expansion limit
+    None
+}
+
+// ============================================================================
+// Min/Max computation using Arrow compute kernels
+// ============================================================================
+
+/// Aggregation type selector.
+#[derive(Clone, Copy)]
+enum Agg {
+    Min,
+    Max,
+}
+
+/// Compute aggregation for a primitive array.
+fn agg_primitive<T>(column: &ArrayRef, agg: Agg) -> DeltaResult<Option<ArrayRef>>
+where
+    T: ArrowPrimitiveType,
+    T::Native: PartialOrd,
+    PrimitiveArray<T>: From<Vec<Option<T::Native>>>,
+{
+    let array = column.as_primitive_opt::<T>().ok_or_else(|| {
+        Error::generic(format!(
+            "Failed to downcast column to PrimitiveArray<{}>",
+            std::any::type_name::<T>()
+        ))
+    })?;
+    let result = match agg {
+        Agg::Min => min(array),
+        Agg::Max => max(array),
+    };
+    Ok(result.map(|v| Arc::new(PrimitiveArray::<T>::from(vec![Some(v)])) as ArrayRef))
+}
+
+/// Compute aggregation for a timestamp array, preserving timezone.
+fn agg_timestamp<T>(
+    column: &ArrayRef,
+    tz: Option<Arc<str>>,
+    agg: Agg,
+) -> DeltaResult<Option<ArrayRef>>
+where
+    T: delta_kernel::arrow::datatypes::ArrowTimestampType,
+    PrimitiveArray<T>: From<Vec<Option<i64>>>,
+{
+    let array = column.as_primitive_opt::<T>().ok_or_else(|| {
+        Error::generic(format!(
+            "Failed to downcast column to PrimitiveArray<{}>",
+            std::any::type_name::<T>()
+        ))
+    })?;
+    let result = match agg {
+        Agg::Min => min(array),
+        Agg::Max => max(array),
+    };
+    Ok(result.map(|v| {
+        Arc::new(PrimitiveArray::<T>::from(vec![Some(v)]).with_timezone_opt(tz)) as ArrayRef
+    }))
+}
+
+/// Compute aggregation for a decimal128 array, preserving precision and scale.
+fn agg_decimal(
+    column: &ArrayRef,
+    precision: u8,
+    scale: i8,
+    agg: Agg,
+) -> DeltaResult<Option<ArrayRef>> {
+    let array = column
+        .as_primitive_opt::<Decimal128Type>()
+        .ok_or_else(|| Error::generic("Failed to downcast column to Decimal128Array"))?;
+    let result = match agg {
+        Agg::Min => min(array),
+        Agg::Max => max(array),
+    };
+    result
+        .map(|v| {
+            Decimal128Array::from(vec![Some(v)])
+                .with_precision_and_scale(precision, scale)
+                .map(|arr| Arc::new(arr) as ArrayRef)
+        })
+        .transpose()
+        .map_err(|e| Error::generic(format!("Invalid decimal precision/scale: {e}")))
+}
+
+/// Compute aggregation for a string array with truncation.
+fn agg_string(column: &ArrayRef, agg: Agg) -> DeltaResult<Option<ArrayRef>> {
+    let array = column
+        .as_string_opt::<i32>()
+        .ok_or_else(|| Error::generic("Failed to downcast column to StringArray"))?;
+    let result = match agg {
+        Agg::Min => min_string(array),
+        Agg::Max => max_string(array),
+    };
+    match (result, agg) {
+        (Some(s), Agg::Min) => {
+            let truncated = truncate_min_string(s);
+            Ok(Some(
+                Arc::new(StringArray::from(vec![Some(truncated)])) as ArrayRef
+            ))
+        }
+        (Some(s), Agg::Max) => Ok(truncate_max_string(s)
+            .map(|t| Arc::new(StringArray::from(vec![Some(&*t)])) as ArrayRef)),
+        (None, _) => Ok(None),
+    }
+}
+
+/// Compute aggregation for a large string array with truncation.
+///
+/// Unlike StringArray, Arrow's compute kernels don't provide min/max for LargeStringArray,
+/// so we iterate manually. `iter()` yields `Option<&str>` per element (None for nulls),
+/// and `flatten()` filters out nulls so we only compare non-null values.
+fn agg_large_string(column: &ArrayRef, agg: Agg) -> DeltaResult<Option<ArrayRef>> {
+    let array = column
+        .as_string_opt::<i64>()
+        .ok_or_else(|| Error::generic("Failed to downcast column to LargeStringArray"))?;
+    let result = match agg {
+        Agg::Min => array.iter().flatten().min(),
+        Agg::Max => array.iter().flatten().max(),
+    };
+    match (result, agg) {
+        (Some(s), Agg::Min) => {
+            let truncated = truncate_min_string(s);
+            Ok(Some(
+                Arc::new(LargeStringArray::from(vec![Some(truncated)])) as ArrayRef,
+            ))
+        }
+        (Some(s), Agg::Max) => Ok(truncate_max_string(s)
+            .map(|t| Arc::new(LargeStringArray::from(vec![Some(&*t)])) as ArrayRef)),
+        (None, _) => Ok(None),
+    }
+}
+
+/// Compute aggregation for a string view array with truncation.
+///
+/// Like LargeStringArray, Arrow's compute kernels don't provide min/max for StringViewArray.
+/// See `agg_large_string` for explanation of `iter().flatten()`.
+fn agg_string_view(column: &ArrayRef, agg: Agg) -> DeltaResult<Option<ArrayRef>> {
+    let array = column
+        .as_string_view_opt()
+        .ok_or_else(|| Error::generic("Failed to downcast column to StringViewArray"))?;
+    let result: Option<&str> = match agg {
+        Agg::Min => array.iter().flatten().min(),
+        Agg::Max => array.iter().flatten().max(),
+    };
+    match (result, agg) {
+        (Some(s), Agg::Min) => {
+            let truncated = truncate_min_string(s);
+            Ok(Some(
+                Arc::new(StringViewArray::from(vec![Some(truncated)])) as ArrayRef
+            ))
+        }
+        (Some(s), Agg::Max) => Ok(truncate_max_string(s)
+            .map(|t| Arc::new(StringViewArray::from(vec![Some(&*t)])) as ArrayRef)),
+        (None, _) => Ok(None),
+    }
+}
+
+/// Compute min or max for a leaf column based on its data type.
+fn compute_leaf_agg(column: &ArrayRef, agg: Agg) -> DeltaResult<Option<ArrayRef>> {
+    match column.data_type() {
+        // Integer types
+        DataType::Int8 => agg_primitive::<Int8Type>(column, agg),
+        DataType::Int16 => agg_primitive::<Int16Type>(column, agg),
+        DataType::Int32 => agg_primitive::<Int32Type>(column, agg),
+        DataType::Int64 => agg_primitive::<Int64Type>(column, agg),
+        DataType::UInt8 => agg_primitive::<UInt8Type>(column, agg),
+        DataType::UInt16 => agg_primitive::<UInt16Type>(column, agg),
+        DataType::UInt32 => agg_primitive::<UInt32Type>(column, agg),
+        DataType::UInt64 => agg_primitive::<UInt64Type>(column, agg),
+
+        // Float types
+        DataType::Float32 => agg_primitive::<Float32Type>(column, agg),
+        DataType::Float64 => agg_primitive::<Float64Type>(column, agg),
+
+        // Date types
+        DataType::Date32 => agg_primitive::<Date32Type>(column, agg),
+        DataType::Date64 => agg_primitive::<Date64Type>(column, agg),
+
+        // Timestamp types (preserve timezone)
+        DataType::Timestamp(TimeUnit::Second, tz) => {
+            agg_timestamp::<TimestampSecondType>(column, tz.clone(), agg)
+        }
+        DataType::Timestamp(TimeUnit::Millisecond, tz) => {
+            agg_timestamp::<TimestampMillisecondType>(column, tz.clone(), agg)
+        }
+        DataType::Timestamp(TimeUnit::Microsecond, tz) => {
+            agg_timestamp::<TimestampMicrosecondType>(column, tz.clone(), agg)
+        }
+        DataType::Timestamp(TimeUnit::Nanosecond, tz) => {
+            agg_timestamp::<TimestampNanosecondType>(column, tz.clone(), agg)
+        }
+
+        // Decimal type (preserve precision/scale)
+        DataType::Decimal128(p, s) => agg_decimal(column, *p, *s, agg),
+
+        // String types (with truncation)
+        DataType::Utf8 => agg_string(column, agg),
+        DataType::LargeUtf8 => agg_large_string(column, agg),
+        DataType::Utf8View => agg_string_view(column, agg),
+
+        // Unsupported types (structs handled separately, others return no min/max)
+        _ => Ok(None),
+    }
+}
+
+// ============================================================================
+// Combined stats computation (single traversal)
+// ============================================================================
+
+/// Statistics computed for a column (leaf or nested struct).
+#[derive(Default)]
+struct ColumnStats {
+    null_count: Option<ArrayRef>,
+    min_value: Option<ArrayRef>,
+    max_value: Option<ArrayRef>,
+}
+
+/// Compute all statistics for a column in a single traversal.
+///
+/// Returns `ColumnStats` containing null_count, min, and max for this column.
+/// For struct columns, these are nested StructArrays. For leaf columns, these are scalar arrays.
+/// Map, List, and other complex types are skipped (returns default empty stats).
+fn compute_column_stats(
+    column: &ArrayRef,
+    path: &mut Vec<String>,
+    filter: &ColumnTrie<'_>,
+) -> DeltaResult<ColumnStats> {
+    match column.data_type() {
+        DataType::Struct(fields) => {
+            let struct_array = column
+                .as_struct_opt()
+                .ok_or_else(|| Error::generic("Failed to downcast column to StructArray"))?;
+
+            // Propagate struct-level nulls to all descendants
+            let fixed_struct = fix_nested_null_masks(struct_array.clone());
+
+            // Accumulators for each stat type
+            let mut null_fields: Vec<Field> = Vec::new();
+            let mut null_arrays: Vec<ArrayRef> = Vec::new();
+            let mut min_fields: Vec<Field> = Vec::new();
+            let mut min_arrays: Vec<ArrayRef> = Vec::new();
+            let mut max_fields: Vec<Field> = Vec::new();
+            let mut max_arrays: Vec<ArrayRef> = Vec::new();
+
+            for (i, field) in fields.iter().enumerate() {
+                path.push(field.name().to_string());
+
+                let child_stats = compute_column_stats(fixed_struct.column(i), path, filter)?;
+
+                if let Some(arr) = child_stats.null_count {
+                    null_fields.push(Field::new(field.name(), arr.data_type().clone(), true));
+                    null_arrays.push(arr);
+                }
+                if let Some(arr) = child_stats.min_value {
+                    min_fields.push(Field::new(field.name(), arr.data_type().clone(), true));
+                    min_arrays.push(arr);
+                }
+                if let Some(arr) = child_stats.max_value {
+                    max_fields.push(Field::new(field.name(), arr.data_type().clone(), true));
+                    max_arrays.push(arr);
+                }
+
+                path.pop();
+            }
+
+            // Build result structs (None if empty)
+            let build_struct =
+                |fields: Vec<Field>, arrays: Vec<ArrayRef>| -> DeltaResult<Option<ArrayRef>> {
+                    if fields.is_empty() {
+                        Ok(None)
+                    } else {
+                        Ok(Some(Arc::new(
+                            StructArray::try_new(fields.into(), arrays, None)
+                                .map_err(|e| Error::generic(format!("stats struct: {e}")))?,
+                        ) as ArrayRef))
+                    }
+                };
+
+            Ok(ColumnStats {
+                null_count: build_struct(null_fields, null_arrays)?,
+                min_value: build_struct(min_fields, min_arrays)?,
+                max_value: build_struct(max_fields, max_arrays)?,
+            })
+        }
+        // Complex types: collect nullCount only (no min/max)
+        DataType::Map(_, _)
+        | DataType::List(_)
+        | DataType::LargeList(_)
+        | DataType::FixedSizeList(_, _)
+        | DataType::ListView(_)
+        | DataType::LargeListView(_) => {
+            if !filter.contains_prefix_of(path) {
+                return Ok(ColumnStats::default());
+            }
+            Ok(ColumnStats {
+                null_count: Some(Arc::new(Int64Array::from(vec![column.null_count() as i64]))),
+                min_value: None,
+                max_value: None,
+            })
+        }
+        _ => {
+            // Leaf: check filter, compute all stats together
+            if !filter.contains_prefix_of(path) {
+                return Ok(ColumnStats::default());
+            }
+
+            // When min/max is None (all nulls or unsupported type), emit a null-valued
+            // single-element array to keep the field present in the stats struct. This
+            // allows downstream consumers (like StatsVerifier) to find the column and
+            // check nullCount == numRecords. The JSON serializer omits null fields, so
+            // the on-disk format still matches Spark's ignoreNullFields behavior.
+            let null_fallback = || -> ArrayRef { Arc::new(new_null_array(column.data_type(), 1)) };
+            Ok(ColumnStats {
+                null_count: Some(Arc::new(Int64Array::from(vec![column.null_count() as i64]))),
+                min_value: Some(compute_leaf_agg(column, Agg::Min)?.unwrap_or_else(&null_fallback)),
+                max_value: Some(compute_leaf_agg(column, Agg::Max)?.unwrap_or_else(null_fallback)),
+            })
+        }
+    }
+}
+
+/// Accumulates (field_name, array) pairs for building a stats struct.
+struct StatsAccumulator {
+    name: &'static str,
+    fields: Vec<Field>,
+    arrays: Vec<ArrayRef>,
+}
+
+impl StatsAccumulator {
+    fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            fields: Vec::new(),
+            arrays: Vec::new(),
+        }
+    }
+
+    fn push(&mut self, field_name: &str, array: ArrayRef) {
+        self.fields
+            .push(Field::new(field_name, array.data_type().clone(), true));
+        self.arrays.push(array);
+    }
+
+    fn build(self) -> DeltaResult<Option<(Field, Arc<dyn Array>)>> {
+        if self.fields.is_empty() {
+            return Ok(None);
+        }
+        let struct_arr = StructArray::try_new(self.fields.into(), self.arrays, None)
+            .map_err(|e| Error::generic(format!("Failed to create {}: {e}", self.name)))?;
+        let field = Field::new(self.name, struct_arr.data_type().clone(), true);
+        Ok(Some((field, Arc::new(struct_arr) as Arc<dyn Array>)))
+    }
+}
+
+/// Collect statistics from a RecordBatch for Delta Lake file statistics.
+///
+/// Returns a StructArray with the following fields:
+/// - `numRecords`: total row count
+/// - `nullCount`: nested struct with null counts per column
+/// - `minValues`: nested struct with min values per column (null when all values are null)
+/// - `maxValues`: nested struct with max values per column (null when all values are null)
+/// - `tightBounds`: always true for new file writes
+///
+/// String min/max values are truncated to a 32-character prefix with appropriate tie-breaker
+/// characters for max values. See the `stats_schema` module documentation for the full stats
+/// value rules.
+///
+/// # Arguments
+/// * `batch` - The RecordBatch to collect statistics from
+/// * `stats_columns` - Column names that should have statistics collected (allowlist).
+///   Only these columns will appear in nullCount/minValues/maxValues.
+pub(crate) fn collect_stats(
+    batch: &RecordBatch,
+    stats_columns: &[ColumnName],
+) -> DeltaResult<StructArray> {
+    let filter = ColumnTrie::from_columns(stats_columns);
+    let schema = batch.schema();
+
+    // Collect all stats in a single traversal
+    let mut null_counts = StatsAccumulator::new("nullCount");
+    let mut min_values = StatsAccumulator::new("minValues");
+    let mut max_values = StatsAccumulator::new("maxValues");
+
+    for (col_idx, field) in schema.fields().iter().enumerate() {
+        let mut path = vec![field.name().to_string()];
+        let column = batch.column(col_idx);
+
+        // Single traversal computes all three stats
+        let stats = compute_column_stats(column, &mut path, &filter)?;
+
+        if let Some(arr) = stats.null_count {
+            null_counts.push(field.name(), arr);
+        }
+        if let Some(arr) = stats.min_value {
+            min_values.push(field.name(), arr);
+        }
+        if let Some(arr) = stats.max_value {
+            max_values.push(field.name(), arr);
+        }
+    }
+
+    // Build output struct
+    let mut fields = vec![Field::new("numRecords", DataType::Int64, true)];
+    let mut arrays: Vec<Arc<dyn Array>> =
+        vec![Arc::new(Int64Array::from(vec![batch.num_rows() as i64]))];
+
+    for acc in [null_counts, min_values, max_values] {
+        if let Some((field, array)) = acc.build()? {
+            fields.push(field);
+            arrays.push(array);
+        }
+    }
+
+    // tightBounds
+    fields.push(Field::new("tightBounds", DataType::Boolean, true));
+    arrays.push(Arc::new(BooleanArray::from(vec![true])));
+
+    StructArray::try_new(fields.into(), arrays, None)
+        .map_err(|e| Error::generic(format!("Failed to create stats struct: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use delta_kernel::arrow::array::{Array, AsArray, Int32Array, Int64Array, StringArray};
+    use delta_kernel::arrow::buffer::NullBuffer;
+    use delta_kernel::arrow::compute::concat_batches;
+    use delta_kernel::arrow::datatypes::{Fields, Schema};
+    use delta_kernel::arrow::datatypes::{Int32Type, Int64Type};
+    use delta_kernel::engine::arrow_expression::evaluate_expression::to_json;
+    use delta_kernel::expressions::column_name;
+    use delta_kernel::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+
+    #[test]
+    fn test_collect_stats_single_batch() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(vec![1, 2, 3]))]).unwrap();
+
+        let stats = collect_stats(&batch, &[column_name!("id")]).unwrap();
+
+        assert_eq!(stats.len(), 1);
+        let num_records = stats
+            .column_by_name("numRecords")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(num_records.value(0), 3);
+    }
+
+    #[test]
+    fn test_collect_stats_null_counts() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("value", DataType::Utf8, true),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+                Arc::new(StringArray::from(vec![Some("a"), None, Some("c")])),
+            ],
+        )
+        .unwrap();
+
+        let stats = collect_stats(&batch, &[column_name!("id"), column_name!("value")]).unwrap();
+
+        // Check nullCount struct
+        let null_count = stats
+            .column_by_name("nullCount")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+
+        // id has 0 nulls
+        let id_null_count = null_count
+            .column_by_name("id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(id_null_count.value(0), 0);
+
+        // value has 1 null
+        let value_null_count = null_count
+            .column_by_name("value")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(value_null_count.value(0), 1);
+    }
+
+    #[test]
+    fn test_collect_stats_respects_stats_columns() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("value", DataType::Utf8, true),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+                Arc::new(StringArray::from(vec![Some("a"), None, Some("c")])),
+            ],
+        )
+        .unwrap();
+
+        // Only collect stats for "id", not "value"
+        let stats = collect_stats(&batch, &[column_name!("id")]).unwrap();
+
+        let null_count = stats
+            .column_by_name("nullCount")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+
+        // Only id should be present
+        assert!(null_count.column_by_name("id").is_some());
+        assert!(null_count.column_by_name("value").is_none());
+    }
+
+    #[test]
+    fn test_collect_stats_min_max() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("number", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![5, 1, 9, 3])),
+                Arc::new(StringArray::from(vec![
+                    Some("banana"),
+                    Some("apple"),
+                    Some("cherry"),
+                    None,
+                ])),
+            ],
+        )
+        .unwrap();
+
+        let stats = collect_stats(&batch, &[column_name!("number"), column_name!("name")]).unwrap();
+
+        // Check minValues
+        let min_values = stats
+            .column_by_name("minValues")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+
+        let number_min = min_values
+            .column_by_name("number")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(number_min.value(0), 1);
+
+        let name_min = min_values
+            .column_by_name("name")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(name_min.value(0), "apple");
+
+        // Check maxValues
+        let max_values = stats
+            .column_by_name("maxValues")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+
+        let number_max = max_values
+            .column_by_name("number")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(number_max.value(0), 9);
+
+        let name_max = max_values
+            .column_by_name("name")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(name_max.value(0), "cherry");
+    }
+
+    #[test]
+    fn test_collect_stats_all_nulls() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "value",
+            DataType::Int64,
+            true,
+        )]));
+
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(Int64Array::from(vec![
+                None as Option<i64>,
+                None,
+                None,
+            ]))],
+        )
+        .unwrap();
+
+        let stats = collect_stats(&batch, &[column_name!("value")]).unwrap();
+
+        // numRecords should be 3
+        let num_records = stats
+            .column_by_name("numRecords")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(num_records.value(0), 3);
+
+        // nullCount should be 3
+        let null_count = stats
+            .column_by_name("nullCount")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+        let value_null_count = null_count
+            .column_by_name("value")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(value_null_count.value(0), 3);
+
+        // All-null columns are present in minValues/maxValues but with null values.
+        // The field must exist so that StatsVerifier can find it via visit_rows and
+        // check nullCount == numRecords. The JSON serializer omits null fields, so
+        // the on-disk format still matches Spark's ignoreNullFields behavior.
+        let min_values = stats
+            .column_by_name("minValues")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+        let min_col = min_values.column_by_name("value").unwrap();
+        assert!(min_col.is_null(0));
+
+        let max_values = stats
+            .column_by_name("maxValues")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+        let max_col = max_values.column_by_name("value").unwrap();
+        assert!(max_col.is_null(0));
+    }
+
+    #[test]
+    fn test_collect_stats_empty_stats_columns() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(vec![1, 2, 3]))]).unwrap();
+
+        // No stats columns requested
+        let stats = collect_stats(&batch, &[]).unwrap();
+
+        // Should still have numRecords and tightBounds
+        assert!(stats.column_by_name("numRecords").is_some());
+        assert!(stats.column_by_name("tightBounds").is_some());
+
+        // Should not have nullCount, minValues, maxValues
+        assert!(stats.column_by_name("nullCount").is_none());
+        assert!(stats.column_by_name("minValues").is_none());
+        assert!(stats.column_by_name("maxValues").is_none());
+    }
+
+    #[test]
+    fn test_collect_stats_string_truncation_ascii() {
+        let schema = Arc::new(Schema::new(vec![Field::new("text", DataType::Utf8, false)]));
+
+        // Create an ASCII string longer than 32 characters
+        let long_string = "a".repeat(50);
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(StringArray::from(vec![long_string.as_str()]))],
+        )
+        .unwrap();
+
+        let stats = collect_stats(&batch, &[column_name!("text")]).unwrap();
+
+        // Check minValues - should be truncated to exactly 32 chars
+        let min_values = stats
+            .column_by_name("minValues")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+
+        let text_min = min_values
+            .column_by_name("text")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+
+        assert_eq!(text_min.value(0).len(), 32);
+        assert_eq!(text_min.value(0), "a".repeat(32));
+
+        // Check maxValues - should be 32 chars + 0x7F tie-breaker (since 'a' < 0x7F)
+        let max_values = stats
+            .column_by_name("maxValues")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+
+        let text_max = max_values
+            .column_by_name("text")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+
+        let expected_max = format!("{}\x7F", "a".repeat(32));
+        assert_eq!(text_max.value(0), expected_max);
+    }
+
+    #[test]
+    fn test_collect_stats_string_truncation_non_ascii() {
+        let schema = Arc::new(Schema::new(vec![Field::new("text", DataType::Utf8, false)]));
+
+        // Create a string where the character BEING TRUNCATED (at position 32) is non-ASCII.
+        // The tie-breaker is chosen based on the first char being removed, not the last kept.
+        // 32 'a's followed by 'À' (>= 0x7F) followed by more chars
+        let long_string = format!("{}À{}", "a".repeat(32), "b".repeat(20));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(StringArray::from(vec![long_string.as_str()]))],
+        )
+        .unwrap();
+
+        let stats = collect_stats(&batch, &[column_name!("text")]).unwrap();
+
+        // Check maxValues - should use UTF8_MAX_CHAR since 'À' (the truncated char) >= 0x7F
+        let max_values = stats
+            .column_by_name("maxValues")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+
+        let text_max = max_values
+            .column_by_name("text")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+
+        // Should be 32 'a's + U+10FFFF (tie-breaker for non-ASCII truncated char)
+        let expected_max = format!("{}\u{10FFFF}", "a".repeat(32));
+        assert_eq!(text_max.value(0), expected_max);
+    }
+
+    #[test]
+    fn test_collect_stats_string_no_truncation_needed() {
+        let schema = Arc::new(Schema::new(vec![Field::new("text", DataType::Utf8, false)]));
+
+        // String within 32 chars - should not be truncated
+        let short_string = "hello world";
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(StringArray::from(vec![short_string]))],
+        )
+        .unwrap();
+
+        let stats = collect_stats(&batch, &[column_name!("text")]).unwrap();
+
+        let min_values = stats
+            .column_by_name("minValues")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+
+        let text_min = min_values
+            .column_by_name("text")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+
+        assert_eq!(text_min.value(0), short_string);
+
+        let max_values = stats
+            .column_by_name("maxValues")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+
+        let text_max = max_values
+            .column_by_name("text")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+
+        assert_eq!(text_max.value(0), short_string);
+    }
+
+    #[test]
+    fn test_truncate_min_string() {
+        // Short string - no truncation
+        assert_eq!(truncate_min_string("hello"), "hello");
+
+        // Exactly 32 chars - no truncation
+        let s32 = "a".repeat(32);
+        assert_eq!(truncate_min_string(&s32), s32);
+
+        // Long string - truncated to 32 chars
+        let s50 = "a".repeat(50);
+        assert_eq!(truncate_min_string(&s50), "a".repeat(32));
+
+        // Multi-byte characters
+        let multi = format!("{}À", "a".repeat(35)); // 'À' is 2 bytes in UTF-8
+        assert_eq!(truncate_min_string(&multi).chars().count(), 32);
+    }
+
+    #[test]
+    fn test_truncate_max_string() {
+        // Short string - no truncation, returns Cow::Borrowed
+        assert_eq!(truncate_max_string("hello").as_deref(), Some("hello"));
+
+        // Exactly 32 chars - no truncation
+        let s32 = "a".repeat(32);
+        assert_eq!(truncate_max_string(&s32).as_deref(), Some(s32.as_str()));
+
+        // Long ASCII string - truncated with 0x7F tie-breaker
+        // The 33rd char ('a') is < 0x7F, so we use 0x7F
+        let s50 = "a".repeat(50);
+        let expected = format!("{}\x7F", "a".repeat(32));
+        assert_eq!(
+            truncate_max_string(&s50).as_deref(),
+            Some(expected.as_str())
+        );
+
+        // Non-ASCII at truncation point - uses UTF8_MAX_CHAR
+        // 32 'a's then 'À' (which is >= 0x7F), so we use UTF8_MAX
+        let non_ascii = format!("{}À{}", "a".repeat(32), "b".repeat(20));
+        let expected = format!("{}\u{10FFFF}", "a".repeat(32));
+        assert_eq!(
+            truncate_max_string(&non_ascii).as_deref(),
+            Some(expected.as_str())
+        );
+
+        // U+10FFFF at truncation point - must skip past it
+        // 32 'a's then U+10FFFF then 'b' - we can't truncate at U+10FFFF (no tie-breaker > it)
+        // so we include U+10FFFF in prefix and use 'b' to determine tie-breaker
+        let with_max_char = format!("{}\u{10FFFF}b{}", "a".repeat(32), "c".repeat(10));
+        let expected = format!("{}\u{10FFFF}\x7F", "a".repeat(32)); // 'b' < 0x7F
+        assert_eq!(
+            truncate_max_string(&with_max_char).as_deref(),
+            Some(expected.as_str())
+        );
+    }
+
+    #[test]
+    fn test_collect_stats_nested_struct() {
+        // Schema: { nested: { a: int64, b: string } }
+        let nested_fields = Fields::from(vec![
+            Field::new("a", DataType::Int64, false),
+            Field::new("b", DataType::Utf8, true),
+        ]);
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "nested",
+            DataType::Struct(nested_fields.clone()),
+            false,
+        )]));
+
+        // Build nested struct data
+        let a_array = Arc::new(Int64Array::from(vec![10, 5, 20]));
+        let b_array = Arc::new(StringArray::from(vec![Some("zebra"), Some("apple"), None]));
+        let nested_struct = StructArray::try_new(
+            nested_fields,
+            vec![a_array as ArrayRef, b_array as ArrayRef],
+            None,
+        )
+        .unwrap();
+
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(nested_struct) as ArrayRef]).unwrap();
+
+        let stats = collect_stats(&batch, &[column_name!("nested")]).unwrap();
+
+        // Check nullCount.nested.a = 0, nullCount.nested.b = 1
+        let null_count = stats
+            .column_by_name("nullCount")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+
+        let nested_null = null_count
+            .column_by_name("nested")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+
+        let a_null = nested_null
+            .column_by_name("a")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(a_null.value(0), 0);
+
+        let b_null = nested_null
+            .column_by_name("b")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(b_null.value(0), 1);
+
+        // Check minValues.nested.a = 5, minValues.nested.b = "apple"
+        let min_values = stats
+            .column_by_name("minValues")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+
+        let nested_min = min_values
+            .column_by_name("nested")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+
+        let a_min = nested_min
+            .column_by_name("a")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(a_min.value(0), 5);
+
+        let b_min = nested_min
+            .column_by_name("b")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(b_min.value(0), "apple");
+
+        // Check maxValues.nested.a = 20, maxValues.nested.b = "zebra"
+        let max_values = stats
+            .column_by_name("maxValues")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+
+        let nested_max = max_values
+            .column_by_name("nested")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+
+        let a_max = nested_max
+            .column_by_name("a")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(a_max.value(0), 20);
+
+        let b_max = nested_max
+            .column_by_name("b")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(b_max.value(0), "zebra");
+    }
+
+    #[test]
+    fn test_collect_stats_complex_types_null_count_only() {
+        use delta_kernel::arrow::array::ListArray;
+        use delta_kernel::arrow::buffer::OffsetBuffer;
+
+        // Schema with list column - should have nullCount but no min/max
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new(
+                "list_col",
+                DataType::List(Arc::new(Field::new("item", DataType::Int64, true))),
+                true,
+            ),
+        ]));
+
+        // Build list array: [[1, 2], null, [4, 5, 6]]
+        let values = Int64Array::from(vec![1, 2, 4, 5, 6]);
+        let offsets = OffsetBuffer::new(vec![0, 2, 2, 5].into());
+        let list_array = ListArray::new(
+            Arc::new(Field::new("item", DataType::Int64, true)),
+            offsets,
+            Arc::new(values),
+            Some(vec![true, false, true].into()), // second element is null
+        );
+
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+                Arc::new(list_array),
+            ],
+        )
+        .unwrap();
+
+        // Request stats for both columns
+        let stats = collect_stats(&batch, &[column_name!("id"), column_name!("list_col")]).unwrap();
+
+        let null_count = stats
+            .column_by_name("nullCount")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+
+        // id should have null count = 0
+        let id_nulls = null_count
+            .column_by_name("id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(id_nulls.value(0), 0);
+
+        // list_col should have null count = 1
+        let list_nulls = null_count
+            .column_by_name("list_col")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(list_nulls.value(0), 1);
+
+        // minValues should have id but NOT list_col
+        let min_values = stats
+            .column_by_name("minValues")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+        assert!(min_values.column_by_name("id").is_some());
+        assert!(min_values.column_by_name("list_col").is_none());
+
+        // maxValues should have id but NOT list_col
+        let max_values = stats
+            .column_by_name("maxValues")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+        assert!(max_values.column_by_name("id").is_some());
+        assert!(max_values.column_by_name("list_col").is_none());
+    }
+
+    #[test]
+    fn test_collect_stats_struct_with_nulls_at_struct_level() {
+        // Schema: { my_struct: { a: int32, b: int32 (nullable) } }
+        // Test both struct-level nulls and field-level nulls
+        let child_fields = Fields::from(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, true),
+        ]);
+
+        let a_values = Int32Array::from(vec![1, 2, 3, 4]);
+        // b has field-level nulls at rows 0 and 2
+        let b_values = Int32Array::from(vec![None, Some(20), None, Some(40)]);
+
+        // Struct validity: [false, true, true, false]
+        // In Arrow: false = null, true = valid
+        // So rows 0 and 3 have null structs (entire struct is null)
+        let nulls = NullBuffer::from(vec![false, true, true, false]);
+
+        let struct_array = StructArray::new(
+            child_fields.clone(),
+            vec![Arc::new(a_values), Arc::new(b_values)],
+            Some(nulls),
+        );
+
+        let schema = Schema::new(vec![Field::new(
+            "my_struct",
+            DataType::Struct(child_fields),
+            true,
+        )]);
+
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(struct_array)]).unwrap();
+
+        let stats = collect_stats(&batch, &[column_name!("my_struct")]).unwrap();
+
+        // Visualizing the data:
+        // Row 0: struct=NULL,  (a=1, b=None are "invisible")
+        // Row 1: struct=VALID, a=2, b=20
+        // Row 2: struct=VALID, a=3, b=None
+        // Row 3: struct=NULL,  (a=4, b=40 are "invisible")
+        //
+        // Expected behavior (struct nulls propagate to children):
+        // - a: visible values are [2, 3], nullCount = 2 (rows 0, 3 are struct-null)
+        // - b: visible values are [20, None], nullCount = 3 (rows 0, 3 struct-null + row 2 field-null)
+        // - a: min=2, max=3
+        // - b: min=20, max=20
+
+        // nullCount includes struct-level nulls
+        assert_eq!(
+            get_stat::<Int64Type>(&stats, "nullCount", "my_struct", "a"),
+            2
+        );
+        assert_eq!(
+            get_stat::<Int64Type>(&stats, "nullCount", "my_struct", "b"),
+            3
+        );
+
+        // minValues excludes values from null struct rows
+        assert_eq!(
+            get_stat::<Int32Type>(&stats, "minValues", "my_struct", "a"),
+            2
+        );
+        assert_eq!(
+            get_stat::<Int32Type>(&stats, "minValues", "my_struct", "b"),
+            20
+        );
+
+        // maxValues excludes values from null struct rows
+        assert_eq!(
+            get_stat::<Int32Type>(&stats, "maxValues", "my_struct", "a"),
+            3
+        );
+        assert_eq!(
+            get_stat::<Int32Type>(&stats, "maxValues", "my_struct", "b"),
+            20
+        );
+    }
+
+    // Generic helper to extract and downcast nested columns from stats
+    fn get_stat<T>(
+        stats: &StructArray,
+        stat_name: &str,
+        struct_name: &str,
+        field_name: &str,
+    ) -> T::Native
+    where
+        T: delta_kernel::arrow::datatypes::ArrowPrimitiveType,
+    {
+        stats
+            .column_by_name(stat_name)
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap()
+            .column_by_name(struct_name)
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap()
+            .column_by_name(field_name)
+            .unwrap()
+            .as_primitive::<T>()
+            .value(0)
+    }
+
+    /// Recursively extracts leaf column names from an Arrow schema for stats collection.
+    fn extract_leaf_columns(fields: &Fields, prefix: &[String]) -> Vec<ColumnName> {
+        let mut columns = Vec::new();
+        for field in fields.iter() {
+            let mut path = prefix.to_vec();
+            path.push(field.name().clone());
+            match field.data_type() {
+                DataType::Struct(sub_fields) => {
+                    columns.extend(extract_leaf_columns(sub_fields, &path));
+                }
+                _ => {
+                    columns.push(ColumnName::new(path));
+                }
+            }
+        }
+        columns
+    }
+
+    /// Recursively compares Spark stats JSON against kernel stats JSON.
+    /// Only checks keys present in `spark_val`; kernel may have extra keys.
+    fn assert_stats_match(
+        spark_val: &serde_json::Value,
+        kernel_val: &serde_json::Value,
+        path: &str,
+    ) {
+        match (spark_val, kernel_val) {
+            (serde_json::Value::Object(spark_map), serde_json::Value::Object(kernel_map)) => {
+                for (key, spark_child) in spark_map {
+                    let child_path = if path.is_empty() {
+                        key.clone()
+                    } else {
+                        format!("{path}.{key}")
+                    };
+                    let kernel_child = kernel_map
+                        .get(key)
+                        .unwrap_or_else(|| panic!("Kernel stats missing key: {child_path}"));
+                    assert_stats_match(spark_child, kernel_child, &child_path);
+                }
+            }
+            (serde_json::Value::Number(s), serde_json::Value::Number(k)) => {
+                let sv = s.as_f64().unwrap();
+                let kv = k.as_f64().unwrap();
+                assert!(
+                    (sv - kv).abs() < 1e-6,
+                    "Numeric mismatch at {path}: spark={sv}, kernel={kv}"
+                );
+            }
+            (serde_json::Value::String(s), serde_json::Value::String(k)) => {
+                // Spark uses "Z" suffix for TZ timestamps and no suffix for NTZ.
+                let s_normalized = s.trim_end_matches('Z').trim_end_matches("+00:00");
+                let k_normalized = k.trim_end_matches('Z').trim_end_matches("+00:00");
+
+                // Spark (Jackson) always includes fractional seconds (e.g., ".000") while Arrow's
+                // JSON encoder omits them when they are zero. Strip zero-only fractional parts
+                // so both formats compare equal.
+                if s_normalized.contains('T') && k_normalized.contains('T') {
+                    let normalize_ts = |ts: &str| -> String {
+                        if let Some(dot_pos) = ts.rfind('.') {
+                            let frac = &ts[dot_pos + 1..];
+                            if frac.chars().all(|c| c == '0') {
+                                return ts[..dot_pos].to_string();
+                            }
+                            let trimmed = frac.trim_end_matches('0');
+                            return format!("{}.{trimmed}", &ts[..dot_pos]);
+                        }
+                        ts.to_string()
+                    };
+                    let s_norm = normalize_ts(s_normalized);
+                    let k_norm = normalize_ts(k_normalized);
+                    assert_eq!(
+                        s_norm, k_norm,
+                        "Timestamp mismatch at {path}: spark={s}, kernel={k}"
+                    );
+                } else {
+                    assert_eq!(s, k, "String mismatch at {path}: spark={s}, kernel={k}");
+                }
+            }
+            _ => {
+                assert_eq!(
+                    spark_val, kernel_val,
+                    "Value mismatch at {path}: spark={spark_val}, kernel={kernel_val}"
+                );
+            }
+        }
+    }
+
+    // Verify that the `assert_stats_match` test helper correctly accepts equivalent values.
+    #[test]
+    fn test_assert_stats_match_accepts_equivalent_values() {
+        // Extra kernel keys are ignored
+        let spark = serde_json::json!({"a": 1, "b": "hello"});
+        let kernel = serde_json::json!({"a": 1, "b": "hello", "extra": true});
+        assert_stats_match(&spark, &kernel, "");
+
+        // Nested objects with extra kernel keys
+        let spark = serde_json::json!({"outer": {"inner": 42}});
+        let kernel = serde_json::json!({"outer": {"inner": 42, "extra": 0}});
+        assert_stats_match(&spark, &kernel, "");
+
+        // Timestamp with trailing ".000Z" vs no fractional part
+        let spark = serde_json::json!({"ts": "2023-06-15T12:30:00.000Z"});
+        let kernel = serde_json::json!({"ts": "2023-06-15T12:30:00Z"});
+        assert_stats_match(&spark, &kernel, "");
+
+        // Timestamp NTZ (no Z suffix) with trailing ".000"
+        let spark = serde_json::json!({"ts": "2023-06-15T12:30:00.000"});
+        let kernel = serde_json::json!({"ts": "2023-06-15T12:30:00"});
+        assert_stats_match(&spark, &kernel, "");
+
+        // Non-zero fractional seconds with different trailing zeros
+        let spark = serde_json::json!({"ts": "2023-06-15T12:30:00.500Z"});
+        let kernel = serde_json::json!({"ts": "2023-06-15T12:30:00.5Z"});
+        assert_stats_match(&spark, &kernel, "");
+    }
+
+    // Verify that the `assert_stats_match` test helper correctly rejects mismatched values.
+    #[test]
+    fn test_assert_stats_match_rejects_mismatches() {
+        let result = std::panic::catch_unwind(|| {
+            let spark = serde_json::json!({"a": 1});
+            let kernel = serde_json::json!({"b": 1});
+            assert_stats_match(&spark, &kernel, "");
+        });
+        assert!(result.is_err(), "should panic on missing key");
+
+        let result = std::panic::catch_unwind(|| {
+            let spark = serde_json::json!({"val": 1.0});
+            let kernel = serde_json::json!({"val": 2.0});
+            assert_stats_match(&spark, &kernel, "");
+        });
+        assert!(result.is_err(), "should panic on numeric mismatch");
+
+        let result = std::panic::catch_unwind(|| {
+            let spark = serde_json::json!({"s": "alpha"});
+            let kernel = serde_json::json!({"s": "beta"});
+            assert_stats_match(&spark, &kernel, "");
+        });
+        assert!(result.is_err(), "should panic on string mismatch");
+    }
+
+    /// Validates that kernel's `collect_stats()` produces file statistics matching Spark's output.
+    ///
+    /// Uses test data generated by PySpark containing all supported stat types: integers, floats,
+    /// date, timestamp, timestamp_ntz, string, decimal, boolean, binary, array, map, and nested
+    /// structs. Reads the parquet data, recomputes stats with kernel, and compares
+    /// numRecords/nullCount/minValues/maxValues against Spark's stats from the delta log.
+    #[test]
+    fn test_collect_stats_matches_spark() {
+        // ===== GIVEN =====
+        // Load a PySpark-generated Delta table containing all supported stat types
+        // and extract Spark's reference stats from the commit log.
+        let test_path =
+            std::fs::canonicalize("../kernel/tests/data/stats-writing-all-types/delta").unwrap();
+
+        let commit_path = test_path
+            .join("_delta_log")
+            .join("00000000000000000001.json");
+        let commit_data = std::fs::read_to_string(&commit_path).expect("read commit 1 json");
+
+        let mut spark_stats_json = None;
+        let mut parquet_path = None;
+
+        for line in commit_data.lines() {
+            let action: serde_json::Value = serde_json::from_str(line).expect("parse JSON line");
+            if let Some(add) = action.get("add") {
+                spark_stats_json = Some(
+                    add["stats"]
+                        .as_str()
+                        .expect("stats should be a string")
+                        .to_string(),
+                );
+                parquet_path = Some(
+                    add["path"]
+                        .as_str()
+                        .expect("path should be a string")
+                        .to_string(),
+                );
+                break;
+            }
+        }
+
+        let spark_stats_json = spark_stats_json.expect("should find add action with stats");
+        let parquet_path = parquet_path.expect("should find add action with path");
+        let spark_stats: serde_json::Value =
+            serde_json::from_str(&spark_stats_json).expect("parse Spark stats JSON");
+
+        // ===== WHEN =====
+        // Read the same parquet file and compute stats using kernel's collect_stats.
+        let parquet_file_path = test_path.join(&parquet_path);
+        let file = std::fs::File::open(&parquet_file_path).expect("open parquet file");
+        let builder =
+            ParquetRecordBatchReaderBuilder::try_new(file).expect("create parquet reader builder");
+        let schema = builder.schema().clone();
+        let reader = builder.build().expect("build parquet reader");
+
+        let batches: Vec<RecordBatch> = reader.map(|b| b.expect("read batch")).collect();
+        let record_batch = concat_batches(&schema, &batches).expect("concat batches");
+
+        // Build stats_columns from all leaf columns in the parquet schema
+        let stats_columns = extract_leaf_columns(schema.fields(), &[]);
+        let stats_struct = collect_stats(&record_batch, &stats_columns).expect("collect stats");
+
+        // Convert kernel stats to JSON
+        let json_array = to_json(&stats_struct).expect("convert stats to JSON");
+        let json_strings = json_array.as_string::<i32>();
+        assert_eq!(json_strings.len(), 1, "should have exactly one stats row");
+        let kernel_stats_json_str = json_strings.value(0);
+        let kernel_stats: serde_json::Value =
+            serde_json::from_str(kernel_stats_json_str).expect("parse kernel stats JSON");
+
+        // ===== THEN =====
+        // Kernel stats must match Spark's numRecords, nullCount, minValues, and maxValues.
+        assert_eq!(
+            spark_stats["numRecords"], kernel_stats["numRecords"],
+            "numRecords mismatch"
+        );
+
+        // Compare nullCount, minValues, maxValues (only keys present in Spark's stats)
+        for section in &["nullCount", "minValues", "maxValues"] {
+            if let Some(spark_section) = spark_stats.get(*section) {
+                let kernel_section = kernel_stats
+                    .get(*section)
+                    .unwrap_or_else(|| panic!("Kernel stats missing {section}"));
+                assert_stats_match(spark_section, kernel_section, section);
+            }
+        }
+    }
+}

--- a/default-engine/src/storage.rs
+++ b/default-engine/src/storage.rs
@@ -1,0 +1,174 @@
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock, RwLock};
+
+use url::Url;
+
+use delta_kernel::object_store::path::Path;
+use delta_kernel::object_store::{self, Error, ObjectStore};
+use delta_kernel::Error as DeltaError;
+
+/// Alias for convenience
+type ClosureReturn = Result<(Box<dyn ObjectStore>, Path), Error>;
+/// This type alias makes it easier to reference the handler closure(s)
+///
+/// It uses a HashMap<String, String> which _must_ be converted in [store_from_url_opts]
+/// because we cannot use generics in this scenario.
+type HandlerClosure = Arc<dyn Fn(&Url, HashMap<String, String>) -> ClosureReturn + Send + Sync>;
+/// hashmap containing scheme => handler fn mappings to allow consumers of delta-kernel-rs provide
+/// their own url opts parsers for different scemes
+type Handlers = HashMap<String, HandlerClosure>;
+/// The URL_REGISTRY contains the custom URL scheme handlers that will parse URL options
+static URL_REGISTRY: LazyLock<RwLock<Handlers>> = LazyLock::new(|| RwLock::new(HashMap::default()));
+
+/// Insert a new URL handler for [store_from_url_opts] with the given `scheme`. This allows
+/// users to provide their own custom URL handler to plug new [delta_kernel::object_store::ObjectStore]
+/// instances into delta-kernel, which is used by [store_from_url_opts] to parse the URL.
+pub fn insert_url_handler(
+    scheme: impl AsRef<str>,
+    handler_closure: HandlerClosure,
+) -> Result<(), DeltaError> {
+    let Ok(mut registry) = URL_REGISTRY.write() else {
+        return Err(DeltaError::generic(
+            "failed to acquire lock for adding a URL handler!",
+        ));
+    };
+    registry.insert(scheme.as_ref().into(), handler_closure);
+    Ok(())
+}
+
+/// Create an [`ObjectStore`] from a URL.
+///
+/// Returns an `Arc<dyn ObjectStore>` ready to use with [`crate::DefaultEngine`].
+///
+/// This function checks for custom URL handlers registered via [`insert_url_handler`]
+/// before falling back to [`object_store`]'s default behavior.
+///
+/// # Example
+///
+/// ```rust
+/// # use url::Url;
+/// # use delta_kernel_default_engine::storage::store_from_url;
+/// # use delta_kernel::DeltaResult;
+/// # fn example() -> DeltaResult<()> {
+/// let url = Url::parse("file:///path/to/table")?;
+/// let store = store_from_url(&url)?;
+/// # Ok(())
+/// # }
+/// ```
+pub fn store_from_url(url: &Url) -> delta_kernel::DeltaResult<Arc<dyn ObjectStore>> {
+    store_from_url_opts(url, std::iter::empty::<(&str, &str)>())
+}
+
+/// Create an [`ObjectStore`] from a URL with custom options.
+///
+/// Returns an `Arc<dyn ObjectStore>` ready to use with [`crate::DefaultEngine`].
+///
+/// This function checks for custom URL handlers registered via [`insert_url_handler`]
+/// before falling back to [`object_store`]'s default behavior.
+///
+/// # Example
+///
+/// ```rust
+/// # use url::Url;
+/// # use std::collections::HashMap;
+/// # use delta_kernel_default_engine::storage::store_from_url_opts;
+/// # use delta_kernel::DeltaResult;
+/// # fn example() -> DeltaResult<()> {
+/// let url = Url::parse("s3://my-bucket/path/to/table")?;
+/// let options = HashMap::from([("region", "us-west-2")]);
+/// let store = store_from_url_opts(&url, options)?;
+/// # Ok(())
+/// # }
+/// ```
+pub fn store_from_url_opts<I, K, V>(
+    url: &Url,
+    options: I,
+) -> delta_kernel::DeltaResult<Arc<dyn ObjectStore>>
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: AsRef<str>,
+    V: Into<String>,
+{
+    // First attempt to use any schemes registered via insert_url_handler,
+    // falling back to the default behavior of delta_kernel::object_store::parse_url_opts
+    let (store, _path) = if let Ok(handlers) = URL_REGISTRY.read() {
+        if let Some(handler) = handlers.get(url.scheme()) {
+            let options = options
+                .into_iter()
+                .map(|(k, v)| (k.as_ref().to_string(), v.into()))
+                .collect();
+            handler(url, options)?
+        } else {
+            object_store::parse_url_opts(url, options)?
+        }
+    } else {
+        object_store::parse_url_opts(url, options)?
+    };
+
+    Ok(Arc::new(store))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use delta_kernel::object_store::{self, path::Path};
+    use hdfs_native_object_store::HdfsObjectStoreBuilder;
+
+    /// Example funciton of doing testing of a custom [HdfsObjectStore] construction
+    fn parse_url_opts_hdfs_native<I, K, V>(
+        url: &Url,
+        options: I,
+    ) -> Result<(Box<dyn ObjectStore>, Path), Error>
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: AsRef<str>,
+        V: Into<String>,
+    {
+        let options_map = options
+            .into_iter()
+            .map(|(k, v)| (k.as_ref().to_string(), v.into()));
+        let store = HdfsObjectStoreBuilder::new()
+            .with_url(url.as_str())
+            .with_config(options_map)
+            .build()?;
+        let path = Path::parse(url.path())?;
+        Ok((Box::new(store), path))
+    }
+
+    #[test]
+    fn test_add_hdfs_scheme() {
+        let scheme = "hdfs";
+        if let Ok(handlers) = URL_REGISTRY.read() {
+            assert!(handlers.get(scheme).is_none());
+        } else {
+            panic!("Failed to read the RwLock for the registry");
+        }
+        insert_url_handler(scheme, Arc::new(parse_url_opts_hdfs_native))
+            .expect("Failed to add new URL scheme handler");
+
+        if let Ok(handlers) = URL_REGISTRY.read() {
+            assert!(handlers.get(scheme).is_some());
+        } else {
+            panic!("Failed to read the RwLock for the registry");
+        }
+
+        let url: Url = Url::parse("hdfs://example").expect("Failed to parse URL");
+        let options: HashMap<String, String> = HashMap::default();
+        // Currently constructing an [HdfsObjectStore] won't work if there isn't an actual HDFS
+        // to connect to, so the only way to really verify that we got the object store we
+        // expected is to inspect the `store` on the error v_v
+        match store_from_url_opts(&url, options) {
+            Err(delta_kernel::Error::ObjectStore(object_store::Error::Generic {
+                store,
+                source: _,
+            })) => {
+                assert_eq!(store, "HdfsObjectStore");
+            }
+            Err(unexpected) => panic!("Unexpected error happened: {unexpected:?}"),
+            Ok(_) => {
+                panic!("Expected to get an error when constructing an HdfsObjectStore, but something didn't work as expected! Either the parse_url_opts_hdfs_native function didn't get called, or the hdfs-native-object-store no longer errors when it cannot connect to HDFS");
+            }
+        }
+    }
+}

--- a/kernel/src/engine/mod.rs
+++ b/kernel/src/engine/mod.rs
@@ -6,12 +6,15 @@
 use crate::parquet::arrow::arrow_reader::ArrowReaderOptions;
 #[cfg(feature = "arrow-expression")]
 use crate::parquet::arrow::arrow_writer::ArrowWriterOptions;
+#[cfg(feature = "arrow-expression")]
+use delta_kernel_derive::internal_api;
 
 /// Returns the standard [`ArrowReaderOptions`] for all default engine parquet reads.
 ///
 /// Skipping the embedded Arrow IPC schema avoids dependence on Arrow-specific metadata and
 /// ensures that type resolution is driven by the kernel schema rather than the file's schema.
 #[cfg(feature = "arrow-expression")]
+#[internal_api]
 pub(crate) fn reader_options() -> ArrowReaderOptions {
     ArrowReaderOptions::new().with_skip_arrow_metadata(true)
 }
@@ -21,6 +24,7 @@ pub(crate) fn reader_options() -> ArrowReaderOptions {
 /// Omitting the Arrow IPC schema from the file metadata keeps Delta files interoperable with
 /// non-Arrow readers and avoids encoding Arrow-specific type information.
 #[cfg(feature = "arrow-expression")]
+#[internal_api]
 pub(crate) fn writer_options() -> ArrowWriterOptions {
     ArrowWriterOptions::new().with_skip_arrow_metadata(true)
 }
@@ -28,7 +32,7 @@ pub(crate) fn writer_options() -> ArrowWriterOptions {
 #[cfg(feature = "arrow-conversion")]
 pub mod arrow_conversion;
 
-#[cfg(all(feature = "arrow-expression", feature = "default-engine-base"))]
+#[cfg(feature = "arrow-expression")]
 pub mod arrow_expression;
 #[cfg(all(feature = "arrow-expression", feature = "internal-api"))]
 pub mod arrow_utils;
@@ -43,15 +47,15 @@ pub mod default;
 #[cfg(test)]
 pub(crate) mod sync;
 
-#[cfg(feature = "default-engine-base")]
+#[cfg(feature = "arrow-expression")]
 pub mod arrow_data;
-#[cfg(feature = "default-engine-base")]
+#[cfg(feature = "arrow-expression")]
 pub(crate) mod arrow_get_data;
-#[cfg(all(feature = "default-engine-base", feature = "internal-api"))]
+#[cfg(all(feature = "arrow-expression", feature = "internal-api"))]
 pub mod ensure_data_types;
-#[cfg(all(feature = "default-engine-base", not(feature = "internal-api")))]
+#[cfg(all(feature = "arrow-expression", not(feature = "internal-api")))]
 pub(crate) mod ensure_data_types;
-#[cfg(feature = "default-engine-base")]
+#[cfg(feature = "arrow-expression")]
 // module is always pub; trait inside is gated by #[internal_api]
 pub mod parquet_row_group_skipping;
 

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -11,9 +11,9 @@ use crate::schema::{DataType, StructType};
 use crate::table_properties::ParseIntervalError;
 use crate::Version;
 
-#[cfg(feature = "default-engine-base")]
+#[cfg(feature = "arrow-expression")]
 use crate::arrow::error::ArrowError;
-#[cfg(feature = "default-engine-base")]
+#[cfg(any(feature = "arrow-57", feature = "arrow-58"))]
 use crate::object_store;
 
 /// A [`std::result::Result`] that has the kernel [`Error`] as the error variant
@@ -34,7 +34,7 @@ pub enum Error {
     },
 
     /// An error performing operations on arrow data
-    #[cfg(feature = "default-engine-base")]
+    #[cfg(feature = "arrow-expression")]
     #[error(transparent)]
     Arrow(ArrowError),
 
@@ -69,19 +69,19 @@ pub enum Error {
     InternalError(String),
 
     /// An error enountered while working with parquet data
-    #[cfg(feature = "default-engine-base")]
+    #[cfg(feature = "arrow-expression")]
     #[error("Arrow error: {0}")]
     Parquet(#[from] crate::parquet::errors::ParquetError),
 
     /// An error interacting with the object_store crate
     // We don't use [#from] object_store::Error here as our From impl transforms
     // object_store::Error::NotFound into Self::FileNotFound
-    #[cfg(feature = "default-engine-base")]
+    #[cfg(any(feature = "arrow-57", feature = "arrow-58"))]
     #[error("Error interacting with object store: {0}")]
     ObjectStore(object_store::Error),
 
     /// An error working with paths from the object_store crate
-    #[cfg(feature = "default-engine-base")]
+    #[cfg(any(feature = "arrow-57", feature = "arrow-58"))]
     #[error("Object store path error: {0}")]
     ObjectStorePath(#[from] object_store::path::Error),
 
@@ -355,14 +355,14 @@ from_with_backtrace!(
     (std::io::Error, IOError)
 );
 
-#[cfg(feature = "default-engine-base")]
+#[cfg(feature = "arrow-expression")]
 impl From<ArrowError> for Error {
     fn from(value: ArrowError) -> Self {
         Self::Arrow(value).with_backtrace()
     }
 }
 
-#[cfg(feature = "default-engine-base")]
+#[cfg(any(feature = "arrow-57", feature = "arrow-58"))]
 impl From<object_store::Error> for Error {
     fn from(value: object_store::Error) -> Self {
         match value {

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -126,6 +126,9 @@ pub mod column_trie;
 #[cfg(not(feature = "internal-api"))]
 pub(crate) mod column_trie;
 pub mod kernel_predicates;
+#[cfg(feature = "internal-api")]
+pub mod utils;
+#[cfg(not(feature = "internal-api"))]
 pub(crate) mod utils;
 
 #[cfg(feature = "internal-api")]

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -96,6 +96,7 @@ fn resolve_uri_type(table_uri: impl AsRef<str>) -> DeltaResult<UriType> {
 }
 
 /// Returns the current time as a Duration since Unix epoch.
+#[internal_api]
 pub(crate) fn current_time_duration() -> DeltaResult<Duration> {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -103,6 +104,7 @@ pub(crate) fn current_time_duration() -> DeltaResult<Duration> {
 }
 
 /// Returns the current time in milliseconds since Unix epoch.
+#[internal_api]
 pub(crate) fn current_time_ms() -> DeltaResult<i64> {
     let duration = current_time_duration()?;
     i64::try_from(duration.as_millis())


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2227/files) to review incremental changes.
- [stack/expand-core-visibility](https://github.com/delta-io/delta-kernel-rs/pull/2226) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2226/files)] [MERGED]
  - [**stack/extract-default-engine**](https://github.com/delta-io/delta-kernel-rs/pull/2227) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2227/files)]
    - [stack/migrate-dependents](https://github.com/delta-io/delta-kernel-rs/pull/2228) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2228/files/ba587946ad92d8580144615f98e06a318057c826..8a891099976fde361296596e4bf4a7be3e47d2b9)]
      - [stack/enhance-sync-engine](https://github.com/delta-io/delta-kernel-rs/pull/2230) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2230/files/8a891099976fde361296596e4bf4a7be3e47d2b9..c1540c2cd1569fc4186f7fd73caef6b3a603386a)]
        - [stack/migrate-tests-to-sync-engine](https://github.com/delta-io/delta-kernel-rs/pull/2231) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2231/files/c1540c2cd1569fc4186f7fd73caef6b3a603386a..295a897a7ad213d716ded74878bdbe177860c8d0)]
          - [stack/crate-split-cleanup](https://github.com/delta-io/delta-kernel-rs/pull/2232) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2232/files/295a897a7ad213d716ded74878bdbe177860c8d0..b0a2634dcab91f08984b503c03f499dbe81ba646)]

---------
## What changes are proposed in this pull request?

Creates `default-engine/` by copying the 8 source files from `kernel/src/engine/default/` and rewriting imports from `crate::` to `delta_kernel::`. Adds new workspace crate `delta_kernel_default_engine`. This is additive, no existing public APIs change.

On the kernel side, widens feature gates from `default-engine-base` to `arrow-expression` for the Arrow/parquet modules the new crate depends on, and widens error variant gates similarly.

## How was this change tested?

cargo tests succeeds