### PR TITLE
docs: Add documentation for current tags

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -80,7 +80,7 @@ Built-in tags (with current table assignments - for the most up-to-date table as
   - Tables: `10kAdds0CommitsSinceChkpt1Chkpt`, `10kAdds0CommitsSinceChkpt1V2Chkpt`
 - **`v2-checkpoint`** — tables with v2 checkpoints
   - Tables: `10kAdds0CommitsSinceChkpt1V2Chkpt`
-- **`crc-optimization`** — tables for comparing how CRC files affect log replay timing; designed to isolate the effect of a single CRC at different versions relative to the checkpoint and latest version
+- **`crc-optimization`** — tables for comparing how CRC files affect log replay timing; designed to isolate the effect of CRC files at different versions relative to the checkpoint and latest version
   - Tables: `101kAdds1kCommitsSinceChkpt1Chkpt`, `20kAdds100CommitsSinceChkpt1Chkpt0CommitsSinceCrc`, `20kAdds100CommitsSinceChkpt1Chkpt50CommitsSinceCrc`, `20kAdds100CommitsSinceChkpt1ChkptNoCrc`
 - **`time-travel-optimization`** — tables with multiple specs or specs not at the latest version, useful for benchmarking snapshot construction at historical versions
   - Tables: `101kAdds1kCommitsSinceChkpt1Chkpt`, `200kAdds0CommitsSinceChkpt2Chkpts0CommitsSinceCrc`


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds documentation for new tags added to the workloads tarball.

Current plan:
- If users want to fully understand the tables that exist and/or test their features with new tables quickly, they should run benchmarking locally
- We've added more tags for CI to be more useful in the short-term; the README explains generally what each tag is used for (along with the names of the tables that currently have those tags) and the user can decide themselves which tags they think are relevant for their PRs. After initially running benchmarking with these new tags, if the user wanted more detail on which tables were ran they can run benchmarking locally to inspect the tables more closely
- I opted to not add any more detail in the README about the specific tables that the tags correspond to (beyond the table names) because at that point, that would be just reiterating the table info. This can also get out of date from the tarball quickly.

When these new tags are approved, the tarball will be updated.

## How was this change tested?
Tarball sent to @OussamaSaoudi, can also be sent to anyone else if they want to inspect the tables (but the README changes describe which tables have the updated tags)