### PR TITLE
feat!: add ScanMetadataCompleted metric event

### DIFF
--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -11,6 +11,28 @@ use uuid::Uuid;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MetricId(Uuid);
 
+/// Identifies which scan execution path produced a scan metadata metrics event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScanType {
+    /// Sequential phase of [`crate::scan::Scan::parallel_scan_metadata`].
+    SequentialPhase,
+    /// Parallel phase of [`crate::scan::Scan::parallel_scan_metadata`].
+    ParallelPhase,
+    /// Scan metadata from [`crate::scan::Scan::scan_metadata`].
+    Full,
+}
+
+impl std::fmt::Display for ScanType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let scan_type = match self {
+            ScanType::SequentialPhase => "sequential",
+            ScanType::ParallelPhase => "parallel",
+            ScanType::Full => "full",
+        };
+        write!(f, "{scan_type}")
+    }
+}
+
 impl MetricId {
     /// Generate a new unique MetricId.
     pub fn new() -> Self {
@@ -95,6 +117,40 @@ pub enum MetricEvent {
     ///
     /// [`ParquetHandler::read_parquet_files`]: crate::ParquetHandler::read_parquet_files
     ParquetReadCompleted { num_files: u64, bytes_read: u64 },
+
+    /// Scan metadata iteration completed.
+    ///
+    /// Emitted when the scan metadata iterator is exhausted. This event captures metrics about the
+    /// log replay process, including file counts and timing information.
+    ScanMetadataCompleted {
+        /// Unique ID to correlate this scan with other events.
+        operation_id: MetricId,
+        /// Indicates which scan execution path produced this event.
+        ///
+        /// This is `SequentialPhase` or `ParallelPhase` for parallel log replay, and `Full` for
+        /// [`crate::scan::Scan::scan_metadata`].
+        scan_type: ScanType,
+        /// Total duration from scan start to iterator exhaustion.
+        total_duration: Duration,
+        /// Add files that entered the deduplication visitor. This excludes files filtered by
+        /// data skipping before deduplication. For the total number of add actions in the log,
+        /// this value plus `num_predicate_filtered` gives a closer approximation.
+        num_add_files_seen: u64,
+        /// Add files that survived log replay (files to read).
+        num_active_add_files: u64,
+        /// Remove files seen (from delta/commit files only).
+        num_remove_files_seen: u64,
+        /// Non-file actions seen (protocol, metadata, etc.).
+        num_non_file_actions: u64,
+        /// Files filtered by predicates (data skipping + partition pruning).
+        num_predicate_filtered: u64,
+        /// Peak size of the deduplication hash set.
+        peak_hash_set_size: usize,
+        /// Time spent in the deduplication visitor (milliseconds).
+        dedup_visitor_time_ms: u64,
+        /// Time spent evaluating predicates (milliseconds).
+        predicate_eval_time_ms: u64,
+    },
 }
 
 impl fmt::Display for MetricEvent {
@@ -164,6 +220,26 @@ impl fmt::Display for MetricEvent {
             } => write!(
                 f,
                 "ParquetReadCompleted(files={num_files}, bytes={bytes_read})"
+            ),
+            MetricEvent::ScanMetadataCompleted {
+                operation_id,
+                scan_type,
+                total_duration,
+                num_add_files_seen,
+                num_active_add_files,
+                num_remove_files_seen,
+                num_non_file_actions,
+                num_predicate_filtered,
+                peak_hash_set_size,
+                dedup_visitor_time_ms,
+                predicate_eval_time_ms,
+            } => write!(
+                f,
+                "ScanMetadataCompleted(id={operation_id}, scan_type={scan_type}, duration={total_duration:?}, \
+                 add_files_seen={num_add_files_seen}, active_add_files={num_active_add_files}, \
+                 remove_files_seen={num_remove_files_seen}, non_file_actions={num_non_file_actions}, \
+                 predicate_filtered={num_predicate_filtered}, peak_hash_set_size={peak_hash_set_size}, \
+                 dedup_visitor_time_ms={dedup_visitor_time_ms}, predicate_eval_time_ms={predicate_eval_time_ms})"
             ),
         }
     }

--- a/kernel/src/metrics/mod.rs
+++ b/kernel/src/metrics/mod.rs
@@ -70,5 +70,5 @@
 mod events;
 mod reporter;
 
-pub use events::{MetricEvent, MetricId};
+pub use events::{MetricEvent, MetricId, ScanType};
 pub use reporter::MetricsReporter;

--- a/kernel/src/parallel/parallel_phase.rs
+++ b/kernel/src/parallel/parallel_phase.rs
@@ -494,10 +494,11 @@ mod tests {
             panic!("Failed to find {} in logs", metric_name);
         };
         let after = &logs[pos + metric_name.len() + 1..];
-        let Some(space_pos) = after.find(char::is_whitespace) else {
-            panic!("Failed to find end of {} value", metric_name);
-        };
-        let value_str = &after[..space_pos];
+        // Find the end of the value (whitespace, comma, or closing paren)
+        let end_pos = after
+            .find(|c: char| c.is_whitespace() || c == ',' || c == ')')
+            .unwrap_or_else(|| panic!("Failed to find end of {} value", metric_name));
+        let value_str = &after[..end_pos];
         value_str
             .parse()
             .unwrap_or_else(|_| panic!("Failed to parse {} value: {}", metric_name, value_str))
@@ -527,19 +528,23 @@ mod tests {
         sequential_expected: &ExpectedMetrics,
         parallel_expected: Option<&ExpectedMetrics>,
     ) {
-        // Verify Sequential metrics were logged
-        assert!(
-            logs.contains("Sequential scan metadata completed"),
-            "Expected Sequential completion log for table '{}'",
-            table_name
-        );
+        // Find the Sequential scan log line and extract metrics from it
+        let sequential_pos = logs
+            .find("Sequential scan metadata completed")
+            .unwrap_or_else(|| {
+                panic!(
+                    "Expected Sequential completion log for table '{}'",
+                    table_name
+                )
+            });
+        let sequential_logs = &logs[sequential_pos..];
 
-        // Extract and verify counter values from Phase 1
-        let add_files_seen = extract_metric(logs, "add_files_seen");
-        let active_add_files = extract_metric(logs, "active_add_files");
-        let remove_files_seen = extract_metric(logs, "remove_files_seen");
-        let non_file_actions = extract_metric(logs, "non_file_actions");
-        let predicate_filtered = extract_metric(logs, "predicate_filtered");
+        // Extract and verify counter values from Phase 1 (sequential log line)
+        let add_files_seen = extract_metric(sequential_logs, "add_files_seen");
+        let active_add_files = extract_metric(sequential_logs, "active_add_files");
+        let remove_files_seen = extract_metric(sequential_logs, "remove_files_seen");
+        let non_file_actions = extract_metric(sequential_logs, "non_file_actions");
+        let predicate_filtered = extract_metric(sequential_logs, "predicate_filtered");
 
         assert_eq!(
             add_files_seen, sequential_expected.add_files_seen,
@@ -563,8 +568,8 @@ mod tests {
         );
 
         // Verify timing metrics are present and parseable (values may be 0 for fast operations)
-        let _dedup_time = extract_metric(logs, "dedup_visitor_time_ms");
-        let _predicate_eval_time = extract_metric(logs, "predicate_eval_time_ms");
+        let _dedup_time = extract_metric(sequential_logs, "dedup_visitor_time_ms");
+        let _predicate_eval_time = extract_metric(sequential_logs, "predicate_eval_time_ms");
 
         // Verify Parallel metrics if expected
         if let Some(expected) = parallel_expected {

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -853,9 +853,12 @@ impl LogReplayProcessor for ScanLogReplayProcessor {
 }
 
 /// Given an iterator of [`ActionsBatch`]s (batches of actions read from the log) and a predicate,
-/// returns an iterator of [`ScanMetadata`]s (which includes the files to be scanned as
-/// [`FilteredEngineData`] and transforms that must be applied to correctly read the data). Each row
-/// that is selected in the returned `engine_data` _must_ be processed to complete the scan.
+/// returns a tuple of:
+/// 1. An iterator of [`ScanMetadata`]s (which includes the files to be scanned as
+///    [`FilteredEngineData`] and transforms that must be applied to correctly read the data).
+/// 2. An `Arc<ScanMetrics>` containing metrics collected during log replay.
+///
+/// Each row that is selected in the returned `engine_data` _must_ be processed to complete the scan.
 /// Non-selected rows _must_ be ignored.
 ///
 /// When `skip_stats` is true, file statistics are not read from checkpoint parquet files and
@@ -870,11 +873,13 @@ pub(crate) fn scan_action_iter(
     state_info: Arc<StateInfo>,
     checkpoint_info: CheckpointReadInfo,
     skip_stats: bool,
-) -> DeltaResult<impl Iterator<Item = DeltaResult<ScanMetadata>>> {
-    Ok(
-        ScanLogReplayProcessor::new(engine, state_info, checkpoint_info, skip_stats)?
-            .process_actions_iter(action_iter),
-    )
+) -> DeltaResult<(
+    impl Iterator<Item = DeltaResult<ScanMetadata>>,
+    Arc<ScanMetrics>,
+)> {
+    let processor = ScanLogReplayProcessor::new(engine, state_info, checkpoint_info, skip_stats)?;
+    let metrics = processor.metrics.clone();
+    Ok((processor.process_actions_iter(action_iter), metrics))
 }
 
 #[cfg(test)]
@@ -1014,7 +1019,7 @@ mod tests {
             physical_stats_schema: None,
             physical_partition_schema: None,
         });
-        let iter = scan_action_iter(
+        let (iter, _metrics) = scan_action_iter(
             &SyncEngine::new(),
             batch
                 .into_iter()
@@ -1042,7 +1047,7 @@ mod tests {
         let partition_cols = vec!["date".to_string()];
         let state_info = get_simple_state_info(schema, partition_cols).unwrap();
         let batch = vec![add_batch_with_partition_col()];
-        let iter = scan_action_iter(
+        let (iter, _metrics) = scan_action_iter(
             &SyncEngine::new(),
             batch
                 .into_iter()
@@ -1127,7 +1132,7 @@ mod tests {
         );
 
         let batch = vec![add_batch_for_row_id(get_commit_schema().clone())];
-        let iter = scan_action_iter(
+        let (iter, _metrics) = scan_action_iter(
             &SyncEngine::new(),
             batch
                 .into_iter()
@@ -1507,7 +1512,7 @@ mod tests {
         ]));
         let state_info = get_simple_state_info(schema, vec!["date".to_string()]).unwrap();
 
-        let iter = scan_action_iter(
+        let (iter, _metrics) = scan_action_iter(
             &SyncEngine::new(),
             batch
                 .into_iter()
@@ -1597,7 +1602,7 @@ mod tests {
         } else {
             vec![add_batch_with_remove(get_commit_schema().clone())]
         };
-        let iter = scan_action_iter(
+        let (iter, _metrics) = scan_action_iter(
             &SyncEngine::new(),
             batch
                 .into_iter()

--- a/kernel/src/scan/metrics.rs
+++ b/kernel/src/scan/metrics.rs
@@ -1,8 +1,11 @@
 //! Metrics for scan log replay operations.
 
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::time::Duration;
 
 use tracing::info;
+
+use crate::metrics::{MetricEvent, MetricId, ScanType};
 
 /// Metrics collected during scan log replay. Metrics are updated and read using relaxed ordering
 /// to keep updates fast across parallel executing threads.
@@ -94,6 +97,31 @@ impl ScanMetrics {
         self.num_predicate_filtered.store(0, Ordering::Relaxed);
         self.dedup_visitor_time_ns.store(0, Ordering::Relaxed);
         self.predicate_eval_time_ns.store(0, Ordering::Relaxed);
+    }
+
+    /// Snapshot all counters into a `MetricEvent::ScanMetadataCompleted`.
+    ///
+    /// `scan_type` identifies whether this event was emitted by full scan metadata replay or
+    /// by a phase of parallel scan metadata replay.
+    pub(crate) fn to_event(
+        &self,
+        operation_id: MetricId,
+        scan_type: ScanType,
+        total_duration: Duration,
+    ) -> MetricEvent {
+        MetricEvent::ScanMetadataCompleted {
+            operation_id,
+            scan_type,
+            total_duration,
+            num_add_files_seen: self.num_add_files_seen.load(Ordering::Relaxed),
+            num_active_add_files: self.num_active_add_files.load(Ordering::Relaxed),
+            num_remove_files_seen: self.num_remove_files_seen.load(Ordering::Relaxed),
+            num_non_file_actions: self.num_non_file_actions.load(Ordering::Relaxed),
+            num_predicate_filtered: self.num_predicate_filtered.load(Ordering::Relaxed),
+            peak_hash_set_size: self.peak_hash_set_size.load(Ordering::Relaxed),
+            dedup_visitor_time_ms: self.dedup_visitor_time_ns.load(Ordering::Relaxed) / 1_000_000,
+            predicate_eval_time_ms: self.predicate_eval_time_ns.load(Ordering::Relaxed) / 1_000_000,
+        }
     }
 
     /// Log all metrics with a message in the current tracing span context.

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -3,11 +3,16 @@
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, LazyLock};
+use std::time::Instant;
 
 use delta_kernel_derive::internal_api;
 use itertools::Itertools;
-use tracing::debug;
+use tracing::{debug, info};
 use url::Url;
+
+use crate::metrics::MetricId;
+use crate::scan::metrics::ScanMetrics;
+use crate::utils::IteratorExt;
 
 use self::data_skipping::as_checkpoint_skipping_predicate;
 use self::log_replay::get_scan_metadata_transform_expr;
@@ -23,6 +28,7 @@ use crate::kernel_predicates::{
 use crate::log_replay::{ActionsBatch, HasSelectionVector};
 use crate::log_segment::{ActionsWithCheckpointInfo, CheckpointReadInfo, LogSegment};
 use crate::log_segment_files::LogSegmentFiles;
+use crate::metrics::ScanType;
 use crate::parallel::sequential_phase::SequentialPhase;
 use crate::scan::log_replay::ScanLogReplayProcessor;
 use crate::scan::log_replay::{
@@ -571,6 +577,12 @@ impl Scan {
 
     /// Get an iterator of [`ScanMetadata`]s that should be used to facilitate a scan. This handles
     /// log-replay, reconciling Add and Remove actions, and applying data skipping (if possible).
+    ///
+    /// Reports metrics: [`MetricEvent::ScanMetadataCompleted`] when the returned iterator is
+    /// fully exhausted.
+    ///
+    /// [`MetricEvent::ScanMetadataCompleted`]: crate::metrics::MetricEvent::ScanMetadataCompleted
+    ///
     /// Each item in the returned iterator is a struct of:
     /// - `Box<dyn EngineData>`: Data in engine format, where each row represents a file to be
     ///   scanned. The schema for each row can be obtained by calling [`scan_row_schema`].
@@ -753,17 +765,35 @@ impl Scan {
             impl Iterator<Item = DeltaResult<ActionsBatch>>,
         >,
     ) -> DeltaResult<impl Iterator<Item = DeltaResult<ScanMetadata>>> {
-        if let PhysicalPredicate::StaticSkipAll = self.state_info.physical_predicate {
-            return Ok(None.into_iter().flatten());
-        }
-        let it = scan_action_iter(
-            engine,
-            actions_with_checkpoint_info.actions,
-            self.state_info.clone(),
-            actions_with_checkpoint_info.checkpoint_info,
-            self.skip_stats(),
-        )?;
-        Ok(Some(it).into_iter().flatten())
+        let start = Instant::now();
+        let reporter = engine.get_metrics_reporter();
+        let operation_id = MetricId::new();
+
+        let (iter, metrics) = match self.state_info.physical_predicate {
+            PhysicalPredicate::StaticSkipAll => {
+                info!("Predicate statically evaluated to false; skipping all files");
+                (None, Arc::new(ScanMetrics::default()))
+            }
+            _ => {
+                let (it, m) = scan_action_iter(
+                    engine,
+                    actions_with_checkpoint_info.actions,
+                    self.state_info.clone(),
+                    actions_with_checkpoint_info.checkpoint_info,
+                    self.skip_stats(),
+                )?;
+                (Some(it), m)
+            }
+        };
+
+        let on_complete = move || {
+            let event = metrics.to_event(operation_id, ScanType::Full, start.elapsed());
+            info!(%event);
+            if let Some(r) = reporter {
+                r.report(event);
+            }
+        };
+        Ok(iter.into_iter().flatten().on_complete(on_complete))
     }
 
     // Factored out to facilitate testing

--- a/kernel/src/scan/test_utils.rs
+++ b/kernel/src/scan/test_utils.rs
@@ -171,7 +171,7 @@ pub(crate) fn run_with_validate_callback<T: Clone>(
         physical_partition_schema: None,
     });
     let checkpoint_info = CheckpointReadInfo::without_stats_parsed();
-    let iter = scan_action_iter(
+    let (iter, _metrics) = scan_action_iter(
         &SyncEngine::new(),
         batch
             .into_iter()

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -1514,3 +1514,116 @@ fn execute_does_not_error_when_parquet_returns_empty_and_stats_absent() {
         "expected no errors for stats-absent files"
     );
 }
+
+/// Tests for ScanMetadataCompleted event emission
+mod scan_metadata_completed_tests {
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use rstest::rstest;
+
+    use crate::engine::default::DefaultEngineBuilder;
+    use crate::expressions::{column_expr, Expression as Expr, Predicate as Pred};
+    use crate::metrics::MetricEvent;
+    use crate::object_store::local::LocalFileSystem;
+    use crate::utils::test_utils::CapturingReporter;
+    use crate::Snapshot;
+
+    fn run_scan(table: &str, predicate: Option<Arc<Pred>>) -> (Arc<CapturingReporter>, usize) {
+        let path = std::fs::canonicalize(PathBuf::from(table)).unwrap();
+        let url = url::Url::from_directory_path(&path).unwrap();
+        let reporter = Arc::new(CapturingReporter::default());
+        let engine = Arc::new(
+            DefaultEngineBuilder::new(Arc::new(LocalFileSystem::new()))
+                .with_metrics_reporter(reporter.clone())
+                .build(),
+        );
+        let snapshot = Snapshot::builder_for(url).build(engine.as_ref()).unwrap();
+        let mut builder = snapshot.scan_builder();
+        if let Some(pred) = predicate {
+            builder = builder.with_predicate(pred);
+        }
+        let scan = builder.build().unwrap();
+        let results: Vec<_> = scan
+            .scan_metadata(engine.as_ref())
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        (reporter, results.len())
+    }
+
+    fn get_scan_event(reporter: &CapturingReporter) -> MetricEvent {
+        reporter
+            .events()
+            .into_iter()
+            .find(|e| matches!(e, MetricEvent::ScanMetadataCompleted { .. }))
+            .expect("expected ScanMetadataCompleted event")
+    }
+
+    #[rstest]
+    #[case::basic_scan("./tests/data/parsed-stats/", None, 6, 6, 0, 0)]
+    #[case::static_skip_all(
+        "./tests/data/parsed-stats/",
+        Some(Arc::new(Pred::literal(false))),
+        0,
+        0,
+        0,
+        0
+    )]
+    #[case::with_removes("./tests/data/table-with-cdf/", None, 1, 0, 2, 0)]
+    #[case::with_removes("./tests/data/with_checkpoint_no_last_checkpoint/", None, 2, 1, 1, 0)]
+    #[case::partition_filter(
+        "./tests/data/basic_partitioned/",
+        Some(Arc::new(Expr::eq(column_expr!("letter"), Expr::literal("a")))),
+        2, 2, 0, 4
+    )]
+    fn test_scan_metrics(
+        #[case] table: &str,
+        #[case] predicate: Option<Arc<Pred>>,
+        #[case] expected_add_seen: u64,
+        #[case] expected_active: u64,
+        #[case] expected_removes: u64,
+        #[case] expected_filtered: u64,
+    ) {
+        let (reporter, _) = run_scan(table, predicate);
+        let MetricEvent::ScanMetadataCompleted {
+            total_duration,
+            num_add_files_seen,
+            num_active_add_files,
+            num_remove_files_seen,
+            num_predicate_filtered,
+            ..
+        } = get_scan_event(&reporter)
+        else {
+            panic!("expected ScanMetadataCompleted");
+        };
+        assert!(total_duration > Duration::ZERO);
+        assert_eq!(num_add_files_seen, expected_add_seen);
+        assert_eq!(num_active_add_files, expected_active);
+        assert_eq!(num_remove_files_seen, expected_removes);
+        assert_eq!(num_predicate_filtered, expected_filtered);
+    }
+
+    #[test]
+    fn test_no_metrics_on_early_drop() {
+        let path = std::fs::canonicalize(PathBuf::from("./tests/data/parsed-stats/")).unwrap();
+        let url = url::Url::from_directory_path(&path).unwrap();
+        let reporter = Arc::new(CapturingReporter::default());
+        let engine = Arc::new(
+            DefaultEngineBuilder::new(Arc::new(LocalFileSystem::new()))
+                .with_metrics_reporter(reporter.clone())
+                .build(),
+        );
+        let snapshot = Snapshot::builder_for(url).build(engine.as_ref()).unwrap();
+        let scan = snapshot.scan_builder().build().unwrap();
+        {
+            let mut iter = scan.scan_metadata(engine.as_ref()).unwrap();
+            let _ = iter.next();
+        }
+        assert!(reporter
+            .events()
+            .iter()
+            .all(|e| !matches!(e, MetricEvent::ScanMetadataCompleted { .. })));
+    }
+}

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -198,30 +198,20 @@ impl SnapshotBuilder {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Mutex};
+    use std::sync::Arc;
 
     use crate::engine::default::{
         executor::tokio::TokioBackgroundExecutor, DefaultEngine, DefaultEngineBuilder,
     };
-    use crate::metrics::{MetricEvent, MetricsReporter};
+    use crate::metrics::MetricEvent;
     use crate::object_store::memory::InMemory;
     use crate::object_store::path::Path;
     use crate::object_store::{DynObjectStore, ObjectStore as _};
+    use crate::utils::test_utils::CapturingReporter;
     use itertools::Itertools;
     use serde_json::json;
 
     use super::*;
-
-    #[derive(Debug, Default)]
-    struct CapturingReporter {
-        events: Mutex<Vec<MetricEvent>>,
-    }
-
-    impl MetricsReporter for CapturingReporter {
-        fn report(&self, event: MetricEvent) {
-            self.events.lock().unwrap().push(event);
-        }
-    }
 
     fn setup_test() -> (
         Arc<DefaultEngine<TokioBackgroundExecutor>>,
@@ -391,12 +381,12 @@ mod tests {
     }
 
     fn assert_has_event(reporter: &CapturingReporter, pred: fn(&MetricEvent) -> bool, msg: &str) {
-        let events = reporter.events.lock().unwrap();
+        let events = reporter.events();
         assert!(events.iter().any(pred), "{msg}");
     }
 
     fn assert_no_event(reporter: &CapturingReporter, pred: fn(&MetricEvent) -> bool, msg: &str) {
-        let events = reporter.events.lock().unwrap();
+        let events = reporter.events();
         assert!(!events.iter().any(pred), "{msg}");
     }
 
@@ -459,7 +449,7 @@ mod tests {
             .unwrap();
 
         // Clear events from the initial build
-        reporter.events.lock().unwrap().clear();
+        reporter.clear();
 
         // Incrementally update to the latest version via the else branch
         let updated = SnapshotBuilder::new_from(base)
@@ -467,7 +457,7 @@ mod tests {
             .unwrap();
         assert_eq!(updated.version(), 1);
 
-        let events = reporter.events.lock().unwrap();
+        let events = reporter.events();
         let snapshot_completed = events.iter().find_map(|e| match e {
             MetricEvent::SnapshotCompleted {
                 version,
@@ -497,7 +487,7 @@ mod tests {
         assert_eq!(base.version(), 1);
 
         // Clear events from the initial build
-        reporter.events.lock().unwrap().clear();
+        reporter.clear();
 
         // Attempt to update to version 0 (earlier than base version 1)
         let result = SnapshotBuilder::new_from(base)
@@ -532,7 +522,7 @@ mod tests {
             "expected a SnapshotCompleted event",
         );
 
-        let events = reporter.events.lock().unwrap();
+        let events = reporter.events();
 
         let log_segment_duration = events
             .iter()

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -109,9 +109,66 @@ pub(crate) fn current_time_ms() -> DeltaResult<i64> {
         .map_err(|_| Error::generic("Current timestamp exceeds i64 millisecond range"))
 }
 
+/// Extension trait for adding completion callbacks to iterators.
+pub(crate) trait IteratorExt: Iterator + Sized {
+    /// Wraps this iterator to call a closure when fully exhausted.
+    ///
+    /// The closure is called only when `next()` returns `None`. If the iterator
+    /// is dropped before exhaustion, a warning is logged but the closure is not called.
+    fn on_complete<F: FnOnce()>(self, f: F) -> OnComplete<Self, F> {
+        OnComplete {
+            inner: self,
+            on_complete: Some(f),
+        }
+    }
+}
+
+impl<I: Iterator> IteratorExt for I {}
+
+/// Iterator adaptor that executes a closure when fully exhausted.
+pub(crate) struct OnComplete<I, F: FnOnce()> {
+    inner: I,
+    on_complete: Option<F>,
+}
+
+impl<I, F: FnOnce()> Drop for OnComplete<I, F> {
+    fn drop(&mut self) {
+        if self.on_complete.is_some() {
+            tracing::debug!(
+                "OnComplete iterator dropped before exhaustion; completion callback not called"
+            );
+        }
+    }
+}
+
+impl<I, F> Iterator for OnComplete<I, F>
+where
+    I: Iterator,
+    F: FnOnce(),
+{
+    type Item = I::Item;
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.inner.next() {
+            Some(item) => Some(item),
+            None => {
+                if let Some(f) = self.on_complete.take() {
+                    f();
+                }
+                None
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 pub(crate) mod test_utils {
     use std::path::PathBuf;
+    use std::sync::Mutex;
     use std::{path::Path, sync::Arc};
 
     use itertools::Itertools;
@@ -129,6 +186,7 @@ pub(crate) mod test_utils {
     use crate::engine::arrow_data::ArrowEngineData;
     use crate::engine::default::DefaultEngineBuilder;
     use crate::engine::sync::SyncEngine;
+    use crate::metrics::{MetricEvent, MetricsReporter};
     use crate::object_store::local::LocalFileSystem;
     use crate::object_store::memory::InMemory;
     use crate::object_store::ObjectStore;
@@ -137,6 +195,30 @@ pub(crate) mod test_utils {
     use crate::transaction::{CreateTable, Transaction};
     use crate::{DeltaResult, EngineData, Error, SnapshotRef};
     use crate::{Engine, Snapshot};
+
+    /// A metrics reporter that captures all events for test assertions.
+    #[derive(Debug, Default)]
+    pub(crate) struct CapturingReporter {
+        events: Mutex<Vec<MetricEvent>>,
+    }
+
+    impl MetricsReporter for CapturingReporter {
+        fn report(&self, event: MetricEvent) {
+            self.events.lock().unwrap().push(event);
+        }
+    }
+
+    impl CapturingReporter {
+        /// Returns a copy of all captured events.
+        pub(crate) fn events(&self) -> Vec<MetricEvent> {
+            self.events.lock().unwrap().clone()
+        }
+
+        /// Clears all captured events.
+        pub(crate) fn clear(&self) {
+            self.events.lock().unwrap().clear();
+        }
+    }
 
     #[derive(Serialize)]
     pub(crate) enum Action {
@@ -816,5 +898,54 @@ mod tests {
             url.to_string(),
             "s3://foo/__unitystorage/catalogs/cid/tables/tid/"
         );
+    }
+
+    mod on_complete_tests {
+        use super::*;
+        use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+        use std::sync::Arc;
+
+        #[test]
+        fn test_calls_on_exhaustion() {
+            let called = Arc::new(AtomicBool::new(false));
+            let called_clone = called.clone();
+            let mut iter = vec![1, 2].into_iter().on_complete(move || {
+                called_clone.store(true, Ordering::SeqCst);
+            });
+            assert_eq!(iter.next(), Some(1));
+            assert!(!called.load(Ordering::SeqCst));
+            assert_eq!(iter.next(), Some(2));
+            assert_eq!(iter.next(), None);
+            assert!(called.load(Ordering::SeqCst));
+        }
+
+        #[test]
+        fn test_does_not_call_on_early_drop() {
+            let called = Arc::new(AtomicBool::new(false));
+            let called_clone = called.clone();
+            {
+                let mut iter = vec![1, 2].into_iter().on_complete(move || {
+                    called_clone.store(true, Ordering::SeqCst);
+                });
+                assert_eq!(iter.next(), Some(1));
+                // Drop without exhausting - callback should NOT be called
+            }
+            assert!(!called.load(Ordering::SeqCst));
+        }
+
+        #[test]
+        fn test_calls_only_once() {
+            let count = Arc::new(AtomicU32::new(0));
+            let count_clone = count.clone();
+            {
+                let mut iter = vec![1].into_iter().on_complete(move || {
+                    count_clone.fetch_add(1, Ordering::SeqCst);
+                });
+                assert_eq!(iter.next(), Some(1));
+                assert_eq!(iter.next(), None); // triggers callback
+                assert_eq!(iter.next(), None); // should not trigger again
+            } // drop should not trigger again
+            assert_eq!(count.load(Ordering::SeqCst), 1);
+        }
     }
 }

--- a/test-utils/src/counting_reporter.rs
+++ b/test-utils/src/counting_reporter.rs
@@ -189,7 +189,9 @@ impl MetricsReporter for CountingReporter {
                     .fetch_add(num_compaction_files, Ordering::Relaxed);
             }
             // Intentionally not tracked -- add counters if needed.
-            MetricEvent::ProtocolMetadataLoaded { .. } | MetricEvent::SnapshotFailed { .. } => {}
+            MetricEvent::ProtocolMetadataLoaded { .. }
+            | MetricEvent::SnapshotFailed { .. }
+            | MetricEvent::ScanMetadataCompleted { .. } => {}
         }
     }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?
   Adds `ScanMetadataCompleted` metric event emitted when the `scan_metadata()` iterator is exhausted.
    This captures log replay metrics including file counts, predicate filtering stats, and timing
   information.

   Key additions:
   - `ScanMetadataCompleted` variant in `MetricEvent`
   - `OnComplete` iterator adaptor for callback on exhaustion
   - Shared `CapturingReporter` test utility

# Breaking changes
The PR updates the public `MetricEvent` enum to contain a `ScanMetadataCompleted` variant. Users should update their code and metrics reporters to handle the new enum variant.

   ## How was this change tested?

   - Unit tests for `OnComplete` iterator behavior
   - Parameterized rstest cases for various scan scenarios
   - Tests for early drop and unique operation IDs
