### PR TITLE
feat: adding ScanBuilder FFI functions for Scans

### DIFF
--- a/ffi/src/scan.rs
+++ b/ffi/src/scan.rs
@@ -137,8 +137,6 @@ pub unsafe extern "C" fn scan(
 
 /// Decode an [`EnginePredicate`] and apply it to a [`ScanBuilder`].
 ///
-/// Decode an [`EnginePredicate`] and apply it to a [`ScanBuilder`].
-///
 /// Returns an error if the engine's visitor fails to produce a valid predicate (i.e. returns
 /// an invalid expression ID). A `None` result from the visitor indicates the engine-side
 /// predicate construction failed, which would silently produce a full-table scan if ignored.


### PR DESCRIPTION
  What changes are proposed in this pull request?               
                                                                                                                                                                                                                                                                             
  The existing scan() FFI function is a monolith that takes optional predicate and schema arguments and builds a Scan in one shot. This PR adds a stepped C ABI for ScanBuilder so language bindings can configure a scan incrementally, matching the Rust builder pattern.  
                                                                                                                                                                                                                                                                             
  New handle and functions:                                     
                                                                                                                                                                                                                                                                             
  | Function                                          | Description                                                                      |                                                                                                                                   
  |---------------------------------------------------|----------------------------------------------------------------------------------|
  | `scan_builder(snapshot)`                          | Create a `MutableScanBuilder` from a snapshot (infallible)                       |                                                                                                                                   
  | `scan_builder_with_predicate(builder, engine, predicate)` | Apply a predicate for data skipping and row-level filtering; consumes and returns the builder |                                                                                                              
  | `scan_builder_with_schema(builder, engine, schema)` | Apply a column projection schema; consumes and returns the builder              |                                                                                                                                  
  | `scan_builder_build(builder, engine)`             | Consume the builder and produce a `SharedScan`                                   |                                                                                                                                   
  | `free_scan_builder(builder)`                      | Drop the builder without building                                                |                                                                                                                                                                                                                                                   
                                                                
  The with_predicate and with_schema steps use a consuming handle pattern: the caller passes in a MutableScanBuilder and receives a new one back (or an error), mirroring Rust's consuming builder API across the FFI boundary.                                              
                                                                
  The existing scan() function is unchanged.                                                                                                                                                                                                                                 
                                                                
  This PR affects the following public APIs                                                                                                                                                                                                                                  
   
  New (non-breaking): MutableScanBuilder, scan_builder, scan_builder_with_predicate, scan_builder_with_schema, scan_builder_build, free_scan_builder                                                                       
                                                                
  How was this change tested?                                                                                                                                                                                                                                                
                                                                
  new unit tests in ffi/src/scan.rs::scan_builder_tests covering:

  - No pushdown, predicate-only, schema-only, predicate+schema, schema+predicate (both orders verify order independence)                                                                                                                                                     
  - free_scan_builder without calling build (no panic/leak)                                                                                                                                                                                                                  
  - Error propagation: invalid schema returns ExternResult::Err with KernelError::SchemaError