### PR TITLE
fix: vendor and pin homebrew actions

### DIFF
--- a/.github/actions/install-and-cache/action.yml
+++ b/.github/actions/install-and-cache/action.yml
@@ -1,0 +1,101 @@
+# This is copied from https://github.com/tecolicom/actions-install-and-cache
+# which is Copyright 2022 Office TECOLI, LLC
+
+name: install-and-cache generic backend
+description: 'GitHub Action to run installer and cache the result'
+branding:
+  color: orange
+  icon:  type
+
+inputs:
+  run:     { required: true,  type: string }
+  path:    { required: true,  type: string }
+  cache:   { required: false, type: string, default: yes }
+  key:     { required: false, type: string }
+  sudo:    { required: false, type: string }
+  verbose: { required: false, type: string, default: false }
+
+outputs:
+  cache-hit:
+    value: ${{ steps.cache.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+
+    - id: setup
+      shell: bash
+      run: |
+        : setup install-and-cache
+        define() { IFS='\n' read -r -d '' ${1} || true ; }
+        define script <<'EOS_cad8_c24e_'
+        ${{ inputs.run }}
+        EOS_cad8_c24e_
+        directory="${{ inputs.path }}"
+        given_key="${{ inputs.key }}"
+        archive= key=
+        case "${{ inputs.cache }}" in
+            yes|workflow)
+                cache="${{ inputs.cache }}"
+                uname -mrs
+                hash=$( (uname -mrs ; cat <<< "$script" ; echo $directory) | \
+                        (md5sum||md5) | awk '{print $1}' )
+                key="${hash}${given_key:+-$given_key}"
+                [ "$cache" == 'workflow' ] && \
+                    key+="-${{ github.run_id }}-${{ github.run_attempt }}"
+                archive=$HOME/archive-$hash.tz
+                ;;
+            *)
+                cache=no
+                ;;
+        esac
+        # use "--recursive-unlink" option if GNU tar is found
+        if tar --version | grep GNU > /dev/null
+        then
+            tar="tar --recursive-unlink"
+        elif gtar --version | grep GNU > /dev/null
+        then
+            tar="gtar --recursive-unlink"
+        else
+            tar=tar
+        fi
+        sed 's/^ *//' << END >> $GITHUB_OUTPUT
+            cache=$cache
+            archive=$archive
+            key=$key
+            tar=$tar
+        END
+
+    - id: cache
+      if: steps.setup.outputs.cache != 'no'
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ${{ steps.setup.outputs.archive }}
+        key:  ${{ steps.setup.outputs.key }}
+
+    - id: extract
+      if: steps.setup.outputs.cache != 'no' && steps.cache.outputs.cache-hit == 'true'
+      shell: bash
+      run: |
+        : extract
+        archive="${{ steps.setup.outputs.archive }}"
+        verbose="${{ inputs.verbose }}"
+        tar="${{ steps.setup.outputs.tar }}"
+        ls -l $archive
+        if [ -s $archive ]
+        then
+            opt=-Pxz
+            [[ $verbose == yes || $verbose == true ]] && opt+=v
+            sudo $tar -C / $opt -f $archive
+        else
+            echo "$archive is empty"
+        fi
+
+    - id: install-and-archive
+      if: steps.cache.outputs.cache-hit != 'true'
+      uses: tecolicom/actions-install-and-archive@9d5afb27f9900f2df47fe40de58fbd837032bddf # v1.3
+      with:
+        run:     ${{ inputs.run }}
+        archive: ${{ steps.setup.outputs.archive }}
+        path:    ${{ inputs.path }}
+        sudo:    ${{ inputs.sudo }}

--- a/.github/actions/use-homebrew-tools/action.yml
+++ b/.github/actions/use-homebrew-tools/action.yml
@@ -1,0 +1,47 @@
+# This is copied from https://github.com/tecolicom/actions-use-homebrew-tools/
+# which is Copyright 2022 Office TECOLI, LLC
+
+name: install-and-cache homebrew tools
+description: 'GitHub Action to install and cache homebrew tools'
+branding:
+  color: orange
+  icon:  type
+
+inputs:
+  tools:   { required: false, type: string }
+  key:     { required: false, type: string }
+  path:    { required: false, type: string }
+  cache:   { required: false, type: string, default: yes }
+  verbose: { required: false, type: boolean, default: false }
+
+outputs:
+  cache-hit:
+    value: ${{ steps.update.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+
+    - id: setup
+      shell: bash
+      run: |
+        : setup use-homebrew-tools
+        given_key="${{ inputs.key }}"
+        brew_version="$(brew --version)"
+        echo "$brew_version"
+        version_key="$( echo "$brew_version" | (md5sum||md5) | awk '{print $1}' )"
+        key="${given_key:+$given_key-}${version_key}"
+        sed 's/^ *//' << END >> $GITHUB_OUTPUT
+            command=brew install
+            prefix=$(brew --prefix)
+            key=$key
+        END
+
+    - id: update
+      uses: ./.github/actions/install-and-cache
+      with:
+        run:     ${{ steps.setup.outputs.command }} ${{ inputs.tools }}
+        path:    ${{ steps.setup.outputs.prefix }} ${{ inputs.path }}
+        key:     ${{ steps.setup.outputs.key }}
+        cache:   ${{ inputs.cache }}
+        verbose: ${{ inputs.verbose }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,7 +226,7 @@ jobs:
            fi
       - name: Install arrow-glib-macOS
         if: runner.os == 'macOS'
-        uses: tecolicom/actions-use-homebrew-tools@b9c066b79607fa3d71e0be05d7003bb75fd9ff34 # v1.3
+        uses: ./.github/actions/use-homebrew-tools
         with:
           tools: "apache-arrow apache-arrow-glib"
       - name: Install minimal stable


### PR DESCRIPTION
## What changes are proposed in this pull request?

We need to vendor these. If we don't then transitively we need to pull in non-pinned runners and things fail.

We were using tecolicom/actions-use-homebrew-tools, and even though that was pinned to a sha, it transitively uses tecolicom/install-and-cache and tecolicom/use-homebrew-tools, which were NOT pinned, so things would fail.

This just copies and pastes those actions into our repo and references them that way instead, and pins their dependencies.


## How was this change tested?

Seeing that things run here