### PR TITLE
ci: harden pr-title-validator a bit

### DIFF
--- a/.github/workflows/pr-validator.yml
+++ b/.github/workflows/pr-validator.yml
@@ -15,17 +15,32 @@ jobs:
         id: pr
         env:
           GH_TOKEN: ${{ github.token }}
+          # Captured as env vars to prevent expression injection into the shell command.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: |
           if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
             pr_json=$(gh api --paginate repos/${{ github.repository }}/pulls \
               --jq ".[] | select(.head.sha == \"${{ github.event.workflow_run.head_sha }}\")")
             echo "number=$(echo "$pr_json" | jq -r '.number')" >> "$GITHUB_OUTPUT"
-            echo "title=$(echo "$pr_json" | jq -r '.title')" >> "$GITHUB_OUTPUT"
+            # Use multiline delimiter syntax so a title containing newlines cannot inject
+            # additional key=value pairs into GITHUB_OUTPUT.
+            {
+              echo 'title<<PR_TITLE_EOF'
+              echo "$pr_json" | jq -r '.title'
+              echo 'PR_TITLE_EOF'
+            } >> "$GITHUB_OUTPUT"
             echo "labels=$(echo "$pr_json" | jq -c '[.labels[].name]')" >> "$GITHUB_OUTPUT"
           else
             echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
-            echo "title=${{ github.event.pull_request.title }}" >> "$GITHUB_OUTPUT"
-            echo "labels=$(echo '${{ toJson(github.event.pull_request.labels.*.name) }}' | jq -c '.')" >> "$GITHUB_OUTPUT"
+            # Use multiline delimiter syntax so a title containing newlines cannot inject
+            # additional key=value pairs into GITHUB_OUTPUT.
+            {
+              echo 'title<<PR_TITLE_EOF'
+              echo "$PR_TITLE"
+              echo 'PR_TITLE_EOF'
+            } >> "$GITHUB_OUTPUT"
+            echo "labels=$(echo "$PR_LABELS_JSON" | jq -c '.')" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1


### PR DESCRIPTION
## What changes are proposed in this pull request?

Move `PR_TITLE` and `PR_LABELS_JSON`  to env. env vars resolve before the shell runs, so they aren't interpolated inline into shell syntax.

Use multiline delimiters which treats the value as opaque data; a title like `feat: x\ncheck_status=success` writes only the title key, the second line lands inside the heredoc body and is not interpreted as a separate key.

## How was this change tested?

correct and incorrect title runs, including with embedded escapes
