### PR TITLE
ci: attempt fixup of semver-label job

### DIFF
--- a/.github/workflows/semver-label.yml
+++ b/.github/workflows/semver-label.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      actions: read
     # Label updates only apply to PRs; merge_group runs have no associated PR to label.
     if: github.event.workflow_run.event == 'pull_request'
     steps:
@@ -32,11 +33,14 @@ jobs:
                 || github.event.workflow_run.head_branch
             }}
         run: |
+          echo "Looking up PR for branch '${PR_BRANCH}' in repo '${PR_TARGET_REPO}'"
           gh pr view --repo "${PR_TARGET_REPO}" "${PR_BRANCH}" \
             --json 'number' --jq '"number=\(.number)"' \
             >> "${GITHUB_OUTPUT}"
+          echo "PR lookup complete: $(cat "${GITHUB_OUTPUT}")"
 
       - name: Update breaking-change label
+        if: steps.pr-context.outputs.number != ''
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.pr-context.outputs.number }}
@@ -47,15 +51,25 @@ jobs:
           # distinguish a breaking change from a clean run. Instead, query the step-level
           # conclusion directly: the Jobs API preserves the original step outcome ("failure")
           # even when continue-on-error prevented it from failing the job.
+          echo "Querying step conclusion for run $RUN_ID, PR #$PR_NUMBER"
           STEP_CONCLUSION=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/jobs" \
             --jq '.jobs[] | select(.name == "check_if_pr_breaks_semver") | .steps[] | select(.name == "Run semver check") | .conclusion')
+          echo "Semver check step conclusion: '${STEP_CONCLUSION}'"
 
           if [[ "$STEP_CONCLUSION" == "failure" ]]; then
+            echo "Breaking change detected -- adding 'breaking-change' label to PR #$PR_NUMBER"
             gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "breaking-change"
           elif [[ "$STEP_CONCLUSION" == "success" ]]; then
             # Remove the label only if it is currently present; gh pr edit fails on absent labels.
             CURRENT_LABELS=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json labels --jq '[.labels[].name]')
+            echo "Current PR labels: $CURRENT_LABELS"
             if echo "$CURRENT_LABELS" | jq -e '.[] | select(. == "breaking-change")' > /dev/null 2>&1; then
+              echo "Semver check passed -- removing 'breaking-change' label from PR #$PR_NUMBER"
               gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "breaking-change"
+            else
+              echo "Semver check passed -- 'breaking-change' label not present, nothing to do"
             fi
+          else
+            echo "ERROR: unexpected or empty step conclusion '${STEP_CONCLUSION}' -- job or step name may have changed in semver-checks.yml"
+            exit 1
           fi


### PR DESCRIPTION
## What changes are proposed in this pull request?

Currently it runs and does nothing. I _suspect_ it's because I missed a `permissions.actions: read` which means it couldn't read the output of the workflow. Fix that, and add some debug logging

## How was this change tested?

Can't without merge