### PR TITLE
ci: Use artifacts for semver label

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -81,7 +81,7 @@ jobs:
         run: echo "$SEMVER_OUTCOME" > semver-outcome.txt
       - name: Upload semver outcome
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: semver-outcome
           path: semver-outcome.txt

--- a/.github/workflows/semver-label.yml
+++ b/.github/workflows/semver-label.yml
@@ -43,7 +43,7 @@ jobs:
       # steps.check.outcome in that workflow is the raw result before continue-on-error
       # converts it to "success", so it correctly reflects whether a breaking change was found.
       - name: Download semver outcome
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: semver-outcome
           github-token: ${{ github.token }}


### PR DESCRIPTION
## What changes are proposed in this pull request?

We need to actually use artifacts to communicate state. We don't want the semver job to "fail" if it finds a breaking change, so this is the only way to communicate failure.

## How was this change tested?

Can't