### PR TITLE
fix: return error when parquet handler returns empty data for scan files

### DIFF
--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -982,17 +982,15 @@ impl Scan {
 
                 let mut read_result_iter = read_result_iter.peekable();
 
-                // Only flag an empty iterator as a connector bug when stats are present
-                // and report a positive row count. When stats are absent we cannot
-                // distinguish a legitimate 0-row file from a buggy connector, so we
-                // conservatively allow it.
+                // Only flag an empty iterator as a connector bug when stats are present and report
+                // a positive row count. When stats are absent we cannot distinguish a legitimate
+                // 0-row file from a buggy connector, so we conservatively allow it.
                 let expect_data = scan_file.stats.as_ref().is_some_and(|s| s.num_records > 0);
                 if expect_data && read_result_iter.peek().is_none() {
                     return Err(Error::internal_error(format!(
-                        "ParquetHandler returned no data for file '{}'. \
-                         This is likely a connector bug -- the handler's \
-                         read_parquet_files must return at least one batch \
-                         for each requested file that contains rows.",
+                        "ParquetHandler returned no data for file '{}'. This is likely a connector \
+                         bug -- the handler's read_parquet_files must return at least one batch for \
+                         each requested file that contains rows.",
                         scan_file.path
                     )));
                 }

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -1452,8 +1452,8 @@ impl ParquetHandler for EmptyParquetHandler {
     }
 }
 
-/// An [`Engine`] that delegates everything to a [`SyncEngine`] except `parquet_handler`,
-/// which returns [`EmptyParquetHandler`].
+/// An [`Engine`] that delegates everything to a [`SyncEngine`] except `parquet_handler`, which
+/// returns [`EmptyParquetHandler`].
 struct EmptyParquetEngine(Arc<SyncEngine>);
 
 impl Engine for EmptyParquetEngine {
@@ -1474,8 +1474,8 @@ impl Engine for EmptyParquetEngine {
     }
 }
 
-/// When a file's Add action stats report `numRecords > 0` and the parquet handler returns an
-/// empty iterator, `execute` must surface an error rather than silently producing no rows.
+/// When a file's Add action stats report `numRecords > 0` and the parquet handler returns an empty
+/// iterator, `execute` must surface an error rather than silently producing no rows.
 #[test]
 fn execute_errors_when_parquet_returns_empty_for_file_with_positive_stats() {
     let path =
@@ -1496,8 +1496,8 @@ fn execute_errors_when_parquet_returns_empty_for_file_with_positive_stats() {
     );
 }
 
-/// When a file's Add action has no stats, an empty iterator from the parquet handler is
-/// allowed -- we conservatively treat the file as possibly legitimately empty.
+/// When a file's Add action has no stats, an empty iterator from the parquet handler is allowed
+/// -- we conservatively treat the file as possibly legitimately empty.
 #[test]
 fn execute_does_not_error_when_parquet_returns_empty_and_stats_absent() {
     let path = std::fs::canonicalize(PathBuf::from("./tests/data/table-with-cdf/")).unwrap();


### PR DESCRIPTION
  ## What changes are proposed in this pull request?                                                                                                       
                                                                                                                                                         
  When a `ParquetHandler` returns an empty iterator for a scan file whose Add action                                                                       
  reports `numRecords > 0`, kernel was silently producing no rows for that file --
  masking connector bugs that drop data entirely.                                                                                                          
                                                                                                                                                         
  This PR detects the empty-iterator case eagerly (using `.peekable()`) and returns                                                                        
  an `Error::internal_error` describing the likely connector bug. When stats are                                                                         
  absent we cannot distinguish a legitimately empty file from a buggy handler, so we                                                                       
  conservatively allow empty iterators in that case.                                                                                                       
                                                                                                                                                           
  ## How was this change tested?                                                                                                                           
                                                                                                                                                           
  Two new unit tests using a stub `EmptyParquetHandler` / `EmptyParquetEngine`:                                                                            
   
  - `execute_errors_when_parquet_returns_empty_for_file_with_positive_stats` --                                                                            
    verifies the error is surfaced when `numRecords > 0` and the handler returns empty.                                                                  
  - `execute_does_not_error_when_parquet_returns_empty_and_stats_absent` --                                                                                
    verifies no error is produced when stats are absent (conservative path).                                                                               
