### PR TITLE
fix: remove debug_assert_eq before require in scan evaluator row count checks

### DIFF
--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -260,7 +260,6 @@ impl DataSkippingFilter {
         let batch_len = batch.len();
 
         let file_stats = self.stats_evaluator.evaluate(batch)?;
-        debug_assert_eq!(file_stats.len(), batch_len);
         require!(
             file_stats.len() == batch_len,
             Error::internal_error(format!(
@@ -271,7 +270,6 @@ impl DataSkippingFilter {
         );
 
         let skipping_predicate = self.skipping_evaluator.evaluate(&*file_stats)?;
-        debug_assert_eq!(skipping_predicate.len(), batch_len);
         require!(
             skipping_predicate.len() == batch_len,
             Error::internal_error(format!(

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -792,7 +792,6 @@ impl LogReplayProcessor for ScanLogReplayProcessor {
             &self.checkpoint_transform
         };
         let transformed = transform.evaluate(actions.as_ref())?;
-        debug_assert_eq!(transformed.len(), actions.len());
         require!(
             transformed.len() == actions.len(),
             Error::internal_error(format!(


### PR DESCRIPTION
  ## What changes are proposed in this pull request?                                                                                                     
                                                                                                                                                           
  Remove three redundant `debug_assert_eq!` calls in the scan path that fire immediately before                                                            
  `require!` macros checking the same condition:                                                                                                           
                                                                                                                                                           
  - `kernel/src/scan/data_skipping.rs`: two assertions on `stats_evaluator` and                                                                            
    `skipping_evaluator` output lengths vs input batch length                                                                                              
  - `kernel/src/scan/log_replay.rs`: one assertion on the transform evaluator output length                                                                
                                                                                                                                                           
  The `require!` macros that follow each removed assertion already handle the mismatch by                                                                  
  returning `Err(Error::internal_error(...))`. The `debug_assert_eq!` was redundant — and                                                                  
  harmful, because it panics in debug builds before `require!` gets a chance to return a clean                                                             
  error. A misbehaving connector returning the wrong number of rows from                                                                                   
  `ExpressionEvaluator::evaluate` should never be able to crash the process.                                                                               
                                                                                                                                                           
  ## How was this change tested?                                                                                                                           
                                                                                                                                                           
  Existing scan tests continue to pass. The correct behavior (returning `Err` rather than                                                                  
  panicking) is verified by bad-connector hardening tests that inject a row-count mismatch         
  from a mock evaluator.    