### PR TITLE
feat: add Snapshot::get_timestamp

### DIFF
--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -969,7 +969,7 @@ impl Snapshot {
 
     /// Get the timestamp for this snapshot's version, in milliseconds since the Unix epoch.
     ///
-    /// When In-Commit Timestamps (ICT) are enabled, returns the In-Commit Timestamp value.
+    /// When In-Commit Timestamp (ICT) are enabled, returns the In-Commit Timestamp value.
     /// Otherwise, falls back to the filesystem last-modified time of the latest commit file.
     ///
     /// Returns an error if the commit file is missing, the ICT configuration is invalid, or the


### PR DESCRIPTION
## What changes are proposed in this pull request?

Currently, there is no method to read the Snapshot's timestamp according to Delta protocol. This PR added a method to get Snapshot's timestamp based on the in commit timestamp (ICT). If the ICT table properties is enabled in the table, the Snapshot's timestamp will be extracted from the in commit timestamp via `snapshot::get_in_commit_timestamp`. If the ICT properties is disabled, snapshot tried to read the latest file modification timestamp from the commit logs. Here is the reference implementation from Delta protocol and the java-kernel:

- Delta protocol: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#recommendations-for-readers-of-tables-with-in-commit-timestamps
- Java kernel reference implementation: https://github.com/delta-io/delta/blob/fc7d92cf740c96a955537a7b262ce578ce47c40e/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java#L172

In the future, the Snapshot::get_timestamp will be exposed to FFI function, allowing engines to use it.

## How was this change tested?
- New unit test was added.
- `cargo test --package delta_kernel --lib --all-features -- snapshot::tests::test_get_timestamp`