### PR TITLE
feat: Cached checkpoint output schema

### DIFF
--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -87,7 +87,7 @@
 // Future extensions:
 // - TODO(#837): Multi-file V2 checkpoints are not supported yet. The API is designed to be extensible for future
 //   multi-file support, but the current implementation only supports single-file checkpoints.
-use std::sync::{Arc, LazyLock};
+use std::sync::{Arc, LazyLock, OnceLock};
 
 use crate::action_reconciliation::log_replay::{
     ActionReconciliationBatch, ActionReconciliationProcessor,
@@ -109,7 +109,6 @@ use crate::schema::{DataType, SchemaRef, StructField, StructType, ToSchema as _}
 use crate::snapshot::SnapshotRef;
 use crate::table_features::TableFeature;
 use crate::table_properties::TableProperties;
-use crate::utils::FallibleLazy;
 use crate::{DeltaResult, Engine, EngineData, Error, EvaluationHandlerExtension, FileMeta};
 
 use url::Url;
@@ -195,7 +194,7 @@ pub struct CheckpointWriter {
     version: i64,
 
     /// Cached checkpoint output schema.
-    checkpoint_output_schema: FallibleLazy<SchemaRef>,
+    checkpoint_output_schema: OnceLock<SchemaRef>,
 }
 
 impl RetentionCalculator for CheckpointWriter {
@@ -222,9 +221,28 @@ impl CheckpointWriter {
         Ok(Self {
             snapshot,
             version,
-            checkpoint_output_schema: FallibleLazy::new(),
+            checkpoint_output_schema: OnceLock::new(),
         })
     }
+    /// Returns the cached output schema, initializing it with `f` on first call.
+    ///
+    /// `OnceLock::get_or_try_init` is unstable, so we use a custom implementation.
+    /// (tracking issue: <https://github.com/rust-lang/rust/issues/109737>).
+    fn get_or_init_output_schema(
+        &self,
+        f: impl FnOnce() -> DeltaResult<SchemaRef>,
+    ) -> DeltaResult<SchemaRef> {
+        if let Some(schema) = self.checkpoint_output_schema.get() {
+            return Ok(schema.clone());
+        }
+        let schema = f()?;
+        let _ = self.checkpoint_output_schema.set(schema);
+        self.checkpoint_output_schema
+            .get()
+            .cloned()
+            .ok_or_else(|| Error::internal_error("OnceLock should be initialized"))
+    }
+
     /// Returns the URL where the checkpoint file should be written.
     ///
     /// This method generates the checkpoint path based on the table's root and the version
@@ -330,7 +348,7 @@ impl CheckpointWriter {
         )
         .process_actions_iter(actions);
 
-        let output_schema = self.checkpoint_output_schema.get_or_try_init(|| {
+        let output_schema = self.get_or_init_output_schema(|| {
             build_checkpoint_output_schema(
                 &config,
                 base_schema,

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -2,7 +2,6 @@
 use std::borrow::Cow;
 use std::ops::Deref;
 use std::path::PathBuf;
-use std::sync::Mutex;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use url::Url;
@@ -20,47 +19,6 @@ macro_rules! require {
 }
 
 pub(crate) use require;
-
-/// Thread-safe fallible lazy value.
-///
-/// `OnceLock::get_or_try_init` is unstable
-/// (tracking issue: <https://github.com/rust-lang/rust/issues/109737>),
-/// so we provide our own implementation.
-#[derive(Debug)]
-pub(crate) struct FallibleLazy<T> {
-    inner: Mutex<Option<T>>,
-}
-
-impl<T: Clone> Clone for FallibleLazy<T> {
-    fn clone(&self) -> Self {
-        // SAFETY: Production code should never panic, so the mutex should never be poisoned.
-        let val = self.inner.lock().unwrap_or_else(|_| unreachable!()).clone();
-        Self {
-            inner: Mutex::new(val),
-        }
-    }
-}
-
-impl<T: Clone> FallibleLazy<T> {
-    /// Creates a new uninitialized `FallibleLazy`.
-    pub(crate) fn new() -> Self {
-        Self {
-            inner: Mutex::new(None),
-        }
-    }
-
-    /// Returns a clone of the cached value, or initializes it with `f` if uninitialized.
-    pub(crate) fn get_or_try_init(&self, f: impl FnOnce() -> DeltaResult<T>) -> DeltaResult<T> {
-        let mut guard = self
-            .inner
-            .lock()
-            .map_err(|_| Error::internal_error("FallibleLazy mutex poisoned"))?;
-        match guard.as_ref() {
-            Some(cached) => Ok(cached.clone()),
-            None => f().map(|val| guard.insert(val).clone()),
-        }
-    }
-}
 
 /// Try to parse string uri into a URL for a table path. This will do it's best to handle things
 /// like `/local/paths`, and even `../relative/paths`.
@@ -888,9 +846,6 @@ pub(crate) mod test_utils {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Barrier};
-    use std::thread;
-
     use super::*;
 
     #[test]
@@ -932,59 +887,6 @@ mod tests {
 
         #[cfg(not(windows))]
         resolve_uri_type("file://foo/bar").expect_err("file://foo/bar should not have parsed");
-    }
-
-    #[test]
-    fn fallible_lazy_first_init_wins() {
-        let lazy = FallibleLazy::new();
-        let val1 = lazy.get_or_try_init(|| Ok(1)).unwrap();
-        assert_eq!(val1, 1);
-        let val2 = lazy.get_or_try_init(|| Ok(2)).unwrap();
-        assert_eq!(val2, 1);
-    }
-
-    #[test]
-    fn fallible_lazy_concurrent_callers_get_same_result() {
-        let lazy = Arc::new(FallibleLazy::new());
-        let barrier = Arc::new(Barrier::new(10));
-        let handles: Vec<_> = (0..10)
-            .map(|i| {
-                let lazy = Arc::clone(&lazy);
-                let barrier = Arc::clone(&barrier);
-                thread::spawn(move || {
-                    barrier.wait();
-                    lazy.get_or_try_init(|| Ok(i)).unwrap()
-                })
-            })
-            .collect();
-        let results: Vec<i32> = handles.into_iter().map(|h| h.join().unwrap()).collect();
-        let first = results[0];
-        assert!(results.iter().all(|&v| v == first));
-    }
-
-    #[test]
-    fn fallible_lazy_clone() {
-        // Clone uninitialized: cloned copy can be initialized independently
-        let lazy: FallibleLazy<i32> = FallibleLazy::new();
-        let cloned = lazy.clone();
-        let val = cloned.get_or_try_init(|| Ok(7)).unwrap();
-        assert_eq!(val, 7);
-
-        // Clone after initialization: cloned copy preserves cached value
-        let lazy = FallibleLazy::new();
-        lazy.get_or_try_init(|| Ok(42)).unwrap();
-        let cloned = lazy.clone();
-        let val = cloned.get_or_try_init(|| Ok(999)).unwrap();
-        assert_eq!(val, 42);
-    }
-
-    #[test]
-    fn fallible_lazy_retries_after_error() {
-        let lazy = FallibleLazy::new();
-        let res = lazy.get_or_try_init(|| Err(Error::generic("init failed")));
-        assert!(res.is_err());
-        let val = lazy.get_or_try_init(|| Ok(42)).unwrap();
-        assert_eq!(val, 42);
     }
 
     #[test]


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2270/files) to review incremental changes.
- [**stack/cache-output-schema**](https://github.com/delta-io/delta-kernel-rs/pull/2270) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2270/files)]
  - [stack/sidecar-iter](https://github.com/delta-io/delta-kernel-rs/pull/2271) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2271/files/36ae1abfe90c9c15aec5e24208c8f2454440fd7b..80094b977ef0472f671b07a58ba32e4f1e77c558)]
    - [stack/engine-update](https://github.com/delta-io/delta-kernel-rs/pull/2287) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2287/files/80094b977ef0472f671b07a58ba32e4f1e77c558..1f66fc9dcc47fc34f98a33e1512fbeb0115c6b8f)]
      - [stack/extract-schemas](https://github.com/delta-io/delta-kernel-rs/pull/2313) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2313/files/1f66fc9dcc47fc34f98a33e1512fbeb0115c6b8f..fecb21e445e8312c48c6a6cfd91c38b86e55d57d)]
        - [stack/support-sidecar](https://github.com/delta-io/delta-kernel-rs/pull/2304) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2304/files/fecb21e445e8312c48c6a6cfd91c38b86e55d57d..4a23712205cec1467354acc986ee641a25ebbcb8)]

---------
## What changes are proposed in this pull request?
Cached output schema for checkpoint in CheckpointWriter, added utils to do that. The cached output schema will be used in following PRs to perform v2 checkpoint sidecar writes
<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

## How was this change tested?
Existing + added