### PR TITLE
refactor: Better naming style for column mapping related functions/variables

### DIFF
--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -270,12 +270,12 @@ impl CheckpointWriter {
 
         // Get clustering columns so they are always included in stats per the Delta protocol.
         let tc = self.snapshot.table_configuration();
-        let clustering_columns_physical = self.snapshot.get_clustering_columns_physical(engine)?;
+        let physical_clustering_columns = self.snapshot.get_physical_clustering_columns(engine)?;
 
         // Get stats schema from table configuration.
         // This already excludes partition columns and applies column mapping.
         let stats_schema = tc
-            .build_expected_stats_schemas(clustering_columns_physical.as_deref(), None)?
+            .build_expected_stats_schemas(physical_clustering_columns.as_deref(), None)?
             .physical;
 
         // Select schema based on V2 checkpoint support

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -649,7 +649,7 @@ impl Snapshot {
     /// The columns are returned as physical column names, respecting the column mapping mode.
     /// Note that this method performs log replay (fetches and processes metadata from storage).
     #[internal_api]
-    pub(crate) fn get_clustering_columns_physical(
+    pub(crate) fn get_physical_clustering_columns(
         &self,
         engine: &dyn Engine,
     ) -> DeltaResult<Option<Vec<ColumnName>>> {

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -220,11 +220,11 @@ impl TableConfiguration {
     #[internal_api]
     pub(crate) fn build_expected_stats_schemas(
         &self,
-        required_columns_physical: Option<&[ColumnName]>,
-        requested_columns_physical: Option<&[ColumnName]>,
+        required_physical_columns: Option<&[ColumnName]>,
+        requested_physical_columns: Option<&[ColumnName]>,
     ) -> DeltaResult<ExpectedStatsSchemas> {
         let physical_data_schema = self.physical_data_schema_without_partition_columns();
-        let required_physical_stats_columns = self.required_stats_columns_physical();
+        let required_physical_stats_columns = self.required_physical_stats_columns();
         let config = StatsConfig {
             data_skipping_stats_columns: required_physical_stats_columns.as_deref(),
             data_skipping_num_indexed_cols: self.table_properties().data_skipping_num_indexed_cols,
@@ -232,8 +232,8 @@ impl TableConfiguration {
         let physical_stats_schema = Arc::new(expected_stats_schema(
             &physical_data_schema,
             &config,
-            required_columns_physical,
-            requested_columns_physical,
+            required_physical_columns,
+            requested_physical_columns,
         )?);
         let physical_stats_schema = strip_metadata(physical_stats_schema);
 
@@ -243,11 +243,11 @@ impl TableConfiguration {
     }
 
     /// Returns the list of physical column names that should have statistics collected.
-    pub(crate) fn stats_column_names_physical(
+    pub(crate) fn physical_stats_column_names(
         &self,
         required_columns: Option<&[ColumnName]>,
     ) -> Vec<ColumnName> {
-        let physical_stats_columns = self.required_stats_columns_physical();
+        let physical_stats_columns = self.required_physical_stats_columns();
         let config = StatsConfig {
             data_skipping_stats_columns: physical_stats_columns.as_deref(),
             data_skipping_num_indexed_cols: self.table_properties().data_skipping_num_indexed_cols,
@@ -326,7 +326,7 @@ impl TableConfiguration {
     ///
     /// Returns `None` if the table property is not set. Entries that cannot be resolved
     /// (e.g. non-existent columns) are silently skipped with a warning.
-    fn required_stats_columns_physical(&self) -> Option<Vec<ColumnName>> {
+    fn required_physical_stats_columns(&self) -> Option<Vec<ColumnName>> {
         self.table_properties()
             .data_skipping_stats_columns
             .as_ref()
@@ -1857,12 +1857,12 @@ mod test {
     }
 
     #[test]
-    fn test_stats_column_names_physical_returns_physical_names() {
-        // stats_column_names_physical should return physical column names
+    fn test_physical_stats_column_names_returns_physical_names() {
+        // physical_stats_column_names should return physical column names
         let schema = schema_with_column_mapping();
         let config = create_table_config_with_column_mapping(schema, "name");
 
-        let column_names = config.stats_column_names_physical(None /* required_columns */);
+        let column_names = config.physical_stats_column_names(None /* required_columns */);
 
         // Should return physical names, not logical names
         assert_eq!(
@@ -1876,13 +1876,13 @@ mod test {
     }
 
     #[test]
-    fn test_stats_column_names_physical_with_data_skipping_stats_columns() {
+    fn test_physical_stats_column_names_with_data_skipping_stats_columns() {
         let config = create_table_config_with_column_mapping_and_props(
             test_schema_nested_with_column_mapping(),
             "name",
             [("delta.dataSkippingStatsColumns", "id,info.name")],
         );
-        let column_names = config.stats_column_names_physical(None);
+        let column_names = config.physical_stats_column_names(None);
         assert_eq!(
             column_names,
             vec![
@@ -1893,13 +1893,13 @@ mod test {
     }
 
     #[test]
-    fn test_stats_column_names_physical_skips_nonexistent_data_skipping_stats_column() {
+    fn test_physical_stats_column_names_skips_nonexistent_data_skipping_stats_column() {
         let config = create_table_config_with_column_mapping_and_props(
             test_schema_nested_with_column_mapping(),
             "name",
             [("delta.dataSkippingStatsColumns", "id,nonexistent")],
         );
-        let column_names = config.stats_column_names_physical(None);
+        let column_names = config.physical_stats_column_names(None);
         assert_eq!(column_names, vec![ColumnName::new(["phys_id"])],);
     }
 
@@ -1980,13 +1980,13 @@ mod test {
         "id",
         vec![ColumnName::new(["phys_id"]), ColumnName::new(["phys_name"])],
     )]
-    fn test_stats_column_names_physical_all_schemas(
+    fn test_physical_stats_column_names_all_schemas(
         #[case] schema: SchemaRef,
         #[case] mode: &str,
         #[case] expected_physical: Vec<ColumnName>,
     ) {
         let config = create_table_config_with_column_mapping(schema, mode);
-        let physical_names = config.stats_column_names_physical(None);
+        let physical_names = config.physical_stats_column_names(None);
         assert_eq!(
             physical_names, expected_physical,
             "Incorrect physical column names for mode '{mode}'"

--- a/kernel/src/transaction/create_table.rs
+++ b/kernel/src/transaction/create_table.rs
@@ -172,7 +172,7 @@ impl CreateTableTransaction {
             engine_commit_info: None,
             is_blind_append: false,
             dv_matched_files: vec![],
-            clustering_columns_physical: clustering_columns,
+            physical_clustering_columns: clustering_columns,
             _state: PhantomData,
         })
     }

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -228,7 +228,7 @@ pub struct Transaction<S = ExistingTable> {
     // Clustering columns from domain metadata. Only populated if the ClusteredTable feature is
     // enabled. Used for determining which columns require statistics collection. Expected to be
     // physical column names.
-    clustering_columns_physical: Option<Vec<ColumnName>>,
+    physical_clustering_columns: Option<Vec<ColumnName>>,
     // PhantomData marker for transaction state (ExistingTable or CreateTable).
     // Zero-sized; only affects the type system.
     _state: PhantomData<S>,
@@ -640,7 +640,7 @@ impl<S> Transaction<S> {
     pub fn stats_schema(&self) -> DeltaResult<SchemaRef> {
         let tc = self.read_snapshot.table_configuration();
         let stats_schemas =
-            tc.build_expected_stats_schemas(self.clustering_columns_physical.as_deref(), None)?;
+            tc.build_expected_stats_schemas(self.physical_clustering_columns.as_deref(), None)?;
         Ok(stats_schemas.physical)
     }
 
@@ -659,7 +659,7 @@ impl<S> Transaction<S> {
     pub fn stats_columns(&self) -> Vec<ColumnName> {
         self.read_snapshot
             .table_configuration()
-            .stats_column_names_physical(self.clustering_columns_physical.as_deref())
+            .physical_stats_column_names(self.physical_clustering_columns.as_deref())
     }
 
     // Generate the logical-to-physical transform expression which must be evaluated on every data
@@ -761,7 +761,7 @@ impl<S> Transaction<S> {
         if add_files.is_empty() {
             return Ok(());
         }
-        if let Some(ref clustering_cols) = self.clustering_columns_physical {
+        if let Some(ref clustering_cols) = self.physical_clustering_columns {
             if !clustering_cols.is_empty() {
                 let physical_schema = self.read_snapshot.table_configuration().physical_schema();
                 let columns_with_types: Vec<(ColumnName, DataType)> = clustering_cols
@@ -1326,7 +1326,7 @@ mod tests {
         /// Set clustering columns for testing purposes without needing a table
         /// with the ClusteredTable feature enabled.
         fn with_clustering_columns_for_test(mut self, columns: Vec<ColumnName>) -> Self {
-            self.clustering_columns_physical = Some(columns);
+            self.physical_clustering_columns = Some(columns);
             self
         }
     }

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -62,7 +62,7 @@ impl Transaction {
             .ensure_operation_supported(Operation::Write)?;
 
         // Read clustering columns from snapshot (returns None if clustering not enabled)
-        let clustering_columns = read_snapshot.get_clustering_columns_physical(engine)?;
+        let clustering_columns = read_snapshot.get_physical_clustering_columns(engine)?;
 
         let commit_timestamp = current_time_ms()?;
 
@@ -89,7 +89,7 @@ impl Transaction {
             engine_commit_info: None,
             is_blind_append: false,
             dv_matched_files: vec![],
-            clustering_columns_physical: clustering_columns,
+            physical_clustering_columns: clustering_columns,
             _state: PhantomData,
         })
     }

--- a/kernel/tests/create_table/clustering.rs
+++ b/kernel/tests/create_table/clustering.rs
@@ -79,7 +79,7 @@ async fn test_create_clustered_table(#[case] col_paths: Vec<Vec<&str>>) -> Delta
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
     let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
 
-    let clustering_columns = snapshot.get_clustering_columns_physical(engine.as_ref())?;
+    let clustering_columns = snapshot.get_physical_clustering_columns(engine.as_ref())?;
     assert_eq!(clustering_columns, Some(expected_cols));
 
     let table_configuration = snapshot.table_configuration();
@@ -133,7 +133,7 @@ async fn test_clustering_with_explicit_feature_signal_no_duplicates() -> DeltaRe
     );
 
     // Verify clustering columns via snapshot read path
-    let clustering_columns = snapshot.get_clustering_columns_physical(engine.as_ref())?;
+    let clustering_columns = snapshot.get_physical_clustering_columns(engine.as_ref())?;
     assert_eq!(clustering_columns, Some(vec![ColumnName::new(["id"])]));
 
     Ok(())

--- a/kernel/tests/create_table/column_mapping.rs
+++ b/kernel/tests/create_table/column_mapping.rs
@@ -307,7 +307,7 @@ fn test_create_clustered_table_with_column_mapping(
     assert!(table_config.is_feature_supported(&TableFeature::DomainMetadata));
 
     // Verify clustering domain metadata exists and uses physical column names
-    let clustering_columns = snapshot.get_clustering_columns_physical(engine.as_ref())?;
+    let clustering_columns = snapshot.get_physical_clustering_columns(engine.as_ref())?;
     let columns = clustering_columns.expect("Clustering columns should be present");
     assert_eq!(
         columns.len(),
@@ -535,7 +535,7 @@ fn test_create_clustered_table_nested_with_column_mapping(
     };
     assert_column_mapping_config(&snapshot, expected_cm_mode);
 
-    let clustering_columns = snapshot.get_clustering_columns_physical(engine.as_ref())?;
+    let clustering_columns = snapshot.get_physical_clustering_columns(engine.as_ref())?;
     let columns = clustering_columns.expect("Clustering columns should be present");
     assert_eq!(columns.len(), expected_cols.len());
 
@@ -609,7 +609,7 @@ fn test_partitioned_table_stores_logical_column_names_with_column_mapping(
         );
     }
 
-    let clustering = snapshot.get_clustering_columns_physical(engine.as_ref())?;
+    let clustering = snapshot.get_physical_clustering_columns(engine.as_ref())?;
     assert!(
         clustering.is_none(),
         "Partitioned table should not have clustering columns"

--- a/kernel/tests/create_table/ctas.rs
+++ b/kernel/tests/create_table/ctas.rs
@@ -102,7 +102,7 @@ fn verify_column_names_in_clustering_metadata(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let schema = snapshot.schema();
     let clustering_columns = snapshot
-        .get_clustering_columns_physical(engine)?
+        .get_physical_clustering_columns(engine)?
         .expect("Clustering columns should be present");
 
     assert_eq!(

--- a/kernel/tests/create_table/partitioned.rs
+++ b/kernel/tests/create_table/partitioned.rs
@@ -27,7 +27,7 @@ fn test_create_table_partitioned_basic() -> DeltaResult<()> {
     let partition_cols = snapshot.table_configuration().partition_columns();
     assert_eq!(partition_cols, &["date"]);
 
-    let clustering = snapshot.get_clustering_columns_physical(engine.as_ref())?;
+    let clustering = snapshot.get_physical_clustering_columns(engine.as_ref())?;
     assert!(
         clustering.is_none(),
         "Partitioned table should not have clustering columns"


### PR DESCRIPTION
## What changes are proposed in this pull request?
Rename xxx_column_physical to physical_xxx_column for better reading
<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

## How was this change tested?
Existing