### PR TITLE
fix: prevent null-safety wrapping inside OR predicates during data skipping

### DIFF
--- a/kernel/src/kernel_predicates/mod.rs
+++ b/kernel/src/kernel_predicates/mod.rs
@@ -434,10 +434,23 @@ pub trait KernelPredicateEvaluator {
         use Pred::*;
         match pred {
             Junction(JunctionPredicate { op, preds }) => {
-                // Recursively invoke `eval_pred_sql_where` instead of the usual `eval_pred` for AND/OR.
-                let mut preds = preds
-                    .iter()
-                    .map(|pred| self.eval_pred_sql_where(pred, inverted));
+                // Only push null-safety wrapping into AND children. OR children must use
+                // normal eval_pred so that NULL (= unknown) propagates instead of being
+                // converted to FALSE. Inside OR, FALSE is fatal: OR(FALSE, FALSE) = FALSE
+                // would incorrectly prune files whose stats are merely missing.
+                let is_and = match (op, inverted) {
+                    (JunctionPredicateOp::And, false) | (JunctionPredicateOp::Or, true) => true,
+                    (JunctionPredicateOp::Or, false) | (JunctionPredicateOp::And, true) => false,
+                };
+                let mut preds: Box<dyn Iterator<Item = Option<Self::Output>>> = if is_and {
+                    Box::new(
+                        preds
+                            .iter()
+                            .map(|pred| self.eval_pred_sql_where(pred, inverted)),
+                    )
+                } else {
+                    Box::new(preds.iter().map(|pred| self.eval_pred(pred, inverted)))
+                };
                 self.finish_eval_pred_junction(*op, &mut preds, inverted)
             }
             Binary(BinaryPredicate { op, left, right }) if op.is_null_intolerant() => {

--- a/kernel/src/kernel_predicates/tests.rs
+++ b/kernel/src/kernel_predicates/tests.rs
@@ -1021,9 +1021,66 @@ fn test_sql_where() {
     expect_eq!(null_filter.eval_sql_where(pred), Some(false), "{pred}");
     expect_eq!(empty_filter.eval_sql_where(pred), None, "{pred}");
 
-    // Ditto for comparison inside OR inside AND
+    // Comparison inside AND inside OR: OR children use normal eval, so the AND inside OR
+    // does not get null-safety wrapping. NULL propagates through the OR conservatively.
     let pred = &Pred::or(FALSE, Pred::and(TRUE, Pred::lt(col.clone(), VAL)));
     expect_eq!(null_filter.eval(pred), None, "{pred}");
+    expect_eq!(null_filter.eval_sql_where(pred), None, "{pred}");
+    expect_eq!(empty_filter.eval_sql_where(pred), None, "{pred}");
+
+    // Null-safety wrapping must NOT be pushed into OR children. Inside AND, wrapping a
+    // null-intolerant comparison as AND(col IS NOT NULL, lit IS NOT NULL, cmp) correctly
+    // converts NULL to FALSE because AND(FALSE, ...) is still FALSE. But inside OR, converting
+    // NULL to FALSE is fatal: OR(FALSE, FALSE) = FALSE causes incorrect file pruning when
+    // stats are merely missing (NULL) rather than indicating all-null data.
+    //
+    // OR children should be evaluated with normal (non-sql-where) semantics so that NULL
+    // (= unknown) propagates through the OR, producing a conservative "can't skip" result.
+
+    // Comparison directly inside OR: should preserve NULL, not convert to FALSE
+    let pred = &Pred::or(Pred::lt(col.clone(), VAL), FALSE);
+    expect_eq!(null_filter.eval(pred), None, "{pred}");
+    expect_eq!(null_filter.eval_sql_where(pred), None, "{pred}");
+    expect_eq!(empty_filter.eval_sql_where(pred), None, "{pred}");
+
+    // Symmetric: FALSE on left, comparison on right
+    let pred = &Pred::or(FALSE, Pred::lt(col.clone(), VAL));
+    expect_eq!(null_filter.eval(pred), None, "{pred}");
+    expect_eq!(null_filter.eval_sql_where(pred), None, "{pred}");
+    expect_eq!(empty_filter.eval_sql_where(pred), None, "{pred}");
+
+    // Multiple null-intolerant comparisons in OR: all should preserve NULL
+    let pred = &Pred::or(Pred::lt(col.clone(), VAL), Pred::gt(col.clone(), VAL));
+    expect_eq!(null_filter.eval(pred), None, "{pred}");
+    expect_eq!(null_filter.eval_sql_where(pred), None, "{pred}");
+    expect_eq!(empty_filter.eval_sql_where(pred), None, "{pred}");
+
+    // OR inside AND: the AND applies sql_where to its children, but the nested OR should
+    // still evaluate its own children with normal semantics
+    let pred = &Pred::and(TRUE, Pred::or(Pred::lt(col.clone(), VAL), FALSE));
+    expect_eq!(null_filter.eval(pred), None, "{pred}");
+    expect_eq!(null_filter.eval_sql_where(pred), None, "{pred}");
+    expect_eq!(empty_filter.eval_sql_where(pred), None, "{pred}");
+
+    // Comparison inside AND inside OR: AND should still null-wrap its children, but the
+    // outer OR should not cause additional wrapping
+    let pred = &Pred::or(Pred::and(TRUE, Pred::lt(col.clone(), VAL)), FALSE);
+    expect_eq!(null_filter.eval(pred), None, "{pred}");
+    expect_eq!(null_filter.eval_sql_where(pred), None, "{pred}");
+    expect_eq!(empty_filter.eval_sql_where(pred), None, "{pred}");
+
+    // NOT(OR(...)) has AND semantics (De Morgan's), so null-wrapping IS applied to children.
+    // NOT(OR(lt(x, 1), TRUE)) = AND(NOT(lt(x, 1)), FALSE) = FALSE regardless.
+    let pred = &Pred::not(Pred::or(Pred::lt(col.clone(), VAL), TRUE));
+    expect_eq!(null_filter.eval(pred), Some(false), "{pred}");
     expect_eq!(null_filter.eval_sql_where(pred), Some(false), "{pred}");
+    expect_eq!(empty_filter.eval_sql_where(pred), Some(false), "{pred}");
+
+    // NOT(AND(...)) has OR semantics, so null-wrapping is NOT applied to children.
+    // NOT(AND(lt(x, 1), TRUE)) = OR(NOT(lt(x, 1)), FALSE). The comparison inside the
+    // (inverted) OR should preserve NULL.
+    let pred = &Pred::not(Pred::and(Pred::lt(col.clone(), VAL), TRUE));
+    expect_eq!(null_filter.eval(pred), None, "{pred}");
+    expect_eq!(null_filter.eval_sql_where(pred), None, "{pred}");
     expect_eq!(empty_filter.eval_sql_where(pred), None, "{pred}");
 }

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -350,14 +350,15 @@ fn test_sql_where() {
     do_test(ALL_NULL, pred, PRESENT, None, Some(false));
     do_test(ALL_NULL, pred, MISSING, None, None);
 
-    // Comparison inside OR works
+    // Comparison inside OR: null-safety wrapping is NOT pushed into OR children, so
+    // all-null columns produce NULL (= can't skip) instead of FALSE.
     let pred = &Pred::or(FALSE, Pred::lt(col.clone(), VAL));
-    do_test(ALL_NULL, pred, PRESENT, None, Some(false));
+    do_test(ALL_NULL, pred, PRESENT, None, None);
     do_test(ALL_NULL, pred, MISSING, None, None);
 
-    // Comparison inside AND inside OR works
+    // Comparison inside AND inside OR: the OR prevents null-wrapping from reaching the AND
     let pred = &Pred::or(FALSE, Pred::and(TRUE, Pred::lt(col.clone(), VAL)));
-    do_test(ALL_NULL, pred, PRESENT, None, Some(false));
+    do_test(ALL_NULL, pred, PRESENT, None, None);
     do_test(ALL_NULL, pred, MISSING, None, None);
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes a bug where eval_pred_sql_where applied null-safety wrapping to OR children, which converted NULL (unknown) comparisons to FALSE (can skip). 

Changed how AND vs OR operates. OR now uses eval_pred.
## How was this change tested?

New unit tests