### PR TITLE
feat!: add catalogManaged to allowed features in CREATE TABLE

### DIFF
--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -1174,10 +1174,7 @@ mod tests {
     #[case::append_only(TableFeature::AppendOnly, "appendOnly")]
     #[case::change_data_feed(TableFeature::ChangeDataFeed, "changeDataFeed")]
     #[case::type_widening(TableFeature::TypeWidening, "typeWidening")]
-    fn test_feature_signal_accepted(
-        #[case] feature: TableFeature,
-        #[case] feature_name: &str,
-    ) {
+    fn test_feature_signal_accepted(#[case] feature: TableFeature, #[case] feature_name: &str) {
         let key = format!("delta.feature.{feature_name}");
         let properties = HashMap::from([(key, "supported".to_string())]);
         let validated = validate_extract_table_features_and_properties(properties).unwrap();


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2293/files) to review incremental changes.
- [**stack/kernel-catalog-managed-create**](https://github.com/delta-io/delta-kernel-rs/pull/2293) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2293/files)]
  - [stack/ccv2-create](https://github.com/delta-io/delta-kernel-rs/pull/2203) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2203/files/8cf518a944cd62f87f35cad6db205195b224c513..9c6826254bddecce6b2fe428aa9a1b6a1af1b6d2)]
    - [stack/ccv2-create-pt2](https://github.com/delta-io/delta-kernel-rs/pull/2247) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2247/files/9c6826254bddecce6b2fe428aa9a1b6a1af1b6d2..6847bd06fd174c05674b34e4970671d5cf073d5a)]
      - [stack/create-table-utils-pt3](https://github.com/delta-io/delta-kernel-rs/pull/2250) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2250/files/6847bd06fd174c05674b34e4970671d5cf073d5a..e1035044d9e0c419eaee5d4ebb1284adb8646bf0)]
        - [stack/create-table-utils-pt4](https://github.com/delta-io/delta-kernel-rs/pull/2254) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2254/files/e1035044d9e0c419eaee5d4ebb1284adb8646bf0..ba618b1a85366699b2312ea3430d6adec8aefc4d)]

---------
## What changes are proposed in this pull request?

Enables creating catalog-managed Delta tables by adding `CatalogManaged` to `ALLOWED_DELTA_FEATURES` in the `create_table` builder. This allows connectors to pass `delta.feature.catalogManaged = "supported"` as a table property during table creation. The feature is gated behind the `catalog-managed` feature flag.

## How was this change tested?

`test_catalog_managed_feature_signal_accepted` - verifies the feature signal is accepted, removed from properties, and added to both reader and writer features
