### PR TITLE
feat: add FFI remove files DML functions

### DIFF
--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -444,8 +444,11 @@ pub unsafe extern "C" fn free_create_table_builder(builder: Handle<ExclusiveCrea
 /// `selection_vector_len` is 0, the `selection_vector` pointer is not accessed and may be null
 /// or any arbitrary value.
 ///
-/// The `data` schema must match the scan row schema returned by
-/// [`scan_metadata_next`](crate::scan::scan_metadata_next).
+/// The `data` and `selection_vector` should be derived from
+/// [`scan_metadata_next`](crate::scan::scan_metadata_next): `data` is the engine data batch and
+/// `selection_vector` is the scan's selection vector, modified to select only the rows (files) to
+/// remove. Selecting rows that were not active in the original scan selection vector produces
+/// invalid Remove actions in the commit log.
 ///
 /// Note: Unlike [`add_files`], this function takes an `engine` handle and returns
 /// [`ExternResult`] because the selection vector validation can fail. Returns `true` on


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds FFI functions for removing files from a Delta table transaction:

- `remove_files` -- removes files using raw engine data and a selection vector. The selection vector indicates which rows in the data represent files to remove (true = selected). A null/empty selection vector selects all rows.

These functions enable C/C++ consumers to implement DELETE/MERGE operations by scanning a table, identifying files to rewrite, and removing the originals.

### This PR affects the following public APIs

New FFI functions: `remove_files`

## How was this change tested?

Unit tests covering:
- `remove_files` with selection vector: same end-to-end flow using raw engine data
- Null selection vector creates empty `FilteredEngineData` (all rows selected)
