### PR TITLE
refactor: use hashbrown with SipHash for file-action dedup sets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1267,6 +1267,7 @@ dependencies = [
  "delta_kernel",
  "delta_kernel_derive",
  "futures",
+ "hashbrown 0.16.1",
  "hdfs-native",
  "hdfs-native-object-store",
  "indexmap",
@@ -1818,6 +1819,9 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "equivalent",
+]
 
 [[package]]
 name = "hdfs-native"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -42,6 +42,7 @@ pre-release-hook = [
 delta_kernel_derive = { path = "../derive-macros", version = "0.20.0" }
 bytes = "1.10"
 chrono = "0.4.41"
+hashbrown = { version = "0.16", default-features = false, features = ["equivalent"] }
 crc = "3.2.2"
 indexmap = "2.10.0"
 itertools = "0.14"

--- a/kernel/src/action_reconciliation/log_replay.rs
+++ b/kernel/src/action_reconciliation/log_replay.rs
@@ -41,6 +41,7 @@ use crate::schema::{column_name, ColumnName, ColumnNamesAndTypes, DataType};
 use crate::utils::require;
 use crate::{DeltaResult, Error};
 
+use std::collections::hash_map::RandomState;
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 use std::sync::{Arc, LazyLock};
@@ -50,7 +51,7 @@ use std::sync::{Arc, LazyLock};
 pub(crate) struct ActionReconciliationProcessor {
     /// Tracks file actions that have been seen during log replay to avoid duplicates.
     /// Contains (data file path, dv_unique_id) pairs as `FileActionKey` instances.
-    seen_file_keys: HashSet<FileActionKey>,
+    seen_file_keys: hashbrown::HashSet<FileActionKey, RandomState>,
     /// Indicates whether a protocol action has been seen in the log.
     seen_protocol: bool,
     /// Indicates whether a metadata action has been seen in the log.
@@ -345,7 +346,7 @@ impl ActionReconciliationVisitor<'_> {
 
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new<'seen>(
-        seen_file_keys: &'seen mut HashSet<FileActionKey>,
+        seen_file_keys: &'seen mut hashbrown::HashSet<FileActionKey, RandomState>,
         is_log_batch: bool,
         selection_vector: Vec<bool>,
         minimum_file_retention_timestamp: i64,
@@ -664,7 +665,7 @@ mod tests {
     #[test]
     fn test_action_reconciliation_visitor() -> DeltaResult<()> {
         let data = action_batch();
-        let mut seen_file_keys = HashSet::new();
+        let mut seen_file_keys = hashbrown::HashSet::with_hasher(RandomState::new());
         let mut seen_txns = HashSet::new();
         let mut seen_domains = HashSet::new();
         let mut visitor = ActionReconciliationVisitor::new(
@@ -722,7 +723,7 @@ mod tests {
         .into();
         let batch = parse_json_batch(json_strings);
 
-        let mut seen_file_keys = HashSet::new();
+        let mut seen_file_keys = hashbrown::HashSet::with_hasher(RandomState::new());
         let mut seen_txns = HashSet::new();
         let mut seen_domains = HashSet::new();
         let mut visitor = ActionReconciliationVisitor::new(
@@ -755,7 +756,7 @@ mod tests {
         .into();
         let batch = parse_json_batch(json_strings);
 
-        let mut seen_file_keys = HashSet::new();
+        let mut seen_file_keys = hashbrown::HashSet::with_hasher(RandomState::new());
         let mut seen_txns = HashSet::new();
         let mut seen_domains = HashSet::new();
         let mut visitor = ActionReconciliationVisitor::new(
@@ -796,7 +797,7 @@ mod tests {
         .into();
         let batch = parse_json_batch(json_strings);
 
-        let mut seen_file_keys = HashSet::new();
+        let mut seen_file_keys = hashbrown::HashSet::with_hasher(RandomState::new());
         let mut seen_txns = HashSet::new();
         let mut seen_domains = HashSet::new();
         let mut visitor = ActionReconciliationVisitor::new(
@@ -831,7 +832,7 @@ mod tests {
         let batch = parse_json_batch(json_strings);
 
         // Pre-populate with txn app1
-        let mut seen_file_keys = HashSet::new();
+        let mut seen_file_keys = hashbrown::HashSet::with_hasher(RandomState::new());
         let mut seen_txns = HashSet::new();
         let mut seen_domains = HashSet::new();
         seen_txns.insert("app1".to_string());
@@ -873,7 +874,7 @@ mod tests {
         .into();
         let batch = parse_json_batch(json_strings);
 
-        let mut seen_file_keys = HashSet::new();
+        let mut seen_file_keys = hashbrown::HashSet::with_hasher(RandomState::new());
         let mut seen_txns = HashSet::new();
         let mut seen_domains = HashSet::new();
         let mut visitor = ActionReconciliationVisitor::new(
@@ -1033,7 +1034,7 @@ mod tests {
         .into();
         let batch = parse_json_batch(json_strings);
 
-        let mut seen_file_keys = HashSet::new();
+        let mut seen_file_keys = hashbrown::HashSet::with_hasher(RandomState::new());
         let mut seen_txns = HashSet::new();
         let mut seen_domains = HashSet::new();
         let mut visitor = ActionReconciliationVisitor::new(
@@ -1191,7 +1192,7 @@ mod tests {
 
     /// Helper function to create a standard action reconciliation visitor for error testing
     fn create_test_visitor<'a>(
-        seen_file_keys: &'a mut HashSet<FileActionKey>,
+        seen_file_keys: &'a mut hashbrown::HashSet<FileActionKey, RandomState>,
         seen_txns: &'a mut HashSet<String>,
         seen_domains: &'a mut HashSet<String>,
         txn_expiration_timestamp: Option<i64>,
@@ -1229,7 +1230,7 @@ mod tests {
     #[test]
     fn test_action_reconciliation_visitor_validation_and_type_errors() {
         // Test 1: Wrong getter count validation
-        let mut seen_file_keys = HashSet::new();
+        let mut seen_file_keys = hashbrown::HashSet::with_hasher(RandomState::new());
         let mut seen_txns = HashSet::new();
         let mut seen_domains = HashSet::new();
         let mut visitor =
@@ -1257,7 +1258,7 @@ mod tests {
         ];
 
         for (getter_index, field_name, error_type, expected_error_text) in test_cases {
-            let mut seen_file_keys = HashSet::new();
+            let mut seen_file_keys = hashbrown::HashSet::with_hasher(RandomState::new());
             let mut seen_txns = HashSet::new();
             let mut seen_domains = HashSet::new();
             let mut visitor =
@@ -1277,7 +1278,7 @@ mod tests {
     #[test]
     fn test_action_reconciliation_visitor_complex_field_errors() {
         // Test txn.lastUpdated with retention enabled
-        let mut seen_file_keys = HashSet::new();
+        let mut seen_file_keys = hashbrown::HashSet::with_hasher(RandomState::new());
         let mut seen_txns = HashSet::new();
         let mut seen_domains = HashSet::new();
         let mut visitor = create_test_visitor(
@@ -1308,7 +1309,7 @@ mod tests {
             .contains("lastUpdated is not of type i64"));
 
         // Test remove.deletionTimestamp
-        let mut seen_file_keys = HashSet::new();
+        let mut seen_file_keys = hashbrown::HashSet::with_hasher(RandomState::new());
         let mut seen_txns = HashSet::new();
         let mut seen_domains = HashSet::new();
         let mut visitor =

--- a/kernel/src/log_replay.rs
+++ b/kernel/src/log_replay.rs
@@ -20,7 +20,7 @@ use crate::{DeltaResult, EngineData};
 
 use delta_kernel_derive::internal_api;
 
-use std::collections::HashSet;
+use std::collections::hash_map::RandomState;
 use std::sync::Arc;
 
 use tracing::debug;
@@ -56,7 +56,7 @@ pub(crate) struct FileActionDeduplicator<'seen> {
     /// A set of (data file path, dv_unique_id) pairs that have been seen thus
     /// far in the log for deduplication. This is a mutable reference to the set
     /// of seen file keys that persists across multiple log batches.
-    seen_file_keys: &'seen mut HashSet<FileActionKey>,
+    seen_file_keys: &'seen mut hashbrown::HashSet<FileActionKey, RandomState>,
     // TODO: Consider renaming to `is_commit_batch`, `deduplicate_batch`, or `save_batch`
     // to better reflect its role in deduplication logic.
     /// Whether we're processing a commit log JSON file (`true`) or a checkpoint file (`false`).
@@ -74,7 +74,7 @@ pub(crate) struct FileActionDeduplicator<'seen> {
 
 impl<'seen> FileActionDeduplicator<'seen> {
     pub(crate) fn new(
-        seen_file_keys: &'seen mut HashSet<FileActionKey>,
+        seen_file_keys: &'seen mut hashbrown::HashSet<FileActionKey, RandomState>,
         is_log_batch: bool,
         add_path_index: usize,
         remove_path_index: usize,
@@ -361,7 +361,7 @@ mod tests {
     use super::*;
     use crate::engine_data::GetData;
     use crate::DeltaResult;
-    use std::collections::{HashMap, HashSet};
+    use std::collections::HashMap;
 
     /// Mock GetData implementation for testing
     struct MockGetData {
@@ -413,7 +413,7 @@ mod tests {
 
     /// Helper to create a FileActionDeduplicator with standard indices
     fn create_deduplicator(
-        seen: &mut HashSet<FileActionKey>,
+        seen: &mut hashbrown::HashSet<FileActionKey, RandomState>,
         is_log_batch: bool,
     ) -> FileActionDeduplicator<'_> {
         FileActionDeduplicator::new(
@@ -450,7 +450,7 @@ mod tests {
 
     #[test]
     fn test_extract_file_action_add() -> DeltaResult<()> {
-        let mut seen = HashSet::new();
+        let mut seen = hashbrown::HashSet::with_hasher(RandomState::new());
         let deduplicator = create_deduplicator(&mut seen, true);
 
         let mut mock_add = MockGetData::new();
@@ -469,7 +469,7 @@ mod tests {
 
     #[test]
     fn test_extract_file_action_remove() -> DeltaResult<()> {
-        let mut seen = HashSet::new();
+        let mut seen = hashbrown::HashSet::with_hasher(RandomState::new());
         let deduplicator = create_deduplicator(&mut seen, true);
 
         let mut mock_remove = MockGetData::new();
@@ -487,7 +487,7 @@ mod tests {
 
     #[test]
     fn test_extract_file_action_with_deletion_vector() -> DeltaResult<()> {
-        let mut seen = HashSet::new();
+        let mut seen = hashbrown::HashSet::with_hasher(RandomState::new());
         let deduplicator = create_deduplicator(&mut seen, true);
 
         let mut mock_dv = MockGetData::new();
@@ -511,7 +511,7 @@ mod tests {
 
     #[test]
     fn test_extract_file_action_skip_removes() -> DeltaResult<()> {
-        let mut seen = HashSet::new();
+        let mut seen = hashbrown::HashSet::with_hasher(RandomState::new());
         let deduplicator = create_deduplicator(&mut seen, true);
 
         let mut mock_remove = MockGetData::new();
@@ -533,7 +533,7 @@ mod tests {
 
     #[test]
     fn test_extract_file_action_no_action_found() -> DeltaResult<()> {
-        let mut seen = HashSet::new();
+        let mut seen = hashbrown::HashSet::with_hasher(RandomState::new());
         let deduplicator = create_deduplicator(&mut seen, true);
 
         let getters = create_getters_with_mocks(None, None);
@@ -546,7 +546,7 @@ mod tests {
 
     #[test]
     fn test_check_and_record_seen() {
-        let mut seen = HashSet::new();
+        let mut seen = hashbrown::HashSet::with_hasher(RandomState::new());
 
         // Pre-populate with an existing key
         let pre_existing_key = FileActionKey::new("existing.parquet", None);
@@ -596,7 +596,7 @@ mod tests {
 
     #[test]
     fn test_is_log_batch() {
-        let mut seen = HashSet::new();
+        let mut seen = hashbrown::HashSet::with_hasher(RandomState::new());
 
         // Test with is_log_batch = true
         let deduplicator_log = create_deduplicator(&mut seen, true);
@@ -611,7 +611,7 @@ mod tests {
 
     #[test]
     fn test_checkpoint_extract_file_action_add() -> DeltaResult<()> {
-        let seen = HashSet::new();
+        let seen = hashbrown::HashSet::with_hasher(RandomState::new());
         let deduplicator = CheckpointDeduplicator::try_new(&seen, 0, 2)?;
 
         let mut mock_add = MockGetData::new();
@@ -630,7 +630,7 @@ mod tests {
 
     #[test]
     fn test_checkpoint_extract_file_action_with_deletion_vector() -> DeltaResult<()> {
-        let seen = HashSet::new();
+        let seen = hashbrown::HashSet::with_hasher(RandomState::new());
         let deduplicator = CheckpointDeduplicator::try_new(&seen, 0, 2)?;
 
         let mut mock_dv = MockGetData::new();
@@ -655,7 +655,7 @@ mod tests {
 
     #[test]
     fn test_checkpoint_deduplicator_filters_commit_duplicates() -> DeltaResult<()> {
-        let mut seen = HashSet::new();
+        let mut seen = hashbrown::HashSet::with_hasher(RandomState::new());
 
         // Files "seen" during commit processing
         seen.insert(FileActionKey::new("modified_in_commit.parquet", None));

--- a/kernel/src/log_replay/deduplicator.rs
+++ b/kernel/src/log_replay/deduplicator.rs
@@ -10,10 +10,10 @@
 //!
 //! [`FileActionDeduplicator`]: crate::log_replay::FileActionDeduplicator
 
-use std::collections::HashSet;
-
 use crate::actions::deletion_vector::DeletionVectorDescriptor;
 use crate::engine_data::{GetData, TypedGetData};
+use std::collections::hash_map::RandomState;
+
 use crate::log_replay::FileActionKey;
 use crate::DeltaResult;
 
@@ -75,7 +75,7 @@ pub(crate) trait Deduplicator {
 /// [`FileActionDeduplicator`]: crate::log_replay::FileActionDeduplicator
 #[allow(unused)]
 pub(crate) struct CheckpointDeduplicator<'a> {
-    seen_file_keys: &'a HashSet<FileActionKey>,
+    seen_file_keys: &'a hashbrown::HashSet<FileActionKey, RandomState>,
     add_path_index: usize,
     add_dv_start_index: usize,
 }
@@ -83,7 +83,7 @@ pub(crate) struct CheckpointDeduplicator<'a> {
 impl<'a> CheckpointDeduplicator<'a> {
     #[allow(unused)]
     pub(crate) fn try_new(
-        seen_file_keys: &'a HashSet<FileActionKey>,
+        seen_file_keys: &'a hashbrown::HashSet<FileActionKey, RandomState>,
         add_path_index: usize,
         add_dv_start_index: usize,
     ) -> DeltaResult<Self> {

--- a/kernel/src/parallel/parallel_phase.rs
+++ b/kernel/src/parallel/parallel_phase.rs
@@ -128,6 +128,8 @@ mod tests {
     use crate::actions::get_log_add_schema;
     use crate::engine::arrow_data::ArrowEngineData;
     use crate::engine::default::DefaultEngine;
+    use std::collections::hash_map::RandomState;
+
     use crate::log_replay::FileActionKey;
     use crate::log_segment::CheckpointReadInfo;
     use crate::object_store::memory::InMemory;
@@ -142,7 +144,6 @@ mod tests {
     use crate::schema::{DataType, StructField, StructType};
     use crate::utils::test_utils::{load_test_table, parse_json_batch};
     use crate::{PredicateRef, SnapshotRef};
-    use std::collections::HashSet;
     use std::sync::Arc;
     use std::thread;
     use url::Url;
@@ -191,7 +192,7 @@ mod tests {
     ) -> DeltaResult<ScanLogReplayProcessor> {
         let state_info = Arc::new(get_simple_state_info(test_schema(), vec![])?);
 
-        let seen_file_keys: HashSet<FileActionKey> = seen_paths
+        let seen_file_keys: hashbrown::HashSet<FileActionKey, RandomState> = seen_paths
             .iter()
             .map(|path| FileActionKey::new(*path, None))
             .collect();

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -1,4 +1,5 @@
 use std::clone::Clone;
+use std::collections::hash_map::RandomState;
 use std::collections::HashSet;
 use std::sync::{Arc, LazyLock};
 
@@ -115,7 +116,7 @@ pub struct ScanLogReplayProcessor {
     /// A set of (data file path, dv_unique_id) pairs that have been seen thus
     /// far in the log. This is used to filter out files with Remove actions as
     /// well as duplicate entries in the log.
-    seen_file_keys: HashSet<FileActionKey>,
+    seen_file_keys: hashbrown::HashSet<FileActionKey, RandomState>,
     /// Skip reading file statistics.
     skip_stats: bool,
     /// Information about checkpoint reading for stats optimization
@@ -146,7 +147,7 @@ impl ScanLogReplayProcessor {
             engine,
             state_info,
             checkpoint_info,
-            HashSet::with_capacity(dedup_capacity),
+            hashbrown::HashSet::with_capacity_and_hasher(dedup_capacity, RandomState::new()),
             skip_stats,
         )
     }
@@ -166,7 +167,7 @@ impl ScanLogReplayProcessor {
         engine: &dyn Engine,
         state_info: Arc<StateInfo>,
         checkpoint_info: CheckpointReadInfo,
-        seen_file_keys: HashSet<FileActionKey>,
+        seen_file_keys: hashbrown::HashSet<FileActionKey, RandomState>,
         skip_stats: bool,
     ) -> DeltaResult<Self> {
         let CheckpointReadInfo {
@@ -315,7 +316,7 @@ impl ScanLogReplayProcessor {
         Ok(SerializableScanState {
             predicate,
             internal_state_blob,
-            seen_file_keys: self.seen_file_keys,
+            seen_file_keys: self.seen_file_keys.into_iter().collect(),
             checkpoint_info: self.checkpoint_info,
         })
     }
@@ -370,7 +371,7 @@ impl ScanLogReplayProcessor {
             engine,
             state_info,
             state.checkpoint_info,
-            state.seen_file_keys,
+            state.seen_file_keys.into_iter().collect(),
             internal_state.skip_stats,
         )
     }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2298/files) to review incremental changes.
- [**stack/perf/introduce-hashbrown**](https://github.com/delta-io/delta-kernel-rs/pull/2298) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2298/files)]

## What changes are proposed in this pull request?

---------
Replace std::collections::HashSet with hashbrown::HashSet<K, RandomState> for
the internal file-action dedup sets used during log replay. This retains the
standard library's SipHash hasher (HashDoS-resistant) while gaining access to
hashbrown's `Equivalent` trait, which enables zero-copy lookups with borrowed
keys in the child PR (perf/zero-alloc-file-action-dedup).

The serialized type (SerializableScanState) continues to use
std::collections::HashSet to avoid exposing hashbrown in public API and to
sidestep cbindgen limitations with multi-param generics.

Scoped to FileActionKey sets only -- other HashSets (seen_txns, seen_domains,
etc.) remain as std.

## How was this change tested?
Existing tests suffice