### PR TITLE
refactor: extract shared stat helpers from RowGroupFilter

### DIFF
--- a/kernel/src/engine/parquet_row_group_skipping.rs
+++ b/kernel/src/engine/parquet_row_group_skipping.rs
@@ -51,7 +51,7 @@ impl<T> ParquetRowGroupSkipping for ArrowReaderBuilder<T> {
     }
 }
 
-/// A ParquetStatsSkippingFilter for row group skipping. It obtains stats from a parquet
+/// A [`ParquetStatsProvider`] for data file row group skipping. It obtains stats from a parquet
 /// [`RowGroupMetaData`] and pre-computes the mapping of each referenced column path to its
 /// corresponding field index, for O(1) stats lookups.
 struct RowGroupFilter<'a> {
@@ -80,122 +80,15 @@ impl<'a> RowGroupFilter<'a> {
             .get(col)
             .map(|&i| self.row_group.column(i).statistics())
     }
-
-    fn decimal_from_bytes(bytes: Option<&[u8]>, dtype: DecimalType) -> Option<Scalar> {
-        // WARNING: The bytes are stored in big-endian order; reverse and then 0-pad to 16 bytes.
-        let bytes = bytes.filter(|b| b.len() <= 16)?;
-        let mut bytes = Vec::from(bytes);
-        bytes.reverse();
-        bytes.resize(16, 0u8);
-        let bytes: [u8; 16] = bytes.try_into().ok()?;
-        let value = DecimalData::try_new(i128::from_le_bytes(bytes), dtype).ok()?;
-        Some(value.into())
-    }
-
-    fn timestamp_from_date(days: Option<&i32>) -> Option<Scalar> {
-        let days = u64::try_from(*days?).ok()?;
-        let timestamp = DateTime::UNIX_EPOCH.checked_add_days(Days::new(days))?;
-        let timestamp = timestamp.signed_duration_since(DateTime::UNIX_EPOCH);
-        Some(Scalar::TimestampNtz(timestamp.num_microseconds()?))
-    }
 }
 
 impl ParquetStatsProvider for RowGroupFilter<'_> {
-    // Extracts a stat value, converting from its physical type to the requested logical type.
-    //
-    // NOTE: This code is highly redundant with [`get_max_stat_value`] below, but parquet
-    // ValueStatistics<T> requires T to impl a private trait, so we can't factor out any kind of
-    // helper method. And macros are hard enough to read that it's not worth defining one.
     fn get_parquet_min_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Scalar> {
-        use PrimitiveType::*;
-        let value = match (data_type.as_primitive_opt()?, self.get_stats(col)??) {
-            (String, Statistics::ByteArray(s)) => s.min_opt()?.as_utf8().ok()?.into(),
-            (String, Statistics::FixedLenByteArray(s)) => s.min_opt()?.as_utf8().ok()?.into(),
-            (String, _) => return None,
-            (Long, Statistics::Int64(s)) => s.min_opt()?.into(),
-            (Long, Statistics::Int32(s)) => (*s.min_opt()? as i64).into(),
-            (Long, _) => return None,
-            (Integer, Statistics::Int32(s)) => s.min_opt()?.into(),
-            (Integer, _) => return None,
-            (Short, Statistics::Int32(s)) => (*s.min_opt()? as i16).into(),
-            (Short, _) => return None,
-            (Byte, Statistics::Int32(s)) => (*s.min_opt()? as i8).into(),
-            (Byte, _) => return None,
-            (Float, Statistics::Float(s)) => s.min_opt()?.into(),
-            (Float, _) => return None,
-            (Double, Statistics::Double(s)) => s.min_opt()?.into(),
-            (Double, Statistics::Float(s)) => (*s.min_opt()? as f64).into(),
-            (Double, _) => return None,
-            (Boolean, Statistics::Boolean(s)) => s.min_opt()?.into(),
-            (Boolean, _) => return None,
-            (Binary, Statistics::ByteArray(s)) => s.min_opt()?.data().into(),
-            (Binary, Statistics::FixedLenByteArray(s)) => s.min_opt()?.data().into(),
-            (Binary, _) => return None,
-            (Date, Statistics::Int32(s)) => Scalar::Date(*s.min_opt()?),
-            (Date, _) => return None,
-            (Timestamp, Statistics::Int64(s)) => Scalar::Timestamp(*s.min_opt()?),
-            (Timestamp, _) => return None, // TODO: Int96 timestamps
-            (TimestampNtz, Statistics::Int64(s)) => Scalar::TimestampNtz(*s.min_opt()?),
-            (TimestampNtz, Statistics::Int32(s)) => Self::timestamp_from_date(s.min_opt())?,
-            (TimestampNtz, _) => return None, // TODO: Int96 timestamps
-            (Decimal(d), Statistics::Int32(i)) => {
-                DecimalData::try_new(*i.min_opt()?, *d).ok()?.into()
-            }
-            (Decimal(d), Statistics::Int64(i)) => {
-                DecimalData::try_new(*i.min_opt()?, *d).ok()?.into()
-            }
-            (Decimal(d), Statistics::FixedLenByteArray(b)) => {
-                Self::decimal_from_bytes(b.min_bytes_opt(), *d)?
-            }
-            (Decimal(..), _) => return None,
-        };
-        Some(value)
+        extract_min_scalar(data_type, self.get_stats(col)??)
     }
 
     fn get_parquet_max_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Scalar> {
-        use PrimitiveType::*;
-        let value = match (data_type.as_primitive_opt()?, self.get_stats(col)??) {
-            (String, Statistics::ByteArray(s)) => s.max_opt()?.as_utf8().ok()?.into(),
-            (String, Statistics::FixedLenByteArray(s)) => s.max_opt()?.as_utf8().ok()?.into(),
-            (String, _) => return None,
-            (Long, Statistics::Int64(s)) => s.max_opt()?.into(),
-            (Long, Statistics::Int32(s)) => (*s.max_opt()? as i64).into(),
-            (Long, _) => return None,
-            (Integer, Statistics::Int32(s)) => s.max_opt()?.into(),
-            (Integer, _) => return None,
-            (Short, Statistics::Int32(s)) => (*s.max_opt()? as i16).into(),
-            (Short, _) => return None,
-            (Byte, Statistics::Int32(s)) => (*s.max_opt()? as i8).into(),
-            (Byte, _) => return None,
-            (Float, Statistics::Float(s)) => s.max_opt()?.into(),
-            (Float, _) => return None,
-            (Double, Statistics::Double(s)) => s.max_opt()?.into(),
-            (Double, Statistics::Float(s)) => (*s.max_opt()? as f64).into(),
-            (Double, _) => return None,
-            (Boolean, Statistics::Boolean(s)) => s.max_opt()?.into(),
-            (Boolean, _) => return None,
-            (Binary, Statistics::ByteArray(s)) => s.max_opt()?.data().into(),
-            (Binary, Statistics::FixedLenByteArray(s)) => s.max_opt()?.data().into(),
-            (Binary, _) => return None,
-            (Date, Statistics::Int32(s)) => Scalar::Date(*s.max_opt()?),
-            (Date, _) => return None,
-            (Timestamp, Statistics::Int64(s)) => Scalar::Timestamp(*s.max_opt()?),
-            (Timestamp, _) => return None, // TODO: Int96 timestamps
-            (TimestampNtz, Statistics::Int64(s)) => Scalar::TimestampNtz(*s.max_opt()?),
-            (TimestampNtz, Statistics::Int32(s)) => Self::timestamp_from_date(s.max_opt())?,
-            (TimestampNtz, _) => return None, // TODO: Int96 timestamps
-            (Decimal(d), Statistics::Int32(i)) => {
-                DecimalData::try_new(*i.max_opt()?, *d).ok()?.into()
-            }
-            (Decimal(d), Statistics::Int64(i)) => {
-                DecimalData::try_new(*i.max_opt()?, *d).ok()?.into()
-            }
-            (Decimal(d), Statistics::FixedLenByteArray(b)) => {
-                Self::decimal_from_bytes(b.max_bytes_opt(), *d)?
-            }
-            (Decimal(..), _) => return None,
-        };
-        Some(value)
+        extract_max_scalar(data_type, self.get_stats(col)??)
     }
 
     fn get_parquet_nullcount_stat(&self, col: &ColumnName) -> Option<i64> {
@@ -208,23 +101,134 @@ impl ParquetStatsProvider for RowGroupFilter<'_> {
             // physical name mapping has been performed. Because we currently lack both the
             // validation and the name mapping support, we must disable this optimization for the
             // time being. See https://github.com/delta-io/delta-kernel-rs/issues/434.
-            return Some(self.get_parquet_rowcount_stat()).filter(|_| false);
+            return self.get_parquet_rowcount_stat().filter(|_| false);
         };
 
-        // WARNING: The parquet footer decoding forces missing stats to Some(0), which would cause
-        // an IS NULL predicate to wrongly skip the file if it contains any NULL values. To be safe,
-        // we must never return Some(0). See https://github.com/apache/arrow-rs/issues/9451.
-        let nullcount = stats?.null_count_opt().filter(|n| *n > 0);
-
-        // Parquet nullcount stats are always u64, so we can directly return the value instead of
-        // wrapping it in a Scalar. We can safely cast it from u64 to i64 because the nullcount can
-        // never be larger than the rowcount and the parquet rowcount stat is i64.
-        Some(nullcount? as i64)
+        extract_nullcount(stats)
     }
 
-    fn get_parquet_rowcount_stat(&self) -> i64 {
-        self.row_group.num_rows()
+    fn get_parquet_rowcount_stat(&self) -> Option<i64> {
+        Some(self.row_group.num_rows())
     }
+}
+
+/// Extracts the minimum stat value from parquet footer statistics, converting from the physical
+/// parquet type to the requested logical Delta type.
+fn extract_min_scalar(data_type: &DataType, stats: &Statistics) -> Option<Scalar> {
+    use PrimitiveType::*;
+    let value = match (data_type.as_primitive_opt()?, stats) {
+        (String, Statistics::ByteArray(s)) => s.min_opt()?.as_utf8().ok()?.into(),
+        (String, Statistics::FixedLenByteArray(s)) => s.min_opt()?.as_utf8().ok()?.into(),
+        (String, _) => return None,
+        (Long, Statistics::Int64(s)) => s.min_opt()?.into(),
+        (Long, Statistics::Int32(s)) => (*s.min_opt()? as i64).into(),
+        (Long, _) => return None,
+        (Integer, Statistics::Int32(s)) => s.min_opt()?.into(),
+        (Integer, _) => return None,
+        (Short, Statistics::Int32(s)) => (*s.min_opt()? as i16).into(),
+        (Short, _) => return None,
+        (Byte, Statistics::Int32(s)) => (*s.min_opt()? as i8).into(),
+        (Byte, _) => return None,
+        (Float, Statistics::Float(s)) => s.min_opt()?.into(),
+        (Float, _) => return None,
+        (Double, Statistics::Double(s)) => s.min_opt()?.into(),
+        (Double, Statistics::Float(s)) => (*s.min_opt()? as f64).into(),
+        (Double, _) => return None,
+        (Boolean, Statistics::Boolean(s)) => s.min_opt()?.into(),
+        (Boolean, _) => return None,
+        (Binary, Statistics::ByteArray(s)) => s.min_opt()?.data().into(),
+        (Binary, Statistics::FixedLenByteArray(s)) => s.min_opt()?.data().into(),
+        (Binary, _) => return None,
+        (Date, Statistics::Int32(s)) => Scalar::Date(*s.min_opt()?),
+        (Date, _) => return None,
+        (Timestamp, Statistics::Int64(s)) => Scalar::Timestamp(*s.min_opt()?),
+        (Timestamp, _) => return None, // TODO: Int96 timestamps
+        (TimestampNtz, Statistics::Int64(s)) => Scalar::TimestampNtz(*s.min_opt()?),
+        (TimestampNtz, Statistics::Int32(s)) => timestamp_from_date(s.min_opt())?,
+        (TimestampNtz, _) => return None, // TODO: Int96 timestamps
+        (Decimal(d), Statistics::Int32(i)) => DecimalData::try_new(*i.min_opt()?, *d).ok()?.into(),
+        (Decimal(d), Statistics::Int64(i)) => DecimalData::try_new(*i.min_opt()?, *d).ok()?.into(),
+        (Decimal(d), Statistics::FixedLenByteArray(b)) => {
+            decimal_from_bytes(b.min_bytes_opt(), *d)?
+        }
+        (Decimal(..), _) => return None,
+    };
+    Some(value)
+}
+
+/// Extracts the maximum stat value from parquet footer statistics, converting from the physical
+/// parquet type to the requested logical Delta type.
+fn extract_max_scalar(data_type: &DataType, stats: &Statistics) -> Option<Scalar> {
+    use PrimitiveType::*;
+    let value = match (data_type.as_primitive_opt()?, stats) {
+        (String, Statistics::ByteArray(s)) => s.max_opt()?.as_utf8().ok()?.into(),
+        (String, Statistics::FixedLenByteArray(s)) => s.max_opt()?.as_utf8().ok()?.into(),
+        (String, _) => return None,
+        (Long, Statistics::Int64(s)) => s.max_opt()?.into(),
+        (Long, Statistics::Int32(s)) => (*s.max_opt()? as i64).into(),
+        (Long, _) => return None,
+        (Integer, Statistics::Int32(s)) => s.max_opt()?.into(),
+        (Integer, _) => return None,
+        (Short, Statistics::Int32(s)) => (*s.max_opt()? as i16).into(),
+        (Short, _) => return None,
+        (Byte, Statistics::Int32(s)) => (*s.max_opt()? as i8).into(),
+        (Byte, _) => return None,
+        (Float, Statistics::Float(s)) => s.max_opt()?.into(),
+        (Float, _) => return None,
+        (Double, Statistics::Double(s)) => s.max_opt()?.into(),
+        (Double, Statistics::Float(s)) => (*s.max_opt()? as f64).into(),
+        (Double, _) => return None,
+        (Boolean, Statistics::Boolean(s)) => s.max_opt()?.into(),
+        (Boolean, _) => return None,
+        (Binary, Statistics::ByteArray(s)) => s.max_opt()?.data().into(),
+        (Binary, Statistics::FixedLenByteArray(s)) => s.max_opt()?.data().into(),
+        (Binary, _) => return None,
+        (Date, Statistics::Int32(s)) => Scalar::Date(*s.max_opt()?),
+        (Date, _) => return None,
+        (Timestamp, Statistics::Int64(s)) => Scalar::Timestamp(*s.max_opt()?),
+        (Timestamp, _) => return None, // TODO: Int96 timestamps
+        (TimestampNtz, Statistics::Int64(s)) => Scalar::TimestampNtz(*s.max_opt()?),
+        (TimestampNtz, Statistics::Int32(s)) => timestamp_from_date(s.max_opt())?,
+        (TimestampNtz, _) => return None, // TODO: Int96 timestamps
+        (Decimal(d), Statistics::Int32(i)) => DecimalData::try_new(*i.max_opt()?, *d).ok()?.into(),
+        (Decimal(d), Statistics::Int64(i)) => DecimalData::try_new(*i.max_opt()?, *d).ok()?.into(),
+        (Decimal(d), Statistics::FixedLenByteArray(b)) => {
+            decimal_from_bytes(b.max_bytes_opt(), *d)?
+        }
+        (Decimal(..), _) => return None,
+    };
+    Some(value)
+}
+
+/// Extracts the null count from parquet footer statistics for a column.
+fn extract_nullcount(stats: Option<&Statistics>) -> Option<i64> {
+    // WARNING: The parquet footer decoding forces missing stats to Some(0), which would cause
+    // an IS NULL predicate to wrongly skip the file if it contains any NULL values. To be safe,
+    // we must never return Some(0). See https://github.com/apache/arrow-rs/issues/9451.
+    let nullcount = stats?.null_count_opt().filter(|n| *n > 0);
+
+    // Parquet nullcount stats are always u64, so we can directly return the value instead of
+    // wrapping it in a Scalar. We can safely cast it from u64 to i64 because the nullcount can
+    // never be larger than the rowcount and the parquet rowcount stat is i64.
+    Some(nullcount? as i64)
+}
+
+fn decimal_from_bytes(bytes: Option<&[u8]>, dtype: DecimalType) -> Option<Scalar> {
+    // WARNING: The bytes are stored in big-endian order; reverse and then 0-pad to 16 bytes.
+    let bytes = bytes.filter(|b| b.len() <= 16)?;
+    let mut bytes = Vec::from(bytes);
+    bytes.reverse();
+    bytes.resize(16, 0u8);
+    let bytes: [u8; 16] = bytes.try_into().ok()?;
+    let value = DecimalData::try_new(i128::from_le_bytes(bytes), dtype).ok()?;
+    Some(value.into())
+}
+
+fn timestamp_from_date(days: Option<&i32>) -> Option<Scalar> {
+    let days = u64::try_from(*days?).ok()?;
+    let timestamp = DateTime::UNIX_EPOCH.checked_add_days(Days::new(days))?;
+    let timestamp = timestamp.signed_duration_since(DateTime::UNIX_EPOCH);
+    Some(Scalar::TimestampNtz(timestamp.num_microseconds()?))
 }
 
 /// Given a predicate of interest and a set of parquet column descriptors, build a column ->

--- a/kernel/src/kernel_predicates/parquet_stats_skipping.rs
+++ b/kernel/src/kernel_predicates/parquet_stats_skipping.rs
@@ -10,9 +10,8 @@ use std::cmp::Ordering;
 #[cfg(test)]
 mod tests;
 
-/// A helper trait (mostly exposed for testing). It provides the four stats getters needed by
-/// [`DataSkippingStatsProvider`]. From there, we can automatically derive a
-/// [`DataSkippingPredicateEvaluator`].
+/// A helper trait (mostly exposed for testing). It provides the four stats getters needed to
+/// derive a [`DataSkippingPredicateEvaluator`] via the blanket impl below.
 pub(crate) trait ParquetStatsProvider {
     /// The min-value stat for this column, if the column exists in this file, has the expected
     /// type, and the parquet footer provides stats for it.
@@ -26,8 +25,10 @@ pub(crate) trait ParquetStatsProvider {
     /// type, and the parquet footer provides stats for it.
     fn get_parquet_nullcount_stat(&self, col: &ColumnName) -> Option<i64>;
 
-    /// The rowcount stat for this row group. It is always available in the parquet footer.
-    fn get_parquet_rowcount_stat(&self) -> i64;
+    /// The rowcount stat for this row group. Returns `None` if the rowcount is not meaningful
+    /// (e.g. in checkpoint files where the footer rowcount is the number of add file rows, not
+    /// the sum of data file row counts).
+    fn get_parquet_rowcount_stat(&self) -> Option<i64>;
 }
 
 // Blanket implementation for all types that impl ParquetStatsProvider.
@@ -48,7 +49,7 @@ impl<T: ParquetStatsProvider> DataSkippingPredicateEvaluator for T {
     }
 
     fn get_rowcount_stat(&self) -> Option<Scalar> {
-        Some(Scalar::from(self.get_parquet_rowcount_stat()))
+        self.get_parquet_rowcount_stat().map(Scalar::from)
     }
 
     fn eval_partial_cmp(

--- a/kernel/src/kernel_predicates/parquet_stats_skipping/tests.rs
+++ b/kernel/src/kernel_predicates/parquet_stats_skipping/tests.rs
@@ -35,7 +35,7 @@ impl ParquetStatsProvider for UnimplementedTestFilter {
         unimplemented!()
     }
 
-    fn get_parquet_rowcount_stat(&self) -> i64 {
+    fn get_parquet_rowcount_stat(&self) -> Option<i64> {
         unimplemented!()
     }
 }
@@ -148,7 +148,7 @@ impl ParquetStatsProvider for MinMaxTestFilter {
         unimplemented!()
     }
 
-    fn get_parquet_rowcount_stat(&self) -> i64 {
+    fn get_parquet_rowcount_stat(&self) -> Option<i64> {
         unimplemented!()
     }
 }
@@ -221,8 +221,8 @@ impl ParquetStatsProvider for NullCountTestFilter {
         self.nullcount
     }
 
-    fn get_parquet_rowcount_stat(&self) -> i64 {
-        self.rowcount
+    fn get_parquet_rowcount_stat(&self) -> Option<i64> {
+        Some(self.rowcount)
     }
 }
 

--- a/kernel/src/kernel_predicates/tests.rs
+++ b/kernel/src/kernel_predicates/tests.rs
@@ -734,8 +734,8 @@ impl ParquetStatsProvider for MinStatsValue {
         Some(0)
     }
 
-    fn get_parquet_rowcount_stat(&self) -> i64 {
-        1
+    fn get_parquet_rowcount_stat(&self) -> Option<i64> {
+        Some(1)
     }
 }
 
@@ -839,8 +839,8 @@ impl ParquetStatsProvider for OneStatsValue {
         Some(nullcount)
     }
 
-    fn get_parquet_rowcount_stat(&self) -> i64 {
-        1
+    fn get_parquet_rowcount_stat(&self) -> Option<i64> {
+        Some(1)
     }
 }
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2324/files) to review incremental changes.
- [**stack/refactor-helpers**](https://github.com/delta-io/delta-kernel-rs/pull/2324) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2324/files)]
  - [stack/row-group-1](https://github.com/delta-io/delta-kernel-rs/pull/1893) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1893/files/89b4729dc0e45dbd22dd5b80dfbcdecad9aa4610..1d1a8d46072ead0fb2abc3a0c54e9311632e84c2)]
    - [stack/row-group-2](https://github.com/delta-io/delta-kernel-rs/pull/1931) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/1931/files/1d1a8d46072ead0fb2abc3a0c54e9311632e84c2..6c11c9f3d6b6a38ace81d38acef096b3af5ba52e)]

---------
## What changes are proposed in this pull request?

Extracts stat extraction helpers from `RowGroupFilter` methods into shared free functions, preparing for reuse by `CheckpointRowGroupFilter` 


## How was this change tested?

Existing tests pass unchanged (test impls updated to wrap return values in `Some()`).