### PR TITLE
feat!: add CRC-related metric events

### DIFF
--- a/kernel/src/crc/reader.rs
+++ b/kernel/src/crc/reader.rs
@@ -1,6 +1,7 @@
 //! CRC file reading functionality.
 
 use super::Crc;
+use crate::metrics::MetricEvent;
 use crate::path::{AsUrl as _, ParsedLogPath};
 use crate::{DeltaResult, Engine, Error};
 
@@ -18,6 +19,12 @@ pub(crate) fn try_read_crc_file(engine: &dyn Engine, crc_path: &ParsedLogPath) -
         .next()
         .ok_or_else(|| Error::generic("CRC file read returned no data"))??;
     let crc: Crc = serde_json::from_slice(&data)?;
+
+    if let Some(reporter) = engine.get_metrics_reporter() {
+        reporter.report(MetricEvent::CrcReadCompleted {
+            bytes_read: data.len() as u64,
+        });
+    }
     Ok(crc)
 }
 
@@ -25,12 +32,15 @@ pub(crate) fn try_read_crc_file(engine: &dyn Engine, crc_path: &ParsedLogPath) -
 mod tests {
     use std::collections::HashMap;
     use std::path::PathBuf;
+    use std::sync::Arc;
 
     use super::*;
     use crate::actions::{Format, Metadata, Protocol};
     use crate::engine::sync::SyncEngine;
+    use crate::metrics::MetricEvent;
     use crate::path::ParsedLogPath;
     use crate::table_features::TableFeature;
+    use crate::utils::test_utils::CapturingReporter;
     use test_utils::assert_result_error_with_message;
 
     fn test_table_root(dir: &str) -> url::Url {
@@ -40,7 +50,8 @@ mod tests {
 
     #[test]
     fn test_read_crc_file() {
-        let engine = SyncEngine::new();
+        let reporter = Arc::new(CapturingReporter::default());
+        let engine = SyncEngine::with_reporter(reporter.clone());
         let table_root = test_table_root("./tests/data/crc-full/");
         let crc_path = ParsedLogPath::create_parsed_crc(&table_root, 0);
 
@@ -138,14 +149,32 @@ mod tests {
         assert!(crc.num_deleted_records_opt.is_none());
         assert!(crc.num_deletion_vectors_opt.is_none());
         assert!(crc.deleted_record_counts_histogram_opt.is_none());
+
+        // Verify CrcReadCompleted metric was emitted
+        let crc_events: Vec<_> = reporter
+            .events()
+            .into_iter()
+            .filter(|e| matches!(e, MetricEvent::CrcReadCompleted { .. }))
+            .collect();
+        assert_eq!(crc_events.len(), 1);
+        assert!(
+            matches!(&crc_events[0], MetricEvent::CrcReadCompleted { bytes_read } if *bytes_read > 0)
+        );
     }
 
     #[test]
     fn test_read_malformed_crc_file_fails() {
-        let engine = SyncEngine::new();
+        let reporter = Arc::new(CapturingReporter::default());
+        let engine = SyncEngine::with_reporter(reporter.clone());
         let table_root = test_table_root("./tests/data/crc-malformed/");
         let crc_path = ParsedLogPath::create_parsed_crc(&table_root, 0);
 
         assert_result_error_with_message(try_read_crc_file(&engine, &crc_path), "expected value");
+
+        // Verify no CrcReadCompleted metric was emitted on parse failure
+        assert!(reporter
+            .events()
+            .iter()
+            .all(|e| !matches!(e, MetricEvent::CrcReadCompleted { .. })));
     }
 }

--- a/kernel/src/crc/reader.rs
+++ b/kernel/src/crc/reader.rs
@@ -1,5 +1,7 @@
 //! CRC file reading functionality.
 
+use std::time::Instant;
+
 use super::Crc;
 use crate::metrics::MetricEvent;
 use crate::path::{AsUrl as _, ParsedLogPath};
@@ -12,19 +14,22 @@ use crate::{DeltaResult, Engine, Error};
 /// Returns `Ok(Crc)` on success, `Err` on any failure (file not readable, corrupt JSON, missing
 /// required fields). The caller should handle errors gracefully by falling back to log replay.
 pub(crate) fn try_read_crc_file(engine: &dyn Engine, crc_path: &ParsedLogPath) -> DeltaResult<Crc> {
+    let start = Instant::now();
     let storage = engine.storage_handler();
     let url = crc_path.location.as_url().clone();
     let data = storage
         .read_files(vec![(url, None)])?
         .next()
         .ok_or_else(|| Error::generic("CRC file read returned no data"))??;
-    let crc: Crc = serde_json::from_slice(&data)?;
 
     if let Some(reporter) = engine.get_metrics_reporter() {
         reporter.report(MetricEvent::CrcReadCompleted {
+            duration: start.elapsed(),
             bytes_read: data.len() as u64,
         });
     }
+
+    let crc: Crc = serde_json::from_slice(&data)?;
     Ok(crc)
 }
 
@@ -51,7 +56,7 @@ mod tests {
     #[test]
     fn test_read_crc_file() {
         let reporter = Arc::new(CapturingReporter::default());
-        let engine = SyncEngine::with_reporter(reporter.clone());
+        let engine = SyncEngine::new_with_reporter(reporter.clone());
         let table_root = test_table_root("./tests/data/crc-full/");
         let crc_path = ParsedLogPath::create_parsed_crc(&table_root, 0);
 
@@ -158,23 +163,28 @@ mod tests {
             .collect();
         assert_eq!(crc_events.len(), 1);
         assert!(
-            matches!(&crc_events[0], MetricEvent::CrcReadCompleted { bytes_read } if *bytes_read > 0)
+            matches!(&crc_events[0], MetricEvent::CrcReadCompleted { bytes_read, .. } if *bytes_read > 0)
         );
     }
 
     #[test]
     fn test_read_malformed_crc_file_fails() {
         let reporter = Arc::new(CapturingReporter::default());
-        let engine = SyncEngine::with_reporter(reporter.clone());
+        let engine = SyncEngine::new_with_reporter(reporter.clone());
         let table_root = test_table_root("./tests/data/crc-malformed/");
         let crc_path = ParsedLogPath::create_parsed_crc(&table_root, 0);
 
         assert_result_error_with_message(try_read_crc_file(&engine, &crc_path), "expected value");
 
-        // Verify no CrcReadCompleted metric was emitted on parse failure
-        assert!(reporter
+        // CrcReadCompleted is emitted after storage read, even when JSON parse fails
+        let crc_events: Vec<_> = reporter
             .events()
-            .iter()
-            .all(|e| !matches!(e, MetricEvent::CrcReadCompleted { .. })));
+            .into_iter()
+            .filter(|e| matches!(e, MetricEvent::CrcReadCompleted { .. }))
+            .collect();
+        assert_eq!(crc_events.len(), 1);
+        assert!(
+            matches!(&crc_events[0], MetricEvent::CrcReadCompleted { bytes_read, .. } if *bytes_read > 0)
+        );
     }
 }

--- a/kernel/src/engine/sync/mod.rs
+++ b/kernel/src/engine/sync/mod.rs
@@ -39,7 +39,8 @@ impl SyncEngine {
         }
     }
 
-    pub(crate) fn with_reporter(reporter: Arc<dyn MetricsReporter>) -> Self {
+    /// Create a new `SyncEngine` with the given metrics reporter.
+    pub(crate) fn new_with_reporter(reporter: Arc<dyn MetricsReporter>) -> Self {
         SyncEngine {
             metrics_reporter: Some(reporter),
             ..Self::new()

--- a/kernel/src/engine/sync/mod.rs
+++ b/kernel/src/engine/sync/mod.rs
@@ -2,6 +2,7 @@
 
 use super::arrow_expression::ArrowEvaluationHandler;
 use crate::engine::arrow_data::ArrowEngineData;
+use crate::metrics::MetricsReporter;
 use crate::{
     DeltaResult, Engine, Error, EvaluationHandler, FileDataReadResultIterator, FileMeta,
     JsonHandler, ParquetHandler, PredicateRef, SchemaRef, StorageHandler,
@@ -24,6 +25,7 @@ pub(crate) struct SyncEngine {
     json_handler: Arc<json::SyncJsonHandler>,
     parquet_handler: Arc<parquet::SyncParquetHandler>,
     evaluation_handler: Arc<ArrowEvaluationHandler>,
+    metrics_reporter: Option<Arc<dyn MetricsReporter>>,
 }
 
 impl SyncEngine {
@@ -33,6 +35,14 @@ impl SyncEngine {
             json_handler: Arc::new(json::SyncJsonHandler {}),
             parquet_handler: Arc::new(parquet::SyncParquetHandler {}),
             evaluation_handler: Arc::new(ArrowEvaluationHandler {}),
+            metrics_reporter: None,
+        }
+    }
+
+    pub(crate) fn with_reporter(reporter: Arc<dyn MetricsReporter>) -> Self {
+        SyncEngine {
+            metrics_reporter: Some(reporter),
+            ..Self::new()
         }
     }
 }
@@ -53,6 +63,10 @@ impl Engine for SyncEngine {
 
     fn json_handler(&self) -> Arc<dyn JsonHandler> {
         self.json_handler.clone()
+    }
+
+    fn get_metrics_reporter(&self) -> Option<Arc<dyn MetricsReporter>> {
+        self.metrics_reporter.clone()
     }
 }
 

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -309,6 +309,7 @@ impl LogSegment {
                         num_checkpoint_files: log_segment.listed.checkpoint_parts.len() as u64,
                         num_compaction_files: log_segment.listed.ascending_compaction_files.len()
                             as u64,
+                        has_latest_crc_file: log_segment.listed.latest_crc_file.is_some(),
                     });
                 });
                 Ok(log_segment)

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -120,8 +120,12 @@ pub enum MetricEvent {
 
     /// CRC file read operation completed (one event per CRC file read).
     ///
+    /// Emitted after the raw bytes are read from storage, regardless of whether JSON
+    /// deserialization succeeds.
+    ///
     /// `bytes_read` is the number of bytes read from the CRC file.
-    CrcReadCompleted { bytes_read: u64 },
+    /// `duration` is the duration of the read operation (not including deserialization).
+    CrcReadCompleted { duration: Duration, bytes_read: u64 },
 
     /// Scan metadata iteration completed.
     ///
@@ -229,8 +233,11 @@ impl fmt::Display for MetricEvent {
                 f,
                 "ParquetReadCompleted(files={num_files}, bytes={bytes_read})"
             ),
-            MetricEvent::CrcReadCompleted { bytes_read } => {
-                write!(f, "CrcReadCompleted(bytes={bytes_read})")
+            MetricEvent::CrcReadCompleted {
+                duration,
+                bytes_read,
+            } => {
+                write!(f, "CrcReadCompleted(duration={duration:?}, bytes={bytes_read})")
             }
             MetricEvent::ScanMetadataCompleted {
                 operation_id,

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -65,6 +65,7 @@ pub enum MetricEvent {
         num_commit_files: u64,
         num_checkpoint_files: u64,
         num_compaction_files: u64,
+        has_latest_crc_file: bool,
     },
 
     /// Protocol and metadata loading completed.
@@ -117,6 +118,11 @@ pub enum MetricEvent {
     /// [`ParquetHandler::read_parquet_files`]: crate::ParquetHandler::read_parquet_files
     ParquetReadCompleted { num_files: u64, bytes_read: u64 },
 
+    /// CRC file read operation completed (one event per CRC file read).
+    ///
+    /// `bytes_read` is the number of bytes read from the CRC file.
+    CrcReadCompleted { bytes_read: u64 },
+
     /// Scan metadata iteration completed.
     ///
     /// Emitted when the scan metadata iterator is exhausted. This event captures metrics about the
@@ -161,9 +167,12 @@ impl fmt::Display for MetricEvent {
                 num_commit_files,
                 num_checkpoint_files,
                 num_compaction_files,
+                has_latest_crc_file,
             } => write!(
                 f,
-                "LogSegmentLoaded(id={operation_id}, duration={duration:?}, commits={num_commit_files}, checkpoints={num_checkpoint_files}, compactions={num_compaction_files})"
+                "LogSegmentLoaded(id={operation_id}, duration={duration:?}, \
+                 commits={num_commit_files}, checkpoints={num_checkpoint_files}, \
+                 compactions={num_compaction_files}, has_latest_crc={has_latest_crc_file})"
             ),
             MetricEvent::ProtocolMetadataLoaded {
                 operation_id,
@@ -220,6 +229,9 @@ impl fmt::Display for MetricEvent {
                 f,
                 "ParquetReadCompleted(files={num_files}, bytes={bytes_read})"
             ),
+            MetricEvent::CrcReadCompleted { bytes_read } => {
+                write!(f, "CrcReadCompleted(bytes={bytes_read})")
+            }
             MetricEvent::ScanMetadataCompleted {
                 operation_id,
                 scan_type,

--- a/test-utils/src/counting_reporter.rs
+++ b/test-utils/src/counting_reporter.rs
@@ -91,10 +91,15 @@ pub struct CountingReporter {
     pub checkpoint_files: RelaxedCounter,
     /// Total log compaction files in the commit tail across all log segment loads.
     pub compaction_files: RelaxedCounter,
-    // TODO: add `crc_files` counter for version checksum (.crc) files read.
-    // Tracking CRC reads is critical for understanding snapshot load costs on tables
-    // that use CRC files heavily. Requires a new MetricEvent variant and emitting it
-    // from the CRC read path. See https://github.com/delta-io/delta-kernel-rs/issues/2257
+    /// Total number of times that a latest CRC file was found in the log segment, across all
+    /// log segment loads.
+    pub num_latest_crc_files_found: RelaxedCounter,
+
+    // CRC reader IO counters
+    /// Number of CRC read calls (one per [`MetricEvent::CrcReadCompleted`]).
+    pub crc_read_calls: RelaxedCounter,
+    /// Total number of bytes read from CRC files, across all CRC read calls.
+    pub crc_bytes_read: RelaxedCounter,
 }
 
 impl CountingReporter {
@@ -124,6 +129,9 @@ impl CountingReporter {
         self.commit_files.reset();
         self.checkpoint_files.reset();
         self.compaction_files.reset();
+        self.num_latest_crc_files_found.reset();
+        self.crc_read_calls.reset();
+        self.crc_bytes_read.reset();
     }
 
     /// Print a human-readable IO and operation summary.
@@ -144,16 +152,20 @@ impl CountingReporter {
         let parquet_calls = self.parquet_read_calls.get();
         let parquet_files = self.parquet_files_read.get();
         let parquet_kib = self.parquet_bytes_read.get() / 1024;
+        let crc_calls = self.crc_read_calls.get();
+        let crc_kib = self.crc_bytes_read.get() / 1024;
         let log_loads = self.log_segment_loads.get();
         let commits = self.commit_files.get();
         let checkpoints = self.checkpoint_files.get();
         let compactions = self.compaction_files.get();
+        let crc_files_found = self.num_latest_crc_files_found.get();
 
         println!("  [io] {label}");
         println!("    storage : {list_calls} list ({list_files} files seen)  {storage_reads} raw read ({storage_files} files, {storage_kib} KiB)  {copy_calls} copy");
         println!("    json    : {json_calls} call(s)  {json_files} files  {json_kib} KiB");
         println!("    parquet : {parquet_calls} call(s)  {parquet_files} files  {parquet_kib} KiB");
-        println!("    log     : {log_loads} segment load(s) -- {commits} commits  {checkpoints} checkpoints  {compactions} compactions");
+        println!("    crc     : {crc_calls} call(s)  {crc_kib} KiB");
+        println!("    log     : {log_loads} segment load(s) -- {commits} commits  {checkpoints} checkpoints  {compactions} compactions  {crc_files_found} latest_crc_files");
     }
 }
 
@@ -199,12 +211,19 @@ impl MetricsReporter for CountingReporter {
                 num_commit_files,
                 num_checkpoint_files,
                 num_compaction_files,
+                has_latest_crc_file,
                 ..
             } => {
                 self.log_segment_loads.inc();
                 self.commit_files.add(num_commit_files);
                 self.checkpoint_files.add(num_checkpoint_files);
                 self.compaction_files.add(num_compaction_files);
+                self.num_latest_crc_files_found
+                    .add(has_latest_crc_file as u64);
+            }
+            MetricEvent::CrcReadCompleted { bytes_read } => {
+                self.crc_read_calls.inc();
+                self.crc_bytes_read.add(bytes_read);
             }
             // Intentionally not tracked -- add counters if needed.
             MetricEvent::ProtocolMetadataLoaded { .. }
@@ -282,11 +301,22 @@ mod tests {
             num_commit_files: 7,
             num_checkpoint_files: 2,
             num_compaction_files: 1,
+            has_latest_crc_file: true,
         });
         assert_eq!(reporter.log_segment_loads.get(), 1);
         assert_eq!(reporter.commit_files.get(), 7);
         assert_eq!(reporter.checkpoint_files.get(), 2);
         assert_eq!(reporter.compaction_files.get(), 1);
+        assert_eq!(reporter.num_latest_crc_files_found.get(), 1);
+    }
+
+    #[test]
+    fn report_crc_read_completed_increments_crc_counters() {
+        let reporter = CountingReporter::new();
+        reporter.report(MetricEvent::CrcReadCompleted { bytes_read: 512 });
+        reporter.report(MetricEvent::CrcReadCompleted { bytes_read: 256 });
+        assert_eq!(reporter.crc_read_calls.get(), 2);
+        assert_eq!(reporter.crc_bytes_read.get(), 768);
     }
 
     #[test]
@@ -322,7 +352,9 @@ mod tests {
             num_commit_files: 7,
             num_checkpoint_files: 2,
             num_compaction_files: 1,
+            has_latest_crc_file: true,
         });
+        reporter.report(MetricEvent::CrcReadCompleted { bytes_read: 512 });
 
         reporter.reset();
 
@@ -343,5 +375,8 @@ mod tests {
         assert_eq!(reporter.commit_files.get(), 0);
         assert_eq!(reporter.checkpoint_files.get(), 0);
         assert_eq!(reporter.compaction_files.get(), 0);
+        assert_eq!(reporter.num_latest_crc_files_found.get(), 0);
+        assert_eq!(reporter.crc_read_calls.get(), 0);
+        assert_eq!(reporter.crc_bytes_read.get(), 0);
     }
 }

--- a/test-utils/src/counting_reporter.rs
+++ b/test-utils/src/counting_reporter.rs
@@ -93,7 +93,7 @@ pub struct CountingReporter {
     pub compaction_files: RelaxedCounter,
     /// Total number of times that a latest CRC file was found in the log segment, across all
     /// log segment loads.
-    pub num_latest_crc_files_found: RelaxedCounter,
+    pub latest_crc_files_found: RelaxedCounter,
 
     // CRC reader IO counters
     /// Number of CRC read calls (one per [`MetricEvent::CrcReadCompleted`]).
@@ -129,7 +129,7 @@ impl CountingReporter {
         self.commit_files.reset();
         self.checkpoint_files.reset();
         self.compaction_files.reset();
-        self.num_latest_crc_files_found.reset();
+        self.latest_crc_files_found.reset();
         self.crc_read_calls.reset();
         self.crc_bytes_read.reset();
     }
@@ -158,7 +158,7 @@ impl CountingReporter {
         let commits = self.commit_files.get();
         let checkpoints = self.checkpoint_files.get();
         let compactions = self.compaction_files.get();
-        let crc_files_found = self.num_latest_crc_files_found.get();
+        let crc_files_found = self.latest_crc_files_found.get();
 
         println!("  [io] {label}");
         println!("    storage : {list_calls} list ({list_files} files seen)  {storage_reads} raw read ({storage_files} files, {storage_kib} KiB)  {copy_calls} copy");
@@ -218,10 +218,9 @@ impl MetricsReporter for CountingReporter {
                 self.commit_files.add(num_commit_files);
                 self.checkpoint_files.add(num_checkpoint_files);
                 self.compaction_files.add(num_compaction_files);
-                self.num_latest_crc_files_found
-                    .add(has_latest_crc_file as u64);
+                self.latest_crc_files_found.add(has_latest_crc_file as u64);
             }
-            MetricEvent::CrcReadCompleted { bytes_read } => {
+            MetricEvent::CrcReadCompleted { bytes_read, .. } => {
                 self.crc_read_calls.inc();
                 self.crc_bytes_read.add(bytes_read);
             }
@@ -307,14 +306,35 @@ mod tests {
         assert_eq!(reporter.commit_files.get(), 7);
         assert_eq!(reporter.checkpoint_files.get(), 2);
         assert_eq!(reporter.compaction_files.get(), 1);
-        assert_eq!(reporter.num_latest_crc_files_found.get(), 1);
+        assert_eq!(reporter.latest_crc_files_found.get(), 1);
+    }
+
+    #[test]
+    fn report_log_segment_loaded_without_crc_does_not_increment_crc_counter() {
+        let reporter = CountingReporter::new();
+        reporter.report(MetricEvent::LogSegmentLoaded {
+            operation_id: MetricId::new(),
+            duration: dur(),
+            num_commit_files: 3,
+            num_checkpoint_files: 1,
+            num_compaction_files: 0,
+            has_latest_crc_file: false,
+        });
+        assert_eq!(reporter.log_segment_loads.get(), 1);
+        assert_eq!(reporter.latest_crc_files_found.get(), 0);
     }
 
     #[test]
     fn report_crc_read_completed_increments_crc_counters() {
         let reporter = CountingReporter::new();
-        reporter.report(MetricEvent::CrcReadCompleted { bytes_read: 512 });
-        reporter.report(MetricEvent::CrcReadCompleted { bytes_read: 256 });
+        reporter.report(MetricEvent::CrcReadCompleted {
+            duration: dur(),
+            bytes_read: 512,
+        });
+        reporter.report(MetricEvent::CrcReadCompleted {
+            duration: dur(),
+            bytes_read: 256,
+        });
         assert_eq!(reporter.crc_read_calls.get(), 2);
         assert_eq!(reporter.crc_bytes_read.get(), 768);
     }
@@ -354,7 +374,10 @@ mod tests {
             num_compaction_files: 1,
             has_latest_crc_file: true,
         });
-        reporter.report(MetricEvent::CrcReadCompleted { bytes_read: 512 });
+        reporter.report(MetricEvent::CrcReadCompleted {
+            duration: dur(),
+            bytes_read: 512,
+        });
 
         reporter.reset();
 
@@ -375,7 +398,7 @@ mod tests {
         assert_eq!(reporter.commit_files.get(), 0);
         assert_eq!(reporter.checkpoint_files.get(), 0);
         assert_eq!(reporter.compaction_files.get(), 0);
-        assert_eq!(reporter.num_latest_crc_files_found.get(), 0);
+        assert_eq!(reporter.latest_crc_files_found.get(), 0);
         assert_eq!(reporter.crc_read_calls.get(), 0);
         assert_eq!(reporter.crc_bytes_read.get(), 0);
     }


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR updates `MetricEvent` with additional CRC-related metrics. Specifically:
1. A `has_latest_crc_file` boolean to the LogSegmentLoaded event
2. A new event called `CrcReadCompleted` which has `bytes read` and is reported each time a CRC file is read.

This PR also updates the code to emit these new metrics and updates the `CountingReporter` implementation to track these.

Fixes https://github.com/delta-io/delta-kernel-rs/issues/2257

## How was this change tested?
Ran existing unit tests + added new unit test for CRC read path.
