### PR TITLE
feat: add FFI bindings for domain metadata write operations

### DIFF
--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -208,7 +208,7 @@ fn with_domain_metadata_removed_impl(
     txn: Transaction,
     domain: KernelStringSlice,
 ) -> DeltaResult<Handle<ExclusiveTransaction>> {
-    let domain: String = unsafe { TryFromStringSlice::try_from_slice(&domain) }?;
+    let domain = unsafe { TryFromStringSlice::try_from_slice(&domain) }?;
     Ok(Box::new(txn.with_domain_metadata_removed(domain)).into())
 }
 
@@ -787,10 +787,11 @@ mod tests {
             .get(&Path::from_url_path(commit_url.path()).unwrap())
             .await
             .unwrap();
-        let actions: Vec<serde_json::Value> = Deserializer::from_slice(&data.bytes().await.unwrap())
-            .into_iter::<serde_json::Value>()
-            .try_collect()
-            .unwrap();
+        let actions: Vec<serde_json::Value> =
+            Deserializer::from_slice(&data.bytes().await.unwrap())
+                .into_iter::<serde_json::Value>()
+                .try_collect()
+                .unwrap();
         actions
             .into_iter()
             .find(|a| a.get("domainMetadata").is_some())


### PR DESCRIPTION
## What changes are proposed in this pull request?

### This PR affects the following public APIs

Two new FFI functions are added (not breaking -- purely additive):

- `with_domain_metadata(txn, domain, configuration, engine)` -- add a `domainMetadata` action to a transaction
- `with_domain_metadata_removed(txn, domain, engine)` -- add a `domainMetadata` removal tombstone to a transaction

Both follow the existing consume-and-return handle pattern used by `with_engine_info`.

## How was this change tested?

Three new FFI tests:
- `test_domain_metadata_add_and_remove` -- happy path: adds domain metadata, commits, verifies JSON in commit log; then removes it in a second transaction and verifies the tombstone
- `test_domain_metadata_system_domain_rejected_at_commit` -- error path: system `delta.*` domain is rejected at commit
- `test_domain_metadata_duplicate_domain_rejected_at_commit` -- error path: duplicate domain in a single transaction is rejected at commit