### PR TITLE
fix: reuse LazyCrc in checkpoint early-return during incremental update

### DIFF
--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -224,6 +224,17 @@ impl LogSegment {
             end_version,
         )?;
 
+        // Invariant: when `latest_commit_file` is set, its version must equal the segment's
+        // end_version.
+        debug_assert!(
+            listed_files
+                .latest_commit_file
+                .as_ref()
+                .is_none_or(|c| c.version == effective_version),
+            "latest_commit_file version {:?} does not match end_version {effective_version}",
+            listed_files.latest_commit_file.as_ref().map(|c| c.version),
+        );
+
         let log_segment = LogSegment {
             end_version: effective_version,
             checkpoint_version,

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -223,17 +223,7 @@ impl LogSegment {
             &listed_files.checkpoint_parts,
             end_version,
         )?;
-
-        // Invariant: when `latest_commit_file` is set, its version must equal the segment's
-        // end_version.
-        debug_assert!(
-            listed_files
-                .latest_commit_file
-                .as_ref()
-                .is_none_or(|c| c.version == effective_version),
-            "latest_commit_file version {:?} does not match end_version {effective_version}",
-            listed_files.latest_commit_file.as_ref().map(|c| c.version),
-        );
+        validate_latest_commit_file(&listed_files, effective_version)?;
 
         let log_segment = LogSegment {
             end_version: effective_version,
@@ -1515,4 +1505,30 @@ fn validate_end_version(
         );
     }
     Ok(effective_version)
+}
+
+/// Validates the `latest_commit_file` field of a [`LogSegmentFiles`]. Enforces:
+///
+/// 1. If `ascending_commit_files` is non-empty, `latest_commit_file` must be `Some`.
+/// 2. If `latest_commit_file` is `Some`, its version must equal `effective_version`.
+fn validate_latest_commit_file(
+    listed: &LogSegmentFiles,
+    effective_version: Version,
+) -> DeltaResult<()> {
+    require!(
+        listed.ascending_commit_files.is_empty() || listed.latest_commit_file.is_some(),
+        Error::internal_error(
+            "latest_commit_file must be Some when ascending_commit_files is non-empty"
+        )
+    );
+    if let Some(commit) = &listed.latest_commit_file {
+        require!(
+            commit.version == effective_version,
+            Error::internal_error(format!(
+                "latest_commit_file version {} does not match end_version {effective_version}",
+                commit.version,
+            ))
+        );
+    }
+    Ok(())
 }

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -2683,6 +2683,9 @@ fn test_log_segment_contiguous_commit_files() {
                 create_log_path("file:///_delta_log/00000000000000000002.json"),
                 create_log_path("file:///_delta_log/00000000000000000003.json"),
             ],
+            latest_commit_file: Some(create_log_path(
+                "file:///_delta_log/00000000000000000003.json",
+            )),
             ..Default::default()
         },
         log_root.clone(),

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -1382,7 +1382,6 @@ async fn test_create_checkpoint_stream_reads_json_checkpoint_batch_without_sidec
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {
             checkpoint_parts: vec![create_log_path(&checkpoint_one_file)],
-            latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
             ..Default::default()
         },
         log_root,
@@ -2906,7 +2905,6 @@ async fn test_get_file_actions_schema_multi_part_v1(#[case] use_hint: bool) -> D
                 create_log_path_with_size(&cp1_file, cp1_size),
                 create_log_path_with_size(&cp2_file, cp2_size),
             ],
-            latest_commit_file: Some(create_log_path("file:///00000000000000000002.json")),
             ..Default::default()
         },
         log_root,

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -163,8 +163,14 @@ impl SnapshotBuilder {
                     effective_version,
                     operation_id,
                 )?;
-                Snapshot::try_new_from_log_segment(table_url, log_segment, engine, operation_id)
-                    .map(Into::into)
+                Snapshot::try_new_from_log_segment(
+                    table_url,
+                    log_segment,
+                    engine,
+                    operation_id,
+                    None,
+                )
+                .map(Into::into)
             })
         } else {
             existing_snapshot

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -2811,7 +2811,7 @@ mod tests {
 
         // Verify structural correctness: same result as a fresh snapshot build.
         let fresh = Snapshot::builder_for(ctx.url.as_str()).build(ctx.engine.as_ref())?;
-        assert_eq!(updated, fresh);
+        compare_snapshots(&updated, &fresh);
         assert_eq!(updated.version(), 3);
         assert_eq!(updated.log_segment.checkpoint_version, Some(1));
 
@@ -2868,7 +2868,7 @@ mod tests {
 
         // Verify structural correctness: same result as a fresh snapshot build.
         let fresh = Snapshot::builder_for(ctx.url.as_str()).build(ctx.engine.as_ref())?;
-        assert_eq!(updated, fresh);
+        compare_snapshots(&updated, &fresh);
         assert_eq!(updated.version(), 3);
         assert_eq!(updated.log_segment.checkpoint_version, Some(1));
 

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -105,27 +105,39 @@ impl Snapshot {
     /// Create a new [`SnapshotBuilder`] to incrementally update a [`Snapshot`] to a more recent
     /// version.
     ///
-    /// Given an existing snapshot and an optional `target_version`, the update proceeds by case:
+    /// `target_version` is the effective requested version: the time-travel version from
+    /// [`SnapshotBuilder::at_version`] when set, otherwise the `max_catalog_version` from
+    /// [`SnapshotBuilder::with_max_catalog_version`] for catalog-managed tables, otherwise
+    /// unset (defaults to latest).
+    ///
+    /// The log listing performed below is catalog-log-tail aware: any `log_tail` provided to
+    /// the builder is merged with filesystem listings.
+    ///
+    /// Given an existing snapshot and `target_version`, the update proceeds by case:
     ///
     /// - **A.** `target_version == existing_version`: return the existing snapshot unchanged.
     /// - **B.** `target_version < existing_version`: error. The incremental path only moves
     ///   forward.
-    /// - Otherwise, list the log from (existing checkpoint version + 1) onward (or from version 1
-    ///   if there is no checkpoint yet), and then one of the following applies:
-    ///   - **C.1.** Listing is empty and `target_version` is set: error (the target is newer than
-    ///     anything in the log).
-    ///   - **C.2.** Listing is empty and no `target_version`: return the existing snapshot.
+    /// - Otherwise, `target_version` is unset or `target_version > existing_version`. List the log
+    ///   from (existing checkpoint version + 1) onward (or from version 1 if there is no checkpoint
+    ///   yet), and then one of the following applies:
+    ///   - **C.** Listing is empty:
+    ///     - **C.1.** `target_version` is set: error (the target is newer than anything in the
+    ///       log).
+    ///     - **C.2.** `target_version` is unset: return the existing snapshot.
     ///   - **D.** Listing contains a checkpoint: build a fresh snapshot from that checkpoint (and
-    ///     any commits after it), reusing the existing CRC if its version matches.
+    ///     any commits after it), reusing the existing CRC if its version matches. TODO(#2351):
+    ///     when the new checkpoint is at or below `existing_version`, the existing snapshot already
+    ///     covers its P+M, so a full rebuild is wasted work. PR #2351 splits this into D.1
+    ///     (checkpoint > `existing_version`: rebuild) and D.2 (checkpoint <= `existing_version`:
+    ///     take the incremental path and advance the checkpoint base).
     ///   - **E.** Listing contains commits but no new checkpoint and no version advance: return the
     ///     existing snapshot.
     ///   - **F.** Listing contains new commits (and no new checkpoint): run lightweight P+M replay
     ///     on the new commits and merge them into the existing log segment.
     ///
-    /// Each case is marked with `// case X` in `Snapshot::try_new_from`.
-    ///
-    /// The target version (default: latest) is set via [`SnapshotBuilder::at_version`], and the
-    /// engine is passed to [`SnapshotBuilder::build`].
+    /// Each case is marked with `// Case X` in `Snapshot::try_new_from`. The engine is passed
+    /// to [`SnapshotBuilder::build`].
     pub fn builder_from(existing_snapshot: SnapshotRef) -> SnapshotBuilder {
         SnapshotBuilder::new_from(existing_snapshot)
     }
@@ -178,11 +190,11 @@ impl Snapshot {
         let requested_version = target_version.into();
         if let Some(requested_version) = requested_version {
             tracing::Span::current().record("version", requested_version);
-            // case A: re-requesting the same version.
+            // Case A: re-requesting the same version.
             if requested_version == existing_snapshot_version {
                 return Ok(existing_snapshot.clone());
             }
-            // case B: incremental path only moves forward.
+            // Case B: incremental path only moves forward.
             if requested_version < existing_snapshot_version {
                 return Err(Error::Generic(format!(
                     "Requested snapshot version {requested_version} is older than snapshot \
@@ -215,7 +227,7 @@ impl Snapshot {
             && new_listed_files.checkpoint_parts().is_empty()
         {
             match requested_version {
-                // case C.1: caller requested a specific version (necessarily >
+                // Case C.1: caller requested a specific version (necessarily >
                 // existing_snapshot_version since cases A and B were handled above), but
                 // no such commit exists in the log.
                 Some(requested_version) => {
@@ -225,7 +237,7 @@ impl Snapshot {
                          {existing_snapshot_version}"
                     )));
                 }
-                // case C.2: no new commits and no explicit target; latest is existing.
+                // Case C.2: no new commits and no explicit target; latest is existing.
                 None => {
                     return Ok(existing_snapshot.clone());
                 }
@@ -253,7 +265,7 @@ impl Snapshot {
             )));
         }
         if new_log_segment.checkpoint_version.is_some() {
-            // case D: listing contains a checkpoint; build a fresh snapshot from it.
+            // Case D: listing contains a checkpoint; build a fresh snapshot from it.
             // TODO(#2218): consider incremental P&M replay instead of full rebuild.
             // `resolve_crc` reuses the existing `LazyCrc` when the resolved CRC version
             // matches, avoiding redundant I/O.
@@ -272,12 +284,12 @@ impl Snapshot {
             return Ok(Arc::new(snapshot?));
         }
 
-        // case E: no new checkpoint, version did not advance; return existing.
+        // Case E: no new checkpoint, version did not advance; return existing.
         if new_end_version == existing_snapshot_version {
             return Ok(existing_snapshot.clone());
         }
 
-        // case F: new commits, no new checkpoint; lightweight P+M replay + merge.
+        // Case F: new commits, no new checkpoint; lightweight P+M replay + merge.
         // First we remove the 'overlap' in commits, example:
         //
         //    existing logsegment checkpoint1-commit1-commit2-commit3
@@ -330,11 +342,7 @@ impl Snapshot {
             .clone();
         ascending_compaction_files.extend(new_log_segment.listed.ascending_compaction_files);
 
-        // Use the new latest_commit if available, otherwise use the existing one.
-        // This handles the case where the new listing returned no commits
-        let latest_commit_file = new_latest_commit_file
-            .or_else(|| existing_log_segment.listed.latest_commit_file.clone());
-        // we can pass in just the existing checkpoint parts since by the time we reach this
+        // We can pass in just the existing checkpoint parts since by the time we reach this
         // line, we know there are no checkpoints in the new log segment.
         let combined_log_segment = LogSegment::try_new(
             LogSegmentFiles {
@@ -342,7 +350,10 @@ impl Snapshot {
                 ascending_compaction_files,
                 checkpoint_parts: existing_log_segment.listed.checkpoint_parts.clone(),
                 latest_crc_file: crc_file,
-                latest_commit_file,
+                // In Case F there are new commits (new_end_version > existing_snapshot_version
+                // with no new checkpoint), so the new listing's `latest_commit_file` is always
+                // `Some(commit @ new_end_version)` and matches the combined snapshot version.
+                latest_commit_file: new_latest_commit_file,
                 max_published_version: new_log_segment
                     .listed
                     .max_published_version

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -246,15 +246,20 @@ impl Snapshot {
         if new_log_segment.checkpoint_version.is_some() {
             // We found a checkpoint in the new log segment, so build a fresh snapshot from it.
             // TODO(#2218): consider incremental P&M replay instead of full rebuild.
-            // Only lazy_crc is needed: the new_log_segment carries its own latest_crc_file. The
-            // lazy_crc may reference the old segment's CRC as a fallback, which is safe:
-            // read_protocol_metadata always validates CRC version against end_version before
-            // trusting its P&M, so log replay runs when the versions differ.
-            let (_, lazy_crc) = Self::resolve_crc(
+            // Pass the resolved lazy_crc so the full rebuild can reuse a loaded CRC if the
+            // version matches. If the new segment has no CRC file, resolve_crc falls back to
+            // the old segment's CRC, which is safe: read_protocol_metadata validates the CRC
+            // version against end_version and falls back to log replay when they differ.
+            let (crc_file, lazy_crc) = Self::resolve_crc(
                 &new_log_segment,
                 old_log_segment,
                 &existing_snapshot.lazy_crc,
             );
+            // Inject the resolved CRC file path so the rebuilt snapshot remembers it.
+            // Without this, if the CRC is below the new listing start (and thus not found
+            // by the listing), the rebuilt snapshot's log_segment.latest_crc_file would be
+            // None, causing future incremental updates to lose the CRC reference.
+            new_log_segment.listed.latest_crc_file = crc_file;
             let snapshot = Self::try_new_from_log_segment(
                 existing_snapshot.table_root().clone(),
                 new_log_segment,
@@ -366,7 +371,6 @@ impl Snapshot {
         let old_crc_file = old_log_segment.listed.latest_crc_file.clone();
         let crc_file = new_crc_file.or(old_crc_file);
         let crc_version = crc_file.as_ref().map(|f| f.version);
-        // Version equality is sufficient: Delta allows at most one CRC file per version.
         let lazy_crc = if crc_version == existing_lazy_crc.crc_version() {
             existing_lazy_crc.clone()
         } else {

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -97,7 +97,7 @@ impl std::fmt::Debug for Snapshot {
 impl Snapshot {
     /// Create a new [`SnapshotBuilder`] to build a new [`Snapshot`] for a given table root. If you
     /// instead have an existing [`Snapshot`] you would like to do minimal work to update, consider
-    /// using
+    /// using [`Snapshot::builder_from`] instead.
     pub fn builder_for(table_root: impl AsRef<str>) -> SnapshotBuilder {
         SnapshotBuilder::new_for(table_root)
     }
@@ -105,25 +105,27 @@ impl Snapshot {
     /// Create a new [`SnapshotBuilder`] to incrementally update a [`Snapshot`] to a more recent
     /// version.
     ///
-    /// We implement a simple heuristic:
-    /// 1. if the caller explicitly requests the existing version, just return the existing snapshot
-    /// 2. if the new version < existing version, error: there is no optimization to do here
-    /// 3. list from (existing checkpoint version + 1) onward (or from version 1 if there is no
-    ///    checkpoint yet)
-    /// 4. if a newer or newly discovered checkpoint is found while refreshing to the latest
-    ///    version, create a new snapshot from that checkpoint (and commits after it), even if the
-    ///    table version itself did not advance
-    /// 5. if no new checkpoint is found and the table version did not advance, return the existing
-    ///    snapshot
-    /// 6. if no new checkpoint is found, do lightweight P+M replay on the latest commits after
-    ///    ensuring we only retain commits > any checkpoints
+    /// Given an existing snapshot and an optional `target_version`, the update proceeds by case:
     ///
-    /// # Parameters
+    /// - **A.** `target_version == existing_version`: return the existing snapshot unchanged.
+    /// - **B.** `target_version < existing_version`: error. The incremental path only moves
+    ///   forward.
+    /// - Otherwise, list the log from (existing checkpoint version + 1) onward (or from version 1
+    ///   if there is no checkpoint yet), and then one of the following applies:
+    ///   - **C.1.** Listing is empty and `target_version` is set: error (the target is newer than
+    ///     anything in the log).
+    ///   - **C.2.** Listing is empty and no `target_version`: return the existing snapshot.
+    ///   - **D.** Listing contains a checkpoint: build a fresh snapshot from that checkpoint (and
+    ///     any commits after it), reusing the existing CRC if its version matches.
+    ///   - **E.** Listing contains commits but no new checkpoint and no version advance: return the
+    ///     existing snapshot.
+    ///   - **F.** Listing contains new commits (and no new checkpoint): run lightweight P+M replay
+    ///     on the new commits and merge them into the existing log segment.
     ///
-    /// - `existing_snapshot`: reference to an existing [`Snapshot`]
-    /// - `engine`: Implementation of [`Engine`] apis.
-    /// - `target_version`: target version of the [`Snapshot`]. None will create a snapshot at the
-    ///   latest version of the table.
+    /// Each case is marked with `// case X` in `Snapshot::try_new_from_impl`.
+    ///
+    /// The target version (default: latest) is set via [`SnapshotBuilder::at_version`], and the
+    /// engine is passed to [`SnapshotBuilder::build`].
     pub fn builder_from(existing_snapshot: SnapshotRef) -> SnapshotBuilder {
         SnapshotBuilder::new_from(existing_snapshot)
     }
@@ -176,12 +178,12 @@ impl Snapshot {
         let requested_version = target_version.into();
         if let Some(requested_version) = requested_version {
             tracing::Span::current().record("version", requested_version);
+            // case A: re-requesting the same version.
             if requested_version == existing_snapshot_version {
-                // Re-requesting the same version
                 return Ok(existing_snapshot.clone());
             }
+            // case B: incremental path only moves forward.
             if requested_version < existing_snapshot_version {
-                // Hint is too new: error since this is effectively an incorrect optimization
                 return Err(Error::Generic(format!(
                     "Requested snapshot version {requested_version} is older than snapshot hint version {existing_snapshot_version}"
                 )));
@@ -212,9 +214,9 @@ impl Snapshot {
             && new_listed_files.checkpoint_parts().is_empty()
         {
             match requested_version {
-                // requested == existing_snapshot_version was handled earlier, and
-                // requested < existing_snapshot_version returned an error earlier, so any Some
-                // here is requested > existing_snapshot_version but no such commit exists.
+                // case C.1: caller requested a specific version (necessarily >
+                // existing_snapshot_version since cases A and B were handled above), but
+                // no such commit exists in the log.
                 Some(requested_version) => {
                     return Err(Error::Generic(format!(
                         "Requested snapshot version {requested_version} is not available: \
@@ -222,8 +224,8 @@ impl Snapshot {
                          {existing_snapshot_version}"
                     )));
                 }
+                // case C.2: no new commits and no explicit target; latest is existing.
                 None => {
-                    // No new commits and no explicit target, just return the same snapshot
                     return Ok(existing_snapshot.clone());
                 }
             }
@@ -248,22 +250,21 @@ impl Snapshot {
                 "Unexpected state: the newest version in the log {new_end_version} is older than the existing snapshot version {existing_snapshot_version}")));
         }
         if new_log_segment.checkpoint_version.is_some() {
-            // We found a checkpoint in the new log segment, so build a fresh snapshot from it.
+            // case D: listing contains a checkpoint; build a fresh snapshot from it.
             // TODO(#2218): consider incremental P&M replay instead of full rebuild.
-            // Pass the resolved lazy_crc so the full rebuild can reuse an already-loaded CRC
-            // when the resolved CRC version matches the existing snapshot's CRC version. If the
-            // new segment has no CRC file, resolve_crc falls back to the existing snapshot's
-            // CRC, which is safe: read_protocol_metadata validates the CRC version against
-            // end_version and falls back to log replay when they differ.
+            // `resolve_crc` picks the CRC for the rebuilt segment (see its doc for the
+            // invariant-preserving fallback rules) and reuses the existing `LazyCrc` when
+            // the resolved CRC version matches.
             let (crc_file, lazy_crc) = Self::resolve_crc(
                 &new_log_segment,
                 existing_log_segment,
                 &existing_snapshot.lazy_crc,
             );
             // Inject the resolved CRC file path so the rebuilt snapshot remembers it.
-            // Without this, if the CRC is below the new listing start (and thus not found
-            // by the listing), the rebuilt snapshot's log_segment.latest_crc_file would be
-            // None, causing future incremental updates to lose the CRC reference.
+            // Without this, if the existing CRC was below the new listing start (and thus
+            // not surfaced by the listing), the rebuilt snapshot would have
+            // `latest_crc_file = None` and future incremental updates would fall through to
+            // full log replay instead of taking the CRC fast path.
             new_log_segment.listed.latest_crc_file = crc_file;
             let snapshot = Self::try_new_from_log_segment(
                 existing_snapshot.table_root().clone(),
@@ -275,18 +276,18 @@ impl Snapshot {
             return Ok(Arc::new(snapshot?));
         }
 
+        // case E: no new checkpoint, version did not advance; return existing.
         if new_end_version == existing_snapshot_version {
-            // No new commits and no newly discovered checkpoint, just return the same snapshot.
             return Ok(existing_snapshot.clone());
         }
 
-        // after this point, we incrementally update the snapshot with the new log segment.
-        // first we remove the 'overlap' in commits, example:
+        // case F: new commits, no new checkpoint; lightweight P+M replay + merge.
+        // First we remove the 'overlap' in commits, example:
         //
-        //    old logsegment checkpoint1-commit1-commit2-commit3
-        // 1. new logsegment             commit1-commit2-commit3
-        // 2. new logsegment             commit1-commit2-commit3-commit4
-        // 3. new logsegment                     checkpoint2+commit2-commit3-commit4
+        //    existing logsegment checkpoint1-commit1-commit2-commit3
+        // 1. new logsegment                  commit1-commit2-commit3
+        // 2. new logsegment                  commit1-commit2-commit3-commit4
+        // 3. new logsegment                          checkpoint2+commit2-commit3-commit4
         //
         // retain does
         // 1. new logsegment             [empty] -> caught above
@@ -367,16 +368,31 @@ impl Snapshot {
 
     /// Determine the CRC file and LazyCrc for an incremental snapshot update.
     ///
-    /// Prefers the new segment's CRC file, falls back to the existing segment's. If the
-    /// resolved CRC version matches the existing snapshot's LazyCrc version, reuses it to
-    /// avoid redundant I/O (it may already be loaded in memory).
+    /// Prefers the new segment's CRC file; falls back to the existing segment's CRC if and
+    /// only if its version is >= the new segment's checkpoint version. If the resolved CRC
+    /// version matches the existing snapshot's LazyCrc version, reuses it to avoid redundant
+    /// I/O (it may already be loaded in memory).
+    ///
+    /// The filter preserves the [`LogSegmentFiles`] invariant `crc.version >=
+    /// checkpoint.version`. Without it, a stale inherited CRC could silently produce wrong
+    /// P&M via [`LogSegment::read_protocol_metadata_opt`]'s Case 2(b) fallback (see test
+    /// `test_incremental_snapshot_drops_stale_crc_preserves_correct_metadata`).
     fn resolve_crc(
         new_log_segment: &LogSegment,
         existing_log_segment: &LogSegment,
         existing_lazy_crc: &Arc<LazyCrc>,
     ) -> (Option<ParsedLogPath>, Arc<LazyCrc>) {
         let new_crc_file = new_log_segment.listed.latest_crc_file.clone();
-        let existing_crc_file = existing_log_segment.listed.latest_crc_file.clone();
+        let crc_satisfies_new_ckpt = |crc: &ParsedLogPath| {
+            new_log_segment
+                .checkpoint_version
+                .is_none_or(|ckpt_v| crc.version >= ckpt_v)
+        };
+        let existing_crc_file = existing_log_segment
+            .listed
+            .latest_crc_file
+            .clone()
+            .filter(crc_satisfies_new_ckpt);
         let crc_file = new_crc_file.or(existing_crc_file);
         let crc_version = crc_file.as_ref().map(|f| f.version);
         let lazy_crc = if crc_version == existing_lazy_crc.crc_version() {
@@ -2619,41 +2635,60 @@ mod tests {
         assert_eq!(post_commit_snapshot.log_segment().end_version, next_version);
     }
 
-    // Helper: create a minimal test table with commits 0-N
+    // Action builders for incremental-snapshot tests. Centralized so commit setup stays
+    // consistent across tests (e.g. the schema matches `make_test_crc_json`).
+    fn protocol_action(min_reader: u32, min_writer: u32) -> serde_json::Value {
+        json!({"protocol": {"minReaderVersion": min_reader, "minWriterVersion": min_writer}})
+    }
+
+    fn metadata_action(configuration: serde_json::Value) -> serde_json::Value {
+        json!({
+            "metaData": {
+                "id": "test-id",
+                "format": {"provider": "parquet", "options": {}},
+                "schemaString": "{\"type\":\"struct\",\"fields\":[{\"name\":\"id\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}",
+                "partitionColumns": [],
+                "configuration": configuration,
+                "createdTime": 1587968585495i64,
+            }
+        })
+    }
+
+    fn add_action(path: &str) -> serde_json::Value {
+        json!({
+            "add": {
+                "path": path,
+                "partitionValues": {},
+                "size": 100,
+                "modificationTime": 1000,
+                "dataChange": true,
+            }
+        })
+    }
+
+    // Helper: create a minimal test table with commits 0..num_commits.
     async fn setup_test_table_with_commits(
         table_root: impl AsRef<str>,
         store: &InMemory,
         num_commits: u64,
     ) -> DeltaResult<()> {
-        // Commit 0: protocol + metadata + first file
-        let commit0 = vec![
-            json!({"protocol": {"minReaderVersion": 1, "minWriterVersion": 2}}),
-            json!({
-                "metaData": {
-                    "id": "test-id",
-                    "format": {"provider": "parquet", "options": {}},
-                    "schemaString": "{\"type\":\"struct\",\"fields\":[{\"name\":\"id\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}",
-                    "partitionColumns": [],
-                    "configuration": {},
-                    "createdTime": 1587968585495i64
-                }
-            }),
-            json!({"add": {"path": "file1.parquet", "partitionValues": {}, "size": 100, "modificationTime": 1000, "dataChange": true}}),
-        ];
-        commit(table_root.as_ref(), store, 0, commit0).await;
+        // Commit 0: protocol + metadata + first file.
+        commit(
+            table_root.as_ref(),
+            store,
+            0,
+            vec![
+                protocol_action(1, 2),
+                metadata_action(json!({})),
+                add_action("file1.parquet"),
+            ],
+        )
+        .await;
 
-        // Additional commits with just add actions
+        // Additional commits with just add actions.
         for i in 1..num_commits {
-            let commit_i = vec![json!({
-                "add": {
-                    "path": format!("file{}.parquet", i + 1),
-                    "partitionValues": {},
-                    "size": (i + 1) * 100,
-                    "modificationTime": (i + 1) * 1000,
-                    "dataChange": true
-                }
-            })];
-            commit(table_root.as_ref(), store, i, commit_i).await;
+            let path = format!("file{}.parquet", i + 1);
+            commit(table_root.as_ref(), store, i, vec![add_action(&path)]).await;
         }
         Ok(())
     }
@@ -2765,13 +2800,13 @@ mod tests {
         Ok(())
     }
 
-    /// CRC JSON for the standard test table (see [`setup_test_table_with_commits`]).
+    // CRC JSON for the standard test table (see `setup_test_table_with_commits`).
     fn make_test_crc_json(table_size_bytes: i64, num_files: i64) -> serde_json::Value {
         json!({
-            "table_size_bytes": table_size_bytes,
-            "num_files": num_files,
-            "num_metadata": 1,
-            "num_protocol": 1,
+            "tableSizeBytes": table_size_bytes,
+            "numFiles": num_files,
+            "numMetadata": 1,
+            "numProtocol": 1,
             "protocol": {"minReaderVersion": 1, "minWriterVersion": 2},
             "metadata": {
                 "id": "test-id",
@@ -2784,105 +2819,235 @@ mod tests {
         })
     }
 
+    // `resolve_crc` in the checkpoint-rebuild path (case D) must correctly decide between
+    // reusing the existing snapshot's CRC, creating a fresh LazyCrc, or dropping the CRC
+    // entirely. Each case below sets up commits 0-3, writes an existing CRC, builds
+    // snapshot_v3, writes a checkpoint, optionally writes a new CRC, then runs the
+    // incremental update and checks the outcome.
+    //
+    // reuse_existing:   existing crc@v2 stays when new ckpt@v1 is below it (invariant OK)
+    //                   and no newer CRC was listed; the LazyCrc Arc is reused (loaded).
+    // refresh_to_newer: existing crc@v2 is superseded by a newly-listed crc@v3; the new
+    //                   CRC version wins and produces a fresh unloaded LazyCrc.
+    // crc_equals_ckpt:  existing crc@v2 and new ckpt@v2 sit at the same version -- sanity
+    //                   coverage for the invariant boundary `crc.version >= checkpoint.version`.
+    //                   (Note: this case does not pin `>=` vs `>` in `resolve_crc`'s filter
+    //                   because the listing also re-surfaces the existing CRC, so
+    //                   `new_crc_file = Some(v2)` wins via `.or(existing)` regardless of the
+    //                   filter's verdict on the existing CRC fallback. A scenario where only
+    //                   the fallback exercises the boundary is structurally unreachable: it
+    //                   would require the existing CRC to be below listing_start, but the
+    //                   LogSegmentFiles invariant forces existing_crc_version >=
+    //                   existing_checkpoint_version = listing_start - 1.)
+    // drop_below_ckpt:  existing crc@v1 would violate the LogSegmentFiles invariant with
+    //                   new ckpt@v2 (1 < 2), so it is filtered out; result has no CRC.
+    #[rstest]
+    #[case::reuse_existing(2, 1, None, Some(2), true)]
+    #[case::refresh_to_newer(2, 1, Some(3), Some(3), true)]
+    #[case::crc_equals_ckpt(2, 2, None, Some(2), true)]
+    #[case::drop_below_ckpt(1, 2, None, None, false)]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_incremental_snapshot_checkpoint_early_return_reuses_lazy_crc() -> DeltaResult<()>
-    {
+    async fn test_incremental_snapshot_checkpoint_rebuild_crc_resolution(
+        #[case] existing_crc_v: u64,
+        #[case] new_ckpt_v: u64,
+        #[case] newly_listed_crc_v: Option<u64>,
+        #[case] expected_crc_v: Option<u64>,
+        #[case] expect_loaded: bool,
+    ) -> DeltaResult<()> {
         let ctx = setup_incremental_snapshot_test()?;
-
-        // Create commits 0-3
         setup_test_table_with_commits(ctx.url.as_str(), &ctx.store, 4).await?;
 
-        // Write a well-formed CRC at v2 with P&M matching the table's schema.
-        let crc_path = delta_path_for_version(2, "crc");
         ctx.store
-            .put(&crc_path, make_test_crc_json(300, 3).to_string().into())
+            .put(
+                &delta_path_for_version(existing_crc_v, "crc"),
+                make_test_crc_json(300, 3).to_string().into(),
+            )
             .await?;
 
-        // Build snapshot at v3 -- its log segment will reference CRC at v2.
         let snapshot_v3 = Snapshot::builder_for(ctx.url.as_str())
             .at_version(3)
             .build(ctx.engine.as_ref())?;
-        assert_eq!(snapshot_v3.lazy_crc.crc_version(), Some(2));
+        assert_eq!(snapshot_v3.lazy_crc.crc_version(), Some(existing_crc_v));
 
-        // Force-load the CRC so it's cached in the OnceLock.
-        let _ = snapshot_v3.lazy_crc.get_or_load(ctx.engine.as_ref());
-        assert!(snapshot_v3.lazy_crc.is_loaded());
-
-        // Write a checkpoint at v1 so that the incremental update hits the checkpoint
-        // early-return. The CRC file (v2) is unchanged.
+        // Write the new checkpoint, plus optionally a newer CRC alongside it.
         Snapshot::builder_for(ctx.url.as_str())
-            .at_version(1)
+            .at_version(new_ckpt_v)
             .build(ctx.engine.as_ref())?
             .checkpoint(ctx.engine.as_ref())?;
+        if let Some(v) = newly_listed_crc_v {
+            ctx.store
+                .put(
+                    &delta_path_for_version(v, "crc"),
+                    make_test_crc_json(400, 4).to_string().into(),
+                )
+                .await?;
+        }
 
-        // Incremental update from v3: discovers the new checkpoint, takes the early-return.
-        let updated = Snapshot::builder_from(snapshot_v3.clone()).build(ctx.engine.as_ref())?;
+        let updated = Snapshot::builder_from(snapshot_v3).build(ctx.engine.as_ref())?;
 
-        // Verify structural correctness: same result as a fresh snapshot build.
+        // Observable equivalence: incremental update matches a fresh rebuild, including
+        // `log_segment.listed.latest_crc_file` (so a filter-bypass regression is caught by
+        // `compare_snapshots`, not just by the explicit CRC assertions below).
         let fresh = Snapshot::builder_for(ctx.url.as_str()).build(ctx.engine.as_ref())?;
         compare_snapshots(&updated, &fresh);
         assert_eq!(updated.version(), 3);
-        assert_eq!(updated.log_segment.checkpoint_version, Some(1));
+        assert_eq!(updated.log_segment.checkpoint_version, Some(new_ckpt_v));
+        assert_eq!(updated.lazy_crc.crc_version(), expected_crc_v);
+        assert_eq!(
+            updated
+                .log_segment
+                .listed
+                .latest_crc_file
+                .as_ref()
+                .map(|f| f.version),
+            expected_crc_v
+        );
+        assert_eq!(updated.lazy_crc.is_loaded(), expect_loaded);
 
-        // The LazyCrc should be reused (already loaded) rather than a fresh unloaded one.
-        assert_eq!(updated.lazy_crc.crc_version(), Some(2));
-        assert!(
-            updated.lazy_crc.is_loaded(),
-            "LazyCrc should be reused from old snapshot, not freshly created"
+        Ok(())
+    }
+
+    // Stronger regression for the `resolve_crc` invariant filter: set up a metadata change
+    // at the checkpoint version so that a stale inherited CRC would produce wrong
+    // Metadata, not just wrong bookkeeping. Without the filter, the incremental update
+    // would return Metadata from commit 0 (via Case 2(b) fallback on a below-checkpoint
+    // CRC); the fresh rebuild would return Metadata from commit 2. `compare_snapshots`
+    // catches that on `table_configuration`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_incremental_snapshot_drops_stale_crc_preserves_correct_metadata(
+    ) -> DeltaResult<()> {
+        let ctx = setup_incremental_snapshot_test()?;
+        let table_root = ctx.url.as_str();
+
+        // commit 0: initial P&M with empty configuration.
+        commit(
+            table_root,
+            &ctx.store,
+            0,
+            vec![
+                protocol_action(1, 2),
+                metadata_action(json!({})),
+                add_action("f0.parquet"),
+            ],
+        )
+        .await;
+        // commit 1: data-only add.
+        commit(table_root, &ctx.store, 1, vec![add_action("f1.parquet")]).await;
+        // commit 2: metadata change (new configuration property). A stale CRC@v1 would miss
+        // this.
+        commit(
+            table_root,
+            &ctx.store,
+            2,
+            vec![
+                metadata_action(json!({"delta.myKey": "myValue"})),
+                add_action("f2.parquet"),
+            ],
+        )
+        .await;
+        // commit 3: data-only add.
+        commit(table_root, &ctx.store, 3, vec![add_action("f3.parquet")]).await;
+
+        // CRC@v1 captures the BEFORE metadata (no "delta.myKey" property). This is the
+        // stale CRC we expect the filter to reject.
+        ctx.store
+            .put(
+                &delta_path_for_version(1, "crc"),
+                make_test_crc_json(200, 2).to_string().into(),
+            )
+            .await?;
+
+        let snapshot_v3 = Snapshot::builder_for(table_root)
+            .at_version(3)
+            .build(ctx.engine.as_ref())?;
+        // snapshot_v3 was built via log replay, which correctly picks up the v2 metadata
+        // change (pruned replay over commits after CRC@v1 finds the new metaData action).
+        assert_eq!(
+            snapshot_v3
+                .table_properties()
+                .unknown_properties
+                .get("delta.myKey"),
+            Some(&"myValue".to_string())
+        );
+
+        // Write checkpoint@v2, incorporating the new metadata.
+        Snapshot::builder_for(table_root)
+            .at_version(2)
+            .build(ctx.engine.as_ref())?
+            .checkpoint(ctx.engine.as_ref())?;
+
+        // Incremental update. With the filter: CRC@v1 dropped, log replay via checkpoint@v2
+        // returns the correct new metadata. Without the filter: Case 2(b) fallback returns
+        // CRC@v1's stale (empty) configuration, and compare_snapshots fails on
+        // table_configuration.
+        let updated = Snapshot::builder_from(snapshot_v3).build(ctx.engine.as_ref())?;
+        let fresh = Snapshot::builder_for(table_root).build(ctx.engine.as_ref())?;
+        compare_snapshots(&updated, &fresh);
+
+        // Observable contract: the user-visible metadata reflects the v2 change, not the
+        // v0 baseline captured by the stale CRC.
+        assert_eq!(
+            updated
+                .table_properties()
+                .unknown_properties
+                .get("delta.myKey"),
+            Some(&"myValue".to_string())
         );
 
         Ok(())
     }
 
-    // When the checkpoint early-return discovers a newer CRC alongside the new checkpoint,
-    // resolve_crc should create a fresh (unloaded) LazyCrc rather than reusing the old one.
+    // Multi-hop: v0 -> v5 (case F, P+M replay) -> v10 (case D, checkpoint rebuild).
+    // Verifies the case-F -> case-D sequence, including that a loaded existing LazyCrc is
+    // not reused when the filter drops it on the case-D hop (the resulting LazyCrc must be
+    // unloaded, not the loaded Arc from snapshot_v5).
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_incremental_snapshot_checkpoint_early_return_creates_fresh_lazy_crc_when_crc_version_changes(
-    ) -> DeltaResult<()> {
+    async fn test_incremental_snapshot_multi_hop_case_f_then_case_d() -> DeltaResult<()> {
         let ctx = setup_incremental_snapshot_test()?;
+        setup_test_table_with_commits(ctx.url.as_str(), &ctx.store, 11).await?;
 
-        // Create commits 0-3
-        setup_test_table_with_commits(ctx.url.as_str(), &ctx.store, 4).await?;
-
-        // Write a CRC at v2 -- this is what snapshot_v3 will reference.
-        let crc_v2_path = delta_path_for_version(2, "crc");
+        // CRC at v5 with matching P&M; it is well above any checkpoint (none exists yet),
+        // so every hop inherits it.
         ctx.store
-            .put(&crc_v2_path, make_test_crc_json(300, 3).to_string().into())
+            .put(
+                &delta_path_for_version(5, "crc"),
+                make_test_crc_json(600, 6).to_string().into(),
+            )
             .await?;
 
-        // Build snapshot at v3 -- references CRC at v2.
-        let snapshot_v3 = Snapshot::builder_for(ctx.url.as_str())
-            .at_version(3)
+        // Hop 1: snapshot at v0.
+        let snapshot_v0 = Snapshot::builder_for(ctx.url.as_str())
+            .at_version(0)
             .build(ctx.engine.as_ref())?;
-        assert_eq!(snapshot_v3.lazy_crc.crc_version(), Some(2));
+        assert_eq!(snapshot_v0.lazy_crc.crc_version(), None);
 
-        // Force-load the v2 CRC into the OnceLock.
-        let _ = snapshot_v3.lazy_crc.get_or_load(ctx.engine.as_ref());
-        assert!(snapshot_v3.lazy_crc.is_loaded());
+        // Hop 2: incremental v0 -> v5 (case F: new commits, no checkpoint). This picks up
+        // CRC@v5 from the listing.
+        let snapshot_v5 = Snapshot::builder_from(snapshot_v0).build(ctx.engine.as_ref())?;
+        assert_eq!(snapshot_v5.log_segment.checkpoint_version, None);
+        assert_eq!(snapshot_v5.lazy_crc.crc_version(), Some(5));
 
-        // Write a checkpoint at v1 AND a newer CRC at v3, so the incremental update
-        // sees a different CRC version than the old snapshot's (v2 -> v3).
+        // Force-load the v5 CRC so we can observe that a dropped CRC yields a fresh
+        // unloaded LazyCrc on the next hop (not the loaded v5 Arc carried forward).
+        let _ = snapshot_v5.lazy_crc.get_or_load(ctx.engine.as_ref());
+        assert!(snapshot_v5.lazy_crc.is_loaded());
+
+        // Write checkpoint at v7.
         Snapshot::builder_for(ctx.url.as_str())
-            .at_version(1)
+            .at_version(7)
             .build(ctx.engine.as_ref())?
             .checkpoint(ctx.engine.as_ref())?;
 
-        let crc_v3_path = delta_path_for_version(3, "crc");
-        ctx.store
-            .put(&crc_v3_path, make_test_crc_json(400, 4).to_string().into())
-            .await?;
-
-        // Incremental update: discovers both the new checkpoint and the newer CRC at v3.
-        let updated = Snapshot::builder_from(snapshot_v3).build(ctx.engine.as_ref())?;
-
-        // Verify structural correctness: same result as a fresh snapshot build.
-        let fresh = Snapshot::builder_for(ctx.url.as_str()).build(ctx.engine.as_ref())?;
-        compare_snapshots(&updated, &fresh);
-        assert_eq!(updated.version(), 3);
-        assert_eq!(updated.log_segment.checkpoint_version, Some(1));
-
-        // A fresh LazyCrc at v3 should have been created rather than reusing the old v2 one.
-        assert_eq!(updated.lazy_crc.crc_version(), Some(3));
+        // Hop 3: incremental v5 -> v10 (case D: discovers checkpoint@v7). CRC@v5 is below
+        // the new checkpoint (5 < 7) so the filter drops it, and the rebuilt snapshot gets
+        // a fresh unloaded LazyCrc rather than the v5 Arc that was loaded above.
+        let snapshot_v10 = Snapshot::builder_from(snapshot_v5).build(ctx.engine.as_ref())?;
+        let fresh_v10 = Snapshot::builder_for(ctx.url.as_str()).build(ctx.engine.as_ref())?;
+        compare_snapshots(&snapshot_v10, &fresh_v10);
+        assert_eq!(snapshot_v10.version(), 10);
+        assert_eq!(snapshot_v10.log_segment.checkpoint_version, Some(7));
+        assert_eq!(snapshot_v10.lazy_crc.crc_version(), None);
+        assert!(!snapshot_v10.lazy_crc.is_loaded());
 
         Ok(())
     }

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -245,13 +245,22 @@ impl Snapshot {
         }
         if new_log_segment.checkpoint_version.is_some() {
             // We found a checkpoint in the new log segment, so build a fresh snapshot from it.
-            // TODO(#2217): reuse old LazyCrc when CRC file matches.
             // TODO(#2218): consider incremental P&M replay instead of full rebuild.
+            // Only lazy_crc is needed: the new_log_segment carries its own latest_crc_file. The
+            // lazy_crc may reference the old segment's CRC as a fallback, which is safe:
+            // read_protocol_metadata always validates CRC version against end_version before
+            // trusting its P&M, so log replay runs when the versions differ.
+            let (_, lazy_crc) = Self::resolve_crc(
+                &new_log_segment,
+                old_log_segment,
+                &existing_snapshot.lazy_crc,
+            );
             let snapshot = Self::try_new_from_log_segment(
                 existing_snapshot.table_root().clone(),
                 new_log_segment,
                 engine,
                 operation_id,
+                Some(lazy_crc),
             );
             return Ok(Arc::new(snapshot?));
         }
@@ -357,6 +366,7 @@ impl Snapshot {
         let old_crc_file = old_log_segment.listed.latest_crc_file.clone();
         let crc_file = new_crc_file.or(old_crc_file);
         let crc_version = crc_file.as_ref().map(|f| f.version);
+        // Version equality is sufficient: Delta allows at most one CRC file per version.
         let lazy_crc = if crc_version == existing_lazy_crc.crc_version() {
             existing_lazy_crc.clone()
         } else {
@@ -366,15 +376,22 @@ impl Snapshot {
     }
 
     /// Create a new [`Snapshot`] instance.
+    ///
+    /// When `inherited_lazy_crc` is `Some`, reuses it (e.g. carried forward from a previous
+    /// snapshot whose CRC version matches); otherwise creates a fresh [`LazyCrc`] from the log
+    /// segment's CRC file.
     #[instrument(err, fields(version, operation_id = %operation_id), skip(engine))]
     fn try_new_from_log_segment(
         location: Url,
         log_segment: LogSegment,
         engine: &dyn Engine,
         operation_id: MetricId,
+        inherited_lazy_crc: Option<Arc<LazyCrc>>,
     ) -> DeltaResult<Self> {
-        // Create lazy CRC loader for P&M optimization
-        let lazy_crc = Arc::new(LazyCrc::new(log_segment.listed.latest_crc_file.clone()));
+        // Reuse the inherited LazyCrc when provided (avoids redundant disk I/O if the CRC
+        // file is the same one the previous snapshot already loaded).
+        let lazy_crc = inherited_lazy_crc
+            .unwrap_or_else(|| Arc::new(LazyCrc::new(log_segment.listed.latest_crc_file.clone())));
 
         // Read protocol and metadata (may use CRC if available)
         let (metadata, protocol) =
@@ -2732,6 +2749,127 @@ mod tests {
         assert_eq!(updated.version(), 3);
         assert_eq!(updated.log_segment.checkpoint_version, Some(2));
         compare_snapshots(&updated, &fresh);
+
+        Ok(())
+    }
+
+    /// CRC JSON for the standard test table (see [`setup_test_table_with_commits`]).
+    fn make_test_crc_json(table_size_bytes: i64, num_files: i64) -> serde_json::Value {
+        json!({
+            "table_size_bytes": table_size_bytes,
+            "num_files": num_files,
+            "num_metadata": 1,
+            "num_protocol": 1,
+            "protocol": {"minReaderVersion": 1, "minWriterVersion": 2},
+            "metadata": {
+                "id": "test-id",
+                "format": {"provider": "parquet", "options": {}},
+                "schemaString": "{\"type\":\"struct\",\"fields\":[{\"name\":\"id\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}",
+                "partitionColumns": [],
+                "configuration": {},
+                "createdTime": 1587968585495i64
+            }
+        })
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_checkpoint_early_return_reuses_lazy_crc() -> DeltaResult<()> {
+        let ctx = setup_incremental_snapshot_test()?;
+
+        // Create commits 0-3
+        setup_test_table_with_commits(ctx.url.as_str(), &ctx.store, 4).await?;
+
+        // Write a well-formed CRC at v2 with P&M matching the table's schema.
+        let crc_path = delta_path_for_version(2, "crc");
+        ctx.store
+            .put(&crc_path, make_test_crc_json(300, 3).to_string().into())
+            .await?;
+
+        // Build snapshot at v3 -- its log segment will reference CRC at v2.
+        let snapshot_v3 = Snapshot::builder_for(ctx.url.as_str())
+            .at_version(3)
+            .build(ctx.engine.as_ref())?;
+        assert_eq!(snapshot_v3.lazy_crc.crc_version(), Some(2));
+
+        // Force-load the CRC so it's cached in the OnceLock.
+        let _ = snapshot_v3.lazy_crc.get_or_load(ctx.engine.as_ref());
+        assert!(snapshot_v3.lazy_crc.is_loaded());
+
+        // Write a checkpoint at v1 so that the incremental update hits the checkpoint
+        // early-return. The CRC file (v2) is unchanged.
+        Snapshot::builder_for(ctx.url.as_str())
+            .at_version(1)
+            .build(ctx.engine.as_ref())?
+            .checkpoint(ctx.engine.as_ref())?;
+
+        // Incremental update from v3: discovers the new checkpoint, takes the early-return.
+        let updated = Snapshot::builder_from(snapshot_v3.clone()).build(ctx.engine.as_ref())?;
+
+        // Verify structural correctness: same result as a fresh snapshot build.
+        let fresh = Snapshot::builder_for(ctx.url.as_str()).build(ctx.engine.as_ref())?;
+        assert_eq!(updated, fresh);
+        assert_eq!(updated.version(), 3);
+        assert_eq!(updated.log_segment.checkpoint_version, Some(1));
+
+        // The LazyCrc should be reused (already loaded) rather than a fresh unloaded one.
+        assert_eq!(updated.lazy_crc.crc_version(), Some(2));
+        assert!(
+            updated.lazy_crc.is_loaded(),
+            "LazyCrc should be reused from old snapshot, not freshly created"
+        );
+
+        Ok(())
+    }
+
+    // When the checkpoint early-return discovers a newer CRC alongside the new checkpoint,
+    // resolve_crc should create a fresh (unloaded) LazyCrc rather than reusing the old one.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_checkpoint_early_return_creates_fresh_lazy_crc_when_version_changes(
+    ) -> DeltaResult<()> {
+        let ctx = setup_incremental_snapshot_test()?;
+
+        // Create commits 0-3
+        setup_test_table_with_commits(ctx.url.as_str(), &ctx.store, 4).await?;
+
+        // Write a CRC at v2 -- this is what snapshot_v3 will reference.
+        let crc_v2_path = delta_path_for_version(2, "crc");
+        ctx.store
+            .put(&crc_v2_path, make_test_crc_json(300, 3).to_string().into())
+            .await?;
+
+        // Build snapshot at v3 -- references CRC at v2.
+        let snapshot_v3 = Snapshot::builder_for(ctx.url.as_str())
+            .at_version(3)
+            .build(ctx.engine.as_ref())?;
+        assert_eq!(snapshot_v3.lazy_crc.crc_version(), Some(2));
+
+        // Force-load the v2 CRC into the OnceLock.
+        let _ = snapshot_v3.lazy_crc.get_or_load(ctx.engine.as_ref());
+        assert!(snapshot_v3.lazy_crc.is_loaded());
+
+        // Write a checkpoint at v1 AND a newer CRC at v3, so the incremental update
+        // sees a different CRC version than the old snapshot's (v2 -> v3).
+        Snapshot::builder_for(ctx.url.as_str())
+            .at_version(1)
+            .build(ctx.engine.as_ref())?
+            .checkpoint(ctx.engine.as_ref())?;
+
+        let crc_v3_path = delta_path_for_version(3, "crc");
+        ctx.store
+            .put(&crc_v3_path, make_test_crc_json(400, 4).to_string().into())
+            .await?;
+
+        // Incremental update: discovers both the new checkpoint and the newer CRC at v3.
+        let updated = Snapshot::builder_from(snapshot_v3).build(ctx.engine.as_ref())?;
+
+        // Verify structural correctness: same result as a fresh snapshot build.
+        let fresh = Snapshot::builder_for(ctx.url.as_str()).build(ctx.engine.as_ref())?;
+        assert_eq!(updated, fresh);
+        assert_eq!(updated.version(), 3);
+        assert_eq!(updated.log_segment.checkpoint_version, Some(1));
+
+        // A fresh LazyCrc at v3 should have been created rather than reusing the old v2 one.
+        assert_eq!(updated.lazy_crc.crc_version(), Some(3));
 
         Ok(())
     }

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -171,30 +171,30 @@ impl Snapshot {
         target_version: impl Into<Option<Version>>,
         operation_id: MetricId,
     ) -> DeltaResult<Arc<Self>> {
-        let old_log_segment = &existing_snapshot.log_segment;
-        let old_version = existing_snapshot.version();
+        let existing_log_segment = &existing_snapshot.log_segment;
+        let existing_snapshot_version = existing_snapshot.version();
         let requested_version = target_version.into();
         if let Some(requested_version) = requested_version {
             tracing::Span::current().record("version", requested_version);
-            if requested_version == old_version {
+            if requested_version == existing_snapshot_version {
                 // Re-requesting the same version
                 return Ok(existing_snapshot.clone());
             }
-            if requested_version < old_version {
+            if requested_version < existing_snapshot_version {
                 // Hint is too new: error since this is effectively an incorrect optimization
                 return Err(Error::Generic(format!(
-                    "Requested snapshot version {requested_version} is older than snapshot hint version {old_version}"
+                    "Requested snapshot version {requested_version} is older than snapshot hint version {existing_snapshot_version}"
                 )));
             }
         } else {
-            tracing::Span::current().record("version", old_version);
+            tracing::Span::current().record("version", existing_snapshot_version);
         }
 
-        let log_root = old_log_segment.log_root.clone();
+        let log_root = existing_log_segment.log_root.clone();
         let storage = engine.storage_handler();
 
         // Start listing just after the previous segment's checkpoint, if any.
-        let listing_start = old_log_segment.checkpoint_version.unwrap_or(0) + 1;
+        let listing_start = existing_log_segment.checkpoint_version.unwrap_or(0) + 1;
 
         // Check for new commits (and CRC)
         let new_listed_files = LogSegmentFiles::list(
@@ -212,14 +212,18 @@ impl Snapshot {
             && new_listed_files.checkpoint_parts().is_empty()
         {
             match requested_version {
-                Some(requested_version) if requested_version != old_version => {
-                    // No new commits, but we are looking for a new version
+                // requested == existing_snapshot_version was handled earlier, and
+                // requested < existing_snapshot_version returned an error earlier, so any Some
+                // here is requested > existing_snapshot_version but no such commit exists.
+                Some(requested_version) => {
                     return Err(Error::Generic(format!(
-                        "Requested snapshot version {requested_version} is newer than the latest version {old_version}"
+                        "Requested snapshot version {requested_version} is not available: \
+                         no new commits were found after existing snapshot version \
+                         {existing_snapshot_version}"
                     )));
                 }
-                _ => {
-                    // No new commits, just return the same snapshot
+                None => {
+                    // No new commits and no explicit target, just return the same snapshot
                     return Ok(existing_snapshot.clone());
                 }
             }
@@ -237,22 +241,23 @@ impl Snapshot {
             LogSegment::try_new(new_listed_files, log_root.clone(), requested_version, None)?;
 
         let new_end_version = new_log_segment.end_version;
-        if new_end_version < old_version {
+        if new_end_version < existing_snapshot_version {
             // we should never see a new log segment with a version < the existing snapshot
             // version, that would mean a commit was incorrectly deleted from the log
             return Err(Error::Generic(format!(
-                "Unexpected state: The newest version in the log {new_end_version} is older than the old version {old_version}")));
+                "Unexpected state: the newest version in the log {new_end_version} is older than the existing snapshot version {existing_snapshot_version}")));
         }
         if new_log_segment.checkpoint_version.is_some() {
             // We found a checkpoint in the new log segment, so build a fresh snapshot from it.
             // TODO(#2218): consider incremental P&M replay instead of full rebuild.
-            // Pass the resolved lazy_crc so the full rebuild can reuse a loaded CRC if the
-            // version matches. If the new segment has no CRC file, resolve_crc falls back to
-            // the old segment's CRC, which is safe: read_protocol_metadata validates the CRC
-            // version against end_version and falls back to log replay when they differ.
+            // Pass the resolved lazy_crc so the full rebuild can reuse an already-loaded CRC
+            // when the resolved CRC version matches the existing snapshot's CRC version. If the
+            // new segment has no CRC file, resolve_crc falls back to the existing snapshot's
+            // CRC, which is safe: read_protocol_metadata validates the CRC version against
+            // end_version and falls back to log replay when they differ.
             let (crc_file, lazy_crc) = Self::resolve_crc(
                 &new_log_segment,
-                old_log_segment,
+                existing_log_segment,
                 &existing_snapshot.lazy_crc,
             );
             // Inject the resolved CRC file path so the rebuilt snapshot remembers it.
@@ -270,7 +275,7 @@ impl Snapshot {
             return Ok(Arc::new(snapshot?));
         }
 
-        if new_end_version == old_version {
+        if new_end_version == existing_snapshot_version {
             // No new commits and no newly discovered checkpoint, just return the same snapshot.
             return Ok(existing_snapshot.clone());
         }
@@ -290,22 +295,23 @@ impl Snapshot {
         new_log_segment
             .listed
             .ascending_commit_files
-            .retain(|log_path| old_version < log_path.version);
+            .retain(|log_path| existing_snapshot_version < log_path.version);
         // Deduplicate compaction files the same way: the new listing re-lists from
-        // checkpoint_version, so it includes compaction files already in the old segment.
-        // Note: This removes all _new_ compaction files that start at or before `old_version`,
-        // which may drop useful compaction files that span across the old/new boundary
-        // (e.g. a new compaction(1, 3) when old_version=2). This is conservative but safe.
+        // checkpoint_version, so it includes compaction files already in the existing segment.
+        // Note: This removes all _new_ compaction files that start at or before
+        // `existing_snapshot_version`, which may drop useful compaction files that span
+        // across the old/new boundary (e.g. a new compaction(1, 3) when
+        // existing_snapshot_version=2). This is conservative but safe.
         new_log_segment
             .listed
             .ascending_compaction_files
-            .retain(|log_path| old_version < log_path.version);
+            .retain(|log_path| existing_snapshot_version < log_path.version);
 
         // we have new commits and no new checkpoint: we replay new commits for P+M and then
         // create a new snapshot by combining LogSegments and building a new TableConfiguration
         let (crc_file, lazy_crc) = Self::resolve_crc(
             &new_log_segment,
-            old_log_segment,
+            existing_log_segment,
             &existing_snapshot.lazy_crc,
         );
 
@@ -319,34 +325,36 @@ impl Snapshot {
         )?;
 
         // NB: we must add the new log segment to the existing snapshot's log segment
-        let mut ascending_commit_files = old_log_segment.listed.ascending_commit_files.clone();
+        let mut ascending_commit_files = existing_log_segment.listed.ascending_commit_files.clone();
         ascending_commit_files.extend(new_log_segment.listed.ascending_commit_files);
-        let mut ascending_compaction_files =
-            old_log_segment.listed.ascending_compaction_files.clone();
+        let mut ascending_compaction_files = existing_log_segment
+            .listed
+            .ascending_compaction_files
+            .clone();
         ascending_compaction_files.extend(new_log_segment.listed.ascending_compaction_files);
 
-        // Use the new latest_commit if available, otherwise use the old one
+        // Use the new latest_commit if available, otherwise use the existing one.
         // This handles the case where the new listing returned no commits
-        let latest_commit_file =
-            new_latest_commit_file.or_else(|| old_log_segment.listed.latest_commit_file.clone());
-        // we can pass in just the old checkpoint parts since by the time we reach this line, we
-        // know there are no checkpoints in the new log segment.
+        let latest_commit_file = new_latest_commit_file
+            .or_else(|| existing_log_segment.listed.latest_commit_file.clone());
+        // we can pass in just the existing checkpoint parts since by the time we reach this
+        // line, we know there are no checkpoints in the new log segment.
         let combined_log_segment = LogSegment::try_new(
             LogSegmentFiles {
                 ascending_commit_files,
                 ascending_compaction_files,
-                checkpoint_parts: old_log_segment.listed.checkpoint_parts.clone(),
+                checkpoint_parts: existing_log_segment.listed.checkpoint_parts.clone(),
                 latest_crc_file: crc_file,
                 latest_commit_file,
                 max_published_version: new_log_segment
                     .listed
                     .max_published_version
-                    .max(old_log_segment.listed.max_published_version),
+                    .max(existing_log_segment.listed.max_published_version),
             },
             log_root,
             requested_version,
-            // Preserve `_last_checkpoint` hint from old segment
-            old_log_segment.last_checkpoint_hint_summary(),
+            // Preserve `_last_checkpoint` hint from existing segment
+            existing_log_segment.last_checkpoint_hint_summary(),
         )?;
 
         tracing::Span::current().record("version", table_configuration.version());
@@ -359,17 +367,17 @@ impl Snapshot {
 
     /// Determine the CRC file and LazyCrc for an incremental snapshot update.
     ///
-    /// Prefers the new segment's CRC file, falls back to the old segment's. If the resolved
-    /// CRC version matches the existing snapshot's LazyCrc, reuses it to avoid redundant I/O
-    /// (it may already be loaded in memory).
+    /// Prefers the new segment's CRC file, falls back to the existing segment's. If the
+    /// resolved CRC version matches the existing snapshot's LazyCrc version, reuses it to
+    /// avoid redundant I/O (it may already be loaded in memory).
     fn resolve_crc(
         new_log_segment: &LogSegment,
-        old_log_segment: &LogSegment,
+        existing_log_segment: &LogSegment,
         existing_lazy_crc: &Arc<LazyCrc>,
     ) -> (Option<ParsedLogPath>, Arc<LazyCrc>) {
         let new_crc_file = new_log_segment.listed.latest_crc_file.clone();
-        let old_crc_file = old_log_segment.listed.latest_crc_file.clone();
-        let crc_file = new_crc_file.or(old_crc_file);
+        let existing_crc_file = existing_log_segment.listed.latest_crc_file.clone();
+        let crc_file = new_crc_file.or(existing_crc_file);
         let crc_version = crc_file.as_ref().map(|f| f.version);
         let lazy_crc = if crc_version == existing_lazy_crc.crc_version() {
             existing_lazy_crc.clone()
@@ -382,8 +390,8 @@ impl Snapshot {
     /// Create a new [`Snapshot`] instance.
     ///
     /// When `inherited_lazy_crc` is `Some`, reuses it (e.g. carried forward from a previous
-    /// snapshot whose CRC version matches); otherwise creates a fresh [`LazyCrc`] from the log
-    /// segment's CRC file.
+    /// snapshot whose CRC version matches `log_segment.listed.latest_crc_file`'s version);
+    /// otherwise creates a fresh [`LazyCrc`] from the log segment's CRC file.
     #[instrument(err, fields(version, operation_id = %operation_id), skip(engine))]
     fn try_new_from_log_segment(
         location: Url,
@@ -1496,7 +1504,7 @@ mod tests {
         // version exceeds latest version of the table = err
         assert!(matches!(
             Snapshot::builder_from(base_snapshot.clone()).at_version(1).build(&engine),
-            Err(Error::Generic(msg)) if msg == "Requested snapshot version 1 is newer than the latest version 0"
+            Err(Error::Generic(msg)) if msg == "Requested snapshot version 1 is not available: no new commits were found after existing snapshot version 0"
         ));
 
         // b. log segment for old..=new version has a checkpoint (with new protocol/metadata)
@@ -2777,7 +2785,8 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_checkpoint_early_return_reuses_lazy_crc() -> DeltaResult<()> {
+    async fn test_incremental_snapshot_checkpoint_early_return_reuses_lazy_crc() -> DeltaResult<()>
+    {
         let ctx = setup_incremental_snapshot_test()?;
 
         // Create commits 0-3
@@ -2828,7 +2837,7 @@ mod tests {
     // When the checkpoint early-return discovers a newer CRC alongside the new checkpoint,
     // resolve_crc should create a fresh (unloaded) LazyCrc rather than reusing the old one.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_checkpoint_early_return_creates_fresh_lazy_crc_when_version_changes(
+    async fn test_incremental_snapshot_checkpoint_early_return_creates_fresh_lazy_crc_when_crc_version_changes(
     ) -> DeltaResult<()> {
         let ctx = setup_incremental_snapshot_test()?;
 
@@ -3034,7 +3043,7 @@ mod tests {
     /// This test documents a limitation: When deduplicating compactions, the deduplication logic
     /// only checks the start version (lo), not the hi version. So a new compaction file (1,3)
     /// added after building the base snapshot at v2 gets filtered out because its start version
-    /// (1) <= old_version (2).
+    /// (1) <= existing_snapshot_version (2).
     #[tokio::test]
     #[ignore = "log compaction disabled (#2337)"]
     async fn test_incremental_snapshot_with_new_compaction_files() -> DeltaResult<()> {
@@ -3064,7 +3073,7 @@ mod tests {
         write_compaction_file(&store, 1, 3).await?;
 
         // Build v3 incrementally - the new (1,3) file gets filtered out because
-        // the deduplication only looks at start version: 1 <= old_version (2)
+        // the deduplication only looks at start version: 1 <= existing_snapshot_version (2)
         let snapshot_v3 = Snapshot::builder_from(snapshot_v2)
             .at_version(3)
             .build(&engine)?;

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -342,12 +342,12 @@ impl Snapshot {
             .clone();
         ascending_compaction_files.extend(new_log_segment.listed.ascending_compaction_files);
 
-        // We can pass in just the existing checkpoint parts since by the time we reach this
-        // line, we know there are no checkpoints in the new log segment.
         let combined_log_segment = LogSegment::try_new(
             LogSegmentFiles {
                 ascending_commit_files,
                 ascending_compaction_files,
+                // We pass in just the existing checkpoint parts since by the time we reach
+                // this line, we know there are no checkpoints in the new log segment.
                 checkpoint_parts: existing_log_segment.listed.checkpoint_parts.clone(),
                 latest_crc_file: crc_file,
                 // In Case F there are new commits (new_end_version > existing_snapshot_version

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -122,7 +122,7 @@ impl Snapshot {
     ///   - **F.** Listing contains new commits (and no new checkpoint): run lightweight P+M replay
     ///     on the new commits and merge them into the existing log segment.
     ///
-    /// Each case is marked with `// case X` in `Snapshot::try_new_from_impl`.
+    /// Each case is marked with `// case X` in `Snapshot::try_new_from`.
     ///
     /// The target version (default: latest) is set via [`SnapshotBuilder::at_version`], and the
     /// engine is passed to [`SnapshotBuilder::build`].
@@ -185,7 +185,8 @@ impl Snapshot {
             // case B: incremental path only moves forward.
             if requested_version < existing_snapshot_version {
                 return Err(Error::Generic(format!(
-                    "Requested snapshot version {requested_version} is older than snapshot hint version {existing_snapshot_version}"
+                    "Requested snapshot version {requested_version} is older than snapshot \
+                    hint version {existing_snapshot_version}"
                 )));
             }
         } else {
@@ -247,25 +248,20 @@ impl Snapshot {
             // we should never see a new log segment with a version < the existing snapshot
             // version, that would mean a commit was incorrectly deleted from the log
             return Err(Error::Generic(format!(
-                "Unexpected state: the newest version in the log {new_end_version} is older than the existing snapshot version {existing_snapshot_version}")));
+                "Unexpected state: the newest version in the log {new_end_version} is \
+                 older than the existing snapshot version {existing_snapshot_version}"
+            )));
         }
         if new_log_segment.checkpoint_version.is_some() {
             // case D: listing contains a checkpoint; build a fresh snapshot from it.
             // TODO(#2218): consider incremental P&M replay instead of full rebuild.
-            // `resolve_crc` picks the CRC for the rebuilt segment (see its doc for the
-            // invariant-preserving fallback rules) and reuses the existing `LazyCrc` when
-            // the resolved CRC version matches.
-            let (crc_file, lazy_crc) = Self::resolve_crc(
+            // `resolve_crc` reuses the existing `LazyCrc` when the resolved CRC version
+            // matches, avoiding redundant I/O.
+            let (_, lazy_crc) = Self::resolve_crc(
                 &new_log_segment,
                 existing_log_segment,
                 &existing_snapshot.lazy_crc,
             );
-            // Inject the resolved CRC file path so the rebuilt snapshot remembers it.
-            // Without this, if the existing CRC was below the new listing start (and thus
-            // not surfaced by the listing), the rebuilt snapshot would have
-            // `latest_crc_file = None` and future incremental updates would fall through to
-            // full log replay instead of taking the CRC fast path.
-            new_log_segment.listed.latest_crc_file = crc_file;
             let snapshot = Self::try_new_from_log_segment(
                 existing_snapshot.table_root().clone(),
                 new_log_segment,
@@ -2825,22 +2821,32 @@ mod tests {
     // snapshot_v3, writes a checkpoint, optionally writes a new CRC, then runs the
     // incremental update and checks the outcome.
     //
-    // reuse_existing:   existing crc@v2 stays when new ckpt@v1 is below it (invariant OK)
-    //                   and no newer CRC was listed; the LazyCrc Arc is reused (loaded).
-    // refresh_to_newer: existing crc@v2 is superseded by a newly-listed crc@v3; the new
-    //                   CRC version wins and produces a fresh unloaded LazyCrc.
-    // crc_equals_ckpt:  existing crc@v2 and new ckpt@v2 sit at the same version -- sanity
-    //                   coverage for the invariant boundary `crc.version >= checkpoint.version`.
-    //                   (Note: this case does not pin `>=` vs `>` in `resolve_crc`'s filter
-    //                   because the listing also re-surfaces the existing CRC, so
-    //                   `new_crc_file = Some(v2)` wins via `.or(existing)` regardless of the
-    //                   filter's verdict on the existing CRC fallback. A scenario where only
-    //                   the fallback exercises the boundary is structurally unreachable: it
-    //                   would require the existing CRC to be below listing_start, but the
-    //                   LogSegmentFiles invariant forces existing_crc_version >=
-    //                   existing_checkpoint_version = listing_start - 1.)
-    // drop_below_ckpt:  existing crc@v1 would violate the LogSegmentFiles invariant with
-    //                   new ckpt@v2 (1 < 2), so it is filtered out; result has no CRC.
+    // Version axis for `refresh_to_newer` (existing_crc_v=2, new_ckpt_v=1, new_crc_v=3):
+    //
+    //   v0 --------- v1 --------- v2 --------- v3
+    //                new_ckpt      existing     newly-listed
+    //                              crc (loaded) crc
+    //                              ^^^^^^^^     ^^^^^^^^^^^^
+    //                         snapshot_v3's    wins on version mismatch
+    //                         lazy_crc         -> fresh unloaded LazyCrc
+    //
+    // Cases:
+    //   reuse_existing:   existing crc@v2 stays when new ckpt@v1 is below it (invariant OK)
+    //                     and no newer CRC was listed; LazyCrc Arc is reused (loaded).
+    //   refresh_to_newer: existing crc@v2 is superseded by a newly-listed crc@v3; new CRC
+    //                     version wins and produces a fresh unloaded LazyCrc.
+    //   crc_equals_ckpt:  existing crc@v2 and new ckpt@v2 sit at the same version; sanity
+    //                     coverage for the invariant boundary `crc.version >= ckpt.version`.
+    //                     (Note: does not pin `>=` vs `>` in `resolve_crc`'s filter because
+    //                     the listing re-surfaces the existing CRC, so `new_crc_file =
+    //                     Some(v2)` wins via `.or(existing)` regardless of the filter. A
+    //                     scenario where only the fallback exercises the boundary is
+    //                     structurally unreachable: it would require the existing CRC to be
+    //                     below listing_start, but the LogSegmentFiles invariant forces
+    //                     existing_crc_version >= existing_checkpoint_version = listing_start
+    //                     - 1.)
+    //   drop_below_ckpt:  existing crc@v1 would violate the LogSegmentFiles invariant with
+    //                     new ckpt@v2 (1 < 2), so it is filtered out; result has no CRC.
     #[rstest]
     #[case::reuse_existing(2, 1, None, Some(2), true)]
     #[case::refresh_to_newer(2, 1, Some(3), Some(3), true)]
@@ -2868,8 +2874,12 @@ mod tests {
             .at_version(3)
             .build(ctx.engine.as_ref())?;
         assert_eq!(snapshot_v3.lazy_crc.crc_version(), Some(existing_crc_v));
+        // Building the snapshot loaded the CRC while resolving P&M: commits after
+        // existing_crc_v contain no P&M changes, so read_protocol_metadata_opt's Case 2(b)
+        // fallback loads the CRC.
+        assert!(snapshot_v3.lazy_crc.is_loaded());
 
-        // Write the new checkpoint, plus optionally a newer CRC alongside it.
+        // Write the new checkpoint, then optionally plant a newer CRC at `newly_listed_crc_v`.
         Snapshot::builder_for(ctx.url.as_str())
             .at_version(new_ckpt_v)
             .build(ctx.engine.as_ref())?
@@ -2997,12 +3007,13 @@ mod tests {
         Ok(())
     }
 
-    // Multi-hop: v0 -> v5 (case F, P+M replay) -> v10 (case D, checkpoint rebuild).
-    // Verifies the case-F -> case-D sequence, including that a loaded existing LazyCrc is
-    // not reused when the filter drops it on the case-D hop (the resulting LazyCrc must be
+    // Multi-hop: v0 -> v5 (incremental P+M replay) -> v10 (checkpoint rebuild).
+    // Verifies that a loaded LazyCrc carried into the second hop is *not* reused when
+    // the new checkpoint invalidates the existing CRC (resulting LazyCrc is fresh and
     // unloaded, not the loaded Arc from snapshot_v5).
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_incremental_snapshot_multi_hop_case_f_then_case_d() -> DeltaResult<()> {
+    async fn test_incremental_snapshot_multi_hop_replay_then_rebuild_drops_stale_crc(
+    ) -> DeltaResult<()> {
         let ctx = setup_incremental_snapshot_test()?;
         setup_test_table_with_commits(ctx.url.as_str(), &ctx.store, 11).await?;
 
@@ -3021,7 +3032,7 @@ mod tests {
             .build(ctx.engine.as_ref())?;
         assert_eq!(snapshot_v0.lazy_crc.crc_version(), None);
 
-        // Hop 2: incremental v0 -> v5 (case F: new commits, no checkpoint). This picks up
+        // Hop 2: incremental v0 -> v5 (new commits, no checkpoint -> P+M replay). This picks up
         // CRC@v5 from the listing.
         let snapshot_v5 = Snapshot::builder_from(snapshot_v0).build(ctx.engine.as_ref())?;
         assert_eq!(snapshot_v5.log_segment.checkpoint_version, None);
@@ -3038,9 +3049,10 @@ mod tests {
             .build(ctx.engine.as_ref())?
             .checkpoint(ctx.engine.as_ref())?;
 
-        // Hop 3: incremental v5 -> v10 (case D: discovers checkpoint@v7). CRC@v5 is below
-        // the new checkpoint (5 < 7) so the filter drops it, and the rebuilt snapshot gets
-        // a fresh unloaded LazyCrc rather than the v5 Arc that was loaded above.
+        // Hop 3: incremental v5 -> v10 (discovers a new checkpoint@v7, triggering rebuild).
+        // CRC@v5 is below the new checkpoint (5 < 7) so the filter drops it, and the rebuilt
+        // snapshot gets a fresh unloaded LazyCrc rather than the v5 Arc that was loaded
+        // above.
         let snapshot_v10 = Snapshot::builder_from(snapshot_v5).build(ctx.engine.as_ref())?;
         let fresh_v10 = Snapshot::builder_for(ctx.url.as_str()).build(ctx.engine.as_ref())?;
         compare_snapshots(&snapshot_v10, &fresh_v10);


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2329/files) to review incremental changes.
- [**stack/incremental-snapshot-checkpoint-fix**](https://github.com/delta-io/delta-kernel-rs/pull/2329) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2329/files)]
  - [stack/incremental-snapshot-checkpoint-pt2](https://github.com/delta-io/delta-kernel-rs/pull/2351) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2351/files/d77008122969e2c29ce542d8deac0a18059a23c2..9def3e363e6b3e8faa33e517b1457c74c2b22eaa)]

---------
## What changes are proposed in this pull request?

When `try_new_from_impl` discovers a new checkpoint and takes the early return path, it previously discarded the existing snapshot's LazyCrc and created a fresh one. If the CRC file version matches, the old LazyCrc may already be loaded in memory. Throwing it away forces a redundant disk read on the next P&M access.                                                                                                                                                                                                       
                                                                                                                                                                                                                                                    
Fix by passing the resolved LazyCrc through `try_new_from_log_segment_impl` via a new `inherited_lazy_crc: Option<Arc<LazyCrc>>` parameter. The existing `resolve_crc` helper already handles the version-match check and is reused at the checkpoint call site.
                                                                                                                                                                                
## How was this change tested?

Testing:                                                                                                                                                                                                                                          
1. `test_checkpoint_early_return_reuses_lazy_crc`: verifies that when the CRC version is unchanged after a checkpoint is written, the rebuilt snapshot's LazyCrc is already loaded (cache hit, no extra I/O)                                                                                                                                                                                  
2. `test_checkpoint_early_return_creates_fresh_lazy_crc_when_version_changes`: verifies that a newer CRC alongside the new checkpoint produces a fresh LazyCrc at the new version rather than reusing the old one
