### PR TITLE
fix!: LogSegment's checkpoint_schema from hint should only be used when valid

### DIFF
--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -425,10 +425,10 @@ impl CheckpointWriter {
         // Skip writing `_last_checkpoint` if the existing hint already points to a newer
         // checkpoint, to avoid regressing the hint.
         let checkpoint_version = self.snapshot.version();
-        if let Some(lcp) = &self.snapshot.log_segment().last_checkpoint_metadata {
-            if lcp.version > checkpoint_version {
+        if let Some(hint_version) = self.snapshot.log_segment().last_checkpoint_version() {
+            if hint_version > checkpoint_version {
                 info!(
-                    hint_version = lcp.version,
+                    hint_version,
                     checkpoint_version,
                     "Skipping _last_checkpoint write: existing hint is newer than checkpoint"
                 );

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -110,10 +110,16 @@ pub(crate) struct LogSegment {
     pub end_version: Version,
     pub checkpoint_version: Option<Version>,
     pub log_root: Url,
-    /// Metadata from the `_last_checkpoint` hint file.
-    pub last_checkpoint_metadata: Option<LastCheckpointHintSummary>,
     /// The set of log files found during listing.
     pub listed: LogSegmentFiles,
+
+    /// Metadata from the `_last_checkpoint` hint file.
+    ///
+    /// Note: This is only populated if the hint file was read during creation of this
+    /// log segment. It may also point to a checkpoint version that is newer than the
+    /// end_version. Hence, callers should use explicit getters (such as `checkpoint_schema()`)
+    /// to avoid incorrect behavior.
+    last_checkpoint_metadata: Option<LastCheckpointHintSummary>,
 }
 
 /// Returns the identifying leaf column path for a known action type, used to build IS NOT NULL
@@ -209,6 +215,32 @@ impl LogSegment {
         Ok(log_segment)
     }
 
+    /// Returns the checkpoint version from the `_last_checkpoint` hint
+    pub(crate) fn last_checkpoint_version(&self) -> Option<Version> {
+        self.last_checkpoint_metadata.as_ref().map(|m| m.version)
+    }
+
+    /// Returns the checkpoint schema from the `_last_checkpoint` hint when it is safe to use for
+    /// this segment's checkpoint.
+    ///
+    /// Returns `None` if there is no hint, if the hint omitted `checkpointSchema`, or if the
+    /// hint's checkpoint version is greater than [`Self::end_version`].
+    pub(crate) fn checkpoint_schema(&self) -> Option<SchemaRef> {
+        let m = self.last_checkpoint_metadata.as_ref()?;
+        if m.version > self.end_version {
+            return None;
+        }
+        m.schema.clone()
+    }
+
+    /// Returns a copy of the stored `_last_checkpoint` hint summary.
+    ///
+    /// Prefer [`Self::checkpoint_schema`] or [`Self::last_checkpoint_version`] when requiring
+    /// individual values from the hint.
+    pub(crate) fn last_checkpoint_hint_summary(&self) -> Option<LastCheckpointHintSummary> {
+        self.last_checkpoint_metadata.clone()
+    }
+
     /// Succinct summary string for logging purposes.
     fn summary(&self) -> String {
         format!(
@@ -292,10 +324,7 @@ impl LogSegment {
         checkpoint_hint: Option<LastCheckpointHint>,
         time_travel_version: Option<Version>,
     ) -> DeltaResult<Self> {
-        // TODO(#2361): This is a bug -> checkpoint schema is being loaded from last_checkpoint
-        // hint file and stored in log_segment even if the checkpoint version from the hint file
-        // is newer than time_travel_version.
-        let last_checkpoint_metadata =
+        let last_checkpoint_summary =
             checkpoint_hint
                 .as_ref()
                 .map(|hint| LastCheckpointHintSummary {
@@ -341,7 +370,7 @@ impl LogSegment {
             listed_files,
             log_root,
             time_travel_version,
-            last_checkpoint_metadata,
+            last_checkpoint_summary,
         )
     }
 
@@ -717,10 +746,7 @@ impl LogSegment {
         engine: &dyn Engine,
     ) -> DeltaResult<(Option<SchemaRef>, Vec<FileMeta>)> {
         // Hint schema from `_last_checkpoint` avoids footer reads when available.
-        let hint_schema = self
-            .last_checkpoint_metadata
-            .as_ref()
-            .and_then(|m| m.schema.as_ref());
+        let hint_schema = self.checkpoint_schema();
 
         // All parts of a multi-part checkpoint belong to the same table version and follow
         // the same V1 spec, so reading any one part's schema is sufficient.
@@ -731,7 +757,8 @@ impl LogSegment {
         match &checkpoint.file_type {
             MultiPartCheckpoint { .. } => {
                 // Multi-part checkpoints are always V1 and never have sidecars.
-                let schema = Self::read_checkpoint_schema(engine, checkpoint, hint_schema)?;
+                let schema =
+                    Self::read_checkpoint_schema(engine, checkpoint, hint_schema.as_ref())?;
                 Ok((Some(schema), vec![]))
             }
             UuidCheckpoint if checkpoint.extension.as_str() == "json" => {
@@ -743,7 +770,7 @@ impl LogSegment {
                 // Parquet checkpoint (classic-named or UUID-named): either can be V1 or V2.
                 // Check for sidecar column to distinguish.
                 let checkpoint_schema =
-                    Self::read_checkpoint_schema(engine, checkpoint, hint_schema)?;
+                    Self::read_checkpoint_schema(engine, checkpoint, hint_schema.as_ref())?;
                 if checkpoint_schema.field(SIDECAR_NAME).is_some() {
                     self.read_sidecar_schema_and_files(engine, checkpoint, Some(&checkpoint_schema))
                 } else {

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -116,9 +116,9 @@ pub(crate) struct LogSegment {
     /// Metadata from the `_last_checkpoint` hint file.
     ///
     /// Note: This is only populated if the hint file was read during creation of this
-    /// log segment. It may also point to a checkpoint version that is newer than the
-    /// end_version. Hence, callers should use explicit getters (such as `checkpoint_schema()`)
-    /// to avoid incorrect behavior.
+    /// log segment. The hint may describe a different checkpoint version than the one in this
+    /// segment. Callers should use explicit getters (such as [`Self::checkpoint_schema`]) rather
+    /// than reading this field directly.
     last_checkpoint_metadata: Option<LastCheckpointHintSummary>,
 }
 
@@ -221,13 +221,14 @@ impl LogSegment {
     }
 
     /// Returns the checkpoint schema from the `_last_checkpoint` hint when it is safe to use for
-    /// this segment's checkpoint.
+    /// this segment's checkpoint parquet.
     ///
-    /// Returns `None` if there is no hint, if the hint omitted `checkpointSchema`, or if the
-    /// hint's checkpoint version is greater than [`Self::end_version`].
+    /// Returns `None` if there is no hint, if the hint omitted `checkpointSchema`, if this segment
+    /// has no checkpoint on disk, or if the hint's checkpoint version does not match this segment's
+    /// checkpoint version.
     pub(crate) fn checkpoint_schema(&self) -> Option<SchemaRef> {
         let m = self.last_checkpoint_metadata.as_ref()?;
-        if m.version > self.end_version {
+        if Some(m.version) != self.checkpoint_version {
             return None;
         }
         m.schema.clone()

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -2744,71 +2744,21 @@ async fn test_checkpoint_schema_propagation_from_hint() {
     assert_eq!(log_segment.checkpoint_schema().unwrap(), sample_schema);
 }
 
-/// Test get_file_actions_schema_and_sidecars with V1 parquet checkpoint using hint schema
-/// This verifies the optimization path where hint schema is used directly (avoiding footer read)
+/// Checkpoint schema resolution uses the `_last_checkpoint` schema only when the hint's version
+/// matches [`LogSegment::checkpoint_version`]. Otherwise the parquet footer is read.
+#[rstest]
+#[case::hint_matches_checkpoint(1, true)]
+#[case::hint_newer_than_checkpoint(99, false)]
+#[case::hint_older_than_checkpoint(0, false)]
 #[tokio::test]
-async fn test_get_file_actions_schema_v1_parquet_with_hint() -> DeltaResult<()> {
-    use crate::schema::{StructField, StructType};
-
+async fn test_get_file_actions_schema_v1_parquet_with_hint(
+    #[case] hint_version: u64,
+    #[case] expect_hint_schema_used: bool,
+) -> DeltaResult<()> {
     let (store, log_root) = new_in_memory_store();
     let engine = DefaultEngineBuilder::new(store.clone()).build();
 
-    // Create a V1 checkpoint (without sidecar column)
-    let v1_schema = get_commit_schema().project(&[ADD_NAME, REMOVE_NAME])?;
-    add_checkpoint_to_store(
-        &store,
-        add_batch_simple(v1_schema.clone()),
-        "00000000000000000001.checkpoint.parquet",
-    )
-    .await?;
-
-    let checkpoint_file = log_root
-        .join("00000000000000000001.checkpoint.parquet")?
-        .to_string();
-
-    // Create a hint schema without sidecar field (indicates V1)
-    let hint_schema: SchemaRef = Arc::new(StructType::new_unchecked([
-        StructField::nullable("add", StructType::new_unchecked([])),
-        StructField::nullable("remove", StructType::new_unchecked([])),
-    ]));
-
-    let log_segment = LogSegment::try_new(
-        LogSegmentFiles {
-            checkpoint_parts: vec![create_log_path(&checkpoint_file)],
-            latest_commit_file: Some(create_log_path("file:///00000000000000000002.json")),
-            ..Default::default()
-        },
-        log_root,
-        None,
-        Some(LastCheckpointHintSummary {
-            version: 1,
-            schema: Some(hint_schema.clone()),
-        }),
-    )?;
-
-    // With V1 hint, should use hint schema and avoid footer read
-    let (schema, sidecars) = log_segment.get_file_actions_schema_and_sidecars(&engine)?;
-    assert!(schema.is_some(), "Should return hint schema for V1");
-    assert_eq!(
-        schema.unwrap(),
-        hint_schema,
-        "Should use hint schema directly"
-    );
-    assert!(sidecars.is_empty(), "V1 checkpoint should have no sidecars");
-
-    Ok(())
-}
-
-/// Test get_file_actions_schema_and_sidecars where the `_last_checkpoint` hint
-/// claims a newer table version than [`LogSegment::end_version`] and carries a different schema.
-/// `get_file_actions_schema_and_sidecars` must not trust that schema and should read the real
-/// schema from the checkpoint parquet footer instead.
-#[tokio::test]
-async fn test_get_file_actions_schema_v1_parquet_stale_hint_uses_footer() -> DeltaResult<()> {
-    let (store, log_root) = new_in_memory_store();
-    let engine = DefaultEngineBuilder::new(store.clone()).build();
-
-    // Create a V1 checkpoint (without sidecar column)
+    // Build a checkpoint with an initial v1 schema
     let v1_schema = get_commit_schema().project(&[ADD_NAME, REMOVE_NAME])?;
     add_checkpoint_to_store(
         &store,
@@ -2821,14 +2771,12 @@ async fn test_get_file_actions_schema_v1_parquet_stale_hint_uses_footer() -> Del
     let checkpoint_file = log_root.join(checkpoint_rel)?.to_string();
     let cp_size = get_file_size(&store, &format!("_delta_log/{checkpoint_rel}")).await;
 
-    // Hint is present but claims a future checkpoint version and a schema that does not match the
-    // parquet file. `end_version` must include the post-checkpoint commit so the segment matches
-    // a real snapshot layout (see `test_get_file_actions_schema_v1_parquet_with_hint`).
-    let newer_hint_schema: SchemaRef =
-        Arc::new(StructType::new_unchecked([StructField::nullable(
-            "metadata",
-            StructType::new_unchecked([]),
-        )]));
+    let hint_schema: SchemaRef = Arc::new(StructType::new_unchecked([StructField::nullable(
+        "metadata",
+        StructType::new_unchecked([]),
+    )]));
+
+    // Build a commit that uses v1 checkpoint and a hint that describes a different schema
     let commit_v2_path = log_root.join("00000000000000000002.json")?.to_string();
     let commit_v2 = create_log_path(&commit_v2_path);
     let log_segment = LogSegment::try_new(
@@ -2841,20 +2789,36 @@ async fn test_get_file_actions_schema_v1_parquet_stale_hint_uses_footer() -> Del
         log_root,
         None,
         Some(LastCheckpointHintSummary {
-            version: 99,
-            schema: Some(newer_hint_schema.clone()),
+            version: hint_version,
+            schema: Some(hint_schema.clone()),
         }),
     )?;
-    assert_eq!(log_segment.end_version, 2);
 
-    // Verify that the original v1_schema is returned
+    // Verify that checkpoint_schema only returns schema if it is valid
+    assert_eq!(log_segment.checkpoint_version, Some(1));
+    assert_eq!(log_segment.end_version, 2);
+    if expect_hint_schema_used {
+        assert_eq!(log_segment.checkpoint_schema().as_ref(), Some(&hint_schema));
+    } else {
+        assert!(
+            log_segment.checkpoint_schema().is_none(),
+            "hint should not have been returned since version does not match checkpoint_version"
+        );
+    }
+
+    // Verify that get_file_actions_schema_and_sidecars returns appropriate schema based on hint version
     let (schema, sidecars) = log_segment.get_file_actions_schema_and_sidecars(&engine)?;
-    assert_eq!(
-        schema.unwrap(),
-        v1_schema,
-        "footer schema must match the checkpoint file, not the stale hint"
-    );
+    let schema = schema.expect("V1 checkpoint should yield a file actions schema");
+    if expect_hint_schema_used {
+        assert_eq!(schema, hint_schema, "should use hint when versions match");
+    } else {
+        assert_eq!(
+            schema, v1_schema,
+            "should read schema from parquet footer when versions mismatch"
+        );
+    }
     assert!(sidecars.is_empty(), "V1 checkpoint should have no sidecars");
+
     Ok(())
 }
 

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -2740,12 +2740,8 @@ async fn test_checkpoint_schema_propagation_from_hint() {
     )
     .unwrap();
 
-    // Verify last_checkpoint_metadata is propagated with version and schema
-    let metadata = log_segment
-        .last_checkpoint_metadata
-        .expect("last_checkpoint_metadata should be Some");
-    assert_eq!(metadata.version, 5);
-    assert_eq!(metadata.schema.unwrap(), sample_schema);
+    assert_eq!(log_segment.last_checkpoint_version(), Some(5));
+    assert_eq!(log_segment.checkpoint_schema().unwrap(), sample_schema);
 }
 
 /// Test get_file_actions_schema_and_sidecars with V1 parquet checkpoint using hint schema
@@ -2800,6 +2796,65 @@ async fn test_get_file_actions_schema_v1_parquet_with_hint() -> DeltaResult<()> 
     );
     assert!(sidecars.is_empty(), "V1 checkpoint should have no sidecars");
 
+    Ok(())
+}
+
+/// Test get_file_actions_schema_and_sidecars where the `_last_checkpoint` hint
+/// claims a newer table version than [`LogSegment::end_version`] and carries a different schema.
+/// `get_file_actions_schema_and_sidecars` must not trust that schema and should read the real
+/// schema from the checkpoint parquet footer instead.
+#[tokio::test]
+async fn test_get_file_actions_schema_v1_parquet_stale_hint_uses_footer() -> DeltaResult<()> {
+    let (store, log_root) = new_in_memory_store();
+    let engine = DefaultEngineBuilder::new(store.clone()).build();
+
+    // Create a V1 checkpoint (without sidecar column)
+    let v1_schema = get_commit_schema().project(&[ADD_NAME, REMOVE_NAME])?;
+    add_checkpoint_to_store(
+        &store,
+        add_batch_simple(v1_schema.clone()),
+        "00000000000000000001.checkpoint.parquet",
+    )
+    .await?;
+
+    let checkpoint_rel = "00000000000000000001.checkpoint.parquet";
+    let checkpoint_file = log_root.join(checkpoint_rel)?.to_string();
+    let cp_size = get_file_size(&store, &format!("_delta_log/{checkpoint_rel}")).await;
+
+    // Hint is present but claims a future checkpoint version and a schema that does not match the
+    // parquet file. `end_version` must include the post-checkpoint commit so the segment matches
+    // a real snapshot layout (see `test_get_file_actions_schema_v1_parquet_with_hint`).
+    let newer_hint_schema: SchemaRef =
+        Arc::new(StructType::new_unchecked([StructField::nullable(
+            "metadata",
+            StructType::new_unchecked([]),
+        )]));
+    let commit_v2_path = log_root.join("00000000000000000002.json")?.to_string();
+    let commit_v2 = create_log_path(&commit_v2_path);
+    let log_segment = LogSegment::try_new(
+        LogSegmentFiles {
+            checkpoint_parts: vec![create_log_path_with_size(&checkpoint_file, cp_size)],
+            ascending_commit_files: vec![commit_v2.clone()],
+            latest_commit_file: Some(commit_v2),
+            ..Default::default()
+        },
+        log_root,
+        None,
+        Some(LastCheckpointHintSummary {
+            version: 99,
+            schema: Some(newer_hint_schema.clone()),
+        }),
+    )?;
+    assert_eq!(log_segment.end_version, 2);
+
+    // Verify that the original v1_schema is returned
+    let (schema, sidecars) = log_segment.get_file_actions_schema_and_sidecars(&engine)?;
+    assert_eq!(
+        schema.unwrap(),
+        v1_schema,
+        "footer schema must match the checkpoint file, not the stale hint"
+    );
+    assert!(sidecars.is_empty(), "V1 checkpoint should have no sidecars");
     Ok(())
 }
 
@@ -4012,7 +4067,7 @@ async fn test_try_new_with_checkpoint_sets_checkpoint_and_clears_commits(#[case]
     assert_eq!(result.listed.checkpoint_parts[0].version, 2);
     assert!(result.listed.ascending_commit_files.is_empty());
     assert!(result.listed.ascending_compaction_files.is_empty());
-    assert!(result.last_checkpoint_metadata.is_none());
+    assert!(result.last_checkpoint_hint_summary().is_none());
 
     // latest_commit_file is preserved for ICT access even though commits are cleared
     assert_eq!(

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -333,8 +333,8 @@ impl Snapshot {
             },
             log_root,
             requested_version,
-            // Preserve last checkpoint metadata from old segment
-            old_log_segment.last_checkpoint_metadata.clone(),
+            // Preserve `_last_checkpoint` hint from old segment
+            old_log_segment.last_checkpoint_hint_summary(),
         )?;
 
         Ok(Arc::new(Snapshot::new_with_crc(


### PR DESCRIPTION
## What changes are proposed in this pull request?
Fixes https://github.com/delta-io/delta-kernel-rs/issues/2361. There is a bug where we may try to use checkpoint schema from the last_checkpoint hint file, even though that schema is from a checkpoint version that is outside of the version range for the current snapshot.

This PR fixes it by adding an explicit getter to LogSegment which will filter out the checkpoint_schema if it is for a version that does not match the LogSegment's checkpoint version. All access of checkpoint_schema must then go through this getter instead.

## How was this change tested?
Added a unit test that fails before the change (repro'ing the bug) and passes after.
