### PR TITLE
fix: acceptance test framework should reject negative snapshot version

### DIFF
--- a/acceptance/tests/acceptance_workloads_reader.rs
+++ b/acceptance/tests/acceptance_workloads_reader.rs
@@ -148,10 +148,6 @@ const EXPECTED_KERNEL_FAILURES: &[(&str, &[&str])] = &[
         ],
     ),
     (
-        "Kernel allows negative version, Spark rejects with DELTA_TABLE_RESTORE_VERSION_INVALID",
-        &["dsReadVersionNegative/specs/dsReadVersionNegative_error"],
-    ),
-    (
         "void/NullType not supported in schema deserialization",
         &[
             "void_001_void_top_level/",

--- a/benchmarks/src/models.rs
+++ b/benchmarks/src/models.rs
@@ -538,7 +538,7 @@ mod tests {
         let tt = TimeTravel::Version { version: -1 };
         assert_eq!(
             tt.as_version(),
-            Err("Snapshot version must be non-negative")
+            Err("Only non-negative snapshot versions are supported")
         );
     }
 

--- a/benchmarks/src/models.rs
+++ b/benchmarks/src/models.rs
@@ -170,31 +170,24 @@ pub enum DataLayout {
 #[derive(Clone, Debug, Deserialize)]
 #[serde(untagged)]
 pub enum TimeTravel {
-    /// Snapshot/read version from the workload JSON. It is i64 so that negative values from
-    /// the test spec can be deserialized correctly; We rely on [`TimeTravel::as_version`] to reject
-    /// values below zero.
-    Version {
-        version: i64,
-    },
-    Timestamp {
-        timestamp: String,
-    },
+    /// Timetravel to a specific snapshot/read version specified by the workload JSON.
+    /// It is i64 so that negative values from the test spec can be deserialized correctly.
+    /// [`TimeTravel::as_version`] will reject values below zero.
+    Version { version: i64 },
+    /// Timetravel to a specific timestamp specified by the workload JSON.
+    /// (not yet supported)
+    Timestamp { timestamp: String },
 }
 
 impl TimeTravel {
     /// Returns the version if this is version-based time travel and the version is non-negative.
     ///
-    /// Returns an error for negative versions or for timestamp-based time travel( which is not
+    /// Returns an error for negative versions or for timestamp-based time travel (which is not
     /// yet supported).
     pub fn as_version(&self) -> Result<u64, &'static str> {
         match self {
-            TimeTravel::Version { version } => {
-                if *version < 0 {
-                    Err("Only non-negative snapshot versions are supported")
-                } else {
-                    Ok(*version as u64)
-                }
-            }
+            TimeTravel::Version { version } => u64::try_from(*version)
+                .map_err(|_| "Only non-negative snapshot versions are supported"),
             TimeTravel::Timestamp { .. } => Err("Timestamp-based time travel is not yet supported"),
         }
     }

--- a/benchmarks/src/models.rs
+++ b/benchmarks/src/models.rs
@@ -170,17 +170,31 @@ pub enum DataLayout {
 #[derive(Clone, Debug, Deserialize)]
 #[serde(untagged)]
 pub enum TimeTravel {
-    Version { version: u64 },
-    Timestamp { timestamp: String },
+    /// Snapshot/read version from the workload JSON. It is i64 so that negative values from
+    /// the test spec can be deserialized correctly; We rely on [`TimeTravel::as_version`] to reject
+    /// values below zero.
+    Version {
+        version: i64,
+    },
+    Timestamp {
+        timestamp: String,
+    },
 }
 
 impl TimeTravel {
-    /// Returns the version if this is version-based time travel.
+    /// Returns the version if this is version-based time travel and the version is non-negative.
     ///
-    /// Returns an error message for timestamp-based time travel, which is not yet supported.
+    /// Returns an error for negative versions or for timestamp-based time travel( which is not
+    /// yet supported).
     pub fn as_version(&self) -> Result<u64, &'static str> {
         match self {
-            TimeTravel::Version { version } => Ok(*version),
+            TimeTravel::Version { version } => {
+                if *version < 0 {
+                    Err("Only non-negative snapshot versions are supported")
+                } else {
+                    Ok(*version as u64)
+                }
+            }
             TimeTravel::Timestamp { .. } => Err("Timestamp-based time travel is not yet supported"),
         }
     }
@@ -490,10 +504,16 @@ mod tests {
         "snapshotConstruction",
         Some(7)
     )]
+    #[case(
+        r#"{"type": "snapshotConstruction", "version": -1}"#,
+        "snapshotConstruction",
+        Some(-1)
+    )]
+    #[case(r#"{"type": "read", "version": -1}"#, "read", Some(-1))]
     fn test_deserialize_spec(
         #[case] json: &str,
         #[case] expected_type: &str,
-        #[case] expected_version: Option<u64>,
+        #[case] expected_version: Option<i64>,
     ) {
         let spec: Spec = serde_json::from_str(json).expect("Failed to deserialize spec");
         assert_eq!(spec.as_str(), expected_type);
@@ -511,6 +531,15 @@ mod tests {
         };
 
         assert_eq!(version, expected_version);
+    }
+
+    #[test]
+    fn test_time_travel_as_version_rejects_negative() {
+        let tt = TimeTravel::Version { version: -1 };
+        assert_eq!(
+            tt.as_version(),
+            Err("Snapshot version must be non-negative")
+        );
     }
 
     #[rstest]


### PR DESCRIPTION
## What changes are proposed in this pull request?
Fixes https://github.com/delta-io/delta-kernel-rs/issues/2265.

The issue linked above originally assumed that the Rust kernel was incorrectly allowing negative snapshot versions. However upon inspection - this is not possible because we use `u64` as the Version type. It turns out that the acceptance test framework was silently casting negative versions from the test specs into u64.

**Proposed Fix**
- The acceptance test framework parses version as i64, but then errors out while trying to execute such test specs

**Rationale**
- In the spirit of "best possible Rust API", we shouldn't modify our existing snapshot construction logic to take in i64s (only to then error out at runtime). 
- Since DAT allows negative version numbers, we can instead rely on the test execution logic to error out on these cases and hence match the Err outcome expected by the test spec. 

## How was this change tested?
Removed the failing DAT workload from the allowlist of failures. Also added unit testing for the JSON parsing and version handling inside of the test framework.
