### PR TITLE
feat: add delta.parquet.format.version table property

### DIFF
--- a/kernel/src/table_properties.rs
+++ b/kernel/src/table_properties.rs
@@ -58,6 +58,7 @@ pub(crate) const MATERIALIZED_ROW_ID_COLUMN_NAME: &str =
 pub(crate) const MATERIALIZED_ROW_COMMIT_VERSION_COLUMN_NAME: &str =
     "delta.rowTracking.materializedRowCommitVersionColumnName";
 pub(crate) const ROW_TRACKING_SUSPENDED: &str = "delta.rowTrackingSuspended";
+pub(crate) const PARQUET_FORMAT_VERSION: &str = "delta.parquet.format.version";
 pub(crate) const ENABLE_IN_COMMIT_TIMESTAMPS: &str = "delta.enableInCommitTimestamps";
 pub(crate) const IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION: &str =
     "delta.inCommitTimestampEnablementVersion";
@@ -201,6 +202,11 @@ pub struct TableProperties {
 
     /// The name of the internal column that contains the materialized row commit version.
     pub materialized_row_commit_version_column_name: Option<String>,
+
+    /// The Parquet format version used when writing data files. Valid values are `"1.0.0"`
+    /// (DataPageV1) and any `"2.x.x"` such as `"2.12.0"` (DataPageV2). Writers SHOULD default
+    /// to `"1.0.0"` when absent. Connectors read this to configure their Parquet writers.
+    pub parquet_format_version: Option<String>,
 
     /// Whether to enable [In-Commit Timestamps]. The in-commit timestamps writer feature strongly
     /// associates a monotonically increasing timestamp with each commit by storing it in the
@@ -370,6 +376,7 @@ mod tests {
             "delta.rowTracking.materializedRowCommitVersionColumnName"
         );
         assert_eq!(ROW_TRACKING_SUSPENDED, "delta.rowTrackingSuspended");
+        assert_eq!(PARQUET_FORMAT_VERSION, "delta.parquet.format.version");
         assert_eq!(
             ENABLE_IN_COMMIT_TIMESTAMPS,
             "delta.enableInCommitTimestamps"
@@ -489,6 +496,7 @@ mod tests {
             (ENABLE_IN_COMMIT_TIMESTAMPS, "true"),
             (IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION, "15"),
             (IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP, "1612345678"),
+            (PARQUET_FORMAT_VERSION, "2.12.0"),
         ];
         let actual = TableProperties::from(properties.into_iter());
         let expected = TableProperties {
@@ -524,6 +532,7 @@ mod tests {
             row_tracking_suspended: Some(false),
             enable_in_commit_timestamps: Some(true),
             in_commit_timestamp_enablement_version: Some(15),
+            parquet_format_version: Some("2.12.0".to_string()),
             in_commit_timestamp_enablement_timestamp: Some(1_612_345_678),
             unknown_properties: HashMap::new(),
         };

--- a/kernel/src/table_properties/deserialize.rs
+++ b/kernel/src/table_properties/deserialize.rs
@@ -87,6 +87,7 @@ fn try_parse(props: &mut TableProperties, k: &str, v: &str) -> Option<()> {
             props.materialized_row_commit_version_column_name = Some(v.to_string())
         }
         ROW_TRACKING_SUSPENDED => props.row_tracking_suspended = Some(parse_bool(v)?),
+        PARQUET_FORMAT_VERSION => props.parquet_format_version = Some(v.to_string()),
         ENABLE_IN_COMMIT_TIMESTAMPS => props.enable_in_commit_timestamps = Some(parse_bool(v)?),
         IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION => {
             props.in_commit_timestamp_enablement_version = Some(parse_non_negative(v)?)

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -31,7 +31,7 @@ use crate::table_properties::{
     TableProperties, APPEND_ONLY, CHECKPOINT_WRITE_STATS_AS_JSON, CHECKPOINT_WRITE_STATS_AS_STRUCT,
     COLUMN_MAPPING_MAX_COLUMN_ID, COLUMN_MAPPING_MODE, DELTA_PROPERTY_PREFIX,
     ENABLE_CHANGE_DATA_FEED, ENABLE_DELETION_VECTORS, ENABLE_IN_COMMIT_TIMESTAMPS,
-    ENABLE_TYPE_WIDENING, SET_TRANSACTION_RETENTION_DURATION,
+    ENABLE_TYPE_WIDENING, PARQUET_FORMAT_VERSION, SET_TRANSACTION_RETENTION_DURATION,
 };
 use crate::transaction::create_table::CreateTableTransaction;
 use crate::transaction::data_layout::DataLayout;
@@ -87,6 +87,8 @@ const ALLOWED_DELTA_PROPERTIES: &[&str] = &[
     APPEND_ONLY,
     // Set transaction retention duration: controls expiration of txn identifiers
     SET_TRANSACTION_RETENTION_DURATION,
+    // Parquet format version: controls the Parquet writer version for data files
+    PARQUET_FORMAT_VERSION,
 ];
 
 /// Ensures that no Delta table exists at the given path.
@@ -768,7 +770,7 @@ mod tests {
     use crate::expressions::ColumnName;
     use crate::schema::{DataType, StructField, StructType};
     use crate::table_features::FeatureType;
-    use crate::table_properties::ENABLE_ICEBERG_COMPAT_V1;
+    use crate::table_properties::{ENABLE_ICEBERG_COMPAT_V1, PARQUET_FORMAT_VERSION};
     use crate::utils::test_utils::assert_result_error_with_message;
 
     fn test_schema() -> SchemaRef {
@@ -860,6 +862,19 @@ mod tests {
             validated.properties.get("custom.setting"),
             Some(&"value".to_string())
         );
+    }
+
+    #[test]
+    fn test_parquet_format_version_accepted() {
+        let properties =
+            HashMap::from([(PARQUET_FORMAT_VERSION.to_string(), "2.12.0".to_string())]);
+        let validated = validate_extract_table_features_and_properties(properties).unwrap();
+        assert_eq!(
+            validated.properties.get(PARQUET_FORMAT_VERSION),
+            Some(&"2.12.0".to_string()),
+        );
+        assert!(validated.reader_features.is_empty());
+        assert!(validated.writer_features.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add support for the delta.parquet.format.version table property so connectors can read it from TableProperties to configure their Parquet writers.

1. Add PARQUET_FORMAT_VERSION constant and parquet_format_version: Option<String> field to TableProperties with parsing in deserialize.rs
2. Add to ALLOWED_DELTA_PROPERTIES for CREATE TABLE support
3. Add tests for property parsing and CREATE TABLE validation

Protocol spec: https://github.com/delta-io/delta/pull/6539

## How was this change tested?

1. test_property_key_constants -- verifies the constant string value
2. test_parse_table_properties -- verifies parsing into TableProperties.parquet_format_version
3. test_parquet_format_version_accepted -- verifies the property passes CREATE TABLE validation and is preserved without triggering any feature flags
4. cargo clippy -p delta_kernel --all-features -- -D warnings passes clean