### PR TITLE
chore!: add tests for histograms and expose stats and histogram

### DIFF
--- a/kernel/src/crc/file_size_histogram.rs
+++ b/kernel/src/crc/file_size_histogram.rs
@@ -248,6 +248,21 @@ impl FileSizeHistogram {
         }
         Ok(self)
     }
+
+    /// Returns the sorted bin boundaries.
+    pub fn sorted_bin_boundaries(&self) -> &[i64] {
+        &self.sorted_bin_boundaries
+    }
+
+    /// Returns the file count for each bin.
+    pub fn file_counts(&self) -> &[i64] {
+        &self.file_counts
+    }
+
+    /// Returns the total bytes for each bin.
+    pub fn total_bytes(&self) -> &[i64] {
+        &self.total_bytes
+    }
 }
 
 #[cfg(test)]

--- a/kernel/src/crc/file_size_histogram.rs
+++ b/kernel/src/crc/file_size_histogram.rs
@@ -79,6 +79,31 @@ pub struct FileSizeHistogram {
 }
 
 impl FileSizeHistogram {
+    /// Returns the sorted bin boundaries defining the histogram ranges.
+    ///
+    /// Each element represents the inclusive lower bound of a bin. The bin covers
+    /// `[sorted_bin_boundaries[i], sorted_bin_boundaries[i+1])`, with the last bin
+    /// extending to infinity. The first element is always 0.
+    pub fn sorted_bin_boundaries(&self) -> &[i64] {
+        &self.sorted_bin_boundaries
+    }
+
+    /// Returns the file count for each bin.
+    ///
+    /// Each element is the number of files whose size falls within the corresponding
+    /// bin's range. Length matches [`sorted_bin_boundaries()`](Self::sorted_bin_boundaries).
+    pub fn file_counts(&self) -> &[i64] {
+        &self.file_counts
+    }
+
+    /// Returns the total bytes for each bin.
+    ///
+    /// Each element is the sum of file sizes within the corresponding bin's range.
+    /// Length matches [`sorted_bin_boundaries()`](Self::sorted_bin_boundaries).
+    pub fn total_bytes(&self) -> &[i64] {
+        &self.total_bytes
+    }
+
     /// Creates a new histogram with the given arrays, after validation.
     ///
     /// Validates that:
@@ -247,21 +272,6 @@ impl FileSizeHistogram {
             );
         }
         Ok(self)
-    }
-
-    /// Returns the sorted bin boundaries.
-    pub fn sorted_bin_boundaries(&self) -> &[i64] {
-        &self.sorted_bin_boundaries
-    }
-
-    /// Returns the file count for each bin.
-    pub fn file_counts(&self) -> &[i64] {
-        &self.file_counts
-    }
-
-    /// Returns the total bytes for each bin.
-    pub fn total_bytes(&self) -> &[i64] {
-        &self.total_bytes
     }
 }
 

--- a/kernel/src/crc/file_stats.rs
+++ b/kernel/src/crc/file_stats.rs
@@ -19,8 +19,12 @@ use crate::{DeltaResult, EngineData, Error, RowVisitor};
 
 /// File-level statistics for a table version: total file count, size, and histogram.
 ///
-/// Obtained via [`Crc::file_stats()`](super::Crc::file_stats), which returns `None` when
-/// the stats are not known to be valid.
+/// Obtained via [`Snapshot::get_or_load_file_stats`], [`Snapshot::get_file_stats_if_loaded`],
+/// or [`Crc::file_stats()`](super::Crc::file_stats). Returns `None` when the stats are not
+/// known to be valid.
+///
+/// [`Snapshot::get_or_load_file_stats`]: crate::snapshot::Snapshot::get_or_load_file_stats
+/// [`Snapshot::get_file_stats_if_loaded`]: crate::snapshot::Snapshot::get_file_stats_if_loaded
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FileStats {
     /// Number of active [`Add`](crate::actions::Add) file actions in this table version.

--- a/kernel/src/crc/file_stats.rs
+++ b/kernel/src/crc/file_stats.rs
@@ -24,12 +24,31 @@ use crate::{DeltaResult, EngineData, Error, RowVisitor};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FileStats {
     /// Number of active [`Add`](crate::actions::Add) file actions in this table version.
-    pub num_files: i64,
+    pub(crate) num_files: i64,
     /// Total size of the table in bytes (sum of all active
     /// [`Add`](crate::actions::Add) file sizes).
-    pub table_size_bytes: i64,
+    pub(crate) table_size_bytes: i64,
     /// Size distribution of active files, if available.
-    pub file_size_histogram: Option<FileSizeHistogram>,
+    pub(crate) file_size_histogram: Option<FileSizeHistogram>,
+}
+
+impl FileStats {
+    /// Returns the number of active [`Add`](crate::actions::Add) file actions in this table
+    /// version.
+    pub fn num_files(&self) -> i64 {
+        self.num_files
+    }
+
+    /// Returns the total size of the table in bytes (sum of all active
+    /// [`Add`](crate::actions::Add) file sizes).
+    pub fn table_size_bytes(&self) -> i64 {
+        self.table_size_bytes
+    }
+
+    /// Returns the size distribution of active files, if available.
+    pub fn file_size_histogram(&self) -> Option<&FileSizeHistogram> {
+        self.file_size_histogram.as_ref()
+    }
 }
 
 /// Net file count and size changes from a single commit, with an optional net histogram.

--- a/kernel/src/crc/mod.rs
+++ b/kernel/src/crc/mod.rs
@@ -18,8 +18,8 @@ mod writer;
 
 #[allow(unused)]
 pub(crate) use delta::CrcDelta;
-pub(crate) use file_size_histogram::FileSizeHistogram;
-pub(crate) use file_stats::FileStats;
+pub use file_size_histogram::FileSizeHistogram;
+pub use file_stats::FileStats;
 #[allow(unused)]
 pub(crate) use file_stats::FileStatsDelta;
 pub(crate) use lazy::{CrcLoadResult, LazyCrc};

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -111,6 +111,7 @@ pub mod table_properties;
 pub mod transaction;
 pub mod transforms;
 
+pub use crc::{FileSizeHistogram, FileStats};
 pub use log_path::LogPath;
 
 // Public under test-utils so integration tests can call get_high_water_mark via snapshot.

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -17,7 +17,7 @@ use crate::clustering::{parse_clustering_columns, CLUSTERING_DOMAIN_NAME};
 use crate::committer::{Committer, PublishMetadata};
 #[cfg(any(test, feature = "test-utils"))]
 use crate::crc::Crc;
-use crate::crc::{try_write_crc_file, CrcDelta, LazyCrc};
+use crate::crc::{try_write_crc_file, CrcDelta, FileStats, LazyCrc};
 use crate::expressions::ColumnName;
 use crate::log_segment::{DomainMetadataMap, LogSegment};
 use crate::log_segment_files::LogSegmentFiles;
@@ -38,13 +38,6 @@ pub use builder::SnapshotBuilder;
 
 /// A shared, thread-safe reference to a [`Snapshot`].
 pub type SnapshotRef = Arc<Snapshot>;
-
-/// File-level statistics for a table version.
-///
-/// NOTE: This is an unstable API expected to change in future releases.
-#[allow(unused)]
-#[internal_api]
-pub(crate) type FileStats = crate::crc::FileStats;
 
 /// Result of attempting to write a version checksum (CRC) file.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -827,24 +827,17 @@ impl Snapshot {
     }
 
     /// Returns file-level statistics, or `None` if no CRC with valid stats exists at this
-    /// snapshot's version.
-    ///
-    /// NOTE: This is an unstable API expected to change in future releases.
-    #[allow(unused)]
-    #[internal_api]
-    pub(crate) fn get_or_load_file_stats(&self, engine: &dyn Engine) -> Option<FileStats> {
+    /// snapshot's version. Attempts to load the CRC from storage if not already cached.
+    pub fn get_or_load_file_stats(&self, engine: &dyn Engine) -> Option<FileStats> {
         let crc = self
             .lazy_crc
             .get_or_load_if_at_version(engine, self.version())?;
         crc.file_stats()
     }
 
-    /// Returns file-level statistics, or `None` if CRC is not loaded, not at this
-    /// version, or has no valid file stats.
-    ///
-    /// NOTE: This API is purely opportunistic, no I/O.
-    #[internal_api]
-    pub(crate) fn get_file_stats_if_loaded(&self) -> Option<FileStats> {
+    /// Returns file-level statistics if the CRC is already loaded at this snapshot's version.
+    /// This method performs no I/O; it returns `None` if the CRC has not already been loaded.
+    pub fn get_file_stats_if_loaded(&self) -> Option<FileStats> {
         let crc = self.lazy_crc.get_if_loaded_at_version(self.version())?;
         crc.file_stats()
     }

--- a/kernel/tests/crc.rs
+++ b/kernel/tests/crc.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use delta_kernel::arrow::array::{ArrayRef, Int32Array};
+use delta_kernel::arrow::array::{ArrayRef, Int32Array, StringArray};
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::crc::{Crc, FileStatsValidity};
 use delta_kernel::engine::default::DefaultEngineBuilder;
@@ -32,9 +32,9 @@ async fn test_get_file_stats_from_crc() -> DeltaResult<()> {
     assert_eq!(snapshot.version(), 0);
 
     let file_stats = snapshot.get_or_load_file_stats(&engine).unwrap();
-    assert_eq!(file_stats.num_files, 10);
-    assert_eq!(file_stats.table_size_bytes, 5259);
-    assert!(file_stats.file_size_histogram.is_some());
+    assert_eq!(file_stats.num_files(), 10);
+    assert_eq!(file_stats.table_size_bytes(), 5259);
+    assert!(file_stats.file_size_histogram().is_some());
 
     Ok(())
 }
@@ -116,8 +116,8 @@ async fn test_get_current_crc_if_loaded_returns_loaded_crc() -> DeltaResult<()> 
 
     // ===== THEN =====
     let file_stats = crc.file_stats().unwrap();
-    assert_eq!(file_stats.table_size_bytes, 5259);
-    assert_eq!(file_stats.num_files, 10);
+    assert_eq!(file_stats.table_size_bytes(), 5259);
+    assert_eq!(file_stats.num_files(), 10);
     assert_eq!(crc.num_metadata, 1);
     assert_eq!(crc.num_protocol, 1);
 
@@ -190,8 +190,8 @@ async fn test_create_table_produces_post_commit_crc() -> DeltaResult<()> {
     let crc = snapshot.get_current_crc_if_loaded_for_testing().unwrap();
 
     let file_stats = crc.file_stats().unwrap();
-    assert_eq!(file_stats.num_files, 0);
-    assert_eq!(file_stats.table_size_bytes, 0);
+    assert_eq!(file_stats.num_files(), 0);
+    assert_eq!(file_stats.table_size_bytes(), 0);
     assert_eq!(crc.num_metadata, 1);
     assert_eq!(crc.num_protocol, 1);
     assert_eq!(crc.protocol, *snapshot.table_configuration().protocol());
@@ -288,8 +288,8 @@ async fn test_post_commit_crc_tracks_file_stats_across_inserts() -> DeltaResult<
     let snapshot_v1 = committed.post_commit_snapshot().unwrap();
     let crc_v1 = write_and_verify_crc(snapshot_v1, &table_path, engine.as_ref());
     let stats_v1 = crc_v1.file_stats().unwrap();
-    assert_eq!(stats_v1.num_files, 1); // <--- 1 file added
-    assert!(stats_v1.table_size_bytes > 0); // <--- size is non-zero
+    assert_eq!(stats_v1.num_files(), 1); // <--- 1 file added
+    assert!(stats_v1.table_size_bytes() > 0); // <--- size is non-zero
 
     // ===== WHEN: Insert values 11..=20 =====
     let col2: ArrayRef = Arc::new(Int32Array::from((11..=20).collect::<Vec<_>>()));
@@ -302,8 +302,8 @@ async fn test_post_commit_crc_tracks_file_stats_across_inserts() -> DeltaResult<
     let snapshot_v2 = committed.post_commit_snapshot().unwrap();
     let crc_v2 = write_and_verify_crc(snapshot_v2, &table_path, engine.as_ref());
     let stats_v2 = crc_v2.file_stats().unwrap();
-    assert_eq!(stats_v2.num_files, 2); // <--- 2 files added
-    assert!(stats_v2.table_size_bytes > stats_v1.table_size_bytes); // <--- size is greater than after first insert
+    assert_eq!(stats_v2.num_files(), 2); // <--- 2 files added
+    assert!(stats_v2.table_size_bytes() > stats_v1.table_size_bytes()); // <--- size is greater than after first insert
 
     // ===== WHEN: Remove all files =====
     let scan = snapshot_v2.clone().scan_builder().build()?;
@@ -322,8 +322,8 @@ async fn test_post_commit_crc_tracks_file_stats_across_inserts() -> DeltaResult<
     let snapshot_v3 = committed.post_commit_snapshot().unwrap();
     let crc_v3 = write_and_verify_crc(snapshot_v3, &table_path, engine.as_ref());
     let stats_v3 = crc_v3.file_stats().unwrap();
-    assert_eq!(stats_v3.num_files, 0); // <--- 0 net file in the table
-    assert_eq!(stats_v3.table_size_bytes, 0); // <--- size is 0
+    assert_eq!(stats_v3.num_files(), 0); // <--- 0 net file in the table
+    assert_eq!(stats_v3.table_size_bytes(), 0); // <--- size is 0
 
     Ok(())
 }
@@ -495,8 +495,8 @@ async fn test_in_memory_crc_chains_across_multiple_commits_then_writes() -> Delt
     assert_eq!(snapshot.version(), 5);
     let crc = write_and_verify_crc(&snapshot, &table_path, engine.as_ref());
     let crc_stats = crc.file_stats().unwrap();
-    assert_eq!(crc_stats.num_files, 5);
-    assert!(crc_stats.table_size_bytes > 0);
+    assert_eq!(crc_stats.num_files(), 5);
+    assert!(crc_stats.table_size_bytes() > 0);
 
     Ok(())
 }
@@ -968,6 +968,341 @@ async fn test_set_txn_null_last_updated_never_expires_via_log_replay() -> DeltaR
         fresh.get_app_id_version("null-app", engine.as_ref())?,
         Some(42)
     );
+
+    Ok(())
+}
+
+// ============================================================================
+// File Histogram End to End Testing
+// ============================================================================
+
+/// Returns sorted sizes of all `.parquet` files in the table directory. Reads actual file
+/// sizes from disk, providing an independent ground truth not derived from the CRC computation.
+///
+/// NOTE: After a Delta remove, call `delete_parquet_files_on_disk` first so that the disk state
+/// reflects only logically-active files (Delta removes are logical, not physical).
+fn parquet_file_sizes_on_disk(table_path: &str) -> Vec<i64> {
+    let url = delta_kernel::try_parse_uri(table_path).unwrap();
+    let dir = url.to_file_path().unwrap();
+    let mut sizes = Vec::new();
+    for entry in std::fs::read_dir(dir).unwrap() {
+        let entry = entry.unwrap();
+        if entry.path().extension().is_some_and(|ext| ext == "parquet") {
+            sizes.push(entry.metadata().unwrap().len() as i64);
+        }
+    }
+    sizes.sort();
+    sizes
+}
+
+/// Deletes all `.parquet` files in the table directory. Called after Delta remove actions
+/// to keep `parquet_file_sizes_on_disk` accurate as ground truth (Delta removes are logical
+/// and leave physical files on disk).
+fn delete_parquet_files_on_disk(table_path: &str) {
+    let url = delta_kernel::try_parse_uri(table_path).unwrap();
+    let dir = url.to_file_path().unwrap();
+    for entry in std::fs::read_dir(dir).unwrap() {
+        let entry = entry.unwrap();
+        if entry.path().extension().is_some_and(|ext| ext == "parquet") {
+            std::fs::remove_file(entry.path()).unwrap();
+        }
+    }
+}
+
+/// Asserts that the CRC histogram totals (summed across all bins) match the expected values.
+fn assert_histogram_totals(crc: &Crc, expected_file_count: i64, expected_total_bytes: i64) {
+    let hist = crc
+        .file_size_histogram
+        .as_ref()
+        .expect("histogram should be present");
+    assert_eq!(hist.file_counts().iter().sum::<i64>(), expected_file_count);
+    assert_eq!(hist.total_bytes().iter().sum::<i64>(), expected_total_bytes);
+}
+
+/// Verifies that the in-memory CRC histogram correctly tracks file adds and removes across
+/// multiple bins, cross-checked against actual file sizes on disk at each step. The CRC is
+/// maintained in memory via `post_commit_snapshot` and written to disk at each step for
+/// verification.
+///
+/// - v0: empty table -> histogram all zeros
+/// - v1: insert small file (< 8KB, bin 0) -> 1 file in bin 0
+/// - v2: insert large file (>= 8KB, bin 1+) -> files span two bins
+/// - v3: remove all files, delete parquet from disk -> histogram returns to all zeros
+#[tokio::test]
+async fn test_file_histogram_tracks_adds_and_removes_across_bins() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let schema = Arc::new(StructType::try_new(vec![
+        StructField::nullable("id", DataType::INTEGER),
+        StructField::nullable("data", DataType::STRING),
+    ])?);
+
+    // ===== v0: empty table =====
+    let committed = create_table(&table_path, schema, "test_engine")
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+    let snapshot = committed.post_commit_snapshot().unwrap();
+    let crc_v0 = write_and_verify_crc(snapshot, &table_path, engine.as_ref());
+    assert_histogram_totals(&crc_v0, 0, 0);
+
+    // ===== v1: insert small file (< 8KB -> bin 0) =====
+    let ids: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+    let data: ArrayRef = Arc::new(StringArray::from(vec!["a", "b", "c"]));
+    let committed = insert_data(snapshot.clone(), &engine, vec![ids, data])
+        .await?
+        .unwrap_committed();
+    let snapshot = committed.post_commit_snapshot().unwrap();
+    let disk_sizes = parquet_file_sizes_on_disk(&table_path);
+    assert_eq!(disk_sizes.len(), 1);
+    let crc_v1 = write_and_verify_crc(snapshot, &table_path, engine.as_ref());
+    assert_histogram_totals(&crc_v1, 1, disk_sizes.iter().sum());
+
+    // ===== v2: insert large file (>= 8KB -> bin 1+) =====
+    let n = 5000i32;
+    let ids: ArrayRef = Arc::new(Int32Array::from((0..n).collect::<Vec<_>>()));
+    let strings: Vec<String> = (0..n).map(|i| format!("{i:0>100}")).collect();
+    let data: ArrayRef = Arc::new(StringArray::from(strings));
+    let committed = insert_data(snapshot.clone(), &engine, vec![ids, data])
+        .await?
+        .unwrap_committed();
+    let snapshot = committed.post_commit_snapshot().unwrap();
+
+    // Cross-check: files land in different bins
+    let disk_sizes = parquet_file_sizes_on_disk(&table_path);
+    assert_eq!(disk_sizes.len(), 2);
+    let small_size = disk_sizes[0];
+    let large_size = disk_sizes[1];
+    assert!(
+        small_size < 8192,
+        "expected small file < 8KB, got {small_size}"
+    );
+    assert!(
+        large_size >= 8192,
+        "expected large file >= 8KB, got {large_size}"
+    );
+
+    let crc_v2 = write_and_verify_crc(snapshot, &table_path, engine.as_ref());
+    let hist = crc_v2.file_size_histogram.as_ref().unwrap();
+    assert_eq!(hist.file_counts()[0], 1, "bin 0 should have the small file");
+    assert_eq!(hist.total_bytes()[0], small_size);
+    assert_eq!(hist.file_counts()[1..].iter().sum::<i64>(), 1);
+    assert_eq!(hist.total_bytes()[1..].iter().sum::<i64>(), large_size);
+
+    // ===== v3: remove all files =====
+    let scan = snapshot.clone().scan_builder().build()?;
+    let mut txn = snapshot
+        .clone()
+        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .with_operation("DELETE".to_string())
+        .with_data_change(true);
+    for sm in scan.scan_metadata(engine.as_ref())? {
+        txn.remove_files(sm?.scan_files);
+    }
+    let committed = txn.commit(engine.as_ref())?.unwrap_committed();
+    let snapshot = committed.post_commit_snapshot().unwrap();
+
+    // Delete physical parquet files so disk ground truth reflects the empty table
+    delete_parquet_files_on_disk(&table_path);
+    assert!(parquet_file_sizes_on_disk(&table_path).is_empty());
+
+    let crc_v3 = write_and_verify_crc(snapshot, &table_path, engine.as_ref());
+    assert_histogram_totals(&crc_v3, 0, 0);
+
+    Ok(())
+}
+
+/// Verifies that the in-memory CRC accumulates correctly across multiple commits without
+/// intermediate disk writes. Each `post_commit_snapshot` applies its delta to the previous
+/// in-memory CRC; the final `write_and_verify_crc` confirms the accumulated result.
+#[tokio::test]
+async fn test_file_histogram_chained_commits_accumulate_correctly() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let committed = create_table_and_commit(&table_path, engine.as_ref())?;
+    let mut snapshot = committed.post_commit_snapshot().unwrap().clone();
+
+    // Chain 5 inserts -- CRC is maintained in memory but not written to disk
+    for i in 0..5 {
+        let col: ArrayRef = Arc::new(Int32Array::from(vec![i]));
+        let committed = insert_data(snapshot, &engine, vec![col])
+            .await?
+            .unwrap_committed();
+        snapshot = committed.post_commit_snapshot().unwrap().clone();
+    }
+
+    // Write the accumulated in-memory CRC to disk and verify it matches
+    assert_eq!(snapshot.version(), 5);
+    let crc = write_and_verify_crc(&snapshot, &table_path, engine.as_ref());
+    let disk_sizes = parquet_file_sizes_on_disk(&table_path);
+    assert_eq!(disk_sizes.len(), 5);
+    assert_histogram_totals(&crc, 5, disk_sizes.iter().sum());
+
+    Ok(())
+}
+
+/// Verifies the disk round-trip path: write the in-memory CRC to disk at v1, load a fresh
+/// snapshot from disk (which deserializes the v1 CRC from JSON), then insert at v2. The v2
+/// post-commit CRC is computed by applying the v2 delta to the deserialized v1 CRC, testing
+/// that the in-memory chain works with a disk-loaded base.
+#[tokio::test]
+async fn test_file_histogram_survives_disk_round_trip_then_delta_merge() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let committed = create_table_and_commit(&table_path, engine.as_ref())?;
+    let snapshot_v0 = committed.post_commit_snapshot().unwrap();
+
+    // v1: insert data and write CRC to disk
+    let col1: ArrayRef = Arc::new(Int32Array::from((1..=10).collect::<Vec<_>>()));
+    let committed = insert_data(snapshot_v0.clone(), &engine, vec![col1])
+        .await?
+        .unwrap_committed();
+    let snapshot_v1 = committed.post_commit_snapshot().unwrap();
+    let v1_bytes = snapshot_v1
+        .get_current_crc_if_loaded_for_testing()
+        .unwrap()
+        .file_stats()
+        .unwrap()
+        .table_size_bytes();
+    snapshot_v1.write_checksum(engine.as_ref())?;
+
+    // Load a FRESH snapshot from disk at v1 (CRC deserialized from JSON, not in-memory)
+    let fresh_v1 = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert_eq!(fresh_v1.version(), 1);
+    assert!(fresh_v1.get_current_crc_if_loaded_for_testing().is_some());
+
+    // v2: insert using the fresh (disk-loaded) snapshot -- the post-commit CRC at v2
+    // is computed by applying the v2 delta to the deserialized v1 CRC
+    let col2: ArrayRef = Arc::new(Int32Array::from((11..=20).collect::<Vec<_>>()));
+    let committed = insert_data(fresh_v1, &engine, vec![col2])
+        .await?
+        .unwrap_committed();
+    assert_eq!(committed.commit_version(), 2);
+
+    // Verify the merged histogram: 2 files, bytes match actual parquet files on disk
+    let snapshot_v2 = committed.post_commit_snapshot().unwrap();
+    let crc_v2 = write_and_verify_crc(snapshot_v2, &table_path, engine.as_ref());
+    let disk_sizes = parquet_file_sizes_on_disk(&table_path);
+    assert_eq!(disk_sizes.len(), 2);
+    assert!(disk_sizes.iter().sum::<i64>() > v1_bytes);
+    assert_histogram_totals(&crc_v2, 2, disk_sizes.iter().sum());
+
+    Ok(())
+}
+
+/// Helper which rewrites the histogram in an on-disk CRC file to use custom 2-bin boundaries `[0, 100]`.
+/// Since any parquet file is > 100 bytes (metadata alone exceeds this), all files land
+/// deterministically in bin 1 regardless of compression. The file_counts and total_bytes
+/// arrays are rebuilt to match the new boundaries using the provided file sizes.
+fn rewrite_crc_with_custom_bins(table_path: &str, version: u64, file_sizes: &[i64]) {
+    let url = delta_kernel::try_parse_uri(table_path).unwrap();
+    let crc_file = url
+        .to_file_path()
+        .unwrap()
+        .join(format!("_delta_log/{version:020}.crc"));
+
+    let json_str = std::fs::read_to_string(&crc_file).unwrap();
+    let mut crc: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+    // All files are > 100 bytes, so bin 0 is empty and bin 1 holds everything
+    let total_bytes: i64 = file_sizes.iter().sum();
+    let num_files = file_sizes.len() as i64;
+    crc["fileSizeHistogram"] = serde_json::json!({
+        "sortedBinBoundaries": [0, 100],
+        "fileCounts": [0, num_files],
+        "totalBytes": [0, total_bytes],
+    });
+
+    std::fs::write(&crc_file, serde_json::to_string(&crc).unwrap()).unwrap();
+}
+
+/// Cross-product test: (custom bins | default bins) x (incremental | non-incremental).
+///
+/// For incremental operations, the in-memory CRC histogram should survive with correct
+/// values and boundary type. For non-incremental operations, the histogram is dropped to
+/// None and file stats become Indeterminate, regardless of boundary type.
+///
+/// Custom bins are injected by rewriting the on-disk CRC to use 2-bin boundaries `[0, 100]`
+/// before loading a fresh snapshot. The fresh snapshot deserializes the custom-bin CRC, and
+/// the next commit's in-memory delta inherits those boundaries.
+#[rstest]
+#[tokio::test]
+async fn test_file_histogram_with_bin_type_and_operation_type(
+    #[values(true, false)] use_custom_bins: bool,
+    #[values(true, false)] incremental: bool,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    // ===== GIVEN: table with 1 file at v1 and CRC on disk =====
+    let committed = create_table_and_commit(&table_path, engine.as_ref())?;
+    let snapshot_v0 = committed.post_commit_snapshot().unwrap();
+    let col: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+    let committed = insert_data(snapshot_v0.clone(), &engine, vec![col])
+        .await?
+        .unwrap_committed();
+    let snapshot_v1 = committed.post_commit_snapshot().unwrap();
+    snapshot_v1.write_checksum(engine.as_ref())?;
+
+    let v1_disk_sizes = parquet_file_sizes_on_disk(&table_path);
+    assert_eq!(v1_disk_sizes.len(), 1);
+
+    if use_custom_bins {
+        rewrite_crc_with_custom_bins(&table_path, 1, &v1_disk_sizes);
+    }
+
+    // Load fresh snapshot from disk (reads the possibly-modified CRC)
+    let fresh_v1 = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert_eq!(fresh_v1.version(), 1);
+    assert!(fresh_v1.get_current_crc_if_loaded_for_testing().is_some());
+
+    // ===== WHEN: perform the operation =====
+    let snapshot_v2 = if incremental {
+        let col: ArrayRef = Arc::new(Int32Array::from(vec![4, 5, 6]));
+        let committed = insert_data(fresh_v1, &engine, vec![col])
+            .await?
+            .unwrap_committed();
+        assert_eq!(committed.commit_version(), 2);
+        committed.post_commit_snapshot().unwrap().clone()
+    } else {
+        let committed = fresh_v1
+            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+            .with_operation("ANALYZE STATS".to_string())
+            .commit(engine.as_ref())?
+            .unwrap_committed();
+        assert_eq!(committed.commit_version(), 2);
+        committed.post_commit_snapshot().unwrap().clone()
+    };
+
+    // ===== THEN: verify histogram state =====
+    let crc_v2 = snapshot_v2.get_current_crc_if_loaded_for_testing().unwrap();
+
+    if !incremental {
+        // Non-incremental operations drop the histogram regardless of bin type
+        assert_eq!(crc_v2.file_stats_validity, FileStatsValidity::Indeterminate);
+        assert!(crc_v2.file_size_histogram.is_none());
+        return Ok(());
+    }
+
+    // Incremental: histogram should be present and correct
+    let hist = crc_v2
+        .file_size_histogram
+        .as_ref()
+        .expect("incremental op should preserve histogram");
+    let counts = hist.file_counts();
+    let bytes = hist.total_bytes();
+    let v2_disk_sizes = parquet_file_sizes_on_disk(&table_path);
+    assert_eq!(v2_disk_sizes.len(), 2);
+    let total_disk_bytes: i64 = v2_disk_sizes.iter().sum();
+
+    if use_custom_bins {
+        // Custom [0, 100] boundaries: 2 bins, all files in bin 1 (all > 100 bytes)
+        assert_eq!(counts.len(), 2, "custom bins should have exactly 2 bins");
+        assert_eq!(counts[0], 0, "no files should be in bin 0 ([0, 100))");
+        assert_eq!(counts[1], 2, "both files should be in bin 1 ([100, inf))");
+        assert_eq!(bytes[0], 0);
+        assert_eq!(bytes[1], total_disk_bytes);
+    } else {
+        // Default 95-bin boundaries: all small test files land in bin 0 ([0, 8KB))
+        assert_eq!(counts.len(), 95, "default bins should have 95 bins");
+        assert_histogram_totals(crc_v2, 2, total_disk_bytes);
+    }
 
     Ok(())
 }

--- a/kernel/tests/crc.rs
+++ b/kernel/tests/crc.rs
@@ -12,6 +12,7 @@ use delta_kernel::schema::{DataType, StructField, StructType};
 use delta_kernel::snapshot::{ChecksumWriteResult, Snapshot, SnapshotRef};
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
+use delta_kernel::FileStats;
 use delta_kernel::{DeltaResult, Engine};
 use rstest::rstest;
 use test_utils::{add_commit, insert_data, test_table_setup};
@@ -498,6 +499,11 @@ async fn test_in_memory_crc_chains_across_multiple_commits_then_writes() -> Delt
     assert_eq!(crc_stats.num_files(), 5);
     assert!(crc_stats.table_size_bytes() > 0);
 
+    // Verify histogram totals match disk ground truth
+    let disk_sizes = parquet_file_sizes_on_disk(&table_path);
+    assert_eq!(disk_sizes.len(), 5);
+    assert_histogram_totals(&crc_stats, 5, disk_sizes.iter().sum());
+
     Ok(())
 }
 
@@ -973,51 +979,78 @@ async fn test_set_txn_null_last_updated_never_expires_via_log_replay() -> DeltaR
 }
 
 // ============================================================================
-// File Histogram End to End Testing
+// File Histogram Tracking Across Commits
 // ============================================================================
 
-/// Returns sorted sizes of all `.parquet` files in the table directory. Reads actual file
-/// sizes from disk, providing an independent ground truth not derived from the CRC computation.
+/// Returns paths of all `.parquet` files in the table root directory.
 ///
-/// NOTE: After a Delta remove, call `delete_parquet_files_on_disk` first so that the disk state
-/// reflects only logically-active files (Delta removes are logical, not physical).
-fn parquet_file_sizes_on_disk(table_path: &str) -> Vec<i64> {
+/// NOTE: Uses non-recursive `read_dir`, so this only finds parquet files
+/// directly in the table root. Partitioned tables store parquet files in
+/// subdirectories and would require a recursive walk.
+fn parquet_paths_on_disk(table_path: &str) -> Vec<PathBuf> {
     let url = delta_kernel::try_parse_uri(table_path).unwrap();
     let dir = url.to_file_path().unwrap();
-    let mut sizes = Vec::new();
-    for entry in std::fs::read_dir(dir).unwrap() {
-        let entry = entry.unwrap();
-        if entry.path().extension().is_some_and(|ext| ext == "parquet") {
-            sizes.push(entry.metadata().unwrap().len() as i64);
-        }
-    }
+    std::fs::read_dir(dir)
+        .unwrap()
+        .filter_map(|entry| {
+            let path = entry.unwrap().path();
+            if path.extension().is_some_and(|ext| ext == "parquet") {
+                Some(path)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Returns sorted sizes of all `.parquet` files in the table directory as
+/// independent ground truth (not derived from the CRC computation).
+///
+/// NOTE: After a Delta remove, call `delete_parquet_files_on_disk` first
+/// so that the disk state reflects only logically-active files (Delta
+/// removes are logical, not physical).
+fn parquet_file_sizes_on_disk(table_path: &str) -> Vec<i64> {
+    let mut sizes: Vec<i64> = parquet_paths_on_disk(table_path)
+        .iter()
+        .map(|p| std::fs::metadata(p).unwrap().len() as i64)
+        .collect();
     sizes.sort();
     sizes
 }
 
-/// Deletes all `.parquet` files in the table directory. Called after Delta remove actions
-/// to keep `parquet_file_sizes_on_disk` accurate as ground truth (Delta removes are logical
-/// and leave physical files on disk).
+/// Deletes all `.parquet` files in the table directory. Called after Delta
+/// remove actions to keep `parquet_file_sizes_on_disk` accurate.
 fn delete_parquet_files_on_disk(table_path: &str) {
-    let url = delta_kernel::try_parse_uri(table_path).unwrap();
-    let dir = url.to_file_path().unwrap();
-    for entry in std::fs::read_dir(dir).unwrap() {
-        let entry = entry.unwrap();
-        if entry.path().extension().is_some_and(|ext| ext == "parquet") {
-            std::fs::remove_file(entry.path()).unwrap();
-        }
+    for path in parquet_paths_on_disk(table_path) {
+        std::fs::remove_file(path).unwrap();
     }
 }
 
-/// Asserts that the CRC histogram totals (summed across all bins) match the expected values.
-fn assert_histogram_totals(crc: &Crc, expected_file_count: i64, expected_total_bytes: i64) {
-    let hist = crc
-        .file_size_histogram
-        .as_ref()
+/// Asserts that the histogram totals (summed across all bins) match the expected values,
+/// and that the histogram file count sum equals [`FileStats::num_files`].
+fn assert_histogram_totals(
+    file_stats: &FileStats,
+    expected_file_count: i64,
+    expected_total_bytes: i64,
+) {
+    let hist = file_stats
+        .file_size_histogram()
         .expect("histogram should be present");
-    assert_eq!(hist.file_counts().iter().sum::<i64>(), expected_file_count);
+    let count_sum: i64 = hist.file_counts().iter().sum();
+    assert_eq!(count_sum, expected_file_count);
+    assert_eq!(count_sum, file_stats.num_files());
     assert_eq!(hist.total_bytes().iter().sum::<i64>(), expected_total_bytes);
 }
+
+/// The first non-zero default histogram bin boundary (8KB).
+const FIRST_BIN_BOUNDARY: i64 = 8192;
+
+/// Approximate bytes per row for `(int32, 100-char padded string)` parquet data.
+const APPROX_BYTES_PER_ROW: i64 = 104;
+
+/// Row count guaranteed to produce a parquet file exceeding [`FIRST_BIN_BOUNDARY`].
+/// Uses 2x the boundary divided by per-row size as a generous margin.
+const LARGE_FILE_ROW_COUNT: i32 = (FIRST_BIN_BOUNDARY * 2 / APPROX_BYTES_PER_ROW) as i32;
 
 /// Verifies that the in-memory CRC histogram correctly tracks file adds and removes across
 /// multiple bins, cross-checked against actual file sizes on disk at each step. The CRC is
@@ -1043,7 +1076,7 @@ async fn test_file_histogram_tracks_adds_and_removes_across_bins() -> DeltaResul
         .unwrap_committed();
     let snapshot = committed.post_commit_snapshot().unwrap();
     let crc_v0 = write_and_verify_crc(snapshot, &table_path, engine.as_ref());
-    assert_histogram_totals(&crc_v0, 0, 0);
+    assert_histogram_totals(&crc_v0.file_stats().unwrap(), 0, 0);
 
     // ===== v1: insert small file (< 8KB -> bin 0) =====
     let ids: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
@@ -1055,10 +1088,16 @@ async fn test_file_histogram_tracks_adds_and_removes_across_bins() -> DeltaResul
     let disk_sizes = parquet_file_sizes_on_disk(&table_path);
     assert_eq!(disk_sizes.len(), 1);
     let crc_v1 = write_and_verify_crc(snapshot, &table_path, engine.as_ref());
-    assert_histogram_totals(&crc_v1, 1, disk_sizes.iter().sum());
+    let stats_v1 = crc_v1.file_stats().unwrap();
+    assert_histogram_totals(&stats_v1, 1, disk_sizes.iter().sum());
+
+    // Verify boundary metadata via public getters
+    let hist = stats_v1.file_size_histogram().unwrap();
+    assert_eq!(hist.sorted_bin_boundaries()[0], 0);
+    assert_eq!(hist.sorted_bin_boundaries().len(), 95);
 
     // ===== v2: insert large file (>= 8KB -> bin 1+) =====
-    let n = 5000i32;
+    let n = LARGE_FILE_ROW_COUNT;
     let ids: ArrayRef = Arc::new(Int32Array::from((0..n).collect::<Vec<_>>()));
     let strings: Vec<String> = (0..n).map(|i| format!("{i:0>100}")).collect();
     let data: ArrayRef = Arc::new(StringArray::from(strings));
@@ -1073,20 +1112,34 @@ async fn test_file_histogram_tracks_adds_and_removes_across_bins() -> DeltaResul
     let small_size = disk_sizes[0];
     let large_size = disk_sizes[1];
     assert!(
-        small_size < 8192,
+        small_size < FIRST_BIN_BOUNDARY,
         "expected small file < 8KB, got {small_size}"
     );
     assert!(
-        large_size >= 8192,
+        large_size >= FIRST_BIN_BOUNDARY,
         "expected large file >= 8KB, got {large_size}"
     );
 
     let crc_v2 = write_and_verify_crc(snapshot, &table_path, engine.as_ref());
-    let hist = crc_v2.file_size_histogram.as_ref().unwrap();
+    let stats_v2 = crc_v2.file_stats().unwrap();
+    let hist = stats_v2.file_size_histogram().unwrap();
     assert_eq!(hist.file_counts()[0], 1, "bin 0 should have the small file");
     assert_eq!(hist.total_bytes()[0], small_size);
-    assert_eq!(hist.file_counts()[1..].iter().sum::<i64>(), 1);
-    assert_eq!(hist.total_bytes()[1..].iter().sum::<i64>(), large_size);
+
+    // Find the exact bin for the large file based on its actual size
+    let boundaries = hist.sorted_bin_boundaries();
+    let large_bin = boundaries
+        .windows(2)
+        .enumerate()
+        .find(|(_, w)| large_size >= w[0] && large_size < w[1])
+        .map(|(i, _)| i)
+        .unwrap_or(boundaries.len() - 1);
+    assert_eq!(
+        hist.file_counts()[large_bin],
+        1,
+        "large file ({large_size} bytes) should be in bin {large_bin}"
+    );
+    assert_eq!(hist.total_bytes()[large_bin], large_size);
 
     // ===== v3: remove all files =====
     let scan = snapshot.clone().scan_builder().build()?;
@@ -1106,35 +1159,7 @@ async fn test_file_histogram_tracks_adds_and_removes_across_bins() -> DeltaResul
     assert!(parquet_file_sizes_on_disk(&table_path).is_empty());
 
     let crc_v3 = write_and_verify_crc(snapshot, &table_path, engine.as_ref());
-    assert_histogram_totals(&crc_v3, 0, 0);
-
-    Ok(())
-}
-
-/// Verifies that the in-memory CRC accumulates correctly across multiple commits without
-/// intermediate disk writes. Each `post_commit_snapshot` applies its delta to the previous
-/// in-memory CRC; the final `write_and_verify_crc` confirms the accumulated result.
-#[tokio::test]
-async fn test_file_histogram_chained_commits_accumulate_correctly() -> DeltaResult<()> {
-    let (_temp_dir, table_path, engine) = test_table_setup()?;
-    let committed = create_table_and_commit(&table_path, engine.as_ref())?;
-    let mut snapshot = committed.post_commit_snapshot().unwrap().clone();
-
-    // Chain 5 inserts -- CRC is maintained in memory but not written to disk
-    for i in 0..5 {
-        let col: ArrayRef = Arc::new(Int32Array::from(vec![i]));
-        let committed = insert_data(snapshot, &engine, vec![col])
-            .await?
-            .unwrap_committed();
-        snapshot = committed.post_commit_snapshot().unwrap().clone();
-    }
-
-    // Write the accumulated in-memory CRC to disk and verify it matches
-    assert_eq!(snapshot.version(), 5);
-    let crc = write_and_verify_crc(&snapshot, &table_path, engine.as_ref());
-    let disk_sizes = parquet_file_sizes_on_disk(&table_path);
-    assert_eq!(disk_sizes.len(), 5);
-    assert_histogram_totals(&crc, 5, disk_sizes.iter().sum());
+    assert_histogram_totals(&crc_v3.file_stats().unwrap(), 0, 0);
 
     Ok(())
 }
@@ -1182,13 +1207,14 @@ async fn test_file_histogram_survives_disk_round_trip_then_delta_merge() -> Delt
     let disk_sizes = parquet_file_sizes_on_disk(&table_path);
     assert_eq!(disk_sizes.len(), 2);
     assert!(disk_sizes.iter().sum::<i64>() > v1_bytes);
-    assert_histogram_totals(&crc_v2, 2, disk_sizes.iter().sum());
+    assert_histogram_totals(&crc_v2.file_stats().unwrap(), 2, disk_sizes.iter().sum());
 
     Ok(())
 }
 
-/// Helper which rewrites the histogram in an on-disk CRC file to use custom 2-bin boundaries `[0, 100]`.
-/// Since any parquet file is > 100 bytes (metadata alone exceeds this), all files land
+/// Rewrites the histogram in an on-disk CRC file to use custom 2-bin
+/// boundaries `[0, 100]`. Since any parquet file is > 100 bytes (metadata
+/// alone exceeds this), all files land
 /// deterministically in bin 1 regardless of compression. The file_counts and total_bytes
 /// arrays are rebuilt to match the new boundaries using the provided file sizes.
 fn rewrite_crc_with_custom_bins(table_path: &str, version: u64, file_sizes: &[i64]) {
@@ -1276,14 +1302,14 @@ async fn test_file_histogram_with_bin_type_and_operation_type(
     if !incremental {
         // Non-incremental operations drop the histogram regardless of bin type
         assert_eq!(crc_v2.file_stats_validity, FileStatsValidity::Indeterminate);
-        assert!(crc_v2.file_size_histogram.is_none());
+        assert!(crc_v2.file_stats().is_none());
         return Ok(());
     }
 
     // Incremental: histogram should be present and correct
-    let hist = crc_v2
-        .file_size_histogram
-        .as_ref()
+    let stats_v2 = crc_v2.file_stats().unwrap();
+    let hist = stats_v2
+        .file_size_histogram()
         .expect("incremental op should preserve histogram");
     let counts = hist.file_counts();
     let bytes = hist.total_bytes();
@@ -1301,7 +1327,7 @@ async fn test_file_histogram_with_bin_type_and_operation_type(
     } else {
         // Default 95-bin boundaries: all small test files land in bin 0 ([0, 8KB))
         assert_eq!(counts.len(), 95, "default bins should have 95 bins");
-        assert_histogram_totals(crc_v2, 2, total_disk_bytes);
+        assert_histogram_totals(&stats_v2, 2, total_disk_bytes);
     }
 
     Ok(())


### PR DESCRIPTION
## What changes are proposed in this pull request?

This change adds tests which validate that file histograms are consistent with actual parquet writes by testing end to end parquet write + commit + crc write and reading the size of written parquet files. This change also exposes file stats and file histogram to connectors using getter methods.

## How was this change tested?

Adds four new integration tests that ensure logic is correct for add and remove actions across only in memory crcs, on disk crcs, and crcs with default bin sizes as well as custom bin sizes.