### PR TITLE
feat!: add typed null literal support to FFI expression visitors

### DIFF
--- a/ffi/examples/visit-expression/engine_to_kernel_expression.h
+++ b/ffi/examples/visit-expression/engine_to_kernel_expression.h
@@ -72,7 +72,10 @@ uintptr_t convert_engine_to_kernel_literal(
       return result.ok;
     }
     case Null: {
-      ExternResultusize result = visit_expression_literal_null(state, allocate_error);
+      // Pass type_tag=3 (Integer), precision=0, scale=0 as a default typed null.
+      // A real engine would track the null's data type and pass the correct tag.
+      ExternResultusize result =
+          visit_expression_literal_null(state, 3, 0, 0, allocate_error);
       if (result.tag == Errusize) {
         print_error("visit_expression_literal_null failed", (Error*)result.err);
         free_error((Error*)result.err);

--- a/ffi/examples/visit-expression/engine_to_kernel_expression.h
+++ b/ffi/examples/visit-expression/engine_to_kernel_expression.h
@@ -72,10 +72,9 @@ uintptr_t convert_engine_to_kernel_literal(
       return result.ok;
     }
     case Null: {
-      // Pass type_tag=3 (Integer), precision=0, scale=0 as a default typed null.
-      // A real engine would track the null's data type and pass the correct tag.
-      ExternResultusize result =
-          visit_expression_literal_null(state, 3, 0, 0, allocate_error);
+      struct NullTypeInfo* nt = &lit->value.null_type;
+      ExternResultusize result = visit_expression_literal_null(
+          state, nt->type_tag, nt->precision, nt->scale, allocate_error);
       if (result.tag == Errusize) {
         print_error("visit_expression_literal_null failed", (Error*)result.err);
         free_error((Error*)result.err);

--- a/ffi/examples/visit-expression/expression.h
+++ b/ffi/examples/visit-expression/expression.h
@@ -269,7 +269,15 @@ void visit_expr_struct_literal(void* data,
   struct_data->values = get_expr_list(data, child_value_list_id);
   put_expr_item(data, sibling_list_id, literal, Literal);
 }
-void visit_expr_null_literal(void* data, uintptr_t sibling_id_list) {
+void visit_expr_null_literal(
+    void* data,
+    uintptr_t sibling_id_list,
+    uint8_t type_tag,
+    uint8_t precision,
+    uint8_t scale) {
+  (void)type_tag;
+  (void)precision;
+  (void)scale;
   struct Literal* literal = malloc(sizeof(struct Literal));
   literal->type = Null;
   put_expr_item(data, sibling_id_list, literal, Literal);

--- a/ffi/examples/visit-expression/expression.h
+++ b/ffi/examples/visit-expression/expression.h
@@ -140,6 +140,11 @@ struct MapData {
   ExpressionItemList keys;
   ExpressionItemList vals;
 };
+struct NullTypeInfo {
+  uint8_t type_tag;
+  uint8_t precision;
+  uint8_t scale;
+};
 struct Literal {
   enum LitType type;
   union LiteralValue {
@@ -156,6 +161,7 @@ struct Literal {
     struct MapData map_data;
     struct BinaryData binary;
     struct Decimal decimal;
+    struct NullTypeInfo null_type;
   } value;
 };
 
@@ -275,11 +281,11 @@ void visit_expr_null_literal(
     uint8_t type_tag,
     uint8_t precision,
     uint8_t scale) {
-  (void)type_tag;
-  (void)precision;
-  (void)scale;
   struct Literal* literal = malloc(sizeof(struct Literal));
   literal->type = Null;
+  literal->value.null_type.type_tag = type_tag;
+  literal->value.null_type.precision = precision;
+  literal->value.null_type.scale = scale;
   put_expr_item(data, sibling_id_list, literal, Literal);
 }
 

--- a/ffi/examples/visit-expression/expression_print.h
+++ b/ffi/examples/visit-expression/expression_print.h
@@ -182,7 +182,7 @@ void print_tree_helper(ExpressionItem ref, int depth) {
             "Double", "String", "Binary", "Date", "Timestamp", "TimestampNtz",
           };
           struct NullTypeInfo* nt = &lit->value.null_type;
-          if (nt->type_tag < 12) {
+          if (nt->type_tag < 12) { // 12 == Decimal (has special precision/scale handling)
             printf("Null(%s)\n", null_type_names[nt->type_tag]);
           } else if (nt->type_tag == 12) {
             printf("Null(Decimal(%d,%d))\n", nt->precision, nt->scale);

--- a/ffi/examples/visit-expression/expression_print.h
+++ b/ffi/examples/visit-expression/expression_print.h
@@ -176,9 +176,21 @@ void print_tree_helper(ExpressionItem ref, int depth) {
                  dec->scale);
           break;
         }
-        case Null:
-          printf("Null\n");
+        case Null: {
+          static const char* null_type_names[] = {
+            "Boolean", "Byte", "Short", "Integer", "Long", "Float",
+            "Double", "String", "Binary", "Date", "Timestamp", "TimestampNtz",
+          };
+          struct NullTypeInfo* nt = &lit->value.null_type;
+          if (nt->type_tag < 12) {
+            printf("Null(%s)\n", null_type_names[nt->type_tag]);
+          } else if (nt->type_tag == 12) {
+            printf("Null(Decimal(%d,%d))\n", nt->precision, nt->scale);
+          } else {
+            printf("Null(tag=%d)\n", nt->type_tag);
+          }
           break;
+        }
         case Struct:
           printf("Struct\n");
           struct Struct* struct_data = &lit->value.struct_data;

--- a/ffi/src/expressions/engine_visitor.rs
+++ b/ffi/src/expressions/engine_visitor.rs
@@ -58,9 +58,9 @@ type VisitParseJsonFn = extern "C" fn(
 ///
 /// WARNING: The visitor MUST NOT retain internal references to string slices or binary data passed
 /// to visitor methods
-/// TODO: Visit type information in struct field and null. This will likely involve using the schema
-/// visitor. Note that struct literals are currently in flux, and may change significantly. Here is
-/// the relevant issue: <https://github.com/delta-io/delta-kernel-rs/issues/412>
+/// TODO: Visit type information in struct field. This will likely involve using the schema visitor.
+/// Note that struct literals are currently in flux, and may change significantly. Here is the
+/// relevant issue: <https://github.com/delta-io/delta-kernel-rs/issues/412>
 #[repr(C)]
 pub struct EngineExpressionVisitor {
     /// An opaque engine state pointer

--- a/ffi/src/expressions/engine_visitor.rs
+++ b/ffi/src/expressions/engine_visitor.rs
@@ -5,6 +5,7 @@ use crate::expressions::{
 };
 use crate::{handle::Handle, kernel_string_slice, KernelStringSlice, SharedSchema};
 
+use super::kernel_visitor::NullTypeTag;
 use delta_kernel::expressions::{
     ArrayData, BinaryExpression, BinaryExpressionOp, BinaryPredicate, BinaryPredicateOp,
     ColumnName, Expression, ExpressionRef, JunctionPredicate, JunctionPredicateOp, MapData,
@@ -13,7 +14,6 @@ use delta_kernel::expressions::{
     UnaryExpression, UnaryExpressionOp, UnaryPredicate, UnaryPredicateOp, VariadicExpression,
     VariadicExpressionOp,
 };
-use delta_kernel::schema::{DataType, PrimitiveType};
 
 use std::ffi::c_void;
 
@@ -131,9 +131,10 @@ pub struct EngineExpressionVisitor {
     ),
     /// Visits a typed null value belonging to the list identified by `sibling_list_id`.
     ///
-    /// The `type_tag` identifies the data type (see [`NullTypeTag`] in `kernel_visitor`). For
-    /// decimal nulls (`type_tag == 12`), `precision` and `scale` carry the decimal type; they
-    /// are zero for all other types.
+    /// The `type_tag` identifies the data type (see [`NullTypeTag`]). For decimal nulls
+    /// (`type_tag == 12`), `precision` and `scale` carry the decimal type parameters; for all
+    /// other types, they are zero. See [`NullTypeTag::NonPrimitive`] for non-primitive null
+    /// types.
     pub visit_literal_null: extern "C" fn(
         data: *mut c_void,
         sibling_list_id: usize,
@@ -545,32 +546,6 @@ fn visit_predicate_opaque(
     );
 }
 
-/// Convert a [`DataType`] to the `(type_tag, precision, scale)` triple used by
-/// [`EngineExpressionVisitor::visit_literal_null`]. Non-primitive types (struct, array, map,
-/// variant) map to `type_tag == 255` — the engine must handle or reject them.
-fn data_type_to_null_tag(data_type: &DataType) -> (u8, u8, u8) {
-    match data_type {
-        DataType::Primitive(p) => match p {
-            PrimitiveType::Boolean => (0, 0, 0),
-            PrimitiveType::Byte => (1, 0, 0),
-            PrimitiveType::Short => (2, 0, 0),
-            PrimitiveType::Integer => (3, 0, 0),
-            PrimitiveType::Long => (4, 0, 0),
-            PrimitiveType::Float => (5, 0, 0),
-            PrimitiveType::Double => (6, 0, 0),
-            PrimitiveType::String => (7, 0, 0),
-            PrimitiveType::Binary => (8, 0, 0),
-            PrimitiveType::Date => (9, 0, 0),
-            PrimitiveType::Timestamp => (10, 0, 0),
-            PrimitiveType::TimestampNtz => (11, 0, 0),
-            PrimitiveType::Decimal(dt) => (12, dt.precision(), dt.scale()),
-        },
-        // Non-primitive nulls use a sentinel tag. Engines that need type details for complex
-        // null types should use opaque expressions or a schema visitor instead.
-        _ => (255, 0, 0),
-    }
-}
-
 fn visit_unknown(visitor: &mut EngineExpressionVisitor, sibling_list_id: usize, name: &str) {
     call!(
         visitor,
@@ -625,12 +600,12 @@ fn visit_expression_scalar(
             )
         }
         Scalar::Null(data_type) => {
-            let (type_tag, precision, scale) = data_type_to_null_tag(data_type);
+            let (tag, precision, scale) = NullTypeTag::from_data_type(data_type);
             call!(
                 visitor,
                 visit_literal_null,
                 sibling_list_id,
-                type_tag,
+                tag as u8,
                 precision,
                 scale
             )

--- a/ffi/src/expressions/engine_visitor.rs
+++ b/ffi/src/expressions/engine_visitor.rs
@@ -131,10 +131,10 @@ pub struct EngineExpressionVisitor {
     ),
     /// Visits a typed null value belonging to the list identified by `sibling_list_id`.
     ///
-    /// The `type_tag` identifies the data type (see [`NullTypeTag`]). For decimal nulls
-    /// (`type_tag == 12`), `precision` and `scale` carry the decimal type parameters; for all
-    /// other types, they are zero. See [`NullTypeTag::NonPrimitive`] for non-primitive null
-    /// types.
+    /// The `type_tag` identifies the data type using the `NullTypeTag` encoding. For decimal
+    /// nulls (`type_tag == 12`), `precision` and `scale` carry the decimal type parameters;
+    /// for all other types, they are zero. Non-primitive types (struct, array, map, variant)
+    /// use `type_tag == 255`.
     pub visit_literal_null: extern "C" fn(
         data: *mut c_void,
         sibling_list_id: usize,

--- a/ffi/src/expressions/engine_visitor.rs
+++ b/ffi/src/expressions/engine_visitor.rs
@@ -13,6 +13,7 @@ use delta_kernel::expressions::{
     UnaryExpression, UnaryExpressionOp, UnaryPredicate, UnaryPredicateOp, VariadicExpression,
     VariadicExpressionOp,
 };
+use delta_kernel::schema::{DataType, PrimitiveType};
 
 use std::ffi::c_void;
 
@@ -128,8 +129,18 @@ pub struct EngineExpressionVisitor {
         key_list_id: usize,
         value_list_id: usize,
     ),
-    /// Visits a null value belonging to the list identified by `sibling_list_id.
-    pub visit_literal_null: extern "C" fn(data: *mut c_void, sibling_list_id: usize),
+    /// Visits a typed null value belonging to the list identified by `sibling_list_id`.
+    ///
+    /// The `type_tag` identifies the data type (see [`NullTypeTag`] in `kernel_visitor`). For
+    /// decimal nulls (`type_tag == 12`), `precision` and `scale` carry the decimal type; they
+    /// are zero for all other types.
+    pub visit_literal_null: extern "C" fn(
+        data: *mut c_void,
+        sibling_list_id: usize,
+        type_tag: u8,
+        precision: u8,
+        scale: u8,
+    ),
     /// Visits an `and` expression belonging to the list identified by `sibling_list_id`.
     /// The sub-expressions of the array are in a list identified by `child_list_id`
     pub visit_and: VisitJunctionFn,
@@ -534,6 +545,32 @@ fn visit_predicate_opaque(
     );
 }
 
+/// Convert a [`DataType`] to the `(type_tag, precision, scale)` triple used by
+/// [`EngineExpressionVisitor::visit_literal_null`]. Non-primitive types (struct, array, map,
+/// variant) map to `type_tag == 255` — the engine must handle or reject them.
+fn data_type_to_null_tag(data_type: &DataType) -> (u8, u8, u8) {
+    match data_type {
+        DataType::Primitive(p) => match p {
+            PrimitiveType::Boolean => (0, 0, 0),
+            PrimitiveType::Byte => (1, 0, 0),
+            PrimitiveType::Short => (2, 0, 0),
+            PrimitiveType::Integer => (3, 0, 0),
+            PrimitiveType::Long => (4, 0, 0),
+            PrimitiveType::Float => (5, 0, 0),
+            PrimitiveType::Double => (6, 0, 0),
+            PrimitiveType::String => (7, 0, 0),
+            PrimitiveType::Binary => (8, 0, 0),
+            PrimitiveType::Date => (9, 0, 0),
+            PrimitiveType::Timestamp => (10, 0, 0),
+            PrimitiveType::TimestampNtz => (11, 0, 0),
+            PrimitiveType::Decimal(dt) => (12, dt.precision(), dt.scale()),
+        },
+        // Non-primitive nulls use a sentinel tag. Engines that need type details for complex
+        // null types should use opaque expressions or a schema visitor instead.
+        _ => (255, 0, 0),
+    }
+}
+
 fn visit_unknown(visitor: &mut EngineExpressionVisitor, sibling_list_id: usize, name: &str) {
     call!(
         visitor,
@@ -587,7 +624,17 @@ fn visit_expression_scalar(
                 v.scale()
             )
         }
-        Scalar::Null(_) => call!(visitor, visit_literal_null, sibling_list_id),
+        Scalar::Null(data_type) => {
+            let (type_tag, precision, scale) = data_type_to_null_tag(data_type);
+            call!(
+                visitor,
+                visit_literal_null,
+                sibling_list_id,
+                type_tag,
+                precision,
+                scale
+            )
+        }
         Scalar::Struct(struct_data) => {
             visit_expression_struct_literal(visitor, struct_data, sibling_list_id)
         }

--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -536,12 +536,12 @@ impl NullTypeTag {
 
 /// Visit a typed null literal expression.
 ///
-/// The `type_tag` identifies the data type (see [`NullTypeTag`]). For decimal nulls
+/// The `type_tag` identifies the data type using the `NullTypeTag` encoding. For decimal nulls
 /// (`type_tag == 12`), `precision` and `scale` specify the decimal type parameters; for all
 /// other types, callers should pass 0 for both.
 ///
-/// Returns an error if the type tag is unrecognized, if the tag is
-/// [`NonPrimitive`](NullTypeTag::NonPrimitive), or if the decimal precision/scale is invalid.
+/// Returns an error if the type tag is unrecognized, if the tag is `NonPrimitive` (255), or
+/// if the decimal precision/scale is invalid.
 #[no_mangle]
 pub extern "C" fn visit_expression_literal_null(
     state: &mut KernelExpressionVisitorState,

--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -439,6 +439,9 @@ pub(crate) enum NullTypeTag {
     /// Null of type `timestamp_ntz` (microseconds since epoch, no timezone).
     TimestampNtz = 11,
     /// Null of type `decimal`. Requires valid `precision` and `scale` parameters.
+    ///
+    /// WARNING: This variant MUST remain `= 12`. It is the only tag with special handling
+    /// (precision/scale parameters), and C consumers key on the value `12` directly.
     Decimal = 12,
     /// Sentinel for non-primitive null types (struct, array, map, variant). Emitted by the
     /// kernel-to-engine visitor when the null's type is not a primitive. Engines that receive

--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -6,6 +6,7 @@ use delta_kernel::expressions::{
     BinaryExpressionOp, BinaryPredicateOp, ColumnName, Expression, Predicate, Scalar,
     UnaryPredicateOp,
 };
+use delta_kernel::schema::{DataType, PrimitiveType};
 use delta_kernel::DeltaResult;
 
 use crate::expressions::{SharedExpression, SharedPredicate};
@@ -401,19 +402,81 @@ fn visit_expression_literal_decimal_impl(
     Ok(wrap_expression(state, Expression::literal(decimal)))
 }
 
-/// Visit a null literal expression.
+/// Type tag for null literal construction via FFI. Identifies the data type of a typed null.
 ///
-/// Returns an error because NULL literal reconstruction is not supported - type information
-/// is lost when converting from kernel to engine format, so we cannot faithfully reconstruct
-/// the original NULL literal.
+/// Primitive types use fixed discriminants 0-11. Decimal uses 12 and requires additional
+/// precision/scale parameters.
+///
+/// NOTE: These values are part of the FFI contract. Changing existing values is a breaking change.
+#[repr(u8)]
+pub enum NullTypeTag {
+    Boolean = 0,
+    Byte = 1,
+    Short = 2,
+    Integer = 3,
+    Long = 4,
+    Float = 5,
+    Double = 6,
+    String = 7,
+    Binary = 8,
+    Date = 9,
+    Timestamp = 10,
+    TimestampNtz = 11,
+    Decimal = 12,
+}
+
+/// Visit a typed null literal expression.
+///
+/// The `type_tag` identifies the data type (see [`NullTypeTag`]). For decimal nulls
+/// (`type_tag == 12`), `precision` and `scale` specify the decimal type parameters; they are
+/// ignored for all other types.
+///
+/// Returns an error if the type tag is unrecognized or if the decimal precision/scale is invalid.
 #[no_mangle]
 pub extern "C" fn visit_expression_literal_null(
-    _state: &mut KernelExpressionVisitorState,
+    state: &mut KernelExpressionVisitorState,
+    type_tag: u8,
+    precision: u8,
+    scale: u8,
     allocate_error: AllocateErrorFn,
 ) -> ExternResult<usize> {
-    let err = delta_kernel::Error::generic("NULL literal reconstruction is not supported");
     // SAFETY: The allocate_error function pointer is provided by the engine and assumed valid.
-    unsafe { Err(err).into_extern_result(&allocate_error) }
+    unsafe {
+        visit_expression_literal_null_impl(state, type_tag, precision, scale)
+            .into_extern_result(&allocate_error)
+    }
+}
+
+fn visit_expression_literal_null_impl(
+    state: &mut KernelExpressionVisitorState,
+    type_tag: u8,
+    precision: u8,
+    scale: u8,
+) -> DeltaResult<usize> {
+    let data_type = match type_tag {
+        0 => DataType::BOOLEAN,
+        1 => DataType::BYTE,
+        2 => DataType::SHORT,
+        3 => DataType::INTEGER,
+        4 => DataType::LONG,
+        5 => DataType::FLOAT,
+        6 => DataType::DOUBLE,
+        7 => DataType::STRING,
+        8 => DataType::BINARY,
+        9 => DataType::DATE,
+        10 => DataType::TIMESTAMP,
+        11 => DataType::TIMESTAMP_NTZ,
+        12 => DataType::Primitive(PrimitiveType::decimal(precision, scale)?),
+        other => {
+            return Err(delta_kernel::Error::generic(format!(
+                "Unrecognized null type tag: {other}"
+            )));
+        }
+    };
+    Ok(wrap_expression(
+        state,
+        Expression::literal(Scalar::Null(data_type)),
+    ))
 }
 
 #[no_mangle]

--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -405,33 +405,143 @@ fn visit_expression_literal_decimal_impl(
 /// Type tag for null literal construction via FFI. Identifies the data type of a typed null.
 ///
 /// Primitive types use fixed discriminants 0-11. Decimal uses 12 and requires additional
-/// precision/scale parameters.
+/// precision/scale parameters. Non-primitive types (struct, array, map, variant) use the
+/// [`NonPrimitive`](Self::NonPrimitive) sentinel -- these cannot be reconstructed from a type
+/// tag alone.
 ///
-/// NOTE: These values are part of the FFI contract. Changing existing values is a breaking change.
+/// NOTE: These values are part of the FFI contract. Changing existing discriminants is a breaking
+/// change.
 #[repr(u8)]
-pub enum NullTypeTag {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NullTypeTag {
+    /// Null of type `boolean`.
     Boolean = 0,
+    /// Null of type `byte` (8-bit signed integer).
     Byte = 1,
+    /// Null of type `short` (16-bit signed integer).
     Short = 2,
+    /// Null of type `integer` (32-bit signed integer).
     Integer = 3,
+    /// Null of type `long` (64-bit signed integer).
     Long = 4,
+    /// Null of type `float` (32-bit IEEE 754).
     Float = 5,
+    /// Null of type `double` (64-bit IEEE 754).
     Double = 6,
+    /// Null of type `string`.
     String = 7,
+    /// Null of type `binary`.
     Binary = 8,
+    /// Null of type `date` (days since epoch).
     Date = 9,
+    /// Null of type `timestamp` (microseconds since epoch, UTC-adjusted).
     Timestamp = 10,
+    /// Null of type `timestamp_ntz` (microseconds since epoch, no timezone).
     TimestampNtz = 11,
+    /// Null of type `decimal`. Requires valid `precision` and `scale` parameters.
     Decimal = 12,
+    /// Sentinel for non-primitive null types (struct, array, map, variant). Emitted by the
+    /// kernel-to-engine visitor when the null's type is not a primitive. Engines that receive
+    /// this tag should use opaque expressions or a schema visitor to obtain full type details.
+    ///
+    /// Passing this tag to [`visit_expression_literal_null`] returns an error because the
+    /// original complex type cannot be reconstructed from a tag alone.
+    NonPrimitive = 255,
+}
+
+impl TryFrom<u8> for NullTypeTag {
+    type Error = delta_kernel::Error;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Boolean),
+            1 => Ok(Self::Byte),
+            2 => Ok(Self::Short),
+            3 => Ok(Self::Integer),
+            4 => Ok(Self::Long),
+            5 => Ok(Self::Float),
+            6 => Ok(Self::Double),
+            7 => Ok(Self::String),
+            8 => Ok(Self::Binary),
+            9 => Ok(Self::Date),
+            10 => Ok(Self::Timestamp),
+            11 => Ok(Self::TimestampNtz),
+            12 => Ok(Self::Decimal),
+            255 => Ok(Self::NonPrimitive),
+            other => Err(delta_kernel::Error::generic(format!(
+                "Unrecognized null type tag: {other}"
+            ))),
+        }
+    }
+}
+
+impl NullTypeTag {
+    /// Convert a [`DataType`] to its null type tag and decimal parameters.
+    ///
+    /// Returns `(tag, precision, scale)`. The `precision` and `scale` are only meaningful when
+    /// `tag` is [`NullTypeTag::Decimal`]; they are zero for all other types.
+    pub(crate) fn from_data_type(data_type: &DataType) -> (Self, u8, u8) {
+        match data_type {
+            DataType::Primitive(p) => match p {
+                PrimitiveType::Boolean => (Self::Boolean, 0, 0),
+                PrimitiveType::Byte => (Self::Byte, 0, 0),
+                PrimitiveType::Short => (Self::Short, 0, 0),
+                PrimitiveType::Integer => (Self::Integer, 0, 0),
+                PrimitiveType::Long => (Self::Long, 0, 0),
+                PrimitiveType::Float => (Self::Float, 0, 0),
+                PrimitiveType::Double => (Self::Double, 0, 0),
+                PrimitiveType::String => (Self::String, 0, 0),
+                PrimitiveType::Binary => (Self::Binary, 0, 0),
+                PrimitiveType::Date => (Self::Date, 0, 0),
+                PrimitiveType::Timestamp => (Self::Timestamp, 0, 0),
+                PrimitiveType::TimestampNtz => (Self::TimestampNtz, 0, 0),
+                PrimitiveType::Decimal(dt) => (Self::Decimal, dt.precision(), dt.scale()),
+            },
+            _ => (Self::NonPrimitive, 0, 0),
+        }
+    }
+
+    /// Convert a null type tag back to a [`DataType`].
+    ///
+    /// For [`Decimal`](Self::Decimal), `precision` and `scale` specify the decimal parameters.
+    /// For all other primitive types, `precision` and `scale` are ignored (callers should
+    /// pass 0).
+    ///
+    /// Returns an error for [`NonPrimitive`](Self::NonPrimitive) since complex types cannot be
+    /// reconstructed from a type tag alone.
+    pub(crate) fn to_data_type(self, precision: u8, scale: u8) -> DeltaResult<DataType> {
+        match self {
+            Self::Boolean => Ok(DataType::BOOLEAN),
+            Self::Byte => Ok(DataType::BYTE),
+            Self::Short => Ok(DataType::SHORT),
+            Self::Integer => Ok(DataType::INTEGER),
+            Self::Long => Ok(DataType::LONG),
+            Self::Float => Ok(DataType::FLOAT),
+            Self::Double => Ok(DataType::DOUBLE),
+            Self::String => Ok(DataType::STRING),
+            Self::Binary => Ok(DataType::BINARY),
+            Self::Date => Ok(DataType::DATE),
+            Self::Timestamp => Ok(DataType::TIMESTAMP),
+            Self::TimestampNtz => Ok(DataType::TIMESTAMP_NTZ),
+            Self::Decimal => Ok(DataType::Primitive(PrimitiveType::decimal(
+                precision, scale,
+            )?)),
+            Self::NonPrimitive => Err(delta_kernel::Error::generic(
+                "Non-primitive null types (struct, array, map, variant) cannot be reconstructed \
+                 from a type tag. Use opaque expressions or a schema visitor instead.",
+            )),
+        }
+    }
 }
 
 /// Visit a typed null literal expression.
 ///
 /// The `type_tag` identifies the data type (see [`NullTypeTag`]). For decimal nulls
-/// (`type_tag == 12`), `precision` and `scale` specify the decimal type parameters; they are
-/// ignored for all other types.
+/// (`type_tag == 12`), `precision` and `scale` specify the decimal type parameters; for all
+/// other types, callers should pass 0 for both.
 ///
-/// Returns an error if the type tag is unrecognized or if the decimal precision/scale is invalid.
+/// Returns an error if the type tag is unrecognized, if the tag is
+/// [`NonPrimitive`](NullTypeTag::NonPrimitive), or if the decimal precision/scale is invalid.
 #[no_mangle]
 pub extern "C" fn visit_expression_literal_null(
     state: &mut KernelExpressionVisitorState,
@@ -453,26 +563,8 @@ fn visit_expression_literal_null_impl(
     precision: u8,
     scale: u8,
 ) -> DeltaResult<usize> {
-    let data_type = match type_tag {
-        0 => DataType::BOOLEAN,
-        1 => DataType::BYTE,
-        2 => DataType::SHORT,
-        3 => DataType::INTEGER,
-        4 => DataType::LONG,
-        5 => DataType::FLOAT,
-        6 => DataType::DOUBLE,
-        7 => DataType::STRING,
-        8 => DataType::BINARY,
-        9 => DataType::DATE,
-        10 => DataType::TIMESTAMP,
-        11 => DataType::TIMESTAMP_NTZ,
-        12 => DataType::Primitive(PrimitiveType::decimal(precision, scale)?),
-        other => {
-            return Err(delta_kernel::Error::generic(format!(
-                "Unrecognized null type tag: {other}"
-            )));
-        }
-    };
+    let tag = NullTypeTag::try_from(type_tag)?;
+    let data_type = tag.to_data_type(precision, scale)?;
     Ok(wrap_expression(
         state,
         Expression::literal(Scalar::Null(data_type)),
@@ -590,4 +682,227 @@ fn visit_engine_predicate_impl(
     })?;
 
     Ok(Arc::new(pred).into())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+    use super::*;
+    use delta_kernel::expressions::{Expression, Scalar};
+    use delta_kernel::schema::{ArrayType, DataType, MapType, StructField, StructType};
+    use rstest::rstest;
+
+    // ============================================================================
+    // NullTypeTag::from_data_type
+    // ============================================================================
+
+    #[rstest]
+    #[case(DataType::BOOLEAN, NullTypeTag::Boolean, 0, 0)]
+    #[case(DataType::BYTE, NullTypeTag::Byte, 0, 0)]
+    #[case(DataType::SHORT, NullTypeTag::Short, 0, 0)]
+    #[case(DataType::INTEGER, NullTypeTag::Integer, 0, 0)]
+    #[case(DataType::LONG, NullTypeTag::Long, 0, 0)]
+    #[case(DataType::FLOAT, NullTypeTag::Float, 0, 0)]
+    #[case(DataType::DOUBLE, NullTypeTag::Double, 0, 0)]
+    #[case(DataType::STRING, NullTypeTag::String, 0, 0)]
+    #[case(DataType::BINARY, NullTypeTag::Binary, 0, 0)]
+    #[case(DataType::DATE, NullTypeTag::Date, 0, 0)]
+    #[case(DataType::TIMESTAMP, NullTypeTag::Timestamp, 0, 0)]
+    #[case(DataType::TIMESTAMP_NTZ, NullTypeTag::TimestampNtz, 0, 0)]
+    fn from_data_type_primitive(
+        #[case] dt: DataType,
+        #[case] expected_tag: NullTypeTag,
+        #[case] expected_precision: u8,
+        #[case] expected_scale: u8,
+    ) {
+        let (tag, p, s) = NullTypeTag::from_data_type(&dt);
+        assert_eq!(tag, expected_tag);
+        assert_eq!(p, expected_precision);
+        assert_eq!(s, expected_scale);
+    }
+
+    #[test]
+    fn from_data_type_decimal() {
+        let dt = DataType::decimal(18, 5).unwrap();
+        let (tag, p, s) = NullTypeTag::from_data_type(&dt);
+        assert_eq!(tag, NullTypeTag::Decimal);
+        assert_eq!(p, 18);
+        assert_eq!(s, 5);
+    }
+
+    #[test]
+    fn from_data_type_non_primitive_produces_sentinel() {
+        let struct_type = DataType::Struct(Box::new(
+            StructType::try_new(vec![StructField::not_null("a", DataType::INTEGER)]).unwrap(),
+        ));
+        assert_eq!(
+            NullTypeTag::from_data_type(&struct_type),
+            (NullTypeTag::NonPrimitive, 0, 0)
+        );
+
+        let array_type = DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, false)));
+        assert_eq!(
+            NullTypeTag::from_data_type(&array_type),
+            (NullTypeTag::NonPrimitive, 0, 0)
+        );
+
+        let map_type = DataType::Map(Box::new(MapType::new(
+            DataType::STRING,
+            DataType::INTEGER,
+            false,
+        )));
+        assert_eq!(
+            NullTypeTag::from_data_type(&map_type),
+            (NullTypeTag::NonPrimitive, 0, 0)
+        );
+
+        let variant_type = DataType::unshredded_variant();
+        assert_eq!(
+            NullTypeTag::from_data_type(&variant_type),
+            (NullTypeTag::NonPrimitive, 0, 0)
+        );
+    }
+
+    // ============================================================================
+    // NullTypeTag::to_data_type
+    // ============================================================================
+
+    #[rstest]
+    #[case(NullTypeTag::Boolean, DataType::BOOLEAN)]
+    #[case(NullTypeTag::Byte, DataType::BYTE)]
+    #[case(NullTypeTag::Short, DataType::SHORT)]
+    #[case(NullTypeTag::Integer, DataType::INTEGER)]
+    #[case(NullTypeTag::Long, DataType::LONG)]
+    #[case(NullTypeTag::Float, DataType::FLOAT)]
+    #[case(NullTypeTag::Double, DataType::DOUBLE)]
+    #[case(NullTypeTag::String, DataType::STRING)]
+    #[case(NullTypeTag::Binary, DataType::BINARY)]
+    #[case(NullTypeTag::Date, DataType::DATE)]
+    #[case(NullTypeTag::Timestamp, DataType::TIMESTAMP)]
+    #[case(NullTypeTag::TimestampNtz, DataType::TIMESTAMP_NTZ)]
+    fn to_data_type_primitive(#[case] tag: NullTypeTag, #[case] expected: DataType) {
+        assert_eq!(tag.to_data_type(0, 0).unwrap(), expected);
+    }
+
+    #[test]
+    fn to_data_type_decimal() {
+        let dt = NullTypeTag::Decimal.to_data_type(10, 2).unwrap();
+        assert_eq!(dt, DataType::decimal(10, 2).unwrap());
+    }
+
+    #[test]
+    fn to_data_type_decimal_invalid_precision_returns_error() {
+        assert!(NullTypeTag::Decimal.to_data_type(0, 0).is_err());
+    }
+
+    #[test]
+    fn to_data_type_decimal_scale_exceeds_precision_returns_error() {
+        assert!(NullTypeTag::Decimal.to_data_type(5, 10).is_err());
+    }
+
+    #[test]
+    fn to_data_type_non_primitive_returns_error() {
+        let result = NullTypeTag::NonPrimitive.to_data_type(0, 0);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("Non-primitive"), "unexpected error: {msg}");
+    }
+
+    // ============================================================================
+    // TryFrom<u8>
+    // ============================================================================
+
+    #[rstest]
+    #[case(0, NullTypeTag::Boolean)]
+    #[case(1, NullTypeTag::Byte)]
+    #[case(2, NullTypeTag::Short)]
+    #[case(3, NullTypeTag::Integer)]
+    #[case(4, NullTypeTag::Long)]
+    #[case(5, NullTypeTag::Float)]
+    #[case(6, NullTypeTag::Double)]
+    #[case(7, NullTypeTag::String)]
+    #[case(8, NullTypeTag::Binary)]
+    #[case(9, NullTypeTag::Date)]
+    #[case(10, NullTypeTag::Timestamp)]
+    #[case(11, NullTypeTag::TimestampNtz)]
+    #[case(12, NullTypeTag::Decimal)]
+    #[case(255, NullTypeTag::NonPrimitive)]
+    fn try_from_u8_valid(#[case] value: u8, #[case] expected: NullTypeTag) {
+        assert_eq!(NullTypeTag::try_from(value).unwrap(), expected);
+    }
+
+    #[rstest]
+    #[case(13)]
+    #[case(42)]
+    #[case(254)]
+    fn try_from_u8_invalid(#[case] value: u8) {
+        let result = NullTypeTag::try_from(value);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("Unrecognized null type tag"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    // ============================================================================
+    // visit_expression_literal_null_impl (error paths)
+    // ============================================================================
+
+    #[test]
+    fn visit_null_decimal_invalid_precision_returns_error() {
+        let mut state = KernelExpressionVisitorState::default();
+        assert!(visit_expression_literal_null_impl(&mut state, 12, 0, 0).is_err());
+    }
+
+    #[test]
+    fn visit_null_unrecognized_tag_returns_error() {
+        let mut state = KernelExpressionVisitorState::default();
+        assert!(visit_expression_literal_null_impl(&mut state, 13, 0, 0).is_err());
+    }
+
+    #[test]
+    fn visit_null_non_primitive_tag_returns_error() {
+        let mut state = KernelExpressionVisitorState::default();
+        assert!(visit_expression_literal_null_impl(&mut state, 255, 0, 0).is_err());
+    }
+
+    // ============================================================================
+    // Round-trip: from_data_type -> (tag as u8, p, s) -> visit_expression_literal_null_impl
+    // ============================================================================
+
+    #[rstest]
+    #[case(DataType::BOOLEAN)]
+    #[case(DataType::BYTE)]
+    #[case(DataType::SHORT)]
+    #[case(DataType::INTEGER)]
+    #[case(DataType::LONG)]
+    #[case(DataType::FLOAT)]
+    #[case(DataType::DOUBLE)]
+    #[case(DataType::STRING)]
+    #[case(DataType::BINARY)]
+    #[case(DataType::DATE)]
+    #[case(DataType::TIMESTAMP)]
+    #[case(DataType::TIMESTAMP_NTZ)]
+    fn null_type_round_trips_through_tag_encoding(#[case] data_type: DataType) {
+        let (tag, precision, scale) = NullTypeTag::from_data_type(&data_type);
+        let mut state = KernelExpressionVisitorState::default();
+        let id =
+            visit_expression_literal_null_impl(&mut state, tag as u8, precision, scale).unwrap();
+        let expr = unwrap_kernel_expression(&mut state, id).unwrap();
+        assert_eq!(expr, Expression::literal(Scalar::Null(data_type)),);
+    }
+
+    #[test]
+    fn decimal_null_round_trips_through_tag_encoding() {
+        let dt = DataType::decimal(20, 3).unwrap();
+        let (tag, precision, scale) = NullTypeTag::from_data_type(&dt);
+        assert_eq!(tag, NullTypeTag::Decimal);
+        let mut state = KernelExpressionVisitorState::default();
+        let id =
+            visit_expression_literal_null_impl(&mut state, tag as u8, precision, scale).unwrap();
+        let expr = unwrap_kernel_expression(&mut state, id).unwrap();
+        assert_eq!(expr, Expression::literal(Scalar::Null(dt)));
+    }
 }

--- a/ffi/src/test_ffi.rs
+++ b/ffi/src/test_ffi.rs
@@ -250,6 +250,7 @@ pub unsafe extern "C" fn get_simple_testing_kernel_expression() -> Handle<Shared
         Scalar::Timestamp(1234567890).into(),
         Scalar::TimestampNtz(9876543210).into(),
         Expr::null_literal(DataType::INTEGER),
+        Expr::null_literal(DataType::decimal(10, 5).unwrap()),
         Expr::binary(
             BinaryExpressionOp::Plus,
             Expr::literal(10),

--- a/ffi/src/test_ffi.rs
+++ b/ffi/src/test_ffi.rs
@@ -249,6 +249,7 @@ pub unsafe extern "C" fn get_simple_testing_kernel_expression() -> Handle<Shared
         Scalar::Date(19000).into(),
         Scalar::Timestamp(1234567890).into(),
         Scalar::TimestampNtz(9876543210).into(),
+        Expr::null_literal(DataType::INTEGER),
         Expr::binary(
             BinaryExpressionOp::Plus,
             Expr::literal(10),

--- a/ffi/tests/test-expression-visitor/expected.txt
+++ b/ffi/tests/test-expression-visitor/expected.txt
@@ -25,7 +25,7 @@ StructExpression
   Date(32)
   Binary(0000deadbeefcafe)
   Decimal(1,1,20,3)
-  Null
+  Null(Short)
   Struct
     Field: top
       Struct
@@ -153,6 +153,7 @@ StructExpression
   Date(19000)
   Timestamp(1234567890)
   TimestampNtz(9876543210)
+  Null(Integer)
   Add
     Integer(10)
     Integer(20)

--- a/ffi/tests/test-expression-visitor/expected.txt
+++ b/ffi/tests/test-expression-visitor/expected.txt
@@ -154,6 +154,7 @@ StructExpression
   Timestamp(1234567890)
   TimestampNtz(9876543210)
   Null(Integer)
+  Null(Decimal(10,5))
   Add
     Integer(10)
     Integer(20)


### PR DESCRIPTION
The FFI null literal functions previously always returned an error because type information was lost. This PR adds a type_tag discriminant (plus precision/scale for decimal) to both directions:

- kernel_visitor: visit_expression_literal_null now accepts type_tag, precision, scale and constructs Scalar::Null(DataType)
- engine_visitor: visit_literal_null now passes type_tag, precision, scale so engines can reconstruct typed nulls

A new NullTypeTag enum documents the FFI contract for type discriminants.

## What changes are proposed in this pull request?

<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

## How was this change tested?
Unit tests
