### PR TITLE
feat!: change get_create_table_builder to accept EngineSchema visitor

### DIFF
--- a/ffi/src/scan.rs
+++ b/ffi/src/scan.rs
@@ -52,13 +52,16 @@ pub struct EnginePredicate {
         extern "C" fn(predicate: *mut c_void, state: &mut KernelExpressionVisitorState) -> usize,
 }
 
-/// A schema for columns to select from the snapshot.
+/// An engine-provided schema along with a visitor function to convert it to a kernel schema.
 ///
-/// Used by [`scan`] and [`scan_builder_with_schema`] for projection pushdown or to specify
-/// metadata columns. The engine provides a pointer to its native schema representation along with
-/// a visitor function. The kernel allocates visitor state internally, which becomes the second
-/// argument to the schema visitor invocation. Thanks to this double indirection, engine and kernel
-/// each retain ownership of their respective objects with no need to coordinate memory lifetimes.
+/// Used by [`scan`] and [`scan_builder_with_schema`] for projection pushdown, and by
+/// [`get_create_table_builder`] to specify the table schema at creation time. The engine
+/// provides a pointer to its native schema representation along with a visitor function. The
+/// kernel allocates visitor state internally, which becomes the second argument to the schema
+/// visitor invocation. Thanks to this double indirection, engine and kernel each retain
+/// ownership of their respective objects with no need to coordinate memory lifetimes.
+///
+/// [`get_create_table_builder`]: crate::transaction::get_create_table_builder
 #[repr(C)]
 pub struct EngineSchema {
     pub schema: *mut c_void,

--- a/ffi/src/scan.rs
+++ b/ffi/src/scan.rs
@@ -132,7 +132,7 @@ pub unsafe extern "C" fn scan(
     snapshot: Handle<SharedSnapshot>,
     engine: Handle<SharedExternEngine>,
     predicate: Option<&mut EnginePredicate>,
-    schema: Option<&mut EngineSchema>,
+    schema: Option<&EngineSchema>,
 ) -> ExternResult<Handle<SharedScan>> {
     let snapshot = unsafe { snapshot.clone_as_arc() };
     scan_impl(snapshot, predicate, schema).into_extern_result(&engine.as_ref())
@@ -162,7 +162,7 @@ fn apply_predicate(
 /// Decode an [`EngineSchema`] and apply it as a column projection to a [`ScanBuilder`].
 ///
 /// Returns an error if the schema visitor produces an invalid schema.
-fn apply_schema(builder: ScanBuilder, schema: &mut EngineSchema) -> DeltaResult<ScanBuilder> {
+fn apply_schema(builder: ScanBuilder, schema: &EngineSchema) -> DeltaResult<ScanBuilder> {
     let mut visitor_state = KernelSchemaVisitorState::default();
     let schema_id = (schema.visitor)(schema.schema, &mut visitor_state);
     let schema = extract_kernel_schema(&mut visitor_state, schema_id)?;
@@ -173,7 +173,7 @@ fn apply_schema(builder: ScanBuilder, schema: &mut EngineSchema) -> DeltaResult<
 fn scan_impl(
     snapshot: SnapshotRef,
     predicate: Option<&mut EnginePredicate>,
-    schema: Option<&mut EngineSchema>,
+    schema: Option<&EngineSchema>,
 ) -> DeltaResult<Handle<SharedScan>> {
     let mut scan_builder = snapshot.scan_builder();
     if let Some(predicate) = predicate {
@@ -245,7 +245,7 @@ pub unsafe extern "C" fn scan_builder_with_predicate(
 pub unsafe extern "C" fn scan_builder_with_schema(
     builder: Handle<ExclusiveScanBuilder>,
     engine: Handle<SharedExternEngine>,
-    schema: &mut EngineSchema,
+    schema: &EngineSchema,
 ) -> ExternResult<Handle<ExclusiveScanBuilder>> {
     let engine = unsafe { engine.as_ref() };
     scan_builder_with_schema_impl(builder, schema).into_extern_result(&engine)
@@ -253,7 +253,7 @@ pub unsafe extern "C" fn scan_builder_with_schema(
 
 fn scan_builder_with_schema_impl(
     builder: Handle<ExclusiveScanBuilder>,
-    schema: &mut EngineSchema,
+    schema: &EngineSchema,
 ) -> DeltaResult<Handle<ExclusiveScanBuilder>> {
     let builder = unsafe { builder.into_inner() };
     Ok(Box::new(apply_schema(*builder, schema)?).into())
@@ -824,7 +824,7 @@ mod scan_builder_tests {
             .await
             .unwrap();
         let builder = unsafe { scan_builder(snapshot.shallow_copy()) };
-        let mut schema_arg = EngineSchema {
+        let schema_arg = EngineSchema {
             schema: std::ptr::null_mut(),
             visitor: visit_id_only_schema,
         };
@@ -832,7 +832,7 @@ mod scan_builder_tests {
             ok_or_panic(scan_builder_with_schema(
                 builder,
                 engine.shallow_copy(),
-                &mut schema_arg,
+                &schema_arg,
             ))
         };
         let scan = unsafe { ok_or_panic(scan_builder_build(builder, engine.shallow_copy())) };
@@ -864,7 +864,7 @@ mod scan_builder_tests {
                 &mut predicate,
             ))
         };
-        let mut schema_arg = EngineSchema {
+        let schema_arg = EngineSchema {
             schema: std::ptr::null_mut(),
             visitor: visit_id_only_schema,
         };
@@ -872,7 +872,7 @@ mod scan_builder_tests {
             ok_or_panic(scan_builder_with_schema(
                 builder,
                 engine.shallow_copy(),
-                &mut schema_arg,
+                &schema_arg,
             ))
         };
         let scan = unsafe { ok_or_panic(scan_builder_build(builder, engine.shallow_copy())) };
@@ -911,7 +911,7 @@ mod scan_builder_tests {
             .await
             .unwrap();
         let builder = unsafe { scan_builder(snapshot.shallow_copy()) };
-        let mut schema_arg = EngineSchema {
+        let schema_arg = EngineSchema {
             schema: std::ptr::null_mut(),
             visitor: visit_id_only_schema,
         };
@@ -919,7 +919,7 @@ mod scan_builder_tests {
             ok_or_panic(scan_builder_with_schema(
                 builder,
                 engine.shallow_copy(),
-                &mut schema_arg,
+                &schema_arg,
             ))
         };
         let mut predicate = EnginePredicate {
@@ -952,12 +952,12 @@ mod scan_builder_tests {
             .await
             .unwrap();
         let builder = unsafe { scan_builder(snapshot.shallow_copy()) };
-        let mut schema_arg = EngineSchema {
+        let schema_arg = EngineSchema {
             schema: std::ptr::null_mut(),
             visitor: visit_invalid_schema_not_struct,
         };
         let result =
-            unsafe { scan_builder_with_schema(builder, engine.shallow_copy(), &mut schema_arg) };
+            unsafe { scan_builder_with_schema(builder, engine.shallow_copy(), &schema_arg) };
         assert!(
             matches!(result, ExternResult::Err(_)),
             "expected ExternResult::Err for invalid schema"

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -6,10 +6,12 @@ use std::sync::Arc;
 
 use crate::error::{ExternResult, IntoExternResult};
 use crate::handle::Handle;
+use crate::scan::EngineSchema;
+use crate::schema_visitor::{extract_kernel_schema, KernelSchemaVisitorState};
 use crate::{unwrap_and_parse_path_as_url, TryFromStringSlice};
 use crate::{DeltaResult, ExternEngine, Snapshot, Url};
 use crate::{ExclusiveEngineData, SharedExternEngine};
-use crate::{KernelStringSlice, SharedSchema, SharedSnapshot};
+use crate::{KernelStringSlice, SharedSnapshot};
 use delta_kernel::committer::{Committer, FileSystemCommitter};
 use delta_kernel::engine_data::FilteredEngineData;
 use delta_kernel::transaction::create_table::{
@@ -366,6 +368,10 @@ pub struct ExclusiveCreateTableBuilder;
 
 /// Create a new [`CreateTableTransactionBuilder`] for creating a Delta table at the given path.
 ///
+/// The schema is provided via the engine's visitor callback pattern ([`EngineSchema`]): the
+/// kernel allocates a [`KernelSchemaVisitorState`], calls the engine's visitor function to
+/// populate it via `visit_field_*` downcalls, then extracts the final schema.
+///
 /// The returned builder can be configured with [`create_table_builder_with_table_property`]
 /// before building with [`create_table_builder_build`]. The engine is only used for error
 /// reporting at this stage.
@@ -373,29 +379,30 @@ pub struct ExclusiveCreateTableBuilder;
 /// # Safety
 ///
 /// Caller is responsible for passing a valid `path`, `schema`, `engine_info`, and `engine`.
-/// Does NOT consume the `schema` handle -- the caller is still responsible for freeing it.
 #[no_mangle]
 pub unsafe extern "C" fn get_create_table_builder(
     path: KernelStringSlice,
-    schema: Handle<SharedSchema>,
+    schema: &EngineSchema,
     engine_info: KernelStringSlice,
     engine: Handle<SharedExternEngine>,
 ) -> ExternResult<Handle<ExclusiveCreateTableBuilder>> {
     let engine = unsafe { engine.as_ref() };
     let path = unsafe { TryFromStringSlice::try_from_slice(&path) };
     let info = unsafe { TryFromStringSlice::try_from_slice(&engine_info) };
-    let schema = unsafe { schema.clone_as_arc() };
     get_create_table_builder_impl(path, schema, info).into_extern_result(&engine)
 }
 
 fn get_create_table_builder_impl(
     path: DeltaResult<&str>,
-    schema: Arc<delta_kernel::schema::Schema>,
+    schema: &EngineSchema,
     engine_info: DeltaResult<&str>,
 ) -> DeltaResult<Handle<ExclusiveCreateTableBuilder>> {
+    let mut visitor_state = KernelSchemaVisitorState::default();
+    let schema_id = (schema.visitor)(schema.schema, &mut visitor_state);
+    let schema = extract_kernel_schema(&mut visitor_state, schema_id)?;
     let builder = delta_kernel::transaction::create_table::create_table(
         path?,
-        schema,
+        Arc::new(schema),
         engine_info?.to_string(),
     );
     Ok(Box::new(builder).into())
@@ -578,11 +585,16 @@ mod tests {
     };
     use delta_kernel_ffi::tests::get_default_engine;
 
+    use crate::schema_visitor::{
+        visit_field_integer, visit_field_long, visit_field_string, visit_field_struct,
+    };
     use crate::{free_engine, free_schema, free_snapshot, kernel_string_slice};
     use crate::{logical_schema, version};
     use write_context::{
         free_write_context, get_unpartitioned_write_context, get_write_path, get_write_schema,
     };
+
+    use std::os::raw::c_void;
 
     use test_utils::{set_json_value, setup_test_tables, test_read};
 
@@ -1301,6 +1313,57 @@ mod tests {
         Ok(())
     }
 
+    /// Schema visitor callback for tests: encodes the schema stored in the `schema` pointer
+    /// (which points to a `Vec<StructField>`) into the kernel's `KernelSchemaVisitorState`.
+    /// Only supports primitive fields (no nested structs/arrays/maps) -- sufficient for tests.
+    extern "C" fn visit_test_schema(
+        schema_ptr: *mut c_void,
+        state: &mut KernelSchemaVisitorState,
+    ) -> usize {
+        let fields = unsafe { &*(schema_ptr as *const Vec<StructField>) };
+        let field_ids: Vec<usize> = fields
+            .iter()
+            .map(|field| {
+                let name = field.name.as_str();
+                let nullable = field.nullable;
+                unsafe {
+                    ok_or_panic(match field.data_type {
+                        DataType::INTEGER => visit_field_integer(
+                            state,
+                            kernel_string_slice!(name),
+                            nullable,
+                            allocate_err,
+                        ),
+                        DataType::STRING => visit_field_string(
+                            state,
+                            kernel_string_slice!(name),
+                            nullable,
+                            allocate_err,
+                        ),
+                        DataType::LONG => visit_field_long(
+                            state,
+                            kernel_string_slice!(name),
+                            nullable,
+                            allocate_err,
+                        ),
+                        _ => panic!("Unsupported test field type: {:?}", field.data_type),
+                    })
+                }
+            })
+            .collect();
+        let root = "schema";
+        unsafe {
+            ok_or_panic(visit_field_struct(
+                state,
+                kernel_string_slice!(root),
+                field_ids.as_ptr(),
+                field_ids.len(),
+                false,
+                allocate_err,
+            ))
+        }
+    }
+
     /// Create a [`CreateTableTransactionBuilder`] handle via the FFI, using the given schema
     /// fields. Returns `(table_path, engine_handle, builder_handle)`. The caller is responsible
     /// for freeing/consuming the engine and builder handles.
@@ -1313,20 +1376,20 @@ mod tests {
         Handle<ExclusiveCreateTableBuilder>,
     ) {
         let table_path = tmp_dir.path().to_str().unwrap().to_string();
-        let schema = Arc::new(StructType::try_new(fields).unwrap());
         let engine = get_default_engine(&table_path);
-        let schema_handle: Handle<SharedSchema> = schema.into();
         let engine_info = "test-engine/1.0";
+        let schema_arg = EngineSchema {
+            schema: &fields as *const Vec<StructField> as *mut c_void,
+            visitor: visit_test_schema,
+        };
         let builder = ok_or_panic(unsafe {
             get_create_table_builder(
                 kernel_string_slice!(table_path),
-                schema_handle.shallow_copy(),
+                &schema_arg,
                 kernel_string_slice!(engine_info),
                 engine.shallow_copy(),
             )
         });
-        // get_create_table_builder does NOT consume the schema handle -- free it
-        unsafe { free_schema(schema_handle) };
         (table_path, engine, builder)
     }
 
@@ -1558,26 +1621,27 @@ mod tests {
         tmp_dir: &tempfile::TempDir,
     ) -> Result<(String, Handle<SharedExternEngine>), Box<dyn std::error::Error>> {
         let table_path = tmp_dir.path().to_str().unwrap();
-        let schema = Arc::new(StructType::try_new(vec![
+        let fields = vec![
             StructField::nullable("number", DataType::INTEGER),
             StructField::nullable("value", DataType::STRING),
-        ])?);
+        ];
 
         let engine = get_default_engine(table_path);
-        let schema_handle: Handle<SharedSchema> = schema.into();
 
         // Create the table
         let engine_info = "test-engine/1.0";
+        let schema_arg = EngineSchema {
+            schema: &fields as *const Vec<StructField> as *mut c_void,
+            visitor: visit_test_schema,
+        };
         let builder = ok_or_panic(unsafe {
             get_create_table_builder(
                 kernel_string_slice!(table_path),
-                schema_handle.shallow_copy(),
+                &schema_arg,
                 kernel_string_slice!(engine_info),
                 engine.shallow_copy(),
             )
         });
-        // get_create_table_builder does NOT consume the schema handle -- free it
-        unsafe { free_schema(schema_handle) };
         build_and_commit(builder, &engine);
 
         // Write a parquet file and commit it


### PR DESCRIPTION
## Summary
- Replace `Handle<SharedSchema>` parameter with `&EngineSchema` in `get_create_table_builder`, matching the visitor callback pattern already used by `scan_builder_with_schema`
- The kernel now allocates a `KernelSchemaVisitorState`, calls the engine's visitor function to populate it via `visit_field_*` downcalls, then extracts the final schema with `extract_kernel_schema`
- This enables FFI consumers to encode schemas using the same visitor pattern used for scan projection pushdown, eliminating the need for `schema_from_json` as the schema bridge

## Test plan
- [x] All 5 existing `test_create_table_*` tests updated and passing
- [x] Full FFI test suite (62 tests) passing
- [x] `cargo clippy` clean