### PR TITLE
feat: add AlterTable framework with add_column support

### DIFF
--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -344,6 +344,18 @@ impl Metadata {
         TableProperties::from(self.configuration.iter())
     }
 
+    /// Returns a new Metadata with the schema replaced, preserving all other fields.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if schema serialization fails.
+    pub(crate) fn with_schema(self, schema: SchemaRef) -> DeltaResult<Self> {
+        Ok(Self {
+            schema_string: serde_json::to_string(&schema)?,
+            ..self
+        })
+    }
+
     #[cfg(test)]
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new_unchecked(

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -243,9 +243,7 @@ impl Metadata {
     /// # Errors
     ///
     /// Returns an error if there are any metadata columns in the schema.
-    // TODO: remove allow(dead_code) after we use this API in CREATE TABLE, etc.
     #[internal_api]
-    #[allow(dead_code)]
     pub(crate) fn try_new(
         name: Option<String>,
         description: Option<String>,

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -194,10 +194,6 @@ pub mod engine;
 /// Delta table version is 8 byte unsigned int
 pub type Version = u64;
 
-/// Sentinel version indicating a pre-commit state (table does not exist yet).
-/// Used for create-table transactions before the first commit.
-pub const PRE_COMMIT_VERSION: Version = u64::MAX;
-
 pub type FileSize = u64;
 pub type FileIndex = u64;
 

--- a/kernel/src/log_segment.rs
+++ b/kernel/src/log_segment.rs
@@ -22,7 +22,7 @@ use crate::schema::{DataType, SchemaRef, StructField, StructType, ToSchema as _}
 use crate::utils::require;
 use crate::{
     DeltaResult, Engine, Error, Expression, FileMeta, Predicate, PredicateRef, RowVisitor,
-    StorageHandler, Version, PRE_COMMIT_VERSION,
+    StorageHandler, Version,
 };
 use delta_kernel_derive::internal_api;
 
@@ -155,20 +155,38 @@ fn schema_to_is_not_null_predicate(schema: &StructType) -> Option<PredicateRef> 
 }
 
 impl LogSegment {
-    /// Creates a synthetic LogSegment for pre-commit transactions (e.g., create-table).
-    /// The sentinel version PRE_COMMIT_VERSION indicates no version exists yet on disk.
-    /// This is used to construct a pre-commit snapshot that provides table configuration
-    /// (protocol, metadata, schema) for operations like CTAS.
-    #[allow(dead_code)] // Used by create_table module
-    pub(crate) fn for_pre_commit(log_root: Url) -> Self {
-        use crate::PRE_COMMIT_VERSION;
-        Self {
-            end_version: PRE_COMMIT_VERSION,
+    /// Creates a LogSegment for a newly created table at version 0.
+    /// The `commit_file` is the parsed commit file for version 0.
+    pub(crate) fn new_for_version_zero(
+        log_root: Url,
+        commit_file: ParsedLogPath,
+    ) -> DeltaResult<Self> {
+        require!(
+            commit_file.version == 0,
+            crate::Error::internal_error(format!(
+                "new_for_version_zero called with version {}",
+                commit_file.version
+            ))
+        );
+        require!(
+            commit_file.is_commit(),
+            crate::Error::internal_error(format!(
+                "new_for_version_zero called with non-commit file type: {:?}",
+                commit_file.file_type
+            ))
+        );
+        Ok(Self {
+            end_version: commit_file.version,
             checkpoint_version: None,
             log_root,
             last_checkpoint_metadata: None,
-            listed: LogSegmentFiles::default(),
-        }
+            listed: LogSegmentFiles {
+                max_published_version: Some(commit_file.version),
+                latest_commit_file: Some(commit_file.clone()),
+                ascending_commit_files: vec![commit_file],
+                ..Default::default()
+            },
+        })
     }
 
     #[internal_api]
@@ -1100,11 +1118,7 @@ impl LogSegment {
     }
 
     /// How many commits since a checkpoint, according to this log segment.
-    /// Returns 0 for pre-commit snapshots (where end_version is PRE_COMMIT_VERSION).
     pub(crate) fn commits_since_checkpoint(&self) -> u64 {
-        if self.end_version == PRE_COMMIT_VERSION {
-            return 0;
-        }
         // we can use 0 as the checkpoint version if there is no checkpoint since `end_version - 0`
         // is the correct number of commits since a checkpoint if there are no checkpoints
         let checkpoint_version = self.checkpoint_version.unwrap_or(0);
@@ -1113,11 +1127,7 @@ impl LogSegment {
     }
 
     /// How many commits since a log-compaction or checkpoint, according to this log segment.
-    /// Returns 0 for pre-commit snapshots (where end_version is PRE_COMMIT_VERSION).
     pub(crate) fn commits_since_log_compaction_or_checkpoint(&self) -> u64 {
-        if self.end_version == PRE_COMMIT_VERSION {
-            return 0;
-        }
         // Annoyingly we have to search all the compaction files to determine this, because we only
         // sort by start version, so technically the max end version could be anywhere in the vec.
         // We can return 0 in the case there is no compaction since end_version - 0 is the correct

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -675,6 +675,18 @@ impl Snapshot {
         Transaction::try_new_existing_table(self, committer, engine)
     }
 
+    /// Creates a builder for altering this table's schema.
+    ///
+    /// The returned builder allows chaining schema evolution operations (such as adding columns)
+    /// before building an [`AlterTableTransaction`] that can be committed.
+    ///
+    /// [`AlterTableTransaction`]: crate::transaction::alter_table::AlterTableTransaction
+    pub fn alter_table(
+        self: Arc<Self>,
+    ) -> crate::transaction::builder::alter_table::AlterTableTransactionBuilder {
+        crate::transaction::builder::alter_table::AlterTableTransactionBuilder::new(self)
+    }
+
     /// Fetch the latest version of the provided `application_id` for this snapshot. Filters the
     /// txn based on the delta.setTransactionRetentionDuration property and lastUpdated.
     ///

--- a/kernel/src/snapshot.rs
+++ b/kernel/src/snapshot.rs
@@ -408,15 +408,12 @@ impl Snapshot {
     /// producing a post-commit snapshot without a full log replay from storage.
     ///
     /// The `crc_delta` captures the CRC-relevant changes from the committed transaction
-    /// (file stats, domain metadata, ICT, etc.). If the pre-commit snapshot had a loaded CRC
-    /// at its version, the delta is applied to produce a precomputed in-memory CRC for the new
-    /// version -- this CRC contains all important table metadata (protocol, metadata, domain
-    /// metadata, set transactions, ICT) and avoids re-reading them from storage. CREATE TABLE
-    /// always produces a CRC at v0. If no CRC was available on the pre-commit snapshot, the
-    /// existing lazy CRC is carried forward unchanged.
+    /// (file stats, domain metadata, ICT, etc.). If this snapshot had a loaded CRC at its
+    /// version, the delta is applied to produce a precomputed in-memory CRC for the new
+    /// version -- this avoids re-reading metadata from storage. If no CRC was available, the
+    /// existing lazy CRC is carried forward unchanged. CREATE TABLE handles CRC construction
+    /// separately in `Transaction::into_committed`.
     ///
-    /// TODO: Handle Protocol changes in CrcDelta (when Kernel-RS supports protocol changes)
-    /// TODO: Handle Metadata changes in CrcDelta (when Kernel-RS supports metadata changes)
     pub(crate) fn new_post_commit(
         &self,
         commit: ParsedLogPath,
@@ -440,8 +437,12 @@ impl Snapshot {
             ))
         );
 
-        let new_table_configuration =
-            TableConfiguration::new_post_commit(self.table_configuration(), new_version);
+        let new_table_configuration = TableConfiguration::new_post_commit(
+            self.table_configuration(),
+            new_version,
+            crc_delta.metadata.clone(),
+            crc_delta.protocol.clone(),
+        )?;
 
         let new_log_segment = self.log_segment.new_with_commit_appended(commit)?;
 
@@ -459,17 +460,14 @@ impl Snapshot {
     /// For CREATE TABLE, builds a fresh CRC from the `crc_delta`. For existing tables, applies
     /// the `crc_delta` to the current CRC if loaded, otherwise carries forward the existing lazy CRC.
     fn compute_post_commit_crc(&self, new_version: Version, crc_delta: CrcDelta) -> Arc<LazyCrc> {
-        let crc = if self.version() == crate::PRE_COMMIT_VERSION {
-            crc_delta.into_crc_for_version_zero()
-        } else {
-            self.lazy_crc
-                .get_if_loaded_at_version(self.version())
-                .map(|base| {
-                    let mut crc = base.as_ref().clone();
-                    crc.apply(crc_delta);
-                    crc
-                })
-        };
+        let crc = self
+            .lazy_crc
+            .get_if_loaded_at_version(self.version())
+            .map(|base| {
+                let mut crc = base.as_ref().clone();
+                crc.apply(crc_delta);
+                crc
+            });
 
         match crc {
             Some(c) => Arc::new(LazyCrc::new_precomputed(c, new_version)),

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -202,17 +202,18 @@ impl TableConfiguration {
     /// Creates a new [`TableConfiguration`] representing the table configuration immediately
     /// after a commit.
     ///
-    /// This method takes a pre-commit table configuration and produces a post-commit
-    /// configuration at the committed version. This allows immediate use of the new table
-    /// configuration without re-reading metadata from storage.
-    ///
-    /// TODO: Take in Protocol (when Kernel-RS supports protocol changes)
-    /// TODO: Take in Metadata (when Kernel-RS supports metadata changes)
-    pub(crate) fn new_post_commit(table_configuration: &Self, new_version: Version) -> Self {
-        Self {
-            version: new_version,
-            ..table_configuration.clone()
-        }
+    /// This method takes the current table configuration and produces a post-commit
+    /// configuration at the committed version. If the commit included new Protocol or Metadata
+    /// actions (e.g. CREATE TABLE or ALTER TABLE), those are passed in and the configuration
+    /// is rebuilt with full validation. Otherwise the existing configuration is cloned with
+    /// only the version updated.
+    pub(crate) fn new_post_commit(
+        table_configuration: &Self,
+        new_version: Version,
+        new_metadata: Option<Metadata>,
+        new_protocol: Option<Protocol>,
+    ) -> DeltaResult<Self> {
+        Self::try_new_from(table_configuration, new_metadata, new_protocol, new_version)
     }
 
     /// Generates the expected schema for file statistics.

--- a/kernel/src/transaction/alter_table.rs
+++ b/kernel/src/transaction/alter_table.rs
@@ -1,0 +1,101 @@
+//! Alter table transaction types and constructor.
+//!
+//! This module defines the [`AlterTableTransaction`] type alias and the
+//! [`try_new_alter_table`](AlterTableTransaction::try_new_alter_table) constructor.
+//! The builder logic lives in [`builder::alter_table`](super::builder::alter_table).
+
+#![allow(unreachable_pub)]
+
+use std::marker::PhantomData;
+
+use crate::committer::Committer;
+use crate::snapshot::SnapshotRef;
+use crate::table_configuration::TableConfiguration;
+use crate::transaction::{AlterTable, Transaction};
+use crate::utils::current_time_ms;
+use crate::DeltaResult;
+
+/// A type alias for alter-table (schema evolution) transactions.
+///
+/// This provides a restricted API surface that only exposes operations valid during schema
+/// evolution. Data file operations are not available at compile time because `AlterTable`
+/// does not implement [`SupportsDataFiles`](super::SupportsDataFiles).
+///
+/// # Operations NOT available on alter-table transactions
+///
+/// - **`add_files()`** -- Cannot add data files in a metadata-only commit.
+/// - **`remove_files()`** -- Cannot remove data files in a metadata-only commit.
+/// - **`get_write_context()`** -- No data files to write.
+/// - **`stats_schema()`** / **`stats_columns()`** -- No data files needing stats.
+/// - **`update_deletion_vectors()`** -- Deletion vectors require data file operations.
+/// - **`with_blind_append()`** -- Not a data append.
+///
+/// ```compile_fail,E0599
+/// fn cannot_add_files(txn: &mut delta_kernel::transaction::alter_table::AlterTableTransaction) {
+///     txn.add_files(todo!());
+/// }
+/// ```
+///
+/// ```compile_fail,E0599
+/// fn cannot_get_write_context(txn: &delta_kernel::transaction::alter_table::AlterTableTransaction) {
+///     let _ = txn.get_write_context();
+/// }
+/// ```
+///
+/// The builder enforces at least one operation before `build()` via the type-state pattern:
+///
+/// ```compile_fail,E0599
+/// fn cannot_build_without_operations(
+///     builder: delta_kernel::transaction::builder::alter_table::AlterTableTransactionBuilder,
+/// ) {
+///     let _ = builder.build(todo!(), todo!());
+/// }
+/// ```
+pub type AlterTableTransaction = Transaction<AlterTable>;
+
+impl AlterTableTransaction {
+    /// Create a new transaction for altering a table's schema. Produces a metadata-only commit
+    /// that emits an updated Metadata action with the evolved schema.
+    ///
+    /// The `effective_table_config` is the evolved table configuration (new schema, same
+    /// protocol). The `read_snapshot` provides the pre-commit state for conflict detection.
+    ///
+    /// This is typically called via `AlterTableTransactionBuilder::build()` rather than directly.
+    pub(crate) fn try_new_alter_table(
+        read_snapshot: SnapshotRef,
+        effective_table_config: TableConfiguration,
+        committer: Box<dyn Committer>,
+    ) -> DeltaResult<Self> {
+        let span = tracing::info_span!(
+            "txn",
+            path = %read_snapshot.table_root(),
+            read_version = read_snapshot.version(),
+            operation = "ALTER TABLE",
+        );
+
+        Ok(Transaction {
+            span,
+            read_snapshot: Some(read_snapshot),
+            effective_table_config,
+            should_emit_protocol: false,
+            should_emit_metadata: true,
+            committer,
+            operation: Some("ALTER TABLE".to_string()),
+            engine_info: None,
+            add_files_metadata: vec![],
+            remove_files_metadata: vec![],
+            set_transactions: vec![],
+            commit_timestamp: current_time_ms()?,
+            user_domain_metadata_additions: vec![],
+            system_domain_metadata_additions: vec![],
+            user_domain_removals: vec![],
+            data_change: false,
+            shared_write_state: std::sync::OnceLock::new(),
+            engine_commit_info: None,
+            is_blind_append: false,
+            dv_matched_files: vec![],
+            physical_clustering_columns: None,
+            _state: PhantomData,
+        })
+    }
+}

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -1,0 +1,128 @@
+//! Builder for ALTER TABLE (schema evolution) transactions.
+//!
+//! This module contains [`AlterTableTransactionBuilder`], which uses a type-state pattern to
+//! enforce valid combinations of schema operations at compile time.
+//!
+//! # Type States
+//!
+//! - [`Ready`]: Initial state. Operations are available, but `build()` is not (at least one
+//!   operation is required).
+//! - [`Modifying`]: After `add_column`. Can chain more `add_column` calls, and `build()` is
+//!   available.
+
+#![allow(unreachable_pub)]
+
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use crate::committer::Committer;
+use crate::schema::StructField;
+use crate::snapshot::SnapshotRef;
+use crate::table_configuration::TableConfiguration;
+use crate::table_features::Operation;
+use crate::transaction::alter_table::AlterTableTransaction;
+use crate::transaction::schema_evolution::{
+    apply_schema_operations, SchemaEvolutionResult, SchemaOperation,
+};
+use crate::{DeltaResult, Engine};
+
+/// Initial state: operations available, `build()` is not.
+pub struct Ready;
+
+/// State after at least one operation has been added. `build()` is available.
+pub struct Modifying;
+
+/// Builder for constructing an [`AlterTableTransaction`] with schema evolution operations.
+///
+/// Uses a type-state pattern to enforce valid operation chaining at compile time.
+pub struct AlterTableTransactionBuilder<S = Ready> {
+    snapshot: SnapshotRef,
+    operations: Vec<SchemaOperation>,
+    _state: PhantomData<S>,
+}
+
+impl<S> AlterTableTransactionBuilder<S> {
+    fn transition<T>(self) -> AlterTableTransactionBuilder<T> {
+        AlterTableTransactionBuilder {
+            snapshot: self.snapshot,
+            operations: self.operations,
+            _state: PhantomData,
+        }
+    }
+}
+
+impl AlterTableTransactionBuilder<Ready> {
+    /// Create a new builder from a snapshot.
+    pub(crate) fn new(snapshot: SnapshotRef) -> Self {
+        AlterTableTransactionBuilder {
+            snapshot,
+            operations: Vec::new(),
+            _state: PhantomData,
+        }
+    }
+
+    /// Add a new top-level column to the table schema.
+    ///
+    /// The field must not already exist in the schema. The field must be nullable because existing
+    /// data files do not contain this column and will read NULL for it.
+    pub fn add_column(mut self, field: StructField) -> AlterTableTransactionBuilder<Modifying> {
+        self.operations.push(SchemaOperation::AddColumn { field });
+        self.transition()
+    }
+}
+
+impl AlterTableTransactionBuilder<Modifying> {
+    /// Add a new top-level nullable column to the table schema.
+    pub fn add_column(mut self, field: StructField) -> Self {
+        self.operations.push(SchemaOperation::AddColumn { field });
+        self
+    }
+
+    /// Validate and apply schema operations, then build the [`AlterTableTransaction`].
+    ///
+    /// This method:
+    /// 1. Validates the table supports writes
+    /// 2. Applies each operation sequentially against the evolving schema
+    /// 3. Constructs new Metadata action with evolved schema
+    /// 4. Builds the new configuration via [`TableConfiguration::try_new`]
+    /// 5. Creates the transaction
+    ///
+    /// # Errors
+    ///
+    /// - Any individual operation fails validation (see per-method errors above)
+    /// - Table does not support writes (unsupported features)
+    /// - TableConfiguration validation fails on the evolved state
+    pub fn build(
+        self,
+        _engine: &dyn Engine, // used by later operations (e.g., drop_column reads clustering columns)
+        committer: Box<dyn Committer>,
+    ) -> DeltaResult<AlterTableTransaction> {
+        let table_config = self.snapshot.table_configuration();
+
+        // Validate the table supports writes
+        table_config.ensure_operation_supported(Operation::Write)?;
+
+        let schema = Arc::unwrap_or_clone(table_config.logical_schema());
+
+        // Apply schema operations
+        let SchemaEvolutionResult {
+            schema: evolved_schema,
+        } = apply_schema_operations(schema, &self.operations)?;
+
+        // Build evolved metadata with new schema
+        let evolved_metadata = table_config
+            .metadata()
+            .clone()
+            .with_schema(evolved_schema)?;
+
+        // Build evolved table configuration
+        let evolved_table_config = TableConfiguration::try_new(
+            evolved_metadata,
+            table_config.protocol().clone(),
+            table_config.table_root().clone(),
+            table_config.version(),
+        )?;
+
+        AlterTableTransaction::try_new_alter_table(self.snapshot, evolved_table_config, committer)
+    }
+}

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -16,10 +16,8 @@ use crate::actions::{DomainMetadata, Metadata, Protocol};
 use crate::clustering::{create_clustering_domain_metadata, validate_clustering_columns};
 use crate::committer::Committer;
 use crate::expressions::ColumnName;
-use crate::log_segment::LogSegment;
 use crate::schema::variant_utils::schema_contains_variant_type;
 use crate::schema::{DataType, SchemaRef, StructType};
-use crate::snapshot::Snapshot;
 use crate::table_configuration::TableConfiguration;
 use crate::table_features::{
     assign_column_mapping_metadata, get_any_level_column_physical_name,
@@ -37,7 +35,7 @@ use crate::transaction::create_table::CreateTableTransaction;
 use crate::transaction::data_layout::DataLayout;
 use crate::transaction::Transaction;
 use crate::utils::{current_time_ms, try_parse_uri};
-use crate::{DeltaResult, Engine, Error, StorageHandler, PRE_COMMIT_VERSION};
+use crate::{DeltaResult, Engine, Error, StorageHandler};
 
 /// Table features allowed to be enabled via `delta.feature.*=supported` during CREATE TABLE.
 ///
@@ -745,15 +743,12 @@ impl CreateTableTransactionBuilder {
             validated.properties,
         )?;
 
-        // Create pre-commit snapshot from protocol/metadata
-        let log_root = table_url.join("_delta_log/")?;
-        let log_segment = LogSegment::for_pre_commit(log_root);
-        let table_configuration =
-            TableConfiguration::try_new(metadata, protocol, table_url, PRE_COMMIT_VERSION)?;
+        // Build TableConfiguration directly for the new table
+        let table_configuration = TableConfiguration::try_new(metadata, protocol, table_url, 0)?;
 
-        // Create Transaction<CreateTable> with pre-commit snapshot
+        // Create Transaction<CreateTable> with the effective table configuration
         Transaction::try_new_create_table(
-            Arc::new(Snapshot::new(log_segment, table_configuration)),
+            table_configuration,
             self.engine_info,
             committer,
             data_layout_result.system_domain_metadata,

--- a/kernel/src/transaction/builder/mod.rs
+++ b/kernel/src/transaction/builder/mod.rs
@@ -5,4 +5,5 @@
 // and for tests. Also allow dead_code since these are used by integration tests.
 #![allow(unreachable_pub, dead_code)]
 
+pub mod alter_table;
 pub mod create_table;

--- a/kernel/src/transaction/create_table.rs
+++ b/kernel/src/transaction/create_table.rs
@@ -38,7 +38,7 @@ use crate::actions::DomainMetadata;
 use crate::committer::Committer;
 use crate::expressions::ColumnName;
 use crate::schema::SchemaRef;
-use crate::snapshot::SnapshotRef;
+use crate::table_configuration::TableConfiguration;
 use crate::transaction::{CreateTable, Transaction};
 use crate::utils::current_time_ms;
 use crate::DeltaResult;
@@ -134,31 +134,29 @@ impl CreateTableTransaction {
     /// Create a new transaction for creating a new table. This is used when the table doesn't
     /// exist yet and we need to create it with Protocol and Metadata actions.
     ///
-    /// The `pre_commit_snapshot` is a synthetic snapshot created from the protocol and metadata
-    /// that will be committed. It uses `PRE_COMMIT_VERSION` as a sentinel to indicate no
-    /// version exists yet on disk.
+    /// The `effective_table_config` is the table configuration that will be committed (protocol,
+    /// metadata, schema).
     ///
     /// This is typically called via `CreateTableTransactionBuilder::build()` rather than directly.
     pub(crate) fn try_new_create_table(
-        pre_commit_snapshot: SnapshotRef,
+        effective_table_config: TableConfiguration,
         engine_info: String,
         committer: Box<dyn Committer>,
         system_domain_metadata: Vec<DomainMetadata>,
         clustering_columns: Option<Vec<ColumnName>>,
     ) -> DeltaResult<Self> {
-        // TODO(sanuj) Today transactions expect a read snapshot to be passed in and we pass
-        // in the pre_commit_snapshot for CREATE. To support other operations such as ALTERs
-        // there might be cleaner alternatives which can clearly disambiguate b/w a snapshot
-        // the was read vs the effective snapshot we will use for the commit.
         let span = tracing::info_span!(
             "txn",
-            path = %pre_commit_snapshot.table_root(),
+            path = %effective_table_config.table_root(),
             operation = "CREATE",
         );
 
         Ok(Transaction {
             span,
-            read_snapshot: pre_commit_snapshot,
+            read_snapshot: None,
+            effective_table_config,
+            should_emit_protocol: true,
+            should_emit_metadata: true,
             committer,
             operation: Some("CREATE TABLE".to_string()),
             engine_info: Some(engine_info),

--- a/kernel/src/transaction/domain_metadata.rs
+++ b/kernel/src/transaction/domain_metadata.rs
@@ -29,8 +29,7 @@ impl<S> Transaction<S> {
         }
 
         if !self
-            .read_snapshot
-            .table_configuration()
+            .effective_table_config
             .is_feature_supported(&TableFeature::DomainMetadata)
         {
             return Err(Error::unsupported(
@@ -114,7 +113,7 @@ impl<S> Transaction<S> {
     /// This prevents arbitrary `delta.*` domains from being added during table creation.
     /// Each known system domain must have its corresponding feature enabled in the protocol.
     fn validate_system_domain_feature(&self, domain: &str) -> DeltaResult<()> {
-        let table_config = self.read_snapshot.table_configuration();
+        let table_config = &self.effective_table_config;
 
         // Map domain to its required feature
         let required_feature = match domain {
@@ -162,7 +161,7 @@ impl<S> Transaction<S> {
             .map(String::as_str)
             .collect();
         let existing_domains = self
-            .read_snapshot
+            .read_snapshot()?
             .get_domain_metadatas_internal(engine, Some(&domains))?;
 
         // Create removal tombstones with pre-image configurations

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -56,8 +56,10 @@ pub mod data_layout;
 #[cfg(not(feature = "internal-api"))]
 pub(crate) mod data_layout;
 
+pub(crate) mod alter_table;
 mod commit_info;
 mod domain_metadata;
+pub(crate) mod schema_evolution;
 mod stats_verifier;
 mod update;
 mod write_context;
@@ -177,6 +179,13 @@ pub struct ExistingTable;
 /// invalid for table creation (e.g. file removal, domain metadata removal) are not available.
 #[derive(Debug)]
 pub struct CreateTable;
+
+/// Marker type for alter-table (schema evolution) transactions.
+///
+/// Transactions in this state perform metadata-only commits. Data file operations are not
+/// available at compile time because `AlterTable` does not implement [`SupportsDataFiles`].
+#[derive(Debug)]
+pub struct AlterTable;
 
 /// Marker trait for transaction states that support data file operations.
 ///

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -19,6 +19,7 @@ use crate::error::Error;
 use crate::expressions::ColumnName;
 use crate::expressions::Scalar;
 use crate::expressions::{ArrayData, Transform, UnaryExpressionOp::ToJson};
+use crate::log_segment::LogSegment;
 use crate::partition::{
     serialization::serialize_partition_value, validation::validate_partition_values,
 };
@@ -30,13 +31,13 @@ use crate::scan::log_replay::{
 };
 use crate::scan::scan_row_schema;
 use crate::schema::{ArrayType, MapType, SchemaRef, StructField, StructType, StructTypeBuilder};
-use crate::snapshot::SnapshotRef;
+use crate::snapshot::{Snapshot, SnapshotRef};
+use crate::table_configuration::TableConfiguration;
 use crate::table_features::TableFeature;
 use crate::utils::require;
 use crate::FileMeta;
 use crate::{
     DataType, DeltaResult, Engine, EngineData, Expression, IntoEngineData, RowVisitor, Version,
-    PRE_COMMIT_VERSION,
 };
 use delta_kernel_derive::internal_api;
 
@@ -198,9 +199,16 @@ pub struct CreateTable;
 /// ```
 pub struct Transaction<S = ExistingTable> {
     span: tracing::Span,
-    // The snapshot this transaction is based on. For create-table transactions,
-    // this is a pre-commit snapshot with PRE_COMMIT_VERSION.
-    read_snapshot: SnapshotRef,
+    // The snapshot this transaction is based on. None for create-table transactions (no
+    // pre-existing table to read from). Use `read_snapshot()` to access for existing tables.
+    read_snapshot: Option<SnapshotRef>,
+    // The table configuration that this commit will produce. For existing-table writes this is
+    // cloned from the read snapshot; for configuration changes it is constructed separately.
+    effective_table_config: TableConfiguration,
+    // Whether to emit a Protocol action in this commit.
+    should_emit_protocol: bool,
+    // Whether to emit a Metadata action in this commit.
+    should_emit_metadata: bool,
     committer: Box<dyn Committer>,
     operation: Option<String>,
     engine_info: Option<String>,
@@ -246,10 +254,9 @@ pub struct Transaction<S = ExistingTable> {
 
 impl<S> std::fmt::Debug for Transaction<S> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let version_info = if self.is_create_table() {
-            "create_table".to_string()
-        } else {
-            format!("{}", self.read_snapshot.version())
+        let version_info = match &self.read_snapshot {
+            Some(snap) => format!("{}", snap.version()),
+            None => "create_table".to_string(),
         };
         f.write_str(&format!(
             "Transaction {{ read_snapshot version: {}, engine_info: {} }}",
@@ -313,8 +320,7 @@ impl<S> Transaction<S> {
             && self.data_change
         {
             let cdf_enabled = self
-                .read_snapshot
-                .table_configuration()
+                .effective_table_config
                 .table_properties()
                 .enable_change_data_feed
                 .unwrap_or(false);
@@ -349,26 +355,22 @@ impl<S> Transaction<S> {
         );
         let commit_info_action = self.generate_commit_info(engine, kernel_commit_info);
 
-        // Step 3: Generate Protocol and Metadata actions for create-table
-        let (protocol_action, metadata_action, protocol, metadata) = if self.is_create_table() {
-            let table_config = self.read_snapshot.table_configuration();
-            let protocol = table_config.protocol().clone();
-            let metadata = table_config.metadata().clone();
-
-            let protocol_schema = get_commit_schema().project(&[PROTOCOL_NAME])?;
-            let metadata_schema = get_commit_schema().project(&[METADATA_NAME])?;
-
-            let protocol_data = protocol.clone().into_engine_data(protocol_schema, engine)?;
-            let metadata_data = metadata.clone().into_engine_data(metadata_schema, engine)?;
-
-            (
-                Some(protocol_data),
-                Some(metadata_data),
-                Some(protocol),
-                Some(metadata),
-            )
+        // Step 3: Generate Protocol and Metadata actions based on emit flags
+        let (protocol_action, protocol) = if self.should_emit_protocol {
+            let protocol = self.effective_table_config.protocol().clone();
+            let schema = get_commit_schema().project(&[PROTOCOL_NAME])?;
+            let action = protocol.clone().into_engine_data(schema, engine)?;
+            (Some(action), Some(protocol))
         } else {
-            (None, None, None, None)
+            (None, None)
+        };
+        let (metadata_action, metadata) = if self.should_emit_metadata {
+            let metadata = self.effective_table_config.metadata().clone();
+            let schema = get_commit_schema().project(&[METADATA_NAME])?;
+            let action = metadata.clone().into_engine_data(schema, engine)?;
+            (Some(action), Some(metadata))
+        } else {
+            (None, None)
         };
 
         // Step 4: Generate add actions and get data for domain metadata actions (e.g. row tracking high watermark)
@@ -417,7 +419,8 @@ impl<S> Transaction<S> {
             Ok(CommitResponse::Committed { file_meta }) => {
                 let bin_boundaries = self
                     .read_snapshot
-                    .get_file_stats_if_loaded()
+                    .as_ref()
+                    .and_then(|snap| snap.get_file_stats_if_loaded())
                     .and_then(|s| s.file_size_histogram)
                     .map(|h| h.sorted_bin_boundaries);
                 let crc_delta = self.build_crc_delta(
@@ -561,20 +564,30 @@ impl<S> Transaction<S> {
         new_metadata: Option<Metadata>,
         domain_metadata_changes: Vec<crate::actions::DomainMetadata>,
     ) -> DeltaResult<CommitMetadata> {
-        let log_root = LogRoot::new(self.read_snapshot.table_root().clone())?;
-        let table_config = self.read_snapshot.table_configuration();
+        let log_root = LogRoot::new(self.effective_table_config.table_root().clone())?;
         let is_create = self.is_create_table();
-        let commit_type = Self::determine_commit_type(is_create, table_config);
+        let commit_type = Self::determine_commit_type(is_create, &self.effective_table_config);
         Self::validate_commit_type(self.committer.is_catalog_committer(), &commit_type)?;
         // For create-table: read P&M is None (no previous table), new P&M is set.
-        // For existing table: read P&M is from the snapshot, new P&M is None.
+        // For existing table with metadata change (e.g. ALTER): read P&M from snapshot,
+        // new P&M from effective config.
+        // For existing table without metadata change: read P&M from snapshot, new is None.
         let (read_protocol, read_metadata) = if is_create {
             (None, None)
         } else {
+            let read_config = self.read_snapshot()?.table_configuration();
             (
-                Some(table_config.protocol().clone()),
-                Some(table_config.metadata().clone()),
+                Some(read_config.protocol().clone()),
+                Some(read_config.metadata().clone()),
             )
+        };
+        let max_published_version = if is_create {
+            None
+        } else {
+            self.read_snapshot()?
+                .log_segment()
+                .listed
+                .max_published_version
         };
         let protocol_metadata = CommitProtocolMetadata::try_new(
             read_protocol,
@@ -587,10 +600,7 @@ impl<S> Transaction<S> {
             commit_version,
             commit_type,
             in_commit_timestamp.unwrap_or(self.commit_timestamp),
-            self.read_snapshot
-                .log_segment()
-                .listed
-                .max_published_version,
+            max_published_version,
             protocol_metadata,
             domain_metadata_changes,
         ))
@@ -632,15 +642,19 @@ impl<S> Transaction<S> {
     }
 
     /// Returns true if this is a create-table transaction.
-    /// A create-table transaction has operation "CREATE TABLE" and a pre-commit snapshot
-    /// with PRE_COMMIT_VERSION.
+    /// A create-table transaction has no read snapshot (no pre-existing table).
     fn is_create_table(&self) -> bool {
-        let is_create = self.operation.as_deref() == Some("CREATE TABLE");
-        debug_assert!(
-            !is_create || self.read_snapshot.version() == PRE_COMMIT_VERSION,
-            "CREATE TABLE transaction must have PRE_COMMIT_VERSION snapshot"
-        );
-        is_create
+        self.read_snapshot.is_none()
+    }
+
+    /// Returns the read snapshot. Returns an error if this is a create-table transaction.
+    /// All callers must be guarded by `!is_create_table()` or only execute for existing tables.
+    fn read_snapshot(&self) -> DeltaResult<&Snapshot> {
+        self.read_snapshot.as_deref().ok_or_else(|| {
+            Error::internal_error(
+                "read_snapshot() called on create-table transaction (read_snapshot is None)",
+            )
+        })
     }
 
     /// Computes the in-commit timestamp for this transaction if ICT is enabled.
@@ -649,8 +663,7 @@ impl<S> Transaction<S> {
     /// property must also be `true` (`is_feature_enabled`).
     fn get_in_commit_timestamp(&self, engine: &dyn Engine) -> DeltaResult<Option<i64>> {
         let has_ict = self
-            .read_snapshot
-            .table_configuration()
+            .effective_table_config
             .is_feature_enabled(&TableFeature::InCommitTimestamp);
 
         if !has_ict {
@@ -667,17 +680,19 @@ impl<S> Transaction<S> {
         // - The time at which the writer attempted the commit
         // - One millisecond later than the previous commit's inCommitTimestamp
         Ok(self
-            .read_snapshot
+            .read_snapshot()?
             .get_in_commit_timestamp(engine)?
             .map(|prev_ict| self.commit_timestamp.max(prev_ict + 1)))
     }
 
     /// Returns the commit version for this transaction.
     /// For existing table transactions, this is snapshot.version() + 1.
-    /// For create-table transactions (PRE_COMMIT_VERSION + 1 wraps to 0), this is 0.
+    /// For create-table transactions, this is 0.
     fn get_commit_version(&self) -> Version {
-        // PRE_COMMIT_VERSION (u64::MAX) + 1 wraps to 0, which is the correct first version
-        self.read_snapshot.version().wrapping_add(1)
+        match &self.read_snapshot {
+            Some(snap) => snap.version() + 1,
+            None => 0,
+        }
     }
 
     /// The schema that the [`Engine`]'s [`ParquetHandler`] is expected to use when reporting information about
@@ -730,9 +745,9 @@ impl<S> Transaction<S> {
     /// settings.
     #[allow(unused)]
     pub fn stats_schema(&self) -> DeltaResult<SchemaRef> {
-        let tc = self.read_snapshot.table_configuration();
-        let stats_schemas =
-            tc.build_expected_stats_schemas(self.physical_clustering_columns.as_deref(), None)?;
+        let stats_schemas = self
+            .effective_table_config
+            .build_expected_stats_schemas(self.physical_clustering_columns.as_deref(), None)?;
         Ok(stats_schemas.physical)
     }
 
@@ -749,23 +764,17 @@ impl<S> Transaction<S> {
     /// regardless of `dataSkippingStatsColumns` or `dataSkippingNumIndexedCols` settings.
     #[allow(unused)]
     pub fn stats_columns(&self) -> Vec<ColumnName> {
-        self.read_snapshot
-            .table_configuration()
+        self.effective_table_config
             .physical_stats_column_names(self.physical_clustering_columns.as_deref())
     }
 
     // Generate the logical-to-physical transform expression which must be evaluated on every data
     // chunk before writing. At the moment, this is a transaction-wide expression.
     fn generate_logical_to_physical(&self) -> Expression {
-        let partition_cols = self
-            .read_snapshot
-            .table_configuration()
-            .partition_columns()
-            .to_vec();
+        let partition_cols = self.effective_table_config.partition_columns().to_vec();
         // Check if materializePartitionColumns feature is enabled
         let materialize_partition_columns = self
-            .read_snapshot
-            .table_configuration()
+            .effective_table_config
             .is_feature_enabled(&TableFeature::MaterializePartitionColumns);
         // Build a Transform expression that drops partition columns from the input
         // (unless materializePartitionColumns is enabled).
@@ -780,16 +789,16 @@ impl<S> Transaction<S> {
 
     /// Returns the logical partition column names for this table.
     pub fn logical_partition_columns(&self) -> &[String] {
-        self.read_snapshot.table_configuration().partition_columns()
+        self.effective_table_config.partition_columns()
     }
 
     /// Lazily builds and caches the [`SharedWriteState`] for this transaction.
     fn shared_write_state(&self) -> &Arc<SharedWriteState> {
         self.shared_write_state.get_or_init(|| {
-            let table_config = self.read_snapshot.table_configuration();
+            let table_config = &self.effective_table_config;
             Arc::new(SharedWriteState {
-                table_root: self.read_snapshot.table_root().clone(),
-                logical_schema: self.read_snapshot.schema(),
+                table_root: table_config.table_root().clone(),
+                logical_schema: table_config.logical_schema(),
                 physical_schema: table_config.physical_write_schema(),
                 logical_to_physical: Arc::new(self.generate_logical_to_physical()),
                 column_mapping_mode: table_config.column_mapping_mode(),
@@ -918,7 +927,7 @@ impl<S> Transaction<S> {
         }
         if let Some(ref clustering_cols) = self.physical_clustering_columns {
             if !clustering_cols.is_empty() {
-                let physical_schema = self.read_snapshot.table_configuration().physical_schema();
+                let physical_schema = self.effective_table_config.physical_schema();
                 let columns_with_types: Vec<(ColumnName, DataType)> = clustering_cols
                     .iter()
                     .map(|col| {
@@ -994,10 +1003,7 @@ impl<S> Transaction<S> {
         let commit_version = i64::try_from(commit_version)
             .map_err(|_| Error::generic("Commit version too large to fit in i64"))?;
 
-        let needs_row_tracking = self
-            .read_snapshot
-            .table_configuration()
-            .should_write_row_tracking();
+        let needs_row_tracking = self.effective_table_config.should_write_row_tracking();
 
         // Row tracking is not yet supported for create-table with data
         if needs_row_tracking && self.is_create_table() {
@@ -1009,7 +1015,7 @@ impl<S> Transaction<S> {
         if needs_row_tracking {
             // Read the current rowIdHighWaterMark from the snapshot's row tracking domain metadata
             let row_id_high_water_mark =
-                RowTrackingDomainMetadata::get_high_water_mark(&self.read_snapshot, engine)?;
+                RowTrackingDomainMetadata::get_high_water_mark(self.read_snapshot()?, engine)?;
 
             // Create a row tracking visitor and visit all files to collect row tracking information
             let mut row_tracking_visitor = RowTrackingVisitor::new(
@@ -1082,24 +1088,55 @@ impl<S> Transaction<S> {
 
         let commit_version = parsed_commit.version;
 
-        let post_commit_stats = PostCommitStats {
-            commits_since_checkpoint: self.read_snapshot.log_segment().commits_since_checkpoint()
-                + 1,
-            commits_since_log_compaction: self
-                .read_snapshot
-                .log_segment()
-                .commits_since_log_compaction_or_checkpoint()
-                + 1,
-        };
-
-        Ok(CommittedTransaction {
-            commit_version,
-            post_commit_stats,
-            post_commit_snapshot: Some(Arc::new(
-                self.read_snapshot
-                    .new_post_commit(parsed_commit, crc_delta)?,
-            )),
-        })
+        match &self.read_snapshot {
+            Some(snap) => {
+                // Existing table path: use the read snapshot to compute post-commit state.
+                let post_commit_stats = PostCommitStats {
+                    commits_since_checkpoint: snap.log_segment().commits_since_checkpoint() + 1,
+                    commits_since_log_compaction: snap
+                        .log_segment()
+                        .commits_since_log_compaction_or_checkpoint()
+                        + 1,
+                };
+                Ok(CommittedTransaction {
+                    commit_version,
+                    post_commit_stats,
+                    post_commit_snapshot: Some(Arc::new(
+                        snap.new_post_commit(parsed_commit, crc_delta)?,
+                    )),
+                })
+            }
+            None => {
+                // CREATE TABLE path: build a fresh Snapshot at version 0.
+                let log_root = self
+                    .effective_table_config
+                    .table_root()
+                    .join("_delta_log/")?;
+                let log_segment = LogSegment::new_for_version_zero(log_root, parsed_commit)?;
+                let new_table_config = TableConfiguration::new_post_commit(
+                    &self.effective_table_config,
+                    0,
+                    crc_delta.metadata.clone(),
+                    crc_delta.protocol.clone(),
+                )?;
+                let crc = crc_delta.into_crc_for_version_zero().ok_or_else(|| {
+                    Error::internal_error("CREATE TABLE CRC delta is missing protocol or metadata")
+                })?;
+                let post_commit_snapshot = Snapshot::new_with_crc(
+                    log_segment,
+                    new_table_config,
+                    Arc::new(crate::crc::LazyCrc::new_precomputed(crc, 0)),
+                );
+                Ok(CommittedTransaction {
+                    commit_version,
+                    post_commit_stats: PostCommitStats {
+                        commits_since_checkpoint: 1,
+                        commits_since_log_compaction: 1,
+                    },
+                    post_commit_snapshot: Some(Arc::new(post_commit_snapshot)),
+                })
+            }
+        }
     }
 
     /// Build a [`CrcDelta`] from the transaction's staged file metadata and commit state.
@@ -1114,13 +1151,14 @@ impl<S> Transaction<S> {
             &self.remove_files_metadata,
             bin_boundaries,
         )?;
-        let is_create = self.is_create_table();
         Ok(CrcDelta {
             file_stats,
-            protocol: is_create
-                .then(|| self.read_snapshot.table_configuration().protocol().clone()),
-            metadata: is_create
-                .then(|| self.read_snapshot.table_configuration().metadata().clone()),
+            protocol: self
+                .should_emit_protocol
+                .then(|| self.effective_table_config.protocol().clone()),
+            metadata: self
+                .should_emit_metadata
+                .then(|| self.effective_table_config.metadata().clone()),
             domain_metadata_changes: dm_changes,
             set_transaction_changes: self.set_transactions.clone(),
             in_commit_timestamp,

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -178,6 +178,15 @@ pub struct ExistingTable;
 #[derive(Debug)]
 pub struct CreateTable;
 
+/// Marker trait for transaction states that support data file operations.
+///
+/// Only transaction types that implement this trait can access methods for adding, removing, or
+/// updating data files. This prevents compile-time misuse by states like `AlterTable` that
+/// only perform metadata-only commits.
+pub trait SupportsDataFiles {}
+impl SupportsDataFiles for ExistingTable {}
+impl SupportsDataFiles for CreateTable {}
+
 /// A transaction represents an in-progress write to a table. After creating a transaction, changes
 /// to the table may be staged via the transaction methods before calling `commit` to commit the
 /// changes to the table.
@@ -719,7 +728,12 @@ impl<S> Transaction<S> {
     pub fn add_files_schema(&self) -> &'static SchemaRef {
         &BASE_ADD_FILES_SCHEMA
     }
+}
 
+// =============================================================================
+// Data file methods -- only available on transaction types that support data files
+// =============================================================================
+impl<S: SupportsDataFiles> Transaction<S> {
     /// Returns the expected schema for file statistics.
     ///
     /// The schema structure is derived from table configuration:
@@ -913,7 +927,12 @@ impl<S> Transaction<S> {
     pub fn add_files(&mut self, add_metadata: Box<dyn EngineData>) {
         self.add_files_metadata.push(add_metadata);
     }
+}
 
+// =============================================================================
+// Internal methods available on ALL transaction types (used by commit path)
+// =============================================================================
+impl<S> Transaction<S> {
     /// Validate that add files have required statistics for clustering columns.
     ///
     /// Per the Delta protocol, writers MUST collect per-file statistics for clustering columns
@@ -1885,7 +1904,7 @@ mod tests {
     // ============================================================================
     // validate_blind_append tests
     // ============================================================================
-    fn add_dummy_file<S>(txn: &mut Transaction<S>) {
+    fn add_dummy_file<S: SupportsDataFiles>(txn: &mut Transaction<S>) {
         let data = string_array_to_engine_data(StringArray::from(vec!["dummy"]));
         txn.add_files(data);
     }

--- a/kernel/src/transaction/schema_evolution.rs
+++ b/kernel/src/transaction/schema_evolution.rs
@@ -1,0 +1,152 @@
+//! Schema evolution operations for ALTER TABLE.
+//!
+//! This module defines the [`SchemaOperation`] enum and the [`apply_schema_operations`] function
+//! that validates and applies schema changes to produce an evolved schema.
+
+use indexmap::IndexMap;
+
+use crate::error::Error;
+use crate::schema::{SchemaRef, StructField, StructType};
+use crate::DeltaResult;
+
+/// A schema evolution operation to be applied during ALTER TABLE.
+///
+/// Operations are validated and applied in order during
+/// [`apply_schema_operations`]. Each operation sees the schema state after all prior operations
+/// have been applied.
+#[derive(Debug, Clone)]
+pub(crate) enum SchemaOperation {
+    /// Add a top-level column.
+    AddColumn { field: StructField },
+}
+
+/// The result of applying schema operations.
+#[derive(Debug)]
+pub(crate) struct SchemaEvolutionResult {
+    /// The evolved schema after all operations are applied.
+    pub schema: SchemaRef,
+}
+
+/// Applies a sequence of schema operations to the given schema, returning the evolved schema.
+///
+/// Each operation is validated against the current schema state (after prior operations have been
+/// applied).
+///
+/// # Errors
+///
+/// Returns an error if any operation fails validation. The error message identifies which
+/// operation failed and why.
+pub(crate) fn apply_schema_operations(
+    schema: StructType,
+    operations: &[SchemaOperation],
+) -> DeltaResult<SchemaEvolutionResult> {
+    // Keys are lowercased for O(1) case-insensitive lookup; StructFields retain original casing.
+    let mut fields: IndexMap<String, StructField> = schema
+        .into_fields()
+        .map(|f| (f.name().to_lowercase(), f))
+        .collect();
+
+    for op in operations {
+        match op {
+            SchemaOperation::AddColumn { field } => {
+                let key = field.name().to_lowercase();
+                if fields.contains_key(&key) {
+                    return Err(Error::generic(format!(
+                        "Cannot add column '{}': a column with that name already exists",
+                        field.name()
+                    )));
+                }
+                // Validate field is nullable (Delta protocol requires added columns to be
+                // nullable so existing data files can return NULL for the new column)
+                if !field.is_nullable() {
+                    return Err(Error::generic(format!(
+                        "Cannot add non-nullable column '{}'. Added columns must be nullable \
+                         because existing data files do not contain this column.",
+                        field.name()
+                    )));
+                }
+                fields.insert(key, field.clone());
+            }
+        }
+    }
+
+    let evolved_schema = StructType::try_new(fields.into_values())?;
+    Ok(SchemaEvolutionResult {
+        schema: evolved_schema.into(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::{DataType, StructField, StructType};
+
+    fn base_schema() -> StructType {
+        StructType::try_new(vec![
+            StructField::not_null("id", DataType::INTEGER),
+            StructField::nullable("name", DataType::STRING),
+        ])
+        .unwrap()
+    }
+
+    #[test]
+    fn add_nullable_column_succeeds() {
+        let ops = vec![SchemaOperation::AddColumn {
+            field: StructField::nullable("email", DataType::STRING),
+        }];
+        let result = apply_schema_operations(base_schema(), &ops).unwrap();
+        assert_eq!(result.schema.fields().count(), 3);
+        assert!(result.schema.field("email").is_some());
+    }
+
+    #[test]
+    fn add_duplicate_column_fails() {
+        let ops = vec![SchemaOperation::AddColumn {
+            field: StructField::nullable("name", DataType::STRING),
+        }];
+        let err = apply_schema_operations(base_schema(), &ops).unwrap_err();
+        assert!(err.to_string().contains("already exists"));
+    }
+
+    #[test]
+    fn add_non_nullable_column_fails() {
+        let ops = vec![SchemaOperation::AddColumn {
+            field: StructField::not_null("age", DataType::INTEGER),
+        }];
+        let err = apply_schema_operations(base_schema(), &ops).unwrap_err();
+        assert!(err.to_string().contains("non-nullable"));
+    }
+
+    #[test]
+    fn add_duplicate_column_case_insensitive_fails() {
+        let ops = vec![SchemaOperation::AddColumn {
+            field: StructField::nullable("Name", DataType::STRING),
+        }];
+        let err = apply_schema_operations(base_schema(), &ops).unwrap_err();
+        assert!(err.to_string().contains("already exists"));
+    }
+
+    #[test]
+    fn add_multiple_columns_succeeds() {
+        let ops = vec![
+            SchemaOperation::AddColumn {
+                field: StructField::nullable("email", DataType::STRING),
+            },
+            SchemaOperation::AddColumn {
+                field: StructField::nullable("age", DataType::INTEGER),
+            },
+        ];
+        let result = apply_schema_operations(base_schema(), &ops).unwrap();
+        assert_eq!(result.schema.fields().count(), 4);
+    }
+
+    #[test]
+    fn add_column_preserves_existing_field_order() {
+        let ops = vec![SchemaOperation::AddColumn {
+            field: StructField::nullable("email", DataType::STRING),
+        }];
+        let result = apply_schema_operations(base_schema(), &ops).unwrap();
+        let names: Vec<&String> = result.schema.fields().map(|f| f.name()).collect();
+        assert_eq!(names, vec!["id", "name", "email"]);
+    }
+}

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -72,9 +72,14 @@ impl Transaction {
             read_version = read_snapshot.version(),
         );
 
+        let effective_table_config = read_snapshot.table_configuration().clone();
+
         Ok(Transaction {
             span,
-            read_snapshot,
+            read_snapshot: Some(read_snapshot),
+            effective_table_config,
+            should_emit_protocol: false,
+            should_emit_metadata: false,
             committer,
             operation: None,
             engine_info: None,
@@ -255,8 +260,7 @@ impl Transaction {
             ));
         }
         if !self
-            .read_snapshot
-            .table_configuration()
+            .effective_table_config
             .is_feature_supported(&TableFeature::DeletionVectors)
         {
             return Err(Error::unsupported(

--- a/kernel/tests/alter_table.rs
+++ b/kernel/tests/alter_table.rs
@@ -1,0 +1,165 @@
+//! Integration tests for ALTER TABLE schema evolution.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use delta_kernel::arrow::array::{Array, Int32Array, StringArray};
+use delta_kernel::arrow::record_batch::RecordBatch;
+use delta_kernel::committer::FileSystemCommitter;
+use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
+use delta_kernel::schema::{DataType, SchemaRef, StructField, StructType};
+use delta_kernel::snapshot::Snapshot;
+use delta_kernel::transaction::create_table::create_table;
+use delta_kernel::DeltaResult;
+use test_utils::{test_table_setup, write_batch_to_table};
+
+fn simple_schema() -> SchemaRef {
+    Arc::new(
+        StructType::try_new(vec![
+            StructField::not_null("id", DataType::INTEGER),
+            StructField::nullable("name", DataType::STRING),
+        ])
+        .unwrap(),
+    )
+}
+
+fn committer() -> Box<FileSystemCommitter> {
+    Box::new(FileSystemCommitter::new())
+}
+
+fn create_test_table(
+    table_path: &str,
+    schema: SchemaRef,
+    engine: &dyn delta_kernel::Engine,
+) -> DeltaResult<Arc<Snapshot>> {
+    let committed = create_table(table_path, schema, "Test/1.0")
+        .build(engine, committer())?
+        .commit(engine)?
+        .unwrap_committed();
+    Ok(committed
+        .post_commit_snapshot()
+        .expect("should have post-commit snapshot")
+        .clone())
+}
+
+#[tokio::test]
+async fn add_column_reload_snapshot_verify_schema() -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let snapshot = create_test_table(&table_path, simple_schema(), engine.as_ref())?;
+
+    // Write data before adding the column
+    let batch = RecordBatch::try_new(
+        Arc::new(simple_schema().as_ref().try_into_arrow().unwrap()),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2])),
+            Arc::new(StringArray::from(vec!["a", "b"])),
+        ],
+    )
+    .unwrap();
+    let snapshot = write_batch_to_table(&snapshot, engine.as_ref(), batch, HashMap::new()).await?;
+
+    // Add a column
+    let _ = snapshot
+        .alter_table()
+        .add_column(StructField::nullable("email", DataType::STRING))
+        .build(engine.as_ref(), committer())?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    // Reload from storage to verify persistence
+    let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert_eq!(reloaded.version(), 2);
+    let schema = reloaded.schema();
+    assert_eq!(schema.fields().count(), 3);
+
+    let email_field = schema.field("email").expect("email should exist");
+    assert_eq!(email_field.data_type(), &DataType::STRING);
+    assert!(email_field.is_nullable());
+
+    // Scan back -- old rows should have NULL for the new column
+    let evolved_arrow_schema: delta_kernel::arrow::datatypes::SchemaRef =
+        Arc::new(reloaded.schema().as_ref().try_into_arrow().unwrap());
+    let scan = reloaded.scan_builder().build()?;
+    let batches = test_utils::read_scan(&scan, engine.clone())?;
+    assert!(!batches.is_empty());
+    let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total_rows, 2);
+    assert_eq!(batches[0].num_columns(), 3);
+    let email_col = batches[0].column_by_name("email").expect("email column");
+    assert_eq!(email_col.null_count(), email_col.len());
+
+    // Write new data WITH the new column populated
+    let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    let batch2 = RecordBatch::try_new(
+        evolved_arrow_schema,
+        vec![
+            Arc::new(Int32Array::from(vec![3, 4])),
+            Arc::new(StringArray::from(vec!["c", "d"])),
+            Arc::new(StringArray::from(vec!["c@test.com", "d@test.com"])),
+        ],
+    )
+    .unwrap();
+    let reloaded = Arc::new(reloaded);
+    let _ = write_batch_to_table(&reloaded, engine.as_ref(), batch2, HashMap::new()).await?;
+
+    // Scan back -- should have 4 rows total
+    let final_snap = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert_eq!(final_snap.version(), 3);
+    let scan = final_snap.scan_builder().build()?;
+    let batches = test_utils::read_scan(&scan, engine.clone())?;
+    let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total_rows, 4);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_column_multiple_in_one_commit() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let snapshot = create_test_table(&table_path, simple_schema(), engine.as_ref())?;
+
+    let _ = snapshot
+        .alter_table()
+        .add_column(StructField::nullable("email", DataType::STRING))
+        .add_column(StructField::nullable("age", DataType::INTEGER))
+        .build(engine.as_ref(), committer())?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    let reloaded = Snapshot::builder_for(table_path).build(engine.as_ref())?;
+    assert_eq!(reloaded.schema().fields().count(), 4);
+    assert!(reloaded.schema().field("email").is_some());
+    assert!(reloaded.schema().field("age").is_some());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_duplicate_column_fails() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let snapshot = create_test_table(&table_path, simple_schema(), engine.as_ref())?;
+
+    let err = snapshot
+        .alter_table()
+        .add_column(StructField::nullable("name", DataType::STRING))
+        .build(engine.as_ref(), committer());
+    assert!(err.is_err());
+    assert!(err.unwrap_err().to_string().contains("already exists"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_non_nullable_column_fails() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let snapshot = create_test_table(&table_path, simple_schema(), engine.as_ref())?;
+
+    let err = snapshot
+        .alter_table()
+        .add_column(StructField::not_null("age", DataType::INTEGER))
+        .build(engine.as_ref(), committer());
+    assert!(err.is_err());
+    assert!(err.unwrap_err().to_string().contains("non-nullable"));
+
+    Ok(())
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Introduces the ALTER TABLE schema evolution framework and the first operation: `add_column`.

- `Snapshot::alter_table()` returns an `AlterTableTransactionBuilder` that uses a type-state
  pattern (`Ready` -> `Modifying`) to enforce at least one operation before `build()`
- `SchemaOperation` enum and `apply_schema_operations()` validate and apply schema changes
- `AlterTableTransaction` commits metadata-only changes (`data_change: false`) with the evolved
  schema
- Added columns must be nullable (existing data files return NULL for the new column)

### This PR affects the following public APIs

New public API: `Snapshot::alter_table()` and `AlterTableTransactionBuilder`. Not a breaking change.

## How was this change tested?

- Unit tests in `schema_evolution.rs`: add column success/failure, case-insensitive duplicate
  detection, `modify_field_at_path` helper (top-level, nested, siblings, error paths)
- Integration tests in `kernel/tests/alter_table.rs`: end-to-end add column with schema reload,
  multiple columns in one commit, duplicate/non-nullable rejection
- compile_fail doctests verifying `build()` is unavailable in `Ready` state and data-file
  operations are unavailable on `AlterTableTransaction`