### PR TITLE
feat: add AlterTable framework with add_column support

### DIFF
--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -214,6 +214,11 @@ impl TryFrom<Format> for Scalar {
 }
 
 // Serde derives are needed for CRC file deserialization (see `crc::reader`).
+//
+// TODO(#2446): `Metadata` stores the schema only as a JSON string. Callers that already hold
+// a parsed `SchemaRef` (e.g. CREATE TABLE) serialize into `schema_string` and then re-parse
+// downstream in `TableConfiguration::try_new` via `parse_schema()`. Caching the parsed schema
+// on `Metadata` would eliminate the round-trip.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 #[internal_api]
@@ -341,6 +346,18 @@ impl Metadata {
     #[internal_api]
     pub(crate) fn parse_table_properties(&self) -> TableProperties {
         TableProperties::from(self.configuration.iter())
+    }
+
+    /// Returns a new Metadata with the schema replaced, preserving all other fields.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if schema serialization fails.
+    pub(crate) fn with_schema(self, schema: SchemaRef) -> DeltaResult<Self> {
+        Ok(Self {
+            schema_string: serde_json::to_string(&schema)?,
+            ..self
+        })
     }
 
     #[cfg(test)]

--- a/kernel/src/schema/validation.rs
+++ b/kernel/src/schema/validation.rs
@@ -1,4 +1,4 @@
-//! Schema validation utilities for Delta table creation.
+//! Schema validation utilities shared by table creation and schema evolution.
 //!
 //! Validates schemas per the Delta protocol specification.
 
@@ -14,7 +14,7 @@ use crate::{DeltaResult, Error};
 /// These characters have special meaning in Parquet schema syntax.
 const INVALID_PARQUET_CHARS: &[char] = &[' ', ',', ';', '{', '}', '(', ')', '\n', '\t', '='];
 
-/// Validates a schema for table creation.
+/// Validates a schema for CREATE TABLE or ALTER TABLE.
 ///
 /// Performs the following checks:
 /// 1. Schema is non-empty
@@ -22,7 +22,7 @@ const INVALID_PARQUET_CHARS: &[char] = &[' ', ',', ';', '{', '}', '(', ')', '\n'
 /// 3. Column names contain only valid characters
 /// 4. Rejects fields with `delta.invariants` metadata (SQL expression invariants are not supported
 ///    by kernel; see `TableConfiguration::ensure_write_supported`)
-pub(crate) fn validate_schema_for_create(
+pub(crate) fn validate_schema(
     schema: &StructType,
     column_mapping_mode: ColumnMappingMode,
 ) -> DeltaResult<()> {
@@ -371,7 +371,7 @@ mod tests {
     #[case::dot_in_name_with_cm(schema_with_dot(), ColumnMappingMode::Name)]
     #[case::different_struct_children(schema_different_struct_children(), ColumnMappingMode::None)]
     fn valid_schema_accepted(#[case] schema: StructType, #[case] cm: ColumnMappingMode) {
-        assert!(validate_schema_for_create(&schema, cm).is_ok());
+        assert!(validate_schema(&schema, cm).is_ok());
     }
 
     // === Invalid schemas ===
@@ -393,7 +393,7 @@ mod tests {
         #[case] cm: ColumnMappingMode,
         #[case] expected_errs: &[&str],
     ) {
-        let result = validate_schema_for_create(&schema, cm);
+        let result = validate_schema(&schema, cm);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         for expected in expected_errs {
@@ -412,7 +412,7 @@ mod tests {
     #[case::array_nested(schema_array_nested_invariant(), "arr.child")]
     #[case::map_nested(schema_map_nested_invariant(), "map.child")]
     fn invariants_metadata_rejected(#[case] schema: StructType, #[case] expected_path: &str) {
-        let result = validate_schema_for_create(&schema, ColumnMappingMode::None);
+        let result = validate_schema(&schema, ColumnMappingMode::None);
         let err = result.expect_err("expected delta.invariants metadata rejection");
         let msg = err.to_string();
         assert!(

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -27,6 +27,7 @@ use crate::schema::SchemaRef;
 use crate::table_configuration::{InCommitTimestampEnablement, TableConfiguration};
 use crate::table_features::{physical_to_logical_column_name, ColumnMappingMode, TableFeature};
 use crate::table_properties::TableProperties;
+use crate::transaction::builder::alter_table::AlterTableTransactionBuilder;
 use crate::transaction::Transaction;
 use crate::utils::require;
 use crate::{DeltaResult, Engine, Error, LogCompactionWriter, Version};
@@ -685,6 +686,17 @@ impl Snapshot {
         engine: &dyn Engine,
     ) -> DeltaResult<Transaction> {
         Transaction::try_new_existing_table(self, committer, engine)
+    }
+
+    /// Creates a builder for altering this table's metadata. Currently supports schema change
+    /// operations.
+    ///
+    /// The returned builder allows chaining operations before building an
+    /// [`AlterTableTransaction`] that can be committed.
+    ///
+    /// [`AlterTableTransaction`]: crate::transaction::AlterTableTransaction
+    pub fn alter_table(self: Arc<Self>) -> AlterTableTransactionBuilder {
+        AlterTableTransactionBuilder::new(self)
     }
 
     /// Fetch the latest version of the provided `application_id` for this snapshot. Filters the

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -150,6 +150,32 @@ impl TableConfiguration {
         version: Version,
     ) -> DeltaResult<Self> {
         let logical_schema = Arc::new(metadata.parse_schema()?);
+        Self::try_new_inner(metadata, protocol, table_root, version, logical_schema)
+    }
+
+    /// Like [`try_new`](Self::try_new), but reuses `base`'s protocol, table root, and version
+    /// and takes a pre-parsed `logical_schema`.
+    pub(crate) fn try_new_with_schema(
+        base: &Self,
+        metadata: Metadata,
+        logical_schema: SchemaRef,
+    ) -> DeltaResult<Self> {
+        Self::try_new_inner(
+            metadata,
+            base.protocol.clone(),
+            base.table_root.clone(),
+            base.version,
+            logical_schema,
+        )
+    }
+
+    fn try_new_inner(
+        metadata: Metadata,
+        protocol: Protocol,
+        table_root: Url,
+        version: Version,
+        logical_schema: SchemaRef,
+    ) -> DeltaResult<Self> {
         let table_properties = metadata.parse_table_properties();
         let column_mapping_mode = column_mapping_mode(&protocol, &table_properties);
 

--- a/kernel/src/transaction/alter_table.rs
+++ b/kernel/src/transaction/alter_table.rs
@@ -1,0 +1,77 @@
+//! Alter table transaction types and constructor.
+//!
+//! This module defines the [`AlterTableTransaction`] type alias and the
+//! [`try_new_alter_table`](AlterTableTransaction::try_new_alter_table) constructor.
+//! The builder logic lives in [`builder::alter_table`](super::builder::alter_table).
+
+#![allow(unreachable_pub)]
+
+use std::marker::PhantomData;
+use std::sync::OnceLock;
+
+use crate::committer::Committer;
+use crate::snapshot::SnapshotRef;
+use crate::table_configuration::TableConfiguration;
+use crate::transaction::{AlterTable, Transaction};
+use crate::utils::current_time_ms;
+use crate::DeltaResult;
+
+/// A type alias for alter-table transactions.
+///
+/// This provides a restricted API surface that only exposes operations valid during ALTER
+/// commands. Data file operations are not available at compile time because `AlterTable`
+/// does not implement [`SupportsDataFiles`](super::SupportsDataFiles).
+pub type AlterTableTransaction = Transaction<AlterTable>;
+
+impl AlterTableTransaction {
+    /// Create a new transaction for altering a table's schema. Produces a metadata-only commit
+    /// that emits an updated Metadata action with the evolved schema.
+    ///
+    /// The `effective_table_config` is the evolved table configuration (new schema, same
+    /// protocol). It must be fully validated before calling this constructor (e.g. schema
+    /// operations applied, protocol feature checks passed). The `read_snapshot` provides the
+    /// pre-commit table state (version, previous protocol/metadata, ICT timestamps) used for
+    /// commit versioning and post-commit snapshots.
+    ///
+    /// This is typically called via `AlterTableTransactionBuilder::build()` rather than directly.
+    pub(crate) fn try_new_alter_table(
+        read_snapshot: SnapshotRef,
+        effective_table_config: TableConfiguration,
+        committer: Box<dyn Committer>,
+    ) -> DeltaResult<Self> {
+        let span = tracing::info_span!(
+            "txn",
+            path = %read_snapshot.table_root(),
+            read_version = read_snapshot.version(),
+            operation = "ALTER TABLE",
+        );
+
+        Ok(Transaction {
+            span,
+            read_snapshot_opt: Some(read_snapshot),
+            effective_table_config,
+            should_emit_protocol: false,
+            should_emit_metadata: true,
+            committer,
+            operation: Some("ALTER TABLE".to_string()),
+            engine_info: None,
+            add_files_metadata: vec![],
+            remove_files_metadata: vec![],
+            set_transactions: vec![],
+            commit_timestamp: current_time_ms()?,
+            user_domain_metadata_additions: vec![],
+            system_domain_metadata_additions: vec![],
+            user_domain_removals: vec![],
+            data_change: false,
+            shared_write_state: OnceLock::new(),
+            engine_commit_info: None,
+            // TODO(#2446): match delta-spark's per-op isBlindAppend policy
+            // (ADD/DROP/DROP NOT NULL -> true, SET NOT NULL -> false). Hardcoded false for
+            // now: safe, but misses the true-case optimization delta-spark applies.
+            is_blind_append: false,
+            dv_matched_files: vec![],
+            physical_clustering_columns: None,
+            _state: PhantomData,
+        })
+    }
+}

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -1,0 +1,164 @@
+//! Builder for ALTER TABLE (schema evolution) transactions.
+//!
+//! This module contains [`AlterTableTransactionBuilder`], which uses a type-state pattern to
+//! enforce valid operation chaining at compile time.
+//!
+//! # Type States
+//!
+//! - [`Ready`]: Initial state. Operations are available, but `build()` is not (at least one
+//!   operation is required).
+//! - [`Modifying`]: After any chainable schema operation. More ops can be chained, and `build()` is
+//!   available. See [`AlterTableTransactionBuilder<Modifying>`] for ops.
+//!
+//! # Transitions
+//!
+//! Each `impl` block below is gated by a state bound and documents which operations that
+//! state enables. Chainable schema operations live on `impl<S: Chainable>` and transition
+//! the builder to a chainable state; `build()` lives on states that are buildable.
+//!
+//! ```ignore
+//! // Allowed: at least one op queued before build().
+//! snapshot.alter_table().add_column(field).build(engine, committer)?;
+//!
+//! // Not allowed: build() is not defined on Ready (no ops queued).
+//! snapshot.alter_table().build(engine, committer)?;  // compile error
+//! ```
+
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use crate::committer::Committer;
+use crate::schema::StructField;
+use crate::snapshot::SnapshotRef;
+use crate::table_configuration::TableConfiguration;
+use crate::table_features::Operation;
+use crate::transaction::alter_table::AlterTableTransaction;
+use crate::transaction::schema_evolution::{
+    apply_schema_operations, SchemaEvolutionResult, SchemaOperation,
+};
+use crate::{DeltaResult, Engine};
+
+/// Initial state: `build()` is not yet available (at least one operation is required).
+/// See [`Chainable`] for the operations available on this state.
+pub struct Ready;
+
+/// State after at least one operation has been added. `build()` is available.
+/// See [`Chainable`] for the operations available on this state.
+pub struct Modifying;
+
+/// Marker trait for builder states that accept chainable schema operations. Grouping states
+/// under one bound lets each op (like `add_column`) live on a single `impl<S: Chainable>`
+/// block -- chainable states share the body rather than duplicating it per state.
+///
+/// Sealed: external types cannot implement this, keeping the set of chainable states closed.
+pub trait Chainable: sealed::Sealed {}
+impl Chainable for Ready {}
+impl Chainable for Modifying {}
+
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for super::Ready {}
+    impl Sealed for super::Modifying {}
+}
+
+/// Builder for constructing an [`AlterTableTransaction`] with schema evolution operations.
+///
+/// Uses a type-state pattern (`S`) to enforce at compile time:
+/// - At least one schema operation must be queued before `build()` is callable.
+/// - Only operations valid for the current state can be chained. This will disallow incompatibel
+///   chaining.
+pub struct AlterTableTransactionBuilder<S = Ready> {
+    snapshot: SnapshotRef,
+    operations: Vec<SchemaOperation>,
+    // PhantomData marker for builder state (Ready or Modifying).
+    // Zero-sized; only affects which methods are available at compile time.
+    _state: PhantomData<S>,
+}
+
+impl<S> AlterTableTransactionBuilder<S> {
+    // Reconstructs the builder with a different PhantomData marker, changing which methods
+    // are available at compile time (e.g. Ready -> Modifying enables `build()`). All real
+    // fields are moved as-is; only the zero-sized type state changes.
+    //
+    // `T` (distinct from the struct's `S`) lets the caller pick the target state:
+    // `self.transition::<Modifying>()` returns `AlterTableTransactionBuilder<Modifying>`.
+    fn transition<T>(self) -> AlterTableTransactionBuilder<T> {
+        AlterTableTransactionBuilder {
+            snapshot: self.snapshot,
+            operations: self.operations,
+            _state: PhantomData,
+        }
+    }
+}
+
+impl AlterTableTransactionBuilder<Ready> {
+    /// Create a new builder from a snapshot.
+    pub(crate) fn new(snapshot: SnapshotRef) -> Self {
+        AlterTableTransactionBuilder {
+            snapshot,
+            operations: Vec::new(),
+            _state: PhantomData,
+        }
+    }
+}
+
+impl<S: Chainable> AlterTableTransactionBuilder<S> {
+    /// Add a new top-level column to the table schema.
+    ///
+    /// The field must not already exist in the schema (case-insensitive). The field must be
+    /// nullable because existing data files do not contain this column and will read NULL for it.
+    /// These constraints are validated during [`build()`](AlterTableTransactionBuilder::build).
+    pub fn add_column(mut self, field: StructField) -> AlterTableTransactionBuilder<Modifying> {
+        self.operations.push(SchemaOperation::AddColumn { field });
+        self.transition()
+    }
+}
+
+impl AlterTableTransactionBuilder<Modifying> {
+    /// Validate and apply schema operations, then build the [`AlterTableTransaction`].
+    ///
+    /// This method:
+    /// 1. Validates the table supports writes
+    /// 2. Applies each operation sequentially against the evolving schema
+    /// 3. Constructs new Metadata action with evolved schema
+    /// 4. Builds the evolved table configuration
+    /// 5. Creates the transaction
+    ///
+    /// # Errors
+    ///
+    /// - Any individual operation fails validation (see per-method errors above)
+    /// - Table does not support writes (unsupported features)
+    /// - The evolved schema requires protocol features not enabled on the table (e.g. adding a
+    ///   `timestampNtz` column without the `timestampNtz` feature)
+    pub fn build(
+        self,
+        _engine: &dyn Engine,
+        committer: Box<dyn Committer>,
+    ) -> DeltaResult<AlterTableTransaction> {
+        let table_config = self.snapshot.table_configuration();
+        // Rejects writes to tables kernel can't safely commit to: writer version out of
+        // kernel's supported range, unsupported writer features, or schemas with SQL-expression
+        // invariants. Runs on the pre-alter snapshot; future ALTER variants that change the
+        // protocol must also re-check this on the evolved `TableConfiguration`.
+        table_config.ensure_operation_supported(Operation::Write)?;
+
+        let schema = Arc::unwrap_or_clone(table_config.logical_schema());
+        let SchemaEvolutionResult {
+            schema: evolved_schema,
+        } = apply_schema_operations(schema, self.operations, table_config.column_mapping_mode())?;
+
+        let evolved_metadata = table_config
+            .metadata()
+            .clone()
+            .with_schema(evolved_schema.clone())?;
+
+        // Validates the evolved metadata against the protocol.
+        let evolved_table_config = TableConfiguration::try_new_with_schema(
+            table_config,
+            evolved_metadata,
+            evolved_schema,
+        )?;
+
+        AlterTableTransaction::try_new_alter_table(self.snapshot, evolved_table_config, committer)
+    }
+}

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -17,7 +17,7 @@ use crate::actions::{DomainMetadata, Metadata, Protocol};
 use crate::clustering::{create_clustering_domain_metadata, validate_clustering_columns};
 use crate::committer::Committer;
 use crate::expressions::ColumnName;
-use crate::schema::validation::validate_schema_for_create;
+use crate::schema::validation::validate_schema;
 use crate::schema::variant_utils::schema_contains_variant_type;
 use crate::schema::{
     normalize_column_names_to_schema_casing, schema_contains_non_null_fields, DataType, SchemaRef,
@@ -390,7 +390,7 @@ fn maybe_enable_timestamp_ntz(schema: &SchemaRef, validated: &mut ValidatedTable
 /// compatible with Spark readers/writers.
 ///
 /// Explicit `delta.invariants` metadata annotations are rejected by
-/// `validate_schema_for_create`, so this only flips on the feature for nullability-driven
+/// `validate_schema`, so this only flips on the feature for nullability-driven
 /// invariants. Kernel does not itself enforce the null mask at write time -- it relies on
 /// the engine's `ParquetHandler` to do so. Kernel's default `ParquetHandler` uses
 /// `arrow-rs`, whose `RecordBatch::try_new` rejects null values in fields marked
@@ -799,7 +799,7 @@ impl CreateTableTransactionBuilder {
             maybe_apply_column_mapping_for_table_create(&self.schema, &mut validated)?;
 
         // Validate schema (non-empty, column names, duplicates, no `delta.invariants` metadata)
-        validate_schema_for_create(&effective_schema, column_mapping_mode)?;
+        validate_schema(&effective_schema, column_mapping_mode)?;
 
         // Validate data layout and resolve column names (physical for clustering, logical
         // for partitioning). Adds required table features for clustering.

--- a/kernel/src/transaction/builder/mod.rs
+++ b/kernel/src/transaction/builder/mod.rs
@@ -5,4 +5,5 @@
 // and for tests. Also allow dead_code since these are used by integration tests.
 #![allow(unreachable_pub, dead_code)]
 
+pub mod alter_table;
 pub mod create_table;

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -55,8 +55,11 @@ pub mod data_layout;
 #[cfg(not(feature = "internal-api"))]
 pub(crate) mod data_layout;
 
+pub(crate) mod alter_table;
+pub use alter_table::AlterTableTransaction;
 mod commit_info;
 mod domain_metadata;
+pub(crate) mod schema_evolution;
 mod stats_verifier;
 mod update;
 mod write_context;
@@ -177,6 +180,13 @@ pub struct ExistingTable;
 /// invalid for table creation (e.g. file removal, domain metadata removal) are not available.
 #[derive(Debug)]
 pub struct CreateTable;
+
+/// Marker type for alter-table (schema evolution) transactions.
+///
+/// Transactions in this state perform metadata-only commits. Data file operations are not
+/// available at compile time because `AlterTable` does not implement [`SupportsDataFiles`].
+#[derive(Debug)]
+pub struct AlterTable;
 
 /// Marker trait for transaction states that support data file operations.
 ///

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -178,6 +178,15 @@ pub struct ExistingTable;
 #[derive(Debug)]
 pub struct CreateTable;
 
+/// Marker trait for transaction states that support data file operations.
+///
+/// Only transaction types that implement this trait can access methods for adding, removing, or
+/// updating data files. This prevents compile-time misuse by states like `AlterTable` that
+/// only perform metadata-only commits.
+pub trait SupportsDataFiles {}
+impl SupportsDataFiles for ExistingTable {}
+impl SupportsDataFiles for CreateTable {}
+
 /// A transaction represents an in-progress write to a table. After creating a transaction, changes
 /// to the table may be staged via the transaction methods before calling `commit` to commit the
 /// changes to the table.
@@ -756,7 +765,12 @@ impl<S> Transaction<S> {
     pub fn add_files_schema(&self) -> &'static SchemaRef {
         &BASE_ADD_FILES_SCHEMA
     }
+}
 
+// =============================================================================
+// Data file methods -- only available on transaction types that support data files
+// =============================================================================
+impl<S: SupportsDataFiles> Transaction<S> {
     /// Returns the expected schema for file statistics.
     ///
     /// The schema structure is derived from table configuration:
@@ -948,7 +962,12 @@ impl<S> Transaction<S> {
     pub fn add_files(&mut self, add_metadata: Box<dyn EngineData>) {
         self.add_files_metadata.push(add_metadata);
     }
+}
 
+// =============================================================================
+// Internal methods available on ALL transaction types (used by commit path)
+// =============================================================================
+impl<S> Transaction<S> {
     /// Validate that add files have required statistics for clustering columns.
     ///
     /// Per the Delta protocol, writers MUST collect per-file statistics for clustering columns
@@ -1946,7 +1965,7 @@ mod tests {
     // ============================================================================
     // validate_blind_append tests
     // ============================================================================
-    fn add_dummy_file<S>(txn: &mut Transaction<S>) {
+    fn add_dummy_file<S: SupportsDataFiles>(txn: &mut Transaction<S>) {
         let data = string_array_to_engine_data(StringArray::from(vec!["dummy"]));
         txn.add_files(data);
     }

--- a/kernel/src/transaction/schema_evolution.rs
+++ b/kernel/src/transaction/schema_evolution.rs
@@ -1,0 +1,186 @@
+//! Schema evolution operations for ALTER TABLE.
+//!
+//! This module defines the [`SchemaOperation`] enum and the [`apply_schema_operations`] function
+//! that validates and applies schema changes to produce an evolved schema.
+
+use indexmap::IndexMap;
+
+use crate::error::Error;
+use crate::schema::validation::validate_schema;
+use crate::schema::{SchemaRef, StructField, StructType};
+use crate::table_features::ColumnMappingMode;
+use crate::DeltaResult;
+
+/// A schema evolution operation to be applied during ALTER TABLE.
+///
+/// Operations are validated and applied in order during
+/// [`apply_schema_operations`]. Each operation sees the schema state after all prior operations
+/// have been applied.
+#[derive(Debug, Clone)]
+pub(crate) enum SchemaOperation {
+    /// Add a top-level column.
+    AddColumn { field: StructField },
+}
+
+/// The result of applying schema operations.
+#[derive(Debug)]
+pub(crate) struct SchemaEvolutionResult {
+    /// The evolved schema after all operations are applied.
+    pub schema: SchemaRef,
+}
+
+/// Applies a sequence of schema operations to the given schema, returning the evolved schema.
+///
+/// Operations are applied sequentially: each one validates against and modifies the schema
+/// produced by all preceding operations, not the original input schema.
+///
+/// # Errors
+///
+/// Returns an error if any operation fails validation. The error message identifies which
+/// operation failed and why.
+pub(crate) fn apply_schema_operations(
+    schema: StructType,
+    operations: Vec<SchemaOperation>,
+    column_mapping_mode: ColumnMappingMode,
+) -> DeltaResult<SchemaEvolutionResult> {
+    let cm_enabled = column_mapping_mode != ColumnMappingMode::None;
+    // IndexMap preserves field insertion order. Keys are lowercased for case-insensitive
+    // duplicate detection; StructFields retain their original casing.
+    let mut fields: IndexMap<String, StructField> = schema
+        .into_fields()
+        .map(|f| (f.name().to_lowercase(), f))
+        .collect();
+
+    for op in operations {
+        match op {
+            // Protocol feature checks for the field's data type (e.g. `timestampNtz`) happen
+            // later when the caller builds a new TableConfiguration from the evolved schema --
+            // the alter is rejected if the table doesn't already have the required feature
+            // enabled. This matches Spark, which also rejects with
+            // `DELTA_FEATURES_REQUIRE_MANUAL_ENABLEMENT` and requires the user to enable the
+            // feature explicitly before adding such a column.
+            SchemaOperation::AddColumn { field } => {
+                // TODO: support column mapping for add_column (assign ID + physical name,
+                // update delta.columnMapping.maxColumnId).
+                if cm_enabled {
+                    return Err(Error::unsupported(
+                        "ALTER TABLE add_column is not yet supported on tables with \
+                         column mapping enabled",
+                    ));
+                }
+                if field.is_metadata_column() {
+                    return Err(Error::schema(format!(
+                        "Cannot add column '{}': metadata columns are not allowed in \
+                         a table schema",
+                        field.name()
+                    )));
+                }
+                let key = field.name().to_lowercase();
+                if fields.contains_key(&key) {
+                    return Err(Error::schema(format!(
+                        "Cannot add column '{}': a column with that name already exists",
+                        field.name()
+                    )));
+                }
+                // Validate field is nullable (Delta protocol requires added columns to be
+                // nullable so existing data files can return NULL for the new column)
+                // NOTE: non-nullable columns depend on invariants feature
+                if !field.is_nullable() {
+                    return Err(Error::schema(format!(
+                        "Cannot add non-nullable column '{}'. Added columns must be nullable \
+                         because existing data files do not contain this column.",
+                        field.name()
+                    )));
+                }
+                fields.insert(key, field);
+            }
+        }
+    }
+
+    let evolved_schema = StructType::try_new(fields.into_values())?;
+
+    validate_schema(&evolved_schema, column_mapping_mode)?;
+    Ok(SchemaEvolutionResult {
+        schema: evolved_schema.into(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+    use crate::schema::{DataType, MetadataColumnSpec, StructField, StructType};
+
+    fn simple_schema() -> StructType {
+        StructType::try_new(vec![
+            StructField::not_null("id", DataType::INTEGER),
+            StructField::nullable("name", DataType::STRING),
+        ])
+        .unwrap()
+    }
+
+    fn add_col(name: &str, nullable: bool) -> SchemaOperation {
+        let field = if nullable {
+            StructField::nullable(name, DataType::STRING)
+        } else {
+            StructField::not_null(name, DataType::STRING)
+        };
+        SchemaOperation::AddColumn { field }
+    }
+
+    // Builds a struct column whose nested leaf field has the given name. Used to prove that
+    // `validate_schema` (not just the top-level dup check or `StructType::try_new`) is
+    // reached from `apply_schema_operations`.
+    fn add_struct_with_nested_leaf(name: &str, leaf_name: &str) -> SchemaOperation {
+        let inner =
+            StructType::try_new(vec![StructField::nullable(leaf_name, DataType::STRING)]).unwrap();
+        SchemaOperation::AddColumn {
+            field: StructField::nullable(name, inner),
+        }
+    }
+
+    #[rstest]
+    #[case::dup_exact(vec![add_col("name", true)], "already exists")]
+    #[case::dup_case_insensitive(vec![add_col("Name", true)], "already exists")]
+    #[case::dup_within_batch(
+        vec![add_col("email", true), add_col("email", true)],
+        "already exists"
+    )]
+    #[case::non_nullable(vec![add_col("age", false)], "non-nullable")]
+    #[case::invalid_parquet_char(vec![add_col("foo,bar", true)], "invalid character")]
+    #[case::nested_invalid_parquet_char(
+        vec![add_struct_with_nested_leaf("addr", "bad,leaf")],
+        "invalid character"
+    )]
+    #[case::metadata_column(
+        vec![SchemaOperation::AddColumn {
+            field: StructField::create_metadata_column("row_idx", MetadataColumnSpec::RowIndex),
+        }],
+        "metadata columns are not allowed"
+    )]
+    fn apply_schema_operations_rejects(
+        #[case] ops: Vec<SchemaOperation>,
+        #[case] error_contains: &str,
+    ) {
+        let err =
+            apply_schema_operations(simple_schema(), ops, ColumnMappingMode::None).unwrap_err();
+        assert!(err.to_string().contains(error_contains));
+    }
+
+    #[rstest]
+    #[case::single(vec![add_col("email", true)], &["id", "name", "email"])]
+    #[case::multiple(
+        vec![add_col("email", true), add_col("age", true)],
+        &["id", "name", "email", "age"]
+    )]
+    fn apply_schema_operations_succeeds(
+        #[case] ops: Vec<SchemaOperation>,
+        #[case] expected_names: &[&str],
+    ) {
+        let result =
+            apply_schema_operations(simple_schema(), ops, ColumnMappingMode::None).unwrap();
+        let actual: Vec<&str> = result.schema.fields().map(|f| f.name().as_str()).collect();
+        assert_eq!(&actual, expected_names);
+    }
+}

--- a/kernel/tests/alter_table.rs
+++ b/kernel/tests/alter_table.rs
@@ -1,0 +1,299 @@
+//! Integration tests for ALTER TABLE schema evolution.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use delta_kernel::arrow::array::{Array, Int32Array, StringArray};
+use delta_kernel::arrow::record_batch::RecordBatch;
+use delta_kernel::committer::FileSystemCommitter;
+use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
+use delta_kernel::schema::{ArrayType, DataType, MapType, SchemaRef, StructField, StructType};
+use delta_kernel::snapshot::Snapshot;
+use delta_kernel::DeltaResult;
+use rstest::rstest;
+use test_utils::{
+    create_table_and_load_snapshot, test_table_setup, test_table_setup_mt, write_batch_to_table,
+};
+
+fn simple_schema() -> SchemaRef {
+    Arc::new(
+        StructType::try_new(vec![
+            StructField::nullable("id", DataType::INTEGER),
+            StructField::nullable("name", DataType::STRING),
+        ])
+        .unwrap(),
+    )
+}
+
+fn committer() -> Box<FileSystemCommitter> {
+    Box::new(FileSystemCommitter::new())
+}
+
+// ============================================================================
+// Add column tests
+// ============================================================================
+
+#[rstest]
+#[case::one_column(1)]
+#[case::three_columns(3)]
+#[tokio::test]
+async fn add_columns_reload_snapshot_verify_schema(
+    #[case] num_columns: usize,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let snapshot =
+        create_table_and_load_snapshot(&table_path, simple_schema(), engine.as_ref(), &[])?;
+
+    // Write two rows with only the original columns populated.
+    let batch = RecordBatch::try_new(
+        Arc::new(simple_schema().as_ref().try_into_arrow().unwrap()),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2])),
+            Arc::new(StringArray::from(vec!["a", "b"])),
+        ],
+    )
+    .unwrap();
+    let snapshot = write_batch_to_table(&snapshot, engine.as_ref(), batch, HashMap::new()).await?;
+
+    let new_col_names: Vec<String> = (0..num_columns).map(|i| format!("col_{i}")).collect();
+
+    // First add_column transitions Ready -> Modifying; subsequent calls stay in Modifying.
+    let (first, rest) = new_col_names.split_first().unwrap();
+    let committed = rest
+        .iter()
+        .fold(
+            snapshot
+                .alter_table()
+                .add_column(StructField::nullable(first, DataType::STRING)),
+            |b, name| b.add_column(StructField::nullable(name, DataType::STRING)),
+        )
+        .build(engine.as_ref(), committer())?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    // Verify post-commit snapshot has evolved schema
+    let post_snap = committed
+        .post_commit_snapshot()
+        .expect("post-commit snapshot");
+    assert_eq!(post_snap.schema().fields().count(), 2 + num_columns);
+
+    // Reload from storage to verify persistence
+    let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert_eq!(reloaded.version(), 2);
+    let schema = reloaded.schema();
+    assert_eq!(schema.fields().count(), 2 + num_columns);
+    for name in &new_col_names {
+        let field = schema.field(name).expect("added field should exist");
+        assert_eq!(field.data_type(), &DataType::STRING);
+        assert!(field.is_nullable());
+    }
+
+    // Scan back -- old rows should have NULL for every new column.
+    let evolved_arrow_schema: delta_kernel::arrow::datatypes::SchemaRef =
+        Arc::new(reloaded.schema().as_ref().try_into_arrow().unwrap());
+    let scan = reloaded.scan_builder().build()?;
+    let batches = test_utils::read_scan(&scan, engine.clone())?;
+    assert!(!batches.is_empty());
+    let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total_rows, 2);
+    assert_eq!(batches[0].num_columns(), 2 + num_columns);
+    for name in &new_col_names {
+        let col = batches[0].column_by_name(name).expect("new column");
+        assert_eq!(col.null_count(), col.len());
+    }
+
+    // Write two more rows with all columns populated.
+    let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    let mut new_arrays: Vec<Arc<dyn Array>> = vec![
+        Arc::new(Int32Array::from(vec![3, 4])),
+        Arc::new(StringArray::from(vec!["c", "d"])),
+    ];
+    for _ in 0..num_columns {
+        new_arrays.push(Arc::new(StringArray::from(vec!["new_c", "new_d"])));
+    }
+    let batch2 = RecordBatch::try_new(evolved_arrow_schema, new_arrays).unwrap();
+    let reloaded = Arc::new(reloaded);
+    let _ = write_batch_to_table(&reloaded, engine.as_ref(), batch2, HashMap::new()).await?;
+
+    // Scan back -- 4 rows total, each new column has 2 NULLs (old rows) and 2 values (new rows).
+    let final_snap = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert_eq!(final_snap.version(), 3);
+    let scan = final_snap.scan_builder().build()?;
+    let batches = test_utils::read_scan(&scan, engine.clone())?;
+    let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total_rows, 4);
+    for name in &new_col_names {
+        let null_count: usize = batches
+            .iter()
+            .map(|b| b.column_by_name(name).expect("new column").null_count())
+            .sum();
+        assert_eq!(null_count, 2, "column {name} should have 2 NULLs");
+    }
+
+    Ok(())
+}
+
+/// Adding columns of complex types (struct, array, map) on a non-CM table. Verifies
+#[rstest]
+#[case::struct_column(
+    StructField::nullable(
+        "address",
+        StructType::try_new(vec![
+            StructField::nullable("city", DataType::STRING),
+            StructField::nullable("zip", DataType::STRING),
+        ]).unwrap(),
+    )
+)]
+#[case::array_of_primitive(StructField::nullable("tags", ArrayType::new(DataType::STRING, true),))]
+#[case::map_of_primitives(StructField::nullable(
+    "labels",
+    MapType::new(DataType::STRING, DataType::INTEGER, true),
+))]
+#[tokio::test]
+async fn add_complex_type_column(#[case] field: StructField) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let snapshot =
+        create_table_and_load_snapshot(&table_path, simple_schema(), engine.as_ref(), &[])?;
+    let field_name = field.name().to_string();
+    let expected_type = field.data_type().clone();
+
+    snapshot
+        .alter_table()
+        .add_column(field)
+        .build(engine.as_ref(), committer())?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    let reloaded = Snapshot::builder_for(table_path).build(engine.as_ref())?;
+    let schema = reloaded.schema();
+    let added = schema.field(&field_name).expect("added field should exist");
+    assert_eq!(added.data_type(), &expected_type);
+    Ok(())
+}
+
+#[rstest]
+#[case::duplicate_column(&[], StructField::nullable("name", DataType::STRING), "already exists")]
+#[case::duplicate_column_case_insensitive(
+    &[],
+    StructField::nullable("NAME", DataType::STRING),
+    "already exists"
+)]
+#[case::timestamp_ntz_without_feature(
+    &[],
+    StructField::nullable("ts", DataType::TIMESTAMP_NTZ),
+    "timestampNtz"
+)]
+#[case::non_nullable(&[], StructField::not_null("age", DataType::INTEGER), "non-nullable")]
+#[case::column_mapping_enabled(
+    &[("delta.columnMapping.mode", "name")],
+    StructField::nullable("email", DataType::STRING),
+    "column mapping"
+)]
+#[tokio::test]
+async fn add_column_failures(
+    #[case] properties: &[(&str, &str)],
+    #[case] field: StructField,
+    #[case] error_contains: &str,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let snapshot =
+        create_table_and_load_snapshot(&table_path, simple_schema(), engine.as_ref(), properties)?;
+
+    let err = snapshot
+        .alter_table()
+        .add_column(field)
+        .build(engine.as_ref(), committer());
+    assert!(err.is_err());
+    assert!(err.unwrap_err().to_string().contains(error_contains));
+
+    Ok(())
+}
+
+/// Back-to-back alters with a checkpoint in between, then a write against the evolved schema.
+/// Exercises: create (v0) → alter add A (v1) → checkpoint at v1 → alter add B (v2) → write
+/// row with values in both new columns (v3) → reload. The reload must rebuild the snapshot
+/// from the checkpoint + alter commits + data commit and return the written values.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn back_to_back_alters_with_checkpoint() -> Result<(), Box<dyn std::error::Error>> {
+    // Checkpoint writing requires the multi-threaded engine (like `maintenance_ops.rs`).
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+
+    // v0: create.
+    let snapshot =
+        create_table_and_load_snapshot(&table_path, simple_schema(), engine.as_ref(), &[])?;
+
+    // v1: add column "a".
+    let v1 = snapshot
+        .alter_table()
+        .add_column(StructField::nullable("a", DataType::STRING))
+        .build(engine.as_ref(), committer())?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+    let v1_snap = v1
+        .post_commit_snapshot()
+        .expect("post-commit snapshot at v1");
+
+    // Checkpoint at v1.
+    let (_, v1_ckpt) = v1_snap.clone().checkpoint(engine.as_ref())?;
+
+    // v2: add column "b" on top of the checkpointed snapshot.
+    let v2 = v1_ckpt
+        .alter_table()
+        .add_column(StructField::nullable("b", DataType::INTEGER))
+        .build(engine.as_ref(), committer())?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+    let v2_snap = v2
+        .post_commit_snapshot()
+        .expect("post-commit snapshot at v2");
+
+    // v3: write one row populating both new columns.
+    let evolved_arrow_schema: delta_kernel::arrow::datatypes::SchemaRef =
+        Arc::new(v2_snap.schema().as_ref().try_into_arrow().unwrap());
+    let batch = RecordBatch::try_new(
+        evolved_arrow_schema,
+        vec![
+            Arc::new(Int32Array::from(vec![1])),
+            Arc::new(StringArray::from(vec!["alice"])),
+            Arc::new(StringArray::from(vec!["val_a"])),
+            Arc::new(delta_kernel::arrow::array::Int32Array::from(vec![100])),
+        ],
+    )
+    .unwrap();
+    write_batch_to_table(v2_snap, engine.as_ref(), batch, HashMap::new()).await?;
+
+    // Reload from scratch: kernel must rebuild from checkpoint + alter commits + data commit.
+    let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert_eq!(reloaded.version(), 3);
+    let schema = reloaded.schema();
+    assert!(
+        schema.field("a").is_some(),
+        "column added at v1 must survive checkpoint"
+    );
+    assert!(
+        schema.field("b").is_some(),
+        "column added at v2 must be present"
+    );
+
+    // Scan the row back and verify values in both newly-added columns.
+    let scan = reloaded.scan_builder().build()?;
+    let batches = test_utils::read_scan(&scan, engine.clone())?;
+    let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total_rows, 1);
+    let a_col = batches[0]
+        .column_by_name("a")
+        .expect("column a")
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .expect("a is string");
+    assert_eq!(a_col.value(0), "val_a");
+    let b_col = batches[0]
+        .column_by_name("b")
+        .expect("column b")
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .expect("b is int");
+    assert_eq!(b_col.value(0), 100);
+
+    Ok(())
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Introduces the ALTER TABLE schema evolution framework and the first operation: `add_column` for adding top level columns on non Column Mapping tables. Support for adding column on Column Mapping tables is in PR5 on the stack.

- `Snapshot::alter_table()` returns an `AlterTableTransactionBuilder` that uses a type-state
  pattern (`Ready` -> `Modifying`) to enforce at least one operation before `build()`
- `SchemaOperation` enum and `apply_schema_operations()` validate and apply schema changes
- `AlterTableTransaction` commits metadata-only changes (`data_change: false`) with the evolved
  schema
- Added columns must be nullable (existing data files return NULL for the new column)

## How was this change tested?

- Unit tests in `schema_evolution.rs`: add column success/failure, case-insensitive duplicate
  detection, `modify_field_at_path` helper (top-level, nested, siblings, error paths)
- Integration tests in `kernel/tests/alter_table.rs`: end-to-end add column with schema reload,
  multiple columns in one commit, duplicate/non-nullable rejection
- compile_fail doctests verifying `build()` is unavailable in `Ready` state and data-file
  operations are unavailable on `AlterTableTransaction`