### PR TITLE
feat: add set_nullable support for ALTER TABLE

### DIFF
--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -817,6 +817,56 @@ impl StructType {
         self.fields.into_values()
     }
 
+    /// Gets a mutable reference to the underlying field map.
+    pub(crate) fn field_map_mut(&mut self) -> &mut IndexMap<String, StructField> {
+        &mut self.fields
+    }
+
+    /// Walk a pre-segmented column path through this schema and return the leaf field.
+    ///
+    /// `path` is the path's individual name segments (one per nesting level), already split by
+    /// the caller. Lookup at each level is case-insensitive. The Delta protocol uses `.` as the
+    /// dotted-path separator at the API surface, but `field_at_path` itself does not split --
+    /// callers typically pass [`ColumnName::path()`](crate::expressions::ColumnName::path),
+    /// which yields the segments directly.
+    ///
+    /// Panics if any segment is missing or an intermediate field is not a struct. Intended for
+    /// use in test assertions.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Schema:
+    /// //   id:      INTEGER  not null
+    /// //   address: STRUCT { city: STRING not null, zip: STRING }
+    /// let path = vec!["address".to_string(), "city".to_string()];
+    /// let city = schema.field_at_path(&path);
+    /// assert_eq!(city.name(), "city");
+    /// assert!(!city.is_nullable());
+    /// ```
+    #[cfg(any(test, feature = "test-utils"))]
+    #[allow(clippy::panic, clippy::expect_used)]
+    pub fn field_at_path<'a>(&'a self, path: &[String]) -> &'a StructField {
+        fn find_ci<'a>(
+            mut fields: impl Iterator<Item = &'a StructField>,
+            name: &str,
+        ) -> &'a StructField {
+            let lowered = name.to_lowercase();
+            fields
+                .find(|f| f.name().to_lowercase() == lowered)
+                .unwrap_or_else(|| panic!("field '{name}' not found"))
+        }
+        let (first, rest) = path.split_first().expect("non-empty path");
+        let mut field = find_ci(self.fields(), first);
+        for seg in rest {
+            let DataType::Struct(s) = field.data_type() else {
+                panic!("expected struct at intermediate segment '{seg}'");
+            };
+            field = find_ci(s.fields(), seg);
+        }
+        field
+    }
+
     /// Gets all the field names in this struct type in the order they are defined.
     pub fn field_names(&self) -> impl ExactSizeIterator<Item = &String> {
         self.fields.keys()

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -28,6 +28,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use crate::committer::Committer;
+use crate::expressions::ColumnName;
 use crate::schema::StructField;
 use crate::snapshot::SnapshotRef;
 use crate::table_configuration::TableConfiguration;
@@ -110,6 +111,16 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
     /// These constraints are validated during [`build()`](AlterTableTransactionBuilder::build).
     pub fn add_column(mut self, field: StructField) -> AlterTableTransactionBuilder<Modifying> {
         self.operations.push(SchemaOperation::AddColumn { field });
+        self.transition()
+    }
+
+    /// Change a column's nullability from NOT NULL to nullable. If the column is already
+    /// nullable, the op is a no-op but still generates a commit.
+    ///
+    /// Note: this matches Spark's behavior.
+    pub fn set_nullable(mut self, column: ColumnName) -> AlterTableTransactionBuilder<Modifying> {
+        self.operations
+            .push(SchemaOperation::SetNullable { column });
         self.transition()
     }
 }

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -178,6 +178,15 @@ pub struct ExistingTable;
 #[derive(Debug)]
 pub struct CreateTable;
 
+/// Marker trait for transaction states that support data file operations.
+///
+/// Only transaction types that implement this trait can access methods for adding, removing, or
+/// updating data files. This prevents compile-time misuse by states like `AlterTable` that
+/// only perform metadata-only commits.
+pub trait SupportsDataFiles {}
+impl SupportsDataFiles for ExistingTable {}
+impl SupportsDataFiles for CreateTable {}
+
 /// A transaction represents an in-progress write to a table. After creating a transaction, changes
 /// to the table may be staged via the transaction methods before calling `commit` to commit the
 /// changes to the table.
@@ -756,7 +765,12 @@ impl<S> Transaction<S> {
     pub fn add_files_schema(&self) -> &'static SchemaRef {
         &BASE_ADD_FILES_SCHEMA
     }
+}
 
+// =============================================================================
+// Data file methods -- only available on transaction types that support data files
+// =============================================================================
+impl<S: SupportsDataFiles> Transaction<S> {
     /// Returns the expected schema for file statistics.
     ///
     /// The schema structure is derived from table configuration:
@@ -948,7 +962,12 @@ impl<S> Transaction<S> {
     pub fn add_files(&mut self, add_metadata: Box<dyn EngineData>) {
         self.add_files_metadata.push(add_metadata);
     }
+}
 
+// =============================================================================
+// Internal methods available on ALL transaction types (used by commit path)
+// =============================================================================
+impl<S> Transaction<S> {
     /// Validate that add files have required statistics for clustering columns.
     ///
     /// Per the Delta protocol, writers MUST collect per-file statistics for clustering columns
@@ -1946,7 +1965,7 @@ mod tests {
     // ============================================================================
     // validate_blind_append tests
     // ============================================================================
-    fn add_dummy_file<S>(txn: &mut Transaction<S>) {
+    fn add_dummy_file<S: SupportsDataFiles>(txn: &mut Transaction<S>) {
         let data = string_array_to_engine_data(StringArray::from(vec!["dummy"]));
         txn.add_files(data);
     }

--- a/kernel/src/transaction/schema_evolution.rs
+++ b/kernel/src/transaction/schema_evolution.rs
@@ -6,8 +6,9 @@
 use indexmap::IndexMap;
 
 use crate::error::Error;
+use crate::expressions::ColumnName;
 use crate::schema::validation::validate_schema;
-use crate::schema::{SchemaRef, StructField, StructType};
+use crate::schema::{DataType, SchemaRef, StructField, StructType};
 use crate::table_features::ColumnMappingMode;
 use crate::DeltaResult;
 
@@ -20,6 +21,60 @@ use crate::DeltaResult;
 pub(crate) enum SchemaOperation {
     /// Add a top-level column.
     AddColumn { field: StructField },
+
+    /// Change a column's nullability from NOT NULL to nullable.
+    SetNullable { column: ColumnName },
+}
+
+// Helper to modify a nested column. For each component in `path`, locates the matching field
+// (case-insensitive), then descends into the next nested struct. At the leaf, calls `modifier`
+// to mutate the field in place.
+//
+// `modifier` is expected to mutate the field's nullability, metadata, or `data_type` -- but
+// not its name. Renames need additional handling (IndexMap re-keying + sibling-conflict check)
+// that downstream PRs will introduce alongside the rename caller.
+//
+// Returns an error if a field in the path does not exist or an intermediate field is not a struct.
+//
+// Example:
+//   fields   = [ id: int not null, address: struct { city: string not null, zip: string } ]
+//   path     = ["address", "city"]
+//   modifier = |f| { f.nullable = true; Ok(()) }
+// yields:
+//   [ id: int not null, address: struct { city: string, zip: string } ]
+fn modify_field_at_path(
+    fields: &mut IndexMap<String, StructField>,
+    path: &[String],
+    modifier: &dyn Fn(&mut StructField) -> DeltaResult<()>,
+) -> DeltaResult<()> {
+    let (first, rest) = path
+        .split_first()
+        .ok_or_else(|| Error::generic("empty column path"))?;
+
+    // Delta column names are case-insensitive.
+    let lowered = first.to_lowercase();
+    let idx = fields
+        .iter()
+        .position(|(_, f)| f.name().to_lowercase() == lowered)
+        .ok_or_else(|| Error::generic(format!("field '{first}' does not exist")))?;
+
+    if !rest.is_empty() {
+        let (_, field) = fields
+            .get_index_mut(idx)
+            .ok_or_else(|| Error::internal_error("idx from position() invalid"))?;
+        let DataType::Struct(inner) = &mut field.data_type else {
+            return Err(Error::generic(format!(
+                "intermediate field '{first}' is not a struct"
+            )));
+        };
+        return modify_field_at_path(inner.field_map_mut(), rest, modifier);
+    }
+
+    // === Leaf handling ===
+    let (_, field) = fields
+        .get_index_mut(idx)
+        .ok_or_else(|| Error::internal_error("idx from position() invalid"))?;
+    modifier(field)
 }
 
 /// The result of applying schema operations.
@@ -39,17 +94,11 @@ pub(crate) struct SchemaEvolutionResult {
 /// Returns an error if any operation fails validation. The error message identifies which
 /// operation failed and why.
 pub(crate) fn apply_schema_operations(
-    schema: StructType,
+    mut schema: StructType,
     operations: Vec<SchemaOperation>,
     column_mapping_mode: ColumnMappingMode,
 ) -> DeltaResult<SchemaEvolutionResult> {
     let cm_enabled = column_mapping_mode != ColumnMappingMode::None;
-    // IndexMap preserves field insertion order. Keys are lowercased for case-insensitive
-    // duplicate detection; StructFields retain their original casing.
-    let mut fields: IndexMap<String, StructField> = schema
-        .into_fields()
-        .map(|f| (f.name().to_lowercase(), f))
-        .collect();
 
     for op in operations {
         match op {
@@ -75,8 +124,12 @@ pub(crate) fn apply_schema_operations(
                         field.name()
                     )));
                 }
-                let key = field.name().to_lowercase();
-                if fields.contains_key(&key) {
+                if !matches!(field.data_type, DataType::Primitive(_)) {
+                    StructType::ensure_no_metadata_columns_in_field(&field)?;
+                }
+                // Case-insensitive sibling-conflict check (O(N) per AddColumn).
+                let lowered = field.name().to_lowercase();
+                if schema.fields().any(|f| f.name().to_lowercase() == lowered) {
                     return Err(Error::schema(format!(
                         "Cannot add column '{}': a column with that name already exists",
                         field.name()
@@ -92,16 +145,23 @@ pub(crate) fn apply_schema_operations(
                         field.name()
                     )));
                 }
-                fields.insert(key, field);
+                schema.field_map_mut().insert(field.name().clone(), field);
+            }
+            SchemaOperation::SetNullable { column } => {
+                modify_field_at_path(schema.field_map_mut(), column.path(), &|f| {
+                    f.nullable = true;
+                    Ok(())
+                })
+                .map_err(|e| {
+                    Error::generic(format!("Cannot set nullable on column '{column}': {e}"))
+                })?;
             }
         }
     }
 
-    let evolved_schema = StructType::try_new(fields.into_values())?;
-
-    validate_schema(&evolved_schema, column_mapping_mode)?;
+    validate_schema(&schema, column_mapping_mode)?;
     Ok(SchemaEvolutionResult {
-        schema: evolved_schema.into(),
+        schema: schema.into(),
     })
 }
 
@@ -110,6 +170,7 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
+    use crate::expressions::{column_name, ColumnName};
     use crate::schema::{DataType, MetadataColumnSpec, StructField, StructType};
 
     fn simple_schema() -> StructType {
@@ -139,6 +200,107 @@ mod tests {
             field: StructField::nullable(name, inner),
         }
     }
+
+    fn nested_schema() -> StructType {
+        StructType::try_new(vec![
+            StructField::not_null("id", DataType::INTEGER),
+            StructField::nullable(
+                "address",
+                StructType::try_new(vec![
+                    StructField::not_null("city", DataType::STRING),
+                    StructField::nullable("zip", DataType::STRING),
+                ])
+                .unwrap(),
+            ),
+        ])
+        .unwrap()
+    }
+
+    // === modify_field_at_path tests ===
+
+    // Convert a StructType into the IndexMap<String, StructField> shape that
+    // `modify_field_at_path` operates on.
+    fn into_field_map(schema: StructType) -> IndexMap<String, StructField> {
+        schema
+            .into_fields()
+            .map(|f| (f.name().clone(), f))
+            .collect()
+    }
+
+    fn set_nullable_modifier(f: &mut StructField) -> DeltaResult<()> {
+        f.nullable = true;
+        Ok(())
+    }
+
+    fn modify_field_at_path_test_helper(
+        schema: StructType,
+        path: &[String],
+    ) -> DeltaResult<IndexMap<String, StructField>> {
+        let mut fields = into_field_map(schema);
+        modify_field_at_path(&mut fields, path, &set_nullable_modifier)?;
+        Ok(fields)
+    }
+
+    #[test]
+    fn modify_top_level_field_sets_nullable() {
+        let path = vec!["id".to_string()];
+        let result = modify_field_at_path_test_helper(simple_schema(), &path).unwrap();
+        let id = result.values().find(|f| f.name() == "id").unwrap();
+        assert!(id.is_nullable());
+    }
+
+    #[test]
+    fn modify_nested_field_modifies_only_leaf() {
+        let path = vec!["address".to_string(), "city".to_string()];
+        let result = modify_field_at_path_test_helper(nested_schema(), &path).unwrap();
+        let addr = result.values().find(|f| f.name() == "address").unwrap();
+        match addr.data_type() {
+            DataType::Struct(s) => assert!(s.field("city").unwrap().is_nullable()),
+            other => panic!("Expected Struct, got: {other:?}"),
+        }
+    }
+
+    /// Modifying one nested leaf (`address.city`) must not touch any other field.
+    /// Guards against the recursive rebuild accidentally replacing siblings when it reconstructs
+    /// the enclosing struct.
+    #[test]
+    fn modify_nested_leaf_preserves_other_fields() {
+        let path = vec!["address".to_string(), "city".to_string()];
+        let result = modify_field_at_path_test_helper(nested_schema(), &path).unwrap();
+        let id = result.values().find(|f| f.name() == "id").unwrap();
+        assert!(!id.is_nullable());
+        let addr = result.values().find(|f| f.name() == "address").unwrap();
+        match addr.data_type() {
+            DataType::Struct(s) => assert!(s.field("zip").unwrap().is_nullable()),
+            other => panic!("Expected Struct, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn modify_nonexistent_field_fails() {
+        let path = vec!["nope".to_string()];
+        let err = modify_field_at_path_test_helper(simple_schema(), &path).unwrap_err();
+        assert!(err.to_string().contains("does not exist"));
+    }
+
+    /// A path that descends into a non-struct intermediate field (here: `name.inner`, where
+    /// `name` is a STRING, not a struct) must error rather than silently succeed or panic.
+    #[test]
+    fn modify_through_non_struct_fails() {
+        let path = vec!["name".to_string(), "inner".to_string()];
+        let err = modify_field_at_path_test_helper(simple_schema(), &path).unwrap_err();
+        assert!(err.to_string().contains("not a struct"));
+    }
+
+    #[test]
+    fn modify_case_insensitive_lookup_finds_field() {
+        let path = vec!["ID".to_string()];
+        let result = modify_field_at_path_test_helper(simple_schema(), &path).unwrap();
+        let id = result.values().find(|f| f.name() == "id").unwrap();
+        assert!(id.is_nullable());
+    }
+
+    // === apply_schema_operations tests ===
 
     #[rstest]
     #[case::dup_exact(vec![add_col("name", true)], "already exists")]
@@ -182,5 +344,114 @@ mod tests {
             apply_schema_operations(simple_schema(), ops, ColumnMappingMode::None).unwrap();
         let actual: Vec<&str> = result.schema.fields().map(|f| f.name().as_str()).collect();
         assert_eq!(&actual, expected_names);
+    }
+
+    // === apply_schema_operations: SetNullable tests ===
+
+    fn deeply_nested_required_schema() -> StructType {
+        StructType::try_new(vec![
+            StructField::not_null("id", DataType::INTEGER),
+            StructField::nullable(
+                "address",
+                StructType::try_new(vec![StructField::nullable(
+                    "location",
+                    StructType::try_new(vec![StructField::not_null("zipcode", DataType::STRING)])
+                        .unwrap(),
+                )])
+                .unwrap(),
+            ),
+        ])
+        .unwrap()
+    }
+
+    #[rstest]
+    #[case::on_required_field(simple_schema(), column_name!("id"))]
+    #[case::already_nullable_is_noop(simple_schema(), column_name!("name"))]
+    #[case::case_insensitive(simple_schema(), column_name!("ID"))]
+    #[case::nested_field(nested_schema(), column_name!("address.city"))]
+    #[case::deeply_nested_field(deeply_nested_required_schema(), column_name!("address.location.zipcode"))]
+    fn set_nullable_succeeds(#[case] schema: StructType, #[case] column: ColumnName) {
+        let ops = vec![SchemaOperation::SetNullable {
+            column: column.clone(),
+        }];
+        let result = apply_schema_operations(schema, ops, ColumnMappingMode::None).unwrap();
+        assert!(result.schema.field_at_path(column.path()).is_nullable());
+    }
+
+    #[rstest]
+    #[case::nonexistent_column(column_name!("nonexistent"), "does not exist")]
+    #[case::through_non_struct(column_name!("name.inner"), "not a struct")]
+    #[case::empty_path(ColumnName::new(Vec::<String>::new()), "empty column path")]
+    fn set_nullable_fails(#[case] column: ColumnName, #[case] error_contains: &str) {
+        let ops = vec![SchemaOperation::SetNullable { column }];
+        let err =
+            apply_schema_operations(simple_schema(), ops, ColumnMappingMode::None).unwrap_err();
+        assert!(
+            err.to_string().contains(error_contains),
+            "expected error to contain '{error_contains}', got: {err}"
+        );
+    }
+
+    /// Setting a struct itself nullable must not mutate inner fields. Kept separate from the
+    /// `set_nullable_succeeds` rstest because it asserts on inner-field preservation.
+    #[test]
+    fn set_nullable_on_struct_itself_preserves_inner_fields() {
+        let schema = StructType::try_new(vec![StructField::not_null(
+            "address",
+            StructType::try_new(vec![StructField::not_null("city", DataType::STRING)]).unwrap(),
+        )])
+        .unwrap();
+        let ops = vec![SchemaOperation::SetNullable {
+            column: column_name!("address"),
+        }];
+        let result = apply_schema_operations(schema, ops, ColumnMappingMode::None).unwrap();
+        let addr = result.schema.field("address").unwrap();
+        assert!(addr.is_nullable(), "struct itself must be nullable");
+        match addr.data_type() {
+            DataType::Struct(s) => assert!(
+                !s.field("city").unwrap().is_nullable(),
+                "inner field must remain NOT NULL"
+            ),
+            other => panic!("Expected Struct, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn chain_add_and_set_nullable_applies_both() {
+        let ops = vec![
+            SchemaOperation::AddColumn {
+                field: StructField::nullable("email", DataType::STRING),
+            },
+            SchemaOperation::SetNullable {
+                column: column_name!("id"),
+            },
+        ];
+        let result =
+            apply_schema_operations(simple_schema(), ops, ColumnMappingMode::None).unwrap();
+        assert_eq!(result.schema.fields().count(), 3);
+        assert!(result.schema.field("email").is_some());
+        assert!(result.schema.field("id").unwrap().is_nullable());
+    }
+
+    #[test]
+    fn set_nullable_nested_preserves_top_level_order() {
+        // SetNullable on a nested field within a middle top-level field must not reorder
+        // the top-level IndexMap.
+        let schema = StructType::try_new(vec![
+            StructField::not_null("alpha", DataType::INTEGER),
+            StructField::nullable(
+                "beta",
+                StructType::try_new(vec![StructField::not_null("nested", DataType::STRING)])
+                    .unwrap(),
+            ),
+            StructField::not_null("gamma", DataType::STRING),
+        ])
+        .unwrap();
+        let ops = vec![SchemaOperation::SetNullable {
+            column: column_name!("beta.nested"),
+        }];
+        let result = apply_schema_operations(schema, ops, ColumnMappingMode::None).unwrap();
+        let names: Vec<&String> = result.schema.fields().map(|f| f.name()).collect();
+        assert_eq!(names, vec!["alpha", "beta", "gamma"]);
     }
 }

--- a/kernel/tests/alter_table.rs
+++ b/kernel/tests/alter_table.rs
@@ -7,8 +7,11 @@ use delta_kernel::arrow::array::{Array, Int32Array, StringArray};
 use delta_kernel::arrow::record_batch::RecordBatch;
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
+use delta_kernel::expressions::{column_name, ColumnName, Scalar};
 use delta_kernel::schema::{ArrayType, DataType, MapType, SchemaRef, StructField, StructType};
 use delta_kernel::snapshot::Snapshot;
+use delta_kernel::transaction::create_table::create_table;
+use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::DeltaResult;
 use rstest::rstest;
 use test_utils::{
@@ -295,5 +298,219 @@ async fn back_to_back_alters_with_checkpoint() -> Result<(), Box<dyn std::error:
         .expect("b is int");
     assert_eq!(b_col.value(0), 100);
 
+    Ok(())
+}
+
+// ============================================================================
+// SET NULLABLE tests
+// ============================================================================
+
+/// Cross-product: 3 schema/column cases x 3 CM modes (off, name, id).
+#[rstest]
+#[case::already_nullable(simple_schema(), column_name!("name"))]
+#[case::required_top_level(
+    Arc::new(StructType::try_new(vec![
+        StructField::not_null("id", DataType::INTEGER),
+        StructField::nullable("name", DataType::STRING),
+    ]).unwrap()),
+    column_name!("id")
+)]
+#[case::required_nested(
+    Arc::new(StructType::try_new(vec![
+        StructField::nullable("id", DataType::INTEGER),
+        StructField::nullable(
+            "address",
+            StructType::try_new(vec![
+                StructField::not_null("city", DataType::STRING),
+                StructField::nullable("zip", DataType::STRING),
+            ]).unwrap(),
+        ),
+    ]).unwrap()),
+    column_name!("address.city")
+)]
+#[tokio::test]
+async fn set_nullable_succeeds(
+    #[case] schema: SchemaRef,
+    #[case] column: ColumnName,
+    #[values(None, Some("name"), Some("id"))] cm_mode: Option<&str>,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let properties: Vec<(&str, &str)> = cm_mode
+        .map(|m| vec![("delta.columnMapping.mode", m)])
+        .unwrap_or_default();
+    let snapshot =
+        create_table_and_load_snapshot(&table_path, schema, engine.as_ref(), &properties)?;
+    // Snapshot the field before the alter so we can prove set_nullable changes only the
+    // nullable bit -- preserving name, data type, and ALL metadata (including column-mapping
+    // id and physical name when CM is enabled).
+    let before = snapshot.schema().field_at_path(column.path()).clone();
+
+    snapshot
+        .alter_table()
+        .set_nullable(column.clone())
+        .build(engine.as_ref(), committer())?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    let reloaded = Snapshot::builder_for(table_path).build(engine.as_ref())?;
+    let reloaded_schema = reloaded.schema();
+    let after = reloaded_schema.field_at_path(column.path());
+    assert!(after.is_nullable());
+    assert_eq!(after.name(), before.name());
+    assert_eq!(after.data_type(), before.data_type());
+    assert_eq!(
+        after.metadata(),
+        before.metadata(),
+        "field metadata (incl. column mapping id/physical name) must be preserved"
+    );
+    Ok(())
+}
+
+/// End-to-end: create a table with a non-null layout column (partition or clustering),
+/// write a row, flip the layout column to nullable, checkpoint, reload from scratch, scan.
+/// Cross-product: layout kind (partitioned, clustered) x column-mapping mode (off, name, id).
+#[rstest]
+#[case::partition("date", DataLayout::partitioned(["date"]), "2026-01-01")]
+#[case::clustered("region", DataLayout::clustered(["region"]), "us")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn set_nullable_on_layout_column_with_checkpoint(
+    #[case] col_name: &str,
+    #[case] layout: DataLayout,
+    #[case] col_value: &str,
+    #[values(None, Some("name"), Some("id"))] cm_mode: Option<&str>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+    // Partition values live in the directory path; clustering values live in the row batch.
+    let is_partitioned = matches!(layout, DataLayout::Partitioned { .. });
+
+    // v0: create the table with the layout column as non-null.
+    let schema = Arc::new(StructType::try_new(vec![
+        StructField::nullable("id", DataType::INTEGER),
+        StructField::not_null(col_name, DataType::STRING),
+    ])?);
+    let properties: Vec<(&str, &str)> = cm_mode
+        .map(|m| vec![("delta.columnMapping.mode", m)])
+        .unwrap_or_default();
+    create_table(&table_path, schema.clone(), "Test/1.0")
+        .with_data_layout(layout)
+        .with_table_properties(properties)
+        .build(engine.as_ref(), committer())?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+    let v0 = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert!(!v0.schema().field(col_name).unwrap().is_nullable());
+
+    // v1: write a single row.
+    let v0_arc = Arc::new(v0);
+    let v1 = if is_partitioned {
+        // Partition cols are excluded from the row batch and passed via partition_values.
+        let nonpartition_arrow_schema: delta_kernel::arrow::datatypes::SchemaRef =
+            Arc::new(delta_kernel::arrow::datatypes::Schema::new(vec![
+                delta_kernel::arrow::datatypes::Field::new(
+                    "id",
+                    delta_kernel::arrow::datatypes::DataType::Int32,
+                    true,
+                ),
+            ]));
+        let batch = RecordBatch::try_new(
+            nonpartition_arrow_schema,
+            vec![Arc::new(Int32Array::from(vec![1]))],
+        )?;
+        let mut partition_values = HashMap::new();
+        partition_values.insert(col_name.to_string(), Scalar::String(col_value.to_string()));
+        write_batch_to_table(&v0_arc, engine.as_ref(), batch, partition_values).await?
+    } else {
+        // Clustering cols are regular columns; partition_values is empty.
+        let arrow_schema: delta_kernel::arrow::datatypes::SchemaRef =
+            Arc::new(schema.as_ref().try_into_arrow().unwrap());
+        let batch = RecordBatch::try_new(
+            arrow_schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1])),
+                Arc::new(StringArray::from(vec![col_value])),
+            ],
+        )?;
+        write_batch_to_table(&v0_arc, engine.as_ref(), batch, HashMap::new()).await?
+    };
+
+    // v2: ALTER TABLE -- set the layout column nullable.
+    let v2 = v1
+        .alter_table()
+        .set_nullable(ColumnName::new([col_name]))
+        .build(engine.as_ref(), committer())?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+    let v2_snap = v2
+        .post_commit_snapshot()
+        .expect("post-commit snapshot at v2");
+    assert!(v2_snap.schema().field(col_name).unwrap().is_nullable());
+
+    // Checkpoint at v2 so reload exercises the checkpoint path.
+    v2_snap.clone().checkpoint(engine.as_ref())?;
+
+    // Reload from scratch and verify the schema and row survive.
+    let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert_eq!(reloaded.version(), 2);
+    assert!(reloaded.schema().field(col_name).unwrap().is_nullable());
+
+    let scan = reloaded.scan_builder().build()?;
+    let batches = test_utils::read_scan(&scan, engine.clone())?;
+    let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total_rows, 1);
+    let col = batches[0]
+        .column_by_name(col_name)
+        .expect("layout column")
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .expect("layout column is string");
+    assert_eq!(col.value(0), col_value);
+    Ok(())
+}
+
+#[tokio::test]
+async fn set_nullable_nonexistent_column_fails() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let snapshot =
+        create_table_and_load_snapshot(&table_path, simple_schema(), engine.as_ref(), &[])?;
+
+    let err = snapshot
+        .alter_table()
+        .set_nullable(column_name!("nonexistent"))
+        .build(engine.as_ref(), committer());
+    assert!(err.is_err());
+    assert!(err.unwrap_err().to_string().contains("does not exist"));
+
+    Ok(())
+}
+
+/// Alternating chain: ADD COLUMN, SET NULLABLE, ADD COLUMN, SET NULLABLE. Verifies that
+/// chaining mixed ops applies them in order and produces the expected final schema. Each
+/// SET NULLABLE flips a still-NOT-NULL column from the original schema.
+#[tokio::test]
+async fn chain_add_column_and_set_nullable() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let schema = Arc::new(StructType::try_new(vec![
+        StructField::not_null("id", DataType::INTEGER),
+        StructField::not_null("name", DataType::STRING),
+    ])?);
+    let snapshot = create_table_and_load_snapshot(&table_path, schema, engine.as_ref(), &[])?;
+
+    snapshot
+        .alter_table()
+        .add_column(StructField::nullable("email", DataType::STRING))
+        .set_nullable(column_name!("id"))
+        .add_column(StructField::nullable("age", DataType::INTEGER))
+        .set_nullable(column_name!("name"))
+        .build(engine.as_ref(), committer())?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    let reloaded = Snapshot::builder_for(table_path).build(engine.as_ref())?;
+    let schema = reloaded.schema();
+    assert_eq!(schema.fields().count(), 4);
+    for name in ["id", "name", "email", "age"] {
+        let field = schema.field(name).expect("field should be present");
+        assert!(field.is_nullable(), "field '{name}' should be nullable");
+    }
     Ok(())
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds the `SetNullable` operation to the ALTER TABLE framework, allowing columns to be changed
from NOT NULL to nullable. Supports nested columns via `ColumnName` paths.

`modify_field_at_path` function to recurse through struct and rebuild bottom-up to update nullable field.

## How was this change tested?

- Unit tests for `modify_field_at_path`: top-level, nested, sibling preservation, nonexistent
  field, non-struct traversal, case-insensitive lookup
- Unit tests for `SetNullable` via `apply_schema_operations`: required->nullable, already
  nullable noop, deeply nested (3 levels), chained with add_column
- Integration tests in `kernel/tests/alter_table.rs`: set_nullable with schema reload,
  already-nullable noop, nonexistent column error, chained add_column + set_nullable