### PR TITLE
feat!: add column mapping support for add_column

### DIFF
--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -360,6 +360,17 @@ impl Metadata {
         })
     }
 
+    /// Returns a new Metadata with a single configuration entry inserted (or replaced),
+    /// preserving all other configuration entries and metadata fields.
+    pub(crate) fn with_configuration_entry(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Self {
+        self.configuration.insert(key.into(), value.into());
+        self
+    }
+
     #[cfg(test)]
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new_unchecked(

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -334,6 +334,37 @@ impl StructField {
         self.metadata.get(key.as_ref())
     }
 
+    /// Returns this field's `delta.columnMapping.id` annotation if present and well-formed.
+    /// Returns `None` if the annotation is missing or carries a non-numeric value.
+    pub fn column_mapping_id(&self) -> Option<i64> {
+        match self.get_config_value(&ColumnMetadataKey::ColumnMappingId)? {
+            MetadataValue::Number(n) => Some(*n),
+            _ => None,
+        }
+    }
+
+    /// Recursively collects every `delta.columnMapping.id` reachable from this field --
+    /// the field's own ID plus any nested struct fields under Struct/Array/Map/Variant.
+    /// Test-only.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn collect_column_mapping_ids(&self) -> Vec<i64> {
+        struct CollectIds(Vec<i64>);
+        impl<'a> SchemaTransform<'a> for CollectIds {
+            fn transform_struct_field(
+                &mut self,
+                field: &'a StructField,
+            ) -> Option<Cow<'a, StructField>> {
+                if let Some(id) = field.column_mapping_id() {
+                    self.0.push(id);
+                }
+                self.recurse_into_struct_field(field)
+            }
+        }
+        let mut visitor = CollectIds(Vec::new());
+        visitor.transform_struct_field(self);
+        visitor.0
+    }
+
     /// Get the physical name for this field as it should be read from parquet.
     ///
     /// When `column_mapping_mode` is `None`, always returns the logical name (even if physical

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -245,7 +245,7 @@ pub(crate) fn get_column_mapping_mode_from_properties(
 /// arrays, and maps. Each field is assigned a new unique ID and physical name.
 ///
 /// Fields with pre-existing column mapping metadata (id or physicalName) are rejected
-/// to avoid conflicts. ALTER TABLE will need different handling in the future.
+/// to avoid conflicts.
 ///
 /// # Arguments
 ///
@@ -262,35 +262,38 @@ pub(crate) fn assign_column_mapping_metadata(
 ) -> DeltaResult<StructType> {
     let new_fields: Vec<StructField> = schema
         .fields()
-        .map(|field| assign_field_column_mapping(field, max_id))
+        .map(|field| try_assign_field_column_mapping(field, max_id))
         .collect::<DeltaResult<Vec<_>>>()?;
 
     StructType::try_new(new_fields)
 }
 
 /// Assigns column mapping metadata to a single field, recursively processing nested types.
+/// Returns a new field with a fresh unique ID and a UUID-based physical name, and increments
+/// `max_id` to reflect the assignment.
 ///
-/// Rejects fields with pre-existing column mapping metadata. Otherwise, assigns a new
-/// unique ID and physical name (incrementing `max_id`).
-fn assign_field_column_mapping(field: &StructField, max_id: &mut i64) -> DeltaResult<StructField> {
-    let has_id = field
-        .get_config_value(&ColumnMetadataKey::ColumnMappingId)
-        .is_some();
-    let has_physical_name = field
-        .get_config_value(&ColumnMetadataKey::ColumnMappingPhysicalName)
-        .is_some();
-
-    // For CREATE TABLE, reject any pre-existing column mapping metadata.
-    // This avoids conflicts between user-provided IDs/physical names and the ones we assign.
-    // ALTER TABLE (adding columns) will need different handling in the future.
+/// # Errors
+///
+/// - Field carries a pre-existing `delta.columnMapping.id` or `delta.columnMapping.physicalName`
+///   annotation.
+pub(crate) fn try_assign_field_column_mapping(
+    field: &StructField,
+    max_id: &mut i64,
+) -> DeltaResult<StructField> {
     // TODO: Also check for nested column IDs (`delta.columnMapping.nested.ids`) once
     // Iceberg compatibility (IcebergCompatV2+) is supported. See issue #1125.
-    if has_id || has_physical_name {
-        return Err(Error::generic(format!(
-            "Field '{}' already has column mapping metadata. \
-             Pre-existing column mapping metadata is not supported for CREATE TABLE.",
-            field.name
-        )));
+    for key in [
+        ColumnMetadataKey::ColumnMappingId,
+        ColumnMetadataKey::ColumnMappingPhysicalName,
+    ] {
+        if field.get_config_value(&key).is_some() {
+            return Err(Error::generic(format!(
+                "Field '{}' has pre-populated `{}` metadata; the caller must not provide \
+                 column-mapping annotations on input fields.",
+                field.name,
+                key.as_ref(),
+            )));
+        }
     }
 
     // Start with the existing field and assign new ID
@@ -314,6 +317,28 @@ fn assign_field_column_mapping(field: &StructField, max_id: &mut i64) -> DeltaRe
     new_field.data_type = process_nested_data_type(&field.data_type, max_id)?;
 
     Ok(new_field)
+}
+
+/// Returns the largest `delta.columnMapping.id` found anywhere in `schema`, including nested
+/// data types. Returns `None` if no field carries a column mapping ID.
+pub(crate) fn find_max_column_id_in_schema(schema: &StructType) -> Option<i64> {
+    let mut visitor = MaxColumnId(None);
+    visitor.transform_struct(schema);
+    visitor.0
+}
+
+/// Visitor that walks a schema and records the largest `delta.columnMapping.id` seen on any
+/// field (including nested struct, array, map, and variant fields).
+struct MaxColumnId(Option<i64>);
+
+impl<'a> SchemaTransform<'a> for MaxColumnId {
+    fn transform_struct_field(&mut self, field: &'a StructField) -> Option<Cow<'a, StructField>> {
+        if let Some(n) = field.column_mapping_id() {
+            self.0 = Some(self.0.map_or(n, |prev| prev.max(n)));
+        }
+        // Recurse into the field's data type so we also visit nested struct/array/map members.
+        self.recurse_into_struct_field(field)
+    }
 }
 
 /// Process nested data types to assign column mapping metadata to any nested struct fields.
@@ -777,8 +802,8 @@ mod tests {
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
         assert!(
-            err_msg.contains("already has column mapping metadata"),
-            "Expected error about existing column mapping metadata, got: {err_msg}"
+            err_msg.contains("pre-populated") && err_msg.contains("delta.columnMapping.id"),
+            "Expected error naming the pre-populated CM annotation, got: {err_msg}"
         );
     }
 
@@ -1306,5 +1331,106 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("is not a struct type"));
+    }
+
+    // === find_max_column_id_in_schema tests ===
+
+    fn field_with_id(name: &str, ty: DataType, id: i64) -> StructField {
+        let mut f = StructField::nullable(name, ty);
+        f.metadata.insert(
+            ColumnMetadataKey::ColumnMappingId.as_ref().to_string(),
+            MetadataValue::Number(id),
+        );
+        f
+    }
+
+    #[test]
+    fn find_max_column_id_empty_schema_is_none() {
+        let schema =
+            StructType::try_new(vec![StructField::nullable("a", DataType::STRING)]).unwrap();
+        assert_eq!(find_max_column_id_in_schema(&schema), None);
+    }
+
+    #[test]
+    fn find_max_column_id_top_level_only() {
+        let schema = StructType::try_new(vec![
+            field_with_id("a", DataType::STRING, 1),
+            field_with_id("b", DataType::INTEGER, 3),
+            field_with_id("c", DataType::STRING, 2),
+        ])
+        .unwrap();
+        assert_eq!(find_max_column_id_in_schema(&schema), Some(3));
+    }
+
+    #[test]
+    fn find_max_column_id_nested_struct() {
+        let inner = DataType::Struct(Box::new(
+            StructType::try_new(vec![
+                field_with_id("x", DataType::STRING, 7),
+                field_with_id("y", DataType::STRING, 5),
+            ])
+            .unwrap(),
+        ));
+        let schema = StructType::try_new(vec![
+            field_with_id("outer", inner, 2),
+            field_with_id("sibling", DataType::STRING, 3),
+        ])
+        .unwrap();
+        assert_eq!(find_max_column_id_in_schema(&schema), Some(7));
+    }
+
+    #[test]
+    fn find_max_column_id_array_and_map_recurse_into_element_types() {
+        let array_elem_struct = DataType::Array(Box::new(ArrayType::new(
+            DataType::Struct(Box::new(
+                StructType::try_new(vec![field_with_id("deep", DataType::STRING, 42)]).unwrap(),
+            )),
+            true,
+        )));
+        let map_ty = DataType::Map(Box::new(MapType::new(
+            DataType::STRING,
+            DataType::Struct(Box::new(
+                StructType::try_new(vec![field_with_id("inside", DataType::STRING, 9)]).unwrap(),
+            )),
+            false,
+        )));
+        let schema = StructType::try_new(vec![
+            field_with_id("arr", array_elem_struct, 1),
+            field_with_id("m", map_ty, 2),
+        ])
+        .unwrap();
+        assert_eq!(find_max_column_id_in_schema(&schema), Some(42));
+    }
+
+    #[test]
+    fn find_max_column_id_map_with_struct_key_recurses() {
+        let key_struct = DataType::Struct(Box::new(
+            StructType::try_new(vec![field_with_id("key_id", DataType::INTEGER, 17)]).unwrap(),
+        ));
+        let value_struct = DataType::Struct(Box::new(
+            StructType::try_new(vec![field_with_id("val_id", DataType::INTEGER, 11)]).unwrap(),
+        ));
+        let map_ty = DataType::Map(Box::new(MapType::new(key_struct, value_struct, false)));
+        let schema = StructType::try_new(vec![field_with_id("m", map_ty, 1)]).unwrap();
+        // Max should come from the key struct's `key_id = 17`, beating value's 11 and
+        // top-level's 1.
+        assert_eq!(find_max_column_id_in_schema(&schema), Some(17));
+    }
+
+    /// Every inner variant field carries a cm.id so the assertion proves all three are walked,
+    /// not just one. The `shred=23` is the max and beats `metadata=10`, `value=20`, and
+    /// top-level `v=4`.
+    #[test]
+    fn find_max_column_id_variant_recurses_into_inner_fields() {
+        let variant = DataType::Variant(Box::new(
+            StructType::try_new(vec![
+                field_with_id("metadata", DataType::BINARY, 10),
+                field_with_id("value", DataType::BINARY, 20),
+                field_with_id("shred", DataType::STRING, 23),
+            ])
+            .unwrap(),
+        ));
+        let schema = StructType::try_new(vec![field_with_id("v", variant, 4)]).unwrap();
+        assert_eq!(find_max_column_id_in_schema(&schema), Some(23));
     }
 }

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -4,8 +4,9 @@ pub(crate) use column_mapping::get_any_level_column_physical_name;
 pub use column_mapping::validate_schema_column_mapping;
 pub use column_mapping::ColumnMappingMode;
 pub(crate) use column_mapping::{
-    assign_column_mapping_metadata, column_mapping_mode, get_column_mapping_mode_from_properties,
-    get_field_column_mapping_info, physical_to_logical_column_name,
+    assign_column_mapping_metadata, column_mapping_mode, find_max_column_id_in_schema,
+    get_column_mapping_mode_from_properties, get_field_column_mapping_info,
+    physical_to_logical_column_name, try_assign_field_column_mapping,
 };
 use delta_kernel_derive::internal_api;
 use itertools::Itertools;
@@ -21,6 +22,7 @@ use crate::schema::derive_macro_utils::ToDataType;
 use crate::schema::DataType;
 use crate::table_properties::TableProperties;
 use crate::{DeltaResult, Error};
+
 mod column_mapping;
 mod timestamp_ntz;
 

--- a/kernel/src/table_properties/deserialize.rs
+++ b/kernel/src/table_properties/deserialize.rs
@@ -54,6 +54,9 @@ fn try_parse(props: &mut TableProperties, k: &str, v: &str) -> Option<()> {
             props.checkpoint_write_stats_as_struct = Some(parse_bool(v)?)
         }
         COLUMN_MAPPING_MODE => props.column_mapping_mode = ColumnMappingMode::try_from(v).ok(),
+        COLUMN_MAPPING_MAX_COLUMN_ID => {
+            props.column_mapping_max_column_id = Some(parse_non_negative(v)?)
+        }
         DATA_SKIPPING_NUM_INDEXED_COLS => {
             props.data_skipping_num_indexed_cols = DataSkippingNumIndexedCols::try_from(v).ok()
         }

--- a/kernel/src/table_properties/mod.rs
+++ b/kernel/src/table_properties/mod.rs
@@ -100,6 +100,11 @@ pub struct TableProperties {
     /// Parquet columns that use different names.
     pub column_mapping_mode: Option<ColumnMappingMode>,
 
+    /// The largest column-mapping ID assigned in the table schema. ALTER TABLE operations
+    /// that add new column-mapped columns must allocate IDs strictly greater than this value
+    /// and bump the property accordingly.
+    pub column_mapping_max_column_id: Option<i64>,
+
     /// The number of columns for Delta Lake to collect statistics about for data skipping.
     /// A value of -1 means to collect statistics for all columns. Updating this property does
     /// not automatically collect statistics again; instead, it redefines the statistics schema
@@ -443,6 +448,34 @@ mod tests {
     }
 
     #[test]
+    fn column_mapping_max_column_id_invalid_falls_through_to_unknown() {
+        // Non-integer and negative values are invalid; following the established pattern,
+        // they fall through to `unknown_properties` rather than failing the whole parse.
+        for invalid in ["not_a_number", "-5", "1.5"] {
+            let properties = HashMap::from([(
+                COLUMN_MAPPING_MAX_COLUMN_ID.to_string(),
+                invalid.to_string(),
+            )]);
+            let parsed = TableProperties::from(properties.iter());
+            assert_eq!(
+                parsed.column_mapping_max_column_id, None,
+                "input: {invalid}"
+            );
+            assert!(parsed
+                .unknown_properties
+                .contains_key(COLUMN_MAPPING_MAX_COLUMN_ID));
+        }
+    }
+
+    #[test]
+    fn column_mapping_max_column_id_zero_is_valid() {
+        let properties =
+            HashMap::from([(COLUMN_MAPPING_MAX_COLUMN_ID.to_string(), "0".to_string())]);
+        let parsed = TableProperties::from(properties.iter());
+        assert_eq!(parsed.column_mapping_max_column_id, Some(0));
+    }
+
+    #[test]
     fn allow_unknown_keys() {
         let properties = [("unknown_properties".to_string(), "two words".to_string())];
         let actual = TableProperties::from(properties.clone().into_iter());
@@ -471,6 +504,7 @@ mod tests {
             (CHECKPOINT_WRITE_STATS_AS_JSON, "true"),
             (CHECKPOINT_WRITE_STATS_AS_STRUCT, "true"),
             (COLUMN_MAPPING_MODE, "id"),
+            (COLUMN_MAPPING_MAX_COLUMN_ID, "42"),
             (DATA_SKIPPING_NUM_INDEXED_COLS, "-1"),
             (DATA_SKIPPING_STATS_COLUMNS, "col1,col2"),
             (DELETED_FILE_RETENTION_DURATION, "interval 1 second"),
@@ -509,6 +543,7 @@ mod tests {
             checkpoint_write_stats_as_json: Some(true),
             checkpoint_write_stats_as_struct: Some(true),
             column_mapping_mode: Some(ColumnMappingMode::Id),
+            column_mapping_max_column_id: Some(42),
             data_skipping_num_indexed_cols: Some(DataSkippingNumIndexedCols::AllColumns),
             data_skipping_stats_columns: Some(vec![column_name!("col1"), column_name!("col2")]),
             deleted_file_retention_duration: Some(Duration::new(1, 0)),

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -33,6 +33,7 @@ use crate::schema::StructField;
 use crate::snapshot::SnapshotRef;
 use crate::table_configuration::TableConfiguration;
 use crate::table_features::Operation;
+use crate::table_properties::COLUMN_MAPPING_MAX_COLUMN_ID;
 use crate::transaction::alter_table::AlterTableTransaction;
 use crate::transaction::schema_evolution::{
     apply_schema_operations, SchemaEvolutionResult, SchemaOperation,
@@ -108,6 +109,9 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
     ///
     /// The field must not already exist in the schema (case-insensitive). The field must be
     /// nullable because existing data files do not contain this column and will read NULL for it.
+    /// `field` and any of its nested fields must not carry `delta.columnMapping.id` or
+    /// `delta.columnMapping.physicalName` annotations.
+    ///
     /// These constraints are validated during [`build()`](AlterTableTransactionBuilder::build).
     pub fn add_column(mut self, field: StructField) -> AlterTableTransactionBuilder<Modifying> {
         self.operations.push(SchemaOperation::AddColumn { field });
@@ -154,14 +158,26 @@ impl AlterTableTransactionBuilder<Modifying> {
         table_config.ensure_operation_supported(Operation::Write)?;
 
         let schema = Arc::unwrap_or_clone(table_config.logical_schema());
+        let column_mapping_mode = table_config.column_mapping_mode();
+        let current_max_column_id = table_config.table_properties().column_mapping_max_column_id;
         let SchemaEvolutionResult {
             schema: evolved_schema,
-        } = apply_schema_operations(schema, self.operations, table_config.column_mapping_mode())?;
+            new_max_column_id,
+        } = apply_schema_operations(
+            schema,
+            self.operations,
+            column_mapping_mode,
+            current_max_column_id,
+        )?;
 
-        let evolved_metadata = table_config
+        let mut evolved_metadata = table_config
             .metadata()
             .clone()
             .with_schema(evolved_schema.clone())?;
+        if let Some(id) = new_max_column_id {
+            evolved_metadata = evolved_metadata
+                .with_configuration_entry(COLUMN_MAPPING_MAX_COLUMN_ID, id.to_string());
+        }
 
         // Validates the evolved metadata against the protocol.
         let evolved_table_config = TableConfiguration::try_new_with_schema(

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -178,6 +178,15 @@ pub struct ExistingTable;
 #[derive(Debug)]
 pub struct CreateTable;
 
+/// Marker trait for transaction states that support data file operations.
+///
+/// Only transaction types that implement this trait can access methods for adding, removing, or
+/// updating data files. This prevents compile-time misuse by states like `AlterTable` that
+/// only perform metadata-only commits.
+pub trait SupportsDataFiles {}
+impl SupportsDataFiles for ExistingTable {}
+impl SupportsDataFiles for CreateTable {}
+
 /// A transaction represents an in-progress write to a table. After creating a transaction, changes
 /// to the table may be staged via the transaction methods before calling `commit` to commit the
 /// changes to the table.
@@ -756,7 +765,12 @@ impl<S> Transaction<S> {
     pub fn add_files_schema(&self) -> &'static SchemaRef {
         &BASE_ADD_FILES_SCHEMA
     }
+}
 
+// =============================================================================
+// Data file methods -- only available on transaction types that support data files
+// =============================================================================
+impl<S: SupportsDataFiles> Transaction<S> {
     /// Returns the expected schema for file statistics.
     ///
     /// The schema structure is derived from table configuration:
@@ -948,7 +962,12 @@ impl<S> Transaction<S> {
     pub fn add_files(&mut self, add_metadata: Box<dyn EngineData>) {
         self.add_files_metadata.push(add_metadata);
     }
+}
 
+// =============================================================================
+// Internal methods available on ALL transaction types (used by commit path)
+// =============================================================================
+impl<S> Transaction<S> {
     /// Validate that add files have required statistics for clustering columns.
     ///
     /// Per the Delta protocol, writers MUST collect per-file statistics for clustering columns
@@ -1946,7 +1965,7 @@ mod tests {
     // ============================================================================
     // validate_blind_append tests
     // ============================================================================
-    fn add_dummy_file<S>(txn: &mut Transaction<S>) {
+    fn add_dummy_file<S: SupportsDataFiles>(txn: &mut Transaction<S>) {
         let data = string_array_to_engine_data(StringArray::from(vec!["dummy"]));
         txn.add_files(data);
     }

--- a/kernel/src/transaction/schema_evolution.rs
+++ b/kernel/src/transaction/schema_evolution.rs
@@ -3,13 +3,17 @@
 //! This module defines the [`SchemaOperation`] enum and the [`apply_schema_operations`] function
 //! that validates and applies schema changes to produce an evolved schema.
 
+use std::cmp::Ordering;
+
 use indexmap::IndexMap;
 
 use crate::error::Error;
 use crate::expressions::ColumnName;
 use crate::schema::validation::validate_schema;
 use crate::schema::{DataType, SchemaRef, StructField, StructType};
-use crate::table_features::ColumnMappingMode;
+use crate::table_features::{
+    find_max_column_id_in_schema, try_assign_field_column_mapping, ColumnMappingMode,
+};
 use crate::DeltaResult;
 
 /// A schema evolution operation to be applied during ALTER TABLE.
@@ -82,9 +86,13 @@ fn modify_field_at_path(
 pub(crate) struct SchemaEvolutionResult {
     /// The evolved schema after all operations are applied.
     pub schema: SchemaRef,
+    /// If `Some(id)`, `delta.columnMapping.maxColumnId` must be updated to this new value.
+    /// `None` means the property should remain unchanged.
+    pub new_max_column_id: Option<i64>,
 }
 
-/// Applies a sequence of schema operations to the given schema, returning the evolved schema.
+/// Applies a sequence of schema operations to the given schema, returning a
+/// [`SchemaEvolutionResult`] (see the struct's docs for details).
 ///
 /// Operations are applied sequentially: each one validates against and modifies the schema
 /// produced by all preceding operations, not the original input schema.
@@ -97,8 +105,17 @@ pub(crate) fn apply_schema_operations(
     mut schema: StructType,
     operations: Vec<SchemaOperation>,
     column_mapping_mode: ColumnMappingMode,
+    current_max_column_id: Option<i64>,
 ) -> DeltaResult<SchemaEvolutionResult> {
     let cm_enabled = column_mapping_mode != ColumnMappingMode::None;
+
+    // When column mapping is enabled and the property is set, defensively take the max with
+    // the schema's actual max in case a non-conforming writer left the property stale.
+    let mut max_id = if cm_enabled {
+        current_max_column_id.map(|cfg| cfg.max(find_max_column_id_in_schema(&schema).unwrap_or(0)))
+    } else {
+        current_max_column_id
+    };
 
     for op in operations {
         match op {
@@ -109,14 +126,6 @@ pub(crate) fn apply_schema_operations(
             // `DELTA_FEATURES_REQUIRE_MANUAL_ENABLEMENT` and requires the user to enable the
             // feature explicitly before adding such a column.
             SchemaOperation::AddColumn { field } => {
-                // TODO: support column mapping for add_column (assign ID + physical name,
-                // update delta.columnMapping.maxColumnId).
-                if cm_enabled {
-                    return Err(Error::unsupported(
-                        "ALTER TABLE add_column is not yet supported on tables with \
-                         column mapping enabled",
-                    ));
-                }
                 if field.is_metadata_column() {
                     return Err(Error::schema(format!(
                         "Cannot add column '{}': metadata columns are not allowed in \
@@ -145,6 +154,22 @@ pub(crate) fn apply_schema_operations(
                         field.name()
                     )));
                 }
+                let field = if cm_enabled {
+                    let id = max_id.as_mut().ok_or_else(|| {
+                        Error::invalid_protocol(
+                            "Column mapping is enabled but delta.columnMapping.maxColumnId \
+                             is not set in table properties",
+                        )
+                    })?;
+                    try_assign_field_column_mapping(&field, id)?
+                } else {
+                    // No upfront reject for stray CM metadata: the recursive walk in
+                    // `StructType::make_physical` (called from
+                    // `TableConfiguration::try_new_with_schema`
+                    // by the AlterTable builder) catches any CM annotation anywhere in the tree.
+                    // CREATE TABLE's non-CM path relies on the same mechanism.
+                    field
+                };
                 schema.field_map_mut().insert(field.name().clone(), field);
             }
             SchemaOperation::SetNullable { column } => {
@@ -160,18 +185,36 @@ pub(crate) fn apply_schema_operations(
     }
 
     validate_schema(&schema, column_mapping_mode)?;
+
+    // `max_id` is only ever incremented by `try_assign_field_column_mapping`. If it grew, the
+    // new value must be persisted; if it went backwards, that's a bug.
+    let new_max_column_id = match max_id.cmp(&current_max_column_id) {
+        Ordering::Greater => max_id,
+        Ordering::Equal => None,
+        Ordering::Less => {
+            return Err(Error::internal_error(
+                "max column ID went backwards during schema evolution",
+            ))
+        }
+    };
     Ok(SchemaEvolutionResult {
         schema: schema.into(),
+        new_max_column_id,
     })
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use rstest::rstest;
 
     use super::*;
     use crate::expressions::{column_name, ColumnName};
-    use crate::schema::{DataType, MetadataColumnSpec, StructField, StructType};
+    use crate::schema::{
+        ArrayType, ColumnMetadataKey, DataType, MapType, MetadataColumnSpec, MetadataValue,
+        StructField, StructType,
+    };
 
     fn simple_schema() -> StructType {
         StructType::try_new(vec![
@@ -325,8 +368,8 @@ mod tests {
         #[case] ops: Vec<SchemaOperation>,
         #[case] error_contains: &str,
     ) {
-        let err =
-            apply_schema_operations(simple_schema(), ops, ColumnMappingMode::None).unwrap_err();
+        let err = apply_schema_operations(simple_schema(), ops, ColumnMappingMode::None, None)
+            .unwrap_err();
         assert!(err.to_string().contains(error_contains));
     }
 
@@ -341,7 +384,7 @@ mod tests {
         #[case] expected_names: &[&str],
     ) {
         let result =
-            apply_schema_operations(simple_schema(), ops, ColumnMappingMode::None).unwrap();
+            apply_schema_operations(simple_schema(), ops, ColumnMappingMode::None, None).unwrap();
         let actual: Vec<&str> = result.schema.fields().map(|f| f.name().as_str()).collect();
         assert_eq!(&actual, expected_names);
     }
@@ -374,7 +417,7 @@ mod tests {
         let ops = vec![SchemaOperation::SetNullable {
             column: column.clone(),
         }];
-        let result = apply_schema_operations(schema, ops, ColumnMappingMode::None).unwrap();
+        let result = apply_schema_operations(schema, ops, ColumnMappingMode::None, None).unwrap();
         assert!(result.schema.field_at_path(column.path()).is_nullable());
     }
 
@@ -384,8 +427,8 @@ mod tests {
     #[case::empty_path(ColumnName::new(Vec::<String>::new()), "empty column path")]
     fn set_nullable_fails(#[case] column: ColumnName, #[case] error_contains: &str) {
         let ops = vec![SchemaOperation::SetNullable { column }];
-        let err =
-            apply_schema_operations(simple_schema(), ops, ColumnMappingMode::None).unwrap_err();
+        let err = apply_schema_operations(simple_schema(), ops, ColumnMappingMode::None, None)
+            .unwrap_err();
         assert!(
             err.to_string().contains(error_contains),
             "expected error to contain '{error_contains}', got: {err}"
@@ -404,7 +447,7 @@ mod tests {
         let ops = vec![SchemaOperation::SetNullable {
             column: column_name!("address"),
         }];
-        let result = apply_schema_operations(schema, ops, ColumnMappingMode::None).unwrap();
+        let result = apply_schema_operations(schema, ops, ColumnMappingMode::None, None).unwrap();
         let addr = result.schema.field("address").unwrap();
         assert!(addr.is_nullable(), "struct itself must be nullable");
         match addr.data_type() {
@@ -427,7 +470,7 @@ mod tests {
             },
         ];
         let result =
-            apply_schema_operations(simple_schema(), ops, ColumnMappingMode::None).unwrap();
+            apply_schema_operations(simple_schema(), ops, ColumnMappingMode::None, None).unwrap();
         assert_eq!(result.schema.fields().count(), 3);
         assert!(result.schema.field("email").is_some());
         assert!(result.schema.field("id").unwrap().is_nullable());
@@ -450,8 +493,220 @@ mod tests {
         let ops = vec![SchemaOperation::SetNullable {
             column: column_name!("beta.nested"),
         }];
-        let result = apply_schema_operations(schema, ops, ColumnMappingMode::None).unwrap();
+        let result = apply_schema_operations(schema, ops, ColumnMappingMode::None, None).unwrap();
         let names: Vec<&String> = result.schema.fields().map(|f| f.name()).collect();
         assert_eq!(names, vec!["alpha", "beta", "gamma"]);
+    }
+
+    // === Column mapping tests ===
+
+    fn get_cm_id(field: &StructField) -> i64 {
+        field
+            .column_mapping_id()
+            .expect("field should have column mapping ID")
+    }
+
+    fn get_physical_name(field: &StructField) -> String {
+        match field
+            .get_config_value(&ColumnMetadataKey::ColumnMappingPhysicalName)
+            .expect("field should have physical name")
+        {
+            MetadataValue::String(s) => s.clone(),
+            other => panic!("expected String, got {other:?}"),
+        }
+    }
+
+    #[rstest]
+    #[case::name_mode(ColumnMappingMode::Name, 2, 3)]
+    #[case::id_mode(ColumnMappingMode::Id, 5, 6)]
+    fn add_column_with_column_mapping_assigns_id_and_physical_name(
+        #[case] mode: ColumnMappingMode,
+        #[case] current_max: i64,
+        #[case] expected_id: i64,
+    ) {
+        let ops = vec![SchemaOperation::AddColumn {
+            field: StructField::nullable("email", DataType::STRING),
+        }];
+        let result =
+            apply_schema_operations(simple_schema(), ops, mode, Some(current_max)).unwrap();
+        let email_field = result.schema.field("email").unwrap();
+
+        assert_eq!(get_cm_id(email_field), expected_id);
+        assert!(get_physical_name(email_field).starts_with("col-"));
+        assert_eq!(result.new_max_column_id, Some(expected_id));
+    }
+
+    #[test]
+    fn add_column_without_max_column_id_fails_when_mapping_enabled() {
+        let ops = vec![SchemaOperation::AddColumn {
+            field: StructField::nullable("email", DataType::STRING),
+        }];
+        let err = apply_schema_operations(simple_schema(), ops, ColumnMappingMode::Name, None)
+            .unwrap_err();
+        assert!(matches!(err, Error::InvalidProtocol(_)));
+        assert!(err.to_string().contains("maxColumnId"));
+    }
+
+    /// Multiple columns added in a single ALTER on a CM table: each must get a distinct ID
+    /// (strictly monotone), a distinct physical name, and `new_max_column_id` must advance by
+    /// exactly the number of added columns.
+    #[test]
+    fn add_multiple_columns_with_column_mapping_assigns_unique_ids() {
+        let ops = vec![
+            SchemaOperation::AddColumn {
+                field: StructField::nullable("a", DataType::STRING),
+            },
+            SchemaOperation::AddColumn {
+                field: StructField::nullable("b", DataType::STRING),
+            },
+            SchemaOperation::AddColumn {
+                field: StructField::nullable("c", DataType::STRING),
+            },
+        ];
+        let result =
+            apply_schema_operations(simple_schema(), ops, ColumnMappingMode::Name, Some(10))
+                .unwrap();
+
+        let id_a = get_cm_id(result.schema.field("a").unwrap());
+        let id_b = get_cm_id(result.schema.field("b").unwrap());
+        let id_c = get_cm_id(result.schema.field("c").unwrap());
+        assert_eq!(id_a, 11);
+        assert_eq!(id_b, 12);
+        assert_eq!(id_c, 13);
+
+        let name_a = get_physical_name(result.schema.field("a").unwrap());
+        let name_b = get_physical_name(result.schema.field("b").unwrap());
+        let name_c = get_physical_name(result.schema.field("c").unwrap());
+        assert_ne!(name_a, name_b);
+        assert_ne!(name_b, name_c);
+        assert_ne!(name_a, name_c);
+
+        assert_eq!(result.new_max_column_id, Some(13));
+    }
+
+    fn struct_of_two_primitives() -> DataType {
+        DataType::Struct(Box::new(
+            StructType::try_new(vec![
+                StructField::nullable("a", DataType::STRING),
+                StructField::nullable("b", DataType::STRING),
+            ])
+            .unwrap(),
+        ))
+    }
+
+    /// Adding a complex column on a CM table: every inner struct field reachable through
+    /// Struct/Array/Map recursion must receive a distinct ID greater than the previous max,
+    /// and `new_max_column_id` must advance to the largest assigned ID.
+    #[rstest]
+    #[case::nested_struct(struct_of_two_primitives(), 3)]
+    #[case::array_of_primitive(
+        DataType::Array(Box::new(ArrayType::new(DataType::STRING, true))),
+        1
+    )]
+    #[case::map_of_primitives(
+        DataType::Map(Box::new(MapType::new(DataType::STRING, DataType::INTEGER, true))),
+        1
+    )]
+    #[case::array_of_struct(
+        DataType::Array(Box::new(ArrayType::new(struct_of_two_primitives(), true))),
+        3
+    )]
+    #[case::map_value_is_struct(
+        DataType::Map(Box::new(MapType::new(
+            DataType::STRING,
+            struct_of_two_primitives(),
+            true,
+        ))),
+        3
+    )]
+    #[case::map_key_is_struct(
+        DataType::Map(Box::new(MapType::new(
+            struct_of_two_primitives(),
+            DataType::INTEGER,
+            true,
+        ))),
+        3
+    )]
+    fn add_complex_column_with_column_mapping_assigns_ids_to_all_inner_fields(
+        #[case] data_type: DataType,
+        #[case] expected_id_count: usize,
+    ) {
+        let ops = vec![SchemaOperation::AddColumn {
+            field: StructField::nullable("col", data_type),
+        }];
+        let result =
+            apply_schema_operations(simple_schema(), ops, ColumnMappingMode::Name, Some(10))
+                .unwrap();
+
+        let added = result.schema.field("col").unwrap();
+        let ids = added.collect_column_mapping_ids();
+        let unique: HashSet<_> = ids.iter().copied().collect();
+
+        assert_eq!(ids.len(), expected_id_count, "expected ID count mismatch");
+        assert_eq!(unique.len(), ids.len(), "all assigned IDs must be distinct");
+        assert!(
+            ids.iter().all(|&id| id > 10),
+            "all assigned IDs must exceed previous max"
+        );
+        assert_eq!(
+            result.new_max_column_id,
+            ids.iter().max().copied(),
+            "new_max_column_id must equal the largest assigned ID",
+        );
+    }
+
+    fn field_with_stray_cm_id(name: &str, ty: DataType) -> StructField {
+        let mut f = StructField::nullable(name, ty);
+        f.metadata.insert(
+            ColumnMetadataKey::ColumnMappingId.as_ref().to_string(),
+            MetadataValue::Number(99),
+        );
+        f
+    }
+
+    /// CM-enabled: stray CM annotations on a new column are rejected at any nesting depth.
+    #[rstest]
+    #[case::top_level(field_with_stray_cm_id("tainted", DataType::STRING))]
+    #[case::nested_in_struct(StructField::nullable(
+        "outer",
+        DataType::Struct(Box::new(
+            StructType::try_new(vec![field_with_stray_cm_id("inner", DataType::STRING)]).unwrap(),
+        )),
+    ))]
+    fn add_column_with_preexisting_cm_metadata_is_rejected_under_cm(#[case] field: StructField) {
+        let ops = vec![SchemaOperation::AddColumn { field }];
+        let err = apply_schema_operations(simple_schema(), ops, ColumnMappingMode::Name, Some(2))
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("pre-populated"));
+        assert!(
+            msg.contains("delta.columnMapping.id"),
+            "error should name the offending annotation, got: {msg}"
+        );
+    }
+
+    /// If the persisted `maxColumnId` is stale (smaller than the actual max ID present in
+    /// the schema), the defensive seed rebases on the schema's max so a newly added column
+    /// cannot collide with an existing field's ID. Matches delta-spark's `findMaxColumnId`.
+    #[test]
+    fn stale_max_column_id_is_self_healed_by_schema_walk() {
+        let mut existing = StructField::nullable("existing", DataType::STRING);
+        existing.metadata.insert(
+            ColumnMetadataKey::ColumnMappingId.as_ref().to_string(),
+            MetadataValue::Number(42),
+        );
+        let schema = StructType::try_new(vec![existing]).unwrap();
+        let ops = vec![SchemaOperation::AddColumn {
+            field: StructField::nullable("new", DataType::STRING),
+        }];
+        // Persisted maxColumnId is stale at 5, but the schema actually contains id=42.
+        let result =
+            apply_schema_operations(schema, ops, ColumnMappingMode::Name, Some(5)).unwrap();
+        let new_id = get_cm_id(result.schema.field("new").unwrap());
+        assert_eq!(
+            new_id, 43,
+            "new id must follow schema max (42), not stale property (5)"
+        );
+        assert_eq!(result.new_max_column_id, Some(43));
     }
 }

--- a/kernel/tests/integration/create_table/column_mapping.rs
+++ b/kernel/tests/integration/create_table/column_mapping.rs
@@ -112,9 +112,7 @@ pub(super) fn assert_column_mapping_config(snapshot: &Snapshot, expected_mode: C
             // No column mapping metadata on any field
             for field in snapshot.schema().fields() {
                 assert!(
-                    field
-                        .get_config_value(&ColumnMetadataKey::ColumnMappingId)
-                        .is_none(),
+                    field.column_mapping_id().is_none(),
                     "Field '{}' should not have a column mapping ID when mode is None",
                     field.name()
                 );

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -1,6 +1,6 @@
 //! Integration tests for ALTER TABLE schema evolution.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use delta_kernel::arrow::array::{Array, Int32Array, StringArray};
@@ -8,7 +8,10 @@ use delta_kernel::arrow::record_batch::RecordBatch;
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::expressions::{column_name, ColumnName, Scalar};
-use delta_kernel::schema::{ArrayType, DataType, MapType, SchemaRef, StructField, StructType};
+use delta_kernel::schema::{
+    ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, SchemaRef, StructField,
+    StructType,
+};
 use delta_kernel::snapshot::Snapshot;
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
@@ -32,20 +35,36 @@ fn committer() -> Box<FileSystemCommitter> {
     Box::new(FileSystemCommitter::new())
 }
 
+fn max_column_id(snap: &Snapshot) -> i64 {
+    snap.table_configuration()
+        .metadata()
+        .configuration()
+        .get("delta.columnMapping.maxColumnId")
+        .and_then(|v| v.parse().ok())
+        .expect("maxColumnId should be set and parseable on a CM table")
+}
+
 // ============================================================================
 // Add column tests
 // ============================================================================
 
+/// End-to-end lifecycle: write, ALTER to add columns, scan, write populated rows, scan again.
+/// Each column is added in its own alter commit with a checkpoint after, exercising
+/// "do some ops -> checkpoint -> do more ops -> checkpoint". Under CM, also verifies fresh
+/// ids/physical names and that `maxColumnId` advanced.
 #[rstest]
-#[case::one_column(1)]
-#[case::three_columns(3)]
-#[tokio::test]
-async fn add_columns_reload_snapshot_verify_schema(
-    #[case] num_columns: usize,
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn add_columns_lifecycle(
+    #[values(None, Some("name"), Some("id"))] cm_mode: Option<&str>,
+    #[values(1, 3)] num_columns: usize,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+    let properties: Vec<(&str, &str)> = cm_mode
+        .map(|m| vec![("delta.columnMapping.mode", m)])
+        .unwrap_or_default();
     let snapshot =
-        create_table_and_load_snapshot(&table_path, simple_schema(), engine.as_ref(), &[])?;
+        create_table_and_load_snapshot(&table_path, simple_schema(), engine.as_ref(), &properties)?;
+    let original_max_id = cm_mode.map(|_| max_column_id(&snapshot));
 
     // Write two rows with only the original columns populated.
     let batch = RecordBatch::try_new(
@@ -60,35 +79,62 @@ async fn add_columns_reload_snapshot_verify_schema(
 
     let new_col_names: Vec<String> = (0..num_columns).map(|i| format!("col_{i}")).collect();
 
-    // First add_column transitions Ready -> Modifying; subsequent calls stay in Modifying.
-    let (first, rest) = new_col_names.split_first().unwrap();
-    let committed = rest
-        .iter()
-        .fold(
-            snapshot
-                .alter_table()
-                .add_column(StructField::nullable(first, DataType::STRING)),
-            |b, name| b.add_column(StructField::nullable(name, DataType::STRING)),
-        )
-        .build(engine.as_ref(), committer())?
-        .commit(engine.as_ref())?
-        .unwrap_committed();
+    // One alter+checkpoint cycle per column.
+    let mut current = snapshot;
+    for name in &new_col_names {
+        let committed = current
+            .alter_table()
+            .add_column(StructField::nullable(name, DataType::STRING))
+            .build(engine.as_ref(), committer())?
+            .commit(engine.as_ref())?
+            .unwrap_committed();
+        let post = committed
+            .post_commit_snapshot()
+            .expect("post-commit snapshot");
+        let (_, ckpt) = post.clone().checkpoint(engine.as_ref())?;
+        current = ckpt;
+    }
 
-    // Verify post-commit snapshot has evolved schema
-    let post_snap = committed
-        .post_commit_snapshot()
-        .expect("post-commit snapshot");
-    assert_eq!(post_snap.schema().fields().count(), 2 + num_columns);
-
-    // Reload from storage to verify persistence
+    // Reload from storage to verify persistence. v0 = create, v1 = write, then `num_columns`
+    // alter commits.
+    let alter_end_version = 1 + num_columns as u64;
     let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
-    assert_eq!(reloaded.version(), 2);
+    assert_eq!(reloaded.version(), alter_end_version);
     let schema = reloaded.schema();
     assert_eq!(schema.fields().count(), 2 + num_columns);
     for name in &new_col_names {
         let field = schema.field(name).expect("added field should exist");
         assert_eq!(field.data_type(), &DataType::STRING);
         assert!(field.is_nullable());
+    }
+
+    // When CM is enabled: each new column must have a fresh id/physical name, and the
+    // table's maxColumnId must have advanced past the original value. When CM is disabled:
+    // the property must remain absent.
+    if let Some(orig) = original_max_id {
+        for name in &new_col_names {
+            let field = schema.field(name).unwrap();
+            let cm_id = field.column_mapping_id().expect("CM id should be assigned");
+            assert!(
+                cm_id > orig,
+                "new column '{name}' id {cm_id} must exceed original max {orig}"
+            );
+            match field
+                .get_config_value(&ColumnMetadataKey::ColumnMappingPhysicalName)
+                .expect("physical name should be assigned")
+            {
+                MetadataValue::String(s) => assert!(s.starts_with("col-")),
+                other => panic!("expected String, got {other:?}"),
+            }
+        }
+        assert!(max_column_id(&reloaded) > orig);
+    } else {
+        assert!(reloaded
+            .table_configuration()
+            .metadata()
+            .configuration()
+            .get("delta.columnMapping.maxColumnId")
+            .is_none());
     }
 
     // Scan back -- old rows should have NULL for every new column.
@@ -120,7 +166,7 @@ async fn add_columns_reload_snapshot_verify_schema(
 
     // Scan back -- 4 rows total, each new column has 2 NULLs (old rows) and 2 values (new rows).
     let final_snap = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
-    assert_eq!(final_snap.version(), 3);
+    assert_eq!(final_snap.version(), alter_end_version + 1);
     let scan = final_snap.scan_builder().build()?;
     let batches = test_utils::read_scan(&scan, engine.clone())?;
     let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
@@ -136,7 +182,11 @@ async fn add_columns_reload_snapshot_verify_schema(
     Ok(())
 }
 
-/// Adding columns of complex types (struct, array, map) on a non-CM table. Verifies
+/// Adding columns of complex types (struct, array, map) -- with and without column mapping.
+/// Verifies the data type round-trips and, under CM, that every reachable struct field
+/// receives a distinct fresh ID and `maxColumnId` advances accordingly. `expected_id_count`
+/// is the number of CM IDs the column should receive (1 for the parent + however many inner
+/// struct fields the recursion reaches).
 #[rstest]
 #[case::struct_column(
     StructField::nullable(
@@ -145,18 +195,78 @@ async fn add_columns_reload_snapshot_verify_schema(
             StructField::nullable("city", DataType::STRING),
             StructField::nullable("zip", DataType::STRING),
         ]).unwrap(),
-    )
+    ),
+    3,
 )]
-#[case::array_of_primitive(StructField::nullable("tags", ArrayType::new(DataType::STRING, true),))]
-#[case::map_of_primitives(StructField::nullable(
-    "labels",
-    MapType::new(DataType::STRING, DataType::INTEGER, true),
-))]
+#[case::array_of_primitive(
+    StructField::nullable("tags", ArrayType::new(DataType::STRING, true)),
+    1
+)]
+#[case::map_of_primitives(
+    StructField::nullable("labels", MapType::new(DataType::STRING, DataType::INTEGER, true)),
+    1
+)]
+#[case::array_of_struct(
+    StructField::nullable(
+        "items",
+        ArrayType::new(
+            DataType::Struct(Box::new(
+                StructType::try_new(vec![
+                    StructField::nullable("a", DataType::STRING),
+                    StructField::nullable("b", DataType::INTEGER),
+                ]).unwrap(),
+            )),
+            true,
+        ),
+    ),
+    3,
+)]
+#[case::map_value_is_struct(
+    StructField::nullable(
+        "by_id",
+        MapType::new(
+            DataType::STRING,
+            DataType::Struct(Box::new(
+                StructType::try_new(vec![
+                    StructField::nullable("a", DataType::STRING),
+                    StructField::nullable("b", DataType::INTEGER),
+                ]).unwrap(),
+            )),
+            true,
+        ),
+    ),
+    3,
+)]
+#[case::map_key_is_struct(
+    StructField::nullable(
+        "lookup",
+        MapType::new(
+            DataType::Struct(Box::new(
+                StructType::try_new(vec![
+                    StructField::nullable("a", DataType::STRING),
+                    StructField::nullable("b", DataType::INTEGER),
+                ]).unwrap(),
+            )),
+            DataType::INTEGER,
+            true,
+        ),
+    ),
+    3,
+)]
 #[tokio::test]
-async fn add_complex_type_column(#[case] field: StructField) -> DeltaResult<()> {
+async fn add_complex_type_column(
+    #[case] field: StructField,
+    #[case] expected_id_count: usize,
+    #[values(None, Some("name"), Some("id"))] cm_mode: Option<&str>,
+) -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let properties: Vec<(&str, &str)> = cm_mode
+        .map(|m| vec![("delta.columnMapping.mode", m)])
+        .unwrap_or_default();
     let snapshot =
-        create_table_and_load_snapshot(&table_path, simple_schema(), engine.as_ref(), &[])?;
+        create_table_and_load_snapshot(&table_path, simple_schema(), engine.as_ref(), &properties)?;
+    let original_max_id = cm_mode.map(|_| max_column_id(&snapshot));
+
     let field_name = field.name().to_string();
     let expected_type = field.data_type().clone();
 
@@ -170,7 +280,27 @@ async fn add_complex_type_column(#[case] field: StructField) -> DeltaResult<()> 
     let reloaded = Snapshot::builder_for(table_path).build(engine.as_ref())?;
     let schema = reloaded.schema();
     let added = schema.field(&field_name).expect("added field should exist");
-    assert_eq!(added.data_type(), &expected_type);
+
+    if let Some(orig_max) = original_max_id {
+        // Under CM, inner struct fields carry CM metadata that `expected_type` doesn't;
+        // strict DataType equality won't hold. The ID-count check below implicitly verifies
+        // that the type structure round-tripped correctly.
+        let ids = added.collect_column_mapping_ids();
+        let unique: HashSet<_> = ids.iter().copied().collect();
+        assert_eq!(ids.len(), expected_id_count, "expected ID count mismatch");
+        assert_eq!(unique.len(), ids.len(), "all assigned IDs must be distinct");
+        assert!(
+            ids.iter().all(|&id| id > orig_max),
+            "all assigned IDs must exceed original max"
+        );
+        assert_eq!(
+            max_column_id(&reloaded),
+            ids.iter().copied().max().unwrap(),
+            "table maxColumnId must equal the largest assigned ID",
+        );
+    } else {
+        assert_eq!(added.data_type(), &expected_type);
+    }
     Ok(())
 }
 
@@ -187,11 +317,6 @@ async fn add_complex_type_column(#[case] field: StructField) -> DeltaResult<()> 
     "timestampNtz"
 )]
 #[case::non_nullable(&[], StructField::not_null("age", DataType::INTEGER), "non-nullable")]
-#[case::column_mapping_enabled(
-    &[("delta.columnMapping.mode", "name")],
-    StructField::nullable("email", DataType::STRING),
-    "column mapping"
-)]
 #[tokio::test]
 async fn add_column_failures(
     #[case] properties: &[(&str, &str)],
@@ -483,27 +608,64 @@ async fn set_nullable_nonexistent_column_fails() -> DeltaResult<()> {
     Ok(())
 }
 
+// ============================================================================
+// CHAIN tests
+// ============================================================================
+
 /// Alternating chain: ADD COLUMN, SET NULLABLE, ADD COLUMN, SET NULLABLE. Verifies that
 /// chaining mixed ops applies them in order and produces the expected final schema. Each
-/// SET NULLABLE flips a still-NOT-NULL column from the original schema.
-#[tokio::test]
-async fn chain_add_column_and_set_nullable() -> DeltaResult<()> {
-    let (_temp_dir, table_path, engine) = test_table_setup()?;
+/// SET NULLABLE flips a still-NOT-NULL column from the original schema. Under CM, also
+/// verifies existing fields' column mapping IDs are preserved by set_nullable while
+/// add_column receives a new CM ID and bumps maxColumnId.
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn chain_add_column_and_set_nullable(
+    #[values(None, Some("name"), Some("id"))] cm_mode: Option<&str>,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
     let schema = Arc::new(StructType::try_new(vec![
         StructField::not_null("id", DataType::INTEGER),
         StructField::not_null("name", DataType::STRING),
     ])?);
-    let snapshot = create_table_and_load_snapshot(&table_path, schema, engine.as_ref(), &[])?;
+    let properties: Vec<(&str, &str)> = cm_mode
+        .map(|m| vec![("delta.columnMapping.mode", m)])
+        .unwrap_or_default();
+    let snapshot =
+        create_table_and_load_snapshot(&table_path, schema, engine.as_ref(), &properties)?;
 
-    snapshot
+    let original_id_cm_id = cm_mode.map(|_| {
+        snapshot
+            .schema()
+            .field("id")
+            .unwrap()
+            .column_mapping_id()
+            .expect("existing field should already have a column mapping ID")
+    });
+    let original_max_id = cm_mode.map(|_| max_column_id(&snapshot));
+
+    // Two alter+checkpoint cycles: (add email + nullable id), (add age + nullable name).
+    let v1 = snapshot
         .alter_table()
         .add_column(StructField::nullable("email", DataType::STRING))
         .set_nullable(column_name!("id"))
+        .build(engine.as_ref(), committer())?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+    let v1_snap = v1
+        .post_commit_snapshot()
+        .expect("post-commit snapshot at v1");
+    let (_, v1_ckpt) = v1_snap.clone().checkpoint(engine.as_ref())?;
+    let v2 = v1_ckpt
+        .alter_table()
         .add_column(StructField::nullable("age", DataType::INTEGER))
         .set_nullable(column_name!("name"))
         .build(engine.as_ref(), committer())?
         .commit(engine.as_ref())?
         .unwrap_committed();
+    let v2_snap = v2
+        .post_commit_snapshot()
+        .expect("post-commit snapshot at v2");
+    v2_snap.clone().checkpoint(engine.as_ref())?;
 
     let reloaded = Snapshot::builder_for(table_path).build(engine.as_ref())?;
     let schema = reloaded.schema();
@@ -512,5 +674,64 @@ async fn chain_add_column_and_set_nullable() -> DeltaResult<()> {
         let field = schema.field(name).expect("field should be present");
         assert!(field.is_nullable(), "field '{name}' should be nullable");
     }
+
+    if let (Some(orig_id), Some(orig_max)) = (original_id_cm_id, original_max_id) {
+        for added in ["email", "age"] {
+            assert!(
+                schema.field(added).unwrap().column_mapping_id().is_some(),
+                "added field '{added}' should have a column mapping ID"
+            );
+        }
+        let id_after = schema
+            .field("id")
+            .unwrap()
+            .column_mapping_id()
+            .expect("existing id column mapping");
+        assert_eq!(id_after, orig_id, "existing id CM id must not change");
+        assert!(
+            max_column_id(&reloaded) > orig_max,
+            "chained add_column must bump maxColumnId"
+        );
+    }
+
+    Ok(())
+}
+
+fn field_with_stray_cm_id(name: &str, ty: DataType) -> StructField {
+    let mut f = StructField::nullable(name, ty);
+    f.metadata.insert(
+        ColumnMetadataKey::ColumnMappingId.as_ref().to_string(),
+        MetadataValue::Number(99),
+    );
+    f
+}
+
+/// On a non-CM table, `apply_schema_operations` doesn't reject stray CM metadata up front --
+/// `StructType::make_physical` (run from `TableConfiguration::try_new_with_schema`) is the
+/// gate. This test locks in that downstream rejection, including for nested annotations.
+#[rstest]
+#[case::top_level(field_with_stray_cm_id("tainted", DataType::STRING))]
+#[case::nested_in_struct(StructField::nullable(
+    "outer",
+    StructType::try_new(vec![field_with_stray_cm_id("inner", DataType::STRING)]).unwrap(),
+))]
+#[tokio::test]
+async fn add_column_with_stray_cm_metadata_on_non_cm_table_fails(
+    #[case] field: StructField,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let snapshot =
+        create_table_and_load_snapshot(&table_path, simple_schema(), engine.as_ref(), &[])?;
+
+    let err = snapshot
+        .alter_table()
+        .add_column(field)
+        .build(engine.as_ref(), committer())
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("column mapping") || msg.contains("columnMapping"),
+        "error should mention column mapping, got: {msg}"
+    );
     Ok(())
 }

--- a/kernel/tests/integration/write/column_mapping.rs
+++ b/kernel/tests/integration/write/column_mapping.rs
@@ -14,7 +14,7 @@ use delta_kernel::expressions::{ColumnName, Scalar};
 use delta_kernel::object_store::local::LocalFileSystem;
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::{DynObjectStore, ObjectStoreExt as _};
-use delta_kernel::schema::{ColumnMetadataKey, DataType, MetadataValue, StructField, StructType};
+use delta_kernel::schema::{DataType, StructField, StructType};
 use delta_kernel::table_features::{get_any_level_column_physical_name, ColumnMappingMode};
 use delta_kernel::{Engine, FileMeta, Snapshot};
 use test_utils::{
@@ -209,11 +209,10 @@ async fn test_column_mapping_write(
             let logical_field = resolve_field(logical_schema.as_ref(), logical_path).unwrap();
             match cm_mode {
                 ColumnMappingMode::Id | ColumnMappingMode::Name => {
-                    let expected_id =
-                        match logical_field.get_config_value(&ColumnMetadataKey::ColumnMappingId) {
-                            Some(MetadataValue::Number(n)) => *n as i32,
-                            other => panic!("expected ColumnMappingId number, got {other:?}"),
-                        };
+                    let expected_id = logical_field
+                        .column_mapping_id()
+                        .expect("expected ColumnMappingId number")
+                        as i32;
                     assert_eq!(
                         field_id,
                         Some(expected_id),


### PR DESCRIPTION
## What changes are proposed in this pull request?

Extends `ALTER TABLE ... ADD COLUMN` to work on tables with column mapping enabled. New columns get a fresh column ID and a UUID-based physical name assigned, and `delta.columnMapping.maxColumnId` is updated in table properties.

## How was this change tested?

- Unit tests covering name mode, id mode, and the missing-maxColumnId error case.
- Integration tests that add a column to a column-mapping table and verify the metadata is assigned correctly, plus round-trip data read after add.