### PR TITLE
feat: add rename_column support for ALTER TABLE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,8 @@ internals. Kernel never does I/O directly -- it defines _what_ to do via its API
 
 Current capabilities: table reads with predicates, data skipping, deletion vectors, change
 data feed, checkpoints (V1 & V2), log compaction (disabled, #2337), blind append writes, table creation
-(including clustered tables), and catalog-managed table support.
+(including clustered tables), ALTER TABLE / schema evolution (add/drop column, set nullable), and
+catalog-managed table support.
 
 ## Build & Test Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ internals. Kernel never does I/O directly -- it defines _what_ to do via its API
 
 Current capabilities: table reads with predicates, data skipping, deletion vectors, change
 data feed, checkpoints (V1 & V2), log compaction (disabled, #2337), blind append writes, table creation
-(including clustered tables), ALTER TABLE / schema evolution (add/drop column, set nullable), and
+(including clustered tables), ALTER TABLE / schema evolution (add/drop/rename column, set nullable), and
 catalog-managed table support.
 
 ## Build & Test Commands

--- a/kernel/src/expressions/column_names.rs
+++ b/kernel/src/expressions/column_names.rs
@@ -117,6 +117,38 @@ impl ColumnName {
             None
         }
     }
+
+    /// Returns `true` if this column name is a case-insensitive prefix of `other`. Equal paths
+    /// return `true` (a name is a prefix of itself), and an empty path is a prefix of every path.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use delta_kernel::expressions::ColumnName;
+    /// let ancestor = ColumnName::new(["user", "address"]);
+    /// let nested = ColumnName::new(["user", "address", "city"]);
+    /// assert!(ancestor.is_prefix_of(&nested));
+    /// assert!(nested.is_prefix_of(&nested));
+    /// assert!(!nested.is_prefix_of(&ancestor));
+    ///
+    /// // Case-insensitive.
+    /// let upper = ColumnName::new(["USER", "ADDRESS"]);
+    /// assert!(upper.is_prefix_of(&nested));
+    ///
+    /// // Empty path is a prefix of everything (including itself).
+    /// let empty = ColumnName::new(Vec::<String>::new());
+    /// assert!(empty.is_prefix_of(&nested));
+    /// assert!(empty.is_prefix_of(&empty));
+    /// assert!(!nested.is_prefix_of(&empty));
+    /// ```
+    pub fn is_prefix_of(&self, other: &ColumnName) -> bool {
+        self.path.len() <= other.path.len()
+            && self
+                .path
+                .iter()
+                .zip(other.path.iter())
+                .all(|(a, b)| a.to_lowercase() == b.to_lowercase())
+    }
 }
 
 /// Creates a new column name from a path of field names. Each field name is taken as-is, and may
@@ -571,6 +603,27 @@ mod test {
 
         let single = ColumnName::new(["field"]);
         assert_eq!(single.parent(), None);
+    }
+
+    #[test]
+    fn test_is_prefix_of_edge_cases() {
+        let empty = ColumnName::empty();
+        let single = column_name!("a");
+        let nested = column_name!("a.b.c");
+
+        // Empty path is a prefix of every path, including itself.
+        assert!(empty.is_prefix_of(&single));
+        assert!(empty.is_prefix_of(&nested));
+        assert!(empty.is_prefix_of(&empty));
+
+        // A non-empty path is not a prefix of an empty path.
+        assert!(!single.is_prefix_of(&empty));
+        assert!(!nested.is_prefix_of(&empty));
+
+        // Case-insensitive equal-length match returns true.
+        let upper = column_name!("A.B.C");
+        assert!(upper.is_prefix_of(&nested));
+        assert!(nested.is_prefix_of(&upper));
     }
 
     #[test]

--- a/kernel/src/expressions/column_names.rs
+++ b/kernel/src/expressions/column_names.rs
@@ -123,8 +123,7 @@ impl ColumnName {
     ///
     /// # Examples
     ///
-    /// ```
-    /// # use delta_kernel::expressions::ColumnName;
+    /// ```ignore
     /// let ancestor = ColumnName::new(["user", "address"]);
     /// let nested = ColumnName::new(["user", "address", "city"]);
     /// assert!(ancestor.is_prefix_of(&nested));
@@ -141,13 +140,13 @@ impl ColumnName {
     /// assert!(empty.is_prefix_of(&empty));
     /// assert!(!nested.is_prefix_of(&empty));
     /// ```
-    pub fn is_prefix_of(&self, other: &ColumnName) -> bool {
+    pub(crate) fn is_prefix_of(&self, other: &ColumnName) -> bool {
         self.path.len() <= other.path.len()
-            && self
-                .path
-                .iter()
-                .zip(other.path.iter())
-                .all(|(a, b)| a.to_lowercase() == b.to_lowercase())
+            && self.path.iter().zip(other.path.iter()).all(|(a, b)| {
+                a.chars()
+                    .flat_map(char::to_lowercase)
+                    .eq(b.chars().flat_map(char::to_lowercase))
+            })
     }
 }
 

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -301,9 +301,10 @@ static INVARIANTS_INFO: FeatureInfo = FeatureInfo {
 };
 
 // TODO: Before flipping `kernel_support` to `Supported`, implement the dependent-expression
-// check in `AlterTableTransactionBuilder::build` for drop_column (mirror Spark's
-// SchemaUtils.checkDependentExpressions): reject drops of columns referenced by any CHECK
-// constraint, and remove the corresponding guard in transaction/builder/alter_table.rs.
+// check in `AlterTableTransactionBuilder::build` for drop_column AND rename_column (mirror
+// Spark's SchemaUtils.checkDependentExpressions): reject drops/renames of columns referenced
+// by any CHECK constraint, and remove the corresponding guard in
+// transaction/builder/alter_table.rs.
 static CHECK_CONSTRAINTS_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::WriterOnly,
     min_legacy_version: Some(MinReaderWriterVersion::new(1, 3)),
@@ -323,9 +324,9 @@ static CHANGE_DATA_FEED_INFO: FeatureInfo = FeatureInfo {
 };
 
 // TODO: Before flipping `kernel_support` to `Supported`, implement the dependent-expression
-// check in `AlterTableTransactionBuilder::build` for drop_column (mirror Spark's
-// SchemaUtils.checkDependentExpressions): reject drops of columns referenced by any
-// generated-column expression, and remove the corresponding guard in
+// check in `AlterTableTransactionBuilder::build` for drop_column AND rename_column (mirror
+// Spark's SchemaUtils.checkDependentExpressions): reject drops/renames of columns referenced
+// by any generated-column expression, and remove the corresponding guard in
 // transaction/builder/alter_table.rs.
 static GENERATED_COLUMNS_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::WriterOnly,
@@ -335,11 +336,10 @@ static GENERATED_COLUMNS_INFO: FeatureInfo = FeatureInfo {
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 
-// TODO: Before flipping `kernel_support` to `Supported`, implement the dependent-expression
-// check in `AlterTableTransactionBuilder::build` for drop_column (mirror Spark's
-// SchemaUtils.checkDependentExpressions): reject drops of identity-tagged columns where the
-// dropped column is the identity column itself, and remove the corresponding guard in
-// transaction/builder/alter_table.rs.
+// TODO: Before flipping `kernel_support` to `Supported`, decide on drop/rename behavior for
+// identity-tagged columns and remove the corresponding guard in
+// transaction/builder/alter_table.rs. (Delta-spark does not block drops/renames here -- the
+// per-field identity metadata vanishes with the field.)
 static IDENTITY_COLUMNS_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::WriterOnly,
     min_legacy_version: Some(MinReaderWriterVersion::new(1, 6)),

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -300,6 +300,10 @@ static INVARIANTS_INFO: FeatureInfo = FeatureInfo {
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 
+// TODO: Before flipping `kernel_support` to `Supported`, implement the dependent-expression
+// check in `AlterTableTransactionBuilder::build` for drop_column (mirror Spark's
+// SchemaUtils.checkDependentExpressions): reject drops of columns referenced by any CHECK
+// constraint, and remove the corresponding guard in transaction/builder/alter_table.rs.
 static CHECK_CONSTRAINTS_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::WriterOnly,
     min_legacy_version: Some(MinReaderWriterVersion::new(1, 3)),
@@ -318,6 +322,11 @@ static CHANGE_DATA_FEED_INFO: FeatureInfo = FeatureInfo {
     }),
 };
 
+// TODO: Before flipping `kernel_support` to `Supported`, implement the dependent-expression
+// check in `AlterTableTransactionBuilder::build` for drop_column (mirror Spark's
+// SchemaUtils.checkDependentExpressions): reject drops of columns referenced by any
+// generated-column expression, and remove the corresponding guard in
+// transaction/builder/alter_table.rs.
 static GENERATED_COLUMNS_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::WriterOnly,
     min_legacy_version: Some(MinReaderWriterVersion::new(1, 4)),
@@ -326,6 +335,11 @@ static GENERATED_COLUMNS_INFO: FeatureInfo = FeatureInfo {
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 
+// TODO: Before flipping `kernel_support` to `Supported`, implement the dependent-expression
+// check in `AlterTableTransactionBuilder::build` for drop_column (mirror Spark's
+// SchemaUtils.checkDependentExpressions): reject drops of identity-tagged columns where the
+// dropped column is the identity column itself, and remove the corresponding guard in
+// transaction/builder/alter_table.rs.
 static IDENTITY_COLUMNS_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::WriterOnly,
     min_legacy_version: Some(MinReaderWriterVersion::new(1, 6)),

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -118,6 +118,26 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
         self.transition()
     }
 
+    /// Drop a column from the table schema. Supports nested columns via [`ColumnName`] paths
+    /// (e.g. `column_name!("address.city")`).
+    ///
+    /// Requires column mapping to be enabled (mode = name or id). The column is removed from the
+    /// logical schema but physical data in existing Parquet files is untouched.
+    ///
+    /// # Errors (at build time)
+    ///
+    /// - Column does not exist in the current schema
+    /// - Column mapping is not enabled on the table
+    /// - Column is a partition column or clustering column
+    /// - Column is the last remaining field at its struct level (would produce an empty struct)
+    /// - Column is an ancestor struct of a clustering column
+    /// - An intermediate component of the path is not a struct (e.g. `name.inner` where `name` is a
+    ///   primitive)
+    pub fn drop_column(mut self, column: ColumnName) -> AlterTableTransactionBuilder<Modifying> {
+        self.operations.push(SchemaOperation::DropColumn { column });
+        self.transition()
+    }
+
     /// Change a column's nullability from NOT NULL to nullable. If the column is already
     /// nullable, the op is a no-op but still generates a commit.
     ///
@@ -147,7 +167,7 @@ impl AlterTableTransactionBuilder<Modifying> {
     ///   `timestampNtz` column without the `timestampNtz` feature)
     pub fn build(
         self,
-        _engine: &dyn Engine,
+        engine: &dyn Engine,
         committer: Box<dyn Committer>,
     ) -> DeltaResult<AlterTableTransaction> {
         let table_config = self.snapshot.table_configuration();
@@ -160,6 +180,8 @@ impl AlterTableTransactionBuilder<Modifying> {
         let schema = Arc::unwrap_or_clone(table_config.logical_schema());
         let column_mapping_mode = table_config.column_mapping_mode();
         let current_max_column_id = table_config.table_properties().column_mapping_max_column_id;
+        let partition_columns = table_config.partition_columns();
+        let clustering_columns = self.snapshot.get_logical_clustering_columns(engine)?;
         let SchemaEvolutionResult {
             schema: evolved_schema,
             new_max_column_id,
@@ -168,6 +190,8 @@ impl AlterTableTransactionBuilder<Modifying> {
             self.operations,
             column_mapping_mode,
             current_max_column_id,
+            partition_columns,
+            clustering_columns.as_deref().unwrap_or(&[]),
         )?;
 
         let mut evolved_metadata = table_config

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -28,11 +28,12 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use crate::committer::Committer;
+use crate::error::Error;
 use crate::expressions::ColumnName;
 use crate::schema::StructField;
 use crate::snapshot::SnapshotRef;
 use crate::table_configuration::TableConfiguration;
-use crate::table_features::Operation;
+use crate::table_features::{Operation, TableFeature};
 use crate::table_properties::COLUMN_MAPPING_MAX_COLUMN_ID;
 use crate::transaction::alter_table::AlterTableTransaction;
 use crate::transaction::schema_evolution::{
@@ -133,6 +134,8 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
     /// - Column is an ancestor struct of a clustering column
     /// - An intermediate component of the path is not a struct (e.g. `name.inner` where `name` is a
     ///   primitive)
+    /// - Table has `delta.dataSkippingStatsColumns` set (kernel doesn't yet rewrite it; #2446)
+    // TODO(#2446): rewrite `delta.dataSkippingStatsColumns` on drop to match delta-spark.
     pub fn drop_column(mut self, column: ColumnName) -> AlterTableTransactionBuilder<Modifying> {
         self.operations.push(SchemaOperation::DropColumn { column });
         self.transition()
@@ -176,6 +179,42 @@ impl AlterTableTransactionBuilder<Modifying> {
         // invariants. Runs on the pre-alter snapshot; future ALTER variants that change the
         // protocol must also re-check this on the evolved `TableConfiguration`.
         table_config.ensure_operation_supported(Operation::Write)?;
+
+        // drop_column does not yet check dependent expressions (Spark's
+        // checkDependentExpressions). Block drops on tables with these features so flipping
+        // any of them to Supported won't silently orphan a generated/CHECK/identity reference.
+        // Also block drops on tables with `delta.dataSkippingStatsColumns` set: drop_column
+        // does not yet rewrite that property to remove the dropped column.
+        if self
+            .operations
+            .iter()
+            .any(|op| matches!(op, SchemaOperation::DropColumn { .. }))
+        {
+            for feature in [
+                TableFeature::GeneratedColumns,
+                TableFeature::CheckConstraints,
+                TableFeature::IdentityColumns,
+            ] {
+                if table_config.is_feature_supported(&feature) {
+                    return Err(Error::unsupported(format!(
+                        "drop_column is not supported on tables with the '{feature}' feature: \
+                         the dropped column may be referenced by a generated-column expression, \
+                         CHECK constraint, or identity column"
+                    )));
+                }
+            }
+            if table_config
+                .table_properties()
+                .data_skipping_stats_columns
+                .is_some()
+            {
+                return Err(Error::unsupported(
+                    "drop_column is not supported on tables with \
+                     'delta.dataSkippingStatsColumns' set: the property may reference the \
+                     dropped column and kernel does not yet rewrite it on drop",
+                ));
+            }
+        }
 
         let schema = Arc::unwrap_or_clone(table_config.logical_schema());
         let column_mapping_mode = table_config.column_mapping_mode();

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -9,12 +9,14 @@
 //!   operation is required).
 //! - [`Modifying`]: After any chainable schema operation. More ops can be chained, and `build()` is
 //!   available. See [`AlterTableTransactionBuilder<Modifying>`] for ops.
+//! - [`Renaming`]: After `rename_column`. Terminal state -- only `build()` is available.
 //!
 //! # Transitions
 //!
 //! Each `impl` block below is gated by a state bound and documents which operations that
 //! state enables. Chainable schema operations live on `impl<S: Chainable>` and transition
-//! the builder to a chainable state; `build()` lives on states that are buildable.
+//! the builder to a chainable state; `build()` lives on states that are buildable
+//! (see [`Buildable`]).
 //!
 //! ```ignore
 //! // Allowed: at least one op queued before build().
@@ -45,9 +47,15 @@ use crate::{DeltaResult, Engine};
 /// See [`Chainable`] for the operations available on this state.
 pub struct Ready;
 
-/// State after at least one operation has been added. `build()` is available.
-/// See [`Chainable`] for the operations available on this state.
+/// State after at least one chainable operation. `build()` is available, more chainable ops
+/// can be queued. See [`Chainable`] for the operations available on this state.
 pub struct Modifying;
+
+/// Terminal state after `rename_column`. Only `build()` is available; no further operations
+/// can be chained. This mirrors delta-spark's per-statement semantics: a single ALTER TABLE
+/// statement that renames a column is not also allowed to add, drop, or set-nullable other
+/// columns.
+pub struct Renaming;
 
 /// Marker trait for builder states that accept chainable schema operations. Grouping states
 /// under one bound lets each op (like `add_column`) live on a single `impl<S: Chainable>`
@@ -58,22 +66,32 @@ pub trait Chainable: sealed::Sealed {}
 impl Chainable for Ready {}
 impl Chainable for Modifying {}
 
+/// Marker trait for builder states that support `build()`. Grouping the post-op states
+/// (`Modifying` and `Renaming`) under one bound lets `build()` live on a single
+/// `impl<S: Buildable>` block -- shared body rather than duplicating per state.
+///
+/// Sealed: external types cannot implement this, keeping the set of buildable states closed.
+pub trait Buildable: sealed::Sealed {}
+impl Buildable for Modifying {}
+impl Buildable for Renaming {}
+
 mod sealed {
     pub trait Sealed {}
     impl Sealed for super::Ready {}
     impl Sealed for super::Modifying {}
+    impl Sealed for super::Renaming {}
 }
 
 /// Builder for constructing an [`AlterTableTransaction`] with schema evolution operations.
 ///
 /// Uses a type-state pattern (`S`) to enforce at compile time:
 /// - At least one schema operation must be queued before `build()` is callable.
-/// - Only operations valid for the current state can be chained. This will disallow incompatibel
+/// - Only operations valid for the current state can be chained. This will disallow incompatible
 ///   chaining.
 pub struct AlterTableTransactionBuilder<S = Ready> {
     snapshot: SnapshotRef,
     operations: Vec<SchemaOperation>,
-    // PhantomData marker for builder state (Ready or Modifying).
+    // PhantomData marker for builder state (Ready, Modifying, or Renaming).
     // Zero-sized; only affects which methods are available at compile time.
     _state: PhantomData<S>,
 }
@@ -150,9 +168,44 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
             .push(SchemaOperation::SetNullable { column });
         self.transition()
     }
+
+    /// Rename a column in the table schema. Supports nested columns via [`ColumnName`] paths.
+    ///
+    /// Requires column mapping to be enabled (mode = name or id). Only the logical name
+    /// changes; the physical name and column ID are preserved, so existing Parquet files
+    /// continue to be readable without rewrites.
+    ///
+    /// Rename is a terminal operation: no further operations can be chained on the same
+    /// builder. This matches delta-spark's per-statement semantics.
+    ///
+    /// Renaming a column to its current name (exact match) is a no-op; a case-only rename
+    /// (e.g. `name` -> `Name`) updates the stored logical name. Both still produce a commit.
+    ///
+    /// # Errors (at build time)
+    ///
+    /// - Column path is empty or the column does not exist in the current schema
+    /// - Column mapping is not enabled on the table
+    /// - `new_name` is empty or contains invalid characters (e.g. newlines)
+    /// - New name conflicts with an existing sibling column (case-insensitive)
+    /// - Column is a partition column, clustering column, or ancestor struct of one
+    /// - An intermediate component of the path is not a struct (e.g. `name.inner` where `name` is a
+    ///   primitive)
+    /// - Table has `delta.dataSkippingStatsColumns` set (kernel doesn't yet rewrite it; #2446)
+    // TODO(#2446): rewrite `delta.dataSkippingStatsColumns` on rename to match delta-spark.
+    pub fn rename_column(
+        mut self,
+        column: ColumnName,
+        new_name: impl Into<String>,
+    ) -> AlterTableTransactionBuilder<Renaming> {
+        self.operations.push(SchemaOperation::RenameColumn {
+            column,
+            new_name: new_name.into(),
+        });
+        self.transition()
+    }
 }
 
-impl AlterTableTransactionBuilder<Modifying> {
+impl<S: Buildable> AlterTableTransactionBuilder<S> {
     /// Validate and apply schema operations, then build the [`AlterTableTransaction`].
     ///
     /// This method:
@@ -180,16 +233,18 @@ impl AlterTableTransactionBuilder<Modifying> {
         // protocol must also re-check this on the evolved `TableConfiguration`.
         table_config.ensure_operation_supported(Operation::Write)?;
 
-        // drop_column does not yet check dependent expressions (Spark's
-        // checkDependentExpressions). Block drops on tables with these features so flipping
-        // any of them to Supported won't silently orphan a generated/CHECK/identity reference.
-        // Also block drops on tables with `delta.dataSkippingStatsColumns` set: drop_column
-        // does not yet rewrite that property to remove the dropped column.
-        if self
-            .operations
-            .iter()
-            .any(|op| matches!(op, SchemaOperation::DropColumn { .. }))
-        {
+        // drop_column and rename_column do not yet check dependent expressions (Spark's
+        // checkDependentExpressions) or rewrite stats-columns metadata. Block these ops on
+        // tables with the corresponding features so flipping any feature to Supported won't
+        // silently orphan a generated/CHECK/identity reference, and so a rewrite gap on
+        // `delta.dataSkippingStatsColumns` doesn't leave the property pointing at a missing
+        // or renamed column.
+        let op_label = self.operations.iter().find_map(|op| match op {
+            SchemaOperation::DropColumn { .. } => Some("drop_column"),
+            SchemaOperation::RenameColumn { .. } => Some("rename_column"),
+            _ => None,
+        });
+        if let Some(op_label) = op_label {
             for feature in [
                 TableFeature::GeneratedColumns,
                 TableFeature::CheckConstraints,
@@ -197,8 +252,8 @@ impl AlterTableTransactionBuilder<Modifying> {
             ] {
                 if table_config.is_feature_supported(&feature) {
                     return Err(Error::unsupported(format!(
-                        "drop_column is not supported on tables with the '{feature}' feature: \
-                         the dropped column may be referenced by a generated-column expression, \
+                        "{op_label} is not supported on tables with the '{feature}' feature: \
+                         the column may be referenced by a generated-column expression, \
                          CHECK constraint, or identity column"
                     )));
                 }
@@ -208,11 +263,11 @@ impl AlterTableTransactionBuilder<Modifying> {
                 .data_skipping_stats_columns
                 .is_some()
             {
-                return Err(Error::unsupported(
-                    "drop_column is not supported on tables with \
+                return Err(Error::unsupported(format!(
+                    "{op_label} is not supported on tables with \
                      'delta.dataSkippingStatsColumns' set: the property may reference the \
-                     dropped column and kernel does not yet rewrite it on drop",
-                ));
+                     column and kernel does not yet rewrite it on drop or rename"
+                )));
             }
         }
 

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -178,6 +178,15 @@ pub struct ExistingTable;
 #[derive(Debug)]
 pub struct CreateTable;
 
+/// Marker trait for transaction states that support data file operations.
+///
+/// Only transaction types that implement this trait can access methods for adding, removing, or
+/// updating data files. This prevents compile-time misuse by states like `AlterTable` that
+/// only perform metadata-only commits.
+pub trait SupportsDataFiles {}
+impl SupportsDataFiles for ExistingTable {}
+impl SupportsDataFiles for CreateTable {}
+
 /// A transaction represents an in-progress write to a table. After creating a transaction, changes
 /// to the table may be staged via the transaction methods before calling `commit` to commit the
 /// changes to the table.
@@ -756,7 +765,12 @@ impl<S> Transaction<S> {
     pub fn add_files_schema(&self) -> &'static SchemaRef {
         &BASE_ADD_FILES_SCHEMA
     }
+}
 
+// =============================================================================
+// Data file methods -- only available on transaction types that support data files
+// =============================================================================
+impl<S: SupportsDataFiles> Transaction<S> {
     /// Returns the expected schema for file statistics.
     ///
     /// The schema structure is derived from table configuration:
@@ -948,7 +962,12 @@ impl<S> Transaction<S> {
     pub fn add_files(&mut self, add_metadata: Box<dyn EngineData>) {
         self.add_files_metadata.push(add_metadata);
     }
+}
 
+// =============================================================================
+// Internal methods available on ALL transaction types (used by commit path)
+// =============================================================================
+impl<S> Transaction<S> {
     /// Validate that add files have required statistics for clustering columns.
     ///
     /// Per the Delta protocol, writers MUST collect per-file statistics for clustering columns
@@ -1946,7 +1965,7 @@ mod tests {
     // ============================================================================
     // validate_blind_append tests
     // ============================================================================
-    fn add_dummy_file<S>(txn: &mut Transaction<S>) {
+    fn add_dummy_file<S: SupportsDataFiles>(txn: &mut Transaction<S>) {
         let data = string_array_to_engine_data(StringArray::from(vec!["dummy"]));
         txn.add_files(data);
     }

--- a/kernel/src/transaction/schema_evolution.rs
+++ b/kernel/src/transaction/schema_evolution.rs
@@ -39,32 +39,32 @@ pub(crate) enum SchemaOperation {
 #[must_use]
 pub(crate) enum LeafAction {
     /// Keep the leaf in its parent IndexMap. Leaf was mutated in place (or unchanged).
-    Kept,
+    Keep,
     /// Remove the leaf field from its parent IndexMap. `modify_field_at_path` rejects this
     /// action if it would leave the parent struct with zero fields.
-    Removed,
+    Remove,
 }
 
 // Helper to modify a nested column. For each component in `path`, locates the matching field
 // (case-insensitive), then descends into the next nested struct. At the leaf, calls `modifier`
 // and applies its returned [`LeafAction`] in place.
 //
-// `Kept` mutations leave the leaf in place after the modifier ran. `Removed` deletes the leaf
+// `Keep` mutations leave the leaf in place after the modifier ran. `Remove` deletes the leaf
 // entry, preserving the order of remaining siblings.
 //
 // Returns an error if a field in the path does not exist, an intermediate field is not a struct,
-// or a `Removed` action would leave the parent struct empty.
+// or a `Remove` action would leave the parent struct empty.
 //
 // Example (mutate):
 //   fields  = [ id: int not null, address: struct { city: string not null, zip: string } ]
 //   path    = ["address", "city"]
-//   modifier = |f| { f.nullable = true; Ok(LeafAction::Kept) }
+//   modifier = |f| { f.nullable = true; Ok(LeafAction::Keep) }
 // yields:
 //   [ id: int not null, address: struct { city: string, zip: string } ]
 //
 // Example (remove):
 //   path    = ["address", "city"]
-//   modifier = |_| Ok(LeafAction::Removed)
+//   modifier = |_| Ok(LeafAction::Remove)
 // yields:
 //   [ id: int not null, address: struct { zip: string } ]
 fn modify_field_at_path(
@@ -97,18 +97,22 @@ fn modify_field_at_path(
 
     // === Leaf handling ===
     let parent_len = fields.len();
+    debug_assert!(
+        parent_len > 0,
+        "idx from position() implies non-empty fields"
+    );
     let (_, field) = fields
         .get_index_mut(idx)
         .ok_or_else(|| Error::internal_error("idx from position() invalid"))?;
     match modifier(field)? {
-        LeafAction::Kept => Ok(()),
-        LeafAction::Removed => {
+        LeafAction::Keep => Ok(()),
+        LeafAction::Remove => {
             // Reject drops that would leave the parent struct empty
             // Note: Matches Spark behaviour.
-            if parent_len <= 1 {
-                let old_name = field.name();
+            if parent_len == 1 {
                 return Err(Error::generic(format!(
-                    "field '{old_name}' is the last field at its level"
+                    "field '{}' is the last field at its level",
+                    field.name()
                 )));
             }
             // Preserve insertion order of remaining siblings.
@@ -132,15 +136,18 @@ fn reject_layout_locked_column(
             "Cannot {op_name} column: empty column path"
         )));
     }
-    // Partition columns are always top-level.
-    if path.len() == 1
-        && partition_columns
+    // Partition columns are always top-level. The slice pattern matches iff path.len() == 1
+    // and binds the sole element to `field_name`.
+    if let [field_name] = path {
+        let field_name_lower = field_name.to_lowercase();
+        if partition_columns
             .iter()
-            .any(|pc| pc.to_lowercase() == path[0].to_lowercase())
-    {
-        return Err(Error::generic(format!(
-            "Cannot {op_name} column '{column}': it is a partition column"
-        )));
+            .any(|pc| pc.to_lowercase() == field_name_lower)
+        {
+            return Err(Error::generic(format!(
+                "Cannot {op_name} column '{column}': it is a partition column"
+            )));
+        }
     }
     // Clustering columns may be nested; dropping an ancestor struct of one is also rejected.
     // Matches Spark.
@@ -248,7 +255,7 @@ pub(crate) fn apply_schema_operations(
             SchemaOperation::SetNullable { column } => {
                 modify_field_at_path(schema.field_map_mut(), column.path(), &|f| {
                     f.nullable = true;
-                    Ok(LeafAction::Kept)
+                    Ok(LeafAction::Keep)
                 })
                 .map_err(|e| {
                     Error::generic(format!("Cannot set nullable on column '{column}': {e}"))
@@ -268,7 +275,7 @@ pub(crate) fn apply_schema_operations(
                     "drop",
                 )?;
                 modify_field_at_path(schema.field_map_mut(), column.path(), &|_| {
-                    Ok(LeafAction::Removed)
+                    Ok(LeafAction::Remove)
                 })
                 .map_err(|e| Error::generic(format!("Cannot drop column '{column}': {e}")))?;
             }
@@ -322,7 +329,7 @@ mod tests {
                 "address",
                 StructType::try_new(vec![
                     StructField::nullable("street", DataType::STRING),
-                    StructField::nullable("city", DataType::STRING),
+                    StructField::not_null("city", DataType::STRING),
                     StructField::nullable("zip", DataType::STRING),
                 ])
                 .unwrap(),
@@ -364,7 +371,7 @@ mod tests {
 
     fn set_nullable_modifier(f: &mut StructField) -> DeltaResult<LeafAction> {
         f.nullable = true;
-        Ok(LeafAction::Kept)
+        Ok(LeafAction::Keep)
     }
 
     fn modify_field_at_path_test_helper(
@@ -381,7 +388,7 @@ mod tests {
         path: &[String],
     ) -> DeltaResult<IndexMap<String, StructField>> {
         let mut fields = into_field_map(schema);
-        modify_field_at_path(&mut fields, path, &|_| Ok(LeafAction::Removed))?;
+        modify_field_at_path(&mut fields, path, &|_| Ok(LeafAction::Remove))?;
         Ok(fields)
     }
 
@@ -458,7 +465,7 @@ mod tests {
         assert!(id.is_nullable());
     }
 
-    // === modify_field_at_path: remove via LeafAction::Removed ===
+    // === modify_field_at_path: remove via LeafAction::Remove ===
 
     #[test]
     fn remove_top_level_field() {
@@ -481,7 +488,7 @@ mod tests {
     }
 
     /// After removing a field, the surviving fields must retain their original order.
-    /// `modify_field_at_path` uses `shift_remove_index` for `LeafAction::Removed`, which
+    /// `modify_field_at_path` uses `shift_remove_index` for `LeafAction::Remove`, which
     /// preserves order. This test verifies that across drop positions (first / middle / last).
     #[rstest]
     #[case::first(0, &["b", "c", "d", "e"])]
@@ -1153,12 +1160,9 @@ mod tests {
         assert_eq!(result.schema.fields().count(), 2);
         let re_added = result.schema.field("name").unwrap();
         assert_eq!(re_added.data_type(), &DataType::INTEGER);
-        let new_id = get_cm_id(re_added);
-        assert!(
-            new_id > dropped_name_id,
-            "re-added column must get a fresh CM id ({new_id}) strictly greater \
-             than the dropped column's id ({dropped_name_id})"
-        );
+        let expected_new_id = dropped_name_id + 1;
+        assert_eq!(get_cm_id(re_added), expected_new_id);
+        assert_eq!(result.new_max_column_id, Some(expected_new_id));
         let new_physical_name = get_physical_name(re_added);
         assert_ne!(
             new_physical_name, "col-existing",

--- a/kernel/src/transaction/schema_evolution.rs
+++ b/kernel/src/transaction/schema_evolution.rs
@@ -26,30 +26,51 @@ pub(crate) enum SchemaOperation {
     /// Add a top-level column.
     AddColumn { field: StructField },
 
+    /// Drop a column. Supports nested columns (e.g. `column_name!("address.city")`).
+    /// Requires column mapping.
+    DropColumn { column: ColumnName },
+
     /// Change a column's nullability from NOT NULL to nullable.
     SetNullable { column: ColumnName },
 }
 
+/// Signal returned by [`modify_field_at_path`] modifiers describing what to do with the leaf
+/// field after the modifier runs.
+#[must_use]
+pub(crate) enum LeafAction {
+    /// Keep the leaf in its parent IndexMap. Leaf was mutated in place (or unchanged).
+    Kept,
+    /// Remove the leaf field from its parent IndexMap. `modify_field_at_path` rejects this
+    /// action if it would leave the parent struct with zero fields.
+    Removed,
+}
+
 // Helper to modify a nested column. For each component in `path`, locates the matching field
 // (case-insensitive), then descends into the next nested struct. At the leaf, calls `modifier`
-// to mutate the field in place.
+// and applies its returned [`LeafAction`] in place.
 //
-// `modifier` is expected to mutate the field's nullability, metadata, or `data_type` -- but
-// not its name. Renames need additional handling (IndexMap re-keying + sibling-conflict check)
-// that downstream PRs will introduce alongside the rename caller.
+// `Kept` mutations leave the leaf in place after the modifier ran. `Removed` deletes the leaf
+// entry, preserving the order of remaining siblings.
 //
-// Returns an error if a field in the path does not exist or an intermediate field is not a struct.
+// Returns an error if a field in the path does not exist, an intermediate field is not a struct,
+// or a `Removed` action would leave the parent struct empty.
 //
-// Example:
-//   fields   = [ id: int not null, address: struct { city: string not null, zip: string } ]
-//   path     = ["address", "city"]
-//   modifier = |f| { f.nullable = true; Ok(()) }
+// Example (mutate):
+//   fields  = [ id: int not null, address: struct { city: string not null, zip: string } ]
+//   path    = ["address", "city"]
+//   modifier = |f| { f.nullable = true; Ok(LeafAction::Kept) }
 // yields:
 //   [ id: int not null, address: struct { city: string, zip: string } ]
+//
+// Example (remove):
+//   path    = ["address", "city"]
+//   modifier = |_| Ok(LeafAction::Removed)
+// yields:
+//   [ id: int not null, address: struct { zip: string } ]
 fn modify_field_at_path(
     fields: &mut IndexMap<String, StructField>,
     path: &[String],
-    modifier: &dyn Fn(&mut StructField) -> DeltaResult<()>,
+    modifier: &dyn Fn(&mut StructField) -> DeltaResult<LeafAction>,
 ) -> DeltaResult<()> {
     let (first, rest) = path
         .split_first()
@@ -75,10 +96,60 @@ fn modify_field_at_path(
     }
 
     // === Leaf handling ===
+    let parent_len = fields.len();
     let (_, field) = fields
         .get_index_mut(idx)
         .ok_or_else(|| Error::internal_error("idx from position() invalid"))?;
-    modifier(field)
+    match modifier(field)? {
+        LeafAction::Kept => Ok(()),
+        LeafAction::Removed => {
+            // Reject drops that would leave the parent struct empty
+            // Note: Matches Spark behaviour.
+            if parent_len <= 1 {
+                let old_name = field.name();
+                return Err(Error::generic(format!(
+                    "field '{old_name}' is the last field at its level"
+                )));
+            }
+            // Preserve insertion order of remaining siblings.
+            fields.shift_remove_index(idx);
+            Ok(())
+        }
+    }
+}
+
+/// Rejects empty paths and columns the table layout locks (partition columns, clustering
+/// columns, or struct ancestors of clustering columns).
+fn reject_layout_locked_column(
+    column: &ColumnName,
+    partition_columns: &[String],
+    clustering_columns: &[ColumnName],
+    op_name: &str,
+) -> DeltaResult<()> {
+    let path = column.path();
+    if path.is_empty() {
+        return Err(Error::generic(format!(
+            "Cannot {op_name} column: empty column path"
+        )));
+    }
+    // Partition columns are always top-level.
+    if path.len() == 1
+        && partition_columns
+            .iter()
+            .any(|pc| pc.to_lowercase() == path[0].to_lowercase())
+    {
+        return Err(Error::generic(format!(
+            "Cannot {op_name} column '{column}': it is a partition column"
+        )));
+    }
+    // Clustering columns may be nested; dropping an ancestor struct of one is also rejected.
+    // Matches Spark.
+    if clustering_columns.iter().any(|cc| column.is_prefix_of(cc)) {
+        return Err(Error::generic(format!(
+            "Cannot {op_name} column '{column}': it is a clustering column or an ancestor of one"
+        )));
+    }
+    Ok(())
 }
 
 /// The result of applying schema operations.
@@ -106,6 +177,8 @@ pub(crate) fn apply_schema_operations(
     operations: Vec<SchemaOperation>,
     column_mapping_mode: ColumnMappingMode,
     current_max_column_id: Option<i64>,
+    partition_columns: &[String],
+    clustering_columns: &[ColumnName],
 ) -> DeltaResult<SchemaEvolutionResult> {
     let cm_enabled = column_mapping_mode != ColumnMappingMode::None;
 
@@ -175,11 +248,29 @@ pub(crate) fn apply_schema_operations(
             SchemaOperation::SetNullable { column } => {
                 modify_field_at_path(schema.field_map_mut(), column.path(), &|f| {
                     f.nullable = true;
-                    Ok(())
+                    Ok(LeafAction::Kept)
                 })
                 .map_err(|e| {
                     Error::generic(format!("Cannot set nullable on column '{column}': {e}"))
                 })?;
+            }
+            SchemaOperation::DropColumn { column } => {
+                if !cm_enabled {
+                    return Err(Error::generic(
+                        "DROP COLUMN requires column mapping to be enabled \
+                         (delta.columnMapping.mode = 'name' or 'id')",
+                    ));
+                }
+                reject_layout_locked_column(
+                    &column,
+                    partition_columns,
+                    clustering_columns,
+                    "drop",
+                )?;
+                modify_field_at_path(schema.field_map_mut(), column.path(), &|_| {
+                    Ok(LeafAction::Removed)
+                })
+                .map_err(|e| Error::generic(format!("Cannot drop column '{column}': {e}")))?;
             }
         }
     }
@@ -224,6 +315,22 @@ mod tests {
         .unwrap()
     }
 
+    fn nested_schema() -> StructType {
+        StructType::try_new(vec![
+            StructField::not_null("id", DataType::INTEGER),
+            StructField::nullable(
+                "address",
+                StructType::try_new(vec![
+                    StructField::nullable("street", DataType::STRING),
+                    StructField::nullable("city", DataType::STRING),
+                    StructField::nullable("zip", DataType::STRING),
+                ])
+                .unwrap(),
+            ),
+        ])
+        .unwrap()
+    }
+
     fn add_col(name: &str, nullable: bool) -> SchemaOperation {
         let field = if nullable {
             StructField::nullable(name, DataType::STRING)
@@ -244,21 +351,6 @@ mod tests {
         }
     }
 
-    fn nested_schema() -> StructType {
-        StructType::try_new(vec![
-            StructField::not_null("id", DataType::INTEGER),
-            StructField::nullable(
-                "address",
-                StructType::try_new(vec![
-                    StructField::not_null("city", DataType::STRING),
-                    StructField::nullable("zip", DataType::STRING),
-                ])
-                .unwrap(),
-            ),
-        ])
-        .unwrap()
-    }
-
     // === modify_field_at_path tests ===
 
     // Convert a StructType into the IndexMap<String, StructField> shape that
@@ -270,9 +362,9 @@ mod tests {
             .collect()
     }
 
-    fn set_nullable_modifier(f: &mut StructField) -> DeltaResult<()> {
+    fn set_nullable_modifier(f: &mut StructField) -> DeltaResult<LeafAction> {
         f.nullable = true;
-        Ok(())
+        Ok(LeafAction::Kept)
     }
 
     fn modify_field_at_path_test_helper(
@@ -281,6 +373,15 @@ mod tests {
     ) -> DeltaResult<IndexMap<String, StructField>> {
         let mut fields = into_field_map(schema);
         modify_field_at_path(&mut fields, path, &set_nullable_modifier)?;
+        Ok(fields)
+    }
+
+    fn remove_field_at_path_test_helper(
+        schema: StructType,
+        path: &[String],
+    ) -> DeltaResult<IndexMap<String, StructField>> {
+        let mut fields = into_field_map(schema);
+        modify_field_at_path(&mut fields, path, &|_| Ok(LeafAction::Removed))?;
         Ok(fields)
     }
 
@@ -319,19 +420,33 @@ mod tests {
         }
     }
 
-    #[test]
-    fn modify_nonexistent_field_fails() {
+    #[rstest]
+    #[case::modify(true)]
+    #[case::remove(false)]
+    fn nonexistent_field_fails(#[case] is_modify: bool) {
         let path = vec!["nope".to_string()];
-        let err = modify_field_at_path_test_helper(simple_schema(), &path).unwrap_err();
+        let err = if is_modify {
+            modify_field_at_path_test_helper(simple_schema(), &path)
+        } else {
+            remove_field_at_path_test_helper(simple_schema(), &path)
+        }
+        .unwrap_err();
         assert!(err.to_string().contains("does not exist"));
     }
 
     /// A path that descends into a non-struct intermediate field (here: `name.inner`, where
     /// `name` is a STRING, not a struct) must error rather than silently succeed or panic.
-    #[test]
-    fn modify_through_non_struct_fails() {
+    #[rstest]
+    #[case::modify(true)]
+    #[case::remove(false)]
+    fn through_non_struct_fails(#[case] is_modify: bool) {
         let path = vec!["name".to_string(), "inner".to_string()];
-        let err = modify_field_at_path_test_helper(simple_schema(), &path).unwrap_err();
+        let err = if is_modify {
+            modify_field_at_path_test_helper(simple_schema(), &path)
+        } else {
+            remove_field_at_path_test_helper(simple_schema(), &path)
+        }
+        .unwrap_err();
         assert!(err.to_string().contains("not a struct"));
     }
 
@@ -343,7 +458,188 @@ mod tests {
         assert!(id.is_nullable());
     }
 
-    // === apply_schema_operations tests ===
+    // === modify_field_at_path: remove via LeafAction::Removed ===
+
+    #[test]
+    fn remove_top_level_field() {
+        let path = vec!["name".to_string()];
+        let result = remove_field_at_path_test_helper(simple_schema(), &path).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.values().next().unwrap().name(), "id");
+    }
+
+    #[test]
+    fn remove_nested_field() {
+        let path = vec!["address".to_string(), "city".to_string()];
+        let result = remove_field_at_path_test_helper(nested_schema(), &path).unwrap();
+        let addr = result.values().find(|f| f.name() == "address").unwrap();
+        let DataType::Struct(s) = addr.data_type() else {
+            panic!("expected struct");
+        };
+        assert!(s.field("city").is_none());
+        assert!(s.field("zip").is_some());
+    }
+
+    /// After removing a field, the surviving fields must retain their original order.
+    /// `modify_field_at_path` uses `shift_remove_index` for `LeafAction::Removed`, which
+    /// preserves order. This test verifies that across drop positions (first / middle / last).
+    #[rstest]
+    #[case::first(0, &["b", "c", "d", "e"])]
+    #[case::middle(2, &["a", "b", "d", "e"])]
+    #[case::last(4, &["a", "b", "c", "d"])]
+    fn remove_preserves_order_at_position(
+        #[case] drop_idx: usize,
+        #[case] expected_order: &[&str],
+    ) {
+        let names = ["a", "b", "c", "d", "e"];
+        let schema = StructType::try_new(
+            names
+                .iter()
+                .map(|n| StructField::nullable(*n, DataType::STRING))
+                .collect::<Vec<_>>(),
+        )
+        .unwrap();
+        let drop_name = names[drop_idx].to_string();
+        let result = remove_field_at_path_test_helper(schema, &[drop_name]).unwrap();
+        let actual_order: Vec<&str> = result.values().map(|f| f.name().as_str()).collect();
+        assert_eq!(&actual_order, expected_order);
+    }
+
+    /// No-empty-struct invariant: removing the last remaining field at any level must error.
+    #[rstest]
+    #[case::top_level(
+        StructType::try_new(vec![StructField::nullable("only", DataType::STRING)]).unwrap(),
+        vec!["only".to_string()]
+    )]
+    #[case::nested(
+        StructType::try_new(vec![
+            StructField::not_null("id", DataType::INTEGER),
+            StructField::nullable(
+                "address",
+                StructType::try_new(vec![StructField::nullable("street", DataType::STRING)])
+                    .unwrap(),
+            ),
+        ])
+        .unwrap(),
+        vec!["address".to_string(), "street".to_string()]
+    )]
+    fn remove_last_field_fails(#[case] schema: StructType, #[case] path: Vec<String>) {
+        let err = remove_field_at_path_test_helper(schema, &path).unwrap_err();
+        assert!(err.to_string().contains("last field at its level"));
+    }
+
+    #[test]
+    fn remove_case_insensitive_lookup() {
+        let path = vec!["NAME".to_string()];
+        let result = remove_field_at_path_test_helper(simple_schema(), &path).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.values().next().unwrap().name(), "id");
+    }
+
+    /// Removing one nested leaf (`address.city`) must not touch any other field. Guards against
+    /// the recursion accidentally replacing siblings when it descends and returns.
+    #[test]
+    fn remove_nested_leaf_preserves_other_fields() {
+        let path = vec!["address".to_string(), "city".to_string()];
+        let result = remove_field_at_path_test_helper(nested_schema(), &path).unwrap();
+        // Top-level "id" unchanged
+        let id = result.values().find(|f| f.name() == "id").unwrap();
+        assert!(!id.is_nullable());
+        // "address" still present, inner "zip" survived, inner "city" gone
+        let addr = result.values().find(|f| f.name() == "address").unwrap();
+        let DataType::Struct(s) = addr.data_type() else {
+            panic!("expected struct");
+        };
+        assert!(s.field("zip").is_some());
+        assert!(s.field("city").is_none());
+    }
+
+    /// Covers 4-level recursion: `a.b.c.d`. Exercises the recursion for both modify and remove.
+    fn four_level_nested_schema() -> StructType {
+        StructType::try_new(vec![StructField::nullable(
+            "a",
+            StructType::try_new(vec![StructField::nullable(
+                "b",
+                StructType::try_new(vec![StructField::nullable(
+                    "c",
+                    StructType::try_new(vec![
+                        StructField::not_null("d", DataType::INTEGER),
+                        StructField::nullable("sibling", DataType::STRING),
+                    ])
+                    .unwrap(),
+                )])
+                .unwrap(),
+            )])
+            .unwrap(),
+        )])
+        .unwrap()
+    }
+
+    /// Walk to `result`'s `a.b.c` leaf struct. The 4-level helpers above produce schemas where
+    /// the modified/removed leaf lives there, so tests just assert on the resulting `d_struct`.
+    fn walk_to_d_struct(result: &IndexMap<String, StructField>) -> &StructType {
+        let a = result.values().next().unwrap();
+        let DataType::Struct(b_struct) = a.data_type() else {
+            panic!("a should be struct");
+        };
+        let DataType::Struct(c_struct) = b_struct.field("b").unwrap().data_type() else {
+            panic!("b should be struct");
+        };
+        let DataType::Struct(d_struct) = c_struct.field("c").unwrap().data_type() else {
+            panic!("c should be struct");
+        };
+        d_struct
+    }
+
+    /// 4-level recursion (`a.b.c.d`) for both modify and remove. The helper must descend
+    /// through each level, apply the leaf action, and rebuild on the way back up without
+    /// disturbing the sibling.
+    #[rstest]
+    #[case::modify(true)]
+    #[case::remove(false)]
+    fn deeply_nested_4_levels(#[case] is_modify: bool) {
+        let path = vec![
+            "a".to_string(),
+            "b".to_string(),
+            "c".to_string(),
+            "d".to_string(),
+        ];
+        let result = if is_modify {
+            modify_field_at_path_test_helper(four_level_nested_schema(), &path).unwrap()
+        } else {
+            remove_field_at_path_test_helper(four_level_nested_schema(), &path).unwrap()
+        };
+        let d_struct = walk_to_d_struct(&result);
+        if is_modify {
+            assert!(d_struct.field("d").unwrap().is_nullable());
+            assert!(d_struct.field("sibling").unwrap().is_nullable());
+        } else {
+            assert!(d_struct.field("d").is_none());
+            assert!(d_struct.field("sibling").is_some());
+        }
+    }
+
+    // Shorthand for apply_schema_operations with no column mapping and no partition/clustering.
+    // Used by AddColumn, SetNullable, and DropColumn tests below.
+    fn apply_ops(
+        schema: StructType,
+        ops: Vec<SchemaOperation>,
+    ) -> DeltaResult<SchemaEvolutionResult> {
+        apply_schema_operations(schema, ops, ColumnMappingMode::None, None, &[], &[])
+    }
+
+    // Shorthand for apply_schema_operations with column mapping enabled and a given max id, but
+    // no partition/clustering columns.
+    fn apply_ops_with_cm(
+        schema: StructType,
+        ops: Vec<SchemaOperation>,
+        mode: ColumnMappingMode,
+        current_max_column_id: Option<i64>,
+    ) -> DeltaResult<SchemaEvolutionResult> {
+        apply_schema_operations(schema, ops, mode, current_max_column_id, &[], &[])
+    }
+
+    // === apply_schema_operations: AddColumn tests ===
 
     #[rstest]
     #[case::dup_exact(vec![add_col("name", true)], "already exists")]
@@ -368,8 +664,7 @@ mod tests {
         #[case] ops: Vec<SchemaOperation>,
         #[case] error_contains: &str,
     ) {
-        let err = apply_schema_operations(simple_schema(), ops, ColumnMappingMode::None, None)
-            .unwrap_err();
+        let err = apply_ops(simple_schema(), ops).unwrap_err();
         assert!(err.to_string().contains(error_contains));
     }
 
@@ -383,8 +678,7 @@ mod tests {
         #[case] ops: Vec<SchemaOperation>,
         #[case] expected_names: &[&str],
     ) {
-        let result =
-            apply_schema_operations(simple_schema(), ops, ColumnMappingMode::None, None).unwrap();
+        let result = apply_ops(simple_schema(), ops).unwrap();
         let actual: Vec<&str> = result.schema.fields().map(|f| f.name().as_str()).collect();
         assert_eq!(&actual, expected_names);
     }
@@ -417,7 +711,7 @@ mod tests {
         let ops = vec![SchemaOperation::SetNullable {
             column: column.clone(),
         }];
-        let result = apply_schema_operations(schema, ops, ColumnMappingMode::None, None).unwrap();
+        let result = apply_ops(schema, ops).unwrap();
         assert!(result.schema.field_at_path(column.path()).is_nullable());
     }
 
@@ -427,8 +721,7 @@ mod tests {
     #[case::empty_path(ColumnName::new(Vec::<String>::new()), "empty column path")]
     fn set_nullable_fails(#[case] column: ColumnName, #[case] error_contains: &str) {
         let ops = vec![SchemaOperation::SetNullable { column }];
-        let err = apply_schema_operations(simple_schema(), ops, ColumnMappingMode::None, None)
-            .unwrap_err();
+        let err = apply_ops(simple_schema(), ops).unwrap_err();
         assert!(
             err.to_string().contains(error_contains),
             "expected error to contain '{error_contains}', got: {err}"
@@ -447,7 +740,7 @@ mod tests {
         let ops = vec![SchemaOperation::SetNullable {
             column: column_name!("address"),
         }];
-        let result = apply_schema_operations(schema, ops, ColumnMappingMode::None, None).unwrap();
+        let result = apply_ops(schema, ops).unwrap();
         let addr = result.schema.field("address").unwrap();
         assert!(addr.is_nullable(), "struct itself must be nullable");
         match addr.data_type() {
@@ -469,36 +762,11 @@ mod tests {
                 column: column_name!("id"),
             },
         ];
-        let result =
-            apply_schema_operations(simple_schema(), ops, ColumnMappingMode::None, None).unwrap();
+        let result = apply_ops(simple_schema(), ops).unwrap();
         assert_eq!(result.schema.fields().count(), 3);
         assert!(result.schema.field("email").is_some());
         assert!(result.schema.field("id").unwrap().is_nullable());
     }
-
-    #[test]
-    fn set_nullable_nested_preserves_top_level_order() {
-        // SetNullable on a nested field within a middle top-level field must not reorder
-        // the top-level IndexMap.
-        let schema = StructType::try_new(vec![
-            StructField::not_null("alpha", DataType::INTEGER),
-            StructField::nullable(
-                "beta",
-                StructType::try_new(vec![StructField::not_null("nested", DataType::STRING)])
-                    .unwrap(),
-            ),
-            StructField::not_null("gamma", DataType::STRING),
-        ])
-        .unwrap();
-        let ops = vec![SchemaOperation::SetNullable {
-            column: column_name!("beta.nested"),
-        }];
-        let result = apply_schema_operations(schema, ops, ColumnMappingMode::None, None).unwrap();
-        let names: Vec<&String> = result.schema.fields().map(|f| f.name()).collect();
-        assert_eq!(names, vec!["alpha", "beta", "gamma"]);
-    }
-
-    // === Column mapping tests ===
 
     fn get_cm_id(field: &StructField) -> i64 {
         field
@@ -527,8 +795,7 @@ mod tests {
         let ops = vec![SchemaOperation::AddColumn {
             field: StructField::nullable("email", DataType::STRING),
         }];
-        let result =
-            apply_schema_operations(simple_schema(), ops, mode, Some(current_max)).unwrap();
+        let result = apply_ops_with_cm(simple_schema(), ops, mode, Some(current_max)).unwrap();
         let email_field = result.schema.field("email").unwrap();
 
         assert_eq!(get_cm_id(email_field), expected_id);
@@ -541,8 +808,8 @@ mod tests {
         let ops = vec![SchemaOperation::AddColumn {
             field: StructField::nullable("email", DataType::STRING),
         }];
-        let err = apply_schema_operations(simple_schema(), ops, ColumnMappingMode::Name, None)
-            .unwrap_err();
+        let err =
+            apply_ops_with_cm(simple_schema(), ops, ColumnMappingMode::Name, None).unwrap_err();
         assert!(matches!(err, Error::InvalidProtocol(_)));
         assert!(err.to_string().contains("maxColumnId"));
     }
@@ -564,8 +831,7 @@ mod tests {
             },
         ];
         let result =
-            apply_schema_operations(simple_schema(), ops, ColumnMappingMode::Name, Some(10))
-                .unwrap();
+            apply_ops_with_cm(simple_schema(), ops, ColumnMappingMode::Name, Some(10)).unwrap();
 
         let id_a = get_cm_id(result.schema.field("a").unwrap());
         let id_b = get_cm_id(result.schema.field("b").unwrap());
@@ -635,8 +901,7 @@ mod tests {
             field: StructField::nullable("col", data_type),
         }];
         let result =
-            apply_schema_operations(simple_schema(), ops, ColumnMappingMode::Name, Some(10))
-                .unwrap();
+            apply_ops_with_cm(simple_schema(), ops, ColumnMappingMode::Name, Some(10)).unwrap();
 
         let added = result.schema.field("col").unwrap();
         let ids = added.collect_column_mapping_ids();
@@ -675,8 +940,8 @@ mod tests {
     ))]
     fn add_column_with_preexisting_cm_metadata_is_rejected_under_cm(#[case] field: StructField) {
         let ops = vec![SchemaOperation::AddColumn { field }];
-        let err = apply_schema_operations(simple_schema(), ops, ColumnMappingMode::Name, Some(2))
-            .unwrap_err();
+        let err =
+            apply_ops_with_cm(simple_schema(), ops, ColumnMappingMode::Name, Some(2)).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("pre-populated"));
         assert!(
@@ -700,13 +965,226 @@ mod tests {
             field: StructField::nullable("new", DataType::STRING),
         }];
         // Persisted maxColumnId is stale at 5, but the schema actually contains id=42.
-        let result =
-            apply_schema_operations(schema, ops, ColumnMappingMode::Name, Some(5)).unwrap();
+        let result = apply_ops_with_cm(schema, ops, ColumnMappingMode::Name, Some(5)).unwrap();
         let new_id = get_cm_id(result.schema.field("new").unwrap());
         assert_eq!(
             new_id, 43,
             "new id must follow schema max (42), not stale property (5)"
         );
         assert_eq!(result.new_max_column_id, Some(43));
+    }
+
+    // === apply_schema_operations: DropColumn tests ===
+
+    /// Schema flavor selector for `drop_column_failures`. Each variant builds a distinct
+    /// schema so one rstest can exercise drops across simple, single-column, and nested shapes.
+    enum DropSchema {
+        /// `simple_schema()` = { id: int not null, name: string }
+        Simple,
+        /// { only: string }
+        SingleColumn,
+        /// { id: int not null, address: struct { street: string } }
+        AddressStreetOnly,
+        /// `nested_schema()` = { id: int not null, address: struct { street, city, zip } }
+        NestedThreeFields,
+    }
+
+    fn build_drop_schema(flavor: DropSchema) -> StructType {
+        match flavor {
+            DropSchema::Simple => simple_schema(),
+            DropSchema::SingleColumn => {
+                StructType::try_new(vec![StructField::nullable("only", DataType::STRING)]).unwrap()
+            }
+            DropSchema::AddressStreetOnly => StructType::try_new(vec![
+                StructField::not_null("id", DataType::INTEGER),
+                StructField::nullable(
+                    "address",
+                    StructType::try_new(vec![StructField::nullable("street", DataType::STRING)])
+                        .unwrap(),
+                ),
+            ])
+            .unwrap(),
+            DropSchema::NestedThreeFields => nested_schema(),
+        }
+    }
+
+    #[rstest]
+    #[case::without_cm(
+        DropSchema::Simple, ColumnMappingMode::None, None,
+        column_name!("name"), vec![], vec![], "column mapping"
+    )]
+    #[case::nonexistent(
+        DropSchema::Simple, ColumnMappingMode::Name, Some(2),
+        column_name!("nonexistent"), vec![], vec![], "does not exist"
+    )]
+    #[case::partition_same_case(
+        DropSchema::Simple, ColumnMappingMode::Name, Some(2),
+        column_name!("name"), vec!["name".to_string()], vec![], "partition column"
+    )]
+    #[case::partition_diff_case(
+        DropSchema::Simple, ColumnMappingMode::Name, Some(2),
+        column_name!("NAME"), vec!["name".to_string()], vec![], "partition column"
+    )]
+    #[case::last_column(
+        DropSchema::SingleColumn, ColumnMappingMode::Name, Some(1),
+        column_name!("only"), vec![], vec![], "last field"
+    )]
+    #[case::last_nested_field(
+        DropSchema::AddressStreetOnly, ColumnMappingMode::Name, Some(3),
+        column_name!("address.street"), vec![], vec![], "last field"
+    )]
+    #[case::clustering_same_case(
+        DropSchema::Simple, ColumnMappingMode::Name, Some(4),
+        column_name!("name"), vec![], vec![column_name!("name")], "clustering column"
+    )]
+    #[case::clustering_diff_case(
+        DropSchema::Simple, ColumnMappingMode::Name, Some(4),
+        column_name!("NAME"), vec![], vec![column_name!("name")], "clustering column"
+    )]
+    #[case::clustering_ancestor(
+        DropSchema::NestedThreeFields, ColumnMappingMode::Name, Some(4),
+        column_name!("address"), vec![], vec![column_name!("address.city")], "clustering column"
+    )]
+    #[case::nested_nonexistent(
+        DropSchema::NestedThreeFields, ColumnMappingMode::Name, Some(4),
+        column_name!("address.country"), vec![], vec![], "does not exist"
+    )]
+    #[case::nested_through_non_struct(
+        DropSchema::Simple, ColumnMappingMode::Name, Some(2),
+        column_name!("name.inner"), vec![], vec![], "not a struct"
+    )]
+    #[case::empty_path(
+        DropSchema::Simple, ColumnMappingMode::Name, Some(2),
+        ColumnName::new(Vec::<String>::new()), vec![], vec![], "empty column path"
+    )]
+    fn drop_column_failures(
+        #[case] schema_flavor: DropSchema,
+        #[case] cm: ColumnMappingMode,
+        #[case] max_id: Option<i64>,
+        #[case] drop_column: ColumnName,
+        #[case] partition: Vec<String>,
+        #[case] clustering: Vec<ColumnName>,
+        #[case] error_contains: &str,
+    ) {
+        let ops = vec![SchemaOperation::DropColumn {
+            column: drop_column,
+        }];
+        let err = apply_schema_operations(
+            build_drop_schema(schema_flavor),
+            ops,
+            cm,
+            max_id,
+            &partition,
+            &clustering,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains(error_contains));
+    }
+
+    #[test]
+    fn drop_column_succeeds() {
+        let schema = simple_schema();
+        let ops = vec![SchemaOperation::DropColumn {
+            column: column_name!("name"),
+        }];
+        let result = apply_ops_with_cm(schema, ops, ColumnMappingMode::Name, Some(2)).unwrap();
+        assert_eq!(result.schema.fields().count(), 1);
+        assert!(result.schema.field("name").is_none());
+        assert!(result.schema.field("id").is_some());
+    }
+
+    #[test]
+    fn chain_add_drop_set_nullable() {
+        let schema = StructType::try_new(vec![
+            StructField::not_null("id", DataType::INTEGER),
+            StructField::nullable("name", DataType::STRING),
+            StructField::nullable("age", DataType::INTEGER),
+        ])
+        .unwrap();
+        let ops = vec![
+            SchemaOperation::AddColumn {
+                field: StructField::nullable("email", DataType::STRING),
+            },
+            SchemaOperation::DropColumn {
+                column: column_name!("age"),
+            },
+            SchemaOperation::SetNullable {
+                column: column_name!("id"),
+            },
+        ];
+        let result = apply_ops_with_cm(schema, ops, ColumnMappingMode::Name, Some(3)).unwrap();
+        assert_eq!(result.schema.fields().count(), 3);
+        assert!(result.schema.field("email").is_some());
+        assert!(result.schema.field("age").is_none());
+        assert!(result.schema.field("id").unwrap().is_nullable());
+    }
+
+    #[test]
+    fn drop_then_re_add_same_column_name() {
+        // Pre-assign a column-mapping id to "name" so we can verify that after drop + re-add
+        // the new "name" gets a fresh id strictly greater than the dropped column's id.
+        let dropped_name_id: i64 = 2;
+        let mut name_field = StructField::nullable("name", DataType::STRING);
+        name_field.metadata.insert(
+            ColumnMetadataKey::ColumnMappingId.as_ref().to_string(),
+            MetadataValue::Number(dropped_name_id),
+        );
+        name_field.metadata.insert(
+            ColumnMetadataKey::ColumnMappingPhysicalName
+                .as_ref()
+                .to_string(),
+            MetadataValue::String("col-existing".to_string()),
+        );
+        let schema = StructType::try_new(vec![
+            StructField::not_null("id", DataType::INTEGER),
+            name_field,
+        ])
+        .unwrap();
+        let ops = vec![
+            SchemaOperation::DropColumn {
+                column: column_name!("name"),
+            },
+            SchemaOperation::AddColumn {
+                field: StructField::nullable("name", DataType::INTEGER),
+            },
+        ];
+        let result =
+            apply_ops_with_cm(schema, ops, ColumnMappingMode::Name, Some(dropped_name_id)).unwrap();
+        assert_eq!(result.schema.fields().count(), 2);
+        let re_added = result.schema.field("name").unwrap();
+        assert_eq!(re_added.data_type(), &DataType::INTEGER);
+        let new_id = get_cm_id(re_added);
+        assert!(
+            new_id > dropped_name_id,
+            "re-added column must get a fresh CM id ({new_id}) strictly greater \
+             than the dropped column's id ({dropped_name_id})"
+        );
+        let new_physical_name = get_physical_name(re_added);
+        assert_ne!(
+            new_physical_name, "col-existing",
+            "re-added column must get a fresh physical name distinct from the dropped column's"
+        );
+    }
+
+    #[test]
+    fn drop_nested_column_succeeds() {
+        let schema = nested_schema();
+        let ops = vec![SchemaOperation::DropColumn {
+            column: column_name!("address.city"),
+        }];
+        let result = apply_ops_with_cm(schema, ops, ColumnMappingMode::Name, Some(4)).unwrap();
+        // Top level still has 2 fields
+        assert_eq!(result.schema.fields().count(), 2);
+        // address struct should have 2 fields (street, zip) -- city removed
+        let addr = result.schema.field("address").unwrap();
+        match addr.data_type() {
+            DataType::Struct(s) => {
+                assert_eq!(s.fields().count(), 2);
+                assert!(s.field("city").is_none());
+                assert!(s.field("street").is_some());
+                assert!(s.field("zip").is_some());
+            }
+            other => panic!("Expected Struct, got: {other:?}"),
+        }
     }
 }

--- a/kernel/src/transaction/schema_evolution.rs
+++ b/kernel/src/transaction/schema_evolution.rs
@@ -30,6 +30,12 @@ pub(crate) enum SchemaOperation {
     /// Requires column mapping.
     DropColumn { column: ColumnName },
 
+    /// Rename a column by path. Supports nested columns. Requires column mapping.
+    RenameColumn {
+        column: ColumnName,
+        new_name: String,
+    },
+
     /// Change a column's nullability from NOT NULL to nullable.
     SetNullable { column: ColumnName },
 }
@@ -49,11 +55,14 @@ pub(crate) enum LeafAction {
 // (case-insensitive), then descends into the next nested struct. At the leaf, calls `modifier`
 // and applies its returned [`LeafAction`] in place.
 //
-// `Keep` mutations leave the leaf in place after the modifier ran. `Remove` deletes the leaf
-// entry, preserving the order of remaining siblings.
+// `Keep` mutations include rename: if `modifier` changes `field.name`, the IndexMap key is
+// updated to match (preserving insertion order) and a case-insensitive sibling-conflict check
+// is applied.
+// `Remove` deletes the leaf entry, preserving the order of remaining siblings.
 //
 // Returns an error if a field in the path does not exist, an intermediate field is not a struct,
-// or a `Remove` action would leave the parent struct empty.
+// a `Keep` rename would collide with a sibling, or a `Remove` action would leave the parent
+// struct empty.
 //
 // Example (mutate):
 //   fields  = [ id: int not null, address: struct { city: string not null, zip: string } ]
@@ -104,8 +113,33 @@ fn modify_field_at_path(
     let (_, field) = fields
         .get_index_mut(idx)
         .ok_or_else(|| Error::internal_error("idx from position() invalid"))?;
+    let old_name = field.name().clone();
     match modifier(field)? {
-        LeafAction::Keep => Ok(()),
+        LeafAction::Keep => {
+            let new_name = field.name().clone();
+            if old_name == new_name {
+                return Ok(());
+            }
+            // Rename: validate against siblings (case-insensitive), then re-key the entry while
+            // preserving insertion order via swap_remove + insert + swap_indices (all O(1)).
+            let lowered_new = new_name.to_lowercase();
+            if fields
+                .iter()
+                .enumerate()
+                .any(|(i, (_, f))| i != idx && f.name().to_lowercase() == lowered_new)
+            {
+                return Err(Error::generic(format!(
+                    "Cannot rename '{old_name}' to '{new_name}': \
+                     a column with that name already exists"
+                )));
+            }
+            let (_, old_value) = fields
+                .swap_remove_index(idx)
+                .ok_or_else(|| Error::internal_error("entry vanished between lookup and remove"))?;
+            fields.insert(new_name, old_value);
+            fields.swap_indices(idx, fields.len() - 1);
+            Ok(())
+        }
         LeafAction::Remove => {
             // Reject drops that would leave the parent struct empty
             // Note: Matches Spark behaviour.
@@ -120,6 +154,18 @@ fn modify_field_at_path(
             Ok(())
         }
     }
+}
+
+/// Rejects an operation when column mapping is not enabled. `op_name_uppercase` is used in the
+/// error message so it reads naturally (e.g. "DROP COLUMN requires...").
+fn require_column_mapping(cm_enabled: bool, op_name_uppercase: &str) -> DeltaResult<()> {
+    if !cm_enabled {
+        return Err(Error::generic(format!(
+            "{op_name_uppercase} requires column mapping to be enabled \
+             (delta.columnMapping.mode = 'name' or 'id')"
+        )));
+    }
+    Ok(())
 }
 
 /// Rejects empty paths and columns the table layout locks (partition columns, clustering
@@ -149,7 +195,7 @@ fn reject_layout_locked_column(
             )));
         }
     }
-    // Clustering columns may be nested; dropping an ancestor struct of one is also rejected.
+    // Clustering columns may be nested; modifying an ancestor struct of one is also rejected.
     // Matches Spark.
     if clustering_columns.iter().any(|cc| column.is_prefix_of(cc)) {
         return Err(Error::generic(format!(
@@ -262,12 +308,7 @@ pub(crate) fn apply_schema_operations(
                 })?;
             }
             SchemaOperation::DropColumn { column } => {
-                if !cm_enabled {
-                    return Err(Error::generic(
-                        "DROP COLUMN requires column mapping to be enabled \
-                         (delta.columnMapping.mode = 'name' or 'id')",
-                    ));
-                }
+                require_column_mapping(cm_enabled, "DROP COLUMN")?;
                 reject_layout_locked_column(
                     &column,
                     partition_columns,
@@ -278,6 +319,25 @@ pub(crate) fn apply_schema_operations(
                     Ok(LeafAction::Remove)
                 })
                 .map_err(|e| Error::generic(format!("Cannot drop column '{column}': {e}")))?;
+            }
+            SchemaOperation::RenameColumn { column, new_name } => {
+                require_column_mapping(cm_enabled, "RENAME COLUMN")?;
+                // `new_name` validity (non-empty, valid chars) is enforced by `validate_schema`
+                // at the end of this function via `SchemaValidator::transform_struct_field`.
+                // TODO(#2446): delta-spark supports renaming partition and clustering columns
+                // and rewrites `Metadata.partitionColumns` / clustering domain metadata
+                // accordingly. Until then, we reject via the layout-lock helper.
+                reject_layout_locked_column(
+                    &column,
+                    partition_columns,
+                    clustering_columns,
+                    "rename",
+                )?;
+                modify_field_at_path(schema.field_map_mut(), column.path(), &|f| {
+                    f.name = new_name.clone();
+                    Ok(LeafAction::Keep)
+                })
+                .map_err(|e| Error::generic(format!("Cannot rename column '{column}': {e}")))?;
             }
         }
     }
@@ -1190,5 +1250,355 @@ mod tests {
             }
             other => panic!("Expected Struct, got: {other:?}"),
         }
+    }
+
+    // === apply_schema_operations: RenameColumn tests ===
+
+    #[rstest]
+    #[case::without_cm(
+        simple_schema(), column_name!("name"), "full_name",
+        ColumnMappingMode::None, vec![], vec![], "column mapping"
+    )]
+    #[case::nonexistent(
+        simple_schema(), column_name!("nonexistent"), "new_name",
+        ColumnMappingMode::Name, vec![], vec![], "does not exist"
+    )]
+    #[case::to_existing_top_level(
+        simple_schema(), column_name!("name"), "id",
+        ColumnMappingMode::Name, vec![], vec![], "already exists"
+    )]
+    #[case::empty_name(
+        simple_schema(), column_name!("name"), "",
+        ColumnMappingMode::Name, vec![], vec![], "cannot be empty"
+    )]
+    #[case::newline_in_name(
+        simple_schema(), column_name!("name"), "full\nname",
+        ColumnMappingMode::Name, vec![], vec![], "newline"
+    )]
+    #[case::partition_column(
+        simple_schema(), column_name!("name"), "full_name",
+        ColumnMappingMode::Name, vec!["name".to_string()], vec![], "partition column"
+    )]
+    #[case::partition_column_target_uppercase(
+        simple_schema(), column_name!("NAME"), "full_name",
+        ColumnMappingMode::Name, vec!["name".to_string()], vec![], "partition column"
+    )]
+    #[case::partition_column_stored_uppercase(
+        simple_schema(), column_name!("name"), "full_name",
+        ColumnMappingMode::Name, vec!["NAME".to_string()], vec![], "partition column"
+    )]
+    #[case::clustering_column(
+        simple_schema(), column_name!("name"), "full_name",
+        ColumnMappingMode::Name, vec![], vec![column_name!("name")], "clustering column"
+    )]
+    #[case::clustering_ancestor_target_uppercase(
+        nested_schema(), column_name!("ADDRESS"), "location",
+        ColumnMappingMode::Name, vec![], vec![column_name!("address.city")],
+        "clustering column"
+    )]
+    #[case::clustering_ancestor(
+        nested_schema(), column_name!("address"), "location",
+        ColumnMappingMode::Name, vec![], vec![column_name!("address.city")],
+        "clustering column"
+    )]
+    #[case::nested_sibling_conflict(
+        nested_schema(), column_name!("address.city"), "street",
+        ColumnMappingMode::Name, vec![], vec![], "already exists"
+    )]
+    #[case::case_insensitive_sibling_conflict(
+        simple_schema(), column_name!("name"), "ID",
+        ColumnMappingMode::Name, vec![], vec![], "already exists"
+    )]
+    #[case::empty_path(
+        simple_schema(), ColumnName::new(Vec::<String>::new()), "new",
+        ColumnMappingMode::Name, vec![], vec![], "empty column path"
+    )]
+    #[case::through_non_struct(
+        simple_schema(), column_name!("name.inner"), "new",
+        ColumnMappingMode::Name, vec![], vec![], "not a struct"
+    )]
+    fn rename_fails(
+        #[case] schema: StructType,
+        #[case] column: ColumnName,
+        #[case] new_name: &str,
+        #[case] mode: ColumnMappingMode,
+        #[case] partition: Vec<String>,
+        #[case] clustering: Vec<ColumnName>,
+        #[case] expected_err: &str,
+    ) {
+        let ops = vec![SchemaOperation::RenameColumn {
+            column,
+            new_name: new_name.to_string(),
+        }];
+        let err = apply_schema_operations(schema, ops, mode, Some(10), &partition, &clustering)
+            .unwrap_err();
+        assert!(
+            err.to_string().contains(expected_err),
+            "expected error containing '{expected_err}', got: {err}"
+        );
+    }
+
+    #[test]
+    fn rename_column_succeeds() {
+        let schema = simple_schema();
+        let ops = vec![SchemaOperation::RenameColumn {
+            column: column_name!("name"),
+            new_name: "full_name".to_string(),
+        }];
+        let result = apply_ops_with_cm(schema, ops, ColumnMappingMode::Name, Some(2)).unwrap();
+        assert!(result.schema.field("full_name").is_some());
+        assert!(result.schema.field("name").is_none());
+        assert_eq!(result.schema.fields().count(), 2);
+    }
+
+    #[test]
+    fn rename_nested_column_succeeds() {
+        let schema = nested_schema();
+        let ops = vec![SchemaOperation::RenameColumn {
+            column: column_name!("address.city"),
+            new_name: "town".to_string(),
+        }];
+        let result = apply_ops_with_cm(schema, ops, ColumnMappingMode::Name, Some(4)).unwrap();
+        let addr = result.schema.field("address").unwrap();
+        match addr.data_type() {
+            DataType::Struct(s) => {
+                assert!(s.field("town").is_some());
+                assert!(s.field("city").is_none());
+                assert_eq!(s.fields().count(), 3); // street, town, zip
+            }
+            other => panic!("Expected Struct, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rename_case_change_succeeds() {
+        let schema = simple_schema();
+        let ops = vec![SchemaOperation::RenameColumn {
+            column: column_name!("name"),
+            new_name: "Name".to_string(),
+        }];
+        let result = apply_ops_with_cm(schema, ops, ColumnMappingMode::Name, Some(2)).unwrap();
+        // Asserting on the literal stored name proves the case actually changed -- the
+        // IndexMap key and the StructField.name both round-trip the requested case.
+        let renamed = result.schema.field("Name").expect("renamed column present");
+        assert_eq!(renamed.name(), "Name");
+        assert!(result.schema.field("name").is_none());
+    }
+
+    #[test]
+    fn rename_to_same_name_is_noop() {
+        let schema = simple_schema();
+        let ops = vec![SchemaOperation::RenameColumn {
+            column: column_name!("name"),
+            new_name: "name".to_string(),
+        }];
+        let result = apply_ops_with_cm(schema, ops, ColumnMappingMode::Name, Some(2)).unwrap();
+        assert!(result.schema.field("name").is_some());
+        assert_eq!(result.schema.fields().count(), 2);
+    }
+
+    /// Rename must preserve the column's `delta.columnMapping.id` and
+    /// `delta.columnMapping.physicalName`. This is the whole point of rename under CM --
+    /// without this invariant, existing Parquet data would be orphaned.
+    #[test]
+    fn rename_preserves_column_mapping_metadata() {
+        let mut name_field = StructField::nullable("name", DataType::STRING);
+        name_field.metadata.insert(
+            ColumnMetadataKey::ColumnMappingId.as_ref().to_string(),
+            MetadataValue::Number(2),
+        );
+        name_field.metadata.insert(
+            ColumnMetadataKey::ColumnMappingPhysicalName
+                .as_ref()
+                .to_string(),
+            MetadataValue::String("col-abc".to_string()),
+        );
+        let schema = StructType::try_new(vec![
+            StructField::not_null("id", DataType::INTEGER),
+            name_field,
+        ])
+        .unwrap();
+        let ops = vec![SchemaOperation::RenameColumn {
+            column: column_name!("name"),
+            new_name: "full_name".to_string(),
+        }];
+        let result = apply_ops_with_cm(schema, ops, ColumnMappingMode::Name, Some(2)).unwrap();
+        let renamed = result.schema.field("full_name").unwrap();
+        assert_eq!(
+            renamed.get_config_value(&ColumnMetadataKey::ColumnMappingId),
+            Some(&MetadataValue::Number(2)),
+            "CM id must be preserved"
+        );
+        assert_eq!(
+            renamed.get_config_value(&ColumnMetadataKey::ColumnMappingPhysicalName),
+            Some(&MetadataValue::String("col-abc".to_string())),
+            "CM physical name must be preserved"
+        );
+    }
+
+    /// Nested rename must preserve CM metadata too (same invariant as top-level).
+    #[test]
+    fn rename_nested_preserves_column_mapping_metadata() {
+        let mut city_field = StructField::nullable("city", DataType::STRING);
+        city_field.metadata.insert(
+            ColumnMetadataKey::ColumnMappingId.as_ref().to_string(),
+            MetadataValue::Number(3),
+        );
+        city_field.metadata.insert(
+            ColumnMetadataKey::ColumnMappingPhysicalName
+                .as_ref()
+                .to_string(),
+            MetadataValue::String("col-xyz".to_string()),
+        );
+        let schema = StructType::try_new(vec![
+            StructField::not_null("id", DataType::INTEGER),
+            StructField::nullable("address", StructType::try_new(vec![city_field]).unwrap()),
+        ])
+        .unwrap();
+        let ops = vec![SchemaOperation::RenameColumn {
+            column: column_name!("address.city"),
+            new_name: "town".to_string(),
+        }];
+        let result = apply_ops_with_cm(schema, ops, ColumnMappingMode::Name, Some(3)).unwrap();
+        let addr = result.schema.field("address").unwrap();
+        let DataType::Struct(inner) = addr.data_type() else {
+            panic!("expected struct");
+        };
+        let town = inner.field("town").expect("renamed column present");
+        assert_eq!(
+            town.get_config_value(&ColumnMetadataKey::ColumnMappingId),
+            Some(&MetadataValue::Number(3)),
+        );
+        assert_eq!(
+            town.get_config_value(&ColumnMetadataKey::ColumnMappingPhysicalName),
+            Some(&MetadataValue::String("col-xyz".to_string())),
+        );
+    }
+
+    /// Rename must NOT bump `maxColumnId` -- it doesn't introduce a column.
+    #[test]
+    fn rename_does_not_bump_max_column_id() {
+        let schema = simple_schema();
+        let ops = vec![SchemaOperation::RenameColumn {
+            column: column_name!("name"),
+            new_name: "full_name".to_string(),
+        }];
+        let result = apply_ops_with_cm(schema, ops, ColumnMappingMode::Name, Some(5)).unwrap();
+        assert_eq!(
+            result.new_max_column_id, None,
+            "rename must not bump maxColumnId"
+        );
+    }
+
+    /// Renaming a nested leaf must not clobber siblings (parallels
+    /// `modify_nested_leaf_preserves_other_fields`).
+    #[test]
+    fn rename_nested_leaf_preserves_other_fields() {
+        let schema = nested_schema();
+        let ops = vec![SchemaOperation::RenameColumn {
+            column: column_name!("address.city"),
+            new_name: "town".to_string(),
+        }];
+        let result = apply_ops_with_cm(schema, ops, ColumnMappingMode::Name, Some(4)).unwrap();
+        // Top-level "id" untouched.
+        assert!(result.schema.field("id").is_some());
+        // Siblings of "city" in address struct must still be present.
+        let addr = result.schema.field("address").unwrap();
+        let DataType::Struct(inner) = addr.data_type() else {
+            panic!("expected struct");
+        };
+        assert!(inner.field("street").is_some());
+        assert!(inner.field("zip").is_some());
+    }
+
+    /// Renaming an ancestor struct must preserve every nested field's CM id and physical name.
+    /// This is the recursive case of the "rename preserves CM metadata" invariant.
+    #[test]
+    fn rename_ancestor_struct_preserves_nested_cm_metadata() {
+        let mut city = StructField::nullable("city", DataType::STRING);
+        city.metadata.insert(
+            ColumnMetadataKey::ColumnMappingId.as_ref().to_string(),
+            MetadataValue::Number(3),
+        );
+        city.metadata.insert(
+            ColumnMetadataKey::ColumnMappingPhysicalName
+                .as_ref()
+                .to_string(),
+            MetadataValue::String("col-city".to_string()),
+        );
+        let mut zip = StructField::nullable("zip", DataType::STRING);
+        zip.metadata.insert(
+            ColumnMetadataKey::ColumnMappingId.as_ref().to_string(),
+            MetadataValue::Number(4),
+        );
+        zip.metadata.insert(
+            ColumnMetadataKey::ColumnMappingPhysicalName
+                .as_ref()
+                .to_string(),
+            MetadataValue::String("col-zip".to_string()),
+        );
+        let schema = StructType::try_new(vec![
+            StructField::not_null("id", DataType::INTEGER),
+            StructField::nullable("address", StructType::try_new(vec![city, zip]).unwrap()),
+        ])
+        .unwrap();
+        let ops = vec![SchemaOperation::RenameColumn {
+            column: column_name!("address"),
+            new_name: "location".to_string(),
+        }];
+        let result = apply_ops_with_cm(schema, ops, ColumnMappingMode::Name, Some(4)).unwrap();
+        let location = result.schema.field("location").expect("renamed struct");
+        let DataType::Struct(inner) = location.data_type() else {
+            panic!("expected struct");
+        };
+        let inner_city = inner.field("city").expect("nested city preserved");
+        assert_eq!(
+            inner_city.get_config_value(&ColumnMetadataKey::ColumnMappingId),
+            Some(&MetadataValue::Number(3)),
+        );
+        assert_eq!(
+            inner_city.get_config_value(&ColumnMetadataKey::ColumnMappingPhysicalName),
+            Some(&MetadataValue::String("col-city".to_string())),
+        );
+        let inner_zip = inner.field("zip").expect("nested zip preserved");
+        assert_eq!(
+            inner_zip.get_config_value(&ColumnMetadataKey::ColumnMappingId),
+            Some(&MetadataValue::Number(4)),
+        );
+        assert_eq!(
+            inner_zip.get_config_value(&ColumnMetadataKey::ColumnMappingPhysicalName),
+            Some(&MetadataValue::String("col-zip".to_string())),
+        );
+    }
+
+    /// Chain `add_column` then `rename_column` in one ALTER. The newly-added column gets a
+    /// fresh CM id and is then renamed to a different logical name in the same pass. This is
+    /// the only chain the type-state allows that involves rename (rename is terminal).
+    #[test]
+    fn chain_add_then_rename_added_column() {
+        let schema = simple_schema();
+        let ops = vec![
+            SchemaOperation::AddColumn {
+                field: StructField::nullable("email", DataType::STRING),
+            },
+            SchemaOperation::RenameColumn {
+                column: column_name!("email"),
+                new_name: "contact_email".to_string(),
+            },
+        ];
+        let result = apply_ops_with_cm(schema, ops, ColumnMappingMode::Name, Some(2)).unwrap();
+        assert!(result.schema.field("contact_email").is_some());
+        assert!(result.schema.field("email").is_none());
+        let added_renamed = result.schema.field("contact_email").unwrap();
+        // The fresh CM id must come from the AddColumn step, not have been wiped by rename.
+        let cm_id = get_cm_id(added_renamed);
+        assert_eq!(cm_id, 3, "added column should get fresh id (max+1)");
+        // Physical name must follow the standard "col-..." pattern from the AddColumn step.
+        assert!(get_physical_name(added_renamed).starts_with("col-"));
+        assert_eq!(
+            result.new_max_column_id,
+            Some(3),
+            "max id advances to cover the added column even though it was renamed"
+        );
     }
 }

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -771,7 +771,7 @@ async fn chain_add_drop_set_nullable_on_cm_table(
     let v1_snap = v1
         .post_commit_snapshot()
         .expect("post-commit snapshot at v1");
-    let (_, v1_ckpt) = v1_snap.clone().checkpoint(engine.as_ref())?;
+    let (_, v1_ckpt) = v1_snap.clone().checkpoint(engine.as_ref(), None)?;
     let v2 = v1_ckpt
         .alter_table()
         .set_nullable(column_name!("id"))
@@ -781,7 +781,7 @@ async fn chain_add_drop_set_nullable_on_cm_table(
     let v2_snap = v2
         .post_commit_snapshot()
         .expect("post-commit snapshot at v2");
-    v2_snap.clone().checkpoint(engine.as_ref())?;
+    v2_snap.clone().checkpoint(engine.as_ref(), None)?;
 
     let reloaded = Snapshot::builder_for(table_path).build(engine.as_ref())?;
     let schema = reloaded.schema();
@@ -853,7 +853,9 @@ async fn chain_add_then_drop_same_column_burns_id_but_no_schema_change() -> Delt
 /// Reload from scratch must rebuild from each checkpoint plus the subsequent commits and:
 /// surface only the surviving columns in the schema and scan output (no value bleed-through
 /// from physical Parquet storage), preserve remaining row data, and leave `maxColumnId`
-/// unchanged (drops never bump it).
+/// unchanged (drops never bump it). Also verifies that time travel back to the pre-drop
+/// version still surfaces the dropped columns with their original values (drops do not
+/// retroactively rewrite earlier versions).
 #[rstest]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn drop_column_lifecycle_removes_column_and_preserves_remaining_data(
@@ -895,7 +897,7 @@ async fn drop_column_lifecycle_removes_column_and_preserves_remaining_data(
         let post = committed
             .post_commit_snapshot()
             .expect("post-commit snapshot");
-        let (_, ckpt) = post.clone().checkpoint(engine.as_ref())?;
+        let (_, ckpt) = post.clone().checkpoint(engine.as_ref(), None)?;
         current = ckpt;
     }
 
@@ -930,6 +932,33 @@ async fn drop_column_lifecycle_removes_column_and_preserves_remaining_data(
     assert_eq!(id_col.value(0), 1);
     assert_eq!(id_col.value(1), 2);
 
+    // Time travel: at v1 (post-write, pre-drop) all 4 columns are still in the schema with
+    // their original values. Drops must not retroactively rewrite earlier versions.
+    let pre_drop = Snapshot::builder_for(&table_path)
+        .at_version(1)
+        .build(engine.as_ref())?;
+    assert_eq!(pre_drop.schema().fields().count(), 4);
+    let scan = pre_drop.scan_builder().build()?;
+    let batches = test_utils::read_scan(&scan, engine.clone())?;
+    let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total_rows, 2);
+    let email_col = batches[0]
+        .column_by_name("email")
+        .expect("v1 must surface 'email'")
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .expect("email is string");
+    assert_eq!(email_col.value(0), "a@x");
+    assert_eq!(email_col.value(1), "b@x");
+    let age_col = batches[0]
+        .column_by_name("age")
+        .expect("v1 must surface 'age'")
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .expect("age is int");
+    assert_eq!(age_col.value(0), 10);
+    assert_eq!(age_col.value(1), 20);
+
     Ok(())
 }
 
@@ -958,6 +987,90 @@ async fn drop_non_clustering_column_on_clustered_table_succeeds() -> DeltaResult
 
     let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
     assert!(reloaded.schema().field("id").is_none());
+    Ok(())
+}
+
+/// Dropping a top-level column whose `DataType` is non-primitive (struct, Array, Map, or a
+/// complex type containing a Struct) succeeds and removes only that column. The matching
+/// failure case for structs -- dropping a struct that is an ancestor of a clustering column
+/// -- is covered by `drop_column_failures::clustering_ancestor`.
+#[rstest]
+#[case::top_level_struct(StructField::nullable(
+    "address",
+    StructType::try_new(vec![
+        StructField::nullable("city", DataType::STRING),
+        StructField::nullable("zip", DataType::STRING),
+    ])
+    .unwrap(),
+))]
+#[case::array_of_primitive(StructField::nullable("tags", ArrayType::new(DataType::STRING, true)))]
+#[case::map_of_primitives(StructField::nullable(
+    "labels",
+    MapType::new(DataType::STRING, DataType::INTEGER, true),
+))]
+#[case::array_of_struct(StructField::nullable(
+    "items",
+    ArrayType::new(
+        DataType::Struct(Box::new(
+            StructType::try_new(vec![
+                StructField::nullable("a", DataType::STRING),
+                StructField::nullable("b", DataType::INTEGER),
+            ])
+            .unwrap(),
+        )),
+        true,
+    ),
+))]
+#[case::map_value_is_struct(StructField::nullable(
+    "by_id",
+    MapType::new(
+        DataType::STRING,
+        DataType::Struct(Box::new(
+            StructType::try_new(vec![
+                StructField::nullable("a", DataType::STRING),
+                StructField::nullable("b", DataType::INTEGER),
+            ])
+            .unwrap(),
+        )),
+        true,
+    ),
+))]
+#[tokio::test]
+async fn drop_complex_type_column(#[case] field: StructField) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let field_name = field.name().to_string();
+    // Schema is simple_schema() + the complex column, so dropping it leaves a non-empty schema.
+    let schema = Arc::new(StructType::try_new(vec![
+        StructField::nullable("id", DataType::INTEGER),
+        StructField::nullable("name", DataType::STRING),
+        field,
+    ])?);
+    let snapshot = create_table_and_load_snapshot(
+        &table_path,
+        schema,
+        engine.as_ref(),
+        &[("delta.columnMapping.mode", "name")],
+    )?;
+    let original_max_id = max_column_id(&snapshot);
+
+    snapshot
+        .alter_table()
+        .drop_column(ColumnName::new([field_name.as_str()]))
+        .build(engine.as_ref(), committer())?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    let reloaded = Snapshot::builder_for(table_path).build(engine.as_ref())?;
+    let schema = reloaded.schema();
+    assert_eq!(schema.fields().count(), 2);
+    assert!(schema.field(&field_name).is_none());
+    assert!(schema.field("id").is_some());
+    assert!(schema.field("name").is_some());
+    assert_eq!(
+        max_column_id(&reloaded),
+        original_max_id,
+        "drop must not bump maxColumnId, including for inner fields lost with a struct"
+    );
     Ok(())
 }
 

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -735,3 +735,361 @@ async fn add_column_with_stray_cm_metadata_on_non_cm_table_fails(
     );
     Ok(())
 }
+
+/// Chain `add_column + drop_column + set_nullable` end-to-end on a column-mapped table,
+/// split across two alter+checkpoint cycles. Verifies the chained ops compose across
+/// checkpoint boundaries, the dropped column is removed, the added column gets a fresh CM id,
+/// and the existing column's CM id is preserved through both checkpoints.
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn chain_add_drop_set_nullable_on_cm_table(
+    #[values("name", "id")] cm_mode: &str,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+    let snapshot = create_table_and_load_snapshot(
+        &table_path,
+        simple_schema(),
+        engine.as_ref(),
+        &[("delta.columnMapping.mode", cm_mode)],
+    )?;
+    let original_max_id = max_column_id(&snapshot);
+    let original_id_cm_id = snapshot
+        .schema()
+        .field("id")
+        .unwrap()
+        .column_mapping_id()
+        .expect("existing field should already have a column mapping ID");
+
+    // Two alter+checkpoint cycles: (add email + drop name), then (set_nullable id).
+    let v1 = snapshot
+        .alter_table()
+        .add_column(StructField::nullable("email", DataType::STRING))
+        .drop_column(column_name!("name"))
+        .build(engine.as_ref(), committer())?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+    let v1_snap = v1
+        .post_commit_snapshot()
+        .expect("post-commit snapshot at v1");
+    let (_, v1_ckpt) = v1_snap.clone().checkpoint(engine.as_ref())?;
+    let v2 = v1_ckpt
+        .alter_table()
+        .set_nullable(column_name!("id"))
+        .build(engine.as_ref(), committer())?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+    let v2_snap = v2
+        .post_commit_snapshot()
+        .expect("post-commit snapshot at v2");
+    v2_snap.clone().checkpoint(engine.as_ref())?;
+
+    let reloaded = Snapshot::builder_for(table_path).build(engine.as_ref())?;
+    let schema = reloaded.schema();
+    assert_eq!(schema.fields().count(), 2, "name dropped, email added");
+    assert!(schema.field("name").is_none());
+    assert!(schema.field("email").is_some());
+    assert!(schema.field("id").unwrap().is_nullable());
+    assert!(
+        max_column_id(&reloaded) > original_max_id,
+        "add_column must bump maxColumnId even when chained with drop"
+    );
+    let id_after = schema
+        .field("id")
+        .unwrap()
+        .column_mapping_id()
+        .expect("existing id column mapping");
+    assert_eq!(
+        id_after, original_id_cm_id,
+        "existing id CM id must not change"
+    );
+
+    Ok(())
+}
+
+/// Edge case: `add(foo) + drop(foo)` in one ALTER. The final schema matches the initial
+/// schema, but `maxColumnId` still advances
+#[tokio::test]
+async fn chain_add_then_drop_same_column_burns_id_but_no_schema_change() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let snapshot = create_table_and_load_snapshot(
+        &table_path,
+        simple_schema(),
+        engine.as_ref(),
+        &[("delta.columnMapping.mode", "name")],
+    )?;
+    let original_max_id = max_column_id(&snapshot);
+    let original_field_count = snapshot.schema().fields().count();
+
+    snapshot
+        .alter_table()
+        .add_column(StructField::nullable("foo", DataType::STRING))
+        .drop_column(column_name!("foo"))
+        .build(engine.as_ref(), committer())?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    let reloaded = Snapshot::builder_for(table_path).build(engine.as_ref())?;
+    let schema = reloaded.schema();
+    assert_eq!(
+        schema.fields().count(),
+        original_field_count,
+        "net schema unchanged"
+    );
+    assert!(schema.field("foo").is_none(), "foo should not be present");
+    assert!(
+        max_column_id(&reloaded) > original_max_id,
+        "maxColumnId must still advance (IDs never reused)"
+    );
+
+    Ok(())
+}
+
+// ============================================================================
+// DROP COLUMN tests
+// ============================================================================
+
+/// End-to-end lifecycle: create a CM table, write rows, then drop columns one at a time with
+/// a checkpoint after each drop ("do some ops -> checkpoint -> do more ops -> checkpoint").
+/// Reload from scratch must rebuild from each checkpoint plus the subsequent commits and:
+/// surface only the surviving columns in the schema and scan output (no value bleed-through
+/// from physical Parquet storage), preserve remaining row data, and leave `maxColumnId`
+/// unchanged (drops never bump it).
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn drop_column_lifecycle_removes_column_and_preserves_remaining_data(
+    #[values("name", "id")] cm_mode: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+    let schema = Arc::new(StructType::try_new(vec![
+        StructField::nullable("id", DataType::INTEGER),
+        StructField::nullable("name", DataType::STRING),
+        StructField::nullable("email", DataType::STRING),
+        StructField::nullable("age", DataType::INTEGER),
+    ])?);
+    let properties = vec![("delta.columnMapping.mode", cm_mode)];
+    let snapshot =
+        create_table_and_load_snapshot(&table_path, schema.clone(), engine.as_ref(), &properties)?;
+    let original_max_id = max_column_id(&snapshot);
+
+    let batch = RecordBatch::try_new(
+        Arc::new(schema.as_ref().try_into_arrow().unwrap()),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2])),
+            Arc::new(StringArray::from(vec!["a", "b"])),
+            Arc::new(StringArray::from(vec!["a@x", "b@x"])),
+            Arc::new(Int32Array::from(vec![10, 20])),
+        ],
+    )
+    .unwrap();
+    let snapshot = write_batch_to_table(&snapshot, engine.as_ref(), batch, HashMap::new()).await?;
+
+    // One alter+checkpoint cycle per drop.
+    let mut current = snapshot;
+    for col in ["email", "age"] {
+        let committed = current
+            .alter_table()
+            .drop_column(ColumnName::new([col]))
+            .build(engine.as_ref(), committer())?
+            .commit(engine.as_ref())?
+            .unwrap_committed();
+        let post = committed
+            .post_commit_snapshot()
+            .expect("post-commit snapshot");
+        let (_, ckpt) = post.clone().checkpoint(engine.as_ref())?;
+        current = ckpt;
+    }
+
+    // Schema: dropped columns gone, `maxColumnId` unchanged across both drops.
+    let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    let schema = reloaded.schema();
+    assert_eq!(schema.fields().count(), 2);
+    assert!(schema.field("email").is_none());
+    assert!(schema.field("age").is_none());
+    assert!(schema.field("id").is_some());
+    assert!(schema.field("name").is_some());
+    assert_eq!(max_column_id(&reloaded), original_max_id);
+
+    // Scan output excludes the dropped columns; remaining values survive.
+    let scan = reloaded.scan_builder().build()?;
+    let batches = test_utils::read_scan(&scan, engine.clone())?;
+    let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total_rows, 2);
+    assert_eq!(batches[0].num_columns(), 2);
+    for dropped in ["email", "age"] {
+        assert!(
+            batches[0].column_by_name(dropped).is_none(),
+            "dropped column '{dropped}' must not appear in scan output"
+        );
+    }
+    let id_col = batches[0]
+        .column_by_name("id")
+        .expect("id column")
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .expect("id is int");
+    assert_eq!(id_col.value(0), 1);
+    assert_eq!(id_col.value(1), 2);
+
+    Ok(())
+}
+
+/// Dropping a non-clustering column on a clustered CM table is allowed; the companion
+/// "dropping the clustering column itself" case is covered by `drop_column_failures`.
+#[tokio::test]
+async fn drop_non_clustering_column_on_clustered_table_succeeds() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let committed = create_table(&table_path, simple_schema(), "Test/1.0")
+        .with_data_layout(DataLayout::clustered(["name"]))
+        .with_table_properties([("delta.columnMapping.mode", "name")])
+        .build(engine.as_ref(), committer())?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+    let snapshot = committed
+        .post_commit_snapshot()
+        .expect("post-commit snapshot")
+        .clone();
+
+    snapshot
+        .alter_table()
+        .drop_column(column_name!("id"))
+        .build(engine.as_ref(), committer())?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert!(reloaded.schema().field("id").is_none());
+    Ok(())
+}
+
+/// Setup-flavor selector for `drop_column_failures`. Each variant creates a distinct table
+/// (CM mode, schema shape, data layout) so one rstest can exercise every drop-failure path.
+enum DropFailureFlavor {
+    /// Plain non-CM table; any drop fails because CM is required.
+    NoCm,
+    /// CM table with `simple_schema()`; used for drops of non-existent columns.
+    Cm,
+    /// CM table with a single-column schema; used for the "last field" rejection.
+    CmSingleColumn,
+    /// CM table partitioned by `name`; used for the partition-column rejection.
+    CmPartitionedByName,
+    /// CM table clustered by top-level `name`; used for the clustering-column rejection.
+    CmClusteredByName,
+    /// CM table clustered by nested `address.city`; used for the clustering-ancestor rejection.
+    CmClusteredByNestedCity,
+}
+
+fn setup_for_drop_failure(
+    table_path: &str,
+    engine: &dyn delta_kernel::Engine,
+    flavor: DropFailureFlavor,
+) -> DeltaResult<Arc<Snapshot>> {
+    let cm = [("delta.columnMapping.mode", "name")];
+    Ok(match flavor {
+        DropFailureFlavor::NoCm => {
+            create_table_and_load_snapshot(table_path, simple_schema(), engine, &[])?
+        }
+        DropFailureFlavor::Cm => {
+            create_table_and_load_snapshot(table_path, simple_schema(), engine, &cm)?
+        }
+        DropFailureFlavor::CmSingleColumn => {
+            let schema = Arc::new(
+                StructType::try_new(vec![StructField::nullable("only", DataType::STRING)]).unwrap(),
+            );
+            create_table_and_load_snapshot(table_path, schema, engine, &cm)?
+        }
+        DropFailureFlavor::CmPartitionedByName => {
+            let committed = create_table(table_path, simple_schema(), "Test/1.0")
+                .with_data_layout(DataLayout::partitioned(["name"]))
+                .with_table_properties(cm.to_vec())
+                .build(engine, committer())?
+                .commit(engine)?
+                .unwrap_committed();
+            committed
+                .post_commit_snapshot()
+                .expect("post-commit snapshot")
+                .clone()
+        }
+        DropFailureFlavor::CmClusteredByName => {
+            let committed = create_table(table_path, simple_schema(), "Test/1.0")
+                .with_data_layout(DataLayout::clustered(["name"]))
+                .with_table_properties(cm.to_vec())
+                .build(engine, committer())?
+                .commit(engine)?
+                .unwrap_committed();
+            committed
+                .post_commit_snapshot()
+                .expect("post-commit snapshot")
+                .clone()
+        }
+        DropFailureFlavor::CmClusteredByNestedCity => {
+            let nested = Arc::new(
+                StructType::try_new(vec![
+                    StructField::nullable("id", DataType::INTEGER),
+                    StructField::nullable(
+                        "address",
+                        StructType::try_new(vec![
+                            StructField::nullable("city", DataType::STRING),
+                            StructField::nullable("zip", DataType::STRING),
+                        ])
+                        .unwrap(),
+                    ),
+                ])
+                .unwrap(),
+            );
+            let committed = create_table(table_path, nested, "Test/1.0")
+                .with_data_layout(DataLayout::Clustered {
+                    columns: vec![column_name!("address.city")],
+                })
+                .with_table_properties(cm.to_vec())
+                .build(engine, committer())?
+                .commit(engine)?
+                .unwrap_committed();
+            committed
+                .post_commit_snapshot()
+                .expect("post-commit snapshot")
+                .clone()
+        }
+    })
+}
+
+#[rstest]
+#[case::without_cm(DropFailureFlavor::NoCm, column_name!("name"), "column mapping")]
+#[case::nonexistent(DropFailureFlavor::Cm, column_name!("nonexistent"), "does not exist")]
+#[case::last_remaining(
+    DropFailureFlavor::CmSingleColumn,
+    column_name!("only"),
+    "last field"
+)]
+#[case::partition_column(
+    DropFailureFlavor::CmPartitionedByName,
+    column_name!("name"),
+    "partition column"
+)]
+#[case::clustering_column(
+    DropFailureFlavor::CmClusteredByName,
+    column_name!("name"),
+    "clustering column"
+)]
+#[case::clustering_ancestor(
+    DropFailureFlavor::CmClusteredByNestedCity,
+    column_name!("address"),
+    "clustering column"
+)]
+#[tokio::test]
+async fn drop_column_failures(
+    #[case] flavor: DropFailureFlavor,
+    #[case] drop_column: delta_kernel::expressions::ColumnName,
+    #[case] error_contains: &str,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let snapshot = setup_for_drop_failure(&table_path, engine.as_ref(), flavor)?;
+
+    let err = snapshot
+        .alter_table()
+        .drop_column(drop_column)
+        .build(engine.as_ref(), committer());
+    assert!(err.is_err());
+    assert!(err.unwrap_err().to_string().contains(error_contains));
+
+    Ok(())
+}

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -1074,12 +1074,13 @@ async fn drop_complex_type_column(#[case] field: StructField) -> DeltaResult<()>
     Ok(())
 }
 
-/// Setup-flavor selector for `drop_column_failures`. Each variant creates a distinct table
-/// (CM mode, schema shape, data layout) so one rstest can exercise every drop-failure path.
-enum DropFailureFlavor {
-    /// Plain non-CM table; any drop fails because CM is required.
+/// Setup-flavor selector for layout-related ALTER failure tests. Each variant creates a
+/// distinct table (CM mode, schema shape, data layout) so one rstest can exercise every
+/// layout/CM-related rejection path. Shared across drop and rename failure tests.
+enum LayoutFailureFlavor {
+    /// Plain non-CM table; any drop/rename fails because CM is required.
     NoCm,
-    /// CM table with `simple_schema()`; used for drops of non-existent columns.
+    /// CM table with `simple_schema()`; used for ops on non-existent columns.
     Cm,
     /// CM table with a single-column schema; used for the "last field" rejection.
     CmSingleColumn,
@@ -1091,26 +1092,26 @@ enum DropFailureFlavor {
     CmClusteredByNestedCity,
 }
 
-fn setup_for_drop_failure(
+fn setup_for_layout_failure(
     table_path: &str,
     engine: &dyn delta_kernel::Engine,
-    flavor: DropFailureFlavor,
+    flavor: LayoutFailureFlavor,
 ) -> DeltaResult<Arc<Snapshot>> {
     let cm = [("delta.columnMapping.mode", "name")];
     Ok(match flavor {
-        DropFailureFlavor::NoCm => {
+        LayoutFailureFlavor::NoCm => {
             create_table_and_load_snapshot(table_path, simple_schema(), engine, &[])?
         }
-        DropFailureFlavor::Cm => {
+        LayoutFailureFlavor::Cm => {
             create_table_and_load_snapshot(table_path, simple_schema(), engine, &cm)?
         }
-        DropFailureFlavor::CmSingleColumn => {
+        LayoutFailureFlavor::CmSingleColumn => {
             let schema = Arc::new(
                 StructType::try_new(vec![StructField::nullable("only", DataType::STRING)]).unwrap(),
             );
             create_table_and_load_snapshot(table_path, schema, engine, &cm)?
         }
-        DropFailureFlavor::CmPartitionedByName => {
+        LayoutFailureFlavor::CmPartitionedByName => {
             let committed = create_table(table_path, simple_schema(), "Test/1.0")
                 .with_data_layout(DataLayout::partitioned(["name"]))
                 .with_table_properties(cm.to_vec())
@@ -1122,7 +1123,7 @@ fn setup_for_drop_failure(
                 .expect("post-commit snapshot")
                 .clone()
         }
-        DropFailureFlavor::CmClusteredByName => {
+        LayoutFailureFlavor::CmClusteredByName => {
             let committed = create_table(table_path, simple_schema(), "Test/1.0")
                 .with_data_layout(DataLayout::clustered(["name"]))
                 .with_table_properties(cm.to_vec())
@@ -1134,7 +1135,7 @@ fn setup_for_drop_failure(
                 .expect("post-commit snapshot")
                 .clone()
         }
-        DropFailureFlavor::CmClusteredByNestedCity => {
+        LayoutFailureFlavor::CmClusteredByNestedCity => {
             let nested = Arc::new(
                 StructType::try_new(vec![
                     StructField::nullable("id", DataType::INTEGER),
@@ -1166,36 +1167,36 @@ fn setup_for_drop_failure(
 }
 
 #[rstest]
-#[case::without_cm(DropFailureFlavor::NoCm, column_name!("name"), "column mapping")]
-#[case::nonexistent(DropFailureFlavor::Cm, column_name!("nonexistent"), "does not exist")]
+#[case::without_cm(LayoutFailureFlavor::NoCm, column_name!("name"), "column mapping")]
+#[case::nonexistent(LayoutFailureFlavor::Cm, column_name!("nonexistent"), "does not exist")]
 #[case::last_remaining(
-    DropFailureFlavor::CmSingleColumn,
+    LayoutFailureFlavor::CmSingleColumn,
     column_name!("only"),
     "last field"
 )]
 #[case::partition_column(
-    DropFailureFlavor::CmPartitionedByName,
+    LayoutFailureFlavor::CmPartitionedByName,
     column_name!("name"),
     "partition column"
 )]
 #[case::clustering_column(
-    DropFailureFlavor::CmClusteredByName,
+    LayoutFailureFlavor::CmClusteredByName,
     column_name!("name"),
     "clustering column"
 )]
 #[case::clustering_ancestor(
-    DropFailureFlavor::CmClusteredByNestedCity,
+    LayoutFailureFlavor::CmClusteredByNestedCity,
     column_name!("address"),
     "clustering column"
 )]
 #[tokio::test]
 async fn drop_column_failures(
-    #[case] flavor: DropFailureFlavor,
+    #[case] flavor: LayoutFailureFlavor,
     #[case] drop_column: delta_kernel::expressions::ColumnName,
     #[case] error_contains: &str,
 ) -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
-    let snapshot = setup_for_drop_failure(&table_path, engine.as_ref(), flavor)?;
+    let snapshot = setup_for_layout_failure(&table_path, engine.as_ref(), flavor)?;
 
     let err = snapshot
         .alter_table()
@@ -1204,5 +1205,352 @@ async fn drop_column_failures(
     assert!(err.is_err());
     assert!(err.unwrap_err().to_string().contains(error_contains));
 
+    Ok(())
+}
+
+// ============================================================================
+// RENAME COLUMN tests
+// ============================================================================
+
+/// End-to-end: create a CM table, write rows, rename a column, checkpoint, reload from
+/// scratch, and verify rows surface under the NEW logical name while the column-mapping id
+/// and physical name are preserved. Under CM, this preservation is the core invariant that
+/// keeps existing Parquet files readable without rewrites. Also verifies that time travel
+/// back to the pre-rename version still surfaces the OLD logical name with the original data
+/// (renames do not retroactively rewrite earlier versions).
+#[rstest]
+#[case::cm_name_mode("name")]
+#[case::cm_id_mode("id")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn rename_column_lifecycle(#[case] cm_mode: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+    let properties = vec![("delta.columnMapping.mode", cm_mode)];
+    let snapshot =
+        create_table_and_load_snapshot(&table_path, simple_schema(), engine.as_ref(), &properties)?;
+    let original_max_id = max_column_id(&snapshot);
+
+    // Capture the "name" column's CM metadata BEFORE rename.
+    let pre_schema = snapshot.schema();
+    let name_before = pre_schema.field("name").unwrap();
+    let cm_id_before = name_before
+        .column_mapping_id()
+        .expect("pre-rename CM id should be assigned");
+    let physical_before = match name_before
+        .get_config_value(&ColumnMetadataKey::ColumnMappingPhysicalName)
+        .expect("pre-rename physical name")
+    {
+        MetadataValue::String(s) => s.clone(),
+        other => panic!("expected String, got {other:?}"),
+    };
+
+    // Write two rows under the original schema.
+    let batch = RecordBatch::try_new(
+        Arc::new(simple_schema().as_ref().try_into_arrow().unwrap()),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2])),
+            Arc::new(StringArray::from(vec!["alice", "bob"])),
+        ],
+    )?;
+    let snapshot = write_batch_to_table(&snapshot, engine.as_ref(), batch, HashMap::new()).await?;
+
+    // Rename `name` -> `full_name`, then checkpoint.
+    let committed = snapshot
+        .alter_table()
+        .rename_column(column_name!("name"), "full_name")
+        .build(engine.as_ref(), committer())?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+    let post = committed
+        .post_commit_snapshot()
+        .expect("post-commit snapshot");
+    post.clone().checkpoint(engine.as_ref(), None)?;
+
+    // Reload and verify: new logical name, preserved CM metadata, unchanged maxColumnId.
+    let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    let schema = reloaded.schema();
+    assert!(schema.field("full_name").is_some(), "new name must exist");
+    assert!(schema.field("name").is_none(), "old name must be gone");
+    assert_eq!(
+        max_column_id(&reloaded),
+        original_max_id,
+        "rename must not bump maxColumnId"
+    );
+
+    let renamed = schema.field("full_name").unwrap();
+    let cm_id_after = renamed
+        .column_mapping_id()
+        .expect("post-rename CM id should be assigned");
+    let physical_after = match renamed
+        .get_config_value(&ColumnMetadataKey::ColumnMappingPhysicalName)
+        .expect("post-rename physical name")
+    {
+        MetadataValue::String(s) => s.clone(),
+        other => panic!("expected String, got {other:?}"),
+    };
+    assert_eq!(
+        cm_id_after, cm_id_before,
+        "CM id must be preserved across rename"
+    );
+    assert_eq!(
+        physical_after, physical_before,
+        "physical name must be preserved across rename"
+    );
+
+    // Capture the evolved arrow schema before scan_builder moves `reloaded`; needed below to
+    // write more rows under the new logical name.
+    let evolved_arrow_schema: delta_kernel::arrow::datatypes::SchemaRef =
+        Arc::new(reloaded.schema().as_ref().try_into_arrow().unwrap());
+
+    // Scan: rows must surface under the NEW logical name with the original values intact.
+    let scan = reloaded.scan_builder().build()?;
+    let batches = test_utils::read_scan(&scan, engine.clone())?;
+    let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total_rows, 2);
+    let renamed_col = batches[0]
+        .column_by_name("full_name")
+        .expect("renamed column should appear in scan output")
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .expect("renamed column is a StringArray");
+    assert_eq!(renamed_col.value(0), "alice");
+    assert_eq!(renamed_col.value(1), "bob");
+    assert!(
+        batches[0].column_by_name("name").is_none(),
+        "old logical name must not appear in scan output"
+    );
+
+    // Time travel: at v1 (post-write, pre-rename) the schema must still expose the OLD
+    // logical name with the original values. Renames must not retroactively rewrite earlier
+    // versions.
+    let pre_rename = Snapshot::builder_for(&table_path)
+        .at_version(1)
+        .build(engine.as_ref())?;
+    assert!(
+        pre_rename.schema().field("name").is_some(),
+        "v1 must surface the old logical name"
+    );
+    assert!(
+        pre_rename.schema().field("full_name").is_none(),
+        "v1 must not surface the new logical name"
+    );
+    let scan = pre_rename.scan_builder().build()?;
+    let batches = test_utils::read_scan(&scan, engine.clone())?;
+    let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total_rows, 2);
+    let pre_rename_col = batches[0]
+        .column_by_name("name")
+        .expect("v1 scan must surface the old logical name")
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .expect("name is a StringArray");
+    assert_eq!(pre_rename_col.value(0), "alice");
+    assert_eq!(pre_rename_col.value(1), "bob");
+
+    // Write two more rows AFTER the rename to prove the table accepts writes under the new
+    // logical name. Reload first because the earlier scan moved `reloaded`. Then verify the
+    // final table has 4 rows total, all surfacing under `full_name`.
+    let post_rename_snap = Arc::new(Snapshot::builder_for(&table_path).build(engine.as_ref())?);
+    let post_rename_batch = RecordBatch::try_new(
+        evolved_arrow_schema,
+        vec![
+            Arc::new(Int32Array::from(vec![3, 4])),
+            Arc::new(StringArray::from(vec!["carol", "dan"])),
+        ],
+    )?;
+    write_batch_to_table(
+        &post_rename_snap,
+        engine.as_ref(),
+        post_rename_batch,
+        HashMap::new(),
+    )
+    .await?;
+
+    let final_snap = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    let scan = final_snap.scan_builder().build()?;
+    let batches = test_utils::read_scan(&scan, engine.clone())?;
+    let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total_rows, 4);
+    let mut names: Vec<&str> = batches
+        .iter()
+        .flat_map(|b| {
+            let col = b
+                .column_by_name("full_name")
+                .expect("renamed column")
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("string");
+            (0..col.len()).map(|i| col.value(i)).collect::<Vec<_>>()
+        })
+        .collect();
+    names.sort();
+    assert_eq!(names, vec!["alice", "bob", "carol", "dan"]);
+
+    Ok(())
+}
+
+#[rstest]
+#[case::without_cm(LayoutFailureFlavor::NoCm, column_name!("name"), "column mapping")]
+#[case::nonexistent(LayoutFailureFlavor::Cm, column_name!("nonexistent"), "does not exist")]
+#[case::partition(
+    LayoutFailureFlavor::CmPartitionedByName,
+    column_name!("name"),
+    "partition column"
+)]
+#[case::clustering(
+    LayoutFailureFlavor::CmClusteredByName,
+    column_name!("name"),
+    "clustering column"
+)]
+#[case::clustering_ancestor(
+    LayoutFailureFlavor::CmClusteredByNestedCity,
+    column_name!("address"),
+    "clustering column"
+)]
+#[tokio::test]
+async fn rename_column_failures(
+    #[case] flavor: LayoutFailureFlavor,
+    #[case] column: ColumnName,
+    #[case] error_contains: &str,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let snapshot = setup_for_layout_failure(&table_path, engine.as_ref(), flavor)?;
+
+    let err = snapshot
+        .alter_table()
+        .rename_column(column, "new_name")
+        .build(engine.as_ref(), committer());
+    assert!(err.is_err());
+    assert!(err.unwrap_err().to_string().contains(error_contains));
+
+    Ok(())
+}
+
+/// Renaming a top-level column whose `DataType` is non-primitive (struct, Array, Map, or a
+/// complex type containing a Struct) succeeds and renames only that column. The matching
+/// failure case for structs -- renaming a struct that is an ancestor of a clustering column
+/// -- is covered by `rename_column_failures::clustering_ancestor`.
+#[rstest]
+#[case::top_level_struct(StructField::nullable(
+    "address",
+    StructType::try_new(vec![
+        StructField::nullable("city", DataType::STRING),
+        StructField::nullable("zip", DataType::STRING),
+    ])
+    .unwrap(),
+))]
+#[case::array_of_primitive(StructField::nullable("tags", ArrayType::new(DataType::STRING, true)))]
+#[case::map_of_primitives(StructField::nullable(
+    "labels",
+    MapType::new(DataType::STRING, DataType::INTEGER, true),
+))]
+#[case::array_of_struct(StructField::nullable(
+    "items",
+    ArrayType::new(
+        DataType::Struct(Box::new(
+            StructType::try_new(vec![
+                StructField::nullable("a", DataType::STRING),
+                StructField::nullable("b", DataType::INTEGER),
+            ])
+            .unwrap(),
+        )),
+        true,
+    ),
+))]
+#[case::map_value_is_struct(StructField::nullable(
+    "by_id",
+    MapType::new(
+        DataType::STRING,
+        DataType::Struct(Box::new(
+            StructType::try_new(vec![
+                StructField::nullable("a", DataType::STRING),
+                StructField::nullable("b", DataType::INTEGER),
+            ])
+            .unwrap(),
+        )),
+        true,
+    ),
+))]
+#[tokio::test]
+async fn rename_complex_type_column(#[case] field: StructField) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let old_name = field.name().to_string();
+    let new_name = format!("{old_name}_renamed");
+    // Schema is simple_schema() + the complex column.
+    let schema = Arc::new(StructType::try_new(vec![
+        StructField::nullable("id", DataType::INTEGER),
+        StructField::nullable("name", DataType::STRING),
+        field,
+    ])?);
+    let snapshot = create_table_and_load_snapshot(
+        &table_path,
+        schema,
+        engine.as_ref(),
+        &[("delta.columnMapping.mode", "name")],
+    )?;
+    let original_max_id = max_column_id(&snapshot);
+
+    snapshot
+        .alter_table()
+        .rename_column(ColumnName::new([old_name.as_str()]), new_name.as_str())
+        .build(engine.as_ref(), committer())?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    let reloaded = Snapshot::builder_for(table_path).build(engine.as_ref())?;
+    let schema = reloaded.schema();
+    assert_eq!(schema.fields().count(), 3);
+    assert!(schema.field(&old_name).is_none());
+    assert!(schema.field(&new_name).is_some());
+    assert!(schema.field("id").is_some());
+    assert!(schema.field("name").is_some());
+    assert_eq!(
+        max_column_id(&reloaded),
+        original_max_id,
+        "rename must not bump maxColumnId"
+    );
+    Ok(())
+}
+
+/// Drives `add_column().rename_column().build()` through the actual builder type-state
+/// pipeline (rather than building a `Vec<SchemaOperation>` directly). Locks in the
+/// `Modifying -> Renaming` transition: a refactor that removed `rename_column` from
+/// `impl<S: Chainable>` would still pass the unit-level chain test but fail to compile here.
+#[tokio::test]
+async fn chain_add_then_rename_via_builder() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let snapshot = create_table_and_load_snapshot(
+        &table_path,
+        simple_schema(),
+        engine.as_ref(),
+        &[("delta.columnMapping.mode", "name")],
+    )?;
+    let original_max_id = max_column_id(&snapshot);
+
+    snapshot
+        .alter_table()
+        .add_column(StructField::nullable("email", DataType::STRING))
+        .rename_column(column_name!("email"), "contact_email")
+        .build(engine.as_ref(), committer())?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    let reloaded = Snapshot::builder_for(table_path).build(engine.as_ref())?;
+    let schema = reloaded.schema();
+    assert!(schema.field("email").is_none(), "old name must be gone");
+    let renamed = schema
+        .field("contact_email")
+        .expect("renamed column must exist");
+    let cm_id = renamed
+        .column_mapping_id()
+        .expect("CM id assigned by add_column survives rename");
+    assert!(
+        cm_id > original_max_id,
+        "added column was assigned a fresh CM id"
+    );
+    assert_eq!(
+        max_column_id(&reloaded),
+        cm_id,
+        "maxColumnId reflects the add_column id; rename did not bump it"
+    );
     Ok(())
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2391/files/4bddfd0cc9c59abe679d0ca9fdbb3f5a0025dfc1..b2009ced29a02c27e6cc314f3424c9136044d1c1) to review incremental changes.
- [stack/alter-table-1-refactor-state](https://github.com/delta-io/delta-kernel-rs/pull/2385) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2385/files)] [MERGED]
  - [stack/alter-table-2-supports-data-files](https://github.com/delta-io/delta-kernel-rs/pull/2386) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2386/files)] [MERGED]
    - [stack/alter-table-3-framework-add-column](https://github.com/delta-io/delta-kernel-rs/pull/2387) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2387/files)] [MERGED]
      - [stack/alter-table-4-set-nullable](https://github.com/delta-io/delta-kernel-rs/pull/2388) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2388/files)] [MERGED]
        - [stack/alter-table-5-column-mapping-add](https://github.com/delta-io/delta-kernel-rs/pull/2389) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2389/files)] [MERGED]
          - [stack/alter-table-6-drop-column](https://github.com/delta-io/delta-kernel-rs/pull/2390) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2390/files)]
            - [**stack/alter-table-7-rename-column**](https://github.com/delta-io/delta-kernel-rs/pull/2391) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2391/files/4bddfd0cc9c59abe679d0ca9fdbb3f5a0025dfc1..b2009ced29a02c27e6cc314f3424c9136044d1c1)]
              - [stack/alter-table-8-operation-string](https://github.com/delta-io/delta-kernel-rs/pull/2447) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2447/files/b2009ced29a02c27e6cc314f3424c9136044d1c1..b06bb4be0d091919436e4ee7800cfd126331acd2)]
                - [stack/alter-table-9-is-blind-append](https://github.com/delta-io/delta-kernel-rs/pull/2448) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2448/files/b06bb4be0d091919436e4ee7800cfd126331acd2..e1a691761a9b3c9255c0813aee7ee98d21c42136)]

---------
## What changes are proposed in this pull request?

Adds `rename_column` to the ALTER TABLE builder. Requires column mapping;
preserves the physical name and column-mapping ID so existing Parquet files
remain readable without rewrites. The builder transitions to a terminal
`Renaming` state (rename cannot be chained with other ops).

Rejects renames of partition columns, clustering columns, clustering
ancestors, and case-insensitive sibling collisions.

## How was this change tested?

Unit + integration tests covering: rename machinery, CM-metadata preservation
across nested depth, case-asymmetric layout guards, sibling conflicts, end-to-end
lifecycle with checkpoint + time travel + post-rename writes, complex-type
renames, builder chaining, and failure paths.
