### PR TITLE
chore!: revert add WriteContext::partition_group_key

### DIFF
--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -820,45 +820,19 @@ impl<S> Transaction<S> {
     }
 
     /// Lazily builds and caches the [`SharedWriteState`] for this transaction.
-    ///
-    /// Resolves partition column names (logical to physical) once and caches the result.
-    /// Returns an error if a partition column is not found in the table schema.
-    // TODO: replace with `get_or_try_init` when stable (rust#109737). That avoids the
-    // early-return + fallible compute + `get_or_init` dance, and prevents a concurrent
-    // caller from redundantly recomputing the state when the first caller is still running.
-    fn shared_write_state(&self) -> DeltaResult<&Arc<SharedWriteState>> {
-        if let Some(state) = self.shared_write_state.get() {
-            return Ok(state);
-        }
-        let table_config = self.read_snapshot.table_configuration();
-        let logical_schema = self.read_snapshot.schema();
-        let cm_mode = table_config.column_mapping_mode();
-        let logical_and_physical_partition_columns: Vec<(String, String)> = table_config
-            .partition_columns()
-            .iter()
-            .map(|logical_name| {
-                let physical_name = logical_schema
-                    .field(logical_name)
-                    .ok_or_else(|| {
-                        Error::internal_error(format!(
-                            "partition column '{logical_name}' not found in table schema"
-                        ))
-                    })?
-                    .physical_name(cm_mode)
-                    .to_string();
-                Ok((logical_name.clone(), physical_name))
+    fn shared_write_state(&self) -> &Arc<SharedWriteState> {
+        self.shared_write_state.get_or_init(|| {
+            let table_config = self.read_snapshot.table_configuration();
+            Arc::new(SharedWriteState {
+                table_root: self.read_snapshot.table_root().clone(),
+                logical_schema: self.read_snapshot.schema(),
+                physical_schema: table_config.physical_write_schema(),
+                logical_to_physical: Arc::new(self.generate_logical_to_physical()),
+                column_mapping_mode: table_config.column_mapping_mode(),
+                stats_columns: self.stats_columns(),
+                logical_partition_columns: table_config.partition_columns().to_vec(),
             })
-            .collect::<DeltaResult<_>>()?;
-        let state = Arc::new(SharedWriteState {
-            table_root: self.read_snapshot.table_root().clone(),
-            logical_schema,
-            physical_schema: table_config.physical_write_schema(),
-            logical_to_physical: Arc::new(self.generate_logical_to_physical()),
-            column_mapping_mode: cm_mode,
-            stats_columns: self.stats_columns(),
-            logical_and_physical_partition_columns,
-        });
-        Ok(self.shared_write_state.get_or_init(|| state))
+        })
     }
 
     /// Creates a write context for writing data to a specific partition.
@@ -900,37 +874,46 @@ impl<S> Transaction<S> {
         &self,
         partition_values: HashMap<String, Scalar>,
     ) -> DeltaResult<WriteContext> {
-        let shared = self.shared_write_state()?;
+        let shared = self.shared_write_state();
         require!(
-            !shared.logical_and_physical_partition_columns.is_empty(),
+            !shared.logical_partition_columns.is_empty(),
             Error::generic("table is not partitioned; use unpartitioned_write_context() instead")
         );
 
         // Validate keys (completeness, case normalization) and value types, then return
         // the map re-keyed to schema case.
-        let logical_names: Vec<String> = shared
-            .logical_and_physical_partition_columns
-            .iter()
-            .map(|(logical, _)| logical.clone())
-            .collect();
-        let normalized =
-            validate_partition_values(&logical_names, &shared.logical_schema, partition_values)?;
+        let normalized = validate_partition_values(
+            &shared.logical_partition_columns,
+            &shared.logical_schema,
+            partition_values,
+        )?;
 
-        // Serialize values using the pre-resolved (logical, physical) pairs from shared
-        // state. WriteContext::new derives the logical partition path from these pairs.
-        let mut physical_partition_values =
-            HashMap::with_capacity(shared.logical_and_physical_partition_columns.len());
-        for (logical_name, physical_name) in &shared.logical_and_physical_partition_columns {
+        // Serialize values and translate keys from logical to physical names.
+        let mut serialized = HashMap::with_capacity(normalized.len());
+        for logical_name in &shared.logical_partition_columns {
             let scalar = normalized.get(logical_name).ok_or_else(|| {
                 Error::internal_error(format!(
                     "partition column '{logical_name}' missing after validation"
                 ))
             })?;
             let value = serialize_partition_value(scalar)?;
-            physical_partition_values.insert(physical_name.clone(), value);
+            let physical_name = shared
+                .logical_schema
+                .field(logical_name)
+                .ok_or_else(|| {
+                    Error::internal_error(format!(
+                        "partition column '{logical_name}' not found in schema after validation"
+                    ))
+                })?
+                .physical_name(shared.column_mapping_mode)
+                .to_string();
+            serialized.insert(physical_name, value);
         }
 
-        Ok(WriteContext::new(shared.clone(), physical_partition_values))
+        Ok(WriteContext {
+            shared: shared.clone(),
+            physical_partition_values: serialized,
+        })
     }
 
     /// Creates a write context for writing data to an unpartitioned table.
@@ -938,12 +921,15 @@ impl<S> Transaction<S> {
     /// Returns an error if the table has partition columns (use
     /// [`partitioned_write_context`](Self::partitioned_write_context) instead).
     pub fn unpartitioned_write_context(&self) -> DeltaResult<WriteContext> {
-        let shared = self.shared_write_state()?;
+        let shared = self.shared_write_state();
         require!(
-            shared.logical_and_physical_partition_columns.is_empty(),
+            shared.logical_partition_columns.is_empty(),
             Error::generic("table is partitioned; use partitioned_write_context() instead")
         );
-        Ok(WriteContext::new(shared.clone(), HashMap::new()))
+        Ok(WriteContext {
+            shared: shared.clone(),
+            physical_partition_values: HashMap::new(),
+        })
     }
 
     /// Add files to include in this transaction. This API generally enables the engine to
@@ -1411,7 +1397,6 @@ mod tests {
     use crate::engine::arrow_conversion::TryIntoArrow;
     use crate::engine::arrow_data::ArrowEngineData;
     use crate::engine::arrow_expression::ArrowEvaluationHandler;
-    use crate::engine::default::DefaultEngineBuilder;
     use crate::engine::sync::SyncEngine;
     use crate::expressions::{MapData, Scalar, StructData};
     use crate::object_store::local::LocalFileSystem;
@@ -1813,44 +1798,6 @@ mod tests {
             "expected '{expected_msg}' in error, got: {err}"
         );
         Ok(())
-    }
-
-    #[test]
-    fn test_write_context_partition_col_not_in_schema_returns_error() {
-        let storage = Arc::new(InMemory::new());
-        let table_root = Url::parse("memory:///").unwrap();
-        let engine = DefaultEngineBuilder::new(storage.clone()).build();
-
-        // Schema has only "id", but metadata claims "ghost" is a partition column.
-        let actions = [
-            r#"{"commitInfo":{"timestamp":1587968586154}}"#,
-            r#"{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}"#,
-            concat!(
-                r#"{"metaData":{"id":"test","format":{"provider":"parquet","options":{}},"#,
-                r#""schemaString":"{\"type\":\"struct\",\"fields\":"#,
-                r#"[{\"name\":\"id\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}","#,
-                r#""partitionColumns":["ghost"],"configuration":{},"createdTime":1587968585495}}"#,
-            ),
-        ]
-        .join("\n");
-
-        let commit_path = Path::from("_delta_log/00000000000000000000.json");
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        rt.block_on(storage.put(&commit_path, actions.into()))
-            .unwrap();
-
-        let snapshot = Snapshot::builder_for(table_root).build(&engine).unwrap();
-        let txn = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), &engine)
-            .unwrap();
-        let err = txn
-            .partitioned_write_context(HashMap::from([("ghost".into(), Scalar::Integer(1))]))
-            .unwrap_err()
-            .to_string();
-        assert!(
-            err.starts_with("Internal error partition column 'ghost' not found in table schema."),
-            "unexpected error: {err}"
-        );
     }
 
     /// Tests that update_deletion_vectors validates table protocol requirements.

--- a/kernel/src/transaction/write_context.rs
+++ b/kernel/src/transaction/write_context.rs
@@ -12,7 +12,7 @@ use crate::table_features::ColumnMappingMode;
 
 /// Table-wide write state shared across all [`WriteContext`] instances created by a
 /// [`Transaction`]. Holds the target directory, schemas, column mapping mode, stats columns,
-/// and resolved partition column name pairs (logical and physical).
+/// and logical partition column names.
 ///
 /// [`Transaction`]: super::Transaction
 #[derive(Debug)]
@@ -23,8 +23,8 @@ pub(super) struct SharedWriteState {
     pub(super) logical_to_physical: ExpressionRef,
     pub(super) column_mapping_mode: ColumnMappingMode,
     pub(super) stats_columns: Vec<ColumnName>,
-    /// Partition columns in metadata-defined order: (logical_name, physical_name).
-    pub(super) logical_and_physical_partition_columns: Vec<(String, String)>,
+    /// Logical partition column names in metadata-defined order.
+    pub(super) logical_partition_columns: Vec<String>,
 }
 
 /// A write context for a specific partition or an unpartitioned table. Created by
@@ -54,54 +54,12 @@ pub(super) struct SharedWriteState {
 pub struct WriteContext {
     pub(super) shared: Arc<SharedWriteState>,
     /// Physical column name -> serialized value (`None` = null partition value).
-    /// Empty for unpartitioned tables. Used for building `add.partitionValues` in the
-    /// Delta log (which requires physical column names as keys).
+    /// Empty for unpartitioned tables. Ordering for hive-style paths comes from
+    /// `shared.logical_partition_columns`, not from this map.
     pub(super) physical_partition_values: HashMap<String, Option<String>>,
-    /// Hive-style partition path using logical column names in metadata-defined order
-    /// (e.g., `"year=2024/region=US/"`). Empty string for unpartitioned tables.
-    ///
-    /// This is not necessarily the filesystem path that data files are written to. With
-    /// column mapping enabled, [`write_dir`] uses a random prefix instead. Computed once
-    /// at construction; exposed via [`partition_group_key`].
-    ///
-    /// [`partition_group_key`]: WriteContext::partition_group_key
-    /// [`write_dir`]: WriteContext::write_dir
-    logical_partition_path: String,
 }
 
 impl WriteContext {
-    pub(super) fn new(
-        shared: Arc<SharedWriteState>,
-        physical_partition_values: HashMap<String, Option<String>>,
-    ) -> Self {
-        let logical_partition_path =
-            Self::build_logical_partition_path(&shared, &physical_partition_values);
-        Self {
-            shared,
-            physical_partition_values,
-            logical_partition_path,
-        }
-    }
-
-    /// Builds a Hive-style partition path using logical column names and serialized values
-    /// (e.g., `year=2024/region=US/`).
-    fn build_logical_partition_path(
-        shared: &SharedWriteState,
-        physical_values: &HashMap<String, Option<String>>,
-    ) -> String {
-        let columns: Vec<(&str, Option<&str>)> = shared
-            .logical_and_physical_partition_columns
-            .iter()
-            .map(|(logical, physical)| {
-                let value = physical_values
-                    .get(physical.as_str())
-                    .and_then(|v| v.as_deref());
-                (logical.as_str(), value)
-            })
-            .collect();
-        build_partition_path(&columns)
-    }
-
     /// Returns the table root URL.
     pub fn table_root_dir(&self) -> &Url {
         &self.shared.table_root
@@ -121,15 +79,6 @@ impl WriteContext {
     /// CM ON uses a random 2-char alphanumeric prefix (matching Delta-Spark's
     /// `getRandomPrefix`) to avoid S3 hotspots. Each call generates a fresh prefix,
     /// matching Delta-Spark's per-file behavior.
-    ///
-    /// # Warning
-    ///
-    /// **Not suitable as a group key.** With CM ON, the random prefix changes on every
-    /// call, so two calls with the same partition values produce different URLs. Use
-    /// [`partition_group_key`] instead when you need a stable, hashable identifier for
-    /// grouping writes by partition.
-    ///
-    /// [`partition_group_key`]: WriteContext::partition_group_key
     // TODO(#2357): respect `delta.randomizeFilePrefixes` and `delta.randomPrefixLength`
     // table properties. Currently random prefixes are only used when column mapping is on.
     pub fn write_dir(&self) -> Url {
@@ -138,8 +87,9 @@ impl WriteContext {
             ColumnMappingMode::None => {
                 // No column mapping: use Hive-style partition directories for partitioned
                 // tables, or just the table root for unpartitioned tables.
-                if !self.logical_partition_path.is_empty() {
-                    url.set_path(&format!("{}{}", url.path(), self.logical_partition_path));
+                if !self.shared.logical_partition_columns.is_empty() {
+                    let path_suffix = self.hive_partition_path_suffix();
+                    url.set_path(&format!("{}{}", url.path(), path_suffix));
                 }
             }
             ColumnMappingMode::Id | ColumnMappingMode::Name => {
@@ -189,32 +139,29 @@ impl WriteContext {
         &self.physical_partition_values
     }
 
-    /// Returns a deterministic, hashable string that uniquely identifies this partition.
-    ///
-    /// Connectors that group rows by partition values need a stable key. This method provides
-    /// one. The returned string uses Hive-style encoding with logical column names in
-    /// metadata-defined order: `"year=2024/region=US/"`.
-    ///
-    /// The key uses **logical** column names regardless of the table's column mapping mode.
-    /// This is intentional: the group key is a connector-side artifact that never reaches
-    /// the Delta log, so physical names (which may be opaque UUIDs) offer no benefit.
-    /// Logical names make the key readable and debuggable.
-    ///
-    /// Returns an empty string for unpartitioned tables (all rows belong to one group).
-    ///
-    /// # Warning
-    ///
-    /// **This is not the path you should write data files to.** Use [`write_dir`] for that.
-    /// The two methods serve different purposes:
-    ///
-    /// - `partition_group_key()` is **stable**: same partition values always produce the
-    ///   same string, regardless of column mapping mode. Safe to use as a `HashMap` key.
-    /// - [`write_dir`] is a **filesystem URL**: with column mapping ON, it includes a
-    ///   random prefix that changes on every call. Not suitable as a group key.
-    ///
-    /// [`write_dir`]: WriteContext::write_dir
-    pub fn partition_group_key(&self) -> &str {
-        &self.logical_partition_path
+    /// Builds the Hive-style partition path suffix (e.g., `year=2024/region=US/`).
+    /// Only called when column mapping is OFF.
+    fn hive_partition_path_suffix(&self) -> String {
+        debug_assert!(
+            self.shared.column_mapping_mode == ColumnMappingMode::None,
+            "Hive-style paths should only be used when column mapping is OFF"
+        );
+        let columns: Vec<(&str, Option<&str>)> = self
+            .shared
+            .logical_partition_columns
+            .iter()
+            .map(|logical_name| {
+                // CM is None, so physical == logical. Use the logical name as both the
+                // directory name (e.g. "year" in "year=2024/") and the key into
+                // physical_partition_values.
+                let value = self
+                    .physical_partition_values
+                    .get(logical_name.as_str())
+                    .and_then(|v| v.as_deref());
+                (logical_name.as_str(), value)
+            })
+            .collect();
+        build_partition_path(&columns)
     }
 
     /// Generate a new unique absolute URL for a deletion vector file.
@@ -265,13 +212,6 @@ mod tests {
 
     use crate::schema::{DataType, StructField, StructType};
 
-    /// Prefix added to logical partition column names to produce fake physical names.
-    /// Using distinct names exercises the logical-to-physical resolution path.
-    const PHYS_PREFIX: &str = "phys_";
-
-    /// Creates a test WriteContext with fake physical names (`phys_<logical>`).
-    /// `partition_values` should be keyed by **logical** names; this helper translates
-    /// them to physical keys internally.
     fn make_write_context(
         cm_mode: ColumnMappingMode,
         partition_columns: Vec<String>,
@@ -281,18 +221,6 @@ mod tests {
             "value",
             DataType::INTEGER,
         )]));
-        let logical_and_physical_cols: Vec<(String, String)> = partition_columns
-            .iter()
-            .map(|name| (name.clone(), format!("{PHYS_PREFIX}{name}")))
-            .collect();
-        let physical_partition_values: HashMap<String, Option<String>> = logical_and_physical_cols
-            .iter()
-            .filter_map(|(logical, physical)| {
-                partition_values
-                    .get(logical.as_str())
-                    .map(|value| (physical.clone(), value.clone()))
-            })
-            .collect();
         let shared = Arc::new(SharedWriteState {
             table_root: Url::parse("s3://bucket/table/").unwrap(),
             logical_schema: schema.clone(),
@@ -300,9 +228,12 @@ mod tests {
             logical_to_physical: Arc::new(Expression::literal(true)),
             column_mapping_mode: cm_mode,
             stats_columns: vec![],
-            logical_and_physical_partition_columns: logical_and_physical_cols,
+            logical_partition_columns: partition_columns,
         });
-        WriteContext::new(shared, physical_partition_values)
+        WriteContext {
+            shared,
+            physical_partition_values: partition_values,
+        }
     }
 
     /// Tests the cross product of ColumnMappingMode x partitioned/unpartitioned.
@@ -402,51 +333,5 @@ mod tests {
                 "prefix should be alphanumeric, got: {prefix}"
             );
         }
-    }
-
-    // ============================================================================
-    // partition_group_key
-    // ============================================================================
-
-    #[test]
-    fn test_partition_group_key_unpartitioned_returns_empty() {
-        let wc = make_write_context(ColumnMappingMode::None, vec![], HashMap::new());
-        assert_eq!(wc.partition_group_key(), "");
-    }
-
-    #[test]
-    fn test_partition_group_key_mixed_null_and_value_produces_correct_path() {
-        let wc = make_write_context(
-            ColumnMappingMode::Name,
-            vec!["year".into(), "region".into()],
-            HashMap::from([
-                ("year".into(), Some("2024".into())),
-                ("region".into(), None),
-            ]),
-        );
-        assert_eq!(
-            wc.partition_group_key(),
-            "year=2024/region=__HIVE_DEFAULT_PARTITION__/"
-        );
-    }
-
-    #[rstest]
-    fn test_partition_group_key_preserves_partition_column_order_across_cm_modes(
-        #[values(
-            ColumnMappingMode::None,
-            ColumnMappingMode::Name,
-            ColumnMappingMode::Id
-        )]
-        cm_mode: ColumnMappingMode,
-    ) {
-        let wc = make_write_context(
-            cm_mode,
-            vec!["b".into(), "a".into()],
-            HashMap::from([
-                ("a".into(), Some("1".into())),
-                ("b".into(), Some("2".into())),
-            ]),
-        );
-        assert_eq!(wc.partition_group_key(), "b=2/a=1/");
     }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

This reverts commit ed6b22f6759a0545a605e3d5d10ab895ef99c056.

That commit added a new WriteContext::partition_group_key API. However, this was the wrong abstraction. I only discovered this by working on the e2e-partition-data-and-write-parquet-files prototype https://github.com/delta-io/delta-kernel-rs/pull/2371

Basically: `WriteContext` shouldn't be used yet to partition the data (i.e. provide you the group-by key). The connector should partition the data (using its own key, such as a Vec of Strings where each String is the serialized partition value), then create the write context.

<details>
<summary>This is what the connector code should be:</summary>

```rust
  // Phase 1: Find partition column indices in the batch
  let partition_cols = txn.logical_partition_columns();
  let col_indices: Vec<usize> = partition_cols
      .iter()
      .map(|name| batch.schema().index_of(name).unwrap())
      .collect();

  // Phase 2: Use Arrow's partition() kernel to find adjacent runs
  let partition_arrays: Vec<ArrayRef> = col_indices
      .iter()
      .map(|&idx| batch.column(idx).clone())
      .collect();
  let ranges = arrow::compute::partition(&partition_arrays)?.ranges();

  // Phase 3: Group non-adjacent runs by serialized values (CHEAP, no WriteContext)
  type GroupKey = Vec<Option<String>>;
  let mut groups: HashMap<GroupKey, (HashMap<String, Scalar>, Vec<RecordBatch>)> =
      HashMap::new();

  for range in &ranges {
      let slice = batch.slice(range.start, range.end - range.start);
      let mut group_key = Vec::with_capacity(col_indices.len());
      let mut values = HashMap::with_capacity(col_indices.len());
      for (name, &idx) in partition_cols.iter().zip(&col_indices) { // <-- no need for wc.partition_group_key
          let scalar = extract_scalar(slice.column(idx).as_ref(), 0)?;
          group_key.push(serialize_partition_value(&scalar)?);
          values.insert(name.clone(), scalar);
      }
      groups.entry(group_key)
          .or_insert_with(|| (values, Vec::new()))
          .1
          .push(slice);
  }

  // Phase 4: Merge slices, then create WriteContext ONCE per distinct partition
  for (values, slices) in groups.into_values() {
      let merged = if slices.len() == 1 {
          slices.into_iter().next().unwrap()
      } else {
          concat_batches(&slices[0].schema(), &slices)?
      };
      let wc = txn.partitioned_write_context(values)?;  // K calls, not N
      let metadata = engine
          .write_parquet(&ArrowEngineData::new(merged), &wc)
          .await?;
      txn.add_files(metadata);
  }

  txn.commit(&engine)?;
```

</details>

## How was this change tested?

UTs
