### PR TITLE
feat: Add a new protocol compliance test crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,6 +1037,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "compliance_suite"
+version = "0.20.0"
+dependencies = [
+ "delta_kernel",
+ "paste",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "acceptance",
     "benchmarks",
+    "compliance-suite",
     "derive-macros",
     "ffi",
     "kernel",

--- a/compliance-suite/Cargo.toml
+++ b/compliance-suite/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "compliance_suite"
+publish = false
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+readme = "README.md"
+version.workspace = true
+rust-version.workspace = true
+
+# for cargo-release
+[package.metadata.release]
+release = false
+
+[features]
+default = ["arrow"]
+arrow = ["arrow-58"]
+arrow-58 = ["delta_kernel/arrow-58"]
+arrow-57 = ["delta_kernel/arrow-57"]
+
+[dev-dependencies]
+delta_kernel = { path = "../kernel", features = [
+  "default-engine-rustls",
+  "internal-api",
+  "prettyprint",
+] }
+paste = "1"
+serde_json = "1"
+tokio = { version = "1.47" }

--- a/compliance-suite/README.md
+++ b/compliance-suite/README.md
@@ -102,7 +102,7 @@ within the file would otherwise repeat the same value verbatim.
 | Field | Type | Description |
 |-------|------|-------------|
 | `name` | string | snake_case, globally unique across all fixture files; used by test code to load by name |
-| `description` | string | One sentence beginning with the operation ("Reading a...", "Creating a...", "Appending to..."): scenario, expected outcome, and the spec reason in brief |
+| `description` | string | One sentence beginning with the operation ("Reading a...", "Creating a...", "Committing to..."): scenario, expected outcome, and the spec reason in brief |
 | `operation` | object | The operation to perform (see Operation types below) |
 | `expected_outcome` | string | `"success"` or `"failure"` |
 
@@ -237,7 +237,7 @@ merging into it. Runners should raise an error at run time if `schemaString` is 
 2. Choose a descriptive `name` in snake_case, unique across all fixture files. Prefix with
    the operation type (`read_snapshot_`, `create_table_`, `empty_commit_`).
 3. Write a `description` that opens with the operation ("Reading a...", "Creating a...",
-   "Appending to...") and in one sentence covers: scenario, expected outcome, spec reason.
+   "Committing to...") and in one sentence covers: scenario, expected outcome, spec reason.
 4. Set `feature` to the Delta feature name if applicable.
 5. Set `flavor` if the case belongs to a sub-category used for filtering (e.g.
    `"unknown_feature"`, `"writer_only_read"`, `"supported_not_active"`).
@@ -367,7 +367,7 @@ gaps:
 
 - **Nested schemas**: the spec requires CM annotations on every nested field (struct,
   map key/value, array element). No case exercises annotation propagation through nesting.
-  Requires adding a `cm_annotated_nested` schema entry and corresponding read/append cases.
+  Requires adding a `cm_annotated_nested` schema entry and corresponding read/commit cases.
 - **`delta.columnMapping.maxColumnId`**: the spec requires this property to increase
   monotonically as columns are introduced. No case verifies its presence or value.
   Requires `schema_evolution` or `insert_rows` operation support.

--- a/compliance-suite/README.md
+++ b/compliance-suite/README.md
@@ -96,6 +96,10 @@ protocol objects, note text) across cases.
 Reference syntax: `"$schemas.simple_int"`, `"$protocols.modern_2_7_deletion_vectors"`,
 `"$notes.feature_active_without_support"`. Only add a shared entry when three or more cases
 within the file would otherwise repeat the same value verbatim.
+Exception: a single-use `$schemas.*` entry is allowed when it avoids an unreadable escaped
+JSON `schemaString` literal in `metaData` setup actions. See TODOs for tracked follow-up.
+Use ASCII-only text in fixture JSON files and notes. Replace typographic punctuation and
+unicode escapes with ASCII equivalents (for example, `--` instead of em dash escapes).
 
 ### Required fields
 
@@ -133,6 +137,12 @@ acceptance PR reference) in a per-fixture `$notes` entry so it does not need to 
 re-derived.
 
 ### Operation types
+
+#### Operation scope
+
+Operations in this fixture format are metadata/protocol oriented. They must not require
+creating or reading data files unless a dedicated operation type explicitly defines that
+contract.
 
 #### `create_table`
 
@@ -175,8 +185,8 @@ Opens a write transaction on a pre-existing table and commits it with no actions
 `setup`. This is sufficient for protocol-level write validation (does the writer accept or
 reject based on the protocol + feature state?). It is NOT sufficient to test row-level
 constraint features (invariants, checkConstraints, generatedColumns) or to exercise data
-write paths (column mapping physical name assignment, DV numRecords, etc.), which require
-a future `insert_rows` operation type (see TODOs).
+write paths (column mapping physical name assignment, DV numRecords, etc.). See TODOs for
+operation types that cover those paths.
 
 ```json
 {
@@ -240,19 +250,15 @@ merging into it. Runners should raise an error at run time if `schemaString` is 
    "Committing to...") and in one sentence covers: scenario, expected outcome, spec reason.
 4. Set `feature` to the Delta feature name if applicable.
 5. Set `flavor` if the case belongs to a sub-category used for filtering (e.g.
-   `"unknown_feature"`, `"writer_only_read"`, `"supported_not_active"`).
+   `"unknown_feature"`, `"writer_only_read"`, `"supported_not_active"`,
+   `"missing_required_metadata"`, `"invalid_metadata_content"`).
 6. For `create_table` cases, supply `operation.protocol` and `operation.metadata`.
 7. For `read_snapshot`/`empty_commit` cases, supply `setup.log_actions` with at least a
-   `protocol` action and a `metaData` action. The `metaData` entry requires only
-   `schemaString`; omit `id`, `format`, empty `partitionColumns`, and empty `configuration`
-   (all have standard defaults applied by the runner at run time).
+   `protocol` action and a `metaData` action. Follow the Setup and defaults rules above.
 8. Set `expected_outcome` to your best reading of the spec.
-9. Add `note` only for spec ambiguity/errata OR non-obvious fixture characteristics. For
-   errata-level controversies, use `"$errata.<key>"` — add a new entry to `errata.json`
-   if none exists yet. No runtime error strings in notes.
+9. Add `note` using the Optional fields rules above.
 10. Use `$schemas.*`, `$protocols.*`, or `$notes.*` references instead of inlining repeated
-    values. Add new shared entries to the relevant section when three or more cases share
-    the same value.
+    values. Follow the Shared reference section rules above.
 
 ### Filtering fixtures
 
@@ -283,10 +289,16 @@ python fixtures/format-json.py protocol-validity.json
 
 ## TODOs
 
+### Operation capability gaps
+
+The current operation set is intentionally metadata/protocol oriented. Feature checks that
+require explicit write payload control, scan-level log validation, or data-file I/O are
+tracked in the TODO items below.
+
 ### `create_table` success cases need postconditions
 
-Currently a `create_table` success case only asserts that no exception was thrown. That is
-insufficient: a runtime could succeed by committing something entirely different from what
+A `create_table` success case only asserts that no exception was thrown. That is
+insufficient: a runtime could succeed by committing something different from what
 was requested, and the fixture would pass.
 
 The correct postcondition for a success case is that the requested feature is supported and
@@ -298,10 +310,9 @@ requests `deletionVectors` must result in a committed table where `deletionVecto
 in both feature lists and `delta.enableDeletionVectors=true` is in the committed
 configuration.
 
-There is no immediate easy fix: supporting postconditions requires the harness to read back
-the committed snapshot and assert against it, and the fixture format needs a way to express
-what "active" means per feature. Until then, `committed_protocol` in the result JSON is
-purely diagnostic.
+Supporting postconditions requires the harness to read back the committed snapshot and
+assert against it, and the fixture format needs a way to express what "active" means per
+feature. `committed_protocol` in the result JSON is diagnostic.
 
 ### nullable=false and the invariants feature
 
@@ -333,7 +344,7 @@ write operation type with explicit log actions exists:
 
 `empty_commit` commits no data rows, so constraint features (invariants, checkConstraints,
 generatedColumns) and data-reading features (columnMapping, typeWidening) cannot be
-validated end-to-end with the current operation types. Two future operation types:
+validated end-to-end. Operation types to cover this:
 
 - **`insert_rows`**: commits a specified set of rows (as inline JSON or a parquet snippet).
   Needed for: invariant violations, constraint violations, generated column enforcement.
@@ -341,10 +352,16 @@ validated end-to-end with the current operation types. Two future operation type
   parquet files + injected `add` actions). Needed for: column mapping physical/logical name
   resolution, type widening coercion, variant decoding. Setup would need to include the
   actual parquet file bytes or a reference to a fixture file.
+- **`validate_scan`** (proposed): consumes and validates scan/log inputs that require looking
+  at all relevant `add` actions without creating or reading data files. Needed for cases that
+  are stronger than `read_snapshot` metadata checks but still intended to remain file-I/O-free.
+- **`write_actions`** (proposed): commits an explicit set of log actions (`add`, `remove`,
+  etc.) without requiring data-file reads. Needed for write-path negative tests such as
+  DV-bearing `add` rejection when deletionVectors is orphaned or supported-but-not-active.
 
 ### Invalid schema/metadata combos on pre-existing tables
 
-The current fixture set only injects valid log actions via `setup.log_actions`. Many
+The fixture set injects only valid log actions via `setup.log_actions`. Many
 validations (e.g. CM annotations present with `mode=none`, duplicate CM IDs, missing
 annotations on nested fields) have no coverage because a writer's own code path would
 never produce these states. TODO: add setup-based cases that inject these states directly
@@ -357,8 +374,8 @@ including intermediate helper nodes for nested types (array `element`, map `key`
 These nodes have no corresponding `StructField` in the Delta schema and therefore no `metadata`
 slot for `delta.columnMapping.id`. The spec stores their IDs in the nearest enclosing
 `StructField`'s metadata under dedicated keys — but the exact key names and encoding structure
-require re-reading the relevant PROTOCOL.md sections before writing cases. No fixture currently
-tests nested CM annotation correctness under icebergCompatV1 or V2.
+require re-reading the relevant PROTOCOL.md sections before writing cases. No fixture tests
+nested CM annotation correctness under icebergCompatV1 or V2.
 
 ### columnMapping: nested schema and maxColumnId coverage
 
@@ -393,7 +410,7 @@ All require a future `write_actions` operation type that can specify exact commi
 
 ### domainMetadata: write-path and multi-commit coverage
 
-Several key domainMetadata spec requirements are untestable with the current operation model:
+Several key domainMetadata spec requirements are untestable with the operation model:
 
 - **System-controlled domain write rejection**: the spec forbids writers from allowing users
   to write `domainMetadata` actions whose domain name starts with `delta.`. Requires a
@@ -409,7 +426,7 @@ Several key domainMetadata spec requirements are untestable with the current ope
 
 ### Cross-cutting feature combinations: dedicated fixture
 
-Cross-feature test cases are currently scattered across per-feature files and were added
+Cross-feature test cases are scattered across per-feature files and were added
 ad-hoc. Several of the existing combinations (e.g. CDF+DV, vacuumProtocolCheck+DV) have no
 spec-defined interaction — "this feature is important so test it alongside things" is not a
 principle. These cases should be audited; those without a concrete spec rationale should be
@@ -436,8 +453,8 @@ combined case unless the spec says something specific about their combination.
 
 ### Additional operation types
 
-CDF reads, schema evolution DDL, OPTIMIZE (file compaction), and VACUUM currently have
-no coverage. These exercise feature-specific write paths not reachable via `empty_commit`.
+CDF reads, schema evolution DDL, OPTIMIZE (file compaction), and VACUUM have no coverage.
+These exercise feature-specific write paths not reachable via `empty_commit`.
 
 ### Feature enablement vs. support state
 
@@ -459,4 +476,4 @@ configurations (e.g. appendOnly feature listed, delta.appendOnly absent).
 - **No error strings in fixtures**: runtime error messages are not portable. Only spec
   rules go in `note`.
 - **`create_table` as starting point**: easier to specify an exact initial protocol state
-  than ALTER TABLE. ALTER TABLE tests are also needed and will be added separately.
+  than ALTER TABLE. ALTER TABLE coverage is tracked through separate operation-type TODOs.

--- a/compliance-suite/README.md
+++ b/compliance-suite/README.md
@@ -1,0 +1,462 @@
+# Delta Protocol Compliance Fixtures
+
+Portable, runtime-neutral test cases for Delta protocol compliance. Each case encodes what
+the Delta spec requires. Runtime-specific harnesses load these fixtures and add concrete
+assertions; divergences are documented in hand-written test code under version control.
+
+**Fixture files encode spec requirements only.** `expected_outcome` must be anchored to
+the actual spec, not to any runtime's behavior. If a runtime diverges — auto-upgrades
+protocols, auto-satisfies feature dependencies, or accepts something the spec forbids —
+that is documented in the runtime's `results/` file, not in the fixture files.
+
+**Protocol + metadata legality is judged on what the spec allows to be committed, not on
+what the caller supplied.** If a fixture presents a protocol/metadata combination that the
+spec forbids as a committed table state, `expected_outcome` is `"failure"`. A runtime that
+transforms the input before committing (e.g. auto-generating column mapping annotations,
+auto-satisfying feature dependencies) is diverging from the literal request; record the
+transformation in `results/` as `committed_protocol` or `committed_schema`, not in the
+fixture.
+
+**No runtime is authoritative** -- all have their own bugs and quirks. `expected_outcome`
+reflects our best reading of the spec; the optional `note` field gives the spec rationale
+for ambiguous or controversial cases. Update based on new spec clarity.
+
+See `errata.json` for open controversies and cases where the spec is ambiguous or silent.
+Fixture cases reference errata entries via `"$errata.<key>"` in their `note` field.
+
+---
+
+## Fixture files
+
+Cases are organized into per-feature files under `fixtures/`:
+
+```
+fixtures/
+  protocol-validity.json           # cross-cutting protocol version and feature list rules
+  catalog-managed.json             # catalogManaged and catalogOwned-preview (pre-ratification alias)
+  column-mapping.json              # columnMapping
+  deletion-vectors.json            # deletionVectors
+  timestamp-ntz.json               # timestampNtz
+  type-widening.json               # typeWidening and typeWidening-preview
+  variant.json                     # variantType and variantType-preview
+  variant-shredding-preview.json   # variantShredding-preview
+  append-only.json                 # appendOnly
+  allow-column-defaults.json       # allowColumnDefaults
+  change-data-feed.json            # changeDataFeed
+  check-constraints.json           # checkConstraints
+  clustering.json                  # clustering
+  domain-metadata.json             # domainMetadata
+  generated-columns.json           # generatedColumns
+  identity-columns.json            # identityColumns
+  in-commit-timestamp.json         # inCommitTimestamp
+  invariants.json                  # invariants
+  materialize-partition-columns.json # materializePartitionColumns
+  row-tracking.json                # rowTracking
+  v2-checkpoint.json               # v2Checkpoint
+  vacuum-protocol-check.json       # vacuumProtocolCheck
+  iceberg-compat-v1.json           # icebergCompatV1
+  iceberg-compat-v2.json           # icebergCompatV2
+  iceberg-compat-v3-preview.json   # icebergCompatV3-preview
+  iceberg-writer-compat.json       # icebergWriterCompatV1-preview
+```
+
+Each file is self-contained: it includes only the `$schemas`, `$protocols`, and `$notes`
+entries used by its own cases.
+
+---
+
+## Fixture file schema
+
+Each fixture file is a top-level JSON object with four keys: `$schemas`, `$protocols`,
+`$notes`, and `cases`.
+
+### Shared reference sections
+
+`$schemas`, `$protocols`, and `$notes` are shared-reference dictionaries local to the
+fixture file. `$errata` is a global registry loaded from `errata.json`.
+Any string value in a case that matches `"$section.key"` is resolved by the
+fixture runner before the case is run. Use these to avoid repeating large blobs (schemas,
+protocol objects, note text) across cases.
+
+```json
+{
+  "$schemas": {
+    "simple_int": { "type": "struct", "fields": [...] }
+  },
+  "$protocols": {
+    "modern_2_7_deletion_vectors": { "minReaderVersion": 2, "minWriterVersion": 7, "writerFeatures": ["deletionVectors"] }
+  },
+  "$notes": {
+    "feature_active_without_support": "Spec defines supported vs active separately. ..."
+  },
+  "cases": [...]
+}
+```
+
+Reference syntax: `"$schemas.simple_int"`, `"$protocols.modern_2_7_deletion_vectors"`,
+`"$notes.feature_active_without_support"`. Only add a shared entry when three or more cases
+within the file would otherwise repeat the same value verbatim.
+
+### Required fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | snake_case, globally unique across all fixture files; used by test code to load by name |
+| `description` | string | One sentence beginning with the operation ("Reading a...", "Creating a...", "Appending to..."): scenario, expected outcome, and the spec reason in brief |
+| `operation` | object | The operation to perform (see Operation types below) |
+| `expected_outcome` | string | `"success"` or `"failure"` |
+
+### Optional fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `flavor` | string | Sub-category tag for cross-feature filtering. Closed vocabulary: `"orphan"` (activation property present but feature not listed in protocol), `"supported_not_active"` (feature listed in protocol but table conditions for activation not met — no activation property, no qualifying schema elements, etc.), `"missing_dependency"` (required co-feature absent from protocol), `"insufficient_protocol"` (protocol version too low to support the feature, regardless of feature lists), `"legacy"` (tests the pre-(3,7) protocol path where a modern path also exists for the same feature), `"unknown_feature"` (unrecognized feature name in readerFeatures/writerFeatures — primarily protocol-validity and write-behavior). Omit for straightforward happy-path cases where the case name is already self-describing. |
+| `feature` | string | Delta feature name for filtering (e.g. `jq '.cases[] | select(.feature=="columnMapping")'`). For `-preview` features, use the preview name (e.g. `"typeWidening-preview"`) so cases are separately filterable from the ratified feature. |
+| `setup` | object | Pre-existing table state; required for `read_snapshot` and `empty_commit` operations |
+| `note` | string | For spec ambiguity or controversy only — use `"$errata.<key>"` to reference an entry in `errata.json`, or a `"$notes.<key>"` local annotation for a non-obvious spec requirement that applies to multiple cases. Do not use `note` to describe fixture coverage gaps or operation limitations. No runtime error strings. |
+
+#### Pre-ratification `-preview` feature names
+
+Several features shipped under a `-preview` suffix before their RFC was accepted (e.g.
+`typeWidening-preview`, `variantType-preview`). The `-preview` name is not in the ratified
+spec; whether the preview and ratified specs are semantically equivalent must be verified
+per feature by checking the full RFC commit history (not just the acceptance PR), since
+RFCs are designed to iterate and often do. Find all commits touching the RFC file via
+`gh api "repos/delta-io/delta/commits?path=protocol_rfcs/<feature>.md"` and review each
+diff for substantive changes to writer/reader requirements or data format.
+
+Use the same `flavor` on `-preview` cases as you would on the equivalent ratified cases
+(or omit it for happy-path creates/reads). Do NOT use `flavor: "unknown_feature"` — that
+flavor is for genuinely unrecognized feature names, not pre-ratification names whose
+semantics are known. Record the result of the verification (equivalent or not, and the
+acceptance PR reference) in a per-fixture `$notes` entry so it does not need to be
+re-derived.
+
+### Operation types
+
+#### `create_table`
+
+Commits a Protocol action + Metadata action as the initial table commit (version 0). No
+setup needed.
+
+```json
+{
+  "operation": {
+    "type": "create_table",
+    "protocol": {
+      "minReaderVersion": 2,
+      "minWriterVersion": 5,
+      "readerFeatures": [],
+      "writerFeatures": []
+    },
+    "metadata": {
+      "configuration": { "delta.columnMapping.mode": "name" },
+      "schemaString": "{\"type\":\"struct\",\"fields\":[...]}"
+    }
+  }
+}
+```
+
+`readerFeatures` and `writerFeatures` are optional; omit them for legacy (pre-3,7) protocols.
+
+#### `read_snapshot`
+
+Opens a pre-existing table and reads its snapshot. Requires `setup`.
+
+```json
+{
+  "operation": { "type": "read_snapshot" }
+}
+```
+
+#### `empty_commit`
+
+Opens a write transaction on a pre-existing table and commits it with no actions. Requires
+`setup`. This is sufficient for protocol-level write validation (does the writer accept or
+reject based on the protocol + feature state?). It is NOT sufficient to test row-level
+constraint features (invariants, checkConstraints, generatedColumns) or to exercise data
+write paths (column mapping physical name assignment, DV numRecords, etc.), which require
+a future `insert_rows` operation type (see TODOs).
+
+```json
+{
+  "operation": { "type": "empty_commit" }
+}
+```
+
+### Setup
+
+The `setup` object contains `log_actions`: an array of Delta log action objects written
+to `_delta_log/00000000000000000000.json`. The objects use standard Delta log action
+wrapper keys (`protocol`, `metaData`, `add`, etc.) as specified in the Delta protocol.
+
+```json
+{
+  "setup": {
+    "log_actions": [
+      { "protocol": { "minReaderVersion": 3, "minWriterVersion": 7, "readerFeatures": ["deletionVectors"], "writerFeatures": ["deletionVectors"] } },
+      { "metaData": { "schemaString": "$schemas.simple_int", "configuration": {"delta.enableDeletionVectors": "true"} } }
+    ]
+  }
+}
+```
+
+#### metaData defaults
+
+`metaData` log action entries use the following defaults for fields that are not
+semantically meaningful to the test case. Specify only `schemaString` (required) and
+any fields that differ from these defaults:
+
+| Field | Default | Notes |
+|-------|---------|-------|
+| `schemaString` | **none — required** | Must always be provided explicitly |
+| `configuration` | `{}` | Omit when empty; include only the properties relevant to the case |
+| `partitionColumns` | `[]` | Omit unless the test specifically exercises partitioning |
+| `id` | `"00000000-0000-0000-0000-000000000001"` | Never varies; omit in all cases |
+| `format` | `{"provider": "parquet", "options": {}}` | Never varies; omit in all cases |
+
+The merge is **shallow**: a fixture-supplied key replaces the default entirely rather than
+merging into it. Runners should raise an error at run time if `schemaString` is absent.
+
+#### domainMetadata defaults
+
+`domainMetadata` log action entries use the following defaults:
+
+| Field | Default | Notes |
+|-------|---------|-------|
+| `domain` | **none — required** | Must always be provided explicitly |
+| `configuration` | **none — required** | Must always be provided explicitly |
+| `removed` | `false` | Omit unless the test specifically exercises domain metadata removal |
+
+---
+
+## Adding New Cases
+
+1. Choose the appropriate fixture file under `fixtures/` for the feature being tested.
+   Create a new file if none exists for that feature.
+2. Choose a descriptive `name` in snake_case, unique across all fixture files. Prefix with
+   the operation type (`read_snapshot_`, `create_table_`, `empty_commit_`).
+3. Write a `description` that opens with the operation ("Reading a...", "Creating a...",
+   "Appending to...") and in one sentence covers: scenario, expected outcome, spec reason.
+4. Set `feature` to the Delta feature name if applicable.
+5. Set `flavor` if the case belongs to a sub-category used for filtering (e.g.
+   `"unknown_feature"`, `"writer_only_read"`, `"supported_not_active"`).
+6. For `create_table` cases, supply `operation.protocol` and `operation.metadata`.
+7. For `read_snapshot`/`empty_commit` cases, supply `setup.log_actions` with at least a
+   `protocol` action and a `metaData` action. The `metaData` entry requires only
+   `schemaString`; omit `id`, `format`, empty `partitionColumns`, and empty `configuration`
+   (all have standard defaults applied by the runner at run time).
+8. Set `expected_outcome` to your best reading of the spec.
+9. Add `note` only for spec ambiguity/errata OR non-obvious fixture characteristics. For
+   errata-level controversies, use `"$errata.<key>"` — add a new entry to `errata.json`
+   if none exists yet. No runtime error strings in notes.
+10. Use `$schemas.*`, `$protocols.*`, or `$notes.*` references instead of inlining repeated
+    values. Add new shared entries to the relevant section when three or more cases share
+    the same value.
+
+### Filtering fixtures
+
+```bash
+# All columnMapping cases
+jq '.cases[] | select(.feature=="columnMapping") | .name' fixtures/column-mapping.json
+
+# All failure cases
+jq '.cases[] | select(.expected_outcome=="failure") | .name' fixtures/protocol-validity.json
+
+# All create_table cases
+jq '.cases[] | select(.operation.type=="create_table") | .name' fixtures/column-mapping.json
+
+# All cases with a given flavor
+jq '.cases[] | select(.flavor=="writer_only_read") | .name' fixtures/column-mapping.json
+```
+
+### Formatting fixtures
+
+```bash
+# Format all fixture files
+python fixtures/format-json.py
+
+# Format one fixture
+python fixtures/format-json.py protocol-validity.json
+```
+---
+
+## TODOs
+
+### `create_table` success cases need postconditions
+
+Currently a `create_table` success case only asserts that no exception was thrown. That is
+insufficient: a runtime could succeed by committing something entirely different from what
+was requested, and the fixture would pass.
+
+The correct postcondition for a success case is that the requested feature is supported and
+active in the committed snapshot — not that the committed protocol matches the requested one
+exactly. Runtimes legitimately transform the input (auto-satisfying co-required features,
+choosing legacy vs. modern protocol paths), so requiring an exact match would be wrong. But
+the feature under test must be present and active. For example, a `create_table` that
+requests `deletionVectors` must result in a committed table where `deletionVectors` appears
+in both feature lists and `delta.enableDeletionVectors=true` is in the committed
+configuration.
+
+There is no immediate easy fix: supporting postconditions requires the harness to read back
+the committed snapshot and assert against it, and the fixture format needs a way to express
+what "active" means per feature. Until then, `committed_protocol` in the result JSON is
+purely diagnostic.
+
+### nullable=false and the invariants feature
+
+The spec says nothing about nullable=false columns requiring any particular feature.
+Protocol history: invariants was introduced at writer v2; checkConstraints at writer v3.
+The base legacy version with no constraint features is `(1,1)`.
+
+Two cases are interesting:
+- `(1,1)`: no constraint feature exists at this version; in theory the writer cannot
+  enforce nullable=false and must accept the table. What protocol is actually committed?
+- `(3,7)` with no constraint feature listed: does the writer reject or auto-upgrade,
+  and to which feature (`invariants` or `checkConstraints`)?
+
+These are covered by `invariants_nullable_false_legacy_1_1_create_table_succeeds` and
+`invariants_nullable_false_without_feature_modern_create_table_fails`.
+
+### appendOnly enforcement and dataChange=false rearrangement
+
+The spec's core appendOnly constraint ("new log entries MUST NOT change or remove data") and its
+exception ("may rearrange data via add/remove actions where `dataChange=false`") are both
+untestable with `empty_commit`, which never issues Remove actions. Two cases are needed once a
+write operation type with explicit log actions exists:
+
+- A write that includes a Remove action on an appendOnly-active table → must fail.
+- A write that includes remove+add actions with `dataChange=false` on an appendOnly-active
+  table → must succeed (the permitted rearrangement exception).
+
+### Row-level constraint and feature testing
+
+`empty_commit` commits no data rows, so constraint features (invariants, checkConstraints,
+generatedColumns) and data-reading features (columnMapping, typeWidening) cannot be
+validated end-to-end with the current operation types. Two future operation types:
+
+- **`insert_rows`**: commits a specified set of rows (as inline JSON or a parquet snippet).
+  Needed for: invariant violations, constraint violations, generated column enforcement.
+- **`read_rows`**: reads back rows from a pre-built table (setup includes hand-crafted
+  parquet files + injected `add` actions). Needed for: column mapping physical/logical name
+  resolution, type widening coercion, variant decoding. Setup would need to include the
+  actual parquet file bytes or a reference to a fixture file.
+
+### Invalid schema/metadata combos on pre-existing tables
+
+The current fixture set only injects valid log actions via `setup.log_actions`. Many
+validations (e.g. CM annotations present with `mode=none`, duplicate CM IDs, missing
+annotations on nested fields) have no coverage because a writer's own code path would
+never produce these states. TODO: add setup-based cases that inject these states directly
+and test `read_snapshot` / `empty_commit` behavior.
+
+### icebergCompatV1/V2: nested type helper field IDs
+
+ICv1 and ICv2 require Parquet-level column IDs on every field in the Parquet schema,
+including intermediate helper nodes for nested types (array `element`, map `key` and `value`).
+These nodes have no corresponding `StructField` in the Delta schema and therefore no `metadata`
+slot for `delta.columnMapping.id`. The spec stores their IDs in the nearest enclosing
+`StructField`'s metadata under dedicated keys — but the exact key names and encoding structure
+require re-reading the relevant PROTOCOL.md sections before writing cases. No fixture currently
+tests nested CM annotation correctness under icebergCompatV1 or V2.
+
+### columnMapping: nested schema and maxColumnId coverage
+
+`fixtures/column-mapping.json` uses a single top-level integer field for all cases. Two
+gaps:
+
+- **Nested schemas**: the spec requires CM annotations on every nested field (struct,
+  map key/value, array element). No case exercises annotation propagation through nesting.
+  Requires adding a `cm_annotated_nested` schema entry and corresponding read/append cases.
+- **`delta.columnMapping.maxColumnId`**: the spec requires this property to increase
+  monotonically as columns are introduced. No case verifies its presence or value.
+  Requires `schema_evolution` or `insert_rows` operation support.
+
+### inCommitTimestamp: write-path invariant coverage
+
+The following ICT writer requirements are untestable with `empty_commit`, which cannot
+control what specific actions the writer includes in the commit:
+
+- **commitInfo absent**: writer must include a `commitInfo` action on every ICT-enabled commit.
+- **inCommitTimestamp field absent from commitInfo**: writer must include the field even if
+  `commitInfo` is present for other reasons.
+- **commitInfo not first action**: spec requires `commitInfo` to be the first action; a commit
+  where it appears after protocol or metaData should fail.
+- **Non-monotonic timestamp**: writer must ensure each commit's `inCommitTimestamp` is at least
+  one millisecond later than the previous commit's value.
+- **Provenance tracking on mid-table enablement**: enabling ICT on a table that already has
+  non-ICT commits must write `delta.inCommitTimestampEnablementVersion` and
+  `delta.inCommitTimestampEnablementTimestamp`, and the enabling commit's timestamp must exceed
+  the file modification time of the immediately preceding commit.
+
+All require a future `write_actions` operation type that can specify exact commit payloads.
+
+### domainMetadata: write-path and multi-commit coverage
+
+Several key domainMetadata spec requirements are untestable with the current operation model:
+
+- **System-controlled domain write rejection**: the spec forbids writers from allowing users
+  to write `domainMetadata` actions whose domain name starts with `delta.`. Requires a
+  future `write_actions` operation type that can specify explicit log action payloads.
+- **Tombstone semantics across commits**: `removed=true` marks a domain as logically deleted
+  in subsequent snapshots. Requires either multi-commit setup or the `write_actions` type.
+- **Action Reconciliation last-write-wins across commits**: when multiple commits each write
+  a `domainMetadata` action for the same domain, the latest one wins. Requires multi-commit
+  setup support in the fixture model.
+- **Writer preservation of unknown user domains**: a writer must carry forward all domains
+  it does not understand into its commit. Requires verifying the committed log, not just
+  that the operation succeeded.
+
+### Cross-cutting feature combinations: dedicated fixture
+
+Cross-feature test cases are currently scattered across per-feature files and were added
+ad-hoc. Several of the existing combinations (e.g. CDF+DV, vacuumProtocolCheck+DV) have no
+spec-defined interaction — "this feature is important so test it alongside things" is not a
+principle. These cases should be audited; those without a concrete spec rationale should be
+removed.
+
+A dedicated `fixtures/cross-cutting.json` should replace the scattered cases and cover only
+combinations where the spec defines explicit requirements for the pair. Selection criteria:
+
+- **Explicit spec restrictions**: mutual exclusions (icebergCompatV1 + deletionVectors support
+  forbidden; icebergCompatV1 vs icebergCompatV2 co-listing), required co-listings
+  (rowTracking + domainMetadata, clustering + domainMetadata).
+- **Shared infrastructure with a concrete interaction**: columnMapping + any SQL expression
+  feature (invariants, checkConstraints, generatedColumns, allowColumnDefaults) share the
+  logical-vs-physical name ambiguity in `$errata.sql_expression_cm_name_resolution`. This is
+  a real interaction — the expression references a column name that may resolve differently
+  depending on how the runtime handles CM.
+- **Spec-cited co-listing examples**: the spec's own protocol examples that show two features
+  co-listed (e.g. `columnMapping + identityColumns`).
+- **Known implementation divergences**.
+
+Explicitly out of scope: "A is important, let's also test it with B" unless there is a
+spec-defined interaction. Two independent features that happen to be co-listed have no
+combined case unless the spec says something specific about their combination.
+
+### Additional operation types
+
+CDF reads, schema evolution DDL, OPTIMIZE (file compaction), and VACUUM currently have
+no coverage. These exercise feature-specific write paths not reachable via `empty_commit`.
+
+### Feature enablement vs. support state
+
+The kernel tests `is_feature_supported` and `is_feature_enabled` separately —
+supported = listed in protocol; enabled = supported AND metadata requirements met. TODO:
+add `read_snapshot` cases that assert on the returned state for supported-but-not-enabled
+configurations (e.g. appendOnly feature listed, delta.appendOnly absent).
+
+---
+
+## Design Decisions
+
+- **One entry per case**: avoids hidden programmatic expansion; each case is readable on
+  its own and grep-able by name.
+- **Per-feature files**: cases are grouped by feature in `fixtures/`. Each file is
+  self-contained with only the shared references it needs.
+- **Protocol-native JSON**: `setup.log_actions` uses the exact Delta log action format,
+  making cases verifiable against the spec without translation.
+- **No error strings in fixtures**: runtime error messages are not portable. Only spec
+  rules go in `note`.
+- **`create_table` as starting point**: easier to specify an exact initial protocol state
+  than ALTER TABLE. ALTER TABLE tests are also needed and will be added separately.

--- a/compliance-suite/errata.json
+++ b/compliance-suite/errata.json
@@ -11,8 +11,8 @@
   },
   "clustering_missing_domain_metadata_action": {
     "title": "Clustered table with no delta.clustering domainMetadata action in the log",
-    "spec_says": "The spec requires writers to track clustering column names via a domainMetadata action with domain delta.clustering. It does not address what readers must do when this action is absent.",
-    "controversy": "Absence of the delta.clustering action may represent a valid transient state (e.g. clustering enabled but no OPTIMIZE run yet) or an invalid one. The spec is silent on whether readers must reject or can proceed."
+    "spec_says": "Clustering is a Writers-only feature. When clustering is supported, writers must track clustering column names in a domainMetadata action with domain delta.clustering. The spec also says clustering columns can be specified at table creation or added later.",
+    "controversy": "The spec does not explicitly say whether a clustered table with no clustering columns selected yet must still carry a delta.clustering domainMetadata action (for example with an empty clusteringColumns list), or whether that action can be omitted until clustering columns are first defined."
   },
   "column_mapping_asymmetric_protocol_support": {
     "title": "columnMapping with asymmetric reader/writer protocol support",

--- a/compliance-suite/errata.json
+++ b/compliance-suite/errata.json
@@ -12,12 +12,12 @@
   "domain_metadata_support_term_ambiguity": {
     "title": "domainMetadata 'support' wording ambiguity",
     "spec_says": "The spec text for domainMetadata uses 'support' in prose about reader behavior while also defining protocol-level support/enablement concepts elsewhere. It also says readers may ignore unrecognized metadata domains.",
-    "controversy": "It is ambiguous whether 'readers who do not support domain metadata' means readers that do not implement domainMetadata semantics, or readers where protocol-level feature support/enablement is absent. This affects interpretation of orphan domainMetadata actions and whether they are tolerated vs rejected."
+    "controversy": "It is ambiguous whether 'readers who do not support domain metadata' means readers that do not implement domainMetadata semantics, or readers where protocol-level feature support/enablement is absent. This affects the interpretation of orphan domainMetadata actions and whether they are expressly tolerated or merely not rejected (because the spec says nothing)."
   },
   "iceberg_compat_dv_restriction": {
-    "title": "icebergCompatV1 vs icebergCompatV2: different DV restriction semantics",
-    "spec_says": "icebergCompatV1 requires deletionVectors not be supported when ICv1 is enabled. icebergCompatV2 only requires deletionVectors not be active (supported-but-not-active is permitted).",
-    "controversy": "The asymmetry between ICv1 and ICv2 is specified but subtle. ICv1 prohibits DV support entirely; ICv2 only prohibits DV activation. Implementations may conflate the two."
+    "title": "Iceberg compatibility: CM support dependency vs DV activation semantics",
+    "spec_says": "For Iceberg compatibility features, columnMapping is a support dependency (feature-level requirement), while deletionVectors restrictions are scoped to active behavior. ICv1 active requires DV not be supported; ICv2 active requires DV not be active.",
+    "controversy": "For ICv1 and ICv2, CM and DV use different support-vs-enablement boundaries: CM is a support dependency, while DV is activation-scoped. Implementations may incorrectly apply ICv1 DV strictness to ICv2, or treat CM as activation-only in either version."
   },
   "nullable_false_invariants": {
     "title": "nullable=false columns and the invariants/checkConstraints feature requirement",

--- a/compliance-suite/errata.json
+++ b/compliance-suite/errata.json
@@ -9,15 +9,10 @@
     "spec_says": "The spec defines writer obligations whose violation produces invalid table state. It does not always specify whether readers must detect and reject such states.",
     "controversy": "When a table violates a writer requirement (e.g. clustered + partitioned, clustering without domainMetadata co-listed), whether readers are obligated to reject is often unspecified. Failure is the expected fixture outcome since the state is definitively invalid."
   },
-  "clustering_missing_domain_metadata_action": {
-    "title": "Clustered table with no delta.clustering domainMetadata action in the log",
-    "spec_says": "Clustering is a Writers-only feature. When clustering is supported, writers must track clustering column names in a domainMetadata action with domain delta.clustering. The spec also says clustering columns can be specified at table creation or added later.",
-    "controversy": "The spec does not explicitly say whether a clustered table with no clustering columns selected yet must still carry a delta.clustering domainMetadata action (for example with an empty clusteringColumns list), or whether that action can be omitted until clustering columns are first defined."
-  },
-  "column_mapping_asymmetric_protocol_support": {
-    "title": "columnMapping with asymmetric reader/writer protocol support",
-    "spec_says": "The CM property 'should only be honored if the table's protocol has reader and writer versions...that support the columnMapping table feature.' Both reader (v2+) and writer (v5+) requirements must be satisfied simultaneously. CM has separate reader and writer version thresholds, unlike most features.",
-    "controversy": "When one side satisfies its CM requirement but the other does not \u2014 e.g. (1,5) where writer v5 is sufficient but reader v1 is not; (2,4) where reader v2 is sufficient but writer v4 is not; (1,7)+CM in writerFeatures where the writer side is satisfied but reader v1 is not \u2014 the property is not honored, but whether such a table state is itself invalid (and should be rejected) or merely degenerate is unspecified."
+  "domain_metadata_support_term_ambiguity": {
+    "title": "domainMetadata 'support' wording ambiguity",
+    "spec_says": "The spec text for domainMetadata uses 'support' in prose about reader behavior while also defining protocol-level support/enablement concepts elsewhere. It also says readers may ignore unrecognized metadata domains.",
+    "controversy": "It is ambiguous whether 'readers who do not support domain metadata' means readers that do not implement domainMetadata semantics, or readers where protocol-level feature support/enablement is absent. This affects interpretation of orphan domainMetadata actions and whether they are tolerated vs rejected."
   },
   "iceberg_compat_dv_restriction": {
     "title": "icebergCompatV1 vs icebergCompatV2: different DV restriction semantics",

--- a/compliance-suite/errata.json
+++ b/compliance-suite/errata.json
@@ -1,0 +1,47 @@
+{
+  "orphan_feature_metadata": {
+    "title": "Feature metadata present without the feature listed in protocol",
+    "spec_says": "All behavioral requirements for a feature are scoped to 'when supported'. The spec does not address what readers or writers must do when feature-related metadata (table properties, schema annotations, log actions) is present but the feature is absent from the protocol.",
+    "controversy": "Whether implementations should proactively reject this inconsistent state or silently ignore the unrecognized metadata is unresolved."
+  },
+  "invalid_table_state_reader_rejection": {
+    "title": "Definitively invalid table state; spec silent on whether readers must reject",
+    "spec_says": "The spec defines writer obligations whose violation produces invalid table state. It does not always specify whether readers must detect and reject such states.",
+    "controversy": "When a table violates a writer requirement (e.g. clustered + partitioned, clustering without domainMetadata co-listed), whether readers are obligated to reject is often unspecified. Failure is the expected fixture outcome since the state is definitively invalid."
+  },
+  "clustering_missing_domain_metadata_action": {
+    "title": "Clustered table with no delta.clustering domainMetadata action in the log",
+    "spec_says": "The spec requires writers to track clustering column names via a domainMetadata action with domain delta.clustering. It does not address what readers must do when this action is absent.",
+    "controversy": "Absence of the delta.clustering action may represent a valid transient state (e.g. clustering enabled but no OPTIMIZE run yet) or an invalid one. The spec is silent on whether readers must reject or can proceed."
+  },
+  "column_mapping_asymmetric_protocol_support": {
+    "title": "columnMapping with asymmetric reader/writer protocol support",
+    "spec_says": "The CM property 'should only be honored if the table's protocol has reader and writer versions...that support the columnMapping table feature.' Both reader (v2+) and writer (v5+) requirements must be satisfied simultaneously. CM has separate reader and writer version thresholds, unlike most features.",
+    "controversy": "When one side satisfies its CM requirement but the other does not \u2014 e.g. (1,5) where writer v5 is sufficient but reader v1 is not; (2,4) where reader v2 is sufficient but writer v4 is not; (1,7)+CM in writerFeatures where the writer side is satisfied but reader v1 is not \u2014 the property is not honored, but whether such a table state is itself invalid (and should be rejected) or merely degenerate is unspecified."
+  },
+  "iceberg_compat_dv_restriction": {
+    "title": "icebergCompatV1 vs icebergCompatV2: different DV restriction semantics",
+    "spec_says": "icebergCompatV1 requires deletionVectors not be supported when ICv1 is enabled. icebergCompatV2 only requires deletionVectors not be active (supported-but-not-active is permitted).",
+    "controversy": "The asymmetry between ICv1 and ICv2 is specified but subtle. ICv1 prohibits DV support entirely; ICv2 only prohibits DV activation. Implementations may conflate the two."
+  },
+  "nullable_false_invariants": {
+    "title": "nullable=false columns and the invariants/checkConstraints feature requirement",
+    "spec_says": "The spec does not specify what protocol version or feature is required to enforce nullable=false columns. The invariants feature covers delta.invariants metadata expressions, not the nullable field itself.",
+    "controversy": "Some implementations require a constraint feature (invariants or checkConstraints) in writerFeatures before accepting a nullable=false schema at (3,7). Which feature is required, and whether this applies at legacy versions, is unclear from the spec."
+  },
+  "row_tracking_enabled_prerequisites": {
+    "title": "delta.enableRowTracking=true without required materialized column name config keys",
+    "spec_says": "Enabling row tracking (setting delta.enableRowTracking=true) is only allowed when delta.rowTracking.materializedRowIdColumnName and delta.rowTracking.materializedRowCommitVersionColumnName have been assigned in the metaData configuration.",
+    "controversy": "Whether a create_table that sets delta.enableRowTracking=true without these config keys must be rejected, or whether the keys are only required when materializing row IDs as visible columns, is unclear. The spec lists them as hard prerequisites under 'This is only allowed if', but create_table implementations may or may not enforce this at table creation time."
+  },
+  "sql_expression_cm_name_resolution": {
+    "title": "SQL expression features + columnMapping: logical vs physical column names",
+    "spec_says": "Invariant expressions (delta.invariants), check constraint expressions (delta.constraints.*), and generation expressions (delta.generationExpression) are SQL strings stored in schema metadata or table configuration. Under columnMapping, the column's display name ('id') differs from its physical name ('col-1'). The spec does not state whether these expressions reference logical or physical names.",
+    "controversy": "Whether SQL expressions in these features must reference logical names (schema display names) or physical names is unspecified across all three features. A writer using the wrong resolution strategy could silently fail to enforce the expression or raise a resolution error."
+  },
+  "protocol_structural_validity_should_vs_must": {
+    "title": "readerFeatures/writerFeatures placement: 'should' vs 'must' in the spec",
+    "spec_says": "Reader features 'should be listed in both readerFeatures and writerFeatures simultaneously' (should, not must). 'It is not allowed to list a feature only in readerFeatures but not in writerFeatures' (explicit prohibition in one direction only).",
+    "controversy": "For a reader-writer feature listed only in writerFeatures: the spec uses 'should', not 'must'. A lenient reader might ignore the asymmetry. Fixture expects failure on the grounds that a reader cannot safely operate on a protocol it cannot fully interpret."
+  }
+}

--- a/compliance-suite/fixtures/allow-column-defaults.json
+++ b/compliance-suite/fixtures/allow-column-defaults.json
@@ -1,0 +1,282 @@
+{
+  "$schemas": {
+    "default_column": {
+      "type": "struct",
+      "fields": [
+        {"name": "id", "type": "integer", "nullable": true, "metadata": {"CURRENT_DEFAULT": "42"}}
+      ]
+    },
+    "cm_default_column": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {
+            "delta.columnMapping.id": 1,
+            "delta.columnMapping.physicalName": "col-1",
+            "CURRENT_DEFAULT": "42"
+          }
+        }
+      ]
+    },
+    "simple_int": {
+      "type": "struct",
+      "fields": [{"name": "id", "type": "integer", "nullable": true, "metadata": {}}]
+    }
+  },
+  "$protocols": {
+    "modern_3_7_allow_check_constraints": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": ["allowColumnDefaults", "checkConstraints"]
+    },
+    "modern_3_7_allow_column_defaults": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": ["allowColumnDefaults"]
+    },
+    "modern_2_7_allow_column_defaults": {
+      "minReaderVersion": 2,
+      "minWriterVersion": 7,
+      "writerFeatures": ["allowColumnDefaults"]
+    },
+    "legacy_1_4": {"minReaderVersion": 1, "minWriterVersion": 4},
+    "modern_3_7_cm_allow_column_defaults": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["columnMapping"],
+      "writerFeatures": ["columnMapping", "allowColumnDefaults"]
+    },
+    "modern_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": []
+    }
+  },
+  "$notes": {
+    "orphan_writer_feature": "At (3,7), the spec requires activation properties to be paired with the corresponding feature in writerFeatures. Writing an activation property for a feature absent from writerFeatures is invalid committed state."
+  },
+  "cases": [
+    {
+      "ordinal": 1,
+      "name": "allow_column_defaults_create_table_3_7_feature_listed_succeeds",
+      "feature": "allowColumnDefaults",
+      "description": "Creating a (3,7)+[allowColumnDefaults] table with a CURRENT_DEFAULT column succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7_allow_column_defaults",
+        "metadata": {"schemaString": "$schemas.default_column"}
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 2,
+      "name": "allow_column_defaults_create_table_3_7_no_feature_listed_fails",
+      "flavor": "orphan",
+      "feature": "allowColumnDefaults",
+      "description": "Creating a (3,7) table with a CURRENT_DEFAULT column but allowColumnDefaults absent from writerFeatures fails.",
+      "note": "$notes.orphan_writer_feature",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7",
+        "metadata": {"schemaString": "$schemas.default_column"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 3,
+      "name": "allow_column_defaults_read_snapshot_3_7_with_default_column_succeeds",
+      "feature": "allowColumnDefaults",
+      "description": "Reading a (3,7)+[allowColumnDefaults] table with a CURRENT_DEFAULT column succeeds: allowColumnDefaults is writer-only.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_allow_column_defaults"},
+          {"metaData": {"schemaString": "$schemas.default_column"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 4,
+      "name": "allow_column_defaults_empty_commit_3_7_no_feature_listed_fails",
+      "flavor": "orphan",
+      "feature": "allowColumnDefaults",
+      "description": "Appending to a (3,7) table with a CURRENT_DEFAULT column but allowColumnDefaults absent from writerFeatures fails.",
+      "note": "$notes.orphan_writer_feature",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7"},
+          {"metaData": {"schemaString": "$schemas.default_column"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 5,
+      "name": "allow_column_defaults_supported_active_empty_commit_succeeds",
+      "feature": "allowColumnDefaults",
+      "description": "Appending to a (3,7)+[allowColumnDefaults] table with a CURRENT_DEFAULT column succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_allow_column_defaults"},
+          {"metaData": {"schemaString": "$schemas.default_column"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 6,
+      "name": "allow_column_defaults_read_snapshot_3_7_no_feature_listed_succeeds",
+      "flavor": "orphan",
+      "feature": "allowColumnDefaults",
+      "description": "Reading a (3,7) table with a CURRENT_DEFAULT column but allowColumnDefaults absent from writerFeatures succeeds; allowColumnDefaults is writer-only.",
+      "note": "$errata.orphan_feature_metadata",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7"},
+          {"metaData": {"schemaString": "$schemas.default_column"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 7,
+      "name": "allow_column_defaults_supported_not_active_empty_commit_succeeds",
+      "flavor": "supported_not_active",
+      "feature": "allowColumnDefaults",
+      "description": "Appending to a (3,7)+[allowColumnDefaults] table without any default column succeeds: the feature is supported but not active.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_allow_column_defaults"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 8,
+      "name": "allow_column_defaults_supported_not_active_read_snapshot_succeeds",
+      "flavor": "supported_not_active",
+      "feature": "allowColumnDefaults",
+      "description": "Reading a (3,7)+[allowColumnDefaults] table without any default column succeeds: the feature is supported but not active.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_allow_column_defaults"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 9,
+      "name": "allow_column_defaults_create_table_1_4_fails",
+      "flavor": "insufficient_protocol",
+      "feature": "allowColumnDefaults",
+      "description": "Creating a (1,4) table with a CURRENT_DEFAULT column fails; allowColumnDefaults has no legacy support and requires Writer Version 7 with the feature listed.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.legacy_1_4",
+        "metadata": {"schemaString": "$schemas.default_column"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 10,
+      "name": "allow_column_defaults_check_constraints_create_table_3_7_succeeds",
+      "feature": "allowColumnDefaults",
+      "description": "Creating a (3,7)+[allowColumnDefaults,checkConstraints] table with a default value that satisfies the check constraint succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7_allow_check_constraints",
+        "metadata": {
+          "schemaString": "$schemas.default_column",
+          "configuration": {"delta.constraints.id_positive": "id > 0"}
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 11,
+      "name": "allow_column_defaults_cm_create_table_3_7_succeeds",
+      "feature": "allowColumnDefaults",
+      "description": "Creating a (3,7)+[columnMapping,allowColumnDefaults] table with a CM-annotated column with a CURRENT_DEFAULT succeeds.",
+      "note": "$errata.sql_expression_cm_name_resolution",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7_cm_allow_column_defaults",
+        "metadata": {
+          "schemaString": "$schemas.cm_default_column",
+          "configuration": {
+            "delta.columnMapping.mode": "id",
+            "delta.columnMapping.maxColumnId": "1"
+          }
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 12,
+      "name": "allow_column_defaults_cm_empty_commit_3_7_succeeds",
+      "feature": "allowColumnDefaults",
+      "description": "Appending to a (3,7)+[columnMapping,allowColumnDefaults] table with a CM-annotated column with a CURRENT_DEFAULT succeeds.",
+      "note": "$errata.sql_expression_cm_name_resolution",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_cm_allow_column_defaults"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.cm_default_column",
+              "configuration": {
+                "delta.columnMapping.mode": "id",
+                "delta.columnMapping.maxColumnId": "1"
+              }
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 13,
+      "name": "allow_column_defaults_read_snapshot_2_7_writer_only_succeeds",
+      "feature": "allowColumnDefaults",
+      "flavor": "supported_not_active",
+      "description": "Reading a (2,7)+[allowColumnDefaults] table succeeds; allowColumnDefaults is writer-only and readers need not understand writer-only features.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_2_7_allow_column_defaults"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 14,
+      "name": "allow_column_defaults_empty_commit_2_7_writer_feature_listed_succeeds",
+      "feature": "allowColumnDefaults",
+      "flavor": "supported_not_active",
+      "description": "Appending to a (2,7)+[allowColumnDefaults] table without a CURRENT_DEFAULT annotation succeeds; no default substitution is required when no rows are written.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_2_7_allow_column_defaults"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    }
+  ]
+}

--- a/compliance-suite/fixtures/allow-column-defaults.json
+++ b/compliance-suite/fixtures/allow-column-defaults.json
@@ -58,9 +58,6 @@
       "writerFeatures": []
     }
   },
-  "$notes": {
-    "orphan_writer_feature": "At (3,7), the spec requires activation properties to be paired with the corresponding feature in writerFeatures. Writing an activation property for a feature absent from writerFeatures is invalid committed state."
-  },
   "cases": [
     {
       "ordinal": 1,
@@ -76,23 +73,23 @@
     },
     {
       "ordinal": 2,
-      "name": "allow_column_defaults_create_table_3_7_no_feature_listed_fails",
+      "name": "allow_column_defaults_create_table_3_7_no_feature_listed_succeeds",
       "flavor": "orphan",
       "feature": "allowColumnDefaults",
-      "description": "Creating a (3,7) table with a CURRENT_DEFAULT column but allowColumnDefaults absent from writerFeatures fails.",
-      "note": "$notes.orphan_writer_feature",
+      "description": "Creating a (3,7) table with a CURRENT_DEFAULT column but allowColumnDefaults absent from writerFeatures succeeds.",
+      "note": "$errata.orphan_feature_metadata",
       "operation": {
         "type": "create_table",
         "protocol": "$protocols.modern_3_7",
         "metadata": {"schemaString": "$schemas.default_column"}
       },
-      "expected_outcome": "failure"
+      "expected_outcome": "success"
     },
     {
       "ordinal": 3,
       "name": "allow_column_defaults_read_snapshot_3_7_with_default_column_succeeds",
       "feature": "allowColumnDefaults",
-      "description": "Reading a (3,7)+[allowColumnDefaults] table with a CURRENT_DEFAULT column succeeds: allowColumnDefaults is writer-only.",
+      "description": "Reading a (3,7)+[allowColumnDefaults] table with a CURRENT_DEFAULT column succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.modern_3_7_allow_column_defaults"},
@@ -104,11 +101,11 @@
     },
     {
       "ordinal": 4,
-      "name": "allow_column_defaults_empty_commit_3_7_no_feature_listed_fails",
+      "name": "allow_column_defaults_empty_commit_3_7_no_feature_listed_succeeds",
       "flavor": "orphan",
       "feature": "allowColumnDefaults",
-      "description": "Appending to a (3,7) table with a CURRENT_DEFAULT column but allowColumnDefaults absent from writerFeatures fails.",
-      "note": "$notes.orphan_writer_feature",
+      "description": "Committing to a (3,7) table with a CURRENT_DEFAULT column but allowColumnDefaults absent from writerFeatures succeeds.",
+      "note": "$errata.orphan_feature_metadata",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.modern_3_7"},
@@ -116,13 +113,13 @@
         ]
       },
       "operation": {"type": "empty_commit"},
-      "expected_outcome": "failure"
+      "expected_outcome": "success"
     },
     {
       "ordinal": 5,
       "name": "allow_column_defaults_supported_active_empty_commit_succeeds",
       "feature": "allowColumnDefaults",
-      "description": "Appending to a (3,7)+[allowColumnDefaults] table with a CURRENT_DEFAULT column succeeds.",
+      "description": "Committing to a (3,7)+[allowColumnDefaults] table with a CURRENT_DEFAULT column succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.modern_3_7_allow_column_defaults"},
@@ -137,7 +134,7 @@
       "name": "allow_column_defaults_read_snapshot_3_7_no_feature_listed_succeeds",
       "flavor": "orphan",
       "feature": "allowColumnDefaults",
-      "description": "Reading a (3,7) table with a CURRENT_DEFAULT column but allowColumnDefaults absent from writerFeatures succeeds; allowColumnDefaults is writer-only.",
+      "description": "Reading a (3,7) table with a CURRENT_DEFAULT column but allowColumnDefaults absent from writerFeatures succeeds.",
       "note": "$errata.orphan_feature_metadata",
       "setup": {
         "log_actions": [
@@ -153,7 +150,7 @@
       "name": "allow_column_defaults_supported_not_active_empty_commit_succeeds",
       "flavor": "supported_not_active",
       "feature": "allowColumnDefaults",
-      "description": "Appending to a (3,7)+[allowColumnDefaults] table without any default column succeeds: the feature is supported but not active.",
+      "description": "Committing to a (3,7)+[allowColumnDefaults] table without any default column succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.modern_3_7_allow_column_defaults"},
@@ -168,7 +165,7 @@
       "name": "allow_column_defaults_supported_not_active_read_snapshot_succeeds",
       "flavor": "supported_not_active",
       "feature": "allowColumnDefaults",
-      "description": "Reading a (3,7)+[allowColumnDefaults] table without any default column succeeds: the feature is supported but not active.",
+      "description": "Reading a (3,7)+[allowColumnDefaults] table without any default column succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.modern_3_7_allow_column_defaults"},
@@ -229,7 +226,7 @@
       "ordinal": 12,
       "name": "allow_column_defaults_cm_empty_commit_3_7_succeeds",
       "feature": "allowColumnDefaults",
-      "description": "Appending to a (3,7)+[columnMapping,allowColumnDefaults] table with a CM-annotated column with a CURRENT_DEFAULT succeeds.",
+      "description": "Committing to a (3,7)+[columnMapping,allowColumnDefaults] table with a CM-annotated column with a CURRENT_DEFAULT succeeds.",
       "note": "$errata.sql_expression_cm_name_resolution",
       "setup": {
         "log_actions": [
@@ -253,7 +250,7 @@
       "name": "allow_column_defaults_read_snapshot_2_7_writer_only_succeeds",
       "feature": "allowColumnDefaults",
       "flavor": "supported_not_active",
-      "description": "Reading a (2,7)+[allowColumnDefaults] table succeeds; allowColumnDefaults is writer-only and readers need not understand writer-only features.",
+      "description": "Reading a (2,7)+[allowColumnDefaults] table succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.modern_2_7_allow_column_defaults"},
@@ -268,7 +265,7 @@
       "name": "allow_column_defaults_empty_commit_2_7_writer_feature_listed_succeeds",
       "feature": "allowColumnDefaults",
       "flavor": "supported_not_active",
-      "description": "Appending to a (2,7)+[allowColumnDefaults] table without a CURRENT_DEFAULT annotation succeeds; no default substitution is required when no rows are written.",
+      "description": "Committing to a (2,7)+[allowColumnDefaults] table without a CURRENT_DEFAULT annotation succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.modern_2_7_allow_column_defaults"},
@@ -277,6 +274,21 @@
       },
       "operation": {"type": "empty_commit"},
       "expected_outcome": "success"
+    },
+    {
+      "ordinal": 15,
+      "name": "allow_column_defaults_check_constraints_create_table_3_7_default_violates_constraint_fails",
+      "feature": "allowColumnDefaults",
+      "description": "Creating a (3,7)+[allowColumnDefaults,checkConstraints] table with a default value that violates the check constraint fails.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7_allow_check_constraints",
+        "metadata": {
+          "schemaString": "$schemas.default_column",
+          "configuration": {"delta.constraints.id_gt_100": "id > 100"}
+        }
+      },
+      "expected_outcome": "failure"
     }
   ]
 }

--- a/compliance-suite/fixtures/append-only.json
+++ b/compliance-suite/fixtures/append-only.json
@@ -1,0 +1,273 @@
+{
+  "$schemas": {
+    "simple_int": {
+      "type": "struct",
+      "fields": [{"name": "id", "type": "integer", "nullable": true, "metadata": {}}]
+    }
+  },
+  "$protocols": {
+    "legacy_1_2": {"minReaderVersion": 1, "minWriterVersion": 2},
+    "legacy_1_1": {"minReaderVersion": 1, "minWriterVersion": 1},
+    "modern_3_7_append_only": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": ["appendOnly"]
+    },
+    "modern_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": []
+    }
+  },
+  "$notes": {
+    "orphan_writer_feature": "At (3,7), the spec requires activation properties to be paired with the corresponding feature in writerFeatures. Writing an activation property for a feature absent from writerFeatures is invalid committed state."
+  },
+  "cases": [
+    {
+      "ordinal": 1,
+      "name": "append_only_create_table_1_1_succeeds",
+      "flavor": "orphan",
+      "feature": "appendOnly",
+      "description": "Creating a (1,1) table with delta.appendOnly=true succeeds; writer version 1 does not support appendOnly but the spec does not require rejection of an unrecognized activation property.",
+      "note": "$errata.orphan_feature_metadata",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.legacy_1_1",
+        "metadata": {
+          "configuration": {"delta.appendOnly": "true"},
+          "schemaString": "$schemas.simple_int"
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 2,
+      "name": "append_only_create_table_1_2_true",
+      "flavor": "legacy",
+      "feature": "appendOnly",
+      "description": "Creating a (1,2) table with delta.appendOnly=true succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.legacy_1_2",
+        "metadata": {
+          "configuration": {"delta.appendOnly": "true"},
+          "schemaString": "$schemas.simple_int"
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 3,
+      "name": "append_only_create_table_1_2_false",
+      "flavor": "legacy",
+      "feature": "appendOnly",
+      "description": "Creating a (1,2) table with delta.appendOnly=false succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.legacy_1_2",
+        "metadata": {
+          "configuration": {"delta.appendOnly": "false"},
+          "schemaString": "$schemas.simple_int"
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 4,
+      "name": "append_only_empty_commit_1_2_succeeds",
+      "flavor": "legacy",
+      "feature": "appendOnly",
+      "description": "Appending to a (1,2) table with delta.appendOnly=true succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.legacy_1_2"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.appendOnly": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 5,
+      "name": "append_only_create_table_3_7_no_feature_listed_with_property",
+      "flavor": "orphan",
+      "feature": "appendOnly",
+      "description": "Creating a (3,7) table with delta.appendOnly=true but appendOnly absent from writerFeatures fails.",
+      "note": "$notes.orphan_writer_feature",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7",
+        "metadata": {
+          "configuration": {"delta.appendOnly": "true"},
+          "schemaString": "$schemas.simple_int"
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 6,
+      "name": "append_only_empty_commit_3_7_no_feature_listed_with_property_fails",
+      "flavor": "orphan",
+      "feature": "appendOnly",
+      "description": "Appending to a (3,7) table with delta.appendOnly=true but appendOnly absent from writerFeatures fails.",
+      "note": "$notes.orphan_writer_feature",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.appendOnly": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 7,
+      "name": "append_only_read_snapshot_3_7_no_feature_listed_with_property",
+      "flavor": "orphan",
+      "feature": "appendOnly",
+      "description": "Reading a (3,7) table with delta.appendOnly=true but appendOnly absent from writerFeatures succeeds; appendOnly is writer-only.",
+      "note": "$errata.orphan_feature_metadata",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.appendOnly": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 8,
+      "name": "append_only_create_table_3_7_feature_listed_succeeds",
+      "feature": "appendOnly",
+      "description": "Creating a (3,7)+[appendOnly] table with delta.appendOnly=true succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7_append_only",
+        "metadata": {
+          "configuration": {"delta.appendOnly": "true"},
+          "schemaString": "$schemas.simple_int"
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 9,
+      "name": "append_only_supported_not_active_empty_commit_succeeds",
+      "flavor": "supported_not_active",
+      "feature": "appendOnly",
+      "description": "Appending to a (3,7)+[appendOnly] table without delta.appendOnly=true succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_append_only"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 10,
+      "name": "append_only_supported_not_active_read_snapshot_succeeds",
+      "flavor": "supported_not_active",
+      "feature": "appendOnly",
+      "description": "Reading a (3,7)+[appendOnly] table without delta.appendOnly=true succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_append_only"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 11,
+      "name": "append_only_supported_active_empty_commit_succeeds",
+      "feature": "appendOnly",
+      "description": "Appending to a (3,7)+[appendOnly] table with delta.appendOnly=true succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_append_only"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.appendOnly": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 12,
+      "name": "append_only_supported_active_read_snapshot_succeeds",
+      "feature": "appendOnly",
+      "description": "Reading a (3,7)+[appendOnly] table with delta.appendOnly=true succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_append_only"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.appendOnly": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 13,
+      "name": "append_only_read_snapshot_1_2_with_property_succeeds",
+      "flavor": "legacy",
+      "feature": "appendOnly",
+      "description": "Reading a (1,2) table with delta.appendOnly=true succeeds; appendOnly is writer-only.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.legacy_1_2"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.appendOnly": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 14,
+      "name": "append_only_supported_not_active_create_table_succeeds",
+      "flavor": "supported_not_active",
+      "feature": "appendOnly",
+      "description": "Creating a (3,7)+[appendOnly] table without delta.appendOnly=true succeeds; the feature is supported but not active.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7_append_only",
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "success"
+    }
+  ]
+}

--- a/compliance-suite/fixtures/append-only.json
+++ b/compliance-suite/fixtures/append-only.json
@@ -21,16 +21,14 @@
       "writerFeatures": []
     }
   },
-  "$notes": {
-    "orphan_writer_feature": "At (3,7), the spec requires activation properties to be paired with the corresponding feature in writerFeatures. Writing an activation property for a feature absent from writerFeatures is invalid committed state."
-  },
+  "$notes": {},
   "cases": [
     {
       "ordinal": 1,
       "name": "append_only_create_table_1_1_succeeds",
       "flavor": "orphan",
       "feature": "appendOnly",
-      "description": "Creating a (1,1) table with delta.appendOnly=true succeeds; writer version 1 does not support appendOnly but the spec does not require rejection of an unrecognized activation property.",
+      "description": "Creating a (1,1) table with delta.appendOnly=true succeeds.",
       "note": "$errata.orphan_feature_metadata",
       "operation": {
         "type": "create_table",
@@ -79,7 +77,7 @@
       "name": "append_only_empty_commit_1_2_succeeds",
       "flavor": "legacy",
       "feature": "appendOnly",
-      "description": "Appending to a (1,2) table with delta.appendOnly=true succeeds.",
+      "description": "Committing to a (1,2) table with delta.appendOnly=true succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.legacy_1_2"},
@@ -96,11 +94,11 @@
     },
     {
       "ordinal": 5,
-      "name": "append_only_create_table_3_7_no_feature_listed_with_property",
+      "name": "append_only_create_table_3_7_no_feature_listed_with_property_succeeds",
       "flavor": "orphan",
       "feature": "appendOnly",
-      "description": "Creating a (3,7) table with delta.appendOnly=true but appendOnly absent from writerFeatures fails.",
-      "note": "$notes.orphan_writer_feature",
+      "description": "Creating a (3,7) table with delta.appendOnly=true but appendOnly absent from writerFeatures succeeds.",
+      "note": "$errata.orphan_feature_metadata",
       "operation": {
         "type": "create_table",
         "protocol": "$protocols.modern_3_7",
@@ -109,15 +107,15 @@
           "schemaString": "$schemas.simple_int"
         }
       },
-      "expected_outcome": "failure"
+      "expected_outcome": "success"
     },
     {
       "ordinal": 6,
-      "name": "append_only_empty_commit_3_7_no_feature_listed_with_property_fails",
+      "name": "append_only_empty_commit_3_7_no_feature_listed_with_property_succeeds",
       "flavor": "orphan",
       "feature": "appendOnly",
-      "description": "Appending to a (3,7) table with delta.appendOnly=true but appendOnly absent from writerFeatures fails.",
-      "note": "$notes.orphan_writer_feature",
+      "description": "Committing to a (3,7) table with delta.appendOnly=true but appendOnly absent from writerFeatures succeeds.",
+      "note": "$errata.orphan_feature_metadata",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.modern_3_7"},
@@ -130,14 +128,14 @@
         ]
       },
       "operation": {"type": "empty_commit"},
-      "expected_outcome": "failure"
+      "expected_outcome": "success"
     },
     {
       "ordinal": 7,
       "name": "append_only_read_snapshot_3_7_no_feature_listed_with_property",
       "flavor": "orphan",
       "feature": "appendOnly",
-      "description": "Reading a (3,7) table with delta.appendOnly=true but appendOnly absent from writerFeatures succeeds; appendOnly is writer-only.",
+      "description": "Reading a (3,7) table with delta.appendOnly=true but appendOnly absent from writerFeatures succeeds.",
       "note": "$errata.orphan_feature_metadata",
       "setup": {
         "log_actions": [
@@ -173,7 +171,7 @@
       "name": "append_only_supported_not_active_empty_commit_succeeds",
       "flavor": "supported_not_active",
       "feature": "appendOnly",
-      "description": "Appending to a (3,7)+[appendOnly] table without delta.appendOnly=true succeeds.",
+      "description": "Committing to a (3,7)+[appendOnly] table with no delta.appendOnly property succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.modern_3_7_append_only"},
@@ -188,7 +186,7 @@
       "name": "append_only_supported_not_active_read_snapshot_succeeds",
       "flavor": "supported_not_active",
       "feature": "appendOnly",
-      "description": "Reading a (3,7)+[appendOnly] table without delta.appendOnly=true succeeds.",
+      "description": "Reading a (3,7)+[appendOnly] table with no delta.appendOnly property succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.modern_3_7_append_only"},
@@ -202,7 +200,7 @@
       "ordinal": 11,
       "name": "append_only_supported_active_empty_commit_succeeds",
       "feature": "appendOnly",
-      "description": "Appending to a (3,7)+[appendOnly] table with delta.appendOnly=true succeeds.",
+      "description": "Committing to a (3,7)+[appendOnly] table with delta.appendOnly=true succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.modern_3_7_append_only"},
@@ -241,7 +239,7 @@
       "name": "append_only_read_snapshot_1_2_with_property_succeeds",
       "flavor": "legacy",
       "feature": "appendOnly",
-      "description": "Reading a (1,2) table with delta.appendOnly=true succeeds; appendOnly is writer-only.",
+      "description": "Reading a (1,2) table with delta.appendOnly=true succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.legacy_1_2"},
@@ -261,12 +259,33 @@
       "name": "append_only_supported_not_active_create_table_succeeds",
       "flavor": "supported_not_active",
       "feature": "appendOnly",
-      "description": "Creating a (3,7)+[appendOnly] table without delta.appendOnly=true succeeds; the feature is supported but not active.",
+      "description": "Creating a (3,7)+[appendOnly] table with no delta.appendOnly property succeeds.",
       "operation": {
         "type": "create_table",
         "protocol": "$protocols.modern_3_7_append_only",
         "metadata": {"schemaString": "$schemas.simple_int"}
       },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 15,
+      "name": "append_only_empty_commit_1_1_succeeds",
+      "flavor": "orphan",
+      "feature": "appendOnly",
+      "description": "Committing to a (1,1) table with delta.appendOnly=true succeeds.",
+      "note": "$errata.orphan_feature_metadata",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.legacy_1_1"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.appendOnly": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
       "expected_outcome": "success"
     }
   ]

--- a/compliance-suite/fixtures/catalog-managed.json
+++ b/compliance-suite/fixtures/catalog-managed.json
@@ -46,7 +46,7 @@
       "ordinal": 1,
       "name": "catalog_managed_create_table_3_7_feature_listed_succeeds",
       "feature": "catalogManaged",
-      "description": "Creating a (3,7)+[catalogManaged,inCommitTimestamp] table succeeds; catalogManaged is reader+writer and must appear in both feature lists.",
+      "description": "Creating a (3,7)+[catalogManaged,inCommitTimestamp] table succeeds.",
       "note": "$notes.catalog_managed_ict_write_enforcement",
       "operation": {
         "type": "create_table",
@@ -62,7 +62,7 @@
       "ordinal": 2,
       "name": "catalog_managed_read_snapshot_3_7_feature_listed_succeeds",
       "feature": "catalogManaged",
-      "description": "Reading a (3,7)+[catalogManaged,inCommitTimestamp] table succeeds; reader requirements concern catalog-based table discovery, not per-file data access.",
+      "description": "Reading a (3,7)+[catalogManaged,inCommitTimestamp] table succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.catalog_managed_3_7"},
@@ -82,7 +82,7 @@
       "name": "catalog_managed_read_snapshot_3_7_without_ict_fails",
       "feature": "catalogManaged",
       "flavor": "missing_dependency",
-      "description": "Reading a (3,7)+[catalogManaged] table that lacks inCommitTimestamp fails; catalogManaged requires inCommitTimestamp to be supported and active.",
+      "description": "Reading a (3,7)+[catalogManaged] table without inCommitTimestamp support fails.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.catalog_managed_3_7_no_ict"},
@@ -96,7 +96,7 @@
       "ordinal": 4,
       "name": "catalog_managed_empty_commit_3_7_no_ict_in_prior_commit_fails",
       "feature": "catalogManaged",
-      "description": "Appending to a (3,7)+[catalogManaged,inCommitTimestamp] table fails when the prior commit lacks inCommitTimestamp.",
+      "description": "Committing to a (3,7)+[catalogManaged,inCommitTimestamp] table fails when there is no prior commitInfo with inCommitTimestamp.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.catalog_managed_3_7"},
@@ -116,7 +116,7 @@
       "name": "catalog_managed_create_table_3_7_writer_only_fails",
       "feature": "catalogManaged",
       "flavor": "insufficient_protocol",
-      "description": "Creating a (3,7) table with catalogManaged in writerFeatures but absent from readerFeatures fails; catalogManaged is a reader+writer feature and must be listed in both.",
+      "description": "Creating a (3,7) table with catalogManaged only in writerFeatures fails.",
       "operation": {
         "type": "create_table",
         "protocol": "$protocols.catalog_managed_3_7_writer_only",
@@ -128,7 +128,7 @@
       "ordinal": 6,
       "name": "catalog_owned_preview_create_table_3_7_feature_listed_succeeds",
       "feature": "catalogOwned-preview",
-      "description": "Creating a (3,7)+[catalogOwned-preview,inCommitTimestamp] table succeeds; catalogOwned-preview is the pre-ratification name for catalogManaged, retained for backwards compatibility.",
+      "description": "Creating a (3,7)+[catalogOwned-preview,inCommitTimestamp] table succeeds.",
       "note": "$notes.catalog_owned_preview_ratification",
       "operation": {
         "type": "create_table",
@@ -144,7 +144,7 @@
       "ordinal": 7,
       "name": "catalog_owned_preview_read_snapshot_3_7_feature_listed_succeeds",
       "feature": "catalogOwned-preview",
-      "description": "Reading a (3,7)+[catalogOwned-preview,inCommitTimestamp] table succeeds; reader requirements are identical to catalogManaged.",
+      "description": "Reading a (3,7)+[catalogOwned-preview,inCommitTimestamp] table succeeds.",
       "note": "$notes.catalog_owned_preview_ratification",
       "setup": {
         "log_actions": [
@@ -164,7 +164,7 @@
       "ordinal": 8,
       "name": "catalog_managed_empty_commit_3_7_with_ict_succeeds",
       "feature": "catalogManaged",
-      "description": "Appending to a (3,7)+[catalogManaged,inCommitTimestamp] table succeeds when the prior commit contains a valid inCommitTimestamp.",
+      "description": "Committing to a (3,7)+[catalogManaged,inCommitTimestamp] table succeeds with valid prior inCommitTimestamp state.",
       "note": "$notes.catalog_managed_ict_write_enforcement",
       "setup": {
         "log_actions": [
@@ -186,7 +186,7 @@
       "name": "catalog_managed_read_snapshot_3_7_reader_only_fails",
       "feature": "catalogManaged",
       "flavor": "insufficient_protocol",
-      "description": "Reading a (3,7) table with catalogManaged in readerFeatures but absent from writerFeatures fails; listing a feature only in readerFeatures is forbidden.",
+      "description": "Reading a (3,7) table with catalogManaged only in readerFeatures fails.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.catalog_managed_3_7_reader_only"},

--- a/compliance-suite/fixtures/catalog-managed.json
+++ b/compliance-suite/fixtures/catalog-managed.json
@@ -1,0 +1,200 @@
+{
+  "$schemas": {
+    "simple_int": {
+      "type": "struct",
+      "fields": [{"name": "id", "type": "integer", "nullable": true, "metadata": {}}]
+    }
+  },
+  "$protocols": {
+    "catalog_managed_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["catalogManaged"],
+      "writerFeatures": ["catalogManaged", "inCommitTimestamp"]
+    },
+    "catalog_managed_3_7_no_ict": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["catalogManaged"],
+      "writerFeatures": ["catalogManaged"]
+    },
+    "catalog_managed_3_7_writer_only": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": ["catalogManaged"]
+    },
+    "catalog_managed_3_7_reader_only": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["catalogManaged"],
+      "writerFeatures": []
+    },
+    "catalog_owned_preview_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["catalogOwned-preview"],
+      "writerFeatures": ["catalogOwned-preview", "inCommitTimestamp"]
+    }
+  },
+  "$notes": {
+    "catalog_managed_ict_write_enforcement": "When catalogManaged is supported and active, the spec requires inCommitTimestamp to also be supported and active (feature in writerFeatures plus delta.enableInCommitTimestamps=true), and every commit must include a txnId field in its commitInfo action. setup.log_actions can model prior commitInfo state, but full write-path enforcement (action ordering/content on the new commit) requires richer write_actions coverage.",
+    "catalog_owned_preview_ratification": "catalogOwned-preview is the pre-ratification name for catalogManaged. The ratified Delta protocol spec defines only catalogManaged; catalogOwned-preview does not appear. Kernel retains support for catalogOwned-preview for backwards compatibility with tables written before ratification. The two feature names are semantically equivalent: both are reader+writer features with identical enablement, writer, and reader requirements."
+  },
+  "cases": [
+    {
+      "ordinal": 1,
+      "name": "catalog_managed_create_table_3_7_feature_listed_succeeds",
+      "feature": "catalogManaged",
+      "description": "Creating a (3,7)+[catalogManaged,inCommitTimestamp] table succeeds; catalogManaged is reader+writer and must appear in both feature lists.",
+      "note": "$notes.catalog_managed_ict_write_enforcement",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.catalog_managed_3_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {"delta.enableInCommitTimestamps": "true"}
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 2,
+      "name": "catalog_managed_read_snapshot_3_7_feature_listed_succeeds",
+      "feature": "catalogManaged",
+      "description": "Reading a (3,7)+[catalogManaged,inCommitTimestamp] table succeeds; reader requirements concern catalog-based table discovery, not per-file data access.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.catalog_managed_3_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.enableInCommitTimestamps": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 3,
+      "name": "catalog_managed_read_snapshot_3_7_without_ict_fails",
+      "feature": "catalogManaged",
+      "flavor": "missing_dependency",
+      "description": "Reading a (3,7)+[catalogManaged] table that lacks inCommitTimestamp fails; catalogManaged requires inCommitTimestamp to be supported and active.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.catalog_managed_3_7_no_ict"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 4,
+      "name": "catalog_managed_empty_commit_3_7_no_ict_in_prior_commit_fails",
+      "feature": "catalogManaged",
+      "description": "Appending to a (3,7)+[catalogManaged,inCommitTimestamp] table fails when the prior commit lacks inCommitTimestamp.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.catalog_managed_3_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.enableInCommitTimestamps": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 5,
+      "name": "catalog_managed_create_table_3_7_writer_only_fails",
+      "feature": "catalogManaged",
+      "flavor": "insufficient_protocol",
+      "description": "Creating a (3,7) table with catalogManaged in writerFeatures but absent from readerFeatures fails; catalogManaged is a reader+writer feature and must be listed in both.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.catalog_managed_3_7_writer_only",
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 6,
+      "name": "catalog_owned_preview_create_table_3_7_feature_listed_succeeds",
+      "feature": "catalogOwned-preview",
+      "description": "Creating a (3,7)+[catalogOwned-preview,inCommitTimestamp] table succeeds; catalogOwned-preview is the pre-ratification name for catalogManaged, retained for backwards compatibility.",
+      "note": "$notes.catalog_owned_preview_ratification",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.catalog_owned_preview_3_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {"delta.enableInCommitTimestamps": "true"}
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 7,
+      "name": "catalog_owned_preview_read_snapshot_3_7_feature_listed_succeeds",
+      "feature": "catalogOwned-preview",
+      "description": "Reading a (3,7)+[catalogOwned-preview,inCommitTimestamp] table succeeds; reader requirements are identical to catalogManaged.",
+      "note": "$notes.catalog_owned_preview_ratification",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.catalog_owned_preview_3_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.enableInCommitTimestamps": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 8,
+      "name": "catalog_managed_empty_commit_3_7_with_ict_succeeds",
+      "feature": "catalogManaged",
+      "description": "Appending to a (3,7)+[catalogManaged,inCommitTimestamp] table succeeds when the prior commit contains a valid inCommitTimestamp.",
+      "note": "$notes.catalog_managed_ict_write_enforcement",
+      "setup": {
+        "log_actions": [
+          {"commitInfo": {"timestamp": 0, "inCommitTimestamp": 0}},
+          {"protocol": "$protocols.catalog_managed_3_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.enableInCommitTimestamps": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 9,
+      "name": "catalog_managed_read_snapshot_3_7_reader_only_fails",
+      "feature": "catalogManaged",
+      "flavor": "insufficient_protocol",
+      "description": "Reading a (3,7) table with catalogManaged in readerFeatures but absent from writerFeatures fails; listing a feature only in readerFeatures is forbidden.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.catalog_managed_3_7_reader_only"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "failure"
+    }
+  ]
+}

--- a/compliance-suite/fixtures/change-data-feed.json
+++ b/compliance-suite/fixtures/change-data-feed.json
@@ -50,9 +50,7 @@
       "writerFeatures": ["appendOnly", "changeDataFeed"]
     }
   },
-  "$notes": {
-    "orphan_writer_feature": "At (3,7), the spec requires activation properties to be paired with the corresponding feature in writerFeatures. Writing an activation property for a feature absent from writerFeatures is invalid committed state."
-  },
+  "$notes": {},
   "cases": [
     {
       "ordinal": 1,
@@ -91,7 +89,7 @@
       "name": "change_data_feed_read_snapshot_1_4_with_property_succeeds",
       "flavor": "legacy",
       "feature": "changeDataFeed",
-      "description": "Reading a (1,4) table with delta.enableChangeDataFeed=true succeeds; changeDataFeed is writer-only.",
+      "description": "Reading a (1,4) table with delta.enableChangeDataFeed=true succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.legacy_1_4"},
@@ -111,7 +109,7 @@
       "name": "change_data_feed_empty_commit_1_4_with_property",
       "flavor": "legacy",
       "feature": "changeDataFeed",
-      "description": "Appending to a (1,4) table with delta.enableChangeDataFeed=true succeeds.",
+      "description": "Committing to a (1,4) table with delta.enableChangeDataFeed=true succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.legacy_1_4"},
@@ -128,11 +126,11 @@
     },
     {
       "ordinal": 5,
-      "name": "change_data_feed_create_table_3_7_no_feature_listed_with_property_fails",
+      "name": "change_data_feed_create_table_3_7_no_feature_listed_with_property_succeeds",
       "flavor": "orphan",
       "feature": "changeDataFeed",
-      "description": "Creating a (3,7) table with delta.enableChangeDataFeed=true but changeDataFeed absent from writerFeatures fails.",
-      "note": "$notes.orphan_writer_feature",
+      "description": "Creating a (3,7) table with delta.enableChangeDataFeed=true but changeDataFeed absent from writerFeatures succeeds.",
+      "note": "$errata.orphan_feature_metadata",
       "operation": {
         "type": "create_table",
         "protocol": "$protocols.modern_3_7",
@@ -141,14 +139,14 @@
           "schemaString": "$schemas.simple_int"
         }
       },
-      "expected_outcome": "failure"
+      "expected_outcome": "success"
     },
     {
       "ordinal": 6,
       "name": "change_data_feed_empty_commit_3_7_no_feature_listed_with_property_succeeds",
       "flavor": "orphan",
       "feature": "changeDataFeed",
-      "description": "Appending to a (3,7) table with delta.enableChangeDataFeed=true but changeDataFeed absent from writerFeatures succeeds.",
+      "description": "Committing to a (3,7) table with delta.enableChangeDataFeed=true but changeDataFeed absent from writerFeatures succeeds.",
       "note": "$errata.orphan_feature_metadata",
       "setup": {
         "log_actions": [
@@ -169,7 +167,7 @@
       "name": "change_data_feed_read_snapshot_3_7_no_feature_listed_with_property",
       "flavor": "orphan",
       "feature": "changeDataFeed",
-      "description": "Reading a (3,7) table with delta.enableChangeDataFeed=true but changeDataFeed absent from writerFeatures succeeds; changeDataFeed is writer-only.",
+      "description": "Reading a (3,7) table with delta.enableChangeDataFeed=true but changeDataFeed absent from writerFeatures succeeds.",
       "note": "$errata.orphan_feature_metadata",
       "setup": {
         "log_actions": [
@@ -205,7 +203,7 @@
       "name": "change_data_feed_supported_not_active_empty_commit_succeeds",
       "flavor": "supported_not_active",
       "feature": "changeDataFeed",
-      "description": "Appending to a (3,7)+[changeDataFeed] table without delta.enableChangeDataFeed=true succeeds.",
+      "description": "Committing to a (3,7)+[changeDataFeed] table without delta.enableChangeDataFeed=true succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.modern_3_7_change_data_feed"},
@@ -234,7 +232,7 @@
       "ordinal": 11,
       "name": "change_data_feed_supported_active_empty_commit_succeeds",
       "feature": "changeDataFeed",
-      "description": "Appending to a (3,7)+[changeDataFeed] table with delta.enableChangeDataFeed=true succeeds.",
+      "description": "Committing to a (3,7)+[changeDataFeed] table with delta.enableChangeDataFeed=true succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.modern_3_7_change_data_feed"},
@@ -325,7 +323,7 @@
       "name": "change_data_feed_supported_not_active_create_table_succeeds",
       "feature": "changeDataFeed",
       "flavor": "supported_not_active",
-      "description": "Creating a (3,7)+[changeDataFeed] table without delta.enableChangeDataFeed=true succeeds; the feature is supported but not active.",
+      "description": "Creating a (3,7)+[changeDataFeed] table without delta.enableChangeDataFeed=true succeeds.",
       "operation": {
         "type": "create_table",
         "protocol": "$protocols.modern_3_7_change_data_feed",

--- a/compliance-suite/fixtures/change-data-feed.json
+++ b/compliance-suite/fixtures/change-data-feed.json
@@ -1,0 +1,337 @@
+{
+  "$schemas": {
+    "cm_simple_int": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {"delta.columnMapping.id": 1, "delta.columnMapping.physicalName": "col-1"}
+        }
+      ]
+    },
+    "simple_int": {
+      "type": "struct",
+      "fields": [{"name": "id", "type": "integer", "nullable": true, "metadata": {}}]
+    }
+  },
+  "$protocols": {
+    "legacy_1_4": {"minReaderVersion": 1, "minWriterVersion": 4},
+    "legacy_1_3": {"minReaderVersion": 1, "minWriterVersion": 3},
+    "modern_3_7_cdf_cm": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["columnMapping"],
+      "writerFeatures": ["columnMapping", "changeDataFeed"]
+    },
+    "modern_3_7_cdf_dv": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["deletionVectors"],
+      "writerFeatures": ["deletionVectors", "changeDataFeed"]
+    },
+    "modern_3_7_change_data_feed": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": ["changeDataFeed"]
+    },
+    "modern_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": []
+    },
+    "modern_3_7_cdf_append_only": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": ["appendOnly", "changeDataFeed"]
+    }
+  },
+  "$notes": {
+    "orphan_writer_feature": "At (3,7), the spec requires activation properties to be paired with the corresponding feature in writerFeatures. Writing an activation property for a feature absent from writerFeatures is invalid committed state."
+  },
+  "cases": [
+    {
+      "ordinal": 1,
+      "name": "change_data_feed_create_table_1_4_with_property",
+      "flavor": "legacy",
+      "feature": "changeDataFeed",
+      "description": "Creating a (1,4) table with delta.enableChangeDataFeed=true succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.legacy_1_4",
+        "metadata": {
+          "configuration": {"delta.enableChangeDataFeed": "true"},
+          "schemaString": "$schemas.simple_int"
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 2,
+      "name": "change_data_feed_create_table_1_3_fails",
+      "flavor": "insufficient_protocol",
+      "feature": "changeDataFeed",
+      "description": "Creating a (1,3) table with delta.enableChangeDataFeed=true fails; changeDataFeed requires minWriterVersion>=4.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.legacy_1_3",
+        "metadata": {
+          "configuration": {"delta.enableChangeDataFeed": "true"},
+          "schemaString": "$schemas.simple_int"
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 3,
+      "name": "change_data_feed_read_snapshot_1_4_with_property_succeeds",
+      "flavor": "legacy",
+      "feature": "changeDataFeed",
+      "description": "Reading a (1,4) table with delta.enableChangeDataFeed=true succeeds; changeDataFeed is writer-only.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.legacy_1_4"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.enableChangeDataFeed": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 4,
+      "name": "change_data_feed_empty_commit_1_4_with_property",
+      "flavor": "legacy",
+      "feature": "changeDataFeed",
+      "description": "Appending to a (1,4) table with delta.enableChangeDataFeed=true succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.legacy_1_4"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.enableChangeDataFeed": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 5,
+      "name": "change_data_feed_create_table_3_7_no_feature_listed_with_property_fails",
+      "flavor": "orphan",
+      "feature": "changeDataFeed",
+      "description": "Creating a (3,7) table with delta.enableChangeDataFeed=true but changeDataFeed absent from writerFeatures fails.",
+      "note": "$notes.orphan_writer_feature",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7",
+        "metadata": {
+          "configuration": {"delta.enableChangeDataFeed": "true"},
+          "schemaString": "$schemas.simple_int"
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 6,
+      "name": "change_data_feed_empty_commit_3_7_no_feature_listed_with_property_succeeds",
+      "flavor": "orphan",
+      "feature": "changeDataFeed",
+      "description": "Appending to a (3,7) table with delta.enableChangeDataFeed=true but changeDataFeed absent from writerFeatures succeeds.",
+      "note": "$errata.orphan_feature_metadata",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.enableChangeDataFeed": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 7,
+      "name": "change_data_feed_read_snapshot_3_7_no_feature_listed_with_property",
+      "flavor": "orphan",
+      "feature": "changeDataFeed",
+      "description": "Reading a (3,7) table with delta.enableChangeDataFeed=true but changeDataFeed absent from writerFeatures succeeds; changeDataFeed is writer-only.",
+      "note": "$errata.orphan_feature_metadata",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.enableChangeDataFeed": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 8,
+      "name": "change_data_feed_create_table_3_7_feature_listed_succeeds",
+      "feature": "changeDataFeed",
+      "description": "Creating a (3,7)+[changeDataFeed] table with delta.enableChangeDataFeed=true succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7_change_data_feed",
+        "metadata": {
+          "configuration": {"delta.enableChangeDataFeed": "true"},
+          "schemaString": "$schemas.simple_int"
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 9,
+      "name": "change_data_feed_supported_not_active_empty_commit_succeeds",
+      "flavor": "supported_not_active",
+      "feature": "changeDataFeed",
+      "description": "Appending to a (3,7)+[changeDataFeed] table without delta.enableChangeDataFeed=true succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_change_data_feed"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 10,
+      "name": "change_data_feed_supported_not_active_read_snapshot_succeeds",
+      "flavor": "supported_not_active",
+      "feature": "changeDataFeed",
+      "description": "Reading a (3,7)+[changeDataFeed] table without delta.enableChangeDataFeed=true succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_change_data_feed"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 11,
+      "name": "change_data_feed_supported_active_empty_commit_succeeds",
+      "feature": "changeDataFeed",
+      "description": "Appending to a (3,7)+[changeDataFeed] table with delta.enableChangeDataFeed=true succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_change_data_feed"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.enableChangeDataFeed": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 12,
+      "name": "change_data_feed_supported_active_read_snapshot_succeeds",
+      "feature": "changeDataFeed",
+      "description": "Reading a (3,7)+[changeDataFeed] table with delta.enableChangeDataFeed=true succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_change_data_feed"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.enableChangeDataFeed": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 13,
+      "name": "change_data_feed_cm_create_table_3_7_succeeds",
+      "feature": "changeDataFeed",
+      "description": "Creating a (3,7)+[columnMapping,changeDataFeed] table with delta.enableChangeDataFeed=true succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7_cdf_cm",
+        "metadata": {
+          "schemaString": "$schemas.cm_simple_int",
+          "configuration": {
+            "delta.columnMapping.mode": "id",
+            "delta.columnMapping.maxColumnId": "1",
+            "delta.enableChangeDataFeed": "true"
+          }
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 14,
+      "name": "change_data_feed_dv_create_table_3_7_succeeds",
+      "feature": "changeDataFeed",
+      "description": "Creating a (3,7)+[deletionVectors,changeDataFeed] table with both features active succeeds; the spec imposes no mutual exclusion between CDF and deletion vectors.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7_cdf_dv",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {
+            "delta.enableDeletionVectors": "true",
+            "delta.enableChangeDataFeed": "true"
+          }
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 15,
+      "name": "change_data_feed_append_only_create_table_3_7_succeeds",
+      "feature": "changeDataFeed",
+      "description": "Creating a (3,7)+[appendOnly,changeDataFeed] table with both delta.appendOnly=true and delta.enableChangeDataFeed=true succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7_cdf_append_only",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {"delta.appendOnly": "true", "delta.enableChangeDataFeed": "true"}
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 16,
+      "name": "change_data_feed_supported_not_active_create_table_succeeds",
+      "feature": "changeDataFeed",
+      "flavor": "supported_not_active",
+      "description": "Creating a (3,7)+[changeDataFeed] table without delta.enableChangeDataFeed=true succeeds; the feature is supported but not active.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7_change_data_feed",
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "success"
+    }
+  ]
+}

--- a/compliance-suite/fixtures/check-constraints.json
+++ b/compliance-suite/fixtures/check-constraints.json
@@ -77,11 +77,11 @@
     },
     {
       "ordinal": 3,
-      "name": "check_constraints_empty_commit_3_7_no_feature_listed_with_constraint_succeeds",
+      "name": "check_constraints_empty_commit_3_7_no_feature_listed_with_constraint_fails",
       "flavor": "orphan",
       "feature": "checkConstraints",
-      "description": "Appending to a (3,7) table with a delta.constraints.* property but checkConstraints absent from writerFeatures succeeds.",
-      "note": "$errata.orphan_feature_metadata",
+      "description": "Committing to a (3,7) table with a delta.constraints.* property but checkConstraints absent from writerFeatures fails.",
+      "note": "$notes.orphan_writer_feature",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.modern_3_7"},
@@ -94,7 +94,7 @@
         ]
       },
       "operation": {"type": "empty_commit"},
-      "expected_outcome": "success"
+      "expected_outcome": "failure"
     },
     {
       "ordinal": 4,
@@ -117,7 +117,7 @@
       "name": "check_constraints_read_snapshot_3_7_no_feature_listed_with_constraint",
       "flavor": "orphan",
       "feature": "checkConstraints",
-      "description": "Reading a (3,7) table with a delta.constraints.* property but checkConstraints absent from writerFeatures succeeds; checkConstraints is writer-only.",
+      "description": "Reading a (3,7) table with a delta.constraints.* property but checkConstraints absent from writerFeatures succeeds.",
       "note": "$errata.orphan_feature_metadata",
       "setup": {
         "log_actions": [
@@ -138,7 +138,7 @@
       "name": "check_constraints_supported_not_active_empty_commit_succeeds",
       "flavor": "supported_not_active",
       "feature": "checkConstraints",
-      "description": "Appending to a (3,7)+[checkConstraints] table without any delta.constraints.* property succeeds: the feature is supported but not active.",
+      "description": "Committing to a (3,7)+[checkConstraints] table without any delta.constraints.* property succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.modern_3_7_check_constraints"},
@@ -152,7 +152,7 @@
       "ordinal": 7,
       "name": "check_constraints_supported_active_empty_commit_succeeds",
       "feature": "checkConstraints",
-      "description": "Appending to a (3,7)+[checkConstraints] table with a delta.constraints.* property succeeds.",
+      "description": "Committing to a (3,7)+[checkConstraints] table with a delta.constraints.* property succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.modern_3_7_check_constraints"},
@@ -172,7 +172,7 @@
       "name": "check_constraints_empty_commit_1_3_with_constraint_succeeds",
       "flavor": "legacy",
       "feature": "checkConstraints",
-      "description": "Appending to a (1,3) table with a delta.constraints.* property succeeds: checkConstraints are always supported at writer version 3.",
+      "description": "Committing to a (1,3) table with a delta.constraints.* property succeeds: checkConstraints are always supported at writer version 3.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.legacy_1_3"},
@@ -244,7 +244,7 @@
       "ordinal": 12,
       "name": "check_constraints_cm_empty_commit_3_7_both_features_listed_succeeds",
       "feature": "checkConstraints",
-      "description": "Appending to a (3,7)+[columnMapping,checkConstraints] table with a CM-annotated column and a constraint referencing the logical column name succeeds.",
+      "description": "Committing to a (3,7)+[columnMapping,checkConstraints] table with a CM-annotated column and a constraint referencing the logical column name succeeds.",
       "note": "$errata.sql_expression_cm_name_resolution",
       "setup": {
         "log_actions": [
@@ -284,7 +284,7 @@
       "name": "check_constraints_read_snapshot_1_3_with_constraint_succeeds",
       "flavor": "legacy",
       "feature": "checkConstraints",
-      "description": "Reading a (1,3) table with a delta.constraints.* property succeeds: checkConstraints is writer-only.",
+      "description": "Reading a (1,3) table with a delta.constraints.* property succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.legacy_1_3"},
@@ -303,7 +303,7 @@
       "ordinal": 15,
       "name": "check_constraints_read_snapshot_3_7_feature_listed_succeeds",
       "feature": "checkConstraints",
-      "description": "Reading a (3,7)+[checkConstraints] table with a delta.constraints.* property succeeds: checkConstraints is writer-only.",
+      "description": "Reading a (3,7)+[checkConstraints] table with a delta.constraints.* property succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.modern_3_7_check_constraints"},
@@ -323,7 +323,7 @@
       "name": "check_constraints_supported_not_active_read_snapshot_succeeds",
       "flavor": "supported_not_active",
       "feature": "checkConstraints",
-      "description": "Reading a (3,7)+[checkConstraints] table without any delta.constraints.* property succeeds: the feature is supported but not active.",
+      "description": "Reading a (3,7)+[checkConstraints] table without any delta.constraints.* property succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.modern_3_7_check_constraints"},

--- a/compliance-suite/fixtures/check-constraints.json
+++ b/compliance-suite/fixtures/check-constraints.json
@@ -117,7 +117,7 @@
       "name": "check_constraints_read_snapshot_3_7_no_feature_listed_with_constraint",
       "flavor": "orphan",
       "feature": "checkConstraints",
-      "description": "Reading a (3,7) table with a delta.constraints.* property but checkConstraints absent from writerFeatures succeeds.",
+      "description": "Reading a (3,7) table with a delta.constraints.* property but checkConstraints absent from writerFeatures succeeds; checkConstraints is writer-only.",
       "note": "$errata.orphan_feature_metadata",
       "setup": {
         "log_actions": [

--- a/compliance-suite/fixtures/check-constraints.json
+++ b/compliance-suite/fixtures/check-constraints.json
@@ -1,0 +1,337 @@
+{
+  "$schemas": {
+    "cm_simple_int": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {"delta.columnMapping.id": 1, "delta.columnMapping.physicalName": "col-1"}
+        }
+      ]
+    },
+    "simple_int": {
+      "type": "struct",
+      "fields": [{"name": "id", "type": "integer", "nullable": true, "metadata": {}}]
+    }
+  },
+  "$protocols": {
+    "modern_3_7_check_constraints": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": ["checkConstraints"]
+    },
+    "legacy_1_2": {"minReaderVersion": 1, "minWriterVersion": 2},
+    "modern_3_7_cm_check_constraints": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["columnMapping"],
+      "writerFeatures": ["columnMapping", "checkConstraints"]
+    },
+    "legacy_1_3": {"minReaderVersion": 1, "minWriterVersion": 3},
+    "modern_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": []
+    }
+  },
+  "$notes": {
+    "orphan_writer_feature": "At (3,7), the spec requires activation properties to be paired with the corresponding feature in writerFeatures. Writing an activation property for a feature absent from writerFeatures is invalid committed state."
+  },
+  "cases": [
+    {
+      "ordinal": 1,
+      "name": "check_constraints_create_table_1_2_fails",
+      "flavor": "insufficient_protocol",
+      "feature": "checkConstraints",
+      "description": "Creating a (1,2) table with a delta.constraints.* property fails: checkConstraints requires minWriterVersion>=3.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.legacy_1_2",
+        "metadata": {
+          "configuration": {"delta.constraints.id_positive": "id > 0"},
+          "schemaString": "$schemas.simple_int"
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 2,
+      "name": "check_constraints_create_table_3_7_no_feature_listed_with_property_fails",
+      "flavor": "orphan",
+      "feature": "checkConstraints",
+      "description": "Creating a (3,7) table with a delta.constraints.* property but checkConstraints absent from writerFeatures fails.",
+      "note": "$notes.orphan_writer_feature",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7",
+        "metadata": {
+          "configuration": {"delta.constraints.id_positive": "id > 0"},
+          "schemaString": "$schemas.simple_int"
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 3,
+      "name": "check_constraints_empty_commit_3_7_no_feature_listed_with_constraint_succeeds",
+      "flavor": "orphan",
+      "feature": "checkConstraints",
+      "description": "Appending to a (3,7) table with a delta.constraints.* property but checkConstraints absent from writerFeatures succeeds.",
+      "note": "$errata.orphan_feature_metadata",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.constraints.id_positive": "id > 0"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 4,
+      "name": "check_constraints_create_table_1_3_with_constraint",
+      "flavor": "legacy",
+      "feature": "checkConstraints",
+      "description": "Creating a (1,3) table with a delta.constraints.* property succeeds: checkConstraints are always supported at writer version 3.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.legacy_1_3",
+        "metadata": {
+          "configuration": {"delta.constraints.id_positive": "id > 0"},
+          "schemaString": "$schemas.simple_int"
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 5,
+      "name": "check_constraints_read_snapshot_3_7_no_feature_listed_with_constraint",
+      "flavor": "orphan",
+      "feature": "checkConstraints",
+      "description": "Reading a (3,7) table with a delta.constraints.* property but checkConstraints absent from writerFeatures succeeds; checkConstraints is writer-only.",
+      "note": "$errata.orphan_feature_metadata",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.constraints.id_positive": "id > 0"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 6,
+      "name": "check_constraints_supported_not_active_empty_commit_succeeds",
+      "flavor": "supported_not_active",
+      "feature": "checkConstraints",
+      "description": "Appending to a (3,7)+[checkConstraints] table without any delta.constraints.* property succeeds: the feature is supported but not active.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_check_constraints"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 7,
+      "name": "check_constraints_supported_active_empty_commit_succeeds",
+      "feature": "checkConstraints",
+      "description": "Appending to a (3,7)+[checkConstraints] table with a delta.constraints.* property succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_check_constraints"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.constraints.id_positive": "id > 0"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 8,
+      "name": "check_constraints_empty_commit_1_3_with_constraint_succeeds",
+      "flavor": "legacy",
+      "feature": "checkConstraints",
+      "description": "Appending to a (1,3) table with a delta.constraints.* property succeeds: checkConstraints are always supported at writer version 3.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.legacy_1_3"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.constraints.id_positive": "id > 0"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 9,
+      "name": "check_constraints_create_table_3_7_nonexistent_column_fails",
+      "feature": "checkConstraints",
+      "description": "Creating a (3,7)+[checkConstraints] table with a constraint expression referencing a column not in the schema fails.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7_check_constraints",
+        "metadata": {
+          "configuration": {"delta.constraints.bad": "nonexistent_col > 0"},
+          "schemaString": "$schemas.simple_int"
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 10,
+      "name": "check_constraints_create_table_3_7_multiple_constraints_succeeds",
+      "feature": "checkConstraints",
+      "description": "Creating a (3,7)+[checkConstraints] table with multiple delta.constraints.* properties succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7_check_constraints",
+        "metadata": {
+          "configuration": {
+            "delta.constraints.id_positive": "id > 0",
+            "delta.constraints.id_lt_100": "id < 100"
+          },
+          "schemaString": "$schemas.simple_int"
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 11,
+      "name": "check_constraints_cm_create_table_3_7_both_features_listed_succeeds",
+      "feature": "checkConstraints",
+      "description": "Creating a (3,7)+[columnMapping,checkConstraints] table with a CM-annotated column and a constraint referencing the logical column name succeeds.",
+      "note": "$errata.sql_expression_cm_name_resolution",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7_cm_check_constraints",
+        "metadata": {
+          "schemaString": "$schemas.cm_simple_int",
+          "configuration": {
+            "delta.columnMapping.mode": "id",
+            "delta.columnMapping.maxColumnId": "1",
+            "delta.constraints.id_positive": "id > 0"
+          }
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 12,
+      "name": "check_constraints_cm_empty_commit_3_7_both_features_listed_succeeds",
+      "feature": "checkConstraints",
+      "description": "Appending to a (3,7)+[columnMapping,checkConstraints] table with a CM-annotated column and a constraint referencing the logical column name succeeds.",
+      "note": "$errata.sql_expression_cm_name_resolution",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_cm_check_constraints"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.cm_simple_int",
+              "configuration": {
+                "delta.columnMapping.mode": "id",
+                "delta.columnMapping.maxColumnId": "1",
+                "delta.constraints.id_positive": "id > 0"
+              }
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 13,
+      "name": "check_constraints_create_table_3_7_feature_listed_succeeds",
+      "feature": "checkConstraints",
+      "description": "Creating a (3,7)+[checkConstraints] table with a delta.constraints.* property succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7_check_constraints",
+        "metadata": {
+          "configuration": {"delta.constraints.id_positive": "id > 0"},
+          "schemaString": "$schemas.simple_int"
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 14,
+      "name": "check_constraints_read_snapshot_1_3_with_constraint_succeeds",
+      "flavor": "legacy",
+      "feature": "checkConstraints",
+      "description": "Reading a (1,3) table with a delta.constraints.* property succeeds: checkConstraints is writer-only.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.legacy_1_3"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.constraints.id_positive": "id > 0"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 15,
+      "name": "check_constraints_read_snapshot_3_7_feature_listed_succeeds",
+      "feature": "checkConstraints",
+      "description": "Reading a (3,7)+[checkConstraints] table with a delta.constraints.* property succeeds: checkConstraints is writer-only.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_check_constraints"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.constraints.id_positive": "id > 0"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 16,
+      "name": "check_constraints_supported_not_active_read_snapshot_succeeds",
+      "flavor": "supported_not_active",
+      "feature": "checkConstraints",
+      "description": "Reading a (3,7)+[checkConstraints] table without any delta.constraints.* property succeeds: the feature is supported but not active.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_check_constraints"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    }
+  ]
+}

--- a/compliance-suite/fixtures/clustering.json
+++ b/compliance-suite/fixtures/clustering.json
@@ -1,0 +1,181 @@
+{
+  "$schemas": {
+    "simple_int": {
+      "type": "struct",
+      "fields": [{"name": "id", "type": "integer", "nullable": true, "metadata": {}}]
+    },
+    "simple_int_with_part": {
+      "type": "struct",
+      "fields": [
+        {"name": "id", "type": "integer", "nullable": true, "metadata": {}},
+        {"name": "part", "type": "string", "nullable": true, "metadata": {}}
+      ]
+    }
+  },
+  "$protocols": {
+    "clustering_1_7": {
+      "minReaderVersion": 1,
+      "minWriterVersion": 7,
+      "writerFeatures": ["clustering", "domainMetadata"]
+    },
+    "clustering_no_domain_1_7": {
+      "minReaderVersion": 1,
+      "minWriterVersion": 7,
+      "writerFeatures": ["clustering"]
+    }
+  },
+  "$notes": {
+    "activation": "clustering is activated solely by its presence in writerFeatures; there is no corresponding table property.",
+    "domain_metadata_required": "The spec requires domainMetadata to be co-listed in writerFeatures; clustering stores clustering column names in a domainMetadata action with domain delta.clustering.",
+    "no_partition_constraint": "The spec forbids defining a clustered and partitioned table at the same time (Writer Requirements for Clustered Table).",
+    "clustering_not_mandatory": "The spec does not require writers to cluster files on every commit; the feature flag only requires that clustering metadata semantics be understood."
+  },
+  "cases": [
+    {
+      "ordinal": 1,
+      "name": "clustering_create_table_1_7_feature_and_domain_metadata_listed_succeeds",
+      "feature": "clustering",
+      "description": "Creating a (1,7)+[clustering,domainMetadata] table succeeds.",
+      "note": "$notes.activation",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.clustering_1_7",
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 2,
+      "name": "clustering_create_table_1_7_feature_listed_missing_domain_metadata_fails",
+      "feature": "clustering",
+      "flavor": "missing_dependency",
+      "description": "Creating a (1,7)+[clustering] table without the required domainMetadata in writerFeatures fails.",
+      "note": "$notes.domain_metadata_required",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.clustering_no_domain_1_7",
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 3,
+      "name": "clustering_create_table_1_7_with_partition_columns_fails",
+      "feature": "clustering",
+      "description": "Creating a (1,7)+[clustering,domainMetadata] table with partition columns fails.",
+      "note": "$notes.no_partition_constraint",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.clustering_1_7",
+        "metadata": {"schemaString": "$schemas.simple_int_with_part", "partitionColumns": ["part"]}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 4,
+      "name": "clustering_read_snapshot_1_7_feature_and_domain_metadata_listed_succeeds",
+      "feature": "clustering",
+      "description": "Reading a (1,7)+[clustering,domainMetadata] table succeeds.",
+      "note": "$errata.clustering_missing_domain_metadata_action",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.clustering_1_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 5,
+      "name": "clustering_read_snapshot_1_7_with_delta_clustering_domain_metadata_succeeds",
+      "feature": "clustering",
+      "description": "Reading a (1,7)+[clustering,domainMetadata] table whose log contains a delta.clustering domainMetadata action succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.clustering_1_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}},
+          {
+            "domainMetadata": {
+              "domain": "delta.clustering",
+              "configuration": "{\"clusteringColumns\":[[\"id\"]]}"
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 6,
+      "name": "clustering_read_snapshot_1_7_with_partition_columns_fails",
+      "feature": "clustering",
+      "description": "Reading a (1,7)+[clustering,domainMetadata] table with partition columns fails.",
+      "note": "$errata.invalid_table_state_reader_rejection",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.clustering_1_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int_with_part",
+              "partitionColumns": ["part"]
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 7,
+      "name": "clustering_read_snapshot_1_7_clustering_without_domain_metadata_in_protocol_fails",
+      "feature": "clustering",
+      "flavor": "missing_dependency",
+      "description": "Reading a (1,7)+[clustering] table with domainMetadata absent from writerFeatures fails.",
+      "note": "$errata.invalid_table_state_reader_rejection",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.clustering_no_domain_1_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 8,
+      "name": "clustering_empty_commit_1_7_feature_and_domain_metadata_listed_succeeds",
+      "feature": "clustering",
+      "description": "Appending to a (1,7)+[clustering,domainMetadata] table succeeds.",
+      "note": "$notes.clustering_not_mandatory",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.clustering_1_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 9,
+      "name": "clustering_empty_commit_1_7_with_partition_columns_fails",
+      "feature": "clustering",
+      "description": "Appending to a (1,7)+[clustering,domainMetadata] table with partition columns fails.",
+      "note": "$notes.no_partition_constraint",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.clustering_1_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int_with_part",
+              "partitionColumns": ["part"]
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    }
+  ]
+}

--- a/compliance-suite/fixtures/clustering.json
+++ b/compliance-suite/fixtures/clustering.json
@@ -94,6 +94,7 @@
       "ordinal": 4,
       "name": "clustering_read_snapshot_1_7_feature_and_domain_metadata_listed_succeeds",
       "feature": "clustering",
+      "flavor": "missing_required_metadata",
       "description": "Reading a (1,7)+[clustering,domainMetadata] table with no delta.clustering domainMetadata action succeeds.",
       "note": "$errata.invalid_table_state_reader_rejection",
       "setup": {

--- a/compliance-suite/fixtures/clustering.json
+++ b/compliance-suite/fixtures/clustering.json
@@ -165,6 +165,7 @@
       "ordinal": 8,
       "name": "clustering_empty_commit_1_7_feature_and_domain_metadata_listed_without_delta_clustering_domain_fails",
       "feature": "clustering",
+      "flavor": "missing_required_metadata",
       "description": "Committing to a (1,7)+[clustering,domainMetadata] table without a delta.clustering domainMetadata action fails.",
       "note": "$notes.domain_metadata_action_required",
       "setup": {
@@ -221,6 +222,7 @@
       "ordinal": 11,
       "name": "clustering_empty_commit_1_7_with_delta_clustering_domain_metadata_invalid_shape_fails",
       "feature": "clustering",
+      "flavor": "invalid_metadata_content",
       "description": "Committing to a (1,7)+[clustering,domainMetadata] table fails when delta.clustering domainMetadata has invalid clusteringColumns JSON shape.",
       "note": "$notes.invalid_domain_metadata_content",
       "setup": {
@@ -242,6 +244,7 @@
       "ordinal": 12,
       "name": "clustering_empty_commit_1_7_with_delta_clustering_nonexistent_column_fails",
       "feature": "clustering",
+      "flavor": "invalid_metadata_content",
       "description": "Committing to a (1,7)+[clustering,domainMetadata] table fails when delta.clustering references a non-existent clustering column.",
       "note": "$notes.invalid_domain_metadata_content",
       "setup": {
@@ -263,6 +266,7 @@
       "ordinal": 13,
       "name": "clustering_empty_commit_3_7_column_mapping_with_logical_names_fails",
       "feature": "clustering",
+      "flavor": "invalid_metadata_content",
       "description": "Committing to a (3,7)+[columnMapping,clustering,domainMetadata] table fails when delta.clustering uses logical names instead of physical names.",
       "note": "$notes.invalid_domain_metadata_content",
       "setup": {

--- a/compliance-suite/fixtures/clustering.json
+++ b/compliance-suite/fixtures/clustering.json
@@ -4,6 +4,17 @@
       "type": "struct",
       "fields": [{"name": "id", "type": "integer", "nullable": true, "metadata": {}}]
     },
+    "cm_simple_int": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {"delta.columnMapping.id": 1, "delta.columnMapping.physicalName": "col-1"}
+        }
+      ]
+    },
     "simple_int_with_part": {
       "type": "struct",
       "fields": [
@@ -22,27 +33,35 @@
       "minReaderVersion": 1,
       "minWriterVersion": 7,
       "writerFeatures": ["clustering"]
+    },
+    "clustering_cm_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["columnMapping"],
+      "writerFeatures": ["columnMapping", "clustering", "domainMetadata"]
     }
   },
   "$notes": {
     "activation": "clustering is activated solely by its presence in writerFeatures; there is no corresponding table property.",
     "domain_metadata_required": "The spec requires domainMetadata to be co-listed in writerFeatures; clustering stores clustering column names in a domainMetadata action with domain delta.clustering.",
-    "no_partition_constraint": "The spec forbids defining a clustered and partitioned table at the same time (Writer Requirements for Clustered Table).",
+    "domain_metadata_action_required": "Under a strict reading of the clustering writer requirements, writers must include a delta.clustering domainMetadata action whenever clustering is supported.",
+    "invalid_domain_metadata_content": "The delta.clustering domainMetadata configuration must encode clusteringColumns with the required JSON shape and valid column references.",
+    "no_partition_constraint": "The spec forbids tables that are both clustered and partitioned.",
     "clustering_not_mandatory": "The spec does not require writers to cluster files on every commit; the feature flag only requires that clustering metadata semantics be understood."
   },
   "cases": [
     {
       "ordinal": 1,
-      "name": "clustering_create_table_1_7_feature_and_domain_metadata_listed_succeeds",
+      "name": "clustering_create_table_1_7_feature_and_domain_metadata_listed_without_delta_clustering_domain_fails",
       "feature": "clustering",
-      "description": "Creating a (1,7)+[clustering,domainMetadata] table succeeds.",
-      "note": "$notes.activation",
+      "description": "Creating a (1,7)+[clustering,domainMetadata] table without a delta.clustering domainMetadata action fails.",
+      "note": "$notes.domain_metadata_action_required",
       "operation": {
         "type": "create_table",
         "protocol": "$protocols.clustering_1_7",
         "metadata": {"schemaString": "$schemas.simple_int"}
       },
-      "expected_outcome": "success"
+      "expected_outcome": "failure"
     },
     {
       "ordinal": 2,
@@ -75,8 +94,8 @@
       "ordinal": 4,
       "name": "clustering_read_snapshot_1_7_feature_and_domain_metadata_listed_succeeds",
       "feature": "clustering",
-      "description": "Reading a (1,7)+[clustering,domainMetadata] table succeeds.",
-      "note": "$errata.clustering_missing_domain_metadata_action",
+      "description": "Reading a (1,7)+[clustering,domainMetadata] table with no delta.clustering domainMetadata action succeeds.",
+      "note": "$errata.invalid_table_state_reader_rejection",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.clustering_1_7"},
@@ -128,10 +147,10 @@
     },
     {
       "ordinal": 7,
-      "name": "clustering_read_snapshot_1_7_clustering_without_domain_metadata_in_protocol_fails",
+      "name": "clustering_read_snapshot_1_7_clustering_without_domain_metadata_in_protocol_succeeds",
       "feature": "clustering",
       "flavor": "missing_dependency",
-      "description": "Reading a (1,7)+[clustering] table with domainMetadata absent from writerFeatures fails.",
+      "description": "Reading a (1,7)+[clustering] table with domainMetadata absent from writerFeatures succeeds.",
       "note": "$errata.invalid_table_state_reader_rejection",
       "setup": {
         "log_actions": [
@@ -140,14 +159,14 @@
         ]
       },
       "operation": {"type": "read_snapshot"},
-      "expected_outcome": "failure"
+      "expected_outcome": "success"
     },
     {
       "ordinal": 8,
-      "name": "clustering_empty_commit_1_7_feature_and_domain_metadata_listed_succeeds",
+      "name": "clustering_empty_commit_1_7_feature_and_domain_metadata_listed_without_delta_clustering_domain_fails",
       "feature": "clustering",
-      "description": "Appending to a (1,7)+[clustering,domainMetadata] table succeeds.",
-      "note": "$notes.clustering_not_mandatory",
+      "description": "Committing to a (1,7)+[clustering,domainMetadata] table without a delta.clustering domainMetadata action fails.",
+      "note": "$notes.domain_metadata_action_required",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.clustering_1_7"},
@@ -155,13 +174,13 @@
         ]
       },
       "operation": {"type": "empty_commit"},
-      "expected_outcome": "success"
+      "expected_outcome": "failure"
     },
     {
       "ordinal": 9,
       "name": "clustering_empty_commit_1_7_with_partition_columns_fails",
       "feature": "clustering",
-      "description": "Appending to a (1,7)+[clustering,domainMetadata] table with partition columns fails.",
+      "description": "Committing to a (1,7)+[clustering,domainMetadata] table with partition columns fails.",
       "note": "$notes.no_partition_constraint",
       "setup": {
         "log_actions": [
@@ -170,6 +189,98 @@
             "metaData": {
               "schemaString": "$schemas.simple_int_with_part",
               "partitionColumns": ["part"]
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 10,
+      "name": "clustering_empty_commit_1_7_with_delta_clustering_domain_metadata_succeeds",
+      "feature": "clustering",
+      "description": "Committing to a (1,7)+[clustering,domainMetadata] table succeeds when delta.clustering domainMetadata is present.",
+      "note": "$notes.clustering_not_mandatory",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.clustering_1_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}},
+          {
+            "domainMetadata": {
+              "domain": "delta.clustering",
+              "configuration": "{\"clusteringColumns\":[[\"id\"]]}"
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 11,
+      "name": "clustering_empty_commit_1_7_with_delta_clustering_domain_metadata_invalid_shape_fails",
+      "feature": "clustering",
+      "description": "Committing to a (1,7)+[clustering,domainMetadata] table fails when delta.clustering domainMetadata has invalid clusteringColumns JSON shape.",
+      "note": "$notes.invalid_domain_metadata_content",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.clustering_1_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}},
+          {
+            "domainMetadata": {
+              "domain": "delta.clustering",
+              "configuration": "{\"clusteringColumns\":\"id\"}"
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 12,
+      "name": "clustering_empty_commit_1_7_with_delta_clustering_nonexistent_column_fails",
+      "feature": "clustering",
+      "description": "Committing to a (1,7)+[clustering,domainMetadata] table fails when delta.clustering references a non-existent clustering column.",
+      "note": "$notes.invalid_domain_metadata_content",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.clustering_1_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}},
+          {
+            "domainMetadata": {
+              "domain": "delta.clustering",
+              "configuration": "{\"clusteringColumns\":[[\"missing_col\"]]}"
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 13,
+      "name": "clustering_empty_commit_3_7_column_mapping_with_logical_names_fails",
+      "feature": "clustering",
+      "description": "Committing to a (3,7)+[columnMapping,clustering,domainMetadata] table fails when delta.clustering uses logical names instead of physical names.",
+      "note": "$notes.invalid_domain_metadata_content",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.clustering_cm_3_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.cm_simple_int",
+              "configuration": {
+                "delta.columnMapping.mode": "id",
+                "delta.columnMapping.maxColumnId": "1"
+              }
+            }
+          },
+          {
+            "domainMetadata": {
+              "domain": "delta.clustering",
+              "configuration": "{\"clusteringColumns\":[[\"id\"]]}"
             }
           }
         ]

--- a/compliance-suite/fixtures/column-mapping.json
+++ b/compliance-suite/fixtures/column-mapping.json
@@ -14,6 +14,37 @@
           "metadata": {"delta.columnMapping.id": 1, "delta.columnMapping.physicalName": "col-abc"}
         }
       ]
+    },
+    "cm_duplicate_ids": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {"delta.columnMapping.id": 1, "delta.columnMapping.physicalName": "col-1"}
+        },
+        {
+          "name": "value",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {"delta.columnMapping.id": 1, "delta.columnMapping.physicalName": "col-2"}
+        }
+      ]
+    },
+    "cm_non_int_id": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {
+            "delta.columnMapping.id": "one",
+            "delta.columnMapping.physicalName": "col-1"
+          }
+        }
+      ]
     }
   },
   "$protocols": {
@@ -24,27 +55,30 @@
       "writerFeatures": ["columnMapping"]
     },
     "legacy_1_2": {"minReaderVersion": 1, "minWriterVersion": 2},
+    "legacy_1_5": {"minReaderVersion": 1, "minWriterVersion": 5},
     "legacy_2_5": {"minReaderVersion": 2, "minWriterVersion": 5}
   },
   "$notes": {
-    "usage_tracking_rfc_gap": "The proposed columnMappingUsageTracking feature (RFC not yet accepted) adds hasDroppedOrRenamed tracking and changes physical name assignment rules. Zero fixture coverage exists. Cases should be added once the RFC is accepted."
+    "mode_annotations_required": "In columnMapping mode=name and mode=id, each field must carry both delta.columnMapping.physicalName and delta.columnMapping.id metadata.",
+    "cm_mode_effect_not_directly_observable": "These metadata-only cases verify accept/reject behavior, but they do not write/read data files. Because of that, they cannot directly verify whether delta.columnMapping.mode was actually applied (for example, via physical names or field IDs)."
   },
   "cases": [
     {
       "ordinal": 1,
-      "name": "column_mapping_name_mode_rejects_protocol_1_5",
+      "name": "column_mapping_name_mode_protocol_1_5_succeeds",
       "feature": "columnMapping",
       "flavor": "insufficient_protocol",
-      "description": "Creating a (1,5) table with mode=name fails; minReaderVersion=1 is insufficient for columnMapping.",
+      "description": "Creating a (1,5) table with mode=name succeeds but does not enable CM.",
+      "note": "$notes.cm_mode_effect_not_directly_observable",
       "operation": {
         "type": "create_table",
-        "protocol": {"minReaderVersion": 1, "minWriterVersion": 5},
+        "protocol": "$protocols.legacy_1_5",
         "metadata": {
           "configuration": {"delta.columnMapping.mode": "name"},
           "schemaString": "$schemas.simple_int"
         }
       },
-      "expected_outcome": "failure"
+      "expected_outcome": "success"
     },
     {
       "ordinal": 2,
@@ -80,34 +114,42 @@
     },
     {
       "ordinal": 4,
-      "name": "column_mapping_name_mode_missing_annotations_create_table_fails",
+      "name": "column_mapping_read_snapshot_3_7_duplicate_column_ids_fails",
       "feature": "columnMapping",
-      "flavor": "legacy",
-      "description": "Creating a (2,5) table with mode=name but no CM schema annotations fails; the committed schema would lack required physical name metadata.",
-      "operation": {
-        "type": "create_table",
-        "protocol": "$protocols.legacy_2_5",
-        "metadata": {
-          "configuration": {"delta.columnMapping.mode": "name"},
-          "schemaString": "$schemas.simple_int"
-        }
+      "flavor": "invalid_metadata_content",
+      "description": "Reading a (3,7)+[columnMapping] table fails when two fields share the same delta.columnMapping.id value.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_column_mapping"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.cm_duplicate_ids",
+              "configuration": {"delta.columnMapping.mode": "id"}
+            }
+          }
+        ]
       },
+      "operation": {"type": "read_snapshot"},
       "expected_outcome": "failure"
     },
     {
       "ordinal": 5,
-      "name": "column_mapping_id_mode_missing_annotations_create_table_fails",
+      "name": "column_mapping_read_snapshot_3_7_non_integer_column_id_fails",
       "feature": "columnMapping",
-      "flavor": "legacy",
-      "description": "Creating a (2,5) table with mode=id but no CM schema annotations fails; the committed schema would lack required physical name and id metadata.",
-      "operation": {
-        "type": "create_table",
-        "protocol": "$protocols.legacy_2_5",
-        "metadata": {
-          "configuration": {"delta.columnMapping.mode": "id"},
-          "schemaString": "$schemas.simple_int"
-        }
+      "flavor": "invalid_metadata_content",
+      "description": "Reading a (3,7)+[columnMapping] table fails when delta.columnMapping.id is not an integer.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_column_mapping"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.cm_non_int_id",
+              "configuration": {"delta.columnMapping.mode": "id"}
+            }
+          }
+        ]
       },
+      "operation": {"type": "read_snapshot"},
       "expected_outcome": "failure"
     },
     {
@@ -142,11 +184,11 @@
     },
     {
       "ordinal": 8,
-      "name": "column_mapping_orphan_metadata_without_feature_succeeds",
+      "name": "column_mapping_read_snapshot_1_2_protocol_insufficient_cm_not_honored_succeeds",
       "feature": "columnMapping",
-      "flavor": "orphan",
-      "description": "Reading a (1,2) table with CM schema annotations and mode=name succeeds.",
-      "note": "$errata.orphan_feature_metadata",
+      "flavor": "insufficient_protocol",
+      "description": "Reading a (1,2) table with CM schema annotations and mode=name succeeds; protocol (1,2) is insufficient for CM.",
+      "note": "$notes.cm_mode_effect_not_directly_observable",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.legacy_1_2"},
@@ -167,10 +209,10 @@
       "feature": "columnMapping",
       "flavor": "insufficient_protocol",
       "description": "Reading a (1,5) table with mode=name succeeds; reader v1 is insufficient for CM.",
-      "note": "$errata.column_mapping_asymmetric_protocol_support",
+      "note": "$notes.cm_mode_effect_not_directly_observable",
       "setup": {
         "log_actions": [
-          {"protocol": {"minReaderVersion": 1, "minWriterVersion": 5}},
+          {"protocol": "$protocols.legacy_1_5"},
           {
             "metaData": {
               "schemaString": "$schemas.cm_annotated",
@@ -188,7 +230,7 @@
       "feature": "columnMapping",
       "flavor": "insufficient_protocol",
       "description": "Reading a (2,4) table with mode=name succeeds; writer v4 is insufficient for CM (v5+ required).",
-      "note": "$errata.column_mapping_asymmetric_protocol_support",
+      "note": "$notes.cm_mode_effect_not_directly_observable",
       "setup": {
         "log_actions": [
           {"protocol": {"minReaderVersion": 2, "minWriterVersion": 4}},
@@ -209,7 +251,7 @@
       "feature": "columnMapping",
       "flavor": "insufficient_protocol",
       "description": "Reading a (1,7)+[columnMapping in writerFeatures] table with mode=name succeeds; reader v1 is insufficient for CM.",
-      "note": "$errata.column_mapping_asymmetric_protocol_support",
+      "note": "$notes.cm_mode_effect_not_directly_observable",
       "setup": {
         "log_actions": [
           {
@@ -274,8 +316,9 @@
       "ordinal": 14,
       "name": "column_mapping_read_snapshot_2_7_cm_in_writer_features_reader_v2_succeeds",
       "feature": "columnMapping",
-      "flavor": "legacy",
+      "flavor": "insufficient_protocol",
       "description": "Reading a (2,7)+[columnMapping in writerFeatures] table with mode=name succeeds; reader v2 honors CM mode.",
+      "note": "$notes.cm_mode_effect_not_directly_observable",
       "setup": {
         "log_actions": [
           {
@@ -301,7 +344,8 @@
       "name": "column_mapping_supported_not_active_read_snapshot_succeeds",
       "feature": "columnMapping",
       "flavor": "supported_not_active",
-      "description": "Reading a (3,7)+[columnMapping] table without delta.columnMapping.mode set succeeds.",
+      "description": "Reading a (3,7)+[columnMapping] table without delta.columnMapping.mode set succeeds; CM is supported but not active.",
+      "note": "$notes.cm_mode_effect_not_directly_observable",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.modern_3_7_column_mapping"},
@@ -317,6 +361,7 @@
       "feature": "columnMapping",
       "flavor": "supported_not_active",
       "description": "Reading a (3,7)+[columnMapping] table with mode=none succeeds; readers use display names directly.",
+      "note": "$notes.cm_mode_effect_not_directly_observable",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.modern_3_7_column_mapping"},
@@ -374,7 +419,7 @@
       "name": "column_mapping_empty_commit_2_5_name_mode_succeeds",
       "feature": "columnMapping",
       "flavor": "legacy",
-      "description": "Appending to a (2,5) table with mode=name and CM schema annotations succeeds.",
+      "description": "Committing to a (2,5) table with mode=name and CM schema annotations succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.legacy_2_5"},
@@ -394,7 +439,7 @@
       "name": "column_mapping_empty_commit_2_5_id_mode_succeeds",
       "feature": "columnMapping",
       "flavor": "legacy",
-      "description": "Appending to a (2,5) table with mode=id and CM schema annotations succeeds.",
+      "description": "Committing to a (2,5) table with mode=id and CM schema annotations succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.legacy_2_5"},
@@ -413,7 +458,7 @@
       "ordinal": 21,
       "name": "column_mapping_empty_commit_3_7_name_mode_succeeds",
       "feature": "columnMapping",
-      "description": "Appending to a (3,7)+[columnMapping] table with mode=name and CM schema annotations succeeds.",
+      "description": "Committing to a (3,7)+[columnMapping] table with mode=name and CM schema annotations succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.modern_3_7_column_mapping"},
@@ -432,7 +477,7 @@
       "ordinal": 22,
       "name": "column_mapping_empty_commit_3_7_id_mode_succeeds",
       "feature": "columnMapping",
-      "description": "Appending to a (3,7)+[columnMapping] table with mode=id and CM schema annotations succeeds.",
+      "description": "Committing to a (3,7)+[columnMapping] table with mode=id and CM schema annotations succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.modern_3_7_column_mapping"},
@@ -451,7 +496,9 @@
       "ordinal": 23,
       "name": "column_mapping_name_mode_missing_annotations_create_table_3_7_fails",
       "feature": "columnMapping",
-      "description": "Creating a (3,7)+[columnMapping] table with mode=name but no CM schema annotations fails; every field must carry delta.columnMapping.physicalName metadata when mode=name is active.",
+      "flavor": "missing_required_metadata",
+      "description": "Creating a (3,7)+[columnMapping] table with mode=name but no CM schema annotations fails.",
+      "note": "$notes.mode_annotations_required",
       "operation": {
         "type": "create_table",
         "protocol": "$protocols.modern_3_7_column_mapping",
@@ -466,7 +513,9 @@
       "ordinal": 24,
       "name": "column_mapping_id_mode_missing_annotations_create_table_3_7_fails",
       "feature": "columnMapping",
-      "description": "Creating a (3,7)+[columnMapping] table with mode=id but no CM schema annotations fails; fields need both delta.columnMapping.physicalName and delta.columnMapping.id metadata.",
+      "flavor": "missing_required_metadata",
+      "description": "Creating a (3,7)+[columnMapping] table with mode=id but no CM schema annotations fails.",
+      "note": "$notes.mode_annotations_required",
       "operation": {
         "type": "create_table",
         "protocol": "$protocols.modern_3_7_column_mapping",
@@ -481,7 +530,9 @@
       "ordinal": 25,
       "name": "column_mapping_name_mode_missing_annotations_empty_commit_3_7_fails",
       "feature": "columnMapping",
-      "description": "Appending to a (3,7)+[columnMapping] table with mode=name but no CM schema annotations fails; every field must carry delta.columnMapping.physicalName metadata when mode=name is active.",
+      "flavor": "missing_required_metadata",
+      "description": "Committing to a (3,7)+[columnMapping] table with mode=name but no CM schema annotations fails.",
+      "note": "$notes.mode_annotations_required",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.modern_3_7_column_mapping"},
@@ -500,7 +551,9 @@
       "ordinal": 26,
       "name": "column_mapping_id_mode_missing_annotations_empty_commit_3_7_fails",
       "feature": "columnMapping",
-      "description": "Appending to a (3,7)+[columnMapping] table with mode=id but no CM schema annotations fails; fields need both delta.columnMapping.physicalName and delta.columnMapping.id metadata.",
+      "flavor": "missing_required_metadata",
+      "description": "Committing to a (3,7)+[columnMapping] table with mode=id but no CM schema annotations fails.",
+      "note": "$notes.mode_annotations_required",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.modern_3_7_column_mapping"},

--- a/compliance-suite/fixtures/column-mapping.json
+++ b/compliance-suite/fixtures/column-mapping.json
@@ -1,0 +1,519 @@
+{
+  "$schemas": {
+    "simple_int": {
+      "type": "struct",
+      "fields": [{"name": "id", "type": "integer", "nullable": true, "metadata": {}}]
+    },
+    "cm_annotated": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {"delta.columnMapping.id": 1, "delta.columnMapping.physicalName": "col-abc"}
+        }
+      ]
+    }
+  },
+  "$protocols": {
+    "modern_3_7_column_mapping": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["columnMapping"],
+      "writerFeatures": ["columnMapping"]
+    },
+    "legacy_1_2": {"minReaderVersion": 1, "minWriterVersion": 2},
+    "legacy_2_5": {"minReaderVersion": 2, "minWriterVersion": 5}
+  },
+  "$notes": {
+    "usage_tracking_rfc_gap": "The proposed columnMappingUsageTracking feature (RFC not yet accepted) adds hasDroppedOrRenamed tracking and changes physical name assignment rules. Zero fixture coverage exists. Cases should be added once the RFC is accepted."
+  },
+  "cases": [
+    {
+      "ordinal": 1,
+      "name": "column_mapping_name_mode_rejects_protocol_1_5",
+      "feature": "columnMapping",
+      "flavor": "insufficient_protocol",
+      "description": "Creating a (1,5) table with mode=name fails; minReaderVersion=1 is insufficient for columnMapping.",
+      "operation": {
+        "type": "create_table",
+        "protocol": {"minReaderVersion": 1, "minWriterVersion": 5},
+        "metadata": {
+          "configuration": {"delta.columnMapping.mode": "name"},
+          "schemaString": "$schemas.simple_int"
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 2,
+      "name": "column_mapping_name_mode_accepts_protocol_2_5",
+      "feature": "columnMapping",
+      "flavor": "legacy",
+      "description": "Creating a (2,5) table with mode=name and CM schema annotations succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.legacy_2_5",
+        "metadata": {
+          "configuration": {"delta.columnMapping.mode": "name"},
+          "schemaString": "$schemas.cm_annotated"
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 3,
+      "name": "column_mapping_id_mode_accepts_protocol_2_5",
+      "feature": "columnMapping",
+      "flavor": "legacy",
+      "description": "Creating a (2,5) table with mode=id and CM schema annotations succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.legacy_2_5",
+        "metadata": {
+          "configuration": {"delta.columnMapping.mode": "id"},
+          "schemaString": "$schemas.cm_annotated"
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 4,
+      "name": "column_mapping_name_mode_missing_annotations_create_table_fails",
+      "feature": "columnMapping",
+      "flavor": "legacy",
+      "description": "Creating a (2,5) table with mode=name but no CM schema annotations fails; the committed schema would lack required physical name metadata.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.legacy_2_5",
+        "metadata": {
+          "configuration": {"delta.columnMapping.mode": "name"},
+          "schemaString": "$schemas.simple_int"
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 5,
+      "name": "column_mapping_id_mode_missing_annotations_create_table_fails",
+      "feature": "columnMapping",
+      "flavor": "legacy",
+      "description": "Creating a (2,5) table with mode=id but no CM schema annotations fails; the committed schema would lack required physical name and id metadata.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.legacy_2_5",
+        "metadata": {
+          "configuration": {"delta.columnMapping.mode": "id"},
+          "schemaString": "$schemas.simple_int"
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 6,
+      "name": "column_mapping_name_mode_accepts_protocol_3_7_feature_listed",
+      "feature": "columnMapping",
+      "description": "Creating a (3,7)+[columnMapping] table with mode=name and CM schema annotations succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7_column_mapping",
+        "metadata": {
+          "configuration": {"delta.columnMapping.mode": "name"},
+          "schemaString": "$schemas.cm_annotated"
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 7,
+      "name": "column_mapping_id_mode_accepts_protocol_3_7_feature_listed",
+      "feature": "columnMapping",
+      "description": "Creating a (3,7)+[columnMapping] table with mode=id and CM schema annotations succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7_column_mapping",
+        "metadata": {
+          "configuration": {"delta.columnMapping.mode": "id"},
+          "schemaString": "$schemas.cm_annotated"
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 8,
+      "name": "column_mapping_orphan_metadata_without_feature_succeeds",
+      "feature": "columnMapping",
+      "flavor": "orphan",
+      "description": "Reading a (1,2) table with CM schema annotations and mode=name succeeds.",
+      "note": "$errata.orphan_feature_metadata",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.legacy_1_2"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.cm_annotated",
+              "configuration": {"delta.columnMapping.mode": "name"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 9,
+      "name": "column_mapping_read_snapshot_1_5_reader_v1_ignores_mode_succeeds",
+      "feature": "columnMapping",
+      "flavor": "insufficient_protocol",
+      "description": "Reading a (1,5) table with mode=name succeeds; reader v1 is insufficient for CM.",
+      "note": "$errata.column_mapping_asymmetric_protocol_support",
+      "setup": {
+        "log_actions": [
+          {"protocol": {"minReaderVersion": 1, "minWriterVersion": 5}},
+          {
+            "metaData": {
+              "schemaString": "$schemas.cm_annotated",
+              "configuration": {"delta.columnMapping.mode": "name"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 10,
+      "name": "column_mapping_read_snapshot_2_4_writer_insufficient_cm_not_honored_succeeds",
+      "feature": "columnMapping",
+      "flavor": "insufficient_protocol",
+      "description": "Reading a (2,4) table with mode=name succeeds; writer v4 is insufficient for CM (v5+ required).",
+      "note": "$errata.column_mapping_asymmetric_protocol_support",
+      "setup": {
+        "log_actions": [
+          {"protocol": {"minReaderVersion": 2, "minWriterVersion": 4}},
+          {
+            "metaData": {
+              "schemaString": "$schemas.cm_annotated",
+              "configuration": {"delta.columnMapping.mode": "name"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 11,
+      "name": "column_mapping_read_snapshot_1_7_reader_v1_ignores_writer_feature_succeeds",
+      "feature": "columnMapping",
+      "flavor": "insufficient_protocol",
+      "description": "Reading a (1,7)+[columnMapping in writerFeatures] table with mode=name succeeds; reader v1 is insufficient for CM.",
+      "note": "$errata.column_mapping_asymmetric_protocol_support",
+      "setup": {
+        "log_actions": [
+          {
+            "protocol": {
+              "minReaderVersion": 1,
+              "minWriterVersion": 7,
+              "writerFeatures": ["columnMapping"]
+            }
+          },
+          {
+            "metaData": {
+              "schemaString": "$schemas.cm_annotated",
+              "configuration": {"delta.columnMapping.mode": "name"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 12,
+      "name": "column_mapping_read_snapshot_2_5_name_mode_succeeds",
+      "feature": "columnMapping",
+      "flavor": "legacy",
+      "description": "Reading a (2,5) table with mode=name and CM schema annotations succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.legacy_2_5"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.cm_annotated",
+              "configuration": {"delta.columnMapping.mode": "name"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 13,
+      "name": "column_mapping_read_snapshot_2_5_id_mode_succeeds",
+      "feature": "columnMapping",
+      "flavor": "legacy",
+      "description": "Reading a (2,5) table with mode=id and CM schema annotations succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.legacy_2_5"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.cm_annotated",
+              "configuration": {"delta.columnMapping.mode": "id"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 14,
+      "name": "column_mapping_read_snapshot_2_7_cm_in_writer_features_reader_v2_succeeds",
+      "feature": "columnMapping",
+      "flavor": "legacy",
+      "description": "Reading a (2,7)+[columnMapping in writerFeatures] table with mode=name succeeds; reader v2 honors CM mode.",
+      "setup": {
+        "log_actions": [
+          {
+            "protocol": {
+              "minReaderVersion": 2,
+              "minWriterVersion": 7,
+              "writerFeatures": ["columnMapping"]
+            }
+          },
+          {
+            "metaData": {
+              "schemaString": "$schemas.cm_annotated",
+              "configuration": {"delta.columnMapping.mode": "name"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 15,
+      "name": "column_mapping_supported_not_active_read_snapshot_succeeds",
+      "feature": "columnMapping",
+      "flavor": "supported_not_active",
+      "description": "Reading a (3,7)+[columnMapping] table without delta.columnMapping.mode set succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_column_mapping"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 16,
+      "name": "column_mapping_mode_none_read_snapshot_succeeds",
+      "feature": "columnMapping",
+      "flavor": "supported_not_active",
+      "description": "Reading a (3,7)+[columnMapping] table with mode=none succeeds; readers use display names directly.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_column_mapping"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.columnMapping.mode": "none"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 17,
+      "name": "column_mapping_read_snapshot_3_7_name_mode_succeeds",
+      "feature": "columnMapping",
+      "description": "Reading a (3,7)+[columnMapping] table with mode=name and CM schema annotations succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_column_mapping"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.cm_annotated",
+              "configuration": {"delta.columnMapping.mode": "name"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 18,
+      "name": "column_mapping_read_snapshot_3_7_id_mode_succeeds",
+      "feature": "columnMapping",
+      "description": "Reading a (3,7)+[columnMapping] table with mode=id and CM schema annotations succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_column_mapping"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.cm_annotated",
+              "configuration": {"delta.columnMapping.mode": "id"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 19,
+      "name": "column_mapping_empty_commit_2_5_name_mode_succeeds",
+      "feature": "columnMapping",
+      "flavor": "legacy",
+      "description": "Appending to a (2,5) table with mode=name and CM schema annotations succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.legacy_2_5"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.cm_annotated",
+              "configuration": {"delta.columnMapping.mode": "name"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 20,
+      "name": "column_mapping_empty_commit_2_5_id_mode_succeeds",
+      "feature": "columnMapping",
+      "flavor": "legacy",
+      "description": "Appending to a (2,5) table with mode=id and CM schema annotations succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.legacy_2_5"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.cm_annotated",
+              "configuration": {"delta.columnMapping.mode": "id"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 21,
+      "name": "column_mapping_empty_commit_3_7_name_mode_succeeds",
+      "feature": "columnMapping",
+      "description": "Appending to a (3,7)+[columnMapping] table with mode=name and CM schema annotations succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_column_mapping"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.cm_annotated",
+              "configuration": {"delta.columnMapping.mode": "name"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 22,
+      "name": "column_mapping_empty_commit_3_7_id_mode_succeeds",
+      "feature": "columnMapping",
+      "description": "Appending to a (3,7)+[columnMapping] table with mode=id and CM schema annotations succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_column_mapping"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.cm_annotated",
+              "configuration": {"delta.columnMapping.mode": "id"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 23,
+      "name": "column_mapping_name_mode_missing_annotations_create_table_3_7_fails",
+      "feature": "columnMapping",
+      "description": "Creating a (3,7)+[columnMapping] table with mode=name but no CM schema annotations fails; every field must carry delta.columnMapping.physicalName metadata when mode=name is active.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7_column_mapping",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {"delta.columnMapping.mode": "name"}
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 24,
+      "name": "column_mapping_id_mode_missing_annotations_create_table_3_7_fails",
+      "feature": "columnMapping",
+      "description": "Creating a (3,7)+[columnMapping] table with mode=id but no CM schema annotations fails; fields need both delta.columnMapping.physicalName and delta.columnMapping.id metadata.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7_column_mapping",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {"delta.columnMapping.mode": "id"}
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 25,
+      "name": "column_mapping_name_mode_missing_annotations_empty_commit_3_7_fails",
+      "feature": "columnMapping",
+      "description": "Appending to a (3,7)+[columnMapping] table with mode=name but no CM schema annotations fails; every field must carry delta.columnMapping.physicalName metadata when mode=name is active.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_column_mapping"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.columnMapping.mode": "name"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 26,
+      "name": "column_mapping_id_mode_missing_annotations_empty_commit_3_7_fails",
+      "feature": "columnMapping",
+      "description": "Appending to a (3,7)+[columnMapping] table with mode=id but no CM schema annotations fails; fields need both delta.columnMapping.physicalName and delta.columnMapping.id metadata.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_column_mapping"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.columnMapping.mode": "id"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    }
+  ]
+}

--- a/compliance-suite/fixtures/deletion-vectors.json
+++ b/compliance-suite/fixtures/deletion-vectors.json
@@ -91,10 +91,10 @@
     },
     {
       "ordinal": 5,
-      "name": "deletion_vectors_supported_not_active_read_snapshot_succeeds",
+      "name": "deletion_vectors_read_snapshot_supported_not_active_succeeds",
       "feature": "deletionVectors",
       "flavor": "supported_not_active",
-      "description": "Reading a (3,7)+[deletionVectors] table without delta.enableDeletionVectors=true succeeds.",
+      "description": "Reading a (3,7)+[deletionVectors] table without delta.enableDeletionVectors property succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.dv_3_7"},
@@ -127,40 +127,9 @@
     },
     {
       "ordinal": 7,
-      "name": "deletion_vectors_read_snapshot_3_7_dv_bearing_add_without_property_succeeds",
-      "feature": "deletionVectors",
-      "description": "Reading a (3,7)+[deletionVectors] table with a DV-bearing add and no delta.enableDeletionVectors=true succeeds; readers honor DVs on add actions even when the property is absent.",
-      "setup": {
-        "log_actions": [
-          {"protocol": "$protocols.dv_3_7"},
-          {"metaData": {"schemaString": "$schemas.simple_int"}},
-          {
-            "add": {
-              "path": "part-0.parquet",
-              "partitionValues": {},
-              "size": 100,
-              "modificationTime": 0,
-              "dataChange": true,
-              "stats": "{\"numRecords\":100}",
-              "deletionVector": {
-                "storageType": "u",
-                "pathOrInlineDv": "ab^-aqEH=-15MacIoDvGr1mDdLSjUDO8nEYfVeKEApE",
-                "offset": null,
-                "sizeInBytes": 36,
-                "cardinality": 1
-              }
-            }
-          }
-        ]
-      },
-      "operation": {"type": "read_snapshot"},
-      "expected_outcome": "success"
-    },
-    {
-      "ordinal": 8,
       "name": "deletion_vectors_empty_commit_3_7_feature_listed_succeeds",
       "feature": "deletionVectors",
-      "description": "Appending to a (3,7)+[deletionVectors] table with delta.enableDeletionVectors=true succeeds.",
+      "description": "Committing to a (3,7)+[deletionVectors] table with delta.enableDeletionVectors=true succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.dv_3_7"},
@@ -176,11 +145,11 @@
       "expected_outcome": "success"
     },
     {
-      "ordinal": 9,
+      "ordinal": 8,
       "name": "deletion_vectors_empty_commit_supported_not_active_succeeds",
       "feature": "deletionVectors",
       "flavor": "supported_not_active",
-      "description": "Appending to a (3,7)+[deletionVectors] table without delta.enableDeletionVectors=true succeeds; writers must not write new DVs without the property.",
+      "description": "Committing to a (3,7)+[deletionVectors] table without delta.enableDeletionVectors=true succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.dv_3_7"},
@@ -191,11 +160,11 @@
       "expected_outcome": "success"
     },
     {
-      "ordinal": 10,
+      "ordinal": 9,
       "name": "deletion_vectors_empty_commit_3_7_orphan_property_succeeds",
       "feature": "deletionVectors",
       "flavor": "orphan",
-      "description": "Appending to a (3,7) table with delta.enableDeletionVectors=true but deletionVectors absent from both feature lists succeeds.",
+      "description": "Committing to a (3,7) table with delta.enableDeletionVectors=true but deletionVectors absent from both feature lists succeeds.",
       "note": "$errata.orphan_feature_metadata",
       "setup": {
         "log_actions": [
@@ -212,11 +181,11 @@
       "expected_outcome": "success"
     },
     {
-      "ordinal": 11,
+      "ordinal": 10,
       "name": "deletion_vectors_create_table_supported_not_active_succeeds",
       "feature": "deletionVectors",
       "flavor": "supported_not_active",
-      "description": "Creating a (3,7)+[deletionVectors] table without delta.enableDeletionVectors=true succeeds; the feature is supported but not active.",
+      "description": "Creating a (3,7)+[deletionVectors] table without delta.enableDeletionVectors=true succeeds.",
       "operation": {
         "type": "create_table",
         "protocol": "$protocols.dv_3_7",
@@ -225,66 +194,60 @@
       "expected_outcome": "success"
     },
     {
-      "ordinal": 12,
-      "name": "deletion_vectors_read_snapshot_3_7_dv_bearing_add_missing_num_records_fails",
+      "ordinal": 11,
+      "name": "deletion_vectors_create_table_supported_not_active_false_property_succeeds",
       "feature": "deletionVectors",
-      "description": "Reading a (3,7)+[deletionVectors] table fails when an add action carries a deletionVector but omits numRecords from stats; DV-bearing adds require numRecords.",
+      "flavor": "supported_not_active",
+      "description": "Creating a (3,7)+[deletionVectors] table with delta.enableDeletionVectors=false succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.dv_3_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {"delta.enableDeletionVectors": "false"}
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 12,
+      "name": "deletion_vectors_read_snapshot_supported_not_active_false_property_succeeds",
+      "feature": "deletionVectors",
+      "flavor": "supported_not_active",
+      "description": "Reading a (3,7)+[deletionVectors] table with delta.enableDeletionVectors=false succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.dv_3_7"},
-          {"metaData": {"schemaString": "$schemas.simple_int"}},
           {
-            "add": {
-              "path": "part-0.parquet",
-              "partitionValues": {},
-              "size": 100,
-              "modificationTime": 0,
-              "dataChange": true,
-              "deletionVector": {
-                "storageType": "u",
-                "pathOrInlineDv": "ab^-aqEH=-15MacIoDvGr1mDdLSjUDO8nEYfVeKEApE",
-                "offset": null,
-                "sizeInBytes": 36,
-                "cardinality": 1
-              }
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.enableDeletionVectors": "false"}
             }
           }
         ]
       },
       "operation": {"type": "read_snapshot"},
-      "expected_outcome": "failure"
+      "expected_outcome": "success"
     },
     {
       "ordinal": 13,
-      "name": "deletion_vectors_read_snapshot_insufficient_protocol_with_dv_add_fails",
+      "name": "deletion_vectors_empty_commit_supported_not_active_false_property_succeeds",
       "feature": "deletionVectors",
-      "flavor": "insufficient_protocol",
-      "description": "Reading a table fails when an add action carries a deletionVector but the protocol does not support deletionVectors.",
+      "flavor": "supported_not_active",
+      "description": "Committing to a (3,7)+[deletionVectors] table with delta.enableDeletionVectors=false succeeds.",
       "setup": {
         "log_actions": [
-          {"protocol": "$protocols.legacy_1_2"},
-          {"metaData": {"schemaString": "$schemas.simple_int"}},
+          {"protocol": "$protocols.dv_3_7"},
           {
-            "add": {
-              "path": "part-0.parquet",
-              "partitionValues": {},
-              "size": 100,
-              "modificationTime": 0,
-              "dataChange": true,
-              "stats": "{\"numRecords\":100}",
-              "deletionVector": {
-                "storageType": "u",
-                "pathOrInlineDv": "ab^-aqEH=-15MacIoDvGr1mDdLSjUDO8nEYfVeKEApE",
-                "offset": null,
-                "sizeInBytes": 36,
-                "cardinality": 1
-              }
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.enableDeletionVectors": "false"}
             }
           }
         ]
       },
-      "operation": {"type": "read_snapshot"},
-      "expected_outcome": "failure"
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
     }
   ]
 }

--- a/compliance-suite/fixtures/deletion-vectors.json
+++ b/compliance-suite/fixtures/deletion-vectors.json
@@ -1,0 +1,290 @@
+{
+  "$schemas": {
+    "simple_int": {
+      "type": "struct",
+      "fields": [{"name": "id", "type": "integer", "nullable": true, "metadata": {}}]
+    }
+  },
+  "$protocols": {
+    "dv_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["deletionVectors"],
+      "writerFeatures": ["deletionVectors"]
+    },
+    "modern_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": []
+    },
+    "legacy_1_2": {"minReaderVersion": 1, "minWriterVersion": 2}
+  },
+  "$notes": {},
+  "cases": [
+    {
+      "ordinal": 1,
+      "name": "deletion_vectors_create_table_3_7_feature_listed_succeeds",
+      "feature": "deletionVectors",
+      "description": "Creating a (3,7)+[deletionVectors] table with delta.enableDeletionVectors=true succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.dv_3_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {"delta.enableDeletionVectors": "true"}
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 2,
+      "name": "deletion_vectors_create_table_1_2_fails",
+      "feature": "deletionVectors",
+      "flavor": "insufficient_protocol",
+      "description": "Creating a (1,2) table with delta.enableDeletionVectors=true fails; deletionVectors requires (3,7) with the feature listed in both feature arrays.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.legacy_1_2",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {"delta.enableDeletionVectors": "true"}
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 3,
+      "name": "deletion_vectors_create_table_3_7_orphan_property_succeeds",
+      "feature": "deletionVectors",
+      "flavor": "orphan",
+      "description": "Creating a (3,7) table with delta.enableDeletionVectors=true but deletionVectors absent from both feature lists succeeds.",
+      "note": "$errata.orphan_feature_metadata",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {"delta.enableDeletionVectors": "true"}
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 4,
+      "name": "deletion_vectors_read_snapshot_3_7_feature_listed_succeeds",
+      "feature": "deletionVectors",
+      "description": "Reading a (3,7)+[deletionVectors] table with delta.enableDeletionVectors=true succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.dv_3_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.enableDeletionVectors": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 5,
+      "name": "deletion_vectors_supported_not_active_read_snapshot_succeeds",
+      "feature": "deletionVectors",
+      "flavor": "supported_not_active",
+      "description": "Reading a (3,7)+[deletionVectors] table without delta.enableDeletionVectors=true succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.dv_3_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 6,
+      "name": "deletion_vectors_read_snapshot_3_7_orphan_property_succeeds",
+      "feature": "deletionVectors",
+      "flavor": "orphan",
+      "description": "Reading a (3,7) table with delta.enableDeletionVectors=true but deletionVectors absent from both feature lists succeeds.",
+      "note": "$errata.orphan_feature_metadata",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.enableDeletionVectors": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 7,
+      "name": "deletion_vectors_read_snapshot_3_7_dv_bearing_add_without_property_succeeds",
+      "feature": "deletionVectors",
+      "description": "Reading a (3,7)+[deletionVectors] table with a DV-bearing add and no delta.enableDeletionVectors=true succeeds; readers honor DVs on add actions even when the property is absent.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.dv_3_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}},
+          {
+            "add": {
+              "path": "part-0.parquet",
+              "partitionValues": {},
+              "size": 100,
+              "modificationTime": 0,
+              "dataChange": true,
+              "stats": "{\"numRecords\":100}",
+              "deletionVector": {
+                "storageType": "u",
+                "pathOrInlineDv": "ab^-aqEH=-15MacIoDvGr1mDdLSjUDO8nEYfVeKEApE",
+                "offset": null,
+                "sizeInBytes": 36,
+                "cardinality": 1
+              }
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 8,
+      "name": "deletion_vectors_empty_commit_3_7_feature_listed_succeeds",
+      "feature": "deletionVectors",
+      "description": "Appending to a (3,7)+[deletionVectors] table with delta.enableDeletionVectors=true succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.dv_3_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.enableDeletionVectors": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 9,
+      "name": "deletion_vectors_empty_commit_supported_not_active_succeeds",
+      "feature": "deletionVectors",
+      "flavor": "supported_not_active",
+      "description": "Appending to a (3,7)+[deletionVectors] table without delta.enableDeletionVectors=true succeeds; writers must not write new DVs without the property.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.dv_3_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 10,
+      "name": "deletion_vectors_empty_commit_3_7_orphan_property_succeeds",
+      "feature": "deletionVectors",
+      "flavor": "orphan",
+      "description": "Appending to a (3,7) table with delta.enableDeletionVectors=true but deletionVectors absent from both feature lists succeeds.",
+      "note": "$errata.orphan_feature_metadata",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.enableDeletionVectors": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 11,
+      "name": "deletion_vectors_create_table_supported_not_active_succeeds",
+      "feature": "deletionVectors",
+      "flavor": "supported_not_active",
+      "description": "Creating a (3,7)+[deletionVectors] table without delta.enableDeletionVectors=true succeeds; the feature is supported but not active.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.dv_3_7",
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 12,
+      "name": "deletion_vectors_read_snapshot_3_7_dv_bearing_add_missing_num_records_fails",
+      "feature": "deletionVectors",
+      "description": "Reading a (3,7)+[deletionVectors] table fails when an add action carries a deletionVector but omits numRecords from stats; DV-bearing adds require numRecords.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.dv_3_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}},
+          {
+            "add": {
+              "path": "part-0.parquet",
+              "partitionValues": {},
+              "size": 100,
+              "modificationTime": 0,
+              "dataChange": true,
+              "deletionVector": {
+                "storageType": "u",
+                "pathOrInlineDv": "ab^-aqEH=-15MacIoDvGr1mDdLSjUDO8nEYfVeKEApE",
+                "offset": null,
+                "sizeInBytes": 36,
+                "cardinality": 1
+              }
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 13,
+      "name": "deletion_vectors_read_snapshot_insufficient_protocol_with_dv_add_fails",
+      "feature": "deletionVectors",
+      "flavor": "insufficient_protocol",
+      "description": "Reading a table fails when an add action carries a deletionVector but the protocol does not support deletionVectors.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.legacy_1_2"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}},
+          {
+            "add": {
+              "path": "part-0.parquet",
+              "partitionValues": {},
+              "size": 100,
+              "modificationTime": 0,
+              "dataChange": true,
+              "stats": "{\"numRecords\":100}",
+              "deletionVector": {
+                "storageType": "u",
+                "pathOrInlineDv": "ab^-aqEH=-15MacIoDvGr1mDdLSjUDO8nEYfVeKEApE",
+                "offset": null,
+                "sizeInBytes": 36,
+                "cardinality": 1
+              }
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "failure"
+    }
+  ]
+}

--- a/compliance-suite/fixtures/domain-metadata.json
+++ b/compliance-suite/fixtures/domain-metadata.json
@@ -1,0 +1,92 @@
+{
+  "$schemas": {
+    "simple_int": {
+      "type": "struct",
+      "fields": [{"name": "id", "type": "integer", "nullable": true, "metadata": {}}]
+    }
+  },
+  "$protocols": {
+    "domain_metadata_1_7": {
+      "minReaderVersion": 1,
+      "minWriterVersion": 7,
+      "writerFeatures": ["domainMetadata"]
+    }
+  },
+  "$notes": {
+    "domain_metadata_user_domain": "User-controlled domains have names without the delta. prefix. Readers that choose to support domainMetadata must apply Action Reconciliation and include all domains \u2014 including user domains \u2014 in the snapshot. Writers must preserve user-controlled domains they do not understand."
+  },
+  "cases": [
+    {
+      "ordinal": 1,
+      "name": "domain_metadata_create_table_1_7_feature_listed_succeeds",
+      "feature": "domainMetadata",
+      "description": "Creating a (1,7)+[domainMetadata] table succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.domain_metadata_1_7",
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 2,
+      "name": "domain_metadata_read_snapshot_1_7_feature_listed_succeeds",
+      "feature": "domainMetadata",
+      "description": "Reading a (1,7)+[domainMetadata] table succeeds; domainMetadata imposes no mandatory reader obligations \u2014 readers that choose to support it must apply Action Reconciliation, but readers that do not are not required to fail.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.domain_metadata_1_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 3,
+      "name": "domain_metadata_empty_commit_1_7_feature_listed_succeeds",
+      "feature": "domainMetadata",
+      "description": "Appending to a (1,7)+[domainMetadata] table succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.domain_metadata_1_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 4,
+      "name": "domain_metadata_read_snapshot_1_7_with_user_domain_succeeds",
+      "feature": "domainMetadata",
+      "description": "Reading a (1,7)+[domainMetadata] table that already has a user-controlled domain action in the log succeeds; readers must apply Action Reconciliation and include the user domain in the snapshot.",
+      "note": "$notes.domain_metadata_user_domain",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.domain_metadata_1_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}},
+          {"domainMetadata": {"domain": "myApp.config", "configuration": "{}"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 5,
+      "name": "domain_metadata_empty_commit_1_7_with_user_domain_succeeds",
+      "feature": "domainMetadata",
+      "description": "Appending to a (1,7)+[domainMetadata] table that already has a user-controlled domain action in the log succeeds; writers must preserve all domains they do not understand.",
+      "note": "$notes.domain_metadata_user_domain",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.domain_metadata_1_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}},
+          {"domainMetadata": {"domain": "myApp.config", "configuration": "{}"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    }
+  ]
+}

--- a/compliance-suite/fixtures/domain-metadata.json
+++ b/compliance-suite/fixtures/domain-metadata.json
@@ -6,15 +6,19 @@
     }
   },
   "$protocols": {
+    "modern_3_7_no_features": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": []
+    },
     "domain_metadata_1_7": {
       "minReaderVersion": 1,
       "minWriterVersion": 7,
       "writerFeatures": ["domainMetadata"]
     }
   },
-  "$notes": {
-    "domain_metadata_user_domain": "User-controlled domains have names without the delta. prefix. Readers that choose to support domainMetadata must apply Action Reconciliation and include all domains \u2014 including user domains \u2014 in the snapshot. Writers must preserve user-controlled domains they do not understand."
-  },
+  "$notes": {},
   "cases": [
     {
       "ordinal": 1,
@@ -32,7 +36,7 @@
       "ordinal": 2,
       "name": "domain_metadata_read_snapshot_1_7_feature_listed_succeeds",
       "feature": "domainMetadata",
-      "description": "Reading a (1,7)+[domainMetadata] table succeeds; domainMetadata imposes no mandatory reader obligations \u2014 readers that choose to support it must apply Action Reconciliation, but readers that do not are not required to fail.",
+      "description": "Reading a (1,7)+[domainMetadata] table succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.domain_metadata_1_7"},
@@ -46,7 +50,7 @@
       "ordinal": 3,
       "name": "domain_metadata_empty_commit_1_7_feature_listed_succeeds",
       "feature": "domainMetadata",
-      "description": "Appending to a (1,7)+[domainMetadata] table succeeds.",
+      "description": "Committing to a (1,7)+[domainMetadata] table succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.domain_metadata_1_7"},
@@ -60,8 +64,7 @@
       "ordinal": 4,
       "name": "domain_metadata_read_snapshot_1_7_with_user_domain_succeeds",
       "feature": "domainMetadata",
-      "description": "Reading a (1,7)+[domainMetadata] table that already has a user-controlled domain action in the log succeeds; readers must apply Action Reconciliation and include the user domain in the snapshot.",
-      "note": "$notes.domain_metadata_user_domain",
+      "description": "Reading a (1,7)+[domainMetadata] table with a user-controlled domain action in the log succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.domain_metadata_1_7"},
@@ -76,11 +79,27 @@
       "ordinal": 5,
       "name": "domain_metadata_empty_commit_1_7_with_user_domain_succeeds",
       "feature": "domainMetadata",
-      "description": "Appending to a (1,7)+[domainMetadata] table that already has a user-controlled domain action in the log succeeds; writers must preserve all domains they do not understand.",
-      "note": "$notes.domain_metadata_user_domain",
+      "description": "Committing to a (1,7)+[domainMetadata] table with a user-controlled domain action in the log succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.domain_metadata_1_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}},
+          {"domainMetadata": {"domain": "myApp.config", "configuration": "{}"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 6,
+      "name": "domain_metadata_empty_commit_3_7_orphan_domain_action_succeeds",
+      "feature": "domainMetadata",
+      "flavor": "orphan",
+      "description": "Committing to a (3,7) table containing a domainMetadata action but without domainMetadata in protocol succeeds.",
+      "note": "$errata.domain_metadata_support_term_ambiguity",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_no_features"},
           {"metaData": {"schemaString": "$schemas.simple_int"}},
           {"domainMetadata": {"domain": "myApp.config", "configuration": "{}"}}
         ]

--- a/compliance-suite/fixtures/format-json.py
+++ b/compliance-suite/fixtures/format-json.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Format compliance fixture JSON files with compact inlining."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+HERE = pathlib.Path(__file__).resolve().parent
+
+
+def _json_compact(obj, level=0, _indent=2, _threshold=100, _h_offset=0):
+    pad = " " * (level * _indent)
+    child = " " * ((level + 1) * _indent)
+    flat = json.dumps(obj)
+    if len(flat) <= _threshold - level * _indent - _h_offset:
+        return flat
+    if isinstance(obj, dict):
+        pairs = ",\n".join(
+            f'{child}{json.dumps(k)}: {_json_compact(v, level + 1, _indent, _threshold, _h_offset=len(json.dumps(k)) + 2)}'
+            for k, v in obj.items()
+        )
+        return "{\n" + pairs + "\n" + pad + "}"
+    if isinstance(obj, list):
+        items = ",\n".join(
+            f'{child}{_json_compact(v, level + 1, _indent, _threshold)}'
+            for v in obj
+        )
+        return "[\n" + items + "\n" + pad + "]"
+    return flat
+
+
+def _format_file(path: pathlib.Path) -> None:
+    data = json.loads(path.read_text())
+    path.write_text(_json_compact(data) + "\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Format fixture JSON files in-place.")
+    parser.add_argument(
+        "files",
+        nargs="*",
+        metavar="FILE",
+        help="Fixture filename(s) relative to fixtures/ (or absolute paths). Omit to format all *.json.",
+    )
+    args = parser.parse_args()
+
+    if args.files:
+        paths = []
+        for f in args.files:
+            p = pathlib.Path(f)
+            if not p.is_absolute():
+                p = HERE / p
+            paths.append(p)
+    else:
+        paths = sorted(HERE.glob("*.json"))
+
+    if not paths:
+        print("No fixture JSON files found.", file=sys.stderr)
+        sys.exit(1)
+
+    for path in paths:
+        _format_file(path)
+        print(f"formatted {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/compliance-suite/fixtures/generated-columns.json
+++ b/compliance-suite/fixtures/generated-columns.json
@@ -78,9 +78,7 @@
       "writerFeatures": ["columnMapping", "generatedColumns"]
     }
   },
-  "$notes": {
-    "orphan_writer_feature": "At (3,7), the spec requires activation properties to be paired with the corresponding feature in writerFeatures. Writing an activation property for a feature absent from writerFeatures is invalid committed state."
-  },
+  "$notes": {},
   "cases": [
     {
       "ordinal": 1,
@@ -97,25 +95,25 @@
     },
     {
       "ordinal": 2,
-      "name": "generated_columns_create_table_3_7_no_feature_listed_with_schema_fails",
+      "name": "generated_columns_create_table_3_7_no_feature_listed_with_schema_succeeds",
       "flavor": "orphan",
       "feature": "generatedColumns",
-      "description": "Creating a (3,7) table with a delta.generationExpression column but generatedColumns absent from writerFeatures fails.",
-      "note": "$notes.orphan_writer_feature",
+      "description": "Creating a (3,7) table with a delta.generationExpression column but generatedColumns absent from writerFeatures succeeds.",
+      "note": "$errata.orphan_feature_metadata",
       "operation": {
         "type": "create_table",
         "protocol": "$protocols.modern_3_7",
         "metadata": {"schemaString": "$schemas.generated_columns_id_doubled"}
       },
-      "expected_outcome": "failure"
+      "expected_outcome": "success"
     },
     {
       "ordinal": 3,
-      "name": "generated_columns_empty_commit_3_7_no_feature_listed_with_schema_fails",
+      "name": "generated_columns_empty_commit_3_7_no_feature_listed_with_schema_succeeds",
       "flavor": "orphan",
       "feature": "generatedColumns",
-      "description": "Appending to a (3,7) table with a delta.generationExpression column but generatedColumns absent from writerFeatures fails.",
-      "note": "$notes.orphan_writer_feature",
+      "description": "Committing to a (3,7) table with a delta.generationExpression column but generatedColumns absent from writerFeatures succeeds.",
+      "note": "$errata.orphan_feature_metadata",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.modern_3_7"},
@@ -123,7 +121,7 @@
         ]
       },
       "operation": {"type": "empty_commit"},
-      "expected_outcome": "failure"
+      "expected_outcome": "success"
     },
     {
       "ordinal": 4,
@@ -143,7 +141,7 @@
       "name": "generated_columns_read_snapshot_3_7_no_feature_listed_with_schema",
       "flavor": "orphan",
       "feature": "generatedColumns",
-      "description": "Reading a (3,7) table with a delta.generationExpression column but generatedColumns absent from writerFeatures succeeds; generatedColumns is writer-only.",
+      "description": "Reading a (3,7) table with a delta.generationExpression column but generatedColumns absent from writerFeatures succeeds.",
       "note": "$errata.orphan_feature_metadata",
       "setup": {
         "log_actions": [
@@ -159,7 +157,7 @@
       "name": "generated_columns_supported_not_active_empty_commit_succeeds",
       "flavor": "supported_not_active",
       "feature": "generatedColumns",
-      "description": "Appending to a (3,7)+[generatedColumns] table without any delta.generationExpression column succeeds: the feature is supported but not active.",
+      "description": "Committing to a (3,7)+[generatedColumns] table without any delta.generationExpression column succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.modern_3_7_generated_columns"},
@@ -173,7 +171,7 @@
       "ordinal": 7,
       "name": "generated_columns_supported_active_empty_commit_succeeds",
       "feature": "generatedColumns",
-      "description": "Appending to a (3,7)+[generatedColumns] table with a delta.generationExpression column succeeds.",
+      "description": "Committing to a (3,7)+[generatedColumns] table with a delta.generationExpression column succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.modern_3_7_generated_columns"},
@@ -200,7 +198,7 @@
       "name": "generated_columns_read_snapshot_1_4_with_schema_succeeds",
       "flavor": "legacy",
       "feature": "generatedColumns",
-      "description": "Reading a (1,4) table with a delta.generationExpression column succeeds: generatedColumns is writer-only.",
+      "description": "Reading a (1,4) table with a delta.generationExpression column succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.legacy_1_4"},
@@ -214,7 +212,7 @@
       "ordinal": 10,
       "name": "generated_columns_read_snapshot_3_7_feature_listed_succeeds",
       "feature": "generatedColumns",
-      "description": "Reading a (3,7)+[generatedColumns] table with a delta.generationExpression column succeeds: generatedColumns is writer-only.",
+      "description": "Reading a (3,7)+[generatedColumns] table with a delta.generationExpression column succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.modern_3_7_generated_columns"},
@@ -229,7 +227,7 @@
       "name": "generated_columns_supported_not_active_read_snapshot_succeeds",
       "flavor": "supported_not_active",
       "feature": "generatedColumns",
-      "description": "Reading a (3,7)+[generatedColumns] table without any delta.generationExpression column succeeds: the feature is supported but not active.",
+      "description": "Reading a (3,7)+[generatedColumns] table without any delta.generationExpression column succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.modern_3_7_generated_columns"},
@@ -244,7 +242,7 @@
       "name": "generated_columns_empty_commit_1_4_with_schema_succeeds",
       "flavor": "legacy",
       "feature": "generatedColumns",
-      "description": "Appending to a (1,4) table with a delta.generationExpression column succeeds: generatedColumns are always supported at writer version 4.",
+      "description": "Committing to a (1,4) table with a delta.generationExpression column succeeds: generatedColumns are always supported at writer version 4.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.legacy_1_4"},
@@ -257,6 +255,7 @@
     {
       "ordinal": 13,
       "name": "generated_columns_create_table_3_7_nonexistent_column_fails",
+      "flavor": "invalid_metadata_content",
       "feature": "generatedColumns",
       "description": "Creating a (3,7)+[generatedColumns] table with a generation expression referencing a column not in the schema fails.",
       "operation": {
@@ -304,7 +303,7 @@
       "ordinal": 16,
       "name": "generated_columns_cm_empty_commit_3_7_both_features_listed_succeeds",
       "feature": "generatedColumns",
-      "description": "Appending to a (3,7)+[columnMapping,generatedColumns] table with CM-annotated columns and a generation expression using the logical column name succeeds.",
+      "description": "Committing to a (3,7)+[columnMapping,generatedColumns] table with CM-annotated columns and a generation expression using the logical column name succeeds.",
       "note": "$errata.sql_expression_cm_name_resolution",
       "setup": {
         "log_actions": [

--- a/compliance-suite/fixtures/generated-columns.json
+++ b/compliance-suite/fixtures/generated-columns.json
@@ -1,0 +1,342 @@
+{
+  "$schemas": {
+    "generated_columns_id_doubled": {
+      "type": "struct",
+      "fields": [
+        {"name": "id", "type": "integer", "nullable": true, "metadata": {}},
+        {
+          "name": "id_doubled",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {"delta.generationExpression": "id * 2"}
+        }
+      ]
+    },
+    "simple_int": {
+      "type": "struct",
+      "fields": [{"name": "id", "type": "integer", "nullable": true, "metadata": {}}]
+    },
+    "generated_columns_bad_ref": {
+      "type": "struct",
+      "fields": [
+        {"name": "id", "type": "integer", "nullable": true, "metadata": {}},
+        {
+          "name": "bad_generated",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {"delta.generationExpression": "nonexistent_col * 2"}
+        }
+      ]
+    },
+    "cm_generated_columns_id_doubled": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {"delta.columnMapping.id": 1, "delta.columnMapping.physicalName": "col-1"}
+        },
+        {
+          "name": "id_doubled",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {
+            "delta.columnMapping.id": 2,
+            "delta.columnMapping.physicalName": "col-2",
+            "delta.generationExpression": "id * 2"
+          }
+        }
+      ]
+    }
+  },
+  "$protocols": {
+    "legacy_1_3": {"minReaderVersion": 1, "minWriterVersion": 3},
+    "legacy_1_4": {"minReaderVersion": 1, "minWriterVersion": 4},
+    "modern_3_7_generated_columns": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": ["generatedColumns"]
+    },
+    "modern_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": []
+    },
+    "modern_3_7_generated_check_constraints": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": ["generatedColumns", "checkConstraints"]
+    },
+    "modern_3_7_cm_generated_columns": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["columnMapping"],
+      "writerFeatures": ["columnMapping", "generatedColumns"]
+    }
+  },
+  "$notes": {
+    "orphan_writer_feature": "At (3,7), the spec requires activation properties to be paired with the corresponding feature in writerFeatures. Writing an activation property for a feature absent from writerFeatures is invalid committed state."
+  },
+  "cases": [
+    {
+      "ordinal": 1,
+      "name": "generated_columns_create_table_1_3_fails",
+      "flavor": "insufficient_protocol",
+      "feature": "generatedColumns",
+      "description": "Creating a (1,3) table with a delta.generationExpression column fails: generatedColumns requires minWriterVersion>=4.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.legacy_1_3",
+        "metadata": {"schemaString": "$schemas.generated_columns_id_doubled"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 2,
+      "name": "generated_columns_create_table_3_7_no_feature_listed_with_schema_fails",
+      "flavor": "orphan",
+      "feature": "generatedColumns",
+      "description": "Creating a (3,7) table with a delta.generationExpression column but generatedColumns absent from writerFeatures fails.",
+      "note": "$notes.orphan_writer_feature",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7",
+        "metadata": {"schemaString": "$schemas.generated_columns_id_doubled"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 3,
+      "name": "generated_columns_empty_commit_3_7_no_feature_listed_with_schema_fails",
+      "flavor": "orphan",
+      "feature": "generatedColumns",
+      "description": "Appending to a (3,7) table with a delta.generationExpression column but generatedColumns absent from writerFeatures fails.",
+      "note": "$notes.orphan_writer_feature",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7"},
+          {"metaData": {"schemaString": "$schemas.generated_columns_id_doubled"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 4,
+      "name": "generated_columns_create_table_1_4_with_schema",
+      "flavor": "legacy",
+      "feature": "generatedColumns",
+      "description": "Creating a (1,4) table with a delta.generationExpression column metadata succeeds: generatedColumns are always supported at writer version 4.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.legacy_1_4",
+        "metadata": {"schemaString": "$schemas.generated_columns_id_doubled"}
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 5,
+      "name": "generated_columns_read_snapshot_3_7_no_feature_listed_with_schema",
+      "flavor": "orphan",
+      "feature": "generatedColumns",
+      "description": "Reading a (3,7) table with a delta.generationExpression column but generatedColumns absent from writerFeatures succeeds; generatedColumns is writer-only.",
+      "note": "$errata.orphan_feature_metadata",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7"},
+          {"metaData": {"schemaString": "$schemas.generated_columns_id_doubled"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 6,
+      "name": "generated_columns_supported_not_active_empty_commit_succeeds",
+      "flavor": "supported_not_active",
+      "feature": "generatedColumns",
+      "description": "Appending to a (3,7)+[generatedColumns] table without any delta.generationExpression column succeeds: the feature is supported but not active.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_generated_columns"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 7,
+      "name": "generated_columns_supported_active_empty_commit_succeeds",
+      "feature": "generatedColumns",
+      "description": "Appending to a (3,7)+[generatedColumns] table with a delta.generationExpression column succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_generated_columns"},
+          {"metaData": {"schemaString": "$schemas.generated_columns_id_doubled"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 8,
+      "name": "generated_columns_create_table_3_7_feature_listed_succeeds",
+      "feature": "generatedColumns",
+      "description": "Creating a (3,7)+[generatedColumns] table with a delta.generationExpression column succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7_generated_columns",
+        "metadata": {"schemaString": "$schemas.generated_columns_id_doubled"}
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 9,
+      "name": "generated_columns_read_snapshot_1_4_with_schema_succeeds",
+      "flavor": "legacy",
+      "feature": "generatedColumns",
+      "description": "Reading a (1,4) table with a delta.generationExpression column succeeds: generatedColumns is writer-only.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.legacy_1_4"},
+          {"metaData": {"schemaString": "$schemas.generated_columns_id_doubled"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 10,
+      "name": "generated_columns_read_snapshot_3_7_feature_listed_succeeds",
+      "feature": "generatedColumns",
+      "description": "Reading a (3,7)+[generatedColumns] table with a delta.generationExpression column succeeds: generatedColumns is writer-only.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_generated_columns"},
+          {"metaData": {"schemaString": "$schemas.generated_columns_id_doubled"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 11,
+      "name": "generated_columns_supported_not_active_read_snapshot_succeeds",
+      "flavor": "supported_not_active",
+      "feature": "generatedColumns",
+      "description": "Reading a (3,7)+[generatedColumns] table without any delta.generationExpression column succeeds: the feature is supported but not active.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_generated_columns"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 12,
+      "name": "generated_columns_empty_commit_1_4_with_schema_succeeds",
+      "flavor": "legacy",
+      "feature": "generatedColumns",
+      "description": "Appending to a (1,4) table with a delta.generationExpression column succeeds: generatedColumns are always supported at writer version 4.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.legacy_1_4"},
+          {"metaData": {"schemaString": "$schemas.generated_columns_id_doubled"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 13,
+      "name": "generated_columns_create_table_3_7_nonexistent_column_fails",
+      "feature": "generatedColumns",
+      "description": "Creating a (3,7)+[generatedColumns] table with a generation expression referencing a column not in the schema fails.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7_generated_columns",
+        "metadata": {"schemaString": "$schemas.generated_columns_bad_ref"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 14,
+      "name": "generated_columns_create_table_3_7_partition_column_succeeds",
+      "feature": "generatedColumns",
+      "description": "Creating a (3,7)+[generatedColumns] table with a generated column listed as a partition column succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7_generated_columns",
+        "metadata": {
+          "schemaString": "$schemas.generated_columns_id_doubled",
+          "partitionColumns": ["id_doubled"]
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 15,
+      "name": "generated_columns_cm_create_table_3_7_both_features_listed_succeeds",
+      "feature": "generatedColumns",
+      "description": "Creating a (3,7)+[columnMapping,generatedColumns] table with CM-annotated columns and a generation expression using the logical column name succeeds.",
+      "note": "$errata.sql_expression_cm_name_resolution",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7_cm_generated_columns",
+        "metadata": {
+          "schemaString": "$schemas.cm_generated_columns_id_doubled",
+          "configuration": {
+            "delta.columnMapping.mode": "id",
+            "delta.columnMapping.maxColumnId": "2"
+          }
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 16,
+      "name": "generated_columns_cm_empty_commit_3_7_both_features_listed_succeeds",
+      "feature": "generatedColumns",
+      "description": "Appending to a (3,7)+[columnMapping,generatedColumns] table with CM-annotated columns and a generation expression using the logical column name succeeds.",
+      "note": "$errata.sql_expression_cm_name_resolution",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_cm_generated_columns"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.cm_generated_columns_id_doubled",
+              "configuration": {
+                "delta.columnMapping.mode": "id",
+                "delta.columnMapping.maxColumnId": "2"
+              }
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 17,
+      "name": "generated_columns_check_constraints_create_table_3_7_both_features_listed_succeeds",
+      "feature": "generatedColumns",
+      "description": "Creating a (3,7)+[generatedColumns,checkConstraints] table with both a generation expression and a check constraint succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7_generated_check_constraints",
+        "metadata": {
+          "schemaString": "$schemas.generated_columns_id_doubled",
+          "configuration": {"delta.constraints.doubled_positive": "id_doubled > 0"}
+        }
+      },
+      "expected_outcome": "success"
+    }
+  ]
+}

--- a/compliance-suite/fixtures/iceberg-compat-v1.json
+++ b/compliance-suite/fixtures/iceberg-compat-v1.json
@@ -14,12 +14,74 @@
     "simple_int": {
       "type": "struct",
       "fields": [{"name": "id", "type": "integer", "nullable": true, "metadata": {}}]
+    },
+    "array_int_mapped": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {"delta.columnMapping.id": 1, "delta.columnMapping.physicalName": "id"}
+        },
+        {
+          "name": "arr_col",
+          "type": {"type": "array", "elementType": "integer", "containsNull": true},
+          "nullable": true,
+          "metadata": {"delta.columnMapping.id": 2, "delta.columnMapping.physicalName": "arr_col"}
+        }
+      ]
+    },
+    "map_string_int_mapped": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {"delta.columnMapping.id": 1, "delta.columnMapping.physicalName": "id"}
+        },
+        {
+          "name": "map_col",
+          "type": {
+            "type": "map",
+            "keyType": "string",
+            "valueType": "integer",
+            "valueContainsNull": true
+          },
+          "nullable": true,
+          "metadata": {"delta.columnMapping.id": 2, "delta.columnMapping.physicalName": "map_col"}
+        }
+      ]
+    },
+    "void_type_mapped": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {"delta.columnMapping.id": 1, "delta.columnMapping.physicalName": "id"}
+        },
+        {
+          "name": "void_col",
+          "type": "void",
+          "nullable": true,
+          "metadata": {"delta.columnMapping.id": 2, "delta.columnMapping.physicalName": "void_col"}
+        }
+      ]
     }
   },
   "$protocols": {
     "column_mapping_only_2_7": {
       "minReaderVersion": 2,
       "minWriterVersion": 7,
+      "writerFeatures": ["columnMapping"]
+    },
+    "column_mapping_only_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["columnMapping"],
       "writerFeatures": ["columnMapping"]
     },
     "iceberg_v1_2_7": {
@@ -36,6 +98,24 @@
       "minReaderVersion": 2,
       "minWriterVersion": 7,
       "writerFeatures": ["icebergCompatV1"]
+    },
+    "iceberg_v1_with_dv_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["columnMapping", "deletionVectors"],
+      "writerFeatures": ["columnMapping", "icebergCompatV1", "deletionVectors"]
+    },
+    "iceberg_v1_no_cm_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": ["icebergCompatV1"]
+    },
+    "no_features_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": []
     },
     "iceberg_v1_3_7": {
       "minReaderVersion": 3,
@@ -71,7 +151,7 @@
       "ordinal": 2,
       "name": "iceberg_v1_create_table_3_7_feature_listed_property_true_succeeds",
       "feature": "icebergCompatV1",
-      "description": "Creating a (3,7)+[columnMapping in readerFeatures and writerFeatures, icebergCompatV1] table with columnMapping mode=name and delta.enableIcebergCompatV1=true succeeds; (3,7) with columnMapping in readerFeatures is a valid alternate protocol path.",
+      "description": "Creating a (3,7)+[columnMapping, icebergCompatV1] table with columnMapping mode=name and delta.enableIcebergCompatV1=true succeeds.",
       "note": "$notes.v1_activation",
       "operation": {
         "type": "create_table",
@@ -91,7 +171,7 @@
       "name": "iceberg_v1_supported_not_active_create_table_succeeds",
       "feature": "icebergCompatV1",
       "flavor": "supported_not_active",
-      "description": "Creating a (2,7)+[columnMapping,icebergCompatV1] table without delta.enableIcebergCompatV1=true succeeds; icebergCompatV1 writer requirements only apply when the feature is active.",
+      "description": "Creating a (2,7)+[columnMapping,icebergCompatV1] table without delta.enableIcebergCompatV1=true succeeds.",
       "operation": {
         "type": "create_table",
         "protocol": "$protocols.iceberg_v1_2_7",
@@ -124,7 +204,7 @@
       "name": "iceberg_v1_create_table_2_7_missing_column_mapping_fails",
       "feature": "icebergCompatV1",
       "flavor": "missing_dependency",
-      "description": "Creating a (2,7)+[icebergCompatV1] table without columnMapping in writerFeatures and delta.enableIcebergCompatV1=true fails; the spec requires columnMapping to be co-listed.",
+      "description": "Creating a (2,7)+[icebergCompatV1] table without columnMapping in writerFeatures and delta.enableIcebergCompatV1=true fails.",
       "operation": {
         "type": "create_table",
         "protocol": "$protocols.iceberg_v1_no_cm_2_7",
@@ -139,7 +219,8 @@
       "ordinal": 6,
       "name": "iceberg_v1_create_table_2_7_column_mapping_not_active_fails",
       "feature": "icebergCompatV1",
-      "description": "Creating a (2,7)+[columnMapping,icebergCompatV1] table with delta.enableIcebergCompatV1=true but no columnMapping mode set fails; the spec requires columnMapping to be active in name or id mode when ICv1 is active.",
+      "flavor": "missing_required_metadata",
+      "description": "Creating a (2,7)+[columnMapping,icebergCompatV1] table with delta.enableIcebergCompatV1=true but no columnMapping mode set fails.",
       "operation": {
         "type": "create_table",
         "protocol": "$protocols.iceberg_v1_2_7",
@@ -154,7 +235,7 @@
       "ordinal": 7,
       "name": "iceberg_v1_create_table_2_7_with_deletion_vectors_active_fails",
       "feature": "icebergCompatV1",
-      "description": "Creating a (2,7)+[columnMapping,icebergCompatV1,deletionVectors] table with delta.enableIcebergCompatV1=true and delta.enableDeletionVectors=true fails; ICv1 requires deletionVectors not be supported.",
+      "description": "Creating a (2,7)+[columnMapping,icebergCompatV1,deletionVectors] table with delta.enableIcebergCompatV1=true and delta.enableDeletionVectors=true fails; deletionVectors must not be supported.",
       "note": "$errata.iceberg_compat_dv_restriction",
       "operation": {
         "type": "create_table",
@@ -174,7 +255,7 @@
       "ordinal": 8,
       "name": "iceberg_v1_create_table_2_7_with_deletion_vectors_supported_not_active_fails",
       "feature": "icebergCompatV1",
-      "description": "Creating a (2,7)+[columnMapping,icebergCompatV1,deletionVectors] table with delta.enableIcebergCompatV1=true but without delta.enableDeletionVectors=true fails; ICv1 requires deletionVectors not be present in the protocol at all, not merely inactive.",
+      "description": "Creating a (2,7)+[columnMapping,icebergCompatV1,deletionVectors] table with delta.enableIcebergCompatV1=true but without delta.enableDeletionVectors=true fails; deletionVectors must not be supported.",
       "note": "$errata.iceberg_compat_dv_restriction",
       "operation": {
         "type": "create_table",
@@ -193,7 +274,7 @@
       "ordinal": 9,
       "name": "iceberg_v1_read_snapshot_2_7_feature_listed_property_true_succeeds",
       "feature": "icebergCompatV1",
-      "description": "Reading a (2,7)+[columnMapping,icebergCompatV1] table with delta.enableIcebergCompatV1=true succeeds; icebergCompatV1 is writer-only.",
+      "description": "Reading a (2,7)+[columnMapping,icebergCompatV1] table with delta.enableIcebergCompatV1=true succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.iceberg_v1_2_7"},
@@ -215,7 +296,7 @@
       "ordinal": 10,
       "name": "iceberg_v1_empty_commit_2_7_feature_listed_property_true_succeeds",
       "feature": "icebergCompatV1",
-      "description": "Appending to a (2,7)+[columnMapping,icebergCompatV1] table with delta.enableIcebergCompatV1=true succeeds.",
+      "description": "Committing to a (2,7)+[columnMapping,icebergCompatV1] table with delta.enableIcebergCompatV1=true succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.iceberg_v1_2_7"},
@@ -235,14 +316,14 @@
     },
     {
       "ordinal": 11,
-      "name": "iceberg_v1_read_snapshot_2_7_no_feature_listed_with_property_succeeds",
+      "name": "iceberg_v1_read_snapshot_3_7_no_feature_listed_with_property_succeeds",
       "feature": "icebergCompatV1",
       "flavor": "orphan",
-      "description": "Reading a (2,7)+[columnMapping] table with delta.enableIcebergCompatV1=true but icebergCompatV1 absent from writerFeatures succeeds; icebergCompatV1 is writer-only and the orphan property has no effect on reads.",
+      "description": "Reading a (3,7)+[columnMapping] table with delta.enableIcebergCompatV1=true but icebergCompatV1 absent from writerFeatures succeeds.",
       "note": "$errata.orphan_feature_metadata",
       "setup": {
         "log_actions": [
-          {"protocol": "$protocols.column_mapping_only_2_7"},
+          {"protocol": "$protocols.column_mapping_only_3_7"},
           {
             "metaData": {
               "schemaString": "$schemas.simple_int_mapped",
@@ -259,18 +340,203 @@
     },
     {
       "ordinal": 12,
-      "name": "iceberg_v1_empty_commit_2_7_without_column_mapping_protocol_fails",
+      "name": "iceberg_v1_create_table_3_7_without_column_mapping_protocol_fails",
       "feature": "icebergCompatV1",
       "flavor": "missing_dependency",
-      "description": "Appending to a (2,7)+[icebergCompatV1] table without columnMapping in writerFeatures fails; the spec requires columnMapping to be co-listed whenever icebergCompatV1 is listed.",
+      "description": "Creating a (3,7)+[icebergCompatV1] table without columnMapping in readerFeatures and writerFeatures fails, even without delta.enableIcebergCompatV1=true; columnMapping must be supported whenever icebergCompatV1 is supported.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v1_no_cm_3_7",
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 13,
+      "name": "iceberg_v1_create_table_3_7_with_array_type_fails",
+      "feature": "icebergCompatV1",
+      "flavor": "invalid_metadata_content",
+      "description": "Creating a (3,7)+[columnMapping,icebergCompatV1] table with delta.enableIcebergCompatV1=true and an Array type column fails; ICv1 forbids Array types when active.",
+      "note": "$notes.v1_activation",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v1_3_7",
+        "metadata": {
+          "schemaString": "$schemas.array_int_mapped",
+          "configuration": {
+            "delta.columnMapping.mode": "name",
+            "delta.enableIcebergCompatV1": "true"
+          }
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 14,
+      "name": "iceberg_v1_create_table_3_7_with_map_type_fails",
+      "feature": "icebergCompatV1",
+      "flavor": "invalid_metadata_content",
+      "description": "Creating a (3,7)+[columnMapping,icebergCompatV1] table with delta.enableIcebergCompatV1=true and a Map type column fails; ICv1 forbids Map types when active.",
+      "note": "$notes.v1_activation",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v1_3_7",
+        "metadata": {
+          "schemaString": "$schemas.map_string_int_mapped",
+          "configuration": {
+            "delta.columnMapping.mode": "name",
+            "delta.enableIcebergCompatV1": "true"
+          }
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 15,
+      "name": "iceberg_v1_read_snapshot_3_7_with_void_type_fails",
+      "feature": "icebergCompatV1",
+      "flavor": "invalid_metadata_content",
+      "description": "Reading a (3,7)+[columnMapping,icebergCompatV1] table with delta.enableIcebergCompatV1=true and a Void type column fails; ICv1 forbids Void types when active.",
+      "note": "$notes.v1_activation",
       "setup": {
         "log_actions": [
-          {"protocol": "$protocols.iceberg_v1_no_cm_2_7"},
-          {"metaData": {"schemaString": "$schemas.simple_int"}}
+          {"protocol": "$protocols.iceberg_v1_3_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.void_type_mapped",
+              "configuration": {
+                "delta.columnMapping.mode": "name",
+                "delta.enableIcebergCompatV1": "true"
+              }
+            }
+          }
         ]
       },
-      "operation": {"type": "empty_commit"},
+      "operation": {"type": "read_snapshot"},
       "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 16,
+      "name": "iceberg_v1_read_snapshot_3_7_with_array_type_fails",
+      "feature": "icebergCompatV1",
+      "flavor": "invalid_metadata_content",
+      "description": "Reading a (3,7)+[columnMapping,icebergCompatV1] table with delta.enableIcebergCompatV1=true and an Array type column fails; ICv1 forbids Array types when active.",
+      "note": "$notes.v1_activation",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.iceberg_v1_3_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.array_int_mapped",
+              "configuration": {
+                "delta.columnMapping.mode": "name",
+                "delta.enableIcebergCompatV1": "true"
+              }
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 17,
+      "name": "iceberg_v1_read_snapshot_3_7_with_map_type_fails",
+      "feature": "icebergCompatV1",
+      "flavor": "invalid_metadata_content",
+      "description": "Reading a (3,7)+[columnMapping,icebergCompatV1] table with delta.enableIcebergCompatV1=true and a Map type column fails; ICv1 forbids Map types when active.",
+      "note": "$notes.v1_activation",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.iceberg_v1_3_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.map_string_int_mapped",
+              "configuration": {
+                "delta.columnMapping.mode": "name",
+                "delta.enableIcebergCompatV1": "true"
+              }
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 18,
+      "name": "iceberg_v1_create_table_3_7_with_void_type_fails",
+      "feature": "icebergCompatV1",
+      "flavor": "invalid_metadata_content",
+      "description": "Creating a (3,7)+[columnMapping,icebergCompatV1] table with delta.enableIcebergCompatV1=true and a Void type column fails; ICv1 forbids Void types when active.",
+      "note": "$notes.v1_activation",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v1_3_7",
+        "metadata": {
+          "schemaString": "$schemas.void_type_mapped",
+          "configuration": {
+            "delta.columnMapping.mode": "name",
+            "delta.enableIcebergCompatV1": "true"
+          }
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 19,
+      "name": "iceberg_v1_supported_not_active_create_table_3_7_with_deletion_vectors_active_succeeds",
+      "feature": "icebergCompatV1",
+      "flavor": "supported_not_active",
+      "description": "Creating a (3,7)+[columnMapping,icebergCompatV1,deletionVectors] table with delta.enableDeletionVectors=true but without delta.enableIcebergCompatV1=true succeeds; ICv1 deletionVectors restrictions apply only when ICv1 is active.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v1_with_dv_3_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int_mapped",
+          "configuration": {
+            "delta.columnMapping.mode": "name",
+            "delta.enableDeletionVectors": "true"
+          }
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 20,
+      "name": "iceberg_v1_supported_not_active_create_table_3_7_with_deletion_vectors_supported_not_active_succeeds",
+      "feature": "icebergCompatV1",
+      "flavor": "supported_not_active",
+      "description": "Creating a (3,7)+[columnMapping,icebergCompatV1,deletionVectors] table without delta.enableIcebergCompatV1=true and without delta.enableDeletionVectors=true succeeds; ICv1 deletionVectors restrictions apply only when ICv1 is active.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v1_with_dv_3_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int_mapped",
+          "configuration": {"delta.columnMapping.mode": "name"}
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 21,
+      "name": "iceberg_v1_create_table_3_7_no_feature_no_cm_property_true_succeeds",
+      "feature": "icebergCompatV1",
+      "flavor": "orphan",
+      "description": "Creating a (3,7)+[] table with delta.enableIcebergCompatV1=true and delta.enableDeletionVectors=true succeeds; columnMapping dependency checks only apply when icebergCompatV1 is supported.",
+      "note": "$errata.orphan_feature_metadata",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.no_features_3_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {
+            "delta.enableIcebergCompatV1": "true",
+            "delta.enableDeletionVectors": "true"
+          }
+        }
+      },
+      "expected_outcome": "success"
     }
   ]
 }

--- a/compliance-suite/fixtures/iceberg-compat-v1.json
+++ b/compliance-suite/fixtures/iceberg-compat-v1.json
@@ -1,0 +1,276 @@
+{
+  "$schemas": {
+    "simple_int_mapped": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {"delta.columnMapping.id": 1, "delta.columnMapping.physicalName": "id"}
+        }
+      ]
+    },
+    "simple_int": {
+      "type": "struct",
+      "fields": [{"name": "id", "type": "integer", "nullable": true, "metadata": {}}]
+    }
+  },
+  "$protocols": {
+    "column_mapping_only_2_7": {
+      "minReaderVersion": 2,
+      "minWriterVersion": 7,
+      "writerFeatures": ["columnMapping"]
+    },
+    "iceberg_v1_2_7": {
+      "minReaderVersion": 2,
+      "minWriterVersion": 7,
+      "writerFeatures": ["columnMapping", "icebergCompatV1"]
+    },
+    "iceberg_v1_with_dv_2_7": {
+      "minReaderVersion": 2,
+      "minWriterVersion": 7,
+      "writerFeatures": ["columnMapping", "icebergCompatV1", "deletionVectors"]
+    },
+    "iceberg_v1_no_cm_2_7": {
+      "minReaderVersion": 2,
+      "minWriterVersion": 7,
+      "writerFeatures": ["icebergCompatV1"]
+    },
+    "iceberg_v1_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["columnMapping"],
+      "writerFeatures": ["columnMapping", "icebergCompatV1"]
+    }
+  },
+  "$notes": {
+    "v1_activation": "icebergCompatV1 is activated by two conditions: (1) the feature listed in writerFeatures, and (2) the table property delta.enableIcebergCompatV1=true. When active, columnMapping must be in name or id mode, deletionVectors must not be supported, partition values must be materialized, and Map/Array/Void types are forbidden."
+  },
+  "cases": [
+    {
+      "ordinal": 1,
+      "name": "iceberg_v1_create_table_2_7_feature_listed_property_true_succeeds",
+      "feature": "icebergCompatV1",
+      "description": "Creating a (2,7)+[columnMapping,icebergCompatV1] table with columnMapping mode=name and delta.enableIcebergCompatV1=true succeeds.",
+      "note": "$notes.v1_activation",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v1_2_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int_mapped",
+          "configuration": {
+            "delta.columnMapping.mode": "name",
+            "delta.enableIcebergCompatV1": "true"
+          }
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 2,
+      "name": "iceberg_v1_create_table_3_7_feature_listed_property_true_succeeds",
+      "feature": "icebergCompatV1",
+      "description": "Creating a (3,7)+[columnMapping in readerFeatures and writerFeatures, icebergCompatV1] table with columnMapping mode=name and delta.enableIcebergCompatV1=true succeeds; (3,7) with columnMapping in readerFeatures is a valid alternate protocol path.",
+      "note": "$notes.v1_activation",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v1_3_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int_mapped",
+          "configuration": {
+            "delta.columnMapping.mode": "name",
+            "delta.enableIcebergCompatV1": "true"
+          }
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 3,
+      "name": "iceberg_v1_supported_not_active_create_table_succeeds",
+      "feature": "icebergCompatV1",
+      "flavor": "supported_not_active",
+      "description": "Creating a (2,7)+[columnMapping,icebergCompatV1] table without delta.enableIcebergCompatV1=true succeeds; icebergCompatV1 writer requirements only apply when the feature is active.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v1_2_7",
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 4,
+      "name": "iceberg_v1_create_table_2_7_no_feature_listed_property_true_succeeds",
+      "feature": "icebergCompatV1",
+      "flavor": "orphan",
+      "description": "Creating a (2,7)+[columnMapping] table with delta.enableIcebergCompatV1=true but icebergCompatV1 absent from writerFeatures succeeds.",
+      "note": "$errata.orphan_feature_metadata",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.column_mapping_only_2_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int_mapped",
+          "configuration": {
+            "delta.columnMapping.mode": "name",
+            "delta.enableIcebergCompatV1": "true"
+          }
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 5,
+      "name": "iceberg_v1_create_table_2_7_missing_column_mapping_fails",
+      "feature": "icebergCompatV1",
+      "flavor": "missing_dependency",
+      "description": "Creating a (2,7)+[icebergCompatV1] table without columnMapping in writerFeatures and delta.enableIcebergCompatV1=true fails; the spec requires columnMapping to be co-listed.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v1_no_cm_2_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {"delta.enableIcebergCompatV1": "true"}
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 6,
+      "name": "iceberg_v1_create_table_2_7_column_mapping_not_active_fails",
+      "feature": "icebergCompatV1",
+      "description": "Creating a (2,7)+[columnMapping,icebergCompatV1] table with delta.enableIcebergCompatV1=true but no columnMapping mode set fails; the spec requires columnMapping to be active in name or id mode when ICv1 is active.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v1_2_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {"delta.enableIcebergCompatV1": "true"}
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 7,
+      "name": "iceberg_v1_create_table_2_7_with_deletion_vectors_active_fails",
+      "feature": "icebergCompatV1",
+      "description": "Creating a (2,7)+[columnMapping,icebergCompatV1,deletionVectors] table with delta.enableIcebergCompatV1=true and delta.enableDeletionVectors=true fails; ICv1 requires deletionVectors not be supported.",
+      "note": "$errata.iceberg_compat_dv_restriction",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v1_with_dv_2_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int_mapped",
+          "configuration": {
+            "delta.columnMapping.mode": "name",
+            "delta.enableIcebergCompatV1": "true",
+            "delta.enableDeletionVectors": "true"
+          }
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 8,
+      "name": "iceberg_v1_create_table_2_7_with_deletion_vectors_supported_not_active_fails",
+      "feature": "icebergCompatV1",
+      "description": "Creating a (2,7)+[columnMapping,icebergCompatV1,deletionVectors] table with delta.enableIcebergCompatV1=true but without delta.enableDeletionVectors=true fails; ICv1 requires deletionVectors not be present in the protocol at all, not merely inactive.",
+      "note": "$errata.iceberg_compat_dv_restriction",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v1_with_dv_2_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int_mapped",
+          "configuration": {
+            "delta.columnMapping.mode": "name",
+            "delta.enableIcebergCompatV1": "true"
+          }
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 9,
+      "name": "iceberg_v1_read_snapshot_2_7_feature_listed_property_true_succeeds",
+      "feature": "icebergCompatV1",
+      "description": "Reading a (2,7)+[columnMapping,icebergCompatV1] table with delta.enableIcebergCompatV1=true succeeds; icebergCompatV1 is writer-only.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.iceberg_v1_2_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int_mapped",
+              "configuration": {
+                "delta.columnMapping.mode": "name",
+                "delta.enableIcebergCompatV1": "true"
+              }
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 10,
+      "name": "iceberg_v1_empty_commit_2_7_feature_listed_property_true_succeeds",
+      "feature": "icebergCompatV1",
+      "description": "Appending to a (2,7)+[columnMapping,icebergCompatV1] table with delta.enableIcebergCompatV1=true succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.iceberg_v1_2_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int_mapped",
+              "configuration": {
+                "delta.columnMapping.mode": "name",
+                "delta.enableIcebergCompatV1": "true"
+              }
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 11,
+      "name": "iceberg_v1_read_snapshot_2_7_no_feature_listed_with_property_succeeds",
+      "feature": "icebergCompatV1",
+      "flavor": "orphan",
+      "description": "Reading a (2,7)+[columnMapping] table with delta.enableIcebergCompatV1=true but icebergCompatV1 absent from writerFeatures succeeds; icebergCompatV1 is writer-only and the orphan property has no effect on reads.",
+      "note": "$errata.orphan_feature_metadata",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.column_mapping_only_2_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int_mapped",
+              "configuration": {
+                "delta.columnMapping.mode": "name",
+                "delta.enableIcebergCompatV1": "true"
+              }
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 12,
+      "name": "iceberg_v1_empty_commit_2_7_without_column_mapping_protocol_fails",
+      "feature": "icebergCompatV1",
+      "flavor": "missing_dependency",
+      "description": "Appending to a (2,7)+[icebergCompatV1] table without columnMapping in writerFeatures fails; the spec requires columnMapping to be co-listed whenever icebergCompatV1 is listed.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.iceberg_v1_no_cm_2_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    }
+  ]
+}

--- a/compliance-suite/fixtures/iceberg-compat-v2.json
+++ b/compliance-suite/fixtures/iceberg-compat-v2.json
@@ -14,6 +14,156 @@
     "simple_int": {
       "type": "struct",
       "fields": [{"name": "id", "type": "integer", "nullable": true, "metadata": {}}]
+    },
+    "array_int_mapped_missing_nested_ids": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {"delta.columnMapping.id": 1, "delta.columnMapping.physicalName": "id"}
+        },
+        {
+          "name": "arr_col",
+          "type": {"type": "array", "elementType": "integer", "containsNull": true},
+          "nullable": true,
+          "metadata": {"delta.columnMapping.id": 2, "delta.columnMapping.physicalName": "arr_col"}
+        }
+      ]
+    },
+    "array_int_mapped_non_int_nested_ids": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {"delta.columnMapping.id": 1, "delta.columnMapping.physicalName": "id"}
+        },
+        {
+          "name": "arr_col",
+          "type": {"type": "array", "elementType": "integer", "containsNull": true},
+          "nullable": true,
+          "metadata": {
+            "delta.columnMapping.id": 2,
+            "delta.columnMapping.physicalName": "arr_col",
+            "parquet.field.nested.ids": {"arr_col.element": "not-an-int"}
+          }
+        }
+      ]
+    },
+    "array_int_mapped_nested_ids_overlap_cm_ids": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {"delta.columnMapping.id": 1, "delta.columnMapping.physicalName": "id"}
+        },
+        {
+          "name": "arr_col",
+          "type": {"type": "array", "elementType": "integer", "containsNull": true},
+          "nullable": true,
+          "metadata": {
+            "delta.columnMapping.id": 2,
+            "delta.columnMapping.physicalName": "arr_col",
+            "parquet.field.nested.ids": {"arr_col.element": 1}
+          }
+        }
+      ]
+    },
+    "map_string_int_mapped_missing_nested_ids": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {"delta.columnMapping.id": 1, "delta.columnMapping.physicalName": "id"}
+        },
+        {
+          "name": "map_col",
+          "type": {
+            "type": "map",
+            "keyType": "string",
+            "valueType": "integer",
+            "valueContainsNull": true
+          },
+          "nullable": true,
+          "metadata": {"delta.columnMapping.id": 2, "delta.columnMapping.physicalName": "map_col"}
+        }
+      ]
+    },
+    "map_string_int_mapped_non_int_nested_ids": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {"delta.columnMapping.id": 1, "delta.columnMapping.physicalName": "id"}
+        },
+        {
+          "name": "map_col",
+          "type": {
+            "type": "map",
+            "keyType": "string",
+            "valueType": "integer",
+            "valueContainsNull": true
+          },
+          "nullable": true,
+          "metadata": {
+            "delta.columnMapping.id": 2,
+            "delta.columnMapping.physicalName": "map_col",
+            "parquet.field.nested.ids": {"map_col.key": "not-an-int", "map_col.value": 100}
+          }
+        }
+      ]
+    },
+    "map_string_int_mapped_nested_ids_overlap_cm_ids": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {"delta.columnMapping.id": 1, "delta.columnMapping.physicalName": "id"}
+        },
+        {
+          "name": "map_col",
+          "type": {
+            "type": "map",
+            "keyType": "string",
+            "valueType": "integer",
+            "valueContainsNull": true
+          },
+          "nullable": true,
+          "metadata": {
+            "delta.columnMapping.id": 2,
+            "delta.columnMapping.physicalName": "map_col",
+            "parquet.field.nested.ids": {"map_col.key": 1, "map_col.value": 2}
+          }
+        }
+      ]
+    },
+    "void_type_mapped": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {"delta.columnMapping.id": 1, "delta.columnMapping.physicalName": "id"}
+        },
+        {
+          "name": "void_col",
+          "type": "void",
+          "nullable": true,
+          "metadata": {"delta.columnMapping.id": 2, "delta.columnMapping.physicalName": "void_col"}
+        }
+      ]
     }
   },
   "$protocols": {
@@ -22,9 +172,21 @@
       "minWriterVersion": 7,
       "writerFeatures": ["columnMapping"]
     },
+    "column_mapping_only_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["columnMapping"],
+      "writerFeatures": ["columnMapping"]
+    },
     "iceberg_v1_and_v2_2_7": {
       "minReaderVersion": 2,
       "minWriterVersion": 7,
+      "writerFeatures": ["columnMapping", "icebergCompatV1", "icebergCompatV2"]
+    },
+    "iceberg_v1_and_v2_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["columnMapping"],
       "writerFeatures": ["columnMapping", "icebergCompatV1", "icebergCompatV2"]
     },
     "iceberg_v2_with_dv_2_7": {
@@ -32,10 +194,28 @@
       "minWriterVersion": 7,
       "writerFeatures": ["columnMapping", "icebergCompatV2", "deletionVectors"]
     },
+    "iceberg_v2_with_dv_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["columnMapping", "deletionVectors"],
+      "writerFeatures": ["columnMapping", "icebergCompatV2", "deletionVectors"]
+    },
     "iceberg_v2_no_cm_2_7": {
       "minReaderVersion": 2,
       "minWriterVersion": 7,
       "writerFeatures": ["icebergCompatV2"]
+    },
+    "iceberg_v2_no_cm_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": ["icebergCompatV2"]
+    },
+    "no_features_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": []
     },
     "iceberg_v2_2_7": {
       "minReaderVersion": 2,
@@ -50,7 +230,7 @@
     }
   },
   "$notes": {
-    "v2_activation": "icebergCompatV2 is activated by two conditions: (1) the feature listed in writerFeatures, and (2) the table property delta.enableIcebergCompatV2=true. When active, columnMapping must be in name or id mode, and deletion vectors must not be active (DV may be supported but inactive \u2014 contrast with ICv1, which forbids DV support entirely). ICv2 also requires nested field identifiers for arrays and maps, int64 timestamps, and columns from an allowed-types list.",
+    "v2_activation": "icebergCompatV2 is activated by two conditions: (1) the feature listed in writerFeatures, and (2) the table property delta.enableIcebergCompatV2=true. When active, columnMapping must be in name or id mode, and deletion vectors must not be active (DV may be supported but inactive -- contrast with ICv1, which forbids DV support entirely). Additional ICv2 constraints (nested IDs for arrays/maps and allowed-type checks) are covered by dedicated negative cases in this fixture.",
     "mutual_exclusion": "icebergCompatV1 and icebergCompatV2 are mutually exclusive. V2 explicitly requires that V1 is not active (feature absent or property not true). icebergCompatV3-preview additionally requires that both V1 and V2 are not active."
   },
   "cases": [
@@ -75,14 +255,14 @@
     },
     {
       "ordinal": 2,
-      "name": "iceberg_v2_create_table_2_7_no_feature_listed_property_true_succeeds",
+      "name": "iceberg_v2_create_table_3_7_no_feature_listed_property_true_succeeds",
       "feature": "icebergCompatV2",
       "flavor": "orphan",
-      "description": "Creating a (2,7)+[columnMapping] table with delta.enableIcebergCompatV2=true but icebergCompatV2 absent from writerFeatures succeeds.",
+      "description": "Creating a (3,7)+[columnMapping] table with delta.enableIcebergCompatV2=true but icebergCompatV2 absent from writerFeatures succeeds.",
       "note": "$errata.orphan_feature_metadata",
       "operation": {
         "type": "create_table",
-        "protocol": "$protocols.column_mapping_only_2_7",
+        "protocol": "$protocols.column_mapping_only_3_7",
         "metadata": {
           "schemaString": "$schemas.simple_int_mapped",
           "configuration": {
@@ -97,7 +277,7 @@
       "ordinal": 3,
       "name": "iceberg_v2_read_snapshot_2_7_feature_listed_property_true_succeeds",
       "feature": "icebergCompatV2",
-      "description": "Reading a (2,7)+[columnMapping,icebergCompatV2] table with delta.enableIcebergCompatV2=true succeeds; icebergCompatV2 is writer-only.",
+      "description": "Reading a (2,7)+[columnMapping,icebergCompatV2] table with delta.enableIcebergCompatV2=true succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.iceberg_v2_2_7"},
@@ -119,7 +299,7 @@
       "ordinal": 4,
       "name": "iceberg_v2_empty_commit_2_7_feature_listed_property_true_succeeds",
       "feature": "icebergCompatV2",
-      "description": "Appending to a (2,7)+[columnMapping,icebergCompatV2] table with delta.enableIcebergCompatV2=true succeeds.",
+      "description": "Committing to a (2,7)+[columnMapping,icebergCompatV2] table with delta.enableIcebergCompatV2=true succeeds.",
       "setup": {
         "log_actions": [
           {"protocol": "$protocols.iceberg_v2_2_7"},
@@ -139,13 +319,13 @@
     },
     {
       "ordinal": 5,
-      "name": "iceberg_v2_supported_not_active_create_table_succeeds",
+      "name": "iceberg_v2_supported_not_active_create_table_3_7_succeeds",
       "feature": "icebergCompatV2",
       "flavor": "supported_not_active",
-      "description": "Creating a (2,7)+[columnMapping,icebergCompatV2] table without delta.enableIcebergCompatV2=true succeeds; icebergCompatV2 writer requirements only apply when the feature is active.",
+      "description": "Creating a (3,7)+[columnMapping,icebergCompatV2] table without delta.enableIcebergCompatV2=true succeeds.",
       "operation": {
         "type": "create_table",
-        "protocol": "$protocols.iceberg_v2_2_7",
+        "protocol": "$protocols.iceberg_v2_3_7",
         "metadata": {"schemaString": "$schemas.simple_int"}
       },
       "expected_outcome": "success"
@@ -154,7 +334,7 @@
       "ordinal": 6,
       "name": "iceberg_v2_create_table_3_7_feature_listed_property_true_succeeds",
       "feature": "icebergCompatV2",
-      "description": "Creating a (3,7)+[columnMapping in readerFeatures and writerFeatures, icebergCompatV2] table with columnMapping mode=name and delta.enableIcebergCompatV2=true succeeds; (3,7) with columnMapping in readerFeatures is a valid alternate protocol path.",
+      "description": "Creating a (3,7)+[columnMapping in readerFeatures and writerFeatures, icebergCompatV2] table with columnMapping mode=name and delta.enableIcebergCompatV2=true succeeds.",
       "operation": {
         "type": "create_table",
         "protocol": "$protocols.iceberg_v2_3_7",
@@ -170,13 +350,13 @@
     },
     {
       "ordinal": 7,
-      "name": "iceberg_v2_create_table_2_7_missing_column_mapping_fails",
+      "name": "iceberg_v2_create_table_3_7_missing_column_mapping_fails",
       "feature": "icebergCompatV2",
       "flavor": "missing_dependency",
-      "description": "Creating a (2,7)+[icebergCompatV2] table without columnMapping in writerFeatures and delta.enableIcebergCompatV2=true fails; the spec requires columnMapping to be co-listed.",
+      "description": "Creating a (3,7)+[icebergCompatV2] table without columnMapping in readerFeatures and writerFeatures fails; icebergCompatV2 support requires columnMapping support.",
       "operation": {
         "type": "create_table",
-        "protocol": "$protocols.iceberg_v2_no_cm_2_7",
+        "protocol": "$protocols.iceberg_v2_no_cm_3_7",
         "metadata": {
           "schemaString": "$schemas.simple_int",
           "configuration": {"delta.enableIcebergCompatV2": "true"}
@@ -186,12 +366,13 @@
     },
     {
       "ordinal": 8,
-      "name": "iceberg_v2_create_table_2_7_column_mapping_not_active_fails",
+      "name": "iceberg_v2_create_table_3_7_column_mapping_not_active_fails",
       "feature": "icebergCompatV2",
-      "description": "Creating a (2,7)+[columnMapping,icebergCompatV2] table with delta.enableIcebergCompatV2=true but no columnMapping mode set fails; the spec requires columnMapping to be active in name or id mode when ICv2 is active.",
+      "flavor": "missing_required_metadata",
+      "description": "Creating a (3,7)+[columnMapping,icebergCompatV2] table with delta.enableIcebergCompatV2=true but no columnMapping mode set fails; enabling icebergCompatV2 requires columnMapping to be active in name or id mode.",
       "operation": {
         "type": "create_table",
-        "protocol": "$protocols.iceberg_v2_2_7",
+        "protocol": "$protocols.iceberg_v2_3_7",
         "metadata": {
           "schemaString": "$schemas.simple_int",
           "configuration": {"delta.enableIcebergCompatV2": "true"}
@@ -201,13 +382,13 @@
     },
     {
       "ordinal": 9,
-      "name": "iceberg_v2_create_table_2_7_with_deletion_vectors_active_fails",
+      "name": "iceberg_v2_create_table_3_7_with_deletion_vectors_active_fails",
       "feature": "icebergCompatV2",
-      "description": "Creating a (2,7)+[columnMapping,icebergCompatV2,deletionVectors] table with delta.enableIcebergCompatV2=true and delta.enableDeletionVectors=true fails; ICv2 requires deletion vectors not be active.",
+      "description": "Creating a (3,7)+[columnMapping,icebergCompatV2,deletionVectors] table with delta.enableIcebergCompatV2=true and delta.enableDeletionVectors=true fails; ICv2 requires deletion vectors not be active.",
       "note": "$errata.iceberg_compat_dv_restriction",
       "operation": {
         "type": "create_table",
-        "protocol": "$protocols.iceberg_v2_with_dv_2_7",
+        "protocol": "$protocols.iceberg_v2_with_dv_3_7",
         "metadata": {
           "schemaString": "$schemas.simple_int_mapped",
           "configuration": {
@@ -221,13 +402,13 @@
     },
     {
       "ordinal": 10,
-      "name": "iceberg_v2_create_table_2_7_with_deletion_vectors_supported_not_active_succeeds",
+      "name": "iceberg_v2_create_table_3_7_with_deletion_vectors_supported_not_active_succeeds",
       "feature": "icebergCompatV2",
-      "description": "Creating a (2,7)+[columnMapping,icebergCompatV2,deletionVectors] table with delta.enableIcebergCompatV2=true but without delta.enableDeletionVectors=true succeeds; ICv2 only prohibits deletion vectors being active, not merely supported. This is the key behavioral difference from ICv1, which prohibits deletion vectors being present in the protocol at all.",
+      "description": "Creating a (3,7)+[columnMapping,icebergCompatV2,deletionVectors] table with delta.enableIcebergCompatV2=true but without delta.enableDeletionVectors=true succeeds; ICv2 only prohibits deletion vectors being active.",
       "note": "$errata.iceberg_compat_dv_restriction",
       "operation": {
         "type": "create_table",
-        "protocol": "$protocols.iceberg_v2_with_dv_2_7",
+        "protocol": "$protocols.iceberg_v2_with_dv_3_7",
         "metadata": {
           "schemaString": "$schemas.simple_int_mapped",
           "configuration": {
@@ -240,12 +421,12 @@
     },
     {
       "ordinal": 11,
-      "name": "iceberg_v1_and_v2_feature_listed_only_v2_property_true_succeeds",
+      "name": "iceberg_v1_and_v2_feature_listed_only_v2_property_true_3_7_succeeds",
       "feature": "icebergCompatV2",
-      "description": "Creating a (2,7)+[columnMapping,icebergCompatV1,icebergCompatV2] table with only delta.enableIcebergCompatV2=true (ICv1 not active) succeeds; the mutual exclusion check fires on ICv1 being active, not merely supported.",
+      "description": "Creating a (3,7)+[columnMapping,icebergCompatV1,icebergCompatV2] table with only delta.enableIcebergCompatV2=true (ICv1 not active) succeeds; the mutual exclusion check fires on ICv1 being active, not merely supported.",
       "operation": {
         "type": "create_table",
-        "protocol": "$protocols.iceberg_v1_and_v2_2_7",
+        "protocol": "$protocols.iceberg_v1_and_v2_3_7",
         "metadata": {
           "schemaString": "$schemas.simple_int_mapped",
           "configuration": {
@@ -258,13 +439,13 @@
     },
     {
       "ordinal": 12,
-      "name": "iceberg_v1_and_v2_create_table_both_active_fails",
+      "name": "iceberg_v1_and_v2_create_table_both_active_3_7_fails",
       "feature": "icebergCompatV2",
       "description": "Creating a table with both delta.enableIcebergCompatV1=true and delta.enableIcebergCompatV2=true fails; V2 requires that V1 is not active.",
       "note": "$notes.mutual_exclusion",
       "operation": {
         "type": "create_table",
-        "protocol": "$protocols.iceberg_v1_and_v2_2_7",
+        "protocol": "$protocols.iceberg_v1_and_v2_3_7",
         "metadata": {
           "schemaString": "$schemas.simple_int_mapped",
           "configuration": {
@@ -278,14 +459,14 @@
     },
     {
       "ordinal": 13,
-      "name": "iceberg_v2_read_snapshot_2_7_no_feature_listed_with_property_succeeds",
+      "name": "iceberg_v2_read_snapshot_3_7_no_feature_listed_with_property_succeeds",
       "feature": "icebergCompatV2",
       "flavor": "orphan",
-      "description": "Reading a (2,7)+[columnMapping] table with delta.enableIcebergCompatV2=true but icebergCompatV2 absent from writerFeatures succeeds; icebergCompatV2 is writer-only and the orphan property has no effect on reads.",
+      "description": "Reading a (3,7)+[columnMapping] table with delta.enableIcebergCompatV2=true but icebergCompatV2 absent from writerFeatures succeeds.",
       "note": "$errata.orphan_feature_metadata",
       "setup": {
         "log_actions": [
-          {"protocol": "$protocols.column_mapping_only_2_7"},
+          {"protocol": "$protocols.column_mapping_only_3_7"},
           {
             "metaData": {
               "schemaString": "$schemas.simple_int_mapped",
@@ -302,17 +483,223 @@
     },
     {
       "ordinal": 14,
-      "name": "iceberg_v2_empty_commit_2_7_without_column_mapping_protocol_fails",
+      "name": "iceberg_v2_create_table_3_7_without_column_mapping_protocol_fails",
       "feature": "icebergCompatV2",
       "flavor": "missing_dependency",
-      "description": "Appending to a (2,7)+[icebergCompatV2] table without columnMapping in writerFeatures fails; the spec requires columnMapping to be co-listed whenever icebergCompatV2 is listed.",
-      "setup": {
-        "log_actions": [
-          {"protocol": "$protocols.iceberg_v2_no_cm_2_7"},
-          {"metaData": {"schemaString": "$schemas.simple_int"}}
-        ]
+      "description": "Creating a (3,7)+[icebergCompatV2] table without columnMapping in readerFeatures and writerFeatures fails, even without delta.enableIcebergCompatV2=true; the spec requires columnMapping support whenever icebergCompatV2 is listed.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v2_no_cm_3_7",
+        "metadata": {"schemaString": "$schemas.simple_int"}
       },
-      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 15,
+      "name": "iceberg_v2_create_table_3_7_no_feature_no_cm_property_true_succeeds",
+      "feature": "icebergCompatV2",
+      "flavor": "orphan",
+      "description": "Creating a (3,7)+[] table with delta.enableIcebergCompatV2=true succeeds; when icebergCompatV2 is absent from protocol, columnMapping dependency checks do not apply.",
+      "note": "$errata.orphan_feature_metadata",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.no_features_3_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {"delta.enableIcebergCompatV2": "true"}
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 16,
+      "name": "iceberg_v2_supported_not_active_create_table_3_7_with_deletion_vectors_active_succeeds",
+      "feature": "icebergCompatV2",
+      "flavor": "supported_not_active",
+      "description": "Creating a (3,7)+[columnMapping,icebergCompatV2,deletionVectors] table with delta.enableDeletionVectors=true but without delta.enableIcebergCompatV2=true succeeds; ICv2 deletionVectors restrictions apply only when ICv2 is active.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v2_with_dv_3_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int_mapped",
+          "configuration": {
+            "delta.columnMapping.mode": "name",
+            "delta.enableDeletionVectors": "true"
+          }
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 17,
+      "name": "iceberg_v2_supported_not_active_create_table_3_7_with_deletion_vectors_supported_not_active_succeeds",
+      "feature": "icebergCompatV2",
+      "flavor": "supported_not_active",
+      "description": "Creating a (3,7)+[columnMapping,icebergCompatV2,deletionVectors] table without delta.enableIcebergCompatV2=true and without delta.enableDeletionVectors=true succeeds; ICv2 deletionVectors restrictions apply only when ICv2 is active.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v2_with_dv_3_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int_mapped",
+          "configuration": {"delta.columnMapping.mode": "name"}
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 18,
+      "name": "iceberg_v2_create_table_3_7_with_void_type_fails",
+      "feature": "icebergCompatV2",
+      "flavor": "invalid_metadata_content",
+      "description": "Creating a (3,7)+[columnMapping,icebergCompatV2] table with delta.enableIcebergCompatV2=true and a Void type column fails; ICv2 allows only its listed data types when active.",
+      "note": "$notes.v2_activation",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v2_3_7",
+        "metadata": {
+          "schemaString": "$schemas.void_type_mapped",
+          "configuration": {
+            "delta.columnMapping.mode": "name",
+            "delta.enableIcebergCompatV2": "true"
+          }
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 19,
+      "name": "iceberg_v2_create_table_3_7_array_missing_nested_ids_fails",
+      "feature": "icebergCompatV2",
+      "flavor": "invalid_metadata_content",
+      "description": "Creating a (3,7)+[columnMapping,icebergCompatV2] table with delta.enableIcebergCompatV2=true fails when Array metadata omits required parquet.field.nested.ids entries.",
+      "note": "$notes.v2_activation",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v2_3_7",
+        "metadata": {
+          "schemaString": "$schemas.array_int_mapped_missing_nested_ids",
+          "configuration": {
+            "delta.columnMapping.mode": "name",
+            "delta.enableIcebergCompatV2": "true"
+          }
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 20,
+      "name": "iceberg_v2_create_table_3_7_map_missing_nested_ids_fails",
+      "feature": "icebergCompatV2",
+      "flavor": "invalid_metadata_content",
+      "description": "Creating a (3,7)+[columnMapping,icebergCompatV2] table with delta.enableIcebergCompatV2=true fails when Map metadata omits required parquet.field.nested.ids entries.",
+      "note": "$notes.v2_activation",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v2_3_7",
+        "metadata": {
+          "schemaString": "$schemas.map_string_int_mapped_missing_nested_ids",
+          "configuration": {
+            "delta.columnMapping.mode": "name",
+            "delta.enableIcebergCompatV2": "true"
+          }
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 21,
+      "name": "iceberg_v2_supported_not_active_create_table_3_7_with_void_type_succeeds",
+      "feature": "icebergCompatV2",
+      "flavor": "supported_not_active",
+      "description": "Creating a (3,7)+[columnMapping,icebergCompatV2] table with a Void type column but without delta.enableIcebergCompatV2=true succeeds; ICv2 type allow-list restrictions apply only when ICv2 is active.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v2_3_7",
+        "metadata": {
+          "schemaString": "$schemas.void_type_mapped",
+          "configuration": {"delta.columnMapping.mode": "name"}
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 22,
+      "name": "iceberg_v2_create_table_3_7_array_non_integer_nested_ids_fails",
+      "feature": "icebergCompatV2",
+      "flavor": "invalid_metadata_content",
+      "description": "Creating a (3,7)+[columnMapping,icebergCompatV2] table with delta.enableIcebergCompatV2=true fails when Array parquet.field.nested.ids values are not integers.",
+      "note": "$notes.v2_activation",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v2_3_7",
+        "metadata": {
+          "schemaString": "$schemas.array_int_mapped_non_int_nested_ids",
+          "configuration": {
+            "delta.columnMapping.mode": "name",
+            "delta.enableIcebergCompatV2": "true"
+          }
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 23,
+      "name": "iceberg_v2_create_table_3_7_map_non_integer_nested_ids_fails",
+      "feature": "icebergCompatV2",
+      "flavor": "invalid_metadata_content",
+      "description": "Creating a (3,7)+[columnMapping,icebergCompatV2] table with delta.enableIcebergCompatV2=true fails when Map parquet.field.nested.ids values are not integers.",
+      "note": "$notes.v2_activation",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v2_3_7",
+        "metadata": {
+          "schemaString": "$schemas.map_string_int_mapped_non_int_nested_ids",
+          "configuration": {
+            "delta.columnMapping.mode": "name",
+            "delta.enableIcebergCompatV2": "true"
+          }
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 24,
+      "name": "iceberg_v2_create_table_3_7_array_nested_ids_overlap_column_mapping_ids_fails",
+      "feature": "icebergCompatV2",
+      "flavor": "invalid_metadata_content",
+      "description": "Creating a (3,7)+[columnMapping,icebergCompatV2] table with delta.enableIcebergCompatV2=true fails when Array parquet.field.nested.ids reuse column-mapping IDs.",
+      "note": "$notes.v2_activation",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v2_3_7",
+        "metadata": {
+          "schemaString": "$schemas.array_int_mapped_nested_ids_overlap_cm_ids",
+          "configuration": {
+            "delta.columnMapping.mode": "name",
+            "delta.enableIcebergCompatV2": "true"
+          }
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 25,
+      "name": "iceberg_v2_create_table_3_7_map_nested_ids_overlap_column_mapping_ids_fails",
+      "feature": "icebergCompatV2",
+      "flavor": "invalid_metadata_content",
+      "description": "Creating a (3,7)+[columnMapping,icebergCompatV2] table with delta.enableIcebergCompatV2=true fails when Map parquet.field.nested.ids reuse column-mapping IDs.",
+      "note": "$notes.v2_activation",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v2_3_7",
+        "metadata": {
+          "schemaString": "$schemas.map_string_int_mapped_nested_ids_overlap_cm_ids",
+          "configuration": {
+            "delta.columnMapping.mode": "name",
+            "delta.enableIcebergCompatV2": "true"
+          }
+        }
+      },
       "expected_outcome": "failure"
     }
   ]

--- a/compliance-suite/fixtures/iceberg-compat-v2.json
+++ b/compliance-suite/fixtures/iceberg-compat-v2.json
@@ -1,0 +1,319 @@
+{
+  "$schemas": {
+    "simple_int_mapped": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {"delta.columnMapping.id": 1, "delta.columnMapping.physicalName": "id"}
+        }
+      ]
+    },
+    "simple_int": {
+      "type": "struct",
+      "fields": [{"name": "id", "type": "integer", "nullable": true, "metadata": {}}]
+    }
+  },
+  "$protocols": {
+    "column_mapping_only_2_7": {
+      "minReaderVersion": 2,
+      "minWriterVersion": 7,
+      "writerFeatures": ["columnMapping"]
+    },
+    "iceberg_v1_and_v2_2_7": {
+      "minReaderVersion": 2,
+      "minWriterVersion": 7,
+      "writerFeatures": ["columnMapping", "icebergCompatV1", "icebergCompatV2"]
+    },
+    "iceberg_v2_with_dv_2_7": {
+      "minReaderVersion": 2,
+      "minWriterVersion": 7,
+      "writerFeatures": ["columnMapping", "icebergCompatV2", "deletionVectors"]
+    },
+    "iceberg_v2_no_cm_2_7": {
+      "minReaderVersion": 2,
+      "minWriterVersion": 7,
+      "writerFeatures": ["icebergCompatV2"]
+    },
+    "iceberg_v2_2_7": {
+      "minReaderVersion": 2,
+      "minWriterVersion": 7,
+      "writerFeatures": ["columnMapping", "icebergCompatV2"]
+    },
+    "iceberg_v2_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["columnMapping"],
+      "writerFeatures": ["columnMapping", "icebergCompatV2"]
+    }
+  },
+  "$notes": {
+    "v2_activation": "icebergCompatV2 is activated by two conditions: (1) the feature listed in writerFeatures, and (2) the table property delta.enableIcebergCompatV2=true. When active, columnMapping must be in name or id mode, and deletion vectors must not be active (DV may be supported but inactive \u2014 contrast with ICv1, which forbids DV support entirely). ICv2 also requires nested field identifiers for arrays and maps, int64 timestamps, and columns from an allowed-types list.",
+    "mutual_exclusion": "icebergCompatV1 and icebergCompatV2 are mutually exclusive. V2 explicitly requires that V1 is not active (feature absent or property not true). icebergCompatV3-preview additionally requires that both V1 and V2 are not active."
+  },
+  "cases": [
+    {
+      "ordinal": 1,
+      "name": "iceberg_v2_create_table_2_7_feature_listed_property_true_succeeds",
+      "feature": "icebergCompatV2",
+      "description": "Creating a (2,7)+[columnMapping,icebergCompatV2] table with columnMapping mode=name and delta.enableIcebergCompatV2=true succeeds.",
+      "note": "$notes.v2_activation",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v2_2_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int_mapped",
+          "configuration": {
+            "delta.columnMapping.mode": "name",
+            "delta.enableIcebergCompatV2": "true"
+          }
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 2,
+      "name": "iceberg_v2_create_table_2_7_no_feature_listed_property_true_succeeds",
+      "feature": "icebergCompatV2",
+      "flavor": "orphan",
+      "description": "Creating a (2,7)+[columnMapping] table with delta.enableIcebergCompatV2=true but icebergCompatV2 absent from writerFeatures succeeds.",
+      "note": "$errata.orphan_feature_metadata",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.column_mapping_only_2_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int_mapped",
+          "configuration": {
+            "delta.columnMapping.mode": "name",
+            "delta.enableIcebergCompatV2": "true"
+          }
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 3,
+      "name": "iceberg_v2_read_snapshot_2_7_feature_listed_property_true_succeeds",
+      "feature": "icebergCompatV2",
+      "description": "Reading a (2,7)+[columnMapping,icebergCompatV2] table with delta.enableIcebergCompatV2=true succeeds; icebergCompatV2 is writer-only.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.iceberg_v2_2_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int_mapped",
+              "configuration": {
+                "delta.columnMapping.mode": "name",
+                "delta.enableIcebergCompatV2": "true"
+              }
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 4,
+      "name": "iceberg_v2_empty_commit_2_7_feature_listed_property_true_succeeds",
+      "feature": "icebergCompatV2",
+      "description": "Appending to a (2,7)+[columnMapping,icebergCompatV2] table with delta.enableIcebergCompatV2=true succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.iceberg_v2_2_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int_mapped",
+              "configuration": {
+                "delta.columnMapping.mode": "name",
+                "delta.enableIcebergCompatV2": "true"
+              }
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 5,
+      "name": "iceberg_v2_supported_not_active_create_table_succeeds",
+      "feature": "icebergCompatV2",
+      "flavor": "supported_not_active",
+      "description": "Creating a (2,7)+[columnMapping,icebergCompatV2] table without delta.enableIcebergCompatV2=true succeeds; icebergCompatV2 writer requirements only apply when the feature is active.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v2_2_7",
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 6,
+      "name": "iceberg_v2_create_table_3_7_feature_listed_property_true_succeeds",
+      "feature": "icebergCompatV2",
+      "description": "Creating a (3,7)+[columnMapping in readerFeatures and writerFeatures, icebergCompatV2] table with columnMapping mode=name and delta.enableIcebergCompatV2=true succeeds; (3,7) with columnMapping in readerFeatures is a valid alternate protocol path.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v2_3_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int_mapped",
+          "configuration": {
+            "delta.columnMapping.mode": "name",
+            "delta.enableIcebergCompatV2": "true"
+          }
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 7,
+      "name": "iceberg_v2_create_table_2_7_missing_column_mapping_fails",
+      "feature": "icebergCompatV2",
+      "flavor": "missing_dependency",
+      "description": "Creating a (2,7)+[icebergCompatV2] table without columnMapping in writerFeatures and delta.enableIcebergCompatV2=true fails; the spec requires columnMapping to be co-listed.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v2_no_cm_2_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {"delta.enableIcebergCompatV2": "true"}
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 8,
+      "name": "iceberg_v2_create_table_2_7_column_mapping_not_active_fails",
+      "feature": "icebergCompatV2",
+      "description": "Creating a (2,7)+[columnMapping,icebergCompatV2] table with delta.enableIcebergCompatV2=true but no columnMapping mode set fails; the spec requires columnMapping to be active in name or id mode when ICv2 is active.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v2_2_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {"delta.enableIcebergCompatV2": "true"}
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 9,
+      "name": "iceberg_v2_create_table_2_7_with_deletion_vectors_active_fails",
+      "feature": "icebergCompatV2",
+      "description": "Creating a (2,7)+[columnMapping,icebergCompatV2,deletionVectors] table with delta.enableIcebergCompatV2=true and delta.enableDeletionVectors=true fails; ICv2 requires deletion vectors not be active.",
+      "note": "$errata.iceberg_compat_dv_restriction",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v2_with_dv_2_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int_mapped",
+          "configuration": {
+            "delta.columnMapping.mode": "name",
+            "delta.enableIcebergCompatV2": "true",
+            "delta.enableDeletionVectors": "true"
+          }
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 10,
+      "name": "iceberg_v2_create_table_2_7_with_deletion_vectors_supported_not_active_succeeds",
+      "feature": "icebergCompatV2",
+      "description": "Creating a (2,7)+[columnMapping,icebergCompatV2,deletionVectors] table with delta.enableIcebergCompatV2=true but without delta.enableDeletionVectors=true succeeds; ICv2 only prohibits deletion vectors being active, not merely supported. This is the key behavioral difference from ICv1, which prohibits deletion vectors being present in the protocol at all.",
+      "note": "$errata.iceberg_compat_dv_restriction",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v2_with_dv_2_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int_mapped",
+          "configuration": {
+            "delta.columnMapping.mode": "name",
+            "delta.enableIcebergCompatV2": "true"
+          }
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 11,
+      "name": "iceberg_v1_and_v2_feature_listed_only_v2_property_true_succeeds",
+      "feature": "icebergCompatV2",
+      "description": "Creating a (2,7)+[columnMapping,icebergCompatV1,icebergCompatV2] table with only delta.enableIcebergCompatV2=true (ICv1 not active) succeeds; the mutual exclusion check fires on ICv1 being active, not merely supported.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v1_and_v2_2_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int_mapped",
+          "configuration": {
+            "delta.columnMapping.mode": "name",
+            "delta.enableIcebergCompatV2": "true"
+          }
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 12,
+      "name": "iceberg_v1_and_v2_create_table_both_active_fails",
+      "feature": "icebergCompatV2",
+      "description": "Creating a table with both delta.enableIcebergCompatV1=true and delta.enableIcebergCompatV2=true fails; V2 requires that V1 is not active.",
+      "note": "$notes.mutual_exclusion",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v1_and_v2_2_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int_mapped",
+          "configuration": {
+            "delta.columnMapping.mode": "name",
+            "delta.enableIcebergCompatV1": "true",
+            "delta.enableIcebergCompatV2": "true"
+          }
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 13,
+      "name": "iceberg_v2_read_snapshot_2_7_no_feature_listed_with_property_succeeds",
+      "feature": "icebergCompatV2",
+      "flavor": "orphan",
+      "description": "Reading a (2,7)+[columnMapping] table with delta.enableIcebergCompatV2=true but icebergCompatV2 absent from writerFeatures succeeds; icebergCompatV2 is writer-only and the orphan property has no effect on reads.",
+      "note": "$errata.orphan_feature_metadata",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.column_mapping_only_2_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int_mapped",
+              "configuration": {
+                "delta.columnMapping.mode": "name",
+                "delta.enableIcebergCompatV2": "true"
+              }
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 14,
+      "name": "iceberg_v2_empty_commit_2_7_without_column_mapping_protocol_fails",
+      "feature": "icebergCompatV2",
+      "flavor": "missing_dependency",
+      "description": "Appending to a (2,7)+[icebergCompatV2] table without columnMapping in writerFeatures fails; the spec requires columnMapping to be co-listed whenever icebergCompatV2 is listed.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.iceberg_v2_no_cm_2_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    }
+  ]
+}

--- a/compliance-suite/fixtures/iceberg-compat-v3-preview.json
+++ b/compliance-suite/fixtures/iceberg-compat-v3-preview.json
@@ -1,0 +1,232 @@
+{
+  "$schemas": {
+    "simple_int_mapped": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {"delta.columnMapping.id": 1, "delta.columnMapping.physicalName": "id"}
+        }
+      ]
+    },
+    "simple_int": {
+      "type": "struct",
+      "fields": [{"name": "id", "type": "integer", "nullable": true, "metadata": {}}]
+    }
+  },
+  "$protocols": {
+    "iceberg_v3_preview_no_cm_2_7": {
+      "minReaderVersion": 2,
+      "minWriterVersion": 7,
+      "writerFeatures": ["domainMetadata", "rowTracking", "icebergCompatV3-preview"]
+    },
+    "iceberg_v3_preview_2_7": {
+      "minReaderVersion": 2,
+      "minWriterVersion": 7,
+      "writerFeatures": [
+        "columnMapping",
+        "domainMetadata",
+        "rowTracking",
+        "icebergCompatV3-preview"
+      ]
+    },
+    "iceberg_v3_preview_and_v1_2_7": {
+      "minReaderVersion": 2,
+      "minWriterVersion": 7,
+      "writerFeatures": [
+        "columnMapping",
+        "domainMetadata",
+        "rowTracking",
+        "icebergCompatV1",
+        "icebergCompatV3-preview"
+      ]
+    },
+    "iceberg_v3_preview_with_dv_2_7": {
+      "minReaderVersion": 2,
+      "minWriterVersion": 7,
+      "writerFeatures": [
+        "columnMapping",
+        "domainMetadata",
+        "rowTracking",
+        "icebergCompatV3-preview",
+        "deletionVectors"
+      ]
+    },
+    "iceberg_v3_preview_and_v2_2_7": {
+      "minReaderVersion": 2,
+      "minWriterVersion": 7,
+      "writerFeatures": [
+        "columnMapping",
+        "domainMetadata",
+        "rowTracking",
+        "icebergCompatV2",
+        "icebergCompatV3-preview"
+      ]
+    }
+  },
+  "$notes": {
+    "mutual_exclusion": "icebergCompatV1 and icebergCompatV2 are mutually exclusive. V2 explicitly requires that V1 is not active (feature absent or property not true). icebergCompatV3-preview additionally requires that both V1 and V2 are not active.",
+    "v3_preview_rfc": "icebergCompatV3 is an RFC-stage feature (protocol_rfcs/iceberg-compat-v3.md) not yet ratified in PROTOCOL.md. Cases use the feature name icebergCompatV3-preview per the pre-ratification naming convention. RFC requirements: CM name or id mode, Row Tracking enabled on the table, ICv1 and ICv2 not active. Unlike ICv1 and ICv2, DV is explicitly permitted to be both supported and active under ICv3."
+  },
+  "cases": [
+    {
+      "ordinal": 1,
+      "name": "iceberg_v3_preview_create_table_2_7_feature_listed_property_true_succeeds",
+      "feature": "icebergCompatV3-preview",
+      "description": "Creating a (2,7)+[columnMapping,domainMetadata,rowTracking,icebergCompatV3-preview] table with columnMapping mode=name, delta.enableIcebergCompatV3=true, and row tracking enabled succeeds.",
+      "note": "$notes.v3_preview_rfc",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v3_preview_2_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int_mapped",
+          "configuration": {
+            "delta.columnMapping.mode": "name",
+            "delta.enableIcebergCompatV3": "true",
+            "delta.enableRowTracking": "true",
+            "delta.rowTracking.materializedRowIdColumnName": "_row_id",
+            "delta.rowTracking.materializedRowCommitVersionColumnName": "_commit_version"
+          }
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 2,
+      "name": "iceberg_v3_preview_supported_not_active_create_table_succeeds",
+      "feature": "icebergCompatV3-preview",
+      "flavor": "supported_not_active",
+      "description": "Creating a (2,7)+[columnMapping,domainMetadata,rowTracking,icebergCompatV3-preview] table without delta.enableIcebergCompatV3=true succeeds; icebergCompatV3-preview writer requirements only apply when the feature is active.",
+      "note": "$notes.v3_preview_rfc",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v3_preview_2_7",
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 3,
+      "name": "iceberg_v3_preview_create_table_2_7_with_deletion_vectors_active_succeeds",
+      "feature": "icebergCompatV3-preview",
+      "description": "Creating a (2,7)+[columnMapping,domainMetadata,rowTracking,icebergCompatV3-preview,deletionVectors] table with delta.enableIcebergCompatV3=true and delta.enableDeletionVectors=true succeeds; unlike ICv1 and ICv2, ICv3 explicitly permits deletion vectors to be both supported and active.",
+      "note": "$notes.v3_preview_rfc",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v3_preview_with_dv_2_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int_mapped",
+          "configuration": {
+            "delta.columnMapping.mode": "name",
+            "delta.enableIcebergCompatV3": "true",
+            "delta.enableRowTracking": "true",
+            "delta.rowTracking.materializedRowIdColumnName": "_row_id",
+            "delta.rowTracking.materializedRowCommitVersionColumnName": "_commit_version",
+            "delta.enableDeletionVectors": "true"
+          }
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 4,
+      "name": "iceberg_v3_preview_create_table_2_7_missing_column_mapping_fails",
+      "feature": "icebergCompatV3-preview",
+      "flavor": "missing_dependency",
+      "description": "Creating a (2,7)+[domainMetadata,rowTracking,icebergCompatV3-preview] table without columnMapping in writerFeatures and delta.enableIcebergCompatV3=true fails; the RFC requires columnMapping to be co-listed.",
+      "note": "$notes.v3_preview_rfc",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v3_preview_no_cm_2_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {"delta.enableIcebergCompatV3": "true"}
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 5,
+      "name": "iceberg_v3_preview_create_table_2_7_column_mapping_not_active_fails",
+      "feature": "icebergCompatV3-preview",
+      "description": "Creating a (2,7)+[columnMapping,domainMetadata,rowTracking,icebergCompatV3-preview] table with delta.enableIcebergCompatV3=true but no columnMapping mode set fails; the RFC requires columnMapping to be active in name or id mode when ICv3 is active.",
+      "note": "$notes.v3_preview_rfc",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v3_preview_2_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {"delta.enableIcebergCompatV3": "true"}
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 6,
+      "name": "iceberg_v3_preview_create_table_2_7_row_tracking_not_enabled_fails",
+      "feature": "icebergCompatV3-preview",
+      "description": "Creating a (2,7)+[columnMapping,domainMetadata,rowTracking,icebergCompatV3-preview] table with delta.enableIcebergCompatV3=true but without delta.enableRowTracking=true fails; the RFC requires Row Tracking to be enabled when ICv3 is active.",
+      "note": "$notes.v3_preview_rfc",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v3_preview_2_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int_mapped",
+          "configuration": {
+            "delta.columnMapping.mode": "name",
+            "delta.enableIcebergCompatV3": "true"
+          }
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 7,
+      "name": "iceberg_v3_preview_and_v2_create_table_both_active_fails",
+      "feature": "icebergCompatV3-preview",
+      "description": "Creating a table with both delta.enableIcebergCompatV2=true and delta.enableIcebergCompatV3=true fails; the RFC requires ICv2 to not be active when ICv3 is active.",
+      "note": "$notes.mutual_exclusion",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v3_preview_and_v2_2_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int_mapped",
+          "configuration": {
+            "delta.columnMapping.mode": "name",
+            "delta.enableIcebergCompatV2": "true",
+            "delta.enableIcebergCompatV3": "true",
+            "delta.enableRowTracking": "true",
+            "delta.rowTracking.materializedRowIdColumnName": "_row_id",
+            "delta.rowTracking.materializedRowCommitVersionColumnName": "_commit_version"
+          }
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 8,
+      "name": "iceberg_v3_preview_and_v1_create_table_both_active_fails",
+      "feature": "icebergCompatV3-preview",
+      "description": "Creating a table with both delta.enableIcebergCompatV1=true and delta.enableIcebergCompatV3=true fails; the RFC requires ICv1 to not be active when ICv3 is active.",
+      "note": "$notes.mutual_exclusion",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_v3_preview_and_v1_2_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int_mapped",
+          "configuration": {
+            "delta.columnMapping.mode": "name",
+            "delta.enableIcebergCompatV1": "true",
+            "delta.enableIcebergCompatV3": "true",
+            "delta.enableRowTracking": "true",
+            "delta.rowTracking.materializedRowIdColumnName": "_row_id",
+            "delta.rowTracking.materializedRowCommitVersionColumnName": "_commit_version"
+          }
+        }
+      },
+      "expected_outcome": "failure"
+    }
+  ]
+}

--- a/compliance-suite/fixtures/iceberg-writer-compat.json
+++ b/compliance-suite/fixtures/iceberg-writer-compat.json
@@ -1,0 +1,172 @@
+{
+  "$schemas": {
+    "simple_int": {
+      "type": "struct",
+      "fields": [{"name": "id", "type": "integer", "nullable": true, "metadata": {}}]
+    },
+    "simple_int_id_col_mapped": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {"delta.columnMapping.id": 1, "delta.columnMapping.physicalName": "col-1"}
+        }
+      ]
+    },
+    "simple_int_name_mapped": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {"delta.columnMapping.id": 1, "delta.columnMapping.physicalName": "id"}
+        }
+      ]
+    },
+    "byte_col_id_col_mapped": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "b",
+          "type": "byte",
+          "nullable": true,
+          "metadata": {"delta.columnMapping.id": 1, "delta.columnMapping.physicalName": "col-1"}
+        }
+      ]
+    }
+  },
+  "$protocols": {
+    "iceberg_writer_v1_preview_2_7": {
+      "minReaderVersion": 2,
+      "minWriterVersion": 7,
+      "writerFeatures": ["columnMapping", "icebergCompatV2", "icebergWriterCompatV1-preview"]
+    },
+    "iceberg_writer_v1_preview_no_v2_2_7": {
+      "minReaderVersion": 2,
+      "minWriterVersion": 7,
+      "writerFeatures": ["columnMapping", "icebergWriterCompatV1-preview"]
+    }
+  },
+  "$notes": {
+    "writer_compat_v1_preview_rfc": "icebergWriterCompatV1 is an RFC-stage feature (protocol_rfcs/iceberg-writer-compat-v1.md) not yet ratified in PROTOCOL.md. Cases use the feature name icebergWriterCompatV1-preview per the pre-ratification naming convention. RFC requires: columnMapping AND icebergCompatV2 in writerFeatures, CM in id mode (tightening of ICv2 which allows name or id), physical names must follow the col-[id] convention, ICv2 must be enabled, no byte or short column types.",
+    "id_mode_required": "icebergWriterCompatV1 tightens ICv2's column mapping mode requirement from name-or-id to id-only, and further requires physical names to exactly follow the col-[id] convention (physicalName == 'col-' + columnMappingId)."
+  },
+  "cases": [
+    {
+      "ordinal": 1,
+      "name": "iceberg_writer_v1_preview_create_table_2_7_feature_listed_property_true_succeeds",
+      "feature": "icebergWriterCompatV1-preview",
+      "description": "Creating a (2,7)+[columnMapping,icebergCompatV2,icebergWriterCompatV1-preview] table with id-mode CM, col-[id] physical names, ICv2 active, and delta.enableIcebergWriterCompatV1=true succeeds.",
+      "note": "$notes.writer_compat_v1_preview_rfc",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_writer_v1_preview_2_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int_id_col_mapped",
+          "configuration": {
+            "delta.columnMapping.mode": "id",
+            "delta.enableIcebergCompatV2": "true",
+            "delta.enableIcebergWriterCompatV1": "true"
+          }
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 2,
+      "name": "iceberg_writer_v1_preview_supported_not_active_create_table_succeeds",
+      "feature": "icebergWriterCompatV1-preview",
+      "flavor": "supported_not_active",
+      "description": "Creating a (2,7)+[columnMapping,icebergCompatV2,icebergWriterCompatV1-preview] table without delta.enableIcebergWriterCompatV1=true succeeds; icebergWriterCompatV1-preview writer requirements only apply when the feature is active.",
+      "note": "$notes.writer_compat_v1_preview_rfc",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_writer_v1_preview_2_7",
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 3,
+      "name": "iceberg_writer_v1_preview_create_table_2_7_missing_iceberg_compat_v2_fails",
+      "feature": "icebergWriterCompatV1-preview",
+      "flavor": "missing_dependency",
+      "description": "Creating a (2,7)+[columnMapping,icebergWriterCompatV1-preview] table without icebergCompatV2 in writerFeatures and delta.enableIcebergWriterCompatV1=true fails; the RFC requires icebergCompatV2 to be co-listed as a protocol-level prerequisite.",
+      "note": "$notes.writer_compat_v1_preview_rfc",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_writer_v1_preview_no_v2_2_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int_id_col_mapped",
+          "configuration": {
+            "delta.columnMapping.mode": "id",
+            "delta.enableIcebergWriterCompatV1": "true"
+          }
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 4,
+      "name": "iceberg_writer_v1_preview_create_table_2_7_iceberg_compat_v2_not_active_fails",
+      "feature": "icebergWriterCompatV1-preview",
+      "description": "Creating a (2,7)+[columnMapping,icebergCompatV2,icebergWriterCompatV1-preview] table with delta.enableIcebergWriterCompatV1=true but without delta.enableIcebergCompatV2=true fails; the RFC requires ICv2 to be enabled (not merely supported) when icebergWriterCompatV1 is active.",
+      "note": "$notes.writer_compat_v1_preview_rfc",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_writer_v1_preview_2_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int_id_col_mapped",
+          "configuration": {
+            "delta.columnMapping.mode": "id",
+            "delta.enableIcebergWriterCompatV1": "true"
+          }
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 5,
+      "name": "iceberg_writer_v1_preview_create_table_2_7_column_mapping_name_mode_fails",
+      "feature": "icebergWriterCompatV1-preview",
+      "description": "Creating a (2,7)+[columnMapping,icebergCompatV2,icebergWriterCompatV1-preview] table with delta.enableIcebergWriterCompatV1=true and columnMapping mode=name fails; the RFC tightens ICv2's name-or-id requirement to id-only.",
+      "note": "$notes.id_mode_required",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_writer_v1_preview_2_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int_name_mapped",
+          "configuration": {
+            "delta.columnMapping.mode": "name",
+            "delta.enableIcebergCompatV2": "true",
+            "delta.enableIcebergWriterCompatV1": "true"
+          }
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 6,
+      "name": "iceberg_writer_v1_preview_create_table_2_7_byte_column_fails",
+      "feature": "icebergWriterCompatV1-preview",
+      "description": "Creating a (2,7)+[columnMapping,icebergCompatV2,icebergWriterCompatV1-preview] table with delta.enableIcebergWriterCompatV1=true and a byte-type column fails; the RFC forbids byte and short column types.",
+      "note": "$notes.writer_compat_v1_preview_rfc",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.iceberg_writer_v1_preview_2_7",
+        "metadata": {
+          "schemaString": "$schemas.byte_col_id_col_mapped",
+          "configuration": {
+            "delta.columnMapping.mode": "id",
+            "delta.enableIcebergCompatV2": "true",
+            "delta.enableIcebergWriterCompatV1": "true"
+          }
+        }
+      },
+      "expected_outcome": "failure"
+    }
+  ]
+}

--- a/compliance-suite/fixtures/identity-columns.json
+++ b/compliance-suite/fixtures/identity-columns.json
@@ -1,0 +1,331 @@
+{
+  "$schemas": {
+    "identity_col": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "long",
+          "nullable": true,
+          "metadata": {
+            "delta.identity.start": 1,
+            "delta.identity.step": 1,
+            "delta.identity.highWaterMark": 0,
+            "delta.identity.allowExplicitInsert": false
+          }
+        }
+      ]
+    },
+    "identity_col_step_zero": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "long",
+          "nullable": true,
+          "metadata": {
+            "delta.identity.start": 1,
+            "delta.identity.step": 0,
+            "delta.identity.highWaterMark": 0,
+            "delta.identity.allowExplicitInsert": false
+          }
+        }
+      ]
+    },
+    "simple_int": {
+      "type": "struct",
+      "fields": [{"name": "id", "type": "integer", "nullable": true, "metadata": {}}]
+    },
+    "identity_col_explicit_insert": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "long",
+          "nullable": true,
+          "metadata": {
+            "delta.identity.start": 1,
+            "delta.identity.step": 1,
+            "delta.identity.highWaterMark": 0,
+            "delta.identity.allowExplicitInsert": true
+          }
+        }
+      ]
+    },
+    "identity_col_negative_step": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "long",
+          "nullable": true,
+          "metadata": {
+            "delta.identity.start": -1,
+            "delta.identity.step": -1,
+            "delta.identity.highWaterMark": 0,
+            "delta.identity.allowExplicitInsert": false
+          }
+        }
+      ]
+    },
+    "cm_identity_col": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "long",
+          "nullable": true,
+          "metadata": {
+            "delta.columnMapping.id": 1,
+            "delta.columnMapping.physicalName": "col-1",
+            "delta.identity.start": 1,
+            "delta.identity.step": 1,
+            "delta.identity.highWaterMark": 0,
+            "delta.identity.allowExplicitInsert": false
+          }
+        }
+      ]
+    }
+  },
+  "$protocols": {
+    "modern_1_7": {"minReaderVersion": 1, "minWriterVersion": 7, "writerFeatures": []},
+    "identity_1_7": {
+      "minReaderVersion": 1,
+      "minWriterVersion": 7,
+      "writerFeatures": ["identityColumns"]
+    },
+    "modern_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": []
+    },
+    "modern_3_7_cm_identity": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["columnMapping"],
+      "writerFeatures": ["columnMapping", "identityColumns"]
+    },
+    "legacy_1_6": {"minReaderVersion": 1, "minWriterVersion": 6}
+  },
+  "$notes": {
+    "identity_columns_activation": "identityColumns is activated by the presence of delta.identity.* metadata keys on a column in the schema. At writerVersion 7, the identityColumns feature must also be listed in writerFeatures. At writerVersion 6, the feature is supported implicitly with no feature flag required.",
+    "identity_columns_high_water_mark": "highWaterMark tracks the highest (or lowest, for negative step) value generated so far. The fixtures use start - step as the uninitialized sentinel (e.g. start=1, step=1 gives highWaterMark=0). This is a common convention; the spec does not define an initialization value."
+  },
+  "cases": [
+    {
+      "ordinal": 1,
+      "name": "identity_columns_create_table_1_7_feature_listed_with_identity_schema_succeeds",
+      "feature": "identityColumns",
+      "description": "Creating a (1,7)+[identityColumns] table with a column carrying delta.identity.* metadata succeeds.",
+      "note": "$notes.identity_columns_activation",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.identity_1_7",
+        "metadata": {"schemaString": "$schemas.identity_col"}
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 2,
+      "name": "identity_columns_create_table_1_7_no_feature_listed_with_identity_schema_succeeds",
+      "feature": "identityColumns",
+      "flavor": "orphan",
+      "description": "Creating a (1,7) table with identity column metadata in the schema but without identityColumns in writerFeatures succeeds.",
+      "note": "$errata.orphan_feature_metadata",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_1_7",
+        "metadata": {"schemaString": "$schemas.identity_col"}
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 3,
+      "name": "identity_columns_read_snapshot_1_7_feature_listed_with_identity_schema_succeeds",
+      "feature": "identityColumns",
+      "description": "Reading a (1,7)+[identityColumns] table with an identity column schema succeeds; identityColumns is writer-only and readers are not required to validate or generate identity values.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.identity_1_7"},
+          {"metaData": {"schemaString": "$schemas.identity_col"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 4,
+      "name": "identity_columns_empty_commit_1_7_feature_listed_with_identity_schema_succeeds",
+      "feature": "identityColumns",
+      "description": "Appending (empty commit) to a (1,7)+[identityColumns] table with an identity column schema succeeds; the empty commit does not generate any identity values.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.identity_1_7"},
+          {"metaData": {"schemaString": "$schemas.identity_col"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 5,
+      "name": "identity_columns_create_table_1_6_with_identity_schema_succeeds",
+      "feature": "identityColumns",
+      "flavor": "legacy",
+      "description": "Creating a (1,6) table with a column carrying delta.identity.* metadata succeeds; writer version 6 provides implicit identity column support without a writerFeatures flag.",
+      "note": "$notes.identity_columns_activation",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.legacy_1_6",
+        "metadata": {"schemaString": "$schemas.identity_col"}
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 6,
+      "name": "identity_columns_read_snapshot_1_6_with_identity_schema_succeeds",
+      "feature": "identityColumns",
+      "flavor": "legacy",
+      "description": "Reading a (1,6) table with an identity column schema succeeds; identityColumns is writer-only.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.legacy_1_6"},
+          {"metaData": {"schemaString": "$schemas.identity_col"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 7,
+      "name": "identity_columns_empty_commit_1_6_with_identity_schema_succeeds",
+      "feature": "identityColumns",
+      "flavor": "legacy",
+      "description": "Appending (empty commit) to a (1,6) table with an identity column schema succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.legacy_1_6"},
+          {"metaData": {"schemaString": "$schemas.identity_col"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 8,
+      "name": "identity_columns_create_table_1_7_step_zero_fails",
+      "feature": "identityColumns",
+      "description": "Creating a (1,7)+[identityColumns] table with a column where delta.identity.step=0 fails; the spec explicitly prohibits a zero step value.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.identity_1_7",
+        "metadata": {"schemaString": "$schemas.identity_col_step_zero"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 9,
+      "name": "identity_columns_create_table_1_7_negative_step_succeeds",
+      "feature": "identityColumns",
+      "description": "Creating a (1,7)+[identityColumns] table with a column where delta.identity.step=-1 succeeds; negative step is valid and generates a descending sequence.",
+      "note": "$notes.identity_columns_high_water_mark",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.identity_1_7",
+        "metadata": {"schemaString": "$schemas.identity_col_negative_step"}
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 10,
+      "name": "identity_columns_create_table_1_7_allow_explicit_insert_succeeds",
+      "feature": "identityColumns",
+      "description": "Creating a (1,7)+[identityColumns] table with a column where delta.identity.allowExplicitInsert=true succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.identity_1_7",
+        "metadata": {"schemaString": "$schemas.identity_col_explicit_insert"}
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 11,
+      "name": "identity_columns_cm_create_table_3_7_succeeds",
+      "feature": "identityColumns",
+      "description": "Creating a (3,7)+[columnMapping,identityColumns] table with a CM-annotated identity column succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7_cm_identity",
+        "metadata": {
+          "schemaString": "$schemas.cm_identity_col",
+          "configuration": {
+            "delta.columnMapping.mode": "id",
+            "delta.columnMapping.maxColumnId": "1"
+          }
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 12,
+      "name": "identity_columns_read_snapshot_3_7_no_feature_listed_with_schema_succeeds",
+      "feature": "identityColumns",
+      "flavor": "orphan",
+      "description": "Reading a (3,7) table with delta.identity.* metadata in the schema but identityColumns absent from writerFeatures succeeds; identityColumns is writer-only.",
+      "note": "$errata.orphan_feature_metadata",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7"},
+          {"metaData": {"schemaString": "$schemas.identity_col"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 13,
+      "name": "identity_columns_supported_not_active_empty_commit_succeeds",
+      "feature": "identityColumns",
+      "flavor": "supported_not_active",
+      "description": "Appending to a (1,7)+[identityColumns] table with no identity column in the schema succeeds; with no delta.identity.* metadata on any field, no identity enforcement is required.",
+      "note": "$notes.identity_columns_activation",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.identity_1_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 14,
+      "name": "identity_columns_create_table_3_7_no_feature_listed_with_identity_schema_fails",
+      "feature": "identityColumns",
+      "flavor": "orphan",
+      "description": "Creating a (3,7) table with delta.identity.* metadata in the schema but identityColumns absent from writerFeatures fails.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7",
+        "metadata": {"schemaString": "$schemas.identity_col"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 15,
+      "name": "identity_columns_empty_commit_3_7_no_feature_listed_with_identity_schema_fails",
+      "feature": "identityColumns",
+      "flavor": "orphan",
+      "description": "Appending to a (3,7) table with delta.identity.* metadata in the schema but identityColumns absent from writerFeatures fails.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7"},
+          {"metaData": {"schemaString": "$schemas.identity_col"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    }
+  ]
+}

--- a/compliance-suite/fixtures/in-commit-timestamp.json
+++ b/compliance-suite/fixtures/in-commit-timestamp.json
@@ -1,0 +1,196 @@
+{
+  "$schemas": {
+    "simple_int": {
+      "type": "struct",
+      "fields": [{"name": "id", "type": "integer", "nullable": true, "metadata": {}}]
+    }
+  },
+  "$protocols": {
+    "ict_1_7": {
+      "minReaderVersion": 1,
+      "minWriterVersion": 7,
+      "writerFeatures": ["inCommitTimestamp"]
+    },
+    "modern_1_7": {"minReaderVersion": 1, "minWriterVersion": 7, "writerFeatures": []}
+  },
+  "$notes": {
+    "ict_activation": "inCommitTimestamp is a writer-only feature with two activation conditions: (1) the feature must be listed in writerFeatures, and (2) the table property delta.enableInCommitTimestamps must be set to true. When active, every commit must include a commitInfo action as the first action with an inCommitTimestamp field set to a monotonically increasing millisecond timestamp.",
+    "ict_reader_not_required": "inCommitTimestamp is writer-only. Readers are not required to check writerFeatures for this feature, nor are they required to fail when delta.enableInCommitTimestamps is set without the feature listed. Readers should use inCommitTimestamp for time-travel when available, but this is a recommendation."
+  },
+  "cases": [
+    {
+      "ordinal": 1,
+      "name": "in_commit_timestamp_create_table_1_7_feature_listed_property_true_succeeds",
+      "feature": "inCommitTimestamp",
+      "description": "Creating a (1,7)+[inCommitTimestamp] table with delta.enableInCommitTimestamps=true succeeds.",
+      "note": "$notes.ict_activation",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.ict_1_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {"delta.enableInCommitTimestamps": "true"}
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 2,
+      "name": "in_commit_timestamp_create_table_1_7_no_feature_listed_property_true_fails",
+      "feature": "inCommitTimestamp",
+      "flavor": "orphan",
+      "description": "Creating a (1,7) table with delta.enableInCommitTimestamps=true but inCommitTimestamp absent from writerFeatures fails; the active property requires the feature to be listed.",
+      "note": "$notes.ict_activation",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_1_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {"delta.enableInCommitTimestamps": "true"}
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 3,
+      "name": "in_commit_timestamp_read_snapshot_1_7_feature_listed_property_true_succeeds",
+      "feature": "inCommitTimestamp",
+      "description": "Reading a (1,7)+[inCommitTimestamp] table with delta.enableInCommitTimestamps=true succeeds; ICT is writer-only and readers are not required to understand or enforce ICT writer invariants.",
+      "note": "$notes.ict_reader_not_required",
+      "setup": {
+        "log_actions": [
+          {
+            "commitInfo": {
+              "timestamp": 1704067200000,
+              "inCommitTimestamp": 1704067200000,
+              "operation": "CREATE TABLE",
+              "operationParameters": {}
+            }
+          },
+          {"protocol": "$protocols.ict_1_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.enableInCommitTimestamps": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 4,
+      "name": "in_commit_timestamp_read_snapshot_1_7_no_feature_listed_property_true_succeeds",
+      "feature": "inCommitTimestamp",
+      "flavor": "orphan",
+      "description": "Reading a (1,7) table with delta.enableInCommitTimestamps=true but inCommitTimestamp absent from writerFeatures succeeds; ICT is writer-only and readers are not required to fail when the property is present without the feature listed.",
+      "note": "$notes.ict_reader_not_required",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_1_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.enableInCommitTimestamps": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 5,
+      "name": "in_commit_timestamp_empty_commit_1_7_feature_listed_property_true_succeeds",
+      "feature": "inCommitTimestamp",
+      "description": "Appending to a (1,7)+[inCommitTimestamp] table with delta.enableInCommitTimestamps=true succeeds; the writer includes commitInfo with inCommitTimestamp in the new commit.",
+      "note": "The setup log entry includes a commitInfo with inCommitTimestamp so that the table's initial commit is ICT-valid; the spec requires every commit on an ICT-enabled table to carry inCommitTimestamp and the writer must be able to verify monotonicity against the previous commit's value.",
+      "setup": {
+        "log_actions": [
+          {
+            "commitInfo": {
+              "timestamp": 1704067200000,
+              "inCommitTimestamp": 1704067200000,
+              "operation": "CREATE TABLE",
+              "operationParameters": {}
+            }
+          },
+          {"protocol": "$protocols.ict_1_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.enableInCommitTimestamps": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 6,
+      "name": "in_commit_timestamp_empty_commit_1_7_no_feature_listed_property_true_fails",
+      "feature": "inCommitTimestamp",
+      "flavor": "orphan",
+      "description": "Appending to a (1,7) table with delta.enableInCommitTimestamps=true but inCommitTimestamp absent from writerFeatures fails; writers must reject tables whose metadata activates a feature not listed in writerFeatures.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_1_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.enableInCommitTimestamps": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 7,
+      "name": "in_commit_timestamp_supported_not_active_create_table_succeeds",
+      "feature": "inCommitTimestamp",
+      "flavor": "supported_not_active",
+      "description": "Creating a (1,7)+[inCommitTimestamp] table without delta.enableInCommitTimestamps=true succeeds; the feature is supported but not active \u2014 both the feature and the property must be present to activate ICT.",
+      "note": "$notes.ict_activation",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.ict_1_7",
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 8,
+      "name": "in_commit_timestamp_supported_not_active_read_snapshot_succeeds",
+      "feature": "inCommitTimestamp",
+      "flavor": "supported_not_active",
+      "description": "Reading a (1,7)+[inCommitTimestamp] table without delta.enableInCommitTimestamps=true succeeds; the feature is supported but not active.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.ict_1_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 9,
+      "name": "in_commit_timestamp_supported_not_active_empty_commit_succeeds",
+      "feature": "inCommitTimestamp",
+      "flavor": "supported_not_active",
+      "description": "Appending to a (1,7)+[inCommitTimestamp] table without delta.enableInCommitTimestamps=true succeeds; ICT writer requirements do not apply when the property is absent.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.ict_1_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    }
+  ]
+}

--- a/compliance-suite/fixtures/invariants.json
+++ b/compliance-suite/fixtures/invariants.json
@@ -1,0 +1,276 @@
+{
+  "$schemas": {
+    "simple_int": {
+      "type": "struct",
+      "fields": [{"name": "id", "type": "integer", "nullable": true, "metadata": {}}]
+    },
+    "cm_invariants_id_gt_0": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {
+            "delta.columnMapping.id": 1,
+            "delta.columnMapping.physicalName": "col-1",
+            "delta.invariants": "{\"expression\":{\"expression\":\"id > 0\"}}"
+          }
+        }
+      ]
+    },
+    "invariants_id_gt_0": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {"delta.invariants": "{\"expression\":{\"expression\":\"id > 0\"}}"}
+        }
+      ]
+    }
+  },
+  "$protocols": {
+    "legacy_1_2": {"minReaderVersion": 1, "minWriterVersion": 2},
+    "modern_3_7_cm_invariants": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["columnMapping"],
+      "writerFeatures": ["columnMapping", "invariants"]
+    },
+    "legacy_1_1": {"minReaderVersion": 1, "minWriterVersion": 1},
+    "modern_3_7_invariants": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": ["invariants"]
+    },
+    "modern_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": []
+    }
+  },
+  "$notes": {
+    "orphan_writer_feature": "At (3,7), the spec requires activation properties to be paired with the corresponding feature in writerFeatures. Writing an activation property for a feature absent from writerFeatures is invalid committed state."
+  },
+  "cases": [
+    {
+      "ordinal": 1,
+      "name": "invariants_create_table_3_7_no_feature_listed_with_schema_fails",
+      "flavor": "orphan",
+      "feature": "invariants",
+      "description": "Creating a (3,7) table with a delta.invariants column but invariants absent from writerFeatures fails.",
+      "note": "$notes.orphan_writer_feature",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7",
+        "metadata": {"schemaString": "$schemas.invariants_id_gt_0"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 2,
+      "name": "invariants_empty_commit_3_7_no_feature_listed_with_schema_fails",
+      "flavor": "orphan",
+      "feature": "invariants",
+      "description": "Appending to a (3,7) table with a delta.invariants column but invariants absent from writerFeatures fails.",
+      "note": "$notes.orphan_writer_feature",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7"},
+          {"metaData": {"schemaString": "$schemas.invariants_id_gt_0"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 3,
+      "name": "invariants_create_table_1_2_with_invariant_schema",
+      "flavor": "legacy",
+      "feature": "invariants",
+      "description": "Creating a (1,2) table with a delta.invariants column metadata succeeds: invariants are always supported at writer version 2.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.legacy_1_2",
+        "metadata": {"schemaString": "$schemas.invariants_id_gt_0"}
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 4,
+      "name": "invariants_empty_commit_1_2_with_invariant_schema",
+      "flavor": "legacy",
+      "feature": "invariants",
+      "description": "Appending to a (1,2) table with a delta.invariants column succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.legacy_1_2"},
+          {"metaData": {"schemaString": "$schemas.invariants_id_gt_0"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 5,
+      "name": "invariants_read_snapshot_3_7_no_feature_listed_with_schema",
+      "flavor": "orphan",
+      "feature": "invariants",
+      "description": "Reading a (3,7) table with a delta.invariants column but invariants absent from writerFeatures succeeds; invariants is writer-only.",
+      "note": "$errata.orphan_feature_metadata",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7"},
+          {"metaData": {"schemaString": "$schemas.invariants_id_gt_0"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 6,
+      "name": "invariants_supported_not_active_empty_commit_succeeds",
+      "flavor": "supported_not_active",
+      "feature": "invariants",
+      "description": "Appending to a (3,7)+[invariants] table without any delta.invariants column metadata succeeds: the feature is supported but not active.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_invariants"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 7,
+      "name": "invariants_supported_active_empty_commit_succeeds",
+      "feature": "invariants",
+      "description": "Appending to a (3,7)+[invariants] table with a delta.invariants column succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_invariants"},
+          {"metaData": {"schemaString": "$schemas.invariants_id_gt_0"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 8,
+      "name": "invariants_create_table_1_1_succeeds",
+      "flavor": "orphan",
+      "feature": "invariants",
+      "description": "Creating a (1,1) table with a delta.invariants column succeeds; writer version 1 predates the invariants feature and the spec does not prohibit committing the metadata.",
+      "note": "$errata.orphan_feature_metadata",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.legacy_1_1",
+        "metadata": {"schemaString": "$schemas.invariants_id_gt_0"}
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 9,
+      "name": "invariants_create_table_3_7_feature_listed_succeeds",
+      "feature": "invariants",
+      "description": "Creating a (3,7)+[invariants] table with a delta.invariants column succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7_invariants",
+        "metadata": {"schemaString": "$schemas.invariants_id_gt_0"}
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 10,
+      "name": "invariants_read_snapshot_1_2_with_schema_succeeds",
+      "flavor": "legacy",
+      "feature": "invariants",
+      "description": "Reading a (1,2) table with a delta.invariants column succeeds: invariants is writer-only and does not affect the reader.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.legacy_1_2"},
+          {"metaData": {"schemaString": "$schemas.invariants_id_gt_0"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 11,
+      "name": "invariants_read_snapshot_3_7_feature_listed_succeeds",
+      "feature": "invariants",
+      "description": "Reading a (3,7)+[invariants] table with a delta.invariants column succeeds: invariants is writer-only.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_invariants"},
+          {"metaData": {"schemaString": "$schemas.invariants_id_gt_0"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 12,
+      "name": "invariants_supported_not_active_read_snapshot_succeeds",
+      "flavor": "supported_not_active",
+      "feature": "invariants",
+      "description": "Reading a (3,7)+[invariants] table without any delta.invariants column succeeds: the feature is supported but not active.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_invariants"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 13,
+      "name": "invariants_cm_create_table_3_7_both_features_listed_succeeds",
+      "feature": "invariants",
+      "description": "Creating a (3,7)+[columnMapping,invariants] table with a CM-annotated column with a delta.invariants expression succeeds.",
+      "note": "$errata.sql_expression_cm_name_resolution",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7_cm_invariants",
+        "metadata": {
+          "schemaString": "$schemas.cm_invariants_id_gt_0",
+          "configuration": {
+            "delta.columnMapping.mode": "id",
+            "delta.columnMapping.maxColumnId": "1"
+          }
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 14,
+      "name": "invariants_cm_empty_commit_3_7_both_features_listed_succeeds",
+      "feature": "invariants",
+      "description": "Appending to a (3,7)+[columnMapping,invariants] table with a CM-annotated column with a delta.invariants expression succeeds.",
+      "note": "$errata.sql_expression_cm_name_resolution",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_cm_invariants"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.cm_invariants_id_gt_0",
+              "configuration": {
+                "delta.columnMapping.mode": "id",
+                "delta.columnMapping.maxColumnId": "1"
+              }
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    }
+  ]
+}

--- a/compliance-suite/fixtures/materialize-partition-columns.json
+++ b/compliance-suite/fixtures/materialize-partition-columns.json
@@ -1,0 +1,44 @@
+{
+  "$schemas": {
+    "simple_int": {
+      "type": "struct",
+      "fields": [{"name": "id", "type": "integer", "nullable": true, "metadata": {}}]
+    }
+  },
+  "$protocols": {
+    "modern_3_7_materialize_partition_columns": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": ["materializePartitionColumns"]
+    }
+  },
+  "cases": [
+    {
+      "ordinal": 1,
+      "name": "materialize_partition_columns_create_table_3_7_feature_listed_succeeds",
+      "feature": "materializePartitionColumns",
+      "description": "Creating a (3,7)+[materializePartitionColumns] table succeeds; the feature instructs writers to store partition column values in data files in addition to the partition metadata.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7_materialize_partition_columns",
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 2,
+      "name": "materialize_partition_columns_read_snapshot_3_7_feature_listed_succeeds",
+      "feature": "materializePartitionColumns",
+      "description": "Reading a (3,7)+[materializePartitionColumns] table succeeds; materializePartitionColumns is writer-only and readers need not understand writer-only features.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_materialize_partition_columns"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    }
+  ]
+}

--- a/compliance-suite/fixtures/protocol-validity.json
+++ b/compliance-suite/fixtures/protocol-validity.json
@@ -1,0 +1,736 @@
+{
+  "$schemas": {
+    "simple_int": {
+      "type": "struct",
+      "fields": [{"name": "id", "type": "integer", "nullable": true, "metadata": {}}]
+    },
+    "simple_int_nn": {
+      "type": "struct",
+      "fields": [{"name": "id", "type": "integer", "nullable": false, "metadata": {}}]
+    }
+  },
+  "$protocols": {
+    "legacy_1_1": {"minReaderVersion": 1, "minWriterVersion": 1},
+    "modern_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": []
+    },
+    "modern_3_7_invariants": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": ["invariants"]
+    },
+    "modern_2_7_unknown_writer": {
+      "minReaderVersion": 2,
+      "minWriterVersion": 7,
+      "writerFeatures": ["unknownFeature"]
+    },
+    "modern_3_7_unknown_writer_only": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": ["unknownFeature"]
+    },
+    "legacy_1_2_with_writer_features": {
+      "minReaderVersion": 1,
+      "minWriterVersion": 2,
+      "writerFeatures": []
+    }
+  },
+  "cases": [
+    {
+      "ordinal": 1,
+      "name": "read_snapshot_legacy_reader_modern_writer_2_7_succeeds",
+      "description": "Reading a valid (2,7) table with no writer features succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": {"minReaderVersion": 2, "minWriterVersion": 7, "writerFeatures": []}},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 2,
+      "name": "read_snapshot_3_7_empty_features_succeeds",
+      "description": "Reading a valid (3,7) table with empty readerFeatures and writerFeatures succeeds.",
+      "setup": {
+        "log_actions": [
+          {
+            "protocol": {
+              "minReaderVersion": 3,
+              "minWriterVersion": 7,
+              "readerFeatures": [],
+              "writerFeatures": []
+            }
+          },
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 3,
+      "name": "read_snapshot_modern_reader_legacy_writer_3_5_missing_reader_features_fails",
+      "description": "Reading a (3,5) table omitting readerFeatures fails; minReaderVersion=3 requires readerFeatures to be present in the protocol action.",
+      "setup": {
+        "log_actions": [
+          {"protocol": {"minReaderVersion": 3, "minWriterVersion": 5}},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 4,
+      "name": "read_snapshot_modern_reader_legacy_writer_3_5_fails",
+      "description": "Reading a (3,5) table with readerFeatures present fails; (3,5) is a structurally invalid version pair.",
+      "setup": {
+        "log_actions": [
+          {"protocol": {"minReaderVersion": 3, "minWriterVersion": 5, "readerFeatures": []}},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 5,
+      "name": "read_snapshot_3_7_missing_writer_features_fails",
+      "description": "Reading an invalid (3,7) table omitting writerFeatures fails.",
+      "setup": {
+        "log_actions": [
+          {"protocol": {"minReaderVersion": 3, "minWriterVersion": 7, "readerFeatures": []}},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 6,
+      "name": "read_snapshot_2_7_with_reader_features_present_fails",
+      "description": "Reading an invalid (2,7) table with readerFeatures present.",
+      "note": "$errata.protocol_structural_validity_should_vs_must",
+      "setup": {
+        "log_actions": [
+          {
+            "protocol": {
+              "minReaderVersion": 2,
+              "minWriterVersion": 7,
+              "readerFeatures": [],
+              "writerFeatures": []
+            }
+          },
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 7,
+      "name": "create_table_reader_v3_writer_v5_fails",
+      "description": "Creating an invalid table with (3,5) fails: minReaderVersion=3 requires minWriterVersion=7.",
+      "operation": {
+        "type": "create_table",
+        "protocol": {"minReaderVersion": 3, "minWriterVersion": 5},
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 8,
+      "name": "read_snapshot_unknown_reader_feature_fails",
+      "flavor": "unknown_feature",
+      "description": "Reading a table with an unknown entry in readerFeatures fails.",
+      "setup": {
+        "log_actions": [
+          {
+            "protocol": {
+              "minReaderVersion": 3,
+              "minWriterVersion": 7,
+              "readerFeatures": ["unknownFeature"],
+              "writerFeatures": ["unknownFeature"]
+            }
+          },
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 9,
+      "name": "read_snapshot_unknown_writer_feature_succeeds",
+      "flavor": "unknown_feature",
+      "description": "Reading a table with an unknown entry in writerFeatures only succeeds: readers need not understand writer-only features.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_2_7_unknown_writer"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 10,
+      "name": "empty_commit_unknown_writer_feature_fails",
+      "flavor": "unknown_feature",
+      "description": "Writing to a table with an unknown entry in writerFeatures fails.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_2_7_unknown_writer"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 11,
+      "name": "read_snapshot_reader_writer_feature_only_in_reader_features_fails",
+      "description": "Reading a table with deletionVectors in readerFeatures but not writerFeatures fails: listing a feature only in readerFeatures is forbidden.",
+      "setup": {
+        "log_actions": [
+          {
+            "protocol": {
+              "minReaderVersion": 3,
+              "minWriterVersion": 7,
+              "readerFeatures": ["deletionVectors"],
+              "writerFeatures": []
+            }
+          },
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 12,
+      "name": "read_snapshot_reader_writer_feature_only_in_writer_features_fails",
+      "description": "Reading a table with deletionVectors in writerFeatures but not readerFeatures fails: reader-writer features must appear in both lists.",
+      "note": "$errata.protocol_structural_validity_should_vs_must",
+      "setup": {
+        "log_actions": [
+          {
+            "protocol": {
+              "minReaderVersion": 3,
+              "minWriterVersion": 7,
+              "readerFeatures": [],
+              "writerFeatures": ["deletionVectors"]
+            }
+          },
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 13,
+      "name": "read_snapshot_protocol_version_too_high_fails",
+      "description": "Reading a table with minReaderVersion=999 fails: readers reject unsupported protocol versions.",
+      "setup": {
+        "log_actions": [
+          {
+            "protocol": {
+              "minReaderVersion": 999,
+              "minWriterVersion": 999,
+              "readerFeatures": [],
+              "writerFeatures": []
+            }
+          },
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 14,
+      "name": "read_snapshot_high_writer_version_only_succeeds",
+      "description": "Reading a table with a supported minReaderVersion but unsupported minWriterVersion=999 succeeds: readers check only the reader version.",
+      "setup": {
+        "log_actions": [
+          {"protocol": {"minReaderVersion": 2, "minWriterVersion": 999, "writerFeatures": []}},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 15,
+      "name": "empty_commit_high_writer_version_only_fails",
+      "description": "Writing to a table with minWriterVersion=999 fails even if the reader version is supported.",
+      "setup": {
+        "log_actions": [
+          {"protocol": {"minReaderVersion": 2, "minWriterVersion": 999, "writerFeatures": []}},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 16,
+      "name": "create_table_3_7_empty_features_succeeds",
+      "description": "Creating a valid (3,7) table with empty readerFeatures and writerFeatures succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": {
+          "minReaderVersion": 3,
+          "minWriterVersion": 7,
+          "readerFeatures": [],
+          "writerFeatures": []
+        },
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 17,
+      "name": "create_table_legacy_reader_modern_writer_2_7_succeeds",
+      "description": "Creating a valid (2,7) table with empty writerFeatures succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": {"minReaderVersion": 2, "minWriterVersion": 7, "writerFeatures": []},
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 18,
+      "name": "create_table_high_writer_version_only_fails",
+      "description": "Creating a table with a supported minReaderVersion but unsupported minWriterVersion=999 fails: writers do not commit unsupported protocol versions.",
+      "operation": {
+        "type": "create_table",
+        "protocol": {"minReaderVersion": 2, "minWriterVersion": 999, "writerFeatures": []},
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 19,
+      "name": "create_table_protocol_version_too_high_fails",
+      "description": "Creating a table with minReaderVersion=999 fails: writers do not commit unsupported protocol versions.",
+      "operation": {
+        "type": "create_table",
+        "protocol": {
+          "minReaderVersion": 999,
+          "minWriterVersion": 999,
+          "readerFeatures": [],
+          "writerFeatures": []
+        },
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 20,
+      "name": "empty_commit_3_7_empty_features_succeeds",
+      "description": "Appending to a valid (3,7) table with empty readerFeatures and writerFeatures succeeds.",
+      "setup": {
+        "log_actions": [
+          {
+            "protocol": {
+              "minReaderVersion": 3,
+              "minWriterVersion": 7,
+              "readerFeatures": [],
+              "writerFeatures": []
+            }
+          },
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 21,
+      "name": "empty_commit_legacy_reader_modern_writer_2_7_succeeds",
+      "description": "Appending to a valid (2,7) table with no writer features succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": {"minReaderVersion": 2, "minWriterVersion": 7, "writerFeatures": []}},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 22,
+      "name": "create_table_3_7_missing_writer_features_fails",
+      "description": "Creating a table with (3,7) but no writerFeatures key fails: writerFeatures is required when minWriterVersion=7.",
+      "operation": {
+        "type": "create_table",
+        "protocol": {"minReaderVersion": 3, "minWriterVersion": 7, "readerFeatures": []},
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 23,
+      "name": "create_table_3_7_missing_reader_features_fails",
+      "description": "Creating a table with (3,7) but no readerFeatures key fails: readerFeatures is required when minReaderVersion=3.",
+      "operation": {
+        "type": "create_table",
+        "protocol": {"minReaderVersion": 3, "minWriterVersion": 7, "writerFeatures": []},
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 24,
+      "name": "create_table_2_7_with_reader_features_present_fails",
+      "description": "Creating a table with (2,7) and readerFeatures present fails: readerFeatures is only valid when minReaderVersion=3.",
+      "note": "$errata.protocol_structural_validity_should_vs_must",
+      "operation": {
+        "type": "create_table",
+        "protocol": {
+          "minReaderVersion": 2,
+          "minWriterVersion": 7,
+          "readerFeatures": [],
+          "writerFeatures": []
+        },
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 25,
+      "name": "empty_commit_3_7_missing_writer_features_fails",
+      "description": "Appending to a (3,7) table missing the writerFeatures key fails.",
+      "setup": {
+        "log_actions": [
+          {"protocol": {"minReaderVersion": 3, "minWriterVersion": 7, "readerFeatures": []}},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 26,
+      "name": "empty_commit_2_7_with_reader_features_present_fails",
+      "description": "Appending to a (2,7) table with readerFeatures present fails: the table is in an invalid protocol state.",
+      "note": "$errata.protocol_structural_validity_should_vs_must",
+      "setup": {
+        "log_actions": [
+          {
+            "protocol": {
+              "minReaderVersion": 2,
+              "minWriterVersion": 7,
+              "readerFeatures": [],
+              "writerFeatures": []
+            }
+          },
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 27,
+      "name": "empty_commit_modern_reader_legacy_writer_3_5_fails",
+      "description": "Appending to a (3,5) table fails; (3,5) is a structurally invalid version pair.",
+      "setup": {
+        "log_actions": [
+          {"protocol": {"minReaderVersion": 3, "minWriterVersion": 5, "readerFeatures": []}},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 28,
+      "name": "create_table_unknown_reader_feature_fails",
+      "flavor": "unknown_feature",
+      "description": "Creating a table listing an unknown reader feature fails: writers do not commit unknown reader features.",
+      "operation": {
+        "type": "create_table",
+        "protocol": {
+          "minReaderVersion": 3,
+          "minWriterVersion": 7,
+          "readerFeatures": ["unknownFeature"],
+          "writerFeatures": ["unknownFeature"]
+        },
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 29,
+      "name": "create_table_unknown_writer_feature_fails",
+      "flavor": "unknown_feature",
+      "description": "Creating a table listing an unknown writer feature fails: writers do not commit unknown writer features.",
+      "operation": {
+        "type": "create_table",
+        "protocol": {
+          "minReaderVersion": 2,
+          "minWriterVersion": 7,
+          "writerFeatures": ["unknownFeature"]
+        },
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 30,
+      "name": "empty_commit_unknown_reader_feature_fails",
+      "flavor": "unknown_feature",
+      "description": "Writing to a table with an unknown reader feature fails.",
+      "setup": {
+        "log_actions": [
+          {
+            "protocol": {
+              "minReaderVersion": 3,
+              "minWriterVersion": 7,
+              "readerFeatures": ["unknownFeature"],
+              "writerFeatures": ["unknownFeature"]
+            }
+          },
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 31,
+      "name": "create_table_reader_writer_feature_only_in_reader_features_fails",
+      "description": "Creating a table with deletionVectors in readerFeatures but not writerFeatures fails: reader-writer features appear in both lists.",
+      "operation": {
+        "type": "create_table",
+        "protocol": {
+          "minReaderVersion": 3,
+          "minWriterVersion": 7,
+          "readerFeatures": ["deletionVectors"],
+          "writerFeatures": []
+        },
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 32,
+      "name": "create_table_reader_writer_feature_only_in_writer_features_fails",
+      "description": "Creating a table with deletionVectors in writerFeatures but not readerFeatures fails: reader-writer features appear in both lists.",
+      "note": "$errata.protocol_structural_validity_should_vs_must",
+      "operation": {
+        "type": "create_table",
+        "protocol": {
+          "minReaderVersion": 3,
+          "minWriterVersion": 7,
+          "readerFeatures": [],
+          "writerFeatures": ["deletionVectors"]
+        },
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 33,
+      "name": "empty_commit_reader_writer_feature_only_in_reader_features_fails",
+      "description": "Writing to a table with deletionVectors in readerFeatures but not writerFeatures fails.",
+      "setup": {
+        "log_actions": [
+          {
+            "protocol": {
+              "minReaderVersion": 3,
+              "minWriterVersion": 7,
+              "readerFeatures": ["deletionVectors"],
+              "writerFeatures": []
+            }
+          },
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 34,
+      "name": "create_table_legacy_1_2_with_writer_features_present_fails",
+      "description": "Creating a (1,2) table with writerFeatures present fails; writerFeatures only exists when minWriterVersion=7.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.legacy_1_2_with_writer_features",
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 35,
+      "name": "create_table_3_7_unknown_writer_feature_only_fails",
+      "flavor": "unknown_feature",
+      "description": "Creating a (3,7) table with an unknown feature in writerFeatures only fails; writers must not commit features they do not implement.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7_unknown_writer_only",
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 36,
+      "name": "empty_commit_reader_writer_feature_only_in_writer_features_fails",
+      "description": "Writing to a table with deletionVectors in writerFeatures but not readerFeatures fails.",
+      "setup": {
+        "log_actions": [
+          {
+            "protocol": {
+              "minReaderVersion": 3,
+              "minWriterVersion": 7,
+              "readerFeatures": [],
+              "writerFeatures": ["deletionVectors"]
+            }
+          },
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 37,
+      "name": "nullable_false_legacy_1_1_create_table_succeeds",
+      "note": "$errata.nullable_false_invariants",
+      "description": "Creating a (1,1) table with a nullable=false column succeeds: no constraint feature exists at writer version 1.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.legacy_1_1",
+        "metadata": {"schemaString": "$schemas.simple_int_nn"}
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 38,
+      "name": "nullable_false_without_constraint_feature_modern_create_table_fails",
+      "note": "$errata.nullable_false_invariants",
+      "description": "Creating a (3,7) table with a nullable=false column but no constraint feature in writerFeatures fails.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7",
+        "metadata": {"schemaString": "$schemas.simple_int_nn"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 39,
+      "name": "nullable_false_with_invariants_feature_empty_commit_succeeds",
+      "feature": "invariants",
+      "note": "$errata.nullable_false_invariants",
+      "description": "Appending to a (3,7)+[invariants] table with a nullable=false column succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7_invariants"},
+          {"metaData": {"schemaString": "$schemas.simple_int_nn"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 40,
+      "name": "read_snapshot_3_7_missing_reader_features_fails",
+      "description": "Reading a (3,7) table with writerFeatures present but no readerFeatures key fails: readerFeatures is required when minReaderVersion=3.",
+      "setup": {
+        "log_actions": [
+          {"protocol": {"minReaderVersion": 3, "minWriterVersion": 7, "writerFeatures": []}},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 41,
+      "name": "empty_commit_3_7_missing_reader_features_fails",
+      "description": "Appending to a (3,7) table with writerFeatures present but no readerFeatures key fails: readerFeatures is required when minReaderVersion=3.",
+      "setup": {
+        "log_actions": [
+          {"protocol": {"minReaderVersion": 3, "minWriterVersion": 7, "writerFeatures": []}},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 42,
+      "name": "create_table_2_7_missing_writer_features_fails",
+      "description": "Creating a table with (2,7) but no writerFeatures key fails: writerFeatures is required when minWriterVersion=7.",
+      "operation": {
+        "type": "create_table",
+        "protocol": {"minReaderVersion": 2, "minWriterVersion": 7},
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 43,
+      "name": "read_snapshot_2_7_missing_writer_features_fails",
+      "description": "Reading a (2,7) table with no writerFeatures key fails: writerFeatures is required when minWriterVersion=7.",
+      "setup": {
+        "log_actions": [
+          {"protocol": {"minReaderVersion": 2, "minWriterVersion": 7}},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 44,
+      "name": "empty_commit_2_7_missing_writer_features_fails",
+      "description": "Appending to a (2,7) table with no writerFeatures key fails: writerFeatures is required when minWriterVersion=7.",
+      "setup": {
+        "log_actions": [
+          {"protocol": {"minReaderVersion": 2, "minWriterVersion": 7}},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 45,
+      "name": "read_snapshot_legacy_1_1_succeeds",
+      "description": "Reading a (1,1) table succeeds; this is the baseline legacy protocol with no table feature lists.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.legacy_1_1"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 46,
+      "name": "empty_commit_legacy_1_1_succeeds",
+      "description": "Appending to a (1,1) table succeeds; this is the baseline legacy protocol with no table feature lists.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.legacy_1_1"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    }
+  ]
+}

--- a/compliance-suite/fixtures/row-tracking.json
+++ b/compliance-suite/fixtures/row-tracking.json
@@ -1,0 +1,265 @@
+{
+  "$schemas": {
+    "simple_int": {
+      "type": "struct",
+      "fields": [{"name": "id", "type": "integer", "nullable": true, "metadata": {}}]
+    }
+  },
+  "$protocols": {
+    "modern_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": []
+    },
+    "row_tracking_no_domain_1_7": {
+      "minReaderVersion": 1,
+      "minWriterVersion": 7,
+      "writerFeatures": ["rowTracking"]
+    },
+    "row_tracking_1_7": {
+      "minReaderVersion": 1,
+      "minWriterVersion": 7,
+      "writerFeatures": ["domainMetadata", "rowTracking"]
+    }
+  },
+  "$notes": {
+    "row_tracking_supported_vs_enabled": "rowTracking has two levels: (1) supported \u2014 feature listed in writerFeatures, writers MUST assign baseRowId and defaultRowCommitVersion in all new add actions (unless suspended); (2) enabled \u2014 feature listed AND delta.enableRowTracking=true, which additionally allows readers to rely on the fields being present. The domainMetadata feature must also be listed in writerFeatures; rowTracking stores its high-water mark in a delta.rowTracking system domain.",
+    "row_tracking_dependency": "The spec explicitly requires domainMetadata to be in writerFeatures whenever rowTracking is listed. A protocol with rowTracking but without domainMetadata is invalid.",
+    "row_tracking_insert_rows_gap": "The mandatory baseRowId/defaultRowCommitVersion assignment on add actions, the domainMetadata high-water mark update, and the backfill prerequisite for enabling row tracking on an existing table all require add actions in the log to exercise. These are not testable with empty_commit and require a future insert_rows operation type."
+  },
+  "cases": [
+    {
+      "ordinal": 1,
+      "name": "row_tracking_create_table_1_7_feature_and_domain_metadata_listed_succeeds",
+      "feature": "rowTracking",
+      "description": "Creating a (1,7)+[rowTracking,domainMetadata] table succeeds; rowTracking is supported but not yet enabled.",
+      "note": "$notes.row_tracking_supported_vs_enabled",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.row_tracking_1_7",
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 2,
+      "name": "row_tracking_create_table_1_7_enabled_with_prerequisites_succeeds",
+      "feature": "rowTracking",
+      "description": "Creating a (1,7)+[rowTracking,domainMetadata] table with delta.enableRowTracking=true and the required materialized column name properties succeeds.",
+      "note": "$errata.row_tracking_enabled_prerequisites",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.row_tracking_1_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {
+            "delta.enableRowTracking": "true",
+            "delta.rowTracking.materializedRowIdColumnName": "_row_id",
+            "delta.rowTracking.materializedRowCommitVersionColumnName": "_commit_version"
+          }
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 3,
+      "name": "row_tracking_create_table_1_7_enabled_missing_prerequisites_fails",
+      "feature": "rowTracking",
+      "description": "Creating a (1,7)+[rowTracking,domainMetadata] table with delta.enableRowTracking=true but without required materialized column name properties fails.",
+      "note": "$errata.row_tracking_enabled_prerequisites",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.row_tracking_1_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {"delta.enableRowTracking": "true"}
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 4,
+      "name": "row_tracking_create_table_1_7_enabled_materialized_row_id_conflicts_with_schema_column_fails",
+      "feature": "rowTracking",
+      "description": "Creating a (1,7)+[rowTracking,domainMetadata] table with delta.enableRowTracking=true where the materialized row ID column name matches an existing schema column fails.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.row_tracking_1_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {
+            "delta.enableRowTracking": "true",
+            "delta.rowTracking.materializedRowIdColumnName": "id",
+            "delta.rowTracking.materializedRowCommitVersionColumnName": "_commit_version"
+          }
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 5,
+      "name": "row_tracking_create_table_1_7_enabled_materialized_commit_version_conflicts_with_schema_column_fails",
+      "feature": "rowTracking",
+      "description": "Creating a (1,7)+[rowTracking,domainMetadata] table with delta.enableRowTracking=true where the materialized row commit version column name matches an existing schema column fails.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.row_tracking_1_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {
+            "delta.enableRowTracking": "true",
+            "delta.rowTracking.materializedRowIdColumnName": "_row_id",
+            "delta.rowTracking.materializedRowCommitVersionColumnName": "id"
+          }
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 6,
+      "name": "row_tracking_create_table_1_7_enabled_materialized_column_names_not_unique_fails",
+      "feature": "rowTracking",
+      "description": "Creating a (1,7)+[rowTracking,domainMetadata] table with delta.enableRowTracking=true where the materialized row ID and row commit version column names are identical fails.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.row_tracking_1_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {
+            "delta.enableRowTracking": "true",
+            "delta.rowTracking.materializedRowIdColumnName": "_row_id",
+            "delta.rowTracking.materializedRowCommitVersionColumnName": "_row_id"
+          }
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 7,
+      "name": "row_tracking_create_table_1_7_feature_listed_missing_domain_metadata_fails",
+      "feature": "rowTracking",
+      "flavor": "missing_dependency",
+      "description": "Creating a (1,7)+[rowTracking] table without domainMetadata in writerFeatures fails; the spec requires domainMetadata to be co-listed whenever rowTracking is used.",
+      "note": "$notes.row_tracking_dependency",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.row_tracking_no_domain_1_7",
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 8,
+      "name": "row_tracking_read_snapshot_1_7_feature_and_domain_metadata_listed_succeeds",
+      "feature": "rowTracking",
+      "description": "Reading a (1,7)+[rowTracking,domainMetadata] table succeeds; rowTracking is writer-only and does not impose reader requirements.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.row_tracking_1_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 9,
+      "name": "row_tracking_empty_commit_1_7_feature_and_domain_metadata_listed_succeeds",
+      "feature": "rowTracking",
+      "description": "Appending to a (1,7)+[rowTracking,domainMetadata] table succeeds.",
+      "note": "$notes.row_tracking_insert_rows_gap",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.row_tracking_1_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 10,
+      "name": "row_tracking_empty_commit_1_7_suspended_succeeds",
+      "feature": "rowTracking",
+      "flavor": "supported_not_active",
+      "description": "Appending to a (1,7)+[rowTracking,domainMetadata] table with delta.rowTrackingSuspended=true succeeds; writers must not assign Row IDs when tracking is suspended.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.row_tracking_1_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.rowTrackingSuspended": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 11,
+      "name": "row_tracking_read_snapshot_3_7_no_feature_listed_with_property_succeeds",
+      "feature": "rowTracking",
+      "flavor": "orphan",
+      "description": "Reading a (3,7) table with delta.enableRowTracking=true but rowTracking absent from writerFeatures succeeds; rowTracking is writer-only and the orphan property has no effect on reads.",
+      "note": "$errata.orphan_feature_metadata",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.enableRowTracking": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 12,
+      "name": "row_tracking_suspended_and_enabled_empty_commit_fails",
+      "feature": "rowTracking",
+      "description": "Appending to a (1,7)+[rowTracking,domainMetadata] table with both delta.enableRowTracking=true and delta.rowTrackingSuspended=true fails; the two properties are mutually exclusive.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.row_tracking_1_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {
+                "delta.enableRowTracking": "true",
+                "delta.rowTrackingSuspended": "true"
+              }
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 13,
+      "name": "row_tracking_supported_and_enabled_empty_commit_missing_prerequisites_fails",
+      "feature": "rowTracking",
+      "description": "Appending to a (1,7)+[rowTracking,domainMetadata] table with delta.enableRowTracking=true but without required materialized column name properties fails; enablement prerequisites are not satisfied.",
+      "note": "$errata.row_tracking_enabled_prerequisites",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.row_tracking_1_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.enableRowTracking": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    }
+  ]
+}

--- a/compliance-suite/fixtures/timestamp-ntz.json
+++ b/compliance-suite/fixtures/timestamp-ntz.json
@@ -1,0 +1,270 @@
+{
+  "$schemas": {
+    "simple_int": {
+      "type": "struct",
+      "fields": [{"name": "id", "type": "integer", "nullable": true, "metadata": {}}]
+    },
+    "timestamp_ntz": {
+      "type": "struct",
+      "fields": [{"name": "ts", "type": "timestamp_ntz", "nullable": true, "metadata": {}}]
+    },
+    "timestamp_ntz_array": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "ts",
+          "type": {"type": "array", "elementType": "timestamp_ntz", "containsNull": true},
+          "nullable": true,
+          "metadata": {}
+        }
+      ]
+    },
+    "timestamp_ntz_widened_from_date": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "ts",
+          "type": "timestamp_ntz",
+          "nullable": true,
+          "metadata": {"delta.typeChanges": [{"fromType": "date", "toType": "timestamp_ntz"}]}
+        }
+      ]
+    }
+  },
+  "$protocols": {
+    "ntz_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["timestampNtz"],
+      "writerFeatures": ["timestampNtz"]
+    },
+    "ntz_and_type_widening_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["timestampNtz", "typeWidening"],
+      "writerFeatures": ["timestampNtz", "typeWidening"]
+    },
+    "type_widening_only_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["typeWidening"],
+      "writerFeatures": ["typeWidening"]
+    },
+    "modern_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": []
+    },
+    "legacy_1_2": {"minReaderVersion": 1, "minWriterVersion": 2}
+  },
+  "$notes": {
+    "ntz_schema_requires_feature": "The spec requires timestampNtz to be listed in both readerFeatures and writerFeatures when the schema contains timestamp_ntz columns. A timestamp_ntz schema without the feature listed is an explicitly invalid table state; failure is spec-grounded rather than errata."
+  },
+  "cases": [
+    {
+      "ordinal": 1,
+      "name": "timestamp_ntz_create_table_3_7_feature_listed_succeeds",
+      "feature": "timestampNtz",
+      "description": "Creating a (3,7)+[timestampNtz] table with a timestamp_ntz column succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.ntz_3_7",
+        "metadata": {"schemaString": "$schemas.timestamp_ntz"}
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 2,
+      "name": "timestamp_ntz_create_table_1_2_with_ntz_schema_fails",
+      "feature": "timestampNtz",
+      "flavor": "insufficient_protocol",
+      "description": "Creating a (1,2) table with a timestamp_ntz column fails; timestampNtz requires minReaderVersion=3, minWriterVersion=7, and the feature in both feature lists.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.legacy_1_2",
+        "metadata": {"schemaString": "$schemas.timestamp_ntz"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 3,
+      "name": "timestamp_ntz_create_table_3_7_no_feature_listed_with_schema_fails",
+      "feature": "timestampNtz",
+      "flavor": "orphan",
+      "description": "Creating a (3,7) table with a timestamp_ntz column but timestampNtz absent from both feature lists fails.",
+      "note": "$notes.ntz_schema_requires_feature",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7",
+        "metadata": {"schemaString": "$schemas.timestamp_ntz"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 4,
+      "name": "timestamp_ntz_read_snapshot_3_7_feature_listed_succeeds",
+      "feature": "timestampNtz",
+      "description": "Reading a (3,7)+[timestampNtz] table with a timestamp_ntz column succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.ntz_3_7"},
+          {"metaData": {"schemaString": "$schemas.timestamp_ntz"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 5,
+      "name": "timestamp_ntz_read_snapshot_3_7_nested_in_array_succeeds",
+      "feature": "timestampNtz",
+      "description": "Reading a (3,7)+[timestampNtz] table with a timestamp_ntz array element column succeeds; the feature requirement applies regardless of nesting depth.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.ntz_3_7"},
+          {"metaData": {"schemaString": "$schemas.timestamp_ntz_array"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 6,
+      "name": "timestamp_ntz_supported_not_active_read_snapshot_succeeds",
+      "feature": "timestampNtz",
+      "flavor": "supported_not_active",
+      "description": "Reading a (3,7)+[timestampNtz] table with no timestamp_ntz columns in the schema succeeds.",
+      "note": "timestampNtz is active only when the schema contains at least one timestamp_ntz column.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.ntz_3_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 7,
+      "name": "timestamp_ntz_read_snapshot_3_7_no_feature_listed_with_schema_fails",
+      "feature": "timestampNtz",
+      "flavor": "orphan",
+      "description": "Reading a (3,7) table with a timestamp_ntz column but timestampNtz absent from both feature lists fails.",
+      "note": "$notes.ntz_schema_requires_feature",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7"},
+          {"metaData": {"schemaString": "$schemas.timestamp_ntz"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 8,
+      "name": "timestamp_ntz_read_snapshot_1_2_with_ntz_schema_fails",
+      "feature": "timestampNtz",
+      "flavor": "insufficient_protocol",
+      "description": "Reading a (1,2) table with a timestamp_ntz column fails; the protocol is insufficient to support timestampNtz.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.legacy_1_2"},
+          {"metaData": {"schemaString": "$schemas.timestamp_ntz"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 9,
+      "name": "timestamp_ntz_empty_commit_3_7_feature_listed_succeeds",
+      "feature": "timestampNtz",
+      "description": "Appending to a (3,7)+[timestampNtz] table with a timestamp_ntz column succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.ntz_3_7"},
+          {"metaData": {"schemaString": "$schemas.timestamp_ntz"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 10,
+      "name": "timestamp_ntz_empty_commit_supported_not_active_succeeds",
+      "feature": "timestampNtz",
+      "flavor": "supported_not_active",
+      "description": "Appending to a (3,7)+[timestampNtz] table with no timestamp_ntz columns in the schema succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.ntz_3_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 11,
+      "name": "timestamp_ntz_empty_commit_3_7_no_feature_listed_with_schema_fails",
+      "feature": "timestampNtz",
+      "flavor": "orphan",
+      "description": "Appending to a (3,7) table with a timestamp_ntz column but timestampNtz absent from both feature lists fails.",
+      "note": "$notes.ntz_schema_requires_feature",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7"},
+          {"metaData": {"schemaString": "$schemas.timestamp_ntz"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 12,
+      "name": "timestamp_ntz_empty_commit_1_2_with_ntz_schema_fails",
+      "feature": "timestampNtz",
+      "flavor": "insufficient_protocol",
+      "description": "Appending to a (1,2) table with a timestamp_ntz column fails; the protocol is insufficient to support timestampNtz.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.legacy_1_2"},
+          {"metaData": {"schemaString": "$schemas.timestamp_ntz"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 13,
+      "name": "timestamp_ntz_type_widening_date_to_ntz_both_features_read_snapshot_succeeds",
+      "feature": "timestampNtz",
+      "description": "Reading a (3,7)+[timestampNtz, typeWidening] table where a column was widened from date to timestamp_ntz succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.ntz_and_type_widening_3_7"},
+          {"metaData": {"schemaString": "$schemas.timestamp_ntz_widened_from_date"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 14,
+      "name": "timestamp_ntz_type_widening_date_to_ntz_missing_ntz_feature_read_snapshot_fails",
+      "feature": "timestampNtz",
+      "flavor": "orphan",
+      "description": "Reading a (3,7)+[typeWidening] table where a column was widened from date to timestamp_ntz but timestampNtz is absent from both feature lists fails; the resulting timestamp_ntz column independently requires the timestampNtz feature.",
+      "note": "$notes.ntz_schema_requires_feature",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.type_widening_only_3_7"},
+          {"metaData": {"schemaString": "$schemas.timestamp_ntz_widened_from_date"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "failure"
+    }
+  ]
+}

--- a/compliance-suite/fixtures/type-widening.json
+++ b/compliance-suite/fixtures/type-widening.json
@@ -1,0 +1,320 @@
+{
+  "$schemas": {
+    "simple_int": {
+      "type": "struct",
+      "fields": [{"name": "id", "type": "integer", "nullable": true, "metadata": {}}]
+    },
+    "type_widened_int": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {"delta.typeChanges": [{"fromType": "short", "toType": "integer"}]}
+        }
+      ]
+    },
+    "type_narrowed_int": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": true,
+          "metadata": {"delta.typeChanges": [{"fromType": "long", "toType": "integer"}]}
+        }
+      ]
+    }
+  },
+  "$protocols": {
+    "type_widening_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["typeWidening"],
+      "writerFeatures": ["typeWidening"]
+    },
+    "type_widening_preview_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["typeWidening-preview"],
+      "writerFeatures": ["typeWidening-preview"]
+    },
+    "type_widening_writer_only_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": ["typeWidening"]
+    },
+    "modern_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": []
+    }
+  },
+  "$notes": {
+    "type_changes_independent_of_property": "delta.typeChanges in the schema records the history of type changes already applied and is independent of the delta.enableTypeWidening property. When typeWidening is listed in readerFeatures, readers must validate and accept or reject all delta.typeChanges entries regardless of whether the property is currently set.",
+    "preview_is_preratification_name": "typeWidening-preview was the feature name used in implementations during the RFC development phase (delta-io/delta#4094). The final RFC draft matched the ratified spec; implementations tracking the RFC used the same semantics as typeWidening. Tables created with typeWidening-preview use the same protocol semantics as typeWidening."
+  },
+  "cases": [
+    {
+      "ordinal": 1,
+      "name": "type_widening_create_table_3_7_feature_listed_succeeds",
+      "feature": "typeWidening",
+      "description": "Creating a (3,7)+[typeWidening] table with delta.enableTypeWidening=true succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.type_widening_3_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {"delta.enableTypeWidening": "true"}
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 2,
+      "name": "type_widening_create_table_3_7_no_feature_listed_with_property_succeeds",
+      "feature": "typeWidening",
+      "flavor": "orphan",
+      "description": "Creating a (3,7) table with delta.enableTypeWidening=true but typeWidening absent from both feature lists succeeds.",
+      "note": "$errata.orphan_feature_metadata",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {"delta.enableTypeWidening": "true"}
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 3,
+      "name": "type_widening_create_table_writer_only_feature_listed_fails",
+      "feature": "typeWidening",
+      "flavor": "missing_dependency",
+      "description": "Creating a (3,7)+[typeWidening in writerFeatures only] table fails; typeWidening requires the feature in both readerFeatures and writerFeatures.",
+      "note": "$errata.protocol_structural_validity_should_vs_must",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.type_widening_writer_only_3_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {"delta.enableTypeWidening": "true"}
+        }
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 4,
+      "name": "type_widening_read_snapshot_3_7_no_feature_listed_with_property_succeeds",
+      "feature": "typeWidening",
+      "flavor": "orphan",
+      "description": "Reading a (3,7) table with delta.enableTypeWidening=true but typeWidening absent from both feature lists succeeds.",
+      "note": "$errata.orphan_feature_metadata",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.enableTypeWidening": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 5,
+      "name": "type_widening_supported_not_enabled_no_type_changes_read_snapshot_succeeds",
+      "feature": "typeWidening",
+      "flavor": "supported_not_active",
+      "description": "Reading a (3,7)+[typeWidening] table with delta.enableTypeWidening absent and no delta.typeChanges in the schema succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.type_widening_3_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 6,
+      "name": "type_widening_supported_enabled_no_type_changes_read_snapshot_succeeds",
+      "feature": "typeWidening",
+      "flavor": "supported_not_active",
+      "description": "Reading a (3,7)+[typeWidening] table with delta.enableTypeWidening=true but no delta.typeChanges in the schema succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.type_widening_3_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.enableTypeWidening": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 7,
+      "name": "type_widening_supported_has_supported_type_change_read_snapshot_succeeds",
+      "feature": "typeWidening",
+      "description": "Reading a (3,7)+[typeWidening] table with a supported delta.typeChanges entry (short to integer) in the schema succeeds.",
+      "note": "$notes.type_changes_independent_of_property",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.type_widening_3_7"},
+          {"metaData": {"schemaString": "$schemas.type_widened_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 8,
+      "name": "type_widening_read_snapshot_unsupported_type_change_in_schema_fails",
+      "feature": "typeWidening",
+      "description": "Reading a (3,7)+[typeWidening] table with an unsupported delta.typeChanges entry (long to integer, a narrowing) in the schema fails; readers must reject unsupported type changes.",
+      "note": "The setup injects a delta.typeChanges entry recording long->integer (a narrowing, not a valid widening) directly via the log, bypassing writer validation. The spec requires readers to fail on any unsupported type change found in delta.typeChanges when typeWidening is in readerFeatures.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.type_widening_3_7"},
+          {"metaData": {"schemaString": "$schemas.type_narrowed_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 9,
+      "name": "type_widening_orphan_type_changes_annotation_read_snapshot_succeeds",
+      "feature": "typeWidening",
+      "flavor": "orphan",
+      "description": "Reading a (3,7) table with delta.typeChanges in the schema but typeWidening absent from both feature lists succeeds; the spec only requires readers to validate delta.typeChanges when typeWidening is in readerFeatures.",
+      "note": "$errata.orphan_feature_metadata",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7"},
+          {"metaData": {"schemaString": "$schemas.type_widened_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 10,
+      "name": "type_widening_read_snapshot_type_changes_in_schema_without_feature_in_reader_succeeds",
+      "feature": "typeWidening",
+      "description": "Reading a (3,7)+[typeWidening in writerFeatures only] table with delta.typeChanges in the schema succeeds; readers only validate delta.typeChanges when typeWidening is in readerFeatures.",
+      "note": "$errata.protocol_structural_validity_should_vs_must",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.type_widening_writer_only_3_7"},
+          {"metaData": {"schemaString": "$schemas.type_widened_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 11,
+      "name": "type_widening_empty_commit_3_7_feature_listed_succeeds",
+      "feature": "typeWidening",
+      "description": "Appending to a (3,7)+[typeWidening] table with delta.enableTypeWidening=true succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.type_widening_3_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.enableTypeWidening": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 12,
+      "name": "type_widening_empty_commit_supported_not_active_succeeds",
+      "feature": "typeWidening",
+      "flavor": "supported_not_active",
+      "description": "Appending to a (3,7)+[typeWidening] table without delta.enableTypeWidening=true succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.type_widening_3_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 13,
+      "name": "type_widening_empty_commit_3_7_no_feature_listed_with_property_succeeds",
+      "feature": "typeWidening",
+      "flavor": "orphan",
+      "description": "Appending to a (3,7) table with delta.enableTypeWidening=true but typeWidening absent from both feature lists succeeds.",
+      "note": "$errata.orphan_feature_metadata",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.enableTypeWidening": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 14,
+      "name": "type_widening_preview_create_table_3_7_feature_listed_succeeds",
+      "feature": "typeWidening-preview",
+      "description": "Creating a (3,7)+[typeWidening-preview] table with delta.enableTypeWidening=true succeeds; typeWidening-preview is the pre-ratification name for typeWidening and shares its spec semantics.",
+      "note": "$notes.preview_is_preratification_name",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.type_widening_preview_3_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {"delta.enableTypeWidening": "true"}
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 15,
+      "name": "type_widening_preview_read_snapshot_3_7_no_feature_listed_with_property_succeeds",
+      "feature": "typeWidening-preview",
+      "flavor": "orphan",
+      "description": "Reading a (3,7) table with delta.enableTypeWidening=true but typeWidening-preview absent from both feature lists succeeds.",
+      "note": "$notes.preview_is_preratification_name",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7"},
+          {
+            "metaData": {
+              "schemaString": "$schemas.simple_int",
+              "configuration": {"delta.enableTypeWidening": "true"}
+            }
+          }
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    }
+  ]
+}

--- a/compliance-suite/fixtures/v2-checkpoint.json
+++ b/compliance-suite/fixtures/v2-checkpoint.json
@@ -1,0 +1,172 @@
+{
+  "$schemas": {
+    "simple_int": {
+      "type": "struct",
+      "fields": [{"name": "id", "type": "integer", "nullable": true, "metadata": {}}]
+    }
+  },
+  "$protocols": {
+    "v2_checkpoint_writer_only_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": ["v2Checkpoint"]
+    },
+    "v2_checkpoint_reader_only_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["v2Checkpoint"],
+      "writerFeatures": []
+    },
+    "v2_checkpoint_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["v2Checkpoint"],
+      "writerFeatures": ["v2Checkpoint"]
+    },
+    "modern_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": []
+    },
+    "v2_checkpoint_insufficient_reader_1_7": {
+      "minReaderVersion": 1,
+      "minWriterVersion": 7,
+      "writerFeatures": ["v2Checkpoint"]
+    }
+  },
+  "$notes": {
+    "v2_checkpoint_activation": "v2Checkpoint is activated solely by its presence in both readerFeatures and writerFeatures; there is no corresponding table property. When listed, the table may use V2-spec or classic checkpoints; writers must not create multi-part checkpoints. Because our fixture setup cannot inject checkpoint files, these cases cover protocol validation only."
+  },
+  "cases": [
+    {
+      "ordinal": 1,
+      "name": "v2_checkpoint_create_table_3_7_feature_listed_succeeds",
+      "feature": "v2Checkpoint",
+      "description": "Creating a (3,7)+[v2Checkpoint] table succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.v2_checkpoint_3_7",
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 2,
+      "name": "v2_checkpoint_read_snapshot_3_7_feature_listed_succeeds",
+      "feature": "v2Checkpoint",
+      "description": "Reading a (3,7)+[v2Checkpoint] table succeeds; when reconstructed from JSON commit files only, no checkpoint format obligations are exercised.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.v2_checkpoint_3_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 3,
+      "name": "v2_checkpoint_empty_commit_3_7_feature_listed_succeeds",
+      "feature": "v2Checkpoint",
+      "description": "Appending to a (3,7)+[v2Checkpoint] table succeeds; the feature governs checkpoint format, not append semantics.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.v2_checkpoint_3_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 4,
+      "name": "v2_checkpoint_read_snapshot_3_7_no_feature_listed_succeeds",
+      "feature": "v2Checkpoint",
+      "description": "Reading a (3,7) table without v2Checkpoint listed succeeds; classic checkpoints are used when the feature is absent.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 5,
+      "name": "v2_checkpoint_create_table_3_7_writer_only_fails",
+      "feature": "v2Checkpoint",
+      "flavor": "insufficient_protocol",
+      "description": "Creating a (3,7) table with v2Checkpoint in writerFeatures but absent from readerFeatures fails; v2Checkpoint is a reader+writer feature and must be listed in both.",
+      "note": "$errata.protocol_structural_validity_should_vs_must",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.v2_checkpoint_writer_only_3_7",
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 6,
+      "name": "v2_checkpoint_create_table_1_7_insufficient_reader_version_fails",
+      "feature": "v2Checkpoint",
+      "flavor": "insufficient_protocol",
+      "description": "Creating a (1,7) table with v2Checkpoint in writerFeatures fails; v2Checkpoint requires minReaderVersion=3 and a readerFeatures entry, neither of which exist at reader version 1.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.v2_checkpoint_insufficient_reader_1_7",
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 7,
+      "name": "v2_checkpoint_create_table_3_7_with_checkpoint_policy_v2_succeeds",
+      "feature": "v2Checkpoint",
+      "description": "Creating a (3,7)+[v2Checkpoint] table with delta.checkpointPolicy=v2 succeeds; feature activation is still driven by protocol feature lists.",
+      "note": "$notes.v2_checkpoint_activation",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.v2_checkpoint_3_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {"delta.checkpointPolicy": "v2"}
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 8,
+      "name": "v2_checkpoint_read_snapshot_3_7_writer_only_fails",
+      "feature": "v2Checkpoint",
+      "flavor": "insufficient_protocol",
+      "description": "Reading a (3,7) table with v2Checkpoint in writerFeatures only fails; v2Checkpoint is a reader+writer feature and must be listed in both.",
+      "note": "$errata.protocol_structural_validity_should_vs_must",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.v2_checkpoint_writer_only_3_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 9,
+      "name": "v2_checkpoint_read_snapshot_3_7_reader_only_fails",
+      "feature": "v2Checkpoint",
+      "flavor": "insufficient_protocol",
+      "description": "Reading a (3,7) table with v2Checkpoint in readerFeatures only fails; listing a feature only in readerFeatures is forbidden.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.v2_checkpoint_reader_only_3_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "failure"
+    }
+  ]
+}

--- a/compliance-suite/fixtures/vacuum-protocol-check.json
+++ b/compliance-suite/fixtures/vacuum-protocol-check.json
@@ -1,0 +1,149 @@
+{
+  "$schemas": {
+    "simple_int": {
+      "type": "struct",
+      "fields": [{"name": "id", "type": "integer", "nullable": true, "metadata": {}}]
+    }
+  },
+  "$protocols": {
+    "vacuum_protocol_check_dv_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["deletionVectors", "vacuumProtocolCheck"],
+      "writerFeatures": ["deletionVectors", "vacuumProtocolCheck"]
+    },
+    "vacuum_protocol_check_writer_only_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": ["vacuumProtocolCheck"]
+    },
+    "vacuum_protocol_check_reader_only_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["vacuumProtocolCheck"],
+      "writerFeatures": []
+    },
+    "vacuum_protocol_check_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["vacuumProtocolCheck"],
+      "writerFeatures": ["vacuumProtocolCheck"]
+    }
+  },
+  "cases": [
+    {
+      "ordinal": 1,
+      "name": "vacuum_protocol_check_create_table_3_7_feature_listed_succeeds",
+      "feature": "vacuumProtocolCheck",
+      "description": "Creating a (3,7)+[vacuumProtocolCheck] table succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.vacuum_protocol_check_3_7",
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 2,
+      "name": "vacuum_protocol_check_read_snapshot_3_7_feature_listed_succeeds",
+      "feature": "vacuumProtocolCheck",
+      "description": "Reading a (3,7)+[vacuumProtocolCheck] table succeeds; the feature only constrains VACUUM operations and has no effect on reads.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.vacuum_protocol_check_3_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 3,
+      "name": "vacuum_protocol_check_empty_commit_3_7_feature_listed_succeeds",
+      "feature": "vacuumProtocolCheck",
+      "description": "Appending to a (3,7)+[vacuumProtocolCheck] table succeeds; the feature only constrains VACUUM operations and has no effect on appends.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.vacuum_protocol_check_3_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 4,
+      "name": "vacuum_protocol_check_create_table_3_7_reader_only_fails",
+      "feature": "vacuumProtocolCheck",
+      "flavor": "insufficient_protocol",
+      "description": "Creating a (3,7) table with vacuumProtocolCheck in readerFeatures only fails; the spec prohibits listing a feature only in readerFeatures without also listing it in writerFeatures.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.vacuum_protocol_check_reader_only_3_7",
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 5,
+      "name": "vacuum_protocol_check_create_table_3_7_writer_only_fails",
+      "feature": "vacuumProtocolCheck",
+      "flavor": "insufficient_protocol",
+      "description": "Creating a (3,7) table with vacuumProtocolCheck in writerFeatures only fails; vacuumProtocolCheck is a reader+writer feature and must be listed in both.",
+      "note": "$errata.protocol_structural_validity_should_vs_must",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.vacuum_protocol_check_writer_only_3_7",
+        "metadata": {"schemaString": "$schemas.simple_int"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 6,
+      "name": "vacuum_protocol_check_dv_create_table_3_7_succeeds",
+      "feature": "vacuumProtocolCheck",
+      "description": "Creating a (3,7)+[deletionVectors,vacuumProtocolCheck] table succeeds; the two features are independent and may be co-listed.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.vacuum_protocol_check_dv_3_7",
+        "metadata": {
+          "schemaString": "$schemas.simple_int",
+          "configuration": {"delta.enableDeletionVectors": "true"}
+        }
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 7,
+      "name": "vacuum_protocol_check_read_snapshot_3_7_reader_only_fails",
+      "feature": "vacuumProtocolCheck",
+      "flavor": "insufficient_protocol",
+      "description": "Reading a (3,7) table with vacuumProtocolCheck in readerFeatures only fails; listing a feature only in readerFeatures is forbidden.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.vacuum_protocol_check_reader_only_3_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 8,
+      "name": "vacuum_protocol_check_read_snapshot_3_7_writer_only_fails",
+      "feature": "vacuumProtocolCheck",
+      "flavor": "insufficient_protocol",
+      "description": "Reading a (3,7) table with vacuumProtocolCheck in writerFeatures only fails; vacuumProtocolCheck is a reader+writer feature and must be listed in both.",
+      "note": "$errata.protocol_structural_validity_should_vs_must",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.vacuum_protocol_check_writer_only_3_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "failure"
+    }
+  ]
+}

--- a/compliance-suite/fixtures/variant-shredding-preview.json
+++ b/compliance-suite/fixtures/variant-shredding-preview.json
@@ -1,0 +1,87 @@
+{
+  "$schemas": {
+    "variant_col": {
+      "type": "struct",
+      "fields": [{"name": "v", "type": "variant", "nullable": true, "metadata": {}}]
+    }
+  },
+  "$protocols": {
+    "variant_shredding_with_preview_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["variantType-preview", "variantShredding-preview"],
+      "writerFeatures": ["variantType-preview", "variantShredding-preview"]
+    },
+    "variant_shredding_with_variant_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["variantType", "variantShredding-preview"],
+      "writerFeatures": ["variantType", "variantShredding-preview"]
+    }
+  },
+  "$notes": {
+    "variantShredding_unreleased": "variantShredding is referenced in PROTOCOL.md only as a forward reference ('will be introduced later as a separate variantShredding table feature'). It is not yet ratified. variantShredding-preview is the only currently available name; cases for it record observed behavior."
+  },
+  "cases": [
+    {
+      "ordinal": 1,
+      "name": "variant_shredding_preview_create_table_3_7_without_variant_type_fails",
+      "feature": "variantShredding-preview",
+      "flavor": "missing_dependency",
+      "description": "Creating a (3,7)+[variantShredding-preview] table without variantType in the feature lists fails; the RFC requires variantType in both readerFeatures and writerFeatures as a prerequisite for variantShredding.",
+      "note": "$notes.variantShredding_unreleased",
+      "operation": {
+        "type": "create_table",
+        "protocol": {
+          "minReaderVersion": 3,
+          "minWriterVersion": 7,
+          "readerFeatures": ["variantShredding-preview"],
+          "writerFeatures": ["variantShredding-preview"]
+        },
+        "metadata": {"schemaString": "$schemas.variant_col"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 2,
+      "name": "variant_shredding_preview_create_table_3_7_with_variant_type_succeeds",
+      "feature": "variantShredding-preview",
+      "description": "Creating a (3,7)+[variantType, variantShredding-preview] table with a variant column succeeds.",
+      "note": "$notes.variantShredding_unreleased",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.variant_shredding_with_variant_3_7",
+        "metadata": {"schemaString": "$schemas.variant_col"}
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 3,
+      "name": "variant_shredding_preview_read_snapshot_3_7_with_variant_type_succeeds",
+      "feature": "variantShredding-preview",
+      "description": "Reading a (3,7)+[variantType, variantShredding-preview] table with a variant column succeeds.",
+      "note": "$notes.variantShredding_unreleased",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.variant_shredding_with_variant_3_7"},
+          {"metaData": {"schemaString": "$schemas.variant_col"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 4,
+      "name": "variant_shredding_preview_create_table_3_7_with_variant_type_preview_succeeds",
+      "feature": "variantShredding-preview",
+      "description": "Creating a (3,7)+[variantType-preview, variantShredding-preview] table with a variant column succeeds.",
+      "note": "$notes.variantShredding_unreleased",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.variant_shredding_with_preview_3_7",
+        "metadata": {"schemaString": "$schemas.variant_col"}
+      },
+      "expected_outcome": "success"
+    }
+  ]
+}

--- a/compliance-suite/fixtures/variant.json
+++ b/compliance-suite/fixtures/variant.json
@@ -1,0 +1,259 @@
+{
+  "$schemas": {
+    "variant_array_col": {
+      "type": "struct",
+      "fields": [
+        {
+          "name": "v",
+          "type": {"type": "array", "elementType": {"type": "variant"}, "containsNull": true},
+          "nullable": true,
+          "metadata": {}
+        }
+      ]
+    },
+    "simple_int": {
+      "type": "struct",
+      "fields": [{"name": "id", "type": "integer", "nullable": true, "metadata": {}}]
+    },
+    "variant_col": {
+      "type": "struct",
+      "fields": [{"name": "v", "type": "variant", "nullable": true, "metadata": {}}]
+    }
+  },
+  "$protocols": {
+    "variant_both_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["variantType-preview", "variantType"],
+      "writerFeatures": ["variantType-preview", "variantType"]
+    },
+    "legacy_1_2": {"minReaderVersion": 1, "minWriterVersion": 2},
+    "variant_preview_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["variantType-preview"],
+      "writerFeatures": ["variantType-preview"]
+    },
+    "variant_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": ["variantType"],
+      "writerFeatures": ["variantType"]
+    },
+    "modern_3_7": {
+      "minReaderVersion": 3,
+      "minWriterVersion": 7,
+      "readerFeatures": [],
+      "writerFeatures": []
+    }
+  },
+  "$notes": {
+    "preview_not_in_spec": "variantType-preview and variantShredding-preview are not described in the ratified Delta protocol spec. The variantType acceptance PR (delta-io/delta#4096) made substantive changes to writer struct-field requirements relative to the original RFC, so preview-era implementations may differ. Cases for preview feature names record observed behavior rather than spec requirements; expected_outcome reflects our best current understanding.",
+    "variant_schema_requires_feature": "The spec requires variantType to be listed in both readerFeatures and writerFeatures when the schema contains variant columns. A variant schema without the feature listed is an explicitly invalid table state, not an ambiguous orphan; failure here is spec-grounded rather than errata."
+  },
+  "cases": [
+    {
+      "ordinal": 1,
+      "name": "variant_type_create_table_3_7_feature_listed_succeeds",
+      "feature": "variantType",
+      "description": "Creating a (3,7)+[variantType] table with a variant column succeeds.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.variant_3_7",
+        "metadata": {"schemaString": "$schemas.variant_col"}
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 2,
+      "name": "variant_type_create_table_1_2_with_variant_schema_fails",
+      "feature": "variantType",
+      "flavor": "insufficient_protocol",
+      "description": "Creating a (1,2) table with a variant column fails; variantType requires minReaderVersion=3, minWriterVersion=7, and the feature listed in both readerFeatures and writerFeatures.",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.legacy_1_2",
+        "metadata": {"schemaString": "$schemas.variant_col"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 3,
+      "name": "variant_type_create_table_3_7_no_feature_listed_with_schema_fails",
+      "feature": "variantType",
+      "flavor": "orphan",
+      "description": "Creating a (3,7) table with a variant column but variantType absent from both feature lists fails; the spec requires the feature to be listed when the schema contains variant columns.",
+      "note": "$notes.variant_schema_requires_feature",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.modern_3_7",
+        "metadata": {"schemaString": "$schemas.variant_col"}
+      },
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 4,
+      "name": "variant_type_read_snapshot_3_7_feature_listed_succeeds",
+      "feature": "variantType",
+      "description": "Reading a (3,7)+[variantType] table with a variant column succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.variant_3_7"},
+          {"metaData": {"schemaString": "$schemas.variant_col"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 5,
+      "name": "variant_type_read_snapshot_3_7_variant_array_column_succeeds",
+      "feature": "variantType",
+      "description": "Reading a (3,7)+[variantType] table with a variant array column succeeds; the spec explicitly shows variant as a valid array element type.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.variant_3_7"},
+          {"metaData": {"schemaString": "$schemas.variant_array_col"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 6,
+      "name": "variant_type_supported_not_active_read_snapshot_succeeds",
+      "feature": "variantType",
+      "flavor": "supported_not_active",
+      "description": "Reading a (3,7)+[variantType] table with no variant columns in the schema succeeds.",
+      "note": "variantType is active only when the schema contains at least one variant column. A table may list the feature without any variant columns.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.variant_3_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 7,
+      "name": "variant_type_read_snapshot_3_7_no_feature_listed_with_schema_fails",
+      "feature": "variantType",
+      "flavor": "orphan",
+      "description": "Reading a (3,7) table with a variant column but variantType absent from both feature lists fails; the spec requires the feature to be listed when the schema contains variant columns.",
+      "note": "$notes.variant_schema_requires_feature",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7"},
+          {"metaData": {"schemaString": "$schemas.variant_col"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 8,
+      "name": "variant_type_empty_commit_3_7_feature_listed_succeeds",
+      "feature": "variantType",
+      "description": "Appending to a (3,7)+[variantType] table with a variant column succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.variant_3_7"},
+          {"metaData": {"schemaString": "$schemas.variant_col"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 9,
+      "name": "variant_type_empty_commit_supported_not_active_succeeds",
+      "feature": "variantType",
+      "flavor": "supported_not_active",
+      "description": "Appending to a (3,7)+[variantType] table with no variant columns in the schema succeeds.",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.variant_3_7"},
+          {"metaData": {"schemaString": "$schemas.simple_int"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 10,
+      "name": "variant_type_empty_commit_3_7_no_feature_listed_with_schema_fails",
+      "feature": "variantType",
+      "flavor": "orphan",
+      "description": "Appending to a (3,7) table with a variant column but variantType absent from both feature lists fails; the spec requires the feature to be listed when the schema contains variant columns.",
+      "note": "$notes.variant_schema_requires_feature",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7"},
+          {"metaData": {"schemaString": "$schemas.variant_col"}}
+        ]
+      },
+      "operation": {"type": "empty_commit"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 11,
+      "name": "variant_type_preview_create_table_3_7_feature_listed_succeeds",
+      "feature": "variantType-preview",
+      "description": "Creating a (3,7)+[variantType-preview] table with a variant column succeeds.",
+      "note": "$notes.preview_not_in_spec",
+      "operation": {
+        "type": "create_table",
+        "protocol": "$protocols.variant_preview_3_7",
+        "metadata": {"schemaString": "$schemas.variant_col"}
+      },
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 12,
+      "name": "variant_type_preview_read_snapshot_3_7_feature_listed_succeeds",
+      "feature": "variantType-preview",
+      "description": "Reading a (3,7)+[variantType-preview] table with a variant column succeeds.",
+      "note": "$notes.preview_not_in_spec",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.variant_preview_3_7"},
+          {"metaData": {"schemaString": "$schemas.variant_col"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    },
+    {
+      "ordinal": 13,
+      "name": "variant_type_preview_read_snapshot_3_7_no_feature_listed_with_schema_fails",
+      "feature": "variantType-preview",
+      "flavor": "orphan",
+      "description": "Reading a (3,7) table with a variant column but variantType-preview absent from both feature lists fails.",
+      "note": "$notes.preview_not_in_spec",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.modern_3_7"},
+          {"metaData": {"schemaString": "$schemas.variant_col"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "failure"
+    },
+    {
+      "ordinal": 14,
+      "name": "variant_type_preview_and_stable_read_snapshot_succeeds",
+      "feature": "variantType",
+      "description": "Reading a (3,7)+[variantType-preview, variantType] table with a variant column succeeds; tables upgraded from preview to stable may carry both feature names.",
+      "note": "$notes.preview_not_in_spec",
+      "setup": {
+        "log_actions": [
+          {"protocol": "$protocols.variant_both_3_7"},
+          {"metaData": {"schemaString": "$schemas.variant_col"}}
+        ]
+      },
+      "operation": {"type": "read_snapshot"},
+      "expected_outcome": "success"
+    }
+  ]
+}

--- a/compliance-suite/src/lib.rs
+++ b/compliance-suite/src/lib.rs
@@ -1,0 +1,1 @@
+//! Delta protocol compliance test crate.

--- a/compliance-suite/tests/compliance.rs
+++ b/compliance-suite/tests/compliance.rs
@@ -1,0 +1,3 @@
+//! Delta protocol compliance integration test entrypoint.
+
+mod compliance_suite;

--- a/compliance-suite/tests/compliance_suite/allow_column_defaults.rs
+++ b/compliance-suite/tests/compliance_suite/allow_column_defaults.rs
@@ -1,0 +1,23 @@
+//! allow column defaults compliance tests.
+
+use super::Fixture;
+use std::sync::LazyLock;
+
+static ALLOW_COLUMN_DEFAULTS: LazyLock<Fixture> =
+    LazyLock::new(|| Fixture::load("allow-column-defaults.json"));
+
+compliance_case_success!(ALLOW_COLUMN_DEFAULTS, 1, "'delta.feature.allowColumnDefaults' is not supported during CREATE TABLE");
+compliance_case_failure!(ALLOW_COLUMN_DEFAULTS, 2, diverges: "kernel does not require allowColumnDefaults listed when property is present");
+compliance_case_success!(ALLOW_COLUMN_DEFAULTS, 3);
+compliance_case_failure!(ALLOW_COLUMN_DEFAULTS, 4, diverges: "kernel does not require allowColumnDefaults listed when property is present");
+compliance_case_success!(ALLOW_COLUMN_DEFAULTS, 5, "Feature 'allowColumnDefaults' is not supported");
+compliance_case_success!(ALLOW_COLUMN_DEFAULTS, 6);
+compliance_case_success!(ALLOW_COLUMN_DEFAULTS, 7, "Feature 'allowColumnDefaults' is not supported");
+compliance_case_success!(ALLOW_COLUMN_DEFAULTS, 8);
+compliance_case_inexpressible!(ALLOW_COLUMN_DEFAULTS, 9); // fixture uses protocol (1,4); create_table() always produces (3,7)
+compliance_case_success!(ALLOW_COLUMN_DEFAULTS, 10, "is not supported during CREATE TABLE"); // allowColumnDefaults + checkConstraints both unsupported; which fires first is non-deterministic
+compliance_case_success!(ALLOW_COLUMN_DEFAULTS, 11, "'delta.feature.allowColumnDefaults' is not supported during CREATE TABLE");
+compliance_case_success!(ALLOW_COLUMN_DEFAULTS, 12, "Feature 'allowColumnDefaults' is not supported");
+compliance_case_success!(ALLOW_COLUMN_DEFAULTS, 13);
+compliance_case_success!(ALLOW_COLUMN_DEFAULTS, 14, "Feature 'allowColumnDefaults' is not supported");
+compliance_case_sentinel!(ALLOW_COLUMN_DEFAULTS, 15);

--- a/compliance-suite/tests/compliance_suite/allow_column_defaults.rs
+++ b/compliance-suite/tests/compliance_suite/allow_column_defaults.rs
@@ -7,9 +7,9 @@ static ALLOW_COLUMN_DEFAULTS: LazyLock<Fixture> =
     LazyLock::new(|| Fixture::load("allow-column-defaults.json"));
 
 compliance_case_success!(ALLOW_COLUMN_DEFAULTS, 1, "'delta.feature.allowColumnDefaults' is not supported during CREATE TABLE");
-compliance_case_failure!(ALLOW_COLUMN_DEFAULTS, 2, diverges: "kernel does not require allowColumnDefaults listed when property is present");
+compliance_case_success!(ALLOW_COLUMN_DEFAULTS, 2);
 compliance_case_success!(ALLOW_COLUMN_DEFAULTS, 3);
-compliance_case_failure!(ALLOW_COLUMN_DEFAULTS, 4, diverges: "kernel does not require allowColumnDefaults listed when property is present");
+compliance_case_success!(ALLOW_COLUMN_DEFAULTS, 4);
 compliance_case_success!(ALLOW_COLUMN_DEFAULTS, 5, "Feature 'allowColumnDefaults' is not supported");
 compliance_case_success!(ALLOW_COLUMN_DEFAULTS, 6);
 compliance_case_success!(ALLOW_COLUMN_DEFAULTS, 7, "Feature 'allowColumnDefaults' is not supported");
@@ -20,4 +20,5 @@ compliance_case_success!(ALLOW_COLUMN_DEFAULTS, 11, "'delta.feature.allowColumnD
 compliance_case_success!(ALLOW_COLUMN_DEFAULTS, 12, "Feature 'allowColumnDefaults' is not supported");
 compliance_case_success!(ALLOW_COLUMN_DEFAULTS, 13);
 compliance_case_success!(ALLOW_COLUMN_DEFAULTS, 14, "Feature 'allowColumnDefaults' is not supported");
-compliance_case_sentinel!(ALLOW_COLUMN_DEFAULTS, 15);
+compliance_case_failure!(ALLOW_COLUMN_DEFAULTS, 15, "is not supported during CREATE TABLE");
+compliance_case_sentinel!(ALLOW_COLUMN_DEFAULTS, 16);

--- a/compliance-suite/tests/compliance_suite/append_only.rs
+++ b/compliance-suite/tests/compliance_suite/append_only.rs
@@ -9,8 +9,8 @@ compliance_case_inexpressible!(APPEND_ONLY, 1); // fixture uses protocol (1,1); 
 compliance_case_inexpressible!(APPEND_ONLY, 2); // fixture uses protocol (1,2); create_table() always produces (3,7)
 compliance_case_inexpressible!(APPEND_ONLY, 3); // fixture uses protocol (1,2); create_table() always produces (3,7)
 compliance_case_success!(APPEND_ONLY, 4);
-compliance_case_failure!(APPEND_ONLY, 5, diverges: "kernel does not require appendOnly listed when delta.appendOnly=true");
-compliance_case_failure!(APPEND_ONLY, 6, diverges: "kernel does not require appendOnly listed when delta.appendOnly=true");
+compliance_case_success!(APPEND_ONLY, 5);
+compliance_case_success!(APPEND_ONLY, 6);
 compliance_case_success!(APPEND_ONLY, 7);
 compliance_case_success!(APPEND_ONLY, 8);
 compliance_case_success!(APPEND_ONLY, 9);
@@ -19,4 +19,5 @@ compliance_case_success!(APPEND_ONLY, 11);
 compliance_case_success!(APPEND_ONLY, 12);
 compliance_case_success!(APPEND_ONLY, 13);
 compliance_case_success!(APPEND_ONLY, 14);
-compliance_case_sentinel!(APPEND_ONLY, 15);
+compliance_case_success!(APPEND_ONLY, 15);
+compliance_case_sentinel!(APPEND_ONLY, 16);

--- a/compliance-suite/tests/compliance_suite/append_only.rs
+++ b/compliance-suite/tests/compliance_suite/append_only.rs
@@ -1,0 +1,22 @@
+//! append only compliance tests.
+
+use super::Fixture;
+use std::sync::LazyLock;
+
+static APPEND_ONLY: LazyLock<Fixture> = LazyLock::new(|| Fixture::load("append-only.json"));
+
+compliance_case_inexpressible!(APPEND_ONLY, 1); // fixture uses protocol (1,1); create_table() always produces (3,7)
+compliance_case_inexpressible!(APPEND_ONLY, 2); // fixture uses protocol (1,2); create_table() always produces (3,7)
+compliance_case_inexpressible!(APPEND_ONLY, 3); // fixture uses protocol (1,2); create_table() always produces (3,7)
+compliance_case_success!(APPEND_ONLY, 4);
+compliance_case_failure!(APPEND_ONLY, 5, diverges: "kernel does not require appendOnly listed when delta.appendOnly=true");
+compliance_case_failure!(APPEND_ONLY, 6, diverges: "kernel does not require appendOnly listed when delta.appendOnly=true");
+compliance_case_success!(APPEND_ONLY, 7);
+compliance_case_success!(APPEND_ONLY, 8);
+compliance_case_success!(APPEND_ONLY, 9);
+compliance_case_success!(APPEND_ONLY, 10);
+compliance_case_success!(APPEND_ONLY, 11);
+compliance_case_success!(APPEND_ONLY, 12);
+compliance_case_success!(APPEND_ONLY, 13);
+compliance_case_success!(APPEND_ONLY, 14);
+compliance_case_sentinel!(APPEND_ONLY, 15);

--- a/compliance-suite/tests/compliance_suite/catalog_managed.rs
+++ b/compliance-suite/tests/compliance_suite/catalog_managed.rs
@@ -1,0 +1,17 @@
+//! catalog managed compliance tests.
+
+use super::Fixture;
+use std::sync::LazyLock;
+
+static CATALOG_MANAGED: LazyLock<Fixture> = LazyLock::new(|| Fixture::load("catalog-managed.json"));
+
+compliance_case_success!(CATALOG_MANAGED, 1, "requires a catalog committer");
+compliance_case_success!(CATALOG_MANAGED, 2);
+compliance_case_failure!(CATALOG_MANAGED, 3, diverges: "kernel does not enforce that catalogManaged tables require inCommitTimestamp");
+compliance_case_failure!(CATALOG_MANAGED, 4, "In-Commit Timestamp not found in commit file");
+compliance_case_failure!(CATALOG_MANAGED, 5, "requires a catalog committer");
+compliance_case_success!(CATALOG_MANAGED, 6, "'delta.feature.catalogOwned-preview' is not supported during CREATE TABLE");
+compliance_case_success!(CATALOG_MANAGED, 7);
+compliance_case_success!(CATALOG_MANAGED, 8, "requires a catalog committer");
+compliance_case_failure!(CATALOG_MANAGED, 9, "Reader features must contain only ReaderWriter features that are also listed in writer features");
+compliance_case_sentinel!(CATALOG_MANAGED, 10);

--- a/compliance-suite/tests/compliance_suite/change_data_feed.rs
+++ b/compliance-suite/tests/compliance_suite/change_data_feed.rs
@@ -10,7 +10,7 @@ compliance_case_inexpressible!(CHANGE_DATA_FEED, 1); // fixture uses protocol (1
 compliance_case_inexpressible!(CHANGE_DATA_FEED, 2); // fixture uses protocol (1,3); create_table() always produces (3,7)
 compliance_case_success!(CHANGE_DATA_FEED, 3);
 compliance_case_success!(CHANGE_DATA_FEED, 4, "Feature 'checkConstraints' is not supported");
-compliance_case_failure!(CHANGE_DATA_FEED, 5, diverges: "kernel does not require changeDataFeed listed when delta.enableChangeDataFeed=true");
+compliance_case_success!(CHANGE_DATA_FEED, 5);
 compliance_case_success!(CHANGE_DATA_FEED, 6);
 compliance_case_success!(CHANGE_DATA_FEED, 7);
 compliance_case_success!(CHANGE_DATA_FEED, 8);

--- a/compliance-suite/tests/compliance_suite/change_data_feed.rs
+++ b/compliance-suite/tests/compliance_suite/change_data_feed.rs
@@ -1,0 +1,25 @@
+//! change data feed compliance tests.
+
+use super::Fixture;
+use std::sync::LazyLock;
+
+static CHANGE_DATA_FEED: LazyLock<Fixture> =
+    LazyLock::new(|| Fixture::load("change-data-feed.json"));
+
+compliance_case_inexpressible!(CHANGE_DATA_FEED, 1); // fixture uses protocol (1,4); create_table() always produces (3,7)
+compliance_case_inexpressible!(CHANGE_DATA_FEED, 2); // fixture uses protocol (1,3); create_table() always produces (3,7)
+compliance_case_success!(CHANGE_DATA_FEED, 3);
+compliance_case_success!(CHANGE_DATA_FEED, 4, "Feature 'checkConstraints' is not supported");
+compliance_case_failure!(CHANGE_DATA_FEED, 5, diverges: "kernel does not require changeDataFeed listed when delta.enableChangeDataFeed=true");
+compliance_case_success!(CHANGE_DATA_FEED, 6);
+compliance_case_success!(CHANGE_DATA_FEED, 7);
+compliance_case_success!(CHANGE_DATA_FEED, 8);
+compliance_case_success!(CHANGE_DATA_FEED, 9);
+compliance_case_success!(CHANGE_DATA_FEED, 10);
+compliance_case_success!(CHANGE_DATA_FEED, 11);
+compliance_case_success!(CHANGE_DATA_FEED, 12);
+compliance_case_success!(CHANGE_DATA_FEED, 13, "'delta.columnMapping.maxColumnId' is not supported during CREATE TABLE");
+compliance_case_success!(CHANGE_DATA_FEED, 14);
+compliance_case_success!(CHANGE_DATA_FEED, 15);
+compliance_case_success!(CHANGE_DATA_FEED, 16);
+compliance_case_sentinel!(CHANGE_DATA_FEED, 17);

--- a/compliance-suite/tests/compliance_suite/check_constraints.rs
+++ b/compliance-suite/tests/compliance_suite/check_constraints.rs
@@ -1,0 +1,25 @@
+//! check constraints compliance tests.
+
+use super::Fixture;
+use std::sync::LazyLock;
+
+static CHECK_CONSTRAINTS: LazyLock<Fixture> =
+    LazyLock::new(|| Fixture::load("check-constraints.json"));
+
+compliance_case_inexpressible!(CHECK_CONSTRAINTS, 1); // fixture uses protocol (1,2); create_table() always produces (3,7)
+compliance_case_failure!(CHECK_CONSTRAINTS, 2, "'delta.constraints.id_positive' is not supported during CREATE TABLE");
+compliance_case_success!(CHECK_CONSTRAINTS, 3);
+compliance_case_inexpressible!(CHECK_CONSTRAINTS, 4); // fixture uses protocol (1,3); create_table() always produces (3,7)
+compliance_case_success!(CHECK_CONSTRAINTS, 5);
+compliance_case_success!(CHECK_CONSTRAINTS, 6, "Feature 'checkConstraints' is not supported");
+compliance_case_success!(CHECK_CONSTRAINTS, 7, "Feature 'checkConstraints' is not supported");
+compliance_case_success!(CHECK_CONSTRAINTS, 8, "Feature 'checkConstraints' is not supported");
+compliance_case_failure!(CHECK_CONSTRAINTS, 9, "'delta.feature.checkConstraints' is not supported during CREATE TABLE");
+compliance_case_success!(CHECK_CONSTRAINTS, 10, "'delta.feature.checkConstraints' is not supported during CREATE TABLE");
+compliance_case_success!(CHECK_CONSTRAINTS, 11, "'delta.feature.checkConstraints' is not supported during CREATE TABLE");
+compliance_case_success!(CHECK_CONSTRAINTS, 12, "Feature 'checkConstraints' is not supported");
+compliance_case_success!(CHECK_CONSTRAINTS, 13, "'delta.feature.checkConstraints' is not supported during CREATE TABLE");
+compliance_case_success!(CHECK_CONSTRAINTS, 14);
+compliance_case_success!(CHECK_CONSTRAINTS, 15);
+compliance_case_success!(CHECK_CONSTRAINTS, 16);
+compliance_case_sentinel!(CHECK_CONSTRAINTS, 17);

--- a/compliance-suite/tests/compliance_suite/check_constraints.rs
+++ b/compliance-suite/tests/compliance_suite/check_constraints.rs
@@ -8,7 +8,7 @@ static CHECK_CONSTRAINTS: LazyLock<Fixture> =
 
 compliance_case_inexpressible!(CHECK_CONSTRAINTS, 1); // fixture uses protocol (1,2); create_table() always produces (3,7)
 compliance_case_failure!(CHECK_CONSTRAINTS, 2, "'delta.constraints.id_positive' is not supported during CREATE TABLE");
-compliance_case_success!(CHECK_CONSTRAINTS, 3);
+compliance_case_failure!(CHECK_CONSTRAINTS, 3, diverges: "kernel does not reject empty_commit on tables that already carry orphan checkConstraints metadata");
 compliance_case_inexpressible!(CHECK_CONSTRAINTS, 4); // fixture uses protocol (1,3); create_table() always produces (3,7)
 compliance_case_success!(CHECK_CONSTRAINTS, 5);
 compliance_case_success!(CHECK_CONSTRAINTS, 6, "Feature 'checkConstraints' is not supported");

--- a/compliance-suite/tests/compliance_suite/clustering.rs
+++ b/compliance-suite/tests/compliance_suite/clustering.rs
@@ -11,7 +11,11 @@ compliance_case_inexpressible!(CLUSTERING, 3); // fixture uses protocol (1,7); c
 compliance_case_success!(CLUSTERING, 4);
 compliance_case_success!(CLUSTERING, 5);
 compliance_case_failure!(CLUSTERING, 6, diverges: "kernel does not reject clustered tables with partition columns");
-compliance_case_failure!(CLUSTERING, 7, diverges: "kernel does not require domainMetadata co-listed with clustering");
-compliance_case_success!(CLUSTERING, 8);
+compliance_case_success!(CLUSTERING, 7);
+compliance_case_failure!(CLUSTERING, 8, diverges: "kernel does not require delta.clustering domainMetadata action before empty_commit");
 compliance_case_failure!(CLUSTERING, 9, diverges: "kernel does not reject clustered tables with partition columns");
-compliance_case_sentinel!(CLUSTERING, 10);
+compliance_case_success!(CLUSTERING, 10);
+compliance_case_failure!(CLUSTERING, 11, "invalid type: string \"id\", expected a sequence");
+compliance_case_failure!(CLUSTERING, 12, diverges: "kernel does not reject delta.clustering domainMetadata that references a non-existent column");
+compliance_case_failure!(CLUSTERING, 13, diverges: "kernel does not require physical column names in delta.clustering domainMetadata when columnMapping is active");
+compliance_case_sentinel!(CLUSTERING, 14);

--- a/compliance-suite/tests/compliance_suite/clustering.rs
+++ b/compliance-suite/tests/compliance_suite/clustering.rs
@@ -1,0 +1,17 @@
+//! clustering compliance tests.
+
+use super::Fixture;
+use std::sync::LazyLock;
+
+static CLUSTERING: LazyLock<Fixture> = LazyLock::new(|| Fixture::load("clustering.json"));
+
+compliance_case_inexpressible!(CLUSTERING, 1); // fixture uses protocol (1,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(CLUSTERING, 2); // fixture uses protocol (1,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(CLUSTERING, 3); // fixture uses protocol (1,7); create_table() always produces (3,7)
+compliance_case_success!(CLUSTERING, 4);
+compliance_case_success!(CLUSTERING, 5);
+compliance_case_failure!(CLUSTERING, 6, diverges: "kernel does not reject clustered tables with partition columns");
+compliance_case_failure!(CLUSTERING, 7, diverges: "kernel does not require domainMetadata co-listed with clustering");
+compliance_case_success!(CLUSTERING, 8);
+compliance_case_failure!(CLUSTERING, 9, diverges: "kernel does not reject clustered tables with partition columns");
+compliance_case_sentinel!(CLUSTERING, 10);

--- a/compliance-suite/tests/compliance_suite/column_mapping.rs
+++ b/compliance-suite/tests/compliance_suite/column_mapping.rs
@@ -1,0 +1,34 @@
+//! column mapping compliance tests.
+
+use super::Fixture;
+use std::sync::LazyLock;
+
+static COLUMN_MAPPING: LazyLock<Fixture> = LazyLock::new(|| Fixture::load("column-mapping.json"));
+
+compliance_case_inexpressible!(COLUMN_MAPPING, 1); // fixture uses protocol (1,5); create_table() always produces (3,7)
+compliance_case_inexpressible!(COLUMN_MAPPING, 2); // fixture uses protocol (2,5); create_table() always produces (3,7)
+compliance_case_inexpressible!(COLUMN_MAPPING, 3); // fixture uses protocol (2,5); create_table() always produces (3,7)
+compliance_case_inexpressible!(COLUMN_MAPPING, 4); // fixture uses protocol (2,5); create_table() always produces (3,7)
+compliance_case_inexpressible!(COLUMN_MAPPING, 5); // fixture uses protocol (2,5); create_table() always produces (3,7)
+compliance_case_success!(COLUMN_MAPPING, 6, "already has column mapping metadata");
+compliance_case_success!(COLUMN_MAPPING, 7, "already has column mapping metadata");
+compliance_case_success!(COLUMN_MAPPING, 8, "is annotated with delta.columnMapping.physicalName");
+compliance_case_success!(COLUMN_MAPPING, 9, "is annotated with delta.columnMapping.physicalName");
+compliance_case_success!(COLUMN_MAPPING, 10);
+compliance_case_success!(COLUMN_MAPPING, 11, "Writer features must be Writer-only or also listed in reader features");
+compliance_case_success!(COLUMN_MAPPING, 12);
+compliance_case_success!(COLUMN_MAPPING, 13);
+compliance_case_success!(COLUMN_MAPPING, 14);
+compliance_case_success!(COLUMN_MAPPING, 15);
+compliance_case_success!(COLUMN_MAPPING, 16);
+compliance_case_success!(COLUMN_MAPPING, 17);
+compliance_case_success!(COLUMN_MAPPING, 18);
+compliance_case_success!(COLUMN_MAPPING, 19, "Feature 'checkConstraints' is not supported");
+compliance_case_success!(COLUMN_MAPPING, 20, "Feature 'checkConstraints' is not supported");
+compliance_case_success!(COLUMN_MAPPING, 21);
+compliance_case_success!(COLUMN_MAPPING, 22);
+compliance_case_failure!(COLUMN_MAPPING, 23, diverges: "kernel auto-annotates missing CM fields (physicalName+id) when mode=name is active instead of rejecting");
+compliance_case_failure!(COLUMN_MAPPING, 24, diverges: "kernel auto-annotates missing CM fields (physicalName+id) when mode=id is active instead of rejecting");
+compliance_case_failure!(COLUMN_MAPPING, 25, "lacks the delta.columnMapping.physicalName annotation");
+compliance_case_failure!(COLUMN_MAPPING, 26, "lacks the delta.columnMapping.physicalName annotation");
+compliance_case_sentinel!(COLUMN_MAPPING, 27);

--- a/compliance-suite/tests/compliance_suite/column_mapping.rs
+++ b/compliance-suite/tests/compliance_suite/column_mapping.rs
@@ -8,8 +8,8 @@ static COLUMN_MAPPING: LazyLock<Fixture> = LazyLock::new(|| Fixture::load("colum
 compliance_case_inexpressible!(COLUMN_MAPPING, 1); // fixture uses protocol (1,5); create_table() always produces (3,7)
 compliance_case_inexpressible!(COLUMN_MAPPING, 2); // fixture uses protocol (2,5); create_table() always produces (3,7)
 compliance_case_inexpressible!(COLUMN_MAPPING, 3); // fixture uses protocol (2,5); create_table() always produces (3,7)
-compliance_case_inexpressible!(COLUMN_MAPPING, 4); // fixture uses protocol (2,5); create_table() always produces (3,7)
-compliance_case_inexpressible!(COLUMN_MAPPING, 5); // fixture uses protocol (2,5); create_table() always produces (3,7)
+compliance_case_failure!(COLUMN_MAPPING, 4, "Duplicate column mapping ID");
+compliance_case_failure!(COLUMN_MAPPING, 5, "annotation on field 'id' must be a number");
 compliance_case_success!(COLUMN_MAPPING, 6, "already has column mapping metadata");
 compliance_case_success!(COLUMN_MAPPING, 7, "already has column mapping metadata");
 compliance_case_success!(COLUMN_MAPPING, 8, "is annotated with delta.columnMapping.physicalName");

--- a/compliance-suite/tests/compliance_suite/deletion_vectors.rs
+++ b/compliance-suite/tests/compliance_suite/deletion_vectors.rs
@@ -17,6 +17,6 @@ compliance_case_success!(DELETION_VECTORS, 8);
 compliance_case_success!(DELETION_VECTORS, 9);
 compliance_case_success!(DELETION_VECTORS, 10);
 compliance_case_success!(DELETION_VECTORS, 11);
-compliance_case_failure!(DELETION_VECTORS, 12, diverges: "kernel does not reject DV-bearing add actions that omit stats.numRecords");
-compliance_case_failure!(DELETION_VECTORS, 13, diverges: "kernel does not reject DV-bearing add actions under insufficient protocol support");
+compliance_case_success!(DELETION_VECTORS, 12);
+compliance_case_success!(DELETION_VECTORS, 13);
 compliance_case_sentinel!(DELETION_VECTORS, 14);

--- a/compliance-suite/tests/compliance_suite/deletion_vectors.rs
+++ b/compliance-suite/tests/compliance_suite/deletion_vectors.rs
@@ -1,0 +1,22 @@
+//! deletion vectors compliance tests.
+
+use super::Fixture;
+use std::sync::LazyLock;
+
+static DELETION_VECTORS: LazyLock<Fixture> =
+    LazyLock::new(|| Fixture::load("deletion-vectors.json"));
+
+compliance_case_success!(DELETION_VECTORS, 1);
+compliance_case_inexpressible!(DELETION_VECTORS, 2); // fixture uses protocol (1,2); create_table() always produces (3,7)
+compliance_case_success!(DELETION_VECTORS, 3);
+compliance_case_success!(DELETION_VECTORS, 4);
+compliance_case_success!(DELETION_VECTORS, 5);
+compliance_case_success!(DELETION_VECTORS, 6);
+compliance_case_success!(DELETION_VECTORS, 7);
+compliance_case_success!(DELETION_VECTORS, 8);
+compliance_case_success!(DELETION_VECTORS, 9);
+compliance_case_success!(DELETION_VECTORS, 10);
+compliance_case_success!(DELETION_VECTORS, 11);
+compliance_case_failure!(DELETION_VECTORS, 12, diverges: "kernel does not reject DV-bearing add actions that omit stats.numRecords");
+compliance_case_failure!(DELETION_VECTORS, 13, diverges: "kernel does not reject DV-bearing add actions under insufficient protocol support");
+compliance_case_sentinel!(DELETION_VECTORS, 14);

--- a/compliance-suite/tests/compliance_suite/domain_metadata.rs
+++ b/compliance-suite/tests/compliance_suite/domain_metadata.rs
@@ -10,4 +10,5 @@ compliance_case_success!(DOMAIN_METADATA, 2);
 compliance_case_success!(DOMAIN_METADATA, 3);
 compliance_case_success!(DOMAIN_METADATA, 4);
 compliance_case_success!(DOMAIN_METADATA, 5);
-compliance_case_sentinel!(DOMAIN_METADATA, 6);
+compliance_case_success!(DOMAIN_METADATA, 6);
+compliance_case_sentinel!(DOMAIN_METADATA, 7);

--- a/compliance-suite/tests/compliance_suite/domain_metadata.rs
+++ b/compliance-suite/tests/compliance_suite/domain_metadata.rs
@@ -1,0 +1,13 @@
+//! domain metadata compliance tests.
+
+use super::Fixture;
+use std::sync::LazyLock;
+
+static DOMAIN_METADATA: LazyLock<Fixture> = LazyLock::new(|| Fixture::load("domain-metadata.json"));
+
+compliance_case_inexpressible!(DOMAIN_METADATA, 1); // fixture uses protocol (1,7); create_table() always produces (3,7)
+compliance_case_success!(DOMAIN_METADATA, 2);
+compliance_case_success!(DOMAIN_METADATA, 3);
+compliance_case_success!(DOMAIN_METADATA, 4);
+compliance_case_success!(DOMAIN_METADATA, 5);
+compliance_case_sentinel!(DOMAIN_METADATA, 6);

--- a/compliance-suite/tests/compliance_suite/generated_columns.rs
+++ b/compliance-suite/tests/compliance_suite/generated_columns.rs
@@ -1,0 +1,26 @@
+//! generated columns compliance tests.
+
+use super::Fixture;
+use std::sync::LazyLock;
+
+static GENERATED_COLUMNS: LazyLock<Fixture> =
+    LazyLock::new(|| Fixture::load("generated-columns.json"));
+
+compliance_case_inexpressible!(GENERATED_COLUMNS, 1); // fixture uses protocol (1,3); create_table() always produces (3,7)
+compliance_case_failure!(GENERATED_COLUMNS, 2, diverges: "kernel does not require generatedColumns listed when schema has generation expressions");
+compliance_case_failure!(GENERATED_COLUMNS, 3, diverges: "kernel does not require generatedColumns listed when schema has generation expressions");
+compliance_case_inexpressible!(GENERATED_COLUMNS, 4); // fixture uses protocol (1,4); create_table() always produces (3,7)
+compliance_case_success!(GENERATED_COLUMNS, 5);
+compliance_case_success!(GENERATED_COLUMNS, 6, "Feature 'generatedColumns' is not supported");
+compliance_case_success!(GENERATED_COLUMNS, 7, "Feature 'generatedColumns' is not supported");
+compliance_case_success!(GENERATED_COLUMNS, 8, "'delta.feature.generatedColumns' is not supported during CREATE TABLE");
+compliance_case_success!(GENERATED_COLUMNS, 9);
+compliance_case_success!(GENERATED_COLUMNS, 10);
+compliance_case_success!(GENERATED_COLUMNS, 11);
+compliance_case_success!(GENERATED_COLUMNS, 12, "Feature 'checkConstraints' is not supported");
+compliance_case_failure!(GENERATED_COLUMNS, 13, "'delta.feature.generatedColumns' is not supported during CREATE TABLE");
+compliance_case_success!(GENERATED_COLUMNS, 14, "'delta.feature.generatedColumns' is not supported during CREATE TABLE");
+compliance_case_success!(GENERATED_COLUMNS, 15, "'delta.feature.generatedColumns' is not supported during CREATE TABLE");
+compliance_case_success!(GENERATED_COLUMNS, 16, "Feature 'generatedColumns' is not supported");
+compliance_case_success!(GENERATED_COLUMNS, 17, "is not supported during CREATE TABLE"); // generatedColumns + checkConstraints both unsupported; which fires first is non-deterministic
+compliance_case_sentinel!(GENERATED_COLUMNS, 18);

--- a/compliance-suite/tests/compliance_suite/generated_columns.rs
+++ b/compliance-suite/tests/compliance_suite/generated_columns.rs
@@ -7,8 +7,8 @@ static GENERATED_COLUMNS: LazyLock<Fixture> =
     LazyLock::new(|| Fixture::load("generated-columns.json"));
 
 compliance_case_inexpressible!(GENERATED_COLUMNS, 1); // fixture uses protocol (1,3); create_table() always produces (3,7)
-compliance_case_failure!(GENERATED_COLUMNS, 2, diverges: "kernel does not require generatedColumns listed when schema has generation expressions");
-compliance_case_failure!(GENERATED_COLUMNS, 3, diverges: "kernel does not require generatedColumns listed when schema has generation expressions");
+compliance_case_success!(GENERATED_COLUMNS, 2);
+compliance_case_success!(GENERATED_COLUMNS, 3);
 compliance_case_inexpressible!(GENERATED_COLUMNS, 4); // fixture uses protocol (1,4); create_table() always produces (3,7)
 compliance_case_success!(GENERATED_COLUMNS, 5);
 compliance_case_success!(GENERATED_COLUMNS, 6, "Feature 'generatedColumns' is not supported");

--- a/compliance-suite/tests/compliance_suite/iceberg_compat_v1.rs
+++ b/compliance-suite/tests/compliance_suite/iceberg_compat_v1.rs
@@ -17,5 +17,14 @@ compliance_case_inexpressible!(ICEBERG_COMPAT_V1, 8); // fixture uses protocol (
 compliance_case_success!(ICEBERG_COMPAT_V1, 9);
 compliance_case_success!(ICEBERG_COMPAT_V1, 10, "Feature 'icebergCompatV1' is not supported");
 compliance_case_success!(ICEBERG_COMPAT_V1, 11);
-compliance_case_failure!(ICEBERG_COMPAT_V1, 12, "Feature 'icebergCompatV1' is not supported");
-compliance_case_sentinel!(ICEBERG_COMPAT_V1, 13);
+compliance_case_failure!(ICEBERG_COMPAT_V1, 12, "is not supported during CREATE TABLE");
+compliance_case_failure!(ICEBERG_COMPAT_V1, 13, "is not supported during CREATE TABLE");
+compliance_case_failure!(ICEBERG_COMPAT_V1, 14, "is not supported during CREATE TABLE");
+compliance_case_failure!(ICEBERG_COMPAT_V1, 15, "Unsupported Delta table type: 'void'");
+compliance_case_failure!(ICEBERG_COMPAT_V1, 16, diverges: "kernel does not reject Array types in read_snapshot when icebergCompatV1 is active");
+compliance_case_failure!(ICEBERG_COMPAT_V1, 17, diverges: "kernel does not reject Map types in read_snapshot when icebergCompatV1 is active");
+compliance_case_failure!(ICEBERG_COMPAT_V1, 18, "Unsupported Delta table type: 'void'");
+compliance_case_success!(ICEBERG_COMPAT_V1, 19, "is not supported during CREATE TABLE");
+compliance_case_success!(ICEBERG_COMPAT_V1, 20, "is not supported during CREATE TABLE");
+compliance_case_success!(ICEBERG_COMPAT_V1, 21, "delta.enableIcebergCompatV1' is not supported during CREATE TABLE");
+compliance_case_sentinel!(ICEBERG_COMPAT_V1, 22);

--- a/compliance-suite/tests/compliance_suite/iceberg_compat_v1.rs
+++ b/compliance-suite/tests/compliance_suite/iceberg_compat_v1.rs
@@ -1,0 +1,21 @@
+//! iceberg compat v1 compliance tests.
+
+use super::Fixture;
+use std::sync::LazyLock;
+
+static ICEBERG_COMPAT_V1: LazyLock<Fixture> =
+    LazyLock::new(|| Fixture::load("iceberg-compat-v1.json"));
+
+compliance_case_inexpressible!(ICEBERG_COMPAT_V1, 1); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_success!(ICEBERG_COMPAT_V1, 2, "'delta.feature.icebergCompatV1' is not supported during CREATE TABLE");
+compliance_case_inexpressible!(ICEBERG_COMPAT_V1, 3); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(ICEBERG_COMPAT_V1, 4); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(ICEBERG_COMPAT_V1, 5); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(ICEBERG_COMPAT_V1, 6); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(ICEBERG_COMPAT_V1, 7); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(ICEBERG_COMPAT_V1, 8); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_success!(ICEBERG_COMPAT_V1, 9);
+compliance_case_success!(ICEBERG_COMPAT_V1, 10, "Feature 'icebergCompatV1' is not supported");
+compliance_case_success!(ICEBERG_COMPAT_V1, 11);
+compliance_case_failure!(ICEBERG_COMPAT_V1, 12, "Feature 'icebergCompatV1' is not supported");
+compliance_case_sentinel!(ICEBERG_COMPAT_V1, 13);

--- a/compliance-suite/tests/compliance_suite/iceberg_compat_v2.rs
+++ b/compliance-suite/tests/compliance_suite/iceberg_compat_v2.rs
@@ -7,17 +7,28 @@ static ICEBERG_COMPAT_V2: LazyLock<Fixture> =
     LazyLock::new(|| Fixture::load("iceberg-compat-v2.json"));
 
 compliance_case_inexpressible!(ICEBERG_COMPAT_V2, 1); // fixture uses protocol (2,7); create_table() always produces (3,7)
-compliance_case_inexpressible!(ICEBERG_COMPAT_V2, 2); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_success!(ICEBERG_COMPAT_V2, 2, "delta.enableIcebergCompatV2' is not supported during CREATE TABLE");
 compliance_case_success!(ICEBERG_COMPAT_V2, 3);
 compliance_case_success!(ICEBERG_COMPAT_V2, 4, "Feature 'icebergCompatV2' is not supported");
-compliance_case_inexpressible!(ICEBERG_COMPAT_V2, 5); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_success!(ICEBERG_COMPAT_V2, 5, "is not supported during CREATE TABLE");
 compliance_case_success!(ICEBERG_COMPAT_V2, 6, "'delta.feature.icebergCompatV2' is not supported during CREATE TABLE");
-compliance_case_inexpressible!(ICEBERG_COMPAT_V2, 7); // fixture uses protocol (2,7); create_table() always produces (3,7)
-compliance_case_inexpressible!(ICEBERG_COMPAT_V2, 8); // fixture uses protocol (2,7); create_table() always produces (3,7)
-compliance_case_inexpressible!(ICEBERG_COMPAT_V2, 9); // fixture uses protocol (2,7); create_table() always produces (3,7)
-compliance_case_inexpressible!(ICEBERG_COMPAT_V2, 10); // fixture uses protocol (2,7); create_table() always produces (3,7)
-compliance_case_inexpressible!(ICEBERG_COMPAT_V2, 11); // fixture requires ICv1+ICv2 combination; inexpressible shape
-compliance_case_inexpressible!(ICEBERG_COMPAT_V2, 12); // fixture requires ICv1+ICv2 combination at (3,7); inexpressible shape
+compliance_case_failure!(ICEBERG_COMPAT_V2, 7, "is not supported during CREATE TABLE");
+compliance_case_failure!(ICEBERG_COMPAT_V2, 8, "is not supported during CREATE TABLE");
+compliance_case_failure!(ICEBERG_COMPAT_V2, 9, "is not supported during CREATE TABLE");
+compliance_case_success!(ICEBERG_COMPAT_V2, 10, "is not supported during CREATE TABLE");
+compliance_case_success!(ICEBERG_COMPAT_V2, 11, "is not supported during CREATE TABLE");
+compliance_case_failure!(ICEBERG_COMPAT_V2, 12, "is not supported during CREATE TABLE");
 compliance_case_success!(ICEBERG_COMPAT_V2, 13);
-compliance_case_failure!(ICEBERG_COMPAT_V2, 14, "Feature 'icebergCompatV2' is not supported");
-compliance_case_sentinel!(ICEBERG_COMPAT_V2, 15);
+compliance_case_failure!(ICEBERG_COMPAT_V2, 14, "is not supported during CREATE TABLE");
+compliance_case_success!(ICEBERG_COMPAT_V2, 15, "delta.enableIcebergCompatV2' is not supported during CREATE TABLE");
+compliance_case_success!(ICEBERG_COMPAT_V2, 16, "is not supported during CREATE TABLE");
+compliance_case_success!(ICEBERG_COMPAT_V2, 17, "is not supported during CREATE TABLE");
+compliance_case_failure!(ICEBERG_COMPAT_V2, 18, "Unsupported Delta table type: 'void'");
+compliance_case_failure!(ICEBERG_COMPAT_V2, 19, "is not supported during CREATE TABLE");
+compliance_case_failure!(ICEBERG_COMPAT_V2, 20, "is not supported during CREATE TABLE");
+compliance_case_success!(ICEBERG_COMPAT_V2, 21, "Unsupported Delta table type: 'void'");
+compliance_case_failure!(ICEBERG_COMPAT_V2, 22, "is not supported during CREATE TABLE");
+compliance_case_failure!(ICEBERG_COMPAT_V2, 23, "is not supported during CREATE TABLE");
+compliance_case_failure!(ICEBERG_COMPAT_V2, 24, "is not supported during CREATE TABLE");
+compliance_case_failure!(ICEBERG_COMPAT_V2, 25, "is not supported during CREATE TABLE");
+compliance_case_sentinel!(ICEBERG_COMPAT_V2, 26);

--- a/compliance-suite/tests/compliance_suite/iceberg_compat_v2.rs
+++ b/compliance-suite/tests/compliance_suite/iceberg_compat_v2.rs
@@ -1,0 +1,23 @@
+//! iceberg compat v2 compliance tests.
+
+use super::Fixture;
+use std::sync::LazyLock;
+
+static ICEBERG_COMPAT_V2: LazyLock<Fixture> =
+    LazyLock::new(|| Fixture::load("iceberg-compat-v2.json"));
+
+compliance_case_inexpressible!(ICEBERG_COMPAT_V2, 1); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(ICEBERG_COMPAT_V2, 2); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_success!(ICEBERG_COMPAT_V2, 3);
+compliance_case_success!(ICEBERG_COMPAT_V2, 4, "Feature 'icebergCompatV2' is not supported");
+compliance_case_inexpressible!(ICEBERG_COMPAT_V2, 5); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_success!(ICEBERG_COMPAT_V2, 6, "'delta.feature.icebergCompatV2' is not supported during CREATE TABLE");
+compliance_case_inexpressible!(ICEBERG_COMPAT_V2, 7); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(ICEBERG_COMPAT_V2, 8); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(ICEBERG_COMPAT_V2, 9); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(ICEBERG_COMPAT_V2, 10); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(ICEBERG_COMPAT_V2, 11); // fixture requires ICv1+ICv2 combination; inexpressible shape
+compliance_case_inexpressible!(ICEBERG_COMPAT_V2, 12); // fixture requires ICv1+ICv2 combination at (3,7); inexpressible shape
+compliance_case_success!(ICEBERG_COMPAT_V2, 13);
+compliance_case_failure!(ICEBERG_COMPAT_V2, 14, "Feature 'icebergCompatV2' is not supported");
+compliance_case_sentinel!(ICEBERG_COMPAT_V2, 15);

--- a/compliance-suite/tests/compliance_suite/iceberg_compat_v3_preview.rs
+++ b/compliance-suite/tests/compliance_suite/iceberg_compat_v3_preview.rs
@@ -1,0 +1,21 @@
+//! iceberg compat v3 preview compliance tests.
+//!
+//! All 8 cases use protocol shapes that `create_table()` cannot produce. The fixture uses
+//! protocol (2,7) with asymmetric feature combinations, while `create_table()` always
+//! produces (3,7) with symmetric feature arrays.
+
+use super::Fixture;
+use std::sync::LazyLock;
+
+static ICEBERG_COMPAT_V3_PREVIEW: LazyLock<Fixture> =
+    LazyLock::new(|| Fixture::load("iceberg-compat-v3-preview.json"));
+
+compliance_case_inexpressible!(ICEBERG_COMPAT_V3_PREVIEW, 1); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(ICEBERG_COMPAT_V3_PREVIEW, 2); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(ICEBERG_COMPAT_V3_PREVIEW, 3); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(ICEBERG_COMPAT_V3_PREVIEW, 4); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(ICEBERG_COMPAT_V3_PREVIEW, 5); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(ICEBERG_COMPAT_V3_PREVIEW, 6); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(ICEBERG_COMPAT_V3_PREVIEW, 7); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(ICEBERG_COMPAT_V3_PREVIEW, 8); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_sentinel!(ICEBERG_COMPAT_V3_PREVIEW, 9);

--- a/compliance-suite/tests/compliance_suite/iceberg_writer_compat.rs
+++ b/compliance-suite/tests/compliance_suite/iceberg_writer_compat.rs
@@ -1,0 +1,19 @@
+//! iceberg writer compat compliance tests.
+//!
+//! All 6 cases use protocol shapes that `create_table()` cannot produce. The fixture uses
+//! protocol (2,7) with asymmetric feature combinations, while `create_table()` always
+//! produces (3,7) with symmetric feature arrays.
+
+use super::Fixture;
+use std::sync::LazyLock;
+
+static ICEBERG_WRITER_COMPAT: LazyLock<Fixture> =
+    LazyLock::new(|| Fixture::load("iceberg-writer-compat.json"));
+
+compliance_case_inexpressible!(ICEBERG_WRITER_COMPAT, 1); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(ICEBERG_WRITER_COMPAT, 2); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(ICEBERG_WRITER_COMPAT, 3); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(ICEBERG_WRITER_COMPAT, 4); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(ICEBERG_WRITER_COMPAT, 5); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(ICEBERG_WRITER_COMPAT, 6); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_sentinel!(ICEBERG_WRITER_COMPAT, 7);

--- a/compliance-suite/tests/compliance_suite/identity_columns.rs
+++ b/compliance-suite/tests/compliance_suite/identity_columns.rs
@@ -1,0 +1,24 @@
+//! identity columns compliance tests.
+
+use super::Fixture;
+use std::sync::LazyLock;
+
+static IDENTITY_COLUMNS: LazyLock<Fixture> =
+    LazyLock::new(|| Fixture::load("identity-columns.json"));
+
+compliance_case_inexpressible!(IDENTITY_COLUMNS, 1); // fixture uses protocol (1,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(IDENTITY_COLUMNS, 2); // fixture uses protocol (1,7); create_table() always produces (3,7)
+compliance_case_success!(IDENTITY_COLUMNS, 3);
+compliance_case_success!(IDENTITY_COLUMNS, 4, "Feature 'identityColumns' is not supported");
+compliance_case_inexpressible!(IDENTITY_COLUMNS, 5); // fixture uses protocol (1,6); create_table() always produces (3,7)
+compliance_case_success!(IDENTITY_COLUMNS, 6);
+compliance_case_success!(IDENTITY_COLUMNS, 7, "Feature 'checkConstraints' is not supported");
+compliance_case_inexpressible!(IDENTITY_COLUMNS, 8); // fixture uses protocol (1,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(IDENTITY_COLUMNS, 9); // fixture uses protocol (1,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(IDENTITY_COLUMNS, 10); // fixture uses protocol (1,7); create_table() always produces (3,7)
+compliance_case_success!(IDENTITY_COLUMNS, 11, "'delta.feature.identityColumns' is not supported during CREATE TABLE");
+compliance_case_success!(IDENTITY_COLUMNS, 12);
+compliance_case_success!(IDENTITY_COLUMNS, 13, "Feature 'identityColumns' is not supported");
+compliance_case_failure!(IDENTITY_COLUMNS, 14, diverges: "kernel allows identity metadata in schema during create_table without identityColumns in writerFeatures");
+compliance_case_failure!(IDENTITY_COLUMNS, 15, diverges: "kernel allows empty_commit on tables with identity metadata without identityColumns in writerFeatures");
+compliance_case_sentinel!(IDENTITY_COLUMNS, 16);

--- a/compliance-suite/tests/compliance_suite/in_commit_timestamp.rs
+++ b/compliance-suite/tests/compliance_suite/in_commit_timestamp.rs
@@ -1,0 +1,18 @@
+//! in commit timestamp compliance tests.
+
+use super::Fixture;
+use std::sync::LazyLock;
+
+static IN_COMMIT_TIMESTAMP: LazyLock<Fixture> =
+    LazyLock::new(|| Fixture::load("in-commit-timestamp.json"));
+
+compliance_case_inexpressible!(IN_COMMIT_TIMESTAMP, 1); // fixture uses protocol (1,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(IN_COMMIT_TIMESTAMP, 2); // fixture uses protocol (1,7); create_table() always produces (3,7)
+compliance_case_success!(IN_COMMIT_TIMESTAMP, 3);
+compliance_case_success!(IN_COMMIT_TIMESTAMP, 4);
+compliance_case_success!(IN_COMMIT_TIMESTAMP, 5);
+compliance_case_failure!(IN_COMMIT_TIMESTAMP, 6, diverges: "kernel does not require inCommitTimestamp listed when delta.enableInCommitTimestamps=true");
+compliance_case_inexpressible!(IN_COMMIT_TIMESTAMP, 7); // fixture uses protocol (1,7); create_table() always produces (3,7)
+compliance_case_success!(IN_COMMIT_TIMESTAMP, 8);
+compliance_case_success!(IN_COMMIT_TIMESTAMP, 9);
+compliance_case_sentinel!(IN_COMMIT_TIMESTAMP, 10);

--- a/compliance-suite/tests/compliance_suite/invariants.rs
+++ b/compliance-suite/tests/compliance_suite/invariants.rs
@@ -1,0 +1,22 @@
+//! invariants compliance tests.
+
+use super::Fixture;
+use std::sync::LazyLock;
+
+static INVARIANTS: LazyLock<Fixture> = LazyLock::new(|| Fixture::load("invariants.json"));
+
+compliance_case_failure!(INVARIANTS, 1, diverges: "kernel does not require invariants listed when schema has invariant expressions");
+compliance_case_failure!(INVARIANTS, 2, diverges: "kernel does not require invariants listed when schema has invariant expressions");
+compliance_case_inexpressible!(INVARIANTS, 3); // fixture uses protocol (1,2); create_table() always produces (3,7)
+compliance_case_success!(INVARIANTS, 4, "Column invariants are not yet supported");
+compliance_case_success!(INVARIANTS, 5);
+compliance_case_success!(INVARIANTS, 6);
+compliance_case_success!(INVARIANTS, 7, "Column invariants are not yet supported");
+compliance_case_inexpressible!(INVARIANTS, 8); // fixture uses protocol (1,1); create_table() always produces (3,7)
+compliance_case_success!(INVARIANTS, 9, "'delta.feature.invariants' is not supported during CREATE TABLE");
+compliance_case_success!(INVARIANTS, 10);
+compliance_case_success!(INVARIANTS, 11);
+compliance_case_success!(INVARIANTS, 12);
+compliance_case_success!(INVARIANTS, 13, "'delta.feature.invariants' is not supported during CREATE TABLE");
+compliance_case_success!(INVARIANTS, 14, "Column invariants are not yet supported");
+compliance_case_sentinel!(INVARIANTS, 15);

--- a/compliance-suite/tests/compliance_suite/materialize_partition_columns.rs
+++ b/compliance-suite/tests/compliance_suite/materialize_partition_columns.rs
@@ -1,0 +1,11 @@
+//! materialize partition columns compliance tests.
+
+use super::Fixture;
+use std::sync::LazyLock;
+
+static MATERIALIZE_PARTITION_COLUMNS: LazyLock<Fixture> =
+    LazyLock::new(|| Fixture::load("materialize-partition-columns.json"));
+
+compliance_case_success!(MATERIALIZE_PARTITION_COLUMNS, 1, "'delta.feature.materializePartitionColumns' is not supported during CREATE TABLE");
+compliance_case_success!(MATERIALIZE_PARTITION_COLUMNS, 2);
+compliance_case_sentinel!(MATERIALIZE_PARTITION_COLUMNS, 3);

--- a/compliance-suite/tests/compliance_suite/mod.rs
+++ b/compliance-suite/tests/compliance_suite/mod.rs
@@ -253,17 +253,30 @@ fn apply_metadata_defaults(metadata: &mut Value) {
         .or_insert_with(|| Value::Object(Default::default()));
 }
 
+/// Apply Delta domainMetadata defaults to the inner domainMetadata object.
+///
+/// Fills in `removed=false` when absent.
+fn apply_domain_metadata_defaults(domain_metadata: &mut Value) {
+    let obj = domain_metadata
+        .as_object_mut()
+        .expect("domainMetadata value must be a JSON object");
+    obj.entry("removed").or_insert(Value::Bool(false));
+}
+
 /// Write a list of Delta log actions as version 0 of the table in `store`.
 ///
 /// Actions are written as NDJSON to `_delta_log/00000000000000000000.json`. Any `metaData`
-/// action in the list has defaults applied before serialization.
+/// or `domainMetadata` action in the list has defaults applied before serialization.
 async fn write_log_v0(store: &InMemory, actions: &[Value]) {
     let ndjson = actions
         .iter()
-        .map(|a| {
-            let mut a = a.clone();
+        .cloned()
+        .map(|mut a| {
             if let Some(metadata) = a.get_mut("metaData") {
                 apply_metadata_defaults(metadata);
+            }
+            if let Some(domain_metadata) = a.get_mut("domainMetadata") {
+                apply_domain_metadata_defaults(domain_metadata);
             }
             serde_json::to_string(&a).expect("serialize log action")
         })

--- a/compliance-suite/tests/compliance_suite/mod.rs
+++ b/compliance-suite/tests/compliance_suite/mod.rs
@@ -1,0 +1,792 @@
+//! Harness for Delta protocol compliance tests.
+//!
+//! Loads fixture files from `compliance-suite/fixtures/`, resolves `$ref`
+//! references within each file, and provides [`Fixture`] and [`Case`] for use in
+//! per-fixture test modules.
+//!
+//! ## Macro API
+//!
+//! Each fixture module declares a `LazyLock<Fixture>` static, then calls one macro per case
+//! (in order) followed by [`compliance_case_sentinel!`]:
+//!
+//! - [`compliance_case_success!`] -- fixture expects `Success`.
+//!   No error arg: kernel passes. Error arg: kernel diverges by failing (arg pins the error).
+//! - [`compliance_case_failure!`] -- fixture expects `Failure`.
+//!   Error arg: kernel fails correctly (arg pins the error). No error arg: kernel diverges by succeeding.
+//! - [`compliance_case_inexpressible!`] -- harness cannot express the fixture's protocol shape
+//!   via the current API. Passes as long as the harness returns `Inexpressible`.
+//! - [`compliance_case_sentinel!`] -- asserts the next case index does not yet exist.
+
+// Each test binary includes this module but uses only a subset of the macros and
+// public functions (e.g. a file with only inexpressible cases never calls run_case_success).
+// Suppress the resulting lint noise here rather than in every test file.
+#![allow(unused_macros, dead_code)]
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use delta_kernel::committer::FileSystemCommitter;
+use delta_kernel::engine::default::DefaultEngineBuilder;
+use delta_kernel::object_store::memory::InMemory;
+use delta_kernel::object_store::{path::Path as StorePath, DynObjectStore, ObjectStoreExt};
+use serde_json::Value;
+
+fn fixtures_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("fixtures")
+}
+
+fn errata_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("errata.json")
+}
+
+/// Recursively resolve `$section.name` references in `value`, consulting `doc` for the
+/// referenced sections.
+///
+/// - `$schemas.x` → compact JSON string of the schema object (Delta's schemaString format).
+/// - All other `$section.name` references → the target value, recursively resolved.
+/// - Non-string and non-reference values are returned unchanged.
+fn resolve(doc: &Value, value: &Value) -> Value {
+    match value {
+        Value::String(s) if s.starts_with('$') => {
+            let (section, name) = s[1..]
+                .split_once('.')
+                .unwrap_or_else(|| panic!("invalid $ref {s:?}: expected '$section.name'"));
+            let section_key = format!("${section}");
+            let resolved = &doc[&section_key][name];
+            assert!(
+                !resolved.is_null(),
+                "unresolved $ref {s:?}: '{name}' not found in '{section_key}'"
+            );
+            if section == "schemas" {
+                // Schemas are serialized to a JSON string (Delta schemaString format).
+                Value::String(resolved.to_string())
+            } else {
+                resolve(doc, resolved)
+            }
+        }
+        Value::Object(map) => Value::Object(
+            map.iter()
+                .map(|(k, v)| (k.clone(), resolve(doc, v)))
+                .collect(),
+        ),
+        Value::Array(arr) => Value::Array(arr.iter().map(|v| resolve(doc, v)).collect()),
+        other => other.clone(),
+    }
+}
+
+/// Outcome of executing a compliance case.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    /// The operation succeeded (reader opened the table, writer committed, etc.).
+    Success,
+    /// The operation was rejected (invalid protocol, unsupported feature, etc.).
+    Failure,
+    /// The harness cannot attempt this case using the current kernel API.
+    ///
+    /// Returned when the fixture's protocol shape or operation cannot be produced
+    /// via the public API (e.g., `create_table()` always produces `(3,7)`, so
+    /// legacy protocol versions are inexpressible). A test that expects
+    /// `Inexpressible` will fail automatically when the harness stops returning
+    /// it, signaling that the API gap has been addressed and the expectation needs
+    /// to be re-evaluated.
+    Inexpressible,
+}
+
+/// A single resolved fixture case.
+#[allow(dead_code)]
+pub struct Case {
+    /// 1-based ordinal declared in the fixture file and validated against array position on load.
+    pub ordinal: usize,
+    pub name: String,
+    pub description: String,
+    pub expected_outcome: Outcome,
+    pub feature: Option<String>,
+    pub flavor: Option<String>,
+    /// Resolved `operation` object. Will be parsed into a typed operation when cases are run.
+    pub operation: Value,
+    /// Resolved `setup` object, if present.
+    pub setup: Option<Value>,
+    /// Resolved `note` field, if present. May be a string (`$notes.*`) or an object (`$errata.*`).
+    pub note: Option<Value>,
+}
+
+/// A loaded and fully resolved fixture file.
+pub struct Fixture {
+    pub filename: &'static str,
+    pub cases: Vec<Case>,
+}
+
+impl Fixture {
+    /// Load and resolve a fixture file by name.
+    ///
+    /// `filename` is resolved relative to `compliance-suite/fixtures/`.
+    /// Errata from `compliance-suite/errata.json` is injected so that
+    /// `$errata.*` references within the file resolve correctly.
+    pub fn load(filename: &'static str) -> Self {
+        let path = fixtures_dir().join(filename);
+        let text = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("failed to read fixture {filename:?}: {e}"));
+        let mut doc: Value = serde_json::from_str(&text)
+            .unwrap_or_else(|e| panic!("failed to parse fixture {filename:?}: {e}"));
+
+        // Inject errata so that "$errata.key" references in case `note` fields resolve.
+        let errata: Value = std::fs::read_to_string(errata_path())
+            .ok()
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or(Value::Object(Default::default()));
+        doc.as_object_mut()
+            .expect("fixture root must be a JSON object")
+            .insert("$errata".to_string(), errata);
+
+        let raw_cases = doc["cases"]
+            .as_array()
+            .unwrap_or_else(|| panic!("{filename}: missing 'cases' array"))
+            .clone();
+
+        let cases = raw_cases
+            .iter()
+            .enumerate()
+            .map(|(i, raw)| {
+                let c = resolve(&doc, raw);
+                let position = i + 1;
+                let ordinal = c["ordinal"].as_u64().unwrap_or_else(|| {
+                    panic!("{filename} case {position}: missing 'ordinal' field")
+                }) as usize;
+                assert_eq!(
+                    ordinal, position,
+                    "{filename} case {position}: declared ordinal {ordinal} does not match \
+                     array position {position}",
+                );
+                Case {
+                    ordinal,
+                    name: c["name"]
+                        .as_str()
+                        .unwrap_or_else(|| panic!("{filename} case {ordinal}: missing 'name'"))
+                        .to_string(),
+                    description: c["description"]
+                        .as_str()
+                        .unwrap_or_else(|| {
+                            panic!("{filename} case {ordinal}: missing 'description'")
+                        })
+                        .to_string(),
+                    expected_outcome: match c["expected_outcome"].as_str() {
+                        Some("success") => Outcome::Success,
+                        Some("failure") => Outcome::Failure,
+                        other => {
+                            panic!("{filename} case {ordinal}: invalid expected_outcome {other:?}")
+                        }
+                    },
+                    feature: c["feature"].as_str().map(str::to_string),
+                    flavor: c["flavor"].as_str().map(str::to_string),
+                    operation: c["operation"].clone(),
+                    setup: {
+                        let v = &c["setup"];
+                        (!v.is_null()).then(|| v.clone())
+                    },
+                    note: {
+                        let v = &c["note"];
+                        (!v.is_null()).then(|| v.clone())
+                    },
+                }
+            })
+            .collect();
+
+        Fixture { filename, cases }
+    }
+
+    /// Return the case at 1-based index `n`.
+    ///
+    /// Panics with a diagnostic if `n` is out of range, e.g. because a case was removed
+    /// from the fixture without removing the corresponding `compliance_case_success!` or
+    /// `compliance_case_failure!` invocation.
+    pub fn case(&self, n: usize) -> &Case {
+        self.cases.get(n - 1).unwrap_or_else(|| {
+            panic!(
+                "compliance_case!({n}) is out of range: '{}' has {} case(s). \
+                 If the case was removed from the fixture, delete the corresponding \
+                 compliance_case! invocation.",
+                self.filename,
+                self.cases.len(),
+            )
+        })
+    }
+
+    /// Assert that no case exists at 1-based index `n`.
+    ///
+    /// Called by `compliance_case_sentinel!` to detect when new cases are added to the
+    /// fixture without corresponding `compliance_case_success!` or `compliance_case_failure!`
+    /// invocations.
+    pub fn assert_sentinel(&self, n: usize) {
+        if let Some(case) = self.cases.get(n - 1) {
+            panic!(
+                "compliance_case_sentinel!({n}) failed: '{}' now has a case at ordinal {n} \
+                 (name: '{}').\n\
+                 Add a compliance_case! invocation above the sentinel and update to \
+                 compliance_case_sentinel!({}).",
+                self.filename,
+                case.name,
+                n + 1,
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Case execution
+// ---------------------------------------------------------------------------
+
+/// Apply Delta MetaData defaults to the inner metaData object.
+///
+/// Fills in `id`, `format`, `partitionColumns`, and `configuration` when absent.
+/// The Python DBR harness (databricks_compliance.py) applies the same defaults before writing log files.
+fn apply_metadata_defaults(metadata: &mut Value) {
+    let obj = metadata
+        .as_object_mut()
+        .expect("metaData value must be a JSON object");
+    obj.entry("id")
+        .or_insert_with(|| Value::String("00000000-0000-0000-0000-000000000001".to_string()));
+    obj.entry("format")
+        .or_insert_with(|| serde_json::json!({"provider": "parquet", "options": {}}));
+    obj.entry("partitionColumns")
+        .or_insert(Value::Array(vec![]));
+    obj.entry("configuration")
+        .or_insert_with(|| Value::Object(Default::default()));
+}
+
+/// Write a list of Delta log actions as version 0 of the table in `store`.
+///
+/// Actions are written as NDJSON to `_delta_log/00000000000000000000.json`. Any `metaData`
+/// action in the list has defaults applied before serialization.
+async fn write_log_v0(store: &InMemory, actions: &[Value]) {
+    let ndjson = actions
+        .iter()
+        .map(|a| {
+            let mut a = a.clone();
+            if let Some(metadata) = a.get_mut("metaData") {
+                apply_metadata_defaults(metadata);
+            }
+            serde_json::to_string(&a).expect("serialize log action")
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let path = StorePath::from("_delta_log/00000000000000000000.json");
+    store.put(&path, ndjson.into()).await.expect("write log v0");
+}
+
+/// Create a fresh in-memory object store and a `DefaultEngine` backed by the same store.
+///
+/// Returns `(store, engine)` where `store` is the raw `Arc<InMemory>` for writing log files
+/// and `engine` is configured to read from that same store.
+fn new_store_and_engine() -> (Arc<InMemory>, impl delta_kernel::Engine) {
+    let store = Arc::new(InMemory::new());
+    let engine = DefaultEngineBuilder::new(store.clone() as Arc<DynObjectStore>).build();
+    (store, engine)
+}
+
+/// Attempt to build a [`Snapshot`] from `memory:///` using the given engine.
+fn try_build_snapshot(
+    engine: &dyn delta_kernel::Engine,
+) -> delta_kernel::DeltaResult<delta_kernel::snapshot::SnapshotRef> {
+    delta_kernel::Snapshot::builder_for("memory:///").build(engine)
+}
+
+/// Run a compliance case where the fixture expects [`Outcome::Success`].
+///
+/// - No `error_pattern`: asserts the kernel produces `Success` (passing case).
+/// - With `error_pattern`: asserts the kernel produces `Failure` with an error matching the
+///   given substring, documenting a known divergence. The test fails automatically when the
+///   divergence is resolved, prompting removal of the error arg from `compliance_case_success!`.
+pub async fn run_case_success(case: &Case, error_pattern: Option<&str>) {
+    assert_eq!(
+        case.expected_outcome,
+        Outcome::Success,
+        "case {} '{}': compliance_case_success! requires expected_outcome=Success, got {:?}",
+        case.ordinal,
+        case.name,
+        case.expected_outcome,
+    );
+    let (actual, actual_error) = execute_case(case).await;
+    match error_pattern {
+        None => {
+            if actual != Outcome::Success {
+                let error_suffix = actual_error
+                    .as_deref()
+                    .map(|e| format!("\n  error: {e}"))
+                    .unwrap_or_default();
+                panic!(
+                    "case {} '{}': expected Success but got {:?}{}",
+                    case.ordinal, case.name, actual, error_suffix,
+                );
+            }
+        }
+        Some(pattern) => {
+            if actual != Outcome::Failure {
+                panic!(
+                    "case {} '{}': divergence resolved — spec expects Success and kernel now \
+                     produces {:?}; remove the error arg from compliance_case_success!",
+                    case.ordinal, case.name, actual,
+                );
+            }
+            let error = actual_error.as_deref().unwrap_or_else(|| {
+                panic!(
+                    "case {} '{}': kernel produced Failure but captured no error message",
+                    case.ordinal, case.name,
+                )
+            });
+            assert!(
+                error.contains(pattern),
+                "case {} '{}': divergence error does not match expected pattern\n  pattern: {:?}\n  error:   {:?}",
+                case.ordinal, case.name, pattern, error,
+            );
+        }
+    }
+}
+
+/// Run a compliance case where the fixture expects [`Outcome::Failure`] and the kernel
+/// correctly rejects the input.
+///
+/// Asserts the kernel produces `Failure` with an error containing `error_pattern`.
+pub async fn run_case_failure(case: &Case, error_pattern: &str) {
+    assert_eq!(
+        case.expected_outcome,
+        Outcome::Failure,
+        "case {} '{}': compliance_case_failure! requires expected_outcome=Failure, got {:?}",
+        case.ordinal,
+        case.name,
+        case.expected_outcome,
+    );
+    let (actual, actual_error) = execute_case(case).await;
+    if actual != Outcome::Failure {
+        panic!(
+            "case {} '{}': expected Failure but got {:?}; \
+             the case may now be diverging — switch to \
+             compliance_case_failure!(diverges: \"...\") to document it",
+            case.ordinal, case.name, actual,
+        );
+    }
+    let error = actual_error.as_deref().unwrap_or_else(|| {
+        panic!(
+            "case {} '{}': kernel produced Failure but captured no error message",
+            case.ordinal, case.name,
+        )
+    });
+    assert!(
+        error.contains(error_pattern),
+        "case {} '{}': failure error does not match expected pattern\n  pattern: {:?}\n  error:   {:?}",
+        case.ordinal, case.name, error_pattern, error,
+    );
+}
+
+/// Run a compliance case where the fixture expects [`Outcome::Failure`] but the kernel
+/// diverges by succeeding.
+///
+/// `reason` documents what the kernel is failing to enforce. The test fails automatically
+/// when the divergence is resolved, including `reason` in the diagnostic to guide the fix.
+pub async fn run_case_failure_diverges(case: &Case, reason: &str) {
+    assert_eq!(
+        case.expected_outcome,
+        Outcome::Failure,
+        "case {} '{}': compliance_case_failure! requires expected_outcome=Failure, got {:?}",
+        case.ordinal,
+        case.name,
+        case.expected_outcome,
+    );
+    let (actual, actual_error) = execute_case(case).await;
+    if actual != Outcome::Success {
+        let error_suffix = actual_error
+            .as_deref()
+            .map(|e| format!("\n  error: {e}"))
+            .unwrap_or_default();
+        panic!(
+            "case {} '{}': divergence resolved ({reason}) — spec expects Failure and kernel \
+             now produces {:?}{}; switch to compliance_case_failure! with an error arg",
+            case.ordinal, case.name, actual, error_suffix,
+        );
+    }
+}
+
+/// Run a compliance case and assert the outcome is [`Outcome::Inexpressible`].
+///
+/// Use this for cases that cannot be tested via the current kernel API. The assertion
+/// fails when the harness stops returning `Inexpressible`, signaling that the API gap
+/// has been addressed. At that point, switch to [`compliance_case_success!`] or
+/// [`compliance_case_failure!`] and verify the actual outcome matches the fixture's
+/// `expected_outcome`.
+pub async fn run_case_expect_inexpressible(case: &Case) {
+    let (actual, _) = execute_case(case).await;
+    assert_eq!(
+        actual,
+        Outcome::Inexpressible,
+        "case {} '{}': expected Inexpressible (API gap) but got {:?}; \
+         the gap may have been addressed — switch to the appropriate compliance_case! \
+         macro and verify the outcome matches the fixture's expected_outcome ({:?})",
+        case.ordinal,
+        case.name,
+        actual,
+        case.expected_outcome,
+    );
+}
+
+async fn execute_case(case: &Case) -> (Outcome, Option<String>) {
+    let op_type = case.operation["type"]
+        .as_str()
+        .unwrap_or_else(|| panic!("case {}: missing operation.type", case.ordinal));
+
+    match op_type {
+        "read_snapshot" => execute_read_snapshot(case).await,
+        "empty_commit" => execute_empty_commit(case).await,
+        "create_table" => execute_create_table(case).await,
+        other => panic!("case {}: unknown operation type {:?}", case.ordinal, other),
+    }
+}
+
+/// Execute a `read_snapshot` operation.
+///
+/// Writes the setup log actions to a fresh in-memory store, builds a snapshot, then attempts
+/// to start a scan. The scan step triggers `ensure_read_supported`, which validates the reader
+/// version and rejects unsupported or unknown reader features. Returns `Success` only if both
+/// snapshot construction and scan setup succeed.
+async fn execute_read_snapshot(case: &Case) -> (Outcome, Option<String>) {
+    let setup = case
+        .setup
+        .as_ref()
+        .unwrap_or_else(|| panic!("case {}: read_snapshot requires setup", case.ordinal));
+    let log_actions: Vec<Value> = setup["log_actions"]
+        .as_array()
+        .unwrap_or_else(|| panic!("case {}: setup.log_actions must be array", case.ordinal))
+        .to_vec();
+
+    let (store, engine) = new_store_and_engine();
+    write_log_v0(&store, &log_actions).await;
+
+    // Build snapshot: validates protocol structural validity (version/feature consistency).
+    let snapshot = match try_build_snapshot(&engine) {
+        Ok(s) => s,
+        Err(e) => return (Outcome::Failure, Some(e.to_string())),
+    };
+
+    // Start a scan: triggers ensure_read_supported, which checks the reader version and rejects
+    // unsupported reader features (including Unknown ones).
+    match snapshot.scan_builder().build() {
+        Ok(_) => (Outcome::Success, None),
+        Err(e) => (Outcome::Failure, Some(e.to_string())),
+    }
+}
+
+/// Execute an `empty_commit` operation.
+///
+/// Writes the setup log actions to a fresh in-memory store, builds a snapshot, creates a
+/// transaction (which triggers `ensure_write_supported`), and commits it. Returns `Success`
+/// only if every step succeeds and the commit is confirmed.
+async fn execute_empty_commit(case: &Case) -> (Outcome, Option<String>) {
+    let setup = case
+        .setup
+        .as_ref()
+        .unwrap_or_else(|| panic!("case {}: empty_commit requires setup", case.ordinal));
+    let log_actions: Vec<Value> = setup["log_actions"]
+        .as_array()
+        .unwrap_or_else(|| panic!("case {}: setup.log_actions must be array", case.ordinal))
+        .to_vec();
+
+    let (store, engine) = new_store_and_engine();
+    write_log_v0(&store, &log_actions).await;
+
+    // Build snapshot: validates protocol structural validity.
+    let snapshot = match try_build_snapshot(&engine) {
+        Ok(s) => s,
+        Err(e) => return (Outcome::Failure, Some(e.to_string())),
+    };
+
+    // Create transaction: triggers ensure_write_supported, which checks the writer version and
+    // rejects unsupported or unknown writer features.
+    let txn = match snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine) {
+        Ok(t) => t,
+        Err(e) => return (Outcome::Failure, Some(e.to_string())),
+    };
+
+    // Commit the transaction.
+    match txn.commit(&engine) {
+        Ok(result) if result.is_committed() => (Outcome::Success, None),
+        Ok(_) => (
+            Outcome::Failure,
+            Some("commit did not complete".to_string()),
+        ),
+        Err(e) => (Outcome::Failure, Some(e.to_string())),
+    }
+}
+
+/// Execute a `create_table` operation via kernel's public `create_table()` API.
+///
+/// Returns [`Outcome::Inexpressible`] when the fixture's protocol shape cannot be produced
+/// by `create_table()`: the API always produces `(3,7)` with both feature arrays present and
+/// symmetric feature placement. Fixtures specifying legacy protocol versions, missing feature
+/// arrays, or asymmetric placement all fall back to `Inexpressible`.
+///
+/// For expressible cases, all features named in `readerFeatures` and `writerFeatures` are
+/// submitted as `delta.feature.X = "supported"` table properties. Kernel validates these
+/// against its allowed-feature list; unknown or disallowed features cause the build step to
+/// return an error, producing `Outcome::Failure`.
+async fn execute_create_table(case: &Case) -> (Outcome, Option<String>) {
+    let op = &case.operation;
+    let protocol_val = op.get("protocol").unwrap_or_else(|| {
+        panic!(
+            "case {}: create_table operation missing 'protocol'",
+            case.ordinal
+        )
+    });
+    let metadata_val = op.get("metadata").unwrap_or_else(|| {
+        panic!(
+            "case {}: create_table operation missing 'metadata'",
+            case.ordinal
+        )
+    });
+
+    // --- Expressibility check ---
+    // The create_table() API always produces (3,7) with both feature arrays present.
+    let reader_version = protocol_val["minReaderVersion"].as_i64().unwrap_or(-1);
+    let writer_version = protocol_val["minWriterVersion"].as_i64().unwrap_or(-1);
+    let reader_features = protocol_val
+        .get("readerFeatures")
+        .and_then(|v| v.as_array());
+    let writer_features = protocol_val
+        .get("writerFeatures")
+        .and_then(|v| v.as_array());
+
+    // create_table() always produces (3,7) with both feature arrays present.
+    // Any other protocol shape is inexpressible via the current API.
+    if reader_version != 3 || writer_version != 7 {
+        return (Outcome::Inexpressible, None);
+    }
+    let Some(reader_features) = reader_features else {
+        return (Outcome::Inexpressible, None);
+    };
+    let Some(writer_features) = writer_features else {
+        return (Outcome::Inexpressible, None);
+    };
+
+    // create_table() enforces symmetric feature placement (all ReaderWriter features
+    // appear in both arrays). Asymmetric placement is inexpressible via the current API.
+    let writer_feature_names: Vec<&str> =
+        writer_features.iter().filter_map(|v| v.as_str()).collect();
+    if reader_features
+        .iter()
+        .filter_map(|v| v.as_str())
+        .any(|f| !writer_feature_names.contains(&f))
+    {
+        return (Outcome::Inexpressible, None);
+    }
+
+    // --- Feature translation ---
+    // Combine reader + writer feature names (deduplicated) and map to delta.feature.X=supported.
+    let mut seen = std::collections::HashSet::new();
+    let feature_props: Vec<(String, String)> = reader_features
+        .iter()
+        .chain(writer_features.iter())
+        .filter_map(|v| v.as_str())
+        .filter(|&f| seen.insert(f))
+        .map(|f| (format!("delta.feature.{f}"), "supported".to_string()))
+        .collect();
+
+    // --- Configuration ---
+    // Pass metadata.configuration entries (e.g. delta.columnMapping.mode) as table properties.
+    let config_props: Vec<(String, String)> = metadata_val
+        .get("configuration")
+        .and_then(|c| c.as_object())
+        .map(|obj| {
+            obj.iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // --- Schema ---
+    let schema_str = metadata_val["schemaString"].as_str().unwrap_or_else(|| {
+        panic!(
+            "case {}: metadata.schemaString must be a string",
+            case.ordinal
+        )
+    });
+    let schema: Arc<delta_kernel::schema::StructType> = Arc::new(
+        serde_json::from_str(schema_str)
+            .unwrap_or_else(|e| panic!("case {}: failed to parse schemaString: {e}", case.ordinal)),
+    );
+
+    // --- Call create_table() ---
+    let (_store, engine) = new_store_and_engine();
+    let build_result = delta_kernel::transaction::create_table::create_table(
+        "memory:///",
+        schema,
+        "compliance-harness/0.1",
+    )
+    .with_table_properties(feature_props.into_iter().chain(config_props))
+    .build(&engine, Box::new(FileSystemCommitter::new()));
+
+    let txn = match build_result {
+        Ok(t) => t,
+        Err(e) => return (Outcome::Failure, Some(e.to_string())),
+    };
+
+    match txn.commit(&engine) {
+        Ok(result) if result.is_committed() => {
+            // After a successful commit, read back the snapshot and compare schemas.
+            // Schema divergence is not a test failure — kernel may auto-annotate fields
+            // (e.g. column mapping metadata). Print differences for debugging only.
+            // Both sides are round-tripped through serde to normalize whitespace/field order.
+            if let Ok(snapshot) = try_build_snapshot(&engine) {
+                let committed_schema = snapshot.schema();
+                let committed_json = serde_json::to_string(committed_schema.as_ref())
+                    .unwrap_or_else(|e| format!("<serialize error: {e}>"));
+                // Normalize the requested schema through the same round-trip so the
+                // comparison is structural rather than textual.
+                let requested_normalized = serde_json::from_str::<delta_kernel::schema::StructType>(schema_str)
+                    .ok()
+                    .and_then(|s| serde_json::to_string(&s).ok())
+                    .unwrap_or_else(|| schema_str.to_string());
+                if committed_json != requested_normalized {
+                    println!(
+                        "case {} '{}': schema divergence after commit\n  \
+                         requested: {}\n  committed: {}",
+                        case.ordinal, case.name, requested_normalized, committed_json,
+                    );
+                }
+            }
+            (Outcome::Success, None)
+        }
+        Ok(_) => (
+            Outcome::Failure,
+            Some("commit did not complete".to_string()),
+        ),
+        Err(e) => (Outcome::Failure, Some(e.to_string())),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Macros
+// ---------------------------------------------------------------------------
+
+/// Generate a compliance test for case `$n` in fixture `$fixture` where the fixture expects
+/// [`Outcome::Success`].
+///
+/// - No error arg: kernel passes correctly.
+/// - With error arg: kernel diverges by failing; arg is a substring that must appear in the
+///   error message. The test fails automatically when the divergence is resolved, prompting
+///   removal of the error arg.
+macro_rules! compliance_case_success {
+    ($fixture:ident, $n:literal) => {
+        paste::paste! {
+            #[tokio::test]
+            async fn [< $fixture:lower _case_ $n >]() {
+                let case = $fixture.case($n);
+                println!("case {}: {}", $n, case.name);
+                super::run_case_success(case, None).await;
+            }
+        }
+    };
+    ($fixture:ident, $n:literal, $error_pattern:literal) => {
+        paste::paste! {
+            #[tokio::test]
+            async fn [< $fixture:lower _case_ $n >]() {
+                let case = $fixture.case($n);
+                println!("case {}: {}", $n, case.name);
+                super::run_case_success(case, Some($error_pattern)).await;
+            }
+        }
+    };
+}
+
+/// Generate a compliance test for case `$n` in fixture `$fixture` where the fixture expects
+/// [`Outcome::Failure`].
+///
+/// - With error arg: kernel fails correctly; arg is a substring that must appear in the error
+///   message. Use this to pin the specific failure mode.
+/// - With `diverges:` arg: kernel diverges by succeeding; arg is a required explanation of
+///   what the kernel is failing to enforce. The test fails automatically when the divergence
+///   is resolved, including the explanation in the diagnostic.
+macro_rules! compliance_case_failure {
+    ($fixture:ident, $n:literal, $error_pattern:literal) => {
+        paste::paste! {
+            #[tokio::test]
+            async fn [< $fixture:lower _case_ $n >]() {
+                let case = $fixture.case($n);
+                println!("case {}: {}", $n, case.name);
+                super::run_case_failure(case, $error_pattern).await;
+            }
+        }
+    };
+    ($fixture:ident, $n:literal, diverges: $reason:literal) => {
+        paste::paste! {
+            #[tokio::test]
+            async fn [< $fixture:lower _case_ $n >]() {
+                let case = $fixture.case($n);
+                println!("case {}: {}", $n, case.name);
+                super::run_case_failure_diverges(case, $reason).await;
+            }
+        }
+    };
+}
+
+/// Generate a compliance test for case `$n` in fixture `$fixture` that expects the harness
+/// to return [`Outcome::Inexpressible`].
+///
+/// Use this when the fixture's protocol shape or operation cannot be produced via the current
+/// kernel API (e.g., legacy protocol versions, missing feature arrays, asymmetric feature
+/// placement). The test passes as long as the harness returns `Inexpressible`. When the API
+/// gap is addressed and the harness starts returning `Success` or `Failure`, the test fails
+/// with a diagnostic prompting a switch to [`compliance_case_success!`] or
+/// [`compliance_case_failure!`].
+macro_rules! compliance_case_inexpressible {
+    ($fixture:ident, $n:literal) => {
+        paste::paste! {
+            #[tokio::test]
+            async fn [< $fixture:lower _case_ $n >]() {
+                let case = $fixture.case($n);
+                println!("case {}: {}", $n, case.name);
+                super::run_case_expect_inexpressible(case).await;
+            }
+        }
+    };
+}
+
+/// Sentinel test asserting that case `$n` does not exist in fixture `$fixture`.
+///
+/// Place this immediately after the last `compliance_case!` invocation for a fixture.
+/// It fails with a diagnostic when the fixture gains a new case, prompting you to add
+/// a `compliance_case!` entry and advance the sentinel.
+macro_rules! compliance_case_sentinel {
+    ($fixture:ident, $n:literal) => {
+        paste::paste! {
+            #[test]
+            fn [< $fixture:lower _sentinel >]() {
+                $fixture.assert_sentinel($n);
+            }
+        }
+    };
+}
+
+// Per-feature compliance tests
+mod allow_column_defaults;
+mod append_only;
+mod catalog_managed;
+mod change_data_feed;
+mod check_constraints;
+mod clustering;
+mod column_mapping;
+mod deletion_vectors;
+mod domain_metadata;
+mod generated_columns;
+mod iceberg_compat_v1;
+mod iceberg_compat_v2;
+mod iceberg_compat_v3_preview;
+mod iceberg_writer_compat;
+mod identity_columns;
+mod in_commit_timestamp;
+mod invariants;
+mod materialize_partition_columns;
+mod protocol;
+mod row_tracking;
+mod timestamp_ntz;
+mod type_widening;
+mod v2_checkpoint;
+mod vacuum_protocol_check;
+mod variant;
+mod variant_shredding_preview;

--- a/compliance-suite/tests/compliance_suite/mod.rs
+++ b/compliance-suite/tests/compliance_suite/mod.rs
@@ -619,10 +619,15 @@ async fn execute_create_table(case: &Case) -> (Outcome, Option<String>) {
             case.ordinal
         )
     });
-    let schema: Arc<delta_kernel::schema::StructType> = Arc::new(
-        serde_json::from_str(schema_str)
-            .unwrap_or_else(|e| panic!("case {}: failed to parse schemaString: {e}", case.ordinal)),
-    );
+    let schema = match serde_json::from_str::<delta_kernel::schema::StructType>(schema_str) {
+        Ok(schema) => Arc::new(schema),
+        Err(e) => {
+            return (
+                Outcome::Failure,
+                Some(format!("failed to parse schemaString: {e}")),
+            );
+        }
+    };
 
     // --- Call create_table() ---
     let (_store, engine) = new_store_and_engine();

--- a/compliance-suite/tests/compliance_suite/protocol.rs
+++ b/compliance-suite/tests/compliance_suite/protocol.rs
@@ -1,0 +1,55 @@
+//! Delta protocol compliance tests.
+
+use super::Fixture;
+use std::sync::LazyLock;
+
+static PROTOCOL_VALIDITY: LazyLock<Fixture> =
+    LazyLock::new(|| Fixture::load("protocol-validity.json"));
+
+compliance_case_success!(PROTOCOL_VALIDITY, 1);
+compliance_case_success!(PROTOCOL_VALIDITY, 2);
+compliance_case_failure!(PROTOCOL_VALIDITY, 3, "Reader features must be present when minimum reader version = 3");
+compliance_case_failure!(PROTOCOL_VALIDITY, 4, "Reader features should be present in writer features");
+compliance_case_failure!(PROTOCOL_VALIDITY, 5, "Writer features must be present when minimum writer version = 7");
+compliance_case_failure!(PROTOCOL_VALIDITY, 6, "Reader features must not be present when minimum reader version != 3");
+compliance_case_inexpressible!(PROTOCOL_VALIDITY, 7); // fixture uses protocol (3,5); create_table() always produces (3,7)
+compliance_case_failure!(PROTOCOL_VALIDITY, 8, "Feature 'unknownFeature' is not supported");
+compliance_case_success!(PROTOCOL_VALIDITY, 9);
+compliance_case_failure!(PROTOCOL_VALIDITY, 10, "Feature 'unknownFeature' is not supported");
+compliance_case_failure!(PROTOCOL_VALIDITY, 11, "Reader features must contain only ReaderWriter features that are also listed in writer features");
+compliance_case_failure!(PROTOCOL_VALIDITY, 12, "Writer features must be Writer-only or also listed in reader features");
+compliance_case_failure!(PROTOCOL_VALIDITY, 13, "Reader features must not be present when minimum reader version != 3");
+compliance_case_success!(PROTOCOL_VALIDITY, 14, "Writer features must not be present when minimum writer version != 7");
+compliance_case_failure!(PROTOCOL_VALIDITY, 15, "Writer features must not be present when minimum writer version != 7");
+compliance_case_success!(PROTOCOL_VALIDITY, 16);
+compliance_case_inexpressible!(PROTOCOL_VALIDITY, 17); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(PROTOCOL_VALIDITY, 18); // fixture uses protocol (2,999); create_table() always produces (3,7)
+compliance_case_inexpressible!(PROTOCOL_VALIDITY, 19); // fixture uses protocol (999,999); create_table() always produces (3,7)
+compliance_case_success!(PROTOCOL_VALIDITY, 20);
+compliance_case_success!(PROTOCOL_VALIDITY, 21);
+compliance_case_inexpressible!(PROTOCOL_VALIDITY, 22); // create_table() always produces both feature arrays; fixture omits writerFeatures
+compliance_case_inexpressible!(PROTOCOL_VALIDITY, 23); // create_table() always produces both feature arrays; fixture omits readerFeatures
+compliance_case_inexpressible!(PROTOCOL_VALIDITY, 24); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_failure!(PROTOCOL_VALIDITY, 25, "Writer features must be present when minimum writer version = 7");
+compliance_case_failure!(PROTOCOL_VALIDITY, 26, "Reader features must not be present when minimum reader version != 3");
+compliance_case_failure!(PROTOCOL_VALIDITY, 27, "Reader features should be present in writer features");
+compliance_case_failure!(PROTOCOL_VALIDITY, 28, "'delta.feature.unknownFeature' is not supported during CREATE TABLE");
+compliance_case_inexpressible!(PROTOCOL_VALIDITY, 29); // fixture uses protocol (2,7); create_table() always produces (3,7)
+compliance_case_failure!(PROTOCOL_VALIDITY, 30, "Feature 'unknownFeature' is not supported");
+compliance_case_inexpressible!(PROTOCOL_VALIDITY, 31); // create_table() enforces symmetric placement; fixture uses reader-only feature
+compliance_case_failure!(PROTOCOL_VALIDITY, 32, diverges: "kernel does not reject reader-writer features listed only in writerFeatures during create_table");
+compliance_case_failure!(PROTOCOL_VALIDITY, 33, "Reader features must contain only ReaderWriter features that are also listed in writer features");
+compliance_case_inexpressible!(PROTOCOL_VALIDITY, 34); // fixture uses protocol (1,2); create_table() always produces (3,7)
+compliance_case_failure!(PROTOCOL_VALIDITY, 35, "'delta.feature.unknownFeature' is not supported during CREATE TABLE");
+compliance_case_failure!(PROTOCOL_VALIDITY, 36, "Writer features must be Writer-only or also listed in reader features");
+compliance_case_inexpressible!(PROTOCOL_VALIDITY, 37); // fixture uses protocol (1,1); create_table() always produces (3,7)
+compliance_case_failure!(PROTOCOL_VALIDITY, 38, diverges: "kernel does not validate nullable=false fields require invariants or checkConstraints");
+compliance_case_success!(PROTOCOL_VALIDITY, 39);
+compliance_case_failure!(PROTOCOL_VALIDITY, 40, "Reader features must be present when minimum reader version = 3");
+compliance_case_failure!(PROTOCOL_VALIDITY, 41, "Reader features must be present when minimum reader version = 3");
+compliance_case_inexpressible!(PROTOCOL_VALIDITY, 42); // create_table() always produces both feature arrays; fixture omits writerFeatures
+compliance_case_failure!(PROTOCOL_VALIDITY, 43, "Writer features must be present when minimum writer version = 7");
+compliance_case_failure!(PROTOCOL_VALIDITY, 44, "Writer features must be present when minimum writer version = 7");
+compliance_case_success!(PROTOCOL_VALIDITY, 45);
+compliance_case_success!(PROTOCOL_VALIDITY, 46);
+compliance_case_sentinel!(PROTOCOL_VALIDITY, 47);

--- a/compliance-suite/tests/compliance_suite/row_tracking.rs
+++ b/compliance-suite/tests/compliance_suite/row_tracking.rs
@@ -1,0 +1,21 @@
+//! row tracking compliance tests.
+
+use super::Fixture;
+use std::sync::LazyLock;
+
+static ROW_TRACKING: LazyLock<Fixture> = LazyLock::new(|| Fixture::load("row-tracking.json"));
+
+compliance_case_inexpressible!(ROW_TRACKING, 1); // fixture uses protocol (1,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(ROW_TRACKING, 2); // fixture uses protocol (1,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(ROW_TRACKING, 3); // fixture uses protocol (1,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(ROW_TRACKING, 4); // fixture uses protocol (1,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(ROW_TRACKING, 5); // fixture uses protocol (1,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(ROW_TRACKING, 6); // fixture uses protocol (1,7); create_table() always produces (3,7)
+compliance_case_inexpressible!(ROW_TRACKING, 7); // fixture uses protocol (1,7); create_table() always produces (3,7)
+compliance_case_success!(ROW_TRACKING, 8);
+compliance_case_success!(ROW_TRACKING, 9);
+compliance_case_success!(ROW_TRACKING, 10);
+compliance_case_success!(ROW_TRACKING, 11);
+compliance_case_failure!(ROW_TRACKING, 12, diverges: "kernel does not reject rowTracking simultaneously suspended and enabled");
+compliance_case_failure!(ROW_TRACKING, 13, diverges: "kernel does not reject missing rowTracking materialized column prerequisites during empty_commit");
+compliance_case_sentinel!(ROW_TRACKING, 14);

--- a/compliance-suite/tests/compliance_suite/timestamp_ntz.rs
+++ b/compliance-suite/tests/compliance_suite/timestamp_ntz.rs
@@ -1,0 +1,22 @@
+//! timestamp ntz compliance tests.
+
+use super::Fixture;
+use std::sync::LazyLock;
+
+static TIMESTAMP_NTZ: LazyLock<Fixture> = LazyLock::new(|| Fixture::load("timestamp-ntz.json"));
+
+compliance_case_success!(TIMESTAMP_NTZ, 1, "'delta.feature.timestampNtz' is not supported during CREATE TABLE");
+compliance_case_inexpressible!(TIMESTAMP_NTZ, 2); // fixture uses protocol (1,2); create_table() always produces (3,7)
+compliance_case_failure!(TIMESTAMP_NTZ, 3, diverges: "kernel does not require timestampNtz listed when schema has TIMESTAMP_NTZ columns");
+compliance_case_success!(TIMESTAMP_NTZ, 4);
+compliance_case_success!(TIMESTAMP_NTZ, 5);
+compliance_case_success!(TIMESTAMP_NTZ, 6);
+compliance_case_failure!(TIMESTAMP_NTZ, 7, "TIMESTAMP_NTZ columns but does not have the required 'timestampNtz' feature");
+compliance_case_failure!(TIMESTAMP_NTZ, 8, "TIMESTAMP_NTZ columns but does not have the required 'timestampNtz' feature");
+compliance_case_success!(TIMESTAMP_NTZ, 9);
+compliance_case_success!(TIMESTAMP_NTZ, 10);
+compliance_case_failure!(TIMESTAMP_NTZ, 11, "TIMESTAMP_NTZ columns but does not have the required 'timestampNtz' feature");
+compliance_case_failure!(TIMESTAMP_NTZ, 12, "TIMESTAMP_NTZ columns but does not have the required 'timestampNtz' feature");
+compliance_case_success!(TIMESTAMP_NTZ, 13);
+compliance_case_failure!(TIMESTAMP_NTZ, 14, "TIMESTAMP_NTZ columns but does not have the required 'timestampNtz' feature");
+compliance_case_sentinel!(TIMESTAMP_NTZ, 15);

--- a/compliance-suite/tests/compliance_suite/type_widening.rs
+++ b/compliance-suite/tests/compliance_suite/type_widening.rs
@@ -1,0 +1,23 @@
+//! type widening compliance tests.
+
+use super::Fixture;
+use std::sync::LazyLock;
+
+static TYPE_WIDENING: LazyLock<Fixture> = LazyLock::new(|| Fixture::load("type-widening.json"));
+
+compliance_case_success!(TYPE_WIDENING, 1);
+compliance_case_success!(TYPE_WIDENING, 2);
+compliance_case_failure!(TYPE_WIDENING, 3, diverges: "kernel does not reject typeWidening listed only in writerFeatures without a matching readerFeatures entry");
+compliance_case_success!(TYPE_WIDENING, 4);
+compliance_case_success!(TYPE_WIDENING, 5);
+compliance_case_success!(TYPE_WIDENING, 6);
+compliance_case_success!(TYPE_WIDENING, 7);
+compliance_case_failure!(TYPE_WIDENING, 8, diverges: "kernel does not reject unsupported type-change entries in the schema");
+compliance_case_success!(TYPE_WIDENING, 9);
+compliance_case_success!(TYPE_WIDENING, 10, "Writer features must be Writer-only or also listed in reader features");
+compliance_case_success!(TYPE_WIDENING, 11, "Feature 'typeWidening' is not supported for writes");
+compliance_case_success!(TYPE_WIDENING, 12, "Feature 'typeWidening' is not supported for writes");
+compliance_case_success!(TYPE_WIDENING, 13);
+compliance_case_success!(TYPE_WIDENING, 14, "'delta.feature.typeWidening-preview' is not supported during CREATE TABLE");
+compliance_case_success!(TYPE_WIDENING, 15);
+compliance_case_sentinel!(TYPE_WIDENING, 16);

--- a/compliance-suite/tests/compliance_suite/v2_checkpoint.rs
+++ b/compliance-suite/tests/compliance_suite/v2_checkpoint.rs
@@ -1,0 +1,17 @@
+//! v2 checkpoint compliance tests.
+
+use super::Fixture;
+use std::sync::LazyLock;
+
+static V2_CHECKPOINT: LazyLock<Fixture> = LazyLock::new(|| Fixture::load("v2-checkpoint.json"));
+
+compliance_case_success!(V2_CHECKPOINT, 1);
+compliance_case_success!(V2_CHECKPOINT, 2);
+compliance_case_success!(V2_CHECKPOINT, 3);
+compliance_case_success!(V2_CHECKPOINT, 4);
+compliance_case_failure!(V2_CHECKPOINT, 5, diverges: "kernel does not enforce v2Checkpoint cannot appear only in writerFeatures");
+compliance_case_inexpressible!(V2_CHECKPOINT, 6); // fixture uses protocol (1,7); create_table() always produces (3,7)
+compliance_case_success!(V2_CHECKPOINT, 7, "'delta.checkpointPolicy' is not supported during CREATE TABLE");
+compliance_case_failure!(V2_CHECKPOINT, 8, "Writer features must be Writer-only or also listed in reader features");
+compliance_case_failure!(V2_CHECKPOINT, 9, "Reader features must contain only ReaderWriter features that are also listed in writer features");
+compliance_case_sentinel!(V2_CHECKPOINT, 10);

--- a/compliance-suite/tests/compliance_suite/vacuum_protocol_check.rs
+++ b/compliance-suite/tests/compliance_suite/vacuum_protocol_check.rs
@@ -1,0 +1,17 @@
+//! vacuum protocol check compliance tests.
+
+use super::Fixture;
+use std::sync::LazyLock;
+
+static VACUUM_PROTOCOL_CHECK: LazyLock<Fixture> =
+    LazyLock::new(|| Fixture::load("vacuum-protocol-check.json"));
+
+compliance_case_success!(VACUUM_PROTOCOL_CHECK, 1);
+compliance_case_success!(VACUUM_PROTOCOL_CHECK, 2);
+compliance_case_success!(VACUUM_PROTOCOL_CHECK, 3);
+compliance_case_inexpressible!(VACUUM_PROTOCOL_CHECK, 4); // fixture uses reader-only feature placement; create_table() enforces symmetric placement
+compliance_case_failure!(VACUUM_PROTOCOL_CHECK, 5, diverges: "kernel does not enforce vacuumProtocolCheck cannot appear only in writerFeatures");
+compliance_case_success!(VACUUM_PROTOCOL_CHECK, 6);
+compliance_case_failure!(VACUUM_PROTOCOL_CHECK, 7, "Reader features must contain only ReaderWriter features that are also listed in writer features");
+compliance_case_failure!(VACUUM_PROTOCOL_CHECK, 8, "Writer features must be Writer-only or also listed in reader features");
+compliance_case_sentinel!(VACUUM_PROTOCOL_CHECK, 9);

--- a/compliance-suite/tests/compliance_suite/variant.rs
+++ b/compliance-suite/tests/compliance_suite/variant.rs
@@ -1,0 +1,22 @@
+//! variant compliance tests.
+
+use super::Fixture;
+use std::sync::LazyLock;
+
+static VARIANT: LazyLock<Fixture> = LazyLock::new(|| Fixture::load("variant.json"));
+
+compliance_case_success!(VARIANT, 1, "'delta.feature.variantType' is not supported during CREATE TABLE");
+compliance_case_inexpressible!(VARIANT, 2); // fixture uses protocol (1,2); create_table() always produces (3,7)
+compliance_case_failure!(VARIANT, 3, diverges: "kernel does not require variantType listed when schema has variant columns");
+compliance_case_success!(VARIANT, 4);
+compliance_case_success!(VARIANT, 5, "Unknown complex type: 'variant'");
+compliance_case_success!(VARIANT, 6);
+compliance_case_failure!(VARIANT, 7, "VARIANT columns but does not have the required 'variantType' feature");
+compliance_case_success!(VARIANT, 8);
+compliance_case_success!(VARIANT, 9);
+compliance_case_failure!(VARIANT, 10, "VARIANT columns but does not have the required 'variantType' feature");
+compliance_case_success!(VARIANT, 11, "'delta.feature.variantType-preview' is not supported during CREATE TABLE");
+compliance_case_success!(VARIANT, 12);
+compliance_case_failure!(VARIANT, 13, "VARIANT columns but does not have the required 'variantType' feature");
+compliance_case_success!(VARIANT, 14);
+compliance_case_sentinel!(VARIANT, 15);

--- a/compliance-suite/tests/compliance_suite/variant_shredding_preview.rs
+++ b/compliance-suite/tests/compliance_suite/variant_shredding_preview.rs
@@ -1,0 +1,13 @@
+//! variant shredding preview compliance tests.
+
+use super::Fixture;
+use std::sync::LazyLock;
+
+static VARIANT_SHREDDING_PREVIEW: LazyLock<Fixture> =
+    LazyLock::new(|| Fixture::load("variant-shredding-preview.json"));
+
+compliance_case_failure!(VARIANT_SHREDDING_PREVIEW, 1, "'delta.feature.variantShredding-preview' is not supported during CREATE TABLE");
+compliance_case_success!(VARIANT_SHREDDING_PREVIEW, 2, "is not supported during CREATE TABLE"); // variantType + variantShredding-preview both unsupported; which fires first is non-deterministic
+compliance_case_success!(VARIANT_SHREDDING_PREVIEW, 3);
+compliance_case_success!(VARIANT_SHREDDING_PREVIEW, 4, "is not supported during CREATE TABLE"); // variantType-preview + variantShredding-preview both unsupported; which fires first is non-deterministic
+compliance_case_sentinel!(VARIANT_SHREDDING_PREVIEW, 5);


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add a new test framework, vaguely similar to DAT, that consists of:
* A set of json fixture files that model various positive and negative test cases based on a strict reading of the Delta spec
* A test harness that maps those fixtures to kernel execution and documents any divergence from expectations

The goal is to have a very detailed "coverage map" for how kernel responds to various scenarios relating to P&M and table feature configurations. Any tests that would involve actual parquet files are out of scope (use DAT for those).

## How was this change tested?

It _is_ a test.