### PR TITLE
ci: skip invalid handle code tests for coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -308,7 +308,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@2d15d02e710b40b6332201aba6af30d595b5cd96 # cargo-llvm-cov
       - name: Generate code coverage
-        run: cargo llvm-cov --locked --all-features --workspace --codecov --output-path codecov.json -- --skip read_table_version_hdfs
+        run: cargo llvm-cov --locked --all-features --workspace --codecov --output-path codecov.json -- --skip read_table_version_hdfs --skip handle::tests::invalid_handle_code
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5.5.3
         with:


### PR DESCRIPTION
## What changes are proposed in this pull request?

`cargo llvm-cov` can run on different versions of rustc, which means we get drift in our expected outputs for the handle trybuild tests. This skips those tests _just for coverage runs_.

The tests are still run in CI by the normal `cargo nextest` runs.

## How was this change tested?
Looking at the [coverage job](https://github.com/delta-io/delta-kernel-rs/actions/runs/24538071275/job/71737707123?pr=2414) which fails without this.