### PR TITLE
feat: auto-enable invariants writer feature for non-null columns in CREATE TABLE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,9 @@ Keep this list updated when new protocol features are added to kernel.
 - Prefer `==` over `matches!` for simple single-variant enum comparisons. `matches!` is
   for patterns with bindings or guards. For example: `self == Variant` not
   `matches!(self, Variant)`.
+- Prefer `StructField::nullable` / `StructField::not_null` over
+  `StructField::new(name, type, bool)` when nullability is known at compile time.
+  Reserve `StructField::new` for cases where nullability is a runtime value.
 - NEVER panic in production code -- use errors instead. Panicking
   (including `unwrap()`, `expect()`, `panic!()`, `unreachable!()`, etc) is acceptable in test code only.
 

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -446,7 +446,7 @@ impl StructField {
         MakePhysical::new(column_mapping_mode).run_field(self)
     }
 
-    fn has_invariants(&self) -> bool {
+    pub(crate) fn has_invariants(&self) -> bool {
         self.metadata
             .contains_key(ColumnMetadataKey::Invariants.as_ref())
     }
@@ -1289,6 +1289,40 @@ pub(crate) fn schema_has_invariants(schema: &Schema) -> bool {
     let mut checker = InvariantChecker(false);
     let _ = checker.transform_struct(schema);
     checker.0
+}
+
+/// Visitor that reports whether any non-null (`nullable: false`) field exists in a schema.
+/// Walks the full schema tree including nested struct, array element, and map value structs.
+struct NonNullFieldChecker {
+    found: bool,
+}
+
+impl<'a> SchemaTransform<'a> for NonNullFieldChecker {
+    /// Skip recursion into variant internals. The `metadata` and `value` fields inside a
+    /// `Variant` are protocol-defined, always non-null, and not user-controlled, so they
+    /// must not be treated as user-declared non-null columns.
+    fn transform_variant(&mut self, stype: &'a StructType) -> Option<Cow<'a, StructType>> {
+        Some(Cow::Borrowed(stype))
+    }
+
+    fn transform_struct_field(&mut self, field: &'a StructField) -> Option<Cow<'a, StructField>> {
+        if !field.is_nullable() {
+            self.found = true;
+        } else if !self.found {
+            let _ = self.recurse_into_struct_field(field);
+        }
+        Some(Cow::Borrowed(field))
+    }
+}
+
+/// Checks if any user-controlled column in the schema (including nested columns) is declared
+/// non-null (`nullable: false`).
+///
+/// Skips `Variant` internal struct fields, which are protocol-defined and always non-null.
+pub(crate) fn schema_contains_non_null_fields(schema: &Schema) -> bool {
+    let mut checker = NonNullFieldChecker { found: false };
+    let _ = checker.transform_struct(schema);
+    checker.found
 }
 
 /// Normalizes column name field names to match the casing in the schema.
@@ -2731,6 +2765,70 @@ mod tests {
             map_field,
         ]);
         assert!(schema_has_invariants(&schema));
+    }
+
+    fn all_nullable_schema() -> StructType {
+        StructType::new_unchecked([
+            StructField::nullable("a", DataType::STRING),
+            StructField::nullable("b", DataType::INTEGER),
+        ])
+    }
+
+    fn top_level_non_null_schema() -> StructType {
+        StructType::new_unchecked([
+            StructField::not_null("id", DataType::INTEGER),
+            StructField::nullable("name", DataType::STRING),
+        ])
+    }
+
+    fn nested_non_null_schema() -> StructType {
+        let nested_field = StructField::nullable(
+            "parent",
+            DataType::try_struct_type([StructField::not_null("child", DataType::INTEGER)]).unwrap(),
+        );
+        StructType::new_unchecked([StructField::nullable("a", DataType::STRING), nested_field])
+    }
+
+    fn array_non_null_schema() -> StructType {
+        let array_field = StructField::nullable(
+            "arr",
+            ArrayType::new(
+                DataType::try_struct_type([StructField::not_null("child", DataType::INTEGER)])
+                    .unwrap(),
+                true,
+            ),
+        );
+        StructType::new_unchecked([array_field])
+    }
+
+    fn map_non_null_schema() -> StructType {
+        let map_field = StructField::nullable(
+            "map",
+            MapType::new(
+                DataType::STRING,
+                DataType::try_struct_type([StructField::not_null("child", DataType::INTEGER)])
+                    .unwrap(),
+                true,
+            ),
+        );
+        StructType::new_unchecked([map_field])
+    }
+
+    fn variant_only_schema() -> StructType {
+        // Variant internal fields (metadata, value) are protocol-defined non-null but
+        // must NOT be counted as user-controlled non-null fields.
+        StructType::new_unchecked([StructField::nullable("v", DataType::unshredded_variant())])
+    }
+
+    #[rstest]
+    #[case::all_nullable(all_nullable_schema(), false)]
+    #[case::top_level(top_level_non_null_schema(), true)]
+    #[case::nested_struct(nested_non_null_schema(), true)]
+    #[case::array_element(array_non_null_schema(), true)]
+    #[case::map_value(map_non_null_schema(), true)]
+    #[case::variant_skipped(variant_only_schema(), false)]
+    fn test_schema_contains_non_null_fields(#[case] schema: StructType, #[case] expected: bool) {
+        assert_eq!(schema_contains_non_null_fields(&schema), expected);
     }
 
     #[test]

--- a/kernel/src/schema/validation.rs
+++ b/kernel/src/schema/validation.rs
@@ -20,16 +20,16 @@ const INVALID_PARQUET_CHARS: &[char] = &[' ', ',', ';', '{', '}', '(', ')', '\n'
 /// 1. Schema is non-empty
 /// 2. No duplicate column names (case-insensitive, including nested fields)
 /// 3. Column names contain only valid characters
-/// 4. Rejects non-null columns when the `invariants` writer feature is not enabled
+/// 4. Rejects fields with `delta.invariants` metadata (SQL expression invariants are not supported
+///    by kernel; see `TableConfiguration::ensure_write_supported`)
 pub(crate) fn validate_schema_for_create(
     schema: &StructType,
     column_mapping_mode: ColumnMappingMode,
-    invariants_enabled: bool,
 ) -> DeltaResult<()> {
     if schema.num_fields() == 0 {
         return Err(Error::generic("Schema cannot be empty"));
     }
-    let mut validator = SchemaValidator::new(column_mapping_mode, invariants_enabled);
+    let mut validator = SchemaValidator::new(column_mapping_mode);
     // We reuse the SchemaTransform trait for its recursive traversal machinery.
     // The validator never transforms the schema -- it only inspects fields and
     // collects errors. The return value is intentionally discarded.
@@ -37,7 +37,8 @@ pub(crate) fn validate_schema_for_create(
     validator.into_result()
 }
 
-/// Schema visitor that validates field names and detects duplicates.
+/// Schema visitor that validates field names, detects duplicates, and rejects
+/// unsupported column metadata.
 ///
 /// Implements `SchemaTransform` to reuse the existing recursive struct/array/map traversal.
 /// Collects all validation errors so the caller gets a complete list of violations in a
@@ -48,17 +49,15 @@ pub(crate) fn validate_schema_for_create(
 /// built with `new_unchecked`.
 struct SchemaValidator {
     cm_enabled: bool,
-    invariants_enabled: bool,
     seen_paths: HashSet<String>,
     current_path: Vec<String>,
     errors: Vec<String>,
 }
 
 impl SchemaValidator {
-    fn new(column_mapping_mode: ColumnMappingMode, invariants_enabled: bool) -> Self {
+    fn new(column_mapping_mode: ColumnMappingMode) -> Self {
         Self {
             cm_enabled: !matches!(column_mapping_mode, ColumnMappingMode::None),
-            invariants_enabled,
             seen_paths: HashSet::new(),
             current_path: Vec::new(),
             errors: Vec::new(),
@@ -78,15 +77,6 @@ impl SchemaValidator {
 }
 
 impl<'a> SchemaTransform<'a> for SchemaValidator {
-    /// The default `transform_variant` recurses into the variant's struct fields
-    /// (metadata, value) via `recurse_into_struct`. Those fields are protocol-defined
-    /// and must be non-null -- they are not user-controlled schema columns. We override
-    /// to return the variant struct unchanged, skipping recursion so the non-null check
-    /// in `transform_struct_field` does not reject these fixed internal fields.
-    fn transform_variant(&mut self, stype: &'a StructType) -> Option<Cow<'a, StructType>> {
-        Some(Cow::Borrowed(stype))
-    }
-
     fn transform_struct_field(&mut self, field: &'a StructField) -> Option<Cow<'a, StructField>> {
         if let Err(e) = validate_field_name(field.name(), self.cm_enabled) {
             self.errors.push(e.to_string());
@@ -97,13 +87,28 @@ impl<'a> SchemaTransform<'a> for SchemaValidator {
         // separator would make column "a.b" indistinguishable from nested field b in
         // struct a. Null bytes cannot appear in column names, so they are safe to use.
         self.current_path.push(field.name().to_ascii_lowercase());
-        if !self.invariants_enabled && !field.is_nullable() {
+
+        // Reject `delta.invariants` metadata on any field. Kernel cannot evaluate SQL
+        // expression invariants, so writing to any table with invariants metadata is
+        // blocked by `TableConfiguration::ensure_write_supported`. Reject at create
+        // time with a clearer, path-aware error.
+        //
+        // Note: unlike `NonNullFieldChecker`, this validator intentionally does NOT
+        // skip recursion into variant internals. Variants are not expected to carry
+        // `delta.invariants`; if they ever do, bubble the error up loudly instead of
+        // silently skipping it.
+        //
+        // When kernel gains SQL expression invariant support, remove this rejection
+        // and replace it with a check that delegates to the invariant evaluation
+        // pipeline.
+        if field.has_invariants() {
             self.errors.push(format!(
-                "Non-null column '{}' is not supported during CREATE TABLE unless \
-                 writer feature 'invariants' is enabled",
+                "Column '{}' has `delta.invariants` metadata; SQL expression invariants \
+                 are not supported by kernel",
                 self.current_path.join(".")
             ));
         }
+
         let key = self.current_path.join("\0");
         if !self.seen_paths.insert(key) {
             self.errors.push(format!(
@@ -154,7 +159,9 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::schema::{ArrayType, DataType, MapType, StructField, StructType};
+    use crate::schema::{
+        ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, StructField, StructType,
+    };
 
     // === Schema builders for test cases ===
 
@@ -294,51 +301,61 @@ mod tests {
         ])
     }
 
-    fn schema_all_nullable() -> StructType {
+    // === Helpers for building invariants metadata ===
+    //
+    // These tests assert that `delta.invariants` metadata is rejected at CREATE TABLE.
+    // When kernel gains SQL expression invariant support (see tracking issue for
+    // invariant evaluation), these tests should be repurposed to feed a supported
+    // invariant expression through the full write path instead of being deleted
+    // outright.
+
+    fn field_with_invariant(name: &str, data_type: DataType, nullable: bool) -> StructField {
+        let mut field = StructField::new(name, data_type, nullable);
+        field.metadata.insert(
+            ColumnMetadataKey::Invariants.as_ref().to_string(),
+            MetadataValue::String(r#"{"expression": {"expression": "x > 0"}}"#.to_string()),
+        );
+        field
+    }
+
+    fn schema_top_level_invariant() -> StructType {
         StructType::new_unchecked(vec![
-            StructField::new("id", DataType::INTEGER, true),
-            StructField::new("name", DataType::STRING, true),
+            field_with_invariant("x", DataType::INTEGER, true),
+            StructField::new("y", DataType::INTEGER, true),
         ])
     }
 
-    fn schema_top_level_non_null() -> StructType {
-        StructType::new_unchecked(vec![
-            StructField::new("id", DataType::INTEGER, false),
-            StructField::new("name", DataType::STRING, true),
-        ])
-    }
-
-    fn schema_nested_non_null() -> StructType {
-        let nested =
-            StructType::new_unchecked(vec![StructField::new("child", DataType::INTEGER, false)]);
+    fn schema_nested_invariant() -> StructType {
+        let inner =
+            StructType::new_unchecked(vec![field_with_invariant("child", DataType::INTEGER, true)]);
         StructType::new_unchecked(vec![StructField::new(
             "parent",
-            DataType::Struct(Box::new(nested)),
+            DataType::Struct(Box::new(inner)),
             true,
         )])
     }
 
-    fn schema_array_nested_non_null() -> StructType {
-        let nested =
-            StructType::new_unchecked(vec![StructField::new("child", DataType::INTEGER, false)]);
+    fn schema_array_nested_invariant() -> StructType {
+        let inner =
+            StructType::new_unchecked(vec![field_with_invariant("child", DataType::INTEGER, true)]);
         StructType::new_unchecked(vec![StructField::new(
             "arr",
             DataType::Array(Box::new(ArrayType::new(
-                DataType::Struct(Box::new(nested)),
+                DataType::Struct(Box::new(inner)),
                 true,
             ))),
             true,
         )])
     }
 
-    fn schema_map_nested_non_null() -> StructType {
-        let nested =
-            StructType::new_unchecked(vec![StructField::new("child", DataType::INTEGER, false)]);
+    fn schema_map_nested_invariant() -> StructType {
+        let inner =
+            StructType::new_unchecked(vec![field_with_invariant("child", DataType::INTEGER, true)]);
         StructType::new_unchecked(vec![StructField::new(
             "map",
             DataType::Map(Box::new(MapType::new(
                 DataType::STRING,
-                DataType::Struct(Box::new(nested)),
+                DataType::Struct(Box::new(inner)),
                 true,
             ))),
             true,
@@ -354,7 +371,7 @@ mod tests {
     #[case::dot_in_name_with_cm(schema_with_dot(), ColumnMappingMode::Name)]
     #[case::different_struct_children(schema_different_struct_children(), ColumnMappingMode::None)]
     fn valid_schema_accepted(#[case] schema: StructType, #[case] cm: ColumnMappingMode) {
-        assert!(validate_schema_for_create(&schema, cm, true).is_ok());
+        assert!(validate_schema_for_create(&schema, cm).is_ok());
     }
 
     // === Invalid schemas ===
@@ -376,7 +393,7 @@ mod tests {
         #[case] cm: ColumnMappingMode,
         #[case] expected_errs: &[&str],
     ) {
-        let result = validate_schema_for_create(&schema, cm, true);
+        let result = validate_schema_for_create(&schema, cm);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         for expected in expected_errs {
@@ -387,63 +404,24 @@ mod tests {
         }
     }
 
+    // === delta.invariants metadata rejection ===
+
     #[rstest]
-    #[case::all_nullable_invariants_disabled(schema_all_nullable(), false, true, None)]
-    #[case::top_level_non_null_invariants_disabled(
-        schema_top_level_non_null(),
-        false,
-        false,
-        Some("id")
-    )]
-    #[case::nested_non_null_invariants_disabled(
-        schema_nested_non_null(),
-        false,
-        false,
-        Some("parent.child")
-    )]
-    #[case::array_nested_non_null_invariants_disabled(
-        schema_array_nested_non_null(),
-        false,
-        false,
-        Some("arr.child")
-    )]
-    #[case::map_nested_non_null_invariants_disabled(
-        schema_map_nested_non_null(),
-        false,
-        false,
-        Some("map.child")
-    )]
-    #[case::top_level_non_null_invariants_enabled(schema_top_level_non_null(), true, true, None)]
-    #[case::nested_non_null_invariants_enabled(schema_nested_non_null(), true, true, None)]
-    fn non_null_columns_require_invariants_feature(
-        #[case] schema: StructType,
-        #[case] invariants_enabled: bool,
-        #[case] expect_ok: bool,
-        #[case] expected_path: Option<&str>,
-    ) {
-        let result =
-            validate_schema_for_create(&schema, ColumnMappingMode::None, invariants_enabled);
-
-        if expect_ok {
-            assert!(result.is_ok(), "expected success, got {result:?}");
-            return;
-        }
-
-        let err = result.expect_err("expected non-null validation error");
+    #[case::top_level(schema_top_level_invariant(), "x")]
+    #[case::nested_struct(schema_nested_invariant(), "parent.child")]
+    #[case::array_nested(schema_array_nested_invariant(), "arr.child")]
+    #[case::map_nested(schema_map_nested_invariant(), "map.child")]
+    fn invariants_metadata_rejected(#[case] schema: StructType, #[case] expected_path: &str) {
+        let result = validate_schema_for_create(&schema, ColumnMappingMode::None);
+        let err = result.expect_err("expected delta.invariants metadata rejection");
         let msg = err.to_string();
         assert!(
-            msg.contains("Non-null column"),
-            "Expected non-null validation error, got: {msg}"
+            msg.contains("delta.invariants"),
+            "Expected delta.invariants mention in error, got: {msg}"
         );
-        if let Some(path) = expected_path {
-            assert!(
-                msg.contains(path),
-                "Expected path '{path}' in error message, got: {msg}"
-            );
-        }
         assert!(
-            msg.contains("writer feature 'invariants'"),
-            "Expected invariants guidance in error message, got: {msg}"
+            msg.contains(expected_path),
+            "Expected path '{expected_path}' in error, got: {msg}"
         );
     }
 }

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -19,7 +19,10 @@ use crate::committer::Committer;
 use crate::expressions::ColumnName;
 use crate::schema::validation::validate_schema_for_create;
 use crate::schema::variant_utils::schema_contains_variant_type;
-use crate::schema::{normalize_column_names_to_schema_casing, DataType, SchemaRef, StructType};
+use crate::schema::{
+    normalize_column_names_to_schema_casing, schema_contains_non_null_fields, DataType, SchemaRef,
+    StructType,
+};
 use crate::table_configuration::TableConfiguration;
 use crate::table_features::{
     assign_column_mapping_metadata, get_any_level_column_physical_name,
@@ -67,6 +70,11 @@ const ALLOWED_DELTA_FEATURES: &[TableFeature] = &[
     TableFeature::ChangeDataFeed,
     TableFeature::TypeWidening,
     TableFeature::RowTracking,
+    // Invariants is auto-enabled by `maybe_enable_invariants` when the schema has non-null
+    // fields. Allowing explicit `delta.feature.invariants=supported` lets users pre-enable
+    // the feature on an all-nullable table so a later ALTER TABLE ADD COLUMN NOT NULL does
+    // not need a protocol upgrade.
+    TableFeature::Invariants,
 ];
 
 /// Delta properties allowed to be set during CREATE TABLE.
@@ -373,6 +381,31 @@ fn maybe_enable_timestamp_ntz(schema: &SchemaRef, validated: &mut ValidatedTable
     }
 }
 
+/// Conditionally adds the `invariants` writer feature to the protocol when the schema contains
+/// any non-null column (`nullable: false`) anywhere in the tree.
+///
+/// Delta-Spark treats `nullable: false` as an implicit column invariant and requires the
+/// `invariants` writer feature to be listed in the protocol's `writerFeatures` to read/write
+/// such tables. Auto-enabling ensures kernel-created tables with non-null columns are
+/// compatible with Spark readers/writers.
+///
+/// Explicit `delta.invariants` metadata annotations are rejected by
+/// `validate_schema_for_create`, so this only flips on the feature for nullability-driven
+/// invariants. Kernel does not itself enforce the null mask at write time -- it relies on
+/// the engine's `ParquetHandler` to do so. Kernel's default `ParquetHandler` uses
+/// `arrow-rs`, whose `RecordBatch::try_new` rejects null values in fields marked
+/// `nullable: false`. Other engine implementations must provide an equivalent guarantee
+/// in their write path.
+fn maybe_enable_invariants(schema: &SchemaRef, validated: &mut ValidatedTableProperties) {
+    if schema_contains_non_null_fields(schema) {
+        add_feature_to_lists(
+            TableFeature::Invariants,
+            &mut validated.reader_features,
+            &mut validated.writer_features,
+        );
+    }
+}
+
 /// Auto-enables allowed features whose [`EnablementCheck::EnabledIf`] check is satisfied by the
 /// table properties. Features with [`EnablementCheck::AlwaysIfSupported`] are skipped since they
 /// don't require property-driven enablement.
@@ -631,7 +664,8 @@ impl CreateTableTransactionBuilder {
     ///
     /// Custom application properties (those not starting with `delta.`) are always allowed.
     /// Delta properties (`delta.*`) are validated against an allow list during [`build()`].
-    /// Feature flags (`delta.feature.*`) are not supported during CREATE TABLE.
+    /// Feature flags (`delta.feature.*=supported`) are supported for the subset of features
+    /// listed in `ALLOWED_DELTA_FEATURES`.
     ///
     /// This method can be called multiple times. If a property key already exists from a
     /// previous call, the new value will overwrite the old one.
@@ -720,9 +754,12 @@ impl CreateTableTransactionBuilder {
     /// - Checks that the table path is valid
     /// - Verifies the table doesn't already exist
     /// - Validates the schema is non-empty
-    /// - Rejects non-null columns unless `invariants` writer feature is enabled
+    /// - Rejects schemas with `delta.invariants` metadata annotations (unsupported by kernel)
     /// - Validates the data layout is valid
     /// - Validates table properties against the allow list
+    ///
+    /// Non-null columns (`nullable: false`) are allowed. The `invariants` writer feature is
+    /// auto-added to the protocol when the schema has any non-null column.
     ///
     /// # Arguments
     ///
@@ -735,7 +772,7 @@ impl CreateTableTransactionBuilder {
     /// - The table path is invalid
     /// - A table already exists at the given path
     /// - The schema is empty
-    /// - The schema has non-null columns without the `invariants` writer feature
+    /// - The schema has `delta.invariants` metadata on any column
     /// - The data layout is invalid
     /// - Unsupported delta properties or feature flags are specified
     pub fn build(
@@ -761,14 +798,8 @@ impl CreateTableTransactionBuilder {
         let (effective_schema, column_mapping_mode) =
             maybe_apply_column_mapping_for_table_create(&self.schema, &mut validated)?;
 
-        // Validate schema (non-empty, column names, duplicates)
-        validate_schema_for_create(
-            &effective_schema,
-            column_mapping_mode,
-            validated
-                .writer_features
-                .contains(&TableFeature::Invariants),
-        )?;
+        // Validate schema (non-empty, column names, duplicates, no `delta.invariants` metadata)
+        validate_schema_for_create(&effective_schema, column_mapping_mode)?;
 
         // Validate data layout and resolve column names (physical for clustering, logical
         // for partitioning). Adds required table features for clustering.
@@ -779,9 +810,10 @@ impl CreateTableTransactionBuilder {
             &mut validated,
         )?;
 
-        // Schema-driven auto-enablement: detect types that require a feature
+        // Schema-driven auto-enablement: detect types or annotations that require a feature
         maybe_enable_variant_type(&effective_schema, &mut validated);
         maybe_enable_timestamp_ntz(&effective_schema, &mut validated);
+        maybe_enable_invariants(&effective_schema, &mut validated);
 
         // Property-driven auto-enablement: check enablement properties
         maybe_auto_enable_property_driven_features(&mut validated);
@@ -1206,6 +1238,62 @@ mod tests {
     }
 
     #[rstest::rstest]
+    #[case::all_nullable(
+        Arc::new(StructType::new_unchecked(vec![
+            StructField::new("id", DataType::INTEGER, true),
+            StructField::new("name", DataType::STRING, true),
+        ])),
+        false,
+    )]
+    #[case::top_level_non_null(
+        Arc::new(StructType::new_unchecked(vec![
+            StructField::new("id", DataType::INTEGER, false),
+            StructField::new("name", DataType::STRING, true),
+        ])),
+        true,
+    )]
+    #[case::nested_non_null(
+        Arc::new(StructType::new_unchecked(vec![StructField::new(
+            "parent",
+            DataType::Struct(Box::new(StructType::new_unchecked(vec![StructField::new(
+                "child",
+                DataType::INTEGER,
+                false,
+            )]))),
+            true,
+        )])),
+        true,
+    )]
+    #[case::variant_only(
+        Arc::new(StructType::new_unchecked(vec![
+            StructField::new("id", DataType::INTEGER, true),
+            StructField::new("v", DataType::unshredded_variant(), true),
+        ])),
+        false,
+    )]
+    fn test_maybe_enable_invariants(#[case] schema: SchemaRef, #[case] expect_invariants: bool) {
+        let mut validated = ValidatedTableProperties {
+            properties: HashMap::new(),
+            reader_features: vec![],
+            writer_features: vec![],
+        };
+
+        maybe_enable_invariants(&schema, &mut validated);
+
+        assert_eq!(
+            validated
+                .writer_features
+                .contains(&TableFeature::Invariants),
+            expect_invariants,
+            "Expected Invariants feature presence = {expect_invariants}"
+        );
+        assert!(
+            validated.reader_features.is_empty(),
+            "Invariants is writer-only; reader_features should be empty"
+        );
+    }
+
+    #[rstest::rstest]
     #[case::property_true(&[("delta.enableInCommitTimestamps", "true")], true, true)]
     #[case::property_false(&[("delta.enableInCommitTimestamps", "false")], false, true)]
     #[case::property_absent(&[], false, false)]
@@ -1252,6 +1340,7 @@ mod tests {
     #[case::change_data_feed(TableFeature::ChangeDataFeed, "changeDataFeed")]
     #[case::type_widening(TableFeature::TypeWidening, "typeWidening")]
     #[case::catalog_managed(TableFeature::CatalogManaged, "catalogManaged")]
+    #[case::invariants(TableFeature::Invariants, "invariants")]
     fn test_feature_signal_accepted(#[case] feature: TableFeature, #[case] feature_name: &str) {
         let key = format!("delta.feature.{feature_name}");
         let properties = HashMap::from([(key, "supported".to_string())]);

--- a/kernel/tests/create_table/main.rs
+++ b/kernel/tests/create_table/main.rs
@@ -12,7 +12,7 @@ mod variant;
 use std::sync::Arc;
 
 use delta_kernel::committer::FileSystemCommitter;
-use delta_kernel::schema::{DataType, StructField, StructType};
+use delta_kernel::schema::{ColumnMetadataKey, DataType, MetadataValue, StructField, StructType};
 use delta_kernel::snapshot::Snapshot;
 use delta_kernel::table_features::{
     TableFeature, TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION,
@@ -28,8 +28,8 @@ use test_utils::{assert_result_error_with_message, test_table_setup};
 /// Shared with sub-modules.
 pub(crate) fn simple_schema() -> DeltaResult<Arc<StructType>> {
     Ok(Arc::new(StructType::try_new(vec![
-        StructField::new("id", DataType::INTEGER, true),
-        StructField::new("value", DataType::STRING, true),
+        StructField::nullable("id", DataType::INTEGER),
+        StructField::nullable("value", DataType::STRING),
     ])?))
 }
 
@@ -37,9 +37,9 @@ pub(crate) fn simple_schema() -> DeltaResult<Arc<StructType>> {
 /// Shared with sub-modules.
 pub(crate) fn partition_test_schema() -> DeltaResult<Arc<StructType>> {
     Ok(Arc::new(StructType::try_new(vec![
-        StructField::new("id", DataType::INTEGER, true),
-        StructField::new("date", DataType::DATE, true),
-        StructField::new("value", DataType::STRING, true),
+        StructField::nullable("id", DataType::INTEGER),
+        StructField::nullable("date", DataType::DATE),
+        StructField::nullable("value", DataType::STRING),
     ])?))
 }
 
@@ -49,11 +49,11 @@ async fn test_create_simple_table() -> DeltaResult<()> {
 
     // Create schema for an events table
     let schema = Arc::new(StructType::try_new(vec![
-        StructField::new("event_id", DataType::LONG, true),
-        StructField::new("user_id", DataType::LONG, true),
-        StructField::new("event_type", DataType::STRING, true),
-        StructField::new("timestamp", DataType::TIMESTAMP, true),
-        StructField::new("properties", DataType::STRING, true),
+        StructField::nullable("event_id", DataType::LONG),
+        StructField::nullable("user_id", DataType::LONG),
+        StructField::nullable("event_type", DataType::STRING),
+        StructField::nullable("timestamp", DataType::TIMESTAMP),
+        StructField::nullable("properties", DataType::STRING),
     ])?);
 
     // Create table using new API
@@ -157,11 +157,11 @@ async fn test_create_table_already_exists() -> DeltaResult<()> {
 
     // Create schema for a user profiles table
     let schema = Arc::new(StructType::try_new(vec![
-        StructField::new("user_id", DataType::LONG, true),
-        StructField::new("username", DataType::STRING, true),
-        StructField::new("email", DataType::STRING, true),
-        StructField::new("created_at", DataType::TIMESTAMP, true),
-        StructField::new("is_active", DataType::BOOLEAN, true),
+        StructField::nullable("user_id", DataType::LONG),
+        StructField::nullable("username", DataType::STRING),
+        StructField::nullable("email", DataType::STRING),
+        StructField::nullable("created_at", DataType::TIMESTAMP),
+        StructField::nullable("is_active", DataType::BOOLEAN),
     ])?);
 
     // Create table first time
@@ -197,38 +197,116 @@ async fn test_create_table_empty_schema_not_supported() -> DeltaResult<()> {
 fn top_level_non_null_schema() -> Arc<StructType> {
     Arc::new(
         StructType::try_new(vec![
-            StructField::new("id", DataType::INTEGER, false),
-            StructField::new("value", DataType::STRING, true),
+            StructField::not_null("id", DataType::INTEGER),
+            StructField::nullable("value", DataType::STRING),
         ])
         .expect("non-null top-level schema should be valid"),
     )
 }
 
 fn nested_non_null_schema() -> Arc<StructType> {
-    let nested = StructType::try_new(vec![StructField::new("child", DataType::INTEGER, false)])
+    let nested = StructType::try_new(vec![StructField::not_null("child", DataType::INTEGER)])
         .expect("nested non-null schema should be valid");
     Arc::new(
-        StructType::try_new(vec![StructField::new(
+        StructType::try_new(vec![StructField::nullable(
             "nested",
             DataType::Struct(Box::new(nested)),
-            true,
         )])
         .expect("top-level nested schema should be valid"),
     )
 }
 
+/// CREATE TABLE with non-null columns succeeds and auto-enables the `invariants`
+/// writer feature in the protocol. Delta-Spark treats non-null schema columns as
+/// implicit invariants and requires the feature to be declared.
 #[rstest]
 #[case::top_level_non_null(top_level_non_null_schema())]
 #[case::nested_non_null(nested_non_null_schema())]
-fn test_create_table_non_null_columns_require_invariants_feature(
+fn test_create_table_with_non_null_columns_auto_enables_invariants(
     #[case] schema: Arc<StructType>,
 ) -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
 
-    let result = create_table(&table_path, schema, "InvalidApp/0.1.0")
+    let _ = create_table(&table_path, schema, "Test/1.0")
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?;
+
+    let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    let protocol = snapshot.table_configuration().protocol();
+    assert!(
+        protocol
+            .writer_features()
+            .is_some_and(|f| f.contains(&TableFeature::Invariants)),
+        "Invariants feature should be auto-added to writer features for non-null schema"
+    );
+    // Invariants is writer-only; reader features should not contain it.
+    assert!(
+        !protocol
+            .reader_features()
+            .is_some_and(|f| f.contains(&TableFeature::Invariants)),
+        "Invariants should not appear in reader features"
+    );
+
+    Ok(())
+}
+
+/// CREATE TABLE with `delta.feature.invariants=supported` + a non-null schema succeeds
+/// and lands the feature in writerFeatures exactly once. Non-null columns auto-enable
+/// the feature and the explicit signal also tries to enable it; both paths firing
+/// together must not duplicate the entry. This also verifies users can pre-enable the
+/// feature so a later ALTER TABLE ADD COLUMN NOT NULL does not need a protocol upgrade.
+#[tokio::test]
+async fn test_create_table_with_invariants_feature_signal_allowed() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    // Non-null schema auto-enables Invariants; the feature signal also tries to add it.
+    // Both code paths firing together must produce exactly one Invariants entry.
+    let schema = top_level_non_null_schema();
+
+    let _ = create_table(&table_path, schema, "Test/1.0")
+        .with_table_properties([("delta.feature.invariants", "supported")])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?;
+
+    let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    let protocol = snapshot.table_configuration().protocol();
+    let writer_features = protocol
+        .writer_features()
+        .expect("writer features should be present");
+    let invariants_count = writer_features
+        .iter()
+        .filter(|f| **f == TableFeature::Invariants)
+        .count();
+    assert_eq!(
+        invariants_count, 1,
+        "Invariants should appear exactly once in writerFeatures; got {invariants_count}"
+    );
+    assert!(
+        !protocol
+            .reader_features()
+            .is_some_and(|f| f.contains(&TableFeature::Invariants)),
+        "Invariants should not appear in readerFeatures (writer-only feature)"
+    );
+
+    Ok(())
+}
+
+/// CREATE TABLE rejects any schema with `delta.invariants` metadata annotations
+/// because kernel cannot evaluate SQL expression invariants.
+#[tokio::test]
+async fn test_create_table_rejects_delta_invariants_metadata() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    let mut field = StructField::nullable("x", DataType::INTEGER);
+    field.metadata.insert(
+        ColumnMetadataKey::Invariants.as_ref().to_string(),
+        MetadataValue::String(r#"{"expression": {"expression": "x > 0"}}"#.to_string()),
+    );
+    let schema = Arc::new(StructType::try_new(vec![field])?);
+
+    let result = create_table(&table_path, schema, "Test/1.0")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()));
 
-    assert_result_error_with_message(result, "Non-null column");
+    assert_result_error_with_message(result, "delta.invariants");
 
     Ok(())
 }
@@ -239,8 +317,8 @@ async fn test_create_table_log_actions() -> DeltaResult<()> {
 
     // Create schema
     let schema = Arc::new(StructType::try_new(vec![
-        StructField::new("user_id", DataType::LONG, true),
-        StructField::new("action", DataType::STRING, true),
+        StructField::nullable("user_id", DataType::LONG),
+        StructField::nullable("action", DataType::STRING),
     ])?);
 
     let engine_info = "AuditService/2.1.0";
@@ -529,8 +607,8 @@ fn test_create_table_special_char_column_name(#[case] cm_enabled: bool) -> Delta
     let (_temp_dir, table_path, engine) = test_table_setup()?;
 
     let schema = Arc::new(StructType::try_new(vec![
-        StructField::new("valid_col", DataType::INTEGER, true),
-        StructField::new("bad column", DataType::STRING, true),
+        StructField::nullable("valid_col", DataType::INTEGER),
+        StructField::nullable("bad column", DataType::STRING),
     ])?);
 
     let mut builder = create_table(&table_path, schema, "Test/1.0");


### PR DESCRIPTION
## What changes are proposed in this pull request?

Auto-adds the invariants writer feature to the protocol when a CREATE TABLE schema contains any user-controlled non-null field (nullable: false). Delta-Spark treats non-nullable schema columns as implicit invariants and requires this feature to be listed in writerFeatures. Previously kernel rejected non-null columns at CREATE; this change makes such tables compatible with Spark readers/writers.

Explicit delta.invariants metadata annotations (SQL expression invariants like x > 3) remain rejected because kernel cannot evaluate them. The existing write guard in TableConfiguration::ensure_write_supported blocks writes to any table with such metadata; we now reject it at CREATE time for a clearer, path-aware error.

Also adds TableFeature::Invariants to ALLOWED_DELTA_FEATURES so users can pre-enable the feature on an all-nullable table via delta.feature.invariants=supported. This is useful when a later ALTER TABLE ADD COLUMN NOT NULL (by Spark) should not need a protocol upgrade.

Core changes:
- validate_schema_for_create no longer takes invariants_enabled and instead rejects fields with delta.invariants metadata
- New schema_contains_non_null_fields helper
- New maybe_enable_invariants in the CREATE builder, following the maybe_enable_variant_type / maybe_enable_timestamp_ntz pattern; adds schema driven Invariants to writer_features only
- TableFeature::Invariants added to ALLOWED_DELTA_FEATURES

## How was this change tested?

- Unit: schema_contains_non_null_fields (top-level, nested, array, map, all-nullable, Variant-skip), test_maybe_enable_invariants (feature flips on for non-null only), invariants_metadata_rejected (all nesting paths), and invariants case in test_feature_signal_accepted
- Integration: test_create_table_with_non_null_columns_auto_enables_invariants, test_create_table_with_invariants_feature_signal_allowed, test_create_table_rejects_delta_invariants_metadata
- Full cargo test -p delta_kernel --all-features --locked --lib --tests passes
- cargo clippy --tests --benches -- -D warnings clean