### PR TITLE
fix: URI-encode Hive partition path for partitioned writes

### DIFF
--- a/CLAUDE/architecture.md
+++ b/CLAUDE/architecture.md
@@ -119,7 +119,8 @@ all returned batches -- the engine may split a single file across multiple batch
 - `kernel/src/snapshot/` -- `Snapshot`, `SnapshotBuilder`, entry point for reads/writes
 - `kernel/src/scan/` -- `Scan`, `ScanBuilder`, log replay, data skipping
 - `kernel/src/transaction/` -- `Transaction`, `WriteContext`, `create_table` builder
-- `kernel/src/partition/` -- partition value validation, serialization, Hive-style path encoding
+- `kernel/src/partition/` -- partition value validation, serialization, Hive-style path
+   encoding, URI encoding for `add.path`
 - `kernel/src/committer/` -- `Committer` trait, `FileSystemCommitter`
 - `kernel/src/log_segment/` -- log file discovery, Protocol/Metadata replay
 - `kernel/src/log_replay.rs` -- file-action deduplication, `LogReplayProcessor` trait

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,6 +1258,7 @@ dependencies = [
  "parquet 57.3.0",
  "parquet 58.1.0",
  "paste",
+ "percent-encoding",
  "rand 0.9.2",
  "reqwest 0.13.2",
  "roaring",

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -45,6 +45,7 @@ chrono = "0.4.41"
 crc = "3.2.2"
 indexmap = "2.10.0"
 itertools = "0.14"
+percent-encoding = "2"
 rand = "0.9"
 roaring = "0.11.2"
 serde = { version = "1", features = ["derive", "rc"] }

--- a/kernel/src/partition/hive.rs
+++ b/kernel/src/partition/hive.rs
@@ -26,7 +26,42 @@
 
 use std::borrow::Cow;
 
+use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
+
 const HEX_UPPER: &[u8; 16] = b"0123456789ABCDEF";
+
+/// Characters encoded by [`uri_encode_path`]: `%`, space, and ASCII chars illegal in a
+/// URI path, plus all ASCII controls via [`CONTROLS`]. Non-ASCII UTF-8 bytes pass through
+/// because [`AsciiSet`] is ASCII-only by construction.
+const HADOOP_URI_PATH_ENCODE_SET: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'"')
+    .add(b'#')
+    .add(b'%')
+    .add(b'<')
+    .add(b'>')
+    .add(b'?')
+    .add(b'[')
+    .add(b'\\')
+    .add(b']')
+    .add(b'^')
+    .add(b'`')
+    .add(b'{')
+    .add(b'|')
+    .add(b'}');
+
+/// URI percent-encodes a Hive-escaped path to produce the string that belongs in
+/// `add.path`. After the Hive layer turns a partition value like `"a:b"` into `"a%3Ab"`,
+/// this turns that into `"a%253Ab"` — a valid URI whose single RFC 2396 decode yields the
+/// literal filesystem directory name `"a%3Ab"`.
+///
+/// Matches Hadoop `Path.toUri().toString()` for the ASCII Hive-escaped inputs produced by
+/// [`build_partition_path`], as used by kernel-java and Delta-Spark. Returns
+/// [`Cow::Borrowed`] when no encoding is needed (zero allocation fast path).
+/// See the module-level documentation in [`super`] for the full pipeline.
+pub(crate) fn uri_encode_path(hive_escaped: &str) -> Cow<'_, str> {
+    utf8_percent_encode(hive_escaped, HADOOP_URI_PATH_ENCODE_SET).into()
+}
 
 /// Placeholder for missing partition values in Hive-style directory paths.
 ///
@@ -567,5 +602,77 @@ mod tests {
             ]),
             "year=2025/region=__HIVE_DEFAULT_PARTITION__/country=US/"
         );
+    }
+
+    // ============================================================================
+    // uri_encode_path
+    // ============================================================================
+
+    /// Every ASCII byte: chars in `HADOOP_URI_PATH_ENCODE_SET` (space, `"`, `#`, `%`, `<`,
+    /// `>`, `?`, `[`, `\`, `]`, `^`, backtick, `{`, `|`, `}`) plus all controls encode to
+    /// `%XX`; everything else passes through unchanged.
+    #[test]
+    fn test_uri_encode_path_every_ascii_byte() {
+        let must_encode: &[u8] = b" \"#%<>?[\\]^`{|}";
+        for byte in 0x00..=0x7Fu8 {
+            let input = String::from(byte as char);
+            let result = uri_encode_path(&input);
+            let is_control = byte <= 0x1F || byte == 0x7F;
+            if must_encode.contains(&byte) || is_control {
+                assert_eq!(result, format!("%{:02X}", byte), "byte 0x{byte:02X}");
+            } else {
+                assert_eq!(result, input, "byte 0x{byte:02X}");
+            }
+        }
+    }
+
+    /// Multi-char contexts for URI-only chars, pinning that surrounding unreserved chars
+    /// pass through while the target gets encoded. Per-byte encoding decisions are covered
+    /// exhaustively by `test_uri_encode_path_every_ascii_byte`; this guards against a
+    /// refactor that only fails at character boundaries.
+    #[rstest]
+    #[case::backtick("a`b", "a%60b")]
+    #[case::right_brace("a}b", "a%7Db")]
+    #[case::double_quote("a\"b", "a%22b")]
+    #[case::space("hello world", "hello%20world")]
+    #[case::less_than("a<b", "a%3Cb")]
+    #[case::greater_than("a>b", "a%3Eb")]
+    #[case::pipe("a|b", "a%7Cb")]
+    fn test_uri_encode_path_encodes_uri_only_set(#[case] input: &str, #[case] expected: &str) {
+        assert_eq!(uri_encode_path(input), expected);
+    }
+
+    /// Composing Hive then URI encoding produces the `add.path` form. Pins the full
+    /// pipeline end-to-end, including mixed cases where a string contains both Hive- and
+    /// URI-encoded bytes after each step.
+    #[rstest]
+    #[case::colon("a:b", "a%3Ab", "a%253Ab")]
+    #[case::slash("US/East", "US%2FEast", "US%252FEast")]
+    #[case::percent("100%", "100%25", "100%2525")]
+    #[case::slash_percent("Serbia/srb%", "Serbia%2Fsrb%25", "Serbia%252Fsrb%2525")]
+    fn test_uri_encode_path_composes_with_hive(
+        #[case] raw: &str,
+        #[case] hive: &str,
+        #[case] add_path: &str,
+    ) {
+        let hive_escaped = escape_partition_value(raw);
+        assert_eq!(hive_escaped, hive);
+        assert_eq!(uri_encode_path(&hive_escaped), add_path);
+    }
+
+    /// Unreserved strings pass through byte-identical AND via the `Cow::Borrowed` fast
+    /// path, so no allocation occurs on the common partition-path input (dates, integers,
+    /// short alnum strings, the Hive null-partition placeholder).
+    #[rstest]
+    #[case::empty("")]
+    #[case::alnum("hello")]
+    #[case::partition_path("p=abc/q=def/")]
+    #[case::hive_default_partition("__HIVE_DEFAULT_PARTITION__")]
+    #[case::alnum_unreserved("A-Za-z0-9_.~")]
+    #[case::date("2024-01-15")]
+    fn test_uri_encode_path_unreserved_borrows_and_passes_through(#[case] input: &str) {
+        let result = uri_encode_path(input);
+        assert_eq!(result, input);
+        assert!(matches!(result, Cow::Borrowed(_)));
     }
 }

--- a/kernel/src/partition/hive.rs
+++ b/kernel/src/partition/hive.rs
@@ -31,8 +31,14 @@ use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 const HEX_UPPER: &[u8; 16] = b"0123456789ABCDEF";
 
 /// Characters encoded by [`uri_encode_path`]: `%`, space, and ASCII chars illegal in a
-/// URI path, plus all ASCII controls via [`CONTROLS`]. Non-ASCII UTF-8 bytes pass through
-/// because [`AsciiSet`] is ASCII-only by construction.
+/// URI path, plus all ASCII controls via [`CONTROLS`]. Non-ASCII UTF-8 bytes are ALSO
+/// percent-encoded by `utf8_percent_encode` (each byte of the UTF-8 sequence becomes
+/// `%XX`), even though they are not in the [`AsciiSet`]. For example:
+/// `uri_encode_path("München") == "M%C3%BCnchen"`, because `ü` is `0xC3 0xBC` in UTF-8.
+///
+/// TODO(#2423): Delta-Spark leaves non-ASCII bytes raw in `add.path` (e.g. `München`
+/// stays as `München`). Our current behavior diverges — revisit once kernel matches
+/// Delta-Spark's `add.path` encoding for non-ASCII.
 const HADOOP_URI_PATH_ENCODE_SET: &AsciiSet = &CONTROLS
     .add(b' ')
     .add(b'"')

--- a/kernel/src/transaction/write_context.rs
+++ b/kernel/src/transaction/write_context.rs
@@ -121,6 +121,8 @@ impl WriteContext {
     /// [`build_add_file_metadata`]: crate::engine::default::build_add_file_metadata
     // TODO(#2357): respect `delta.randomizeFilePrefixes` and `delta.randomPrefixLength`
     // table properties. Currently random prefixes are only used when column mapping is on.
+    // TODO(#2436): revisit this API shape. Returning a `Url` forces callers to URI-decode
+    // before filesystem writes and keep it encoded for `add.path`, which is unintuitive.
     pub fn write_dir(&self) -> Url {
         let mut url = self.shared.table_root.clone();
         match self.shared.column_mapping_mode {

--- a/kernel/src/transaction/write_context.rs
+++ b/kernel/src/transaction/write_context.rs
@@ -6,7 +6,7 @@ use url::Url;
 
 use crate::actions::deletion_vector::DeletionVectorPath;
 use crate::expressions::{ColumnName, ExpressionRef};
-use crate::partition::hive::build_partition_path;
+use crate::partition::hive::{build_partition_path, uri_encode_path};
 use crate::schema::SchemaRef;
 use crate::table_features::ColumnMappingMode;
 use crate::{DeltaResult, Error};
@@ -66,9 +66,45 @@ impl WriteContext {
         &self.shared.table_root
     }
 
-    /// Returns the recommended directory for writing Parquet data files. Connectors should
-    /// write files as `<write_dir>/<uuid>.parquet`. Not strictly required (data files can
-    /// live anywhere under the table root), but produces the conventional layout.
+    /// Returns the recommended directory URL for writing Parquet data files. Connectors
+    /// should write files as `<write_dir>/<uuid>.parquet`. Not strictly required (data files
+    /// can live anywhere under the table root), but produces the conventional layout.
+    ///
+    /// # The returned URL is URI-encoded
+    ///
+    /// For CM=none partitioned tables, the Hive-escaped partition prefix is double-encoded
+    /// in the URL (e.g. `%3A` appears as `%253A`). Concrete examples for a single STRING
+    /// partition column `p`:
+    ///
+    /// ```text
+    /// partition value  |  encoded path prefix       |  URI-decoded (filesystem path)
+    /// -----------------+----------------------------+--------------------------------
+    /// "abc"            |  p=abc/                    |  p=abc/
+    /// "a%c"            |  p=a%2525c/                |  p=a%25c/
+    /// "a "             |  p=a%20/                   |  p=a /
+    /// ```
+    ///
+    /// On Windows, the Hive layer additionally escapes space, so `"a "` produces encoded
+    /// path prefix `p=a%2520/` with filesystem directory `p=a%20/`.
+    ///
+    /// The same URL drives two outputs and custom engines must handle each correctly:
+    ///
+    /// 1. **Filesystem write path** — URI-decode once to get the on-disk directory name. Custom
+    ///    engines MUST decode before feeding `url.path()` to an OS-filesystem API. Use
+    ///    `object_store::path::Path::from_url_path` or an equivalent decoder. Feeding `url.path()`
+    ///    directly to the filesystem produces directories literally named `p=a%253Ab/` and breaks
+    ///    interop with every other Delta writer.
+    ///
+    /// 2. **`add.path` in the Delta log** — keep the URL URI-encoded. After writing the parquet
+    ///    file, pass the full (still-encoded) file URL — this URL plus the generated filename — to
+    ///    [`WriteContext::resolve_file_path`] to produce `add.path`. `make_relative` preserves the
+    ///    URI-encoded form, which is what the Delta protocol requires. Arrow-based engines can use
+    ///    [`build_add_file_metadata`] which handles this step.
+    ///
+    /// [`DefaultEngine::write_parquet`] handles both steps automatically via `object_store`
+    /// and [`build_add_file_metadata`].
+    ///
+    /// # Layout
     ///
     /// ```text
     ///              | CM OFF                              | CM ON
@@ -80,20 +116,29 @@ impl WriteContext {
     /// CM ON uses a random 2-char alphanumeric prefix (matching Delta-Spark's
     /// `getRandomPrefix`) to avoid S3 hotspots. Each call generates a fresh prefix,
     /// matching Delta-Spark's per-file behavior.
+    ///
+    /// [`DefaultEngine::write_parquet`]: crate::engine::default::DefaultEngine::write_parquet
+    /// [`build_add_file_metadata`]: crate::engine::default::build_add_file_metadata
     // TODO(#2357): respect `delta.randomizeFilePrefixes` and `delta.randomPrefixLength`
     // table properties. Currently random prefixes are only used when column mapping is on.
     pub fn write_dir(&self) -> Url {
         let mut url = self.shared.table_root.clone();
         match self.shared.column_mapping_mode {
             ColumnMappingMode::None => {
-                // No column mapping: use Hive-style partition directories for partitioned
-                // tables, or just the table root for unpartitioned tables.
+                // URI-encode on top of Hive-escaping because the fn-level contract (see
+                // doc above) requires callers to URI-decode once before using the URL as
+                // a filesystem path. That decode recovers the Hive-escaped form, which
+                // is the on-disk layout Delta-Spark and kernel-java produce.
                 if !self.shared.logical_partition_columns.is_empty() {
-                    let path_suffix = self.hive_partition_path_suffix();
-                    url.set_path(&format!("{}{}", url.path(), path_suffix));
+                    let hive_escaped = self.hive_partition_path_suffix();
+                    let uri_encoded = uri_encode_path(&hive_escaped);
+                    url.set_path(&format!("{}{}", url.path(), uri_encoded));
                 }
             }
             ColumnMappingMode::Id | ColumnMappingMode::Name => {
+                // Column mapping on: the random 2-char alphanumeric prefix contains only
+                // ASCII letters/digits (all RFC 3986 unreserved chars), so no URI encoding
+                // is needed — the string is already URI-safe as-is.
                 let prefix = random_alphanumeric_prefix();
                 url.set_path(&format!("{}{}/", url.path(), prefix));
             }
@@ -356,6 +401,51 @@ mod tests {
         );
     }
 
+    /// CM=None + partitioned: `write_dir` applies URI encoding on top of Hive escaping, so
+    /// a Hive `%XX` sequence in the suffix comes out as `%25XX` in the URL path. Guards
+    /// against a refactor that drops the URI layer; such a regression would silently leave
+    /// the previous Hive-only layout, which every other Delta writer misreads.
+    #[rstest]
+    #[case::colon("p", "2025-03-31T15:30:00Z", "/table/p=2025-03-31T15%253A30%253A00Z/")]
+    #[case::slash("region", "US/East", "/table/region=US%252FEast/")]
+    #[case::percent_literal("col", "100%", "/table/col=100%2525/")]
+    fn test_write_dir_cm_off_partitioned_double_encodes_hive_output(
+        #[case] col: &str,
+        #[case] value: &str,
+        #[case] expected_path: &str,
+    ) {
+        let wc = make_write_context(
+            ColumnMappingMode::None,
+            vec![col.into()],
+            HashMap::from([(col.into(), Some(value.into()))]),
+        );
+        assert_eq!(wc.write_dir().path(), expected_path);
+    }
+
+    /// CM=Id/Name: `write_dir` emits the random prefix verbatim into the URL path. The
+    /// prefix charset is guarded by `test_random_alphanumeric_prefix_format`; this test
+    /// just checks that the CM-on arm doesn't introduce a `%` or mangle the prefix.
+    #[rstest]
+    #[case::name_mode(ColumnMappingMode::Name)]
+    #[case::id_mode(ColumnMappingMode::Id)]
+    fn test_write_dir_cm_on_prefix_is_uri_safe(#[case] cm_mode: ColumnMappingMode) {
+        let wc = make_write_context(cm_mode, vec!["p".into()], HashMap::new());
+        let path = wc.write_dir().path().to_string();
+        assert!(
+            !path.contains('%'),
+            "CM-on path must not contain '%': {path}"
+        );
+        let prefix = path
+            .strip_prefix("/table/")
+            .unwrap()
+            .strip_suffix('/')
+            .unwrap();
+        assert!(
+            prefix.chars().all(|c| c.is_ascii_alphanumeric()),
+            "prefix should be URI-safe: {prefix:?}"
+        );
+    }
+
     #[test]
     fn test_random_alphanumeric_prefix_format() {
         for _ in 0..100 {
@@ -375,6 +465,18 @@ mod tests {
     #[case::relative_with_subdirectory(
         "s3://bucket/table/year=2024/abc.parquet",
         Ok("year=2024/abc.parquet")
+    )]
+    #[case::uri_encoded_partition(
+        "s3://bucket/table/p=a%253Ab/uuid.parquet",
+        Ok("p=a%253Ab/uuid.parquet")
+    )]
+    #[case::double_percent_partition(
+        "s3://bucket/table/p=100%252525/uuid.parquet",
+        Ok("p=100%252525/uuid.parquet")
+    )]
+    #[case::multi_partition_encoded(
+        "s3://bucket/table/year=2025/region=US%252FEast/uuid.parquet",
+        Ok("year=2025/region=US%252FEast/uuid.parquet")
     )]
     #[case::error_different_scheme("gs://other-bucket/table/abc.parquet", Err(()))]
     #[case::error_different_host("s3://other-bucket/table/abc.parquet", Err(()))]

--- a/kernel/tests/write_partitioned.rs
+++ b/kernel/tests/write_partitioned.rs
@@ -50,14 +50,26 @@ async fn test_write_partitioned_normal_values_roundtrip(
     let (add, rel_path) = read_single_add(&table_path, 1)?;
     match cm_mode {
         ColumnMappingMode::None => {
-            // Hive-style path with Hive encoding: colons -> %3A, spaces -> %20.
-            let expected_prefix = "\
-                p_string=hello/p_int=42/p_long=9876543210/p_short=7/\
-                p_byte=3/p_float=1.25/p_double=99.99/p_boolean=true/p_date=2025-03-31/\
-                p_timestamp=2025-03-31T15%3A30%3A00.123456Z/p_decimal=123.45/\
-                p_binary=Hello/p_timestamp_ntz=2025-03-31%2015%3A30%3A00.123456/";
+            // Every value except the timestamps is unreserved ASCII and passes through
+            // both encoding layers unchanged. The two timestamps differ on `:`:
+            //   `:` -> Hive `%3A` -> URI `%253A`  (all platforms)
+            // TIMESTAMP_NTZ additionally contains a space, which diverges by platform:
+            //   ` ` on non-Windows: Hive passes it through -> URI `%20`
+            //   ` ` on Windows:     Hive escapes to `%20`  -> URI `%2520`
+            // TIMESTAMP uses ISO-Z format (no space), so it's platform-identical.
+            let ntz_segment = if cfg!(target_os = "windows") {
+                "p_timestamp_ntz=2025-03-31%252015%253A30%253A00.123456/"
+            } else {
+                "p_timestamp_ntz=2025-03-31%2015%253A30%253A00.123456/"
+            };
+            let expected_prefix = format!(
+                "p_string=hello/p_int=42/p_long=9876543210/p_short=7/\
+                 p_byte=3/p_float=1.25/p_double=99.99/p_boolean=true/p_date=2025-03-31/\
+                 p_timestamp=2025-03-31T15%253A30%253A00.123456Z/p_decimal=123.45/\
+                 p_binary=Hello/{ntz_segment}"
+            );
             assert!(
-                rel_path.starts_with(expected_prefix),
+                rel_path.starts_with(&expected_prefix),
                 "CM off: relative path mismatch.\n  \
                  expected: {expected_prefix}<uuid>.parquet\n  got: {rel_path}"
             );
@@ -154,6 +166,158 @@ async fn test_write_partitioned_null_values_roundtrip(
 
     Ok(())
 }
+
+// On Windows the Hive escape set additionally includes space, `<`, `>`, `|`. They get
+// Hive-escaped to `%XX` first, and the URI layer double-encodes the leading `%`. Non-Windows
+// passes them through Hive, so the URI layer applies only single encoding.
+macro_rules! platform_path {
+    ($win:literal, $non_win:literal) => {
+        if cfg!(target_os = "windows") {
+            $win
+        } else {
+            $non_win
+        }
+    };
+}
+
+/// Asserts `add.path` correctly encodes every non-control character in
+/// `HADOOP_URI_PATH_ENCODE_SET`, a sample of ASCII controls, plus the Hive-only chars that
+/// exercise the Hive -> URI double-encoding path. Partition value is always a three-char
+/// string `a<char>b`, so `add.path` must start with `p=a<encoded>b/` (the encoded partition
+/// directory plus its trailing separator) and end in `.parquet`. The `partitionValues` map
+/// should carry the raw value unchanged.
+#[rstest]
+// === Chars in both Hive and URI sets: Hive `%XX` -> URI `%25XX` (double-encoded) ===
+#[case::percent("a%b", "p=a%2525b/")]
+#[case::quote("a\"b", "p=a%2522b/")]
+#[case::hash("a#b", "p=a%2523b/")]
+#[case::question("a?b", "p=a%253Fb/")]
+#[case::backslash("a\\b", "p=a%255Cb/")]
+#[case::caret("a^b", "p=a%255Eb/")]
+#[case::left_brace("a{b", "p=a%257Bb/")]
+#[case::left_bracket("a[b", "p=a%255Bb/")]
+#[case::right_bracket("a]b", "p=a%255Db/")]
+// === Hive set only (URI just double-encodes the `%` Hive produced) ===
+#[case::colon("a:b", "p=a%253Ab/")]
+#[case::slash("a/b", "p=a%252Fb/")]
+#[case::equals("a=b", "p=a%253Db/")]
+#[case::apostrophe("a'b", "p=a%2527b/")]
+#[case::asterisk("a*b", "p=a%252Ab/")]
+#[case::slash_percent("Serbia/srb%", "p=Serbia%252Fsrb%2525/")]
+// === URI set only (Hive passthrough; URI single-encodes) ===
+#[case::backtick("a`b", "p=a%60b/")]
+#[case::right_brace("a}b", "p=a%7Db/")]
+// === Platform-divergent: Hive set on Windows only ===
+#[case::space("a b", platform_path!("p=a%2520b/", "p=a%20b/"))]
+#[case::less_than("a<b", platform_path!("p=a%253Cb/", "p=a%3Cb/"))]
+#[case::greater_than("a>b", platform_path!("p=a%253Eb/", "p=a%3Eb/"))]
+#[case::pipe("a|b", platform_path!("p=a%257Cb/", "p=a%7Cb/"))]
+#[case::multi_space("a   b", platform_path!("p=a%2520%2520%2520b/", "p=a%20%20%20b/"))]
+// === A few ASCII control characters (sample: NUL, TAB, LF, DEL) ===
+#[case::null_byte("a\0b", "p=a%2500b/")]
+#[case::tab("a\tb", "p=a%2509b/")]
+#[case::newline("a\nb", "p=a%250Ab/")]
+#[case::del("a\x7Fb", "p=a%257Fb/")]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_write_partitioned_path_encodes_special_chars(
+    #[case] value: &str,
+    #[case] expected_path_prefix: &str,
+    #[values(
+        ColumnMappingMode::None,
+        ColumnMappingMode::Name,
+        ColumnMappingMode::Id
+    )]
+    cm_mode: ColumnMappingMode,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // ===== Step 1: Create a single-STRING-partition table and write one row. =====
+    let schema = Arc::new(
+        StructType::try_new(vec![
+            StructField::nullable("value", DataType::INTEGER),
+            StructField::nullable("p", DataType::STRING),
+        ])
+        .unwrap(),
+    );
+    let (_tmp_dir, table_path, snapshot, engine) = setup_and_write(
+        schema,
+        &["p"],
+        cm_mode,
+        vec![
+            Arc::new(Int32Array::from(vec![1])),
+            Arc::new(StringArray::from(vec![value])) as ArrayRef,
+        ],
+        HashMap::from([("p".to_string(), Scalar::String(value.into()))]),
+    )
+    .await?;
+
+    // ===== Step 2: Read the single add action from the commit log JSON. =====
+    let (add, rel_path) = read_single_add(&table_path, 1)?;
+
+    // ===== Step 3: Validate add.partitionValues carries the raw value unchanged. =====
+    let logical_schema = snapshot.schema();
+    let physical_key = logical_schema.field("p").unwrap().physical_name(cm_mode);
+    let pv = add["partitionValues"].as_object().unwrap();
+    assert_eq!(
+        pv.get(physical_key).and_then(|v| v.as_str()),
+        Some(value),
+        "partitionValues[{physical_key}] mismatch"
+    );
+
+    // ===== Step 4: Validate add.path has the expected URI-encoded layout. =====
+    match cm_mode {
+        ColumnMappingMode::None => {
+            assert!(
+                rel_path.starts_with(expected_path_prefix),
+                "CM off: expected path to start with {expected_path_prefix:?}, got {rel_path:?}"
+            );
+            assert!(rel_path.ends_with(".parquet"));
+        }
+        ColumnMappingMode::Name | ColumnMappingMode::Id => {
+            assert_cm_path(&rel_path);
+        }
+    }
+
+    // ===== Step 5: Scan and verify the row round-trips across checkpoint + reload. =====
+    verify_and_checkpoint(&snapshot, engine, |sorted| {
+        assert_eq!(sorted.num_rows(), 1);
+        assert_eq!(
+            sorted
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap()
+                .value(0),
+            1,
+            "value column mismatch"
+        );
+        assert_eq!(
+            sorted
+                .column(1)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap()
+                .value(0),
+            value,
+            "partition column `p` mismatch"
+        );
+    })?;
+
+    Ok(())
+}
+
+// TODO: Test extreme low/high values
+//       e.g. i32::MIN/MAX, f64::MAX, f64::MIN_POSITIVE, f64::INFINITY, f64::NEG_INFINITY,
+//       f64::NAN, Date(-719_162) (year 0001), Date(2_932_896) (year 9999)
+
+// TODO(#2423): Test non-ASCII UTF-8 strings once `add.path` encoding matches Delta-Spark.
+//              Kernel currently percent-encodes non-ASCII UTF-8 bytes (e.g. München ->
+//              M%C3%BCnchen) while Delta-Spark leaves them raw in `add.path`.
+//              e.g. "M\u{00FC}nchen", "日本語", "🎵🎶"
+
+// TODO: Test binary valid UTF-8
+//       e.g. Scalar::Binary(b"HELLO".to_vec()), Scalar::Binary(vec![0x2F, 0x3D, 0x25])
+
+// TODO: Test binary with non-UTF-8
+//       e.g. Scalar::Binary(vec![0xDE, 0xAD, 0xBE, 0xEF]), Scalar::Binary(vec![0x00, 0xFF])
 
 // ==============================================================================
 // Schema and partition column definitions
@@ -509,7 +673,7 @@ async fn setup_and_write(
 fn verify_and_checkpoint(
     snapshot: &Arc<Snapshot>,
     engine: Arc<dyn delta_kernel::Engine>,
-    assert_fn: fn(&RecordBatch),
+    assert_fn: impl Fn(&RecordBatch),
 ) -> Result<(), Box<dyn std::error::Error>> {
     let sorted = read_sorted(snapshot, engine.clone())?;
     assert_fn(&sorted);


### PR DESCRIPTION
## What changes are proposed in this pull request?

URI-encode the Hive-escaped partition path when building `add.path` for CM=None partitioned writes, matching delta-spark and kernel-java (Hadoop `Path.toUri().toString()`).

Examples for a STRING partition column `p` ..

| value | before (add.path) | after (add.path) | on-disk dir |
|-------|-------------------|------------------|-------------|
| `"a:b"` | `p=a:b/` | `p=a%253Ab/` | `p=a%3Ab/` |
| `"a b"` | `p=a b/` | `p=a%20b/` | `p=a b/` (non-Windows) |

## How was this change tested?

Extensive new UTs and E2E tests. Validated against delta-spark (for each value in the test). Also wrote kernel-rs and delta-spark against the same table to test some sample values:

DATA1 | PART1 | Source | On-disk file path | add.path | add.partitionValues
-- | -- | -- | -- | -- | --
1 | abc | Kernel | PART1=abc/<uuid>.parquet | PART1=abc/<uuid>.parquet | {"PART1":"abc"}
2 | a:c | Kernel | PART1=a%3Ac/<uuid>.parquet | PART1=a%253Ac/<uuid>.parquet | {"PART1":"a:c"}
3 | a/c | Kernel | PART1=a%2Fc/<uuid>.parquet | PART1=a%252Fc/<uuid>.parquet | {"PART1":"a/c"}
4 | a c | Kernel | PART1=a c/<uuid>.parquet | PART1=a%20c/<uuid>.parquet | {"PART1":"a c"}
5 | a%c | Kernel | PART1=a%25c/<uuid>.parquet | PART1=a%2525c/<uuid>.parquet | {"PART1":"a%c"}
6 | abc | delta-spark | PART1=abc/<uuid>.snappy.parquet | PART1=abc/<uuid>.snappy.parquet | {"PART1":"abc"}
7 | a:c | delta-spark | PART1=a%3Ac/<uuid>.snappy.parquet | PART1=a%253Ac/<uuid>.snappy.parquet | {"PART1":"a:c"}
8 | a/c | delta-spark | PART1=a%2Fc/<uuid>.snappy.parquet | PART1=a%252Fc/<uuid>.snappy.parquet | {"PART1":"a/c"}
9 | a c | delta-spark | PART1=a c/<uuid>.snappy.parquet | PART1=a%20c/<uuid>.snappy.parquet | {"PART1":"a c"}
10 | a%c | delta-spark | PART1=a%25c/<uuid>.snappy.parquet | PART1=a%2525c/<uuid>.snappy.parquet | {"PART1":"a%c"}
