### PR TITLE
fix: restore the Snapshot::new internal API

### DIFF
--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -129,6 +129,17 @@ impl Snapshot {
         SnapshotBuilder::new_from(existing_snapshot)
     }
 
+    /// Create a new [`Snapshot`] from a [`LogSegment`] and [`TableConfiguration`].
+    #[internal_api]
+    #[allow(unused)]
+    pub(crate) fn new(log_segment: LogSegment, table_configuration: TableConfiguration) -> Self {
+        Self::new_with_crc(
+            log_segment,
+            table_configuration,
+            Arc::new(LazyCrc::new(None)),
+        )
+    }
+
     /// Internal constructor that accepts an explicit [`LazyCrc`].
     pub(crate) fn new_with_crc(
         log_segment: LogSegment,

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -129,6 +129,16 @@ impl Snapshot {
         SnapshotBuilder::new_from(existing_snapshot)
     }
 
+    /// Create a new [`Snapshot`] from a [`LogSegment`] and [`TableConfiguration`].
+    #[internal_api]
+    pub(crate) fn new(log_segment: LogSegment, table_configuration: TableConfiguration) -> Self {
+        Self::new_with_crc(
+            log_segment,
+            table_configuration,
+            Arc::new(LazyCrc::new(None)),
+        )
+    }
+
     /// Internal constructor that accepts an explicit [`LazyCrc`].
     pub(crate) fn new_with_crc(
         log_segment: LogSegment,


### PR DESCRIPTION
This APi was removed in the upstream delta-io/delta-kernel-rs#2385 but this is a load-bearing API for delta-rs. The removal was not related to the change and seems like an erroneous removal that wasn't caught in review.

