### PR TITLE
fix: drop partitionValues_parsed in build_remove_transform

### DIFF
--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -116,7 +116,6 @@ use crate::table_properties::TableProperties;
 use crate::{DeltaResult, Engine, EngineData, Error, EvaluationHandlerExtension, FileMeta};
 
 mod checkpoint_transform;
-pub(crate) use checkpoint_transform::PARTITION_VALUES_PARSED_FIELD;
 #[allow(unused)]
 // Used once sidecar checkpoint writing is enabled
 mod sidecar;

--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -116,6 +116,7 @@ use crate::table_properties::TableProperties;
 use crate::{DeltaResult, Engine, EngineData, Error, EvaluationHandlerExtension, FileMeta};
 
 mod checkpoint_transform;
+pub(crate) use checkpoint_transform::PARTITION_VALUES_PARSED_FIELD;
 #[allow(unused)]
 // Used once sidecar checkpoint writing is enabled
 mod sidecar;

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -546,6 +546,7 @@ pub(crate) static DEFAULT_ROW_COMMIT_VERSION_NAME: &str = "defaultRowCommitVersi
 pub(crate) static CLUSTERING_PROVIDER_NAME: &str = "clusteringProvider";
 pub(crate) static TAGS_NAME: &str = "tags";
 pub(crate) static STATS_PARSED_NAME: &str = "stats_parsed";
+pub(crate) static PARTITION_VALUES_PARSED_NAME: &str = "partitionValues_parsed";
 
 // NB: If you update this schema, ensure you update the comment describing it in the doc comment
 // for `scan_row_schema` in scan/mod.rs! You'll also need to update ScanFileVisitor as the
@@ -599,7 +600,7 @@ fn scan_row_schema_with_parsed_columns(
     }
     if let Some(schema) = partition_schema {
         fields.push(StructField::nullable(
-            "partitionValues_parsed",
+            PARTITION_VALUES_PARSED_NAME,
             schema.as_ref().clone(),
         ));
     }

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -11,6 +11,7 @@ use crate::actions::{
     as_log_add_schema, get_commit_schema, get_log_remove_schema, get_log_txn_schema, CommitInfo,
     DomainMetadata, Metadata, Protocol, SetTransaction, METADATA_NAME, PROTOCOL_NAME,
 };
+use crate::checkpoint::PARTITION_VALUES_PARSED_FIELD;
 use crate::committer::{
     CommitMetadata, CommitProtocolMetadata, CommitResponse, CommitType, Committer,
 };
@@ -1327,7 +1328,11 @@ fn build_remove_transform(
             Expression::column([FILE_CONSTANT_VALUES_NAME, DEFAULT_ROW_COMMIT_VERSION_NAME]).into(),
         )
         .with_dropped_field(FILE_CONSTANT_VALUES_NAME)
-        .with_dropped_field("modificationTime");
+        .with_dropped_field("modificationTime")
+        // Scans with a partition-touching predicate add `partitionValues_parsed`
+        // to the scan output schema (see scan/log_replay.rs); drop it so the
+        // remove-transform's field count matches its target schema. See #2426.
+        .with_dropped_field_if_exists(PARTITION_VALUES_PARSED_FIELD);
 
     for column_to_drop in columns_to_drop {
         transform = transform.with_dropped_field(*column_to_drop);

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -11,7 +11,6 @@ use crate::actions::{
     as_log_add_schema, get_commit_schema, get_log_remove_schema, get_log_txn_schema, CommitInfo,
     DomainMetadata, Metadata, Protocol, SetTransaction, METADATA_NAME, PROTOCOL_NAME,
 };
-use crate::checkpoint::PARTITION_VALUES_PARSED_FIELD;
 use crate::committer::{
     CommitMetadata, CommitProtocolMetadata, CommitResponse, CommitType, Committer,
 };
@@ -28,7 +27,7 @@ use crate::row_tracking::{RowTrackingDomainMetadata, RowTrackingVisitor};
 use crate::scan::data_skipping::stats_schema::schema_with_all_fields_nullable;
 use crate::scan::log_replay::{
     BASE_ROW_ID_NAME, DEFAULT_ROW_COMMIT_VERSION_NAME, FILE_CONSTANT_VALUES_NAME,
-    STATS_PARSED_NAME, TAGS_NAME,
+    PARTITION_VALUES_PARSED_NAME, STATS_PARSED_NAME, TAGS_NAME,
 };
 use crate::scan::scan_row_schema;
 use crate::schema::{ArrayType, MapType, SchemaRef, StructField, StructType, StructTypeBuilder};
@@ -1272,11 +1271,15 @@ impl<S> Transaction<S> {
 
 /// Builds the transform expression for converting scan row metadata into a Remove action.
 ///
-/// When `coalesce_stats_with_parsed` is true, the `stats` field is replaced with
-/// `COALESCE(stats, TO_JSON(stats_parsed))` and `stats_parsed` is dropped. This handles
-/// scan files produced by predicate-based scans that include a `stats_parsed` column: if
-/// `stats` is null (e.g., because `skip_stats=true` was used), the stats are reconstructed
-/// from the parsed representation before writing the remove action.
+/// Handles two "parsed" columns that predicate-based scans add to scan metadata:
+///
+/// - `stats_parsed`: when `coalesce_stats_with_parsed` is true, the `stats` field is replaced with
+///   `COALESCE(stats, TO_JSON(stats_parsed))` and `stats_parsed` is dropped. The coalesce handles
+///   cases where `stats` is null (e.g., `skip_stats=true` or V2 checkpoints with
+///   `writeStatsAsJson=false`) by reconstructing the JSON from the parsed representation.
+/// - `partitionValues_parsed`: dropped if present. Unlike stats, no reconstruction is needed: the
+///   Remove action's `partitionValues` is sourced from `fileConstantValues.partitionValues`, which
+///   scans always populate from `add.partitionValues`.
 fn build_remove_transform(
     commit_timestamp: i64,
     data_change: bool,
@@ -1329,10 +1332,8 @@ fn build_remove_transform(
         )
         .with_dropped_field(FILE_CONSTANT_VALUES_NAME)
         .with_dropped_field("modificationTime")
-        // Scans with a partition-touching predicate add `partitionValues_parsed`
-        // to the scan output schema (see scan/log_replay.rs); drop it so the
-        // remove-transform's field count matches its target schema. See #2426.
-        .with_dropped_field_if_exists(PARTITION_VALUES_PARSED_FIELD);
+        // Added to scan output when the predicate touches a partition column.
+        .with_dropped_field_if_exists(PARTITION_VALUES_PARSED_NAME);
 
     for column_to_drop in columns_to_drop {
         transform = transform.with_dropped_field(*column_to_drop);

--- a/kernel/tests/write.rs
+++ b/kernel/tests/write.rs
@@ -3116,6 +3116,103 @@ async fn test_remove_files_after_predicate_scan_includes_stats_parsed(
     Ok(())
 }
 
+/// Scan with a partition predicate -> `Transaction::remove_files` commits and produces
+/// remove actions only for the targeted partition.
+#[tokio::test]
+async fn test_remove_files_after_partition_predicate_scan() -> Result<(), Box<dyn std::error::Error>>
+{
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let partition_col = "country";
+    let table_schema = Arc::new(StructType::try_new(vec![
+        StructField::nullable("id", DataType::INTEGER),
+        StructField::nullable("country", DataType::STRING),
+    ])?);
+    let data_schema = Arc::new(StructType::try_new(vec![StructField::nullable(
+        "id",
+        DataType::INTEGER,
+    )])?);
+
+    // Local directory backing — `read_actions_from_commit` reads the commit JSON
+    // off disk and does not support the default in-memory store's `memory://` URL.
+    let tmp_dir = tempdir()?;
+    let tmp_url = Url::from_directory_path(tmp_dir.path()).unwrap();
+
+    for (table_url, engine, _store, _table_name) in setup_test_tables(
+        table_schema.clone(),
+        &[partition_col],
+        Some(&tmp_url),
+        "test_table",
+    )
+    .await?
+    {
+        let engine = Arc::new(engine);
+
+        // Write two partitions: country="usa" and country="japan".
+        let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
+        let mut txn = snapshot
+            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+            .with_data_change(true);
+        let append_data = [[1, 2, 3], [10, 20, 30]].map(|data| -> DeltaResult<_> {
+            let data = RecordBatch::try_new(
+                Arc::new(data_schema.as_ref().try_into_arrow()?),
+                vec![Arc::new(Int32Array::from(data.to_vec()))],
+            )?;
+            Ok(Box::new(ArrowEngineData::new(data)))
+        });
+        for (data, partition_val) in append_data.into_iter().zip(["usa", "japan"]) {
+            let ctx = Arc::new(txn.partitioned_write_context(HashMap::from([(
+                partition_col.to_string(),
+                Scalar::String(partition_val.into()),
+            )]))?);
+            let add_meta = engine.write_parquet(data?.as_ref(), ctx.as_ref()).await?;
+            txn.add_files(add_meta);
+        }
+        txn.commit(engine.as_ref())?.unwrap_committed();
+
+        // Predicate on the partition column: causes scan metadata to include the
+        // `partitionValues_parsed` column. Feeding this to remove_files previously
+        // failed at commit ("Too few fields in output schema"). See #2426.
+        let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
+        let scan = snapshot
+            .clone()
+            .scan_builder()
+            .with_predicate(Arc::new(Pred::eq(
+                column_expr!("country"),
+                Expr::literal("usa".to_string()),
+            )))
+            .build()?;
+
+        let mut txn = snapshot
+            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+            .with_data_change(true);
+        for scan_metadata in scan.scan_metadata(engine.as_ref())? {
+            txn.remove_files(scan_metadata?.scan_files);
+        }
+        let committed = txn.commit(engine.as_ref())?.unwrap_committed();
+        assert_eq!(committed.commit_version(), 2);
+
+        // Exactly one file was written to the `usa` partition, so exactly one
+        // remove action is expected. Asserting the count catches a regression
+        // where the scan returns zero files (making per-element checks vacuous).
+        let remove_actions = read_actions_from_commit(&table_url, 2, "remove")?;
+        assert_eq!(
+            remove_actions.len(),
+            1,
+            "expected exactly one remove action for the 'usa' partition; got {}: {remove_actions:?}",
+            remove_actions.len()
+        );
+        for remove in &remove_actions {
+            assert_eq!(
+                remove["partitionValues"]["country"].as_str(),
+                Some("usa"),
+                "remove action should only touch the 'usa' partition; got: {remove}"
+            );
+        }
+    }
+    Ok(())
+}
+
 // Helper function to create a table with CDF enabled
 async fn create_cdf_table(
     table_name: &str,

--- a/kernel/tests/write.rs
+++ b/kernel/tests/write.rs
@@ -3116,11 +3116,41 @@ async fn test_remove_files_after_predicate_scan_includes_stats_parsed(
     Ok(())
 }
 
-/// Scan with a partition predicate -> `Transaction::remove_files` commits and produces
-/// remove actions only for the targeted partition.
+/// Remove files via scan metadata on a partitioned table. Covers three predicate
+/// shapes against the same table so the remove-transform correctly handles the
+/// parsed scan columns in every combination:
+/// - no predicate: no `partitionValues_parsed`.
+/// - data-column predicate: no `partitionValues_parsed` (negative case; the fix must not affect
+///   scans whose predicate misses the partition columns).
+/// - partition predicate: `partitionValues_parsed` present.
+///
+/// Every case calls `.include_all_stats_columns()`, which forces `stats_parsed`
+/// into the scan output regardless of the predicate shape, so the partition-
+/// predicate case exercises both parsed-column drop paths together while the
+/// other two exercise only the `stats_parsed` drop path. The coalesce
+/// *reconstruction* of `stats` from `stats_parsed` is not exercised here
+/// because `stats` is non-null; the sibling
+/// `test_remove_files_after_predicate_scan_includes_stats_parsed` covers that.
+///
+/// `expected_partitions` is the multiset of `country` values expected across
+/// the generated Remove actions. Its length gives the expected Remove count,
+/// and its contents pin the correct partition was chosen (catches regressions
+/// where the wrong partition is removed).
+#[rstest::rstest]
+#[case::no_predicate(None, &["usa", "japan"])]
+#[case::data_predicate(
+    Some(Pred::gt(column_expr!("id"), Expr::literal(0_i32))),
+    &["usa", "japan"]
+)]
+#[case::partition_predicate(
+    Some(Pred::eq(column_expr!("country"), Expr::literal("usa".to_string()))),
+    &["usa"]
+)]
 #[tokio::test]
-async fn test_remove_files_after_partition_predicate_scan() -> Result<(), Box<dyn std::error::Error>>
-{
+async fn test_remove_files_partitioned_with_parsed_columns(
+    #[case] predicate: Option<Pred>,
+    #[case] expected_partitions: &[&str],
+) -> Result<(), Box<dyn std::error::Error>> {
     let _ = tracing_subscriber::fmt::try_init();
 
     let partition_col = "country";
@@ -3133,8 +3163,8 @@ async fn test_remove_files_after_partition_predicate_scan() -> Result<(), Box<dy
         DataType::INTEGER,
     )])?);
 
-    // Local directory backing — `read_actions_from_commit` reads the commit JSON
-    // off disk and does not support the default in-memory store's `memory://` URL.
+    // Local directory backing: `read_actions_from_commit` reads commit JSON off disk
+    // and does not support the default in-memory store's `memory://` URL.
     let tmp_dir = tempdir()?;
     let tmp_url = Url::from_directory_path(tmp_dir.path()).unwrap();
 
@@ -3170,18 +3200,12 @@ async fn test_remove_files_after_partition_predicate_scan() -> Result<(), Box<dy
         }
         txn.commit(engine.as_ref())?.unwrap_committed();
 
-        // Predicate on the partition column: causes scan metadata to include the
-        // `partitionValues_parsed` column. Feeding this to remove_files previously
-        // failed at commit ("Too few fields in output schema"). See #2426.
         let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
-        let scan = snapshot
-            .clone()
-            .scan_builder()
-            .with_predicate(Arc::new(Pred::eq(
-                column_expr!("country"),
-                Expr::literal("usa".to_string()),
-            )))
-            .build()?;
+        let mut scan_builder = snapshot.clone().scan_builder().include_all_stats_columns();
+        if let Some(pred) = predicate.clone() {
+            scan_builder = scan_builder.with_predicate(Arc::new(pred));
+        }
+        let scan = scan_builder.build()?;
 
         let mut txn = snapshot
             .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
@@ -3192,21 +3216,42 @@ async fn test_remove_files_after_partition_predicate_scan() -> Result<(), Box<dy
         let committed = txn.commit(engine.as_ref())?.unwrap_committed();
         assert_eq!(committed.commit_version(), 2);
 
-        // Exactly one file was written to the `usa` partition, so exactly one
-        // remove action is expected. Asserting the count catches a regression
-        // where the scan returns zero files (making per-element checks vacuous).
         let remove_actions = read_actions_from_commit(&table_url, 2, "remove")?;
         assert_eq!(
             remove_actions.len(),
-            1,
-            "expected exactly one remove action for the 'usa' partition; got {}: {remove_actions:?}",
+            expected_partitions.len(),
+            "unexpected remove count; got {}: {remove_actions:?}",
             remove_actions.len()
         );
+
+        let mut actual_partitions: Vec<String> = remove_actions
+            .iter()
+            .filter_map(|r| {
+                r["partitionValues"][partition_col]
+                    .as_str()
+                    .map(String::from)
+            })
+            .collect();
+        actual_partitions.sort();
+        let mut expected_sorted: Vec<String> =
+            expected_partitions.iter().map(|s| s.to_string()).collect();
+        expected_sorted.sort();
+        assert_eq!(
+            actual_partitions, expected_sorted,
+            "partitionValues mismatch across removes; got: {remove_actions:?}"
+        );
+
+        // stats_parsed is present on every scan row, so the stats-with-parsed
+        // evaluator is selected for every case; it must still yield a populated
+        // stats JSON on every remove action.
         for remove in &remove_actions {
-            assert_eq!(
-                remove["partitionValues"]["country"].as_str(),
-                Some("usa"),
-                "remove action should only touch the 'usa' partition; got: {remove}"
+            let stats_str = remove["stats"]
+                .as_str()
+                .expect("stats field should be a non-null JSON string");
+            let stats: serde_json::Value = serde_json::from_str(stats_str)?;
+            assert!(
+                stats["numRecords"].as_i64().unwrap_or(0) > 0,
+                "stats.numRecords should be populated, got: {stats}"
             );
         }
     }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes #2426. `Transaction::remove_files` failed at commit with "Too few fields in output schema" when fed scan metadata produced by a scan that had a partition touching predicate. `Scan::with_predicate` on a partition column adds a `partitionValues_parsed` column to the scan output schema, and `build_remove_transform` had no drop rule for it. This fix adds the missing `.with_dropped_field_if_exists(PARTITION_VALUES_PARSED_FIELD)` to the remove transform.

## How was this change tested?
Added a test which creates a partitioned table, writes two partitions, runs a scan, feeds the scan metadata into `remove_files`, and asserts commit succeeds with exactly one remove action for the partition.