### PR TITLE
fix!: make scan_table_changes_next return *mut ArrowFFIData

### DIFF
--- a/ffi/examples/delta-kernel-unity-catalog-example/README.md
+++ b/ffi/examples/delta-kernel-unity-catalog-example/README.md
@@ -1,35 +1,43 @@
 delta-kernel-unity-catalog example
 ===================================
 
-Simple example to show how to use the delta-kernel-unity-catalog ffi features
+Simple example showing how to use the delta-kernel-unity-catalog FFI surface -- namely
+`get_uc_commit_client`, `get_uc_committer`, and `transaction_with_committer` -- to run a
+commit against a catalog-managed table using a custom commit callback.
 
 # Building
 
-This example is built with [cmake]. Instructions below assume you start in the directory containing this README.
+This example is built with [cmake]. Instructions below assume you start in the directory
+containing this README.
 
-Note that prior to building these examples you must build `delta_kernel_ffi` with all feature enabled (see [the FFI readme] for details). TLDR:
+Before building this example, you must build `delta_kernel_ffi` with **all features** enabled
+so that the Unity Catalog bindings are present in `delta_kernel_ffi.h`. See
+[the FFI readme](../../README.md) for details. TLDR:
+
 ```bash
 # from repo root
 $ cargo build -p delta_kernel_ffi [--release] --all-features
-# from ffi/ dir
+# or, from the ffi/ dir
 $ cargo build [--release] --all-features
-```
-
-There are two configurations that can currently be configured in cmake:
-```bash
-# turn on VERBOSE mode (default is off) - print more diagnostics
-$ cmake -DVERBOSE=yes ..
-# turn off PRINT_DATA (default is on) - see below
-$ cmake -DPRINT_DATA=no ..
 ```
 
 ## Linux / MacOS
 
-Most likely something like this should work:
 ```
 $ mkdir build
 $ cd build
 $ cmake ..
 $ make
-$ ./delta_kernel_unity_catalog_example [path/to/table]
+$ ./delta_kernel_unity_catalog_example [path/to/catalog-managed-table]
 ```
+
+The included ctest (`test_delta_kernel_unity_catalog_ffi`) runs the binary against the
+catalog-managed fixture at
+`delta-kernel-unity-catalog/tests/data/catalog_managed_0`, so you generally don't need to
+supply your own table to see it work:
+
+```
+$ ctest --output-on-failure
+```
+
+[cmake]: https://cmake.org/

--- a/ffi/examples/read-table/arrow.c
+++ b/ffi/examples/read-table/arrow.c
@@ -160,7 +160,11 @@ static void visit_read_data(void* vcontext, ExclusiveEngineData* data)
   }
   ArrowFFIData* arrow_data = arrow_res.ok;
   add_batch_to_context(context->arrow_context, arrow_data);
-  free(arrow_data); // just frees the struct, the data and schema are freed/owned by add_batch_to_context
+  // The inner FFI_ArrowArray/FFI_ArrowSchema have already been imported by arrow-glib
+  // inside add_batch_to_context (which moves their release callbacks), so this call only
+  // drops the outer Box. It's still necessary to use the kernel-provided free because the
+  // struct was allocated by Rust's global allocator.
+  free_arrow_ffi_data(arrow_data);
 }
 
 // We call this for each file we get called back to read in read_table.c::visit_callback

--- a/ffi/examples/read-table/read_table.c
+++ b/ffi/examples/read-table/read_table.c
@@ -369,7 +369,10 @@ int main(int argc, char* argv[])
     return -1;
   }
 
-  // an example of using a builder to set options when building an engine
+  // Example of using the builder to set object-store options before building the engine. The
+  // keys accepted here come from object_store's configuration vocabulary (e.g. "aws_region",
+  // "aws_access_key_id"). They are object-store-specific and only meaningful when the table URL
+  // points at that backend -- for a local file:// table the setters have no effect.
   EngineBuilder* engine_builder = engine_builder_res.ok;
   if (!set_builder_opt(engine_builder, "aws_region", "us-west-2")) {
     return -1;
@@ -384,8 +387,8 @@ int main(int argc, char* argv[])
   //   get_default_engine(table_path_slice, NULL);
 
   if (engine_res.tag != OkHandleSharedExternEngine) {
-    print_error("File to get engine", (Error*)engine_builder_res.err);
-    free_error((Error*)engine_builder_res.err);
+    print_error("Failed to get engine", (Error*)engine_res.err);
+    free_error((Error*)engine_res.err);
     return -1;
   }
 
@@ -395,12 +398,16 @@ int main(int argc, char* argv[])
   if (snapshot_builder_res.tag != OkHandleMutableFfiSnapshotBuilder) {
     print_error("Failed to get snapshot builder.", (Error*)snapshot_builder_res.err);
     free_error((Error*)snapshot_builder_res.err);
+    free_engine(engine);
     return -1;
   }
+  // snapshot_builder_build consumes the builder handle whether it succeeds or fails, so there
+  // is nothing to free for the builder here.
   ExternResultHandleSharedSnapshot snapshot_res = snapshot_builder_build(snapshot_builder_res.ok);
   if (snapshot_res.tag != OkHandleSharedSnapshot) {
     print_error("Failed to create snapshot.", (Error*)snapshot_res.err);
     free_error((Error*)snapshot_res.err);
+    free_engine(engine);
     return -1;
   }
 
@@ -477,6 +484,14 @@ int main(int argc, char* argv[])
   if (data_iter_res.tag != OkHandleSharedScanMetadataIterator) {
     print_error("Failed to construct scan metadata iterator.", (Error*)data_iter_res.err);
     free_error((Error*)data_iter_res.err);
+    free_scan(scan);
+    free_schema(logical_schema);
+    free_schema(physical_schema);
+    free_snapshot(snapshot);
+    free_engine(engine);
+    free(context.table_root);
+    free(scan_table_path);
+    free_partition_list(context.partition_cols);
     return -1;
   }
 
@@ -484,6 +499,7 @@ int main(int argc, char* argv[])
 
   print_diag("\nIterating scan metadata\n");
 
+  int exit_code = 0;
   // iterate scan files
   for (;;) {
     ExternResultbool ok_res =
@@ -491,7 +507,8 @@ int main(int argc, char* argv[])
     if (ok_res.tag != Okbool) {
       print_error("Failed to iterate scan metadata.", (Error*)ok_res.err);
       free_error((Error*)ok_res.err);
-      return -1;
+      exit_code = -1;
+      break;
     } else if (!ok_res.ok) {
       print_diag("Scan metadata iterator done\n");
       break;
@@ -516,5 +533,5 @@ int main(int argc, char* argv[])
   free(scan_table_path);
   free_partition_list(context.partition_cols);
 
-  return 0;
+  return exit_code;
 }

--- a/ffi/examples/visit-expression/CMakeLists.txt
+++ b/ffi/examples/visit-expression/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(visit_expression PUBLIC delta_kernel_ffi)
 target_compile_options(visit_expression PUBLIC)
 
 if(MSVC)
-  target_compile_options(read_table PRIVATE /W4 /WX)
+  target_compile_options(visit_expression PRIVATE /W4 /WX)
 else()
   # no-strict-prototypes because arrow headers have fn defs without prototypes
   target_compile_options(visit_expression PRIVATE -Wall -Wextra -Wpedantic -Werror -Wno-strict-prototypes -g -fsanitize=address)

--- a/ffi/src/engine_data.rs
+++ b/ffi/src/engine_data.rs
@@ -90,7 +90,8 @@ impl ArrowFFIData {
 // TODO: This should use a callback to avoid having to have the engine free the struct
 /// Get an [`ArrowFFIData`] to allow binding to the arrow [C Data
 /// Interface](https://arrow.apache.org/docs/format/CDataInterface.html). This includes the data and
-/// the schema. If this function returns an `Ok` variant the _engine_ must free the returned struct.
+/// the schema. If this function returns an `Ok` variant the _engine_ must free the returned struct
+/// via [`free_arrow_ffi_data`] exactly once.
 ///
 /// # Safety
 /// data_handle must be a valid ExclusiveEngineData as read by the
@@ -111,6 +112,31 @@ fn get_raw_arrow_data_impl(data: Box<dyn EngineData>) -> DeltaResult<*mut ArrowF
     Ok(Box::into_raw(Box::new(ArrowFFIData::try_from_engine_data(
         data,
     )?)))
+}
+
+/// Free an [`ArrowFFIData`] pointer produced by a kernel FFI function (e.g.
+/// [`get_raw_arrow_data`] or [`crate::table_changes::scan_table_changes_next`]).
+///
+/// If the consumer has already imported the inner `FFI_ArrowArray` / `FFI_ArrowSchema` via a
+/// foreign Arrow layer (e.g. arrow-glib's `garrow_record_batch_import`), that import has
+/// moved ownership of the release callbacks out of the structs; dropping the `Box` here is
+/// then a cheap no-op on the arrays. If the consumer has not imported them, the structs'
+/// `Drop` impls will call their release callbacks so no memory is leaked.
+///
+/// A null pointer is a no-op, matching the convention used by
+/// [`crate::scan::free_scan_metadata_arrow_result`].
+///
+/// # Safety
+///
+/// `result` must be either null, or a pointer returned by a kernel FFI function that produces
+/// `*mut ArrowFFIData`. Must be called at most once per non-null pointer.
+#[cfg(feature = "default-engine-base")]
+#[no_mangle]
+pub unsafe extern "C" fn free_arrow_ffi_data(result: *mut ArrowFFIData) {
+    if result.is_null() {
+        return;
+    }
+    let _ = unsafe { Box::from_raw(result) };
 }
 
 /// Creates engine data from Arrow C Data Interface array and schema.
@@ -143,4 +169,61 @@ unsafe fn get_engine_data_impl(
     let arrow_engine_data: ArrowEngineData = record_batch.into();
     let engine_data: Box<dyn EngineData> = Box::new(arrow_engine_data);
     Ok(engine_data.into())
+}
+
+#[cfg(all(test, feature = "default-engine-base"))]
+mod tests {
+    use std::sync::Arc;
+
+    use delta_kernel::arrow::array::{Array, Int32Array, StructArray};
+    use delta_kernel::arrow::datatypes::{DataType, Field};
+    use delta_kernel::arrow::ffi::to_ffi;
+
+    use super::*;
+
+    /// Build a one-column `ArrowFFIData` we can use as a free-target. Mirrors the layout
+    /// produced by [`ArrowFFIData::try_from_engine_data`] (a struct array exported via
+    /// [`to_ffi`]) without going through the engine.
+    fn make_arrow_ffi_data() -> ArrowFFIData {
+        let column = Arc::new(Int32Array::from(vec![1, 2, 3]));
+        let field = Arc::new(Field::new("x", DataType::Int32, true));
+        let struct_array = StructArray::from(vec![(field, column as _)]);
+        let array_data = struct_array.into_data();
+        let (array, schema) = to_ffi(&array_data).expect("to_ffi");
+        ArrowFFIData { array, schema }
+    }
+
+    #[test]
+    fn free_null_is_safe() {
+        // Mirrors the convention enforced by `free_scan_metadata_arrow_result`.
+        unsafe { free_arrow_ffi_data(std::ptr::null_mut()) };
+    }
+
+    #[test]
+    fn free_drops_box_and_invokes_release_callbacks() {
+        // Verifies the common path: kernel allocates, engine immediately frees. The Drop
+        // impls on FFI_ArrowArray / FFI_ArrowSchema invoke their release callbacks; this
+        // test passes if there is no double-free / leak under sanitizers.
+        let ptr = Box::into_raw(Box::new(make_arrow_ffi_data()));
+        unsafe { free_arrow_ffi_data(ptr) };
+    }
+
+    #[test]
+    fn free_after_consumer_imported_arrays() {
+        // Mirrors the read-table example flow: an engine imports the Arrow arrays via
+        // `from_ffi` (which moves the release callbacks out, leaving the inner structs in
+        // a release-callback-less state), then frees the now-empty box. The Drop impls
+        // become no-ops on the consumed structs, but the Box itself still needs reclaiming.
+        let mut data = make_arrow_ffi_data();
+        // Move the array+schema out via from_ffi -- this is what an engine does to import
+        // the data into its own arrow runtime. After this, `data.array` and `data.schema`
+        // have been replaced with empty stand-ins whose Drop impls are no-ops.
+        let array = std::mem::replace(&mut data.array, FFI_ArrowArray::empty());
+        let schema = std::mem::replace(&mut data.schema, FFI_ArrowSchema::empty());
+        // Consume them to release the underlying arrow allocations.
+        let _ = unsafe { arrow::array::ffi::from_ffi(array, &schema) }.expect("from_ffi");
+        // Now free the now-empty box.
+        let ptr = Box::into_raw(Box::new(data));
+        unsafe { free_arrow_ffi_data(ptr) };
+    }
 }

--- a/ffi/src/table_changes.rs
+++ b/ffi/src/table_changes.rs
@@ -293,26 +293,30 @@ pub unsafe extern "C" fn free_scan_table_changes_iter(
 
 /// Get next batch of data from the table changes iterator.
 ///
+/// Returns `Ok(non-null)` with a heap-allocated [`ArrowFFIData`] containing the next batch,
+/// `Ok(null)` when the iterator is exhausted, or `Err` on failure. A non-null pointer must
+/// be freed by the engine via [`crate::engine_data::free_arrow_ffi_data`] exactly once.
+///
 /// # Safety
 ///
-/// The iterator must be valid (returned by [table_changes_scan_execute]) and not yet freed by
-/// [`free_scan_table_changes_iter`].
+/// The iterator must be valid (returned by [`table_changes_scan_execute`]) and not yet freed
+/// by [`free_scan_table_changes_iter`].
 #[no_mangle]
 pub unsafe extern "C" fn scan_table_changes_next(
     data: Handle<SharedScanTableChangesIterator>,
-) -> ExternResult<ArrowFFIData> {
+) -> ExternResult<*mut ArrowFFIData> {
     let data = unsafe { data.as_ref() };
     scan_table_changes_next_impl(data).into_extern_result(&data.engine.as_ref())
 }
 
-fn scan_table_changes_next_impl(data: &ScanTableChangesIterator) -> DeltaResult<ArrowFFIData> {
+fn scan_table_changes_next_impl(data: &ScanTableChangesIterator) -> DeltaResult<*mut ArrowFFIData> {
     let mut data = data
         .data
         .lock()
         .map_err(|_| Error::generic("poisoned scan table changes iterator mutex"))?;
 
     let Some(data) = data.next().transpose()? else {
-        return Ok(ArrowFFIData::empty());
+        return Ok(std::ptr::null_mut());
     };
 
     let record_batch = data.try_into_record_batch()?;
@@ -320,10 +324,10 @@ fn scan_table_changes_next_impl(data: &ScanTableChangesIterator) -> DeltaResult<
     let batch_struct_array: StructArray = record_batch.into();
     let array_data: ArrayData = batch_struct_array.into_data();
     let (out_array, out_schema) = to_ffi(&array_data)?;
-    Ok(ArrowFFIData {
+    Ok(Box::into_raw(Box::new(ArrowFFIData {
         array: out_array,
         schema: out_schema,
-    })
+    })))
 }
 
 #[cfg(test)]
@@ -704,14 +708,16 @@ mod tests {
         let mut i: i32 = 0;
         loop {
             i += 1;
-            let data = ok_or_panic(unsafe {
+            let data_ptr = ok_or_panic(unsafe {
                 scan_table_changes_next(table_changes_scan_iter_result.shallow_copy())
             });
-            if data.array.is_empty() {
+            if data_ptr.is_null() {
                 break;
             }
-            let engine_data =
-                ok_or_panic(unsafe { get_engine_data(data.array, &data.schema, allocate_err) });
+            // Take ownership of the boxed ArrowFFIData; the inner array/schema are moved
+            // into get_engine_data which takes ownership of the FFI_ArrowArray.
+            let ArrowFFIData { array, schema } = *unsafe { Box::from_raw(data_ptr) };
+            let engine_data = ok_or_panic(unsafe { get_engine_data(array, &schema, allocate_err) });
             let record_batch = unsafe { engine_data.into_inner().try_into_record_batch() }?;
 
             println!("Batch ({i}) num rows {:?}", record_batch.num_rows());


### PR DESCRIPTION
## Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2430/files/213cca275fece2e8021600adadc5f1acf538cfc1..1c3353699a0e3c96dde64b5019233f4b28d72977) to review incremental changes.
- [stack/chiin/ffi-examples-fixup](https://github.com/delta-io/delta-kernel-rs/pull/2432) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2432/files)]
  - [**stack/chiin/ffi-scan-table-changes-abi**](https://github.com/delta-io/delta-kernel-rs/pull/2430) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2430/files/213cca275fece2e8021600adadc5f1acf538cfc1..1c3353699a0e3c96dde64b5019233f4b28d72977)]
    - [stack/chiin/ffi-new-examples](https://github.com/delta-io/delta-kernel-rs/pull/2431) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2431/files/1c3353699a0e3c96dde64b5019233f4b28d72977..970f51dc4ac19f24e579a781ab1bb4f10affe4ff)]

---------
scan_table_changes_next was declared as

    -> ExternResult<ArrowFFIData>

in Rust, but cbindgen renders the Ok variant of that return as `struct ArrowFFIData *ok`. That is an ABI mismatch: C callers dereferencing `res.ok` per the header would actually read the first pointer-sized bytes of the inline `ArrowFFIData` (the `length` field of FFI_ArrowArray) and treat them as a pointer.

Align the Rust signature with what the C header already claims by returning `*mut ArrowFFIData`, allocating via `Box::into_raw` (and returning `null_mut()` when the iterator is exhausted), matching the sibling `get_raw_arrow_data` / `scan_metadata_next_arrow` pattern.

Add `free_arrow_ffi_data` in engine_data.rs so engines have a proper cleanup function for any `*mut ArrowFFIData` the kernel allocates -- including the existing `get_raw_arrow_data` path.

Update the read-table example to use the new free function instead of relying on plain `free()` on a Box::into_raw pointer (which happens to work today because Rust's global allocator falls through to the system malloc, but is formally implementation-defined).

The Rust-side iterator test that exercised scan_table_changes_next is updated to consume the returned pointer via Box::from_raw before handing the inner array/schema to get_engine_data.

This is a breaking change to the FFI: consumers of scan_table_changes_next must switch from value-style access to pointer access and call free_arrow_ffi_data on non-null results.

## What changes are proposed in this pull request?

<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

## How was this change tested?
