### PR TITLE
fix: correct inaccuracies in ffi examples

### DIFF
--- a/ffi/examples/delta-kernel-unity-catalog-example/README.md
+++ b/ffi/examples/delta-kernel-unity-catalog-example/README.md
@@ -1,35 +1,43 @@
 delta-kernel-unity-catalog example
 ===================================
 
-Simple example to show how to use the delta-kernel-unity-catalog ffi features
+Simple example showing how to use the delta-kernel-unity-catalog FFI surface -- namely
+`get_uc_commit_client`, `get_uc_committer`, and `transaction_with_committer` -- to run a
+commit against a catalog-managed table using a custom commit callback.
 
 # Building
 
-This example is built with [cmake]. Instructions below assume you start in the directory containing this README.
+This example is built with [cmake]. Instructions below assume you start in the directory
+containing this README.
 
-Note that prior to building these examples you must build `delta_kernel_ffi` with all feature enabled (see [the FFI readme] for details). TLDR:
+Before building this example, you must build `delta_kernel_ffi` with **all features** enabled
+so that the Unity Catalog bindings are present in `delta_kernel_ffi.h`. See
+[the FFI readme](../../README.md) for details. TLDR:
+
 ```bash
 # from repo root
 $ cargo build -p delta_kernel_ffi [--release] --all-features
-# from ffi/ dir
+# or, from the ffi/ dir
 $ cargo build [--release] --all-features
-```
-
-There are two configurations that can currently be configured in cmake:
-```bash
-# turn on VERBOSE mode (default is off) - print more diagnostics
-$ cmake -DVERBOSE=yes ..
-# turn off PRINT_DATA (default is on) - see below
-$ cmake -DPRINT_DATA=no ..
 ```
 
 ## Linux / MacOS
 
-Most likely something like this should work:
 ```
 $ mkdir build
 $ cd build
 $ cmake ..
 $ make
-$ ./delta_kernel_unity_catalog_example [path/to/table]
+$ ./delta_kernel_unity_catalog_example [path/to/catalog-managed-table]
 ```
+
+The included ctest (`test_delta_kernel_unity_catalog_ffi`) runs the binary against the
+catalog-managed fixture at
+`delta-kernel-unity-catalog/tests/data/catalog_managed_0`, so you generally don't need to
+supply your own table to see it work:
+
+```
+$ ctest --output-on-failure
+```
+
+[cmake]: https://cmake.org/

--- a/ffi/examples/read-table/read_table.c
+++ b/ffi/examples/read-table/read_table.c
@@ -369,7 +369,10 @@ int main(int argc, char* argv[])
     return -1;
   }
 
-  // an example of using a builder to set options when building an engine
+  // Example of using the builder to set object-store options before building the engine. The
+  // keys accepted here come from object_store's configuration vocabulary (e.g. "aws_region",
+  // "aws_access_key_id"). They are object-store-specific and only meaningful when the table URL
+  // points at that backend -- for a local file:// table the setters have no effect.
   EngineBuilder* engine_builder = engine_builder_res.ok;
   if (!set_builder_opt(engine_builder, "aws_region", "us-west-2")) {
     return -1;
@@ -384,8 +387,8 @@ int main(int argc, char* argv[])
   //   get_default_engine(table_path_slice, NULL);
 
   if (engine_res.tag != OkHandleSharedExternEngine) {
-    print_error("File to get engine", (Error*)engine_builder_res.err);
-    free_error((Error*)engine_builder_res.err);
+    print_error("Failed to get engine", (Error*)engine_res.err);
+    free_error((Error*)engine_res.err);
     return -1;
   }
 
@@ -395,12 +398,16 @@ int main(int argc, char* argv[])
   if (snapshot_builder_res.tag != OkHandleMutableFfiSnapshotBuilder) {
     print_error("Failed to get snapshot builder.", (Error*)snapshot_builder_res.err);
     free_error((Error*)snapshot_builder_res.err);
+    free_engine(engine);
     return -1;
   }
+  // snapshot_builder_build consumes the builder handle whether it succeeds or fails, so there
+  // is nothing to free for the builder here.
   ExternResultHandleSharedSnapshot snapshot_res = snapshot_builder_build(snapshot_builder_res.ok);
   if (snapshot_res.tag != OkHandleSharedSnapshot) {
     print_error("Failed to create snapshot.", (Error*)snapshot_res.err);
     free_error((Error*)snapshot_res.err);
+    free_engine(engine);
     return -1;
   }
 
@@ -477,6 +484,14 @@ int main(int argc, char* argv[])
   if (data_iter_res.tag != OkHandleSharedScanMetadataIterator) {
     print_error("Failed to construct scan metadata iterator.", (Error*)data_iter_res.err);
     free_error((Error*)data_iter_res.err);
+    free_scan(scan);
+    free_schema(logical_schema);
+    free_schema(physical_schema);
+    free_snapshot(snapshot);
+    free_engine(engine);
+    free(context.table_root);
+    free(scan_table_path);
+    free_partition_list(context.partition_cols);
     return -1;
   }
 
@@ -484,6 +499,7 @@ int main(int argc, char* argv[])
 
   print_diag("\nIterating scan metadata\n");
 
+  int exit_code = 0;
   // iterate scan files
   for (;;) {
     ExternResultbool ok_res =
@@ -491,7 +507,8 @@ int main(int argc, char* argv[])
     if (ok_res.tag != Okbool) {
       print_error("Failed to iterate scan metadata.", (Error*)ok_res.err);
       free_error((Error*)ok_res.err);
-      return -1;
+      exit_code = -1;
+      break;
     } else if (!ok_res.ok) {
       print_diag("Scan metadata iterator done\n");
       break;
@@ -516,5 +533,5 @@ int main(int argc, char* argv[])
   free(scan_table_path);
   free_partition_list(context.partition_cols);
 
-  return 0;
+  return exit_code;
 }

--- a/ffi/examples/visit-expression/CMakeLists.txt
+++ b/ffi/examples/visit-expression/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(visit_expression PUBLIC delta_kernel_ffi)
 target_compile_options(visit_expression PUBLIC)
 
 if(MSVC)
-  target_compile_options(read_table PRIVATE /W4 /WX)
+  target_compile_options(visit_expression PRIVATE /W4 /WX)
 else()
   # no-strict-prototypes because arrow headers have fn defs without prototypes
   target_compile_options(visit_expression PRIVATE -Wall -Wextra -Wpedantic -Werror -Wno-strict-prototypes -g -fsanitize=address)


### PR DESCRIPTION
## Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2432/files) to review incremental changes.
- [**stack/chiin/ffi-examples-fixup**](https://github.com/delta-io/delta-kernel-rs/pull/2432) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2432/files)]
  - [stack/chiin/ffi-scan-table-changes-abi](https://github.com/delta-io/delta-kernel-rs/pull/2430) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2430/files/213cca275fece2e8021600adadc5f1acf538cfc1..1c3353699a0e3c96dde64b5019233f4b28d72977)]
    - [stack/chiin/ffi-new-examples](https://github.com/delta-io/delta-kernel-rs/pull/2431) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2431/files/1c3353699a0e3c96dde64b5019233f4b28d72977..970f51dc4ac19f24e579a781ab1bb4f10affe4ff)]

---------
- read-table: fix wrong error handle in builder_build failure branch (was freeing engine_builder_res.err twice and not reporting the real engine build error); plug resource leaks on snapshot-builder, snapshot, and scan-metadata-iter error paths; route scan_metadata_next errors through the normal cleanup block; clarify that the set_builder_opt keys are object-store-specific and no-op for local file:// tables.
- visit-expression: MSVC compile options were targeting read_table instead of visit_expression, so /W4 /WX never applied on Windows builds.
- delta-kernel-unity-catalog-example: rewrite README to accurately describe the feature flags required for this example (all-features) and drop copy/pasted PRINT_DATA/VERBOSE toggles that the CMakeLists does not actually expose; add a pointer to the catalog_managed_0 fixture used by the ctest.

## What changes are proposed in this pull request?

<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

## How was this change tested?
existing test cases suffice