### PR TITLE
fix: Work around Azure/OneLake list_with_offset edge case

### DIFF
--- a/kernel/src/log_segment_files.rs
+++ b/kernel/src/log_segment_files.rs
@@ -908,4 +908,98 @@ mod list_log_files_with_log_tail_tests {
         // max_published_version reflects all published commits seen (filesystem 0-5 + log_tail 6-10)
         assert_eq!(max_pub, Some(10));
     }
+
+    /// Mimics Azure/OneLake's buggy `list_with_offset`: when `list_from` is called with a
+    /// "bare offset" path (last segment is all digits with no extension, e.g.
+    /// `_delta_log/00000000000000000005`), the underlying service treats it as a prefix
+    /// boundary and excludes any file whose path starts with that offset string —
+    /// notably `00000000000000000005.checkpoint.parquet`. For directory-like paths
+    /// (ending in `/`) the handler behaves correctly.
+    struct OneLakeMockStorageHandler {
+        files: Vec<FileMeta>,
+    }
+
+    impl StorageHandler for OneLakeMockStorageHandler {
+        fn list_from(
+            &self,
+            path: &Url,
+        ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<FileMeta>>>> {
+            let path_str = path.as_str().to_string();
+            let last_segment = path
+                .path_segments()
+                .and_then(|mut s| s.next_back())
+                .unwrap_or("");
+            let is_bare_offset = !last_segment.is_empty()
+                && !last_segment.contains('.')
+                && last_segment.chars().all(|c| c.is_ascii_digit());
+
+            let mut out: Vec<FileMeta> = self
+                .files
+                .iter()
+                .filter(|f| {
+                    let s = f.location.as_str();
+                    if is_bare_offset {
+                        s > path_str.as_str() && !s.starts_with(&path_str)
+                    } else {
+                        s >= path_str.as_str()
+                    }
+                })
+                .cloned()
+                .collect();
+            out.sort_by(|a, b| a.location.as_str().cmp(b.location.as_str()));
+            Ok(Box::new(out.into_iter().map(Ok)))
+        }
+        fn read_files(
+            &self,
+            _: Vec<crate::FileSlice>,
+        ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<bytes::Bytes>>>> {
+            panic!("read_files should not be called during listing");
+        }
+        fn put(&self, _: &Url, _: bytes::Bytes, _: bool) -> DeltaResult<()> {
+            panic!("put should not be called during listing");
+        }
+        fn copy_atomic(&self, _: &Url, _: &Url) -> DeltaResult<()> {
+            panic!("copy_atomic should not be called during listing");
+        }
+        fn head(&self, _: &Url) -> DeltaResult<FileMeta> {
+            panic!("head should not be called during listing");
+        }
+    }
+
+    fn file_meta(url: &str) -> FileMeta {
+        FileMeta {
+            location: Url::parse(url).unwrap(),
+            last_modified: 0,
+            size: 100,
+        }
+    }
+
+    /// Regression for [#2433]: Azure/OneLake's `list_with_offset` treated a bare offset
+    /// path like `_delta_log/00000000000000000005` as a prefix boundary, causing the
+    /// matching `00000000000000000005.checkpoint.parquet` to be omitted. Listing must
+    /// work around this — listing from the directory root and filtering by start_version.
+    ///
+    /// [#2433]: https://github.com/delta-io/delta-kernel-rs/issues/2433
+    #[test]
+    fn test_list_with_onelake_offset_prefix_bug() {
+        let log_root = Url::parse("memory:///_delta_log/").unwrap();
+        let mut files: Vec<FileMeta> = (0u64..=5)
+            .map(|v| file_meta(&format!("memory:///_delta_log/{v:020}.json")))
+            .collect();
+        files.push(file_meta(
+            "memory:///_delta_log/00000000000000000005.checkpoint.parquet",
+        ));
+
+        let storage = OneLakeMockStorageHandler { files };
+        let result =
+            LogSegmentFiles::list(&storage, &log_root, vec![], Some(5), None).unwrap();
+
+        // Pre-fix: list_from was called with `memory:///_delta_log/00000000000000000005`,
+        // the mock would drop the .checkpoint.parquet file, and checkpoint_parts would be empty.
+        assert_eq!(result.checkpoint_parts.len(), 1);
+        assert_eq!(result.checkpoint_parts[0].version, 5);
+        assert!(result.checkpoint_parts[0].is_checkpoint());
+        // The commit at version 5 is preserved as latest_commit_file across the checkpoint flush.
+        assert_eq!(result.latest_commit_file.as_ref().unwrap().version, 5);
+    }
 }

--- a/kernel/src/log_segment_files.rs
+++ b/kernel/src/log_segment_files.rs
@@ -56,7 +56,14 @@ fn list_from_storage(
     start_version: Version,
     end_version: Version,
 ) -> DeltaResult<impl Iterator<Item = DeltaResult<ParsedLogPath>>> {
-    let start_from = log_root.join(&format!("{start_version:020}"))?;
+    // List from the directory root instead of a specific version offset.
+    // This works around an issue in Azure/OneLake's list_with_offset where
+    // an offset path like _delta_log/00000000000000000643 (no extension) is treated
+    // as a prefix boundary, incorrectly excluding files at that exact version.
+    // By listing the entire directory and filtering by start_version below,
+    // we avoid the edge case and work correctly regardless of table structure.
+    // See: https://github.com/delta-io/delta-kernel-rs/issues/2433
+    let start_from = log_root.clone();
     let files = storage
         .list_from(&start_from)?
         .map(|meta| ParsedLogPath::try_from(meta?))
@@ -66,7 +73,7 @@ fn list_from_storage(
         // normal `version.crc` files which are listed + captured normally. Additionally
         // we likely aren't even 'seeing' these files since lexicographically the string
         // "." comes before the string "0".
-        .filter_map_ok(|path_opt| path_opt.filter(|p| p.should_list()))
+        .filter_map_ok(move |path_opt| path_opt.filter(|p| p.should_list() && p.version >= start_version))
         .take_while(move |path_res| match path_res {
             // discard any path with too-large version; keep errors
             Ok(path) => path.version <= end_version,


### PR DESCRIPTION
## Summary

Fixes #2433 - OneLake Delta table reading regression in delta-kernel-rs 0.21

When listing Delta log files, the code constructs an offset path like `_delta_log/00000000000000000643` (a bare version number without file extension). This offset path doesn't exist as an actual file.

Azure/OneLake's `list_with_offset` implementation treats such bare offset paths as prefix boundaries rather than pure lexicographic strings. When a file like `00000000000000000643.checkpoint.parquet` exists, Azure incorrectly excludes it from results.

This causes tables with `_last_checkpoint` hints to fail with:
```
Invalid Checkpoint: Had a _last_checkpoint hint but didn't find any checkpoints
```

## Changes

**File:** `kernel/src/log_segment_files.rs` → `list_from_storage()` function

1. List from the log root directory instead of a versioned offset path
2. Add `start_version` filter to exclude files below the requested version
3. Existing `end_version` filter still correctly stops at the upper bound

## Why This Works

- Tables WITH checkpoints: All files are listed, checkpoint is found
- Tables WITHOUT checkpoints (version 0): All files listed from directory, filtered to >= 0
- Tables without version 0 (cleaned up): All files listed, filtered to >= whatever start_version is

## Impact

This fix affects DuckDB, delta-rs, and all other engines using delta-kernel-rs 0.21 when querying Delta tables on Azure/OneLake.

## Testing

✅ All 9 existing log_segment_files tests pass

Edit : the code was generated by opus 4.7