### PR TITLE
fix: decode \u00XX escape sequences when parsing Binary partition values

### DIFF
--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -703,7 +703,13 @@ impl PrimitiveType {
 
         match self {
             String => Ok(Scalar::String(raw.to_string())),
-            Binary => Ok(Scalar::Binary(raw.to_string().into_bytes())),
+            // Binary partition values are serialized in the Delta log as a sequence of `\u00XX`
+            // escape groups, one per byte, per the partition-value serialization rules:
+            // https://github.com/delta-io/delta/blob/master/PROTOCOL.md#partition-value-serialization
+            // Decode the escape sequences back to raw bytes instead of returning the UTF-8 bytes
+            // of the literal escape string (which would double-encode the value for any downstream
+            // consumer that treats the result as real binary data).
+            Binary => parse_binary_partition_value(raw).map(Scalar::Binary),
             Byte => self.parse_str_as_scalar(raw, Scalar::Byte),
             Decimal(dtype) => Self::parse_decimal(raw, *dtype),
             Short => self.parse_str_as_scalar(raw, Scalar::Short),
@@ -818,6 +824,29 @@ impl PrimitiveType {
         };
         Ok(Scalar::Decimal(DecimalData::try_new(int, dtype)?))
     }
+}
+
+/// Decode a Binary partition value stored in the `\u00XX`-escaped format mandated by the Delta
+/// Lake protocol. Each byte is represented by exactly six ASCII characters: a backslash, the
+/// letter `u`, the literal `00`, and two hexadecimal digits (upper- or lower-case).
+///
+/// See [the protocol](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#partition-value-serialization).
+fn parse_binary_partition_value(raw: &str) -> Result<Vec<u8>, Error> {
+    let parse_err = || Error::ParseError(raw.to_string(), DataType::BINARY);
+    let bytes = raw.as_bytes();
+    if !bytes.len().is_multiple_of(6) {
+        return Err(parse_err());
+    }
+    let mut out = Vec::with_capacity(bytes.len() / 6);
+    for chunk in bytes.chunks_exact(6) {
+        if &chunk[..4] != b"\\u00" {
+            return Err(parse_err());
+        }
+        let hex = std::str::from_utf8(&chunk[4..6]).map_err(|_| parse_err())?;
+        let byte = u8::from_str_radix(hex, 16).map_err(|_| parse_err())?;
+        out.push(byte);
+    }
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -1324,6 +1353,35 @@ mod tests {
             assert!(data.is_empty());
         } else {
             panic!("Expected Binary scalar");
+        }
+    }
+
+    #[test]
+    fn test_parse_binary_partition_value() {
+        // Per the Delta protocol a Binary partition value serializes each byte as `\u00XX`.
+        let round_trip = |bytes: &[u8]| {
+            let encoded: String = bytes.iter().map(|b| format!("\\u{b:04X}")).collect();
+            let scalar = PrimitiveType::Binary.parse_scalar(&encoded).unwrap();
+            assert_eq!(scalar, Scalar::Binary(bytes.to_vec()));
+        };
+
+        round_trip(b"\x00\x01\x7F\x80\xFF");
+        round_trip(&[0x23, 0xE8, 0x07, 0xDE, 0x56, 0x50, 0x9B, 0x48, 0xA1, 0x5F]);
+
+        // Lower-case hex digits are accepted too.
+        let scalar = PrimitiveType::Binary.parse_scalar("\\u00ab\\u00cd").unwrap();
+        assert_eq!(scalar, Scalar::Binary(vec![0xAB, 0xCD]));
+
+        // An empty input still maps to Null (shared behavior across all primitive types).
+        let empty = PrimitiveType::Binary.parse_scalar("").unwrap();
+        assert!(empty.is_null());
+
+        // Malformed inputs are rejected.
+        for bad in ["\\u0041X", "\\u00ZZ", "\\u0041\\", "\\u00\\u00ab", "partial"] {
+            assert!(
+                PrimitiveType::Binary.parse_scalar(bad).is_err(),
+                "expected parse error for {bad:?}"
+            );
         }
     }
 }


### PR DESCRIPTION
The Delta Lake protocol requires Binary partition values to be serialized as a sequence of `\u00XX` escape groups, one per byte:

  https://github.com/delta-io/delta/blob/master/PROTOCOL.md#partition-value-serialization

`PrimitiveType::parse_scalar` was treating that escape string as raw binary data (`raw.to_string().into_bytes()`), so downstream consumers that go back through `Scalar::serialize()` (e.g. `EagerSnapshot::file_views()`, the DataFusion table provider) ended up with a doubly-escaped value instead of the original bytes. Round-trip the escape format on parse so the resulting `Scalar::Binary` actually contains the original bytes.

We currently have to [work this around](https://github.com/pathwaycom/pathway/blob/main/src/connectors/data_lake/delta.rs#L886-L907) when binary partition columns are queried.

## What changes are proposed in this pull request?

`PrimitiveType::parse_scalar` decodes every primitive type from its Delta-log string form, but the Binary branch was simply wrapping the UTF-8 bytes of the literal escape string:

```rust
  Binary => Ok(Scalar::Binary(raw.to_string().into_bytes())),
```

The https://github.com/delta-io/delta/blob/master/PROTOCOL.md#partition-value-serialization requires Binary values to be stored as a sequence of `\u00XX` escape groups, one per byte — so for a two-byte partition value `[0x23, 0xE8]`, the log contains the 12-character string `\u0023\u00E8`, and `parse_scalar` was returning `Scalar::Binary([0x5C, 0x75, 0x30, 0x30, 0x32, 0x33, 0x5C, 0x75, 0x30, 0x30, 0x45, 0x38])` — the bytes of the escape string, not the original value.

This corrupts every downstream consumer that keeps the result as `Scalar::Binary`. In particular, `Scalar::serialize()` (in deltalake-core's `ScalarExt`) re-escapes those bytes, producing a doubly-escaped partition value that surfaces through `EagerSnapshot::file_views()`, the DataFusion table provider, and any `add_action()` round-trip.

This PR:

- Replaces the `Binary` arm with a call to a new `parse_binary_partition_value(raw)` helper that walks the input in six-character chunks, requires each chunk to match `\u00XX` (upper- or lower-case hex), and returns the decoded `Vec<u8>`; malformed input produces a standard `Error::ParseError` for the `Binary` type. Empty input keeps its existing meaning (`Scalar::Null`).
- Adds an inline comment pointing at the protocol section so the invariant doesn't get re-broken.

  Net diff: `kernel/src/expressions/scalars.rs` only; no public API changes.

## How was this change tested?

Added `test_parse_binary_partition_value` in the existing `expressions::scalars::tests` module, covering:

- Round-trip encode/decode for non-trivial byte payloads including the boundary values `0x00`, `0x7F`, `0x80`, `0xFF`, and a 10-byte random-looking payload that reproduces the Delta protocol's expected form.
- Acceptance of lower-case hex digits (`\u00ab\u00cd`).
- Empty string still parses to `Scalar::Null(Binary)` — the behavior shared by every primitive type and asserted via `scalar.is_null()`.
- Explicit rejection of malformed inputs: trailing junk (`\u0041X`), non-hex digits (`\u00ZZ`), truncated groups (`\u0041\`, `\u00\u00ab`), and bare strings with no escape prefix at all (partial).

Verified locally:

```
$ cargo test -p delta_kernel --lib expressions::scalars
test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 2288 filtered out
```
