### PR TITLE
fix: treat signed zero as equal in Arrow comparisons

### DIFF
--- a/kernel/benches/expression_bench.rs
+++ b/kernel/benches/expression_bench.rs
@@ -12,16 +12,25 @@
 //! git checkout your-branch
 //! cargo bench --bench expression_bench -- --baseline main
 //! ```
+//!
+//! Filter with `float_predicates` for signed-zero comparisons or `dictionary_nullable` to compare
+//! dictionary decoding with plain arrays containing the same logical values.
 
 use std::hint::black_box;
 use std::sync::Arc;
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use delta_kernel::arrow::array::{
-    ArrayRef, BooleanBuilder, Float64Builder, Int32Builder, StringBuilder, StructArray,
+use criterion::measurement::WallTime;
+use criterion::{
+    criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion, Throughput,
 };
-use delta_kernel::arrow::datatypes::{DataType, Field, Fields};
-use delta_kernel::engine::arrow_expression::evaluate_expression::to_json;
+use delta_kernel::arrow::array::{
+    ArrayRef, BooleanBuilder, DictionaryArray, Float32Array, Float64Array, Float64Builder,
+    Int32Array, Int32Builder, RecordBatch, StringBuilder, StructArray,
+};
+use delta_kernel::arrow::compute::cast;
+use delta_kernel::arrow::datatypes::{DataType, Field, Fields, Int32Type};
+use delta_kernel::engine::arrow_expression::evaluate_expression::{evaluate_predicate, to_json};
+use delta_kernel::expressions::{col, lit, Expression};
 
 /// Creates a test struct array with realistic data for benchmarking.
 fn create_test_struct_array(num_rows: usize) -> StructArray {
@@ -172,5 +181,136 @@ fn to_json_benchmark(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, to_json_benchmark);
+macro_rules! float_predicate_benchmark {
+    ($name:ident, $float:ty, $array:ty) => {
+        fn $name(c: &mut Criterion) {
+            let mut group = c.benchmark_group(format!("float_predicates/{}", stringify!($float)));
+            let special_values: [$float; 17] = [
+                -0.0,
+                0.0,
+                -1.0,
+                1.0,
+                <$float>::INFINITY,
+                <$float>::NEG_INFINITY,
+                <$float>::MIN,
+                <$float>::MAX,
+                <$float>::MIN_POSITIVE,
+                -<$float>::MIN_POSITIVE,
+                <$float>::from_bits(1),
+                -<$float>::from_bits(1),
+                <$float>::NAN,
+                -<$float>::NAN,
+                <$float>::from_bits(<$float>::NAN.to_bits() + 1),
+                <$float>::from_bits(<$float>::INFINITY.to_bits() + 1),
+                -<$float>::from_bits(<$float>::INFINITY.to_bits() + 1),
+            ];
+            for special in [false, true] {
+                let dataset = if special {
+                    "nullable_special"
+                } else {
+                    "finite"
+                };
+                for num_rows in [4_096, 65_536] {
+                    let mut seed = 0x3141592653589793_u64;
+                    let mut make_array = |offset: usize, null_every: usize| -> ArrayRef {
+                        let values = (0..num_rows)
+                            .map(|index| {
+                                let value = if special && index % 4 == 0 {
+                                    special_values[(index / 4 + offset) % special_values.len()]
+                                } else {
+                                    seed ^= seed << 13;
+                                    seed ^= seed >> 7;
+                                    seed ^= seed << 17;
+                                    (seed % 200_001) as $float - 100_000.0
+                                };
+                                if special && index % null_every == 0 {
+                                    None
+                                } else {
+                                    Some(value)
+                                }
+                            })
+                            .collect::<Vec<_>>();
+                        Arc::new(<$array>::from(values))
+                    };
+                    let batch = RecordBatch::try_from_iter([
+                        ("left", make_array(0, 7)),
+                        ("right", make_array(1, 11)),
+                    ])
+                    .unwrap();
+                    bench_float_predicates(&mut group, dataset, &batch, lit(0.0 as $float));
+                }
+            }
+
+            let values = special_values
+                .into_iter()
+                .map(Some)
+                .chain([None])
+                .collect::<Vec<_>>();
+            let (plain, dictionary) = float_dictionary_batches(Arc::new(<$array>::from(values)));
+            for (representation, batch) in [("plain", plain), ("encoded", dictionary)] {
+                bench_float_predicates(
+                    &mut group,
+                    &format!("dictionary_nullable/{representation}"),
+                    &batch,
+                    lit(0.0 as $float),
+                );
+            }
+            group.finish();
+        }
+    };
+}
+
+float_predicate_benchmark!(float32_predicate_benchmark, f32, Float32Array);
+float_predicate_benchmark!(float64_predicate_benchmark, f64, Float64Array);
+
+fn bench_float_predicates(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    name: &str,
+    batch: &RecordBatch,
+    literal: Expression,
+) {
+    group.throughput(Throughput::Elements(batch.num_rows() as u64));
+    for (shape, right) in [("literal", literal), ("column", col!("right"))] {
+        for (operation, predicate) in [
+            ("eq", col!("left").eq(right.clone())),
+            ("lt", col!("left").lt(right.clone())),
+            ("distinct", col!("left").distinct(right)),
+        ] {
+            group.bench_function(
+                BenchmarkId::new(format!("{name}/{shape}/{operation}"), batch.num_rows()),
+                |b| {
+                    b.iter(|| {
+                        evaluate_predicate(black_box(&predicate), black_box(batch), false).unwrap()
+                    })
+                },
+            );
+        }
+    }
+}
+
+fn float_dictionary_batches(values: ArrayRef) -> (RecordBatch, RecordBatch) {
+    let make_dictionary = |offset: usize, null_every: usize| -> ArrayRef {
+        let keys = Int32Array::from_iter((0..65_536).map(|index| {
+            (index % null_every != 0).then_some(((index + offset) % values.len()) as i32)
+        }));
+        Arc::new(DictionaryArray::<Int32Type>::try_new(keys, values.clone()).unwrap())
+    };
+    let left = make_dictionary(0, 7);
+    let right = make_dictionary(1, 11);
+    // Decode outside timing so plain and encoded cases differ only in their input representation.
+    let plain = RecordBatch::try_from_iter([
+        ("left", cast(&left, values.data_type()).unwrap()),
+        ("right", cast(&right, values.data_type()).unwrap()),
+    ])
+    .unwrap();
+    let dictionary = RecordBatch::try_from_iter([("left", left), ("right", right)]).unwrap();
+    (plain, dictionary)
+}
+
+criterion_group!(
+    benches,
+    to_json_benchmark,
+    float32_predicate_benchmark,
+    float64_predicate_benchmark
+);
 criterion_main!(benches);

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -590,24 +590,28 @@ fn arrow_convert_to_view_type(vals: Arc<dyn Array>) -> DeltaResult<Arc<dyn Array
     }
 }
 
-/// Compares two float values with `-0.0 == 0.0` (the actual bug fix) while preserving Arrow's
-/// existing NaN ordering (`NaN` greater than all non-NaN values). We need custom NaN handling
-/// here because bypassing Arrow's kernels also loses its NaN-as-greatest behavior. Rust's
-/// [`PartialOrd`] treats NaN as incomparable, so we restore Arrow/Spark's NaN semantics
-/// explicitly.
-///
-/// WARNING: Any new code path that compares float arrays MUST route through
-/// [`float_sql_cmp`] or [`float_sql_distinct`] (or use the scalar path via
-/// `logical_partial_cmp`). Calling Arrow's `cmp` kernels (`eq`, `lt`, `gt`, etc.) directly
-/// on float arrays will reintroduce the `-0.0 != 0.0` bug because those kernels use total
-/// ordering. The scalar path already handles this correctly for partition pruning and
-/// parquet row group skipping; only the Arrow expression evaluator needs this workaround.
+// === Float SQL comparison helpers ===
+//
+// Arrow's `cmp` kernels (`eq`, `lt`, `gt`, etc.) use total ordering for floats: `-0.0 < 0.0`
+// and NaN sorts greatest. SQL semantics require `-0.0 == 0.0` while keeping Spark's
+// NaN-as-greatest with `NaN == NaN`. The helpers below implement that hybrid ordering.
+//
+// Any new code path that compares float arrays via the Arrow expression evaluator should
+// route through [`float_sql_cmp`] / [`float_sql_distinct`]. Calling Arrow's `cmp` kernels
+// directly on float arrays will reintroduce the `-0.0 != 0.0` bug. The `IN` predicate path
+// (`eval_in`) currently uses Arrow's `in_list`, which does Rust IEEE `PartialEq` per element:
+// `-0.0 == 0.0` is correct, but `NaN IN [NaN]` is `false` (not `true`). Aligning IN with
+// these helpers is tracked separately. The scalar path (`Scalar::logical_partial_cmp`)
+// uses `partial_cmp`: correct for `-0.0`, but returns `None` for NaN rather than treating
+// NaN as greatest. That divergence is also tracked separately and is safe today because
+// both paths conservatively keep files when NaN is present.
+
+/// Returns the SQL ordering of two floats: `-0.0 == 0.0`, `NaN == NaN`, and NaN sorts
+/// greater than every non-NaN value (matching Spark's `SQLOrderingUtil.compareDoubles`).
 fn sql_float_cmp<F: PartialOrd>(a: F, b: F) -> Ordering {
     match a.partial_cmp(&b) {
         Some(ord) => ord,
-        // partial_cmp returns None only when at least one operand is NaN.
-        // NaN sorts greater than all non-NaN values, and NaN == NaN.
-        // Detect which operand is NaN: x.partial_cmp(&x) is None iff x is NaN.
+        // partial_cmp(&x) is None iff x is NaN; this is the generic equivalent of !x.is_nan().
         None => match (a.partial_cmp(&a).is_some(), b.partial_cmp(&b).is_some()) {
             (true, false) => Ordering::Less,
             (false, true) => Ordering::Greater,
@@ -616,14 +620,48 @@ fn sql_float_cmp<F: PartialOrd>(a: F, b: F) -> Ordering {
     }
 }
 
-/// Element-wise float comparison using [`sql_float_cmp`]. Compares all value pairs unconditionally
-/// against the expected [`Ordering`](std::cmp::Ordering), then unions the null masks from both
-/// arrays. This avoids per-element null branching (which prevents vectorization). The `inverted`
-/// flag flips results (for representing `>=`, `<=`, and `!=` as inverted `<`, `>`, and `=`).
+/// Element-wise float comparison using [`sql_float_cmp`].
+///
+/// # Parameters
+/// - `left`, `right`: input arrays of equal length.
+/// - `ord`: the [`Ordering`] result that produces `true` for each row (e.g. [`Ordering::Less`] for
+///   `<`, [`Ordering::Equal`] for `=`).
+/// - `inverted`: when true, flips each output bit. Used to express `>=` as `NOT <`, `<=` as `NOT
+///   >`, and `!=` as `NOT =`.
+///
+/// Returns a [`BooleanArray`] whose null mask is the union of the input null masks. Values
+/// are compared unconditionally; null branching only happens once at the end (single
+/// `NullBuffer::union`) rather than per element.
 fn float_sql_cmp<T: ArrowPrimitiveType>(
     left: &PrimitiveArray<T>,
     right: &PrimitiveArray<T>,
     ord: Ordering,
+    inverted: bool,
+) -> BooleanArray
+where
+    T::Native: PartialOrd,
+{
+    let mut builder = BooleanBufferBuilder::new(left.len());
+    for (l, r) in left.values().iter().zip(right.values().iter()) {
+        builder.append((sql_float_cmp(*l, *r) == ord) != inverted);
+    }
+    let nulls = NullBuffer::union(left.nulls(), right.nulls());
+    BooleanArray::new(builder.finish(), nulls)
+}
+
+/// Like [`float_sql_cmp`], but for `IS DISTINCT FROM` / `IS NOT DISTINCT FROM` which treat
+/// nulls as comparable values: `NULL IS NOT DISTINCT FROM NULL` is true.
+///
+/// # Parameters
+/// - `left`, `right`: input arrays of equal length.
+/// - `inverted`: when false, computes `IS DISTINCT FROM` (true for unequal values or null
+///   mismatch). When true, computes `IS NOT DISTINCT FROM`.
+///
+/// Unlike [`float_sql_cmp`], this inspects nulls per element since null equality is part of
+/// the result rather than something to propagate. Output never contains nulls.
+fn float_sql_distinct<T: ArrowPrimitiveType>(
+    left: &PrimitiveArray<T>,
+    right: &PrimitiveArray<T>,
     inverted: bool,
 ) -> BooleanArray
 where
@@ -634,43 +672,43 @@ where
     let right_vals = right.values();
     let mut builder = BooleanBufferBuilder::new(len);
     for i in 0..len {
-        builder.append((sql_float_cmp(left_vals[i], right_vals[i]) == ord) != inverted);
-    }
-    let nulls = NullBuffer::union(left.nulls(), right.nulls());
-    BooleanArray::new(builder.finish(), nulls)
-}
-
-/// Like [`float_sql_cmp`], but for `DISTINCT` / `NOT DISTINCT` which treat nulls as comparable
-/// values: `NULL IS NOT DISTINCT FROM NULL` is true. When `negated` is false, computes
-/// `IS DISTINCT FROM` (true for unequal values or null mismatch). When true, computes
-/// `IS NOT DISTINCT FROM`. Unlike [`float_sql_cmp`], this must inspect nulls per element since
-/// null equality is part of the result (not just propagated).
-fn float_sql_distinct<T: ArrowPrimitiveType>(
-    left: &PrimitiveArray<T>,
-    right: &PrimitiveArray<T>,
-    negated: bool,
-) -> BooleanArray
-where
-    T::Native: PartialOrd,
-{
-    let len = left.len();
-    let left_vals = left.values();
-    let right_vals = right.values();
-    let mut builder = BooleanBufferBuilder::new(len);
-    for i in 0..len {
-        let l_null = left.is_null(i);
-        let r_null = right.is_null(i);
-        let result = match (l_null, r_null) {
+        // SQL: NULL is not distinct from NULL; NULL is distinct from any value.
+        let result = match (left.is_null(i), right.is_null(i)) {
             (false, false) => {
-                (sql_float_cmp(left_vals[i], right_vals[i]) != Ordering::Equal) != negated
+                (sql_float_cmp(left_vals[i], right_vals[i]) != Ordering::Equal) != inverted
             }
-            (true, true) => negated, // NULL vs NULL: not distinct
-            _ => !negated,           // NULL vs value: distinct
+            (true, true) => inverted,
+            _ => !inverted,
         };
         builder.append(result);
     }
-    // DISTINCT never produces nulls (all outputs are non-null booleans)
     BooleanArray::new(builder.finish(), None)
+}
+
+/// Dispatches a float-array comparison to [`float_sql_cmp`] or [`float_sql_distinct`].
+/// Caller already established `op` is one of `Equal`, `LessThan`, `GreaterThan`, or
+/// `Distinct`; `In` is handled separately via `eval_in` and would be a programmer error here.
+fn float_dispatch<T: ArrowPrimitiveType>(
+    left: &PrimitiveArray<T>,
+    right: &PrimitiveArray<T>,
+    op: BinaryPredicateOp,
+    inverted: bool,
+) -> DeltaResult<BooleanArray>
+where
+    T::Native: PartialOrd,
+{
+    use BinaryPredicateOp::*;
+    Ok(match op {
+        Distinct => float_sql_distinct(left, right, inverted),
+        LessThan => float_sql_cmp(left, right, Ordering::Less, inverted),
+        GreaterThan => float_sql_cmp(left, right, Ordering::Greater, inverted),
+        Equal => float_sql_cmp(left, right, Ordering::Equal, inverted),
+        In => {
+            return Err(Error::internal_error(
+                "unexpected IN predicate in float comparison dispatch",
+            ))
+        }
+    })
 }
 
 /// Evaluates a (possibly inverted) kernel predicate over a record batch
@@ -802,30 +840,27 @@ pub fn evaluate_predicate(
                 )
             };
 
-            // Arrow's comparison kernels use total ordering for floats, where -0.0 != 0.0.
-            // For float types, bypass Arrow's kernels and use `sql_float_cmp`, which fixes
-            // -0.0 == 0.0 while preserving Arrow's NaN-as-greatest ordering.
-            macro_rules! float_dispatch {
-                ($float_type:ty) => {{
-                    let l = left.as_primitive::<$float_type>();
-                    let r = right.as_primitive::<$float_type>();
-                    Ok(match op {
-                        Distinct => float_sql_distinct(l, r, inverted),
-                        LessThan => float_sql_cmp(l, r, Ordering::Less, inverted),
-                        GreaterThan => float_sql_cmp(l, r, Ordering::Greater, inverted),
-                        Equal => float_sql_cmp(l, r, Ordering::Equal, inverted),
-                        // IN is handled above and never reaches this macro.
-                        In => {
-                            return Err(Error::internal_error(
-                                "unexpected IN predicate in float comparison dispatch",
-                            ))
-                        }
-                    })
-                }};
-            }
-            match left.data_type() {
-                ArrowDataType::Float32 => float_dispatch!(Float32Type),
-                ArrowDataType::Float64 => float_dispatch!(Float64Type),
+            // Arrow's `cmp` kernels use total ordering for floats (-0.0 != 0.0), which
+            // would silently drop rows during data skipping. Float arrays are routed to
+            // `float_dispatch` for SQL semantics (-0.0 == 0.0, NaN == NaN, NaN > all). See
+            // the section comment above `sql_float_cmp` for paths still on Arrow's kernels.
+            match (left.data_type(), right.data_type()) {
+                (ArrowDataType::Float32, ArrowDataType::Float32) => {
+                    let l = left.as_primitive_opt::<Float32Type>();
+                    let r = right.as_primitive_opt::<Float32Type>();
+                    if let (Some(l), Some(r)) = (l, r) {
+                        return float_dispatch(l, r, *op, inverted);
+                    }
+                    Ok(eval_fn(&left, &right)?)
+                }
+                (ArrowDataType::Float64, ArrowDataType::Float64) => {
+                    let l = left.as_primitive_opt::<Float64Type>();
+                    let r = right.as_primitive_opt::<Float64Type>();
+                    if let (Some(l), Some(r)) = (l, r) {
+                        return float_dispatch(l, r, *op, inverted);
+                    }
+                    Ok(eval_fn(&left, &right)?)
+                }
                 _ => Ok(eval_fn(&left, &right)?),
             }
         }

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -672,15 +672,12 @@ where
     let right_vals = right.values();
     let mut builder = BooleanBufferBuilder::new(len);
     for i in 0..len {
-        // SQL: NULL is not distinct from NULL; NULL is distinct from any value.
-        let result = match (left.is_null(i), right.is_null(i)) {
-            (false, false) => {
-                (sql_float_cmp(left_vals[i], right_vals[i]) != Ordering::Equal) != inverted
-            }
-            (true, true) => inverted,
-            _ => !inverted,
+        let is_distinct = match (left.is_null(i), right.is_null(i)) {
+            (false, false) => sql_float_cmp(left_vals[i], right_vals[i]) != Ordering::Equal,
+            // NULL is not distinct from NULL, but is distinct from any non-null value.
+            (l_null, r_null) => l_null != r_null,
         };
-        builder.append(result);
+        builder.append(is_distinct != inverted);
     }
     BooleanArray::new(builder.finish(), None)
 }
@@ -845,22 +842,18 @@ pub fn evaluate_predicate(
             // `float_dispatch` for SQL semantics (-0.0 == 0.0, NaN == NaN, NaN > all). See
             // the section comment above `sql_float_cmp` for paths still on Arrow's kernels.
             match (left.data_type(), right.data_type()) {
-                (ArrowDataType::Float32, ArrowDataType::Float32) => {
-                    let l = left.as_primitive_opt::<Float32Type>();
-                    let r = right.as_primitive_opt::<Float32Type>();
-                    if let (Some(l), Some(r)) = (l, r) {
-                        return float_dispatch(l, r, *op, inverted);
-                    }
-                    Ok(eval_fn(&left, &right)?)
-                }
-                (ArrowDataType::Float64, ArrowDataType::Float64) => {
-                    let l = left.as_primitive_opt::<Float64Type>();
-                    let r = right.as_primitive_opt::<Float64Type>();
-                    if let (Some(l), Some(r)) = (l, r) {
-                        return float_dispatch(l, r, *op, inverted);
-                    }
-                    Ok(eval_fn(&left, &right)?)
-                }
+                (ArrowDataType::Float32, ArrowDataType::Float32) => float_dispatch(
+                    left.as_primitive::<Float32Type>(),
+                    right.as_primitive::<Float32Type>(),
+                    *op,
+                    inverted,
+                ),
+                (ArrowDataType::Float64, ArrowDataType::Float64) => float_dispatch(
+                    left.as_primitive::<Float64Type>(),
+                    right.as_primitive::<Float64Type>(),
+                    *op,
+                    inverted,
+                ),
                 _ => Ok(eval_fn(&left, &right)?),
             }
         }

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -1,5 +1,6 @@
 //! Expression handling based on arrow-rs compute kernels.
 use std::borrow::Cow;
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -10,8 +11,8 @@ use tracing::warn;
 use crate::arrow::array::types::*;
 use crate::arrow::array::{
     self as arrow_array, make_array, new_null_array, Array, ArrayBuilder, ArrayData, ArrayRef,
-    AsArray, BooleanArray, Datum, ListArray, MapArray, MutableArrayData, NullBufferBuilder,
-    RecordBatch, StringArray, StructArray,
+    AsArray, BooleanArray, BooleanBufferBuilder, Datum, ListArray, MapArray, MutableArrayData,
+    NullBufferBuilder, PrimitiveArray, RecordBatch, StringArray, StructArray,
 };
 use crate::arrow::buffer::{NullBuffer, OffsetBuffer};
 use crate::arrow::compute::kernels::cast_utils::{string_to_datetime, Parser};
@@ -589,6 +590,89 @@ fn arrow_convert_to_view_type(vals: Arc<dyn Array>) -> DeltaResult<Arc<dyn Array
     }
 }
 
+/// Compares two float values with `-0.0 == 0.0` (the actual bug fix) while preserving Arrow's
+/// existing NaN ordering (`NaN` greater than all non-NaN values). We need custom NaN handling
+/// here because bypassing Arrow's kernels also loses its NaN-as-greatest behavior. Rust's
+/// [`PartialOrd`] treats NaN as incomparable, so we restore Arrow/Spark's NaN semantics
+/// explicitly.
+///
+/// WARNING: Any new code path that compares float arrays MUST route through
+/// [`float_sql_cmp`] or [`float_sql_distinct`] (or use the scalar path via
+/// `logical_partial_cmp`). Calling Arrow's `cmp` kernels (`eq`, `lt`, `gt`, etc.) directly
+/// on float arrays will reintroduce the `-0.0 != 0.0` bug because those kernels use total
+/// ordering. The scalar path already handles this correctly for partition pruning and
+/// parquet row group skipping; only the Arrow expression evaluator needs this workaround.
+fn sql_float_cmp<F: PartialOrd>(a: F, b: F) -> Ordering {
+    match a.partial_cmp(&b) {
+        Some(ord) => ord,
+        // partial_cmp returns None only when at least one operand is NaN.
+        // NaN sorts greater than all non-NaN values, and NaN == NaN.
+        // Detect which operand is NaN: x.partial_cmp(&x) is None iff x is NaN.
+        None => match (a.partial_cmp(&a).is_some(), b.partial_cmp(&b).is_some()) {
+            (true, false) => Ordering::Less,
+            (false, true) => Ordering::Greater,
+            _ => Ordering::Equal,
+        },
+    }
+}
+
+/// Element-wise float comparison using [`sql_float_cmp`]. Compares all value pairs unconditionally
+/// against the expected [`Ordering`](std::cmp::Ordering), then unions the null masks from both
+/// arrays. This avoids per-element null branching (which prevents vectorization). The `inverted`
+/// flag flips results (for representing `>=`, `<=`, and `!=` as inverted `<`, `>`, and `=`).
+fn float_sql_cmp<T: ArrowPrimitiveType>(
+    left: &PrimitiveArray<T>,
+    right: &PrimitiveArray<T>,
+    ord: Ordering,
+    inverted: bool,
+) -> BooleanArray
+where
+    T::Native: PartialOrd,
+{
+    let len = left.len();
+    let left_vals = left.values();
+    let right_vals = right.values();
+    let mut builder = BooleanBufferBuilder::new(len);
+    for i in 0..len {
+        builder.append((sql_float_cmp(left_vals[i], right_vals[i]) == ord) != inverted);
+    }
+    let nulls = NullBuffer::union(left.nulls(), right.nulls());
+    BooleanArray::new(builder.finish(), nulls)
+}
+
+/// Like [`float_sql_cmp`], but for `DISTINCT` / `NOT DISTINCT` which treat nulls as comparable
+/// values: `NULL IS NOT DISTINCT FROM NULL` is true. When `negated` is false, computes
+/// `IS DISTINCT FROM` (true for unequal values or null mismatch). When true, computes
+/// `IS NOT DISTINCT FROM`. Unlike [`float_sql_cmp`], this must inspect nulls per element since
+/// null equality is part of the result (not just propagated).
+fn float_sql_distinct<T: ArrowPrimitiveType>(
+    left: &PrimitiveArray<T>,
+    right: &PrimitiveArray<T>,
+    negated: bool,
+) -> BooleanArray
+where
+    T::Native: PartialOrd,
+{
+    let len = left.len();
+    let left_vals = left.values();
+    let right_vals = right.values();
+    let mut builder = BooleanBufferBuilder::new(len);
+    for i in 0..len {
+        let l_null = left.is_null(i);
+        let r_null = right.is_null(i);
+        let result = match (l_null, r_null) {
+            (false, false) => {
+                (sql_float_cmp(left_vals[i], right_vals[i]) != Ordering::Equal) != negated
+            }
+            (true, true) => negated, // NULL vs NULL: not distinct
+            _ => !negated,           // NULL vs value: distinct
+        };
+        builder.append(result);
+    }
+    // DISTINCT never produces nulls (all outputs are non-null booleans)
+    BooleanArray::new(builder.finish(), None)
+}
+
 /// Evaluates a (possibly inverted) kernel predicate over a record batch
 pub fn evaluate_predicate(
     predicate: &Predicate,
@@ -717,7 +801,33 @@ pub fn evaluate_predicate(
                     arrow_convert_to_view_type(right)?,
                 )
             };
-            Ok(eval_fn(&left, &right)?)
+
+            // Arrow's comparison kernels use total ordering for floats, where -0.0 != 0.0.
+            // For float types, bypass Arrow's kernels and use `sql_float_cmp`, which fixes
+            // -0.0 == 0.0 while preserving Arrow's NaN-as-greatest ordering.
+            macro_rules! float_dispatch {
+                ($float_type:ty) => {{
+                    let l = left.as_primitive::<$float_type>();
+                    let r = right.as_primitive::<$float_type>();
+                    Ok(match op {
+                        Distinct => float_sql_distinct(l, r, inverted),
+                        LessThan => float_sql_cmp(l, r, Ordering::Less, inverted),
+                        GreaterThan => float_sql_cmp(l, r, Ordering::Greater, inverted),
+                        Equal => float_sql_cmp(l, r, Ordering::Equal, inverted),
+                        // IN is handled above and never reaches this macro.
+                        In => {
+                            return Err(Error::internal_error(
+                                "unexpected IN predicate in float comparison dispatch",
+                            ))
+                        }
+                    })
+                }};
+            }
+            match left.data_type() {
+                ArrowDataType::Float32 => float_dispatch!(Float32Type),
+                ArrowDataType::Float64 => float_dispatch!(Float64Type),
+                _ => Ok(eval_fn(&left, &right)?),
+            }
         }
         Junction(JunctionPredicate { op, preds }) => {
             // Leverage de Morgan's laws (invert the children and swap the operator):

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -616,24 +616,28 @@ fn arrow_convert_to_view_type(vals: Arc<dyn Array>) -> DeltaResult<Arc<dyn Array
     }
 }
 
-/// Compares two float values with `-0.0 == 0.0` (the actual bug fix) while preserving Arrow's
-/// existing NaN ordering (`NaN` greater than all non-NaN values). We need custom NaN handling
-/// here because bypassing Arrow's kernels also loses its NaN-as-greatest behavior. Rust's
-/// [`PartialOrd`] treats NaN as incomparable, so we restore Arrow/Spark's NaN semantics
-/// explicitly.
-///
-/// WARNING: Any new code path that compares float arrays MUST route through
-/// [`float_sql_cmp`] or [`float_sql_distinct`] (or use the scalar path via
-/// `logical_partial_cmp`). Calling Arrow's `cmp` kernels (`eq`, `lt`, `gt`, etc.) directly
-/// on float arrays will reintroduce the `-0.0 != 0.0` bug because those kernels use total
-/// ordering. The scalar path already handles this correctly for partition pruning and
-/// parquet row group skipping; only the Arrow expression evaluator needs this workaround.
+// === Float SQL comparison helpers ===
+//
+// Arrow's `cmp` kernels (`eq`, `lt`, `gt`, etc.) use total ordering for floats: `-0.0 < 0.0`
+// and NaN sorts greatest. SQL semantics require `-0.0 == 0.0` while keeping Spark's
+// NaN-as-greatest with `NaN == NaN`. The helpers below implement that hybrid ordering.
+//
+// Any new code path that compares float arrays via the Arrow expression evaluator should
+// route through [`float_sql_cmp`] / [`float_sql_distinct`]. Calling Arrow's `cmp` kernels
+// directly on float arrays will reintroduce the `-0.0 != 0.0` bug. The `IN` predicate path
+// (`eval_in`) currently uses Arrow's `in_list`, which does Rust IEEE `PartialEq` per element:
+// `-0.0 == 0.0` is correct, but `NaN IN [NaN]` is `false` (not `true`). Aligning IN with
+// these helpers is tracked separately. The scalar path (`Scalar::logical_partial_cmp`)
+// uses `partial_cmp`: correct for `-0.0`, but returns `None` for NaN rather than treating
+// NaN as greatest. That divergence is also tracked separately and is safe today because
+// both paths conservatively keep files when NaN is present.
+
+/// Returns the SQL ordering of two floats: `-0.0 == 0.0`, `NaN == NaN`, and NaN sorts
+/// greater than every non-NaN value (matching Spark's `SQLOrderingUtil.compareDoubles`).
 fn sql_float_cmp<F: PartialOrd>(a: F, b: F) -> Ordering {
     match a.partial_cmp(&b) {
         Some(ord) => ord,
-        // partial_cmp returns None only when at least one operand is NaN.
-        // NaN sorts greater than all non-NaN values, and NaN == NaN.
-        // Detect which operand is NaN: x.partial_cmp(&x) is None iff x is NaN.
+        // partial_cmp(&x) is None iff x is NaN; this is the generic equivalent of !x.is_nan().
         None => match (a.partial_cmp(&a).is_some(), b.partial_cmp(&b).is_some()) {
             (true, false) => Ordering::Less,
             (false, true) => Ordering::Greater,
@@ -642,14 +646,48 @@ fn sql_float_cmp<F: PartialOrd>(a: F, b: F) -> Ordering {
     }
 }
 
-/// Element-wise float comparison using [`sql_float_cmp`]. Compares all value pairs unconditionally
-/// against the expected [`Ordering`](std::cmp::Ordering), then unions the null masks from both
-/// arrays. This avoids per-element null branching (which prevents vectorization). The `inverted`
-/// flag flips results (for representing `>=`, `<=`, and `!=` as inverted `<`, `>`, and `=`).
+/// Element-wise float comparison using [`sql_float_cmp`].
+///
+/// # Parameters
+/// - `left`, `right`: input arrays of equal length.
+/// - `ord`: the [`Ordering`] result that produces `true` for each row (e.g. [`Ordering::Less`] for
+///   `<`, [`Ordering::Equal`] for `=`).
+/// - `inverted`: when true, flips each output bit. Used to express `>=` as `NOT <`, `<=` as `NOT
+///   >`, and `!=` as `NOT =`.
+///
+/// Returns a [`BooleanArray`] whose null mask is the union of the input null masks. Values
+/// are compared unconditionally; null branching only happens once at the end (single
+/// `NullBuffer::union`) rather than per element.
 fn float_sql_cmp<T: ArrowPrimitiveType>(
     left: &PrimitiveArray<T>,
     right: &PrimitiveArray<T>,
     ord: Ordering,
+    inverted: bool,
+) -> BooleanArray
+where
+    T::Native: PartialOrd,
+{
+    let mut builder = BooleanBufferBuilder::new(left.len());
+    for (l, r) in left.values().iter().zip(right.values().iter()) {
+        builder.append((sql_float_cmp(*l, *r) == ord) != inverted);
+    }
+    let nulls = NullBuffer::union(left.nulls(), right.nulls());
+    BooleanArray::new(builder.finish(), nulls)
+}
+
+/// Like [`float_sql_cmp`], but for `IS DISTINCT FROM` / `IS NOT DISTINCT FROM` which treat
+/// nulls as comparable values: `NULL IS NOT DISTINCT FROM NULL` is true.
+///
+/// # Parameters
+/// - `left`, `right`: input arrays of equal length.
+/// - `inverted`: when false, computes `IS DISTINCT FROM` (true for unequal values or null
+///   mismatch). When true, computes `IS NOT DISTINCT FROM`.
+///
+/// Unlike [`float_sql_cmp`], this inspects nulls per element since null equality is part of
+/// the result rather than something to propagate. Output never contains nulls.
+fn float_sql_distinct<T: ArrowPrimitiveType>(
+    left: &PrimitiveArray<T>,
+    right: &PrimitiveArray<T>,
     inverted: bool,
 ) -> BooleanArray
 where
@@ -660,43 +698,43 @@ where
     let right_vals = right.values();
     let mut builder = BooleanBufferBuilder::new(len);
     for i in 0..len {
-        builder.append((sql_float_cmp(left_vals[i], right_vals[i]) == ord) != inverted);
-    }
-    let nulls = NullBuffer::union(left.nulls(), right.nulls());
-    BooleanArray::new(builder.finish(), nulls)
-}
-
-/// Like [`float_sql_cmp`], but for `DISTINCT` / `NOT DISTINCT` which treat nulls as comparable
-/// values: `NULL IS NOT DISTINCT FROM NULL` is true. When `negated` is false, computes
-/// `IS DISTINCT FROM` (true for unequal values or null mismatch). When true, computes
-/// `IS NOT DISTINCT FROM`. Unlike [`float_sql_cmp`], this must inspect nulls per element since
-/// null equality is part of the result (not just propagated).
-fn float_sql_distinct<T: ArrowPrimitiveType>(
-    left: &PrimitiveArray<T>,
-    right: &PrimitiveArray<T>,
-    negated: bool,
-) -> BooleanArray
-where
-    T::Native: PartialOrd,
-{
-    let len = left.len();
-    let left_vals = left.values();
-    let right_vals = right.values();
-    let mut builder = BooleanBufferBuilder::new(len);
-    for i in 0..len {
-        let l_null = left.is_null(i);
-        let r_null = right.is_null(i);
-        let result = match (l_null, r_null) {
+        // SQL: NULL is not distinct from NULL; NULL is distinct from any value.
+        let result = match (left.is_null(i), right.is_null(i)) {
             (false, false) => {
-                (sql_float_cmp(left_vals[i], right_vals[i]) != Ordering::Equal) != negated
+                (sql_float_cmp(left_vals[i], right_vals[i]) != Ordering::Equal) != inverted
             }
-            (true, true) => negated, // NULL vs NULL: not distinct
-            _ => !negated,           // NULL vs value: distinct
+            (true, true) => inverted,
+            _ => !inverted,
         };
         builder.append(result);
     }
-    // DISTINCT never produces nulls (all outputs are non-null booleans)
     BooleanArray::new(builder.finish(), None)
+}
+
+/// Dispatches a float-array comparison to [`float_sql_cmp`] or [`float_sql_distinct`].
+/// Caller already established `op` is one of `Equal`, `LessThan`, `GreaterThan`, or
+/// `Distinct`; `In` is handled separately via `eval_in` and would be a programmer error here.
+fn float_dispatch<T: ArrowPrimitiveType>(
+    left: &PrimitiveArray<T>,
+    right: &PrimitiveArray<T>,
+    op: BinaryPredicateOp,
+    inverted: bool,
+) -> DeltaResult<BooleanArray>
+where
+    T::Native: PartialOrd,
+{
+    use BinaryPredicateOp::*;
+    Ok(match op {
+        Distinct => float_sql_distinct(left, right, inverted),
+        LessThan => float_sql_cmp(left, right, Ordering::Less, inverted),
+        GreaterThan => float_sql_cmp(left, right, Ordering::Greater, inverted),
+        Equal => float_sql_cmp(left, right, Ordering::Equal, inverted),
+        In => {
+            return Err(Error::internal_error(
+                "unexpected IN predicate in float comparison dispatch",
+            ))
+        }
+    })
 }
 
 /// Evaluates a (possibly inverted) kernel predicate over a record batch
@@ -831,30 +869,27 @@ pub fn evaluate_predicate(
                 )
             };
 
-            // Arrow's comparison kernels use total ordering for floats, where -0.0 != 0.0.
-            // For float types, bypass Arrow's kernels and use `sql_float_cmp`, which fixes
-            // -0.0 == 0.0 while preserving Arrow's NaN-as-greatest ordering.
-            macro_rules! float_dispatch {
-                ($float_type:ty) => {{
-                    let l = left.as_primitive::<$float_type>();
-                    let r = right.as_primitive::<$float_type>();
-                    Ok(match op {
-                        Distinct => float_sql_distinct(l, r, inverted),
-                        LessThan => float_sql_cmp(l, r, Ordering::Less, inverted),
-                        GreaterThan => float_sql_cmp(l, r, Ordering::Greater, inverted),
-                        Equal => float_sql_cmp(l, r, Ordering::Equal, inverted),
-                        // IN is handled above and never reaches this macro.
-                        In => {
-                            return Err(Error::internal_error(
-                                "unexpected IN predicate in float comparison dispatch",
-                            ))
-                        }
-                    })
-                }};
-            }
-            match left.data_type() {
-                ArrowDataType::Float32 => float_dispatch!(Float32Type),
-                ArrowDataType::Float64 => float_dispatch!(Float64Type),
+            // Arrow's `cmp` kernels use total ordering for floats (-0.0 != 0.0), which
+            // would silently drop rows during data skipping. Float arrays are routed to
+            // `float_dispatch` for SQL semantics (-0.0 == 0.0, NaN == NaN, NaN > all). See
+            // the section comment above `sql_float_cmp` for paths still on Arrow's kernels.
+            match (left.data_type(), right.data_type()) {
+                (ArrowDataType::Float32, ArrowDataType::Float32) => {
+                    let l = left.as_primitive_opt::<Float32Type>();
+                    let r = right.as_primitive_opt::<Float32Type>();
+                    if let (Some(l), Some(r)) = (l, r) {
+                        return float_dispatch(l, r, *op, inverted);
+                    }
+                    Ok(eval_fn(&left, &right)?)
+                }
+                (ArrowDataType::Float64, ArrowDataType::Float64) => {
+                    let l = left.as_primitive_opt::<Float64Type>();
+                    let r = right.as_primitive_opt::<Float64Type>();
+                    if let (Some(l), Some(r)) = (l, r) {
+                        return float_dispatch(l, r, *op, inverted);
+                    }
+                    Ok(eval_fn(&left, &right)?)
+                }
                 _ => Ok(eval_fn(&left, &right)?),
             }
         }

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -1,5 +1,6 @@
 //! Expression handling based on arrow-rs compute kernels.
 use std::borrow::Cow;
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -10,8 +11,8 @@ use tracing::warn;
 use crate::arrow::array::types::*;
 use crate::arrow::array::{
     self as arrow_array, make_array, new_null_array, Array, ArrayBuilder, ArrayData, ArrayRef,
-    AsArray, BooleanArray, Datum, ListArray, MapArray, MutableArrayData, NullBufferBuilder,
-    RecordBatch, StringArray, StructArray,
+    AsArray, BooleanArray, BooleanBufferBuilder, Datum, ListArray, MapArray, MutableArrayData,
+    NullBufferBuilder, PrimitiveArray, RecordBatch, StringArray, StructArray,
 };
 use crate::arrow::buffer::{NullBuffer, OffsetBuffer};
 use crate::arrow::compute::kernels::cast_utils::{string_to_datetime, Parser};
@@ -615,6 +616,89 @@ fn arrow_convert_to_view_type(vals: Arc<dyn Array>) -> DeltaResult<Arc<dyn Array
     }
 }
 
+/// Compares two float values with `-0.0 == 0.0` (the actual bug fix) while preserving Arrow's
+/// existing NaN ordering (`NaN` greater than all non-NaN values). We need custom NaN handling
+/// here because bypassing Arrow's kernels also loses its NaN-as-greatest behavior. Rust's
+/// [`PartialOrd`] treats NaN as incomparable, so we restore Arrow/Spark's NaN semantics
+/// explicitly.
+///
+/// WARNING: Any new code path that compares float arrays MUST route through
+/// [`float_sql_cmp`] or [`float_sql_distinct`] (or use the scalar path via
+/// `logical_partial_cmp`). Calling Arrow's `cmp` kernels (`eq`, `lt`, `gt`, etc.) directly
+/// on float arrays will reintroduce the `-0.0 != 0.0` bug because those kernels use total
+/// ordering. The scalar path already handles this correctly for partition pruning and
+/// parquet row group skipping; only the Arrow expression evaluator needs this workaround.
+fn sql_float_cmp<F: PartialOrd>(a: F, b: F) -> Ordering {
+    match a.partial_cmp(&b) {
+        Some(ord) => ord,
+        // partial_cmp returns None only when at least one operand is NaN.
+        // NaN sorts greater than all non-NaN values, and NaN == NaN.
+        // Detect which operand is NaN: x.partial_cmp(&x) is None iff x is NaN.
+        None => match (a.partial_cmp(&a).is_some(), b.partial_cmp(&b).is_some()) {
+            (true, false) => Ordering::Less,
+            (false, true) => Ordering::Greater,
+            _ => Ordering::Equal,
+        },
+    }
+}
+
+/// Element-wise float comparison using [`sql_float_cmp`]. Compares all value pairs unconditionally
+/// against the expected [`Ordering`](std::cmp::Ordering), then unions the null masks from both
+/// arrays. This avoids per-element null branching (which prevents vectorization). The `inverted`
+/// flag flips results (for representing `>=`, `<=`, and `!=` as inverted `<`, `>`, and `=`).
+fn float_sql_cmp<T: ArrowPrimitiveType>(
+    left: &PrimitiveArray<T>,
+    right: &PrimitiveArray<T>,
+    ord: Ordering,
+    inverted: bool,
+) -> BooleanArray
+where
+    T::Native: PartialOrd,
+{
+    let len = left.len();
+    let left_vals = left.values();
+    let right_vals = right.values();
+    let mut builder = BooleanBufferBuilder::new(len);
+    for i in 0..len {
+        builder.append((sql_float_cmp(left_vals[i], right_vals[i]) == ord) != inverted);
+    }
+    let nulls = NullBuffer::union(left.nulls(), right.nulls());
+    BooleanArray::new(builder.finish(), nulls)
+}
+
+/// Like [`float_sql_cmp`], but for `DISTINCT` / `NOT DISTINCT` which treat nulls as comparable
+/// values: `NULL IS NOT DISTINCT FROM NULL` is true. When `negated` is false, computes
+/// `IS DISTINCT FROM` (true for unequal values or null mismatch). When true, computes
+/// `IS NOT DISTINCT FROM`. Unlike [`float_sql_cmp`], this must inspect nulls per element since
+/// null equality is part of the result (not just propagated).
+fn float_sql_distinct<T: ArrowPrimitiveType>(
+    left: &PrimitiveArray<T>,
+    right: &PrimitiveArray<T>,
+    negated: bool,
+) -> BooleanArray
+where
+    T::Native: PartialOrd,
+{
+    let len = left.len();
+    let left_vals = left.values();
+    let right_vals = right.values();
+    let mut builder = BooleanBufferBuilder::new(len);
+    for i in 0..len {
+        let l_null = left.is_null(i);
+        let r_null = right.is_null(i);
+        let result = match (l_null, r_null) {
+            (false, false) => {
+                (sql_float_cmp(left_vals[i], right_vals[i]) != Ordering::Equal) != negated
+            }
+            (true, true) => negated, // NULL vs NULL: not distinct
+            _ => !negated,           // NULL vs value: distinct
+        };
+        builder.append(result);
+    }
+    // DISTINCT never produces nulls (all outputs are non-null booleans)
+    BooleanArray::new(builder.finish(), None)
+}
+
 /// Evaluates a (possibly inverted) kernel predicate over a record batch
 pub fn evaluate_predicate(
     predicate: &Predicate,
@@ -746,7 +830,33 @@ pub fn evaluate_predicate(
                     arrow_convert_to_view_type(right)?,
                 )
             };
-            Ok(eval_fn(&left, &right)?)
+
+            // Arrow's comparison kernels use total ordering for floats, where -0.0 != 0.0.
+            // For float types, bypass Arrow's kernels and use `sql_float_cmp`, which fixes
+            // -0.0 == 0.0 while preserving Arrow's NaN-as-greatest ordering.
+            macro_rules! float_dispatch {
+                ($float_type:ty) => {{
+                    let l = left.as_primitive::<$float_type>();
+                    let r = right.as_primitive::<$float_type>();
+                    Ok(match op {
+                        Distinct => float_sql_distinct(l, r, inverted),
+                        LessThan => float_sql_cmp(l, r, Ordering::Less, inverted),
+                        GreaterThan => float_sql_cmp(l, r, Ordering::Greater, inverted),
+                        Equal => float_sql_cmp(l, r, Ordering::Equal, inverted),
+                        // IN is handled above and never reaches this macro.
+                        In => {
+                            return Err(Error::internal_error(
+                                "unexpected IN predicate in float comparison dispatch",
+                            ))
+                        }
+                    })
+                }};
+            }
+            match left.data_type() {
+                ArrowDataType::Float32 => float_dispatch!(Float32Type),
+                ArrowDataType::Float64 => float_dispatch!(Float64Type),
+                _ => Ok(eval_fn(&left, &right)?),
+            }
         }
         Junction(JunctionPredicate { op, preds }) => {
             // Leverage de Morgan's laws (invert the children and swap the operator):

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -698,15 +698,12 @@ where
     let right_vals = right.values();
     let mut builder = BooleanBufferBuilder::new(len);
     for i in 0..len {
-        // SQL: NULL is not distinct from NULL; NULL is distinct from any value.
-        let result = match (left.is_null(i), right.is_null(i)) {
-            (false, false) => {
-                (sql_float_cmp(left_vals[i], right_vals[i]) != Ordering::Equal) != inverted
-            }
-            (true, true) => inverted,
-            _ => !inverted,
+        let is_distinct = match (left.is_null(i), right.is_null(i)) {
+            (false, false) => sql_float_cmp(left_vals[i], right_vals[i]) != Ordering::Equal,
+            // NULL is not distinct from NULL, but is distinct from any non-null value.
+            (l_null, r_null) => l_null != r_null,
         };
-        builder.append(result);
+        builder.append(is_distinct != inverted);
     }
     BooleanArray::new(builder.finish(), None)
 }
@@ -874,22 +871,18 @@ pub fn evaluate_predicate(
             // `float_dispatch` for SQL semantics (-0.0 == 0.0, NaN == NaN, NaN > all). See
             // the section comment above `sql_float_cmp` for paths still on Arrow's kernels.
             match (left.data_type(), right.data_type()) {
-                (ArrowDataType::Float32, ArrowDataType::Float32) => {
-                    let l = left.as_primitive_opt::<Float32Type>();
-                    let r = right.as_primitive_opt::<Float32Type>();
-                    if let (Some(l), Some(r)) = (l, r) {
-                        return float_dispatch(l, r, *op, inverted);
-                    }
-                    Ok(eval_fn(&left, &right)?)
-                }
-                (ArrowDataType::Float64, ArrowDataType::Float64) => {
-                    let l = left.as_primitive_opt::<Float64Type>();
-                    let r = right.as_primitive_opt::<Float64Type>();
-                    if let (Some(l), Some(r)) = (l, r) {
-                        return float_dispatch(l, r, *op, inverted);
-                    }
-                    Ok(eval_fn(&left, &right)?)
-                }
+                (ArrowDataType::Float32, ArrowDataType::Float32) => float_dispatch(
+                    left.as_primitive::<Float32Type>(),
+                    right.as_primitive::<Float32Type>(),
+                    *op,
+                    inverted,
+                ),
+                (ArrowDataType::Float64, ArrowDataType::Float64) => float_dispatch(
+                    left.as_primitive::<Float64Type>(),
+                    right.as_primitive::<Float64Type>(),
+                    *op,
+                    inverted,
+                ),
                 _ => Ok(eval_fn(&left, &right)?),
             }
         }

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -616,37 +616,37 @@ fn arrow_convert_to_view_type(vals: Arc<dyn Array>) -> DeltaResult<Arc<dyn Array
     }
 }
 
-// === Float SQL comparison helpers ===
+// === Float comparison helpers ===
 //
-// Arrow's `cmp` kernels (`eq`, `lt`, `gt`, etc.) use total ordering for floats: `-0.0 < 0.0`
-// and NaN sorts greatest. SQL semantics require `-0.0 == 0.0` while keeping Spark's
-// NaN-as-greatest with `NaN == NaN`. The helpers below implement that hybrid ordering.
-//
-// Any new code path that compares float arrays via the Arrow expression evaluator should
-// route through [`float_sql_cmp`] / [`float_sql_distinct`]. Calling Arrow's `cmp` kernels
-// directly on float arrays will reintroduce the `-0.0 != 0.0` bug. The `IN` predicate path
-// (`eval_in`) currently uses Arrow's `in_list`, which does Rust IEEE `PartialEq` per element:
-// `-0.0 == 0.0` is correct, but `NaN IN [NaN]` is `false` (not `true`). Aligning IN with
-// these helpers is tracked separately. The scalar path (`Scalar::logical_partial_cmp`)
-// uses `partial_cmp`: correct for `-0.0`, but returns `None` for NaN rather than treating
-// NaN as greatest. That divergence is also tracked separately and is safe today because
-// both paths conservatively keep files when NaN is present.
+// Arrow's comparison kernels use IEEE total ordering, which distinguishes signed zero. Kernel's
+// logical comparison treats both zeros as equal. Preserve Arrow's ordering for every other value,
+// including NaNs, so this fix does not change established behavior beyond signed zero.
 
-/// Returns the SQL ordering of two floats: `-0.0 == 0.0`, `NaN == NaN`, and NaN sorts
-/// greater than every non-NaN value (matching Spark's `SQLOrderingUtil.compareDoubles`).
-fn sql_float_cmp<F: PartialOrd>(a: F, b: F) -> Ordering {
-    match a.partial_cmp(&b) {
-        Some(ord) => ord,
-        // partial_cmp(&x) is None iff x is NaN; this is the generic equivalent of !x.is_nan().
-        None => match (a.partial_cmp(&a).is_some(), b.partial_cmp(&b).is_some()) {
-            (true, false) => Ordering::Less,
-            (false, true) => Ordering::Greater,
-            _ => Ordering::Equal,
-        },
+trait LogicalFloat {
+    fn logical_cmp(self, other: Self) -> Ordering;
+}
+
+impl LogicalFloat for f32 {
+    fn logical_cmp(self, other: Self) -> Ordering {
+        if self == 0.0 && other == 0.0 {
+            Ordering::Equal
+        } else {
+            self.total_cmp(&other)
+        }
     }
 }
 
-/// Element-wise float comparison using [`sql_float_cmp`].
+impl LogicalFloat for f64 {
+    fn logical_cmp(self, other: Self) -> Ordering {
+        if self == 0.0 && other == 0.0 {
+            Ordering::Equal
+        } else {
+            self.total_cmp(&other)
+        }
+    }
+}
+
+/// Element-wise float comparison using [`LogicalFloat::logical_cmp`].
 ///
 /// # Parameters
 /// - `left`, `right`: input arrays of equal length.
@@ -658,24 +658,24 @@ fn sql_float_cmp<F: PartialOrd>(a: F, b: F) -> Ordering {
 /// Returns a [`BooleanArray`] whose null mask is the union of the input null masks. Values
 /// are compared unconditionally; null branching only happens once at the end (single
 /// `NullBuffer::union`) rather than per element.
-fn float_sql_cmp<T: ArrowPrimitiveType>(
+fn float_logical_cmp<T: ArrowPrimitiveType>(
     left: &PrimitiveArray<T>,
     right: &PrimitiveArray<T>,
     ord: Ordering,
     inverted: bool,
 ) -> BooleanArray
 where
-    T::Native: PartialOrd,
+    T::Native: LogicalFloat,
 {
     let mut builder = BooleanBufferBuilder::new(left.len());
     for (l, r) in left.values().iter().zip(right.values().iter()) {
-        builder.append((sql_float_cmp(*l, *r) == ord) != inverted);
+        builder.append((l.logical_cmp(*r) == ord) != inverted);
     }
     let nulls = NullBuffer::union(left.nulls(), right.nulls());
     BooleanArray::new(builder.finish(), nulls)
 }
 
-/// Like [`float_sql_cmp`], but for `IS DISTINCT FROM` / `IS NOT DISTINCT FROM` which treat
+/// Like [`float_logical_cmp`], but for `IS DISTINCT FROM` / `IS NOT DISTINCT FROM` which treat
 /// nulls as comparable values: `NULL IS NOT DISTINCT FROM NULL` is true.
 ///
 /// # Parameters
@@ -683,15 +683,15 @@ where
 /// - `inverted`: when false, computes `IS DISTINCT FROM` (true for unequal values or null
 ///   mismatch). When true, computes `IS NOT DISTINCT FROM`.
 ///
-/// Unlike [`float_sql_cmp`], this inspects nulls per element since null equality is part of
+/// Unlike [`float_logical_cmp`], this inspects nulls per element since null equality is part of
 /// the result rather than something to propagate. Output never contains nulls.
-fn float_sql_distinct<T: ArrowPrimitiveType>(
+fn float_logical_distinct<T: ArrowPrimitiveType>(
     left: &PrimitiveArray<T>,
     right: &PrimitiveArray<T>,
     inverted: bool,
 ) -> BooleanArray
 where
-    T::Native: PartialOrd,
+    T::Native: LogicalFloat,
 {
     let len = left.len();
     let left_vals = left.values();
@@ -699,7 +699,7 @@ where
     let mut builder = BooleanBufferBuilder::new(len);
     for i in 0..len {
         let is_distinct = match (left.is_null(i), right.is_null(i)) {
-            (false, false) => sql_float_cmp(left_vals[i], right_vals[i]) != Ordering::Equal,
+            (false, false) => left_vals[i].logical_cmp(right_vals[i]) != Ordering::Equal,
             // NULL is not distinct from NULL, but is distinct from any non-null value.
             (l_null, r_null) => l_null != r_null,
         };
@@ -708,7 +708,7 @@ where
     BooleanArray::new(builder.finish(), None)
 }
 
-/// Dispatches a float-array comparison to [`float_sql_cmp`] or [`float_sql_distinct`].
+/// Dispatches a float-array comparison to [`float_logical_cmp`] or [`float_logical_distinct`].
 /// Caller already established `op` is one of `Equal`, `LessThan`, `GreaterThan`, or
 /// `Distinct`; `In` is handled separately via `eval_in` and would be a programmer error here.
 fn float_dispatch<T: ArrowPrimitiveType>(
@@ -718,14 +718,14 @@ fn float_dispatch<T: ArrowPrimitiveType>(
     inverted: bool,
 ) -> DeltaResult<BooleanArray>
 where
-    T::Native: PartialOrd,
+    T::Native: LogicalFloat,
 {
     use BinaryPredicateOp::*;
     Ok(match op {
-        Distinct => float_sql_distinct(left, right, inverted),
-        LessThan => float_sql_cmp(left, right, Ordering::Less, inverted),
-        GreaterThan => float_sql_cmp(left, right, Ordering::Greater, inverted),
-        Equal => float_sql_cmp(left, right, Ordering::Equal, inverted),
+        Distinct => float_logical_distinct(left, right, inverted),
+        LessThan => float_logical_cmp(left, right, Ordering::Less, inverted),
+        GreaterThan => float_logical_cmp(left, right, Ordering::Greater, inverted),
+        Equal => float_logical_cmp(left, right, Ordering::Equal, inverted),
         In => {
             return Err(Error::internal_error(
                 "unexpected IN predicate in float comparison dispatch",
@@ -866,10 +866,8 @@ pub fn evaluate_predicate(
                 )
             };
 
-            // Arrow's `cmp` kernels use total ordering for floats (-0.0 != 0.0), which
-            // would silently drop rows during data skipping. Float arrays are routed to
-            // `float_dispatch` for SQL semantics (-0.0 == 0.0, NaN == NaN, NaN > all). See
-            // the section comment above `sql_float_cmp` for paths still on Arrow's kernels.
+            // Arrow's total ordering distinguishes signed zero, so use Kernel's logical float
+            // comparisons for Float32 and Float64.
             match (left.data_type(), right.data_type()) {
                 (ArrowDataType::Float32, ArrowDataType::Float32) => float_dispatch(
                     left.as_primitive::<Float32Type>(),

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -1,6 +1,5 @@
 //! Expression handling based on arrow-rs compute kernels.
 use std::borrow::Cow;
-use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -11,10 +10,10 @@ use tracing::warn;
 use crate::arrow::array::types::*;
 use crate::arrow::array::{
     self as arrow_array, make_array, new_null_array, Array, ArrayBuilder, ArrayData, ArrayRef,
-    AsArray, BooleanArray, BooleanBufferBuilder, Datum, ListArray, MapArray, MutableArrayData,
-    NullBufferBuilder, PrimitiveArray, RecordBatch, StringArray, StructArray,
+    AsArray, BooleanArray, Datum, ListArray, MapArray, MutableArrayData, NullBufferBuilder,
+    PrimitiveArray, RecordBatch, StringArray, StructArray,
 };
-use crate::arrow::buffer::{NullBuffer, OffsetBuffer};
+use crate::arrow::buffer::{BooleanBuffer, NullBuffer, OffsetBuffer};
 use crate::arrow::compute::kernels::cast_utils::{string_to_datetime, Parser};
 use crate::arrow::compute::kernels::cmp::{distinct, eq, gt, gt_eq, lt, lt_eq, neq, not_distinct};
 use crate::arrow::compute::kernels::comparison::in_list_utf8;
@@ -623,89 +622,152 @@ fn arrow_convert_to_view_type(vals: Arc<dyn Array>) -> DeltaResult<Arc<dyn Array
 // including NaNs, so this fix does not change established behavior beyond signed zero.
 
 trait LogicalFloat {
-    fn logical_cmp(self, other: Self) -> Ordering;
+    fn ieee_eq(self, other: Self) -> bool;
+    fn logical_eq(self, other: Self) -> bool;
+    fn logical_lt(self, other: Self) -> bool;
+    fn logical_gt(self, other: Self) -> bool;
 }
 
 impl LogicalFloat for f32 {
-    fn logical_cmp(self, other: Self) -> Ordering {
-        if self == 0.0 && other == 0.0 {
-            Ordering::Equal
-        } else {
-            self.total_cmp(&other)
-        }
+    #[inline]
+    fn ieee_eq(self, other: Self) -> bool {
+        self == other
+    }
+
+    #[inline]
+    fn logical_eq(self, other: Self) -> bool {
+        self == other || self.to_bits() == other.to_bits()
+    }
+
+    #[inline]
+    fn logical_lt(self, other: Self) -> bool {
+        self.total_cmp(&other).is_lt() && !(self == 0.0 && other == 0.0)
+    }
+
+    #[inline]
+    fn logical_gt(self, other: Self) -> bool {
+        self.total_cmp(&other).is_gt() && !(self == 0.0 && other == 0.0)
     }
 }
 
 impl LogicalFloat for f64 {
-    fn logical_cmp(self, other: Self) -> Ordering {
-        if self == 0.0 && other == 0.0 {
-            Ordering::Equal
-        } else {
-            self.total_cmp(&other)
-        }
+    #[inline]
+    fn ieee_eq(self, other: Self) -> bool {
+        self == other
+    }
+
+    #[inline]
+    fn logical_eq(self, other: Self) -> bool {
+        self == other || self.to_bits() == other.to_bits()
+    }
+
+    #[inline]
+    fn logical_lt(self, other: Self) -> bool {
+        self.total_cmp(&other).is_lt() && !(self == 0.0 && other == 0.0)
+    }
+
+    #[inline]
+    fn logical_gt(self, other: Self) -> bool {
+        self.total_cmp(&other).is_gt() && !(self == 0.0 && other == 0.0)
     }
 }
 
-/// Element-wise float comparison using [`LogicalFloat::logical_cmp`].
-///
-/// # Parameters
-/// - `left`, `right`: input arrays of equal length.
-/// - `ord`: the [`Ordering`] result that produces `true` for each row (e.g. [`Ordering::Less`] for
-///   `<`, [`Ordering::Equal`] for `=`).
-/// - `inverted`: when true, flips each output bit. Used to express `>=` as `NOT <`, `<=` as `NOT
-///   >`, and `!=` as `NOT =`.
-///
-/// Returns a [`BooleanArray`] whose null mask is the union of the input null masks. Values
-/// are compared unconditionally; null branching only happens once at the end (single
-/// `NullBuffer::union`) rather than per element.
+fn collect_bool(len: usize, inverted: bool, f: impl Fn(usize) -> bool) -> BooleanBuffer {
+    let mut buffer = Vec::with_capacity(len.div_ceil(64));
+    let chunks = len / 64;
+
+    buffer.extend((0..chunks).map(|chunk| {
+        let mut packed = 0;
+        for bit in 0..64 {
+            packed |= (f(chunk * 64 + bit) as u64) << bit;
+        }
+        if inverted {
+            !packed
+        } else {
+            packed
+        }
+    }));
+
+    let remainder = len % 64;
+    if remainder != 0 {
+        let mut packed = 0;
+        for bit in 0..remainder {
+            packed |= (f(chunks * 64 + bit) as u64) << bit;
+        }
+        buffer.push(if inverted { !packed } else { packed });
+    }
+
+    BooleanBuffer::new(buffer.into(), 0, len)
+}
+
+fn float_logical_values<T: ArrowPrimitiveType>(
+    left: &PrimitiveArray<T>,
+    right: &PrimitiveArray<T>,
+    inverted: bool,
+    op: impl Fn(T::Native, T::Native) -> bool,
+) -> BooleanBuffer
+where
+    T::Native: LogicalFloat,
+{
+    let left = left.values();
+    let right = right.values();
+    // SAFETY: float_dispatch rejects unequal lengths, and collect_bool only visits 0..left.len().
+    collect_bool(left.len(), inverted, |index| unsafe {
+        op(*left.get_unchecked(index), *right.get_unchecked(index))
+    })
+}
+
 fn float_logical_cmp<T: ArrowPrimitiveType>(
     left: &PrimitiveArray<T>,
     right: &PrimitiveArray<T>,
-    ord: Ordering,
     inverted: bool,
+    op: impl Fn(T::Native, T::Native) -> bool,
 ) -> BooleanArray
 where
     T::Native: LogicalFloat,
 {
-    let mut builder = BooleanBufferBuilder::new(left.len());
-    for (l, r) in left.values().iter().zip(right.values().iter()) {
-        builder.append((l.logical_cmp(*r) == ord) != inverted);
-    }
+    let values = float_logical_values(left, right, inverted, op);
     let nulls = NullBuffer::union(left.nulls(), right.nulls());
-    BooleanArray::new(builder.finish(), nulls)
+    BooleanArray::new(values, nulls)
 }
 
-/// Like [`float_logical_cmp`], but for `IS DISTINCT FROM` / `IS NOT DISTINCT FROM` which treat
-/// nulls as comparable values: `NULL IS NOT DISTINCT FROM NULL` is true.
-///
-/// # Parameters
-/// - `left`, `right`: input arrays of equal length.
-/// - `inverted`: when false, computes `IS DISTINCT FROM` (true for unequal values or null
-///   mismatch). When true, computes `IS NOT DISTINCT FROM`.
-///
-/// Unlike [`float_logical_cmp`], this inspects nulls per element since null equality is part of
-/// the result rather than something to propagate. Output never contains nulls.
 fn float_logical_distinct<T: ArrowPrimitiveType>(
     left: &PrimitiveArray<T>,
     right: &PrimitiveArray<T>,
     inverted: bool,
+    eq: impl Fn(T::Native, T::Native) -> bool,
 ) -> BooleanArray
 where
     T::Native: LogicalFloat,
 {
     let len = left.len();
-    let left_vals = left.values();
-    let right_vals = right.values();
-    let mut builder = BooleanBufferBuilder::new(len);
-    for i in 0..len {
-        let is_distinct = match (left.is_null(i), right.is_null(i)) {
-            (false, false) => left_vals[i].logical_cmp(right_vals[i]) != Ordering::Equal,
-            // NULL is not distinct from NULL, but is distinct from any non-null value.
-            (l_null, r_null) => l_null != r_null,
-        };
-        builder.append(is_distinct != inverted);
-    }
-    BooleanArray::new(builder.finish(), None)
+    let equal = float_logical_values(left, right, false, eq);
+    let invert = |word: u64| if inverted { !word } else { word };
+    let buffer = match (left.nulls(), right.nulls()) {
+        (Some(left), Some(right)) => {
+            let left = left.inner().bit_chunks().iter_padded();
+            let right = right.inner().bit_chunks().iter_padded();
+            let equal = equal.bit_chunks().iter_padded();
+            left.zip(right)
+                .zip(equal)
+                .map(|((left, right), equal)| invert((left ^ right) | (left & right & !equal)))
+                .collect()
+        }
+        (Some(valid), None) | (None, Some(valid)) => {
+            let valid = valid.inner().bit_chunks().iter_padded();
+            let equal = equal.bit_chunks().iter_padded();
+            valid
+                .zip(equal)
+                .map(|(valid, equal)| invert(!valid | !equal))
+                .collect()
+        }
+        (None, None) => equal
+            .bit_chunks()
+            .iter_padded()
+            .map(|equal| invert(!equal))
+            .collect(),
+    };
+    BooleanArray::new(BooleanBuffer::new(buffer, 0, len), None)
 }
 
 /// Dispatches a float-array comparison to [`float_logical_cmp`] or [`float_logical_distinct`].
@@ -716,22 +778,45 @@ fn float_dispatch<T: ArrowPrimitiveType>(
     right: &PrimitiveArray<T>,
     op: BinaryPredicateOp,
     inverted: bool,
+    has_non_nan_literal: bool,
 ) -> DeltaResult<BooleanArray>
 where
     T::Native: LogicalFloat,
 {
+    if left.len() != right.len() {
+        return Err(Error::invalid_expression(format!(
+            "Cannot compare arrays of different lengths, got {} and {}",
+            left.len(),
+            right.len()
+        )));
+    }
+
     use BinaryPredicateOp::*;
     Ok(match op {
-        Distinct => float_logical_distinct(left, right, inverted),
-        LessThan => float_logical_cmp(left, right, Ordering::Less, inverted),
-        GreaterThan => float_logical_cmp(left, right, Ordering::Greater, inverted),
-        Equal => float_logical_cmp(left, right, Ordering::Equal, inverted),
+        Distinct if has_non_nan_literal => {
+            float_logical_distinct(left, right, inverted, LogicalFloat::ieee_eq)
+        }
+        Distinct => float_logical_distinct(left, right, inverted, LogicalFloat::logical_eq),
+        LessThan => float_logical_cmp(left, right, inverted, LogicalFloat::logical_lt),
+        GreaterThan => float_logical_cmp(left, right, inverted, LogicalFloat::logical_gt),
+        Equal if has_non_nan_literal => {
+            float_logical_cmp(left, right, inverted, LogicalFloat::ieee_eq)
+        }
+        Equal => float_logical_cmp(left, right, inverted, LogicalFloat::logical_eq),
         In => {
             return Err(Error::internal_error(
                 "unexpected IN predicate in float comparison dispatch",
             ))
         }
     })
+}
+
+fn is_non_nan_float_literal(expr: &Expression) -> bool {
+    match expr {
+        Expression::Literal(Scalar::Float(value)) => !value.is_nan(),
+        Expression::Literal(Scalar::Double(value)) => !value.is_nan(),
+        _ => false,
+    }
 }
 
 /// Evaluates a (possibly inverted) kernel predicate over a record batch
@@ -771,6 +856,8 @@ pub fn evaluate_predicate(
         }
         Binary(BinaryPredicate { op, left, right }) => {
             let (left, right) = (left.as_ref(), right.as_ref());
+            let has_non_nan_float_literal =
+                is_non_nan_float_literal(left) || is_non_nan_float_literal(right);
 
             // IN is different from all the others, and also quite complex, so factor it out.
             //
@@ -874,12 +961,14 @@ pub fn evaluate_predicate(
                     right.as_primitive::<Float32Type>(),
                     *op,
                     inverted,
+                    has_non_nan_float_literal,
                 ),
                 (ArrowDataType::Float64, ArrowDataType::Float64) => float_dispatch(
                     left.as_primitive::<Float64Type>(),
                     right.as_primitive::<Float64Type>(),
                     *op,
                     inverted,
+                    has_non_nan_float_literal,
                 ),
                 _ => Ok(eval_fn(&left, &right)?),
             }

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -10,10 +10,10 @@ use tracing::warn;
 use crate::arrow::array::types::*;
 use crate::arrow::array::{
     self as arrow_array, make_array, new_null_array, Array, ArrayBuilder, ArrayData, ArrayRef,
-    AsArray, BooleanArray, Datum, ListArray, MapArray, MutableArrayData, NullBufferBuilder,
-    PrimitiveArray, RecordBatch, StringArray, StructArray,
+    ArrowNativeTypeOp, AsArray, BooleanArray, Datum, ListArray, MapArray, MutableArrayData,
+    NullBufferBuilder, PrimitiveArray, RecordBatch, StringArray, StructArray,
 };
-use crate::arrow::buffer::{BooleanBuffer, NullBuffer, OffsetBuffer};
+use crate::arrow::buffer::{NullBuffer, OffsetBuffer};
 use crate::arrow::compute::kernels::cast_utils::{string_to_datetime, Parser};
 use crate::arrow::compute::kernels::cmp::{distinct, eq, gt, gt_eq, lt, lt_eq, neq, not_distinct};
 use crate::arrow::compute::kernels::comparison::in_list_utf8;
@@ -615,210 +615,6 @@ fn arrow_convert_to_view_type(vals: Arc<dyn Array>) -> DeltaResult<Arc<dyn Array
     }
 }
 
-// === Float comparison helpers ===
-//
-// Arrow's comparison kernels use IEEE total ordering, which distinguishes signed zero. Kernel's
-// logical comparison treats both zeros as equal. Preserve Arrow's ordering for every other value,
-// including NaNs, so this fix does not change established behavior beyond signed zero.
-
-trait LogicalFloat {
-    fn ieee_eq(self, other: Self) -> bool;
-    fn logical_eq(self, other: Self) -> bool;
-    fn logical_lt(self, other: Self) -> bool;
-    fn logical_gt(self, other: Self) -> bool;
-}
-
-impl LogicalFloat for f32 {
-    #[inline]
-    fn ieee_eq(self, other: Self) -> bool {
-        self == other
-    }
-
-    #[inline]
-    fn logical_eq(self, other: Self) -> bool {
-        self == other || self.to_bits() == other.to_bits()
-    }
-
-    #[inline]
-    fn logical_lt(self, other: Self) -> bool {
-        self.total_cmp(&other).is_lt() && !(self == 0.0 && other == 0.0)
-    }
-
-    #[inline]
-    fn logical_gt(self, other: Self) -> bool {
-        self.total_cmp(&other).is_gt() && !(self == 0.0 && other == 0.0)
-    }
-}
-
-impl LogicalFloat for f64 {
-    #[inline]
-    fn ieee_eq(self, other: Self) -> bool {
-        self == other
-    }
-
-    #[inline]
-    fn logical_eq(self, other: Self) -> bool {
-        self == other || self.to_bits() == other.to_bits()
-    }
-
-    #[inline]
-    fn logical_lt(self, other: Self) -> bool {
-        self.total_cmp(&other).is_lt() && !(self == 0.0 && other == 0.0)
-    }
-
-    #[inline]
-    fn logical_gt(self, other: Self) -> bool {
-        self.total_cmp(&other).is_gt() && !(self == 0.0 && other == 0.0)
-    }
-}
-
-fn collect_bool(len: usize, inverted: bool, f: impl Fn(usize) -> bool) -> BooleanBuffer {
-    let mut buffer = Vec::with_capacity(len.div_ceil(64));
-    let chunks = len / 64;
-
-    buffer.extend((0..chunks).map(|chunk| {
-        let mut packed = 0;
-        for bit in 0..64 {
-            packed |= (f(chunk * 64 + bit) as u64) << bit;
-        }
-        if inverted {
-            !packed
-        } else {
-            packed
-        }
-    }));
-
-    let remainder = len % 64;
-    if remainder != 0 {
-        let mut packed = 0;
-        for bit in 0..remainder {
-            packed |= (f(chunks * 64 + bit) as u64) << bit;
-        }
-        buffer.push(if inverted { !packed } else { packed });
-    }
-
-    BooleanBuffer::new(buffer.into(), 0, len)
-}
-
-fn float_logical_values<T: ArrowPrimitiveType>(
-    left: &PrimitiveArray<T>,
-    right: &PrimitiveArray<T>,
-    inverted: bool,
-    op: impl Fn(T::Native, T::Native) -> bool,
-) -> BooleanBuffer
-where
-    T::Native: LogicalFloat,
-{
-    let left = left.values();
-    let right = right.values();
-    // SAFETY: float_dispatch rejects unequal lengths, and collect_bool only visits 0..left.len().
-    collect_bool(left.len(), inverted, |index| unsafe {
-        op(*left.get_unchecked(index), *right.get_unchecked(index))
-    })
-}
-
-fn float_logical_cmp<T: ArrowPrimitiveType>(
-    left: &PrimitiveArray<T>,
-    right: &PrimitiveArray<T>,
-    inverted: bool,
-    op: impl Fn(T::Native, T::Native) -> bool,
-) -> BooleanArray
-where
-    T::Native: LogicalFloat,
-{
-    let values = float_logical_values(left, right, inverted, op);
-    let nulls = NullBuffer::union(left.nulls(), right.nulls());
-    BooleanArray::new(values, nulls)
-}
-
-fn float_logical_distinct<T: ArrowPrimitiveType>(
-    left: &PrimitiveArray<T>,
-    right: &PrimitiveArray<T>,
-    inverted: bool,
-    eq: impl Fn(T::Native, T::Native) -> bool,
-) -> BooleanArray
-where
-    T::Native: LogicalFloat,
-{
-    let len = left.len();
-    let equal = float_logical_values(left, right, false, eq);
-    let invert = |word: u64| if inverted { !word } else { word };
-    let buffer = match (left.nulls(), right.nulls()) {
-        (Some(left), Some(right)) => {
-            let left = left.inner().bit_chunks().iter_padded();
-            let right = right.inner().bit_chunks().iter_padded();
-            let equal = equal.bit_chunks().iter_padded();
-            left.zip(right)
-                .zip(equal)
-                .map(|((left, right), equal)| invert((left ^ right) | (left & right & !equal)))
-                .collect()
-        }
-        (Some(valid), None) | (None, Some(valid)) => {
-            let valid = valid.inner().bit_chunks().iter_padded();
-            let equal = equal.bit_chunks().iter_padded();
-            valid
-                .zip(equal)
-                .map(|(valid, equal)| invert(!valid | !equal))
-                .collect()
-        }
-        (None, None) => equal
-            .bit_chunks()
-            .iter_padded()
-            .map(|equal| invert(!equal))
-            .collect(),
-    };
-    BooleanArray::new(BooleanBuffer::new(buffer, 0, len), None)
-}
-
-/// Dispatches a float-array comparison to [`float_logical_cmp`] or [`float_logical_distinct`].
-/// Caller already established `op` is one of `Equal`, `LessThan`, `GreaterThan`, or
-/// `Distinct`; `In` is handled separately via `eval_in` and would be a programmer error here.
-fn float_dispatch<T: ArrowPrimitiveType>(
-    left: &PrimitiveArray<T>,
-    right: &PrimitiveArray<T>,
-    op: BinaryPredicateOp,
-    inverted: bool,
-    has_non_nan_literal: bool,
-) -> DeltaResult<BooleanArray>
-where
-    T::Native: LogicalFloat,
-{
-    if left.len() != right.len() {
-        return Err(Error::invalid_expression(format!(
-            "Cannot compare arrays of different lengths, got {} and {}",
-            left.len(),
-            right.len()
-        )));
-    }
-
-    use BinaryPredicateOp::*;
-    Ok(match op {
-        Distinct if has_non_nan_literal => {
-            float_logical_distinct(left, right, inverted, LogicalFloat::ieee_eq)
-        }
-        Distinct => float_logical_distinct(left, right, inverted, LogicalFloat::logical_eq),
-        LessThan => float_logical_cmp(left, right, inverted, LogicalFloat::logical_lt),
-        GreaterThan => float_logical_cmp(left, right, inverted, LogicalFloat::logical_gt),
-        Equal if has_non_nan_literal => {
-            float_logical_cmp(left, right, inverted, LogicalFloat::ieee_eq)
-        }
-        Equal => float_logical_cmp(left, right, inverted, LogicalFloat::logical_eq),
-        In => {
-            return Err(Error::internal_error(
-                "unexpected IN predicate in float comparison dispatch",
-            ))
-        }
-    })
-}
-
-fn is_non_nan_float_literal(expr: &Expression) -> bool {
-    match expr {
-        Expression::Literal(Scalar::Float(value)) => !value.is_nan(),
-        Expression::Literal(Scalar::Double(value)) => !value.is_nan(),
-        _ => false,
-    }
-}
-
 /// Evaluates a (possibly inverted) kernel predicate over a record batch
 pub fn evaluate_predicate(
     predicate: &Predicate,
@@ -856,8 +652,6 @@ pub fn evaluate_predicate(
         }
         Binary(BinaryPredicate { op, left, right }) => {
             let (left, right) = (left.as_ref(), right.as_ref());
-            let has_non_nan_float_literal =
-                is_non_nan_float_literal(left) || is_non_nan_float_literal(right);
 
             // IN is different from all the others, and also quite complex, so factor it out.
             //
@@ -937,8 +731,33 @@ pub fn evaluate_predicate(
                 (In, _) => return Ok(maybe_inverted(Cow::Owned(eval_in()?))?),
             };
 
+            let has_non_nan_literal =
+                is_non_nan_float_literal(left) || is_non_nan_float_literal(right);
             let left = evaluate_expression(left, batch, None)?;
             let right = evaluate_expression(right, batch, None)?;
+            match (left.data_type(), right.data_type()) {
+                (ArrowDataType::Float32, ArrowDataType::Float32) => {
+                    return compare_float_arrays::<Float32Type>(
+                        left.as_primitive(),
+                        right.as_primitive(),
+                        *op,
+                        inverted,
+                        has_non_nan_literal,
+                    );
+                }
+                (ArrowDataType::Float64, ArrowDataType::Float64) => {
+                    return compare_float_arrays::<Float64Type>(
+                        left.as_primitive(),
+                        right.as_primitive(),
+                        *op,
+                        inverted,
+                        has_non_nan_literal,
+                    );
+                }
+                _ => {}
+            }
+            let left = normalize_comparison_zeros(left)?;
+            let right = normalize_comparison_zeros(right)?;
 
             // If the types differ (e.g. one side is a view type and the other is not),
             // normalize both to view types since benchamrking results show that casting from
@@ -952,26 +771,7 @@ pub fn evaluate_predicate(
                     arrow_convert_to_view_type(right)?,
                 )
             };
-
-            // Arrow's total ordering distinguishes signed zero, so use Kernel's logical float
-            // comparisons for Float32 and Float64.
-            match (left.data_type(), right.data_type()) {
-                (ArrowDataType::Float32, ArrowDataType::Float32) => float_dispatch(
-                    left.as_primitive::<Float32Type>(),
-                    right.as_primitive::<Float32Type>(),
-                    *op,
-                    inverted,
-                    has_non_nan_float_literal,
-                ),
-                (ArrowDataType::Float64, ArrowDataType::Float64) => float_dispatch(
-                    left.as_primitive::<Float64Type>(),
-                    right.as_primitive::<Float64Type>(),
-                    *op,
-                    inverted,
-                    has_non_nan_float_literal,
-                ),
-                _ => Ok(eval_fn(&left, &right)?),
-            }
+            Ok(eval_fn(&left, &right)?)
         }
         Junction(JunctionPredicate { op, preds }) => {
             // Leverage de Morgan's laws (invert the children and swap the operator):
@@ -1334,6 +1134,117 @@ fn validate_array_type(array: ArrayRef, expected: Option<&DataType>) -> DeltaRes
         ensure_data_types(expected, array.data_type(), ValidationMode::TypesAndNames)?;
     }
     Ok(array)
+}
+
+// Fuse signed-zero handling into the comparison to avoid copying full float columns. Arrow's
+// native comparisons preserve NaN payload ordering; Rust equality makes the two zeros equal.
+fn compare_float_arrays<T: ArrowPrimitiveType>(
+    left: &PrimitiveArray<T>,
+    right: &PrimitiveArray<T>,
+    op: BinaryPredicateOp,
+    inverted: bool,
+    has_non_nan_literal: bool,
+) -> DeltaResult<BooleanArray> {
+    if left.len() != right.len() {
+        return Err(Error::invalid_expression(format!(
+            "Cannot compare arrays of different lengths, got {} and {}",
+            left.len(),
+            right.len()
+        )));
+    }
+
+    let result = match op {
+        // A non-NaN literal cannot match a NaN, so IEEE equality is sufficient.
+        BinaryPredicateOp::Equal | BinaryPredicateOp::Distinct if has_non_nan_literal => {
+            BooleanArray::from_binary(left, right, |a, b| a == b)
+        }
+        BinaryPredicateOp::Equal | BinaryPredicateOp::Distinct => {
+            BooleanArray::from_binary(left, right, |a, b| a == b || a.is_eq(b))
+        }
+        BinaryPredicateOp::LessThan => {
+            BooleanArray::from_binary(left, right, |a, b| a.is_lt(b) && a != b)
+        }
+        BinaryPredicateOp::GreaterThan => {
+            BooleanArray::from_binary(left, right, |a, b| a.is_gt(b) && a != b)
+        }
+        BinaryPredicateOp::In => {
+            return Err(Error::internal_error(
+                "unexpected IN predicate in float comparison",
+            ))
+        }
+    };
+    let (mut values, mut nulls) = result.into_parts();
+    if op == BinaryPredicateOp::Distinct {
+        // Null-safe equality: both null, or both valid and equal.
+        if let Some(valid) = &nulls {
+            values &= valid.inner();
+        }
+        if let (Some(left), Some(right)) = (left.nulls(), right.nulls()) {
+            let both_null = !&(left.inner() | right.inner());
+            values |= &both_null;
+        }
+        nulls = None;
+    }
+    if inverted != (op == BinaryPredicateOp::Distinct) {
+        values = !&values;
+    }
+    Ok(BooleanArray::new(values, nulls))
+}
+
+fn is_non_nan_float_literal(expr: &Expression) -> bool {
+    match expr {
+        Expression::Literal(Scalar::Float(value)) => !value.is_nan(),
+        Expression::Literal(Scalar::Double(value)) => !value.is_nan(),
+        _ => false,
+    }
+}
+
+// Dictionary comparisons stay encoded. Normalize only comparison operands so the original arrays
+// retain their signed-zero bits and Arrow preserves its NaN and null semantics.
+fn normalize_comparison_zeros(array: ArrayRef) -> DeltaResult<ArrayRef> {
+    match array.data_type() {
+        ArrowDataType::Float32 => Ok(normalize_float_zeros::<Float32Type>(array)),
+        ArrowDataType::Float64 => Ok(normalize_float_zeros::<Float64Type>(array)),
+        ArrowDataType::Dictionary(_, value_type) => {
+            let mut leaf_type = value_type.as_ref();
+            while let ArrowDataType::Dictionary(_, inner) = leaf_type {
+                leaf_type = inner;
+            }
+            if !matches!(leaf_type, ArrowDataType::Float32 | ArrowDataType::Float64) {
+                return Ok(array);
+            }
+            let dictionary = array.as_any_dictionary();
+            // Arrow comparisons support one dictionary layer. Flatten only nested values, keeping
+            // the outer keys shared instead of materializing every row.
+            let values = if dictionary.values().data_type() == leaf_type {
+                dictionary.values().clone()
+            } else {
+                cast(dictionary.values(), leaf_type)?
+            };
+            let values = normalize_comparison_zeros(values)?;
+            if Arc::ptr_eq(dictionary.values(), &values) {
+                Ok(array)
+            } else {
+                Ok(dictionary.with_values(values))
+            }
+        }
+        _ => Ok(array),
+    }
+}
+
+fn normalize_float_zeros<T: ArrowPrimitiveType>(array: ArrayRef) -> ArrayRef {
+    let floats = array.as_primitive::<T>();
+    let zero = T::Native::ZERO;
+    let negative_zero = zero.neg_wrapping();
+    // Arrow's is_eq compares float bits; the non-short-circuiting reduction can vectorize.
+    let needs_copy = floats
+        .values()
+        .iter()
+        .fold(false, |found, value| found | value.is_eq(negative_zero));
+    if !needs_copy {
+        return array;
+    }
+    Arc::new(floats.unary::<_, T>(|value| if value.is_zero() { zero } else { value }))
 }
 
 #[cfg(test)]

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -1332,6 +1332,27 @@ mod tests {
     }
 
     #[test]
+    fn test_compare_float_arrays_rejects_invalid_inputs() {
+        let left = Float64Array::from(vec![0.0]);
+        let right = Float64Array::from(vec![0.0, 1.0]);
+        assert_result_error_with_message(
+            compare_float_arrays::<Float64Type>(
+                &left,
+                &right,
+                BinaryPredicateOp::Equal,
+                false,
+                true,
+            ),
+            "Cannot compare arrays of different lengths",
+        );
+
+        assert_result_error_with_message(
+            compare_float_arrays::<Float64Type>(&left, &left, BinaryPredicateOp::In, false, true),
+            "unexpected IN predicate in float comparison",
+        );
+    }
+
+    #[test]
     fn test_identity_transforms() {
         let batch = create_test_batch();
 

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -1828,8 +1828,9 @@ fn test_float_not_distinct_from(
     );
 }
 
-/// Column-vs-column comparisons exercise `NullBuffer::union` with disjoint null positions
-/// and the `(false, false) => Equal` arm of `sql_float_cmp` for both-NaN rows.
+/// Column-vs-column comparisons exercise `NullBuffer::union` with disjoint null positions,
+/// the `(false, false) => Equal` arm of `sql_float_cmp` for both-NaN rows, and the
+/// both-null row where DISTINCT is false and `<=>` is true.
 #[test]
 fn test_float_column_vs_column() {
     let left = Arc::new(Float64Array::from(vec![
@@ -1839,6 +1840,7 @@ fn test_float_column_vs_column() {
         None,
         Some(1.0),
         Some(2.0),
+        None,
     ])) as ArrayRef;
     let right = Arc::new(Float64Array::from(vec![
         Some(0.0),
@@ -1847,6 +1849,7 @@ fn test_float_column_vs_column() {
         Some(1.0),
         None,
         Some(2.0),
+        None,
     ])) as ArrayRef;
     let schema = Schema::new(vec![
         Field::new("a", DataType::Float64, true),
@@ -1866,7 +1869,8 @@ fn test_float_column_vs_column() {
             Some(false),
             None,
             None,
-            Some(true)
+            Some(true),
+            None
         ]),
         "a eq b: -0.0/0.0 equal, NaN/NaN equal, NULLs propagate"
     );
@@ -1875,8 +1879,16 @@ fn test_float_column_vs_column() {
     let result = evaluate_predicate(&pred, &batch, false).unwrap();
     assert_eq!(
         result,
-        BooleanArray::from(vec![false, false, true, true, true, false]),
-        "a distinct b: NULLs treated as values"
+        BooleanArray::from(vec![false, false, true, true, true, false, false]),
+        "a distinct b: NULL is distinct from a value but not from NULL"
+    );
+
+    let pred = a.clone().distinct(b.clone());
+    let result = evaluate_predicate(&pred, &batch, true).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![true, true, false, false, false, true, true]),
+        "a not_distinct b: NULL <=> NULL is true, NULL <=> value is false"
     );
 
     let pred = a.gt(b);
@@ -1889,7 +1901,8 @@ fn test_float_column_vs_column() {
             Some(true),
             None,
             None,
-            Some(false)
+            Some(false),
+            None
         ]),
         "a gt b: NaN > 1.0"
     );

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -1784,3 +1784,218 @@ fn test_float_nan_sql_ordering(
         "NOT (col eq NaN)"
     );
 }
+
+/// Verifies the inverted-distinct branches of `float_sql_distinct` (IS NOT DISTINCT FROM).
+/// `IS NOT DISTINCT FROM` treats nulls as comparable: `NULL <=> NULL` is true, `NULL <=> v`
+/// is false. SQL float semantics: `-0.0 <=> 0.0` is true, `NaN <=> NaN` is true.
+#[rstest]
+#[case::f64(
+    Arc::new(Float64Array::from(vec![Some(-0.0f64), Some(0.0), Some(1.0), Some(f64::NAN), None])) as ArrayRef,
+    DataType::Float64,
+    Scalar::Double(0.0),
+    Scalar::Double(f64::NAN),
+)]
+#[case::f32(
+    Arc::new(Float32Array::from(vec![Some(-0.0f32), Some(0.0), Some(1.0), Some(f32::NAN), None])) as ArrayRef,
+    DataType::Float32,
+    Scalar::Float(0.0),
+    Scalar::Float(f32::NAN),
+)]
+fn test_float_not_distinct_from(
+    #[case] array: ArrayRef,
+    #[case] dtype: DataType,
+    #[case] zero: Scalar,
+    #[case] nan: Scalar,
+) {
+    let schema = Schema::new([Arc::new(Field::new("col", dtype, true))]);
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![array]).unwrap();
+    let col = column_expr!("col");
+
+    let pred = col.clone().distinct(Expr::literal(zero));
+    let result = evaluate_predicate(&pred, &batch, true).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![true, true, false, false, false]),
+        "col not_distinct 0.0: -0.0/0.0 match, 1.0/NaN/NULL do not"
+    );
+
+    let pred = col.distinct(Expr::literal(nan));
+    let result = evaluate_predicate(&pred, &batch, true).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![false, false, false, true, false]),
+        "col not_distinct NaN: only NaN matches"
+    );
+}
+
+/// Column-vs-column comparisons exercise `NullBuffer::union` with disjoint null positions
+/// and the `(false, false) => Equal` arm of `sql_float_cmp` for both-NaN rows.
+#[test]
+fn test_float_column_vs_column() {
+    let left = Arc::new(Float64Array::from(vec![
+        Some(-0.0),
+        Some(f64::NAN),
+        Some(f64::NAN),
+        None,
+        Some(1.0),
+        Some(2.0),
+    ])) as ArrayRef;
+    let right = Arc::new(Float64Array::from(vec![
+        Some(0.0),
+        Some(f64::NAN),
+        Some(1.0),
+        Some(1.0),
+        None,
+        Some(2.0),
+    ])) as ArrayRef;
+    let schema = Schema::new(vec![
+        Field::new("a", DataType::Float64, true),
+        Field::new("b", DataType::Float64, true),
+    ]);
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![left, right]).unwrap();
+    let a = column_expr!("a");
+    let b = column_expr!("b");
+
+    let pred = a.clone().eq(b.clone());
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![
+            Some(true),
+            Some(true),
+            Some(false),
+            None,
+            None,
+            Some(true)
+        ]),
+        "a eq b: -0.0/0.0 equal, NaN/NaN equal, NULLs propagate"
+    );
+
+    let pred = a.clone().distinct(b.clone());
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![false, false, true, true, true, false]),
+        "a distinct b: NULLs treated as values"
+    );
+
+    let pred = a.gt(b);
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![
+            Some(false),
+            Some(false),
+            Some(true),
+            None,
+            None,
+            Some(false)
+        ]),
+        "a gt b: NaN > 1.0"
+    );
+}
+
+/// Empty and all-null float arrays should not panic and should produce the expected results.
+#[rstest]
+#[case::empty_f64(Arc::new(Float64Array::from(Vec::<Option<f64>>::new())) as ArrayRef, 0)]
+#[case::all_null_f64(Arc::new(Float64Array::from(vec![None::<f64>, None, None])) as ArrayRef, 3)]
+#[case::empty_f32(Arc::new(Float32Array::from(Vec::<Option<f32>>::new())) as ArrayRef, 0)]
+#[case::all_null_f32(Arc::new(Float32Array::from(vec![None::<f32>, None, None])) as ArrayRef, 3)]
+fn test_float_cmp_empty_and_all_null(#[case] array: ArrayRef, #[case] len: usize) {
+    let dtype = array.data_type().clone();
+    let zero = match dtype {
+        DataType::Float64 => Scalar::Double(0.0),
+        DataType::Float32 => Scalar::Float(0.0),
+        _ => unreachable!(),
+    };
+    let schema = Schema::new([Arc::new(Field::new("col", dtype, true))]);
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![array]).unwrap();
+    let col = column_expr!("col");
+
+    let pred = col.clone().eq(Expr::literal(zero.clone()));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(result.len(), len);
+    assert!((0..len).all(|i| result.is_null(i)));
+
+    let pred = col.distinct(Expr::literal(zero));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(result.len(), len);
+    assert!(result.nulls().is_none(), "distinct never produces nulls");
+    assert!(
+        (0..len).all(|i| result.value(i)),
+        "NULL is distinct from any value"
+    );
+}
+
+/// Literal-on-left form: dispatch must trigger regardless of operand order.
+#[test]
+fn test_float_literal_on_left() {
+    let array = Arc::new(Float64Array::from(vec![
+        Some(-0.0),
+        Some(0.0),
+        Some(1.0),
+        None,
+    ])) as ArrayRef;
+    let schema = Schema::new([Arc::new(Field::new("col", DataType::Float64, true))]);
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![array]).unwrap();
+
+    let pred = Expr::literal(Scalar::Double(0.0)).eq(column_expr!("col"));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![Some(true), Some(true), Some(false), None]),
+        "0.0 eq col"
+    );
+}
+
+/// Sliced arrays (offset != 0) should produce results aligned to the slice. `float_sql_cmp`
+/// indexes `values()` via the array's `Buffer`, which respects the slice offset.
+#[test]
+fn test_float_sliced_array() {
+    let full = Float64Array::from(vec![
+        Some(99.0),
+        Some(99.0),
+        Some(-0.0),
+        Some(0.0),
+        Some(1.0),
+    ]);
+    let sliced: ArrayRef = Arc::new(full.slice(2, 3));
+    let schema = Schema::new([Arc::new(Field::new("col", DataType::Float64, true))]);
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![sliced]).unwrap();
+
+    let pred = column_expr!("col").eq(Expr::literal(Scalar::Double(0.0)));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![Some(true), Some(true), Some(false)]),
+        "sliced col eq 0.0"
+    );
+}
+
+/// Documents IN-predicate behavior on float lists: Arrow's `in_list` uses Rust IEEE
+/// `PartialEq`, which gets `-0.0 == 0.0` right but treats `NaN != NaN`. The new SQL kernel
+/// disagrees with IN on NaN; aligning them is tracked separately.
+#[test]
+fn test_float_nan_in_predicate_uses_ieee_semantics() {
+    let field = Arc::new(Field::new("item", DataType::Float64, true));
+    let list_field = Arc::new(Field::new("list", DataType::List(field.clone()), true));
+    let schema = Schema::new([list_field]);
+
+    // Two rows: [NaN, 1.0] and [2.0, 3.0]
+    let values = Float64Array::from(vec![f64::NAN, 1.0, 2.0, 3.0]);
+    let offsets = OffsetBuffer::new(ScalarBuffer::from(vec![0i32, 2, 4]));
+    let list_array = ListArray::new(field, offsets, Arc::new(values), None);
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(list_array)]).unwrap();
+
+    let pred = Pred::binary(
+        BinaryPredicateOp::In,
+        Expr::literal(Scalar::Double(f64::NAN)),
+        column_expr!("list"),
+    );
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![false, false]),
+        "NaN IN [NaN, ...]: false under IEEE PartialEq used by Arrow's in_list"
+    );
+}

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -6,9 +6,9 @@ use Predicate as Pred;
 
 use super::*;
 use crate::arrow::array::{
-    create_array, Array, ArrayRef, BinaryViewArray, BooleanArray, GenericStringArray, Int32Array,
-    Int32Builder, ListArray, ListViewArray, MapArray, MapBuilder, MapFieldNames, StringArray,
-    StringBuilder, StringViewArray, StructArray,
+    create_array, Array, ArrayRef, BinaryViewArray, BooleanArray, Float32Array, Float64Array,
+    GenericStringArray, Int32Array, Int32Builder, ListArray, ListViewArray, MapArray, MapBuilder,
+    MapFieldNames, StringArray, StringBuilder, StringViewArray, StructArray,
 };
 use crate::arrow::buffer::{BooleanBuffer, NullBuffer, OffsetBuffer, ScalarBuffer};
 use crate::arrow::compute::kernels::cmp::{gt_eq, lt};
@@ -1490,4 +1490,297 @@ fn test_void_scalar_to_array() {
     let array = scalar.to_array(5).unwrap();
     assert_eq!(array.len(), 5);
     assert_eq!(*array.data_type(), DataType::Null);
+}
+
+// === Negative zero float comparison tests ===
+//
+// Verify that -0.0 and 0.0 compare as equal per SQL semantics.
+
+#[rstest]
+#[case::f64(
+    Arc::new(Float64Array::from(vec![Some(-0.0f64), Some(0.0), Some(1.0), Some(-1.0), None])) as ArrayRef,
+    DataType::Float64,
+    Scalar::Double(0.0),
+    Scalar::Double(-0.0),
+)]
+#[case::f32(
+    Arc::new(Float32Array::from(vec![Some(-0.0f32), Some(0.0), Some(1.0), Some(-1.0), None])) as ArrayRef,
+    DataType::Float32,
+    Scalar::Float(0.0),
+    Scalar::Float(-0.0),
+)]
+fn test_float_negative_zero_comparisons(
+    #[case] array: ArrayRef,
+    #[case] dtype: DataType,
+    #[case] pos_zero: Scalar,
+    #[case] neg_zero: Scalar,
+) {
+    // Array: [-0.0, 0.0, 1.0, -1.0, NULL]
+    let schema = Schema::new([Arc::new(Field::new("col", dtype, true))]);
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![array]).unwrap();
+    let col = column_expr!("col");
+
+    // Both -0.0 and 0.0 in the array should compare equal to literal 0.0
+    let pred = col.clone().eq(Expr::literal(pos_zero.clone()));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![Some(true), Some(true), Some(false), Some(false), None]),
+        "col eq 0.0"
+    );
+
+    // Both -0.0 and 0.0 in the array should compare equal to literal -0.0
+    let pred = col.clone().eq(Expr::literal(neg_zero.clone()));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![Some(true), Some(true), Some(false), Some(false), None]),
+        "col eq -0.0"
+    );
+
+    // Neither -0.0 nor 0.0 should be less than 0.0
+    let pred = col.clone().lt(Expr::literal(pos_zero.clone()));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![
+            Some(false),
+            Some(false),
+            Some(false),
+            Some(true),
+            None
+        ]),
+        "col lt 0.0"
+    );
+
+    // Neither -0.0 nor 0.0 should be greater than 0.0
+    let pred = col.clone().gt(Expr::literal(pos_zero.clone()));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![
+            Some(false),
+            Some(false),
+            Some(true),
+            Some(false),
+            None
+        ]),
+        "col gt 0.0"
+    );
+
+    // Both -0.0 and 0.0 should be <= 0.0
+    let pred = col.clone().le(Expr::literal(pos_zero.clone()));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![Some(true), Some(true), Some(false), Some(true), None]),
+        "col le 0.0"
+    );
+
+    // Both -0.0 and 0.0 should be >= 0.0
+    let pred = col.clone().ge(Expr::literal(pos_zero.clone()));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![Some(true), Some(true), Some(true), Some(false), None]),
+        "col ge 0.0"
+    );
+
+    // -0.0 and 0.0 are NOT DISTINCT (they are the same value in SQL)
+    let pred = col.clone().distinct(Expr::literal(pos_zero.clone()));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![
+            Some(false),
+            Some(false),
+            Some(true),
+            Some(true),
+            Some(true)
+        ]),
+        "col distinct 0.0"
+    );
+
+    // Inverted eq (ne): -0.0 and 0.0 should NOT be unequal
+    let pred = col.clone().eq(Expr::literal(neg_zero));
+    let result = evaluate_predicate(&pred, &batch, true).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![Some(false), Some(false), Some(true), Some(true), None]),
+        "NOT (col eq -0.0)"
+    );
+
+    // Inverted lt (ge): -0.0 and 0.0 are >= 0.0
+    let pred = col.clone().lt(Expr::literal(pos_zero.clone()));
+    let result = evaluate_predicate(&pred, &batch, true).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![Some(true), Some(true), Some(true), Some(false), None]),
+        "NOT (col lt 0.0) = col ge 0.0"
+    );
+
+    // Inverted gt (le): -0.0 and 0.0 are <= 0.0
+    let pred = col.clone().gt(Expr::literal(pos_zero));
+    let result = evaluate_predicate(&pred, &batch, true).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![Some(true), Some(true), Some(false), Some(true), None]),
+        "NOT (col gt 0.0) = col le 0.0"
+    );
+}
+
+#[test]
+fn test_float_neg_zero_in_predicate() {
+    // -0.0 should be found IN a list containing 0.0, and vice versa
+    let field = Arc::new(Field::new("item", DataType::Float64, true));
+    let list_field = Arc::new(Field::new("list", DataType::List(field.clone()), true));
+    let schema = Schema::new([list_field]);
+
+    // Three rows: [0.0, 1.0], [-0.0, 2.0], [3.0, 4.0]
+    let values = Float64Array::from(vec![0.0, 1.0, -0.0, 2.0, 3.0, 4.0]);
+    let offsets = OffsetBuffer::new(ScalarBuffer::from(vec![0i32, 2, 4, 6]));
+    let list_array = ListArray::new(field, offsets, Arc::new(values), None);
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(list_array)]).unwrap();
+
+    // -0.0 IN [0.0, 1.0] should be true (row 0 has 0.0 which equals -0.0)
+    let pred = Pred::binary(
+        BinaryPredicateOp::In,
+        Expr::literal(Scalar::Double(-0.0)),
+        column_expr!("list"),
+    );
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![true, true, false]),
+        "-0.0 IN list"
+    );
+
+    // 0.0 IN [-0.0, 2.0] should be true (row 1 has -0.0 which equals 0.0)
+    let pred = Pred::binary(
+        BinaryPredicateOp::In,
+        Expr::literal(Scalar::Double(0.0)),
+        column_expr!("list"),
+    );
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![true, true, false]),
+        "0.0 IN list"
+    );
+}
+
+#[rstest]
+#[case::f64(
+    Arc::new(Float64Array::from(vec![Some(f64::NAN), Some(0.0), Some(f64::INFINITY), Some(f64::NEG_INFINITY), None])) as ArrayRef,
+    DataType::Float64,
+    Scalar::Double(0.0),
+    Scalar::Double(f64::NAN),
+)]
+#[case::f32(
+    Arc::new(Float32Array::from(vec![Some(f32::NAN), Some(0.0), Some(f32::INFINITY), Some(f32::NEG_INFINITY), None])) as ArrayRef,
+    DataType::Float32,
+    Scalar::Float(0.0),
+    Scalar::Float(f32::NAN),
+)]
+fn test_float_nan_sql_ordering(
+    #[case] array: ArrayRef,
+    #[case] dtype: DataType,
+    #[case] zero: Scalar,
+    #[case] nan: Scalar,
+) {
+    // Array: [NaN, 0.0, inf, -inf, NULL]
+    // SQL ordering: -inf < 0.0 < inf < NaN
+    let schema = Schema::new([Arc::new(Field::new("col", dtype, true))]);
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![array]).unwrap();
+    let col = column_expr!("col");
+
+    // NaN > 0.0: [true, false, true, false, NULL]
+    let pred = col.clone().gt(Expr::literal(zero.clone()));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![Some(true), Some(false), Some(true), Some(false), None]),
+        "col gt 0.0 (NaN should be greater)"
+    );
+
+    // col < NaN: everything except NaN itself is less than NaN
+    let pred = col.clone().lt(Expr::literal(nan.clone()));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![Some(false), Some(true), Some(true), Some(true), None]),
+        "col lt NaN"
+    );
+
+    // NaN == NaN: only the NaN row
+    let pred = col.clone().eq(Expr::literal(nan.clone()));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![
+            Some(true),
+            Some(false),
+            Some(false),
+            Some(false),
+            None
+        ]),
+        "col eq NaN"
+    );
+
+    // col <= NaN: everything is <= NaN
+    let pred = col.clone().le(Expr::literal(nan.clone()));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![Some(true), Some(true), Some(true), Some(true), None]),
+        "col le NaN"
+    );
+
+    // col >= NaN: only NaN itself
+    let pred = col.clone().ge(Expr::literal(nan.clone()));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![
+            Some(true),
+            Some(false),
+            Some(false),
+            Some(false),
+            None
+        ]),
+        "col ge NaN"
+    );
+
+    // NaN is NOT DISTINCT FROM NaN
+    let pred = col.clone().distinct(Expr::literal(nan.clone()));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![
+            Some(false),
+            Some(true),
+            Some(true),
+            Some(true),
+            Some(true)
+        ]),
+        "col distinct NaN"
+    );
+
+    // Inverted gt: NOT (col > 0.0) = col <= 0.0, NaN should be false
+    let pred = col.clone().gt(Expr::literal(zero));
+    let result = evaluate_predicate(&pred, &batch, true).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![Some(false), Some(true), Some(false), Some(true), None]),
+        "NOT (col gt 0.0) with NaN"
+    );
+
+    // Inverted eq: NOT (col == NaN) = col != NaN
+    let pred = col.clone().eq(Expr::literal(nan));
+    let result = evaluate_predicate(&pred, &batch, true).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![Some(false), Some(true), Some(true), Some(true), None]),
+        "NOT (col eq NaN)"
+    );
 }

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -1459,6 +1459,7 @@ fn test_void_scalar_to_array() {
     assert_eq!(array.len(), 5);
     assert_eq!(*array.data_type(), DataType::Null);
 }
+
 // Interval scalars materialize as their physical integer arrays (Int32 months / Int64 micros).
 #[rstest]
 #[case::year_month(Scalar::IntervalYearMonth(30), DataType::Int32)]
@@ -1485,11 +1486,9 @@ fn test_geo_append_null_unsupported(#[case] dt: KernelDataType) {
         "expected Unsupported, got: {err:?}"
     );
 }
-||||||| parent of 44afbbe3f (fix: use SQL float comparison semantics in Arrow expression evaluator)
-
 // === Negative zero float comparison tests ===
 //
-// Verify that -0.0 and 0.0 compare as equal per SQL semantics.
+// Verify that -0.0 and 0.0 compare as logically equal.
 
 #[rstest]
 #[case::f64(
@@ -1677,14 +1676,14 @@ fn test_float_neg_zero_in_predicate() {
     Scalar::Float(0.0),
     Scalar::Float(f32::NAN),
 )]
-fn test_float_nan_sql_ordering(
+fn test_float_positive_nan_total_ordering(
     #[case] array: ArrayRef,
     #[case] dtype: DataType,
     #[case] zero: Scalar,
     #[case] nan: Scalar,
 ) {
     // Array: [NaN, 0.0, inf, -inf, NULL]
-    // SQL ordering: -inf < 0.0 < inf < NaN
+    // Arrow's total order places this positive NaN above all non-NaN values.
     let schema = Schema::new([Arc::new(Field::new("col", dtype, true))]);
     let batch = RecordBatch::try_new(Arc::new(schema), vec![array]).unwrap();
     let col = column_expr!("col");
@@ -1780,9 +1779,9 @@ fn test_float_nan_sql_ordering(
     );
 }
 
-/// Verifies the inverted-distinct branches of `float_sql_distinct` (IS NOT DISTINCT FROM).
+/// Verifies the inverted-distinct branches of `float_logical_distinct`.
 /// `IS NOT DISTINCT FROM` treats nulls as comparable: `NULL <=> NULL` is true, `NULL <=> v`
-/// is false. SQL float semantics: `-0.0 <=> 0.0` is true, `NaN <=> NaN` is true.
+/// is false. Signed zeros and identical NaN values are not distinct.
 #[rstest]
 #[case::f64(
     Arc::new(Float64Array::from(vec![Some(-0.0f64), Some(0.0), Some(1.0), Some(f64::NAN), None])) as ArrayRef,
@@ -1824,7 +1823,7 @@ fn test_float_not_distinct_from(
 }
 
 /// Column-vs-column comparisons exercise `NullBuffer::union` with disjoint null positions,
-/// the `(false, false) => Equal` arm of `sql_float_cmp` for both-NaN rows, and the
+/// the non-null arm of `float_logical_distinct` for both-NaN rows, and the
 /// both-null row where DISTINCT is false and `<=>` is true.
 #[test]
 fn test_float_column_vs_column() {
@@ -1903,6 +1902,21 @@ fn test_float_column_vs_column() {
     );
 }
 
+#[test]
+fn test_float_negative_nan_total_ordering_is_preserved() {
+    let negative_nan = f64::from_bits(f64::NAN.to_bits() | (1 << 63));
+    let array = Arc::new(Float64Array::from(vec![negative_nan, f64::NAN])) as ArrayRef;
+    let schema = Schema::new([Arc::new(Field::new("col", DataType::Float64, false))]);
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![array]).unwrap();
+    let col = col!("col");
+
+    let result = evaluate_predicate(&col.clone().lt(lit(0.0)), &batch, false).unwrap();
+    assert_eq!(result, BooleanArray::from(vec![true, false]));
+
+    let result = evaluate_predicate(&col.gt(lit(0.0)), &batch, false).unwrap();
+    assert_eq!(result, BooleanArray::from(vec![false, true]));
+}
+
 /// Empty and all-null float arrays should not panic and should produce the expected results.
 #[rstest]
 #[case::empty_f64(Arc::new(Float64Array::from(Vec::<Option<f64>>::new())) as ArrayRef, 0)]
@@ -1956,8 +1970,7 @@ fn test_float_literal_on_left() {
     );
 }
 
-/// Sliced arrays (offset != 0) should produce results aligned to the slice. `float_sql_cmp`
-/// indexes `values()` via the array's `Buffer`, which respects the slice offset.
+/// Sliced arrays (offset != 0) should produce results aligned to the slice.
 #[test]
 fn test_float_sliced_array() {
     let full = Float64Array::from(vec![
@@ -1980,9 +1993,8 @@ fn test_float_sliced_array() {
     );
 }
 
-/// Documents IN-predicate behavior on float lists: Arrow's `in_list` uses Rust IEEE
-/// `PartialEq`, which gets `-0.0 == 0.0` right but treats `NaN != NaN`. The new SQL kernel
-/// disagrees with IN on NaN; aligning them is tracked separately.
+/// Documents that float `IN` uses IEEE equality: signed zeros are equal, but NaN is not equal to
+/// itself.
 #[test]
 fn test_float_nan_in_predicate_uses_ieee_semantics() {
     let field = Arc::new(Field::new("item", DataType::Float64, true));

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -1913,8 +1913,30 @@ fn test_float_negative_nan_total_ordering_is_preserved() {
     let result = evaluate_predicate(&col.clone().lt(lit(0.0)), &batch, false).unwrap();
     assert_eq!(result, BooleanArray::from(vec![true, false]));
 
-    let result = evaluate_predicate(&col.gt(lit(0.0)), &batch, false).unwrap();
+    let result = evaluate_predicate(&col.clone().gt(lit(0.0)), &batch, false).unwrap();
     assert_eq!(result, BooleanArray::from(vec![false, true]));
+
+    let result = evaluate_predicate(&col.eq(lit(0.0)), &batch, false).unwrap();
+    assert_eq!(result, BooleanArray::from(vec![false, false]));
+}
+
+#[test]
+fn test_float_nan_payload_total_ordering_is_preserved() {
+    let lower_nan = f64::NAN;
+    let higher_nan = f64::from_bits(lower_nan.to_bits() + 1);
+    let array = Arc::new(Float64Array::from(vec![lower_nan, higher_nan])) as ArrayRef;
+    let schema = Schema::new([Arc::new(Field::new("col", DataType::Float64, false))]);
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![array]).unwrap();
+    let col = col!("col");
+
+    let result = evaluate_predicate(&col.clone().eq(lit(higher_nan)), &batch, false).unwrap();
+    assert_eq!(result, BooleanArray::from(vec![false, true]));
+
+    let result = evaluate_predicate(&col.clone().lt(lit(higher_nan)), &batch, false).unwrap();
+    assert_eq!(result, BooleanArray::from(vec![true, false]));
+
+    let result = evaluate_predicate(&col.distinct(lit(higher_nan)), &batch, false).unwrap();
+    assert_eq!(result, BooleanArray::from(vec![true, false]));
 }
 
 /// Empty and all-null float arrays should not panic and should produce the expected results.

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -1823,8 +1823,9 @@ fn test_float_not_distinct_from(
     );
 }
 
-/// Column-vs-column comparisons exercise `NullBuffer::union` with disjoint null positions
-/// and the `(false, false) => Equal` arm of `sql_float_cmp` for both-NaN rows.
+/// Column-vs-column comparisons exercise `NullBuffer::union` with disjoint null positions,
+/// the `(false, false) => Equal` arm of `sql_float_cmp` for both-NaN rows, and the
+/// both-null row where DISTINCT is false and `<=>` is true.
 #[test]
 fn test_float_column_vs_column() {
     let left = Arc::new(Float64Array::from(vec![
@@ -1834,6 +1835,7 @@ fn test_float_column_vs_column() {
         None,
         Some(1.0),
         Some(2.0),
+        None,
     ])) as ArrayRef;
     let right = Arc::new(Float64Array::from(vec![
         Some(0.0),
@@ -1842,6 +1844,7 @@ fn test_float_column_vs_column() {
         Some(1.0),
         None,
         Some(2.0),
+        None,
     ])) as ArrayRef;
     let schema = Schema::new(vec![
         Field::new("a", DataType::Float64, true),
@@ -1861,7 +1864,8 @@ fn test_float_column_vs_column() {
             Some(false),
             None,
             None,
-            Some(true)
+            Some(true),
+            None
         ]),
         "a eq b: -0.0/0.0 equal, NaN/NaN equal, NULLs propagate"
     );
@@ -1870,8 +1874,16 @@ fn test_float_column_vs_column() {
     let result = evaluate_predicate(&pred, &batch, false).unwrap();
     assert_eq!(
         result,
-        BooleanArray::from(vec![false, false, true, true, true, false]),
-        "a distinct b: NULLs treated as values"
+        BooleanArray::from(vec![false, false, true, true, true, false, false]),
+        "a distinct b: NULL is distinct from a value but not from NULL"
+    );
+
+    let pred = a.clone().distinct(b.clone());
+    let result = evaluate_predicate(&pred, &batch, true).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![true, true, false, false, false, true, true]),
+        "a not_distinct b: NULL <=> NULL is true, NULL <=> value is false"
     );
 
     let pred = a.gt(b);
@@ -1884,7 +1896,8 @@ fn test_float_column_vs_column() {
             Some(true),
             None,
             None,
-            Some(false)
+            Some(false),
+            None
         ]),
         "a gt b: NaN > 1.0"
     );

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -1779,3 +1779,218 @@ fn test_float_nan_sql_ordering(
         "NOT (col eq NaN)"
     );
 }
+
+/// Verifies the inverted-distinct branches of `float_sql_distinct` (IS NOT DISTINCT FROM).
+/// `IS NOT DISTINCT FROM` treats nulls as comparable: `NULL <=> NULL` is true, `NULL <=> v`
+/// is false. SQL float semantics: `-0.0 <=> 0.0` is true, `NaN <=> NaN` is true.
+#[rstest]
+#[case::f64(
+    Arc::new(Float64Array::from(vec![Some(-0.0f64), Some(0.0), Some(1.0), Some(f64::NAN), None])) as ArrayRef,
+    DataType::Float64,
+    Scalar::Double(0.0),
+    Scalar::Double(f64::NAN),
+)]
+#[case::f32(
+    Arc::new(Float32Array::from(vec![Some(-0.0f32), Some(0.0), Some(1.0), Some(f32::NAN), None])) as ArrayRef,
+    DataType::Float32,
+    Scalar::Float(0.0),
+    Scalar::Float(f32::NAN),
+)]
+fn test_float_not_distinct_from(
+    #[case] array: ArrayRef,
+    #[case] dtype: DataType,
+    #[case] zero: Scalar,
+    #[case] nan: Scalar,
+) {
+    let schema = Schema::new([Arc::new(Field::new("col", dtype, true))]);
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![array]).unwrap();
+    let col = column_expr!("col");
+
+    let pred = col.clone().distinct(Expr::literal(zero));
+    let result = evaluate_predicate(&pred, &batch, true).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![true, true, false, false, false]),
+        "col not_distinct 0.0: -0.0/0.0 match, 1.0/NaN/NULL do not"
+    );
+
+    let pred = col.distinct(Expr::literal(nan));
+    let result = evaluate_predicate(&pred, &batch, true).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![false, false, false, true, false]),
+        "col not_distinct NaN: only NaN matches"
+    );
+}
+
+/// Column-vs-column comparisons exercise `NullBuffer::union` with disjoint null positions
+/// and the `(false, false) => Equal` arm of `sql_float_cmp` for both-NaN rows.
+#[test]
+fn test_float_column_vs_column() {
+    let left = Arc::new(Float64Array::from(vec![
+        Some(-0.0),
+        Some(f64::NAN),
+        Some(f64::NAN),
+        None,
+        Some(1.0),
+        Some(2.0),
+    ])) as ArrayRef;
+    let right = Arc::new(Float64Array::from(vec![
+        Some(0.0),
+        Some(f64::NAN),
+        Some(1.0),
+        Some(1.0),
+        None,
+        Some(2.0),
+    ])) as ArrayRef;
+    let schema = Schema::new(vec![
+        Field::new("a", DataType::Float64, true),
+        Field::new("b", DataType::Float64, true),
+    ]);
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![left, right]).unwrap();
+    let a = column_expr!("a");
+    let b = column_expr!("b");
+
+    let pred = a.clone().eq(b.clone());
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![
+            Some(true),
+            Some(true),
+            Some(false),
+            None,
+            None,
+            Some(true)
+        ]),
+        "a eq b: -0.0/0.0 equal, NaN/NaN equal, NULLs propagate"
+    );
+
+    let pred = a.clone().distinct(b.clone());
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![false, false, true, true, true, false]),
+        "a distinct b: NULLs treated as values"
+    );
+
+    let pred = a.gt(b);
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![
+            Some(false),
+            Some(false),
+            Some(true),
+            None,
+            None,
+            Some(false)
+        ]),
+        "a gt b: NaN > 1.0"
+    );
+}
+
+/// Empty and all-null float arrays should not panic and should produce the expected results.
+#[rstest]
+#[case::empty_f64(Arc::new(Float64Array::from(Vec::<Option<f64>>::new())) as ArrayRef, 0)]
+#[case::all_null_f64(Arc::new(Float64Array::from(vec![None::<f64>, None, None])) as ArrayRef, 3)]
+#[case::empty_f32(Arc::new(Float32Array::from(Vec::<Option<f32>>::new())) as ArrayRef, 0)]
+#[case::all_null_f32(Arc::new(Float32Array::from(vec![None::<f32>, None, None])) as ArrayRef, 3)]
+fn test_float_cmp_empty_and_all_null(#[case] array: ArrayRef, #[case] len: usize) {
+    let dtype = array.data_type().clone();
+    let zero = match dtype {
+        DataType::Float64 => Scalar::Double(0.0),
+        DataType::Float32 => Scalar::Float(0.0),
+        _ => unreachable!(),
+    };
+    let schema = Schema::new([Arc::new(Field::new("col", dtype, true))]);
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![array]).unwrap();
+    let col = column_expr!("col");
+
+    let pred = col.clone().eq(Expr::literal(zero.clone()));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(result.len(), len);
+    assert!((0..len).all(|i| result.is_null(i)));
+
+    let pred = col.distinct(Expr::literal(zero));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(result.len(), len);
+    assert!(result.nulls().is_none(), "distinct never produces nulls");
+    assert!(
+        (0..len).all(|i| result.value(i)),
+        "NULL is distinct from any value"
+    );
+}
+
+/// Literal-on-left form: dispatch must trigger regardless of operand order.
+#[test]
+fn test_float_literal_on_left() {
+    let array = Arc::new(Float64Array::from(vec![
+        Some(-0.0),
+        Some(0.0),
+        Some(1.0),
+        None,
+    ])) as ArrayRef;
+    let schema = Schema::new([Arc::new(Field::new("col", DataType::Float64, true))]);
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![array]).unwrap();
+
+    let pred = Expr::literal(Scalar::Double(0.0)).eq(column_expr!("col"));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![Some(true), Some(true), Some(false), None]),
+        "0.0 eq col"
+    );
+}
+
+/// Sliced arrays (offset != 0) should produce results aligned to the slice. `float_sql_cmp`
+/// indexes `values()` via the array's `Buffer`, which respects the slice offset.
+#[test]
+fn test_float_sliced_array() {
+    let full = Float64Array::from(vec![
+        Some(99.0),
+        Some(99.0),
+        Some(-0.0),
+        Some(0.0),
+        Some(1.0),
+    ]);
+    let sliced: ArrayRef = Arc::new(full.slice(2, 3));
+    let schema = Schema::new([Arc::new(Field::new("col", DataType::Float64, true))]);
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![sliced]).unwrap();
+
+    let pred = column_expr!("col").eq(Expr::literal(Scalar::Double(0.0)));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![Some(true), Some(true), Some(false)]),
+        "sliced col eq 0.0"
+    );
+}
+
+/// Documents IN-predicate behavior on float lists: Arrow's `in_list` uses Rust IEEE
+/// `PartialEq`, which gets `-0.0 == 0.0` right but treats `NaN != NaN`. The new SQL kernel
+/// disagrees with IN on NaN; aligning them is tracked separately.
+#[test]
+fn test_float_nan_in_predicate_uses_ieee_semantics() {
+    let field = Arc::new(Field::new("item", DataType::Float64, true));
+    let list_field = Arc::new(Field::new("list", DataType::List(field.clone()), true));
+    let schema = Schema::new([list_field]);
+
+    // Two rows: [NaN, 1.0] and [2.0, 3.0]
+    let values = Float64Array::from(vec![f64::NAN, 1.0, 2.0, 3.0]);
+    let offsets = OffsetBuffer::new(ScalarBuffer::from(vec![0i32, 2, 4]));
+    let list_array = ListArray::new(field, offsets, Arc::new(values), None);
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(list_array)]).unwrap();
+
+    let pred = Pred::binary(
+        BinaryPredicateOp::In,
+        Expr::literal(Scalar::Double(f64::NAN)),
+        column_expr!("list"),
+    );
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![false, false]),
+        "NaN IN [NaN, ...]: false under IEEE PartialEq used by Arrow's in_list"
+    );
+}

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -6,9 +6,9 @@ use Predicate as Pred;
 
 use super::*;
 use crate::arrow::array::{
-    create_array, Array, ArrayRef, BinaryViewArray, BooleanArray, GenericStringArray, Int32Array,
-    Int32Builder, ListArray, ListViewArray, MapArray, MapBuilder, MapFieldNames, StringArray,
-    StringBuilder, StringViewArray, StructArray,
+    create_array, Array, ArrayRef, BinaryViewArray, BooleanArray, Float32Array, Float64Array,
+    GenericStringArray, Int32Array, Int32Builder, ListArray, ListViewArray, MapArray, MapBuilder,
+    MapFieldNames, StringArray, StringBuilder, StringViewArray, StructArray,
 };
 use crate::arrow::buffer::{BooleanBuffer, NullBuffer, OffsetBuffer, ScalarBuffer};
 use crate::arrow::compute::kernels::cmp::{gt_eq, lt};
@@ -1459,7 +1459,6 @@ fn test_void_scalar_to_array() {
     assert_eq!(array.len(), 5);
     assert_eq!(*array.data_type(), DataType::Null);
 }
-
 // Interval scalars materialize as their physical integer arrays (Int32 months / Int64 micros).
 #[rstest]
 #[case::year_month(Scalar::IntervalYearMonth(30), DataType::Int32)]
@@ -1484,5 +1483,299 @@ fn test_geo_append_null_unsupported(#[case] dt: KernelDataType) {
     assert!(
         matches!(err, Error::Unsupported(_)),
         "expected Unsupported, got: {err:?}"
+    );
+}
+||||||| parent of 44afbbe3f (fix: use SQL float comparison semantics in Arrow expression evaluator)
+
+// === Negative zero float comparison tests ===
+//
+// Verify that -0.0 and 0.0 compare as equal per SQL semantics.
+
+#[rstest]
+#[case::f64(
+    Arc::new(Float64Array::from(vec![Some(-0.0f64), Some(0.0), Some(1.0), Some(-1.0), None])) as ArrayRef,
+    DataType::Float64,
+    Scalar::Double(0.0),
+    Scalar::Double(-0.0),
+)]
+#[case::f32(
+    Arc::new(Float32Array::from(vec![Some(-0.0f32), Some(0.0), Some(1.0), Some(-1.0), None])) as ArrayRef,
+    DataType::Float32,
+    Scalar::Float(0.0),
+    Scalar::Float(-0.0),
+)]
+fn test_float_negative_zero_comparisons(
+    #[case] array: ArrayRef,
+    #[case] dtype: DataType,
+    #[case] pos_zero: Scalar,
+    #[case] neg_zero: Scalar,
+) {
+    // Array: [-0.0, 0.0, 1.0, -1.0, NULL]
+    let schema = Schema::new([Arc::new(Field::new("col", dtype, true))]);
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![array]).unwrap();
+    let col = column_expr!("col");
+
+    // Both -0.0 and 0.0 in the array should compare equal to literal 0.0
+    let pred = col.clone().eq(Expr::literal(pos_zero.clone()));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![Some(true), Some(true), Some(false), Some(false), None]),
+        "col eq 0.0"
+    );
+
+    // Both -0.0 and 0.0 in the array should compare equal to literal -0.0
+    let pred = col.clone().eq(Expr::literal(neg_zero.clone()));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![Some(true), Some(true), Some(false), Some(false), None]),
+        "col eq -0.0"
+    );
+
+    // Neither -0.0 nor 0.0 should be less than 0.0
+    let pred = col.clone().lt(Expr::literal(pos_zero.clone()));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![
+            Some(false),
+            Some(false),
+            Some(false),
+            Some(true),
+            None
+        ]),
+        "col lt 0.0"
+    );
+
+    // Neither -0.0 nor 0.0 should be greater than 0.0
+    let pred = col.clone().gt(Expr::literal(pos_zero.clone()));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![
+            Some(false),
+            Some(false),
+            Some(true),
+            Some(false),
+            None
+        ]),
+        "col gt 0.0"
+    );
+
+    // Both -0.0 and 0.0 should be <= 0.0
+    let pred = col.clone().le(Expr::literal(pos_zero.clone()));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![Some(true), Some(true), Some(false), Some(true), None]),
+        "col le 0.0"
+    );
+
+    // Both -0.0 and 0.0 should be >= 0.0
+    let pred = col.clone().ge(Expr::literal(pos_zero.clone()));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![Some(true), Some(true), Some(true), Some(false), None]),
+        "col ge 0.0"
+    );
+
+    // -0.0 and 0.0 are NOT DISTINCT (they are the same value in SQL)
+    let pred = col.clone().distinct(Expr::literal(pos_zero.clone()));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![
+            Some(false),
+            Some(false),
+            Some(true),
+            Some(true),
+            Some(true)
+        ]),
+        "col distinct 0.0"
+    );
+
+    // Inverted eq (ne): -0.0 and 0.0 should NOT be unequal
+    let pred = col.clone().eq(Expr::literal(neg_zero));
+    let result = evaluate_predicate(&pred, &batch, true).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![Some(false), Some(false), Some(true), Some(true), None]),
+        "NOT (col eq -0.0)"
+    );
+
+    // Inverted lt (ge): -0.0 and 0.0 are >= 0.0
+    let pred = col.clone().lt(Expr::literal(pos_zero.clone()));
+    let result = evaluate_predicate(&pred, &batch, true).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![Some(true), Some(true), Some(true), Some(false), None]),
+        "NOT (col lt 0.0) = col ge 0.0"
+    );
+
+    // Inverted gt (le): -0.0 and 0.0 are <= 0.0
+    let pred = col.clone().gt(Expr::literal(pos_zero));
+    let result = evaluate_predicate(&pred, &batch, true).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![Some(true), Some(true), Some(false), Some(true), None]),
+        "NOT (col gt 0.0) = col le 0.0"
+    );
+}
+
+#[test]
+fn test_float_neg_zero_in_predicate() {
+    // -0.0 should be found IN a list containing 0.0, and vice versa
+    let field = Arc::new(Field::new("item", DataType::Float64, true));
+    let list_field = Arc::new(Field::new("list", DataType::List(field.clone()), true));
+    let schema = Schema::new([list_field]);
+
+    // Three rows: [0.0, 1.0], [-0.0, 2.0], [3.0, 4.0]
+    let values = Float64Array::from(vec![0.0, 1.0, -0.0, 2.0, 3.0, 4.0]);
+    let offsets = OffsetBuffer::new(ScalarBuffer::from(vec![0i32, 2, 4, 6]));
+    let list_array = ListArray::new(field, offsets, Arc::new(values), None);
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(list_array)]).unwrap();
+
+    // -0.0 IN [0.0, 1.0] should be true (row 0 has 0.0 which equals -0.0)
+    let pred = Pred::binary(
+        BinaryPredicateOp::In,
+        Expr::literal(Scalar::Double(-0.0)),
+        column_expr!("list"),
+    );
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![true, true, false]),
+        "-0.0 IN list"
+    );
+
+    // 0.0 IN [-0.0, 2.0] should be true (row 1 has -0.0 which equals 0.0)
+    let pred = Pred::binary(
+        BinaryPredicateOp::In,
+        Expr::literal(Scalar::Double(0.0)),
+        column_expr!("list"),
+    );
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![true, true, false]),
+        "0.0 IN list"
+    );
+}
+
+#[rstest]
+#[case::f64(
+    Arc::new(Float64Array::from(vec![Some(f64::NAN), Some(0.0), Some(f64::INFINITY), Some(f64::NEG_INFINITY), None])) as ArrayRef,
+    DataType::Float64,
+    Scalar::Double(0.0),
+    Scalar::Double(f64::NAN),
+)]
+#[case::f32(
+    Arc::new(Float32Array::from(vec![Some(f32::NAN), Some(0.0), Some(f32::INFINITY), Some(f32::NEG_INFINITY), None])) as ArrayRef,
+    DataType::Float32,
+    Scalar::Float(0.0),
+    Scalar::Float(f32::NAN),
+)]
+fn test_float_nan_sql_ordering(
+    #[case] array: ArrayRef,
+    #[case] dtype: DataType,
+    #[case] zero: Scalar,
+    #[case] nan: Scalar,
+) {
+    // Array: [NaN, 0.0, inf, -inf, NULL]
+    // SQL ordering: -inf < 0.0 < inf < NaN
+    let schema = Schema::new([Arc::new(Field::new("col", dtype, true))]);
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![array]).unwrap();
+    let col = column_expr!("col");
+
+    // NaN > 0.0: [true, false, true, false, NULL]
+    let pred = col.clone().gt(Expr::literal(zero.clone()));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![Some(true), Some(false), Some(true), Some(false), None]),
+        "col gt 0.0 (NaN should be greater)"
+    );
+
+    // col < NaN: everything except NaN itself is less than NaN
+    let pred = col.clone().lt(Expr::literal(nan.clone()));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![Some(false), Some(true), Some(true), Some(true), None]),
+        "col lt NaN"
+    );
+
+    // NaN == NaN: only the NaN row
+    let pred = col.clone().eq(Expr::literal(nan.clone()));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![
+            Some(true),
+            Some(false),
+            Some(false),
+            Some(false),
+            None
+        ]),
+        "col eq NaN"
+    );
+
+    // col <= NaN: everything is <= NaN
+    let pred = col.clone().le(Expr::literal(nan.clone()));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![Some(true), Some(true), Some(true), Some(true), None]),
+        "col le NaN"
+    );
+
+    // col >= NaN: only NaN itself
+    let pred = col.clone().ge(Expr::literal(nan.clone()));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![
+            Some(true),
+            Some(false),
+            Some(false),
+            Some(false),
+            None
+        ]),
+        "col ge NaN"
+    );
+
+    // NaN is NOT DISTINCT FROM NaN
+    let pred = col.clone().distinct(Expr::literal(nan.clone()));
+    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![
+            Some(false),
+            Some(true),
+            Some(true),
+            Some(true),
+            Some(true)
+        ]),
+        "col distinct NaN"
+    );
+
+    // Inverted gt: NOT (col > 0.0) = col <= 0.0, NaN should be false
+    let pred = col.clone().gt(Expr::literal(zero));
+    let result = evaluate_predicate(&pred, &batch, true).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![Some(false), Some(true), Some(false), Some(true), None]),
+        "NOT (col gt 0.0) with NaN"
+    );
+
+    // Inverted eq: NOT (col == NaN) = col != NaN
+    let pred = col.clone().eq(Expr::literal(nan));
+    let result = evaluate_predicate(&pred, &batch, true).unwrap();
+    assert_eq!(
+        result,
+        BooleanArray::from(vec![Some(false), Some(true), Some(true), Some(true), None]),
+        "NOT (col eq NaN)"
     );
 }

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -6,13 +6,14 @@ use Predicate as Pred;
 
 use super::*;
 use crate::arrow::array::{
-    create_array, Array, ArrayRef, BinaryViewArray, BooleanArray, Float32Array, Float64Array,
-    GenericStringArray, Int32Array, Int32Builder, ListArray, ListViewArray, MapArray, MapBuilder,
-    MapFieldNames, StringArray, StringBuilder, StringViewArray, StructArray,
+    create_array, Array, ArrayRef, BinaryViewArray, BooleanArray, DictionaryArray, Float32Array,
+    Float64Array, GenericStringArray, Int32Array, Int32Builder, ListArray, ListViewArray, MapArray,
+    MapBuilder, MapFieldNames, StringArray, StringBuilder, StringViewArray, StructArray,
 };
 use crate::arrow::buffer::{BooleanBuffer, NullBuffer, OffsetBuffer, ScalarBuffer};
+use crate::arrow::compute::cast;
 use crate::arrow::compute::kernels::cmp::{gt_eq, lt};
-use crate::arrow::datatypes::{DataType, Field, Fields, Schema};
+use crate::arrow::datatypes::{DataType, Field, Fields, Int32Type, Schema};
 use crate::engine::arrow_data::{ArrowEngineData, EngineDataArrowExt as _};
 use crate::engine::arrow_expression::evaluate_expression::to_json;
 use crate::engine::arrow_expression::opaque::{
@@ -1491,135 +1492,35 @@ fn test_geo_append_null_unsupported(#[case] dt: KernelDataType) {
 // Verify that -0.0 and 0.0 compare as logically equal.
 
 #[rstest]
-#[case::f64(
-    Arc::new(Float64Array::from(vec![Some(-0.0f64), Some(0.0), Some(1.0), Some(-1.0), None])) as ArrayRef,
-    DataType::Float64,
-    Scalar::Double(0.0),
-    Scalar::Double(-0.0),
-)]
-#[case::f32(
-    Arc::new(Float32Array::from(vec![Some(-0.0f32), Some(0.0), Some(1.0), Some(-1.0), None])) as ArrayRef,
-    DataType::Float32,
-    Scalar::Float(0.0),
-    Scalar::Float(-0.0),
-)]
+#[case::equal(Expr::eq, false, [Some(true), Some(true), Some(false), Some(false), None])]
+#[case::less(Expr::lt, false, [Some(false), Some(false), Some(false), Some(true), None])]
+#[case::greater(Expr::gt, false, [Some(false), Some(false), Some(true), Some(false), None])]
+#[case::less_equal(Expr::le, false, [Some(true), Some(true), Some(false), Some(true), None])]
+#[case::greater_equal(Expr::ge, false, [Some(true), Some(true), Some(true), Some(false), None])]
+#[case::distinct(Expr::distinct, false, [Some(false), Some(false), Some(true), Some(true), Some(true)])]
+#[case::inverted_equal(Expr::eq, true, [Some(false), Some(false), Some(true), Some(true), None])]
+#[case::inverted_less(Expr::lt, true, [Some(true), Some(true), Some(true), Some(false), None])]
+#[case::inverted_greater(Expr::gt, true, [Some(true), Some(true), Some(false), Some(true), None])]
 fn test_float_negative_zero_comparisons(
-    #[case] array: ArrayRef,
-    #[case] dtype: DataType,
-    #[case] pos_zero: Scalar,
-    #[case] neg_zero: Scalar,
+    #[case] make_predicate: fn(Expr, Expr) -> Pred,
+    #[case] inverted: bool,
+    #[case] expected: [Option<bool>; 5],
+    #[values(DataType::Float32, DataType::Float64)] data_type: DataType,
+    #[values(false, true)] negative_literal: bool,
 ) {
-    // Array: [-0.0, 0.0, 1.0, -1.0, NULL]
-    let schema = Schema::new([Arc::new(Field::new("col", dtype, true))]);
-    let batch = RecordBatch::try_new(Arc::new(schema), vec![array]).unwrap();
-    let col = column_expr!("col");
-
-    // Both -0.0 and 0.0 in the array should compare equal to literal 0.0
-    let pred = col.clone().eq(Expr::literal(pos_zero.clone()));
-    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    let values = Float64Array::from(vec![Some(-0.0), Some(0.0), Some(1.0), Some(-1.0), None]);
+    let array = cast(&values, &data_type).unwrap();
+    let zero = if negative_literal { -0.0 } else { 0.0 };
+    let literal = match data_type {
+        DataType::Float32 => Scalar::Float(zero as f32),
+        DataType::Float64 => Scalar::Double(zero),
+        _ => unreachable!(),
+    };
+    let batch = RecordBatch::try_from_iter([("col", array)]).unwrap();
+    let predicate = make_predicate(col!("col"), lit(literal));
     assert_eq!(
-        result,
-        BooleanArray::from(vec![Some(true), Some(true), Some(false), Some(false), None]),
-        "col eq 0.0"
-    );
-
-    // Both -0.0 and 0.0 in the array should compare equal to literal -0.0
-    let pred = col.clone().eq(Expr::literal(neg_zero.clone()));
-    let result = evaluate_predicate(&pred, &batch, false).unwrap();
-    assert_eq!(
-        result,
-        BooleanArray::from(vec![Some(true), Some(true), Some(false), Some(false), None]),
-        "col eq -0.0"
-    );
-
-    // Neither -0.0 nor 0.0 should be less than 0.0
-    let pred = col.clone().lt(Expr::literal(pos_zero.clone()));
-    let result = evaluate_predicate(&pred, &batch, false).unwrap();
-    assert_eq!(
-        result,
-        BooleanArray::from(vec![
-            Some(false),
-            Some(false),
-            Some(false),
-            Some(true),
-            None
-        ]),
-        "col lt 0.0"
-    );
-
-    // Neither -0.0 nor 0.0 should be greater than 0.0
-    let pred = col.clone().gt(Expr::literal(pos_zero.clone()));
-    let result = evaluate_predicate(&pred, &batch, false).unwrap();
-    assert_eq!(
-        result,
-        BooleanArray::from(vec![
-            Some(false),
-            Some(false),
-            Some(true),
-            Some(false),
-            None
-        ]),
-        "col gt 0.0"
-    );
-
-    // Both -0.0 and 0.0 should be <= 0.0
-    let pred = col.clone().le(Expr::literal(pos_zero.clone()));
-    let result = evaluate_predicate(&pred, &batch, false).unwrap();
-    assert_eq!(
-        result,
-        BooleanArray::from(vec![Some(true), Some(true), Some(false), Some(true), None]),
-        "col le 0.0"
-    );
-
-    // Both -0.0 and 0.0 should be >= 0.0
-    let pred = col.clone().ge(Expr::literal(pos_zero.clone()));
-    let result = evaluate_predicate(&pred, &batch, false).unwrap();
-    assert_eq!(
-        result,
-        BooleanArray::from(vec![Some(true), Some(true), Some(true), Some(false), None]),
-        "col ge 0.0"
-    );
-
-    // -0.0 and 0.0 are NOT DISTINCT (they are the same value in SQL)
-    let pred = col.clone().distinct(Expr::literal(pos_zero.clone()));
-    let result = evaluate_predicate(&pred, &batch, false).unwrap();
-    assert_eq!(
-        result,
-        BooleanArray::from(vec![
-            Some(false),
-            Some(false),
-            Some(true),
-            Some(true),
-            Some(true)
-        ]),
-        "col distinct 0.0"
-    );
-
-    // Inverted eq (ne): -0.0 and 0.0 should NOT be unequal
-    let pred = col.clone().eq(Expr::literal(neg_zero));
-    let result = evaluate_predicate(&pred, &batch, true).unwrap();
-    assert_eq!(
-        result,
-        BooleanArray::from(vec![Some(false), Some(false), Some(true), Some(true), None]),
-        "NOT (col eq -0.0)"
-    );
-
-    // Inverted lt (ge): -0.0 and 0.0 are >= 0.0
-    let pred = col.clone().lt(Expr::literal(pos_zero.clone()));
-    let result = evaluate_predicate(&pred, &batch, true).unwrap();
-    assert_eq!(
-        result,
-        BooleanArray::from(vec![Some(true), Some(true), Some(true), Some(false), None]),
-        "NOT (col lt 0.0) = col ge 0.0"
-    );
-
-    // Inverted gt (le): -0.0 and 0.0 are <= 0.0
-    let pred = col.clone().gt(Expr::literal(pos_zero));
-    let result = evaluate_predicate(&pred, &batch, true).unwrap();
-    assert_eq!(
-        result,
-        BooleanArray::from(vec![Some(true), Some(true), Some(false), Some(true), None]),
-        "NOT (col gt 0.0) = col le 0.0"
+        evaluate_predicate(&predicate, &batch, inverted).unwrap(),
+        BooleanArray::from(expected.to_vec())
     );
 }
 
@@ -1664,122 +1565,42 @@ fn test_float_neg_zero_in_predicate() {
 }
 
 #[rstest]
-#[case::f64(
-    Arc::new(Float64Array::from(vec![Some(f64::NAN), Some(0.0), Some(f64::INFINITY), Some(f64::NEG_INFINITY), None])) as ArrayRef,
-    DataType::Float64,
-    Scalar::Double(0.0),
-    Scalar::Double(f64::NAN),
-)]
-#[case::f32(
-    Arc::new(Float32Array::from(vec![Some(f32::NAN), Some(0.0), Some(f32::INFINITY), Some(f32::NEG_INFINITY), None])) as ArrayRef,
-    DataType::Float32,
-    Scalar::Float(0.0),
-    Scalar::Float(f32::NAN),
-)]
+#[case::above_zero(Expr::gt, 0.0, false, [Some(true), Some(false), Some(true), Some(false), None])]
+#[case::below_nan(Expr::lt, f64::NAN, false, [Some(false), Some(true), Some(true), Some(true), None])]
+#[case::equal_nan(Expr::eq, f64::NAN, false, [Some(true), Some(false), Some(false), Some(false), None])]
+#[case::less_equal_nan(Expr::le, f64::NAN, false, [Some(true), Some(true), Some(true), Some(true), None])]
+#[case::greater_equal_nan(Expr::ge, f64::NAN, false, [Some(true), Some(false), Some(false), Some(false), None])]
+#[case::distinct_nan(Expr::distinct, f64::NAN, false, [Some(false), Some(true), Some(true), Some(true), Some(true)])]
+#[case::inverted_greater(Expr::gt, 0.0, true, [Some(false), Some(true), Some(false), Some(true), None])]
+#[case::inverted_equal(Expr::eq, f64::NAN, true, [Some(false), Some(true), Some(true), Some(true), None])]
 fn test_float_positive_nan_total_ordering(
-    #[case] array: ArrayRef,
-    #[case] dtype: DataType,
-    #[case] zero: Scalar,
-    #[case] nan: Scalar,
+    #[case] make_predicate: fn(Expr, Expr) -> Pred,
+    #[case] literal: f64,
+    #[case] inverted: bool,
+    #[case] expected: [Option<bool>; 5],
+    #[values(DataType::Float32, DataType::Float64)] data_type: DataType,
 ) {
-    // Array: [NaN, 0.0, inf, -inf, NULL]
-    // Arrow's total order places this positive NaN above all non-NaN values.
-    let schema = Schema::new([Arc::new(Field::new("col", dtype, true))]);
-    let batch = RecordBatch::try_new(Arc::new(schema), vec![array]).unwrap();
-    let col = column_expr!("col");
-
-    // NaN > 0.0: [true, false, true, false, NULL]
-    let pred = col.clone().gt(Expr::literal(zero.clone()));
-    let result = evaluate_predicate(&pred, &batch, false).unwrap();
+    let values = Float64Array::from(vec![
+        Some(f64::NAN),
+        Some(0.0),
+        Some(f64::INFINITY),
+        Some(f64::NEG_INFINITY),
+        None,
+    ]);
+    let array = cast(&values, &data_type).unwrap();
+    let literal = match data_type {
+        DataType::Float32 => Scalar::Float(literal as f32),
+        DataType::Float64 => Scalar::Double(literal),
+        _ => unreachable!(),
+    };
+    let batch = RecordBatch::try_from_iter([("col", array)]).unwrap();
+    let predicate = make_predicate(col!("col"), lit(literal));
     assert_eq!(
-        result,
-        BooleanArray::from(vec![Some(true), Some(false), Some(true), Some(false), None]),
-        "col gt 0.0 (NaN should be greater)"
-    );
-
-    // col < NaN: everything except NaN itself is less than NaN
-    let pred = col.clone().lt(Expr::literal(nan.clone()));
-    let result = evaluate_predicate(&pred, &batch, false).unwrap();
-    assert_eq!(
-        result,
-        BooleanArray::from(vec![Some(false), Some(true), Some(true), Some(true), None]),
-        "col lt NaN"
-    );
-
-    // NaN == NaN: only the NaN row
-    let pred = col.clone().eq(Expr::literal(nan.clone()));
-    let result = evaluate_predicate(&pred, &batch, false).unwrap();
-    assert_eq!(
-        result,
-        BooleanArray::from(vec![
-            Some(true),
-            Some(false),
-            Some(false),
-            Some(false),
-            None
-        ]),
-        "col eq NaN"
-    );
-
-    // col <= NaN: everything is <= NaN
-    let pred = col.clone().le(Expr::literal(nan.clone()));
-    let result = evaluate_predicate(&pred, &batch, false).unwrap();
-    assert_eq!(
-        result,
-        BooleanArray::from(vec![Some(true), Some(true), Some(true), Some(true), None]),
-        "col le NaN"
-    );
-
-    // col >= NaN: only NaN itself
-    let pred = col.clone().ge(Expr::literal(nan.clone()));
-    let result = evaluate_predicate(&pred, &batch, false).unwrap();
-    assert_eq!(
-        result,
-        BooleanArray::from(vec![
-            Some(true),
-            Some(false),
-            Some(false),
-            Some(false),
-            None
-        ]),
-        "col ge NaN"
-    );
-
-    // NaN is NOT DISTINCT FROM NaN
-    let pred = col.clone().distinct(Expr::literal(nan.clone()));
-    let result = evaluate_predicate(&pred, &batch, false).unwrap();
-    assert_eq!(
-        result,
-        BooleanArray::from(vec![
-            Some(false),
-            Some(true),
-            Some(true),
-            Some(true),
-            Some(true)
-        ]),
-        "col distinct NaN"
-    );
-
-    // Inverted gt: NOT (col > 0.0) = col <= 0.0, NaN should be false
-    let pred = col.clone().gt(Expr::literal(zero));
-    let result = evaluate_predicate(&pred, &batch, true).unwrap();
-    assert_eq!(
-        result,
-        BooleanArray::from(vec![Some(false), Some(true), Some(false), Some(true), None]),
-        "NOT (col gt 0.0) with NaN"
-    );
-
-    // Inverted eq: NOT (col == NaN) = col != NaN
-    let pred = col.clone().eq(Expr::literal(nan));
-    let result = evaluate_predicate(&pred, &batch, true).unwrap();
-    assert_eq!(
-        result,
-        BooleanArray::from(vec![Some(false), Some(true), Some(true), Some(true), None]),
-        "NOT (col eq NaN)"
+        evaluate_predicate(&predicate, &batch, inverted).unwrap(),
+        BooleanArray::from(expected.to_vec())
     );
 }
 
-/// Verifies the inverted-distinct branches of `float_logical_distinct`.
 /// `IS NOT DISTINCT FROM` treats nulls as comparable: `NULL <=> NULL` is true, `NULL <=> v`
 /// is false. Signed zeros and identical NaN values are not distinct.
 #[rstest]
@@ -1822,9 +1643,7 @@ fn test_float_not_distinct_from(
     );
 }
 
-/// Column-vs-column comparisons exercise `NullBuffer::union` with disjoint null positions,
-/// the non-null arm of `float_logical_distinct` for both-NaN rows, and the
-/// both-null row where DISTINCT is false and `<=>` is true.
+/// Covers signed zeros, identical NaNs, disjoint nulls, and matching nulls across float columns.
 #[test]
 fn test_float_column_vs_column() {
     let left = Arc::new(Float64Array::from(vec![
@@ -1937,6 +1756,177 @@ fn test_float_nan_payload_total_ordering_is_preserved() {
 
     let result = evaluate_predicate(&col.distinct(lit(higher_nan)), &batch, false).unwrap();
     assert_eq!(result, BooleanArray::from(vec![true, false]));
+}
+
+#[rstest]
+fn test_float_dictionary_comparisons_match_plain_arrays(
+    #[values(DataType::Float32, DataType::Float64)] data_type: DataType,
+    #[values(
+        BinaryPredicateOp::Equal,
+        BinaryPredicateOp::LessThan,
+        BinaryPredicateOp::GreaterThan,
+        BinaryPredicateOp::Distinct
+    )]
+    op: BinaryPredicateOp,
+    #[values(false, true)] inverted: bool,
+    #[values("literal", "column", "dictionary")] rhs: &str,
+    #[values(false, true)] swap: bool,
+    #[values(1, 2)] dictionary_depth: usize,
+) {
+    let values = [
+        Some(-0.0),
+        Some(0.0),
+        Some(-1.0),
+        Some(1.0),
+        Some(f64::NAN),
+        Some(-f64::NAN),
+        None,
+    ];
+    let left_keys = [
+        Some(0),
+        Some(1),
+        Some(2),
+        Some(3),
+        Some(4),
+        Some(5),
+        Some(6),
+        None,
+        Some(0),
+        None,
+        Some(3),
+    ];
+    let right_keys = [
+        Some(1),
+        Some(0),
+        Some(2),
+        Some(2),
+        Some(4),
+        Some(4),
+        Some(0),
+        Some(1),
+        Some(6),
+        None,
+        None,
+    ];
+    let make_arrays = |keys: &[Option<i32>]| {
+        let plain: Float64Array = keys
+            .iter()
+            .map(|key| key.and_then(|key| values[key as usize]))
+            .collect();
+        let plain = cast(&plain, &data_type).unwrap();
+        let dictionary_values = cast(&Float64Array::from(values.to_vec()), &data_type).unwrap();
+        let mut encoded: ArrayRef = Arc::new(DictionaryArray::<Int32Type>::new(
+            Int32Array::from(keys.to_vec()),
+            dictionary_values,
+        ));
+        for _ in 1..dictionary_depth {
+            encoded = Arc::new(DictionaryArray::<Int32Type>::new(
+                Int32Array::from_iter_values(0..keys.len() as i32),
+                encoded,
+            ));
+        }
+        (plain, encoded)
+    };
+    let (plain_left, encoded_left) = make_arrays(&left_keys);
+    let (plain_right, encoded_right) = make_arrays(&right_keys);
+    let encoded_right = if rhs == "dictionary" {
+        encoded_right
+    } else {
+        plain_right.clone()
+    };
+    let plain = RecordBatch::try_from_iter([("left", plain_left), ("right", plain_right)]).unwrap();
+    let encoded =
+        RecordBatch::try_from_iter([("left", encoded_left), ("right", encoded_right)]).unwrap();
+    let right = if rhs == "literal" {
+        lit(match data_type {
+            DataType::Float32 => Scalar::Float(0.0),
+            DataType::Float64 => Scalar::Double(0.0),
+            _ => unreachable!(),
+        })
+    } else {
+        col!("right")
+    };
+    let (left, right) = if swap {
+        (right, col!("left"))
+    } else {
+        (col!("left"), right)
+    };
+    let predicate = Pred::binary(op, left, right);
+    let expected = evaluate_predicate(&predicate, &plain, inverted).unwrap();
+    if op == BinaryPredicateOp::Equal {
+        assert_eq!(expected.value(0), !inverted);
+        assert_eq!(expected.value(1), !inverted);
+    }
+    assert_eq!(
+        evaluate_predicate(&predicate, &encoded, inverted).unwrap(),
+        expected
+    );
+}
+
+#[rstest]
+fn test_float_distinct_without_nulls_across_bitmap_boundaries(
+    #[values(DataType::Float32, DataType::Float64)] data_type: DataType,
+    #[values(0, 1, 63, 64, 65, 129)] len: usize,
+    #[values(false, true)] inverted: bool,
+) {
+    let make_array = |values: &[f64]| -> ArrayRef {
+        match data_type {
+            DataType::Float32 => Arc::new(Float32Array::from_iter_values(
+                (0..len).map(|index| values[index % values.len()] as f32),
+            )),
+            DataType::Float64 => Arc::new(Float64Array::from_iter_values(
+                (0..len).map(|index| values[index % values.len()]),
+            )),
+            _ => unreachable!(),
+        }
+    };
+    let batch = RecordBatch::try_from_iter([
+        ("left", make_array(&[-0.0, 0.0, 1.0, f64::NAN, f64::NAN])),
+        ("right", make_array(&[0.0, -0.0, 2.0, f64::NAN, 1.0])),
+    ])
+    .unwrap();
+    let predicate = col!("left").distinct(col!("right"));
+    let result = evaluate_predicate(&predicate, &batch, inverted).unwrap();
+    let expected = BooleanArray::from_iter(
+        (0..len).map(|index| Some((index % 5 == 2 || index % 5 == 4) ^ inverted)),
+    );
+    assert_eq!(result, expected);
+    assert!(result.nulls().is_none());
+}
+
+#[rstest]
+#[case::left_nulls(true, false)]
+#[case::right_nulls(false, true)]
+#[case::both_nulls(true, true)]
+fn test_float_distinct_nullable_slices_across_bitmap_boundaries(
+    #[case] left_nullable: bool,
+    #[case] right_nullable: bool,
+    #[values(DataType::Float32, DataType::Float64)] data_type: DataType,
+    #[values(0, 1, 63, 64)] offset: usize,
+    #[values(0, 1, 63, 64, 65, 129)] len: usize,
+    #[values(false, true)] inverted: bool,
+) {
+    let make_array = |zero: f64, nullable: bool, period: usize, start: usize| {
+        let values: Float64Array = (0..start + len)
+            .map(|index| (!nullable || index % period != 0).then_some(zero))
+            .collect();
+        cast(&values, &data_type).unwrap().slice(start, len)
+    };
+    let left = make_array(-0.0, left_nullable, 3, offset);
+    let right = make_array(0.0, right_nullable, 5, offset + 1);
+    let expected = BooleanArray::from_iter((0..len).map(|row| {
+        let left_null = left_nullable && (offset + row) % 3 == 0;
+        let right_null = right_nullable && (offset + 1 + row) % 5 == 0;
+        Some(match (left_null, right_null) {
+            (true, true) | (false, false) => inverted,
+            _ => !inverted,
+        })
+    }));
+    let batch = RecordBatch::try_from_iter([("left", left), ("right", right)]).unwrap();
+    let result =
+        evaluate_predicate(&col!("left").distinct(col!("right")), &batch, inverted).unwrap();
+    assert_eq!(result, expected);
+    assert!(result.nulls().is_none());
 }
 
 /// Empty and all-null float arrays should not panic and should produce the expected results.

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -1908,15 +1908,15 @@ fn test_float_distinct_nullable_slices_across_bitmap_boundaries(
 ) {
     let make_array = |zero: f64, nullable: bool, period: usize, start: usize| {
         let values: Float64Array = (0..start + len)
-            .map(|index| (!nullable || index % period != 0).then_some(zero))
+            .map(|index| (!nullable || !index.is_multiple_of(period)).then_some(zero))
             .collect();
         cast(&values, &data_type).unwrap().slice(start, len)
     };
     let left = make_array(-0.0, left_nullable, 3, offset);
     let right = make_array(0.0, right_nullable, 5, offset + 1);
     let expected = BooleanArray::from_iter((0..len).map(|row| {
-        let left_null = left_nullable && (offset + row) % 3 == 0;
-        let right_null = right_nullable && (offset + 1 + row) % 5 == 0;
+        let left_null = left_nullable && (offset + row).is_multiple_of(3);
+        let right_null = right_nullable && (offset + 1 + row).is_multiple_of(5);
         Some(match (left_null, right_null) {
             (true, true) | (false, false) => inverted,
             _ => !inverted,

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -3,6 +3,9 @@ use std::collections::HashMap;
 use rstest::rstest;
 
 use super::*;
+use crate::arrow::array::{ArrayRef, BooleanArray, Float64Array, RecordBatch, StructArray};
+use crate::arrow::datatypes::{DataType as ArrowDataType, Field};
+use crate::engine::arrow_expression::evaluate_expression::evaluate_predicate;
 use crate::expressions::{col, column_expr_ref, column_name, lit};
 use crate::kernel_predicates::{
     DefaultKernelPredicateEvaluator, EmptyColumnResolver, UnimplementedColumnResolver,
@@ -1375,6 +1378,33 @@ fn test_partition_column_comparison_uses_exact_value() {
         (column_name!("is_add"), Scalar::from(true)),
     ]));
     assert_eq!(resolver.eval(&skipping_pred), TRUE);
+}
+
+#[test]
+fn test_arrow_partition_data_skipping_treats_signed_zero_as_equal() {
+    let partition_columns = test_partition_columns();
+    let partition_values = StructArray::from(vec![(
+        Arc::new(Field::new("part_col", ArrowDataType::Float64, false)),
+        Arc::new(Float64Array::from(vec![-0.0, 0.0])) as ArrayRef,
+    )]);
+    let batch = RecordBatch::try_from_iter([
+        (
+            "partitionValues_parsed",
+            Arc::new(partition_values) as ArrayRef,
+        ),
+        (
+            "is_add",
+            Arc::new(BooleanArray::from(vec![true, true])) as ArrayRef,
+        ),
+    ])
+    .unwrap();
+
+    for zero in [0.0, -0.0] {
+        let pred = Pred::eq(col!("part_col"), lit(zero));
+        let skipping_pred = as_sql_data_skipping_predicate(&pred, &partition_columns).unwrap();
+        let result = evaluate_predicate(&skipping_pred, &batch, false).unwrap();
+        assert_eq!(result, BooleanArray::from(vec![true, true]));
+    }
 }
 
 #[test]


### PR DESCRIPTION
## What changes are proposed in this pull request?

Arrow's total ordering distinguishes `-0.0` from `+0.0`. That can wrongly prune a file when an exact float value, such as a parsed partition value of `-0.0`, is compared with `+0.0`.

Treat signed zeros as equal in `Float32` and `Float64` comparisons while preserving Arrow's existing NaN ordering, null propagation, and null-safe `DISTINCT` behavior. Plain arrays handle zeros during comparison; dictionary arrays normalize their values without decoding every row. Ordering against a nonzero literal keeps Arrow's existing fast path.

This addresses exact-value pruning. Conformant Parquet range statistics already bracket signed zero with a `-0.0` minimum and `+0.0` maximum.

## How was this change tested?

- Signed-zero, NaN, null, `DISTINCT`, sliced-array, operand-order, and dictionary coverage, plus an exact partition-pruning regression. The focused matrix passes on Arrow 58 and 59.
- CI-selected workspace tests: 14,348 passed, 64 skipped, using the same HDFS and FFI diagnostic test exclusions as CI.
- Formatting, workspace docs, and strict kernel Clippy. Strict workspace Clippy hits the unchanged `redundant_closure` warning in `ffi/src/ffi_tracing.rs:384`; it passes with that lint allowed.

Local benchmarks used finite data without `-0.0`. The nonzero-literal fast path matched main in stable runs (about 13% faster than the pre-optimization PR for f32 at 32K rows). At 64K rows, zero-literal ordering still measured 9-15% slower and column equality 18-19% slower than main. Full-scan timings were too noisy to draw a conclusion. Benchmark harnesses are kept out of this PR; the correctness tests remain.
