### PR TITLE
feat: collect nullCount statistics for array, map, and variant columns

### DIFF
--- a/kernel/src/column_trie.rs
+++ b/kernel/src/column_trie.rs
@@ -75,13 +75,44 @@ impl<'col> ColumnTrie<'col> {
         node.is_terminal = true;
     }
 
+    /// Returns true if `path` exactly matches a terminal (leaf) column in the trie.
+    ///
+    /// This is used by stats collection to detect columns that are structs at the Arrow level
+    /// but should be treated as leaf columns for statistics (e.g. Variant, which is
+    /// `Struct { metadata, value }` in Arrow but a single leaf in the stats schema). For such
+    /// columns, stats collection computes nullCount at the struct level instead of recursing
+    /// into sub-fields.
+    ///
+    /// Unlike [`contains_prefix_of`], this does NOT match descendants. It returns true only
+    /// when the path ends at a terminal node. `contains_prefix_of` would return true for both
+    /// a terminal column and its descendants, which can't distinguish a stats-leaf struct from
+    /// a regular struct whose children are stats columns.
+    ///
+    /// For example, if the trie contains `["a", "b"]`:
+    /// - `["a", "b"]` -> true (exact terminal match)
+    /// - `["a", "b", "c"]` -> false (descendant, not exact)
+    /// - `["a"]` -> false (not terminal)
+    ///
+    /// [`contains_prefix_of`]: Self::contains_prefix_of
+    #[internal_api]
+    pub(crate) fn is_terminal(&self, path: &[String]) -> bool {
+        let mut node = self;
+        for part in path {
+            match node.children.get(part.as_str()) {
+                Some(child) => node = child,
+                None => return false,
+            }
+        }
+        node.is_terminal
+    }
+
     /// Returns true if `path` equals or is a descendant of any inserted column.
     ///
     /// For example, if the trie contains `["a", "b"]`:
-    /// - `["a", "b"]` → true (exact match)
-    /// - `["a", "b", "c"]` → true (descendant)
-    /// - `["a"]` → false (ancestor, not descendant)
-    /// - `["a", "x"]` → false (divergent path)
+    /// - `["a", "b"]` -> true (exact match)
+    /// - `["a", "b", "c"]` -> true (descendant)
+    /// - `["a"]` -> false (ancestor, not descendant)
+    /// - `["a", "x"]` -> false (divergent path)
     #[internal_api]
     pub(crate) fn contains_prefix_of(&self, path: &[String]) -> bool {
         let mut node = self;
@@ -111,21 +142,21 @@ mod tests {
         let columns = [ColumnName::new(["a", "b"])];
         let trie = ColumnTrie::from_columns(&columns);
 
-        // Exact match: path = ["a", "b"] → include
+        // Exact match: path = ["a", "b"] -> include
         assert!(trie.contains_prefix_of(&["a".to_string(), "b".to_string()]));
 
-        // Descendant of specified: path = ["a", "b", "c"] → include
+        // Descendant of specified: path = ["a", "b", "c"] -> include
         assert!(trie.contains_prefix_of(&["a".to_string(), "b".to_string(), "c".to_string()]));
 
-        // Ancestor of specified: path = ["a"] → NOT include
+        // Ancestor of specified: path = ["a"] -> NOT include
         assert!(!trie.contains_prefix_of(&["a".to_string()]));
 
-        // Unrelated paths → NOT include
+        // Unrelated paths -> NOT include
         assert!(!trie.contains_prefix_of(&["a".to_string(), "c".to_string()]));
         assert!(!trie.contains_prefix_of(&["x".to_string(), "y".to_string()]));
 
         // Non-existent nested path: trie has ["a", "b", "c", "d"], path = ["a", "b"]
-        // User asked for a.b.c.d but a.b is a leaf → NOT include
+        // User asked for a.b.c.d but a.b is a leaf -> NOT include
         let deep_columns = [ColumnName::new(["a", "b", "c", "d"])];
         let deep_trie = ColumnTrie::from_columns(&deep_columns);
         assert!(!deep_trie.contains_prefix_of(&["a".to_string(), "b".to_string()]));
@@ -150,5 +181,27 @@ mod tests {
         assert!(!multi_trie.contains_prefix_of(&["x".to_string(), "y".to_string()])); // ancestor
         assert!(!multi_trie.contains_prefix_of(&["a".to_string(), "c".to_string()]));
         // divergent
+    }
+
+    #[test]
+    fn test_is_terminal() {
+        let columns = [ColumnName::new(["a", "b"]), ColumnName::new(["x"])];
+        let trie = ColumnTrie::from_columns(&columns);
+
+        // Exact terminal match
+        assert!(trie.is_terminal(&["a".to_string(), "b".to_string()]));
+        assert!(trie.is_terminal(&["x".to_string()]));
+
+        // Non-terminal ancestor
+        assert!(!trie.is_terminal(&["a".to_string()]));
+
+        // Descendant past terminal
+        assert!(!trie.is_terminal(&["a".to_string(), "b".to_string(), "c".to_string()]));
+
+        // Path not in trie
+        assert!(!trie.is_terminal(&["z".to_string()]));
+
+        // Empty path (root is never terminal)
+        assert!(!trie.is_terminal(&[]));
     }
 }

--- a/kernel/src/engine/default/stats.rs
+++ b/kernel/src/engine/default/stats.rs
@@ -1265,26 +1265,14 @@ mod tests {
         let stats = collect_stats(&batch, &[column_name!("id"), column_name!("map_col")]).unwrap();
 
         // === THEN: map_col has nullCount=1 but no min/max ===
-        let null_count = stats
-            .column_by_name("nullCount")
-            .unwrap()
-            .as_any()
-            .downcast_ref::<StructArray>()
-            .unwrap();
+        let null_count = child_struct(&stats, "nullCount");
         let map_nulls = null_count
             .column_by_name("map_col")
             .unwrap()
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .unwrap();
+            .as_primitive::<Int64Type>();
         assert_eq!(map_nulls.value(0), 1);
 
-        let min_values = stats
-            .column_by_name("minValues")
-            .unwrap()
-            .as_any()
-            .downcast_ref::<StructArray>()
-            .unwrap();
+        let min_values = child_struct(&stats, "minValues");
         assert!(min_values.column_by_name("id").is_some());
         assert!(min_values.column_by_name("map_col").is_none());
     }
@@ -1330,34 +1318,22 @@ mod tests {
         )
         .unwrap();
 
-        // === WHEN: collecting stats with "v" as a terminal column (not "v.metadata", "v.value") ===
+        // === WHEN: collecting stats with "v" as a terminal column ===
         let stats = collect_stats(&batch, &[column_name!("id"), column_name!("v")]).unwrap();
 
         // === THEN: v has nullCount=1 at the struct level, no recursion, no min/max ===
-        let null_count = stats
-            .column_by_name("nullCount")
-            .unwrap()
-            .as_any()
-            .downcast_ref::<StructArray>()
-            .unwrap();
+        let null_count = child_struct(&stats, "nullCount");
         let v_nulls = null_count
             .column_by_name("v")
             .unwrap()
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .unwrap();
+            .as_primitive::<Int64Type>();
         assert_eq!(v_nulls.value(0), 1);
 
         // v must NOT be recursed into, no nested metadata/value in nullCount
         assert!(null_count.column_by_name("metadata").is_none());
         assert!(null_count.column_by_name("value").is_none());
 
-        let min_values = stats
-            .column_by_name("minValues")
-            .unwrap()
-            .as_any()
-            .downcast_ref::<StructArray>()
-            .unwrap();
+        let min_values = child_struct(&stats, "minValues");
         assert!(min_values.column_by_name("id").is_some());
         assert!(min_values.column_by_name("v").is_none());
     }
@@ -1442,6 +1418,16 @@ mod tests {
             get_stat::<Int32Type>(&stats, "maxValues", "my_struct", "b"),
             20
         );
+    }
+
+    /// Extracts a named child column from a StructArray, downcasting it to StructArray.
+    fn child_struct<'a>(parent: &'a StructArray, name: &str) -> &'a StructArray {
+        parent
+            .column_by_name(name)
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap()
     }
 
     // Generic helper to extract and downcast nested columns from stats

--- a/kernel/src/engine/default/stats.rs
+++ b/kernel/src/engine/default/stats.rs
@@ -343,13 +343,22 @@ struct ColumnStats {
 ///
 /// Returns `ColumnStats` containing null_count, min, and max for this column.
 /// For struct columns, these are nested StructArrays. For leaf columns, these are scalar arrays.
-/// Map, List, and other complex types are skipped (returns default empty stats).
+/// Complex types (Map, List, Variant) get nullCount only because they have no meaningful
+/// ordering for min/max data skipping, but null counts are still useful for tracking nullability.
 fn compute_column_stats(
     column: &ArrayRef,
     path: &mut Vec<String>,
     filter: &ColumnTrie<'_>,
 ) -> DeltaResult<ColumnStats> {
     match column.data_type() {
+        // A struct column that the filter marks as a terminal leaf (e.g. Variant, which is a
+        // struct at the Arrow level but a leaf for stats purposes) gets nullCount only, no
+        // recursion into sub-fields and no min/max.
+        DataType::Struct(_) if filter.is_terminal(path) => Ok(ColumnStats {
+            null_count: Some(Arc::new(Int64Array::from(vec![column.null_count() as i64]))),
+            min_value: None,
+            max_value: None,
+        }),
         DataType::Struct(fields) => {
             let struct_array = column
                 .as_struct_opt()
@@ -547,8 +556,10 @@ pub(crate) fn collect_stats(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::arrow::array::{Array, AsArray, Int32Array, Int64Array, StringArray};
-    use crate::arrow::buffer::NullBuffer;
+    use crate::arrow::array::{
+        Array, AsArray, BinaryArray, Int32Array, Int64Array, ListArray, MapArray, StringArray,
+    };
+    use crate::arrow::buffer::{NullBuffer, OffsetBuffer};
     use crate::arrow::compute::concat_batches;
     use crate::arrow::datatypes::{Fields, Int32Type, Int64Type, Schema};
     use crate::engine::arrow_expression::evaluate_expression::to_json;
@@ -1025,7 +1036,11 @@ mod tests {
         let batch =
             RecordBatch::try_new(schema, vec![Arc::new(nested_struct) as ArrayRef]).unwrap();
 
-        let stats = collect_stats(&batch, &[column_name!("nested")]).unwrap();
+        let stats = collect_stats(
+            &batch,
+            &[column_name!("nested.a"), column_name!("nested.b")],
+        )
+        .unwrap();
 
         // Check nullCount.nested.a = 0, nullCount.nested.b = 1
         let null_count = stats
@@ -1123,9 +1138,6 @@ mod tests {
 
     #[test]
     fn test_collect_stats_complex_types_null_count_only() {
-        use crate::arrow::array::ListArray;
-        use crate::arrow::buffer::OffsetBuffer;
-
         // Schema with list column - should have nullCount but no min/max
         let schema = Arc::new(Schema::new(vec![
             Field::new("id", DataType::Int64, false),
@@ -1205,6 +1217,152 @@ mod tests {
     }
 
     #[test]
+    fn test_collect_stats_map_null_count_only() {
+        // === GIVEN: a batch with an id column and a map column (1 null out of 3 rows) ===
+        let map_field = Field::new(
+            "entries",
+            DataType::Struct(Fields::from(vec![
+                Field::new("key", DataType::Utf8, false),
+                Field::new("value", DataType::Int64, true),
+            ])),
+            false,
+        );
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new(
+                "map_col",
+                DataType::Map(Arc::new(map_field.clone()), false),
+                true,
+            ),
+        ]));
+        let keys = StringArray::from(vec!["a", "b"]);
+        let values = Int64Array::from(vec![1, 2]);
+        let entries = StructArray::new(
+            Fields::from(vec![
+                Field::new("key", DataType::Utf8, false),
+                Field::new("value", DataType::Int64, true),
+            ]),
+            vec![Arc::new(keys) as ArrayRef, Arc::new(values) as ArrayRef],
+            None,
+        );
+        let map_array = MapArray::new(
+            Arc::new(map_field),
+            OffsetBuffer::new(vec![0, 1, 1, 2].into()),
+            entries,
+            Some(vec![true, false, true].into()), // second element is null
+            false,
+        );
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+                Arc::new(map_array),
+            ],
+        )
+        .unwrap();
+
+        // === WHEN: collecting stats for both columns ===
+        let stats = collect_stats(&batch, &[column_name!("id"), column_name!("map_col")]).unwrap();
+
+        // === THEN: map_col has nullCount=1 but no min/max ===
+        let null_count = stats
+            .column_by_name("nullCount")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+        let map_nulls = null_count
+            .column_by_name("map_col")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(map_nulls.value(0), 1);
+
+        let min_values = stats
+            .column_by_name("minValues")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+        assert!(min_values.column_by_name("id").is_some());
+        assert!(min_values.column_by_name("map_col").is_none());
+    }
+
+    #[test]
+    fn test_collect_stats_variant_terminal_struct_null_count_only() {
+        // Variant is Struct { metadata: Binary, value: Binary } at the Arrow level, but
+        // stats_column_names lists it as a terminal leaf ["v"]. The is_terminal guard in
+        // compute_column_stats must produce nullCount at the struct level without recursing
+        // into metadata/value sub-fields.
+
+        // === GIVEN: a batch with an id column and a Variant column (1 null out of 3 rows) ===
+        let variant_fields = Fields::from(vec![
+            Field::new("metadata", DataType::Binary, false),
+            Field::new("value", DataType::Binary, false),
+        ]);
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("v", DataType::Struct(variant_fields.clone()), true),
+        ]));
+        let variant_array = StructArray::new(
+            variant_fields,
+            vec![
+                Arc::new(BinaryArray::from(vec![
+                    Some([0x01, 0x00, 0x00].as_slice()),
+                    None,
+                    Some([0x01, 0x00, 0x00].as_slice()),
+                ])) as ArrayRef,
+                Arc::new(BinaryArray::from(vec![
+                    Some([0x0C].as_slice()),
+                    None,
+                    Some([0x0C].as_slice()),
+                ])) as ArrayRef,
+            ],
+            Some(NullBuffer::from_iter([true, false, true])), // row 1 is null
+        );
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+                Arc::new(variant_array),
+            ],
+        )
+        .unwrap();
+
+        // === WHEN: collecting stats with "v" as a terminal column (not "v.metadata", "v.value") ===
+        let stats = collect_stats(&batch, &[column_name!("id"), column_name!("v")]).unwrap();
+
+        // === THEN: v has nullCount=1 at the struct level, no recursion, no min/max ===
+        let null_count = stats
+            .column_by_name("nullCount")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+        let v_nulls = null_count
+            .column_by_name("v")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(v_nulls.value(0), 1);
+
+        // v must NOT be recursed into, no nested metadata/value in nullCount
+        assert!(null_count.column_by_name("metadata").is_none());
+        assert!(null_count.column_by_name("value").is_none());
+
+        let min_values = stats
+            .column_by_name("minValues")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+        assert!(min_values.column_by_name("id").is_some());
+        assert!(min_values.column_by_name("v").is_none());
+    }
+
+    #[test]
     fn test_collect_stats_struct_with_nulls_at_struct_level() {
         // Schema: { my_struct: { a: int32, b: int32 (nullable) } }
         // Test both struct-level nulls and field-level nulls
@@ -1236,7 +1394,11 @@ mod tests {
 
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(struct_array)]).unwrap();
 
-        let stats = collect_stats(&batch, &[column_name!("my_struct")]).unwrap();
+        let stats = collect_stats(
+            &batch,
+            &[column_name!("my_struct.a"), column_name!("my_struct.b")],
+        )
+        .unwrap();
 
         // Visualizing the data:
         // Row 0: struct=NULL,  (a=1, b=None are "invisible")

--- a/kernel/src/scan/data_skipping/stats_schema/column_filter.rs
+++ b/kernel/src/scan/data_skipping/stats_schema/column_filter.rs
@@ -227,8 +227,9 @@ impl<'col> StatsColumnFilter<'col> {
                     self.collect_field(child, result);
                 }
             }
-            // Map, Array, and Variant types are not eligible for statistics collection.
-            DataType::Map(_) | DataType::Array(_) | DataType::Variant(_) => {}
+            // All non-struct types are leaf columns for stats purposes: they count against
+            // the column limit and are included in nullCount. Array, Map, and Variant are
+            // excluded from min/max by MinMaxStatsTransform.
             _ => {
                 if self.should_include_for_table() {
                     result.push(ColumnName::new(&self.path));

--- a/kernel/src/scan/data_skipping/stats_schema/mod.rs
+++ b/kernel/src/scan/data_skipping/stats_schema/mod.rs
@@ -28,10 +28,11 @@ use crate::{DeltaResult, Error};
 /// It tracks the count of null values for each column. All leaf fields from the base schema
 /// are converted to LONG type (since null counts are always integers).
 ///
-/// Note: Map, Array, and Variant types are excluded from statistics entirely (including
-/// `nullCount`) as they are not eligible for data skipping. The `nullCount` schema includes
-/// primitive types that aren't eligible for min/max (e.g., Boolean, Binary) since null counts
-/// are still meaningful for those types.
+/// Note: Array, Map, and Variant types are included in `nullCount` (null counts are meaningful
+/// for these types) but excluded from `minValues`/`maxValues` (not eligible for data skipping).
+/// They count as leaf columns against the indexed column limit. The `nullCount` schema also
+/// includes primitive types that aren't eligible for min/max (e.g., Boolean, Binary) since null
+/// counts are still meaningful for those types.
 ///
 /// The `minValues`/`maxValues` struct fields are also nested structures mirroring the table's
 /// column hierarchy. They additionally filter out leaf fields with non-eligible data types
@@ -324,10 +325,22 @@ impl<'col> BaseStatsTransform<'col> {
             filter: StatsColumnFilter::new(config, required_columns, requested_columns),
         }
     }
+
+    /// Checks whether a leaf column (primitive, array, map, or variant) should be included in the
+    /// stats schema and records it against the column limit if so. The column limit is based on
+    /// schema order, so we count all leaf columns that pass the table filter, but only generate
+    /// stats for requested columns.
+    fn include_leaf(&mut self) -> bool {
+        if !self.filter.should_include_for_table() {
+            return false;
+        }
+        self.filter.record_included();
+        self.filter.should_include_for_requested()
+    }
 }
 
 impl<'a> SchemaTransform<'a> for BaseStatsTransform<'_> {
-    // Always traverse struct fields -- only primitive leaf values count against the column limit
+    // Always traverse struct fields. All non-struct leaf types count against the column limit.
     fn transform_struct_field(&mut self, field: &'a StructField) -> Option<Cow<'a, StructField>> {
         self.filter.enter_field(field.name());
         let data_type = self.transform(&field.data_type);
@@ -336,28 +349,19 @@ impl<'a> SchemaTransform<'a> for BaseStatsTransform<'_> {
     }
 
     fn transform_primitive(&mut self, ptype: &'a PrimitiveType) -> Option<Cow<'a, PrimitiveType>> {
-        if !self.filter.should_include_for_table() {
-            return None;
-        }
-
-        // The n_columns limit is based on schema order, so we count all leaf columns that pass the
-        // table filter, but then we only generate stats for requested columns.
-        self.filter.record_included();
-        self.filter
-            .should_include_for_requested()
-            .then_some(Cow::Borrowed(ptype))
+        self.include_leaf().then_some(Cow::Borrowed(ptype))
     }
 
-    fn transform_array(&mut self, _: &'a ArrayType) -> Option<Cow<'a, ArrayType>> {
-        None // not stats-eligible
+    fn transform_array(&mut self, atype: &'a ArrayType) -> Option<Cow<'a, ArrayType>> {
+        self.include_leaf().then_some(Cow::Borrowed(atype))
     }
 
-    fn transform_map(&mut self, _: &'a MapType) -> Option<Cow<'a, MapType>> {
-        None // not stats-eligible
+    fn transform_map(&mut self, mtype: &'a MapType) -> Option<Cow<'a, MapType>> {
+        self.include_leaf().then_some(Cow::Borrowed(mtype))
     }
 
-    fn transform_variant(&mut self, _: &'a StructType) -> Option<Cow<'a, StructType>> {
-        None // not stats-eligible
+    fn transform_variant(&mut self, vtype: &'a StructType) -> Option<Cow<'a, StructType>> {
+        self.include_leaf().then_some(Cow::Borrowed(vtype))
     }
 }
 
@@ -368,9 +372,8 @@ impl<'a> SchemaTransform<'a> for BaseStatsTransform<'_> {
 struct MinMaxStatsTransform;
 
 impl<'a> SchemaTransform<'a> for MinMaxStatsTransform {
-    // Array, Map, and Variant fields are filtered out by BaseStatsTransform, so these methods
-    // are typically not called. They're kept as a safety net in case the transform is used
-    // independently or the filtering logic changes.
+    // Array, Map, and Variant fields pass through BaseStatsTransform (for nullCount) but must
+    // be excluded from min/max stats.
     fn transform_array(&mut self, _: &'a ArrayType) -> Option<Cow<'a, ArrayType>> {
         None
     }
@@ -523,9 +526,10 @@ mod tests {
         )
         .unwrap();
 
-        // nullCount excludes array fields (tags) - only eligible primitive types
+        // nullCount includes array fields (tags) as leaf columns
         let expected_null_nested = StructType::new_unchecked([
             StructField::nullable("name", DataType::LONG),
+            StructField::nullable("tags", DataType::LONG),
             StructField::nullable("score", DataType::LONG),
         ]);
         let expected_null = StructType::new_unchecked([
@@ -584,6 +588,62 @@ mod tests {
             .into_owned();
 
         let expected = expected_stats(null_count, expected_fields);
+
+        assert_eq!(&expected, &stats_schema);
+    }
+
+    #[test]
+    fn test_stats_schema_stats_columns_with_complex_types() {
+        // When dataSkippingStatsColumns explicitly names a complex type column, only that
+        // column (plus any other named columns) should appear in the stats schema.
+        let properties: TableProperties = [(
+            "delta.dataSkippingStatsColumns".to_string(),
+            "id,tags".to_string(),
+        )]
+        .into();
+
+        let file_schema = StructType::new_unchecked([
+            StructField::nullable("id", DataType::LONG),
+            StructField::nullable(
+                "tags",
+                DataType::Array(Box::new(ArrayType::new(DataType::STRING, false))),
+            ),
+            StructField::nullable(
+                "metadata",
+                DataType::Map(Box::new(MapType::new(
+                    DataType::STRING,
+                    DataType::STRING,
+                    true,
+                ))),
+            ),
+            StructField::nullable("name", DataType::STRING),
+        ]);
+
+        let stats_schema = expected_stats_schema(
+            &file_schema,
+            &stats_config_from_table_properties(&properties),
+            None,
+            None,
+        )
+        .unwrap();
+
+        // nullCount: only id and tags (explicitly requested)
+        let expected_null_count = StructType::new_unchecked([
+            StructField::nullable("id", DataType::LONG),
+            StructField::nullable("tags", DataType::LONG),
+        ]);
+
+        // minValues/maxValues: only id (tags excluded by MinMaxStatsTransform)
+        let expected_min_max =
+            StructType::new_unchecked([StructField::nullable("id", DataType::LONG)]);
+
+        let expected = StructType::new_unchecked([
+            StructField::nullable("numRecords", DataType::LONG),
+            StructField::nullable("nullCount", expected_null_count),
+            StructField::nullable("minValues", expected_min_max.clone()),
+            StructField::nullable("maxValues", expected_min_max),
+            StructField::nullable("tightBounds", DataType::BOOLEAN),
+        ]);
 
         assert_eq!(&expected, &stats_schema);
     }
@@ -736,13 +796,14 @@ mod tests {
         )
         .unwrap();
 
-        // nullCount includes boolean and binary (primitives) but excludes array
+        // nullCount includes boolean, binary, and array (all non-struct types get nullCount)
         let expected_null_count = StructType::new_unchecked([
             StructField::nullable("is_active", DataType::LONG),
             StructField::nullable("metadata", DataType::LONG),
+            StructField::nullable("tags", DataType::LONG),
         ]);
 
-        // minValues/maxValues: no fields are eligible (boolean/binary excluded)
+        // minValues/maxValues: no fields are eligible (boolean/binary/array excluded)
         let expected = StructType::new_unchecked([
             StructField::nullable("numRecords", DataType::LONG),
             StructField::nullable("nullCount", expected_null_count),
@@ -753,14 +814,15 @@ mod tests {
     }
 
     #[test]
-    fn test_stats_schema_map_array_dont_count_against_limit() {
-        // Test that Map and Array fields don't count against the column limit.
-        // With a limit of 2, if we have: array, map, col1, col2, col3
-        // We should get stats for col1 and col2 (the first 2 eligible columns),
-        // not be limited by the array and map fields.
+    fn test_stats_schema_complex_types_count_against_limit() {
+        // Array, Map, and Variant are leaf columns that count against the column limit,
+        // matching Spark's truncateSchema which counts all non-struct fields.
+        // With a limit of 3, if we have: array, map, variant, col1, col2
+        // We should get nullCount for the 3 complex types (the first 3 leaf columns),
+        // and col1/col2 are excluded by the limit.
         let properties: TableProperties = [(
             "delta.dataSkippingNumIndexedCols".to_string(),
-            "2".to_string(),
+            "3".to_string(),
         )]
         .into();
 
@@ -777,9 +839,9 @@ mod tests {
                     true,
                 ))),
             ),
+            StructField::nullable("v", DataType::unshredded_variant()),
             StructField::nullable("col1", DataType::LONG),
             StructField::nullable("col2", DataType::STRING),
-            StructField::nullable("col3", DataType::INTEGER), // Should be excluded by limit
         ]);
 
         let stats_schema = expected_stats_schema(
@@ -790,21 +852,70 @@ mod tests {
         )
         .unwrap();
 
-        // nullCount has only eligible primitive columns (col1 and col2).
-        // Map/Array/Variant are excluded from all stats.
+        // nullCount includes array, map, and variant (the first 3 leaf columns).
+        // col1/col2 are excluded by the limit.
         let expected_null_count = StructType::new_unchecked([
-            StructField::nullable("col1", DataType::LONG),
-            StructField::nullable("col2", DataType::LONG),
+            StructField::nullable("tags", DataType::LONG),
+            StructField::nullable("metadata", DataType::LONG),
+            StructField::nullable("v", DataType::LONG),
         ]);
 
-        // minValues/maxValues only have eligible primitive types (col1 and col2).
-        // Map/Array are filtered out by MinMaxStatsTransform.
-        let expected_min_max = StructType::new_unchecked([
-            StructField::nullable("col1", DataType::LONG),
-            StructField::nullable("col2", DataType::STRING),
+        // minValues/maxValues: all 3 complex types are excluded by MinMaxStatsTransform,
+        // and col1/col2 are past the limit, so no min/max fields at all.
+        let expected = StructType::new_unchecked([
+            StructField::nullable("numRecords", DataType::LONG),
+            StructField::nullable("nullCount", expected_null_count),
+            StructField::nullable("tightBounds", DataType::BOOLEAN),
         ]);
 
-        let expected = expected_stats(expected_null_count, expected_min_max);
+        assert_eq!(&expected, &stats_schema);
+    }
+
+    #[test]
+    fn test_stats_schema_complex_type_consumes_slot_before_primitive() {
+        // Validates that a complex type consuming a slot causes a subsequent primitive to
+        // be excluded. With limit=2: id (long), tags (array), name (string), only id and
+        // tags get stats, name is excluded.
+        let properties: TableProperties = [(
+            "delta.dataSkippingNumIndexedCols".to_string(),
+            "2".to_string(),
+        )]
+        .into();
+
+        let file_schema = StructType::new_unchecked([
+            StructField::nullable("id", DataType::LONG),
+            StructField::nullable(
+                "tags",
+                DataType::Array(Box::new(ArrayType::new(DataType::STRING, false))),
+            ),
+            StructField::nullable("name", DataType::STRING),
+        ]);
+
+        let stats_schema = expected_stats_schema(
+            &file_schema,
+            &stats_config_from_table_properties(&properties),
+            None,
+            None,
+        )
+        .unwrap();
+
+        // nullCount: id and tags (first 2 leaf columns). name is excluded.
+        let expected_null_count = StructType::new_unchecked([
+            StructField::nullable("id", DataType::LONG),
+            StructField::nullable("tags", DataType::LONG),
+        ]);
+
+        // minValues/maxValues: only id (tags excluded by MinMaxStatsTransform, name past limit)
+        let expected_min_max =
+            StructType::new_unchecked([StructField::nullable("id", DataType::LONG)]);
+
+        let expected = StructType::new_unchecked([
+            StructField::nullable("numRecords", DataType::LONG),
+            StructField::nullable("nullCount", expected_null_count),
+            StructField::nullable("minValues", expected_min_max.clone()),
+            StructField::nullable("maxValues", expected_min_max),
+            StructField::nullable("tightBounds", DataType::BOOLEAN),
+        ]);
 
         assert_eq!(&expected, &stats_schema);
     }
@@ -901,7 +1012,7 @@ mod tests {
     }
 
     #[test]
-    fn test_stats_column_names_skips_non_eligible_types() {
+    fn test_stats_column_names_includes_complex_types() {
         let properties: TableProperties = [("key", "value")].into();
 
         let file_schema = StructType::new_unchecked([
@@ -918,6 +1029,7 @@ mod tests {
                     true,
                 ))),
             ),
+            StructField::nullable("v", DataType::unshredded_variant()),
             StructField::nullable("name", DataType::STRING),
         ]);
 
@@ -927,10 +1039,16 @@ mod tests {
         };
         let columns = stats_column_names(&file_schema, &config, None);
 
-        // Array and Map types should be excluded
+        // Array, Map, and Variant are leaf columns and included in the stats column list
         assert_eq!(
             columns,
-            vec![ColumnName::new(["id"]), ColumnName::new(["name"]),]
+            vec![
+                ColumnName::new(["id"]),
+                ColumnName::new(["tags"]),
+                ColumnName::new(["metadata"]),
+                ColumnName::new(["v"]),
+                ColumnName::new(["name"]),
+            ]
         );
     }
 

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -2096,7 +2096,7 @@ mod test {
         "id",
         vec![ColumnName::new(["phys_id"]), ColumnName::new(["phys_name"])],
     )]
-    // --- nested schema ---
+    // --- nested schema (includes map/array inside struct as leaf columns) ---
     #[case::nested_none(
         test_schema_nested(),
         "none",
@@ -2104,6 +2104,8 @@ mod test {
             ColumnName::new(["id"]),
             ColumnName::new(["info", "name"]),
             ColumnName::new(["info", "age"]),
+            ColumnName::new(["info", "tags"]),
+            ColumnName::new(["info", "scores"]),
         ],
     )]
     #[case::nested_name(
@@ -2113,6 +2115,8 @@ mod test {
             ColumnName::new(["phys_id"]),
             ColumnName::new(["phys_info", "phys_name"]),
             ColumnName::new(["phys_info", "phys_age"]),
+            ColumnName::new(["phys_info", "phys_tags"]),
+            ColumnName::new(["phys_info", "phys_scores"]),
         ],
     )]
     #[case::nested_id(
@@ -2122,39 +2126,41 @@ mod test {
             ColumnName::new(["phys_id"]),
             ColumnName::new(["phys_info", "phys_name"]),
             ColumnName::new(["phys_info", "phys_age"]),
+            ColumnName::new(["phys_info", "phys_tags"]),
+            ColumnName::new(["phys_info", "phys_scores"]),
         ],
     )]
-    // --- schema with map (map fields excluded from stats) ---
+    // --- schema with map (included as leaf for nullCount stats) ---
     #[case::map_none(
         test_schema_with_map(),
         "none",
-        vec![ColumnName::new(["id"]), ColumnName::new(["name"])],
+        vec![ColumnName::new(["id"]), ColumnName::new(["entries"]), ColumnName::new(["name"])],
     )]
     #[case::map_name(
         test_schema_with_map_and_column_mapping(),
         "name",
-        vec![ColumnName::new(["phys_id"]), ColumnName::new(["phys_name"])],
+        vec![ColumnName::new(["phys_id"]), ColumnName::new(["phys_entries"]), ColumnName::new(["phys_name"])],
     )]
     #[case::map_id(
         test_schema_with_map_and_column_mapping(),
         "id",
-        vec![ColumnName::new(["phys_id"]), ColumnName::new(["phys_name"])],
+        vec![ColumnName::new(["phys_id"]), ColumnName::new(["phys_entries"]), ColumnName::new(["phys_name"])],
     )]
-    // --- schema with array (array fields excluded from stats) ---
+    // --- schema with array (included as leaf for nullCount stats) ---
     #[case::array_none(
         test_schema_with_array(),
         "none",
-        vec![ColumnName::new(["id"]), ColumnName::new(["name"])],
+        vec![ColumnName::new(["id"]), ColumnName::new(["items"]), ColumnName::new(["name"])],
     )]
     #[case::array_name(
         test_schema_with_array_and_column_mapping(),
         "name",
-        vec![ColumnName::new(["phys_id"]), ColumnName::new(["phys_name"])],
+        vec![ColumnName::new(["phys_id"]), ColumnName::new(["phys_items"]), ColumnName::new(["phys_name"])],
     )]
     #[case::array_id(
         test_schema_with_array_and_column_mapping(),
         "id",
-        vec![ColumnName::new(["phys_id"]), ColumnName::new(["phys_name"])],
+        vec![ColumnName::new(["phys_id"]), ColumnName::new(["phys_items"]), ColumnName::new(["phys_name"])],
     )]
     fn test_physical_stats_column_names_all_schemas(
         #[case] schema: SchemaRef,

--- a/kernel/tests/write.rs
+++ b/kernel/tests/write.rs
@@ -8,7 +8,7 @@ use delta_kernel::arrow::array::{
     StructArray, TimestampMicrosecondArray,
 };
 use delta_kernel::arrow::buffer::{NullBuffer, OffsetBuffer};
-use delta_kernel::arrow::datatypes::{DataType as ArrowDataType, Field};
+use delta_kernel::arrow::datatypes::{DataType as ArrowDataType, Field, Schema as ArrowSchema};
 use delta_kernel::arrow::error::ArrowError;
 use delta_kernel::arrow::record_batch::RecordBatch;
 use delta_kernel::committer::FileSystemCommitter;
@@ -45,7 +45,7 @@ use test_utils::{
     create_default_engine_mt_executor, create_table, create_table_and_load_snapshot,
     engine_store_setup, nested_batches, nested_schema, read_actions_from_commit, read_add_infos,
     remove_all_and_get_remove_actions, resolve_field, set_json_value, setup_test_tables, test_read,
-    test_table_setup, write_batch_to_table,
+    test_table_setup, test_table_setup_mt, write_batch_to_table,
 };
 use url::Url;
 use uuid::Uuid;
@@ -497,7 +497,7 @@ async fn test_commit_info_with_engine_commit_info() -> Result<(), Box<dyn std::e
         //   - "myApp"    : engine-only field, must pass through unchanged.
         //   - "myVersion": engine-only field, must pass through unchanged.
         //   - "operation": overlapping with CommitInfo; kernel must override with "WRITE".
-        let arrow_schema = Arc::new(delta_kernel::arrow::datatypes::Schema::new(vec![
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![
             Field::new("myApp", ArrowDataType::Utf8, false),
             Field::new("myVersion", ArrowDataType::Utf8, false),
             Field::new("operation", ArrowDataType::Utf8, false),
@@ -4453,10 +4453,112 @@ async fn test_create_table_with_data_uses_relative_paths() -> Result<(), Box<dyn
     Ok(())
 }
 
+/// Builds a RecordBatch with schema (id: long, tags: array<string>, props: map<string, long>,
+/// v: variant). Each row gets one entry in tags, one entry in props, and a simple integer variant.
+/// If `nulls` is provided, it sets the null buffer for tags, props, and variant columns.
+fn complex_type_batch(schema: &StructType, ids: &[i64], nulls: Option<&[bool]>) -> RecordBatch {
+    let arrow_schema: ArrowSchema = schema.try_into_arrow().unwrap();
+    let arrow_schema = Arc::new(arrow_schema);
+    let n = ids.len();
+
+    let id_array = Int64Array::from(ids.to_vec());
+
+    // tags: one string element per row
+    let tag_values = StringArray::from((0..n).map(|i| format!("t{i}")).collect::<Vec<_>>());
+    let tag_offsets = OffsetBuffer::new((0..=n).map(|i| i as i32).collect::<Vec<_>>().into());
+    let list_field = match arrow_schema.field_with_name("tags").unwrap().data_type() {
+        ArrowDataType::List(f) => f.clone(),
+        other => panic!("expected List, got {other:?}"),
+    };
+    let tag_array = ListArray::new(
+        list_field,
+        tag_offsets,
+        Arc::new(tag_values),
+        nulls.map(NullBuffer::from),
+    );
+
+    // props: one {"k": id} entry per row
+    let map_keys = StringArray::from(vec!["k"; n]);
+    let map_vals = Int64Array::from(ids.to_vec());
+    let (map_entries_field, map_sorted) =
+        match arrow_schema.field_with_name("props").unwrap().data_type() {
+            ArrowDataType::Map(f, sorted) => (f.clone(), *sorted),
+            other => panic!("expected Map, got {other:?}"),
+        };
+    let entries_fields = match map_entries_field.data_type() {
+        ArrowDataType::Struct(f) => f.clone(),
+        other => panic!("expected Struct, got {other:?}"),
+    };
+    let entries = StructArray::new(
+        entries_fields,
+        vec![
+            Arc::new(map_keys) as ArrayRef,
+            Arc::new(map_vals) as ArrayRef,
+        ],
+        None,
+    );
+    let map_offsets = OffsetBuffer::new((0..=n).map(|i| i as i32).collect::<Vec<_>>().into());
+    let map_array = MapArray::new(
+        map_entries_field,
+        map_offsets,
+        entries,
+        nulls.map(NullBuffer::from),
+        map_sorted,
+    );
+
+    // v: simple integer variant per row (metadata=[0x01,0x00,0x00], value=[0x0C, low_byte])
+    let variant_meta = BinaryArray::from(
+        ids.iter()
+            .map(|_| Some(&[0x01u8, 0x00, 0x00][..]))
+            .collect::<Vec<_>>(),
+    );
+    let variant_val_data: Vec<[u8; 2]> = ids.iter().map(|&id| [0x0Cu8, id as u8]).collect();
+    let variant_val = BinaryArray::from(
+        variant_val_data
+            .iter()
+            .map(|v| Some(&v[..]))
+            .collect::<Vec<_>>(),
+    );
+    let variant_fields = match arrow_schema.field_with_name("v").unwrap().data_type() {
+        ArrowDataType::Struct(fields) => fields.clone(),
+        other => panic!("expected Struct, got {other:?}"),
+    };
+    let variant_array = StructArray::new(
+        variant_fields,
+        vec![
+            Arc::new(variant_meta) as ArrayRef,
+            Arc::new(variant_val) as ArrayRef,
+        ],
+        nulls.map(NullBuffer::from),
+    );
+
+    RecordBatch::try_new(
+        arrow_schema,
+        vec![
+            Arc::new(id_array) as ArrayRef,
+            Arc::new(tag_array) as ArrayRef,
+            Arc::new(map_array) as ArrayRef,
+            Arc::new(variant_array) as ArrayRef,
+        ],
+    )
+    .unwrap()
+}
+
 /// Verifies that writing a table with array, map, and variant columns produces nullCount
-/// statistics for those columns while excluding them from minValues/maxValues.
-#[tokio::test]
-async fn test_write_stats_for_complex_type_columns() -> Result<(), Box<dyn std::error::Error>> {
+/// statistics for those columns while excluding them from minValues/maxValues. Then writes a
+/// second file and scans with a predicate to verify data skipping works e2e. Parameterized
+/// over column mapping mode and whether a checkpoint is taken before the scan.
+#[rstest::rstest]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_write_stats_for_complex_type_columns(
+    #[values(
+        ColumnMappingMode::None,
+        ColumnMappingMode::Id,
+        ColumnMappingMode::Name
+    )]
+    cm_mode: ColumnMappingMode,
+    #[values(false, true)] use_checkpoint: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
     let _ = tracing_subscriber::fmt::try_init();
 
     let schema = Arc::new(StructType::try_new(vec![
@@ -4476,100 +4578,48 @@ async fn test_write_stats_for_complex_type_columns() -> Result<(), Box<dyn std::
         StructField::nullable("v", DataType::unshredded_variant()),
     ])?);
 
-    let (_tmp_dir, table_path, engine) = test_table_setup()?;
-    let snapshot =
-        create_table_and_load_snapshot(&table_path, schema.clone(), engine.as_ref(), &[])?;
-    let table_url = Url::from_directory_path(table_path).unwrap();
-
-    // Build Arrow arrays: 3 rows, with one null in each complex column
-    let arrow_schema: delta_kernel::arrow::datatypes::Schema = schema.as_ref().try_into_arrow()?;
-    let arrow_schema = Arc::new(arrow_schema);
-
-    let id_array = Int64Array::from(vec![1, 2, 3]);
-
-    // Extract the exact field types from the converted schema to avoid field name mismatches
-    let tags_field = arrow_schema.field_with_name("tags").unwrap();
-    let props_field = arrow_schema.field_with_name("props").unwrap();
-
-    // tags: [["a", "b"], null, ["c"]]
-    let tag_values = StringArray::from(vec!["a", "b", "c"]);
-    let tag_offsets = OffsetBuffer::new(vec![0, 2, 2, 3].into());
-    let list_element_field = match tags_field.data_type() {
-        ArrowDataType::List(f) => f.clone(),
-        other => panic!("expected List, got {other:?}"),
+    let mode_str = match cm_mode {
+        ColumnMappingMode::None => "none",
+        ColumnMappingMode::Id => "id",
+        ColumnMappingMode::Name => "name",
     };
-    let tag_array = ListArray::new(
-        list_element_field,
-        tag_offsets,
-        Arc::new(tag_values),
-        Some(NullBuffer::from_iter([true, false, true])),
-    );
-
-    // props: [{"k1": 10}, {"k2": 20}, null]
-    let map_keys = StringArray::from(vec!["k1", "k2"]);
-    let map_values = Int64Array::from(vec![Some(10i64), Some(20)]);
-    let (map_entries_field, map_sorted) = match props_field.data_type() {
-        ArrowDataType::Map(f, sorted) => (f.clone(), *sorted),
-        other => panic!("expected Map, got {other:?}"),
-    };
-    let entries_struct_fields = match map_entries_field.data_type() {
-        ArrowDataType::Struct(fields) => fields.clone(),
-        other => panic!("expected Struct for map entries, got {other:?}"),
-    };
-    let map_entries = StructArray::new(
-        entries_struct_fields,
-        vec![
-            Arc::new(map_keys) as ArrayRef,
-            Arc::new(map_values) as ArrayRef,
-        ],
-        None,
-    );
-    let map_offsets = OffsetBuffer::new(vec![0, 1, 2, 2].into());
-    let map_array = MapArray::new(
-        map_entries_field,
-        map_offsets,
-        map_entries,
-        Some(NullBuffer::from_iter([true, true, false])),
-        map_sorted,
-    );
-
-    // v: [variant(1), null, variant({"a": 2})]
-    let variant_metadata = BinaryArray::from(vec![
-        Some(&[0x01, 0x00, 0x00][..]),             // metadata for integer 1
-        None,                                      // null
-        Some(&[0x01, 0x01, 0x00, 0x01, 0x61][..]), // metadata for {"a": 2}
-    ]);
-    let variant_value = BinaryArray::from(vec![
-        Some(&[0x0C, 0x01][..]),                         // value for integer 1
-        None,                                            // null
-        Some(&[0x02, 0x01, 0x00, 0x00, 0x01, 0x02][..]), // value for {"a": 2}
-    ]);
-    let variant_fields = match arrow_schema.field_with_name("v").unwrap().data_type() {
-        ArrowDataType::Struct(fields) => fields.clone(),
-        other => panic!("expected Struct for variant, got {other:?}"),
-    };
-    let variant_array = StructArray::new(
-        variant_fields,
-        vec![
-            Arc::new(variant_metadata) as ArrayRef,
-            Arc::new(variant_value) as ArrayRef,
-        ],
-        Some(NullBuffer::from_iter([true, false, true])),
-    );
-
-    let batch = RecordBatch::try_new(
-        arrow_schema,
-        vec![
-            Arc::new(id_array) as ArrayRef,
-            Arc::new(tag_array) as ArrayRef,
-            Arc::new(map_array) as ArrayRef,
-            Arc::new(variant_array) as ArrayRef,
-        ],
+    let (_tmp_dir, table_path, engine) = test_table_setup_mt()?;
+    let snapshot = create_table_and_load_snapshot(
+        &table_path,
+        schema.clone(),
+        engine.as_ref(),
+        &[("delta.columnMapping.mode", mode_str)],
     )?;
+    let table_url = Url::from_directory_path(&table_path).unwrap();
 
-    let _snapshot = write_batch_to_table(&snapshot, engine.as_ref(), batch, HashMap::new()).await?;
+    // Resolve physical column names for stats JSON verification
+    let cm = snapshot
+        .table_properties()
+        .column_mapping_mode
+        .unwrap_or(ColumnMappingMode::None);
+    let physical_name = |logical: &str| -> String {
+        get_any_level_column_physical_name(
+            snapshot.schema().as_ref(),
+            &ColumnName::new([logical]),
+            cm,
+        )
+        .unwrap()
+        .into_inner()
+        .into_iter()
+        .next()
+        .unwrap()
+    };
+    let id_phys = physical_name("id");
+    let tags_phys = physical_name("tags");
+    let props_phys = physical_name("props");
+    let v_phys = physical_name("v");
 
-    // Read the commit and verify stats
+    // Batch 1: ids [1,2,3] with one null per complex column
+    let batch1 = complex_type_batch(&schema, &[1, 2, 3], Some(&[true, false, true]));
+    let _snapshot =
+        write_batch_to_table(&snapshot, engine.as_ref(), batch1, HashMap::new()).await?;
+
+    // Read the commit and verify stats use correct (physical) column names
     let add_actions = read_actions_from_commit(&table_url, 1, "add")?;
     assert_eq!(add_actions.len(), 1);
 
@@ -4583,15 +4633,15 @@ async fn test_write_stats_for_complex_type_columns() -> Result<(), Box<dyn std::
     assert_eq!(stats["numRecords"], 3);
 
     // nullCount should be present for all columns including array, map, and variant
-    assert_eq!(stats["nullCount"]["id"], 0);
-    assert_eq!(stats["nullCount"]["tags"], 1);
-    assert_eq!(stats["nullCount"]["props"], 1);
-    assert_eq!(stats["nullCount"]["v"], 1);
+    assert_eq!(stats["nullCount"][&id_phys], 0);
+    assert_eq!(stats["nullCount"][&tags_phys], 1);
+    assert_eq!(stats["nullCount"][&props_phys], 1);
+    assert_eq!(stats["nullCount"][&v_phys], 1);
 
     // minValues/maxValues should have id but NOT complex types
-    assert!(stats["minValues"]["id"].is_number());
-    assert!(stats["maxValues"]["id"].is_number());
-    for col in ["tags", "props", "v"] {
+    assert!(stats["minValues"][&id_phys].is_number());
+    assert!(stats["maxValues"][&id_phys].is_number());
+    for col in [&tags_phys, &props_phys, &v_phys] {
         assert!(
             stats["minValues"].get(col).is_none(),
             "minValues should not contain {col}"
@@ -4601,6 +4651,207 @@ async fn test_write_stats_for_complex_type_columns() -> Result<(), Box<dyn std::
             "maxValues should not contain {col}"
         );
     }
+
+    // Batch 2: ids [10,11,12] with no nulls, written to a separate file
+    let batch2 = complex_type_batch(&schema, &[10, 11, 12], None);
+    let snapshot2 = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
+    let snapshot2 =
+        write_batch_to_table(&snapshot2, engine.as_ref(), batch2, HashMap::new()).await?;
+
+    // Optionally checkpoint to verify stats survive the checkpoint round-trip
+    let scan_snapshot = if use_checkpoint {
+        snapshot2.checkpoint(engine.as_ref())?;
+        Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?
+    } else {
+        snapshot2
+    };
+
+    // Scan with predicate id > 5. File 1 has id in [1,3], file 2 has id in [10,12].
+    // Data skipping should skip file 1 entirely and return only file 2's rows.
+    let scan = scan_snapshot
+        .scan_builder()
+        .with_predicate(Arc::new(Pred::gt(column_expr!("id"), Expr::literal(5_i64))))
+        .build()?;
+    let batches: Vec<RecordBatch> = scan
+        .execute(engine.clone())?
+        .map(|r| {
+            let data = r.unwrap();
+            ArrowEngineData::try_from_engine_data(data)
+                .unwrap()
+                .record_batch()
+                .clone()
+        })
+        .collect();
+
+    let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(
+        total_rows, 3,
+        "predicate id > 5 should return only the second file's 3 rows"
+    );
+
+    let result_schema = batches[0].schema();
+    let combined = delta_kernel::arrow::compute::concat_batches(&result_schema, &batches)?;
+    let ids: Vec<i64> = combined
+        .column_by_name("id")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap()
+        .values()
+        .iter()
+        .copied()
+        .collect();
+    assert_eq!(ids, vec![10, 11, 12]);
+
+    Ok(())
+}
+
+/// Verifies that complex types in a nested schema count against `dataSkippingNumIndexedCols`.
+/// Schema: (id: long, data: struct<name: string, tags: array<string>, props: map<string, long>>).
+/// With numIndexedCols=3, the first 3 leaf columns (id, data.name, data.tags) get stats. The
+/// 4th leaf (data.props) is excluded because the limit is reached.
+#[tokio::test]
+async fn test_write_stats_nested_complex_types_respect_column_limit(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let schema = Arc::new(StructType::try_new(vec![
+        StructField::nullable("id", DataType::LONG),
+        StructField::nullable(
+            "data",
+            DataType::try_struct_type(vec![
+                StructField::nullable("name", DataType::STRING),
+                StructField::nullable(
+                    "tags",
+                    DataType::Array(Box::new(ArrayType::new(DataType::STRING, true))),
+                ),
+                StructField::nullable(
+                    "props",
+                    DataType::Map(Box::new(MapType::new(
+                        DataType::STRING,
+                        DataType::LONG,
+                        true,
+                    ))),
+                ),
+            ])?,
+        ),
+    ])?);
+
+    let (_tmp_dir, table_path, engine) = test_table_setup()?;
+    let table_url = Url::from_directory_path(&table_path).unwrap();
+    let snapshot =
+        create_table_and_load_snapshot(&table_path, schema.clone(), engine.as_ref(), &[])?;
+    let snapshot = set_table_properties(
+        &table_path,
+        &table_url,
+        engine.as_ref(),
+        snapshot.version(),
+        &[("delta.dataSkippingNumIndexedCols", "3")],
+    )?;
+
+    // Build a batch with 3 rows
+    let arrow_schema: ArrowSchema = schema.as_ref().try_into_arrow()?;
+    let arrow_schema = Arc::new(arrow_schema);
+
+    let id_array = Int64Array::from(vec![1, 2, 3]);
+    let name_array = StringArray::from(vec!["a", "b", "c"]);
+
+    // tags: [["x"], null, ["y"]]
+    let data_field = arrow_schema.field_with_name("data").unwrap();
+    let data_struct_fields = match data_field.data_type() {
+        ArrowDataType::Struct(f) => f,
+        other => panic!("expected Struct, got {other:?}"),
+    };
+    let tags_field = &data_struct_fields[1];
+    let list_field = match tags_field.data_type() {
+        ArrowDataType::List(f) => f.clone(),
+        other => panic!("expected List, got {other:?}"),
+    };
+    let tag_values = StringArray::from(vec!["x", "y"]);
+    let tag_offsets = OffsetBuffer::new(vec![0, 1, 1, 2].into());
+    let tag_array = ListArray::new(
+        list_field,
+        tag_offsets,
+        Arc::new(tag_values),
+        Some(NullBuffer::from_iter([true, false, true])),
+    );
+
+    // props: [{"k": 1}, {"k": 2}, null]
+    let props_field = &data_struct_fields[2];
+    let (map_entries_field, map_sorted) = match props_field.data_type() {
+        ArrowDataType::Map(f, sorted) => (f.clone(), *sorted),
+        other => panic!("expected Map, got {other:?}"),
+    };
+    let entries_fields = match map_entries_field.data_type() {
+        ArrowDataType::Struct(f) => f.clone(),
+        other => panic!("expected Struct, got {other:?}"),
+    };
+    let map_keys = StringArray::from(vec!["k", "k"]);
+    let map_vals = Int64Array::from(vec![1i64, 2]);
+    let entries = StructArray::new(
+        entries_fields,
+        vec![
+            Arc::new(map_keys) as ArrayRef,
+            Arc::new(map_vals) as ArrayRef,
+        ],
+        None,
+    );
+    let map_offsets = OffsetBuffer::new(vec![0, 1, 2, 2].into());
+    let map_array = MapArray::new(
+        map_entries_field,
+        map_offsets,
+        entries,
+        Some(NullBuffer::from_iter([true, true, false])),
+        map_sorted,
+    );
+
+    // Assemble the data struct
+    let data_array = StructArray::new(
+        data_struct_fields.clone(),
+        vec![
+            Arc::new(name_array) as ArrayRef,
+            Arc::new(tag_array) as ArrayRef,
+            Arc::new(map_array) as ArrayRef,
+        ],
+        None,
+    );
+
+    let batch = RecordBatch::try_new(
+        arrow_schema,
+        vec![
+            Arc::new(id_array) as ArrayRef,
+            Arc::new(data_array) as ArrayRef,
+        ],
+    )?;
+
+    let _snapshot = write_batch_to_table(&snapshot, engine.as_ref(), batch, HashMap::new()).await?;
+
+    // Version 0=create, 1=set properties, 2=data write
+    let add_actions = read_actions_from_commit(&table_url, 2, "add")?;
+    let stats: serde_json::Value = serde_json::from_str(
+        add_actions[0]
+            .get("stats")
+            .and_then(|s| s.as_str())
+            .expect("add action should have stats"),
+    )?;
+
+    assert_eq!(stats["numRecords"], 3);
+
+    // First 3 leaves: id, data.name, data.tags all get nullCount
+    assert_eq!(stats["nullCount"]["id"], 0);
+    assert_eq!(stats["nullCount"]["data"]["name"], 0);
+    assert_eq!(stats["nullCount"]["data"]["tags"], 1);
+
+    // 4th leaf data.props is excluded by the column limit
+    assert!(
+        stats["nullCount"]["data"].get("props").is_none(),
+        "props should be excluded by numIndexedCols=3"
+    );
+
+    // id and data.name get min/max; data.tags does not (complex type)
+    assert!(stats["minValues"]["id"].is_number());
+    assert!(stats["minValues"]["data"]["name"].is_string());
+    assert!(stats["minValues"]["data"].get("tags").is_none());
 
     Ok(())
 }

--- a/kernel/tests/write.rs
+++ b/kernel/tests/write.rs
@@ -4,10 +4,10 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use delta_kernel::actions::deletion_vector::{DeletionVectorDescriptor, DeletionVectorStorageType};
 use delta_kernel::arrow::array::{
-    Array, ArrayRef, BinaryArray, Int32Array, Int64Array, StringArray, StructArray,
-    TimestampMicrosecondArray,
+    Array, ArrayRef, BinaryArray, Int32Array, Int64Array, ListArray, MapArray, StringArray,
+    StructArray, TimestampMicrosecondArray,
 };
-use delta_kernel::arrow::buffer::NullBuffer;
+use delta_kernel::arrow::buffer::{NullBuffer, OffsetBuffer};
 use delta_kernel::arrow::datatypes::{DataType as ArrowDataType, Field};
 use delta_kernel::arrow::error::ArrowError;
 use delta_kernel::arrow::record_batch::RecordBatch;
@@ -26,7 +26,8 @@ use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::{DynObjectStore, ObjectStoreExt as _};
 use delta_kernel::parquet::file::reader::{FileReader, SerializedFileReader};
 use delta_kernel::schema::{
-    ColumnMetadataKey, DataType, MetadataValue, SchemaRef, StructField, StructType,
+    ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, SchemaRef, StructField,
+    StructType,
 };
 use delta_kernel::table_features::{get_any_level_column_physical_name, ColumnMappingMode};
 use delta_kernel::transaction::create_table::create_table as create_table_txn;
@@ -4448,6 +4449,158 @@ async fn test_create_table_with_data_uses_relative_paths() -> Result<(), Box<dyn
     let batches = test_utils::read_scan(&scan, engine_ref)?;
     assert_eq!(batches.len(), 1);
     assert_eq!(batches[0].num_rows(), 2);
+
+    Ok(())
+}
+
+/// Verifies that writing a table with array, map, and variant columns produces nullCount
+/// statistics for those columns while excluding them from minValues/maxValues.
+#[tokio::test]
+async fn test_write_stats_for_complex_type_columns() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let schema = Arc::new(StructType::try_new(vec![
+        StructField::nullable("id", DataType::LONG),
+        StructField::nullable(
+            "tags",
+            DataType::Array(Box::new(ArrayType::new(DataType::STRING, true))),
+        ),
+        StructField::nullable(
+            "props",
+            DataType::Map(Box::new(MapType::new(
+                DataType::STRING,
+                DataType::LONG,
+                true,
+            ))),
+        ),
+        StructField::nullable("v", DataType::unshredded_variant()),
+    ])?);
+
+    let (_tmp_dir, table_path, engine) = test_table_setup()?;
+    let snapshot =
+        create_table_and_load_snapshot(&table_path, schema.clone(), engine.as_ref(), &[])?;
+    let table_url = Url::from_directory_path(table_path).unwrap();
+
+    // Build Arrow arrays: 3 rows, with one null in each complex column
+    let arrow_schema: delta_kernel::arrow::datatypes::Schema = schema.as_ref().try_into_arrow()?;
+    let arrow_schema = Arc::new(arrow_schema);
+
+    let id_array = Int64Array::from(vec![1, 2, 3]);
+
+    // Extract the exact field types from the converted schema to avoid field name mismatches
+    let tags_field = arrow_schema.field_with_name("tags").unwrap();
+    let props_field = arrow_schema.field_with_name("props").unwrap();
+
+    // tags: [["a", "b"], null, ["c"]]
+    let tag_values = StringArray::from(vec!["a", "b", "c"]);
+    let tag_offsets = OffsetBuffer::new(vec![0, 2, 2, 3].into());
+    let list_element_field = match tags_field.data_type() {
+        ArrowDataType::List(f) => f.clone(),
+        other => panic!("expected List, got {other:?}"),
+    };
+    let tag_array = ListArray::new(
+        list_element_field,
+        tag_offsets,
+        Arc::new(tag_values),
+        Some(NullBuffer::from_iter([true, false, true])),
+    );
+
+    // props: [{"k1": 10}, {"k2": 20}, null]
+    let map_keys = StringArray::from(vec!["k1", "k2"]);
+    let map_values = Int64Array::from(vec![Some(10i64), Some(20)]);
+    let (map_entries_field, map_sorted) = match props_field.data_type() {
+        ArrowDataType::Map(f, sorted) => (f.clone(), *sorted),
+        other => panic!("expected Map, got {other:?}"),
+    };
+    let entries_struct_fields = match map_entries_field.data_type() {
+        ArrowDataType::Struct(fields) => fields.clone(),
+        other => panic!("expected Struct for map entries, got {other:?}"),
+    };
+    let map_entries = StructArray::new(
+        entries_struct_fields,
+        vec![
+            Arc::new(map_keys) as ArrayRef,
+            Arc::new(map_values) as ArrayRef,
+        ],
+        None,
+    );
+    let map_offsets = OffsetBuffer::new(vec![0, 1, 2, 2].into());
+    let map_array = MapArray::new(
+        map_entries_field,
+        map_offsets,
+        map_entries,
+        Some(NullBuffer::from_iter([true, true, false])),
+        map_sorted,
+    );
+
+    // v: [variant(1), null, variant({"a": 2})]
+    let variant_metadata = BinaryArray::from(vec![
+        Some(&[0x01, 0x00, 0x00][..]),             // metadata for integer 1
+        None,                                      // null
+        Some(&[0x01, 0x01, 0x00, 0x01, 0x61][..]), // metadata for {"a": 2}
+    ]);
+    let variant_value = BinaryArray::from(vec![
+        Some(&[0x0C, 0x01][..]),                         // value for integer 1
+        None,                                            // null
+        Some(&[0x02, 0x01, 0x00, 0x00, 0x01, 0x02][..]), // value for {"a": 2}
+    ]);
+    let variant_fields = match arrow_schema.field_with_name("v").unwrap().data_type() {
+        ArrowDataType::Struct(fields) => fields.clone(),
+        other => panic!("expected Struct for variant, got {other:?}"),
+    };
+    let variant_array = StructArray::new(
+        variant_fields,
+        vec![
+            Arc::new(variant_metadata) as ArrayRef,
+            Arc::new(variant_value) as ArrayRef,
+        ],
+        Some(NullBuffer::from_iter([true, false, true])),
+    );
+
+    let batch = RecordBatch::try_new(
+        arrow_schema,
+        vec![
+            Arc::new(id_array) as ArrayRef,
+            Arc::new(tag_array) as ArrayRef,
+            Arc::new(map_array) as ArrayRef,
+            Arc::new(variant_array) as ArrayRef,
+        ],
+    )?;
+
+    let _snapshot = write_batch_to_table(&snapshot, engine.as_ref(), batch, HashMap::new()).await?;
+
+    // Read the commit and verify stats
+    let add_actions = read_actions_from_commit(&table_url, 1, "add")?;
+    assert_eq!(add_actions.len(), 1);
+
+    let stats: serde_json::Value = serde_json::from_str(
+        add_actions[0]
+            .get("stats")
+            .and_then(|s| s.as_str())
+            .expect("add action should have stats"),
+    )?;
+
+    assert_eq!(stats["numRecords"], 3);
+
+    // nullCount should be present for all columns including array, map, and variant
+    assert_eq!(stats["nullCount"]["id"], 0);
+    assert_eq!(stats["nullCount"]["tags"], 1);
+    assert_eq!(stats["nullCount"]["props"], 1);
+    assert_eq!(stats["nullCount"]["v"], 1);
+
+    // minValues/maxValues should have id but NOT complex types
+    assert!(stats["minValues"]["id"].is_number());
+    assert!(stats["maxValues"]["id"].is_number());
+    for col in ["tags", "props", "v"] {
+        assert!(
+            stats["minValues"].get(col).is_none(),
+            "minValues should not contain {col}"
+        );
+        assert!(
+            stats["maxValues"].get(col).is_none(),
+            "maxValues should not contain {col}"
+        );
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Previously kernel excluded Array, Map, and Variant column types from all statistics including nullCount. This was incorrect as Delta Spark collects nullCount for these types. Only min/max stats should be excluded for non-orderable types.

This PR treats Array, Map, and Variant as leaf columns in the stats schema layer. They count against `dataSkippingNumIndexedCols` (matching Spark's `truncateSchema` which counts all non-struct fields), are included in nullCount, and remain excluded from min/max by `MinMaxStatsTransform`.


## How was this change tested?
New unit and integration tests