### PR TITLE
fix: clear stale CRC file in LogSegment::try_new_with_checkpoint

### DIFF
--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -533,6 +533,10 @@ impl LogSegment {
     /// Creates a new LogSegment reflecting a checkpoint written at this segment's version.
     /// The checkpoint must be at `end_version`. Kernel does not write multi-part checkpoints,
     /// so the checkpoint must be a single file (classic parquet or V2 UUID).
+    ///
+    /// If the existing `latest_crc_file` is older than the new checkpoint version, it is
+    /// cleared to preserve the `LogSegmentFiles` invariant that `latest_crc_file.version >=
+    /// checkpoint version`.
     pub(crate) fn try_new_with_checkpoint(&self, checkpoint: ParsedLogPath) -> DeltaResult<Self> {
         require!(
             matches!(
@@ -556,11 +560,19 @@ impl LogSegment {
 
         let mut new_log_segment = self.clone();
         new_log_segment.checkpoint_version = Some(checkpoint.version);
+        let checkpoint_version = checkpoint.version;
         new_log_segment.listed.checkpoint_parts = vec![checkpoint];
         // A snapshot at version N only contains commits and compactions at versions <= N,
         // so a checkpoint at N covers everything and we can clear them entirely.
         new_log_segment.listed.ascending_commit_files.clear();
         new_log_segment.listed.ascending_compaction_files.clear();
+        // Preserve the LogSegmentFiles invariant that `latest_crc_file.version >= checkpoint
+        // version`. A stale CRC is worse than missing: downstream P&M fallbacks (see
+        // `read_protocol_metadata_opt`) would load an older P&M and overwrite the current one.
+        new_log_segment
+            .listed
+            .latest_crc_file
+            .take_if(|crc| crc.version < checkpoint_version);
         // TODO(#839): Once CheckpointWriter exposes the output schema, build a
         // LastCheckpointHintSummary and thread it through here instead of None. Today the
         // schema is computed inside checkpoint_data() but not returned. With None, the next

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -4030,38 +4030,32 @@ async fn test_try_new_with_checkpoint_rejects_invalid_path(
     assert_result_error_with_message(result, expected_error);
 }
 
+// CRC state is orthogonal to checkpoint path format, so we express the path format as a
+// `#[values]` axis (classic parquet vs. V2 UUID) and the CRC state as `#[case]` rows. The
+// cartesian product covers every pairing without enumerating 6 `#[case]`s by hand.
+//
+// CRC states:
+//   - no_crc:                  no pre-existing CRC (most common path)
+//   - stale_crc_cleared:       CRC@v1 < checkpoint@v2. Must be cleared to preserve the
+//     LogSegmentFiles invariant `latest_crc_file.version >= checkpoint version`.
+//   - crc_at_checkpoint_retained: CRC@v2 satisfies the invariant and must be retained.
 #[rstest]
-// Classic parquet checkpoint with no pre-existing CRC (most common path).
-#[case::classic_parquet_no_crc(
-    "file:///_delta_log/00000000000000000002.checkpoint.parquet",
-    None,
-    None
-)]
-// V2 UUID checkpoint with no pre-existing CRC.
-#[case::v2_uuid_no_crc(
-    "file:///_delta_log/00000000000000000002.checkpoint.3a0d65cd-4056-49b8-937b-95f9e3ee90e5.parquet",
-    None,
-    None,
-)]
-// Stale CRC (version 1 < checkpoint 2) must be cleared to preserve the LogSegmentFiles
-// invariant that `latest_crc_file.version >= checkpoint version`.
-#[case::stale_crc_cleared(
-    "file:///_delta_log/00000000000000000002.checkpoint.parquet",
-    Some(1),
-    None
-)]
-// CRC at the checkpoint version satisfies the invariant and must be retained.
-#[case::crc_at_checkpoint_version_retained(
-    "file:///_delta_log/00000000000000000002.checkpoint.parquet",
-    Some(2),
-    Some(2)
-)]
+#[case::no_crc(None, None)]
+#[case::stale_crc_cleared(Some(1), None)]
+#[case::crc_at_checkpoint_retained(Some(2), Some(2))]
 #[tokio::test]
 async fn test_try_new_with_checkpoint(
-    #[case] ckpt_path: &str,
+    #[values(
+        "checkpoint.parquet",
+        "checkpoint.3a0d65cd-4056-49b8-937b-95f9e3ee90e5.parquet"
+    )]
+    ckpt_suffix: &str,
     #[case] crc_version: Option<u64>,
     #[case] expected_crc_version: Option<u64>,
 ) {
+    const CHECKPOINT_VERSION: u64 = 2;
+    let ckpt_url = format!("file:///_delta_log/{CHECKPOINT_VERSION:020}.{ckpt_suffix}");
+
     let mut log_segment = create_segment_for(LogSegmentConfig {
         published_commit_versions: &[0, 1, 2],
         compaction_versions: &[(0, 2)],
@@ -4078,12 +4072,15 @@ async fn test_try_new_with_checkpoint(
     assert!(log_segment.listed.ascending_compaction_files.is_empty());
 
     let result = log_segment
-        .try_new_with_checkpoint(create_log_path(ckpt_path))
+        .try_new_with_checkpoint(create_log_path(&ckpt_url))
         .unwrap();
 
-    assert_eq!(result.checkpoint_version, Some(2));
+    assert_eq!(result.checkpoint_version, Some(CHECKPOINT_VERSION));
     assert_eq!(result.listed.checkpoint_parts.len(), 1);
-    assert_eq!(result.listed.checkpoint_parts[0].version, 2);
+    assert_eq!(
+        result.listed.checkpoint_parts[0].version,
+        CHECKPOINT_VERSION
+    );
     assert!(result.listed.ascending_commit_files.is_empty());
     assert!(result.listed.ascending_compaction_files.is_empty());
     assert!(result.last_checkpoint_hint_summary().is_none());

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -4030,15 +4030,6 @@ async fn test_try_new_with_checkpoint_rejects_invalid_path(
     assert_result_error_with_message(result, expected_error);
 }
 
-// CRC state is orthogonal to checkpoint path format, so we express the path format as a
-// `#[values]` axis (classic parquet vs. V2 UUID) and the CRC state as `#[case]` rows. The
-// cartesian product covers every pairing without enumerating 6 `#[case]`s by hand.
-//
-// CRC states:
-//   - no_crc:                  no pre-existing CRC (most common path)
-//   - stale_crc_cleared:       CRC@v1 < checkpoint@v2. Must be cleared to preserve the
-//     LogSegmentFiles invariant `latest_crc_file.version >= checkpoint version`.
-//   - crc_at_checkpoint_retained: CRC@v2 satisfies the invariant and must be retained.
 #[rstest]
 #[case::no_crc(None, None)]
 #[case::stale_crc_cleared(Some(1), None)]

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -4031,24 +4031,55 @@ async fn test_try_new_with_checkpoint_rejects_invalid_path(
 }
 
 #[rstest]
-#[case::classic_parquet("file:///_delta_log/00000000000000000002.checkpoint.parquet")]
-#[case::v2_uuid(
-    "file:///_delta_log/00000000000000000002.checkpoint.3a0d65cd-4056-49b8-937b-95f9e3ee90e5.parquet"
+// Classic parquet checkpoint with no pre-existing CRC (most common path).
+#[case::classic_parquet_no_crc(
+    "file:///_delta_log/00000000000000000002.checkpoint.parquet",
+    None,
+    None
+)]
+// V2 UUID checkpoint with no pre-existing CRC.
+#[case::v2_uuid_no_crc(
+    "file:///_delta_log/00000000000000000002.checkpoint.3a0d65cd-4056-49b8-937b-95f9e3ee90e5.parquet",
+    None,
+    None,
+)]
+// Stale CRC (version 1 < checkpoint 2) must be cleared to preserve the LogSegmentFiles
+// invariant that `latest_crc_file.version >= checkpoint version`.
+#[case::stale_crc_cleared(
+    "file:///_delta_log/00000000000000000002.checkpoint.parquet",
+    Some(1),
+    None
+)]
+// CRC at the checkpoint version satisfies the invariant and must be retained.
+#[case::crc_at_checkpoint_version_retained(
+    "file:///_delta_log/00000000000000000002.checkpoint.parquet",
+    Some(2),
+    Some(2)
 )]
 #[tokio::test]
-async fn test_try_new_with_checkpoint_sets_checkpoint_and_clears_commits(#[case] path: &str) {
-    let log_segment = create_segment_for(LogSegmentConfig {
+async fn test_try_new_with_checkpoint(
+    #[case] ckpt_path: &str,
+    #[case] crc_version: Option<u64>,
+    #[case] expected_crc_version: Option<u64>,
+) {
+    let mut log_segment = create_segment_for(LogSegmentConfig {
         published_commit_versions: &[0, 1, 2],
         compaction_versions: &[(0, 2)],
         ..Default::default()
     })
     .await;
+    if let Some(v) = crc_version {
+        // Bypass try_new_with_crc_file's end_version check so we can plant a stale CRC.
+        log_segment.listed.latest_crc_file =
+            Some(create_log_path(&format!("file:///_delta_log/{v:020}.crc")));
+    }
     assert!(!log_segment.listed.ascending_commit_files.is_empty());
     // TODO(#2337): restore to assert !is_empty() when log compaction is re-enabled
     assert!(log_segment.listed.ascending_compaction_files.is_empty());
 
-    let ckpt_path = create_log_path(path);
-    let result = log_segment.try_new_with_checkpoint(ckpt_path).unwrap();
+    let result = log_segment
+        .try_new_with_checkpoint(create_log_path(ckpt_path))
+        .unwrap();
 
     assert_eq!(result.checkpoint_version, Some(2));
     assert_eq!(result.listed.checkpoint_parts.len(), 1);
@@ -4056,6 +4087,10 @@ async fn test_try_new_with_checkpoint_sets_checkpoint_and_clears_commits(#[case]
     assert!(result.listed.ascending_commit_files.is_empty());
     assert!(result.listed.ascending_compaction_files.is_empty());
     assert!(result.last_checkpoint_hint_summary().is_none());
+    assert_eq!(
+        result.listed.latest_crc_file.as_ref().map(|c| c.version),
+        expected_crc_version
+    );
 
     // latest_commit_file is preserved for ICT access even though commits are cleared
     assert_eq!(

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -544,22 +544,16 @@ impl Snapshot {
         let checkpoint_log_path = ParsedLogPath::try_from(file_meta)?.ok_or_else(|| {
             Error::internal_error("Checkpoint path could not be parsed as a log path")
         })?;
-        let checkpoint_version = checkpoint_log_path.version;
         let new_log_segment = self
             .log_segment
             .try_new_with_checkpoint(checkpoint_log_path)?;
-        // Keep `lazy_crc` in sync with `log_segment.listed.latest_crc_file`: when
-        // `try_new_with_checkpoint` clears a stale CRC, we must drop the cached LazyCrc
-        // tracking that same stale version. Otherwise the snapshot would advertise no
-        // CRC via its log segment while still holding the old P&M in lazy_crc.
-        let lazy_crc = if self
-            .lazy_crc
-            .crc_version()
-            .is_some_and(|v| v < checkpoint_version)
-        {
-            Arc::new(LazyCrc::new(None))
-        } else {
+        // Mirror `lazy_crc` from the new log segment's `latest_crc_file`:
+        // `try_new_with_checkpoint` either preserves the existing CRC or clears a stale
+        // one, and `lazy_crc` must track whichever outcome occurred.
+        let lazy_crc = if new_log_segment.listed.latest_crc_file.is_some() {
             self.lazy_crc.clone()
+        } else {
+            Arc::new(LazyCrc::new(None))
         };
         Ok((
             CheckpointWriteResult::Written,

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -544,15 +544,29 @@ impl Snapshot {
         let checkpoint_log_path = ParsedLogPath::try_from(file_meta)?.ok_or_else(|| {
             Error::internal_error("Checkpoint path could not be parsed as a log path")
         })?;
+        let checkpoint_version = checkpoint_log_path.version;
         let new_log_segment = self
             .log_segment
             .try_new_with_checkpoint(checkpoint_log_path)?;
+        // Keep `lazy_crc` in sync with `log_segment.listed.latest_crc_file`: when
+        // `try_new_with_checkpoint` clears a stale CRC, we must drop the cached LazyCrc
+        // tracking that same stale version. Otherwise the snapshot would advertise no
+        // CRC via its log segment while still holding the old P&M in lazy_crc.
+        let lazy_crc = if self
+            .lazy_crc
+            .crc_version()
+            .is_some_and(|v| v < checkpoint_version)
+        {
+            Arc::new(LazyCrc::new(None))
+        } else {
+            self.lazy_crc.clone()
+        };
         Ok((
             CheckpointWriteResult::Written,
             Arc::new(Snapshot::new_with_crc(
                 new_log_segment,
                 self.table_configuration().clone(),
-                self.lazy_crc.clone(),
+                lazy_crc,
             )),
         ))
     }

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -544,16 +544,19 @@ impl Snapshot {
         let checkpoint_log_path = ParsedLogPath::try_from(file_meta)?.ok_or_else(|| {
             Error::internal_error("Checkpoint path could not be parsed as a log path")
         })?;
+        let checkpoint_version = checkpoint_log_path.version;
         let new_log_segment = self
             .log_segment
             .try_new_with_checkpoint(checkpoint_log_path)?;
-        // Mirror `lazy_crc` from the new log segment's `latest_crc_file`:
-        // `try_new_with_checkpoint` either preserves the existing CRC or clears a stale
-        // one, and `lazy_crc` must track whichever outcome occurred.
-        let lazy_crc = if new_log_segment.listed.latest_crc_file.is_some() {
-            self.lazy_crc.clone()
-        } else {
+        // Drop a cached CRC that predates the checkpoint version.
+        let lazy_crc = if self
+            .lazy_crc
+            .crc_version()
+            .is_some_and(|v| v < checkpoint_version)
+        {
             Arc::new(LazyCrc::new(None))
+        } else {
+            self.lazy_crc.clone()
         };
         Ok((
             CheckpointWriteResult::Written,


### PR DESCRIPTION
## What changes are proposed in this pull request?

try_new_with_checkpoint installed a new checkpoint without checking the existing latest_crc_file. If the CRC version was older than the new checkpoint version, the resulting LogSegmentFiles violated its invariant (latest_crc_file.version >= checkpoint version).

## How was this change tested?

Added new unit tests