### PR TITLE
test: cover non-catalog-managed UC tables in read/write examples

### DIFF
--- a/delta-kernel-unity-catalog/src/lib.rs
+++ b/delta-kernel-unity-catalog/src/lib.rs
@@ -124,36 +124,79 @@ mod tests {
     use std::env;
     use std::sync::Arc;
 
+    use delta_kernel::committer::{Committer, FileSystemCommitter};
     use delta_kernel::engine::default::DefaultEngineBuilder;
     use delta_kernel::object_store;
     use delta_kernel::object_store::memory::InMemory;
+    use delta_kernel::table_features::{
+        SET_TABLE_FEATURE_SUPPORTED_PREFIX, SET_TABLE_FEATURE_SUPPORTED_VALUE,
+    };
     use delta_kernel::transaction::CommitResult;
     use tracing::info;
     use unity_catalog_delta_client_api::{Commit, InMemoryCommitsClient, Operation, TableData};
+    use unity_catalog_delta_rest_client::models::TablesResponse;
     use unity_catalog_delta_rest_client::{UCClient, UCCommitsRestClient};
 
     use super::*;
+
+    /// Returns `true` when the UC `get_table` response indicates the table uses the
+    /// `catalogManaged` protocol feature.
+    ///
+    /// We key off the UC `properties` map because the snapshot has not been loaded yet and we
+    /// need the answer to decide *how* to load it (catalog round-trip vs. direct object-store
+    /// read). Once a snapshot is in hand, protocol inspection is the authoritative source.
+    fn is_catalog_managed(table: &TablesResponse) -> bool {
+        let key = format!("{SET_TABLE_FEATURE_SUPPORTED_PREFIX}catalogManaged");
+        table.properties.get(&key).map(String::as_str) == Some(SET_TABLE_FEATURE_SUPPORTED_VALUE)
+    }
+
+    /// Load a snapshot of the given UC Delta table, picking the correct strategy based on whether
+    /// the table uses the `catalogManaged` protocol feature. Catalog-managed tables are loaded via
+    /// [`UCKernelClient`] (which queries UC for the authoritative log tail); other UC Delta tables
+    /// are loaded directly from object storage via [`Snapshot::builder_for`].
+    ///
+    /// When `version` is `None`, loads the latest snapshot; otherwise loads the snapshot at the
+    /// given version.
+    async fn load_uc_table_snapshot(
+        table: &TablesResponse,
+        commits_client: &UCCommitsRestClient,
+        version: Option<Version>,
+        engine: &dyn Engine,
+    ) -> Result<Arc<Snapshot>, Box<dyn std::error::Error + Send + Sync>> {
+        if is_catalog_managed(table) {
+            UCKernelClient::new(commits_client)
+                .load_snapshot_inner(&table.table_id, &table.storage_location, version, engine)
+                .await
+        } else {
+            let mut builder = Snapshot::builder_for(&table.storage_location);
+            if let Some(v) = version {
+                builder = builder.at_version(v);
+            }
+            Ok(builder.build(engine)?)
+        }
+    }
 
     // We could just re-export UCClient's get_table to not require consumers to directly import
     // unity_catalog_delta_rest_client themselves.
     async fn get_table(
         client: &UCClient,
         table_name: &str,
-    ) -> Result<(String, String), Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<TablesResponse, Box<dyn std::error::Error + Send + Sync>> {
         let res = client.get_table(table_name).await?;
-        let table_id = res.table_id;
-        let table_uri = res.storage_location;
-
         info!(
-            "[GET TABLE] got table_id: {}, table_uri: {}\n",
-            table_id, table_uri
+            "[GET TABLE] got table_id: {}, table_uri: {}, catalog_managed: {}\n",
+            res.table_id,
+            res.storage_location,
+            is_catalog_managed(&res),
         );
-
-        Ok((table_id, table_uri))
+        Ok(res)
     }
 
     // ignored test which you can run manually to play around with reading a UC table. run with:
     // `ENDPOINT=".." TABLENAME=".." TOKEN=".." cargo t read_uc_table --nocapture -- --ignored`
+    //
+    // Supports both catalog-managed Delta tables (via UCKernelClient, which queries UC for the
+    // log tail) and non-catalog-managed UC tables (via Snapshot::builder_for).
     #[ignore]
     #[tokio::test]
     async fn read_uc_table() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -169,13 +212,11 @@ mod tests {
         let uc_client = UCClient::new(config.clone())?;
         let uc_commits_client = UCCommitsRestClient::new(config)?;
 
-        let (table_id, table_uri) = get_table(&uc_client, &table_name).await?;
+        let table = get_table(&uc_client, &table_name).await?;
         let creds = uc_client
-            .get_credentials(&table_id, Operation::Read)
+            .get_credentials(&table.table_id, Operation::Read)
             .await
             .map_err(|e| format!("Failed to get credentials: {e}"))?;
-
-        let catalog = UCKernelClient::new(&uc_commits_client);
 
         // TODO: support non-AWS
         let creds = creds
@@ -189,19 +230,16 @@ mod tests {
             ("session_token", &creds.session_token),
         ];
 
-        let table_url = Url::parse(&table_uri)?;
+        let table_url = Url::parse(&table.storage_location)?;
         let (store, path) = object_store::parse_url_opts(&table_url, options)?;
 
         info!("created object store: {:?}\npath: {:?}\n", store, path);
 
         let engine = DefaultEngineBuilder::new(store.into()).build();
 
-        // read table
-        let snapshot = catalog
-            .load_snapshot(&table_id, &table_uri, &engine)
-            .await?;
-        // or time travel
-        // let snapshot = catalog.load_snapshot_at(&table, 2).await?;
+        let snapshot = load_uc_table_snapshot(&table, &uc_commits_client, None, &engine).await?;
+        // or time travel, e.g.
+        // load_uc_table_snapshot(&table, &uc_commits_client, Some(2), &engine).await?;
 
         println!("loaded snapshot: {snapshot:?}");
 
@@ -210,6 +248,9 @@ mod tests {
 
     // ignored test which you can run manually to play around with writing to a UC table. run with:
     // `ENDPOINT=".." TABLENAME=".." TOKEN=".." cargo t write_uc_table --nocapture -- --ignored`
+    //
+    // Supports both catalog-managed Delta tables (via UCKernelClient + UCCommitter) and
+    // non-catalog-managed UC tables (via Snapshot::builder_for + FileSystemCommitter).
     #[ignore]
     #[tokio::test(flavor = "multi_thread")]
     async fn write_uc_table() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -225,13 +266,11 @@ mod tests {
         let client = UCClient::new(config.clone())?;
         let commits_client = Arc::new(UCCommitsRestClient::new(config)?);
 
-        let (table_id, table_uri) = get_table(&client, &table_name).await?;
+        let table = get_table(&client, &table_name).await?;
         let creds = client
-            .get_credentials(&table_id, Operation::ReadWrite)
+            .get_credentials(&table.table_id, Operation::ReadWrite)
             .await
             .map_err(|e| format!("Failed to get credentials: {e}"))?;
-
-        let catalog = UCKernelClient::new(commits_client.as_ref());
 
         // TODO: support non-AWS
         let creds = creds
@@ -245,27 +284,36 @@ mod tests {
             ("session_token", &creds.session_token),
         ];
 
-        let table_url = Url::parse(&table_uri)?;
+        let table_url = Url::parse(&table.storage_location)?;
         let (store, _path) = object_store::parse_url_opts(&table_url, options)?;
         let store = Arc::new(store);
 
         let engine = DefaultEngineBuilder::new(store.clone()).build();
-        let committer = Box::new(UCCommitter::new(commits_client.clone(), table_id.clone()));
-        let snapshot = catalog
-            .load_snapshot(&table_id, &table_uri, &engine)
-            .await?;
+
+        let snapshot = load_uc_table_snapshot(&table, &commits_client, None, &engine).await?;
         println!("latest snapshot version: {:?}", snapshot.version());
+
+        // UC catalogManaged tables must commit through UC; UC non-catalogManaged commit through
+        // the filesystem.
+        let committer: Box<dyn Committer> = if is_catalog_managed(&table) {
+            Box::new(UCCommitter::new(
+                commits_client.clone(),
+                table.table_id.clone(),
+            ))
+        } else {
+            Box::new(FileSystemCommitter::new())
+        };
         let txn = snapshot.clone().transaction(committer, &engine)?;
         let _write_context = txn.unpartitioned_write_context()?;
 
         match txn.commit(&engine)? {
             CommitResult::CommittedTransaction(t) => {
                 println!("committed version {}", t.commit_version());
-                // TODO: should use post-commit snapshot here (plumb through log tail)
-                let _snapshot = catalog
-                    .load_snapshot_at(&table_id, &table_uri, t.commit_version(), &engine)
-                    .await?;
-                // then do publish
+                let _snapshot = t
+                    .post_commit_snapshot()
+                    .ok_or("no post commit snapshot")?
+                    .clone();
+                // then do publish (catalog-managed only)
             }
             CommitResult::ConflictedTransaction(t) => {
                 println!("commit conflicted at version {}", t.conflict_version());


### PR DESCRIPTION
## What changes are proposed in this pull request?

Teach the `read_uc_table` / `write_uc_table` examples to handle UC Delta tables that are not catalog-managed: branch on `delta.feature.catalogManaged` and, when absent, use `Snapshot::builder_for` + `FileSystemCommitter` instead of `UCKernelClient` + `UCCommitter`.

## How was this change tested?

Manually test against real UC managed tables.