### PR TITLE
feat!: Add geo schema types and table feature

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,0 @@
-# The kernel Error enum contains large variants (ArrowError, ObjectStore::Error) that push
-# the enum past clippy's default 128-byte threshold. Raise the threshold to accommodate the
-# existing design rather than boxing all error variants.
-large-error-threshold = 200

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,4 @@
+# The kernel Error enum contains large variants (ArrowError, ObjectStore::Error) that push
+# the enum past clippy's default 128-byte threshold. Raise the threshold to accommodate the
+# existing design rather than boxing all error variants.
+large-error-threshold = 200

--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -525,8 +525,8 @@ impl NullTypeTag {
                 // either way -- there is no side channel for it here. Once real FFI geo
                 // support lands, new NullTypeTag::Geometry / ::Geography variants will
                 // replace this arm.
-                // TODO: Once real FFI geo support lands, new NullTypeTag::Geometry / ::Geography variants
-                // will replace this arm.
+                // TODO: Once real FFI geo support lands, new NullTypeTag::Geometry / ::Geography
+                // variants will replace this arm.
                 PrimitiveType::Geometry(_) | PrimitiveType::Geography(_) => (Self::Binary, 0, 0),
             },
             _ => (Self::NonPrimitive, 0, 0),

--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -526,7 +526,7 @@ impl NullTypeTag {
                 // support lands, new NullTypeTag::Geometry / ::Geography variants will
                 // replace this arm.
                 // TODO: Once real FFI geo support lands, new NullTypeTag::Geometry / ::Geography variants
-                // willreplace this arm.
+                // will replace this arm.
                 PrimitiveType::Geometry(_) | PrimitiveType::Geography(_) => (Self::Binary, 0, 0),
             },
             _ => (Self::NonPrimitive, 0, 0),

--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -525,6 +525,8 @@ impl NullTypeTag {
                 // either way -- there is no side channel for it here. Once real FFI geo
                 // support lands, new NullTypeTag::Geometry / ::Geography variants will
                 // replace this arm.
+                // TODO: Once real FFI geo support lands, new NullTypeTag::Geometry / ::Geography variants
+                // willreplace this arm.
                 PrimitiveType::Geometry(_) | PrimitiveType::Geography(_) => (Self::Binary, 0, 0),
             },
             _ => (Self::NonPrimitive, 0, 0),

--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -516,6 +516,16 @@ impl NullTypeTag {
                 // case, so this arm is a defensive fallback rather than part of the normal
                 // void-column path.
                 PrimitiveType::Void => (Self::NonPrimitive, 0, 0),
+                // Geometry/Geography carry an SRID string (and for Geography, an edge
+                // algorithm) that cannot fit in the (tag, u8, u8) payload this function
+                // returns. We route them through NullTypeTag::Binary to stay consistent
+                // with the FFI schema visitor (which routes geo columns through
+                // visit_binary): consumers see a uniformly binary view of geo across
+                // schema and expressions in this PR. CRS is lost at the FFI boundary
+                // either way -- there is no side channel for it here. Once real FFI geo
+                // support lands, new NullTypeTag::Geometry / ::Geography variants will
+                // replace this arm.
+                PrimitiveType::Geometry(_) | PrimitiveType::Geography(_) => (Self::Binary, 0, 0),
             },
             _ => (Self::NonPrimitive, 0, 0),
         }

--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -517,17 +517,13 @@ impl NullTypeTag {
                 // void-column path.
                 PrimitiveType::Void => (Self::NonPrimitive, 0, 0),
                 // Geometry/Geography carry an SRID string (and for Geography, an edge
-                // algorithm) that cannot fit in the (tag, u8, u8) payload this function
-                // returns. We route them through NullTypeTag::Binary to stay consistent
-                // with the FFI schema visitor (which routes geo columns through
-                // visit_binary): consumers see a uniformly binary view of geo across
-                // schema and expressions in this PR. CRS is lost at the FFI boundary
-                // either way -- there is no side channel for it here. Once real FFI geo
-                // support lands, new NullTypeTag::Geometry / ::Geography variants will
-                // replace this arm.
-                // TODO: Once real FFI geo support lands, new NullTypeTag::Geometry / ::Geography
-                // variants will replace this arm.
-                PrimitiveType::Geometry(_) | PrimitiveType::Geography(_) => (Self::Binary, 0, 0),
+                // algorithm) that cannot fit in the (tag, u8, u8) payload. Like intervals
+                // above, they fall back to the sentinel so a reconstruction attempt errors
+                // rather than silently mistyping the null; the SRID is not recoverable from
+                // the tag. See #2914 for adding real geo FFI support.
+                PrimitiveType::Geometry(_) | PrimitiveType::Geography(_) => {
+                    (Self::NonPrimitive, 0, 0)
+                }
             },
             _ => (Self::NonPrimitive, 0, 0),
         }

--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -516,10 +516,10 @@ impl NullTypeTag {
                 // case, so this arm is a defensive fallback rather than part of the normal
                 // void-column path.
                 PrimitiveType::Void => (Self::NonPrimitive, 0, 0),
-                // Geometry/Geography carry an SRID string (and for Geography, an edge
+                // Geometry/Geography carry a CRS string (and for Geography, an edge
                 // algorithm) that cannot fit in the (tag, u8, u8) payload. Like intervals
                 // above, they fall back to the sentinel so a reconstruction attempt errors
-                // rather than silently mistyping the null; the SRID is not recoverable from
+                // rather than silently mistyping the null; the CRS is not recoverable from
                 // the tag. See #2914 for adding real geo FFI support.
                 PrimitiveType::Geometry(_) | PrimitiveType::Geography(_) => {
                     (Self::NonPrimitive, 0, 0)

--- a/ffi/src/schema.rs
+++ b/ffi/src/schema.rs
@@ -355,6 +355,8 @@ fn visit_schema_impl(schema: &StructType, visitor: &mut EngineSchemaVisitor) -> 
             // produce meaningless results. Tables with geo columns should not be consumed
             // through this FFI until dedicated visit_geometry / visit_geography callbacks
             // carrying the SRID are added.
+            // Geometry/Geography are WKB-encoded bytes at the FFI layer
+            // TODO: Add visit_geometry / visit_geography callbacks carrying the SRID once real FFI geo support lands
             DataType::Primitive(PrimitiveType::Geometry(_))
             | DataType::Primitive(PrimitiveType::Geography(_)) => call!(visit_binary),
         }

--- a/ffi/src/schema.rs
+++ b/ffi/src/schema.rs
@@ -344,22 +344,12 @@ fn visit_schema_impl(schema: &StructType, visitor: &mut EngineSchemaVisitor) -> 
                 // TODO(#2811): add visit_interval_* callbacks; skipping silently drops the column
                 tracing::warn!("Skipping unsupported interval field '{name}' in FFI schema visit");
             }
-            // Geometry/Geography are WKB-encoded bytes at the FFI layer -- route through
-            // visit_binary. The SRID (and edge algorithm for Geography) carried on the
-            // kernel PrimitiveType is not surfaced through this visitor; FFI consumers see
-            // only a binary column. The companion null-literal path in
-            // ffi/src/expressions/kernel_visitor.rs emits NullTypeTag::Binary for the same
-            // reason, giving consumers a uniformly binary view across schema and
-            // expressions. This is a pragmatic stub, not a claim that geo is semantically
-            // equivalent to binary -- CRS-aware operations against these columns will
-            // produce meaningless results. Tables with geo columns should not be consumed
-            // through this FFI until dedicated visit_geometry / visit_geography callbacks
-            // carrying the SRID are added.
-            // Geometry/Geography are WKB-encoded bytes at the FFI layer
-            // TODO: Add visit_geometry / visit_geography callbacks carrying the SRID once real FFI
-            // geo support lands
             DataType::Primitive(PrimitiveType::Geometry(_))
-            | DataType::Primitive(PrimitiveType::Geography(_)) => call!(visit_binary),
+            | DataType::Primitive(PrimitiveType::Geography(_)) => {
+                // TODO(#2914): add visit_geometry / visit_geography callbacks carrying the SRID;
+                // skipping silently drops the column
+                tracing::warn!("Skipping unsupported geo field '{name}' in FFI schema visit");
+            }
         }
     }
 

--- a/ffi/src/schema.rs
+++ b/ffi/src/schema.rs
@@ -346,7 +346,7 @@ fn visit_schema_impl(schema: &StructType, visitor: &mut EngineSchemaVisitor) -> 
             }
             DataType::Primitive(PrimitiveType::Geometry(_))
             | DataType::Primitive(PrimitiveType::Geography(_)) => {
-                // TODO(#2914): add visit_geometry / visit_geography callbacks carrying the SRID;
+                // TODO(#2914): add visit_geometry / visit_geography callbacks carrying the CRS;
                 // skipping silently drops the column
                 tracing::warn!("Skipping unsupported geo field '{name}' in FFI schema visit");
             }

--- a/ffi/src/schema.rs
+++ b/ffi/src/schema.rs
@@ -344,6 +344,19 @@ fn visit_schema_impl(schema: &StructType, visitor: &mut EngineSchemaVisitor) -> 
                 // TODO(#2811): add visit_interval_* callbacks; skipping silently drops the column
                 tracing::warn!("Skipping unsupported interval field '{name}' in FFI schema visit");
             }
+            // Geometry/Geography are WKB-encoded bytes at the FFI layer -- route through
+            // visit_binary. The SRID (and edge algorithm for Geography) carried on the
+            // kernel PrimitiveType is not surfaced through this visitor; FFI consumers see
+            // only a binary column. The companion null-literal path in
+            // ffi/src/expressions/kernel_visitor.rs emits NullTypeTag::Binary for the same
+            // reason, giving consumers a uniformly binary view across schema and
+            // expressions. This is a pragmatic stub, not a claim that geo is semantically
+            // equivalent to binary -- CRS-aware operations against these columns will
+            // produce meaningless results. Tables with geo columns should not be consumed
+            // through this FFI until dedicated visit_geometry / visit_geography callbacks
+            // carrying the SRID are added.
+            DataType::Primitive(PrimitiveType::Geometry(_))
+            | DataType::Primitive(PrimitiveType::Geography(_)) => call!(visit_binary),
         }
     }
 

--- a/ffi/src/schema.rs
+++ b/ffi/src/schema.rs
@@ -356,7 +356,8 @@ fn visit_schema_impl(schema: &StructType, visitor: &mut EngineSchemaVisitor) -> 
             // through this FFI until dedicated visit_geometry / visit_geography callbacks
             // carrying the SRID are added.
             // Geometry/Geography are WKB-encoded bytes at the FFI layer
-            // TODO: Add visit_geometry / visit_geography callbacks carrying the SRID once real FFI geo support lands
+            // TODO: Add visit_geometry / visit_geography callbacks carrying the SRID once real FFI
+            // geo support lands
             DataType::Primitive(PrimitiveType::Geometry(_))
             | DataType::Primitive(PrimitiveType::Geography(_)) => call!(visit_binary),
         }

--- a/kernel/proto/schema.proto
+++ b/kernel/proto/schema.proto
@@ -47,15 +47,15 @@ enum EdgeInterpolationAlgorithm {
   EDGE_INTERPOLATION_ALGORITHM_KARNEY = 5;
 }
 
-// Geometry column type carrying a spatial reference identifier (SRID) in
+// Geometry column type carrying a coordinate reference system (CRS) in
 // AUTHORITY:CODE form.
 message GeometryType {
-  string srid = 1;
+  string crs = 1;
 }
 
-// Geography column type carrying an SRID and an edge interpolation algorithm.
+// Geography column type carrying a CRS and an edge interpolation algorithm.
 message GeographyType {
-  string srid = 1;
+  string crs = 1;
   EdgeInterpolationAlgorithm algorithm = 2;
 }
 

--- a/kernel/proto/schema.proto
+++ b/kernel/proto/schema.proto
@@ -1,4 +1,4 @@
-// Proto mirror of `kernel/src/schema/mod.rs` 
+// Proto mirror of `kernel/src/schema/mod.rs`
 
 syntax = "proto3";
 
@@ -37,10 +37,34 @@ message DecimalType {
   uint32 scale = 2;
 }
 
+// Edge interpolation algorithm for geography type.
+enum EdgeInterpolationAlgorithm {
+  EDGE_INTERPOLATION_ALGORITHM_UNSPECIFIED = 0;
+  EDGE_INTERPOLATION_ALGORITHM_SPHERICAL = 1;
+  EDGE_INTERPOLATION_ALGORITHM_VINCENTY = 2;
+  EDGE_INTERPOLATION_ALGORITHM_THOMAS = 3;
+  EDGE_INTERPOLATION_ALGORITHM_ANDOYER = 4;
+  EDGE_INTERPOLATION_ALGORITHM_KARNEY = 5;
+}
+
+// Geometry column type carrying a spatial reference identifier (SRID) in
+// AUTHORITY:CODE form.
+message GeometryType {
+  string srid = 1;
+}
+
+// Geography column type carrying an SRID and an edge interpolation algorithm.
+message GeographyType {
+  string srid = 1;
+  EdgeInterpolationAlgorithm algorithm = 2;
+}
+
 message PrimitiveType {
   oneof kind {
     SimplePrimitiveType simple = 1;
     DecimalType decimal = 2;
+    GeometryType geometry = 3;
+    GeographyType geography = 4;
   }
 }
 

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -374,13 +374,9 @@ impl TryFromKernel<&DataType> for ArrowDataType {
                             "Interval types are not yet supported in the default engine: {p}"
                         )))
                     }
-                    // Geometry/Geography are WKB-encoded bytes at the Arrow layer. The SRID
-                    // (and edge algorithm for Geography) belongs on the ArrowField as
-                    // GeoArrow extension metadata (the `crs` / `edges` keys), not on the
-                    // ArrowDataType itself. Attaching that metadata is deferred to the
-                    // StructField -> ArrowField conversion path.
+
                     // Geometry/Geography are WKB-encoded bytes.
-                    // The SRID (and edge algorithm for Geometry) belongs on the ArrowField
+                    // The CRS (and edge algorithm for Geography) belongs on the ArrowField
                     // as GeoArrow extension metadata
                     PrimitiveType::Geometry(_) | PrimitiveType::Geography(_) => {
                         Ok(ArrowDataType::Binary)

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -379,6 +379,9 @@ impl TryFromKernel<&DataType> for ArrowDataType {
                     // GeoArrow extension metadata (the `crs` / `edges` keys), not on the
                     // ArrowDataType itself. Attaching that metadata is deferred to the
                     // StructField -> ArrowField conversion path.
+                    // Geometry/Geography are WKB-encoded bytes.
+                    // The SRID (and edge algorithm for Geometry) belongs on the ArrowField
+                    // as GeoArrow extension metadata
                     PrimitiveType::Geometry(_) | PrimitiveType::Geography(_) => {
                         Ok(ArrowDataType::Binary)
                     }

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -374,6 +374,14 @@ impl TryFromKernel<&DataType> for ArrowDataType {
                             "Interval types are not yet supported in the default engine: {p}"
                         )))
                     }
+                    // Geometry/Geography are WKB-encoded bytes at the Arrow layer. The SRID
+                    // (and edge algorithm for Geography) belongs on the ArrowField as
+                    // GeoArrow extension metadata (the `crs` / `edges` keys), not on the
+                    // ArrowDataType itself. Attaching that metadata is deferred to the
+                    // StructField -> ArrowField conversion path.
+                    PrimitiveType::Geometry(_) | PrimitiveType::Geography(_) => {
+                        Ok(ArrowDataType::Binary)
+                    }
                 }
             }
             DataType::Struct(s) => Ok(ArrowDataType::Struct(

--- a/kernel/src/engine/arrow_expression/mod.rs
+++ b/kernel/src/engine/arrow_expression/mod.rs
@@ -218,6 +218,12 @@ impl Scalar {
                     "Interval is not supported as scalar yet.",
                 ));
             }
+            // Geometry/Geography are WKB-encoded bytes at the Arrow layer, so null appends
+            // route through the BinaryBuilder path. GeoArrow extension metadata is attached
+            // at the ArrowField level (in a schema), not to the builder produced here.
+            DataType::Primitive(PrimitiveType::Geometry(_) | PrimitiveType::Geography(_)) => {
+                append_nulls_as!(array::BinaryBuilder)
+            }
         }
         Ok(())
     }

--- a/kernel/src/engine/ensure_data_types.rs
+++ b/kernel/src/engine/ensure_data_types.rs
@@ -9,7 +9,7 @@ use itertools::Itertools;
 use super::arrow_conversion::TryIntoArrow as _;
 use crate::arrow::datatypes::{DataType as ArrowDataType, Field as ArrowField, TimeUnit};
 use crate::engine::arrow_utils::make_arrow_error;
-use crate::schema::{DataType, MetadataValue, StructField};
+use crate::schema::{DataType, MetadataValue, PrimitiveType, StructField};
 use crate::utils::require;
 use crate::{DeltaResult, Error};
 
@@ -125,6 +125,12 @@ impl EnsureDataTypes {
             | (&DataType::BINARY, ArrowDataType::BinaryView)
             | (&DataType::BINARY, ArrowDataType::Binary)
             | (&DataType::VOID, ArrowDataType::Null) => Ok(DataTypeCompat::Identical),
+            // Geometry and Geography values are stored as WKB bytes in a Binary array; the
+            // kernel schema carries the geo annotation while the physical Arrow type is Binary.
+            (
+                DataType::Primitive(PrimitiveType::Geometry(_) | PrimitiveType::Geography(_)),
+                ArrowDataType::Binary | ArrowDataType::LargeBinary | ArrowDataType::BinaryView,
+            ) => Ok(DataTypeCompat::Identical),
             (DataType::Array(inner_type), ArrowDataType::List(arrow_list_field))
             | (DataType::Array(inner_type), ArrowDataType::LargeList(arrow_list_field))
             | (DataType::Array(inner_type), ArrowDataType::ListView(arrow_list_field))

--- a/kernel/src/engine/parquet_row_group_skipping.rs
+++ b/kernel/src/engine/parquet_row_group_skipping.rs
@@ -203,6 +203,9 @@ fn extract_min_scalar(data_type: &DataType, stats: &Statistics) -> Option<Scalar
         (Decimal(..), _) => return None,
         // Void columns have no Parquet representation, so no stats exist
         (Void, _) => return None,
+        // WKB bytes are not lexicographically orderable, so parquet min/max are not
+        // meaningful for Geometry/Geography columns.
+        (Geometry(_) | Geography(_), _) => return None,
     };
     Some(value)
 }
@@ -250,6 +253,9 @@ fn extract_max_scalar(data_type: &DataType, stats: &Statistics) -> Option<Scalar
         (Decimal(..), _) => return None,
         // Void columns have no Parquet representation, so no stats exist
         (Void, _) => return None,
+        // WKB bytes are not lexicographically orderable, so parquet min/max are not
+        // meaningful for Geometry/Geography columns.
+        (Geometry(_) | Geography(_), _) => return None,
     };
     Some(value)
 }

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -184,6 +184,14 @@ pub enum Error {
     #[error("Invalid decimal: {0}")]
     InvalidDecimal(String),
 
+    /// Invalid srid for a GeometryType
+    #[error("Invalid geometry: {0}")]
+    InvalidGeometry(String),
+
+    /// Invalid srid for a GeographyType
+    #[error("Invalid geography: {0}")]
+    InvalidGeography(String),
+
     /// Inconsistent data passed to struct scalar
     #[error("Invalid struct data: {0}")]
     InvalidStructData(String),
@@ -294,6 +302,12 @@ impl Error {
     }
     pub fn invalid_decimal(msg: impl ToString) -> Self {
         Self::InvalidDecimal(msg.to_string())
+    }
+    pub fn invalid_geometry(msg: impl ToString) -> Self {
+        Self::InvalidGeometry(msg.to_string())
+    }
+    pub fn invalid_geography(msg: impl ToString) -> Self {
+        Self::InvalidGeography(msg.to_string())
     }
     pub fn invalid_struct_data(msg: impl ToString) -> Self {
         Self::InvalidStructData(msg.to_string())

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -184,13 +184,9 @@ pub enum Error {
     #[error("Invalid decimal: {0}")]
     InvalidDecimal(String),
 
-    /// Invalid srid for a GeometryType
-    #[error("Invalid geometry: {0}")]
-    InvalidGeometry(String),
-
-    /// Invalid srid for a GeographyType
-    #[error("Invalid geography: {0}")]
-    InvalidGeography(String),
+    /// Invalid SRID or other parameter for a Geometry / Geography type
+    #[error("Invalid geo parameters: {0}")]
+    InvalidGeoParams(String),
 
     /// Inconsistent data passed to struct scalar
     #[error("Invalid struct data: {0}")]
@@ -303,11 +299,8 @@ impl Error {
     pub fn invalid_decimal(msg: impl ToString) -> Self {
         Self::InvalidDecimal(msg.to_string())
     }
-    pub fn invalid_geometry(msg: impl ToString) -> Self {
-        Self::InvalidGeometry(msg.to_string())
-    }
-    pub fn invalid_geography(msg: impl ToString) -> Self {
-        Self::InvalidGeography(msg.to_string())
+    pub fn invalid_geo_params(msg: impl ToString) -> Self {
+        Self::InvalidGeoParams(msg.to_string())
     }
     pub fn invalid_struct_data(msg: impl ToString) -> Self {
         Self::InvalidStructData(msg.to_string())

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -184,7 +184,7 @@ pub enum Error {
     #[error("Invalid decimal: {0}")]
     InvalidDecimal(String),
 
-    /// Invalid SRID or other parameter for a Geometry / Geography type
+    /// Invalid CRS or other parameter for a Geometry / Geography type
     #[error("Invalid geo parameters: {0}")]
     InvalidGeoParams(String),
 

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -788,9 +788,7 @@ impl PrimitiveType {
             IntervalYearMonth | IntervalDayTime => Err(Error::unsupported(
                 "Interval types are not supported as scalar or partition values",
             )),
-            // Geometry/Geography are not valid partition column types, so there is no
-            // partition-value string format to parse here
-            // Kernel does not support parsing text into Geometry/Geography types
+            // Kernel does not support parsing text into Geometry/Geography types yet.
             Geometry(_) | Geography(_) => Err(Error::Unsupported(format!(
                 "parse_scalar is not supported for {self:?}"
             ))),

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -790,6 +790,7 @@ impl PrimitiveType {
             )),
             // Geometry/Geography are not valid partition column types, so there is no
             // partition-value string format to parse here
+            // Kernel does not support parsing text into Geometry/Geography types
             Geometry(_) | Geography(_) => Err(Error::Unsupported(format!(
                 "parse_scalar is not supported for {self:?}"
             ))),

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -788,6 +788,11 @@ impl PrimitiveType {
             IntervalYearMonth | IntervalDayTime => Err(Error::unsupported(
                 "Interval types are not supported as scalar or partition values",
             )),
+            // Geometry/Geography are not valid partition column types, so there is no
+            // partition-value string format to parse here.
+            Geometry(_) | Geography(_) => Err(Error::generic(
+                "Geometry and Geography types are not supported as partition column values",
+            )),
         }
     }
 

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -789,10 +789,10 @@ impl PrimitiveType {
                 "Interval types are not supported as scalar or partition values",
             )),
             // Geometry/Geography are not valid partition column types, so there is no
-            // partition-value string format to parse here.
-            Geometry(_) | Geography(_) => Err(Error::generic(
-                "Geometry and Geography types are not supported as partition column values",
-            )),
+            // partition-value string format to parse here
+            Geometry(_) | Geography(_) => Err(Error::Unsupported(format!(
+                "parse_scalar is not supported for {self:?}"
+            ))),
         }
     }
 

--- a/kernel/src/plans/proto/convert.rs
+++ b/kernel/src/plans/proto/convert.rs
@@ -868,7 +868,7 @@ impl TryFrom<proto_schema::GeographyType> for GeographyType {
                 ))
             })?
             .try_into()?;
-        GeographyType::try_new(Some(&proto.srid), Some(algorithm))
+        GeographyType::try_new(&proto.srid, algorithm)
     }
 }
 
@@ -2131,7 +2131,7 @@ mod tests {
     }
 
     #[rstest]
-    #[case(GeometryType::default())]
+    #[case(GeometryType::try_new("OGC:CRS84").unwrap())]
     #[case(GeometryType::try_new("EPSG:4326").unwrap())]
     fn round_trip_geometry(#[case] geometry: GeometryType) {
         assert_data_type_round_trips(DataType::Primitive(PrimitiveType::Geometry(Box::new(
@@ -2141,7 +2141,7 @@ mod tests {
 
     #[rstest]
     fn round_trip_geography(
-        #[values(None, Some("EPSG:4326"))] srid: Option<&str>,
+        #[values("OGC:CRS84", "EPSG:4326")] srid: &str,
         #[values(
             EdgeInterpolationAlgorithm::Spherical,
             EdgeInterpolationAlgorithm::Vincenty,
@@ -2151,7 +2151,7 @@ mod tests {
         )]
         algorithm: EdgeInterpolationAlgorithm,
     ) {
-        let geography = GeographyType::try_new(srid, Some(algorithm)).unwrap();
+        let geography = GeographyType::try_new(srid, algorithm).unwrap();
         assert_data_type_round_trips(DataType::Primitive(PrimitiveType::Geography(Box::new(
             geography,
         ))));

--- a/kernel/src/plans/proto/convert.rs
+++ b/kernel/src/plans/proto/convert.rs
@@ -4,7 +4,7 @@ use super::plan::agg as proto_agg;
 use super::schema::data_type::Kind as DataTypeKind;
 use super::schema::metadata_value::Value as MetadataValueKind;
 use super::schema::primitive_type::Kind as PrimitiveTypeKind;
-use super::schema::SimplePrimitiveType as Simple;
+use super::schema::{EdgeInterpolationAlgorithm as EdgeAlgo, SimplePrimitiveType as Simple};
 use super::{
     expressions as proto_expr, operation as proto_op, plan as proto_plan, schema as proto_schema,
 };
@@ -22,8 +22,8 @@ use crate::plans::ir::nodes::{
 use crate::plans::ir::plan::{Plan, PlanNode};
 use crate::plans::{IoOperation, Operation};
 use crate::schema::{
-    ArrayType, DataType, DecimalType, MapType, MetadataValue, PrimitiveType, StructField,
-    StructType,
+    ArrayType, DataType, DecimalType, EdgeInterpolationAlgorithm, GeographyType, GeometryType,
+    MapType, MetadataValue, PrimitiveType, StructField, StructType,
 };
 use crate::{DeltaResult, Error, FileMeta, FileSlice};
 
@@ -628,6 +628,12 @@ impl From<&PrimitiveType> for proto_schema::PrimitiveType {
             PrimitiveType::Timestamp => PrimitiveTypeKind::Simple(Simple::Timestamp as i32),
             PrimitiveType::TimestampNtz => PrimitiveTypeKind::Simple(Simple::TimestampNtz as i32),
             PrimitiveType::Decimal(decimal) => PrimitiveTypeKind::Decimal((*decimal).into()),
+            PrimitiveType::Geometry(geometry) => {
+                PrimitiveTypeKind::Geometry(geometry.as_ref().into())
+            }
+            PrimitiveType::Geography(geography) => {
+                PrimitiveTypeKind::Geography(geography.as_ref().into())
+            }
             PrimitiveType::Void => PrimitiveTypeKind::Simple(Simple::Void as i32),
             PrimitiveType::IntervalYearMonth => {
                 PrimitiveTypeKind::Simple(Simple::IntervalYearMonth as i32)
@@ -645,6 +651,35 @@ impl From<DecimalType> for proto_schema::DecimalType {
         proto_schema::DecimalType {
             precision: u32::from(decimal.precision()),
             scale: u32::from(decimal.scale()),
+        }
+    }
+}
+
+impl From<&GeometryType> for proto_schema::GeometryType {
+    fn from(geometry: &GeometryType) -> Self {
+        proto_schema::GeometryType {
+            srid: geometry.srid().to_string(),
+        }
+    }
+}
+
+impl From<&GeographyType> for proto_schema::GeographyType {
+    fn from(geography: &GeographyType) -> Self {
+        proto_schema::GeographyType {
+            srid: geography.srid().to_string(),
+            algorithm: EdgeAlgo::from(geography.algorithm()) as i32,
+        }
+    }
+}
+
+impl From<&EdgeInterpolationAlgorithm> for EdgeAlgo {
+    fn from(algorithm: &EdgeInterpolationAlgorithm) -> Self {
+        match algorithm {
+            EdgeInterpolationAlgorithm::Spherical => EdgeAlgo::Spherical,
+            EdgeInterpolationAlgorithm::Vincenty => EdgeAlgo::Vincenty,
+            EdgeInterpolationAlgorithm::Thomas => EdgeAlgo::Thomas,
+            EdgeInterpolationAlgorithm::Andoyer => EdgeAlgo::Andoyer,
+            EdgeInterpolationAlgorithm::Karney => EdgeAlgo::Karney,
         }
     }
 }
@@ -792,6 +827,12 @@ impl TryFrom<proto_schema::PrimitiveType> for PrimitiveType {
                 }
             }
             PrimitiveTypeKind::Decimal(decimal) => PrimitiveType::Decimal(decimal.try_into()?),
+            PrimitiveTypeKind::Geometry(geometry) => {
+                PrimitiveType::Geometry(Box::new(geometry.try_into()?))
+            }
+            PrimitiveTypeKind::Geography(geography) => {
+                PrimitiveType::Geography(Box::new(geography.try_into()?))
+            }
         };
         Ok(primitive)
     }
@@ -806,6 +847,47 @@ impl TryFrom<proto_schema::DecimalType> for DecimalType {
         let scale = u8::try_from(proto.scale)
             .map_err(|_| Error::invalid_decimal(format!("scale out of range: {}", proto.scale)))?;
         DecimalType::try_new(precision, scale)
+    }
+}
+
+impl TryFrom<proto_schema::GeometryType> for GeometryType {
+    type Error = Error;
+    fn try_from(proto: proto_schema::GeometryType) -> DeltaResult<Self> {
+        GeometryType::try_new(&proto.srid)
+    }
+}
+
+impl TryFrom<proto_schema::GeographyType> for GeographyType {
+    type Error = Error;
+    fn try_from(proto: proto_schema::GeographyType) -> DeltaResult<Self> {
+        let algorithm = EdgeAlgo::try_from(proto.algorithm)
+            .map_err(|_| {
+                Error::invalid_geo_params(format!(
+                    "unknown EdgeInterpolationAlgorithm value: {}",
+                    proto.algorithm
+                ))
+            })?
+            .try_into()?;
+        GeographyType::try_new(Some(&proto.srid), Some(algorithm))
+    }
+}
+
+impl TryFrom<EdgeAlgo> for EdgeInterpolationAlgorithm {
+    type Error = Error;
+    fn try_from(proto: EdgeAlgo) -> DeltaResult<Self> {
+        let algorithm = match proto {
+            EdgeAlgo::Spherical => EdgeInterpolationAlgorithm::Spherical,
+            EdgeAlgo::Vincenty => EdgeInterpolationAlgorithm::Vincenty,
+            EdgeAlgo::Thomas => EdgeInterpolationAlgorithm::Thomas,
+            EdgeAlgo::Andoyer => EdgeInterpolationAlgorithm::Andoyer,
+            EdgeAlgo::Karney => EdgeInterpolationAlgorithm::Karney,
+            EdgeAlgo::Unspecified => {
+                return Err(Error::invalid_geo_params(
+                    "EdgeInterpolationAlgorithm is unspecified",
+                ))
+            }
+        };
+        Ok(algorithm)
     }
 }
 
@@ -886,8 +968,8 @@ mod tests {
     };
     use crate::plans::{IoOperation, Operation};
     use crate::schema::{
-        ArrayType, DataType, DecimalType, MapType, MetadataValue, PrimitiveType, SchemaRef,
-        StructField, StructType,
+        ArrayType, DataType, DecimalType, EdgeInterpolationAlgorithm, GeographyType, GeometryType,
+        MapType, MetadataValue, PrimitiveType, SchemaRef, StructField, StructType,
     };
     use crate::{DeltaResult, FileMeta, FileSlice};
 
@@ -2046,6 +2128,33 @@ mod tests {
         assert_data_type_round_trips(DataType::Primitive(
             PrimitiveType::decimal(precision, scale).unwrap(),
         ));
+    }
+
+    #[rstest]
+    #[case(GeometryType::default())]
+    #[case(GeometryType::try_new("EPSG:4326").unwrap())]
+    fn round_trip_geometry(#[case] geometry: GeometryType) {
+        assert_data_type_round_trips(DataType::Primitive(PrimitiveType::Geometry(Box::new(
+            geometry,
+        ))));
+    }
+
+    #[rstest]
+    fn round_trip_geography(
+        #[values(None, Some("EPSG:4326"))] srid: Option<&str>,
+        #[values(
+            EdgeInterpolationAlgorithm::Spherical,
+            EdgeInterpolationAlgorithm::Vincenty,
+            EdgeInterpolationAlgorithm::Thomas,
+            EdgeInterpolationAlgorithm::Andoyer,
+            EdgeInterpolationAlgorithm::Karney
+        )]
+        algorithm: EdgeInterpolationAlgorithm,
+    ) {
+        let geography = GeographyType::try_new(srid, Some(algorithm)).unwrap();
+        assert_data_type_round_trips(DataType::Primitive(PrimitiveType::Geography(Box::new(
+            geography,
+        ))));
     }
 
     #[rstest]

--- a/kernel/src/plans/proto/convert.rs
+++ b/kernel/src/plans/proto/convert.rs
@@ -658,7 +658,7 @@ impl From<DecimalType> for proto_schema::DecimalType {
 impl From<&GeometryType> for proto_schema::GeometryType {
     fn from(geometry: &GeometryType) -> Self {
         proto_schema::GeometryType {
-            srid: geometry.srid().to_string(),
+            crs: geometry.crs().to_string(),
         }
     }
 }
@@ -666,7 +666,7 @@ impl From<&GeometryType> for proto_schema::GeometryType {
 impl From<&GeographyType> for proto_schema::GeographyType {
     fn from(geography: &GeographyType) -> Self {
         proto_schema::GeographyType {
-            srid: geography.srid().to_string(),
+            crs: geography.crs().to_string(),
             algorithm: EdgeAlgo::from(geography.algorithm()) as i32,
         }
     }
@@ -853,7 +853,7 @@ impl TryFrom<proto_schema::DecimalType> for DecimalType {
 impl TryFrom<proto_schema::GeometryType> for GeometryType {
     type Error = Error;
     fn try_from(proto: proto_schema::GeometryType) -> DeltaResult<Self> {
-        GeometryType::try_new(&proto.srid)
+        GeometryType::try_new(&proto.crs)
     }
 }
 
@@ -868,7 +868,7 @@ impl TryFrom<proto_schema::GeographyType> for GeographyType {
                 ))
             })?
             .try_into()?;
-        GeographyType::try_new(&proto.srid, algorithm)
+        GeographyType::try_new(&proto.crs, algorithm)
     }
 }
 
@@ -2141,7 +2141,7 @@ mod tests {
 
     #[rstest]
     fn round_trip_geography(
-        #[values("OGC:CRS84", "EPSG:4326")] srid: &str,
+        #[values("OGC:CRS84", "EPSG:4326")] crs: &str,
         #[values(
             EdgeInterpolationAlgorithm::Spherical,
             EdgeInterpolationAlgorithm::Vincenty,
@@ -2151,7 +2151,7 @@ mod tests {
         )]
         algorithm: EdgeInterpolationAlgorithm,
     ) {
-        let geography = GeographyType::try_new(srid, algorithm).unwrap();
+        let geography = GeographyType::try_new(crs, algorithm).unwrap();
         assert_data_type_round_trips(DataType::Primitive(PrimitiveType::Geography(Box::new(
             geography,
         ))));

--- a/kernel/src/scan/data_skipping/stats_schema/mod.rs
+++ b/kernel/src/scan/data_skipping/stats_schema/mod.rs
@@ -379,6 +379,11 @@ impl<'a> SchemaTransform<'a> for MinMaxStatsTransform {
 /// meaningful. When `nullCount` stats are present for a void column, `eval_pred_is_null` can
 /// use them for `IS NULL` / `IS NOT NULL` file skipping.
 ///
+/// Geometry and Geography are excluded here even though the Delta protocol lists them as
+/// skipping-eligible: kernel does not yet parse or compare geo min/max stats (`parse_scalar`
+/// errors on geo), so claiming eligibility would emit predicate refs to stats kernel can't
+/// evaluate. Add them back once geo stats parsing and comparison are implemented.
+///
 /// See: <https://github.com/delta-io/delta/blob/143ab3337121248d2ca6a7d5bc31deae7c8fe4be/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java#L61>
 pub(crate) fn is_skipping_eligible_datatype(data_type: &PrimitiveType) -> bool {
     matches!(
@@ -394,15 +399,15 @@ pub(crate) fn is_skipping_eligible_datatype(data_type: &PrimitiveType) -> bool {
             | &PrimitiveType::TimestampNtz
             | &PrimitiveType::String
             | PrimitiveType::Decimal(_)
-            | PrimitiveType::Geometry(_)
-            | PrimitiveType::Geography(_)
     )
 }
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
-    use crate::schema::ArrayType;
+    use crate::schema::{ArrayType, EdgeInterpolationAlgorithm, GeographyType, GeometryType};
     use crate::table_properties::TableProperties;
 
     fn stats_config_from_table_properties(properties: &TableProperties) -> StatsConfig<'_> {
@@ -1321,5 +1326,14 @@ mod tests {
         let expected = expected_stats(expected_null, expected_nested);
 
         assert_eq!(&expected, &stats_schema);
+    }
+
+    #[rstest]
+    #[case(PrimitiveType::Geometry(Box::new(GeometryType::try_new("EPSG:4326").unwrap())))]
+    #[case(PrimitiveType::Geography(Box::new(
+        GeographyType::try_new("EPSG:4326", EdgeInterpolationAlgorithm::Spherical).unwrap()
+    )))]
+    fn test_geo_types_are_not_skipping_eligible(#[case] ptype: PrimitiveType) {
+        assert!(!is_skipping_eligible_datatype(&ptype));
     }
 }

--- a/kernel/src/scan/data_skipping/stats_schema/mod.rs
+++ b/kernel/src/scan/data_skipping/stats_schema/mod.rs
@@ -394,6 +394,8 @@ pub(crate) fn is_skipping_eligible_datatype(data_type: &PrimitiveType) -> bool {
             | &PrimitiveType::TimestampNtz
             | &PrimitiveType::String
             | PrimitiveType::Decimal(_)
+            | PrimitiveType::Geometry(_)
+            | PrimitiveType::Geography(_)
     )
 }
 

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -1778,9 +1778,6 @@ fn default_true() -> bool {
     true
 }
 
-/// Default spatial reference identifier for geometry and geography types.
-pub const DEFAULT_GEO_SRID: &str = "OGC:CRS84";
-
 /// Validates that an SRID is in AUTHORITY:CODE form: contains a colon, has non-empty text
 /// before and after it, and has no leading or trailing whitespace. Validating the value
 /// against the full set of recognized SRIDs is future work.
@@ -1853,8 +1850,7 @@ pub struct GeometryType {
 
 impl GeometryType {
     /// Constructs a GeometryType from the given SRID, or returns an error if the SRID is
-    /// not in AUTHORITY:CODE form. Use GeometryType::default to build with the default
-    /// SRID (OGC:CRS84).
+    /// not in AUTHORITY:CODE form.
     pub fn try_new(srid: &str) -> DeltaResult<Self> {
         validate_srid(srid)?;
         Ok(Self {
@@ -1864,14 +1860,6 @@ impl GeometryType {
 
     pub fn srid(&self) -> &str {
         &self.srid
-    }
-}
-
-impl Default for GeometryType {
-    fn default() -> Self {
-        Self {
-            srid: DEFAULT_GEO_SRID.to_string(),
-        }
     }
 }
 
@@ -1889,22 +1877,14 @@ pub struct GeographyType {
 }
 
 impl GeographyType {
-    /// Constructs a GeographyType. Pass None for either argument to use the default: SRID
-    /// defaults to OGC:CRS84; algorithm defaults to Spherical. Returns an error if srid is
-    /// Some(...) but not in AUTHORITY:CODE form.
-    pub fn try_new(
-        srid: Option<&str>,
-        algorithm: Option<EdgeInterpolationAlgorithm>,
-    ) -> DeltaResult<Self> {
-        let srid = match srid {
-            None => DEFAULT_GEO_SRID.to_string(),
-            Some(s) => {
-                validate_srid(s)?;
-                s.to_string()
-            }
-        };
-        let algorithm = algorithm.unwrap_or(EdgeInterpolationAlgorithm::Spherical);
-        Ok(Self { srid, algorithm })
+    /// Constructs a GeographyType from the given SRID and edge interpolation algorithm, or
+    /// returns an error if the SRID is not in AUTHORITY:CODE form.
+    pub fn try_new(srid: &str, algorithm: EdgeInterpolationAlgorithm) -> DeltaResult<Self> {
+        validate_srid(srid)?;
+        Ok(Self {
+            srid: srid.to_string(),
+            algorithm,
+        })
     }
 
     pub fn srid(&self) -> &str {
@@ -1913,15 +1893,6 @@ impl GeographyType {
 
     pub fn algorithm(&self) -> &EdgeInterpolationAlgorithm {
         &self.algorithm
-    }
-}
-
-impl Default for GeographyType {
-    fn default() -> Self {
-        Self {
-            srid: DEFAULT_GEO_SRID.to_string(),
-            algorithm: EdgeInterpolationAlgorithm::Spherical,
-        }
     }
 }
 
@@ -2181,7 +2152,6 @@ impl<'de> serde::Deserialize<'de> for PrimitiveType {
                     .map(PrimitiveType::Decimal)
                     .map_err(serde::de::Error::custom)
             }
-            "geometry" => Ok(PrimitiveType::Geometry(Box::default())),
             geo_str if geo_str.starts_with("geometry(") && geo_str.ends_with(')') => {
                 let srid = &geo_str[9..geo_str.len() - 1];
                 GeometryType::try_new(srid.trim())
@@ -2189,40 +2159,25 @@ impl<'de> serde::Deserialize<'de> for PrimitiveType {
                     .map(PrimitiveType::Geometry)
                     .map_err(serde::de::Error::custom)
             }
-            "geography" => Ok(PrimitiveType::Geography(Box::default())),
             geo_str if geo_str.starts_with("geography(") && geo_str.ends_with(')') => {
                 let inner = &geo_str[10..geo_str.len() - 1];
-                // Three accepted shapes:
-                //   geography(<srid>, <algorithm>) - both
-                //   geography(<srid>)              - SRID only (contains ':')
-                //   geography(<algorithm>)         - algorithm only (no ':')
-                match inner.rfind(',') {
-                    Some(pos) => {
-                        let srid = inner[..pos].trim();
-                        let algo_str = inner[pos + 1..].trim();
+                // Kernel accepts only the canonical serialized form that every writer emits:
+                //   geography(<crs>, <algorithm>)
+                // TODO: reevaluate whether accepting padded input like
+                // geography(  EPSG:4326 ,  vincenty  ) is desired.
+                match inner.split_once(',') {
+                    Some((srid, algo_str)) => {
                         let algorithm: EdgeInterpolationAlgorithm =
-                            algo_str.parse().map_err(serde::de::Error::custom)?;
-                        GeographyType::try_new(Some(srid), Some(algorithm))
+                            algo_str.trim().parse().map_err(serde::de::Error::custom)?;
+                        GeographyType::try_new(srid.trim(), algorithm)
                             .map(Box::new)
                             .map(PrimitiveType::Geography)
                             .map_err(serde::de::Error::custom)
                     }
-                    None => {
-                        let trimmed = inner.trim();
-                        if trimmed.contains(':') {
-                            GeographyType::try_new(Some(trimmed), None)
-                                .map(Box::new)
-                                .map(PrimitiveType::Geography)
-                                .map_err(serde::de::Error::custom)
-                        } else {
-                            let algorithm: EdgeInterpolationAlgorithm =
-                                trimmed.parse().map_err(serde::de::Error::custom)?;
-                            GeographyType::try_new(None, Some(algorithm))
-                                .map(Box::new)
-                                .map(PrimitiveType::Geography)
-                                .map_err(serde::de::Error::custom)
-                        }
-                    }
+                    None => Err(serde::de::Error::custom(format!(
+                        "Invalid geography type '{geo_str}': expected \
+                         'geography(<crs>, <algorithm>)'"
+                    ))),
                 }
             }
             unsupported => Err(serde::de::Error::custom(format!(
@@ -2840,60 +2795,6 @@ mod tests {
     }
 
     #[test]
-    fn test_roundtrip_geometry() {
-        let data = r#"
-        {
-            "name": "g",
-            "type": "geometry(EPSG:4326)",
-            "nullable": true,
-            "metadata": {}
-        }
-        "#;
-        let field: StructField = serde_json::from_str(data).unwrap();
-        assert_eq!(
-            field.data_type,
-            DataType::Primitive(PrimitiveType::Geometry(Box::new(
-                GeometryType::try_new("EPSG:4326").unwrap()
-            )))
-        );
-
-        let json_str = serde_json::to_string(&field).unwrap();
-        assert_eq!(
-            json_str,
-            r#"{"name":"g","type":"geometry(EPSG:4326)","nullable":true,"metadata":{}}"#
-        );
-    }
-
-    #[test]
-    fn test_roundtrip_geography() {
-        let data = r#"
-        {
-            "name": "g",
-            "type": "geography(EPSG:4326, vincenty)",
-            "nullable": true,
-            "metadata": {}
-        }
-        "#;
-        let field: StructField = serde_json::from_str(data).unwrap();
-        assert_eq!(
-            field.data_type,
-            DataType::Primitive(PrimitiveType::Geography(Box::new(
-                GeographyType::try_new(
-                    Some("EPSG:4326"),
-                    Some(EdgeInterpolationAlgorithm::Vincenty)
-                )
-                .unwrap()
-            )))
-        );
-
-        let json_str = serde_json::to_string(&field).unwrap();
-        assert_eq!(
-            json_str,
-            r#"{"name":"g","type":"geography(EPSG:4326, vincenty)","nullable":true,"metadata":{}}"#
-        );
-    }
-
-    #[test]
     fn test_roundtrip_void() {
         let data = r#"
         {
@@ -3078,36 +2979,61 @@ mod tests {
         );
     }
 
+    fn geography(srid: &str, algorithm: EdgeInterpolationAlgorithm) -> PrimitiveType {
+        PrimitiveType::Geography(Box::new(GeographyType::try_new(srid, algorithm).unwrap()))
+    }
+
+    fn geo_field_json(type_str: &str) -> String {
+        format!(r#"{{"name":"g","type":"{type_str}","nullable":true,"metadata":{{}}}}"#)
+    }
+
     #[rstest]
-    #[case("geometry", PrimitiveType::Geometry(Box::default()))]
-    #[case("geography", PrimitiveType::Geography(Box::default()))]
     #[case(
         "geometry(EPSG:4326)",
-        PrimitiveType::Geometry(Box::new(GeometryType::try_new("EPSG:4326").unwrap()))
+        PrimitiveType::Geometry(Box::new(GeometryType::try_new("EPSG:4326").unwrap())),
+        "geometry(EPSG:4326)"
     )]
     #[case(
-        "geography(EPSG:4326)",
-        PrimitiveType::Geography(Box::new(
-            GeographyType::try_new(Some("EPSG:4326"), None).unwrap()
-        ))
+        "geography(EPSG:4326, spherical)",
+        geography("EPSG:4326", EdgeInterpolationAlgorithm::Spherical),
+        "geography(EPSG:4326, spherical)"
     )]
     #[case(
         "geography(EPSG:4326, vincenty)",
-        PrimitiveType::Geography(Box::new(
-            GeographyType::try_new(Some("EPSG:4326"), Some(EdgeInterpolationAlgorithm::Vincenty))
-                .unwrap()
-        ))
+        geography("EPSG:4326", EdgeInterpolationAlgorithm::Vincenty),
+        "geography(EPSG:4326, vincenty)"
     )]
     #[case(
-        "geography(vincenty)",
-        PrimitiveType::Geography(Box::new(
-            GeographyType::try_new(None, Some(EdgeInterpolationAlgorithm::Vincenty)).unwrap()
-        ))
+        "geography(EPSG:4326, thomas)",
+        geography("EPSG:4326", EdgeInterpolationAlgorithm::Thomas),
+        "geography(EPSG:4326, thomas)"
     )]
-    fn test_geo_deserialize_defaults(#[case] type_str: &str, #[case] expected: PrimitiveType) {
-        let json = format!(r#"{{"name":"g","type":"{type_str}","nullable":true,"metadata":{{}}}}"#);
-        let field: StructField = serde_json::from_str(&json).unwrap();
-        assert_eq!(field.data_type, DataType::Primitive(expected));
+    #[case(
+        "geography(EPSG:4326, andoyer)",
+        geography("EPSG:4326", EdgeInterpolationAlgorithm::Andoyer),
+        "geography(EPSG:4326, andoyer)"
+    )]
+    #[case(
+        "geography(EPSG:4326, karney)",
+        geography("EPSG:4326", EdgeInterpolationAlgorithm::Karney),
+        "geography(EPSG:4326, karney)"
+    )]
+    #[case(
+        "geography( EPSG:4326 , karney  )",
+        geography("EPSG:4326", EdgeInterpolationAlgorithm::Karney),
+        "geography(EPSG:4326, karney)"
+    )]
+    fn test_geo_deserialize_succeed(
+        #[case] type_str: &str,
+        #[case] expected: PrimitiveType,
+        #[case] canonical: &str,
+    ) {
+        let field: StructField = serde_json::from_str(&geo_field_json(type_str)).unwrap();
+        assert_eq!(field.data_type, DataType::Primitive(expected.clone()));
+
+        assert_eq!(expected.to_string(), canonical);
+        let roundtrip: StructField = serde_json::from_str(&geo_field_json(canonical)).unwrap();
+        assert_eq!(roundtrip.data_type, DataType::Primitive(expected));
     }
 
     #[rstest]
@@ -3116,23 +3042,21 @@ mod tests {
         "Unknown edge interpolation algorithm"
     )]
     #[case("geography(EPSG:4326,)", "Unknown edge interpolation algorithm")]
-    #[case("geography(unknown_algo)", "Unknown edge interpolation algorithm")]
     #[case("geometry(EPSG:4326", "Unsupported Delta table type")]
     #[case("geographyz", "Unsupported Delta table type")]
+    #[case("geometry", "Unsupported Delta table type")]
+    #[case("geography", "Unsupported Delta table type")]
     #[case("geometry()", "must be in 'AUTHORITY:CODE' format")]
     #[case("geography(, vincenty)", "must be in 'AUTHORITY:CODE' format")]
+    #[case("geography(EPSG:4326)", "expected 'geography(<crs>, <algorithm>)'")]
+    #[case("geography(vincenty)", "expected 'geography(<crs>, <algorithm>)'")]
+    #[case(
+        "geography(EPSG:4326, vincenty, karney)",
+        "Unknown edge interpolation algorithm"
+    )]
     fn test_invalid_geo_format(#[case] invalid_type: &str, #[case] expected_error: &str) {
-        let data = format!(
-            r#"{{
-                "name": "invalid",
-                "type": "{invalid_type}",
-                "nullable": false,
-                "metadata": {{}}
-            }}"#
-        );
-        let result: Result<StructField, _> = serde_json::from_str(&data);
-        assert!(result.is_err());
-        let err = result.unwrap_err();
+        let result: Result<StructField, _> = serde_json::from_str(&geo_field_json(invalid_type));
+        let err = result.expect_err(&format!("expected '{invalid_type}' to be rejected"));
         assert!(
             err.to_string().contains(expected_error),
             "Expected error containing '{expected_error}', got: {err}"
@@ -3140,39 +3064,29 @@ mod tests {
     }
 
     #[rstest]
-    #[case::no_colon("foo")]
-    #[case::empty_after_colon("srid:")]
-    #[case::colon_only(":")]
-    #[case::empty("")]
-    #[case::empty_before_colon(":CRS84")]
-    #[case::leading_whitespace(" EPSG:4326")]
-    #[case::trailing_whitespace("EPSG:4326 ")]
-    #[case::surrounding_whitespace(" EPSG:4326 ")]
-    fn test_geometry_try_new_rejects_invalid_srid(#[case] srid: &str) {
-        let err =
+    fn test_geo_try_new_rejects_invalid_srid(
+        #[values(
+            "foo",
+            "srid:",
+            ":",
+            "",
+            ":CRS84",
+            " EPSG:4326",
+            "EPSG:4326 ",
+            " EPSG:4326 "
+        )]
+        srid: &str,
+    ) {
+        let geometry_err =
             GeometryType::try_new(srid).expect_err(&format!("expected '{srid}' to be rejected"));
-        assert!(
-            err.to_string().contains("SRID"),
-            "expected SRID error for '{srid}', got: {err}"
-        );
-    }
-
-    #[rstest]
-    #[case::no_colon("foo")]
-    #[case::empty_after_colon("srid:")]
-    #[case::colon_only(":")]
-    #[case::empty("")]
-    #[case::empty_before_colon(":CRS84")]
-    #[case::leading_whitespace(" EPSG:4326")]
-    #[case::trailing_whitespace("EPSG:4326 ")]
-    #[case::surrounding_whitespace(" EPSG:4326 ")]
-    fn test_geography_try_new_rejects_invalid_srid(#[case] srid: &str) {
-        let err = GeographyType::try_new(Some(srid), None)
+        let geography_err = GeographyType::try_new(srid, EdgeInterpolationAlgorithm::Spherical)
             .expect_err(&format!("expected '{srid}' to be rejected"));
-        assert!(
-            err.to_string().contains("SRID"),
-            "expected SRID error for '{srid}', got: {err}"
-        );
+        for err in [geometry_err, geography_err] {
+            assert!(
+                err.to_string().contains("SRID"),
+                "expected SRID error for '{srid}', got: {err}"
+            );
+        }
     }
 
     #[rstest]

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -1778,6 +1778,142 @@ fn default_true() -> bool {
     true
 }
 
+/// The default spatial reference identifier for geometry and geography types.
+pub const DEFAULT_GEO_SRID: &str = "OGC:CRS84";
+
+/// The algorithm used to interpolate edges between two vertices of a geography path.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum EdgeInterpolationAlgorithm {
+    /// Great circle paths on a sphere.
+    Spherical,
+    /// Vincenty's inverse formula on an ellipsoid.
+    Vincenty,
+    /// Thomas's formula on an ellipsoid.
+    Thomas,
+    /// Andoyer's method on an ellipsoid.
+    Andoyer,
+    /// Karney's method on an ellipsoid.
+    Karney,
+}
+
+impl Display for EdgeInterpolationAlgorithm {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Spherical => write!(f, "spherical"),
+            Self::Vincenty => write!(f, "vincenty"),
+            Self::Thomas => write!(f, "thomas"),
+            Self::Andoyer => write!(f, "andoyer"),
+            Self::Karney => write!(f, "karney"),
+        }
+    }
+}
+
+impl std::str::FromStr for EdgeInterpolationAlgorithm {
+    type Err = Error;
+    fn from_str(s: &str) -> DeltaResult<Self> {
+        match s.trim() {
+            "spherical" => Ok(Self::Spherical),
+            "vincenty" => Ok(Self::Vincenty),
+            "thomas" => Ok(Self::Thomas),
+            "andoyer" => Ok(Self::Andoyer),
+            "karney" => Ok(Self::Karney),
+            other => Err(Error::generic(format!(
+                "Unknown edge interpolation algorithm: '{other}'"
+            ))),
+        }
+    }
+}
+
+/// A geometry column type with an associated spatial reference identifier (SRID).
+///
+/// Geometry values are encoded as WKB (Well-Known Binary) bytes in the Arrow layer,
+/// represented as a `Binary` physical array with GeoArrow field metadata.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct GeometryType {
+    srid: String,
+}
+
+impl GeometryType {
+    /// Creates a new [`GeometryType`] with the given SRID.
+    ///
+    /// # Parameters
+    /// - `srid`: The spatial reference identifier (e.g. `"OGC:CRS84"`, `"EPSG:4326"`).
+    pub fn try_new(srid: impl Into<String>) -> DeltaResult<Self> {
+        Ok(Self { srid: srid.into() })
+    }
+
+    /// Returns the SRID associated with this geometry type.
+    pub fn srid(&self) -> &str {
+        &self.srid
+    }
+}
+
+impl Default for GeometryType {
+    fn default() -> Self {
+        Self {
+            srid: DEFAULT_GEO_SRID.to_string(),
+        }
+    }
+}
+
+impl Display for GeometryType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "geometry({})", self.srid)
+    }
+}
+
+/// A geography column type with an associated SRID and edge interpolation algorithm.
+///
+/// Geography values are encoded as WKB bytes in the Arrow layer,
+/// represented as a `Binary` physical array with GeoArrow field metadata.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct GeographyType {
+    srid: String,
+    algorithm: EdgeInterpolationAlgorithm,
+}
+
+impl GeographyType {
+    /// Creates a new [`GeographyType`] with the given SRID and edge interpolation algorithm.
+    ///
+    /// # Parameters
+    /// - `srid`: The spatial reference identifier (e.g. `"OGC:CRS84"`).
+    /// - `algorithm`: The edge interpolation algorithm to use.
+    pub fn try_new(
+        srid: impl Into<String>,
+        algorithm: EdgeInterpolationAlgorithm,
+    ) -> DeltaResult<Self> {
+        Ok(Self {
+            srid: srid.into(),
+            algorithm,
+        })
+    }
+
+    /// Returns the SRID associated with this geography type.
+    pub fn srid(&self) -> &str {
+        &self.srid
+    }
+
+    /// Returns the edge interpolation algorithm for this geography type.
+    pub fn algorithm(&self) -> &EdgeInterpolationAlgorithm {
+        &self.algorithm
+    }
+}
+
+impl Default for GeographyType {
+    fn default() -> Self {
+        Self {
+            srid: DEFAULT_GEO_SRID.to_string(),
+            algorithm: EdgeInterpolationAlgorithm::Spherical,
+        }
+    }
+}
+
+impl Display for GeographyType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "geography({}, {})", self.srid, self.algorithm)
+    }
+}
+
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
 pub struct DecimalType {
     precision: u8,
@@ -1850,6 +1986,14 @@ pub enum PrimitiveType {
     IntervalDayTime,
     #[serde(serialize_with = "serialize_decimal", untagged)]
     Decimal(DecimalType),
+    /// A geometry type with an associated spatial reference identifier.
+    /// Values are stored as WKB (Well-Known Binary) bytes.
+    #[serde(serialize_with = "serialize_geometry", untagged)]
+    Geometry(GeometryType),
+    /// A geography type with an associated SRID and edge interpolation algorithm.
+    /// Values are stored as WKB bytes.
+    #[serde(serialize_with = "serialize_geography", untagged)]
+    Geography(GeographyType),
 }
 
 impl PrimitiveType {
@@ -1922,6 +2066,20 @@ fn serialize_decimal<S: serde::Serializer>(
     serializer: S,
 ) -> Result<S::Ok, S::Error> {
     serializer.serialize_str(&format!("decimal({},{})", dtype.precision(), dtype.scale()))
+}
+
+fn serialize_geometry<S: serde::Serializer>(
+    gtype: &GeometryType,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    serializer.serialize_str(&gtype.to_string())
+}
+
+fn serialize_geography<S: serde::Serializer>(
+    gtype: &GeographyType,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    serializer.serialize_str(&gtype.to_string())
 }
 
 fn serialize_variant<S: serde::Serializer>(
@@ -2005,6 +2163,35 @@ impl<'de> serde::Deserialize<'de> for PrimitiveType {
                     .map(PrimitiveType::Decimal)
                     .map_err(serde::de::Error::custom)
             }
+            "geometry" => Ok(PrimitiveType::Geometry(GeometryType::default())),
+            geo_str if geo_str.starts_with("geometry(") && geo_str.ends_with(')') => {
+                let srid = &geo_str[9..geo_str.len() - 1];
+                GeometryType::try_new(srid.trim())
+                    .map(PrimitiveType::Geometry)
+                    .map_err(serde::de::Error::custom)
+            }
+            "geography" => Ok(PrimitiveType::Geography(GeographyType::default())),
+            geo_str if geo_str.starts_with("geography(") && geo_str.ends_with(')') => {
+                let inner = &geo_str[10..geo_str.len() - 1];
+                // Split on the last comma to separate SRID from algorithm
+                match inner.rfind(',') {
+                    Some(pos) => {
+                        let srid = inner[..pos].trim();
+                        let algo_str = inner[pos + 1..].trim();
+                        let algorithm: EdgeInterpolationAlgorithm =
+                            algo_str.parse().map_err(serde::de::Error::custom)?;
+                        GeographyType::try_new(srid, algorithm)
+                            .map(PrimitiveType::Geography)
+                            .map_err(serde::de::Error::custom)
+                    }
+                    None => {
+                        // No comma -- treat entire inner as SRID with default algorithm
+                        GeographyType::try_new(inner.trim(), EdgeInterpolationAlgorithm::Spherical)
+                            .map(PrimitiveType::Geography)
+                            .map_err(serde::de::Error::custom)
+                    }
+                }
+            }
             unsupported => Err(serde::de::Error::custom(format!(
                 "Unsupported Delta table type: '{unsupported}'"
             ))),
@@ -2033,6 +2220,8 @@ impl Display for PrimitiveType {
                 write!(f, "decimal({},{})", dtype.precision(), dtype.scale())
             }
             PrimitiveType::Void => write!(f, "void"),
+            PrimitiveType::Geometry(t) => write!(f, "{t}"),
+            PrimitiveType::Geography(t) => write!(f, "{t}"),
         }
     }
 }
@@ -2064,6 +2253,26 @@ impl From<DecimalType> for PrimitiveType {
 impl From<DecimalType> for DataType {
     fn from(dtype: DecimalType) -> Self {
         PrimitiveType::from(dtype).into()
+    }
+}
+impl From<GeometryType> for PrimitiveType {
+    fn from(gtype: GeometryType) -> Self {
+        PrimitiveType::Geometry(gtype)
+    }
+}
+impl From<GeometryType> for DataType {
+    fn from(gtype: GeometryType) -> Self {
+        PrimitiveType::from(gtype).into()
+    }
+}
+impl From<GeographyType> for PrimitiveType {
+    fn from(gtype: GeographyType) -> Self {
+        PrimitiveType::Geography(gtype)
+    }
+}
+impl From<GeographyType> for DataType {
+    fn from(gtype: GeographyType) -> Self {
+        PrimitiveType::from(gtype).into()
     }
 }
 impl From<PrimitiveType> for DataType {

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -1778,21 +1778,16 @@ fn default_true() -> bool {
     true
 }
 
-/// The default spatial reference identifier for geometry and geography types.
+/// Default spatial reference identifier for geometry and geography types.
 pub const DEFAULT_GEO_SRID: &str = "OGC:CRS84";
 
-/// The algorithm used to interpolate edges between two vertices of a geography path.
+/// Algorithm used to interpolate edges between two vertices of a geography path.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum EdgeInterpolationAlgorithm {
-    /// Great circle paths on a sphere.
     Spherical,
-    /// Vincenty's inverse formula on an ellipsoid.
     Vincenty,
-    /// Thomas's formula on an ellipsoid.
     Thomas,
-    /// Andoyer's method on an ellipsoid.
     Andoyer,
-    /// Karney's method on an ellipsoid.
     Karney,
 }
 
@@ -1824,21 +1819,13 @@ impl std::str::FromStr for EdgeInterpolationAlgorithm {
     }
 }
 
-/// A geometry column type with an associated spatial reference identifier (SRID).
-///
-/// Geometry values are encoded as WKB (Well-Known Binary) bytes in the Arrow layer,
-/// represented as a `Binary` physical array with GeoArrow field metadata.
+/// A geometry column type with an associated spatial reference identifier (SRID)
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct GeometryType {
     srid: String,
 }
 
 impl GeometryType {
-    /// Creates a new GeometryType with the given SRID.
-    ///
-    /// # Parameters
-    /// - `srid`: The spatial reference identifier (e.g. `"OGC:CRS84"`, `"EPSG:4326"`). Must be
-    ///   non-empty.
     pub fn try_new(srid: impl Into<String>) -> DeltaResult<Self> {
         let srid = srid.into();
         if srid.is_empty() {
@@ -1847,7 +1834,6 @@ impl GeometryType {
         Ok(Self { srid })
     }
 
-    /// Returns the SRID associated with this geometry type.
     pub fn srid(&self) -> &str {
         &self.srid
     }
@@ -1867,10 +1853,7 @@ impl Display for GeometryType {
     }
 }
 
-/// A geography column type with an associated SRID and edge interpolation algorithm.
-///
-/// Geography values are encoded as WKB bytes in the Arrow layer,
-/// represented as a `Binary` physical array with GeoArrow field metadata.
+/// Geography column type with an associated SRID and edge interpolation algorithm.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct GeographyType {
     srid: String,
@@ -1878,11 +1861,6 @@ pub struct GeographyType {
 }
 
 impl GeographyType {
-    /// Creates a new GeographyType with the given SRID and edge interpolation algorithm.
-    ///
-    /// # Parameters
-    /// - `srid`: The spatial reference identifier (e.g. `"OGC:CRS84"`). Must be non-empty.
-    /// - `algorithm`: The edge interpolation algorithm to use.
     pub fn try_new(
         srid: impl Into<String>,
         algorithm: EdgeInterpolationAlgorithm,
@@ -1894,24 +1872,18 @@ impl GeographyType {
         Ok(Self { srid, algorithm })
     }
 
-    /// Creates a new GeographyType with the given SRID and the default edge interpolation
-    /// algorithm ([`EdgeInterpolationAlgorithm::Spherical`]).
     pub fn try_new_with_srid(srid: impl Into<String>) -> DeltaResult<Self> {
         Self::try_new(srid, EdgeInterpolationAlgorithm::Spherical)
     }
 
-    /// Creates a new GeographyType with the given edge interpolation algorithm and the
-    /// default SRID (DEFAULT_GEO_SRID).
     pub fn try_new_with_algorithm(algorithm: EdgeInterpolationAlgorithm) -> DeltaResult<Self> {
         Self::try_new(DEFAULT_GEO_SRID, algorithm)
     }
 
-    /// Returns the SRID associated with this geography type.
     pub fn srid(&self) -> &str {
         &self.srid
     }
 
-    /// Returns the edge interpolation algorithm for this geography type.
     pub fn algorithm(&self) -> &EdgeInterpolationAlgorithm {
         &self.algorithm
     }
@@ -2189,9 +2161,9 @@ impl<'de> serde::Deserialize<'de> for PrimitiveType {
             geo_str if geo_str.starts_with("geography(") && geo_str.ends_with(')') => {
                 let inner = &geo_str[10..geo_str.len() - 1];
                 // Three accepted shapes:
-                //   geography(<srid>, <algorithm>) -- both
-                //   geography(<srid>)              -- SRID only (contains ':')
-                //   geography(<algorithm>)         -- algorithm only (no ':')
+                //   geography(<srid>, <algorithm>) - both
+                //   geography(<srid>)              - SRID only (contains ':')
+                //   geography(<algorithm>)         - algorithm only (no ':')
                 match inner.rfind(',') {
                     Some(pos) => {
                         let srid = inner[..pos].trim();

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -1778,28 +1778,28 @@ fn default_true() -> bool {
     true
 }
 
-/// Validates that an SRID is in AUTHORITY:CODE form: contains a colon, has non-empty text
+/// Validates that a CRS is in AUTHORITY:CODE form: contains a colon, has non-empty text
 /// before and after it, and has no leading or trailing whitespace. Validating the value
-/// against the full set of recognized SRIDs is future work.
-fn validate_srid(srid: &str) -> DeltaResult<()> {
+/// against the full set of recognized CRSes is future work.
+fn validate_crs(crs: &str) -> DeltaResult<()> {
     require!(
-        srid == srid.trim(),
+        crs == crs.trim(),
         Error::invalid_geo_params(format!(
-            "SRID '{srid}' must not have leading or trailing whitespace"
+            "CRS '{crs}' must not have leading or trailing whitespace"
         ))
     );
-    let (authority, code) = srid.split_once(':').ok_or_else(|| {
-        Error::invalid_geo_params(format!("SRID '{srid}' must be in 'AUTHORITY:CODE' format"))
+    let (authority, code) = crs.split_once(':').ok_or_else(|| {
+        Error::invalid_geo_params(format!("CRS '{crs}' must be in 'AUTHORITY:CODE' format"))
     })?;
     require!(
         !authority.is_empty(),
         Error::invalid_geo_params(format!(
-            "SRID '{srid}' must have an authority before the colon"
+            "CRS '{crs}' must have an authority before the colon"
         ))
     );
     require!(
         !code.is_empty(),
-        Error::invalid_geo_params(format!("SRID '{srid}' must have a code after the colon"))
+        Error::invalid_geo_params(format!("CRS '{crs}' must have a code after the colon"))
     );
     Ok(())
 }
@@ -1842,53 +1842,53 @@ impl std::str::FromStr for EdgeInterpolationAlgorithm {
     }
 }
 
-/// A geometry column type with an associated spatial reference identifier (SRID)
+/// A geometry column type with an associated coordinate reference system (CRS)
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct GeometryType {
-    srid: String,
+    crs: String,
 }
 
 impl GeometryType {
-    /// Constructs a GeometryType from the given SRID, or returns an error if the SRID is
+    /// Constructs a GeometryType from the given CRS, or returns an error if the CRS is
     /// not in AUTHORITY:CODE form.
-    pub fn try_new(srid: &str) -> DeltaResult<Self> {
-        validate_srid(srid)?;
+    pub fn try_new(crs: &str) -> DeltaResult<Self> {
+        validate_crs(crs)?;
         Ok(Self {
-            srid: srid.to_string(),
+            crs: crs.to_string(),
         })
     }
 
-    pub fn srid(&self) -> &str {
-        &self.srid
+    pub fn crs(&self) -> &str {
+        &self.crs
     }
 }
 
 impl Display for GeometryType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "geometry({})", self.srid)
+        write!(f, "geometry({})", self.crs)
     }
 }
 
-/// Geography column type with an associated SRID and edge interpolation algorithm.
+/// Geography column type with an associated CRS and edge interpolation algorithm.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct GeographyType {
-    srid: String,
+    crs: String,
     algorithm: EdgeInterpolationAlgorithm,
 }
 
 impl GeographyType {
-    /// Constructs a GeographyType from the given SRID and edge interpolation algorithm, or
-    /// returns an error if the SRID is not in AUTHORITY:CODE form.
-    pub fn try_new(srid: &str, algorithm: EdgeInterpolationAlgorithm) -> DeltaResult<Self> {
-        validate_srid(srid)?;
+    /// Constructs a GeographyType from the given CRS and edge interpolation algorithm, or
+    /// returns an error if the CRS is not in AUTHORITY:CODE form.
+    pub fn try_new(crs: &str, algorithm: EdgeInterpolationAlgorithm) -> DeltaResult<Self> {
+        validate_crs(crs)?;
         Ok(Self {
-            srid: srid.to_string(),
+            crs: crs.to_string(),
             algorithm,
         })
     }
 
-    pub fn srid(&self) -> &str {
-        &self.srid
+    pub fn crs(&self) -> &str {
+        &self.crs
     }
 
     pub fn algorithm(&self) -> &EdgeInterpolationAlgorithm {
@@ -1898,7 +1898,7 @@ impl GeographyType {
 
 impl Display for GeographyType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "geography({}, {})", self.srid, self.algorithm)
+        write!(f, "geography({}, {})", self.crs, self.algorithm)
     }
 }
 
@@ -2153,8 +2153,8 @@ impl<'de> serde::Deserialize<'de> for PrimitiveType {
                     .map_err(serde::de::Error::custom)
             }
             geo_str if geo_str.starts_with("geometry(") && geo_str.ends_with(')') => {
-                let srid = &geo_str[9..geo_str.len() - 1];
-                GeometryType::try_new(srid.trim())
+                let crs = &geo_str[9..geo_str.len() - 1];
+                GeometryType::try_new(crs.trim())
                     .map(Box::new)
                     .map(PrimitiveType::Geometry)
                     .map_err(serde::de::Error::custom)
@@ -2166,10 +2166,10 @@ impl<'de> serde::Deserialize<'de> for PrimitiveType {
                 // TODO: reevaluate whether accepting padded input like
                 // geography(  EPSG:4326 ,  vincenty  ) is desired.
                 match inner.split_once(',') {
-                    Some((srid, algo_str)) => {
+                    Some((crs, algo_str)) => {
                         let algorithm: EdgeInterpolationAlgorithm =
                             algo_str.trim().parse().map_err(serde::de::Error::custom)?;
-                        GeographyType::try_new(srid.trim(), algorithm)
+                        GeographyType::try_new(crs.trim(), algorithm)
                             .map(Box::new)
                             .map(PrimitiveType::Geography)
                             .map_err(serde::de::Error::custom)
@@ -2979,8 +2979,8 @@ mod tests {
         );
     }
 
-    fn geography(srid: &str, algorithm: EdgeInterpolationAlgorithm) -> PrimitiveType {
-        PrimitiveType::Geography(Box::new(GeographyType::try_new(srid, algorithm).unwrap()))
+    fn geography(crs: &str, algorithm: EdgeInterpolationAlgorithm) -> PrimitiveType {
+        PrimitiveType::Geography(Box::new(GeographyType::try_new(crs, algorithm).unwrap()))
     }
 
     fn geo_field_json(type_str: &str) -> String {
@@ -3064,10 +3064,10 @@ mod tests {
     }
 
     #[rstest]
-    fn test_geo_try_new_rejects_invalid_srid(
+    fn test_geo_try_new_rejects_invalid_crs(
         #[values(
             "foo",
-            "srid:",
+            "authority:",
             ":",
             "",
             ":CRS84",
@@ -3075,16 +3075,16 @@ mod tests {
             "EPSG:4326 ",
             " EPSG:4326 "
         )]
-        srid: &str,
+        crs: &str,
     ) {
         let geometry_err =
-            GeometryType::try_new(srid).expect_err(&format!("expected '{srid}' to be rejected"));
-        let geography_err = GeographyType::try_new(srid, EdgeInterpolationAlgorithm::Spherical)
-            .expect_err(&format!("expected '{srid}' to be rejected"));
+            GeometryType::try_new(crs).expect_err(&format!("expected '{crs}' to be rejected"));
+        let geography_err = GeographyType::try_new(crs, EdgeInterpolationAlgorithm::Spherical)
+            .expect_err(&format!("expected '{crs}' to be rejected"));
         for err in [geometry_err, geography_err] {
             assert!(
-                err.to_string().contains("SRID"),
-                "expected SRID error for '{srid}', got: {err}"
+                err.to_string().contains("CRS"),
+                "expected CRS error for '{crs}', got: {err}"
             );
         }
     }

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -2889,6 +2889,53 @@ mod tests {
     }
 
     #[test]
+    fn test_roundtrip_void() {
+        let data = r#"
+        {
+            "name": "v",
+            "type": "void",
+            "nullable": true,
+            "metadata": {}
+        }
+        "#;
+        let field: StructField = serde_json::from_str(data).unwrap();
+        assert_eq!(field.data_type, DataType::VOID);
+
+        let json_str = serde_json::to_string(&field).unwrap();
+        assert_eq!(
+            json_str,
+            r#"{"name":"v","type":"void","nullable":true,"metadata":{}}"#
+        );
+    }
+
+    #[test]
+    fn test_roundtrip_void_non_nullable() {
+        let data = r#"
+        {
+            "name": "v",
+            "type": "void",
+            "nullable": false,
+            "metadata": {}
+        }
+        "#;
+        let field: StructField = serde_json::from_str(data).unwrap();
+        assert_eq!(field.data_type, DataType::VOID);
+        assert!(!field.nullable);
+
+        let json_str = serde_json::to_string(&field).unwrap();
+        assert_eq!(
+            json_str,
+            r#"{"name":"v","type":"void","nullable":false,"metadata":{}}"#
+        );
+    }
+
+    #[test]
+    fn test_void_display() {
+        assert_eq!(PrimitiveType::Void.to_string(), "void");
+        assert_eq!(DataType::VOID.to_string(), "void");
+    }
+
+    #[test]
     fn test_unshredded_variant() {
         let unshredded_variant_type = DataType::unshredded_variant();
 

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -2072,6 +2072,11 @@ impl PrimitiveType {
     pub(crate) fn is_stats_type_compatible_with(&self, target: &Self) -> bool {
         self == target || self.can_widen_to(target) || self.is_checkpoint_cast_compatible(target)
     }
+
+    /// Returns `true` if this primitive type can be used as a partition column.
+    pub(crate) fn is_partition_col(&self) -> bool {
+        !matches!(self, Self::Geometry(_) | Self::Geography(_))
+    }
 }
 
 fn serialize_decimal<S: serde::Serializer>(

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -1831,6 +1831,8 @@ impl GeometryType {
     ///
     /// Returns `Err` if `srid` is empty.
     pub fn try_new(srid: &str) -> DeltaResult<Self> {
+        // We only check that the SRID is non-empty; validating the value against the full set
+        // of (1000+) recognized SRIDs is future work.
         if srid.is_empty() {
             return Err(Error::invalid_geometry("SRID cannot be empty"));
         }
@@ -1875,6 +1877,8 @@ impl GeographyType {
         srid: Option<&str>,
         algorithm: Option<EdgeInterpolationAlgorithm>,
     ) -> DeltaResult<Self> {
+        // We only check that the SRID is non-empty; validating the value against the full set
+        // of (1000+) recognized SRIDs is future work.
         let srid = match srid {
             None => DEFAULT_GEO_SRID.to_string(),
             Some(s) => {

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -2005,9 +2005,9 @@ pub enum PrimitiveType {
     #[serde(serialize_with = "serialize_decimal", untagged)]
     Decimal(DecimalType),
     #[serde(serialize_with = "serialize_geometry", untagged)]
-    Geometry(GeometryType),
+    Geometry(Box<GeometryType>),
     #[serde(serialize_with = "serialize_geography", untagged)]
-    Geography(GeographyType),
+    Geography(Box<GeographyType>),
 }
 
 impl PrimitiveType {
@@ -2177,14 +2177,15 @@ impl<'de> serde::Deserialize<'de> for PrimitiveType {
                     .map(PrimitiveType::Decimal)
                     .map_err(serde::de::Error::custom)
             }
-            "geometry" => Ok(PrimitiveType::Geometry(GeometryType::default())),
+            "geometry" => Ok(PrimitiveType::Geometry(Box::default())),
             geo_str if geo_str.starts_with("geometry(") && geo_str.ends_with(')') => {
                 let srid = &geo_str[9..geo_str.len() - 1];
                 GeometryType::try_new(srid.trim())
+                    .map(Box::new)
                     .map(PrimitiveType::Geometry)
                     .map_err(serde::de::Error::custom)
             }
-            "geography" => Ok(PrimitiveType::Geography(GeographyType::default())),
+            "geography" => Ok(PrimitiveType::Geography(Box::default())),
             geo_str if geo_str.starts_with("geography(") && geo_str.ends_with(')') => {
                 let inner = &geo_str[10..geo_str.len() - 1];
                 // Three accepted shapes:
@@ -2198,6 +2199,7 @@ impl<'de> serde::Deserialize<'de> for PrimitiveType {
                         let algorithm: EdgeInterpolationAlgorithm =
                             algo_str.parse().map_err(serde::de::Error::custom)?;
                         GeographyType::try_new(srid, algorithm)
+                            .map(Box::new)
                             .map(PrimitiveType::Geography)
                             .map_err(serde::de::Error::custom)
                     }
@@ -2205,12 +2207,14 @@ impl<'de> serde::Deserialize<'de> for PrimitiveType {
                         let trimmed = inner.trim();
                         if trimmed.contains(':') {
                             GeographyType::try_new_with_srid(trimmed)
+                                .map(Box::new)
                                 .map(PrimitiveType::Geography)
                                 .map_err(serde::de::Error::custom)
                         } else {
                             let algorithm: EdgeInterpolationAlgorithm =
                                 trimmed.parse().map_err(serde::de::Error::custom)?;
                             GeographyType::try_new_with_algorithm(algorithm)
+                                .map(Box::new)
                                 .map(PrimitiveType::Geography)
                                 .map_err(serde::de::Error::custom)
                         }
@@ -2282,7 +2286,7 @@ impl From<DecimalType> for DataType {
 }
 impl From<GeometryType> for PrimitiveType {
     fn from(gtype: GeometryType) -> Self {
-        PrimitiveType::Geometry(gtype)
+        PrimitiveType::Geometry(Box::new(gtype))
     }
 }
 impl From<GeometryType> for DataType {
@@ -2292,7 +2296,7 @@ impl From<GeometryType> for DataType {
 }
 impl From<GeographyType> for PrimitiveType {
     fn from(gtype: GeographyType) -> Self {
-        PrimitiveType::Geography(gtype)
+        PrimitiveType::Geography(Box::new(gtype))
     }
 }
 impl From<GeographyType> for DataType {
@@ -2844,9 +2848,9 @@ mod tests {
         let field: StructField = serde_json::from_str(data).unwrap();
         assert_eq!(
             field.data_type,
-            DataType::Primitive(PrimitiveType::Geometry(
+            DataType::Primitive(PrimitiveType::Geometry(Box::new(
                 GeometryType::try_new("EPSG:4326").unwrap()
-            ))
+            )))
         );
 
         let json_str = serde_json::to_string(&field).unwrap();
@@ -2869,9 +2873,9 @@ mod tests {
         let field: StructField = serde_json::from_str(data).unwrap();
         assert_eq!(
             field.data_type,
-            DataType::Primitive(PrimitiveType::Geography(
+            DataType::Primitive(PrimitiveType::Geography(Box::new(
                 GeographyType::try_new("EPSG:4326", EdgeInterpolationAlgorithm::Vincenty).unwrap()
-            ))
+            )))
         );
 
         let json_str = serde_json::to_string(&field).unwrap();
@@ -3020,27 +3024,27 @@ mod tests {
     }
 
     #[rstest]
-    #[case("geometry", PrimitiveType::Geometry(GeometryType::default()))]
-    #[case("geography", PrimitiveType::Geography(GeographyType::default()))]
+    #[case("geometry", PrimitiveType::Geometry(Box::default()))]
+    #[case("geography", PrimitiveType::Geography(Box::default()))]
     #[case(
         "geometry(EPSG:4326)",
-        PrimitiveType::Geometry(GeometryType::try_new("EPSG:4326").unwrap())
+        PrimitiveType::Geometry(Box::new(GeometryType::try_new("EPSG:4326").unwrap()))
     )]
     #[case(
         "geography(EPSG:4326)",
-        PrimitiveType::Geography(GeographyType::try_new_with_srid("EPSG:4326").unwrap())
+        PrimitiveType::Geography(Box::new(GeographyType::try_new_with_srid("EPSG:4326").unwrap()))
     )]
     #[case(
         "geography(EPSG:4326, vincenty)",
-        PrimitiveType::Geography(
+        PrimitiveType::Geography(Box::new(
             GeographyType::try_new("EPSG:4326", EdgeInterpolationAlgorithm::Vincenty).unwrap()
-        )
+        ))
     )]
     #[case(
         "geography(vincenty)",
-        PrimitiveType::Geography(
+        PrimitiveType::Geography(Box::new(
             GeographyType::try_new_with_algorithm(EdgeInterpolationAlgorithm::Vincenty).unwrap()
-        )
+        ))
     )]
     fn test_geo_deserialize_defaults(#[case] type_str: &str, #[case] expected: PrimitiveType) {
         let json = format!(r#"{{"name":"g","type":"{type_str}","nullable":true,"metadata":{{}}}}"#);

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -1826,12 +1826,17 @@ pub struct GeometryType {
 }
 
 impl GeometryType {
-    pub fn try_new(srid: impl Into<String>) -> DeltaResult<Self> {
-        let srid = srid.into();
+    /// Constructs a [`GeometryType`] from the given SRID. Use [`GeometryType::default`] to
+    /// build with [`DEFAULT_GEO_SRID`] (`OGC:CRS84`).
+    ///
+    /// Returns `Err` if `srid` is empty.
+    pub fn try_new(srid: &str) -> DeltaResult<Self> {
         if srid.is_empty() {
             return Err(Error::invalid_geometry("SRID cannot be empty"));
         }
-        Ok(Self { srid })
+        Ok(Self {
+            srid: srid.to_string(),
+        })
     }
 
     pub fn srid(&self) -> &str {
@@ -1861,23 +1866,26 @@ pub struct GeographyType {
 }
 
 impl GeographyType {
+    /// Constructs a GeographyType. Pass `None` for either argument to use the default:
+    /// SRID defaults to DEFAULT_GEO_SRID (`OGC:CRS84`); algorithm defaults to
+    /// EdgeInterpolationAlgorithm::Spherical.
+    ///
+    /// Returns `Err` if `srid` is `Some("")` (empty string is not a valid SRID).
     pub fn try_new(
-        srid: impl Into<String>,
-        algorithm: EdgeInterpolationAlgorithm,
+        srid: Option<&str>,
+        algorithm: Option<EdgeInterpolationAlgorithm>,
     ) -> DeltaResult<Self> {
-        let srid = srid.into();
-        if srid.is_empty() {
-            return Err(Error::invalid_geography("SRID cannot be empty"));
-        }
+        let srid = match srid {
+            None => DEFAULT_GEO_SRID.to_string(),
+            Some(s) => {
+                if s.is_empty() {
+                    return Err(Error::invalid_geography("SRID cannot be empty"));
+                }
+                s.to_string()
+            }
+        };
+        let algorithm = algorithm.unwrap_or(EdgeInterpolationAlgorithm::Spherical);
         Ok(Self { srid, algorithm })
-    }
-
-    pub fn try_new_with_srid(srid: impl Into<String>) -> DeltaResult<Self> {
-        Self::try_new(srid, EdgeInterpolationAlgorithm::Spherical)
-    }
-
-    pub fn try_new_with_algorithm(algorithm: EdgeInterpolationAlgorithm) -> DeltaResult<Self> {
-        Self::try_new(DEFAULT_GEO_SRID, algorithm)
     }
 
     pub fn srid(&self) -> &str {
@@ -2170,7 +2178,7 @@ impl<'de> serde::Deserialize<'de> for PrimitiveType {
                         let algo_str = inner[pos + 1..].trim();
                         let algorithm: EdgeInterpolationAlgorithm =
                             algo_str.parse().map_err(serde::de::Error::custom)?;
-                        GeographyType::try_new(srid, algorithm)
+                        GeographyType::try_new(Some(srid), Some(algorithm))
                             .map(Box::new)
                             .map(PrimitiveType::Geography)
                             .map_err(serde::de::Error::custom)
@@ -2178,14 +2186,14 @@ impl<'de> serde::Deserialize<'de> for PrimitiveType {
                     None => {
                         let trimmed = inner.trim();
                         if trimmed.contains(':') {
-                            GeographyType::try_new_with_srid(trimmed)
+                            GeographyType::try_new(Some(trimmed), None)
                                 .map(Box::new)
                                 .map(PrimitiveType::Geography)
                                 .map_err(serde::de::Error::custom)
                         } else {
                             let algorithm: EdgeInterpolationAlgorithm =
                                 trimmed.parse().map_err(serde::de::Error::custom)?;
-                            GeographyType::try_new_with_algorithm(algorithm)
+                            GeographyType::try_new(None, Some(algorithm))
                                 .map(Box::new)
                                 .map(PrimitiveType::Geography)
                                 .map_err(serde::de::Error::custom)
@@ -2846,7 +2854,11 @@ mod tests {
         assert_eq!(
             field.data_type,
             DataType::Primitive(PrimitiveType::Geography(Box::new(
-                GeographyType::try_new("EPSG:4326", EdgeInterpolationAlgorithm::Vincenty).unwrap()
+                GeographyType::try_new(
+                    Some("EPSG:4326"),
+                    Some(EdgeInterpolationAlgorithm::Vincenty)
+                )
+                .unwrap()
             )))
         );
 
@@ -3004,18 +3016,21 @@ mod tests {
     )]
     #[case(
         "geography(EPSG:4326)",
-        PrimitiveType::Geography(Box::new(GeographyType::try_new_with_srid("EPSG:4326").unwrap()))
+        PrimitiveType::Geography(Box::new(
+            GeographyType::try_new(Some("EPSG:4326"), None).unwrap()
+        ))
     )]
     #[case(
         "geography(EPSG:4326, vincenty)",
         PrimitiveType::Geography(Box::new(
-            GeographyType::try_new("EPSG:4326", EdgeInterpolationAlgorithm::Vincenty).unwrap()
+            GeographyType::try_new(Some("EPSG:4326"), Some(EdgeInterpolationAlgorithm::Vincenty))
+                .unwrap()
         ))
     )]
     #[case(
         "geography(vincenty)",
         PrimitiveType::Geography(Box::new(
-            GeographyType::try_new_with_algorithm(EdgeInterpolationAlgorithm::Vincenty).unwrap()
+            GeographyType::try_new(None, Some(EdgeInterpolationAlgorithm::Vincenty)).unwrap()
         ))
     )]
     fn test_geo_deserialize_defaults(#[case] type_str: &str, #[case] expected: PrimitiveType) {
@@ -3030,6 +3045,7 @@ mod tests {
         "Unknown edge interpolation algorithm"
     )]
     #[case("geography(EPSG:4326,)", "Unknown edge interpolation algorithm")]
+    #[case("geography(unknown_algo)", "Unknown edge interpolation algorithm")]
     #[case("geometry(EPSG:4326", "Unsupported Delta table type")]
     #[case("geographyz", "Unsupported Delta table type")]
     #[case("geometry()", "SRID cannot be empty")]

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -1837,8 +1837,8 @@ impl GeometryType {
     /// Creates a new GeometryType with the given SRID.
     ///
     /// # Parameters
-    /// - `srid`: The spatial reference identifier (e.g. `"OGC:CRS84"`, `"EPSG:4326"`).
-    ///   Must be non-empty.
+    /// - `srid`: The spatial reference identifier (e.g. `"OGC:CRS84"`, `"EPSG:4326"`). Must be
+    ///   non-empty.
     pub fn try_new(srid: impl Into<String>) -> DeltaResult<Self> {
         let srid = srid.into();
         if srid.is_empty() {

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -1834,12 +1834,17 @@ pub struct GeometryType {
 }
 
 impl GeometryType {
-    /// Creates a new [`GeometryType`] with the given SRID.
+    /// Creates a new GeometryType with the given SRID.
     ///
     /// # Parameters
     /// - `srid`: The spatial reference identifier (e.g. `"OGC:CRS84"`, `"EPSG:4326"`).
+    ///   Must be non-empty.
     pub fn try_new(srid: impl Into<String>) -> DeltaResult<Self> {
-        Ok(Self { srid: srid.into() })
+        let srid = srid.into();
+        if srid.is_empty() {
+            return Err(Error::invalid_geometry("SRID cannot be empty"));
+        }
+        Ok(Self { srid })
     }
 
     /// Returns the SRID associated with this geometry type.
@@ -1873,19 +1878,32 @@ pub struct GeographyType {
 }
 
 impl GeographyType {
-    /// Creates a new [`GeographyType`] with the given SRID and edge interpolation algorithm.
+    /// Creates a new GeographyType with the given SRID and edge interpolation algorithm.
     ///
     /// # Parameters
-    /// - `srid`: The spatial reference identifier (e.g. `"OGC:CRS84"`).
+    /// - `srid`: The spatial reference identifier (e.g. `"OGC:CRS84"`). Must be non-empty.
     /// - `algorithm`: The edge interpolation algorithm to use.
     pub fn try_new(
         srid: impl Into<String>,
         algorithm: EdgeInterpolationAlgorithm,
     ) -> DeltaResult<Self> {
-        Ok(Self {
-            srid: srid.into(),
-            algorithm,
-        })
+        let srid = srid.into();
+        if srid.is_empty() {
+            return Err(Error::invalid_geography("SRID cannot be empty"));
+        }
+        Ok(Self { srid, algorithm })
+    }
+
+    /// Creates a new GeographyType with the given SRID and the default edge interpolation
+    /// algorithm ([`EdgeInterpolationAlgorithm::Spherical`]).
+    pub fn try_new_with_srid(srid: impl Into<String>) -> DeltaResult<Self> {
+        Self::try_new(srid, EdgeInterpolationAlgorithm::Spherical)
+    }
+
+    /// Creates a new GeographyType with the given edge interpolation algorithm and the
+    /// default SRID (DEFAULT_GEO_SRID).
+    pub fn try_new_with_algorithm(algorithm: EdgeInterpolationAlgorithm) -> DeltaResult<Self> {
+        Self::try_new(DEFAULT_GEO_SRID, algorithm)
     }
 
     /// Returns the SRID associated with this geography type.
@@ -1986,12 +2004,8 @@ pub enum PrimitiveType {
     IntervalDayTime,
     #[serde(serialize_with = "serialize_decimal", untagged)]
     Decimal(DecimalType),
-    /// A geometry type with an associated spatial reference identifier.
-    /// Values are stored as WKB (Well-Known Binary) bytes.
     #[serde(serialize_with = "serialize_geometry", untagged)]
     Geometry(GeometryType),
-    /// A geography type with an associated SRID and edge interpolation algorithm.
-    /// Values are stored as WKB bytes.
     #[serde(serialize_with = "serialize_geography", untagged)]
     Geography(GeographyType),
 }
@@ -2173,7 +2187,10 @@ impl<'de> serde::Deserialize<'de> for PrimitiveType {
             "geography" => Ok(PrimitiveType::Geography(GeographyType::default())),
             geo_str if geo_str.starts_with("geography(") && geo_str.ends_with(')') => {
                 let inner = &geo_str[10..geo_str.len() - 1];
-                // Split on the last comma to separate SRID from algorithm
+                // Three accepted shapes:
+                //   geography(<srid>, <algorithm>) -- both
+                //   geography(<srid>)              -- SRID only (contains ':')
+                //   geography(<algorithm>)         -- algorithm only (no ':')
                 match inner.rfind(',') {
                     Some(pos) => {
                         let srid = inner[..pos].trim();
@@ -2185,10 +2202,18 @@ impl<'de> serde::Deserialize<'de> for PrimitiveType {
                             .map_err(serde::de::Error::custom)
                     }
                     None => {
-                        // No comma -- treat entire inner as SRID with default algorithm
-                        GeographyType::try_new(inner.trim(), EdgeInterpolationAlgorithm::Spherical)
-                            .map(PrimitiveType::Geography)
-                            .map_err(serde::de::Error::custom)
+                        let trimmed = inner.trim();
+                        if trimmed.contains(':') {
+                            GeographyType::try_new_with_srid(trimmed)
+                                .map(PrimitiveType::Geography)
+                                .map_err(serde::de::Error::custom)
+                        } else {
+                            let algorithm: EdgeInterpolationAlgorithm =
+                                trimmed.parse().map_err(serde::de::Error::custom)?;
+                            GeographyType::try_new_with_algorithm(algorithm)
+                                .map(PrimitiveType::Geography)
+                                .map_err(serde::de::Error::custom)
+                        }
                     }
                 }
             }
@@ -2807,50 +2832,53 @@ mod tests {
     }
 
     #[test]
-    fn test_roundtrip_void() {
+    fn test_roundtrip_geometry() {
         let data = r#"
         {
-            "name": "v",
-            "type": "void",
+            "name": "g",
+            "type": "geometry(EPSG:4326)",
             "nullable": true,
             "metadata": {}
         }
         "#;
         let field: StructField = serde_json::from_str(data).unwrap();
-        assert_eq!(field.data_type, DataType::VOID);
+        assert_eq!(
+            field.data_type,
+            DataType::Primitive(PrimitiveType::Geometry(
+                GeometryType::try_new("EPSG:4326").unwrap()
+            ))
+        );
 
         let json_str = serde_json::to_string(&field).unwrap();
         assert_eq!(
             json_str,
-            r#"{"name":"v","type":"void","nullable":true,"metadata":{}}"#
+            r#"{"name":"g","type":"geometry(EPSG:4326)","nullable":true,"metadata":{}}"#
         );
     }
 
     #[test]
-    fn test_roundtrip_void_non_nullable() {
+    fn test_roundtrip_geography() {
         let data = r#"
         {
-            "name": "v",
-            "type": "void",
-            "nullable": false,
+            "name": "g",
+            "type": "geography(EPSG:4326, vincenty)",
+            "nullable": true,
             "metadata": {}
         }
         "#;
         let field: StructField = serde_json::from_str(data).unwrap();
-        assert_eq!(field.data_type, DataType::VOID);
-        assert!(!field.nullable);
+        assert_eq!(
+            field.data_type,
+            DataType::Primitive(PrimitiveType::Geography(
+                GeographyType::try_new("EPSG:4326", EdgeInterpolationAlgorithm::Vincenty).unwrap()
+            ))
+        );
 
         let json_str = serde_json::to_string(&field).unwrap();
         assert_eq!(
             json_str,
-            r#"{"name":"v","type":"void","nullable":false,"metadata":{}}"#
+            r#"{"name":"g","type":"geography(EPSG:4326, vincenty)","nullable":true,"metadata":{}}"#
         );
-    }
-
-    #[test]
-    fn test_void_display() {
-        assert_eq!(PrimitiveType::Void.to_string(), "void");
-        assert_eq!(DataType::VOID.to_string(), "void");
     }
 
     #[test]
@@ -2974,6 +3002,63 @@ mod tests {
     #[case("decimal()", "Invalid precision in decimal")]
     #[case("decimal(10,2,99)", "Invalid decimal format (expected 2 parts)")]
     fn test_invalid_decimal_format(#[case] invalid_type: &str, #[case] expected_error: &str) {
+        let data = format!(
+            r#"{{
+                "name": "invalid",
+                "type": "{invalid_type}",
+                "nullable": false,
+                "metadata": {{}}
+            }}"#
+        );
+        let result: Result<StructField, _> = serde_json::from_str(&data);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains(expected_error),
+            "Expected error containing '{expected_error}', got: {err}"
+        );
+    }
+
+    #[rstest]
+    #[case("geometry", PrimitiveType::Geometry(GeometryType::default()))]
+    #[case("geography", PrimitiveType::Geography(GeographyType::default()))]
+    #[case(
+        "geometry(EPSG:4326)",
+        PrimitiveType::Geometry(GeometryType::try_new("EPSG:4326").unwrap())
+    )]
+    #[case(
+        "geography(EPSG:4326)",
+        PrimitiveType::Geography(GeographyType::try_new_with_srid("EPSG:4326").unwrap())
+    )]
+    #[case(
+        "geography(EPSG:4326, vincenty)",
+        PrimitiveType::Geography(
+            GeographyType::try_new("EPSG:4326", EdgeInterpolationAlgorithm::Vincenty).unwrap()
+        )
+    )]
+    #[case(
+        "geography(vincenty)",
+        PrimitiveType::Geography(
+            GeographyType::try_new_with_algorithm(EdgeInterpolationAlgorithm::Vincenty).unwrap()
+        )
+    )]
+    fn test_geo_deserialize_defaults(#[case] type_str: &str, #[case] expected: PrimitiveType) {
+        let json = format!(r#"{{"name":"g","type":"{type_str}","nullable":true,"metadata":{{}}}}"#);
+        let field: StructField = serde_json::from_str(&json).unwrap();
+        assert_eq!(field.data_type, DataType::Primitive(expected));
+    }
+
+    #[rstest]
+    #[case(
+        "geography(EPSG:4326, unknown_algo)",
+        "Unknown edge interpolation algorithm"
+    )]
+    #[case("geography(EPSG:4326,)", "Unknown edge interpolation algorithm")]
+    #[case("geometry(EPSG:4326", "Unsupported Delta table type")]
+    #[case("geographyz", "Unsupported Delta table type")]
+    #[case("geometry()", "SRID cannot be empty")]
+    #[case("geography(, vincenty)", "SRID cannot be empty")]
+    fn test_invalid_geo_format(#[case] invalid_type: &str, #[case] expected_error: &str) {
         let data = format!(
             r#"{{
                 "name": "invalid",

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -1781,6 +1781,32 @@ fn default_true() -> bool {
 /// Default spatial reference identifier for geometry and geography types.
 pub const DEFAULT_GEO_SRID: &str = "OGC:CRS84";
 
+/// Validates that an SRID is in AUTHORITY:CODE form: contains a colon, has non-empty text
+/// before and after it, and has no leading or trailing whitespace. Validating the value
+/// against the full set of recognized SRIDs is future work.
+fn validate_srid(srid: &str) -> DeltaResult<()> {
+    require!(
+        srid == srid.trim(),
+        Error::invalid_geo_params(format!(
+            "SRID '{srid}' must not have leading or trailing whitespace"
+        ))
+    );
+    let (authority, code) = srid.split_once(':').ok_or_else(|| {
+        Error::invalid_geo_params(format!("SRID '{srid}' must be in 'AUTHORITY:CODE' format"))
+    })?;
+    require!(
+        !authority.is_empty(),
+        Error::invalid_geo_params(format!(
+            "SRID '{srid}' must have an authority before the colon"
+        ))
+    );
+    require!(
+        !code.is_empty(),
+        Error::invalid_geo_params(format!("SRID '{srid}' must have a code after the colon"))
+    );
+    Ok(())
+}
+
 /// Algorithm used to interpolate edges between two vertices of a geography path.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum EdgeInterpolationAlgorithm {
@@ -1826,16 +1852,11 @@ pub struct GeometryType {
 }
 
 impl GeometryType {
-    /// Constructs a [`GeometryType`] from the given SRID. Use [`GeometryType::default`] to
-    /// build with [`DEFAULT_GEO_SRID`] (`OGC:CRS84`).
-    ///
-    /// Returns `Err` if `srid` is empty.
+    /// Constructs a GeometryType from the given SRID, or returns an error if the SRID is
+    /// not in AUTHORITY:CODE form. Use GeometryType::default to build with the default
+    /// SRID (OGC:CRS84).
     pub fn try_new(srid: &str) -> DeltaResult<Self> {
-        // We only check that the SRID is non-empty; validating the value against the full set
-        // of (1000+) recognized SRIDs is future work.
-        if srid.is_empty() {
-            return Err(Error::invalid_geometry("SRID cannot be empty"));
-        }
+        validate_srid(srid)?;
         Ok(Self {
             srid: srid.to_string(),
         })
@@ -1868,23 +1889,17 @@ pub struct GeographyType {
 }
 
 impl GeographyType {
-    /// Constructs a GeographyType. Pass `None` for either argument to use the default:
-    /// SRID defaults to DEFAULT_GEO_SRID (`OGC:CRS84`); algorithm defaults to
-    /// EdgeInterpolationAlgorithm::Spherical.
-    ///
-    /// Returns `Err` if `srid` is `Some("")` (empty string is not a valid SRID).
+    /// Constructs a GeographyType. Pass None for either argument to use the default: SRID
+    /// defaults to OGC:CRS84; algorithm defaults to Spherical. Returns an error if srid is
+    /// Some(...) but not in AUTHORITY:CODE form.
     pub fn try_new(
         srid: Option<&str>,
         algorithm: Option<EdgeInterpolationAlgorithm>,
     ) -> DeltaResult<Self> {
-        // We only check that the SRID is non-empty; validating the value against the full set
-        // of (1000+) recognized SRIDs is future work.
         let srid = match srid {
             None => DEFAULT_GEO_SRID.to_string(),
             Some(s) => {
-                if s.is_empty() {
-                    return Err(Error::invalid_geography("SRID cannot be empty"));
-                }
+                validate_srid(s)?;
                 s.to_string()
             }
         };
@@ -3052,8 +3067,8 @@ mod tests {
     #[case("geography(unknown_algo)", "Unknown edge interpolation algorithm")]
     #[case("geometry(EPSG:4326", "Unsupported Delta table type")]
     #[case("geographyz", "Unsupported Delta table type")]
-    #[case("geometry()", "SRID cannot be empty")]
-    #[case("geography(, vincenty)", "SRID cannot be empty")]
+    #[case("geometry()", "must be in 'AUTHORITY:CODE' format")]
+    #[case("geography(, vincenty)", "must be in 'AUTHORITY:CODE' format")]
     fn test_invalid_geo_format(#[case] invalid_type: &str, #[case] expected_error: &str) {
         let data = format!(
             r#"{{
@@ -3069,6 +3084,42 @@ mod tests {
         assert!(
             err.to_string().contains(expected_error),
             "Expected error containing '{expected_error}', got: {err}"
+        );
+    }
+
+    #[rstest]
+    #[case::no_colon("foo")]
+    #[case::empty_after_colon("srid:")]
+    #[case::colon_only(":")]
+    #[case::empty("")]
+    #[case::empty_before_colon(":CRS84")]
+    #[case::leading_whitespace(" EPSG:4326")]
+    #[case::trailing_whitespace("EPSG:4326 ")]
+    #[case::surrounding_whitespace(" EPSG:4326 ")]
+    fn test_geometry_try_new_rejects_invalid_srid(#[case] srid: &str) {
+        let err =
+            GeometryType::try_new(srid).expect_err(&format!("expected '{srid}' to be rejected"));
+        assert!(
+            err.to_string().contains("SRID"),
+            "expected SRID error for '{srid}', got: {err}"
+        );
+    }
+
+    #[rstest]
+    #[case::no_colon("foo")]
+    #[case::empty_after_colon("srid:")]
+    #[case::colon_only(":")]
+    #[case::empty("")]
+    #[case::empty_before_colon(":CRS84")]
+    #[case::leading_whitespace(" EPSG:4326")]
+    #[case::trailing_whitespace("EPSG:4326 ")]
+    #[case::surrounding_whitespace(" EPSG:4326 ")]
+    fn test_geography_try_new_rejects_invalid_srid(#[case] srid: &str) {
+        let err = GeographyType::try_new(Some(srid), None)
+            .expect_err(&format!("expected '{srid}' to be rejected"));
+        assert!(
+            err.to_string().contains("SRID"),
+            "expected SRID error for '{srid}', got: {err}"
         );
     }
 

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -1692,7 +1692,7 @@ mod test {
             r#"Feature 'typeWidening' is not supported for writes"#,
         );
 
-        // Geospatial is not supported for writes
+        // Geospatial is not supported for writes yet.
         let config = create_mock_table_config(&[], &[TableFeature::GeospatialType]);
         assert_result_error_with_message(
             config.ensure_operation_supported(Operation::Write),

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -25,12 +25,13 @@ pub(crate) use crate::schema::variant_utils::validate_variant_type_feature_suppo
 use crate::schema::void_utils::strip_void_from_schema;
 use crate::schema::{schema_has_invariants, SchemaRef, StructField, StructType};
 use crate::table_features::{
-    check_reader_version_range, column_mapping_mode, extract_enabled_reader_features,
-    get_any_level_column_physical_name, validate_iceberg_compat_if_needed,
-    validate_timestamp_ntz_feature_support, ColumnMappingMode, EnablementCheck, FeatureRequirement,
-    FeatureType, KernelSupport, Operation, TableFeature, LEGACY_WRITER_FEATURES,
-    MAX_VALID_WRITER_VERSION, MIN_VALID_RW_VERSION, TABLE_FEATURES_MIN_READER_VERSION,
-    TABLE_FEATURES_MIN_WRITER_VERSION, V3_VALIDATOR,
+    check_reader_version_range, column_mapping_mode, column_mapping_mode,
+    extract_enabled_reader_features, get_any_level_column_physical_name,
+    get_any_level_column_physical_name, validate_geospatial_feature_support,
+    validate_iceberg_compat_if_needed, validate_timestamp_ntz_feature_support, ColumnMappingMode,
+    EnablementCheck, FeatureRequirement, FeatureType, KernelSupport, Operation, TableFeature,
+    LEGACY_WRITER_FEATURES, MAX_VALID_WRITER_VERSION, MIN_VALID_RW_VERSION,
+    TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION, V3_VALIDATOR,
 };
 use crate::table_properties::TableProperties;
 use crate::transforms::SchemaTransform as _;
@@ -216,6 +217,7 @@ impl TableConfiguration {
 
         // Validate schema against protocol features now that we have a TC instance.
         validate_timestamp_ntz_feature_support(&table_config)?;
+        validate_geospatial_feature_support(&table_config)?;
         validate_variant_type_feature_support(&table_config)?;
         validate_iceberg_compat_if_needed(&table_config, &V3_VALIDATOR)?;
 

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -1669,6 +1669,12 @@ mod test {
             7,
         );
         assert!(config.ensure_operation_supported(Operation::Scan).is_ok());
+
+        {
+            let config = create_mock_table_config(&[], &[TableFeature::GeospatialType]);
+            assert!(config.ensure_operation_supported(Operation::Scan).is_ok());
+            assert!(config.ensure_operation_supported(Operation::Cdf).is_ok());
+        }
     }
 
     #[test]

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -25,8 +25,7 @@ pub(crate) use crate::schema::variant_utils::validate_variant_type_feature_suppo
 use crate::schema::void_utils::strip_void_from_schema;
 use crate::schema::{schema_has_invariants, SchemaRef, StructField, StructType};
 use crate::table_features::{
-    check_reader_version_range, column_mapping_mode, column_mapping_mode,
-    extract_enabled_reader_features, get_any_level_column_physical_name,
+    check_reader_version_range, column_mapping_mode, extract_enabled_reader_features,
     get_any_level_column_physical_name, validate_geospatial_feature_support,
     validate_iceberg_compat_if_needed, validate_timestamp_ntz_feature_support, ColumnMappingMode,
     EnablementCheck, FeatureRequirement, FeatureType, KernelSupport, Operation, TableFeature,

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -1692,6 +1692,13 @@ mod test {
             config.ensure_operation_supported(Operation::Write),
             r#"Feature 'typeWidening' is not supported for writes"#,
         );
+
+        // Geospatial is not supported for writes
+        let config = create_mock_table_config(&[], &[TableFeature::GeospatialType]);
+        assert_result_error_with_message(
+            config.ensure_operation_supported(Operation::Write),
+            r#"Feature 'geospatial' is not supported for writes"#,
+        );
     }
 
     #[test]

--- a/kernel/src/table_features/geospatial.rs
+++ b/kernel/src/table_features/geospatial.rs
@@ -49,9 +49,7 @@ pub(crate) fn validate_geospatial_feature_support(tc: &TableConfiguration) -> De
 #[cfg(test)]
 mod tests {
     use crate::actions::Protocol;
-    use crate::schema::{
-        DataType, GeographyType, GeometryType, PrimitiveType, StructField, StructType,
-    };
+    use crate::schema::{DataType, PrimitiveType, StructField, StructType};
     use crate::table_features::TableFeature;
     use crate::utils::test_utils::{
         assert_result_error_with_message, assert_schema_feature_validation,
@@ -63,7 +61,7 @@ mod tests {
             StructField::new("id", DataType::INTEGER, false),
             StructField::new(
                 "geom",
-                DataType::Primitive(PrimitiveType::Geometry(GeometryType::default())),
+                DataType::Primitive(PrimitiveType::Geometry(Box::default())),
                 true,
             ),
         ]);
@@ -77,7 +75,7 @@ mod tests {
                 "nested",
                 DataType::Struct(Box::new(StructType::new_unchecked([StructField::new(
                     "inner_geo",
-                    DataType::Primitive(PrimitiveType::Geography(GeographyType::default())),
+                    DataType::Primitive(PrimitiveType::Geography(Box::default())),
                     true,
                 )]))),
                 true,

--- a/kernel/src/table_features/geospatial.rs
+++ b/kernel/src/table_features/geospatial.rs
@@ -1,0 +1,101 @@
+//! Validation logic for the `geospatial` table feature.
+
+use std::borrow::Cow;
+
+use super::TableFeature;
+use crate::schema::{PrimitiveType, Schema};
+use crate::table_configuration::TableConfiguration;
+use crate::transforms::SchemaTransform;
+use crate::utils::require;
+use crate::{DeltaResult, Error};
+
+/// Validates that if a table schema contains geometry or geography columns, the table must have
+/// the `geospatial` feature in both reader and writer features.
+pub(crate) fn validate_geospatial_feature_support(tc: &TableConfiguration) -> DeltaResult<()> {
+    let protocol = tc.protocol();
+    if !protocol.has_table_feature(&TableFeature::GeospatialType) {
+        require!(
+            !schema_contains_geospatial(&tc.logical_schema()),
+            Error::unsupported(
+                "Table contains geometry or geography columns but does not have the required 'geospatial' feature in reader and writer features"
+            )
+        );
+    }
+    Ok(())
+}
+
+/// Returns `true` if the schema contains at least one geometry or geography column,
+/// including nested structs, arrays, and maps.
+pub(crate) fn schema_contains_geospatial(schema: &Schema) -> bool {
+    let mut detector = GeoDetector(false);
+    let _ = detector.transform_struct(schema);
+    detector.0
+}
+
+struct GeoDetector(bool);
+
+impl<'a> SchemaTransform<'a> for GeoDetector {
+    fn transform_primitive(&mut self, ptype: &'a PrimitiveType) -> Option<Cow<'a, PrimitiveType>> {
+        if matches!(
+            ptype,
+            PrimitiveType::Geometry(_) | PrimitiveType::Geography(_)
+        ) {
+            self.0 = true;
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::actions::Protocol;
+    use crate::schema::{
+        DataType, GeographyType, GeometryType, PrimitiveType, StructField, StructType,
+    };
+    use crate::table_features::TableFeature;
+    use crate::utils::test_utils::assert_schema_feature_validation;
+
+    #[test]
+    fn test_geospatial_feature_validation() {
+        let schema_with = StructType::new_unchecked([
+            StructField::new("id", DataType::INTEGER, false),
+            StructField::new(
+                "geom",
+                DataType::Primitive(PrimitiveType::Geometry(GeometryType::default())),
+                true,
+            ),
+        ]);
+        let schema_without = StructType::new_unchecked([
+            StructField::new("id", DataType::INTEGER, false),
+            StructField::new("name", DataType::STRING, true),
+        ]);
+        let nested_schema_with = StructType::new_unchecked([
+            StructField::new("id", DataType::INTEGER, false),
+            StructField::new(
+                "nested",
+                DataType::Struct(Box::new(StructType::new_unchecked([StructField::new(
+                    "inner_geo",
+                    DataType::Primitive(PrimitiveType::Geography(GeographyType::default())),
+                    true,
+                )]))),
+                true,
+            ),
+        ]);
+        let protocol_with = Protocol::try_new_modern(
+            [TableFeature::GeospatialType],
+            [TableFeature::GeospatialType],
+        )
+        .unwrap();
+        let protocol_without =
+            Protocol::try_new_modern(TableFeature::EMPTY_LIST, TableFeature::EMPTY_LIST).unwrap();
+
+        assert_schema_feature_validation(
+            &schema_with,
+            &schema_without,
+            &protocol_with,
+            &protocol_without,
+            &[&nested_schema_with],
+            "Table contains geometry or geography columns but does not have the required 'geospatial' feature in reader and writer features",
+        );
+    }
+}

--- a/kernel/src/table_features/geospatial.rs
+++ b/kernel/src/table_features/geospatial.rs
@@ -9,6 +9,28 @@ use crate::transforms::SchemaTransform;
 use crate::utils::require;
 use crate::{DeltaResult, Error};
 
+struct UsesGeo(bool);
+
+impl<'a> SchemaTransform<'a> for UsesGeo {
+    fn transform_primitive(&mut self, ptype: &'a PrimitiveType) -> Option<Cow<'a, PrimitiveType>> {
+        if matches!(
+            ptype,
+            PrimitiveType::Geometry(_) | PrimitiveType::Geography(_)
+        ) {
+            self.0 = true;
+        }
+        None
+    }
+}
+
+/// Returns `true` if the schema contains at least one geometry or geography column,
+/// including nested structs, arrays, and maps.
+pub(crate) fn schema_contains_geospatial(schema: &Schema) -> bool {
+    let mut visitor = UsesGeo(false);
+    let _ = visitor.transform_struct(schema);
+    visitor.0
+}
+
 /// Validates that if a table schema contains geometry or geography columns, the table must have
 /// the `geospatial` feature in both reader and writer features.
 pub(crate) fn validate_geospatial_feature_support(tc: &TableConfiguration) -> DeltaResult<()> {
@@ -24,28 +46,6 @@ pub(crate) fn validate_geospatial_feature_support(tc: &TableConfiguration) -> De
     Ok(())
 }
 
-/// Returns `true` if the schema contains at least one geometry or geography column,
-/// including nested structs, arrays, and maps.
-pub(crate) fn schema_contains_geospatial(schema: &Schema) -> bool {
-    let mut detector = GeoDetector(false);
-    let _ = detector.transform_struct(schema);
-    detector.0
-}
-
-struct GeoDetector(bool);
-
-impl<'a> SchemaTransform<'a> for GeoDetector {
-    fn transform_primitive(&mut self, ptype: &'a PrimitiveType) -> Option<Cow<'a, PrimitiveType>> {
-        if matches!(
-            ptype,
-            PrimitiveType::Geometry(_) | PrimitiveType::Geography(_)
-        ) {
-            self.0 = true;
-        }
-        None
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::actions::Protocol;
@@ -53,7 +53,9 @@ mod tests {
         DataType, GeographyType, GeometryType, PrimitiveType, StructField, StructType,
     };
     use crate::table_features::TableFeature;
-    use crate::utils::test_utils::assert_schema_feature_validation;
+    use crate::utils::test_utils::{
+        assert_result_error_with_message, assert_schema_feature_validation,
+    };
 
     #[test]
     fn test_geospatial_feature_validation() {
@@ -88,6 +90,16 @@ mod tests {
         .unwrap();
         let protocol_without =
             Protocol::try_new_modern(TableFeature::EMPTY_LIST, TableFeature::EMPTY_LIST).unwrap();
+
+        // ReaderWriter features must be listed on both sides
+        assert_result_error_with_message(
+            Protocol::try_new_modern([&TableFeature::GeospatialType], TableFeature::EMPTY_LIST),
+            "Reader features must contain only ReaderWriter features that are also listed in writer features",
+        );
+        assert_result_error_with_message(
+            Protocol::try_new_modern(TableFeature::EMPTY_LIST, [&TableFeature::GeospatialType]),
+            "Writer features must be Writer-only or also listed in reader features",
+        );
 
         assert_schema_feature_validation(
             &schema_with,

--- a/kernel/src/table_features/geospatial.rs
+++ b/kernel/src/table_features/geospatial.rs
@@ -1,25 +1,23 @@
 //! Validation logic for the `geospatial` table feature.
 
-use std::borrow::Cow;
-
 use super::TableFeature;
 use crate::schema::{PrimitiveType, Schema};
 use crate::table_configuration::TableConfiguration;
 use crate::transforms::SchemaTransform;
 use crate::utils::require;
-use crate::{DeltaResult, Error};
+use crate::{transform_output_type, DeltaResult, Error};
 
 struct UsesGeo(bool);
 
 impl<'a> SchemaTransform<'a> for UsesGeo {
-    fn transform_primitive(&mut self, ptype: &'a PrimitiveType) -> Option<Cow<'a, PrimitiveType>> {
+    transform_output_type!(|'a, T| ());
+    fn transform_primitive(&mut self, ptype: &'a PrimitiveType) {
         if matches!(
             ptype,
             PrimitiveType::Geometry(_) | PrimitiveType::Geography(_)
         ) {
             self.0 = true;
         }
-        None
     }
 }
 
@@ -27,7 +25,7 @@ impl<'a> SchemaTransform<'a> for UsesGeo {
 /// including nested structs, arrays, and maps.
 pub(crate) fn schema_contains_geospatial(schema: &Schema) -> bool {
     let mut visitor = UsesGeo(false);
-    let _ = visitor.transform_struct(schema);
+    visitor.transform_struct(schema);
     visitor.0
 }
 

--- a/kernel/src/table_features/geospatial.rs
+++ b/kernel/src/table_features/geospatial.rs
@@ -47,7 +47,10 @@ pub(crate) fn validate_geospatial_feature_support(tc: &TableConfiguration) -> De
 #[cfg(test)]
 mod tests {
     use crate::actions::Protocol;
-    use crate::schema::{DataType, PrimitiveType, StructField, StructType};
+    use crate::schema::{
+        DataType, EdgeInterpolationAlgorithm, GeographyType, GeometryType, PrimitiveType,
+        StructField, StructType,
+    };
     use crate::table_features::TableFeature;
     use crate::utils::test_utils::{
         assert_result_error_with_message, assert_schema_feature_validation,
@@ -59,7 +62,9 @@ mod tests {
             StructField::new("id", DataType::INTEGER, false),
             StructField::new(
                 "geom",
-                DataType::Primitive(PrimitiveType::Geometry(Box::default())),
+                DataType::Primitive(PrimitiveType::Geometry(Box::new(
+                    GeometryType::try_new("EPSG:4326").unwrap(),
+                ))),
                 true,
             ),
         ]);
@@ -73,7 +78,10 @@ mod tests {
                 "nested",
                 DataType::Struct(Box::new(StructType::new_unchecked([StructField::new(
                     "inner_geo",
-                    DataType::Primitive(PrimitiveType::Geography(Box::default())),
+                    DataType::Primitive(PrimitiveType::Geography(Box::new(
+                        GeographyType::try_new("EPSG:4326", EdgeInterpolationAlgorithm::Spherical)
+                            .unwrap(),
+                    ))),
                     true,
                 )]))),
                 true,

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -13,6 +13,7 @@ pub(crate) use column_mapping::{
     validate_column_mapping_id, StaleAnnotationPolicy,
 };
 use delta_kernel_derive::internal_api;
+pub(crate) use geospatial::validate_geospatial_feature_support;
 pub(crate) use iceberg_compat::v3::V3_VALIDATOR;
 pub(crate) use iceberg_compat::validate_iceberg_compat_if_needed;
 use itertools::Itertools;
@@ -31,6 +32,7 @@ use crate::utils::require;
 use crate::{DeltaResult, Error};
 
 mod column_mapping;
+mod geospatial;
 mod iceberg_compat;
 mod timestamp_ntz;
 
@@ -173,6 +175,10 @@ pub(crate) enum TableFeature {
     #[strum(serialize = "adaptiveMetadata-preview")]
     #[serde(rename = "adaptiveMetadata-preview")]
     AdaptiveMetadataPreview,
+    /// Geospatial type support (geometry and geography columns)
+    #[strum(serialize = "geospatial")]
+    #[serde(rename = "geospatial")]
+    GeospatialType,
 
     #[serde(untagged)]
     #[strum(default)]
@@ -667,6 +673,14 @@ static ADAPTIVE_METADATA_PREVIEW_INFO: FeatureInfo = FeatureInfo {
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 
+static GEOSPATIAL_TYPE_INFO: FeatureInfo = FeatureInfo {
+    feature_type: FeatureType::ReaderWriter,
+    min_legacy_version: None,
+    feature_requirements: &[],
+    kernel_support: KernelSupport::Supported,
+    enablement_check: EnablementCheck::AlwaysIfSupported,
+};
+
 /// By definition, kernel cannot know how to handle unknown features and must assume they're always
 /// enabled if supported in protocol. However, the read path ignores all writer-only features,
 /// including unknown ones. Unknown features are never inferred from legacy protocol versions.
@@ -699,7 +713,8 @@ impl TableFeature {
             | TableFeature::VariantTypePreview
             | TableFeature::VariantShredding
             | TableFeature::VariantShreddingPreview
-            | TableFeature::AdaptiveMetadataPreview => FeatureType::ReaderWriter,
+            | TableFeature::AdaptiveMetadataPreview
+            | TableFeature::GeospatialType => FeatureType::ReaderWriter,
             TableFeature::AppendOnly
             | TableFeature::DomainMetadata
             | TableFeature::Invariants
@@ -767,6 +782,7 @@ impl TableFeature {
             TableFeature::VariantShredding => &VARIANT_SHREDDING_INFO,
             TableFeature::VariantShreddingPreview => &VARIANT_SHREDDING_PREVIEW_INFO,
             TableFeature::AdaptiveMetadataPreview => &ADAPTIVE_METADATA_PREVIEW_INFO,
+            TableFeature::GeospatialType => &GEOSPATIAL_TYPE_INFO,
 
             // Unknown features: not supported by kernel, no legacy version inference.
             TableFeature::Unknown(_) => &UNKNOWN_FEATURE_INFO,
@@ -1081,6 +1097,7 @@ mod tests {
                 TableFeature::VariantShreddingPreview => "variantShredding-preview",
                 TableFeature::AdaptiveMetadataPreview => "adaptiveMetadata-preview",
                 TableFeature::AllowColumnDefaults => "allowColumnDefaults",
+                TableFeature::GeospatialType => "geospatial",
                 TableFeature::Unknown(_) => continue, // tested in test_unknown_features
             };
 

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -677,7 +677,12 @@ static GEOSPATIAL_TYPE_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::ReaderWriter,
     min_legacy_version: None,
     feature_requirements: &[],
-    kernel_support: KernelSupport::Supported,
+    kernel_support: KernelSupport::Custom(|_, _, op| match op {
+        Operation::Scan | Operation::Cdf => Ok(()),
+        Operation::Write => Err(Error::unsupported(
+            "Feature 'geospatial' is not supported for writes",
+        )),
+    }),
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -1642,7 +1642,7 @@ mod tests {
         assert!(result
             .unwrap_err()
             .to_string()
-            .contains("non-primitive type"));
+            .contains("has unsupported type"));
     }
 
     #[rstest::rstest]
@@ -1660,7 +1660,7 @@ mod tests {
     )]
     #[case::geography(
         DataType::Primitive(PrimitiveType::Geography(Box::new(GeographyType::try_new(
-            Some("OGC:CRS84"), Some(EdgeInterpolationAlgorithm::Thomas)
+            "OGC:CRS84", EdgeInterpolationAlgorithm::Thomas
         ).unwrap()))),
         false
     )]

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -246,8 +246,8 @@ struct DataLayoutResult {
 /// 1. Top-level columns (nested paths are not supported)
 /// 2. Present in the schema
 /// 3. Not duplicated
-/// 4. Of a primitive type (Struct, Array, Map are rejected because partition values must be
-///    representable as directory-path strings)
+/// 4. Of a primitive type which is not Geospatial type. (Struct, Array, Map are rejected because
+///    partition values must be representable as directory-path strings)
 /// 5. A strict subset of the schema columns (at least one non-partition column required)
 fn validate_partition_columns(
     schema: &StructType,
@@ -284,12 +284,14 @@ fn validate_partition_columns(
             Error::generic(format!("Partition column '{col}' not found in schema"))
         })?;
 
-        if !matches!(field.data_type(), DataType::Primitive(_)) {
-            return Err(Error::generic(format!(
-                "Partition column '{col}' has non-primitive type '{}'. \
-                 Partition columns must have primitive types.",
-                field.data_type()
-            )));
+        match field.data_type() {
+            DataType::Primitive(p) if p.is_partition_col() => {}
+            data_type => {
+                return Err(Error::generic(format!(
+                    "Partition column '{col}' has unsupported type '{data_type}'. \
+                     Partition column must be a primitive, non-geospatial type.",
+                )));
+            }
         }
     }
     Ok(())
@@ -972,7 +974,8 @@ mod tests {
     use crate::expressions::ColumnName;
     use crate::scan::data_skipping::stats_schema::StripFieldMetadataTransform;
     use crate::schema::{
-        schema_ref, ColumnMetadataKey, DataType, MetadataValue, StructField, StructType,
+        schema_ref, ColumnMetadataKey, DataType, EdgeInterpolationAlgorithm, GeographyType,
+        GeometryType, MetadataValue, PrimitiveType, StructField, StructType,
     };
     use crate::table_features::FeatureType;
     use crate::table_properties::{
@@ -1643,19 +1646,37 @@ mod tests {
     }
 
     #[rstest::rstest]
-    #[case::integer(DataType::INTEGER)]
-    #[case::string(DataType::STRING)]
-    #[case::date(DataType::DATE)]
-    #[case::timestamp(DataType::TIMESTAMP)]
-    #[case::boolean(DataType::BOOLEAN)]
-    #[case::long(DataType::LONG)]
-    fn test_validate_partition_columns_primitive_types_accepted(#[case] data_type: DataType) {
+    #[case::integer(DataType::INTEGER, true)]
+    #[case::string(DataType::STRING, true)]
+    #[case::date(DataType::DATE, true)]
+    #[case::timestamp(DataType::TIMESTAMP, true)]
+    #[case::boolean(DataType::BOOLEAN, true)]
+    #[case::long(DataType::LONG, true)]
+    #[case::geometry(
+        DataType::Primitive(PrimitiveType::Geometry(Box::new(GeometryType::try_new(
+            "OGC:CRS84"
+        ).unwrap()))),
+        false
+    )]
+    #[case::geography(
+        DataType::Primitive(PrimitiveType::Geography(Box::new(GeographyType::try_new(
+            Some("OGC:CRS84"), Some(EdgeInterpolationAlgorithm::Thomas)
+        ).unwrap()))),
+        false
+    )]
+    fn test_validate_partition_columns_primitive_types(
+        #[case] data_type: DataType,
+        #[case] expected_value: bool,
+    ) {
         let schema = StructType::new_unchecked(vec![
             StructField::new("id", DataType::INTEGER, false),
             StructField::new("col", data_type, false),
         ]);
         let columns = vec![ColumnName::new(["col"])];
-        assert!(validate_partition_columns(&schema, &columns).is_ok());
+        assert_eq!(
+            validate_partition_columns(&schema, &columns).is_ok(),
+            expected_value
+        );
     }
 
     #[test]

--- a/kernel/src/transaction/stats_verifier.rs
+++ b/kernel/src/transaction/stats_verifier.rs
@@ -191,6 +191,8 @@ fn column_types_for(dt: &DataType) -> DeltaResult<&'static ColumnNamesAndTypes> 
             format!("Interval types are not supported for stats validation: {dt}"),
         )),
         &DataType::VOID
+        | DataType::Primitive(PrimitiveType::Geometry(_))
+        | DataType::Primitive(PrimitiveType::Geography(_))
         | DataType::Struct(_)
         | DataType::Array(_)
         | DataType::Map(_)
@@ -224,10 +226,15 @@ fn is_stat_present<'b>(
         DataType::Primitive(PrimitiveType::Decimal(_)) => {
             Ok(getter.get_decimal(row_idx, field_name)?.is_some())
         }
+<<<<<<< HEAD
         &DataType::INTERVAL_YEAR_MONTH | &DataType::INTERVAL_DAY_TIME => Err(Error::unsupported(
             format!("Interval types are not supported for stats presence check: {data_type}"),
         )),
         &DataType::VOID
+=======
+        DataType::Primitive(PrimitiveType::Geometry(_))
+        | DataType::Primitive(PrimitiveType::Geography(_))
+>>>>>>> 16671702 (geo schema type and table feat)
         | DataType::Struct(_)
         | DataType::Array(_)
         | DataType::Map(_)

--- a/kernel/src/transaction/stats_verifier.rs
+++ b/kernel/src/transaction/stats_verifier.rs
@@ -226,15 +226,12 @@ fn is_stat_present<'b>(
         DataType::Primitive(PrimitiveType::Decimal(_)) => {
             Ok(getter.get_decimal(row_idx, field_name)?.is_some())
         }
-<<<<<<< HEAD
         &DataType::INTERVAL_YEAR_MONTH | &DataType::INTERVAL_DAY_TIME => Err(Error::unsupported(
             format!("Interval types are not supported for stats presence check: {data_type}"),
         )),
         &DataType::VOID
-=======
-        DataType::Primitive(PrimitiveType::Geometry(_))
+        | DataType::Primitive(PrimitiveType::Geometry(_))
         | DataType::Primitive(PrimitiveType::Geography(_))
->>>>>>> 16671702 (geo schema type and table feat)
         | DataType::Struct(_)
         | DataType::Array(_)
         | DataType::Map(_)

--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -1838,6 +1838,9 @@ fn scalar_for_type(data_type: &DataType, seed: usize) -> Scalar {
             PrimitiveType::IntervalYearMonth | PrimitiveType::IntervalDayTime => {
                 panic!("interval types are not supported as partition values")
             }
+            PrimitiveType::Geometry(_) | PrimitiveType::Geography(_) => {
+                panic!("Geometry/Geography are not valid partition column types")
+            }
         },
         other => panic!("partition columns must be primitive types, got: {other:?}"),
     }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2464/files) to review incremental changes.
- [stack/schema-table-feat-geo](https://github.com/delta-io/delta-kernel-rs/pull/2464) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2464/files)]

---------
Note: don't merge until the [RFC](https://github.com/delta-io/delta/pull/4726) is merged.

## What changes are proposed in this pull request?
This PR implements the following:

- New schema types for geo: GeometryType, GeographyType
- Geo schema type serialization/deserialization
- _geospatial_ reader/writer table feature support

## How was this change tested?
All tests follow pre-existing test patterns for other types.
- Test all valid deserialization cases for correct output - see [this](https://github.com/delta-io/delta-kernel-rs/pull/2464#discussion_r3163018749) comment
- Test invalid geo serialized format 
- Test roundtrip serde of geo types
- Test feature validation