### PR TITLE
refactor!: change committer to be wrapped in an arc rather than box

### DIFF
--- a/delta-kernel-unity-catalog/src/committer.rs
+++ b/delta-kernel-unity-catalog/src/committer.rs
@@ -31,10 +31,10 @@ macro_rules! require {
 ///
 /// For version >= 1, the committer writes a staged commit and calls the UC commit API to ratify it.
 ///
-/// NOTE: this [`Committer`] requires a multi-threaded tokio runtime. That is, whatever
-/// implementation consumes the Committer to commit to the table, must call `commit` from within a
-/// muti-threaded tokio runtime context. Since the default engine uses tokio, this is compatible,
-/// but must ensure that the multi-threaded runtime is used.
+/// NOTE: this [`Committer`] requires a multi-threaded tokio runtime. That is, whatever code calls
+/// [`commit`](Committer::commit) on the Committer must do so from within a multi-threaded tokio
+/// runtime context. Since the default engine uses tokio, this is compatible, but must ensure that
+/// the multi-threaded runtime is used.
 #[derive(Debug, Clone)]
 pub struct UCCommitter<C: CommitClient> {
     commits_client: Arc<C>,

--- a/delta-kernel-unity-catalog/src/lib.rs
+++ b/delta-kernel-unity-catalog/src/lib.rs
@@ -250,7 +250,7 @@ mod tests {
         let store = Arc::new(store);
 
         let engine = DefaultEngineBuilder::new(store.clone()).build();
-        let committer = Box::new(UCCommitter::new(commits_client.clone(), table_id.clone()));
+        let committer = Arc::new(UCCommitter::new(commits_client.clone(), table_id.clone()));
         let snapshot = catalog
             .load_snapshot(&table_id, &table_uri, &engine)
             .await?;

--- a/delta-kernel-unity-catalog/src/utils/create_table.rs
+++ b/delta-kernel-unity-catalog/src/utils/create_table.rs
@@ -182,7 +182,7 @@ mod tests {
         let _ = create_table(table_path, schema, "Test/1.0")
             .with_table_properties(disk_props)
             .with_data_layout(DataLayout::clustered(["region"]))
-            .build(&engine, Box::new(MockCatalogCommitter))
+            .build(&engine, Arc::new(MockCatalogCommitter))
             .unwrap()
             .commit(&engine)
             .unwrap();
@@ -250,7 +250,7 @@ mod tests {
                     ColumnName::new(["address", "city"]),
                 ],
             })
-            .build(&engine, Box::new(MockCatalogCommitter))
+            .build(&engine, Arc::new(MockCatalogCommitter))
             .unwrap()
             .commit(&engine)
             .unwrap();
@@ -285,7 +285,7 @@ mod tests {
         let disk_props = get_required_properties_for_disk("test-table-id");
         let _ = create_table(table_path, schema, "Test/1.0")
             .with_table_properties(disk_props)
-            .build(&engine, Box::new(MockCatalogCommitter))
+            .build(&engine, Arc::new(MockCatalogCommitter))
             .unwrap()
             .commit(&engine)
             .unwrap();
@@ -294,7 +294,7 @@ mod tests {
             .build(&engine)
             .unwrap();
         let result = v0_snapshot
-            .transaction(Box::new(MockCatalogCommitter), &engine)
+            .transaction(Arc::new(MockCatalogCommitter), &engine)
             .unwrap()
             .commit(&engine)
             .unwrap();

--- a/delta-kernel-unity-catalog/tests/e2e_in_memory.rs
+++ b/delta-kernel-unity-catalog/tests/e2e_in_memory.rs
@@ -101,7 +101,7 @@ fn commit(
     commits_client: &Arc<InMemoryCommitsClient>,
     engine: &DefaultEngine<TokioMultiThreadExecutor>,
 ) -> Result<Arc<Snapshot>, TestError> {
-    let committer = Box::new(UCCommitter::new(commits_client.clone(), TABLE_ID));
+    let committer = Arc::new(UCCommitter::new(commits_client.clone(), TABLE_ID));
     match snapshot
         .clone()
         .transaction(committer, engine)?
@@ -161,7 +161,7 @@ async fn test_insert_without_publish_hits_limit() -> Result<(), TestError> {
     assert_eq!(snapshot.version(), max);
 
     // Next insert should fail with MaxUnpublishedCommitsExceeded
-    let committer = Box::new(UCCommitter::new(commits_client.clone(), TABLE_ID));
+    let committer = Arc::new(UCCommitter::new(commits_client.clone(), TABLE_ID));
     let err = snapshot
         .clone()
         .transaction(committer, &engine)?

--- a/docs/user-guide/src/concepts/architecture.md
+++ b/docs/user-guide/src/concepts/architecture.md
@@ -155,7 +155,7 @@ A `Transaction` writes data to a table. It is built from a snapshot:
 
 ```rust,ignore
 let mut txn = snapshot                              // Arc<Snapshot>
-    .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+    .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
     .with_operation("INSERT".to_string())
     .with_data_change(true);
 

--- a/docs/user-guide/src/getting_started/quick_start_write.md
+++ b/docs/user-guide/src/getting_started/quick_start_write.md
@@ -59,7 +59,7 @@ async fn main() -> DeltaResult<()> {
     ])?);
 
     create_table(url.as_str(), schema.clone(), "quick-start/1.0")
-        .build(&engine, Box::new(FileSystemCommitter::new()))?
+        .build(&engine, Arc::new(FileSystemCommitter::new()))?
         .commit(&engine)?;
     println!("Created table at {url}");
 
@@ -67,7 +67,7 @@ async fn main() -> DeltaResult<()> {
     let snapshot = Snapshot::builder_for(url.clone()).build(&engine)?;
 
     let mut txn = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+        .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
         .with_operation("INSERT".to_string())
         .with_engine_info("quick-start/1.0")
         .with_data_change(true);
@@ -130,7 +130,7 @@ let schema = Arc::new(StructType::try_new(vec![
 ])?);
 
 create_table(url.as_str(), schema.clone(), "quick-start/1.0")
-    .build(&engine, Box::new(FileSystemCommitter::new()))?
+    .build(&engine, Arc::new(FileSystemCommitter::new()))?
     .commit(&engine)?;
 ```
 
@@ -152,7 +152,7 @@ The write flow has four parts:
 **Start a transaction:**
 ```rust,ignore
 let mut txn = snapshot
-    .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+    .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
     .with_operation("INSERT".to_string())
     .with_data_change(true);
 ```

--- a/docs/user-guide/src/writing/alter_table.md
+++ b/docs/user-guide/src/writing/alter_table.md
@@ -57,7 +57,7 @@ let snapshot = Snapshot::builder_for(url).build(&engine)?;
 let result = snapshot
     .alter_table()
     .add_column(StructField::nullable("country", DataType::STRING))
-    .build(&engine, Box::new(FileSystemCommitter::new()))?
+    .build(&engine, Arc::new(FileSystemCommitter::new()))?
     .with_engine_info("my-app/1.0")
     .commit(&engine)?;
 
@@ -106,7 +106,7 @@ let result = snapshot
     .alter_table()
     .add_column(StructField::nullable("country", DataType::STRING))
     .add_column(StructField::nullable("postal_code", DataType::STRING))
-    .build(&engine, Box::new(FileSystemCommitter::new()))?
+    .build(&engine, Arc::new(FileSystemCommitter::new()))?
     .commit(&engine)?;
 ```
 

--- a/docs/user-guide/src/writing/append.md
+++ b/docs/user-guide/src/writing/append.md
@@ -41,7 +41,7 @@ let snapshot = Snapshot::builder_for(url).build(&engine)?;
 
 // 2. Create a transaction
 let mut txn = snapshot
-    .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+    .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
     .with_operation("INSERT".to_string())
     .with_engine_info("my-app/1.0")
     .with_data_change(true);
@@ -85,7 +85,7 @@ writing against:
 
 ```rust,ignore
 let mut txn = snapshot
-    .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+    .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
     .with_operation("INSERT".to_string())
     .with_engine_info("my-app/1.0")
     .with_data_change(true);
@@ -183,7 +183,7 @@ construction:
 
 ```rust,ignore
 let txn = snapshot
-    .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+    .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
     .with_operation("INSERT".to_string())
     .with_blind_append();
 ```
@@ -215,7 +215,7 @@ that action, call `with_commit_info()` with your custom data and its schema:
 
 ```rust,ignore
 let txn = snapshot
-    .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+    .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
     .with_operation("INSERT".to_string())
     .with_commit_info(engine_commit_info, commit_info_schema);
 ```

--- a/docs/user-guide/src/writing/create_table.md
+++ b/docs/user-guide/src/writing/create_table.md
@@ -28,7 +28,7 @@ let schema = Arc::new(StructType::try_new([
 ])?);
 
 create_table(url.as_str(), schema, "my-app/1.0")
-    .build(&engine, Box::new(FileSystemCommitter::new()))?
+    .build(&engine, Arc::new(FileSystemCommitter::new()))?
     .commit(&engine)?;
 # Ok(())
 # }
@@ -111,7 +111,7 @@ create_table(url.as_str(), schema, "my-app/1.0")
         ("myapp.version", "2.0"),
         ("myapp.owner", "data-team"),
     ])
-    .build(&engine, Box::new(FileSystemCommitter::new()))?
+    .build(&engine, Arc::new(FileSystemCommitter::new()))?
     .commit(&engine)?;
 # Ok(())
 # }
@@ -147,7 +147,7 @@ let schema = Arc::new(StructType::try_new([
 
 create_table(url.as_str(), schema, "my-app/1.0")
     .with_data_layout(DataLayout::clustered(["region", "timestamp"]))
-    .build(&engine, Box::new(FileSystemCommitter::new()))?
+    .build(&engine, Arc::new(FileSystemCommitter::new()))?
     .commit(&engine)?;
 # Ok(())
 # }
@@ -203,7 +203,7 @@ let schema = Arc::new(StructType::try_new([
 
 create_table(url.as_str(), schema, "my-app/1.0")
     .with_data_layout(DataLayout::partitioned(["year", "month"]))
-    .build(&engine, Box::new(FileSystemCommitter::new()))?
+    .build(&engine, Arc::new(FileSystemCommitter::new()))?
     .commit(&engine)?;
 # Ok(())
 # }

--- a/docs/user-guide/src/writing/domain_metadata.md
+++ b/docs/user-guide/src/writing/domain_metadata.md
@@ -32,7 +32,7 @@ transactions.
 # let engine = DefaultEngine::builder(store_from_url(&url)?).build();
 # let snapshot = Snapshot::builder_for(url).build(&engine)?;
 let txn = snapshot
-    .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+    .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
     .with_domain_metadata(
         "myConnector.settings".to_string(),
         r#"{"version": 1, "compress": true}"#.to_string(),
@@ -78,7 +78,7 @@ exist yet.
 # let engine = DefaultEngine::builder(store_from_url(&url)?).build();
 # let snapshot = Snapshot::builder_for(url).build(&engine)?;
 let txn = snapshot
-    .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+    .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
     .with_domain_metadata_removed("myConnector.settings".to_string())
     .with_operation("REMOVE METADATA".to_string());
 

--- a/docs/user-guide/src/writing/idempotent_writes.md
+++ b/docs/user-guide/src/writing/idempotent_writes.md
@@ -51,7 +51,7 @@ if let Some(committed_version) = snapshot.get_app_id_version(app_id, &engine)? {
 
 // Not yet committed. Proceed with the write.
 let txn = snapshot
-    .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+    .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
     .with_transaction_id(app_id.to_string(), batch_version)
     .with_operation("STREAMING UPDATE".to_string());
 

--- a/docs/user-guide/src/writing/partitioned_writes.md
+++ b/docs/user-guide/src/writing/partitioned_writes.md
@@ -43,7 +43,7 @@ The pattern for partitioned writes is: **group your data by partition values, cr
 # let engine = DefaultEngine::builder(store_from_url(&url)?).build();
 let snapshot = Snapshot::builder_for(url).build(&engine)?;
 let mut txn = snapshot
-    .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+    .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
     .with_operation("INSERT".to_string())
     .with_data_change(true);
 

--- a/docs/user-guide/src/writing/removing_files.md
+++ b/docs/user-guide/src/writing/removing_files.md
@@ -149,7 +149,7 @@ let snapshot = Snapshot::builder_for(url).build(&engine)?;
 // 2. Create a transaction
 let mut txn = snapshot
     .clone()
-    .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+    .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
     .with_operation("DELETE".to_string());
 
 // 3. Build a scan and get file metadata

--- a/ffi/examples/delta-kernel-unity-catalog-example/delta_kernel_unity_catalog_example.c
+++ b/ffi/examples/delta-kernel-unity-catalog-example/delta_kernel_unity_catalog_example.c
@@ -132,17 +132,17 @@ int main(int argc, char* argv[])
     const char* table_id = "64dcd182-b3b4-4ee0-88e0-63c159a4121c";
     KernelStringSlice table_id_slice = { .ptr = table_id, .len = strlen(table_id) };
 
-    ExternResultHandleMutableCommitter committer_res =
+    ExternResultHandleSharedCommitter committer_res =
         get_uc_committer(uc_client, table_id_slice, allocate_error);
 
-    if (committer_res.tag != OkHandleMutableCommitter) {
+    if (committer_res.tag != OkHandleSharedCommitter) {
         print_error("Failed to create UC committer", (Error*)committer_res.err);
         free_error((Error*)committer_res.err);
         free_uc_commit_client(uc_client);
         return -1;
     }
 
-    HandleMutableCommitter uc_committer = committer_res.ok;
+    HandleSharedCommitter uc_committer = committer_res.ok;
 
     // Get the default engine
     KernelStringSlice table_path_slice = { .ptr = table_path, .len = strlen(table_path) };
@@ -152,6 +152,7 @@ int main(int argc, char* argv[])
     if (engine_builder_res.tag != OkEngineBuilder) {
         print_error("Could not get engine builder", (Error*)engine_builder_res.err);
         free_error((Error*)engine_builder_res.err);
+        free_uc_committer(uc_committer);
         free_uc_commit_client(uc_client);
         return -1;
     }
@@ -162,6 +163,7 @@ int main(int argc, char* argv[])
     if (engine_res.tag != OkHandleSharedExternEngine) {
         print_error("Failed to build engine", (Error*)engine_res.err);
         free_error((Error*)engine_res.err);
+        free_uc_committer(uc_committer);
         free_uc_commit_client(uc_client);
         return -1;
     }
@@ -172,6 +174,7 @@ int main(int argc, char* argv[])
     if (snapshot_builder_res.tag != OkHandleMutableFfiSnapshotBuilder) {
       print_error("Failed to get snapshot builder.", (Error*)snapshot_builder_res.err);
       free_error((Error*)snapshot_builder_res.err);
+      free_uc_committer(uc_committer);
       free_engine(engine);
       free_uc_commit_client(uc_client);
       return -1;
@@ -183,6 +186,7 @@ int main(int argc, char* argv[])
     if (snapshot_res.tag != OkHandleSharedSnapshot) {
       print_error("Failed to create snapshot.", (Error*)snapshot_res.err);
       free_error((Error*)snapshot_res.err);
+      free_uc_committer(uc_committer);
       free_engine(engine);
       free_uc_commit_client(uc_client);
       return -1;
@@ -197,6 +201,8 @@ int main(int argc, char* argv[])
     if (txn_res.tag != OkHandleExclusiveTransaction) {
         print_error("Failed to create transaction with UC committer", (Error*)txn_res.err);
         free_error((Error*)txn_res.err);
+        free_uc_committer(uc_committer);
+        free_snapshot(snapshot);
         free_engine(engine);
         free_uc_commit_client(uc_client);
         return -1;
@@ -216,6 +222,8 @@ int main(int argc, char* argv[])
     if (txn_with_info_res.tag != OkHandleExclusiveTransaction) {
         print_error("Failed to set engine info", (Error*)txn_with_info_res.err);
         free_error((Error*)txn_with_info_res.err);
+        free_uc_committer(uc_committer);
+        free_snapshot(snapshot);
         free_engine(engine);
         free_uc_commit_client(uc_client);
         return -1;
@@ -228,6 +236,8 @@ int main(int argc, char* argv[])
     if (commit_res.tag != Oku64) {
         print_error("Commit failed", (Error*)commit_res.err);
         free_error((Error*)commit_res.err);
+        free_uc_committer(uc_committer);
+        free_snapshot(snapshot);
         free_engine(engine);
         free_uc_commit_client(uc_client);
         return -1;
@@ -235,8 +245,10 @@ int main(int argc, char* argv[])
 
     printf("\nCommitted version: %lu\n", (unsigned long)commit_res.ok);
 
-    // Cleanup
-    // Note: txn_with_info was consumed by commit(), so we don't free it
+    // Cleanup.
+    // Note: txn_with_info was consumed by commit(), so we don't free it. The committer
+    // handle is NOT consumed by transaction_with_committer -- we own it and must free it.
+    free_uc_committer(uc_committer);
     free_engine(engine);
     free_uc_commit_client(uc_client);
     free_snapshot(snapshot);

--- a/ffi/src/delta_kernel_unity_catalog.rs
+++ b/ffi/src/delta_kernel_unity_catalog.rs
@@ -122,11 +122,12 @@ pub struct SharedFfiUCCommitClient;
 /// Get a commit client that will call the passed callbacks when it wants to make a commit. The
 /// context will be passed back to the callback when called.
 ///
-/// IMPORTANT: The pointer passed for the context MUST be safe for **concurrent access from
-/// multiple threads** (i.e. `Sync`, not merely `Send`) and MUST remain valid for as long as the
-/// client is used. Because the returned commit client is wrapped in a shared committer handle
-/// (`SharedCommitter`), its callback can be invoked concurrently on the same context from
-/// multiple threads driving independent transactions. It is valid to pass NULL as the context.
+/// IMPORTANT: The context pointer (and any data it transitively references) MUST be safe to
+/// dereference and mutate concurrently from multiple OS threads. If the context is shared across
+/// threads, the caller MUST synchronize accesses internally (e.g. via a mutex). The pointer must
+/// also remain valid for as long as the client is used. NULL is permitted. The kernel may invoke
+/// `commit_callback` from different threads at the same time when this client is shared across
+/// transactions via a `SharedCommitter` handle.
 ///
 /// # Safety
 ///

--- a/ffi/src/delta_kernel_unity_catalog.rs
+++ b/ffi/src/delta_kernel_unity_catalog.rs
@@ -18,7 +18,7 @@ use unity_catalog_delta_client_api::{
 };
 
 use crate::error::{AllocateErrorFn, ExternResult, IntoExternResult as _};
-use crate::transaction::MutableCommitter;
+use crate::transaction::SharedCommitter;
 use crate::{ExclusiveRustString, NullableCvoid};
 
 /// Data representing a commit.
@@ -59,8 +59,11 @@ pub struct FfiUCCommitClient {
     commit_callback: CCommit,
 }
 
-// NullableCvoid is NOT `Send` by itself. Here we declare our struct to be Send as it's up to the
-// caller to ensure they pass a thread safe pointer that remains valid
+// NullableCvoid is NOT `Send + Sync` by itself. Here we declare our struct to be Send + Sync, and
+// it's up to the caller to ensure the context pointer is safe for concurrent access from multiple
+// threads. Because committers are shared via `Arc<dyn Committer>`, `commit_callback(self.context,
+// ...)` below can be invoked concurrently on the same context from different threads driving
+// different transactions.
 unsafe impl Send for FfiUCCommitClient {}
 unsafe impl Sync for FfiUCCommitClient {}
 
@@ -119,9 +122,11 @@ pub struct SharedFfiUCCommitClient;
 /// Get a commit client that will call the passed callbacks when it wants to make a commit. The
 /// context will be passed back to the callback when called.
 ///
-/// IMPORTANT: The pointer passed for the context MUST be thread-safe (i.e. be able to be sent
-/// between threads safely) and MUST remain valid for as long as the client is used. It is valid to
-/// pass NULL as the context.
+/// IMPORTANT: The pointer passed for the context MUST be safe for **concurrent access from
+/// multiple threads** (i.e. `Sync`, not merely `Send`) and MUST remain valid for as long as the
+/// client is used. Because the returned commit client is wrapped in a shared committer handle
+/// (`SharedCommitter`), its callback can be invoked concurrently on the same context from
+/// multiple threads driving independent transactions. It is valid to pass NULL as the context.
 ///
 /// # Safety
 ///
@@ -195,7 +200,12 @@ impl<C: CommitClient + 'static> Committer for FfiUCCommitter<C> {
     }
 }
 
-/// Get a commit client that will call the passed callbacks when it wants to make a commit.
+/// Construct a Unity Catalog [`Committer`] bound to the given `commit_client` and `table_id`.
+///
+/// The returned handle wraps a shared `Arc<dyn Committer>` and may be passed to
+/// `transaction_with_committer` or `create_table_builder_build_with_committer` multiple times
+/// (both functions clone the underlying `Arc` rather than consuming the handle). The handle must
+/// ultimately be freed by calling [`free_uc_committer`].
 ///
 /// # Safety
 ///
@@ -207,33 +217,37 @@ pub unsafe extern "C" fn get_uc_committer(
     commit_client: Handle<SharedFfiUCCommitClient>,
     table_id: KernelStringSlice,
     error_fn: AllocateErrorFn,
-) -> ExternResult<Handle<MutableCommitter>> {
+) -> ExternResult<Handle<SharedCommitter>> {
     get_uc_committer_impl(commit_client, table_id).into_extern_result(&error_fn)
 }
 
 fn get_uc_committer_impl(
     commit_client: Handle<SharedFfiUCCommitClient>,
     table_id: KernelStringSlice,
-) -> DeltaResult<Handle<MutableCommitter>> {
+) -> DeltaResult<Handle<SharedCommitter>> {
     let client: Arc<FfiUCCommitClient> = unsafe { commit_client.clone_as_arc() };
     let table_id_str: String = unsafe { TryFromStringSlice::try_from_slice(&table_id) }?;
-    let committer: Box<dyn Committer> = Box::new(FfiUCCommitter {
+    let committer: Arc<dyn Committer> = Arc::new(FfiUCCommitter {
         inner: UCCommitter::new(client, table_id_str),
     });
     Ok(committer.into())
 }
 
-/// Free a committer obtained via get_uc_committer. Warning! Normally the value returned here will
-/// be consumed when creating a transaction via [`crate::transaction::transaction_with_committer`]
-/// and will NOT need to be freed.
+/// Release a committer handle obtained via [`get_uc_committer`].
+///
+/// Must be called exactly once per handle returned by `get_uc_committer`. The committer's
+/// underlying `Arc<dyn Committer>` is shared with any transactions started via
+/// [`crate::transaction::transaction_with_committer`] or
+/// [`crate::transaction::create_table_builder_build_with_committer`]; the underlying object is
+/// only dropped when all outstanding Arc references are released.
 ///
 /// # Safety
 ///
 /// Caller is responsible for passing a valid handle obtained via `get_uc_committer`
 #[no_mangle]
-pub unsafe extern "C" fn free_uc_committer(commit_client: Handle<MutableCommitter>) {
+pub unsafe extern "C" fn free_uc_committer(committer: Handle<SharedCommitter>) {
     debug!("released uc committer");
-    commit_client.drop_handle();
+    committer.drop_handle();
 }
 
 #[cfg(test)]
@@ -415,5 +429,15 @@ pub(crate) mod tests {
             free_uc_commit_client(client);
             free_uc_committer(committer);
         }
+    }
+
+    // Lock in that `FfiUCCommitter` (and therefore `UCCommitter<FfiUCCommitClient>`) satisfies
+    // the `Send + Sync` bound required by `Committer`. A future change to `UCCommitter` or
+    // `CommitClient` that silently drops `Sync` would otherwise only fail at the cast site in
+    // `get_uc_committer_impl`, with a confusing error.
+    #[test]
+    fn ffi_uc_committer_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<FfiUCCommitter<FfiUCCommitClient>>();
     }
 }

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -1588,49 +1588,10 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    #[cfg_attr(miri, ignore)]
-    async fn test_create_table_with_custom_committer() -> Result<(), Box<dyn std::error::Error>> {
-        let tmp_dir = tempdir()?;
-        let (table_path, engine, builder) = create_table_builder(
-            &tmp_dir,
-            vec![StructField::nullable("id", DataType::INTEGER)],
-        );
-        let table_path_str = table_path.as_str();
-
-        // Create a FileSystemCommitter handle and pass it to build_with_committer
-        let committer: Arc<dyn delta_kernel::committer::Committer> =
-            Arc::new(FileSystemCommitter::new());
-        let committer_handle: Handle<SharedCommitter> = committer.into();
-
-        let txn = ok_or_panic(unsafe {
-            create_table_builder_build_with_committer(
-                builder,
-                committer_handle.shallow_copy(),
-                engine.shallow_copy(),
-            )
-        });
-        let committed_version =
-            ok_or_panic(unsafe { create_table_commit(txn, engine.shallow_copy()) });
-        assert_eq!(committed_version, 0);
-
-        // Verify the table was created
-        let snap =
-            unsafe { build_snapshot(kernel_string_slice!(table_path_str), engine.shallow_copy()) };
-        assert_eq!(unsafe { version(snap.shallow_copy()) }, 0);
-
-        unsafe { free_snapshot(snap) };
-        // The committer handle is NOT consumed by create_table_builder_build_with_committer --
-        // the caller owns it and must drop it explicitly.
-        unsafe { committer_handle.drop_handle() };
-        unsafe { free_engine(engine) };
-        Ok(())
-    }
-
     // Exercises the motivating property of `SharedCommitter`: a single committer handle can
     // drive multiple independent transactions via `shallow_copy`. If either of the FFI entry
     // points accidentally reverted to consume-on-use semantics, this test would fault at the
-    // second use.
+    // second use. Also verifies the resulting table is loadable at version 0.
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
     async fn test_shared_committer_handle_drives_multiple_tables(
@@ -1641,10 +1602,11 @@ mod tests {
 
         for _ in 0..2 {
             let tmp_dir = tempdir()?;
-            let (_table_path, engine, builder) = create_table_builder(
+            let (table_path, engine, builder) = create_table_builder(
                 &tmp_dir,
                 vec![StructField::nullable("id", DataType::INTEGER)],
             );
+            let table_path_str = table_path.as_str();
             let txn = ok_or_panic(unsafe {
                 create_table_builder_build_with_committer(
                     builder,
@@ -1655,10 +1617,16 @@ mod tests {
             let committed_version =
                 ok_or_panic(unsafe { create_table_commit(txn, engine.shallow_copy()) });
             assert_eq!(committed_version, 0);
+
+            let snap = unsafe {
+                build_snapshot(kernel_string_slice!(table_path_str), engine.shallow_copy())
+            };
+            assert_eq!(unsafe { version(snap.shallow_copy()) }, 0);
+            unsafe { free_snapshot(snap) };
             unsafe { free_engine(engine) };
         }
 
-        // Committer handle was not consumed by either build_with_committer call -- still valid.
+        // Committer handle was not consumed by either build_with_committer call, still valid.
         unsafe { committer_handle.drop_handle() };
         Ok(())
     }

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -36,9 +36,12 @@ pub struct ExclusiveTransaction;
 #[handle_descriptor(target=CreateTableTransaction, mutable=true, sized=true)]
 pub struct ExclusiveCreateTransaction;
 
-/// Handle for a mutable boxed committer that can be passed across FFI
-#[handle_descriptor(target = dyn Committer, mutable = true, sized = false)]
-pub struct MutableCommitter;
+/// Handle for a shared committer (Arc) that can be passed across FFI.
+///
+/// Committers are held as `Arc<dyn Committer>` so a single committer instance can be
+/// constructed once and shared across many transactions.
+#[handle_descriptor(target=dyn Committer, mutable=false, sized=false)]
+pub struct SharedCommitter;
 
 /// Start a transaction on the latest snapshot of the table.
 ///
@@ -61,13 +64,15 @@ fn transaction_impl(
 ) -> DeltaResult<Handle<ExclusiveTransaction>> {
     let engine = extern_engine.engine();
     let snapshot = Snapshot::builder_for(url?).build(engine.as_ref())?;
-    let committer = Box::new(FileSystemCommitter::new());
+    let committer = Arc::new(FileSystemCommitter::new());
     let transaction = snapshot.transaction(committer, engine.as_ref());
     Ok(Box::new(transaction?).into())
 }
 
-/// Start a transaction with a custom committer
-/// NOTE: This consumes the committer handle
+/// Start a transaction with a custom committer.
+///
+/// Clones the committer's underlying `Arc<dyn Committer>`; the caller still owns the handle and
+/// must free it with the appropriate `free_*` function (e.g. `free_uc_committer`).
 ///
 /// # Safety
 ///
@@ -76,18 +81,18 @@ fn transaction_impl(
 pub unsafe extern "C" fn transaction_with_committer(
     snapshot: Handle<SharedSnapshot>,
     engine: Handle<SharedExternEngine>,
-    committer: Handle<MutableCommitter>,
+    committer: Handle<SharedCommitter>,
 ) -> ExternResult<Handle<ExclusiveTransaction>> {
     let snapshot = unsafe { snapshot.clone_as_arc() };
     let engine = unsafe { engine.as_ref() };
-    let committer = unsafe { committer.into_inner() };
+    let committer = unsafe { committer.clone_as_arc() };
     transaction_with_committer_impl(snapshot, engine, committer).into_extern_result(&engine)
 }
 
 fn transaction_with_committer_impl(
     snapshot: Arc<Snapshot>,
     extern_engine: &dyn ExternEngine,
-    committer: Box<dyn Committer>,
+    committer: Arc<dyn Committer>,
 ) -> DeltaResult<Handle<ExclusiveTransaction>> {
     let engine = extern_engine.engine();
     let transaction = snapshot.transaction(committer, engine.as_ref());
@@ -458,7 +463,7 @@ pub unsafe extern "C" fn create_table_builder_build(
 ) -> ExternResult<Handle<ExclusiveCreateTransaction>> {
     let builder = unsafe { *builder.into_inner() };
     let extern_engine = unsafe { engine.as_ref() };
-    let committer = Box::new(FileSystemCommitter::new());
+    let committer = Arc::new(FileSystemCommitter::new());
     create_table_builder_build_impl(builder, committer, extern_engine)
         .into_extern_result(&extern_engine)
 }
@@ -466,18 +471,21 @@ pub unsafe extern "C" fn create_table_builder_build(
 /// Build a create-table transaction with a custom committer. Same as
 /// [`create_table_builder_build`] but uses the provided committer instead of the default.
 ///
+/// Clones the committer's underlying `Arc<dyn Committer>`; the caller still owns the committer
+/// handle and must free it with the appropriate `free_*` function (e.g. `free_uc_committer`).
+///
 /// # Safety
 ///
-/// Caller is responsible for passing valid handles.
-/// CONSUMES both the builder and committer handles -- caller must not use them after this call.
+/// Caller is responsible for passing valid handles. CONSUMES the builder handle -- caller must
+/// not use the builder after this call.
 #[no_mangle]
 pub unsafe extern "C" fn create_table_builder_build_with_committer(
     builder: Handle<ExclusiveCreateTableBuilder>,
-    committer: Handle<MutableCommitter>,
+    committer: Handle<SharedCommitter>,
     engine: Handle<SharedExternEngine>,
 ) -> ExternResult<Handle<ExclusiveCreateTransaction>> {
     let builder = unsafe { *builder.into_inner() };
-    let committer = unsafe { committer.into_inner() };
+    let committer = unsafe { committer.clone_as_arc() };
     let extern_engine = unsafe { engine.as_ref() };
     create_table_builder_build_impl(builder, committer, extern_engine)
         .into_extern_result(&extern_engine)
@@ -485,7 +493,7 @@ pub unsafe extern "C" fn create_table_builder_build_with_committer(
 
 fn create_table_builder_build_impl(
     builder: CreateTableTransactionBuilder,
-    committer: Box<dyn Committer>,
+    committer: Arc<dyn Committer>,
     extern_engine: &dyn ExternEngine,
 ) -> DeltaResult<Handle<ExclusiveCreateTransaction>> {
     let engine = extern_engine.engine();
@@ -1096,7 +1104,8 @@ mod tests {
             cast_test_context, get_test_context, recover_test_context,
         };
         use crate::delta_kernel_unity_catalog::{
-            free_uc_commit_client, get_uc_commit_client, get_uc_committer, CommitRequest,
+            free_uc_commit_client, free_uc_committer, get_uc_commit_client, get_uc_committer,
+            CommitRequest,
         };
         use crate::{Handle, NullableCvoid, OptionalValue};
 
@@ -1171,7 +1180,11 @@ mod tests {
             };
 
             let txn = ok_or_panic(unsafe {
-                transaction_with_committer(snapshot, engine.shallow_copy(), uc_committer)
+                transaction_with_committer(
+                    snapshot,
+                    engine.shallow_copy(),
+                    uc_committer.shallow_copy(),
+                )
             });
             unsafe { set_data_change(txn.shallow_copy(), false) };
 
@@ -1299,6 +1312,9 @@ mod tests {
             );
 
             unsafe { free_write_context(write_context) };
+            // The committer handle is NOT consumed by transaction_with_committer -- the caller
+            // owns it and must free it explicitly.
+            unsafe { free_uc_committer(uc_committer) };
             unsafe { free_engine(engine) };
             unsafe { free_uc_commit_client(uc_client) };
         }
@@ -1583,14 +1599,14 @@ mod tests {
         let table_path_str = table_path.as_str();
 
         // Create a FileSystemCommitter handle and pass it to build_with_committer
-        let committer: Box<dyn delta_kernel::committer::Committer> =
-            Box::new(FileSystemCommitter::new());
-        let committer_handle: Handle<MutableCommitter> = committer.into();
+        let committer: Arc<dyn delta_kernel::committer::Committer> =
+            Arc::new(FileSystemCommitter::new());
+        let committer_handle: Handle<SharedCommitter> = committer.into();
 
         let txn = ok_or_panic(unsafe {
             create_table_builder_build_with_committer(
                 builder,
-                committer_handle,
+                committer_handle.shallow_copy(),
                 engine.shallow_copy(),
             )
         });
@@ -1604,7 +1620,46 @@ mod tests {
         assert_eq!(unsafe { version(snap.shallow_copy()) }, 0);
 
         unsafe { free_snapshot(snap) };
+        // The committer handle is NOT consumed by create_table_builder_build_with_committer --
+        // the caller owns it and must drop it explicitly.
+        unsafe { committer_handle.drop_handle() };
         unsafe { free_engine(engine) };
+        Ok(())
+    }
+
+    // Exercises the motivating property of `SharedCommitter`: a single committer handle can
+    // drive multiple independent transactions via `shallow_copy`. If either of the FFI entry
+    // points accidentally reverted to consume-on-use semantics, this test would fault at the
+    // second use.
+    #[tokio::test]
+    #[cfg_attr(miri, ignore)]
+    async fn test_shared_committer_handle_drives_multiple_tables(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let committer: Arc<dyn delta_kernel::committer::Committer> =
+            Arc::new(FileSystemCommitter::new());
+        let committer_handle: Handle<SharedCommitter> = committer.into();
+
+        for _ in 0..2 {
+            let tmp_dir = tempdir()?;
+            let (_table_path, engine, builder) = create_table_builder(
+                &tmp_dir,
+                vec![StructField::nullable("id", DataType::INTEGER)],
+            );
+            let txn = ok_or_panic(unsafe {
+                create_table_builder_build_with_committer(
+                    builder,
+                    committer_handle.shallow_copy(),
+                    engine.shallow_copy(),
+                )
+            });
+            let committed_version =
+                ok_or_panic(unsafe { create_table_commit(txn, engine.shallow_copy()) });
+            assert_eq!(committed_version, 0);
+            unsafe { free_engine(engine) };
+        }
+
+        // Committer handle was not consumed by either build_with_committer call -- still valid.
+        unsafe { committer_handle.drop_handle() };
         Ok(())
     }
 

--- a/kernel/examples/write-table/src/main.rs
+++ b/kernel/examples/write-table/src/main.rs
@@ -86,7 +86,7 @@ async fn try_main() -> DeltaResult<()> {
     let sample_data = create_sample_data(&snapshot.schema(), cli.num_rows)?;
 
     // Write sample data to the table
-    let committer = Box::new(FileSystemCommitter::new());
+    let committer = Arc::new(FileSystemCommitter::new());
     let mut txn = snapshot
         .transaction(committer, &engine)?
         .with_operation("INSERT".to_string())
@@ -197,7 +197,7 @@ async fn create_table(table_url: &Url, schema: &SchemaRef, engine: &dyn Engine) 
     // Use the create_table API to create the table
     let table_path = table_url.as_str();
     let _result = create_delta_table(table_path, schema.clone(), "write-table-example/1.0")
-        .build(engine, Box::new(FileSystemCommitter::new()))?
+        .build(engine, Arc::new(FileSystemCommitter::new()))?
         .commit(engine)?;
 
     println!("✓ Created Delta table with schema: {schema:#?}");

--- a/kernel/src/checkpoint/tests.rs
+++ b/kernel/src/checkpoint/tests.rs
@@ -819,7 +819,7 @@ async fn test_checkpoint_preserves_domain_metadata() -> DeltaResult<()> {
 
     let commit_domain_metadata = |domain: &str, value: &str| -> DeltaResult<()> {
         let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
-        let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
+        let txn = snapshot.transaction(Arc::new(FileSystemCommitter::new()), &engine)?;
         let result = txn
             .with_domain_metadata(domain.to_string(), value.to_string())
             .commit(&engine)?;
@@ -870,7 +870,7 @@ async fn test_checkpoint_skips_last_checkpoint_write_when_hint_version_is_newer(
         )])),
         "test",
     )
-    .build(&engine, Box::new(FileSystemCommitter::new()))?
+    .build(&engine, Arc::new(FileSystemCommitter::new()))?
     .commit(&engine)?;
 
     // Version 1

--- a/kernel/src/committer/filesystem.rs
+++ b/kernel/src/committer/filesystem.rs
@@ -119,7 +119,7 @@ mod tests {
             .build(&engine)
             .unwrap();
         // Try to commit a transaction with FileSystemCommitter
-        let committer = Box::new(FileSystemCommitter::new());
+        let committer = Arc::new(FileSystemCommitter::new());
         let err = snapshot
             .transaction(committer, &engine)
             .unwrap()

--- a/kernel/src/committer/filesystem.rs
+++ b/kernel/src/committer/filesystem.rs
@@ -99,6 +99,16 @@ mod tests {
     use crate::object_store::ObjectStoreExt as _;
     use crate::path::LogRoot;
 
+    // Lock in that `FileSystemCommitter` satisfies the `Send + Sync` bound required by
+    // `Committer`. Trivially true today (unit struct), but a future change that adds a
+    // non-Sync field would otherwise only fail at distant `Arc::new(...)` cast sites with
+    // a confusing error.
+    #[test]
+    fn file_system_committer_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<FileSystemCommitter>();
+    }
+
     #[tokio::test]
     async fn disallow_filesystem_committer_for_catalog_managed_tables() {
         let storage = Arc::new(InMemory::new());

--- a/kernel/src/committer/mod.rs
+++ b/kernel/src/committer/mod.rs
@@ -50,8 +50,11 @@ use crate::{DeltaResult, Engine, FilteredEngineData};
 ///
 /// Committers are passed as `Arc<dyn Committer>` so a single instance (e.g. a `UCCommitter`
 /// wrapping a shared catalog client) can be constructed once and reused across many transactions.
-/// The `Send + Sync` bound means implementations must be safe to call [`commit`] and [`publish`]
-/// concurrently from multiple threads on the same instance.
+/// The kernel itself invokes [`commit`] and [`publish`] at most once per transaction, but a
+/// connector may drive multiple transactions concurrently from the same shared instance. The
+/// `Send + Sync` bound therefore requires implementations to be safe to call [`commit`] and
+/// [`publish`] from multiple threads at once. Because both methods take `&self`, any mutable
+/// state must be protected by interior synchronization (mutex, atomic, etc.).
 ///
 /// [`commit`]: Committer::commit
 /// [`publish`]: Committer::publish

--- a/kernel/src/committer/mod.rs
+++ b/kernel/src/committer/mod.rs
@@ -46,14 +46,17 @@ use crate::{DeltaResult, Engine, FilteredEngineData};
 /// actions (as [`EngineData`] batches) to commit to the table at the given version
 /// ([`CommitMetadata::version`]).
 ///
+/// # Sharing and concurrency
+///
+/// Committers are passed as `Arc<dyn Committer>` so a single instance (e.g. a `UCCommitter`
+/// wrapping a shared catalog client) can be constructed once and reused across many transactions.
+/// The `Send + Sync` bound means implementations must be safe to call [`commit`] and [`publish`]
+/// concurrently from multiple threads on the same instance.
+///
 /// [`commit`]: Committer::commit
+/// [`publish`]: Committer::publish
 /// [`EngineData`]: crate::EngineData
-//
-// Note: While we could omit the Send bound, we keep it here for simplicity - so usage can be
-// Arc<dyn Committer> (instead of Arc<dyn Committer + Send>). If there is a strong case for a !Send
-// Committer then we can remove this bound and possibly just do an alias like CommitterRef =
-// Arc<dyn Committer + Send>.
-pub trait Committer: Send {
+pub trait Committer: Send + Sync {
     /// Commits actions to the table at the version specified in [`CommitMetadata`].
     ///
     /// Implementations must ensure that actions are committed atomically and either:

--- a/kernel/src/log_segment/domain_metadata_replay.rs
+++ b/kernel/src/log_segment/domain_metadata_replay.rs
@@ -97,7 +97,7 @@ mod tests {
             "test",
         )
         .with_table_properties([("delta.feature.domainMetadata", "supported")])
-        .build(&engine, Box::new(FileSystemCommitter::new()))
+        .build(&engine, Arc::new(FileSystemCommitter::new()))
         .unwrap()
         .with_domain_metadata("domainC".to_string(), "cfgC".to_string())
         .commit(&engine)
@@ -106,7 +106,7 @@ mod tests {
         // Commit 1: add domainA and domainB via an existing-table transaction.
         let snapshot = Snapshot::builder_for(url.clone()).build(&engine).unwrap();
         let _ = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), &engine)
+            .transaction(Arc::new(FileSystemCommitter::new()), &engine)
             .unwrap()
             .with_domain_metadata("domainA".to_string(), "cfgA".to_string())
             .with_domain_metadata("domainB".to_string(), "cfgB".to_string())

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -784,7 +784,7 @@ impl Snapshot {
     /// columns from domain metadata, which may have a performance cost.
     pub fn transaction(
         self: Arc<Self>,
-        committer: Box<dyn Committer>,
+        committer: Arc<dyn Committer>,
         engine: &dyn Engine,
     ) -> DeltaResult<Transaction> {
         Transaction::try_new_existing_table(self, committer, engine)
@@ -2418,7 +2418,7 @@ mod tests {
         }
 
         let _ = create_table_builder
-            .build(&engine, Box::new(FileSystemCommitter::new()))?
+            .build(&engine, Arc::new(FileSystemCommitter::new()))?
             .commit(&engine)?;
 
         let snapshot = Snapshot::builder_for(&table_path).build(&engine)?;
@@ -3466,7 +3466,7 @@ mod tests {
         let _ = builder
             .build(
                 &engine,
-                Box::new(crate::committer::FileSystemCommitter::new()),
+                Arc::new(crate::committer::FileSystemCommitter::new()),
             )
             .unwrap()
             .commit(&engine)

--- a/kernel/src/transaction/alter_table.rs
+++ b/kernel/src/transaction/alter_table.rs
@@ -7,7 +7,7 @@
 #![allow(unreachable_pub)]
 
 use std::marker::PhantomData;
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 
 use crate::committer::Committer;
 use crate::snapshot::SnapshotRef;
@@ -37,7 +37,7 @@ impl AlterTableTransaction {
     pub(crate) fn try_new_alter_table(
         read_snapshot: SnapshotRef,
         effective_table_config: TableConfiguration,
-        committer: Box<dyn Committer>,
+        committer: Arc<dyn Committer>,
     ) -> DeltaResult<Self> {
         let span = tracing::info_span!(
             "txn",

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -148,7 +148,7 @@ impl AlterTableTransactionBuilder<Modifying> {
     pub fn build(
         self,
         _engine: &dyn Engine,
-        committer: Box<dyn Committer>,
+        committer: Arc<dyn Committer>,
     ) -> DeltaResult<AlterTableTransaction> {
         let table_config = self.snapshot.table_configuration();
         // Rejects writes to tables kernel can't safely commit to: writer version out of

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -783,7 +783,7 @@ impl CreateTableTransactionBuilder {
     pub fn build(
         self,
         engine: &dyn Engine,
-        committer: Box<dyn Committer>,
+        committer: Arc<dyn Committer>,
     ) -> DeltaResult<CreateTableTransaction> {
         // Validate path
         let table_url = try_parse_uri(&self.path)?;

--- a/kernel/src/transaction/commit_info.rs
+++ b/kernel/src/transaction/commit_info.rs
@@ -248,7 +248,7 @@ mod tests {
     ) -> DeltaResult<(Arc<dyn Engine>, Transaction)> {
         let (engine, snapshot, _tempdir) = load_test_table("table-without-dv-small")?;
         let mut txn = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+            .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
             .with_operation("WRITE".to_string());
         if let Some((engine_commit_info_data, engine_commit_info_schema)) = engine_commit_info {
             txn = txn.with_commit_info(engine_commit_info_data, engine_commit_info_schema);

--- a/kernel/src/transaction/create_table.rs
+++ b/kernel/src/transaction/create_table.rs
@@ -20,7 +20,7 @@
 //!
 //! let result = create_table("/path/to/table", schema, "MyApp/1.0")
 //!     .with_table_properties([("myapp.version", "1.0")])
-//!     .build(engine, Box::new(FileSystemCommitter::new()))?
+//!     .build(engine, Arc::new(FileSystemCommitter::new()))?
 //!     .commit(engine)?;
 //! # Ok(())
 //! # }
@@ -32,7 +32,7 @@
 #![allow(unreachable_pub, dead_code)]
 
 use std::marker::PhantomData;
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 
 // Re-export the builder so callers can still access it from this module path.
 pub use super::builder::create_table::CreateTableTransactionBuilder;
@@ -76,7 +76,7 @@ use crate::DeltaResult;
 /// ])?);
 ///
 /// let result = create_table("/path/to/table", schema, "MyApp/1.0")
-///     .build(engine, Box::new(FileSystemCommitter::new()))?
+///     .build(engine, Arc::new(FileSystemCommitter::new()))?
 ///     .commit(engine)?;
 /// # Ok(())
 /// # }
@@ -114,7 +114,7 @@ pub type CreateTableTransaction = Transaction<CreateTable>;
 /// let engine = DefaultEngineBuilder::new(store_from_url(&url)?).build();
 ///
 /// let transaction = create_table("/tmp/my_table", schema, "MyApp/1.0")
-///     .build(&engine, Box::new(FileSystemCommitter::new()))?;
+///     .build(&engine, Arc::new(FileSystemCommitter::new()))?;
 ///
 /// // Commit the transaction to create the table
 /// transaction.commit(&engine)?;
@@ -140,7 +140,7 @@ impl CreateTableTransaction {
     pub(crate) fn try_new_create_table(
         effective_table_config: TableConfiguration,
         engine_info: String,
-        committer: Box<dyn Committer>,
+        committer: Arc<dyn Committer>,
         system_domain_metadata: Vec<DomainMetadata>,
         clustering_columns: Option<Vec<ColumnName>>,
     ) -> DeltaResult<Self> {

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -229,7 +229,7 @@ pub struct Transaction<S = ExistingTable> {
     should_emit_protocol: bool,
     // Whether to emit a Metadata action. True for CREATE TABLE and ALTER TABLE, false otherwise.
     should_emit_metadata: bool,
-    committer: Box<dyn Committer>,
+    committer: Arc<dyn Committer>,
     operation: Option<String>,
     engine_info: Option<String>,
     engine_commit_info: Option<(Box<dyn EngineData>, SchemaRef)>,
@@ -1646,7 +1646,7 @@ mod tests {
         engine: &dyn Engine,
     ) -> DeltaResult<Transaction> {
         Ok(snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), engine)?
+            .transaction(Arc::new(FileSystemCommitter::new()), engine)?
             .with_operation("DELETE".to_string())
             .with_engine_info("test_engine"))
     }
@@ -1663,7 +1663,7 @@ mod tests {
             .build(&engine)
             .unwrap();
         let txn = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+            .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
             .with_engine_info("default engine");
 
         let schema = txn.add_files_schema();
@@ -1701,7 +1701,7 @@ mod tests {
             .build(&engine)
             .unwrap();
         let txn = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+            .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
             .with_engine_info("default engine");
         let write_context = txn.unpartitioned_write_context().unwrap();
 
@@ -1732,7 +1732,7 @@ mod tests {
         let url = url::Url::from_directory_path(path).unwrap();
         let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
         let txn = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+            .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
             .with_engine_info("default engine");
 
         let write_context = txn.partitioned_write_context(HashMap::from([(
@@ -1781,7 +1781,7 @@ mod tests {
         let snapshot = Snapshot::builder_for(url).build(&engine)?;
         let txn = snapshot
             .clone()
-            .transaction(Box::new(FileSystemCommitter::new()), &engine)?;
+            .transaction(Arc::new(FileSystemCommitter::new()), &engine)?;
         let partition_cols = txn.logical_partition_columns();
         assert!(
             !partition_cols.is_empty(),
@@ -1878,7 +1878,7 @@ mod tests {
         let url = url::Url::from_directory_path(path).unwrap();
         let snapshot = Snapshot::builder_for(url).at_version(1).build(&engine)?;
 
-        let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
+        let txn = snapshot.transaction(Arc::new(FileSystemCommitter::new()), &engine)?;
         let write_context = txn.partitioned_write_context(HashMap::from([(
             "letter".to_string(),
             Scalar::String("a".into()),
@@ -1917,7 +1917,7 @@ mod tests {
         let path = std::fs::canonicalize(PathBuf::from(table_path)).unwrap();
         let url = url::Url::from_directory_path(path).unwrap();
         let snapshot = Snapshot::builder_for(url).build(&engine)?;
-        let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
+        let txn = snapshot.transaction(Arc::new(FileSystemCommitter::new()), &engine)?;
         let result = if call_partitioned {
             txn.partitioned_write_context(HashMap::from([("x".to_string(), Scalar::Integer(1))]))
         } else {
@@ -2004,7 +2004,7 @@ mod tests {
     fn create_existing_table_txn(
     ) -> DeltaResult<(Arc<dyn Engine>, Transaction, Option<tempfile::TempDir>)> {
         let (engine, snapshot, tempdir) = load_test_table("table-without-dv-small")?;
-        let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?;
+        let txn = snapshot.transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?;
         Ok((engine, txn, tempdir))
     }
 
@@ -2079,7 +2079,7 @@ mod tests {
             schema,
             "test_engine",
         )
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?;
         // CreateTableTransaction does not expose with_blind_append() (compile-time
         // prevention per #1768). Directly set the field to test the runtime check.
         txn.is_blind_append = true;
@@ -2142,7 +2142,7 @@ mod tests {
     #[test]
     fn test_commit_io_error_returns_retryable_transaction() -> DeltaResult<()> {
         let (engine, snapshot, _tempdir) = load_test_table("table-without-dv-small")?;
-        let mut txn = snapshot.transaction(Box::new(IoErrorCommitter), engine.as_ref())?;
+        let mut txn = snapshot.transaction(Arc::new(IoErrorCommitter), engine.as_ref())?;
         add_dummy_file(&mut txn);
         let result = txn.commit(engine.as_ref())?;
         assert!(
@@ -2421,7 +2421,7 @@ mod tests {
     fn test_stats_validation_allows_all_null_clustering_column() {
         let (engine, snapshot) = setup_non_dv_table();
         let txn = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), &engine)
+            .transaction(Arc::new(FileSystemCommitter::new()), &engine)
             .unwrap()
             .with_operation("WRITE".to_string())
             .with_clustering_columns_for_test(vec![ColumnName::new(["value"])]);
@@ -2440,7 +2440,7 @@ mod tests {
     fn test_stats_validation_when_clustering_cols_missing_stats() {
         let (engine, snapshot) = setup_non_dv_table();
         let txn = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), &engine)
+            .transaction(Arc::new(FileSystemCommitter::new()), &engine)
             .unwrap()
             .with_operation("WRITE".to_string())
             // Enable clustering columns for this test
@@ -2468,7 +2468,7 @@ mod tests {
     fn test_stats_validation_when_clustering_stats_present() {
         let (engine, snapshot) = setup_non_dv_table();
         let txn = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), &engine)
+            .transaction(Arc::new(FileSystemCommitter::new()), &engine)
             .unwrap()
             .with_operation("WRITE".to_string())
             // Enable clustering columns for this test
@@ -2490,7 +2490,7 @@ mod tests {
     fn test_stats_validation_skipped_without_clustering() {
         let (engine, snapshot) = setup_non_dv_table();
         let txn = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), &engine)
+            .transaction(Arc::new(FileSystemCommitter::new()), &engine)
             .unwrap()
             .with_operation("WRITE".to_string());
         // No clustering columns set (default)
@@ -2528,7 +2528,7 @@ mod tests {
         let snapshot = Snapshot::builder_for(table_root).build(&engine).unwrap();
 
         // Try to commit with a catalog committer to a non-catalog-managed table
-        let committer = Box::new(MockCatalogCommitter);
+        let committer = Arc::new(MockCatalogCommitter);
         let err = snapshot
             .transaction(committer, &engine)
             .unwrap()
@@ -2549,7 +2549,7 @@ mod tests {
         let schema = Arc::new(crate::schema::StructType::new_unchecked(vec![
             crate::schema::StructField::new("id", crate::schema::DataType::INTEGER, true),
         ]));
-        let committer = Box::new(MockCatalogCommitter);
+        let committer = Arc::new(MockCatalogCommitter);
         let err = create_table("memory:///", schema, "test-engine")
             .build(&engine, committer)
             .unwrap()
@@ -2658,7 +2658,7 @@ mod tests {
         assert_eq!(prev_ict, Some(future_ict));
 
         let (committer, captured_ts) = CapturingCommitter::new();
-        let mut txn = snapshot.transaction(Box::new(committer), &engine)?;
+        let mut txn = snapshot.transaction(Arc::new(committer), &engine)?;
         add_dummy_file(&mut txn);
 
         let result = txn.commit(&engine)?;

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -50,7 +50,7 @@ impl Transaction {
     /// a snapshot.
     pub(crate) fn try_new_existing_table(
         snapshot: impl Into<SnapshotRef>,
-        committer: Box<dyn Committer>,
+        committer: Arc<dyn Committer>,
         engine: &dyn Engine,
     ) -> DeltaResult<Self> {
         let read_snapshot = snapshot.into();
@@ -152,7 +152,7 @@ impl Transaction {
     /// # fn example(engine: Arc<dyn Engine>, table_url: url::Url) -> delta_kernel::DeltaResult<()> {
     /// // Create a snapshot and transaction
     /// let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
-    /// let mut txn = snapshot.clone().transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?;
+    /// let mut txn = snapshot.clone().transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?;
     ///
     /// // Get file metadata from a scan
     /// let scan = snapshot.scan_builder().build()?;
@@ -225,7 +225,7 @@ impl Transaction {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// let mut txn = snapshot.clone().transaction(Box::new(FileSystemCommitter::new()))?
+    /// let mut txn = snapshot.clone().transaction(Arc::new(FileSystemCommitter::new()))?
     ///     .with_operation("UPDATE".to_string());
     ///
     /// let scan = snapshot.scan_builder().build()?;

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -225,7 +225,7 @@ impl Transaction {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// let mut txn = snapshot.clone().transaction(Arc::new(FileSystemCommitter::new()))?
+    /// let mut txn = snapshot.clone().transaction(Arc::new(FileSystemCommitter::new()), engine)?
     ///     .with_operation("UPDATE".to_string());
     ///
     /// let scan = snapshot.scan_builder().build()?;

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -726,7 +726,7 @@ pub(crate) mod test_utils {
 
         let txn = create_table("memory:///test_table", schema, "DefaultEngine")
             .with_table_properties([("delta.columnMapping.mode", mode_str)])
-            .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
+            .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?;
         Ok((engine, txn))
     }
 

--- a/kernel/tests/integration/common/write_utils.rs
+++ b/kernel/tests/integration/common/write_utils.rs
@@ -175,7 +175,7 @@ pub async fn write_data_and_check_result_and_stats(
     expected_since_commit: u64,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
-    let committer = Box::new(FileSystemCommitter::new());
+    let committer = Arc::new(FileSystemCommitter::new());
     let mut txn = snapshot
         .transaction(committer, engine.as_ref())?
         .with_data_change(true);
@@ -361,7 +361,7 @@ pub async fn create_dv_table_with_files(
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
     let mut txn = snapshot
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_engine_info("test engine")
         .with_operation("WRITE".to_string())
         .with_data_change(true);

--- a/kernel/tests/integration/create_table/clustering.rs
+++ b/kernel/tests/integration/create_table/clustering.rs
@@ -71,7 +71,7 @@ async fn test_create_clustered_table(#[case] col_paths: Vec<Vec<&str>>) -> Delta
         .with_data_layout(DataLayout::Clustered {
             columns: input_cols,
         })
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?;
 
     let stats_cols = txn.stats_columns();
     for col in &expected_cols {
@@ -118,7 +118,7 @@ async fn test_clustering_with_explicit_feature_signal_no_duplicates() -> DeltaRe
     let _ = create_table(&table_path, schema, "Test/1.0")
         .with_table_properties([("delta.feature.domainMetadata", "supported")])
         .with_data_layout(DataLayout::clustered(["id"]))
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     // Read back using kernel APIs and verify no duplicate features
@@ -160,7 +160,7 @@ async fn test_clustering_stats_columns_within_limit() -> DeltaResult<()> {
     // Create clustered table on col5
     let txn = create_table(&table_path, schema, "Test/1.0")
         .with_data_layout(DataLayout::clustered(["col5"]))
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?;
 
     // Verify stats_columns includes the clustering column
     let stats_cols = txn.stats_columns();
@@ -185,7 +185,7 @@ async fn test_clustering_stats_columns_beyond_limit() -> DeltaResult<()> {
     // Create clustered table on col35 (position > 32)
     let txn = create_table(&table_path, schema, "Test/1.0")
         .with_data_layout(DataLayout::clustered(["col35"]))
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?;
 
     // Verify stats_columns includes the clustering column even beyond limit
     let stats_cols = txn.stats_columns();
@@ -221,7 +221,7 @@ async fn test_clustering_column_error(
         .with_data_layout(DataLayout::Clustered {
             columns: vec![ColumnName::new(col_path.iter().copied())],
         })
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()));
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()));
 
     assert_result_error_with_message(result, expected_error);
 

--- a/kernel/tests/integration/create_table/column_mapping.rs
+++ b/kernel/tests/integration/create_table/column_mapping.rs
@@ -232,7 +232,7 @@ fn test_column_mapping_feature_only_without_mode() -> DeltaResult<()> {
     // Create table with ONLY the feature flag, no delta.columnMapping.mode
     let _ = create_table(&table_path, schema, "Test/1.0")
         .with_table_properties([("delta.feature.columnMapping", "supported")])
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
@@ -263,7 +263,7 @@ fn test_column_mapping_invalid_mode_rejected() {
     // Try to create table with invalid column mapping mode
     let result = create_table(&table_path, schema, "Test/1.0")
         .with_table_properties([("delta.columnMapping.mode", "invalid")])
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()));
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()));
 
     assert!(result.is_err());
     assert!(result
@@ -290,7 +290,7 @@ fn test_create_clustered_table_with_column_mapping(
     let _ = create_table(&table_path, schema, "Test/1.0")
         .with_table_properties([("delta.columnMapping.mode", "name")])
         .with_data_layout(DataLayout::clustered(clustering_cols.iter().copied()))
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     // Load snapshot (validates column mapping annotations on read)
@@ -511,7 +511,7 @@ fn test_create_clustered_table_nested_with_column_mapping(
         .with_data_layout(DataLayout::Clustered {
             columns: expected_cols.clone(),
         })
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
@@ -571,7 +571,7 @@ fn test_partitioned_table_stores_logical_column_names_with_column_mapping(
     let _ = create_table(&table_path, schema, "Test/1.0")
         .with_table_properties([("delta.columnMapping.mode", "name")])
         .with_data_layout(DataLayout::partitioned(partition_cols.iter().copied()))
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     let table_url = delta_kernel::try_parse_uri(&table_path)?;

--- a/kernel/tests/integration/create_table/ctas.rs
+++ b/kernel/tests/integration/create_table/ctas.rs
@@ -221,7 +221,7 @@ async fn run_ctas_test(
             builder = builder.with_data_layout(DataLayout::clustered(["row_number"]));
         }
         let result = builder
-            .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+            .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
             .commit(engine.as_ref())?;
         match result {
             CommitResult::CommittedTransaction(c) => c
@@ -259,7 +259,7 @@ async fn run_ctas_test(
     if tgt_clustered {
         tgt_builder = tgt_builder.with_data_layout(DataLayout::clustered(["row_number"]));
     }
-    let mut tgt_txn = tgt_builder.build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
+    let mut tgt_txn = tgt_builder.build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?;
 
     let write_context = Arc::new(tgt_txn.unpartitioned_write_context()?);
     let add_meta = engine

--- a/kernel/tests/integration/create_table/ict.rs
+++ b/kernel/tests/integration/create_table/ict.rs
@@ -4,6 +4,7 @@
 //! `inCommitTimestamp` feature to the protocol (writer-only) and that the snapshot exposes a
 //! valid `inCommitTimestamp` value.
 
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use delta_kernel::committer::FileSystemCommitter;
@@ -83,7 +84,7 @@ fn test_create_table_ict(
 
     let committed = create_table(&table_path, super::simple_schema()?, "Test/1.0")
         .with_table_properties(properties.iter().copied())
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?
         .unwrap_committed();
 

--- a/kernel/tests/integration/create_table/mod.rs
+++ b/kernel/tests/integration/create_table/mod.rs
@@ -58,7 +58,7 @@ async fn test_create_simple_table() -> DeltaResult<()> {
 
     // Create table using new API
     let _ = create_table(&table_path, schema.clone(), "DeltaKernel-RS/0.17.0")
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     // Verify table was created
@@ -109,7 +109,7 @@ async fn test_create_table_with_user_domain_metadata() -> DeltaResult<()> {
     // Create table with domainMetadata feature enabled
     let txn = create_table(&table_path, schema, "Test/1.0")
         .with_table_properties([("delta.feature.domainMetadata", "supported")])
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?;
 
     // Add user domain metadata during table creation
     let domain = "app.settings";
@@ -166,12 +166,12 @@ async fn test_create_table_already_exists() -> DeltaResult<()> {
 
     // Create table first time
     let _ = create_table(&table_path, schema.clone(), "UserManagementService/1.2.0")
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     // Try to create again - should fail at build time (table already exists)
     let result = create_table(&table_path, schema.clone(), "UserManagementService/1.2.0")
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()));
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()));
 
     assert_result_error_with_message(result, "already exists");
 
@@ -187,7 +187,7 @@ async fn test_create_table_empty_schema_not_supported() -> DeltaResult<()> {
 
     // Try to create table with empty schema - should fail at build time
     let result = create_table(&table_path, schema, "InvalidApp/0.1.0")
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()));
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()));
 
     assert_result_error_with_message(result, "cannot be empty");
 
@@ -228,7 +228,7 @@ fn test_create_table_with_non_null_columns_auto_enables_invariants(
     let (_temp_dir, table_path, engine) = test_table_setup()?;
 
     let _ = create_table(&table_path, schema, "Test/1.0")
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
@@ -264,7 +264,7 @@ async fn test_create_table_with_invariants_feature_signal_allowed() -> DeltaResu
 
     let _ = create_table(&table_path, schema, "Test/1.0")
         .with_table_properties([("delta.feature.invariants", "supported")])
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
@@ -302,9 +302,8 @@ async fn test_create_table_rejects_delta_invariants_metadata() -> DeltaResult<()
         MetadataValue::String(r#"{"expression": {"expression": "x > 0"}}"#.to_string()),
     );
     let schema = Arc::new(StructType::try_new(vec![field])?);
-
-    let result = create_table(&table_path, schema, "Test/1.0")
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()));
+    let result = create_table(&table_path, schema, "InvalidApp/0.1.0")
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()));
 
     assert_result_error_with_message(result, "delta.invariants");
 
@@ -325,7 +324,7 @@ async fn test_create_table_log_actions() -> DeltaResult<()> {
 
     // Create table
     let _ = create_table(&table_path, schema, engine_info)
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     // Read the actual Delta log file
@@ -444,7 +443,7 @@ fn create_test_create_table_txn() -> DeltaResult<(
         .expect("valid schema"),
     );
     let txn = create_table(&table_path, schema, "test_engine")
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?;
     Ok((engine, txn, tempdir))
 }
 
@@ -488,7 +487,7 @@ fn test_create_table_with_feature_signal(
     let property_key = format!("delta.feature.{feature_name}");
     let _ = create_table(&table_path, simple_schema()?, "Test/1.0")
         .with_table_properties([(property_key.as_str(), "supported")])
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
@@ -537,7 +536,7 @@ fn test_create_table_with_checkpoint_stats_properties(
             ("delta.checkpoint.writeStatsAsJson", json_val.as_str()),
             ("delta.checkpoint.writeStatsAsStruct", struct_val.as_str()),
         ])
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
@@ -570,7 +569,7 @@ fn test_create_table_with_enablement_property(
 
     let _ = create_table(&table_path, simple_schema()?, "Test/1.0")
         .with_table_properties([(property, value.as_str())])
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
@@ -622,7 +621,7 @@ fn test_create_table_special_char_column_name(#[case] cm_enabled: bool) -> Delta
     if cm_enabled {
         builder = builder.with_table_properties([("delta.columnMapping.mode", "name")]);
     }
-    let result = builder.build(engine.as_ref(), Box::new(FileSystemCommitter::new()));
+    let result = builder.build(engine.as_ref(), Arc::new(FileSystemCommitter::new()));
 
     if cm_enabled {
         let txn = result?;

--- a/kernel/tests/integration/create_table/partitioned.rs
+++ b/kernel/tests/integration/create_table/partitioned.rs
@@ -2,6 +2,8 @@
 //!
 //! TODO(#2201): Add end-to-end tests for insert + scan + checkpoint on partitioned tables.
 
+use std::sync::Arc;
+
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::snapshot::Snapshot;
 use delta_kernel::table_features::TableFeature;
@@ -22,7 +24,7 @@ fn test_create_table_partitioned_basic(#[case] partition_col: &str) -> DeltaResu
 
     let _ = create_table(&table_path, schema, "Test/1.0")
         .with_data_layout(DataLayout::partitioned([partition_col]))
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
@@ -64,7 +66,7 @@ fn test_create_table_with_materialize_partition_columns_partitioned_and_not(
         builder = builder.with_data_layout(DataLayout::partitioned(["date"]));
     }
     let _ = builder
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;

--- a/kernel/tests/integration/create_table/row_tracking.rs
+++ b/kernel/tests/integration/create_table/row_tracking.rs
@@ -82,7 +82,7 @@ async fn test_create_table_with_row_tracking(
 
     let mut txn = create_table(&table_path, schema.clone(), "Test/1.0")
         .with_table_properties([(key, value)])
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?;
 
     if with_data {
         // Write one parquet file with 5 rows
@@ -198,7 +198,7 @@ async fn test_create_table_with_multiple_files_and_row_tracking() -> DeltaResult
     let schema = super::simple_schema()?;
     let mut txn = create_table(&table_path, schema.clone(), "Test/1.0")
         .with_table_properties([("delta.enableRowTracking", "true")])
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?;
 
     let arrow_schema: Arc<delta_kernel::arrow::datatypes::Schema> =
         Arc::new(schema.as_ref().try_into_arrow()?);
@@ -271,7 +271,7 @@ fn test_create_table_with_row_tracking_and_clustering() -> DeltaResult<()> {
     let committed = create_table(&table_path, super::simple_schema()?, "Test/1.0")
         .with_table_properties([("delta.enableRowTracking", "true")])
         .with_data_layout(DataLayout::clustered(["id"]))
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?
         .unwrap_committed();
 
@@ -323,7 +323,7 @@ async fn test_create_table_with_row_tracking_and_clustering_and_data() -> DeltaR
     let mut txn = create_table(&table_path, schema.clone(), "Test/1.0")
         .with_table_properties([("delta.enableRowTracking", "true")])
         .with_data_layout(DataLayout::clustered(["id"]))
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?;
 
     let arrow_schema = Arc::new(schema.as_ref().try_into_arrow()?);
     let batch = RecordBatch::try_new(
@@ -408,7 +408,7 @@ async fn test_feature_signal_create_then_append_assigns_correct_base_row_id() ->
     // Create empty table with feature signal only (no enablement property)
     let _ = create_table(&table_path, super::simple_schema()?, "Test/1.0")
         .with_table_properties([("delta.feature.rowTracking", "supported")])
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     let table_url = Url::from_directory_path(&table_path).expect("valid path");

--- a/kernel/tests/integration/create_table/timestamp_ntz.rs
+++ b/kernel/tests/integration/create_table/timestamp_ntz.rs
@@ -49,7 +49,7 @@ fn test_create_table_with_timestamp_ntz(
 
     let _ = create_table(&table_path, schema.clone(), "Test/1.0")
         .with_table_properties(cm_properties(cm_mode))
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
@@ -93,7 +93,7 @@ fn test_create_table_no_timestamp_ntz_no_feature() -> DeltaResult<()> {
     ])?);
 
     let _ = create_table(&table_path, schema, "Test/1.0")
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
@@ -120,7 +120,7 @@ fn test_create_table_timestamp_ntz_and_variant() -> DeltaResult<()> {
     ]));
 
     let _ = create_table(&table_path, schema, "Test/1.0")
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     let table_url = delta_kernel::try_parse_uri(&table_path)?;

--- a/kernel/tests/integration/create_table/variant.rs
+++ b/kernel/tests/integration/create_table/variant.rs
@@ -54,7 +54,7 @@ fn test_create_table_with_variant(
 
     let _ = create_table(&table_path, schema.clone(), "Test/1.0")
         .with_table_properties(cm_properties(cm_mode))
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
@@ -100,7 +100,7 @@ fn test_create_table_no_variant_no_feature() -> DeltaResult<()> {
     ])?);
 
     let _ = create_table(&table_path, schema, "Test/1.0")
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
@@ -122,7 +122,7 @@ fn test_create_table_variant_clustering_rejected() -> DeltaResult<()> {
 
     let result = create_table(&table_path, top_level_variant_schema(), "Test/1.0")
         .with_data_layout(DataLayout::clustered(["col"]))
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()));
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()));
 
     assert_result_error_with_message(result, "unsupported type");
 

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -31,8 +31,8 @@ fn simple_schema() -> SchemaRef {
     )
 }
 
-fn committer() -> Box<FileSystemCommitter> {
-    Box::new(FileSystemCommitter::new())
+fn committer() -> Arc<FileSystemCommitter> {
+    Arc::new(FileSystemCommitter::new())
 }
 
 fn max_column_id(snap: &Snapshot) -> i64 {

--- a/kernel/tests/integration/features/clustering_e2e.rs
+++ b/kernel/tests/integration/features/clustering_e2e.rs
@@ -47,7 +47,7 @@ async fn test_clustered_table_write_and_checkpoint(
         .with_data_layout(DataLayout::Clustered {
             columns: expected_clustering.clone(),
         })
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     let snapshot = if use_fresh_snapshot {
@@ -163,7 +163,7 @@ async fn test_clustered_table_write_all_null_clustering_column() {
                 ColumnName::new(["region_id"]),
             ],
         })
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))
         .unwrap()
         .commit(engine.as_ref())
         .unwrap();

--- a/kernel/tests/integration/features/dv.rs
+++ b/kernel/tests/integration/features/dv.rs
@@ -91,7 +91,7 @@ fn get_write_context(
     engine: &dyn delta_kernel::Engine,
 ) -> Result<delta_kernel::transaction::WriteContext, Box<dyn std::error::Error>> {
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine)?;
-    let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), engine)?;
+    let txn = snapshot.transaction(Arc::new(FileSystemCommitter::new()), engine)?;
     Ok(txn.unpartitioned_write_context()?)
 }
 
@@ -128,7 +128,7 @@ fn create_dv_update_transaction(
 ) -> Result<delta_kernel::transaction::Transaction, Box<dyn std::error::Error>> {
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine)?;
     Ok(snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), engine)?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine)?
         .with_engine_info("test engine")
         .with_operation("DELETE".to_string()))
 }
@@ -250,7 +250,7 @@ async fn test_write_deletion_vectors_end_to_end() -> Result<(), Box<dyn std::err
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
     let mut txn = snapshot
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_engine_info("test engine")
         .with_operation("WRITE".to_string());
 

--- a/kernel/tests/integration/features/maintenance_ops.rs
+++ b/kernel/tests/integration/features/maintenance_ops.rs
@@ -28,7 +28,7 @@ async fn test_checkpoint_and_checksum_return_updated_snapshots(
         builder = builder.with_table_properties([("delta.feature.v2Checkpoint", "supported")]);
     }
     let committed = builder
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?
         .unwrap_committed();
     let snapshot = committed.post_commit_snapshot().unwrap();
@@ -88,7 +88,7 @@ async fn test_checkpoint_already_exists(#[case] v2_checkpoint: bool) -> DeltaRes
         builder = builder.with_table_properties([("delta.feature.v2Checkpoint", "supported")]);
     }
     let committed = builder
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?
         .unwrap_committed();
     let snapshot = committed.post_commit_snapshot().unwrap();

--- a/kernel/tests/integration/features/row_tracking.rs
+++ b/kernel/tests/integration/features/row_tracking.rs
@@ -59,7 +59,7 @@ async fn write_data_to_table(
     data: Vec<ArrowEngineData>,
 ) -> DeltaResult<CommitResult> {
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
-    let committer = Box::new(FileSystemCommitter::new());
+    let committer = Arc::new(FileSystemCommitter::new());
     let mut txn = snapshot
         .transaction(committer, engine.as_ref())?
         .with_data_change(true);
@@ -580,7 +580,7 @@ async fn test_row_tracking_without_adds() -> DeltaResult<()> {
     let (_schema, table_url, engine, store) =
         setup_number_table(&tmp_test_dir, "test_consecutive_commits").await?;
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
-    let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?;
+    let txn = snapshot.transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?;
 
     // Commit without adding any add files
     assert!(txn.commit(engine.as_ref())?.is_committed());
@@ -619,11 +619,11 @@ async fn test_row_tracking_parallel_transactions_conflict() -> DeltaResult<()> {
 
     // Create two transactions from the same snapshot (simulating parallel transactions)
     let mut txn1 = snapshot1
-        .transaction(Box::new(FileSystemCommitter::new()), engine1.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine1.as_ref())?
         .with_engine_info("transaction 1")
         .with_data_change(true);
     let mut txn2 = snapshot2
-        .transaction(Box::new(FileSystemCommitter::new()), engine2.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine2.as_ref())?
         .with_engine_info("transaction 2")
         .with_data_change(true);
 

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -49,7 +49,7 @@ async fn test_get_file_stats_no_crc() -> DeltaResult<()> {
     ])?);
 
     let _ = create_table(&table_path, schema, "Test/1.0")
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
@@ -80,7 +80,7 @@ async fn test_get_file_stats_crc_not_at_snapshot_version() -> DeltaResult<()> {
 
     // ===== WHEN =====
     // Empty commit to advance to version 1 (no new CRC file written)
-    let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?;
+    let txn = snapshot.transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?;
     let _ = txn.commit(engine.as_ref())?;
 
     // ===== THEN =====
@@ -145,7 +145,7 @@ async fn test_get_current_crc_if_loaded_returns_none_when_no_crc() -> DeltaResul
     )])?);
 
     let _ = create_table(&table_path, schema, "Test/1.0")
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
@@ -172,7 +172,7 @@ fn create_table_and_commit(
     )])?);
     let txn = create_table(table_path, schema, "test_engine")
         .with_data_layout(DataLayout::clustered(["id"]))
-        .build(engine, Box::new(FileSystemCommitter::new()))?
+        .build(engine, Arc::new(FileSystemCommitter::new()))?
         .with_domain_metadata("zip".to_string(), "zap0".to_string());
 
     Ok(txn.commit(engine)?.unwrap_committed())
@@ -227,7 +227,7 @@ async fn test_post_commit_crc_chains_only_if_read_snapshot_has_crc(
     );
 
     let committed = read_snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_operation("WRITE".to_string())
         .with_domain_metadata("zip".to_string(), "zap1".to_string())
         .commit(engine.as_ref())?
@@ -309,7 +309,7 @@ async fn test_post_commit_crc_tracks_file_stats_across_inserts() -> DeltaResult<
     let scan = snapshot_v2.clone().scan_builder().build()?;
     let mut txn = snapshot_v2
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_operation("DELETE".to_string())
         .with_data_change(true);
     for sm in scan.scan_metadata(engine.as_ref())? {
@@ -344,7 +344,7 @@ async fn test_post_commit_crc_tracks_domain_metadata_changes() -> DeltaResult<()
     // ===== WHEN: update zip -> zap1, add foo -> bar =====
     let txn = snapshot_v0
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_operation("WRITE".to_string())
         .with_domain_metadata("zip".to_string(), "zap1".to_string()) // <-- set to zap1
         .with_domain_metadata("foo".to_string(), "bar".to_string()); // <-- add foo
@@ -360,7 +360,7 @@ async fn test_post_commit_crc_tracks_domain_metadata_changes() -> DeltaResult<()
     // ===== WHEN: remove zip, keep foo =====
     let txn = snapshot_v1
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_operation("WRITE".to_string())
         .with_domain_metadata_removed("zip".to_string()); // <-- remove zip
     let committed = txn.commit(engine.as_ref())?.unwrap_committed();
@@ -393,7 +393,7 @@ async fn test_post_commit_crc_non_incremental_op_makes_file_stats_indeterminate(
     // ===== WHEN: Commit a non-incremental operation (ANALYZE STATS) =====
     let committed = snapshot_v1
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_operation("ANALYZE STATS".to_string())
         .commit(engine.as_ref())?
         .unwrap_committed();
@@ -644,7 +644,7 @@ async fn test_write_checksum_with_no_dms_writes_empty_list(
         builder = builder.with_table_properties(properties);
     }
     let committed = builder
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?
         .unwrap_committed();
 
@@ -691,7 +691,7 @@ async fn test_get_domain_metadata_with_crc_skips_log_replay() -> DeltaResult<()>
     // v1: update zip -> zap1, add foo -> bar
     let committed = snapshot_v0
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_operation("WRITE".to_string())
         .with_domain_metadata("zip".to_string(), "zap1".to_string())
         .with_domain_metadata("foo".to_string(), "bar".to_string())
@@ -781,7 +781,7 @@ async fn test_set_transaction_crc_tracking_and_fast_path() -> DeltaResult<()> {
     // -- v1: commit with my-app=1 --
     let committed = snapshot_v0
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_operation("WRITE".to_string())
         .with_transaction_id("my-app".to_string(), 1)
         .commit(engine.as_ref())?
@@ -826,7 +826,7 @@ async fn test_set_transaction_crc_tracking_and_fast_path() -> DeltaResult<()> {
     // -- v2: commit with my-app=2 (upsert) + other-app=1 (new) --
     let committed = snapshot_v1
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_operation("WRITE".to_string())
         .with_transaction_id("my-app".to_string(), 2)
         .with_transaction_id("other-app".to_string(), 1)
@@ -899,14 +899,14 @@ async fn test_set_txn_expiration_via_crc_fast_path(
         builder = builder.with_table_properties([("delta.setTransactionRetentionDuration", r)]);
     }
     let committed = builder
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?
         .unwrap_committed();
 
     // v1: commit a set transaction for "my-app" (lastUpdated = now)
     let snapshot_v0 = committed.post_commit_snapshot().unwrap().clone();
     let committed = snapshot_v0
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_operation("WRITE".to_string())
         .with_transaction_id("my-app".to_string(), 1)
         .commit(engine.as_ref())?
@@ -949,7 +949,7 @@ async fn test_set_txn_null_last_updated_never_expires_via_log_replay() -> DeltaR
             "delta.setTransactionRetentionDuration",
             "interval 0 seconds",
         )])
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?
         .unwrap_committed();
 
@@ -1070,7 +1070,7 @@ async fn test_file_histogram_tracks_adds_and_removes_across_bins() -> DeltaResul
 
     // ===== v0: empty table =====
     let committed = create_table(&table_path, schema, "test_engine")
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?
         .unwrap_committed();
     let snapshot = committed.post_commit_snapshot().unwrap();
@@ -1144,7 +1144,7 @@ async fn test_file_histogram_tracks_adds_and_removes_across_bins() -> DeltaResul
     let scan = snapshot.clone().scan_builder().build()?;
     let mut txn = snapshot
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_operation("DELETE".to_string())
         .with_data_change(true);
     for sm in scan.scan_metadata(engine.as_ref())? {
@@ -1287,7 +1287,7 @@ async fn test_file_histogram_with_bin_type_and_operation_type(
         committed.post_commit_snapshot().unwrap().clone()
     } else {
         let committed = fresh_v1
-            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+            .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
             .with_operation("ANALYZE STATS".to_string())
             .commit(engine.as_ref())?
             .unwrap_committed();

--- a/kernel/tests/integration/log/v2_checkpoints.rs
+++ b/kernel/tests/integration/log/v2_checkpoints.rs
@@ -267,7 +267,7 @@ async fn test_v2_checkpoint_parquet_write() -> DeltaResult<()> {
     )])?);
     let _ = create_table(&table_path, schema.clone(), "Test/1.0")
         .with_table_properties([("delta.feature.v2Checkpoint", "supported")])
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     // Commit an add action via the transaction API so the checkpoint has action batches

--- a/kernel/tests/integration/log/v2_checkpoints.rs
+++ b/kernel/tests/integration/log/v2_checkpoints.rs
@@ -361,7 +361,7 @@ async fn test_v2_checkpoint_with_sidecars() -> DeltaResult<()> {
     .unwrap_post_commit_snapshot();
 
     let post_ckpt_snapshot = post_ckpt_snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_domain_metadata("app.settings".to_string(), r#"{"version":3}"#.to_string())
         .commit(engine.as_ref())?
         .unwrap_post_commit_snapshot();
@@ -777,7 +777,7 @@ async fn test_checkpoint_spec_rejected(
         builder = builder.with_table_properties([("delta.feature.v2Checkpoint", "supported")]);
     }
     let _ = builder
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
@@ -808,7 +808,7 @@ async fn test_v2_sidecar_checkpoint_with_no_file_actions() -> DeltaResult<()> {
     // v2 table, no data commits -> only protocol + metadata at version 0.
     let _ = create_table(&table_path, schema, "Test/1.0")
         .with_table_properties([("delta.feature.v2Checkpoint", "supported")])
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
@@ -914,7 +914,7 @@ async fn v2_table_with_domain_metadata_and_txn<E: TaskExecutor>(
             ("delta.feature.v2Checkpoint", "supported"),
             ("delta.feature.domainMetadata", "supported"),
         ])
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     // Insert 8 files (one per commit) -> ids 1..=8
@@ -931,7 +931,7 @@ async fn v2_table_with_domain_metadata_and_txn<E: TaskExecutor>(
     // Domain metadata commit (no data) -- exercises the empty-file-batch skip path in the
     // sidecar splitter. Sets two domains initially.
     snapshot = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_domain_metadata("app.settings".to_string(), r#"{"version":1}"#.to_string())
         .with_domain_metadata(
             "app.feature_flags".to_string(),
@@ -943,7 +943,7 @@ async fn v2_table_with_domain_metadata_and_txn<E: TaskExecutor>(
     // Another domain metadata commit -- updates "app.settings" to verify reconciliation
     // picks the latest value, and adds a new domain.
     snapshot = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_domain_metadata(
             "app.analytics".to_string(),
             r#"{"tracking":false}"#.to_string(),
@@ -956,7 +956,7 @@ async fn v2_table_with_domain_metadata_and_txn<E: TaskExecutor>(
     // plus a second update to `app1` to verify reconciliation picks the latest version.
     for (app_id, version) in [("app1", 1i64), ("app2", 5), ("app1", 3)] {
         snapshot = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+            .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
             .with_transaction_id(app_id.to_string(), version)
             .commit(engine.as_ref())?
             .unwrap_post_commit_snapshot();
@@ -965,7 +965,7 @@ async fn v2_table_with_domain_metadata_and_txn<E: TaskExecutor>(
     // Remove all 8 files -> 8 remove tombstones
     let scan = snapshot.clone().scan_builder().build()?;
     let mut txn = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_operation("DELETE".to_string())
         .with_data_change(true);
     for sm in scan.scan_metadata(engine.as_ref())? {
@@ -1159,7 +1159,7 @@ async fn create_partitioned_stats_table<E: TaskExecutor>(
             ("delta.checkpoint.writeStatsAsStruct", "true"),
         ])
         .with_data_layout(DataLayout::partitioned(["part_key"]))
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     let data_schema = StructType::try_new(vec![
@@ -1444,7 +1444,7 @@ async fn test_v2_sidecar_preserves_dv_and_row_tracking_on_add(
             ("delta.feature.deletionVectors", "supported"),
             ("delta.enableRowTracking", "true"),
         ])
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     // === Step 2: Append one batch. ===
@@ -1476,7 +1476,7 @@ async fn test_v2_sidecar_preserves_dv_and_row_tracking_on_add(
         .map_ok(|sm| sm.scan_files)
         .try_collect()?;
     let mut txn = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_data_change(true);
     txn.update_deletion_vectors(
         HashMap::from([(path, dv.clone())]),
@@ -1538,14 +1538,14 @@ async fn test_v2_sidecar_default_hint_splits_at_50k() -> Result<(), Box<dyn std:
     // === Step 1: Create v2Checkpoint table. ===
     let _ = create_table(&table_path, get_simple_schema(), "Test/1.0")
         .with_table_properties([("delta.feature.v2Checkpoint", "supported")])
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     // === Step 2: Run 60 commits of 1_000 synthetic adds each (60_000 total). ===
     let mut snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
     for c in 0..COMMITS {
         let mut txn = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+            .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
             .with_data_change(true);
         let add_files_schema = txn.add_files_schema().clone();
         let paths: Vec<String> = (0..PER_COMMIT)
@@ -1648,7 +1648,7 @@ async fn build_v2_table_with_feature<E: TaskExecutor>(
         builder = builder.with_data_layout(layout);
     }
     let _ = builder
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     // For partitioned tables, the data batches must NOT include the partition column --

--- a/kernel/tests/integration/metrics/mod.rs
+++ b/kernel/tests/integration/metrics/mod.rs
@@ -101,7 +101,7 @@ async fn setup_table_with_v1_checkpoint() -> DeltaResult<(
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
 
     let _ = create_table(&table_path, simple_schema(), "Test/1.0")
-        .build(setup_engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(setup_engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(setup_engine.as_ref())?;
 
     let snap0 = Snapshot::builder_for(table_url.clone()).build(setup_engine.as_ref())?;

--- a/kernel/tests/integration/metrics/snapshot_load.rs
+++ b/kernel/tests/integration/metrics/snapshot_load.rs
@@ -254,7 +254,7 @@ async fn crc_at_prior_version_triggers_tail_replay_then_falls_back_to_crc() -> D
     // commit 0: create table; write CRC from the post-commit snapshot.
     // `write_checksum` requires an in-memory CRC computed during the transaction.
     let create_committed = create_table(&table_path, simple_schema(), "Test/1.0")
-        .build(setup_engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(setup_engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(setup_engine.as_ref())?
         .unwrap_committed();
     create_committed

--- a/kernel/tests/integration/write/append.rs
+++ b/kernel/tests/integration/write/append.rs
@@ -125,7 +125,7 @@ async fn test_no_add_actions() -> Result<(), Box<dyn std::error::Error>> {
     {
         let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
         let txn = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+            .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
             .with_engine_info("default engine");
 
         // Commit without adding any add files
@@ -201,7 +201,7 @@ async fn test_append_partitioned() -> Result<(), Box<dyn std::error::Error>> {
     {
         let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
         let mut txn = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+            .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
             .with_engine_info("default engine")
             .with_data_change(false);
 
@@ -347,7 +347,7 @@ async fn test_append_invalid_schema() -> Result<(), Box<dyn std::error::Error>> 
     {
         let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
         let txn = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+            .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
             .with_engine_info("default engine");
 
         // create two new arrow record batches to append

--- a/kernel/tests/integration/write/cdf.rs
+++ b/kernel/tests/integration/write/cdf.rs
@@ -53,7 +53,7 @@ async fn write_data_to_table(
 ) -> Result<Version, Box<dyn std::error::Error>> {
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
     let mut txn = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_engine_info("test");
 
     add_files_to_transaction(&mut txn, engine, schema, values).await?;
@@ -119,7 +119,7 @@ async fn test_cdf_write_all_removes_succeeds() -> Result<(), Box<dyn std::error:
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
     let mut txn = snapshot
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_engine_info("cdf remove test")
         .with_data_change(true);
 
@@ -159,7 +159,7 @@ async fn test_cdf_write_mixed_no_data_change_succeeds() -> Result<(), Box<dyn st
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
     let mut txn = snapshot
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_engine_info("cdf mixed test")
         .with_data_change(false); // dataChange=false is key here
 
@@ -202,7 +202,7 @@ async fn test_cdf_write_mixed_with_data_change_fails() -> Result<(), Box<dyn std
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
     let mut txn = snapshot
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_engine_info("cdf mixed fail test")
         .with_data_change(true); // dataChange=true - this should fail
 

--- a/kernel/tests/integration/write/clustered.rs
+++ b/kernel/tests/integration/write/clustered.rs
@@ -120,7 +120,7 @@ fn setup_clustered_table(
         .with_data_layout(DataLayout::Clustered {
             columns: clustering_cols,
         })
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     let snapshot = set_table_properties(

--- a/kernel/tests/integration/write/commit_info.rs
+++ b/kernel/tests/integration/write/commit_info.rs
@@ -31,7 +31,7 @@ async fn test_commit_info() -> Result<(), Box<dyn std::error::Error>> {
     {
         // create a transaction
         let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
-        let committer = Box::new(FileSystemCommitter::new());
+        let committer = Arc::new(FileSystemCommitter::new());
         let txn = snapshot
             .transaction(committer, &engine)?
             .with_engine_info("default engine");
@@ -80,7 +80,7 @@ async fn test_commit_info_action() -> Result<(), Box<dyn std::error::Error>> {
     {
         let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
         let txn = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+            .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
             .with_engine_info("default engine");
 
         let _ = txn.commit(&engine)?;
@@ -157,7 +157,7 @@ async fn test_commit_info_with_engine_commit_info() -> Result<(), Box<dyn std::e
 
         let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
         let txn = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+            .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
             .with_operation("WRITE".to_string())
             .with_commit_info(Box::new(ArrowEngineData::new(batch)), engine_schema);
 

--- a/kernel/tests/integration/write/domain_metadata.rs
+++ b/kernel/tests/integration/write/domain_metadata.rs
@@ -1,5 +1,7 @@
 //! Integration tests for domain metadata set/remove flows.
 
+use std::sync::Arc;
+
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::ObjectStoreExt as _;
@@ -32,7 +34,7 @@ async fn test_set_domain_metadata_basic() -> Result<(), Box<dyn std::error::Erro
 
     let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
 
-    let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
+    let txn = snapshot.transaction(Arc::new(FileSystemCommitter::new()), &engine)?;
 
     // write context does not conflict with domain metadata
     let _write_context = txn.unpartitioned_write_context().unwrap();
@@ -110,7 +112,7 @@ async fn test_set_domain_metadata_errors() -> Result<(), Box<dyn std::error::Err
     // System domain rejection
     let txn = snapshot
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), &engine)?;
+        .transaction(Arc::new(FileSystemCommitter::new()), &engine)?;
     let res = txn
         .with_domain_metadata("delta.system".to_string(), "config".to_string())
         .commit(&engine);
@@ -122,7 +124,7 @@ async fn test_set_domain_metadata_errors() -> Result<(), Box<dyn std::error::Err
     // Duplicate domain rejection
     let txn2 = snapshot
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), &engine)?;
+        .transaction(Arc::new(FileSystemCommitter::new()), &engine)?;
     let res = txn2
         .with_domain_metadata("app.config".to_string(), "v1".to_string())
         .with_domain_metadata("app.config".to_string(), "v2".to_string())
@@ -159,7 +161,7 @@ async fn test_set_domain_metadata_unsupported_writer_feature(
 
     let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
     let res = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+        .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
         .with_domain_metadata("app.config".to_string(), "test_config".to_string())
         .commit(&engine);
 
@@ -192,7 +194,7 @@ async fn test_remove_domain_metadata_unsupported_writer_feature(
 
     let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
     let res = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+        .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
         .with_domain_metadata_removed("app.config".to_string())
         .commit(&engine);
 
@@ -223,7 +225,7 @@ async fn test_remove_domain_metadata_non_existent_domain() -> Result<(), Box<dyn
     .await?;
 
     let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
-    let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
+    let txn = snapshot.transaction(Arc::new(FileSystemCommitter::new()), &engine)?;
 
     let domain = "app.deprecated";
 
@@ -281,7 +283,7 @@ async fn test_domain_metadata_set_remove_conflicts() -> Result<(), Box<dyn std::
     // set then remove same domain
     let txn = snapshot
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), &engine)?;
+        .transaction(Arc::new(FileSystemCommitter::new()), &engine)?;
     let err = txn
         .with_domain_metadata("app.config".to_string(), "v1".to_string())
         .with_domain_metadata_removed("app.config".to_string())
@@ -294,7 +296,7 @@ async fn test_domain_metadata_set_remove_conflicts() -> Result<(), Box<dyn std::
     // remove then set same domain
     let txn2 = snapshot
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), &engine)?;
+        .transaction(Arc::new(FileSystemCommitter::new()), &engine)?;
     let err = txn2
         .with_domain_metadata_removed("test.domain".to_string())
         .with_domain_metadata("test.domain".to_string(), "v1".to_string())
@@ -307,7 +309,7 @@ async fn test_domain_metadata_set_remove_conflicts() -> Result<(), Box<dyn std::
     // remove same domain twice
     let txn3 = snapshot
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), &engine)?;
+        .transaction(Arc::new(FileSystemCommitter::new()), &engine)?;
     let err = txn3
         .with_domain_metadata_removed("another.domain".to_string())
         .with_domain_metadata_removed("another.domain".to_string())
@@ -320,7 +322,7 @@ async fn test_domain_metadata_set_remove_conflicts() -> Result<(), Box<dyn std::
     // remove system domain
     let txn4 = snapshot
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), &engine)?;
+        .transaction(Arc::new(FileSystemCommitter::new()), &engine)?;
     let err = txn4
         .with_domain_metadata_removed("delta.system".to_string())
         .commit(&engine)
@@ -357,14 +359,14 @@ async fn test_domain_metadata_set_then_remove() -> Result<(), Box<dyn std::error
 
     // txn 1: set domain metadata
     let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
-    let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
+    let txn = snapshot.transaction(Arc::new(FileSystemCommitter::new()), &engine)?;
     let _ = txn
         .with_domain_metadata(domain.to_string(), configuration.to_string())
         .commit(&engine)?;
 
     // txn 2: remove the same domain metadata
     let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
-    let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
+    let txn = snapshot.transaction(Arc::new(FileSystemCommitter::new()), &engine)?;
     let _ = txn
         .with_domain_metadata_removed(domain.to_string())
         .commit(&engine)?;

--- a/kernel/tests/integration/write/ict.rs
+++ b/kernel/tests/integration/write/ict.rs
@@ -108,7 +108,7 @@ async fn test_ict_commit_e2e() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let mut txn = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+        .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
         .with_engine_info("ict test");
 
     // Add some data
@@ -152,7 +152,7 @@ async fn test_ict_commit_e2e() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let mut txn2 = snapshot2
-        .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+        .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
         .with_engine_info("ict test 2");
 
     // Add more data

--- a/kernel/tests/integration/write/partitioned.rs
+++ b/kernel/tests/integration/write/partitioned.rs
@@ -576,7 +576,7 @@ fn create_partitioned_table(
             builder.with_table_properties([("delta.columnMapping.mode", cm_mode_str(cm_mode))]);
     }
     let _ = builder
-        .build(engine, Box::new(FileSystemCommitter::new()))?
+        .build(engine, Arc::new(FileSystemCommitter::new()))?
         .commit(engine)?;
     Ok(Snapshot::builder_for(table_path).build(engine)?)
 }
@@ -756,12 +756,12 @@ async fn test_materialized_partition_columns_excluded_from_stats(
     let _ = create_table(&table_path, table_schema.clone(), "test/1.0")
         .with_data_layout(DataLayout::partitioned([partition_col]))
         .with_table_properties([("delta.feature.materializePartitionColumns", "supported")])
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
     let mut txn = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_engine_info("default engine");
 
     // Build the input logical batch with all schema columns, including the partition column.

--- a/kernel/tests/integration/write/partitioned.rs
+++ b/kernel/tests/integration/write/partitioned.rs
@@ -872,7 +872,7 @@ async fn test_partition_null_validation_non_materialized(
     let snapshot = create_partitioned_table(&table_path, engine.as_ref(), schema, &["p"], cm_mode)?;
 
     let result = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_engine_info("default engine")
         .partitioned_write_context(HashMap::from([("p".to_string(), value)]));
 
@@ -927,7 +927,7 @@ async fn test_partition_null_validation_mixed_nullability(
 
     snapshot
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_engine_info("default engine")
         .partitioned_write_context(HashMap::from([
             ("p_required".to_string(), Scalar::String("a".into())),
@@ -936,7 +936,7 @@ async fn test_partition_null_validation_mixed_nullability(
 
     snapshot
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_engine_info("default engine")
         .partitioned_write_context(HashMap::from([
             ("p_required".to_string(), Scalar::String("a".into())),
@@ -944,7 +944,7 @@ async fn test_partition_null_validation_mixed_nullability(
         ]))?;
 
     let err = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_engine_info("default engine")
         .partitioned_write_context(HashMap::from([
             ("p_required".to_string(), Scalar::Null(DataType::STRING)),
@@ -976,7 +976,7 @@ async fn test_partition_null_validation_in_batch_materialized(
     let _ = create_table(&table_path, schema.clone(), "test/1.0")
         .with_data_layout(DataLayout::partitioned(["p"]))
         .with_table_properties([("delta.feature.materializePartitionColumns", "supported")])
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
@@ -994,7 +994,7 @@ async fn test_partition_null_validation_in_batch_materialized(
     // in a `nullable: false` field is rejected at batch construction below, independent of
     // whatever value the mock map carries here.
     let txn = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_engine_info("default engine");
     let _write_context = txn.partitioned_write_context(HashMap::from([(
         "p".to_string(),

--- a/kernel/tests/integration/write/post_commit.rs
+++ b/kernel/tests/integration/write/post_commit.rs
@@ -29,7 +29,7 @@ async fn test_post_commit_snapshot_create_then_insert() -> DeltaResult<()> {
 
     // Create table and verify post_commit_snapshot
     let create_result = create_table_txn(table_url.as_str(), schema, env!("CARGO_PKG_VERSION"))
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     let mut current_snapshot = match create_result {
@@ -56,7 +56,7 @@ async fn test_post_commit_snapshot_create_then_insert() -> DeltaResult<()> {
 
         let txn = current_snapshot
             .clone()
-            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+            .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
             .with_engine_info("test");
 
         match txn.commit(engine.as_ref())? {
@@ -133,7 +133,7 @@ async fn test_write_parquet_rejects_partitioned_write_context_on_unpartitioned_t
         let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
         let txn = snapshot
             .clone()
-            .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+            .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
             .with_engine_info("test");
 
         let result = txn.partitioned_write_context(HashMap::from([(

--- a/kernel/tests/integration/write/relative_paths.rs
+++ b/kernel/tests/integration/write/relative_paths.rs
@@ -25,7 +25,7 @@ async fn write_batch_to_table_simple(
 ) -> Result<Arc<Snapshot>, Box<dyn std::error::Error>> {
     let mut txn = snapshot
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), engine)?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine)?
         .with_engine_info("test");
     let write_context = txn.unpartitioned_write_context()?;
     let add_meta = engine
@@ -78,7 +78,7 @@ async fn test_multiple_files_in_commit_all_use_relative_paths(
 
     let mut txn = snapshot
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_engine_info("test");
     let write_context = txn.unpartitioned_write_context().unwrap();
     for values in [vec![1, 2], vec![3, 4]] {
@@ -140,7 +140,7 @@ async fn test_create_table_with_data_uses_relative_paths() -> Result<(), Box<dyn
     let table_url = Url::from_directory_path(&table_path).unwrap();
 
     let mut txn = create_table_txn(table_url.as_str(), schema.clone(), "test/1.0")
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?;
     let write_context = txn.unpartitioned_write_context()?;
     let add_meta = engine
         .write_parquet(

--- a/kernel/tests/integration/write/remove_dv.rs
+++ b/kernel/tests/integration/write/remove_dv.rs
@@ -58,7 +58,7 @@ async fn test_remove_files_adds_expected_entries() -> Result<(), Box<dyn std::er
 
     let mut txn = snapshot
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_engine_info("test engine")
         .with_data_change(true);
 
@@ -242,7 +242,7 @@ async fn test_update_deletion_vectors_adds_expected_entries(
     // Create transaction with DV update mode enabled
     let mut txn = snapshot
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_engine_info("test engine")
         .with_operation("UPDATE".to_string())
         .with_data_change(true);
@@ -540,7 +540,7 @@ async fn test_update_deletion_vectors_multiple_files() -> Result<(), Box<dyn std
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
     let mut txn = snapshot
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_engine_info("test engine")
         .with_operation("UPDATE".to_string())
         .with_data_change(true);
@@ -686,7 +686,7 @@ async fn test_remove_files_verify_files_excluded_from_scan(
         // Now create a transaction to remove files
         let mut txn = snapshot
             .clone()
-            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?;
+            .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?;
 
         // Create a new scan to get file metadata for removal
         let scan2 = snapshot.scan_builder().build()?;
@@ -782,7 +782,7 @@ async fn test_remove_files_with_modified_selection_vector() -> Result<(), Box<dy
         // Create a transaction to remove files in two batches
         let mut txn = snapshot
             .clone()
-            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+            .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
             .with_engine_info("selective remove test")
             .with_operation("DELETE".to_string())
             .with_data_change(true);
@@ -962,7 +962,7 @@ async fn test_remove_files_after_predicate_scan_includes_stats_parsed(
         let scan = scan_builder.build()?;
 
         let mut txn = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+            .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
             .with_data_change(true);
 
         // Pass scan metadata (which contains stats_parsed) directly to remove_files.
@@ -1063,7 +1063,7 @@ async fn test_remove_files_partitioned_with_parsed_columns(
         // Write two partitions: country="usa" and country="japan".
         let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
         let mut txn = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+            .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
             .with_data_change(true);
         let append_data = [[1, 2, 3], [10, 20, 30]].map(|data| -> delta_kernel::DeltaResult<_> {
             let data = RecordBatch::try_new(
@@ -1090,7 +1090,7 @@ async fn test_remove_files_partitioned_with_parsed_columns(
         let scan = scan_builder.build()?;
 
         let mut txn = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+            .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
             .with_data_change(true);
         for scan_metadata in scan.scan_metadata(engine.as_ref())? {
             txn.remove_files(scan_metadata?.scan_files);

--- a/kernel/tests/integration/write/row_tracking.rs
+++ b/kernel/tests/integration/write/row_tracking.rs
@@ -59,7 +59,7 @@ async fn test_row_tracking_fields_in_add_and_remove_actions(
     // ===== FIRST COMMIT: Add files with row tracking =====
     let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
     let mut txn = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+        .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
         .with_engine_info("row tracking test")
         .with_data_change(true);
 
@@ -127,7 +127,7 @@ async fn test_row_tracking_fields_in_add_and_remove_actions(
     let snapshot2 = Snapshot::builder_for(table_url.clone()).build(engine_arc.as_ref())?;
     let mut txn2 = snapshot2
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), engine_arc.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine_arc.as_ref())?
         .with_engine_info("row tracking remove test")
         .with_data_change(true);
 

--- a/kernel/tests/integration/write/txn.rs
+++ b/kernel/tests/integration/write/txn.rs
@@ -1,5 +1,7 @@
 //! Integration tests for transaction-identifier write paths.
 
+use std::sync::Arc;
+
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::ObjectStoreExt as _;
@@ -25,7 +27,7 @@ async fn test_write_txn_actions() -> Result<(), Box<dyn std::error::Error>> {
         let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
         assert!(matches!(
             snapshot
-                .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+                .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
                 .with_transaction_id("app_id1".to_string(), 0)
                 .with_transaction_id("app_id1".to_string(), 1)
                 .commit(&engine),
@@ -34,7 +36,7 @@ async fn test_write_txn_actions() -> Result<(), Box<dyn std::error::Error>> {
 
         let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
         let txn = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+            .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
             .with_engine_info("default engine")
             .with_transaction_id("app_id1".to_string(), 1)
             .with_transaction_id("app_id2".to_string(), 2);

--- a/kernel/tests/integration/write/types.rs
+++ b/kernel/tests/integration/write/types.rs
@@ -50,7 +50,7 @@ async fn test_append_timestamp_ntz() -> Result<(), Box<dyn std::error::Error>> {
 
     let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
     let mut txn = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+        .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
         .with_engine_info("default engine");
 
     // Create Arrow data with TIMESTAMP_NTZ values including edge cases
@@ -169,7 +169,7 @@ async fn test_append_variant() -> Result<(), Box<dyn std::error::Error>> {
 
     let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
     let mut txn = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+        .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
         .with_data_change(true);
 
     // First value corresponds to the variant value "1". Third value corresponds to the variant
@@ -376,7 +376,7 @@ async fn test_shredded_variant_read_rejection() -> Result<(), Box<dyn std::error
 
     let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
     let mut txn = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+        .transaction(Arc::new(FileSystemCommitter::new()), &engine)?
         .with_data_change(true);
 
     // First value corresponds to the variant value "1". Third value corresponds to the variant

--- a/kernel/tests/integration/write/types.rs
+++ b/kernel/tests/integration/write/types.rs
@@ -505,7 +505,7 @@ async fn test_not_null_data_column_rejects_null_in_batch(
     )])?);
     let (_tmp_dir, table_path, engine) = test_table_setup()?;
     let _ = kernel_create_table(&table_path, schema.clone(), "test/1.0")
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
@@ -520,7 +520,7 @@ async fn test_not_null_data_column_rejects_null_in_batch(
     );
 
     let write_context = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_engine_info("default engine")
         .unpartitioned_write_context()?;
 

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -669,7 +669,7 @@ pub async fn insert_data<E: TaskExecutor>(
     let batch = RecordBatch::try_new(Arc::new(arrow_schema), columns)
         .map_err(|e| delta_kernel::Error::generic(e.to_string()))?;
     let mut txn = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_operation("WRITE".to_string())
         .with_data_change(true);
 
@@ -1013,7 +1013,7 @@ pub async fn write_batch_to_table(
 ) -> Result<Arc<Snapshot>, Box<dyn std::error::Error>> {
     let mut txn = snapshot
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), engine)?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine)?
         .with_engine_info("DefaultEngine")
         .with_data_change(true);
     let write_context = if txn.logical_partition_columns().is_empty() {
@@ -1111,7 +1111,7 @@ pub fn create_table_and_load_snapshot(
 
     let _ = create_table(table_path, schema, "Test/1.0")
         .with_table_properties(properties.to_vec())
-        .build(engine, Box::new(FileSystemCommitter::new()))?
+        .build(engine, Arc::new(FileSystemCommitter::new()))?
         .commit(engine)?;
 
     let table_url = delta_kernel::try_parse_uri(table_path)?;
@@ -1249,7 +1249,7 @@ pub fn remove_all_and_get_remove_actions(
 
     let mut txn = snapshot
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), engine)?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine)?
         .with_engine_info("DefaultEngine")
         .with_data_change(true);
     for sm in all_scan_metadata {

--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -762,7 +762,7 @@ impl TestTableBuilder {
             ));
         }
         let committed = builder
-            .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+            .build(engine.as_ref(), Arc::new(FileSystemCommitter::new()))?
             .commit(engine.as_ref())?
             .unwrap_committed();
         let mut snapshot = committed.post_commit_snapshot().unwrap().clone();
@@ -823,7 +823,7 @@ async fn write_data_commit(
         .map_err(|e| delta_kernel::Error::generic(e.to_string()))?;
 
     let mut txn = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), engine)?
+        .transaction(Arc::new(FileSystemCommitter::new()), engine)?
         .with_operation("WRITE".to_string())
         .with_data_change(true);
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
Primarily mechanical change which changes `Committer` to be borrowed with an `Arc` rather than moved with a `Box` and thus expands the Committer trait to be send and sync. This change will allow connectors to reuse committers rather than creating a new committer for every single transaction. This PR will not have that dramatic of an effect on runtime; however, it is still a win in that it changes the signature of `Committer` to better reflect its usage pattern.

## How was this change tested?
Passing all of the original unit and integration tests.

## Note to reviewers
Real changes live in `kernel/src/committer/mod.rs`, `ffi/src/transaction/mod.rs`, `ffi/src/delta_kernel_unity_catalog.rs`, and `ffi/examples/delta-kernel-unity-catalog-example/delta_kernel_unity_catalog_example.c`.