### PR TITLE
feat: enforce and test non-null column invariant on writes

### DIFF
--- a/kernel/src/partition/validation.rs
+++ b/kernel/src/partition/validation.rs
@@ -19,7 +19,8 @@
 //! - [`validate_keys`]: checks key completeness (case-insensitive matching, normalizes to schema
 //!   case, detects post-normalization duplicates).
 //! - [`validate_types`]: checks that each `Scalar`'s type matches the partition column's schema
-//!   type. Null scalars skip the type check.
+//!   type, and that null scalars are only used for nullable partition columns. Null scalars skip
+//!   the value type check; the column's nullability is still enforced.
 
 use std::collections::HashMap;
 
@@ -105,8 +106,10 @@ fn validate_keys(
 }
 
 /// Validates that each [`Scalar`] value's type is compatible with the corresponding
-/// partition column's type in the table schema. Null scalars skip the type check
-/// (null is valid for any partition column type).
+/// partition column's type in the table schema. Null scalars skip the value type check, but a
+/// null is only legal when the schema field is nullable. This matches Delta-Spark's
+/// `DELTA_NOT_NULL_CONSTRAINT_VIOLATED` rejection of NULL writes into a NOT NULL partition
+/// column.
 ///
 /// # Parameters
 /// - `logical_schema`: the table's logical schema.
@@ -117,6 +120,7 @@ fn validate_keys(
 /// # Errors
 /// - A partition column is not found in the table schema
 /// - A partition column's schema type is not a primitive (struct, array, map are rejected)
+/// - A null value is provided for a non-nullable partition column
 /// - A non-null value's type does not match the partition column's schema type
 fn validate_types(
     logical_schema: &StructType,
@@ -139,6 +143,13 @@ fn validate_types(
             )));
         }
         if value.is_null() {
+            // Null partition values are only valid for nullable partition columns. This
+            // mirrors Spark `DELTA_NOT_NULL_CONSTRAINT_VIOLATED` (SQLSTATE 23502).
+            if !field.nullable {
+                return Err(Error::invalid_partition_values(format!(
+                    "partition column '{col_name}' is not nullable but received a null value"
+                )));
+            }
             continue;
         }
         let actual_type = value.data_type();
@@ -170,6 +181,14 @@ mod tests {
         let schema = StructType::new_unchecked(vec![StructField::not_null("p", data_type)]);
         let values = HashMap::from([("p".to_string(), value)]);
         validate_types(&schema, &values).unwrap_err().to_string()
+    }
+
+    /// Like [`assert_type_ok`] but uses a `nullable` schema field. Used by null-value cases,
+    /// since null scalars are only valid for nullable partition columns.
+    fn assert_type_ok_nullable(data_type: DataType, value: Scalar) {
+        let schema = StructType::new_unchecked(vec![StructField::nullable("p", data_type)]);
+        let values = HashMap::from([("p".to_string(), value)]);
+        validate_types(&schema, &values).unwrap();
     }
 
     // ============================================================================
@@ -340,8 +359,8 @@ mod tests {
         assert_type_ok(data_type, value);
     }
 
-    /// NULL rows from the encoding table. Null is valid for every partition column type,
-    /// regardless of the Scalar::Null inner type.
+    /// NULL rows from the encoding table. Null is valid for every partition column type when
+    /// the schema field is nullable, regardless of the `Scalar::Null` inner type.
     #[rstest]
     #[case(DataType::INTEGER, Scalar::Null(DataType::INTEGER))] // row 5
     #[case(DataType::LONG, Scalar::Null(DataType::LONG))] // row 8
@@ -356,16 +375,45 @@ mod tests {
     #[case(DataType::TIMESTAMP_NTZ, Scalar::Null(DataType::TIMESTAMP_NTZ))] // row 46
     #[case(DataType::STRING, Scalar::Null(DataType::STRING))] // row 66
     #[case(DataType::BINARY, Scalar::Null(DataType::BINARY))] // (binary NULL)
-    fn test_validate_types_null_returns_ok(#[case] data_type: DataType, #[case] value: Scalar) {
-        assert_type_ok(data_type, value);
+    fn test_validate_types_null_into_nullable_returns_ok(
+        #[case] data_type: DataType,
+        #[case] value: Scalar,
+    ) {
+        assert_type_ok_nullable(data_type, value);
     }
 
-    /// Null skips the type check even when the Scalar::Null inner type does not match
-    /// the schema column type. This is intentional: null is valid for any partition
-    /// column regardless of what type the Null carries.
+    /// Null skips the value type check even when the `Scalar::Null` inner type does not match
+    /// the schema column type. This is intentional: null carries no concrete type to compare
+    /// against.
     #[test]
     fn test_validate_types_null_with_mismatched_inner_type_returns_ok() {
-        assert_type_ok(DataType::INTEGER, Scalar::Null(DataType::STRING));
+        assert_type_ok_nullable(DataType::INTEGER, Scalar::Null(DataType::STRING));
+    }
+
+    /// A null partition value for a non-nullable partition column is rejected, matching
+    /// Delta-Spark's `DELTA_NOT_NULL_CONSTRAINT_VIOLATED` (SQLSTATE 23502) behavior. The
+    /// `Scalar::Null` inner type is irrelevant -- the rejection is driven entirely by the
+    /// schema field's nullability.
+    #[rstest]
+    #[case(DataType::INTEGER, Scalar::Null(DataType::INTEGER))]
+    #[case(DataType::LONG, Scalar::Null(DataType::LONG))]
+    #[case(DataType::STRING, Scalar::Null(DataType::STRING))]
+    #[case(DataType::BINARY, Scalar::Null(DataType::BINARY))]
+    #[case(DataType::BOOLEAN, Scalar::Null(DataType::BOOLEAN))]
+    #[case(DataType::DATE, Scalar::Null(DataType::DATE))]
+    #[case(DataType::TIMESTAMP, Scalar::Null(DataType::TIMESTAMP))]
+    #[case(DataType::TIMESTAMP_NTZ, Scalar::Null(DataType::TIMESTAMP_NTZ))]
+    #[case(DataType::decimal(10, 2).unwrap(), Scalar::Null(DataType::decimal(10, 2).unwrap()))]
+    // Null with mismatched inner type is also rejected -- the schema's nullability is the
+    // only thing checked for null scalars.
+    #[case(DataType::INTEGER, Scalar::Null(DataType::STRING))]
+    fn test_validate_types_null_into_non_nullable_returns_error(
+        #[case] data_type: DataType,
+        #[case] value: Scalar,
+    ) {
+        let err = assert_type_err(data_type, value);
+        assert!(err.contains("not nullable"), "{err}");
+        assert!(err.contains("'p'"), "{err}");
     }
 
     /// Type mismatch: every non-null Scalar variant against the wrong schema type.

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -75,6 +75,14 @@ const ALLOWED_DELTA_FEATURES: &[TableFeature] = &[
     // the feature on an all-nullable table so a later ALTER TABLE ADD COLUMN NOT NULL does
     // not need a protocol upgrade.
     TableFeature::Invariants,
+    // MaterializePartitionColumns keeps partition columns in the data files (rather than
+    // dropping them via the logical-to-physical transform). The feature is fully wired in
+    // kernel (write: `Transaction::generate_logical_to_physical` and
+    // `TableConfiguration::physical_write_schema`; read: scan reconstructs from
+    // `add.partitionValues` regardless), and `KernelSupport::Supported`. There is no
+    // `delta.*` enablement property for it, so the only opt-in at create time is the
+    // explicit feature signal `delta.feature.materializePartitionColumns=supported`.
+    TableFeature::MaterializePartitionColumns,
 ];
 
 /// Delta properties allowed to be set during CREATE TABLE.

--- a/kernel/tests/create_table/partitioned.rs
+++ b/kernel/tests/create_table/partitioned.rs
@@ -4,6 +4,7 @@
 
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::snapshot::Snapshot;
+use delta_kernel::table_features::TableFeature;
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::DeltaResult;
@@ -35,6 +36,51 @@ fn test_create_table_partitioned_basic(#[case] partition_col: &str) -> DeltaResu
     assert!(
         clustering.is_none(),
         "Partitioned table should not have clustering columns"
+    );
+
+    Ok(())
+}
+
+/// CREATE TABLE with `delta.feature.materializePartitionColumns=supported` lands the feature
+/// in `writerFeatures` exactly once and not in `readerFeatures` (writer-only feature). The
+/// feature has no `delta.*` enablement property and is not auto-enabled by any schema or
+/// metadata, so the explicit feature signal is the only opt-in path at create time.
+#[test]
+fn test_create_table_with_materialize_partition_columns_feature_signal_allowed() -> DeltaResult<()>
+{
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let schema = partition_test_schema()?;
+
+    let _ = create_table(&table_path, schema, "Test/1.0")
+        .with_data_layout(DataLayout::partitioned(["date"]))
+        .with_table_properties([("delta.feature.materializePartitionColumns", "supported")])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?;
+
+    let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    let protocol = snapshot.table_configuration().protocol();
+    let writer_features = protocol
+        .writer_features()
+        .expect("writer features should be present");
+    let count = writer_features
+        .iter()
+        .filter(|f| **f == TableFeature::MaterializePartitionColumns)
+        .count();
+    assert_eq!(
+        count, 1,
+        "MaterializePartitionColumns should appear exactly once in writerFeatures; got {count}"
+    );
+    assert!(
+        !protocol
+            .reader_features()
+            .is_some_and(|f| f.contains(&TableFeature::MaterializePartitionColumns)),
+        "MaterializePartitionColumns is writer-only and must not appear in readerFeatures"
+    );
+    assert!(
+        snapshot
+            .table_configuration()
+            .is_feature_enabled(&TableFeature::MaterializePartitionColumns),
+        "MaterializePartitionColumns should be enabled when listed in writerFeatures"
     );
 
     Ok(())

--- a/kernel/tests/write/append.rs
+++ b/kernel/tests/write/append.rs
@@ -17,7 +17,7 @@ use delta_kernel::schema::{DataType, StructField, StructType};
 use delta_kernel::{DeltaResult, Error as KernelError, Snapshot};
 use itertools::Itertools;
 use serde_json::{json, Deserializer};
-use test_utils::{create_table, engine_store_setup, set_json_value, setup_test_tables, test_read};
+use test_utils::{set_json_value, setup_test_tables, test_read};
 
 use crate::common::write_utils::{
     check_action_timestamps, get_and_check_all_parquet_sizes, get_simple_int_schema,
@@ -324,100 +324,6 @@ async fn test_append_partitioned() -> Result<(), Box<dyn std::error::Error>> {
             engine,
         )?;
     }
-    Ok(())
-}
-
-// Verify that materialized partition columns do not get stats collected. The partition column
-// is physically present in the parquet file, but its stats should be omitted because the
-// value is already in the Add action's `partitionValues`.
-#[tokio::test]
-async fn test_materialized_partition_columns_excluded_from_stats(
-) -> Result<(), Box<dyn std::error::Error>> {
-    let _ = tracing_subscriber::fmt::try_init();
-
-    let partition_col = "partition";
-    let table_schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("number", DataType::INTEGER),
-        StructField::nullable("partition", DataType::STRING),
-    ])?);
-
-    // Create a table with materializePartitionColumns writer feature
-    let (store, engine, table_location) = engine_store_setup("test_mat_part", None);
-    let table_url = create_table(
-        store.clone(),
-        table_location,
-        table_schema.clone(),
-        &[partition_col],
-        true, // use_37_protocol for writer features
-        vec![],
-        vec!["materializePartitionColumns"],
-    )
-    .await?;
-
-    let engine = Arc::new(engine);
-    let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
-    let mut txn = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
-        .with_engine_info("default engine");
-
-    // With materializePartitionColumns, the data batch includes the partition column
-    let arrow_schema = Arc::new(table_schema.as_ref().try_into_arrow()?);
-    let batch = RecordBatch::try_new(
-        arrow_schema,
-        vec![
-            Arc::new(Int32Array::from(vec![1, 2, 3])),
-            Arc::new(StringArray::from(vec!["a", "a", "a"])),
-        ],
-    )?;
-    let data = Box::new(ArrowEngineData::new(batch));
-
-    let write_context = txn.partitioned_write_context(HashMap::from([(
-        partition_col.to_string(),
-        Scalar::String("a".into()),
-    )]))?;
-    let result = engine.write_parquet(&data, &write_context).await?;
-    txn.add_files(result);
-    assert!(txn.commit(engine.as_ref())?.is_committed());
-
-    // Read the commit log and verify stats
-    let commit = store
-        .get(&Path::from(
-            "/test_mat_part/_delta_log/00000000000000000001.json",
-        ))
-        .await?;
-    let parsed: Vec<serde_json::Value> = Deserializer::from_slice(&commit.bytes().await?)
-        .into_iter::<serde_json::Value>()
-        .try_collect()?;
-
-    let add = parsed
-        .iter()
-        .find(|v| v.get("add").is_some())
-        .expect("should have an add action");
-    let stats: serde_json::Value =
-        serde_json::from_str(add["add"]["stats"].as_str().unwrap()).unwrap();
-
-    // Stats should contain the data column but NOT the partition column
-    assert!(
-        stats["minValues"].get("number").is_some(),
-        "Data column 'number' should have minValues"
-    );
-    assert!(
-        stats["maxValues"].get("number").is_some(),
-        "Data column 'number' should have maxValues"
-    );
-    assert!(
-        stats["minValues"].get("partition").is_none(),
-        "Partition column should not have minValues even when materialized"
-    );
-    assert!(
-        stats["maxValues"].get("partition").is_none(),
-        "Partition column should not have maxValues even when materialized"
-    );
-    assert!(
-        stats["nullCount"].get("partition").is_none(),
-        "Partition column should not have nullCount even when materialized"
-    );
-
     Ok(())
 }
 

--- a/kernel/tests/write/partitioned.rs
+++ b/kernel/tests/write/partitioned.rs
@@ -12,6 +12,7 @@ use delta_kernel::arrow::array::{
 use delta_kernel::arrow::datatypes::Schema as ArrowSchema;
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
+use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::expressions::Scalar;
 use delta_kernel::schema::{DataType, StructField, StructType};
 use delta_kernel::table_features::ColumnMappingMode;
@@ -730,4 +731,82 @@ fn read_single_add(
         "should produce relative paths, got: {rel_path}"
     );
     Ok((add, rel_path))
+}
+
+// ==============================================================================
+// materializePartitionColumns tests
+// ==============================================================================
+
+/// Materialized partition columns are physically present in the parquet file, but their
+/// stats must be omitted from the Add action because the value is already in
+/// `partitionValues`. Pins the stat-collection contract for materialized partition tables
+/// end-to-end through the kernel `create_table` builder.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_materialized_partition_columns_excluded_from_stats(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let partition_col = "partition";
+    let table_schema = Arc::new(StructType::try_new(vec![
+        StructField::nullable("number", DataType::INTEGER),
+        StructField::nullable(partition_col, DataType::STRING),
+    ])?);
+
+    let (_tmp_dir, table_path, engine) = test_table_setup_mt()?;
+    let _ = create_table(&table_path, table_schema.clone(), "test/1.0")
+        .with_data_layout(DataLayout::partitioned([partition_col]))
+        .with_table_properties([("delta.feature.materializePartitionColumns", "supported")])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?;
+
+    let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    let mut txn = snapshot
+        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .with_engine_info("default engine");
+
+    // With materializePartitionColumns, the data batch retains the partition column.
+    let arrow_schema = Arc::new(table_schema.as_ref().try_into_arrow()?);
+    let batch = RecordBatch::try_new(
+        arrow_schema,
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3])),
+            Arc::new(StringArray::from(vec!["a", "a", "a"])),
+        ],
+    )?;
+    let data = Box::new(ArrowEngineData::new(batch));
+
+    let write_context = txn.partitioned_write_context(HashMap::from([(
+        partition_col.to_string(),
+        Scalar::String("a".into()),
+    )]))?;
+    let result = engine.write_parquet(&data, &write_context).await?;
+    txn.add_files(result);
+    assert!(txn.commit(engine.as_ref())?.is_committed());
+
+    let (add, _) = read_single_add(&table_path, 1)?;
+    let stats: serde_json::Value = serde_json::from_str(add["stats"].as_str().unwrap()).unwrap();
+
+    // Stats should contain the data column but NOT the partition column.
+    assert!(
+        stats["minValues"].get("number").is_some(),
+        "data column 'number' should have minValues"
+    );
+    assert!(
+        stats["maxValues"].get("number").is_some(),
+        "data column 'number' should have maxValues"
+    );
+    assert!(
+        stats["minValues"].get(partition_col).is_none(),
+        "partition column should not have minValues even when materialized"
+    );
+    assert!(
+        stats["maxValues"].get(partition_col).is_none(),
+        "partition column should not have maxValues even when materialized"
+    );
+    assert!(
+        stats["nullCount"].get(partition_col).is_none(),
+        "partition column should not have nullCount even when materialized"
+    );
+
+    Ok(())
 }

--- a/kernel/tests/write/partitioned.rs
+++ b/kernel/tests/write/partitioned.rs
@@ -810,3 +810,172 @@ async fn test_materialized_partition_columns_excluded_from_stats(
 
     Ok(())
 }
+
+// ==============================================================================
+// NOT NULL partition column tests
+// ==============================================================================
+//
+// See [#2465](https://github.com/delta-io/delta-kernel-rs/issues/2465). These tests pin the
+// kernel contract that mirrors Delta-Spark's `DELTA_NOT_NULL_CONSTRAINT_VIOLATED` (SQLSTATE
+// 23502): a NULL written into a `NOT NULL` partition column must be rejected on the default
+// engine. The two arms exercise the two enforcement seams:
+//
+// 1. **Non-materialized** (default): `Transaction::generate_logical_to_physical` drops partition
+//    columns from the batch before Parquet write, so the partition-value map is the authority. The
+//    fix in `validate_types` rejects null `Scalar`s for `nullable: false` partition columns at
+//    `partitioned_write_context` time.
+// 2. **Materialized** (`materializePartitionColumns` writer feature): partition columns stay in the
+//    batch through the transform, so a null in the NOT NULL column is rejected by `arrow-rs` at
+//    `RecordBatch::try_new`, matching the data-column NOT NULL contract.
+
+/// Non-materialized: a null partition `Scalar` for a `NOT NULL` partition column is rejected
+/// at `partitioned_write_context` (i.e. before `engine.write_parquet` is called and before
+/// any path encoding). This is the partition-map authority described in the issue plan.
+///
+/// The CM axis is orthogonal to nullability validation -- `validate_types` runs against
+/// logical column names and field nullability before serialization. Unit tests in
+/// `kernel/src/partition/validation.rs` cover the type matrix; this test only confirms the
+/// e2e wiring through `Transaction`.
+#[rstest]
+#[case::cm_none(ColumnMappingMode::None)]
+#[case::cm_name(ColumnMappingMode::Name)]
+#[case::cm_id(ColumnMappingMode::Id)]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_partition_not_null_rejects_null_scalar_non_materialized(
+    #[case] cm_mode: ColumnMappingMode,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    // Schema: a nullable data column + a NOT NULL string partition column.
+    let schema = Arc::new(StructType::try_new(vec![
+        StructField::nullable("value", DataType::INTEGER),
+        StructField::not_null("p", DataType::STRING),
+    ])?);
+    let partition_cols = ["p"];
+
+    let (_tmp_dir, table_path, engine) = test_table_setup_mt()?;
+    let snapshot = create_partitioned_table(
+        &table_path,
+        engine.as_ref(),
+        schema,
+        &partition_cols,
+        cm_mode,
+    )?;
+
+    // The transform drops the partition column from the batch, so the partition-value map
+    // is the only place a null can show up for `p`. Driving `partitioned_write_context` with
+    // `Scalar::Null` must surface kernel's NOT NULL rejection from `validate_types`.
+    let txn = snapshot
+        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .with_engine_info("default engine");
+    let result = txn.partitioned_write_context(HashMap::from([(
+        "p".to_string(),
+        Scalar::Null(DataType::STRING),
+    )]));
+
+    let err = result
+        .err()
+        .ok_or("expected partitioned_write_context to error for null into NOT NULL partition")?
+        .to_string();
+    assert!(err.contains("not nullable"), "{err}");
+    assert!(err.contains("'p'"), "{err}");
+
+    Ok(())
+}
+
+/// Non-materialized counterpart: a non-null partition `Scalar` for a `NOT NULL` partition
+/// column is accepted, and the partition-map authority test does not regress the legal
+/// path. Confirms our error case in
+/// [`test_partition_not_null_rejects_null_scalar_non_materialized`] is shape-driven, not a
+/// blanket rejection.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_partition_not_null_accepts_non_null_scalar_non_materialized(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let schema = Arc::new(StructType::try_new(vec![
+        StructField::nullable("value", DataType::INTEGER),
+        StructField::not_null("p", DataType::STRING),
+    ])?);
+    let (_tmp_dir, table_path, engine) = test_table_setup_mt()?;
+    let snapshot = create_partitioned_table(
+        &table_path,
+        engine.as_ref(),
+        schema,
+        &["p"],
+        ColumnMappingMode::None,
+    )?;
+
+    let txn = snapshot
+        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .with_engine_info("default engine");
+    txn.partitioned_write_context(HashMap::from([(
+        "p".to_string(),
+        Scalar::String("a".into()),
+    )]))?;
+
+    Ok(())
+}
+
+/// Materialized arm: with `materializePartitionColumns` enabled, partition columns stay in
+/// the logical batch (`Transaction::generate_logical_to_physical` does not drop them). The
+/// kernel-derived Arrow schema preserves `nullable: false`, and `arrow-rs` rejects a null
+/// in the NOT NULL partition column at `RecordBatch::try_new` -- the same enforcement seam
+/// as a NOT NULL data column. The feature is enabled at create time via the explicit
+/// feature signal `delta.feature.materializePartitionColumns=supported`.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_partition_not_null_rejects_null_in_batch_materialized(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let schema = Arc::new(StructType::try_new(vec![
+        StructField::nullable("value", DataType::INTEGER),
+        StructField::not_null("p", DataType::STRING),
+    ])?);
+
+    let (_tmp_dir, table_path, engine) = test_table_setup_mt()?;
+    let _ = create_table(&table_path, schema.clone(), "test/1.0")
+        .with_data_layout(DataLayout::partitioned(["p"]))
+        .with_table_properties([("delta.feature.materializePartitionColumns", "supported")])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?;
+
+    let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert!(
+        snapshot.table_configuration().is_feature_supported(
+            &delta_kernel::table_features::TableFeature::MaterializePartitionColumns
+        ),
+        "test setup must enable materializePartitionColumns"
+    );
+
+    // Partitioned write context with a non-null partition value. The materialize feature
+    // means the partition column stays in the logical batch; constructing that batch with a
+    // null in the NOT NULL `p` column is the failure surface we care about.
+    let txn = snapshot
+        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .with_engine_info("default engine");
+    let _write_context = txn.partitioned_write_context(HashMap::from([(
+        "p".to_string(),
+        Scalar::String("a".into()),
+    )]))?;
+
+    let arrow_schema: ArrowSchema = schema.as_ref().try_into_arrow()?;
+    assert!(
+        !arrow_schema.field_with_name("p")?.is_nullable(),
+        "kernel `not_null` partition field must produce Arrow `nullable: false`",
+    );
+
+    let result = RecordBatch::try_new(
+        Arc::new(arrow_schema),
+        vec![
+            Arc::new(Int32Array::from(vec![Some(1)])),
+            Arc::new(StringArray::from(vec![None as Option<&str>])),
+        ],
+    );
+    assert!(
+        result.is_err(),
+        "RecordBatch::try_new should reject null in NOT NULL materialized partition column; got: {result:?}",
+    );
+
+    Ok(())
+}

--- a/kernel/tests/write/types.rs
+++ b/kernel/tests/write/types.rs
@@ -3,7 +3,8 @@
 use std::sync::Arc;
 
 use delta_kernel::arrow::array::{
-    ArrayRef, BinaryArray, Int32Array, StructArray, TimestampMicrosecondArray,
+    ArrayRef, BinaryArray, BooleanArray, Decimal128Array, Int32Array, Int64Array, StringArray,
+    StructArray, TimestampMicrosecondArray,
 };
 use delta_kernel::arrow::buffer::NullBuffer;
 use delta_kernel::arrow::datatypes::{DataType as ArrowDataType, Field};
@@ -16,11 +17,13 @@ use delta_kernel::engine::default::parquet::DefaultParquetHandler;
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::ObjectStoreExt as _;
 use delta_kernel::schema::{DataType, StructField, StructType};
+use delta_kernel::transaction::create_table::create_table as kernel_create_table;
 use delta_kernel::{Engine, Error as KernelError, Snapshot};
 use itertools::Itertools;
+use rstest::rstest;
 use serde_json::Deserializer;
 use tempfile::tempdir;
-use test_utils::{create_table, engine_store_setup, test_read};
+use test_utils::{create_table, engine_store_setup, test_read, test_table_setup};
 use url::Url;
 
 #[tokio::test]
@@ -461,6 +464,136 @@ async fn test_shredded_variant_read_rejection() -> Result<(), Box<dyn std::error
     let res = test_read(&ArrowEngineData::new(data), &table_url, engine);
     assert!(matches!(res,
         Err(e) if e.to_string().contains("The default engine does not support shredded reads")));
+
+    Ok(())
+}
+
+// =============================================================================
+// NOT NULL data column tests (default engine)
+// =============================================================================
+//
+// These tests pin the contract documented on `maybe_enable_invariants` (see
+// `kernel/src/transaction/builder/create_table.rs`): kernel does not enforce
+// nullability at write time -- it relies on the engine's `ParquetHandler` to
+// do so. The default engine inherits the guarantee from `arrow-rs`, which
+// rejects null values for fields with `nullable: false` at
+// `RecordBatch::try_new`.
+//
+// Each case creates the table via the kernel `create_table` builder so the
+// non-null schema drives the auto-enablement of the `invariants` writer
+// feature end-to-end (the protocol is not hand-crafted). The test then opens
+// the standard write path (snapshot + transaction + `unpartitioned_write_context`)
+// and asserts that the input `RecordBatch` for `engine.write_parquet` cannot
+// be constructed with a null in the NOT NULL column. The failure surfaces
+// before the engine is ever invoked.
+
+fn null_array_int32() -> ArrayRef {
+    Arc::new(Int32Array::from(vec![None as Option<i32>]))
+}
+
+fn null_array_int64() -> ArrayRef {
+    Arc::new(Int64Array::from(vec![None as Option<i64>]))
+}
+
+fn null_array_string() -> ArrayRef {
+    Arc::new(StringArray::from(vec![None as Option<&str>]))
+}
+
+fn null_array_binary() -> ArrayRef {
+    Arc::new(BinaryArray::from(vec![None as Option<&[u8]>]))
+}
+
+fn null_array_boolean() -> ArrayRef {
+    Arc::new(BooleanArray::from(vec![None as Option<bool>]))
+}
+
+fn null_array_timestamp_utc() -> ArrayRef {
+    Arc::new(TimestampMicrosecondArray::from(vec![None as Option<i64>]).with_timezone("UTC"))
+}
+
+fn null_array_decimal_10_2() -> ArrayRef {
+    Arc::new(
+        Decimal128Array::from(vec![None as Option<i128>])
+            .with_precision_and_scale(10, 2)
+            .unwrap(),
+    )
+}
+
+/// Verifies the default-engine NOT NULL contract for non-partition columns
+/// across a representative set of primitive types. The contract:
+///
+/// 1. `nullable: false` propagates from kernel's `StructField` into the Arrow logical schema
+///    produced by `try_into_arrow`.
+/// 2. Constructing the Arrow `RecordBatch` an engine would hand to `engine.write_parquet` with a
+///    null in the NOT NULL column fails at `RecordBatch::try_new`, before the engine is invoked.
+///
+/// See [#2465](https://github.com/delta-io/delta-kernel-rs/issues/2465).
+#[rstest]
+#[case::integer(DataType::INTEGER, null_array_int32 as fn() -> ArrayRef)]
+#[case::long(DataType::LONG, null_array_int64 as fn() -> ArrayRef)]
+#[case::string(DataType::STRING, null_array_string as fn() -> ArrayRef)]
+#[case::binary(DataType::BINARY, null_array_binary as fn() -> ArrayRef)]
+#[case::boolean(DataType::BOOLEAN, null_array_boolean as fn() -> ArrayRef)]
+#[case::timestamp(DataType::TIMESTAMP, null_array_timestamp_utc as fn() -> ArrayRef)]
+#[case::decimal(DataType::decimal(10, 2).unwrap(), null_array_decimal_10_2 as fn() -> ArrayRef)]
+#[tokio::test]
+async fn test_not_null_data_column_rejects_null_in_batch(
+    #[case] data_type: DataType,
+    #[case] null_array_fn: fn() -> ArrayRef,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    // Step 1: Create the table via the kernel builder. The non-null schema is
+    // the only signal needed -- `maybe_enable_invariants` auto-adds the
+    // `invariants` writer feature. The test exercises the full chain
+    // (schema -> auto-enable -> engine enforcement) rather than hand-crafting
+    // the protocol.
+    let schema = Arc::new(StructType::try_new(vec![StructField::not_null(
+        "c",
+        data_type.clone(),
+    )])?);
+    let (_tmp_dir, table_path, engine) = test_table_setup()?;
+    let _ = kernel_create_table(&table_path, schema.clone(), "test/1.0")
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?;
+
+    // Step 2: Confirm the protocol auto-enabled `invariants` -- the upstream
+    // half of the contract this test pins.
+    let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert!(
+        snapshot
+            .table_configuration()
+            .protocol()
+            .writer_features()
+            .is_some_and(|f| f.contains(&delta_kernel::table_features::TableFeature::Invariants)),
+        "non-null schema must auto-enable the `invariants` writer feature",
+    );
+
+    // Step 3: Open the standard default-engine write path. Going through
+    // `Snapshot::transaction` and `unpartitioned_write_context` exercises the
+    // exact setup an engine performs prior to calling `engine.write_parquet`.
+    let txn = snapshot
+        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .with_engine_info("default engine");
+    let _write_context = txn.unpartitioned_write_context()?;
+
+    // Step 4: Confirm `nullable: false` propagates from kernel into the
+    // logical Arrow schema engines build batches against.
+    let arrow_schema: delta_kernel::arrow::datatypes::Schema = schema.as_ref().try_into_arrow()?;
+    assert!(
+        !arrow_schema.field(0).is_nullable(),
+        "kernel `not_null` field must produce Arrow `nullable: false`",
+    );
+
+    // Step 5: Building the input `RecordBatch` for `engine.write_parquet` with
+    // a null in the NOT NULL column must fail at `RecordBatch::try_new`,
+    // before the engine is called. This is the default-engine NOT NULL
+    // enforcement seam documented on `maybe_enable_invariants`.
+    let result = RecordBatch::try_new(Arc::new(arrow_schema), vec![null_array_fn()]);
+    assert!(
+        result.is_err(),
+        "RecordBatch::try_new should reject null in NOT NULL column ({data_type:?}); got: {result:?}",
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Closes the write-time enforcement gap left by #2418, which auto-enables the invariants writer feature on schemas with non-null columns but does not itself reject nulls on writes. Kernel now rejects Scalar::Null partition values for partition columns with nullable: false in partitioned_write_context, matching Delta-Spark's DELTA_NOT_NULL_CONSTRAINT_VIOLATED (SQLSTATE 23502).

The check sits in validate_types alongside the existing type checks. The Scalar::Null inner type continues to be ignored on nulls, so connectors can keep constructing null partition values without first looking up the schema; only the schema field's nullability is enforced. This matches Catalyst's NullType permissiveness and the type-erased on-wire format (partitionValues serializes nulls as JSON null with no type information).

This PR is the top of a 3-PR stack. Until #2481 and #2482 land, the diff here also shows their commits (cumulative diff against main):

1/ #2481 (bottom) -- adds MaterializePartitionColumns to ALLOWED_DELTA_FEATURES so create_table can enable the feature.

2/ #2482 (middle) -- migrates the pre-existing test_materialized_partition_columns_excluded_from_stats off the test_utils::create_table JSON helper to the kernel builder.

3/ This PR (top) -- the NOT NULL write enforcement plus the new tests; the materialized NOT NULL test uses the kernel builder uniformly with the rest, so no local raw-JSON helper is needed.

Adds integration tests covering all three non-null write paths:

1/ Non-materialized partitioned writes (default): kernel rejects the null Scalar at partitioned_write_context time, before serialization. Covered across all column-mapping modes via the kernel create_table builder.

2/ Materialized partitioned writes (materializePartitionColumns): kernel delegates to the engine's ParquetHandler. The default engine inherits the guarantee from arrow-rs, whose RecordBatch::try_new rejects nulls in fields with nullable: false. The table for this case is set up via the kernel create_table builder with delta.feature.materializePartitionColumns=supported (allow-listed by #2481).

3/ Plain non-null data columns: same engine-delegation seam, exercised across a representative primitive type matrix (integer, long, string, binary, boolean, timestamp, decimal). The table is created via the kernel create_table builder so the non-null schema drives the auto-enablement of the invariants writer feature end-to-end; the test asserts both the auto-enable and the downstream RecordBatch::try_new rejection. Pins the full chain documented on maybe_enable_invariants in transaction/builder/create_table.rs.

Fixes #2465.

## How was this change tested?

New unit tests in kernel/src/partition/validation.rs cover null-into-nullable (parameterized over all primitive types), null-with-mismatched-inner-type into nullable, and null-into-non-nullable (parameterized over all primitive types plus the mismatched-inner-type case).

New integration tests in kernel/tests/write/partitioned.rs:

1/ test_partition_not_null_rejects_null_scalar_non_materialized, rstest over ColumnMappingMode::{None, Name, Id}.

2/ test_partition_not_null_accepts_non_null_scalar_non_materialized, happy-path companion confirming the rejection is shape-driven.

3/ test_partition_not_null_rejects_null_in_batch_materialized, builds the materialize-enabled table via the kernel create_table builder using delta.feature.materializePartitionColumns=supported, asserts the feature is enabled, and asserts RecordBatch::try_new rejects a null in the NOT NULL partition column.

New integration test in kernel/tests/write/types.rs:

1/ test_not_null_data_column_rejects_null_in_batch, rstest over integer, long, string, binary, boolean, timestamp, and decimal(10,2). Goes through the full default-engine write-path setup via the kernel create_table builder, asserts invariants was auto-enabled, and asserts the input batch is rejected before the engine is invoked.

Local verification:

1/ cargo +nightly fmt --check
2/ cargo clippy --workspace --benches --tests --all-features -- -D warnings
3/ cargo doc --workspace --all-features --no-deps
4/ cargo test -p delta_kernel --all-features for affected paths