### PR TITLE
feat: add IncrementalScanBuilder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,8 @@ internals. Kernel never does I/O directly -- it defines _what_ to do via its API
 
 Current capabilities: table reads with predicates, data skipping, deletion vectors, change
 data feed, checkpoints (V1 & V2), log compaction (disabled, #2337), blind append writes, table creation
-(including clustered tables), and catalog-managed table support.
+(including clustered tables), catalog-managed table support, and incremental scan over a
+version range (`incremental_scan`).
 
 ## Build & Test Commands
 

--- a/kernel/src/incremental_scan/mod.rs
+++ b/kernel/src/incremental_scan/mod.rs
@@ -1,0 +1,545 @@
+//! Incremental scan API for advancing a cached file listing from a base version to a target
+//! version.
+//!
+//! The flow:
+//! 1. [`IncrementalScanBuilder::build`] returns either an [`IncrementalScanStream`] (success) or
+//!    [`IncrementalScanResult::CommitsUnavailable`] when the snapshot's log_segment cannot serve
+//!    `(base_version, target_version]`. The most common cause is that the snapshot's commit list
+//!    starts past `base_version` (loaded from a checkpoint at version `c >= base_version + 1`, or
+//!    older JSONs were vacuumed away).
+//! 2. The stream is an [`Iterator`] over surviving Add batches in newest-first order. Each item is
+//!    one [`FilteredEngineData`]: the underlying columnar buffer the engine read, with a selection
+//!    vector that picks out the surviving Add rows. Commits whose Adds were all cancelled by later
+//!    Removes do not produce an item.
+//! 3. Call one of the terminal methods to consume the stream:
+//!    - [`IncrementalScanStream::finish_raw`] returns the surviving path sets, no cross-snapshot
+//!      classification.
+//!    - [`IncrementalScanStream::finish`] takes the consumer's base file paths and classifies
+//!      metadata-only re-adds (paths from the surviving Adds that also exist in the base).
+//!    - [`IncrementalScanStream::collect_listing`] is eager sugar that collects every surviving Add
+//!      batch and returns an [`IncrementalListing`]. This is the only path that buffers Add batches
+//!      in memory; the streaming `finish` / `finish_raw` paths do not.
+//!
+//! V2 checkpoint sidecars and log compaction files in the range are not consulted; the stream
+//! reads commit JSONs directly and ignores both. Compaction files are an optimization over the
+//! same underlying actions, and V2 checkpoint sidecars are not aligned to range boundaries.
+//!
+//! Memory: the stream holds one [`HashSet`] of surviving Add paths and one of surviving
+//! Remove paths (sized in `O(adds_in_range)` and `O(removes_in_range)`). It reads commit
+//! JSONs one at a time and drops each batch after dedup. Output buffering is
+//! consumer-controlled (`finish`/`finish_raw` are streaming; `collect_listing` is eager).
+//!
+//! [`HashSet`]: std::collections::HashSet
+//!
+//! # Example
+//! ```rust,no_run
+//! # use std::sync::Arc;
+//! # use delta_kernel::engine::default::{DefaultEngine, DefaultEngineBuilder};
+//! # use delta_kernel::engine::default::storage::store_from_url;
+//! # use delta_kernel::incremental_scan::{IncrementalScanBuilder, IncrementalScanResult};
+//! # use delta_kernel::{Snapshot, DeltaResult, Error};
+//! # let url = delta_kernel::try_parse_uri("./tests/data/basic_partitioned")?;
+//! # let engine = Arc::new(DefaultEngineBuilder::new(store_from_url(&url)?).build());
+//! let target = Snapshot::builder_for(url).at_version(1).build(engine.as_ref())?;
+//! let base_paths: Vec<&str> = vec![]; // empty base for this example
+//! let result = IncrementalScanBuilder::new(target, 0).build(engine.as_ref())?;
+//!
+//! match result {
+//!     IncrementalScanResult::Stream(mut stream) => {
+//!         // Consume surviving Add batches as they arrive (or buffer them).
+//!         while let Some(batch) = stream.next() {
+//!             let _batch = batch?; // append to delta cache
+//!         }
+//!         // Then finalize: kernel intersects base_paths with the surviving Adds.
+//!         let footer = stream.finish(base_paths.iter().copied())?;
+//!         // mask = footer.remove_files U footer.duplicate_add_paths (set union)
+//!         let _ = footer;
+//!     }
+//!     IncrementalScanResult::CommitsUnavailable => { /* full scan fallback */ }
+//!     _ => unreachable!(),
+//! }
+//! # Ok::<(), Error>(())
+//! ```
+
+use std::collections::HashSet;
+use std::sync::{Arc, LazyLock};
+
+use crate::actions::{Add, Remove, ADD_NAME, REMOVE_NAME};
+use crate::engine_data::{FilteredEngineData, GetData, RowVisitor};
+use crate::expressions::{column_name, ColumnName};
+use crate::log_replay::deduplicator::Deduplicator;
+use crate::log_replay::{FileActionDeduplicator, FileActionKey};
+use crate::path::ParsedLogPath;
+use crate::schema::{ColumnNamesAndTypes, DataType, SchemaRef, StructField, StructType, ToSchema};
+use crate::snapshot::SnapshotRef;
+use crate::table_features::Operation;
+use crate::utils::require;
+use crate::{DeltaResult, Engine, EngineData, Error, FileDataReadResultIterator, Version};
+
+/// Schema projected from each commit JSON: `add` and `remove` only. Protocol and metadata
+/// updates between base and target are validated against the target snapshot's protocol via
+/// [`Operation::Scan`]. By the protocol's feature-immutability rule (features cannot be removed
+/// once added), any reader feature present in an intermediate commit is also present in the
+/// target snapshot's protocol; checking the target alone is sufficient.
+static INCREMENTAL_READ_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
+    Arc::new(StructType::new_unchecked([
+        StructField::nullable(ADD_NAME, Add::to_schema()),
+        StructField::nullable(REMOVE_NAME, Remove::to_schema()),
+    ]))
+});
+
+/// Builder for an incremental scan over `(base_version, target_version]`. The target version
+/// is taken from the supplied snapshot; the base version is supplied at construction.
+#[derive(Debug)]
+pub struct IncrementalScanBuilder {
+    snapshot: SnapshotRef,
+    base_version: Version,
+}
+
+impl IncrementalScanBuilder {
+    /// Create a new builder for the range `(base_version, snapshot.version()]`. Listing,
+    /// dedup, and the protocol check happen in [`IncrementalScanBuilder::build`].
+    pub fn new(snapshot: impl Into<SnapshotRef>, base_version: Version) -> Self {
+        Self {
+            snapshot: snapshot.into(),
+            base_version,
+        }
+    }
+
+    /// Build the incremental scan stream.
+    ///
+    /// Runs version validation, the protocol-feature check, and the snapshot-covers-the-range
+    /// check upfront. If the range can be served, returns an [`IncrementalScanStream`] that
+    /// the consumer drives commit-by-commit. Otherwise returns
+    /// [`IncrementalScanResult::CommitsUnavailable`] and the consumer should fall back to a
+    /// full scan via [`crate::Snapshot::scan_builder`].
+    ///
+    /// # Errors
+    /// - `Err` if `base_version >= snapshot.version()` (caller error).
+    /// - `Err` if the target snapshot's protocol contains an unsupported reader feature.
+    ///
+    /// I/O errors and other read failures surface from the [`IncrementalScanStream`] itself
+    /// (or from its terminal methods), not here.
+    pub fn build<'a>(self, engine: &'a dyn Engine) -> DeltaResult<IncrementalScanResult<'a>> {
+        // TODO(#2493): the version validation, the snapshot-commit-list extraction and
+        // clipping below, and the "snapshot covers the range" check should all be replaced
+        // by a single `CommitRangeBuilder::from_snapshot(...).build(engine)` call once
+        // that primitive lands. https://github.com/delta-io/delta-kernel-rs/issues/2493
+        let target_version = self.snapshot.version();
+        require!(
+            self.base_version < target_version,
+            Error::generic(format!(
+                "IncrementalScanBuilder: base_version ({}) must be less than target_version ({})",
+                self.base_version, target_version
+            ))
+        );
+
+        // Confirm kernel supports the target's reader features. Mirrors `Scan::new`. The
+        // intermediate commits in `(base_version, target_version]` are read for their `add`
+        // and `remove` actions only -- their schemas/stats are passed through opaquely to
+        // the caller, who is expected to interpret them against the target snapshot.
+        self.snapshot
+            .table_configuration()
+            .ensure_operation_supported(Operation::Scan)?;
+
+        // TODO(#2493): replace this block with `CommitRange` once it exists.
+        // Today we use the snapshot's already-validated commit list rather than re-listing
+        // storage. This is correct for catalog-managed tables: the snapshot's log_segment
+        // includes any staged/ratified-but-unpublished commits passed in via `with_log_tail`,
+        // which a fresh storage listing would silently miss. `CommitRange` will own this
+        // listing-and-validation responsibility centrally.
+        let snapshot_commits = &self.snapshot.log_segment().listed.ascending_commit_files;
+        let snapshot_first_version = snapshot_commits.first().map(|c| c.version);
+
+        // TODO(#2493): this "snapshot covers range" check becomes a typed error from
+        // `CommitRange::build` (e.g. `Error::CommitsUnavailable { missing: Range<Version> }`),
+        // pattern-matched here to produce `IncrementalScanResult::CommitsUnavailable`.
+        let start_version = self.base_version + 1;
+        if snapshot_first_version.is_none_or(|v| v > start_version) {
+            return Ok(IncrementalScanResult::CommitsUnavailable);
+        }
+
+        // Collect the in-range commits in ascending order. The stream pops from the end so
+        // the iteration order is newest-first, which gives `FileActionDeduplicator`
+        // newest-wins semantics across the range.
+        let commits_remaining: Vec<ParsedLogPath> = snapshot_commits
+            .iter()
+            .filter(|c| c.version >= start_version && c.version <= target_version)
+            .cloned()
+            .collect();
+
+        Ok(IncrementalScanResult::Stream(IncrementalScanStream {
+            base_version: self.base_version,
+            target_version,
+            engine,
+            commits_remaining,
+            current_batches: None,
+            seen_file_keys: HashSet::new(),
+            surviving_add_paths: HashSet::new(),
+            remove_files: HashSet::new(),
+            errored: false,
+        }))
+    }
+}
+
+/// Outcome of [`IncrementalScanBuilder::build`].
+//
+// The size disparity between `Stream` (carries the dedup state) and `CommitsUnavailable`
+// (unit) is intentional. Boxing the stream would force every consumer through a heap
+// allocation on the common path; consumers destructure this enum immediately after
+// `build()`, so the move is one-shot and the size is fine.
+#[allow(clippy::large_enum_variant)]
+#[non_exhaustive]
+pub enum IncrementalScanResult<'a> {
+    /// Drive this stream commit-by-commit, then call one of the terminal methods
+    /// ([`IncrementalScanStream::finish`], [`IncrementalScanStream::finish_raw`], or
+    /// [`IncrementalScanStream::collect_listing`]) to finalize.
+    Stream(IncrementalScanStream<'a>),
+    /// The snapshot's log_segment cannot serve `(base_version, target_version]`.
+    /// Consumers should fall back to a full scan via [`crate::Snapshot::scan_builder`].
+    CommitsUnavailable,
+}
+
+impl std::fmt::Debug for IncrementalScanResult<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Stream(s) => f.debug_tuple("Stream").field(s).finish(),
+            Self::CommitsUnavailable => f.write_str("CommitsUnavailable"),
+        }
+    }
+}
+
+/// Streaming output of an incremental scan: surviving Add batches in newest-first order,
+/// followed by a terminal method that returns the surviving path sets.
+///
+/// Driving the iterator is what advances dedup state, so any of the terminal methods
+/// drains anything the consumer hasn't pulled before computing the final state.
+///
+/// If the iterator surfaces an error, the dedup state becomes inconsistent. Calling a
+/// terminal method on an errored stream returns `Err` rather than producing a stale
+/// footer. The terminal methods consume `self`, so the type system prevents reuse.
+pub struct IncrementalScanStream<'a> {
+    base_version: Version,
+    target_version: Version,
+    engine: &'a dyn Engine,
+    /// Commits to read, in ascending order. We pop from the end so iteration is newest-first.
+    commits_remaining: Vec<ParsedLogPath>,
+    /// Batch iterator for the commit currently being read. `None` between commits.
+    current_batches: Option<FileDataReadResultIterator>,
+    seen_file_keys: HashSet<FileActionKey>,
+    surviving_add_paths: HashSet<String>,
+    remove_files: HashSet<String>,
+    /// Set when the iterator yields an `Err`. Subsequent `next()` calls return `None`;
+    /// terminal methods return `Err`.
+    errored: bool,
+}
+
+impl Iterator for IncrementalScanStream<'_> {
+    type Item = DeltaResult<FilteredEngineData>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.errored {
+            return None;
+        }
+        loop {
+            // Take the in-flight batch iterator, or open one for the next commit. We use
+            // `Option::insert` rather than a separate `is_none()` check followed by an
+            // unwrap so the borrow checker sees a single mutable borrow path.
+            let batches = match &mut self.current_batches {
+                Some(b) => b,
+                None => {
+                    let commit = self.commits_remaining.pop()?;
+                    let result = self.engine.json_handler().read_json_files(
+                        std::slice::from_ref(&commit.location),
+                        INCREMENTAL_READ_SCHEMA.clone(),
+                        None,
+                    );
+                    match result {
+                        Ok(b) => self.current_batches.insert(b),
+                        Err(e) => {
+                            self.errored = true;
+                            return Some(Err(e));
+                        }
+                    }
+                }
+            };
+
+            match batches.next() {
+                None => {
+                    // Current commit exhausted; loop to the next commit.
+                    self.current_batches = None;
+                    continue;
+                }
+                Some(Err(e)) => {
+                    self.errored = true;
+                    return Some(Err(e));
+                }
+                Some(Ok(batch)) => {
+                    match process_batch(
+                        batch,
+                        &mut self.seen_file_keys,
+                        &mut self.surviving_add_paths,
+                        &mut self.remove_files,
+                    ) {
+                        Ok(Some(filtered)) => return Some(Ok(filtered)),
+                        Ok(None) => continue,
+                        Err(e) => {
+                            self.errored = true;
+                            return Some(Err(e));
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl IncrementalScanStream<'_> {
+    /// Drain any unread commits, then return the surviving path sets without applying
+    /// cross-snapshot dedup. Consumers can intersect these against whatever base
+    /// data structure they prefer.
+    ///
+    /// # Errors
+    /// Returns `Err` if the stream previously yielded an error (dedup state is incomplete),
+    /// or if draining produces an error.
+    pub fn finish_raw(mut self) -> DeltaResult<IncrementalScanRawFooter> {
+        if self.errored {
+            return Err(Error::generic(
+                "IncrementalScanStream: cannot finish a stream that previously errored",
+            ));
+        }
+        // Drain anything the consumer didn't pull. `self.next()` propagates errors via
+        // `Some(Err(_))` and sets `errored`; the `?` below surfaces them.
+        for item in self.by_ref() {
+            item?;
+        }
+        Ok(IncrementalScanRawFooter {
+            base_version: self.base_version,
+            target_version: self.target_version,
+            surviving_add_paths: self.surviving_add_paths,
+            remove_files: self.remove_files,
+        })
+    }
+
+    /// Drain any unread commits, then intersect `base_paths` against the surviving-Add
+    /// path set to compute `duplicate_add_paths`. Sugar over [`finish_raw`] plus a single
+    /// pass over `base_paths`.
+    ///
+    /// `base_paths` is iterated exactly once. Memory stays `O(surviving_adds)`; kernel
+    /// does not materialize a HashSet of base paths.
+    ///
+    /// [`finish_raw`]: Self::finish_raw
+    pub fn finish<P: AsRef<str>>(
+        self,
+        base_paths: impl IntoIterator<Item = P>,
+    ) -> DeltaResult<IncrementalListingFooter> {
+        let raw = self.finish_raw()?;
+        let duplicate_add_paths: HashSet<String> = base_paths
+            .into_iter()
+            .filter(|p| raw.surviving_add_paths.contains(p.as_ref()))
+            .map(|p| p.as_ref().to_string())
+            .collect();
+        Ok(IncrementalListingFooter {
+            base_version: raw.base_version,
+            target_version: raw.target_version,
+            duplicate_add_paths,
+            remove_files: raw.remove_files,
+        })
+    }
+
+    /// Eager helper: collect every surviving Add batch into a [`Vec`], then call
+    /// [`finish`] to produce a fully-classified [`IncrementalListing`]. Use this when
+    /// the diff fits in memory and the consumer prefers the simpler eager shape.
+    ///
+    /// [`finish`]: Self::finish
+    pub fn collect_listing<P: AsRef<str>>(
+        mut self,
+        base_paths: impl IntoIterator<Item = P>,
+    ) -> DeltaResult<IncrementalListing> {
+        let mut add_files: Vec<FilteredEngineData> = Vec::new();
+        for item in self.by_ref() {
+            add_files.push(item?);
+        }
+        let footer = self.finish(base_paths)?;
+        Ok(IncrementalListing { footer, add_files })
+    }
+}
+
+impl std::fmt::Debug for IncrementalScanStream<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IncrementalScanStream")
+            .field("base_version", &self.base_version)
+            .field("target_version", &self.target_version)
+            .field("commits_remaining", &self.commits_remaining.len())
+            .field("surviving_add_paths", &self.surviving_add_paths.len())
+            .field("remove_files", &self.remove_files.len())
+            .field("errored", &self.errored)
+            .finish()
+    }
+}
+
+/// Surviving path sets without cross-snapshot classification, returned by
+/// [`IncrementalScanStream::finish_raw`].
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct IncrementalScanRawFooter {
+    /// Exclusive lower bound of the scan range, as supplied to [`IncrementalScanBuilder`].
+    pub base_version: Version,
+    /// Inclusive upper bound; equals the source snapshot's version.
+    pub target_version: Version,
+    /// Paths of surviving Add actions in `(base_version, target_version]`.
+    pub surviving_add_paths: HashSet<String>,
+    /// Paths of surviving Remove actions in `(base_version, target_version]`.
+    pub remove_files: HashSet<String>,
+}
+
+/// Cross-snapshot-classified path sets, returned by [`IncrementalScanStream::finish`].
+///
+/// To advance a delta-on-base file listing cache, append the streamed Add batches to
+/// the delta layer and use the union `remove_files U duplicate_add_paths` as the
+/// remove-mask against the base. Both sets are required: `remove_files` masks paths
+/// that left the table; `duplicate_add_paths` masks the stale base entry of each
+/// path that the range re-added with new metadata.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct IncrementalListingFooter {
+    /// Exclusive lower bound of the scan range.
+    pub base_version: Version,
+    /// Inclusive upper bound; equals the source snapshot's version.
+    pub target_version: Version,
+    /// Paths from the surviving Add stream that also appear in the consumer's base
+    /// listing (metadata-only re-adds, e.g. OPTIMIZE / liquid clustering re-tag).
+    /// Surfaced separately so consumers can mask matching base entries or mirror the
+    /// set for telemetry. The corresponding rows are still in the streamed Adds.
+    pub duplicate_add_paths: HashSet<String>,
+    /// Paths of surviving Remove actions. Consumers must union this with
+    /// `duplicate_add_paths` when masking the base; the union is what makes
+    /// metadata-only re-adds correct (the new Add is the live entry, the stale
+    /// base copy must be masked).
+    pub remove_files: HashSet<String>,
+}
+
+/// Eager output of [`IncrementalScanStream::collect_listing`]: the buffered Add batches
+/// plus the classified footer.
+#[non_exhaustive]
+pub struct IncrementalListing {
+    /// Classified path sets for the range; see [`IncrementalListingFooter`].
+    pub footer: IncrementalListingFooter,
+    /// All surviving Add batches in descending commit-version order. One entry per source
+    /// commit batch that produced any surviving Adds.
+    pub add_files: Vec<FilteredEngineData>,
+}
+
+impl std::fmt::Debug for IncrementalListing {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IncrementalListing")
+            .field("footer", &self.footer)
+            .field("add_files_batch_count", &self.add_files.len())
+            .finish()
+    }
+}
+
+/// Visit one commit-batch, updating dedup state and accumulators. Returns the filtered Add
+/// rows for this batch, or `None` if no Adds survived dedup in this batch.
+fn process_batch(
+    batch: Box<dyn EngineData>,
+    seen_file_keys: &mut HashSet<FileActionKey>,
+    surviving_add_paths: &mut HashSet<String>,
+    remove_files: &mut HashSet<String>,
+) -> DeltaResult<Option<FilteredEngineData>> {
+    let row_count = batch.len();
+    let mut adds_sel = vec![false; row_count];
+
+    let deduplicator = FileActionDeduplicator::new(
+        seen_file_keys,
+        true, // commit batches always update the seen set
+        ADD_PATH_INDEX,
+        REMOVE_PATH_INDEX,
+        ADD_DV_START_INDEX,
+        REMOVE_DV_START_INDEX,
+    );
+    let mut visitor = IncrementalDedupVisitor {
+        deduplicator,
+        adds_sel: &mut adds_sel,
+        surviving_add_paths,
+        remove_files,
+    };
+    visitor.visit_rows_of(batch.as_ref())?;
+
+    if !adds_sel.iter().any(|s| *s) {
+        return Ok(None);
+    }
+    Ok(Some(FilteredEngineData::try_new(batch, adds_sel)?))
+}
+
+// === Visitor ===
+
+// Indices of the leaf columns visited per row; must match `selected_column_names_and_types`.
+const ADD_PATH_INDEX: usize = 0;
+const ADD_DV_START_INDEX: usize = 1; // .storageType, .pathOrInlineDv, .offset
+const REMOVE_PATH_INDEX: usize = 4;
+const REMOVE_DV_START_INDEX: usize = 5; // .storageType, .pathOrInlineDv, .offset
+
+struct IncrementalDedupVisitor<'a, 'seen> {
+    deduplicator: FileActionDeduplicator<'seen>,
+    adds_sel: &'a mut [bool],
+    surviving_add_paths: &'a mut HashSet<String>,
+    remove_files: &'a mut HashSet<String>,
+}
+
+impl RowVisitor for IncrementalDedupVisitor<'_, '_> {
+    fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
+        static NAMES_AND_TYPES: LazyLock<ColumnNamesAndTypes> = LazyLock::new(|| {
+            const STRING: DataType = DataType::STRING;
+            const INTEGER: DataType = DataType::INTEGER;
+            let columns = vec![
+                (STRING, column_name!("add.path")),
+                (STRING, column_name!("add.deletionVector.storageType")),
+                (STRING, column_name!("add.deletionVector.pathOrInlineDv")),
+                (INTEGER, column_name!("add.deletionVector.offset")),
+                (STRING, column_name!("remove.path")),
+                (STRING, column_name!("remove.deletionVector.storageType")),
+                (STRING, column_name!("remove.deletionVector.pathOrInlineDv")),
+                (INTEGER, column_name!("remove.deletionVector.offset")),
+            ];
+            let (types, names) = columns.into_iter().unzip();
+            (names, types).into()
+        });
+        let (names, types) = NAMES_AND_TYPES.as_ref();
+        (names, types)
+    }
+
+    fn visit<'a>(&mut self, row_count: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
+        require!(
+            getters.len() == 8,
+            Error::InternalError(format!(
+                "IncrementalDedupVisitor expected 8 getters, got {}",
+                getters.len()
+            ))
+        );
+
+        for i in 0..row_count {
+            let Some((key, is_add)) = self.deduplicator.extract_file_action(i, getters, false)?
+            else {
+                continue;
+            };
+
+            // Both Adds AND Removes update the seen set. A duplicate Add for a file
+            // removed earlier in the range (later chronologically, since we read newest
+            // first) must not leak through.
+            let path = key.path.clone();
+            if self.deduplicator.check_and_record_seen(key) {
+                continue;
+            }
+
+            if is_add {
+                self.adds_sel[i] = true;
+                self.surviving_add_paths.insert(path);
+            } else {
+                self.remove_files.insert(path);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -98,6 +98,7 @@ pub(crate) mod crc;
 pub mod engine_data;
 pub mod error;
 pub mod expressions;
+pub mod incremental_scan;
 mod log_compaction;
 mod log_path;
 mod log_reader;

--- a/kernel/tests/incremental_scan.rs
+++ b/kernel/tests/incremental_scan.rs
@@ -1,0 +1,1042 @@
+//! Integration tests for [`IncrementalScanBuilder`].
+//!
+//! These cover the dedup edge cases that were known to bite consumers doing their own
+//! cross-commit deduplication: cross-commit cancellation, chained add/remove/add, and
+//! metadata-only re-adds (paths in the consumer's base that get a new Add action in
+//! the range).
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use delta_kernel::engine::default::executor::tokio::TokioBackgroundExecutor;
+use delta_kernel::engine::default::{DefaultEngine, DefaultEngineBuilder};
+use delta_kernel::incremental_scan::{
+    IncrementalListing, IncrementalScanBuilder, IncrementalScanRawFooter, IncrementalScanResult,
+};
+use delta_kernel::object_store::memory::InMemory;
+use delta_kernel::object_store::path::Path as ObjectStorePath;
+use delta_kernel::object_store::ObjectStoreExt;
+use delta_kernel::Snapshot;
+use rstest::rstest;
+use test_utils::{
+    actions_to_string, actions_to_string_catalog_managed, add_commit, add_staged_commit,
+    compacted_log_path_for_versions, create_log_path, delta_path_for_version, TestAction,
+};
+use url::Url;
+
+fn setup_test() -> (
+    Arc<InMemory>,
+    Arc<DefaultEngine<TokioBackgroundExecutor>>,
+    Url,
+) {
+    let storage = Arc::new(InMemory::new());
+    let table_root = Url::parse("memory:///").unwrap();
+    let engine = Arc::new(DefaultEngineBuilder::new(storage.clone()).build());
+    (storage, engine, table_root)
+}
+
+fn surviving_add_count(listing: &IncrementalListing) -> usize {
+    listing
+        .add_files
+        .iter()
+        .map(|f| f.selection_vector().iter().filter(|s| **s).count())
+        .sum()
+}
+
+fn unwrap_listing<P: AsRef<str>>(
+    result: IncrementalScanResult<'_>,
+    base_paths: impl IntoIterator<Item = P>,
+) -> IncrementalListing {
+    match result {
+        IncrementalScanResult::Stream(s) => s
+            .collect_listing(base_paths)
+            .expect("collect_listing succeeded"),
+        other => panic!("expected Stream, got {other:?}"),
+    }
+}
+
+// Compaction-chain pattern: an Add in commit N is cancelled by a Remove for
+// the same path in a later commit. The kernel's `(path, dv_unique_id)` dedup, walking
+// newest-first with first-seen-wins, drops the older Add and keeps the surviving Remove.
+#[tokio::test]
+async fn newer_remove_cancels_older_add() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    // v0: Metadata + Protocol (table creation).
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        actions_to_string(vec![TestAction::Metadata]),
+    )
+    .await?;
+    // v1: add(X).
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        1,
+        actions_to_string(vec![TestAction::Add("X".to_string())]),
+    )
+    .await?;
+    // v2: remove(X).
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        2,
+        actions_to_string(vec![TestAction::Remove("X".to_string())]),
+    )
+    .await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(2)
+        .build(engine.as_ref())?;
+
+    let listing = unwrap_listing(
+        IncrementalScanBuilder::new(target, 0).build(engine.as_ref())?,
+        std::iter::empty::<&str>(),
+    );
+
+    assert_eq!(
+        surviving_add_count(&listing),
+        0,
+        "older Add(X) is cancelled by newer Remove(X)"
+    );
+    assert!(
+        listing.footer.remove_files.contains("X"),
+        "Remove(X) survives in remove_files"
+    );
+    assert!(listing.footer.duplicate_add_paths.is_empty());
+
+    Ok(())
+}
+
+// Compaction-chain (3 commits): every add is cancelled by a later remove except the
+// last. Without correct cross-commit dedup, an Add for a removed file would leak through.
+#[tokio::test]
+async fn compaction_chain_cancels_intermediate_adds() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        actions_to_string(vec![TestAction::Metadata]),
+    )
+    .await?;
+    // v1: add(A)
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        1,
+        actions_to_string(vec![TestAction::Add("A".to_string())]),
+    )
+    .await?;
+    // v2: add(B), remove(A)
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        2,
+        actions_to_string(vec![
+            TestAction::Add("B".to_string()),
+            TestAction::Remove("A".to_string()),
+        ]),
+    )
+    .await?;
+    // v3: add(C), remove(B)
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        3,
+        actions_to_string(vec![
+            TestAction::Add("C".to_string()),
+            TestAction::Remove("B".to_string()),
+        ]),
+    )
+    .await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(3)
+        .build(engine.as_ref())?;
+
+    let listing = unwrap_listing(
+        IncrementalScanBuilder::new(target, 0).build(engine.as_ref())?,
+        std::iter::empty::<&str>(),
+    );
+
+    // Only C survives as an add; A and B were cancelled by their respective newer Removes.
+    assert_eq!(surviving_add_count(&listing), 1);
+    // Both Removes survive in remove_files (A and B). They harmlessly target a base
+    // that does not contain them, but the kernel does not assume base content here.
+    assert!(listing.footer.remove_files.contains("A"));
+    assert!(listing.footer.remove_files.contains("B"));
+    assert!(listing.footer.duplicate_add_paths.is_empty());
+
+    Ok(())
+}
+
+// Metadata-only re-add: a path that is already in the consumer's base listing gets a new
+// Add action in the range (e.g., OPTIMIZE / liquid clustering re-tag). The Add row stays
+// in `add_files` (so the new metadata is delivered); the path is also surfaced in
+// `duplicate_add_paths` so the consumer can mask its stale base entry.
+#[tokio::test]
+async fn metadata_only_readd_surfaces_in_duplicate_add_paths(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        actions_to_string(vec![TestAction::Metadata]),
+    )
+    .await?;
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        1,
+        actions_to_string(vec![TestAction::Add("re-added.parquet".to_string())]),
+    )
+    .await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(1)
+        .build(engine.as_ref())?;
+
+    // Consumer's base has the path that v1 re-adds.
+    let base_paths: HashSet<&str> = ["re-added.parquet"].into_iter().collect();
+    let listing = unwrap_listing(
+        IncrementalScanBuilder::new(target, 0).build(engine.as_ref())?,
+        base_paths.iter().copied(),
+    );
+
+    assert_eq!(
+        surviving_add_count(&listing),
+        1,
+        "the re-add row stays in add_files so new metadata is delivered"
+    );
+    assert!(
+        listing
+            .footer
+            .duplicate_add_paths
+            .contains("re-added.parquet"),
+        "path is surfaced as duplicate so consumers mask stale base entries"
+    );
+    assert!(listing.footer.remove_files.is_empty());
+
+    Ok(())
+}
+
+// Mix: one Add that's truly new and one Add that's a metadata-only re-add. The two
+// classifications coexist and are reported correctly.
+#[tokio::test]
+async fn mixed_new_and_duplicate_adds() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        actions_to_string(vec![TestAction::Metadata]),
+    )
+    .await?;
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        1,
+        actions_to_string(vec![
+            TestAction::Add("brand-new.parquet".to_string()),
+            TestAction::Add("re-added.parquet".to_string()),
+        ]),
+    )
+    .await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(1)
+        .build(engine.as_ref())?;
+
+    let base_paths: HashSet<&str> = ["re-added.parquet"].into_iter().collect();
+    let listing = unwrap_listing(
+        IncrementalScanBuilder::new(target, 0).build(engine.as_ref())?,
+        base_paths.iter().copied(),
+    );
+
+    assert_eq!(surviving_add_count(&listing), 2);
+    assert_eq!(listing.footer.duplicate_add_paths.len(), 1);
+    assert!(listing
+        .footer
+        .duplicate_add_paths
+        .contains("re-added.parquet"));
+
+    Ok(())
+}
+
+// Catalog-managed: commits in the range live as staged JSONs under `_staged_commits/`
+// (not in the published log) and are surfaced to the snapshot via `with_log_tail`.
+// `IncrementalScanBuilder` must walk the snapshot's commit list -- not re-list storage --
+// or those commits are silently invisible and the diff is wrong.
+#[tokio::test]
+async fn picks_up_staged_commits_from_log_tail() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    // v0: published, catalog-managed metadata. v1, v2: staged-only.
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        actions_to_string_catalog_managed(vec![TestAction::Metadata]),
+    )
+    .await?;
+    let staged1 = add_staged_commit(
+        table_root,
+        storage.as_ref(),
+        1,
+        actions_to_string(vec![TestAction::Add("staged-1.parquet".to_string())]),
+    )
+    .await?;
+    let staged2 = add_staged_commit(
+        table_root,
+        storage.as_ref(),
+        2,
+        actions_to_string(vec![TestAction::Add("staged-2.parquet".to_string())]),
+    )
+    .await?;
+
+    let log_tail = vec![
+        create_log_path(&table_url, staged1),
+        create_log_path(&table_url, staged2),
+    ];
+    let target = Snapshot::builder_for(table_url)
+        .with_log_tail(log_tail)
+        .with_max_catalog_version(2)
+        .build(engine.as_ref())?;
+    assert_eq!(target.version(), 2);
+
+    let listing = unwrap_listing(
+        IncrementalScanBuilder::new(target, 0).build(engine.as_ref())?,
+        std::iter::empty::<&str>(),
+    );
+
+    // Both staged Adds must survive -- they're only reachable via log_tail.
+    assert_eq!(
+        surviving_add_count(&listing),
+        2,
+        "expected 2 surviving Adds from staged commits in log_tail"
+    );
+    assert_eq!(listing.footer.target_version, 2);
+
+    Ok(())
+}
+
+// A commit in the range that contains only Remove actions (no Adds) should not crash,
+// should produce no entries in `add_files`, and the Remove paths should land in
+// `remove_files`.
+#[tokio::test]
+async fn removes_only_commit_in_range() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        actions_to_string(vec![TestAction::Metadata]),
+    )
+    .await?;
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        1,
+        actions_to_string(vec![
+            TestAction::Remove("gone-a.parquet".to_string()),
+            TestAction::Remove("gone-b.parquet".to_string()),
+        ]),
+    )
+    .await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(1)
+        .build(engine.as_ref())?;
+
+    let listing = unwrap_listing(
+        IncrementalScanBuilder::new(target, 0).build(engine.as_ref())?,
+        std::iter::empty::<&str>(),
+    );
+
+    assert_eq!(surviving_add_count(&listing), 0);
+    assert!(listing.add_files.is_empty(), "no Adds means no add batches");
+    assert_eq!(listing.footer.remove_files.len(), 2);
+    assert!(listing.footer.remove_files.contains("gone-a.parquet"));
+    assert!(listing.footer.remove_files.contains("gone-b.parquet"));
+
+    Ok(())
+}
+
+// A commit in the range with only metadata actions (no Add or Remove) should be
+// silently skipped: no add batches, no removes.
+#[tokio::test]
+async fn metadata_only_commit_in_range() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        actions_to_string(vec![TestAction::Metadata]),
+    )
+    .await?;
+    // v1 contains only the standard Metadata; no Add or Remove.
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        1,
+        actions_to_string(vec![TestAction::Metadata]),
+    )
+    .await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(1)
+        .build(engine.as_ref())?;
+
+    let listing = unwrap_listing(
+        IncrementalScanBuilder::new(target, 0).build(engine.as_ref())?,
+        std::iter::empty::<&str>(),
+    );
+
+    assert_eq!(surviving_add_count(&listing), 0);
+    assert!(listing.add_files.is_empty());
+    assert!(listing.footer.remove_files.is_empty());
+    assert!(listing.footer.duplicate_add_paths.is_empty());
+
+    Ok(())
+}
+
+// === DV-aware dedup ===
+// The kernel's dedup key is `(path, dv_unique_id)`, where `dv_unique_id` is built from
+// `(storageType, pathOrInlineDv, offset)`. These tests construct raw commit JSON
+// (TestAction doesn't emit DV-bearing Adds) to exercise the DV cases.
+
+const ACTION_METADATA: &str = "{\"metaData\":{\"id\":\"test-id\",\"format\":{\"provider\":\"parquet\",\"options\":{}},\"schemaString\":\"{\\\"type\\\":\\\"struct\\\",\\\"fields\\\":[]}\",\"partitionColumns\":[],\"configuration\":{},\"createdTime\":1700000000000}}\n{\"protocol\":{\"minReaderVersion\":3,\"minWriterVersion\":7,\"readerFeatures\":[\"deletionVectors\"],\"writerFeatures\":[\"deletionVectors\"]}}";
+
+fn add_with_dv(path: &str, storage_type: &str, path_or_inline: &str, offset: i32) -> String {
+    format!(
+        "{{\"add\":{{\"path\":\"{path}\",\"partitionValues\":{{}},\"size\":100,\"modificationTime\":1700000000000,\"dataChange\":true,\"stats\":null,\"tags\":null,\"deletionVector\":{{\"storageType\":\"{storage_type}\",\"pathOrInlineDv\":\"{path_or_inline}\",\"offset\":{offset},\"sizeInBytes\":10,\"cardinality\":1}},\"baseRowId\":null,\"defaultRowCommitVersion\":null,\"clusteringProvider\":null}}}}"
+    )
+}
+
+fn add_no_dv(path: &str) -> String {
+    format!(
+        "{{\"add\":{{\"path\":\"{path}\",\"partitionValues\":{{}},\"size\":100,\"modificationTime\":1700000000000,\"dataChange\":true,\"stats\":null,\"tags\":null,\"deletionVector\":null,\"baseRowId\":null,\"defaultRowCommitVersion\":null,\"clusteringProvider\":null}}}}"
+    )
+}
+
+// Same path with two different DVs across commits: both rows must survive. The dedup
+// key includes dv_unique_id, so `(X, dv1)` and `(X, dv2)` are distinct and neither
+// cancels the other. This is the protocol-correct outcome for DV-update flows where
+// the file's tombstone state changes between commits.
+#[tokio::test]
+async fn same_path_different_dvs_both_survive() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    add_commit(table_root, storage.as_ref(), 0, ACTION_METADATA.to_string()).await?;
+    // v1: Add(X, dv=u/abc/1)
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        1,
+        add_with_dv("X.parquet", "u", "abc", 1),
+    )
+    .await?;
+    // v2: Add(X, dv=u/xyz/2) -- different DV id, distinct key.
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        2,
+        add_with_dv("X.parquet", "u", "xyz", 2),
+    )
+    .await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(2)
+        .build(engine.as_ref())?;
+
+    let listing = unwrap_listing(
+        IncrementalScanBuilder::new(target, 0).build(engine.as_ref())?,
+        std::iter::empty::<&str>(),
+    );
+
+    assert_eq!(
+        surviving_add_count(&listing),
+        2,
+        "two Adds for the same path with different DVs must both survive (distinct keys)"
+    );
+    assert!(listing.footer.remove_files.is_empty());
+
+    Ok(())
+}
+
+// Same path with the same DV across commits: only the newest Add survives. With dedup
+// walking newest-first, the first occurrence of `(X, dv)` wins and the older copy is
+// dropped. This is the standard "duplicate Add" case.
+#[tokio::test]
+async fn same_path_same_dv_only_newest_survives() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    add_commit(table_root, storage.as_ref(), 0, ACTION_METADATA.to_string()).await?;
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        1,
+        add_with_dv("X.parquet", "u", "abc", 1),
+    )
+    .await?;
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        2,
+        add_with_dv("X.parquet", "u", "abc", 1),
+    )
+    .await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(2)
+        .build(engine.as_ref())?;
+
+    let listing = unwrap_listing(
+        IncrementalScanBuilder::new(target, 0).build(engine.as_ref())?,
+        std::iter::empty::<&str>(),
+    );
+
+    assert_eq!(
+        surviving_add_count(&listing),
+        1,
+        "duplicate `(path, dv)` keys collapse to one surviving Add"
+    );
+
+    Ok(())
+}
+
+// DV-update pattern: v1 introduces the file with no DV; v2 emits Remove(X, no_dv) +
+// Add(X, dv1). The Remove has key `(X, NULL)` and cancels the v1 Add. The new Add has
+// key `(X, dv1)` -- distinct -- and survives. The consumer sees one surviving Add
+// with the new DV and one surviving Remove for the old (no-DV) version.
+#[tokio::test]
+async fn dv_update_remove_no_dv_add_with_dv() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    add_commit(table_root, storage.as_ref(), 0, ACTION_METADATA.to_string()).await?;
+    // v1: Add(X) without a DV.
+    add_commit(table_root, storage.as_ref(), 1, add_no_dv("X.parquet")).await?;
+    // v2: Remove(X, no_dv) + Add(X, dv=u/abc/1).
+    let remove_no_dv = "{\"remove\":{\"path\":\"X.parquet\",\"deletionTimestamp\":1700000000000,\"dataChange\":true,\"deletionVector\":null}}".to_string();
+    let v2_actions = format!(
+        "{}\n{}",
+        remove_no_dv,
+        add_with_dv("X.parquet", "u", "abc", 1),
+    );
+    add_commit(table_root, storage.as_ref(), 2, v2_actions).await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(2)
+        .build(engine.as_ref())?;
+
+    let listing = unwrap_listing(
+        IncrementalScanBuilder::new(target, 0).build(engine.as_ref())?,
+        std::iter::empty::<&str>(),
+    );
+
+    // The new DV-bearing Add (key `(X, dv1)`) survives. The v1 no-DV Add (key `(X, NULL)`)
+    // is cancelled by the v2 no-DV Remove (same key).
+    assert_eq!(
+        surviving_add_count(&listing),
+        1,
+        "the new DV-bearing Add survives; the old no-DV Add is cancelled"
+    );
+    assert!(
+        listing.footer.remove_files.contains("X.parquet"),
+        "the no-DV Remove survives in remove_files"
+    );
+
+    Ok(())
+}
+
+// A commit file that the snapshot listed is removed before the stream reads it (e.g. a
+// vacuum races between snapshot construction and the incremental scan). The build() call
+// only does metadata-only checks and succeeds, but the stream surfaces `FileNotFound`
+// while reading the missing commit. Consumers fall back to a full scan on any stream
+// error.
+#[tokio::test]
+async fn missing_commit_file_surfaces_error_during_iteration(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        actions_to_string(vec![TestAction::Metadata]),
+    )
+    .await?;
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        1,
+        actions_to_string(vec![TestAction::Add("a.parquet".to_string())]),
+    )
+    .await?;
+
+    let target = Snapshot::builder_for(table_url.clone())
+        .at_version(1)
+        .build(engine.as_ref())?;
+
+    // Simulate a vacuum: delete the v1 commit JSON from underlying storage AFTER the
+    // snapshot is built (so the snapshot still lists it, but reading it will fail).
+    let v1_path: ObjectStorePath = delta_path_for_version(1, "json");
+    storage.delete(&v1_path).await?;
+
+    let result = IncrementalScanBuilder::new(target, 0).build(engine.as_ref())?;
+    let mut stream = match result {
+        IncrementalScanResult::Stream(s) => s,
+        other => panic!("expected Stream, got {other:?}"),
+    };
+
+    // The stream reads commit JSONs lazily; the missing file surfaces here.
+    let item = stream
+        .next()
+        .expect("stream should yield an error item before exhausting");
+    let err = match item {
+        Ok(_) => panic!("expected FileNotFound from the stream, got an Ok batch"),
+        Err(e) => e,
+    };
+    assert!(
+        matches!(err, delta_kernel::Error::FileNotFound(_)),
+        "expected FileNotFound, got {err:?}"
+    );
+
+    // Subsequent finish_raw must also error rather than silently returning a
+    // partial footer.
+    let finish_err = stream
+        .finish_raw()
+        .expect_err("finish_raw should error on a previously-errored stream");
+    assert!(
+        finish_err.to_string().contains("previously errored"),
+        "unexpected finish_raw error: {finish_err}"
+    );
+
+    Ok(())
+}
+
+// Caller errors: a base_version that is not strictly less than the target snapshot's version
+// must surface as `Err`, not as a `CommitsUnavailable` listing. The latter is reserved for
+// log-retention / vacuum-race scenarios; equal or inverted ranges are programmer mistakes.
+// Target snapshot is at v1; the parameter is the (invalid) base_version.
+#[rstest]
+#[case::base_equals_target(1)]
+#[case::base_above_target(2)]
+#[case::base_at_max(u64::MAX)]
+#[tokio::test]
+async fn rejects_invalid_base_version(
+    #[case] bad_base: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        actions_to_string(vec![TestAction::Metadata]),
+    )
+    .await?;
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        1,
+        actions_to_string(vec![TestAction::Add("a.parquet".to_string())]),
+    )
+    .await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(1)
+        .build(engine.as_ref())?;
+
+    let err = IncrementalScanBuilder::new(target, bad_base)
+        .build(engine.as_ref())
+        .expect_err("expected Err for invalid base_version");
+    assert!(
+        err.to_string().contains("must be less than"),
+        "unexpected error: {err}"
+    );
+
+    Ok(())
+}
+
+// A log compaction file alongside the JSON commits in the range must not affect the
+// result. Kernel's incremental path reads commit JSONs directly (the snapshot's log
+// segment exposes commits and compactions on separate fields, and this builder iterates
+// only `ascending_commit_files`). The compaction is ignored. We assert the listing matches
+// what we'd get without the compaction file present at all.
+#[tokio::test]
+async fn compaction_file_in_range_is_ignored() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    // v0 Metadata; v1 add A,B; v2 remove A; v3 add C.
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        actions_to_string(vec![TestAction::Metadata]),
+    )
+    .await?;
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        1,
+        actions_to_string(vec![
+            TestAction::Add("A".to_string()),
+            TestAction::Add("B".to_string()),
+        ]),
+    )
+    .await?;
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        2,
+        actions_to_string(vec![TestAction::Remove("A".to_string())]),
+    )
+    .await?;
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        3,
+        actions_to_string(vec![TestAction::Add("C".to_string())]),
+    )
+    .await?;
+
+    // Drop a compaction file covering 1-3 next to the commit JSONs. Body is irrelevant
+    // because the incremental scan never opens it.
+    let compaction_path: ObjectStorePath = compacted_log_path_for_versions(1, 3, "json");
+    storage
+        .put(&compaction_path, bytes::Bytes::new().into())
+        .await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(3)
+        .build(engine.as_ref())?;
+
+    let listing = unwrap_listing(
+        IncrementalScanBuilder::new(target, 0).build(engine.as_ref())?,
+        std::iter::empty::<&str>(),
+    );
+
+    assert_eq!(
+        surviving_add_count(&listing),
+        2,
+        "B (live) and C (live) survive; A is cancelled by the v2 Remove"
+    );
+    assert_eq!(
+        listing.footer.remove_files,
+        HashSet::from(["A".to_string()]),
+        "Remove(A) survives"
+    );
+    assert!(listing.footer.duplicate_add_paths.is_empty());
+
+    Ok(())
+}
+
+// `finish_raw` returns the surviving Add and Remove path sets without applying the
+// cross-snapshot intersection. Connectors that own a non-HashSet base data structure
+// take this path and apply their own intersection.
+#[tokio::test]
+async fn finish_raw_returns_surviving_paths() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        actions_to_string(vec![TestAction::Metadata]),
+    )
+    .await?;
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        1,
+        actions_to_string(vec![
+            TestAction::Add("A".to_string()),
+            TestAction::Add("B".to_string()),
+        ]),
+    )
+    .await?;
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        2,
+        actions_to_string(vec![
+            TestAction::Remove("A".to_string()),
+            TestAction::Add("C".to_string()),
+        ]),
+    )
+    .await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(2)
+        .build(engine.as_ref())?;
+
+    let stream = match IncrementalScanBuilder::new(target, 0).build(engine.as_ref())? {
+        IncrementalScanResult::Stream(s) => s,
+        other => panic!("expected Stream, got {other:?}"),
+    };
+
+    // Drain entirely via finish_raw without ever calling next() ourselves.
+    let footer: IncrementalScanRawFooter = stream.finish_raw()?;
+    assert_eq!(footer.base_version, 0);
+    assert_eq!(footer.target_version, 2);
+    assert_eq!(
+        footer.surviving_add_paths,
+        HashSet::from(["B".to_string(), "C".to_string()]),
+    );
+    assert_eq!(footer.remove_files, HashSet::from(["A".to_string()]));
+
+    Ok(())
+}
+
+// The iterator yields one batch per source commit that produced surviving Adds, in
+// descending commit-version order. Commits whose Adds were all cancelled by later
+// Removes do not produce an item, but they still update dedup state for older commits.
+#[tokio::test]
+async fn streaming_yields_batches_newest_first_skipping_cancelled_commits(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    // v0: Metadata
+    // v1: add(A)
+    // v2: add(B)
+    // v3: remove(A), remove(B)  -> all earlier Adds cancelled; v3 itself only has Removes,
+    //                              which do not contribute to add_files. v1's and v2's
+    //                              Adds are also cancelled.
+    // v4: add(C)
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        actions_to_string(vec![TestAction::Metadata]),
+    )
+    .await?;
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        1,
+        actions_to_string(vec![TestAction::Add("A".to_string())]),
+    )
+    .await?;
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        2,
+        actions_to_string(vec![TestAction::Add("B".to_string())]),
+    )
+    .await?;
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        3,
+        actions_to_string(vec![
+            TestAction::Remove("A".to_string()),
+            TestAction::Remove("B".to_string()),
+        ]),
+    )
+    .await?;
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        4,
+        actions_to_string(vec![TestAction::Add("C".to_string())]),
+    )
+    .await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(4)
+        .build(engine.as_ref())?;
+
+    let mut stream = match IncrementalScanBuilder::new(target, 0).build(engine.as_ref())? {
+        IncrementalScanResult::Stream(s) => s,
+        other => panic!("expected Stream, got {other:?}"),
+    };
+
+    let mut batches: Vec<delta_kernel::engine_data::FilteredEngineData> = Vec::new();
+    for item in stream.by_ref() {
+        batches.push(item?);
+    }
+
+    // v4 produced the surviving add(C); v3 had only Removes (no add item);
+    // v2 and v1 had their adds cancelled by v3 (no add items). So exactly one batch.
+    assert_eq!(
+        batches.len(),
+        1,
+        "expected one yielded batch (v4 only); v3 has no Adds, v1/v2 cancelled"
+    );
+    let surviving: usize = batches[0].selection_vector().iter().filter(|s| **s).count();
+    assert_eq!(surviving, 1, "the single yielded batch contains add(C)");
+
+    // Removes still flow into remove_files even though their commit didn't produce a batch.
+    let footer = stream.finish(std::iter::empty::<&str>())?;
+    assert_eq!(
+        footer.remove_files,
+        HashSet::from(["A".to_string(), "B".to_string()]),
+    );
+
+    Ok(())
+}
+
+// The pull-then-finalize flow: drive the iterator manually with `next()`, then call
+// `finish(base_paths)` to classify duplicates. This is the documented streaming
+// consumer pattern (the module-level example shows exactly this).
+#[tokio::test]
+async fn finish_after_manual_streaming_classifies_duplicates(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        actions_to_string(vec![TestAction::Metadata]),
+    )
+    .await?;
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        1,
+        actions_to_string(vec![
+            TestAction::Add("brand-new.parquet".to_string()),
+            TestAction::Add("re-added.parquet".to_string()),
+        ]),
+    )
+    .await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(1)
+        .build(engine.as_ref())?;
+
+    let mut stream = match IncrementalScanBuilder::new(target, 0).build(engine.as_ref())? {
+        IncrementalScanResult::Stream(s) => s,
+        other => panic!("expected Stream, got {other:?}"),
+    };
+
+    let mut yielded = 0;
+    for item in stream.by_ref() {
+        let _batch = item?;
+        yielded += 1;
+    }
+    assert_eq!(yielded, 1, "v1 produced one Add batch");
+
+    // base contains "re-added" and a path that's NOT in the surviving Adds; only the
+    // intersection should appear in duplicate_add_paths.
+    let footer = stream.finish(["re-added.parquet", "not-in-range.parquet"].iter().copied())?;
+    assert_eq!(
+        footer.duplicate_add_paths,
+        HashSet::from(["re-added.parquet".to_string()]),
+        "non-matching base path is filtered out"
+    );
+    assert!(footer.remove_files.is_empty());
+
+    Ok(())
+}
+
+// A single batch where some Adds survive dedup and some are cancelled. Exercises the
+// non-trivial selection-vector path in `process_batch` (mixed booleans, not all-true
+// or all-false).
+#[tokio::test]
+async fn mixed_intra_batch_selection_vector() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    // v0: Metadata
+    // v1: add(A)
+    // v2: add(B), add(C), add(D)   <- all three are Adds, but B and D get cancelled by v3
+    // v3: remove(B), remove(D)
+    // base = 0, target = 3. Newest-first: v3 records (B,-) and (D,-) seen. v2's Adds:
+    //   B is seen -> cancelled, C is new -> survives, D is seen -> cancelled.
+    // So v2's batch has selection vector = [false, true, false] (mixed).
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        actions_to_string(vec![TestAction::Metadata]),
+    )
+    .await?;
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        1,
+        actions_to_string(vec![TestAction::Add("A".to_string())]),
+    )
+    .await?;
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        2,
+        actions_to_string(vec![
+            TestAction::Add("B".to_string()),
+            TestAction::Add("C".to_string()),
+            TestAction::Add("D".to_string()),
+        ]),
+    )
+    .await?;
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        3,
+        actions_to_string(vec![
+            TestAction::Remove("B".to_string()),
+            TestAction::Remove("D".to_string()),
+        ]),
+    )
+    .await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(3)
+        .build(engine.as_ref())?;
+
+    let listing = unwrap_listing(
+        IncrementalScanBuilder::new(target, 0).build(engine.as_ref())?,
+        std::iter::empty::<&str>(),
+    );
+
+    // Two yielded batches: v2 (with mixed selection [false,true,false]) and v1 (with [true]).
+    assert_eq!(listing.add_files.len(), 2);
+    let total_surviving = surviving_add_count(&listing);
+    assert_eq!(total_surviving, 2, "C and A survive; B and D cancelled");
+    assert_eq!(
+        listing.footer.remove_files,
+        HashSet::from(["B".to_string(), "D".to_string()]),
+    );
+
+    // Find the batch whose selection has both true and false entries (the v2 batch),
+    // confirming the non-trivial mask path was exercised.
+    let mixed_batch = listing
+        .add_files
+        .iter()
+        .find(|b| {
+            let sv = b.selection_vector();
+            sv.iter().any(|s| *s) && sv.iter().any(|s| !*s)
+        })
+        .expect("expected at least one batch with mixed selection");
+    assert_eq!(mixed_batch.selection_vector().len(), 3);
+
+    Ok(())
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds `IncrementalScanBuilder`, a public API for advancing a cached file listing from a base version to a target version without re-scanning the table.

The stream is an `Iterator<Item = DeltaResult<FilteredEngineData>>` of deduped Add batches in newest-first order; each batch carries the underlying columnar buffer the engine read, with a selection vector picking out the surviving Add rows. 

After driving the iterator, the consumer calls one of three terminal methods to finalize:

- `finish_raw()` returns `IncrementalScanRawFooter { surviving_add_paths, remove_files }`. Connectors with non-HashSet base structures (sorted vec, bloom filter, async lookup) can apply their own intersection.
- `finish(base_paths)` returns `IncrementalListingFooter { duplicate_add_paths, remove_files }`. Kernel streams `base_paths` once and intersects against the surviving-Add path set to classify metadata-only re-adds.
- `collect_listing(base_paths)` buffers every surviving Add batch and calls `finish`, returning `IncrementalListing { footer, add_files }`.

The output maps directly onto a delta-on-base file listing cache: append each yielded batch to the delta layer as it arrives, and union `footer.remove_files` with `footer.duplicate_add_paths` to mask base entries. 




## Example

```rust
use std::collections::HashSet;
use delta_kernel::incremental_scan::{IncrementalScanBuilder, IncrementalScanResult};
use delta_kernel::Snapshot;

let target = Snapshot::builder_for(table_url).at_version(target_version).build(engine)?;

match IncrementalScanBuilder::new(target, base_version).build(engine)? {
    IncrementalScanResult::Stream(mut stream) => {
        while let Some(batch) = stream.next() {
            apply_to_cache(batch?);
        }
        let footer = stream.finish(base_file_paths.iter().copied())?;
        let mut mask: HashSet<String> = footer.remove_files;
        mask.extend(footer.duplicate_add_paths);
        mask_in_cache(mask);
    }
    IncrementalScanResult::CommitsUnavailable => {
        full_scan(target);
    }
    _ => unreachable!(),
}
```

## How was this change tested?

Integration tests 