### PR TITLE
feat: allow materializePartitionColumns feature signal in CREATE TABLE

### DIFF
--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -75,6 +75,11 @@ const ALLOWED_DELTA_FEATURES: &[TableFeature] = &[
     // the feature on an all-nullable table so a later ALTER TABLE ADD COLUMN NOT NULL does
     // not need a protocol upgrade.
     TableFeature::Invariants,
+    // MaterializePartitionColumns keeps partition columns in the data files instead of
+    // dropping them on write. There is no `delta.*` enablement property; the only opt-in at
+    // create time is the explicit feature signal
+    // `delta.feature.materializePartitionColumns=supported`.
+    TableFeature::MaterializePartitionColumns,
 ];
 
 /// Delta properties allowed to be set during CREATE TABLE.

--- a/kernel/tests/create_table/main.rs
+++ b/kernel/tests/create_table/main.rs
@@ -470,6 +470,13 @@ async fn test_create_table_txn_debug() -> DeltaResult<()> {
 #[case("appendOnly", TableFeature::AppendOnly, false, false)]
 #[case("changeDataFeed", TableFeature::ChangeDataFeed, false, false)]
 #[case("rowTracking", TableFeature::RowTracking, false, false)]
+// WriterOnly features (AlwaysIfSupported)
+#[case(
+    "materializePartitionColumns",
+    TableFeature::MaterializePartitionColumns,
+    false,
+    true
+)]
 fn test_create_table_with_feature_signal(
     #[case] feature_name: &str,
     #[case] feature: TableFeature,

--- a/kernel/tests/create_table/partitioned.rs
+++ b/kernel/tests/create_table/partitioned.rs
@@ -4,13 +4,14 @@
 
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::snapshot::Snapshot;
+use delta_kernel::table_features::TableFeature;
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::DeltaResult;
 use rstest::rstest;
 use test_utils::test_table_setup;
 
-use super::partition_test_schema;
+use super::{partition_test_schema, simple_schema};
 
 #[rstest]
 #[case::exact_casing("date")]
@@ -35,6 +36,43 @@ fn test_create_table_partitioned_basic(#[case] partition_col: &str) -> DeltaResu
     assert!(
         clustering.is_none(),
         "Partitioned table should not have clustering columns"
+    );
+
+    Ok(())
+}
+
+/// CREATE TABLE accepts `delta.feature.materializePartitionColumns=supported` regardless of
+/// whether the table is partitioned. The feature is harmless on a non-partitioned table
+/// (nothing to materialize) and Delta-Spark also does not error in that case, so kernel
+/// matches that behavior.
+#[rstest]
+#[case::partitioned(true)]
+#[case::non_partitioned(false)]
+fn test_create_table_with_materialize_partition_columns_partitioned_and_not(
+    #[case] partitioned: bool,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let schema = if partitioned {
+        partition_test_schema()?
+    } else {
+        simple_schema()?
+    };
+
+    let mut builder = create_table(&table_path, schema, "Test/1.0")
+        .with_table_properties([("delta.feature.materializePartitionColumns", "supported")]);
+    if partitioned {
+        builder = builder.with_data_layout(DataLayout::partitioned(["date"]));
+    }
+    let _ = builder
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?;
+
+    let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert!(
+        snapshot
+            .table_configuration()
+            .is_feature_enabled(&TableFeature::MaterializePartitionColumns),
+        "MaterializePartitionColumns should be enabled (partitioned={partitioned})"
     );
 
     Ok(())


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds TableFeature::MaterializePartitionColumns to ALLOWED_DELTA_FEATURES.

The feature is already fully understood by kernel: KernelSupport::Supported, the write path keeps
partition columns in data files when the feature is on (Transaction::generate_logical_to_physical and TableConfiguration::physical_write_schema), and the read path is correct (scan reconstructs partition columns
from add.partitionValues regardless of whether they are materialized in the file).

The remaining gap was the create_table builder allow-list, which rejected delta.feature.materializePartitionColumns=supported at build time.

There is no delta.* enablement property for materializePartitionColumns in kernel today (MATERIALIZE_PARTITION_COLUMNS_INFO is EnablementCheck::AlwaysIfSupported), so the
only opt-in at create time is the explicit feature signal.

## How was this change tested?

1/ New unit test test_create_table_with_materialize_partition_columns_feature_signal_allowed in kernel/tests/create_table/partitioned.rs. asserts that the feature signal lands in writerFeatures exactly once, does not appear in readerFeatures (writer-only), and is_feature_enabled returns true.

2/ Local verification:

  - cargo +nightly fmt --check
  - cargo clippy --workspace --benches --tests --all-features -- -D warnings
  - cargo doc --workspace --all-features --no-deps
  - cargo test -p delta_kernel --all-features for affected paths
