### PR TITLE
feat: enforce and test non-null column invariant on writes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,8 @@ directly -- always use the visitor pattern (`visit_rows` with typed `GetData` ac
   whether a new test duplicates the flow of an existing nearby test and should be
   merged into it as a new `#[case]`. A common pattern is toggling a feature (e.g.
   column mapping on/off) and asserting success vs. error.
-- Reuse helpers from `test_utils` instead of writing custom ones when possible.
+- Reuse helpers from `test_utils` and the integration-test fixtures instead of writing
+  custom ones when possible. See **Common test helpers** below for a curated starter list.
 - **Committing in tests:** Use `txn.commit(engine)?.unwrap_committed()` to assert a
   successful commit and get the `CommittedTransaction`. Do NOT use `match` + `panic!`
   for this -- `unwrap_committed()` provides a clear error message on failure. Available
@@ -139,6 +140,64 @@ directly -- always use the visitor pattern (`visit_rows` with typed `GetData` ac
   `InMemory::new()` with `"memory:///"`. Always use the same `table_root` URL string for
   both `add_commit` (writing log files) and `snapshot`/`Snapshot::try_new` (reading the
   table). Always include a trailing slash in directory URLs to ensure correct path joining.
+
+### Common test helpers
+
+Before writing a custom helper, check this curated list and the locations below.
+This list is non-exhaustive -- when in doubt, browse the source files directly
+(`test-utils/src/lib.rs`, `kernel/tests/integration/common/`,
+`kernel/tests/integration/<topic>/mod.rs`).
+
+**Arrow construction (from `delta_kernel::arrow`)**
+
+- `arrow::array::new_null_array(&arrow_type, n)` -- Arrow array of `n` nulls of any Arrow
+  type. Prefer this over per-type `Int32Array::from(vec![None as Option<i32>])` builders.
+- `engine::arrow_conversion::TryIntoArrow`:
+  `(&kernel_data_type).try_into_arrow()` for `DataType`,
+  `(&kernel_struct_type).try_into_arrow()` for `StructType` -> Arrow `Schema`.
+
+**Engine + table setup (from `test_utils`)**
+
+- `test_table_setup()` / `test_table_setup_mt()` -- engine + temp table path. Use the `_mt`
+  variant under `#[tokio::test(flavor = "multi_thread")]`.
+- `engine_store_setup(name, opts)` -- returns `(store, engine, table_location)` when a test
+  needs direct object-store access.
+- `setup_test_tables(...)` -- multiple pre-built tables for read/scan tests.
+
+**Table creation in tests**
+
+- Prefer the kernel `create_table` builder
+  (`delta_kernel::transaction::create_table::create_table`). It exercises the same path
+  connectors use and auto-derives the protocol from the schema and feature flags.
+- `test_utils::create_table` (a JSON helper that hand-rolls protocol + metadata) is older
+  but still needed when the kernel builder cannot enable a particular feature combination.
+
+**Schema fixtures**
+
+- `test_utils`: `nested_schema`, `schema_with_type`, `nested_schema_with_type`,
+  `multi_schema_with_type`, `top_level_ntz_schema` / `nested_ntz_schema` /
+  `multiple_ntz_schema`, `top_level_variant_schema` / `nested_variant_schema` /
+  `multiple_variant_schema`.
+- `kernel/tests/integration/create_table/mod.rs`: `simple_schema`, `partition_test_schema`.
+
+**Commit + read helpers (from `test_utils`)**
+
+- `add_commit`, `add_staged_commit` -- write a JSON commit at a given version.
+- `read_actions_from_commit` -- read raw JSON actions from a specific commit. Use this
+  instead of hand-rolled `serde_json` parsing.
+- `test_read` -- full-scan read of a table; use for round-trip assertions.
+- `into_record_batch` -- convert `Box<dyn EngineData>` to Arrow `RecordBatch`.
+
+**Assertion helpers (from `test_utils`)**
+
+- `assert_schema_has_field(schema, &["a", "b"])` -- assert a (possibly nested) field path.
+- `assert_result_error_with_message(result, "needle")` -- assert an error contains a
+  substring.
+
+**If a name here doesn't match what's in code:** the list may have drifted from a rename.
+Run `rg '^pub (fn|async fn)' test-utils/src/lib.rs` to discover the current public surface,
+and update this section in your PR. The same pattern works for
+`kernel/tests/integration/common/write_utils.rs`.
 
 ## Protocol TLDR
 

--- a/kernel/src/partition/serialization.rs
+++ b/kernel/src/partition/serialization.rs
@@ -44,13 +44,35 @@ const UNIX_EPOCH_CE_DAYS: i32 = 719_163;
 // Binary            Raw UTF-8: String::from_utf8            strict, error on invalid
 // Struct/Array/Map  Error                                   not valid partition types
 
+/// Whether a partition-value [`Scalar`] is equivalent to null under the Delta protocol's
+/// partition value serialization rules.
+///
+/// The protocol collapses three Scalar shapes onto JSON null in `AddFile.partitionValues`:
+/// `Scalar::Null(_)`, empty `Scalar::String`, and empty `Scalar::Binary`. Partition
+/// values are serialized according to protocol rules on write and interpreted against
+/// the table schema on read, so all three forms must be treated as null before enforcing
+/// NOT NULL constraints.
+///
+/// Read paths do not need this predicate: the on-wire collapse to JSON null is undone at
+/// JSON deserialization (null map entries are dropped before kernel sees a Scalar), so a
+/// "null" partition value never appears in Scalar form on reads.
+pub(crate) fn would_serialize_to_null(value: &Scalar) -> bool {
+    match value {
+        Scalar::Null(_) => true,
+        Scalar::String(s) if s.is_empty() => true,
+        Scalar::Binary(b) if b.is_empty() => true,
+        _ => false,
+    }
+}
+
 /// Serializes a [`Scalar`] partition value to a protocol-compliant string for the
 /// `partitionValues` map in Add actions.
 ///
-/// Returns `Ok(None)` for null values (regardless of the null's data type), empty strings,
-/// and empty binary (the Delta protocol treats all three as null partition values). Returns
-/// `Err` for non-null values of types that cannot be partition columns (Struct, Array, Map)
-/// or for binary values that are not valid UTF-8.
+/// Returns `Ok(None)` for any value the Delta protocol treats as null in `partitionValues`:
+/// `Scalar::Null`, empty `Scalar::String`, and empty `Scalar::Binary`. Non-null partition
+/// values are serialized according to protocol rules; readers interpret the stored value
+/// against the table schema. Returns `Err` for non-null values of types that cannot be
+/// partition columns (Struct, Array, Map) or for binary values that are not valid UTF-8.
 ///
 /// The inverse of [`PrimitiveType::parse_scalar`].
 ///
@@ -58,7 +80,8 @@ const UNIX_EPOCH_CE_DAYS: i32 = 719_163;
 pub fn serialize_partition_value(value: &Scalar) -> DeltaResult<Option<String>> {
     match value {
         Scalar::Null(_) => Ok(None),
-        Scalar::String(s) => Ok(if s.is_empty() { None } else { Some(s.clone()) }),
+        Scalar::String(s) if s.is_empty() => Ok(None),
+        Scalar::String(s) => Ok(Some(s.clone())),
         Scalar::Boolean(v) => Ok(Some(v.to_string())),
         Scalar::Byte(v) => Ok(Some(v.to_string())),
         Scalar::Short(v) => Ok(Some(v.to_string())),
@@ -70,13 +93,8 @@ pub fn serialize_partition_value(value: &Scalar) -> DeltaResult<Option<String>> 
         Scalar::Timestamp(us) => Ok(Some(format_timestamp(*us)?)),
         Scalar::TimestampNtz(us) => Ok(Some(format_timestamp_ntz(*us)?)),
         Scalar::Decimal(d) => Ok(Some(format_decimal(d))),
-        Scalar::Binary(b) => {
-            if b.is_empty() {
-                Ok(None)
-            } else {
-                Ok(Some(format_binary(b)?))
-            }
-        }
+        Scalar::Binary(b) if b.is_empty() => Ok(None),
+        Scalar::Binary(b) => Ok(Some(format_binary(b)?)),
         Scalar::Struct(_) | Scalar::Array(_) | Scalar::Map(_) => Err(Error::generic(format!(
             "cannot serialize partition value: type {:?} is not a valid partition column type",
             value.data_type()
@@ -252,6 +270,39 @@ mod tests {
     #[case::row49_empty_binary(Scalar::Binary(vec![]))]
     fn test_spark_ref_empty_value_returns_none(#[case] input: Scalar) {
         assert_eq!(serialize_partition_value(&input).unwrap(), None);
+    }
+
+    /// Tests the canonical null-equivalence rule: `would_serialize_to_null` returns true for
+    /// exactly the three Scalar shapes that collapse to JSON null (`Scalar::Null`, empty
+    /// `Scalar::String`, empty `Scalar::Binary`) and false for everything else, including
+    /// non-empty strings/binary and primitive scalars.
+    #[rstest]
+    // Null-equivalent: all three shapes return true.
+    #[case::null_int(Scalar::Null(DataType::INTEGER), true)]
+    #[case::null_string(Scalar::Null(DataType::STRING), true)]
+    #[case::null_binary(Scalar::Null(DataType::BINARY), true)]
+    #[case::empty_string(Scalar::String(String::new()), true)]
+    #[case::empty_binary(Scalar::Binary(Vec::new()), true)]
+    // Non-empty strings/binary and primitive scalars return false.
+    #[case::nonempty_string(Scalar::String("a".into()), false)]
+    #[case::single_space(Scalar::String(" ".into()), false)]
+    #[case::nonempty_binary(Scalar::Binary(vec![0x00]), false)]
+    #[case::integer(Scalar::Integer(0), false)]
+    #[case::boolean_false(Scalar::Boolean(false), false)]
+    fn test_would_serialize_to_null(#[case] value: Scalar, #[case] expected: bool) {
+        assert_eq!(would_serialize_to_null(&value), expected);
+    }
+
+    /// Cross-check: any value where `would_serialize_to_null` is true must also serialize
+    /// to `Ok(None)`, and vice versa for the cases above. Locks the predicate to the actual
+    /// serialization outcome so the helper cannot drift from `serialize_partition_value`.
+    #[rstest]
+    #[case(Scalar::Null(DataType::INTEGER))]
+    #[case(Scalar::String(String::new()))]
+    #[case(Scalar::Binary(Vec::new()))]
+    fn test_would_serialize_to_null_matches_serialize_result(#[case] value: Scalar) {
+        assert!(would_serialize_to_null(&value));
+        assert_eq!(serialize_partition_value(&value).unwrap(), None);
     }
 
     // ============================================================================

--- a/kernel/src/partition/validation.rs
+++ b/kernel/src/partition/validation.rs
@@ -19,11 +19,12 @@
 //! - [`validate_keys`]: checks key completeness (case-insensitive matching, normalizes to schema
 //!   case, detects post-normalization duplicates).
 //! - [`validate_types`]: checks that each `Scalar`'s type matches the partition column's schema
-//!   type. Null scalars skip the type check.
-
+//!   type, and that non-null partition columns are never assigned a value that would serialize to a
+//!   null partition value.
 use std::collections::HashMap;
 
 use crate::expressions::Scalar;
+use crate::partition::serialization::would_serialize_to_null;
 use crate::schema::{DataType, StructType};
 use crate::{DeltaResult, Error};
 
@@ -105,8 +106,15 @@ fn validate_keys(
 }
 
 /// Validates that each [`Scalar`] value's type is compatible with the corresponding
-/// partition column's type in the table schema. Null scalars skip the type check
-/// (null is valid for any partition column type).
+/// partition column's type in the table schema. Values that would serialize to a null
+/// partition value skip the value type check, but a
+/// null partition value is only legal when the schema field is nullable.
+///
+/// Nullability is enforced before any non-null type check, so the rejection treats null
+/// scalars and their serialization-equivalent forms (empty strings, empty binary)
+/// uniformly -- otherwise an empty `Scalar::String` for a `nullable: false` column would
+/// pass validation, then collapse to JSON null at serialization, landing a null value in
+/// a NOT NULL column.
 ///
 /// # Parameters
 /// - `logical_schema`: the table's logical schema.
@@ -117,6 +125,8 @@ fn validate_keys(
 /// # Errors
 /// - A partition column is not found in the table schema
 /// - A partition column's schema type is not a primitive (struct, array, map are rejected)
+/// - A null-equivalent value (null scalar, empty string, or empty binary) is provided for a
+///   non-nullable partition column
 /// - A non-null value's type does not match the partition column's schema type
 fn validate_types(
     logical_schema: &StructType,
@@ -138,7 +148,13 @@ fn validate_types(
                  Partition columns must be primitive types."
             )));
         }
-        if value.is_null() {
+        if would_serialize_to_null(value) {
+            if !field.nullable {
+                return Err(Error::invalid_partition_values(format!(
+                    "partition column '{col_name}' is not nullable but received a value that \
+                     serializes to null (null scalar, empty string, or empty binary)"
+                )));
+            }
             continue;
         }
         let actual_type = value.data_type();
@@ -170,6 +186,14 @@ mod tests {
         let schema = StructType::new_unchecked(vec![StructField::not_null("p", data_type)]);
         let values = HashMap::from([("p".to_string(), value)]);
         validate_types(&schema, &values).unwrap_err().to_string()
+    }
+
+    /// Like [`assert_type_ok`] but uses a `nullable` schema field. Used by null-value cases,
+    /// since null scalars are only valid for nullable partition columns.
+    fn assert_type_ok_nullable(data_type: DataType, value: Scalar) {
+        let schema = StructType::new_unchecked(vec![StructField::nullable("p", data_type)]);
+        let values = HashMap::from([("p".to_string(), value)]);
+        validate_types(&schema, &values).unwrap();
     }
 
     // ============================================================================
@@ -310,7 +334,9 @@ mod tests {
     /// Every non-null row from the "String and binary encoding" table in
     /// `partition/mod.rs`. Row numbers reference that table.
     #[rstest]
-    // STRING rows
+    // STRING rows. Rows 49 (empty binary) and 65 (empty string) are null-equivalent under
+    // the protocol and are covered by the null-into-nullable / null-into-non-nullable tests
+    // further down -- they are intentionally absent from this "type-match passes" group.
     #[case(DataType::STRING, Scalar::String("\x00".into()))] // row 47
     #[case(DataType::STRING, Scalar::String("before\x00after".into()))] // row 48
     #[case(DataType::STRING, Scalar::String("a{b".into()))] // row 54
@@ -324,11 +350,9 @@ mod tests {
     #[case(DataType::STRING, Scalar::String("a&b+c$d;e,f".into()))] // row 62
     #[case(DataType::STRING, Scalar::String("Serbia/srb%".into()))] // row 63
     #[case(DataType::STRING, Scalar::String("100%25".into()))] // row 64
-    #[case(DataType::STRING, Scalar::String("".into()))] // row 65
     #[case(DataType::STRING, Scalar::String(" ".into()))] // row 67
     #[case(DataType::STRING, Scalar::String("  ".into()))] // row 68
     // BINARY rows
-    #[case(DataType::BINARY, Scalar::Binary(vec![]))] // row 49
     #[case(DataType::BINARY, Scalar::Binary(vec![0xDE, 0xAD, 0xBE, 0xEF]))] // row 50
     #[case(DataType::BINARY, Scalar::Binary(vec![0x48, 0x45, 0x4C, 0x4C, 0x4F]))] // row 51
     #[case(DataType::BINARY, Scalar::Binary(vec![0x00, 0xFF]))] // row 52
@@ -340,8 +364,10 @@ mod tests {
         assert_type_ok(data_type, value);
     }
 
-    /// NULL rows from the encoding table. Null is valid for every partition column type,
-    /// regardless of the Scalar::Null inner type.
+    /// Null-equivalent rows from the encoding table. Under the Delta protocol, three Scalar
+    /// shapes serialize to JSON null in `partitionValues`: `Scalar::Null`, empty `Scalar::String`,
+    /// and empty `Scalar::Binary`. All three are valid for every partition column type when the
+    /// schema field is nullable, regardless of the `Scalar::Null` inner type.
     #[rstest]
     #[case(DataType::INTEGER, Scalar::Null(DataType::INTEGER))] // row 5
     #[case(DataType::LONG, Scalar::Null(DataType::LONG))] // row 8
@@ -356,16 +382,50 @@ mod tests {
     #[case(DataType::TIMESTAMP_NTZ, Scalar::Null(DataType::TIMESTAMP_NTZ))] // row 46
     #[case(DataType::STRING, Scalar::Null(DataType::STRING))] // row 66
     #[case(DataType::BINARY, Scalar::Null(DataType::BINARY))] // (binary NULL)
-    fn test_validate_types_null_returns_ok(#[case] data_type: DataType, #[case] value: Scalar) {
-        assert_type_ok(data_type, value);
+    #[case(DataType::STRING, Scalar::String(String::new()))] // row 65: empty string
+    #[case(DataType::BINARY, Scalar::Binary(Vec::new()))] // row 49: empty binary
+    fn test_validate_types_null_into_nullable_returns_ok(
+        #[case] data_type: DataType,
+        #[case] value: Scalar,
+    ) {
+        assert_type_ok_nullable(data_type, value);
     }
 
-    /// Null skips the type check even when the Scalar::Null inner type does not match
-    /// the schema column type. This is intentional: null is valid for any partition
-    /// column regardless of what type the Null carries.
+    /// Null skips the value type check even when the `Scalar::Null` inner type does not match
+    /// the schema column type. This is intentional: null carries no concrete type to compare
+    /// against.
     #[test]
     fn test_validate_types_null_with_mismatched_inner_type_returns_ok() {
-        assert_type_ok(DataType::INTEGER, Scalar::Null(DataType::STRING));
+        assert_type_ok_nullable(DataType::INTEGER, Scalar::Null(DataType::STRING));
+    }
+
+    /// A null-equivalent partition value (null scalar, empty string, or empty binary) for
+    /// a non-nullable partition column is rejected
+    #[rstest]
+    #[case(DataType::INTEGER, Scalar::Null(DataType::INTEGER))]
+    #[case(DataType::LONG, Scalar::Null(DataType::LONG))]
+    #[case(DataType::STRING, Scalar::Null(DataType::STRING))]
+    #[case(DataType::BINARY, Scalar::Null(DataType::BINARY))]
+    #[case(DataType::BOOLEAN, Scalar::Null(DataType::BOOLEAN))]
+    #[case(DataType::DATE, Scalar::Null(DataType::DATE))]
+    #[case(DataType::TIMESTAMP, Scalar::Null(DataType::TIMESTAMP))]
+    #[case(DataType::TIMESTAMP_NTZ, Scalar::Null(DataType::TIMESTAMP_NTZ))]
+    #[case(DataType::decimal(10, 2).unwrap(), Scalar::Null(DataType::decimal(10, 2).unwrap()))]
+    // Null with mismatched inner type is also rejected the schema's nullability is the
+    // only thing checked for null scalars.
+    #[case(DataType::INTEGER, Scalar::Null(DataType::STRING))]
+    // Empty string and empty binary serialize to JSON null per the Delta protocol; they
+    // must be rejected for NOT NULL partition columns alongside `Scalar::Null` so a
+    // serialization-equivalent value cannot bypass the nullability check.
+    #[case(DataType::STRING, Scalar::String(String::new()))]
+    #[case(DataType::BINARY, Scalar::Binary(Vec::new()))]
+    fn test_validate_types_null_into_non_nullable_returns_error(
+        #[case] data_type: DataType,
+        #[case] value: Scalar,
+    ) {
+        let err = assert_type_err(data_type, value);
+        assert!(err.contains("not nullable"), "{err}");
+        assert!(err.contains("'p'"), "{err}");
     }
 
     /// Type mismatch: every non-null Scalar variant against the wrong schema type.

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -884,7 +884,10 @@ impl<S: SupportsDataFiles> Transaction<S> {
     /// - **Type checking**: rejects non-primitive partition column types (struct, array, map) and
     ///   validates that each non-null `Scalar`'s type matches the partition column's schema type.
     ///   For example, passing `Scalar::String("2024")` for an `INTEGER` column returns an error.
-    ///   Null scalars skip the value type check (null is valid for any primitive partition column).
+    ///   Null-equivalent scalars (null scalars, empty strings, and empty binary) all of which
+    ///   collapse to JSON null in `partitionValues`) skip the value type check, but they are only
+    ///   legal when the partition column is nullable; passing any of these for a `nullable: false`
+    ///   partition column returns an error.
     ///
     /// - **Value serialization**: serializes each `Scalar` to a protocol-compliant string per the
     ///   Delta protocol's "Partition Value Serialization" rules. `Scalar::Null(...)` becomes `None`

--- a/kernel/tests/integration/write/partitioned.rs
+++ b/kernel/tests/integration/write/partitioned.rs
@@ -813,3 +813,211 @@ async fn test_materialized_partition_columns_excluded_from_stats(
 
     Ok(())
 }
+
+// ==============================================================================
+// NOT NULL partition column tests
+// ==============================================================================
+//
+// See [#2465](https://github.com/delta-io/delta-kernel-rs/issues/2465). These tests pin the
+// kernel contract that mirrors Delta-Spark's `DELTA_NOT_NULL_CONSTRAINT_VIOLATED` (SQLSTATE
+// 23502): a NULL written into a `NOT NULL` partition column must be rejected on the default
+// engine. The two arms exercise the two enforcement seams:
+//
+// 1. Non-materialized (default): partition columns are stripped from the batch before the Parquet
+//    write, so the partition-value map is the authority. Kernel validation rejects null-equivalent
+//    values for `nullable: false` partition columns up front.
+// 2. Materialized (`materializePartitionColumns` writer feature): partition columns stay in the
+//    batch on the way to the engine, so a null in the NOT NULL column is rejected by the engine
+//    (arrow-rs) at batch construction, matching the data-column NOT NULL contract.
+
+/// Validates the e2e NOT NULL contract on partition values for the non-materialized path: a
+/// null-equivalent value into a `nullable: false` partition column is rejected before
+/// serialization, and ordinary non-null values pass through unchanged. The column-mapping
+/// axis is orthogonal. Validation runs against logical names and field nullability before
+/// any column-mapping renaming, so the same outcome is expected under all three CM modes.
+///
+/// Three value cases cross-multiplied against three column-mapping modes:
+///
+/// - `Scalar::Null(STRING)` -- explicit null, must be rejected.
+/// - `Scalar::String("a")`  -- ordinary non-null value, must be accepted.
+/// - `Scalar::String("")`   -- empty string, which the Delta protocol treats as JSON null in
+///   `partitionValues`. It must be rejected for the same reason as `Scalar::Null` -- otherwise it
+///   would slip past the nullability check and land a null value in a NOT NULL column.
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_partition_null_validation_non_materialized(
+    #[values(
+        ColumnMappingMode::None,
+        ColumnMappingMode::Name,
+        ColumnMappingMode::Id
+    )]
+    cm_mode: ColumnMappingMode,
+    #[values(
+        (Scalar::Null(DataType::STRING), Some("not nullable")),
+        (Scalar::String("a".into()), None),
+        (Scalar::String(String::new()), Some("not nullable")),
+    )]
+    case: (Scalar, Option<&'static str>),
+) -> Result<(), Box<dyn std::error::Error>> {
+    let _ = tracing_subscriber::fmt::try_init();
+    let (value, expected_err) = case;
+
+    // Schema: a nullable data column + a NOT NULL string partition column.
+    let schema = Arc::new(StructType::try_new(vec![
+        StructField::nullable("value", DataType::INTEGER),
+        StructField::not_null("p", DataType::STRING),
+    ])?);
+
+    let (_tmp_dir, table_path, engine) = test_table_setup_mt()?;
+    let snapshot = create_partitioned_table(&table_path, engine.as_ref(), schema, &["p"], cm_mode)?;
+
+    let result = snapshot
+        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .with_engine_info("default engine")
+        .partitioned_write_context(HashMap::from([("p".to_string(), value)]));
+
+    match expected_err {
+        Some(needle) => {
+            let err = result
+                .err()
+                .ok_or(
+                    "expected partitioned_write_context to error for a null-equivalent value into NOT NULL partition",
+                )?
+                .to_string();
+            assert!(err.contains(needle), "{err}");
+            assert!(err.contains("'p'"), "{err}");
+        }
+        None => {
+            result?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Verifies mixed-nullability partition schemas enforce each partition column's own contract:
+/// null-equivalent values are accepted for nullable partition columns and rejected for NOT NULL
+/// partition columns.
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_partition_null_validation_mixed_nullability(
+    #[values(
+        ColumnMappingMode::None,
+        ColumnMappingMode::Name,
+        ColumnMappingMode::Id
+    )]
+    cm_mode: ColumnMappingMode,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let schema = Arc::new(StructType::try_new(vec![
+        StructField::nullable("value", DataType::INTEGER),
+        StructField::not_null("p_required", DataType::STRING),
+        StructField::nullable("p_optional", DataType::STRING),
+    ])?);
+
+    let (_tmp_dir, table_path, engine) = test_table_setup_mt()?;
+    let snapshot = create_partitioned_table(
+        &table_path,
+        engine.as_ref(),
+        schema,
+        &["p_required", "p_optional"],
+        cm_mode,
+    )?;
+
+    snapshot
+        .clone()
+        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .with_engine_info("default engine")
+        .partitioned_write_context(HashMap::from([
+            ("p_required".to_string(), Scalar::String("a".into())),
+            ("p_optional".to_string(), Scalar::Null(DataType::STRING)),
+        ]))?;
+
+    snapshot
+        .clone()
+        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .with_engine_info("default engine")
+        .partitioned_write_context(HashMap::from([
+            ("p_required".to_string(), Scalar::String("a".into())),
+            ("p_optional".to_string(), Scalar::String(String::new())),
+        ]))?;
+
+    let err = snapshot
+        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .with_engine_info("default engine")
+        .partitioned_write_context(HashMap::from([
+            ("p_required".to_string(), Scalar::Null(DataType::STRING)),
+            ("p_optional".to_string(), Scalar::String("b".into())),
+        ]))
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("not nullable"), "{err}");
+    assert!(err.contains("'p_required'"), "{err}");
+
+    Ok(())
+}
+
+/// Materialized arm: with the `materializePartitionColumns` writer feature enabled, partition
+/// columns stay in the engine-bound Arrow batch, so the NOT NULL enforcement seam is the same
+/// as for data columns where the engine rejects a null in a `nullable: false` field at batch
+/// construction.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_partition_null_validation_in_batch_materialized(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let schema = Arc::new(StructType::try_new(vec![
+        StructField::nullable("value", DataType::INTEGER),
+        StructField::not_null("p", DataType::STRING),
+    ])?);
+
+    let (_tmp_dir, table_path, engine) = test_table_setup_mt()?;
+    let _ = create_table(&table_path, schema.clone(), "test/1.0")
+        .with_data_layout(DataLayout::partitioned(["p"]))
+        .with_table_properties([("delta.feature.materializePartitionColumns", "supported")])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?;
+
+    let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert!(
+        snapshot.table_configuration().is_feature_enabled(
+            &delta_kernel::table_features::TableFeature::MaterializePartitionColumns
+        ),
+        "test setup must enable materializePartitionColumns"
+    );
+
+    // The partition-value map below is a benign mock: it satisfies the kernel write API
+    // but is decoupled from this test's assertion. With the materialize feature enabled,
+    // the partition column stays in the Arrow batch on the way to the engine (rather than
+    // being filtered out), so the NOT NULL enforcement seam moves into the engine: a null
+    // in a `nullable: false` field is rejected at batch construction below, independent of
+    // whatever value the mock map carries here.
+    let txn = snapshot
+        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .with_engine_info("default engine");
+    let _write_context = txn.partitioned_write_context(HashMap::from([(
+        "p".to_string(),
+        Scalar::String("a".into()),
+    )]))?;
+
+    let arrow_schema: ArrowSchema = schema.as_ref().try_into_arrow()?;
+    assert!(
+        !arrow_schema.field_with_name("p")?.is_nullable(),
+        "kernel `not_null` partition field must produce Arrow `nullable: false`",
+    );
+
+    let result = RecordBatch::try_new(
+        Arc::new(arrow_schema),
+        vec![
+            Arc::new(Int32Array::from(vec![Some(1)])),
+            Arc::new(StringArray::from(vec![None as Option<&str>])),
+        ],
+    );
+    assert!(
+        result.is_err(),
+        "RecordBatch::try_new should reject null in NOT NULL materialized partition column; got: {result:?}",
+    );
+
+    Ok(())
+}

--- a/kernel/tests/integration/write/types.rs
+++ b/kernel/tests/integration/write/types.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use delta_kernel::arrow::array::{
-    ArrayRef, BinaryArray, Int32Array, StructArray, TimestampMicrosecondArray,
+    new_null_array, ArrayRef, BinaryArray, Int32Array, StructArray, TimestampMicrosecondArray,
 };
 use delta_kernel::arrow::buffer::NullBuffer;
 use delta_kernel::arrow::datatypes::{DataType as ArrowDataType, Field};
@@ -16,11 +16,13 @@ use delta_kernel::engine::default::parquet::DefaultParquetHandler;
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::ObjectStoreExt as _;
 use delta_kernel::schema::{DataType, StructField, StructType};
+use delta_kernel::transaction::create_table::create_table as kernel_create_table;
 use delta_kernel::{Engine, Error as KernelError, Snapshot};
 use itertools::Itertools;
+use rstest::rstest;
 use serde_json::Deserializer;
 use tempfile::tempdir;
-use test_utils::{create_table, engine_store_setup, test_read};
+use test_utils::{create_table, engine_store_setup, test_read, test_table_setup};
 use url::Url;
 
 #[tokio::test]
@@ -461,6 +463,90 @@ async fn test_shredded_variant_read_rejection() -> Result<(), Box<dyn std::error
     let res = test_read(&ArrowEngineData::new(data), &table_url, engine);
     assert!(matches!(res,
         Err(e) if e.to_string().contains("The default engine does not support shredded reads")));
+
+    Ok(())
+}
+
+// =============================================================================
+// NOT NULL data column tests (default engine)
+// =============================================================================
+//
+// These tests validate data-column nullability on the default engine. Kernel preserves
+// `nullable: false` in the connector-facing schema and relies on the engine to reject
+// nulls before writing.
+
+/// Verifies the default-engine NOT NULL contract for non-partition columns
+/// across a representative set of primitive types. The contract:
+///
+/// 1. `nullable: false` propagates from kernel's logical schema through the connector-facing
+///    physical schema and into the Arrow schema engines build batches against.
+/// 2. Constructing the Arrow batch an engine would hand to the kernel write API with a null in the
+///    NOT NULL column fails at batch construction, before the engine is invoked.
+///
+/// See [#2465](https://github.com/delta-io/delta-kernel-rs/issues/2465).
+#[rstest]
+#[case::integer(DataType::INTEGER)]
+#[case::long(DataType::LONG)]
+#[case::string(DataType::STRING)]
+#[case::binary(DataType::BINARY)]
+#[case::boolean(DataType::BOOLEAN)]
+#[case::timestamp(DataType::TIMESTAMP)]
+#[case::decimal(DataType::decimal(10, 2).unwrap())]
+#[tokio::test]
+async fn test_not_null_data_column_rejects_null_in_batch(
+    #[case] data_type: DataType,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    // Create a table with a NOT NULL column.
+    let schema = Arc::new(StructType::try_new(vec![StructField::not_null(
+        "c",
+        data_type.clone(),
+    )])?);
+    let (_tmp_dir, table_path, engine) = test_table_setup()?;
+    let _ = kernel_create_table(&table_path, schema.clone(), "test/1.0")
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?;
+
+    let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    // The non-null schema auto-enables the `invariants` writer feature.
+    assert!(
+        snapshot
+            .table_configuration()
+            .protocol()
+            .writer_features()
+            .is_some_and(|f| f.contains(&delta_kernel::table_features::TableFeature::Invariants)),
+        "non-null schema must auto-enable the `invariants` writer feature",
+    );
+
+    let write_context = snapshot
+        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .with_engine_info("default engine")
+        .unpartitioned_write_context()?;
+
+    // Use the connector-facing physical schema (not the logical one); the logical schema
+    // would hide bugs in the logical->physical mapping that engines hit in production.
+    let physical = write_context.physical_schema();
+    let physical_field = physical
+        .field("c")
+        .expect("physical schema must contain column 'c'");
+    assert!(
+        !physical_field.nullable,
+        "physical schema must preserve `nullable: false` for column 'c'",
+    );
+    let arrow_schema: delta_kernel::arrow::datatypes::Schema =
+        physical.as_ref().try_into_arrow()?;
+    assert!(
+        !arrow_schema.field(0).is_nullable(),
+        "Arrow conversion of physical schema must preserve `nullable: false`",
+    );
+
+    let arrow_type = arrow_schema.field(0).data_type().clone();
+    let result = RecordBatch::try_new(Arc::new(arrow_schema), vec![new_null_array(&arrow_type, 1)]);
+    assert!(
+        result.is_err(),
+        "batch construction should reject null in NOT NULL column ({data_type:?}); got: {result:?}",
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes #2465.

Closes the write-time enforcement gap left by #2418, which auto-enables the invariants writer feature on schemas with non-null columns but does not itself reject nulls on writes. Kernel now rejects Scalar::Null partition values for partition columns with nullable: false in partitioned_write_context, matching Delta-Spark's DELTA_NOT_NULL_CONSTRAINT_VIOLATED (SQLSTATE 23502).

The check sits in validate_types alongside the existing type checks. The Scalar::Null inner type continues to be ignored on nulls, so connectors can keep constructing null partition values without first looking up the schema; only the schema field's nullability is enforced. This matches Catalyst's NullType permissiveness and the type-erased on-wire format (partitionValues serializes nulls as JSON null with no type information).

## How was this change tested?

Adds integration tests covering all three non-null write paths:

1/ Non-materialized partitioned writes (default): kernel rejects the null Scalar at partitioned_write_context time, before serialization. Covered across all column-mapping modes via the kernel create_table builder.

2/ Materialized partitioned writes (materializePartitionColumns): kernel delegates to the engine's ParquetHandler. The default engine inherits the guarantee from arrow-rs, whose RecordBatch::try_new rejects nulls in fields with nullable: false. The table for this case is set up via the kernel create_table builder with delta.feature.materializePartitionColumns=supported (allow-listed by #2481).

3/ Plain non-null data columns: same engine-delegation seam, exercised across a representative primitive type matrix (integer, long, string, binary, boolean, timestamp, decimal). The table is created via the kernel create_table builder so the non-null schema drives the auto-enablement of the invariants writer feature end-to-end; the test asserts both the auto-enable and the downstream RecordBatch::try_new rejection. Pins the full chain documented on maybe_enable_invariants in transaction/builder/create_table.rs.

Local verification:

1/ cargo +nightly fmt --check
2/ cargo clippy --workspace --benches --tests --all-features -- -D warnings
3/ cargo doc --workspace --all-features --no-deps
4/ cargo test -p delta_kernel --all-features for affected paths
