### PR TITLE
feat: expose CommittedTransaction with post-commit snapshot

### DIFF
--- a/ffi/CLAUDE.md
+++ b/ffi/CLAUDE.md
@@ -51,7 +51,15 @@ The caller owns the returned builder handle and must call either `snapshot_build
 
 ```
 get_default_engine() -> transaction() -> with_engine_info() -> with_operation() -> add_files() -> commit()
+                                                                                  |
+                                                                                  v
+              committed_transaction_version / committed_transaction_post_commit_snapshot
+                                                                                  |
+                                                                                  v
+                                                                  free_committed_transaction
 ```
+
+`commit()` and `create_table_commit()` return a `Handle<ExclusiveCommittedTransaction>` that the caller can read via `committed_transaction_version` and `committed_transaction_post_commit_snapshot`, then must release with `free_committed_transaction`. The post-commit snapshot, when present, is a separate `SharedSnapshot` handle that must be freed with `free_snapshot`.
 
 ## Building
 

--- a/ffi/examples/create-table/create_table.c
+++ b/ffi/examples/create-table/create_table.c
@@ -171,14 +171,16 @@ int main(int argc, char* argv[]) {
   ExclusiveCreateTransaction* txn = txn_res.ok;
 
   // === Commit ===
-  ExternResultu64 commit_res = create_table_commit(txn, engine);
-  if (commit_res.tag != Oku64) {
+  ExternResultHandleExclusiveCommittedTransaction commit_res = create_table_commit(txn, engine);
+  if (commit_res.tag != OkHandleExclusiveCommittedTransaction) {
     print_error("create_table_commit failed.", (Error*)commit_res.err);
     free_error((Error*)commit_res.err);
     free_engine(engine);
     return 1;
   }
-  printf("Committed version: %" PRIu64 "\n", commit_res.ok);
+  HandleExclusiveCommittedTransaction committed = commit_res.ok;
+  printf("Committed version: %" PRIu64 "\n", committed_transaction_version(committed));
+  free_committed_transaction(committed);
 
   // === Open a snapshot on the new table to confirm it landed ===
   ExternResultHandleMutableFfiSnapshotBuilder snapshot_builder_res =

--- a/ffi/examples/create-table/create_table.c
+++ b/ffi/examples/create-table/create_table.c
@@ -179,7 +179,7 @@ int main(int argc, char* argv[]) {
     return 1;
   }
   HandleExclusiveCommittedTransaction committed = commit_res.ok;
-  printf("Committed version: %" PRIu64 "\n", committed_transaction_version(committed));
+  printf("Committed version: %" PRIu64 "\n", committed_transaction_version(&committed));
   free_committed_transaction(committed);
 
   // === Open a snapshot on the new table to confirm it landed ===

--- a/ffi/examples/delta-kernel-unity-catalog-example/delta_kernel_unity_catalog_example.c
+++ b/ffi/examples/delta-kernel-unity-catalog-example/delta_kernel_unity_catalog_example.c
@@ -235,7 +235,7 @@ int main(int argc, char* argv[])
 
     HandleExclusiveCommittedTransaction committed = commit_res.ok;
     printf("\nCommitted version: %lu\n",
-           (unsigned long)committed_transaction_version(committed));
+           (unsigned long)committed_transaction_version(&committed));
     free_committed_transaction(committed);
 
     // Cleanup

--- a/ffi/examples/delta-kernel-unity-catalog-example/delta_kernel_unity_catalog_example.c
+++ b/ffi/examples/delta-kernel-unity-catalog-example/delta_kernel_unity_catalog_example.c
@@ -223,9 +223,9 @@ int main(int argc, char* argv[])
 
     HandleExclusiveTransaction txn_with_info = txn_with_info_res.ok;
     // calling commit here will end up calling our callback
-    ExternResultu64 commit_res = commit(txn_with_info, engine);
+    ExternResultHandleExclusiveCommittedTransaction commit_res = commit(txn_with_info, engine);
 
-    if (commit_res.tag != Oku64) {
+    if (commit_res.tag != OkHandleExclusiveCommittedTransaction) {
         print_error("Commit failed", (Error*)commit_res.err);
         free_error((Error*)commit_res.err);
         free_engine(engine);
@@ -233,7 +233,10 @@ int main(int argc, char* argv[])
         return -1;
     }
 
-    printf("\nCommitted version: %lu\n", (unsigned long)commit_res.ok);
+    HandleExclusiveCommittedTransaction committed = commit_res.ok;
+    printf("\nCommitted version: %lu\n",
+           (unsigned long)committed_transaction_version(committed));
+    free_committed_transaction(committed);
 
     // Cleanup
     // Note: txn_with_info was consumed by commit(), so we don't free it

--- a/ffi/examples/write-table/write_table.c
+++ b/ffi/examples/write-table/write_table.c
@@ -21,8 +21,11 @@
 //   - get_unpartitioned_write_context(txn, engine) + get_write_schema/get_write_path
 //     (the values an engine needs when writing parquet files itself)
 //   - set_data_change(txn, false) because this empty commit does not add data
-//   - commit(txn, engine) to produce an empty commit
-//   - Reading the committed version back via a new snapshot to confirm
+//   - commit(txn, engine) to produce an empty commit, returning a CommittedTransaction handle
+//   - committed_transaction_version + committed_transaction_post_commit_snapshot to read the
+//     version and (when available) the post-commit snapshot directly from the result, avoiding
+//     a fresh snapshot load
+//   - free_committed_transaction to release the result handle
 //
 // NOTE: This example does NOT call add_files. Staging new files requires building an Arrow
 // RecordBatch that matches Transaction::add_files_schema (path, partitionValues, size,
@@ -115,36 +118,52 @@ int main(int argc, char* argv[]) {
   free_write_context(write_context);
 
   // === Commit ===
-  ExternResultu64 commit_res = commit(txn, engine);
-  if (commit_res.tag != Oku64) {
+  ExternResultHandleExclusiveCommittedTransaction commit_res = commit(txn, engine);
+  if (commit_res.tag != OkHandleExclusiveCommittedTransaction) {
     print_error("commit failed.", (Error*)commit_res.err);
     free_error((Error*)commit_res.err);
     free_engine(engine);
     return 1;
   }
-  printf("Committed version: %" PRIu64 "\n", commit_res.ok);
+  HandleExclusiveCommittedTransaction committed = commit_res.ok;
+  uint64_t committed_version = committed_transaction_version(committed);
+  printf("Committed version: %" PRIu64 "\n", committed_version);
 
-  // === Read back via snapshot to confirm ===
-  ExternResultHandleMutableFfiSnapshotBuilder snapshot_builder_res =
-      get_snapshot_builder(table_path_slice, engine);
-  if (snapshot_builder_res.tag != OkHandleMutableFfiSnapshotBuilder) {
-    print_error("Failed to get snapshot builder.", (Error*)snapshot_builder_res.err);
-    free_error((Error*)snapshot_builder_res.err);
-    free_engine(engine);
-    return 1;
+  // === Read post-commit snapshot directly from the CommittedTransaction ===
+  // This avoids a fresh snapshot load: the kernel handed us an already-built snapshot for
+  // the post-commit version. If the handle does not carry one (e.g. some catalog-managed or
+  // retried-commit paths), fall back to loading via snapshot_builder_build.
+  HandleSharedSnapshot snap;
+  bool has_post_commit = committed_transaction_post_commit_snapshot(committed, &snap);
+  if (has_post_commit) {
+    printf("Post-commit snapshot version: %" PRIu64 "\n", version(snap));
+    free_snapshot(snap);
+  } else {
+    printf("No post-commit snapshot available; loading via snapshot builder.\n");
+    ExternResultHandleMutableFfiSnapshotBuilder snapshot_builder_res =
+        get_snapshot_builder(table_path_slice, engine);
+    if (snapshot_builder_res.tag != OkHandleMutableFfiSnapshotBuilder) {
+      print_error("Failed to get snapshot builder.", (Error*)snapshot_builder_res.err);
+      free_error((Error*)snapshot_builder_res.err);
+      free_committed_transaction(committed);
+      free_engine(engine);
+      return 1;
+    }
+    ExternResultHandleSharedSnapshot snap_res =
+        snapshot_builder_build(snapshot_builder_res.ok);
+    if (snap_res.tag != OkHandleSharedSnapshot) {
+      print_error("Failed to load snapshot after commit.", (Error*)snap_res.err);
+      free_error((Error*)snap_res.err);
+      free_committed_transaction(committed);
+      free_engine(engine);
+      return 1;
+    }
+    HandleSharedSnapshot loaded = snap_res.ok;
+    printf("Snapshot version after commit: %" PRIu64 "\n", version(loaded));
+    free_snapshot(loaded);
   }
-  ExternResultHandleSharedSnapshot snap_res =
-      snapshot_builder_build(snapshot_builder_res.ok);
-  if (snap_res.tag != OkHandleSharedSnapshot) {
-    print_error("Failed to load snapshot after commit.", (Error*)snap_res.err);
-    free_error((Error*)snap_res.err);
-    free_engine(engine);
-    return 1;
-  }
-  SharedSnapshot* snap = snap_res.ok;
-  printf("Snapshot version after commit: %" PRIu64 "\n", version(snap));
 
-  free_snapshot(snap);
+  free_committed_transaction(committed);
   free_engine(engine);
   return 0;
 }

--- a/ffi/examples/write-table/write_table.c
+++ b/ffi/examples/write-table/write_table.c
@@ -23,8 +23,8 @@
 //   - set_data_change(txn, false) because this empty commit does not add data
 //   - commit(txn, engine) to produce an empty commit, returning a CommittedTransaction handle
 //   - committed_transaction_version + committed_transaction_post_commit_snapshot to read the
-//     version and (when available) the post-commit snapshot directly from the result, avoiding
-//     a fresh snapshot load
+//     version and the post-commit snapshot directly from the result, avoiding a fresh
+//     snapshot load
 //   - free_committed_transaction to release the result handle
 //
 // NOTE: This example does NOT call add_files. Staging new files requires building an Arrow
@@ -126,16 +126,15 @@ int main(int argc, char* argv[]) {
     return 1;
   }
   HandleExclusiveCommittedTransaction committed = commit_res.ok;
-  uint64_t committed_version = committed_transaction_version(committed);
-  printf("Committed version: %" PRIu64 "\n", committed_version);
+  printf("Committed version: %" PRIu64 "\n", committed_transaction_version(&committed));
 
   // === Read post-commit snapshot directly from the CommittedTransaction ===
-  // This avoids a fresh snapshot load: the kernel handed us an already-built snapshot for
-  // the post-commit version. If the handle does not carry one (e.g. some catalog-managed or
-  // retried-commit paths), fall back to loading via snapshot_builder_build.
-  HandleSharedSnapshot snap;
-  bool has_post_commit = committed_transaction_post_commit_snapshot(committed, &snap);
-  if (has_post_commit) {
+  // Avoids a fresh snapshot load: the kernel hands back the already-built snapshot
+  // for the post-commit version.
+  struct OptionalValueHandleSharedSnapshot post_commit =
+      committed_transaction_post_commit_snapshot(&committed);
+  if (post_commit.tag == SomeHandleSharedSnapshot) {
+    HandleSharedSnapshot snap = post_commit.some;
     printf("Post-commit snapshot version: %" PRIu64 "\n", version(snap));
     free_snapshot(snap);
   } else {

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -9,7 +9,7 @@ use delta_kernel::engine_data::FilteredEngineData;
 use delta_kernel::transaction::create_table::{
     CreateTableTransaction, CreateTableTransactionBuilder,
 };
-use delta_kernel::transaction::{CommitResult, Transaction};
+use delta_kernel::transaction::{CommitResult, CommittedTransaction, Transaction};
 use delta_kernel_ffi_macros::handle_descriptor;
 
 use crate::error::{ExternResult, IntoExternResult};
@@ -35,6 +35,15 @@ pub struct ExclusiveTransaction;
 /// file removal, blind append, and deletion vector updates are not available.
 #[handle_descriptor(target=CreateTableTransaction, mutable=true, sized=true)]
 pub struct ExclusiveCreateTransaction;
+
+/// A handle for a successfully [`CommittedTransaction`].
+///
+/// Returned by [`commit`] and [`create_table_commit`]. Carries the committed version and,
+/// when available, the post-commit snapshot. Use [`committed_transaction_version`] and
+/// [`committed_transaction_post_commit_snapshot`] to read the contents, then release with
+/// [`free_committed_transaction`].
+#[handle_descriptor(target=CommittedTransaction, mutable=true, sized=true)]
+pub struct ExclusiveCommittedTransaction;
 
 /// Handle for a mutable boxed committer that can be passed across FFI
 #[handle_descriptor(target = dyn Committer, mutable = true, sized = false)]
@@ -94,13 +103,18 @@ fn transaction_with_committer_impl(
     Ok(Box::new(transaction?).into())
 }
 
-/// Convert a [`CommitResult`] into a committed version number, or an error if the commit was not
-/// successful.
+/// Convert a [`CommitResult`] into a [`CommittedTransaction`] handle, or an error if the commit
+/// was not successful.
+///
+/// The returned handle owns the [`CommittedTransaction`] and must be freed with
+/// [`free_committed_transaction`].
 ///
 /// TODO: expose the full `CommitResult` enum through FFI for conflict resolution.
-fn commit_result_to_version<S>(result: DeltaResult<CommitResult<S>>) -> DeltaResult<u64> {
+fn commit_result_to_committed_handle<S>(
+    result: DeltaResult<CommitResult<S>>,
+) -> DeltaResult<Handle<ExclusiveCommittedTransaction>> {
     match result? {
-        CommitResult::CommittedTransaction(committed) => Ok(committed.commit_version()),
+        CommitResult::CommittedTransaction(committed) => Ok(Box::new(committed).into()),
         CommitResult::RetryableTransaction(_) => Err(delta_kernel::Error::unsupported(
             "commit failed: retryable transaction not supported in FFI (yet)",
         )),
@@ -270,8 +284,11 @@ pub unsafe extern "C" fn set_data_change(mut txn: Handle<ExclusiveTransaction>, 
     underlying_txn.set_data_change(data_change);
 }
 
-/// Attempt to commit a transaction to the table. Returns version number if successful.
-/// Returns error if the commit fails.
+/// Attempt to commit a transaction to the table. On success, returns a handle to the
+/// [`CommittedTransaction`] from which the caller can read the version and the optional
+/// post-commit snapshot. The returned handle must be freed with [`free_committed_transaction`].
+///
+/// Returns an error if the commit fails (including conflicts and retryable IO errors).
 ///
 /// # Safety
 ///
@@ -281,11 +298,12 @@ pub unsafe extern "C" fn set_data_change(mut txn: Handle<ExclusiveTransaction>, 
 pub unsafe extern "C" fn commit(
     txn: Handle<ExclusiveTransaction>,
     engine: Handle<SharedExternEngine>,
-) -> ExternResult<u64> {
+) -> ExternResult<Handle<ExclusiveCommittedTransaction>> {
     let txn = unsafe { txn.into_inner() };
     let extern_engine = unsafe { engine.as_ref() };
     let engine = extern_engine.engine();
-    commit_result_to_version(txn.commit(engine.as_ref())).into_extern_result(&extern_engine)
+    commit_result_to_committed_handle(txn.commit(engine.as_ref()))
+        .into_extern_result(&extern_engine)
 }
 
 // ============================================================================
@@ -358,8 +376,11 @@ pub unsafe extern "C" fn create_table_set_data_change(
     underlying_txn.set_data_change(data_change);
 }
 
-/// Attempt to commit a create-table transaction. Returns version number if successful.
-/// Returns error if the commit fails.
+/// Attempt to commit a create-table transaction. On success, returns a handle to the
+/// [`CommittedTransaction`] from which the caller can read the version and the optional
+/// post-commit snapshot. The returned handle must be freed with [`free_committed_transaction`].
+///
+/// Returns an error if the commit fails.
 ///
 /// # Safety
 ///
@@ -369,11 +390,78 @@ pub unsafe extern "C" fn create_table_set_data_change(
 pub unsafe extern "C" fn create_table_commit(
     txn: Handle<ExclusiveCreateTransaction>,
     engine: Handle<SharedExternEngine>,
-) -> ExternResult<u64> {
+) -> ExternResult<Handle<ExclusiveCommittedTransaction>> {
     let txn = unsafe { txn.into_inner() };
     let extern_engine = unsafe { engine.as_ref() };
     let engine = extern_engine.engine();
-    commit_result_to_version(txn.commit(engine.as_ref())).into_extern_result(&extern_engine)
+    commit_result_to_committed_handle(txn.commit(engine.as_ref()))
+        .into_extern_result(&extern_engine)
+}
+
+// ============================================================================
+// Committed transaction accessors
+// ============================================================================
+
+/// Free a [`CommittedTransaction`] handle.
+///
+/// # Safety
+///
+/// Caller is responsible for passing a valid handle and must not use it after this call.
+#[no_mangle]
+pub unsafe extern "C" fn free_committed_transaction(txn: Handle<ExclusiveCommittedTransaction>) {
+    txn.drop_handle();
+}
+
+/// Read the committed version from a [`CommittedTransaction`] handle.
+///
+/// Does not consume the handle; the caller still owns it and must eventually pass it to
+/// [`free_committed_transaction`].
+///
+/// # Safety
+///
+/// Caller is responsible for passing a valid handle.
+#[no_mangle]
+pub unsafe extern "C" fn committed_transaction_version(
+    txn: Handle<ExclusiveCommittedTransaction>,
+) -> u64 {
+    let committed = unsafe { txn.as_ref() };
+    committed.commit_version()
+}
+
+/// Read the post-commit snapshot from a [`CommittedTransaction`] handle.
+///
+/// Returns `true` if a post-commit snapshot is available (in which case `*out_snapshot` is
+/// written with a fresh [`SharedSnapshot`] handle that the caller must eventually free with
+/// [`free_snapshot`](crate::free_snapshot)). Returns `false` otherwise (in which case
+/// `*out_snapshot` is not modified). The kernel does not currently produce post-commit
+/// snapshots for transactions that experienced conflicts; in the FFI today, conflicts are
+/// reported as errors at commit time rather than as committed transactions, so a `false`
+/// return primarily indicates that this committed transaction was constructed without a
+/// post-commit snapshot.
+///
+/// Does not consume the handle; the caller still owns it and must eventually pass it to
+/// [`free_committed_transaction`]. Calling this function multiple times yields independent
+/// snapshot handles, each of which must be freed.
+///
+/// # Safety
+///
+/// Caller is responsible for passing a valid handle and a valid, writable `out_snapshot`
+/// pointer.
+#[no_mangle]
+pub unsafe extern "C" fn committed_transaction_post_commit_snapshot(
+    txn: Handle<ExclusiveCommittedTransaction>,
+    out_snapshot: *mut Handle<SharedSnapshot>,
+) -> bool {
+    let committed = unsafe { txn.as_ref() };
+    match committed.post_commit_snapshot() {
+        Some(snap) => {
+            // Arc::clone bumps the refcount; the resulting Handle owns its own strong reference,
+            // so freeing the CommittedTransaction handle later does not invalidate the snapshot.
+            unsafe { out_snapshot.write(Arc::clone(snap).into()) };
+            true
+        }
+        None => false,
+    }
 }
 
 // ============================================================================
@@ -627,6 +715,22 @@ mod tests {
 
     const ZERO_UUID: &str = "00000000-0000-0000-0000-000000000000";
 
+    /// Read the version from a [`Handle<ExclusiveCommittedTransaction>`] and free the handle.
+    ///
+    /// Most existing tests only assert against the committed version, so this preserves the
+    /// pre-handle-API ergonomics (`let v = ok_or_panic(commit(...))`) while still exercising
+    /// the new accessor and explicit free.
+    ///
+    /// # Safety
+    ///
+    /// Caller asserts the handle is valid (i.e. produced by [`commit`] / [`create_table_commit`]
+    /// and not previously freed).
+    unsafe fn version_and_free(committed: Handle<ExclusiveCommittedTransaction>) -> u64 {
+        let version = unsafe { committed_transaction_version(committed.shallow_copy()) };
+        unsafe { free_committed_transaction(committed) };
+        version
+    }
+
     fn check_txn_id_exists(commit_info: &serde_json::Value) {
         commit_info["txnId"]
             .as_str()
@@ -803,7 +907,8 @@ mod tests {
 
             unsafe { add_files(txn.shallow_copy(), file_info_engine_data) };
 
-            ok_or_panic(unsafe { commit(txn, engine.shallow_copy()) });
+            let committed = ok_or_panic(unsafe { commit(txn, engine.shallow_copy()) });
+            unsafe { free_committed_transaction(committed) };
 
             // Confirm that our commit is what we expect
             let commit1_url = table_url
@@ -941,7 +1046,8 @@ mod tests {
             )
         });
 
-        let version = ok_or_panic(unsafe { commit(txn, engine.shallow_copy()) });
+        let committed = ok_or_panic(unsafe { commit(txn, engine.shallow_copy()) });
+        let version = unsafe { version_and_free(committed) };
         assert_eq!(version, 1);
 
         let dm = read_domain_metadata_action(&*store, &table_url, 1).await;
@@ -959,7 +1065,8 @@ mod tests {
             with_domain_metadata_removed(txn, kernel_string_slice!(domain), engine.shallow_copy())
         });
 
-        let version = ok_or_panic(unsafe { commit(txn, engine.shallow_copy()) });
+        let committed = ok_or_panic(unsafe { commit(txn, engine.shallow_copy()) });
+        let version = unsafe { version_and_free(committed) };
         assert_eq!(version, 2);
 
         let dm = read_domain_metadata_action(&*store, &table_url, 2).await;
@@ -1256,6 +1363,9 @@ mod tests {
 
             // UC committer returns success from our mock callback
             assert!(commit_result.is_ok(), "Commit should succeed");
+            if let ExternResult::Ok(committed) = commit_result {
+                unsafe { free_committed_transaction(committed) };
+            }
 
             let context = recover_test_context(context).unwrap();
 
@@ -1423,7 +1533,8 @@ mod tests {
     ) -> u64 {
         let txn =
             ok_or_panic(unsafe { create_table_builder_build(builder, engine.shallow_copy()) });
-        let version = ok_or_panic(unsafe { create_table_commit(txn, engine.shallow_copy()) });
+        let committed = ok_or_panic(unsafe { create_table_commit(txn, engine.shallow_copy()) });
+        let version = unsafe { version_and_free(committed) };
         assert_eq!(version, 0);
         version
     }
@@ -1458,6 +1569,97 @@ mod tests {
 
         unsafe { free_schema(snap_schema) };
         unsafe { free_snapshot(snap) };
+        unsafe { free_engine(engine) };
+        Ok(())
+    }
+
+    /// CREATE TABLE: the committed transaction must expose a post-commit snapshot at version 0
+    /// without re-listing the log.
+    #[tokio::test]
+    #[cfg_attr(miri, ignore)]
+    async fn test_post_commit_snapshot_create_table() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp_dir = tempdir()?;
+        let (_table_path, engine, builder) = create_table_builder(
+            &tmp_dir,
+            vec![StructField::nullable("id", DataType::INTEGER)],
+        );
+
+        let txn =
+            ok_or_panic(unsafe { create_table_builder_build(builder, engine.shallow_copy()) });
+        let committed = ok_or_panic(unsafe { create_table_commit(txn, engine.shallow_copy()) });
+
+        assert_eq!(
+            unsafe { committed_transaction_version(committed.shallow_copy()) },
+            0
+        );
+
+        let mut slot = std::mem::MaybeUninit::<Handle<SharedSnapshot>>::uninit();
+        let has_snapshot = unsafe {
+            committed_transaction_post_commit_snapshot(committed.shallow_copy(), slot.as_mut_ptr())
+        };
+        assert!(
+            has_snapshot,
+            "create_table commit should produce a post-commit snapshot"
+        );
+        let snap = unsafe { slot.assume_init() };
+        assert_eq!(unsafe { version(snap.shallow_copy()) }, 0);
+
+        unsafe { free_snapshot(snap) };
+        unsafe { free_committed_transaction(committed) };
+        unsafe { free_engine(engine) };
+        Ok(())
+    }
+
+    /// Existing-table commit: the committed transaction's post-commit snapshot must be at the
+    /// just-committed version. Also verifies that calling the accessor a second time yields an
+    /// independent handle (Arc clone).
+    #[tokio::test]
+    #[cfg_attr(miri, ignore)]
+    async fn test_post_commit_snapshot_existing_table() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp_dir = tempdir()?;
+        // create_table_with_one_file commits v0 (create) and v1 (file add).
+        let (table_path, engine) = create_table_with_one_file(&tmp_dir)?;
+
+        // Blind no-op commit on top of v1 -> v2.
+        let txn = ok_or_panic(unsafe {
+            transaction(kernel_string_slice!(table_path), engine.shallow_copy())
+        });
+        unsafe { set_data_change(txn.shallow_copy(), false) };
+        let engine_info = "test-engine/1.0";
+        let txn = ok_or_panic(unsafe {
+            with_engine_info(
+                txn,
+                kernel_string_slice!(engine_info),
+                engine.shallow_copy(),
+            )
+        });
+
+        let committed = ok_or_panic(unsafe { commit(txn, engine.shallow_copy()) });
+        let v = unsafe { committed_transaction_version(committed.shallow_copy()) };
+        assert_eq!(v, 2);
+
+        let mut slot = std::mem::MaybeUninit::<Handle<SharedSnapshot>>::uninit();
+        let has_snapshot = unsafe {
+            committed_transaction_post_commit_snapshot(committed.shallow_copy(), slot.as_mut_ptr())
+        };
+        assert!(
+            has_snapshot,
+            "existing-table commit should produce a post-commit snapshot"
+        );
+        let snap = unsafe { slot.assume_init() };
+        assert_eq!(unsafe { version(snap.shallow_copy()) }, v);
+
+        // Calling the accessor a second time must yield an independent handle (Arc clone).
+        let mut slot2 = std::mem::MaybeUninit::<Handle<SharedSnapshot>>::uninit();
+        assert!(unsafe {
+            committed_transaction_post_commit_snapshot(committed.shallow_copy(), slot2.as_mut_ptr())
+        });
+        let snap2 = unsafe { slot2.assume_init() };
+        assert_eq!(unsafe { version(snap2.shallow_copy()) }, v);
+
+        unsafe { free_snapshot(snap2) };
+        unsafe { free_snapshot(snap) };
+        unsafe { free_committed_transaction(committed) };
         unsafe { free_engine(engine) };
         Ok(())
     }
@@ -1623,8 +1825,8 @@ mod tests {
                 engine.shallow_copy(),
             )
         });
-        let committed_version =
-            ok_or_panic(unsafe { create_table_commit(txn, engine.shallow_copy()) });
+        let committed = ok_or_panic(unsafe { create_table_commit(txn, engine.shallow_copy()) });
+        let committed_version = unsafe { version_and_free(committed) };
         assert_eq!(committed_version, 0);
 
         // Verify the table was created
@@ -1705,7 +1907,8 @@ mod tests {
             )
         });
         unsafe { add_files(txn.shallow_copy(), file_info_engine_data) };
-        ok_or_panic(unsafe { commit(txn, engine.shallow_copy()) });
+        let committed = ok_or_panic(unsafe { commit(txn, engine.shallow_copy()) });
+        unsafe { free_committed_transaction(committed) };
 
         Ok((table_path.to_string(), engine))
     }
@@ -1812,7 +2015,8 @@ mod tests {
             )
         });
 
-        ok_or_panic(unsafe { commit(txn, engine.shallow_copy()) });
+        let committed = ok_or_panic(unsafe { commit(txn, engine.shallow_copy()) });
+        unsafe { free_committed_transaction(committed) };
         assert_no_active_files(&kernel_engine, table_path.as_str())?;
 
         unsafe { free_engine(engine) };

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -18,7 +18,8 @@ use crate::scan::EngineSchema;
 use crate::schema_visitor::{extract_kernel_schema, KernelSchemaVisitorState};
 use crate::{
     unwrap_and_parse_path_as_url, DeltaResult, ExclusiveEngineData, ExternEngine,
-    KernelStringSlice, SharedExternEngine, SharedSnapshot, Snapshot, TryFromStringSlice, Url,
+    KernelStringSlice, OptionalValue, SharedExternEngine, SharedSnapshot, Snapshot,
+    TryFromStringSlice, Url,
 };
 
 /// A handle for an existing-table transaction (`Transaction<ExistingTable>`).
@@ -36,7 +37,7 @@ pub struct ExclusiveTransaction;
 #[handle_descriptor(target=CreateTableTransaction, mutable=true, sized=true)]
 pub struct ExclusiveCreateTransaction;
 
-/// A handle for a successfully [`CommittedTransaction`].
+/// A handle for a [`CommittedTransaction`].
 ///
 /// Returned by [`commit`] and [`create_table_commit`]. Carries the committed version and,
 /// when available, the post-commit snapshot. Use [`committed_transaction_version`] and
@@ -288,7 +289,8 @@ pub unsafe extern "C" fn set_data_change(mut txn: Handle<ExclusiveTransaction>, 
 /// [`CommittedTransaction`] from which the caller can read the version and the optional
 /// post-commit snapshot. The returned handle must be freed with [`free_committed_transaction`].
 ///
-/// Returns an error if the commit fails (including conflicts and retryable IO errors).
+/// Returns an error if the commit fails. The FFI surfaces conflicted and retryable
+/// `CommitResult` variants as errors today (see TODO on `commit_result_to_committed_handle`).
 ///
 /// # Safety
 ///
@@ -402,6 +404,8 @@ pub unsafe extern "C" fn create_table_commit(
 // Committed transaction accessors
 // ============================================================================
 
+// TODO: expose CommittedTransaction::post_commit_stats through FFI.
+
 /// Free a [`CommittedTransaction`] handle.
 ///
 /// # Safety
@@ -422,46 +426,36 @@ pub unsafe extern "C" fn free_committed_transaction(txn: Handle<ExclusiveCommitt
 /// Caller is responsible for passing a valid handle.
 #[no_mangle]
 pub unsafe extern "C" fn committed_transaction_version(
-    txn: Handle<ExclusiveCommittedTransaction>,
+    txn: &Handle<ExclusiveCommittedTransaction>,
 ) -> u64 {
-    let committed = unsafe { txn.as_ref() };
-    committed.commit_version()
+    unsafe { txn.as_ref() }.commit_version()
 }
 
-/// Read the post-commit snapshot from a [`CommittedTransaction`] handle.
+/// Reads the post-commit snapshot, if available.
 ///
-/// Returns `true` if a post-commit snapshot is available (in which case `*out_snapshot` is
-/// written with a fresh [`SharedSnapshot`] handle that the caller must eventually free with
-/// [`free_snapshot`](crate::free_snapshot)). Returns `false` otherwise (in which case
-/// `*out_snapshot` is not modified). The kernel does not currently produce post-commit
-/// snapshots for transactions that experienced conflicts; in the FFI today, conflicts are
-/// reported as errors at commit time rather than as committed transactions, so a `false`
-/// return primarily indicates that this committed transaction was constructed without a
-/// post-commit snapshot.
+/// Returns `Some` with a fresh [`SharedSnapshot`] handle if the committed transaction has an
+/// associated post-commit snapshot. Returns `None` otherwise.
 ///
-/// Does not consume the handle; the caller still owns it and must eventually pass it to
-/// [`free_committed_transaction`]. Calling this function multiple times yields independent
-/// snapshot handles, each of which must be freed.
+/// Not every commit path produces a post-commit snapshot (see
+/// [`CommittedTransaction::post_commit_snapshot`] for the kernel-side rationale); callers
+/// can fall back to building a snapshot via [`get_snapshot_builder`](crate::get_snapshot_builder)
+/// in that case.
+///
+/// Each `Some` result contains an independent handle that the caller must eventually free with
+/// [`free_snapshot`](crate::free_snapshot). Does not consume the input handle; the caller must
+/// eventually pass it to [`free_committed_transaction`].
 ///
 /// # Safety
 ///
-/// Caller is responsible for passing a valid handle and a valid, writable `out_snapshot`
-/// pointer.
+/// Caller is responsible for passing a valid handle.
 #[no_mangle]
 pub unsafe extern "C" fn committed_transaction_post_commit_snapshot(
-    txn: Handle<ExclusiveCommittedTransaction>,
-    out_snapshot: *mut Handle<SharedSnapshot>,
-) -> bool {
-    let committed = unsafe { txn.as_ref() };
-    match committed.post_commit_snapshot() {
-        Some(snap) => {
-            // Arc::clone bumps the refcount; the resulting Handle owns its own strong reference,
-            // so freeing the CommittedTransaction handle later does not invalidate the snapshot.
-            unsafe { out_snapshot.write(Arc::clone(snap).into()) };
-            true
-        }
-        None => false,
-    }
+    txn: &Handle<ExclusiveCommittedTransaction>,
+) -> OptionalValue<Handle<SharedSnapshot>> {
+    unsafe { txn.as_ref() }
+        .post_commit_snapshot()
+        .map(|snap| Arc::clone(snap).into())
+        .into()
 }
 
 // ============================================================================
@@ -715,18 +709,18 @@ mod tests {
 
     const ZERO_UUID: &str = "00000000-0000-0000-0000-000000000000";
 
-    /// Read the version from a [`Handle<ExclusiveCommittedTransaction>`] and free the handle.
+    /// Reads the committed version from a [`Handle<ExclusiveCommittedTransaction>`] and
+    /// frees the handle.
     ///
-    /// Most existing tests only assert against the committed version, so this preserves the
-    /// pre-handle-API ergonomics (`let v = ok_or_panic(commit(...))`) while still exercising
-    /// the new accessor and explicit free.
+    /// Useful for tests that only need to assert on the version. Tests that also need
+    /// the post-commit snapshot should call the accessors directly.
     ///
     /// # Safety
     ///
-    /// Caller asserts the handle is valid (i.e. produced by [`commit`] / [`create_table_commit`]
-    /// and not previously freed).
+    /// Caller asserts the handle is valid (i.e. produced by [`commit`] /
+    /// [`create_table_commit`] and not previously freed).
     unsafe fn version_and_free(committed: Handle<ExclusiveCommittedTransaction>) -> u64 {
-        let version = unsafe { committed_transaction_version(committed.shallow_copy()) };
+        let version = unsafe { committed_transaction_version(&committed) };
         unsafe { free_committed_transaction(committed) };
         version
     }
@@ -1362,10 +1356,8 @@ mod tests {
             let commit_result = unsafe { commit(txn_with_engine_info, engine.shallow_copy()) };
 
             // UC committer returns success from our mock callback
-            assert!(commit_result.is_ok(), "Commit should succeed");
-            if let ExternResult::Ok(committed) = commit_result {
-                unsafe { free_committed_transaction(committed) };
-            }
+            let committed = ok_or_panic(commit_result);
+            unsafe { free_committed_transaction(committed) };
 
             let context = recover_test_context(context).unwrap();
 
@@ -1588,20 +1580,14 @@ mod tests {
             ok_or_panic(unsafe { create_table_builder_build(builder, engine.shallow_copy()) });
         let committed = ok_or_panic(unsafe { create_table_commit(txn, engine.shallow_copy()) });
 
-        assert_eq!(
-            unsafe { committed_transaction_version(committed.shallow_copy()) },
-            0
-        );
+        assert_eq!(unsafe { committed_transaction_version(&committed) }, 0);
 
-        let mut slot = std::mem::MaybeUninit::<Handle<SharedSnapshot>>::uninit();
-        let has_snapshot = unsafe {
-            committed_transaction_post_commit_snapshot(committed.shallow_copy(), slot.as_mut_ptr())
+        let snap = match unsafe { committed_transaction_post_commit_snapshot(&committed) } {
+            OptionalValue::Some(snap) => snap,
+            OptionalValue::None => {
+                panic!("create_table commit should produce a post-commit snapshot")
+            }
         };
-        assert!(
-            has_snapshot,
-            "create_table commit should produce a post-commit snapshot"
-        );
-        let snap = unsafe { slot.assume_init() };
         assert_eq!(unsafe { version(snap.shallow_copy()) }, 0);
 
         unsafe { free_snapshot(snap) };
@@ -1635,31 +1621,34 @@ mod tests {
         });
 
         let committed = ok_or_panic(unsafe { commit(txn, engine.shallow_copy()) });
-        let v = unsafe { committed_transaction_version(committed.shallow_copy()) };
+        let v = unsafe { committed_transaction_version(&committed) };
         assert_eq!(v, 2);
 
-        let mut slot = std::mem::MaybeUninit::<Handle<SharedSnapshot>>::uninit();
-        let has_snapshot = unsafe {
-            committed_transaction_post_commit_snapshot(committed.shallow_copy(), slot.as_mut_ptr())
+        let snap = match unsafe { committed_transaction_post_commit_snapshot(&committed) } {
+            OptionalValue::Some(snap) => snap,
+            OptionalValue::None => {
+                panic!("existing-table commit should produce a post-commit snapshot")
+            }
         };
-        assert!(
-            has_snapshot,
-            "existing-table commit should produce a post-commit snapshot"
-        );
-        let snap = unsafe { slot.assume_init() };
         assert_eq!(unsafe { version(snap.shallow_copy()) }, v);
 
         // Calling the accessor a second time must yield an independent handle (Arc clone).
-        let mut slot2 = std::mem::MaybeUninit::<Handle<SharedSnapshot>>::uninit();
-        assert!(unsafe {
-            committed_transaction_post_commit_snapshot(committed.shallow_copy(), slot2.as_mut_ptr())
-        });
-        let snap2 = unsafe { slot2.assume_init() };
+        let snap2 = match unsafe { committed_transaction_post_commit_snapshot(&committed) } {
+            OptionalValue::Some(snap) => snap,
+            OptionalValue::None => {
+                panic!("existing-table commit should produce a second post-commit snapshot")
+            }
+        };
         assert_eq!(unsafe { version(snap2.shallow_copy()) }, v);
 
+        // Free the CommittedTransaction handle first to verify the post-commit snapshot
+        // remains valid afterwards (per Arc::clone semantics in
+        // committed_transaction_post_commit_snapshot).
+        unsafe { free_committed_transaction(committed) };
+        assert_eq!(unsafe { version(snap.shallow_copy()) }, v);
+        assert_eq!(unsafe { version(snap2.shallow_copy()) }, v);
         unsafe { free_snapshot(snap2) };
         unsafe { free_snapshot(snap) };
-        unsafe { free_committed_transaction(committed) };
         unsafe { free_engine(engine) };
         Ok(())
     }

--- a/ffi/src/transaction/transaction_id.rs
+++ b/ffi/src/transaction/transaction_id.rs
@@ -86,7 +86,7 @@ mod tests {
     use crate::ffi_test_utils::ok_or_panic;
     use crate::kernel_string_slice;
     use crate::tests::get_default_engine;
-    use crate::transaction::{commit, transaction};
+    use crate::transaction::{commit, free_committed_transaction, transaction};
 
     #[cfg(feature = "default-engine-base")]
     #[tokio::test]
@@ -137,7 +137,9 @@ mod tests {
             });
 
             // commit!
-            ok_or_panic(unsafe { commit(txn, default_engine_handle.shallow_copy()) });
+            let committed =
+                ok_or_panic(unsafe { commit(txn, default_engine_handle.shallow_copy()) });
+            unsafe { free_committed_transaction(committed) };
 
             let snapshot: Arc<Snapshot> = Snapshot::builder_for(table_url.clone())
                 .at_version(1)

--- a/ffi/tests/write-table-testing/expected-data/empty-commit.expected
+++ b/ffi/tests/write-table-testing/expected-data/empty-commit.expected
@@ -3,4 +3,4 @@ Write context:
   schema_handle: <obtained>
   write_path:    file://<TABLE>/
 Committed version: 1
-Snapshot version after commit: 1
+Post-commit snapshot version: 1


### PR DESCRIPTION
## What changes are proposed in this pull request?

The FFI commit/create_table_commit functions previously discarded everything except the version. Replace the u64 return with a Handle<ExclusiveCommittedTransaction> that callers can read with three new accessors:

- committed_transaction_version(handle) -> u64
- committed_transaction_post_commit_snapshot(handle, *out_snapshot) -> bool
- free_committed_transaction(handle)

This unblocks engines that need to surface TransactionCommitResult.getPostCommitSnapshot() without re-loading the snapshot from storage. The snapshot is handed back via Arc::clone, so freeing the committed-transaction handle does not invalidate it; callers may also fetch the snapshot multiple times to obtain independent handles.

Conflicted/retryable commits remain reported as errors (matching prior FFI behavior). The kernel does not currently produce post-commit snapshots after conflicts, so a 'false' return today indicates a CommittedTransaction built without one (e.g. a future retry path).

## How was this change tested?

Tests:
- test_post_commit_snapshot_create_table verifies a fresh CREATE TABLE commit exposes a post-commit snapshot at version 0.
- test_post_commit_snapshot_existing_table verifies an existing-table commit exposes a snapshot at the just-committed version, and that calling the accessor twice yields independent (Arc-cloned) handles.

Examples (create-table, write-table, delta-kernel-unity-catalog-example) are updated to use the new API; write-table now demonstrates reading the post-commit snapshot directly from the commit result instead of re-loading it.

### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
commit_result_to_version -> commit_result_to_committed_handle