### PR TITLE
feat: expose deletion vector cardinality via FFI

### DIFF
--- a/ffi/examples/read-table/read_table.c
+++ b/ffi/examples/read-table/read_table.c
@@ -78,6 +78,7 @@ void scan_row_callback(
   KernelBoolSlice selection_vector;
 
   if (cdv_info->has_vector) {
+    print_diag("  Deletion vector cardinality: %" PRId64 "\n", cdv_info->cardinality);
     ExternResultKernelBoolSlice selection_vector_res =
       selection_vector_from_dv(cdv_info->info, context->engine, table_root_slice);
     if (selection_vector_res.tag != OkKernelBoolSlice) {

--- a/ffi/src/scan.rs
+++ b/ffi/src/scan.rs
@@ -466,6 +466,15 @@ pub struct Stats {
 pub struct CDvInfo<'a> {
     info: &'a DvInfo,
     has_vector: bool,
+    /// Number of rows logically removed from the data file by this Deletion Vector. The value is
+    /// the `cardinality` field of the DV descriptor as written by the producing writer (kernel
+    /// does not reconcile it against the physical DV bytes). Meaningful only when `has_vector`
+    /// is `true`; `0` otherwise. Per the protocol, when a DV is present `cardinality` is always
+    /// available, so this field never observes the "DV present but cardinality missing" case.
+    /// Note that combining this with [`Stats::num_records`] to compute the logical row count
+    /// (`num_records - cardinality`) is only sound when the file's stats are tight against the
+    /// data file.
+    cardinality: i64,
 }
 
 /// This callback will be invoked for each valid file that needs to be read for a scan.
@@ -655,6 +664,7 @@ fn rust_callback(context: &mut ContextWrapper, scan_file: ScanFile) {
     let cdv_info = CDvInfo {
         info: &scan_file.dv_info,
         has_vector: scan_file.dv_info.has_vector(),
+        cardinality: scan_file.dv_info.cardinality().unwrap_or(0),
     };
     let path = scan_file.path.as_str();
     (context.callback)(

--- a/kernel/src/scan/state.rs
+++ b/kernel/src/scan/state.rs
@@ -48,6 +48,21 @@ impl DvInfo {
         self.deletion_vector.is_some()
     }
 
+    /// Number of rows logically removed by this Deletion Vector. Lets engines plan or report
+    /// deleted-row counts without reading the DV bytes.
+    ///
+    /// Returns `None` exactly when [`Self::has_vector`] returns `false`; per the protocol,
+    /// cardinality is always present alongside a DV descriptor.
+    ///
+    /// The value is taken verbatim from the descriptor's `cardinality` field as written by the
+    /// producing writer; kernel does not reconcile it against the physical DV bytes. Combining
+    /// this with [`Stats::num_records`] to compute the logical row count
+    /// (`num_records - cardinality`) is only sound when the file's stats are tight against the
+    /// data file.
+    pub fn cardinality(&self) -> Option<i64> {
+        self.deletion_vector.as_ref().map(|dv| dv.cardinality)
+    }
+
     pub(crate) fn get_treemap(
         &self,
         engine: &dyn Engine,
@@ -230,6 +245,7 @@ impl<T> FilteredRowVisitor for ScanFileVisitor<'_, T> {
 
 #[cfg(test)]
 mod tests {
+    use crate::actions::deletion_vector::{DeletionVectorDescriptor, DeletionVectorStorageType};
     use crate::actions::get_commit_schema;
     use crate::scan::state::ScanFile;
     use crate::scan::test_utils::{add_batch_simple, run_with_validate_callback};
@@ -253,7 +269,8 @@ mod tests {
             Some(&"2017-12-10".to_string())
         );
         assert_eq!(scan_file.partition_values.get("non-existent"), None);
-        assert!(scan_file.dv_info.deletion_vector.is_some());
+        assert!(scan_file.dv_info.has_vector());
+        assert_eq!(scan_file.dv_info.cardinality(), Some(2));
         let dv = scan_file.dv_info.deletion_vector.unwrap();
         assert_eq!(dv.unique_id(), "uvBn[lx{q8@P<9BNH/isA@1");
         assert!(scan_file.transform.is_none());
@@ -271,5 +288,36 @@ mod tests {
             context,
             validate_visit,
         );
+    }
+
+    #[test]
+    fn dv_info_cardinality_none_when_no_descriptor() {
+        let dv_info = super::DvInfo::default();
+        assert!(!dv_info.has_vector());
+        assert_eq!(dv_info.cardinality(), None);
+    }
+
+    #[test]
+    fn dv_info_cardinality_returns_descriptor_field() {
+        // Cardinality of zero is legal per spec and must round-trip as Some(0), not None.
+        let zero: super::DvInfo = DeletionVectorDescriptor {
+            storage_type: DeletionVectorStorageType::Inline,
+            path_or_inline_dv: String::new(),
+            offset: None,
+            size_in_bytes: 0,
+            cardinality: 0,
+        }
+        .into();
+        assert_eq!(zero.cardinality(), Some(0));
+
+        let typical: super::DvInfo = DeletionVectorDescriptor {
+            storage_type: DeletionVectorStorageType::Inline,
+            path_or_inline_dv: String::new(),
+            offset: None,
+            size_in_bytes: 0,
+            cardinality: i64::MAX,
+        }
+        .into();
+        assert_eq!(typical.cardinality(), Some(i64::MAX));
     }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds a public accessor for the Deletion Vector `cardinality` field so engines can report or plan around deleted-row counts without paying to read the DV bytes.

- `DvInfo::cardinality() -> Option<i64>` (kernel) — returns `None` exactly when no DV is present; per the protocol, cardinality is always present alongside a DV descriptor.
- New `cardinality: i64` field on the FFI `CDvInfo` struct, populated alongside `has_vector`. Following the existing struct's documented design rationale, this avoids an extra FFI call per scan-row callback.
- Doc comment notes the value is taken verbatim from the descriptor (writer-asserted, not reconciled against physical DV bytes), and cross-links `Stats::num_records` since combining the two requires tight stats.

## How was this change tested?

- Unit tests for `DvInfo::cardinality()`: `None` for no descriptor, `Some(0)` and `Some(i64::MAX)` boundary cases.
- Extended `test_simple_visit_scan_metadata` to assert `cardinality() == Some(2)` against the persistent (`storageType="u"`) DV in the existing `add_batch_simple` fixture.
- Manually verified end-to-end: built the C `read_table` example against `kernel/tests/data/table-with-dv-small/` and confirmed it prints `Deletion vector cardinality: 2`.
