### PR TITLE
	feat: Add arrow conversion support in default engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ar_archive_writer"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1275,6 +1284,10 @@ dependencies = [
  "delta_kernel",
  "delta_kernel_derive",
  "futures",
+ "geoarrow-array 0.7.0",
+ "geoarrow-array 0.8.0",
+ "geoarrow-schema 0.7.0",
+ "geoarrow-schema 0.8.0",
  "hdfs-native",
  "hdfs-native-object-store",
  "indexmap",
@@ -1735,6 +1748,84 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "geo-traits"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7c353d12a704ccfab1ba8bfb1a7fe6cb18b665bf89d37f4f7890edcd260206"
+dependencies = [
+ "geo-types",
+]
+
+[[package]]
+name = "geo-types"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94776032c45f950d30a13af6113c2ad5625316c9abfbccee4dd5a6695f8fe0f5"
+dependencies = [
+ "approx",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "geoarrow-array"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1cc4106ac0a0a512c398961ce95d8150475c84a84e17c4511c3643fa120a17"
+dependencies = [
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-schema 57.3.0",
+ "geo-traits",
+ "geoarrow-schema 0.7.0",
+ "num-traits",
+ "wkb",
+ "wkt",
+]
+
+[[package]]
+name = "geoarrow-array"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dafe7b7de3fab1a8b7099fd6a6434ca955fa65065f9c19f0f8a133693f3c2b0e"
+dependencies = [
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-schema 58.1.0",
+ "geo-traits",
+ "geoarrow-schema 0.8.0",
+ "num-traits",
+ "wkb",
+ "wkt",
+]
+
+[[package]]
+name = "geoarrow-schema"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e97be4e9f523f92bd6a0e0458323f4b783d073d011664decd8dbf05651704f34"
+dependencies = [
+ "arrow-schema 57.3.0",
+ "geo-traits",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "geoarrow-schema"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d4a7edb2a1d87024a93805332a9c8184a0354836271d42c0d18cf628a5e3cd0"
+dependencies = [
+ "arrow-schema 58.1.0",
+ "geo-traits",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2641,6 +2732,28 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -5288,6 +5401,31 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "wkb"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a120b336c7ad17749026d50427c23d838ecb50cd64aaea6254b5030152f890a9"
+dependencies = [
+ "byteorder",
+ "geo-traits",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "wkt"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb2b923ccc882312e559ffaa832a055ba9d1ac0cc8e86b3e25453247e4b81d7"
+dependencies = [
+ "geo-traits",
+ "geo-types",
+ "log",
+ "num-traits",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,0 @@
-# The kernel Error enum contains large variants (ArrowError, ObjectStore::Error) that push
-# the enum past clippy's default 128-byte threshold. Raise the threshold to accommodate the
-# existing design rather than boxing all error variants.
-large-error-threshold = 200

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,4 @@
+# The kernel Error enum contains large variants (ArrowError, ObjectStore::Error) that push
+# the enum past clippy's default 128-byte threshold. Raise the threshold to accommodate the
+# existing design rather than boxing all error variants.
+large-error-threshold = 200

--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -501,7 +501,7 @@ impl NullTypeTag {
                 PrimitiveType::TimestampNtz => (Self::TimestampNtz, 0, 0),
                 PrimitiveType::Decimal(dt) => (Self::Decimal, dt.precision(), dt.scale()),
                 // TODO: Once real FFI geo support lands, new NullTypeTag::Geometry / ::Geography variants
-                // willreplace this arm.
+                // will replace this arm.
                 PrimitiveType::Geometry(_) | PrimitiveType::Geography(_) => (Self::Binary, 0, 0),
             },
             _ => (Self::NonPrimitive, 0, 0),

--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -500,6 +500,16 @@ impl NullTypeTag {
                 PrimitiveType::Timestamp => (Self::Timestamp, 0, 0),
                 PrimitiveType::TimestampNtz => (Self::TimestampNtz, 0, 0),
                 PrimitiveType::Decimal(dt) => (Self::Decimal, dt.precision(), dt.scale()),
+                // Geometry/Geography carry an SRID string (and for Geography, an edge
+                // algorithm) that cannot fit in the (tag, u8, u8) payload this function
+                // returns. We route them through NullTypeTag::Binary to stay consistent
+                // with the FFI schema visitor (which routes geo columns through
+                // visit_binary): consumers see a uniformly binary view of geo across
+                // schema and expressions in this PR. CRS is lost at the FFI boundary
+                // either way -- there is no side channel for it here. Once real FFI geo
+                // support lands, new NullTypeTag::Geometry / ::Geography variants will
+                // replace this arm.
+                PrimitiveType::Geometry(_) | PrimitiveType::Geography(_) => (Self::Binary, 0, 0),
             },
             _ => (Self::NonPrimitive, 0, 0),
         }

--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -500,8 +500,8 @@ impl NullTypeTag {
                 PrimitiveType::Timestamp => (Self::Timestamp, 0, 0),
                 PrimitiveType::TimestampNtz => (Self::TimestampNtz, 0, 0),
                 PrimitiveType::Decimal(dt) => (Self::Decimal, dt.precision(), dt.scale()),
-                // TODO: Once real FFI geo support lands, new NullTypeTag::Geometry / ::Geography variants
-                // will replace this arm.
+                // TODO: Once real FFI geo support lands, new NullTypeTag::Geometry / ::Geography
+                // variants will replace this arm.
                 PrimitiveType::Geometry(_) | PrimitiveType::Geography(_) => (Self::Binary, 0, 0),
             },
             _ => (Self::NonPrimitive, 0, 0),

--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -500,15 +500,8 @@ impl NullTypeTag {
                 PrimitiveType::Timestamp => (Self::Timestamp, 0, 0),
                 PrimitiveType::TimestampNtz => (Self::TimestampNtz, 0, 0),
                 PrimitiveType::Decimal(dt) => (Self::Decimal, dt.precision(), dt.scale()),
-                // Geometry/Geography carry an SRID string (and for Geography, an edge
-                // algorithm) that cannot fit in the (tag, u8, u8) payload this function
-                // returns. We route them through NullTypeTag::Binary to stay consistent
-                // with the FFI schema visitor (which routes geo columns through
-                // visit_binary): consumers see a uniformly binary view of geo across
-                // schema and expressions in this PR. CRS is lost at the FFI boundary
-                // either way -- there is no side channel for it here. Once real FFI geo
-                // support lands, new NullTypeTag::Geometry / ::Geography variants will
-                // replace this arm.
+                // TODO: Once real FFI geo support lands, new NullTypeTag::Geometry / ::Geography variants
+                // willreplace this arm.
                 PrimitiveType::Geometry(_) | PrimitiveType::Geography(_) => (Self::Binary, 0, 0),
             },
             _ => (Self::NonPrimitive, 0, 0),

--- a/ffi/src/schema.rs
+++ b/ffi/src/schema.rs
@@ -330,17 +330,8 @@ fn visit_schema_impl(schema: &StructType, visitor: &mut EngineSchemaVisitor) -> 
             &DataType::DATE => call!(visit_date),
             &DataType::TIMESTAMP => call!(visit_timestamp),
             &DataType::TIMESTAMP_NTZ => call!(visit_timestamp_ntz),
-            // Geometry/Geography are WKB-encoded bytes at the FFI layer -- route through
-            // visit_binary. The SRID (and edge algorithm for Geography) carried on the
-            // kernel PrimitiveType is not surfaced through this visitor; FFI consumers see
-            // only a binary column. The companion null-literal path in
-            // ffi/src/expressions/kernel_visitor.rs emits NullTypeTag::Binary for the same
-            // reason, giving consumers a uniformly binary view across schema and
-            // expressions. This is a pragmatic stub, not a claim that geo is semantically
-            // equivalent to binary -- CRS-aware operations against these columns will
-            // produce meaningless results. Tables with geo columns should not be consumed
-            // through this FFI until dedicated visit_geometry / visit_geography callbacks
-            // carrying the SRID are added.
+            // Geometry/Geography are WKB-encoded bytes at the FFI layer
+            // TODO: Add visit_geometry / visit_geography callbacks carrying the SRID once real FFI geo support lands
             DataType::Primitive(PrimitiveType::Geometry(_))
             | DataType::Primitive(PrimitiveType::Geography(_)) => call!(visit_binary),
         }

--- a/ffi/src/schema.rs
+++ b/ffi/src/schema.rs
@@ -330,6 +330,19 @@ fn visit_schema_impl(schema: &StructType, visitor: &mut EngineSchemaVisitor) -> 
             &DataType::DATE => call!(visit_date),
             &DataType::TIMESTAMP => call!(visit_timestamp),
             &DataType::TIMESTAMP_NTZ => call!(visit_timestamp_ntz),
+            // Geometry/Geography are WKB-encoded bytes at the FFI layer -- route through
+            // visit_binary. The SRID (and edge algorithm for Geography) carried on the
+            // kernel PrimitiveType is not surfaced through this visitor; FFI consumers see
+            // only a binary column. The companion null-literal path in
+            // ffi/src/expressions/kernel_visitor.rs emits NullTypeTag::Binary for the same
+            // reason, giving consumers a uniformly binary view across schema and
+            // expressions. This is a pragmatic stub, not a claim that geo is semantically
+            // equivalent to binary -- CRS-aware operations against these columns will
+            // produce meaningless results. Tables with geo columns should not be consumed
+            // through this FFI until dedicated visit_geometry / visit_geography callbacks
+            // carrying the SRID are added.
+            DataType::Primitive(PrimitiveType::Geometry(_))
+            | DataType::Primitive(PrimitiveType::Geography(_)) => call!(visit_binary),
         }
     }
 

--- a/ffi/src/schema.rs
+++ b/ffi/src/schema.rs
@@ -331,7 +331,8 @@ fn visit_schema_impl(schema: &StructType, visitor: &mut EngineSchemaVisitor) -> 
             &DataType::TIMESTAMP => call!(visit_timestamp),
             &DataType::TIMESTAMP_NTZ => call!(visit_timestamp_ntz),
             // Geometry/Geography are WKB-encoded bytes at the FFI layer
-            // TODO: Add visit_geometry / visit_geography callbacks carrying the SRID once real FFI geo support lands
+            // TODO: Add visit_geometry / visit_geography callbacks carrying the SRID once real FFI
+            // geo support lands
             DataType::Primitive(PrimitiveType::Geometry(_))
             | DataType::Primitive(PrimitiveType::Geography(_)) => call!(visit_binary),
         }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -81,6 +81,14 @@ package = "parquet"
 version = "57"
 features = ["async", "object_store"]
 optional = true
+[dependencies.geoarrow_array_07]
+package = "geoarrow-array"
+version = "0.7"
+optional = true
+[dependencies.geoarrow_schema_07]
+package = "geoarrow-schema"
+version = "0.7"
+optional = true
 
 # arrow 58
 [dependencies.arrow_58]
@@ -93,7 +101,14 @@ package = "parquet"
 version = "58"
 features = ["async", "object_store"]
 optional = true
-
+[dependencies.geoarrow_array_08]
+package = "geoarrow-array"
+version = "0.8"
+optional = true
+[dependencies.geoarrow_schema_08]
+package = "geoarrow-schema"
+version = "0.8"
+optional = true
 [features]
 # no default features
 default = []
@@ -110,8 +125,20 @@ integration-test = ["hdfs-native-object-store/integration-test"]
 arrow = ["arrow-58"] # latest arrow version
 need-arrow = [] # need-arrow is a marker that the feature needs arrow dep
 
-arrow-57 = ["dep:arrow_57", "dep:parquet_57", "dep:object_store_12"]
-arrow-58 = ["dep:arrow_58", "dep:parquet_58", "dep:object_store_13"]
+arrow-57 = [
+  "dep:arrow_57",
+  "dep:parquet_57",
+  "dep:object_store_12",
+  "dep:geoarrow_array_07",
+  "dep:geoarrow_schema_07",
+]
+arrow-58 = [
+  "dep:arrow_58",
+  "dep:parquet_58",
+  "dep:object_store_13",
+  "dep:geoarrow_array_08",
+  "dep:geoarrow_schema_08",
+]
 arrow-conversion = ["need-arrow"]
 arrow-expression = ["need-arrow"]
 

--- a/kernel/src/arrow_compat.rs
+++ b/kernel/src/arrow_compat.rs
@@ -3,6 +3,8 @@
 #[cfg(feature = "arrow-58")]
 mod arrow_compat_shims {
     pub use arrow_58 as arrow;
+    pub use geoarrow_array_08 as geoarrow_array;
+    pub use geoarrow_schema_08 as geoarrow_schema;
     pub use parquet_58 as parquet;
 
     pub mod object_store {
@@ -13,6 +15,8 @@ mod arrow_compat_shims {
 #[cfg(all(feature = "arrow-57", not(feature = "arrow-58")))]
 mod arrow_compat_shims {
     pub use arrow_57 as arrow;
+    pub use geoarrow_array_07 as geoarrow_array;
+    pub use geoarrow_schema_07 as geoarrow_schema;
     pub use parquet_57 as parquet;
 
     pub mod object_store {

--- a/kernel/src/engine/arrow_conversion/geo.rs
+++ b/kernel/src/engine/arrow_conversion/geo.rs
@@ -1,0 +1,44 @@
+//! Conversions between kernel geo types and GeoArrow WKB extension fields.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::arrow::datatypes::Field as ArrowField;
+use crate::geoarrow_schema::crs::Crs;
+use crate::geoarrow_schema::{Edges, GeoArrowType, Metadata, WkbType};
+use crate::schema::EdgeInterpolationAlgorithm;
+
+fn algorithm_to_edges(algo: &EdgeInterpolationAlgorithm) -> Edges {
+    match algo {
+        EdgeInterpolationAlgorithm::Spherical => Edges::Spherical,
+        EdgeInterpolationAlgorithm::Vincenty => Edges::Vincenty,
+        EdgeInterpolationAlgorithm::Thomas => Edges::Thomas,
+        EdgeInterpolationAlgorithm::Andoyer => Edges::Andoyer,
+        EdgeInterpolationAlgorithm::Karney => Edges::Karney,
+    }
+}
+
+/// Builds an Arrow Field for a WKB-encoded geospatial column with GeoArrow extension
+/// metadata encoding the CRS and (for geography) the edge interpolation algorithm.
+///
+/// Pass algorithm = None for Geometry (planar) and Some(...) for Geography. Any
+/// extra_metadata is merged on top of the GeoArrow extension metadata.
+pub(super) fn wkb_arrow_field(
+    name: &str,
+    srid: &str,
+    algorithm: Option<&EdgeInterpolationAlgorithm>,
+    nullable: bool,
+    extra_metadata: HashMap<String, String>,
+) -> ArrowField {
+    let edges = algorithm.map(algorithm_to_edges);
+    let geoarrow_metadata = Arc::new(Metadata::new(Crs::from_srid(srid.to_string()), edges));
+    let wkb_type = WkbType::new(geoarrow_metadata);
+    let field = GeoArrowType::Wkb(wkb_type).to_field(name, nullable);
+    if extra_metadata.is_empty() {
+        field
+    } else {
+        let mut merged = field.metadata().clone();
+        merged.extend(extra_metadata);
+        field.with_metadata(merged)
+    }
+}

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -1,5 +1,6 @@
 //! Conversions between kernel schema types and arrow schema types.
 
+mod geo;
 pub mod scalar;
 
 use std::collections::HashMap;
@@ -107,9 +108,26 @@ impl TryFromKernel<&StructType> for ArrowSchema {
 
 impl TryFromKernel<&StructField> for ArrowField {
     fn try_from_kernel(f: &StructField) -> Result<Self, ArrowError> {
-        let metadata = kernel_metadata_to_arrow_metadata(f)?;
-        let field = ArrowField::new(f.name(), f.data_type().try_into_arrow()?, f.is_nullable())
-            .with_metadata(metadata);
+        let kernel_metadata = kernel_metadata_to_arrow_metadata(f)?;
+
+        let field = match f.data_type() {
+            DataType::Primitive(PrimitiveType::Geometry(geo_type)) => geo::wkb_arrow_field(
+                f.name(),
+                geo_type.srid(),
+                None,
+                f.is_nullable(),
+                kernel_metadata,
+            ),
+            DataType::Primitive(PrimitiveType::Geography(geo_type)) => geo::wkb_arrow_field(
+                f.name(),
+                geo_type.srid(),
+                Some(geo_type.algorithm()),
+                f.is_nullable(),
+                kernel_metadata,
+            ),
+            _ => ArrowField::new(f.name(), f.data_type().try_into_arrow()?, f.is_nullable())
+                .with_metadata(kernel_metadata),
+        };
 
         Ok(field)
     }
@@ -176,9 +194,7 @@ impl TryFromKernel<&DataType> for ArrowDataType {
                     PrimitiveType::TimestampNtz => {
                         Ok(ArrowDataType::Timestamp(TimeUnit::Microsecond, None))
                     }
-                    // Geometry/Geography are WKB-encoded bytes.
-                    // The SRID (and edge algorithm for Geometry) belongs on the ArrowField
-                    // as GeoArrow extension metadata
+                    // Geo values are WKB binary; GeoArrow extension metadata lives on the field.
                     PrimitiveType::Geometry(_) | PrimitiveType::Geography(_) => {
                         Ok(ArrowDataType::Binary)
                     }
@@ -644,5 +660,108 @@ mod tests {
             StructField::try_from_arrow(&arrow_field),
             "conflicting parquet field IDs",
         );
+    }
+
+    #[cfg(feature = "arrow-conversion")]
+    #[test]
+    fn test_geometry_field_produces_geoarrow_wkb_extension_metadata() -> DeltaResult<()> {
+        use crate::schema::GeometryType;
+
+        let geo_type = GeometryType::try_new("EPSG:4326")?;
+        let kernel_schema = StructType::try_new(vec![StructField::nullable(
+            "geom",
+            DataType::Primitive(PrimitiveType::Geometry(Box::new(geo_type))),
+        )])?;
+        let arrow_schema = ArrowSchema::try_from_kernel(&kernel_schema)?;
+        let field = arrow_schema.field(0);
+
+        assert_eq!(*field.data_type(), ArrowDataType::Binary);
+        assert_eq!(
+            field
+                .metadata()
+                .get("ARROW:extension:name")
+                .map(|s| s.as_str()),
+            Some("geoarrow.wkb"),
+        );
+        assert!(
+            field.metadata().contains_key("ARROW:extension:metadata"),
+            "GeoArrow extension metadata should be present"
+        );
+
+        // Verify CRS is encoded in the metadata JSON
+        let ext_meta = field.metadata().get("ARROW:extension:metadata").unwrap();
+        assert!(
+            ext_meta.contains("EPSG:4326"),
+            "Extension metadata should contain the SRID: {ext_meta}"
+        );
+        Ok(())
+    }
+
+    #[cfg(feature = "arrow-conversion")]
+    #[test]
+    fn test_geography_field_produces_geoarrow_wkb_extension_metadata() -> DeltaResult<()> {
+        use crate::schema::{EdgeInterpolationAlgorithm, GeographyType};
+
+        let geo_type = GeographyType::try_new(
+            Some("OGC:CRS84"),
+            Some(EdgeInterpolationAlgorithm::Spherical),
+        )?;
+        let kernel_schema = StructType::try_new(vec![StructField::nullable(
+            "geog",
+            DataType::Primitive(PrimitiveType::Geography(Box::new(geo_type))),
+        )])?;
+        let arrow_schema = ArrowSchema::try_from_kernel(&kernel_schema)?;
+        let field = arrow_schema.field(0);
+
+        assert_eq!(*field.data_type(), ArrowDataType::Binary);
+        assert_eq!(
+            field
+                .metadata()
+                .get("ARROW:extension:name")
+                .map(|s| s.as_str()),
+            Some("geoarrow.wkb"),
+        );
+        let ext_meta = field.metadata().get("ARROW:extension:metadata").unwrap();
+        assert!(
+            ext_meta.contains("OGC:CRS84"),
+            "Extension metadata should contain the SRID: {ext_meta}"
+        );
+        Ok(())
+    }
+
+    #[cfg(feature = "arrow-conversion")]
+    #[test]
+    fn test_geo_field_preserves_kernel_metadata_alongside_geoarrow() -> DeltaResult<()> {
+        use crate::schema::GeometryType;
+
+        let geo_type = GeometryType::try_new("EPSG:4326")?;
+        let field = StructField::nullable(
+            "geom",
+            DataType::Primitive(PrimitiveType::Geometry(Box::new(geo_type))),
+        )
+        .with_metadata([(
+            ColumnMetadataKey::ParquetFieldId.as_ref(),
+            MetadataValue::Number(42),
+        )]);
+
+        let arrow_field = ArrowField::try_from_kernel(&field)?;
+
+        // GeoArrow metadata is present
+        assert_eq!(
+            arrow_field
+                .metadata()
+                .get("ARROW:extension:name")
+                .map(|s| s.as_str()),
+            Some("geoarrow.wkb"),
+        );
+        // Kernel metadata (parquet field ID) is also present
+        assert_eq!(
+            arrow_field
+                .metadata()
+                .get(PARQUET_FIELD_ID_META_KEY)
+                .map(|s| s.as_str()),
+            Some("42"),
+        );
+        Ok(())
     }
 }

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -176,6 +176,14 @@ impl TryFromKernel<&DataType> for ArrowDataType {
                     PrimitiveType::TimestampNtz => {
                         Ok(ArrowDataType::Timestamp(TimeUnit::Microsecond, None))
                     }
+                    // Geometry/Geography are WKB-encoded bytes at the Arrow layer. The SRID
+                    // (and edge algorithm for Geography) belongs on the ArrowField as
+                    // GeoArrow extension metadata (the `crs` / `edges` keys), not on the
+                    // ArrowDataType itself. Attaching that metadata is deferred to the
+                    // StructField -> ArrowField conversion path.
+                    PrimitiveType::Geometry(_) | PrimitiveType::Geography(_) => {
+                        Ok(ArrowDataType::Binary)
+                    }
                 }
             }
             DataType::Struct(s) => Ok(ArrowDataType::Struct(

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -176,11 +176,9 @@ impl TryFromKernel<&DataType> for ArrowDataType {
                     PrimitiveType::TimestampNtz => {
                         Ok(ArrowDataType::Timestamp(TimeUnit::Microsecond, None))
                     }
-                    // Geometry/Geography are WKB-encoded bytes at the Arrow layer. The SRID
-                    // (and edge algorithm for Geography) belongs on the ArrowField as
-                    // GeoArrow extension metadata (the `crs` / `edges` keys), not on the
-                    // ArrowDataType itself. Attaching that metadata is deferred to the
-                    // StructField -> ArrowField conversion path.
+                    // Geometry/Geography are WKB-encoded bytes.
+                    // The SRID (and edge algorithm for Geometry) belongs on the ArrowField
+                    // as GeoArrow extension metadata
                     PrimitiveType::Geometry(_) | PrimitiveType::Geography(_) => {
                         Ok(ArrowDataType::Binary)
                     }

--- a/kernel/src/engine/arrow_expression/apply_schema.rs
+++ b/kernel/src/engine/arrow_expression/apply_schema.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use itertools::Itertools;
 
-use super::super::arrow_conversion::kernel_metadata_to_arrow_metadata;
+use super::super::arrow_conversion::{kernel_metadata_to_arrow_metadata, TryIntoArrow as _};
 use super::super::arrow_utils::make_arrow_error;
 use crate::arrow::array::{
     Array, ArrayRef, AsArray, ListArray, MapArray, RecordBatch, StructArray,
@@ -15,7 +15,7 @@ use crate::arrow::datatypes::{
 use crate::engine::ensure_data_types::{ensure_data_types, ValidationMode};
 use crate::error::{DeltaResult, Error};
 use crate::parquet::arrow::PARQUET_FIELD_ID_META_KEY;
-use crate::schema::{ArrayType, DataType, MapType, Schema, StructField};
+use crate::schema::{ArrayType, DataType, MapType, PrimitiveType, Schema, StructField};
 
 // Apply a schema to an array. The array _must_ be a `StructArray`. Returns a `RecordBatch` where
 // the names of fields, nullable, and metadata in the struct have been transformed to match those
@@ -88,12 +88,21 @@ fn transform_struct(
                     )));
                 }
             }
-            let transformed_field = new_field_with_metadata(
-                &target_field.name,
-                transformed_col.data_type(),
-                target_field.nullable,
-                Some(arrow_metadata),
-            );
+
+            let transformed_field = match target_field.data_type() {
+                // The generic path would drop the geoarrow extension keys, so route geo
+                // targets through the full kernel-to-arrow field conversion
+                DataType::Primitive(PrimitiveType::Geometry(_) | PrimitiveType::Geography(_)) => {
+                    let field: ArrowField = target_field.try_into_arrow()?;
+                    field.with_data_type(transformed_col.data_type().clone())
+                }
+                _ => new_field_with_metadata(
+                    &target_field.name,
+                    transformed_col.data_type(),
+                    target_field.nullable,
+                    Some(arrow_metadata),
+                ),
+            };
             Ok((transformed_field, transformed_col))
         });
     let (transformed_fields, transformed_cols): (Vec<ArrowField>, Vec<ArrayRef>) =

--- a/kernel/src/engine/arrow_expression/apply_schema.rs
+++ b/kernel/src/engine/arrow_expression/apply_schema.rs
@@ -375,6 +375,46 @@ mod apply_schema_validation_tests {
         );
     }
 
+    #[cfg(feature = "arrow-conversion")]
+    #[test]
+    fn test_apply_schema_attaches_geoarrow_metadata_for_geo_field() {
+        use crate::arrow::array::BinaryArray;
+        use crate::schema::{GeometryType, PrimitiveType};
+
+        let target_schema = StructType::new_unchecked([StructField::nullable(
+            "geom",
+            DataType::Primitive(PrimitiveType::Geometry(Box::new(
+                GeometryType::try_new("EPSG:4326").unwrap(),
+            ))),
+        )]);
+
+        let arrow_field = ArrowField::new("geom", ArrowDataType::Binary, true);
+        let input_array = StructArray::try_new(
+            vec![arrow_field].into(),
+            vec![Arc::new(BinaryArray::from(vec![Some(
+                b"\x01\x01\x00\x00\x00".as_ref(),
+            )]))],
+            None,
+        )
+        .unwrap();
+
+        let result = apply_schema_to_struct(&input_array, &target_schema).unwrap();
+
+        let (_, output_field) = result.fields().find("geom").unwrap();
+        assert_eq!(
+            output_field
+                .metadata()
+                .get("ARROW:extension:name")
+                .map(String::as_str),
+            Some("geoarrow.wkb"),
+        );
+        let ext_meta = output_field
+            .metadata()
+            .get("ARROW:extension:metadata")
+            .expect("geo target should produce CRS extension metadata");
+        assert!(ext_meta.contains("EPSG:4326"));
+    }
+
     /// Test that apply_schema succeeds when the input Arrow field already carries the same field
     /// ID as the target kernel schema field (no conflict).
     #[test]

--- a/kernel/src/engine/arrow_expression/mod.rs
+++ b/kernel/src/engine/arrow_expression/mod.rs
@@ -213,9 +213,6 @@ impl Scalar {
                     "Variant is not supported as scalar yet.",
                 ));
             }
-            // Geometry/Geography are WKB-encoded bytes at the Arrow layer, so null appends
-            // route through the BinaryBuilder path. GeoArrow extension metadata is attached
-            // at the ArrowField level (in a schema), not to the builder produced here.
             DataType::Primitive(PrimitiveType::Geometry(_) | PrimitiveType::Geography(_)) => {
                 append_nulls_as!(array::BinaryBuilder)
             }

--- a/kernel/src/engine/arrow_expression/mod.rs
+++ b/kernel/src/engine/arrow_expression/mod.rs
@@ -213,6 +213,12 @@ impl Scalar {
                     "Variant is not supported as scalar yet.",
                 ));
             }
+            // Geometry/Geography are WKB-encoded bytes at the Arrow layer, so null appends
+            // route through the BinaryBuilder path. GeoArrow extension metadata is attached
+            // at the ArrowField level (in a schema), not to the builder produced here.
+            DataType::Primitive(PrimitiveType::Geometry(_) | PrimitiveType::Geography(_)) => {
+                append_nulls_as!(array::BinaryBuilder)
+            }
         }
         Ok(())
     }

--- a/kernel/src/engine/arrow_utils.rs
+++ b/kernel/src/engine/arrow_utils.rs
@@ -23,7 +23,9 @@ use crate::arrow::json::{Encoder, EncoderFactory, EncoderOptions, ReaderBuilder,
 use crate::engine::arrow_conversion::{TryFromKernel as _, TryIntoArrow as _};
 use crate::engine::arrow_data::ArrowEngineData;
 use crate::engine::ensure_data_types::DataTypeCompat;
+use crate::engine::parse_json_geo;
 use crate::engine_data::FilteredEngineData;
+use crate::geoarrow_schema::GeoArrowType;
 use crate::parquet::arrow::{ProjectionMask, PARQUET_FIELD_ID_META_KEY};
 use crate::parquet::file::metadata::RowGroupMetaData;
 use crate::parquet::schema::types::SchemaDescriptor;
@@ -393,15 +395,26 @@ pub(crate) fn coerce_batch_nullability(
                             )));
                         }
                     }
-                    let coerced_field = if src_field.is_nullable() == target_field.is_nullable() {
-                        src_field.clone()
-                    } else {
-                        Arc::new(
+
+                    // At this point, the fields should be identical other than nullability, and geo-related metadata (for geo types only)
+                    // We want to return a field with the target field nullability (and geo-related metadata if present)
+                    let coerced_field = match GeoArrowType::try_from(target_field.as_ref()) {
+                        Ok(GeoArrowType::Wkb(wkb_type)) => Arc::new(
+                            src_field
+                                .as_ref()
+                                .clone()
+                                .with_nullable(target_field.is_nullable())
+                                .with_extension_type(wkb_type),
+                        ),
+                        _ if src_field.is_nullable() == target_field.is_nullable() => {
+                            src_field.clone()
+                        }
+                        _ => Arc::new(
                             src_field
                                 .as_ref()
                                 .clone()
                                 .with_nullable(target_field.is_nullable()),
-                        )
+                        ),
                     };
                     return Ok((src_column, coerced_field));
                 }
@@ -1388,7 +1401,16 @@ pub(crate) fn parse_json_impl(
         return Ok(RecordBatch::new_empty(schema));
     }
 
-    let mut decoder = ReaderBuilder::new(schema.clone())
+    // Geo fields are Binary in the schema but on-disk JSON stats encode geometry bounds as
+    // WKT strings, so swap geo leaves to Utf8 for decoding and convert back to WKB after.
+    let (temp_schema, has_geo) = parse_json_geo::replace_geo_fields_with_utf8(&schema);
+    let temp_schema = if has_geo {
+        Arc::new(temp_schema)
+    } else {
+        schema.clone()
+    };
+
+    let mut decoder = ReaderBuilder::new(temp_schema)
         .with_batch_size(json_strings.len())
         .with_coerce_primitive(true)
         .build_decoder()?;
@@ -1418,6 +1440,11 @@ pub(crate) fn parse_json_impl(
                 json_strings.len()
             )));
         }
+        let batch = if has_geo {
+            parse_json_geo::convert_geo_columns(batch, &schema)?
+        } else {
+            batch
+        };
         return Ok(batch);
     }
     Err(Error::generic(
@@ -4460,5 +4487,181 @@ mod tests {
                 ReorderIndex::missing(1, expected_empty_field),
             ]
         );
+    }
+
+    #[cfg(feature = "arrow-conversion")]
+    #[test]
+    fn test_parse_json_impl_converts_wkt_to_wkb_for_geo_fields() {
+        use crate::geoarrow_schema::{GeoArrowType, Metadata, WkbType};
+
+        let geo_metadata = Arc::new(Metadata::new(
+            crate::geoarrow_schema::crs::Crs::from_srid("OGC:CRS84".to_string()),
+            None,
+        ));
+        let wkb_field = GeoArrowType::Wkb(WkbType::new(geo_metadata)).to_field("geom", true);
+
+        // Shape: { minValues: { geom: geoarrow.wkb } }
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "minValues",
+            ArrowDataType::Struct(ArrowFields::from(vec![wkb_field])),
+            true,
+        )]));
+
+        // Valid WKT string produces non-null WKB binary
+        let input: Vec<Option<&str>> = vec![Some(r#"{"minValues":{"geom":"POINT(1.0 2.0)"}}"#)];
+        let batch = parse_json_impl(&input.into(), schema.clone()).unwrap();
+        assert_eq!(batch.num_rows(), 1);
+
+        let min_values = batch.column(0).as_struct();
+        let geom_col = min_values.column(0);
+        assert_eq!(
+            *geom_col.data_type(),
+            ArrowDataType::Binary,
+            "geo field should be Binary (WKB), not Utf8"
+        );
+        assert!(!geom_col.is_null(0), "WKB value should not be null");
+        let binary_array = geom_col
+            .as_any()
+            .downcast_ref::<crate::arrow::array::BinaryArray>()
+            .expect("should be BinaryArray");
+        assert!(
+            !binary_array.value(0).is_empty(),
+            "WKB bytes should be non-empty"
+        );
+
+        // Missing geom field produces a null entry
+        let input: Vec<Option<&str>> = vec![Some(r#"{"minValues":{}}"#)];
+        let batch = parse_json_impl(&input.into(), schema.clone()).unwrap();
+        assert_eq!(batch.num_rows(), 1);
+        let min_values = batch.column(0).as_struct();
+        let geom_col = min_values.column(0);
+        assert_eq!(*geom_col.data_type(), ArrowDataType::Binary);
+        assert!(geom_col.is_null(0), "missing geom should produce null");
+
+        // Null JSON row produces a null entry
+        let input: Vec<Option<&str>> = vec![None];
+        let batch = parse_json_impl(&input.into(), schema).unwrap();
+        assert_eq!(batch.num_rows(), 1);
+        let min_values = batch.column(0).as_struct();
+        let geom_col = min_values.column(0);
+        assert_eq!(*geom_col.data_type(), ArrowDataType::Binary);
+        assert!(
+            geom_col.is_null(0),
+            "null JSON row should produce null geom"
+        );
+    }
+
+    #[cfg(feature = "arrow-conversion")]
+    #[test]
+    fn test_parse_json_impl_converts_wkt_to_wkb_in_list() {
+        use crate::geoarrow_schema::{GeoArrowType, Metadata, WkbType};
+
+        let geo_metadata = Arc::new(Metadata::new(
+            crate::geoarrow_schema::crs::Crs::from_srid("OGC:CRS84".to_string()),
+            None,
+        ));
+        let geo_element =
+            Arc::new(GeoArrowType::Wkb(WkbType::new(geo_metadata)).to_field("element", true));
+        let list_field = ArrowField::new("geoms", ArrowDataType::List(geo_element), true);
+        let schema = Arc::new(ArrowSchema::new(vec![list_field]));
+
+        let input: Vec<Option<&str>> =
+            vec![Some(r#"{"geoms":["POINT(1.0 2.0)","POINT(3.0 4.0)"]}"#)];
+        let batch = parse_json_impl(&input.into(), schema).unwrap();
+        assert_eq!(batch.num_rows(), 1);
+
+        let list = batch.column(0).as_list::<i32>();
+        let values = list.values();
+        assert_eq!(
+            *values.data_type(),
+            ArrowDataType::Binary,
+            "list element should be Binary (WKB), not Utf8"
+        );
+        let binary = values
+            .as_any()
+            .downcast_ref::<crate::arrow::array::BinaryArray>()
+            .expect("should be BinaryArray");
+        assert_eq!(binary.len(), 2);
+        assert!(!binary.value(0).is_empty(), "first WKB should be non-empty");
+        assert!(
+            !binary.value(1).is_empty(),
+            "second WKB should be non-empty"
+        );
+    }
+
+    #[cfg(feature = "arrow-conversion")]
+    #[test]
+    fn test_parse_json_impl_converts_wkt_to_wkb_in_struct_inside_list() {
+        use crate::geoarrow_schema::{GeoArrowType, Metadata, WkbType};
+
+        // Shape: { rows: array<struct<g: geometry>> }
+        let geo_metadata = Arc::new(Metadata::new(
+            crate::geoarrow_schema::crs::Crs::from_srid("OGC:CRS84".to_string()),
+            None,
+        ));
+        let geo_field = GeoArrowType::Wkb(WkbType::new(geo_metadata)).to_field("g", true);
+        let struct_field = Arc::new(ArrowField::new(
+            "element",
+            ArrowDataType::Struct(ArrowFields::from(vec![geo_field])),
+            true,
+        ));
+        let list_field = ArrowField::new("rows", ArrowDataType::List(struct_field), true);
+        let schema = Arc::new(ArrowSchema::new(vec![list_field]));
+
+        let input: Vec<Option<&str>> = vec![Some(
+            r#"{"rows":[{"g":"POINT(1.0 2.0)"},{"g":"POINT(3.0 4.0)"}]}"#,
+        )];
+        let batch = parse_json_impl(&input.into(), schema).unwrap();
+        assert_eq!(batch.num_rows(), 1);
+
+        let list = batch.column(0).as_list::<i32>();
+        let struct_values = list.values().as_struct();
+        let geom_col = struct_values.column(0);
+        assert_eq!(
+            *geom_col.data_type(),
+            ArrowDataType::Binary,
+            "geo leaf inside list<struct> should be Binary"
+        );
+        let binary = geom_col
+            .as_any()
+            .downcast_ref::<crate::arrow::array::BinaryArray>()
+            .expect("should be BinaryArray");
+        assert_eq!(binary.len(), 2);
+        assert!(!binary.value(0).is_empty());
+        assert!(!binary.value(1).is_empty());
+    }
+
+    #[cfg(feature = "arrow-conversion")]
+    #[test]
+    fn test_parse_json_impl_converts_wkt_to_wkb_in_map_value() {
+        use crate::geoarrow_schema::{GeoArrowType, Metadata, WkbType};
+
+        let geo_metadata = Arc::new(Metadata::new(
+            crate::geoarrow_schema::crs::Crs::from_srid("OGC:CRS84".to_string()),
+            None,
+        ));
+        let key_field = Arc::new(ArrowField::new("keys", ArrowDataType::Utf8, false));
+        let value_field =
+            Arc::new(GeoArrowType::Wkb(WkbType::new(geo_metadata)).to_field("values", true));
+        let map_field = ArrowField::new_map("m", "entries", key_field, value_field, false, true);
+        let schema = Arc::new(ArrowSchema::new(vec![map_field]));
+
+        let input: Vec<Option<&str>> = vec![Some(r#"{"m":{"k1":"POINT(1.0 2.0)"}}"#)];
+        let batch = parse_json_impl(&input.into(), schema).unwrap();
+        assert_eq!(batch.num_rows(), 1);
+
+        let map = batch.column(0).as_map();
+        let values = map.values();
+        assert_eq!(
+            *values.data_type(),
+            ArrowDataType::Binary,
+            "map value should be Binary (WKB), not Utf8"
+        );
+        let binary = values
+            .as_any()
+            .downcast_ref::<crate::arrow::array::BinaryArray>()
+            .expect("should be BinaryArray");
+        assert_eq!(binary.len(), 1);
+        assert!(!binary.value(0).is_empty(), "WKB bytes should be non-empty");
     }
 }

--- a/kernel/src/engine/arrow_utils.rs
+++ b/kernel/src/engine/arrow_utils.rs
@@ -4174,6 +4174,56 @@ mod tests {
         assert!(map_val.is_nullable());
     }
 
+    #[cfg(feature = "arrow-conversion")]
+    #[test]
+    fn test_coerce_batch_nullability_geo_target_attaches_extension() {
+        use std::collections::HashMap;
+
+        use crate::geoarrow_schema::{GeoArrowType, Metadata, WkbType};
+
+        let src_field = ArrowField::new("geom", ArrowDataType::Binary, true)
+            .with_metadata(HashMap::from([(
+                "parquet.field.id".to_string(),
+                "1".to_string(),
+            )]));
+        let src_array: Arc<dyn ArrowArray> = Arc::new(crate::arrow::array::BinaryArray::from(
+            vec![Some(b"\x01\x01\x00\x00\x00".as_ref())],
+        ));
+        let src_schema = Arc::new(ArrowSchema::new(vec![src_field]));
+        let batch = RecordBatch::try_new(src_schema, vec![src_array]).unwrap();
+
+        let crs = crate::geoarrow_schema::crs::Crs::from_srid("EPSG:4326".to_string());
+        let target_field =
+            GeoArrowType::Wkb(WkbType::new(Arc::new(Metadata::new(crs, None)))).to_field("geom", true);
+        let target_schema = Arc::new(ArrowSchema::new(vec![target_field]));
+
+        let result = coerce_batch_nullability(batch, &target_schema, None).unwrap();
+        let out_field = result.schema().field(0).clone();
+
+        assert_eq!(
+            out_field
+                .metadata()
+                .get("ARROW:extension:name")
+                .map(String::as_str),
+            Some("geoarrow.wkb"),
+        );
+        let ext_meta = out_field
+            .metadata()
+            .get("ARROW:extension:metadata")
+            .expect("CRS metadata should be present");
+        assert!(ext_meta.contains("EPSG:4326"));
+
+        // `with_extension_type` preserves source metadata; the prior `target_field.clone()`
+        // path would have dropped this.
+        assert_eq!(
+            out_field
+                .metadata()
+                .get("parquet.field.id")
+                .map(String::as_str),
+            Some("1"),
+        );
+    }
+
     // --- Tests for build_json_reorder_indices and json_arrow_schema ---
 
     const FILE_PATH: &str = "s3://bucket/test.json";
@@ -4529,6 +4579,26 @@ mod tests {
             "WKB bytes should be non-empty"
         );
 
+        let geom_field = match batch.schema().field(0).data_type() {
+            ArrowDataType::Struct(f) => f[0].clone(),
+            other => panic!("expected Struct minValues, got {other:?}"),
+        };
+        assert_eq!(
+            geom_field
+                .metadata()
+                .get("ARROW:extension:name")
+                .map(String::as_str),
+            Some("geoarrow.wkb"),
+        );
+        let ext_meta = geom_field
+            .metadata()
+            .get("ARROW:extension:metadata")
+            .expect("CRS metadata should be present on output");
+        assert!(
+            ext_meta.contains("OGC:CRS84"),
+            "output CRS should be OGC:CRS84, got {ext_meta}"
+        );
+
         // Missing geom field produces a null entry
         let input: Vec<Option<&str>> = vec![Some(r#"{"minValues":{}}"#)];
         let batch = parse_json_impl(&input.into(), schema.clone()).unwrap();
@@ -4663,5 +4733,73 @@ mod tests {
             .expect("should be BinaryArray");
         assert_eq!(binary.len(), 1);
         assert!(!binary.value(0).is_empty(), "WKB bytes should be non-empty");
+    }
+
+    #[cfg(feature = "arrow-conversion")]
+    #[test]
+    fn test_parse_json_impl_preserves_crs_and_edges_metadata() {
+        use crate::geoarrow_schema::{Edges, GeoArrowType, Metadata, WkbType};
+
+        fn parse_one_geo_row(geo_type: GeoArrowType, field_name: &str) -> ArrowField {
+            let geo_field = geo_type.to_field(field_name, true);
+            let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+                "minValues",
+                ArrowDataType::Struct(ArrowFields::from(vec![geo_field])),
+                true,
+            )]));
+            let json = format!(r#"{{"minValues":{{"{field_name}":"POINT(1.0 2.0)"}}}}"#);
+            let input: Vec<Option<&str>> = vec![Some(&json)];
+            let batch = parse_json_impl(&input.into(), schema).unwrap();
+            match batch.schema().field(0).data_type() {
+                ArrowDataType::Struct(f) => f[0].as_ref().clone(),
+                other => panic!("expected Struct, got {other:?}"),
+            }
+        }
+
+        let crs = crate::geoarrow_schema::crs::Crs::from_srid("EPSG:4326".to_string());
+        let geometry_field = parse_one_geo_row(
+            GeoArrowType::Wkb(WkbType::new(Arc::new(Metadata::new(crs, None)))),
+            "geom",
+        );
+        let geometry_meta = geometry_field
+            .metadata()
+            .get("ARROW:extension:metadata")
+            .expect("Geometry output should have CRS metadata");
+        assert!(
+            geometry_meta.contains("EPSG:4326"),
+            "Geometry CRS should be EPSG:4326, got {geometry_meta}"
+        );
+
+        let crs = crate::geoarrow_schema::crs::Crs::from_srid("OGC:CRS84".to_string());
+        let geography_field = parse_one_geo_row(
+            GeoArrowType::Wkb(WkbType::new(Arc::new(Metadata::new(
+                crs,
+                Some(Edges::Vincenty),
+            )))),
+            "geog",
+        );
+        let geography_meta = geography_field
+            .metadata()
+            .get("ARROW:extension:metadata")
+            .expect("Geography output should have CRS metadata");
+        assert!(
+            geography_meta.contains("\"edges\":\"vincenty\""),
+            "Geography output should carry edges=vincenty, got {geography_meta}"
+        );
+    }
+
+    #[test]
+    fn test_parse_json_impl_no_op_when_schema_has_no_geo() {
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("id", ArrowDataType::Int64, true),
+            ArrowField::new("name", ArrowDataType::Utf8, true),
+        ]));
+
+        let input: Vec<Option<&str>> = vec![Some(r#"{"id":42,"name":"hello"}"#)];
+        let batch = parse_json_impl(&input.into(), schema.clone()).unwrap();
+
+        assert_eq!(*batch.schema(), *schema);
+        assert_eq!(batch.num_rows(), 1);
+        assert_eq!(batch.num_columns(), 2);
     }
 }

--- a/kernel/src/engine/ensure_data_types.rs
+++ b/kernel/src/engine/ensure_data_types.rs
@@ -9,7 +9,7 @@ use itertools::Itertools;
 use super::arrow_conversion::TryIntoArrow as _;
 use crate::arrow::datatypes::{DataType as ArrowDataType, Field as ArrowField, TimeUnit};
 use crate::engine::arrow_utils::make_arrow_error;
-use crate::schema::{DataType, MetadataValue, StructField};
+use crate::schema::{DataType, MetadataValue, PrimitiveType, StructField};
 use crate::utils::require;
 use crate::{DeltaResult, Error};
 
@@ -89,6 +89,12 @@ impl EnsureDataTypes {
             | (&DataType::BINARY, ArrowDataType::LargeBinary)
             | (&DataType::BINARY, ArrowDataType::BinaryView)
             | (&DataType::BINARY, ArrowDataType::Binary) => Ok(DataTypeCompat::Identical),
+            // Geometry and Geography values are stored as WKB bytes in a Binary array; the
+            // kernel schema carries the geo annotation while the physical Arrow type is Binary.
+            (
+                DataType::Primitive(PrimitiveType::Geometry(_) | PrimitiveType::Geography(_)),
+                ArrowDataType::Binary | ArrowDataType::LargeBinary | ArrowDataType::BinaryView,
+            ) => Ok(DataTypeCompat::Identical),
             (DataType::Array(inner_type), ArrowDataType::List(arrow_list_field))
             | (DataType::Array(inner_type), ArrowDataType::LargeList(arrow_list_field))
             | (DataType::Array(inner_type), ArrowDataType::ListView(arrow_list_field))
@@ -782,5 +788,52 @@ mod tests {
             ensure_data_types(&kernel, &arrow, ValidationMode::TypesOnly),
             "Incorrect datatype",
         );
+    }
+
+    #[test]
+    fn ensure_geo_types_against_binary_variants() {
+        use crate::schema::{
+            EdgeInterpolationAlgorithm, GeographyType, GeometryType, PrimitiveType,
+        };
+        let geometry = DataType::Primitive(PrimitiveType::Geometry(Box::<GeometryType>::default()));
+        let geography =
+            DataType::Primitive(PrimitiveType::Geography(Box::<GeographyType>::default()));
+        let geography_vincenty = DataType::Primitive(PrimitiveType::Geography(Box::new(
+            GeographyType::try_new(
+                Some("EPSG:4326"),
+                Some(EdgeInterpolationAlgorithm::Vincenty),
+            )
+            .unwrap(),
+        )));
+
+        for arrow_type in [
+            ArrowDataType::Binary,
+            ArrowDataType::LargeBinary,
+            ArrowDataType::BinaryView,
+        ] {
+            assert_eq!(
+                ensure_data_types(&geometry, &arrow_type, ValidationMode::Full).unwrap(),
+                DataTypeCompat::Identical,
+                "Geometry vs {arrow_type:?}"
+            );
+            assert_eq!(
+                ensure_data_types(&geography, &arrow_type, ValidationMode::Full).unwrap(),
+                DataTypeCompat::Identical,
+                "Geography (default) vs {arrow_type:?}"
+            );
+            assert_eq!(
+                ensure_data_types(&geography_vincenty, &arrow_type, ValidationMode::Full).unwrap(),
+                DataTypeCompat::Identical,
+                "Geography (Vincenty) vs {arrow_type:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn ensure_geo_types_reject_non_binary() {
+        use crate::schema::{GeometryType, PrimitiveType};
+        let geometry = DataType::Primitive(PrimitiveType::Geometry(Box::<GeometryType>::default()));
+        assert!(ensure_data_types(&geometry, &ArrowDataType::Utf8, ValidationMode::Full).is_err());
+        assert!(ensure_data_types(&geometry, &ArrowDataType::Int64, ValidationMode::Full).is_err());
     }
 }

--- a/kernel/src/engine/mod.rs
+++ b/kernel/src/engine/mod.rs
@@ -37,6 +37,9 @@ pub(crate) mod arrow_utils;
 #[cfg(feature = "internal-api")]
 pub use self::arrow_utils::{parse_json, to_json_bytes};
 
+#[cfg(feature = "arrow-expression")]
+mod parse_json_geo;
+
 #[cfg(feature = "default-engine-base")]
 pub mod default;
 

--- a/kernel/src/engine/parquet_row_group_skipping.rs
+++ b/kernel/src/engine/parquet_row_group_skipping.rs
@@ -199,8 +199,6 @@ fn extract_min_scalar(data_type: &DataType, stats: &Statistics) -> Option<Scalar
             decimal_from_bytes(b.min_bytes_opt(), *d)?
         }
         (Decimal(..), _) => return None,
-        // WKB bytes are not lexicographically orderable, so parquet min/max are not
-        // meaningful for Geometry/Geography columns.
         (Geometry(_) | Geography(_), _) => return None,
     };
     Some(value)

--- a/kernel/src/engine/parquet_row_group_skipping.rs
+++ b/kernel/src/engine/parquet_row_group_skipping.rs
@@ -199,6 +199,9 @@ fn extract_min_scalar(data_type: &DataType, stats: &Statistics) -> Option<Scalar
             decimal_from_bytes(b.min_bytes_opt(), *d)?
         }
         (Decimal(..), _) => return None,
+        // WKB bytes are not lexicographically orderable, so parquet min/max are not
+        // meaningful for Geometry/Geography columns.
+        (Geometry(_) | Geography(_), _) => return None,
     };
     Some(value)
 }
@@ -243,6 +246,9 @@ fn extract_max_scalar(data_type: &DataType, stats: &Statistics) -> Option<Scalar
             decimal_from_bytes(b.max_bytes_opt(), *d)?
         }
         (Decimal(..), _) => return None,
+        // WKB bytes are not lexicographically orderable, so parquet min/max are not
+        // meaningful for Geometry/Geography columns.
+        (Geometry(_) | Geography(_), _) => return None,
     };
     Some(value)
 }

--- a/kernel/src/engine/parquet_row_group_skipping.rs
+++ b/kernel/src/engine/parquet_row_group_skipping.rs
@@ -244,8 +244,6 @@ fn extract_max_scalar(data_type: &DataType, stats: &Statistics) -> Option<Scalar
             decimal_from_bytes(b.max_bytes_opt(), *d)?
         }
         (Decimal(..), _) => return None,
-        // WKB bytes are not lexicographically orderable, so parquet min/max are not
-        // meaningful for Geometry/Geography columns.
         (Geometry(_) | Geography(_), _) => return None,
     };
     Some(value)

--- a/kernel/src/engine/parse_json_geo.rs
+++ b/kernel/src/engine/parse_json_geo.rs
@@ -1,0 +1,213 @@
+//! GeoArrow WKT-to-WKB conversion helpers for JSON stats parsing.
+//!
+//! Delta JSON stats store geometry bounds as WKT strings, but GeoArrow WKB fields have
+//! DataType::Binary. The Arrow JSON reader cannot parse WKT into binary, so we temporarily
+//! replace geo fields with Utf8 for parsing, then convert the resulting WKT strings back to
+//! WKB binary afterward. Tables with no geo columns skip both passes.
+
+use std::sync::Arc;
+
+use crate::arrow::array::cast::AsArray;
+use crate::arrow::array::{
+    Array as ArrowArray, GenericListArray, MapArray, RecordBatch, StructArray,
+};
+use crate::arrow::datatypes::{
+    DataType as ArrowDataType, Field as ArrowField, FieldRef as ArrowFieldRef,
+    Fields as ArrowFields, Schema as ArrowSchema,
+};
+use crate::geoarrow_array::array::WktArray;
+use crate::geoarrow_array::{cast as geo_cast, GeoArrowArray};
+use crate::geoarrow_schema::{GeoArrowType, WktType};
+use crate::{DeltaResult, Error};
+
+fn is_geoarrow_field(field: &ArrowField) -> bool {
+    GeoArrowType::try_from(field).is_ok()
+}
+
+/// Builds a copy of schema with every GeoArrow field replaced by Utf8, recursing through
+/// Struct, List, and Map children. The flag in the return is true iff any GeoArrow leaf
+/// was found; when false, the caller can skip the conversion pass entirely.
+pub(super) fn replace_geo_fields_with_utf8(schema: &ArrowSchema) -> (ArrowSchema, bool) {
+    let (new_fields, has_geo) = rebuild_fields_replacing_geo(schema.fields());
+    (
+        ArrowSchema::new_with_metadata(new_fields, schema.metadata().clone()),
+        has_geo,
+    )
+}
+
+fn rebuild_fields_replacing_geo(fields: &ArrowFields) -> (ArrowFields, bool) {
+    let mut has_geo = false;
+    let new_fields: Vec<_> = fields
+        .iter()
+        .map(|f| {
+            let (new_field, child_has_geo) = rebuild_field_replacing_geo(f);
+            if child_has_geo {
+                has_geo = true;
+            }
+            new_field
+        })
+        .collect();
+    (ArrowFields::from(new_fields), has_geo)
+}
+
+// When no geo leaf is found in a subtree, returns the original Arc unchanged to avoid
+// cloning the field tree.
+fn rebuild_field_replacing_geo(field: &ArrowFieldRef) -> (ArrowFieldRef, bool) {
+    if is_geoarrow_field(field) {
+        let new_field = ArrowField::new(field.name(), ArrowDataType::Utf8, field.is_nullable());
+        return (Arc::new(new_field), true);
+    }
+    match field.data_type() {
+        ArrowDataType::Struct(children) => {
+            let (new_children, child_has_geo) = rebuild_fields_replacing_geo(children);
+            if !child_has_geo {
+                return (Arc::clone(field), false);
+            }
+            let new_field = ArrowField::new(
+                field.name(),
+                ArrowDataType::Struct(new_children),
+                field.is_nullable(),
+            )
+            .with_metadata(field.metadata().clone());
+            (Arc::new(new_field), true)
+        }
+        ArrowDataType::List(element) => {
+            let (new_element, child_has_geo) = rebuild_field_replacing_geo(element);
+            if !child_has_geo {
+                return (Arc::clone(field), false);
+            }
+            let new_field = ArrowField::new(
+                field.name(),
+                ArrowDataType::List(new_element),
+                field.is_nullable(),
+            )
+            .with_metadata(field.metadata().clone());
+            (Arc::new(new_field), true)
+        }
+        ArrowDataType::Map(entries_field, sorted) => {
+            let ArrowDataType::Struct(entry_children) = entries_field.data_type() else {
+                return (Arc::clone(field), false);
+            };
+            let (new_entry_children, child_has_geo) = rebuild_fields_replacing_geo(entry_children);
+            if !child_has_geo {
+                return (Arc::clone(field), false);
+            }
+            let new_entries = Arc::new(
+                ArrowField::new(
+                    entries_field.name(),
+                    ArrowDataType::Struct(new_entry_children),
+                    entries_field.is_nullable(),
+                )
+                .with_metadata(entries_field.metadata().clone()),
+            );
+            let new_field = ArrowField::new(
+                field.name(),
+                ArrowDataType::Map(new_entries, *sorted),
+                field.is_nullable(),
+            )
+            .with_metadata(field.metadata().clone());
+            (Arc::new(new_field), true)
+        }
+        _ => (Arc::clone(field), false),
+    }
+}
+
+/// Converts a Utf8 array of WKT strings to a Binary array of WKB bytes, preserving the CRS
+/// from original_field's GeoArrow extension metadata. Errors if original_field is not a
+/// GeoArrow WKB field.
+fn convert_wkt_array_to_wkb(
+    array: &Arc<dyn ArrowArray>,
+    original_field: &ArrowField,
+) -> DeltaResult<Arc<dyn ArrowArray>> {
+    let metadata = match GeoArrowType::try_from(original_field) {
+        Ok(GeoArrowType::Wkb(wkb_type)) => wkb_type.metadata().clone(),
+        _ => {
+            return Err(Error::generic(format!(
+                "convert_wkt_array_to_wkb called on non-GeoArrow-WKB field '{}'",
+                original_field.name()
+            )));
+        }
+    };
+    let wkt_array = WktArray::from((array.as_string::<i32>().clone(), WktType::new(metadata)));
+    let wkb_array = geo_cast::to_wkb::<i32>(&wkt_array)
+        .map_err(|e| Error::generic(format!("WKT to WKB conversion failed: {e}")))?;
+    Ok(wkb_array.into_array_ref())
+}
+
+/// Walks batch and target_schema in parallel, converting WKT Utf8 columns to WKB Binary at
+/// every GeoArrow leaf and recursing through Struct, List, and Map containers. Non-geo
+/// non-container columns pass through unchanged.
+pub(super) fn convert_geo_columns(
+    batch: RecordBatch,
+    target_schema: &ArrowSchema,
+) -> DeltaResult<RecordBatch> {
+    let (_, columns, _) = batch.into_parts();
+    let new_columns: Vec<_> = columns
+        .into_iter()
+        .zip(target_schema.fields().iter())
+        .map(|(col, target_field)| convert_geo_column(col, target_field))
+        .collect::<DeltaResult<_>>()?;
+    Ok(RecordBatch::try_new(
+        Arc::new(target_schema.clone()),
+        new_columns,
+    )?)
+}
+
+fn convert_geo_column(
+    column: Arc<dyn ArrowArray>,
+    target_field: &ArrowField,
+) -> DeltaResult<Arc<dyn ArrowArray>> {
+    if is_geoarrow_field(target_field) {
+        return convert_wkt_array_to_wkb(&column, target_field);
+    }
+    match target_field.data_type() {
+        ArrowDataType::Struct(target_children) => {
+            let (_, child_arrays, nulls) = column.as_struct().clone().into_parts();
+            let new_children: Vec<_> = child_arrays
+                .into_iter()
+                .zip(target_children.iter())
+                .map(|(c, f)| convert_geo_column(c, f))
+                .collect::<DeltaResult<_>>()?;
+            Ok(Arc::new(StructArray::try_new(
+                target_children.clone(),
+                new_children,
+                nulls,
+            )?))
+        }
+        ArrowDataType::List(target_element) => {
+            let (_, offsets, values, nulls) = column.as_list::<i32>().clone().into_parts();
+            let new_values = convert_geo_column(values, target_element)?;
+            Ok(Arc::new(GenericListArray::<i32>::try_new(
+                Arc::clone(target_element),
+                offsets,
+                new_values,
+                nulls,
+            )?))
+        }
+        ArrowDataType::Map(target_entries, sorted) => {
+            let ArrowDataType::Struct(target_entry_children) = target_entries.data_type() else {
+                return Err(Error::generic("Map entries field is not a struct"));
+            };
+            let (_, offsets, entries, nulls, _) = column.as_map().clone().into_parts();
+            let (_, entry_arrays, entry_nulls) = entries.into_parts();
+            let new_entry_children: Vec<_> = entry_arrays
+                .into_iter()
+                .zip(target_entry_children.iter())
+                .map(|(c, f)| convert_geo_column(c, f))
+                .collect::<DeltaResult<_>>()?;
+            let new_entries = StructArray::try_new(
+                target_entry_children.clone(),
+                new_entry_children,
+                entry_nulls,
+            )?;
+            Ok(Arc::new(MapArray::try_new(
+                Arc::clone(target_entries),
+                offsets,
+                new_entries,
+                nulls,
+                *sorted,
+            )?))
+        }
+        _ => Ok(column),
+    }
+}

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -174,6 +174,14 @@ pub enum Error {
     #[error("Invalid decimal: {0}")]
     InvalidDecimal(String),
 
+    /// Invalid srid for a GeometryType
+    #[error("Invalid geometry: {0}")]
+    InvalidGeometry(String),
+
+    /// Invalid srid for a GeographyType
+    #[error("Invalid geography: {0}")]
+    InvalidGeography(String),
+
     /// Inconsistent data passed to struct scalar
     #[error("Invalid struct data: {0}")]
     InvalidStructData(String),
@@ -277,6 +285,12 @@ impl Error {
     }
     pub fn invalid_decimal(msg: impl ToString) -> Self {
         Self::InvalidDecimal(msg.to_string())
+    }
+    pub fn invalid_geometry(msg: impl ToString) -> Self {
+        Self::InvalidGeometry(msg.to_string())
+    }
+    pub fn invalid_geography(msg: impl ToString) -> Self {
+        Self::InvalidGeography(msg.to_string())
     }
     pub fn invalid_struct_data(msg: impl ToString) -> Self {
         Self::InvalidStructData(msg.to_string())

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -757,10 +757,10 @@ impl PrimitiveType {
                 }
             }
             // Geometry/Geography are not valid partition column types, so there is no
-            // partition-value string format to parse here.
-            Geometry(_) | Geography(_) => Err(Error::generic(
-                "Geometry and Geography types are not supported as partition column values",
-            )),
+            // partition-value string format to parse here
+            Geometry(_) | Geography(_) => Err(Error::Unsupported(format!(
+                "parse_scalar is not supported for {self:?}"
+            ))),
         }
     }
 

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -756,6 +756,11 @@ impl PrimitiveType {
                     _ => unreachable!(),
                 }
             }
+            // Geometry/Geography are not valid partition column types, so there is no
+            // partition-value string format to parse here.
+            Geometry(_) | Geography(_) => Err(Error::generic(
+                "Geometry and Geography types are not supported as partition column values",
+            )),
         }
     }
 

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -756,8 +756,7 @@ impl PrimitiveType {
                     _ => unreachable!(),
                 }
             }
-            // Geometry/Geography are not valid partition column types, so there is no
-            // partition-value string format to parse here
+            // Kernel does not support parsing text into Geometry/Geography types
             Geometry(_) | Geography(_) => Err(Error::Unsupported(format!(
                 "parse_scalar is not supported for {self:?}"
             ))),

--- a/kernel/src/scan/data_skipping/stats_schema/mod.rs
+++ b/kernel/src/scan/data_skipping/stats_schema/mod.rs
@@ -412,6 +412,8 @@ pub(crate) fn is_skipping_eligible_datatype(data_type: &PrimitiveType) -> bool {
             | &PrimitiveType::TimestampNtz
             | &PrimitiveType::String
             | PrimitiveType::Decimal(_)
+            | PrimitiveType::Geometry(_)
+            | PrimitiveType::Geography(_)
     )
 }
 

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -1563,12 +1563,17 @@ pub struct GeometryType {
 }
 
 impl GeometryType {
-    /// Creates a new [`GeometryType`] with the given SRID.
+    /// Creates a new GeometryType with the given SRID.
     ///
     /// # Parameters
     /// - `srid`: The spatial reference identifier (e.g. `"OGC:CRS84"`, `"EPSG:4326"`).
+    ///   Must be non-empty.
     pub fn try_new(srid: impl Into<String>) -> DeltaResult<Self> {
-        Ok(Self { srid: srid.into() })
+        let srid = srid.into();
+        if srid.is_empty() {
+            return Err(Error::invalid_geometry("SRID cannot be empty"));
+        }
+        Ok(Self { srid })
     }
 
     /// Returns the SRID associated with this geometry type.
@@ -1602,19 +1607,32 @@ pub struct GeographyType {
 }
 
 impl GeographyType {
-    /// Creates a new [`GeographyType`] with the given SRID and edge interpolation algorithm.
+    /// Creates a new GeographyType with the given SRID and edge interpolation algorithm.
     ///
     /// # Parameters
-    /// - `srid`: The spatial reference identifier (e.g. `"OGC:CRS84"`).
+    /// - `srid`: The spatial reference identifier (e.g. `"OGC:CRS84"`). Must be non-empty.
     /// - `algorithm`: The edge interpolation algorithm to use.
     pub fn try_new(
         srid: impl Into<String>,
         algorithm: EdgeInterpolationAlgorithm,
     ) -> DeltaResult<Self> {
-        Ok(Self {
-            srid: srid.into(),
-            algorithm,
-        })
+        let srid = srid.into();
+        if srid.is_empty() {
+            return Err(Error::invalid_geography("SRID cannot be empty"));
+        }
+        Ok(Self { srid, algorithm })
+    }
+
+    /// Creates a new GeographyType with the given SRID and the default edge interpolation
+    /// algorithm ([`EdgeInterpolationAlgorithm::Spherical`]).
+    pub fn try_new_with_srid(srid: impl Into<String>) -> DeltaResult<Self> {
+        Self::try_new(srid, EdgeInterpolationAlgorithm::Spherical)
+    }
+
+    /// Creates a new GeographyType with the given edge interpolation algorithm and the
+    /// default SRID (DEFAULT_GEO_SRID).
+    pub fn try_new_with_algorithm(algorithm: EdgeInterpolationAlgorithm) -> DeltaResult<Self> {
+        Self::try_new(DEFAULT_GEO_SRID, algorithm)
     }
 
     /// Returns the SRID associated with this geography type.
@@ -1703,12 +1721,8 @@ pub enum PrimitiveType {
     TimestampNtz,
     #[serde(serialize_with = "serialize_decimal", untagged)]
     Decimal(DecimalType),
-    /// A geometry type with an associated spatial reference identifier.
-    /// Values are stored as WKB (Well-Known Binary) bytes.
     #[serde(serialize_with = "serialize_geometry", untagged)]
     Geometry(GeometryType),
-    /// A geography type with an associated SRID and edge interpolation algorithm.
-    /// Values are stored as WKB bytes.
     #[serde(serialize_with = "serialize_geography", untagged)]
     Geography(GeographyType),
 }
@@ -1866,7 +1880,10 @@ impl<'de> serde::Deserialize<'de> for PrimitiveType {
             "geography" => Ok(PrimitiveType::Geography(GeographyType::default())),
             geo_str if geo_str.starts_with("geography(") && geo_str.ends_with(')') => {
                 let inner = &geo_str[10..geo_str.len() - 1];
-                // Split on the last comma to separate SRID from algorithm
+                // Three accepted shapes:
+                //   geography(<srid>, <algorithm>) -- both
+                //   geography(<srid>)              -- SRID only (contains ':')
+                //   geography(<algorithm>)         -- algorithm only (no ':')
                 match inner.rfind(',') {
                     Some(pos) => {
                         let srid = inner[..pos].trim();
@@ -1878,10 +1895,18 @@ impl<'de> serde::Deserialize<'de> for PrimitiveType {
                             .map_err(serde::de::Error::custom)
                     }
                     None => {
-                        // No comma -- treat entire inner as SRID with default algorithm
-                        GeographyType::try_new(inner.trim(), EdgeInterpolationAlgorithm::Spherical)
-                            .map(PrimitiveType::Geography)
-                            .map_err(serde::de::Error::custom)
+                        let trimmed = inner.trim();
+                        if trimmed.contains(':') {
+                            GeographyType::try_new_with_srid(trimmed)
+                                .map(PrimitiveType::Geography)
+                                .map_err(serde::de::Error::custom)
+                        } else {
+                            let algorithm: EdgeInterpolationAlgorithm =
+                                trimmed.parse().map_err(serde::de::Error::custom)?;
+                            GeographyType::try_new_with_algorithm(algorithm)
+                                .map(PrimitiveType::Geography)
+                                .map_err(serde::de::Error::custom)
+                        }
                     }
                 }
             }
@@ -2449,6 +2474,56 @@ mod tests {
     }
 
     #[test]
+    fn test_roundtrip_geometry() {
+        let data = r#"
+        {
+            "name": "g",
+            "type": "geometry(EPSG:4326)",
+            "nullable": true,
+            "metadata": {}
+        }
+        "#;
+        let field: StructField = serde_json::from_str(data).unwrap();
+        assert_eq!(
+            field.data_type,
+            DataType::Primitive(PrimitiveType::Geometry(
+                GeometryType::try_new("EPSG:4326").unwrap()
+            ))
+        );
+
+        let json_str = serde_json::to_string(&field).unwrap();
+        assert_eq!(
+            json_str,
+            r#"{"name":"g","type":"geometry(EPSG:4326)","nullable":true,"metadata":{}}"#
+        );
+    }
+
+    #[test]
+    fn test_roundtrip_geography() {
+        let data = r#"
+        {
+            "name": "g",
+            "type": "geography(EPSG:4326, vincenty)",
+            "nullable": true,
+            "metadata": {}
+        }
+        "#;
+        let field: StructField = serde_json::from_str(data).unwrap();
+        assert_eq!(
+            field.data_type,
+            DataType::Primitive(PrimitiveType::Geography(
+                GeographyType::try_new("EPSG:4326", EdgeInterpolationAlgorithm::Vincenty).unwrap()
+            ))
+        );
+
+        let json_str = serde_json::to_string(&field).unwrap();
+        assert_eq!(
+            json_str,
+            r#"{"name":"g","type":"geography(EPSG:4326, vincenty)","nullable":true,"metadata":{}}"#
+        );
+    }
+
+    #[test]
     fn test_unshredded_variant() {
         let unshredded_variant_type = DataType::unshredded_variant();
 
@@ -2547,6 +2622,63 @@ mod tests {
     #[case("decimal()", "Invalid precision in decimal")]
     #[case("decimal(10,2,99)", "Invalid decimal format (expected 2 parts)")]
     fn test_invalid_decimal_format(#[case] invalid_type: &str, #[case] expected_error: &str) {
+        let data = format!(
+            r#"{{
+                "name": "invalid",
+                "type": "{invalid_type}",
+                "nullable": false,
+                "metadata": {{}}
+            }}"#
+        );
+        let result: Result<StructField, _> = serde_json::from_str(&data);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains(expected_error),
+            "Expected error containing '{expected_error}', got: {err}"
+        );
+    }
+
+    #[rstest]
+    #[case("geometry", PrimitiveType::Geometry(GeometryType::default()))]
+    #[case("geography", PrimitiveType::Geography(GeographyType::default()))]
+    #[case(
+        "geometry(EPSG:4326)",
+        PrimitiveType::Geometry(GeometryType::try_new("EPSG:4326").unwrap())
+    )]
+    #[case(
+        "geography(EPSG:4326)",
+        PrimitiveType::Geography(GeographyType::try_new_with_srid("EPSG:4326").unwrap())
+    )]
+    #[case(
+        "geography(EPSG:4326, vincenty)",
+        PrimitiveType::Geography(
+            GeographyType::try_new("EPSG:4326", EdgeInterpolationAlgorithm::Vincenty).unwrap()
+        )
+    )]
+    #[case(
+        "geography(vincenty)",
+        PrimitiveType::Geography(
+            GeographyType::try_new_with_algorithm(EdgeInterpolationAlgorithm::Vincenty).unwrap()
+        )
+    )]
+    fn test_geo_deserialize_defaults(#[case] type_str: &str, #[case] expected: PrimitiveType) {
+        let json = format!(r#"{{"name":"g","type":"{type_str}","nullable":true,"metadata":{{}}}}"#);
+        let field: StructField = serde_json::from_str(&json).unwrap();
+        assert_eq!(field.data_type, DataType::Primitive(expected));
+    }
+
+    #[rstest]
+    #[case(
+        "geography(EPSG:4326, unknown_algo)",
+        "Unknown edge interpolation algorithm"
+    )]
+    #[case("geography(EPSG:4326,)", "Unknown edge interpolation algorithm")]
+    #[case("geometry(EPSG:4326", "Unsupported Delta table type")]
+    #[case("geographyz", "Unsupported Delta table type")]
+    #[case("geometry()", "SRID cannot be empty")]
+    #[case("geography(, vincenty)", "SRID cannot be empty")]
+    fn test_invalid_geo_format(#[case] invalid_type: &str, #[case] expected_error: &str) {
         let data = format!(
             r#"{{
                 "name": "invalid",

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -1560,6 +1560,8 @@ impl GeometryType {
     ///
     /// Returns `Err` if `srid` is empty.
     pub fn try_new(srid: &str) -> DeltaResult<Self> {
+        // We only check that the SRID is non-empty; validating the value against the full set
+        // of (1000+) recognized SRIDs is future work.
         if srid.is_empty() {
             return Err(Error::invalid_geometry("SRID cannot be empty"));
         }
@@ -1604,6 +1606,8 @@ impl GeographyType {
         srid: Option<&str>,
         algorithm: Option<EdgeInterpolationAlgorithm>,
     ) -> DeltaResult<Self> {
+        // We only check that the SRID is non-empty; validating the value against the full set
+        // of (1000+) recognized SRIDs is future work.
         let srid = match srid {
             None => DEFAULT_GEO_SRID.to_string(),
             Some(s) => {

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -1722,9 +1722,9 @@ pub enum PrimitiveType {
     #[serde(serialize_with = "serialize_decimal", untagged)]
     Decimal(DecimalType),
     #[serde(serialize_with = "serialize_geometry", untagged)]
-    Geometry(GeometryType),
+    Geometry(Box<GeometryType>),
     #[serde(serialize_with = "serialize_geography", untagged)]
-    Geography(GeographyType),
+    Geography(Box<GeographyType>),
 }
 
 impl PrimitiveType {
@@ -1870,14 +1870,15 @@ impl<'de> serde::Deserialize<'de> for PrimitiveType {
                     .map(PrimitiveType::Decimal)
                     .map_err(serde::de::Error::custom)
             }
-            "geometry" => Ok(PrimitiveType::Geometry(GeometryType::default())),
+            "geometry" => Ok(PrimitiveType::Geometry(Box::default())),
             geo_str if geo_str.starts_with("geometry(") && geo_str.ends_with(')') => {
                 let srid = &geo_str[9..geo_str.len() - 1];
                 GeometryType::try_new(srid.trim())
+                    .map(Box::new)
                     .map(PrimitiveType::Geometry)
                     .map_err(serde::de::Error::custom)
             }
-            "geography" => Ok(PrimitiveType::Geography(GeographyType::default())),
+            "geography" => Ok(PrimitiveType::Geography(Box::default())),
             geo_str if geo_str.starts_with("geography(") && geo_str.ends_with(')') => {
                 let inner = &geo_str[10..geo_str.len() - 1];
                 // Three accepted shapes:
@@ -1891,6 +1892,7 @@ impl<'de> serde::Deserialize<'de> for PrimitiveType {
                         let algorithm: EdgeInterpolationAlgorithm =
                             algo_str.parse().map_err(serde::de::Error::custom)?;
                         GeographyType::try_new(srid, algorithm)
+                            .map(Box::new)
                             .map(PrimitiveType::Geography)
                             .map_err(serde::de::Error::custom)
                     }
@@ -1898,12 +1900,14 @@ impl<'de> serde::Deserialize<'de> for PrimitiveType {
                         let trimmed = inner.trim();
                         if trimmed.contains(':') {
                             GeographyType::try_new_with_srid(trimmed)
+                                .map(Box::new)
                                 .map(PrimitiveType::Geography)
                                 .map_err(serde::de::Error::custom)
                         } else {
                             let algorithm: EdgeInterpolationAlgorithm =
                                 trimmed.parse().map_err(serde::de::Error::custom)?;
                             GeographyType::try_new_with_algorithm(algorithm)
+                                .map(Box::new)
                                 .map(PrimitiveType::Geography)
                                 .map_err(serde::de::Error::custom)
                         }
@@ -1972,7 +1976,7 @@ impl From<DecimalType> for DataType {
 }
 impl From<GeometryType> for PrimitiveType {
     fn from(gtype: GeometryType) -> Self {
-        PrimitiveType::Geometry(gtype)
+        PrimitiveType::Geometry(Box::new(gtype))
     }
 }
 impl From<GeometryType> for DataType {
@@ -1982,7 +1986,7 @@ impl From<GeometryType> for DataType {
 }
 impl From<GeographyType> for PrimitiveType {
     fn from(gtype: GeographyType) -> Self {
-        PrimitiveType::Geography(gtype)
+        PrimitiveType::Geography(Box::new(gtype))
     }
 }
 impl From<GeographyType> for DataType {
@@ -2486,9 +2490,9 @@ mod tests {
         let field: StructField = serde_json::from_str(data).unwrap();
         assert_eq!(
             field.data_type,
-            DataType::Primitive(PrimitiveType::Geometry(
+            DataType::Primitive(PrimitiveType::Geometry(Box::new(
                 GeometryType::try_new("EPSG:4326").unwrap()
-            ))
+            )))
         );
 
         let json_str = serde_json::to_string(&field).unwrap();
@@ -2511,9 +2515,9 @@ mod tests {
         let field: StructField = serde_json::from_str(data).unwrap();
         assert_eq!(
             field.data_type,
-            DataType::Primitive(PrimitiveType::Geography(
+            DataType::Primitive(PrimitiveType::Geography(Box::new(
                 GeographyType::try_new("EPSG:4326", EdgeInterpolationAlgorithm::Vincenty).unwrap()
-            ))
+            )))
         );
 
         let json_str = serde_json::to_string(&field).unwrap();
@@ -2640,27 +2644,27 @@ mod tests {
     }
 
     #[rstest]
-    #[case("geometry", PrimitiveType::Geometry(GeometryType::default()))]
-    #[case("geography", PrimitiveType::Geography(GeographyType::default()))]
+    #[case("geometry", PrimitiveType::Geometry(Box::default()))]
+    #[case("geography", PrimitiveType::Geography(Box::default()))]
     #[case(
         "geometry(EPSG:4326)",
-        PrimitiveType::Geometry(GeometryType::try_new("EPSG:4326").unwrap())
+        PrimitiveType::Geometry(Box::new(GeometryType::try_new("EPSG:4326").unwrap()))
     )]
     #[case(
         "geography(EPSG:4326)",
-        PrimitiveType::Geography(GeographyType::try_new_with_srid("EPSG:4326").unwrap())
+        PrimitiveType::Geography(Box::new(GeographyType::try_new_with_srid("EPSG:4326").unwrap()))
     )]
     #[case(
         "geography(EPSG:4326, vincenty)",
-        PrimitiveType::Geography(
+        PrimitiveType::Geography(Box::new(
             GeographyType::try_new("EPSG:4326", EdgeInterpolationAlgorithm::Vincenty).unwrap()
-        )
+        ))
     )]
     #[case(
         "geography(vincenty)",
-        PrimitiveType::Geography(
+        PrimitiveType::Geography(Box::new(
             GeographyType::try_new_with_algorithm(EdgeInterpolationAlgorithm::Vincenty).unwrap()
-        )
+        ))
     )]
     fn test_geo_deserialize_defaults(#[case] type_str: &str, #[case] expected: PrimitiveType) {
         let json = format!(r#"{{"name":"g","type":"{type_str}","nullable":true,"metadata":{{}}}}"#);

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -1507,21 +1507,16 @@ fn default_true() -> bool {
     true
 }
 
-/// The default spatial reference identifier for geometry and geography types.
+/// Default spatial reference identifier for geometry and geography types.
 pub const DEFAULT_GEO_SRID: &str = "OGC:CRS84";
 
-/// The algorithm used to interpolate edges between two vertices of a geography path.
+/// Algorithm used to interpolate edges between two vertices of a geography path.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum EdgeInterpolationAlgorithm {
-    /// Great circle paths on a sphere.
     Spherical,
-    /// Vincenty's inverse formula on an ellipsoid.
     Vincenty,
-    /// Thomas's formula on an ellipsoid.
     Thomas,
-    /// Andoyer's method on an ellipsoid.
     Andoyer,
-    /// Karney's method on an ellipsoid.
     Karney,
 }
 
@@ -1553,21 +1548,13 @@ impl std::str::FromStr for EdgeInterpolationAlgorithm {
     }
 }
 
-/// A geometry column type with an associated spatial reference identifier (SRID).
-///
-/// Geometry values are encoded as WKB (Well-Known Binary) bytes in the Arrow layer,
-/// represented as a `Binary` physical array with GeoArrow field metadata.
+/// A geometry column type with an associated spatial reference identifier (SRID)
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct GeometryType {
     srid: String,
 }
 
 impl GeometryType {
-    /// Creates a new GeometryType with the given SRID.
-    ///
-    /// # Parameters
-    /// - `srid`: The spatial reference identifier (e.g. `"OGC:CRS84"`, `"EPSG:4326"`). Must be
-    ///   non-empty.
     pub fn try_new(srid: impl Into<String>) -> DeltaResult<Self> {
         let srid = srid.into();
         if srid.is_empty() {
@@ -1576,7 +1563,6 @@ impl GeometryType {
         Ok(Self { srid })
     }
 
-    /// Returns the SRID associated with this geometry type.
     pub fn srid(&self) -> &str {
         &self.srid
     }
@@ -1596,10 +1582,7 @@ impl Display for GeometryType {
     }
 }
 
-/// A geography column type with an associated SRID and edge interpolation algorithm.
-///
-/// Geography values are encoded as WKB bytes in the Arrow layer,
-/// represented as a `Binary` physical array with GeoArrow field metadata.
+/// Geography column type with an associated SRID and edge interpolation algorithm.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct GeographyType {
     srid: String,
@@ -1607,11 +1590,6 @@ pub struct GeographyType {
 }
 
 impl GeographyType {
-    /// Creates a new GeographyType with the given SRID and edge interpolation algorithm.
-    ///
-    /// # Parameters
-    /// - `srid`: The spatial reference identifier (e.g. `"OGC:CRS84"`). Must be non-empty.
-    /// - `algorithm`: The edge interpolation algorithm to use.
     pub fn try_new(
         srid: impl Into<String>,
         algorithm: EdgeInterpolationAlgorithm,
@@ -1623,24 +1601,18 @@ impl GeographyType {
         Ok(Self { srid, algorithm })
     }
 
-    /// Creates a new GeographyType with the given SRID and the default edge interpolation
-    /// algorithm ([`EdgeInterpolationAlgorithm::Spherical`]).
     pub fn try_new_with_srid(srid: impl Into<String>) -> DeltaResult<Self> {
         Self::try_new(srid, EdgeInterpolationAlgorithm::Spherical)
     }
 
-    /// Creates a new GeographyType with the given edge interpolation algorithm and the
-    /// default SRID (DEFAULT_GEO_SRID).
     pub fn try_new_with_algorithm(algorithm: EdgeInterpolationAlgorithm) -> DeltaResult<Self> {
         Self::try_new(DEFAULT_GEO_SRID, algorithm)
     }
 
-    /// Returns the SRID associated with this geography type.
     pub fn srid(&self) -> &str {
         &self.srid
     }
 
-    /// Returns the edge interpolation algorithm for this geography type.
     pub fn algorithm(&self) -> &EdgeInterpolationAlgorithm {
         &self.algorithm
     }
@@ -1882,9 +1854,9 @@ impl<'de> serde::Deserialize<'de> for PrimitiveType {
             geo_str if geo_str.starts_with("geography(") && geo_str.ends_with(')') => {
                 let inner = &geo_str[10..geo_str.len() - 1];
                 // Three accepted shapes:
-                //   geography(<srid>, <algorithm>) -- both
-                //   geography(<srid>)              -- SRID only (contains ':')
-                //   geography(<algorithm>)         -- algorithm only (no ':')
+                //   geography(<srid>, <algorithm>) - both
+                //   geography(<srid>)              - SRID only (contains ':')
+                //   geography(<algorithm>)         - algorithm only (no ':')
                 match inner.rfind(',') {
                     Some(pos) => {
                         let srid = inner[..pos].trim();

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -1507,6 +1507,142 @@ fn default_true() -> bool {
     true
 }
 
+/// The default spatial reference identifier for geometry and geography types.
+pub const DEFAULT_GEO_SRID: &str = "OGC:CRS84";
+
+/// The algorithm used to interpolate edges between two vertices of a geography path.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum EdgeInterpolationAlgorithm {
+    /// Great circle paths on a sphere.
+    Spherical,
+    /// Vincenty's inverse formula on an ellipsoid.
+    Vincenty,
+    /// Thomas's formula on an ellipsoid.
+    Thomas,
+    /// Andoyer's method on an ellipsoid.
+    Andoyer,
+    /// Karney's method on an ellipsoid.
+    Karney,
+}
+
+impl Display for EdgeInterpolationAlgorithm {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Spherical => write!(f, "spherical"),
+            Self::Vincenty => write!(f, "vincenty"),
+            Self::Thomas => write!(f, "thomas"),
+            Self::Andoyer => write!(f, "andoyer"),
+            Self::Karney => write!(f, "karney"),
+        }
+    }
+}
+
+impl std::str::FromStr for EdgeInterpolationAlgorithm {
+    type Err = Error;
+    fn from_str(s: &str) -> DeltaResult<Self> {
+        match s.trim() {
+            "spherical" => Ok(Self::Spherical),
+            "vincenty" => Ok(Self::Vincenty),
+            "thomas" => Ok(Self::Thomas),
+            "andoyer" => Ok(Self::Andoyer),
+            "karney" => Ok(Self::Karney),
+            other => Err(Error::generic(format!(
+                "Unknown edge interpolation algorithm: '{other}'"
+            ))),
+        }
+    }
+}
+
+/// A geometry column type with an associated spatial reference identifier (SRID).
+///
+/// Geometry values are encoded as WKB (Well-Known Binary) bytes in the Arrow layer,
+/// represented as a `Binary` physical array with GeoArrow field metadata.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct GeometryType {
+    srid: String,
+}
+
+impl GeometryType {
+    /// Creates a new [`GeometryType`] with the given SRID.
+    ///
+    /// # Parameters
+    /// - `srid`: The spatial reference identifier (e.g. `"OGC:CRS84"`, `"EPSG:4326"`).
+    pub fn try_new(srid: impl Into<String>) -> DeltaResult<Self> {
+        Ok(Self { srid: srid.into() })
+    }
+
+    /// Returns the SRID associated with this geometry type.
+    pub fn srid(&self) -> &str {
+        &self.srid
+    }
+}
+
+impl Default for GeometryType {
+    fn default() -> Self {
+        Self {
+            srid: DEFAULT_GEO_SRID.to_string(),
+        }
+    }
+}
+
+impl Display for GeometryType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "geometry({})", self.srid)
+    }
+}
+
+/// A geography column type with an associated SRID and edge interpolation algorithm.
+///
+/// Geography values are encoded as WKB bytes in the Arrow layer,
+/// represented as a `Binary` physical array with GeoArrow field metadata.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct GeographyType {
+    srid: String,
+    algorithm: EdgeInterpolationAlgorithm,
+}
+
+impl GeographyType {
+    /// Creates a new [`GeographyType`] with the given SRID and edge interpolation algorithm.
+    ///
+    /// # Parameters
+    /// - `srid`: The spatial reference identifier (e.g. `"OGC:CRS84"`).
+    /// - `algorithm`: The edge interpolation algorithm to use.
+    pub fn try_new(
+        srid: impl Into<String>,
+        algorithm: EdgeInterpolationAlgorithm,
+    ) -> DeltaResult<Self> {
+        Ok(Self {
+            srid: srid.into(),
+            algorithm,
+        })
+    }
+
+    /// Returns the SRID associated with this geography type.
+    pub fn srid(&self) -> &str {
+        &self.srid
+    }
+
+    /// Returns the edge interpolation algorithm for this geography type.
+    pub fn algorithm(&self) -> &EdgeInterpolationAlgorithm {
+        &self.algorithm
+    }
+}
+
+impl Default for GeographyType {
+    fn default() -> Self {
+        Self {
+            srid: DEFAULT_GEO_SRID.to_string(),
+            algorithm: EdgeInterpolationAlgorithm::Spherical,
+        }
+    }
+}
+
+impl Display for GeographyType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "geography({}, {})", self.srid, self.algorithm)
+    }
+}
+
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
 pub struct DecimalType {
     precision: u8,
@@ -1567,6 +1703,14 @@ pub enum PrimitiveType {
     TimestampNtz,
     #[serde(serialize_with = "serialize_decimal", untagged)]
     Decimal(DecimalType),
+    /// A geometry type with an associated spatial reference identifier.
+    /// Values are stored as WKB (Well-Known Binary) bytes.
+    #[serde(serialize_with = "serialize_geometry", untagged)]
+    Geometry(GeometryType),
+    /// A geography type with an associated SRID and edge interpolation algorithm.
+    /// Values are stored as WKB bytes.
+    #[serde(serialize_with = "serialize_geography", untagged)]
+    Geography(GeographyType),
 }
 
 impl PrimitiveType {
@@ -1641,6 +1785,20 @@ fn serialize_decimal<S: serde::Serializer>(
     serializer.serialize_str(&format!("decimal({},{})", dtype.precision(), dtype.scale()))
 }
 
+fn serialize_geometry<S: serde::Serializer>(
+    gtype: &GeometryType,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    serializer.serialize_str(&gtype.to_string())
+}
+
+fn serialize_geography<S: serde::Serializer>(
+    gtype: &GeographyType,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    serializer.serialize_str(&gtype.to_string())
+}
+
 fn serialize_variant<S: serde::Serializer>(
     _: &StructType,
     serializer: S,
@@ -1698,6 +1856,35 @@ impl<'de> serde::Deserialize<'de> for PrimitiveType {
                     .map(PrimitiveType::Decimal)
                     .map_err(serde::de::Error::custom)
             }
+            "geometry" => Ok(PrimitiveType::Geometry(GeometryType::default())),
+            geo_str if geo_str.starts_with("geometry(") && geo_str.ends_with(')') => {
+                let srid = &geo_str[9..geo_str.len() - 1];
+                GeometryType::try_new(srid.trim())
+                    .map(PrimitiveType::Geometry)
+                    .map_err(serde::de::Error::custom)
+            }
+            "geography" => Ok(PrimitiveType::Geography(GeographyType::default())),
+            geo_str if geo_str.starts_with("geography(") && geo_str.ends_with(')') => {
+                let inner = &geo_str[10..geo_str.len() - 1];
+                // Split on the last comma to separate SRID from algorithm
+                match inner.rfind(',') {
+                    Some(pos) => {
+                        let srid = inner[..pos].trim();
+                        let algo_str = inner[pos + 1..].trim();
+                        let algorithm: EdgeInterpolationAlgorithm =
+                            algo_str.parse().map_err(serde::de::Error::custom)?;
+                        GeographyType::try_new(srid, algorithm)
+                            .map(PrimitiveType::Geography)
+                            .map_err(serde::de::Error::custom)
+                    }
+                    None => {
+                        // No comma -- treat entire inner as SRID with default algorithm
+                        GeographyType::try_new(inner.trim(), EdgeInterpolationAlgorithm::Spherical)
+                            .map(PrimitiveType::Geography)
+                            .map_err(serde::de::Error::custom)
+                    }
+                }
+            }
             unsupported => Err(serde::de::Error::custom(format!(
                 "Unsupported Delta table type: '{unsupported}'"
             ))),
@@ -1723,6 +1910,8 @@ impl Display for PrimitiveType {
             PrimitiveType::Decimal(dtype) => {
                 write!(f, "decimal({},{})", dtype.precision(), dtype.scale())
             }
+            PrimitiveType::Geometry(t) => write!(f, "{t}"),
+            PrimitiveType::Geography(t) => write!(f, "{t}"),
         }
     }
 }
@@ -1754,6 +1943,26 @@ impl From<DecimalType> for PrimitiveType {
 impl From<DecimalType> for DataType {
     fn from(dtype: DecimalType) -> Self {
         PrimitiveType::from(dtype).into()
+    }
+}
+impl From<GeometryType> for PrimitiveType {
+    fn from(gtype: GeometryType) -> Self {
+        PrimitiveType::Geometry(gtype)
+    }
+}
+impl From<GeometryType> for DataType {
+    fn from(gtype: GeometryType) -> Self {
+        PrimitiveType::from(gtype).into()
+    }
+}
+impl From<GeographyType> for PrimitiveType {
+    fn from(gtype: GeographyType) -> Self {
+        PrimitiveType::Geography(gtype)
+    }
+}
+impl From<GeographyType> for DataType {
+    fn from(gtype: GeographyType) -> Self {
+        PrimitiveType::from(gtype).into()
     }
 }
 impl From<PrimitiveType> for DataType {

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -1555,12 +1555,17 @@ pub struct GeometryType {
 }
 
 impl GeometryType {
-    pub fn try_new(srid: impl Into<String>) -> DeltaResult<Self> {
-        let srid = srid.into();
+    /// Constructs a [`GeometryType`] from the given SRID. Use [`GeometryType::default`] to
+    /// build with [`DEFAULT_GEO_SRID`] (`OGC:CRS84`).
+    ///
+    /// Returns `Err` if `srid` is empty.
+    pub fn try_new(srid: &str) -> DeltaResult<Self> {
         if srid.is_empty() {
             return Err(Error::invalid_geometry("SRID cannot be empty"));
         }
-        Ok(Self { srid })
+        Ok(Self {
+            srid: srid.to_string(),
+        })
     }
 
     pub fn srid(&self) -> &str {
@@ -1590,23 +1595,26 @@ pub struct GeographyType {
 }
 
 impl GeographyType {
+    /// Constructs a GeographyType. Pass `None` for either argument to use the default:
+    /// SRID defaults to DEFAULT_GEO_SRID (`OGC:CRS84`); algorithm defaults to
+    /// EdgeInterpolationAlgorithm::Spherical.
+    ///
+    /// Returns `Err` if `srid` is `Some("")` (empty string is not a valid SRID).
     pub fn try_new(
-        srid: impl Into<String>,
-        algorithm: EdgeInterpolationAlgorithm,
+        srid: Option<&str>,
+        algorithm: Option<EdgeInterpolationAlgorithm>,
     ) -> DeltaResult<Self> {
-        let srid = srid.into();
-        if srid.is_empty() {
-            return Err(Error::invalid_geography("SRID cannot be empty"));
-        }
+        let srid = match srid {
+            None => DEFAULT_GEO_SRID.to_string(),
+            Some(s) => {
+                if s.is_empty() {
+                    return Err(Error::invalid_geography("SRID cannot be empty"));
+                }
+                s.to_string()
+            }
+        };
+        let algorithm = algorithm.unwrap_or(EdgeInterpolationAlgorithm::Spherical);
         Ok(Self { srid, algorithm })
-    }
-
-    pub fn try_new_with_srid(srid: impl Into<String>) -> DeltaResult<Self> {
-        Self::try_new(srid, EdgeInterpolationAlgorithm::Spherical)
-    }
-
-    pub fn try_new_with_algorithm(algorithm: EdgeInterpolationAlgorithm) -> DeltaResult<Self> {
-        Self::try_new(DEFAULT_GEO_SRID, algorithm)
     }
 
     pub fn srid(&self) -> &str {
@@ -1863,7 +1871,7 @@ impl<'de> serde::Deserialize<'de> for PrimitiveType {
                         let algo_str = inner[pos + 1..].trim();
                         let algorithm: EdgeInterpolationAlgorithm =
                             algo_str.parse().map_err(serde::de::Error::custom)?;
-                        GeographyType::try_new(srid, algorithm)
+                        GeographyType::try_new(Some(srid), Some(algorithm))
                             .map(Box::new)
                             .map(PrimitiveType::Geography)
                             .map_err(serde::de::Error::custom)
@@ -1871,14 +1879,14 @@ impl<'de> serde::Deserialize<'de> for PrimitiveType {
                     None => {
                         let trimmed = inner.trim();
                         if trimmed.contains(':') {
-                            GeographyType::try_new_with_srid(trimmed)
+                            GeographyType::try_new(Some(trimmed), None)
                                 .map(Box::new)
                                 .map(PrimitiveType::Geography)
                                 .map_err(serde::de::Error::custom)
                         } else {
                             let algorithm: EdgeInterpolationAlgorithm =
                                 trimmed.parse().map_err(serde::de::Error::custom)?;
-                            GeographyType::try_new_with_algorithm(algorithm)
+                            GeographyType::try_new(None, Some(algorithm))
                                 .map(Box::new)
                                 .map(PrimitiveType::Geography)
                                 .map_err(serde::de::Error::custom)
@@ -2488,7 +2496,11 @@ mod tests {
         assert_eq!(
             field.data_type,
             DataType::Primitive(PrimitiveType::Geography(Box::new(
-                GeographyType::try_new("EPSG:4326", EdgeInterpolationAlgorithm::Vincenty).unwrap()
+                GeographyType::try_new(
+                    Some("EPSG:4326"),
+                    Some(EdgeInterpolationAlgorithm::Vincenty)
+                )
+                .unwrap()
             )))
         );
 
@@ -2624,18 +2636,21 @@ mod tests {
     )]
     #[case(
         "geography(EPSG:4326)",
-        PrimitiveType::Geography(Box::new(GeographyType::try_new_with_srid("EPSG:4326").unwrap()))
+        PrimitiveType::Geography(Box::new(
+            GeographyType::try_new(Some("EPSG:4326"), None).unwrap()
+        ))
     )]
     #[case(
         "geography(EPSG:4326, vincenty)",
         PrimitiveType::Geography(Box::new(
-            GeographyType::try_new("EPSG:4326", EdgeInterpolationAlgorithm::Vincenty).unwrap()
+            GeographyType::try_new(Some("EPSG:4326"), Some(EdgeInterpolationAlgorithm::Vincenty))
+                .unwrap()
         ))
     )]
     #[case(
         "geography(vincenty)",
         PrimitiveType::Geography(Box::new(
-            GeographyType::try_new_with_algorithm(EdgeInterpolationAlgorithm::Vincenty).unwrap()
+            GeographyType::try_new(None, Some(EdgeInterpolationAlgorithm::Vincenty)).unwrap()
         ))
     )]
     fn test_geo_deserialize_defaults(#[case] type_str: &str, #[case] expected: PrimitiveType) {
@@ -2650,6 +2665,7 @@ mod tests {
         "Unknown edge interpolation algorithm"
     )]
     #[case("geography(EPSG:4326,)", "Unknown edge interpolation algorithm")]
+    #[case("geography(unknown_algo)", "Unknown edge interpolation algorithm")]
     #[case("geometry(EPSG:4326", "Unsupported Delta table type")]
     #[case("geographyz", "Unsupported Delta table type")]
     #[case("geometry()", "SRID cannot be empty")]

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -1566,8 +1566,8 @@ impl GeometryType {
     /// Creates a new GeometryType with the given SRID.
     ///
     /// # Parameters
-    /// - `srid`: The spatial reference identifier (e.g. `"OGC:CRS84"`, `"EPSG:4326"`).
-    ///   Must be non-empty.
+    /// - `srid`: The spatial reference identifier (e.g. `"OGC:CRS84"`, `"EPSG:4326"`). Must be
+    ///   non-empty.
     pub fn try_new(srid: impl Into<String>) -> DeltaResult<Self> {
         let srid = srid.into();
         if srid.is_empty() {

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -24,7 +24,7 @@ use crate::scan::data_skipping::stats_schema::{
 pub(crate) use crate::schema::variant_utils::validate_variant_type_feature_support;
 use crate::schema::{schema_has_invariants, SchemaRef, StructField, StructType};
 use crate::table_features::{
-    column_mapping_mode, get_any_level_column_physical_name,
+    column_mapping_mode, get_any_level_column_physical_name, validate_geospatial_feature_support,
     validate_timestamp_ntz_feature_support, ColumnMappingMode, EnablementCheck, FeatureRequirement,
     FeatureType, KernelSupport, Operation, TableFeature, LEGACY_READER_FEATURES,
     LEGACY_WRITER_FEATURES, MAX_VALID_READER_VERSION, MAX_VALID_WRITER_VERSION,
@@ -195,6 +195,7 @@ impl TableConfiguration {
 
         // Validate schema against protocol features now that we have a TC instance.
         validate_timestamp_ntz_feature_support(&table_config)?;
+        validate_geospatial_feature_support(&table_config)?;
         validate_variant_type_feature_support(&table_config)?;
 
         Ok(table_config)

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -1661,6 +1661,13 @@ mod test {
             config.ensure_operation_supported(Operation::Write),
             r#"Feature 'typeWidening' is not supported for writes"#,
         );
+
+        // Geospatial is not supported for writes
+        let config = create_mock_table_config(&[], &[TableFeature::GeospatialType]);
+        assert_result_error_with_message(
+            config.ensure_operation_supported(Operation::Write),
+            r#"Feature 'geospatial' is not supported for writes"#,
+        );
     }
 
     #[test]

--- a/kernel/src/table_features/geospatial.rs
+++ b/kernel/src/table_features/geospatial.rs
@@ -49,9 +49,7 @@ pub(crate) fn validate_geospatial_feature_support(tc: &TableConfiguration) -> De
 #[cfg(test)]
 mod tests {
     use crate::actions::Protocol;
-    use crate::schema::{
-        DataType, GeographyType, GeometryType, PrimitiveType, StructField, StructType,
-    };
+    use crate::schema::{DataType, PrimitiveType, StructField, StructType};
     use crate::table_features::TableFeature;
     use crate::utils::test_utils::{
         assert_result_error_with_message, assert_schema_feature_validation,
@@ -63,7 +61,7 @@ mod tests {
             StructField::new("id", DataType::INTEGER, false),
             StructField::new(
                 "geom",
-                DataType::Primitive(PrimitiveType::Geometry(GeometryType::default())),
+                DataType::Primitive(PrimitiveType::Geometry(Box::default())),
                 true,
             ),
         ]);
@@ -77,7 +75,7 @@ mod tests {
                 "nested",
                 DataType::Struct(Box::new(StructType::new_unchecked([StructField::new(
                     "inner_geo",
-                    DataType::Primitive(PrimitiveType::Geography(GeographyType::default())),
+                    DataType::Primitive(PrimitiveType::Geography(Box::default())),
                     true,
                 )]))),
                 true,

--- a/kernel/src/table_features/geospatial.rs
+++ b/kernel/src/table_features/geospatial.rs
@@ -1,0 +1,101 @@
+//! Validation logic for the `geospatial` table feature.
+
+use std::borrow::Cow;
+
+use super::TableFeature;
+use crate::schema::{PrimitiveType, Schema};
+use crate::table_configuration::TableConfiguration;
+use crate::transforms::SchemaTransform;
+use crate::utils::require;
+use crate::{DeltaResult, Error};
+
+/// Validates that if a table schema contains geometry or geography columns, the table must have
+/// the `geospatial` feature in both reader and writer features.
+pub(crate) fn validate_geospatial_feature_support(tc: &TableConfiguration) -> DeltaResult<()> {
+    let protocol = tc.protocol();
+    if !protocol.has_table_feature(&TableFeature::GeospatialType) {
+        require!(
+            !schema_contains_geospatial(&tc.logical_schema()),
+            Error::unsupported(
+                "Table contains geometry or geography columns but does not have the required 'geospatial' feature in reader and writer features"
+            )
+        );
+    }
+    Ok(())
+}
+
+/// Returns `true` if the schema contains at least one geometry or geography column,
+/// including nested structs, arrays, and maps.
+pub(crate) fn schema_contains_geospatial(schema: &Schema) -> bool {
+    let mut detector = GeoDetector(false);
+    let _ = detector.transform_struct(schema);
+    detector.0
+}
+
+struct GeoDetector(bool);
+
+impl<'a> SchemaTransform<'a> for GeoDetector {
+    fn transform_primitive(&mut self, ptype: &'a PrimitiveType) -> Option<Cow<'a, PrimitiveType>> {
+        if matches!(
+            ptype,
+            PrimitiveType::Geometry(_) | PrimitiveType::Geography(_)
+        ) {
+            self.0 = true;
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::actions::Protocol;
+    use crate::schema::{
+        DataType, GeographyType, GeometryType, PrimitiveType, StructField, StructType,
+    };
+    use crate::table_features::TableFeature;
+    use crate::utils::test_utils::assert_schema_feature_validation;
+
+    #[test]
+    fn test_geospatial_feature_validation() {
+        let schema_with = StructType::new_unchecked([
+            StructField::new("id", DataType::INTEGER, false),
+            StructField::new(
+                "geom",
+                DataType::Primitive(PrimitiveType::Geometry(GeometryType::default())),
+                true,
+            ),
+        ]);
+        let schema_without = StructType::new_unchecked([
+            StructField::new("id", DataType::INTEGER, false),
+            StructField::new("name", DataType::STRING, true),
+        ]);
+        let nested_schema_with = StructType::new_unchecked([
+            StructField::new("id", DataType::INTEGER, false),
+            StructField::new(
+                "nested",
+                DataType::Struct(Box::new(StructType::new_unchecked([StructField::new(
+                    "inner_geo",
+                    DataType::Primitive(PrimitiveType::Geography(GeographyType::default())),
+                    true,
+                )]))),
+                true,
+            ),
+        ]);
+        let protocol_with = Protocol::try_new_modern(
+            [TableFeature::GeospatialType],
+            [TableFeature::GeospatialType],
+        )
+        .unwrap();
+        let protocol_without =
+            Protocol::try_new_modern(TableFeature::EMPTY_LIST, TableFeature::EMPTY_LIST).unwrap();
+
+        assert_schema_feature_validation(
+            &schema_with,
+            &schema_without,
+            &protocol_with,
+            &protocol_without,
+            &[&nested_schema_with],
+            "Table contains geometry or geography columns but does not have the required 'geospatial' feature in reader and writer features",
+        );
+    }
+}

--- a/kernel/src/table_features/geospatial.rs
+++ b/kernel/src/table_features/geospatial.rs
@@ -9,6 +9,28 @@ use crate::transforms::SchemaTransform;
 use crate::utils::require;
 use crate::{DeltaResult, Error};
 
+struct UsesGeo(bool);
+
+impl<'a> SchemaTransform<'a> for UsesGeo {
+    fn transform_primitive(&mut self, ptype: &'a PrimitiveType) -> Option<Cow<'a, PrimitiveType>> {
+        if matches!(
+            ptype,
+            PrimitiveType::Geometry(_) | PrimitiveType::Geography(_)
+        ) {
+            self.0 = true;
+        }
+        None
+    }
+}
+
+/// Returns `true` if the schema contains at least one geometry or geography column,
+/// including nested structs, arrays, and maps.
+pub(crate) fn schema_contains_geospatial(schema: &Schema) -> bool {
+    let mut visitor = UsesGeo(false);
+    let _ = visitor.transform_struct(schema);
+    visitor.0
+}
+
 /// Validates that if a table schema contains geometry or geography columns, the table must have
 /// the `geospatial` feature in both reader and writer features.
 pub(crate) fn validate_geospatial_feature_support(tc: &TableConfiguration) -> DeltaResult<()> {
@@ -24,28 +46,6 @@ pub(crate) fn validate_geospatial_feature_support(tc: &TableConfiguration) -> De
     Ok(())
 }
 
-/// Returns `true` if the schema contains at least one geometry or geography column,
-/// including nested structs, arrays, and maps.
-pub(crate) fn schema_contains_geospatial(schema: &Schema) -> bool {
-    let mut detector = GeoDetector(false);
-    let _ = detector.transform_struct(schema);
-    detector.0
-}
-
-struct GeoDetector(bool);
-
-impl<'a> SchemaTransform<'a> for GeoDetector {
-    fn transform_primitive(&mut self, ptype: &'a PrimitiveType) -> Option<Cow<'a, PrimitiveType>> {
-        if matches!(
-            ptype,
-            PrimitiveType::Geometry(_) | PrimitiveType::Geography(_)
-        ) {
-            self.0 = true;
-        }
-        None
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::actions::Protocol;
@@ -53,7 +53,9 @@ mod tests {
         DataType, GeographyType, GeometryType, PrimitiveType, StructField, StructType,
     };
     use crate::table_features::TableFeature;
-    use crate::utils::test_utils::assert_schema_feature_validation;
+    use crate::utils::test_utils::{
+        assert_result_error_with_message, assert_schema_feature_validation,
+    };
 
     #[test]
     fn test_geospatial_feature_validation() {
@@ -88,6 +90,16 @@ mod tests {
         .unwrap();
         let protocol_without =
             Protocol::try_new_modern(TableFeature::EMPTY_LIST, TableFeature::EMPTY_LIST).unwrap();
+
+        // ReaderWriter features must be listed on both sides
+        assert_result_error_with_message(
+            Protocol::try_new_modern([&TableFeature::GeospatialType], TableFeature::EMPTY_LIST),
+            "Reader features must contain only ReaderWriter features that are also listed in writer features",
+        );
+        assert_result_error_with_message(
+            Protocol::try_new_modern(TableFeature::EMPTY_LIST, [&TableFeature::GeospatialType]),
+            "Writer features must be Writer-only or also listed in reader features",
+        );
 
         assert_schema_feature_validation(
             &schema_with,

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -8,6 +8,7 @@ pub(crate) use column_mapping::{
     get_field_column_mapping_info, physical_to_logical_column_name,
 };
 use delta_kernel_derive::internal_api;
+pub(crate) use geospatial::validate_geospatial_feature_support;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use strum::{AsRefStr, Display as StrumDisplay, EnumCount, EnumIter, EnumString};
@@ -22,6 +23,7 @@ use crate::schema::DataType;
 use crate::table_properties::TableProperties;
 use crate::{DeltaResult, Error};
 mod column_mapping;
+mod geospatial;
 mod timestamp_ntz;
 
 /// Minimum reader/writer protocol version that the kernel can handle.
@@ -153,6 +155,10 @@ pub(crate) enum TableFeature {
     #[strum(serialize = "variantShredding-preview")]
     #[serde(rename = "variantShredding-preview")]
     VariantShreddingPreview,
+    /// Geospatial type support (geometry and geography columns)
+    #[strum(serialize = "geospatial")]
+    #[serde(rename = "geospatial")]
+    GeospatialType,
 
     #[serde(untagged)]
     #[strum(default)]
@@ -562,6 +568,14 @@ static VARIANT_SHREDDING_PREVIEW_INFO: FeatureInfo = FeatureInfo {
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 
+static GEOSPATIAL_TYPE_INFO: FeatureInfo = FeatureInfo {
+    feature_type: FeatureType::ReaderWriter,
+    min_legacy_version: None,
+    feature_requirements: &[],
+    kernel_support: KernelSupport::Supported,
+    enablement_check: EnablementCheck::AlwaysIfSupported,
+};
+
 /// By definition, kernel cannot know how to handle unknown features and must assume they're always
 /// enabled if supported in protocol. However, the read path ignores all writer-only features,
 /// including unknown ones. Unknown features are never inferred from legacy protocol versions.
@@ -592,7 +606,8 @@ impl TableFeature {
             | TableFeature::VacuumProtocolCheck
             | TableFeature::VariantType
             | TableFeature::VariantTypePreview
-            | TableFeature::VariantShreddingPreview => FeatureType::ReaderWriter,
+            | TableFeature::VariantShreddingPreview
+            | TableFeature::GeospatialType => FeatureType::ReaderWriter,
             TableFeature::AppendOnly
             | TableFeature::DomainMetadata
             | TableFeature::Invariants
@@ -654,6 +669,7 @@ impl TableFeature {
             TableFeature::VariantType => &VARIANT_TYPE_INFO,
             TableFeature::VariantTypePreview => &VARIANT_TYPE_PREVIEW_INFO,
             TableFeature::VariantShreddingPreview => &VARIANT_SHREDDING_PREVIEW_INFO,
+            TableFeature::GeospatialType => &GEOSPATIAL_TYPE_INFO,
 
             // Unknown features: not supported by kernel, no legacy version inference.
             TableFeature::Unknown(_) => &UNKNOWN_FEATURE_INFO,
@@ -790,6 +806,7 @@ mod tests {
                 TableFeature::VariantType => "variantType",
                 TableFeature::VariantTypePreview => "variantType-preview",
                 TableFeature::VariantShreddingPreview => "variantShredding-preview",
+                TableFeature::GeospatialType => "geospatial",
                 TableFeature::Unknown(_) => continue, // tested in test_unknown_features
             };
 

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -572,7 +572,12 @@ static GEOSPATIAL_TYPE_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::ReaderWriter,
     min_legacy_version: None,
     feature_requirements: &[],
-    kernel_support: KernelSupport::Supported,
+    kernel_support: KernelSupport::Custom(|_, _, op| match op {
+        Operation::Scan | Operation::Cdf => Ok(()),
+        Operation::Write => Err(Error::unsupported(
+            "Feature 'geospatial' is not supported for writes",
+        )),
+    }),
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 

--- a/kernel/src/transaction/stats_verifier.rs
+++ b/kernel/src/transaction/stats_verifier.rs
@@ -179,9 +179,14 @@ fn column_types_for(dt: &DataType) -> DeltaResult<&'static ColumnNamesAndTypes> 
         &DataType::TIMESTAMP => Ok(&COL_TYPES_TIMESTAMP),
         &DataType::TIMESTAMP_NTZ => Ok(&COL_TYPES_TIMESTAMP_NTZ),
         DataType::Primitive(PrimitiveType::Decimal(_)) => Ok(&COL_TYPES_DECIMAL),
-        DataType::Struct(_) | DataType::Array(_) | DataType::Map(_) | DataType::Variant(_) => Err(
-            Error::internal_error(format!("Unsupported data type for stats validation: {dt}")),
-        ),
+        DataType::Primitive(PrimitiveType::Geometry(_))
+        | DataType::Primitive(PrimitiveType::Geography(_))
+        | DataType::Struct(_)
+        | DataType::Array(_)
+        | DataType::Map(_)
+        | DataType::Variant(_) => Err(Error::internal_error(format!(
+            "Unsupported data type for stats validation: {dt}"
+        ))),
     }
 }
 
@@ -209,11 +214,14 @@ fn is_stat_present<'b>(
         DataType::Primitive(PrimitiveType::Decimal(_)) => {
             Ok(getter.get_decimal(row_idx, field_name)?.is_some())
         }
-        DataType::Struct(_) | DataType::Array(_) | DataType::Map(_) | DataType::Variant(_) => {
-            Err(Error::internal_error(format!(
-                "Unsupported data type for stats presence check: {data_type}"
-            )))
-        }
+        DataType::Primitive(PrimitiveType::Geometry(_))
+        | DataType::Primitive(PrimitiveType::Geography(_))
+        | DataType::Struct(_)
+        | DataType::Array(_)
+        | DataType::Map(_)
+        | DataType::Variant(_) => Err(Error::internal_error(format!(
+            "Unsupported data type for stats presence check: {data_type}"
+        ))),
     }
 }
 

--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -1178,6 +1178,9 @@ fn scalar_for_type(data_type: &DataType, seed: usize) -> Scalar {
                 Scalar::decimal(bits, dt.precision(), dt.scale())
                     .expect("test seed produced invalid decimal")
             }
+            PrimitiveType::Geometry(_) | PrimitiveType::Geography(_) => {
+                panic!("Geometry/Geography are not valid partition column types")
+            }
         },
         other => panic!("partition columns must be primitive types, got: {other:?}"),
     }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2496/files/10b79aa023a1ac2c2ffcd7eb20dff7c260aa6593..e31c15fc704accffffa71a50648d38a2beeee01b) to review incremental changes.
- [stack/schema-table-feat-geo](https://github.com/delta-io/delta-kernel-rs/pull/2464) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2464/files)]
  - [**stack/geo-arrow**](https://github.com/delta-io/delta-kernel-rs/pull/2496) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2496/files/10b79aa023a1ac2c2ffcd7eb20dff7c260aa6593..e31c15fc704accffffa71a50648d38a2beeee01b)]

---------
## What changes are proposed in this pull request?
This PR adds the following:
- Conversion from kernel to arrow - GeoArrow tagged fields + binary physical Arrow type for geo
- ParseJson workaround code to parse WKT stats into WKB

## How was this change tested?'
Testing added for:
- WKT to WKB conversion preserves GeoArrow extension data
- JSON parsing on schemas with and without geo fields
- Nullability coercion on a geo-target field attaches the geoarrow extension metadata while preserving the source field's other metadata (e.g. parquet field IDs)
- The transform path in expression evaluation attaches geoarrow extension metadata + CRS when applying a Geometry target field, instead of producing plain Binary