### PR TITLE
feat: Materialize partition values when `icebergCompatV3` enabled

### DIFF
--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -463,6 +463,7 @@ impl TableConfiguration {
     /// [`MaterializePartitionColumns`]: crate::table_features::TableFeature::MaterializePartitionColumns
     /// [`IcebergCompatV3`]: crate::table_features::TableFeature::IcebergCompatV3
     pub(crate) fn should_materialize_partition_columns(&self) -> bool {
+        // TODO(#1125): add IcebergcompatV1/V2 here when they are supported.
         self.is_feature_enabled(&TableFeature::MaterializePartitionColumns)
             || self.is_feature_enabled(&TableFeature::IcebergCompatV3)
     }

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -2235,12 +2235,14 @@ mod test {
         vec!["value", "pcol"],
     )]
     #[case::v3_supported_but_property_unset(&[], vec!["value"])]
-    fn test_physical_write_schema_iceberg_compat_v3_materializes_iff_enabled(
+    fn test_physical_write_schema_materializes_pv_when_iceberg_compact_v3_enabled(
         #[case] extra_props: &[(&str, &str)],
         #[case] expected_field_names: Vec<&str>,
     ) {
         // Partitioned schema: one data col + one partition col. No column mapping, so physical
         // names equal logical names.
+        // IcebergCompatV3 requires column mapping. This test bypasses that requirement for
+        // convenience.
         let schema = Arc::new(StructType::new_unchecked([
             StructField::nullable("value", DataType::INTEGER),
             StructField::nullable("pcol", DataType::STRING),

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -455,15 +455,27 @@ impl TableConfiguration {
         self.physical_schemas.full.clone()
     }
 
+    /// Whether partition column values must be materialized into data files.
+    /// Returns true when either:
+    ///   * The [`MaterializePartitionColumns`] writer feature is enabled, or
+    ///   * [`IcebergCompatV3`] is enabled
+    ///
+    /// [`MaterializePartitionColumns`]: crate::table_features::TableFeature::MaterializePartitionColumns
+    /// [`IcebergCompatV3`]: crate::table_features::TableFeature::IcebergCompatV3
+    pub(crate) fn should_materialize_partition_columns(&self) -> bool {
+        self.is_feature_enabled(&TableFeature::MaterializePartitionColumns)
+            || self.is_feature_enabled(&TableFeature::IcebergCompatV3)
+    }
+
     /// The physical schema for writing data files.
     ///
-    /// When [`MaterializePartitionColumns`] is enabled, returns the full physical schema
+    /// When [`should_materialize_partition_columns`] is true, returns the full physical schema
     /// (partition columns are materialized in data files). Otherwise, returns the physical
     /// schema with partition columns excluded.
     ///
-    /// [`MaterializePartitionColumns`]: crate::table_features::TableFeature::MaterializePartitionColumns
+    /// [`should_materialize_partition_columns`]: Self::should_materialize_partition_columns
     pub(crate) fn physical_write_schema(&self) -> SchemaRef {
-        if self.is_feature_enabled(&TableFeature::MaterializePartitionColumns) {
+        if self.should_materialize_partition_columns() {
             self.physical_schema()
         } else {
             self.physical_data_schema_without_partition_columns()
@@ -2213,6 +2225,50 @@ mod test {
             config.ensure_operation_supported(Operation::Write).is_ok(),
             "ClusteredTable with DomainMetadata should be supported for writes"
         );
+    }
+
+    // V3 supported + property set -> partition column materialized into the write schema;
+    // V3 supported but property unset -> partition column stripped from the write schema.
+    #[rstest]
+    #[case::v3_enabled(
+        &[(ENABLE_ICEBERG_COMPAT_V3, "true"), (ENABLE_ROW_TRACKING, "true")],
+        vec!["value", "pcol"],
+    )]
+    #[case::v3_supported_but_property_unset(&[], vec!["value"])]
+    fn test_physical_write_schema_iceberg_compat_v3_materializes_iff_enabled(
+        #[case] extra_props: &[(&str, &str)],
+        #[case] expected_field_names: Vec<&str>,
+    ) {
+        // Partitioned schema: one data col + one partition col. No column mapping, so physical
+        // names equal logical names.
+        let schema = Arc::new(StructType::new_unchecked([
+            StructField::nullable("value", DataType::INTEGER),
+            StructField::nullable("pcol", DataType::STRING),
+        ]));
+        let props: HashMap<String, String> = extra_props
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        let metadata =
+            Metadata::try_new(None, None, schema, vec!["pcol".to_string()], 0, props).unwrap();
+        let protocol = Protocol::try_new(
+            TABLE_FEATURES_MIN_READER_VERSION,
+            TABLE_FEATURES_MIN_WRITER_VERSION,
+            Some(Vec::<TableFeature>::new()),
+            Some(vec![
+                TableFeature::IcebergCompatV3,
+                TableFeature::RowTracking,
+                TableFeature::DomainMetadata,
+            ]),
+        )
+        .unwrap();
+        let config =
+            TableConfiguration::try_new(metadata, protocol, Url::try_from("file:///").unwrap(), 0)
+                .unwrap();
+
+        let write_schema = config.physical_write_schema();
+        let field_names: Vec<&str> = write_schema.fields().map(|f| f.name.as_str()).collect();
+        assert_eq!(field_names, expected_field_names);
     }
 
     #[test]

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -2232,6 +2232,7 @@ mod test {
     #[rstest]
     #[case::v3_enabled(
         &[(ENABLE_ICEBERG_COMPAT_V3, "true"), (ENABLE_ROW_TRACKING, "true")],
+        // pcol is included, meaning we expect the partition col to be materialized to disk.
         vec!["value", "pcol"],
     )]
     #[case::v3_supported_but_property_unset(&[], vec!["value"])]
@@ -2269,6 +2270,8 @@ mod test {
                 .unwrap();
 
         let write_schema = config.physical_write_schema();
+        // This is the final check: whether the partition column `pcol` is present in the
+        // physical schema as expected.
         let field_names: Vec<&str> = write_schema.fields().map(|f| f.name.as_str()).collect();
         assert_eq!(field_names, expected_field_names);
     }

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -833,14 +833,14 @@ impl<S: SupportsDataFiles> Transaction<S> {
     // chunk before writing. At the moment, this is a transaction-wide expression.
     fn generate_logical_to_physical(&self) -> Expression {
         let partition_cols = self.effective_table_config.partition_columns().to_vec();
-        // Check if materializePartitionColumns feature is enabled
-        let materialize_partition_columns = self
+        // Check if partition columns should be materialized into data files.
+        let should_materialize_partition_columns = self
             .effective_table_config
-            .is_feature_enabled(&TableFeature::MaterializePartitionColumns);
+            .should_materialize_partition_columns();
         // Build a Transform expression that drops partition columns from the input
-        // (unless materializePartitionColumns is enabled).
+        // (unless they should be materialized).
         let mut transform = Transform::new_top_level();
-        if !materialize_partition_columns {
+        if !should_materialize_partition_columns {
             for col in &partition_cols {
                 transform = transform.with_dropped_field_if_exists(col);
             }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2504/files) to review incremental changes.
- [stack/add-v3-feature](https://github.com/delta-io/delta-kernel-rs/pull/2475) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2475/files)] [MERGED]
  - [**stack/write-part-when-ice3**](https://github.com/delta-io/delta-kernel-rs/pull/2504) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2504/files)]
    - [stack/block-alter-table](https://github.com/delta-io/delta-kernel-rs/pull/2505) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2505/files/15d151f8b271a72cb421ccfa81cda7d5887d1b37..562605f3911acd99854efae7940deb9344e7ee55)]
      - [stack/write-nested-id](https://github.com/delta-io/delta-kernel-rs/pull/2508) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2508/files/562605f3911acd99854efae7940deb9344e7ee55..766ace41c2176c546f533be4ff0d7a9aa24ae001)]
        - [stack/detect-no-num](https://github.com/delta-io/delta-kernel-rs/pull/2512) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2512/files/766ace41c2176c546f533be4ff0d7a9aa24ae001..eb4f572891dcc4595ea57f02bd105b9167ffbb52)]

---------
## Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2504/files) to review incremental changes.
- [stack/add-v3-feature](https://github.com/delta-io/delta-kernel-rs/pull/2475) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2475/files)] [MERGED]
  - [**stack/write-part-when-ice3**](https://github.com/delta-io/delta-kernel-rs/pull/2504) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2504/files)]
    - [stack/block-alter-table](https://github.com/delta-io/delta-kernel-rs/pull/2505) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2505/files/15d151f8b271a72cb421ccfa81cda7d5887d1b37..562605f3911acd99854efae7940deb9344e7ee55)]
      - [stack/write-nested-id](https://github.com/delta-io/delta-kernel-rs/pull/2508) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2508/files/562605f3911acd99854efae7940deb9344e7ee55..766ace41c2176c546f533be4ff0d7a9aa24ae001)]

---------
## What changes are proposed in this pull request?
Materialize partition values when icebergCompatV3 enabled.

## How was this change tested?
1. When `icebergCompatV3` enabled, partition columns are contained into `physical_write_schema`
2. When `icebergCompatV3` supported but not enabled, partition columns are not contained into `physical_write_schema`

Note: other related cases(e.g. `MaterializePartitionColumns`) are already covered by existing tests so we are not adding tests here
