### PR TITLE
feat: Block alter table when `icebergCompatV3` enabled

### DIFF
--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -409,10 +409,14 @@ static ICEBERG_COMPAT_V2_INFO: FeatureInfo = FeatureInfo {
     }),
 };
 
-// IcebergCompatV3 ensures tables can be converted to Apache Iceberg V3.
-// Spec: <https://github.com/delta-io/delta/blob/master/protocol_rfcs/iceberg-compat-v3.md>
-//
-// TODO: Implement the write-side requirements for IcebergCompatV3.
+/// IcebergCompatV3 ensures tables can be converted to Apache Iceberg V3.
+///
+/// Spec: <https://github.com/delta-io/delta/blob/master/protocol_rfcs/iceberg-compat-v3.md>
+///
+/// TODO: Implement the write-side requirements for IcebergCompatV3.
+/// TODO: Support ALTER TABLE on tables with IcebergCompatV3 enabled.
+///
+/// Tracking issue: <https://github.com/delta-io/delta-kernel-rs/issues/2492>
 static ICEBERG_COMPAT_V3_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::WriterOnly,
     min_legacy_version: None,

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -32,13 +32,13 @@ use crate::expressions::ColumnName;
 use crate::schema::StructField;
 use crate::snapshot::SnapshotRef;
 use crate::table_configuration::TableConfiguration;
-use crate::table_features::Operation;
+use crate::table_features::{Operation, TableFeature};
 use crate::table_properties::COLUMN_MAPPING_MAX_COLUMN_ID;
 use crate::transaction::alter_table::AlterTableTransaction;
 use crate::transaction::schema_evolution::{
     apply_schema_operations, SchemaEvolutionResult, SchemaOperation,
 };
-use crate::{DeltaResult, Engine};
+use crate::{DeltaResult, Engine, Error};
 
 /// Initial state: `build()` is not yet available (at least one operation is required).
 /// See [`Chainable`] for the operations available on this state.
@@ -151,6 +151,13 @@ impl AlterTableTransactionBuilder<Modifying> {
         committer: Box<dyn Committer>,
     ) -> DeltaResult<AlterTableTransaction> {
         let table_config = self.snapshot.table_configuration();
+        // We don't support ALTER TABLE on tables with icebergCompatV3 enabled yet. See
+        // [`crate::table_features::ICEBERG_COMPAT_V3_INFO`] for the tracking issue.
+        if table_config.is_feature_enabled(&TableFeature::IcebergCompatV3) {
+            return Err(Error::unsupported(
+                "ALTER TABLE is not supported on tables with icebergCompatV3 enabled",
+            ));
+        }
         // Rejects writes to tables kernel can't safely commit to: writer version out of
         // kernel's supported range, unsupported writer features, or schemas with SQL-expression
         // invariants. Runs on the pre-alter snapshot; future ALTER variants that change the

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -155,7 +155,7 @@ impl AlterTableTransactionBuilder<Modifying> {
         // [`crate::table_features::ICEBERG_COMPAT_V3_INFO`] for the tracking issue.
         if table_config.is_feature_enabled(&TableFeature::IcebergCompatV3) {
             return Err(Error::unsupported(
-                "ALTER TABLE is not supported on tables with icebergCompatV3 enabled",
+                "ALTER TABLE is not yet supported on tables with icebergCompatV3 enabled",
             ));
         }
         // Rejects writes to tables kernel can't safely commit to: writer version out of

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -751,11 +751,65 @@ async fn alter_blocked_when_iceberg_compat_v3_enabled() -> Result<(), Box<dyn st
     // mapping (V3 requires CM `name`/`id` mode) + row tracking. Single column carries the
     // column-mapping annotations the metadata loader expects when CM mode is set.
     // Note: Create table doesn't support IcebergCompatV3 yet, so we hand-craft the commit here.
+    let schema = StructType::try_new(vec![StructField::nullable("id", DataType::INTEGER)
+        .with_metadata([
+            (
+                ColumnMetadataKey::ColumnMappingId.as_ref(),
+                MetadataValue::from(1),
+            ),
+            (
+                ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
+                MetadataValue::from("col-1"),
+            ),
+        ])])?;
+    let schema_string = serde_json::to_string(&schema)?;
     let commit = [
-        r#"{"commitInfo":{"timestamp":1587968586154,"operation":"CREATE TABLE","operationParameters":{},"isBlindAppend":true}}"#,
-        r#"{"protocol":{"minReaderVersion":3,"minWriterVersion":7,"readerFeatures":["columnMapping"],"writerFeatures":["icebergCompatV3","columnMapping","rowTracking","domainMetadata"]}}"#,
-        r#"{"metaData":{"id":"deadbeef-1234-5678-abcd-000000000000","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"id\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{\"delta.columnMapping.id\":1,\"delta.columnMapping.physicalName\":\"col-1\"}}]}","partitionColumns":[],"configuration":{"delta.enableIcebergCompatV3":"true","delta.columnMapping.mode":"name","delta.enableRowTracking":"true","delta.rowTracking.materializedRowIdColumnName":"_row_id","delta.rowTracking.materializedRowCommitVersionColumnName":"_row_commit_version","delta.columnMapping.maxColumnId":"1"},"createdTime":1234567890000}}"#,
+        serde_json::json!({
+            "commitInfo": {
+                "timestamp": 1587968586154_i64,
+                "operation": "CREATE TABLE",
+                "operationParameters": {},
+                "isBlindAppend": true,
+            }
+        }),
+        serde_json::json!({
+            "protocol": {
+                "minReaderVersion": 3,
+                "minWriterVersion": 7,
+                "readerFeatures": ["columnMapping"],
+                "writerFeatures": [
+                    "icebergCompatV3",
+                    "columnMapping",
+                    "rowTracking",
+                    "domainMetadata",
+                ],
+            }
+        }),
+        serde_json::json!({
+            "metaData": {
+                "id": "deadbeef-1234-5678-abcd-000000000000",
+                "format": {
+                    "provider": "parquet",
+                    "options": {},
+                },
+                "schemaString": schema_string,
+                "partitionColumns": [],
+                "configuration": {
+                    "delta.enableIcebergCompatV3": "true",
+                    "delta.columnMapping.mode": "name",
+                    "delta.enableRowTracking": "true",
+                    "delta.rowTracking.materializedRowIdColumnName": "_row_id",
+                    "delta.rowTracking.materializedRowCommitVersionColumnName":
+                        "_row_commit_version",
+                    "delta.columnMapping.maxColumnId": "1",
+                },
+                "createdTime": 1234567890000_i64,
+            }
+        }),
     ]
+    .into_iter()
+    .map(|action| serde_json::to_string(&action))
+    .collect::<Result<Vec<_>, _>>()?
     .join("\n");
     add_commit(table_root, storage.as_ref(), 0, commit.to_string()).await?;
 

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -7,7 +7,10 @@ use delta_kernel::arrow::array::{Array, Int32Array, StringArray};
 use delta_kernel::arrow::record_batch::RecordBatch;
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
+use delta_kernel::engine::default::executor::tokio::TokioBackgroundExecutor;
+use delta_kernel::engine::default::DefaultEngineBuilder;
 use delta_kernel::expressions::{column_name, ColumnName, Scalar};
+use delta_kernel::object_store::memory::InMemory;
 use delta_kernel::schema::{
     ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, SchemaRef, StructField,
     StructType,
@@ -18,7 +21,8 @@ use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::DeltaResult;
 use rstest::rstest;
 use test_utils::{
-    create_table_and_load_snapshot, test_table_setup, test_table_setup_mt, write_batch_to_table,
+    add_commit, create_table_and_load_snapshot, test_table_setup, test_table_setup_mt,
+    write_batch_to_table,
 };
 
 fn simple_schema() -> SchemaRef {
@@ -733,5 +737,40 @@ async fn add_column_with_stray_cm_metadata_on_non_cm_table_fails(
         msg.contains("column mapping") || msg.contains("columnMapping"),
         "error should mention column mapping, got: {msg}"
     );
+    Ok(())
+}
+
+#[tokio::test]
+async fn alter_blocked_when_iceberg_compat_v3_enabled() -> Result<(), Box<dyn std::error::Error>> {
+    let storage = Arc::new(InMemory::new());
+    let table_root = "memory:///";
+    let engine =
+        Arc::new(DefaultEngineBuilder::<TokioBackgroundExecutor>::new(storage.clone()).build());
+
+    // V0 commit: protocol with V3 + dependent writer features, metadata enabling V3 + column
+    // mapping (V3 requires CM `name`/`id` mode) + row tracking. Single column carries the
+    // column-mapping annotations the metadata loader expects when CM mode is set.
+    // Note: Create table doesn't support IcebergCompatV3 yet, so we hand-craft the commit here.
+    let commit = [
+        r#"{"commitInfo":{"timestamp":1587968586154,"operation":"CREATE TABLE","operationParameters":{},"isBlindAppend":true}}"#,
+        r#"{"protocol":{"minReaderVersion":3,"minWriterVersion":7,"readerFeatures":["columnMapping"],"writerFeatures":["icebergCompatV3","columnMapping","rowTracking","domainMetadata"]}}"#,
+        r#"{"metaData":{"id":"deadbeef-1234-5678-abcd-000000000000","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"id\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{\"delta.columnMapping.id\":1,\"delta.columnMapping.physicalName\":\"col-1\"}}]}","partitionColumns":[],"configuration":{"delta.enableIcebergCompatV3":"true","delta.columnMapping.mode":"name","delta.enableRowTracking":"true","delta.rowTracking.materializedRowIdColumnName":"_row_id","delta.rowTracking.materializedRowCommitVersionColumnName":"_row_commit_version","delta.columnMapping.maxColumnId":"1"},"createdTime":1234567890000}}"#,
+    ]
+    .join("\n");
+    add_commit(table_root, storage.as_ref(), 0, commit.to_string()).await?;
+
+    let snapshot = Snapshot::builder_for(table_root).build(engine.as_ref())?;
+
+    let msg = snapshot
+        .alter_table()
+        .add_column(StructField::nullable("new_col", DataType::STRING))
+        .build(engine.as_ref(), committer())
+        .unwrap_err()
+        .to_string();
+    assert!(
+        msg.contains("ALTER TABLE is not supported on tables with icebergCompatV3 enabled"),
+        "unexpected error: {msg}",
+    );
+
     Ok(())
 }

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -821,7 +821,7 @@ async fn alter_blocked_when_iceberg_compat_v3_enabled() -> Result<(), Box<dyn st
         .unwrap_err()
         .to_string();
     assert!(
-        msg.contains("ALTER TABLE is not supported on tables with icebergCompatV3 enabled"),
+        msg.contains("ALTER TABLE is not yet supported on tables with icebergCompatV3 enabled"),
         "unexpected error: {msg}",
     );
 

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -747,10 +747,9 @@ async fn alter_blocked_when_iceberg_compat_v3_enabled() -> Result<(), Box<dyn st
     let engine =
         Arc::new(DefaultEngineBuilder::<TokioBackgroundExecutor>::new(storage.clone()).build());
 
-    // V0 commit: protocol with V3 + dependent writer features, metadata enabling V3 + column
-    // mapping (V3 requires CM `name`/`id` mode) + row tracking. Single column carries the
-    // column-mapping annotations the metadata loader expects when CM mode is set.
-    // Note: Create table doesn't support IcebergCompatV3 yet, so we hand-craft the commit here.
+    // Create table doesn't support IcebergCompatV3 yet, so this test hand-crafts a V0 commit.
+    // The commit enables V3, column mapping, and row tracking. The schema contains one `id`
+    // column with the column-mapping metadata required when CM mode is set.
     let schema = StructType::try_new(vec![StructField::nullable("id", DataType::INTEGER)
         .with_metadata([
             (


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2505/files) to review incremental changes.
- [stack/add-v3-feature](https://github.com/delta-io/delta-kernel-rs/pull/2475) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2475/files)] [MERGED]
  - [stack/write-part-when-ice3](https://github.com/delta-io/delta-kernel-rs/pull/2504) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2504/files)] [MERGED]
    - [**stack/block-alter-table**](https://github.com/delta-io/delta-kernel-rs/pull/2505) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2505/files)]
      - [stack/write-nested-id](https://github.com/delta-io/delta-kernel-rs/pull/2508) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2508/files/cd4bf3f2a391fb8dd0917c651939fa2eb85478f4..1ba9effe3a15faaa022623a8b9a8e54a2a5ddb4c)]
        - [stack/detect-no-num](https://github.com/delta-io/delta-kernel-rs/pull/2512) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2512/files/1ba9effe3a15faaa022623a8b9a8e54a2a5ddb4c..ab75881181139ad69d4226d52d02d70991335578)]
          - [stack/create-ice-v3-table](https://github.com/delta-io/delta-kernel-rs/pull/2517) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2517/files/ab75881181139ad69d4226d52d02d70991335578..5f0c22fdf49aa8216c240fe2d93c17079efabdce)]

---------
## Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2505/files) to review incremental changes.
- [stack/add-v3-feature](https://github.com/delta-io/delta-kernel-rs/pull/2475) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2475/files)] [MERGED]
  - [stack/write-part-when-ice3](https://github.com/delta-io/delta-kernel-rs/pull/2504) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2504/files)] [MERGED]
    - [**stack/block-alter-table**](https://github.com/delta-io/delta-kernel-rs/pull/2505) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2505/files)]
      - [stack/write-nested-id](https://github.com/delta-io/delta-kernel-rs/pull/2508) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2508/files/cd4bf3f2a391fb8dd0917c651939fa2eb85478f4..1ba9effe3a15faaa022623a8b9a8e54a2a5ddb4c)]
        - [stack/detect-no-num](https://github.com/delta-io/delta-kernel-rs/pull/2512) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2512/files/1ba9effe3a15faaa022623a8b9a8e54a2a5ddb4c..ab75881181139ad69d4226d52d02d70991335578)]
          - [stack/create-ice-v3-table](https://github.com/delta-io/delta-kernel-rs/pull/2517) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2517/files/ab75881181139ad69d4226d52d02d70991335578..dbd1714c2170213fa25934e8a5b48eb4c06c3d0a)]

---------
## What changes are proposed in this pull request?
Block alter table when icebergCompatV3 enabled. Alter table transactions are expected to build from `AlterTableTransactionBuilder::build`, thus we block that function on icebergCompatV3 tables.

## How was this change tested?
Integration test: create an `icebergCompatV3` table and validate the error.

Note: Successful paths have been covered by existing tests so we are not adding test for successful path here