### PR TITLE
feat: Write parquet id for nested items in map/array according to metadata

### DIFF
--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -94,16 +94,12 @@ pub(crate) fn lookup_nested_field_id(
     let Some(value) = field.metadata().get(key) else {
         return Ok(None);
     };
-    let obj = match value {
-        MetadataValue::Other(serde_json::Value::Object(obj)) => Some(obj),
-        _ => None,
-    }
-    .ok_or_else(|| {
-        ArrowError::SchemaError(format!(
+    let MetadataValue::Other(serde_json::Value::Object(obj)) = value else {
+        return Err(ArrowError::SchemaError(format!(
             "'{key}' on field '{}' must be a JSON object",
             field.name()
-        ))
-    })?;
+        )));
+    };
     // Missing entry returns Ok(None) rather than Err. The JSON map's keys are rooted at the
     // *physical* field name, so when this function is invoked on a logical schema, it's
     // expected that the lookup misses.

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -213,7 +213,65 @@ impl TryFromKernel<&StructField> for ArrowField {
 /// - `relative_path`: dot-chained path rooted at `ancestor.name()`.
 /// - `datatype`: the kernel data type at the current position.
 ///
-/// See [`lookup_nested_field_id`] for an example of the `(ancestor, path) -> id` lookup.
+/// # Example
+///
+/// Kernel field: [`StructField`] (rendered as Delta-protocol-style JSON):
+///
+/// ```json
+/// {
+///   "name": "array_in_map",
+///   "type": {
+///     "type": "map",
+///     "keyType":   "integer",
+///     "valueType": { "type": "array", "elementType": "integer", "containsNull": true },
+///     "valueContainsNull": true
+///   },
+///   "nullable": true,
+///   "metadata": {
+///     "parquet.field.nested.ids": {
+///       "array_in_map.key":           100,
+///       "array_in_map.value":         101,
+///       "array_in_map.value.element": 102
+///     }
+///   }
+/// }
+/// ```
+///
+/// Calling `kernel_map_array_into_arrow(field, "array_in_map", &field.data_type())`
+/// produces this Arrow `DataType` (each synthesized `key`/`value`/`element` Arrow Field
+/// carries `PARQUET:field_id` in its `metadata`, looked up from the JSON above):
+///
+/// ```json
+/// {
+///   "type": "map",
+///   "keys_sorted": false,
+///   "entries": {
+///     "name": "key_value",
+///     "type": "struct",
+///     "nullable": false,
+///     "fields": [
+///       {
+///         "name": "key",
+///         "type": "int32",
+///         "nullable": false,
+///         "metadata": { "PARQUET:field_id": "100" }
+///       },
+///       {
+///         "name": "value",
+///         "type": "list",
+///         "nullable": true,
+///         "metadata": { "PARQUET:field_id": "101" },
+///         "element": {
+///           "name": "element",
+///           "type": "int32",
+///           "nullable": true,
+///           "metadata": { "PARQUET:field_id": "102" }
+///         }
+///       }
+///     ]
+///   }
+/// }
+/// ```
 fn kernel_map_array_into_arrow(
     ancestor: &StructField,
     relative_path: &str,

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -215,7 +215,7 @@ impl TryFromKernel<&StructField> for ArrowField {
 ///
 /// # Example
 ///
-/// Kernel field: [`StructField`] (rendered as Delta-protocol-style JSON):
+/// Kernel field: [`StructField`]:
 ///
 /// ```json
 /// {

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -42,7 +42,7 @@ pub(crate) const MAP_VALUE_DEFAULT: &str = "value";
 /// Translate a kernel [`StructField`]'s flat (non-nested) parquet field id metadata into Arrow
 /// field metadata: rewrites kernel-side `"parquet.field.id"` to arrow-side `"PARQUET:field_id"`
 /// (see [`PARQUET_FIELD_ID_META_KEY`]). All other entries pass through unchanged.
-pub(crate) fn kernel_flat_parquet_id_to_arrow(
+pub(crate) fn kernel_flat_parquet_id_to_arrow_metadata(
     field: &StructField,
 ) -> Result<HashMap<String, String>, ArrowError> {
     field
@@ -178,7 +178,7 @@ impl TryFromKernel<&StructType> for ArrowSchema {
 
 impl TryFromKernel<&StructField> for ArrowField {
     fn try_from_kernel(f: &StructField) -> Result<Self, ArrowError> {
-        let mut metadata = kernel_flat_parquet_id_to_arrow(f)?;
+        let mut metadata = kernel_flat_parquet_id_to_arrow_metadata(f)?;
         // `ColumnMetadataKey::ColumnMappingNestedIds` is a kernel-side metadata key, not
         // retained in Arrow; its content is processed by `kernel_field_into_arrow`.
         metadata.remove(ColumnMetadataKey::ColumnMappingNestedIds.as_ref());

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -26,15 +26,23 @@ pub(crate) const MAP_VALUE_DEFAULT: &str = "value";
 
 /// Converts kernel [`StructField`] metadata to Arrow field metadata format.
 ///
-/// Specifically, this transforms the `"parquet.field.id"` key (used by kernel/delta-spark) to
-/// `"PARQUET:field_id"` (the native Parquet/Arrow metadata key), enabling correct field ID
-/// handling by the Arrow/Parquet writer.
+/// Specifically:
+/// - Transforms the `"parquet.field.id"` key (used by kernel/delta-spark) to `"PARQUET:field_id"`
+///   (the native Parquet/Arrow metadata key), enabling correct field ID handling by the
+///   Arrow/Parquet writer.
+/// - Strips the nested-ids JSON keys (`"parquet.field.nested.ids"` and
+///   `"delta.columnMapping.nested.ids"`). Their content is already projected onto the synthesized
+///   list/map fields' `"PARQUET:field_id"` by [`kernel_map_array_into_arrow`].
 pub(crate) fn kernel_metadata_to_arrow_metadata(
     field: &StructField,
 ) -> Result<HashMap<String, String>, ArrowError> {
     field
         .metadata()
         .iter()
+        .filter(|(key, _)| {
+            *key != ColumnMetadataKey::ParquetFieldNestedIds.as_ref()
+                && *key != ColumnMetadataKey::ColumnMappingNestedIds.as_ref()
+        })
         .map(|(key, val)| {
             let transformed_key = if key == ColumnMetadataKey::ParquetFieldId.as_ref() {
                 PARQUET_FIELD_ID_META_KEY.to_string()
@@ -68,8 +76,9 @@ pub(crate) fn kernel_metadata_to_arrow_metadata(
 /// - `lookup_nested_field_id(col2, "col2.value.element")` -> `Some(104)`
 ///
 /// Returns `None` when neither metadata key is present, or when the path is not in the JSON
-/// map (which happens naturally when the caller passes a logical schema. As the nested.ids JSON
-/// keys are rooted at the *physical* field name, so logical-schema lookups miss).
+/// map. The latter is expected when the caller passes a logical schema, because nested.ids
+/// JSON keys are rooted at the physical field name.
+///
 /// Returns an error when the metadata value is not a JSON object, or the id found is not an
 /// integer.
 ///
@@ -428,13 +437,13 @@ impl TryFromArrow<ArrowSchemaRef> for StructType {
 
 impl TryFromArrow<&ArrowField> for StructField {
     fn try_from_arrow(arrow_field: &ArrowField) -> Result<Self, ArrowError> {
-        let metadata = arrow_field.metadata();
+        let arrow_metadata = arrow_field.metadata();
         // If both the native Arrow key (PARQUET:field_id) and the kernel key (parquet.field.id)
         // are present with different values, the translation below would silently overwrite one
         // with the other. Detect and reject this up front.
         if let (Some(arrow_id), Some(kernel_id)) = (
-            metadata.get(PARQUET_FIELD_ID_META_KEY),
-            metadata.get(ColumnMetadataKey::ParquetFieldId.as_ref()),
+            arrow_metadata.get(PARQUET_FIELD_ID_META_KEY),
+            arrow_metadata.get(ColumnMetadataKey::ParquetFieldId.as_ref()),
         ) {
             if arrow_id != kernel_id {
                 return Err(ArrowError::SchemaError(format!(
@@ -447,21 +456,115 @@ impl TryFromArrow<&ArrowField> for StructField {
                 )));
             }
         }
+        let mut kernel_metadata: HashMap<String, MetadataValue> = arrow_metadata
+            .iter()
+            .map(|(k, v)| -> Result<_, ArrowError> {
+                // Transform "PARQUET:field_id" to "parquet.field.id" when reading from Parquet.
+                // `parquet.field.id` in kernel is `MetadataValue::Number(i64)`.
+                if k == PARQUET_FIELD_ID_META_KEY || k == ColumnMetadataKey::ParquetFieldId.as_ref()
+                {
+                    let id: i64 = v.parse().map_err(|_| {
+                        ArrowError::SchemaError(format!(
+                            "'{k}' on field '{}' must be an integer, got '{v}'",
+                            arrow_field.name()
+                        ))
+                    })?;
+                    return Ok((
+                        ColumnMetadataKey::ParquetFieldId.as_ref().to_string(),
+                        MetadataValue::Number(id),
+                    ));
+                }
+                Ok((k.clone(), MetadataValue::from(v)))
+            })
+            .collect::<Result<_, _>>()?;
+        let mut nested_ids = serde_json::Map::new();
+        collect_nested_field_ids_from_arrow(
+            arrow_field.data_type(),
+            arrow_field.name(),
+            &mut nested_ids,
+        )?;
+        if !nested_ids.is_empty() {
+            kernel_metadata.insert(
+                ColumnMetadataKey::ParquetFieldNestedIds
+                    .as_ref()
+                    .to_string(),
+                MetadataValue::Other(serde_json::Value::Object(nested_ids)),
+            );
+        }
+
         Ok(StructField::new(
             arrow_field.name().clone(),
             DataType::try_from_arrow(arrow_field.data_type())?,
             arrow_field.is_nullable(),
         )
-        .with_metadata(metadata.iter().map(|(k, v)| {
-            // Transform "PARQUET:field_id" to "parquet.field.id" when reading from Parquet
-            let transformed_key = if k == PARQUET_FIELD_ID_META_KEY {
-                ColumnMetadataKey::ParquetFieldId.as_ref().to_string()
-            } else {
-                k.clone()
-            };
-            (transformed_key, v)
-        })))
+        .with_metadata(kernel_metadata))
     }
+}
+
+/// Inverse of [`kernel_map_array_into_arrow`]: walks `arrow_type` and aggregates
+/// `PARQUET:field_id` from the element/key/value fields of any list/map, keyed by dot-path
+/// rooted at `relative_path`.
+///
+/// # Example
+///
+/// Given an Arrow [`MapArray`] field `m: map<int, list<int>>` whose inner `key`, `value`, and
+/// `value.element` fields carry `PARQUET:field_id` of `100`, `101`, `102`, calling
+/// `collect_nested_field_ids_from_arrow(m.data_type(), "m", &mut out)` populates `out` with:
+///
+/// ```text
+/// { "m.key": 100, "m.value": 101, "m.value.element": 102 }
+/// ```
+///
+/// TODO: Replace `parquet.field.nested.ids` with `delta.columnMapping.nested.ids` after the
+/// protocol update. Tracking issue: <https://github.com/delta-io/delta/issues/6688>
+///
+/// [`MapArray`]: arrow::array::MapArray
+fn collect_nested_field_ids_from_arrow(
+    arrow_type: &ArrowDataType,
+    relative_path: &str,
+    out: &mut serde_json::Map<String, serde_json::Value>,
+) -> Result<(), ArrowError> {
+    // `parquet.field.nested.ids` only stores the nested field ids element/key/values
+    // of list/map fields. So we only recurse into list/map here.
+    let inner_fields: Vec<(&ArrowField, &str)> = match arrow_type {
+        ArrowDataType::List(elem)
+        | ArrowDataType::ListView(elem)
+        | ArrowDataType::LargeList(elem)
+        | ArrowDataType::LargeListView(elem) => vec![(elem.as_ref(), LIST_ARRAY_ROOT)],
+        ArrowDataType::FixedSizeList(elem, _) => vec![(elem.as_ref(), LIST_ARRAY_ROOT)],
+        ArrowDataType::Map(entries, _) => match entries.data_type() {
+            ArrowDataType::Struct(fields) if fields.len() == 2 => vec![
+                (fields[0].as_ref(), MAP_KEY_DEFAULT),
+                (fields[1].as_ref(), MAP_VALUE_DEFAULT),
+            ],
+            other => {
+                return Err(ArrowError::SchemaError(format!(
+                    "Map entries must be a struct with exactly 2 fields (key, value), got {other}"
+                )))
+            }
+        },
+        // Dictionary is a transparent wrapper (kernel side collapses it to its value type), so
+        // recurse without consuming a path segment.
+        ArrowDataType::Dictionary(_, value_type) => {
+            return collect_nested_field_ids_from_arrow(value_type, relative_path, out);
+        }
+        _ => return Ok(()),
+    };
+
+    for (inner, segment) in inner_fields {
+        let path = format!("{relative_path}.{segment}");
+        if let Some(id_str) = inner.metadata().get(PARQUET_FIELD_ID_META_KEY) {
+            let id: i64 = id_str.parse().map_err(|_| {
+                ArrowError::SchemaError(format!(
+                    "'{PARQUET_FIELD_ID_META_KEY}' on '{}' must be an integer, got '{id_str}'",
+                    inner.name()
+                ))
+            })?;
+            out.insert(path.clone(), serde_json::Value::from(id));
+        }
+        collect_nested_field_ids_from_arrow(inner.data_type(), &path, out)?;
+    }
+    Ok(())
 }
 
 impl TryFromArrow<&ArrowDataType> for DataType {
@@ -898,8 +1001,15 @@ mod tests {
             ]
             .into(),
         );
-        let result = StructField::try_from_arrow(&arrow_field);
-        assert!(result.is_ok(), "Matching field IDs should succeed");
+        let kernel = StructField::try_from_arrow(&arrow_field).unwrap();
+        // The two arrow keys collapse to a single kernel `parquet.field.id` entry whose value is
+        // a `Number`.
+        assert_eq!(
+            kernel
+                .metadata()
+                .get(ColumnMetadataKey::ParquetFieldId.as_ref()),
+            Some(&MetadataValue::Number(42)),
+        );
     }
 
     /// When an Arrow field carries both `PARQUET:field_id` and `parquet.field.id` with *different*
@@ -917,9 +1027,102 @@ mod tests {
             ]
             .into(),
         );
-        crate::utils::test_utils::assert_result_error_with_message(
+        assert_result_error_with_message(
             StructField::try_from_arrow(&arrow_field),
             "conflicting parquet field IDs",
         );
+    }
+
+    /// Inverse of `test_try_into_arrow_threads_nested_ids_onto_arrow_schema`: feed the same
+    /// fixture's expected Arrow schema back through `try_from_arrow` and verify it round-trips
+    /// to the original kernel schema.
+    #[test]
+    fn test_try_from_arrow_aggregates_synthesized_nested_ids() {
+        let fixture =
+            complex_nested_with_field_ids(ColumnMetadataKey::ParquetFieldNestedIds.as_ref());
+        let kernel_schema_from_arrow: StructType =
+            (&fixture.expected_arrow_schema).try_into_kernel().unwrap();
+        assert_eq!(kernel_schema_from_arrow, fixture.kernel_schema);
+    }
+
+    /// When the input Arrow schema has no `PARQUET:field_id` on any inner list/map field, the
+    /// resulting kernel [`StructField`] must not carry a `parquet.field.nested.ids` entry.
+    #[test]
+    fn test_try_from_arrow_no_nested_ids_when_input_lacks_field_ids() {
+        let kernel_schema_without_metadata =
+            array_in_map_kernel_schema(std::iter::empty::<(String, MetadataValue)>());
+        let arrow_schema_without_parquet_id: ArrowSchema =
+            (&kernel_schema_without_metadata).try_into_arrow().unwrap();
+
+        let kernel_schema: StructType = (&arrow_schema_without_parquet_id)
+            .try_into_kernel()
+            .unwrap();
+        let array_in_map = kernel_schema.fields().next().unwrap();
+        assert!(!array_in_map
+            .metadata()
+            .contains_key(ColumnMetadataKey::ParquetFieldNestedIds.as_ref()));
+    }
+
+    /// A non-integer `PARQUET:field_id` on an inner list/map field must produce a clear error
+    /// rather than silently being dropped.
+    #[test]
+    fn test_try_from_arrow_invalid_inner_field_id_errors() {
+        let element_field = ArrowField::new("element", ArrowDataType::Int32, true)
+            .with_metadata([(PARQUET_FIELD_ID_META_KEY.to_string(), "oops".to_string())].into());
+        let list_field = ArrowField::new("arr", ArrowDataType::List(Arc::new(element_field)), true);
+        assert_result_error_with_message(
+            StructField::try_from_arrow(&list_field),
+            "must be an integer",
+        );
+    }
+
+    /// Every list-flavored Arrow datatype that the converter accepts must also be walked by the
+    /// nested-ids aggregator.
+    #[rstest]
+    #[case::list(ArrowDataType::List(arc_elem_with_id(42)))]
+    #[case::list_view(ArrowDataType::ListView(arc_elem_with_id(42)))]
+    #[case::large_list(ArrowDataType::LargeList(arc_elem_with_id(42)))]
+    #[case::large_list_view(ArrowDataType::LargeListView(arc_elem_with_id(42)))]
+    #[case::fixed_size_list(ArrowDataType::FixedSizeList(arc_elem_with_id(42), 3))]
+    fn test_try_from_arrow_aggregates_nested_id_for_all_list_kinds(
+        #[case] dt: ArrowDataType,
+    ) -> DeltaResult<()> {
+        let arrow_field = ArrowField::new("arr", dt, true);
+        let kernel = StructField::try_from_arrow(&arrow_field)?;
+        assert_eq!(
+            kernel
+                .metadata()
+                .get(ColumnMetadataKey::ParquetFieldNestedIds.as_ref()),
+            Some(&MetadataValue::Other(
+                serde_json::json!({"arr.element": 42})
+            )),
+        );
+        Ok(())
+    }
+
+    /// `Dictionary` is a transparent wrapper on the Arrow side (kernel collapses it to its value
+    /// type), so a nested-ids walker must still descend through it.
+    #[test]
+    fn test_try_from_arrow_aggregates_nested_id_through_dictionary() -> DeltaResult<()> {
+        let arrow_dict = ArrowDataType::Dictionary(
+            Box::new(ArrowDataType::Int32),
+            Box::new(ArrowDataType::List(arc_elem_with_id(7))),
+        );
+        let arrow_field = ArrowField::new("arr", arrow_dict, true);
+        let kernel = StructField::try_from_arrow(&arrow_field)?;
+        assert_eq!(
+            kernel
+                .metadata()
+                .get(ColumnMetadataKey::ParquetFieldNestedIds.as_ref()),
+            Some(&MetadataValue::Other(serde_json::json!({"arr.element": 7}))),
+        );
+        Ok(())
+    }
+
+    fn arc_elem_with_id(id: i32) -> Arc<ArrowField> {
+        Arc::new(
+            ArrowField::new("element", ArrowDataType::Int32, true)
+                .with_metadata([(PARQUET_FIELD_ID_META_KEY.to_string(), id.to_string())].into()),
+        )
     }
 }

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -52,6 +52,85 @@ pub(crate) fn kernel_metadata_to_arrow_metadata(
         .collect()
 }
 
+/// Looks up a nested-field id for the given dot-path on a StructField's nested-ids metadata.
+///
+/// Parquet field IDs for synthesized list/map element/key/value fields are stored under either
+/// `delta.columnMapping.nested.ids` or `parquet.field.nested.ids`. The path is dot-chained from
+/// the nearest ancestor StructField's name.
+///
+/// # Example
+///
+/// Given `col2: map[int, array[int]]` whose StructField's metadata has
+/// `{ "col2.key": 102, "col2.value": 103, "col2.value.element": 104 }`:
+///
+/// - `lookup_nested_field_id(col2, "col2.key")` -> `Some(102)`
+/// - `lookup_nested_field_id(col2, "col2.value")` -> `Some(103)`
+/// - `lookup_nested_field_id(col2, "col2.value.element")` -> `Some(104)`
+///
+/// Returns `None` when neither metadata key is present, or when the path is not in the JSON
+/// map (which happens naturally when the caller passes a logical schema. As the nested.ids JSON
+/// keys are rooted at the *physical* field name, so logical-schema lookups miss).
+/// Returns an error when the metadata value is not a JSON object, or the id found is not an
+/// integer.
+///
+/// Note: currently both `delta.columnMapping.nested.ids` and `parquet.field.nested.ids` are used;
+/// `parquet.field.nested.ids` will be deprecated. Tracking issue:
+/// <https://github.com/delta-io/delta/issues/6688>
+pub(crate) fn lookup_nested_field_id(
+    field: &StructField,
+    path: &str,
+) -> Result<Option<i64>, ArrowError> {
+    // Note: If both `delta.columnMapping.nested.ids` and `parquet.field.nested.ids` are present
+    // but different, the table is invalid. We are not doing defense-in-depth here to keep the
+    // code simple.
+    let keys = [
+        ColumnMetadataKey::ColumnMappingNestedIds.as_ref(),
+        ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
+    ];
+    for key in keys {
+        let Some(value) = field.metadata().get(key) else {
+            continue;
+        };
+        let obj = match value {
+            MetadataValue::Other(serde_json::Value::Object(obj)) => Some(obj),
+            _ => None,
+        }
+        .ok_or_else(|| {
+            ArrowError::SchemaError(format!(
+                "'{key}' on field '{}' must be a JSON object",
+                field.name()
+            ))
+        })?;
+        // `serde_json::Map::get` is O(log n) (BTreeMap-backed by default). For nested-id maps
+        // n is bounded by the depth of a single field's type (typically <10 entries), so the
+        // O(log n) factor is negligible. Could move to a HashMap for O(1) lookup if needed,
+        // but the simpler code wins here.
+        //
+        // Missing entry returns Ok(None) rather than Err. The JSON map's keys are rooted at the
+        // *physical* field name, so when this function is invoked on a
+        // logical schema, it's expected that the lookup misses.
+        return obj.get(path).map_or(Ok(None), |entry| {
+            entry.as_i64().map(Some).ok_or_else(|| {
+                ArrowError::SchemaError(format!(
+                    "'{key}['{path}']' on field '{}' must be an integer, got {entry}",
+                    field.name()
+                ))
+            })
+        });
+    }
+    Ok(None)
+}
+
+/// Builds Arrow field metadata containing the `PARQUET:field_id` entry, or empty if `id` is
+/// `None`.
+pub(crate) fn parquet_field_id_metadata(id: Option<i64>) -> HashMap<String, String> {
+    let mut meta = HashMap::new();
+    if let Some(id) = id {
+        meta.insert(PARQUET_FIELD_ID_META_KEY.to_string(), id.to_string());
+    }
+    meta
+}
+
 /// Convert a kernel type into an arrow type (automatically implemented for all types that
 /// implement [`TryFromKernel`])
 pub trait TryIntoArrow<ArrowType> {
@@ -108,10 +187,80 @@ impl TryFromKernel<&StructType> for ArrowSchema {
 impl TryFromKernel<&StructField> for ArrowField {
     fn try_from_kernel(f: &StructField) -> Result<Self, ArrowError> {
         let metadata = kernel_metadata_to_arrow_metadata(f)?;
-        let field = ArrowField::new(f.name(), f.data_type().try_into_arrow()?, f.is_nullable())
-            .with_metadata(metadata);
+        // For Array/Map fields, recurse via `kernel_map_array_into_arrow` so that any
+        // `delta.columnMapping.nested.ids` / `parquet.field.nested.ids` metadata on this
+        // StructField gets threaded onto the synthesized element/key/value Arrow fields.
+        // Other types (Struct, Primitive, Variant) keep using the default conversion.
+        let arrow_type = match f.data_type() {
+            DataType::Array(_) | DataType::Map(_) => {
+                kernel_map_array_into_arrow(f, f.name(), f.data_type())?
+            }
+            _ => f.data_type().try_into_arrow()?,
+        };
+        let field = ArrowField::new(f.name(), arrow_type, f.is_nullable()).with_metadata(metadata);
 
         Ok(field)
+    }
+}
+
+/// Recursive Arrow-type builder that propagates nested field IDs from `ancestor`'s
+/// `delta.columnMapping.nested.ids` / `parquet.field.nested.ids` metadata onto the synthesized
+/// `element` / `key` / `value` Arrow fields.
+///
+/// # Parameters
+/// - `ancestor`: the nearest ancestor kernel [`StructField`]; its metadata holds the nested-ids
+///   JSON map.
+/// - `relative_path`: dot-chained path rooted at `ancestor.name()`.
+/// - `datatype`: the kernel data type at the current position.
+///
+/// See [`lookup_nested_field_id`] for an example of the `(ancestor, path) -> id` lookup.
+fn kernel_map_array_into_arrow(
+    ancestor: &StructField,
+    relative_path: &str,
+    datatype: &DataType,
+) -> Result<ArrowDataType, ArrowError> {
+    match datatype {
+        DataType::Array(a) => {
+            let element_path = format!("{relative_path}.{LIST_ARRAY_ROOT}");
+            let element_id = lookup_nested_field_id(ancestor, &element_path)?;
+            let arrow_element_type =
+                kernel_map_array_into_arrow(ancestor, &element_path, a.element_type())?;
+            // Kernel's array element field is anonymous; we use `LIST_ARRAY_ROOT` as the
+            // synthesized field name by convention. Same below for map's `key`/`value` fields.
+            let arrow_element_field =
+                ArrowField::new(LIST_ARRAY_ROOT, arrow_element_type, a.contains_null())
+                    .with_metadata(parquet_field_id_metadata(element_id));
+            Ok(ArrowDataType::List(Arc::new(arrow_element_field)))
+        }
+        DataType::Map(m) => {
+            let key_path = format!("{relative_path}.{MAP_KEY_DEFAULT}");
+            let value_path = format!("{relative_path}.{MAP_VALUE_DEFAULT}");
+            let key_id = lookup_nested_field_id(ancestor, &key_path)?;
+            let value_id = lookup_nested_field_id(ancestor, &value_path)?;
+            let arrow_key_type = kernel_map_array_into_arrow(ancestor, &key_path, m.key_type())?;
+            let arrow_value_type =
+                kernel_map_array_into_arrow(ancestor, &value_path, m.value_type())?;
+            // Map keys are never nullable.
+            let arrow_key_field = ArrowField::new(MAP_KEY_DEFAULT, arrow_key_type, false)
+                .with_metadata(parquet_field_id_metadata(key_id));
+            let arrow_value_field =
+                ArrowField::new(MAP_VALUE_DEFAULT, arrow_value_type, m.value_contains_null())
+                    .with_metadata(parquet_field_id_metadata(value_id));
+            // `MapArray::try_new` rejects a nullable entries field, so hardcode nullable to `false`
+            // here. See <https://docs.rs/arrow/latest/arrow/array/struct.MapArray.html#method.try_new>.
+            let arrow_entries_field = ArrowField::new(
+                MAP_ROOT_DEFAULT,
+                ArrowDataType::Struct(vec![arrow_key_field, arrow_value_field].into()),
+                false, /* always non-null */
+            );
+            Ok(ArrowDataType::Map(
+                Arc::new(arrow_entries_field),
+                false, /* keys_sorted */
+            ))
+        }
+        DataType::Struct(_) | DataType::Primitive(_) | DataType::Variant(_) => {
+            datatype.try_into_arrow()
+        }
     }
 }
 
@@ -356,6 +505,8 @@ impl TryFromArrow<&ArrowDataType> for DataType {
 mod tests {
     use std::collections::HashMap;
 
+    use rstest::rstest;
+
     use super::*;
     use crate::engine::arrow_conversion::ArrowField;
     use crate::engine::arrow_data::unshredded_variant_arrow_type;
@@ -364,6 +515,10 @@ mod tests {
         ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, StructField, StructType,
     };
     use crate::transforms::{transform_output_type, SchemaTransform};
+    use crate::utils::test_utils::{
+        array_in_map_kernel_schema, assert_result_error_with_message, collect_arrow_field_metadata,
+        complex_nested_with_field_ids,
+    };
     use crate::DeltaResult;
 
     #[test]
@@ -423,47 +578,118 @@ mod tests {
         }
     }
 
-    /// Helper function to recursively collect field IDs from an Arrow schema
-    fn collect_arrow_field_ids(schema: &ArrowSchema, metadata_key: &str) -> Vec<(String, String)> {
-        let mut field_ids = Vec::new();
+    #[test]
+    fn test_try_into_arrow_threads_nested_ids_onto_arrow_schema() -> DeltaResult<()> {
+        for meta_key in [
+            ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
+            ColumnMetadataKey::ColumnMappingNestedIds.as_ref(),
+        ] {
+            let fixture = complex_nested_with_field_ids(meta_key);
+            let arrow_schema: ArrowSchema = (&fixture.kernel_schema).try_into_arrow()?;
 
-        fn collect_from_fields(
-            fields: &[std::sync::Arc<ArrowField>],
-            metadata_key: &str,
-            field_ids: &mut Vec<(String, String)>,
-        ) {
-            for field in fields {
-                collect_from_field(field, metadata_key, field_ids);
-            }
+            assert_eq!(
+                arrow_schema, fixture.expected_arrow_schema,
+                "try_into_arrow should attach nested field ids for metadata key {meta_key}",
+            );
         }
+        Ok(())
+    }
 
-        fn collect_from_field(
-            field: &ArrowField,
-            metadata_key: &str,
-            field_ids: &mut Vec<(String, String)>,
-        ) {
-            // Collect field ID from this field
-            if let Some(id) = field.metadata().get(metadata_key) {
-                field_ids.push((field.name().clone(), id.clone()));
-            }
+    #[test]
+    fn test_try_into_arrow_delta_nested_id_key_takes_precedence() -> DeltaResult<()> {
+        let schema = array_in_map_kernel_schema([
+            (
+                ColumnMetadataKey::ColumnMappingNestedIds
+                    .as_ref()
+                    .to_string(),
+                MetadataValue::Other(test_utils::nested_ids_json(&[
+                    ("array_in_map.key", 100),
+                    ("array_in_map.value", 101),
+                    ("array_in_map.value.element", 102),
+                ])),
+            ),
+            (
+                ColumnMetadataKey::ParquetFieldNestedIds
+                    .as_ref()
+                    .to_string(),
+                MetadataValue::Other(test_utils::nested_ids_json(&[
+                    ("array_in_map.key", 900),
+                    ("array_in_map.value", 901),
+                    ("array_in_map.value.element", 902),
+                ])),
+            ),
+        ]);
+        let arrow_schema: ArrowSchema = (&schema).try_into_arrow()?;
+        let field_ids: HashMap<String, String> =
+            collect_arrow_field_metadata(&arrow_schema, PARQUET_FIELD_ID_META_KEY)
+                .into_iter()
+                .collect();
 
-            // Recurse into nested types
-            match field.data_type() {
-                ArrowDataType::Struct(fields) => {
-                    collect_from_fields(fields, metadata_key, field_ids);
-                }
-                ArrowDataType::List(entry)
-                | ArrowDataType::LargeList(entry)
-                | ArrowDataType::FixedSizeList(entry, _)
-                | ArrowDataType::Map(entry, _) => {
-                    collect_from_field(entry, metadata_key, field_ids);
-                }
-                _ => {}
-            }
+        assert_eq!(field_ids.get("key").map(String::as_str), Some("100"));
+        assert_eq!(field_ids.get("value").map(String::as_str), Some("101"));
+        assert_eq!(field_ids.get("element").map(String::as_str), Some("102"));
+        Ok(())
+    }
+
+    #[rstest]
+    /// The whole nested ids JSON map is missing(i.e. neither `delta.columnMapping.nested.ids`
+    /// nor `parquet.field.nested.ids` are present).
+    #[case::without_nested_id_metadata(array_in_map_kernel_schema(std::iter::empty::<(
+        String,
+        MetadataValue,
+    )>()), /* expected_field_ids */ &[])]
+    /// Only some of the nested ids are present.
+    #[case::only_partial_nested_ids_match(array_in_map_kernel_schema([(
+        ColumnMetadataKey::ParquetFieldNestedIds.as_ref().to_string(),
+        MetadataValue::Other(test_utils::nested_ids_json(&[
+            ("array_in_map.key", 100),
+            ("array_in_map.value.element", 102),
+            ("array_in_map.notTheKey", 999),
+        ])),
+    )]), &[("element", "102"), ("key", "100")])]
+    fn test_try_into_arrow_sets_field_ids_for_matched_nested_ids_only(
+        #[case] schema: StructType,
+        #[case] expected_field_ids: &[(&str, &str)],
+    ) -> DeltaResult<()> {
+        let arrow_schema: ArrowSchema = (&schema).try_into_arrow()?;
+        let field_ids: HashMap<String, String> =
+            collect_arrow_field_metadata(&arrow_schema, PARQUET_FIELD_ID_META_KEY)
+                .into_iter()
+                .collect();
+
+        assert_eq!(field_ids.len(), expected_field_ids.len());
+        for (field_name, expected_id) in expected_field_ids {
+            assert_eq!(
+                field_ids.get(*field_name).map(String::as_str),
+                Some(*expected_id),
+            );
         }
+        Ok(())
+    }
 
-        collect_from_fields(schema.fields(), metadata_key, &mut field_ids);
-        field_ids
+    #[test]
+    fn test_try_into_arrow_invalid_nested_ids_metadata_errors() {
+        let schema = array_in_map_kernel_schema([(
+            ColumnMetadataKey::ParquetFieldNestedIds
+                .as_ref()
+                .to_string(),
+            MetadataValue::String("not a json object".to_string()),
+        )]);
+        assert_result_error_with_message(
+            ArrowSchema::try_from_kernel(&schema),
+            "must be a JSON object",
+        );
+
+        let schema = array_in_map_kernel_schema([(
+            ColumnMetadataKey::ParquetFieldNestedIds
+                .as_ref()
+                .to_string(),
+            MetadataValue::Other(serde_json::json!({ "array_in_map.key": "oops" })),
+        )]);
+        assert_result_error_with_message(
+            ArrowSchema::try_from_kernel(&schema),
+            "must be an integer",
+        );
     }
 
     #[test]
@@ -579,7 +805,7 @@ mod tests {
 
         // Verify field IDs are transformed to PARQUET:field_id at all levels
         let arrow_field_ids: HashMap<String, String> =
-            collect_arrow_field_ids(&arrow_schema, PARQUET_FIELD_ID_META_KEY)
+            collect_arrow_field_metadata(&arrow_schema, PARQUET_FIELD_ID_META_KEY)
                 .into_iter()
                 .collect();
         assert_eq!(

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -1,4 +1,12 @@
 //! Conversions between kernel schema types and arrow schema types.
+//!
+//! Two directions, used at the engine <-> kernel boundary:
+//!
+//! - **arrow -> kernel** ([`TryFromArrow`] / [`TryIntoKernel`]): an example usage is parsing a
+//!   parquet footer's Arrow schema into a kernel `StructType` for checkpoint introspection.
+//!
+//! - **kernel -> arrow** ([`TryFromKernel`] / [`TryIntoArrow`]): an example usage is materializing
+//!   a kernel `StructType` as an `ArrowSchema` to build a `RecordBatch` on the write path.
 
 pub mod scalar;
 
@@ -30,19 +38,16 @@ pub(crate) const MAP_VALUE_DEFAULT: &str = "value";
 /// - Transforms the `"parquet.field.id"` key (used by kernel/delta-spark) to `"PARQUET:field_id"`
 ///   (the native Parquet/Arrow metadata key), enabling correct field ID handling by the
 ///   Arrow/Parquet writer.
-/// - Strips the nested-ids JSON keys (`"parquet.field.nested.ids"` and
-///   `"delta.columnMapping.nested.ids"`). Their content is already projected onto the synthesized
-///   list/map fields' `"PARQUET:field_id"` by [`kernel_map_array_into_arrow`].
+/// - Strips the nested-ids JSON key (`"delta.columnMapping.nested.ids"`). Its content is already
+///   projected onto the synthesized list/map fields' `"PARQUET:field_id"` by
+///   [`kernel_map_array_into_arrow`].
 pub(crate) fn kernel_metadata_to_arrow_metadata(
     field: &StructField,
 ) -> Result<HashMap<String, String>, ArrowError> {
     field
         .metadata()
         .iter()
-        .filter(|(key, _)| {
-            *key != ColumnMetadataKey::ParquetFieldNestedIds.as_ref()
-                && *key != ColumnMetadataKey::ColumnMappingNestedIds.as_ref()
-        })
+        .filter(|(key, _)| *key != ColumnMetadataKey::ColumnMappingNestedIds.as_ref())
         .map(|(key, val)| {
             let transformed_key = if key == ColumnMetadataKey::ParquetFieldId.as_ref() {
                 PARQUET_FIELD_ID_META_KEY.to_string()
@@ -62,9 +67,9 @@ pub(crate) fn kernel_metadata_to_arrow_metadata(
 
 /// Looks up a nested-field id for the given dot-path on a StructField's nested-ids metadata.
 ///
-/// Parquet field IDs for synthesized list/map element/key/value fields are stored under either
-/// `delta.columnMapping.nested.ids` or `parquet.field.nested.ids`. The path is dot-chained from
-/// the nearest ancestor StructField's name.
+/// Parquet field IDs for synthesized list/map element/key/value fields are stored under
+/// `delta.columnMapping.nested.ids`. The path is dot-chained from the nearest ancestor
+/// StructField's name.
 ///
 /// # Example
 ///
@@ -75,59 +80,41 @@ pub(crate) fn kernel_metadata_to_arrow_metadata(
 /// - `lookup_nested_field_id(col2, "col2.value")` -> `Some(103)`
 /// - `lookup_nested_field_id(col2, "col2.value.element")` -> `Some(104)`
 ///
-/// Returns `None` when neither metadata key is present, or when the path is not in the JSON
+/// Returns `None` when the metadata key is not present, or when the path is not in the JSON
 /// map. The latter is expected when the caller passes a logical schema, because nested.ids
 /// JSON keys are rooted at the physical field name.
 ///
 /// Returns an error when the metadata value is not a JSON object, or the id found is not an
 /// integer.
-///
-/// Note: currently both `delta.columnMapping.nested.ids` and `parquet.field.nested.ids` are used;
-/// `parquet.field.nested.ids` will be deprecated. Tracking issue:
-/// <https://github.com/delta-io/delta/issues/6688>
 pub(crate) fn lookup_nested_field_id(
     field: &StructField,
     path: &str,
 ) -> Result<Option<i64>, ArrowError> {
-    // Note: If both `delta.columnMapping.nested.ids` and `parquet.field.nested.ids` are present
-    // but different, the table is invalid. We are not doing defense-in-depth here to keep the
-    // code simple.
-    let keys = [
-        ColumnMetadataKey::ColumnMappingNestedIds.as_ref(),
-        ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
-    ];
-    for key in keys {
-        let Some(value) = field.metadata().get(key) else {
-            continue;
-        };
-        let obj = match value {
-            MetadataValue::Other(serde_json::Value::Object(obj)) => Some(obj),
-            _ => None,
-        }
-        .ok_or_else(|| {
+    let key = ColumnMetadataKey::ColumnMappingNestedIds.as_ref();
+    let Some(value) = field.metadata().get(key) else {
+        return Ok(None);
+    };
+    let obj = match value {
+        MetadataValue::Other(serde_json::Value::Object(obj)) => Some(obj),
+        _ => None,
+    }
+    .ok_or_else(|| {
+        ArrowError::SchemaError(format!(
+            "'{key}' on field '{}' must be a JSON object",
+            field.name()
+        ))
+    })?;
+    // Missing entry returns Ok(None) rather than Err. The JSON map's keys are rooted at the
+    // *physical* field name, so when this function is invoked on a logical schema, it's
+    // expected that the lookup misses.
+    obj.get(path).map_or(Ok(None), |entry| {
+        entry.as_i64().map(Some).ok_or_else(|| {
             ArrowError::SchemaError(format!(
-                "'{key}' on field '{}' must be a JSON object",
+                "'{key}['{path}']' on field '{}' must be an integer, got {entry}",
                 field.name()
             ))
-        })?;
-        // `serde_json::Map::get` is O(log n) (BTreeMap-backed by default). For nested-id maps
-        // n is bounded by the depth of a single field's type (typically <10 entries), so the
-        // O(log n) factor is negligible. Could move to a HashMap for O(1) lookup if needed,
-        // but the simpler code wins here.
-        //
-        // Missing entry returns Ok(None) rather than Err. The JSON map's keys are rooted at the
-        // *physical* field name, so when this function is invoked on a
-        // logical schema, it's expected that the lookup misses.
-        return obj.get(path).map_or(Ok(None), |entry| {
-            entry.as_i64().map(Some).ok_or_else(|| {
-                ArrowError::SchemaError(format!(
-                    "'{key}['{path}']' on field '{}' must be an integer, got {entry}",
-                    field.name()
-                ))
-            })
-        });
-    }
-    Ok(None)
+        })
+    })
 }
 
 /// Builds Arrow field metadata containing the `PARQUET:field_id` entry, or empty if `id` is
@@ -197,9 +184,9 @@ impl TryFromKernel<&StructField> for ArrowField {
     fn try_from_kernel(f: &StructField) -> Result<Self, ArrowError> {
         let metadata = kernel_metadata_to_arrow_metadata(f)?;
         // For Array/Map fields, recurse via `kernel_map_array_into_arrow` so that any
-        // `delta.columnMapping.nested.ids` / `parquet.field.nested.ids` metadata on this
-        // StructField gets threaded onto the synthesized element/key/value Arrow fields.
-        // Other types (Struct, Primitive, Variant) keep using the default conversion.
+        // `delta.columnMapping.nested.ids` metadata on this StructField gets threaded onto the
+        // synthesized element/key/value Arrow fields. Other types (Struct, Primitive, Variant)
+        // keep using the default conversion.
         let arrow_type = match f.data_type() {
             DataType::Array(_) | DataType::Map(_) => {
                 kernel_map_array_into_arrow(f, f.name(), f.data_type())?
@@ -213,8 +200,8 @@ impl TryFromKernel<&StructField> for ArrowField {
 }
 
 /// Recursive Arrow-type builder that propagates nested field IDs from `ancestor`'s
-/// `delta.columnMapping.nested.ids` / `parquet.field.nested.ids` metadata onto the synthesized
-/// `element` / `key` / `value` Arrow fields.
+/// `delta.columnMapping.nested.ids` metadata onto the synthesized `element` / `key` / `value`
+/// Arrow fields.
 ///
 /// # Parameters
 /// - `ancestor`: the nearest ancestor kernel [`StructField`]; its metadata holds the nested-ids
@@ -237,7 +224,7 @@ impl TryFromKernel<&StructField> for ArrowField {
 ///   },
 ///   "nullable": true,
 ///   "metadata": {
-///     "parquet.field.nested.ids": {
+///     "delta.columnMapping.nested.ids": {
 ///       "array_in_map.key":           100,
 ///       "array_in_map.value":         101,
 ///       "array_in_map.value.element": 102
@@ -485,7 +472,7 @@ impl TryFromArrow<&ArrowField> for StructField {
         )?;
         if !nested_ids.is_empty() {
             kernel_metadata.insert(
-                ColumnMetadataKey::ParquetFieldNestedIds
+                ColumnMetadataKey::ColumnMappingNestedIds
                     .as_ref()
                     .to_string(),
                 MetadataValue::Other(serde_json::Value::Object(nested_ids)),
@@ -515,16 +502,13 @@ impl TryFromArrow<&ArrowField> for StructField {
 /// { "m.key": 100, "m.value": 101, "m.value.element": 102 }
 /// ```
 ///
-/// TODO: Replace `parquet.field.nested.ids` with `delta.columnMapping.nested.ids` after the
-/// protocol update. Tracking issue: <https://github.com/delta-io/delta/issues/6688>
-///
 /// [`MapArray`]: arrow::array::MapArray
 fn collect_nested_field_ids_from_arrow(
     arrow_type: &ArrowDataType,
     relative_path: &str,
     out: &mut serde_json::Map<String, serde_json::Value>,
 ) -> Result<(), ArrowError> {
-    // `parquet.field.nested.ids` only stores the nested field ids element/key/values
+    // `delta.columnMapping.nested.ids` only stores the nested field ids element/key/values
     // of list/map fields. So we only recurse into list/map here.
     let inner_fields: Vec<(&ArrowField, &str)> = match arrow_type {
         ArrowDataType::List(elem)
@@ -741,67 +725,26 @@ mod tests {
 
     #[test]
     fn test_try_into_arrow_threads_nested_ids_onto_arrow_schema() -> DeltaResult<()> {
-        for meta_key in [
-            ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
-            ColumnMetadataKey::ColumnMappingNestedIds.as_ref(),
-        ] {
-            let fixture = complex_nested_with_field_ids(meta_key);
-            let arrow_schema: ArrowSchema = (&fixture.kernel_schema).try_into_arrow()?;
+        let meta_key = ColumnMetadataKey::ColumnMappingNestedIds.as_ref();
+        let fixture = complex_nested_with_field_ids(meta_key);
+        let arrow_schema: ArrowSchema = (&fixture.kernel_schema).try_into_arrow()?;
 
-            assert_eq!(
-                arrow_schema, fixture.expected_arrow_schema,
-                "try_into_arrow should attach nested field ids for metadata key {meta_key}",
-            );
-        }
-        Ok(())
-    }
-
-    #[test]
-    fn test_try_into_arrow_delta_nested_id_key_takes_precedence() -> DeltaResult<()> {
-        let schema = array_in_map_kernel_schema([
-            (
-                ColumnMetadataKey::ColumnMappingNestedIds
-                    .as_ref()
-                    .to_string(),
-                MetadataValue::Other(test_utils::nested_ids_json(&[
-                    ("array_in_map.key", 100),
-                    ("array_in_map.value", 101),
-                    ("array_in_map.value.element", 102),
-                ])),
-            ),
-            (
-                ColumnMetadataKey::ParquetFieldNestedIds
-                    .as_ref()
-                    .to_string(),
-                MetadataValue::Other(test_utils::nested_ids_json(&[
-                    ("array_in_map.key", 900),
-                    ("array_in_map.value", 901),
-                    ("array_in_map.value.element", 902),
-                ])),
-            ),
-        ]);
-        let arrow_schema: ArrowSchema = (&schema).try_into_arrow()?;
-        let field_ids: HashMap<String, String> =
-            collect_arrow_field_metadata(&arrow_schema, PARQUET_FIELD_ID_META_KEY)
-                .into_iter()
-                .collect();
-
-        assert_eq!(field_ids.get("key").map(String::as_str), Some("100"));
-        assert_eq!(field_ids.get("value").map(String::as_str), Some("101"));
-        assert_eq!(field_ids.get("element").map(String::as_str), Some("102"));
+        assert_eq!(
+            arrow_schema, fixture.expected_arrow_schema,
+            "try_into_arrow should attach nested field ids for metadata key {meta_key}",
+        );
         Ok(())
     }
 
     #[rstest]
-    /// The whole nested ids JSON map is missing(i.e. neither `delta.columnMapping.nested.ids`
-    /// nor `parquet.field.nested.ids` are present).
+    /// The nested ids JSON map is missing (i.e. `delta.columnMapping.nested.ids` is not present).
     #[case::without_nested_id_metadata(array_in_map_kernel_schema(std::iter::empty::<(
         String,
         MetadataValue,
     )>()), /* expected_field_ids */ &[])]
     /// Only some of the nested ids are present.
     #[case::only_partial_nested_ids_match(array_in_map_kernel_schema([(
-        ColumnMetadataKey::ParquetFieldNestedIds.as_ref().to_string(),
+        ColumnMetadataKey::ColumnMappingNestedIds.as_ref().to_string(),
         MetadataValue::Other(test_utils::nested_ids_json(&[
             ("array_in_map.key", 100),
             ("array_in_map.value.element", 102),
@@ -831,7 +774,7 @@ mod tests {
     #[test]
     fn test_try_into_arrow_invalid_nested_ids_metadata_errors() {
         let schema = array_in_map_kernel_schema([(
-            ColumnMetadataKey::ParquetFieldNestedIds
+            ColumnMetadataKey::ColumnMappingNestedIds
                 .as_ref()
                 .to_string(),
             MetadataValue::String("not a json object".to_string()),
@@ -842,7 +785,7 @@ mod tests {
         );
 
         let schema = array_in_map_kernel_schema([(
-            ColumnMetadataKey::ParquetFieldNestedIds
+            ColumnMetadataKey::ColumnMappingNestedIds
                 .as_ref()
                 .to_string(),
             MetadataValue::Other(serde_json::json!({ "array_in_map.key": "oops" })),
@@ -1039,14 +982,14 @@ mod tests {
     #[test]
     fn test_try_from_arrow_aggregates_synthesized_nested_ids() {
         let fixture =
-            complex_nested_with_field_ids(ColumnMetadataKey::ParquetFieldNestedIds.as_ref());
+            complex_nested_with_field_ids(ColumnMetadataKey::ColumnMappingNestedIds.as_ref());
         let kernel_schema_from_arrow: StructType =
             (&fixture.expected_arrow_schema).try_into_kernel().unwrap();
         assert_eq!(kernel_schema_from_arrow, fixture.kernel_schema);
     }
 
     /// When the input Arrow schema has no `PARQUET:field_id` on any inner list/map field, the
-    /// resulting kernel [`StructField`] must not carry a `parquet.field.nested.ids` entry.
+    /// resulting kernel [`StructField`] must not carry a `delta.columnMapping.nested.ids` entry.
     #[test]
     fn test_try_from_arrow_no_nested_ids_when_input_lacks_field_ids() {
         let kernel_schema_without_metadata =
@@ -1060,7 +1003,7 @@ mod tests {
         let array_in_map = kernel_schema.fields().next().unwrap();
         assert!(!array_in_map
             .metadata()
-            .contains_key(ColumnMetadataKey::ParquetFieldNestedIds.as_ref()));
+            .contains_key(ColumnMetadataKey::ColumnMappingNestedIds.as_ref()));
     }
 
     /// A non-integer `PARQUET:field_id` on an inner list/map field must produce a clear error
@@ -1092,7 +1035,7 @@ mod tests {
         assert_eq!(
             kernel
                 .metadata()
-                .get(ColumnMetadataKey::ParquetFieldNestedIds.as_ref()),
+                .get(ColumnMetadataKey::ColumnMappingNestedIds.as_ref()),
             Some(&MetadataValue::Other(
                 serde_json::json!({"arr.element": 42})
             )),
@@ -1113,7 +1056,7 @@ mod tests {
         assert_eq!(
             kernel
                 .metadata()
-                .get(ColumnMetadataKey::ParquetFieldNestedIds.as_ref()),
+                .get(ColumnMetadataKey::ColumnMappingNestedIds.as_ref()),
             Some(&MetadataValue::Other(serde_json::json!({"arr.element": 7}))),
         );
         Ok(())

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -10,9 +10,10 @@
 //!
 //! These conversions can be used on both logical and physical schemas. E.g. when writing a parquet
 //! file, the default engine converts the physical kernel schema to an Arrow schema and writes the
-//! data. When transforming physical data to logical data via an [`Expression`],
-//! [`DefaultExpressionEvaluator`] converts the logical schema to an Arrow schema as the output
-//! schema.
+//! data. When transforming physical data to logical data via an
+//! [`Expression`][crate::expressions::Expression],
+//! [`DefaultExpressionEvaluator`][crate::engine::arrow_expression::DefaultExpressionEvaluator]
+//! converts the logical schema to an Arrow schema as the output schema.
 
 pub mod scalar;
 

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -2,8 +2,8 @@
 //!
 //! Two directions, used at the engine <-> kernel boundary:
 //!
-//! - **arrow -> kernel** ([`TryFromArrow`] / [`TryIntoKernel`]): an example usage is parsing a
-//!   parquet footer's Arrow schema into a kernel `StructType` for checkpoint introspection.
+//! - **arrow -> kernel** ([`TryFromArrow`] / [`TryIntoKernel`]): an example usage is converting a
+//!   checkpoint Parquet file's Arrow footer schema into a kernel `StructType` during log replay.
 //!
 //! - **kernel -> arrow** ([`TryFromKernel`] / [`TryIntoArrow`]): an example usage is materializing
 //!   a kernel `StructType` as an `ArrowSchema` to build a `RecordBatch` on the write path.
@@ -32,22 +32,15 @@ pub(crate) const MAP_ROOT_DEFAULT: &str = "key_value";
 pub(crate) const MAP_KEY_DEFAULT: &str = "key";
 pub(crate) const MAP_VALUE_DEFAULT: &str = "value";
 
-/// Converts kernel [`StructField`] metadata to Arrow field metadata format.
-///
-/// Specifically:
-/// - Transforms the `"parquet.field.id"` key (used by kernel/delta-spark) to `"PARQUET:field_id"`
-///   (the native Parquet/Arrow metadata key), enabling correct field ID handling by the
-///   Arrow/Parquet writer.
-/// - Strips the nested-ids JSON key (`"delta.columnMapping.nested.ids"`). Its content is already
-///   projected onto the synthesized list/map fields' `"PARQUET:field_id"` by
-///   [`kernel_map_array_into_arrow`].
-pub(crate) fn kernel_metadata_to_arrow_metadata(
+/// Translate a kernel [`StructField`]'s flat (non-nested) parquet field id metadata into Arrow
+/// field metadata: rewrites kernel-side `"parquet.field.id"` to arrow-side `"PARQUET:field_id"`
+/// (see [`PARQUET_FIELD_ID_META_KEY`]). All other entries pass through unchanged.
+pub(crate) fn kernel_flat_parquet_id_to_arrow(
     field: &StructField,
 ) -> Result<HashMap<String, String>, ArrowError> {
     field
         .metadata()
         .iter()
-        .filter(|(key, _)| *key != ColumnMetadataKey::ColumnMappingNestedIds.as_ref())
         .map(|(key, val)| {
             let transformed_key = if key == ColumnMetadataKey::ParquetFieldId.as_ref() {
                 PARQUET_FIELD_ID_META_KEY.to_string()
@@ -178,11 +171,10 @@ impl TryFromKernel<&StructType> for ArrowSchema {
 
 impl TryFromKernel<&StructField> for ArrowField {
     fn try_from_kernel(f: &StructField) -> Result<Self, ArrowError> {
-        let metadata = kernel_metadata_to_arrow_metadata(f)?;
-        // For Array/Map fields, recurse via `kernel_map_array_into_arrow` so that any
-        // `delta.columnMapping.nested.ids` metadata on this StructField gets threaded onto the
-        // synthesized element/key/value Arrow fields. Other types (Struct, Primitive, Variant)
-        // keep using the default conversion.
+        let mut metadata = kernel_flat_parquet_id_to_arrow(f)?;
+        // `ColumnMetadataKey::ColumnMappingNestedIds` is a kernel-side metadata key, not
+        // retained in Arrow; its content is processed by `kernel_map_array_into_arrow`.
+        metadata.remove(ColumnMetadataKey::ColumnMappingNestedIds.as_ref());
         let arrow_type = match f.data_type() {
             DataType::Array(_) | DataType::Map(_) => {
                 kernel_map_array_into_arrow(f, f.name(), f.data_type())?

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -7,6 +7,12 @@
 //!
 //! - **kernel -> arrow** ([`TryFromKernel`] / [`TryIntoArrow`]): an example usage is materializing
 //!   a kernel `StructType` as an `ArrowSchema` to build a `RecordBatch` on the write path.
+//!
+//! These conversions can be used on both logical and physical schemas. E.g. when writing a parquet
+//! file, the default engine converts the physical kernel schema to an Arrow schema and writes the
+//! data. When transforming physical data to logical data via an [`Expression`],
+//! [`DefaultExpressionEvaluator`] converts the logical schema to an Arrow schema as the output
+//! schema.
 
 pub mod scalar;
 

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -180,28 +180,23 @@ impl TryFromKernel<&StructField> for ArrowField {
     fn try_from_kernel(f: &StructField) -> Result<Self, ArrowError> {
         let mut metadata = kernel_flat_parquet_id_to_arrow(f)?;
         // `ColumnMetadataKey::ColumnMappingNestedIds` is a kernel-side metadata key, not
-        // retained in Arrow; its content is processed by `kernel_map_array_into_arrow`.
+        // retained in Arrow; its content is processed by `kernel_field_into_arrow`.
         metadata.remove(ColumnMetadataKey::ColumnMappingNestedIds.as_ref());
-        let arrow_type = match f.data_type() {
-            DataType::Array(_) | DataType::Map(_) => {
-                kernel_map_array_into_arrow(f, f.name(), f.data_type())?
-            }
-            _ => f.data_type().try_into_arrow()?,
-        };
-        let field = ArrowField::new(f.name(), arrow_type, f.is_nullable()).with_metadata(metadata);
-
-        Ok(field)
+        let arrow_type = kernel_field_into_arrow(f, f.name(), f.data_type())?;
+        Ok(ArrowField::new(f.name(), arrow_type, f.is_nullable()).with_metadata(metadata))
     }
 }
 
-/// Recursive Arrow-type builder that propagates nested field IDs from `ancestor`'s
-/// `delta.columnMapping.nested.ids` metadata onto the synthesized `element` / `key` / `value`
-/// Arrow fields.
+/// Recursive Arrow-type builder. For Array/Map types, it propagates nested field IDs from
+/// `ancestor`'s `delta.columnMapping.nested.ids` metadata onto the synthesized
+/// `element` / `key` / `value` Arrow fields. For Struct/Primitive/Variant types it delegates to
+/// the standard `DataType -> ArrowDataType` conversion.
 ///
 /// # Parameters
 /// - `ancestor`: the nearest ancestor kernel [`StructField`]; its metadata holds the nested-ids
-///   JSON map.
-/// - `relative_path`: dot-chained path rooted at `ancestor.name()`.
+///   JSON map. Unused for Struct/Primitive/Variant types, only consulted on Array/Map recursion.
+/// - `relative_path`: dot-chained path rooted at `ancestor.name()`. Only consulted for Array/Map
+///   recursion.
 /// - `datatype`: the kernel data type at the current position.
 ///
 /// # Example
@@ -228,7 +223,7 @@ impl TryFromKernel<&StructField> for ArrowField {
 /// }
 /// ```
 ///
-/// Calling `kernel_map_array_into_arrow(field, "array_in_map", &field.data_type())`
+/// Calling `kernel_field_into_arrow(field, "array_in_map", &field.data_type())`
 /// produces this Arrow `DataType` (each synthesized `key`/`value`/`element` Arrow Field
 /// carries `PARQUET:field_id` in its `metadata`, looked up from the JSON above):
 ///
@@ -263,7 +258,7 @@ impl TryFromKernel<&StructField> for ArrowField {
 ///   }
 /// }
 /// ```
-fn kernel_map_array_into_arrow(
+fn kernel_field_into_arrow(
     ancestor: &StructField,
     relative_path: &str,
     datatype: &DataType,
@@ -273,7 +268,7 @@ fn kernel_map_array_into_arrow(
             let element_path = format!("{relative_path}.{LIST_ARRAY_ROOT}");
             let element_id = lookup_nested_field_id(ancestor, &element_path)?;
             let arrow_element_type =
-                kernel_map_array_into_arrow(ancestor, &element_path, a.element_type())?;
+                kernel_field_into_arrow(ancestor, &element_path, a.element_type())?;
             // Kernel's array element field is anonymous; we use `LIST_ARRAY_ROOT` as the
             // synthesized field name by convention. Same below for map's `key`/`value` fields.
             let arrow_element_field =
@@ -286,9 +281,8 @@ fn kernel_map_array_into_arrow(
             let value_path = format!("{relative_path}.{MAP_VALUE_DEFAULT}");
             let key_id = lookup_nested_field_id(ancestor, &key_path)?;
             let value_id = lookup_nested_field_id(ancestor, &value_path)?;
-            let arrow_key_type = kernel_map_array_into_arrow(ancestor, &key_path, m.key_type())?;
-            let arrow_value_type =
-                kernel_map_array_into_arrow(ancestor, &value_path, m.value_type())?;
+            let arrow_key_type = kernel_field_into_arrow(ancestor, &key_path, m.key_type())?;
+            let arrow_value_type = kernel_field_into_arrow(ancestor, &value_path, m.value_type())?;
             // Map keys are never nullable.
             let arrow_key_field = ArrowField::new(MAP_KEY_DEFAULT, arrow_key_type, false)
                 .with_metadata(parquet_field_id_metadata(key_id));
@@ -483,7 +477,7 @@ impl TryFromArrow<&ArrowField> for StructField {
     }
 }
 
-/// Inverse of [`kernel_map_array_into_arrow`]: walks `arrow_type` and aggregates
+/// Inverse of [`kernel_field_into_arrow`]: walks `arrow_type` and aggregates
 /// `PARQUET:field_id` from the element/key/value fields of any list/map, keyed by dot-path
 /// rooted at `relative_path`.
 ///

--- a/kernel/src/engine/arrow_expression/apply_schema.rs
+++ b/kernel/src/engine/arrow_expression/apply_schema.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use itertools::Itertools;
 
 use super::super::arrow_conversion::{
-    kernel_flat_parquet_id_to_arrow, lookup_nested_field_id, parquet_field_id_metadata,
+    kernel_flat_parquet_id_to_arrow_metadata, lookup_nested_field_id, parquet_field_id_metadata,
     LIST_ARRAY_ROOT, MAP_KEY_DEFAULT, MAP_VALUE_DEFAULT,
 };
 use super::super::arrow_utils::make_arrow_error;
@@ -82,7 +82,7 @@ fn transform_struct(
                 Some(target_field),
                 &target_field.name,
             )?;
-            let mut arrow_metadata = kernel_flat_parquet_id_to_arrow(target_field)?;
+            let mut arrow_metadata = kernel_flat_parquet_id_to_arrow_metadata(target_field)?;
             // `ColumnMetadataKey::ColumnMappingNestedIds` is a kernel-side metadata key, not
             // retained in Arrow; its content is processed by `apply_schema_to_list` /
             // `apply_schema_to_map`.

--- a/kernel/src/engine/arrow_expression/apply_schema.rs
+++ b/kernel/src/engine/arrow_expression/apply_schema.rs
@@ -129,44 +129,9 @@ fn apply_schema_to_struct(array: &dyn Array, kernel_fields: &Schema) -> DeltaRes
     transform_struct(sa, kernel_fields.fields())
 }
 
-// Apply a kernel [`ArrayType`] to an Arrow [`ListArray`].
-// This function will deconstruct the array, then rebuild the mapped version, and set parquet field
-// id.
-//
-// # Example
-//
-// The blocks below show only the *schema* of the input and output ListArrays. Data values,
-// offsets, and the null buffer pass through unchanged.
-//
-// Given an ancestor [`StructField`] `arr: array<int>` whose metadata has
-// `parquet.field.nested.ids: { "arr.element": 42 }`, and an input ListArray with schema:
-//
-// ```json
-// {
-//   "type": "list",
-//   "element": {
-//     "name": "element",
-//     "type": "int32",
-//     "nullable": true,
-//     "metadata": { /* anything; replaced by kernel-derived metadata below */ }
-//   }
-// }
-// ```
-//
-// calling `apply_schema_to_list(input, &ArrayType::new(int, true), Some(arr), "arr")` produces
-// a ListArray with the same data and the rebuilt schema:
-//
-// ```json
-// {
-//   "type": "list",
-//   "element": {
-//     "name": "element",
-//     "type": "int32",
-//     "nullable": true,
-//     "metadata": { "PARQUET:field_id": "42" }
-//   }
-// }
-// ```
+// Rebuild a [`ListArray`] under the contract of [`apply_schema_to_inner`] (see that fn's doc
+// for an example). The inner value field's `PARQUET:field_id` (if any) is looked up at
+// `<relative_path>.element` on `nearest_ancestor_struct_field`'s nested-ids JSON.
 fn apply_schema_to_list(
     array: &dyn Array,
     target_inner_type: &ArrayType,
@@ -178,11 +143,8 @@ fn apply_schema_to_list(
             "Arrow claimed to be a list but isn't a ListArray",
         ));
     };
-    // 1. Deconstruct the input ListArray into its parts.
     let (arrow_element_field, offset_buffer, arrow_values, nulls) = la.clone().into_parts();
 
-    // 2. Look up the synthesized `element` field's nested id from the ancestor, and recurse on the
-    //    values column.
     let element_path = format!("{relative_path}.{LIST_ARRAY_ROOT}");
     let element_id = nearest_ancestor_struct_field
         .map(|f| lookup_nested_field_id(f, &element_path))
@@ -195,12 +157,8 @@ fn apply_schema_to_list(
         &element_path,
     )?;
 
-    // 3. Rebuild the element field. `apply_schema` applies kernel's schema, so the input arrow
-    //    field's metadata comes entirely from the kernel side. Parquet field ID is the only
-    //    metadata that should be set on the element field here. Since kernel's
-    //    `ArrayType::element_type` is a bare `DataType` (not a `StructField`), there is no
-    //    per-element metadata on the kernel side. The element's Parquet field ID comes from the
-    //    ancestor's metadata.
+    // Bare element type carries no kernel-side metadata; `PARQUET:field_id` is the only
+    // metadata to set, looked up from the ancestor's nested-ids JSON.
     let transformed_arrow_element_field = ArrowField::new(
         arrow_element_field.name(),
         transformed_arrow_values.data_type().clone(),
@@ -215,56 +173,9 @@ fn apply_schema_to_list(
     )?)
 }
 
-// Apply a kernel [`MapType`] to an Arrow [`MapArray`].
-// Deconstruct a map, then rebuild it with the specified target kernel type,
-// and set parquet field id on the synthesized `key`/`value` Arrow fields.
-//
-// # Example
-//
-// The blocks below show only the *schema* of the input and output MapArrays. Data values,
-// offsets, and null buffers pass through unchanged.
-// input.
-//
-// Given an ancestor StructField `m: map<int, int>` whose metadata has
-// `parquet.field.nested.ids: { "m.key": 100, "m.value": 101 }`, and an input MapArray with
-// schema:
-//
-// ```json
-// {
-//   "type": "map",
-//   "keys_sorted": false,
-//   "entries": {
-//     "name": "key_value",
-//     "type": "struct",
-//     "fields": [
-//       { "name": "k", "type": "int32", "nullable": false,
-//         "metadata": { /* anything; will bereplaced */ } },
-//       { "name": "v", "type": "int32", "nullable": true,
-//         "metadata": { /* anything; will bereplaced */ } }
-//     ]
-//   }
-// }
-// ```
-//
-// calling `apply_schema_to_map(input, &MapType::new(int, int, true), Some(m), "m")` produces a
-// MapArray with the same data and the rebuilt schema:
-//
-// ```json
-// {
-//   "type": "map",
-//   "keys_sorted": false,
-//   "entries": {
-//     "name": "key_value",
-//     "type": "struct",
-//     "fields": [
-//       { "name": "k", "type": "int32", "nullable": false,
-//         "metadata": { "PARQUET:field_id": "100" } },
-//       { "name": "v", "type": "int32", "nullable": true,
-//         "metadata": { "PARQUET:field_id": "101" } }
-//     ]
-//   }
-// }
-// ```
+// Rebuild a [`MapArray`] under the contract of [`apply_schema_to_inner`] (see that fn's doc
+// for an example). The inner key and value fields' `PARQUET:field_id` (if any) are looked
+// up at `<relative_path>.key` and `<relative_path>.value` on `ancestor`'s nested-ids JSON.
 fn apply_schema_to_map(
     array: &dyn Array,
     kernel_map_type: &MapType,
@@ -276,7 +187,7 @@ fn apply_schema_to_map(
             "Arrow claimed to be a map but isn't a MapArray",
         ));
     };
-    // 1. Deconstruct the input MapArray and its inner entries struct.
+    // Deconstruct the input MapArray and its inner entries struct.
     let (arrow_map_field, offset_buffer, arrow_map_struct_array, nulls, ordered) =
         ma.clone().into_parts();
     let (arrow_input_fields, mut arrow_cols, arrow_struct_nulls) =
@@ -292,7 +203,7 @@ fn apply_schema_to_map(
     let arrow_input_key_name = arrow_input_fields[0].name().clone();
     let arrow_input_value_name = arrow_input_fields[1].name().clone();
 
-    // 2. Look up nested field ids for the synthesized key/value fields from the ancestor, and
+    // Look up nested field ids for the synthesized key/value fields from the ancestor, and
     //    recurse on each column.
     let key_path = format!("{relative_path}.{MAP_KEY_DEFAULT}");
     let value_path = format!("{relative_path}.{MAP_VALUE_DEFAULT}");
@@ -317,13 +228,8 @@ fn apply_schema_to_map(
         &value_path,
     )?;
 
-    // 3. Rebuild the key/value fields, repack the entries struct, and wrap in a new MapArray.
-    //    `apply_schema` applies kernel's schema, so the synthesized fields' metadata comes entirely
-    //    from the kernel side. Parquet field IDs are the only metadata that should be set on the
-    //    key/value fields here. Since kernel's `MapType::{key,value}_type` are bare `DataType`s
-    //    (not `StructField`s), there is no per-key/per-value metadata on the kernel side. The IDs
-    //    come from the ancestor's metadata.
-    // Map keys are never nullable.
+    // Bare key/value types carry no kernel-side metadata; `PARQUET:field_id` is the only
+    // metadata to set, looked up from the ancestor's nested-ids JSON.
     let arrow_key_field = ArrowField::new(
         arrow_input_key_name,
         transformed_arrow_key.data_type().clone(),
@@ -361,19 +267,87 @@ pub(crate) fn apply_schema_to(array: &ArrayRef, schema: &DataType) -> DeltaResul
     apply_schema_to_inner(array, schema, None, "")
 }
 
-/// Recursive worker for `apply_schema_to`. Rebuilds `array` to match `schema`, threading nested
-/// field-id metadata onto the synthesized `element` / `key` / `value` Arrow fields of any
-/// list/map types it visits.
+/// Recursive worker for [`apply_schema_to`]. Rebuilds `array` recursively so that its schema is
+/// aligned with the kernel-side schema. This will try to change the name, nullability, and
+/// metadata of the input `array` to match the kernel-side schema. Data values, offsets, and null
+/// buffers pass through unchanged. Specifically:
 ///
-/// # Parameters
-/// - `array`: the Arrow input to transform.
-/// - `schema`: the target kernel data type.
-/// - `ancestor`: the nearest ancestor kernel [`StructField`]; its metadata holds the nested-ids
-///   JSON map.
-/// - `relative_path`: dot-chained path rooted at `ancestor`'s name.
+/// - Name: use the kernel-side name when kernel has one (e.g. on a [`StructField`]); retain the
+///   input Arrow name when kernel has none (e.g. on a list `element` or map `key`/`value`; kernel's
+///   [`ArrayType::element_type`] / [`MapType::key_type`] / [`MapType::value_type`] are bare
+///   [`DataType`]s with no name).
+/// - Nullability: use the kernel-side nullability.
 ///
-/// See [`crate::engine::arrow_conversion::lookup_nested_field_id`] for an example of the
-/// `(ancestor, path) -> id` lookup.
+/// `ancestor` is the nearest ancestor kernel [`StructField`]; its metadata holds the nested-ids
+/// JSON map (`None` at the top level). `relative_path` is the dot-chained path rooted at
+/// `ancestor`'s name (empty at the top level).
+///
+/// # Example
+///
+/// `arr_in_map: map<int, array<int>>`. Kernel side dictates the top-level field's name,
+/// nullability, and metadata. Inner field names
+/// are producer-defined and pass through unchanged; their nullability comes from the kernel
+/// side.
+///
+/// Kernel [`StructField`]:
+///
+/// ```json
+/// {
+///   "name": "arr_in_map",
+///   "type": {
+///     "type": "map",
+///     "keyType": "integer",
+///     "valueType": {"type": "array", "elementType": "integer", "containsNull": true},
+///     "valueContainsNull": true
+///   },
+///   "nullable": true,
+///   "metadata": {
+///     "parquet.field.id": 1,
+///     "parquet.field.nested.ids": {
+///       "arr_in_map.key": 100,
+///       "arr_in_map.value": 101,
+///       "arr_in_map.value.element": 102
+///     }
+///   }
+/// }
+/// ```
+///
+/// Input Arrow schema (custom names, mismatched nullability, stale field id):
+///
+/// ```json
+/// {
+///   "name": "stale_name", "type": "map", "nullable": false,
+///   "metadata": {"PARQUET:field_id": "999"},
+///   "entries": {
+///     "name": "custom_entries", "type": "struct", "nullable": false,
+///     "fields": [
+///       {"name": "custom_key", "type": "int32", "nullable": false},
+///       {"name": "custom_value", "type": "list", "nullable": false,
+///        "element": {"name": "custom_item", "type": "int32", "nullable": false}}
+///     ]
+///   }
+/// }
+/// ```
+///
+/// Rebuilt Arrow schema:
+///
+/// ```json
+/// {
+///   "name": "arr_in_map", "type": "map", "nullable": true,
+///   "metadata": {"PARQUET:field_id": "1"},
+///   "entries": {
+///     "name": "custom_entries", "type": "struct", "nullable": false,
+///     "fields": [
+///       {"name": "custom_key", "type": "int32", "nullable": false,
+///        "metadata": {"PARQUET:field_id": "100"}},
+///       {"name": "custom_value", "type": "list", "nullable": true,
+///        "metadata": {"PARQUET:field_id": "101"},
+///        "element": {"name": "custom_item", "type": "int32", "nullable": true,
+///                    "metadata": {"PARQUET:field_id": "102"}}}
+///     ]
+///   }
+/// }
+/// ```
 fn apply_schema_to_inner(
     array: &ArrayRef,
     schema: &DataType,

--- a/kernel/src/engine/arrow_expression/apply_schema.rs
+++ b/kernel/src/engine/arrow_expression/apply_schema.rs
@@ -132,6 +132,41 @@ fn apply_schema_to_struct(array: &dyn Array, kernel_fields: &Schema) -> DeltaRes
 // Apply a kernel [`ArrayType`] to an Arrow [`ListArray`].
 // This function will deconstruct the array, then rebuild the mapped version, and set parquet field
 // id.
+//
+// # Example
+//
+// The blocks below show only the *schema* of the input and output ListArrays. Data values,
+// offsets, and the null buffer pass through unchanged.
+//
+// Given an ancestor [`StructField`] `arr: array<int>` whose metadata has
+// `parquet.field.nested.ids: { "arr.element": 42 }`, and an input ListArray with schema:
+//
+// ```json
+// {
+//   "type": "list",
+//   "element": {
+//     "name": "element",
+//     "type": "int32",
+//     "nullable": true,
+//     "metadata": { /* anything; replaced by kernel-derived metadata below */ }
+//   }
+// }
+// ```
+//
+// calling `apply_schema_to_list(input, &ArrayType::new(int, true), Some(arr), "arr")` produces
+// a ListArray with the same data and the rebuilt schema:
+//
+// ```json
+// {
+//   "type": "list",
+//   "element": {
+//     "name": "element",
+//     "type": "int32",
+//     "nullable": true,
+//     "metadata": { "PARQUET:field_id": "42" }
+//   }
+// }
+// ```
 fn apply_schema_to_list(
     array: &dyn Array,
     target_inner_type: &ArrayType,
@@ -183,6 +218,53 @@ fn apply_schema_to_list(
 // Apply a kernel [`MapType`] to an Arrow [`MapArray`].
 // Deconstruct a map, then rebuild it with the specified target kernel type,
 // and set parquet field id on the synthesized `key`/`value` Arrow fields.
+//
+// # Example
+//
+// The blocks below show only the *schema* of the input and output MapArrays. Data values,
+// offsets, and null buffers pass through unchanged.
+// input.
+//
+// Given an ancestor StructField `m: map<int, int>` whose metadata has
+// `parquet.field.nested.ids: { "m.key": 100, "m.value": 101 }`, and an input MapArray with
+// schema:
+//
+// ```json
+// {
+//   "type": "map",
+//   "keys_sorted": false,
+//   "entries": {
+//     "name": "key_value",
+//     "type": "struct",
+//     "fields": [
+//       { "name": "k", "type": "int32", "nullable": false,
+//         "metadata": { /* anything; will bereplaced */ } },
+//       { "name": "v", "type": "int32", "nullable": true,
+//         "metadata": { /* anything; will bereplaced */ } }
+//     ]
+//   }
+// }
+// ```
+//
+// calling `apply_schema_to_map(input, &MapType::new(int, int, true), Some(m), "m")` produces a
+// MapArray with the same data and the rebuilt schema:
+//
+// ```json
+// {
+//   "type": "map",
+//   "keys_sorted": false,
+//   "entries": {
+//     "name": "key_value",
+//     "type": "struct",
+//     "fields": [
+//       { "name": "k", "type": "int32", "nullable": false,
+//         "metadata": { "PARQUET:field_id": "100" } },
+//       { "name": "v", "type": "int32", "nullable": true,
+//         "metadata": { "PARQUET:field_id": "101" } }
+//     ]
+//   }
+// }
+// ```
 fn apply_schema_to_map(
     array: &dyn Array,
     kernel_map_type: &MapType,

--- a/kernel/src/engine/arrow_expression/apply_schema.rs
+++ b/kernel/src/engine/arrow_expression/apply_schema.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use itertools::Itertools;
 
 use super::super::arrow_conversion::{
-    kernel_metadata_to_arrow_metadata, lookup_nested_field_id, parquet_field_id_metadata,
+    kernel_flat_parquet_id_to_arrow, lookup_nested_field_id, parquet_field_id_metadata,
     LIST_ARRAY_ROOT, MAP_KEY_DEFAULT, MAP_VALUE_DEFAULT,
 };
 use super::super::arrow_utils::make_arrow_error;
@@ -18,7 +18,7 @@ use crate::arrow::datatypes::{
 use crate::engine::ensure_data_types::{ensure_data_types, ValidationMode};
 use crate::error::{DeltaResult, Error};
 use crate::parquet::arrow::PARQUET_FIELD_ID_META_KEY;
-use crate::schema::{ArrayType, DataType, MapType, Schema, StructField};
+use crate::schema::{ArrayType, ColumnMetadataKey, DataType, MapType, Schema, StructField};
 
 // Apply a schema to an array. The array _must_ be a `StructArray`. Returns a `RecordBatch` where
 // the names of fields, nullable, and metadata in the struct have been transformed to match those
@@ -82,7 +82,11 @@ fn transform_struct(
                 Some(target_field),
                 &target_field.name,
             )?;
-            let arrow_metadata = kernel_metadata_to_arrow_metadata(target_field)?;
+            let mut arrow_metadata = kernel_flat_parquet_id_to_arrow(target_field)?;
+            // `ColumnMetadataKey::ColumnMappingNestedIds` is a kernel-side metadata key, not
+            // retained in Arrow; its content is processed by `apply_schema_to_list` /
+            // `apply_schema_to_map`.
+            arrow_metadata.remove(ColumnMetadataKey::ColumnMappingNestedIds.as_ref());
             // If both the input field and the target field carry a field ID they must agree,
             // otherwise we would silently overwrite one field ID with another.
             if let (Some(input_id), Some(target_id)) = (

--- a/kernel/src/engine/arrow_expression/apply_schema.rs
+++ b/kernel/src/engine/arrow_expression/apply_schema.rs
@@ -265,7 +265,7 @@ fn apply_schema_to_map(
     )?)
 }
 
-// apply `schema` to `array`. This handles renaming, and adjusting nullability and metadata. if the
+// Apply `schema` to `array`. This handles renaming, and adjusting nullability and metadata. if the
 // actual data types don't match, this will return an error.
 pub(crate) fn apply_schema_to(array: &ArrayRef, schema: &DataType) -> DeltaResult<ArrayRef> {
     apply_schema_to_inner(array, schema, None, "")

--- a/kernel/src/engine/arrow_expression/apply_schema.rs
+++ b/kernel/src/engine/arrow_expression/apply_schema.rs
@@ -4,7 +4,10 @@ use std::sync::Arc;
 
 use itertools::Itertools;
 
-use super::super::arrow_conversion::kernel_metadata_to_arrow_metadata;
+use super::super::arrow_conversion::{
+    kernel_metadata_to_arrow_metadata, lookup_nested_field_id, parquet_field_id_metadata,
+    LIST_ARRAY_ROOT, MAP_KEY_DEFAULT, MAP_VALUE_DEFAULT,
+};
 use super::super::arrow_utils::make_arrow_error;
 use crate::arrow::array::{
     Array, ArrayRef, AsArray, ListArray, MapArray, RecordBatch, StructArray,
@@ -73,7 +76,12 @@ fn transform_struct(
         .zip(target_fields)
         .map(|((sa_col, input_field), target_field)| -> DeltaResult<_> {
             let target_field = target_field.borrow();
-            let transformed_col = apply_schema_to(&sa_col, target_field.data_type())?;
+            let transformed_col = apply_schema_to_inner(
+                &sa_col,
+                target_field.data_type(),
+                Some(target_field),
+                &target_field.name,
+            )?;
             let arrow_metadata = kernel_metadata_to_arrow_metadata(target_field)?;
             // If both the input field and the target field carry a field ID they must agree,
             // otherwise we would silently overwrite one field ID with another.
@@ -99,7 +107,7 @@ fn transform_struct(
     let (transformed_fields, transformed_cols): (Vec<ArrowField>, Vec<ArrayRef>) =
         result_iter.process_results(|iter| iter.unzip())?;
     if transformed_cols.len() != input_col_count {
-        return Err(Error::InternalError(format!(
+        return Err(Error::internal_error(format!(
             "Passed struct had {input_col_count} columns, but transformed column has {}",
             transformed_cols.len()
         )));
@@ -121,76 +129,180 @@ fn apply_schema_to_struct(array: &dyn Array, kernel_fields: &Schema) -> DeltaRes
     transform_struct(sa, kernel_fields.fields())
 }
 
-// deconstruct the array, then rebuild the mapped version
+// Apply a kernel [`ArrayType`] to an Arrow [`ListArray`].
+// This function will deconstruct the array, then rebuild the mapped version, and set parquet field
+// id.
 fn apply_schema_to_list(
     array: &dyn Array,
     target_inner_type: &ArrayType,
+    nearest_ancestor_struct_field: Option<&StructField>,
+    relative_path: &str,
 ) -> DeltaResult<ListArray> {
     let Some(la) = array.as_list_opt() else {
         return Err(make_arrow_error(
             "Arrow claimed to be a list but isn't a ListArray",
         ));
     };
-    let (field, offset_buffer, values, nulls) = la.clone().into_parts();
+    // 1. Deconstruct the input ListArray into its parts.
+    let (arrow_element_field, offset_buffer, arrow_values, nulls) = la.clone().into_parts();
 
-    let transformed_values = apply_schema_to(&values, &target_inner_type.element_type)?;
-    let transformed_field = ArrowField::new(
-        field.name(),
-        transformed_values.data_type().clone(),
+    // 2. Look up the synthesized `element` field's nested id from the ancestor, and recurse on the
+    //    values column.
+    let element_path = format!("{relative_path}.{LIST_ARRAY_ROOT}");
+    let element_id = nearest_ancestor_struct_field
+        .map(|f| lookup_nested_field_id(f, &element_path))
+        .transpose()?
+        .flatten();
+    let transformed_arrow_values = apply_schema_to_inner(
+        &arrow_values,
+        &target_inner_type.element_type,
+        nearest_ancestor_struct_field,
+        &element_path,
+    )?;
+
+    // 3. Rebuild the element field. `apply_schema` applies kernel's schema, so the input arrow
+    //    field's metadata comes entirely from the kernel side. Parquet field ID is the only
+    //    metadata that should be set on the element field here. Since kernel's
+    //    `ArrayType::element_type` is a bare `DataType` (not a `StructField`), there is no
+    //    per-element metadata on the kernel side. The element's Parquet field ID comes from the
+    //    ancestor's metadata.
+    let transformed_arrow_element_field = ArrowField::new(
+        arrow_element_field.name(),
+        transformed_arrow_values.data_type().clone(),
         target_inner_type.contains_null,
-    );
+    )
+    .with_metadata(parquet_field_id_metadata(element_id));
     Ok(ListArray::try_new(
-        Arc::new(transformed_field),
+        Arc::new(transformed_arrow_element_field),
         offset_buffer,
-        transformed_values,
+        transformed_arrow_values,
         nulls,
     )?)
 }
 
-// deconstruct a map, and rebuild it with the specified target kernel type
-fn apply_schema_to_map(array: &dyn Array, kernel_map_type: &MapType) -> DeltaResult<MapArray> {
+// Apply a kernel [`MapType`] to an Arrow [`MapArray`].
+// Deconstruct a map, then rebuild it with the specified target kernel type,
+// and set parquet field id on the synthesized `key`/`value` Arrow fields.
+fn apply_schema_to_map(
+    array: &dyn Array,
+    kernel_map_type: &MapType,
+    ancestor: Option<&StructField>,
+    relative_path: &str,
+) -> DeltaResult<MapArray> {
     let Some(ma) = array.as_map_opt() else {
         return Err(make_arrow_error(
             "Arrow claimed to be a map but isn't a MapArray",
         ));
     };
-    let (map_field, offset_buffer, map_struct_array, nulls, ordered) = ma.clone().into_parts();
-    let target_fields = map_struct_array
-        .fields()
-        .iter()
-        .zip([&kernel_map_type.key_type, &kernel_map_type.value_type])
-        .zip([false, kernel_map_type.value_contains_null])
-        .map(|((arrow_field, target_type), nullable)| {
-            StructField::new(arrow_field.name(), target_type.clone(), nullable)
-        });
+    // 1. Deconstruct the input MapArray and its inner entries struct.
+    let (arrow_map_field, offset_buffer, arrow_map_struct_array, nulls, ordered) =
+        ma.clone().into_parts();
+    let (arrow_input_fields, mut arrow_cols, arrow_struct_nulls) =
+        arrow_map_struct_array.into_parts();
+    if arrow_cols.len() != 2 || arrow_input_fields.len() != 2 {
+        return Err(Error::internal_error(format!(
+            "Map entries struct must have exactly 2 columns (key, value), got {}",
+            arrow_cols.len()
+        )));
+    }
+    let arrow_value_col = arrow_cols.remove(1);
+    let arrow_key_col = arrow_cols.remove(0);
+    let arrow_input_key_name = arrow_input_fields[0].name().clone();
+    let arrow_input_value_name = arrow_input_fields[1].name().clone();
 
-    // Arrow puts the key type/val as the first field/col and the value type/val as the second. So
-    // we just transform like a 'normal' struct, but we know there are two fields/cols and we
-    // specify the key/value types as the target type iterator.
-    let transformed_map_struct_array = transform_struct(&map_struct_array, target_fields)?;
+    // 2. Look up nested field ids for the synthesized key/value fields from the ancestor, and
+    //    recurse on each column.
+    let key_path = format!("{relative_path}.{MAP_KEY_DEFAULT}");
+    let value_path = format!("{relative_path}.{MAP_VALUE_DEFAULT}");
+    let key_id = ancestor
+        .map(|a| lookup_nested_field_id(a, &key_path))
+        .transpose()?
+        .flatten();
+    let value_id = ancestor
+        .map(|a| lookup_nested_field_id(a, &value_path))
+        .transpose()?
+        .flatten();
+    let transformed_arrow_key = apply_schema_to_inner(
+        &arrow_key_col,
+        &kernel_map_type.key_type,
+        ancestor,
+        &key_path,
+    )?;
+    let transformed_arrow_value = apply_schema_to_inner(
+        &arrow_value_col,
+        &kernel_map_type.value_type,
+        ancestor,
+        &value_path,
+    )?;
 
-    let transformed_map_field = ArrowField::new(
-        map_field.name().clone(),
-        transformed_map_struct_array.data_type().clone(),
-        map_field.is_nullable(),
+    // 3. Rebuild the key/value fields, repack the entries struct, and wrap in a new MapArray.
+    //    `apply_schema` applies kernel's schema, so the synthesized fields' metadata comes entirely
+    //    from the kernel side. Parquet field IDs are the only metadata that should be set on the
+    //    key/value fields here. Since kernel's `MapType::{key,value}_type` are bare `DataType`s
+    //    (not `StructField`s), there is no per-key/per-value metadata on the kernel side. The IDs
+    //    come from the ancestor's metadata.
+    // Map keys are never nullable.
+    let arrow_key_field = ArrowField::new(
+        arrow_input_key_name,
+        transformed_arrow_key.data_type().clone(),
+        false,
+    )
+    .with_metadata(parquet_field_id_metadata(key_id));
+    let arrow_value_field = ArrowField::new(
+        arrow_input_value_name,
+        transformed_arrow_value.data_type().clone(),
+        kernel_map_type.value_contains_null,
+    )
+    .with_metadata(parquet_field_id_metadata(value_id));
+    let arrow_entries_struct = StructArray::try_new(
+        vec![arrow_key_field.clone(), arrow_value_field.clone()].into(),
+        vec![transformed_arrow_key, transformed_arrow_value],
+        arrow_struct_nulls,
+    )?;
+    let arrow_entries_field = ArrowField::new(
+        arrow_map_field.name(),
+        ArrowDataType::Struct(vec![arrow_key_field, arrow_value_field].into()),
+        arrow_map_field.is_nullable(),
     );
     Ok(MapArray::try_new(
-        Arc::new(transformed_map_field),
+        Arc::new(arrow_entries_field),
         offset_buffer,
-        transformed_map_struct_array,
+        arrow_entries_struct,
         nulls,
         ordered,
     )?)
 }
 
 // apply `schema` to `array`. This handles renaming, and adjusting nullability and metadata. if the
-// actual data types don't match, this will return an error
+// actual data types don't match, this will return an error.
 pub(crate) fn apply_schema_to(array: &ArrayRef, schema: &DataType) -> DeltaResult<ArrayRef> {
+    apply_schema_to_inner(array, schema, None, "")
+}
+
+/// Recursive worker for `apply_schema_to`. Rebuilds `array` to match `schema`, threading nested
+/// field-id metadata onto the synthesized `element` / `key` / `value` Arrow fields of any
+/// list/map types it visits.
+///
+/// # Parameters
+/// - `array`: the Arrow input to transform.
+/// - `schema`: the target kernel data type.
+/// - `ancestor`: the nearest ancestor kernel [`StructField`]; its metadata holds the nested-ids
+///   JSON map.
+/// - `relative_path`: dot-chained path rooted at `ancestor`'s name.
+///
+/// See [`crate::engine::arrow_conversion::lookup_nested_field_id`] for an example of the
+/// `(ancestor, path) -> id` lookup.
+fn apply_schema_to_inner(
+    array: &ArrayRef,
+    schema: &DataType,
+    ancestor: Option<&StructField>,
+    relative_path: &str,
+) -> DeltaResult<ArrayRef> {
     use DataType::*;
     let array: ArrayRef = match schema {
         Struct(stype) => Arc::new(apply_schema_to_struct(array, stype)?),
-        Array(atype) => Arc::new(apply_schema_to_list(array, atype)?),
-        Map(mtype) => Arc::new(apply_schema_to_map(array, mtype)?),
+        Array(atype) => Arc::new(apply_schema_to_list(array, atype, ancestor, relative_path)?),
+        Map(mtype) => Arc::new(apply_schema_to_map(array, mtype, ancestor, relative_path)?),
         _ => {
             ensure_data_types(schema, array.data_type(), ValidationMode::Full)?;
             array.clone()
@@ -201,17 +313,24 @@ pub(crate) fn apply_schema_to(array: &ArrayRef, schema: &DataType) -> DeltaResul
 
 #[cfg(test)]
 mod apply_schema_validation_tests {
+    use std::collections::HashMap;
     use std::sync::Arc;
 
+    use rstest::rstest;
+
     use super::*;
-    use crate::arrow::array::{Int32Array, StructArray};
+    use crate::arrow::array::{Int32Array, RecordBatch, StructArray};
     use crate::arrow::buffer::{BooleanBuffer, NullBuffer};
     use crate::arrow::datatypes::{
         DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
     };
     use crate::parquet::arrow::PARQUET_FIELD_ID_META_KEY;
     use crate::schema::{ColumnMetadataKey, DataType, MetadataValue, StructField, StructType};
-    use crate::utils::test_utils::assert_result_error_with_message;
+    use crate::utils::test_utils::{
+        array_in_map_arrow_data_without_field_ids, array_in_map_kernel_schema,
+        array_in_map_with_field_ids, assert_result_error_with_message,
+        collect_arrow_field_metadata, complex_nested_with_field_ids,
+    };
 
     #[test]
     fn test_apply_schema_basic_functionality() {
@@ -410,5 +529,165 @@ mod apply_schema_validation_tests {
             apply_schema_to_struct(&input_array, &target_schema),
             "conflicts with",
         );
+    }
+
+    // === Nested-id propagation tests ===
+
+    #[rstest]
+    #[case::parquet_field_nested_ids(ColumnMetadataKey::ParquetFieldNestedIds.as_ref())]
+    #[case::delta_column_mapping_nested_ids(ColumnMetadataKey::ColumnMappingNestedIds.as_ref())]
+    fn test_apply_schema_threads_nested_ids_onto_arrow_schema(#[case] meta_key: &str) {
+        let fixture = complex_nested_with_field_ids(meta_key);
+        let kernel_type = DataType::Struct(Box::new(fixture.kernel_schema));
+        let result = apply_schema(&fixture.input_arrow_data, &kernel_type).unwrap();
+
+        assert_eq!(
+            result.schema().as_ref(),
+            &fixture.expected_arrow_schema,
+            "apply_schema should attach nested field ids to synthesized map/array fields",
+        );
+    }
+
+    /// Custom field names on the input arrow schema should survive `apply_schema`. The
+    /// metadata from the input arrow schema is replaced by kernel-derived metadata.
+    #[test]
+    fn test_apply_schema_retains_synthesized_field_names_and_metadata() {
+        let one = |k: &str, v: &str| HashMap::from([(k.to_string(), v.to_string())]);
+        let input = array_in_map_arrow_data_with_custom_names_and_meta(
+            one("custom.key", "key_val"),
+            one("custom.value", "value_val"),
+            one("custom.element", "elem_val"),
+        );
+        let kernel_schema =
+            array_in_map_with_field_ids(ColumnMetadataKey::ParquetFieldNestedIds.as_ref());
+        let result = apply_schema(&input, &DataType::Struct(Box::new(kernel_schema))).unwrap();
+
+        let result_schema = result.schema();
+        let ArrowDataType::Map(entries_field, _) = result_schema.field(0).data_type() else {
+            panic!("array_in_map should remain a map");
+        };
+        assert_eq!(entries_field.name(), "custom_entries");
+        let ArrowDataType::Struct(fields) = entries_field.data_type() else {
+            panic!("map entries should remain a struct");
+        };
+        assert_eq!(fields[0].name(), "custom_key");
+        assert_eq!(fields[1].name(), "custom_value");
+        let ArrowDataType::List(element_field) = fields[1].data_type() else {
+            panic!("map value should remain a list");
+        };
+        assert_eq!(element_field.name(), "custom_item");
+
+        // Kernel-derived `PARQUET:field_id` is the *only* metadata on each synthesized field
+        // (input metadata is replaced wholesale).
+        let expect_only_field_id = |f: &ArrowField, id: &str| {
+            assert_eq!(
+                f.metadata(),
+                &HashMap::from([(PARQUET_FIELD_ID_META_KEY.to_string(), id.to_string())]),
+            );
+        };
+        expect_only_field_id(&fields[0], "100");
+        expect_only_field_id(&fields[1], "101");
+        expect_only_field_id(element_field, "102");
+    }
+
+    #[rstest]
+    /// The whole nested ids JSON map is missing(i.e. neither `delta.columnMapping.nested.ids`
+    /// nor `parquet.field.nested.ids` are present).
+    #[case::without_nested_id_metadata(array_in_map_kernel_schema(std::iter::empty::<(
+        String,
+        MetadataValue,
+    )>()), /* expected_field_ids */ &[])]
+    /// Only some of the nested ids are present.
+    #[case::only_partial_nested_ids_match(array_in_map_kernel_schema([(
+        ColumnMetadataKey::ParquetFieldNestedIds.as_ref().to_string(),
+        MetadataValue::Other(test_utils::nested_ids_json(&[
+            ("array_in_map.key", 100),
+            ("array_in_map.value.element", 102),
+            ("array_in_map.notTheKey", 999),
+        ])),
+    )]), &[("element", "102"), ("key", "100")])]
+    fn test_apply_schema_sets_field_ids_for_matched_nested_ids_only(
+        #[case] schema: StructType,
+        #[case] expected_field_ids: &[(&str, &str)],
+    ) {
+        let kernel_type = DataType::Struct(Box::new(schema));
+        let result =
+            apply_schema(&array_in_map_arrow_data_without_field_ids(), &kernel_type).unwrap();
+        let field_ids: HashMap<String, String> =
+            collect_arrow_field_metadata(result.schema().as_ref(), PARQUET_FIELD_ID_META_KEY)
+                .into_iter()
+                .collect();
+
+        assert_eq!(field_ids.len(), expected_field_ids.len());
+        for (field_name, expected_id) in expected_field_ids {
+            assert_eq!(
+                field_ids.get(*field_name).map(String::as_str),
+                Some(*expected_id),
+            );
+        }
+    }
+
+    #[rstest]
+    #[case::not_json_object(
+        MetadataValue::String("not a json object".to_string()),
+        "must be a JSON object",
+    )]
+    #[case::entry_not_an_integer(
+        MetadataValue::Other(serde_json::json!({ "array_in_map.key": "oops" })),
+        "must be an integer",
+    )]
+    fn test_apply_schema_invalid_nested_ids_metadata_errors(
+        #[case] value: MetadataValue,
+        #[case] expected_error_substring: &str,
+    ) {
+        let schema = array_in_map_kernel_schema([(
+            ColumnMetadataKey::ParquetFieldNestedIds
+                .as_ref()
+                .to_string(),
+            value,
+        )]);
+        let kernel_type = DataType::Struct(Box::new(schema));
+
+        assert_result_error_with_message(
+            apply_schema(&array_in_map_arrow_data_without_field_ids(), &kernel_type),
+            expected_error_substring,
+        );
+    }
+
+    /// Build a StructArray for `array_in_map: map<int, list<int>>` with custom Arrow names and
+    /// caller-provided metadata.
+    fn array_in_map_arrow_data_with_custom_names_and_meta(
+        key_metadata: HashMap<String, String>,
+        value_metadata: HashMap<String, String>,
+        element_metadata: HashMap<String, String>,
+    ) -> StructArray {
+        let element_field = ArrowField::new("custom_item", ArrowDataType::Int32, true)
+            .with_metadata(element_metadata);
+        let key_field =
+            ArrowField::new("custom_key", ArrowDataType::Int32, false).with_metadata(key_metadata);
+        let value_field = ArrowField::new(
+            "custom_value",
+            ArrowDataType::List(Arc::new(element_field)),
+            true,
+        )
+        .with_metadata(value_metadata);
+        let entries_field = ArrowField::new(
+            "custom_entries",
+            ArrowDataType::Struct(vec![key_field, value_field].into()),
+            false,
+        );
+        let array_in_map_field = ArrowField::new(
+            "array_in_map",
+            ArrowDataType::Map(Arc::new(entries_field), false),
+            true,
+        );
+        let input_batch =
+            RecordBatch::new_empty(Arc::new(ArrowSchema::new(vec![array_in_map_field])));
+        StructArray::try_new(
+            input_batch.schema().fields.clone(),
+            input_batch.columns().to_vec(),
+            None,
+        )
+        .unwrap()
     }
 }

--- a/kernel/src/engine/arrow_expression/apply_schema.rs
+++ b/kernel/src/engine/arrow_expression/apply_schema.rs
@@ -305,7 +305,7 @@ pub(crate) fn apply_schema_to(array: &ArrayRef, schema: &DataType) -> DeltaResul
 ///   "nullable": true,
 ///   "metadata": {
 ///     "parquet.field.id": 1,
-///     "parquet.field.nested.ids": {
+///     "delta.columnMapping.nested.ids": {
 ///       "arr_in_map.key": 100,
 ///       "arr_in_map.value": 101,
 ///       "arr_in_map.value.element": 102
@@ -591,10 +591,9 @@ mod apply_schema_validation_tests {
 
     // === Nested-id propagation tests ===
 
-    #[rstest]
-    #[case::parquet_field_nested_ids(ColumnMetadataKey::ParquetFieldNestedIds.as_ref())]
-    #[case::delta_column_mapping_nested_ids(ColumnMetadataKey::ColumnMappingNestedIds.as_ref())]
-    fn test_apply_schema_threads_nested_ids_onto_arrow_schema(#[case] meta_key: &str) {
+    #[test]
+    fn test_apply_schema_threads_nested_ids_onto_arrow_schema() {
+        let meta_key = ColumnMetadataKey::ColumnMappingNestedIds.as_ref();
         let fixture = complex_nested_with_field_ids(meta_key);
         let kernel_type = DataType::Struct(Box::new(fixture.kernel_schema));
         let result = apply_schema(&fixture.input_arrow_data, &kernel_type).unwrap();
@@ -617,7 +616,7 @@ mod apply_schema_validation_tests {
             one("custom.element", "elem_val"),
         );
         let kernel_schema =
-            array_in_map_with_field_ids(ColumnMetadataKey::ParquetFieldNestedIds.as_ref());
+            array_in_map_with_field_ids(ColumnMetadataKey::ColumnMappingNestedIds.as_ref());
         let result = apply_schema(&input, &DataType::Struct(Box::new(kernel_schema))).unwrap();
 
         let result_schema = result.schema();
@@ -649,15 +648,14 @@ mod apply_schema_validation_tests {
     }
 
     #[rstest]
-    /// The whole nested ids JSON map is missing(i.e. neither `delta.columnMapping.nested.ids`
-    /// nor `parquet.field.nested.ids` are present).
+    /// The nested ids JSON map is missing (i.e. `delta.columnMapping.nested.ids` is not present).
     #[case::without_nested_id_metadata(array_in_map_kernel_schema(std::iter::empty::<(
         String,
         MetadataValue,
     )>()), /* expected_field_ids */ &[])]
     /// Only some of the nested ids are present.
     #[case::only_partial_nested_ids_match(array_in_map_kernel_schema([(
-        ColumnMetadataKey::ParquetFieldNestedIds.as_ref().to_string(),
+        ColumnMetadataKey::ColumnMappingNestedIds.as_ref().to_string(),
         MetadataValue::Other(test_utils::nested_ids_json(&[
             ("array_in_map.key", 100),
             ("array_in_map.value.element", 102),
@@ -699,7 +697,7 @@ mod apply_schema_validation_tests {
         #[case] expected_error_substring: &str,
     ) {
         let schema = array_in_map_kernel_schema([(
-            ColumnMetadataKey::ParquetFieldNestedIds
+            ColumnMetadataKey::ColumnMappingNestedIds
                 .as_ref()
                 .to_string(),
             value,

--- a/kernel/src/engine/arrow_expression/apply_schema.rs
+++ b/kernel/src/engine/arrow_expression/apply_schema.rs
@@ -277,6 +277,8 @@ pub(crate) fn apply_schema_to(array: &ArrayRef, schema: &DataType) -> DeltaResul
 ///   [`ArrayType::element_type`] / [`MapType::key_type`] / [`MapType::value_type`] are bare
 ///   [`DataType`]s with no name).
 /// - Nullability: use the kernel-side nullability.
+/// - Metadata: take the kernel side for most keys; translate the few that have an Arrow-native form
+///   (e.g. `parquet.field.id` -> `PARQUET:field_id`). Input Arrow metadata is dropped.
 ///
 /// `ancestor` is the nearest ancestor kernel [`StructField`]; its metadata holds the nested-ids
 /// JSON map (`None` at the top level). `relative_path` is the dot-chained path rooted at
@@ -607,7 +609,7 @@ mod apply_schema_validation_tests {
     /// Custom field names on the input arrow schema should survive `apply_schema`. The
     /// metadata from the input arrow schema is replaced by kernel-derived metadata.
     #[test]
-    fn test_apply_schema_retains_synthesized_field_names_and_metadata() {
+    fn test_apply_schema_retains_field_names() {
         let one = |k: &str, v: &str| HashMap::from([(k.to_string(), v.to_string())]);
         let input = array_in_map_arrow_data_with_custom_names_and_meta(
             one("custom.key", "key_val"),

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -598,7 +598,7 @@ mod tests {
     use crate::object_store::local::LocalFileSystem;
     use crate::object_store::memory::InMemory;
     use crate::parquet::arrow::{ARROW_SCHEMA_META_KEY, PARQUET_FIELD_ID_META_KEY};
-    use crate::schema::ColumnMetadataKey;
+    use crate::schema::{ColumnMetadataKey, MetadataValue};
     use crate::utils::current_time_ms;
     use crate::utils::test_utils::assert_result_error_with_message;
     use crate::EngineData;
@@ -1286,12 +1286,13 @@ mod tests {
             .find(|f| f.name() == "value")
             .unwrap();
 
-        // Field ID is transformed to kernel key when reading
+        // Field ID is transformed to kernel key when reading. arrow->kernel parses the
+        // `PARQUET:field_id` string back into kernel's canonical `MetadataValue::Number(i64)`.
         assert_eq!(
             field
                 .metadata()
                 .get(ColumnMetadataKey::ParquetFieldId.as_ref()),
-            Some(&"42".into())
+            Some(&MetadataValue::Number(42))
         );
 
         // Field ID should be accessible via documented API

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -856,6 +856,17 @@ pub trait ParquetHandler: AsAny {
     /// This will overwrite the file if it already exists. For filesystem-backed
     /// implementations, the parent directories must be created if they do not exist.
     ///
+    /// # Parquet field IDs
+    ///
+    /// The engine must write a Parquet `field_id` correctly when the kernel
+    /// [`StructField`] carries a field-id related annotation, including:
+    /// - [`ColumnMetadataKey::ColumnMappingId`] / [`ColumnMetadataKey::ParquetFieldId`]
+    /// - [`ColumnMetadataKey::ColumnMappingNestedIds`] /
+    ///   [`ColumnMetadataKey::ParquetFieldNestedIds`]
+    ///
+    /// For how to use these keys, refer to the Delta protocol's [Column Mapping] and
+    /// [IcebergCompatV2] sections.
+    ///
     /// # Parameters
     ///
     /// - `url` - The full URL path where the Parquet file should be written (e.g.,
@@ -865,6 +876,14 @@ pub trait ParquetHandler: AsAny {
     /// # Returns
     ///
     /// A [`DeltaResult`] indicating success or failure.
+    ///
+    /// [`StructField`]: crate::schema::StructField
+    /// [`ColumnMetadataKey::ColumnMappingId`]: crate::schema::ColumnMetadataKey::ColumnMappingId
+    /// [`ColumnMetadataKey::ParquetFieldId`]: crate::schema::ColumnMetadataKey::ParquetFieldId
+    /// [`ColumnMetadataKey::ColumnMappingNestedIds`]: crate::schema::ColumnMetadataKey::ColumnMappingNestedIds
+    /// [`ColumnMetadataKey::ParquetFieldNestedIds`]: crate::schema::ColumnMetadataKey::ParquetFieldNestedIds
+    /// [Column Mapping]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#column-mapping
+    /// [IcebergCompatV2]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#iceberg-compatibility-v2
     fn write_parquet_file(
         &self,
         location: url::Url,

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -861,8 +861,7 @@ pub trait ParquetHandler: AsAny {
     /// The engine must write a Parquet `field_id` correctly when the kernel
     /// [`StructField`] carries a field-id related annotation, including:
     /// - [`ColumnMetadataKey::ColumnMappingId`] / [`ColumnMetadataKey::ParquetFieldId`]
-    /// - [`ColumnMetadataKey::ColumnMappingNestedIds`] /
-    ///   [`ColumnMetadataKey::ParquetFieldNestedIds`]
+    /// - [`ColumnMetadataKey::ColumnMappingNestedIds`]
     ///
     /// For how to use these keys, refer to the Delta protocol's [Column Mapping] and
     /// [IcebergCompatV2] sections.
@@ -881,7 +880,6 @@ pub trait ParquetHandler: AsAny {
     /// [`ColumnMetadataKey::ColumnMappingId`]: crate::schema::ColumnMetadataKey::ColumnMappingId
     /// [`ColumnMetadataKey::ParquetFieldId`]: crate::schema::ColumnMetadataKey::ParquetFieldId
     /// [`ColumnMetadataKey::ColumnMappingNestedIds`]: crate::schema::ColumnMetadataKey::ColumnMappingNestedIds
-    /// [`ColumnMetadataKey::ParquetFieldNestedIds`]: crate::schema::ColumnMetadataKey::ParquetFieldNestedIds
     /// [Column Mapping]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#column-mapping
     /// [IcebergCompatV2]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#iceberg-compatibility-v2
     fn write_parquet_file(

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -866,6 +866,10 @@ pub trait ParquetHandler: AsAny {
     /// For how to use these keys, refer to the Delta protocol's [Column Mapping] and
     /// [IcebergCompatV2] sections.
     ///
+    /// **Non-compliance produces files with incorrect `field_id`s**, which may lead to
+    /// read failures when column mapping mode is `id` and to failures when converting
+    /// the table to Iceberg.   
+    ///
     /// # Parameters
     ///
     /// - `url` - The full URL path where the Parquet file should be written (e.g.,

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -100,6 +100,24 @@ impl From<bool> for MetadataValue {
 pub enum ColumnMetadataKey {
     ColumnMappingId,
     ColumnMappingPhysicalName,
+    /// Parquet field IDs for the synthesized `element` / `key` / `value` fields of an Array or
+    /// Map. Stored on the *nearest ancestor* StructField as a JSON object whose keys are
+    /// dot-paths rooted at that field's name.
+    ///
+    /// # Example: list-in-map
+    ///
+    /// For `m: map<int, array<int>>` and the key/value/element fields having field ids
+    /// 100/101/102, the metadata on `m` should be:
+    ///
+    /// ```json
+    /// {
+    ///   "delta.columnMapping.nested.ids": {
+    ///     "m.key":           100,
+    ///     "m.value":         101,
+    ///     "m.value.element": 102
+    ///   }
+    /// }
+    /// ```
     ColumnMappingNestedIds,
     ParquetFieldId,
     ParquetFieldNestedIds,
@@ -118,15 +136,15 @@ impl AsRef<str> for ColumnMetadataKey {
         match self {
             Self::ColumnMappingId => "delta.columnMapping.id",
             Self::ColumnMappingPhysicalName => "delta.columnMapping.physicalName",
-            // "delta.columnMapping.nested.ids" is not defined by the Delta protocol, but follows
-            // the convention established by delta-spark and other Delta ecosystem implementations.
-            // It will replace "parquet.field.nested.ids", tracking issue:
-            // <https://github.com/delta-io/delta/issues/6688>
             Self::ColumnMappingNestedIds => "delta.columnMapping.nested.ids",
             // "parquet.field.id" is not defined by the Delta protocol, but follows the convention
             // established by delta-spark and other Delta ecosystem implementations for storing
             // Parquet field IDs in StructField metadata.
             Self::ParquetFieldId => "parquet.field.id",
+            // The Delta protocol defines this key for IcebergCompatV2/V3 nested field ids. It is
+            // legacy and will be replaced by `delta.columnMapping.nested.ids` (which kernel
+            // uses everywhere). Kept here for protocol compatibility only.
+            // Tracking issue: <https://github.com/delta-io/delta/issues/6688>
             Self::ParquetFieldNestedIds => "parquet.field.nested.ids",
             Self::GenerationExpression => "delta.generationExpression",
             Self::IdentityAllowExplicitInsert => "delta.identity.allowExplicitInsert",

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -100,7 +100,9 @@ impl From<bool> for MetadataValue {
 pub enum ColumnMetadataKey {
     ColumnMappingId,
     ColumnMappingPhysicalName,
+    ColumnMappingNestedIds,
     ParquetFieldId,
+    ParquetFieldNestedIds,
     GenerationExpression,
     IdentityStart,
     IdentityStep,
@@ -116,10 +118,16 @@ impl AsRef<str> for ColumnMetadataKey {
         match self {
             Self::ColumnMappingId => "delta.columnMapping.id",
             Self::ColumnMappingPhysicalName => "delta.columnMapping.physicalName",
+            // "delta.columnMapping.nested.ids" is not defined by the Delta protocol, but follows
+            // the convention established by delta-spark and other Delta ecosystem implementations.
+            // It will replace "parquet.field.nested.ids", tracking issue:
+            // <https://github.com/delta-io/delta/issues/6688>
+            Self::ColumnMappingNestedIds => "delta.columnMapping.nested.ids",
             // "parquet.field.id" is not defined by the Delta protocol, but follows the convention
             // established by delta-spark and other Delta ecosystem implementations for storing
             // Parquet field IDs in StructField metadata.
             Self::ParquetFieldId => "parquet.field.id",
+            Self::ParquetFieldNestedIds => "parquet.field.nested.ids",
             Self::GenerationExpression => "delta.generationExpression",
             Self::IdentityAllowExplicitInsert => "delta.identity.allowExplicitInsert",
             Self::IdentityHighWaterMark => "delta.identity.highWaterMark",

--- a/kernel/src/schema/validation.rs
+++ b/kernel/src/schema/validation.rs
@@ -4,8 +4,9 @@
 
 use std::collections::HashSet;
 
-use crate::schema::{StructField, StructType};
-use crate::table_features::ColumnMappingMode;
+use crate::schema::{ColumnMetadataKey, StructField, StructType};
+use crate::table_configuration::TableConfiguration;
+use crate::table_features::{ColumnMappingMode, TableFeature};
 use crate::transforms::SchemaTransform;
 use crate::{transform_output_type, DeltaResult, Error};
 
@@ -120,6 +121,56 @@ impl<'a> SchemaTransform<'a> for SchemaValidator {
 
         self.recurse_into_struct_field(field);
         self.current_path.pop();
+    }
+}
+
+/// `parquet.field.nested.ids` is to be deprecated in favor of `delta.columnMapping.nested.ids`.
+/// Validates that no fields in the schema have `parquet.field.nested.ids` metadata.
+///
+/// Tracking issue: <https://github.com/delta-io/delta/issues/6688>
+pub(crate) fn validate_iceberg_compat_v3_no_legacy_nested_id(
+    tc: &TableConfiguration,
+) -> DeltaResult<()> {
+    if !tc.is_feature_enabled(&TableFeature::IcebergCompatV3) {
+        return Ok(());
+    }
+    let mut v = LegacyNestedIdsVisitor {
+        path: vec![],
+        offender: None,
+    };
+    v.transform_struct(&tc.logical_schema());
+    let Some(offender) = v.offender else {
+        return Ok(());
+    };
+    Err(Error::generic(format!(
+        "icebergCompatV3: field `{offender}` carries deprecated `{}` metadata; \
+         use `{}` instead. See https://github.com/delta-io/delta/issues/6688",
+        ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
+        ColumnMetadataKey::ColumnMappingNestedIds.as_ref(),
+    )))
+}
+
+struct LegacyNestedIdsVisitor {
+    path: Vec<String>,
+    offender: Option<String>,
+}
+
+impl<'a> SchemaTransform<'a> for LegacyNestedIdsVisitor {
+    transform_output_type!(|'a, T| ());
+
+    fn transform_struct_field(&mut self, f: &'a StructField) {
+        if self.offender.is_some() {
+            return;
+        }
+        self.path.push(f.name().to_string());
+        if f.metadata()
+            .contains_key(ColumnMetadataKey::ParquetFieldNestedIds.as_ref())
+        {
+            self.offender = Some(self.path.join("."));
+            return;
+        }
+        self.recurse_into_struct_field(f);
+        self.path.pop();
     }
 }
 
@@ -423,5 +474,110 @@ mod tests {
             msg.contains(expected_path),
             "Expected path '{expected_path}' in error, got: {msg}"
         );
+    }
+
+    // === LegacyNestedIdsVisitor: parquet.field.nested.ids detection ===
+
+    #[rstest]
+    #[case::clean_schema(simple_schema(), None)]
+    #[case::column_mapping_nested_id_key_only(schema_with_good_nested_ids(), None)]
+    #[case::top_level_legacy(schema_with_legacy_at("top"), Some("top".to_string()))]
+    #[case::nested_struct_legacy(schema_struct_with_legacy_at_inner(), Some("parent.inner".to_string()))]
+    #[case::array_struct_legacy(schema_array_struct_with_legacy_at_inner(), Some("arr.inner".to_string()))]
+    #[case::map_value_struct_legacy(schema_map_value_struct_with_legacy_at_inner(), Some("m.inner".to_string()))]
+    #[case::first_offender_wins(schema_two_legacy_fields(), Some("a".to_string()))]
+    fn legacy_nested_ids_visitor_finds_first_offender(
+        #[case] schema: StructType,
+        #[case] expected: Option<String>,
+    ) {
+        let mut v = LegacyNestedIdsVisitor {
+            path: vec![],
+            offender: None,
+        };
+        v.transform_struct(&schema);
+        assert_eq!(v.offender, expected);
+    }
+
+    fn field_with_metadata(name: &str, dtype: DataType, key: &str) -> StructField {
+        let mut f = StructField::nullable(name, dtype);
+        f.metadata.insert(
+            key.to_string(),
+            MetadataValue::Other(serde_json::json!({ "x.element": 1 })),
+        );
+        f
+    }
+
+    fn schema_with_good_nested_ids() -> StructType {
+        StructType::new_unchecked(vec![field_with_metadata(
+            "x",
+            DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+            ColumnMetadataKey::ColumnMappingNestedIds.as_ref(),
+        )])
+    }
+
+    fn schema_with_legacy_at(name: &str) -> StructType {
+        StructType::new_unchecked(vec![field_with_metadata(
+            name,
+            DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+            ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
+        )])
+    }
+
+    fn schema_struct_with_legacy_at_inner() -> StructType {
+        let inner = StructType::new_unchecked(vec![field_with_metadata(
+            "inner",
+            DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+            ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
+        )]);
+        StructType::new_unchecked(vec![StructField::nullable(
+            "parent",
+            DataType::Struct(Box::new(inner)),
+        )])
+    }
+
+    fn schema_array_struct_with_legacy_at_inner() -> StructType {
+        let inner = StructType::new_unchecked(vec![field_with_metadata(
+            "inner",
+            DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+            ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
+        )]);
+        StructType::new_unchecked(vec![StructField::nullable(
+            "arr",
+            DataType::Array(Box::new(ArrayType::new(
+                DataType::Struct(Box::new(inner)),
+                true,
+            ))),
+        )])
+    }
+
+    fn schema_map_value_struct_with_legacy_at_inner() -> StructType {
+        let inner = StructType::new_unchecked(vec![field_with_metadata(
+            "inner",
+            DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+            ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
+        )]);
+        StructType::new_unchecked(vec![StructField::nullable(
+            "m",
+            DataType::Map(Box::new(MapType::new(
+                DataType::STRING,
+                DataType::Struct(Box::new(inner)),
+                true,
+            ))),
+        )])
+    }
+
+    fn schema_two_legacy_fields() -> StructType {
+        StructType::new_unchecked(vec![
+            field_with_metadata(
+                "a",
+                DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+                ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
+            ),
+            field_with_metadata(
+                "b",
+                DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+                ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
+            ),
+        ])
     }
 }

--- a/kernel/src/schema/validation.rs
+++ b/kernel/src/schema/validation.rs
@@ -143,8 +143,8 @@ pub(crate) fn validate_iceberg_compat_v3_no_legacy_nested_id(
         return Ok(());
     };
     Err(Error::generic(format!(
-        "icebergCompatV3: field `{offender}` carries deprecated `{}` metadata; \
-         use `{}` instead. See https://github.com/delta-io/delta/issues/6688",
+        "field `{offender}` carries deprecated `{}` metadata; use `{}` instead. \
+         See https://github.com/delta-io/delta/issues/6688",
         ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
         ColumnMetadataKey::ColumnMappingNestedIds.as_ref(),
     )))

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -2237,7 +2237,7 @@ mod test {
         vec!["value", "pcol"],
     )]
     #[case::v3_supported_but_property_unset(&[], vec!["value"])]
-    fn test_physical_write_schema_materializes_pv_when_iceberg_compact_v3_enabled(
+    fn test_physical_write_schema_materializes_pv_when_iceberg_compat_v3_enabled(
         #[case] extra_props: &[(&str, &str)],
         #[case] expected_field_names: Vec<&str>,
     ) {

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -21,6 +21,7 @@ use crate::expressions::ColumnName;
 use crate::scan::data_skipping::stats_schema::{
     expected_stats_schema, stats_column_names, StatsConfig, StripFieldMetadataTransform,
 };
+use crate::schema::validation::validate_iceberg_compat_v3_no_legacy_nested_id;
 pub(crate) use crate::schema::variant_utils::validate_variant_type_feature_support;
 use crate::schema::{schema_has_invariants, SchemaRef, StructField, StructType};
 use crate::table_features::{
@@ -196,6 +197,7 @@ impl TableConfiguration {
         // Validate schema against protocol features now that we have a TC instance.
         validate_timestamp_ntz_feature_support(&table_config)?;
         validate_variant_type_feature_support(&table_config)?;
+        validate_iceberg_compat_v3_no_legacy_nested_id(&table_config)?;
 
         Ok(table_config)
     }

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -732,7 +732,7 @@ pub(crate) mod test_utils {
             ("inner.value", 201),
             ("inner.value.element", 202),
         ]);
-        // Each top-level field carries `parquet.field.id` plus the nested-ids JSON.
+        // Each `StructField` carries `parquet.field.id` plus the nested-ids JSON.
         let inner_field = StructField::nullable("inner", complex_nested_inner_map_type())
             .with_metadata([
                 (

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -625,24 +625,56 @@ pub(crate) mod test_utils {
     ///
     /// What `try_into_arrow(kernel schema)` and
     /// `apply_schema(input arrow schema, kernel schema)` should both produce:
-    /// - `top` and `inner` carry `PARQUET:field_id` (rewritten from `parquet.field.id`) plus the
-    ///   nested-ids JSON.
+    /// - `top` and `inner` carry `PARQUET:field_id` (rewritten from `parquet.field.id`).
     /// - Synthesized list/map `key`/`value`/`element` fields each carry `PARQUET:field_id` pulled
     ///   from the corresponding nested-ids JSON entry. `top.key.element` has `101` (kernel's), not
     ///   the stale `999` from the input.
+    ///
+    /// ```json
+    /// {
+    ///   "fields": [{
+    ///     "name": "top", "type": "map",
+    ///     "metadata": {"PARQUET:field_id": "1"},
+    ///     "entries": { "name": "key_value", "type": "struct", "fields": [
+    ///       {
+    ///         "name": "key", "type": "list",
+    ///         "metadata": {"PARQUET:field_id": "100"},
+    ///         "element": {
+    ///           "name": "element", "type": "int32",
+    ///           "metadata": {"PARQUET:field_id": "101"}
+    ///         }
+    ///       },
+    ///       {
+    ///         "name": "value", "type": "struct",
+    ///         "metadata": {"PARQUET:field_id": "102"},
+    ///         "fields": [{
+    ///           "name": "inner", "type": "map",
+    ///           "metadata": {"PARQUET:field_id": "2"},
+    ///           "entries": { "name": "key_value", "type": "struct", "fields": [
+    ///             {
+    ///               "name": "key", "type": "int32",
+    ///               "metadata": {"PARQUET:field_id": "200"}
+    ///             },
+    ///             {
+    ///               "name": "value", "type": "list",
+    ///               "metadata": {"PARQUET:field_id": "201"},
+    ///               "element": {
+    ///                 "name": "element", "type": "int32",
+    ///                 "metadata": {"PARQUET:field_id": "202"}
+    ///               }
+    ///             }
+    ///           ]}
+    ///         }]
+    ///       }
+    ///     ]}
+    ///   }]
+    /// }
+    /// ```
     pub(crate) fn complex_nested_with_field_ids(nested_ids_meta_key: &str) -> NestedFieldIdFixture {
-        let (kernel_schema, top_nested_ids, inner_nested_ids) =
-            build_complex_nested_kernel_schema(nested_ids_meta_key);
-        let input_arrow_data = build_arrow_input_with_stale_element_id();
-        let expected_arrow_schema = expected_complex_nested_arrow_schema(
-            nested_ids_meta_key,
-            top_nested_ids,
-            inner_nested_ids,
-        );
         NestedFieldIdFixture {
-            kernel_schema,
-            input_arrow_data,
-            expected_arrow_schema,
+            kernel_schema: build_complex_nested_kernel_schema(nested_ids_meta_key),
+            input_arrow_data: build_arrow_input_with_stale_element_id(),
+            expected_arrow_schema: expected_complex_nested_arrow_schema(),
         }
     }
 
@@ -716,12 +748,8 @@ pub(crate) mod test_utils {
         )))
     }
 
-    /// Build the kernel schema described by [`complex_nested_with_field_ids`], returning the
-    /// schema and the two nested-id JSON maps (top + inner) so the expected-Arrow-schema helper
-    /// can reuse them without re-deriving.
-    fn build_complex_nested_kernel_schema(
-        nested_ids_meta_key: &str,
-    ) -> (StructType, serde_json::Value, serde_json::Value) {
+    /// Build the kernel schema described by [`complex_nested_with_field_ids`].
+    fn build_complex_nested_kernel_schema(nested_ids_meta_key: &str) -> StructType {
         let top_nested_ids = test_utils::nested_ids_json(&[
             ("top.key", 100),
             ("top.key.element", 101),
@@ -741,7 +769,7 @@ pub(crate) mod test_utils {
                 ),
                 (
                     nested_ids_meta_key.to_string(),
-                    MetadataValue::Other(inner_nested_ids.clone()),
+                    MetadataValue::Other(inner_nested_ids),
                 ),
             ]);
         let top_field = StructField::nullable(
@@ -755,19 +783,14 @@ pub(crate) mod test_utils {
             ),
             (
                 nested_ids_meta_key.to_string(),
-                MetadataValue::Other(top_nested_ids.clone()),
+                MetadataValue::Other(top_nested_ids),
             ),
         ]);
-        let schema = StructType::try_new(vec![top_field]).unwrap();
-        (schema, top_nested_ids, inner_nested_ids)
+        StructType::try_new(vec![top_field]).unwrap()
     }
 
     /// Build the expected output Arrow schema for [`complex_nested_with_field_ids`].
-    fn expected_complex_nested_arrow_schema(
-        nested_ids_meta_key: &str,
-        top_nested_ids: serde_json::Value,
-        inner_nested_ids: serde_json::Value,
-    ) -> ArrowSchema {
+    fn expected_complex_nested_arrow_schema() -> ArrowSchema {
         // top.value.inner.value.element: int (PARQUET:field_id=202).
         let inner_list_element = Field::new("element", DataType::Int32, true)
             .with_metadata(parquet_field_id_metadata(Some(202)));
@@ -783,17 +806,9 @@ pub(crate) mod test_utils {
             DataType::Struct(vec![inner_key, inner_value].into()),
             false,
         );
-        // top.value.inner: map<int, list<int>> (PARQUET:field_id=2 + nested-ids JSON).
-        let inner_field_metadata = [
-            (PARQUET_FIELD_ID_META_KEY.to_string(), "2".to_string()),
-            (
-                nested_ids_meta_key.to_string(),
-                serde_json::to_string(&inner_nested_ids).unwrap(),
-            ),
-        ]
-        .into();
+        // top.value.inner: map<int, list<int>> (PARQUET:field_id=2).
         let inner_field = Field::new("inner", DataType::Map(Arc::new(inner_entries), false), true)
-            .with_metadata(inner_field_metadata);
+            .with_metadata(parquet_field_id_metadata(Some(2)));
         // top.value: struct<inner: ...> (PARQUET:field_id=102).
         let struct_value_field =
             Field::new("value", DataType::Struct(vec![inner_field].into()), true)
@@ -810,17 +825,9 @@ pub(crate) mod test_utils {
             DataType::Struct(vec![outer_key, struct_value_field].into()),
             false,
         );
-        // top: map<list<int>, struct<...>> (PARQUET:field_id=1 + nested-ids JSON).
-        let top_field_metadata = [
-            (PARQUET_FIELD_ID_META_KEY.to_string(), "1".to_string()),
-            (
-                nested_ids_meta_key.to_string(),
-                serde_json::to_string(&top_nested_ids).unwrap(),
-            ),
-        ]
-        .into();
+        // top: map<list<int>, struct<...>> (PARQUET:field_id=1).
         let top_field = Field::new("top", DataType::Map(Arc::new(outer_entries), false), true)
-            .with_metadata(top_field_metadata);
+            .with_metadata(parquet_field_id_metadata(Some(1)));
         ArrowSchema::new(vec![top_field])
     }
 

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -179,9 +179,10 @@ pub(crate) mod test_utils {
     use crate::actions::{
         get_all_actions_schema, Add, Cdc, CommitInfo, Metadata, Protocol, Remove,
     };
-    use crate::arrow::array::{RecordBatch, StringArray};
+    use crate::arrow::array::{RecordBatch, StringArray, StructArray};
     use crate::arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
     use crate::committer::FileSystemCommitter;
+    use crate::engine::arrow_conversion::{parquet_field_id_metadata, TryIntoArrow as _};
     use crate::engine::arrow_data::ArrowEngineData;
     use crate::engine::default::DefaultEngineBuilder;
     use crate::engine::sync::SyncEngine;
@@ -189,6 +190,7 @@ pub(crate) mod test_utils {
     use crate::object_store::local::LocalFileSystem;
     use crate::object_store::memory::InMemory;
     use crate::object_store::ObjectStoreExt as _;
+    use crate::parquet::arrow::PARQUET_FIELD_ID_META_KEY;
     use crate::table_features::ColumnMappingMode;
     use crate::transaction::create_table::create_table;
     use crate::transaction::{CreateTable, Transaction};
@@ -482,6 +484,344 @@ pub(crate) mod test_utils {
                 MetadataValue::String(physical_name.into()),
             ),
         ])
+    }
+
+    /// Shared fixture for nested field-id propagation tests.
+    pub(crate) struct NestedFieldIdFixture {
+        pub(crate) kernel_schema: StructType,
+        pub(crate) input_arrow_data: StructArray,
+        pub(crate) expected_arrow_schema: ArrowSchema,
+    }
+
+    /// Recursively collect `(field_name, metadata_value)` pairs for the given metadata key
+    /// across all (nested) Arrow fields in `schema`.
+    pub(crate) fn collect_arrow_field_metadata(
+        schema: &ArrowSchema,
+        metadata_key: &str,
+    ) -> Vec<(String, String)> {
+        fn collect_from_fields(
+            fields: &[Arc<Field>],
+            metadata_key: &str,
+            out: &mut Vec<(String, String)>,
+        ) {
+            for field in fields {
+                collect_from_field(field, metadata_key, out);
+            }
+        }
+
+        fn collect_from_field(field: &Field, metadata_key: &str, out: &mut Vec<(String, String)>) {
+            if let Some(value) = field.metadata().get(metadata_key) {
+                out.push((field.name().clone(), value.clone()));
+            }
+
+            match field.data_type() {
+                DataType::Struct(fields) => collect_from_fields(fields, metadata_key, out),
+                DataType::List(entry) | DataType::Map(entry, _) => {
+                    collect_from_field(entry, metadata_key, out)
+                }
+                _ => {}
+            }
+        }
+
+        let mut out = Vec::new();
+        collect_from_fields(schema.fields(), metadata_key, &mut out);
+        out
+    }
+
+    /// Build the kernel schema for `array_in_map: map<int, array<int>>` with caller-provided
+    /// top-level field metadata.
+    pub(crate) fn array_in_map_kernel_schema(
+        metadata: impl IntoIterator<Item = (String, MetadataValue)>,
+    ) -> StructType {
+        let array_in_map = StructField::nullable(
+            "array_in_map",
+            KernelDataType::Map(Box::new(MapType::new(
+                KernelDataType::INTEGER,
+                KernelDataType::Array(Box::new(ArrayType::new(KernelDataType::INTEGER, true))),
+                true,
+            ))),
+        )
+        .with_metadata(metadata);
+        StructType::try_new(vec![array_in_map]).unwrap()
+    }
+
+    /// Build an [`array_in_map_kernel_schema`] with `parquet.field.id` on the top-level field
+    /// and a nested-ids JSON map (key/value/element) under `nested_ids_meta_key`.
+    pub(crate) fn array_in_map_with_field_ids(nested_ids_meta_key: &str) -> StructType {
+        let nested_ids = MetadataValue::Other(test_utils::nested_ids_json(&[
+            ("array_in_map.key", 100),
+            ("array_in_map.value", 101),
+            ("array_in_map.value.element", 102),
+        ]));
+        array_in_map_kernel_schema([
+            (
+                ColumnMetadataKey::ParquetFieldId.as_ref().to_string(),
+                MetadataValue::from(1i64),
+            ),
+            (nested_ids_meta_key.to_string(), nested_ids),
+        ])
+    }
+
+    /// Build an empty Arrow `StructArray` matching [`array_in_map_kernel_schema`] with no field-id
+    /// metadata.
+    pub(crate) fn array_in_map_arrow_data_without_field_ids() -> StructArray {
+        let kernel_schema =
+            array_in_map_kernel_schema(std::iter::empty::<(String, MetadataValue)>());
+        let arrow_schema: ArrowSchema = (&kernel_schema).try_into_arrow().unwrap();
+        let batch = RecordBatch::new_empty(Arc::new(arrow_schema));
+        StructArray::try_new(
+            batch.schema().fields.clone(),
+            batch.columns().to_vec(),
+            None,
+        )
+        .unwrap()
+    }
+
+    /// Build a [`NestedFieldIdFixture`] covering Array+Map nested-id propagation through a
+    /// Struct boundary.
+    ///
+    /// ## 1. Kernel schema
+    ///
+    /// Two [`StructField`]s `top` and `inner` carry `parquet.field.id` (rewritten to
+    /// `PARQUET:field_id` in the Arrow output) plus a `<nested_ids_meta_key>` JSON map rooted
+    /// at each field's name. Each carries an array inside a map.
+    ///
+    /// ```json
+    /// {
+    ///   "type": "struct",
+    ///   "fields": [{
+    ///     "name": "top",
+    ///     "type": {
+    ///       "type": "map",
+    ///       "keyType":   {"type": "array", "elementType": "integer"},
+    ///       "valueType": {"type": "struct", "fields": [{
+    ///         "name": "inner",
+    ///         "type": {"type": "map", "keyType": "integer",
+    ///                  "valueType": {"type": "array", "elementType": "integer"}},
+    ///         "metadata": {
+    ///           "parquet.field.id": 2,
+    ///           "<nested_ids_meta_key>": {
+    ///             "inner.key": 200, "inner.value": 201, "inner.value.element": 202
+    ///           }
+    ///         }
+    ///       }]}
+    ///     },
+    ///     "metadata": {
+    ///       "parquet.field.id": 1,
+    ///       "<nested_ids_meta_key>": {
+    ///         "top.key": 100, "top.key.element": 101, "top.value": 102
+    ///       }
+    ///     }
+    ///   }]
+    /// }
+    /// ```
+    ///
+    /// ## 2. Input Arrow schema
+    ///
+    /// Same shape as kernel schema with no metadata anywhere, except a *stale*
+    /// `PARQUET:field_id=999` on the synthesized `top.key.element` field.
+    ///
+    /// ## 3. Expected output Arrow schema
+    ///
+    /// What `try_into_arrow(kernel schema)` and
+    /// `apply_schema(input arrow schema, kernel schema)` should both produce:
+    /// - `top` and `inner` carry `PARQUET:field_id` (rewritten from `parquet.field.id`) plus the
+    ///   nested-ids JSON.
+    /// - Synthesized list/map `key`/`value`/`element` fields each carry `PARQUET:field_id` pulled
+    ///   from the corresponding nested-ids JSON entry. `top.key.element` has `101` (kernel's), not
+    ///   the stale `999` from the input.
+    pub(crate) fn complex_nested_with_field_ids(nested_ids_meta_key: &str) -> NestedFieldIdFixture {
+        let (kernel_schema, top_nested_ids, inner_nested_ids) =
+            build_complex_nested_kernel_schema(nested_ids_meta_key);
+        let input_arrow_data = build_arrow_input_with_stale_element_id();
+        let expected_arrow_schema = expected_complex_nested_arrow_schema(
+            nested_ids_meta_key,
+            top_nested_ids,
+            inner_nested_ids,
+        );
+        NestedFieldIdFixture {
+            kernel_schema,
+            input_arrow_data,
+            expected_arrow_schema,
+        }
+    }
+
+    /// Build the input Arrow data for [`complex_nested_with_field_ids`] by
+    /// striping the metadata from [`build_complex_nested_kernel_schema`], and
+    /// add one stale `PARQUET:field_id` to the `top.key.element` field.
+    fn build_arrow_input_with_stale_element_id() -> StructArray {
+        // Get the no-meta Arrow shape from the kernel schema.
+        let plain_inner = StructField::nullable("inner", complex_nested_inner_map_type());
+        let plain_top = StructField::nullable(
+            "top",
+            complex_nested_outer_map_type(StructType::try_new(vec![plain_inner]).unwrap()),
+        );
+        let plain_kernel_schema = StructType::try_new(vec![plain_top]).unwrap();
+        let plain_arrow_schema: ArrowSchema = (&plain_kernel_schema).try_into_arrow().unwrap();
+
+        // Add stale `PARQUET:field_id` to the `top.key.element` field.
+        let top = plain_arrow_schema.field(0);
+        let DataType::Map(entries, sorted) = top.data_type() else {
+            unreachable!("top is a Map by construction");
+        };
+        let DataType::Struct(entries_fields) = entries.data_type() else {
+            unreachable!("map entries is a Struct by construction");
+        };
+        let outer_key = &entries_fields[0];
+        let DataType::List(outer_element) = outer_key.data_type() else {
+            unreachable!("outer map key is a List by construction");
+        };
+        let stale_element = outer_element
+            .as_ref()
+            .clone()
+            .with_metadata([(PARQUET_FIELD_ID_META_KEY.to_string(), "999".to_string())].into());
+        let new_outer_key = Field::new(
+            outer_key.name(),
+            DataType::List(Arc::new(stale_element)),
+            outer_key.is_nullable(),
+        );
+        let new_entries = Field::new(
+            entries.name(),
+            DataType::Struct(vec![new_outer_key, entries_fields[1].as_ref().clone()].into()),
+            entries.is_nullable(),
+        );
+        let new_top = Field::new(
+            top.name(),
+            DataType::Map(Arc::new(new_entries), *sorted),
+            top.is_nullable(),
+        );
+        let arrow_input_schema = ArrowSchema::new(vec![new_top]);
+        let batch = RecordBatch::new_empty(Arc::new(arrow_input_schema));
+        StructArray::try_new(
+            batch.schema().fields.clone(),
+            batch.columns().to_vec(),
+            None,
+        )
+        .unwrap()
+    }
+
+    fn complex_nested_inner_map_type() -> KernelDataType {
+        KernelDataType::Map(Box::new(MapType::new(
+            KernelDataType::INTEGER,
+            KernelDataType::Array(Box::new(ArrayType::new(KernelDataType::INTEGER, true))),
+            true,
+        )))
+    }
+
+    fn complex_nested_outer_map_type(struct_value: StructType) -> KernelDataType {
+        KernelDataType::Map(Box::new(MapType::new(
+            KernelDataType::Array(Box::new(ArrayType::new(KernelDataType::INTEGER, true))),
+            KernelDataType::Struct(Box::new(struct_value)),
+            true,
+        )))
+    }
+
+    /// Build the kernel schema described by [`complex_nested_with_field_ids`], returning the
+    /// schema and the two nested-id JSON maps (top + inner) so the expected-Arrow-schema helper
+    /// can reuse them without re-deriving.
+    fn build_complex_nested_kernel_schema(
+        nested_ids_meta_key: &str,
+    ) -> (StructType, serde_json::Value, serde_json::Value) {
+        let top_nested_ids = test_utils::nested_ids_json(&[
+            ("top.key", 100),
+            ("top.key.element", 101),
+            ("top.value", 102),
+        ]);
+        let inner_nested_ids = test_utils::nested_ids_json(&[
+            ("inner.key", 200),
+            ("inner.value", 201),
+            ("inner.value.element", 202),
+        ]);
+        // Each top-level field carries `parquet.field.id` plus the nested-ids JSON.
+        let inner_field = StructField::nullable("inner", complex_nested_inner_map_type())
+            .with_metadata([
+                (
+                    ColumnMetadataKey::ParquetFieldId.as_ref().to_string(),
+                    MetadataValue::from(2i64),
+                ),
+                (
+                    nested_ids_meta_key.to_string(),
+                    MetadataValue::Other(inner_nested_ids.clone()),
+                ),
+            ]);
+        let top_field = StructField::nullable(
+            "top",
+            complex_nested_outer_map_type(StructType::try_new(vec![inner_field]).unwrap()),
+        )
+        .with_metadata([
+            (
+                ColumnMetadataKey::ParquetFieldId.as_ref().to_string(),
+                MetadataValue::from(1i64),
+            ),
+            (
+                nested_ids_meta_key.to_string(),
+                MetadataValue::Other(top_nested_ids.clone()),
+            ),
+        ]);
+        let schema = StructType::try_new(vec![top_field]).unwrap();
+        (schema, top_nested_ids, inner_nested_ids)
+    }
+
+    /// Build the expected output Arrow schema for [`complex_nested_with_field_ids`].
+    fn expected_complex_nested_arrow_schema(
+        nested_ids_meta_key: &str,
+        top_nested_ids: serde_json::Value,
+        inner_nested_ids: serde_json::Value,
+    ) -> ArrowSchema {
+        // top.value.inner.value.element: int (PARQUET:field_id=202).
+        let inner_list_element = Field::new("element", DataType::Int32, true)
+            .with_metadata(parquet_field_id_metadata(Some(202)));
+        // top.value.inner.value: list<int> (PARQUET:field_id=201).
+        let inner_value = Field::new("value", DataType::List(Arc::new(inner_list_element)), true)
+            .with_metadata(parquet_field_id_metadata(Some(201)));
+        // top.value.inner.key: int (PARQUET:field_id=200).
+        let inner_key = Field::new("key", DataType::Int32, false)
+            .with_metadata(parquet_field_id_metadata(Some(200)));
+        // top.value.inner.key_value: synthesized map-entries struct (no field id).
+        let inner_entries = Field::new(
+            "key_value",
+            DataType::Struct(vec![inner_key, inner_value].into()),
+            false,
+        );
+        // top.value.inner: map<int, list<int>> (PARQUET:field_id=2 + nested-ids JSON).
+        let inner_field_metadata = [
+            (PARQUET_FIELD_ID_META_KEY.to_string(), "2".to_string()),
+            (
+                nested_ids_meta_key.to_string(),
+                serde_json::to_string(&inner_nested_ids).unwrap(),
+            ),
+        ]
+        .into();
+        let inner_field = Field::new("inner", DataType::Map(Arc::new(inner_entries), false), true)
+            .with_metadata(inner_field_metadata);
+        // top.value: struct<inner: ...> (PARQUET:field_id=102).
+        let struct_value_field =
+            Field::new("value", DataType::Struct(vec![inner_field].into()), true)
+                .with_metadata(parquet_field_id_metadata(Some(102)));
+        // top.key.element: int (PARQUET:field_id=101).
+        let outer_key_element = Field::new("element", DataType::Int32, true)
+            .with_metadata(parquet_field_id_metadata(Some(101)));
+        // top.key: list<int> (PARQUET:field_id=100).
+        let outer_key = Field::new("key", DataType::List(Arc::new(outer_key_element)), false)
+            .with_metadata(parquet_field_id_metadata(Some(100)));
+        // top.key_value: synthesized map-entries struct (no field id).
+        let outer_entries = Field::new(
+            "key_value",
+            DataType::Struct(vec![outer_key, struct_value_field].into()),
+            false,
+        );
+        // top: map<list<int>, struct<...>> (PARQUET:field_id=1 + nested-ids JSON).
+        let top_field_metadata = [
+            (PARQUET_FIELD_ID_META_KEY.to_string(), "1".to_string()),
+            (
+                nested_ids_meta_key.to_string(),
+                serde_json::to_string(&top_nested_ids).unwrap(),
+            ),
+        ]
+        .into();
+        let top_field = Field::new("top", DataType::Map(Arc::new(outer_entries), false), true)
+            .with_metadata(top_field_metadata);
+        ArrowSchema::new(vec![top_field])
     }
 
     /// Flat schema: `[id: long, name: string]`

--- a/kernel/tests/integration/common/write_utils.rs
+++ b/kernel/tests/integration/common/write_utils.rs
@@ -6,6 +6,7 @@
 
 #![allow(dead_code)]
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -20,6 +21,7 @@ use delta_kernel::engine_data::FilteredEngineData;
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::DynObjectStore;
 use delta_kernel::parquet::file::reader::{FileReader, SerializedFileReader};
+use delta_kernel::parquet::schema::types::Type as ParquetType;
 use delta_kernel::path::ParsedLogPath;
 use delta_kernel::schema::{DataType, SchemaRef, StructField, StructType};
 use delta_kernel::table_features::ColumnMappingMode;
@@ -69,6 +71,18 @@ pub fn load_existing_single_file_checkpoint_path(
     panic!("checkpoint parquet file not found for version {version} in {log_dir:?}");
 }
 
+/// Open a parquet file and return its root schema.
+fn read_parquet_root_schema(parquet_file: &std::path::Path) -> ParquetType {
+    let file = std::fs::File::open(parquet_file).unwrap();
+    let reader = SerializedFileReader::new(file).unwrap();
+    reader
+        .metadata()
+        .file_metadata()
+        .schema_descr()
+        .root_schema()
+        .clone()
+}
+
 /// Returns the native parquet `field_id` for a field at the given physical path in a parquet file,
 /// or `None` if the field has no `field_id` set.
 ///
@@ -77,15 +91,7 @@ pub fn get_parquet_field_id(
     parquet_file: &std::path::Path,
     physical_path: &[String],
 ) -> Option<i32> {
-    let file = std::fs::File::open(parquet_file).unwrap();
-    let reader = SerializedFileReader::new(file).unwrap();
-    let root = reader
-        .metadata()
-        .file_metadata()
-        .schema_descr()
-        .root_schema()
-        .clone();
-
+    let root = read_parquet_root_schema(parquet_file);
     let mut current = &root;
     for name in physical_path {
         current = current
@@ -97,6 +103,30 @@ pub fn get_parquet_field_id(
 
     let info = current.get_basic_info();
     info.has_id().then(|| info.id())
+}
+
+/// Recursively walks a parquet schema tree and returns a map from each node's absolute
+/// dot-separated path to its `field_id`. Top-level fields appear under their bare name.
+pub fn collect_all_parquet_field_ids(parquet_file: &std::path::Path) -> HashMap<String, i64> {
+    fn walk(t: &ParquetType, path: &str, out: &mut HashMap<String, i64>) {
+        let info = t.get_basic_info();
+        if info.has_id() {
+            out.insert(path.to_string(), info.id() as i64);
+        }
+        if let ParquetType::GroupType { fields, .. } = t {
+            for f in fields {
+                walk(f, &format!("{path}.{}", f.name()), out);
+            }
+        }
+    }
+
+    let mut ids = HashMap::new();
+    if let ParquetType::GroupType { fields, .. } = &read_parquet_root_schema(parquet_file) {
+        for f in fields {
+            walk(f, f.name(), &mut ids);
+        }
+    }
+    ids
 }
 
 /// Validate that `commitInfo["txnId"]` is a valid UUID.

--- a/kernel/tests/integration/write/mod.rs
+++ b/kernel/tests/integration/write/mod.rs
@@ -7,6 +7,7 @@ mod column_mapping;
 mod commit_info;
 mod domain_metadata;
 mod ict;
+mod nested_field_ids;
 mod partitioned;
 mod post_commit;
 mod relative_paths;

--- a/kernel/tests/integration/write/nested_field_ids.rs
+++ b/kernel/tests/integration/write/nested_field_ids.rs
@@ -1,0 +1,135 @@
+//! End-to-end nested parquet field id propagation tests for `DefaultParquetHandler`.
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use delta_kernel::arrow::array::RecordBatch;
+use delta_kernel::arrow::datatypes::Schema as ArrowSchema;
+use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
+use delta_kernel::engine::arrow_data::ArrowEngineData;
+use delta_kernel::engine::default::executor::tokio::TokioBackgroundExecutor;
+use delta_kernel::engine::default::parquet::DefaultParquetHandler;
+use delta_kernel::object_store::local::LocalFileSystem;
+use delta_kernel::schema::{
+    ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, StructField, StructType,
+};
+use delta_kernel::{EngineData, ParquetHandler};
+use rstest::rstest;
+use test_utils::nested_ids_json;
+use url::Url;
+
+use crate::common::write_utils::collect_all_parquet_field_ids;
+
+#[rstest]
+#[case::parquet_field_nested_ids(ColumnMetadataKey::ParquetFieldNestedIds.as_ref())]
+#[case::delta_column_mapping_nested_ids(ColumnMetadataKey::ColumnMappingNestedIds.as_ref())]
+#[tokio::test]
+async fn test_nested_field_ids_round_trip(#[case] nested_ids_meta_key: &str) {
+    let kernel_schema = build_kernel_schema(nested_ids_meta_key);
+    let arrow_schema: ArrowSchema = (&kernel_schema).try_into_arrow().unwrap();
+
+    // Empty record batch is enough; the parquet writer still emits the schema (with field ids)
+    // in the file footer regardless of row count.
+    let record_batch = RecordBatch::new_empty(Arc::new(arrow_schema));
+    let local_path = write_via_default_engine(record_batch);
+    let id_by_path = collect_all_parquet_field_ids(&local_path);
+
+    let expected: HashMap<String, i64> = [
+        // array_in_map: map<int, array<int>>
+        ("array_in_map", 1),
+        ("array_in_map.key_value.key", 100),
+        ("array_in_map.key_value.value", 101),
+        ("array_in_map.key_value.value.list.element", 102),
+        // map_in_list: list<map<int, int>>
+        ("map_in_list", 2),
+        ("map_in_list.list.element", 200),
+        ("map_in_list.list.element.key_value.key", 201),
+        ("map_in_list.list.element.key_value.value", 202),
+    ]
+    .into_iter()
+    .map(|(k, v)| (k.to_string(), v))
+    .collect();
+    assert_eq!(
+        id_by_path, expected,
+        "parquet field ids by path don't match expected; got {id_by_path:?}",
+    );
+}
+
+/// Build a kernel schema with two doubly nested top-level fields. `nested_ids_meta_key` chooses
+/// which metadata key carries the nested-id JSON on each top-level field.
+///
+/// Layout:
+/// - `array_in_map: map<int, array<int>>`
+///   - top-level parquet.field.id = 1
+///   - nested ids: `array_in_map.key` -> 100, `.value` -> 101, `.value.element` -> 102
+/// - `map_in_list: list<map<int, int>>`
+///   - top-level parquet.field.id = 2
+///   - nested ids: `map_in_list.element` -> 200, `.element.key` -> 201, `.element.value` -> 202
+fn build_kernel_schema(nested_ids_meta_key: &str) -> StructType {
+    let with_field_ids = |name: &str, dtype, top_id: i64, nested: &[(&str, i64)]| {
+        StructField::nullable(name, dtype).with_metadata([
+            (
+                ColumnMetadataKey::ParquetFieldId.as_ref(),
+                MetadataValue::from(top_id),
+            ),
+            (
+                nested_ids_meta_key,
+                MetadataValue::Other(nested_ids_json(nested)),
+            ),
+        ])
+    };
+
+    let array_in_map = with_field_ids(
+        "array_in_map",
+        DataType::Map(Box::new(MapType::new(
+            DataType::INTEGER,
+            DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+            true,
+        ))),
+        1,
+        &[
+            ("array_in_map.key", 100),
+            ("array_in_map.value", 101),
+            ("array_in_map.value.element", 102),
+        ],
+    );
+
+    let map_in_list = with_field_ids(
+        "map_in_list",
+        DataType::Array(Box::new(ArrayType::new(
+            DataType::Map(Box::new(MapType::new(
+                DataType::INTEGER,
+                DataType::INTEGER,
+                true,
+            ))),
+            true,
+        ))),
+        2,
+        &[
+            ("map_in_list.element", 200),
+            ("map_in_list.element.key", 201),
+            ("map_in_list.element.value", 202),
+        ],
+    );
+
+    StructType::try_new(vec![array_in_map, map_in_list]).unwrap()
+}
+
+/// Write `record_batch` via the `ParquetHandler::write_parquet_file` trait method to a
+/// temp directory and return the resulting on-disk path.
+fn write_via_default_engine(record_batch: RecordBatch) -> std::path::PathBuf {
+    let temp_dir = tempfile::tempdir().unwrap();
+    // Keep the tempdir so the file outlives this function; the OS cleans it up on test exit.
+    let dir_path = temp_dir.keep();
+    let file_path = dir_path.join("data.parquet");
+    let location = Url::from_file_path(&file_path).unwrap();
+
+    let store = Arc::new(LocalFileSystem::new());
+    let handler = DefaultParquetHandler::new(store, Arc::new(TokioBackgroundExecutor::new()));
+    let data: Box<dyn Iterator<Item = delta_kernel::DeltaResult<Box<dyn EngineData>>> + Send> =
+        Box::new(std::iter::once(Ok(
+            Box::new(ArrowEngineData::new(record_batch)) as Box<dyn EngineData>,
+        )));
+
+    ParquetHandler::write_parquet_file(&handler, location, data).unwrap();
+    file_path
+}

--- a/kernel/tests/integration/write/nested_field_ids.rs
+++ b/kernel/tests/integration/write/nested_field_ids.rs
@@ -13,17 +13,14 @@ use delta_kernel::schema::{
     ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, StructField, StructType,
 };
 use delta_kernel::{EngineData, ParquetHandler};
-use rstest::rstest;
 use test_utils::nested_ids_json;
 use url::Url;
 
 use crate::common::write_utils::collect_all_parquet_field_ids;
 
-#[rstest]
-#[case::parquet_field_nested_ids(ColumnMetadataKey::ParquetFieldNestedIds.as_ref())]
-#[case::delta_column_mapping_nested_ids(ColumnMetadataKey::ColumnMappingNestedIds.as_ref())]
 #[tokio::test]
-async fn test_nested_field_ids_round_trip(#[case] nested_ids_meta_key: &str) {
+async fn test_nested_field_ids_round_trip() {
+    let nested_ids_meta_key = ColumnMetadataKey::ColumnMappingNestedIds.as_ref();
     let kernel_schema = build_kernel_schema(nested_ids_meta_key);
     let arrow_schema: ArrowSchema = (&kernel_schema).try_into_arrow().unwrap();
 
@@ -54,8 +51,7 @@ async fn test_nested_field_ids_round_trip(#[case] nested_ids_meta_key: &str) {
     );
 }
 
-/// Build a kernel schema with two doubly nested top-level fields. `nested_ids_meta_key` chooses
-/// which metadata key carries the nested-id JSON on each top-level field.
+/// Build a kernel schema with two doubly nested top-level fields.
 ///
 /// Layout:
 /// - `array_in_map: map<int, array<int>>`

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -1262,6 +1262,21 @@ pub fn remove_all_and_get_remove_actions(
     read_actions_from_commit(table_url, committed.commit_version(), "remove")
 }
 
+/// Build a `serde_json::Value` mapping nested dot-paths to ids.
+///
+/// For example, `nested_ids_json(&[("array_in_map.key", 100)])` builds:
+///
+/// ```json
+/// { "array_in_map.key": 100 }
+/// ```
+pub fn nested_ids_json(entries: &[(&str, i64)]) -> serde_json::Value {
+    let obj: serde_json::Map<String, serde_json::Value> = entries
+        .iter()
+        .map(|(k, v)| (k.to_string(), serde_json::Value::from(*v)))
+        .collect();
+    serde_json::Value::Object(obj)
+}
+
 /// Asserts that `action["partitionValues"]` contains the given key with the expected value.
 pub fn assert_partition_values(action: &serde_json::Value, key: &str, expected_value: &str) {
     let pv = action["partitionValues"]


### PR DESCRIPTION
## Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2508/files) to review incremental changes.
- [stack/add-v3-feature](https://github.com/delta-io/delta-kernel-rs/pull/2475) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2475/files)] [MERGED]
  - [stack/write-part-when-ice3](https://github.com/delta-io/delta-kernel-rs/pull/2504) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2504/files)] [MERGED]
    - [stack/block-alter-table](https://github.com/delta-io/delta-kernel-rs/pull/2505) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2505/files)] [MERGED]
      - [**stack/write-nested-id**](https://github.com/delta-io/delta-kernel-rs/pull/2508) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2508/files)]
        - [stack/detect-no-num](https://github.com/delta-io/delta-kernel-rs/pull/2512) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2512/files/bd48ce6fe07b0773c781f5dc35540c195094c1be..b8384ac7ebe8eb082136a38b56fb1a25fb036722)]
          - [stack/create-ice-v3-table](https://github.com/delta-io/delta-kernel-rs/pull/2517) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2517/files/b8384ac7ebe8eb082136a38b56fb1a25fb036722..c841272404f52a8c04e586ee2147aa90c3b773aa)]
            - [stack/support-ice-v3](https://github.com/delta-io/delta-kernel-rs/pull/2518) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2518/files/c841272404f52a8c04e586ee2147aa90c3b773aa..dcc69fcf8358b54e3367957665eb62cf52e822fb)]

---------
## What changes are proposed in this pull request?

Added the functionality to attach parquet field id for key/value/element in kernel map/array, when we transform a kernel schema to arrow schema in `DefaultEngine`. Added comments on `engine` trait stating `engine` need to be aware of the nested parquet id metadata as well.

Note: The protocol defines a metadata `parquet.field.nested.ids` but it will be replaced by `delta.columnMapping.nested.ids` soon. We only supports `delta.columnMapping.nested.ids` in the PR to keep simple. We will raise error for `delta.columnMapping.nested.ids`  in logical schema as a defense. Reference: https://github.com/delta-io/delta/issues/6688

Recommended review start: `ArrowField::try_from_kernel`, `apply_schema`, and `StructField::try_from_arrow`. These three func are entrance of transforming kernel schema to arrow schema, or applying kernel schema onto arrow data


## How was this change tested?
Integration test:
1. Create a `RecordBatch` and kernel schema with nested parquet id. Write to a parquet file and read the raw just-written parquet to validate the field ids are correctly written.

Unit tests:
For both `ArrowField::try_from_kernel` and `apply_schema`
1. Deep nested schema `struct<map<array, struct<map<array,int>>>>` to validate parquet id attaching properly.
2. Test both metadata keys `parquet.field.nested.ids` and `delta.columnMapping.nested.ids`
3. Test error cases(`parquet.field.nested.ids` is not a json, `parquet.field.nested.ids` contains non-integer parquet id)

For apply_schema
1. Arrow data with existing metadata and existing parquet id, validates the metadata is reserved and the existing parquet id is override by kernel schema

For `StructField::try_from_arrow`:
1. Deep nested schema `struct<map<array, struct<map<array,int>>>>` to validate parquet nested id metadata filled correctly.
2. When arrow schema doesn't contain nested parquet id, the parquet id metadata in kernel is not filled
3. Error case(parquet id not an integer)
4. Test against various arrow list type(e.g. largelist)