### PR TITLE
feat: expose ffi accessors for column mapping write path

### DIFF
--- a/ffi/examples/write-table/README.md
+++ b/ffi/examples/write-table/README.md
@@ -2,7 +2,8 @@ write-table
 ===========
 
 C FFI example for the write transaction surface. Demonstrates `transaction`,
-`with_engine_info`, `get_unpartitioned_write_context`, `get_write_schema`, `get_write_path`,
+`with_engine_info`, `get_unpartitioned_write_context`, the four write-context accessors
+(`get_write_schema`, `get_physical_write_schema`, `get_logical_to_physical`, `get_write_path`),
 `set_data_change`, and `commit` against an existing table.
 
 # Building

--- a/ffi/examples/write-table/write_table.c
+++ b/ffi/examples/write-table/write_table.c
@@ -18,8 +18,14 @@
 // Demonstrates the write-path FFI surface:
 //   - transaction(path, engine) to start an existing-table transaction
 //   - with_engine_info(txn, "...", engine) to set commitInfo.engineInfo
-//   - get_unpartitioned_write_context(txn, engine) + get_write_schema/get_write_path
-//     (the values an engine needs when writing parquet files itself)
+//   - get_unpartitioned_write_context(txn, engine) plus the four
+//     write-context accessors an engine needs when writing parquet files itself:
+//       - get_write_schema           -- logical (user-facing) schema
+//       - get_physical_write_schema  -- on-disk parquet schema (carries
+//                                       parquet.field.id under column mapping)
+//       - get_logical_to_physical    -- transform to apply per batch
+//       - get_write_path             -- table root URL (partitioned write
+//                                       directory support tracked by #2355)
 //   - set_data_change(txn, false) because this empty commit does not add data
 //   - commit(txn, engine) to produce an empty commit
 //   - Reading the committed version back via a new snapshot to confirm
@@ -86,9 +92,9 @@ int main(int argc, char* argv[]) {
 
   // === Inspect the unpartitioned write context ===
   //
-  // The WriteContext tells an engine what schema its parquet writer should use and where to
-  // put the files. This example does not actually write any files, but we print these so
-  // users see the shape of the information they'd consume in a real engine.
+  // The WriteContext carries the schema an engine's parquet writer should use plus the table
+  // root URL it should write under. This example does not actually write any files, but we
+  // print these so users see the shape of the information they'd consume in a real engine.
   ExternResultHandleSharedWriteContext wc_res = get_unpartitioned_write_context(txn, engine);
   if (wc_res.tag != OkHandleSharedWriteContext) {
     print_error("get_unpartitioned_write_context failed.", (Error*)wc_res.err);
@@ -99,19 +105,28 @@ int main(int argc, char* argv[]) {
   }
   SharedWriteContext* write_context = wc_res.ok;
 
-  // SharedSchema is opaque in the C API; engines typically walk it with visit_schema (see
-  // read-table/schema.h). We just confirm we got a valid handle and then free it.
-  SharedSchema* write_schema = get_write_schema(write_context);
+  // SharedSchema and SharedExpression are opaque in the C API. Schemas are walked with
+  // visit_schema (see read-table/schema.h); expressions are consumed by passing them to
+  // new_expression_evaluator. A real engine feeds (logical_schema, logical_to_physical,
+  // physical_schema) into new_expression_evaluator and applies the resulting evaluator to
+  // each batch before handing the rewritten data to its parquet writer.
+  SharedSchema* logical_schema = get_write_schema(write_context);
+  SharedSchema* physical_schema = get_physical_write_schema(write_context);
+  SharedExpression* logical_to_physical = get_logical_to_physical(write_context);
   printf("Write context:\n");
-  printf("  schema_handle: %s\n", write_schema ? "<obtained>" : "<null>");
+  printf("  logical_schema:      %s\n", logical_schema ? "<obtained>" : "<null>");
+  printf("  physical_schema:     %s\n", physical_schema ? "<obtained>" : "<null>");
+  printf("  logical_to_physical: %s\n", logical_to_physical ? "<obtained>" : "<null>");
   char* write_path = get_write_path(write_context, allocate_string);
   if (write_path) {
-    printf("  write_path:    %s\n", write_path);
+    printf("  write_path:          %s\n", write_path);
     free(write_path);
   } else {
-    printf("  write_path:    <none>\n");
+    printf("  write_path:          <none>\n");
   }
-  free_schema(write_schema);
+  free_kernel_expression(logical_to_physical);
+  free_schema(physical_schema);
+  free_schema(logical_schema);
   free_write_context(write_context);
 
   // === Commit ===

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -1525,10 +1525,6 @@ mod tests {
         unsafe { free_engine(engine) };
     }
 
-    /// Verifies that the FFI write-context accessors expose CM-aware write metadata for both
-    /// `Name` and `Id` modes: physical schema field names differ from logical names and carry
-    /// the `parquet.field.id` metadata that Delta's writer requirements for column mapping
-    /// require.
     #[rstest]
     #[case::name_mode("name")]
     #[case::id_mode("id")]
@@ -1552,24 +1548,18 @@ mod tests {
                 engine.shallow_copy(),
             )
         });
-
-        // Build the create-table transaction (do not commit -- we only need the WriteContext).
         let txn =
             ok_or_panic(unsafe { create_table_builder_build(builder, engine.shallow_copy()) });
-
         let write_context = ok_or_panic(unsafe {
             create_table_get_unpartitioned_write_context(txn.shallow_copy(), engine.shallow_copy())
         });
 
-        // Logical schema retains user-facing names.
         let logical = unsafe { get_write_schema(write_context.shallow_copy()) };
         let logical_ref = unsafe { logical.as_ref() };
         assert_eq!(logical_ref.num_fields(), 2);
         assert_eq!(logical_ref.field_at_index(0).unwrap().name, "id");
         assert_eq!(logical_ref.field_at_index(1).unwrap().name, "name");
 
-        // Physical schema has CM-assigned physical names distinct from logical names, and
-        // each field carries the parquet.field.id metadata required by the Delta protocol.
         let physical = unsafe { get_physical_write_schema(write_context.shallow_copy()) };
         let physical_ref = unsafe { physical.as_ref() };
         assert_eq!(physical_ref.num_fields(), 2);
@@ -1586,9 +1576,6 @@ mod tests {
             );
         }
 
-        // Smoke-check that the transform handle is reachable. The kernel-side
-        // `validate_logical_to_physical_transform` test covers expression semantics;
-        // `test_cm_write_context_evaluator_composition` (below) covers FFI composition.
         let l2p = unsafe { get_logical_to_physical(write_context.shallow_copy()) };
 
         unsafe { free_kernel_expression(l2p) };
@@ -1599,10 +1586,8 @@ mod tests {
         unsafe { free_engine(engine) };
     }
 
-    /// Composes all three FFI accessors into a [`new_expression_evaluator`] call to prove the
-    /// documented contract on `get_logical_to_physical`: an engine can construct an evaluator
-    /// from `(logical, l2p, physical)` and have it succeed. Catches handle-wiring mistakes
-    /// the smoke test in `test_cm_write_context_accessors` cannot.
+    /// Builds an evaluator from (logical, l2p, physical) to verify the three FFI write-context
+    /// accessors compose correctly.
     #[test]
     #[cfg_attr(miri, ignore)]
     fn test_cm_write_context_evaluator_composition() {

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -614,7 +614,9 @@ mod tests {
     use tempfile::tempdir;
     use test_utils::{set_json_value, setup_test_tables, test_read};
     use write_context::{
-        free_write_context, get_unpartitioned_write_context, get_write_path, get_write_schema,
+        create_table_get_unpartitioned_write_context, free_write_context, get_logical_to_physical,
+        get_physical_write_schema, get_unpartitioned_write_context, get_write_path,
+        get_write_schema,
     };
 
     use super::*;
@@ -1517,6 +1519,84 @@ mod tests {
         assert!(config.is_feature_enabled(&TableFeature::AppendOnly));
 
         unsafe { free_snapshot(snap) };
+        unsafe { free_engine(engine) };
+    }
+
+    /// Verifies that the FFI write-context accessors needed to write a column-mapping table --
+    /// `get_write_schema` (logical), `get_physical_write_schema` (physical names + parquet
+    /// field IDs), and `get_logical_to_physical` (transform expression) -- produce a
+    /// physical schema whose field names differ from the logical names and a non-null
+    /// transform expression handle. Together these are what an FFM-side engine must thread
+    /// through its evaluator + parquet writer to write a CM-enabled table.
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_cm_write_context_accessors() {
+        use crate::expressions::free_kernel_expression;
+
+        let tmp_dir = tempdir().unwrap();
+        let (_table_path, engine, builder) = create_table_builder(
+            &tmp_dir,
+            vec![
+                StructField::nullable("id", DataType::INTEGER),
+                StructField::nullable("name", DataType::STRING),
+            ],
+        );
+
+        // Enable column mapping in name mode. Kernel will assign physical names like
+        // `col-<uuid>` to every field during build.
+        let cm_key = "delta.columnMapping.mode";
+        let cm_val = "name";
+        let builder = ok_or_panic(unsafe {
+            create_table_builder_with_table_property(
+                builder,
+                kernel_string_slice!(cm_key),
+                kernel_string_slice!(cm_val),
+                engine.shallow_copy(),
+            )
+        });
+
+        // Build the create-table transaction (do not commit -- we only need the WriteContext).
+        let txn =
+            ok_or_panic(unsafe { create_table_builder_build(builder, engine.shallow_copy()) });
+
+        let write_context = ok_or_panic(unsafe {
+            create_table_get_unpartitioned_write_context(txn.shallow_copy(), engine.shallow_copy())
+        });
+
+        // Logical schema retains user-facing names.
+        let logical = unsafe { get_write_schema(write_context.shallow_copy()) };
+        let logical_ref = unsafe { logical.as_ref() };
+        assert_eq!(logical_ref.num_fields(), 2);
+        assert_eq!(logical_ref.field_at_index(0).unwrap().name, "id");
+        assert_eq!(logical_ref.field_at_index(1).unwrap().name, "name");
+
+        // Physical schema has CM-assigned `col-<uuid>` names. Distinct from logical names.
+        let physical = unsafe { get_physical_write_schema(write_context.shallow_copy()) };
+        let physical_ref = unsafe { physical.as_ref() };
+        assert_eq!(physical_ref.num_fields(), 2);
+        let phys_id = &physical_ref.field_at_index(0).unwrap().name;
+        let phys_name = &physical_ref.field_at_index(1).unwrap().name;
+        assert!(
+            phys_id.starts_with("col-"),
+            "expected CM physical name prefix `col-`, got {phys_id}"
+        );
+        assert!(
+            phys_name.starts_with("col-"),
+            "expected CM physical name prefix `col-`, got {phys_name}"
+        );
+        assert_ne!(phys_id, "id");
+        assert_ne!(phys_name, "name");
+
+        // Logical-to-physical transform handle is reachable; the kernel-built expression
+        // currently only drops partition columns. We do not evaluate it here -- the rename
+        // is carried by the physical schema above.
+        let l2p = unsafe { get_logical_to_physical(write_context.shallow_copy()) };
+
+        unsafe { free_kernel_expression(l2p) };
+        unsafe { free_schema(physical) };
+        unsafe { free_schema(logical) };
+        unsafe { free_write_context(write_context) };
+        unsafe { create_table_free_transaction(txn) };
         unsafe { free_engine(engine) };
     }
 

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -600,7 +600,7 @@ mod tests {
     use delta_kernel::object_store::{DynObjectStore, ObjectStoreExt as _};
     use delta_kernel::parquet::arrow::arrow_writer::ArrowWriter;
     use delta_kernel::parquet::file::properties::WriterProperties;
-    use delta_kernel::schema::{DataType, StructField, StructType};
+    use delta_kernel::schema::{DataType, MetadataValue, StructField, StructType};
     use delta_kernel::table_features::TableFeature;
     use delta_kernel_ffi::engine_data::{get_engine_data, ArrowFFIData};
     use delta_kernel_ffi::error::KernelError;
@@ -610,6 +610,7 @@ mod tests {
     };
     use delta_kernel_ffi::tests::get_default_engine;
     use itertools::Itertools;
+    use rstest::rstest;
     use serde_json::{json, Deserializer};
     use tempfile::tempdir;
     use test_utils::{set_json_value, setup_test_tables, test_read};
@@ -620,6 +621,8 @@ mod tests {
     };
 
     use super::*;
+    use crate::engine_funcs::{free_expression_evaluator, new_expression_evaluator};
+    use crate::expressions::free_kernel_expression;
     use crate::schema_visitor::{
         visit_field_integer, visit_field_long, visit_field_string, visit_field_struct,
     };
@@ -1522,17 +1525,15 @@ mod tests {
         unsafe { free_engine(engine) };
     }
 
-    /// Verifies that the FFI write-context accessors needed to write a column-mapping table --
-    /// `get_write_schema` (logical), `get_physical_write_schema` (physical names + parquet
-    /// field IDs), and `get_logical_to_physical` (transform expression) -- produce a
-    /// physical schema whose field names differ from the logical names and a non-null
-    /// transform expression handle. Together these are what an FFM-side engine must thread
-    /// through its evaluator + parquet writer to write a CM-enabled table.
-    #[test]
+    /// Verifies that the FFI write-context accessors expose CM-aware write metadata for both
+    /// `Name` and `Id` modes: physical schema field names differ from logical names and carry
+    /// the `parquet.field.id` metadata that Delta's writer requirements for column mapping
+    /// require.
+    #[rstest]
+    #[case::name_mode("name")]
+    #[case::id_mode("id")]
     #[cfg_attr(miri, ignore)]
-    fn test_cm_write_context_accessors() {
-        use crate::expressions::free_kernel_expression;
-
+    fn test_cm_write_context_accessors(#[case] cm_mode: &str) {
         let tmp_dir = tempdir().unwrap();
         let (_table_path, engine, builder) = create_table_builder(
             &tmp_dir,
@@ -1542,15 +1543,12 @@ mod tests {
             ],
         );
 
-        // Enable column mapping in name mode. Kernel will assign physical names like
-        // `col-<uuid>` to every field during build.
         let cm_key = "delta.columnMapping.mode";
-        let cm_val = "name";
         let builder = ok_or_panic(unsafe {
             create_table_builder_with_table_property(
                 builder,
                 kernel_string_slice!(cm_key),
-                kernel_string_slice!(cm_val),
+                kernel_string_slice!(cm_mode),
                 engine.shallow_copy(),
             )
         });
@@ -1570,28 +1568,82 @@ mod tests {
         assert_eq!(logical_ref.field_at_index(0).unwrap().name, "id");
         assert_eq!(logical_ref.field_at_index(1).unwrap().name, "name");
 
-        // Physical schema has CM-assigned `col-<uuid>` names. Distinct from logical names.
+        // Physical schema has CM-assigned physical names distinct from logical names, and
+        // each field carries the parquet.field.id metadata required by the Delta protocol.
         let physical = unsafe { get_physical_write_schema(write_context.shallow_copy()) };
         let physical_ref = unsafe { physical.as_ref() };
         assert_eq!(physical_ref.num_fields(), 2);
-        let phys_id = &physical_ref.field_at_index(0).unwrap().name;
-        let phys_name = &physical_ref.field_at_index(1).unwrap().name;
-        assert!(
-            phys_id.starts_with("col-"),
-            "expected CM physical name prefix `col-`, got {phys_id}"
-        );
-        assert!(
-            phys_name.starts_with("col-"),
-            "expected CM physical name prefix `col-`, got {phys_name}"
-        );
-        assert_ne!(phys_id, "id");
-        assert_ne!(phys_name, "name");
+        for (i, logical_name) in ["id", "name"].iter().enumerate() {
+            let field = physical_ref.field_at_index(i).unwrap();
+            assert_ne!(
+                &field.name, logical_name,
+                "physical name for field {i} must differ from logical name {logical_name}"
+            );
+            let field_id = field.metadata.get("parquet.field.id");
+            assert!(
+                matches!(field_id, Some(MetadataValue::Number(_))),
+                "field {i} must carry parquet.field.id metadata as a Number, got {field_id:?}"
+            );
+        }
 
-        // Logical-to-physical transform handle is reachable; the kernel-built expression
-        // currently only drops partition columns. We do not evaluate it here -- the rename
-        // is carried by the physical schema above.
+        // Smoke-check that the transform handle is reachable. The kernel-side
+        // `validate_logical_to_physical_transform` test covers expression semantics;
+        // `test_cm_write_context_evaluator_composition` (below) covers FFI composition.
         let l2p = unsafe { get_logical_to_physical(write_context.shallow_copy()) };
 
+        unsafe { free_kernel_expression(l2p) };
+        unsafe { free_schema(physical) };
+        unsafe { free_schema(logical) };
+        unsafe { free_write_context(write_context) };
+        unsafe { create_table_free_transaction(txn) };
+        unsafe { free_engine(engine) };
+    }
+
+    /// Composes all three FFI accessors into a [`new_expression_evaluator`] call to prove the
+    /// documented contract on `get_logical_to_physical`: an engine can construct an evaluator
+    /// from `(logical, l2p, physical)` and have it succeed. Catches handle-wiring mistakes
+    /// the smoke test in `test_cm_write_context_accessors` cannot.
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_cm_write_context_evaluator_composition() {
+        let tmp_dir = tempdir().unwrap();
+        let (_table_path, engine, builder) = create_table_builder(
+            &tmp_dir,
+            vec![
+                StructField::nullable("id", DataType::INTEGER),
+                StructField::nullable("name", DataType::STRING),
+            ],
+        );
+        let cm_key = "delta.columnMapping.mode";
+        let cm_val = "name";
+        let builder = ok_or_panic(unsafe {
+            create_table_builder_with_table_property(
+                builder,
+                kernel_string_slice!(cm_key),
+                kernel_string_slice!(cm_val),
+                engine.shallow_copy(),
+            )
+        });
+        let txn =
+            ok_or_panic(unsafe { create_table_builder_build(builder, engine.shallow_copy()) });
+        let write_context = ok_or_panic(unsafe {
+            create_table_get_unpartitioned_write_context(txn.shallow_copy(), engine.shallow_copy())
+        });
+
+        let logical = unsafe { get_write_schema(write_context.shallow_copy()) };
+        let physical = unsafe { get_physical_write_schema(write_context.shallow_copy()) };
+        let l2p = unsafe { get_logical_to_physical(write_context.shallow_copy()) };
+
+        let evaluator = ok_or_panic(unsafe {
+            new_expression_evaluator(
+                engine.shallow_copy(),
+                logical.shallow_copy(),
+                l2p.as_ref(),
+                physical.shallow_copy(),
+            )
+        });
+
+        unsafe { free_expression_evaluator(evaluator) };
         unsafe { free_kernel_expression(l2p) };
         unsafe { free_schema(physical) };
         unsafe { free_schema(logical) };

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -1623,13 +1623,15 @@ mod tests {
             )
         });
 
-        unsafe { free_expression_evaluator(evaluator) };
-        unsafe { free_kernel_expression(l2p) };
-        unsafe { free_schema(physical) };
-        unsafe { free_schema(logical) };
-        unsafe { free_write_context(write_context) };
-        unsafe { create_table_free_transaction(txn) };
-        unsafe { free_engine(engine) };
+        unsafe {
+            free_expression_evaluator(evaluator);
+            free_kernel_expression(l2p);
+            free_schema(physical);
+            free_schema(logical);
+            free_write_context(write_context);
+            create_table_free_transaction(txn);
+            free_engine(engine);
+        }
     }
 
     #[tokio::test]

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -600,7 +600,9 @@ mod tests {
     use delta_kernel::object_store::{DynObjectStore, ObjectStoreExt as _};
     use delta_kernel::parquet::arrow::arrow_writer::ArrowWriter;
     use delta_kernel::parquet::file::properties::WriterProperties;
-    use delta_kernel::schema::{DataType, MetadataValue, StructField, StructType};
+    use delta_kernel::schema::{
+        ColumnMetadataKey, DataType, MetadataValue, StructField, StructType,
+    };
     use delta_kernel::table_features::TableFeature;
     use delta_kernel_ffi::engine_data::{get_engine_data, ArrowFFIData};
     use delta_kernel_ffi::error::KernelError;
@@ -617,7 +619,7 @@ mod tests {
     use write_context::{
         create_table_get_unpartitioned_write_context, free_write_context, get_logical_to_physical,
         get_physical_write_schema, get_unpartitioned_write_context, get_write_path,
-        get_write_schema,
+        get_write_schema, SharedWriteContext,
     };
 
     use super::*;
@@ -1525,100 +1527,93 @@ mod tests {
         unsafe { free_engine(engine) };
     }
 
-    #[rstest]
-    #[case::name_mode("name")]
-    #[case::id_mode("id")]
-    #[cfg_attr(miri, ignore)]
-    fn test_cm_write_context_accessors(#[case] cm_mode: &str) {
-        let tmp_dir = tempdir().unwrap();
-        let (_table_path, engine, builder) = create_table_builder(
-            &tmp_dir,
+    /// Builds a create-table transaction and its unpartitioned write context, optionally
+    /// enabling column mapping. Returns handles the caller must free.
+    fn cm_table_write_context(
+        tmp_dir: &tempfile::TempDir,
+        cm_mode: Option<&str>,
+    ) -> (
+        Handle<SharedExternEngine>,
+        Handle<ExclusiveCreateTransaction>,
+        Handle<SharedWriteContext>,
+    ) {
+        let (_table_path, engine, mut builder) = create_table_builder(
+            tmp_dir,
             vec![
                 StructField::nullable("id", DataType::INTEGER),
                 StructField::nullable("name", DataType::STRING),
             ],
         );
-
-        let cm_key = "delta.columnMapping.mode";
-        let builder = ok_or_panic(unsafe {
-            create_table_builder_with_table_property(
-                builder,
-                kernel_string_slice!(cm_key),
-                kernel_string_slice!(cm_mode),
-                engine.shallow_copy(),
-            )
-        });
+        if let Some(mode) = cm_mode {
+            let cm_key = "delta.columnMapping.mode";
+            builder = ok_or_panic(unsafe {
+                create_table_builder_with_table_property(
+                    builder,
+                    kernel_string_slice!(cm_key),
+                    kernel_string_slice!(mode),
+                    engine.shallow_copy(),
+                )
+            });
+        }
         let txn =
             ok_or_panic(unsafe { create_table_builder_build(builder, engine.shallow_copy()) });
         let write_context = ok_or_panic(unsafe {
             create_table_get_unpartitioned_write_context(txn.shallow_copy(), engine.shallow_copy())
         });
+        (engine, txn, write_context)
+    }
+
+    #[rstest]
+    #[case::no_column_mapping(None)]
+    #[case::name_mode(Some("name"))]
+    #[case::id_mode(Some("id"))]
+    #[cfg_attr(miri, ignore)]
+    fn test_write_context_accessors(#[case] cm_mode: Option<&str>) {
+        let tmp_dir = tempdir().unwrap();
+        let (engine, txn, write_context) = cm_table_write_context(&tmp_dir, cm_mode);
 
         let logical = unsafe { get_write_schema(write_context.shallow_copy()) };
+        let physical = unsafe { get_physical_write_schema(write_context.shallow_copy()) };
+        let l2p = unsafe { get_logical_to_physical(write_context.shallow_copy()) };
+
         let logical_ref = unsafe { logical.as_ref() };
+        let physical_ref = unsafe { physical.as_ref() };
         assert_eq!(logical_ref.num_fields(), 2);
+        assert_eq!(physical_ref.num_fields(), 2);
         assert_eq!(logical_ref.field_at_index(0).unwrap().name, "id");
         assert_eq!(logical_ref.field_at_index(1).unwrap().name, "name");
 
-        let physical = unsafe { get_physical_write_schema(write_context.shallow_copy()) };
-        let physical_ref = unsafe { physical.as_ref() };
-        assert_eq!(physical_ref.num_fields(), 2);
+        let field_id_key = ColumnMetadataKey::ParquetFieldId.as_ref();
         for (i, logical_name) in ["id", "name"].iter().enumerate() {
             let field = physical_ref.field_at_index(i).unwrap();
-            assert_ne!(
-                &field.name, logical_name,
-                "physical name for field {i} must differ from logical name {logical_name}"
-            );
-            let field_id = field.metadata.get("parquet.field.id");
-            assert!(
-                matches!(field_id, Some(MetadataValue::Number(_))),
-                "field {i} must carry parquet.field.id metadata as a Number, got {field_id:?}"
-            );
+            let field_id = field.metadata.get(field_id_key);
+            match cm_mode {
+                Some(_) => {
+                    // Column mapping rewrites each logical name to a fresh `col-<uuid>` per
+                    // the Delta protocol's column-mapping section, and stamps a numeric
+                    // `parquet.field.id` so the field id reaches the parquet file.
+                    assert!(
+                        field.name.starts_with("col-"),
+                        "field {i}: expected `col-<uuid>` physical name, got {:?}",
+                        field.name,
+                    );
+                    assert_ne!(&field.name, logical_name);
+                    assert!(
+                        matches!(field_id, Some(MetadataValue::Number(_))),
+                        "field {i}: parquet.field.id should be a Number, got {field_id:?}",
+                    );
+                }
+                None => {
+                    assert_eq!(&field.name, logical_name);
+                    assert!(
+                        field_id.is_none(),
+                        "field {i}: parquet.field.id should be absent without column mapping, got {field_id:?}",
+                    );
+                }
+            }
         }
 
-        let l2p = unsafe { get_logical_to_physical(write_context.shallow_copy()) };
-
-        unsafe { free_kernel_expression(l2p) };
-        unsafe { free_schema(physical) };
-        unsafe { free_schema(logical) };
-        unsafe { free_write_context(write_context) };
-        unsafe { create_table_free_transaction(txn) };
-        unsafe { free_engine(engine) };
-    }
-
-    /// Builds an evaluator from (logical, l2p, physical) to verify the three FFI write-context
-    /// accessors compose correctly.
-    #[test]
-    #[cfg_attr(miri, ignore)]
-    fn test_cm_write_context_evaluator_composition() {
-        let tmp_dir = tempdir().unwrap();
-        let (_table_path, engine, builder) = create_table_builder(
-            &tmp_dir,
-            vec![
-                StructField::nullable("id", DataType::INTEGER),
-                StructField::nullable("name", DataType::STRING),
-            ],
-        );
-        let cm_key = "delta.columnMapping.mode";
-        let cm_val = "name";
-        let builder = ok_or_panic(unsafe {
-            create_table_builder_with_table_property(
-                builder,
-                kernel_string_slice!(cm_key),
-                kernel_string_slice!(cm_val),
-                engine.shallow_copy(),
-            )
-        });
-        let txn =
-            ok_or_panic(unsafe { create_table_builder_build(builder, engine.shallow_copy()) });
-        let write_context = ok_or_panic(unsafe {
-            create_table_get_unpartitioned_write_context(txn.shallow_copy(), engine.shallow_copy())
-        });
-
-        let logical = unsafe { get_write_schema(write_context.shallow_copy()) };
-        let physical = unsafe { get_physical_write_schema(write_context.shallow_copy()) };
-        let l2p = unsafe { get_logical_to_physical(write_context.shallow_copy()) };
-
+        // Smoke-check that (logical, l2p, physical) compose into a valid evaluator.
         let evaluator = ok_or_panic(unsafe {
             new_expression_evaluator(
                 engine.shallow_copy(),

--- a/ffi/src/transaction/write_context.rs
+++ b/ffi/src/transaction/write_context.rs
@@ -90,15 +90,17 @@ pub unsafe extern "C" fn get_write_schema(
 ///
 /// - Field names are physical column-mapping names (e.g. `col-<uuid>`) when column mapping is
 ///   enabled, and identical to the logical names otherwise.
-/// - Per-field `parquet.field.id` metadata is stamped under both `Id` and `Name` modes so the
-///   parquet footer carries field IDs (required by the Delta protocol).
-/// - Partition columns are excluded unless the table has the `materializePartitionColumns` feature
-///   enabled.
+/// - Field metadata carries the parquet field IDs that the Delta protocol writer requirements for
+///   column mapping mandate when column mapping is enabled.
+/// - Partition columns are excluded unless a feature requiring partition materialization (e.g.
+///   `materializePartitionColumns`) is active.
 ///
-/// Engines that perform their own logical-to-physical transformation must pass this schema
-/// as the output schema of the expression evaluator (see
-/// [`crate::engine_funcs::new_expression_evaluator`]). Engines that write parquet directly
-/// must use this as the writer's schema so that field IDs and physical names land in the file.
+/// Engines that perform their own logical-to-physical transformation must pass this schema as
+/// the output schema of the expression evaluator (see
+/// [`crate::engine_funcs::new_expression_evaluator`]). The evaluator realizes the
+/// logical->physical column rename by positionally matching input columns to the fields of
+/// this output schema. Engines that write parquet directly must use this as the writer's
+/// schema so that field IDs and physical names land in the file.
 ///
 /// The returned schema must be freed when no longer needed via [`crate::free_schema`].
 ///
@@ -116,10 +118,16 @@ pub unsafe extern "C" fn get_physical_write_schema(
 /// kernel-built [`Expression`] an engine must apply (via an [`ExpressionEvaluator`]) to
 /// every batch of logical data before writing it to a parquet file.
 ///
-/// The expression itself only encodes structural changes -- specifically, dropping partition
-/// columns when `materializePartitionColumns` is not enabled. The logical-to-physical column
-/// rename is carried by the schema returned from [`get_physical_write_schema`], not by this
-/// expression. Callers must therefore construct an evaluator with:
+/// Today the kernel-built expression only drops partition columns (when
+/// `materializePartitionColumns` is not enabled). It may grow to encode additional
+/// structural transforms over time -- for example, type coercion or generated-column
+/// materialization. Engines must always evaluate this expression against the logical
+/// batch; do not skip evaluation on the assumption it is a no-op.
+///
+/// The logical->physical column rename is carried by the schema returned from
+/// [`get_physical_write_schema`], not by this expression: the evaluator realizes the rename
+/// by positionally matching input columns to fields of the output schema. Callers must
+/// therefore construct an evaluator with:
 ///
 /// - input schema  = [`get_write_schema`] (logical)
 /// - transform     = this expression

--- a/ffi/src/transaction/write_context.rs
+++ b/ffi/src/transaction/write_context.rs
@@ -84,7 +84,8 @@ pub unsafe extern "C" fn get_write_schema(
 /// written to parquet files. With column mapping enabled, field names are physical
 /// (e.g. `col-<uuid>`) and each field has a `parquet.field.id` metadata entry per the Delta
 /// column-mapping spec; otherwise it matches the logical schema. Partition columns are
-/// excluded unless the `materializePartitionColumns` writer feature is enabled.
+/// excluded unless the `materializePartitionColumns` writer feature or `IcebergCompatV3` is
+/// enabled.
 ///
 /// Use this as the parquet writer schema and as the output schema of the evaluator built
 /// from [`get_logical_to_physical`].
@@ -103,7 +104,7 @@ pub unsafe extern "C" fn get_physical_write_schema(
 
 /// Returns the logical-to-physical transform from a [`WriteContext`] handle. Engines apply
 /// it via an [`ExpressionEvaluator`] to each batch of logical data before writing parquet.
-/// It drops partition columns when `materializePartitionColumns` is not enabled. The column
+/// It drops partition columns when partition columns are not materialized. The column
 /// rename itself is encoded in the physical schema (the evaluator matches input columns to
 /// output fields by position), not in this expression.
 ///

--- a/ffi/src/transaction/write_context.rs
+++ b/ffi/src/transaction/write_context.rs
@@ -5,6 +5,7 @@ use delta_kernel_ffi_macros::handle_descriptor;
 
 use super::{ExclusiveCreateTransaction, ExclusiveTransaction};
 use crate::error::{ExternResult, IntoExternResult};
+use crate::expressions::SharedExpression;
 use crate::handle::Handle;
 use crate::{
     kernel_string_slice, AllocateStringFn, NullableCvoid, SharedExternEngine, SharedSchema,
@@ -63,8 +64,16 @@ pub unsafe extern "C" fn free_write_context(write_context: Handle<SharedWriteCon
     write_context.drop_handle();
 }
 
-/// Get schema from WriteContext handle. The schema must be freed when no longer needed via
-/// [`free_schema`].
+/// Get the **logical** schema from a [`WriteContext`] handle. This is the user-facing schema
+/// the engine should produce as the input to its logical-to-physical transform.
+///
+/// To write a column-mapping-enabled table, an engine MUST also use
+/// [`get_physical_write_schema`] (the evaluator's output schema and the parquet writer's
+/// schema) and [`get_logical_to_physical`] (the transform expression that drops partition
+/// columns when not materialized). For non-column-mapping unpartitioned tables, the logical
+/// and physical schemas are identical.
+///
+/// The returned schema must be freed when no longer needed via [`crate::free_schema`].
 ///
 /// # Safety
 /// Engine is responsible for providing a valid WriteContext pointer
@@ -74,6 +83,62 @@ pub unsafe extern "C" fn get_write_schema(
 ) -> Handle<SharedSchema> {
     let write_context = unsafe { write_context.as_ref() };
     write_context.logical_schema().clone().into()
+}
+
+/// Get the **physical write schema** from a [`WriteContext`] handle. This is the schema of
+/// the data that will be written to parquet files:
+///
+/// - Field names are physical column-mapping names (e.g. `col-<uuid>`) when column mapping is
+///   enabled, and identical to the logical names otherwise.
+/// - Per-field `parquet.field.id` metadata is stamped under both `Id` and `Name` modes so the
+///   parquet footer carries field IDs (required by the Delta protocol).
+/// - Partition columns are excluded unless the table has the `materializePartitionColumns` feature
+///   enabled.
+///
+/// Engines that perform their own logical-to-physical transformation must pass this schema
+/// as the output schema of the expression evaluator (see
+/// [`crate::engine_funcs::new_expression_evaluator`]). Engines that write parquet directly
+/// must use this as the writer's schema so that field IDs and physical names land in the file.
+///
+/// The returned schema must be freed when no longer needed via [`crate::free_schema`].
+///
+/// # Safety
+/// Engine is responsible for providing a valid WriteContext pointer
+#[no_mangle]
+pub unsafe extern "C" fn get_physical_write_schema(
+    write_context: Handle<SharedWriteContext>,
+) -> Handle<SharedSchema> {
+    let write_context = unsafe { write_context.as_ref() };
+    write_context.physical_schema().clone().into()
+}
+
+/// Get the **logical-to-physical transform** from a [`WriteContext`] handle. This is the
+/// kernel-built [`Expression`] an engine must apply (via an [`ExpressionEvaluator`]) to
+/// every batch of logical data before writing it to a parquet file.
+///
+/// The expression itself only encodes structural changes -- specifically, dropping partition
+/// columns when `materializePartitionColumns` is not enabled. The logical-to-physical column
+/// rename is carried by the schema returned from [`get_physical_write_schema`], not by this
+/// expression. Callers must therefore construct an evaluator with:
+///
+/// - input schema  = [`get_write_schema`] (logical)
+/// - transform     = this expression
+/// - output schema = [`get_physical_write_schema`] (physical)
+///
+/// The returned expression must be freed when no longer needed via
+/// [`crate::expressions::free_kernel_expression`].
+///
+/// # Safety
+/// Engine is responsible for providing a valid WriteContext pointer
+///
+/// [`Expression`]: delta_kernel::Expression
+/// [`ExpressionEvaluator`]: delta_kernel::ExpressionEvaluator
+#[no_mangle]
+pub unsafe extern "C" fn get_logical_to_physical(
+    write_context: Handle<SharedWriteContext>,
+) -> Handle<SharedExpression> {
+    let write_context = unsafe { write_context.as_ref() };
+    write_context.logical_to_physical().into()
 }
 
 /// Get the table root URL from a WriteContext handle. Returns the table root, not the

--- a/ffi/src/transaction/write_context.rs
+++ b/ffi/src/transaction/write_context.rs
@@ -64,12 +64,11 @@ pub unsafe extern "C" fn free_write_context(write_context: Handle<SharedWriteCon
     write_context.drop_handle();
 }
 
-/// Returns the logical schema from a [`WriteContext`] handle: the user-facing schema, used as
-/// the input to the logical-to-physical transform. See [`get_logical_to_physical`] for the
-/// full evaluator recipe (input/transform/output) needed to write column-mapping-enabled
-/// tables. For non-column-mapping unpartitioned tables, logical and physical are identical.
+/// Returns the logical (user-facing) write schema from a [`WriteContext`] handle. For
+/// column-mapping-enabled writes, pair with [`get_physical_write_schema`] and
+/// [`get_logical_to_physical`].
 ///
-/// The returned schema must be freed when no longer needed via [`crate::free_schema`].
+/// The returned schema must be freed via [`crate::free_schema`].
 ///
 /// # Safety
 /// Engine is responsible for providing a valid WriteContext pointer
@@ -82,21 +81,15 @@ pub unsafe extern "C" fn get_write_schema(
 }
 
 /// Returns the physical write schema from a [`WriteContext`] handle: the schema of the data
-/// that will be written to parquet files.
+/// written to parquet files. With column mapping enabled, field names are physical
+/// (e.g. `col-<uuid>`) and each field has a `parquet.field.id` metadata entry per the Delta
+/// column-mapping spec; otherwise it matches the logical schema. Partition columns are
+/// excluded unless the `materializePartitionColumns` writer feature is enabled.
 ///
-/// - Field names are physical column-mapping names (e.g. `col-<uuid>`) when column mapping is
-///   enabled, and identical to the logical names otherwise.
-/// - Field metadata carries `parquet.field.id` entries when column mapping is enabled, per the
-///   Delta protocol writer requirements for column mapping.
-/// - Partition columns are excluded unless a feature requiring partition materialization (e.g.
-///   `materializePartitionColumns`) is active.
+/// Use this as the parquet writer schema and as the output schema of the evaluator built
+/// from [`get_logical_to_physical`].
 ///
-/// Engines doing their own logical-to-physical transformation pass this as the evaluator's
-/// output schema (see [`crate::engine_funcs::new_expression_evaluator`] and
-/// [`get_logical_to_physical`] for the full recipe). Engines writing parquet directly use
-/// this as the writer schema so field IDs and physical names land in the file.
-///
-/// The returned schema must be freed when no longer needed via [`crate::free_schema`].
+/// The returned schema must be freed via [`crate::free_schema`].
 ///
 /// # Safety
 /// Engine is responsible for providing a valid WriteContext pointer
@@ -108,31 +101,21 @@ pub unsafe extern "C" fn get_physical_write_schema(
     write_context.physical_schema().clone().into()
 }
 
-/// Returns the logical-to-physical transform from a [`WriteContext`] handle: the kernel-built
-/// [`Expression`] an engine applies (via an [`ExpressionEvaluator`]) to every batch of logical
-/// data before writing it to a parquet file.
+/// Returns the logical-to-physical transform from a [`WriteContext`] handle. Engines apply
+/// it via an [`ExpressionEvaluator`] to each batch of logical data before writing parquet.
+/// It drops partition columns when `materializePartitionColumns` is not enabled. The column
+/// rename itself is encoded in the physical schema (the evaluator matches input columns to
+/// output fields by position), not in this expression.
 ///
-/// The expression drops partition columns when `materializePartitionColumns` is not enabled,
-/// and may encode additional structural transforms (e.g. type coercion, generated-column
-/// materialization). Always evaluate it against the logical batch -- do not skip on the
-/// assumption it is a no-op.
+/// To build the evaluator, pass [`get_write_schema`] as the input, this expression as the
+/// transform, and [`get_physical_write_schema`] as the output. See
+/// [`crate::engine_funcs::new_expression_evaluator`].
 ///
-/// The logical-to-physical column rename is carried by [`get_physical_write_schema`], not by
-/// this expression: the evaluator realizes the rename by positionally matching input columns
-/// to fields of the output schema. Callers construct an evaluator (see
-/// [`crate::engine_funcs::new_expression_evaluator`]) with:
-///
-/// - input schema  = [`get_write_schema`] (logical)
-/// - transform     = this expression
-/// - output schema = [`get_physical_write_schema`] (physical)
-///
-/// The returned expression must be freed when no longer needed via
-/// [`crate::expressions::free_kernel_expression`].
+/// The returned expression must be freed via [`crate::expressions::free_kernel_expression`].
 ///
 /// # Safety
 /// Engine is responsible for providing a valid WriteContext pointer
 ///
-/// [`Expression`]: delta_kernel::Expression
 /// [`ExpressionEvaluator`]: delta_kernel::ExpressionEvaluator
 #[no_mangle]
 pub unsafe extern "C" fn get_logical_to_physical(

--- a/ffi/src/transaction/write_context.rs
+++ b/ffi/src/transaction/write_context.rs
@@ -64,14 +64,10 @@ pub unsafe extern "C" fn free_write_context(write_context: Handle<SharedWriteCon
     write_context.drop_handle();
 }
 
-/// Get the **logical** schema from a [`WriteContext`] handle. This is the user-facing schema
-/// the engine should produce as the input to its logical-to-physical transform.
-///
-/// To write a column-mapping-enabled table, an engine MUST also use
-/// [`get_physical_write_schema`] (the evaluator's output schema and the parquet writer's
-/// schema) and [`get_logical_to_physical`] (the transform expression that drops partition
-/// columns when not materialized). For non-column-mapping unpartitioned tables, the logical
-/// and physical schemas are identical.
+/// Returns the logical schema from a [`WriteContext`] handle: the user-facing schema, used as
+/// the input to the logical-to-physical transform. See [`get_logical_to_physical`] for the
+/// full evaluator recipe (input/transform/output) needed to write column-mapping-enabled
+/// tables. For non-column-mapping unpartitioned tables, logical and physical are identical.
 ///
 /// The returned schema must be freed when no longer needed via [`crate::free_schema`].
 ///
@@ -85,22 +81,20 @@ pub unsafe extern "C" fn get_write_schema(
     write_context.logical_schema().clone().into()
 }
 
-/// Get the **physical write schema** from a [`WriteContext`] handle. This is the schema of
-/// the data that will be written to parquet files:
+/// Returns the physical write schema from a [`WriteContext`] handle: the schema of the data
+/// that will be written to parquet files.
 ///
 /// - Field names are physical column-mapping names (e.g. `col-<uuid>`) when column mapping is
 ///   enabled, and identical to the logical names otherwise.
-/// - Field metadata carries the parquet field IDs that the Delta protocol writer requirements for
-///   column mapping mandate when column mapping is enabled.
+/// - Field metadata carries `parquet.field.id` entries when column mapping is enabled, per the
+///   Delta protocol writer requirements for column mapping.
 /// - Partition columns are excluded unless a feature requiring partition materialization (e.g.
 ///   `materializePartitionColumns`) is active.
 ///
-/// Engines that perform their own logical-to-physical transformation must pass this schema as
-/// the output schema of the expression evaluator (see
-/// [`crate::engine_funcs::new_expression_evaluator`]). The evaluator realizes the
-/// logical->physical column rename by positionally matching input columns to the fields of
-/// this output schema. Engines that write parquet directly must use this as the writer's
-/// schema so that field IDs and physical names land in the file.
+/// Engines doing their own logical-to-physical transformation pass this as the evaluator's
+/// output schema (see [`crate::engine_funcs::new_expression_evaluator`] and
+/// [`get_logical_to_physical`] for the full recipe). Engines writing parquet directly use
+/// this as the writer schema so field IDs and physical names land in the file.
 ///
 /// The returned schema must be freed when no longer needed via [`crate::free_schema`].
 ///
@@ -114,20 +108,19 @@ pub unsafe extern "C" fn get_physical_write_schema(
     write_context.physical_schema().clone().into()
 }
 
-/// Get the **logical-to-physical transform** from a [`WriteContext`] handle. This is the
-/// kernel-built [`Expression`] an engine must apply (via an [`ExpressionEvaluator`]) to
-/// every batch of logical data before writing it to a parquet file.
+/// Returns the logical-to-physical transform from a [`WriteContext`] handle: the kernel-built
+/// [`Expression`] an engine applies (via an [`ExpressionEvaluator`]) to every batch of logical
+/// data before writing it to a parquet file.
 ///
-/// Today the kernel-built expression only drops partition columns (when
-/// `materializePartitionColumns` is not enabled). It may grow to encode additional
-/// structural transforms over time -- for example, type coercion or generated-column
-/// materialization. Engines must always evaluate this expression against the logical
-/// batch; do not skip evaluation on the assumption it is a no-op.
+/// The expression drops partition columns when `materializePartitionColumns` is not enabled,
+/// and may encode additional structural transforms (e.g. type coercion, generated-column
+/// materialization). Always evaluate it against the logical batch -- do not skip on the
+/// assumption it is a no-op.
 ///
-/// The logical->physical column rename is carried by the schema returned from
-/// [`get_physical_write_schema`], not by this expression: the evaluator realizes the rename
-/// by positionally matching input columns to fields of the output schema. Callers must
-/// therefore construct an evaluator with:
+/// The logical-to-physical column rename is carried by [`get_physical_write_schema`], not by
+/// this expression: the evaluator realizes the rename by positionally matching input columns
+/// to fields of the output schema. Callers construct an evaluator (see
+/// [`crate::engine_funcs::new_expression_evaluator`]) with:
 ///
 /// - input schema  = [`get_write_schema`] (logical)
 /// - transform     = this expression

--- a/ffi/tests/write-table-testing/expected-data/empty-commit.expected
+++ b/ffi/tests/write-table-testing/expected-data/empty-commit.expected
@@ -1,6 +1,8 @@
 Writing empty commit to <TABLE>
 Write context:
-  schema_handle: <obtained>
-  write_path:    file://<TABLE>/
+  logical_schema:      <obtained>
+  physical_schema:     <obtained>
+  logical_to_physical: <obtained>
+  write_path:          file://<TABLE>/
 Committed version: 1
 Snapshot version after commit: 1


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds two FFI accessors so engines can write column-mapping-enabled Delta tables:

- `get_physical_write_schema` -- physical schema with CM physical names and per-field `parquet.field.id` metadata.
- `get_logical_to_physical` -- kernel-built transform expression (drops partition columns when `materializePartitionColumns` is off).

`get_write_schema` is unchanged; its doc now points at the new accessors.

Partitioned CM writes still need #2355.

## How was this change tested?

Unit test `test_write_context_accessors` (rstest over CM None / Name / Id): asserts physical-name and `parquet.field.id` shape per mode, and that `(logical, l2p, physical)` compose into a valid `ExpressionEvaluator`.