### PR TITLE
refactor: Mark ICT feature as fully supported

### DIFF
--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -331,9 +331,7 @@ static IN_COMMIT_TIMESTAMP_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::WriterOnly,
     min_legacy_version: None,
     feature_requirements: &[],
-    kernel_support: KernelSupport::Custom(|_protocol, _properties, operation| match operation {
-        Operation::Scan | Operation::Write | Operation::Cdf => Ok(()),
-    }),
+    kernel_support: KernelSupport::Supported,
     enablement_check: EnablementCheck::EnabledIf(|props| {
         props.enable_in_commit_timestamps == Some(true)
     }),


### PR DESCRIPTION
## What changes are proposed in this pull request?
Trivial refactor - the KernelSupport::Custom closure returned Ok(()) for all operation variants, so we can just put KernelSupport::Supported instead. Follow up to [previous PR](https://github.com/delta-io/delta-kernel-rs/pull/1670/changes#diff-a3e3bd123f8836c3b0aa8b4409aa5a8e75c108bdb0f8dc8a65b99c7b9b207bf1)

## How was this change tested?
