### PR TITLE
feat: validate `stats.numRecords` on writes for icebergCompatV3 tables

### DIFF
--- a/kernel/src/engine/default/stats.rs
+++ b/kernel/src/engine/default/stats.rs
@@ -439,7 +439,7 @@ fn compute_column_stats(
 
             // When min/max is None (all nulls or unsupported type), emit a null-valued
             // single-element array to keep the field present in the stats struct. This
-            // allows downstream consumers (like StatsVerifier) to find the column and
+            // allows downstream consumers (like StatsColumnVerifier) to find the column and
             // check nullCount == numRecords. The JSON serializer omits null fields, so
             // the on-disk format still matches Spark's ignoreNullFields behavior.
             let null_fallback = || -> ArrayRef { Arc::new(new_null_array(column.data_type(), 1)) };
@@ -778,7 +778,7 @@ mod tests {
         assert_eq!(value_null_count.value(0), 3);
 
         // All-null columns are present in minValues/maxValues but with null values.
-        // The field must exist so that StatsVerifier can find it via visit_rows and
+        // The field must exist so that StatsColumnVerifier can find it via visit_rows and
         // check nullCount == numRecords. The JSON serializer omits null fields, so
         // the on-disk format still matches Spark's ignoreNullFields behavior.
         let min_values = stats

--- a/kernel/src/scan/data_skipping/stats_schema/mod.rs
+++ b/kernel/src/scan/data_skipping/stats_schema/mod.rs
@@ -15,6 +15,9 @@ use crate::schema::{
 use crate::transforms::{transform_output_type, SchemaTransform};
 use crate::DeltaResult;
 
+/// Sub-field of an AddFile's `stats` struct: total number of rows in the file.
+pub(crate) const STATS_NUM_RECORDS: &str = "numRecords";
+
 /// Generates the expected schema for file statistics.
 ///
 /// The base stats schema is dependent on the current table configuration and derived via:

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -850,6 +850,12 @@ impl TableConfiguration {
             EnablementCheck::EnabledIf(check_fn) => check_fn(&self.table_properties),
         }
     }
+
+    /// Returns true when the table requires every AddFile to carry a non-null
+    /// `stats.numRecords`.
+    pub(crate) fn requires_stats_num_records(&self) -> bool {
+        self.is_feature_enabled(&TableFeature::IcebergCompatV3)
+    }
 }
 
 #[cfg(test)]

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -854,6 +854,7 @@ impl TableConfiguration {
     /// Returns true when the table requires every AddFile to carry a non-null
     /// `stats.numRecords`.
     pub(crate) fn requires_stats_num_records(&self) -> bool {
+        // TODO(#1125): Add icebergCompatV2 to the list when it is supported.
         self.is_feature_enabled(&TableFeature::IcebergCompatV3)
     }
 }

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -64,7 +64,7 @@ mod stats_verifier;
 mod update;
 mod write_context;
 
-use stats_verifier::StatsVerifier;
+use stats_verifier::StatsColumnVerifier;
 use write_context::SharedWriteState;
 pub use write_context::WriteContext;
 
@@ -992,6 +992,13 @@ impl<S> Transaction<S> {
         if add_files.is_empty() {
             return Ok(());
         }
+        // IcebergCompatV3 requires every AddFile to carry `stats.numRecords`.
+        if self
+            .effective_table_config
+            .is_feature_enabled(&TableFeature::IcebergCompatV3)
+        {
+            stats_verifier::verify_num_records_present(add_files)?;
+        }
         if let Some(ref clustering_cols) = self.physical_clustering_columns {
             if !clustering_cols.is_empty() {
                 let physical_schema = self.effective_table_config.physical_schema();
@@ -1010,7 +1017,7 @@ impl<S> Transaction<S> {
                         Ok((col.clone(), data_type))
                     })
                     .collect::<DeltaResult<_>>()?;
-                let verifier = StatsVerifier::new(columns_with_types);
+                let verifier = StatsColumnVerifier::new(columns_with_types);
                 verifier.verify(add_files)?;
             }
         }

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -999,6 +999,8 @@ impl<S> Transaction<S> {
             return Ok(());
         }
         if self.effective_table_config.requires_stats_num_records() {
+            // TODO: Likely it's better to merge this with the clustering column validation below,
+            // benchmark it and see if it's faster. If so, refactor this to do both validations in one pass.
             stats_verifier::verify_num_records_present(add_files)?;
         }
         if let Some(ref clustering_cols) = self.physical_clustering_columns {

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -981,22 +981,24 @@ impl<S: SupportsDataFiles> Transaction<S> {
 // Internal methods available on ALL transaction types (used by commit path)
 // =============================================================================
 impl<S> Transaction<S> {
-    /// Validate that add files have required statistics for clustering columns.
+    /// Validate that add files carry the per-file statistics required by the table's protocol.
     ///
-    /// Per the Delta protocol, writers MUST collect per-file statistics for clustering columns
-    /// when the `ClusteredTable` feature is enabled. Other stat columns (e.g. the conventional
-    /// "first 32 columns") are not validated here because they are not protocol-required.
+    /// Currently checks two protocol requirements:
+    /// - `stats.numRecords` must be present when [`requires_stats_num_records`] returns true.
+    /// - Per-file min/max/nullCount must be present for clustering columns when the
+    ///   `ClusteredTable` feature is enabled.
     ///
-    /// Only add files are validated — remove files do not carry statistics.
+    /// Other stat columns (e.g. the conventional "first 32 columns") are not validated here
+    /// because they are not protocol-required.
+    ///
+    /// Only add files are validated(remove files do not carry statistics).
+    ///
+    /// [`requires_stats_num_records`]: crate::table_configuration::TableConfiguration::requires_stats_num_records
     fn validate_add_files_stats(&self, add_files: &[Box<dyn EngineData>]) -> DeltaResult<()> {
         if add_files.is_empty() {
             return Ok(());
         }
-        // IcebergCompatV3 requires every AddFile to carry `stats.numRecords`.
-        if self
-            .effective_table_config
-            .is_feature_enabled(&TableFeature::IcebergCompatV3)
-        {
+        if self.effective_table_config.requires_stats_num_records() {
             stats_verifier::verify_num_records_present(add_files)?;
         }
         if let Some(ref clustering_cols) = self.physical_clustering_columns {

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -1000,7 +1000,8 @@ impl<S> Transaction<S> {
         }
         if self.effective_table_config.requires_stats_num_records() {
             // TODO: Likely it's better to merge this with the clustering column validation below,
-            // benchmark it and see if it's faster. If so, refactor this to do both validations in one pass.
+            // benchmark it and see if it's faster. If so, refactor this to do both validations in
+            // one pass.
             stats_verifier::verify_num_records_present(add_files)?;
         }
         if let Some(ref clustering_cols) = self.physical_clustering_columns {

--- a/kernel/src/transaction/stats_verifier.rs
+++ b/kernel/src/transaction/stats_verifier.rs
@@ -19,11 +19,11 @@ use crate::DeltaResult;
 /// For each required column, validates that `nullCount` is present (non-null) and that
 /// `minValues` and `maxValues` are present unless the column is all-null
 /// (`nullCount == numRecords`).
-pub(crate) struct StatsVerifier {
+pub(crate) struct StatsColumnVerifier {
     required_columns: Vec<(ColumnName, DataType)>,
 }
 
-impl StatsVerifier {
+impl StatsColumnVerifier {
     /// Create a new verifier that checks statistics for the given required columns and types.
     pub(crate) fn new(required_columns: Vec<(ColumnName, DataType)>) -> Self {
         Self { required_columns }
@@ -163,6 +163,14 @@ static COL_TYPES_DECIMAL: LazyLock<ColumnNamesAndTypes> = LazyLock::new(|| {
     (names, types).into()
 });
 
+/// [`ColumnNamesAndTypes`] for [`NumRecordsValidator`]. The `names` is
+/// just a placeholder, the actual column names are provided by `EngineData::visit_rows`.
+static NUM_RECORDS_TYPES: LazyLock<ColumnNamesAndTypes> = LazyLock::new(|| {
+    let names = vec![column_name!("path"), column_name!("nr")];
+    let types = vec![DataType::STRING, DataType::LONG];
+    (names, types).into()
+});
+
 /// Select the predefined static type array for a given column data type.
 fn column_types_for(dt: &DataType) -> DeltaResult<&'static ColumnNamesAndTypes> {
     match dt {
@@ -261,6 +269,62 @@ impl RowVisitor for ColumnStatsVisitor<'_> {
             }
         }
 
+        Ok(())
+    }
+}
+
+/// Verify that every `add` action has `stats.numRecords` populated. Short-circuits on the first
+/// violation and returns an error containing the `add.path`.
+pub(crate) fn verify_num_records_present(
+    add_files: &[Box<dyn crate::EngineData>],
+) -> DeltaResult<()> {
+    let column_names = vec![
+        ColumnName::new(["path"]),
+        ColumnName::new(["stats", "numRecords"]),
+    ];
+    let mut first_missing: Option<String> = None;
+    for batch in add_files {
+        let mut visitor = NumRecordsValidator {
+            first_missing: &mut first_missing,
+        };
+        batch.visit_rows(&column_names, &mut visitor)?;
+        if first_missing.is_some() {
+            break;
+        }
+    }
+    if let Some(path) = first_missing {
+        return Err(Error::stats_validation(format!(
+            "'stats.numRecords' is required by icebergCompatV3, but is missing for file '{path}'",
+        )));
+    }
+    Ok(())
+}
+
+/// Visitor validates that every `add` action has `stats.numRecords` populated.
+/// Stops at the first row whose `numRecords` is null and records that row's `add.path`.
+struct NumRecordsValidator<'a> {
+    first_missing: &'a mut Option<String>,
+}
+
+impl RowVisitor for NumRecordsValidator<'_> {
+    fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
+        NUM_RECORDS_TYPES.as_ref()
+    }
+
+    fn visit<'b>(&mut self, row_count: usize, getters: &[&'b dyn GetData<'b>]) -> DeltaResult<()> {
+        require!(
+            getters.len() == 2,
+            Error::internal_error(format!(
+                "Expected 2 getters for numRecords validation, got {}",
+                getters.len()
+            ))
+        );
+        for row_idx in 0..row_count {
+            if getters[1].get_long(row_idx, "numRecords")?.is_none() {
+                *self.first_missing = Some(getters[0].get(row_idx, "path")?);
+                return Ok(());
+            }
+        }
         Ok(())
     }
 }
@@ -365,7 +429,7 @@ mod tests {
     #[test]
     fn test_verifier_with_empty_add_files() {
         let columns = vec![(ColumnName::new(["col"]), DataType::LONG)];
-        let verifier = StatsVerifier::new(columns);
+        let verifier = StatsColumnVerifier::new(columns);
         let result = verifier.verify(&[]);
         assert!(result.is_ok());
     }
@@ -381,7 +445,7 @@ mod tests {
         );
 
         let columns = vec![(ColumnName::new(["col"]), DataType::LONG)];
-        let verifier = StatsVerifier::new(columns);
+        let verifier = StatsColumnVerifier::new(columns);
         let result = verifier.verify(&[batch]);
         assert!(result.is_ok());
     }
@@ -401,7 +465,8 @@ mod tests {
                 min_values,
                 max_values,
             );
-            let verifier = StatsVerifier::new(vec![(ColumnName::new(["col"]), DataType::LONG)]);
+            let verifier =
+                StatsColumnVerifier::new(vec![(ColumnName::new(["col"]), DataType::LONG)]);
             let err_msg = verifier.verify(&[batch]).unwrap_err().to_string();
             assert!(err_msg.contains("file1.parquet"), "case: {category}");
             assert!(err_msg.contains(category), "case: {category}");
@@ -426,7 +491,7 @@ mod tests {
         );
 
         let columns = vec![(ColumnName::new(["col"]), DataType::LONG)];
-        let verifier = StatsVerifier::new(columns);
+        let verifier = StatsColumnVerifier::new(columns);
         let result = verifier.verify(&[batch1, batch2]);
 
         assert!(result.is_err());
@@ -445,7 +510,7 @@ mod tests {
             vec![None],
         );
 
-        let verifier = StatsVerifier::new(vec![]);
+        let verifier = StatsColumnVerifier::new(vec![]);
         let result = verifier.verify(&[batch]);
         assert!(result.is_ok());
     }
@@ -462,7 +527,7 @@ mod tests {
         );
 
         let columns = vec![(ColumnName::new(["col"]), DataType::LONG)];
-        let verifier = StatsVerifier::new(columns);
+        let verifier = StatsColumnVerifier::new(columns);
         assert!(verifier.verify(&[batch]).is_ok());
     }
 
@@ -478,7 +543,7 @@ mod tests {
         );
 
         let columns = vec![(ColumnName::new(["col"]), DataType::LONG)];
-        let verifier = StatsVerifier::new(columns);
+        let verifier = StatsColumnVerifier::new(columns);
         let result = verifier.verify(&[batch]);
         assert!(matches!(result, Err(Error::StatsValidation(_))));
         let err = result.unwrap_err().to_string();
@@ -566,7 +631,7 @@ mod tests {
             (ColumnName::new(["col_a"]), DataType::LONG),
             (ColumnName::new(["col_b"]), DataType::LONG),
         ];
-        assert!(StatsVerifier::new(columns).verify(&[batch]).is_ok());
+        assert!(StatsColumnVerifier::new(columns).verify(&[batch]).is_ok());
 
         // col_a valid, col_b missing minValues
         let batch = create_two_column_batch(
@@ -583,7 +648,7 @@ mod tests {
             (ColumnName::new(["col_a"]), DataType::LONG),
             (ColumnName::new(["col_b"]), DataType::LONG),
         ];
-        let err_msg = StatsVerifier::new(columns)
+        let err_msg = StatsColumnVerifier::new(columns)
             .verify(&[batch])
             .unwrap_err()
             .to_string();
@@ -594,7 +659,7 @@ mod tests {
 
     /// Verifies that stats collected from non-standard Arrow string representations
     /// (LargeUtf8/LargeStringArray, Utf8View/StringViewArray) can be validated by
-    /// StatsVerifier, which expects Delta's logical STRING type. Engines may use any of
+    /// StatsColumnVerifier, which expects Delta's logical STRING type. Engines may use any of
     /// these representations, and the stats pipeline must handle them without type errors.
     #[rstest]
     #[case::large_utf8(Arc::new(LargeStringArray::from(vec!["Austin", "Boston", "Chicago"])) as ArrayRef)]
@@ -625,13 +690,14 @@ mod tests {
 
         let engine_data: Box<dyn EngineData> = Box::new(ArrowEngineData::new(add_file_batch));
 
-        let verifier = StatsVerifier::new(vec![(ColumnName::new(["city"]), DataType::STRING)]);
+        let verifier =
+            StatsColumnVerifier::new(vec![(ColumnName::new(["city"]), DataType::STRING)]);
         verifier.verify(&[engine_data]).unwrap();
     }
 
     /// Verify collect_stats produces correct stats shape for all-null and empty batches.
     /// These cases keep the column in minValues/maxValues with null values (so that
-    /// StatsVerifier can find the field via visit_rows and check nullCount == numRecords).
+    /// StatsColumnVerifier can find the field via visit_rows and check nullCount == numRecords).
     #[rstest]
     #[case::all_null_values(Arc::new(Int64Array::from(vec![None::<i64>, None, None])) as ArrayRef)]
     #[case::empty_batch(Arc::new(Int64Array::from(Vec::<Option<i64>>::new())) as ArrayRef)]
@@ -808,7 +874,76 @@ mod tests {
 
         let engine_data: Box<dyn EngineData> = Box::new(ArrowEngineData::new(add_file_batch));
 
-        let verifier = StatsVerifier::new(vec![(ColumnName::new(["col"]), dt)]);
+        let verifier = StatsColumnVerifier::new(vec![(ColumnName::new(["col"]), dt)]);
         verifier.verify(&[engine_data]).unwrap();
+    }
+
+    // ============================================================================
+    // verify_num_records_present tests
+    // ============================================================================
+
+    #[rstest]
+    #[case::empty_input(vec![], None, vec![])]
+    #[case::all_present(
+        vec![vec![("a.parquet", Some(10)), ("b.parquet", Some(20))]],
+        None/* expected_first_offender */,
+        vec![]/* later_offenders */,
+    )]
+    #[case::first_offender_named_later_offenders_hidden(
+        vec![vec![("a.parquet", Some(10)), ("b.parquet", None), ("c.parquet", None)]],
+        Some("b.parquet"),
+        vec!["c.parquet"],
+    )]
+    #[case::short_circuits_across_batches(
+        vec![
+            vec![("a.parquet", None), ("b.parquet", Some(20))],
+            vec![("c.parquet", Some(30)), ("d.parquet", None)],
+        ],
+        Some("a.parquet"),
+        vec!["d.parquet"],
+    )]
+    fn test_verify_num_records_present(
+        #[case] batches: Vec<Vec<(&str, Option<i64>)>>,
+        #[case] expected_first_offender: Option<&str>,
+        #[case] later_offenders: Vec<&str>,
+    ) {
+        let batches: Vec<Box<dyn EngineData>> = batches
+            .into_iter()
+            .map(|rows| {
+                let (paths, num_records): (Vec<_>, Vec<_>) = rows.into_iter().unzip();
+                create_add_file_batch_with_num_records(paths, num_records)
+            })
+            .collect();
+        let result = verify_num_records_present(&batches);
+        match expected_first_offender {
+            None => result.unwrap(),
+            Some(path) => {
+                let err = result.unwrap_err().to_string();
+                assert!(
+                    err.contains("'stats.numRecords' is required") && err.contains(path),
+                    "expected error containing '{path}', but got: {err}",
+                );
+                for later_offender in &later_offenders {
+                    assert!(
+                        !err.contains(later_offender),
+                        "error should not mention '{later_offender}': {err}",
+                    );
+                }
+            }
+        }
+    }
+
+    fn create_add_file_batch_with_num_records(
+        paths: Vec<&str>,
+        num_records: Vec<Option<i64>>,
+    ) -> Box<dyn EngineData> {
+        let n = paths.len();
+        create_add_file_batch(
+            paths,
+            num_records,
+            vec![None; n],
+            vec![None; n],
+            vec![None; n],
+        )
     }
 }

--- a/kernel/src/transaction/stats_verifier.rs
+++ b/kernel/src/transaction/stats_verifier.rs
@@ -10,6 +10,7 @@ use std::sync::LazyLock;
 use crate::engine_data::{GetData, RowVisitor, TypedGetData as _};
 use crate::error::Error;
 use crate::expressions::{column_name, ColumnName};
+use crate::scan::data_skipping::stats_schema::STATS_NUM_RECORDS;
 use crate::schema::{ColumnNamesAndTypes, DataType, DecimalType, PrimitiveType};
 use crate::utils::require;
 use crate::DeltaResult;
@@ -67,7 +68,7 @@ impl StatsColumnVerifier {
         let mut missing_max: Vec<String> = Vec::new();
 
         for batch in add_files {
-            let mut visitor = ColumnStatsVisitor {
+            let mut visitor = ColumnStatsValidator {
                 data_type,
                 types,
                 missing_null_count: &mut missing_null_count,
@@ -227,7 +228,7 @@ fn is_stat_present<'b>(
 
 /// Visitor that checks nullCount, minValues, and maxValues for a single column in one pass.
 /// Expects 5 getters: [path, numRecords, nullCount, minValues, maxValues].
-struct ColumnStatsVisitor<'a> {
+struct ColumnStatsValidator<'a> {
     data_type: &'a DataType,
     types: &'static ColumnNamesAndTypes,
     missing_null_count: &'a mut Vec<String>,
@@ -235,7 +236,7 @@ struct ColumnStatsVisitor<'a> {
     missing_max: &'a mut Vec<String>,
 }
 
-impl RowVisitor for ColumnStatsVisitor<'_> {
+impl RowVisitor for ColumnStatsValidator<'_> {
     fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
         self.types.as_ref()
     }
@@ -280,7 +281,7 @@ pub(crate) fn verify_num_records_present(
 ) -> DeltaResult<()> {
     let column_names = vec![
         ColumnName::new(["path"]),
-        ColumnName::new(["stats", "numRecords"]),
+        ColumnName::new(["stats", STATS_NUM_RECORDS]),
     ];
     let mut first_missing: Option<String> = None;
     for batch in add_files {
@@ -294,7 +295,8 @@ pub(crate) fn verify_num_records_present(
     }
     if let Some(path) = first_missing {
         return Err(Error::stats_validation(format!(
-            "'stats.numRecords' is required by icebergCompatV3, but is missing for file '{path}'",
+            "'stats.numRecords' is required for this table (see \
+             `TableConfiguration::requires_stats_num_records`), but is missing for file '{path}'",
         )));
     }
     Ok(())
@@ -320,7 +322,7 @@ impl RowVisitor for NumRecordsValidator<'_> {
             ))
         );
         for row_idx in 0..row_count {
-            if getters[1].get_long(row_idx, "numRecords")?.is_none() {
+            if getters[1].get_long(row_idx, STATS_NUM_RECORDS)?.is_none() {
                 *self.first_missing = Some(getters[0].get(row_idx, "path")?);
                 return Ok(());
             }
@@ -933,6 +935,25 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_verify_num_records_present_flags_add_without_stats() {
+        let batch = create_add_file_batch_with_stats_mask(
+            vec!["a.parquet", "b.parquet"],
+            vec![true, false],
+        );
+        let err = verify_num_records_present(&[batch])
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("'stats.numRecords' is required") && err.contains("b.parquet"),
+            "expected error naming b.parquet, got: {err}",
+        );
+        assert!(
+            !err.contains("a.parquet"),
+            "row with stats present should not be flagged: {err}",
+        );
+    }
+
     fn create_add_file_batch_with_num_records(
         paths: Vec<&str>,
         num_records: Vec<Option<i64>>,
@@ -945,5 +966,62 @@ mod tests {
             vec![None; n],
             vec![None; n],
         )
+    }
+
+    /// Build an add-file batch where rows with `stats_present[i] == false` carry no `stats`
+    /// at all; other rows get `numRecords = 10`.
+    fn create_add_file_batch_with_stats_mask(
+        paths: Vec<&str>,
+        stats_present: Vec<bool>,
+    ) -> Box<dyn EngineData> {
+        assert_eq!(paths.len(), stats_present.len());
+        let n = paths.len();
+        let num_records: Vec<Option<i64>> = stats_present.iter().map(|p| p.then_some(10)).collect();
+        let path_array = StringArray::from(paths);
+
+        let col_field = Arc::new(ArrowField::new("col", ArrowDataType::Int64, true));
+        let inner_struct_type = |name: &str| {
+            ArrowField::new(
+                name,
+                ArrowDataType::Struct(Fields::from(vec![ArrowField::new(
+                    "col",
+                    ArrowDataType::Int64,
+                    true,
+                )])),
+                true,
+            )
+        };
+        let stats_fields = Fields::from(vec![
+            ArrowField::new("numRecords", ArrowDataType::Int64, true),
+            inner_struct_type("nullCount"),
+            inner_struct_type("minValues"),
+            inner_struct_type("maxValues"),
+        ]);
+        let zero_inner_struct_array = StructArray::new(
+            Fields::from(vec![col_field]),
+            vec![Arc::new(Int64Array::from(vec![None as Option<i64>; n])) as ArrayRef],
+            None, /* null buffer */
+        );
+        let stats_struct_array = StructArray::new(
+            stats_fields.clone(),
+            vec![
+                Arc::new(Int64Array::from(num_records)) as ArrayRef,
+                Arc::new(zero_inner_struct_array.clone()) as ArrayRef,
+                Arc::new(zero_inner_struct_array.clone()) as ArrayRef,
+                Arc::new(zero_inner_struct_array) as ArrayRef,
+            ],
+            // null buffer: rows with stats_present[i] == false are null
+            Some(stats_present.into_iter().collect()),
+        );
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("path", ArrowDataType::Utf8, false),
+            ArrowField::new("stats", ArrowDataType::Struct(stats_fields), true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(path_array), Arc::new(stats_struct_array)],
+        )
+        .unwrap();
+        Box::new(ArrowEngineData::new(batch))
     }
 }

--- a/kernel/src/transaction/stats_verifier.rs
+++ b/kernel/src/transaction/stats_verifier.rs
@@ -164,10 +164,9 @@ static COL_TYPES_DECIMAL: LazyLock<ColumnNamesAndTypes> = LazyLock::new(|| {
     (names, types).into()
 });
 
-/// [`ColumnNamesAndTypes`] for [`NumRecordsValidator`]. The `names` is
-/// just a placeholder, the actual column names are provided by `EngineData::visit_rows`.
+/// [`ColumnNamesAndTypes`] for [`NumRecordsValidator`].
 static NUM_RECORDS_TYPES: LazyLock<ColumnNamesAndTypes> = LazyLock::new(|| {
-    let names = vec![column_name!("path"), column_name!("nr")];
+    let names = vec![column_name!("path"), column_name!("stats.numRecords")];
     let types = vec![DataType::STRING, DataType::LONG];
     (names, types).into()
 });

--- a/kernel/tests/integration/features/clustering_e2e.rs
+++ b/kernel/tests/integration/features/clustering_e2e.rs
@@ -142,8 +142,8 @@ async fn test_clustered_table_write_and_checkpoint(
 /// Regression test: writing a batch where a clustering column has ALL null values should succeed.
 ///
 /// `collect_stats` emits null-valued min/max entries for all-null columns, allowing
-/// `StatsVerifier` to find the field and confirm `nullCount == numRecords`. The JSON serializer
-/// omits null fields on disk, matching Spark's `ignoreNullFields` behavior.
+/// `StatsColumnVerifier` to find the field and confirm `nullCount == numRecords`. The JSON
+/// serializer omits null fields on disk, matching Spark's `ignoreNullFields` behavior.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_clustered_table_write_all_null_clustering_column() {
     let (_temp_dir, table_path, engine) = test_table_setup_mt().unwrap();


### PR DESCRIPTION
## Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2512/files) to review incremental changes.
- [stack/add-v3-feature](https://github.com/delta-io/delta-kernel-rs/pull/2475) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2475/files)] [MERGED]
  - [stack/write-part-when-ice3](https://github.com/delta-io/delta-kernel-rs/pull/2504) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2504/files)] [MERGED]
    - [stack/block-alter-table](https://github.com/delta-io/delta-kernel-rs/pull/2505) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2505/files)] [MERGED]
      - [stack/write-nested-id](https://github.com/delta-io/delta-kernel-rs/pull/2508) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2508/files)] [MERGED]
        - [**stack/detect-no-num**](https://github.com/delta-io/delta-kernel-rs/pull/2512) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2512/files)]
          - [stack/create-ice-v3-table](https://github.com/delta-io/delta-kernel-rs/pull/2517) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2517/files/15d67592285eb84c33be0c01473ba7d2d0dedec1..da50a6cbcefa0d8b0ccd7721e74453ed75b4c6c8)]
            - [stack/support-ice-v3](https://github.com/delta-io/delta-kernel-rs/pull/2518) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2518/files/da50a6cbcefa0d8b0ccd7721e74453ed75b4c6c8..13f33477d90ae2a9c3e60f249effd665bb6f4d6d)]

---------
## What changes are proposed in this pull request?
Added a new `NumRecordsValidator` to validate `add.stats.numRecords` must exist on writes when `icebergCompatV3` enabled. Renamed Existing `StatsVerifier` to `StatsColumnValidator` to distinguish.


## How was this change tested?
Unit tests for:
1. Empty `EngineData` batches.
2. One `EngineData` batches with several `numRecords` as `None`(validates early-return).
3. Two `EngineData` batches with several `numRecords` as `None`(validates early-return).
4. One `EngineData` batch with `numRecords` in all add actions.