### PR TITLE
feat: respect randomizeFilePrefixes and randomPrefixLength in write_dir

### DIFF
--- a/kernel/src/table_properties/mod.rs
+++ b/kernel/src/table_properties/mod.rs
@@ -179,8 +179,8 @@ pub struct TableProperties {
     /// volumes of Amazon S3 calls to better partition across S3 servers.
     pub randomize_file_prefixes: Option<bool>,
 
-    /// When delta.randomizeFilePrefixes is set to true, the number of characters that Delta
-    /// generates for random prefixes.
+    /// The number of characters to use for random file path prefixes. Used when
+    /// `delta.randomizeFilePrefixes` is true or when column mapping is enabled.
     pub random_prefix_length: Option<NonZero<u64>>,
 
     /// The shortest duration within which new snapshots will retain transaction identifiers (for
@@ -252,17 +252,19 @@ impl TableProperties {
     }
 
     /// Returns whether to emit a random alphanumeric prefix in file paths regardless of column
-    /// mapping mode. Default: `false` per the Delta protocol.
+    /// mapping mode. Default: `false`.
     pub fn should_randomize_file_prefixes(&self) -> bool {
         self.randomize_file_prefixes.unwrap_or(false)
     }
 
     /// Returns the number of characters to use for random file path prefixes.
-    /// Default: `2`, matching Delta-Spark's `delta.randomPrefixLength` default.
-    pub fn random_prefix_length(&self) -> usize {
+    /// Default: `2`.
+    pub fn random_prefix_length(&self) -> NonZero<usize> {
+        const DEFAULT: NonZero<usize> = NonZero::<usize>::new(2).unwrap();
         self.random_prefix_length
-            .map(|n| n.get() as usize)
-            .unwrap_or(2)
+            .and_then(|n| usize::try_from(n.get()).ok())
+            .and_then(NonZero::new)
+            .unwrap_or(DEFAULT)
     }
 }
 

--- a/kernel/src/table_properties/mod.rs
+++ b/kernel/src/table_properties/mod.rs
@@ -250,6 +250,20 @@ impl TableProperties {
     pub fn should_write_stats_as_struct(&self) -> bool {
         self.checkpoint_write_stats_as_struct.unwrap_or(false)
     }
+
+    /// Returns whether to emit a random alphanumeric prefix in file paths regardless of column
+    /// mapping mode. Default: `false` per the Delta protocol.
+    pub fn should_randomize_file_prefixes(&self) -> bool {
+        self.randomize_file_prefixes.unwrap_or(false)
+    }
+
+    /// Returns the number of characters to use for random file path prefixes.
+    /// Default: `2`, matching Delta-Spark's `delta.randomPrefixLength` default.
+    pub fn random_prefix_length(&self) -> usize {
+        self.random_prefix_length
+            .map(|n| n.get() as usize)
+            .unwrap_or(2)
+    }
 }
 
 /// Default number of leaf columns to collect statistics on when `dataSkippingNumIndexedCols`

--- a/kernel/src/table_properties/mod.rs
+++ b/kernel/src/table_properties/mod.rs
@@ -258,6 +258,20 @@ impl TableProperties {
         self.checkpoint_write_stats_as_struct.unwrap_or(false)
     }
 
+    /// Returns whether to emit a random alphanumeric prefix in file paths regardless of column
+    /// mapping mode. Default: `false` per the Delta protocol.
+    pub fn should_randomize_file_prefixes(&self) -> bool {
+        self.randomize_file_prefixes.unwrap_or(false)
+    }
+
+    /// Returns the number of characters to use for random file path prefixes.
+    /// Default: `2`, matching Delta-Spark's `delta.randomPrefixLength` default.
+    pub fn random_prefix_length(&self) -> usize {
+        self.random_prefix_length
+            .map(|n| n.get() as usize)
+            .unwrap_or(2)
+    }
+
     /// Returns the Parquet compression codec for new data and checkpoint files, applying the
     /// Delta protocol's recommended fallback ([`ParquetCompressionCodec::Zstd`]) when the
     /// table property is absent.

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -857,6 +857,13 @@ impl<S: SupportsDataFiles> Transaction<S> {
     fn shared_write_state(&self) -> &Arc<SharedWriteState> {
         self.shared_write_state.get_or_init(|| {
             let table_config = &self.effective_table_config;
+            let props = table_config.table_properties();
+            let randomize_file_prefixes = props.randomize_file_prefixes.unwrap_or(false);
+            // Default prefix length matches Delta-Spark's `delta.randomPrefixLength` default.
+            let random_prefix_length = props
+                .random_prefix_length
+                .map(|n| n.get() as usize)
+                .unwrap_or(2);
             Arc::new(SharedWriteState {
                 table_root: table_config.table_root().clone(),
                 logical_schema: table_config.logical_schema(),
@@ -865,6 +872,8 @@ impl<S: SupportsDataFiles> Transaction<S> {
                 column_mapping_mode: table_config.column_mapping_mode(),
                 stats_columns: self.stats_columns(),
                 logical_partition_columns: table_config.partition_columns().to_vec(),
+                randomize_file_prefixes,
+                random_prefix_length,
             })
         })
     }

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -858,12 +858,8 @@ impl<S: SupportsDataFiles> Transaction<S> {
         self.shared_write_state.get_or_init(|| {
             let table_config = &self.effective_table_config;
             let props = table_config.table_properties();
-            let randomize_file_prefixes = props.randomize_file_prefixes.unwrap_or(false);
-            // Default prefix length matches Delta-Spark's `delta.randomPrefixLength` default.
-            let random_prefix_length = props
-                .random_prefix_length
-                .map(|n| n.get() as usize)
-                .unwrap_or(2);
+            let randomize_file_prefixes = props.should_randomize_file_prefixes();
+            let random_prefix_length = props.random_prefix_length();
             Arc::new(SharedWriteState {
                 table_root: table_config.table_root().clone(),
                 logical_schema: table_config.logical_schema(),

--- a/kernel/src/transaction/write_context.rs
+++ b/kernel/src/transaction/write_context.rs
@@ -399,7 +399,13 @@ mod tests {
 
     #[test]
     fn test_write_dir_cm_on_generates_different_prefixes_per_call() {
-        let wc = make_write_context_with_randomize(ColumnMappingMode::Name, vec![], HashMap::new(), false, 2);
+        let wc = make_write_context_with_randomize(
+            ColumnMappingMode::Name,
+            vec![],
+            HashMap::new(),
+            false,
+            2,
+        );
         let dirs: Vec<String> = (0..20).map(|_| wc.write_dir().path().to_string()).collect();
         let unique: HashSet<_> = dirs.iter().collect();
         assert!(
@@ -454,7 +460,8 @@ mod tests {
     #[case::name_mode(ColumnMappingMode::Name)]
     #[case::id_mode(ColumnMappingMode::Id)]
     fn test_write_dir_cm_on_prefix_is_uri_safe(#[case] cm_mode: ColumnMappingMode) {
-        let wc = make_write_context_with_randomize(cm_mode, vec!["p".into()], HashMap::new(), false, 2);
+        let wc =
+            make_write_context_with_randomize(cm_mode, vec!["p".into()], HashMap::new(), false, 2);
         let path = wc.write_dir().path().to_string();
         assert!(
             !path.contains('%'),
@@ -492,7 +499,11 @@ mod tests {
     /// pins the matrix described in the `write_dir` doc comment.
     #[rstest]
     fn test_write_dir_with_randomize_property(
-        #[values(ColumnMappingMode::None, ColumnMappingMode::Name, ColumnMappingMode::Id)]
+        #[values(
+            ColumnMappingMode::None,
+            ColumnMappingMode::Name,
+            ColumnMappingMode::Id
+        )]
         cm_mode: ColumnMappingMode,
         #[values(true, false)] randomize: bool,
         #[values(true, false)] is_partitioned: bool,
@@ -623,7 +634,13 @@ mod tests {
     #[case::error_outside_table_root("s3://bucket/other/abc.parquet", Err(()))]
     #[test]
     fn test_resolve_file_path(#[case] file_url: &str, #[case] expected: Result<&str, ()>) {
-        let wc = make_write_context_with_randomize(ColumnMappingMode::None, vec![], HashMap::new(), false, 2);
+        let wc = make_write_context_with_randomize(
+            ColumnMappingMode::None,
+            vec![],
+            HashMap::new(),
+            false,
+            2,
+        );
         let file = Url::parse(file_url).unwrap();
         match expected {
             Ok(exp) => assert_eq!(wc.resolve_file_path(&file).unwrap(), exp),

--- a/kernel/src/transaction/write_context.rs
+++ b/kernel/src/transaction/write_context.rs
@@ -13,7 +13,7 @@ use crate::{DeltaResult, Error};
 
 /// Table-wide write state shared across all [`WriteContext`] instances created by a
 /// [`Transaction`]. Holds the target directory, schemas, column mapping mode, stats columns,
-/// and logical partition column names.
+/// logical partition column names, and randomized-prefix configuration.
 ///
 /// [`Transaction`]: super::Transaction
 #[derive(Debug)]
@@ -26,6 +26,14 @@ pub(super) struct SharedWriteState {
     pub(super) stats_columns: Vec<ColumnName>,
     /// Logical partition column names in metadata-defined order.
     pub(super) logical_partition_columns: Vec<String>,
+    /// Resolved value of the `delta.randomizeFilePrefixes` table property (default: false).
+    /// When true, [`WriteContext::write_dir`] emits a random alphanumeric prefix regardless
+    /// of column mapping mode.
+    pub(super) randomize_file_prefixes: bool,
+    /// Resolved value of the `delta.randomPrefixLength` table property (default: 2). Drives
+    /// the length of the random prefix in [`WriteContext::write_dir`] for both the column
+    /// mapping and `randomizeFilePrefixes` paths.
+    pub(super) random_prefix_length: usize,
 }
 
 /// A write context for a specific partition or an unpartitioned table. Created by
@@ -106,44 +114,50 @@ impl WriteContext {
     ///
     /// # Layout
     ///
+    /// A random alphanumeric prefix is emitted whenever column mapping is on **or** the
+    /// `delta.randomizeFilePrefixes` table property is true. The prefix length is controlled
+    /// by `delta.randomPrefixLength` (default 2, matching Delta-Spark). When a random prefix
+    /// is used on a partitioned table, Hive-style path components are suppressed; the
+    /// partition values are still recorded in `add.partitionValues`.
+    ///
     /// ```text
-    ///              | CM OFF                              | CM ON
-    /// -------------|-------------------------------------|-------------------------------
-    /// Unpartitioned| <table_root>/<uuid>.parquet         | <table_root>/<2char>/<uuid>.parquet
-    /// Partitioned  | <table_root>/col=val/.../<uuid>.pq  | <table_root>/<2char>/<uuid>.parquet
+    ///                            | randomize=false                     | randomize=true
+    /// ---------------------------|-------------------------------------|--------------------------------
+    /// CM=None,  unpartitioned    | <table_root>/<uuid>.parquet         | <table_root>/<prefix>/<uuid>.parquet
+    /// CM=None,  partitioned      | <table_root>/col=val/.../<uuid>.pq  | <table_root>/<prefix>/<uuid>.parquet
+    /// CM=Id/Name, any            | <table_root>/<prefix>/<uuid>.parquet| <table_root>/<prefix>/<uuid>.parquet
     /// ```
     ///
-    /// CM ON uses a random 2-char alphanumeric prefix (matching Delta-Spark's
-    /// `getRandomPrefix`) to avoid S3 hotspots. Each call generates a fresh prefix,
-    /// matching Delta-Spark's per-file behavior.
+    /// Each call generates a fresh prefix, matching Delta-Spark's per-file behavior
+    /// (`Utils.getRandomPrefix`). The alphanumeric charset is RFC 3986 unreserved, so
+    /// the prefix is URI-safe at any length.
     ///
     /// [`DefaultEngine::write_parquet`]: crate::engine::default::DefaultEngine::write_parquet
     /// [`build_add_file_metadata`]: crate::engine::default::build_add_file_metadata
-    // TODO(#2357): respect `delta.randomizeFilePrefixes` and `delta.randomPrefixLength`
-    // table properties. Currently random prefixes are only used when column mapping is on.
     // TODO(#2436): revisit this API shape. Returning a `Url` forces callers to URI-decode
     // before filesystem writes and keep it encoded for `add.path`, which is unintuitive.
     pub fn write_dir(&self) -> Url {
         let mut url = self.shared.table_root.clone();
-        match self.shared.column_mapping_mode {
-            ColumnMappingMode::None => {
-                // URI-encode on top of Hive-escaping because the fn-level contract (see
-                // doc above) requires callers to URI-decode once before using the URL as
-                // a filesystem path. That decode recovers the Hive-escaped form, which
-                // is the on-disk layout Delta-Spark and kernel-java produce.
-                if !self.shared.logical_partition_columns.is_empty() {
-                    let hive_escaped = self.hive_partition_path_suffix();
-                    let uri_encoded = uri_encode_path(&hive_escaped);
-                    url.set_path(&format!("{}{}", url.path(), uri_encoded));
-                }
-            }
-            ColumnMappingMode::Id | ColumnMappingMode::Name => {
-                // Column mapping on: the random 2-char alphanumeric prefix contains only
-                // ASCII letters/digits (all RFC 3986 unreserved chars), so no URI encoding
-                // is needed — the string is already URI-safe as-is.
-                let prefix = random_alphanumeric_prefix();
-                url.set_path(&format!("{}{}/", url.path(), prefix));
-            }
+        // A random prefix is used when column mapping is on (to avoid leaking physical
+        // UUID column names into paths) or when `delta.randomizeFilePrefixes` is set (to
+        // avoid S3 hotspots). When a random prefix is used, the Hive-style partition path
+        // is suppressed -- partition values are recorded in `add.partitionValues` instead.
+        let should_prefix = self.shared.column_mapping_mode != ColumnMappingMode::None
+            || self.shared.randomize_file_prefixes;
+        if should_prefix {
+            // The alphanumeric charset is RFC 3986 unreserved, so the prefix is URI-safe
+            // as-is and needs no further encoding.
+            let prefix = random_alphanumeric_prefix(self.shared.random_prefix_length);
+            url.set_path(&format!("{}{}/", url.path(), prefix));
+        } else if !self.shared.logical_partition_columns.is_empty() {
+            // CM=None, no randomization: emit a Hive-style partition path. URI-encode on
+            // top of Hive-escaping because the fn-level contract (see doc above) requires
+            // callers to URI-decode once before using the URL as a filesystem path. That
+            // decode recovers the Hive-escaped form, which is the on-disk layout
+            // Delta-Spark and kernel-java produce.
+            let hive_escaped = self.hive_partition_path_suffix();
+            let uri_encoded = uri_encode_path(&hive_escaped);
+            url.set_path(&format!("{}{}", url.path(), uri_encoded));
         }
         url
     }
@@ -270,13 +284,14 @@ impl WriteContext {
     }
 }
 
-/// Generates a random 2-character alphanumeric prefix for partition directory paths, matching
-/// Delta-Spark's `Utils.getRandomPrefix` (`Random.alphanumeric.take(2)`). Used when column mapping
-/// is enabled to avoid S3 hotspots and prevent leaking physical UUID column names into paths.
-fn random_alphanumeric_prefix() -> String {
+/// Generates a random alphanumeric prefix of the given length for data file directory paths,
+/// matching Delta-Spark's `Utils.getRandomPrefix` (`Random.alphanumeric.take(n)`). Used to avoid
+/// S3 hotspots and to prevent leaking physical UUID column names into paths when column mapping
+/// is enabled.
+fn random_alphanumeric_prefix(len: usize) -> String {
     const CHARSET: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
     let mut rng = rand::rng();
-    (0..2)
+    (0..len)
         .map(|_| CHARSET[rng.random_range(0..CHARSET.len())] as char)
         .collect()
 }
@@ -297,6 +312,16 @@ mod tests {
         partition_columns: Vec<String>,
         partition_values: HashMap<String, Option<String>>,
     ) -> WriteContext {
+        make_write_context_with_randomize(cm_mode, partition_columns, partition_values, false, 2)
+    }
+
+    fn make_write_context_with_randomize(
+        cm_mode: ColumnMappingMode,
+        partition_columns: Vec<String>,
+        partition_values: HashMap<String, Option<String>>,
+        randomize_file_prefixes: bool,
+        random_prefix_length: usize,
+    ) -> WriteContext {
         let schema = Arc::new(StructType::new_unchecked(vec![StructField::nullable(
             "value",
             DataType::INTEGER,
@@ -309,6 +334,8 @@ mod tests {
             column_mapping_mode: cm_mode,
             stats_columns: vec![],
             logical_partition_columns: partition_columns,
+            randomize_file_prefixes,
+            random_prefix_length,
         });
         WriteContext {
             shared,
@@ -448,16 +475,130 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_random_alphanumeric_prefix_format() {
+    #[rstest]
+    #[case(1)]
+    #[case(2)]
+    #[case(8)]
+    #[case(32)]
+    fn test_random_alphanumeric_prefix_format(#[case] len: usize) {
         for _ in 0..100 {
-            let prefix = random_alphanumeric_prefix();
-            assert_eq!(prefix.len(), 2, "prefix should be exactly 2 chars");
+            let prefix = random_alphanumeric_prefix(len);
+            assert_eq!(prefix.len(), len, "prefix should be exactly {len} chars");
             assert!(
                 prefix.chars().all(|c| c.is_ascii_alphanumeric()),
                 "prefix should be alphanumeric, got: {prefix}"
             );
         }
+    }
+
+    /// `randomizeFilePrefixes` triggers a random prefix even when CM is off, and suppresses
+    /// the Hive-style partition path. Combined with the existing CM-on behavior, this fully
+    /// pins the matrix described in the `write_dir` doc comment.
+    #[rstest]
+    fn test_write_dir_with_randomize_property(
+        #[values(ColumnMappingMode::None, ColumnMappingMode::Name)] cm_mode: ColumnMappingMode,
+        #[values(true, false)] randomize: bool,
+        #[values(true, false)] is_partitioned: bool,
+    ) {
+        let (cols, pvs) = if is_partitioned {
+            (
+                vec!["year".into()],
+                HashMap::from([("year".into(), Some("2024".into()))]),
+            )
+        } else {
+            (vec![], HashMap::new())
+        };
+        let wc = make_write_context_with_randomize(cm_mode, cols, pvs, randomize, 2);
+        let path = wc.write_dir().path().to_string();
+
+        let should_prefix = cm_mode != ColumnMappingMode::None || randomize;
+        if should_prefix {
+            assert!(
+                !path.contains("year="),
+                "random prefix should suppress Hive dirs, got: {path}"
+            );
+            let prefix = path
+                .strip_prefix("/table/")
+                .unwrap()
+                .strip_suffix('/')
+                .unwrap();
+            assert_eq!(prefix.len(), 2, "expected 2-char prefix, got: {prefix}");
+            assert!(
+                prefix.chars().all(|c| c.is_ascii_alphanumeric()),
+                "prefix should be alphanumeric, got: {prefix}"
+            );
+        } else if is_partitioned {
+            assert_eq!(path, "/table/year=2024/");
+        } else {
+            assert_eq!(path, "/table/");
+        }
+    }
+
+    /// `randomPrefixLength` controls the prefix length for both the column-mapping path
+    /// and the `randomizeFilePrefixes` path.
+    #[rstest]
+    #[case::cm_on_default(ColumnMappingMode::Name, false, 2)]
+    #[case::cm_on_short(ColumnMappingMode::Name, false, 1)]
+    #[case::cm_on_long(ColumnMappingMode::Name, false, 16)]
+    #[case::randomize_short(ColumnMappingMode::None, true, 1)]
+    #[case::randomize_default(ColumnMappingMode::None, true, 2)]
+    #[case::randomize_long(ColumnMappingMode::None, true, 16)]
+    fn test_write_dir_random_prefix_length_property(
+        #[case] cm_mode: ColumnMappingMode,
+        #[case] randomize: bool,
+        #[case] prefix_len: usize,
+    ) {
+        let wc = make_write_context_with_randomize(
+            cm_mode,
+            vec![],
+            HashMap::new(),
+            randomize,
+            prefix_len,
+        );
+        let path = wc.write_dir().path().to_string();
+        let prefix = path
+            .strip_prefix("/table/")
+            .unwrap()
+            .strip_suffix('/')
+            .unwrap();
+        assert_eq!(
+            prefix.len(),
+            prefix_len,
+            "expected {prefix_len}-char prefix, got: {prefix:?}"
+        );
+        assert!(
+            prefix.chars().all(|c| c.is_ascii_alphanumeric()),
+            "prefix should be alphanumeric, got: {prefix}"
+        );
+    }
+
+    /// Pins the decision that for CM=None + partitioned + randomize=true, the random prefix
+    /// REPLACES the Hive path (matching Delta-Spark's `DelayedCommitProtocol.getFilename`).
+    /// Partition values are still recorded in `add.partitionValues`; this test only asserts
+    /// the on-disk layout. If the maintainer prefers prefix-then-Hive, flip this assertion.
+    #[test]
+    fn test_write_dir_cm_off_randomize_suppresses_hive() {
+        let wc = make_write_context_with_randomize(
+            ColumnMappingMode::None,
+            vec!["year".into(), "month".into()],
+            HashMap::from([
+                ("year".into(), Some("2024".into())),
+                ("month".into(), Some("03".into())),
+            ]),
+            true,
+            2,
+        );
+        let path = wc.write_dir().path().to_string();
+        assert!(
+            !path.contains('='),
+            "randomize=true should suppress Hive dirs, got: {path}"
+        );
+        let prefix = path
+            .strip_prefix("/table/")
+            .unwrap()
+            .strip_suffix('/')
+            .unwrap();
+        assert_eq!(prefix.len(), 2);
     }
 
     // === resolve_file_path tests ===

--- a/kernel/src/transaction/write_context.rs
+++ b/kernel/src/transaction/write_context.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::num::NonZero;
 use std::sync::Arc;
 
 use rand::Rng;
@@ -26,14 +27,14 @@ pub(super) struct SharedWriteState {
     pub(super) stats_columns: Vec<ColumnName>,
     /// Logical partition column names in metadata-defined order.
     pub(super) logical_partition_columns: Vec<String>,
-    /// Resolved value of the `delta.randomizeFilePrefixes` table property (default: false).
-    /// When true, [`WriteContext::write_dir`] emits a random alphanumeric prefix regardless
-    /// of column mapping mode.
+    /// Resolved value of the `delta.randomizeFilePrefixes` table property. When true,
+    /// [`WriteContext::write_dir`] emits a random alphanumeric prefix regardless of column
+    /// mapping mode.
     pub(super) randomize_file_prefixes: bool,
-    /// Resolved value of the `delta.randomPrefixLength` table property (default: 2). Drives
-    /// the length of the random prefix in [`WriteContext::write_dir`] for both the column
-    /// mapping and `randomizeFilePrefixes` paths.
-    pub(super) random_prefix_length: usize,
+    /// Resolved value of the `delta.randomPrefixLength` table property. Drives the length
+    /// of the random prefix in [`WriteContext::write_dir`] for both the column mapping and
+    /// `randomizeFilePrefixes` paths.
+    pub(super) random_prefix_length: NonZero<usize>,
 }
 
 /// A write context for a specific partition or an unpartitioned table. Created by
@@ -114,11 +115,11 @@ impl WriteContext {
     ///
     /// # Layout
     ///
-    /// A random alphanumeric prefix is emitted whenever column mapping is on **or** the
-    /// `delta.randomizeFilePrefixes` table property is true. The prefix length is controlled
-    /// by `delta.randomPrefixLength` (default 2, matching Delta-Spark). When a random prefix
-    /// is used on a partitioned table, Hive-style path components are suppressed; the
-    /// partition values are still recorded in `add.partitionValues`.
+    /// A random alphanumeric prefix is emitted whenever column mapping is on or the
+    /// `delta.randomizeFilePrefixes` table property is true. The prefix length is
+    /// controlled by `delta.randomPrefixLength`. When a random prefix is used on a
+    /// partitioned table, Hive-style path components are suppressed; the partition
+    /// values are still recorded in `add.partitionValues`.
     ///
     /// ```text
     ///                            | randomize=false                     | randomize=true
@@ -128,9 +129,8 @@ impl WriteContext {
     /// CM=Id/Name, any            | <table_root>/<prefix>/<uuid>.parquet| <table_root>/<prefix>/<uuid>.parquet
     /// ```
     ///
-    /// Each call generates a fresh prefix, matching Delta-Spark's per-file behavior
-    /// (`Utils.getRandomPrefix`). The alphanumeric charset is RFC 3986 unreserved, so
-    /// the prefix is URI-safe at any length.
+    /// Each call generates a fresh prefix. The alphanumeric charset is RFC 3986
+    /// unreserved, so the prefix is URI-safe at any length.
     ///
     /// [`DefaultEngine::write_parquet`]: crate::engine::default::DefaultEngine::write_parquet
     /// [`build_add_file_metadata`]: crate::engine::default::build_add_file_metadata
@@ -141,7 +141,7 @@ impl WriteContext {
         // A random prefix is used when column mapping is on (to avoid leaking physical
         // UUID column names into paths) or when `delta.randomizeFilePrefixes` is set (to
         // avoid S3 hotspots). When a random prefix is used, the Hive-style partition path
-        // is suppressed -- partition values are recorded in `add.partitionValues` instead.
+        // is suppressed; partition values are recorded in `add.partitionValues` instead.
         let should_prefix = self.shared.column_mapping_mode != ColumnMappingMode::None
             || self.shared.randomize_file_prefixes;
         if should_prefix {
@@ -284,14 +284,13 @@ impl WriteContext {
     }
 }
 
-/// Generates a random alphanumeric prefix of the given length for data file directory paths,
-/// matching Delta-Spark's `Utils.getRandomPrefix` (`Random.alphanumeric.take(n)`). Used to avoid
-/// S3 hotspots and to prevent leaking physical UUID column names into paths when column mapping
-/// is enabled.
-fn random_alphanumeric_prefix(len: usize) -> String {
+/// Generates a random alphanumeric prefix of the given length for data file directory paths.
+/// Used to avoid S3 hotspots and to keep physical UUID column names out of paths when column
+/// mapping is enabled.
+fn random_alphanumeric_prefix(len: NonZero<usize>) -> String {
     const CHARSET: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
     let mut rng = rand::rng();
-    (0..len)
+    (0..len.get())
         .map(|_| CHARSET[rng.random_range(0..CHARSET.len())] as char)
         .collect()
 }
@@ -307,7 +306,7 @@ mod tests {
     use crate::expressions::Expression;
     use crate::schema::{DataType, StructField, StructType};
 
-    fn make_write_context_with_randomize(
+    fn make_write_context(
         cm_mode: ColumnMappingMode,
         partition_columns: Vec<String>,
         partition_values: HashMap<String, Option<String>>,
@@ -327,7 +326,8 @@ mod tests {
             stats_columns: vec![],
             logical_partition_columns: partition_columns,
             randomize_file_prefixes,
-            random_prefix_length,
+            random_prefix_length: NonZero::new(random_prefix_length)
+                .expect("test prefix length must be > 0"),
         });
         WriteContext {
             shared,
@@ -357,7 +357,7 @@ mod tests {
         } else {
             (vec![], HashMap::new())
         };
-        let wc = make_write_context_with_randomize(cm_mode, cols, pvs, false, 2);
+        let wc = make_write_context(cm_mode, cols, pvs, false, 2);
         let path = wc.write_dir().path().to_string();
 
         match cm_mode {
@@ -399,13 +399,7 @@ mod tests {
 
     #[test]
     fn test_write_dir_cm_on_generates_different_prefixes_per_call() {
-        let wc = make_write_context_with_randomize(
-            ColumnMappingMode::Name,
-            vec![],
-            HashMap::new(),
-            false,
-            2,
-        );
+        let wc = make_write_context(ColumnMappingMode::Name, vec![], HashMap::new(), false, 2);
         let dirs: Vec<String> = (0..20).map(|_| wc.write_dir().path().to_string()).collect();
         let unique: HashSet<_> = dirs.iter().collect();
         assert!(
@@ -416,7 +410,7 @@ mod tests {
 
     #[test]
     fn test_write_dir_cm_off_partitioned_null_value_uses_hive_default() {
-        let wc = make_write_context_with_randomize(
+        let wc = make_write_context(
             ColumnMappingMode::None,
             vec!["region".into()],
             HashMap::from([("region".into(), None)]),
@@ -443,7 +437,7 @@ mod tests {
         #[case] value: &str,
         #[case] expected_path: &str,
     ) {
-        let wc = make_write_context_with_randomize(
+        let wc = make_write_context(
             ColumnMappingMode::None,
             vec![col.into()],
             HashMap::from([(col.into(), Some(value.into()))]),
@@ -460,8 +454,7 @@ mod tests {
     #[case::name_mode(ColumnMappingMode::Name)]
     #[case::id_mode(ColumnMappingMode::Id)]
     fn test_write_dir_cm_on_prefix_is_uri_safe(#[case] cm_mode: ColumnMappingMode) {
-        let wc =
-            make_write_context_with_randomize(cm_mode, vec!["p".into()], HashMap::new(), false, 2);
+        let wc = make_write_context(cm_mode, vec!["p".into()], HashMap::new(), false, 2);
         let path = wc.write_dir().path().to_string();
         assert!(
             !path.contains('%'),
@@ -484,8 +477,9 @@ mod tests {
     #[case(8)]
     #[case(32)]
     fn test_random_alphanumeric_prefix_format(#[case] len: usize) {
+        let nz_len = NonZero::new(len).unwrap();
         for _ in 0..100 {
-            let prefix = random_alphanumeric_prefix(len);
+            let prefix = random_alphanumeric_prefix(nz_len);
             assert_eq!(prefix.len(), len, "prefix should be exactly {len} chars");
             assert!(
                 prefix.chars().all(|c| c.is_ascii_alphanumeric()),
@@ -494,9 +488,9 @@ mod tests {
         }
     }
 
-    /// `randomizeFilePrefixes` triggers a random prefix even when CM is off, and suppresses
-    /// the Hive-style partition path. Combined with the existing CM-on behavior, this fully
-    /// pins the matrix described in the `write_dir` doc comment.
+    /// When CM is off and `randomizeFilePrefixes=true`, the random prefix replaces the
+    /// Hive-style path on disk for partitioned tables. Combined with the existing CM-on
+    /// behavior, this covers the full matrix described in the `write_dir` doc comment.
     #[rstest]
     fn test_write_dir_with_randomize_property(
         #[values(
@@ -516,7 +510,7 @@ mod tests {
         } else {
             (vec![], HashMap::new())
         };
-        let wc = make_write_context_with_randomize(cm_mode, cols, pvs, randomize, 2);
+        let wc = make_write_context(cm_mode, cols, pvs, randomize, 2);
         let path = wc.write_dir().path().to_string();
 
         let should_prefix = cm_mode != ColumnMappingMode::None || randomize;
@@ -556,13 +550,7 @@ mod tests {
         #[case] randomize: bool,
         #[case] prefix_len: usize,
     ) {
-        let wc = make_write_context_with_randomize(
-            cm_mode,
-            vec![],
-            HashMap::new(),
-            randomize,
-            prefix_len,
-        );
+        let wc = make_write_context(cm_mode, vec![], HashMap::new(), randomize, prefix_len);
         let path = wc.write_dir().path().to_string();
         let prefix = path
             .strip_prefix("/table/")
@@ -580,13 +568,12 @@ mod tests {
         );
     }
 
-    /// Pins the decision that for CM=None + partitioned + randomize=true, the random prefix
-    /// REPLACES the Hive path (matching Delta-Spark's `DelayedCommitProtocol.getFilename`).
-    /// Partition values are still recorded in `add.partitionValues`; this test only asserts
-    /// the on-disk layout.
+    /// When CM is off and a partitioned table has `randomizeFilePrefixes=true`, the random
+    /// prefix replaces the Hive-style path on disk. Partition values are still recorded in
+    /// `add.partitionValues`; this test only checks the on-disk layout.
     #[test]
     fn test_write_dir_cm_off_randomize_suppresses_hive() {
-        let wc = make_write_context_with_randomize(
+        let wc = make_write_context(
             ColumnMappingMode::None,
             vec!["year".into(), "month".into()],
             HashMap::from([
@@ -634,13 +621,7 @@ mod tests {
     #[case::error_outside_table_root("s3://bucket/other/abc.parquet", Err(()))]
     #[test]
     fn test_resolve_file_path(#[case] file_url: &str, #[case] expected: Result<&str, ()>) {
-        let wc = make_write_context_with_randomize(
-            ColumnMappingMode::None,
-            vec![],
-            HashMap::new(),
-            false,
-            2,
-        );
+        let wc = make_write_context(ColumnMappingMode::None, vec![], HashMap::new(), false, 2);
         let file = Url::parse(file_url).unwrap();
         match expected {
             Ok(exp) => assert_eq!(wc.resolve_file_path(&file).unwrap(), exp),

--- a/kernel/src/transaction/write_context.rs
+++ b/kernel/src/transaction/write_context.rs
@@ -307,14 +307,6 @@ mod tests {
     use crate::expressions::Expression;
     use crate::schema::{DataType, StructField, StructType};
 
-    fn make_write_context(
-        cm_mode: ColumnMappingMode,
-        partition_columns: Vec<String>,
-        partition_values: HashMap<String, Option<String>>,
-    ) -> WriteContext {
-        make_write_context_with_randomize(cm_mode, partition_columns, partition_values, false, 2)
-    }
-
     fn make_write_context_with_randomize(
         cm_mode: ColumnMappingMode,
         partition_columns: Vec<String>,
@@ -365,7 +357,7 @@ mod tests {
         } else {
             (vec![], HashMap::new())
         };
-        let wc = make_write_context(cm_mode, cols, pvs);
+        let wc = make_write_context_with_randomize(cm_mode, cols, pvs, false, 2);
         let path = wc.write_dir().path().to_string();
 
         match cm_mode {
@@ -407,7 +399,13 @@ mod tests {
 
     #[test]
     fn test_write_dir_cm_on_generates_different_prefixes_per_call() {
-        let wc = make_write_context(ColumnMappingMode::Name, vec![], HashMap::new());
+        let wc = make_write_context_with_randomize(
+            ColumnMappingMode::Name,
+            vec![],
+            HashMap::new(),
+            false,
+            2,
+        );
         let dirs: Vec<String> = (0..20).map(|_| wc.write_dir().path().to_string()).collect();
         let unique: HashSet<_> = dirs.iter().collect();
         assert!(
@@ -418,10 +416,12 @@ mod tests {
 
     #[test]
     fn test_write_dir_cm_off_partitioned_null_value_uses_hive_default() {
-        let wc = make_write_context(
+        let wc = make_write_context_with_randomize(
             ColumnMappingMode::None,
             vec!["region".into()],
             HashMap::from([("region".into(), None)]),
+            false,
+            2,
         );
         let path = wc.write_dir().path().to_string();
         assert!(
@@ -443,10 +443,12 @@ mod tests {
         #[case] value: &str,
         #[case] expected_path: &str,
     ) {
-        let wc = make_write_context(
+        let wc = make_write_context_with_randomize(
             ColumnMappingMode::None,
             vec![col.into()],
             HashMap::from([(col.into(), Some(value.into()))]),
+            false,
+            2,
         );
         assert_eq!(wc.write_dir().path(), expected_path);
     }
@@ -458,7 +460,8 @@ mod tests {
     #[case::name_mode(ColumnMappingMode::Name)]
     #[case::id_mode(ColumnMappingMode::Id)]
     fn test_write_dir_cm_on_prefix_is_uri_safe(#[case] cm_mode: ColumnMappingMode) {
-        let wc = make_write_context(cm_mode, vec!["p".into()], HashMap::new());
+        let wc =
+            make_write_context_with_randomize(cm_mode, vec!["p".into()], HashMap::new(), false, 2);
         let path = wc.write_dir().path().to_string();
         assert!(
             !path.contains('%'),
@@ -496,7 +499,12 @@ mod tests {
     /// pins the matrix described in the `write_dir` doc comment.
     #[rstest]
     fn test_write_dir_with_randomize_property(
-        #[values(ColumnMappingMode::None, ColumnMappingMode::Name)] cm_mode: ColumnMappingMode,
+        #[values(
+            ColumnMappingMode::None,
+            ColumnMappingMode::Name,
+            ColumnMappingMode::Id
+        )]
+        cm_mode: ColumnMappingMode,
         #[values(true, false)] randomize: bool,
         #[values(true, false)] is_partitioned: bool,
     ) {
@@ -575,7 +583,7 @@ mod tests {
     /// Pins the decision that for CM=None + partitioned + randomize=true, the random prefix
     /// REPLACES the Hive path (matching Delta-Spark's `DelayedCommitProtocol.getFilename`).
     /// Partition values are still recorded in `add.partitionValues`; this test only asserts
-    /// the on-disk layout. If the maintainer prefers prefix-then-Hive, flip this assertion.
+    /// the on-disk layout.
     #[test]
     fn test_write_dir_cm_off_randomize_suppresses_hive() {
         let wc = make_write_context_with_randomize(
@@ -626,7 +634,13 @@ mod tests {
     #[case::error_outside_table_root("s3://bucket/other/abc.parquet", Err(()))]
     #[test]
     fn test_resolve_file_path(#[case] file_url: &str, #[case] expected: Result<&str, ()>) {
-        let wc = make_write_context(ColumnMappingMode::None, vec![], HashMap::new());
+        let wc = make_write_context_with_randomize(
+            ColumnMappingMode::None,
+            vec![],
+            HashMap::new(),
+            false,
+            2,
+        );
         let file = Url::parse(file_url).unwrap();
         match expected {
             Ok(exp) => assert_eq!(wc.resolve_file_path(&file).unwrap(), exp),

--- a/kernel/src/transaction/write_context.rs
+++ b/kernel/src/transaction/write_context.rs
@@ -307,14 +307,6 @@ mod tests {
     use crate::expressions::Expression;
     use crate::schema::{DataType, StructField, StructType};
 
-    fn make_write_context(
-        cm_mode: ColumnMappingMode,
-        partition_columns: Vec<String>,
-        partition_values: HashMap<String, Option<String>>,
-    ) -> WriteContext {
-        make_write_context_with_randomize(cm_mode, partition_columns, partition_values, false, 2)
-    }
-
     fn make_write_context_with_randomize(
         cm_mode: ColumnMappingMode,
         partition_columns: Vec<String>,
@@ -365,7 +357,7 @@ mod tests {
         } else {
             (vec![], HashMap::new())
         };
-        let wc = make_write_context(cm_mode, cols, pvs);
+        let wc = make_write_context_with_randomize(cm_mode, cols, pvs, false, 2);
         let path = wc.write_dir().path().to_string();
 
         match cm_mode {
@@ -407,7 +399,7 @@ mod tests {
 
     #[test]
     fn test_write_dir_cm_on_generates_different_prefixes_per_call() {
-        let wc = make_write_context(ColumnMappingMode::Name, vec![], HashMap::new());
+        let wc = make_write_context_with_randomize(ColumnMappingMode::Name, vec![], HashMap::new(), false, 2);
         let dirs: Vec<String> = (0..20).map(|_| wc.write_dir().path().to_string()).collect();
         let unique: HashSet<_> = dirs.iter().collect();
         assert!(
@@ -418,10 +410,12 @@ mod tests {
 
     #[test]
     fn test_write_dir_cm_off_partitioned_null_value_uses_hive_default() {
-        let wc = make_write_context(
+        let wc = make_write_context_with_randomize(
             ColumnMappingMode::None,
             vec!["region".into()],
             HashMap::from([("region".into(), None)]),
+            false,
+            2,
         );
         let path = wc.write_dir().path().to_string();
         assert!(
@@ -443,10 +437,12 @@ mod tests {
         #[case] value: &str,
         #[case] expected_path: &str,
     ) {
-        let wc = make_write_context(
+        let wc = make_write_context_with_randomize(
             ColumnMappingMode::None,
             vec![col.into()],
             HashMap::from([(col.into(), Some(value.into()))]),
+            false,
+            2,
         );
         assert_eq!(wc.write_dir().path(), expected_path);
     }
@@ -458,7 +454,7 @@ mod tests {
     #[case::name_mode(ColumnMappingMode::Name)]
     #[case::id_mode(ColumnMappingMode::Id)]
     fn test_write_dir_cm_on_prefix_is_uri_safe(#[case] cm_mode: ColumnMappingMode) {
-        let wc = make_write_context(cm_mode, vec!["p".into()], HashMap::new());
+        let wc = make_write_context_with_randomize(cm_mode, vec!["p".into()], HashMap::new(), false, 2);
         let path = wc.write_dir().path().to_string();
         assert!(
             !path.contains('%'),
@@ -496,7 +492,8 @@ mod tests {
     /// pins the matrix described in the `write_dir` doc comment.
     #[rstest]
     fn test_write_dir_with_randomize_property(
-        #[values(ColumnMappingMode::None, ColumnMappingMode::Name)] cm_mode: ColumnMappingMode,
+        #[values(ColumnMappingMode::None, ColumnMappingMode::Name, ColumnMappingMode::Id)]
+        cm_mode: ColumnMappingMode,
         #[values(true, false)] randomize: bool,
         #[values(true, false)] is_partitioned: bool,
     ) {
@@ -575,7 +572,7 @@ mod tests {
     /// Pins the decision that for CM=None + partitioned + randomize=true, the random prefix
     /// REPLACES the Hive path (matching Delta-Spark's `DelayedCommitProtocol.getFilename`).
     /// Partition values are still recorded in `add.partitionValues`; this test only asserts
-    /// the on-disk layout. If the maintainer prefers prefix-then-Hive, flip this assertion.
+    /// the on-disk layout.
     #[test]
     fn test_write_dir_cm_off_randomize_suppresses_hive() {
         let wc = make_write_context_with_randomize(
@@ -626,7 +623,7 @@ mod tests {
     #[case::error_outside_table_root("s3://bucket/other/abc.parquet", Err(()))]
     #[test]
     fn test_resolve_file_path(#[case] file_url: &str, #[case] expected: Result<&str, ()>) {
-        let wc = make_write_context(ColumnMappingMode::None, vec![], HashMap::new());
+        let wc = make_write_context_with_randomize(ColumnMappingMode::None, vec![], HashMap::new(), false, 2);
         let file = Url::parse(file_url).unwrap();
         match expected {
             Ok(exp) => assert_eq!(wc.resolve_file_path(&file).unwrap(), exp),


### PR DESCRIPTION
WriteContext::write_dir() now emits a random alphanumeric prefix whenever column mapping is on or delta.randomizeFilePrefixes is set, and the prefix length is driven by delta.randomPrefixLength (default 2). When a random prefix is used on a partitioned table, Hive-style path components are suppressed; partition values are still recorded in add.partitionValues. This matches Delta-Spark's getRandomPrefix / DelayedCommitProtocol behavior so kernel writers produce a compatible on-disk layout.

Closes #2357.

## What changes are proposed in this pull request?

`WriteContext::write_dir()` previously emitted a random 2-char alphanumeric prefix only when column mapping was enabled. This PR makes it also respect the two table properties Delta-Spark uses for the same purpose:

- `delta.randomizeFilePrefixes` (bool, default `false`) — when `true`, a random prefix is emitted regardless of column mapping mode.
- `delta.randomPrefixLength` (positive int, default `2`) — controls the prefix length for both the column-mapping path and the new randomize path.

Both properties were already deserialized into `TableProperties`; the implementation is purely in the write path:

- `Transaction::shared_write_state` reads the two properties from `effective_table_config.table_properties()` and stores resolved values on `SharedWriteState`.
- `random_alphanumeric_prefix(len)` is now parameterized by length.
- `write_dir()` uses a single `should_prefix` decision: a random prefix is used iff column mapping is on **or** `randomizeFilePrefixes` is set. 
  When a random prefix is used on a partitioned table, Hive-style path components are suppressed; partition values are still recorded in `add.partitionValues`.

## How was this change tested?

- All existing `write_context` unit tests pass unchanged (`make_write_context` is now a thin wrapper around a new helper that also accepts the randomize parameters).
- New rstest matrices added in `kernel/src/transaction/write_context.rs`:
    - `test_write_dir_with_randomize_property` — cartesian over `cm_mode × randomize × is_partitioned`.
    - `test_write_dir_random_prefix_length_property` — verifies prefix length is honored for lengths 1, 2, and 16 in both the CM-on and `randomize=true` paths.
    - `test_write_dir_cm_off_randomize_suppresses_hive` — pins the decision flagged in "Open question" above so a future flip is deliberate.
- `test_random_alphanumeric_prefix_format` extended to loop over multiple lengths (1, 2, 8, 32).
