### PR TITLE
feat: Support `icebergCompatV3` for create table

### DIFF
--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -357,8 +357,7 @@ pub(crate) fn try_assign_flat_column_mapping_info(
     Ok(new_field)
 }
 
-/// Recurses through `data_type`, descending into struct/array/map members so any nested
-/// StructFields receive CM id + physical name via [`assign_column_mapping_metadata`].
+/// Process nested data types to assign flat column mapping metadata to any nested struct fields.
 fn flat_cm_info_for_nested_data_type(
     data_type: &DataType,
     max_id: &mut i64,
@@ -467,6 +466,7 @@ fn assign_nested_cm_ids(schema: &StructType, max_id: &mut i64) -> DeltaResult<St
     StructType::try_new(new_fields)
 }
 
+// Get the physical name for a field. Error if the field is missing the physical name annotation.
 fn expect_physical_name(field: &StructField) -> DeltaResult<String> {
     match field
         .metadata
@@ -474,8 +474,7 @@ fn expect_physical_name(field: &StructField) -> DeltaResult<String> {
     {
         Some(MetadataValue::String(s)) => Ok(s.clone()),
         _ => Err(Error::internal_error(format!(
-            "nested-id assignment requires every StructField to already carry a physical \
-             name; '{}' is missing one",
+            "Expect field '{}' to have a physical name annotation",
             field.name,
         ))),
     }
@@ -602,7 +601,9 @@ mod tests {
     use super::*;
     use crate::expressions::ColumnName;
     use crate::schema::{DataType, MetadataValue, StructField, StructType};
-    use crate::utils::test_utils::{make_test_tc, test_deep_nested_schema_missing_leaf_cm};
+    use crate::utils::test_utils::{
+        assert_result_error_with_message, make_test_tc, test_deep_nested_schema_missing_leaf_cm,
+    };
 
     #[test]
     fn test_column_mapping_mode() {
@@ -866,7 +867,7 @@ mod tests {
     #[case::across_array(cm_schema_array_duplicates())]
     #[case::across_map(cm_schema_map_duplicates())]
     fn test_duplicate_column_mapping_ids_rejected(#[case] schema: StructType) {
-        crate::utils::test_utils::assert_result_error_with_message(
+        assert_result_error_with_message(
             validate_schema_column_mapping(&schema, ColumnMappingMode::Id),
             "Duplicate column mapping ID",
         );
@@ -874,7 +875,7 @@ mod tests {
 
     #[test]
     fn test_duplicate_column_mapping_ids_rejected_in_name_mode() {
-        crate::utils::test_utils::assert_result_error_with_message(
+        assert_result_error_with_message(
             validate_schema_column_mapping(
                 &cm_schema_same_level_duplicates(),
                 ColumnMappingMode::Name,
@@ -1409,6 +1410,34 @@ mod tests {
             err.contains(expected_err),
             "Expected error containing '{expected_err}', got: {err}"
         );
+    }
+
+    #[rstest::rstest]
+    #[case::string_value(Some(MetadataValue::String("col-x".into())), Some("col-x"))]
+    #[case::missing(None /* annotation */, None /* expected(None means error) */)]
+    #[case::wrong_type_number(Some(MetadataValue::Number(7)), None /* expected(None means error) */)]
+    #[case::wrong_type_boolean(Some(MetadataValue::Boolean(true)), None /* expected(None means error) */)]
+    #[case::wrong_type_other(
+        Some(MetadataValue::Other(serde_json::Value::from("col-x"))),
+        None /* expected(None means error) */,
+    )]
+    fn test_expect_physical_name(
+        #[case] annotation: Option<MetadataValue>,
+        #[case] expected: Option<&str>,
+    ) {
+        let mut field = StructField::new("a", DataType::INTEGER, true);
+        if let Some(value) = annotation {
+            field = field
+                .add_metadata([(ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(), value)]);
+        }
+        let result = expect_physical_name(&field);
+        match expected {
+            Some(expected) => assert_eq!(result.unwrap(), expected),
+            None => assert_result_error_with_message(
+                result,
+                "Expect field 'a' to have a physical name annotation",
+            ),
+        }
     }
 
     #[test]

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -272,10 +272,6 @@ pub(crate) fn get_column_mapping_mode_from_properties(
 /// }
 /// ```
 ///
-/// Note the assignment order: the Map walker stamps both `<pname>.key` and `<pname>.value` ids
-/// first, then recurses into the key/value subtypes (here, `<pname>.key.element` for the inner
-/// list).
-///
 /// `max_id` ends at `4`. With `with_nested_ids = false` the same field gets only the CM
 /// metadata and `max_id` ends at `1`:
 ///

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -266,11 +266,15 @@ pub(crate) fn get_column_mapping_mode_from_properties(
 ///   "delta.columnMapping.physicalName": "<pname>",
 ///   "delta.columnMapping.nested.ids": {
 ///     "<pname>.key":         2,
-///     "<pname>.key.element": 3,
-///     "<pname>.value":       4
+///     "<pname>.value":       3,
+///     "<pname>.key.element": 4
 ///   }
 /// }
 /// ```
+///
+/// Note the assignment order: the Map walker stamps both `<pname>.key` and `<pname>.value` ids
+/// first, then recurses into the key/value subtypes (here, `<pname>.key.element` for the inner
+/// list).
 ///
 /// `max_id` ends at `4`. With `with_nested_ids = false` the same field gets only the CM
 /// metadata and `max_id` ends at `1`:
@@ -302,8 +306,8 @@ pub(crate) fn assign_column_mapping_metadata(
 ///
 /// # Errors
 ///
-/// - Field carries a pre-existing `delta.columnMapping.id` or `delta.columnMapping.physicalName`
-///   annotation.
+/// - Field carries a pre-existing `delta.columnMapping.id`, `delta.columnMapping.physicalName`,
+///   `delta.columnMapping.nested.ids`, or `parquet.field.nested.ids` annotation.
 pub(crate) fn try_assign_field_column_mapping(
     field: &StructField,
     max_id: &mut i64,
@@ -360,24 +364,43 @@ pub(crate) fn try_assign_field_column_mapping(
     Ok(new_field)
 }
 
-/// Returns the largest `delta.columnMapping.id` found anywhere in `schema`, including nested
-/// data types. Returns `None` if no field carries a column mapping ID.
+/// Returns the largest column mapping id found anywhere in `schema`. This includes both
+/// per-field `delta.columnMapping.id` annotations and the nested ids in
+/// `delta.columnMapping.nested.ids` metadata.
 pub(crate) fn find_max_column_id_in_schema(schema: &StructType) -> Option<i64> {
     let mut visitor = MaxColumnId(None);
     visitor.transform_struct(schema);
     visitor.0
 }
 
-/// Visitor that walks a schema and records the largest `delta.columnMapping.id` seen on any
-/// field (including nested struct, array, map, and variant fields).
+/// Visitor that walks a schema and records the largest column mapping id seen on any field,
+/// counting both `delta.columnMapping.id` (per-field) and the integer values inside any
+/// `delta.columnMapping.nested.ids` JSON map (for element/key/value of Array/Map).
 struct MaxColumnId(Option<i64>);
+
+impl MaxColumnId {
+    fn observe(&mut self, n: i64) {
+        self.0 = Some(self.0.map_or(n, |prev| prev.max(n)));
+    }
+}
 
 impl<'a> SchemaTransform<'a> for MaxColumnId {
     transform_output_type!(|'a, T| ());
 
     fn transform_struct_field(&mut self, field: &'a StructField) {
         if let Some(n) = field.column_mapping_id() {
-            self.0 = Some(self.0.map_or(n, |prev| prev.max(n)));
+            self.observe(n);
+        }
+        // Nested-ids JSON holds ids for element/key/value of Array/Map.
+        if let Some(MetadataValue::Other(serde_json::Value::Object(obj))) = field
+            .metadata()
+            .get(ColumnMetadataKey::ColumnMappingNestedIds.as_ref())
+        {
+            for v in obj.values() {
+                if let Some(n) = v.as_i64() {
+                    self.observe(n);
+                }
+            }
         }
         // Recurse into the field's data type so we also visit nested struct/array/map members.
         self.recurse_into_struct_field(field)
@@ -1505,5 +1528,31 @@ mod tests {
         ));
         let schema = StructType::try_new(vec![field_with_id("v", variant, 4)]).unwrap();
         assert_eq!(find_max_column_id_in_schema(&schema), Some(23));
+    }
+
+    /// Nested-ids JSON entries (assigned to element/key/value of Array/Map) are real column-mapping
+    /// ids and must beat the per-field `delta.columnMapping.id` when larger.
+    #[test]
+    fn find_max_column_id_picks_up_nested_ids_metadata() {
+        let mut field = field_with_id(
+            "m",
+            DataType::Map(Box::new(MapType::new(
+                DataType::INTEGER,
+                DataType::INTEGER,
+                false,
+            ))),
+            1,
+        );
+        field.metadata.insert(
+            ColumnMetadataKey::ColumnMappingNestedIds
+                .as_ref()
+                .to_string(),
+            MetadataValue::Other(serde_json::json!({
+                "m.key":   2,
+                "m.value": 99,
+            })),
+        );
+        let schema = StructType::try_new(vec![field]).unwrap();
+        assert_eq!(find_max_column_id_in_schema(&schema), Some(99));
     }
 }

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -290,27 +290,28 @@ pub(crate) fn assign_column_mapping_metadata(
     assign_nested_field_ids: bool,
 ) -> DeltaResult<StructType> {
     // Assign CM id + physical name to every StructField (top-level and nested).
+    // `delta.columnMapping.nested.ids` is assigned later separately, this is to
+    // align with delta-spark's behavior.
     let new_fields: Vec<StructField> = schema
         .fields()
         .map(|field| try_assign_flat_column_mapping_info(field, max_id))
         .collect::<DeltaResult<Vec<_>>>()?;
-    let with_cm_ids = StructType::try_new(new_fields)?;
+    let with_flat_cm_info = StructType::try_new(new_fields)?;
     if !assign_nested_field_ids {
-        return Ok(with_cm_ids);
+        return Ok(with_flat_cm_info);
     }
     // Then populate `delta.columnMapping.nested.ids` per StructField.
-    assign_nested_cm_ids(&with_cm_ids, max_id)
+    assign_nested_cm_ids(&with_flat_cm_info, max_id)
 }
 
 /// JSON object holding [`ColumnMetadataKey::ColumnMappingNestedIds`] entries for an Array/Map
 /// field.
 type NestedFieldIds = serde_json::Map<String, serde_json::Value>;
 
-/// Assigns flat column mapping metadata(id and physical name) to a single field under the contract of
-/// [`assign_column_mapping_metadata`], recursively processing nested struct fields. Returns a
-/// new field with a fresh `delta.columnMapping.id` and a UUID-based
-/// `delta.columnMapping.physicalName`.
-/// 
+/// Assigns flat column mapping metadata(id and physical name) to a single field, recursively
+/// processing nested types. Returns a new field with a fresh unique ID and a UUID-based physical
+/// name, and increments `max_id` to reflect the assignment.
+///
 /// `delta.columnMapping.nested.ids` is not assigned here.
 ///
 /// # Errors
@@ -336,38 +337,57 @@ pub(crate) fn try_assign_flat_column_mapping_info(
             )));
         }
     }
+    // Start with the existing field and assign new ID
     let mut new_field = field.clone();
     *max_id += 1;
     new_field.metadata.insert(
         ColumnMetadataKey::ColumnMappingId.as_ref().to_string(),
         MetadataValue::Number(*max_id),
     );
+    // Assign physical name
+    let physical_name = format!("col-{}", Uuid::new_v4());
     new_field.metadata.insert(
         ColumnMetadataKey::ColumnMappingPhysicalName
             .as_ref()
             .to_string(),
-        MetadataValue::String(format!("col-{}", Uuid::new_v4())),
+        MetadataValue::String(physical_name),
     );
+    // Recursively process nested types
     new_field.data_type = flat_cm_info_for_nested_data_type(&field.data_type, max_id)?;
     Ok(new_field)
 }
 
 /// Recurses through `data_type`, descending into struct/array/map members so any nested
 /// StructFields receive CM id + physical name via [`assign_column_mapping_metadata`].
-fn flat_cm_info_for_nested_data_type(data_type: &DataType, max_id: &mut i64) -> DeltaResult<DataType> {
+fn flat_cm_info_for_nested_data_type(
+    data_type: &DataType,
+    max_id: &mut i64,
+) -> DeltaResult<DataType> {
     match data_type {
-        DataType::Struct(inner) => Ok(DataType::Struct(Box::new(
-            assign_column_mapping_metadata(inner, max_id, false)?,
-        ))),
-        DataType::Array(at) => Ok(DataType::Array(Box::new(ArrayType::new(
-            flat_cm_info_for_nested_data_type(at.element_type(), max_id)?,
-            at.contains_null(),
-        )))),
-        DataType::Map(mt) => Ok(DataType::Map(Box::new(MapType::new(
-            flat_cm_info_for_nested_data_type(mt.key_type(), max_id)?,
-            flat_cm_info_for_nested_data_type(mt.value_type(), max_id)?,
-            mt.value_contains_null(),
-        )))),
+        DataType::Struct(inner) => {
+            let new_inner = assign_column_mapping_metadata(
+                inner, max_id, /* assign_nested_field_ids */ false,
+            )?;
+            Ok(DataType::Struct(Box::new(new_inner)))
+        }
+        DataType::Array(array_type) => {
+            let new_element_type =
+                flat_cm_info_for_nested_data_type(array_type.element_type(), max_id)?;
+            Ok(DataType::Array(Box::new(ArrayType::new(
+                new_element_type,
+                array_type.contains_null(),
+            ))))
+        }
+        DataType::Map(map_type) => {
+            let new_key_type = flat_cm_info_for_nested_data_type(map_type.key_type(), max_id)?;
+            let new_value_type = flat_cm_info_for_nested_data_type(map_type.value_type(), max_id)?;
+            Ok(DataType::Map(Box::new(MapType::new(
+                new_key_type,
+                new_value_type,
+                map_type.value_contains_null(),
+            ))))
+        }
+        // Primitive and Variant types don't contain nested struct fields - return as-is
         DataType::Primitive(_) | DataType::Variant(_) => Ok(data_type.clone()),
     }
 }
@@ -375,9 +395,10 @@ fn flat_cm_info_for_nested_data_type(data_type: &DataType, max_id: &mut i64) -> 
 /// Walks `schema` (already carrying CM id + physical name on every StructField) and populates
 /// `delta.columnMapping.nested.ids` on Array/Map fields.
 ///
-/// `delta.columnMapping.nested.ids` is a JSON object on a StructField that records the parquet field ids
-/// for the synthetic Array `element` and Map `key`/`value` slots inside that field's subtree.
-/// Keys are dotted paths anchored at the field's physical name; values are parquet field ids.
+/// `delta.columnMapping.nested.ids` is a JSON object on a StructField that records the parquet
+/// field ids for the synthetic Array `element` and Map `key`/`value` slots inside that field's
+/// subtree. Keys are dotted paths anchored at the field's physical name; values are parquet field
+/// ids.
 ///
 /// Example for `m: Map<List<int>, int>` with physical name `<phys>`:
 ///
@@ -399,29 +420,30 @@ fn assign_nested_cm_ids(schema: &StructType, max_id: &mut i64) -> DeltaResult<St
             DataType::Struct(inner) => Ok(DataType::Struct(Box::new(assign_nested_cm_ids(
                 inner, max_id,
             )?))),
-            DataType::Array(at) => {
+            DataType::Array(array_type) => {
                 let element_path = format!("{path}.element");
                 *max_id += 1;
                 nested_ids.insert(element_path.clone(), serde_json::Value::from(*max_id));
-                let new_element = walk(at.element_type(), max_id, &element_path, nested_ids)?;
+                let new_element =
+                    walk(array_type.element_type(), max_id, &element_path, nested_ids)?;
                 Ok(DataType::Array(Box::new(ArrayType::new(
                     new_element,
-                    at.contains_null(),
+                    array_type.contains_null(),
                 ))))
             }
-            DataType::Map(mt) => {
+            DataType::Map(map_type) => {
                 let key_path = format!("{path}.key");
                 let value_path = format!("{path}.value");
                 *max_id += 1;
                 nested_ids.insert(key_path.clone(), serde_json::Value::from(*max_id));
-                let new_key = walk(mt.key_type(), max_id, &key_path, nested_ids)?;
+                let new_key = walk(map_type.key_type(), max_id, &key_path, nested_ids)?;
                 *max_id += 1;
                 nested_ids.insert(value_path.clone(), serde_json::Value::from(*max_id));
-                let new_value = walk(mt.value_type(), max_id, &value_path, nested_ids)?;
+                let new_value = walk(map_type.value_type(), max_id, &value_path, nested_ids)?;
                 Ok(DataType::Map(Box::new(MapType::new(
                     new_key,
                     new_value,
-                    mt.value_contains_null(),
+                    map_type.value_contains_null(),
                 ))))
             }
             DataType::Primitive(_) | DataType::Variant(_) => Ok(data_type.clone()),

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -231,14 +231,14 @@ pub(crate) fn get_column_mapping_mode_from_properties(
 }
 
 /// Assigns column mapping metadata (id and physicalName) to all fields in `schema`, and also
-/// assigns `delta.columnMapping.nested.ids` on Array/Map fields when `with_nested_ids` is
-/// `true`.
+/// assigns `delta.columnMapping.nested.ids` on Array/Map fields when
+/// `assign_nested_field_ids` is `true`.
 ///
 /// This function recursively processes all fields in the schema, including nested structs,
 /// arrays, and maps. Each field is assigned a new unique ID and physical name. When
-/// `with_nested_ids` is true, each element/key/value in Array/Map is assigned a new unique parquet
-/// field id and stored in the `delta.columnMapping.nested.ids` metadata of the nearest ancestor
-/// `StructField`.
+/// `assign_nested_field_ids` is true, each element/key/value in Array/Map is assigned a new
+/// unique parquet field id and stored in the `delta.columnMapping.nested.ids` metadata of the
+/// nearest ancestor `StructField`.
 ///
 /// Fields with pre-existing column mapping metadata (id or physicalName) are rejected to avoid
 /// conflicts.
@@ -248,8 +248,10 @@ pub(crate) fn get_column_mapping_mode_from_properties(
 /// * `schema` - The schema to transform.
 /// * `max_id` - Tracks the highest column ID assigned. Updated in place. Should be initialized to
 ///   `0` for a new table.
-/// * `with_nested_ids` - When `true`, also assigns parquet field ids for element/key/value in
-///   Array/Map.
+/// * `assign_nested_field_ids` - When `true`, also allocates IDs for synthetic `Array.element` and
+///   `Map.key`/`Map.value` fields, stores them in `delta.columnMapping.nested.ids`, and includes
+///   them in `max_id`. Assigning IDs to these nested fields is a hard requirement for
+///   IcebergCompatV2/3.
 ///
 /// # Returns
 ///
@@ -258,7 +260,8 @@ pub(crate) fn get_column_mapping_mode_from_properties(
 /// # Example
 ///
 /// Given a top-level field `m: map<list<int>, int>`, after calling with
-/// `with_nested_ids = true` the field gets (`<pname>` is the assigned UUID-based physical name):
+/// `assign_nested_field_ids = true` the field gets (`<pname>` is the assigned UUID-based
+/// physical name):
 ///
 /// ```json
 /// {
@@ -266,14 +269,14 @@ pub(crate) fn get_column_mapping_mode_from_properties(
 ///   "delta.columnMapping.physicalName": "<pname>",
 ///   "delta.columnMapping.nested.ids": {
 ///     "<pname>.key":         2,
-///     "<pname>.value":       3,
-///     "<pname>.key.element": 4
+///     "<pname>.key.element": 3,
+///     "<pname>.value":       4
 ///   }
 /// }
 /// ```
 ///
-/// `max_id` ends at `4`. With `with_nested_ids = false` the same field gets only the CM
-/// metadata and `max_id` ends at `1`:
+/// `max_id` ends at `4`. With `assign_nested_field_ids = false` the same field gets only the
+/// CM metadata and `max_id` ends at `1`:
 ///
 /// ```json
 /// {
@@ -284,20 +287,24 @@ pub(crate) fn get_column_mapping_mode_from_properties(
 pub(crate) fn assign_column_mapping_metadata(
     schema: &StructType,
     max_id: &mut i64,
-    with_nested_ids: bool,
+    assign_nested_field_ids: bool,
 ) -> DeltaResult<StructType> {
     let new_fields: Vec<StructField> = schema
         .fields()
-        .map(|field| try_assign_field_column_mapping(field, max_id, with_nested_ids))
+        .map(|field| try_assign_field_column_mapping(field, max_id, assign_nested_field_ids))
         .collect::<DeltaResult<Vec<_>>>()?;
 
     StructType::try_new(new_fields)
 }
 
+/// JSON object holding [`ColumnMetadataKey::ColumnMappingNestedIds`] entries for an Array/Map
+/// field.
+type NestedFieldIds = serde_json::Map<String, serde_json::Value>;
+
 /// Assigns column mapping metadata to a single field under the contract of
 /// [`assign_column_mapping_metadata`], recursively processing nested types. Returns a new field
 /// with a fresh `delta.columnMapping.id` and a UUID-based `delta.columnMapping.physicalName`.
-/// When `with_nested_ids` is `true` and the field's type is Array or Map, also stamps
+/// When `assign_nested_field_ids` is `true` and the field's type is Array or Map, also sets
 /// `delta.columnMapping.nested.ids` on the field. Increments `max_id` for every assignment.
 ///
 /// # Errors
@@ -307,7 +314,7 @@ pub(crate) fn assign_column_mapping_metadata(
 pub(crate) fn try_assign_field_column_mapping(
     field: &StructField,
     max_id: &mut i64,
-    with_nested_ids: bool,
+    assign_nested_field_ids: bool,
 ) -> DeltaResult<StructField> {
     for key in [
         ColumnMetadataKey::ColumnMappingId,
@@ -341,23 +348,30 @@ pub(crate) fn try_assign_field_column_mapping(
             .to_string(),
         MetadataValue::String(physical_name.clone()),
     );
-
-    // Recursively process nested types. Accumulate directly into a `serde_json::Map` so we
-    // can wrap it as `MetadataValue::Other(Value::Object(_))` without a post-walk conversion.
-    let mut nested_ids: Option<serde_json::Map<String, serde_json::Value>> =
-        with_nested_ids.then(serde_json::Map::new);
-    new_field.data_type =
-        process_nested_data_type(&field.data_type, max_id, &physical_name, &mut nested_ids)?;
-    if let Some(ids) = nested_ids.filter(|m| !m.is_empty()) {
-        new_field.metadata.insert(
-            ColumnMetadataKey::ColumnMappingNestedIds
-                .as_ref()
-                .to_string(),
-            MetadataValue::Other(serde_json::Value::Object(ids)),
-        );
+    // Recursively process nested types.
+    let mut nested_field_ids: Option<NestedFieldIds> =
+        assign_nested_field_ids.then(NestedFieldIds::new);
+    new_field.data_type = process_nested_data_type(
+        &field.data_type,
+        max_id,
+        &physical_name,
+        &mut nested_field_ids,
+    )?;
+    if let Some(ids) = nested_field_ids.filter(|m| !m.is_empty()) {
+        insert_nested_field_ids_metadata(&mut new_field, ids);
     }
 
     Ok(new_field)
+}
+
+/// Sets the collected nested ids on `field` under the `delta.columnMapping.nested.ids` key.
+fn insert_nested_field_ids_metadata(field: &mut StructField, ids: NestedFieldIds) {
+    field.metadata.insert(
+        ColumnMetadataKey::ColumnMappingNestedIds
+            .as_ref()
+            .to_string(),
+        MetadataValue::Other(serde_json::Value::Object(ids)),
+    );
 }
 
 /// Returns the largest column mapping id found anywhere in `schema`. This includes both
@@ -387,7 +401,10 @@ impl<'a> SchemaTransform<'a> for MaxColumnId {
         if let Some(n) = field.column_mapping_id() {
             self.observe(n);
         }
-        // Nested-ids JSON holds ids for element/key/value of Array/Map.
+        // `delta.columnMapping.nested.ids` is a JSON object set on Array/Map fields. Shape: {
+        // "<phys>.key": <id>, "<phys>.value": <id>, "<phys>.key.element": <id>, ... }
+        // (string paths -> nested column-mapping ids). See the definition of
+        // `ColumnMetadataKey::ColumnMappingNestedIds` for more details.
         if let Some(MetadataValue::Other(serde_json::Value::Object(obj))) = field
             .metadata()
             .get(ColumnMetadataKey::ColumnMappingNestedIds.as_ref())
@@ -406,14 +423,14 @@ impl<'a> SchemaTransform<'a> for MaxColumnId {
 /// Recurse through `data_type`, descending into nested struct/array/map types to assign column
 /// mapping metadata to any nested struct fields.
 ///
-/// When `nested_ids` is `Some(_)`, also stamp `delta.columnMapping.nested.ids` on Array/Map fields.
+/// When `nested_ids` is `Some(_)`, also sets `delta.columnMapping.nested.ids` on Array/Map fields.
 ///
 /// See [`assign_column_mapping_metadata`] for an concrete example.
 fn process_nested_data_type(
     data_type: &DataType,
     max_id: &mut i64,
     path: &str,
-    nested_ids: &mut Option<serde_json::Map<String, serde_json::Value>>,
+    nested_ids: &mut Option<NestedFieldIds>,
 ) -> DeltaResult<DataType> {
     match data_type {
         DataType::Struct(inner) => {
@@ -440,14 +457,19 @@ fn process_nested_data_type(
         DataType::Map(map_type) => {
             let key_path = format!("{path}.key");
             let value_path = format!("{path}.value");
+            // DFS order: set nested ids for `key`, recurse into key (descendants get next ids),
+            // then set nested ids `value`, recurse into value. Matches delta-spark's
+            // behavior.
             if let Some(ids) = nested_ids.as_mut() {
                 *max_id += 1;
                 ids.insert(key_path.clone(), serde_json::Value::from(*max_id));
-                *max_id += 1;
-                ids.insert(value_path.clone(), serde_json::Value::from(*max_id));
             }
             let new_key_type =
                 process_nested_data_type(map_type.key_type(), max_id, &key_path, nested_ids)?;
+            if let Some(ids) = nested_ids.as_mut() {
+                *max_id += 1;
+                ids.insert(value_path.clone(), serde_json::Value::from(*max_id));
+            }
             let new_value_type =
                 process_nested_data_type(map_type.value_type(), max_id, &value_path, nested_ids)?;
             Ok(DataType::Map(Box::new(MapType::new(

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -289,32 +289,37 @@ pub(crate) fn assign_column_mapping_metadata(
     max_id: &mut i64,
     assign_nested_field_ids: bool,
 ) -> DeltaResult<StructType> {
+    // Assign CM id + physical name to every StructField (top-level and nested).
     let new_fields: Vec<StructField> = schema
         .fields()
-        .map(|field| try_assign_field_column_mapping(field, max_id, assign_nested_field_ids))
+        .map(|field| try_assign_flat_column_mapping_info(field, max_id))
         .collect::<DeltaResult<Vec<_>>>()?;
-
-    StructType::try_new(new_fields)
+    let with_cm_ids = StructType::try_new(new_fields)?;
+    if !assign_nested_field_ids {
+        return Ok(with_cm_ids);
+    }
+    // Then populate `delta.columnMapping.nested.ids` per StructField.
+    assign_nested_cm_ids(&with_cm_ids, max_id)
 }
 
 /// JSON object holding [`ColumnMetadataKey::ColumnMappingNestedIds`] entries for an Array/Map
 /// field.
 type NestedFieldIds = serde_json::Map<String, serde_json::Value>;
 
-/// Assigns column mapping metadata to a single field under the contract of
-/// [`assign_column_mapping_metadata`], recursively processing nested types. Returns a new field
-/// with a fresh `delta.columnMapping.id` and a UUID-based `delta.columnMapping.physicalName`.
-/// When `assign_nested_field_ids` is `true` and the field's type is Array or Map, also sets
-/// `delta.columnMapping.nested.ids` on the field. Increments `max_id` for every assignment.
+/// Assigns flat column mapping metadata(id and physical name) to a single field under the contract of
+/// [`assign_column_mapping_metadata`], recursively processing nested struct fields. Returns a
+/// new field with a fresh `delta.columnMapping.id` and a UUID-based
+/// `delta.columnMapping.physicalName`.
+/// 
+/// `delta.columnMapping.nested.ids` is not assigned here.
 ///
 /// # Errors
 ///
 /// - Field carries a pre-existing `delta.columnMapping.id`, `delta.columnMapping.physicalName`,
 ///   `delta.columnMapping.nested.ids`, or `parquet.field.nested.ids` annotation.
-pub(crate) fn try_assign_field_column_mapping(
+pub(crate) fn try_assign_flat_column_mapping_info(
     field: &StructField,
     max_id: &mut i64,
-    assign_nested_field_ids: bool,
 ) -> DeltaResult<StructField> {
     for key in [
         ColumnMetadataKey::ColumnMappingId,
@@ -331,37 +336,127 @@ pub(crate) fn try_assign_field_column_mapping(
             )));
         }
     }
-
-    // Start with the existing field and assign new ID
     let mut new_field = field.clone();
     *max_id += 1;
     new_field.metadata.insert(
         ColumnMetadataKey::ColumnMappingId.as_ref().to_string(),
         MetadataValue::Number(*max_id),
     );
-
-    // Assign physical name
-    let physical_name = format!("col-{}", Uuid::new_v4());
     new_field.metadata.insert(
         ColumnMetadataKey::ColumnMappingPhysicalName
             .as_ref()
             .to_string(),
-        MetadataValue::String(physical_name.clone()),
+        MetadataValue::String(format!("col-{}", Uuid::new_v4())),
     );
-    // Recursively process nested types.
-    let mut nested_field_ids: Option<NestedFieldIds> =
-        assign_nested_field_ids.then(NestedFieldIds::new);
-    new_field.data_type = process_nested_data_type(
-        &field.data_type,
-        max_id,
-        &physical_name,
-        &mut nested_field_ids,
-    )?;
-    if let Some(ids) = nested_field_ids.filter(|m| !m.is_empty()) {
-        insert_nested_field_ids_metadata(&mut new_field, ids);
+    new_field.data_type = flat_cm_info_for_nested_data_type(&field.data_type, max_id)?;
+    Ok(new_field)
+}
+
+/// Recurses through `data_type`, descending into struct/array/map members so any nested
+/// StructFields receive CM id + physical name via [`assign_column_mapping_metadata`].
+fn flat_cm_info_for_nested_data_type(data_type: &DataType, max_id: &mut i64) -> DeltaResult<DataType> {
+    match data_type {
+        DataType::Struct(inner) => Ok(DataType::Struct(Box::new(
+            assign_column_mapping_metadata(inner, max_id, false)?,
+        ))),
+        DataType::Array(at) => Ok(DataType::Array(Box::new(ArrayType::new(
+            flat_cm_info_for_nested_data_type(at.element_type(), max_id)?,
+            at.contains_null(),
+        )))),
+        DataType::Map(mt) => Ok(DataType::Map(Box::new(MapType::new(
+            flat_cm_info_for_nested_data_type(mt.key_type(), max_id)?,
+            flat_cm_info_for_nested_data_type(mt.value_type(), max_id)?,
+            mt.value_contains_null(),
+        )))),
+        DataType::Primitive(_) | DataType::Variant(_) => Ok(data_type.clone()),
+    }
+}
+
+/// Walks `schema` (already carrying CM id + physical name on every StructField) and populates
+/// `delta.columnMapping.nested.ids` on Array/Map fields.
+///
+/// `delta.columnMapping.nested.ids` is a JSON object on a StructField that records the parquet field ids
+/// for the synthetic Array `element` and Map `key`/`value` slots inside that field's subtree.
+/// Keys are dotted paths anchored at the field's physical name; values are parquet field ids.
+///
+/// Example for `m: Map<List<int>, int>` with physical name `<phys>`:
+///
+/// ```json
+/// {
+///   "<phys>.key":         2,
+///   "<phys>.key.element": 3,
+///   "<phys>.value":       4
+/// }
+/// ```
+fn assign_nested_cm_ids(schema: &StructType, max_id: &mut i64) -> DeltaResult<StructType> {
+    fn walk(
+        data_type: &DataType,
+        max_id: &mut i64,
+        path: &str,
+        nested_ids: &mut NestedFieldIds,
+    ) -> DeltaResult<DataType> {
+        match data_type {
+            DataType::Struct(inner) => Ok(DataType::Struct(Box::new(assign_nested_cm_ids(
+                inner, max_id,
+            )?))),
+            DataType::Array(at) => {
+                let element_path = format!("{path}.element");
+                *max_id += 1;
+                nested_ids.insert(element_path.clone(), serde_json::Value::from(*max_id));
+                let new_element = walk(at.element_type(), max_id, &element_path, nested_ids)?;
+                Ok(DataType::Array(Box::new(ArrayType::new(
+                    new_element,
+                    at.contains_null(),
+                ))))
+            }
+            DataType::Map(mt) => {
+                let key_path = format!("{path}.key");
+                let value_path = format!("{path}.value");
+                *max_id += 1;
+                nested_ids.insert(key_path.clone(), serde_json::Value::from(*max_id));
+                let new_key = walk(mt.key_type(), max_id, &key_path, nested_ids)?;
+                *max_id += 1;
+                nested_ids.insert(value_path.clone(), serde_json::Value::from(*max_id));
+                let new_value = walk(mt.value_type(), max_id, &value_path, nested_ids)?;
+                Ok(DataType::Map(Box::new(MapType::new(
+                    new_key,
+                    new_value,
+                    mt.value_contains_null(),
+                ))))
+            }
+            DataType::Primitive(_) | DataType::Variant(_) => Ok(data_type.clone()),
+        }
     }
 
-    Ok(new_field)
+    let new_fields: Vec<StructField> = schema
+        .fields()
+        .map(|field| {
+            let physical = expect_physical_name(field)?;
+            let mut nested_ids = NestedFieldIds::new();
+            let new_dt = walk(&field.data_type, max_id, &physical, &mut nested_ids)?;
+            let mut new_field = field.clone();
+            new_field.data_type = new_dt;
+            if !nested_ids.is_empty() {
+                insert_nested_field_ids_metadata(&mut new_field, nested_ids);
+            }
+            Ok(new_field)
+        })
+        .collect::<DeltaResult<Vec<_>>>()?;
+    StructType::try_new(new_fields)
+}
+
+fn expect_physical_name(field: &StructField) -> DeltaResult<String> {
+    match field
+        .metadata
+        .get(ColumnMetadataKey::ColumnMappingPhysicalName.as_ref())
+    {
+        Some(MetadataValue::String(s)) => Ok(s.clone()),
+        _ => Err(Error::internal_error(format!(
+            "nested-id assignment requires every StructField to already carry a physical \
+             name; '{}' is missing one",
+            field.name,
+        ))),
+    }
 }
 
 /// Sets the collected nested ids on `field` under the `delta.columnMapping.nested.ids` key.
@@ -417,69 +512,6 @@ impl<'a> SchemaTransform<'a> for MaxColumnId {
         }
         // Recurse into the field's data type so we also visit nested struct/array/map members.
         self.recurse_into_struct_field(field)
-    }
-}
-
-/// Recurse through `data_type`, descending into nested struct/array/map types to assign column
-/// mapping metadata to any nested struct fields.
-///
-/// When `nested_ids` is `Some(_)`, also sets `delta.columnMapping.nested.ids` on Array/Map fields.
-///
-/// See [`assign_column_mapping_metadata`] for an concrete example.
-fn process_nested_data_type(
-    data_type: &DataType,
-    max_id: &mut i64,
-    path: &str,
-    nested_ids: &mut Option<NestedFieldIds>,
-) -> DeltaResult<DataType> {
-    match data_type {
-        DataType::Struct(inner) => {
-            let new_inner = assign_column_mapping_metadata(inner, max_id, nested_ids.is_some())?;
-            Ok(DataType::Struct(Box::new(new_inner)))
-        }
-        DataType::Array(array_type) => {
-            let element_path = format!("{path}.element");
-            if let Some(ids) = nested_ids.as_mut() {
-                *max_id += 1;
-                ids.insert(element_path.clone(), serde_json::Value::from(*max_id));
-            }
-            let new_element_type = process_nested_data_type(
-                array_type.element_type(),
-                max_id,
-                &element_path,
-                nested_ids,
-            )?;
-            Ok(DataType::Array(Box::new(ArrayType::new(
-                new_element_type,
-                array_type.contains_null(),
-            ))))
-        }
-        DataType::Map(map_type) => {
-            let key_path = format!("{path}.key");
-            let value_path = format!("{path}.value");
-            // DFS order: set nested ids for `key`, recurse into key (descendants get next ids),
-            // then set nested ids `value`, recurse into value. Matches delta-spark's
-            // behavior.
-            if let Some(ids) = nested_ids.as_mut() {
-                *max_id += 1;
-                ids.insert(key_path.clone(), serde_json::Value::from(*max_id));
-            }
-            let new_key_type =
-                process_nested_data_type(map_type.key_type(), max_id, &key_path, nested_ids)?;
-            if let Some(ids) = nested_ids.as_mut() {
-                *max_id += 1;
-                ids.insert(value_path.clone(), serde_json::Value::from(*max_id));
-            }
-            let new_value_type =
-                process_nested_data_type(map_type.value_type(), max_id, &value_path, nested_ids)?;
-            Ok(DataType::Map(Box::new(MapType::new(
-                new_key_type,
-                new_value_type,
-                map_type.value_contains_null(),
-            ))))
-        }
-        // Primitive and Variant types don't contain nested struct fields - return as-is
-        DataType::Primitive(_) | DataType::Variant(_) => Ok(data_type.clone()),
     }
 }
 

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -230,38 +230,75 @@ pub(crate) fn get_column_mapping_mode_from_properties(
     }
 }
 
-/// Assigns column mapping metadata (id and physicalName) to all fields in a schema.
+/// Assigns column mapping metadata (id and physicalName) to all fields in `schema`, and also
+/// assigns `delta.columnMapping.nested.ids` on Array/Map fields when `with_nested_ids` is
+/// `true`.
 ///
 /// This function recursively processes all fields in the schema, including nested structs,
-/// arrays, and maps. Each field is assigned a new unique ID and physical name.
+/// arrays, and maps. Each field is assigned a new unique ID and physical name. When
+/// `with_nested_ids`  is true, each element/key/value in Array/Map is assigned a new unique parquet
+/// field id and  stored in the `delta.columnMapping.nested.ids` metadata of the nearest ancestor
+/// `StructField`.
 ///
-/// Fields with pre-existing column mapping metadata (id or physicalName) are rejected
-/// to avoid conflicts.
+/// Fields with pre-existing column mapping metadata (id or physicalName) are rejected to avoid
+/// conflicts.
 ///
 /// # Arguments
 ///
-/// * `schema` - The schema to transform
-/// * `max_id` - Tracks the highest column ID assigned. Updated in place. Should be initialized to 0
-///   for a new table.
+/// * `schema` - The schema to transform.
+/// * `max_id` - Tracks the highest column ID assigned. Updated in place. Should be initialized to
+///   `0` for a new table.
+/// * `with_nested_ids` - When `true`, also assigns parquet field ids for element/key/value in
+///   Array/Map.
 ///
 /// # Returns
 ///
 /// A new schema with column mapping metadata on all fields.
+///
+/// # Example
+///
+/// Given a top-level field `m: map<list<int>, int>`, after calling with
+/// `with_nested_ids = true` the field gets (`<pname>` is the assigned UUID-based physical name):
+///
+/// ```json
+/// {
+///   "delta.columnMapping.id": 1,
+///   "delta.columnMapping.physicalName": "<pname>",
+///   "delta.columnMapping.nested.ids": {
+///     "<pname>.key":         2,
+///     "<pname>.key.element": 3,
+///     "<pname>.value":       4
+///   }
+/// }
+/// ```
+///
+/// `max_id` ends at `4`. With `with_nested_ids = false` the same field gets only the CM
+/// metadata and `max_id` ends at `1`:
+///
+/// ```json
+/// {
+///   "delta.columnMapping.id": 1,
+///   "delta.columnMapping.physicalName": "<pname>"
+/// }
+/// ```
 pub(crate) fn assign_column_mapping_metadata(
     schema: &StructType,
     max_id: &mut i64,
+    with_nested_ids: bool,
 ) -> DeltaResult<StructType> {
     let new_fields: Vec<StructField> = schema
         .fields()
-        .map(|field| try_assign_field_column_mapping(field, max_id))
+        .map(|field| try_assign_field_column_mapping(field, max_id, with_nested_ids))
         .collect::<DeltaResult<Vec<_>>>()?;
 
     StructType::try_new(new_fields)
 }
 
-/// Assigns column mapping metadata to a single field, recursively processing nested types.
-/// Returns a new field with a fresh unique ID and a UUID-based physical name, and increments
-/// `max_id` to reflect the assignment.
+/// Assigns column mapping metadata to a single field under the contract of
+/// [`assign_column_mapping_metadata`], recursively processing nested types. Returns a new field
+/// with a fresh `delta.columnMapping.id` and a UUID-based `delta.columnMapping.physicalName`.
+/// When `with_nested_ids` is `true` and the field's type is Array or Map, also stamps
+/// `delta.columnMapping.nested.ids` on the field. Increments `max_id` for every assignment.
 ///
 /// # Errors
 ///
@@ -270,12 +307,13 @@ pub(crate) fn assign_column_mapping_metadata(
 pub(crate) fn try_assign_field_column_mapping(
     field: &StructField,
     max_id: &mut i64,
+    with_nested_ids: bool,
 ) -> DeltaResult<StructField> {
-    // TODO: Also check for nested column IDs (`delta.columnMapping.nested.ids`) once
-    // Iceberg compatibility (IcebergCompatV2+) is supported. See issue #1125.
     for key in [
         ColumnMetadataKey::ColumnMappingId,
         ColumnMetadataKey::ColumnMappingPhysicalName,
+        ColumnMetadataKey::ColumnMappingNestedIds,
+        ColumnMetadataKey::ParquetFieldNestedIds,
     ] {
         if field.get_config_value(&key).is_some() {
             return Err(Error::generic(format!(
@@ -301,11 +339,24 @@ pub(crate) fn try_assign_field_column_mapping(
         ColumnMetadataKey::ColumnMappingPhysicalName
             .as_ref()
             .to_string(),
-        MetadataValue::String(physical_name),
+        MetadataValue::String(physical_name.clone()),
     );
 
-    // Recursively process nested types
-    new_field.data_type = process_nested_data_type(&field.data_type, max_id)?;
+    // Recursively process nested types.
+    // Note: The walker accumulates nested ids directly into a `serde_json::Map` instead of a
+    // `HashMap`, because MetadataValue::Other requires a `serde_json::Value::Object`.
+    let mut nested_ids: Option<serde_json::Map<String, serde_json::Value>> =
+        with_nested_ids.then(serde_json::Map::new);
+    new_field.data_type =
+        process_nested_data_type(&field.data_type, max_id, &physical_name, &mut nested_ids)?;
+    if let Some(ids) = nested_ids.filter(|m| !m.is_empty()) {
+        new_field.metadata.insert(
+            ColumnMetadataKey::ColumnMappingNestedIds
+                .as_ref()
+                .to_string(),
+            MetadataValue::Other(serde_json::Value::Object(ids)),
+        );
+    }
 
     Ok(new_field)
 }
@@ -334,23 +385,53 @@ impl<'a> SchemaTransform<'a> for MaxColumnId {
     }
 }
 
-/// Process nested data types to assign column mapping metadata to any nested struct fields.
-fn process_nested_data_type(data_type: &DataType, max_id: &mut i64) -> DeltaResult<DataType> {
+/// Recurse through `data_type`, descending into nested struct/array/map types to assign column
+/// mapping metadata to any nested struct fields.
+///
+/// When `nested_ids` is `Some(_)`, also stamp `delta.columnMapping.nested.ids` on Array/Map fields.
+///
+/// See [`assign_column_mapping_metadata`] for an concrete example.
+fn process_nested_data_type(
+    data_type: &DataType,
+    max_id: &mut i64,
+    path: &str,
+    nested_ids: &mut Option<serde_json::Map<String, serde_json::Value>>,
+) -> DeltaResult<DataType> {
     match data_type {
         DataType::Struct(inner) => {
-            let new_inner = assign_column_mapping_metadata(inner, max_id)?;
+            let new_inner = assign_column_mapping_metadata(inner, max_id, nested_ids.is_some())?;
             Ok(DataType::Struct(Box::new(new_inner)))
         }
         DataType::Array(array_type) => {
-            let new_element_type = process_nested_data_type(array_type.element_type(), max_id)?;
+            let element_path = format!("{path}.element");
+            if let Some(ids) = nested_ids.as_mut() {
+                *max_id += 1;
+                ids.insert(element_path.clone(), serde_json::Value::from(*max_id));
+            }
+            let new_element_type = process_nested_data_type(
+                array_type.element_type(),
+                max_id,
+                &element_path,
+                nested_ids,
+            )?;
             Ok(DataType::Array(Box::new(ArrayType::new(
                 new_element_type,
                 array_type.contains_null(),
             ))))
         }
         DataType::Map(map_type) => {
-            let new_key_type = process_nested_data_type(map_type.key_type(), max_id)?;
-            let new_value_type = process_nested_data_type(map_type.value_type(), max_id)?;
+            let key_path = format!("{path}.key");
+            let value_path = format!("{path}.value");
+            if let Some(ids) = nested_ids.as_mut() {
+                *max_id += 1;
+                ids.insert(key_path.clone(), serde_json::Value::from(*max_id));
+                *max_id += 1;
+                ids.insert(value_path.clone(), serde_json::Value::from(*max_id));
+            }
+            let new_key_type =
+                process_nested_data_type(map_type.key_type(), max_id, &key_path, nested_ids)?;
+            let new_value_type =
+                process_nested_data_type(map_type.value_type(), max_id, &value_path, nested_ids)?;
             Ok(DataType::Map(Box::new(MapType::new(
                 new_key_type,
                 new_value_type,
@@ -743,7 +824,7 @@ mod tests {
         ]);
 
         let mut max_id = 0;
-        let result = assign_column_mapping_metadata(&schema, &mut max_id).unwrap();
+        let result = assign_column_mapping_metadata(&schema, &mut max_id, false).unwrap();
 
         // Should have assigned IDs 1 and 2
         assert_eq!(max_id, 2);
@@ -790,7 +871,7 @@ mod tests {
         ]);
 
         let mut max_id = 0;
-        let result = assign_column_mapping_metadata(&schema, &mut max_id);
+        let result = assign_column_mapping_metadata(&schema, &mut max_id, false);
 
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
@@ -813,7 +894,7 @@ mod tests {
         ]);
 
         let mut max_id = 0;
-        let result = assign_column_mapping_metadata(&schema, &mut max_id).unwrap();
+        let result = assign_column_mapping_metadata(&schema, &mut max_id, false).unwrap();
 
         // Should have assigned IDs to all 4 fields
         assert_eq!(max_id, 4);
@@ -914,7 +995,7 @@ mod tests {
         )]);
 
         let mut max_id = 0;
-        let result = assign_column_mapping_metadata(&schema, &mut max_id).unwrap();
+        let result = assign_column_mapping_metadata(&schema, &mut max_id, false).unwrap();
 
         // Should assign IDs to: my_map (1), k (2), v (3)
         assert_eq!(max_id, 3);
@@ -960,7 +1041,7 @@ mod tests {
         )]);
 
         let mut max_id = 0;
-        let result = assign_column_mapping_metadata(&schema, &mut max_id).unwrap();
+        let result = assign_column_mapping_metadata(&schema, &mut max_id, false).unwrap();
 
         // Should assign IDs to: my_array (1), elem (2)
         assert_eq!(max_id, 2);
@@ -1002,7 +1083,7 @@ mod tests {
         )]);
 
         let mut max_id = 0;
-        let result = assign_column_mapping_metadata(&schema, &mut max_id).unwrap();
+        let result = assign_column_mapping_metadata(&schema, &mut max_id, false).unwrap();
 
         // Should assign IDs to: nested_arrays (1), deep (2)
         assert_eq!(max_id, 2);
@@ -1057,7 +1138,7 @@ mod tests {
         )]);
 
         let mut max_id = 0;
-        let result = assign_column_mapping_metadata(&schema, &mut max_id).unwrap();
+        let result = assign_column_mapping_metadata(&schema, &mut max_id, false).unwrap();
 
         // Should assign IDs to: cursed (1), k (2), v (3)
         assert_eq!(max_id, 3);

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -236,8 +236,8 @@ pub(crate) fn get_column_mapping_mode_from_properties(
 ///
 /// This function recursively processes all fields in the schema, including nested structs,
 /// arrays, and maps. Each field is assigned a new unique ID and physical name. When
-/// `with_nested_ids`  is true, each element/key/value in Array/Map is assigned a new unique parquet
-/// field id and  stored in the `delta.columnMapping.nested.ids` metadata of the nearest ancestor
+/// `with_nested_ids` is true, each element/key/value in Array/Map is assigned a new unique parquet
+/// field id and stored in the `delta.columnMapping.nested.ids` metadata of the nearest ancestor
 /// `StructField`.
 ///
 /// Fields with pre-existing column mapping metadata (id or physicalName) are rejected to avoid
@@ -342,9 +342,8 @@ pub(crate) fn try_assign_field_column_mapping(
         MetadataValue::String(physical_name.clone()),
     );
 
-    // Recursively process nested types.
-    // Note: The walker accumulates nested ids directly into a `serde_json::Map` instead of a
-    // `HashMap`, because MetadataValue::Other requires a `serde_json::Value::Object`.
+    // Recursively process nested types. Accumulate directly into a `serde_json::Map` so we
+    // can wrap it as `MetadataValue::Other(Value::Object(_))` without a post-walk conversion.
     let mut nested_ids: Option<serde_json::Map<String, serde_json::Value>> =
         with_nested_ids.then(serde_json::Map::new);
     new_field.data_type =

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -6,7 +6,7 @@ pub use column_mapping::ColumnMappingMode;
 pub(crate) use column_mapping::{
     assign_column_mapping_metadata, column_mapping_mode, find_max_column_id_in_schema,
     get_column_mapping_mode_from_properties, get_field_column_mapping_info,
-    physical_to_logical_column_name, try_assign_field_column_mapping,
+    physical_to_logical_column_name, try_assign_flat_column_mapping_info,
 };
 use delta_kernel_derive::internal_api;
 use itertools::Itertools;

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -985,7 +985,8 @@ mod tests {
     use crate::schema::{ColumnMetadataKey, DataType, MetadataValue, StructField, StructType};
     use crate::table_features::FeatureType;
     use crate::table_properties::{
-        ENABLE_ICEBERG_COMPAT_V1, ENABLE_ICEBERG_COMPAT_V3, PARQUET_FORMAT_VERSION,
+        COLUMN_MAPPING_MAX_COLUMN_ID, ENABLE_ICEBERG_COMPAT_V1, ENABLE_ICEBERG_COMPAT_V3,
+        PARQUET_FORMAT_VERSION,
     };
     use crate::transforms::SchemaTransform;
     use crate::utils::test_utils::{
@@ -1871,22 +1872,23 @@ mod tests {
             maybe_apply_column_mapping_for_table_create(&schema, &mut validated, pre_cm).unwrap();
         assert_eq!(mode, ColumnMappingMode::Name);
 
-        // top: CM id=1, nested-ids = {<top_physical>.{key:2, key.element:3, value:4}}
-        // DFS order: top-level (1) -> Map.key (2) -> recurse into key
-        // (Array<int>): key.element (3) -> Map.value (4). Matches delta-spark's behavior.
+        // Spark-aligned two-pass numbering:
+        //   Pass 1 (CM ids, DFS over StructFields): top=1, inner=2, region=3.
+        //   Pass 2 (nested ids, per StructField, starting from max=3):
+        //     top:   {key:4, key.element:5, value:6}
+        //     inner: {key:7, value:8, value.element:9}
         let top = effective_schema.field("top").expect("missing top");
         let top_physical = expect_field_id_and_physical_name(top, 1);
         assert_eq!(
             extract_nested_ids(top),
             serde_json::json!({
-                format!("{top_physical}.key"): 2,
-                format!("{top_physical}.key.element"): 3,
-                format!("{top_physical}.value"): 4,
+                format!("{top_physical}.key"): 4,
+                format!("{top_physical}.key.element"): 5,
+                format!("{top_physical}.value"): 6,
             }),
             "top's nested-ids JSON",
         );
 
-        // inner: CM id=5, nested-ids = {<inner_physical>.{key:6, value:7, value.element:8}}
         let DataType::Map(top_map) = top.data_type() else {
             panic!("top must be a map");
         };
@@ -1894,23 +1896,31 @@ mod tests {
             panic!("top's value must be a struct");
         };
         let inner = value_struct.fields().next().expect("missing inner");
-        let inner_physical = expect_field_id_and_physical_name(inner, 5);
+        let inner_physical = expect_field_id_and_physical_name(inner, 2);
         assert_eq!(
             extract_nested_ids(inner),
             serde_json::json!({
-                format!("{inner_physical}.key"): 6,
-                format!("{inner_physical}.value"): 7,
-                format!("{inner_physical}.value.element"): 8,
+                format!("{inner_physical}.key"): 7,
+                format!("{inner_physical}.value"): 8,
+                format!("{inner_physical}.value.element"): 9,
             }),
             "inner's nested-ids JSON",
         );
 
-        // region: CM id=9, primitive (no nested-ids).
         let region = effective_schema.field("region").expect("missing region");
-        let _ = expect_field_id_and_physical_name(region, 9);
+        let _ = expect_field_id_and_physical_name(region, 3);
         assert!(!region
             .metadata
             .contains_key(ColumnMetadataKey::ColumnMappingNestedIds.as_ref()));
+
+        // maxColumnId tracks the largest assigned CM id, including nested ids.
+        assert_eq!(
+            validated
+                .properties
+                .get(COLUMN_MAPPING_MAX_COLUMN_ID)
+                .map(String::as_str),
+            Some("9"),
+        );
 
         // === Property-driven feature enablement + Invariants ===
         maybe_enable_invariants(&effective_schema, &mut validated);

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -982,13 +982,10 @@ mod tests {
     use super::*;
     use crate::expressions::ColumnName;
     use crate::scan::data_skipping::stats_schema::StripFieldMetadataTransform;
-    use crate::schema::{
-        ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, StructField, StructType,
-    };
+    use crate::schema::{ColumnMetadataKey, DataType, MetadataValue, StructField, StructType};
     use crate::table_features::FeatureType;
     use crate::table_properties::{
-        COLUMN_MAPPING_MAX_COLUMN_ID, ENABLE_ICEBERG_COMPAT_V1, ENABLE_ICEBERG_COMPAT_V3,
-        PARQUET_FORMAT_VERSION,
+        ENABLE_ICEBERG_COMPAT_V1, ENABLE_ICEBERG_COMPAT_V3, PARQUET_FORMAT_VERSION,
     };
     use crate::transforms::SchemaTransform;
     use crate::utils::test_utils::{

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -33,9 +33,11 @@ use crate::table_features::{
 use crate::table_properties::{
     TableProperties, APPEND_ONLY, CHECKPOINT_WRITE_STATS_AS_JSON, CHECKPOINT_WRITE_STATS_AS_STRUCT,
     COLUMN_MAPPING_MAX_COLUMN_ID, COLUMN_MAPPING_MODE, DELTA_PROPERTY_PREFIX,
-    ENABLE_CHANGE_DATA_FEED, ENABLE_DELETION_VECTORS, ENABLE_IN_COMMIT_TIMESTAMPS,
+    ENABLE_CHANGE_DATA_FEED, ENABLE_DELETION_VECTORS, ENABLE_ICEBERG_COMPAT_V1,
+    ENABLE_ICEBERG_COMPAT_V2, ENABLE_ICEBERG_COMPAT_V3, ENABLE_IN_COMMIT_TIMESTAMPS,
     ENABLE_ROW_TRACKING, ENABLE_TYPE_WIDENING, MATERIALIZED_ROW_COMMIT_VERSION_COLUMN_NAME,
-    MATERIALIZED_ROW_ID_COLUMN_NAME, PARQUET_FORMAT_VERSION, SET_TRANSACTION_RETENTION_DURATION,
+    MATERIALIZED_ROW_ID_COLUMN_NAME, PARQUET_FORMAT_VERSION, ROW_TRACKING_SUSPENDED,
+    SET_TRANSACTION_RETENTION_DURATION,
 };
 use crate::transaction::create_table::CreateTableTransaction;
 use crate::transaction::data_layout::DataLayout;
@@ -80,6 +82,10 @@ const ALLOWED_DELTA_FEATURES: &[TableFeature] = &[
     // create time is the explicit feature signal
     // `delta.feature.materializePartitionColumns=supported`.
     TableFeature::MaterializePartitionColumns,
+    // IcebergCompatV3 is a writer-only feature that gates Iceberg V3 conversion compatibility.
+    // Dependent features (ColumnMapping, RowTracking, DomainMetadata) are auto-added during
+    // create table.
+    TableFeature::IcebergCompatV3,
 ];
 
 /// Delta properties allowed to be set during CREATE TABLE.
@@ -105,6 +111,9 @@ const ALLOWED_DELTA_PROPERTIES: &[&str] = &[
     SET_TRANSACTION_RETENTION_DURATION,
     // Parquet format version: controls the Parquet writer version for data files
     PARQUET_FORMAT_VERSION,
+    // IcebergCompatV3 enablement: triggers auto-enablement of ColumnMapping,
+    // RowTracking, DomainMetadata.
+    ENABLE_ICEBERG_COMPAT_V3,
 ];
 
 /// Ensures that no Delta table exists at the given path.
@@ -502,6 +511,93 @@ fn maybe_enable_ict_for_catalog_managed(
     Ok(())
 }
 
+/// When `delta.enableIcebergCompatV3=true` is set, auto-enables V3's required dependencies in
+/// `validated.properties` (defaulting them when absent, rejecting conflicting values).
+///
+/// Specifically:
+///   * Set `delta.columnMapping.mode` to `name` when absent, reject if it's `none`.
+///   * Set `delta.enableRowTracking` to `true` when absent, reject if it's `false`.
+///   * Reject if `delta.rowTrackingSuspended` is `true`.
+///   * Reject if `delta.enableIcebergCompatV1` or `delta.enableIcebergCompatV2` is `true`.
+///
+/// Must be called BEFORE [`maybe_apply_column_mapping_for_table_create`] so the column-mapping
+/// mode is in place by the time column mapping is applied.
+fn maybe_enable_iceberg_compat_v3_dependencies(
+    validated: &mut ValidatedTableProperties,
+) -> DeltaResult<()> {
+    if validated
+        .properties
+        .get(ENABLE_ICEBERG_COMPAT_V3)
+        .map(String::as_str)
+        != Some("true")
+    {
+        return Ok(());
+    }
+
+    // Column mapping: require `name` or `id`; default to `name`.
+    match validated
+        .properties
+        .get(COLUMN_MAPPING_MODE)
+        .map(String::as_str)
+    {
+        None => {
+            validated
+                .properties
+                .insert(COLUMN_MAPPING_MODE.to_string(), "name".to_string());
+        }
+        Some("name") | Some("id") => {}
+        Some(other) => {
+            return Err(Error::generic(format!(
+                "IcebergCompatV3 requires '{COLUMN_MAPPING_MODE}' to be 'name' or 'id', got \
+                 '{other}'"
+            )));
+        }
+    }
+
+    // Row tracking enablement: require `true`; default to `true`.
+    match validated
+        .properties
+        .get(ENABLE_ROW_TRACKING)
+        .map(String::as_str)
+    {
+        None => {
+            validated
+                .properties
+                .insert(ENABLE_ROW_TRACKING.to_string(), "true".to_string());
+        }
+        Some("true") => {}
+        Some(other) => {
+            return Err(Error::generic(format!(
+                "IcebergCompatV3 requires '{ENABLE_ROW_TRACKING}' to be 'true', got '{other}'"
+            )));
+        }
+    }
+
+    // Row tracking must not be suspended (suspension cannot coexist with row tracking
+    // actively enabled, which V3 requires).
+    if validated
+        .properties
+        .get(ROW_TRACKING_SUSPENDED)
+        .map(String::as_str)
+        == Some("true")
+    {
+        return Err(Error::generic(format!(
+            "IcebergCompatV3 cannot be enabled while '{ROW_TRACKING_SUSPENDED}' is 'true'"
+        )));
+    }
+
+    // V1/V2 must not be active.
+    for key in [ENABLE_ICEBERG_COMPAT_V1, ENABLE_ICEBERG_COMPAT_V2] {
+        if validated.properties.get(key).map(String::as_str) == Some("true") {
+            return Err(Error::generic(format!(
+                "IcebergCompatV3 cannot be enabled together with '{key}'"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
 /// Conditionally applies column mapping for table creation based on the mode in properties.
 ///
 /// If `delta.columnMapping.mode` is set to `name` or `id`, this function:
@@ -535,9 +631,17 @@ fn maybe_apply_column_mapping_for_table_create(
                 &mut validated.writer_features,
             );
 
-            // Transform schema: assign IDs and physical names to all fields
+            // Transform schema: assign IDs and physical names to all fields. When
+            // IcebergCompatV3 is enabled, allocated nested ids for element/key/value in Array/Map
+            // as well.
+            let with_nested_ids = validated
+                .properties
+                .get(ENABLE_ICEBERG_COMPAT_V3)
+                .map(String::as_str)
+                == Some("true");
             let mut max_id = 0i64;
-            let transformed_schema = assign_column_mapping_metadata(schema, &mut max_id)?;
+            let transformed_schema =
+                assign_column_mapping_metadata(schema, &mut max_id, with_nested_ids)?;
 
             // Add maxColumnId to properties
             validated
@@ -799,6 +903,10 @@ impl CreateTableTransactionBuilder {
         // - Returns reader/writer features to add to protocol
         let mut validated = validate_extract_table_features_and_properties(self.table_properties)?;
 
+        // When IcebergCompatV3 is enabled, fill in / validate required dependencies before
+        // column mapping is applied so the CM mode is in place.
+        maybe_enable_iceberg_compat_v3_dependencies(&mut validated)?;
+
         // Apply column mapping if mode is name or id (must happen BEFORE data layout)
         let (effective_schema, column_mapping_mode) =
             maybe_apply_column_mapping_for_table_create(&self.schema, &mut validated)?;
@@ -868,14 +976,20 @@ impl CreateTableTransactionBuilder {
 mod tests {
     use std::sync::Arc;
 
+    use rstest::rstest;
+
     use super::*;
     use crate::expressions::ColumnName;
-    use crate::schema::{DataType, StructField, StructType};
+    use crate::scan::data_skipping::stats_schema::StripFieldMetadataTransform;
+    use crate::schema::{ColumnMetadataKey, DataType, MetadataValue, StructField, StructType};
     use crate::table_features::FeatureType;
     use crate::table_properties::{
         ENABLE_ICEBERG_COMPAT_V1, ENABLE_ICEBERG_COMPAT_V3, PARQUET_FORMAT_VERSION,
     };
-    use crate::utils::test_utils::assert_result_error_with_message;
+    use crate::transforms::SchemaTransform;
+    use crate::utils::test_utils::{
+        assert_result_error_with_message, build_complex_nested_kernel_schema,
+    };
 
     fn test_schema() -> SchemaRef {
         Arc::new(StructType::new_unchecked(vec![StructField::new(
@@ -989,13 +1103,6 @@ mod tests {
         assert_result_error_with_message(
             validate_extract_table_features_and_properties(properties),
             "Setting delta property 'delta.enableIcebergCompatV1' is not supported",
-        );
-
-        let mut properties = HashMap::new();
-        properties.insert(ENABLE_ICEBERG_COMPAT_V3.to_string(), "true".to_string());
-        assert_result_error_with_message(
-            validate_extract_table_features_and_properties(properties),
-            "Setting delta property 'delta.enableIcebergCompatV3' is not supported",
         );
 
         // Feature signals for features not in ALLOWED_DELTA_FEATURES are rejected
@@ -1662,5 +1769,273 @@ mod tests {
             err.to_string().contains("enableInCommitTimestamps"),
             "expected ICT conflict error, got: {err}"
         );
+    }
+
+    /// Builds the V3 create-table test schema:
+    ///
+    /// ```json
+    /// {
+    ///   "type": "struct",
+    ///   "fields": [
+    ///     {
+    ///       "name": "top",
+    ///       "type": {
+    ///         "type": "map",
+    ///         "keyType":   {"type": "array", "elementType": "integer"},
+    ///         "valueType": {"type": "struct", "fields": [{
+    ///           "name": "inner",
+    ///           "type": {"type": "map", "keyType": "integer",
+    ///                    "valueType": {"type": "array", "elementType": "integer"}}
+    ///         }]}
+    ///       }
+    ///     },
+    ///     {"name": "region", "type": "string"}
+    ///   ]
+    /// }
+    /// ```
+    fn build_v3_test_schema() -> SchemaRef {
+        let with_metadata =
+            build_complex_nested_kernel_schema(ColumnMetadataKey::ColumnMappingNestedIds.as_ref());
+        let complex = StripFieldMetadataTransform
+            .transform_struct(&with_metadata)
+            .into_owned();
+        let mut fields: Vec<StructField> = complex.fields().cloned().collect();
+        fields.push(StructField::nullable("region", DataType::STRING));
+        Arc::new(StructType::try_new(fields).unwrap())
+    }
+
+    /// V3 create-table flow with the same schema for minumum feature set and maximum feature set.
+    /// Validates final features and physical name/parquet field id assignments.
+    #[rstest]
+    #[case::v3_only(
+        /* extra_props */ &[],
+        /* expected_features */ &[
+            TableFeature::IcebergCompatV3,
+            TableFeature::ColumnMapping,
+            TableFeature::RowTracking,
+            TableFeature::DomainMetadata,
+        ],
+    )]
+    #[case::v3_with_cross_features(
+        /* extra_props */ &[
+            (ENABLE_DELETION_VECTORS, "true"),
+            (ENABLE_IN_COMMIT_TIMESTAMPS, "true"),
+            (ENABLE_TYPE_WIDENING, "true"),
+            (APPEND_ONLY, "true"),
+            (ENABLE_CHANGE_DATA_FEED, "true"),
+        ],
+        /* expected_features */ &[
+            TableFeature::IcebergCompatV3,
+            TableFeature::ColumnMapping,
+            TableFeature::RowTracking,
+            TableFeature::DomainMetadata,
+            TableFeature::DeletionVectors,
+            TableFeature::InCommitTimestamp,
+            TableFeature::TypeWidening,
+            TableFeature::AppendOnly,
+            TableFeature::ChangeDataFeed,
+        ],
+    )]
+    fn test_create_table_v3(
+        #[case] extra_props: &[(&str, &str)],
+        #[case] expected_features: &[TableFeature],
+    ) {
+        let schema = build_v3_test_schema();
+        let mut props: HashMap<String, String> =
+            HashMap::from([(ENABLE_ICEBERG_COMPAT_V3.to_string(), "true".to_string())]);
+        for (k, v) in extra_props {
+            props.insert(k.to_string(), v.to_string());
+        }
+        let mut validated = validate_extract_table_features_and_properties(props).unwrap();
+
+        // === V3 dependency defaults ===
+        maybe_enable_iceberg_compat_v3_dependencies(&mut validated).unwrap();
+        assert_eq!(
+            validated
+                .properties
+                .get(COLUMN_MAPPING_MODE)
+                .map(String::as_str),
+            Some("name"),
+        );
+        assert_eq!(
+            validated
+                .properties
+                .get(ENABLE_ROW_TRACKING)
+                .map(String::as_str),
+            Some("true"),
+        );
+
+        // === Column mapping + nested-id assignment ===
+        let (effective_schema, mode) =
+            maybe_apply_column_mapping_for_table_create(&schema, &mut validated).unwrap();
+        assert_eq!(mode, ColumnMappingMode::Name);
+
+        // top: CM id=1, nested-ids = {<top_physical>.{key:2, value:3, key.element:4}}
+        let top = effective_schema.field("top").expect("missing top");
+        let top_physical = expect_field_id_and_physical_name(top, 1);
+        assert_eq!(
+            extract_nested_ids(top),
+            serde_json::json!({
+                format!("{top_physical}.key"): 2,
+                format!("{top_physical}.value"): 3,
+                format!("{top_physical}.key.element"): 4,
+            }),
+            "top's nested-ids JSON",
+        );
+
+        // inner: CM id=5, nested-ids = {<inner_physical>.{key:6, value:7, value.element:8}}
+        let DataType::Map(top_map) = top.data_type() else {
+            panic!("top must be a map");
+        };
+        let DataType::Struct(value_struct) = top_map.value_type() else {
+            panic!("top's value must be a struct");
+        };
+        let inner = value_struct.fields().next().expect("missing inner");
+        let inner_physical = expect_field_id_and_physical_name(inner, 5);
+        assert_eq!(
+            extract_nested_ids(inner),
+            serde_json::json!({
+                format!("{inner_physical}.key"): 6,
+                format!("{inner_physical}.value"): 7,
+                format!("{inner_physical}.value.element"): 8,
+            }),
+            "inner's nested-ids JSON",
+        );
+
+        // region: CM id=9, primitive (no nested-ids).
+        let region = effective_schema.field("region").expect("missing region");
+        let _ = expect_field_id_and_physical_name(region, 9);
+        assert!(!region
+            .metadata
+            .contains_key(ColumnMetadataKey::ColumnMappingNestedIds.as_ref()));
+
+        // === Property-driven feature enablement + Invariants ===
+        maybe_enable_invariants(&effective_schema, &mut validated);
+        maybe_auto_enable_property_driven_features(&mut validated);
+
+        for f in expected_features {
+            assert!(
+                validated.writer_features.contains(f) || validated.reader_features.contains(f),
+                "expected {f:?} in protocol features (writer={:?}, reader={:?})",
+                validated.writer_features,
+                validated.reader_features,
+            );
+        }
+        // V3 implies partition materialization without adding the MaterializePartitionColumns flag.
+        assert!(
+            !validated
+                .writer_features
+                .contains(&TableFeature::MaterializePartitionColumns),
+            "MaterializePartitionColumns flag should not be auto-added by V3",
+        );
+    }
+
+    /// Property combinations that violate V3's dependency requirements must be rejected by
+    /// `maybe_enable_iceberg_compat_v3_dependencies`. Some of these properties (e.g.
+    /// `delta.rowTrackingSuspended`, `delta.enableIcebergCompatV1`) aren't in the CREATE-TABLE
+    /// allow-list, so we construct `ValidatedTableProperties` directly to get around the
+    /// allow-list.
+    #[rstest]
+    #[case::cm_mode_none(
+        &[(COLUMN_MAPPING_MODE, "none")],
+        "delta.columnMapping.mode",
+    )]
+    #[case::row_tracking_false(
+        &[(ENABLE_ROW_TRACKING, "false")],
+        "delta.enableRowTracking",
+    )]
+    #[case::row_tracking_suspended(
+        &[("delta.rowTrackingSuspended", "true")],
+        "delta.rowTrackingSuspended",
+    )]
+    #[case::v1_concurrent(
+        &[(ENABLE_ICEBERG_COMPAT_V1, "true")],
+        "delta.enableIcebergCompatV1",
+    )]
+    #[case::v2_concurrent(
+        &[("delta.enableIcebergCompatV2", "true")],
+        "delta.enableIcebergCompatV2",
+    )]
+    fn test_v3_dependencies_rejects_invalid_combinations(
+        #[case] extra_props: &[(&str, &str)],
+        #[case] expected_substring: &str,
+    ) {
+        let mut properties: HashMap<String, String> =
+            HashMap::from([(ENABLE_ICEBERG_COMPAT_V3.to_string(), "true".to_string())]);
+        for (k, v) in extra_props {
+            properties.insert(k.to_string(), v.to_string());
+        }
+        let mut validated = ValidatedTableProperties {
+            properties,
+            reader_features: Vec::new(),
+            writer_features: Vec::new(),
+        };
+        let err = maybe_enable_iceberg_compat_v3_dependencies(&mut validated).unwrap_err();
+        assert!(
+            err.to_string().contains(expected_substring),
+            "expected error mentioning '{expected_substring}', got: {err}",
+        );
+    }
+
+    /// `assign_column_mapping_metadata` rejects schemas where any field has pre-populated CM
+    /// or nested-ids metadata.
+    #[test]
+    fn test_create_table_v3_rejects_pre_existing_nested_ids() {
+        // The fixture's kernel schema already carries `delta.columnMapping.nested.ids` on the
+        // `top` and `inner` StructFields, so feeding it through the V3 create path must
+        // surface the pre-population error.
+        let schema = Arc::new(build_complex_nested_kernel_schema(
+            ColumnMetadataKey::ColumnMappingNestedIds.as_ref(),
+        ));
+        let mut validated = validate_extract_table_features_and_properties(HashMap::from([(
+            ENABLE_ICEBERG_COMPAT_V3.to_string(),
+            "true".to_string(),
+        )]))
+        .unwrap();
+        maybe_enable_iceberg_compat_v3_dependencies(&mut validated).unwrap();
+        let err = maybe_apply_column_mapping_for_table_create(&schema, &mut validated).unwrap_err();
+        assert!(
+            err.to_string().contains("has pre-populated"),
+            "expected pre-populated metadata error, got: {err}",
+        );
+    }
+
+    /// Asserts the field has CM id == `expected_id` and a `col-` prefixed physical name; returns
+    /// the physical name for further use.
+    fn expect_field_id_and_physical_name(field: &StructField, expected_id: i64) -> String {
+        assert_eq!(
+            field
+                .metadata
+                .get(ColumnMetadataKey::ColumnMappingId.as_ref()),
+            Some(&MetadataValue::Number(expected_id)),
+            "field '{}' CM id mismatch",
+            field.name(),
+        );
+        let MetadataValue::String(physical_name) = field
+            .metadata
+            .get(ColumnMetadataKey::ColumnMappingPhysicalName.as_ref())
+            .unwrap_or_else(|| panic!("field '{}' missing physicalName", field.name()))
+        else {
+            panic!("field '{}' physicalName must be a String", field.name());
+        };
+        assert!(
+            physical_name.starts_with("col-"),
+            "field '{}' physicalName '{physical_name}' must start with 'col-'",
+            field.name(),
+        );
+        physical_name.clone()
+    }
+
+    /// Extracts the `delta.columnMapping.nested.ids` JSON object from a field, panicking if
+    /// it's missing or wrongly typed.
+    fn extract_nested_ids(field: &StructField) -> serde_json::Value {
+        let MetadataValue::Other(value) = field
+            .metadata
+            .get(ColumnMetadataKey::ColumnMappingNestedIds.as_ref())
+            .unwrap_or_else(|| panic!("field '{}' missing nested-ids", field.name()))
+        else {
+            panic!("field '{}' nested-ids must be a JSON object", field.name());
+        };
+        value.clone()
     }
 }

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -2008,12 +2008,20 @@ mod tests {
     #[test]
     fn test_create_table_v3_supported_but_not_enabled_skips_nested_ids() {
         let schema = build_iceberg_compat_v3_test_schema();
-        // Explicit CM mode "name", but V3 is NOT enabled (no delta.enableIcebergCompatV3=true).
-        let mut validated = validate_extract_table_features_and_properties(HashMap::from([(
-            COLUMN_MAPPING_MODE.to_string(),
-            "name".to_string(),
-        )]))
+        let mut validated = validate_extract_table_features_and_properties(HashMap::from([
+            (
+                "delta.feature.icebergCompatV3".to_string(),
+                "supported".to_string(),
+            ),
+            (COLUMN_MAPPING_MODE.to_string(), "name".to_string()),
+        ]))
         .unwrap();
+        assert!(
+            validated
+                .writer_features
+                .contains(&TableFeature::IcebergCompatV3),
+            "V3 must be in writerFeatures (supported) for this test to be meaningful",
+        );
         let pre_cm = maybe_enable_iceberg_compat_v3_dependencies(&mut validated).unwrap();
         let (effective_schema, mode) =
             maybe_apply_column_mapping_for_table_create(&schema, &mut validated, pre_cm).unwrap();

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -554,6 +554,19 @@ fn maybe_enable_iceberg_compat_v3_dependencies(
         }
     }
 
+    // Row tracking must not be suspended (suspension cannot coexist with row tracking actively
+    // enabled, which V3 requires).
+    if validated
+        .properties
+        .get(ROW_TRACKING_SUSPENDED)
+        .map(String::as_str)
+        == Some("true")
+    {
+        return Err(Error::generic(format!(
+            "IcebergCompatV3 cannot be enabled while '{ROW_TRACKING_SUSPENDED}' is 'true'"
+        )));
+    }
+
     // Row tracking enablement: require `true`; default to `true`.
     match validated
         .properties
@@ -571,19 +584,6 @@ fn maybe_enable_iceberg_compat_v3_dependencies(
                 "IcebergCompatV3 requires '{ENABLE_ROW_TRACKING}' to be 'true', got '{other}'"
             )));
         }
-    }
-
-    // Row tracking must not be suspended (suspension cannot coexist with row tracking
-    // actively enabled, which V3 requires).
-    if validated
-        .properties
-        .get(ROW_TRACKING_SUSPENDED)
-        .map(String::as_str)
-        == Some("true")
-    {
-        return Err(Error::generic(format!(
-            "IcebergCompatV3 cannot be enabled while '{ROW_TRACKING_SUSPENDED}' is 'true'"
-        )));
     }
 
     // V1/V2 must not be active.
@@ -1771,7 +1771,7 @@ mod tests {
         );
     }
 
-    /// Builds the V3 create-table test schema:
+    /// Builds the icebergCompatV3 create-table test schema:
     ///
     /// ```json
     /// {
@@ -1793,7 +1793,7 @@ mod tests {
     ///   ]
     /// }
     /// ```
-    fn build_v3_test_schema() -> SchemaRef {
+    fn build_iceberg_compat_v3_test_schema() -> SchemaRef {
         let with_metadata =
             build_complex_nested_kernel_schema(ColumnMetadataKey::ColumnMappingNestedIds.as_ref());
         let complex = StripFieldMetadataTransform
@@ -1804,8 +1804,8 @@ mod tests {
         Arc::new(StructType::try_new(fields).unwrap())
     }
 
-    /// V3 create-table flow with the same schema for minumum feature set and maximum feature set.
-    /// Validates final features and physical name/parquet field id assignments.
+    /// V3 create-table flow with the same schema for minimum and maximum feature sets.
+    /// Validates final features, CM id assignments, and nested-id JSON contents.
     #[rstest]
     #[case::v3_only(
         /* extra_props */ &[],
@@ -1836,11 +1836,11 @@ mod tests {
             TableFeature::ChangeDataFeed,
         ],
     )]
-    fn test_create_table_v3(
+    fn test_create_table_iceberg_compat_v3(
         #[case] extra_props: &[(&str, &str)],
         #[case] expected_features: &[TableFeature],
     ) {
-        let schema = build_v3_test_schema();
+        let schema = build_iceberg_compat_v3_test_schema();
         let mut props: HashMap<String, String> =
             HashMap::from([(ENABLE_ICEBERG_COMPAT_V3.to_string(), "true".to_string())]);
         for (k, v) in extra_props {

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -638,10 +638,10 @@ fn maybe_apply_column_mapping_for_table_create(
             // Transform schema: assign IDs and physical names to all fields. When
             // IcebergCompatV3 is enabled, allocated nested ids for element/key/value in Array/Map
             // as well.
-            let with_nested_ids = validated.is_property_true(ENABLE_ICEBERG_COMPAT_V3);
+            let assign_nested_field_ids = validated.is_property_true(ENABLE_ICEBERG_COMPAT_V3);
             let mut max_id = 0i64;
             let transformed_schema =
-                assign_column_mapping_metadata(schema, &mut max_id, with_nested_ids)?;
+                assign_column_mapping_metadata(schema, &mut max_id, assign_nested_field_ids)?;
 
             // Add maxColumnId to properties
             validated
@@ -982,10 +982,13 @@ mod tests {
     use super::*;
     use crate::expressions::ColumnName;
     use crate::scan::data_skipping::stats_schema::StripFieldMetadataTransform;
-    use crate::schema::{ColumnMetadataKey, DataType, MetadataValue, StructField, StructType};
+    use crate::schema::{
+        ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, StructField, StructType,
+    };
     use crate::table_features::FeatureType;
     use crate::table_properties::{
-        ENABLE_ICEBERG_COMPAT_V1, ENABLE_ICEBERG_COMPAT_V3, PARQUET_FORMAT_VERSION,
+        COLUMN_MAPPING_MAX_COLUMN_ID, ENABLE_ICEBERG_COMPAT_V1, ENABLE_ICEBERG_COMPAT_V3,
+        PARQUET_FORMAT_VERSION,
     };
     use crate::transforms::SchemaTransform;
     use crate::utils::test_utils::{
@@ -1871,15 +1874,17 @@ mod tests {
             maybe_apply_column_mapping_for_table_create(&schema, &mut validated, pre_cm).unwrap();
         assert_eq!(mode, ColumnMappingMode::Name);
 
-        // top: CM id=1, nested-ids = {<top_physical>.{key:2, value:3, key.element:4}}
+        // top: CM id=1, nested-ids = {<top_physical>.{key:2, key.element:3, value:4}}
+        // DFS order: top-level (1) -> Map.key (2) -> recurse into key
+        // (Array<int>): key.element (3) -> Map.value (4). Matches delta-spark's behavior.
         let top = effective_schema.field("top").expect("missing top");
         let top_physical = expect_field_id_and_physical_name(top, 1);
         assert_eq!(
             extract_nested_ids(top),
             serde_json::json!({
                 format!("{top_physical}.key"): 2,
-                format!("{top_physical}.value"): 3,
-                format!("{top_physical}.key.element"): 4,
+                format!("{top_physical}.key.element"): 3,
+                format!("{top_physical}.value"): 4,
             }),
             "top's nested-ids JSON",
         );
@@ -2004,7 +2009,7 @@ mod tests {
 
     /// Listing IcebergCompatV3 in writerFeatures (i.e. "supported") without setting
     /// `delta.enableIcebergCompatV3=true` does NOT activate V3 behavior: column mapping is
-    /// applied per the explicit property, but no nested ids are stamped on Array/Map fields.
+    /// applied per the explicit property, but no nested ids are set on Array/Map fields.
     #[test]
     fn test_create_table_v3_supported_but_not_enabled_skips_nested_ids() {
         let schema = build_iceberg_compat_v3_test_schema();

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -178,6 +178,13 @@ struct ValidatedTableProperties {
     writer_features: Vec<TableFeature>,
 }
 
+impl ValidatedTableProperties {
+    /// Returns `true` iff `properties[key] == "true"`.
+    fn is_property_true(&self, key: &str) -> bool {
+        self.properties.get(key).map(String::as_str) == Some("true")
+    }
+}
+
 /// Adds a feature to the appropriate reader/writer feature lists based on its type.
 ///
 /// - ReaderWriter features are added to both reader and writer lists
@@ -511,6 +518,12 @@ fn maybe_enable_ict_for_catalog_managed(
     Ok(())
 }
 
+/// Witness that all property-flipping passes which must run before column mapping is applied
+/// have completed.
+#[must_use]
+#[derive(Debug)]
+struct PreColumnMappingResolved;
+
 /// When `delta.enableIcebergCompatV3=true` is set, auto-enables V3's required dependencies in
 /// `validated.properties` (defaulting them when absent, rejecting conflicting values).
 ///
@@ -520,18 +533,13 @@ fn maybe_enable_ict_for_catalog_managed(
 ///   * Reject if `delta.rowTrackingSuspended` is `true`.
 ///   * Reject if `delta.enableIcebergCompatV1` or `delta.enableIcebergCompatV2` is `true`.
 ///
-/// Must be called BEFORE [`maybe_apply_column_mapping_for_table_create`] so the column-mapping
-/// mode is in place by the time column mapping is applied.
+/// Returns a [`PreColumnMappingResolved`] witness that
+/// [`maybe_apply_column_mapping_for_table_create`] requires, ensuring this pass runs first.
 fn maybe_enable_iceberg_compat_v3_dependencies(
     validated: &mut ValidatedTableProperties,
-) -> DeltaResult<()> {
-    if validated
-        .properties
-        .get(ENABLE_ICEBERG_COMPAT_V3)
-        .map(String::as_str)
-        != Some("true")
-    {
-        return Ok(());
+) -> DeltaResult<PreColumnMappingResolved> {
+    if !validated.is_property_true(ENABLE_ICEBERG_COMPAT_V3) {
+        return Ok(PreColumnMappingResolved);
     }
 
     // Column mapping: require `name` or `id`; default to `name`.
@@ -556,12 +564,7 @@ fn maybe_enable_iceberg_compat_v3_dependencies(
 
     // Row tracking must not be suspended (suspension cannot coexist with row tracking actively
     // enabled, which V3 requires).
-    if validated
-        .properties
-        .get(ROW_TRACKING_SUSPENDED)
-        .map(String::as_str)
-        == Some("true")
-    {
+    if validated.is_property_true(ROW_TRACKING_SUSPENDED) {
         return Err(Error::generic(format!(
             "IcebergCompatV3 cannot be enabled while '{ROW_TRACKING_SUSPENDED}' is 'true'"
         )));
@@ -588,14 +591,14 @@ fn maybe_enable_iceberg_compat_v3_dependencies(
 
     // V1/V2 must not be active.
     for key in [ENABLE_ICEBERG_COMPAT_V1, ENABLE_ICEBERG_COMPAT_V2] {
-        if validated.properties.get(key).map(String::as_str) == Some("true") {
+        if validated.is_property_true(key) {
             return Err(Error::generic(format!(
                 "IcebergCompatV3 cannot be enabled together with '{key}'"
             )));
         }
     }
 
-    Ok(())
+    Ok(PreColumnMappingResolved)
 }
 
 /// Conditionally applies column mapping for table creation based on the mode in properties.
@@ -619,6 +622,7 @@ fn maybe_enable_iceberg_compat_v3_dependencies(
 fn maybe_apply_column_mapping_for_table_create(
     schema: &SchemaRef,
     validated: &mut ValidatedTableProperties,
+    _pre_cm: PreColumnMappingResolved,
 ) -> DeltaResult<(SchemaRef, ColumnMappingMode)> {
     let column_mapping_mode = get_column_mapping_mode_from_properties(&validated.properties)?;
 
@@ -634,11 +638,7 @@ fn maybe_apply_column_mapping_for_table_create(
             // Transform schema: assign IDs and physical names to all fields. When
             // IcebergCompatV3 is enabled, allocated nested ids for element/key/value in Array/Map
             // as well.
-            let with_nested_ids = validated
-                .properties
-                .get(ENABLE_ICEBERG_COMPAT_V3)
-                .map(String::as_str)
-                == Some("true");
+            let with_nested_ids = validated.is_property_true(ENABLE_ICEBERG_COMPAT_V3);
             let mut max_id = 0i64;
             let transformed_schema =
                 assign_column_mapping_metadata(schema, &mut max_id, with_nested_ids)?;
@@ -904,12 +904,13 @@ impl CreateTableTransactionBuilder {
         let mut validated = validate_extract_table_features_and_properties(self.table_properties)?;
 
         // When IcebergCompatV3 is enabled, fill in / validate required dependencies before
-        // column mapping is applied so the CM mode is in place.
-        maybe_enable_iceberg_compat_v3_dependencies(&mut validated)?;
+        // column mapping is applied so the CM mode is in place. The returned witness is
+        // required by `maybe_apply_column_mapping_for_table_create` below.
+        let pre_cm = maybe_enable_iceberg_compat_v3_dependencies(&mut validated)?;
 
         // Apply column mapping if mode is name or id (must happen BEFORE data layout)
         let (effective_schema, column_mapping_mode) =
-            maybe_apply_column_mapping_for_table_create(&self.schema, &mut validated)?;
+            maybe_apply_column_mapping_for_table_create(&self.schema, &mut validated, pre_cm)?;
 
         // Validate schema (non-empty, column names, duplicates, no `delta.invariants` metadata)
         validate_schema(&effective_schema, column_mapping_mode)?;
@@ -1849,7 +1850,7 @@ mod tests {
         let mut validated = validate_extract_table_features_and_properties(props).unwrap();
 
         // === V3 dependency defaults ===
-        maybe_enable_iceberg_compat_v3_dependencies(&mut validated).unwrap();
+        let pre_cm = maybe_enable_iceberg_compat_v3_dependencies(&mut validated).unwrap();
         assert_eq!(
             validated
                 .properties
@@ -1867,7 +1868,7 @@ mod tests {
 
         // === Column mapping + nested-id assignment ===
         let (effective_schema, mode) =
-            maybe_apply_column_mapping_for_table_create(&schema, &mut validated).unwrap();
+            maybe_apply_column_mapping_for_table_create(&schema, &mut validated, pre_cm).unwrap();
         assert_eq!(mode, ColumnMappingMode::Name);
 
         // top: CM id=1, nested-ids = {<top_physical>.{key:2, value:3, key.element:4}}
@@ -1977,26 +1978,59 @@ mod tests {
         );
     }
 
-    /// `assign_column_mapping_metadata` rejects schemas where any field has pre-populated CM
-    /// or nested-ids metadata.
-    #[test]
-    fn test_create_table_v3_rejects_pre_existing_nested_ids() {
-        // The fixture's kernel schema already carries `delta.columnMapping.nested.ids` on the
+    /// `assign_column_mapping_metadata` rejects schemas where any field has pre-populated
+    /// nested-ids metadata under either the canonical or the legacy key.
+    #[rstest]
+    #[case::canonical_key(ColumnMetadataKey::ColumnMappingNestedIds.as_ref())]
+    #[case::legacy_key(ColumnMetadataKey::ParquetFieldNestedIds.as_ref())]
+    fn test_create_table_v3_rejects_pre_existing_nested_ids(#[case] nested_ids_meta_key: &str) {
+        // The fixture's kernel schema already carries the chosen nested-ids key on the
         // `top` and `inner` StructFields, so feeding it through the V3 create path must
         // surface the pre-population error.
-        let schema = Arc::new(build_complex_nested_kernel_schema(
-            ColumnMetadataKey::ColumnMappingNestedIds.as_ref(),
-        ));
+        let schema = Arc::new(build_complex_nested_kernel_schema(nested_ids_meta_key));
         let mut validated = validate_extract_table_features_and_properties(HashMap::from([(
             ENABLE_ICEBERG_COMPAT_V3.to_string(),
             "true".to_string(),
         )]))
         .unwrap();
-        maybe_enable_iceberg_compat_v3_dependencies(&mut validated).unwrap();
-        let err = maybe_apply_column_mapping_for_table_create(&schema, &mut validated).unwrap_err();
+        let pre_cm = maybe_enable_iceberg_compat_v3_dependencies(&mut validated).unwrap();
+        let err = maybe_apply_column_mapping_for_table_create(&schema, &mut validated, pre_cm)
+            .unwrap_err();
         assert!(
             err.to_string().contains("has pre-populated"),
             "expected pre-populated metadata error, got: {err}",
+        );
+    }
+
+    /// Listing IcebergCompatV3 in writerFeatures (i.e. "supported") without setting
+    /// `delta.enableIcebergCompatV3=true` does NOT activate V3 behavior: column mapping is
+    /// applied per the explicit property, but no nested ids are stamped on Array/Map fields.
+    #[test]
+    fn test_create_table_v3_supported_but_not_enabled_skips_nested_ids() {
+        let schema = build_iceberg_compat_v3_test_schema();
+        // Explicit CM mode "name", but V3 is NOT enabled (no delta.enableIcebergCompatV3=true).
+        let mut validated = validate_extract_table_features_and_properties(HashMap::from([(
+            COLUMN_MAPPING_MODE.to_string(),
+            "name".to_string(),
+        )]))
+        .unwrap();
+        let pre_cm = maybe_enable_iceberg_compat_v3_dependencies(&mut validated).unwrap();
+        let (effective_schema, mode) =
+            maybe_apply_column_mapping_for_table_create(&schema, &mut validated, pre_cm).unwrap();
+        assert_eq!(mode, ColumnMappingMode::Name);
+
+        // Top-level Map field gets CM id + physicalName but no nested-ids metadata under
+        // either the canonical or the legacy key.
+        let top = effective_schema.field("top").expect("missing field top");
+        assert!(
+            !top.metadata()
+                .contains_key(ColumnMetadataKey::ColumnMappingNestedIds.as_ref()),
+            "top should not carry delta.columnMapping.nested.ids when V3 is not enabled",
+        );
+        assert!(
+            !top.metadata()
+                .contains_key(ColumnMetadataKey::ParquetFieldNestedIds.as_ref()),
+            "top should not carry parquet.field.nested.ids when V3 is not enabled",
         );
     }
 

--- a/kernel/src/transaction/schema_evolution.rs
+++ b/kernel/src/transaction/schema_evolution.rs
@@ -161,7 +161,10 @@ pub(crate) fn apply_schema_operations(
                              is not set in table properties",
                         )
                     })?;
-                    try_assign_field_column_mapping(&field, id)?
+                    // We don't support icebergCompatV3 on alter table yet, with_nested_ids is
+                    // always false here Tracking issue:
+                    // <https://github.com/delta-io/delta-kernel-rs/issues/2492>
+                    try_assign_field_column_mapping(&field, id, /* with_nested_ids */ false)?
                 } else {
                     // No upfront reject for stray CM metadata: the recursive walk in
                     // `StructType::make_physical` (called from

--- a/kernel/src/transaction/schema_evolution.rs
+++ b/kernel/src/transaction/schema_evolution.rs
@@ -161,10 +161,12 @@ pub(crate) fn apply_schema_operations(
                              is not set in table properties",
                         )
                     })?;
-                    // ALTER TABLE doesn't support icebergCompatV3 yet, so `with_nested_ids` is
-                    // always false. Tracking issue:
+                    // ALTER TABLE doesn't support icebergCompatV3 yet, so
+                    // `assign_nested_field_ids` is always false. Tracking issue:
                     // <https://github.com/delta-io/delta-kernel-rs/issues/2492>
-                    try_assign_field_column_mapping(&field, id, /* with_nested_ids */ false)?
+                    try_assign_field_column_mapping(
+                        &field, id, /* assign_nested_field_ids */ false,
+                    )?
                 } else {
                     // No upfront reject for stray CM metadata: the recursive walk in
                     // `StructType::make_physical` (called from

--- a/kernel/src/transaction/schema_evolution.rs
+++ b/kernel/src/transaction/schema_evolution.rs
@@ -12,7 +12,7 @@ use crate::expressions::ColumnName;
 use crate::schema::validation::validate_schema;
 use crate::schema::{DataType, SchemaRef, StructField, StructType};
 use crate::table_features::{
-    find_max_column_id_in_schema, try_assign_field_column_mapping, ColumnMappingMode,
+    find_max_column_id_in_schema, try_assign_flat_column_mapping_info, ColumnMappingMode,
 };
 use crate::DeltaResult;
 
@@ -161,12 +161,10 @@ pub(crate) fn apply_schema_operations(
                              is not set in table properties",
                         )
                     })?;
-                    // ALTER TABLE doesn't support icebergCompatV3 yet, so
-                    // `assign_nested_field_ids` is always false. Tracking issue:
+                    // ALTER TABLE doesn't support icebergCompatV3 yet, so the new field never
+                    // gets `delta.columnMapping.nested.ids` here. Tracking issue:
                     // <https://github.com/delta-io/delta-kernel-rs/issues/2492>
-                    try_assign_field_column_mapping(
-                        &field, id, /* assign_nested_field_ids */ false,
-                    )?
+                    try_assign_flat_column_mapping_info(&field, id)?
                 } else {
                     // No upfront reject for stray CM metadata: the recursive walk in
                     // `StructType::make_physical` (called from

--- a/kernel/src/transaction/schema_evolution.rs
+++ b/kernel/src/transaction/schema_evolution.rs
@@ -161,8 +161,8 @@ pub(crate) fn apply_schema_operations(
                              is not set in table properties",
                         )
                     })?;
-                    // We don't support icebergCompatV3 on alter table yet, with_nested_ids is
-                    // always false here Tracking issue:
+                    // ALTER TABLE doesn't support icebergCompatV3 yet, so `with_nested_ids` is
+                    // always false. Tracking issue:
                     // <https://github.com/delta-io/delta-kernel-rs/issues/2492>
                     try_assign_field_column_mapping(&field, id, /* with_nested_ids */ false)?
                 } else {

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -749,7 +749,7 @@ pub(crate) mod test_utils {
     }
 
     /// Build the kernel schema described by [`complex_nested_with_field_ids`].
-    fn build_complex_nested_kernel_schema(nested_ids_meta_key: &str) -> StructType {
+    pub(crate) fn build_complex_nested_kernel_schema(nested_ids_meta_key: &str) -> StructType {
         let top_nested_ids = test_utils::nested_ids_json(&[
             ("top.key", 100),
             ("top.key.element", 101),

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -7,10 +7,7 @@ use delta_kernel::arrow::array::{Array, Int32Array, StringArray};
 use delta_kernel::arrow::record_batch::RecordBatch;
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
-use delta_kernel::engine::default::executor::tokio::TokioBackgroundExecutor;
-use delta_kernel::engine::default::DefaultEngineBuilder;
 use delta_kernel::expressions::{column_name, ColumnName, Scalar};
-use delta_kernel::object_store::memory::InMemory;
 use delta_kernel::schema::{
     ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, SchemaRef, StructField,
     StructType,
@@ -21,8 +18,7 @@ use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::DeltaResult;
 use rstest::rstest;
 use test_utils::{
-    add_commit, create_table_and_load_snapshot, test_table_setup, test_table_setup_mt,
-    write_batch_to_table,
+    create_table_and_load_snapshot, test_table_setup, test_table_setup_mt, write_batch_to_table,
 };
 
 fn simple_schema() -> SchemaRef {
@@ -740,79 +736,15 @@ async fn add_column_with_stray_cm_metadata_on_non_cm_table_fails(
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn alter_blocked_when_iceberg_compat_v3_enabled() -> Result<(), Box<dyn std::error::Error>> {
-    let storage = Arc::new(InMemory::new());
-    let table_root = "memory:///";
-    let engine =
-        Arc::new(DefaultEngineBuilder::<TokioBackgroundExecutor>::new(storage.clone()).build());
-
-    // Create table doesn't support IcebergCompatV3 yet, so this test hand-crafts a V0 commit.
-    // The commit enables V3, column mapping, and row tracking. The schema contains one `id`
-    // column with the column-mapping metadata required when CM mode is set.
-    let schema = StructType::try_new(vec![StructField::nullable("id", DataType::INTEGER)
-        .with_metadata([
-            (
-                ColumnMetadataKey::ColumnMappingId.as_ref(),
-                MetadataValue::from(1),
-            ),
-            (
-                ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
-                MetadataValue::from("col-1"),
-            ),
-        ])])?;
-    let schema_string = serde_json::to_string(&schema)?;
-    let commit = [
-        serde_json::json!({
-            "commitInfo": {
-                "timestamp": 1587968586154_i64,
-                "operation": "CREATE TABLE",
-                "operationParameters": {},
-                "isBlindAppend": true,
-            }
-        }),
-        serde_json::json!({
-            "protocol": {
-                "minReaderVersion": 3,
-                "minWriterVersion": 7,
-                "readerFeatures": ["columnMapping"],
-                "writerFeatures": [
-                    "icebergCompatV3",
-                    "columnMapping",
-                    "rowTracking",
-                    "domainMetadata",
-                ],
-            }
-        }),
-        serde_json::json!({
-            "metaData": {
-                "id": "deadbeef-1234-5678-abcd-000000000000",
-                "format": {
-                    "provider": "parquet",
-                    "options": {},
-                },
-                "schemaString": schema_string,
-                "partitionColumns": [],
-                "configuration": {
-                    "delta.enableIcebergCompatV3": "true",
-                    "delta.columnMapping.mode": "name",
-                    "delta.enableRowTracking": "true",
-                    "delta.rowTracking.materializedRowIdColumnName": "_row_id",
-                    "delta.rowTracking.materializedRowCommitVersionColumnName":
-                        "_row_commit_version",
-                    "delta.columnMapping.maxColumnId": "1",
-                },
-                "createdTime": 1234567890000_i64,
-            }
-        }),
-    ]
-    .into_iter()
-    .map(|action| serde_json::to_string(&action))
-    .collect::<Result<Vec<_>, _>>()?
-    .join("\n");
-    add_commit(table_root, storage.as_ref(), 0, commit.to_string()).await?;
-
-    let snapshot = Snapshot::builder_for(table_root).build(engine.as_ref())?;
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+    let snapshot = create_table_and_load_snapshot(
+        &table_path,
+        simple_schema(),
+        engine.as_ref(),
+        &[("delta.enableIcebergCompatV3", "true")],
+    )?;
 
     let msg = snapshot
         .alter_table()


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2517/files) to review incremental changes.
- [stack/add-v3-feature](https://github.com/delta-io/delta-kernel-rs/pull/2475) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2475/files)] [MERGED]
  - [stack/write-part-when-ice3](https://github.com/delta-io/delta-kernel-rs/pull/2504) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2504/files)] [MERGED]
    - [stack/block-alter-table](https://github.com/delta-io/delta-kernel-rs/pull/2505) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2505/files)] [MERGED]
      - [stack/write-nested-id](https://github.com/delta-io/delta-kernel-rs/pull/2508) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2508/files)] [MERGED]
        - [stack/detect-no-num](https://github.com/delta-io/delta-kernel-rs/pull/2512) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2512/files)] [MERGED]
          - [**stack/create-ice-v3-table**](https://github.com/delta-io/delta-kernel-rs/pull/2517) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2517/files)]
            - [stack/support-ice-v3](https://github.com/delta-io/delta-kernel-rs/pull/2518) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2518/files/8260ca4b164ddb366b0eaeb22fcbd0f0ecd1b400..fe87d6607c2c6ea9c2d4dfb301cabd9e23d44316)]

---------
## What changes are proposed in this pull request?
Support icebergCompatV3 for create table. This will auto-enable the prerequisite features and allocate nested parquet ids.

Recommended review start: 
1. `maybe_enable_iceberg_compat_v3_dependencies`: Auto-enable prerequisite features for `icebergCompatV3`.
2. `assign_column_mapping_metadata`: This will allocate the nested parquet id metadata.

## How was this change tested?
Unit test:
1. Maximum + minumum feature set
2. Error test: Covers error cases for `icebergCompatV3` enablement and nested id metadata assignment
3. Test icebergCompatV3 is supported but not enabled

Currently `icebergCompatV3` is an unsupported feature so we are not able to add integration test, integration test is covered in https://github.com/delta-io/delta-kernel-rs/pull/2518, `v3_create_table_rejects_incompatible_props` for negative tests and `v3_e2e_partitioned_writes_with_field_ids` for positivie tests