### PR TITLE
feat: Support `icebergCompatV3` 

### DIFF
--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -2287,7 +2287,7 @@ mod test {
     }
 
     #[test]
-    fn test_iceberg_compat_v3_write_rejected_as_not_supported() {
+    fn test_iceberg_compat_v3_write_supported() {
         let config = create_mock_table_config_with_cm(
             &[
                 (ENABLE_ICEBERG_COMPAT_V3, "true"),
@@ -2302,10 +2302,9 @@ mod test {
                 TableFeature::DomainMetadata,
             ],
         );
-        assert_result_error_with_message(
-            config.ensure_operation_supported(Operation::Write),
-            "Feature 'icebergCompatV3' is not supported",
-        );
+        config
+            .ensure_operation_supported(Operation::Write)
+            .expect("V3 write should be supported once kernel_support flips to Supported");
     }
 
     #[rstest]

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -420,15 +420,14 @@ static ICEBERG_COMPAT_V2_INFO: FeatureInfo = FeatureInfo {
 /// TODO: Support ALTER TABLE on tables with IcebergCompatV3 enabled.
 ///
 /// Attention in the future:
-/// - Geo types: when supported, they must not be usable as partition columns on
-///   IcebergCompatV3 tables.
+/// - Geo types: when supported, they must not be usable as partition columns on IcebergCompatV3
+///   tables.
 /// - Column defaults: when supported, only literal expressions are allowed.
-/// - REPLACE TABLE: when supported, partition columns must not change across
-///   the replace.
-/// - Timestamp parquet encoding: when kernel can write INT96 or INT64,
-///   IcebergCompatV3 tables must always use INT64; INT96 is forbidden.
-/// - ALTER TABLE SET/UNSET TBLPROPERTIES: when supported, reject any property
-///   change that would disable IcebergCompatV3 on an existing table.
+/// - REPLACE TABLE: when supported, partition columns must not change across the replace.
+/// - Timestamp parquet encoding: when kernel can write INT96 or INT64, IcebergCompatV3 tables must
+///   always use INT64; INT96 is forbidden.
+/// - ALTER TABLE SET/UNSET TBLPROPERTIES: when supported, reject any property change that would
+///   disable IcebergCompatV3 on an existing table.
 /// - Void type: when supported, it must not appear inside map or array types.
 ///
 /// Tracking issue: <https://github.com/delta-io/delta-kernel-rs/issues/2492>

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -346,6 +346,9 @@ static IN_COMMIT_TIMESTAMP_INFO: FeatureInfo = FeatureInfo {
     }),
 };
 
+/// TODO: When kernel writes the materialized `row_id` / `row_commit_version`
+/// columns, they must use the reserved parquet field IDs defined by the
+/// protocol on IcebergCompatV3 tables, not auto-assigned IDs.
 static ROW_TRACKING_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::WriterOnly,
     min_legacy_version: None,
@@ -415,6 +418,18 @@ static ICEBERG_COMPAT_V2_INFO: FeatureInfo = FeatureInfo {
 ///
 /// TODO: Implement the write-side requirements for IcebergCompatV3.
 /// TODO: Support ALTER TABLE on tables with IcebergCompatV3 enabled.
+///
+/// Attention in the future:
+/// - Geo types: when supported, they must not be usable as partition columns on
+///   IcebergCompatV3 tables.
+/// - Column defaults: when supported, only literal expressions are allowed.
+/// - REPLACE TABLE: when supported, partition columns must not change across
+///   the replace.
+/// - Timestamp parquet encoding: when kernel can write INT96 or INT64,
+///   IcebergCompatV3 tables must always use INT64; INT96 is forbidden.
+/// - ALTER TABLE SET/UNSET TBLPROPERTIES: when supported, reject any property
+///   change that would disable IcebergCompatV3 on an existing table.
+/// - Void type: when supported, it must not appear inside map or array types.
 ///
 /// Tracking issue: <https://github.com/delta-io/delta-kernel-rs/issues/2492>
 static ICEBERG_COMPAT_V3_INFO: FeatureInfo = FeatureInfo {
@@ -510,6 +525,9 @@ static TIMESTAMP_WITHOUT_TIMEZONE_INFO: FeatureInfo = FeatureInfo {
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 
+/// TODO: When type widening is supported on writes, restrict the allowed
+/// widenings on IcebergCompatV3 tables to the subset permitted by the Iceberg v3
+/// schema-evolution rules. Ref: <https://iceberg.apache.org/spec/#schema-evolution>
 static TYPE_WIDENING_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::ReaderWriter,
     min_legacy_version: None,
@@ -523,6 +541,9 @@ static TYPE_WIDENING_INFO: FeatureInfo = FeatureInfo {
     enablement_check: EnablementCheck::EnabledIf(|props| props.enable_type_widening == Some(true)),
 };
 
+/// TODO: When type widening is supported on writes, restrict the allowed
+/// widenings on IcebergCompatV3 tables to the subset permitted by the Iceberg
+/// schema-evolution rules. Ref: <https://iceberg.apache.org/spec/#schema-evolution>
 static TYPE_WIDENING_PREVIEW_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::ReaderWriter,
     min_legacy_version: None,

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -431,7 +431,7 @@ static ICEBERG_COMPAT_V3_INFO: FeatureInfo = FeatureInfo {
         FeatureRequirement::NotEnabled(TableFeature::IcebergCompatV1),
         FeatureRequirement::NotEnabled(TableFeature::IcebergCompatV2),
     ],
-    kernel_support: KernelSupport::NotSupported,
+    kernel_support: KernelSupport::Supported,
     enablement_check: EnablementCheck::EnabledIf(|props| {
         props.enable_iceberg_compat_v3 == Some(true)
     }),

--- a/kernel/tests/integration/common/write_utils.rs
+++ b/kernel/tests/integration/common/write_utils.rs
@@ -399,7 +399,7 @@ pub async fn create_dv_table_with_files(
     let add_files_schema = txn.add_files_schema();
 
     // Build metadata for all files at once
-    let files: Vec<(&str, i64, i64, i64)> = file_paths
+    let files: Vec<(&str, i64, i64, Option<i64>)> = file_paths
         .iter()
         .enumerate()
         .map(|(i, &path)| {
@@ -407,7 +407,7 @@ pub async fn create_dv_table_with_files(
                 path,
                 1024 + i as i64 * 100, // size
                 1000000 + i as i64,    // mod_time
-                3,                     // num_records
+                Some(3),               // num_records
             )
         })
         .collect();

--- a/kernel/tests/integration/common/write_utils.rs
+++ b/kernel/tests/integration/common/write_utils.rs
@@ -72,7 +72,7 @@ pub fn load_existing_single_file_checkpoint_path(
 }
 
 /// Open a parquet file and return its root schema.
-fn read_parquet_root_schema(parquet_file: &std::path::Path) -> ParquetType {
+pub fn read_parquet_root_schema(parquet_file: &std::path::Path) -> ParquetType {
     let file = std::fs::File::open(parquet_file).unwrap();
     let reader = SerializedFileReader::new(file).unwrap();
     reader

--- a/kernel/tests/integration/create_table/iceberg_compat.rs
+++ b/kernel/tests/integration/create_table/iceberg_compat.rs
@@ -1,0 +1,110 @@
+//! IcebergCompatV3 integration tests for the CreateTable API.
+
+use std::sync::Arc;
+
+use delta_kernel::committer::FileSystemCommitter;
+use delta_kernel::schema::{
+    ArrayType, ColumnMetadataKey, DataType, MapType, StructField, StructType,
+};
+use delta_kernel::snapshot::Snapshot;
+use delta_kernel::table_features::{ColumnMappingMode, TableFeature};
+use delta_kernel::transaction::create_table::create_table;
+use delta_kernel::DeltaResult;
+use rstest::rstest;
+use test_utils::test_table_setup;
+
+/// V3 create-table negative paths: enabling V3 alongside an incompatible property must fail at
+/// `.build(...)` with a clear error.
+///
+/// `cm_mode_none` and `row_tracking_disabled` are blocked by V3's dependency check
+/// (`maybe_enable_iceberg_compat_v3_dependencies`); the others are blocked earlier because
+/// the property is not in `ALLOWED_DELTA_PROPERTIES` for CREATE TABLE. Keep them here
+/// so that in the future when we support these properties for create table, we will remember
+/// to update this test.
+#[rstest]
+#[case::cm_mode_none(
+    &[("delta.columnMapping.mode", "none")],
+    "to be 'name' or 'id', got 'none'",
+)]
+#[case::row_tracking_disabled(
+    &[("delta.enableRowTracking", "false")],
+    "to be 'true', got 'false'",
+)]
+#[case::iceberg_compat_v1_active(
+    &[("delta.enableIcebergCompatV1", "true")],
+    "Setting delta property 'delta.enableIcebergCompatV1' is not supported",
+)]
+#[case::iceberg_compat_v2_active(
+    &[("delta.enableIcebergCompatV2", "true")],
+    "Setting delta property 'delta.enableIcebergCompatV2' is not supported",
+)]
+fn v3_create_table_rejects_incompatible_props(
+    #[case] extra_props: &[(&str, &str)],
+    #[case] err_substring: &str,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let mut props: Vec<(&str, &str)> = vec![("delta.enableIcebergCompatV3", "true")];
+    props.extend_from_slice(extra_props);
+
+    let err = create_table(&table_path, super::simple_schema()?, "Test/1.0")
+        .with_table_properties(props)
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))
+        .unwrap_err()
+        .to_string();
+    assert!(
+        err.contains(err_substring),
+        "expected error containing {err_substring:?}, got: {err}",
+    );
+    Ok(())
+}
+
+/// Listing IcebergCompatV3 in writerFeatures (i.e. "supported") without setting
+/// `delta.enableIcebergCompatV3=true` must not activate V3: column mapping stays off and
+/// no nested-id metadata is set on the Map field.
+#[test]
+fn v3_supported_but_not_enabled_skips_cm_and_nested_ids() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
+        "data",
+        DataType::Map(Box::new(MapType::new(
+            DataType::INTEGER,
+            DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+            true,
+        ))),
+    )])?);
+
+    let _ = create_table(&table_path, schema, "Test/1.0")
+        .with_table_properties([("delta.feature.icebergCompatV3", "supported")])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?;
+    let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+
+    // 1. V3 is in writerFeatures (supported).
+    let writer_features = snapshot
+        .table_configuration()
+        .protocol()
+        .writer_features()
+        .expect("writerFeatures present");
+    assert!(
+        writer_features.contains(&TableFeature::IcebergCompatV3),
+        "expected icebergCompatV3 in writerFeatures, got: {writer_features:?}",
+    );
+
+    // 2. CM is not enabled (no auto-enable from V3 being merely supported).
+    assert_eq!(
+        snapshot.table_configuration().column_mapping_mode(),
+        ColumnMappingMode::None,
+    );
+
+    // 3. No nested-id metadata set on the Map field.
+    let loaded_schema = snapshot.schema();
+    let data_field = loaded_schema.field("data").expect("data field present");
+    assert!(
+        !data_field
+            .metadata
+            .contains_key(ColumnMetadataKey::ColumnMappingNestedIds.as_ref()),
+        "unexpected delta.columnMapping.nested.ids on data: {:?}",
+        data_field.metadata,
+    );
+    Ok(())
+}

--- a/kernel/tests/integration/create_table/mod.rs
+++ b/kernel/tests/integration/create_table/mod.rs
@@ -3,6 +3,7 @@
 mod clustering;
 mod column_mapping;
 mod ctas;
+mod iceberg_compat;
 mod ict;
 mod partitioned;
 mod row_tracking;

--- a/kernel/tests/integration/features/dv.rs
+++ b/kernel/tests/integration/features/dv.rs
@@ -259,8 +259,8 @@ async fn test_write_deletion_vectors_end_to_end() -> Result<(), Box<dyn std::err
     let add_metadata = create_add_files_metadata(
         add_files_schema,
         vec![
-            (&data_file_path_1, parquet_data_len_1 as i64, 1000000, 10),
-            (&data_file_path_2, parquet_data_len_2 as i64, 1000000, 10),
+            (&data_file_path_1, parquet_data_len_1 as i64, 1000000, Some(10)),
+            (&data_file_path_2, parquet_data_len_2 as i64, 1000000, Some(10)),
         ],
     )?;
 

--- a/kernel/tests/integration/features/dv.rs
+++ b/kernel/tests/integration/features/dv.rs
@@ -259,8 +259,18 @@ async fn test_write_deletion_vectors_end_to_end() -> Result<(), Box<dyn std::err
     let add_metadata = create_add_files_metadata(
         add_files_schema,
         vec![
-            (&data_file_path_1, parquet_data_len_1 as i64, 1000000, Some(10)),
-            (&data_file_path_2, parquet_data_len_2 as i64, 1000000, Some(10)),
+            (
+                &data_file_path_1,
+                parquet_data_len_1 as i64,
+                1000000,
+                Some(10),
+            ),
+            (
+                &data_file_path_2,
+                parquet_data_len_2 as i64,
+                1000000,
+                Some(10),
+            ),
         ],
     )?;
 

--- a/kernel/tests/integration/features/iceberg_compat.rs
+++ b/kernel/tests/integration/features/iceberg_compat.rs
@@ -1,4 +1,4 @@
-//! Integration tests for icebergCompat (V3) write- and load-time validations.
+//! Integration tests for icebergCompat
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -29,7 +29,9 @@ use delta_kernel::schema::{
     ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, StructField, StructType,
 };
 use delta_kernel::snapshot::Snapshot;
-use delta_kernel::table_features::{get_any_level_column_physical_name, ColumnMappingMode};
+use delta_kernel::table_features::{
+    get_any_level_column_physical_name, ColumnMappingMode, TableFeature,
+};
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::transforms::{transform_output_type, SchemaTransform};
@@ -134,6 +136,63 @@ async fn snapshot_blocked_when_v3_schema_has_legacy_nested_ids() {
             && err.contains("delta.columnMapping.nested.ids")
             && err.contains("data"),
         "expected error mentioning the legacy key, replacement key, and field path, got: {err}",
+    );
+}
+
+/// Listing IcebergCompatV3 in writerFeatures (i.e. "supported") without setting
+/// `delta.enableIcebergCompatV3=true` must not activate V3: column mapping stays off and
+/// no nested-id metadata is stamped on the Map field.
+#[tokio::test]
+async fn v3_supported_but_not_enabled_skips_cm_and_nested_ids() {
+    let (_, engine) = make_engine();
+    let schema = Arc::new(
+        StructType::try_new(vec![StructField::nullable(
+            "data",
+            DataType::Map(Box::new(MapType::new(
+                DataType::INTEGER,
+                DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+                true,
+            ))),
+        )])
+        .unwrap(),
+    );
+
+    let _ = create_table(TABLE_ROOT, schema, "Test/1.0")
+        .with_table_properties([("delta.feature.icebergCompatV3", "supported")])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))
+        .unwrap()
+        .commit(engine.as_ref())
+        .unwrap();
+    let snapshot = Snapshot::builder_for(TABLE_ROOT)
+        .build(engine.as_ref())
+        .unwrap();
+
+    // 1. V3 is in writerFeatures (supported).
+    let writer_features = snapshot
+        .table_configuration()
+        .protocol()
+        .writer_features()
+        .expect("writerFeatures present");
+    assert!(
+        writer_features.contains(&TableFeature::IcebergCompatV3),
+        "expected icebergCompatV3 in writerFeatures, got: {writer_features:?}",
+    );
+
+    // 2. CM is not enabled (no auto-enable from V3 being merely supported).
+    assert_eq!(
+        snapshot.table_configuration().column_mapping_mode(),
+        ColumnMappingMode::None,
+    );
+
+    // 3. No nested-id metadata stamped on the Map field.
+    let loaded_schema = snapshot.schema();
+    let data_field = loaded_schema.field("data").expect("data field present");
+    assert!(
+        !data_field
+            .metadata
+            .contains_key(ColumnMetadataKey::ColumnMappingNestedIds.as_ref()),
+        "unexpected delta.columnMapping.nested.ids on data: {:?}",
+        data_field.metadata,
     );
 }
 
@@ -353,7 +412,7 @@ async fn v3_e2e_partitioned_writes_with_field_ids(
         let parquet_url = table_url.join(&add.path).unwrap();
         let local_path = parquet_url.to_file_path().unwrap();
         let ids = collect_all_parquet_field_ids(&local_path);
-        let root = read_parquet_root_schema(&local_path);
+        let parquet_root_schema = read_parquet_root_schema(&local_path);
 
         // Top-level + nested column-mapping IDs all appear as expected.
         // Expected count for `nested_schema_with_all_delta_types`:
@@ -374,7 +433,7 @@ async fn v3_e2e_partitioned_writes_with_field_ids(
         let region_physical =
             get_top_level_physical_name(logical_schema.as_ref(), "region", cm_mode);
         assert!(
-            find_top_level_field_in_parquet(&root, &region_physical).is_some(),
+            find_top_level_field_in_parquet(&parquet_root_schema, &region_physical).is_some(),
             "partition column `region` (physical {region_physical}) not materialized in {parquet_url}",
         );
 
@@ -382,14 +441,14 @@ async fn v3_e2e_partitioned_writes_with_field_ids(
         for col in ["timestamp_col", "timestamp_ntz_col"] {
             let physical = get_top_level_physical_name(logical_schema.as_ref(), col, cm_mode);
             assert_eq!(
-                find_top_level_physical_type_in_parquet(&root, &physical),
+                find_top_level_physical_type_in_parquet(&parquet_root_schema, &physical),
                 ParquetPhysicalType::INT64,
                 "{col} must be INT64 in parquet",
             );
         }
     }
 
-    // === (5) Exact scan contents ===
+    // === Exact scan contents ===
     verify_scan_contents(final_snap.clone(), engine.clone());
 }
 
@@ -602,7 +661,7 @@ fn build_all_null_complex_array(rows: usize) -> ArrayRef {
         ArrowDataType::Struct(fields) => fields.clone(),
         other => panic!("map entries must be struct, got {other:?}"),
     };
-    // Empty entries struct: no rows since every map is null.
+    // Empty entries struct.
     let empty_entries = StructArray::new(
         entries_struct_fields,
         entries_field_arrays_empty(entries_field.as_ref()),
@@ -878,11 +937,7 @@ impl<'a> SchemaTransform<'a> for ExpectedFieldIdMap {
 }
 
 /// Translate a `delta.columnMapping.nested.ids` key (e.g. `<phys>.key.element`) to its
-/// parquet_schema_path. The first segment of `physical_nested_path` is the field's physical
-/// name -- the same as the last segment of `field_parquet_schema_path` -- so we replace the
-/// whole prefix wholesale with `field_parquet_schema_path` and translate the remaining
-/// synthetic segments: `key`/`value` -> `key_value.key`/`key_value.value` (Map wrapper),
-/// `element` -> `list.element` (Array wrapper).
+/// `parquet_schema_path` for map/array element/key/value fields.
 fn translate_nested_path(field_parquet_schema_path: &str, physical_nested_path: &str) -> String {
     let segs: Vec<&str> = physical_nested_path.split('.').collect();
     let mut out = field_parquet_schema_path.to_string();

--- a/kernel/tests/integration/features/iceberg_compat.rs
+++ b/kernel/tests/integration/features/iceberg_compat.rs
@@ -186,9 +186,9 @@ async fn v3_commit_validates_num_records(
     }
 }
 
-/// V3 partitioned end-to-end: create + 4 commits with a checkpoint between, then validate
-/// protocol features, parquet field IDs (top-level + nested), partition materialization,
-/// timestamp physical type, and exact scan content.
+/// V3 partitioned end-to-end: create + 8 commits with a checkpoint in the middle, then validate
+/// protocol features, parquet field IDs (top-level + nested), partition materialization, timestamp
+/// physical type, and exact scan content.
 ///
 /// IcebergCompatV3 supports all delta types, so we use a schema with all delta types here.
 /// Two test cases:

--- a/kernel/tests/integration/features/iceberg_compat.rs
+++ b/kernel/tests/integration/features/iceberg_compat.rs
@@ -14,7 +14,6 @@ use delta_kernel::arrow::datatypes::{
 };
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::engine::arrow_conversion::{TryFromKernel, TryIntoArrow as _};
-use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::engine::default::executor::tokio::{
     TokioBackgroundExecutor, TokioMultiThreadExecutor,
 };
@@ -209,6 +208,7 @@ async fn v3_commit_validates_num_records(
     // Intentionally set `delta.columnMapping.mode=id`, since the `min` case already covers the
     // V3-default `name` mode.
     /* extra_props */ &[("delta.columnMapping.mode", "id")],
+    // Some features are enabled via schema content (e.g. TS_NTZ) so not in this list.
     /* enable_features */ &[
         "deletionVectors", "inCommitTimestamp", "changeDataFeed", "appendOnly",
         "v2Checkpoint", "vacuumProtocolCheck", "invariants",
@@ -235,9 +235,8 @@ async fn v3_e2e_partitioned_writes_with_field_ids(
 
     // === Create partitioned V3 table ===
     let schema = nested_schema_with_all_delta_types();
-    // Features without an enable property are added via `delta.feature.X=supported`. Build
-    // the signal strings up front so the property tuples below can borrow them.
-    let signal_props: Vec<(String, String)> = enable_features
+    // Features without an enable property are added via `delta.feature.X=supported`.
+    let feature_enabled_by_supported: Vec<(String, String)> = enable_features
         .iter()
         .filter(|f| enable_property_for(f).is_none())
         .map(|f| (format!("delta.feature.{f}"), "supported".to_string()))
@@ -249,7 +248,11 @@ async fn v3_e2e_partitioned_writes_with_field_ids(
             .iter()
             .filter_map(|f| enable_property_for(f).map(|p| (p, "true"))),
     );
-    props.extend(signal_props.iter().map(|(k, v)| (k.as_str(), v.as_str())));
+    props.extend(
+        feature_enabled_by_supported
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str())),
+    );
     let _ = create_table(&table_path, schema.clone(), "Test/1.0")
         .with_table_properties(props)
         .with_data_layout(DataLayout::partitioned(["region"]))
@@ -298,11 +301,7 @@ async fn v3_e2e_partitioned_writes_with_field_ids(
 
     // === Per-data-file validations ===
     let add_actions = read_add_infos(&final_snap, engine.as_ref()).unwrap();
-    assert_eq!(
-        add_actions.len(),
-        8,
-        "expected 4 outer iters x 2 partitions = 8 add files",
-    );
+    assert_eq!(add_actions.len(), 8, "expected 8 add files",);
     let logical_schema = final_snap.schema();
     for add in &add_actions {
         let parquet_url = table_url.join(&add.path).unwrap();

--- a/kernel/tests/integration/features/iceberg_compat.rs
+++ b/kernel/tests/integration/features/iceberg_compat.rs
@@ -10,7 +10,7 @@ use delta_kernel::arrow::array::{
 };
 use delta_kernel::arrow::buffer::{NullBuffer, OffsetBuffer};
 use delta_kernel::arrow::datatypes::{
-    DataType as ArrowDataType, Field as ArrowField, Fields, Schema as ArrowSchema,
+    DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
 };
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::engine::arrow_conversion::{TryFromKernel, TryIntoArrow as _};
@@ -32,8 +32,8 @@ use delta_kernel::snapshot::Snapshot;
 use delta_kernel::table_features::{get_any_level_column_physical_name, ColumnMappingMode};
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
-use delta_kernel::EngineData;
-use test_utils::{add_commit, read_add_infos, test_table_setup_mt, write_batch_to_table};
+use delta_kernel::transforms::{transform_output_type, SchemaTransform};
+use test_utils::{add_commit, create_add_files_metadata, read_add_infos, test_table_setup_mt};
 use url::Url;
 
 use crate::common::write_utils::{collect_all_parquet_field_ids, read_parquet_root_schema};
@@ -41,8 +41,7 @@ use crate::common::write_utils::{collect_all_parquet_field_ids, read_parquet_roo
 const TABLE_ROOT: &str = "memory:///";
 
 /// Hand-crafts a V0 create commit on an icebergCompatV3 table whose `data` field carries the
-/// deprecated `parquet.field.nested.ids` metadata. Loading the snapshot must fail because the
-/// validator runs in `TableConfiguration::try_new`.
+/// to-be-deprecated `parquet.field.nested.ids` metadata. Loading the snapshot must fail.
 #[tokio::test]
 async fn snapshot_blocked_when_v3_schema_has_legacy_nested_ids() {
     let (storage, engine) = make_engine();
@@ -149,7 +148,7 @@ async fn v3_commit_validates_num_records(
     let (_, engine) = make_engine();
 
     let _ = create_table(TABLE_ROOT, simple_schema(), "Test/1.0")
-        .with_table_properties(v3_table_properties())
+        .with_table_properties([("delta.enableIcebergCompatV3", "true")])
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))
         .unwrap()
         .commit(engine.as_ref())
@@ -163,8 +162,12 @@ async fn v3_commit_validates_num_records(
         .unwrap()
         .with_engine_info("Test/1.0")
         .with_data_change(true);
-    let add_schema = ArrowSchema::try_from_kernel(txn.add_files_schema().as_ref()).unwrap();
-    txn.add_files(synthetic_add_files_metadata(&add_schema, num_records));
+    let add_files = create_add_files_metadata(
+        txn.add_files_schema(),
+        vec![("part-fake.parquet", 1024, 1_000_000, num_records)],
+    )
+    .unwrap();
+    txn.add_files(add_files);
 
     match expected {
         Ok(expected_version) => {
@@ -181,68 +184,85 @@ async fn v3_commit_validates_num_records(
     }
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn write_succeeds_on_v3_table() {
+/// V3 create-table negative paths: enabling V3 alongside an incompatible property must fail at
+/// `.build(...)` with a clear error.
+///
+/// `cm_mode_none` and `row_tracking_disabled` are blocked by V3's dependency check
+/// (`maybe_enable_iceberg_compat_v3_dependencies`); the others are blocked earlier because
+/// the property is not in `ALLOWED_DELTA_PROPERTIES` for CREATE TABLE. Keep them here
+/// so that in the future when we support these properties for create table, we will remember to
+/// update this test.
+#[rstest::rstest]
+#[case::cm_mode_none(
+    &[("delta.columnMapping.mode", "none")],
+    "to be 'name' or 'id', got 'none'",
+)]
+#[case::row_tracking_disabled(
+    &[("delta.enableRowTracking", "false")],
+    "to be 'true', got 'false'",
+)]
+#[case::iceberg_compat_v1_active(
+    &[("delta.enableIcebergCompatV1", "true")],
+    "Setting delta property 'delta.enableIcebergCompatV1' is not supported",
+)]
+#[case::iceberg_compat_v2_active(
+    &[("delta.enableIcebergCompatV2", "true")],
+    "Setting delta property 'delta.enableIcebergCompatV2' is not supported",
+)]
+#[tokio::test]
+async fn v3_create_table_rejects_incompatible_props(
+    #[case] extra_props: &[(&str, &str)],
+    #[case] err_substring: &str,
+) {
     let (_, engine) = make_engine();
+    let mut props: Vec<(&str, &str)> = vec![("delta.enableIcebergCompatV3", "true")];
+    props.extend_from_slice(extra_props);
 
-    let schema = simple_schema();
-    let _ = create_table(TABLE_ROOT, schema.clone(), "Test/1.0")
-        .with_table_properties(v3_table_properties())
+    let err = create_table(TABLE_ROOT, simple_schema(), "Test/1.0")
+        .with_table_properties(props)
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))
-        .unwrap()
-        .commit(engine.as_ref())
-        .unwrap();
-    let snapshot = Snapshot::builder_for(TABLE_ROOT)
-        .build(engine.as_ref())
-        .unwrap();
-
-    // Real write through the default engine: stats are auto-collected and include numRecords.
-    let arrow_schema: ArrowSchema = (schema.as_ref()).try_into_arrow().unwrap();
-    let id_col: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
-    let name_col: ArrayRef = Arc::new(StringArray::from(vec!["a", "b", "c"]));
-    let batch = RecordBatch::try_new(Arc::new(arrow_schema), vec![id_col, name_col]).unwrap();
-
-    let new_snapshot = write_batch_to_table(&snapshot, engine.as_ref(), batch, HashMap::new())
-        .await
-        .expect("V3 write should succeed");
-    assert_eq!(new_snapshot.version(), 1);
+        .unwrap_err()
+        .to_string();
+    assert!(
+        err.contains(err_substring),
+        "expected error containing {err_substring:?}, got: {err}",
+    );
 }
 
-/// End-to-end V3 round-trip on a partitioned table with a kitchen-sink schema:
+/// V3 partitioned end-to-end: create + 4 commits with a checkpoint between, then validate
+/// protocol features, parquet field IDs (top-level + nested), partition materialization,
+/// timestamp physical type, and exact scan content.
 ///
-/// - Schema covers every primitive Delta type plus an unshredded VARIANT and a deeply nested
-///   `map<list<int>, struct<inner_map: map<list<int>, int>, n: int>>` column.
-/// - Partition column is `region: STRING`. V3 forces partition values to be materialized into the
-///   parquet data files (no `MaterializePartitionColumns` flag needed).
-/// - Two parameterized cases:
-///     - `min`: only `delta.enableIcebergCompatV3=true` (auto-pulls columnMapping=name,
-///       rowTracking, domainMetadata; the schema auto-pulls timestampNtz + variantType). Checkpoint
-///       at version 2 lands as a V1 single-parquet checkpoint.
-///     - `max`: same as `min` plus `delta.feature.{deletionVectors, v2Checkpoint,
-///       inCommitTimestamp, vacuumProtocolCheck}=supported`. Checkpoint at version 2 lands as a V2
-///       multi-part checkpoint.
-/// - Four commits, each writing 2 partitions x 3 rows = 6 rows. A checkpoint runs after commits
-///   1-2; commits 3-4 land after the checkpoint.
-///
-/// Validations after the final write:
-///   1. Protocol contains the expected reader/writer features for the case.
-///   2. Every parquet data file has `field_id` set on every leaf, including map keys/values and
-///      list elements. The total number of field-id-bearing nodes equals the count of typed leaves
-///      in the kernel schema (15 + 3 nested-map leaves).
-///   3. The partition column is physically materialized in each data file.
-///   4. `ts` (TIMESTAMP) and `ts_ntz` (TIMESTAMP_NTZ) are written with parquet physical type INT64
-///      (microseconds).
-///   5. A full scan returns all 24 rows.
-///   6. Parquet field IDs match `delta.columnMapping.id` from the table schema for every top-level
-///      column and for the nested map/list leaves of `complex`.
+/// IcebergCompatV3 supports all delta types, so we use a schema with all delta types here.
+/// Two test cases:
+/// - `min`: minimum feature set. Enables only `delta.enableIcebergCompatV3=true` and relies on
+///   V3's auto-enablement of `columnMapping=name` + `rowTracking=true`.
+/// - `max`: maximum feature set we are able to enable through create table, with exceptions for:
+///   `materializePartitionColumns` (omitted so the partition-materialization check below proves
+///   V3 implies it), `typeWidening` (kernel rejects writes against tables declaring it), and
+///   `catalogManaged` (requires a catalog committer).
 #[rstest::rstest]
-#[case::min(false)]
-#[case::max(true)]
+#[case::min(&[], &[])]
+#[case::max(
+    // Features enabled through properties.
+    // Intentionally set `delta.columnMapping.mode=id`, as the `min` case tests 
+    // `name` mode(auto-enabled as a default by V3).
+    &[
+        ("delta.columnMapping.mode", "id"),
+        ("delta.enableDeletionVectors", "true"),
+        ("delta.enableInCommitTimestamps", "true"),
+        ("delta.enableChangeDataFeed", "true"),
+        ("delta.appendOnly", "true"),
+    ],
+    // Enablement through feature signals(i.e. delta.feature.X=supported).
+    &["v2Checkpoint", "vacuumProtocolCheck", "invariants"],
+)]
 #[tokio::test(flavor = "multi_thread")]
-async fn v3_e2e_partitioned_writes_with_field_ids(#[case] max_features: bool) {
-    let _ = tracing_subscriber::fmt::try_init();
-
-    // === Setup: filesystem-backed engine on a temp dir ===
+async fn v3_e2e_partitioned_writes_with_field_ids(
+    #[case] extra_props: &[(&str, &str)],
+    #[case] extra_feature_signals: &[&str],
+) {
+    // === Setup ===
     let (_tmp_dir, table_path, _) = test_table_setup_mt().unwrap();
     let table_url = Url::from_directory_path(&table_path).unwrap();
     let store: Arc<DynObjectStore> = Arc::new(LocalFileSystem::new());
@@ -255,20 +275,14 @@ async fn v3_e2e_partitioned_writes_with_field_ids(#[case] max_features: bool) {
     );
 
     // === Create partitioned V3 table ===
-    let schema = kitchen_sink_schema();
-    let mut props: Vec<(&str, &str)> = vec![
-        ("delta.enableIcebergCompatV3", "true"),
-        ("delta.columnMapping.mode", "name"),
-        ("delta.enableRowTracking", "true"),
-    ];
-    if max_features {
-        props.extend([
-            ("delta.feature.deletionVectors", "supported"),
-            ("delta.feature.v2Checkpoint", "supported"),
-            ("delta.feature.inCommitTimestamp", "supported"),
-            ("delta.feature.vacuumProtocolCheck", "supported"),
-        ]);
-    }
+    let schema = nested_schema_with_all_delta_types();
+    let signal_props: Vec<(String, String)> = extra_feature_signals
+        .iter()
+        .map(|f| (format!("delta.feature.{f}"), "supported".to_string()))
+        .collect();
+    let mut props: Vec<(&str, &str)> = vec![("delta.enableIcebergCompatV3", "true")];
+    props.extend(extra_props.iter().copied());
+    props.extend(signal_props.iter().map(|(k, v)| (k.as_str(), v.as_str())));
     let _ = create_table(&table_path, schema.clone(), "Test/1.0")
         .with_table_properties(props)
         .with_data_layout(DataLayout::partitioned(["region"]))
@@ -277,9 +291,9 @@ async fn v3_e2e_partitioned_writes_with_field_ids(#[case] max_features: bool) {
         .commit(engine.as_ref())
         .unwrap();
 
-    // === 2 commits, then checkpoint, then 2 more commits ===
+    // === 2 commits, checkpoint, 2 more commits ===
     for commit_idx in 0..2_i32 {
-        write_partitioned_v3_commit(&table_url, engine.clone(), &schema, commit_idx).await;
+        write_partitioned_data(&table_url, engine.clone(), commit_idx).await;
     }
     Snapshot::builder_for(table_url.clone())
         .build(engine.as_ref())
@@ -287,176 +301,95 @@ async fn v3_e2e_partitioned_writes_with_field_ids(#[case] max_features: bool) {
         .checkpoint(engine.as_ref(), None)
         .unwrap();
     for commit_idx in 2..4_i32 {
-        write_partitioned_v3_commit(&table_url, engine.clone(), &schema, commit_idx).await;
+        write_partitioned_data(&table_url, engine.clone(), commit_idx).await;
     }
 
     let final_snap = Snapshot::builder_for(table_url.clone())
         .build(engine.as_ref())
         .unwrap();
 
-    // === (1) Protocol features ===
-    let protocol = final_snap.table_configuration().protocol();
-    let writer_features: Vec<String> = protocol
-        .writer_features()
-        .expect("V3 table must publish writerFeatures")
-        .iter()
-        .map(|f| f.as_ref().to_string())
-        .collect();
-    for f in [
+    // === Verify protocol features and column mapping mode ===
+    let baseline_features = [
         "icebergCompatV3",
         "columnMapping",
         "rowTracking",
         "domainMetadata",
         "timestampNtz",
         "variantType",
-    ] {
-        assert!(
-            writer_features.iter().any(|w| w == f),
-            "writerFeatures missing {f}; got {writer_features:?}",
-        );
-    }
-    if max_features {
-        for f in [
-            "deletionVectors",
-            "v2Checkpoint",
-            "inCommitTimestamp",
-            "vacuumProtocolCheck",
-        ] {
-            assert!(
-                writer_features.iter().any(|w| w == f),
-                "writerFeatures missing {f} for max case; got {writer_features:?}",
-            );
-        }
-    }
-    assert_eq!(
-        final_snap
-            .table_properties()
-            .column_mapping_mode
-            .unwrap_or(ColumnMappingMode::None),
-        ColumnMappingMode::Name,
-    );
+    ];
+    let auto_enabled_features: Vec<&str> = extra_props
+        .iter()
+        .filter(|(_, v)| *v == "true")
+        .map(|(k, _)| feature_for_enable_property(k))
+        .collect();
+    let mut expected_features: Vec<&str> = baseline_features.to_vec();
+    expected_features.extend(auto_enabled_features);
+    expected_features.extend(extra_feature_signals.iter().copied());
+    verify_protocol(&final_snap, &expected_features);
+    let cm_mode = final_snap
+        .table_properties()
+        .column_mapping_mode
+        .expect("V3 must enable column mapping");
+    let expected_cm_mode = extra_props
+        .iter()
+        .find(|(k, _)| *k == "delta.columnMapping.mode")
+        .map(|(_, v)| match *v {
+            "id" => ColumnMappingMode::Id,
+            "name" => ColumnMappingMode::Name,
+            other => panic!("unexpected column mapping mode {other:?}"),
+        })
+        .unwrap_or(ColumnMappingMode::Name);
+    assert_eq!(cm_mode, expected_cm_mode);
 
-    // === (2)-(4) Per-data-file validations ===
+    // === Per-data-file validations ===
     let add_actions = read_add_infos(&final_snap, engine.as_ref()).unwrap();
     assert_eq!(
         add_actions.len(),
         8,
         "expected 4 commits x 2 partitions = 8 add files",
     );
+    let logical_schema = final_snap.schema();
     for add in &add_actions {
         let parquet_url = table_url.join(&add.path).unwrap();
         let local_path = parquet_url.to_file_path().unwrap();
         let ids = collect_all_parquet_field_ids(&local_path);
+        let root = read_parquet_root_schema(&local_path);
 
-        // Field IDs match column mapping IDs from the logical schema for top-level columns.
-        let logical_schema = final_snap.schema();
-        for field in logical_schema.fields() {
-            let physical = get_any_level_column_physical_name(
-                logical_schema.as_ref(),
-                &ColumnName::new([field.name()]),
-                ColumnMappingMode::Name,
-            )
-            .unwrap()
-            .into_inner();
-            let id_in_parquet = ids.get(&physical[0]).copied().unwrap_or_else(|| {
-                panic!(
-                    "missing field_id for top-level column {} (physical {:?}) in {}",
-                    field.name(),
-                    physical,
-                    parquet_url
-                )
-            });
-            let expected = field.column_mapping_id().unwrap_or_else(|| {
-                panic!(
-                    "logical field {} missing column mapping id; metadata: {:?}",
-                    field.name(),
-                    field.metadata()
-                )
-            });
+        // Top-level + nested column-mapping IDs all appear as expected.
+        // Expected count for `nested_schema_with_all_delta_types`:
+        //   16 top-level fields
+        //   + 3 nested.ids on `complex` (`complex.{key, key.element, value}`)
+        //   + 2 struct fields inside `complex.value` (`inner_map`, `n`)
+        //   + 3 nested.ids on `inner_map` (`inner_map.{key, key.element, value}`)
+        //   = 24
+        verify_column_mapping_ids_in_parquet(
+            logical_schema.as_ref(),
+            cm_mode,
+            &ids,
+            &parquet_url,
+            24, /* expected_num_ids */
+        );
+
+        // Partition column is physically materialized (V3 invariant).
+        let region_physical = get_top_level_physical_name(logical_schema.as_ref(), "region", cm_mode);
+        assert!(
+            find_top_level_field_in_parquet(&root, &region_physical).is_some(),
+            "partition column `region` (physical {region_physical}) not materialized in {parquet_url}",
+        );
+
+        // timestamp / timestamp_ntz are INT64 in parquet.
+        for col in ["timestamp_col", "timestamp_ntz_col"] {
+            let physical = get_top_level_physical_name(logical_schema.as_ref(), col, cm_mode);
             assert_eq!(
-                id_in_parquet,
-                expected,
-                "parquet field_id mismatch for top-level {}: parquet={id_in_parquet}, schema={expected}",
-                field.name()
+                find_top_level_physical_type_in_parquet(&root, &physical),
+                ParquetPhysicalType::INT64,
+                "{col} must be INT64 in parquet",
             );
         }
-
-        // Field IDs are present on every leaf inside the deeply nested `complex` column.
-        // The leaves below correspond to: outer map key (list<int>) -> int element,
-        // outer map value (struct) -> inner_map key (list<int>) -> int element,
-        // outer map value -> inner_map value (int), outer map value -> n (int).
-        let complex_physical = get_any_level_column_physical_name(
-            logical_schema.as_ref(),
-            &ColumnName::new(["complex"]),
-            ColumnMappingMode::Name,
-        )
-        .unwrap()
-        .into_inner();
-        let complex_paths = collect_paths_with_prefix(&ids, &complex_physical[0]);
-        assert!(
-            complex_paths.len() >= 7,
-            "expected >=7 field-id-bearing nodes under `complex` (physical {complex_physical:?}), got {complex_paths:?}",
-        );
-
-        // Partition column physically materialized in each data file (V3 invariant).
-        let region_physical = get_any_level_column_physical_name(
-            logical_schema.as_ref(),
-            &ColumnName::new(["region"]),
-            ColumnMappingMode::Name,
-        )
-        .unwrap()
-        .into_inner();
-        let root = read_parquet_root_schema(&local_path);
-        assert!(
-            top_level_field(&root, &region_physical[0]).is_some(),
-            "partition column `region` (physical {region_physical:?}) is not materialized in {parquet_url}",
-        );
-
-        // ts / ts_ntz physical type is INT64.
-        let ts_physical = get_any_level_column_physical_name(
-            logical_schema.as_ref(),
-            &ColumnName::new(["ts"]),
-            ColumnMappingMode::Name,
-        )
-        .unwrap()
-        .into_inner();
-        let ts_ntz_physical = get_any_level_column_physical_name(
-            logical_schema.as_ref(),
-            &ColumnName::new(["ts_ntz"]),
-            ColumnMappingMode::Name,
-        )
-        .unwrap()
-        .into_inner();
-        assert_eq!(
-            top_level_physical_type(&root, &ts_physical[0]),
-            ParquetPhysicalType::INT64,
-            "ts must be INT64 in parquet",
-        );
-        assert_eq!(
-            top_level_physical_type(&root, &ts_ntz_physical[0]),
-            ParquetPhysicalType::INT64,
-            "ts_ntz must be INT64 in parquet",
-        );
     }
 
-    // === (5) Scan returns all 24 rows ===
-    let scan = final_snap.scan_builder().build().unwrap();
-    let total_rows: usize = scan
-        .execute(engine.clone())
-        .unwrap()
-        .map(|res| -> usize {
-            let raw = res.unwrap();
-            let batch: RecordBatch = ArrowEngineData::try_from_engine_data(raw)
-                .unwrap()
-                .record_batch()
-                .clone();
-            batch.num_rows()
-        })
-        .sum();
-    assert_eq!(
-        total_rows, 24,
-        "expected 4 commits x 2 partitions x 3 rows = 24 rows",
-    );
+    // === (5) Exact scan contents ===
+    verify_scan_contents(final_snap.clone(), engine.clone());
 }
 
 // === Helpers ===
@@ -466,14 +399,6 @@ fn make_engine() -> (Arc<InMemory>, Arc<DefaultEngine<TokioBackgroundExecutor>>)
     let engine =
         Arc::new(DefaultEngineBuilder::<TokioBackgroundExecutor>::new(storage.clone()).build());
     (storage, engine)
-}
-
-fn v3_table_properties() -> Vec<(&'static str, &'static str)> {
-    vec![
-        ("delta.enableIcebergCompatV3", "true"),
-        ("delta.columnMapping.mode", "name"),
-        ("delta.enableRowTracking", "true"),
-    ]
 }
 
 fn simple_schema() -> Arc<StructType> {
@@ -486,103 +411,36 @@ fn simple_schema() -> Arc<StructType> {
     )
 }
 
-/// Build add_files metadata for one synthetic file matching the schema returned by
-/// `Transaction::add_files_schema()`. `num_records` controls the `stats.numRecords` field
-/// (`None` -> NULL, `Some(n)` -> `n`); the other stats fields are populated with empty
-/// structs / `tightBounds=true`.
-fn synthetic_add_files_metadata(
-    arrow_schema: &ArrowSchema,
-    num_records: Option<i64>,
-) -> Box<dyn EngineData> {
-    let path_array = StringArray::from(vec!["part-fake.parquet"]);
-    let size_array = Int64Array::from(vec![1024_i64]);
-    let mod_time_array = Int64Array::from(vec![1_000_000_i64]);
-
-    // partitionValues: empty Map<string, string>.
-    let entries_field = Arc::new(ArrowField::new(
-        "key_value",
-        ArrowDataType::Struct(Fields::from(vec![
-            ArrowField::new("key", ArrowDataType::Utf8, false),
-            ArrowField::new("value", ArrowDataType::Utf8, true),
-        ])),
-        false,
-    ));
-    let empty_keys = StringArray::from(Vec::<&str>::new());
-    let empty_values = StringArray::from(Vec::<Option<&str>>::new());
-    let empty_entries = StructArray::from(vec![
-        (
-            Arc::new(ArrowField::new("key", ArrowDataType::Utf8, false)),
-            Arc::new(empty_keys) as ArrayRef,
-        ),
-        (
-            Arc::new(ArrowField::new("value", ArrowDataType::Utf8, true)),
-            Arc::new(empty_values) as ArrayRef,
-        ),
-    ]);
-    let partition_values_array = Arc::new(MapArray::new(
-        entries_field,
-        OffsetBuffer::from_lengths(vec![0]),
-        empty_entries,
-        None,
-        false,
-    ));
-
-    let empty_struct_fields: Fields = Vec::<Arc<ArrowField>>::new().into();
-    let empty_struct = StructArray::new_empty_fields(1, None);
-    let stats_struct = StructArray::from(vec![
-        (
-            Arc::new(ArrowField::new("numRecords", ArrowDataType::Int64, true)),
-            Arc::new(Int64Array::from(vec![num_records])) as ArrayRef,
-        ),
-        (
-            Arc::new(ArrowField::new(
-                "nullCount",
-                ArrowDataType::Struct(empty_struct_fields.clone()),
-                true,
-            )),
-            Arc::new(empty_struct.clone()) as ArrayRef,
-        ),
-        (
-            Arc::new(ArrowField::new(
-                "minValues",
-                ArrowDataType::Struct(empty_struct_fields.clone()),
-                true,
-            )),
-            Arc::new(empty_struct.clone()) as ArrayRef,
-        ),
-        (
-            Arc::new(ArrowField::new(
-                "maxValues",
-                ArrowDataType::Struct(empty_struct_fields),
-                true,
-            )),
-            Arc::new(empty_struct) as ArrayRef,
-        ),
-        (
-            Arc::new(ArrowField::new("tightBounds", ArrowDataType::Boolean, true)),
-            Arc::new(BooleanArray::from(vec![true])) as ArrayRef,
-        ),
-    ]);
-
-    let batch = RecordBatch::try_new(
-        Arc::new(arrow_schema.clone()),
-        vec![
-            Arc::new(path_array) as ArrayRef,
-            partition_values_array as ArrayRef,
-            Arc::new(size_array) as ArrayRef,
-            Arc::new(mod_time_array) as ArrayRef,
-            Arc::new(stats_struct) as ArrayRef,
-        ],
+/// Schema covering every Delta types(primitive, struct, map, array, variant)
+/// Including a deeply nested map<list<int>, struct<inner_map: map<list<int>, int>, n: int>> column.
+/// `region` is the partition column.
+fn nested_schema_with_all_delta_types() -> Arc<StructType> {
+    Arc::new(
+        StructType::try_new(vec![
+            StructField::nullable("region", DataType::STRING),
+            StructField::nullable("int_col", DataType::INTEGER),
+            StructField::nullable("bool_col", DataType::BOOLEAN),
+            StructField::nullable("byte_col", DataType::BYTE),
+            StructField::nullable("short_col", DataType::SHORT),
+            StructField::nullable("long_col", DataType::LONG),
+            StructField::nullable("float_col", DataType::FLOAT),
+            StructField::nullable("double_col", DataType::DOUBLE),
+            StructField::nullable("decimal_col", DataType::decimal(10, 2).unwrap()),
+            StructField::nullable("string_col", DataType::STRING),
+            StructField::nullable("binary_col", DataType::BINARY),
+            StructField::nullable("date_col", DataType::DATE),
+            StructField::nullable("timestamp_col", DataType::TIMESTAMP),
+            StructField::nullable("timestamp_ntz_col", DataType::TIMESTAMP_NTZ),
+            StructField::nullable("variant_col", DataType::unshredded_variant()),
+            StructField::nullable("complex", complex_nested_data_type()),
+        ])
+        .unwrap(),
     )
-    .unwrap();
-
-    Box::new(ArrowEngineData::new(batch))
 }
 
-/// Schema covering every primitive Delta type plus an unshredded VARIANT and a deeply nested
-/// map<list<int>, struct<inner_map: map<list<int>, int>, n: int>> column. `region` is the
-/// partition column.
-fn kitchen_sink_schema() -> Arc<StructType> {
+/// `map<list<int>, struct<inner_map: map<list<int>, int>, n: int>>`. A deeply nested
+/// type used to validate field-id propagation through every level of map/list/struct.
+fn complex_nested_data_type() -> DataType {
     let inner_struct = StructType::try_new(vec![
         StructField::nullable(
             "inner_map",
@@ -595,132 +453,109 @@ fn kitchen_sink_schema() -> Arc<StructType> {
         StructField::nullable("n", DataType::INTEGER),
     ])
     .unwrap();
-
-    Arc::new(
-        StructType::try_new(vec![
-            StructField::nullable("region", DataType::STRING),
-            StructField::nullable("id", DataType::INTEGER),
-            StructField::nullable("b", DataType::BOOLEAN),
-            StructField::nullable("byte_c", DataType::BYTE),
-            StructField::nullable("short_c", DataType::SHORT),
-            StructField::nullable("long_c", DataType::LONG),
-            StructField::nullable("f", DataType::FLOAT),
-            StructField::nullable("d", DataType::DOUBLE),
-            StructField::nullable("dec", DataType::decimal(10, 2).unwrap()),
-            StructField::nullable("s", DataType::STRING),
-            StructField::nullable("bin", DataType::BINARY),
-            StructField::nullable("date_c", DataType::DATE),
-            StructField::nullable("ts", DataType::TIMESTAMP),
-            StructField::nullable("ts_ntz", DataType::TIMESTAMP_NTZ),
-            StructField::nullable("v", DataType::unshredded_variant()),
-            StructField::nullable(
-                "complex",
-                DataType::Map(Box::new(MapType::new(
-                    DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
-                    DataType::Struct(Box::new(inner_struct)),
-                    true,
-                ))),
-            ),
-        ])
-        .unwrap(),
-    )
+    DataType::Map(Box::new(MapType::new(
+        DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+        DataType::Struct(Box::new(inner_struct)),
+        true,
+    )))
 }
 
-/// Build a 3-row record batch for the partition `region`. Column data is keyed off `commit_idx`
-/// so different commits produce distinguishable rows. The deeply nested `complex` column and
-/// the `v` (VARIANT) column are written as all-null -- this exercises the schema (field IDs
-/// at every nested leaf) without requiring per-row binary/struct construction.
-///
-/// V3 materializes partition values into data files, so the `region` column is included in
-/// the data with the partition value repeated for every row.
-fn build_partition_batch(
-    schema: &StructType,
-    commit_idx: i32,
-    region: &str,
-    rows: usize,
-) -> RecordBatch {
-    let n = rows as i32;
-    let base = commit_idx * 100
-        + match region {
-            "a" => 0,
-            "b" => 50,
-            _ => panic!("unsupported region {region}"),
-        };
+const ROWS_PER_PARTITION: i32 = 3;
+const PARTITION_REGIONS: &[&str] = &["a", "b"];
 
-    let arrow_schema: ArrowSchema = schema.try_into_arrow().unwrap();
+/// Build a [`RecordBatch`] with [`ROWS_PER_PARTITION`] rows for the given `region` following the schema of
+/// [`nested_schema_with_all_delta_types`]. `random_seed` is used directly to produce different values
+/// so different calls produce distinguishable rows;
+fn build_partition_batch(random_seed: i32, region: &str) -> RecordBatch {
+    let rows = ROWS_PER_PARTITION as usize;
 
-    let region_col: ArrayRef = Arc::new(StringArray::from(vec![region; rows]));
-    let id: ArrayRef = Arc::new(Int32Array::from(
-        (0..n).map(|i| base + i).collect::<Vec<_>>(),
+    let schema = nested_schema_with_all_delta_types();
+    let arrow_schema: ArrowSchema = schema.as_ref().try_into_arrow().unwrap();
+
+    let region_partition_col: ArrayRef = Arc::new(StringArray::from(vec![region; rows]));
+    let int_col: ArrayRef = Arc::new(Int32Array::from(
+        (0..ROWS_PER_PARTITION).map(|i| random_seed + i).collect::<Vec<_>>(),
     ));
-    let b: ArrayRef = Arc::new(BooleanArray::from(
+    let bool_col: ArrayRef = Arc::new(BooleanArray::from(
         (0..rows).map(|i| i % 2 == 0).collect::<Vec<_>>(),
     ));
-    let byte_c: ArrayRef = Arc::new(Int8Array::from(
-        (0..n).map(|i| (base + i) as i8).collect::<Vec<_>>(),
+    let byte_col: ArrayRef = Arc::new(Int8Array::from(
+        (0..ROWS_PER_PARTITION).map(|i| (random_seed + i) as i8).collect::<Vec<_>>(),
     ));
-    let short_c: ArrayRef = Arc::new(Int16Array::from(
-        (0..n).map(|i| (base + i) as i16).collect::<Vec<_>>(),
+    let short_col: ArrayRef = Arc::new(Int16Array::from(
+        (0..ROWS_PER_PARTITION).map(|i| (random_seed + i) as i16).collect::<Vec<_>>(),
     ));
-    let long_c: ArrayRef = Arc::new(Int64Array::from(
-        (0..n).map(|i| (base + i) as i64).collect::<Vec<_>>(),
+    let long_col: ArrayRef = Arc::new(Int64Array::from(
+        (0..ROWS_PER_PARTITION).map(|i| (random_seed + i) as i64).collect::<Vec<_>>(),
     ));
-    let f: ArrayRef = Arc::new(Float32Array::from(
-        (0..n).map(|i| (base + i) as f32 + 0.5).collect::<Vec<_>>(),
+    let float_col: ArrayRef = Arc::new(Float32Array::from(
+        (0..ROWS_PER_PARTITION).map(|i| (random_seed + i) as f32 + 0.5).collect::<Vec<_>>(),
     ));
-    let d: ArrayRef = Arc::new(Float64Array::from(
-        (0..n).map(|i| (base + i) as f64 + 0.25).collect::<Vec<_>>(),
+    let double_col: ArrayRef = Arc::new(Float64Array::from(
+        (0..ROWS_PER_PARTITION).map(|i| (random_seed + i) as f64 + 0.25).collect::<Vec<_>>(),
     ));
     // Decimal(10, 2): values stored as scaled i128.
-    let dec: ArrayRef = Arc::new(
-        Decimal128Array::from((0..n).map(|i| (base + i) as i128 * 100).collect::<Vec<_>>())
-            .with_precision_and_scale(10, 2)
-            .unwrap(),
+    let decimal_col: ArrayRef = Arc::new(
+        Decimal128Array::from(
+            (0..ROWS_PER_PARTITION).map(|i| (random_seed + i) as i128 * 100).collect::<Vec<_>>(),
+        )
+        .with_precision_and_scale(10, 2)
+        .unwrap(),
     );
-    let s: ArrayRef = Arc::new(StringArray::from(
+    let string_col: ArrayRef = Arc::new(StringArray::from(
         (0..rows)
-            .map(|i| format!("s-{base}-{i}"))
+            .map(|i| format!("s-{random_seed}-{i}"))
             .collect::<Vec<_>>(),
     ));
-    let bin: ArrayRef = Arc::new(BinaryArray::from_iter_values(
-        (0..rows).map(|i| vec![(base as u8).wrapping_add(i as u8)]),
+    let binary_col: ArrayRef = Arc::new(BinaryArray::from_iter_values(
+        (0..rows).map(|i| vec![(random_seed as u8).wrapping_add(i as u8)]),
     ));
     // Days since 1970-01-01.
-    let date_c: ArrayRef = Arc::new(Date32Array::from(
-        (0..n).map(|i| 19000 + base + i).collect::<Vec<_>>(),
+    let date_col: ArrayRef = Arc::new(Date32Array::from(
+        (0..ROWS_PER_PARTITION).map(|i| 19000 + random_seed + i).collect::<Vec<_>>(),
     ));
     // Microseconds since epoch: TIMESTAMP carries UTC ("+00:00"), TIMESTAMP_NTZ has no zone.
-    let ts: ArrayRef = Arc::new(
+    let timestamp_col: ArrayRef = Arc::new(
         TimestampMicrosecondArray::from(
-            (0..n)
-                .map(|i| 1_700_000_000_000_000_i64 + (base + i) as i64)
+            (0..ROWS_PER_PARTITION)
+                .map(|i| 1_700_000_000_000_000_i64 + (random_seed + i) as i64)
                 .collect::<Vec<_>>(),
         )
         .with_timezone("UTC"),
     );
-    let ts_ntz: ArrayRef = Arc::new(TimestampMicrosecondArray::from(
-        (0..n)
-            .map(|i| 1_700_000_000_000_000_i64 + (base + i) as i64 + 1)
+    let timestamp_ntz_col: ArrayRef = Arc::new(TimestampMicrosecondArray::from(
+        (0..ROWS_PER_PARTITION)
+            .map(|i| 1_700_000_000_000_000_i64 + (random_seed + i) as i64 + 1)
             .collect::<Vec<_>>(),
     ));
-    let v: ArrayRef = build_all_null_variant_array(rows);
-    let complex: ArrayRef = build_all_null_complex_array(schema, rows);
+    let variant_col: ArrayRef = build_all_null_variant_array(rows);
+    let complex: ArrayRef = build_all_null_complex_array(rows);
 
     RecordBatch::try_new(
         Arc::new(arrow_schema),
         vec![
-            region_col, id, b, byte_c, short_c, long_c, f, d, dec, s, bin, date_c, ts, ts_ntz, v,
+            region_partition_col,
+            int_col,
+            bool_col,
+            byte_col,
+            short_col,
+            long_col,
+            float_col,
+            double_col,
+            decimal_col,
+            string_col,
+            binary_col,
+            date_col,
+            timestamp_col,
+            timestamp_ntz_col,
+            variant_col,
             complex,
         ],
     )
     .unwrap()
 }
 
-/// Builds an all-null unshredded variant column (struct<metadata: binary, value: binary>) of
-/// length `rows`. Mirrors the shape used by `test_append_variant`. The struct fields are
-/// non-null physically (kernel's unshredded variant schema marks them required), so we provide
-/// empty placeholder bytes for every row and rely on the outer null bitmap to mark all rows
-/// null at the variant level.
+/// Builds an all-null unshredded variant column with [`rows`] rows.
 fn build_all_null_variant_array(rows: usize) -> ArrayRef {
     let metadata_bytes: Vec<&[u8]> = (0..rows).map(|_| &[0x01, 0x00, 0x00][..]).collect();
     let value_bytes: Vec<&[u8]> = (0..rows).map(|_| &[0x0C, 0x01][..]).collect();
@@ -738,17 +573,13 @@ fn build_all_null_variant_array(rows: usize) -> ArrayRef {
     )
 }
 
-/// Builds an all-null `complex` MapArray matching the kitchen-sink schema's `complex` field.
-/// All `rows` map entries are null; the underlying entries struct is empty. This is enough to
-/// exercise schema/field-id paths through the deeply nested type without per-row construction.
-fn build_all_null_complex_array(schema: &StructType, rows: usize) -> ArrayRef {
-    let complex_field = schema
-        .fields()
-        .find(|f| f.name() == "complex")
-        .expect("schema must include `complex`");
-    let arrow_field: ArrowField = complex_field.try_into_arrow().unwrap();
-    let (entries_field, _sorted) = match arrow_field.data_type() {
-        ArrowDataType::Map(entries, sorted) => (entries.clone(), *sorted),
+/// Builds an all-null `complex` MapArray of length `rows` matching [`complex_nested_data_type`].
+/// All map entries are null; the underlying entries struct is empty.
+fn build_all_null_complex_array(rows: usize) -> ArrayRef {
+    let complex_arrow_type: ArrowDataType =
+        (&complex_nested_data_type()).try_into_arrow().unwrap();
+    let (entries_field, _sorted) = match complex_arrow_type {
+        ArrowDataType::Map(entries, sorted) => (entries, sorted),
         other => panic!("complex must be a Map type, got {other:?}"),
     };
     let entries_struct_fields = match entries_field.data_type() {
@@ -772,9 +603,6 @@ fn build_all_null_complex_array(schema: &StructType, rows: usize) -> ArrayRef {
     ))
 }
 
-/// Produce empty arrays for each field of a map's `entries` struct. Each array has length 0
-/// and matches the field's declared arrow data type. Recurses into nested struct/list/map
-/// types via Arrow's `new_empty_array` factory.
 fn entries_field_arrays_empty(entries_field: &ArrowField) -> Vec<ArrayRef> {
     match entries_field.data_type() {
         ArrowDataType::Struct(fields) => fields
@@ -787,25 +615,36 @@ fn entries_field_arrays_empty(entries_field: &ArrowField) -> Vec<ArrayRef> {
 
 /// Open a transaction on `table_url`, write 2 partitions x 3 rows (regions "a" and "b") via the
 /// engine's parquet handler, and commit. Stats and `numRecords` are auto-collected by the
-/// default engine, so the V3 numRecords invariant is satisfied.
-async fn write_partitioned_v3_commit(
+/// default engine, so the numRecords invariant is satisfied.
+/// Assume the table schema is [`nested_schema_with_all_delta_types`].
+async fn write_partitioned_data(
     table_url: &Url,
     engine: Arc<DefaultEngine<TokioMultiThreadExecutor>>,
-    schema: &StructType,
-    commit_idx: i32,
+    random_seed: i32,
 ) {
     let snapshot = Snapshot::builder_for(table_url.clone())
         .build(engine.as_ref())
         .unwrap();
+    // Defensive sanity check: confirm the table schema matches what `build_partition_batch`
+    // produces. We compare top-level field names rather than full structs for simplicity.
+    let actual_schema = snapshot.schema();
+    let expected_schema = nested_schema_with_all_delta_types();
+    let actual_fields: Vec<&str> = actual_schema.fields().map(|f| f.name().as_str()).collect();
+    let expected_fields: Vec<&str> =
+        expected_schema.fields().map(|f| f.name().as_str()).collect();
+    assert_eq!(
+        actual_fields, expected_fields,
+        "table schema does not match `nested_schema_with_all_delta_types`",
+    );
     let mut txn = snapshot
         .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())
         .unwrap()
-        .with_engine_info(format!("Test/v3-commit-{commit_idx}"))
+        .with_engine_info(format!("Test/v3-commit-seed-{random_seed}"))
         .with_data_change(true);
 
     // Each partition gets its own write_parquet call with a partitioned WriteContext.
-    for region in ["a", "b"] {
-        let batch = build_partition_batch(schema, commit_idx, region, 3 /* rows */);
+    for region in PARTITION_REGIONS {
+        let batch = build_partition_batch(random_seed, region);
         let write_context = txn
             .partitioned_write_context(HashMap::from([(
                 "region".to_string(),
@@ -821,8 +660,231 @@ async fn write_partitioned_v3_commit(
     let _ = txn.commit(engine.as_ref()).unwrap().unwrap_committed();
 }
 
+/// Map a `delta.enable*` (or `delta.appendOnly`) enablement-property key to the feature
+/// name. Panics on unknown keys to surface case-input typos.
+fn feature_for_enable_property(key: &str) -> &'static str {
+    match key {
+        "delta.enableDeletionVectors" => "deletionVectors",
+        "delta.enableInCommitTimestamps" => "inCommitTimestamp",
+        "delta.enableChangeDataFeed" => "changeDataFeed",
+        "delta.appendOnly" => "appendOnly",
+        "delta.enableRowTracking" => "rowTracking",
+        other => panic!("unknown enablement property '{other}'"),
+    }
+}
+
+/// ReaderWriter features used in this test file.
+const READER_WRITER_FEATURES: &[&str] = &[
+    "columnMapping",
+    "deletionVectors",
+    "timestampNtz",
+    "v2Checkpoint",
+    "vacuumProtocolCheck",
+    "variantType",
+];
+
+/// Assert each name in `expected_features` appears in `writerFeatures`, plus that any
+/// reader+writer feature also appears in `readerFeatures`.
+fn verify_protocol(snapshot: &Snapshot, expected_features: &[&str]) {
+    let protocol = snapshot.table_configuration().protocol();
+    let writer_features: Vec<String> = protocol
+        .writer_features()
+        .expect("V3 table must publish writerFeatures")
+        .iter()
+        .map(|f| f.as_ref().to_string())
+        .collect();
+    let reader_features: Vec<String> = protocol
+        .reader_features()
+        .map(|fs| fs.iter().map(|f| f.as_ref().to_string()).collect())
+        .unwrap_or_default();
+    for f in expected_features {
+        assert!(
+            writer_features.iter().any(|w| w == f),
+            "writerFeatures missing {f}; got {writer_features:?}",
+        );
+        if READER_WRITER_FEATURES.contains(f) {
+            assert!(
+                reader_features.iter().any(|r| r == f),
+                "readerFeatures missing {f} (reader+writer feature); got {reader_features:?}",
+            );
+        }
+    }
+}
+
+/// Look up the physical name of a top-level logical column. Panics if not found.
+fn get_top_level_physical_name(schema: &StructType, logical: &str, mode: ColumnMappingMode) -> String {
+    let physical = get_any_level_column_physical_name(schema, &ColumnName::new([logical]), mode)
+        .unwrap()
+        .into_inner();
+    physical
+        .into_iter()
+        .next()
+        .unwrap_or_else(|| panic!("no physical path for column {logical}"))
+}
+
+/// Assert that every column-mapping ID lands at the right `parquet_schema_path` in the parquet
+/// schema. Walks the kernel schema, builds an expected `parquet_schema_path -> id` map (from
+/// both `delta.columnMapping.id` and `delta.columnMapping.nested.ids`), then for each entry
+/// asserts the parquet file has the same id at that path.
+///
+/// A `parquet_schema_path` is the dot-joined path of a field from the parquet schema root.
+///
+/// Example. A kernel schema with one column `m: map<list<int>, int>` carrying:
+/// ```text
+/// delta.columnMapping.id           = 1
+/// delta.columnMapping.physicalName = "col-X"
+/// delta.columnMapping.nested.ids   = {
+///     "col-X.key":         2,
+///     "col-X.key.element": 3,
+///     "col-X.value":       4,
+/// }
+/// ```
+/// produces the expected `parquet_schema_path -> id` map:
+/// ```text
+/// {
+///   "col-X":                            1,
+///   "col-X.key_value.key":              2,
+///   "col-X.key_value.key.list.element": 3,
+///   "col-X.key_value.value":            4,
+/// }
+/// ```
+fn verify_column_mapping_ids_in_parquet(
+    logical_schema: &StructType,
+    mode: ColumnMappingMode,
+    parquet_ids: &HashMap<String, i64>,
+    parquet_url: &Url,
+    expected_num_ids: usize,
+) {
+    let mut visitor = ExpectedFieldIdMap {
+        mode,
+        parquet_schema_path_stack: Vec::new(),
+        expected: HashMap::new(),
+    };
+    visitor.transform_struct(logical_schema);
+    assert_eq!(
+        parquet_ids.len(),
+        expected_num_ids,
+        "expected {expected_num_ids} field IDs in {parquet_url}, got {}: {parquet_ids:?}",
+        parquet_ids.len(),
+    );
+    for (parquet_schema_path, expected_id) in &visitor.expected {
+        let actual_id = parquet_ids.get(parquet_schema_path).copied().unwrap_or_else(|| {
+            panic!(
+                "expected field_id {expected_id} at parquet_schema_path \
+                 '{parquet_schema_path}' in {parquet_url}; actual ids: {parquet_ids:?}",
+            )
+        });
+        assert_eq!(
+            actual_id, *expected_id,
+            "parquet field_id mismatch at parquet_schema_path \
+             '{parquet_schema_path}' in {parquet_url}: expected {expected_id}, got {actual_id}",
+        );
+    }
+}
+
+/// Schema visitor that builds `parquet_schema_path -> id` for
+/// [`verify_column_mapping_ids_in_parquet`].
+struct ExpectedFieldIdMap {
+    mode: ColumnMappingMode,
+    parquet_schema_path_stack: Vec<String>,
+    expected: HashMap<String, i64>,
+}
+
+impl ExpectedFieldIdMap {
+    fn current_parquet_schema_path(&self) -> String {
+        self.parquet_schema_path_stack.join(".")
+    }
+}
+
+impl<'a> SchemaTransform<'a> for ExpectedFieldIdMap {
+    transform_output_type!(|'a, T| ());
+
+    fn transform_struct_field(&mut self, field: &'a StructField) {
+        self.parquet_schema_path_stack
+            .push(field.physical_name(self.mode).to_string());
+        let field_parquet_schema_path = self.current_parquet_schema_path();
+        if let Some(id) = field.column_mapping_id() {
+            self.expected.insert(field_parquet_schema_path.clone(), id);
+        }
+        if let Some(MetadataValue::Other(json)) =
+            field.get_config_value(&ColumnMetadataKey::ColumnMappingNestedIds)
+        {
+            if let Some(obj) = json.as_object() {
+                // Each key is a relative path rooted at the field's physical name, e.g.
+                // `<phys>.key`, `<phys>.key.element`. We translate it to its corresponding
+                // `parquet_schema_path`.
+                for (physical_nested_path, value) in obj {
+                    if let Some(id) = value.as_i64() {
+                        self.expected.insert(
+                            translate_nested_path(
+                                &field_parquet_schema_path,
+                                physical_nested_path,
+                            ),
+                            id,
+                        );
+                    }
+                }
+            }
+        }
+        self.recurse_into_struct_field(field);
+        self.parquet_schema_path_stack.pop();
+    }
+
+    fn transform_map(&mut self, mtype: &'a MapType) {
+        self.parquet_schema_path_stack.push("key_value".to_string());
+        self.parquet_schema_path_stack.push("key".to_string());
+        self.transform_map_key(&mtype.key_type);
+        self.parquet_schema_path_stack.pop();
+        self.parquet_schema_path_stack.push("value".to_string());
+        self.transform_map_value(&mtype.value_type);
+        self.parquet_schema_path_stack.pop();
+        self.parquet_schema_path_stack.pop();
+    }
+
+    fn transform_array(&mut self, atype: &'a ArrayType) {
+        self.parquet_schema_path_stack.push("list".to_string());
+        self.parquet_schema_path_stack.push("element".to_string());
+        self.transform_array_element(&atype.element_type);
+        self.parquet_schema_path_stack.pop();
+        self.parquet_schema_path_stack.pop();
+    }
+
+    // Variant has its own internal struct (metadata/value) but the kernel parquet writer
+    // does not carry column-mapping IDs into it; skip recursion to avoid recording paths
+    // that don't correspond to parquet field IDs.
+    fn transform_variant(&mut self, _stype: &'a StructType) {}
+}
+
+/// Translate a `delta.columnMapping.nested.ids` key (e.g. `<phys>.key.element`) to its
+/// parquet_schema_path. The first segment of `physical_nested_path` is the field's physical
+/// name -- the same as the last segment of `field_parquet_schema_path` -- so we replace the
+/// whole prefix wholesale with `field_parquet_schema_path` and translate the remaining
+/// synthetic segments: `key`/`value` -> `key_value.key`/`key_value.value` (Map wrapper),
+/// `element` -> `list.element` (Array wrapper).
+fn translate_nested_path(
+    field_parquet_schema_path: &str,
+    physical_nested_path: &str,
+) -> String {
+    let segs: Vec<&str> = physical_nested_path.split('.').collect();
+    let mut out = field_parquet_schema_path.to_string();
+    for seg in &segs[1..] {
+        match *seg {
+            "key" => out.push_str(".key_value.key"),
+            "value" => out.push_str(".key_value.value"),
+            "element" => out.push_str(".list.element"),
+            other => panic!(
+                "unexpected nested-id path segment '{other}' in '{physical_nested_path}'"
+            ),
+        }
+    }
+    out
+}
+
 /// Find a top-level field by physical name in a parquet root schema, or `None` if absent.
-fn top_level_field<'a>(root: &'a ParquetType, name: &str) -> Option<&'a ParquetType> {
+fn find_top_level_field_in_parquet<'a>(
+    root: &'a ParquetType,
+    name: &str,
+) -> Option<&'a ParquetType> {
     root.get_fields()
         .iter()
         .find(|f| f.name() == name)
@@ -831,8 +893,11 @@ fn top_level_field<'a>(root: &'a ParquetType, name: &str) -> Option<&'a ParquetT
 
 /// Get the parquet physical type of a top-level field (looked up by physical name). Panics if
 /// the field is missing or is a group (i.e. not a primitive leaf).
-fn top_level_physical_type(root: &ParquetType, name: &str) -> ParquetPhysicalType {
-    let field = top_level_field(root, name)
+fn find_top_level_physical_type_in_parquet(
+    root: &ParquetType,
+    name: &str,
+) -> ParquetPhysicalType {
+    let field = find_top_level_field_in_parquet(root, name)
         .unwrap_or_else(|| panic!("top-level field {name} not found in parquet schema"));
     match field {
         ParquetType::PrimitiveType { physical_type, .. } => *physical_type,
@@ -842,11 +907,85 @@ fn top_level_physical_type(root: &ParquetType, name: &str) -> ParquetPhysicalTyp
     }
 }
 
-/// Collect every entry from `ids` whose path starts with `prefix.` or equals `prefix`. Used to
-/// count field-id-bearing nodes under a nested column.
-fn collect_paths_with_prefix(ids: &HashMap<String, i64>, prefix: &str) -> Vec<String> {
-    ids.keys()
-        .filter(|k| k.as_str() == prefix || k.starts_with(&format!("{prefix}.")))
-        .cloned()
-        .collect()
+/// Run a full scan and assert exact `(region, int_col, bool_col)` content for every row, plus
+/// that `variant_col` and `complex` are entirely null. `int_col` derives from the writer's
+/// `random_seed`, so the expected list is reproduced by replaying the same seeds (0..4) and
+/// regions; sorting both sides by `(region, int_col)` makes the comparison order-independent.
+fn verify_scan_contents(
+    snapshot: Arc<Snapshot>,
+    engine: Arc<DefaultEngine<TokioMultiThreadExecutor>>,
+) {
+    let scan = snapshot.scan_builder().build().unwrap();
+    let mut rows: Vec<(String, i32, bool)> = Vec::new();
+    let mut variant_null_count = 0_usize;
+    let mut complex_null_count = 0_usize;
+    let mut total_rows = 0_usize;
+
+    for res in scan.execute(engine).unwrap() {
+        let raw = res.unwrap();
+        let batch: RecordBatch = ArrowEngineData::try_from_engine_data(raw)
+            .unwrap()
+            .record_batch()
+            .clone();
+
+        let region_arr = batch
+            .column_by_name("region")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .expect("region column missing or wrong type");
+        let int_arr = batch
+            .column_by_name("int_col")
+            .and_then(|c| c.as_any().downcast_ref::<Int32Array>())
+            .expect("int_col column missing or wrong type");
+        let bool_arr = batch
+            .column_by_name("bool_col")
+            .and_then(|c| c.as_any().downcast_ref::<BooleanArray>())
+            .expect("bool_col column missing or wrong type");
+        let variant_arr = batch
+            .column_by_name("variant_col")
+            .expect("variant_col column missing");
+        let complex_arr = batch
+            .column_by_name("complex")
+            .expect("complex column missing");
+
+        for i in 0..batch.num_rows() {
+            rows.push((
+                region_arr.value(i).to_string(),
+                int_arr.value(i),
+                bool_arr.value(i),
+            ));
+            if variant_arr.is_null(i) {
+                variant_null_count += 1;
+            }
+            if complex_arr.is_null(i) {
+                complex_null_count += 1;
+            }
+            total_rows += 1;
+        }
+    }
+
+    // Sort by (region, int_col): same `random_seed` produces equal `int_col` across regions,
+    // so `(region, int_col)` is the unique row key.
+    rows.sort();
+
+    let mut expected: Vec<(String, i32, bool)> = Vec::new();
+    for random_seed in 0..4_i32 {
+        for region in PARTITION_REGIONS {
+            for i in 0..ROWS_PER_PARTITION {
+                expected.push((region.to_string(), random_seed + i, i % 2 == 0));
+            }
+        }
+    }
+    expected.sort();
+
+    let total_expected = expected.len();
+    assert_eq!(rows, expected, "scan contents mismatch");
+    assert_eq!(total_rows, total_expected);
+    assert_eq!(
+        variant_null_count, total_expected,
+        "all variant_col values must be null",
+    );
+    assert_eq!(
+        complex_null_count, total_expected,
+        "all complex (map) values must be null",
+    );
 }

--- a/kernel/tests/integration/features/iceberg_compat.rs
+++ b/kernel/tests/integration/features/iceberg_compat.rs
@@ -4,54 +4,41 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use delta_kernel::arrow::array::{
-    ArrayRef, BooleanArray, Int32Array, Int64Array, MapArray, RecordBatch, StringArray, StructArray,
+    ArrayRef, BinaryArray, BooleanArray, Date32Array, Decimal128Array, Float32Array, Float64Array,
+    Int16Array, Int32Array, Int64Array, Int8Array, MapArray, RecordBatch, StringArray, StructArray,
+    TimestampMicrosecondArray,
 };
-use delta_kernel::arrow::buffer::OffsetBuffer;
+use delta_kernel::arrow::buffer::{NullBuffer, OffsetBuffer};
 use delta_kernel::arrow::datatypes::{
     DataType as ArrowDataType, Field as ArrowField, Fields, Schema as ArrowSchema,
 };
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::engine::arrow_conversion::{TryFromKernel, TryIntoArrow as _};
 use delta_kernel::engine::arrow_data::ArrowEngineData;
-use delta_kernel::engine::default::executor::tokio::TokioBackgroundExecutor;
+use delta_kernel::engine::default::executor::tokio::{
+    TokioBackgroundExecutor, TokioMultiThreadExecutor,
+};
 use delta_kernel::engine::default::{DefaultEngine, DefaultEngineBuilder};
+use delta_kernel::expressions::{ColumnName, Scalar};
+use delta_kernel::object_store::local::LocalFileSystem;
 use delta_kernel::object_store::memory::InMemory;
+use delta_kernel::object_store::DynObjectStore;
+use delta_kernel::parquet::basic::Type as ParquetPhysicalType;
+use delta_kernel::parquet::schema::types::Type as ParquetType;
 use delta_kernel::schema::{
     ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, StructField, StructType,
 };
 use delta_kernel::snapshot::Snapshot;
+use delta_kernel::table_features::{get_any_level_column_physical_name, ColumnMappingMode};
 use delta_kernel::transaction::create_table::create_table;
+use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::EngineData;
-use test_utils::{add_commit, write_batch_to_table};
+use test_utils::{add_commit, read_add_infos, test_table_setup_mt, write_batch_to_table};
+use url::Url;
+
+use crate::common::write_utils::{collect_all_parquet_field_ids, read_parquet_root_schema};
 
 const TABLE_ROOT: &str = "memory:///";
-
-fn make_engine() -> (Arc<InMemory>, Arc<DefaultEngine<TokioBackgroundExecutor>>) {
-    let storage = Arc::new(InMemory::new());
-    let engine =
-        Arc::new(DefaultEngineBuilder::<TokioBackgroundExecutor>::new(storage.clone()).build());
-    (storage, engine)
-}
-
-fn v3_table_properties() -> Vec<(&'static str, &'static str)> {
-    vec![
-        ("delta.enableIcebergCompatV3", "true"),
-        ("delta.columnMapping.mode", "name"),
-        ("delta.enableRowTracking", "true"),
-    ]
-}
-
-fn simple_schema() -> Arc<StructType> {
-    Arc::new(
-        StructType::try_new(vec![
-            StructField::nullable("id", DataType::INTEGER),
-            StructField::nullable("name", DataType::STRING),
-        ])
-        .unwrap(),
-    )
-}
-
-// === Test 1: legacy `parquet.field.nested.ids` on a V3 table is rejected at snapshot load ===
 
 /// Hand-crafts a V0 create commit on an icebergCompatV3 table whose `data` field carries the
 /// deprecated `parquet.field.nested.ids` metadata. Loading the snapshot must fail because the
@@ -59,7 +46,7 @@ fn simple_schema() -> Arc<StructType> {
 #[tokio::test]
 async fn snapshot_blocked_when_v3_schema_has_legacy_nested_ids() {
     let (storage, engine) = make_engine();
-
+    // Create table doesn't support the legacy nested ids metadata, so we hand-craft a V0 commit.
     let nested_ids_legacy = serde_json::json!({
         "data.key": 100,
         "data.value": 101,
@@ -151,12 +138,362 @@ async fn snapshot_blocked_when_v3_schema_has_legacy_nested_ids() {
     );
 }
 
-// === Test 2: V3 add_files without `stats.numRecords` is rejected at commit ===
+#[rstest::rstest]
+#[case::missing_num_records(None/* num_records */, Err("'stats.numRecords' is required"))]
+#[case::with_num_records(Some(3), Ok(1))]
+#[tokio::test]
+async fn v3_commit_validates_num_records(
+    #[case] num_records: Option<i64>,
+    #[case] expected: Result<u64, &'static str>,
+) {
+    let (_, engine) = make_engine();
 
-/// Build add_files metadata for one synthetic file whose `stats` carries every required field
-/// EXCEPT `numRecords` (which is null), matching the schema returned by
-/// `Transaction::add_files_schema()`.
-fn add_files_metadata_without_num_records(arrow_schema: &ArrowSchema) -> Box<dyn EngineData> {
+    let _ = create_table(TABLE_ROOT, simple_schema(), "Test/1.0")
+        .with_table_properties(v3_table_properties())
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))
+        .unwrap()
+        .commit(engine.as_ref())
+        .unwrap();
+    let snapshot = Snapshot::builder_for(TABLE_ROOT)
+        .build(engine.as_ref())
+        .unwrap();
+
+    let mut txn = snapshot
+        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())
+        .unwrap()
+        .with_engine_info("Test/1.0")
+        .with_data_change(true);
+    let add_schema = ArrowSchema::try_from_kernel(txn.add_files_schema().as_ref()).unwrap();
+    txn.add_files(synthetic_add_files_metadata(&add_schema, num_records));
+
+    match expected {
+        Ok(expected_version) => {
+            let committed = txn.commit(engine.as_ref()).unwrap().unwrap_committed();
+            assert_eq!(committed.commit_version(), expected_version);
+        }
+        Err(needle) => {
+            let err = txn.commit(engine.as_ref()).unwrap_err().to_string();
+            assert!(
+                err.contains(needle) && err.contains("part-fake.parquet"),
+                "expected error containing {needle:?} and 'part-fake.parquet', got: {err}",
+            );
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn write_succeeds_on_v3_table() {
+    let (_, engine) = make_engine();
+
+    let schema = simple_schema();
+    let _ = create_table(TABLE_ROOT, schema.clone(), "Test/1.0")
+        .with_table_properties(v3_table_properties())
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))
+        .unwrap()
+        .commit(engine.as_ref())
+        .unwrap();
+    let snapshot = Snapshot::builder_for(TABLE_ROOT)
+        .build(engine.as_ref())
+        .unwrap();
+
+    // Real write through the default engine: stats are auto-collected and include numRecords.
+    let arrow_schema: ArrowSchema = (schema.as_ref()).try_into_arrow().unwrap();
+    let id_col: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+    let name_col: ArrayRef = Arc::new(StringArray::from(vec!["a", "b", "c"]));
+    let batch = RecordBatch::try_new(Arc::new(arrow_schema), vec![id_col, name_col]).unwrap();
+
+    let new_snapshot = write_batch_to_table(&snapshot, engine.as_ref(), batch, HashMap::new())
+        .await
+        .expect("V3 write should succeed");
+    assert_eq!(new_snapshot.version(), 1);
+}
+
+/// End-to-end V3 round-trip on a partitioned table with a kitchen-sink schema:
+///
+/// - Schema covers every primitive Delta type plus an unshredded VARIANT and a deeply nested
+///   `map<list<int>, struct<inner_map: map<list<int>, int>, n: int>>` column.
+/// - Partition column is `region: STRING`. V3 forces partition values to be materialized into the
+///   parquet data files (no `MaterializePartitionColumns` flag needed).
+/// - Two parameterized cases:
+///     - `min`: only `delta.enableIcebergCompatV3=true` (auto-pulls columnMapping=name,
+///       rowTracking, domainMetadata; the schema auto-pulls timestampNtz + variantType). Checkpoint
+///       at version 2 lands as a V1 single-parquet checkpoint.
+///     - `max`: same as `min` plus `delta.feature.{deletionVectors, v2Checkpoint,
+///       inCommitTimestamp, vacuumProtocolCheck}=supported`. Checkpoint at version 2 lands as a V2
+///       multi-part checkpoint.
+/// - Four commits, each writing 2 partitions x 3 rows = 6 rows. A checkpoint runs after commits
+///   1-2; commits 3-4 land after the checkpoint.
+///
+/// Validations after the final write:
+///   1. Protocol contains the expected reader/writer features for the case.
+///   2. Every parquet data file has `field_id` set on every leaf, including map keys/values and
+///      list elements. The total number of field-id-bearing nodes equals the count of typed leaves
+///      in the kernel schema (15 + 3 nested-map leaves).
+///   3. The partition column is physically materialized in each data file.
+///   4. `ts` (TIMESTAMP) and `ts_ntz` (TIMESTAMP_NTZ) are written with parquet physical type INT64
+///      (microseconds).
+///   5. A full scan returns all 24 rows.
+///   6. Parquet field IDs match `delta.columnMapping.id` from the table schema for every top-level
+///      column and for the nested map/list leaves of `complex`.
+#[rstest::rstest]
+#[case::min(false)]
+#[case::max(true)]
+#[tokio::test(flavor = "multi_thread")]
+async fn v3_e2e_partitioned_writes_with_field_ids(#[case] max_features: bool) {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    // === Setup: filesystem-backed engine on a temp dir ===
+    let (_tmp_dir, table_path, _) = test_table_setup_mt().unwrap();
+    let table_url = Url::from_directory_path(&table_path).unwrap();
+    let store: Arc<DynObjectStore> = Arc::new(LocalFileSystem::new());
+    let engine = Arc::new(
+        DefaultEngineBuilder::new(store.clone())
+            .with_task_executor(Arc::new(TokioMultiThreadExecutor::new(
+                tokio::runtime::Handle::current(),
+            )))
+            .build(),
+    );
+
+    // === Create partitioned V3 table ===
+    let schema = kitchen_sink_schema();
+    let mut props: Vec<(&str, &str)> = vec![
+        ("delta.enableIcebergCompatV3", "true"),
+        ("delta.columnMapping.mode", "name"),
+        ("delta.enableRowTracking", "true"),
+    ];
+    if max_features {
+        props.extend([
+            ("delta.feature.deletionVectors", "supported"),
+            ("delta.feature.v2Checkpoint", "supported"),
+            ("delta.feature.inCommitTimestamp", "supported"),
+            ("delta.feature.vacuumProtocolCheck", "supported"),
+        ]);
+    }
+    let _ = create_table(&table_path, schema.clone(), "Test/1.0")
+        .with_table_properties(props)
+        .with_data_layout(DataLayout::partitioned(["region"]))
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))
+        .unwrap()
+        .commit(engine.as_ref())
+        .unwrap();
+
+    // === 2 commits, then checkpoint, then 2 more commits ===
+    for commit_idx in 0..2_i32 {
+        write_partitioned_v3_commit(&table_url, engine.clone(), &schema, commit_idx).await;
+    }
+    Snapshot::builder_for(table_url.clone())
+        .build(engine.as_ref())
+        .unwrap()
+        .checkpoint(engine.as_ref(), None)
+        .unwrap();
+    for commit_idx in 2..4_i32 {
+        write_partitioned_v3_commit(&table_url, engine.clone(), &schema, commit_idx).await;
+    }
+
+    let final_snap = Snapshot::builder_for(table_url.clone())
+        .build(engine.as_ref())
+        .unwrap();
+
+    // === (1) Protocol features ===
+    let protocol = final_snap.table_configuration().protocol();
+    let writer_features: Vec<String> = protocol
+        .writer_features()
+        .expect("V3 table must publish writerFeatures")
+        .iter()
+        .map(|f| f.as_ref().to_string())
+        .collect();
+    for f in [
+        "icebergCompatV3",
+        "columnMapping",
+        "rowTracking",
+        "domainMetadata",
+        "timestampNtz",
+        "variantType",
+    ] {
+        assert!(
+            writer_features.iter().any(|w| w == f),
+            "writerFeatures missing {f}; got {writer_features:?}",
+        );
+    }
+    if max_features {
+        for f in [
+            "deletionVectors",
+            "v2Checkpoint",
+            "inCommitTimestamp",
+            "vacuumProtocolCheck",
+        ] {
+            assert!(
+                writer_features.iter().any(|w| w == f),
+                "writerFeatures missing {f} for max case; got {writer_features:?}",
+            );
+        }
+    }
+    assert_eq!(
+        final_snap
+            .table_properties()
+            .column_mapping_mode
+            .unwrap_or(ColumnMappingMode::None),
+        ColumnMappingMode::Name,
+    );
+
+    // === (2)-(4) Per-data-file validations ===
+    let add_actions = read_add_infos(&final_snap, engine.as_ref()).unwrap();
+    assert_eq!(
+        add_actions.len(),
+        8,
+        "expected 4 commits x 2 partitions = 8 add files",
+    );
+    for add in &add_actions {
+        let parquet_url = table_url.join(&add.path).unwrap();
+        let local_path = parquet_url.to_file_path().unwrap();
+        let ids = collect_all_parquet_field_ids(&local_path);
+
+        // Field IDs match column mapping IDs from the logical schema for top-level columns.
+        let logical_schema = final_snap.schema();
+        for field in logical_schema.fields() {
+            let physical = get_any_level_column_physical_name(
+                logical_schema.as_ref(),
+                &ColumnName::new([field.name()]),
+                ColumnMappingMode::Name,
+            )
+            .unwrap()
+            .into_inner();
+            let id_in_parquet = ids.get(&physical[0]).copied().unwrap_or_else(|| {
+                panic!(
+                    "missing field_id for top-level column {} (physical {:?}) in {}",
+                    field.name(),
+                    physical,
+                    parquet_url
+                )
+            });
+            let expected = field.column_mapping_id().unwrap_or_else(|| {
+                panic!(
+                    "logical field {} missing column mapping id; metadata: {:?}",
+                    field.name(),
+                    field.metadata()
+                )
+            });
+            assert_eq!(
+                id_in_parquet,
+                expected,
+                "parquet field_id mismatch for top-level {}: parquet={id_in_parquet}, schema={expected}",
+                field.name()
+            );
+        }
+
+        // Field IDs are present on every leaf inside the deeply nested `complex` column.
+        // The leaves below correspond to: outer map key (list<int>) -> int element,
+        // outer map value (struct) -> inner_map key (list<int>) -> int element,
+        // outer map value -> inner_map value (int), outer map value -> n (int).
+        let complex_physical = get_any_level_column_physical_name(
+            logical_schema.as_ref(),
+            &ColumnName::new(["complex"]),
+            ColumnMappingMode::Name,
+        )
+        .unwrap()
+        .into_inner();
+        let complex_paths = collect_paths_with_prefix(&ids, &complex_physical[0]);
+        assert!(
+            complex_paths.len() >= 7,
+            "expected >=7 field-id-bearing nodes under `complex` (physical {complex_physical:?}), got {complex_paths:?}",
+        );
+
+        // Partition column physically materialized in each data file (V3 invariant).
+        let region_physical = get_any_level_column_physical_name(
+            logical_schema.as_ref(),
+            &ColumnName::new(["region"]),
+            ColumnMappingMode::Name,
+        )
+        .unwrap()
+        .into_inner();
+        let root = read_parquet_root_schema(&local_path);
+        assert!(
+            top_level_field(&root, &region_physical[0]).is_some(),
+            "partition column `region` (physical {region_physical:?}) is not materialized in {parquet_url}",
+        );
+
+        // ts / ts_ntz physical type is INT64.
+        let ts_physical = get_any_level_column_physical_name(
+            logical_schema.as_ref(),
+            &ColumnName::new(["ts"]),
+            ColumnMappingMode::Name,
+        )
+        .unwrap()
+        .into_inner();
+        let ts_ntz_physical = get_any_level_column_physical_name(
+            logical_schema.as_ref(),
+            &ColumnName::new(["ts_ntz"]),
+            ColumnMappingMode::Name,
+        )
+        .unwrap()
+        .into_inner();
+        assert_eq!(
+            top_level_physical_type(&root, &ts_physical[0]),
+            ParquetPhysicalType::INT64,
+            "ts must be INT64 in parquet",
+        );
+        assert_eq!(
+            top_level_physical_type(&root, &ts_ntz_physical[0]),
+            ParquetPhysicalType::INT64,
+            "ts_ntz must be INT64 in parquet",
+        );
+    }
+
+    // === (5) Scan returns all 24 rows ===
+    let scan = final_snap.scan_builder().build().unwrap();
+    let total_rows: usize = scan
+        .execute(engine.clone())
+        .unwrap()
+        .map(|res| -> usize {
+            let raw = res.unwrap();
+            let batch: RecordBatch = ArrowEngineData::try_from_engine_data(raw)
+                .unwrap()
+                .record_batch()
+                .clone();
+            batch.num_rows()
+        })
+        .sum();
+    assert_eq!(
+        total_rows, 24,
+        "expected 4 commits x 2 partitions x 3 rows = 24 rows",
+    );
+}
+
+// === Helpers ===
+
+fn make_engine() -> (Arc<InMemory>, Arc<DefaultEngine<TokioBackgroundExecutor>>) {
+    let storage = Arc::new(InMemory::new());
+    let engine =
+        Arc::new(DefaultEngineBuilder::<TokioBackgroundExecutor>::new(storage.clone()).build());
+    (storage, engine)
+}
+
+fn v3_table_properties() -> Vec<(&'static str, &'static str)> {
+    vec![
+        ("delta.enableIcebergCompatV3", "true"),
+        ("delta.columnMapping.mode", "name"),
+        ("delta.enableRowTracking", "true"),
+    ]
+}
+
+fn simple_schema() -> Arc<StructType> {
+    Arc::new(
+        StructType::try_new(vec![
+            StructField::nullable("id", DataType::INTEGER),
+            StructField::nullable("name", DataType::STRING),
+        ])
+        .unwrap(),
+    )
+}
+
+/// Build add_files metadata for one synthetic file matching the schema returned by
+/// `Transaction::add_files_schema()`. `num_records` controls the `stats.numRecords` field
+/// (`None` -> NULL, `Some(n)` -> `n`); the other stats fields are populated with empty
+/// structs / `tightBounds=true`.
+fn synthetic_add_files_metadata(
+    arrow_schema: &ArrowSchema,
+    num_records: Option<i64>,
+) -> Box<dyn EngineData> {
     let path_array = StringArray::from(vec!["part-fake.parquet"]);
     let size_array = Int64Array::from(vec![1024_i64]);
     let mod_time_array = Int64Array::from(vec![1_000_000_i64]);
@@ -190,13 +527,12 @@ fn add_files_metadata_without_num_records(arrow_schema: &ArrowSchema) -> Box<dyn
         false,
     ));
 
-    // stats: numRecords=NULL, empty nullCount/minValues/maxValues structs, tightBounds=true.
     let empty_struct_fields: Fields = Vec::<Arc<ArrowField>>::new().into();
     let empty_struct = StructArray::new_empty_fields(1, None);
     let stats_struct = StructArray::from(vec![
         (
             Arc::new(ArrowField::new("numRecords", ArrowDataType::Int64, true)),
-            Arc::new(Int64Array::from(vec![None as Option<i64>])) as ArrayRef,
+            Arc::new(Int64Array::from(vec![num_records])) as ArrayRef,
         ),
         (
             Arc::new(ArrowField::new(
@@ -243,60 +579,274 @@ fn add_files_metadata_without_num_records(arrow_schema: &ArrowSchema) -> Box<dyn
     Box::new(ArrowEngineData::new(batch))
 }
 
-#[tokio::test]
-async fn write_blocked_when_v3_add_lacks_num_records() {
-    let (_, engine) = make_engine();
+/// Schema covering every primitive Delta type plus an unshredded VARIANT and a deeply nested
+/// map<list<int>, struct<inner_map: map<list<int>, int>, n: int>> column. `region` is the
+/// partition column.
+fn kitchen_sink_schema() -> Arc<StructType> {
+    let inner_struct = StructType::try_new(vec![
+        StructField::nullable(
+            "inner_map",
+            DataType::Map(Box::new(MapType::new(
+                DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+                DataType::INTEGER,
+                true,
+            ))),
+        ),
+        StructField::nullable("n", DataType::INTEGER),
+    ])
+    .unwrap();
 
-    let _ = create_table(TABLE_ROOT, simple_schema(), "Test/1.0")
-        .with_table_properties(v3_table_properties())
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))
-        .unwrap()
-        .commit(engine.as_ref())
-        .unwrap();
-    let snapshot = Snapshot::builder_for(TABLE_ROOT)
+    Arc::new(
+        StructType::try_new(vec![
+            StructField::nullable("region", DataType::STRING),
+            StructField::nullable("id", DataType::INTEGER),
+            StructField::nullable("b", DataType::BOOLEAN),
+            StructField::nullable("byte_c", DataType::BYTE),
+            StructField::nullable("short_c", DataType::SHORT),
+            StructField::nullable("long_c", DataType::LONG),
+            StructField::nullable("f", DataType::FLOAT),
+            StructField::nullable("d", DataType::DOUBLE),
+            StructField::nullable("dec", DataType::decimal(10, 2).unwrap()),
+            StructField::nullable("s", DataType::STRING),
+            StructField::nullable("bin", DataType::BINARY),
+            StructField::nullable("date_c", DataType::DATE),
+            StructField::nullable("ts", DataType::TIMESTAMP),
+            StructField::nullable("ts_ntz", DataType::TIMESTAMP_NTZ),
+            StructField::nullable("v", DataType::unshredded_variant()),
+            StructField::nullable(
+                "complex",
+                DataType::Map(Box::new(MapType::new(
+                    DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+                    DataType::Struct(Box::new(inner_struct)),
+                    true,
+                ))),
+            ),
+        ])
+        .unwrap(),
+    )
+}
+
+/// Build a 3-row record batch for the partition `region`. Column data is keyed off `commit_idx`
+/// so different commits produce distinguishable rows. The deeply nested `complex` column and
+/// the `v` (VARIANT) column are written as all-null -- this exercises the schema (field IDs
+/// at every nested leaf) without requiring per-row binary/struct construction.
+///
+/// V3 materializes partition values into data files, so the `region` column is included in
+/// the data with the partition value repeated for every row.
+fn build_partition_batch(
+    schema: &StructType,
+    commit_idx: i32,
+    region: &str,
+    rows: usize,
+) -> RecordBatch {
+    let n = rows as i32;
+    let base = commit_idx * 100
+        + match region {
+            "a" => 0,
+            "b" => 50,
+            _ => panic!("unsupported region {region}"),
+        };
+
+    let arrow_schema: ArrowSchema = schema.try_into_arrow().unwrap();
+
+    let region_col: ArrayRef = Arc::new(StringArray::from(vec![region; rows]));
+    let id: ArrayRef = Arc::new(Int32Array::from(
+        (0..n).map(|i| base + i).collect::<Vec<_>>(),
+    ));
+    let b: ArrayRef = Arc::new(BooleanArray::from(
+        (0..rows).map(|i| i % 2 == 0).collect::<Vec<_>>(),
+    ));
+    let byte_c: ArrayRef = Arc::new(Int8Array::from(
+        (0..n).map(|i| (base + i) as i8).collect::<Vec<_>>(),
+    ));
+    let short_c: ArrayRef = Arc::new(Int16Array::from(
+        (0..n).map(|i| (base + i) as i16).collect::<Vec<_>>(),
+    ));
+    let long_c: ArrayRef = Arc::new(Int64Array::from(
+        (0..n).map(|i| (base + i) as i64).collect::<Vec<_>>(),
+    ));
+    let f: ArrayRef = Arc::new(Float32Array::from(
+        (0..n).map(|i| (base + i) as f32 + 0.5).collect::<Vec<_>>(),
+    ));
+    let d: ArrayRef = Arc::new(Float64Array::from(
+        (0..n).map(|i| (base + i) as f64 + 0.25).collect::<Vec<_>>(),
+    ));
+    // Decimal(10, 2): values stored as scaled i128.
+    let dec: ArrayRef = Arc::new(
+        Decimal128Array::from((0..n).map(|i| (base + i) as i128 * 100).collect::<Vec<_>>())
+            .with_precision_and_scale(10, 2)
+            .unwrap(),
+    );
+    let s: ArrayRef = Arc::new(StringArray::from(
+        (0..rows)
+            .map(|i| format!("s-{base}-{i}"))
+            .collect::<Vec<_>>(),
+    ));
+    let bin: ArrayRef = Arc::new(BinaryArray::from_iter_values(
+        (0..rows).map(|i| vec![(base as u8).wrapping_add(i as u8)]),
+    ));
+    // Days since 1970-01-01.
+    let date_c: ArrayRef = Arc::new(Date32Array::from(
+        (0..n).map(|i| 19000 + base + i).collect::<Vec<_>>(),
+    ));
+    // Microseconds since epoch: TIMESTAMP carries UTC ("+00:00"), TIMESTAMP_NTZ has no zone.
+    let ts: ArrayRef = Arc::new(
+        TimestampMicrosecondArray::from(
+            (0..n)
+                .map(|i| 1_700_000_000_000_000_i64 + (base + i) as i64)
+                .collect::<Vec<_>>(),
+        )
+        .with_timezone("UTC"),
+    );
+    let ts_ntz: ArrayRef = Arc::new(TimestampMicrosecondArray::from(
+        (0..n)
+            .map(|i| 1_700_000_000_000_000_i64 + (base + i) as i64 + 1)
+            .collect::<Vec<_>>(),
+    ));
+    let v: ArrayRef = build_all_null_variant_array(rows);
+    let complex: ArrayRef = build_all_null_complex_array(schema, rows);
+
+    RecordBatch::try_new(
+        Arc::new(arrow_schema),
+        vec![
+            region_col, id, b, byte_c, short_c, long_c, f, d, dec, s, bin, date_c, ts, ts_ntz, v,
+            complex,
+        ],
+    )
+    .unwrap()
+}
+
+/// Builds an all-null unshredded variant column (struct<metadata: binary, value: binary>) of
+/// length `rows`. Mirrors the shape used by `test_append_variant`. The struct fields are
+/// non-null physically (kernel's unshredded variant schema marks them required), so we provide
+/// empty placeholder bytes for every row and rely on the outer null bitmap to mark all rows
+/// null at the variant level.
+fn build_all_null_variant_array(rows: usize) -> ArrayRef {
+    let metadata_bytes: Vec<&[u8]> = (0..rows).map(|_| &[0x01, 0x00, 0x00][..]).collect();
+    let value_bytes: Vec<&[u8]> = (0..rows).map(|_| &[0x0C, 0x01][..]).collect();
+    let null_bitmap = NullBuffer::from(vec![false; rows]);
+    let metadata_arr: ArrayRef = Arc::new(BinaryArray::from(metadata_bytes));
+    let value_arr: ArrayRef = Arc::new(BinaryArray::from(value_bytes));
+    let arrow_variant: ArrowDataType =
+        ArrowDataType::try_from_kernel(&DataType::unshredded_variant()).unwrap();
+    let fields = match arrow_variant {
+        ArrowDataType::Struct(fields) => fields,
+        _ => panic!("variant arrow type must be struct"),
+    };
+    Arc::new(
+        StructArray::try_new(fields, vec![metadata_arr, value_arr], Some(null_bitmap)).unwrap(),
+    )
+}
+
+/// Builds an all-null `complex` MapArray matching the kitchen-sink schema's `complex` field.
+/// All `rows` map entries are null; the underlying entries struct is empty. This is enough to
+/// exercise schema/field-id paths through the deeply nested type without per-row construction.
+fn build_all_null_complex_array(schema: &StructType, rows: usize) -> ArrayRef {
+    let complex_field = schema
+        .fields()
+        .find(|f| f.name() == "complex")
+        .expect("schema must include `complex`");
+    let arrow_field: ArrowField = complex_field.try_into_arrow().unwrap();
+    let (entries_field, _sorted) = match arrow_field.data_type() {
+        ArrowDataType::Map(entries, sorted) => (entries.clone(), *sorted),
+        other => panic!("complex must be a Map type, got {other:?}"),
+    };
+    let entries_struct_fields = match entries_field.data_type() {
+        ArrowDataType::Struct(fields) => fields.clone(),
+        other => panic!("map entries must be struct, got {other:?}"),
+    };
+    // Empty entries struct: no rows since every map is null.
+    let empty_entries = StructArray::new(
+        entries_struct_fields,
+        entries_field_arrays_empty(entries_field.as_ref()),
+        None,
+    );
+    let offsets = OffsetBuffer::from_lengths(vec![0_usize; rows]);
+    let nulls = NullBuffer::from(vec![false; rows]);
+    Arc::new(MapArray::new(
+        entries_field,
+        offsets,
+        empty_entries,
+        Some(nulls),
+        false,
+    ))
+}
+
+/// Produce empty arrays for each field of a map's `entries` struct. Each array has length 0
+/// and matches the field's declared arrow data type. Recurses into nested struct/list/map
+/// types via Arrow's `new_empty_array` factory.
+fn entries_field_arrays_empty(entries_field: &ArrowField) -> Vec<ArrayRef> {
+    match entries_field.data_type() {
+        ArrowDataType::Struct(fields) => fields
+            .iter()
+            .map(|f| delta_kernel::arrow::array::new_empty_array(f.data_type()))
+            .collect(),
+        other => panic!("expected struct entries, got {other:?}"),
+    }
+}
+
+/// Open a transaction on `table_url`, write 2 partitions x 3 rows (regions "a" and "b") via the
+/// engine's parquet handler, and commit. Stats and `numRecords` are auto-collected by the
+/// default engine, so the V3 numRecords invariant is satisfied.
+async fn write_partitioned_v3_commit(
+    table_url: &Url,
+    engine: Arc<DefaultEngine<TokioMultiThreadExecutor>>,
+    schema: &StructType,
+    commit_idx: i32,
+) {
+    let snapshot = Snapshot::builder_for(table_url.clone())
         .build(engine.as_ref())
         .unwrap();
-
     let mut txn = snapshot
         .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())
         .unwrap()
-        .with_engine_info("Test/1.0")
+        .with_engine_info(format!("Test/v3-commit-{commit_idx}"))
         .with_data_change(true);
-    let add_schema = ArrowSchema::try_from_kernel(txn.add_files_schema().as_ref()).unwrap();
-    txn.add_files(add_files_metadata_without_num_records(&add_schema));
 
-    let err = txn.commit(engine.as_ref()).unwrap_err().to_string();
-    assert!(
-        err.contains("'stats.numRecords' is required") && err.contains("part-fake.parquet"),
-        "expected numRecords-missing error, got: {err}",
-    );
+    // Each partition gets its own write_parquet call with a partitioned WriteContext.
+    for region in ["a", "b"] {
+        let batch = build_partition_batch(schema, commit_idx, region, 3 /* rows */);
+        let write_context = txn
+            .partitioned_write_context(HashMap::from([(
+                "region".to_string(),
+                Scalar::String(region.to_string()),
+            )]))
+            .unwrap();
+        let add_files = engine
+            .write_parquet(&ArrowEngineData::new(batch), &write_context)
+            .await
+            .unwrap();
+        txn.add_files(add_files);
+    }
+    let _ = txn.commit(engine.as_ref()).unwrap().unwrap_committed();
 }
 
-// === Test 3: V3 happy path: create + write commits successfully ===
+/// Find a top-level field by physical name in a parquet root schema, or `None` if absent.
+fn top_level_field<'a>(root: &'a ParquetType, name: &str) -> Option<&'a ParquetType> {
+    root.get_fields()
+        .iter()
+        .find(|f| f.name() == name)
+        .map(|f| f.as_ref())
+}
 
-#[tokio::test(flavor = "multi_thread")]
-async fn write_succeeds_on_v3_table() {
-    let (_, engine) = make_engine();
+/// Get the parquet physical type of a top-level field (looked up by physical name). Panics if
+/// the field is missing or is a group (i.e. not a primitive leaf).
+fn top_level_physical_type(root: &ParquetType, name: &str) -> ParquetPhysicalType {
+    let field = top_level_field(root, name)
+        .unwrap_or_else(|| panic!("top-level field {name} not found in parquet schema"));
+    match field {
+        ParquetType::PrimitiveType { physical_type, .. } => *physical_type,
+        ParquetType::GroupType { .. } => {
+            panic!("top-level field {name} is a group, expected primitive leaf")
+        }
+    }
+}
 
-    let schema = simple_schema();
-    let _ = create_table(TABLE_ROOT, schema.clone(), "Test/1.0")
-        .with_table_properties(v3_table_properties())
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))
-        .unwrap()
-        .commit(engine.as_ref())
-        .unwrap();
-    let snapshot = Snapshot::builder_for(TABLE_ROOT)
-        .build(engine.as_ref())
-        .unwrap();
-
-    // Real write through the default engine: stats are auto-collected and include numRecords.
-    let arrow_schema: ArrowSchema = (schema.as_ref()).try_into_arrow().unwrap();
-    let id_col: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
-    let name_col: ArrayRef = Arc::new(StringArray::from(vec!["a", "b", "c"]));
-    let batch = RecordBatch::try_new(Arc::new(arrow_schema), vec![id_col, name_col]).unwrap();
-
-    let new_snapshot = write_batch_to_table(&snapshot, engine.as_ref(), batch, HashMap::new())
-        .await
-        .expect("V3 write should succeed");
-    assert_eq!(new_snapshot.version(), 1);
+/// Collect every entry from `ids` whose path starts with `prefix.` or equals `prefix`. Used to
+/// count field-id-bearing nodes under a nested column.
+fn collect_paths_with_prefix(ids: &HashMap<String, i64>, prefix: &str) -> Vec<String> {
+    ids.keys()
+        .filter(|k| k.as_str() == prefix || k.starts_with(&format!("{prefix}.")))
+        .cloned()
+        .collect()
 }

--- a/kernel/tests/integration/features/iceberg_compat.rs
+++ b/kernel/tests/integration/features/iceberg_compat.rs
@@ -235,11 +235,11 @@ async fn v3_create_table_rejects_incompatible_props(
 ///
 /// IcebergCompatV3 supports all delta types, so we use a schema with all delta types here.
 /// Two test cases:
-/// - `min`: minimum feature set. Enables only `delta.enableIcebergCompatV3=true` and relies on
-///   V3's auto-enablement of `columnMapping=name` + `rowTracking=true`.
+/// - `min`: minimum feature set. Enables only `delta.enableIcebergCompatV3=true` and relies on V3's
+///   auto-enablement of `columnMapping=name` + `rowTracking=true`.
 /// - `max`: maximum feature set we are able to enable through create table, with exceptions for:
-///   `materializePartitionColumns` (omitted so the partition-materialization check below proves
-///   V3 implies it), `typeWidening` (kernel rejects writes against tables declaring it), and
+///   `materializePartitionColumns` (omitted so the partition-materialization check below proves V3
+///   implies it), `typeWidening` (kernel rejects writes against tables declaring it), and
 ///   `catalogManaged` (requires a catalog committer).
 #[rstest::rstest]
 #[case::min(&[], &[])]
@@ -371,7 +371,8 @@ async fn v3_e2e_partitioned_writes_with_field_ids(
         );
 
         // Partition column is physically materialized (V3 invariant).
-        let region_physical = get_top_level_physical_name(logical_schema.as_ref(), "region", cm_mode);
+        let region_physical =
+            get_top_level_physical_name(logical_schema.as_ref(), "region", cm_mode);
         assert!(
             find_top_level_field_in_parquet(&root, &region_physical).is_some(),
             "partition column `region` (physical {region_physical}) not materialized in {parquet_url}",
@@ -463,9 +464,9 @@ fn complex_nested_data_type() -> DataType {
 const ROWS_PER_PARTITION: i32 = 3;
 const PARTITION_REGIONS: &[&str] = &["a", "b"];
 
-/// Build a [`RecordBatch`] with [`ROWS_PER_PARTITION`] rows for the given `region` following the schema of
-/// [`nested_schema_with_all_delta_types`]. `random_seed` is used directly to produce different values
-/// so different calls produce distinguishable rows;
+/// Build a [`RecordBatch`] with [`ROWS_PER_PARTITION`] rows for the given `region` following the
+/// schema of [`nested_schema_with_all_delta_types`]. `random_seed` is used directly to produce
+/// different values so different calls produce distinguishable rows;
 fn build_partition_batch(random_seed: i32, region: &str) -> RecordBatch {
     let rows = ROWS_PER_PARTITION as usize;
 
@@ -474,30 +475,44 @@ fn build_partition_batch(random_seed: i32, region: &str) -> RecordBatch {
 
     let region_partition_col: ArrayRef = Arc::new(StringArray::from(vec![region; rows]));
     let int_col: ArrayRef = Arc::new(Int32Array::from(
-        (0..ROWS_PER_PARTITION).map(|i| random_seed + i).collect::<Vec<_>>(),
+        (0..ROWS_PER_PARTITION)
+            .map(|i| random_seed + i)
+            .collect::<Vec<_>>(),
     ));
     let bool_col: ArrayRef = Arc::new(BooleanArray::from(
         (0..rows).map(|i| i % 2 == 0).collect::<Vec<_>>(),
     ));
     let byte_col: ArrayRef = Arc::new(Int8Array::from(
-        (0..ROWS_PER_PARTITION).map(|i| (random_seed + i) as i8).collect::<Vec<_>>(),
+        (0..ROWS_PER_PARTITION)
+            .map(|i| (random_seed + i) as i8)
+            .collect::<Vec<_>>(),
     ));
     let short_col: ArrayRef = Arc::new(Int16Array::from(
-        (0..ROWS_PER_PARTITION).map(|i| (random_seed + i) as i16).collect::<Vec<_>>(),
+        (0..ROWS_PER_PARTITION)
+            .map(|i| (random_seed + i) as i16)
+            .collect::<Vec<_>>(),
     ));
     let long_col: ArrayRef = Arc::new(Int64Array::from(
-        (0..ROWS_PER_PARTITION).map(|i| (random_seed + i) as i64).collect::<Vec<_>>(),
+        (0..ROWS_PER_PARTITION)
+            .map(|i| (random_seed + i) as i64)
+            .collect::<Vec<_>>(),
     ));
     let float_col: ArrayRef = Arc::new(Float32Array::from(
-        (0..ROWS_PER_PARTITION).map(|i| (random_seed + i) as f32 + 0.5).collect::<Vec<_>>(),
+        (0..ROWS_PER_PARTITION)
+            .map(|i| (random_seed + i) as f32 + 0.5)
+            .collect::<Vec<_>>(),
     ));
     let double_col: ArrayRef = Arc::new(Float64Array::from(
-        (0..ROWS_PER_PARTITION).map(|i| (random_seed + i) as f64 + 0.25).collect::<Vec<_>>(),
+        (0..ROWS_PER_PARTITION)
+            .map(|i| (random_seed + i) as f64 + 0.25)
+            .collect::<Vec<_>>(),
     ));
     // Decimal(10, 2): values stored as scaled i128.
     let decimal_col: ArrayRef = Arc::new(
         Decimal128Array::from(
-            (0..ROWS_PER_PARTITION).map(|i| (random_seed + i) as i128 * 100).collect::<Vec<_>>(),
+            (0..ROWS_PER_PARTITION)
+                .map(|i| (random_seed + i) as i128 * 100)
+                .collect::<Vec<_>>(),
         )
         .with_precision_and_scale(10, 2)
         .unwrap(),
@@ -512,7 +527,9 @@ fn build_partition_batch(random_seed: i32, region: &str) -> RecordBatch {
     ));
     // Days since 1970-01-01.
     let date_col: ArrayRef = Arc::new(Date32Array::from(
-        (0..ROWS_PER_PARTITION).map(|i| 19000 + random_seed + i).collect::<Vec<_>>(),
+        (0..ROWS_PER_PARTITION)
+            .map(|i| 19000 + random_seed + i)
+            .collect::<Vec<_>>(),
     ));
     // Microseconds since epoch: TIMESTAMP carries UTC ("+00:00"), TIMESTAMP_NTZ has no zone.
     let timestamp_col: ArrayRef = Arc::new(
@@ -576,8 +593,7 @@ fn build_all_null_variant_array(rows: usize) -> ArrayRef {
 /// Builds an all-null `complex` MapArray of length `rows` matching [`complex_nested_data_type`].
 /// All map entries are null; the underlying entries struct is empty.
 fn build_all_null_complex_array(rows: usize) -> ArrayRef {
-    let complex_arrow_type: ArrowDataType =
-        (&complex_nested_data_type()).try_into_arrow().unwrap();
+    let complex_arrow_type: ArrowDataType = (&complex_nested_data_type()).try_into_arrow().unwrap();
     let (entries_field, _sorted) = match complex_arrow_type {
         ArrowDataType::Map(entries, sorted) => (entries, sorted),
         other => panic!("complex must be a Map type, got {other:?}"),
@@ -630,8 +646,10 @@ async fn write_partitioned_data(
     let actual_schema = snapshot.schema();
     let expected_schema = nested_schema_with_all_delta_types();
     let actual_fields: Vec<&str> = actual_schema.fields().map(|f| f.name().as_str()).collect();
-    let expected_fields: Vec<&str> =
-        expected_schema.fields().map(|f| f.name().as_str()).collect();
+    let expected_fields: Vec<&str> = expected_schema
+        .fields()
+        .map(|f| f.name().as_str())
+        .collect();
     assert_eq!(
         actual_fields, expected_fields,
         "table schema does not match `nested_schema_with_all_delta_types`",
@@ -712,7 +730,11 @@ fn verify_protocol(snapshot: &Snapshot, expected_features: &[&str]) {
 }
 
 /// Look up the physical name of a top-level logical column. Panics if not found.
-fn get_top_level_physical_name(schema: &StructType, logical: &str, mode: ColumnMappingMode) -> String {
+fn get_top_level_physical_name(
+    schema: &StructType,
+    logical: &str,
+    mode: ColumnMappingMode,
+) -> String {
     let physical = get_any_level_column_physical_name(schema, &ColumnName::new([logical]), mode)
         .unwrap()
         .into_inner();
@@ -768,12 +790,15 @@ fn verify_column_mapping_ids_in_parquet(
         parquet_ids.len(),
     );
     for (parquet_schema_path, expected_id) in &visitor.expected {
-        let actual_id = parquet_ids.get(parquet_schema_path).copied().unwrap_or_else(|| {
-            panic!(
-                "expected field_id {expected_id} at parquet_schema_path \
+        let actual_id = parquet_ids
+            .get(parquet_schema_path)
+            .copied()
+            .unwrap_or_else(|| {
+                panic!(
+                    "expected field_id {expected_id} at parquet_schema_path \
                  '{parquet_schema_path}' in {parquet_url}; actual ids: {parquet_ids:?}",
-            )
-        });
+                )
+            });
         assert_eq!(
             actual_id, *expected_id,
             "parquet field_id mismatch at parquet_schema_path \
@@ -816,10 +841,7 @@ impl<'a> SchemaTransform<'a> for ExpectedFieldIdMap {
                 for (physical_nested_path, value) in obj {
                     if let Some(id) = value.as_i64() {
                         self.expected.insert(
-                            translate_nested_path(
-                                &field_parquet_schema_path,
-                                physical_nested_path,
-                            ),
+                            translate_nested_path(&field_parquet_schema_path, physical_nested_path),
                             id,
                         );
                     }
@@ -861,10 +883,7 @@ impl<'a> SchemaTransform<'a> for ExpectedFieldIdMap {
 /// whole prefix wholesale with `field_parquet_schema_path` and translate the remaining
 /// synthetic segments: `key`/`value` -> `key_value.key`/`key_value.value` (Map wrapper),
 /// `element` -> `list.element` (Array wrapper).
-fn translate_nested_path(
-    field_parquet_schema_path: &str,
-    physical_nested_path: &str,
-) -> String {
+fn translate_nested_path(field_parquet_schema_path: &str, physical_nested_path: &str) -> String {
     let segs: Vec<&str> = physical_nested_path.split('.').collect();
     let mut out = field_parquet_schema_path.to_string();
     for seg in &segs[1..] {
@@ -872,9 +891,9 @@ fn translate_nested_path(
             "key" => out.push_str(".key_value.key"),
             "value" => out.push_str(".key_value.value"),
             "element" => out.push_str(".list.element"),
-            other => panic!(
-                "unexpected nested-id path segment '{other}' in '{physical_nested_path}'"
-            ),
+            other => {
+                panic!("unexpected nested-id path segment '{other}' in '{physical_nested_path}'")
+            }
         }
     }
     out
@@ -893,10 +912,7 @@ fn find_top_level_field_in_parquet<'a>(
 
 /// Get the parquet physical type of a top-level field (looked up by physical name). Panics if
 /// the field is missing or is a group (i.e. not a primitive leaf).
-fn find_top_level_physical_type_in_parquet(
-    root: &ParquetType,
-    name: &str,
-) -> ParquetPhysicalType {
+fn find_top_level_physical_type_in_parquet(root: &ParquetType, name: &str) -> ParquetPhysicalType {
     let field = find_top_level_field_in_parquet(root, name)
         .unwrap_or_else(|| panic!("top-level field {name} not found in parquet schema"));
     match field {

--- a/kernel/tests/integration/features/iceberg_compat.rs
+++ b/kernel/tests/integration/features/iceberg_compat.rs
@@ -29,13 +29,14 @@ use delta_kernel::schema::{
     ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, StructField, StructType,
 };
 use delta_kernel::snapshot::Snapshot;
-use delta_kernel::table_features::{
-    get_any_level_column_physical_name, ColumnMappingMode, TableFeature,
-};
+use delta_kernel::table_features::{get_any_level_column_physical_name, ColumnMappingMode};
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::transforms::{transform_output_type, SchemaTransform};
-use test_utils::{add_commit, create_add_files_metadata, read_add_infos, test_table_setup_mt};
+use test_utils::{
+    add_commit, create_add_files_metadata, into_record_batch, read_add_infos, test_table_setup_mt,
+    write_batch_to_table,
+};
 use url::Url;
 
 use crate::common::write_utils::{collect_all_parquet_field_ids, read_parquet_root_schema};
@@ -46,7 +47,7 @@ const TABLE_ROOT: &str = "memory:///";
 /// to-be-deprecated `parquet.field.nested.ids` metadata. Loading the snapshot must fail.
 #[tokio::test]
 async fn snapshot_blocked_when_v3_schema_has_legacy_nested_ids() {
-    let (storage, engine) = make_engine();
+    let (storage, engine) = make_default_engine_and_store();
     // Create table doesn't support the legacy nested ids metadata, so we hand-craft a V0 commit.
     let nested_ids_legacy = serde_json::json!({
         "data.key": 100,
@@ -139,63 +140,6 @@ async fn snapshot_blocked_when_v3_schema_has_legacy_nested_ids() {
     );
 }
 
-/// Listing IcebergCompatV3 in writerFeatures (i.e. "supported") without setting
-/// `delta.enableIcebergCompatV3=true` must not activate V3: column mapping stays off and
-/// no nested-id metadata is stamped on the Map field.
-#[tokio::test]
-async fn v3_supported_but_not_enabled_skips_cm_and_nested_ids() {
-    let (_, engine) = make_engine();
-    let schema = Arc::new(
-        StructType::try_new(vec![StructField::nullable(
-            "data",
-            DataType::Map(Box::new(MapType::new(
-                DataType::INTEGER,
-                DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
-                true,
-            ))),
-        )])
-        .unwrap(),
-    );
-
-    let _ = create_table(TABLE_ROOT, schema, "Test/1.0")
-        .with_table_properties([("delta.feature.icebergCompatV3", "supported")])
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))
-        .unwrap()
-        .commit(engine.as_ref())
-        .unwrap();
-    let snapshot = Snapshot::builder_for(TABLE_ROOT)
-        .build(engine.as_ref())
-        .unwrap();
-
-    // 1. V3 is in writerFeatures (supported).
-    let writer_features = snapshot
-        .table_configuration()
-        .protocol()
-        .writer_features()
-        .expect("writerFeatures present");
-    assert!(
-        writer_features.contains(&TableFeature::IcebergCompatV3),
-        "expected icebergCompatV3 in writerFeatures, got: {writer_features:?}",
-    );
-
-    // 2. CM is not enabled (no auto-enable from V3 being merely supported).
-    assert_eq!(
-        snapshot.table_configuration().column_mapping_mode(),
-        ColumnMappingMode::None,
-    );
-
-    // 3. No nested-id metadata stamped on the Map field.
-    let loaded_schema = snapshot.schema();
-    let data_field = loaded_schema.field("data").expect("data field present");
-    assert!(
-        !data_field
-            .metadata
-            .contains_key(ColumnMetadataKey::ColumnMappingNestedIds.as_ref()),
-        "unexpected delta.columnMapping.nested.ids on data: {:?}",
-        data_field.metadata,
-    );
-}
-
 #[rstest::rstest]
 #[case::missing_num_records(None/* num_records */, Err("'stats.numRecords' is required"))]
 #[case::with_num_records(Some(3), Ok(1))]
@@ -204,7 +148,7 @@ async fn v3_commit_validates_num_records(
     #[case] num_records: Option<i64>,
     #[case] expected: Result<u64, &'static str>,
 ) {
-    let (_, engine) = make_engine();
+    let (_, engine) = make_default_engine_and_store();
 
     let _ = create_table(TABLE_ROOT, simple_schema(), "Test/1.0")
         .with_table_properties([("delta.enableIcebergCompatV3", "true")])
@@ -243,51 +187,6 @@ async fn v3_commit_validates_num_records(
     }
 }
 
-/// V3 create-table negative paths: enabling V3 alongside an incompatible property must fail at
-/// `.build(...)` with a clear error.
-///
-/// `cm_mode_none` and `row_tracking_disabled` are blocked by V3's dependency check
-/// (`maybe_enable_iceberg_compat_v3_dependencies`); the others are blocked earlier because
-/// the property is not in `ALLOWED_DELTA_PROPERTIES` for CREATE TABLE. Keep them here
-/// so that in the future when we support these properties for create table, we will remember to
-/// update this test.
-#[rstest::rstest]
-#[case::cm_mode_none(
-    &[("delta.columnMapping.mode", "none")],
-    "to be 'name' or 'id', got 'none'",
-)]
-#[case::row_tracking_disabled(
-    &[("delta.enableRowTracking", "false")],
-    "to be 'true', got 'false'",
-)]
-#[case::iceberg_compat_v1_active(
-    &[("delta.enableIcebergCompatV1", "true")],
-    "Setting delta property 'delta.enableIcebergCompatV1' is not supported",
-)]
-#[case::iceberg_compat_v2_active(
-    &[("delta.enableIcebergCompatV2", "true")],
-    "Setting delta property 'delta.enableIcebergCompatV2' is not supported",
-)]
-#[tokio::test]
-async fn v3_create_table_rejects_incompatible_props(
-    #[case] extra_props: &[(&str, &str)],
-    #[case] err_substring: &str,
-) {
-    let (_, engine) = make_engine();
-    let mut props: Vec<(&str, &str)> = vec![("delta.enableIcebergCompatV3", "true")];
-    props.extend_from_slice(extra_props);
-
-    let err = create_table(TABLE_ROOT, simple_schema(), "Test/1.0")
-        .with_table_properties(props)
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))
-        .unwrap_err()
-        .to_string();
-    assert!(
-        err.contains(err_substring),
-        "expected error containing {err_substring:?}, got: {err}",
-    );
-}
-
 /// V3 partitioned end-to-end: create + 4 commits with a checkpoint between, then validate
 /// protocol features, parquet field IDs (top-level + nested), partition materialization,
 /// timestamp physical type, and exact scan content.
@@ -301,25 +200,26 @@ async fn v3_create_table_rejects_incompatible_props(
 ///   implies it), `typeWidening` (kernel rejects writes against tables declaring it), and
 ///   `catalogManaged` (requires a catalog committer).
 #[rstest::rstest]
-#[case::min(&[], &[])]
+#[case::min(
+    /* extra_props */ &[],
+    /* enable_features */ &[],
+    /* expected_features */ &[V3_BASELINE_FEATURES],
+)]
 #[case::max(
-    // Features enabled through properties.
-    // Intentionally set `delta.columnMapping.mode=id`, as the `min` case tests 
-    // `name` mode(auto-enabled as a default by V3).
-    &[
-        ("delta.columnMapping.mode", "id"),
-        ("delta.enableDeletionVectors", "true"),
-        ("delta.enableInCommitTimestamps", "true"),
-        ("delta.enableChangeDataFeed", "true"),
-        ("delta.appendOnly", "true"),
+    // Intentionally set `delta.columnMapping.mode=id`, since the `min` case already covers the
+    // V3-default `name` mode.
+    /* extra_props */ &[("delta.columnMapping.mode", "id")],
+    /* enable_features */ &[
+        "deletionVectors", "inCommitTimestamp", "changeDataFeed", "appendOnly",
+        "v2Checkpoint", "vacuumProtocolCheck", "invariants",
     ],
-    // Enablement through feature signals(i.e. delta.feature.X=supported).
-    &["v2Checkpoint", "vacuumProtocolCheck", "invariants"],
+    /* expected_features */ &[READER_WRITER_FEATURES, WRITER_FEATURES],
 )]
 #[tokio::test(flavor = "multi_thread")]
 async fn v3_e2e_partitioned_writes_with_field_ids(
     #[case] extra_props: &[(&str, &str)],
-    #[case] extra_feature_signals: &[&str],
+    #[case] enable_features: &[&str],
+    #[case] expected_features: &[&[&str]],
 ) {
     // === Setup ===
     let (_tmp_dir, table_path, _) = test_table_setup_mt().unwrap();
@@ -335,12 +235,20 @@ async fn v3_e2e_partitioned_writes_with_field_ids(
 
     // === Create partitioned V3 table ===
     let schema = nested_schema_with_all_delta_types();
-    let signal_props: Vec<(String, String)> = extra_feature_signals
+    // Features without an enable property are added via `delta.feature.X=supported`. Build
+    // the signal strings up front so the property tuples below can borrow them.
+    let signal_props: Vec<(String, String)> = enable_features
         .iter()
+        .filter(|f| enable_property_for(f).is_none())
         .map(|f| (format!("delta.feature.{f}"), "supported".to_string()))
         .collect();
     let mut props: Vec<(&str, &str)> = vec![("delta.enableIcebergCompatV3", "true")];
     props.extend(extra_props.iter().copied());
+    props.extend(
+        enable_features
+            .iter()
+            .filter_map(|f| enable_property_for(f).map(|p| (p, "true"))),
+    );
     props.extend(signal_props.iter().map(|(k, v)| (k.as_str(), v.as_str())));
     let _ = create_table(&table_path, schema.clone(), "Test/1.0")
         .with_table_properties(props)
@@ -350,7 +258,7 @@ async fn v3_e2e_partitioned_writes_with_field_ids(
         .commit(engine.as_ref())
         .unwrap();
 
-    // === 2 commits, checkpoint, 2 more commits ===
+    // === 4 commits (2 outer iters x 2 partitions), checkpoint, 4 more commits ===
     for commit_idx in 0..2_i32 {
         write_partitioned_data(&table_url, engine.clone(), commit_idx).await;
     }
@@ -368,23 +276,11 @@ async fn v3_e2e_partitioned_writes_with_field_ids(
         .unwrap();
 
     // === Verify protocol features and column mapping mode ===
-    let baseline_features = [
-        "icebergCompatV3",
-        "columnMapping",
-        "rowTracking",
-        "domainMetadata",
-        "timestampNtz",
-        "variantType",
-    ];
-    let auto_enabled_features: Vec<&str> = extra_props
+    let expected: Vec<&str> = expected_features
         .iter()
-        .filter(|(_, v)| *v == "true")
-        .map(|(k, _)| feature_for_enable_property(k))
+        .flat_map(|list| list.iter().copied())
         .collect();
-    let mut expected_features: Vec<&str> = baseline_features.to_vec();
-    expected_features.extend(auto_enabled_features);
-    expected_features.extend(extra_feature_signals.iter().copied());
-    verify_protocol(&final_snap, &expected_features);
+    verify_protocol(&final_snap, &expected);
     let cm_mode = final_snap
         .table_properties()
         .column_mapping_mode
@@ -405,7 +301,7 @@ async fn v3_e2e_partitioned_writes_with_field_ids(
     assert_eq!(
         add_actions.len(),
         8,
-        "expected 4 commits x 2 partitions = 8 add files",
+        "expected 4 outer iters x 2 partitions = 8 add files",
     );
     let logical_schema = final_snap.schema();
     for add in &add_actions {
@@ -454,7 +350,7 @@ async fn v3_e2e_partitioned_writes_with_field_ids(
 
 // === Helpers ===
 
-fn make_engine() -> (Arc<InMemory>, Arc<DefaultEngine<TokioBackgroundExecutor>>) {
+fn make_default_engine_and_store() -> (Arc<InMemory>, Arc<DefaultEngine<TokioBackgroundExecutor>>) {
     let storage = Arc::new(InMemory::new());
     let engine =
         Arc::new(DefaultEngineBuilder::<TokioBackgroundExecutor>::new(storage.clone()).build());
@@ -688,23 +584,22 @@ fn entries_field_arrays_empty(entries_field: &ArrowField) -> Vec<ArrayRef> {
     }
 }
 
-/// Open a transaction on `table_url`, write 2 partitions x 3 rows (regions "a" and "b") via the
-/// engine's parquet handler, and commit. Stats and `numRecords` are auto-collected by the
-/// default engine, so the numRecords invariant is satisfied.
-/// Assume the table schema is [`nested_schema_with_all_delta_types`].
+/// Write one commit per partition (regions "a" and "b"). Stats and
+/// `numRecords` are auto-collected by the default engine, so the numRecords invariant is
+/// satisfied. Assume the table schema is [`nested_schema_with_all_delta_types`].
 async fn write_partitioned_data(
     table_url: &Url,
     engine: Arc<DefaultEngine<TokioMultiThreadExecutor>>,
     random_seed: i32,
 ) {
-    let snapshot = Snapshot::builder_for(table_url.clone())
+    let mut snapshot = Snapshot::builder_for(table_url.clone())
         .build(engine.as_ref())
         .unwrap();
     // Defensive sanity check: confirm the table schema matches what `build_partition_batch`
     // produces. We compare top-level field names rather than full structs for simplicity.
     let actual_schema = snapshot.schema();
-    let expected_schema = nested_schema_with_all_delta_types();
     let actual_fields: Vec<&str> = actual_schema.fields().map(|f| f.name().as_str()).collect();
+    let expected_schema = nested_schema_with_all_delta_types();
     let expected_fields: Vec<&str> = expected_schema
         .fields()
         .map(|f| f.name().as_str())
@@ -713,42 +608,27 @@ async fn write_partitioned_data(
         actual_fields, expected_fields,
         "table schema does not match `nested_schema_with_all_delta_types`",
     );
-    let mut txn = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())
-        .unwrap()
-        .with_engine_info(format!("Test/v3-commit-seed-{random_seed}"))
-        .with_data_change(true);
 
-    // Each partition gets its own write_parquet call with a partitioned WriteContext.
     for region in PARTITION_REGIONS {
         let batch = build_partition_batch(random_seed, region);
-        let write_context = txn
-            .partitioned_write_context(HashMap::from([(
-                "region".to_string(),
-                Scalar::String(region.to_string()),
-            )]))
-            .unwrap();
-        let add_files = engine
-            .write_parquet(&ArrowEngineData::new(batch), &write_context)
+        let partition_values =
+            HashMap::from([("region".to_string(), Scalar::String(region.to_string()))]);
+        snapshot = write_batch_to_table(&snapshot, engine.as_ref(), batch, partition_values)
             .await
             .unwrap();
-        txn.add_files(add_files);
     }
-    let _ = txn.commit(engine.as_ref()).unwrap().unwrap_committed();
 }
 
-/// Map a `delta.enable*` (or `delta.appendOnly`) enablement-property key to the feature
-/// name. Panics on unknown keys to surface case-input typos.
-fn feature_for_enable_property(key: &str) -> &'static str {
-    match key {
-        "delta.enableDeletionVectors" => "deletionVectors",
-        "delta.enableInCommitTimestamps" => "inCommitTimestamp",
-        "delta.enableChangeDataFeed" => "changeDataFeed",
-        "delta.appendOnly" => "appendOnly",
-        "delta.enableRowTracking" => "rowTracking",
-        other => panic!("unknown enablement property '{other}'"),
-    }
-}
+/// Features that V3 auto-enables (plus TS_NTZ and variant types which are auto-enabled by our test
+/// schema).
+const V3_BASELINE_FEATURES: &[&str] = &[
+    "icebergCompatV3",
+    "columnMapping",
+    "rowTracking",
+    "domainMetadata",
+    "timestampNtz",
+    "variantType",
+];
 
 /// ReaderWriter features used in this test file.
 const READER_WRITER_FEATURES: &[&str] = &[
@@ -759,6 +639,37 @@ const READER_WRITER_FEATURES: &[&str] = &[
     "vacuumProtocolCheck",
     "variantType",
 ];
+
+/// Writer-only features used in this test file.
+const WRITER_FEATURES: &[&str] = &[
+    "appendOnly",
+    "changeDataFeed",
+    "domainMetadata",
+    "icebergCompatV3",
+    "inCommitTimestamp",
+    "invariants",
+    "rowTracking",
+];
+
+/// Maps each enablement-driven feature to its `delta.enable*` (or `delta.appendOnly`)
+/// property name.
+const FEATURE_ENABLE_PROPERTY: &[(&str, &str)] = &[
+    ("appendOnly", "delta.appendOnly"),
+    ("changeDataFeed", "delta.enableChangeDataFeed"),
+    ("deletionVectors", "delta.enableDeletionVectors"),
+    ("icebergCompatV3", "delta.enableIcebergCompatV3"),
+    ("inCommitTimestamp", "delta.enableInCommitTimestamps"),
+    ("rowTracking", "delta.enableRowTracking"),
+];
+
+/// Returns the `delta.enable*` property name for `feature` if one exists, or `None` if the
+/// feature must be added via the `delta.feature.X=supported` signal instead.
+fn enable_property_for(feature: &str) -> Option<&'static str> {
+    FEATURE_ENABLE_PROPERTY
+        .iter()
+        .find(|(name, _)| *name == feature)
+        .map(|(_, prop)| *prop)
+}
 
 /// Assert each name in `expected_features` appears in `writerFeatures`, plus that any
 /// reader+writer feature also appears in `readerFeatures`.
@@ -779,10 +690,23 @@ fn verify_protocol(snapshot: &Snapshot, expected_features: &[&str]) {
             writer_features.iter().any(|w| w == f),
             "writerFeatures missing {f}; got {writer_features:?}",
         );
-        if READER_WRITER_FEATURES.contains(f) {
+        let is_reader_writer = READER_WRITER_FEATURES.contains(f);
+        let is_writer_only = WRITER_FEATURES.contains(f);
+        assert!(
+            is_reader_writer || is_writer_only,
+            "feature '{f}' is not classified in READER_WRITER_FEATURES or WRITER_FEATURES; \
+             update one of those lists",
+        );
+        if is_reader_writer {
             assert!(
                 reader_features.iter().any(|r| r == f),
                 "readerFeatures missing {f} (reader+writer feature); got {reader_features:?}",
+            );
+        } else {
+            assert!(
+                !reader_features.iter().any(|r| r == f),
+                "readerFeatures unexpectedly contains writer-only feature {f}; \
+                 got {reader_features:?}",
             );
         }
     }
@@ -993,11 +917,7 @@ fn verify_scan_contents(
     let mut total_rows = 0_usize;
 
     for res in scan.execute(engine).unwrap() {
-        let raw = res.unwrap();
-        let batch: RecordBatch = ArrowEngineData::try_from_engine_data(raw)
-            .unwrap()
-            .record_batch()
-            .clone();
+        let batch = into_record_batch(res.unwrap());
 
         let region_arr = batch
             .column_by_name("region")

--- a/kernel/tests/integration/features/iceberg_compat.rs
+++ b/kernel/tests/integration/features/iceberg_compat.rs
@@ -1,0 +1,302 @@
+//! Integration tests for icebergCompat (V3) write- and load-time validations.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use delta_kernel::arrow::array::{
+    ArrayRef, BooleanArray, Int32Array, Int64Array, MapArray, RecordBatch, StringArray, StructArray,
+};
+use delta_kernel::arrow::buffer::OffsetBuffer;
+use delta_kernel::arrow::datatypes::{
+    DataType as ArrowDataType, Field as ArrowField, Fields, Schema as ArrowSchema,
+};
+use delta_kernel::committer::FileSystemCommitter;
+use delta_kernel::engine::arrow_conversion::{TryFromKernel, TryIntoArrow as _};
+use delta_kernel::engine::arrow_data::ArrowEngineData;
+use delta_kernel::engine::default::executor::tokio::TokioBackgroundExecutor;
+use delta_kernel::engine::default::{DefaultEngine, DefaultEngineBuilder};
+use delta_kernel::object_store::memory::InMemory;
+use delta_kernel::schema::{
+    ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, StructField, StructType,
+};
+use delta_kernel::snapshot::Snapshot;
+use delta_kernel::transaction::create_table::create_table;
+use delta_kernel::EngineData;
+use test_utils::{add_commit, write_batch_to_table};
+
+const TABLE_ROOT: &str = "memory:///";
+
+fn make_engine() -> (Arc<InMemory>, Arc<DefaultEngine<TokioBackgroundExecutor>>) {
+    let storage = Arc::new(InMemory::new());
+    let engine =
+        Arc::new(DefaultEngineBuilder::<TokioBackgroundExecutor>::new(storage.clone()).build());
+    (storage, engine)
+}
+
+fn v3_table_properties() -> Vec<(&'static str, &'static str)> {
+    vec![
+        ("delta.enableIcebergCompatV3", "true"),
+        ("delta.columnMapping.mode", "name"),
+        ("delta.enableRowTracking", "true"),
+    ]
+}
+
+fn simple_schema() -> Arc<StructType> {
+    Arc::new(
+        StructType::try_new(vec![
+            StructField::nullable("id", DataType::INTEGER),
+            StructField::nullable("name", DataType::STRING),
+        ])
+        .unwrap(),
+    )
+}
+
+// === Test 1: legacy `parquet.field.nested.ids` on a V3 table is rejected at snapshot load ===
+
+/// Hand-crafts a V0 create commit on an icebergCompatV3 table whose `data` field carries the
+/// deprecated `parquet.field.nested.ids` metadata. Loading the snapshot must fail because the
+/// validator runs in `TableConfiguration::try_new`.
+#[tokio::test]
+async fn snapshot_blocked_when_v3_schema_has_legacy_nested_ids() {
+    let (storage, engine) = make_engine();
+
+    let nested_ids_legacy = serde_json::json!({
+        "data.key": 100,
+        "data.value": 101,
+        "data.value.element": 102,
+    });
+    let schema = StructType::try_new(vec![StructField::nullable(
+        "data",
+        DataType::Map(Box::new(MapType::new(
+            DataType::INTEGER,
+            DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+            true,
+        ))),
+    )
+    .with_metadata([
+        (
+            ColumnMetadataKey::ColumnMappingId.as_ref(),
+            MetadataValue::from(1),
+        ),
+        (
+            ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
+            MetadataValue::from("col-1"),
+        ),
+        (
+            ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
+            MetadataValue::Other(nested_ids_legacy),
+        ),
+    ])])
+    .unwrap();
+    let schema_string = serde_json::to_string(&schema).unwrap();
+
+    let commit = [
+        serde_json::json!({
+            "commitInfo": {
+                "timestamp": 1587968586154_i64,
+                "operation": "CREATE TABLE",
+                "operationParameters": {},
+                "isBlindAppend": true,
+            }
+        }),
+        serde_json::json!({
+            "protocol": {
+                "minReaderVersion": 3,
+                "minWriterVersion": 7,
+                "readerFeatures": ["columnMapping"],
+                "writerFeatures": [
+                    "icebergCompatV3",
+                    "columnMapping",
+                    "rowTracking",
+                    "domainMetadata",
+                ],
+            }
+        }),
+        serde_json::json!({
+            "metaData": {
+                "id": "deadbeef-1234-5678-abcd-000000000001",
+                "format": { "provider": "parquet", "options": {} },
+                "schemaString": schema_string,
+                "partitionColumns": [],
+                "configuration": {
+                    "delta.enableIcebergCompatV3": "true",
+                    "delta.columnMapping.mode": "name",
+                    "delta.enableRowTracking": "true",
+                    "delta.rowTracking.materializedRowIdColumnName": "_row_id",
+                    "delta.rowTracking.materializedRowCommitVersionColumnName":
+                        "_row_commit_version",
+                    "delta.columnMapping.maxColumnId": "1",
+                },
+                "createdTime": 1234567890000_i64,
+            }
+        }),
+    ]
+    .into_iter()
+    .map(|action| serde_json::to_string(&action).unwrap())
+    .collect::<Vec<_>>()
+    .join("\n");
+    add_commit(TABLE_ROOT, storage.as_ref(), 0, commit)
+        .await
+        .unwrap();
+
+    let err = Snapshot::builder_for(TABLE_ROOT)
+        .build(engine.as_ref())
+        .unwrap_err()
+        .to_string();
+    assert!(
+        err.contains("parquet.field.nested.ids")
+            && err.contains("delta.columnMapping.nested.ids")
+            && err.contains("data"),
+        "expected error mentioning the legacy key, replacement key, and field path, got: {err}",
+    );
+}
+
+// === Test 2: V3 add_files without `stats.numRecords` is rejected at commit ===
+
+/// Build add_files metadata for one synthetic file whose `stats` carries every required field
+/// EXCEPT `numRecords` (which is null), matching the schema returned by
+/// `Transaction::add_files_schema()`.
+fn add_files_metadata_without_num_records(arrow_schema: &ArrowSchema) -> Box<dyn EngineData> {
+    let path_array = StringArray::from(vec!["part-fake.parquet"]);
+    let size_array = Int64Array::from(vec![1024_i64]);
+    let mod_time_array = Int64Array::from(vec![1_000_000_i64]);
+
+    // partitionValues: empty Map<string, string>.
+    let entries_field = Arc::new(ArrowField::new(
+        "key_value",
+        ArrowDataType::Struct(Fields::from(vec![
+            ArrowField::new("key", ArrowDataType::Utf8, false),
+            ArrowField::new("value", ArrowDataType::Utf8, true),
+        ])),
+        false,
+    ));
+    let empty_keys = StringArray::from(Vec::<&str>::new());
+    let empty_values = StringArray::from(Vec::<Option<&str>>::new());
+    let empty_entries = StructArray::from(vec![
+        (
+            Arc::new(ArrowField::new("key", ArrowDataType::Utf8, false)),
+            Arc::new(empty_keys) as ArrayRef,
+        ),
+        (
+            Arc::new(ArrowField::new("value", ArrowDataType::Utf8, true)),
+            Arc::new(empty_values) as ArrayRef,
+        ),
+    ]);
+    let partition_values_array = Arc::new(MapArray::new(
+        entries_field,
+        OffsetBuffer::from_lengths(vec![0]),
+        empty_entries,
+        None,
+        false,
+    ));
+
+    // stats: numRecords=NULL, empty nullCount/minValues/maxValues structs, tightBounds=true.
+    let empty_struct_fields: Fields = Vec::<Arc<ArrowField>>::new().into();
+    let empty_struct = StructArray::new_empty_fields(1, None);
+    let stats_struct = StructArray::from(vec![
+        (
+            Arc::new(ArrowField::new("numRecords", ArrowDataType::Int64, true)),
+            Arc::new(Int64Array::from(vec![None as Option<i64>])) as ArrayRef,
+        ),
+        (
+            Arc::new(ArrowField::new(
+                "nullCount",
+                ArrowDataType::Struct(empty_struct_fields.clone()),
+                true,
+            )),
+            Arc::new(empty_struct.clone()) as ArrayRef,
+        ),
+        (
+            Arc::new(ArrowField::new(
+                "minValues",
+                ArrowDataType::Struct(empty_struct_fields.clone()),
+                true,
+            )),
+            Arc::new(empty_struct.clone()) as ArrayRef,
+        ),
+        (
+            Arc::new(ArrowField::new(
+                "maxValues",
+                ArrowDataType::Struct(empty_struct_fields),
+                true,
+            )),
+            Arc::new(empty_struct) as ArrayRef,
+        ),
+        (
+            Arc::new(ArrowField::new("tightBounds", ArrowDataType::Boolean, true)),
+            Arc::new(BooleanArray::from(vec![true])) as ArrayRef,
+        ),
+    ]);
+
+    let batch = RecordBatch::try_new(
+        Arc::new(arrow_schema.clone()),
+        vec![
+            Arc::new(path_array) as ArrayRef,
+            partition_values_array as ArrayRef,
+            Arc::new(size_array) as ArrayRef,
+            Arc::new(mod_time_array) as ArrayRef,
+            Arc::new(stats_struct) as ArrayRef,
+        ],
+    )
+    .unwrap();
+
+    Box::new(ArrowEngineData::new(batch))
+}
+
+#[tokio::test]
+async fn write_blocked_when_v3_add_lacks_num_records() {
+    let (_, engine) = make_engine();
+
+    let _ = create_table(TABLE_ROOT, simple_schema(), "Test/1.0")
+        .with_table_properties(v3_table_properties())
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))
+        .unwrap()
+        .commit(engine.as_ref())
+        .unwrap();
+    let snapshot = Snapshot::builder_for(TABLE_ROOT)
+        .build(engine.as_ref())
+        .unwrap();
+
+    let mut txn = snapshot
+        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())
+        .unwrap()
+        .with_engine_info("Test/1.0")
+        .with_data_change(true);
+    let add_schema = ArrowSchema::try_from_kernel(txn.add_files_schema().as_ref()).unwrap();
+    txn.add_files(add_files_metadata_without_num_records(&add_schema));
+
+    let err = txn.commit(engine.as_ref()).unwrap_err().to_string();
+    assert!(
+        err.contains("'stats.numRecords' is required") && err.contains("part-fake.parquet"),
+        "expected numRecords-missing error, got: {err}",
+    );
+}
+
+// === Test 3: V3 happy path: create + write commits successfully ===
+
+#[tokio::test(flavor = "multi_thread")]
+async fn write_succeeds_on_v3_table() {
+    let (_, engine) = make_engine();
+
+    let schema = simple_schema();
+    let _ = create_table(TABLE_ROOT, schema.clone(), "Test/1.0")
+        .with_table_properties(v3_table_properties())
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))
+        .unwrap()
+        .commit(engine.as_ref())
+        .unwrap();
+    let snapshot = Snapshot::builder_for(TABLE_ROOT)
+        .build(engine.as_ref())
+        .unwrap();
+
+    // Real write through the default engine: stats are auto-collected and include numRecords.
+    let arrow_schema: ArrowSchema = (schema.as_ref()).try_into_arrow().unwrap();
+    let id_col: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+    let name_col: ArrayRef = Arc::new(StringArray::from(vec!["a", "b", "c"]));
+    let batch = RecordBatch::try_new(Arc::new(arrow_schema), vec![id_col, name_col]).unwrap();
+
+    let new_snapshot = write_batch_to_table(&snapshot, engine.as_ref(), batch, HashMap::new())
+        .await
+        .expect("V3 write should succeed");
+    assert_eq!(new_snapshot.version(), 1);
+}

--- a/kernel/tests/integration/features/mod.rs
+++ b/kernel/tests/integration/features/mod.rs
@@ -4,5 +4,6 @@ mod alter_table;
 mod cdf;
 mod clustering_e2e;
 mod dv;
+mod iceberg_compat;
 mod maintenance_ops;
 mod row_tracking;

--- a/kernel/tests/integration/log/v2_checkpoints.rs
+++ b/kernel/tests/integration/log/v2_checkpoints.rs
@@ -1552,8 +1552,10 @@ async fn test_v2_sidecar_default_hint_splits_at_50k() -> Result<(), Box<dyn std:
             .map(|i| format!("part-{c:03}-{i:04}.parquet"))
             .collect();
         // Each tuple is (path, size_bytes, modification_time, num_records).
-        let files: Vec<(&str, i64, i64, Option<i64>)> =
-            paths.iter().map(|p| (p.as_str(), 100, 0, Some(1))).collect();
+        let files: Vec<(&str, i64, i64, Option<i64>)> = paths
+            .iter()
+            .map(|p| (p.as_str(), 100, 0, Some(1)))
+            .collect();
         txn.add_files(create_add_files_metadata(&add_files_schema, files)?);
         snapshot = txn.commit(engine.as_ref())?.unwrap_post_commit_snapshot();
     }

--- a/kernel/tests/integration/log/v2_checkpoints.rs
+++ b/kernel/tests/integration/log/v2_checkpoints.rs
@@ -1552,8 +1552,8 @@ async fn test_v2_sidecar_default_hint_splits_at_50k() -> Result<(), Box<dyn std:
             .map(|i| format!("part-{c:03}-{i:04}.parquet"))
             .collect();
         // Each tuple is (path, size_bytes, modification_time, num_records).
-        let files: Vec<(&str, i64, i64, i64)> =
-            paths.iter().map(|p| (p.as_str(), 100, 0, 1)).collect();
+        let files: Vec<(&str, i64, i64, Option<i64>)> =
+            paths.iter().map(|p| (p.as_str(), 100, 0, Some(1))).collect();
         txn.add_files(create_add_files_metadata(&add_files_schema, files)?);
         snapshot = txn.commit(engine.as_ref())?.unwrap_post_commit_snapshot();
     }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -903,10 +903,12 @@ pub fn assert_result_error_with_message<T, E: ToString>(res: Result<T, E>, messa
 }
 
 /// Creates add file metadata for one or more files without partition values.
-/// Each tuple contains: (file_path, file_size, mod_time, num_records)
+///
+/// Each tuple contains `(file_path, file_size, mod_time, num_records)`. `num_records` is
+/// `Option<i64>` so callers can produce a NULL `stats.numRecords` cell.
 pub fn create_add_files_metadata(
     add_files_schema: &SchemaRef,
-    files: Vec<(&str, i64, i64, i64)>,
+    files: Vec<(&str, i64, i64, Option<i64>)>,
 ) -> Result<Box<dyn delta_kernel::EngineData>, Box<dyn std::error::Error>> {
     let num_files = files.len();
 


### PR DESCRIPTION
## Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2518/files) to review incremental changes.
- [stack/add-v3-feature](https://github.com/delta-io/delta-kernel-rs/pull/2475) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2475/files)] [MERGED]
  - [stack/write-part-when-ice3](https://github.com/delta-io/delta-kernel-rs/pull/2504) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2504/files)] [MERGED]
    - [stack/block-alter-table](https://github.com/delta-io/delta-kernel-rs/pull/2505) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2505/files)] [MERGED]
      - [stack/write-nested-id](https://github.com/delta-io/delta-kernel-rs/pull/2508) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2508/files)] [MERGED]
        - [stack/detect-no-num](https://github.com/delta-io/delta-kernel-rs/pull/2512) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2512/files)] [MERGED]
          - [stack/create-ice-v3-table](https://github.com/delta-io/delta-kernel-rs/pull/2517) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2517/files)] [MERGED]
            - [**stack/support-ice-v3**](https://github.com/delta-io/delta-kernel-rs/pull/2518) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2518/files)]

---------
## What changes are proposed in this pull request?

Turn the `icebergCompatV3` into `support` And add unit tests. Some features may conflict with `icebergCompatV3` in the future, added comments on feature infos for future attentions as well.
## How was this change tested?
Integration tests for happy path:

write to icebergCompatV3 table with minimum/maximum feature sets, table schema contains all delta types. Validate
1. Protocol features on table
2. Parquet field IDs (top-level + nested)
3. Partition values materialization
4. Timestamps is written as i64 in parquet
5. Scan back the data and validate.

Create table with icebergCompatV3 supported but not enabled, validate
1. icebergCompatV3 in writerfeatures
2. CM not auto-enabled
3. No nested id metadata allocated


Integration tests for error path:
1. Create table with 
- `delta.columnMapping.mode == none`
- `delta.enableRowTracking == false`
2. Commit addFile without `stats.numRecords`
3. Insert to table with legacy `parquet.field.nested.ids`
