### PR TITLE
feat: classify metadata-only re-adds on incremental scan

### DIFF
--- a/kernel/src/incremental_scan/mod.rs
+++ b/kernel/src/incremental_scan/mod.rs
@@ -266,7 +266,7 @@ impl IncrementalScanStream {
     /// when your cache holds keys in a streamable shape and you don't have a faster
     /// `contains` lookup.
     ///
-    /// Prefer [`into_summary_against_base_with`] when your cache supports
+    /// Prefer [`into_summary_against_base_closure`] when your cache supports
     /// `contains`-style lookup (HashMap, HashSet, BTreeMap, custom index). That form
     /// iterates the (typically much smaller) live-Add set and probes your base via the
     /// supplied closure, dropping work from `O(|base|)` to `O(|live_adds|)`.
@@ -275,8 +275,8 @@ impl IncrementalScanStream {
     /// See [`into_summary`].
     ///
     /// [`into_summary`]: Self::into_summary
-    /// [`into_summary_against_base_with`]: Self::into_summary_against_base_with
-    pub fn into_summary_against_base<'a>(
+    /// [`into_summary_against_base_closure`]: Self::into_summary_against_base_closure
+    pub fn into_summary_against_base_iter<'a>(
         self,
         base_keys: impl IntoIterator<Item = &'a FileActionKey>,
     ) -> DeltaResult<IncrementalScanSummaryAgainstBase> {
@@ -294,7 +294,7 @@ impl IncrementalScanStream {
         })
     }
 
-    /// Predicate form of [`into_summary_against_base`]: pass a closure that answers
+    /// Predicate form of [`into_summary_against_base_iter`]: pass a closure that answers
     /// "is this key in your base?" Iterates the live-Add set (typically much smaller than
     /// the base) and calls `base_contains` once per live-Add key.
     ///
@@ -308,8 +308,8 @@ impl IncrementalScanStream {
     /// See [`into_summary`].
     ///
     /// [`into_summary`]: Self::into_summary
-    /// [`into_summary_against_base`]: Self::into_summary_against_base
-    pub fn into_summary_against_base_with(
+    /// [`into_summary_against_base_iter`]: Self::into_summary_against_base_iter
+    pub fn into_summary_against_base_closure(
         self,
         base_contains: impl Fn(&FileActionKey) -> bool,
     ) -> DeltaResult<IncrementalScanSummaryAgainstBase> {
@@ -329,20 +329,20 @@ impl IncrementalScanStream {
     }
 
     /// Eager classified helper: collect every live Add batch and call
-    /// [`into_summary_against_base`] against `base_keys`. Returns an
+    /// [`into_summary_against_base_iter`] against `base_keys`. Returns an
     /// [`IncrementalListingAgainstBase`] with the classified summary.
     ///
-    /// Prefer [`into_listing_against_base_with`] when your base supports `contains`-style
-    /// lookup — see [`into_summary_against_base_with`] for the rationale.
+    /// Prefer [`into_listing_against_base_closure`] when your base supports `contains`-style
+    /// lookup — see [`into_summary_against_base_closure`] for the rationale.
     ///
     /// # Errors
     /// See [`into_summary`].
     ///
     /// [`into_summary`]: Self::into_summary
-    /// [`into_summary_against_base`]: Self::into_summary_against_base
-    /// [`into_summary_against_base_with`]: Self::into_summary_against_base_with
-    /// [`into_listing_against_base_with`]: Self::into_listing_against_base_with
-    pub fn into_listing_against_base<'a>(
+    /// [`into_summary_against_base_iter`]: Self::into_summary_against_base_iter
+    /// [`into_summary_against_base_closure`]: Self::into_summary_against_base_closure
+    /// [`into_listing_against_base_closure`]: Self::into_listing_against_base_closure
+    pub fn into_listing_against_base_iter<'a>(
         mut self,
         base_keys: impl IntoIterator<Item = &'a FileActionKey>,
     ) -> DeltaResult<IncrementalListingAgainstBase> {
@@ -350,20 +350,20 @@ impl IncrementalScanStream {
         for item in self.by_ref() {
             add_files.push(item?);
         }
-        let summary = self.into_summary_against_base(base_keys)?;
+        let summary = self.into_summary_against_base_iter(base_keys)?;
         Ok(IncrementalListingAgainstBase { summary, add_files })
     }
 
-    /// Predicate form of [`into_listing_against_base`]; see
-    /// [`into_summary_against_base_with`] for the rationale.
+    /// Predicate form of [`into_listing_against_base_iter`]; see
+    /// [`into_summary_against_base_closure`] for the rationale.
     ///
     /// # Errors
     /// See [`into_summary`].
     ///
     /// [`into_summary`]: Self::into_summary
-    /// [`into_listing_against_base`]: Self::into_listing_against_base
-    /// [`into_summary_against_base_with`]: Self::into_summary_against_base_with
-    pub fn into_listing_against_base_with(
+    /// [`into_listing_against_base_iter`]: Self::into_listing_against_base_iter
+    /// [`into_summary_against_base_closure`]: Self::into_summary_against_base_closure
+    pub fn into_listing_against_base_closure(
         mut self,
         base_contains: impl Fn(&FileActionKey) -> bool,
     ) -> DeltaResult<IncrementalListingAgainstBase> {
@@ -371,7 +371,7 @@ impl IncrementalScanStream {
         for item in self.by_ref() {
             add_files.push(item?);
         }
-        let summary = self.into_summary_against_base_with(base_contains)?;
+        let summary = self.into_summary_against_base_closure(base_contains)?;
         Ok(IncrementalListingAgainstBase { summary, add_files })
     }
 }
@@ -431,7 +431,7 @@ impl std::fmt::Debug for IncrementalListing {
 }
 
 /// Cross-snapshot-classified file-key sets, returned by
-/// [`IncrementalScanStream::into_summary_against_base`].
+/// [`IncrementalScanStream::into_summary_against_base_iter`] (or its closure variant).
 ///
 /// To advance a delta-on-base file listing cache, append the streamed Add batches to
 /// the delta layer and use the union `removes U duplicate_adds` as the remove-mask
@@ -455,7 +455,8 @@ pub struct IncrementalScanSummaryAgainstBase {
     pub removes: HashSet<FileActionKey>,
 }
 
-/// Eager output of [`IncrementalScanStream::into_listing_against_base`]: the buffered
+/// Eager output of [`IncrementalScanStream::into_listing_against_base_iter`] (or its
+/// closure variant): the buffered
 /// Add batches plus the classified summary.
 #[non_exhaustive]
 pub struct IncrementalListingAgainstBase {

--- a/kernel/src/incremental_scan/mod.rs
+++ b/kernel/src/incremental_scan/mod.rs
@@ -203,8 +203,13 @@ impl IncrementalScanStream {
     /// data structure they prefer.
     ///
     /// # Errors
-    /// Returns `Err` if the stream previously yielded an error (dedup state is incomplete),
-    /// or if draining produces an error.
+    /// - [`Error::IOError`] / [`Error::ObjectStore`] / [`Error::Reqwest`] -- transient I/O on
+    ///   commit reads; retryable by rebuilding the stream.
+    /// - [`Error::FileNotFound`] -- commit vacuumed mid-scan; rebuilding will likely return
+    ///   `Ok(None)` (commits unavailable), fall back to [`crate::Snapshot::scan_builder`].
+    /// - [`Error::MalformedJson`] -- commit corruption; not retryable.
+    /// - [`Error::Generic`] "cannot finish a stream that previously errored" -- terminal called on
+    ///   a stream whose `next()` already returned `Err`; rebuild to retry.
     pub fn into_summary(mut self) -> DeltaResult<IncrementalScanSummary> {
         if self.errored {
             return Err(Error::generic(
@@ -233,6 +238,9 @@ impl IncrementalScanStream {
     /// batch-size limits). One yielded batch produces at most one `Vec` entry, and a
     /// commit whose Adds were all cancelled by later Removes produces no entry at all.
     ///
+    /// # Errors
+    /// See [`into_summary`].
+    ///
     /// [`into_summary`]: Self::into_summary
     /// [`ActionsBatch`]: crate::log_replay::ActionsBatch
     pub fn into_listing(mut self) -> DeltaResult<IncrementalListing> {
@@ -258,6 +266,9 @@ impl IncrementalScanStream {
     /// `contains`-style lookup (HashMap, HashSet, BTreeMap, custom index). That form
     /// iterates the (typically much smaller) live-Add set and probes your base via the
     /// supplied closure, dropping work from `O(|base|)` to `O(|live_adds|)`.
+    ///
+    /// # Errors
+    /// See [`into_summary`].
     ///
     /// [`into_summary`]: Self::into_summary
     /// [`into_summary_against_base_with`]: Self::into_summary_against_base_with
@@ -289,6 +300,10 @@ impl IncrementalScanStream {
     /// - `BTreeMap<FileActionKey, _>` -> `|k| map.contains_key(k)`
     /// - Sorted `Vec<FileActionKey>` -> `|k| vec.binary_search(k).is_ok()`
     ///
+    /// # Errors
+    /// See [`into_summary`].
+    ///
+    /// [`into_summary`]: Self::into_summary
     /// [`into_summary_against_base`]: Self::into_summary_against_base
     pub fn into_summary_against_base_with(
         self,
@@ -316,6 +331,10 @@ impl IncrementalScanStream {
     /// Prefer [`into_listing_against_base_with`] when your base supports `contains`-style
     /// lookup — see [`into_summary_against_base_with`] for the rationale.
     ///
+    /// # Errors
+    /// See [`into_summary`].
+    ///
+    /// [`into_summary`]: Self::into_summary
     /// [`into_summary_against_base`]: Self::into_summary_against_base
     /// [`into_summary_against_base_with`]: Self::into_summary_against_base_with
     /// [`into_listing_against_base_with`]: Self::into_listing_against_base_with
@@ -334,6 +353,10 @@ impl IncrementalScanStream {
     /// Predicate form of [`into_listing_against_base`]; see
     /// [`into_summary_against_base_with`] for the rationale.
     ///
+    /// # Errors
+    /// See [`into_summary`].
+    ///
+    /// [`into_summary`]: Self::into_summary
     /// [`into_listing_against_base`]: Self::into_listing_against_base
     /// [`into_summary_against_base_with`]: Self::into_summary_against_base_with
     pub fn into_listing_against_base_with(

--- a/kernel/src/incremental_scan/mod.rs
+++ b/kernel/src/incremental_scan/mod.rs
@@ -244,13 +244,12 @@ impl IncrementalScanStream {
         Ok(IncrementalListing { summary, add_files })
     }
 
-    /// Drain any unread batches, then intersect `base_keys` against the surviving-Add
-    /// file-key set to compute `duplicate_adds` (file keys in the consumer's base
-    /// listing that the range re-adds with new metadata, e.g. OPTIMIZE / liquid
-    /// clustering re-tag).
+    /// Drain any unread batches, then intersect `base_keys` against the live-Add file-key
+    /// set to compute `duplicate_adds` (file keys in the consumer's base listing that the
+    /// range re-adds with new metadata, e.g. OPTIMIZE / liquid clustering re-tag).
     ///
     /// Sugar over [`into_summary`] plus a single pass over `base_keys`. The iterator is
-    /// consumed exactly once; memory stays `O(surviving_adds)`.
+    /// consumed exactly once; memory stays `O(live_adds)`.
     ///
     /// [`into_summary`]: Self::into_summary
     pub fn into_summary_against_base(
@@ -260,7 +259,7 @@ impl IncrementalScanStream {
         let summary = self.into_summary()?;
         let duplicate_adds: HashSet<FileActionKey> = base_keys
             .into_iter()
-            .filter(|k| summary.surviving_adds.contains(k))
+            .filter(|k| summary.live_adds.contains(k))
             .collect();
         Ok(IncrementalScanSummaryAgainstBase {
             base_version: summary.base_version,
@@ -270,7 +269,7 @@ impl IncrementalScanStream {
         })
     }
 
-    /// Eager classified helper: collect every surviving Add batch and call
+    /// Eager classified helper: collect every live Add batch and call
     /// [`into_summary_against_base`] against `base_keys`. Returns an
     /// [`IncrementalListingAgainstBase`] with the classified summary.
     ///
@@ -358,11 +357,11 @@ pub struct IncrementalScanSummaryAgainstBase {
     pub base_version: Version,
     /// Inclusive upper bound; equals the source snapshot's version.
     pub target_version: Version,
-    /// File keys from the surviving Add stream that also appear in the consumer's base
+    /// File keys from the live Add stream that also appear in the consumer's base
     /// listing (metadata-only re-adds, e.g. OPTIMIZE / liquid clustering re-tag).
     /// The corresponding rows are still in the streamed Adds.
     pub duplicate_adds: HashSet<FileActionKey>,
-    /// File keys of surviving Remove actions. Consumers must union this with
+    /// File keys of Remove actions in the range. Consumers must union this with
     /// `duplicate_adds` when masking the base.
     pub removes: HashSet<FileActionKey>,
 }
@@ -373,7 +372,7 @@ pub struct IncrementalScanSummaryAgainstBase {
 pub struct IncrementalListingAgainstBase {
     /// Classified file-key sets for the range; see [`IncrementalScanSummaryAgainstBase`].
     pub summary: IncrementalScanSummaryAgainstBase,
-    /// All surviving Add batches in descending commit-version order.
+    /// All live Add batches in descending commit-version order.
     pub add_files: Vec<FilteredEngineData>,
 }
 

--- a/kernel/src/incremental_scan/mod.rs
+++ b/kernel/src/incremental_scan/mod.rs
@@ -248,38 +248,28 @@ impl IncrementalScanStream {
     /// set to compute `duplicate_adds` (file keys in the consumer's base listing that the
     /// range re-adds with new metadata, e.g. OPTIMIZE / liquid clustering re-tag).
     ///
-    /// Streaming form: accepts any source of base keys (Vec, lazy iterator, paginated
-    /// cache lookup, etc.). Kernel does not materialize a HashSet of base keys — it
-    /// streams `base_keys` once and tests each against the live-Add set. Use this when
-    /// your cache holds base keys in any shape other than `HashSet<FileActionKey>`:
-    /// constructing a HashSet just to call [`into_summary_against_base_set`] would cost
-    /// `O(|base|)` hashing + allocation, exceeding the work this method does.
+    /// Streaming form: accepts borrowed keys from any source (`&HashSet`, `&Vec`, `&[…]`,
+    /// `map.keys()`, custom iterator). Kernel streams `base_keys` once and probes the
+    /// live-Add set per element. Work is `O(|base|)` with no call-site clones. Use this
+    /// when your cache holds keys in a streamable shape and you don't have a faster
+    /// `contains` lookup.
     ///
-    /// Prefer [`into_summary_against_base_set`] only when your cache *already* holds a
-    /// `HashSet<FileActionKey>` you keep across diffs. That form uses `.intersection()` to
-    /// iterate the (typically much smaller) live-Add set instead of the whole base, so
-    /// the work drops from `O(|base|)` to `O(|live_adds|)`.
-    ///
-    /// # Errors
-    /// Inherits all errors from [`into_summary`]. Two categories:
-    /// - Stream previously yielded `Some(Err(_))` from [`Iterator::next`]: dedup state is
-    ///   incomplete, so this call returns `Err` rather than a partial summary. Not recoverable on
-    ///   this stream — the consumer must rebuild the stream from [`IncrementalScanBuilder`] to
-    ///   retry.
-    /// - Draining the remaining batches produces an `Err` (engine I/O, JSON parse, etc.). The
-    ///   underlying engine error determines retryability; typically retryable by rebuilding the
-    ///   stream.
+    /// Prefer [`into_summary_against_base_with`] when your cache supports
+    /// `contains`-style lookup (HashMap, HashSet, BTreeMap, custom index). That form
+    /// iterates the (typically much smaller) live-Add set and probes your base via the
+    /// supplied closure, dropping work from `O(|base|)` to `O(|live_adds|)`.
     ///
     /// [`into_summary`]: Self::into_summary
-    /// [`into_summary_against_base_set`]: Self::into_summary_against_base_set
-    pub fn into_summary_against_base(
+    /// [`into_summary_against_base_with`]: Self::into_summary_against_base_with
+    pub fn into_summary_against_base<'a>(
         self,
-        base_keys: impl IntoIterator<Item = FileActionKey>,
+        base_keys: impl IntoIterator<Item = &'a FileActionKey>,
     ) -> DeltaResult<IncrementalScanSummaryAgainstBase> {
         let summary = self.into_summary()?;
         let duplicate_adds: HashSet<FileActionKey> = base_keys
             .into_iter()
-            .filter(|k| summary.live_adds.contains(k))
+            .filter(|k| summary.live_adds.contains(*k))
+            .cloned()
             .collect();
         Ok(IncrementalScanSummaryAgainstBase {
             base_version: summary.base_version,
@@ -289,22 +279,28 @@ impl IncrementalScanStream {
         })
     }
 
-    /// HashSet form of [`into_summary_against_base`]: pass a borrowed `&HashSet` directly
-    /// when your cache already holds one and you keep it across diffs. Iterates the
-    /// live-Add set (typically smaller than `base_keys`) and clones only the intersection
-    /// — strictly fewer clones than the streaming form's call-site `iter().cloned()`.
+    /// Predicate form of [`into_summary_against_base`]: pass a closure that answers
+    /// "is this key in your base?" Iterates the live-Add set (typically much smaller than
+    /// the base) and calls `base_contains` once per live-Add key.
     ///
-    /// # Errors
-    /// See [`into_summary_against_base`].
+    /// Works with any base shape that supports membership lookup:
+    /// - `HashMap<FileActionKey, _>` -> `|k| map.contains_key(k)`
+    /// - `HashSet<FileActionKey>` -> `|k| set.contains(k)`
+    /// - `BTreeMap<FileActionKey, _>` -> `|k| map.contains_key(k)`
+    /// - Sorted `Vec<FileActionKey>` -> `|k| vec.binary_search(k).is_ok()`
     ///
     /// [`into_summary_against_base`]: Self::into_summary_against_base
-    pub fn into_summary_against_base_set(
+    pub fn into_summary_against_base_with(
         self,
-        base_keys: &HashSet<FileActionKey>,
+        base_contains: impl Fn(&FileActionKey) -> bool,
     ) -> DeltaResult<IncrementalScanSummaryAgainstBase> {
         let summary = self.into_summary()?;
-        let duplicate_adds: HashSet<FileActionKey> =
-            summary.live_adds.intersection(base_keys).cloned().collect();
+        let duplicate_adds: HashSet<FileActionKey> = summary
+            .live_adds
+            .iter()
+            .filter(|k| base_contains(k))
+            .cloned()
+            .collect();
         Ok(IncrementalScanSummaryAgainstBase {
             base_version: summary.base_version,
             target_version: summary.target_version,
@@ -317,18 +313,15 @@ impl IncrementalScanStream {
     /// [`into_summary_against_base`] against `base_keys`. Returns an
     /// [`IncrementalListingAgainstBase`] with the classified summary.
     ///
-    /// Prefer [`into_listing_against_base_set`] when your cache already holds a
-    /// `HashSet<FileActionKey>` — see [`into_summary_against_base_set`] for the rationale.
-    ///
-    /// # Errors
-    /// See [`into_summary_against_base`].
+    /// Prefer [`into_listing_against_base_with`] when your base supports `contains`-style
+    /// lookup — see [`into_summary_against_base_with`] for the rationale.
     ///
     /// [`into_summary_against_base`]: Self::into_summary_against_base
-    /// [`into_summary_against_base_set`]: Self::into_summary_against_base_set
-    /// [`into_listing_against_base_set`]: Self::into_listing_against_base_set
-    pub fn into_listing_against_base(
+    /// [`into_summary_against_base_with`]: Self::into_summary_against_base_with
+    /// [`into_listing_against_base_with`]: Self::into_listing_against_base_with
+    pub fn into_listing_against_base<'a>(
         mut self,
-        base_keys: impl IntoIterator<Item = FileActionKey>,
+        base_keys: impl IntoIterator<Item = &'a FileActionKey>,
     ) -> DeltaResult<IncrementalListingAgainstBase> {
         let mut add_files: Vec<FilteredEngineData> = Vec::new();
         for item in self.by_ref() {
@@ -338,24 +331,20 @@ impl IncrementalScanStream {
         Ok(IncrementalListingAgainstBase { summary, add_files })
     }
 
-    /// HashSet form of [`into_listing_against_base`]; see
-    /// [`into_summary_against_base_set`] for the rationale.
-    ///
-    /// # Errors
-    /// See [`into_summary_against_base`].
+    /// Predicate form of [`into_listing_against_base`]; see
+    /// [`into_summary_against_base_with`] for the rationale.
     ///
     /// [`into_listing_against_base`]: Self::into_listing_against_base
-    /// [`into_summary_against_base`]: Self::into_summary_against_base
-    /// [`into_summary_against_base_set`]: Self::into_summary_against_base_set
-    pub fn into_listing_against_base_set(
+    /// [`into_summary_against_base_with`]: Self::into_summary_against_base_with
+    pub fn into_listing_against_base_with(
         mut self,
-        base_keys: &HashSet<FileActionKey>,
+        base_contains: impl Fn(&FileActionKey) -> bool,
     ) -> DeltaResult<IncrementalListingAgainstBase> {
         let mut add_files: Vec<FilteredEngineData> = Vec::new();
         for item in self.by_ref() {
             add_files.push(item?);
         }
-        let summary = self.into_summary_against_base_set(base_keys)?;
+        let summary = self.into_summary_against_base_with(base_contains)?;
         Ok(IncrementalListingAgainstBase { summary, add_files })
     }
 }

--- a/kernel/src/incremental_scan/mod.rs
+++ b/kernel/src/incremental_scan/mod.rs
@@ -249,15 +249,15 @@ impl IncrementalScanStream {
     /// listing that the range re-adds with new metadata, e.g. OPTIMIZE / liquid
     /// clustering re-tag).
     ///
-    /// Sugar over [`finish`] plus a single pass over `base_keys`. The iterator is
+    /// Sugar over [`into_summary`] plus a single pass over `base_keys`. The iterator is
     /// consumed exactly once; memory stays `O(surviving_adds)`.
     ///
-    /// [`finish`]: Self::finish
-    pub fn finish_against_base(
+    /// [`into_summary`]: Self::into_summary
+    pub fn into_summary_against_base(
         self,
         base_keys: impl IntoIterator<Item = FileActionKey>,
     ) -> DeltaResult<IncrementalScanSummaryAgainstBase> {
-        let summary = self.finish()?;
+        let summary = self.into_summary()?;
         let duplicate_adds: HashSet<FileActionKey> = base_keys
             .into_iter()
             .filter(|k| summary.surviving_adds.contains(k))
@@ -271,11 +271,11 @@ impl IncrementalScanStream {
     }
 
     /// Eager classified helper: collect every surviving Add batch and call
-    /// [`finish_against_base`] against `base_keys`. Returns an
+    /// [`into_summary_against_base`] against `base_keys`. Returns an
     /// [`IncrementalListingAgainstBase`] with the classified summary.
     ///
-    /// [`finish_against_base`]: Self::finish_against_base
-    pub fn collect_listing_against_base(
+    /// [`into_summary_against_base`]: Self::into_summary_against_base
+    pub fn into_listing_against_base(
         mut self,
         base_keys: impl IntoIterator<Item = FileActionKey>,
     ) -> DeltaResult<IncrementalListingAgainstBase> {
@@ -283,7 +283,7 @@ impl IncrementalScanStream {
         for item in self.by_ref() {
             add_files.push(item?);
         }
-        let summary = self.finish_against_base(base_keys)?;
+        let summary = self.into_summary_against_base(base_keys)?;
         Ok(IncrementalListingAgainstBase { summary, add_files })
     }
 }
@@ -343,7 +343,7 @@ impl std::fmt::Debug for IncrementalListing {
 }
 
 /// Cross-snapshot-classified file-key sets, returned by
-/// [`IncrementalScanStream::finish_against_base`].
+/// [`IncrementalScanStream::into_summary_against_base`].
 ///
 /// To advance a delta-on-base file listing cache, append the streamed Add batches to
 /// the delta layer and use the union `removes U duplicate_adds` as the remove-mask
@@ -367,7 +367,7 @@ pub struct IncrementalScanSummaryAgainstBase {
     pub removes: HashSet<FileActionKey>,
 }
 
-/// Eager output of [`IncrementalScanStream::collect_listing_against_base`]: the buffered
+/// Eager output of [`IncrementalScanStream::into_listing_against_base`]: the buffered
 /// Add batches plus the classified summary.
 #[non_exhaustive]
 pub struct IncrementalListingAgainstBase {

--- a/kernel/src/incremental_scan/mod.rs
+++ b/kernel/src/incremental_scan/mod.rs
@@ -243,6 +243,49 @@ impl IncrementalScanStream {
         let summary = self.into_summary()?;
         Ok(IncrementalListing { summary, add_files })
     }
+
+    /// Drain any unread batches, then intersect `base_keys` against the surviving-Add
+    /// file-key set to compute `duplicate_adds` (file keys in the consumer's base
+    /// listing that the range re-adds with new metadata, e.g. OPTIMIZE / liquid
+    /// clustering re-tag).
+    ///
+    /// Sugar over [`finish`] plus a single pass over `base_keys`. The iterator is
+    /// consumed exactly once; memory stays `O(surviving_adds)`.
+    ///
+    /// [`finish`]: Self::finish
+    pub fn finish_against_base(
+        self,
+        base_keys: impl IntoIterator<Item = FileActionKey>,
+    ) -> DeltaResult<IncrementalScanSummaryAgainstBase> {
+        let summary = self.finish()?;
+        let duplicate_adds: HashSet<FileActionKey> = base_keys
+            .into_iter()
+            .filter(|k| summary.surviving_adds.contains(k))
+            .collect();
+        Ok(IncrementalScanSummaryAgainstBase {
+            base_version: summary.base_version,
+            target_version: summary.target_version,
+            duplicate_adds,
+            removes: summary.removes,
+        })
+    }
+
+    /// Eager classified helper: collect every surviving Add batch and call
+    /// [`finish_against_base`] against `base_keys`. Returns an
+    /// [`IncrementalListingAgainstBase`] with the classified summary.
+    ///
+    /// [`finish_against_base`]: Self::finish_against_base
+    pub fn collect_listing_against_base(
+        mut self,
+        base_keys: impl IntoIterator<Item = FileActionKey>,
+    ) -> DeltaResult<IncrementalListingAgainstBase> {
+        let mut add_files: Vec<FilteredEngineData> = Vec::new();
+        for item in self.by_ref() {
+            add_files.push(item?);
+        }
+        let summary = self.finish_against_base(base_keys)?;
+        Ok(IncrementalListingAgainstBase { summary, add_files })
+    }
 }
 
 impl std::fmt::Debug for IncrementalScanStream {
@@ -293,6 +336,50 @@ pub struct IncrementalListing {
 impl std::fmt::Debug for IncrementalListing {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("IncrementalListing")
+            .field("summary", &self.summary)
+            .field("add_files_batch_count", &self.add_files.len())
+            .finish()
+    }
+}
+
+/// Cross-snapshot-classified file-key sets, returned by
+/// [`IncrementalScanStream::finish_against_base`].
+///
+/// To advance a delta-on-base file listing cache, append the streamed Add batches to
+/// the delta layer and use the union `removes U duplicate_adds` as the remove-mask
+/// against the base. Both sets are required: `removes` masks files that left the table;
+/// `duplicate_adds` masks the stale base entry of each file the range re-added with new
+/// metadata. Matching against the full `(path, dv_unique_id)` key (not path alone) keeps
+/// distinct DV-revision entries separate.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct IncrementalScanSummaryAgainstBase {
+    /// Exclusive lower bound of the scan range.
+    pub base_version: Version,
+    /// Inclusive upper bound; equals the source snapshot's version.
+    pub target_version: Version,
+    /// File keys from the surviving Add stream that also appear in the consumer's base
+    /// listing (metadata-only re-adds, e.g. OPTIMIZE / liquid clustering re-tag).
+    /// The corresponding rows are still in the streamed Adds.
+    pub duplicate_adds: HashSet<FileActionKey>,
+    /// File keys of surviving Remove actions. Consumers must union this with
+    /// `duplicate_adds` when masking the base.
+    pub removes: HashSet<FileActionKey>,
+}
+
+/// Eager output of [`IncrementalScanStream::collect_listing_against_base`]: the buffered
+/// Add batches plus the classified summary.
+#[non_exhaustive]
+pub struct IncrementalListingAgainstBase {
+    /// Classified file-key sets for the range; see [`IncrementalScanSummaryAgainstBase`].
+    pub summary: IncrementalScanSummaryAgainstBase,
+    /// All surviving Add batches in descending commit-version order.
+    pub add_files: Vec<FilteredEngineData>,
+}
+
+impl std::fmt::Debug for IncrementalListingAgainstBase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IncrementalListingAgainstBase")
             .field("summary", &self.summary)
             .field("add_files_batch_count", &self.add_files.len())
             .finish()

--- a/kernel/src/incremental_scan/mod.rs
+++ b/kernel/src/incremental_scan/mod.rs
@@ -248,10 +248,30 @@ impl IncrementalScanStream {
     /// set to compute `duplicate_adds` (file keys in the consumer's base listing that the
     /// range re-adds with new metadata, e.g. OPTIMIZE / liquid clustering re-tag).
     ///
-    /// Sugar over [`into_summary`] plus a single pass over `base_keys`. The iterator is
-    /// consumed exactly once; memory stays `O(live_adds)`.
+    /// Streaming form: accepts any source of base keys (Vec, lazy iterator, paginated
+    /// cache lookup, etc.). Kernel does not materialize a HashSet of base keys — it
+    /// streams `base_keys` once and tests each against the live-Add set. Use this when
+    /// your base file-keys are not already held in a HashSet, or are large enough that
+    /// materializing one upfront is wasteful.
+    ///
+    /// Prefer [`into_summary_against_base_set`] when your cache already holds a
+    /// `HashSet<FileActionKey>` you keep across diffs — it avoids the call-site
+    /// `iter().cloned()` and clones only the intersection.
+    ///
+    /// # Errors
+    /// Inherits all errors from [`into_summary`]. Two categories:
+    /// - Stream previously yielded `Some(Err(_))` from [`Iterator::next`]: dedup state is
+    ///   incomplete, so this call returns `Err` rather than a partial summary. Not recoverable on
+    ///   this stream — the consumer must rebuild the stream from [`IncrementalScanBuilder`] to
+    ///   retry.
+    /// - Draining the remaining batches produces an `Err` (engine I/O, JSON parse, etc.). The
+    ///   underlying engine error determines retryability; typically retryable by rebuilding the
+    ///   stream.
+    ///
+    /// This method itself adds no new error conditions over [`into_summary`].
     ///
     /// [`into_summary`]: Self::into_summary
+    /// [`into_summary_against_base_set`]: Self::into_summary_against_base_set
     pub fn into_summary_against_base(
         self,
         base_keys: impl IntoIterator<Item = FileActionKey>,
@@ -269,11 +289,43 @@ impl IncrementalScanStream {
         })
     }
 
+    /// HashSet form of [`into_summary_against_base`]: pass a borrowed `&HashSet` directly
+    /// when your cache already holds one and you keep it across diffs. Iterates the
+    /// live-Add set (typically smaller than `base_keys`) and clones only the intersection
+    /// — strictly fewer clones than the streaming form's call-site `iter().cloned()`.
+    ///
+    /// # Errors
+    /// See [`into_summary_against_base`].
+    ///
+    /// [`into_summary_against_base`]: Self::into_summary_against_base
+    pub fn into_summary_against_base_set(
+        self,
+        base_keys: &HashSet<FileActionKey>,
+    ) -> DeltaResult<IncrementalScanSummaryAgainstBase> {
+        let summary = self.into_summary()?;
+        let duplicate_adds: HashSet<FileActionKey> =
+            summary.live_adds.intersection(base_keys).cloned().collect();
+        Ok(IncrementalScanSummaryAgainstBase {
+            base_version: summary.base_version,
+            target_version: summary.target_version,
+            duplicate_adds,
+            removes: summary.removes,
+        })
+    }
+
     /// Eager classified helper: collect every live Add batch and call
     /// [`into_summary_against_base`] against `base_keys`. Returns an
     /// [`IncrementalListingAgainstBase`] with the classified summary.
     ///
+    /// Prefer [`into_listing_against_base_set`] when your cache already holds a
+    /// `HashSet<FileActionKey>` — see [`into_summary_against_base_set`] for the rationale.
+    ///
+    /// # Errors
+    /// See [`into_summary_against_base`].
+    ///
     /// [`into_summary_against_base`]: Self::into_summary_against_base
+    /// [`into_summary_against_base_set`]: Self::into_summary_against_base_set
+    /// [`into_listing_against_base_set`]: Self::into_listing_against_base_set
     pub fn into_listing_against_base(
         mut self,
         base_keys: impl IntoIterator<Item = FileActionKey>,
@@ -283,6 +335,27 @@ impl IncrementalScanStream {
             add_files.push(item?);
         }
         let summary = self.into_summary_against_base(base_keys)?;
+        Ok(IncrementalListingAgainstBase { summary, add_files })
+    }
+
+    /// HashSet form of [`into_listing_against_base`]; see
+    /// [`into_summary_against_base_set`] for the rationale.
+    ///
+    /// # Errors
+    /// See [`into_summary_against_base`].
+    ///
+    /// [`into_listing_against_base`]: Self::into_listing_against_base
+    /// [`into_summary_against_base`]: Self::into_summary_against_base
+    /// [`into_summary_against_base_set`]: Self::into_summary_against_base_set
+    pub fn into_listing_against_base_set(
+        mut self,
+        base_keys: &HashSet<FileActionKey>,
+    ) -> DeltaResult<IncrementalListingAgainstBase> {
+        let mut add_files: Vec<FilteredEngineData> = Vec::new();
+        for item in self.by_ref() {
+            add_files.push(item?);
+        }
+        let summary = self.into_summary_against_base_set(base_keys)?;
         Ok(IncrementalListingAgainstBase { summary, add_files })
     }
 }

--- a/kernel/src/incremental_scan/mod.rs
+++ b/kernel/src/incremental_scan/mod.rs
@@ -203,13 +203,17 @@ impl IncrementalScanStream {
     /// data structure they prefer.
     ///
     /// # Errors
-    /// - [`Error::IOError`] / [`Error::ObjectStore`] / [`Error::Reqwest`] -- transient I/O on
-    ///   commit reads; retryable by rebuilding the stream.
-    /// - [`Error::FileNotFound`] -- commit vacuumed mid-scan; rebuilding will likely return
-    ///   `Ok(None)` (commits unavailable), fall back to [`crate::Snapshot::scan_builder`].
-    /// - [`Error::MalformedJson`] -- commit corruption; not retryable.
-    /// - [`Error::Generic`] "cannot finish a stream that previously errored" -- terminal called on
-    ///   a stream whose `next()` already returned `Err`; rebuild to retry.
+    /// - [`Error::IOError`], [`Error::ObjectStore`], or [`Error::Reqwest`] on transient I/O while
+    ///   reading commit JSONs. Retryable by rebuilding the stream.
+    /// - [`Error::FileNotFound`] if a commit was vacuumed between [`IncrementalScanBuilder::build`]
+    ///   and stream consumption. Rebuilding will likely return `Ok(None)` (commits unavailable);
+    ///   fall back to [`crate::Snapshot::scan_builder`].
+    /// - [`Error::MalformedJson`] or [`Error::Arrow`] (default-engine) on commit JSON corruption.
+    ///   Not retryable.
+    /// - [`Error::Generic`] on malformed `deletionVector` fields in a commit row, or on "cannot
+    ///   finish a stream that previously errored" when a terminal method is called after a prior
+    ///   `next()` returned `Err`. Rebuild to retry the latter; the former indicates table
+    ///   corruption.
     pub fn into_summary(mut self) -> DeltaResult<IncrementalScanSummary> {
         if self.errored {
             return Err(Error::generic(

--- a/kernel/src/incremental_scan/mod.rs
+++ b/kernel/src/incremental_scan/mod.rs
@@ -268,8 +268,6 @@ impl IncrementalScanStream {
     ///   underlying engine error determines retryability; typically retryable by rebuilding the
     ///   stream.
     ///
-    /// This method itself adds no new error conditions over [`into_summary`].
-    ///
     /// [`into_summary`]: Self::into_summary
     /// [`into_summary_against_base_set`]: Self::into_summary_against_base_set
     pub fn into_summary_against_base(

--- a/kernel/src/incremental_scan/mod.rs
+++ b/kernel/src/incremental_scan/mod.rs
@@ -251,12 +251,14 @@ impl IncrementalScanStream {
     /// Streaming form: accepts any source of base keys (Vec, lazy iterator, paginated
     /// cache lookup, etc.). Kernel does not materialize a HashSet of base keys — it
     /// streams `base_keys` once and tests each against the live-Add set. Use this when
-    /// your base file-keys are not already held in a HashSet, or are large enough that
-    /// materializing one upfront is wasteful.
+    /// your cache holds base keys in any shape other than `HashSet<FileActionKey>`:
+    /// constructing a HashSet just to call [`into_summary_against_base_set`] would cost
+    /// `O(|base|)` hashing + allocation, exceeding the work this method does.
     ///
-    /// Prefer [`into_summary_against_base_set`] when your cache already holds a
-    /// `HashSet<FileActionKey>` you keep across diffs — it avoids the call-site
-    /// `iter().cloned()` and clones only the intersection.
+    /// Prefer [`into_summary_against_base_set`] only when your cache *already* holds a
+    /// `HashSet<FileActionKey>` you keep across diffs. That form uses `.intersection()` to
+    /// iterate the (typically much smaller) live-Add set instead of the whole base, so
+    /// the work drops from `O(|base|)` to `O(|live_adds|)`.
     ///
     /// # Errors
     /// Inherits all errors from [`into_summary`]. Two categories:

--- a/kernel/tests/incremental_scan.rs
+++ b/kernel/tests/incremental_scan.rs
@@ -915,7 +915,7 @@ async fn single_commit_split_across_batches_dedups_correctly(
 
 // === Classification ===
 //
-// `into_summary_against_base(base_keys)` and `into_listing_against_base(base_keys)`
+// `into_summary_against_base_iter(base_keys)` / `into_listing_against_base_iter(base_keys)`
 // intersect the consumer's base file keys (`(path, dv_unique_id)`) against the live
 // Adds to surface metadata-only re-adds in `duplicate_adds`. The Add row itself stays in
 // the streamed Adds; the key is also surfaced separately so the consumer can mask the
@@ -927,8 +927,8 @@ fn unwrap_classified_listing<'a>(
 ) -> IncrementalListingAgainstBase {
     result
         .expect("expected Some(stream), got None (commits unavailable)")
-        .into_listing_against_base(base_keys)
-        .expect("into_listing_against_base succeeded")
+        .into_listing_against_base_iter(base_keys)
+        .expect("into_listing_against_base_iter succeeded")
 }
 
 fn classified_add_count(listing: &IncrementalListingAgainstBase) -> usize {
@@ -993,7 +993,7 @@ async fn classifies_metadata_only_re_adds(
 }
 
 // The pull-then-finalize flow: drive the iterator manually with `next()`, then call
-// `into_summary_against_base(base_keys)`. This is the documented streaming consumer
+// `into_summary_against_base_iter(base_keys)`. This is the documented streaming consumer
 // pattern.
 #[tokio::test]
 async fn into_summary_after_manual_streaming_classifies_duplicates(
@@ -1036,7 +1036,7 @@ async fn into_summary_after_manual_streaming_classifies_duplicates(
     assert_eq!(yielded, 1, "v1 produced one Add batch");
 
     let base_keys = [key("re-added.parquet"), key("not-in-range.parquet")];
-    let summary = stream.into_summary_against_base(&base_keys)?;
+    let summary = stream.into_summary_against_base_iter(&base_keys)?;
     assert_eq!(
         summary.duplicate_adds,
         HashSet::from([key("re-added.parquet")]),
@@ -1091,7 +1091,7 @@ async fn predicate_variants_match_iterator_variants() -> Result<(), Box<dyn std:
         .incremental_scan_builder(0)
         .build(engine.as_ref())?
         .expect("expected Some(stream)");
-    let summary_with = stream.into_summary_against_base_with(|k| base_index.contains_key(k))?;
+    let summary_with = stream.into_summary_against_base_closure(|k| base_index.contains_key(k))?;
     assert_eq!(
         summary_with.duplicate_adds,
         HashSet::from([key("re-added.parquet")]),
@@ -1102,7 +1102,7 @@ async fn predicate_variants_match_iterator_variants() -> Result<(), Box<dyn std:
         .incremental_scan_builder(0)
         .build(engine.as_ref())?
         .expect("expected Some(stream)");
-    let listing_with = stream.into_listing_against_base_with(|k| base_index.contains_key(k))?;
+    let listing_with = stream.into_listing_against_base_closure(|k| base_index.contains_key(k))?;
     assert_eq!(
         listing_with.summary.duplicate_adds,
         summary_with.duplicate_adds
@@ -1149,7 +1149,7 @@ async fn empty_base_keys_produces_no_duplicates() -> Result<(), Box<dyn std::err
         .build(engine.as_ref())?
         .expect("expected Some(stream)");
     let empty: [FileActionKey; 0] = [];
-    let summary_iter = stream.into_summary_against_base(&empty)?;
+    let summary_iter = stream.into_summary_against_base_iter(&empty)?;
     assert!(summary_iter.duplicate_adds.is_empty());
     assert_eq!(summary_iter.removes, HashSet::from([key("gone.parquet")]));
 
@@ -1158,7 +1158,7 @@ async fn empty_base_keys_produces_no_duplicates() -> Result<(), Box<dyn std::err
         .incremental_scan_builder(0)
         .build(engine.as_ref())?
         .expect("expected Some(stream)");
-    let summary_with = stream.into_summary_against_base_with(|_| false)?;
+    let summary_with = stream.into_summary_against_base_closure(|_| false)?;
     assert!(summary_with.duplicate_adds.is_empty());
     assert_eq!(summary_with.removes, HashSet::from([key("gone.parquet")]));
 

--- a/kernel/tests/incremental_scan.rs
+++ b/kernel/tests/incremental_scan.rs
@@ -915,11 +915,11 @@ async fn single_commit_split_across_batches_dedups_correctly(
 
 // === Classification ===
 //
-// `finish_against_base(base_keys)` and `collect_listing_against_base(base_keys)` intersect
-// the consumer's base file keys (`(path, dv_unique_id)`) against the surviving Adds to
-// surface metadata-only re-adds in `duplicate_adds`. The Add row itself stays in the
-// streamed Adds; the key is also surfaced separately so the consumer can mask the stale
-// base entry.
+// `into_summary_against_base(base_keys)` and `into_listing_against_base(base_keys)`
+// intersect the consumer's base file keys (`(path, dv_unique_id)`) against the surviving
+// Adds to surface metadata-only re-adds in `duplicate_adds`. The Add row itself stays in
+// the streamed Adds; the key is also surfaced separately so the consumer can mask the
+// stale base entry.
 
 fn unwrap_classified_listing(
     result: Option<IncrementalScanStream>,
@@ -927,8 +927,8 @@ fn unwrap_classified_listing(
 ) -> IncrementalListingAgainstBase {
     result
         .expect("expected Some(stream), got None (commits unavailable)")
-        .collect_listing_against_base(base_keys)
-        .expect("collect_listing_against_base succeeded")
+        .into_listing_against_base(base_keys)
+        .expect("into_listing_against_base succeeded")
 }
 
 fn classified_add_count(listing: &IncrementalListingAgainstBase) -> usize {
@@ -992,9 +992,10 @@ async fn classifies_metadata_only_re_adds(
 }
 
 // The pull-then-finalize flow: drive the iterator manually with `next()`, then call
-// `finish_against_base(base_keys)`. This is the documented streaming consumer pattern.
+// `into_summary_against_base(base_keys)`. This is the documented streaming consumer
+// pattern.
 #[tokio::test]
-async fn finish_after_manual_streaming_classifies_duplicates(
+async fn into_summary_after_manual_streaming_classifies_duplicates(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let (storage, engine, table_url) = setup_test();
     let table_root = table_url.as_str();
@@ -1034,7 +1035,7 @@ async fn finish_after_manual_streaming_classifies_duplicates(
     assert_eq!(yielded, 1, "v1 produced one Add batch");
 
     let summary =
-        stream.finish_against_base([key("re-added.parquet"), key("not-in-range.parquet")])?;
+        stream.into_summary_against_base([key("re-added.parquet"), key("not-in-range.parquet")])?;
     assert_eq!(
         summary.duplicate_adds,
         HashSet::from([key("re-added.parquet")]),

--- a/kernel/tests/incremental_scan.rs
+++ b/kernel/tests/incremental_scan.rs
@@ -1045,3 +1045,65 @@ async fn into_summary_after_manual_streaming_classifies_duplicates(
 
     Ok(())
 }
+
+// HashSet variants (`*_set`) take `&HashSet<FileActionKey>` and produce the same
+// `duplicate_adds` as the streaming-iterator variants. Asserts that for a fixed
+// (range, base) pair both forms agree on the classified output.
+#[tokio::test]
+async fn hashset_variants_match_iterator_variants() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        actions_to_string(vec![TestAction::Metadata]),
+    )
+    .await?;
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        1,
+        actions_to_string(vec![
+            TestAction::Add("brand-new.parquet".to_string()),
+            TestAction::Add("re-added.parquet".to_string()),
+        ]),
+    )
+    .await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(1)
+        .build(engine.as_ref())?;
+
+    let base_keys: HashSet<FileActionKey> =
+        [key("re-added.parquet"), key("not-in-range.parquet")].into();
+
+    // HashSet form of into_summary_against_base.
+    let stream = target
+        .clone()
+        .incremental_scan_builder(0)
+        .build(engine.as_ref())?
+        .expect("expected Some(stream)");
+    let summary_set = stream.into_summary_against_base_set(&base_keys)?;
+    assert_eq!(
+        summary_set.duplicate_adds,
+        HashSet::from([key("re-added.parquet")]),
+    );
+    assert!(summary_set.removes.is_empty());
+
+    // HashSet form of into_listing_against_base produces the same classification.
+    let stream = target
+        .incremental_scan_builder(0)
+        .build(engine.as_ref())?
+        .expect("expected Some(stream)");
+    let listing_set = stream.into_listing_against_base_set(&base_keys)?;
+    assert_eq!(
+        listing_set.summary.duplicate_adds,
+        summary_set.duplicate_adds
+    );
+    assert_eq!(listing_set.summary.removes, summary_set.removes);
+    assert_eq!(classified_add_count(&listing_set), 2);
+
+    Ok(())
+}

--- a/kernel/tests/incremental_scan.rs
+++ b/kernel/tests/incremental_scan.rs
@@ -1112,3 +1112,55 @@ async fn predicate_variants_match_iterator_variants() -> Result<(), Box<dyn std:
 
     Ok(())
 }
+
+// Empty base: `duplicate_adds` is empty (nothing in the range overlaps the empty base),
+// but `removes` still surfaces every range remove. Exercises both against-base forms.
+#[tokio::test]
+async fn empty_base_keys_produces_no_duplicates() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        actions_to_string(vec![TestAction::Metadata]),
+    )
+    .await?;
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        1,
+        actions_to_string(vec![
+            TestAction::Add("a.parquet".to_string()),
+            TestAction::Remove("gone.parquet".to_string()),
+        ]),
+    )
+    .await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(1)
+        .build(engine.as_ref())?;
+
+    // By-ref iterator with empty input.
+    let stream = target
+        .clone()
+        .incremental_scan_builder(0)
+        .build(engine.as_ref())?
+        .expect("expected Some(stream)");
+    let empty: [FileActionKey; 0] = [];
+    let summary_iter = stream.into_summary_against_base(&empty)?;
+    assert!(summary_iter.duplicate_adds.is_empty());
+    assert_eq!(summary_iter.removes, HashSet::from([key("gone.parquet")]));
+
+    // Predicate closure that always returns false.
+    let stream = target
+        .incremental_scan_builder(0)
+        .build(engine.as_ref())?
+        .expect("expected Some(stream)");
+    let summary_with = stream.into_summary_against_base_with(|_| false)?;
+    assert!(summary_with.duplicate_adds.is_empty());
+    assert_eq!(summary_with.removes, HashSet::from([key("gone.parquet")]));
+
+    Ok(())
+}

--- a/kernel/tests/incremental_scan.rs
+++ b/kernel/tests/incremental_scan.rs
@@ -916,7 +916,7 @@ async fn single_commit_split_across_batches_dedups_correctly(
 // === Classification ===
 //
 // `into_summary_against_base(base_keys)` and `into_listing_against_base(base_keys)`
-// intersect the consumer's base file keys (`(path, dv_unique_id)`) against the surviving
+// intersect the consumer's base file keys (`(path, dv_unique_id)`) against the live
 // Adds to surface metadata-only re-adds in `duplicate_adds`. The Add row itself stays in
 // the streamed Adds; the key is also surfaced separately so the consumer can mask the
 // stale base entry.
@@ -956,7 +956,7 @@ fn classified_add_count(listing: &IncrementalListingAgainstBase) -> usize {
 async fn classifies_metadata_only_re_adds(
     #[case] range_adds: Vec<&'static str>,
     #[case] base_paths: Vec<&'static str>,
-    #[case] expected_surviving: usize,
+    #[case] expected_live: usize,
     #[case] expected_duplicates: Vec<&'static str>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let (storage, engine, table_url) = setup_test();
@@ -983,7 +983,7 @@ async fn classifies_metadata_only_re_adds(
         base_paths.iter().map(|p| key(p)),
     );
 
-    assert_eq!(classified_add_count(&listing), expected_surviving);
+    assert_eq!(classified_add_count(&listing), expected_live);
     let expected: HashSet<FileActionKey> = expected_duplicates.iter().map(|p| key(p)).collect();
     assert_eq!(listing.summary.duplicate_adds, expected);
     assert!(listing.summary.removes.is_empty());

--- a/kernel/tests/incremental_scan.rs
+++ b/kernel/tests/incremental_scan.rs
@@ -921,9 +921,9 @@ async fn single_commit_split_across_batches_dedups_correctly(
 // the streamed Adds; the key is also surfaced separately so the consumer can mask the
 // stale base entry.
 
-fn unwrap_classified_listing(
+fn unwrap_classified_listing<'a>(
     result: Option<IncrementalScanStream>,
-    base_keys: impl IntoIterator<Item = FileActionKey>,
+    base_keys: impl IntoIterator<Item = &'a FileActionKey>,
 ) -> IncrementalListingAgainstBase {
     result
         .expect("expected Some(stream), got None (commits unavailable)")
@@ -978,9 +978,10 @@ async fn classifies_metadata_only_re_adds(
     let target = Snapshot::builder_for(table_url)
         .at_version(1)
         .build(engine.as_ref())?;
+    let base_keys: Vec<FileActionKey> = base_paths.iter().map(|p| key(p)).collect();
     let listing = unwrap_classified_listing(
         target.incremental_scan_builder(0).build(engine.as_ref())?,
-        base_paths.iter().map(|p| key(p)),
+        &base_keys,
     );
 
     assert_eq!(classified_add_count(&listing), expected_live);
@@ -1034,8 +1035,8 @@ async fn into_summary_after_manual_streaming_classifies_duplicates(
     }
     assert_eq!(yielded, 1, "v1 produced one Add batch");
 
-    let summary =
-        stream.into_summary_against_base([key("re-added.parquet"), key("not-in-range.parquet")])?;
+    let base_keys = [key("re-added.parquet"), key("not-in-range.parquet")];
+    let summary = stream.into_summary_against_base(&base_keys)?;
     assert_eq!(
         summary.duplicate_adds,
         HashSet::from([key("re-added.parquet")]),
@@ -1046,11 +1047,13 @@ async fn into_summary_after_manual_streaming_classifies_duplicates(
     Ok(())
 }
 
-// HashSet variants (`*_set`) take `&HashSet<FileActionKey>` and produce the same
-// `duplicate_adds` as the streaming-iterator variants. Asserts that for a fixed
-// (range, base) pair both forms agree on the classified output.
+// Predicate variants (`*_with`) take a closure and produce the same `duplicate_adds`
+// as the iterator variants. Asserts that for a fixed (range, base) pair both forms
+// agree on the classified output. Demonstrates HashMap-backed base via closure.
 #[tokio::test]
-async fn hashset_variants_match_iterator_variants() -> Result<(), Box<dyn std::error::Error>> {
+async fn predicate_variants_match_iterator_variants() -> Result<(), Box<dyn std::error::Error>> {
+    use std::collections::HashMap;
+
     let (storage, engine, table_url) = setup_test();
     let table_root = table_url.as_str();
 
@@ -1076,34 +1079,36 @@ async fn hashset_variants_match_iterator_variants() -> Result<(), Box<dyn std::e
         .at_version(1)
         .build(engine.as_ref())?;
 
-    let base_keys: HashSet<FileActionKey> =
-        [key("re-added.parquet"), key("not-in-range.parquet")].into();
+    // Base lives in a HashMap (key -> metadata). Closure does the contains-check.
+    let base_index: HashMap<FileActionKey, i64> = [
+        (key("re-added.parquet"), 100),
+        (key("not-in-range.parquet"), 200),
+    ]
+    .into();
 
-    // HashSet form of into_summary_against_base.
     let stream = target
         .clone()
         .incremental_scan_builder(0)
         .build(engine.as_ref())?
         .expect("expected Some(stream)");
-    let summary_set = stream.into_summary_against_base_set(&base_keys)?;
+    let summary_with = stream.into_summary_against_base_with(|k| base_index.contains_key(k))?;
     assert_eq!(
-        summary_set.duplicate_adds,
+        summary_with.duplicate_adds,
         HashSet::from([key("re-added.parquet")]),
     );
-    assert!(summary_set.removes.is_empty());
+    assert!(summary_with.removes.is_empty());
 
-    // HashSet form of into_listing_against_base produces the same classification.
     let stream = target
         .incremental_scan_builder(0)
         .build(engine.as_ref())?
         .expect("expected Some(stream)");
-    let listing_set = stream.into_listing_against_base_set(&base_keys)?;
+    let listing_with = stream.into_listing_against_base_with(|k| base_index.contains_key(k))?;
     assert_eq!(
-        listing_set.summary.duplicate_adds,
-        summary_set.duplicate_adds
+        listing_with.summary.duplicate_adds,
+        summary_with.duplicate_adds
     );
-    assert_eq!(listing_set.summary.removes, summary_set.removes);
-    assert_eq!(classified_add_count(&listing_set), 2);
+    assert_eq!(listing_with.summary.removes, summary_with.removes);
+    assert_eq!(classified_add_count(&listing_with), 2);
 
     Ok(())
 }

--- a/kernel/tests/incremental_scan.rs
+++ b/kernel/tests/incremental_scan.rs
@@ -11,7 +11,8 @@ use delta_kernel::engine::default::executor::tokio::TokioBackgroundExecutor;
 use delta_kernel::engine::default::json::DefaultJsonHandler;
 use delta_kernel::engine::default::{DefaultEngine, DefaultEngineBuilder};
 use delta_kernel::incremental_scan::{
-    IncrementalListing, IncrementalScanStream, IncrementalScanSummary,
+    IncrementalListing, IncrementalListingAgainstBase, IncrementalScanStream,
+    IncrementalScanSummary,
 };
 use delta_kernel::log_replay::FileActionKey;
 use delta_kernel::object_store::memory::InMemory;
@@ -908,6 +909,138 @@ async fn single_commit_split_across_batches_dedups_correctly(
         7,
         "selection-vector counts must not depend on batch_size (got batch_size={batch_size})"
     );
+
+    Ok(())
+}
+
+// === Classification ===
+//
+// `finish_against_base(base_keys)` and `collect_listing_against_base(base_keys)` intersect
+// the consumer's base file keys (`(path, dv_unique_id)`) against the surviving Adds to
+// surface metadata-only re-adds in `duplicate_adds`. The Add row itself stays in the
+// streamed Adds; the key is also surfaced separately so the consumer can mask the stale
+// base entry.
+
+fn unwrap_classified_listing(
+    result: Option<IncrementalScanStream>,
+    base_keys: impl IntoIterator<Item = FileActionKey>,
+) -> IncrementalListingAgainstBase {
+    result
+        .expect("expected Some(stream), got None (commits unavailable)")
+        .collect_listing_against_base(base_keys)
+        .expect("collect_listing_against_base succeeded")
+}
+
+fn classified_add_count(listing: &IncrementalListingAgainstBase) -> usize {
+    listing
+        .add_files
+        .iter()
+        .map(|f| f.selection_vector().iter().filter(|s| **s).count())
+        .sum()
+}
+
+#[rstest]
+#[case::all_re_adds(
+    vec!["re-added.parquet"],
+    vec!["re-added.parquet"],
+    1,
+    vec!["re-added.parquet"],
+)]
+#[case::mixed_new_and_re_added(
+    vec!["brand-new.parquet", "re-added.parquet"],
+    vec!["re-added.parquet"],
+    2,
+    vec!["re-added.parquet"],
+)]
+#[tokio::test]
+async fn classifies_metadata_only_re_adds(
+    #[case] range_adds: Vec<&'static str>,
+    #[case] base_paths: Vec<&'static str>,
+    #[case] expected_surviving: usize,
+    #[case] expected_duplicates: Vec<&'static str>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        actions_to_string(vec![TestAction::Metadata]),
+    )
+    .await?;
+    let actions: Vec<TestAction> = range_adds
+        .iter()
+        .map(|p| TestAction::Add(p.to_string()))
+        .collect();
+    add_commit(table_root, storage.as_ref(), 1, actions_to_string(actions)).await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(1)
+        .build(engine.as_ref())?;
+    let listing = unwrap_classified_listing(
+        target.incremental_scan_builder(0).build(engine.as_ref())?,
+        base_paths.iter().map(|p| key(p)),
+    );
+
+    assert_eq!(classified_add_count(&listing), expected_surviving);
+    let expected: HashSet<FileActionKey> = expected_duplicates.iter().map(|p| key(p)).collect();
+    assert_eq!(listing.summary.duplicate_adds, expected);
+    assert!(listing.summary.removes.is_empty());
+
+    Ok(())
+}
+
+// The pull-then-finalize flow: drive the iterator manually with `next()`, then call
+// `finish_against_base(base_keys)`. This is the documented streaming consumer pattern.
+#[tokio::test]
+async fn finish_after_manual_streaming_classifies_duplicates(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        actions_to_string(vec![TestAction::Metadata]),
+    )
+    .await?;
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        1,
+        actions_to_string(vec![
+            TestAction::Add("brand-new.parquet".to_string()),
+            TestAction::Add("re-added.parquet".to_string()),
+        ]),
+    )
+    .await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(1)
+        .build(engine.as_ref())?;
+
+    let mut stream = target
+        .incremental_scan_builder(0)
+        .build(engine.as_ref())?
+        .expect("expected Some(stream)");
+
+    let mut yielded = 0;
+    for item in stream.by_ref() {
+        let _batch = item?;
+        yielded += 1;
+    }
+    assert_eq!(yielded, 1, "v1 produced one Add batch");
+
+    let summary =
+        stream.finish_against_base([key("re-added.parquet"), key("not-in-range.parquet")])?;
+    assert_eq!(
+        summary.duplicate_adds,
+        HashSet::from([key("re-added.parquet")]),
+        "non-matching base key is filtered out"
+    );
+    assert!(summary.removes.is_empty());
 
     Ok(())
 }


### PR DESCRIPTION

## What changes are proposed in this pull request?

Adds cross-snapshot classification to `IncrementalScanStream` for connectors that maintain a key-indexed base file listing.

Two symmetric forms, picked by how the consumer's base supports key lookup:

- `into_summary_against_base_iter(impl IntoIterator<Item = &FileActionKey>)`. Kernel iterates them and probes the live-Add set per element. Use when keys are in a streamable shape (slice, `&Vec`, `&HashSet`, `map.keys()`, custom iterator) and there is no faster contains-check available. Work is O(|base|), zero call-site clones.

- `into_summary_against_base_closure(impl Fn(&FileActionKey) -> bool)` Kernel iterates the (typically much smaller) live-Add set and calls the closure once per live-Add key. Use when the base is `HashMap`, `HashSet`, `BTreeMap`, sorted Vec + binary search, or any custom indexed structure. Work is O(|live_adds|).

Eager counterparts `into_listing_against_base_iter` and `into_listing_against_base_closure` produce the same classification plus the buffered Add batches.

Both forms return `IncrementalScanSummaryAgainstBase { duplicate_adds: HashSet<FileActionKey>, removes: HashSet<FileActionKey> }`. Consumers append the streamed Adds to their delta layer and use `removes U duplicate_adds` as the remove-mask against their base.

`into_summary()` / `into_listing()` from #2519 remain the right shape for consumers without a key-indexed base.

## How was this change tested?

Integration tests, unit tests