### PR TITLE
feat!: add delta.parquet.compression.codec table property

### DIFF
--- a/kernel/src/table_properties/deserialize.rs
+++ b/kernel/src/table_properties/deserialize.rs
@@ -92,6 +92,11 @@ fn try_parse(props: &mut TableProperties, k: &str, v: &str) -> Option<()> {
         }
         ROW_TRACKING_SUSPENDED => props.row_tracking_suspended = Some(parse_bool(v)?),
         PARQUET_FORMAT_VERSION => props.parquet_format_version = Some(v.to_string()),
+        PARQUET_COMPRESSION_CODEC => {
+            // Preserve unrecognized codecs in `unknown_properties` so connectors can fall back
+            // themselves.
+            props.parquet_compression_codec = Some(ParquetCompressionCodec::try_from(v).ok()?)
+        }
         ENABLE_IN_COMMIT_TIMESTAMPS => props.enable_in_commit_timestamps = Some(parse_bool(v)?),
         IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION => {
             props.in_commit_timestamp_enablement_version = Some(parse_non_negative(v)?)
@@ -374,6 +379,72 @@ mod tests {
                 .unwrap()
                 .to_string(),
             "Interval 'interval -25 hours' cannot be negative".to_string()
+        );
+    }
+
+    #[test]
+    fn test_parse_compression_codec_accepts_all_variants_case_insensitively() {
+        use ParquetCompressionCodec::*;
+        for (input, expected) in [
+            ("uncompressed", Uncompressed),
+            ("UNCOMPRESSED", Uncompressed),
+            ("UnCoMpReSsEd", Uncompressed),
+            ("none", Uncompressed),
+            ("NONE", Uncompressed),
+            ("nOnE", Uncompressed),
+            ("snappy", Snappy),
+            ("SNAPPY", Snappy),
+            ("sNaPpY", Snappy),
+            ("gzip", Gzip),
+            ("GZIP", Gzip),
+            ("gZiP", Gzip),
+            ("lz4", Lz4),
+            ("LZ4", Lz4),
+            ("lZ4", Lz4),
+            ("lz4_raw", Lz4Raw),
+            ("LZ4_RAW", Lz4Raw),
+            ("Lz4_Raw", Lz4Raw),
+            ("zstd", Zstd),
+            ("ZSTD", Zstd),
+            ("zStD", Zstd),
+        ] {
+            let props = TableProperties::from([(PARQUET_COMPRESSION_CODEC, input)]);
+            assert_eq!(props.parquet_compression_codec, Some(expected), "{input}");
+            assert!(props.unknown_properties.is_empty(), "{input}");
+        }
+    }
+
+    #[test]
+    fn test_compression_codec_round_trips_to_canonical_protocol_string() {
+        use ParquetCompressionCodec::*;
+        // Each variant must Display-format to its Delta-protocol canonical name (lowercased,
+        // snake_case). The `Uncompressed` variant has `none` as a parser-only alias; its
+        // canonical output is `uncompressed`.
+        for (variant, expected) in [
+            (Zstd, "zstd"),
+            (Uncompressed, "uncompressed"),
+            (Snappy, "snappy"),
+            (Gzip, "gzip"),
+            (Lz4, "lz4"),
+            (Lz4Raw, "lz4_raw"),
+        ] {
+            assert_eq!(variant.to_string(), expected);
+            assert_eq!(<&'static str>::from(variant), expected);
+            // And the canonical string parses back to the same variant.
+            assert_eq!(
+                ParquetCompressionCodec::try_from(expected).unwrap(),
+                variant
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_compression_codec_unknown_falls_through_to_unknown_properties() {
+        let props = TableProperties::from([(PARQUET_COMPRESSION_CODEC, "brotli")]);
+        assert_eq!(props.parquet_compression_codec, None);
+        assert_eq!(
+            props.unknown_properties.get(PARQUET_COMPRESSION_CODEC),
+            Some(&"brotli".to_string())
         );
     }
 }

--- a/kernel/src/table_properties/deserialize.rs
+++ b/kernel/src/table_properties/deserialize.rs
@@ -227,6 +227,8 @@ fn parse_interval_impl(value: &str) -> Result<Duration, ParseIntervalError> {
 
 #[cfg(test)]
 mod tests {
+    use ParquetCompressionCodec::*;
+
     use super::*;
 
     #[test]
@@ -384,7 +386,6 @@ mod tests {
 
     #[test]
     fn test_parse_compression_codec_accepts_all_variants_case_insensitively() {
-        use ParquetCompressionCodec::*;
         for (input, expected) in [
             ("uncompressed", Uncompressed),
             ("UNCOMPRESSED", Uncompressed),
@@ -415,8 +416,17 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_compression_codec_unknown_falls_through_to_unknown_properties() {
+        let props = TableProperties::from([(PARQUET_COMPRESSION_CODEC, "brotli")]);
+        assert_eq!(props.parquet_compression_codec, None);
+        assert_eq!(
+            props.unknown_properties.get(PARQUET_COMPRESSION_CODEC),
+            Some(&"brotli".to_string())
+        );
+    }
+
+    #[test]
     fn test_compression_codec_round_trips_to_canonical_protocol_string() {
-        use ParquetCompressionCodec::*;
         // Each variant must Display-format to its Delta-protocol canonical name (lowercased,
         // snake_case). The `Uncompressed` variant has `none` as a parser-only alias; its
         // canonical output is `uncompressed`.
@@ -439,12 +449,13 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_compression_codec_unknown_falls_through_to_unknown_properties() {
-        let props = TableProperties::from([(PARQUET_COMPRESSION_CODEC, "brotli")]);
-        assert_eq!(props.parquet_compression_codec, None);
-        assert_eq!(
-            props.unknown_properties.get(PARQUET_COMPRESSION_CODEC),
-            Some(&"brotli".to_string())
-        );
+    fn test_compression_codec_or_default_falls_back_to_zstd_when_absent() {
+        // Absent: applies the spec-recommended Zstd fallback.
+        let props = TableProperties::default();
+        assert_eq!(props.compression_codec_or_default(), Zstd);
+
+        // Present: returns the parsed value as-is.
+        let props = TableProperties::from([(PARQUET_COMPRESSION_CODEC, "snappy")]);
+        assert_eq!(props.compression_codec_or_default(), Snappy);
     }
 }

--- a/kernel/src/table_properties/mod.rs
+++ b/kernel/src/table_properties/mod.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 use std::num::NonZero;
 use std::time::Duration;
 
-use strum::EnumString;
+use strum::{Display, EnumString, IntoStaticStr};
 
 use crate::expressions::ColumnName;
 use crate::table_features::ColumnMappingMode;
@@ -60,6 +60,7 @@ pub(crate) const MATERIALIZED_ROW_COMMIT_VERSION_COLUMN_NAME: &str =
     "delta.rowTracking.materializedRowCommitVersionColumnName";
 pub(crate) const ROW_TRACKING_SUSPENDED: &str = "delta.rowTrackingSuspended";
 pub(crate) const PARQUET_FORMAT_VERSION: &str = "delta.parquet.format.version";
+pub(crate) const PARQUET_COMPRESSION_CODEC: &str = "delta.parquet.compression.codec";
 pub(crate) const ENABLE_IN_COMMIT_TIMESTAMPS: &str = "delta.enableInCommitTimestamps";
 pub(crate) const IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION: &str =
     "delta.inCommitTimestampEnablementVersion";
@@ -220,6 +221,12 @@ pub struct TableProperties {
     /// to `"1.0.0"` when absent. Connectors read this to configure their Parquet writers.
     pub parquet_format_version: Option<String>,
 
+    /// Compression codec to use when writing new Parquet data and checkpoint files. Connectors
+    /// SHOULD honor this property when configuring their Parquet writer. Use
+    /// [`TableProperties::compression_codec_or_default`] to apply the protocol-recommended
+    /// fallback ([`ParquetCompressionCodec::Zstd`]) when this field is `None`.
+    pub parquet_compression_codec: Option<ParquetCompressionCodec>,
+
     /// Whether to enable [In-Commit Timestamps]. The in-commit timestamps writer feature strongly
     /// associates a monotonically increasing timestamp with each commit by storing it in the
     /// commit's metadata.
@@ -249,6 +256,17 @@ impl TableProperties {
     /// Default: `false` per the Delta protocol.
     pub fn should_write_stats_as_struct(&self) -> bool {
         self.checkpoint_write_stats_as_struct.unwrap_or(false)
+    }
+
+    /// Returns the Parquet compression codec for new data and checkpoint files, applying the
+    /// Delta protocol's recommended fallback ([`ParquetCompressionCodec::Zstd`]) when the
+    /// table property is absent.
+    ///
+    /// Use the returned value's `Display` impl (`codec.to_string()`) or `Into<&'static str>`
+    /// (`codec.into()`) to get the canonical Delta-protocol string for a Parquet writer.
+    pub fn compression_codec_or_default(&self) -> ParquetCompressionCodec {
+        self.parquet_compression_codec
+            .unwrap_or(ParquetCompressionCodec::Zstd)
     }
 }
 
@@ -322,6 +340,33 @@ pub enum CheckpointPolicy {
     V2,
 }
 
+/// Compression codec for newly written Parquet data files, controlled by the
+/// `delta.parquet.compression.codec` table property.
+///
+/// Per the Delta protocol, parsing is case-insensitive, and `none` is accepted as an alias for
+/// `uncompressed`. When the property is absent, writers SHOULD default to [`Self::Zstd`].
+///
+/// See [Table Properties] in the Delta protocol.
+///
+/// [Table Properties]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#table-properties
+#[derive(Debug, Display, EnumString, IntoStaticStr, Copy, Clone, PartialEq, Eq)]
+#[strum(serialize_all = "snake_case", ascii_case_insensitive)]
+pub enum ParquetCompressionCodec {
+    /// `zstd`. Recommended fallback per the Delta protocol when the property is absent.
+    Zstd,
+    /// `uncompressed` (alias: `none`). No compression.
+    #[strum(serialize = "uncompressed", serialize = "none")]
+    Uncompressed,
+    /// `snappy`.
+    Snappy,
+    /// `gzip`.
+    Gzip,
+    /// `lz4`. Deprecated by the Delta protocol (Hadoop framing); prefer [`Self::Lz4Raw`].
+    Lz4,
+    /// `lz4_raw`. LZ4 block format.
+    Lz4Raw,
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -390,6 +435,7 @@ mod tests {
         );
         assert_eq!(ROW_TRACKING_SUSPENDED, "delta.rowTrackingSuspended");
         assert_eq!(PARQUET_FORMAT_VERSION, "delta.parquet.format.version");
+        assert_eq!(PARQUET_COMPRESSION_CODEC, "delta.parquet.compression.codec");
         assert_eq!(
             ENABLE_IN_COMMIT_TIMESTAMPS,
             "delta.enableInCommitTimestamps"
@@ -553,6 +599,7 @@ mod tests {
             (IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION, "15"),
             (IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP, "1612345678"),
             (PARQUET_FORMAT_VERSION, "2.12.0"),
+            (PARQUET_COMPRESSION_CODEC, "zstd"),
         ];
         let actual = TableProperties::from(properties.into_iter());
         let expected = TableProperties {
@@ -591,6 +638,7 @@ mod tests {
             enable_in_commit_timestamps: Some(true),
             in_commit_timestamp_enablement_version: Some(15),
             parquet_format_version: Some("2.12.0".to_string()),
+            parquet_compression_codec: Some(ParquetCompressionCodec::Zstd),
             in_commit_timestamp_enablement_timestamp: Some(1_612_345_678),
             unknown_properties: HashMap::new(),
         };


### PR DESCRIPTION
## What changes are proposed in this pull request?

Expose the protocol's `delta.parquet.compression.codec` property as a typed `parquet_compression_codec: Option<ParquetCompressionCodec>` field on `TableProperties`.

Parsing is case-insensitive and accepts `none` as an alias for `uncompressed`, matching the protocol.

## How was this change tested?

New simple UTs.
