### PR TITLE
feat: expose last_checkpoint_hint_summary via internal-api

### DIFF
--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -114,9 +114,8 @@ pub(crate) struct LogSegment {
     ///
     /// Note: This is only populated if the hint file was read during creation of this
     /// log segment. The hint may describe a different checkpoint version than the one in this
-    /// segment. Callers should use explicit getters (such as [`Self::checkpoint_schema`]) rather
-    /// than reading this field directly.
-    last_checkpoint_metadata: Option<LastCheckpointHintSummary>,
+    /// segment.
+    pub last_checkpoint_metadata: Option<LastCheckpointHintSummary>,
 }
 
 /// Returns the identifying leaf column path for a known action type, used to build IS NOT NULL

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -114,7 +114,8 @@ pub(crate) struct LogSegment {
     ///
     /// Note: This is only populated if the hint file was read during creation of this
     /// log segment. The hint may describe a different checkpoint version than the one in this
-    /// segment.
+    /// segment. Callers should use explicit getters (such as [Self::checkpoint_schema]) rather
+    /// than reading this field directly.
     pub last_checkpoint_metadata: Option<LastCheckpointHintSummary>,
 }
 

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -114,7 +114,7 @@ pub(crate) struct LogSegment {
     ///
     /// Note: This is only populated if the hint file was read during creation of this
     /// log segment. The hint may describe a different checkpoint version than the one in this
-    /// segment. Callers should use explicit getters (such as [Self::checkpoint_schema]) rather
+    /// segment. Callers should use explicit getters (such as Self::checkpoint_schema) rather
     /// than reading this field directly.
     pub last_checkpoint_metadata: Option<LastCheckpointHintSummary>,
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?
Every other field is public. Connectors can construct LogSegments for testing, and can only do so if lat_checkpoint_hint_summary is also public.

## How was this change tested?
