### PR TITLE
feat: lazily create default executor in DefaultEngineBuilder

### DIFF
--- a/kernel/src/engine/default/mod.rs
+++ b/kernel/src/engine/default/mod.rs
@@ -169,10 +169,10 @@ pub struct DefaultEngine<E: TaskExecutor> {
 ///     .build();
 /// ```
 #[derive(Debug)]
-pub struct DefaultEngineBuilder<Executor> {
+pub struct DefaultEngineBuilder<E> {
     object_store: Arc<DynObjectStore>,
     /// The state is either [`DefaultTaskExecutor`] or `Arc<E>` with a custom task executor.
-    task_executor: Executor,
+    task_executor: E,
 }
 
 /// Represents the default [`TaskExecutor`]. The executor is created lazily to avoid unnecessary
@@ -195,7 +195,7 @@ impl DefaultEngineBuilder<DefaultTaskExecutor> {
     }
 }
 
-impl<State> DefaultEngineBuilder<State> {
+impl<E> DefaultEngineBuilder<E> {
     /// Set a custom task executor for the engine.
     ///
     /// See [`executor::TaskExecutor`] for more details.

--- a/kernel/src/engine/default/mod.rs
+++ b/kernel/src/engine/default/mod.rs
@@ -169,35 +169,48 @@ pub struct DefaultEngine<E: TaskExecutor> {
 ///     .build();
 /// ```
 #[derive(Debug)]
-pub struct DefaultEngineBuilder<E: TaskExecutor> {
+pub struct DefaultEngineBuilder<Executor> {
     object_store: Arc<DynObjectStore>,
-    task_executor: Arc<E>,
+    /// The state is either [`DefaultTaskExecutor`] or `Arc<E>` with a custom task executor.
+    task_executor: Executor,
 }
 
-impl DefaultEngineBuilder<executor::tokio::TokioBackgroundExecutor> {
+/// Represents the default [`TaskExecutor`]. The executor is created lazily to avoid unnecessary
+/// instantiations.
+pub struct DefaultTaskExecutor;
+
+impl DefaultEngineBuilder<DefaultTaskExecutor> {
     /// Create a new [`DefaultEngineBuilder`] instance with the default executor.
     pub fn new(object_store: Arc<DynObjectStore>) -> Self {
         Self {
             object_store,
-            task_executor: Arc::new(executor::tokio::TokioBackgroundExecutor::new()),
+            task_executor: DefaultTaskExecutor,
         }
+    }
+
+    /// Build the [`DefaultEngine`] instance.
+    pub fn build(self) -> DefaultEngine<executor::tokio::TokioBackgroundExecutor> {
+        let task_executor = Arc::new(executor::tokio::TokioBackgroundExecutor::new());
+        DefaultEngine::new_with_opts(self.object_store, task_executor)
     }
 }
 
-impl<E: TaskExecutor> DefaultEngineBuilder<E> {
+impl<State> DefaultEngineBuilder<State> {
     /// Set a custom task executor for the engine.
     ///
     /// See [`executor::TaskExecutor`] for more details.
     pub fn with_task_executor<F: TaskExecutor>(
         self,
         task_executor: Arc<F>,
-    ) -> DefaultEngineBuilder<F> {
+    ) -> DefaultEngineBuilder<Arc<F>> {
         DefaultEngineBuilder {
             object_store: self.object_store,
             task_executor,
         }
     }
+}
 
+impl<E: TaskExecutor> DefaultEngineBuilder<Arc<E>> {
     /// Build the [`DefaultEngine`] instance.
     pub fn build(self) -> DefaultEngine<E> {
         DefaultEngine::new_with_opts(self.object_store, self.task_executor)
@@ -210,9 +223,7 @@ impl DefaultEngine<executor::tokio::TokioBackgroundExecutor> {
     /// # Parameters
     ///
     /// - `object_store`: The object store to use.
-    pub fn builder(
-        object_store: Arc<DynObjectStore>,
-    ) -> DefaultEngineBuilder<executor::tokio::TokioBackgroundExecutor> {
+    pub fn builder(object_store: Arc<DynObjectStore>) -> DefaultEngineBuilder<DefaultTaskExecutor> {
         DefaultEngineBuilder::new(object_store)
     }
 }

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -7,7 +7,6 @@ use delta_kernel::arrow::array::{Array, Int32Array, StringArray};
 use delta_kernel::arrow::record_batch::RecordBatch;
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
-use delta_kernel::engine::default::executor::tokio::TokioBackgroundExecutor;
 use delta_kernel::engine::default::DefaultEngineBuilder;
 use delta_kernel::expressions::{column_name, ColumnName, Scalar};
 use delta_kernel::object_store::memory::InMemory;

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -744,8 +744,7 @@ async fn add_column_with_stray_cm_metadata_on_non_cm_table_fails(
 async fn alter_blocked_when_iceberg_compat_v3_enabled() -> Result<(), Box<dyn std::error::Error>> {
     let storage = Arc::new(InMemory::new());
     let table_root = "memory:///";
-    let engine =
-        Arc::new(DefaultEngineBuilder::<TokioBackgroundExecutor>::new(storage.clone()).build());
+    let engine = Arc::new(DefaultEngineBuilder::new(storage.clone()).build());
 
     // Create table doesn't support IcebergCompatV3 yet, so this test hand-crafts a V0 commit.
     // The commit enables V3, column mapping, and row tracking. The schema contains one `id`

--- a/kernel/tests/integration/features/iceberg_compat.rs
+++ b/kernel/tests/integration/features/iceberg_compat.rs
@@ -351,8 +351,7 @@ async fn v3_e2e_partitioned_writes_with_field_ids(
 
 fn make_default_engine_and_store() -> (Arc<InMemory>, Arc<DefaultEngine<TokioBackgroundExecutor>>) {
     let storage = Arc::new(InMemory::new());
-    let engine =
-        Arc::new(DefaultEngineBuilder::<TokioBackgroundExecutor>::new(storage.clone()).build());
+    let engine = Arc::new(DefaultEngineBuilder::new(storage.clone()).build());
     (storage, engine)
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

In our project's test suite we're creating many delta tables. Somewhere during that process, the default implementation of `LogStore::engine` is called which isntantiates a `DefaultEngine`. Even thought we're using a multi-threaded tokio runtime, thus ultimately using `TokioMultiThreadExecutor` as a task executor, we still unnecessarily create a new `TokioBackgroundExecutor` for each engine creation. As this executor immediately starts a background thread, we would like to avoid this. For example, when profiling our testsuite we see around 5000 created threads.

The `get_engine` method in `delta-rs` is defined as follows:

```rust
pub(crate) fn get_engine(store: Arc<dyn ObjectStore>) -> Arc<dyn Engine> {
    let handle = tokio::runtime::Handle::current();
    match handle.runtime_flavor() {
        RuntimeFlavor::MultiThread => Arc::new(
            DefaultEngineBuilder::new(store) // <-- A TokioBackgroundExecutor is created and a thread is spawned
                .with_task_executor(Arc::new(TokioMultiThreadExecutor::new(handle))) // But it's never used.
                .build(),
        ),
        RuntimeFlavor::CurrentThread => Arc::new(
            DefaultEngineBuilder::new(store)
                .with_task_executor(Arc::new(TokioBackgroundExecutor::new()))
                .build(),
        ),
        _ => panic!("unsupported runtime flavor"),
    }
}
```

The new design lazily created the `TokioBackgroundExecutor` during `build`, such that usages of the `.with_task_executor` directly benefit from it.

I've created a patch on our project to [a test fork](https://github.com/tschwarzinger/delta-kernel-rs/tree/prevent-background-executor-creation-bouyant) with some hacks.

I've recorded traces of our testsuite with the following command:
`samply record cargo test <single testsuite>`

The results show:
- Number of tracks in Samply profile: ~5000 -> 19
- Total execution time of one test suite: From what I observed it's a minor improvement but nothing crazy on our workload (maybe 10.5s -> 10s but take it with a grain of salt).

I haven't filed an issue for this small change but I can do that if further discussion is necessary.

### This PR affects the following public APIs

- `DefaultEngineBuilder::new`
- `DefaultEngine::builder`
- Type argument of `DefaultEngineBuilder`

This breaks the existing public API slightly. See, for example, the change in `kernel/tests/integration/features/alter_table.rs` for a possible issue. This affects usages that explicitly mention the task executor type. The alternative would be to add a new `DefaultEngineBuilder::new_with_task_executor` (which was my original design) but I think this is too easy to overlook, leading to many users still instantiating the  `TokioBackgroundExecutor`.

## How was this change tested?

Existing tests that use the default executor pass.