### PR TITLE
feat: unified CRC state with eager Arc<Crc> on Snapshot

### DIFF
--- a/CLAUDE/crc_design.md
+++ b/CLAUDE/crc_design.md
@@ -1,0 +1,495 @@
+# CRC (Version Checksum) Design — `delta-kernel-rs`
+
+This document describes the in-memory CRC architecture in `delta-kernel-rs`: how CRCs flow
+through the connector, how the kernel produces and applies CRC deltas, and which log-state
+situations are handled by which code path. Focus is on **CUJs** (customer user journeys),
+**flow** (data + control), and **state**, not implementation details.
+
+For the field-level mechanics see the source: `kernel/src/crc/{mod,delta,state,file_stats,
+file_size_histogram,reader,writer,lazy}.rs` and `kernel/src/log_segment/crc_replay.rs`.
+
+---
+
+## TL;DR
+
+- Every `Snapshot` carries an eager `Arc<Crc>` — the in-memory representation of the table's
+  version-checksum state. Always present, never lazy.
+- `CrcUpdate` is the universal "delta" type. It captures the changes from one commit (or an
+  accumulated range of commits).
+- `Crc::apply(CrcUpdate)` is the **only** mutator. It implements the fundamental invariant
+  `Crc[N] + CrcUpdate(N→N+1) = Crc[N+1]` (and more generally, `Crc[X] + CrcUpdate(X→M) = Crc[M]`
+  for any range).
+- All four CRC production paths (commit-time, stale-CRC catchup, no-CRC bootstrap, future
+  rebase + recovery) feed the same `Crc::apply`. They differ only in *how* they produce the
+  `CrcUpdate`.
+- File stats use a typed state enum (`FileStatsState`: Valid / RequiresCheckpointRead /
+  Indeterminate / Untrackable) so misuse is unrepresentable. Domain metadata and set
+  transactions use the same Complete / Partial / Untracked completeness pattern.
+
+---
+
+## Customer User Journeys (CUJs)
+
+### CUJ 1: Read a snapshot, query domain metadata
+
+```rust
+let snap = Snapshot::builder_for(table_url).build(&engine)?;
+let zip = snap.get_domain_metadata("zip", &engine)?;
+```
+
+**Flow:**
+
+1. `builder_for(...).build(engine)` triggers snapshot loading. The kernel:
+   - Lists log files in `_delta_log/`.
+   - Builds the `Crc` (see CUJ 5 for variants).
+   - Wraps it in `Arc<Crc>` on the `Snapshot`.
+2. `get_domain_metadata("zip", engine)` branches on `crc.domain_metadata`:
+   - `Complete(map)`: serve from map (hit or miss is authoritative).
+   - `Partial(map)`: hit → serve; miss → log replay only for the missed domain.
+   - `Untracked`: log replay.
+
+**Cost:** for the common case (CRC at target on disk OR full-replay produces Complete DM),
+the second call is **zero I/O** — DM is in memory.
+
+### CUJ 2: Query file stats (Reyden, vacuum, etc.)
+
+```rust
+let stats = snap.get_file_stats_if_loaded();   // no I/O
+// or
+let stats = snap.get_or_load_file_stats(&engine);
+```
+
+**Flow:** both methods read `crc.file_stats()`, which returns `Some(FileStats)` only when
+`FileStatsState` is `Valid`. For other states (Indeterminate, Untrackable, RequiresCheckpointRead),
+returns `None`.
+
+**Cost:** zero I/O — file stats are precomputed during snapshot load.
+
+**Recovery (deferred):** if `crc.file_stats_validity()` is `Indeterminate` (e.g. ANALYZE STATS
+ran), call `snap.load_file_stats(&engine)` to trigger a full action-reconciliation pass that
+recovers absolute file stats. Currently stubbed; lands with priority 5.
+
+### CUJ 3: Commit a transaction
+
+```rust
+let txn = snap.transaction(committer, &engine)?
+    .with_operation("WRITE")
+    .with_domain_metadata("zip", "zap1");
+let committed = txn.commit(&engine)?.unwrap_committed();
+let new_snap = committed.post_commit_snapshot().unwrap();
+```
+
+**Flow:**
+
+1. Transaction stages add/remove file metadata, DM changes, set transactions, etc.
+2. On `commit`:
+   - Kernel writes the commit JSON via `Committer`.
+   - On success, kernel builds `CrcUpdate` from staged actions:
+     - File stats: `FileStatsDelta` (net counts, bytes, histogram).
+     - DM map: keyed by domain name.
+     - txn map: keyed by app_id.
+     - ICT, P/M (only if changed), `operation_safe` (precomputed from `with_operation`).
+   - `read_snapshot.crc.apply(update)` produces the post-commit CRC.
+   - Wraps in a new `Snapshot` (post-commit snapshot).
+3. Caller may now call `new_snap.write_checksum(&engine)` to persist `Crc[N+1]` as `N+1.crc`.
+
+**Invariant:** `Crc[N] (read) + CrcUpdate(N→N+1) (txn) = Crc[N+1] (post-commit)`.
+
+### CUJ 4: Write a checksum file
+
+```rust
+let (result, new_snap) = snap.write_checksum(&engine)?;
+match result {
+    ChecksumWriteResult::Written => /* CRC at this version persisted */,
+    ChecksumWriteResult::AlreadyExists => /* another writer beat us, benign */,
+}
+```
+
+**Flow:**
+
+1. Check if `<version>.crc` already exists in the log segment → `AlreadyExists`, benign.
+2. `try_write_crc_file(engine, &path, &crc)`:
+   - Validates `crc.file_stats.is_writable()` — only `Valid` states are writable. Non-Valid
+     states return `Error::ChecksumWriteUnsupported`.
+   - Serializes via `serde_json::to_vec(&crc)` (uses `CrcRaw` intermediate to map typed enums
+     to flat JSON).
+   - Writes via `engine.storage_handler().put(path, data, overwrite=false)` — atomic
+     put-if-absent. Concurrent writers race; one wins, others get `FileAlreadyExists`.
+
+**Per Delta protocol:** writers MUST NOT overwrite existing CRC files.
+
+### CUJ 5: Snapshot loading variants
+
+The kernel handles multiple log states transparently. Caller writes the same `Snapshot::builder_for(url).build(engine)`; the kernel picks the right path.
+
+| Log state | Path | Cost |
+|---|---|---|
+| CRC file at target version | Load directly from disk, no log replay. P&M comes from CRC. | One storage read. |
+| CRC file at older version (stale) + commits since | Load stale CRC, reverse-replay commits in `(crc_version, end_version]`, apply once via `Crc::apply`. | One storage read + one batched read of commits. |
+| No CRC file, has checkpoint + commits | Reverse-replay full segment (commits + checkpoint actions), `into_fresh_crc()`. | One batched read of commits + checkpoint. |
+| No CRC file, no checkpoint | Reverse-replay all commits 0..N, `into_fresh_crc()`. | One batched read of all commits. |
+| CRC file corrupt | Warn, fall back to full log replay. | One storage read (CRC, fails) + one batched read. |
+| Time travel target older than CRC | Ignore the CRC, fall back to full log replay. | Same as no-CRC path. |
+
+All paths produce an `Arc<Crc>` on the Snapshot. The eager design means the Snapshot's
+contract is consistent: callers always have a `Crc` to query.
+
+### CUJ 6: Catalog-managed table snapshot loading
+
+Same as CUJ 5, but the log segment includes catalog-provided "log tail" commits via
+`SnapshotBuilder::with_log_tail()`. The reverse-replay accumulator processes log-tail
+batches the same as any other commit batches — no special casing.
+
+---
+
+## Architecture
+
+### The universal mutator
+
+```
+Crc[N] + CrcUpdate(N→N+1) = Crc[N+1]
+       ^                    ^
+   apply() is forward       result is the new CRC at N+1
+```
+
+`Crc::apply(CrcUpdate)` is the only mutator. It uses last-write-wins semantics: `Some` fields
+in the update overwrite, `None` fields don't change the base. Maps upsert per key (DM
+tombstones remove the entry).
+
+Repeated apply composes: `Crc[N].apply(δ₁); .apply(δ₂); ...` is equivalent to
+`Crc[N].apply(δ₁ ⊕ δ₂ ⊕ ...)` where `⊕` is delta-merge.
+
+### Three production strategies
+
+The four ways to produce a `CrcUpdate`:
+
+1. **Commit-time** (`Transaction::build_crc_update`): one commit's staged actions →
+   one `CrcUpdate`. Direction-agnostic (single commit).
+2. **Reverse-accumulate** (`LogSegment::build_crc_from_stale`,
+   `LogSegment::build_crc_from_scratch`): stream commits descending via
+   `read_actions`; visitor (`CrcReplayVisitor`) does first-seen-wins per key, sums file
+   stats; finalize → one `CrcUpdate`. Used for:
+   - Stale-CRC catchup (apply the update onto the loaded base CRC).
+   - No-CRC bootstrap (call `into_fresh_crc()` to construct a fresh `Crc`).
+3. **Forward per-commit** *(future)*: rebase / row-level concurrency. Each winning commit's
+   actions → one `CrcUpdate`, applied per-commit with conflict checks interleaved. Same
+   `CrcUpdate` shape, same `Crc::apply`.
+4. **Action reconciliation** *(future, priority 5)*: forked visitor with wider schema +
+   `FileActionDeduplicator` recovers absolute file stats from `Indeterminate`. Same
+   `CrcUpdate` output, same `Crc::apply`.
+
+All four feed the same mutator. Direction (forward vs reverse) is a per-strategy
+implementation choice; the `CrcUpdate` shape is direction-agnostic.
+
+### State enums
+
+```
+FileStatsState ::= Valid { num_files, table_size_bytes, histogram }
+                 | RequiresCheckpointRead { commit_delta_files, ..., commit_delta_histogram }
+                 | Indeterminate
+                 | Untrackable
+
+DomainMetadataState ::= Complete(HashMap) | Partial(HashMap) | Untracked
+SetTransactionState ::= Complete(HashMap) | Partial(HashMap) | Untracked
+```
+
+Each variant carries exactly the data that variant requires. You cannot read an absolute
+file count from `Indeterminate` because there's no field there to read — the type system
+prevents the bug.
+
+State transitions (during `Crc::apply`):
+
+| Current FileStats | + safe op | + unsafe op | + missing remove.size |
+|-------------------|-----------|-------------|-----------------------|
+| Valid | Valid | Indeterminate | Untrackable |
+| RequiresCheckpointRead | RCR | Indeterminate | Untrackable |
+| Indeterminate | Indeterminate | Indeterminate | Untrackable |
+| Untrackable | Untrackable | Untrackable | Untrackable |
+
+| Base DM/txn | + entries from update | + nothing |
+|-------------|-----------------------|-----------|
+| Complete | Complete (upserted) | Complete |
+| Partial | Partial (upserted) | Partial |
+| Untracked | Partial (entries from update) | Untracked |
+
+The `Untracked → Partial` transition is important: when a stale CRC base lacks DM but newer
+commits have DM, the post-replay state is `Partial(map_with_just_those_entries)`. Snapshot DM
+queries can serve hits from `Partial` directly; only misses fall through to log replay.
+
+### On-disk JSON ↔ in-memory enums
+
+`CrcRaw` is a private serde intermediate that maps the typed in-memory `Crc` to/from the flat
+JSON shape from the Delta protocol spec:
+
+```
+CrcRaw { tableSizeBytes, numFiles, numMetadata, numProtocol,
+         metadata, protocol, inCommitTimestampOpt,
+         setTransactions: Option<Vec>, domainMetadata: Option<Vec>,
+         fileSizeHistogram: Option<...> }
+```
+
+Mediated by `#[serde(from = "CrcRaw", into = "CrcRaw")]` on `Crc`. Deserialization always
+yields `Valid` file stats and `Complete` DM/txns (or `Untracked` if the JSON omits them). The
+writer (`try_write_crc_file`) gates on `is_writable()` so non-Valid CRCs are never persisted.
+
+---
+
+## Cases covered
+
+The following scenarios are handled by the implementation. Test coverage is in
+`kernel/src/crc/{state,delta,mod,reader,writer}.rs` (unit), `kernel/src/log_segment/{crc_replay,crc_tests}.rs` (snapshot-load unit tests), and `kernel/tests/crc.rs` (integration).
+
+### Bootstrap (snapshot loading from disk)
+
+| # | Scenario | State after load |
+|---|----------|------------------|
+| B1 | CRC file at target, all fields populated | Valid + Complete + ICT |
+| B2 | CRC file at target, missing DM | Valid + Untracked DM |
+| B3 | CRC file at target, missing histogram | Valid (no histogram) + Complete |
+| B4 | CRC file at target, missing ICT | Valid + Complete + ICT=None (falls back to commit file on query) |
+| B5 | Stale CRC at X + commits X+1..M, all safe ops | Valid + Complete (or Partial DM if older CRC was Untracked) |
+| B6 | Stale CRC at X, replay hits ANALYZE STATS | Indeterminate file stats (DM/txn/P/M still updated) |
+| B7 | Stale CRC at X, replay hits a remove with missing size | Untrackable file stats |
+| B8 | CRC at target corrupt | Warn, fall back to full replay (build_crc_from_scratch) |
+| B9 | Stale CRC at X corrupt | Warn, fall back to full replay |
+| B10 | No CRC, V1 single-part checkpoint | Valid + Complete from checkpoint+commits |
+| B11 | No CRC, V1 multi-part checkpoint | Same as B10 (all parts read) |
+| B12 | No CRC, V2 checkpoint with sidecars | Same, sidecars read via existing checkpoint stream |
+| B13 | No CRC, no checkpoint, several commits | Valid + Complete from full reverse replay |
+| B14 | No CRC, ANALYZE STATS in log | Indeterminate file stats |
+| B15 | Time travel to v50 when CRC at v100 exists | Ignore that CRC, fall back to full replay |
+| B16 | Catalog-managed log tail | Reverse-replay treats log-tail batches uniformly |
+
+### Post-commit (in-memory chaining)
+
+| # | Scenario | Transition |
+|---|----------|------------|
+| P1 | CREATE TABLE | Crc[0] built via `into_crc_for_version_zero` |
+| P2 | Blind append | Valid → Valid (sums + histogram bins inserted) |
+| P3 | MERGE / UPDATE / DELETE | Valid → Valid |
+| P4 | OPTIMIZE | Valid → Valid (many adds + many removes; net file count drops) |
+| P5 | DV update (remove + add same path/size) | Valid → Valid (net zero) |
+| P6 | Empty commit (commitInfo only) | Valid → Valid (only ICT updates) |
+| P7 | Schema evolution (Metadata change) | New metadata applied |
+| P8 | Protocol upgrade | New protocol applied |
+| P9 | Domain metadata set | DM upsert |
+| P10 | Domain metadata remove (tombstone) | DM removed from map |
+| P11 | Set transaction | txn upsert |
+| P12 | ICT enabled mid-table | ICT None → Some |
+| P13 | ICT disabled mid-table | ICT Some → None |
+| P14 | REPLACE TABLE (RTAS) | Big churn but still Valid |
+| P15 | Pre-commit Crc was Indeterminate | Stays Indeterminate |
+| P16 | Pre-commit Crc was Untrackable | Stays Untrackable |
+| P17 | Unknown / unrecognized operation | operation_safe=false → Indeterminate |
+
+### Read fast paths
+
+| # | Scenario | Behavior |
+|---|----------|----------|
+| R1 | get_domain_metadata, CRC has Complete DM | Serve from CRC, no I/O |
+| R2 | get_domain_metadata, CRC has Partial DM, hit | Serve from CRC, no I/O |
+| R3 | get_domain_metadata, CRC has Partial DM, miss | Log replay for missing domain |
+| R4 | get_domain_metadata, CRC has Untracked DM | Full log replay |
+| R5 | get_app_id_version, txns Complete | Serve from CRC, no I/O |
+| R6 | get_app_id_version, txns Partial, hit | Serve from CRC, no I/O |
+| R7 | get_app_id_version, txns Partial, miss | Full log replay |
+| R8 | get_app_id_version, txns Untracked | Full log replay |
+| R9 | get_in_commit_timestamp, CRC has ICT | Serve from CRC, no I/O |
+| R10 | get_in_commit_timestamp, CRC has ICT=None | Fall back to reading latest commit file |
+
+### Write checksum
+
+| # | Scenario | Result |
+|---|----------|--------|
+| W1 | CRC already on disk at this version | `AlreadyExists` (idempotent, benign) |
+| W2 | CRC has Valid file stats | `Written` |
+| W3 | CRC has RequiresCheckpointRead/Indeterminate/Untrackable | `Error::ChecksumWriteUnsupported` |
+| W4 | Two writers race | One wins (`Written`), other gets `AlreadyExists` (atomic put-if-absent) |
+| W5 | CRC has Complete DM (typical post-commit) | DM serialized as `[...]` array |
+| W6 | CRC has Partial DM | DM omitted from JSON (only Complete is persisted) |
+
+### Concurrency and safety
+
+| # | Scenario | Behavior |
+|---|----------|----------|
+| C1 | Two writers commit at v101 | One wins (committer atomic put), other gets `ConflictedTransaction` |
+| C2 | Two writers attempt v101.crc concurrently | One succeeds, other gets `AlreadyExists` (benign per protocol) |
+| C3 | CRC written but `_last_checkpoint` not updated | Independent — CRC is just a hint |
+| C4 | Reader loads snapshot during concurrent commit | Sees consistent state at its version (snapshots are immutable) |
+
+### Recovery (deferred, priority 5)
+
+| # | Scenario | Future behavior |
+|---|----------|-----------------|
+| Rec1 | Indeterminate Crc, caller calls `load_file_stats` | Trigger reverse reconciliation, recover Valid |
+| Rec2 | Untrackable Crc, caller calls `load_file_stats` | Error (permanently unrecoverable) |
+| Rec3 | RequiresCheckpointRead, caller calls `load_file_stats` | Read checkpoint adds, merge with deltas, transition to Valid |
+
+Today: `Snapshot::load_file_stats(engine)` is stubbed as `Err`. The API surface is locked
+in for connectors.
+
+---
+
+## Connector usage patterns
+
+### "Lazy" / read-mostly (OSS Spark connector, kernel-java)
+
+```
+Snapshot::builder_for → build → query DM/txn/ICT/file_stats from in-memory Crc.
+No write_checksum unless writing.
+```
+
+Cost: one snapshot load (one batched read). Subsequent queries are zero I/O.
+
+### "Eager" writer (Reyden, Zerobus)
+
+```
+Loop:
+  txn = snap.transaction(committer, engine)
+  txn.add_files(...)
+  committed = txn.commit(engine)?.unwrap_committed()
+  let (_, new_snap) = committed.post_commit_snapshot()
+      .unwrap()
+      .write_checksum(engine)?;
+  snap = new_snap
+```
+
+Each iteration: one commit + one CRC file written. No re-read of the log between commits
+because the post-commit snapshot has `Crc[N+1]` in memory.
+
+### Cost-aware writer (advanced)
+
+```
+let crc = snap.get_current_crc_if_loaded_for_testing();  // test API today; production API TBD
+match crc.file_stats_validity() {
+    Valid => { snap.write_checksum(engine) }
+    Indeterminate | Untrackable => { /* skip CRC write, log warning */ }
+    RequiresCheckpointRead => { snap.load_file_stats(engine)?.write_checksum(engine) }
+}
+```
+
+Connectors can inspect the validity classification via `FileStatsValidity` and decide whether
+to write CRC synchronously, asynchronously, or call `load_file_stats` first.
+
+---
+
+## Log state situations and the right path
+
+The kernel automatically picks the right CRC build strategy based on the log state. Connectors
+just call `Snapshot::builder_for(...).build(engine)` and get a `Snapshot` with `Arc<Crc>`.
+
+```
+log files → list → log segment → try_build_crc_from_file?
+                                  yes (CRC at target):
+                                    load → done (no log replay)
+                                  yes (CRC stale, X < target):
+                                    load + segment_after_crc(X).build_crc_from_stale
+                                          → reverse replay X+1..target
+                                          → accumulator → CrcUpdate
+                                          → base.apply(update) → Crc[target]
+                                  no:
+                                    log_segment.build_crc_from_scratch
+                                          → reverse replay full segment (commits + checkpoint)
+                                          → accumulator → CrcUpdate
+                                          → into_fresh_crc → Crc[target]
+```
+
+For a stale or corrupt CRC that fails to load: warn and fall back to the no-CRC path.
+
+---
+
+## Performance characteristics
+
+- **One batched engine call per replay range.** `LogSegment::read_actions` calls
+  `engine.json_handler().read_json_files(&all_files, schema, None)` once per range. The
+  engine controls all I/O parallelism internally.
+- **Eager Crc cost:** one extra parquet read per V1 parquet checkpoint at snapshot load
+  (sidecar probe — V1 checkpoints written by kernel include an empty sidecar field in the
+  schema; the existing checkpoint-stream code path probes for sidecars when the read schema
+  includes Add/Remove). For V2 checkpoints with real sidecars, this read is necessary
+  anyway. Trade-off: a small constant cost per snapshot load in exchange for free DM/txn/file
+  stats queries forever after.
+- **Histogram merge:** short-circuits to `None` on boundary mismatch. Connectors that pass
+  custom bin boundaries should be consistent across writes.
+- **Per-batch accumulator:** does not allocate per row. Visitor uses typed `GetData`
+  accessors and accumulates into pre-allocated state.
+
+---
+
+## Known costs and trade-offs
+
+1. **Sidecar probe on V1 parquet checkpoints.** Documented in the metric tests
+   (`tests/metrics/snapshot_load.rs`). Could be elided with a smarter check
+   ("classic-named single part = always V1, skip sidecar probe") but is structurally
+   correct as-is.
+2. **`Untracked → Partial` may surprise callers.** A snapshot loaded from a CRC that lacked
+   DM, then incrementally updated, has a Partial DM map after the update. Specific-domain
+   queries against Partial that hit the cache return without I/O, but the cache is not
+   exhaustive — callers requesting "all domains" trigger a full log replay.
+3. **Histogram dropped on degraded state.** Indeterminate and Untrackable have no histogram
+   field. Recovery via `load_file_stats` (priority 5) will rebuild it.
+4. **Operation safety whitelist is conservative.** `INCREMENTAL_SAFE_OPS` lists
+   `WRITE`, `MERGE`, `UPDATE`, `DELETE`, `OPTIMIZE`, `CREATE TABLE`, `REPLACE TABLE`,
+   `CREATE TABLE AS SELECT`, `REPLACE TABLE AS SELECT`, `CREATE OR REPLACE TABLE AS SELECT`.
+   Unknown ops (including new Delta protocol additions) default to unsafe → Indeterminate.
+   Conservative but recoverable.
+5. **Log compactions are not yet handled.** The accumulator treats compaction batches as
+   regular commit batches, which over-counts. Log compaction is currently disabled (#2337);
+   when re-enabled, compactions need to be filtered out of the CRC-replay segment or have
+   their own visitor logic.
+
+---
+
+## Future work
+
+- **Priority 4 (rebase / row-level concurrency):** implement forward per-commit apply onto a
+  pre-rebase `Crc`. Adds `LogSegment::read_actions_ascending` helper. Reuses `CrcUpdate` and
+  `Crc::apply`.
+- **Priority 5 (file stats recovery):** real implementation of `Snapshot::load_file_stats`.
+  Wide schema includes `add.path`, `add.deletionVector`, `add.size`. Forks the visitor for
+  `FileActionDeduplicator` integration. Recovers `Indeterminate` to `Valid`. Handles
+  `RequiresCheckpointRead` by reading checkpoint adds and merging with deltas.
+- **Connector hint API:** `SnapshotBuilder::with_eager_file_stats(bool)` for callers that
+  want to skip the eager CRC build (e.g. for time-travel reads where file stats aren't
+  needed).
+- **Log compaction support:** filter compaction batches out of CRC-replay or fork visitor.
+- **Smarter sidecar probe:** classic-named single-part checkpoints don't need sidecar
+  probing — a small optimization.
+
+---
+
+## File map
+
+| File | Purpose |
+|------|---------|
+| `kernel/src/crc/mod.rs` | `Crc` struct, `CrcRaw` serde intermediate, `minimal_from_pm` |
+| `kernel/src/crc/state.rs` | `FileStatsState`, `DomainMetadataState`, `SetTransactionState`, `FileStatsValidity` |
+| `kernel/src/crc/delta.rs` | `CrcUpdate`, `Crc::apply`, `into_fresh_crc`, `into_crc_for_version_zero`, histogram merge |
+| `kernel/src/crc/file_stats.rs` | `FileStats`, `FileStatsDelta`, `try_compute_for_txn`, `is_incremental_safe` whitelist |
+| `kernel/src/crc/file_size_histogram.rs` | `FileSizeHistogram`, default bins, `try_apply_delta`, `try_add`, `try_sub` |
+| `kernel/src/crc/reader.rs` | `try_read_crc_file` (storage handler) |
+| `kernel/src/crc/writer.rs` | `try_write_crc_file` (storage handler, gates on `is_writable`) |
+| `kernel/src/crc/lazy.rs` | `LazyCrc` helper for the P&M-replay path (used internally by incremental snapshot updates) |
+| `kernel/src/log_segment/crc_replay.rs` | `CrcReplayVisitor`, `CrcReplayAccumulator`, `build_crc_from_stale`, `build_crc_from_scratch` |
+| `kernel/src/snapshot/mod.rs` | `Snapshot.crc: Arc<Crc>`, `try_build_crc_from_file`, `build_crc`, `new_post_commit`, `write_checksum`, `load_file_stats` (stub) |
+| `kernel/src/transaction/mod.rs` | `build_crc_update` (commit-time delta production), `into_committed` (CREATE TABLE → fresh Crc, otherwise apply onto read snapshot's Crc) |
+| `kernel/tests/crc.rs` | Integration tests for CRC API on `Snapshot` |
+| `kernel/src/log_segment/crc_tests.rs` | Unit tests for P&M replay + ICT reads with CRC files |
+
+---
+
+## Summary
+
+The CRC system in `delta-kernel-rs` is built around **one mutator** (`Crc::apply`),
+**one delta type** (`CrcUpdate`), and **typed state enums** that make invalid states
+unrepresentable. Every snapshot has an eager `Arc<Crc>` available for zero-I/O DM / txn /
+ICT / file-stats queries.
+
+The kernel transparently handles every common log state: CRC at target, stale CRC, no CRC
++ checkpoint, no CRC + no checkpoint, corrupt CRC, time travel. Connectors call
+`Snapshot::builder_for(...)` and get the right behavior. For writers, the post-commit
+chain (`Crc[N] + CrcUpdate(N→N+1) = Crc[N+1]`) keeps the CRC up-to-date in memory and
+lets `write_checksum` persist it cheaply.
+
+Future priorities (rebase, action reconciliation) reuse the same primitives — the design is
+ready for them without a refactor.

--- a/CLAUDE/crc_design.md
+++ b/CLAUDE/crc_design.md
@@ -51,23 +51,33 @@ let zip = snap.get_domain_metadata("zip", &engine)?;
 **Cost:** for the common case (CRC at target on disk OR full-replay produces Complete DM),
 the second call is **zero I/O** — DM is in memory.
 
-### CUJ 2: Query file stats (Reyden, vacuum, etc.)
+### CUJ 2: Query file stats (vacuum-style readers, etc.)
 
 ```rust
-let stats = snap.get_file_stats_if_loaded();   // no I/O
-// or
-let stats = snap.get_or_load_file_stats(&engine);
+// No I/O. Returns Some(FileStats) only when CRC's FileStatsState is Valid.
+let stats = snap.get_file_stats();
 ```
 
-**Flow:** both methods read `crc.file_stats()`, which returns `Some(FileStats)` only when
-`FileStatsState` is `Valid`. For other states (Indeterminate, Untrackable, RequiresCheckpointRead),
-returns `None`.
+**Flow:** reads `crc.file_stats()`, which returns `Some(FileStats)` only when
+`FileStatsState` is `Valid`. For other states (`Indeterminate`, `Untrackable`,
+`RequiresCheckpointRead`), returns `None`.
 
 **Cost:** zero I/O — file stats are precomputed during snapshot load.
 
-**Recovery (deferred):** if `crc.file_stats_validity()` is `Indeterminate` (e.g. ANALYZE STATS
-ran), call `snap.load_file_stats(&engine)` to trigger a full action-reconciliation pass that
-recovers absolute file stats. Currently stubbed; lands with priority 5.
+**Recovery:** if `crc.file_stats_validity()` is `Indeterminate` or
+`RequiresCheckpointRead`, call
+
+```rust
+let recovered: SnapshotRef = snap.load_file_stats(&engine)?;
+```
+
+to perform a full action-reconciliation pass and rebuild absolute file stats. The
+recovered snapshot has `Valid` file stats (or `Untrackable` if a remove with missing
+size was found during recovery, in which case byte-level stats are permanently
+impossible). All other CRC fields (P/M, DM, txns, ICT) are preserved.
+
+If `crc.file_stats_validity()` is already `Untrackable`, `load_file_stats` returns
+`Error::ChecksumWriteUnsupported` — there is no recovery path.
 
 ### CUJ 3: Commit a transaction
 
@@ -159,7 +169,7 @@ tombstones remove the entry).
 Repeated apply composes: `Crc[N].apply(δ₁); .apply(δ₂); ...` is equivalent to
 `Crc[N].apply(δ₁ ⊕ δ₂ ⊕ ...)` where `⊕` is delta-merge.
 
-### Three production strategies
+### Production strategies
 
 The four ways to produce a `CrcUpdate`:
 
@@ -171,15 +181,19 @@ The four ways to produce a `CrcUpdate`:
    stats; finalize → one `CrcUpdate`. Used for:
    - Stale-CRC catchup (apply the update onto the loaded base CRC).
    - No-CRC bootstrap (call `into_fresh_crc()` to construct a fresh `Crc`).
-3. **Forward per-commit** *(future)*: rebase / row-level concurrency. Each winning commit's
+3. **Action reconciliation** (`LogSegment::recover_file_stats`, called by
+   `Snapshot::load_file_stats`): a dedicated `ReconciliationVisitor` reads the entire
+   segment with `(path, dv_unique_id)` deduplication, building absolute file stats
+   from scratch. The result is a `FileStatsState` that replaces the snapshot's CRC
+   `file_stats` field; other CRC fields are preserved.
+4. **Forward per-commit** *(future)*: rebase / row-level concurrency. Each winning commit's
    actions → one `CrcUpdate`, applied per-commit with conflict checks interleaved. Same
    `CrcUpdate` shape, same `Crc::apply`.
-4. **Action reconciliation** *(future, priority 5)*: forked visitor with wider schema +
-   `FileActionDeduplicator` recovers absolute file stats from `Indeterminate`. Same
-   `CrcUpdate` output, same `Crc::apply`.
 
-All four feed the same mutator. Direction (forward vs reverse) is a per-strategy
-implementation choice; the `CrcUpdate` shape is direction-agnostic.
+The first three are implemented today. Strategies 1, 2, and 4 feed the same `Crc::apply`
+mutator; strategy 3 directly produces a `FileStatsState` and patches the CRC field.
+Direction (forward vs reverse) is a per-strategy implementation choice; the `CrcUpdate`
+shape is direction-agnostic.
 
 ### State enums
 
@@ -264,7 +278,7 @@ The following scenarios are handled by the implementation. Test coverage is in
 
 | # | Scenario | Transition |
 |---|----------|------------|
-| P1 | CREATE TABLE | Crc[0] built via `into_crc_for_version_zero` |
+| P1 | CREATE TABLE | Crc[0] built via `CrcUpdate::into_fresh_crc` |
 | P2 | Blind append | Valid → Valid (sums + histogram bins inserted) |
 | P3 | MERGE / UPDATE / DELETE | Valid → Valid |
 | P4 | OPTIMIZE | Valid → Valid (many adds + many removes; net file count drops) |
@@ -317,16 +331,17 @@ The following scenarios are handled by the implementation. Test coverage is in
 | C3 | CRC written but `_last_checkpoint` not updated | Independent — CRC is just a hint |
 | C4 | Reader loads snapshot during concurrent commit | Sees consistent state at its version (snapshots are immutable) |
 
-### Recovery (deferred, priority 5)
+### Recovery via `Snapshot::load_file_stats`
 
-| # | Scenario | Future behavior |
-|---|----------|-----------------|
-| Rec1 | Indeterminate Crc, caller calls `load_file_stats` | Trigger reverse reconciliation, recover Valid |
-| Rec2 | Untrackable Crc, caller calls `load_file_stats` | Error (permanently unrecoverable) |
-| Rec3 | RequiresCheckpointRead, caller calls `load_file_stats` | Read checkpoint adds, merge with deltas, transition to Valid |
+| # | Scenario | Behavior |
+|---|----------|----------|
+| Rec1 | Indeterminate Crc, caller calls `load_file_stats` | Full reverse-replay with `(path, dv_unique_id)` deduplication; transitions to Valid (or Untrackable if a Remove with missing size is observed). |
+| Rec2 | Untrackable Crc, caller calls `load_file_stats` | Returns `Error::ChecksumWriteUnsupported` (permanently unrecoverable). |
+| Rec3 | RequiresCheckpointRead, caller calls `load_file_stats` | Same full-replay pass: reads commits + checkpoint together, dedups by `(path, dv_unique_id)`, transitions to Valid. |
+| Rec4 | Valid Crc, caller calls `load_file_stats` | No-op fast path; returns `Arc::clone(self)`. |
 
-Today: `Snapshot::load_file_stats(engine)` is stubbed as `Err`. The API surface is locked
-in for connectors.
+All other CRC fields (P/M, DM, txns, ICT) are preserved through recovery; only
+`file_stats` is rebuilt.
 
 ---
 
@@ -341,7 +356,7 @@ No write_checksum unless writing.
 
 Cost: one snapshot load (one batched read). Subsequent queries are zero I/O.
 
-### "Eager" writer (Reyden, Zerobus)
+### "Eager" streaming writer
 
 ```
 Loop:
@@ -427,7 +442,8 @@ For a stale or corrupt CRC that fails to load: warn and fall back to the no-CRC 
    queries against Partial that hit the cache return without I/O, but the cache is not
    exhaustive — callers requesting "all domains" trigger a full log replay.
 3. **Histogram dropped on degraded state.** Indeterminate and Untrackable have no histogram
-   field. Recovery via `load_file_stats` (priority 5) will rebuild it.
+   field. Recovery via `load_file_stats` rebuilds the histogram from active files (using
+   default bin boundaries).
 4. **Operation safety whitelist is conservative.** `INCREMENTAL_SAFE_OPS` lists
    `WRITE`, `MERGE`, `UPDATE`, `DELETE`, `OPTIMIZE`, `CREATE TABLE`, `REPLACE TABLE`,
    `CREATE TABLE AS SELECT`, `REPLACE TABLE AS SELECT`, `CREATE OR REPLACE TABLE AS SELECT`.
@@ -464,7 +480,7 @@ For a stale or corrupt CRC that fails to load: warn and fall back to the no-CRC 
 |------|---------|
 | `kernel/src/crc/mod.rs` | `Crc` struct, `CrcRaw` serde intermediate, `minimal_from_pm` |
 | `kernel/src/crc/state.rs` | `FileStatsState`, `DomainMetadataState`, `SetTransactionState`, `FileStatsValidity` |
-| `kernel/src/crc/delta.rs` | `CrcUpdate`, `Crc::apply`, `into_fresh_crc`, `into_crc_for_version_zero`, histogram merge |
+| `kernel/src/crc/delta.rs` | `CrcUpdate`, `Crc::apply`, `into_fresh_crc`, `transition_file_stats`, histogram merge |
 | `kernel/src/crc/file_stats.rs` | `FileStats`, `FileStatsDelta`, `try_compute_for_txn`, `is_incremental_safe` whitelist |
 | `kernel/src/crc/file_size_histogram.rs` | `FileSizeHistogram`, default bins, `try_apply_delta`, `try_add`, `try_sub` |
 | `kernel/src/crc/reader.rs` | `try_read_crc_file` (storage handler) |

--- a/CLAUDE/crc_design_decisions_log.md
+++ b/CLAUDE/crc_design_decisions_log.md
@@ -1,0 +1,266 @@
+# CRC Prototype 4 — Design Decisions Log
+
+Running log of decisions made while implementing the CRC redesign on `stack/crc_prototype_4` (branched off `main`), with code copied/adapted from the stale `stack/crc_replay_prototype_3` per `~/claude_plans/2026_04_25_crc_design_plan.md`.
+
+## Source-of-truth pointers
+
+- Plan: `~/claude_plans/2026_04_25_crc_design_plan.md`
+- Stale prototype: `origin/stack/crc_replay_prototype_3` (10 commits, diverged at `f5b7b5af`)
+- Current base: `main` (HEAD `6486bd26`, post #2387)
+
+## Decision log
+
+### 2026-04-25 — Starting state
+
+Current branch already has the "prototype 3" structural foundation from the stale prototype: `Crc` exists, has serde-friendly fields, `CrcDelta` + `Crc::apply` mutator exist, `LazyCrc` is on `Snapshot`, `try_compute_for_txn` builds histograms, `try_write_crc_file` gates on validity. So this is more an evolution than a full rewrite.
+
+### What's missing (vs. plan)
+
+1. **State enums.** `Crc` has flat `table_size_bytes: i64` + `num_files: i64` + a *separate* `file_stats_validity` flag. Plan calls for the typed `FileStatsState` enum so misuse is impossible. Same story for `Option<HashMap>` for DM/txns: plan calls for `DomainMetadataState` / `SetTransactionState` (Complete / Partial / Untracked). Currently `Option::None` doubles as both "not tracked" and "tracked but empty" with comments papering over it.
+2. **Eager `Arc<Crc>` on Snapshot.** Today still `Arc<LazyCrc>` (read-on-demand). Plan wants the CRC always materialised (free choice path: at most one batched read per replay range, no `OnceLock` ceremony in get-paths).
+3. **`CrcUpdate` (renamed from `CrcDelta`).** Plan unifies "single-commit delta" and "batched-replay accumulator output" under one type with `apply` and `into_fresh_crc`. Today `CrcDelta` only handles single commits (writes path); the snapshot-load path uses `LazyCrc.load → P&M-only`.
+4. **Reverse log replay accumulator.** No equivalent of `crc_replay.rs` — today the `LazyCrc` only ever loads a single CRC file from disk; stale CRCs are not "completed" via replay. The P&M replay path (`protocol_metadata_replay.rs`) is parallel infrastructure that only handles two fields.
+5. **`Snapshot::load_file_stats` stub.** No public surface for priority-5 recovery yet.
+6. **Partial state transitions.** Today `Crc::apply` *skips* DM/txn updates when the base is `None` (= Untracked). Plan wants `Untracked → Partial` so newer commits' DM/txns are observable even if the CRC base was missing them.
+7. **Histogram already wired** via `bin_boundaries` plumbing — keep it.
+
+### Decision A — Refactor in place, do NOT add `CrcRaw` serde intermediate
+
+Prototype 3 introduced `CrcRaw` as a flat 1:1-with-disk-spec struct, with `#[serde(from, into)]` on `Crc` to bridge typed enums to flat JSON. Reasons against:
+
+- `Crc`'s public API is `pub(crate)` (only escapes to `pub` under `test-utils`) — no external connectors round-trip it.
+- `CrcRaw` doubles the surface area, doubles maintenance burden, every new field touches both structs.
+- The typed-state enums can serialise themselves directly with custom `#[serde(with = ...)]` helpers, same as today's `de_opt_vec_to_opt_map` handles `HashMap` ↔ `Vec`.
+
+**Pick:** add custom serde helpers on the new state-enum fields; keep `Crc` as the single source of truth for the JSON. Saves ~150 lines of conversion code and one indirection layer.
+
+### Decision B — `FileStatsState` is the *whole* file-stats field
+
+That is, `Crc.file_stats: FileStatsState` replaces the 3-tuple of `table_size_bytes` + `num_files` + `file_stats_validity` + `file_size_histogram`. The histogram lives *inside* `FileStatsState::Valid { histogram, .. }` and `RequiresCheckpointRead { commit_delta_histogram, .. }`. Indeterminate / Untrackable have no histogram (because what would it mean?).
+
+This makes the variant-and-data invariant compiler-checked. You cannot read `num_files` from an `Indeterminate` state because there's no field there to read.
+
+### Decision C — `CrcRaw` JSON spec field mapping
+
+The on-disk `.crc` JSON spec is fixed (Delta protocol). For a Valid CRC, the relevant fields are:
+
+```
+{ "tableSizeBytes": int, "numFiles": int, "numMetadata": 1, "numProtocol": 1,
+  "metadata": {...}, "protocol": {...}, "inCommitTimestampOpt": int|null,
+  "setTransactions": [...]|null, "domainMetadata": [...]|null,
+  "fileSizeHistogram": {...}|null }
+```
+
+When deserialising we always start from `Valid` (a CRC file on disk is by definition valid). When serialising, we require `Valid` (writer rejects others via `is_writable`). So the serde mapping is one-way easy: the typed enum and the flat JSON are *isomorphic* on the writable subset.
+
+**Implementation:** custom `Serialize`/`Deserialize` for `Crc` directly that emits the flat JSON shape from the typed `FileStatsState::Valid` variant, and rejects on others. Or — cleaner — make `Crc` derive `Serialize`/`Deserialize` and use `#[serde(flatten)]` on the file-stats sub-struct with a manual writability gate.
+
+After looking at the existing implementation closely, the cleanest path is:
+
+- Keep `Crc` itself derived `Serialize, Deserialize` with the existing flat camelCase fields *visible* to serde.
+- Add private `pub` methods on `FileStatsState` to project to/from the flat triple. `Crc` exposes its file-stats *only* through accessors and a `file_stats` enum field that is `#[serde(skip)]`.
+- During deserialise: read flat fields into a temporary, then set the enum to `Valid {…}`.
+- During serialise: extract flat fields from the `Valid` variant, error on others.
+
+**Update after starting work:** the cleanest realisation is exactly what prototype 3 did with `CrcRaw` — except the maintenance burden complaint above is overstated. `CrcRaw` is a private-to-the-module flat mirror of disk JSON, lives next to `Crc`, and is a one-time write. Going with `CrcRaw` after all. Reverses Decision A.
+
+### Decision D — DM/txn states: `Untracked → Partial` via apply
+
+Per plan, when a commit's DM update lands on a CRC whose `domain_metadata` is `Untracked`, the result is `Partial(map_with_just_those_entries)`. This makes post-commit snapshots' DM cache "warm" for the most-recent domains even when the disk CRC didn't track them.
+
+The Snapshot fast-path branches on the variant:
+- `Complete(map)` → return from map (authoritative for both hits and misses)
+- `Partial(map)` → check map; on miss for a *specific* domain, do a log replay; on full enumeration, must do a log replay
+- `Untracked` → log replay
+
+### Decision E — Defer connector-hint API
+
+`SnapshotBuilder::with_eager_file_stats(bool)` is in the plan's "deferred" bucket. Skip for now. We always do the cheap path (load CRC file, replay if stale). Reyden / Untrackable recovery comes via `Snapshot::load_file_stats(engine)` (stubbed `Err`).
+
+### Decision F — Keep the existing `LazyCrc` plumbing for P&M-only replay
+
+The `LazyCrc` machinery in `protocol_metadata_replay.rs` is finely tuned for the case where we have a CRC file but P&M *might* still be in newer commits. Rewriting that path is out of scope. We keep `LazyCrc` as an internal helper for the P&M-only path inside the incremental snapshot updater (`Snapshot::try_new_from`), and add a new path for the full-CRC build (`try_build_crc_from_file` on the snapshot, called from `try_new_from_log_segment`).
+
+The Snapshot's *stored* CRC moves from `Arc<LazyCrc>` to `Arc<Crc>`. The `LazyCrc` lives only as a transient local var inside the incremental updater. **This is the prototype-3 shape.** Net result: zero external API change to `LazyCrc`, the eager `Arc<Crc>` is the public contract for `Snapshot`.
+
+### Decision G — Direction (reverse vs forward) — DEEP ANALYSIS
+
+**The plan recommends reverse.** I challenged this by going through forward's strengths in detail. Outcome below.
+
+#### Engine API constraint check
+
+`JsonHandler::read_json_files` contract (kernel/src/lib.rs:626-642): "the engine data iterator must first return all the engine data from file 'a', _then_ all the engine data from file 'b'." **The engine returns data in file order.** So direction is purely a kernel-side concern (it depends on whether `find_commit_cover` returns ascending or descending).
+
+`find_commit_cover` ends with `selected_files.reverse()`, returning descending. That's a *convention*, not a constraint. Adding a forward variant (`find_commit_cover_ascending`) would be a few lines.
+
+#### Direction-agnostic vs direction-sensitive aggregations
+
+| Aggregation | Reverse | Forward | Direction-agnostic? |
+|---|---|---|---|
+| Add `size` sum | += | += | ✓ |
+| Remove `size` sum (log only) | -= | -= | ✓ |
+| Histogram bins | += / -= | += / -= | ✓ |
+| Protocol replace | first-seen-wins (skip if Some) | last-wins (overwrite if Some) | ✓ (symmetric) |
+| Metadata replace | first-seen | last-wins | ✓ |
+| DM upsert per `domain` | first-seen-wins | last-wins | ✓ |
+| txn upsert per `app_id` | first-seen-wins | last-wins | ✓ |
+| ICT (newest commit) | first commitInfo seen | last commitInfo seen | ✓ |
+| `operation_safe` (any unsafe → Indeterminate) | OR | OR | ✓ |
+| Action dedup (path, dv_id) — priority 5 | first-seen-wins | last-wins | ✓ (memory same) |
+
+**Every CRC field is direction-agnostic.** The plan's "priority 5 requires reverse" claim is false: `FileActionDeduplicator` *was designed for* reverse, but reconciliation works in either direction with the same `O(distinct_files)` memory.
+
+#### Forward arguments
+
+1. **Unifies the apply path.** One mutator (`Crc::apply`); one shape (per-commit `CrcUpdate`); no separate accumulator with special `into_fresh_crc` finalization. The build-from-scratch path becomes literally `for batch in commits: crc.apply(extract(batch))`.
+2. **Composes with priority 4 (rebase).** Rebase is forward by necessity (apply each winning commit, interleaved with conflict checks). If CRC build is also forward, both share `Crc::apply` AND the per-commit shape.
+3. **Matches Delta protocol semantics.** "CRC at N = state of replaying commits 0..N forward." Forward replay literally implements this.
+4. **No `into_fresh_crc` ambiguity.** For reverse, an accumulated update represents a *range* of commits, but its semantics (first-seen P/M, summed file stats, etc.) only make sense when applied in one shot. For forward, every per-commit update is self-contained — apply repeatedly without aggregation.
+5. **Engine API is direction-agnostic** (proven above). No engine refactoring needed.
+6. **Visitor is the same complexity.** `map.insert()` (last-wins) is no harder than `entry().or_insert_with()` (first-wins).
+
+#### Reverse arguments
+
+1. **Existing `read_actions` returns reverse.** Adding ascending requires touching `find_commit_cover` (5 lines).
+2. **Current code already produces "one delta, apply once".** The in-memory commit-time path produces a single `CrcDelta` and applies once; reverse-batched-replay fits this model directly.
+3. **Aligns with kernel's reverse-replay convention** (`LogReplayProcessor`, `FileActionDeduplicator`). Going forward for CRC is the odd one out.
+4. **Plan explicitly recommends reverse.** Diverging from documented design needs stronger evidence than "forward is conceptually nicer."
+5. **Forward's main win (rebase composition) is theoretical** — rebase is priority 4, not built yet, may evolve.
+6. **For "stale CRC + replay newer commits," reverse-then-apply-once produces the cleanest 2-arg API**: `crc.apply(replay_update)` — one network read produces one mutation.
+
+#### Histogram merge subtlety (forward only)
+
+Forward replay starting from `Crc::default()` has `histogram = None`. The first commit's update has `Some(histogram)`. Today's merge logic drops the histogram if base is `Some` and delta is `None`, but for `(None, Some)` it returns `None` (not great — we should adopt the delta's histogram).
+
+This is a fixable issue but it does mean forward needs a slightly different merge rule:
+- `(Some, Some)` → merge
+- `(Some, None)` → drop
+- `(None, Some)` → adopt delta
+- `(None, None)` → stay None
+
+Reverse doesn't hit `(None, Some)` because the reverse-accumulator builds the histogram once at the end.
+
+#### Priority 4 (rebase) compatibility
+
+Both directions support rebase. Rebase forward-applies each winning commit's `CrcUpdate` onto the pre-rebase Crc. The `CrcUpdate` shape is the same regardless of how the original CRC was built. Reverse-built CRCs can be forward-rebased without issue.
+
+#### My take
+
+Forward is conceptually nicer but reverse is closer to the current code. Given:
+
+- Plan explicitly says reverse.
+- Current code already does one-delta-one-apply (reverse-style).
+- Engine API supports both.
+- Visitor logic is mirror-image.
+- Both are correct.
+- Forward's rebase win is hypothetical (priority 4 is far out).
+- Forward needs a histogram merge tweak.
+
+**Going with REVERSE.** Simpler delta from current state, matches plan, defers the rebase-shape question until it actually matters.
+
+#### What this means for the visitor
+
+Reverse-iterate. Visitor:
+
+- **Protocol/Metadata**: first-seen-wins. The accumulator holds `Option<Protocol>` / `Option<Metadata>` — set once, then skip.
+- **DomainMetadata**: first-seen-wins per `domain` via `entry().or_insert_with()`.
+- **SetTransaction**: first-seen-wins per `app_id`.
+- **Add file size**: `+= add.size` always (no dedup — `Incremental` strategy).
+- **Remove file size**: `-= remove.size` *only on commit batches* (`is_log_batch=true`). Checkpoint tombstones are skipped (they're for vacuum, not active state).
+- **Histogram**: insert add, remove remove, only on commit batches for removes.
+- **commitInfo.operation**: any commit row whose operation is not `INCREMENTAL_SAFE_OPS` flips `operation_safe = false`. Missing commitInfo also flips it.
+- **commitInfo.inCommitTimestamp**: first seen (= newest commit's) ICT, captured into `in_commit_timestamp`.
+- **Missing remove.size**: any remove with null size flips `has_missing_file_size = true`.
+
+After iteration, the accumulator yields a `CrcUpdate`. We then either:
+- `base.apply(update)` for stale-CRC + replay (priorities 1).
+- `update.into_fresh_crc()` for full-replay (priorities 3, no checkpoint or no CRC).
+
+For checkpoint-bootstrap, the segment includes checkpoint + commits; the same one-pass replay handles both via `is_log_batch` gating (commits get full delta semantics, checkpoint adds get summed in, checkpoint removes are skipped). At the end, `into_fresh_crc()` produces a Valid Crc.
+
+### Decision G.2 — Long-term direction architecture (revised)
+
+User asked for long-term design, not just-for-this-PR thinking. Re-examining:
+
+**Long-term right answer:**
+
+Different consumers need different directions. The architecture should *support both*, with each consumer picking what fits its workload:
+
+| Consumer | Best direction | Why |
+|---|---|---|
+| Action reconciliation (P5) | Reverse | `FileActionDeduplicator` was designed reverse; sharing primitive |
+| Rebase (P4) | Forward per-commit | Interleaved with conflict checks; can't pre-batch |
+| Stale-CRC catch-up (P1) | Either | Long-term: pick *forward* (matches commit-time + rebase shape) |
+| No-CRC bootstrap with checkpoint (P3) | Reverse | Checkpoint is "state at C", commits are deltas after; reverse handles both uniformly via the accumulator |
+| Full replay 0..N (P3) | Reverse | Accumulator + `into_fresh_crc` validates full state at end |
+
+The shared primitives are direction-agnostic:
+
+- `CrcUpdate` (the universal delta type)
+- `Crc::apply(CrcUpdate)` (the universal mutator, last-write-wins)
+- `CrcUpdate::into_fresh_crc() -> DeltaResult<Crc>` (constructor when no base CRC exists)
+
+The direction-specific helpers are:
+
+- `extract_crc_update_for_batch(batch) -> CrcUpdate` (single-batch extractor; direction-agnostic)
+- `ReverseCrcAccumulator` (composes batches with first-seen-wins; for reverse callers)
+- *Future:* `LogSegment::read_actions_ascending` for forward callers (rebase + forward stale-catchup option)
+
+### What lands in this PR (long-term-correct subset)
+
+For prototype 4, ship the universal pieces and the reverse accumulator:
+
+1. `CrcUpdate` type with `apply` and `into_fresh_crc`.
+2. `Crc::apply` last-write-wins mutator.
+3. `ReverseCrcAccumulator` for stale-CRC catch-up AND no-CRC bootstrap.
+4. Both consumers share `read_actions` (existing reverse-streaming).
+5. The per-batch extractor lives inside `ReverseCrcAccumulator::absorb` for now; extracting it as a standalone function is a future refactor when forward consumers (rebase) need it.
+
+When rebase lands later:
+- Pull `extract_crc_update_for_batch(batch) -> CrcUpdate` out of `ReverseCrcAccumulator::absorb`.
+- Add `LogSegment::read_actions_ascending`.
+- Implement forward-per-commit apply in the rebase code path.
+- *Optional:* migrate stale-CRC catch-up to forward (free choice, not blocking).
+
+This shape:
+- Doesn't lock us into reverse-only.
+- Doesn't ship infrastructure we don't need yet.
+- Provides a clean factoring point when rebase forces our hand.
+
+### Decision H — Ignore log compactions in CRC replay (for now)
+
+Per user direction and CLAUDE.md ("log compaction (disabled, #2337)"). The visitor doesn't currently distinguish compaction batches from regular commit batches. If compactions later contain pre-summed deltas, the accumulator would over-count. For now: don't go out of our way to support them. If they appear in a CRC-replay segment, the accumulator treats them as commit batches, which over-counts file stats. Real fix: filter compactions out of the CRC-replay segment, or have the visitor flip `operation_safe = false` when seeing a compaction batch. Tracked as TODO.
+
+### Decision G.1 — Direction is per-use-case, abstractions are direction-agnostic
+
+The user pushed back: action reconciliation needs reverse, rebase needs forward, stale-CRC could be either. The right answer is to make `Crc::apply` + `CrcUpdate` direction-agnostic so the choice for "free" cases is just a per-call decision, not an architecture commitment.
+
+**Concretely:**
+
+- `extract_update_for_batch(batch) -> CrcUpdate` — direction-agnostic per-batch extractor. Each commit has at most one Protocol/Metadata/commitInfo, so within a single batch there's no first/last ambiguity.
+- `Crc::apply(CrcUpdate)` — last-write-wins (overwrite if `Some`, `map.insert()`). That's the natural shape for forward-per-batch.
+- `ReverseCrcAccumulator` — for reverse callers. Internally does first-seen-wins as it absorbs each batch. Finalizes to a single `CrcUpdate` that's already been merged. The single `Crc::apply` then has nothing to overwrite.
+
+Both paths produce identical Crc state. The choice is a caller knob.
+
+**For this PR**, stale-CRC catch-up uses reverse-accumulator-then-apply, because:
+- Closer to current code shape.
+- Aligns with priority-5 direction (shared scaffolding).
+- Engine `read_actions` already streams reverse.
+- Engine API supports both, so this is not a one-way door.
+
+**For priority 4 (rebase)**, when it lands, it'll use forward-per-commit `Crc::apply` directly — no accumulator needed. Same `CrcUpdate` type.
+
+**For priority 5 (reconciliation)**, when it lands, it'll fork the visitor for the wide schema + dedup needs, but feed the result through the same `Crc::apply`.
+
+#### What changes in `Crc::apply` semantics for `CrcUpdate`
+
+The current `CrcDelta` has `domain_metadata_changes: Vec<DomainMetadata>` and `set_transaction_changes: Vec<SetTransaction>`. Replay produces *map-keyed* updates (already deduplicated by domain / app_id). To unify, change the field types to `HashMap<String, _>` matching the in-memory storage. Commit-time path (`Transaction::commit`) builds the map from its `Vec` source.
+
+ICT semantics: today `apply` does `self.in_commit_timestamp_opt = delta.in_commit_timestamp;` unconditionally. Keep that. For commit-time deltas, this sets the new commit's ICT. For reverse-replay updates, this sets the *newest* commit's ICT (because the visitor captured first-seen-in-reverse). Both correct.
+
+operation_safe: today `apply` checks `delta.operation` (Option<String>) against the whitelist. For reverse-replay, the visitor has *already* computed `operation_safe: bool` (any unsafe seen). So the field type changes from `operation: Option<String>` to `operation_safe: bool`. Commit-time path computes this once.
+
+### Decision H — `Snapshot::load_file_stats` is `pub`, returns `SnapshotRef`
+
+The plan says "`Snapshot::load_file_stats(engine) -> SnapshotRef`". Public API surface, returns a *new* snapshot (immutable upgrade) with the recovered file stats. Today: stub returns `Err(Error::FileStatsRecoveryNotImplemented)` (new error variant or generic). Connector contract is locked but recovery is post-MVP.

--- a/CLAUDE/crc_design_decisions_log.md
+++ b/CLAUDE/crc_design_decisions_log.md
@@ -1,12 +1,13 @@
 # CRC Prototype 4 — Design Decisions Log
 
-Running log of decisions made while implementing the CRC redesign on `stack/crc_prototype_4` (branched off `main`), with code copied/adapted from the stale `stack/crc_replay_prototype_3` per `~/claude_plans/2026_04_25_crc_design_plan.md`.
+Running log of decisions made while implementing the CRC redesign on `stack/crc_prototype_4`
+(branched off `main`), with code copied/adapted from the stale `stack/crc_replay_prototype_3`.
 
 ## Source-of-truth pointers
 
-- Plan: `~/claude_plans/2026_04_25_crc_design_plan.md`
 - Stale prototype: `origin/stack/crc_replay_prototype_3` (10 commits, diverged at `f5b7b5af`)
 - Current base: `main` (HEAD `6486bd26`, post #2387)
+- Design doc shipped in tree: [`CLAUDE/crc_design.md`](./crc_design.md)
 
 ## Decision log
 
@@ -75,7 +76,7 @@ The Snapshot fast-path branches on the variant:
 
 ### Decision E — Defer connector-hint API
 
-`SnapshotBuilder::with_eager_file_stats(bool)` is in the plan's "deferred" bucket. Skip for now. We always do the cheap path (load CRC file, replay if stale). Reyden / Untrackable recovery comes via `Snapshot::load_file_stats(engine)` (stubbed `Err`).
+`SnapshotBuilder::with_eager_file_stats(bool)` is in the plan's "deferred" bucket. Skip for now. We always do the cheap path (load CRC file, replay if stale). Recovery from `Indeterminate` / `RequiresCheckpointRead` is implemented via `Snapshot::load_file_stats(engine)`.
 
 ### Decision F — Keep the existing `LazyCrc` plumbing for P&M-only replay
 

--- a/kernel/src/crc/delta.rs
+++ b/kernel/src/crc/delta.rs
@@ -6,8 +6,8 @@
 //! This satisfies the fundamental invariant of the CRC system:
 //!
 //! ```text
-//! Crc[N] + CrcUpdate(N→N+1) = Crc[N+1]
-//! Crc[N] + CrcUpdate(N→M)   = Crc[M]    (M > N+1)
+//! Crc[N] + CrcUpdate(N->N+1) = Crc[N+1]
+//! Crc[N] + CrcUpdate(N->M)   = Crc[M]    (M > N+1)
 //! ```
 //!
 //! `apply` itself is *forward*: it always reads the equation left-to-right (older + delta =
@@ -156,15 +156,15 @@ impl CrcUpdate {
 /// would be misleading).
 ///
 /// Behavior:
-/// - `(Some(base), Some(net))` → merge via [`FileSizeHistogram::try_apply_delta`]; on failure
+/// - `(Some(base), Some(net))` -> merge via [`FileSizeHistogram::try_apply_delta`]; on failure
 ///   (boundary mismatch, negative counts after merge), drop and warn.
-/// - `(Some(base), None)` → drop. The base had a histogram but the update could not provide one;
+/// - `(Some(base), None)` -> drop. The base had a histogram but the update could not provide one;
 ///   carrying the base forward without the update's contribution would be stale.
-/// - `(None, Some(_))` → drop. The base lacked a histogram, so the update's net histogram alone (a
+/// - `(None, Some(_))` -> drop. The base lacked a histogram, so the update's net histogram alone (a
 ///   delta over an unknown baseline) cannot be turned into an absolute. The right place to seed an
 ///   initial histogram is [`CrcUpdate::into_fresh_crc`], which receives an absolute (full-replay)
 ///   histogram rather than a delta.
-/// - `(None, None)` → stay `None`.
+/// - `(None, None)` -> stay `None`.
 fn merge_histogram(
     base: Option<&FileSizeHistogram>,
     delta: Option<&FileSizeHistogram>,
@@ -188,7 +188,7 @@ fn merge_histogram(
 impl Crc {
     /// Apply a [`CrcUpdate`], advancing this CRC to the new version.
     ///
-    /// Implements the fundamental invariant `Crc[N] + CrcUpdate(N→M) = Crc[M]`. Direction-
+    /// Implements the fundamental invariant `Crc[N] + CrcUpdate(N->M) = Crc[M]`. Direction-
     /// agnostic: works for single-commit deltas (M = N+1) or accumulated multi-commit
     /// deltas (M > N+1) interchangeably.
     ///
@@ -239,7 +239,7 @@ impl Crc {
         }
 
         // Set transactions: upsert from update map. No tombstone semantic for txns. Same
-        // Untracked → Partial transition.
+        // Untracked -> Partial transition.
         if !set_transactions.is_empty() {
             match &mut self.set_transactions {
                 SetTransactionState::Complete(map) | SetTransactionState::Partial(map) => {
@@ -744,7 +744,7 @@ mod tests {
 
     #[test]
     fn apply_drops_histogram_when_base_none_delta_some() {
-        // A base CRC without a histogram + an update with a delta histogram → the
+        // A base CRC without a histogram + an update with a delta histogram -> the
         // resulting CRC has no histogram. The delta is an *increment* over an unknown
         // baseline, so adopting it as the absolute histogram would be wrong (it would
         // describe only this commit's files, not the table's full file set). The right

--- a/kernel/src/crc/delta.rs
+++ b/kernel/src/crc/delta.rs
@@ -65,9 +65,18 @@ pub(crate) struct CrcUpdate {
     pub(crate) domain_metadata: HashMap<String, DomainMetadata>,
     /// Set transaction changes keyed by `app_id`. Pre-keyed for direct upsert.
     pub(crate) set_transactions: HashMap<String, SetTransaction>,
-    /// In-commit timestamp from the latest commit covered by this update. `None` clears,
-    /// `Some` sets.
-    pub(crate) in_commit_timestamp: Option<i64>,
+    /// In-commit timestamp observed by the producer. The outer `Option` is "did the
+    /// producer observe ICT data" (None = no observation; the apply leaves the base CRC's
+    /// ICT untouched). The inner `Option` is the ICT value itself: `Some(v)` sets the new
+    /// ICT, `None` clears it (e.g. ICT was disabled).
+    ///
+    /// In practice:
+    /// - Commit-time path: always `Some(maybe_ict)` -- the transaction either has ICT enabled
+    ///   (`Some(Some(v))`) or doesn't (`Some(None)`).
+    /// - Reverse-replay accumulator: `Some(maybe_ict)` only when at least one commit's
+    ///   `commitInfo.inCommitTimestamp` was observed; `None` when the segment was empty or
+    ///   contained no commitInfo (trivially safe / checkpoint-only branches).
+    pub(crate) in_commit_timestamp: Option<Option<i64>>,
     /// `true` iff every observed commit had an incremental-safe operation. `false` if any
     /// commit's `commitInfo.operation` was unrecognized, missing, or known-unsafe (e.g.
     /// `ANALYZE STATS`). Producers compute this once.
@@ -137,7 +146,7 @@ impl CrcUpdate {
             file_stats,
             domain_metadata,
             set_transactions,
-            in_commit_timestamp_opt: self.in_commit_timestamp,
+            in_commit_timestamp_opt: self.in_commit_timestamp.flatten(),
         })
     }
 }
@@ -242,9 +251,14 @@ impl Crc {
             }
         }
 
-        // In-commit timestamp: replace unconditionally. ICT could be disabled (Some →
-        // None) or enabled (None → Some) or updated (Some → Some).
-        self.in_commit_timestamp_opt = in_commit_timestamp;
+        // In-commit timestamp: replace ONLY when the producer observed it (Some(_)).
+        // `None` means "no observation" -- leave base CRC's ICT untouched (this is the
+        // empty-segment / checkpoint-only / no-commitInfo trivially-safe path). When the
+        // producer did observe ICT, the inner Option is the new value (Some = enabled,
+        // None = ICT disabled).
+        if let Some(observed_ict) = in_commit_timestamp {
+            self.in_commit_timestamp_opt = observed_ict;
+        }
 
         self.file_stats = transition_file_stats(
             &self.file_stats,
@@ -564,20 +578,34 @@ mod tests {
     }
 
     #[test]
-    fn apply_ict_replaces_unconditionally() {
+    fn apply_ict_observation_semantics() {
         let mut crc = base_crc();
         crc.in_commit_timestamp_opt = Some(1000);
 
-        // None clears
+        // None outer = "did not observe ICT" -- leave base alone.
         crc.apply(CrcUpdate {
             in_commit_timestamp: None,
             ..write_update(0, 0)
         });
-        assert_eq!(crc.in_commit_timestamp_opt, None);
+        assert_eq!(
+            crc.in_commit_timestamp_opt,
+            Some(1000),
+            "None means 'no observation'; base is preserved"
+        );
 
-        // Some sets
+        // Some(None) = "observed: ICT disabled" -- clears base.
         crc.apply(CrcUpdate {
-            in_commit_timestamp: Some(2000),
+            in_commit_timestamp: Some(None),
+            ..write_update(0, 0)
+        });
+        assert_eq!(
+            crc.in_commit_timestamp_opt, None,
+            "Some(None) clears the ICT (observed disabled)"
+        );
+
+        // Some(Some(v)) sets.
+        crc.apply(CrcUpdate {
+            in_commit_timestamp: Some(Some(2000)),
             ..write_update(0, 0)
         });
         assert_eq!(crc.in_commit_timestamp_opt, Some(2000));

--- a/kernel/src/crc/delta.rs
+++ b/kernel/src/crc/delta.rs
@@ -140,14 +140,6 @@ impl CrcUpdate {
             in_commit_timestamp_opt: self.in_commit_timestamp,
         })
     }
-
-    /// Convert this update into a fresh [`Crc`] for version zero (CREATE TABLE).
-    ///
-    /// Returns `None` if protocol or metadata are missing (both are required for a valid
-    /// CRC). Wraps [`into_fresh_crc`] for the version-zero post-commit path.
-    pub(crate) fn into_crc_for_version_zero(self) -> Option<Crc> {
-        self.into_fresh_crc().ok()
-    }
 }
 
 /// Merge a base histogram with the update's net histogram. Returns `Some(merged)` on

--- a/kernel/src/crc/delta.rs
+++ b/kernel/src/crc/delta.rs
@@ -1,205 +1,292 @@
-//! Incremental CRC state updates via commit deltas.
+//! Incremental CRC state updates.
 //!
-//! A [`CrcDelta`] captures CRC-relevant changes from a single commit (produced by reading a
-//! `.json` commit file during log replay, or from in-memory transaction state during writes).
-//! [`Crc::apply`] advances a CRC forward one commit at a time by applying a delta.
+//! A [`CrcUpdate`] captures CRC-relevant changes from a single commit OR from a multi-commit
+//! replay. [`Crc::apply`] is the universal mutator, applying an update onto a base CRC.
 //!
-//! A CRC tracks two categories of fields, updated differently:
-//! - **Metadata fields** (protocol, metadata, domain metadata, set transactions, in-commit
-//!   timestamp): always kept up-to-date -- every `apply` unconditionally merges these from the
-//!   delta.
-//! - **File stats** (`num_files`, `table_size_bytes`): only updated when the current
-//!   [`FileStatsValidity`] is not terminal and the commit's operation is incremental-safe. Once
-//!   validity degrades (e.g. a non-incremental operation like ANALYZE STATS, or a missing file
-//!   size), file stats stop updating for the lifetime of that CRC.
+//! This satisfies the fundamental invariant of the CRC system:
+//!
+//! ```text
+//! Crc[N] + CrcUpdate(N→N+1) = Crc[N+1]
+//! Crc[N] + CrcUpdate(N→M)   = Crc[M]    (M > N+1)
+//! ```
+//!
+//! `apply` itself is *forward*: it always reads the equation left-to-right (older + delta =
+//! newer). The update can be *produced* by either direction:
+//!
+//! - **Commit-time**: a single commit's actions are turned into one update; apply once.
+//! - **Stale-CRC reverse-replay**: commits N+1..M read in reverse, accumulated into one update via
+//!   [`ReverseCrcAccumulator`](crate::log_segment::CrcReplayAccumulator); apply once. (Reverse uses
+//!   first-seen-wins per key; the resulting update is equivalent to `δ_{N+1} + δ_{N+2} + ... + δ_M`
+//!   produced forward.)
+//! - **Future: forward per-commit replay** (used by rebase): each commit produces an update,
+//!   applied repeatedly. No accumulator needed.
+//! - **Future: action reconciliation**: a wider visitor with deduplication produces one update,
+//!   applied once. Same shape, different production.
+//!
+//! All four producers share `CrcUpdate` and feed `Crc::apply`.
+//!
+//! # Field semantics on apply
+//!
+//! - **Protocol / Metadata**: replace if `Some` (last-write-wins).
+//! - **Domain metadata / Set transactions**: upsert from update map; tombstones (DM with
+//!   `removed=true`) remove the entry. If base is [`Untracked`](super::DomainMetadataState),
+//!   transition to [`Partial`](super::DomainMetadataState) when update has entries.
+//! - **In-commit timestamp**: replace unconditionally (`None` clears, `Some` sets).
+//! - **File stats**: state-machine transition based on update flags and base variant. See the table
+//!   on [`FileStatsState`].
+
+use std::collections::HashMap;
 
 use tracing::warn;
 
 use super::file_stats::FileStatsDelta;
-use super::{Crc, FileStatsValidity};
+use super::{Crc, DomainMetadataState, FileSizeHistogram, FileStatsState, SetTransactionState};
 use crate::actions::{DomainMetadata, Metadata, Protocol, SetTransaction};
+use crate::{DeltaResult, Error};
 
-/// The CRC-relevant changes ("delta") from a single commit. Produced either by reading a
-/// `.json` commit file during log replay, or from in-memory transaction state during writes.
+/// CRC-relevant changes ("delta") to apply to a base [`Crc`]. Universal type used by
+/// commit-time, log-replay, and (future) rebase paths.
+///
+/// **Last-write-wins semantics**: every field in this struct represents "what should be set
+/// on the resulting CRC at the new version." The producer is responsible for ensuring the
+/// values are correct for the target version (e.g. reverse-replay producers use first-seen
+/// wins to capture the newest values).
 #[derive(Debug, Clone, Default)]
-pub(crate) struct CrcDelta {
-    /// Net file count, size changes and histograms.
+pub(crate) struct CrcUpdate {
+    /// Net file count, size changes, and optional histogram (see [`FileStatsDelta`]).
     pub(crate) file_stats: FileStatsDelta,
-    /// New protocol action, if this commit changed it.
+    /// New protocol action, if changed in this update. `None` means "no change."
     pub(crate) protocol: Option<Protocol>,
-    /// New metadata action, if this commit changed it.
+    /// New metadata action, if changed. `None` means "no change."
     pub(crate) metadata: Option<Metadata>,
-    /// All DM actions in this commit (additions and removals). `apply()` only processes these
-    /// when the base CRC's `domain_metadata` is `Some` (tracked).
-    pub(crate) domain_metadata_changes: Vec<DomainMetadata>,
-    /// All SetTransaction actions in this commit. `apply()` only processes these when the base
-    /// CRC's `set_transactions` is `Some` (tracked).
-    pub(crate) set_transaction_changes: Vec<SetTransaction>,
-    /// In-commit timestamp, if present in this commit.
+    /// Domain metadata changes keyed by domain name. Tombstones (DM with `removed=true`)
+    /// remove the entry on apply. Pre-keyed for direct upsert -- producers (commit-time
+    /// path, reverse-replay accumulator) own the dedup logic.
+    pub(crate) domain_metadata: HashMap<String, DomainMetadata>,
+    /// Set transaction changes keyed by `app_id`. Pre-keyed for direct upsert.
+    pub(crate) set_transactions: HashMap<String, SetTransaction>,
+    /// In-commit timestamp from the latest commit covered by this update. `None` clears,
+    /// `Some` sets.
     pub(crate) in_commit_timestamp: Option<i64>,
-    /// Must be `Some` with an incremental-safe value for file stats to update. `None` or
-    /// unrecognized values transition validity to `Indeterminate`.
-    pub(crate) operation: Option<String>,
-    /// A file action in this commit had a missing `size` field, making byte-level file stats
-    /// impossible to compute.
+    /// `true` iff every observed commit had an incremental-safe operation. `false` if any
+    /// commit's `commitInfo.operation` was unrecognized, missing, or known-unsafe (e.g.
+    /// `ANALYZE STATS`). Producers compute this once.
+    pub(crate) operation_safe: bool,
+    /// `true` iff any observed file action had a missing `size` field. Permanent: an update
+    /// with this flag transitions file stats to [`Untrackable`](FileStatsState::Untrackable).
     pub(crate) has_missing_file_size: bool,
 }
 
-impl CrcDelta {
-    /// Convert this delta into a fresh [`Crc`]. Used when the delta represents the entire table
-    /// state (e.g. CREATE TABLE or the first commit in a forward replay from version zero).
+impl CrcUpdate {
+    /// Convert this update into a fresh [`Crc`].
     ///
-    /// Returns `None` if protocol or metadata are missing (both are required for a valid CRC).
-    pub(crate) fn into_crc_for_version_zero(self) -> Option<Crc> {
-        let protocol = self.protocol?;
-        let metadata = self.metadata?;
-        // For CREATE TABLE we always know the full domain metadata state: the transaction
-        // either included domain metadata actions or it didn't. So this is always `Some` --
-        // an empty map means "no domain metadata", not "unknown".
-        let domain_metadata = Some(
-            self.domain_metadata_changes
+    /// Used when the update represents the *complete* table state (no base CRC to apply
+    /// onto). Specifically: full log replay from version 0, or no-CRC bootstrap from a
+    /// checkpoint + commits where the accumulator captured everything.
+    ///
+    /// Returns:
+    /// - `FileStatsState::Untrackable` if `has_missing_file_size`
+    /// - `FileStatsState::Indeterminate` if `!operation_safe`
+    /// - `FileStatsState::Valid { ... }` otherwise (with histogram if present)
+    /// - DM and txns: [`Complete`](DomainMetadataState::Complete) (full state was captured)
+    /// - Filters DM tombstones from the resulting map
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `protocol` or `metadata` is missing -- both are required to
+    /// construct a valid CRC.
+    pub(crate) fn into_fresh_crc(self) -> DeltaResult<Crc> {
+        let protocol = self.protocol.ok_or(Error::MissingProtocol)?;
+        let metadata = self.metadata.ok_or(Error::MissingMetadata)?;
+
+        let domain_metadata = DomainMetadataState::Complete(
+            self.domain_metadata
                 .into_iter()
-                .filter(|dm| !dm.is_removed())
-                .map(|dm| (dm.domain().to_string(), dm))
+                .filter(|(_, dm)| !dm.is_removed())
                 .collect(),
         );
-        // CREATE TABLE starts with a known-complete set of transactions (possibly empty),
-        // so we always track them.
-        let set_transactions = Some(
-            self.set_transaction_changes
-                .into_iter()
-                .map(|txn| (txn.app_id.clone(), txn))
-                .collect(),
-        );
-        // For version zero the delta IS the full table histogram. Validate that all bins
-        // are non-negative (a real table can't have negative file counts). If validation
-        // fails, drop the histogram.
-        let initial_histogram = self.file_stats.net_histogram.and_then(|delta| {
-            delta
-                .check_non_negative()
-                .inspect_err(|e| {
-                    warn!("Non-negative file count check failed, dropping file size histogram for version zero: {e}");
-                })
-                .ok()
-        });
-        Some(Crc {
-            table_size_bytes: self.file_stats.net_bytes,
-            num_files: self.file_stats.net_files,
-            num_metadata: 1,
-            num_protocol: 1,
+        let set_transactions = SetTransactionState::Complete(self.set_transactions);
+
+        let file_stats = if self.has_missing_file_size {
+            FileStatsState::Untrackable
+        } else if !self.operation_safe {
+            FileStatsState::Indeterminate
+        } else {
+            // For a full-replay update, file_stats.net_files / net_bytes / net_histogram are
+            // the absolute totals (no negatives possible since we're summing checkpoint
+            // adds + commit adds - commit removes from a complete history). If for any
+            // reason the histogram has negative bins (corrupted log), drop it rather than
+            // emit a Valid CRC with a bad histogram.
+            let histogram = self.file_stats.net_histogram.and_then(|hist| {
+                hist.check_non_negative()
+                    .inspect_err(|e| {
+                        warn!("into_fresh_crc: dropping histogram due to negative bins: {e}");
+                    })
+                    .ok()
+            });
+            FileStatsState::Valid {
+                num_files: self.file_stats.net_files,
+                table_size_bytes: self.file_stats.net_bytes,
+                histogram,
+            }
+        };
+
+        Ok(Crc {
             protocol,
             metadata,
+            file_stats,
             domain_metadata,
             set_transactions,
             in_commit_timestamp_opt: self.in_commit_timestamp,
-            file_size_histogram: initial_histogram,
-            ..Default::default()
         })
+    }
+
+    /// Convert this update into a fresh [`Crc`] for version zero (CREATE TABLE).
+    ///
+    /// Returns `None` if protocol or metadata are missing (both are required for a valid
+    /// CRC). Wraps [`into_fresh_crc`] for the version-zero post-commit path.
+    pub(crate) fn into_crc_for_version_zero(self) -> Option<Crc> {
+        self.into_fresh_crc().ok()
     }
 }
 
-/// Commit delta application for [`Crc`]. See the [module-level docs](self) for details.
+/// Merge a base histogram with the update's net histogram. Returns `Some(merged)` on
+/// success, `None` to drop the histogram (when the merge would fail or produce stale data).
+///
+/// Behavior:
+/// - `(Some(base), Some(net))` → merge via [`FileSizeHistogram::try_apply_delta`]; on failure
+///   (boundary mismatch, negative counts), drop and warn.
+/// - `(Some(base), None)` → drop. The base had a histogram but the update could not provide one;
+///   stale data is worse than no data.
+/// - `(None, Some(net))` → adopt the update's histogram. Useful for forward replay starting from a
+///   base with no histogram, or for stale-catchup against a CRC that lacked a histogram.
+/// - `(None, None)` → stay `None`.
+fn merge_histogram(
+    base: Option<&FileSizeHistogram>,
+    delta: Option<&FileSizeHistogram>,
+) -> Option<FileSizeHistogram> {
+    match (base, delta) {
+        (Some(base_hist), Some(delta_hist)) => match base_hist.try_apply_delta(delta_hist) {
+            Ok(merged) => Some(merged),
+            Err(e) => {
+                warn!("Histogram merge failed, dropping file size histogram: {e}");
+                None
+            }
+        },
+        (None, Some(delta_hist)) => Some(delta_hist.clone()),
+        (Some(_), None) | (None, None) => None,
+    }
+}
+
+// ============================================================================
+// Crc::apply -- the universal mutator
+// ============================================================================
+
 impl Crc {
-    /// Apply a commit delta, updating all CRC fields and adjusting file stats validity.
+    /// Apply a [`CrcUpdate`], advancing this CRC to the new version.
     ///
-    /// Metadata fields are always updated. File stats are only updated when:
-    /// - Validity is not already terminal ([`Untrackable`](FileStatsValidity::Untrackable) or
-    ///   [`Indeterminate`](FileStatsValidity::Indeterminate))
-    /// - The delta has no missing file sizes
-    /// - The operation is incremental-safe
-    pub(crate) fn apply(&mut self, delta: CrcDelta) {
-        // Protocol and metadata: replace if present.
-        if let Some(p) = delta.protocol {
+    /// Implements the fundamental invariant `Crc[N] + CrcUpdate(N→M) = Crc[M]`. Direction-
+    /// agnostic: works for single-commit deltas (M = N+1) or accumulated multi-commit
+    /// deltas (M > N+1) interchangeably.
+    ///
+    /// Field semantics: see the [module-level docs](self).
+    pub(crate) fn apply(&mut self, update: CrcUpdate) {
+        // Protocol / Metadata: replace if present.
+        if let Some(p) = update.protocol {
             self.protocol = p;
         }
-        if let Some(m) = delta.metadata {
+        if let Some(m) = update.metadata {
             self.metadata = m;
         }
 
-        // Domain metadata: insert or remove by domain name. Only update if the base CRC
-        // tracks domain metadata (Some). If None ("not tracked"), leave it as None --
-        // applying partial changes would create an incomplete map.
-        if !delta.domain_metadata_changes.is_empty() {
-            if let Some(map) = &mut self.domain_metadata {
-                for dm in delta.domain_metadata_changes {
-                    if dm.is_removed() {
-                        map.remove(dm.domain());
-                    } else {
-                        let domain = dm.domain().to_string();
-                        map.insert(domain, dm);
+        // Domain metadata: upsert from update map, removing tombstones. If base is
+        // Untracked but the update has entries (e.g. older CRC didn't track DM but newer
+        // commits do), transition to Partial.
+        if !update.domain_metadata.is_empty() {
+            match &mut self.domain_metadata {
+                DomainMetadataState::Complete(map) | DomainMetadataState::Partial(map) => {
+                    for (domain, dm) in update.domain_metadata {
+                        if dm.is_removed() {
+                            map.remove(&domain);
+                        } else {
+                            map.insert(domain, dm);
+                        }
                     }
                 }
-            }
-        }
-
-        // Set transactions: upsert by app_id. Only update if the base CRC tracks set
-        // transactions (Some). If None ("not tracked"), leave it as None.
-        if let Some(map) = &mut self.set_transactions {
-            map.extend(
-                delta
-                    .set_transaction_changes
-                    .into_iter()
-                    .map(|txn| (txn.app_id.clone(), txn)),
-            );
-        }
-
-        // In-commit timestamp: unconditional replace (not guarded by `if let Some`).
-        // If ICT was disabled after being enabled, the delta carries None, which correctly
-        // clears the previous value.
-        self.in_commit_timestamp_opt = delta.in_commit_timestamp;
-
-        // Bail if already Untrackable -- nothing can recover missing file stats or histograms.
-        if self.file_stats_validity == FileStatsValidity::Untrackable {
-            return;
-        }
-
-        // Missing file size poisons stats permanently. Checked after the Untrackable bail-out
-        // so that Untrackable can never transition to Indeterminate below.
-        if delta.has_missing_file_size {
-            self.file_stats_validity = FileStatsValidity::Untrackable;
-            self.file_size_histogram = None;
-            return;
-        }
-
-        // Bail if already Indeterminate (theoretically recoverable via full replay).
-        if self.file_stats_validity == FileStatsValidity::Indeterminate {
-            return;
-        }
-
-        let is_incremental_safe = delta
-            .operation
-            .as_deref()
-            .is_some_and(FileStatsDelta::is_incremental_safe);
-        if !is_incremental_safe {
-            self.file_stats_validity = FileStatsValidity::Indeterminate;
-            self.file_size_histogram = None;
-            return;
-        }
-        self.num_files += delta.file_stats.net_files;
-        self.table_size_bytes += delta.file_stats.net_bytes;
-
-        // Histogram: merge base and delta.
-        // Only update if the base CRC has a histogram AND the delta provides one.
-        // If the merge fails (e.g. negative counts from corrupted data) or the delta is
-        // missing a histogram, drop it rather than leaving stale data.
-        if let (Some(base_hist), Some(delta_hist)) = (
-            self.file_size_histogram.as_ref(),
-            &delta.file_stats.net_histogram,
-        ) {
-            match base_hist.try_apply_delta(delta_hist) {
-                Ok(merged) => self.file_size_histogram = Some(merged),
-                Err(e) => {
-                    warn!("Histogram merge failed, dropping file size histogram: {e}");
-                    self.file_size_histogram = None;
+                DomainMetadataState::Untracked => {
+                    self.domain_metadata = DomainMetadataState::Partial(
+                        update
+                            .domain_metadata
+                            .into_iter()
+                            .filter(|(_, dm)| !dm.is_removed())
+                            .collect(),
+                    );
                 }
             }
-        } else if self.file_size_histogram.is_some() {
-            // The base had a histogram but the delta couldn't provide one. Drop it rather than
-            // leaving a stale value.
-            self.file_size_histogram = None;
         }
+
+        // Set transactions: upsert from update map. No tombstone semantic for txns. Same
+        // Untracked → Partial transition.
+        if !update.set_transactions.is_empty() {
+            match &mut self.set_transactions {
+                SetTransactionState::Complete(map) | SetTransactionState::Partial(map) => {
+                    map.extend(update.set_transactions);
+                }
+                SetTransactionState::Untracked => {
+                    self.set_transactions = SetTransactionState::Partial(update.set_transactions);
+                }
+            }
+        }
+
+        // In-commit timestamp: replace unconditionally. ICT could be disabled (Some →
+        // None) or enabled (None → Some) or updated (Some → Some).
+        self.in_commit_timestamp_opt = update.in_commit_timestamp;
+
+        // File stats: state-machine transition. See the table on FileStatsState.
+        self.file_stats = match &self.file_stats {
+            FileStatsState::Untrackable => {
+                // Terminal: nothing recovers missing file size.
+                return;
+            }
+            _ if update.has_missing_file_size => FileStatsState::Untrackable,
+            FileStatsState::Indeterminate => {
+                // Terminal for incremental tracking (recoverable only via full replay,
+                // which is currently the deferred load_file_stats path).
+                return;
+            }
+            _ if !update.operation_safe => FileStatsState::Indeterminate,
+            FileStatsState::Valid {
+                num_files,
+                table_size_bytes,
+                histogram,
+            } => {
+                let histogram =
+                    merge_histogram(histogram.as_ref(), update.file_stats.net_histogram.as_ref());
+                FileStatsState::Valid {
+                    num_files: num_files + update.file_stats.net_files,
+                    table_size_bytes: table_size_bytes + update.file_stats.net_bytes,
+                    histogram,
+                }
+            }
+            FileStatsState::RequiresCheckpointRead {
+                commit_delta_files,
+                commit_delta_bytes,
+                commit_delta_histogram,
+            } => FileStatsState::RequiresCheckpointRead {
+                commit_delta_files: commit_delta_files + update.file_stats.net_files,
+                commit_delta_bytes: commit_delta_bytes + update.file_stats.net_bytes,
+                commit_delta_histogram: merge_histogram(
+                    commit_delta_histogram.as_ref(),
+                    update.file_stats.net_histogram.as_ref(),
+                ),
+            },
+        };
     }
 }
+
+// ============================================================================
+// Tests
+// ============================================================================
 
 #[cfg(test)]
 mod tests {
@@ -209,299 +296,30 @@ mod tests {
 
     use super::*;
     use crate::actions::{DomainMetadata, Metadata, Protocol};
-    use crate::crc::FileSizeHistogram;
+    use crate::crc::FileStatsValidity;
 
-    fn base_crc() -> Crc {
-        Crc {
-            table_size_bytes: 1000,
-            num_files: 10,
-            num_metadata: 1,
-            num_protocol: 1,
-            ..Default::default()
-        }
-    }
-
-    fn write_delta(net_files: i64, net_bytes: i64) -> CrcDelta {
-        CrcDelta {
+    fn write_update(net_files: i64, net_bytes: i64) -> CrcUpdate {
+        CrcUpdate {
             file_stats: FileStatsDelta {
                 net_files,
                 net_bytes,
-                ..Default::default()
+                net_histogram: None,
             },
-            operation: Some("WRITE".to_string()),
+            operation_safe: true,
             ..Default::default()
         }
     }
 
-    // ===== is_incremental_safe tests =====
-
-    #[test]
-    fn test_incremental_safe_operations() {
-        for op in [
-            "WRITE",
-            "MERGE",
-            "UPDATE",
-            "DELETE",
-            "OPTIMIZE",
-            "CREATE TABLE",
-            "REPLACE TABLE",
-            "CREATE TABLE AS SELECT",
-            "REPLACE TABLE AS SELECT",
-            "CREATE OR REPLACE TABLE AS SELECT",
-        ] {
-            assert!(
-                FileStatsDelta::is_incremental_safe(op),
-                "{op} should be incremental-safe"
-            );
+    fn base_crc() -> Crc {
+        Crc {
+            file_stats: FileStatsState::Valid {
+                num_files: 10,
+                table_size_bytes: 1000,
+                histogram: None,
+            },
+            ..Default::default()
         }
     }
-
-    #[test]
-    fn test_non_incremental_safe_operations() {
-        assert!(!FileStatsDelta::is_incremental_safe("ANALYZE STATS"));
-        assert!(!FileStatsDelta::is_incremental_safe("UNKNOWN"));
-    }
-
-    // ===== Crc deserialized from CRC file (default validity) =====
-
-    #[test]
-    fn test_deserialized_crc_has_valid_stats() {
-        let crc = base_crc();
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Valid);
-        assert_eq!(crc.num_files, 10);
-        assert_eq!(crc.table_size_bytes, 1000);
-    }
-
-    // ===== Crc::apply tests =====
-
-    #[test]
-    fn test_apply_updates_file_stats() {
-        let mut crc = base_crc();
-        crc.apply(write_delta(3, 600));
-        assert_eq!(crc.num_files, 13); // 10 + 3
-        assert_eq!(crc.table_size_bytes, 1600); // 1000 + 600
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Valid);
-    }
-
-    /// Applies multiple commit deltas sequentially.
-    #[test]
-    fn test_apply_multiple_deltas() {
-        let mut crc = base_crc();
-        crc.apply(write_delta(3, 600));
-        crc.apply(write_delta(-2, -400));
-        assert_eq!(crc.num_files, 11); // 10 + 3 - 2
-        assert_eq!(crc.table_size_bytes, 1200); // 1000 + 600 - 400
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Valid);
-    }
-
-    #[test]
-    fn test_apply_unsafe_op_transitions_to_indeterminate() {
-        let mut crc = base_crc();
-        let unsafe_change = CrcDelta {
-            operation: Some("ANALYZE STATS".to_string()),
-            ..write_delta(1, 100)
-        };
-        crc.apply(unsafe_change);
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Indeterminate);
-    }
-
-    #[test]
-    fn test_apply_none_op_transitions_to_indeterminate() {
-        let mut crc = base_crc();
-        let unknown_delta = CrcDelta {
-            operation: None,
-            ..write_delta(1, 100)
-        };
-        crc.apply(unknown_delta);
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Indeterminate);
-    }
-
-    #[test]
-    fn test_indeterminate_stays_indeterminate() {
-        let mut crc = base_crc();
-        let unsafe_change = CrcDelta {
-            operation: Some("ANALYZE STATS".to_string()),
-            ..write_delta(1, 100)
-        };
-        crc.apply(unsafe_change);
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Indeterminate);
-
-        // Subsequent safe op doesn't recover validity.
-        crc.apply(write_delta(5, 500));
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Indeterminate);
-    }
-
-    // ===== apply: Untrackable (missing file size) tests =====
-
-    #[test]
-    fn test_missing_file_size_transitions_to_untrackable() {
-        let mut crc = base_crc();
-        let delta = CrcDelta {
-            has_missing_file_size: true,
-            ..write_delta(1, 100)
-        };
-        crc.apply(delta);
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Untrackable);
-    }
-
-    #[test]
-    fn test_untrackable_stays_untrackable() {
-        let mut crc = base_crc();
-        let delta = CrcDelta {
-            has_missing_file_size: true,
-            ..write_delta(1, 100)
-        };
-        crc.apply(delta);
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Untrackable);
-
-        // Applying a safe delta does not recover from Untrackable.
-        crc.apply(write_delta(5, 500));
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Untrackable);
-
-        // Applying an unsafe delta also stays Untrackable (does not downgrade to Indeterminate).
-        crc.apply(CrcDelta {
-            operation: None,
-            ..write_delta(1, 100)
-        });
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Untrackable);
-    }
-
-    #[test]
-    fn test_indeterminate_transitions_to_untrackable_on_missing_size() {
-        let mut crc = base_crc();
-        let unsafe_change = CrcDelta {
-            operation: Some("ANALYZE STATS".to_string()),
-            ..write_delta(1, 100)
-        };
-        crc.apply(unsafe_change);
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Indeterminate);
-
-        // Missing size escalates Indeterminate to Untrackable.
-        let delta = CrcDelta {
-            has_missing_file_size: true,
-            ..write_delta(1, 100)
-        };
-        crc.apply(delta);
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Untrackable);
-    }
-
-    // ===== apply: non-file-stats field updates =====
-
-    #[test]
-    fn test_apply_replaces_protocol() {
-        let mut crc = base_crc();
-        let new_protocol = Protocol::try_new(
-            2,
-            5,
-            None::<Vec<crate::table_features::TableFeature>>,
-            None::<Vec<crate::table_features::TableFeature>>,
-        )
-        .unwrap();
-        let delta = CrcDelta {
-            protocol: Some(new_protocol.clone()),
-            ..write_delta(0, 0)
-        };
-        crc.apply(delta);
-        assert_eq!(crc.protocol, new_protocol);
-        assert_eq!(crc.metadata, Metadata::default()); // unchanged
-    }
-
-    #[test]
-    fn test_apply_adds_domain_metadata_to_tracked_map() {
-        let mut crc = base_crc();
-        crc.domain_metadata = Some(HashMap::new());
-        let dm = DomainMetadata::new("my.domain".to_string(), "config1".to_string());
-        let delta = CrcDelta {
-            domain_metadata_changes: vec![dm],
-            ..write_delta(0, 0)
-        };
-        crc.apply(delta);
-
-        let map = crc.domain_metadata.as_ref().unwrap();
-        assert_eq!(map.len(), 1);
-        assert_eq!(map["my.domain"].configuration(), "config1");
-    }
-
-    #[test]
-    fn test_apply_with_untracked_domain_metadata_skips_changes() {
-        let mut crc = base_crc();
-        assert!(crc.domain_metadata.is_none()); // Not tracked (default)
-        let dm = DomainMetadata::new("my.domain".to_string(), "config1".to_string());
-        let delta = CrcDelta {
-            domain_metadata_changes: vec![dm],
-            ..write_delta(0, 0)
-        };
-        crc.apply(delta);
-
-        // domain_metadata stays None -- apply() must not create a partial map.
-        assert!(crc.domain_metadata.is_none());
-    }
-
-    #[test]
-    fn test_apply_upserts_domain_metadata() {
-        let mut crc = base_crc();
-        crc.domain_metadata = Some(HashMap::from([(
-            "my.domain".to_string(),
-            DomainMetadata::new("my.domain".to_string(), "old_config".to_string()),
-        )]));
-
-        let dm = DomainMetadata::new("my.domain".to_string(), "new_config".to_string());
-        let delta = CrcDelta {
-            domain_metadata_changes: vec![dm],
-            ..write_delta(0, 0)
-        };
-        crc.apply(delta);
-
-        let map = crc.domain_metadata.as_ref().unwrap();
-        assert_eq!(map.len(), 1);
-        assert_eq!(map["my.domain"].configuration(), "new_config");
-    }
-
-    #[test]
-    fn test_apply_removes_domain_metadata() {
-        let mut crc = base_crc();
-        crc.domain_metadata = Some(HashMap::from([(
-            "my.domain".to_string(),
-            DomainMetadata::new("my.domain".to_string(), "config1".to_string()),
-        )]));
-
-        let dm = DomainMetadata::remove("my.domain".to_string(), "config1".to_string());
-        let delta = CrcDelta {
-            domain_metadata_changes: vec![dm],
-            ..write_delta(0, 0)
-        };
-        crc.apply(delta);
-
-        let map = crc.domain_metadata.as_ref().unwrap();
-        assert!(map.is_empty());
-    }
-
-    #[test]
-    fn test_apply_replaces_in_commit_timestamp() {
-        let mut crc = base_crc();
-        let delta = CrcDelta {
-            in_commit_timestamp: Some(9999),
-            ..write_delta(0, 0)
-        };
-        crc.apply(delta);
-        assert_eq!(crc.in_commit_timestamp_opt, Some(9999));
-    }
-
-    #[test]
-    fn test_apply_clears_in_commit_timestamp_when_ict_disabled() {
-        let mut crc = base_crc();
-        crc.in_commit_timestamp_opt = Some(1000);
-
-        // Delta without ICT (e.g. ICT was disabled) clears the previous value.
-        let delta = CrcDelta {
-            in_commit_timestamp: None,
-            ..write_delta(0, 0)
-        };
-        crc.apply(delta);
-        assert_eq!(crc.in_commit_timestamp_opt, None);
-    }
-
-    // ===== CrcDelta::into_crc_for_version_zero tests =====
 
     fn test_protocol() -> Protocol {
         Protocol::try_new(
@@ -513,367 +331,438 @@ mod tests {
         .unwrap()
     }
 
-    #[test]
-    fn test_into_crc_for_version_zero_with_protocol_and_metadata() {
-        let protocol = test_protocol();
-        let metadata = Metadata::default();
-        let delta = CrcDelta {
-            protocol: Some(protocol.clone()),
-            metadata: Some(metadata.clone()),
-            ..write_delta(5, 1000)
-        };
-        let crc = delta.into_crc_for_version_zero().unwrap();
-        assert_eq!(crc.protocol, protocol);
-        assert_eq!(crc.metadata, metadata);
-        assert_eq!(crc.num_files, 5);
-        assert_eq!(crc.table_size_bytes, 1000);
-        assert_eq!(crc.num_metadata, 1);
-        assert_eq!(crc.num_protocol, 1);
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Valid);
-        assert_eq!(crc.domain_metadata, Some(HashMap::new()));
-        assert_eq!(crc.in_commit_timestamp_opt, None);
-    }
+    // ===== Crc::apply: file stats state machine =====
 
     #[test]
-    fn test_into_crc_for_version_zero_returns_none_without_protocol() {
-        let delta = CrcDelta {
-            metadata: Some(Metadata::default()),
-            ..write_delta(5, 1000)
-        };
-        assert!(delta.into_crc_for_version_zero().is_none());
-    }
-
-    #[test]
-    fn test_into_crc_for_version_zero_returns_none_without_metadata() {
-        let delta = CrcDelta {
-            protocol: Some(test_protocol()),
-            ..write_delta(5, 1000)
-        };
-        assert!(delta.into_crc_for_version_zero().is_none());
-    }
-
-    #[test]
-    fn test_into_crc_for_version_zero_with_domain_metadata() {
-        let dm = DomainMetadata::new("my.domain".to_string(), "config1".to_string());
-        let delta = CrcDelta {
-            protocol: Some(test_protocol()),
-            metadata: Some(Metadata::default()),
-            domain_metadata_changes: vec![dm],
-            ..write_delta(0, 0)
-        };
-        let crc = delta.into_crc_for_version_zero().unwrap();
-        let map = crc.domain_metadata.as_ref().unwrap();
-        assert_eq!(map.len(), 1);
-        assert_eq!(map["my.domain"].configuration(), "config1");
-    }
-
-    #[test]
-    fn test_into_crc_for_version_zero_with_in_commit_timestamp() {
-        let delta = CrcDelta {
-            protocol: Some(test_protocol()),
-            metadata: Some(Metadata::default()),
-            in_commit_timestamp: Some(12345),
-            ..write_delta(0, 0)
-        };
-        let crc = delta.into_crc_for_version_zero().unwrap();
-        assert_eq!(crc.in_commit_timestamp_opt, Some(12345));
-    }
-
-    // ===== apply: set transaction tests =====
-
-    #[test]
-    fn test_apply_adds_set_transaction_to_tracked_map() {
+    fn apply_safe_op_keeps_valid_and_sums() {
         let mut crc = base_crc();
-        crc.set_transactions = Some(HashMap::new());
-        let txn = SetTransaction::new("my-app".to_string(), 1, Some(1000));
-        let delta = CrcDelta {
-            set_transaction_changes: vec![txn],
-            ..write_delta(0, 0)
-        };
-        crc.apply(delta);
-
-        let map = crc.set_transactions.as_ref().unwrap();
-        assert_eq!(map.len(), 1);
-        assert_eq!(map["my-app"].version, 1);
-        assert_eq!(map["my-app"].last_updated, Some(1000));
+        crc.apply(write_update(3, 600));
+        let stats = crc.file_stats().unwrap();
+        assert_eq!(stats.num_files(), 13);
+        assert_eq!(stats.table_size_bytes(), 1600);
+        assert_eq!(crc.file_stats_validity(), FileStatsValidity::Valid);
     }
 
     #[test]
-    fn test_apply_with_untracked_set_transactions_skips_changes() {
+    fn apply_multiple_safe_updates_sums_correctly() {
+        // Demonstrates Crc[N] + δ + δ + δ = Crc[N+3] composition.
         let mut crc = base_crc();
-        assert!(crc.set_transactions.is_none()); // Not tracked (default)
-        let txn = SetTransaction::new("my-app".to_string(), 1, Some(1000));
-        let delta = CrcDelta {
-            set_transaction_changes: vec![txn],
-            ..write_delta(0, 0)
-        };
-        crc.apply(delta);
-
-        // set_transactions stays None -- apply() must not create a partial map.
-        assert!(crc.set_transactions.is_none());
+        crc.apply(write_update(3, 600));
+        crc.apply(write_update(-2, -400));
+        crc.apply(write_update(1, 100));
+        let stats = crc.file_stats().unwrap();
+        assert_eq!(stats.num_files(), 12); // 10 + 3 - 2 + 1
+        assert_eq!(stats.table_size_bytes(), 1300); // 1000 + 600 - 400 + 100
+        assert_eq!(crc.file_stats_validity(), FileStatsValidity::Valid);
     }
 
     #[test]
-    fn test_apply_upserts_set_transaction() {
+    fn apply_unsafe_op_transitions_valid_to_indeterminate() {
         let mut crc = base_crc();
-        crc.set_transactions = Some(HashMap::from([(
-            "my-app".to_string(),
-            SetTransaction::new("my-app".to_string(), 1, Some(1000)),
-        )]));
-
-        let txn = SetTransaction::new("my-app".to_string(), 2, Some(2000));
-        let delta = CrcDelta {
-            set_transaction_changes: vec![txn],
-            ..write_delta(0, 0)
-        };
-        crc.apply(delta);
-
-        let map = crc.set_transactions.as_ref().unwrap();
-        assert_eq!(map.len(), 1);
-        assert_eq!(map["my-app"].version, 2);
-        assert_eq!(map["my-app"].last_updated, Some(2000));
-    }
-
-    // ===== into_crc_for_version_zero: set transaction tests =====
-
-    #[test]
-    fn test_into_crc_for_version_zero_with_set_transactions() {
-        let txn = SetTransaction::new("my-app".to_string(), 5, Some(3000));
-        let delta = CrcDelta {
-            protocol: Some(test_protocol()),
-            metadata: Some(Metadata::default()),
-            set_transaction_changes: vec![txn],
-            ..write_delta(0, 0)
-        };
-        let crc = delta.into_crc_for_version_zero().unwrap();
-        let map = crc.set_transactions.as_ref().unwrap();
-        assert_eq!(map.len(), 1);
-        assert_eq!(map["my-app"].version, 5);
-        assert_eq!(map["my-app"].last_updated, Some(3000));
+        crc.apply(CrcUpdate {
+            operation_safe: false,
+            ..write_update(1, 100)
+        });
+        assert_eq!(crc.file_stats_validity(), FileStatsValidity::Indeterminate);
     }
 
     #[test]
-    fn test_into_crc_for_version_zero_with_no_set_transactions() {
-        let delta = CrcDelta {
-            protocol: Some(test_protocol()),
-            metadata: Some(Metadata::default()),
-            ..write_delta(0, 0)
-        };
-        let crc = delta.into_crc_for_version_zero().unwrap();
-        // Empty map, not None -- we always know the full state at version zero.
-        assert_eq!(crc.set_transactions, Some(HashMap::new()));
-    }
-
-    // ===== Histogram tests =====
-
-    /// Helper: creates a default-boundary histogram populated with the given file sizes.
-    fn histogram_from_sizes(sizes: &[i64]) -> FileSizeHistogram {
-        let mut hist = FileSizeHistogram::create_default();
-        for &size in sizes {
-            hist.insert(size).unwrap();
-        }
-        hist
-    }
-
-    /// Helper: creates a CRC with a histogram containing the given file sizes.
-    fn base_crc_with_histogram(file_sizes: &[i64]) -> Crc {
-        let hist = histogram_from_sizes(file_sizes);
-        Crc {
-            table_size_bytes: file_sizes.iter().sum(),
-            num_files: file_sizes.len() as i64,
-            num_metadata: 1,
-            num_protocol: 1,
-            file_size_histogram: Some(hist),
-            ..Default::default()
-        }
-    }
-
-    /// Helper: creates a CrcDelta with a delta histogram built from adds and removes.
-    fn write_delta_with_histograms(add_sizes: &[i64], remove_sizes: &[i64]) -> CrcDelta {
-        let mut hist = FileSizeHistogram::create_default();
-        for &s in add_sizes {
-            hist.insert(s).unwrap();
-        }
-        for &s in remove_sizes {
-            hist.remove(s).unwrap();
-        }
-        let net_files = add_sizes.len() as i64 - remove_sizes.len() as i64;
-        let net_bytes: i64 = add_sizes.iter().sum::<i64>() - remove_sizes.iter().sum::<i64>();
-        CrcDelta {
-            file_stats: FileStatsDelta {
-                net_files,
-                net_bytes,
-                net_histogram: Some(hist),
-            },
-            operation: Some("WRITE".to_string()),
-            ..Default::default()
-        }
-    }
-
-    /// Histogram bins used in tests (default boundaries):
-    ///   Bin 0: [0, 8KB)     -- e.g. 100, 200, 300, 500
-    ///   Bin 1: [8KB, 16KB)  -- e.g. 10_000
-    ///   Bin 2: [16KB, 32KB) -- e.g. 20_000
-    ///   Bin 10: [4MB, 8MB)  -- e.g. 5_000_000
-    #[rstest]
-    #[case::single_bin(&[100, 200, 300], &[500], &[200], &[(0, 3, 900)])]
-    #[case::adds_only(&[100], &[200, 300], &[], &[(0, 3, 600)])]
-    #[case::removes_only(&[100, 200, 300], &[], &[100, 200], &[(0, 1, 300)])]
-    #[case::empty_delta(&[100, 10_000], &[], &[], &[(0, 1, 100), (1, 1, 10_000)])]
-    #[case::multi_bin(
-        &[100, 10_000, 20_000],
-        &[200, 10_500],
-        &[100, 20_000],
-        &[(0, 1, 200), (1, 2, 20_500), (2, 0, 0)]
-    )]
-    #[case::large_files(
-        &[100, 5_000_000],
-        &[10_000, 5_500_000],
-        &[100],
-        &[(0, 0, 0), (1, 1, 10_000), (10, 2, 10_500_000)]
-    )]
-    fn apply_merges_histogram(
-        #[case] base: &[i64],
-        #[case] add: &[i64],
-        #[case] remove: &[i64],
-        #[case] expected_bins: &[(usize, i64, i64)],
-    ) {
-        let mut crc = base_crc_with_histogram(base);
-        let delta = write_delta_with_histograms(add, remove);
-        crc.apply(delta);
-
-        let hist = crc.file_size_histogram.as_ref().unwrap();
-        for &(bin, count, bytes) in expected_bins {
-            assert_eq!(hist.file_counts[bin], count, "file_counts[{bin}]");
-            assert_eq!(hist.total_bytes[bin], bytes, "total_bytes[{bin}]");
-        }
-    }
-
-    #[rstest]
-    #[case::base_none_delta_none(None)]
-    #[case::base_some_delta_none(Some(vec![100i64, 200]))]
-    fn apply_drops_histogram_when_delta_missing_histogram(#[case] base_files: Option<Vec<i64>>) {
-        let mut crc = match &base_files {
-            Some(sizes) => base_crc_with_histogram(sizes),
-            None => base_crc(),
-        };
-        let delta = CrcDelta {
-            file_stats: FileStatsDelta {
-                net_files: 1,
-                net_bytes: 100,
-                net_histogram: None,
-            },
-            operation: Some("WRITE".to_string()),
-            ..Default::default()
-        };
-        crc.apply(delta);
-        assert!(
-            crc.file_size_histogram.is_none(),
-            "histogram should be None when delta doesn't provide a histogram"
-        );
+    fn apply_indeterminate_stays_indeterminate_on_safe_update() {
+        let mut crc = base_crc();
+        crc.apply(CrcUpdate {
+            operation_safe: false,
+            ..write_update(1, 100)
+        });
+        crc.apply(write_update(5, 500));
+        assert_eq!(crc.file_stats_validity(), FileStatsValidity::Indeterminate);
     }
 
     #[test]
-    fn apply_drops_histogram_on_indeterminate() {
-        let mut crc = base_crc_with_histogram(&[100, 200]);
-        let unsafe_delta = CrcDelta {
-            operation: Some("ANALYZE STATS".to_string()),
-            ..write_delta(1, 100)
-        };
-        crc.apply(unsafe_delta);
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Indeterminate);
-        assert!(crc.file_size_histogram.is_none());
-    }
-
-    #[test]
-    fn apply_drops_histogram_on_untrackable() {
-        let mut crc = base_crc_with_histogram(&[100, 200]);
-        // A missing file size makes byte-level stats impossible, so the histogram is dropped.
-        let delta = CrcDelta {
+    fn apply_missing_file_size_transitions_valid_to_untrackable() {
+        let mut crc = base_crc();
+        crc.apply(CrcUpdate {
             has_missing_file_size: true,
-            ..write_delta(1, 100)
-        };
-        crc.apply(delta);
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Untrackable);
-        assert!(crc.file_size_histogram.is_none());
+            ..write_update(1, 100)
+        });
+        assert_eq!(crc.file_stats_validity(), FileStatsValidity::Untrackable);
     }
 
     #[test]
-    fn into_crc_for_version_zero_includes_histogram() {
-        let delta_hist = histogram_from_sizes(&[500, 1000]);
-        let delta = CrcDelta {
-            protocol: Some(test_protocol()),
-            metadata: Some(Metadata::default()),
-            file_stats: FileStatsDelta {
-                net_files: 2,
-                net_bytes: 1500,
-                net_histogram: Some(delta_hist),
-            },
-            operation: Some("WRITE".to_string()),
-            ..Default::default()
-        };
-        let crc = delta.into_crc_for_version_zero().unwrap();
-        let hist = crc.file_size_histogram.as_ref().unwrap();
-        assert_eq!(hist.file_counts[0], 2);
-        assert_eq!(hist.total_bytes[0], 1500);
+    fn apply_untrackable_stays_untrackable() {
+        let mut crc = base_crc();
+        crc.apply(CrcUpdate {
+            has_missing_file_size: true,
+            ..write_update(1, 100)
+        });
+        crc.apply(write_update(5, 500));
+        crc.apply(CrcUpdate {
+            operation_safe: false,
+            ..write_update(1, 100)
+        });
+        assert_eq!(crc.file_stats_validity(), FileStatsValidity::Untrackable);
     }
 
     #[test]
-    fn into_crc_for_version_zero_without_histogram() {
-        // write_delta() produces a CrcDelta with no histogram delta, so
-        // into_crc_for_version_zero cannot construct a file size histogram.
-        let delta = CrcDelta {
-            protocol: Some(test_protocol()),
-            metadata: Some(Metadata::default()),
-            ..write_delta(0, 0)
-        };
-        let crc = delta.into_crc_for_version_zero().unwrap();
-        assert!(crc.file_size_histogram.is_none());
+    fn apply_indeterminate_transitions_to_untrackable_on_missing_size() {
+        let mut crc = base_crc();
+        crc.apply(CrcUpdate {
+            operation_safe: false,
+            ..write_update(1, 100)
+        });
+        crc.apply(CrcUpdate {
+            has_missing_file_size: true,
+            ..write_update(1, 100)
+        });
+        assert_eq!(crc.file_stats_validity(), FileStatsValidity::Untrackable);
     }
 
+    // ===== Crc::apply: P&M, DM, txn, ICT =====
+
     #[test]
-    fn apply_merges_histogram_with_non_default_boundaries() {
-        // Base CRC with custom 3-bin histogram: [0, 200) [200, 1000) [1000, inf)
-        let boundaries = vec![0, 200, 1000];
-        let base_hist = FileSizeHistogram::try_new(
-            boundaries.clone(),
-            vec![2, 1, 0], // 2 files in bin 0, 1 in bin 1
-            vec![300, 500, 0],
+    fn apply_replaces_protocol_and_metadata_when_present() {
+        let mut crc = base_crc();
+        let new_protocol = Protocol::try_new(
+            2,
+            5,
+            None::<Vec<crate::table_features::TableFeature>>,
+            None::<Vec<crate::table_features::TableFeature>>,
         )
         .unwrap();
-        let mut crc = Crc {
-            table_size_bytes: 800,
-            num_files: 3,
-            num_metadata: 1,
-            num_protocol: 1,
-            file_size_histogram: Some(base_hist),
+        crc.apply(CrcUpdate {
+            protocol: Some(new_protocol.clone()),
+            ..write_update(0, 0)
+        });
+        assert_eq!(crc.protocol, new_protocol);
+        assert_eq!(crc.metadata, Metadata::default()); // unchanged
+    }
+
+    #[test]
+    fn apply_dm_to_complete_upserts_and_removes_tombstones() {
+        let mut crc = base_crc();
+        let mut dms = HashMap::new();
+        dms.insert(
+            "old".to_string(),
+            DomainMetadata::new("old".to_string(), "v1".to_string()),
+        );
+        crc.domain_metadata = DomainMetadataState::Complete(dms);
+
+        let mut update_map = HashMap::new();
+        update_map.insert(
+            "old".to_string(),
+            DomainMetadata::new("old".to_string(), "v2".to_string()),
+        ); // upsert
+        update_map.insert(
+            "new".to_string(),
+            DomainMetadata::new("new".to_string(), "config".to_string()),
+        ); // add
+        crc.apply(CrcUpdate {
+            domain_metadata: update_map,
+            ..write_update(0, 0)
+        });
+
+        let map = crc.domain_metadata.map().unwrap();
+        assert_eq!(map["old"].configuration(), "v2");
+        assert_eq!(map["new"].configuration(), "config");
+        assert!(crc.domain_metadata.is_complete());
+    }
+
+    #[test]
+    fn apply_dm_tombstone_removes_from_complete_map() {
+        let mut crc = base_crc();
+        let mut dms = HashMap::new();
+        dms.insert(
+            "d".to_string(),
+            DomainMetadata::new("d".to_string(), "v".to_string()),
+        );
+        crc.domain_metadata = DomainMetadataState::Complete(dms);
+
+        let mut update_map = HashMap::new();
+        update_map.insert(
+            "d".to_string(),
+            DomainMetadata::remove("d".to_string(), "v".to_string()),
+        );
+        crc.apply(CrcUpdate {
+            domain_metadata: update_map,
+            ..write_update(0, 0)
+        });
+
+        let map = crc.domain_metadata.map().unwrap();
+        assert!(map.is_empty());
+        assert!(crc.domain_metadata.is_complete()); // stays Complete
+    }
+
+    #[test]
+    fn apply_dm_to_untracked_transitions_to_partial() {
+        // Crucial: a CRC missing DM (Untracked) gets DM entries from newer commits via
+        // apply. The result is Partial — entries are correct but the cache is incomplete.
+        let mut crc = base_crc();
+        assert!(matches!(
+            crc.domain_metadata,
+            DomainMetadataState::Untracked
+        ));
+        let mut update_map = HashMap::new();
+        update_map.insert(
+            "d".to_string(),
+            DomainMetadata::new("d".to_string(), "v".to_string()),
+        );
+        crc.apply(CrcUpdate {
+            domain_metadata: update_map,
+            ..write_update(0, 0)
+        });
+        assert!(matches!(
+            crc.domain_metadata,
+            DomainMetadataState::Partial(_)
+        ));
+        let map = crc.domain_metadata.map().unwrap();
+        assert_eq!(map["d"].configuration(), "v");
+    }
+
+    #[test]
+    fn apply_txn_to_untracked_transitions_to_partial() {
+        let mut crc = base_crc();
+        let mut update_map = HashMap::new();
+        update_map.insert(
+            "app".to_string(),
+            SetTransaction::new("app".to_string(), 5, None),
+        );
+        crc.apply(CrcUpdate {
+            set_transactions: update_map,
+            ..write_update(0, 0)
+        });
+        assert!(matches!(
+            crc.set_transactions,
+            SetTransactionState::Partial(_)
+        ));
+        let map = crc.set_transactions.map().unwrap();
+        assert_eq!(map["app"].version, 5);
+    }
+
+    #[test]
+    fn apply_ict_replaces_unconditionally() {
+        let mut crc = base_crc();
+        crc.in_commit_timestamp_opt = Some(1000);
+
+        // None clears
+        crc.apply(CrcUpdate {
+            in_commit_timestamp: None,
+            ..write_update(0, 0)
+        });
+        assert_eq!(crc.in_commit_timestamp_opt, None);
+
+        // Some sets
+        crc.apply(CrcUpdate {
+            in_commit_timestamp: Some(2000),
+            ..write_update(0, 0)
+        });
+        assert_eq!(crc.in_commit_timestamp_opt, Some(2000));
+    }
+
+    // ===== into_fresh_crc =====
+
+    #[test]
+    fn into_fresh_crc_with_protocol_and_metadata_succeeds() {
+        let update = CrcUpdate {
+            protocol: Some(test_protocol()),
+            metadata: Some(Metadata::default()),
+            ..write_update(5, 1000)
+        };
+        let crc = update.into_fresh_crc().unwrap();
+        assert_eq!(crc.file_stats().unwrap().num_files(), 5);
+        assert_eq!(crc.file_stats().unwrap().table_size_bytes(), 1000);
+        assert_eq!(crc.file_stats_validity(), FileStatsValidity::Valid);
+        assert!(crc.domain_metadata.is_complete());
+        assert!(crc.set_transactions.is_complete());
+    }
+
+    #[rstest]
+    #[case::missing_protocol(None, Some(Metadata::default()))]
+    #[case::missing_metadata(Some(test_protocol()), None)]
+    #[case::missing_both(None, None)]
+    fn into_fresh_crc_requires_both_protocol_and_metadata(
+        #[case] protocol: Option<Protocol>,
+        #[case] metadata: Option<Metadata>,
+    ) {
+        let update = CrcUpdate {
+            protocol,
+            metadata,
+            ..write_update(0, 0)
+        };
+        assert!(update.into_fresh_crc().is_err());
+    }
+
+    #[test]
+    fn into_fresh_crc_unsafe_op_produces_indeterminate() {
+        let update = CrcUpdate {
+            protocol: Some(test_protocol()),
+            metadata: Some(Metadata::default()),
+            operation_safe: false,
             ..Default::default()
         };
+        let crc = update.into_fresh_crc().unwrap();
+        assert_eq!(crc.file_stats_validity(), FileStatsValidity::Indeterminate);
+    }
 
-        // Delta with matching non-default boundaries: +100 and +1500, -150
-        let mut delta_hist = FileSizeHistogram::create_empty_with_boundaries(boundaries).unwrap();
-        delta_hist.insert(100).unwrap(); // bin 0
-        delta_hist.insert(1500).unwrap(); // bin 2
-        delta_hist.remove(150).unwrap(); // bin 0
+    #[test]
+    fn into_fresh_crc_missing_size_produces_untrackable() {
+        let update = CrcUpdate {
+            protocol: Some(test_protocol()),
+            metadata: Some(Metadata::default()),
+            has_missing_file_size: true,
+            operation_safe: true,
+            ..Default::default()
+        };
+        let crc = update.into_fresh_crc().unwrap();
+        assert_eq!(crc.file_stats_validity(), FileStatsValidity::Untrackable);
+    }
 
-        let delta = CrcDelta {
+    #[test]
+    fn into_fresh_crc_filters_dm_tombstones() {
+        let mut dms = HashMap::new();
+        dms.insert(
+            "alive".to_string(),
+            DomainMetadata::new("alive".to_string(), "v".to_string()),
+        );
+        dms.insert(
+            "dead".to_string(),
+            DomainMetadata::remove("dead".to_string(), "v".to_string()),
+        );
+        let update = CrcUpdate {
+            protocol: Some(test_protocol()),
+            metadata: Some(Metadata::default()),
+            domain_metadata: dms,
+            operation_safe: true,
+            ..Default::default()
+        };
+        let crc = update.into_fresh_crc().unwrap();
+        let map = crc.domain_metadata.map().unwrap();
+        assert!(map.contains_key("alive"));
+        assert!(!map.contains_key("dead"));
+    }
+
+    // ===== histogram merge =====
+
+    #[test]
+    fn apply_merges_histogram_when_both_present() {
+        let mut hist = FileSizeHistogram::create_default();
+        hist.insert(100).unwrap();
+        hist.insert(200).unwrap();
+        let mut crc = base_crc();
+        crc.file_stats = FileStatsState::Valid {
+            num_files: 2,
+            table_size_bytes: 300,
+            histogram: Some(hist),
+        };
+
+        let mut delta_hist = FileSizeHistogram::create_default();
+        delta_hist.insert(500).unwrap();
+        crc.apply(CrcUpdate {
             file_stats: FileStatsDelta {
-                net_files: 1,    // +2 - 1
-                net_bytes: 1450, // (100 + 1500) - 150
+                net_files: 1,
+                net_bytes: 500,
                 net_histogram: Some(delta_hist),
             },
-            operation: Some("WRITE".to_string()),
+            operation_safe: true,
             ..Default::default()
+        });
+
+        let stats = crc.file_stats().unwrap();
+        let merged = stats.file_size_histogram().unwrap();
+        assert_eq!(merged.file_counts()[0], 3); // bin 0: 100, 200, 500
+        assert_eq!(merged.total_bytes()[0], 800);
+    }
+
+    #[test]
+    fn apply_drops_histogram_when_base_some_delta_none() {
+        let mut hist = FileSizeHistogram::create_default();
+        hist.insert(100).unwrap();
+        let mut crc = base_crc();
+        crc.file_stats = FileStatsState::Valid {
+            num_files: 1,
+            table_size_bytes: 100,
+            histogram: Some(hist),
         };
 
-        crc.apply(delta);
+        crc.apply(write_update(0, 0)); // delta has no histogram
 
-        // Histogram should be preserved (boundaries match)
-        let hist = crc.file_size_histogram.as_ref().unwrap();
-        assert_eq!(hist.sorted_bin_boundaries, vec![0, 200, 1000]);
-        assert_eq!(hist.file_counts, vec![2, 1, 1]); // (2+1-1), (1+0-0), (0+1-0)
-        assert_eq!(hist.total_bytes, vec![250, 500, 1500]); // (300+100-150), (500+0-0), (0+1500-0)
-        assert_eq!(crc.num_files, 4);
-        assert_eq!(crc.table_size_bytes, 2250);
+        let stats = crc.file_stats().unwrap();
+        assert!(stats.file_size_histogram().is_none());
+    }
+
+    #[test]
+    fn apply_adopts_histogram_when_base_none_delta_some() {
+        // Forward-replay-friendly: a base CRC without a histogram + an update with a
+        // histogram → CRC adopts the update's histogram. Useful when forward-replaying
+        // onto a base that lacked histogram support.
+        let mut crc = base_crc();
+        crc.file_stats = FileStatsState::Valid {
+            num_files: 0,
+            table_size_bytes: 0,
+            histogram: None,
+        };
+
+        let mut delta_hist = FileSizeHistogram::create_default();
+        delta_hist.insert(500).unwrap();
+        crc.apply(CrcUpdate {
+            file_stats: FileStatsDelta {
+                net_files: 1,
+                net_bytes: 500,
+                net_histogram: Some(delta_hist),
+            },
+            operation_safe: true,
+            ..Default::default()
+        });
+
+        let stats = crc.file_stats().unwrap();
+        let adopted = stats.file_size_histogram().unwrap();
+        assert_eq!(adopted.file_counts()[0], 1);
+        assert_eq!(adopted.total_bytes()[0], 500);
+    }
+
+    #[test]
+    fn apply_drops_histogram_on_indeterminate_transition() {
+        let mut hist = FileSizeHistogram::create_default();
+        hist.insert(100).unwrap();
+        let mut crc = base_crc();
+        crc.file_stats = FileStatsState::Valid {
+            num_files: 1,
+            table_size_bytes: 100,
+            histogram: Some(hist),
+        };
+
+        crc.apply(CrcUpdate {
+            operation_safe: false,
+            ..write_update(0, 0)
+        });
+
+        // Indeterminate has no histogram field — the data is gone.
+        assert!(matches!(crc.file_stats, FileStatsState::Indeterminate));
+        assert!(crc.file_stats().is_none());
+    }
+
+    #[test]
+    fn apply_to_requires_checkpoint_read_accumulates_deltas() {
+        let mut crc = Crc::minimal_from_pm(Protocol::default(), Metadata::default());
+        assert_eq!(
+            crc.file_stats_validity(),
+            FileStatsValidity::RequiresCheckpointRead
+        );
+        crc.apply(write_update(3, 600));
+        crc.apply(write_update(-1, -200));
+
+        // Stays RequiresCheckpointRead, with accumulated deltas.
+        assert_eq!(
+            crc.file_stats_validity(),
+            FileStatsValidity::RequiresCheckpointRead
+        );
+        let FileStatsState::RequiresCheckpointRead {
+            commit_delta_files,
+            commit_delta_bytes,
+            ..
+        } = &crc.file_stats
+        else {
+            panic!("expected RequiresCheckpointRead, got {:?}", crc.file_stats);
+        };
+        assert_eq!(*commit_delta_files, 2); // 3 - 1
+        assert_eq!(*commit_delta_bytes, 400); // 600 - 200
     }
 }

--- a/kernel/src/crc/delta.rs
+++ b/kernel/src/crc/delta.rs
@@ -151,15 +151,18 @@ impl CrcUpdate {
 }
 
 /// Merge a base histogram with the update's net histogram. Returns `Some(merged)` on
-/// success, `None` to drop the histogram (when the merge would fail or produce stale data).
+/// success, `None` to drop the histogram (when the merge would fail or when partial data
+/// would be misleading).
 ///
 /// Behavior:
 /// - `(Some(base), Some(net))` → merge via [`FileSizeHistogram::try_apply_delta`]; on failure
-///   (boundary mismatch, negative counts), drop and warn.
+///   (boundary mismatch, negative counts after merge), drop and warn.
 /// - `(Some(base), None)` → drop. The base had a histogram but the update could not provide one;
-///   stale data is worse than no data.
-/// - `(None, Some(net))` → adopt the update's histogram. Useful for forward replay starting from a
-///   base with no histogram, or for stale-catchup against a CRC that lacked a histogram.
+///   carrying the base forward without the update's contribution would be stale.
+/// - `(None, Some(_))` → drop. The base lacked a histogram, so the update's net histogram alone (a
+///   delta over an unknown baseline) cannot be turned into an absolute. The right place to seed an
+///   initial histogram is [`CrcUpdate::into_fresh_crc`], which receives an absolute (full-replay)
+///   histogram rather than a delta.
 /// - `(None, None)` → stay `None`.
 fn merge_histogram(
     base: Option<&FileSizeHistogram>,
@@ -173,8 +176,7 @@ fn merge_histogram(
                 None
             }
         },
-        (None, Some(delta_hist)) => Some(delta_hist.clone()),
-        (Some(_), None) | (None, None) => None,
+        _ => None,
     }
 }
 
@@ -191,21 +193,32 @@ impl Crc {
     ///
     /// Field semantics: see the [module-level docs](self).
     pub(crate) fn apply(&mut self, update: CrcUpdate) {
+        let CrcUpdate {
+            file_stats,
+            protocol,
+            metadata,
+            domain_metadata,
+            set_transactions,
+            in_commit_timestamp,
+            operation_safe,
+            has_missing_file_size,
+        } = update;
+
         // Protocol / Metadata: replace if present.
-        if let Some(p) = update.protocol {
+        if let Some(p) = protocol {
             self.protocol = p;
         }
-        if let Some(m) = update.metadata {
+        if let Some(m) = metadata {
             self.metadata = m;
         }
 
         // Domain metadata: upsert from update map, removing tombstones. If base is
         // Untracked but the update has entries (e.g. older CRC didn't track DM but newer
         // commits do), transition to Partial.
-        if !update.domain_metadata.is_empty() {
+        if !domain_metadata.is_empty() {
             match &mut self.domain_metadata {
                 DomainMetadataState::Complete(map) | DomainMetadataState::Partial(map) => {
-                    for (domain, dm) in update.domain_metadata {
+                    for (domain, dm) in domain_metadata {
                         if dm.is_removed() {
                             map.remove(&domain);
                         } else {
@@ -215,8 +228,7 @@ impl Crc {
                 }
                 DomainMetadataState::Untracked => {
                     self.domain_metadata = DomainMetadataState::Partial(
-                        update
-                            .domain_metadata
+                        domain_metadata
                             .into_iter()
                             .filter(|(_, dm)| !dm.is_removed())
                             .collect(),
@@ -227,60 +239,82 @@ impl Crc {
 
         // Set transactions: upsert from update map. No tombstone semantic for txns. Same
         // Untracked → Partial transition.
-        if !update.set_transactions.is_empty() {
+        if !set_transactions.is_empty() {
             match &mut self.set_transactions {
                 SetTransactionState::Complete(map) | SetTransactionState::Partial(map) => {
-                    map.extend(update.set_transactions);
+                    map.extend(set_transactions);
                 }
                 SetTransactionState::Untracked => {
-                    self.set_transactions = SetTransactionState::Partial(update.set_transactions);
+                    self.set_transactions = SetTransactionState::Partial(set_transactions);
                 }
             }
         }
 
         // In-commit timestamp: replace unconditionally. ICT could be disabled (Some →
         // None) or enabled (None → Some) or updated (Some → Some).
-        self.in_commit_timestamp_opt = update.in_commit_timestamp;
+        self.in_commit_timestamp_opt = in_commit_timestamp;
 
-        // File stats: state-machine transition. See the table on FileStatsState.
-        self.file_stats = match &self.file_stats {
-            FileStatsState::Untrackable => {
-                // Terminal: nothing recovers missing file size.
-                return;
-            }
-            _ if update.has_missing_file_size => FileStatsState::Untrackable,
-            FileStatsState::Indeterminate => {
-                // Terminal for incremental tracking (recoverable only via full replay,
-                // which is currently the deferred load_file_stats path).
-                return;
-            }
-            _ if !update.operation_safe => FileStatsState::Indeterminate,
-            FileStatsState::Valid {
-                num_files,
-                table_size_bytes,
-                histogram,
-            } => {
-                let histogram =
-                    merge_histogram(histogram.as_ref(), update.file_stats.net_histogram.as_ref());
-                FileStatsState::Valid {
-                    num_files: num_files + update.file_stats.net_files,
-                    table_size_bytes: table_size_bytes + update.file_stats.net_bytes,
-                    histogram,
-                }
-            }
-            FileStatsState::RequiresCheckpointRead {
-                commit_delta_files,
-                commit_delta_bytes,
-                commit_delta_histogram,
-            } => FileStatsState::RequiresCheckpointRead {
-                commit_delta_files: commit_delta_files + update.file_stats.net_files,
-                commit_delta_bytes: commit_delta_bytes + update.file_stats.net_bytes,
-                commit_delta_histogram: merge_histogram(
-                    commit_delta_histogram.as_ref(),
-                    update.file_stats.net_histogram.as_ref(),
-                ),
-            },
-        };
+        self.file_stats = transition_file_stats(
+            &self.file_stats,
+            &file_stats,
+            operation_safe,
+            has_missing_file_size,
+        );
+    }
+}
+
+/// Compute the next [`FileStatsState`] given the current state and an incoming delta.
+///
+/// Implements the state-machine table on [`FileStatsState`]. Read top-to-bottom:
+///
+/// 1. `Untrackable` is terminal -- nothing recovers missing file size.
+/// 2. Any delta with `has_missing_file_size` poisons the state to `Untrackable`.
+/// 3. `Indeterminate` is terminal except for the `Untrackable` escalation handled above.
+/// 4. Any delta with `!operation_safe` transitions to `Indeterminate`.
+/// 5. Otherwise, the current state is `Valid` or `RequiresCheckpointRead` and we sum counts/bytes
+///    and merge histograms.
+fn transition_file_stats(
+    current: &FileStatsState,
+    delta: &FileStatsDelta,
+    operation_safe: bool,
+    has_missing_file_size: bool,
+) -> FileStatsState {
+    if matches!(current, FileStatsState::Untrackable) {
+        return FileStatsState::Untrackable;
+    }
+    if has_missing_file_size {
+        return FileStatsState::Untrackable;
+    }
+    if matches!(current, FileStatsState::Indeterminate) {
+        return FileStatsState::Indeterminate;
+    }
+    if !operation_safe {
+        return FileStatsState::Indeterminate;
+    }
+    match current {
+        FileStatsState::Valid {
+            num_files,
+            table_size_bytes,
+            histogram,
+        } => FileStatsState::Valid {
+            num_files: num_files + delta.net_files,
+            table_size_bytes: table_size_bytes + delta.net_bytes,
+            histogram: merge_histogram(histogram.as_ref(), delta.net_histogram.as_ref()),
+        },
+        FileStatsState::RequiresCheckpointRead {
+            commit_delta_files,
+            commit_delta_bytes,
+            commit_delta_histogram,
+        } => FileStatsState::RequiresCheckpointRead {
+            commit_delta_files: commit_delta_files + delta.net_files,
+            commit_delta_bytes: commit_delta_bytes + delta.net_bytes,
+            commit_delta_histogram: merge_histogram(
+                commit_delta_histogram.as_ref(),
+                delta.net_histogram.as_ref(),
+            ),
+        },
+        // Untrackable / Indeterminate handled by early returns above.
+        FileStatsState::Untrackable | FileStatsState::Indeterminate => current.clone(),
     }
 }
 
@@ -689,10 +723,13 @@ mod tests {
     }
 
     #[test]
-    fn apply_adopts_histogram_when_base_none_delta_some() {
-        // Forward-replay-friendly: a base CRC without a histogram + an update with a
-        // histogram → CRC adopts the update's histogram. Useful when forward-replaying
-        // onto a base that lacked histogram support.
+    fn apply_drops_histogram_when_base_none_delta_some() {
+        // A base CRC without a histogram + an update with a delta histogram → the
+        // resulting CRC has no histogram. The delta is an *increment* over an unknown
+        // baseline, so adopting it as the absolute histogram would be wrong (it would
+        // describe only this commit's files, not the table's full file set). The right
+        // way to seed an initial histogram is via CrcUpdate::into_fresh_crc when doing a
+        // full replay.
         let mut crc = base_crc();
         crc.file_stats = FileStatsState::Valid {
             num_files: 0,
@@ -713,9 +750,12 @@ mod tests {
         });
 
         let stats = crc.file_stats().unwrap();
-        let adopted = stats.file_size_histogram().unwrap();
-        assert_eq!(adopted.file_counts()[0], 1);
-        assert_eq!(adopted.total_bytes()[0], 500);
+        assert!(
+            stats.file_size_histogram().is_none(),
+            "delta is not an absolute baseline"
+        );
+        assert_eq!(stats.num_files(), 1);
+        assert_eq!(stats.table_size_bytes(), 500);
     }
 
     #[test]

--- a/kernel/src/crc/file_stats.rs
+++ b/kernel/src/crc/file_stats.rs
@@ -19,12 +19,12 @@ use crate::{DeltaResult, EngineData, Error, RowVisitor};
 
 /// File-level statistics for a table version: total file count, size, and histogram.
 ///
-/// Obtained via [`Snapshot::get_or_load_file_stats`], [`Snapshot::get_file_stats_if_loaded`],
-/// or [`Crc::file_stats()`](super::Crc::file_stats). Returns `None` when the stats are not
-/// known to be valid.
+/// Obtained via [`Snapshot::get_file_stats`] or
+/// [`Crc::file_stats()`](super::Crc::file_stats). Returns `None` when the stats are not
+/// known to be valid; callers can recover via
+/// [`Snapshot::load_file_stats`](crate::snapshot::Snapshot::load_file_stats).
 ///
-/// [`Snapshot::get_or_load_file_stats`]: crate::snapshot::Snapshot::get_or_load_file_stats
-/// [`Snapshot::get_file_stats_if_loaded`]: crate::snapshot::Snapshot::get_file_stats_if_loaded
+/// [`Snapshot::get_file_stats`]: crate::snapshot::Snapshot::get_file_stats
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FileStats {
     /// Number of active [`Add`](crate::actions::Add) file actions in this table version.

--- a/kernel/src/crc/lazy.rs
+++ b/kernel/src/crc/lazy.rs
@@ -68,6 +68,7 @@ impl LazyCrc {
     /// The CRC is immediately available via `get_or_load` without any I/O. The `version`
     /// parameter records which table version this CRC corresponds to, enabling
     /// `get_if_loaded_at_version` to work for chained commits.
+    #[allow(dead_code)] // Reserved for future paths that pre-compute CRCs without disk-backed files.
     pub(crate) fn new_precomputed(crc: Crc, version: Version) -> Self {
         let cached = OnceLock::new();
         // OnceLock::set cannot fail here because we just created it
@@ -100,6 +101,7 @@ impl LazyCrc {
     }
 
     /// Returns the CRC only if the CRC file is at the given version, loading if necessary.
+    #[allow(dead_code)] // Reserved for future paths.
     pub(crate) fn get_or_load_if_at_version(
         &self,
         engine: &dyn Engine,
@@ -115,6 +117,7 @@ impl LazyCrc {
     ///
     /// This is purely opportunistic: it returns `Some` only when the CRC was previously loaded
     /// (via `get_or_load`) or precomputed (via `new_precomputed`) AND the version matches.
+    #[allow(dead_code)] // Reserved for future paths.
     pub(crate) fn get_if_loaded_at_version(&self, version: Version) -> Option<&Arc<Crc>> {
         if self.crc_version() != Some(version) {
             return None;
@@ -162,15 +165,24 @@ mod tests {
     #[test]
     fn test_crc_load_result_loaded() {
         let crc = Crc {
-            table_size_bytes: 100,
-            num_files: 10,
-            num_metadata: 1,
-            num_protocol: 1,
+            file_stats: crate::crc::FileStatsState::Valid {
+                num_files: 10,
+                table_size_bytes: 100,
+                histogram: None,
+            },
             ..Default::default()
         };
         let loaded = CrcLoadResult::Loaded(Arc::new(crc));
         assert!(loaded.get().is_some());
-        assert_eq!(loaded.get().unwrap().table_size_bytes, 100);
+        assert_eq!(
+            loaded
+                .get()
+                .unwrap()
+                .file_stats()
+                .unwrap()
+                .table_size_bytes(),
+            100
+        );
     }
 
     #[rstest]
@@ -228,7 +240,7 @@ mod tests {
         assert!(lazy.is_loaded());
 
         let crc = result.get().unwrap();
-        assert_eq!(crc.table_size_bytes, 5259);
+        assert_eq!(crc.file_stats().unwrap().table_size_bytes(), 5259);
     }
 
     #[test]
@@ -250,10 +262,11 @@ mod tests {
 
     fn test_crc(table_size_bytes: i64) -> Crc {
         Crc {
-            table_size_bytes,
-            num_files: 1,
-            num_metadata: 1,
-            num_protocol: 1,
+            file_stats: crate::crc::FileStatsState::Valid {
+                num_files: 1,
+                table_size_bytes,
+                histogram: None,
+            },
             ..Default::default()
         }
     }
@@ -269,7 +282,7 @@ mod tests {
         // get_if_loaded_at_version should return the CRC at the correct version
         let loaded = lazy.get_if_loaded_at_version(5);
         assert!(loaded.is_some());
-        assert_eq!(loaded.unwrap().table_size_bytes, 42);
+        assert_eq!(loaded.unwrap().file_stats().unwrap().table_size_bytes(), 42);
 
         // Wrong version should return None
         assert!(lazy.get_if_loaded_at_version(4).is_none());

--- a/kernel/src/crc/lazy.rs
+++ b/kernel/src/crc/lazy.rs
@@ -1,7 +1,13 @@
-//! Lazy CRC loading support.
+//! Lazy CRC loading helper for the protocol+metadata replay shortcut.
 //!
-//! Provides thread-safe lazy loading of CRC files, ensuring they are read at most once and the
-//! result is shared across all consumers.
+//! Used internally by [`LogSegment::read_protocol_metadata_opt`](crate::log_segment::LogSegment)
+//! to read a CRC file at most once and skip log replay if Protocol/Metadata are present.
+//! The `Snapshot`'s eager `Arc<Crc>` (constructed during snapshot load) is unrelated to
+//! this helper -- this exists solely as a "transient cache" for the P&M shortcut path.
+//!
+//! Once the eager-CRC + reverse-replay accumulator handles all snapshot-load paths, this
+//! helper can be folded into the P&M-replay path or removed entirely. Until then, it's
+//! the minimal surface needed to keep that path working.
 
 use std::sync::{Arc, OnceLock};
 
@@ -13,7 +19,7 @@ use crate::{Engine, Version};
 
 /// Result of attempting to load a CRC file.
 ///
-/// The "not yet loaded" state is represented by `OnceLock::get()` returning `None`, not as an enum
+/// "Not yet loaded" is represented by `OnceLock::get()` returning `None`, not as an enum
 /// variant.
 #[derive(Debug, Clone)]
 pub(crate) enum CrcLoadResult {
@@ -25,65 +31,28 @@ pub(crate) enum CrcLoadResult {
     Loaded(Arc<Crc>),
 }
 
-impl CrcLoadResult {
-    /// Returns the CRC if successfully loaded.
-    #[allow(dead_code)] // Used in future phases (domain metadata, ICT)
-    pub(crate) fn get(&self) -> Option<&Arc<Crc>> {
-        match self {
-            CrcLoadResult::Loaded(crc) => Some(crc),
-            _ => None,
-        }
-    }
-}
-
-/// Lazy loader for CRC info that ensures it's only read once.
-///
-/// Uses `OnceLock` to ensure thread-safe initialization that happens at most once.
-/// Can also hold a precomputed CRC (e.g. from post-commit CRC merge) without a backing file.
+/// Lazy loader for a CRC file. Ensures the file is read at most once and the result is
+/// cached for subsequent accesses.
 #[derive(Debug)]
 pub(crate) struct LazyCrc {
     /// The CRC file path, if one exists in the log segment.
     crc_file: Option<ParsedLogPath>,
     /// Cached load result (loaded lazily, at most once).
-    pub(crate) cached: OnceLock<CrcLoadResult>,
-    /// Version of a precomputed CRC (set when CRC was computed rather than read from file).
-    /// When set, this takes priority over `crc_file` for version checks.
-    precomputed_version: Option<Version>,
+    cached: OnceLock<CrcLoadResult>,
 }
 
 impl LazyCrc {
-    /// Create a new lazy CRC loader.
-    ///
-    /// If `crc_file` is `None`, the loader will immediately return `DoesNotExist` when accessed.
+    /// Create a new lazy CRC loader. If `crc_file` is `None`, the loader will return
+    /// [`CrcLoadResult::DoesNotExist`] on access without any I/O.
     pub(crate) fn new(crc_file: Option<ParsedLogPath>) -> Self {
         Self {
             crc_file,
             cached: OnceLock::new(),
-            precomputed_version: None,
         }
     }
 
-    /// Create a `LazyCrc` with a precomputed CRC value (no backing file).
-    ///
-    /// The CRC is immediately available via `get_or_load` without any I/O. The `version`
-    /// parameter records which table version this CRC corresponds to, enabling
-    /// `get_if_loaded_at_version` to work for chained commits.
-    #[allow(dead_code)] // Reserved for future paths that pre-compute CRCs without disk-backed files.
-    pub(crate) fn new_precomputed(crc: Crc, version: Version) -> Self {
-        let cached = OnceLock::new();
-        // OnceLock::set cannot fail here because we just created it
-        let _ = cached.set(CrcLoadResult::Loaded(Arc::new(crc)));
-        Self {
-            crc_file: None,
-            cached,
-            precomputed_version: Some(version),
-        }
-    }
-
-    /// Returns the CRC load result, loading if necessary.
-    ///
-    /// The loading closure is only called once, even across threads. Subsequent calls return the
-    /// cached result.
+    /// Returns the CRC load result, loading from storage if not yet cached. The loading
+    /// closure runs at most once across all callers.
     pub(crate) fn get_or_load(&self, engine: &dyn Engine) -> &CrcLoadResult {
         self.cached.get_or_init(|| match &self.crc_file {
             None => CrcLoadResult::DoesNotExist,
@@ -100,44 +69,9 @@ impl LazyCrc {
         })
     }
 
-    /// Returns the CRC only if the CRC file is at the given version, loading if necessary.
-    #[allow(dead_code)] // Reserved for future paths.
-    pub(crate) fn get_or_load_if_at_version(
-        &self,
-        engine: &dyn Engine,
-        version: Version,
-    ) -> Option<&Arc<Crc>> {
-        if self.crc_version() != Some(version) {
-            return None;
-        }
-        self.get_or_load(engine).get()
-    }
-
-    /// Returns the CRC only if it is already loaded (no I/O) and matches the given version.
-    ///
-    /// This is purely opportunistic: it returns `Some` only when the CRC was previously loaded
-    /// (via `get_or_load`) or precomputed (via `new_precomputed`) AND the version matches.
-    #[allow(dead_code)] // Reserved for future paths.
-    pub(crate) fn get_if_loaded_at_version(&self, version: Version) -> Option<&Arc<Crc>> {
-        if self.crc_version() != Some(version) {
-            return None;
-        }
-        self.cached.get()?.get()
-    }
-
-    /// Check if CRC has been loaded (without triggering loading).
-    #[allow(dead_code)] // Used in future phases (domain metadata, ICT)
-    pub(crate) fn is_loaded(&self) -> bool {
-        self.cached.get().is_some()
-    }
-
-    /// Returns the CRC version, checking precomputed version first, then CRC file version.
-    ///
-    /// This enables chaining: a post-commit snapshot with a precomputed CRC at version N+1
-    /// can serve as the read snapshot for a transaction targeting version N+2.
+    /// Returns the version of the CRC file backing this loader, if any. No I/O.
     pub(crate) fn crc_version(&self) -> Option<Version> {
-        self.precomputed_version
-            .or_else(|| self.crc_file.as_ref().map(|f| f.version))
+        self.crc_file.as_ref().map(|f| f.version)
     }
 }
 
@@ -145,9 +79,8 @@ impl LazyCrc {
 mod tests {
     use std::path::PathBuf;
 
-    use rstest::rstest;
-
     use super::*;
+    use crate::crc::FileStatsState;
     use crate::engine::default::executor::tokio::TokioBackgroundExecutor;
     use crate::engine::default::{DefaultEngine, DefaultEngineBuilder};
     use crate::object_store::memory::InMemory;
@@ -160,160 +93,73 @@ mod tests {
         DefaultEngineBuilder::new(Arc::new(InMemory::new())).build()
     }
 
-    // ===== CrcLoadResult Tests =====
-
-    #[test]
-    fn test_crc_load_result_loaded() {
-        let crc = Crc {
-            file_stats: crate::crc::FileStatsState::Valid {
-                num_files: 10,
-                table_size_bytes: 100,
-                histogram: None,
-            },
-            ..Default::default()
-        };
-        let loaded = CrcLoadResult::Loaded(Arc::new(crc));
-        assert!(loaded.get().is_some());
-        assert_eq!(
-            loaded
-                .get()
-                .unwrap()
-                .file_stats()
-                .unwrap()
-                .table_size_bytes(),
-            100
-        );
-    }
-
-    #[rstest]
-    #[case::does_not_exist(CrcLoadResult::DoesNotExist)]
-    #[case::corrupt(CrcLoadResult::CorruptOrFailed)]
-    fn test_crc_load_result(#[case] result: CrcLoadResult) {
-        assert!(result.get().is_none());
-    }
-
-    // ===== LazyCrc Tests =====
-
-    #[test]
-    fn test_lazy_crc_no_file() {
-        let engine = test_engine();
-
-        let lazy = LazyCrc::new(None);
-        assert!(!lazy.is_loaded());
-        assert_eq!(lazy.crc_version(), None);
-
-        let result = lazy.get_or_load(&engine);
-        assert!(matches!(result, CrcLoadResult::DoesNotExist));
-        assert!(result.get().is_none());
-        assert!(lazy.is_loaded());
-    }
-
-    #[test]
-    fn test_lazy_crc_missing_file() {
-        let engine = test_engine();
-
-        let lazy = LazyCrc::new(Some(ParsedLogPath::create_parsed_crc(&table_root(), 5)));
-        assert!(!lazy.is_loaded());
-        assert_eq!(lazy.crc_version(), Some(5));
-
-        let result = lazy.get_or_load(&engine);
-        assert!(matches!(result, CrcLoadResult::CorruptOrFailed));
-        assert!(result.get().is_none());
-        assert!(lazy.is_loaded());
-    }
-
     fn test_table_root(dir: &str) -> url::Url {
         let path = std::fs::canonicalize(PathBuf::from(dir)).unwrap();
         url::Url::from_directory_path(path).unwrap()
     }
 
     #[test]
-    fn test_lazy_crc_loads_real_file() {
+    fn lazy_crc_with_no_file_returns_does_not_exist() {
+        let engine = test_engine();
+        let lazy = LazyCrc::new(None);
+        assert_eq!(lazy.crc_version(), None);
+
+        let result = lazy.get_or_load(&engine);
+        assert!(matches!(result, CrcLoadResult::DoesNotExist));
+    }
+
+    #[test]
+    fn lazy_crc_with_missing_file_path_returns_corrupt_or_failed() {
+        let engine = test_engine();
+        let lazy = LazyCrc::new(Some(ParsedLogPath::create_parsed_crc(&table_root(), 5)));
+        assert_eq!(lazy.crc_version(), Some(5));
+
+        let result = lazy.get_or_load(&engine);
+        assert!(matches!(result, CrcLoadResult::CorruptOrFailed));
+    }
+
+    #[test]
+    fn lazy_crc_loads_real_file() {
         let engine = crate::engine::sync::SyncEngine::new();
         let table_root = test_table_root("./tests/data/crc-full/");
-
         let lazy = LazyCrc::new(Some(ParsedLogPath::create_parsed_crc(&table_root, 0)));
-        assert!(!lazy.is_loaded());
         assert_eq!(lazy.crc_version(), Some(0));
 
         let result = lazy.get_or_load(&engine);
-        assert!(lazy.is_loaded());
-
-        let crc = result.get().unwrap();
+        let CrcLoadResult::Loaded(crc) = result else {
+            panic!("expected Loaded, got {result:?}");
+        };
         assert_eq!(crc.file_stats().unwrap().table_size_bytes(), 5259);
     }
 
     #[test]
-    fn test_lazy_crc_malformed_file() {
+    fn lazy_crc_with_malformed_file_returns_corrupt_or_failed() {
         let engine = crate::engine::sync::SyncEngine::new();
         let table_root = test_table_root("./tests/data/crc-malformed/");
-
         let lazy = LazyCrc::new(Some(ParsedLogPath::create_parsed_crc(&table_root, 0)));
-        assert!(!lazy.is_loaded());
-        assert_eq!(lazy.crc_version(), Some(0));
 
         let result = lazy.get_or_load(&engine);
         assert!(matches!(result, CrcLoadResult::CorruptOrFailed));
-        assert!(result.get().is_none());
-        assert!(lazy.is_loaded());
-    }
-
-    // ===== Precomputed LazyCrc Tests =====
-
-    fn test_crc(table_size_bytes: i64) -> Crc {
-        Crc {
-            file_stats: crate::crc::FileStatsState::Valid {
-                num_files: 1,
-                table_size_bytes,
-                histogram: None,
-            },
-            ..Default::default()
-        }
     }
 
     #[test]
-    fn test_lazy_crc_precomputed() {
-        let crc = test_crc(42);
-        let lazy = LazyCrc::new_precomputed(crc, 5);
+    fn lazy_crc_caches_result_across_calls() {
+        // Build a CRC with a real file behind it. Calling get_or_load twice must return
+        // the same Loaded result without doing the I/O twice (covered indirectly: a
+        // second call doesn't error even if the file vanished, because the result was
+        // cached on the first call).
+        let engine = crate::engine::sync::SyncEngine::new();
+        let table_root = test_table_root("./tests/data/crc-full/");
+        let lazy = LazyCrc::new(Some(ParsedLogPath::create_parsed_crc(&table_root, 0)));
+        let first = lazy.get_or_load(&engine);
+        let second = lazy.get_or_load(&engine);
+        // OnceLock returns the same reference both times.
+        assert!(std::ptr::eq(first, second));
 
-        assert!(lazy.is_loaded());
-        assert_eq!(lazy.crc_version(), Some(5));
-
-        // get_if_loaded_at_version should return the CRC at the correct version
-        let loaded = lazy.get_if_loaded_at_version(5);
-        assert!(loaded.is_some());
-        assert_eq!(loaded.unwrap().file_stats().unwrap().table_size_bytes(), 42);
-
-        // Wrong version should return None
-        assert!(lazy.get_if_loaded_at_version(4).is_none());
-        assert!(lazy.get_if_loaded_at_version(6).is_none());
-    }
-
-    #[test]
-    fn test_lazy_crc_precomputed_version_takes_priority() {
-        let crc = test_crc(100);
-        let lazy = LazyCrc::new_precomputed(crc, 3);
-        assert_eq!(lazy.crc_version(), Some(3));
-    }
-
-    #[test]
-    fn test_get_if_loaded_at_version_not_loaded() {
-        // CRC file exists but not yet loaded -> should return None (no I/O)
-        let lazy = LazyCrc::new(Some(ParsedLogPath::create_parsed_crc(&table_root(), 5)));
-        assert!(!lazy.is_loaded());
-        assert!(lazy.get_if_loaded_at_version(5).is_none());
-    }
-
-    #[test]
-    fn test_get_if_loaded_at_version_wrong_version() {
-        let crc = test_crc(100);
-        let lazy = LazyCrc::new_precomputed(crc, 5);
-        assert!(lazy.get_if_loaded_at_version(3).is_none());
-    }
-
-    #[test]
-    fn test_get_if_loaded_at_version_no_crc() {
-        let lazy = LazyCrc::new(None);
-        assert!(lazy.get_if_loaded_at_version(0).is_none());
+        // Sanity: still Loaded.
+        let CrcLoadResult::Loaded(crc) = first else {
+            panic!("expected Loaded");
+        };
+        assert!(matches!(crc.file_stats, FileStatsState::Valid { .. }));
     }
 }

--- a/kernel/src/crc/mod.rs
+++ b/kernel/src/crc/mod.rs
@@ -3,7 +3,30 @@
 //! A [CRC file] contains a snapshot of table state at a specific version, which can be used to
 //! optimize log replay operations like reading Protocol/Metadata, domain metadata, and ICT.
 //!
+//! # Architecture
+//!
+//! The in-memory representation [`Crc`] uses typed state enums that encode both the value and
+//! the trustworthiness of every field. This makes invalid states unrepresentable: you cannot
+//! accidentally read an absolute file count from a relative delta because they live in
+//! different variants of [`FileStatsState`].
+//!
+//! On-disk JSON serialization goes through [`CrcRaw`], a flat 1:1 mirror of the Delta protocol
+//! [CRC file] format. The mapping is mediated by `#[serde(from, into)]` on [`Crc`].
+//!
+//! [`CrcUpdate`] is the universal delta type. Every CRC mutation flows through
+//! [`Crc::apply`]. There are four ways to produce a `CrcUpdate`:
+//!
+//! 1. **Commit-time** ([`Transaction::commit`]): build from staged add/remove metadata + the
+//!    transaction's own commitInfo / DM / txn changes. Apply once to the read snapshot's CRC.
+//! 2. **Stale-CRC catch-up**: reverse-replay commits after the CRC version, accumulate, apply once.
+//!    The accumulator does first-seen-wins for per-key fields (DM/txn/P/M).
+//! 3. **No-CRC bootstrap**: same shape as (2) but the segment includes a checkpoint and the base is
+//!    built via [`CrcUpdate::into_fresh_crc`].
+//! 4. **Future: forward rebase / action reconciliation** (priorities 4 and 5 in the design plan):
+//!    different production strategies, same `Crc::apply`.
+//!
 //! [CRC file]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#version-checksum-file
+//! [`Transaction::commit`]: crate::transaction::Transaction::commit
 
 // Allow unreachable_pub because this module is pub when test-utils is enabled
 // but pub(crate) otherwise. The items need to be pub for integration tests.
@@ -14,206 +37,235 @@ mod file_size_histogram;
 mod file_stats;
 mod lazy;
 mod reader;
+mod state;
 mod writer;
 
-use std::collections::HashMap;
-
 #[allow(unused)]
-pub(crate) use delta::CrcDelta;
+pub(crate) use delta::CrcUpdate;
 pub use file_size_histogram::FileSizeHistogram;
 pub use file_stats::FileStats;
 #[allow(unused)]
 pub(crate) use file_stats::FileStatsDelta;
 pub(crate) use lazy::{CrcLoadResult, LazyCrc};
 pub(crate) use reader::try_read_crc_file;
-use serde::de::Deserializer;
-use serde::ser::Serializer;
 use serde::{Deserialize, Serialize};
+pub use state::{DomainMetadataState, FileStatsState, FileStatsValidity, SetTransactionState};
 #[allow(unused)]
 pub(crate) use writer::try_write_crc_file;
 
-use crate::actions::{Add, DomainMetadata, Metadata, Protocol, SetTransaction};
+use crate::actions::{DomainMetadata, Metadata, Protocol, SetTransaction};
 
-/// Tracks whether file stats (`num_files`, `table_size_bytes`) are trustworthy.
+/// In-memory CRC state for a snapshot. Always present on
+/// [`Snapshot`](crate::snapshot::Snapshot).
 ///
-/// Defaults to [`Valid`](Self::Valid), which is the correct state when deserializing a CRC file
-/// from disk (a CRC file's stats are correct by definition).
-#[allow(dead_code)] // Variants used in follow-up PRs (forward replay, transaction delta).
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub enum FileStatsValidity {
-    /// File stats are known-correct absolute totals. This is the case when seeded from a CRC
-    /// file (which contains `num_files` and `table_size_bytes`) or when replay starts from
-    /// version zero (where the initial state is trivially zero). Safe to write to disk.
-    #[default]
-    Valid,
-    /// File stats are relative deltas, not absolute totals. This happens when seeding from a
-    /// checkpoint: we extract metadata fields but not file counts (reading all add actions from
-    /// a checkpoint just for counts is too expensive). The accumulated deltas are correct, but
-    /// without a baseline they cannot produce final totals. Not safe to write to disk.
-    RequiresCheckpointRead,
-    /// A non-incremental operation was seen: file stats cannot be determined incrementally.
-    /// For example, ANALYZE STATS re-adds existing files with updated statistics but no
-    /// corresponding removes, so naively counting adds would double-count.
-    /// A full log replay from scratch could recover correct file stats. Not safe to write to disk.
-    Indeterminate,
-    /// A file action had a missing size field: correct file stats are impossible to compute.
-    /// For example, the Delta protocol allows `remove.size` to be null -- when encountered,
-    /// we can no longer track byte totals. Unlike [`Indeterminate`](Self::Indeterminate), no
-    /// amount of replay can recover the missing data. Not safe to write to disk.
-    Untrackable,
-}
-
-/// Parsed content of a CRC (version checksum) file.
+/// `Crc` carries P&M (always), file statistics with typed validity ([`FileStatsState`]),
+/// completeness-tracked maps for domain metadata and set transactions
+/// ([`DomainMetadataState`] / [`SetTransactionState`]), and an optional in-commit timestamp.
 ///
-/// A `Crc` is either (a) loaded from disk (deserialized from a `.crc` JSON file) or (b) computed
-/// in memory (built incrementally via `Crc::apply`).
+/// Mutated only via [`Crc::apply`]. Constructed either by deserializing from disk (via the
+/// [`CrcRaw`] serde intermediate), by [`Crc::minimal_from_pm`], or by
+/// [`CrcUpdate::into_fresh_crc`] (when there is no base CRC to apply onto).
 ///
-/// A CRC file must:
-/// 1. Be named `{version}.crc` with version zero-padded to 20 digits: `00000000000000000001.crc`
-/// 2. Be stored directly in the _delta_log directory alongside Delta log files
-/// 3. Contain exactly one JSON object with the schema of this struct.
-///
-/// This struct and its fields are marked `pub`, but the `crc` module is only re-exported as `pub`
-/// when the `test-utils` feature is enabled (otherwise `pub(crate)`). See `kernel/src/lib.rs`.
-// Deserialized directly from JSON via serde. See `reader::try_read_crc_file`.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+/// This struct and its fields are `pub` so integration tests under the `test-utils` feature
+/// can inspect them; without `test-utils` the `crc` module is `pub(crate)`. See
+/// `kernel/src/lib.rs`.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(from = "CrcRaw", into = "CrcRaw")]
 pub struct Crc {
-    // ===== Required fields =====
-    /// Total size of the table in bytes, calculated as the sum of the `size` field of all live
-    /// [`Add`] actions. Private -- use [`Crc::file_stats()`] to access safely.
-    table_size_bytes: i64,
-    /// Number of live [`Add`] actions in this table version after action reconciliation.
-    /// Private -- use [`Crc::file_stats()`] to access safely.
-    num_files: i64,
-    /// Number of [`Metadata`] actions. Must be 1.
-    pub num_metadata: i64,
-    /// Number of [`Protocol`] actions. Must be 1.
-    pub num_protocol: i64,
-    /// The table [`Metadata`] at this version.
-    pub metadata: Metadata,
     /// The table [`Protocol`] at this version.
     pub protocol: Protocol,
-    /// Whether the file stats (`num_files`, `table_size_bytes`) in this CRC are trustworthy.
-    /// Not serialized -- this is an in-memory replay concern only. When deserialized from a CRC
-    /// file on disk, defaults to [`FileStatsValidity::Valid`] (a CRC file's stats are correct
-    /// by definition). A CRC is only safe to write to disk when validity is `Valid`.
-    #[serde(skip)]
-    pub file_stats_validity: FileStatsValidity,
-
-    // ===== Optional fields =====
-    /// A unique identifier for the transaction that produced this commit.
-    #[serde(skip)]
-    pub txn_id: Option<String>,
-    /// The in-commit timestamp of this version. Present iff In-Commit Timestamps are enabled.
+    /// The table [`Metadata`] at this version.
+    pub metadata: Metadata,
+    /// File-level statistics with typed validity. Encodes both values and their
+    /// trustworthiness.
+    pub file_stats: FileStatsState,
+    /// Domain metadata completeness state.
+    pub domain_metadata: DomainMetadataState,
+    /// Set transaction completeness state.
+    pub set_transactions: SetTransactionState,
+    /// In-commit timestamp from the latest commit, if ICT is enabled at this version.
     pub in_commit_timestamp_opt: Option<i64>,
-    /// Live transaction identifier ([`SetTransaction`]) actions at this version. `None` = not
-    /// tracked (field absent in CRC JSON or not computed). `Some(empty_map)` = tracked, no
-    /// active set transactions. `apply()` skips updates when `None`.
-    ///
-    /// Stored as a HashMap keyed by `app_id` for efficient lookup. The CRC JSON format uses
-    /// a Vec, which is converted via custom serde deserialization.
-    #[serde(
-        default,
-        deserialize_with = "de_opt_vec_to_opt_map",
-        serialize_with = "ser_opt_map_to_opt_vec"
-    )]
-    pub set_transactions: Option<HashMap<String, SetTransaction>>,
-    /// Active (non-removed) [`DomainMetadata`] actions at this version. Tombstones
-    /// (`removed=true`) are never stored. `None` = not tracked (field absent in CRC JSON or not
-    /// computed). `Some(empty_map)` = tracked, no active domain metadata. `apply()` skips
-    /// updates when `None`.
-    ///
-    /// Stored as a HashMap keyed by domain name for efficient lookup. The CRC JSON format uses
-    /// a Vec, which is converted via custom serde deserialization.
-    #[serde(
-        default,
-        deserialize_with = "de_opt_vec_to_opt_map",
-        serialize_with = "ser_opt_map_to_opt_vec"
-    )]
-    pub domain_metadata: Option<HashMap<String, DomainMetadata>>,
-    /// Size distribution information of files remaining after action reconciliation.
-    #[serde(
-        default,
-        deserialize_with = "de_validated_file_size_histogram",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub file_size_histogram: Option<FileSizeHistogram>,
-    /// All live [`Add`] file actions at this version.
-    #[serde(skip)]
-    pub all_files: Option<Vec<Add>>,
-    /// Number of records deleted through Deletion Vectors in this table version.
-    #[serde(skip)]
-    pub num_deleted_records_opt: Option<i64>,
-    /// Number of Deletion Vectors active in this table version.
-    #[serde(skip)]
-    pub num_deletion_vectors_opt: Option<i64>,
-    /// Distribution of deleted record counts across files. See this section for more details.
-    #[serde(skip)]
-    pub deleted_record_counts_histogram_opt: Option<DeletedRecordCountsHistogram>,
 }
 
-impl Crc {
-    /// Returns file-level statistics only if they are known to be valid.
-    ///
-    /// Returns `None` when file stats cannot be trusted -- for example, when the CRC was
-    /// built from incremental replay that encountered a non-incremental operation or a
-    /// missing file size.
-    pub fn file_stats(&self) -> Option<FileStats> {
-        match self.file_stats_validity {
-            FileStatsValidity::Valid => Some(FileStats {
-                num_files: self.num_files,
-                table_size_bytes: self.table_size_bytes,
-                file_size_histogram: self.file_size_histogram.clone(),
-            }),
-            _ => None,
+impl Default for Crc {
+    /// Default CRC: [`Valid`](FileStatsState::Valid) with zero counts and no histogram,
+    /// [`Untracked`](DomainMetadataState::Untracked) DM and txns, default P&M.
+    fn default() -> Self {
+        Crc {
+            protocol: Protocol::default(),
+            metadata: Metadata::default(),
+            file_stats: FileStatsState::default(),
+            domain_metadata: DomainMetadataState::default(),
+            set_transactions: SetTransactionState::default(),
+            in_commit_timestamp_opt: None,
         }
     }
 }
 
-/// Trait for types that can be stored in a HashMap keyed by a string identifier.
-/// Used by CRC serde helpers to convert between Vec (JSON format) and HashMap (in-memory).
-trait MapKey {
-    fn map_key(&self) -> &str;
-}
+impl Crc {
+    /// Returns file-level statistics if [`FileStatsState`] is `Valid`, else `None`.
+    pub fn file_stats(&self) -> Option<FileStats> {
+        self.file_stats.file_stats()
+    }
 
-impl MapKey for DomainMetadata {
-    fn map_key(&self) -> &str {
-        self.domain()
+    /// Returns the simplified validity classification of file stats. Useful for cost
+    /// inspection by connectors.
+    pub fn file_stats_validity(&self) -> FileStatsValidity {
+        self.file_stats.validity()
+    }
+
+    /// Build a minimal CRC from Protocol and Metadata only. File stats are
+    /// [`RequiresCheckpointRead`](FileStatsState::RequiresCheckpointRead), DM/txns are
+    /// [`Untracked`](DomainMetadataState::Untracked), histogram is `None`, ICT is `None`.
+    ///
+    /// Used when no CRC file is available and a full log replay was not performed -- e.g.
+    /// the incremental snapshot update fallback path.
+    pub(crate) fn minimal_from_pm(protocol: Protocol, metadata: Metadata) -> Self {
+        Crc {
+            protocol,
+            metadata,
+            file_stats: FileStatsState::RequiresCheckpointRead {
+                commit_delta_files: 0,
+                commit_delta_bytes: 0,
+                commit_delta_histogram: None,
+            },
+            ..Default::default()
+        }
     }
 }
 
-impl MapKey for SetTransaction {
-    fn map_key(&self) -> &str {
-        &self.app_id
-    }
-}
+// ============================================================================
+// CrcRaw: serde intermediate representation
+// ============================================================================
 
-/// Deserialize an `Option<Vec<T>>` from JSON into `Option<HashMap<String, T>>`, using
-/// [`MapKey::map_key`] to derive the HashMap key for each element.
-fn de_opt_vec_to_opt_map<'de, D, T>(deserializer: D) -> Result<Option<HashMap<String, T>>, D::Error>
-where
-    D: Deserializer<'de>,
-    T: Deserialize<'de> + MapKey,
-{
-    let opt_vec: Option<Vec<T>> = Option::deserialize(deserializer)?;
-    Ok(opt_vec.map(|vec| {
-        vec.into_iter()
-            .map(|item| (item.map_key().to_string(), item))
-            .collect()
-    }))
-}
-
-/// Deserializes an `Option<FileSizeHistogram>` from a CRC JSON file with validation.
+/// Flat 1:1 mirror of the on-disk CRC JSON format from the Delta protocol spec.
 ///
-/// After serde deserializes the raw JSON fields, this validates the histogram invariants
-/// (sorted boundaries, matching array lengths, etc.) via [`FileSizeHistogram::try_new`],
-/// ensuring malformed CRC files are rejected rather than causing panics later.
-fn de_validated_file_size_histogram<'de, D>(
+/// Used only as a serde intermediate via `#[serde(from, into)]` on [`Crc`]. Maps the typed
+/// in-memory enums to/from the flat JSON shape.
+///
+/// The Delta protocol always writes complete data (or omits the field entirely): a CRC file
+/// on disk is `Valid` for file stats, and `Complete` (or absent) for DM and txns. The serde
+/// intermediate enforces this via deserialization (always to `Valid` / `Complete`) and via
+/// [`try_write_crc_file`] (which gates on [`FileStatsState::is_writable`]).
+///
+/// Fields with `#[serde(default)]` produce the appropriate "absent" state when missing or
+/// `null`: `set_transactions` and `domain_metadata` map to `Untracked`, `file_size_histogram`
+/// stays `None`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CrcRaw {
+    /// Total size of the table in bytes (sum of all active Add file sizes).
+    table_size_bytes: i64,
+    /// Number of active Add file actions.
+    num_files: i64,
+    /// Number of Metadata actions. Always 1.
+    num_metadata: i64,
+    /// Number of Protocol actions. Always 1.
+    num_protocol: i64,
+    metadata: Metadata,
+    protocol: Protocol,
+    /// In-commit timestamp from the latest commit, when ICT is enabled. Skipped on
+    /// serialize when `None` to avoid emitting `null`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    in_commit_timestamp_opt: Option<i64>,
+    /// Active set transactions, when tracked. `None` (absent or `null` in JSON) maps to
+    /// [`SetTransactionState::Untracked`].
+    #[serde(default)]
+    set_transactions: Option<Vec<SetTransaction>>,
+    /// Active (non-removed) domain metadata, when tracked. `None` maps to
+    /// [`DomainMetadataState::Untracked`].
+    #[serde(default)]
+    domain_metadata: Option<Vec<DomainMetadata>>,
+    /// File size histogram, when present. Validated on deserialize via
+    /// [`FileSizeHistogram::try_new`].
+    #[serde(
+        default,
+        deserialize_with = "deserialize_validated_histogram",
+        skip_serializing_if = "Option::is_none"
+    )]
+    file_size_histogram: Option<FileSizeHistogram>,
+}
+
+impl From<CrcRaw> for Crc {
+    fn from(raw: CrcRaw) -> Self {
+        let file_stats = FileStatsState::Valid {
+            num_files: raw.num_files,
+            table_size_bytes: raw.table_size_bytes,
+            histogram: raw.file_size_histogram,
+        };
+        let domain_metadata = match raw.domain_metadata {
+            Some(vec) => DomainMetadataState::Complete(
+                vec.into_iter()
+                    .map(|dm| (dm.domain().to_string(), dm))
+                    .collect(),
+            ),
+            None => DomainMetadataState::Untracked,
+        };
+        let set_transactions = match raw.set_transactions {
+            Some(vec) => SetTransactionState::Complete(
+                vec.into_iter()
+                    .map(|txn| (txn.app_id.clone(), txn))
+                    .collect(),
+            ),
+            None => SetTransactionState::Untracked,
+        };
+        Crc {
+            protocol: raw.protocol,
+            metadata: raw.metadata,
+            file_stats,
+            domain_metadata,
+            set_transactions,
+            in_commit_timestamp_opt: raw.in_commit_timestamp_opt,
+        }
+    }
+}
+
+impl From<Crc> for CrcRaw {
+    fn from(crc: Crc) -> Self {
+        // For non-Valid states, fall back to zeros and no histogram. The writer guards
+        // against writing non-Valid CRCs via FileStatsState::is_writable, so this branch
+        // is only hit for in-memory serde round-trips of degraded states (mostly tests).
+        let (num_files, table_size_bytes, file_size_histogram) = match crc.file_stats {
+            FileStatsState::Valid {
+                num_files,
+                table_size_bytes,
+                histogram,
+            } => (num_files, table_size_bytes, histogram),
+            _ => (0, 0, None),
+        };
+        // Only Complete maps serialize to arrays; Partial and Untracked omit the field
+        // (writers can only write Complete, enforced upstream).
+        let domain_metadata = match crc.domain_metadata {
+            DomainMetadataState::Complete(map) => Some(map.into_values().collect()),
+            _ => None,
+        };
+        let set_transactions = match crc.set_transactions {
+            SetTransactionState::Complete(map) => Some(map.into_values().collect()),
+            _ => None,
+        };
+        CrcRaw {
+            table_size_bytes,
+            num_files,
+            num_metadata: 1,
+            num_protocol: 1,
+            metadata: crc.metadata,
+            protocol: crc.protocol,
+            in_commit_timestamp_opt: crc.in_commit_timestamp_opt,
+            set_transactions,
+            domain_metadata,
+            file_size_histogram,
+        }
+    }
+}
+
+/// Deserializes an `Option<FileSizeHistogram>` and validates structural invariants via
+/// [`FileSizeHistogram::try_new`] (sorted boundaries, matching array lengths, etc.). Rejects
+/// malformed CRC files instead of producing a panicky histogram later.
+fn deserialize_validated_histogram<'de, D>(
     deserializer: D,
 ) -> Result<Option<FileSizeHistogram>, D::Error>
 where
-    D: Deserializer<'de>,
+    D: serde::Deserializer<'de>,
 {
     let opt: Option<FileSizeHistogram> = Option::deserialize(deserializer)?;
     match opt {
@@ -228,67 +280,23 @@ where
     }
 }
 
-/// Serialize `Option<HashMap<String, T>>` back to `Option<Vec<T>>` so the CRC JSON format
-/// uses an array (matching the Delta protocol spec).
-fn ser_opt_map_to_opt_vec<S, T>(
-    map: &Option<HashMap<String, T>>,
-    serializer: S,
-) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-    T: Serialize,
-{
-    match map {
-        None => serializer.serialize_none(),
-        Some(m) => m.values().collect::<Vec<_>>().serialize(serializer),
-    }
-}
-
-/// The [DeletedRecordCountsHistogram] object represents a histogram tracking the distribution of
-/// deleted record counts across files in the table. Each bin in the histogram represents a range
-/// of deletion counts and stores the number of files having that many deleted records.
-///
-/// The histogram bins correspond to the following ranges:
-/// Bin 0: [0, 0] (files with no deletions)
-/// Bin 1: [1, 9] (files with 1-9 deleted records)
-/// Bin 2: [10, 99] (files with 10-99 deleted records)
-/// Bin 3: [100, 999] (files with 100-999 deleted records)
-/// Bin 4: [1000, 9999] (files with 1,000-9,999 deleted records)
-/// Bin 5: [10000, 99999] (files with 10,000-99,999 deleted records)
-/// Bin 6: [100000, 999999] (files with 100,000-999,999 deleted records)
-/// Bin 7: [1000000, 9999999] (files with 1,000,000-9,999,999 deleted records)
-/// Bin 8: [10000000, 2147483646] (files with 10,000,000 to 2,147,483,646 deleted records)
-/// Bin 9: [2147483647, inf) (files with 2,147,483,647 or more deleted records)
-///
-/// [DeletedRecordCountsHistogram]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#deleted-record-counts-histogram-schema
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DeletedRecordCountsHistogram {
-    /// Array of size 10 where each element represents the count of files falling into a specific
-    /// deletion count range.
-    pub(crate) deleted_record_counts: Vec<i64>,
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
 
-    use super::Crc;
-    use crate::actions::{DomainMetadata, SetTransaction};
+    use super::*;
 
-    /// Helper to create a minimal `Crc` with only set_transactions and domain_metadata populated.
-    fn crc_with(
-        txns: Option<HashMap<String, SetTransaction>>,
-        domains: Option<HashMap<String, DomainMetadata>>,
-    ) -> Crc {
+    /// Helper: build a minimal `Crc` overriding only the DM and txn states.
+    fn crc_with(dm: DomainMetadataState, txns: SetTransactionState) -> Crc {
         Crc {
+            domain_metadata: dm,
             set_transactions: txns,
-            domain_metadata: domains,
             ..Default::default()
         }
     }
 
     #[test]
-    fn de_vec_to_map_produces_correct_keys_and_values() {
+    fn de_vec_to_complete_state_with_correct_keys() {
         let json = r#"{
             "tableSizeBytes": 0,
             "numFiles": 0,
@@ -315,27 +323,24 @@ mod tests {
 
         let crc: Crc = serde_json::from_str(json).unwrap();
 
-        let txns = crc.set_transactions.as_ref().unwrap();
+        let txns = crc.set_transactions.map().unwrap();
         assert_eq!(txns.len(), 2);
+        assert_eq!(txns["app-1"].version, 3);
+        assert_eq!(txns["app-1"].last_updated, Some(1000));
+        assert_eq!(txns["app-2"].version, 7);
+        assert_eq!(txns["app-2"].last_updated, None);
 
-        let txn1 = &txns["app-1"];
-        assert_eq!(txn1.app_id, "app-1");
-        assert_eq!(txn1.version, 3);
-        assert_eq!(txn1.last_updated, Some(1000));
-
-        let txn2 = &txns["app-2"];
-        assert_eq!(txn2.app_id, "app-2");
-        assert_eq!(txn2.version, 7);
-        assert_eq!(txn2.last_updated, None);
-
-        let domains = crc.domain_metadata.as_ref().unwrap();
+        let domains = crc.domain_metadata.map().unwrap();
         assert_eq!(domains.len(), 2);
         assert!(domains.contains_key("delta.rowTracking"));
         assert!(domains.contains_key("delta.clustering"));
+
+        // File stats from disk are always Valid.
+        assert_eq!(crc.file_stats_validity(), FileStatsValidity::Valid);
     }
 
     #[test]
-    fn de_null_deserializes_to_none() {
+    fn de_null_dm_and_txns_become_untracked() {
         let json = r#"{
             "tableSizeBytes": 0,
             "numFiles": 0,
@@ -354,12 +359,18 @@ mod tests {
             "domainMetadata": null
         }"#;
         let crc: Crc = serde_json::from_str(json).unwrap();
-        assert!(crc.set_transactions.is_none());
-        assert!(crc.domain_metadata.is_none());
+        assert!(matches!(
+            crc.set_transactions,
+            SetTransactionState::Untracked
+        ));
+        assert!(matches!(
+            crc.domain_metadata,
+            DomainMetadataState::Untracked
+        ));
     }
 
     #[test]
-    fn de_missing_field_deserializes_to_none() {
+    fn de_missing_dm_and_txn_fields_become_untracked() {
         let json = r#"{
             "tableSizeBytes": 0,
             "numFiles": 0,
@@ -376,37 +387,45 @@ mod tests {
             "protocol": {"minReaderVersion": 1, "minWriterVersion": 1}
         }"#;
         let crc: Crc = serde_json::from_str(json).unwrap();
-        assert!(crc.set_transactions.is_none());
-        assert!(crc.domain_metadata.is_none());
+        assert!(matches!(
+            crc.set_transactions,
+            SetTransactionState::Untracked
+        ));
+        assert!(matches!(
+            crc.domain_metadata,
+            DomainMetadataState::Untracked
+        ));
     }
 
     #[test]
-    fn ser_none_serializes_to_null() {
-        let crc = crc_with(None, None);
+    fn ser_untracked_omits_dm_and_txn_fields() {
+        // Untracked produces None in CrcRaw; with default serde, Option::None becomes null.
+        let crc = crc_with(
+            DomainMetadataState::Untracked,
+            SetTransactionState::Untracked,
+        );
         let json = serde_json::to_value(&crc).unwrap();
         assert!(json["setTransactions"].is_null());
         assert!(json["domainMetadata"].is_null());
     }
 
     #[test]
-    fn ser_map_round_trips_through_vec() {
+    fn ser_de_round_trip_complete_state() {
         let mut txns = HashMap::new();
         txns.insert(
             "app-1".to_string(),
             SetTransaction::new("app-1".to_string(), 5, Some(2000)),
         );
-        txns.insert(
-            "app-2".to_string(),
-            SetTransaction::new("app-2".to_string(), 10, None),
-        );
-
         let mut domains = HashMap::new();
         domains.insert(
             "delta.rowTracking".to_string(),
             DomainMetadata::new("delta.rowTracking".to_string(), "{}".to_string()),
         );
 
-        let original = crc_with(Some(txns), Some(domains));
+        let original = crc_with(
+            DomainMetadataState::Complete(domains),
+            SetTransactionState::Complete(txns),
+        );
 
         let json_str = serde_json::to_string(&original).unwrap();
         let deserialized: Crc = serde_json::from_str(&json_str).unwrap();
@@ -415,98 +434,57 @@ mod tests {
     }
 
     #[test]
-    fn round_trip_empty_maps() {
-        let original = crc_with(Some(HashMap::new()), Some(HashMap::new()));
+    fn ser_complete_empty_map_produces_empty_array() {
+        let original = crc_with(
+            DomainMetadataState::Complete(HashMap::new()),
+            SetTransactionState::Complete(HashMap::new()),
+        );
 
-        let json_str = serde_json::to_string(&original).unwrap();
-        let deserialized: Crc = serde_json::from_str(&json_str).unwrap();
-
-        assert_eq!(original, deserialized);
-
-        // Verify the JSON has empty arrays (not null)
         let json_value = serde_json::to_value(&original).unwrap();
         assert_eq!(json_value["setTransactions"], serde_json::json!([]));
         assert_eq!(json_value["domainMetadata"], serde_json::json!([]));
+
+        // Empty Complete round-trips to Complete (not Untracked).
+        let json_str = serde_json::to_string(&original).unwrap();
+        let deserialized: Crc = serde_json::from_str(&json_str).unwrap();
+        assert!(deserialized.domain_metadata.is_complete());
+        assert!(deserialized.set_transactions.is_complete());
     }
 
     #[test]
-    fn test_crc_with_multiple_domain_metadatas_and_set_transactions() {
-        let mut txns = HashMap::new();
-        txns.insert(
-            "streaming-app".to_string(),
-            SetTransaction::new("streaming-app".to_string(), 42, Some(1700000000)),
+    fn ser_partial_state_omits_fields() {
+        // Partial DM/txns shouldn't be persisted (writer guards via is_writable, but the
+        // serde mapping for Partial drops the field anyway).
+        let mut dm_map = HashMap::new();
+        dm_map.insert(
+            "d".to_string(),
+            DomainMetadata::new("d".to_string(), "{}".to_string()),
         );
-        txns.insert(
-            "batch-job".to_string(),
-            SetTransaction::new("batch-job".to_string(), 100, None),
+        let crc = crc_with(
+            DomainMetadataState::Partial(dm_map),
+            SetTransactionState::Untracked,
         );
-        txns.insert(
-            "etl-pipeline".to_string(),
-            SetTransaction::new("etl-pipeline".to_string(), 7, Some(1700001000)),
-        );
+        let json = serde_json::to_value(&crc).unwrap();
+        assert!(json["domainMetadata"].is_null());
+        assert!(json["setTransactions"].is_null());
+    }
 
-        let mut domains = HashMap::new();
-        domains.insert(
-            "delta.rowTracking".to_string(),
-            DomainMetadata::new(
-                "delta.rowTracking".to_string(),
-                r#"{"rowIdHighWaterMark":500}"#.to_string(),
-            ),
-        );
-        domains.insert(
-            "delta.clustering".to_string(),
-            DomainMetadata::new("delta.clustering".to_string(), "{}".to_string()),
-        );
-        domains.insert(
-            "custom.app".to_string(),
-            DomainMetadata::new("custom.app".to_string(), r#"{"version":"2.0"}"#.to_string()),
-        );
-
+    #[test]
+    fn ser_non_valid_file_stats_becomes_zeros() {
+        // Non-Valid CRCs should not normally be serialized (writer guards), but if forced
+        // (e.g. for in-memory debugging), file stats fields fall back to zero/None.
         let crc = Crc {
-            table_size_bytes: 1024 * 1024,
-            num_files: 10,
-            num_metadata: 1,
-            num_protocol: 1,
-            set_transactions: Some(txns),
-            domain_metadata: Some(domains),
+            file_stats: FileStatsState::Indeterminate,
             ..Default::default()
         };
-
-        // Round-trip through JSON
-        let json_str = serde_json::to_string(&crc).unwrap();
-        let deserialized: Crc = serde_json::from_str(&json_str).unwrap();
-
-        // Verify scalar fields survive the round-trip
-        assert_eq!(deserialized.table_size_bytes, 1024 * 1024);
-        assert_eq!(deserialized.num_files, 10);
-
-        // Verify all set transactions
-        let txns = deserialized.set_transactions.as_ref().unwrap();
-        assert_eq!(txns.len(), 3);
-        assert_eq!(txns["streaming-app"].version, 42);
-        assert_eq!(txns["streaming-app"].last_updated, Some(1700000000));
-        assert_eq!(txns["batch-job"].version, 100);
-        assert_eq!(txns["batch-job"].last_updated, None);
-        assert_eq!(txns["etl-pipeline"].version, 7);
-
-        // Verify all domain metadatas
-        let domains = deserialized.domain_metadata.as_ref().unwrap();
-        assert_eq!(domains.len(), 3);
-        assert!(domains.contains_key("delta.rowTracking"));
-        assert!(domains.contains_key("delta.clustering"));
-        assert!(domains.contains_key("custom.app"));
-        assert_eq!(
-            domains["custom.app"].configuration(),
-            r#"{"version":"2.0"}"#
-        );
-
-        // Verify the original and deserialized are equal
-        assert_eq!(crc, deserialized);
+        let json = serde_json::to_value(&crc).unwrap();
+        assert_eq!(json["numFiles"], 0);
+        assert_eq!(json["tableSizeBytes"], 0);
+        assert!(json.get("fileSizeHistogram").is_none());
     }
 
     // ===== File size histogram validation =====
 
-    /// Minimal CRC JSON with a file size histogram field spliced in.
     fn crc_json_with_histogram(histogram_json: &str) -> String {
         format!(
             r#"{{
@@ -529,19 +507,21 @@ mod tests {
     }
 
     #[test]
-    fn de_valid_file_size_histogram_succeeds() {
+    fn de_valid_histogram_lands_in_file_stats() {
         let json = crc_json_with_histogram(
             r#"{"sortedBinBoundaries": [0, 100, 200], "fileCounts": [1, 2, 3], "totalBytes": [10, 200, 300]}"#,
         );
         let crc: Crc = serde_json::from_str(&json).unwrap();
-        assert!(crc.file_size_histogram.is_some());
+        let stats = crc.file_stats().unwrap();
+        let hist = stats.file_size_histogram().unwrap();
+        assert_eq!(hist.sorted_bin_boundaries(), &[0, 100, 200]);
     }
 
     #[test]
-    fn de_null_file_size_histogram_deserializes_to_none() {
+    fn de_null_histogram_is_none() {
         let json = crc_json_with_histogram("null");
         let crc: Crc = serde_json::from_str(&json).unwrap();
-        assert!(crc.file_size_histogram.is_none());
+        assert!(crc.file_stats().unwrap().file_size_histogram().is_none());
     }
 
     use rstest::rstest;
@@ -559,8 +539,25 @@ mod tests {
     #[case::single_boundary(
         r#"{"sortedBinBoundaries": [0], "fileCounts": [0], "totalBytes": [0]}"#
     )]
-    fn de_malformed_file_size_histogram_returns_error(#[case] histogram_json: &str) {
+    fn de_malformed_histogram_returns_error(#[case] histogram_json: &str) {
         let json = crc_json_with_histogram(histogram_json);
         assert!(serde_json::from_str::<Crc>(&json).is_err());
+    }
+
+    #[test]
+    fn minimal_from_pm_produces_requires_checkpoint_read() {
+        let crc = Crc::minimal_from_pm(Protocol::default(), Metadata::default());
+        assert_eq!(
+            crc.file_stats_validity(),
+            FileStatsValidity::RequiresCheckpointRead
+        );
+        assert!(matches!(
+            crc.domain_metadata,
+            DomainMetadataState::Untracked
+        ));
+        assert!(matches!(
+            crc.set_transactions,
+            SetTransactionState::Untracked
+        ));
     }
 }

--- a/kernel/src/crc/mod.rs
+++ b/kernel/src/crc/mod.rs
@@ -10,27 +10,24 @@
 //! accidentally read an absolute file count from a relative delta because they live in
 //! different variants of [`FileStatsState`].
 //!
-//! On-disk JSON serialization goes through [`CrcRaw`], a flat 1:1 mirror of the Delta protocol
+//! On-disk JSON serialization goes through `CrcRaw`, a flat 1:1 mirror of the Delta protocol
 //! [CRC file] format. The mapping is mediated by `#[serde(from, into)]` on [`Crc`].
 //!
-//! [`CrcUpdate`] is the universal delta type. Every CRC mutation flows through
-//! [`Crc::apply`]. There are four ways to produce a `CrcUpdate`:
+//! `CrcUpdate` is the universal delta type. Every CRC mutation flows through `Crc::apply`.
+//! There are four ways to produce a `CrcUpdate`:
 //!
 //! 1. **Commit-time** ([`Transaction::commit`]): build from staged add/remove metadata + the
 //!    transaction's own commitInfo / DM / txn changes. Apply once to the read snapshot's CRC.
 //! 2. **Stale-CRC catch-up**: reverse-replay commits after the CRC version, accumulate, apply once.
 //!    The accumulator does first-seen-wins for per-key fields (DM/txn/P/M).
 //! 3. **No-CRC bootstrap**: same shape as (2) but the segment includes a checkpoint and the base is
-//!    built via [`CrcUpdate::into_fresh_crc`].
-//! 4. **Future: forward rebase / action reconciliation** (priorities 4 and 5 in the design plan):
-//!    different production strategies, same `Crc::apply`.
+//!    built via `CrcUpdate::into_fresh_crc`.
+//! 4. **Action reconciliation** for
+//!    [`Snapshot::load_file_stats`](crate::snapshot::Snapshot::load_file_stats): a wider visitor
+//!    with `(path, dv_unique_id)` deduplication recovers absolute file stats.
 //!
 //! [CRC file]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#version-checksum-file
 //! [`Transaction::commit`]: crate::transaction::Transaction::commit
-
-// Allow unreachable_pub because this module is pub when test-utils is enabled
-// but pub(crate) otherwise. The items need to be pub for integration tests.
-#![allow(unreachable_pub)]
 
 mod delta;
 mod file_size_histogram;
@@ -59,9 +56,9 @@ use crate::actions::{DomainMetadata, Metadata, Protocol, SetTransaction};
 /// completeness-tracked maps for domain metadata and set transactions
 /// ([`DomainMetadataState`] / [`SetTransactionState`]), and an optional in-commit timestamp.
 ///
-/// Mutated only via [`Crc::apply`]. Constructed either by deserializing from disk (via the
-/// [`CrcRaw`] serde intermediate), by [`Crc::minimal_from_pm`], or by
-/// [`CrcUpdate::into_fresh_crc`] (when there is no base CRC to apply onto).
+/// Mutated only via the kernel-internal `Crc::apply` mutator. Constructed either by
+/// deserializing from disk (via the `CrcRaw` serde intermediate), by `Crc::minimal_from_pm`,
+/// or by `CrcUpdate::into_fresh_crc` (when there is no base CRC to apply onto).
 ///
 /// This struct and its fields are `pub` so integration tests under the `test-utils` feature
 /// can inspect them; without `test-utils` the `crc` module is `pub(crate)`. See
@@ -143,7 +140,7 @@ impl Crc {
 /// The Delta protocol always writes complete data (or omits the field entirely): a CRC file
 /// on disk is `Valid` for file stats, and `Complete` (or absent) for DM and txns. The serde
 /// intermediate enforces this via deserialization (always to `Valid` / `Complete`) and via
-/// [`try_write_crc_file`] (which gates on [`FileStatsState::is_writable`]).
+/// `try_write_crc_file` (which gates on [`FileStatsState::is_writable`]).
 ///
 /// Fields with `#[serde(default)]` produce the appropriate "absent" state when missing or
 /// `null`: `set_transactions` and `domain_metadata` map to `Untracked`, `file_size_histogram`

--- a/kernel/src/crc/mod.rs
+++ b/kernel/src/crc/mod.rs
@@ -40,17 +40,14 @@ mod reader;
 mod state;
 mod writer;
 
-#[allow(unused)]
 pub(crate) use delta::CrcUpdate;
 pub use file_size_histogram::FileSizeHistogram;
 pub use file_stats::FileStats;
-#[allow(unused)]
 pub(crate) use file_stats::FileStatsDelta;
 pub(crate) use lazy::{CrcLoadResult, LazyCrc};
 pub(crate) use reader::try_read_crc_file;
 use serde::{Deserialize, Serialize};
 pub use state::{DomainMetadataState, FileStatsState, FileStatsValidity, SetTransactionState};
-#[allow(unused)]
 pub(crate) use writer::try_write_crc_file;
 
 use crate::actions::{DomainMetadata, Metadata, Protocol, SetTransaction};

--- a/kernel/src/crc/reader.rs
+++ b/kernel/src/crc/reader.rs
@@ -6,10 +6,12 @@ use crate::{DeltaResult, Engine, Error};
 
 /// Attempt to read and parse a CRC file.
 ///
-/// Reads raw bytes via the storage handler and deserializes with serde_json.
+/// Reads raw bytes via the storage handler and deserializes with serde_json into a [`Crc`]
+/// (via the [`CrcRaw`](super::CrcRaw) serde intermediate -- see `crc/mod.rs`).
 ///
-/// Returns `Ok(Crc)` on success, `Err` on any failure (file not readable, corrupt JSON, missing
-/// required fields). The caller should handle errors gracefully by falling back to log replay.
+/// Returns `Ok(Crc)` on success, `Err` on any failure (file not readable, corrupt JSON,
+/// missing required fields, malformed histogram). Callers should handle errors gracefully
+/// by falling back to log replay.
 pub(crate) fn try_read_crc_file(engine: &dyn Engine, crc_path: &ParsedLogPath) -> DeltaResult<Crc> {
     let storage = engine.storage_handler();
     let url = crc_path.location.as_url().clone();
@@ -45,14 +47,12 @@ mod tests {
         let table_root = test_table_root("./tests/data/crc-full/");
         let crc_path = ParsedLogPath::create_parsed_crc(&table_root, 0);
 
-        // Read and parse the CRC file
         let crc = try_read_crc_file(&engine, &crc_path).unwrap();
 
-        // Verify basic fields
-        assert_eq!(crc.table_size_bytes, 5259);
-        assert_eq!(crc.num_files, 10);
-        assert_eq!(crc.num_metadata, 1);
-        assert_eq!(crc.num_protocol, 1);
+        // File stats are loaded as Valid from disk.
+        let stats = crc.file_stats().unwrap();
+        assert_eq!(stats.table_size_bytes(), 5259);
+        assert_eq!(stats.num_files(), 10);
         assert_eq!(crc.in_commit_timestamp_opt, Some(1694758257000));
 
         // Verify protocol
@@ -105,9 +105,8 @@ mod tests {
         assert_eq!(crc.metadata, expected_metadata);
 
         // Verify domain metadatas
-        let dms = crc.domain_metadata.unwrap();
+        let dms = crc.domain_metadata.map().unwrap();
         assert_eq!(dms.len(), 3);
-
         assert!(dms["delta.clustering"]
             .configuration()
             .contains("clusteringColumns"));
@@ -117,28 +116,20 @@ mod tests {
         assert!(dms["myApp.metadata"].configuration().contains("key"));
 
         // Verify set transactions
-        let txns = crc.set_transactions.unwrap();
+        let txns = crc.set_transactions.map().unwrap();
         assert_eq!(txns.len(), 2);
         assert_eq!(txns["spark-app-1"].version, 42);
         assert_eq!(txns["spark-app-1"].last_updated, Some(1694758250000));
         assert_eq!(txns["streaming-job-abc"].version, 100);
         assert_eq!(txns["streaming-job-abc"].last_updated, Some(1694758255000));
 
-        // Verify file size histogram was deserialized (all 10 files in bin 0, < 8KB)
-        let hist = crc.file_size_histogram.as_ref().unwrap();
-        assert_eq!(hist.sorted_bin_boundaries.len(), 95);
-        assert_eq!(hist.file_counts[0], 10);
-        assert_eq!(hist.total_bytes[0], 5259);
-        // All other bins should be zero
-        assert!(hist.file_counts[1..].iter().all(|&c| c == 0));
-        assert!(hist.total_bytes[1..].iter().all(|&b| b == 0));
-
-        // Remaining skipped fields are still None (pending serde support on their types)
-        assert!(crc.txn_id.is_none());
-        assert!(crc.all_files.is_none());
-        assert!(crc.num_deleted_records_opt.is_none());
-        assert!(crc.num_deletion_vectors_opt.is_none());
-        assert!(crc.deleted_record_counts_histogram_opt.is_none());
+        // Verify file size histogram (all 10 files in bin 0, < 8KB)
+        let hist = stats.file_size_histogram().unwrap();
+        assert_eq!(hist.sorted_bin_boundaries().len(), 95);
+        assert_eq!(hist.file_counts()[0], 10);
+        assert_eq!(hist.total_bytes()[0], 5259);
+        assert!(hist.file_counts()[1..].iter().all(|&c| c == 0));
+        assert!(hist.total_bytes()[1..].iter().all(|&b| b == 0));
     }
 
     #[test]

--- a/kernel/src/crc/state.rs
+++ b/kernel/src/crc/state.rs
@@ -1,0 +1,365 @@
+//! State enums for CRC tracking: file stats, domain metadata, and set transactions.
+//!
+//! Each enum encodes both *what we know* and *how to recover what we don't*.
+//!
+//! - [`FileStatsState`] tracks the validity AND values of file statistics. The variant carries
+//!   exactly the data that variant requires: `Valid` carries `num_files`/`table_size_bytes`,
+//!   `RequiresCheckpointRead` carries `commit_delta_files`/`commit_delta_bytes`, etc. You cannot
+//!   accidentally read an absolute file count from a delta because they live in different variants
+//!   under different field names.
+//! - [`DomainMetadataState`] / [`SetTransactionState`] track the *completeness* of cached domain
+//!   metadata and set transactions. `Complete` is authoritative for misses (a domain not in the map
+//!   does not exist at this version). `Partial` means the map has known-correct entries from newer
+//!   commits but the older base did not track them, so a miss requires log replay. `Untracked`
+//!   means we have nothing -- every query requires log replay.
+
+use std::collections::HashMap;
+
+use super::file_size_histogram::FileSizeHistogram;
+use super::file_stats::FileStats;
+use crate::actions::{DomainMetadata, SetTransaction};
+
+// ============================================================================
+// File stats state
+// ============================================================================
+
+/// The state of file statistics for a CRC. Encodes both what we know and how to recover what
+/// we don't.
+///
+/// Each variant carries exactly the data that makes sense for that state. You cannot
+/// accidentally use a commit delta as an absolute file count because they live in different
+/// variants with different field names.
+///
+/// State transitions during [`Crc::apply`](super::Crc::apply):
+///
+/// | Current                | + safe op | + unsafe op   | + missing remove.size |
+/// |------------------------|-----------|---------------|-----------------------|
+/// | Valid                  | Valid     | Indeterminate | Untrackable           |
+/// | RequiresCheckpointRead | RCR       | Indeterminate | Untrackable           |
+/// | Indeterminate          | Indet.    | Indet.        | Untrackable           |
+/// | Untrackable            | Untrack.  | Untrack.      | Untrackable           |
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FileStatsState {
+    /// File stats are known-correct absolute totals. Histogram is optional: `Some` when the
+    /// base CRC had a histogram (or full replay produced one), `None` when the base CRC lacked
+    /// a histogram. Safe to write CRC to disk (with or without histogram).
+    Valid {
+        num_files: i64,
+        table_size_bytes: i64,
+        histogram: Option<FileSizeHistogram>,
+    },
+
+    /// Relative deltas from commits only. Checkpoint file actions were not read during snapshot
+    /// load. Recovery: read checkpoint adds via a checkpoint add scanner, merge with these
+    /// deltas. Currently unreachable in normal load paths -- reserved for future
+    /// connector-hint and time-travel optimisations.
+    RequiresCheckpointRead {
+        /// Net file count change from commits (NOT an absolute count).
+        commit_delta_files: i64,
+        /// Net byte change from commits (NOT an absolute byte total).
+        commit_delta_bytes: i64,
+        /// Delta histogram from commits (adds inserted, removes removed). Merge with the
+        /// checkpoint baseline histogram during recovery to get the complete histogram.
+        /// `None` when the replay did not produce histogram data.
+        commit_delta_histogram: Option<FileSizeHistogram>,
+    },
+
+    /// A non-incremental operation (like ANALYZE STATS) was encountered during replay. File
+    /// stats cannot be determined incrementally because files may have been re-added without
+    /// corresponding removes. Recovery: full add/remove deduplication (deferred --
+    /// [`Snapshot::load_file_stats`](crate::snapshot::Snapshot::load_file_stats) stub).
+    Indeterminate,
+
+    /// A remove action had a missing `size` field. Byte-level file stats are permanently
+    /// unrecoverable -- no amount of replay can recover the missing data.
+    Untrackable,
+}
+
+impl FileStatsState {
+    /// Returns absolute file stats if available.
+    ///
+    /// Returns `Some` only for [`Valid`](Self::Valid) (with or without histogram). Returns
+    /// `None` for all other variants.
+    pub fn file_stats(&self) -> Option<FileStats> {
+        match self {
+            Self::Valid {
+                num_files,
+                table_size_bytes,
+                histogram,
+            } => Some(FileStats {
+                num_files: *num_files,
+                table_size_bytes: *table_size_bytes,
+                file_size_histogram: histogram.clone(),
+            }),
+            _ => None,
+        }
+    }
+
+    /// Returns true if a CRC can be written to disk in this state. Only [`Valid`](Self::Valid)
+    /// is safe to write. The CRC will include the histogram if present, or omit it if `None`.
+    pub fn is_writable(&self) -> bool {
+        matches!(self, Self::Valid { .. })
+    }
+
+    /// Returns the simplified validity classification for cost inspection by connectors.
+    ///
+    /// Connectors use this to decide whether to write CRC synchronously, asynchronously, or
+    /// call [`Snapshot::load_file_stats`](crate::snapshot::Snapshot::load_file_stats) first.
+    pub fn validity(&self) -> FileStatsValidity {
+        match self {
+            Self::Valid { .. } => FileStatsValidity::Valid,
+            Self::RequiresCheckpointRead { .. } => FileStatsValidity::RequiresCheckpointRead,
+            Self::Indeterminate => FileStatsValidity::Indeterminate,
+            Self::Untrackable => FileStatsValidity::Untrackable,
+        }
+    }
+}
+
+impl Default for FileStatsState {
+    /// Default is `Valid` with zero counts and no histogram. This is the correct initial state
+    /// for a brand new table (CREATE TABLE) before any files are added.
+    fn default() -> Self {
+        Self::Valid {
+            num_files: 0,
+            table_size_bytes: 0,
+            histogram: None,
+        }
+    }
+}
+
+/// Simplified validity classification of file stats for cost inspection. Connectors use this
+/// to decide whether to write CRC synchronously, asynchronously, or recover stats first.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum FileStatsValidity {
+    /// Free: file stats are complete. Just call
+    /// [`Snapshot::write_checksum`](crate::snapshot::Snapshot::write_checksum).
+    #[default]
+    Valid,
+    /// Medium: need to read checkpoint file actions before writing CRC.
+    RequiresCheckpointRead,
+    /// Expensive: need full add/remove deduplication before writing CRC.
+    Indeterminate,
+    /// Impossible: missing `remove.size`, permanently unrecoverable.
+    Untrackable,
+}
+
+// ============================================================================
+// Domain metadata state
+// ============================================================================
+
+/// The completeness state of domain metadata in a CRC. Owns the underlying [`HashMap`].
+///
+/// Serde behaviour for CRC JSON files (handled at the [`Crc`](super::Crc) struct level):
+/// - `Complete(map)` serialises as `[...]` (array of DM entries)
+/// - `Partial` and `Untracked` both serialise as the field being absent (writers can only write
+///   `Complete` -- enforced in [`try_write_crc_file`](super::try_write_crc_file) indirectly via
+///   [`FileStatsState::is_writable`])
+/// - Deserialisation from `[...]` produces `Complete(map)`, from `null`/absent produces `Untracked`
+///   (CRC files on disk always have complete data or no data)
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum DomainMetadataState {
+    /// All domain metadata is known. The map is the complete set of active (non-removed)
+    /// domains. If a domain is not in the map, it does not exist at this table version.
+    Complete(HashMap<String, DomainMetadata>),
+
+    /// We have some domain metadata from the replay range (commits after the base CRC), but
+    /// the base CRC lacked a domain metadata field. Entries in the map are guaranteed correct
+    /// (they come from newer commits, which take priority). Querying a domain NOT in the map
+    /// requires log replay to determine if it exists in older commits.
+    Partial(HashMap<String, DomainMetadata>),
+
+    /// Domain metadata is not tracked. The CRC JSON field was absent, and no domain metadata
+    /// was found during replay. All queries require log replay.
+    #[default]
+    Untracked,
+}
+
+impl DomainMetadataState {
+    /// Returns the map if available (`Complete` or `Partial`), `None` if `Untracked`.
+    pub fn map(&self) -> Option<&HashMap<String, DomainMetadata>> {
+        match self {
+            Self::Complete(map) | Self::Partial(map) => Some(map),
+            Self::Untracked => None,
+        }
+    }
+
+    /// Returns true if the map is exhaustive (no log replay needed for misses).
+    pub fn is_complete(&self) -> bool {
+        matches!(self, Self::Complete(_))
+    }
+}
+
+// ============================================================================
+// Set transaction state
+// ============================================================================
+
+/// The completeness state of set transactions in a CRC. Owns the underlying [`HashMap`].
+///
+/// Same serde and completeness semantics as [`DomainMetadataState`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum SetTransactionState {
+    /// All set transactions are known. If an `app_id` is not in the map, no transaction
+    /// exists for it at this table version.
+    Complete(HashMap<String, SetTransaction>),
+
+    /// We have some set transactions from the replay range, but the base CRC lacked a set
+    /// transactions field. Entries are guaranteed correct (newest commits take priority).
+    /// Querying an `app_id` NOT in the map requires log replay.
+    Partial(HashMap<String, SetTransaction>),
+
+    /// Set transactions are not tracked. All queries require log replay.
+    #[default]
+    Untracked,
+}
+
+impl SetTransactionState {
+    /// Returns the map if available (`Complete` or `Partial`), `None` if `Untracked`.
+    pub fn map(&self) -> Option<&HashMap<String, SetTransaction>> {
+        match self {
+            Self::Complete(map) | Self::Partial(map) => Some(map),
+            Self::Untracked => None,
+        }
+    }
+
+    /// Returns true if the map is exhaustive (no log replay needed for misses).
+    pub fn is_complete(&self) -> bool {
+        matches!(self, Self::Complete(_))
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ===== FileStatsState =====
+
+    #[test]
+    fn test_valid_with_histogram_returns_file_stats() {
+        let state = FileStatsState::Valid {
+            num_files: 10,
+            table_size_bytes: 5000,
+            histogram: Some(FileSizeHistogram::create_default()),
+        };
+        let stats = state.file_stats().unwrap();
+        assert_eq!(stats.num_files(), 10);
+        assert_eq!(stats.table_size_bytes(), 5000);
+        assert!(stats.file_size_histogram().is_some());
+    }
+
+    #[test]
+    fn test_valid_without_histogram_returns_file_stats_with_no_histogram() {
+        let state = FileStatsState::Valid {
+            num_files: 10,
+            table_size_bytes: 5000,
+            histogram: None,
+        };
+        let stats = state.file_stats().unwrap();
+        assert_eq!(stats.num_files(), 10);
+        assert_eq!(stats.table_size_bytes(), 5000);
+        assert!(stats.file_size_histogram().is_none());
+    }
+
+    #[test]
+    fn test_non_valid_states_return_none_for_file_stats_and_are_not_writable() {
+        let states = [
+            FileStatsState::RequiresCheckpointRead {
+                commit_delta_files: 5,
+                commit_delta_bytes: 2000,
+                commit_delta_histogram: None,
+            },
+            FileStatsState::Indeterminate,
+            FileStatsState::Untrackable,
+        ];
+        for state in states {
+            assert!(state.file_stats().is_none(), "{state:?}");
+            assert!(!state.is_writable(), "{state:?}");
+        }
+    }
+
+    #[test]
+    fn test_valid_is_writable() {
+        assert!(FileStatsState::default().is_writable());
+    }
+
+    #[test]
+    fn test_validity_classification_matches_variant() {
+        assert_eq!(
+            FileStatsState::default().validity(),
+            FileStatsValidity::Valid
+        );
+        assert_eq!(
+            FileStatsState::RequiresCheckpointRead {
+                commit_delta_files: 0,
+                commit_delta_bytes: 0,
+                commit_delta_histogram: None,
+            }
+            .validity(),
+            FileStatsValidity::RequiresCheckpointRead
+        );
+        assert_eq!(
+            FileStatsState::Indeterminate.validity(),
+            FileStatsValidity::Indeterminate
+        );
+        assert_eq!(
+            FileStatsState::Untrackable.validity(),
+            FileStatsValidity::Untrackable
+        );
+    }
+
+    #[test]
+    fn test_default_is_valid_zero() {
+        let state = FileStatsState::default();
+        assert!(matches!(
+            state,
+            FileStatsState::Valid {
+                num_files: 0,
+                table_size_bytes: 0,
+                histogram: None,
+            }
+        ));
+    }
+
+    // ===== DomainMetadataState =====
+
+    #[test]
+    fn test_dm_state_map_accessor() {
+        let map = HashMap::from([(
+            "d".to_string(),
+            DomainMetadata::new("d".to_string(), "{}".to_string()),
+        )]);
+        assert!(DomainMetadataState::Complete(map.clone()).map().is_some());
+        assert!(DomainMetadataState::Partial(map).map().is_some());
+        assert!(DomainMetadataState::Untracked.map().is_none());
+    }
+
+    #[test]
+    fn test_dm_state_is_complete() {
+        assert!(DomainMetadataState::Complete(HashMap::new()).is_complete());
+        assert!(!DomainMetadataState::Partial(HashMap::new()).is_complete());
+        assert!(!DomainMetadataState::Untracked.is_complete());
+    }
+
+    // ===== SetTransactionState =====
+
+    #[test]
+    fn test_txn_state_map_accessor() {
+        let map = HashMap::from([(
+            "app".to_string(),
+            SetTransaction::new("app".to_string(), 1, None),
+        )]);
+        assert!(SetTransactionState::Complete(map.clone()).map().is_some());
+        assert!(SetTransactionState::Partial(map).map().is_some());
+        assert!(SetTransactionState::Untracked.map().is_none());
+    }
+
+    #[test]
+    fn test_txn_state_is_complete() {
+        assert!(SetTransactionState::Complete(HashMap::new()).is_complete());
+        assert!(!SetTransactionState::Partial(HashMap::new()).is_complete());
+        assert!(!SetTransactionState::Untracked.is_complete());
+    }
+}

--- a/kernel/src/crc/state.rs
+++ b/kernel/src/crc/state.rs
@@ -38,7 +38,11 @@ use crate::actions::{DomainMetadata, SetTransaction};
 /// | RequiresCheckpointRead | RCR       | Indeterminate | Untrackable           |
 /// | Indeterminate          | Indet.    | Indet.        | Untrackable           |
 /// | Untrackable            | Untrack.  | Untrack.      | Untrackable           |
+///
+/// Marked `#[non_exhaustive]` so future variants (e.g. additional recovery states for
+/// priority-5 work) can be added without breaking external matchers.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum FileStatsState {
     /// File stats are known-correct absolute totals. Histogram is optional: `Some` when the
     /// base CRC had a histogram (or full replay produced one), `None` when the base CRC lacked
@@ -129,7 +133,11 @@ impl Default for FileStatsState {
 
 /// Simplified validity classification of file stats for cost inspection. Connectors use this
 /// to decide whether to write CRC synchronously, asynchronously, or recover stats first.
+///
+/// Marked `#[non_exhaustive]` so future variants can be added without breaking external
+/// matchers.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum FileStatsValidity {
     /// Free: file stats are complete. Just call
     /// [`Snapshot::write_checksum`](crate::snapshot::Snapshot::write_checksum).
@@ -156,7 +164,10 @@ pub enum FileStatsValidity {
 ///   [`FileStatsState::is_writable`])
 /// - Deserialisation from `[...]` produces `Complete(map)`, from `null`/absent produces `Untracked`
 ///   (CRC files on disk always have complete data or no data)
+///
+/// `#[non_exhaustive]` so future variants are non-breaking.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum DomainMetadataState {
     /// All domain metadata is known. The map is the complete set of active (non-removed)
     /// domains. If a domain is not in the map, it does not exist at this table version.
@@ -196,7 +207,10 @@ impl DomainMetadataState {
 /// The completeness state of set transactions in a CRC. Owns the underlying [`HashMap`].
 ///
 /// Same serde and completeness semantics as [`DomainMetadataState`].
+///
+/// `#[non_exhaustive]` so future variants are non-breaking.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum SetTransactionState {
     /// All set transactions are known. If an `app_id` is not in the map, no transaction
     /// exists for it at this table version.

--- a/kernel/src/crc/state.rs
+++ b/kernel/src/crc/state.rs
@@ -70,8 +70,8 @@ pub enum FileStatsState {
 
     /// A non-incremental operation (like ANALYZE STATS) was encountered during replay. File
     /// stats cannot be determined incrementally because files may have been re-added without
-    /// corresponding removes. Recovery: full add/remove deduplication (deferred --
-    /// [`Snapshot::load_file_stats`](crate::snapshot::Snapshot::load_file_stats) stub).
+    /// corresponding removes. Recovery: full add/remove deduplication via
+    /// [`Snapshot::load_file_stats`](crate::snapshot::Snapshot::load_file_stats).
     Indeterminate,
 
     /// A remove action had a missing `size` field. Byte-level file stats are permanently

--- a/kernel/src/crc/state.rs
+++ b/kernel/src/crc/state.rs
@@ -30,7 +30,7 @@ use crate::actions::{DomainMetadata, SetTransaction};
 /// accidentally use a commit delta as an absolute file count because they live in different
 /// variants with different field names.
 ///
-/// State transitions during [`Crc::apply`](super::Crc::apply):
+/// State transitions during the kernel-internal `Crc::apply` mutator:
 ///
 /// | Current                | + safe op | + unsafe op   | + missing remove.size |
 /// |------------------------|-----------|---------------|-----------------------|
@@ -160,8 +160,7 @@ pub enum FileStatsValidity {
 /// Serde behaviour for CRC JSON files (handled at the [`Crc`](super::Crc) struct level):
 /// - `Complete(map)` serialises as `[...]` (array of DM entries)
 /// - `Partial` and `Untracked` both serialise as the field being absent (writers can only write
-///   `Complete` -- enforced in [`try_write_crc_file`](super::try_write_crc_file) indirectly via
-///   [`FileStatsState::is_writable`])
+///   `Complete` -- enforced by the writer via [`FileStatsState::is_writable`])
 /// - Deserialisation from `[...]` produces `Complete(map)`, from `null`/absent produces `Untracked`
 ///   (CRC files on disk always have complete data or no data)
 ///

--- a/kernel/src/crc/writer.rs
+++ b/kernel/src/crc/writer.rs
@@ -2,23 +2,24 @@
 
 use url::Url;
 
-use super::{Crc, FileStatsValidity};
+use super::Crc;
 use crate::utils::require;
 use crate::{DeltaResult, Engine, Error};
 
 /// Serialize and write a CRC file to storage.
 ///
-/// Serializes the [`Crc`] struct to JSON via serde and writes the raw bytes using the storage
-/// handler. Returns [`Error::ChecksumWriteUnsupported`] if file stats are not valid (a CRC file
-/// on disk must have correct stats). Per the Delta protocol, writers MUST NOT overwrite existing
-/// CRC files, so this always writes with `overwrite = false`. If the file already exists, returns
+/// Serializes the [`Crc`] struct to JSON via serde and writes the raw bytes using the
+/// storage handler. Returns [`Error::ChecksumWriteUnsupported`] if file stats are not in a
+/// writable state -- a CRC file on disk must have correct, complete file stats. Per the
+/// Delta protocol, writers MUST NOT overwrite existing CRC files, so this always writes
+/// with `overwrite = false`. If the file already exists, returns
 /// `Err(Error::FileAlreadyExists)`.
 pub(crate) fn try_write_crc_file(engine: &dyn Engine, path: &Url, crc: &Crc) -> DeltaResult<()> {
     require!(
-        crc.file_stats_validity == FileStatsValidity::Valid,
+        crc.file_stats.is_writable(),
         Error::ChecksumWriteUnsupported(format!(
             "Cannot write CRC file with {:?} file stats",
-            crc.file_stats_validity
+            crc.file_stats_validity()
         ))
     );
     let data = serde_json::to_vec(crc)?;
@@ -35,7 +36,7 @@ mod tests {
     use super::*;
     use crate::actions::{DomainMetadata, Protocol, SetTransaction};
     use crate::crc::reader::try_read_crc_file;
-    use crate::crc::{FileSizeHistogram, FileStatsValidity};
+    use crate::crc::{DomainMetadataState, FileSizeHistogram, FileStatsState, SetTransactionState};
     use crate::engine::default::DefaultEngineBuilder;
     use crate::object_store::memory::InMemory;
     use crate::path::{AsUrl, ParsedLogPath};
@@ -67,22 +68,21 @@ mod tests {
         let app_id = "testAppId".to_string();
         let set_transactions =
             HashMap::from([(app_id.clone(), SetTransaction::new(app_id, 1, Some(ict)))]);
-        // Build a histogram with 5 files totaling 1024 bytes, all in the first bin (< 8KB).
+        // 5 files totaling 1024 bytes, all in the first bin (< 8KB).
         let mut histogram = FileSizeHistogram::create_default();
         for size in [100, 200, 300, 150, 274] {
-            histogram.insert(size).unwrap(); // 5 files, 1024 bytes total
+            histogram.insert(size).unwrap();
         }
         Crc {
-            table_size_bytes: 1024,
-            num_files: 5,
-            num_metadata: 1,
-            num_protocol: 1,
             protocol,
-            txn_id: None,
             in_commit_timestamp_opt: Some(ict),
-            set_transactions: Some(set_transactions),
-            domain_metadata: Some(domain_metadata),
-            file_size_histogram: Some(histogram),
+            set_transactions: SetTransactionState::Complete(set_transactions),
+            domain_metadata: DomainMetadataState::Complete(domain_metadata),
+            file_stats: FileStatsState::Valid {
+                num_files: 5,
+                table_size_bytes: 1024,
+                histogram: Some(histogram),
+            },
             ..Default::default()
         }
     }
@@ -92,7 +92,6 @@ mod tests {
         let crc = test_crc();
         let json_bytes = serde_json::to_vec(&crc).unwrap();
         let round_tripped: Crc = serde_json::from_slice(&json_bytes).unwrap();
-
         assert_eq!(round_tripped, crc);
     }
 
@@ -201,23 +200,27 @@ mod tests {
     }
 
     #[test]
-    fn test_write_rejects_invalid_file_stats_with_checksum_write_unsupported() {
+    fn test_write_rejects_non_writable_file_stats_state() {
         let store = Arc::new(InMemory::new());
         let engine = DefaultEngineBuilder::new(store).build();
         let table_root = url::Url::parse("memory:///test_table/").unwrap();
         let crc_path = ParsedLogPath::create_parsed_crc(&table_root, 0);
 
-        for invalid_validity in [
-            FileStatsValidity::RequiresCheckpointRead,
-            FileStatsValidity::Indeterminate,
-            FileStatsValidity::Untrackable,
+        for non_writable in [
+            FileStatsState::RequiresCheckpointRead {
+                commit_delta_files: 0,
+                commit_delta_bytes: 0,
+                commit_delta_histogram: None,
+            },
+            FileStatsState::Indeterminate,
+            FileStatsState::Untrackable,
         ] {
             let mut crc = test_crc();
-            crc.file_stats_validity = invalid_validity;
+            crc.file_stats = non_writable.clone();
             let result = try_write_crc_file(&engine, crc_path.location.as_url(), &crc);
             assert!(
                 matches!(result, Err(Error::ChecksumWriteUnsupported(_))),
-                "should reject {invalid_validity:?} with ChecksumWriteUnsupported"
+                "should reject {non_writable:?} with ChecksumWriteUnsupported"
             );
         }
     }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -89,12 +89,13 @@ mod action_reconciliation;
 pub mod actions;
 pub mod checkpoint;
 pub mod committer;
-// Public under test-utils so integration tests can inspect CRC state via
-// Snapshot::get_current_crc_if_loaded_for_testing.
-#[cfg(feature = "test-utils")]
+// `pub` always: connector-facing types (`FileStats`, `FileStatsState`, `FileStatsValidity`,
+// `DomainMetadataState`, `SetTransactionState`, `Crc`) live here. Internal-only items
+// inside the module remain `pub(crate)`. The `#[cfg(any(test, feature = "test-utils"))]`
+// gating on `Snapshot::get_current_crc_if_loaded_for_testing` controls test-only access
+// to `&Crc`; the public type itself is always available so doc links resolve correctly
+// regardless of feature set.
 pub mod crc;
-#[cfg(not(feature = "test-utils"))]
-pub(crate) mod crc;
 pub mod engine_data;
 pub mod error;
 pub mod expressions;

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -115,12 +115,22 @@ impl LogSegment {
                 accumulator.metadata = Metadata::try_new_from_data(data)?;
             }
 
-            // DM, txn, file stats, commitInfo via visitor.
+            // DM, txn, file stats, commitInfo via visitor. The visitor tracks per-batch
+            // "saw file actions" and "saw commitInfo" flags so we can detect commit
+            // batches that had file actions but no commitInfo (provenance unknown).
             let mut visitor = CrcReplayVisitor {
                 is_log_batch: batch.is_log_batch,
+                batch_saw_file_action: false,
+                batch_saw_commit_info: false,
                 acc: &mut accumulator,
             };
             visitor.visit_rows_of(data)?;
+            // After this batch: if it was a commit batch, had file actions, but no
+            // commitInfo, the operation is unknown for that commit.
+            if batch.is_log_batch && visitor.batch_saw_file_action && !visitor.batch_saw_commit_info
+            {
+                accumulator.operation_safe = false;
+            }
         }
 
         Ok(accumulator.into_crc_update())
@@ -214,7 +224,9 @@ impl CrcReplayAccumulator {
             metadata: self.metadata,
             domain_metadata: self.domain_metadata,
             set_transactions: self.set_transactions,
-            in_commit_timestamp: self.in_commit_timestamp,
+            // Outer Some only if we actually saw a commitInfo with ICT data; otherwise
+            // None tells `Crc::apply` "I didn't observe ICT, leave the base alone."
+            in_commit_timestamp: self.ict_seen.then_some(self.in_commit_timestamp),
             operation_safe,
             has_missing_file_size: self.has_missing_remove_size,
         }
@@ -235,6 +247,14 @@ impl CrcReplayAccumulator {
 /// for vacuum and commitInfo is absent).
 struct CrcReplayVisitor<'a> {
     is_log_batch: bool,
+    /// Set to true if this batch contained any add or remove row. Used together with
+    /// `batch_saw_commit_info` to detect "commit batch with file actions but no
+    /// commitInfo" -- a configuration with unknown operation provenance, treated as
+    /// unsafe.
+    batch_saw_file_action: bool,
+    /// Set to true if this batch contained a commitInfo row. (Per protocol every commit
+    /// has at most one commitInfo, but a batch might span any subset of a commit's rows.)
+    batch_saw_commit_info: bool,
     acc: &'a mut CrcReplayAccumulator,
 }
 
@@ -288,6 +308,7 @@ impl RowVisitor for CrcReplayVisitor<'_> {
                 self.acc.net_histogram.insert(size)?;
                 if self.is_log_batch {
                     self.acc.has_log_action_inputs = true;
+                    self.batch_saw_file_action = true;
                 }
             }
 
@@ -301,6 +322,7 @@ impl RowVisitor for CrcReplayVisitor<'_> {
                 let remove_path: Option<String> = getters[1].get_opt(i, "remove.path")?;
                 if remove_path.is_some() {
                     self.acc.has_log_action_inputs = true;
+                    self.batch_saw_file_action = true;
                     let remove_size: Option<i64> = getters[2].get_opt(i, "remove.size")?;
                     if let Some(size) = remove_size {
                         self.acc.net_count -= 1;
@@ -346,13 +368,15 @@ impl RowVisitor for CrcReplayVisitor<'_> {
             }
 
             // commitInfo: only on commit batches. Operation safety + ICT.
-            // We use the operation column to detect commitInfo presence (every commitInfo
-            // action has an operation per protocol spec).
+            // We use the operation column to detect commitInfo presence (in practice
+            // every commitInfo action has an operation; missing operation is treated as
+            // 'no provenance' and flips operation_safe via the per-batch heuristic below).
             if self.is_log_batch {
                 let operation: Option<String> = getters[9].get_opt(i, "commitInfo.operation")?;
                 if let Some(op) = operation {
                     self.acc.has_commit_info = true;
                     self.acc.has_log_action_inputs = true;
+                    self.batch_saw_commit_info = true;
                     if !FileStatsDelta::is_incremental_safe(&op) {
                         self.acc.operation_safe = false;
                     }

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -41,7 +41,8 @@ use crate::{DeltaResult, Engine, RowVisitor};
 /// transitions file stats to [`Untrackable`](crate::crc::FileStatsState::Untrackable).
 ///
 /// Does NOT include `add.path` or DV columns -- the accumulator does no deduplication
-/// (Incremental strategy). Action reconciliation (priority 5) will need a wider schema.
+/// (Incremental strategy). Action reconciliation (`Snapshot::load_file_stats`) uses a
+/// separate visitor with a wider schema (see `file_stats_recovery.rs`).
 fn crc_replay_schema() -> DeltaResult<SchemaRef> {
     get_commit_schema().project(&[
         ADD_NAME,
@@ -62,7 +63,7 @@ impl LogSegment {
     /// to contain only commits in `(crc_version, end_version]`. The base CRC is the loaded
     /// value of `{crc_version}.crc` from disk.
     ///
-    /// Implements the universal invariant `Crc[X] + CrcUpdate(X→M) = Crc[M]`. The update
+    /// Implements the universal invariant `Crc[X] + CrcUpdate(X->M) = Crc[M]`. The update
     /// is produced via reverse iteration with first-seen-wins semantics; the apply is
     /// forward (last-write-wins, but the update has already pre-merged via first-seen).
     #[instrument(name = "log_seg.build_crc_from_stale", skip_all, err)]
@@ -205,7 +206,7 @@ impl CrcReplayAccumulator {
     fn into_crc_update(self) -> CrcUpdate {
         // Operation-safety classification:
         // - If we observed log inputs and saw commitInfo: trust `operation_safe`.
-        // - If we observed log inputs but no commitInfo: provenance unknown → unsafe.
+        // - If we observed log inputs but no commitInfo: provenance unknown -> unsafe.
         // - If we observed no log inputs (empty range or checkpoint-only): trivially safe -- there
         //   were no operations to evaluate.
         let operation_safe = if self.has_log_action_inputs {
@@ -430,7 +431,7 @@ mod tests {
     #[test]
     fn accumulator_with_log_inputs_but_no_commit_info_is_indeterminate() {
         // We saw add/remove rows in commit batches but no commitInfo: provenance unknown.
-        // Conservative: mark unsafe → file stats become Indeterminate via Crc::apply.
+        // Conservative: mark unsafe -> file stats become Indeterminate via Crc::apply.
         let mut acc = empty_acc();
         acc.has_log_action_inputs = true;
         // has_commit_info stays false.

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -144,23 +144,29 @@ struct CrcReplayAccumulator {
     domain_metadata: HashMap<String, DomainMetadata>,
     set_transactions: HashMap<String, SetTransaction>,
 
-    // Sums
-    add_count: i64,
-    add_bytes: i64,
-    add_histogram: FileSizeHistogram,
-    remove_count: i64,
-    remove_bytes: i64,
-    remove_histogram: FileSizeHistogram,
+    // Net file stats: a single histogram that adds increment and removes decrement (may
+    // contain negative bins for stale-replay ranges where some files were added before
+    // the range and removed within it). The non-negativity check happens in
+    // [`Crc::apply`](crate::crc::Crc::apply) when this delta is merged with the absolute
+    // base histogram, not here.
+    net_count: i64,
+    net_bytes: i64,
+    net_histogram: FileSizeHistogram,
 
     // Flags
     has_missing_remove_size: bool,
     /// Cumulative AND of operation safety across all observed commitInfo rows.
     /// `true` initially; flips to `false` on any unrecognized/unsafe op.
     operation_safe: bool,
-    /// Whether any commitInfo action was seen across all commit batches. If no commit had
-    /// a commitInfo (malformed log or no commits at all), operation safety cannot be
-    /// determined and we must treat file stats as Indeterminate.
+    /// Whether any commitInfo action was seen across all commit batches. Used together
+    /// with `has_log_action_inputs` to decide whether an empty / checkpoint-only segment
+    /// should be classified as safe (no work) or indeterminate (no provenance).
     has_commit_info: bool,
+    /// Whether the segment had any log-batch input that could plausibly carry an
+    /// operation: a commit's add, remove, or commitInfo row. If false, the segment is
+    /// either empty or checkpoint-only, in which case there were no operations to
+    /// evaluate -- a degenerate "trivially safe" case.
+    has_log_action_inputs: bool,
 
     // ICT: first-seen (newest) wins
     in_commit_timestamp: Option<i64>,
@@ -174,38 +180,35 @@ impl CrcReplayAccumulator {
             metadata: None,
             domain_metadata: HashMap::new(),
             set_transactions: HashMap::new(),
-            add_count: 0,
-            add_bytes: 0,
-            add_histogram: FileSizeHistogram::create_default(),
-            remove_count: 0,
-            remove_bytes: 0,
-            remove_histogram: FileSizeHistogram::create_default(),
+            net_count: 0,
+            net_bytes: 0,
+            net_histogram: FileSizeHistogram::create_default(),
             has_missing_remove_size: false,
             operation_safe: true,
             has_commit_info: false,
+            has_log_action_inputs: false,
             in_commit_timestamp: None,
             ict_seen: false,
         }
     }
 
     fn into_crc_update(self) -> CrcUpdate {
-        // If no commitInfo was seen across the entire replay, we cannot determine
-        // operation safety. Conservative: mark as unsafe, transitioning file stats to
-        // Indeterminate.
-        let operation_safe = self.operation_safe && self.has_commit_info;
-
-        // Build the net histogram by subtracting removes from adds. If subtraction fails
-        // (e.g. negative bins from a corrupted log) we drop the histogram. The resulting
-        // CRC is still valid; just the histogram is missing.
-        let net_histogram = negate_histogram(&self.remove_histogram)
-            .and_then(|negated| self.add_histogram.try_apply_delta(&negated))
-            .ok();
+        // Operation-safety classification:
+        // - If we observed log inputs and saw commitInfo: trust `operation_safe`.
+        // - If we observed log inputs but no commitInfo: provenance unknown → unsafe.
+        // - If we observed no log inputs (empty range or checkpoint-only): trivially safe -- there
+        //   were no operations to evaluate.
+        let operation_safe = if self.has_log_action_inputs {
+            self.operation_safe && self.has_commit_info
+        } else {
+            true
+        };
 
         CrcUpdate {
             file_stats: FileStatsDelta {
-                net_files: self.add_count - self.remove_count,
-                net_bytes: self.add_bytes - self.remove_bytes,
-                net_histogram,
+                net_files: self.net_count,
+                net_bytes: self.net_bytes,
+                net_histogram: Some(self.net_histogram),
             },
             protocol: self.protocol,
             metadata: self.metadata,
@@ -216,15 +219,6 @@ impl CrcReplayAccumulator {
             has_missing_file_size: self.has_missing_remove_size,
         }
     }
-}
-
-/// Negate every bin in a histogram (for subtraction via try_apply_delta). Returns an error
-/// if the input histogram fails its structural invariants -- in practice this can't happen
-/// because the input was already validated, but we propagate rather than panic.
-fn negate_histogram(hist: &FileSizeHistogram) -> DeltaResult<FileSizeHistogram> {
-    let counts: Vec<i64> = hist.file_counts().iter().map(|&c| -c).collect();
-    let bytes: Vec<i64> = hist.total_bytes().iter().map(|&b| -b).collect();
-    FileSizeHistogram::try_new(hist.sorted_bin_boundaries().to_vec(), counts, bytes)
 }
 
 // ============================================================================
@@ -286,16 +280,19 @@ impl RowVisitor for CrcReplayVisitor<'_> {
 
     fn visit<'a>(&mut self, row_count: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
         for i in 0..row_count {
-            // Add: contributes to file stats sums (commit and checkpoint Adds both).
+            // Add: contributes positively to file stats sums (commit AND checkpoint Adds).
             if let Some(size) = getters[0].get_opt(i, "add.size")? {
                 let size: i64 = size;
-                self.acc.add_count += 1;
-                self.acc.add_bytes += size;
-                self.acc.add_histogram.insert(size)?;
+                self.acc.net_count += 1;
+                self.acc.net_bytes += size;
+                self.acc.net_histogram.insert(size)?;
+                if self.is_log_batch {
+                    self.acc.has_log_action_inputs = true;
+                }
             }
 
-            // Remove: contributes only on commit batches (checkpoint Removes are
-            // tombstones for vacuum, not active state).
+            // Remove: contributes negatively, but only on commit batches (checkpoint
+            // Removes are vacuum tombstones, not active state).
             //
             // remove.path detects remove presence; remove.size is the bytes. If path is
             // set but size is null, that's a "remove with missing size" which transitions
@@ -303,11 +300,16 @@ impl RowVisitor for CrcReplayVisitor<'_> {
             if self.is_log_batch {
                 let remove_path: Option<String> = getters[1].get_opt(i, "remove.path")?;
                 if remove_path.is_some() {
+                    self.acc.has_log_action_inputs = true;
                     let remove_size: Option<i64> = getters[2].get_opt(i, "remove.size")?;
                     if let Some(size) = remove_size {
-                        self.acc.remove_count += 1;
-                        self.acc.remove_bytes += size;
-                        self.acc.remove_histogram.insert(size)?;
+                        self.acc.net_count -= 1;
+                        self.acc.net_bytes -= size;
+                        // FileSizeHistogram::remove correctly produces negative bin
+                        // counts when removes outweigh adds in a bin -- the net
+                        // histogram is a delta, not an absolute. The non-negativity
+                        // check happens later when Crc::apply merges with the base.
+                        self.acc.net_histogram.remove(size)?;
                     } else {
                         self.acc.has_missing_remove_size = true;
                     }
@@ -350,6 +352,7 @@ impl RowVisitor for CrcReplayVisitor<'_> {
                 let operation: Option<String> = getters[9].get_opt(i, "commitInfo.operation")?;
                 if let Some(op) = operation {
                     self.acc.has_commit_info = true;
+                    self.acc.has_log_action_inputs = true;
                     if !FileStatsDelta::is_incremental_safe(&op) {
                         self.acc.operation_safe = false;
                     }
@@ -381,24 +384,41 @@ mod tests {
     }
 
     #[test]
-    fn empty_accumulator_with_no_commit_info_produces_indeterminate_update() {
-        // No commitInfo was ever seen → operation_safe AND has_commit_info → false → !ok.
+    fn empty_accumulator_with_no_log_inputs_is_trivially_safe() {
+        // No log inputs at all = trivially safe (no operations to evaluate). This is the
+        // empty-stale-segment case (CRC at target version + segment_after_crc returns
+        // empty) and the checkpoint-only case (no commits in the segment).
         let acc = empty_acc();
         let update = acc.into_crc_update();
         assert!(update.protocol.is_none());
         assert!(update.metadata.is_none());
         assert!(update.domain_metadata.is_empty());
         assert!(update.set_transactions.is_empty());
-        assert!(!update.operation_safe);
+        assert!(
+            update.operation_safe,
+            "empty/checkpoint-only is trivially safe"
+        );
         assert!(!update.has_missing_file_size);
         assert_eq!(update.file_stats.net_files, 0);
         assert_eq!(update.file_stats.net_bytes, 0);
     }
 
     #[test]
+    fn accumulator_with_log_inputs_but_no_commit_info_is_indeterminate() {
+        // We saw add/remove rows in commit batches but no commitInfo: provenance unknown.
+        // Conservative: mark unsafe → file stats become Indeterminate via Crc::apply.
+        let mut acc = empty_acc();
+        acc.has_log_action_inputs = true;
+        // has_commit_info stays false.
+        let update = acc.into_crc_update();
+        assert!(!update.operation_safe);
+    }
+
+    #[test]
     fn accumulator_with_commit_info_and_safe_op_produces_safe_update() {
         let mut acc = empty_acc();
         acc.has_commit_info = true;
+        acc.has_log_action_inputs = true;
         acc.operation_safe = true;
         let update = acc.into_crc_update();
         assert!(update.operation_safe);
@@ -408,6 +428,7 @@ mod tests {
     fn accumulator_unsafe_op_propagates_to_update() {
         let mut acc = empty_acc();
         acc.has_commit_info = true;
+        acc.has_log_action_inputs = true;
         acc.operation_safe = false;
         let update = acc.into_crc_update();
         assert!(!update.operation_safe);
@@ -417,19 +438,19 @@ mod tests {
     fn accumulator_missing_remove_size_propagates_to_update() {
         let mut acc = empty_acc();
         acc.has_commit_info = true;
+        acc.has_log_action_inputs = true;
         acc.has_missing_remove_size = true;
         let update = acc.into_crc_update();
         assert!(update.has_missing_file_size);
     }
 
     #[test]
-    fn accumulator_sums_file_counts_and_bytes() {
+    fn accumulator_net_file_counts_and_bytes() {
         let mut acc = empty_acc();
         acc.has_commit_info = true;
-        acc.add_count = 5;
-        acc.add_bytes = 1500;
-        acc.remove_count = 2;
-        acc.remove_bytes = 400;
+        acc.has_log_action_inputs = true;
+        acc.net_count = 3;
+        acc.net_bytes = 1100;
         let update = acc.into_crc_update();
         assert_eq!(update.file_stats.net_files, 3);
         assert_eq!(update.file_stats.net_bytes, 1100);
@@ -452,8 +473,9 @@ mod tests {
 
         let mut acc = empty_acc();
         acc.has_commit_info = true;
-        acc.add_count = 1;
-        acc.add_bytes = 400;
+        acc.has_log_action_inputs = true;
+        acc.net_count = 1;
+        acc.net_bytes = 400;
         let update = acc.into_crc_update();
 
         base.apply(update);
@@ -464,12 +486,56 @@ mod tests {
     }
 
     #[test]
-    fn negate_histogram_inverts_signs() {
-        let mut h = FileSizeHistogram::create_default();
-        h.insert(100).unwrap();
-        h.insert(200).unwrap();
-        let neg = negate_histogram(&h).unwrap();
-        assert_eq!(neg.file_counts()[0], -2);
-        assert_eq!(neg.total_bytes()[0], -300);
+    fn accumulator_negative_histogram_bin_when_removes_outweigh_adds_in_range() {
+        // Stale-replay scenario: the segment removes more bytes in some bin than it
+        // adds (e.g. removing files that were added before the CRC base). The accumulator
+        // produces a delta histogram with negative bins; the merge with the base must
+        // result in a non-negative absolute histogram, but the delta itself can be
+        // negative. This test asserts the visitor correctly produces such a delta and
+        // that Crc::apply merges it correctly when the base has matching counts.
+        let mut acc = empty_acc();
+        acc.has_commit_info = true;
+        acc.has_log_action_inputs = true;
+        // Two adds (100, 200) and three removes (100, 100, 200) all fall in bin 0.
+        // Net: -1 file, -100 bytes in bin 0.
+        for sz in [100i64, 200] {
+            acc.net_count += 1;
+            acc.net_bytes += sz;
+            acc.net_histogram.insert(sz).unwrap();
+        }
+        for sz in [100i64, 100, 200] {
+            acc.net_count -= 1;
+            acc.net_bytes -= sz;
+            acc.net_histogram.remove(sz).unwrap();
+        }
+        let update = acc.into_crc_update();
+        assert_eq!(update.file_stats.net_files, -1);
+        assert_eq!(update.file_stats.net_bytes, -100);
+        let net_hist = update.file_stats.net_histogram.as_ref().unwrap();
+        assert_eq!(net_hist.file_counts()[0], -1);
+        assert_eq!(net_hist.total_bytes()[0], -100);
+
+        // Apply onto a base that has enough to absorb the removes.
+        let mut base = Crc {
+            file_stats: crate::crc::FileStatsState::Valid {
+                num_files: 5,
+                table_size_bytes: 1000,
+                histogram: Some({
+                    let mut h = FileSizeHistogram::create_default();
+                    for _ in 0..5 {
+                        h.insert(200).unwrap();
+                    }
+                    h
+                }),
+            },
+            ..Default::default()
+        };
+        base.apply(update);
+        let stats = base.file_stats().unwrap();
+        assert_eq!(stats.num_files(), 4); // 5 - 1
+        assert_eq!(stats.table_size_bytes(), 900); // 1000 - 100
+        let merged = stats.file_size_histogram().unwrap();
+        assert_eq!(merged.file_counts()[0], 4);
+        assert_eq!(merged.total_bytes()[0], 900);
     }
 }

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -1,0 +1,475 @@
+//! Reverse log replay accumulator for CRC builds.
+//!
+//! Builds a [`CrcUpdate`] by reading commits and (optionally) a checkpoint in reverse via
+//! [`LogSegment::read_actions`]. The accumulator does first-seen-wins for per-key fields
+//! (Protocol, Metadata, DomainMetadata, SetTransaction, ICT) so that the resulting
+//! `CrcUpdate` is *equivalent* to a forward-produced delta — the apply step
+//! ([`Crc::apply`](crate::crc::Crc::apply)) is direction-agnostic and reads "old + delta =
+//! new" regardless of how the delta was produced.
+//!
+//! Two entry points on [`LogSegment`]:
+//!
+//! - [`build_crc_from_stale`](LogSegment::build_crc_from_stale): segment is `(X, M]` (commits after
+//!   stale CRC); applies the accumulated update onto the loaded base CRC, producing `Crc[M]`.
+//! - [`build_crc_from_scratch`](LogSegment::build_crc_from_scratch): segment is `[0, M]` or
+//!   `(checkpoint_C, M] + checkpoint_C`; calls [`CrcUpdate::into_fresh_crc`] to produce `Crc[M]`
+//!   from the captured complete state.
+
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+use tracing::instrument;
+
+use super::LogSegment;
+use crate::actions::{
+    get_commit_schema, DomainMetadata, Metadata, Protocol, SetTransaction, ADD_NAME,
+    COMMIT_INFO_NAME, DOMAIN_METADATA_NAME, METADATA_NAME, PROTOCOL_NAME, REMOVE_NAME,
+    SET_TRANSACTION_NAME,
+};
+use crate::crc::{Crc, CrcUpdate, FileSizeHistogram, FileStatsDelta};
+use crate::engine_data::{GetData, TypedGetData as _};
+use crate::schema::{ColumnName, ColumnNamesAndTypes, DataType, SchemaRef};
+use crate::{DeltaResult, Engine, RowVisitor};
+
+/// Schema for CRC reverse replay. Reads file stats columns (add.size, remove.path,
+/// remove.size), full Protocol/Metadata, DomainMetadata, SetTransaction, and commitInfo
+/// (operation + inCommitTimestamp) from each batch.
+///
+/// `remove.path` is included alongside `remove.size` to detect removes whose `size` is
+/// null: if `path` is set but `size` is null, that's a "remove with missing size" which
+/// transitions file stats to [`Untrackable`](crate::crc::FileStatsState::Untrackable).
+///
+/// Does NOT include `add.path` or DV columns -- the accumulator does no deduplication
+/// (Incremental strategy). Action reconciliation (priority 5) will need a wider schema.
+fn crc_replay_schema() -> DeltaResult<SchemaRef> {
+    get_commit_schema().project(&[
+        ADD_NAME,
+        REMOVE_NAME,
+        PROTOCOL_NAME,
+        METADATA_NAME,
+        SET_TRANSACTION_NAME,
+        DOMAIN_METADATA_NAME,
+        COMMIT_INFO_NAME,
+    ])
+}
+
+impl LogSegment {
+    /// Build a complete [`Crc`] by replaying commits after a stale CRC and applying the
+    /// accumulated update onto the loaded base.
+    ///
+    /// The segment should already be pruned via [`segment_after_crc`](Self::segment_after_crc)
+    /// to contain only commits in `(crc_version, end_version]`. The base CRC is the loaded
+    /// value of `{crc_version}.crc` from disk.
+    ///
+    /// Implements the universal invariant `Crc[X] + CrcUpdate(X→M) = Crc[M]`. The update
+    /// is produced via reverse iteration with first-seen-wins semantics; the apply is
+    /// forward (last-write-wins, but the update has already pre-merged via first-seen).
+    #[instrument(name = "log_seg.build_crc_from_stale", skip_all, err)]
+    pub(crate) fn build_crc_from_stale(
+        &self,
+        engine: &dyn Engine,
+        base: &mut Crc,
+    ) -> DeltaResult<()> {
+        let update = self.replay_for_crc_update(engine)?;
+        base.apply(update);
+        Ok(())
+    }
+
+    /// Build a fresh [`Crc`] from scratch by replaying the entire log segment (checkpoint +
+    /// commits). Used when no CRC file is on disk.
+    ///
+    /// The resulting CRC has:
+    /// - P&M from the log (first-seen in reverse = newest = correct for end_version)
+    /// - DM/txns: [`Complete`](crate::crc::DomainMetadataState::Complete) (full state was captured)
+    /// - File stats: [`Valid`](crate::crc::FileStatsState::Valid) when no unsafe ops were seen and
+    ///   no remove had a missing size
+    ///
+    /// Returns `Err` if Protocol or Metadata cannot be found in the log (a malformed log).
+    #[instrument(name = "log_seg.build_crc_from_scratch", skip_all, err)]
+    pub(crate) fn build_crc_from_scratch(&self, engine: &dyn Engine) -> DeltaResult<Crc> {
+        self.replay_for_crc_update(engine)?.into_fresh_crc()
+    }
+
+    /// Reverse-replay this segment and accumulate a [`CrcUpdate`].
+    ///
+    /// For each [`ActionsBatch`](crate::log_replay::ActionsBatch) returned by
+    /// [`read_actions`](Self::read_actions):
+    /// - Extract Protocol and Metadata via [`Protocol::try_new_from_data`] /
+    ///   [`Metadata::try_new_from_data`] (first-seen-wins, since the accumulator skips if already
+    ///   populated).
+    /// - Run [`CrcReplayVisitor`] for DM, txn, file stats, and commitInfo extraction.
+    fn replay_for_crc_update(&self, engine: &dyn Engine) -> DeltaResult<CrcUpdate> {
+        let schema = crc_replay_schema()?;
+        let mut accumulator = CrcReplayAccumulator::new();
+
+        for batch_result in self.read_actions(engine, schema)? {
+            let batch = batch_result?;
+            let data = batch.actions.as_ref();
+
+            // Protocol / Metadata: first-seen-wins (skip if already found).
+            if accumulator.protocol.is_none() {
+                accumulator.protocol = Protocol::try_new_from_data(data)?;
+            }
+            if accumulator.metadata.is_none() {
+                accumulator.metadata = Metadata::try_new_from_data(data)?;
+            }
+
+            // DM, txn, file stats, commitInfo via visitor.
+            let mut visitor = CrcReplayVisitor {
+                is_log_batch: batch.is_log_batch,
+                acc: &mut accumulator,
+            };
+            visitor.visit_rows_of(data)?;
+        }
+
+        Ok(accumulator.into_crc_update())
+    }
+}
+
+// ============================================================================
+// Accumulator
+// ============================================================================
+
+/// In-progress state for a single CRC reverse replay. Once all batches are absorbed, call
+/// [`into_crc_update`](Self::into_crc_update) to finalize.
+///
+/// First-seen-wins semantics for per-key fields means: in reverse iteration, the FIRST
+/// time we see a Protocol/Metadata/DM/txn/ICT, that value wins. This is equivalent to
+/// "newest wins at end_version" because we read newest-first.
+struct CrcReplayAccumulator {
+    // First-seen-wins (per key)
+    protocol: Option<Protocol>,
+    metadata: Option<Metadata>,
+    domain_metadata: HashMap<String, DomainMetadata>,
+    set_transactions: HashMap<String, SetTransaction>,
+
+    // Sums
+    add_count: i64,
+    add_bytes: i64,
+    add_histogram: FileSizeHistogram,
+    remove_count: i64,
+    remove_bytes: i64,
+    remove_histogram: FileSizeHistogram,
+
+    // Flags
+    has_missing_remove_size: bool,
+    /// Cumulative AND of operation safety across all observed commitInfo rows.
+    /// `true` initially; flips to `false` on any unrecognized/unsafe op.
+    operation_safe: bool,
+    /// Whether any commitInfo action was seen across all commit batches. If no commit had
+    /// a commitInfo (malformed log or no commits at all), operation safety cannot be
+    /// determined and we must treat file stats as Indeterminate.
+    has_commit_info: bool,
+
+    // ICT: first-seen (newest) wins
+    in_commit_timestamp: Option<i64>,
+    ict_seen: bool,
+}
+
+impl CrcReplayAccumulator {
+    fn new() -> Self {
+        Self {
+            protocol: None,
+            metadata: None,
+            domain_metadata: HashMap::new(),
+            set_transactions: HashMap::new(),
+            add_count: 0,
+            add_bytes: 0,
+            add_histogram: FileSizeHistogram::create_default(),
+            remove_count: 0,
+            remove_bytes: 0,
+            remove_histogram: FileSizeHistogram::create_default(),
+            has_missing_remove_size: false,
+            operation_safe: true,
+            has_commit_info: false,
+            in_commit_timestamp: None,
+            ict_seen: false,
+        }
+    }
+
+    fn into_crc_update(self) -> CrcUpdate {
+        // If no commitInfo was seen across the entire replay, we cannot determine
+        // operation safety. Conservative: mark as unsafe, transitioning file stats to
+        // Indeterminate.
+        let operation_safe = self.operation_safe && self.has_commit_info;
+
+        // Build the net histogram by subtracting removes from adds. If subtraction fails
+        // (e.g. negative bins from a corrupted log) we drop the histogram. The resulting
+        // CRC is still valid; just the histogram is missing.
+        let net_histogram = negate_histogram(&self.remove_histogram)
+            .and_then(|negated| self.add_histogram.try_apply_delta(&negated))
+            .ok();
+
+        CrcUpdate {
+            file_stats: FileStatsDelta {
+                net_files: self.add_count - self.remove_count,
+                net_bytes: self.add_bytes - self.remove_bytes,
+                net_histogram,
+            },
+            protocol: self.protocol,
+            metadata: self.metadata,
+            domain_metadata: self.domain_metadata,
+            set_transactions: self.set_transactions,
+            in_commit_timestamp: self.in_commit_timestamp,
+            operation_safe,
+            has_missing_file_size: self.has_missing_remove_size,
+        }
+    }
+}
+
+/// Negate every bin in a histogram (for subtraction via try_apply_delta). Returns an error
+/// if the input histogram fails its structural invariants -- in practice this can't happen
+/// because the input was already validated, but we propagate rather than panic.
+fn negate_histogram(hist: &FileSizeHistogram) -> DeltaResult<FileSizeHistogram> {
+    let counts: Vec<i64> = hist.file_counts().iter().map(|&c| -c).collect();
+    let bytes: Vec<i64> = hist.total_bytes().iter().map(|&b| -b).collect();
+    FileSizeHistogram::try_new(hist.sorted_bin_boundaries().to_vec(), counts, bytes)
+}
+
+// ============================================================================
+// Visitor
+// ============================================================================
+
+/// Single-batch visitor that extracts CRC-relevant fields from one
+/// [`ActionsBatch`](crate::log_replay::ActionsBatch). Protocol and Metadata are handled
+/// separately (via `try_new_from_data` before this visitor runs); this visitor handles
+/// DomainMetadata, SetTransaction, file stats, and commitInfo.
+///
+/// The `is_log_batch` flag distinguishes commit-file batches (where remove actions and
+/// commitInfo are meaningful) from checkpoint batches (where remove actions are tombstones
+/// for vacuum and commitInfo is absent).
+struct CrcReplayVisitor<'a> {
+    is_log_batch: bool,
+    acc: &'a mut CrcReplayAccumulator,
+}
+
+impl RowVisitor for CrcReplayVisitor<'_> {
+    fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
+        static NAMES_AND_TYPES: LazyLock<ColumnNamesAndTypes> = LazyLock::new(|| {
+            (
+                vec![
+                    // File stats
+                    ColumnName::new(["add", "size"]),    // 0
+                    ColumnName::new(["remove", "path"]), // 1: detect remove presence
+                    ColumnName::new(["remove", "size"]), // 2
+                    // DomainMetadata
+                    ColumnName::new(["domainMetadata", "domain"]), // 3
+                    ColumnName::new(["domainMetadata", "configuration"]), // 4
+                    ColumnName::new(["domainMetadata", "removed"]), // 5
+                    // SetTransaction
+                    ColumnName::new(["txn", "appId"]),       // 6
+                    ColumnName::new(["txn", "version"]),     // 7
+                    ColumnName::new(["txn", "lastUpdated"]), // 8
+                    // commitInfo
+                    ColumnName::new(["commitInfo", "operation"]), // 9
+                    ColumnName::new(["commitInfo", "inCommitTimestamp"]), // 10
+                ],
+                vec![
+                    DataType::LONG,    // add.size
+                    DataType::STRING,  // remove.path
+                    DataType::LONG,    // remove.size
+                    DataType::STRING,  // dm.domain
+                    DataType::STRING,  // dm.configuration
+                    DataType::BOOLEAN, // dm.removed
+                    DataType::STRING,  // txn.appId
+                    DataType::LONG,    // txn.version
+                    DataType::LONG,    // txn.lastUpdated
+                    DataType::STRING,  // commitInfo.operation
+                    DataType::LONG,    // commitInfo.inCommitTimestamp
+                ],
+            )
+                .into()
+        });
+        NAMES_AND_TYPES.as_ref()
+    }
+
+    fn visit<'a>(&mut self, row_count: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
+        for i in 0..row_count {
+            // Add: contributes to file stats sums (commit and checkpoint Adds both).
+            if let Some(size) = getters[0].get_opt(i, "add.size")? {
+                let size: i64 = size;
+                self.acc.add_count += 1;
+                self.acc.add_bytes += size;
+                self.acc.add_histogram.insert(size)?;
+            }
+
+            // Remove: contributes only on commit batches (checkpoint Removes are
+            // tombstones for vacuum, not active state).
+            //
+            // remove.path detects remove presence; remove.size is the bytes. If path is
+            // set but size is null, that's a "remove with missing size" which transitions
+            // file stats to Untrackable.
+            if self.is_log_batch {
+                let remove_path: Option<String> = getters[1].get_opt(i, "remove.path")?;
+                if remove_path.is_some() {
+                    let remove_size: Option<i64> = getters[2].get_opt(i, "remove.size")?;
+                    if let Some(size) = remove_size {
+                        self.acc.remove_count += 1;
+                        self.acc.remove_bytes += size;
+                        self.acc.remove_histogram.insert(size)?;
+                    } else {
+                        self.acc.has_missing_remove_size = true;
+                    }
+                }
+            }
+
+            // DomainMetadata: first-seen-wins per domain.
+            let dm_domain: Option<String> = getters[3].get_opt(i, "domainMetadata.domain")?;
+            if let Some(domain) = dm_domain {
+                if let Entry::Vacant(e) = self.acc.domain_metadata.entry(domain.clone()) {
+                    let configuration: String = getters[4]
+                        .get_opt(i, "domainMetadata.configuration")?
+                        .unwrap_or_default();
+                    let removed: bool = getters[5]
+                        .get_opt(i, "domainMetadata.removed")?
+                        .unwrap_or(false);
+                    let dm = if removed {
+                        DomainMetadata::remove(domain, configuration)
+                    } else {
+                        DomainMetadata::new(domain, configuration)
+                    };
+                    e.insert(dm);
+                }
+            }
+
+            // SetTransaction: first-seen-wins per app_id.
+            let txn_app_id: Option<String> = getters[6].get_opt(i, "txn.appId")?;
+            if let Some(app_id) = txn_app_id {
+                if let Entry::Vacant(e) = self.acc.set_transactions.entry(app_id.clone()) {
+                    let version: i64 = getters[7].get(i, "txn.version")?;
+                    let last_updated: Option<i64> = getters[8].get_opt(i, "txn.lastUpdated")?;
+                    e.insert(SetTransaction::new(app_id, version, last_updated));
+                }
+            }
+
+            // commitInfo: only on commit batches. Operation safety + ICT.
+            // We use the operation column to detect commitInfo presence (every commitInfo
+            // action has an operation per protocol spec).
+            if self.is_log_batch {
+                let operation: Option<String> = getters[9].get_opt(i, "commitInfo.operation")?;
+                if let Some(op) = operation {
+                    self.acc.has_commit_info = true;
+                    if !FileStatsDelta::is_incremental_safe(&op) {
+                        self.acc.operation_safe = false;
+                    }
+
+                    // ICT: first commitInfo seen in reverse = newest commit's ICT.
+                    if !self.acc.ict_seen {
+                        self.acc.in_commit_timestamp =
+                            getters[10].get_opt(i, "commitInfo.inCommitTimestamp")?;
+                        self.acc.ict_seen = true;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crc::FileStatsValidity;
+
+    fn empty_acc() -> CrcReplayAccumulator {
+        CrcReplayAccumulator::new()
+    }
+
+    #[test]
+    fn empty_accumulator_with_no_commit_info_produces_indeterminate_update() {
+        // No commitInfo was ever seen → operation_safe AND has_commit_info → false → !ok.
+        let acc = empty_acc();
+        let update = acc.into_crc_update();
+        assert!(update.protocol.is_none());
+        assert!(update.metadata.is_none());
+        assert!(update.domain_metadata.is_empty());
+        assert!(update.set_transactions.is_empty());
+        assert!(!update.operation_safe);
+        assert!(!update.has_missing_file_size);
+        assert_eq!(update.file_stats.net_files, 0);
+        assert_eq!(update.file_stats.net_bytes, 0);
+    }
+
+    #[test]
+    fn accumulator_with_commit_info_and_safe_op_produces_safe_update() {
+        let mut acc = empty_acc();
+        acc.has_commit_info = true;
+        acc.operation_safe = true;
+        let update = acc.into_crc_update();
+        assert!(update.operation_safe);
+    }
+
+    #[test]
+    fn accumulator_unsafe_op_propagates_to_update() {
+        let mut acc = empty_acc();
+        acc.has_commit_info = true;
+        acc.operation_safe = false;
+        let update = acc.into_crc_update();
+        assert!(!update.operation_safe);
+    }
+
+    #[test]
+    fn accumulator_missing_remove_size_propagates_to_update() {
+        let mut acc = empty_acc();
+        acc.has_commit_info = true;
+        acc.has_missing_remove_size = true;
+        let update = acc.into_crc_update();
+        assert!(update.has_missing_file_size);
+    }
+
+    #[test]
+    fn accumulator_sums_file_counts_and_bytes() {
+        let mut acc = empty_acc();
+        acc.has_commit_info = true;
+        acc.add_count = 5;
+        acc.add_bytes = 1500;
+        acc.remove_count = 2;
+        acc.remove_bytes = 400;
+        let update = acc.into_crc_update();
+        assert_eq!(update.file_stats.net_files, 3);
+        assert_eq!(update.file_stats.net_bytes, 1100);
+    }
+
+    #[test]
+    fn replay_update_applied_to_base_produces_combined_crc() {
+        // Simulates: load Crc[X] from disk, replay X+1..M, apply.
+        // Asserts the universal equation: Crc[X] + Update = Crc[M].
+        let base_json = r#"{
+            "tableSizeBytes": 300,
+            "numFiles": 2,
+            "numMetadata": 1,
+            "numProtocol": 1,
+            "metadata": {"id":"t","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[]}","partitionColumns":[],"configuration":{},"createdTime":0},
+            "protocol": {"minReaderVersion": 1, "minWriterVersion": 2}
+        }"#;
+        let mut base: Crc = serde_json::from_str(base_json).unwrap();
+        assert_eq!(base.file_stats_validity(), FileStatsValidity::Valid);
+
+        let mut acc = empty_acc();
+        acc.has_commit_info = true;
+        acc.add_count = 1;
+        acc.add_bytes = 400;
+        let update = acc.into_crc_update();
+
+        base.apply(update);
+
+        let stats = base.file_stats().unwrap();
+        assert_eq!(stats.num_files(), 3);
+        assert_eq!(stats.table_size_bytes(), 700);
+    }
+
+    #[test]
+    fn negate_histogram_inverts_signs() {
+        let mut h = FileSizeHistogram::create_default();
+        h.insert(100).unwrap();
+        h.insert(200).unwrap();
+        let neg = negate_histogram(&h).unwrap();
+        assert_eq!(neg.file_counts()[0], -2);
+        assert_eq!(neg.total_bytes()[0], -300);
+    }
+}

--- a/kernel/src/log_segment/crc_tests.rs
+++ b/kernel/src/log_segment/crc_tests.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use serde_json::json;
-use test_utils::{assert_result_error_with_message, delta_path_for_version};
+use test_utils::delta_path_for_version;
 use url::Url;
 
 use crate::actions::{CommitInfo, Format, Metadata, Protocol};
@@ -577,7 +577,12 @@ async fn test_ict_from_crc_at_snapshot_version() {
 }
 
 #[tokio::test]
-async fn test_ict_errors_when_crc_has_no_ict() {
+async fn test_ict_falls_back_to_commit_file_when_crc_has_no_ict() {
+    // Under the eager Arc<Crc> design, a snapshot's CRC always exists. If the loaded CRC
+    // happens to have no ICT (None), get_in_commit_timestamp falls back to reading the
+    // commit file directly rather than erroring. This is more lenient than the old
+    // behaviour but better matches user expectations -- an absent ICT in the CRC is not a
+    // hard error if the commit file has the data.
     let setup = CrcReadTest::new()
         .v2_checkpoint(0, protocol_v2_ict(), metadata_ict())
         .delta_with_ict(1, 2000)
@@ -589,10 +594,6 @@ async fn test_ict_errors_when_crc_has_no_ict() {
         .build(&setup.engine)
         .unwrap();
 
-    let result = snapshot.get_in_commit_timestamp(&setup.engine);
-
-    assert_result_error_with_message(
-        result,
-        "In-Commit Timestamp not found in CRC file at version 1",
-    );
+    let ict = snapshot.get_in_commit_timestamp(&setup.engine).unwrap();
+    assert_eq!(ict, Some(2000));
 }

--- a/kernel/src/log_segment/file_stats_recovery.rs
+++ b/kernel/src/log_segment/file_stats_recovery.rs
@@ -1,0 +1,336 @@
+//! Full action reconciliation for recovering absolute file statistics.
+//!
+//! This module implements the recovery path for snapshots whose CRC has
+//! [`Indeterminate`](crate::crc::FileStatsState::Indeterminate) or
+//! [`RequiresCheckpointRead`](crate::crc::FileStatsState::RequiresCheckpointRead) file stats.
+//! It performs a full reverse log replay with `(path, dv_unique_id)` deduplication, summing
+//! the sizes of currently-active files to produce known-correct
+//! [`Valid`](crate::crc::FileStatsState::Valid) stats.
+//!
+//! Algorithm (newest-to-oldest reverse iteration):
+//! 1. For each row in each batch, extract the file action key `(path, dv_unique_id)`.
+//! 2. If we have already seen that key, skip (we processed the newest version already).
+//! 3. Otherwise, record the key. If the action is an Add, count it as an active file and accumulate
+//!    its size; if it is a Remove, treat it as a tombstone (record but don't count -- and don't
+//!    count any older Add for the same key).
+//! 4. Checkpoint batches (`is_log_batch = false`) contribute Adds only; their Removes are vacuum
+//!    tombstones and are ignored.
+//! 5. If any Remove encountered has a missing `size` field, the recovery returns
+//!    [`Untrackable`](crate::crc::FileStatsState::Untrackable) -- byte-level totals are permanently
+//!    impossible to compute.
+//!
+//! This is the priority-5 path from the CRC design plan. The ordinary (non-recovery)
+//! snapshot-load path does cheaper incremental tracking; recovery is only needed when
+//! incremental tracking has degraded.
+
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+use tracing::instrument;
+
+use super::LogSegment;
+use crate::actions::deletion_vector::DeletionVectorDescriptor;
+use crate::actions::{get_commit_schema, ADD_NAME, REMOVE_NAME};
+use crate::crc::{FileSizeHistogram, FileStatsState};
+use crate::engine_data::{GetData, TypedGetData as _};
+use crate::schema::{ColumnName, ColumnNamesAndTypes, DataType, SchemaRef};
+use crate::{DeltaResult, Engine, RowVisitor};
+
+impl LogSegment {
+    /// Reconcile add/remove actions across the entire segment to compute absolute file
+    /// statistics from scratch.
+    ///
+    /// Returns:
+    /// - [`FileStatsState::Valid`] with absolute counts, byte totals, and a histogram when
+    ///   reconciliation succeeds.
+    /// - [`FileStatsState::Untrackable`] when any Remove has a missing `size` field. Byte totals
+    ///   cannot be computed in this case.
+    ///
+    /// The histogram is rebuilt over the active file set using the standard
+    /// [`FileSizeHistogram::create_default`] boundaries. Callers wanting different
+    /// boundaries should adjust the resulting CRC's histogram via subsequent applies, OR
+    /// pass a custom-bin variant -- left for future work.
+    #[instrument(name = "log_seg.recover_file_stats", skip_all, err)]
+    pub(crate) fn recover_file_stats(&self, engine: &dyn Engine) -> DeltaResult<FileStatsState> {
+        let schema = recovery_schema()?;
+        let mut accumulator = ReconciliationAccumulator::new();
+        for batch_result in self.read_actions(engine, schema)? {
+            let batch = batch_result?;
+            let data = batch.actions.as_ref();
+            let mut visitor = ReconciliationVisitor {
+                is_log_batch: batch.is_log_batch,
+                acc: &mut accumulator,
+            };
+            visitor.visit_rows_of(data)?;
+        }
+        Ok(accumulator.into_file_stats_state())
+    }
+}
+
+/// Schema for recovery: needs `path`, `size`, and the three DV descriptor fields used to
+/// compute the unique key (`storageType`, `pathOrInlineDv`, `offset`) for both Add and
+/// Remove. Other Add/Remove fields (e.g. partitionValues, modificationTime, tags) are not
+/// needed because we are reconciling for file-stat counts, not for emitting actions.
+fn recovery_schema() -> DeltaResult<SchemaRef> {
+    get_commit_schema().project(&[ADD_NAME, REMOVE_NAME])
+}
+
+// ============================================================================
+// Accumulator
+// ============================================================================
+
+/// Tracks dedup state and running totals across batches.
+///
+/// `seen` keys are `(path, dv_unique_id)`. When the value is `true`, the first-seen action
+/// for that key was an Add (file is active and counted). When `false`, the first-seen action
+/// was a Remove (file is tombstoned and any older Add for the same key must be ignored).
+struct ReconciliationAccumulator {
+    /// Map of `(path, dv_unique_id)` → was-first-seen-an-add (true) or remove (false).
+    /// Using a HashMap (not a HashSet) lets us assert the dedup invariant:
+    /// the same key should never be inserted twice.
+    seen: HashMap<FileKey, bool>,
+    num_files: i64,
+    total_size: i64,
+    histogram: FileSizeHistogram,
+    /// Set when a Remove had a null `size` -- byte totals become unknown forever.
+    has_missing_remove_size: bool,
+}
+
+impl ReconciliationAccumulator {
+    fn new() -> Self {
+        Self {
+            seen: HashMap::new(),
+            num_files: 0,
+            total_size: 0,
+            histogram: FileSizeHistogram::create_default(),
+            has_missing_remove_size: false,
+        }
+    }
+
+    fn into_file_stats_state(self) -> FileStatsState {
+        if self.has_missing_remove_size {
+            return FileStatsState::Untrackable;
+        }
+        FileStatsState::Valid {
+            num_files: self.num_files,
+            table_size_bytes: self.total_size,
+            histogram: Some(self.histogram),
+        }
+    }
+}
+
+#[derive(Hash, PartialEq, Eq, Debug, Clone)]
+struct FileKey {
+    path: String,
+    dv_unique_id: Option<String>,
+}
+
+// ============================================================================
+// Visitor
+// ============================================================================
+
+/// Per-batch visitor that drives the reconciliation accumulator.
+///
+/// For each row, attempts (in order):
+/// 1. If the row has an Add action (`add.path` is non-null): extract its `(path, dv_id)` key. If
+///    first-seen for that key, record it and count the file (sum size, update histogram). If
+///    already seen, skip silently.
+/// 2. If the row has a Remove action AND we are processing a commit batch: extract its `(path,
+///    dv_id)` key. If first-seen, record it as a tombstone (don't count). If the Remove has a null
+///    `size`, set the `has_missing_remove_size` flag.
+/// 3. Checkpoint Removes (`is_log_batch = false`) are ignored entirely (vacuum tombstones).
+struct ReconciliationVisitor<'a> {
+    is_log_batch: bool,
+    acc: &'a mut ReconciliationAccumulator,
+}
+
+impl RowVisitor for ReconciliationVisitor<'_> {
+    fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
+        static NAMES_AND_TYPES: LazyLock<ColumnNamesAndTypes> = LazyLock::new(|| {
+            (
+                vec![
+                    // Add columns
+                    ColumnName::new(["add", "path"]), // 0
+                    ColumnName::new(["add", "size"]), // 1
+                    ColumnName::new(["add", "deletionVector", "storageType"]), // 2
+                    ColumnName::new(["add", "deletionVector", "pathOrInlineDv"]), // 3
+                    ColumnName::new(["add", "deletionVector", "offset"]), // 4
+                    // Remove columns
+                    ColumnName::new(["remove", "path"]), // 5
+                    ColumnName::new(["remove", "size"]), // 6
+                    ColumnName::new(["remove", "deletionVector", "storageType"]), // 7
+                    ColumnName::new(["remove", "deletionVector", "pathOrInlineDv"]), // 8
+                    ColumnName::new(["remove", "deletionVector", "offset"]), // 9
+                ],
+                vec![
+                    DataType::STRING,  // add.path
+                    DataType::LONG,    // add.size
+                    DataType::STRING,  // add.dv.storageType
+                    DataType::STRING,  // add.dv.pathOrInlineDv
+                    DataType::INTEGER, // add.dv.offset
+                    DataType::STRING,  // remove.path
+                    DataType::LONG,    // remove.size
+                    DataType::STRING,  // remove.dv.storageType
+                    DataType::STRING,  // remove.dv.pathOrInlineDv
+                    DataType::INTEGER, // remove.dv.offset
+                ],
+            )
+                .into()
+        });
+        NAMES_AND_TYPES.as_ref()
+    }
+
+    fn visit<'a>(&mut self, row_count: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
+        for i in 0..row_count {
+            // Try Add first.
+            if let Some(add_path) = getters[0].get_str(i, "add.path")? {
+                let dv_unique_id = extract_dv_unique_id(i, getters, 2)?;
+                let key = FileKey {
+                    path: add_path.to_string(),
+                    dv_unique_id,
+                };
+                if let Entry::Vacant(slot) = self.acc.seen.entry(key) {
+                    // First-seen-in-reverse Add: this is the newest action for this file
+                    // and the file is active.
+                    slot.insert(true);
+                    let size: i64 = getters[1].get(i, "add.size")?;
+                    self.acc.num_files += 1;
+                    self.acc.total_size += size;
+                    self.acc.histogram.insert(size)?;
+                }
+                continue;
+            }
+
+            // Then Remove. Only commit batches contribute Removes (checkpoint Removes are
+            // vacuum tombstones, not active state).
+            if !self.is_log_batch {
+                continue;
+            }
+            if let Some(remove_path) = getters[5].get_str(i, "remove.path")? {
+                let dv_unique_id = extract_dv_unique_id(i, getters, 7)?;
+                let key = FileKey {
+                    path: remove_path.to_string(),
+                    dv_unique_id,
+                };
+                if let Entry::Vacant(slot) = self.acc.seen.entry(key) {
+                    // First-seen-in-reverse Remove: file is tombstoned. Don't count, but
+                    // record so older Adds for the same key are skipped.
+                    slot.insert(false);
+                    // Detect missing remove.size, which makes byte totals unknowable.
+                    let remove_size: Option<i64> = getters[6].get_opt(i, "remove.size")?;
+                    if remove_size.is_none() {
+                        self.acc.has_missing_remove_size = true;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Extracts `(path, dv_id)` deletion-vector unique ID from a triple of getters starting at
+/// `dv_start_index`. Mirrors
+/// [`Deduplicator::extract_dv_unique_id`](crate::log_replay::deduplicator::Deduplicator::extract_dv_unique_id)
+/// but kept local to avoid coupling this module to the trait machinery.
+fn extract_dv_unique_id<'a>(
+    i: usize,
+    getters: &[&'a dyn GetData<'a>],
+    dv_start_index: usize,
+) -> DeltaResult<Option<String>> {
+    let Some(storage_type) = getters[dv_start_index].get_opt(i, "deletionVector.storageType")?
+    else {
+        return Ok(None);
+    };
+    let path_or_inline = getters[dv_start_index + 1].get(i, "deletionVector.pathOrInlineDv")?;
+    let offset = getters[dv_start_index + 2].get_opt(i, "deletionVector.offset")?;
+    Ok(Some(DeletionVectorDescriptor::unique_id_from_parts(
+        storage_type,
+        path_or_inline,
+        offset,
+    )))
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_acc() -> ReconciliationAccumulator {
+        ReconciliationAccumulator::new()
+    }
+
+    fn key(path: &str) -> FileKey {
+        FileKey {
+            path: path.to_string(),
+            dv_unique_id: None,
+        }
+    }
+
+    #[test]
+    fn empty_accumulator_yields_valid_zero_stats() {
+        let state = empty_acc().into_file_stats_state();
+        assert!(matches!(
+            state,
+            FileStatsState::Valid {
+                num_files: 0,
+                table_size_bytes: 0,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn missing_remove_size_yields_untrackable() {
+        let mut acc = empty_acc();
+        acc.has_missing_remove_size = true;
+        assert!(matches!(
+            acc.into_file_stats_state(),
+            FileStatsState::Untrackable
+        ));
+    }
+
+    #[test]
+    fn accumulator_sums_bytes_and_counts_files() {
+        let mut acc = empty_acc();
+        acc.seen.insert(key("f1"), true);
+        acc.seen.insert(key("f2"), true);
+        acc.num_files = 2;
+        acc.total_size = 300;
+        acc.histogram.insert(100).unwrap();
+        acc.histogram.insert(200).unwrap();
+        let state = acc.into_file_stats_state();
+        let FileStatsState::Valid {
+            num_files,
+            table_size_bytes,
+            histogram,
+        } = state
+        else {
+            panic!("expected Valid");
+        };
+        assert_eq!(num_files, 2);
+        assert_eq!(table_size_bytes, 300);
+        let h = histogram.unwrap();
+        assert_eq!(h.file_counts()[0], 2);
+        assert_eq!(h.total_bytes()[0], 300);
+    }
+
+    #[test]
+    fn distinct_keys_with_same_path_different_dv_are_separate() {
+        let mut acc = empty_acc();
+        let k1 = FileKey {
+            path: "f".to_string(),
+            dv_unique_id: Some("a".to_string()),
+        };
+        let k2 = FileKey {
+            path: "f".to_string(),
+            dv_unique_id: Some("b".to_string()),
+        };
+        acc.seen.insert(k1, true);
+        acc.seen.insert(k2, true);
+        assert_eq!(acc.seen.len(), 2);
+    }
+}

--- a/kernel/src/log_segment/file_stats_recovery.rs
+++ b/kernel/src/log_segment/file_stats_recovery.rs
@@ -86,7 +86,7 @@ fn recovery_schema() -> DeltaResult<SchemaRef> {
 /// for that key was an Add (file is active and counted). When `false`, the first-seen action
 /// was a Remove (file is tombstoned and any older Add for the same key must be ignored).
 struct ReconciliationAccumulator {
-    /// Map of `(path, dv_unique_id)` → was-first-seen-an-add (true) or remove (false).
+    /// Map of `(path, dv_unique_id)` -> was-first-seen-an-add (true) or remove (false).
     /// Using a HashMap (not a HashSet) lets us assert the dedup invariant:
     /// the same key should never be inserted twice.
     seen: HashMap<FileKey, bool>,

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -31,6 +31,7 @@ use crate::{
     StorageHandler, Version,
 };
 
+mod crc_replay;
 mod domain_metadata_replay;
 mod protocol_metadata_replay;
 

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -33,6 +33,7 @@ use crate::{
 
 mod crc_replay;
 mod domain_metadata_replay;
+mod file_stats_recovery;
 mod protocol_metadata_replay;
 
 pub(crate) use domain_metadata_replay::DomainMetadataMap;

--- a/kernel/src/log_segment/protocol_metadata_replay.rs
+++ b/kernel/src/log_segment/protocol_metadata_replay.rs
@@ -20,6 +20,7 @@ impl LogSegment {
     /// fresh snapshot creation where both Protocol and Metadata must exist.
     // Span name must match `SEGMENT_READ_METADATA_SPAN` in `metrics::reporter`.
     #[instrument(name = "segment.read_metadata", fields(report, operation_id = %operation_id), skip(engine))]
+    #[allow(dead_code)] // Used by tests; live code paths use read_protocol_metadata_opt
     pub(crate) fn read_protocol_metadata(
         &self,
         engine: &dyn Engine,

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -398,9 +398,9 @@ impl Snapshot {
     /// Create a new [`Snapshot`] instance.
     ///
     /// Eagerly builds the [`Crc`] from disk:
-    /// - CRC at target version → load directly, P&M from the CRC.
-    /// - CRC at an older version (stale) → load + reverse-replay newer commits + apply.
-    /// - No CRC, or CRC failed → reverse-replay the entire segment (checkpoint + commits) to build
+    /// - CRC at target version -> load directly, P&M from the CRC.
+    /// - CRC at an older version (stale) -> load + reverse-replay newer commits + apply.
+    /// - No CRC, or CRC failed -> reverse-replay the entire segment (checkpoint + commits) to build
     ///   a fresh `Crc` from scratch.
     #[instrument(err, fields(version, operation_id = %operation_id), skip(engine))]
     fn try_new_from_log_segment(
@@ -514,7 +514,7 @@ impl Snapshot {
 
     /// Creates a new [`Snapshot`] representing the table state immediately after a commit.
     ///
-    /// Implements the universal invariant `Crc[N] + CrcUpdate(N→N+1) = Crc[N+1]`:
+    /// Implements the universal invariant `Crc[N] + CrcUpdate(N->N+1) = Crc[N+1]`:
     /// 1. Append the new commit to the log segment, bumping version to N+1.
     /// 2. Clone this snapshot's CRC (which is `Crc[N]`).
     /// 3. Apply the `crc_update` produced by the transaction.
@@ -557,7 +557,7 @@ impl Snapshot {
 
         let new_log_segment = self.log_segment.new_with_commit_appended(commit)?;
 
-        // Crc[N] + CrcUpdate(N→N+1) = Crc[N+1].
+        // Crc[N] + CrcUpdate(N->N+1) = Crc[N+1].
         let mut new_crc = (*self.crc).clone();
         new_crc.apply(crc_update);
 
@@ -802,8 +802,8 @@ impl Snapshot {
     ///   such txn exists at this version. Return directly.
     /// - [`Partial`](SetTransactionState::Partial): the cache has known-correct entries from newer
     ///   commits. On hit, return; on miss, the txn might exist in older commits not covered by the
-    ///   cache → fall through to log replay.
-    /// - [`Untracked`](SetTransactionState::Untracked): no cache → fall through to log replay.
+    ///   cache -> fall through to log replay.
+    /// - [`Untracked`](SetTransactionState::Untracked): no cache -> fall through to log replay.
     // TODO: add a get_app_id_versions to fetch all at once using SetTransactionScanner::get_all
     #[instrument(parent = &self.span, name = "snap.get_app_id_version", skip_all, err)]
     pub fn get_app_id_version(
@@ -946,7 +946,7 @@ impl Snapshot {
     ///   commits. For specific-domain queries, check cache; on miss, replay only the missing
     ///   domains. For "all domains" queries, must fully replay (cache might be missing older
     ///   domains).
-    /// - [`Untracked`](DomainMetadataState::Untracked): no cache → log replay.
+    /// - [`Untracked`](DomainMetadataState::Untracked): no cache -> log replay.
     ///
     /// This is the single entry point for all domain metadata reads on a snapshot.
     #[internal_api]
@@ -1106,11 +1106,11 @@ impl Snapshot {
     ///   ([`Valid`](crate::crc::FileStatsState::Valid)). Non-Valid states arise from: (a) a
     ///   non-incremental operation like `ANALYZE STATS`
     ///   ([`Indeterminate`](crate::crc::FileStatsState::Indeterminate)) -- recoverable via
-    ///   [`load_file_stats`](Self::load_file_stats) (priority 5, currently stubbed); (b) a file
-    ///   action had a missing size ([`Untrackable`](crate::crc::FileStatsState::Untrackable)) --
-    ///   permanently unrecoverable; (c) the snapshot was built without a checkpoint read
+    ///   [`load_file_stats`](Self::load_file_stats); (b) a file action had a missing size
+    ///   ([`Untrackable`](crate::crc::FileStatsState::Untrackable)) -- permanently
+    ///   unrecoverable; (c) the snapshot was built without a checkpoint read
     ///   ([`RequiresCheckpointRead`](crate::crc::FileStatsState::RequiresCheckpointRead)) --
-    ///   recoverable via the same path.
+    ///   recoverable via [`load_file_stats`](Self::load_file_stats).
     /// - I/O errors from the engine's storage handler if the write fails.
     ///
     /// [`CommittedTransaction::post_commit_snapshot`]: crate::transaction::CommittedTransaction::post_commit_snapshot

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -77,8 +77,8 @@ pub struct Snapshot {
     /// - Loading a stale CRC file + reverse-replaying commits after it (yields the same `Crc[N]`
     ///   as if it had been written at version N), OR
     /// - Building from scratch via full reverse log replay (no CRC file on disk), OR
-    /// - For the incremental fallback path: a [`Crc::minimal_from_pm`] with
-    ///   `RequiresCheckpointRead` file stats.
+    /// - For the incremental fallback path: a minimal CRC with `RequiresCheckpointRead` file
+    ///   stats.
     ///
     /// Mutated only via [`Crc::apply`] (see the post-commit
     /// [`new_post_commit`](Self::new_post_commit) flow).
@@ -147,7 +147,8 @@ impl Snapshot {
 
     /// Create a new [`Snapshot`] from a [`LogSegment`] and [`TableConfiguration`].
     ///
-    /// Builds a minimal CRC from the table configuration's P&M via [`Crc::minimal_from_pm`].
+    /// Builds a minimal CRC from the table configuration's P&M (via the kernel-internal
+    /// `Crc::minimal_from_pm`).
     /// File stats are
     /// [`RequiresCheckpointRead`](crate::crc::FileStatsState::RequiresCheckpointRead),
     /// DM/txns are [`Untracked`](crate::crc::DomainMetadataState::Untracked).

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -1037,24 +1037,66 @@ impl Snapshot {
         Some(self.version())
     }
 
-    /// Recover file stats for an [`Indeterminate`](crate::crc::FileStatsState::Indeterminate)
-    /// or [`RequiresCheckpointRead`](crate::crc::FileStatsState::RequiresCheckpointRead)
-    /// CRC by performing a full action reconciliation pass over the log.
+    /// Recover file stats by performing full action reconciliation across the log.
     ///
-    /// Returns a new [`SnapshotRef`] whose CRC has [`Valid`](crate::crc::FileStatsState::Valid)
-    /// file stats (or [`Untrackable`](crate::crc::FileStatsState::Untrackable) if a remove
-    /// with missing size was found during recovery).
+    /// Returns a new [`SnapshotRef`] whose CRC has either:
+    /// - [`Valid`](crate::crc::FileStatsState::Valid) absolute counts, byte totals, and a
+    ///   histogram, OR
+    /// - [`Untrackable`](crate::crc::FileStatsState::Untrackable) if any Remove action in the
+    ///   reachable history had a missing `size` field (byte totals are then permanently impossible
+    ///   to compute).
     ///
-    /// **Currently stubbed** as `Err(Error::FileStatsRecoveryNotImplemented)`. Locks in the
-    /// recovery API surface for connectors; the implementation lands when priority 5
-    /// (action reconciliation) is built. See `~/claude_plans/2026_04_25_crc_design_plan.md`.
-    #[allow(unused)]
-    pub fn load_file_stats(self: &SnapshotRef, _engine: &dyn Engine) -> DeltaResult<SnapshotRef> {
-        Err(Error::generic(
-            "Snapshot::load_file_stats is not yet implemented. \
-             File stats recovery for Indeterminate/RequiresCheckpointRead CRCs lands with \
-             priority 5 (action reconciliation).",
-        ))
+    /// Behavior by current CRC state:
+    /// - [`Valid`](crate::crc::FileStatsState::Valid): returns the same snapshot. No work.
+    /// - [`Indeterminate`](crate::crc::FileStatsState::Indeterminate) /
+    ///   [`RequiresCheckpointRead`](crate::crc::FileStatsState::RequiresCheckpointRead):
+    ///   reverse-replays the entire log segment with `(path, dv_unique_id)` deduplication and
+    ///   rebuilds file stats from scratch.
+    /// - [`Untrackable`](crate::crc::FileStatsState::Untrackable): returns
+    ///   [`Error::ChecksumWriteUnsupported`]. There is no recovery for this state -- a Remove
+    ///   action committed without a `size` permanently destroys byte-level tracking.
+    ///
+    /// All other CRC fields (P&M, DM, txns, ICT) are preserved.
+    ///
+    /// # Cost
+    ///
+    /// Reads every commit in the log segment plus the checkpoint (if any), with a wider
+    /// schema than ordinary snapshot loads (includes Add/Remove `path`, `size`, and DV
+    /// descriptor columns for deduplication). Connectors should call this only when
+    /// [`Crc::file_stats_validity`](crate::crc::Crc::file_stats_validity) indicates a
+    /// non-`Valid` state.
+    ///
+    /// # Errors
+    ///
+    /// - I/O errors from the engine while reading commits and checkpoint.
+    /// - [`Error::ChecksumWriteUnsupported`] when the current state is `Untrackable`.
+    #[instrument(parent = &self.span, name = "snap.load_file_stats", skip_all, err)]
+    pub fn load_file_stats(self: &SnapshotRef, engine: &dyn Engine) -> DeltaResult<SnapshotRef> {
+        use crate::crc::FileStatsValidity;
+
+        match self.crc.file_stats_validity() {
+            FileStatsValidity::Valid => return Ok(Arc::clone(self)),
+            FileStatsValidity::Untrackable => {
+                return Err(Error::ChecksumWriteUnsupported(
+                    "File stats are Untrackable -- a Remove action with a missing size \
+                     was encountered. Byte-level statistics are permanently unrecoverable."
+                        .to_string(),
+                ));
+            }
+            FileStatsValidity::Indeterminate | FileStatsValidity::RequiresCheckpointRead => {}
+        }
+
+        let recovered = self.log_segment().recover_file_stats(engine)?;
+
+        // Preserve all other CRC fields; only file_stats is rebuilt.
+        let mut new_crc = (*self.crc).clone();
+        new_crc.file_stats = recovered;
+
+        Ok(Arc::new(Snapshot::new_with_crc(
+            self.log_segment().clone(),
+            self.table_configuration().clone(),
+            Arc::new(new_crc),
+        )))
     }
 
     /// Writes a version checksum (CRC) file for this snapshot. Writers should call this

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -996,27 +996,18 @@ impl Snapshot {
         self.log_segment().scan_domain_metadatas(domains, engine)
     }
 
-    /// Returns file-level statistics if the CRC has [`Valid`] file stats at this version,
-    /// otherwise `None`.
-    ///
-    /// The `_engine` parameter is currently unused (the eager `Crc` is already loaded), but
-    /// reserved for future paths that may trigger I/O (e.g. recovery via
-    /// [`load_file_stats`](Self::load_file_stats)).
-    ///
-    /// [`Valid`]: crate::crc::FileStatsState::Valid
-    #[allow(unused)]
-    pub fn get_or_load_file_stats(&self, _engine: &dyn Engine) -> Option<FileStats> {
-        self.crc.file_stats()
-    }
-
     /// Returns file-level statistics if the CRC has [`Valid`] file stats. Performs no I/O.
     ///
-    /// Equivalent to [`get_or_load_file_stats`](Self::get_or_load_file_stats) under the
-    /// eager-`Arc<Crc>` design (the CRC is always already loaded). Kept as a separate
-    /// method for forward-compatibility with future lazy/recovery paths.
+    /// Returns `None` for non-`Valid` states ([`Indeterminate`], [`Untrackable`],
+    /// [`RequiresCheckpointRead`]). Callers that need to recover from a non-`Valid` state
+    /// should call [`load_file_stats`](Self::load_file_stats), which returns a new
+    /// [`SnapshotRef`] with rebuilt stats.
     ///
     /// [`Valid`]: crate::crc::FileStatsState::Valid
-    pub fn get_file_stats_if_loaded(&self) -> Option<FileStats> {
+    /// [`Indeterminate`]: crate::crc::FileStatsState::Indeterminate
+    /// [`Untrackable`]: crate::crc::FileStatsState::Untrackable
+    /// [`RequiresCheckpointRead`]: crate::crc::FileStatsState::RequiresCheckpointRead
+    pub fn get_file_stats(&self) -> Option<FileStats> {
         self.crc.file_stats()
     }
 

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -14,9 +14,10 @@ use crate::actions::{DomainMetadata, INTERNAL_DOMAIN_PREFIX};
 use crate::checkpoint::{CheckpointWriter, LastCheckpointHintStats};
 use crate::clustering::{parse_clustering_columns, CLUSTERING_DOMAIN_NAME};
 use crate::committer::{Committer, PublishMetadata};
-#[cfg(any(test, feature = "test-utils"))]
-use crate::crc::Crc;
-use crate::crc::{try_write_crc_file, CrcDelta, FileStats, LazyCrc};
+use crate::crc::{
+    try_read_crc_file, try_write_crc_file, Crc, CrcUpdate, DomainMetadataState, FileStats, LazyCrc,
+    SetTransactionState,
+};
 use crate::expressions::ColumnName;
 use crate::log_segment::{DomainMetadataMap, LogSegment};
 use crate::log_segment_files::LogSegmentFiles;
@@ -66,7 +67,22 @@ pub struct Snapshot {
     span: tracing::Span,
     log_segment: LogSegment,
     table_configuration: TableConfiguration,
-    lazy_crc: Arc<LazyCrc>,
+    /// Eager in-memory CRC state for this snapshot, always at the snapshot's version.
+    ///
+    /// `Crc` is the universal type that captures everything CRC tracks: P/M, file
+    /// statistics with typed validity, domain metadata / set transactions with
+    /// completeness tracking, and ICT. Constructed during snapshot creation by:
+    ///
+    /// - Loading the CRC file at the target version, OR
+    /// - Loading a stale CRC file + reverse-replaying commits after it (yields the same `Crc[N]`
+    ///   as if it had been written at version N), OR
+    /// - Building from scratch via full reverse log replay (no CRC file on disk), OR
+    /// - For the incremental fallback path: a [`Crc::minimal_from_pm`] with
+    ///   `RequiresCheckpointRead` file stats.
+    ///
+    /// Mutated only via [`Crc::apply`] (see the post-commit
+    /// [`new_post_commit`](Self::new_post_commit) flow).
+    crc: Arc<Crc>,
 }
 
 impl PartialEq for Snapshot {
@@ -130,21 +146,29 @@ impl Snapshot {
     }
 
     /// Create a new [`Snapshot`] from a [`LogSegment`] and [`TableConfiguration`].
+    ///
+    /// Builds a minimal CRC from the table configuration's P&M via [`Crc::minimal_from_pm`].
+    /// File stats are
+    /// [`RequiresCheckpointRead`](crate::crc::FileStatsState::RequiresCheckpointRead),
+    /// DM/txns are [`Untracked`](crate::crc::DomainMetadataState::Untracked).
     #[internal_api]
     #[allow(unused)]
     pub(crate) fn new(log_segment: LogSegment, table_configuration: TableConfiguration) -> Self {
-        Self::new_with_crc(
-            log_segment,
-            table_configuration,
-            Arc::new(LazyCrc::new(None)),
-        )
+        let crc = Arc::new(Crc::minimal_from_pm(
+            table_configuration.protocol().clone(),
+            table_configuration.metadata().clone(),
+        ));
+        Self::new_with_crc(log_segment, table_configuration, crc)
     }
 
-    /// Internal constructor that accepts an explicit [`LazyCrc`].
+    /// Internal constructor that accepts an explicit [`Crc`].
+    ///
+    /// Callers are responsible for ensuring the CRC matches the snapshot's version. Used by
+    /// snapshot creation paths that have already constructed (or loaded) the CRC.
     pub(crate) fn new_with_crc(
         log_segment: LogSegment,
         table_configuration: TableConfiguration,
-        lazy_crc: Arc<LazyCrc>,
+        crc: Arc<Crc>,
     ) -> Self {
         let span = tracing::info_span!(
             parent: tracing::Span::none(),
@@ -157,7 +181,7 @@ impl Snapshot {
             span,
             log_segment,
             table_configuration,
-            lazy_crc,
+            crc,
         }
     }
 
@@ -288,16 +312,18 @@ impl Snapshot {
             .ascending_compaction_files
             .retain(|log_path| old_version < log_path.version);
 
-        // we have new commits and no new checkpoint: we replay new commits for P+M and then
-        // create a new snapshot by combining LogSegments and building a new TableConfiguration
-        let (crc_file, lazy_crc) = Self::resolve_crc(
-            &new_log_segment,
-            old_log_segment,
-            &existing_snapshot.lazy_crc,
-        );
+        // We have new commits and no new checkpoint: replay new commits for P+M and then
+        // create a new snapshot by combining LogSegments and building a new TableConfiguration.
+        //
+        // For the P&M optimization here we still use a transient `LazyCrc` (it lets
+        // `read_protocol_metadata_opt` use the CRC file to skip log replay if P&M are in
+        // the CRC). The Snapshot's eager CRC is built separately below via
+        // `try_build_crc_from_file`.
+        let crc_file = Self::resolve_crc_file(&new_log_segment, old_log_segment);
+        let local_lazy_crc = LazyCrc::new(crc_file.clone());
 
         let (new_metadata, new_protocol) =
-            new_log_segment.read_protocol_metadata_opt(engine, &lazy_crc)?;
+            new_log_segment.read_protocol_metadata_opt(engine, &local_lazy_crc)?;
         let table_configuration = TableConfiguration::try_new_from(
             existing_snapshot.table_configuration(),
             new_metadata,
@@ -336,37 +362,45 @@ impl Snapshot {
             old_log_segment.last_checkpoint_hint_summary(),
         )?;
 
+        // Build the snapshot's eager CRC. Try CRC file first; fall back to a minimal CRC
+        // built from the just-loaded P&M (no file stats / DM / txn — RequiresCheckpointRead
+        // and Untracked respectively).
+        let crc =
+            Self::try_build_crc_from_file(&combined_log_segment, engine).unwrap_or_else(|| {
+                Arc::new(Crc::minimal_from_pm(
+                    table_configuration.protocol().clone(),
+                    table_configuration.metadata().clone(),
+                ))
+            });
+
         tracing::Span::current().record("version", table_configuration.version());
         Ok(Arc::new(Snapshot::new_with_crc(
             combined_log_segment,
             table_configuration,
-            lazy_crc,
+            crc,
         )))
     }
 
-    /// Determine the CRC file and LazyCrc for an incremental snapshot update.
-    ///
-    /// Prefers the new segment's CRC file, falls back to the old segment's. If the resolved
-    /// CRC version matches the existing snapshot's LazyCrc, reuses it to avoid redundant I/O
-    /// (it may already be loaded in memory).
-    fn resolve_crc(
+    /// Determine which CRC file to use for an incremental snapshot update. Prefers the new
+    /// segment's CRC file, falls back to the old segment's.
+    fn resolve_crc_file(
         new_log_segment: &LogSegment,
         old_log_segment: &LogSegment,
-        existing_lazy_crc: &Arc<LazyCrc>,
-    ) -> (Option<ParsedLogPath>, Arc<LazyCrc>) {
-        let new_crc_file = new_log_segment.listed.latest_crc_file.clone();
-        let old_crc_file = old_log_segment.listed.latest_crc_file.clone();
-        let crc_file = new_crc_file.or(old_crc_file);
-        let crc_version = crc_file.as_ref().map(|f| f.version);
-        let lazy_crc = if crc_version == existing_lazy_crc.crc_version() {
-            existing_lazy_crc.clone()
-        } else {
-            Arc::new(LazyCrc::new(crc_file.clone()))
-        };
-        (crc_file, lazy_crc)
+    ) -> Option<ParsedLogPath> {
+        new_log_segment
+            .listed
+            .latest_crc_file
+            .clone()
+            .or_else(|| old_log_segment.listed.latest_crc_file.clone())
     }
 
     /// Create a new [`Snapshot`] instance.
+    ///
+    /// Eagerly builds the [`Crc`] from disk:
+    /// - CRC at target version → load directly, P&M from the CRC.
+    /// - CRC at an older version (stale) → load + reverse-replay newer commits + apply.
+    /// - No CRC, or CRC failed → reverse-replay the entire segment (checkpoint + commits) to build
+    ///   a fresh `Crc` from scratch.
     #[instrument(err, fields(version, operation_id = %operation_id), skip(engine))]
     fn try_new_from_log_segment(
         location: Url,
@@ -374,40 +408,126 @@ impl Snapshot {
         engine: &dyn Engine,
         operation_id: MetricId,
     ) -> DeltaResult<Self> {
-        // Create lazy CRC loader for P&M optimization
-        let lazy_crc = Arc::new(LazyCrc::new(log_segment.listed.latest_crc_file.clone()));
+        let crc = Self::build_crc(&log_segment, engine, operation_id)?;
 
-        // Read protocol and metadata (may use CRC if available)
-        let (metadata, protocol) =
-            log_segment.read_protocol_metadata(engine, &lazy_crc, operation_id)?;
-
-        let table_configuration =
-            TableConfiguration::try_new(metadata, protocol, location, log_segment.end_version)?;
+        let table_configuration = TableConfiguration::try_new(
+            crc.metadata.clone(),
+            crc.protocol.clone(),
+            location,
+            log_segment.end_version,
+        )?;
 
         tracing::Span::current().record("version", table_configuration.version());
 
-        Ok(Self::new_with_crc(
-            log_segment,
-            table_configuration,
-            lazy_crc,
-        ))
+        Ok(Self::new_with_crc(log_segment, table_configuration, crc))
+    }
+
+    /// Build the [`Crc`] for a snapshot at `log_segment.end_version` from storage.
+    ///
+    /// Strategy:
+    /// 1. **CRC file present at target version**: load directly, no log replay.
+    /// 2. **CRC file present at older version** (stale): load it, reverse-replay commits in
+    ///    `(crc_version, end_version]`, apply update.
+    /// 3. **No CRC file** (or load failed): reverse-replay the entire segment to build fresh.
+    ///
+    /// All paths produce a `Crc[end_version]` with P&M, file stats (typed validity), DM,
+    /// txns, and ICT populated to the extent possible from the available log.
+    ///
+    /// The span name `segment.read_metadata` is significant -- the metrics reporter
+    /// converts it into a
+    /// [`ProtocolMetadataLoaded`](crate::metrics::events::MetricEvent::ProtocolMetadataLoaded)
+    /// event.
+    #[instrument(name = "segment.read_metadata", fields(report, operation_id = %operation_id), skip_all, err)]
+    fn build_crc(
+        log_segment: &LogSegment,
+        engine: &dyn Engine,
+        operation_id: MetricId,
+    ) -> DeltaResult<Arc<Crc>> {
+        let _ = operation_id; // span field
+        match Self::try_build_crc_from_file(log_segment, engine) {
+            Some(crc) => Ok(crc),
+            None => {
+                info!("No CRC file usable; building Crc from scratch via full log replay");
+                Ok(Arc::new(log_segment.build_crc_from_scratch(engine)?))
+            }
+        }
+    }
+
+    /// Try to build a [`Crc`] from a CRC file on disk. Handles both CRC at target version
+    /// (loaded directly, no replay) and stale CRC (loaded + incremental replay of newer
+    /// commits). Returns `None` if no CRC file exists or any step (read or replay) failed.
+    fn try_build_crc_from_file(log_segment: &LogSegment, engine: &dyn Engine) -> Option<Arc<Crc>> {
+        let crc_file = log_segment.listed.latest_crc_file.as_ref()?;
+        let crc_version = crc_file.version;
+        let target_version = log_segment.end_version;
+
+        let loaded = match try_read_crc_file(engine, crc_file) {
+            Ok(crc) => crc,
+            Err(e) => {
+                warn!(
+                    "Failed to read CRC file at version {crc_version}: {e}; \
+                     falling back to log replay"
+                );
+                return None;
+            }
+        };
+
+        if crc_version == target_version {
+            info!("CRC loaded from disk at target version {target_version}");
+            return Some(Arc::new(loaded));
+        }
+
+        if crc_version > target_version {
+            // Time-travel target older than CRC: cannot use this CRC. Fall back.
+            warn!(
+                "CRC at version {crc_version} is newer than target {target_version}; \
+                 ignoring (time-travel)"
+            );
+            return None;
+        }
+
+        // Stale CRC: replay commits in (crc_version, target_version] and apply.
+        info!(
+            "Building Crc[{}] from stale CRC[{}] + incremental replay",
+            target_version, crc_version
+        );
+        let pruned = log_segment.segment_after_crc(crc_version);
+        let mut crc = loaded;
+        match pruned.build_crc_from_stale(engine, &mut crc) {
+            Ok(()) => {
+                info!(
+                    "Built Crc[{}] from stale CRC[{}]",
+                    target_version, crc_version
+                );
+                Some(Arc::new(crc))
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to incrementally replay onto stale CRC[{crc_version}]: {e}; \
+                     falling back to full log replay"
+                );
+                None
+            }
+        }
     }
 
     /// Creates a new [`Snapshot`] representing the table state immediately after a commit.
     ///
-    /// Appends the newly committed file to this snapshot's log segment and bumps the version,
-    /// producing a post-commit snapshot without a full log replay from storage.
+    /// Implements the universal invariant `Crc[N] + CrcUpdate(N→N+1) = Crc[N+1]`:
+    /// 1. Append the new commit to the log segment, bumping version to N+1.
+    /// 2. Clone this snapshot's CRC (which is `Crc[N]`).
+    /// 3. Apply the `crc_update` produced by the transaction.
+    /// 4. Wrap the result as the post-commit snapshot's CRC.
     ///
-    /// The `crc_delta` captures the CRC-relevant changes from the committed transaction
-    /// (file stats, domain metadata, ICT, etc.). If this snapshot had a loaded CRC at its
-    /// version, the delta is applied to produce a precomputed in-memory CRC for the new
-    /// version -- this avoids re-reading metadata from storage. If no CRC was available, the
-    /// existing lazy CRC is carried forward unchanged. CREATE TABLE handles CRC construction
-    /// separately in `Transaction::into_committed`.
+    /// The result is `Crc[N+1]` available in memory without any I/O. Connectors may then
+    /// optionally call [`write_checksum`](Self::write_checksum) to persist it as N+1.crc.
+    ///
+    /// Note: CREATE TABLE doesn't go through this path; it builds the CRC via
+    /// [`CrcUpdate::into_fresh_crc`] in [`Transaction::into_committed`].
     pub(crate) fn new_post_commit(
         &self,
         commit: ParsedLogPath,
-        crc_delta: CrcDelta,
+        crc_update: CrcUpdate,
     ) -> DeltaResult<Self> {
         require!(
             commit.is_commit(),
@@ -430,40 +550,21 @@ impl Snapshot {
         let new_table_configuration = TableConfiguration::new_post_commit(
             self.table_configuration(),
             new_version,
-            crc_delta.metadata.clone(),
-            crc_delta.protocol.clone(),
+            crc_update.metadata.clone(),
+            crc_update.protocol.clone(),
         )?;
 
         let new_log_segment = self.log_segment.new_with_commit_appended(commit)?;
 
-        let new_lazy_crc = self.compute_post_commit_crc(new_version, crc_delta);
+        // Crc[N] + CrcUpdate(N→N+1) = Crc[N+1].
+        let mut new_crc = (*self.crc).clone();
+        new_crc.apply(crc_update);
 
         Ok(Snapshot::new_with_crc(
             new_log_segment,
             new_table_configuration,
-            new_lazy_crc,
+            Arc::new(new_crc),
         ))
-    }
-
-    /// Compute the lazy CRC for a post-commit snapshot by applying a [`CrcDelta`].
-    ///
-    /// Applies the `crc_delta` to the current CRC if loaded, otherwise carries forward the
-    /// existing lazy CRC. Not used by CREATE TABLE, which builds its CRC from scratch via
-    /// `CrcDelta::into_crc_for_version_zero` in `Transaction::into_committed`.
-    fn compute_post_commit_crc(&self, new_version: Version, crc_delta: CrcDelta) -> Arc<LazyCrc> {
-        let crc = self
-            .lazy_crc
-            .get_if_loaded_at_version(self.version())
-            .map(|base| {
-                let mut crc = base.as_ref().clone();
-                crc.apply(crc_delta);
-                crc
-            });
-
-        match crc {
-            Some(c) => Arc::new(LazyCrc::new_precomputed(c, new_version)),
-            None => self.lazy_crc.clone(),
-        }
     }
 
     /// Creates a [`CheckpointWriter`] for generating a checkpoint from this snapshot.
@@ -545,26 +646,19 @@ impl Snapshot {
         let checkpoint_log_path = ParsedLogPath::try_from(file_meta)?.ok_or_else(|| {
             Error::internal_error("Checkpoint path could not be parsed as a log path")
         })?;
-        let checkpoint_version = checkpoint_log_path.version;
+        let _checkpoint_version = checkpoint_log_path.version;
         let new_log_segment = self
             .log_segment
             .try_new_with_checkpoint(checkpoint_log_path)?;
-        // Drop a cached CRC that predates the checkpoint version.
-        let lazy_crc = if self
-            .lazy_crc
-            .crc_version()
-            .is_some_and(|v| v < checkpoint_version)
-        {
-            Arc::new(LazyCrc::new(None))
-        } else {
-            self.lazy_crc.clone()
-        };
+        // The CRC carries forward unchanged: it represents the same logical state as before
+        // the checkpoint write (just at a more compact log representation). Stale-CRC
+        // detection is per-load-time, not per-checkpoint-time.
         Ok((
             CheckpointWriteResult::Written,
             Arc::new(Snapshot::new_with_crc(
                 new_log_segment,
                 self.table_configuration().clone(),
-                lazy_crc,
+                self.crc.clone(),
             )),
         ))
     }
@@ -699,10 +793,16 @@ impl Snapshot {
         AlterTableTransactionBuilder::new(self)
     }
 
-    /// Fetch the latest version of the provided `application_id` for this snapshot. Filters the
-    /// txn based on the delta.setTransactionRetentionDuration property and lastUpdated.
+    /// Fetch the latest version of the provided `application_id` for this snapshot. Filters
+    /// the txn based on `delta.setTransactionRetentionDuration` and `lastUpdated`.
     ///
-    /// Uses the CRC fast path when available, otherwise falls back to log replay.
+    /// Branches on the CRC's [`SetTransactionState`]:
+    /// - [`Complete`](SetTransactionState::Complete): the cache is authoritative; a miss means no
+    ///   such txn exists at this version. Return directly.
+    /// - [`Partial`](SetTransactionState::Partial): the cache has known-correct entries from newer
+    ///   commits. On hit, return; on miss, the txn might exist in older commits not covered by the
+    ///   cache → fall through to log replay.
+    /// - [`Untracked`](SetTransactionState::Untracked): no cache → fall through to log replay.
     // TODO: add a get_app_id_versions to fetch all at once using SetTransactionScanner::get_all
     #[instrument(parent = &self.span, name = "snap.get_app_id_version", skip_all, err)]
     pub fn get_app_id_version(
@@ -713,17 +813,28 @@ impl Snapshot {
         let expiration_timestamp =
             calculate_transaction_expiration_timestamp(self.table_properties())?;
 
-        // Fast path: serve from CRC if it tracks set transactions at this version.
-        if let Some(crc) = self
-            .lazy_crc
-            .get_or_load_if_at_version(engine, self.version())
-        {
-            if let Some(txn_map) = &crc.set_transactions {
-                return Ok(txn_map
+        match &self.crc.set_transactions {
+            SetTransactionState::Complete(map) => {
+                // Authoritative for both hits and misses.
+                return Ok(map
                     .get(application_id)
                     .filter(|txn| !is_set_txn_expired(expiration_timestamp, txn.last_updated))
                     .map(|txn| txn.version));
             }
+            SetTransactionState::Partial(map) => {
+                // Hit: return. Miss: must fall through to log replay (older commits may
+                // have set this txn, and the partial cache doesn't know).
+                if let Some(txn) = map.get(application_id) {
+                    return Ok(
+                        if is_set_txn_expired(expiration_timestamp, txn.last_updated) {
+                            None
+                        } else {
+                            Some(txn.version)
+                        },
+                    );
+                }
+            }
+            SetTransactionState::Untracked => {}
         }
 
         // Fallback: full log replay.
@@ -824,78 +935,131 @@ impl Snapshot {
         }
     }
 
-    /// Load domain metadata from this snapshot. If `domains` is `Some`, only load the specified
-    /// domains (with early termination). If `None`, load all domains.
+    /// Load domain metadata from this snapshot. If `domains` is `Some`, only load the
+    /// specified domains. If `None`, load all domains.
     ///
-    /// This is the single entry point for all domain metadata reads on a snapshot. All public
-    /// and internal domain metadata APIs delegate to this method.
+    /// Branches on the CRC's [`DomainMetadataState`]:
+    /// - [`Complete`](DomainMetadataState::Complete): cache is authoritative for hits AND misses.
+    ///   Return directly (filtered by `domains` if specified).
+    /// - [`Partial`](DomainMetadataState::Partial): cache has known-correct entries from newer
+    ///   commits. For specific-domain queries, check cache; on miss, replay only the missing
+    ///   domains. For "all domains" queries, must fully replay (cache might be missing older
+    ///   domains).
+    /// - [`Untracked`](DomainMetadataState::Untracked): no cache → log replay.
+    ///
+    /// This is the single entry point for all domain metadata reads on a snapshot.
     #[internal_api]
     pub(crate) fn get_domain_metadatas_internal(
         &self,
         engine: &dyn Engine,
         domains: Option<&HashSet<&str>>,
     ) -> DeltaResult<DomainMetadataMap> {
-        // Fast path: serve from CRC if it tracks domain metadata at this version.
-        if let Some(crc) = self
-            .lazy_crc
-            .get_or_load_if_at_version(engine, self.version())
-        {
-            if let Some(dm_map) = &crc.domain_metadata {
-                return Ok(match domains {
-                    None => dm_map.clone(),
-                    Some(filter) => dm_map
+        match &self.crc.domain_metadata {
+            DomainMetadataState::Complete(map) => {
+                let result = match domains {
+                    None => map.clone(),
+                    Some(filter) => map
                         .iter()
                         .filter(|(k, _)| filter.contains(k.as_str()))
                         .map(|(k, v)| (k.clone(), v.clone()))
                         .collect(),
-                });
+                };
+                return Ok(result);
             }
+            DomainMetadataState::Partial(map) => {
+                if let Some(filter) = domains {
+                    // Specific-domain query: serve hits from cache, replay only misses.
+                    let mut result: DomainMetadataMap = HashMap::new();
+                    let mut missing: HashSet<&str> = HashSet::new();
+                    for &domain in filter {
+                        if let Some(dm) = map.get(domain) {
+                            result.insert(domain.to_string(), dm.clone());
+                        } else {
+                            missing.insert(domain);
+                        }
+                    }
+                    if missing.is_empty() {
+                        return Ok(result);
+                    }
+                    let replayed = self
+                        .log_segment()
+                        .scan_domain_metadatas(Some(&missing), engine)?;
+                    result.extend(replayed);
+                    return Ok(result);
+                }
+                // "All domains" query against Partial: must replay (cache may miss older
+                // domains).
+            }
+            DomainMetadataState::Untracked => {}
         }
         // Fallback: full log replay.
         self.log_segment().scan_domain_metadatas(domains, engine)
     }
 
-    /// Returns file-level statistics, or `None` if no CRC with valid stats exists at this
-    /// snapshot's version. Attempts to load the CRC from storage if not already cached.
-    pub fn get_or_load_file_stats(&self, engine: &dyn Engine) -> Option<FileStats> {
-        let crc = self
-            .lazy_crc
-            .get_or_load_if_at_version(engine, self.version())?;
-        crc.file_stats()
-    }
-
-    /// Returns file-level statistics if the CRC is already loaded at this snapshot's version.
-    /// This method performs no I/O; it returns `None` if the CRC has not already been loaded.
-    pub fn get_file_stats_if_loaded(&self) -> Option<FileStats> {
-        let crc = self.lazy_crc.get_if_loaded_at_version(self.version())?;
-        crc.file_stats()
-    }
-
-    /// Returns the CRC if one has been loaded at this snapshot's version (no I/O).
+    /// Returns file-level statistics if the CRC has [`Valid`] file stats at this version,
+    /// otherwise `None`.
     ///
-    /// This is a test-only helper for integration tests to inspect the CRC state.
+    /// The `_engine` parameter is currently unused (the eager `Crc` is already loaded), but
+    /// reserved for future paths that may trigger I/O (e.g. recovery via
+    /// [`load_file_stats`](Self::load_file_stats)).
+    ///
+    /// [`Valid`]: crate::crc::FileStatsState::Valid
+    #[allow(unused)]
+    pub fn get_or_load_file_stats(&self, _engine: &dyn Engine) -> Option<FileStats> {
+        self.crc.file_stats()
+    }
+
+    /// Returns file-level statistics if the CRC has [`Valid`] file stats. Performs no I/O.
+    ///
+    /// Equivalent to [`get_or_load_file_stats`](Self::get_or_load_file_stats) under the
+    /// eager-`Arc<Crc>` design (the CRC is always already loaded). Kept as a separate
+    /// method for forward-compatibility with future lazy/recovery paths.
+    ///
+    /// [`Valid`]: crate::crc::FileStatsState::Valid
+    pub fn get_file_stats_if_loaded(&self) -> Option<FileStats> {
+        self.crc.file_stats()
+    }
+
+    /// Returns the snapshot's eager CRC. Always available since `crc` is always present.
+    ///
+    /// Test-only helper for integration tests to inspect CRC state.
     #[cfg(any(test, feature = "test-utils"))]
     pub fn get_current_crc_if_loaded_for_testing(&self) -> Option<&Crc> {
-        if self.lazy_crc.crc_version() != Some(self.version()) {
-            return None;
-        }
-        self.lazy_crc.cached.get()?.get().map(|arc| arc.as_ref())
+        Some(self.crc.as_ref())
     }
 
-    /// Returns the CRC version tracked by this snapshot's LazyCrc, if any.
+    /// Returns the snapshot's CRC version. Always equals [`version`](Self::version) under
+    /// the eager-`Arc<Crc>` design.
     ///
-    /// This is a test-only helper for integration tests to inspect the CRC version.
+    /// Test-only helper.
     #[cfg(any(test, feature = "test-utils"))]
     pub fn crc_version_for_testing(&self) -> Option<Version> {
-        self.lazy_crc.crc_version()
+        Some(self.version())
     }
 
-    /// Writes a version checksum (CRC) file for this snapshot. Writers should call this after
-    /// every commit because checksums enable faster snapshot loading and table state validation.
+    /// Recover file stats for an [`Indeterminate`](crate::crc::FileStatsState::Indeterminate)
+    /// or [`RequiresCheckpointRead`](crate::crc::FileStatsState::RequiresCheckpointRead)
+    /// CRC by performing a full action reconciliation pass over the log.
     ///
-    /// Currently only supports writing from a post-commit snapshot that has pre-computed CRC
-    /// information in memory (i.e. the snapshot returned by
-    /// [`CommittedTransaction::post_commit_snapshot`]).
+    /// Returns a new [`SnapshotRef`] whose CRC has [`Valid`](crate::crc::FileStatsState::Valid)
+    /// file stats (or [`Untrackable`](crate::crc::FileStatsState::Untrackable) if a remove
+    /// with missing size was found during recovery).
+    ///
+    /// **Currently stubbed** as `Err(Error::FileStatsRecoveryNotImplemented)`. Locks in the
+    /// recovery API surface for connectors; the implementation lands when priority 5
+    /// (action reconciliation) is built. See `~/claude_plans/2026_04_25_crc_design_plan.md`.
+    #[allow(unused)]
+    pub fn load_file_stats(self: &SnapshotRef, _engine: &dyn Engine) -> DeltaResult<SnapshotRef> {
+        Err(Error::generic(
+            "Snapshot::load_file_stats is not yet implemented. \
+             File stats recovery for Indeterminate/RequiresCheckpointRead CRCs lands with \
+             priority 5 (action reconciliation).",
+        ))
+    }
+
+    /// Writes a version checksum (CRC) file for this snapshot. Writers should call this
+    /// after every commit because checksums enable faster snapshot loading and table state
+    /// validation.
     ///
     /// Returns a tuple of [`ChecksumWriteResult`] and a [`SnapshotRef`]. On
     /// [`ChecksumWriteResult::Written`], the returned snapshot has the CRC file recorded in
@@ -904,12 +1068,15 @@ impl Snapshot {
     ///
     /// # Errors
     ///
-    /// - [`Error::ChecksumWriteUnsupported`] if no in-memory CRC is available at this snapshot's
-    ///   version (e.g. a snapshot loaded from disk that has no CRC file), or if the CRC's file
-    ///   stats are not valid. File stats can be invalid for two reasons: (a) a non-incremental
-    ///   operation like ANALYZE STATS was encountered, which is recoverable with a full state
-    ///   reconstruction in the future; (b) a file action had a missing size (e.g. `remove.size` is
-    ///   null), which is permanently unrecoverable.
+    /// - [`Error::ChecksumWriteUnsupported`] if the CRC's file stats are not in a writable state
+    ///   ([`Valid`](crate::crc::FileStatsState::Valid)). Non-Valid states arise from: (a) a
+    ///   non-incremental operation like `ANALYZE STATS`
+    ///   ([`Indeterminate`](crate::crc::FileStatsState::Indeterminate)) -- recoverable via
+    ///   [`load_file_stats`](Self::load_file_stats) (priority 5, currently stubbed); (b) a file
+    ///   action had a missing size ([`Untrackable`](crate::crc::FileStatsState::Untrackable)) --
+    ///   permanently unrecoverable; (c) the snapshot was built without a checkpoint read
+    ///   ([`RequiresCheckpointRead`](crate::crc::FileStatsState::RequiresCheckpointRead)) --
+    ///   recoverable via the same path.
     /// - I/O errors from the engine's storage handler if the write fails.
     ///
     /// [`CommittedTransaction::post_commit_snapshot`]: crate::transaction::CommittedTransaction::post_commit_snapshot
@@ -933,26 +1100,17 @@ impl Snapshot {
             return Ok((ChecksumWriteResult::AlreadyExists, Arc::clone(self)));
         }
 
-        let crc = self
-            .lazy_crc
-            .get_if_loaded_at_version(self.version())
-            .ok_or_else(|| {
-                Error::ChecksumWriteUnsupported(
-                    "No in-memory CRC available at this snapshot version.".to_string(),
-                )
-            })?;
-
         let crc_path = ParsedLogPath::new_crc(self.table_root(), self.version())?;
 
-        // Note: try_write_crc_file validates file stats validity before writing.
-        match try_write_crc_file(engine, &crc_path.location, crc) {
+        // try_write_crc_file validates is_writable() before writing.
+        match try_write_crc_file(engine, &crc_path.location, &self.crc) {
             Ok(()) => {
                 info!("Wrote CRC file at {}", crc_path.location);
                 let new_log_segment = self.log_segment.try_new_with_crc_file(crc_path)?;
                 let new_snapshot = Arc::new(Snapshot::new_with_crc(
                     new_log_segment,
                     self.table_configuration().clone(),
-                    self.lazy_crc.clone(),
+                    self.crc.clone(),
                 ));
                 Ok((ChecksumWriteResult::Written, new_snapshot))
             }
@@ -1031,7 +1189,7 @@ impl Snapshot {
         Ok(Arc::new(Snapshot::new_with_crc(
             self.log_segment().new_as_published()?,
             self.table_configuration().clone(),
-            self.lazy_crc.clone(),
+            self.crc.clone(),
         )))
     }
 
@@ -1105,23 +1263,14 @@ impl Snapshot {
             }
         }
 
-        // Fast path: try reading ICT from CRC file (if it is at this snapshot version)
-        if let Some(crc) = self
-            .lazy_crc
-            .get_or_load_if_at_version(engine, self.version())
-        {
-            match crc.in_commit_timestamp_opt {
-                Some(ict) => return Ok(Some(ict)),
-                None => {
-                    return Err(Error::generic(format!(
-                        "In-Commit Timestamp not found in CRC file at version {}",
-                        self.version()
-                    )));
-                }
-            }
+        // Fast path: serve from CRC if it has an ICT.
+        if let Some(ict) = self.crc.in_commit_timestamp_opt {
+            return Ok(Some(ict));
         }
 
-        // Fallback: read the ICT from latest_commit_file
+        // Fallback: read the ICT from the latest commit file. (CRC may lack ICT if it was
+        // written before ICT was enabled, or if the CRC was built via an incremental
+        // path that did not capture commitInfo.)
         match &self.log_segment.listed.latest_commit_file {
             Some(commit_file_meta) => {
                 let ict = commit_file_meta.read_in_commit_timestamp(engine)?;
@@ -1325,11 +1474,11 @@ mod tests {
         let log_segment =
             LogSegment::try_new(listed_files, url.join("_delta_log/")?, Some(0), None)?;
 
-        Ok(Snapshot::new_with_crc(
-            log_segment,
-            table_cfg,
-            Arc::new(LazyCrc::new(None)),
-        ))
+        let crc = Arc::new(Crc::minimal_from_pm(
+            table_cfg.protocol().clone(),
+            table_cfg.metadata().clone(),
+        ));
+        Ok(Snapshot::new_with_crc(log_segment, table_cfg, crc))
     }
 
     #[test]
@@ -2605,7 +2754,7 @@ mod tests {
         // WHEN
         let fake_new_commit = ParsedLogPath::create_parsed_published_commit(&url, next_version);
         let post_commit_snapshot = base_snapshot
-            .new_post_commit(fake_new_commit, CrcDelta::default())
+            .new_post_commit(fake_new_commit, CrcUpdate::default())
             .unwrap();
 
         // THEN

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -1194,10 +1194,18 @@ impl<S> Transaction<S> {
         // caller (engine_info / commitInfo). Unknown / unsafe ops produce a CrcUpdate with
         // `operation_safe = false`, which transitions the post-commit Crc's file stats to
         // Indeterminate.
-        let operation_safe = self
-            .operation
-            .as_deref()
-            .is_some_and(FileStatsDelta::is_incremental_safe);
+        //
+        // Special case: CREATE TABLE has no prior file state (it IS the prior state), so
+        // its file stats are trivially safe regardless of the connector-supplied
+        // operation string. Without this carve-out, a CREATE TABLE without
+        // `with_operation(...)` would produce an Indeterminate CRC at v0 -- which then
+        // can't be persisted via write_checksum, defeating the whole post-commit-CRC
+        // feature for the simplest case.
+        let operation_safe = self.is_create_table()
+            || self
+                .operation
+                .as_deref()
+                .is_some_and(FileStatsDelta::is_incremental_safe);
         Ok(CrcUpdate {
             file_stats,
             protocol: self

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -14,7 +14,7 @@ use crate::actions::{
 use crate::committer::{
     CommitMetadata, CommitProtocolMetadata, CommitResponse, CommitType, Committer,
 };
-use crate::crc::{CrcDelta, FileStatsDelta, LazyCrc};
+use crate::crc::{CrcUpdate, FileStatsDelta};
 use crate::engine_data::FilteredEngineData;
 use crate::error::Error;
 use crate::expressions::UnaryExpressionOp::ToJson;
@@ -481,13 +481,13 @@ impl<S> Transaction<S> {
                     .and_then(|snap| snap.get_file_stats_if_loaded())
                     .and_then(|s| s.file_size_histogram)
                     .map(|h| h.sorted_bin_boundaries);
-                let crc_delta = self.build_crc_delta(
+                let crc_update = self.build_crc_update(
                     in_commit_timestamp,
                     dm_changes,
                     bin_boundaries.as_deref(),
                 )?;
                 Ok(CommitResult::CommittedTransaction(
-                    self.into_committed(file_meta, crc_delta)?,
+                    self.into_committed(file_meta, crc_update)?,
                 ))
             }
             Ok(CommitResponse::Conflict { version }) => Ok(CommitResult::ConflictedTransaction(
@@ -1128,7 +1128,7 @@ impl<S> Transaction<S> {
     fn into_committed(
         self,
         file_meta: FileMeta,
-        crc_delta: CrcDelta,
+        crc_update: CrcUpdate,
     ) -> DeltaResult<CommittedTransaction> {
         let parsed_commit = ParsedLogPath::parse_commit(file_meta)?;
 
@@ -1136,7 +1136,7 @@ impl<S> Transaction<S> {
 
         let (post_commit_stats, post_commit_snapshot) = match &self.read_snapshot_opt {
             Some(snap) => {
-                // Existing table path: use the read snapshot to compute post-commit state.
+                // Existing table path: Crc[N] + CrcUpdate(N→N+1) = Crc[N+1].
                 let stats = PostCommitStats {
                     commits_since_checkpoint: snap.log_segment().commits_since_checkpoint() + 1,
                     commits_since_log_compaction: snap
@@ -1144,28 +1144,26 @@ impl<S> Transaction<S> {
                         .commits_since_log_compaction_or_checkpoint()
                         + 1,
                 };
-                let snapshot = snap.new_post_commit(parsed_commit, crc_delta)?;
+                let snapshot = snap.new_post_commit(parsed_commit, crc_update)?;
                 (stats, Arc::new(snapshot))
             }
             None => {
-                // CREATE TABLE path: build a fresh Snapshot at version 0.
+                // CREATE TABLE path: no read snapshot, no Crc[N] to apply onto. Build a
+                // fresh Crc[0] directly via CrcUpdate::into_fresh_crc.
                 let log_root = self
                     .effective_table_config
                     .table_root()
                     .join("_delta_log/")?;
                 let log_segment = LogSegment::new_for_version_zero(log_root, parsed_commit)?;
-                let crc = crc_delta.into_crc_for_version_zero().ok_or_else(|| {
-                    Error::internal_error("CREATE TABLE CRC delta is missing protocol or metadata")
+                let crc = crc_update.into_crc_for_version_zero().ok_or_else(|| {
+                    Error::internal_error("CREATE TABLE CrcUpdate is missing protocol or metadata")
                 })?;
                 let stats = PostCommitStats {
                     commits_since_checkpoint: 1,
                     commits_since_log_compaction: 1,
                 };
-                let snapshot = Snapshot::new_with_crc(
-                    log_segment,
-                    self.effective_table_config,
-                    Arc::new(LazyCrc::new_precomputed(crc, 0)),
-                );
+                let snapshot =
+                    Snapshot::new_with_crc(log_segment, self.effective_table_config, Arc::new(crc));
                 (stats, Arc::new(snapshot))
             }
         };
@@ -1177,19 +1175,30 @@ impl<S> Transaction<S> {
         })
     }
 
-    /// Build a [`CrcDelta`] from the transaction's staged file metadata and commit state.
-    fn build_crc_delta(
+    /// Build a [`CrcUpdate`] from the transaction's staged file metadata and commit state.
+    ///
+    /// Produces the universal delta type. The post-commit path applies it onto the read
+    /// snapshot's [`Crc`] (or builds a fresh Crc for CREATE TABLE).
+    fn build_crc_update(
         &self,
         in_commit_timestamp: Option<i64>,
         dm_changes: Vec<DomainMetadata>,
         bin_boundaries: Option<&[i64]>,
-    ) -> DeltaResult<CrcDelta> {
+    ) -> DeltaResult<CrcUpdate> {
         let file_stats = FileStatsDelta::try_compute_for_txn(
             &self.add_files_metadata,
             &self.remove_files_metadata,
             bin_boundaries,
         )?;
-        Ok(CrcDelta {
+        // Operation safety: precomputed once. The transaction's operation comes from the
+        // caller (engine_info / commitInfo). Unknown / unsafe ops produce a CrcUpdate with
+        // `operation_safe = false`, which transitions the post-commit Crc's file stats to
+        // Indeterminate.
+        let operation_safe = self
+            .operation
+            .as_deref()
+            .is_some_and(FileStatsDelta::is_incremental_safe);
+        Ok(CrcUpdate {
             file_stats,
             protocol: self
                 .should_emit_protocol
@@ -1197,11 +1206,18 @@ impl<S> Transaction<S> {
             metadata: self
                 .should_emit_metadata
                 .then(|| self.effective_table_config.metadata().clone()),
-            domain_metadata_changes: dm_changes,
-            set_transaction_changes: self.set_transactions.clone(),
+            domain_metadata: dm_changes
+                .into_iter()
+                .map(|dm| (dm.domain().to_string(), dm))
+                .collect(),
+            set_transactions: self
+                .set_transactions
+                .iter()
+                .map(|txn| (txn.app_id.clone(), txn.clone()))
+                .collect(),
             in_commit_timestamp,
-            operation: self.operation.clone(),
-            has_missing_file_size: false, // writes always have sizes
+            operation_safe,
+            has_missing_file_size: false, // writes always include file sizes
         })
     }
 

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -1136,7 +1136,7 @@ impl<S> Transaction<S> {
 
         let (post_commit_stats, post_commit_snapshot) = match &self.read_snapshot_opt {
             Some(snap) => {
-                // Existing table path: Crc[N] + CrcUpdate(N→N+1) = Crc[N+1].
+                // Existing table path: Crc[N] + CrcUpdate(N->N+1) = Crc[N+1].
                 let stats = PostCommitStats {
                     commits_since_checkpoint: snap.log_segment().commits_since_checkpoint() + 1,
                     commits_since_log_compaction: snap

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -478,7 +478,7 @@ impl<S> Transaction<S> {
                 let bin_boundaries = self
                     .read_snapshot_opt
                     .as_ref()
-                    .and_then(|snap| snap.get_file_stats_if_loaded())
+                    .and_then(|snap| snap.get_file_stats())
                     .and_then(|s| s.file_size_histogram)
                     .map(|h| h.sorted_bin_boundaries);
                 let crc_update = self.build_crc_update(
@@ -1155,9 +1155,9 @@ impl<S> Transaction<S> {
                     .table_root()
                     .join("_delta_log/")?;
                 let log_segment = LogSegment::new_for_version_zero(log_root, parsed_commit)?;
-                let crc = crc_update.into_crc_for_version_zero().ok_or_else(|| {
-                    Error::internal_error("CREATE TABLE CrcUpdate is missing protocol or metadata")
-                })?;
+                // into_fresh_crc preserves the underlying error variant (MissingProtocol /
+                // MissingMetadata) instead of collapsing to a generic message.
+                let crc = crc_update.into_fresh_crc()?;
                 let stats = PostCommitStats {
                     commits_since_checkpoint: 1,
                     commits_since_log_compaction: 1,

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -1223,7 +1223,9 @@ impl<S> Transaction<S> {
                 .iter()
                 .map(|txn| (txn.app_id.clone(), txn.clone()))
                 .collect(),
-            in_commit_timestamp,
+            // Commit-time always observes ICT (the transaction either has ICT enabled
+            // and computed a value, or doesn't). Wrap in outer Some to signal "observed".
+            in_commit_timestamp: Some(in_commit_timestamp),
             operation_safe,
             has_missing_file_size: false, // writes always include file sizes
         })

--- a/kernel/tests/crc.rs
+++ b/kernel/tests/crc.rs
@@ -432,6 +432,131 @@ async fn test_post_commit_crc_non_incremental_op_makes_file_stats_indeterminate(
     Ok(())
 }
 
+#[tokio::test]
+async fn test_load_file_stats_recovers_indeterminate_to_valid() -> DeltaResult<()> {
+    // Given a snapshot whose CRC has Indeterminate file stats (because an unsafe op was
+    // applied), load_file_stats performs full action reconciliation and returns a new
+    // snapshot with Valid stats. All other CRC fields (P/M, DM, txns) are preserved.
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    // Build a table with two inserts then an ANALYZE STATS, putting the post-commit CRC
+    // into Indeterminate.
+    let committed = create_table_and_commit(&table_path, engine.as_ref())?;
+    let snapshot_v0 = committed.post_commit_snapshot().unwrap().clone();
+
+    let col: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+    let committed = insert_data(snapshot_v0, &engine, vec![col])
+        .await?
+        .unwrap_committed();
+    let snapshot_v1 = committed.post_commit_snapshot().unwrap().clone();
+    let stats_v1 = snapshot_v1.get_or_load_file_stats(engine.as_ref()).unwrap();
+
+    // ANALYZE STATS at v2 → Indeterminate
+    let committed = snapshot_v1
+        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .with_operation("ANALYZE STATS".to_string())
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+    let snapshot_v2 = committed.post_commit_snapshot().unwrap().clone();
+    assert_eq!(
+        snapshot_v2
+            .get_current_crc_if_loaded_for_testing()
+            .unwrap()
+            .file_stats_validity(),
+        FileStatsValidity::Indeterminate
+    );
+
+    // ===== WHEN =====
+    let recovered = snapshot_v2.load_file_stats(engine.as_ref())?;
+
+    // ===== THEN: file stats are Valid and match what they were before the unsafe op =====
+    assert_eq!(
+        recovered
+            .get_current_crc_if_loaded_for_testing()
+            .unwrap()
+            .file_stats_validity(),
+        FileStatsValidity::Valid
+    );
+    let stats_recovered = recovered.get_or_load_file_stats(engine.as_ref()).unwrap();
+    assert_eq!(stats_recovered.num_files(), stats_v1.num_files());
+    assert_eq!(
+        stats_recovered.table_size_bytes(),
+        stats_v1.table_size_bytes()
+    );
+    // Histogram is rebuilt during recovery.
+    assert!(stats_recovered.file_size_histogram().is_some());
+
+    // Other CRC fields preserved.
+    let recovered_crc = recovered.get_current_crc_if_loaded_for_testing().unwrap();
+    let original_crc = snapshot_v2.get_current_crc_if_loaded_for_testing().unwrap();
+    assert_eq!(recovered_crc.protocol, original_crc.protocol);
+    assert_eq!(recovered_crc.metadata, original_crc.metadata);
+    assert_eq!(
+        recovered_crc.domain_metadata.map(),
+        original_crc.domain_metadata.map()
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_load_file_stats_recovered_crc_can_be_written_to_disk() -> DeltaResult<()> {
+    // After recovery, the snapshot's CRC is Valid, so write_checksum succeeds. This is the
+    // end-to-end win for connectors: ANALYZE STATS no longer permanently blocks CRC writes.
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let committed = create_table_and_commit(&table_path, engine.as_ref())?;
+    let snapshot_v0 = committed.post_commit_snapshot().unwrap().clone();
+
+    let col: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+    let committed = insert_data(snapshot_v0, &engine, vec![col])
+        .await?
+        .unwrap_committed();
+    let snapshot_v1 = committed.post_commit_snapshot().unwrap().clone();
+
+    let committed = snapshot_v1
+        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .with_operation("ANALYZE STATS".to_string())
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+    let snapshot_v2 = committed.post_commit_snapshot().unwrap().clone();
+
+    // Before recovery: write_checksum errors with ChecksumWriteUnsupported.
+    let err = snapshot_v2.write_checksum(engine.as_ref()).unwrap_err();
+    assert!(matches!(
+        err,
+        delta_kernel::Error::ChecksumWriteUnsupported(_)
+    ));
+
+    // Recover and write succeeds.
+    let recovered = snapshot_v2.load_file_stats(engine.as_ref())?;
+    let (result, _) = recovered.write_checksum(engine.as_ref())?;
+    assert_eq!(result, ChecksumWriteResult::Written);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_load_file_stats_on_valid_snapshot_returns_same_snapshot() -> DeltaResult<()> {
+    // load_file_stats short-circuits when the CRC is already Valid: returns Arc::clone(self).
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let committed = create_table_and_commit(&table_path, engine.as_ref())?;
+    let snapshot = committed.post_commit_snapshot().unwrap().clone();
+    assert_eq!(
+        snapshot
+            .get_current_crc_if_loaded_for_testing()
+            .unwrap()
+            .file_stats_validity(),
+        FileStatsValidity::Valid
+    );
+
+    let recovered = snapshot.load_file_stats(engine.as_ref())?;
+
+    // Same Arc.
+    assert!(Arc::ptr_eq(&snapshot, &recovered));
+
+    Ok(())
+}
+
 // ============================================================================
 // Write checksum to disk
 // ============================================================================

--- a/kernel/tests/crc.rs
+++ b/kernel/tests/crc.rs
@@ -1510,3 +1510,175 @@ async fn test_file_histogram_with_bin_type_and_operation_type(
 
     Ok(())
 }
+
+// ============================================================================
+// Stale CRC: replay newer commits onto older CRC. Covers:
+//   - CRC missing DomainMetadata field   ->  Untracked + Partial transition
+//   - CRC missing setTransactions field  ->  Untracked + Partial transition
+//   - CRC missing fileSizeHistogram      ->  no histogram in result
+//   - Replay encounters non-incremental  ->  Indeterminate
+// ============================================================================
+
+/// Rewrites `<table>/_delta_log/<version>.crc` by mutating its parsed JSON via the given
+/// closure. This is the test helper for "what if the on-disk CRC file lacked field X?"
+/// scenarios.
+fn rewrite_crc_with<F: FnOnce(&mut serde_json::Value)>(table_path: &str, version: u64, mutate: F) {
+    let crc_file = std::path::PathBuf::from(table_path)
+        .join("_delta_log")
+        .join(format!("{version:020}.crc"));
+    let bytes = std::fs::read(&crc_file).unwrap();
+    let mut value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    mutate(&mut value);
+    std::fs::write(&crc_file, serde_json::to_string(&value).unwrap()).unwrap();
+}
+
+#[tokio::test]
+async fn test_stale_crc_missing_dm_replays_to_partial_with_newer_commit_dm() -> DeltaResult<()> {
+    // GIVEN: table with CRC at v0 (Complete DM), then v1 adds a new domain.
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let committed = create_table_and_commit(&table_path, engine.as_ref())?;
+    let snapshot_v0 = committed.post_commit_snapshot().unwrap().clone();
+    snapshot_v0.write_checksum(engine.as_ref())?;
+
+    // Strip domainMetadata from 0.crc to simulate an older CRC writer that didn't track DM.
+    rewrite_crc_with(&table_path, 0, |v| {
+        v.as_object_mut().unwrap().remove("domainMetadata");
+    });
+
+    // v1: a new domain "alpha" with a value.
+    let committed = snapshot_v0
+        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .with_operation("WRITE".to_string())
+        .with_domain_metadata("alpha".to_string(), "{\"v\": 1}".to_string())
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+    assert_eq!(committed.commit_version(), 1);
+    drop(committed);
+
+    // WHEN: load fresh snapshot at v1 (forces stale-CRC + replay path).
+    let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert_eq!(snapshot.version(), 1);
+
+    // THEN: DM state is Partial — we have alpha from the v1 replay, but the older clustering
+    // domain (set at CREATE TABLE) is unknown to the cache (CRC didn't track it).
+    let crc = snapshot.get_current_crc_if_loaded_for_testing().unwrap();
+    assert!(
+        matches!(crc.domain_metadata, DomainMetadataState::Partial(_)),
+        "expected Partial, got {:?}",
+        crc.domain_metadata
+    );
+    let map = crc.domain_metadata.map().unwrap();
+    assert_eq!(map["alpha"].configuration(), "{\"v\": 1}");
+    // Specific-domain query for a USER (non-internal) domain that's known absent from
+    // both the Partial cache and the log: returns None (cache miss falls through to
+    // replay).
+    let unknown = snapshot.get_domain_metadata("never.set", engine.as_ref())?;
+    assert!(unknown.is_none(), "unknown user domain should be None");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_stale_crc_missing_set_transactions_replays_to_partial() -> DeltaResult<()> {
+    // GIVEN: table at v0 with CRC, then v1 adds a setTransaction.
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let committed = create_table_and_commit(&table_path, engine.as_ref())?;
+    let snapshot_v0 = committed.post_commit_snapshot().unwrap().clone();
+    snapshot_v0.write_checksum(engine.as_ref())?;
+
+    rewrite_crc_with(&table_path, 0, |v| {
+        v.as_object_mut().unwrap().remove("setTransactions");
+    });
+
+    // v1: empty commit with a setTransaction.
+    let committed = snapshot_v0
+        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .with_operation("WRITE".to_string())
+        .with_transaction_id("app-1".to_string(), 7)
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+    assert_eq!(committed.commit_version(), 1);
+    drop(committed);
+
+    let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert!(
+        matches!(
+            snapshot
+                .get_current_crc_if_loaded_for_testing()
+                .unwrap()
+                .set_transactions,
+            SetTransactionState::Partial(_)
+        ),
+        "expected Partial set_transactions"
+    );
+    // Specific app_id query against Partial returns from cache (no log replay).
+    let app_version = snapshot.get_app_id_version("app-1", engine.as_ref())?;
+    assert_eq!(app_version, Some(7));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_stale_crc_missing_histogram_replays_with_no_histogram() -> DeltaResult<()> {
+    // When the on-disk CRC at X has no histogram, applying a delta histogram from
+    // commits X+1..N onto a None base must drop the histogram (per the histogram merge
+    // rule (None, Some) -> None: a delta is an increment over an unknown baseline).
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let committed = create_table_and_commit(&table_path, engine.as_ref())?;
+    let snapshot_v0 = committed.post_commit_snapshot().unwrap().clone();
+    snapshot_v0.write_checksum(engine.as_ref())?;
+
+    rewrite_crc_with(&table_path, 0, |v| {
+        v.as_object_mut().unwrap().remove("fileSizeHistogram");
+    });
+
+    let col: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+    let _ = insert_data(snapshot_v0, &engine, vec![col])
+        .await?
+        .unwrap_committed();
+
+    let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    let crc = snapshot.get_current_crc_if_loaded_for_testing().unwrap();
+    let stats = crc.file_stats().unwrap();
+    assert_eq!(stats.num_files(), 1);
+    assert!(stats.table_size_bytes() > 0);
+    assert!(
+        stats.file_size_histogram().is_none(),
+        "stale CRC without histogram + delta histogram → no histogram in result"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_stale_crc_replay_hits_non_incremental_op_transitions_to_indeterminate(
+) -> DeltaResult<()> {
+    // CRC at v0 is Valid; v1 commit has ANALYZE STATS (non-incremental). The stale-replay
+    // path produces a CrcUpdate with operation_safe=false; Crc::apply transitions file
+    // stats to Indeterminate.
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let committed = create_table_and_commit(&table_path, engine.as_ref())?;
+    let snapshot_v0 = committed.post_commit_snapshot().unwrap().clone();
+    snapshot_v0.write_checksum(engine.as_ref())?;
+
+    let _committed = snapshot_v0
+        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .with_operation("ANALYZE STATS".to_string())
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert_eq!(snapshot.version(), 1);
+    let crc = snapshot.get_current_crc_if_loaded_for_testing().unwrap();
+    assert_eq!(crc.file_stats_validity(), FileStatsValidity::Indeterminate);
+
+    // Recovery via load_file_stats restores Valid.
+    let recovered = snapshot.load_file_stats(engine.as_ref())?;
+    let crc_recovered = recovered.get_current_crc_if_loaded_for_testing().unwrap();
+    assert_eq!(
+        crc_recovered.file_stats_validity(),
+        FileStatsValidity::Valid
+    );
+
+    Ok(())
+}

--- a/kernel/tests/crc.rs
+++ b/kernel/tests/crc.rs
@@ -224,7 +224,7 @@ async fn test_post_commit_crc_always_chains_under_eager_arc_crc_design(
     #[case] use_post_commit_snapshot: bool,
 ) -> DeltaResult<()> {
     // Under the eager Arc<Crc> design, every snapshot has a CRC. The post-commit chain
-    // (Crc[N] + CrcUpdate(N→N+1) = Crc[N+1]) works regardless of how Crc[N] was sourced
+    // (Crc[N] + CrcUpdate(N->N+1) = Crc[N+1]) works regardless of how Crc[N] was sourced
     // -- post-commit-from-prior-commit, fresh-from-disk, full replay, etc.
     let (_temp_dir, table_path, engine) = test_table_setup()?;
     let create_committed = create_table_and_commit(&table_path, engine.as_ref())?;
@@ -451,7 +451,7 @@ async fn test_load_file_stats_recovers_indeterminate_to_valid() -> DeltaResult<(
     let snapshot_v1 = committed.post_commit_snapshot().unwrap().clone();
     let stats_v1 = snapshot_v1.get_file_stats().unwrap();
 
-    // ANALYZE STATS at v2 → Indeterminate
+    // ANALYZE STATS at v2 -> Indeterminate
     let committed = snapshot_v1
         .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_operation("ANALYZE STATS".to_string())
@@ -761,7 +761,7 @@ async fn test_incremental_snapshot_old_crc_only_builds_crc_via_stale_replay() ->
 
     // Incrementally update from v0 -> v1. The new listing finds no v1 CRC file but the
     // old segment's 0.crc is preserved. The new snapshot's CRC is built by:
-    //   load 0.crc → Crc[0] → reverse-replay commit v1 → apply → Crc[1].
+    //   load 0.crc -> Crc[0] -> reverse-replay commit v1 -> apply -> Crc[1].
     let incremental_v1 = Snapshot::builder_from(fresh_v0).build(engine.as_ref())?;
     assert_eq!(incremental_v1.version(), 1);
     let crc_v1 = incremental_v1
@@ -1644,7 +1644,7 @@ async fn test_stale_crc_missing_histogram_replays_with_no_histogram() -> DeltaRe
     assert!(stats.table_size_bytes() > 0);
     assert!(
         stats.file_size_histogram().is_none(),
-        "stale CRC without histogram + delta histogram → no histogram in result"
+        "stale CRC without histogram + delta histogram -> no histogram in result"
     );
 
     Ok(())

--- a/kernel/tests/crc.rs
+++ b/kernel/tests/crc.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use delta_kernel::arrow::array::{ArrayRef, Int32Array, StringArray};
 use delta_kernel::committer::FileSystemCommitter;
-use delta_kernel::crc::{Crc, FileStatsValidity};
+use delta_kernel::crc::{Crc, DomainMetadataState, FileStatsValidity, SetTransactionState};
 use delta_kernel::engine::default::DefaultEngineBuilder;
 use delta_kernel::object_store::local::LocalFileSystem;
 use delta_kernel::schema::{DataType, StructField, StructType};
@@ -40,7 +40,11 @@ async fn test_get_file_stats_from_crc() -> DeltaResult<()> {
 }
 
 #[tokio::test]
-async fn test_get_file_stats_no_crc() -> DeltaResult<()> {
+async fn test_get_file_stats_no_crc_file_built_from_scratch_has_valid_zero_stats() -> DeltaResult<()>
+{
+    // Under the eager Arc<Crc> design, snapshots without an on-disk CRC fall through to
+    // `build_crc_from_scratch` (full reverse log replay). For a freshly created table
+    // (just CREATE TABLE), this produces Valid file stats with zero counts and bytes.
     let (_temp_dir, table_path, engine) = test_table_setup()?;
 
     let schema = Arc::new(StructType::try_new(vec![
@@ -56,8 +60,9 @@ async fn test_get_file_stats_no_crc() -> DeltaResult<()> {
     let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
     assert_eq!(snapshot.version(), 0);
 
-    let file_stats = snapshot.get_or_load_file_stats(engine.as_ref());
-    assert_eq!(file_stats, None);
+    let file_stats = snapshot.get_or_load_file_stats(engine.as_ref()).unwrap();
+    assert_eq!(file_stats.num_files(), 0);
+    assert_eq!(file_stats.table_size_bytes(), 0);
 
     Ok(())
 }
@@ -118,15 +123,13 @@ async fn test_get_current_crc_if_loaded_returns_loaded_crc() -> DeltaResult<()> 
     let file_stats = crc.file_stats().unwrap();
     assert_eq!(file_stats.table_size_bytes(), 5259);
     assert_eq!(file_stats.num_files(), 10);
-    assert_eq!(crc.num_metadata, 1);
-    assert_eq!(crc.num_protocol, 1);
 
     // Protocol and metadata should match the snapshot's table configuration
     assert_eq!(crc.protocol, *snapshot.table_configuration().protocol());
     assert_eq!(crc.metadata, *snapshot.table_configuration().metadata());
 
     // Domain metadata
-    let dms = crc.domain_metadata.as_ref().unwrap();
+    let dms = crc.domain_metadata.map().unwrap();
     assert_eq!(dms.len(), 3);
     assert!(dms.contains_key("delta.clustering"));
     assert!(dms.contains_key("delta.rowTracking"));
@@ -136,7 +139,10 @@ async fn test_get_current_crc_if_loaded_returns_loaded_crc() -> DeltaResult<()> 
 }
 
 #[tokio::test]
-async fn test_get_current_crc_if_loaded_returns_none_when_no_crc() -> DeltaResult<()> {
+async fn test_crc_built_from_scratch_when_no_crc_file_on_disk() -> DeltaResult<()> {
+    // Under the eager-Arc<Crc> design, snapshot loading always produces a Crc[N]. When no
+    // CRC file is on disk, the snapshot path falls through to build_crc_from_scratch (full
+    // log replay). The resulting Crc is Valid (no unsafe ops, no missing remove sizes).
     let (_temp_dir, table_path, engine) = test_table_setup()?;
 
     let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
@@ -152,8 +158,18 @@ async fn test_get_current_crc_if_loaded_returns_none_when_no_crc() -> DeltaResul
     let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
     assert_eq!(snapshot.version(), 0);
 
-    // No CRC file exists, so get_current_crc_if_loaded_for_testing should return None
-    assert!(snapshot.get_current_crc_if_loaded_for_testing().is_none());
+    // CRC is always present.
+    let crc = snapshot.get_current_crc_if_loaded_for_testing().unwrap();
+
+    // Full replay produces Valid file stats (CREATE TABLE has 0 files).
+    assert_eq!(crc.file_stats_validity(), FileStatsValidity::Valid);
+    let stats = crc.file_stats().unwrap();
+    assert_eq!(stats.num_files(), 0);
+    assert_eq!(stats.table_size_bytes(), 0);
+
+    // Full replay captures complete DM and txn state.
+    assert!(crc.domain_metadata.is_complete());
+    assert!(crc.set_transactions.is_complete());
 
     Ok(())
 }
@@ -192,39 +208,42 @@ async fn test_create_table_produces_post_commit_crc() -> DeltaResult<()> {
     let file_stats = crc.file_stats().unwrap();
     assert_eq!(file_stats.num_files(), 0);
     assert_eq!(file_stats.table_size_bytes(), 0);
-    assert_eq!(crc.num_metadata, 1);
-    assert_eq!(crc.num_protocol, 1);
     assert_eq!(crc.protocol, *snapshot.table_configuration().protocol());
     assert_eq!(crc.metadata, *snapshot.table_configuration().metadata());
-    let dms = crc.domain_metadata.as_ref().unwrap();
+    let dms = crc.domain_metadata.map().unwrap();
     assert_eq!(dms["zip"].configuration(), "zap0");
 
     Ok(())
 }
 
 #[rstest]
-#[case::with_in_memory_crc(true)]
-#[case::without_crc(false)]
+#[case::from_post_commit_snapshot(true)]
+#[case::from_fresh_disk_snapshot(false)]
 #[tokio::test]
-async fn test_post_commit_crc_chains_only_if_read_snapshot_has_crc(
+async fn test_post_commit_crc_always_chains_under_eager_arc_crc_design(
     #[case] use_post_commit_snapshot: bool,
 ) -> DeltaResult<()> {
+    // Under the eager Arc<Crc> design, every snapshot has a CRC. The post-commit chain
+    // (Crc[N] + CrcUpdate(N→N+1) = Crc[N+1]) works regardless of how Crc[N] was sourced
+    // -- post-commit-from-prior-commit, fresh-from-disk, full replay, etc.
     let (_temp_dir, table_path, engine) = test_table_setup()?;
     let create_committed = create_table_and_commit(&table_path, engine.as_ref())?;
 
     let read_snapshot = if use_post_commit_snapshot {
-        // Post-commit snapshot has in-memory CRC from the previous commit.
+        // Post-commit snapshot's Crc was constructed via apply().
         create_committed.post_commit_snapshot().unwrap().clone()
     } else {
-        // Fresh-from-disk snapshot has no CRC (no .crc file on disk).
+        // Fresh-from-disk snapshot's Crc was built via build_crc_from_scratch (no CRC file).
         Snapshot::builder_for(table_path).build(engine.as_ref())?
     };
-    assert_eq!(
-        read_snapshot
-            .get_current_crc_if_loaded_for_testing()
-            .is_some(),
-        use_post_commit_snapshot
-    );
+    let base_crc = read_snapshot
+        .get_current_crc_if_loaded_for_testing()
+        .unwrap();
+    // Both paths produce Valid file stats and Complete DM, just via different routes:
+    //   post-commit: CrcUpdate::into_fresh_crc on a CREATE TABLE delta.
+    //   fresh-from-disk: build_crc_from_scratch reverse-replays the entire log.
+    assert_eq!(base_crc.file_stats_validity(), FileStatsValidity::Valid);
+    assert!(base_crc.domain_metadata.is_complete());
 
     let committed = read_snapshot
         .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
@@ -233,16 +252,19 @@ async fn test_post_commit_crc_chains_only_if_read_snapshot_has_crc(
         .commit(engine.as_ref())?
         .unwrap_committed();
 
-    // The new post-commit snapshot should only have a CRC if the read snapshot had one.
     assert_eq!(committed.commit_version(), 1);
-    assert_eq!(
-        committed
-            .post_commit_snapshot()
-            .unwrap()
-            .get_current_crc_if_loaded_for_testing()
-            .is_some(),
-        use_post_commit_snapshot
-    );
+    let post_crc = committed
+        .post_commit_snapshot()
+        .unwrap()
+        .get_current_crc_if_loaded_for_testing()
+        .unwrap();
+    // Both paths produce Valid + Complete because Crc[N].apply(update) preserves the
+    // base's variant: a Valid base + safe op stays Valid, a Complete DM map upserts and
+    // stays Complete.
+    assert_eq!(post_crc.file_stats_validity(), FileStatsValidity::Valid);
+    assert!(post_crc.domain_metadata.is_complete());
+    let dms = post_crc.domain_metadata.map().unwrap();
+    assert_eq!(dms["zip"].configuration(), "zap1");
 
     Ok(())
 }
@@ -338,7 +360,7 @@ async fn test_post_commit_crc_tracks_domain_metadata_changes() -> DeltaResult<()
 
     // ===== THEN: should have CRC at v0 with zip -> zap0 =====
     let crc_v0 = write_and_verify_crc(snapshot_v0, &table_path, engine.as_ref());
-    let dms = crc_v0.domain_metadata.as_ref().unwrap();
+    let dms = crc_v0.domain_metadata.map().unwrap();
     assert_eq!(dms["zip"].configuration(), "zap0");
 
     // ===== WHEN: update zip -> zap1, add foo -> bar =====
@@ -353,7 +375,7 @@ async fn test_post_commit_crc_tracks_domain_metadata_changes() -> DeltaResult<()
     // ===== THEN: should have CRC at v1 with zip -> zap1, foo -> bar =====
     let snapshot_v1 = committed.post_commit_snapshot().unwrap();
     let crc_v1 = write_and_verify_crc(snapshot_v1, &table_path, engine.as_ref());
-    let dms = crc_v1.domain_metadata.as_ref().unwrap();
+    let dms = crc_v1.domain_metadata.map().unwrap();
     assert_eq!(dms["zip"].configuration(), "zap1"); // <-- must be zap1
     assert_eq!(dms["foo"].configuration(), "bar"); // <-- must be bar
 
@@ -368,7 +390,7 @@ async fn test_post_commit_crc_tracks_domain_metadata_changes() -> DeltaResult<()
     // ===== THEN: should have CRC at v2 with zip gone, foo still there =====
     let snapshot_v2 = committed.post_commit_snapshot().unwrap();
     let crc_v2 = write_and_verify_crc(snapshot_v2, &table_path, engine.as_ref());
-    let dms = crc_v2.domain_metadata.as_ref().unwrap();
+    let dms = crc_v2.domain_metadata.map().unwrap();
     assert!(!dms.contains_key("zip")); // <-- must be gone
     assert_eq!(dms["foo"].configuration(), "bar"); // <-- must still be bar
 
@@ -402,7 +424,10 @@ async fn test_post_commit_crc_non_incremental_op_makes_file_stats_indeterminate(
     assert_eq!(committed.commit_version(), 2);
     let snapshot_v2 = committed.post_commit_snapshot().unwrap();
     let crc_v2 = snapshot_v2.get_current_crc_if_loaded_for_testing().unwrap();
-    assert_eq!(crc_v2.file_stats_validity, FileStatsValidity::Indeterminate);
+    assert_eq!(
+        crc_v2.file_stats_validity(),
+        FileStatsValidity::Indeterminate
+    );
 
     Ok(())
 }
@@ -457,15 +482,26 @@ async fn test_write_checksum_double_write_returns_already_exists(
 }
 
 #[tokio::test]
-async fn test_write_checksum_with_no_in_memory_crc_returns_error() -> DeltaResult<()> {
+async fn test_write_checksum_from_fresh_disk_snapshot_succeeds_under_eager_arc_crc(
+) -> DeltaResult<()> {
+    // Under the eager Arc<Crc> design, a fresh-from-disk snapshot has a CRC built via
+    // build_crc_from_scratch (full reverse log replay). For a freshly created table with
+    // no remove actions and a known WRITE op, the resulting Crc has Valid file stats and
+    // can be written to disk.
     let (_temp_dir, table_path, engine) = test_table_setup()?;
     let _ = create_table_and_commit(&table_path, engine.as_ref())?;
 
-    // Load from disk -- no CRC file on disk, so no in-memory CRC
     let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert_eq!(
+        snapshot
+            .get_current_crc_if_loaded_for_testing()
+            .unwrap()
+            .file_stats_validity(),
+        FileStatsValidity::Valid
+    );
 
-    let result = snapshot.write_checksum(engine.as_ref());
-    assert!(result.is_err());
+    let (result, _) = snapshot.write_checksum(engine.as_ref())?;
+    assert_eq!(result, ChecksumWriteResult::Written);
 
     Ok(())
 }
@@ -566,11 +602,11 @@ async fn test_incremental_snapshot_preserves_loaded_crc() -> DeltaResult<()> {
 }
 
 // Incremental update where only the old segment has a CRC file (no new CRC written).
-// The old CRC is preserved and the LazyCrc is reused from the old snapshot, but since
-// it's at v0 while the snapshot is at v1, it won't be reported as loaded at the
-// snapshot's version.
+// Under the eager Arc<Crc> design, the snapshot at v1 builds Crc[1] via stale CRC
+// (loading 0.crc) + reverse-replaying commit v1 + applying. Result: the snapshot has a
+// real, complete Crc[1] in memory.
 #[tokio::test]
-async fn test_incremental_snapshot_old_crc_no_new_crc() -> DeltaResult<()> {
+async fn test_incremental_snapshot_old_crc_only_builds_crc_via_stale_replay() -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
 
     // Create table at v0 and write CRC to disk
@@ -591,28 +627,29 @@ async fn test_incremental_snapshot_old_crc_no_new_crc() -> DeltaResult<()> {
     .unwrap_committed();
     assert_eq!(committed_v1.commit_version(), 1);
 
-    // Load a fresh snapshot at v0 (this loads 0.crc during P&M reading)
+    // Load a fresh snapshot at v0 -- has Crc[0] loaded directly from 0.crc.
     let fresh_v0 = Snapshot::builder_for(&table_path)
         .at_version(0)
         .build(engine.as_ref())?;
-    assert!(
-        fresh_v0.get_current_crc_if_loaded_for_testing().is_some(),
-        "Fresh v0 snapshot should have CRC loaded from 0.crc"
-    );
+    let crc_v0 = fresh_v0.get_current_crc_if_loaded_for_testing().unwrap();
+    assert_eq!(crc_v0.file_stats().unwrap().num_files(), 0);
 
-    // Incrementally update from v0 -> v1. The new listing (starting at v1) doesn't find
-    // any CRC file, so it falls back to the old segment's 0.crc. Since the old snapshot's
-    // LazyCrc is at the same version, it is reused (may already be loaded in memory).
+    // Incrementally update from v0 -> v1. The new listing finds no v1 CRC file but the
+    // old segment's 0.crc is preserved. The new snapshot's CRC is built by:
+    //   load 0.crc → Crc[0] → reverse-replay commit v1 → apply → Crc[1].
     let incremental_v1 = Snapshot::builder_from(fresh_v0).build(engine.as_ref())?;
     assert_eq!(incremental_v1.version(), 1);
-
-    // The CRC is at v0, not v1, so it won't be reported as loaded at v1
-    assert!(
-        incremental_v1
-            .get_current_crc_if_loaded_for_testing()
-            .is_none(),
-        "CRC at v0 should not be reported as loaded at v1 (version mismatch)"
+    let crc_v1 = incremental_v1
+        .get_current_crc_if_loaded_for_testing()
+        .unwrap();
+    assert_eq!(
+        crc_v1.file_stats_validity(),
+        FileStatsValidity::Valid,
+        "Stale CRC + replay should produce a Valid Crc[1]"
     );
+    let stats_v1 = crc_v1.file_stats().unwrap();
+    assert_eq!(stats_v1.num_files(), 1, "v1 added one file");
+    assert!(stats_v1.table_size_bytes() > 0);
 
     Ok(())
 }
@@ -653,7 +690,10 @@ async fn test_write_checksum_with_no_dms_writes_empty_list(
         .get_all_domain_metadata(engine.as_ref())?
         .is_empty());
     let crc = write_and_verify_crc(snapshot, &table_path, engine.as_ref());
-    assert_eq!(crc.domain_metadata, Some(Default::default()));
+    assert_eq!(
+        crc.domain_metadata,
+        DomainMetadataState::Complete(Default::default())
+    );
 
     Ok(())
 }
@@ -721,29 +761,37 @@ async fn test_get_domain_metadata_with_crc_skips_log_replay() -> DeltaResult<()>
         );
     };
 
-    // Case 1: Post-commit snapshot with in-memory CRC => DM loaded from CRC (fast path).
-    //         Use NoJsonReadsEngine to prove no log replay occurs.
+    // Case 1: Post-commit snapshot's CRC is built via apply with Complete DM state.
+    //         FailingEngine proves no log replay occurs.
     let post_commit_snapshot = committed.post_commit_snapshot().unwrap();
     assert!(post_commit_snapshot
         .get_current_crc_if_loaded_for_testing()
-        .is_some());
+        .unwrap()
+        .domain_metadata
+        .is_complete());
     assert_domain_metadata(post_commit_snapshot, &FailingEngine);
 
-    // Case 2: Fresh snapshot loaded from disk, no CRC file => DM loaded via log replay (slow path)
+    // Case 2: Fresh snapshot loaded from disk, no CRC file. Under the eager Arc<Crc>
+    //         design, build_crc_from_scratch reverse-replays the entire log and produces a
+    //         CRC with Complete DM state. So the DM fast path serves directly from CRC --
+    //         FailingEngine still works.
     let fresh_snapshot_no_crc = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
     assert!(fresh_snapshot_no_crc
         .get_current_crc_if_loaded_for_testing()
-        .is_none());
-    assert_domain_metadata(&fresh_snapshot_no_crc, engine.as_ref());
+        .unwrap()
+        .domain_metadata
+        .is_complete());
+    assert_domain_metadata(&fresh_snapshot_no_crc, &FailingEngine);
 
-    // Case 3: Write CRC to disk, then reload fresh snapshot => DM loaded from CRC (fast path)
-    //         Use NoJsonReadsEngine to prove no log replay occurs.
+    // Case 3: Write CRC to disk, reload. CRC at target loaded directly. Same fast path.
     let _ = post_commit_snapshot.write_checksum(engine.as_ref())?;
 
     let fresh_snapshot_with_crc = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
     assert!(fresh_snapshot_with_crc
         .get_current_crc_if_loaded_for_testing()
-        .is_some());
+        .unwrap()
+        .domain_metadata
+        .is_complete());
     assert_domain_metadata(&fresh_snapshot_with_crc, &FailingEngine);
 
     Ok(())
@@ -766,7 +814,10 @@ async fn test_set_transaction_crc_tracking_and_fast_path() -> DeltaResult<()> {
 
     // Post-commit CRC has empty set_transactions (not null)
     let crc_v0 = write_and_verify_crc(snapshot_v0, &table_path, engine.as_ref());
-    assert_eq!(crc_v0.set_transactions, Some(Default::default()));
+    assert_eq!(
+        crc_v0.set_transactions,
+        SetTransactionState::Complete(Default::default())
+    );
 
     // Fresh snapshot with CRC on disk serves queries via fast path (no log replay)
     let fresh_v0 = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
@@ -804,7 +855,7 @@ async fn test_set_transaction_crc_tracking_and_fast_path() -> DeltaResult<()> {
 
     // Write CRC to disk, reload, verify round-trip and fast path
     let crc_v1 = write_and_verify_crc(snapshot_v1, &table_path, engine.as_ref());
-    let txns_v1 = crc_v1.set_transactions.as_ref().unwrap();
+    let txns_v1 = crc_v1.set_transactions.map().unwrap();
     assert_eq!(txns_v1.len(), 1);
     assert!(txns_v1.contains_key("my-app"));
 
@@ -850,7 +901,7 @@ async fn test_set_transaction_crc_tracking_and_fast_path() -> DeltaResult<()> {
 
     // Write CRC to disk, reload, verify round-trip and fast path
     let crc_v2 = write_and_verify_crc(snapshot_v2, &table_path, engine.as_ref());
-    let txns_v2 = crc_v2.set_transactions.as_ref().unwrap();
+    let txns_v2 = crc_v2.set_transactions.map().unwrap();
     assert_eq!(txns_v2.len(), 2);
 
     let fresh_v2 = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
@@ -1300,7 +1351,10 @@ async fn test_file_histogram_with_bin_type_and_operation_type(
 
     if !incremental {
         // Non-incremental operations drop the histogram regardless of bin type
-        assert_eq!(crc_v2.file_stats_validity, FileStatsValidity::Indeterminate);
+        assert_eq!(
+            crc_v2.file_stats_validity(),
+            FileStatsValidity::Indeterminate
+        );
         assert!(crc_v2.file_stats().is_none());
         return Ok(());
     }

--- a/kernel/tests/crc.rs
+++ b/kernel/tests/crc.rs
@@ -31,7 +31,7 @@ async fn test_get_file_stats_from_crc() -> DeltaResult<()> {
     let snapshot = Snapshot::builder_for(table_root).build(&engine)?;
     assert_eq!(snapshot.version(), 0);
 
-    let file_stats = snapshot.get_or_load_file_stats(&engine).unwrap();
+    let file_stats = snapshot.get_file_stats().unwrap();
     assert_eq!(file_stats.num_files(), 10);
     assert_eq!(file_stats.table_size_bytes(), 5259);
     assert!(file_stats.file_size_histogram().is_some());
@@ -60,7 +60,7 @@ async fn test_get_file_stats_no_crc_file_built_from_scratch_has_valid_zero_stats
     let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
     assert_eq!(snapshot.version(), 0);
 
-    let file_stats = snapshot.get_or_load_file_stats(engine.as_ref()).unwrap();
+    let file_stats = snapshot.get_file_stats().unwrap();
     assert_eq!(file_stats.num_files(), 0);
     assert_eq!(file_stats.table_size_bytes(), 0);
 
@@ -81,7 +81,7 @@ async fn test_get_file_stats_crc_not_at_snapshot_version() -> DeltaResult<()> {
     // Verify the table starts at version 0 with valid CRC stats
     let snapshot = Snapshot::builder_for(table_path.clone()).build(engine.as_ref())?;
     assert_eq!(snapshot.version(), 0);
-    assert!(snapshot.get_or_load_file_stats(engine.as_ref()).is_some());
+    assert!(snapshot.get_file_stats().is_some());
 
     // ===== WHEN =====
     // Empty commit to advance to version 1 (no new CRC file written)
@@ -94,7 +94,7 @@ async fn test_get_file_stats_crc_not_at_snapshot_version() -> DeltaResult<()> {
     assert_eq!(snapshot.version(), 1);
 
     // No CRC at version 1, so file stats should be None
-    let file_stats = snapshot.get_or_load_file_stats(engine.as_ref());
+    let file_stats = snapshot.get_file_stats();
     assert_eq!(file_stats, None);
 
     Ok(())
@@ -449,7 +449,7 @@ async fn test_load_file_stats_recovers_indeterminate_to_valid() -> DeltaResult<(
         .await?
         .unwrap_committed();
     let snapshot_v1 = committed.post_commit_snapshot().unwrap().clone();
-    let stats_v1 = snapshot_v1.get_or_load_file_stats(engine.as_ref()).unwrap();
+    let stats_v1 = snapshot_v1.get_file_stats().unwrap();
 
     // ANALYZE STATS at v2 → Indeterminate
     let committed = snapshot_v1
@@ -477,7 +477,7 @@ async fn test_load_file_stats_recovers_indeterminate_to_valid() -> DeltaResult<(
             .file_stats_validity(),
         FileStatsValidity::Valid
     );
-    let stats_recovered = recovered.get_or_load_file_stats(engine.as_ref()).unwrap();
+    let stats_recovered = recovered.get_file_stats().unwrap();
     assert_eq!(stats_recovered.num_files(), stats_v1.num_files());
     assert_eq!(
         stats_recovered.table_size_bytes(),

--- a/kernel/tests/metrics/snapshot_load.rs
+++ b/kernel/tests/metrics/snapshot_load.rs
@@ -91,14 +91,11 @@ async fn snapshot_with_v1_checkpoint_and_tail_commit_emits_expected_metrics() ->
     assert_eq!(reporter.compaction_files.get(), 0);
 
     // One JSON read for the tail commit. Two Parquet reads for the checkpoint:
-    //   1. Sidecar extraction probe (the CRC schema includes Add/Remove file actions, so
-    //      `create_checkpoint_stream` triggers `extract_sidecar_refs` to detect potential V2
-    //      sidecars; the kernel-written V1 checkpoint includes an empty `sidecar` column in its
-    //      schema, so the probe reads the file).
+    //   1. Sidecar extraction probe -- the CRC build schema includes Add/Remove, so
+    //      `create_checkpoint_stream` triggers `extract_sidecar_refs` to detect any V2 sidecars.
+    //      Kernel-written V1 checkpoints include an empty `sidecar` column in their schema, so the
+    //      probe reads the file.
     //   2. The full data read for the CRC build.
-    // Pre-eager-Crc, the snapshot loaded only with a P&M-only schema (no Add/Remove), so
-    // step 1 was skipped. The eager-Crc design pays this extra read once per snapshot
-    // load on V1 parquet checkpoints.
     assert_eq!(reporter.json_read_calls.get(), 1);
     assert_eq!(reporter.json_files_read.get(), 1);
     assert_eq!(reporter.parquet_read_calls.get(), 2);
@@ -393,7 +390,7 @@ fn get_domain_metadata_after_snapshot_build_is_served_from_crc_with_no_io() -> D
     assert_eq!(
         reporter.json_read_calls.get(),
         0,
-        "get_domain_metadata serves from CRC's Complete DM state under the eager-Crc design"
+        "get_domain_metadata serves from CRC's Complete DM state without log replay"
     );
 
     Ok(())

--- a/kernel/tests/metrics/snapshot_load.rs
+++ b/kernel/tests/metrics/snapshot_load.rs
@@ -90,11 +90,19 @@ async fn snapshot_with_v1_checkpoint_and_tail_commit_emits_expected_metrics() ->
     assert_eq!(reporter.checkpoint_files.get(), 1);
     assert_eq!(reporter.compaction_files.get(), 0);
 
-    // One JSON read for the tail commit; one Parquet read for the checkpoint
+    // One JSON read for the tail commit. Two Parquet reads for the checkpoint:
+    //   1. Sidecar extraction probe (the CRC schema includes Add/Remove file actions, so
+    //      `create_checkpoint_stream` triggers `extract_sidecar_refs` to detect potential V2
+    //      sidecars; the kernel-written V1 checkpoint includes an empty `sidecar` column in its
+    //      schema, so the probe reads the file).
+    //   2. The full data read for the CRC build.
+    // Pre-eager-Crc, the snapshot loaded only with a P&M-only schema (no Add/Remove), so
+    // step 1 was skipped. The eager-Crc design pays this extra read once per snapshot
+    // load on V1 parquet checkpoints.
     assert_eq!(reporter.json_read_calls.get(), 1);
     assert_eq!(reporter.json_files_read.get(), 1);
-    assert_eq!(reporter.parquet_read_calls.get(), 1);
-    assert_eq!(reporter.parquet_files_read.get(), 1);
+    assert_eq!(reporter.parquet_read_calls.get(), 2);
+    assert_eq!(reporter.parquet_files_read.get(), 2);
     // On Windows (NTFS), listing a file written moments earlier can return size=0 because
     // the OS has not yet flushed size metadata to the directory entry. bytes_read is sourced
     // from these FileMeta::size values, so it can be 0 even when real I/O occurred.
@@ -127,11 +135,12 @@ async fn snapshot_at_checkpoint_tip_emits_expected_metrics() -> DeltaResult<()> 
     assert_eq!(reporter.checkpoint_files.get(), 1);
     assert_eq!(reporter.compaction_files.get(), 0);
 
-    // JSON handler is called with zero files; Parquet reads the checkpoint
+    // JSON handler is called once with zero files (empty commit cover). Parquet handler
+    // is called twice: sidecar probe (see comment in scenario 2 above) + full data read.
     assert_eq!(reporter.json_read_calls.get(), 1);
     assert_eq!(reporter.json_files_read.get(), 0);
-    assert_eq!(reporter.parquet_read_calls.get(), 1);
-    assert_eq!(reporter.parquet_files_read.get(), 1);
+    assert_eq!(reporter.parquet_read_calls.get(), 2);
+    assert_eq!(reporter.parquet_files_read.get(), 2);
 
     Ok(())
 }
@@ -336,10 +345,11 @@ async fn checkpoint_with_multiple_tail_commits_emits_expected_metrics() -> Delta
     // Checkpoint at v1 -- listing starts from v2; tail is v2, v3, v4
     assert_eq!(reporter.commit_files.get(), 3);
     assert_eq!(reporter.checkpoint_files.get(), 1);
-    // All 3 tail commits read in a single JSON call; checkpoint in a single Parquet call
+    // All 3 tail commits read in a single JSON call. Checkpoint reads twice: sidecar
+    // probe + full data read (see Scenario 2 comment).
     assert_eq!(reporter.json_read_calls.get(), 1);
     assert_eq!(reporter.json_files_read.get(), 3);
-    assert_eq!(reporter.parquet_read_calls.get(), 1);
+    assert_eq!(reporter.parquet_read_calls.get(), 2);
     // See Scenario 2 comment: Windows NTFS may report stale size=0 for recently written files.
     #[cfg(not(windows))]
     assert!(reporter.json_bytes_read.get() > 0);
@@ -353,15 +363,16 @@ async fn checkpoint_with_multiple_tail_commits_emits_expected_metrics() -> Delta
 // Scenario 8: on-demand domain metadata query incurs additional log replay
 // ============================================================================
 
-/// `snapshot.get_domain_metadata()` always performs a full log replay when no CRC is
-/// present at the target version. Calling it after a snapshot is already built generates
-/// a second round of JSON reads, demonstrating that on-demand metadata queries carry
-/// their own I/O cost.
+/// Under the eager-Crc design, snapshot build captures `Complete` domain metadata as part
+/// of the same reverse log replay used to construct `Crc[N]`. Subsequent
+/// `snapshot.get_domain_metadata()` calls serve from the in-memory `DomainMetadataState::Complete`
+/// map without any additional log replay.
 ///
-/// The specific count (`json_read_calls = 1`) reflects this test's table: 2 commits, no
-/// checkpoint, no CRC. Tables with different log structures will produce different counts.
+/// This is a fast-path win: the OLD design did P&M-only replay during snapshot build and
+/// had to do a separate (full) log replay on first DM query. The new design does ONE
+/// reverse replay total.
 #[test]
-fn get_domain_metadata_when_no_latest_crc_incurs_additional_log_replay() -> DeltaResult<()> {
+fn get_domain_metadata_after_snapshot_build_is_served_from_crc_with_no_io() -> DeltaResult<()> {
     let table = TestTableBuilder::new()
         .with_log_state(LogState::with_commits(2))
         .with_data(1, 1)
@@ -370,19 +381,20 @@ fn get_domain_metadata_when_no_latest_crc_incurs_additional_log_replay() -> Delt
     let (engine, reporter, _guard) = measuring_engine(table.store().clone());
     let snap = Snapshot::builder_for(table.table_root()).build(&engine)?;
 
-    // Snapshot build reads both commit files in one JSON call
+    // Snapshot build reads both commit files in one JSON call (the reverse-replay pass
+    // that builds `Crc[N]` and captures `Complete` DM state).
     assert_eq!(reporter.json_read_calls.get(), 1);
 
-    // Reset so the domain metadata query cost is isolated
+    // Reset so the domain metadata query cost is isolated.
     reporter.reset();
     let _ = snap.get_domain_metadata("myapp.config", &engine)?;
 
+    // Under the eager-Crc design, DM is served from the CRC -- no additional log replay.
     assert_eq!(
         reporter.json_read_calls.get(),
-        1,
-        "get_domain_metadata replays the log, incurring one additional JSON read call"
+        0,
+        "get_domain_metadata serves from CRC's Complete DM state under the eager-Crc design"
     );
-    assert!(reporter.json_files_read.get() > 0);
 
     Ok(())
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Refactor the CRC subsystem around the universal invariant
Crc[N] + CrcUpdate(N->N+1) = Crc[N+1].

- Snapshot stores eager Arc<Crc> instead of Arc<LazyCrc>; CRC always present
- New typed state enums make invalid states unrepresentable:
  FileStatsState (Valid / RequiresCheckpointRead / Indeterminate / Untrackable)
  DomainMetadataState (Complete / Partial / Untracked)
  SetTransactionState (same shape)
- CrcUpdate is the universal delta type; Crc::apply is the only mutator
- CrcRaw serde intermediate maps typed enums to flat Delta-spec JSON
- New reverse log replay accumulator (CrcReplayVisitor) builds Crc from log
  via build_crc_from_stale (stale CRC + replay) and build_crc_from_scratch
  (no CRC, full replay including checkpoint)
- Snapshot::load_file_stats(engine) stub for priority-5 recovery API
- Untracked DM/txn transition to Partial when apply finds entries from
  newer commits, enabling cache-first queries

Includes design doc CLAUDE/crc_design.md covering CUJs, flows, and the
log-state situations covered.

## How was this change tested?
