### PR TITLE
feat!: crc merics using tracing instrumentation

### DIFF
--- a/docs/user-guide/src/observability/observability.md
+++ b/docs/user-guide/src/observability/observability.md
@@ -114,7 +114,7 @@ tracing_subscriber::registry()
 When a snapshot loads, you'll see output like:
 
 ```text
-[kernel-metrics] LogSegmentLoaded(id=a1b2c3d4-..., duration=12.34ms, commits=5, checkpoints=1, compactions=0)
+[kernel-metrics] LogSegmentLoaded(id=a1b2c3d4-..., duration=12.34ms, commits=5, checkpoints=1, compactions=0, has_latest_crc=true)
 [kernel-metrics] ProtocolMetadataLoaded(id=a1b2c3d4-..., duration=3.21ms)
 [kernel-metrics] SnapshotCompleted(id=a1b2c3d4-..., version=5, duration=15.55ms)
 ```
@@ -132,7 +132,7 @@ events from the same snapshot load together.
 
 | Event | Fields | What it measures |
 |-------|--------|------------------|
-| `LogSegmentLoaded` | `operation_id`, `duration`, `num_commit_files`, `num_checkpoint_files`, `num_compaction_files` | Time to list and organize log files into a log segment. |
+| `LogSegmentLoaded` | `operation_id`, `duration`, `num_commit_files`, `num_checkpoint_files`, `num_compaction_files`, `has_latest_crc_file` | Time to list and organize log files into a log segment. |
 | `ProtocolMetadataLoaded` | `operation_id`, `duration` | Time to read protocol and metadata actions from the log. |
 | `SnapshotCompleted` | `operation_id`, `version`, `total_duration` | End-to-end snapshot creation, including the table version that was loaded. |
 | `SnapshotFailed` | `operation_id`, `duration` | Snapshot creation failed. Use this to track error rates. |
@@ -183,6 +183,7 @@ storage call may serve multiple higher-level operations.
 | `StorageCopyCompleted` | `duration` | A storage copy/rename call. |
 | `JsonReadCompleted` | `num_files`, `bytes_read` | One `JsonHandler::read_json_files` call completed. `bytes_read` is the sum of on-disk file sizes. |
 | `ParquetReadCompleted` | `num_files`, `bytes_read` | One `ParquetHandler::read_parquet_files` call completed. `bytes_read` is the sum of on-disk file sizes. |
+| `CrcReadCompleted` | `duration`, `bytes_read` | One CRC file read completed. `bytes_read` is the raw byte count from storage. |
 
 > [!NOTE]
 > If you implement a custom `JsonHandler` or `ParquetHandler`, call

--- a/kernel/src/crc/reader.rs
+++ b/kernel/src/crc/reader.rs
@@ -1,6 +1,9 @@
 //! CRC file reading functionality.
 
+use tracing::instrument;
+
 use super::Crc;
+use crate::metrics::reporter::CRC_READ_COMPLETED_SPAN;
 use crate::path::{AsUrl as _, ParsedLogPath};
 use crate::{DeltaResult, Engine, Error};
 
@@ -11,6 +14,9 @@ use crate::{DeltaResult, Engine, Error};
 /// Returns `Ok(Crc)` on success, `Err` on any failure (file not readable, corrupt JSON,
 /// missing required fields). The caller should handle errors gracefully by falling back to log
 /// replay.
+///
+/// Reports metrics: `CrcReadCompleted`.
+#[instrument(name = CRC_READ_COMPLETED_SPAN, skip_all, fields(report, bytes_read))]
 pub(crate) fn try_read_crc_file(engine: &dyn Engine, crc_path: &ParsedLogPath) -> DeltaResult<Crc> {
     let storage = engine.storage_handler();
     let url = crc_path.location.as_url().clone();
@@ -18,6 +24,7 @@ pub(crate) fn try_read_crc_file(engine: &dyn Engine, crc_path: &ParsedLogPath) -
         .read_files(vec![(url, None)])?
         .next()
         .ok_or_else(|| Error::generic("CRC file read returned no data"))??;
+    tracing::Span::current().record("bytes_read", data.len() as u64);
     let crc: Crc = serde_json::from_slice(&data)?;
     Ok(crc)
 }
@@ -26,14 +33,17 @@ pub(crate) fn try_read_crc_file(engine: &dyn Engine, crc_path: &ParsedLogPath) -
 mod tests {
     use std::collections::HashMap;
     use std::path::PathBuf;
+    use std::sync::Arc;
 
     use test_utils::assert_result_error_with_message;
 
     use super::*;
     use crate::actions::{Format, Metadata, Protocol};
     use crate::engine::sync::SyncEngine;
+    use crate::metrics::MetricEvent;
     use crate::path::ParsedLogPath;
     use crate::table_features::TableFeature;
+    use crate::utils::test_utils::{install_thread_local_metrics_reporter, CapturingReporter};
 
     fn test_table_root(dir: &str) -> url::Url {
         let path = std::fs::canonicalize(PathBuf::from(dir)).unwrap();
@@ -42,6 +52,9 @@ mod tests {
 
     #[test]
     fn test_read_crc_file() {
+        let reporter = Arc::new(CapturingReporter::default());
+        let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
         let engine = SyncEngine::new();
         let table_root = test_table_root("./tests/data/crc-full/");
         let crc_path = ParsedLogPath::create_parsed_crc(&table_root, 0);
@@ -139,14 +152,39 @@ mod tests {
         assert!(crc.num_deleted_records_opt.is_none());
         assert!(crc.num_deletion_vectors_opt.is_none());
         assert!(crc.deleted_record_counts_histogram_opt.is_none());
+
+        // Verify CrcReadCompleted metric was emitted
+        let crc_events: Vec<_> = reporter
+            .events()
+            .into_iter()
+            .filter(|e| matches!(e, MetricEvent::CrcReadCompleted { .. }))
+            .collect();
+        assert_eq!(crc_events.len(), 1);
+        assert!(
+            matches!(&crc_events[0], MetricEvent::CrcReadCompleted { bytes_read, .. } if *bytes_read > 0)
+        );
     }
 
     #[test]
-    fn test_read_malformed_crc_file_fails() {
+    fn test_read_malformed_crc_file_emits_metric_then_fails() {
+        let reporter = Arc::new(CapturingReporter::default());
+        let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
         let engine = SyncEngine::new();
         let table_root = test_table_root("./tests/data/crc-malformed/");
         let crc_path = ParsedLogPath::create_parsed_crc(&table_root, 0);
 
         assert_result_error_with_message(try_read_crc_file(&engine, &crc_path), "expected value");
+
+        // CrcReadCompleted is emitted after storage read, even when JSON parse fails
+        let crc_events: Vec<_> = reporter
+            .events()
+            .into_iter()
+            .filter(|e| matches!(e, MetricEvent::CrcReadCompleted { .. }))
+            .collect();
+        assert_eq!(crc_events.len(), 1);
+        assert!(
+            matches!(&crc_events[0], MetricEvent::CrcReadCompleted { bytes_read, .. } if *bytes_read > 0)
+        );
     }
 }

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -304,7 +304,7 @@ impl LogSegment {
         name = "segment.for_snapshot",
         err,
         skip(storage, time_travel_version),
-        fields(report, operation_id = %operation_id, num_commit_files, num_checkpoint_files, num_compaction_files)
+        fields(report, operation_id = %operation_id, num_commit_files, num_checkpoint_files, num_compaction_files, has_latest_crc_file)
     )]
     #[internal_api]
     pub(crate) fn for_snapshot(
@@ -337,6 +337,10 @@ impl LogSegment {
                 tracing::Span::current().record(
                     "num_compaction_files",
                     log_segment.listed.ascending_compaction_files.len() as u64,
+                );
+                tracing::Span::current().record(
+                    "has_latest_crc_file",
+                    log_segment.listed.latest_crc_file.is_some(),
                 );
                 Ok(log_segment)
             }

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -121,11 +121,9 @@ pub enum MetricEvent {
 
     /// CRC file read operation completed (one event per CRC file read).
     ///
-    /// Emitted when [`try_read_crc_file`] completes. The `duration` covers the entire function
+    /// Emitted when CRC read completes. The `duration` covers the entire function
     /// including storage IO and JSON deserialization. `bytes_read` is the raw byte count from
     /// storage (zero if the storage read failed before bytes were returned).
-    ///
-    /// [`try_read_crc_file`]: crate::crc::try_read_crc_file
     CrcReadCompleted { duration: Duration, bytes_read: u64 },
 
     /// Scan metadata iteration completed.

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -66,6 +66,7 @@ pub enum MetricEvent {
         num_commit_files: u64,
         num_checkpoint_files: u64,
         num_compaction_files: u64,
+        has_latest_crc_file: bool,
     },
 
     /// Protocol and metadata loading completed.
@@ -118,6 +119,15 @@ pub enum MetricEvent {
     /// [`ParquetHandler::read_parquet_files`]: crate::ParquetHandler::read_parquet_files
     ParquetReadCompleted { num_files: u64, bytes_read: u64 },
 
+    /// CRC file read operation completed (one event per CRC file read).
+    ///
+    /// Emitted when [`try_read_crc_file`] completes. The `duration` covers the entire function
+    /// including storage IO and JSON deserialization. `bytes_read` is the raw byte count from
+    /// storage (zero if the storage read failed before bytes were returned).
+    ///
+    /// [`try_read_crc_file`]: crate::crc::try_read_crc_file
+    CrcReadCompleted { duration: Duration, bytes_read: u64 },
+
     /// Scan metadata iteration completed.
     ///
     /// Emitted when the scan metadata iterator is exhausted. This event captures metrics about the
@@ -162,9 +172,12 @@ impl fmt::Display for MetricEvent {
                 num_commit_files,
                 num_checkpoint_files,
                 num_compaction_files,
+                has_latest_crc_file,
             } => write!(
                 f,
-                "LogSegmentLoaded(id={operation_id}, duration={duration:?}, commits={num_commit_files}, checkpoints={num_checkpoint_files}, compactions={num_compaction_files})"
+                "LogSegmentLoaded(id={operation_id}, duration={duration:?}, \
+                 commits={num_commit_files}, checkpoints={num_checkpoint_files}, \
+                 compactions={num_compaction_files}, has_latest_crc={has_latest_crc_file})"
             ),
             MetricEvent::ProtocolMetadataLoaded {
                 operation_id,
@@ -220,6 +233,13 @@ impl fmt::Display for MetricEvent {
             } => write!(
                 f,
                 "ParquetReadCompleted(files={num_files}, bytes={bytes_read})"
+            ),
+            MetricEvent::CrcReadCompleted {
+                duration,
+                bytes_read,
+            } => write!(
+                f,
+                "CrcReadCompleted(duration={duration:?}, bytes={bytes_read})"
             ),
             MetricEvent::ScanMetadataCompleted {
                 operation_id,

--- a/kernel/src/metrics/reporter.rs
+++ b/kernel/src/metrics/reporter.rs
@@ -113,41 +113,65 @@ impl EventVisitor {
                 *total_duration = target_duration
             }
             Some(MetricEvent::SnapshotFailed { duration, .. }) => *duration = target_duration,
+            Some(MetricEvent::CrcReadCompleted { duration, .. }) => *duration = target_duration,
             _ => {}
         }
+    }
+
+    fn record_invalid_field_warning(&mut self, field: &Field, span_name: &str) {
+        self.pending_warnings.push(format!(
+            "Invalid field '{}' recorded on {span_name} span",
+            field.name()
+        ));
     }
 }
 
 impl Visit for EventVisitor {
     fn record_u64(&mut self, field: &Field, value: u64) {
-        if let Some(MetricEvent::LogSegmentLoaded {
-            ref mut num_commit_files,
-            ref mut num_checkpoint_files,
-            ref mut num_compaction_files,
-            ..
-        }) = self.event
-        {
-            match field.name() {
+        match &mut self.event {
+            Some(MetricEvent::LogSegmentLoaded {
+                ref mut num_commit_files,
+                ref mut num_checkpoint_files,
+                ref mut num_compaction_files,
+                ..
+            }) => match field.name() {
                 "num_commit_files" => *num_commit_files = value,
                 "num_checkpoint_files" => *num_checkpoint_files = value,
                 "num_compaction_files" => *num_compaction_files = value,
-                _ => self.pending_warnings.push(format!(
-                    "Invalid field '{}' recorded on {SEGMENT_FOR_SNAPSHOT_SPAN} span",
-                    field.name()
-                )),
+                _ => self.record_invalid_field_warning(field, SEGMENT_FOR_SNAPSHOT_SPAN),
+            },
+            Some(MetricEvent::SnapshotCompleted {
+                ref mut version, ..
+            }) => {
+                if field.name() == "version" {
+                    *version = value;
+                } else {
+                    self.record_invalid_field_warning(field, SNAP_BUILD_SPAN);
+                }
             }
+            Some(MetricEvent::CrcReadCompleted {
+                ref mut bytes_read, ..
+            }) => {
+                if field.name() == "bytes_read" {
+                    *bytes_read = value;
+                } else {
+                    self.record_invalid_field_warning(field, CRC_READ_COMPLETED_SPAN);
+                }
+            }
+            _ => {}
         }
+    }
 
-        if let Some(MetricEvent::SnapshotCompleted {
-            ref mut version, ..
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        if let Some(MetricEvent::LogSegmentLoaded {
+            ref mut has_latest_crc_file,
+            ..
         }) = self.event
         {
-            match field.name() {
-                "version" => *version = value,
-                _ => self.pending_warnings.push(format!(
-                    "Invalid field '{}' recorded on {SNAP_BUILD_SPAN} span",
-                    field.name()
-                )),
+            if field.name() == "has_latest_crc_file" {
+                *has_latest_crc_file = value;
+            } else {
+                self.record_invalid_field_warning(field, SEGMENT_FOR_SNAPSHOT_SPAN);
             }
         }
     }
@@ -197,6 +221,7 @@ pub(crate) const SEGMENT_FOR_SNAPSHOT_SPAN: &str = "segment.for_snapshot";
 pub(crate) const SEGMENT_READ_METADATA_SPAN: &str = "segment.read_metadata";
 pub(crate) const SNAP_BUILD_SPAN: &str = "snap.build";
 pub(crate) const STORAGE_SPAN: &str = "storage";
+pub(crate) const CRC_READ_COMPLETED_SPAN: &str = "crc_read_completed";
 const JSON_READ_COMPLETED_SPAN: &str = "json_read_completed";
 const PARQUET_READ_COMPLETED_SPAN: &str = "parquet_read_completed";
 const SCAN_METADATA_COMPLETED_SPAN: &str = "scan.metadata_completed";
@@ -426,6 +451,7 @@ where
                 num_commit_files: 0,
                 num_checkpoint_files: 0,
                 num_compaction_files: 0,
+                has_latest_crc_file: false,
             }),
             SEGMENT_READ_METADATA_SPAN => Some(MetricEvent::ProtocolMetadataLoaded {
                 operation_id: MetricId(new_span_visitor.uuid),
@@ -471,6 +497,10 @@ where
                     bytes_read: v.bytes_read,
                 })
             }
+            CRC_READ_COMPLETED_SPAN => Some(MetricEvent::CrcReadCompleted {
+                duration: std::time::Duration::default(),
+                bytes_read: 0,
+            }),
             SCAN_METADATA_COMPLETED_SPAN => {
                 let mut v = ScanMetadataVisitor::default();
                 attrs.record(&mut v);

--- a/test-utils/src/counting_reporter.rs
+++ b/test-utils/src/counting_reporter.rs
@@ -167,10 +167,15 @@ pub struct CountingReporter {
     pub checkpoint_files: RelaxedCounter,
     /// Total log compaction files in the commit tail across all log segment loads.
     pub compaction_files: RelaxedCounter,
-    // TODO: add `crc_files` counter for version checksum (.crc) files read.
-    // Tracking CRC reads is critical for understanding snapshot load costs on tables
-    // that use CRC files heavily. Requires a new MetricEvent variant and emitting it
-    // from the CRC read path. See https://github.com/delta-io/delta-kernel-rs/issues/2257
+    /// Total number of times a latest CRC file was found in the log segment, across all
+    /// log segment loads.
+    pub latest_crc_files_found: RelaxedCounter,
+
+    // CRC reader IO counters
+    /// Number of CRC read calls (one per [`MetricEvent::CrcReadCompleted`]).
+    pub crc_read_calls: RelaxedCounter,
+    /// Total number of bytes read from CRC files, across all CRC read calls.
+    pub crc_bytes_read: RelaxedCounter,
 }
 
 impl CountingReporter {
@@ -200,6 +205,9 @@ impl CountingReporter {
         self.commit_files.reset();
         self.checkpoint_files.reset();
         self.compaction_files.reset();
+        self.latest_crc_files_found.reset();
+        self.crc_read_calls.reset();
+        self.crc_bytes_read.reset();
     }
 
     /// Print a human-readable IO and operation summary.
@@ -220,16 +228,20 @@ impl CountingReporter {
         let parquet_calls = self.parquet_read_calls.get();
         let parquet_files = self.parquet_files_read.get();
         let parquet_kib = self.parquet_bytes_read.get() / 1024;
+        let crc_calls = self.crc_read_calls.get();
+        let crc_kib = self.crc_bytes_read.get() / 1024;
         let log_loads = self.log_segment_loads.get();
         let commits = self.commit_files.get();
         let checkpoints = self.checkpoint_files.get();
         let compactions = self.compaction_files.get();
+        let crc_files_found = self.latest_crc_files_found.get();
 
         println!("  [io] {label}");
         println!("    storage : {list_calls} list ({list_files} files seen)  {storage_reads} raw read ({storage_files} files, {storage_kib} KiB)  {copy_calls} copy");
         println!("    json    : {json_calls} call(s)  {json_files} files  {json_kib} KiB");
         println!("    parquet : {parquet_calls} call(s)  {parquet_files} files  {parquet_kib} KiB");
-        println!("    log     : {log_loads} segment load(s) -- {commits} commits  {checkpoints} checkpoints  {compactions} compactions");
+        println!("    crc     : {crc_calls} call(s)  {crc_kib} KiB");
+        println!("    log     : {log_loads} segment load(s) -- {commits} commits  {checkpoints} checkpoints  {compactions} compactions  {crc_files_found} latest_crc_files");
     }
 }
 
@@ -275,12 +287,18 @@ impl MetricsReporter for CountingReporter {
                 num_commit_files,
                 num_checkpoint_files,
                 num_compaction_files,
+                has_latest_crc_file,
                 ..
             } => {
                 self.log_segment_loads.inc();
                 self.commit_files.add(num_commit_files);
                 self.checkpoint_files.add(num_checkpoint_files);
                 self.compaction_files.add(num_compaction_files);
+                self.latest_crc_files_found.add(has_latest_crc_file as u64);
+            }
+            MetricEvent::CrcReadCompleted { bytes_read, .. } => {
+                self.crc_read_calls.inc();
+                self.crc_bytes_read.add(bytes_read);
             }
             // Intentionally not tracked -- add counters if needed.
             MetricEvent::ProtocolMetadataLoaded { .. }
@@ -358,11 +376,43 @@ mod tests {
             num_commit_files: 7,
             num_checkpoint_files: 2,
             num_compaction_files: 1,
+            has_latest_crc_file: true,
         });
         assert_eq!(reporter.log_segment_loads.get(), 1);
         assert_eq!(reporter.commit_files.get(), 7);
         assert_eq!(reporter.checkpoint_files.get(), 2);
         assert_eq!(reporter.compaction_files.get(), 1);
+        assert_eq!(reporter.latest_crc_files_found.get(), 1);
+    }
+
+    #[test]
+    fn report_log_segment_loaded_without_crc_does_not_increment_crc_counter() {
+        let reporter = CountingReporter::new();
+        reporter.report(MetricEvent::LogSegmentLoaded {
+            operation_id: MetricId::new(),
+            duration: dur(),
+            num_commit_files: 3,
+            num_checkpoint_files: 1,
+            num_compaction_files: 0,
+            has_latest_crc_file: false,
+        });
+        assert_eq!(reporter.log_segment_loads.get(), 1);
+        assert_eq!(reporter.latest_crc_files_found.get(), 0);
+    }
+
+    #[test]
+    fn report_crc_read_completed_increments_crc_counters() {
+        let reporter = CountingReporter::new();
+        reporter.report(MetricEvent::CrcReadCompleted {
+            duration: dur(),
+            bytes_read: 512,
+        });
+        reporter.report(MetricEvent::CrcReadCompleted {
+            duration: dur(),
+            bytes_read: 256,
+        });
+        assert_eq!(reporter.crc_read_calls.get(), 2);
+        assert_eq!(reporter.crc_bytes_read.get(), 768);
     }
 
     #[test]
@@ -398,6 +448,11 @@ mod tests {
             num_commit_files: 7,
             num_checkpoint_files: 2,
             num_compaction_files: 1,
+            has_latest_crc_file: true,
+        });
+        reporter.report(MetricEvent::CrcReadCompleted {
+            duration: dur(),
+            bytes_read: 512,
         });
 
         reporter.reset();
@@ -419,5 +474,8 @@ mod tests {
         assert_eq!(reporter.commit_files.get(), 0);
         assert_eq!(reporter.checkpoint_files.get(), 0);
         assert_eq!(reporter.compaction_files.get(), 0);
+        assert_eq!(reporter.latest_crc_files_found.get(), 0);
+        assert_eq!(reporter.crc_read_calls.get(), 0);
+        assert_eq!(reporter.crc_bytes_read.get(), 0);
     }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR is a new approach for https://github.com/delta-io/delta-kernel-rs/pull/2325. This PR follows the new reporting layer / tracing approach for reporting metric events. Key changes:
- Update LogSegmentLoaded event to include a "has latest crc" indicator
- Add new event for CRC reading that includes duration + bytes read

Also update CountingReporter to handle these new events/fields.

Fixes https://github.com/delta-io/delta-kernel-rs/issues/2257

## How was this change tested?
Unit tests added