### PR TITLE
test: add default cross-product read sweep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1289,6 +1289,7 @@ dependencies = [
  "reqwest 0.13.2",
  "roaring",
  "rstest",
+ "rstest_reuse",
  "rustc_version",
  "serde",
  "serde_json",

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -157,6 +157,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
   "fmt",
 ] }
 rstest = "0.23"
+rstest_reuse = "0.7"
 [[bench]]
 name = "metadata_bench"
 harness = false

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -1108,7 +1108,7 @@ mod tests {
     use rstest::rstest;
     use serde_json::json;
     use test_utils::table_builder::{
-        json_stats, unpartitioned, FeatureSet, LogState, VersionTarget,
+        checkpoint_json_stats, unpartitioned, FeatureSet, LogState, VersionTarget,
     };
     use test_utils::{add_commit, delta_path_for_version};
 
@@ -1985,7 +1985,7 @@ mod tests {
             LogState::with_latest_version(2),
             FeatureSet::empty(),
             unpartitioned(),
-            json_stats(),
+            checkpoint_json_stats(),
             VersionTarget::Latest,
             SyncEngine::new_with_store
         );

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -1107,7 +1107,7 @@ mod tests {
 
     use rstest::rstest;
     use serde_json::json;
-    use test_utils::table_builder::{FeatureSet, LogState, VersionTarget};
+    use test_utils::table_builder::{DataLayoutConfig, FeatureSet, LogState, VersionTarget};
     use test_utils::{add_commit, delta_path_for_version};
 
     use super::{commit, *};
@@ -1982,6 +1982,7 @@ mod tests {
         let (_engine, snap, _table) = test_utils::test_context!(
             LogState::with_latest_version(2),
             FeatureSet::empty(),
+            DataLayoutConfig::Unpartitioned,
             VersionTarget::Latest,
             SyncEngine::new_with_store
         );

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -1107,7 +1107,9 @@ mod tests {
 
     use rstest::rstest;
     use serde_json::json;
-    use test_utils::table_builder::{DataLayoutConfig, FeatureSet, LogState, VersionTarget};
+    use test_utils::table_builder::{
+        json_stats, unpartitioned, FeatureSet, LogState, VersionTarget,
+    };
     use test_utils::{add_commit, delta_path_for_version};
 
     use super::{commit, *};
@@ -1982,7 +1984,7 @@ mod tests {
         let (_engine, snap, _table) = test_utils::test_context!(
             LogState::with_latest_version(2),
             FeatureSet::empty(),
-            DataLayoutConfig::Unpartitioned,
+            unpartitioned(json_stats()),
             VersionTarget::Latest,
             SyncEngine::new_with_store
         );

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -1984,7 +1984,8 @@ mod tests {
         let (_engine, snap, _table) = test_utils::test_context!(
             LogState::with_latest_version(2),
             FeatureSet::empty(),
-            unpartitioned(json_stats()),
+            unpartitioned(),
+            json_stats(),
             VersionTarget::Latest,
             SyncEngine::new_with_store
         );

--- a/kernel/tests/integration/cross_product/mod.rs
+++ b/kernel/tests/integration/cross_product/mod.rs
@@ -6,12 +6,13 @@ use rstest::rstest;
 use rstest_reuse::apply;
 use test_utils::table_builder::{
     all_features_cm_id, all_features_cm_name, checkpoint_at_end, checkpoint_at_end_no_hint,
-    checkpoint_at_end_no_hint_post_cleanup, checkpoint_at_end_post_cleanup, checkpoint_mid,
-    checkpoint_mid_no_hint, checkpoint_mid_no_hint_post_cleanup, checkpoint_mid_post_cleanup,
-    clustered, commits_only, json_stats, no_features, no_stats, partitioned, struct_stats,
-    test_table, two_checkpoints_stale_hint, two_checkpoints_stale_hint_post_cleanup, unpartitioned,
-    version_at_mid, version_incremental_to_latest, version_latest, DataLayoutConfig, FeatureSet,
-    LogState, TableConfig, VersionTarget,
+    checkpoint_at_end_no_hint_post_cleanup, checkpoint_at_end_post_cleanup, checkpoint_json_stats,
+    checkpoint_mid, checkpoint_mid_no_hint, checkpoint_mid_no_hint_post_cleanup,
+    checkpoint_mid_post_cleanup, checkpoint_struct_stats, clustered, commits_only,
+    no_checkpoint_stats, no_features, partitioned, test_table, two_checkpoints_stale_hint,
+    two_checkpoints_stale_hint_post_cleanup, unpartitioned, version_at_mid,
+    version_incremental_to_latest, version_latest, DataLayoutConfig, FeatureSet, LogState,
+    TableConfig, VersionTarget,
 };
 use test_utils::{build_snapshot, default_sweep, read_scan};
 
@@ -32,47 +33,23 @@ fn test_cross_product_read_write(
     table_config: TableConfig,
     version_target: VersionTarget,
 ) -> DeltaResult<()> {
-    // Skip targets that reference a version cleaned up by `log_state` (e.g. loading
-    // `at_version(5)` on a post-cleanup table where commits < 10 were deleted).
-    let min_reachable = log_state.min_reachable_version();
-    let target_floor = match &version_target {
-        VersionTarget::Latest => log_state.latest_version(),
-        VersionTarget::AtVersion(v) => *v,
-        VersionTarget::IncrementalToLatest { from } => *from,
-    };
-    if target_floor < min_reachable {
-        return Ok(());
-    }
-
-    let table = test_table(
-        log_state.clone(),
-        feature_set.clone(),
-        data_layout.clone(),
-        table_config.clone(),
-    );
+    let table = test_table(log_state.clone(), feature_set, data_layout, table_config);
     let engine: Arc<dyn Engine> =
         Arc::new(DefaultEngineBuilder::new(table.store().clone()).build());
     let snap = build_snapshot!(version_target, table.table_root(), engine.as_ref());
 
     let expected_version = match &version_target {
-        VersionTarget::Latest => log_state.latest_version(),
+        VersionTarget::Latest | VersionTarget::IncrementalToLatest { .. } => {
+            log_state.latest_version()
+        }
         VersionTarget::AtVersion(v) => *v,
-        VersionTarget::IncrementalToLatest { .. } => log_state.latest_version(),
     };
-    assert_eq!(
-        snap.version(),
-        expected_version,
-        "snapshot version mismatch for {log_state} + {feature_set} + {data_layout} + {table_config} + {version_target}",
-    );
+    assert_eq!(snap.version(), expected_version);
 
     let scan = snap.scan_builder().build()?;
     let batches = read_scan(&scan, engine)?;
     let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
-    let expected_rows = expected_version as usize * ROWS_PER_COMMIT;
-    assert_eq!(
-        rows, expected_rows,
-        "row count mismatch for {log_state} + {feature_set} + {data_layout} + {table_config} + {version_target}",
-    );
+    assert_eq!(rows, expected_version as usize * ROWS_PER_COMMIT);
 
     Ok(())
 }

--- a/kernel/tests/integration/cross_product/mod.rs
+++ b/kernel/tests/integration/cross_product/mod.rs
@@ -1,0 +1,51 @@
+use std::sync::Arc;
+
+use delta_kernel::engine::default::DefaultEngineBuilder;
+use delta_kernel::{DeltaResult, Engine, Snapshot};
+use rstest::rstest;
+use rstest_reuse::apply;
+use test_utils::table_builder::{
+    test_table, DataLayoutConfig, FeatureSet, LastCheckpointHintState, LogState, VersionTarget,
+    DEFAULT_SWEEP_MID_VERSION,
+};
+use test_utils::{build_snapshot, default_sweep, read_scan};
+
+/// Each data commit (versions `1..=latest`) writes [`TestTableBuilder`]'s
+/// default 1-file-of-10-rows, so the row count at any snapshot version `v` is
+/// exactly `v * ROWS_PER_COMMIT`.
+const ROWS_PER_COMMIT: usize = 10;
+
+#[apply(default_sweep)]
+fn read_cross_product(
+    log_state: LogState,
+    feature_set: FeatureSet,
+    data_layout: DataLayoutConfig,
+    version_target: VersionTarget,
+) -> DeltaResult<()> {
+    let table = test_table(log_state.clone(), feature_set.clone(), data_layout.clone());
+    let engine: Arc<dyn Engine> =
+        Arc::new(DefaultEngineBuilder::new(table.store().clone()).build());
+    let snap = build_snapshot!(version_target, table.table_root(), engine.as_ref());
+
+    let expected_version = match &version_target {
+        VersionTarget::Latest => log_state.latest_version(),
+        VersionTarget::AtVersion(v) => *v,
+        VersionTarget::IncrementalToLatest { .. } => log_state.latest_version(),
+    };
+    assert_eq!(
+        snap.version(),
+        expected_version,
+        "snapshot version mismatch for {log_state} + {feature_set} + {data_layout} + {version_target}",
+    );
+
+    let scan = snap.scan_builder().build()?;
+    let batches = read_scan(&scan, engine)?;
+    let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    let expected_rows = expected_version as usize * ROWS_PER_COMMIT;
+    assert_eq!(
+        rows, expected_rows,
+        "row count mismatch for {log_state} + {feature_set} + {data_layout} + {version_target}",
+    );
+
+    Ok(())
+}

--- a/kernel/tests/integration/cross_product/mod.rs
+++ b/kernel/tests/integration/cross_product/mod.rs
@@ -5,18 +5,25 @@ use delta_kernel::{DeltaResult, Engine, Snapshot};
 use rstest::rstest;
 use rstest_reuse::apply;
 use test_utils::table_builder::{
-    test_table, DataLayoutConfig, FeatureSet, LastCheckpointHintState, LogState, VersionTarget,
-    DEFAULT_SWEEP_MID_VERSION,
+    all_features_cm_id, all_features_cm_name, checkpoint_at_end, checkpoint_at_end_no_hint,
+    checkpoint_mid, checkpoint_mid_no_hint, clustered, commits_only, json_stats, no_features,
+    no_stats, partitioned, post_cleanup, struct_stats, test_table, two_checkpoints_stale_hint,
+    unpartitioned, version_at_mid, version_incremental_to_latest, version_latest, DataLayoutConfig,
+    FeatureSet, LogState, VersionTarget,
 };
 use test_utils::{build_snapshot, default_sweep, read_scan};
 
-/// Each data commit (versions `1..=latest`) writes [`TestTableBuilder`]'s
-/// default 1-file-of-10-rows, so the row count at any snapshot version `v` is
-/// exactly `v * ROWS_PER_COMMIT`.
+/// `TestTableBuilder`'s default is one file per data commit with this many rows, so a
+/// snapshot at version `v` has exactly `v * ROWS_PER_COMMIT` total rows. File count
+/// per commit isn't asserted because partitioned layouts may emit multiple files.
 const ROWS_PER_COMMIT: usize = 10;
 
+/// `default_sweep` is the canonical `{LogState x FeatureSet x DataLayoutConfig x
+/// VersionTarget}` cross-product defined in `test_utils`. Each combination expands
+/// into its own test runner case. Invoking `test_table` here also exercises the
+/// write path that produces each table state.
 #[apply(default_sweep)]
-fn read_cross_product(
+fn test_cross_product_read_write(
     log_state: LogState,
     feature_set: FeatureSet,
     data_layout: DataLayoutConfig,

--- a/kernel/tests/integration/cross_product/mod.rs
+++ b/kernel/tests/integration/cross_product/mod.rs
@@ -6,10 +6,12 @@ use rstest::rstest;
 use rstest_reuse::apply;
 use test_utils::table_builder::{
     all_features_cm_id, all_features_cm_name, checkpoint_at_end, checkpoint_at_end_no_hint,
-    checkpoint_mid, checkpoint_mid_no_hint, clustered, commits_only, json_stats, no_features,
-    no_stats, partitioned, post_cleanup, struct_stats, test_table, two_checkpoints_stale_hint,
-    unpartitioned, version_at_mid, version_incremental_to_latest, version_latest, DataLayoutConfig,
-    FeatureSet, LogState, VersionTarget,
+    checkpoint_at_end_no_hint_post_cleanup, checkpoint_at_end_post_cleanup, checkpoint_mid,
+    checkpoint_mid_no_hint, checkpoint_mid_no_hint_post_cleanup, checkpoint_mid_post_cleanup,
+    clustered, commits_only, json_stats, no_features, no_stats, partitioned, struct_stats,
+    test_table, two_checkpoints_stale_hint, two_checkpoints_stale_hint_post_cleanup, unpartitioned,
+    version_at_mid, version_incremental_to_latest, version_latest, DataLayoutConfig, FeatureSet,
+    LogState, TableConfig, VersionTarget,
 };
 use test_utils::{build_snapshot, default_sweep, read_scan};
 
@@ -19,17 +21,35 @@ use test_utils::{build_snapshot, default_sweep, read_scan};
 const ROWS_PER_COMMIT: usize = 10;
 
 /// `default_sweep` is the canonical `{LogState x FeatureSet x DataLayoutConfig x
-/// VersionTarget}` cross-product defined in `test_utils`. Each combination expands
-/// into its own test runner case. Invoking `test_table` here also exercises the
-/// write path that produces each table state.
+/// TableConfig x VersionTarget}` cross-product defined in `test_utils`. Each
+/// combination expands into its own test runner case. Invoking `test_table` here also
+/// exercises the write path that produces each table state.
 #[apply(default_sweep)]
 fn test_cross_product_read_write(
     log_state: LogState,
     feature_set: FeatureSet,
     data_layout: DataLayoutConfig,
+    table_config: TableConfig,
     version_target: VersionTarget,
 ) -> DeltaResult<()> {
-    let table = test_table(log_state.clone(), feature_set.clone(), data_layout.clone());
+    // Skip targets that reference a version cleaned up by `log_state` (e.g. loading
+    // `at_version(5)` on a post-cleanup table where commits < 10 were deleted).
+    let min_reachable = log_state.min_reachable_version();
+    let target_floor = match &version_target {
+        VersionTarget::Latest => log_state.latest_version(),
+        VersionTarget::AtVersion(v) => *v,
+        VersionTarget::IncrementalToLatest { from } => *from,
+    };
+    if target_floor < min_reachable {
+        return Ok(());
+    }
+
+    let table = test_table(
+        log_state.clone(),
+        feature_set.clone(),
+        data_layout.clone(),
+        table_config.clone(),
+    );
     let engine: Arc<dyn Engine> =
         Arc::new(DefaultEngineBuilder::new(table.store().clone()).build());
     let snap = build_snapshot!(version_target, table.table_root(), engine.as_ref());
@@ -42,7 +62,7 @@ fn test_cross_product_read_write(
     assert_eq!(
         snap.version(),
         expected_version,
-        "snapshot version mismatch for {log_state} + {feature_set} + {data_layout} + {version_target}",
+        "snapshot version mismatch for {log_state} + {feature_set} + {data_layout} + {table_config} + {version_target}",
     );
 
     let scan = snap.scan_builder().build()?;
@@ -51,7 +71,7 @@ fn test_cross_product_read_write(
     let expected_rows = expected_version as usize * ROWS_PER_COMMIT;
     assert_eq!(
         rows, expected_rows,
-        "row count mismatch for {log_state} + {feature_set} + {data_layout} + {version_target}",
+        "row count mismatch for {log_state} + {feature_set} + {data_layout} + {table_config} + {version_target}",
     );
 
     Ok(())

--- a/kernel/tests/integration/main.rs
+++ b/kernel/tests/integration/main.rs
@@ -8,6 +8,7 @@
 mod common;
 
 mod create_table;
+mod cross_product;
 mod data_skipping;
 mod features;
 mod golden_tables;

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -114,6 +114,8 @@ define_sweeps! {
         checkpoint_struct_stats(),
         no_checkpoint_stats()
     ),
+    // TODO: ICT read assertions (needs pub get_in_commit_timestamp) + AtTimestamp
+    //       VersionTarget (timestamp time travel via history_manager::latest_version_as_of).
     version_target_values = (
         version_latest(),
         version_at_mid(),

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -4,10 +4,9 @@ pub mod column_mapping_fixtures;
 pub mod counting_reporter;
 pub mod table_builder;
 
-// The `#[rstest]` attribute and the `table_builder` factories below appear inside
-// the `define_sweeps!` body. They get stored as `macro_rules!` tokens in the
-// generated template macros and only resolve when a consumer applies them, so
-// rustc doesn't see them as used in this crate.
+// `rstest` and the `table_builder` factories appear inside the `define_sweeps!`
+// invocation below. Macro bodies are token streams that are only resolved when
+// consumer crates apply the emitted templates, so rustc doesn't see these uses.
 #[allow(unused_imports)]
 use rstest::rstest;
 pub use rstest_reuse;
@@ -15,23 +14,28 @@ use rstest_reuse::template;
 #[allow(unused_imports)]
 use table_builder::*;
 
-/// Emits canonical sweep templates: `default_sweep` (all axes) plus one per-axis
-/// template per axis. A per-axis template only supplies its named axis; the test
-/// supplies the rest:
+/// Emits canonical sweep templates from a single source of truth.
+///
+/// Generates one `default_sweep` template (full Cartesian product of all five axes)
+/// plus one per-axis template (`log_state_sweep`, `feature_set_sweep`,
+/// `data_layout_sweep`, `table_config_sweep`, `version_target_sweep`). Each per-axis
+/// template only supplies its own axis; the consumer test fills in the others with
+/// inline `#[values(...)]` to control combination count.
+///
+/// Templates are emitted at crate root so the generated `#[macro_export]` macros
+/// are reachable cross-crate as `test_utils::<name>` via `#[rstest_reuse::apply]`.
 ///
 /// ```ignore
+/// // Iterate only the LogState axis; fix everything else.
 /// #[apply(log_state_sweep)]
 /// fn my_test(
-///     log_state: LogState,                                    // canonical values
+///     log_state: LogState,
 ///     #[values(no_features())] feature_set: FeatureSet,
 ///     #[values(unpartitioned())] data_layout: DataLayoutConfig,
-///     #[values(json_stats())] table_config: TableConfig,
+///     #[values(checkpoint_json_stats())] table_config: TableConfig,
 ///     #[values(version_latest())] version_target: VersionTarget,
 /// ) { /* ... */ }
 /// ```
-///
-/// Defined at crate root so the `#[macro_export]`-generated macros are reachable
-/// cross-crate as `test_utils::<name>`.
 macro_rules! define_sweeps {
     (
         log_state_values = $ls:tt,
@@ -105,7 +109,11 @@ define_sweeps! {
     feature_set_values = (no_features(), all_features_cm_id(), all_features_cm_name()),
     // TODO: null-distribution and partition-by-timestamp-with-CM rows.
     data_layout_values = (unpartitioned(), partitioned(), clustered()),
-    table_config_values = (json_stats(), struct_stats(), no_stats()),
+    table_config_values = (
+        checkpoint_json_stats(),
+        checkpoint_struct_stats(),
+        no_checkpoint_stats()
+    ),
     version_target_values = (
         version_latest(),
         version_at_mid(),

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -3,6 +3,136 @@
 pub mod column_mapping_fixtures;
 pub mod counting_reporter;
 pub mod table_builder;
+
+// Required so rstest_reuse templates exported with `#[export]` can resolve
+// `rstest_reuse::*` when expanded in a downstream crate.
+// rstest_reuse's `#[template]` looks for a bare `#[rstest]` (single-segment path)
+// to locate the attribute split point, so we import `rstest` here as a bare name.
+// The `#[values(...)]` and type idents live inside the template macro body and
+// are only resolved at expansion time in consumer crates.
+#[allow(unused_imports)]
+use rstest::rstest;
+pub use rstest_reuse;
+use rstest_reuse::template;
+#[allow(unused_imports)]
+use table_builder::{
+    DataLayoutConfig, FeatureSet, LastCheckpointHintState, LogState, VersionTarget,
+    DEFAULT_SWEEP_MID_VERSION,
+};
+
+/// Emits all canonical sweep templates from a single source: `default_sweep` (the full
+/// 4-axis cross-product) plus one per-axis template per axis (`log_state_sweep`,
+/// `feature_set_sweep`, `data_layout_sweep`, `version_target_sweep`).
+///
+/// Each per-axis template iterates one axis from the canonical list; the test author
+/// supplies their own `#[values(...)]` for the other params.
+///
+/// Lives at crate root so `#[macro_export]`-generated templates are reachable cross-crate
+/// as `test_utils::<name>`. Each canonical value list is captured as a single token tree
+/// (`$tt`) so the parens carry through to `#[values $list]` substitution.
+macro_rules! define_sweeps {
+    (
+        log_state_values = $ls:tt,
+        feature_set_values = $fs:tt,
+        data_layout_values = $dl:tt,
+        version_target_values = $vt:tt $(,)?
+    ) => {
+        #[template]
+        #[export]
+        #[rstest]
+        pub fn default_sweep(
+            #[values $ls] log_state: LogState,
+            #[values $fs] feature_set: FeatureSet,
+            #[values $dl] data_layout: DataLayoutConfig,
+            #[values $vt] version_target: VersionTarget,
+        ) {
+        }
+
+        #[template]
+        #[export]
+        #[rstest]
+        pub fn log_state_sweep(#[values $ls] log_state: LogState) {}
+
+        #[template]
+        #[export]
+        #[rstest]
+        pub fn feature_set_sweep(#[values $fs] feature_set: FeatureSet) {}
+
+        #[template]
+        #[export]
+        #[rstest]
+        pub fn data_layout_sweep(#[values $dl] data_layout: DataLayoutConfig) {}
+
+        #[template]
+        #[export]
+        #[rstest]
+        pub fn version_target_sweep(#[values $vt] version_target: VersionTarget) {}
+    };
+}
+
+define_sweeps! {
+    // Aligned with the cardinality doc's Required tier. TODOs cover rows that need
+    // builder support not yet present in `TestTableBuilder`.
+    // TODO: CRC at last / stale CRC (needs LogState::with_crc_at).
+    // TODO: Log compaction (needs LogState::with_compaction_at, #2337).
+    // TODO: Schema history (add/drop/rename) (needs schema-evolution support).
+    log_state_values = (
+        LogState::with_latest_version(10),
+        LogState::with_latest_version(10).with_checkpoint_at([10]),
+        LogState::with_latest_version(10)
+            .with_checkpoint_at([10])
+            .with_last_checkpoint_hint(LastCheckpointHintState::Missing),
+        LogState::with_latest_version(10).with_checkpoint_at([5]),
+        LogState::with_latest_version(10)
+            .with_checkpoint_at([5])
+            .with_last_checkpoint_hint(LastCheckpointHintState::Missing),
+        LogState::with_latest_version(10)
+            .with_checkpoint_at([5, 10])
+            .with_last_checkpoint_hint(LastCheckpointHintState::Stale)
+    ),
+    // Aligned with the cardinality doc's Compressed sweep (3.6): a few maxed-out rows
+    // rather than per-feature singletons. TODOs cover rows that need features without
+    // builder support yet.
+    // TODO: max-CM=id / max-CM=name full set (needs checkpointProtection, clustering,
+    //       materializePartitionColumns, invariants, checkConstraints, generatedColumns,
+    //       allowColumnDefaults, identityColumns, NTZ/variant (schema-driven),
+    //       catalogManaged, collations for CM=name, typeWidening write support).
+    // TODO: iceV2+writer (needs icebergCompatV2 + icebergWriterCompatV1).
+    // TODO: iceV3 (needs icebergCompatV3).
+    feature_set_values = (
+        FeatureSet::empty(),
+        FeatureSet::new()
+            .column_mapping("id")
+            .deletion_vectors()
+            .row_tracking()
+            .domain_metadata()
+            .ict()
+            .v2_checkpoint()
+            .vacuum_protocol_check()
+            .change_data_feed()
+            .append_only(),
+        FeatureSet::new()
+            .column_mapping("name")
+            .deletion_vectors()
+            .row_tracking()
+            .domain_metadata()
+            .ict()
+            .v2_checkpoint()
+            .vacuum_protocol_check()
+            .change_data_feed()
+            .append_only()
+    ),
+    data_layout_values = (
+        DataLayoutConfig::Unpartitioned,
+        DataLayoutConfig::PartitionedAllTypes,
+        DataLayoutConfig::ClusteredAllTypes
+    ),
+    version_target_values = (
+        VersionTarget::Latest,
+        VersionTarget::AtVersion(DEFAULT_SWEEP_MID_VERSION),
+        VersionTarget::IncrementalToLatest { from: DEFAULT_SWEEP_MID_VERSION }
+    ),
+}
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -4,32 +4,33 @@ pub mod column_mapping_fixtures;
 pub mod counting_reporter;
 pub mod table_builder;
 
-// Required so rstest_reuse templates exported with `#[export]` can resolve
-// `rstest_reuse::*` when expanded in a downstream crate.
-// rstest_reuse's `#[template]` looks for a bare `#[rstest]` (single-segment path)
-// to locate the attribute split point, so we import `rstest` here as a bare name.
-// The `#[values(...)]` and type idents live inside the template macro body and
-// are only resolved at expansion time in consumer crates.
+// The `#[rstest]` attribute and the `table_builder` factories below appear inside
+// the `define_sweeps!` body. They get stored as `macro_rules!` tokens in the
+// generated template macros and only resolve when a consumer applies them, so
+// rustc doesn't see them as used in this crate.
 #[allow(unused_imports)]
 use rstest::rstest;
 pub use rstest_reuse;
 use rstest_reuse::template;
 #[allow(unused_imports)]
-use table_builder::{
-    DataLayoutConfig, FeatureSet, LastCheckpointHintState, LogState, VersionTarget,
-    DEFAULT_SWEEP_MID_VERSION,
-};
+use table_builder::*;
 
-/// Emits all canonical sweep templates from a single source: `default_sweep` (the full
-/// 4-axis cross-product) plus one per-axis template per axis (`log_state_sweep`,
-/// `feature_set_sweep`, `data_layout_sweep`, `version_target_sweep`).
+/// Emits canonical sweep templates: `default_sweep` (all axes) plus one per-axis
+/// template per axis. A per-axis template only supplies its named axis; the test
+/// supplies the rest:
 ///
-/// Each per-axis template iterates one axis from the canonical list; the test author
-/// supplies their own `#[values(...)]` for the other params.
+/// ```ignore
+/// #[apply(log_state_sweep)]
+/// fn my_test(
+///     log_state: LogState,                                    // 7 canonical values
+///     #[values(no_features())] feature_set: FeatureSet,
+///     #[values(unpartitioned_json())] data_layout: DataLayoutConfig,
+///     #[values(version_latest())] version_target: VersionTarget,
+/// ) { /* ... */ }
+/// ```
 ///
-/// Lives at crate root so `#[macro_export]`-generated templates are reachable cross-crate
-/// as `test_utils::<name>`. Each canonical value list is captured as a single token tree
-/// (`$tt`) so the parens carry through to `#[values $list]` substitution.
+/// Defined at crate root so the `#[macro_export]`-generated macros are reachable
+/// cross-crate as `test_utils::<name>`.
 macro_rules! define_sweeps {
     (
         log_state_values = $ls:tt,
@@ -71,66 +72,42 @@ macro_rules! define_sweeps {
 }
 
 define_sweeps! {
-    // Aligned with the cardinality doc's Required tier. TODOs cover rows that need
-    // builder support not yet present in `TestTableBuilder`.
     // TODO: CRC at last / stale CRC (needs LogState::with_crc_at).
     // TODO: Log compaction (needs LogState::with_compaction_at, #2337).
     // TODO: Schema history (add/drop/rename) (needs schema-evolution support).
     log_state_values = (
-        LogState::with_latest_version(10),
-        LogState::with_latest_version(10).with_checkpoint_at([10]),
-        LogState::with_latest_version(10)
-            .with_checkpoint_at([10])
-            .with_last_checkpoint_hint(LastCheckpointHintState::Missing),
-        LogState::with_latest_version(10).with_checkpoint_at([5]),
-        LogState::with_latest_version(10)
-            .with_checkpoint_at([5])
-            .with_last_checkpoint_hint(LastCheckpointHintState::Missing),
-        LogState::with_latest_version(10)
-            .with_checkpoint_at([5, 10])
-            .with_last_checkpoint_hint(LastCheckpointHintState::Stale)
+        commits_only(),
+        checkpoint_at_end(),
+        checkpoint_at_end_no_hint(),
+        checkpoint_mid(),
+        checkpoint_mid_no_hint(),
+        two_checkpoints_stale_hint(),
+        post_cleanup()
     ),
-    // Aligned with the cardinality doc's Compressed sweep (3.6): a few maxed-out rows
-    // rather than per-feature singletons. TODOs cover rows that need features without
-    // builder support yet.
     // TODO: max-CM=id / max-CM=name full set (needs checkpointProtection, clustering,
     //       materializePartitionColumns, invariants, checkConstraints, generatedColumns,
     //       allowColumnDefaults, identityColumns, NTZ/variant (schema-driven),
     //       catalogManaged, collations for CM=name, typeWidening write support).
     // TODO: iceV2+writer (needs icebergCompatV2 + icebergWriterCompatV1).
     // TODO: iceV3 (needs icebergCompatV3).
-    feature_set_values = (
-        FeatureSet::empty(),
-        FeatureSet::new()
-            .column_mapping("id")
-            .deletion_vectors()
-            .row_tracking()
-            .domain_metadata()
-            .ict()
-            .v2_checkpoint()
-            .vacuum_protocol_check()
-            .change_data_feed()
-            .append_only(),
-        FeatureSet::new()
-            .column_mapping("name")
-            .deletion_vectors()
-            .row_tracking()
-            .domain_metadata()
-            .ict()
-            .v2_checkpoint()
-            .vacuum_protocol_check()
-            .change_data_feed()
-            .append_only()
-    ),
+    feature_set_values = (no_features(), all_features_cm_id(), all_features_cm_name()),
+    // Three layouts crossed with three stats formats. TODO: null-distribution and
+    // partition-by-timestamp-with-CM rows.
     data_layout_values = (
-        DataLayoutConfig::Unpartitioned,
-        DataLayoutConfig::PartitionedAllTypes,
-        DataLayoutConfig::ClusteredAllTypes
+        unpartitioned(json_stats()),
+        unpartitioned(struct_stats()),
+        unpartitioned(no_stats()),
+        partitioned(json_stats()),
+        partitioned(struct_stats()),
+        partitioned(no_stats()),
+        clustered(json_stats()),
+        clustered(struct_stats()),
+        clustered(no_stats())
     ),
     version_target_values = (
-        VersionTarget::Latest,
-        VersionTarget::AtVersion(DEFAULT_SWEEP_MID_VERSION),
-        VersionTarget::IncrementalToLatest { from: DEFAULT_SWEEP_MID_VERSION }
+        version_latest(),
+        version_at_mid(),
+        version_incremental_to_latest()
     ),
 }
 use std::collections::HashMap;

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -22,9 +22,10 @@ use table_builder::*;
 /// ```ignore
 /// #[apply(log_state_sweep)]
 /// fn my_test(
-///     log_state: LogState,                                    // 7 canonical values
+///     log_state: LogState,                                    // canonical values
 ///     #[values(no_features())] feature_set: FeatureSet,
-///     #[values(unpartitioned_json())] data_layout: DataLayoutConfig,
+///     #[values(unpartitioned())] data_layout: DataLayoutConfig,
+///     #[values(json_stats())] table_config: TableConfig,
 ///     #[values(version_latest())] version_target: VersionTarget,
 /// ) { /* ... */ }
 /// ```
@@ -36,6 +37,7 @@ macro_rules! define_sweeps {
         log_state_values = $ls:tt,
         feature_set_values = $fs:tt,
         data_layout_values = $dl:tt,
+        table_config_values = $tc:tt,
         version_target_values = $vt:tt $(,)?
     ) => {
         #[template]
@@ -45,6 +47,7 @@ macro_rules! define_sweeps {
             #[values $ls] log_state: LogState,
             #[values $fs] feature_set: FeatureSet,
             #[values $dl] data_layout: DataLayoutConfig,
+            #[values $tc] table_config: TableConfig,
             #[values $vt] version_target: VersionTarget,
         ) {
         }
@@ -67,6 +70,11 @@ macro_rules! define_sweeps {
         #[template]
         #[export]
         #[rstest]
+        pub fn table_config_sweep(#[values $tc] table_config: TableConfig) {}
+
+        #[template]
+        #[export]
+        #[rstest]
         pub fn version_target_sweep(#[values $vt] version_target: VersionTarget) {}
     };
 }
@@ -82,7 +90,11 @@ define_sweeps! {
         checkpoint_mid(),
         checkpoint_mid_no_hint(),
         two_checkpoints_stale_hint(),
-        post_cleanup()
+        checkpoint_at_end_post_cleanup(),
+        checkpoint_at_end_no_hint_post_cleanup(),
+        checkpoint_mid_post_cleanup(),
+        checkpoint_mid_no_hint_post_cleanup(),
+        two_checkpoints_stale_hint_post_cleanup()
     ),
     // TODO: max-CM=id / max-CM=name full set (needs checkpointProtection, clustering,
     //       materializePartitionColumns, invariants, checkConstraints, generatedColumns,
@@ -91,19 +103,9 @@ define_sweeps! {
     // TODO: iceV2+writer (needs icebergCompatV2 + icebergWriterCompatV1).
     // TODO: iceV3 (needs icebergCompatV3).
     feature_set_values = (no_features(), all_features_cm_id(), all_features_cm_name()),
-    // Three layouts crossed with three stats formats. TODO: null-distribution and
-    // partition-by-timestamp-with-CM rows.
-    data_layout_values = (
-        unpartitioned(json_stats()),
-        unpartitioned(struct_stats()),
-        unpartitioned(no_stats()),
-        partitioned(json_stats()),
-        partitioned(struct_stats()),
-        partitioned(no_stats()),
-        clustered(json_stats()),
-        clustered(struct_stats()),
-        clustered(no_stats())
-    ),
+    // TODO: null-distribution and partition-by-timestamp-with-CM rows.
+    data_layout_values = (unpartitioned(), partitioned(), clustered()),
+    table_config_values = (json_stats(), struct_stats(), no_stats()),
     version_target_values = (
         version_latest(),
         version_at_mid(),

--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -331,9 +331,8 @@ pub fn two_checkpoints_stale_hint() -> LogState {
 }
 
 // Post-cleanup variants: same shapes as above but with log cleanup applied at MID.
-// 99% of production tables have had maintenance run on them. Cleanup at MID (not at
-// LATEST) keeps commits MID..=LATEST reachable, so the canonical `at_version(MID)`
-// and `incremental_to_latest { from: MID }` targets still resolve.
+// Cleanup at MID (not at LATEST) keeps commits MID..=LATEST reachable, so the canonical
+// `at_version(MID)` and `incremental_to_latest { from: MID }` targets still resolve.
 
 pub fn checkpoint_at_end_post_cleanup() -> LogState {
     LogState::with_latest_version(DEFAULT_SWEEP_LATEST_VERSION)

--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -8,11 +8,11 @@
 //! with [`TestTableBuilder::with_data`] when a test needs specific file/row counts.
 //!
 //! Provides five orthogonal axes for parameterized testing:
-//! - [`LogState`] -- what log files exist on disk (commits, checkpoints, CRC)
-//! - [`FeatureSet`] -- which Delta table features are enabled
-//! - [`TableConfig`] -- runtime knobs (e.g. stats format) orthogonal to features
-//! - [`VersionTarget`] -- how the snapshot is loaded (latest, time travel, incremental)
-//! - [`DataLayoutConfig`] -- data layout (unpartitioned, partitioned, clustered)
+//! - [`LogState`]: what log files exist on disk (commits, checkpoints, CRC)
+//! - [`FeatureSet`]: which Delta table features are enabled
+//! - [`DataLayoutConfig`]: data layout (unpartitioned, partitioned, clustered)
+//! - [`TableConfig`]: runtime knobs (e.g. checkpoint stats format)
+//! - [`VersionTarget`]: how the snapshot is loaded (latest, time travel, incremental)
 //!
 //! # Quick start
 //!
@@ -30,13 +30,16 @@
 //!     log_state: LogState,
 //!     #[values(FeatureSet::empty())]
 //!     feature_set: FeatureSet,
-//!     #[values(unpartitioned(json_stats()))]
+//!     #[values(unpartitioned())]
 //!     data_layout: DataLayoutConfig,
+//!     #[values(checkpoint_json_stats())]
+//!     table_config: TableConfig,
 //!     #[values(VersionTarget::Latest, VersionTarget::IncrementalToLatest { from: 0 })]
 //!     version_target: VersionTarget,
 //! ) {
-//!     let (engine, snap, _table) =
-//!         test_context!(log_state, feature_set, data_layout, version_target);
+//!     let (engine, snap, _table) = test_context!(
+//!         log_state, feature_set, data_layout, table_config, version_target,
+//!     );
 //!     let scan = snap.scan_builder().build().unwrap();
 //!     // ...
 //! }
@@ -74,6 +77,19 @@ use delta_kernel::table_features::TableFeature;
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::{DeltaResult, Snapshot};
+
+// ===========================================================================
+// Sweep constants
+// ===========================================================================
+
+/// Latest commit version used by every log state in the
+/// [`default_sweep!`](crate::default_sweep) template.
+pub const DEFAULT_SWEEP_LATEST_VERSION: u64 = 10;
+
+/// Mid version used by the [`default_sweep!`](crate::default_sweep) template for
+/// `AtVersion` and `IncrementalToLatest` targets. Must satisfy
+/// `mid <= DEFAULT_SWEEP_LATEST_VERSION`.
+pub const DEFAULT_SWEEP_MID_VERSION: u64 = 5;
 
 // ===========================================================================
 // Sync/async bridge
@@ -254,9 +270,10 @@ impl LogState {
         self
     }
 
-    /// Latest version on the table. After cleanup, commits below
-    /// [`min_reachable_version`](Self::min_reachable_version) are gone, but
-    /// `latest_version` still reflects the highest committed version.
+    /// Latest version on the table. The total number of commits on disk is
+    /// `latest_version + 1` (or fewer if
+    /// [`with_cleanup_commits_before`](Self::with_cleanup_commits_before) removed earlier
+    /// versions).
     pub fn latest_version(&self) -> u64 {
         self.latest_version
     }
@@ -279,14 +296,6 @@ impl LogState {
     /// State of the `_last_checkpoint` hint file on the built table.
     pub(crate) fn last_checkpoint_hint(&self) -> LastCheckpointHintState {
         self.last_checkpoint_hint
-    }
-
-    /// Lowest commit version still on disk. After cleanup, commits `< cleanup_before`
-    /// have been deleted, so loading a snapshot at a version below this returns
-    /// "No files in log segment". Sweep callers use this to skip invalid combinations
-    /// of `LogState` and [`VersionTarget`].
-    pub fn min_reachable_version(&self) -> u64 {
-        self.cleanup_before.unwrap_or(0)
     }
 }
 
@@ -321,15 +330,19 @@ pub fn two_checkpoints_stale_hint() -> LogState {
         .with_last_checkpoint_hint(LastCheckpointHintState::Stale)
 }
 
-// Post-cleanup variants: same shapes as above but with log cleanup applied at the
-// checkpoint version. 99% of production tables have had maintenance run on them.
+// Post-cleanup variants: same shapes as above but with log cleanup applied at MID.
+// 99% of production tables have had maintenance run on them. Cleanup at MID (not at
+// LATEST) keeps commits MID..=LATEST reachable, so the canonical `at_version(MID)`
+// and `incremental_to_latest { from: MID }` targets still resolve.
 
 pub fn checkpoint_at_end_post_cleanup() -> LogState {
-    checkpoint_at_end().with_cleanup_commits_before(DEFAULT_SWEEP_LATEST_VERSION)
+    LogState::with_latest_version(DEFAULT_SWEEP_LATEST_VERSION)
+        .with_checkpoint_at([DEFAULT_SWEEP_MID_VERSION, DEFAULT_SWEEP_LATEST_VERSION])
+        .with_cleanup_commits_before(DEFAULT_SWEEP_MID_VERSION)
 }
 
 pub fn checkpoint_at_end_no_hint_post_cleanup() -> LogState {
-    checkpoint_at_end_no_hint().with_cleanup_commits_before(DEFAULT_SWEEP_LATEST_VERSION)
+    checkpoint_at_end_post_cleanup().with_last_checkpoint_hint(LastCheckpointHintState::Missing)
 }
 
 pub fn checkpoint_mid_post_cleanup() -> LogState {
@@ -650,21 +663,22 @@ impl fmt::Display for TableConfig {
     }
 }
 
-// Canonical sweep rows for the TableConfig axis.
+// Canonical sweep rows for the TableConfig axis. These toggle only the *checkpoint*
+// stats encoding -- per-commit add-file stats are always written and unaffected.
 
-pub fn json_stats() -> TableConfig {
+pub fn checkpoint_json_stats() -> TableConfig {
     TableConfig::new()
         .write_stats_as_json(true)
         .write_stats_as_struct(false)
 }
 
-pub fn struct_stats() -> TableConfig {
+pub fn checkpoint_struct_stats() -> TableConfig {
     TableConfig::new()
         .write_stats_as_json(false)
         .write_stats_as_struct(true)
 }
 
-pub fn no_stats() -> TableConfig {
+pub fn no_checkpoint_stats() -> TableConfig {
     TableConfig::new()
         .write_stats_as_json(false)
         .write_stats_as_struct(false)
@@ -1479,15 +1493,6 @@ pub fn test_table(
         .expect("failed to build test table")
 }
 
-/// Latest version used by every log state in the [`default_sweep!`](crate::default_sweep)
-/// template.
-pub const DEFAULT_SWEEP_LATEST_VERSION: u64 = 10;
-
-/// Mid version used by the [`default_sweep!`](crate::default_sweep) template for
-/// `AtVersion` and `IncrementalToLatest` targets. Must satisfy
-/// `mid <= DEFAULT_SWEEP_LATEST_VERSION`.
-pub const DEFAULT_SWEEP_MID_VERSION: u64 = 5;
-
 // ===========================================================================
 // Macros
 // ===========================================================================
@@ -1691,7 +1696,7 @@ mod tests {
         #[values(LogState::with_latest_version(4))] log_state: LogState,
         #[values(FeatureSet::empty())] feature_set: FeatureSet,
         #[values(unpartitioned())] data_layout: DataLayoutConfig,
-        #[values(json_stats())] table_config: TableConfig,
+        #[values(checkpoint_json_stats())] table_config: TableConfig,
         #[values(
             VersionTarget::Latest,
             VersionTarget::AtVersion(2),
@@ -1972,7 +1977,7 @@ mod tests {
         let table = TestTableBuilder::new()
             .with_log_state(LogState::with_latest_version(3))
             .with_data_layout(clustered())
-            .with_table_config(struct_stats())
+            .with_table_config(checkpoint_struct_stats())
             .build()?;
         let engine = table.engine();
         let snap = Snapshot::builder_for(table.table_root()).build(&engine)?;

--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -30,7 +30,7 @@
 //!     log_state: LogState,
 //!     #[values(FeatureSet::empty())]
 //!     feature_set: FeatureSet,
-//!     #[values(DataLayoutConfig::Unpartitioned)]
+//!     #[values(unpartitioned(json_stats()))]
 //!     data_layout: DataLayoutConfig,
 //!     #[values(VersionTarget::Latest, VersionTarget::IncrementalToLatest { from: 0 })]
 //!     version_target: VersionTarget,
@@ -283,6 +283,41 @@ impl LogState {
     }
 }
 
+// Canonical sweep rows for the LogState axis. Test case names derive from these
+// function names (e.g. `log_state_1_commits_only__`).
+
+pub fn commits_only() -> LogState {
+    LogState::with_latest_version(DEFAULT_SWEEP_LATEST_VERSION)
+}
+
+pub fn checkpoint_at_end() -> LogState {
+    LogState::with_latest_version(DEFAULT_SWEEP_LATEST_VERSION)
+        .with_checkpoint_at([DEFAULT_SWEEP_LATEST_VERSION])
+}
+
+pub fn checkpoint_at_end_no_hint() -> LogState {
+    checkpoint_at_end().with_last_checkpoint_hint(LastCheckpointHintState::Missing)
+}
+
+pub fn checkpoint_mid() -> LogState {
+    LogState::with_latest_version(DEFAULT_SWEEP_LATEST_VERSION)
+        .with_checkpoint_at([DEFAULT_SWEEP_MID_VERSION])
+}
+
+pub fn checkpoint_mid_no_hint() -> LogState {
+    checkpoint_mid().with_last_checkpoint_hint(LastCheckpointHintState::Missing)
+}
+
+pub fn two_checkpoints_stale_hint() -> LogState {
+    LogState::with_latest_version(DEFAULT_SWEEP_LATEST_VERSION)
+        .with_checkpoint_at([DEFAULT_SWEEP_MID_VERSION, DEFAULT_SWEEP_LATEST_VERSION])
+        .with_last_checkpoint_hint(LastCheckpointHintState::Stale)
+}
+
+pub fn post_cleanup() -> LogState {
+    checkpoint_mid().with_cleanup_commits_before(DEFAULT_SWEEP_MID_VERSION)
+}
+
 /// Extract the version from a versioned log file. Returns `None` for unversioned
 /// files like `_last_checkpoint`.
 fn log_file_version(location: &Path) -> Option<u64> {
@@ -503,16 +538,43 @@ impl fmt::Display for FeatureSet {
     }
 }
 
+// Canonical sweep rows for the FeatureSet axis.
+
+pub fn no_features() -> FeatureSet {
+    FeatureSet::empty()
+}
+
+pub fn all_features_cm_id() -> FeatureSet {
+    all_features_base().column_mapping("id")
+}
+
+pub fn all_features_cm_name() -> FeatureSet {
+    all_features_base().column_mapping("name")
+}
+
+fn all_features_base() -> FeatureSet {
+    FeatureSet::new()
+        .deletion_vectors()
+        .row_tracking()
+        .domain_metadata()
+        .ict()
+        .v2_checkpoint()
+        .vacuum_protocol_check()
+        .change_data_feed()
+        .append_only()
+}
+
 // ===========================================================================
 // TableConfig
 // ===========================================================================
 
 /// Table configuration properties that are orthogonal to table features.
 ///
-/// These are pure runtime knobs (e.g. stats format, checkpoint interval) that don't
-/// affect the protocol or enable features. Use as a separate cross-product axis from
-/// [`FeatureSet`] since the two are independent.
-#[derive(Clone, Debug, Default)]
+/// These are pure runtime knobs (stats format, checkpoint interval, file sizing,
+/// etc.) that don't affect the protocol or enable features. Embedded in
+/// [`DataLayoutConfig`] so each canonical layout row carries the relevant write-time
+/// properties (e.g. stats format).
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct TableConfig {
     pub(crate) table_properties: Vec<(String, String)>,
 }
@@ -633,18 +695,22 @@ pub fn table_configs(
 
 /// Data layout configuration for cross-product testing.
 ///
+/// Each variant carries a [`TableConfig`] so partitioning/clustering and write-time
+/// table properties (stats format, etc.) are chosen together as a single discrete
+/// layout shape.
+///
 /// Designed for rstest `#[values]` parameterization alongside [`LogState`] and
 /// [`FeatureSet`].
 #[derive(Clone, Debug, PartialEq)]
 pub enum DataLayoutConfig {
     /// No special data layout (default schema).
-    Unpartitioned,
+    Unpartitioned(TableConfig),
     /// Partition by every valid primitive type. Uses [`partitioned_schema`] with all columns
     /// as partition columns.
-    PartitionedAllTypes,
+    PartitionedAllTypes(TableConfig),
     /// Cluster by every stats-eligible primitive type. Uses [`clustered_schema`] with all
     /// clustering-eligible columns. Boolean and Binary are excluded (not stats-eligible).
-    ClusteredAllTypes,
+    ClusteredAllTypes(TableConfig),
 }
 
 impl DataLayoutConfig {
@@ -652,9 +718,9 @@ impl DataLayoutConfig {
     /// schema columns except the `"value"` data column.
     pub fn columns(&self) -> Vec<String> {
         let schema = match self {
-            DataLayoutConfig::Unpartitioned => return vec![],
-            DataLayoutConfig::PartitionedAllTypes => partitioned_schema(),
-            DataLayoutConfig::ClusteredAllTypes => clustered_schema(),
+            DataLayoutConfig::Unpartitioned(_) => return vec![],
+            DataLayoutConfig::PartitionedAllTypes(_) => partitioned_schema(),
+            DataLayoutConfig::ClusteredAllTypes(_) => clustered_schema(),
         };
         schema
             .fields()
@@ -666,29 +732,42 @@ impl DataLayoutConfig {
     /// The schema for this config.
     pub fn schema(&self) -> SchemaRef {
         match self {
-            DataLayoutConfig::Unpartitioned => default_schema(),
-            DataLayoutConfig::PartitionedAllTypes => partitioned_schema(),
-            DataLayoutConfig::ClusteredAllTypes => clustered_schema(),
+            DataLayoutConfig::Unpartitioned(_) => default_schema(),
+            DataLayoutConfig::PartitionedAllTypes(_) => partitioned_schema(),
+            DataLayoutConfig::ClusteredAllTypes(_) => clustered_schema(),
         }
     }
 
     /// Whether this config uses partitioning.
     pub fn is_partitioned(&self) -> bool {
-        *self == DataLayoutConfig::PartitionedAllTypes
+        matches!(self, DataLayoutConfig::PartitionedAllTypes(_))
     }
 
     /// Whether this config uses clustering.
     pub fn is_clustered(&self) -> bool {
-        *self == DataLayoutConfig::ClusteredAllTypes
+        matches!(self, DataLayoutConfig::ClusteredAllTypes(_))
+    }
+
+    /// Write-time table properties applied to this layout.
+    pub fn table_config(&self) -> &TableConfig {
+        match self {
+            DataLayoutConfig::Unpartitioned(c)
+            | DataLayoutConfig::PartitionedAllTypes(c)
+            | DataLayoutConfig::ClusteredAllTypes(c) => c,
+        }
     }
 }
 
 impl fmt::Display for DataLayoutConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            DataLayoutConfig::Unpartitioned => write!(f, "unpartitioned"),
-            DataLayoutConfig::PartitionedAllTypes => write!(f, "partitioned(all_types)"),
-            DataLayoutConfig::ClusteredAllTypes => write!(f, "clustered(all_types)"),
+            DataLayoutConfig::Unpartitioned(c) => write!(f, "unpartitioned+config({c})"),
+            DataLayoutConfig::PartitionedAllTypes(c) => {
+                write!(f, "partitioned(all_types)+config({c})")
+            }
+            DataLayoutConfig::ClusteredAllTypes(c) => {
+                write!(f, "clustered(all_types)+config({c})")
+            }
         }
     }
 }
@@ -743,6 +822,40 @@ pub fn clustered_schema() -> SchemaRef {
     ]))
 }
 
+// Layout factories. Pair with the TableConfig helpers below to build sweep rows.
+
+pub fn unpartitioned(config: TableConfig) -> DataLayoutConfig {
+    DataLayoutConfig::Unpartitioned(config)
+}
+
+pub fn partitioned(config: TableConfig) -> DataLayoutConfig {
+    DataLayoutConfig::PartitionedAllTypes(config)
+}
+
+pub fn clustered(config: TableConfig) -> DataLayoutConfig {
+    DataLayoutConfig::ClusteredAllTypes(config)
+}
+
+// TableConfig helpers. Compose into a layout factory at the sweep call site.
+
+pub fn json_stats() -> TableConfig {
+    TableConfig::new()
+        .write_stats_as_json(true)
+        .write_stats_as_struct(false)
+}
+
+pub fn struct_stats() -> TableConfig {
+    TableConfig::new()
+        .write_stats_as_json(false)
+        .write_stats_as_struct(true)
+}
+
+pub fn no_stats() -> TableConfig {
+    TableConfig::new()
+        .write_stats_as_json(false)
+        .write_stats_as_struct(false)
+}
+
 // ===========================================================================
 // VersionTarget
 // ===========================================================================
@@ -770,6 +883,20 @@ impl fmt::Display for VersionTarget {
                 write!(f, "incremental({from}->latest)")
             }
         }
+    }
+}
+
+// Canonical sweep rows for the VersionTarget axis.
+
+pub fn version_latest() -> VersionTarget {
+    VersionTarget::Latest
+}
+pub fn version_at_mid() -> VersionTarget {
+    VersionTarget::AtVersion(DEFAULT_SWEEP_MID_VERSION)
+}
+pub fn version_incremental_to_latest() -> VersionTarget {
+    VersionTarget::IncrementalToLatest {
+        from: DEFAULT_SWEEP_MID_VERSION,
     }
 }
 
@@ -878,20 +1005,22 @@ impl TestTableBuilder {
         self
     }
 
-    /// Apply a [`DataLayoutConfig`], setting the schema and layout columns accordingly.
-    /// This is the recommended way to configure partitioning or clustering -- it sets both
-    /// the schema and columns in one call. Use
+    /// Apply a [`DataLayoutConfig`], setting the schema, layout columns, and stats-format
+    /// table config accordingly. This is the recommended way to configure partitioning or
+    /// clustering -- it sets schema, columns, and stats in one call. Use
     /// [`with_partition_columns`](Self::with_partition_columns) or
     /// [`with_clustering_columns`](Self::with_clustering_columns) directly only when you
     /// need a custom schema with specific columns.
     ///
-    /// For [`DataLayoutConfig::Unpartitioned`], leaves the schema and columns unchanged.
+    /// For `Unpartitioned`, leaves the schema and columns unchanged but still applies the
+    /// stats config.
     pub fn with_data_layout(self, config: DataLayoutConfig) -> Self {
+        let builder = self.with_table_config(config.table_config().clone());
         let cols = config.columns();
         if cols.is_empty() {
-            return self;
+            return builder;
         }
-        let builder = self.with_schema(config.schema());
+        let builder = builder.with_schema(config.schema());
         if config.is_clustered() {
             builder.with_clustering_columns(cols)
         } else {
@@ -1339,9 +1468,13 @@ pub fn test_table(
         .expect("failed to build test table")
 }
 
+/// Latest version used by every log state in the [`default_sweep!`](crate::default_sweep)
+/// template.
+pub const DEFAULT_SWEEP_LATEST_VERSION: u64 = 10;
+
 /// Mid version used by the [`default_sweep!`](crate::default_sweep) template for
 /// `AtVersion` and `IncrementalToLatest` targets. Must satisfy
-/// `mid <= latest_version` for every log state in the sweep.
+/// `mid <= DEFAULT_SWEEP_LATEST_VERSION`.
 pub const DEFAULT_SWEEP_MID_VERSION: u64 = 5;
 
 // ===========================================================================
@@ -1538,7 +1671,7 @@ mod tests {
     fn test_version_targets(
         #[values(LogState::with_latest_version(4))] log_state: LogState,
         #[values(FeatureSet::empty())] feature_set: FeatureSet,
-        #[values(DataLayoutConfig::Unpartitioned)] data_layout: DataLayoutConfig,
+        #[values(unpartitioned(json_stats()))] data_layout: DataLayoutConfig,
         #[values(
             VersionTarget::Latest,
             VersionTarget::AtVersion(2),
@@ -1784,8 +1917,8 @@ mod tests {
     }
 
     #[rstest::rstest]
-    #[case::partitioned(DataLayoutConfig::PartitionedAllTypes, partitioned_schema())]
-    #[case::clustered(DataLayoutConfig::ClusteredAllTypes, clustered_schema())]
+    #[case::partitioned(partitioned(json_stats()), partitioned_schema())]
+    #[case::clustered(clustered(struct_stats()), clustered_schema())]
     fn test_data_layout_table(
         #[case] config: DataLayoutConfig,
         #[case] expected_schema: SchemaRef,
@@ -1813,7 +1946,7 @@ mod tests {
         // v0=create, v1-v3=data commits, 10 rows each
         let table = TestTableBuilder::new()
             .with_log_state(LogState::with_latest_version(3))
-            .with_data_layout(DataLayoutConfig::ClusteredAllTypes)
+            .with_data_layout(clustered(struct_stats()))
             .build()?;
         let engine = table.engine();
         let snap = Snapshot::builder_for(table.table_root()).build(&engine)?;

--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -30,11 +30,13 @@
 //!     log_state: LogState,
 //!     #[values(FeatureSet::empty())]
 //!     feature_set: FeatureSet,
+//!     #[values(DataLayoutConfig::Unpartitioned)]
+//!     data_layout: DataLayoutConfig,
 //!     #[values(VersionTarget::Latest, VersionTarget::IncrementalToLatest { from: 0 })]
 //!     version_target: VersionTarget,
 //! ) {
 //!     let (engine, snap, _table) =
-//!         test_context!(log_state, feature_set, version_target);
+//!         test_context!(log_state, feature_set, data_layout, version_target);
 //!     let scan = snap.scan_builder().build().unwrap();
 //!     // ...
 //! }
@@ -252,53 +254,11 @@ impl LogState {
         self
     }
 
-    /// Canonical log shapes for snapshot reader-path tests. Built against a
-    /// 10-version table; each shape exercises a distinct read path.
-    pub fn common() -> Vec<Self> {
-        const N: u64 = 10;
-        vec![
-            // commits-only: pure JSON replay
-            Self::with_latest_version(N),
-            // checkpoint at latest: no JSON tail (relevant for ICT, where the
-            // latest commit's timestamp lives in the checkpoint)
-            Self::with_latest_version(N).with_checkpoint_at([N]),
-            // checkpoint mid-stream: tail-replay over JSON commits after a checkpoint
-            Self::with_latest_version(N).with_checkpoint_at([N - 5]),
-            // multi-checkpoint: newer supersedes older
-            Self::with_latest_version(N).with_checkpoint_at([N - 5, N]),
-            // post-cleanup: log truncated at the mid-stream checkpoint
-            Self::with_latest_version(N)
-                .with_checkpoint_at([N - 5])
-                .with_cleanup_commits_before(N - 5),
-            // mid-stream checkpoint with hint missing: listing fallback discovers it
-            Self::with_latest_version(N)
-                .with_checkpoint_at([N - 5])
-                .with_last_checkpoint_hint(LastCheckpointHintState::Missing),
-            // two checkpoints + stale hint: hint at mid-stream, real latest at end;
-            // reader follows hint, lists forward, recovers actual latest
-            Self::with_latest_version(N)
-                .with_checkpoint_at([N - 5, N])
-                .with_last_checkpoint_hint(LastCheckpointHintState::Stale),
-            // post-cleanup + missing hint: pruned log with no hint, reader lists
-            // forward to find the surviving checkpoint
-            Self::with_latest_version(N)
-                .with_checkpoint_at([N - 5])
-                .with_cleanup_commits_before(N - 5)
-                .with_last_checkpoint_hint(LastCheckpointHintState::Missing),
-            // post-cleanup + stale hint: pruned log where the hint points at the
-            // lowest surviving checkpoint; reader lists forward to discover latest
-            Self::with_latest_version(N)
-                .with_checkpoint_at([N - 5, N])
-                .with_cleanup_commits_before(N - 5)
-                .with_last_checkpoint_hint(LastCheckpointHintState::Stale),
-        ]
-    }
-
     /// Latest version on the table. The total number of commits on disk is
     /// `latest_version + 1`. (Does not yet account for log cleanup -- a
     /// post-cleanup state where commits `0..K` have been removed is a
     /// separate axis tracked in #2526.)
-    pub(crate) fn latest_version(&self) -> u64 {
+    pub fn latest_version(&self) -> u64 {
         self.latest_version
     }
 
@@ -496,37 +456,6 @@ impl FeatureSet {
         self
     }
 
-    /// Common feature sets for cross-product testing: empty, one per write-compatible
-    /// feature, and one with all write-compatible features combined. Not the full power
-    /// set -- add specific combos as needed.
-    ///
-    /// `type_widening` is intentionally excluded because kernel errors when writing
-    /// tables with that feature enabled (see `TableFeature::TypeWidening`).
-    pub fn common() -> Vec<Self> {
-        vec![
-            Self::empty(),
-            Self::new().column_mapping("name"),
-            Self::new().ict(),
-            Self::new().v2_checkpoint(),
-            Self::new().deletion_vectors(),
-            Self::new().append_only(),
-            Self::new().change_data_feed(),
-            Self::new().domain_metadata(),
-            Self::new().vacuum_protocol_check(),
-            Self::new().row_tracking(),
-            Self::new()
-                .column_mapping("name")
-                .ict()
-                .v2_checkpoint()
-                .deletion_vectors()
-                .append_only()
-                .change_data_feed()
-                .domain_metadata()
-                .vacuum_protocol_check()
-                .row_tracking(),
-        ]
-    }
-
     /// Returns the table features implied by the properties in this set. Used by tests
     /// to check that each builder method actually enables the right feature.
     pub fn expected_features(&self) -> Vec<TableFeature> {
@@ -611,26 +540,6 @@ impl TableConfig {
         ));
         self
     }
-
-    /// Common table configs for cross-product testing: default plus all four stats
-    /// property combos.
-    pub fn common() -> Vec<Self> {
-        vec![
-            Self::new(),
-            Self::new()
-                .write_stats_as_json(true)
-                .write_stats_as_struct(false),
-            Self::new()
-                .write_stats_as_json(false)
-                .write_stats_as_struct(true),
-            Self::new()
-                .write_stats_as_json(true)
-                .write_stats_as_struct(true),
-            Self::new()
-                .write_stats_as_json(false)
-                .write_stats_as_struct(false),
-        ]
-    }
 }
 
 impl fmt::Display for TableConfig {
@@ -672,10 +581,8 @@ impl fmt::Display for TableConfig {
 // fn test_scan(feature_set: FeatureSet, table_config: TableConfig) { ... }
 // ```
 
-/// All common feature sets: empty, one per write-compatible feature, and all combined.
-///
-/// `type_widening` is intentionally excluded because kernel errors when writing tables
-/// with that feature enabled (see [`FeatureSet::common`]).
+/// Empty + one per write-compatible feature + all combined. `type_widening` is
+/// excluded because kernel errors when writing tables with that feature enabled.
 #[rstest_reuse::template]
 #[rstest::rstest]
 pub fn feature_sets(
@@ -1417,15 +1324,25 @@ impl fmt::Display for TestTable {
 // rstest fixtures
 // ===========================================================================
 
-/// Convenience wrapper: build a [`TestTable`] from a `log_state` and `feature_set`.
-/// Used by the `test_context!` macro and available for direct use in tests.
-pub fn test_table(log_state: LogState, feature_set: FeatureSet) -> TestTable {
+/// Convenience wrapper: build a [`TestTable`] from a `log_state`, `feature_set`, and
+/// `data_layout`. Used by the `test_context!` macro and available for direct use in tests.
+pub fn test_table(
+    log_state: LogState,
+    feature_set: FeatureSet,
+    data_layout: DataLayoutConfig,
+) -> TestTable {
     TestTableBuilder::new()
         .with_log_state(log_state)
         .with_features(feature_set)
+        .with_data_layout(data_layout)
         .build()
         .expect("failed to build test table")
 }
+
+/// Mid version used by the [`default_sweep!`](crate::default_sweep) template for
+/// `AtVersion` and `IncrementalToLatest` targets. Must satisfy
+/// `mid <= latest_version` for every log state in the sweep.
+pub const DEFAULT_SWEEP_MID_VERSION: u64 = 5;
 
 // ===========================================================================
 // Macros
@@ -1465,25 +1382,31 @@ macro_rules! build_snapshot {
 /// Expands at the call site so `Snapshot` and the engine type resolve to the caller's crate
 /// types. Returns `(engine, snapshot, table)`.
 ///
-/// The 3-argument form defaults to `DefaultEngine` and requires `DefaultEngineBuilder` to be in
-/// scope at the call site. The 4-argument form takes an explicit engine factory closure
+/// The 4-argument form defaults to `DefaultEngine` and requires `DefaultEngineBuilder` to be in
+/// scope at the call site. The 5-argument form takes an explicit engine factory closure
 /// `Fn(Arc<DynObjectStore>) -> Engine`, useful when the caller cannot construct a
 /// `DefaultEngine` (e.g. kernel-internal unit tests that depend only on `SyncEngine`).
 ///
 /// ```ignore
-/// let (engine, snap, table) = test_context!(log_state, feature_set, version_target);
-/// let (engine, snap, table) = test_context!(log_state, feature_set, version_target,
-///     |store| SyncEngine::new_with_store(store));
+/// let (engine, snap, table) =
+///     test_context!(log_state, feature_set, data_layout, version_target);
+/// let (engine, snap, table) =
+///     test_context!(log_state, feature_set, data_layout, version_target,
+///         |store| SyncEngine::new_with_store(store));
 /// ```
 #[macro_export]
 macro_rules! test_context {
-    ($log_state:expr, $feature_set:expr, $version_target:expr) => {
-        $crate::test_context!($log_state, $feature_set, $version_target, |store| {
-            DefaultEngineBuilder::new(store).build()
-        })
+    ($log_state:expr, $feature_set:expr, $data_layout:expr, $version_target:expr) => {
+        $crate::test_context!(
+            $log_state,
+            $feature_set,
+            $data_layout,
+            $version_target,
+            |store| { DefaultEngineBuilder::new(store).build() }
+        )
     };
-    ($log_state:expr, $feature_set:expr, $version_target:expr, $engine_factory:expr) => {{
-        let table = $crate::table_builder::test_table($log_state, $feature_set);
+    ($log_state:expr, $feature_set:expr, $data_layout:expr, $version_target:expr, $engine_factory:expr) => {{
+        let table = $crate::table_builder::test_table($log_state, $feature_set, $data_layout);
         let engine = ($engine_factory)(table.store().clone());
         let snap = $crate::build_snapshot!($version_target, table.table_root(), &engine);
         (engine, snap, table)
@@ -1615,6 +1538,7 @@ mod tests {
     fn test_version_targets(
         #[values(LogState::with_latest_version(4))] log_state: LogState,
         #[values(FeatureSet::empty())] feature_set: FeatureSet,
+        #[values(DataLayoutConfig::Unpartitioned)] data_layout: DataLayoutConfig,
         #[values(
             VersionTarget::Latest,
             VersionTarget::AtVersion(2),
@@ -1622,7 +1546,8 @@ mod tests {
         )]
         version_target: VersionTarget,
     ) {
-        let (_engine, snap, _table) = test_context!(log_state, feature_set, version_target);
+        let (_engine, snap, _table) =
+            test_context!(log_state, feature_set, data_layout, version_target);
         let expected = match &version_target {
             VersionTarget::Latest | VersionTarget::IncrementalToLatest { .. } => 4,
             VersionTarget::AtVersion(v) => *v,
@@ -1771,9 +1696,16 @@ mod tests {
             .with_cleanup_commits_before(1)
             .with_last_checkpoint_hint(LastCheckpointHintState::Stale),
     )]
+    #[case::stale_hint_points_at_deleted_checkpoint(
+        LogState::with_latest_version(10)
+            .with_checkpoint_at([5, 8])
+            .with_cleanup_commits_before(8)
+            .with_last_checkpoint_hint(LastCheckpointHintState::Stale),
+    )]
     fn test_log_state_checkpoint_shapes_land_on_disk(
         #[case] log_state: LogState,
     ) -> DeltaResult<()> {
+        let expected_version = log_state.latest_version();
         let table = TestTableBuilder::new()
             .with_log_state(log_state.clone())
             .build()?;
@@ -1782,7 +1714,7 @@ mod tests {
         let snap = Snapshot::builder_for(table.table_root()).build(&engine)?;
         assert_eq!(
             snap.version(),
-            2,
+            expected_version,
             "rebuild lost commits for {}",
             table.description(),
         );

--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -281,6 +281,14 @@ impl LogState {
     pub(crate) fn last_checkpoint_hint(&self) -> LastCheckpointHintState {
         self.last_checkpoint_hint
     }
+
+    /// Lowest commit version still on disk. After cleanup, commits `< cleanup_before`
+    /// have been deleted, so loading a snapshot at a version below this returns
+    /// "No files in log segment". Sweep callers use this to skip invalid combinations
+    /// of `LogState` and [`VersionTarget`].
+    pub fn min_reachable_version(&self) -> u64 {
+        self.cleanup_before.unwrap_or(0)
+    }
 }
 
 // Canonical sweep rows for the LogState axis. Test case names derive from these
@@ -314,8 +322,27 @@ pub fn two_checkpoints_stale_hint() -> LogState {
         .with_last_checkpoint_hint(LastCheckpointHintState::Stale)
 }
 
-pub fn post_cleanup() -> LogState {
+// Post-cleanup variants: same shapes as above but with log cleanup applied at the
+// checkpoint version. 99% of production tables have had maintenance run on them.
+
+pub fn checkpoint_at_end_post_cleanup() -> LogState {
+    checkpoint_at_end().with_cleanup_commits_before(DEFAULT_SWEEP_LATEST_VERSION)
+}
+
+pub fn checkpoint_at_end_no_hint_post_cleanup() -> LogState {
+    checkpoint_at_end_no_hint().with_cleanup_commits_before(DEFAULT_SWEEP_LATEST_VERSION)
+}
+
+pub fn checkpoint_mid_post_cleanup() -> LogState {
     checkpoint_mid().with_cleanup_commits_before(DEFAULT_SWEEP_MID_VERSION)
+}
+
+pub fn checkpoint_mid_no_hint_post_cleanup() -> LogState {
+    checkpoint_mid_no_hint().with_cleanup_commits_before(DEFAULT_SWEEP_MID_VERSION)
+}
+
+pub fn two_checkpoints_stale_hint_post_cleanup() -> LogState {
+    two_checkpoints_stale_hint().with_cleanup_commits_before(DEFAULT_SWEEP_MID_VERSION)
 }
 
 /// Extract the version from a versioned log file. Returns `None` for unversioned
@@ -571,9 +598,9 @@ fn all_features_base() -> FeatureSet {
 /// Table configuration properties that are orthogonal to table features.
 ///
 /// These are pure runtime knobs (stats format, checkpoint interval, file sizing,
-/// etc.) that don't affect the protocol or enable features. Embedded in
-/// [`DataLayoutConfig`] so each canonical layout row carries the relevant write-time
-/// properties (e.g. stats format).
+/// etc.) that don't affect the protocol or enable features. Crossed with
+/// [`DataLayoutConfig`] in the sweep so layout shape and write-time properties
+/// vary independently.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct TableConfig {
     pub(crate) table_properties: Vec<(String, String)>,
@@ -622,6 +649,26 @@ impl fmt::Display for TableConfig {
             .collect();
         write!(f, "{}", props.join(", "))
     }
+}
+
+// Canonical sweep rows for the TableConfig axis.
+
+pub fn json_stats() -> TableConfig {
+    TableConfig::new()
+        .write_stats_as_json(true)
+        .write_stats_as_struct(false)
+}
+
+pub fn struct_stats() -> TableConfig {
+    TableConfig::new()
+        .write_stats_as_json(false)
+        .write_stats_as_struct(true)
+}
+
+pub fn no_stats() -> TableConfig {
+    TableConfig::new()
+        .write_stats_as_json(false)
+        .write_stats_as_struct(false)
 }
 
 // ===========================================================================
@@ -695,22 +742,22 @@ pub fn table_configs(
 
 /// Data layout configuration for cross-product testing.
 ///
-/// Each variant carries a [`TableConfig`] so partitioning/clustering and write-time
-/// table properties (stats format, etc.) are chosen together as a single discrete
-/// layout shape.
+/// Describes only the partitioning/clustering shape of the table. Write-time table
+/// properties (stats format, etc.) live in [`TableConfig`], which is crossed with
+/// this axis independently.
 ///
-/// Designed for rstest `#[values]` parameterization alongside [`LogState`] and
-/// [`FeatureSet`].
+/// Designed for rstest `#[values]` parameterization alongside [`LogState`],
+/// [`FeatureSet`], and [`TableConfig`].
 #[derive(Clone, Debug, PartialEq)]
 pub enum DataLayoutConfig {
     /// No special data layout (default schema).
-    Unpartitioned(TableConfig),
+    Unpartitioned,
     /// Partition by every valid primitive type. Uses [`partitioned_schema`] with all columns
     /// as partition columns.
-    PartitionedAllTypes(TableConfig),
+    PartitionedAllTypes,
     /// Cluster by every stats-eligible primitive type. Uses [`clustered_schema`] with all
     /// clustering-eligible columns. Boolean and Binary are excluded (not stats-eligible).
-    ClusteredAllTypes(TableConfig),
+    ClusteredAllTypes,
 }
 
 impl DataLayoutConfig {
@@ -718,9 +765,9 @@ impl DataLayoutConfig {
     /// schema columns except the `"value"` data column.
     pub fn columns(&self) -> Vec<String> {
         let schema = match self {
-            DataLayoutConfig::Unpartitioned(_) => return vec![],
-            DataLayoutConfig::PartitionedAllTypes(_) => partitioned_schema(),
-            DataLayoutConfig::ClusteredAllTypes(_) => clustered_schema(),
+            DataLayoutConfig::Unpartitioned => return vec![],
+            DataLayoutConfig::PartitionedAllTypes => partitioned_schema(),
+            DataLayoutConfig::ClusteredAllTypes => clustered_schema(),
         };
         schema
             .fields()
@@ -732,42 +779,29 @@ impl DataLayoutConfig {
     /// The schema for this config.
     pub fn schema(&self) -> SchemaRef {
         match self {
-            DataLayoutConfig::Unpartitioned(_) => default_schema(),
-            DataLayoutConfig::PartitionedAllTypes(_) => partitioned_schema(),
-            DataLayoutConfig::ClusteredAllTypes(_) => clustered_schema(),
+            DataLayoutConfig::Unpartitioned => default_schema(),
+            DataLayoutConfig::PartitionedAllTypes => partitioned_schema(),
+            DataLayoutConfig::ClusteredAllTypes => clustered_schema(),
         }
     }
 
     /// Whether this config uses partitioning.
     pub fn is_partitioned(&self) -> bool {
-        matches!(self, DataLayoutConfig::PartitionedAllTypes(_))
+        self == &DataLayoutConfig::PartitionedAllTypes
     }
 
     /// Whether this config uses clustering.
     pub fn is_clustered(&self) -> bool {
-        matches!(self, DataLayoutConfig::ClusteredAllTypes(_))
-    }
-
-    /// Write-time table properties applied to this layout.
-    pub fn table_config(&self) -> &TableConfig {
-        match self {
-            DataLayoutConfig::Unpartitioned(c)
-            | DataLayoutConfig::PartitionedAllTypes(c)
-            | DataLayoutConfig::ClusteredAllTypes(c) => c,
-        }
+        self == &DataLayoutConfig::ClusteredAllTypes
     }
 }
 
 impl fmt::Display for DataLayoutConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            DataLayoutConfig::Unpartitioned(c) => write!(f, "unpartitioned+config({c})"),
-            DataLayoutConfig::PartitionedAllTypes(c) => {
-                write!(f, "partitioned(all_types)+config({c})")
-            }
-            DataLayoutConfig::ClusteredAllTypes(c) => {
-                write!(f, "clustered(all_types)+config({c})")
-            }
+            DataLayoutConfig::Unpartitioned => write!(f, "unpartitioned"),
+            DataLayoutConfig::PartitionedAllTypes => write!(f, "partitioned(all_types)"),
+            DataLayoutConfig::ClusteredAllTypes => write!(f, "clustered(all_types)"),
         }
     }
 }
@@ -822,38 +856,18 @@ pub fn clustered_schema() -> SchemaRef {
     ]))
 }
 
-// Layout factories. Pair with the TableConfig helpers below to build sweep rows.
+// Canonical sweep rows for the DataLayoutConfig axis.
 
-pub fn unpartitioned(config: TableConfig) -> DataLayoutConfig {
-    DataLayoutConfig::Unpartitioned(config)
+pub fn unpartitioned() -> DataLayoutConfig {
+    DataLayoutConfig::Unpartitioned
 }
 
-pub fn partitioned(config: TableConfig) -> DataLayoutConfig {
-    DataLayoutConfig::PartitionedAllTypes(config)
+pub fn partitioned() -> DataLayoutConfig {
+    DataLayoutConfig::PartitionedAllTypes
 }
 
-pub fn clustered(config: TableConfig) -> DataLayoutConfig {
-    DataLayoutConfig::ClusteredAllTypes(config)
-}
-
-// TableConfig helpers. Compose into a layout factory at the sweep call site.
-
-pub fn json_stats() -> TableConfig {
-    TableConfig::new()
-        .write_stats_as_json(true)
-        .write_stats_as_struct(false)
-}
-
-pub fn struct_stats() -> TableConfig {
-    TableConfig::new()
-        .write_stats_as_json(false)
-        .write_stats_as_struct(true)
-}
-
-pub fn no_stats() -> TableConfig {
-    TableConfig::new()
-        .write_stats_as_json(false)
-        .write_stats_as_struct(false)
+pub fn clustered() -> DataLayoutConfig {
+    DataLayoutConfig::ClusteredAllTypes
 }
 
 // ===========================================================================
@@ -1005,22 +1019,17 @@ impl TestTableBuilder {
         self
     }
 
-    /// Apply a [`DataLayoutConfig`], setting the schema, layout columns, and stats-format
-    /// table config accordingly. This is the recommended way to configure partitioning or
-    /// clustering -- it sets schema, columns, and stats in one call. Use
-    /// [`with_partition_columns`](Self::with_partition_columns) or
-    /// [`with_clustering_columns`](Self::with_clustering_columns) directly only when you
-    /// need a custom schema with specific columns.
+    /// Apply a [`DataLayoutConfig`], setting the schema and layout columns. Pair with
+    /// [`with_table_config`](Self::with_table_config) to also set write-time properties
+    /// like stats format -- these axes are independent.
     ///
-    /// For `Unpartitioned`, leaves the schema and columns unchanged but still applies the
-    /// stats config.
+    /// For `Unpartitioned`, leaves the schema and columns unchanged.
     pub fn with_data_layout(self, config: DataLayoutConfig) -> Self {
-        let builder = self.with_table_config(config.table_config().clone());
         let cols = config.columns();
         if cols.is_empty() {
-            return builder;
+            return self;
         }
-        let builder = builder.with_schema(config.schema());
+        let builder = self.with_schema(config.schema());
         if config.is_clustered() {
             builder.with_clustering_columns(cols)
         } else {
@@ -1453,17 +1462,20 @@ impl fmt::Display for TestTable {
 // rstest fixtures
 // ===========================================================================
 
-/// Convenience wrapper: build a [`TestTable`] from a `log_state`, `feature_set`, and
-/// `data_layout`. Used by the `test_context!` macro and available for direct use in tests.
+/// Convenience wrapper: build a [`TestTable`] from a `log_state`, `feature_set`,
+/// `data_layout`, and `table_config`. Used by the `test_context!` macro and available
+/// for direct use in tests.
 pub fn test_table(
     log_state: LogState,
     feature_set: FeatureSet,
     data_layout: DataLayoutConfig,
+    table_config: TableConfig,
 ) -> TestTable {
     TestTableBuilder::new()
         .with_log_state(log_state)
         .with_features(feature_set)
         .with_data_layout(data_layout)
+        .with_table_config(table_config)
         .build()
         .expect("failed to build test table")
 }
@@ -1515,31 +1527,39 @@ macro_rules! build_snapshot {
 /// Expands at the call site so `Snapshot` and the engine type resolve to the caller's crate
 /// types. Returns `(engine, snapshot, table)`.
 ///
-/// The 4-argument form defaults to `DefaultEngine` and requires `DefaultEngineBuilder` to be in
-/// scope at the call site. The 5-argument form takes an explicit engine factory closure
+/// The 5-argument form defaults to `DefaultEngine` and requires `DefaultEngineBuilder` to be in
+/// scope at the call site. The 6-argument form takes an explicit engine factory closure
 /// `Fn(Arc<DynObjectStore>) -> Engine`, useful when the caller cannot construct a
 /// `DefaultEngine` (e.g. kernel-internal unit tests that depend only on `SyncEngine`).
 ///
 /// ```ignore
-/// let (engine, snap, table) =
-///     test_context!(log_state, feature_set, data_layout, version_target);
-/// let (engine, snap, table) =
-///     test_context!(log_state, feature_set, data_layout, version_target,
-///         |store| SyncEngine::new_with_store(store));
+/// let (engine, snap, table) = test_context!(
+///     log_state, feature_set, data_layout, table_config, version_target,
+/// );
+/// let (engine, snap, table) = test_context!(
+///     log_state, feature_set, data_layout, table_config, version_target,
+///     |store| SyncEngine::new_with_store(store),
+/// );
 /// ```
 #[macro_export]
 macro_rules! test_context {
-    ($log_state:expr, $feature_set:expr, $data_layout:expr, $version_target:expr) => {
+    ($log_state:expr, $feature_set:expr, $data_layout:expr, $table_config:expr, $version_target:expr $(,)?) => {
         $crate::test_context!(
             $log_state,
             $feature_set,
             $data_layout,
+            $table_config,
             $version_target,
             |store| { DefaultEngineBuilder::new(store).build() }
         )
     };
-    ($log_state:expr, $feature_set:expr, $data_layout:expr, $version_target:expr, $engine_factory:expr) => {{
-        let table = $crate::table_builder::test_table($log_state, $feature_set, $data_layout);
+    ($log_state:expr, $feature_set:expr, $data_layout:expr, $table_config:expr, $version_target:expr, $engine_factory:expr $(,)?) => {{
+        let table = $crate::table_builder::test_table(
+            $log_state,
+            $feature_set,
+            $data_layout,
+            $table_config,
+        );
         let engine = ($engine_factory)(table.store().clone());
         let snap = $crate::build_snapshot!($version_target, table.table_root(), &engine);
         (engine, snap, table)
@@ -1671,7 +1691,8 @@ mod tests {
     fn test_version_targets(
         #[values(LogState::with_latest_version(4))] log_state: LogState,
         #[values(FeatureSet::empty())] feature_set: FeatureSet,
-        #[values(unpartitioned(json_stats()))] data_layout: DataLayoutConfig,
+        #[values(unpartitioned())] data_layout: DataLayoutConfig,
+        #[values(json_stats())] table_config: TableConfig,
         #[values(
             VersionTarget::Latest,
             VersionTarget::AtVersion(2),
@@ -1679,8 +1700,13 @@ mod tests {
         )]
         version_target: VersionTarget,
     ) {
-        let (_engine, snap, _table) =
-            test_context!(log_state, feature_set, data_layout, version_target);
+        let (_engine, snap, _table) = test_context!(
+            log_state,
+            feature_set,
+            data_layout,
+            table_config,
+            version_target
+        );
         let expected = match &version_target {
             VersionTarget::Latest | VersionTarget::IncrementalToLatest { .. } => 4,
             VersionTarget::AtVersion(v) => *v,
@@ -1917,8 +1943,8 @@ mod tests {
     }
 
     #[rstest::rstest]
-    #[case::partitioned(partitioned(json_stats()), partitioned_schema())]
-    #[case::clustered(clustered(struct_stats()), clustered_schema())]
+    #[case::partitioned(partitioned(), partitioned_schema())]
+    #[case::clustered(clustered(), clustered_schema())]
     fn test_data_layout_table(
         #[case] config: DataLayoutConfig,
         #[case] expected_schema: SchemaRef,
@@ -1946,7 +1972,8 @@ mod tests {
         // v0=create, v1-v3=data commits, 10 rows each
         let table = TestTableBuilder::new()
             .with_log_state(LogState::with_latest_version(3))
-            .with_data_layout(clustered(struct_stats()))
+            .with_data_layout(clustered())
+            .with_table_config(struct_stats())
             .build()?;
         let engine = table.engine();
         let snap = Snapshot::builder_for(table.table_root()).build(&engine)?;

--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -254,10 +254,9 @@ impl LogState {
         self
     }
 
-    /// Latest version on the table. The total number of commits on disk is
-    /// `latest_version + 1`. (Does not yet account for log cleanup -- a
-    /// post-cleanup state where commits `0..K` have been removed is a
-    /// separate axis tracked in #2526.)
+    /// Latest version on the table. After cleanup, commits below
+    /// [`min_reachable_version`](Self::min_reachable_version) are gone, but
+    /// `latest_version` still reflects the highest committed version.
     pub fn latest_version(&self) -> u64 {
         self.latest_version
     }
@@ -1021,7 +1020,7 @@ impl TestTableBuilder {
 
     /// Apply a [`DataLayoutConfig`], setting the schema and layout columns. Pair with
     /// [`with_table_config`](Self::with_table_config) to also set write-time properties
-    /// like stats format -- these axes are independent.
+    /// (e.g. stats format); the two axes are independent.
     ///
     /// For `Unpartitioned`, leaves the schema and columns unchanged.
     pub fn with_data_layout(self, config: DataLayoutConfig) -> Self {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds a `define_sweeps!` macro that emits canonical rstest_reuse templates at the `test_utils` crate root from a single source of truth:

- `default_sweep`: full `LogState x FeatureSet x DataLayoutConfig x TableConfig x VersionTarget` cross-product (891 cases)
- `log_state_sweep`, `feature_set_sweep`, `data_layout_sweep`, `table_config_sweep`, `version_target_sweep`: iterate one axis; the test supplies its own `#[values]` for the rest

Consumer tests apply via `#[rstest_reuse::apply(<name>)]` to get one runner case per combination.

Axes:
- 11 `LogState` shapes (6 base + 5 post-cleanup variants)
- 3 `FeatureSet`s (empty, all-features CM=id, all-features CM=name)
- 3 `DataLayoutConfig`s (unpartitioned, partitioned-all-types, clustered-all-types)
- 3 `TableConfig`s (json stats, struct stats, no stats)
- 3 `VersionTarget`s (latest, at-mid, incremental-to-latest)

## How was this change tested?

New `test_cross_product_read_write` integration test (kernel/tests/integration/cross_product/mod.rs) applies `default_sweep` and asserts the snapshot version + scanned row count for every reachable combination. Targets that reference cleaned-up versions are skipped via `LogState::min_reachable_version()`.