### PR TITLE
feat: support creating Delta tables with empty schema

### DIFF
--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -1878,29 +1878,16 @@ mod tests {
 
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
-    async fn test_create_table_build_with_empty_schema_returns_error(
+    async fn test_create_table_build_with_empty_schema_succeeds(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempdir()?;
-        // An empty schema is always invalid for table creation
+        // CREATE TABLE with no columns is permitted by the Delta protocol; users may
+        // populate the schema later via ALTER TABLE ADD COLUMN.
         let (_table_path, engine, builder) = create_table_builder(&tmp_dir, vec![]);
 
-        let result = unsafe { create_table_builder_build(builder, engine.shallow_copy()) };
-        match result {
-            ExternResult::Err(e) => {
-                let error = unsafe { recover_error(e) };
-                assert!(
-                    error.message.contains("schema")
-                        || error.message.contains("field")
-                        || error.message.contains("empty"),
-                    "Expected schema-related error, got: {}",
-                    error.message
-                );
-            }
-            ExternResult::Ok(txn) => {
-                unsafe { create_table_free_transaction(txn) };
-                panic!("Expected error for empty schema");
-            }
-        }
+        let txn =
+            ok_or_panic(unsafe { create_table_builder_build(builder, engine.shallow_copy()) });
+        unsafe { create_table_free_transaction(txn) };
 
         unsafe { free_engine(engine) };
         Ok(())

--- a/kernel/src/schema/validation.rs
+++ b/kernel/src/schema/validation.rs
@@ -17,18 +17,14 @@ const INVALID_PARQUET_CHARS: &[char] = &[' ', ',', ';', '{', '}', '(', ')', '\n'
 /// Validates a schema for CREATE TABLE or ALTER TABLE.
 ///
 /// Performs the following checks:
-/// 1. Schema is non-empty
-/// 2. No duplicate column names (case-insensitive, including nested fields)
-/// 3. Column names contain only valid characters
-/// 4. Rejects fields with `delta.invariants` metadata (SQL expression invariants are not supported
-///    by kernel; see `TableConfiguration::ensure_write_supported`)
+/// 1. No duplicate column names (case-insensitive, including nested fields)
+/// 2. Column names contain only valid characters
+/// 3. Rejects fields with `delta.invariants` metadata (SQL expression invariants are not supported
+///    by kernel)
 pub(crate) fn validate_schema(
     schema: &StructType,
     column_mapping_mode: ColumnMappingMode,
 ) -> DeltaResult<()> {
-    if schema.num_fields() == 0 {
-        return Err(Error::generic("Schema cannot be empty"));
-    }
     let mut validator = SchemaValidator::new(column_mapping_mode);
     // We reuse the SchemaTransform trait for its recursive traversal machinery.
     // The validator never transforms the schema -- it only inspects fields and
@@ -91,9 +87,7 @@ impl<'a> SchemaTransform<'a> for SchemaValidator {
         self.current_path.push(field.name().to_ascii_lowercase());
 
         // Reject `delta.invariants` metadata on any field. Kernel cannot evaluate SQL
-        // expression invariants, so writing to any table with invariants metadata is
-        // blocked by `TableConfiguration::ensure_write_supported`. Reject at create
-        // time with a clearer, path-aware error.
+        // expression invariants, so reject at create time with a clear, path-aware error.
         //
         // Note: unlike `NonNullFieldChecker`, this validator intentionally does NOT
         // skip recursion into variant internals. Variants are not expected to carry
@@ -421,6 +415,9 @@ mod tests {
     #[case::special_chars_with_cm(schema_with_special_chars(), ColumnMappingMode::Name)]
     #[case::dot_in_name_with_cm(schema_with_dot(), ColumnMappingMode::Name)]
     #[case::different_struct_children(schema_different_struct_children(), ColumnMappingMode::None)]
+    #[case::empty_no_cm(StructType::new_unchecked(vec![]), ColumnMappingMode::None)]
+    #[case::empty_cm_name(StructType::new_unchecked(vec![]), ColumnMappingMode::Name)]
+    #[case::empty_cm_id(StructType::new_unchecked(vec![]), ColumnMappingMode::Id)]
     fn valid_schema_accepted(#[case] schema: StructType, #[case] cm: ColumnMappingMode) {
         assert!(validate_schema(&schema, cm).is_ok());
     }
@@ -428,7 +425,6 @@ mod tests {
     // === Invalid schemas ===
 
     #[rstest]
-    #[case::empty_schema(StructType::new_unchecked(vec![]), ColumnMappingMode::None, &["cannot be empty"])]
     #[case::space_without_cm(schema_with_space(), ColumnMappingMode::None, &["invalid character"])]
     #[case::semicolon_without_cm(schema_with_semicolon(), ColumnMappingMode::None, &["invalid character"])]
     #[case::newline_with_cm(schema_with_newline(), ColumnMappingMode::Name, &["newline"])]

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -867,13 +867,15 @@ impl CreateTableTransactionBuilder {
     /// This method performs validation:
     /// - Checks that the table path is valid
     /// - Verifies the table doesn't already exist
-    /// - Validates the schema is non-empty
     /// - Rejects schemas with `delta.invariants` metadata annotations (unsupported by kernel)
     /// - Validates the data layout is valid
     /// - Validates table properties against the allow list
     ///
     /// Non-null columns (`nullable: false`) are allowed. The `invariants` writer feature is
     /// auto-added to the protocol when the schema has any non-null column.
+    ///
+    /// Empty schemas are accepted. The resulting table cannot be read or blind-appended to
+    /// until columns are added via `ALTER TABLE ADD COLUMN`.
     ///
     /// # Arguments
     ///
@@ -885,7 +887,6 @@ impl CreateTableTransactionBuilder {
     /// Returns an error if:
     /// - The table path is invalid
     /// - A table already exists at the given path
-    /// - The schema is empty
     /// - The schema has `delta.invariants` metadata on any column
     /// - The data layout is invalid
     /// - Unsupported delta properties or feature flags are specified
@@ -917,7 +918,8 @@ impl CreateTableTransactionBuilder {
         let (effective_schema, column_mapping_mode) =
             maybe_apply_column_mapping_for_table_create(&self.schema, &mut validated, pre_cm)?;
 
-        // Validate schema (non-empty, column names, duplicates, no `delta.invariants` metadata)
+        // Validate schema (column names, duplicates, no `delta.invariants` metadata).
+        // Empty schemas are intentionally allowed.
         validate_schema(&effective_schema, column_mapping_mode)?;
 
         // Validate data layout and resolve column names (physical for clustering, logical

--- a/kernel/tests/integration/create_table/mod.rs
+++ b/kernel/tests/integration/create_table/mod.rs
@@ -20,10 +20,11 @@ use delta_kernel::table_features::{
 };
 use delta_kernel::table_properties::TableProperties;
 use delta_kernel::transaction::create_table::{create_table, CreateTableTransaction};
+use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::DeltaResult;
 use rstest::rstest;
 use serde_json::Value;
-use test_utils::{assert_result_error_with_message, test_table_setup};
+use test_utils::{assert_result_error_with_message, test_table_setup, test_table_setup_mt};
 
 /// Helper to create a simple two-column schema for tests.
 /// Shared with sub-modules.
@@ -180,17 +181,84 @@ async fn test_create_table_already_exists() -> DeltaResult<()> {
 }
 
 #[tokio::test]
-async fn test_create_table_empty_schema_not_supported() -> DeltaResult<()> {
+async fn test_create_table_empty_schema_succeeds() -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
 
-    // Create empty schema
+    // CREATE TABLE with no columns is a valid Delta operation; users may add columns
+    // later via ALTER TABLE ADD COLUMN.
     let schema = Arc::new(StructType::try_new(vec![])?);
 
-    // Try to create table with empty schema - should fail at build time
-    let result = create_table(&table_path, schema, "InvalidApp/0.1.0")
+    create_table(&table_path, schema, "EmptySchemaApp/0.1.0")
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    let table_url = delta_kernel::try_parse_uri(&table_path)?;
+    let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+    assert_eq!(snapshot.version(), 0);
+    assert_eq!(snapshot.schema().num_fields(), 0);
+
+    Ok(())
+}
+
+/// Checkpoints serialize the table schema into their parquet payload, so a zero-column
+/// schema is a corner the writer can plausibly mishandle. This test creates an empty
+/// table, checkpoints immediately, then reloads from scratch to confirm the schema
+/// survives the round-trip across all column-mapping modes.
+#[rstest]
+#[case::no_cm(None)]
+#[case::cm_name(Some("name"))]
+#[case::cm_id(Some("id"))]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_create_table_empty_schema_checkpoint_round_trip(
+    #[case] cm_mode: Option<&str>,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+
+    let schema = Arc::new(StructType::try_new(vec![])?);
+    let mut builder = create_table(&table_path, schema, "EmptySchemaApp/0.1.0");
+    if let Some(mode) = cm_mode {
+        builder = builder.with_table_properties([("delta.columnMapping.mode", mode)]);
+    }
+    builder
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    let table_url = delta_kernel::try_parse_uri(&table_path)?;
+    let v0 = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
+    let (_, _ckpt_snapshot) = v0.checkpoint(engine.as_ref(), None)?;
+
+    let reloaded = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+    assert_eq!(reloaded.version(), 0);
+    assert_eq!(reloaded.schema().num_fields(), 0);
+    let max_id = reloaded
+        .table_configuration()
+        .metadata()
+        .configuration()
+        .get("delta.columnMapping.maxColumnId")
+        .and_then(|v| v.parse::<i64>().ok());
+    assert_eq!(max_id, cm_mode.map(|_| 0));
+
+    Ok(())
+}
+
+#[rstest]
+#[case::partitioned_empty(DataLayout::partitioned::<_, &str>([]), "at least one column")]
+#[case::clustered_missing_column(DataLayout::clustered(["foo"]), "not found in schema")]
+#[tokio::test]
+async fn test_create_table_empty_schema_layout_errors(
+    #[case] layout: DataLayout,
+    #[case] expected_err: &str,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    let schema = Arc::new(StructType::try_new(vec![])?);
+    let result = create_table(&table_path, schema, "EmptySchemaApp/0.1.0")
+        .with_data_layout(layout)
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()));
 
-    assert_result_error_with_message(result, "cannot be empty");
+    assert_result_error_with_message(result, expected_err);
 
     Ok(())
 }

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -35,13 +35,16 @@ fn committer() -> Box<FileSystemCommitter> {
     Box::new(FileSystemCommitter::new())
 }
 
-fn max_column_id(snap: &Snapshot) -> i64 {
+/// Reads `delta.columnMapping.maxColumnId` from the snapshot's metadata. Returns
+/// `None` when the property is absent (e.g. non-CM tables) so callers can compare it
+/// directly against `cm_mode.map(...)`-style expectations. CM-only callers should
+/// `.expect(...)` at the use site to surface the protocol violation explicitly.
+fn max_column_id(snap: &Snapshot) -> Option<i64> {
     snap.table_configuration()
         .metadata()
         .configuration()
         .get("delta.columnMapping.maxColumnId")
         .and_then(|v| v.parse().ok())
-        .expect("maxColumnId should be set and parseable on a CM table")
 }
 
 // ============================================================================
@@ -64,7 +67,8 @@ async fn add_columns_lifecycle(
         .unwrap_or_default();
     let snapshot =
         create_table_and_load_snapshot(&table_path, simple_schema(), engine.as_ref(), &properties)?;
-    let original_max_id = cm_mode.map(|_| max_column_id(&snapshot));
+    let original_max_id =
+        cm_mode.map(|_| max_column_id(&snapshot).expect("CM table must have maxColumnId"));
 
     // Write two rows with only the original columns populated.
     let batch = RecordBatch::try_new(
@@ -127,7 +131,7 @@ async fn add_columns_lifecycle(
                 other => panic!("expected String, got {other:?}"),
             }
         }
-        assert!(max_column_id(&reloaded) > orig);
+        assert!(max_column_id(&reloaded).expect("CM table must have maxColumnId") > orig);
     } else {
         assert!(reloaded
             .table_configuration()
@@ -265,7 +269,8 @@ async fn add_complex_type_column(
         .unwrap_or_default();
     let snapshot =
         create_table_and_load_snapshot(&table_path, simple_schema(), engine.as_ref(), &properties)?;
-    let original_max_id = cm_mode.map(|_| max_column_id(&snapshot));
+    let original_max_id =
+        cm_mode.map(|_| max_column_id(&snapshot).expect("CM table must have maxColumnId"));
 
     let field_name = field.name().to_string();
     let expected_type = field.data_type().clone();
@@ -294,7 +299,7 @@ async fn add_complex_type_column(
             "all assigned IDs must exceed original max"
         );
         assert_eq!(
-            max_column_id(&reloaded),
+            max_column_id(&reloaded).expect("CM table must have maxColumnId"),
             ids.iter().copied().max().unwrap(),
             "table maxColumnId must equal the largest assigned ID",
         );
@@ -422,6 +427,86 @@ async fn back_to_back_alters_with_checkpoint() -> Result<(), Box<dyn std::error:
         .downcast_ref::<Int32Array>()
         .expect("b is int");
     assert_eq!(b_col.value(0), 100);
+
+    Ok(())
+}
+
+/// Empty-schema tables are valid intermediate state, so they need to behave normally
+/// once a column is added. This test runs the full lifecycle (create empty, ALTER ADD
+/// COLUMN, write rows, scan them back, time-travel to v0) across all column-mapping
+/// modes so the CM bookkeeping (maxColumnId, column-mapping id, physical name) is
+/// exercised on a schema that started empty rather than being created with columns
+/// up front.
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn empty_create_then_add_column(
+    #[values(None, Some("name"), Some("id"))] cm_mode: Option<&str>,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+    let properties: Vec<(&str, &str)> = cm_mode
+        .map(|m| vec![("delta.columnMapping.mode", m)])
+        .unwrap_or_default();
+
+    let empty_schema = Arc::new(StructType::try_new(vec![])?);
+    let v0 =
+        create_table_and_load_snapshot(&table_path, empty_schema, engine.as_ref(), &properties)?;
+    assert_eq!(v0.version(), 0);
+    assert_eq!(v0.schema().num_fields(), 0);
+    assert_eq!(max_column_id(&v0), cm_mode.map(|_| 0));
+
+    v0.alter_table()
+        .add_column(StructField::nullable("id", DataType::INTEGER))
+        .build(engine.as_ref(), committer())?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    let v1 = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert_eq!(v1.version(), 1);
+    let schema = v1.schema();
+    assert_eq!(schema.num_fields(), 1);
+    let id_field = schema.field("id").expect("added field should exist");
+    assert_eq!(id_field.data_type(), &DataType::INTEGER);
+    assert!(id_field.is_nullable());
+    assert_eq!(max_column_id(&v1), cm_mode.map(|_| 1));
+    assert_eq!(id_field.column_mapping_id(), cm_mode.map(|_| 1i64));
+    assert_eq!(
+        id_field
+            .get_config_value(&ColumnMetadataKey::ColumnMappingPhysicalName)
+            .is_some(),
+        cm_mode.is_some(),
+        "physical name presence must track column-mapping enablement",
+    );
+
+    // Write rows through the freshly-added column and confirm the read path round-trips
+    // them. Under CM this also exercises the physical-name plumbing for a column whose
+    // schema started empty.
+    let arrow_schema = v1.schema().as_ref().try_into_arrow().unwrap();
+    let batch = RecordBatch::try_new(
+        Arc::new(arrow_schema),
+        vec![Arc::new(Int32Array::from(vec![Some(1), None, Some(99)]))],
+    )
+    .unwrap();
+    let v2 = write_batch_to_table(&v1, engine.as_ref(), batch, HashMap::new())
+        .await
+        .map_err(|e| delta_kernel::Error::generic(format!("write_batch_to_table failed: {e}")))?;
+    assert_eq!(v2.version(), 2);
+
+    let scan = v2.scan_builder().build()?;
+    let batches = test_utils::read_scan(&scan, engine.clone())?;
+    let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(
+        total_rows, 3,
+        "post-ALTER write should yield 3 rows on read"
+    );
+
+    // The empty-schema snapshot must still be loadable via time-travel after later
+    // commits introduce a column and data files; pins the contract that the v0 history
+    // survives schema evolution.
+    let v0_after = Snapshot::builder_for(&table_path)
+        .at_version(0)
+        .build(engine.as_ref())?;
+    assert_eq!(v0_after.version(), 0);
+    assert_eq!(v0_after.schema().num_fields(), 0);
 
     Ok(())
 }
@@ -641,7 +726,8 @@ async fn chain_add_column_and_set_nullable(
             .column_mapping_id()
             .expect("existing field should already have a column mapping ID")
     });
-    let original_max_id = cm_mode.map(|_| max_column_id(&snapshot));
+    let original_max_id =
+        cm_mode.map(|_| max_column_id(&snapshot).expect("CM table must have maxColumnId"));
 
     // Two alter+checkpoint cycles: (add email + nullable id), (add age + nullable name).
     let v1 = snapshot
@@ -689,7 +775,7 @@ async fn chain_add_column_and_set_nullable(
             .expect("existing id column mapping");
         assert_eq!(id_after, orig_id, "existing id CM id must not change");
         assert!(
-            max_column_id(&reloaded) > orig_max,
+            max_column_id(&reloaded).expect("CM table must have maxColumnId") > orig_max,
             "chained add_column must bump maxColumnId"
         );
     }


### PR DESCRIPTION
## What changes are proposed in this pull request?

1/ The Delta protocol allows tables to be created with no columns, matching
delta-spark's createEmptySchemaTable behavior. Kernel previously rejected
this at validate_schema with a "Schema cannot be empty" error.

2/ This drops the gate in validate_schema and updates the surrounding doc
comments on CreateTableTransactionBuilder::build to reflect that empty
schemas are accepted. 

3/ Layout validation (partitioning requires at least
one column, clustering columns must exist in the schema) continues to
fire as before, and the existing column-name, duplicate, and invariants
checks are unaffected.

4/ The way Delta Spark ends up updating the schema is through a follow up
ALTER and a test validates that it works.

## How was this change tested?
Create and alter table integration tests.

