### PR TITLE
feat: block read and blind-append on empty-schema Delta tables

### DIFF
--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -240,6 +240,17 @@ impl ScanBuilder {
     /// [`Scan`] type itself can be used to fetch the files and associated metadata required to
     /// perform actual data reads.
     pub fn build(self) -> DeltaResult<Scan> {
+        // Reject scans of empty-schema tables. CREATE TABLE accepts an empty schema as
+        // a transient state, but a scan over zero columns has no way to derive row
+        // counts downstream and panics in the arrow layer. Users must populate the
+        // schema with ALTER TABLE ADD COLUMN before scanning.
+        if self.snapshot.schema().num_fields() == 0 {
+            return Err(Error::generic(
+                "Cannot scan Delta table with empty schema; use ALTER TABLE ADD COLUMN \
+                 to add at least one column before scanning",
+            ));
+        }
+
         // if no schema is provided, use snapshot's entire schema (e.g. SELECT *)
         let logical_schema = self.schema.unwrap_or_else(|| self.snapshot.schema());
 

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -372,6 +372,7 @@ impl<S> Transaction<S> {
         }
 
         self.validate_blind_append_semantics()?;
+        self.ensure_schema_non_empty_for_data_writes()?;
 
         // CDF check only applies to existing tables (not create table)
         // If there are add and remove files with data change in the same transaction, we block it.
@@ -703,6 +704,34 @@ impl<S> Transaction<S> {
         Ok(())
     }
 
+    /// Reject data file writes (add/remove/DV) against an empty-schema table.
+    /// CREATE TABLE and metadata-only commits are exempt.
+    fn ensure_schema_non_empty_for_data_writes(&self) -> DeltaResult<()> {
+        if self.is_create_table() {
+            return Ok(());
+        }
+        if self.has_data_file_actions() {
+            self.ensure_schema_non_empty_for_write_context()?;
+        }
+        Ok(())
+    }
+
+    /// Reject `WriteContext` handouts on empty-schema tables, so engines fail
+    /// before staging any parquet. CREATE TABLE is exempt.
+    fn ensure_schema_non_empty_for_write_context(&self) -> DeltaResult<()> {
+        if self.is_create_table() {
+            return Ok(());
+        }
+        if self.effective_table_config.logical_schema().num_fields() == 0 {
+            return Err(Error::generic(
+                "Cannot write data files to a Delta table with empty schema; \
+                 use `snapshot.alter_table().add_column(...)` to add at least one \
+                 column before writing data",
+            ));
+        }
+        Ok(())
+    }
+
     /// Returns true if this is a create-table transaction.
     /// A create-table transaction has no read snapshot (no pre-existing table).
     fn is_create_table(&self) -> bool {
@@ -711,6 +740,13 @@ impl<S> Transaction<S> {
             "CREATE TABLE operation should not have a read snapshot"
         );
         self.read_snapshot_opt.is_none()
+    }
+
+    /// True iff this transaction stages any data-file action (add, remove, or DV update).
+    fn has_data_file_actions(&self) -> bool {
+        !self.add_files_metadata.is_empty()
+            || !self.remove_files_metadata.is_empty()
+            || !self.dv_matched_files.is_empty()
     }
 
     // Returns the read snapshot. Returns an error if this is a create-table transaction.
@@ -922,6 +958,7 @@ impl<S: SupportsDataFiles> Transaction<S> {
         &self,
         partition_values: HashMap<String, Scalar>,
     ) -> DeltaResult<WriteContext> {
+        self.ensure_schema_non_empty_for_write_context()?;
         let shared = self.shared_write_state();
         require!(
             !shared.logical_partition_columns.is_empty(),
@@ -969,6 +1006,7 @@ impl<S: SupportsDataFiles> Transaction<S> {
     /// Returns an error if the table has partition columns (use
     /// [`partitioned_write_context`](Self::partitioned_write_context) instead).
     pub fn unpartitioned_write_context(&self) -> DeltaResult<WriteContext> {
+        self.ensure_schema_non_empty_for_write_context()?;
         let shared = self.shared_write_state();
         require!(
             shared.logical_partition_columns.is_empty(),

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -454,6 +454,30 @@ async fn empty_create_then_add_column(
     assert_eq!(v0.schema().num_fields(), 0);
     assert_eq!(max_column_id(&v0), cm_mode.map(|_| 0));
 
+    // Scans and blind appends against the empty-schema snapshot are blocked with
+    // friendly errors that point users at ALTER TABLE ADD COLUMN.
+    let scan_err = v0
+        .clone()
+        .scan_builder()
+        .build()
+        .expect_err("scan_builder().build() must reject empty-schema snapshots");
+    assert!(
+        scan_err.to_string().contains("empty schema")
+            && scan_err.to_string().contains("ALTER TABLE ADD COLUMN"),
+        "scan error must point at ALTER TABLE ADD COLUMN, got: {scan_err}"
+    );
+    let write_err = v0
+        .clone()
+        .transaction(committer(), engine.as_ref())?
+        .with_engine_info("EmptySchemaApp/0.1.0")
+        .unpartitioned_write_context()
+        .expect_err("unpartitioned_write_context() must reject empty-schema snapshots");
+    assert!(
+        write_err.to_string().contains("empty schema")
+            && write_err.to_string().contains("alter_table"),
+        "write_context error must point at alter_table, got: {write_err}"
+    );
+
     v0.alter_table()
         .add_column(StructField::nullable("id", DataType::INTEGER))
         .build(engine.as_ref(), committer())?


### PR DESCRIPTION
## What changes are proposed in this pull request?

Phase 2 of empty-schema CREATE TABLE support. Parent PR #2545 made empty-schema CREATE legal; this PR adds the matching guards so those tables error cleanly on read and on data-file writes until ALTER TABLE ADD COLUMN populates the schema. Mirrors delta-spark's contract and prevents an arrow-layer panic on the read path (#2461).

- `ScanBuilder::build` rejects empty-schema snapshots.
- `Transaction` rejects `WriteContext` handouts and data-file commits on empty-schema tables. CREATE TABLE and metadata-only commits stay permitted; ALTER TABLE bypasses naturally via its own transaction type.

## How was this change tested?

Extends the `empty_create_then_add_column` rstest in alter_table integration tests to assert both guards fire on the v0 (empty-schema) snapshot before the ALTER.
