### PR TITLE
ci: clean full target before user-guide doc tests

### DIFF
--- a/docs/user-guide/Makefile
+++ b/docs/user-guide/Makefile
@@ -13,7 +13,7 @@ serve:
 
 # Test that code examples compile
 test:
-	cargo clean --manifest-path $(KERNEL_PATH)/kernel/Cargo.toml -p delta_kernel
+	cargo clean --manifest-path $(KERNEL_PATH)/kernel/Cargo.toml
 	cargo build --locked --manifest-path $(KERNEL_PATH)/kernel/Cargo.toml --features "$(KERNEL_FEATURES)"
 	mdbook test -L $(KERNEL_PATH)/target/debug/deps
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Drop `-p delta_kernel` from the `cargo clean` step in `docs/user-guide/Makefile` so the entire target tree is cleared before the doc-test build.

With the previous flag, only kernel's own artifacts were purged. Stale `.rmeta` files for transitive deps survived in `target/debug/deps/` (populated from the CI cache restored on PR runs). When a PR's `Cargo.lock` churn caused recompiles of crates like `tokio`, `url`, or `arrow`, both old and new rmeta files coexisted in `deps/`. `mdbook test -L target/debug/deps` then tripped rustdoc's E0464 "multiple candidates for rmeta dependency" check.

Triggered by the user-guide CI failure on #2366: https://github.com/delta-io/delta-kernel-rs/actions/runs/25707208489/job/75623148964?pr=2366

## How was this change tested?

Ran `make test` in `docs/user-guide/` locally. All 38 chapters pass.