### PR TITLE
fix: accumulate warnings so reporter no longer has deadlock risk

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,6 +199,7 @@ jobs:
         if: steps.filter.outputs.ffi == 'true'
         run: cargo test --locked --package delta_kernel_ffi --features internal-api -- invalid_handle_code
       - name: metrics deadlock test
+        shell: bash
         run: |
           output=$(cargo run --profile test --example metrics-tester)
           echo "$output" | grep -q 'invalid_field'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,8 +200,9 @@ jobs:
         run: cargo test --locked --package delta_kernel_ffi --features internal-api -- invalid_handle_code
       - name: metrics deadlock test
         run: |
-          count=$(cargo run --profile test --example metrics-tester | grep -E 'invalid_field|Invalid uuid' | wc -l)
-          [ "$count" -ge 2 ]
+          output=$(cargo run --profile test --example metrics-tester)
+          echo "$output" | grep -q 'invalid_field'
+          echo "$output" | grep -q 'Invalid uuid'
 
   ffi_test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,6 +198,8 @@ jobs:
       - name: trybuild tests
         if: steps.filter.outputs.ffi == 'true'
         run: cargo test --locked --package delta_kernel_ffi --features internal-api -- invalid_handle_code
+      - name: metrics deadlock test
+        run: cargo run --locked --profile test --example metrics-tester
 
   ffi_test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,7 +199,9 @@ jobs:
         if: steps.filter.outputs.ffi == 'true'
         run: cargo test --locked --package delta_kernel_ffi --features internal-api -- invalid_handle_code
       - name: metrics deadlock test
-        run: cargo run --locked --profile test --example metrics-tester
+        run: |
+          count=$(cargo run --profile test --example metrics-tester | grep -E 'invalid_field|Invalid uuid' | wc -l)
+          [ "$count" -eq 2 ]
 
   ffi_test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,7 +201,7 @@ jobs:
       - name: metrics deadlock test
         run: |
           count=$(cargo run --profile test --example metrics-tester | grep -E 'invalid_field|Invalid uuid' | wc -l)
-          [ "$count" -eq 2 ]
+          [ "$count" -ge 2 ]
 
   ffi_test:
     runs-on: ${{ matrix.os }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,6 +240,14 @@ Keep this list updated when new protocol features are added to kernel.
   column names (defined by the protocol) are not subject to column mapping.
 - **Transforms:** Generic recursive schema and expression transform traits and helpers
   are in `kernel/src/transforms/`.
+- **Tracing layer callbacks must not emit tracing events directly:** Calling `warn!()` or
+  any tracing macro inside a `tracing_subscriber::Layer` callback (`on_event`, `on_record`,
+  `on_close`) while holding a span's `extensions_mut()` write lock will re-enter the layer
+  and deadlock on the same lock. In `on_new_span`, no extension lock is held during
+  `attrs.record()`, so direct `warn!()` is safe there. In `on_event` and `on_record`, store
+  warnings in a `pending_warnings: Vec<String>` field on the visitor, take them out after
+  the extensions block closes, and emit via `warn!()` only then. See
+  `kernel/src/metrics/reporter.rs` for the canonical pattern.
 
 ## Code Style / Documentation
 

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -169,3 +169,8 @@ harness = false
 [[test]]
 name = "integration"
 path = "tests/integration/main.rs"
+
+# Declare as an example for access to test_utils
+[[example]]
+name = "metrics-tester"
+path = "tests/integration/metrics_main.rs"

--- a/kernel/src/metrics/reporter.rs
+++ b/kernel/src/metrics/reporter.rs
@@ -69,6 +69,23 @@ impl ReportGeneratorLayer {
     pub fn new(reporter: Arc<dyn MetricsReporter>) -> Self {
         ReportGeneratorLayer { reporter }
     }
+
+    fn drain_into_visitor<S>(
+        span: Option<tracing_subscriber::registry::SpanRef<'_, S>>,
+        record: impl FnOnce(&mut EventVisitor),
+    ) where
+        S: Subscriber + for<'l> tracing_subscriber::registry::LookupSpan<'l>,
+    {
+        let warnings = span.and_then(|span| {
+            let mut extensions = span.extensions_mut();
+            let visitor = extensions.get_mut::<EventVisitor>()?;
+            record(visitor);
+            Some(std::mem::take(&mut visitor.pending_warnings))
+        });
+        for warn in warnings.unwrap_or_default() {
+            warn!("{warn}");
+        }
+    }
 }
 
 struct EventVisitor {
@@ -476,32 +493,11 @@ where
     }
 
     fn on_event(&self, event: &tracing::Event<'_>, ctx: Context<'_, S>) {
-        let mut warnings = vec![];
-        if let Some(span) = ctx.event_span(event) {
-            let mut extensions = span.extensions_mut();
-            if let Some(visitor) = extensions.get_mut::<EventVisitor>() {
-                event.record(visitor);
-                warnings.append(&mut visitor.pending_warnings);
-            }
-        }
-
-        for warn in warnings {
-            warn!("{warn}");
-        }
+        Self::drain_into_visitor(ctx.event_span(event), |v| event.record(v));
     }
 
     fn on_record(&self, id: &Id, values: &Record<'_>, ctx: Context<'_, S>) {
-        let mut warnings = vec![];
-        if let Some(span) = ctx.span(id) {
-            let mut extensions = span.extensions_mut();
-            if let Some(visitor) = extensions.get_mut::<EventVisitor>() {
-                values.record(visitor);
-                warnings.append(&mut visitor.pending_warnings);
-            }
-        }
-        for warn in warnings {
-            warn!("{warn}");
-        }
+        Self::drain_into_visitor(ctx.span(id), |v| values.record(v));
     }
 
     fn on_enter(&self, id: &Id, ctx: Context<'_, S>) {
@@ -522,15 +518,19 @@ where
         };
         if metadata.fields().field("report").is_some() {
             let Some(span) = ctx.span(&id) else { return };
-            let mut extensions = span.extensions_mut();
-            let duration = extensions.get_mut::<Instant>().map(|start| start.elapsed());
-            if let Some(event_visitor) = extensions.get_mut::<EventVisitor>() {
-                if let Some(duration) = duration {
-                    event_visitor.set_duration(duration);
+            let event = {
+                let mut extensions = span.extensions_mut();
+                let duration = extensions.get_mut::<Instant>().map(|start| start.elapsed());
+                let Some(event_visitor) = extensions.get_mut::<EventVisitor>() else {
+                    return;
+                };
+                if let Some(d) = duration {
+                    event_visitor.set_duration(d);
                 }
-                if let Some(event) = event_visitor.event.take() {
-                    self.reporter.report(event);
-                }
+                event_visitor.event.take()
+            }; // unlock the extensions before reporting so the reporter itself is safe to warn! etc
+            if let Some(event) = event {
+                self.reporter.report(event);
             }
         }
     }

--- a/kernel/src/metrics/reporter.rs
+++ b/kernel/src/metrics/reporter.rs
@@ -73,11 +73,17 @@ impl ReportGeneratorLayer {
 
 struct EventVisitor {
     event: Option<MetricEvent>,
+    // We store any warnings so they can be emitted after the caller releases any span extension
+    // locks. Calling warn!() while holding extensions_mut() would re-enter on_event and deadlock.
+    pending_warnings: Vec<String>,
 }
 
 impl EventVisitor {
     fn new(event: Option<MetricEvent>) -> Self {
-        Self { event }
+        Self {
+            event,
+            pending_warnings: vec![],
+        }
     }
 
     fn set_duration(&mut self, target_duration: std::time::Duration) {
@@ -108,7 +114,10 @@ impl Visit for EventVisitor {
                 "num_commit_files" => *num_commit_files = value,
                 "num_checkpoint_files" => *num_checkpoint_files = value,
                 "num_compaction_files" => *num_compaction_files = value,
-                _ => warn!("Invalid field recorded on {SEGMENT_FOR_SNAPSHOT_SPAN} span"),
+                _ => self.pending_warnings.push(format!(
+                    "Invalid field '{}' recorded on {SEGMENT_FOR_SNAPSHOT_SPAN} span",
+                    field.name()
+                )),
             }
         }
 
@@ -118,7 +127,10 @@ impl Visit for EventVisitor {
         {
             match field.name() {
                 "version" => *version = value,
-                _ => warn!("Invalid field recorded on {SNAP_BUILD_SPAN} span"),
+                _ => self.pending_warnings.push(format!(
+                    "Invalid field '{}' recorded on {SNAP_BUILD_SPAN} span",
+                    field.name()
+                )),
             }
         }
     }
@@ -139,13 +151,16 @@ impl Visit for EventVisitor {
     }
 }
 
+#[derive(Default)]
 enum StorageEventType {
+    #[default]
     None,
     Copy,
     List,
     Read,
 }
 
+#[derive(Default)]
 struct StorageEventTypeVisitor {
     typ: StorageEventType,
     num_files: u64,
@@ -370,9 +385,7 @@ impl Visit for NewSpanVisitor {
             let s = format!("{:?}", value);
             match Uuid::from_str(&s) {
                 Ok(u) => self.uuid = u,
-                Err(e) => {
-                    warn!("Invalid uuid recorded to span: {value:?}. {e}. Using a default")
-                }
+                Err(e) => warn!("Invalid uuid recorded to span: {value:?}. {e}. Using a default"),
             }
         }
     }
@@ -407,12 +420,7 @@ where
                 total_duration: std::time::Duration::default(),
             }),
             STORAGE_SPAN => {
-                let mut storage_visitor = StorageEventTypeVisitor {
-                    typ: StorageEventType::None,
-                    num_files: 0,
-                    bytes_read: 0,
-                    duration: 0,
-                };
+                let mut storage_visitor = StorageEventTypeVisitor::default();
                 attrs.record(&mut storage_visitor);
                 match storage_visitor.typ {
                     StorageEventType::None => None,
@@ -456,6 +464,11 @@ where
 
         let mut visitor = EventVisitor::new(event);
         attrs.record(&mut visitor);
+        // emit warnings before taking the extensions lock. No lock is held here, so
+        // warn!() is safe to call directly, unlike in on_event/on_record.
+        for w in std::mem::take(&mut visitor.pending_warnings) {
+            warn!("{w}");
+        }
         if let Some(span) = ctx.span(id) {
             let mut extensions = span.extensions_mut();
             extensions.insert(visitor);
@@ -463,20 +476,31 @@ where
     }
 
     fn on_event(&self, event: &tracing::Event<'_>, ctx: Context<'_, S>) {
+        let mut warnings = vec![];
         if let Some(span) = ctx.event_span(event) {
             let mut extensions = span.extensions_mut();
             if let Some(visitor) = extensions.get_mut::<EventVisitor>() {
                 event.record(visitor);
+                warnings.append(&mut visitor.pending_warnings);
             }
+        }
+
+        for warn in warnings {
+            warn!("{warn}");
         }
     }
 
     fn on_record(&self, id: &Id, values: &Record<'_>, ctx: Context<'_, S>) {
+        let mut warnings = vec![];
         if let Some(span) = ctx.span(id) {
             let mut extensions = span.extensions_mut();
             if let Some(visitor) = extensions.get_mut::<EventVisitor>() {
                 values.record(visitor);
+                warnings.append(&mut visitor.pending_warnings);
             }
+        }
+        for warn in warnings {
+            warn!("{warn}");
         }
     }
 

--- a/kernel/tests/integration/metrics_main.rs
+++ b/kernel/tests/integration/metrics_main.rs
@@ -1,0 +1,66 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use delta_kernel::engine::default::DefaultEngineBuilder;
+use delta_kernel::metrics::{MetricEvent, MetricsReporter, WithMetricsReporterLayer as _};
+use delta_kernel::Snapshot;
+use test_utils::table_builder::{LogState, TestTableBuilder};
+use tracing_subscriber::layer::SubscriberExt as _;
+
+#[derive(Debug, Default)]
+struct NoopReporter;
+impl MetricsReporter for NoopReporter {
+    fn report(&self, _: MetricEvent) {}
+}
+
+fn main() {
+    let table = TestTableBuilder::new()
+        .with_log_state(LogState::with_latest_version(1))
+        .with_data(1, 1)
+        .build()
+        .expect("build test table");
+    let table_url = delta_kernel::try_parse_uri(table.table_root()).expect("parse table url");
+    let engine = DefaultEngineBuilder::new(table.store().clone()).build();
+
+    let subscriber = tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer().with_ansi(false))
+        .with_metrics_reporter_layer(Arc::new(NoopReporter));
+    tracing::dispatcher::set_global_default(tracing::Dispatch::new(subscriber)).unwrap();
+
+    let done = Arc::new(AtomicBool::new(false));
+    let watch = Arc::clone(&done);
+    std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_secs(5));
+        if !watch.load(Ordering::SeqCst) {
+            eprintln!("WATCHDOG: deadlock - aborting");
+            std::process::abort();
+        }
+    });
+
+    let _snap = Snapshot::builder_for(table_url).build(&engine);
+
+    {
+        // trigger the invalid uuid warn
+        let _ = tracing::info_span!(
+            "snap.build",
+            operation_id = "not-a-uuid",
+            version = 0u64,
+            report = tracing::field::Empty,
+        );
+    }
+    {
+        // trigger invalid field warn
+        let s = tracing::info_span!(
+            "snap.build",
+            operation_id = %uuid::Uuid::new_v4(),
+            version = 0u64,
+            report = tracing::field::Empty,
+            invalid_field = tracing::field::Empty,
+        );
+        s.record("invalid_field", 42u64);
+    }
+
+    done.store(true, Ordering::SeqCst);
+    println!("PASS");
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

See #2547 for some details. Instead of `warn!`ing directly, we now accumulate warnings and emit them when the lock is no longer held.

Also updated CLAUDE.md to help avoid this in the future.

Fixes: #2547

## How was this change tested?
Added a new test binary. We need to be able to use `set_global_default` (see #2547 for details). This binary is run from CI. I verified that it deadlocks without the fixes.