### PR TITLE
fix: put correct msrv badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Delta Kernel (rust) &emsp; [![build-status]][actions] [![latest-version]][crates.io] [![docs]][docs.rs] ![Crates.io MSRV](https://img.shields.io/crates/msrv/:crate)
+# Delta Kernel (rust) &emsp; [![build-status]][actions] [![latest-version]][crates.io] [![docs]][docs.rs] ![Crates.io MSRV](https://img.shields.io/crates/msrv/delta_kernel)
 
 [build-status]: https://img.shields.io/github/actions/workflow/status/delta-io/delta-kernel-rs/build.yml?branch=main
 [actions]: https://github.com/delta-io/delta-kernel-rs/actions/workflows/build.yml?query=branch%3Amain

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Delta Kernel (rust) &emsp; [![build-status]][actions] [![latest-version]][crates.io] [![docs]][docs.rs] [![rustc-version-1.88+]][rustc]
+# Delta Kernel (rust) &emsp; [![build-status]][actions] [![latest-version]][crates.io] [![docs]][docs.rs] ![Crates.io MSRV](https://img.shields.io/crates/msrv/:crate)
 
 [build-status]: https://img.shields.io/github/actions/workflow/status/delta-io/delta-kernel-rs/build.yml?branch=main
 [actions]: https://github.com/delta-io/delta-kernel-rs/actions/workflows/build.yml?query=branch%3Amain


### PR DESCRIPTION
## What changes are proposed in this pull request?
The previous README wasn't working and renders really poorly:
<img width="697" height="141" alt="image" src="https://github.com/user-attachments/assets/00c97d29-5dc4-4350-873b-c4b136d4e6c7" />


This uses the shields.io badge: https://shields.io/badges/crates-io-msrv meaning it'll also auto-update

## How was this change tested?

View the readme file, now it's nice:
<img width="1225" height="67" alt="image" src="https://github.com/user-attachments/assets/838149cf-e3ae-469e-ba95-519e37153664" />

