### PR TITLE
refactor!: cleanup crc/mod.rs

### DIFF
--- a/kernel/src/crc/delta.rs
+++ b/kernel/src/crc/delta.rs
@@ -85,8 +85,6 @@ impl CrcDelta {
         Some(Crc {
             table_size_bytes: self.file_stats.net_bytes,
             num_files: self.file_stats.net_files,
-            num_metadata: 1,
-            num_protocol: 1,
             protocol,
             metadata,
             domain_metadata,
@@ -215,8 +213,6 @@ mod tests {
         Crc {
             table_size_bytes: 1000,
             num_files: 10,
-            num_metadata: 1,
-            num_protocol: 1,
             ..Default::default()
         }
     }
@@ -527,8 +523,6 @@ mod tests {
         assert_eq!(crc.metadata, metadata);
         assert_eq!(crc.num_files, 5);
         assert_eq!(crc.table_size_bytes, 1000);
-        assert_eq!(crc.num_metadata, 1);
-        assert_eq!(crc.num_protocol, 1);
         assert_eq!(crc.file_stats_validity, FileStatsValidity::Valid);
         assert_eq!(crc.domain_metadata, Some(HashMap::new()));
         assert_eq!(crc.in_commit_timestamp_opt, None);
@@ -681,8 +675,6 @@ mod tests {
         Crc {
             table_size_bytes: file_sizes.iter().sum(),
             num_files: file_sizes.len() as i64,
-            num_metadata: 1,
-            num_protocol: 1,
             file_size_histogram: Some(hist),
             ..Default::default()
         }
@@ -844,8 +836,6 @@ mod tests {
         let mut crc = Crc {
             table_size_bytes: 800,
             num_files: 3,
-            num_metadata: 1,
-            num_protocol: 1,
             file_size_histogram: Some(base_hist),
             ..Default::default()
         };

--- a/kernel/src/crc/lazy.rs
+++ b/kernel/src/crc/lazy.rs
@@ -163,8 +163,6 @@ mod tests {
         let crc = Crc {
             table_size_bytes: 100,
             num_files: 10,
-            num_metadata: 1,
-            num_protocol: 1,
             ..Default::default()
         };
         let loaded = CrcLoadResult::Loaded(Arc::new(crc));
@@ -251,8 +249,6 @@ mod tests {
         Crc {
             table_size_bytes,
             num_files: 1,
-            num_metadata: 1,
-            num_protocol: 1,
             ..Default::default()
         }
     }

--- a/kernel/src/crc/mod.rs
+++ b/kernel/src/crc/mod.rs
@@ -98,10 +98,6 @@ pub struct Crc {
     /// Number of live [`Add`] actions in this table version after action reconciliation.
     /// Private -- use [`Crc::file_stats()`] to access safely.
     num_files: i64,
-    /// Number of [`Metadata`] actions. Must be 1.
-    pub num_metadata: i64,
-    /// Number of [`Protocol`] actions. Must be 1.
-    pub num_protocol: i64,
     /// The table [`Metadata`] at this version.
     pub metadata: Metadata,
     /// The table [`Protocol`] at this version.
@@ -139,15 +135,15 @@ pub struct Crc {
 
     // ===== Not yet supported fields =====
     /// A unique identifier for the transaction that produced this commit.
-    pub txn_id: Option<String>,
+    pub(crate) txn_id: Option<String>,
     /// All live [`Add`] file actions at this version.
-    pub all_files: Option<Vec<Add>>,
+    pub(crate) all_files: Option<Vec<Add>>,
     /// Number of records deleted through Deletion Vectors in this table version.
-    pub num_deleted_records_opt: Option<i64>,
+    pub(crate) num_deleted_records_opt: Option<i64>,
     /// Number of Deletion Vectors active in this table version.
-    pub num_deletion_vectors_opt: Option<i64>,
+    pub(crate) num_deletion_vectors_opt: Option<i64>,
     /// Distribution of deleted record counts across files.
-    pub deleted_record_counts_histogram_opt: Option<DeletedRecordCountsHistogram>,
+    pub(crate) deleted_record_counts_histogram_opt: Option<DeletedRecordCountsHistogram>,
 }
 
 impl Crc {
@@ -209,40 +205,30 @@ impl TryFrom<CrcRaw> for Crc {
     fn try_from(raw: CrcRaw) -> Result<Self, Self::Error> {
         // Per the Delta protocol spec, numMetadata and numProtocol MUST be 1 in any CRC file.
         // Reject malformed files at the deserialization boundary so callers can trust the value.
-        if raw.num_metadata != 1 {
-            return Err(Error::generic(format!(
-                "CRC file has invalid numMetadata: expected 1, got {}",
-                raw.num_metadata
-            )));
+        for (name, value) in [
+            ("numMetadata", raw.num_metadata),
+            ("numProtocol", raw.num_protocol),
+        ] {
+            if value != 1 {
+                return Err(Error::generic(format!(
+                    "CRC file has invalid {name}: expected 1, got {value}"
+                )));
+            }
         }
-        if raw.num_protocol != 1 {
-            return Err(Error::generic(format!(
-                "CRC file has invalid numProtocol: expected 1, got {}",
-                raw.num_protocol
-            )));
-        }
-        let domain_metadata = raw.domain_metadata.map(|vec| {
-            vec.into_iter()
-                .map(|dm| (dm.domain().to_string(), dm))
-                .collect()
-        });
-        let set_transactions = raw.set_transactions.map(|vec| {
-            vec.into_iter()
-                .map(|txn| (txn.app_id.clone(), txn))
-                .collect()
-        });
         Ok(Crc {
             table_size_bytes: raw.table_size_bytes,
             num_files: raw.num_files,
-            num_metadata: raw.num_metadata,
-            num_protocol: raw.num_protocol,
             metadata: raw.metadata,
             protocol: raw.protocol,
             // A CRC file on disk is by definition valid; we never deserialize a degraded state.
             file_stats_validity: FileStatsValidity::Valid,
             in_commit_timestamp_opt: raw.in_commit_timestamp_opt,
-            set_transactions,
-            domain_metadata,
+            set_transactions: raw
+                .set_transactions
+                .map(|v| v.into_iter().map(|t| (t.app_id.clone(), t)).collect()),
+            domain_metadata: raw
+                .domain_metadata
+                .map(|v| v.into_iter().map(|d| (d.domain().to_string(), d)).collect()),
             file_size_histogram: raw.file_size_histogram,
             // Not yet round-tripped through CrcRaw; see the "not yet supported" fields on Crc.
             txn_id: None,
@@ -264,12 +250,8 @@ impl From<Crc> for CrcRaw {
             metadata: crc.metadata,
             protocol: crc.protocol,
             in_commit_timestamp_opt: crc.in_commit_timestamp_opt,
-            set_transactions: crc
-                .set_transactions
-                .map(|map| map.into_values().collect::<Vec<_>>()),
-            domain_metadata: crc
-                .domain_metadata
-                .map(|map| map.into_values().collect::<Vec<_>>()),
+            set_transactions: crc.set_transactions.map(|m| m.into_values().collect()),
+            domain_metadata: crc.domain_metadata.map(|m| m.into_values().collect()),
             file_size_histogram: crc.file_size_histogram,
         }
     }
@@ -327,6 +309,8 @@ pub struct DeletedRecordCountsHistogram {
 mod tests {
     use std::collections::HashMap;
 
+    use rstest::rstest;
+
     use super::Crc;
     use crate::actions::{DomainMetadata, SetTransaction};
 
@@ -336,8 +320,6 @@ mod tests {
         domains: Option<HashMap<String, DomainMetadata>>,
     ) -> Crc {
         Crc {
-            num_metadata: 1,
-            num_protocol: 1,
             set_transactions: txns,
             domain_metadata: domains,
             ..Default::default()
@@ -522,8 +504,6 @@ mod tests {
         let crc = Crc {
             table_size_bytes: 1024 * 1024,
             num_files: 10,
-            num_metadata: 1,
-            num_protocol: 1,
             set_transactions: Some(txns),
             domain_metadata: Some(domains),
             ..Default::default()
@@ -563,7 +543,8 @@ mod tests {
 
     // ===== numMetadata / numProtocol rejection =====
 
-    /// Minimal CRC JSON with a given numMetadata / numProtocol pair. Both fields are required.
+    /// Minimal CRC JSON with the supplied numMetadata / numProtocol values; used to construct
+    /// invalid CRCs and verify rejection.
     fn crc_json_with_counts(num_metadata: i64, num_protocol: i64) -> String {
         format!(
             r#"{{
@@ -584,30 +565,23 @@ mod tests {
         )
     }
 
-    /// Per the Delta protocol spec, `numMetadata` MUST be 1.
-    #[test]
-    fn de_invalid_num_metadata_is_rejected() {
-        for bad in [0i64, 2, 3, -1] {
-            let json = crc_json_with_counts(bad, 1);
-            let err = serde_json::from_str::<Crc>(&json).unwrap_err().to_string();
-            assert!(
-                err.contains("numMetadata"),
-                "expected error to mention numMetadata for value {bad}, got: {err}"
-            );
-        }
-    }
-
-    /// Per the Delta protocol spec, `numProtocol` MUST be 1.
-    #[test]
-    fn de_invalid_num_protocol_is_rejected() {
-        for bad in [0i64, 2, 3, -1] {
-            let json = crc_json_with_counts(1, bad);
-            let err = serde_json::from_str::<Crc>(&json).unwrap_err().to_string();
-            assert!(
-                err.contains("numProtocol"),
-                "expected error to mention numProtocol for value {bad}, got: {err}"
-            );
-        }
+    /// Per the Delta protocol spec, both `numMetadata` and `numProtocol` MUST be 1; any other
+    /// value (zero, two, negative) is rejected, and the error names the offending field.
+    #[rstest]
+    #[case::num_metadata("numMetadata", |b| (b, 1))]
+    #[case::num_protocol("numProtocol", |b| (1, b))]
+    fn de_invalid_count_is_rejected(
+        #[case] field: &str,
+        #[case] counts: fn(i64) -> (i64, i64),
+        #[values(0i64, 2, 3, -1)] bad: i64,
+    ) {
+        let (m, p) = counts(bad);
+        let json = crc_json_with_counts(m, p);
+        let err = serde_json::from_str::<Crc>(&json).unwrap_err().to_string();
+        assert!(
+            err.contains(field),
+            "expected error to mention {field} for value {bad}, got: {err}"
+        );
     }
 
     // ===== File size histogram validation =====
@@ -635,8 +609,6 @@ mod tests {
             }}"#
         )
     }
-
-    use rstest::rstest;
 
     /// Both the Delta spec field name and the legacy Delta-Spark name must deserialize.
     #[rstest]

--- a/kernel/src/crc/mod.rs
+++ b/kernel/src/crc/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! [`Crc`] holds the in-memory state using shapes that make kernel queries easy: typed
 //! validity enums and `HashMap`s keyed by id, instead of the flat scalars and arrays of the
-//! on-disk format. It (de)serializes to/from JSON via the private [`CrcRaw`] serde
+//! on-disk format. It (de)serializes to/from JSON via the private `CrcRaw` serde
 //! intermediate, which mirrors the wire format exactly.
 //!
 //! [CRC file]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#version-checksum-file
@@ -77,13 +77,13 @@ pub enum FileStatsValidity {
 /// Parsed content of a CRC (version checksum) file.
 ///
 /// A `Crc` is either (a) loaded from disk (deserialized from a `.crc` JSON file via
-/// the private [`CrcRaw`] intermediate) or (b) computed in memory (built incrementally via
-/// [`Crc::apply`]).
+/// the private `CrcRaw` intermediate) or (b) computed in memory (built incrementally via
+/// `Crc::apply`).
 ///
 /// A CRC file must:
 /// 1. Be named `{version}.crc` with version zero-padded to 20 digits: `00000000000000000001.crc`
 /// 2. Be stored directly in the _delta_log directory alongside Delta log files
-/// 3. Contain exactly one JSON object with the schema mirrored by [`CrcRaw`].
+/// 3. Contain exactly one JSON object with the schema mirrored by `CrcRaw`.
 ///
 /// This struct and its fields are marked `pub`, but the `crc` module is only re-exported as `pub`
 /// when the `test-utils` feature is enabled (otherwise `pub(crate)`). See `kernel/src/lib.rs`.
@@ -115,20 +115,20 @@ pub struct Crc {
     //       observations" from "fully tracked but empty".
     /// Live transaction identifier ([`SetTransaction`]) actions at this version. `None` = not
     /// tracked (field absent in CRC JSON or not computed). `Some(empty_map)` = tracked, no
-    /// active set transactions. [`Crc::apply`] skips updates when `None`.
+    /// active set transactions. `Crc::apply` skips updates when `None`.
     ///
     /// Stored as a HashMap keyed by `app_id` for efficient lookup. The CRC JSON format uses
-    /// a Vec, which is converted via the [`CrcRaw`] serde intermediate.
+    /// a Vec, which is converted via the `CrcRaw` serde intermediate.
     pub set_transactions: Option<HashMap<String, SetTransaction>>,
     // TODO: introduce `DomainMetadataState` (Complete / Partial) to disambiguate "no
     //       observations" from "fully tracked but empty".
     /// Active (non-removed) [`DomainMetadata`] actions at this version. Tombstones
     /// (`removed=true`) are never stored. `None` = not tracked (field absent in CRC JSON or not
-    /// computed). `Some(empty_map)` = tracked, no active domain metadata. [`Crc::apply`]
+    /// computed). `Some(empty_map)` = tracked, no active domain metadata. `Crc::apply`
     /// skips updates when `None`.
     ///
     /// Stored as a HashMap keyed by domain name for efficient lookup. The CRC JSON format uses
-    /// a Vec, which is converted via the [`CrcRaw`] serde intermediate.
+    /// a Vec, which is converted via the `CrcRaw` serde intermediate.
     pub domain_metadata: Option<HashMap<String, DomainMetadata>>,
     /// Size distribution information of files remaining after action reconciliation.
     pub file_size_histogram: Option<FileSizeHistogram>,

--- a/kernel/src/crc/mod.rs
+++ b/kernel/src/crc/mod.rs
@@ -3,6 +3,11 @@
 //! A [CRC file] contains a snapshot of table state at a specific version, which can be used to
 //! optimize log replay operations like reading Protocol/Metadata, domain metadata, and ICT.
 //!
+//! [`Crc`] holds the in-memory state using shapes that make kernel queries easy: typed
+//! validity enums and `HashMap`s keyed by id, instead of the flat scalars and arrays of the
+//! on-disk format. It (de)serializes to/from JSON via the private [`CrcRaw`] serde
+//! intermediate, which mirrors the wire format exactly.
+//!
 //! [CRC file]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#version-checksum-file
 
 // Allow unreachable_pub because this module is pub when test-utils is enabled
@@ -27,17 +32,19 @@ pub(crate) use file_stats::FileStatsDelta;
 pub(crate) use lazy::{CrcLoadResult, LazyCrc};
 pub(crate) use reader::try_read_crc_file;
 use serde::de::Deserializer;
-use serde::ser::Serializer;
 use serde::{Deserialize, Serialize};
 #[allow(unused)]
 pub(crate) use writer::try_write_crc_file;
 
 use crate::actions::{Add, DomainMetadata, Metadata, Protocol, SetTransaction};
+use crate::Error;
 
 /// Tracks whether file stats (`num_files`, `table_size_bytes`) are trustworthy.
 ///
 /// Defaults to [`Valid`](Self::Valid), which is the correct state when deserializing a CRC file
 /// from disk (a CRC file's stats are correct by definition).
+// TODO: replace `FileStatsValidity` with a typed `FileStatsState` enum that carries the
+//       data per variant so reads from a degraded state are a compile error.
 #[allow(dead_code)] // Variants used in follow-up PRs (forward replay, transaction delta).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum FileStatsValidity {
@@ -63,21 +70,26 @@ pub enum FileStatsValidity {
     Untrackable,
 }
 
+// ============================================================================
+// Crc: in-memory representation
+// ============================================================================
+
 /// Parsed content of a CRC (version checksum) file.
 ///
-/// A `Crc` is either (a) loaded from disk (deserialized from a `.crc` JSON file) or (b) computed
-/// in memory (built incrementally via `Crc::apply`).
+/// A `Crc` is either (a) loaded from disk (deserialized from a `.crc` JSON file via
+/// the private [`CrcRaw`] intermediate) or (b) computed in memory (built incrementally via
+/// [`Crc::apply`]).
 ///
 /// A CRC file must:
 /// 1. Be named `{version}.crc` with version zero-padded to 20 digits: `00000000000000000001.crc`
 /// 2. Be stored directly in the _delta_log directory alongside Delta log files
-/// 3. Contain exactly one JSON object with the schema of this struct.
+/// 3. Contain exactly one JSON object with the schema mirrored by [`CrcRaw`].
 ///
 /// This struct and its fields are marked `pub`, but the `crc` module is only re-exported as `pub`
 /// when the `test-utils` feature is enabled (otherwise `pub(crate)`). See `kernel/src/lib.rs`.
-// Deserialized directly from JSON via serde. See `reader::try_read_crc_file`.
+// TODO: rename `Crc` to `CrcState` to align with `FileStatsState`, `SetTransactionState`, etc.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(try_from = "CrcRaw", into = "CrcRaw")]
 pub struct Crc {
     // ===== Required fields =====
     /// Total size of the table in bytes, calculated as the sum of the `size` field of all live
@@ -98,66 +110,43 @@ pub struct Crc {
     /// Not serialized -- this is an in-memory replay concern only. When deserialized from a CRC
     /// file on disk, defaults to [`FileStatsValidity::Valid`] (a CRC file's stats are correct
     /// by definition). A CRC is only safe to write to disk when validity is `Valid`.
-    #[serde(skip)]
     pub file_stats_validity: FileStatsValidity,
 
     // ===== Optional fields =====
-    /// A unique identifier for the transaction that produced this commit.
-    #[serde(skip)]
-    pub txn_id: Option<String>,
     /// The in-commit timestamp of this version. Present iff In-Commit Timestamps are enabled.
     pub in_commit_timestamp_opt: Option<i64>,
+    // TODO: introduce `SetTransactionState` (Complete / Partial) to disambiguate "no
+    //       observations" from "fully tracked but empty".
     /// Live transaction identifier ([`SetTransaction`]) actions at this version. `None` = not
     /// tracked (field absent in CRC JSON or not computed). `Some(empty_map)` = tracked, no
-    /// active set transactions. `apply()` skips updates when `None`.
+    /// active set transactions. [`Crc::apply`] skips updates when `None`.
     ///
     /// Stored as a HashMap keyed by `app_id` for efficient lookup. The CRC JSON format uses
-    /// a Vec, which is converted via custom serde deserialization.
-    #[serde(
-        default,
-        deserialize_with = "de_opt_vec_to_opt_map",
-        serialize_with = "ser_opt_map_to_opt_vec"
-    )]
+    /// a Vec, which is converted via the [`CrcRaw`] serde intermediate.
     pub set_transactions: Option<HashMap<String, SetTransaction>>,
+    // TODO: introduce `DomainMetadataState` (Complete / Partial) to disambiguate "no
+    //       observations" from "fully tracked but empty".
     /// Active (non-removed) [`DomainMetadata`] actions at this version. Tombstones
     /// (`removed=true`) are never stored. `None` = not tracked (field absent in CRC JSON or not
-    /// computed). `Some(empty_map)` = tracked, no active domain metadata. `apply()` skips
-    /// updates when `None`.
+    /// computed). `Some(empty_map)` = tracked, no active domain metadata. [`Crc::apply`]
+    /// skips updates when `None`.
     ///
     /// Stored as a HashMap keyed by domain name for efficient lookup. The CRC JSON format uses
-    /// a Vec, which is converted via custom serde deserialization.
-    #[serde(
-        default,
-        deserialize_with = "de_opt_vec_to_opt_map",
-        serialize_with = "ser_opt_map_to_opt_vec"
-    )]
+    /// a Vec, which is converted via the [`CrcRaw`] serde intermediate.
     pub domain_metadata: Option<HashMap<String, DomainMetadata>>,
     /// Size distribution information of files remaining after action reconciliation.
-    ///
-    /// The Delta protocol spec names this field `fileSizeHistogram`, but Delta-Spark writers
-    /// historically emit it as `histogramOpt`. To remain compatible with CRC files written by
-    /// those tools, deserialization accepts either name, but not both. If both are present
-    /// deserialization will throw an error. Serialization always emits the spec-correct
-    /// `fileSizeHistogram`. Mirrors the kernel-java fix in
-    /// <https://github.com/delta-io/delta/pull/6281>.
-    #[serde(
-        default,
-        alias = "histogramOpt",
-        deserialize_with = "de_validated_file_size_histogram",
-        skip_serializing_if = "Option::is_none"
-    )]
     pub file_size_histogram: Option<FileSizeHistogram>,
+
+    // ===== Not yet supported fields =====
+    /// A unique identifier for the transaction that produced this commit.
+    pub txn_id: Option<String>,
     /// All live [`Add`] file actions at this version.
-    #[serde(skip)]
     pub all_files: Option<Vec<Add>>,
     /// Number of records deleted through Deletion Vectors in this table version.
-    #[serde(skip)]
     pub num_deleted_records_opt: Option<i64>,
     /// Number of Deletion Vectors active in this table version.
-    #[serde(skip)]
     pub num_deletion_vectors_opt: Option<i64>,
-    /// Distribution of deleted record counts across files. See this section for more details.
-    #[serde(skip)]
+    /// Distribution of deleted record counts across files.
     pub deleted_record_counts_histogram_opt: Option<DeletedRecordCountsHistogram>,
 }
 
@@ -179,37 +168,111 @@ impl Crc {
     }
 }
 
-/// Trait for types that can be stored in a HashMap keyed by a string identifier.
-/// Used by CRC serde helpers to convert between Vec (JSON format) and HashMap (in-memory).
-trait MapKey {
-    fn map_key(&self) -> &str;
+// ============================================================================
+// CrcRaw: serde intermediate
+// ============================================================================
+
+/// The on-disk JSON shape of a CRC file. Serves as the serde intermediate for [`Crc`].
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CrcRaw {
+    table_size_bytes: i64,
+    num_files: i64,
+    num_metadata: i64,
+    num_protocol: i64,
+    metadata: Metadata,
+    protocol: Protocol,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    in_commit_timestamp_opt: Option<i64>,
+    #[serde(default)]
+    set_transactions: Option<Vec<SetTransaction>>,
+    #[serde(default)]
+    domain_metadata: Option<Vec<DomainMetadata>>,
+    /// The Delta protocol spec names this field `fileSizeHistogram`, but Delta-Spark writers
+    /// historically emit it as `histogramOpt`. To remain compatible with CRC files written by
+    /// those tools, deserialization accepts either name, but not both. If both are present
+    /// deserialization will throw an error. Serialization always emits the spec-correct
+    /// `fileSizeHistogram`. Mirrors the kernel-java fix in
+    /// <https://github.com/delta-io/delta/pull/6281>.
+    #[serde(
+        default,
+        alias = "histogramOpt",
+        deserialize_with = "de_validated_file_size_histogram",
+        skip_serializing_if = "Option::is_none"
+    )]
+    file_size_histogram: Option<FileSizeHistogram>,
 }
 
-impl MapKey for DomainMetadata {
-    fn map_key(&self) -> &str {
-        self.domain()
+impl TryFrom<CrcRaw> for Crc {
+    type Error = Error;
+
+    fn try_from(raw: CrcRaw) -> Result<Self, Self::Error> {
+        // Per the Delta protocol spec, numMetadata and numProtocol MUST be 1 in any CRC file.
+        // Reject malformed files at the deserialization boundary so callers can trust the value.
+        if raw.num_metadata != 1 {
+            return Err(Error::generic(format!(
+                "CRC file has invalid numMetadata: expected 1, got {}",
+                raw.num_metadata
+            )));
+        }
+        if raw.num_protocol != 1 {
+            return Err(Error::generic(format!(
+                "CRC file has invalid numProtocol: expected 1, got {}",
+                raw.num_protocol
+            )));
+        }
+        let domain_metadata = raw.domain_metadata.map(|vec| {
+            vec.into_iter()
+                .map(|dm| (dm.domain().to_string(), dm))
+                .collect()
+        });
+        let set_transactions = raw.set_transactions.map(|vec| {
+            vec.into_iter()
+                .map(|txn| (txn.app_id.clone(), txn))
+                .collect()
+        });
+        Ok(Crc {
+            table_size_bytes: raw.table_size_bytes,
+            num_files: raw.num_files,
+            num_metadata: raw.num_metadata,
+            num_protocol: raw.num_protocol,
+            metadata: raw.metadata,
+            protocol: raw.protocol,
+            // A CRC file on disk is by definition valid; we never deserialize a degraded state.
+            file_stats_validity: FileStatsValidity::Valid,
+            in_commit_timestamp_opt: raw.in_commit_timestamp_opt,
+            set_transactions,
+            domain_metadata,
+            file_size_histogram: raw.file_size_histogram,
+            // Not yet round-tripped through CrcRaw; see the "not yet supported" fields on Crc.
+            txn_id: None,
+            all_files: None,
+            num_deleted_records_opt: None,
+            num_deletion_vectors_opt: None,
+            deleted_record_counts_histogram_opt: None,
+        })
     }
 }
 
-impl MapKey for SetTransaction {
-    fn map_key(&self) -> &str {
-        &self.app_id
+impl From<Crc> for CrcRaw {
+    fn from(crc: Crc) -> Self {
+        CrcRaw {
+            table_size_bytes: crc.table_size_bytes,
+            num_files: crc.num_files,
+            num_metadata: 1,
+            num_protocol: 1,
+            metadata: crc.metadata,
+            protocol: crc.protocol,
+            in_commit_timestamp_opt: crc.in_commit_timestamp_opt,
+            set_transactions: crc
+                .set_transactions
+                .map(|map| map.into_values().collect::<Vec<_>>()),
+            domain_metadata: crc
+                .domain_metadata
+                .map(|map| map.into_values().collect::<Vec<_>>()),
+            file_size_histogram: crc.file_size_histogram,
+        }
     }
-}
-
-/// Deserialize an `Option<Vec<T>>` from JSON into `Option<HashMap<String, T>>`, using
-/// [`MapKey::map_key`] to derive the HashMap key for each element.
-fn de_opt_vec_to_opt_map<'de, D, T>(deserializer: D) -> Result<Option<HashMap<String, T>>, D::Error>
-where
-    D: Deserializer<'de>,
-    T: Deserialize<'de> + MapKey,
-{
-    let opt_vec: Option<Vec<T>> = Option::deserialize(deserializer)?;
-    Ok(opt_vec.map(|vec| {
-        vec.into_iter()
-            .map(|item| (item.map_key().to_string(), item))
-            .collect()
-    }))
 }
 
 /// Deserializes an `Option<FileSizeHistogram>` from a CRC JSON file with validation.
@@ -233,22 +296,6 @@ where
         .map(Some)
         .map_err(serde::de::Error::custom),
         None => Ok(None),
-    }
-}
-
-/// Serialize `Option<HashMap<String, T>>` back to `Option<Vec<T>>` so the CRC JSON format
-/// uses an array (matching the Delta protocol spec).
-fn ser_opt_map_to_opt_vec<S, T>(
-    map: &Option<HashMap<String, T>>,
-    serializer: S,
-) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-    T: Serialize,
-{
-    match map {
-        None => serializer.serialize_none(),
-        Some(m) => m.values().collect::<Vec<_>>().serialize(serializer),
     }
 }
 
@@ -289,6 +336,8 @@ mod tests {
         domains: Option<HashMap<String, DomainMetadata>>,
     ) -> Crc {
         Crc {
+            num_metadata: 1,
+            num_protocol: 1,
             set_transactions: txns,
             domain_metadata: domains,
             ..Default::default()
@@ -512,6 +561,55 @@ mod tests {
         assert_eq!(crc, deserialized);
     }
 
+    // ===== numMetadata / numProtocol rejection =====
+
+    /// Minimal CRC JSON with a given numMetadata / numProtocol pair. Both fields are required.
+    fn crc_json_with_counts(num_metadata: i64, num_protocol: i64) -> String {
+        format!(
+            r#"{{
+                "tableSizeBytes": 0,
+                "numFiles": 0,
+                "numMetadata": {num_metadata},
+                "numProtocol": {num_protocol},
+                "metadata": {{
+                    "id": "test",
+                    "format": {{"provider": "parquet", "options": {{}}}},
+                    "schemaString": "{{\"type\":\"struct\",\"fields\":[]}}",
+                    "partitionColumns": [],
+                    "configuration": {{}},
+                    "createdTime": 0
+                }},
+                "protocol": {{"minReaderVersion": 1, "minWriterVersion": 1}}
+            }}"#
+        )
+    }
+
+    /// Per the Delta protocol spec, `numMetadata` MUST be 1.
+    #[test]
+    fn de_invalid_num_metadata_is_rejected() {
+        for bad in [0i64, 2, 3, -1] {
+            let json = crc_json_with_counts(bad, 1);
+            let err = serde_json::from_str::<Crc>(&json).unwrap_err().to_string();
+            assert!(
+                err.contains("numMetadata"),
+                "expected error to mention numMetadata for value {bad}, got: {err}"
+            );
+        }
+    }
+
+    /// Per the Delta protocol spec, `numProtocol` MUST be 1.
+    #[test]
+    fn de_invalid_num_protocol_is_rejected() {
+        for bad in [0i64, 2, 3, -1] {
+            let json = crc_json_with_counts(1, bad);
+            let err = serde_json::from_str::<Crc>(&json).unwrap_err().to_string();
+            assert!(
+                err.contains("numProtocol"),
+                "expected error to mention numProtocol for value {bad}, got: {err}"
+            );
+        }
+    }
+
     // ===== File size histogram validation =====
 
     /// Minimal CRC JSON with a file size histogram field spliced in under the given field name
@@ -605,7 +703,7 @@ mod tests {
     /// "duplicate field" error -- serde's `#[serde(alias)]` treats both names as the same
     /// logical field and refuses to deserialize repeated sets. No real producer emits both
     /// fields today (Delta-Spark writes only `histogramOpt` or only `fileSizeHistogram`,
-    /// kernel-java / kernel-rust write only `fileSizeHistogram`), so this is a defensive guard  
+    /// kernel-java / kernel-rust write only `fileSizeHistogram`), so this is a defensive guard
     /// against malformed CRCs. The error fires regardless of the data carried under each name.
     /// The cases below exercise both matching and mismatched payloads, in both JSON orderings.
     #[rstest]

--- a/kernel/src/crc/reader.rs
+++ b/kernel/src/crc/reader.rs
@@ -8,8 +8,9 @@ use crate::{DeltaResult, Engine, Error};
 ///
 /// Reads raw bytes via the storage handler and deserializes with serde_json.
 ///
-/// Returns `Ok(Crc)` on success, `Err` on any failure (file not readable, corrupt JSON, missing
-/// required fields). The caller should handle errors gracefully by falling back to log replay.
+/// Returns `Ok(Crc)` on success, `Err` on any failure (file not readable, corrupt JSON,
+/// missing required fields). The caller should handle errors gracefully by falling back to log
+/// replay.
 pub(crate) fn try_read_crc_file(engine: &dyn Engine, crc_path: &ParsedLogPath) -> DeltaResult<Crc> {
     let storage = engine.storage_handler();
     let url = crc_path.location.as_url().clone();
@@ -133,7 +134,7 @@ mod tests {
         assert!(hist.file_counts[1..].iter().all(|&c| c == 0));
         assert!(hist.total_bytes[1..].iter().all(|&b| b == 0));
 
-        // Remaining skipped fields are still None (pending serde support on their types)
+        // These fields are on the Crc struct but not yet round-tripped through CrcRaw.
         assert!(crc.txn_id.is_none());
         assert!(crc.all_files.is_none());
         assert!(crc.num_deleted_records_opt.is_none());

--- a/kernel/src/crc/reader.rs
+++ b/kernel/src/crc/reader.rs
@@ -52,8 +52,6 @@ mod tests {
         // Verify basic fields
         assert_eq!(crc.table_size_bytes, 5259);
         assert_eq!(crc.num_files, 10);
-        assert_eq!(crc.num_metadata, 1);
-        assert_eq!(crc.num_protocol, 1);
         assert_eq!(crc.in_commit_timestamp_opt, Some(1694758257000));
 
         // Verify protocol

--- a/kernel/src/crc/writer.rs
+++ b/kernel/src/crc/writer.rs
@@ -75,8 +75,6 @@ mod tests {
         Crc {
             table_size_bytes: 1024,
             num_files: 5,
-            num_metadata: 1,
-            num_protocol: 1,
             protocol,
             txn_id: None,
             in_commit_timestamp_opt: Some(ict),

--- a/kernel/src/crc/writer.rs
+++ b/kernel/src/crc/writer.rs
@@ -8,7 +8,7 @@ use crate::{DeltaResult, Engine, Error};
 
 /// Serialize and write a CRC file to storage.
 ///
-/// Serializes the [`Crc`] struct to JSON via serde and writes the raw bytes using the storage
+/// Serializes the [`Crc`] to JSON via serde and writes the raw bytes using the storage
 /// handler. Returns [`Error::ChecksumWriteUnsupported`] if file stats are not valid (a CRC file
 /// on disk must have correct stats). Per the Delta protocol, writers MUST NOT overwrite existing
 /// CRC files, so this always writes with `overwrite = false`. If the file already exists, returns

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -117,8 +117,6 @@ async fn test_get_current_crc_if_loaded_returns_loaded_crc() -> DeltaResult<()> 
     let file_stats = crc.file_stats().unwrap();
     assert_eq!(file_stats.table_size_bytes(), 5259);
     assert_eq!(file_stats.num_files(), 10);
-    assert_eq!(crc.num_metadata, 1);
-    assert_eq!(crc.num_protocol, 1);
 
     // Protocol and metadata should match the snapshot's table configuration
     assert_eq!(crc.protocol, *snapshot.table_configuration().protocol());
@@ -191,8 +189,6 @@ async fn test_create_table_produces_post_commit_crc() -> DeltaResult<()> {
     let file_stats = crc.file_stats().unwrap();
     assert_eq!(file_stats.num_files(), 0);
     assert_eq!(file_stats.table_size_bytes(), 0);
-    assert_eq!(crc.num_metadata, 1);
-    assert_eq!(crc.num_protocol, 1);
     assert_eq!(crc.protocol, *snapshot.table_configuration().protocol());
     assert_eq!(crc.metadata, *snapshot.table_configuration().metadata());
     let dms = crc.domain_metadata.as_ref().unwrap();


### PR DESCRIPTION
Part of #1781 (CRC tracking issue) -- see there for the subsequent `incremental_crc_*` PRs in this series.

## What changes are proposed in this pull request?

This PR separates `Crc` into `Crc` (with helpful accessors for Kernel code) and `CrcRaw` which represents strictly the on-disk Crc format.

This split will be helpful for subsequent incremental-crc PRs when we have more complex Crc accessors, such as:
- FileStatsState -- similar to the existing enum today, but this enum will guard/wrap the underlying data, preventing illegal access on incomplete data
- SetTransactionState { Complete (data), Partial (Data) }
- DomainMetadataState { Complete (data), Partial (Data) }

Note: we will also rename Crc into CrcState, later, to align our naming

Performs minor cleanups along the way.

## How was this change tested?

Mainly just a refactor. Existing UTs.
