### PR TITLE
chore: make delta_kernel_default_engine publishable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ cargo +nightly fmt \
 | Crate                                    | Directory                                  | Description                                             |
 |------------------------------------------|--------------------------------------------|---------------------------------------------------------|
 | `delta_kernel`                           | `kernel/`                                  | Core library                                            |
+| `delta_kernel_default_engine`            | `default-engine/`                          | Default Arrow/Tokio `Engine` implementation             |
 | `delta_kernel_ffi`                       | `ffi/`                                     | C/C++ FFI bindings                                      |
 | `delta_kernel_derive`                    | `derive-macros/`                           | Proc macros                                             |
 | `acceptance`                             | `acceptance/`                              | Acceptance tests (DAT)                                  |
@@ -64,11 +65,12 @@ cargo +nightly fmt \
 
 Some noteworthy ones (see `[features]` in `kernel/Cargo.toml` for the full list):
 
-- `default-engine-rustls` / `default-engine-native-tls` -- async Arrow/Tokio engine (pick a TLS backend)
+- TLS backend selection (`rustls` / `native-tls`) lives on the `delta_kernel_default_engine`
+  crate, not on kernel itself.
 - `arrow`, `arrow-XX`, `arrow-YY` -- Arrow version selection (kernel tracks the latest two
   major Arrow releases; `arrow` defaults to latest). Kernel itself does not depend on Arrow,
   but the default engine does.
-- `arrow-conversion`, `arrow-expression` -- Arrow interop (auto-enabled by default engine)
+- `arrow-conversion`, `arrow-expression` -- Arrow interop (auto-enabled by `default-engine-base`)
 - `prettyprint` -- enables Arrow pretty-print helpers (primarily test/example oriented)
 - `clustered-table` -- clustered table write support (experimental)
 - `column-defaults-in-dev` -- column defaults write support (experimental, in development).

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ is the Rust/C equivalent of [Java Delta Kernel][java-kernel].
 Delta-kernel-rs is split into a few different crates:
 
 - kernel: The actual core kernel crate
+- default-engine: The default Arrow/Tokio-based `Engine` implementation, published as
+  `delta_kernel_default_engine`
 - acceptance: Acceptance tests that validate correctness  via the [Delta Acceptance Tests][dat]
 - derive-macros: A crate for our [derive-macros] to live in
 - ffi: Functionality that enables delta-kernel-rs to be used from `C` or `C++` See the [ffi](ffi)
@@ -45,27 +47,34 @@ In general, you will want to depend on `delta-kernel-rs` by adding it as a depen
 module. The core kernel includes facilities for reading and writing delta tables, and allows the
 consumer to implement their own `Engine` trait in order to build engine-specific implementations of
 the various `Engine` APIs that the kernel relies on (e.g. implement an engine-specific
-`read_json_files()` using the native engine JSON reader). If there is no need to implement the
-consumer's own `Engine` trait, the kernel has a feature flag to enable a default, asynchronous
-`Engine` implementation built with [Arrow] and [Tokio].
+`read_json_files()` using the native engine JSON reader). If you do not need a custom `Engine`,
+add the `delta_kernel_default_engine` crate to get the default asynchronous `Engine` implementation
+built with [Arrow] and [Tokio].
 
 ```toml
 # fewer dependencies, requires consumer to implement Engine trait.
 # allows consumers to implement their own in-memory format
 delta_kernel = "0.24.0"
 
-# or turn on the default engine, based on latest arrow
-delta_kernel = { version = "0.24.0", features = ["default-engine-rustls", "arrow"] }
+# or pull in the default Arrow/Tokio engine alongside the kernel
+delta_kernel = "0.24.0"
+delta_kernel_default_engine = { version = "0.24.0", features = ["rustls"] }
 ```
 
 ### Feature flags
-There are more feature flags in addition to the `default-engine-rustls` flag shown above. Relevant
-flags include:
+`delta_kernel_default_engine` exposes the following feature flags:
 
 | Feature flag  | Description   |
 | ------------- | ------------- |
-| `default-engine-rustls`    | Turn on the 'default' engine with rustls TLS backend  |
-| `default-engine-native-tls`| Turn on the 'default' engine with native-tls TLS backend  |
+| `rustls`      | Use the rustls TLS backend for HTTPS object stores  |
+| `native-tls`  | Use the native-tls TLS backend for HTTPS object stores  |
+| `arrow-57`    | Build against arrow 57 (see Arrow versioning below) |
+| `arrow-58`    | Build against arrow 58 (see Arrow versioning below) |
+
+The `delta_kernel` crate itself exposes a few additional flags:
+
+| Feature flag  | Description   |
+| ------------- | ------------- |
 | `arrow-conversion`  | Conversion utilities for arrow/kernel schema interoperation |
 | `arrow-expression`  | Expression system implementation for arrow |
 
@@ -75,7 +84,7 @@ are still unstable. We therefore may break APIs within minor releases (that is, 
 we will not break APIs in patch releases (`0.1.0` -> `0.1.1`).
 
 ## Arrow versioning
-If you enable a default engine feature (`default-engine-rustls` or `default-engine-native-tls`),
+If you depend on `delta_kernel_default_engine` (with either the `rustls` or `native-tls` feature),
 you get an implementation of the `Engine` trait that uses [Arrow] as its data format.
 
 The [`arrow crate`](https://docs.rs/arrow/latest/arrow/) tends to release new major versions rather

--- a/default-engine/Cargo.toml
+++ b/default-engine/Cargo.toml
@@ -11,7 +11,9 @@ rust-version.workspace = true
 
 # for cargo-release
 [package.metadata.release]
-release = false
+pre-release-replacements = [
+  { file = "../README.md", search = "delta_kernel_default_engine = \\{ version = \"[a-z0-9\\.-]+\"", replace = "delta_kernel_default_engine = { version = \"{{version}}\"" },
+]
 
 [dependencies]
 delta_kernel = { path = "../kernel", version = "0.24.0", features = [

--- a/release.sh
+++ b/release.sh
@@ -7,8 +7,8 @@
 ###################################################################################################
 
 # This is a script to automate a large portion of the release process for the crates we publish to
-# crates.io. Currently only `delta_kernel` (in the kernel/ dir) and `delta_kernel_derive` (in the
-# derive-macros/ dir) are released.
+# crates.io. Currently `delta_kernel` (in the kernel/ dir), `delta_kernel_derive` (in the
+# derive-macros/ dir), and `delta_kernel_default_engine` (in the default-engine/ dir) are released.
 
 # Exit on error, undefined variables, and pipe failures
 set -euo pipefail
@@ -122,8 +122,10 @@ handle_release_branch() {
 # Handle main branch workflow (publish and tag)
 handle_main_branch() {
     # could potentially just use full 'cargo release' command here
+    # publish order matters: each crate depends on the previous at the same workspace version
     publish "delta_kernel_derive"
     publish "delta_kernel"
+    publish "delta_kernel_default_engine"
 
     # hack: just redo getting the version
     local version


### PR DESCRIPTION
## What changes are proposed in this pull request?

Make `delta_kernel_default_engine` publishable on crates.io.

Changes:
- Drop `release = false` from `default-engine/Cargo.toml` so `cargo release` picks it up.
- Add a `pre-release-replacements` entry that keeps the README's `delta_kernel_default_engine = { version = "x.y.z" }` snippet in sync on independent default-engine releases.
- `release.sh`: add `delta_kernel_default_engine` to the publish list 

Publish order after merge: `delta_kernel_derive`, then `delta_kernel`, then `delta_kernel_default_engine`.


## How was this change tested?

`cargo build --workspace --all-features` passes locally. `cargo package -p delta_kernel_default_engine --no-verify` produces a clean artifact. `bash -n release.sh` passes.