### PR TITLE
refactor!: introduce FileStatsState typed enum

### DIFF
--- a/kernel/src/crc/delta.rs
+++ b/kernel/src/crc/delta.rs
@@ -8,15 +8,15 @@
 //! - **Metadata fields** (protocol, metadata, domain metadata, set transactions, in-commit
 //!   timestamp): always kept up-to-date -- every `apply` unconditionally merges these from the
 //!   delta.
-//! - **File stats** (`num_files`, `table_size_bytes`): only updated when the current
-//!   [`FileStatsValidity`] is not terminal and the commit's operation is incremental-safe. Once
-//!   validity degrades (e.g. a non-incremental operation like ANALYZE STATS, or a missing file
-//!   size), file stats stop updating for the lifetime of that CRC.
+//! - **File stats** ([`FileStatsState`]): only updated when the state is `Complete` and the
+//!   commit's operation is incremental-safe. Once the state degrades (e.g. a non-incremental
+//!   operation like ANALYZE STATS, or a missing file size), file stats stop updating for the
+//!   lifetime of that CRC.
 
 use tracing::warn;
 
 use super::file_stats::FileStatsDelta;
-use super::{Crc, FileStatsValidity};
+use super::{Crc, FileSizeHistogram, FileStats, FileStatsState};
 use crate::actions::{DomainMetadata, Metadata, Protocol, SetTransaction};
 
 /// The CRC-relevant changes ("delta") from a single commit. Produced either by reading a
@@ -38,7 +38,7 @@ pub(crate) struct CrcDelta {
     /// In-commit timestamp, if present in this commit.
     pub(crate) in_commit_timestamp: Option<i64>,
     /// Must be `Some` with an incremental-safe value for file stats to update. `None` or
-    /// unrecognized values transition validity to `Indeterminate`.
+    /// unrecognized values transition the [`FileStatsState`] to `Indeterminate`.
     pub(crate) operation: Option<String>,
     /// A file action in this commit had a missing `size` field, making byte-level file stats
     /// impossible to compute.
@@ -83,14 +83,16 @@ impl CrcDelta {
                 .ok()
         });
         Some(Crc {
-            table_size_bytes: self.file_stats.net_bytes,
-            num_files: self.file_stats.net_files,
+            file_stats_state: FileStatsState::Complete(FileStats {
+                num_files: self.file_stats.net_files,
+                table_size_bytes: self.file_stats.net_bytes,
+                file_size_histogram: initial_histogram,
+            }),
             protocol,
             metadata,
             domain_metadata,
             set_transactions,
             in_commit_timestamp_opt: self.in_commit_timestamp,
-            file_size_histogram: initial_histogram,
             ..Default::default()
         })
     }
@@ -98,13 +100,9 @@ impl CrcDelta {
 
 /// Commit delta application for [`Crc`]. See the [module-level docs](self) for details.
 impl Crc {
-    /// Apply a commit delta, updating all CRC fields and adjusting file stats validity.
-    ///
-    /// Metadata fields are always updated. File stats are only updated when:
-    /// - Validity is not already terminal ([`Untrackable`](FileStatsValidity::Untrackable) or
-    ///   [`Indeterminate`](FileStatsValidity::Indeterminate))
-    /// - The delta has no missing file sizes
-    /// - The operation is incremental-safe
+    /// Apply a commit delta. Protocol, metadata, and ICT update unconditionally; domain
+    /// metadata and set transactions update only when already tracked (`Some`); file stats
+    /// follow the [`FileStatsState`] state machine.
     pub(crate) fn apply(&mut self, delta: CrcDelta) {
         // Protocol and metadata: replace if present.
         if let Some(p) = delta.protocol {
@@ -146,56 +144,64 @@ impl Crc {
         // clears the previous value.
         self.in_commit_timestamp_opt = delta.in_commit_timestamp;
 
-        // Bail if already Untrackable -- nothing can recover missing file stats or histograms.
-        if self.file_stats_validity == FileStatsValidity::Untrackable {
-            return;
-        }
-
-        // Missing file size poisons stats permanently. Checked after the Untrackable bail-out
-        // so that Untrackable can never transition to Indeterminate below.
-        if delta.has_missing_file_size {
-            self.file_stats_validity = FileStatsValidity::Untrackable;
-            self.file_size_histogram = None;
-            return;
-        }
-
-        // Bail if already Indeterminate (theoretically recoverable via full replay).
-        if self.file_stats_validity == FileStatsValidity::Indeterminate {
-            return;
-        }
-
         let is_incremental_safe = delta
             .operation
             .as_deref()
             .is_some_and(FileStatsDelta::is_incremental_safe);
-        if !is_incremental_safe {
-            self.file_stats_validity = FileStatsValidity::Indeterminate;
-            self.file_size_histogram = None;
-            return;
-        }
-        self.num_files += delta.file_stats.net_files;
-        self.table_size_bytes += delta.file_stats.net_bytes;
+        self.file_stats_state = transition_file_stats(
+            &self.file_stats_state,
+            &delta.file_stats,
+            is_incremental_safe,
+            delta.has_missing_file_size,
+        );
+    }
+}
 
-        // Histogram: merge base and delta.
-        // Only update if the base CRC has a histogram AND the delta provides one.
-        // If the merge fails (e.g. negative counts from corrupted data) or the delta is
-        // missing a histogram, drop it rather than leaving stale data.
-        if let (Some(base_hist), Some(delta_hist)) = (
-            self.file_size_histogram.as_ref(),
-            &delta.file_stats.net_histogram,
-        ) {
-            match base_hist.try_apply_delta(delta_hist) {
-                Ok(merged) => self.file_size_histogram = Some(merged),
-                Err(e) => {
-                    warn!("Histogram merge failed, dropping file size histogram: {e}");
-                    self.file_size_histogram = None;
-                }
+/// Compute the next [`FileStatsState`] given the current state and an incoming delta.
+///
+/// See [`FileStatsState`] for the full transition table.
+fn transition_file_stats(
+    current: &FileStatsState,
+    delta: &FileStatsDelta,
+    is_incremental_safe: bool,
+    has_missing_file_size: bool,
+) -> FileStatsState {
+    match current {
+        // Indeterminate is terminal in incremental replay. A future full add/remove dedup
+        // pass could recover Complete.
+        FileStatsState::Indeterminate => FileStatsState::Indeterminate,
+        // Either a non-incremental op (e.g. ANALYZE STATS) or a missing remove.size makes
+        // incremental tracking impossible: a full add/remove reconciliation can recover.
+        _ if !is_incremental_safe || has_missing_file_size => FileStatsState::Indeterminate,
+        FileStatsState::Complete(stats) => FileStatsState::Complete(FileStats {
+            // Counts and bytes have no non-negative check.
+            num_files: stats.num_files + delta.net_files,
+            table_size_bytes: stats.table_size_bytes + delta.net_bytes,
+            // Histogram: per-bin merge; drop on failure. See `merge_histogram`.
+            file_size_histogram: merge_histogram(
+                stats.file_size_histogram.as_ref(),
+                delta.net_histogram.as_ref(),
+            ),
+        }),
+    }
+}
+
+/// Merge a base histogram with a delta histogram. Returns `Some(merged)` only when both are
+/// present and [`FileSizeHistogram::try_apply_delta`] succeeds; otherwise returns `None`.
+/// `try_apply_delta` fails on boundary mismatch or negative per-bin sums.
+fn merge_histogram(
+    base: Option<&FileSizeHistogram>,
+    delta: Option<&FileSizeHistogram>,
+) -> Option<FileSizeHistogram> {
+    match (base, delta) {
+        (Some(base_hist), Some(delta_hist)) => match base_hist.try_apply_delta(delta_hist) {
+            Ok(merged) => Some(merged),
+            Err(e) => {
+                warn!("Histogram merge failed, dropping file size histogram: {e}");
+                None
             }
-        } else if self.file_size_histogram.is_some() {
-            // The base had a histogram but the delta couldn't provide one. Drop it rather than
-            // leaving a stale value.
-            self.file_size_histogram = None;
-        }
+        },
+        _ => None,
     }
 }
 
@@ -211,8 +217,11 @@ mod tests {
 
     fn base_crc() -> Crc {
         Crc {
-            table_size_bytes: 1000,
-            num_files: 10,
+            file_stats_state: FileStatsState::Complete(FileStats {
+                num_files: 10,
+                table_size_bytes: 1000,
+                file_size_histogram: None,
+            }),
             ..Default::default()
         }
     }
@@ -258,14 +267,15 @@ mod tests {
         assert!(!FileStatsDelta::is_incremental_safe("UNKNOWN"));
     }
 
-    // ===== Crc deserialized from CRC file (default validity) =====
+    // ===== Crc deserialized from CRC file (default state) =====
 
     #[test]
-    fn test_deserialized_crc_has_valid_stats() {
+    fn test_deserialized_crc_has_complete_stats() {
         let crc = base_crc();
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Valid);
-        assert_eq!(crc.num_files, 10);
-        assert_eq!(crc.table_size_bytes, 1000);
+        let stats = crc.file_stats().unwrap();
+        assert!(crc.file_stats_state.is_complete());
+        assert_eq!(stats.num_files(), 10);
+        assert_eq!(stats.table_size_bytes(), 1000);
     }
 
     // ===== Crc::apply tests =====
@@ -274,9 +284,10 @@ mod tests {
     fn test_apply_updates_file_stats() {
         let mut crc = base_crc();
         crc.apply(write_delta(3, 600));
-        assert_eq!(crc.num_files, 13); // 10 + 3
-        assert_eq!(crc.table_size_bytes, 1600); // 1000 + 600
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Valid);
+        let stats = crc.file_stats().unwrap();
+        assert_eq!(stats.num_files(), 13); // 10 + 3
+        assert_eq!(stats.table_size_bytes(), 1600); // 1000 + 600
+        assert!(crc.file_stats_state.is_complete());
     }
 
     /// Applies multiple commit deltas sequentially.
@@ -285,9 +296,10 @@ mod tests {
         let mut crc = base_crc();
         crc.apply(write_delta(3, 600));
         crc.apply(write_delta(-2, -400));
-        assert_eq!(crc.num_files, 11); // 10 + 3 - 2
-        assert_eq!(crc.table_size_bytes, 1200); // 1000 + 600 - 400
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Valid);
+        let stats = crc.file_stats().unwrap();
+        assert_eq!(stats.num_files(), 11); // 10 + 3 - 2
+        assert_eq!(stats.table_size_bytes(), 1200); // 1000 + 600 - 400
+        assert!(crc.file_stats_state.is_complete());
     }
 
     #[test]
@@ -298,7 +310,7 @@ mod tests {
             ..write_delta(1, 100)
         };
         crc.apply(unsafe_change);
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Indeterminate);
+        assert!(crc.file_stats_state.is_indeterminate());
     }
 
     #[test]
@@ -309,7 +321,7 @@ mod tests {
             ..write_delta(1, 100)
         };
         crc.apply(unknown_delta);
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Indeterminate);
+        assert!(crc.file_stats_state.is_indeterminate());
     }
 
     #[test]
@@ -320,65 +332,24 @@ mod tests {
             ..write_delta(1, 100)
         };
         crc.apply(unsafe_change);
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Indeterminate);
+        assert!(crc.file_stats_state.is_indeterminate());
 
-        // Subsequent safe op doesn't recover validity.
+        // Subsequent safe op doesn't recover the state.
         crc.apply(write_delta(5, 500));
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Indeterminate);
+        assert!(crc.file_stats_state.is_indeterminate());
     }
 
-    // ===== apply: Untrackable (missing file size) tests =====
+    // ===== apply: missing-file-size tests =====
 
     #[test]
-    fn test_missing_file_size_transitions_to_untrackable() {
+    fn test_missing_file_size_transitions_to_indeterminate() {
         let mut crc = base_crc();
         let delta = CrcDelta {
             has_missing_file_size: true,
             ..write_delta(1, 100)
         };
         crc.apply(delta);
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Untrackable);
-    }
-
-    #[test]
-    fn test_untrackable_stays_untrackable() {
-        let mut crc = base_crc();
-        let delta = CrcDelta {
-            has_missing_file_size: true,
-            ..write_delta(1, 100)
-        };
-        crc.apply(delta);
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Untrackable);
-
-        // Applying a safe delta does not recover from Untrackable.
-        crc.apply(write_delta(5, 500));
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Untrackable);
-
-        // Applying an unsafe delta also stays Untrackable (does not downgrade to Indeterminate).
-        crc.apply(CrcDelta {
-            operation: None,
-            ..write_delta(1, 100)
-        });
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Untrackable);
-    }
-
-    #[test]
-    fn test_indeterminate_transitions_to_untrackable_on_missing_size() {
-        let mut crc = base_crc();
-        let unsafe_change = CrcDelta {
-            operation: Some("ANALYZE STATS".to_string()),
-            ..write_delta(1, 100)
-        };
-        crc.apply(unsafe_change);
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Indeterminate);
-
-        // Missing size escalates Indeterminate to Untrackable.
-        let delta = CrcDelta {
-            has_missing_file_size: true,
-            ..write_delta(1, 100)
-        };
-        crc.apply(delta);
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Untrackable);
+        assert!(crc.file_stats_state.is_indeterminate());
     }
 
     // ===== apply: non-file-stats field updates =====
@@ -519,11 +490,12 @@ mod tests {
             ..write_delta(5, 1000)
         };
         let crc = delta.into_crc_for_version_zero().unwrap();
+        let stats = crc.file_stats().unwrap();
         assert_eq!(crc.protocol, protocol);
         assert_eq!(crc.metadata, metadata);
-        assert_eq!(crc.num_files, 5);
-        assert_eq!(crc.table_size_bytes, 1000);
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Valid);
+        assert_eq!(stats.num_files(), 5);
+        assert_eq!(stats.table_size_bytes(), 1000);
+        assert!(crc.file_stats_state.is_complete());
         assert_eq!(crc.domain_metadata, Some(HashMap::new()));
         assert_eq!(crc.in_commit_timestamp_opt, None);
     }
@@ -673,9 +645,11 @@ mod tests {
     fn base_crc_with_histogram(file_sizes: &[i64]) -> Crc {
         let hist = histogram_from_sizes(file_sizes);
         Crc {
-            table_size_bytes: file_sizes.iter().sum(),
-            num_files: file_sizes.len() as i64,
-            file_size_histogram: Some(hist),
+            file_stats_state: FileStatsState::Complete(FileStats {
+                num_files: file_sizes.len() as i64,
+                table_size_bytes: file_sizes.iter().sum(),
+                file_size_histogram: Some(hist),
+            }),
             ..Default::default()
         }
     }
@@ -734,7 +708,8 @@ mod tests {
         let delta = write_delta_with_histograms(add, remove);
         crc.apply(delta);
 
-        let hist = crc.file_size_histogram.as_ref().unwrap();
+        let stats = crc.file_stats().unwrap();
+        let hist = stats.file_size_histogram().unwrap();
         for &(bin, count, bytes) in expected_bins {
             assert_eq!(hist.file_counts[bin], count, "file_counts[{bin}]");
             assert_eq!(hist.total_bytes[bin], bytes, "total_bytes[{bin}]");
@@ -759,8 +734,9 @@ mod tests {
             ..Default::default()
         };
         crc.apply(delta);
+        let stats = crc.file_stats().unwrap();
         assert!(
-            crc.file_size_histogram.is_none(),
+            stats.file_size_histogram().is_none(),
             "histogram should be None when delta doesn't provide a histogram"
         );
     }
@@ -773,21 +749,21 @@ mod tests {
             ..write_delta(1, 100)
         };
         crc.apply(unsafe_delta);
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Indeterminate);
-        assert!(crc.file_size_histogram.is_none());
+        // Indeterminate has no histogram field; the histogram data is gone.
+        assert!(crc.file_stats_state.is_indeterminate());
+        assert!(crc.file_stats().is_none());
     }
 
     #[test]
-    fn apply_drops_histogram_on_untrackable() {
+    fn apply_drops_histogram_on_missing_file_size() {
         let mut crc = base_crc_with_histogram(&[100, 200]);
-        // A missing file size makes byte-level stats impossible, so the histogram is dropped.
         let delta = CrcDelta {
             has_missing_file_size: true,
             ..write_delta(1, 100)
         };
         crc.apply(delta);
-        assert_eq!(crc.file_stats_validity, FileStatsValidity::Untrackable);
-        assert!(crc.file_size_histogram.is_none());
+        assert!(crc.file_stats_state.is_indeterminate());
+        assert!(crc.file_stats().is_none());
     }
 
     #[test]
@@ -805,7 +781,8 @@ mod tests {
             ..Default::default()
         };
         let crc = delta.into_crc_for_version_zero().unwrap();
-        let hist = crc.file_size_histogram.as_ref().unwrap();
+        let stats = crc.file_stats().unwrap();
+        let hist = stats.file_size_histogram().unwrap();
         assert_eq!(hist.file_counts[0], 2);
         assert_eq!(hist.total_bytes[0], 1500);
     }
@@ -820,7 +797,8 @@ mod tests {
             ..write_delta(0, 0)
         };
         let crc = delta.into_crc_for_version_zero().unwrap();
-        assert!(crc.file_size_histogram.is_none());
+        let stats = crc.file_stats().unwrap();
+        assert!(stats.file_size_histogram().is_none());
     }
 
     #[test]
@@ -834,9 +812,11 @@ mod tests {
         )
         .unwrap();
         let mut crc = Crc {
-            table_size_bytes: 800,
-            num_files: 3,
-            file_size_histogram: Some(base_hist),
+            file_stats_state: FileStatsState::Complete(FileStats {
+                num_files: 3,
+                table_size_bytes: 800,
+                file_size_histogram: Some(base_hist),
+            }),
             ..Default::default()
         };
 
@@ -859,11 +839,12 @@ mod tests {
         crc.apply(delta);
 
         // Histogram should be preserved (boundaries match)
-        let hist = crc.file_size_histogram.as_ref().unwrap();
+        let stats = crc.file_stats().unwrap();
+        let hist = stats.file_size_histogram().unwrap();
         assert_eq!(hist.sorted_bin_boundaries, vec![0, 200, 1000]);
         assert_eq!(hist.file_counts, vec![2, 1, 1]); // (2+1-1), (1+0-0), (0+1-0)
         assert_eq!(hist.total_bytes, vec![250, 500, 1500]); // (300+100-150), (500+0-0), (0+1500-0)
-        assert_eq!(crc.num_files, 4);
-        assert_eq!(crc.table_size_bytes, 2250);
+        assert_eq!(stats.num_files(), 4);
+        assert_eq!(stats.table_size_bytes(), 2250);
     }
 }

--- a/kernel/src/crc/delta.rs
+++ b/kernel/src/crc/delta.rs
@@ -755,7 +755,9 @@ mod tests {
     }
 
     #[test]
-    fn apply_drops_histogram_on_missing_file_size() {
+    fn apply_remove_without_size_transitions_to_indeterminate() {
+        // A remove action with missing size makes incremental tracking impossible;
+        // file_stats returns None because Indeterminate carries no data.
         let mut crc = base_crc_with_histogram(&[100, 200]);
         let delta = CrcDelta {
             has_missing_file_size: true,

--- a/kernel/src/crc/file_stats.rs
+++ b/kernel/src/crc/file_stats.rs
@@ -20,12 +20,12 @@ use crate::{DeltaResult, EngineData, Error, RowVisitor};
 /// File-level statistics for a table version: total file count, size, and histogram.
 ///
 /// Obtained via [`Snapshot::get_or_load_file_stats`], [`Snapshot::get_file_stats_if_loaded`],
-/// or [`Crc::file_stats()`](super::Crc::file_stats). Returns `None` when the stats are not
-/// known to be valid.
+/// or [`Crc::file_stats()`](super::Crc::file_stats). Returns `None` when the source CRC's
+/// `file_stats_state` is not `Complete`.
 ///
 /// [`Snapshot::get_or_load_file_stats`]: crate::snapshot::Snapshot::get_or_load_file_stats
 /// [`Snapshot::get_file_stats_if_loaded`]: crate::snapshot::Snapshot::get_file_stats_if_loaded
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct FileStats {
     /// Number of active [`Add`](crate::actions::Add) file actions in this table version.
     pub(crate) num_files: i64,

--- a/kernel/src/crc/lazy.rs
+++ b/kernel/src/crc/lazy.rs
@@ -145,6 +145,7 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
+    use crate::crc::{FileStats, FileStatsState};
     use crate::engine::sync::SyncEngine;
     use crate::object_store::memory::InMemory;
 
@@ -161,13 +162,16 @@ mod tests {
     #[test]
     fn test_crc_load_result_loaded() {
         let crc = Crc {
-            table_size_bytes: 100,
-            num_files: 10,
+            file_stats_state: FileStatsState::Complete(FileStats {
+                num_files: 10,
+                table_size_bytes: 100,
+                file_size_histogram: None,
+            }),
             ..Default::default()
         };
         let loaded = CrcLoadResult::Loaded(Arc::new(crc));
-        assert!(loaded.get().is_some());
-        assert_eq!(loaded.get().unwrap().table_size_bytes, 100);
+        let stats = loaded.get().unwrap().file_stats().unwrap();
+        assert_eq!(stats.table_size_bytes(), 100);
     }
 
     #[rstest]
@@ -225,7 +229,7 @@ mod tests {
         assert!(lazy.is_loaded());
 
         let crc = result.get().unwrap();
-        assert_eq!(crc.table_size_bytes, 5259);
+        assert_eq!(crc.file_stats().unwrap().table_size_bytes(), 5259);
     }
 
     #[test]
@@ -247,8 +251,11 @@ mod tests {
 
     fn test_crc(table_size_bytes: i64) -> Crc {
         Crc {
-            table_size_bytes,
-            num_files: 1,
+            file_stats_state: FileStatsState::Complete(FileStats {
+                num_files: 1,
+                table_size_bytes,
+                file_size_histogram: None,
+            }),
             ..Default::default()
         }
     }
@@ -263,8 +270,7 @@ mod tests {
 
         // get_if_loaded_at_version should return the CRC at the correct version
         let loaded = lazy.get_if_loaded_at_version(5);
-        assert!(loaded.is_some());
-        assert_eq!(loaded.unwrap().table_size_bytes, 42);
+        assert_eq!(loaded.unwrap().file_stats().unwrap().table_size_bytes(), 42);
 
         // Wrong version should return None
         assert!(lazy.get_if_loaded_at_version(4).is_none());

--- a/kernel/src/crc/mod.rs
+++ b/kernel/src/crc/mod.rs
@@ -3,10 +3,10 @@
 //! A [CRC file] contains a snapshot of table state at a specific version, which can be used to
 //! optimize log replay operations like reading Protocol/Metadata, domain metadata, and ICT.
 //!
-//! [`Crc`] holds the in-memory state using shapes that make kernel queries easy: typed
-//! validity enums and `HashMap`s keyed by id, instead of the flat scalars and arrays of the
-//! on-disk format. It (de)serializes to/from JSON via the private `CrcRaw` serde
-//! intermediate, which mirrors the wire format exactly.
+//! [`Crc`] holds the in-memory state using shapes that make kernel queries easy: a typed
+//! state enum (`FileStatsState`) and `HashMap`s keyed by id, instead of the flat scalars and
+//! arrays of the on-disk format. It (de)serializes to/from JSON via the private `CrcRaw`
+//! serde intermediate, which mirrors the wire format exactly.
 //!
 //! [CRC file]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#version-checksum-file
 
@@ -19,6 +19,7 @@ mod file_size_histogram;
 mod file_stats;
 mod lazy;
 mod reader;
+mod state;
 mod writer;
 
 use std::collections::HashMap;
@@ -33,42 +34,12 @@ pub(crate) use lazy::{CrcLoadResult, LazyCrc};
 pub(crate) use reader::try_read_crc_file;
 use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
+pub use state::FileStatsState;
 #[allow(unused)]
 pub(crate) use writer::try_write_crc_file;
 
 use crate::actions::{Add, DomainMetadata, Metadata, Protocol, SetTransaction};
 use crate::Error;
-
-/// Tracks whether file stats (`num_files`, `table_size_bytes`) are trustworthy.
-///
-/// Defaults to [`Valid`](Self::Valid), which is the correct state when deserializing a CRC file
-/// from disk (a CRC file's stats are correct by definition).
-// TODO: replace `FileStatsValidity` with a typed `FileStatsState` enum that carries the
-//       data per variant so reads from a degraded state are a compile error.
-#[allow(dead_code)] // Variants used in follow-up PRs (forward replay, transaction delta).
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub enum FileStatsValidity {
-    /// File stats are known-correct absolute totals. This is the case when seeded from a CRC
-    /// file (which contains `num_files` and `table_size_bytes`) or when replay starts from
-    /// version zero (where the initial state is trivially zero). Safe to write to disk.
-    #[default]
-    Valid,
-    /// File stats are relative deltas, not absolute totals. This happens when seeding from a
-    /// checkpoint: we extract metadata fields but not file counts (reading all add actions from
-    /// a checkpoint just for counts is too expensive). The accumulated deltas are correct, but
-    /// without a baseline they cannot produce final totals. Not safe to write to disk.
-    RequiresCheckpointRead,
-    /// A non-incremental operation was seen: file stats cannot be determined incrementally.
-    /// For example, ANALYZE STATS re-adds existing files with updated statistics but no
-    /// corresponding removes, so naively counting adds would double-count.
-    /// A full log replay from scratch could recover correct file stats. Not safe to write to disk.
-    Indeterminate,
-    /// A file action had a missing size field: correct file stats are impossible to compute.
-    /// For example, the Delta protocol allows `remove.size` to be null -- when encountered,
-    /// we can no longer track byte totals. Unlike [`Indeterminate`](Self::Indeterminate), no
-    /// amount of replay can recover the missing data. Not safe to write to disk.
-    Untrackable,
-}
 
 // ============================================================================
 // Crc: in-memory representation
@@ -88,25 +59,16 @@ pub enum FileStatsValidity {
 /// This struct and its fields are marked `pub`, but the `crc` module is only re-exported as `pub`
 /// when the `test-utils` feature is enabled (otherwise `pub(crate)`). See `kernel/src/lib.rs`.
 // TODO: rename `Crc` to `CrcState` to align with `FileStatsState`, `SetTransactionState`, etc.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(try_from = "CrcRaw", into = "CrcRaw")]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(try_from = "CrcRaw")]
 pub struct Crc {
     // ===== Required fields =====
-    /// Total size of the table in bytes, calculated as the sum of the `size` field of all live
-    /// [`Add`] actions. Private -- use [`Crc::file_stats()`] to access safely.
-    table_size_bytes: i64,
-    /// Number of live [`Add`] actions in this table version after action reconciliation.
-    /// Private -- use [`Crc::file_stats()`] to access safely.
-    num_files: i64,
     /// The table [`Metadata`] at this version.
     pub metadata: Metadata,
     /// The table [`Protocol`] at this version.
     pub protocol: Protocol,
-    /// Whether the file stats (`num_files`, `table_size_bytes`) in this CRC are trustworthy.
-    /// Not serialized -- this is an in-memory replay concern only. When deserialized from a CRC
-    /// file on disk, defaults to [`FileStatsValidity::Valid`] (a CRC file's stats are correct
-    /// by definition). A CRC is only safe to write to disk when validity is `Valid`.
-    pub file_stats_validity: FileStatsValidity,
+    /// File-level statistics as a typed state. See [`FileStatsState`].
+    pub(crate) file_stats_state: FileStatsState,
 
     // ===== Optional fields =====
     /// The in-commit timestamp of this version. Present iff In-Commit Timestamps are enabled.
@@ -130,8 +92,6 @@ pub struct Crc {
     /// Stored as a HashMap keyed by domain name for efficient lookup. The CRC JSON format uses
     /// a Vec, which is converted via the `CrcRaw` serde intermediate.
     pub domain_metadata: Option<HashMap<String, DomainMetadata>>,
-    /// Size distribution information of files remaining after action reconciliation.
-    pub file_size_histogram: Option<FileSizeHistogram>,
 
     // ===== Not yet supported fields =====
     /// A unique identifier for the transaction that produced this commit.
@@ -147,20 +107,30 @@ pub struct Crc {
 }
 
 impl Crc {
-    /// Returns file-level statistics only if they are known to be valid.
+    /// Returns absolute file-level statistics only if `file_stats_state` is `Complete`.
     ///
     /// Returns `None` when file stats cannot be trusted -- for example, when the CRC was
     /// built from incremental replay that encountered a non-incremental operation or a
     /// missing file size.
-    pub fn file_stats(&self) -> Option<FileStats> {
-        match self.file_stats_validity {
-            FileStatsValidity::Valid => Some(FileStats {
-                num_files: self.num_files,
-                table_size_bytes: self.table_size_bytes,
-                file_size_histogram: self.file_size_histogram.clone(),
-            }),
-            _ => None,
-        }
+    pub fn file_stats(&self) -> Option<&FileStats> {
+        self.file_stats_state.file_stats()
+    }
+
+    /// Returns the typed file-stats state. Useful for callers that want to inspect the
+    /// variant directly (via `matches!` or the `is_*` predicates).
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn file_stats_state(&self) -> &FileStatsState {
+        &self.file_stats_state
+    }
+}
+
+/// Refuses to serialize a degraded (non-`Complete`) CRC, so an invalid state can never
+/// round-trip through disk.
+impl Serialize for Crc {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        CrcRaw::try_from(self)
+            .map_err(serde::ser::Error::custom)?
+            .serialize(serializer)
     }
 }
 
@@ -215,13 +185,16 @@ impl TryFrom<CrcRaw> for Crc {
                 )));
             }
         }
-        Ok(Crc {
-            table_size_bytes: raw.table_size_bytes,
+        // A CRC file on disk is by definition complete; we never deserialize a degraded state.
+        let file_stats_state = FileStatsState::Complete(FileStats {
             num_files: raw.num_files,
+            table_size_bytes: raw.table_size_bytes,
+            file_size_histogram: raw.file_size_histogram,
+        });
+        Ok(Crc {
             metadata: raw.metadata,
             protocol: raw.protocol,
-            // A CRC file on disk is by definition valid; we never deserialize a degraded state.
-            file_stats_validity: FileStatsValidity::Valid,
+            file_stats_state,
             in_commit_timestamp_opt: raw.in_commit_timestamp_opt,
             set_transactions: raw
                 .set_transactions
@@ -229,7 +202,6 @@ impl TryFrom<CrcRaw> for Crc {
             domain_metadata: raw
                 .domain_metadata
                 .map(|v| v.into_iter().map(|d| (d.domain().to_string(), d)).collect()),
-            file_size_histogram: raw.file_size_histogram,
             // Not yet round-tripped through CrcRaw; see the "not yet supported" fields on Crc.
             txn_id: None,
             all_files: None,
@@ -240,20 +212,34 @@ impl TryFrom<CrcRaw> for Crc {
     }
 }
 
-impl From<Crc> for CrcRaw {
-    fn from(crc: Crc) -> Self {
-        CrcRaw {
-            table_size_bytes: crc.table_size_bytes,
-            num_files: crc.num_files,
+/// Fails for non-`Complete` file stats: a degraded CRC has no well-defined on-disk shape.
+impl TryFrom<&Crc> for CrcRaw {
+    type Error = Error;
+    fn try_from(crc: &Crc) -> Result<Self, Self::Error> {
+        let FileStatsState::Complete(stats) = &crc.file_stats_state else {
+            return Err(Error::ChecksumWriteUnsupported(format!(
+                "Cannot serialize CRC with {:?} file stats",
+                crc.file_stats_state
+            )));
+        };
+        Ok(CrcRaw {
+            table_size_bytes: stats.table_size_bytes,
+            num_files: stats.num_files,
             num_metadata: 1,
             num_protocol: 1,
-            metadata: crc.metadata,
-            protocol: crc.protocol,
+            metadata: crc.metadata.clone(),
+            protocol: crc.protocol.clone(),
             in_commit_timestamp_opt: crc.in_commit_timestamp_opt,
-            set_transactions: crc.set_transactions.map(|m| m.into_values().collect()),
-            domain_metadata: crc.domain_metadata.map(|m| m.into_values().collect()),
-            file_size_histogram: crc.file_size_histogram,
-        }
+            set_transactions: crc
+                .set_transactions
+                .as_ref()
+                .map(|m| m.values().cloned().collect()),
+            domain_metadata: crc
+                .domain_metadata
+                .as_ref()
+                .map(|m| m.values().cloned().collect()),
+            file_size_histogram: stats.file_size_histogram.clone(),
+        })
     }
 }
 
@@ -311,7 +297,7 @@ mod tests {
 
     use rstest::rstest;
 
-    use super::Crc;
+    use super::{Crc, CrcRaw, FileStats, FileStatsState};
     use crate::actions::{DomainMetadata, SetTransaction};
 
     /// Helper to create a minimal `Crc` with only set_transactions and domain_metadata populated.
@@ -502,8 +488,11 @@ mod tests {
         );
 
         let crc = Crc {
-            table_size_bytes: 1024 * 1024,
-            num_files: 10,
+            file_stats_state: FileStatsState::Complete(FileStats {
+                num_files: 10,
+                table_size_bytes: 1024 * 1024,
+                file_size_histogram: None,
+            }),
             set_transactions: Some(txns),
             domain_metadata: Some(domains),
             ..Default::default()
@@ -514,8 +503,9 @@ mod tests {
         let deserialized: Crc = serde_json::from_str(&json_str).unwrap();
 
         // Verify scalar fields survive the round-trip
-        assert_eq!(deserialized.table_size_bytes, 1024 * 1024);
-        assert_eq!(deserialized.num_files, 10);
+        let stats = deserialized.file_stats().unwrap();
+        assert_eq!(stats.table_size_bytes(), 1024 * 1024);
+        assert_eq!(stats.num_files(), 10);
 
         // Verify all set transactions
         let txns = deserialized.set_transactions.as_ref().unwrap();
@@ -584,6 +574,32 @@ mod tests {
         );
     }
 
+    #[test]
+    fn ser_indeterminate_file_stats_returns_error() {
+        let crc = Crc {
+            file_stats_state: FileStatsState::Indeterminate,
+            ..Default::default()
+        };
+        let err = serde_json::to_string(&crc).unwrap_err().to_string();
+        assert!(
+            err.contains("Cannot serialize CRC"),
+            "expected serialize-rejection error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn try_from_ref_indeterminate_returns_checksum_write_unsupported() {
+        let crc = Crc {
+            file_stats_state: FileStatsState::Indeterminate,
+            ..Default::default()
+        };
+        let err = CrcRaw::try_from(&crc).unwrap_err();
+        assert!(
+            matches!(err, crate::Error::ChecksumWriteUnsupported(_)),
+            "expected ChecksumWriteUnsupported, got: {err:?}"
+        );
+    }
+
     // ===== File size histogram validation =====
 
     /// Minimal CRC JSON with a file size histogram field spliced in under the given field name
@@ -620,7 +636,7 @@ mod tests {
             r#"{"sortedBinBoundaries": [0, 100, 200], "fileCounts": [1, 2, 3], "totalBytes": [10, 200, 300]}"#,
         );
         let crc: Crc = serde_json::from_str(&json).unwrap();
-        assert!(crc.file_size_histogram.is_some());
+        assert!(crc.file_stats().unwrap().file_size_histogram().is_some());
     }
 
     #[rstest]
@@ -629,7 +645,7 @@ mod tests {
     fn de_null_file_size_histogram_deserializes_to_none(#[case] field_name: &str) {
         let json = crc_json_with_histogram(field_name, "null");
         let crc: Crc = serde_json::from_str(&json).unwrap();
-        assert!(crc.file_size_histogram.is_none());
+        assert!(crc.file_stats().unwrap().file_size_histogram().is_none());
     }
 
     /// Validation must reject malformed histograms regardless of which field name they arrived

--- a/kernel/src/crc/reader.rs
+++ b/kernel/src/crc/reader.rs
@@ -50,8 +50,9 @@ mod tests {
         let crc = try_read_crc_file(&engine, &crc_path).unwrap();
 
         // Verify basic fields
-        assert_eq!(crc.table_size_bytes, 5259);
-        assert_eq!(crc.num_files, 10);
+        let stats = crc.file_stats().unwrap();
+        assert_eq!(stats.table_size_bytes(), 5259);
+        assert_eq!(stats.num_files(), 10);
         assert_eq!(crc.in_commit_timestamp_opt, Some(1694758257000));
 
         // Verify protocol
@@ -104,7 +105,7 @@ mod tests {
         assert_eq!(crc.metadata, expected_metadata);
 
         // Verify domain metadatas
-        let dms = crc.domain_metadata.unwrap();
+        let dms = crc.domain_metadata.as_ref().unwrap();
         assert_eq!(dms.len(), 3);
 
         assert!(dms["delta.clustering"]
@@ -116,7 +117,7 @@ mod tests {
         assert!(dms["myApp.metadata"].configuration().contains("key"));
 
         // Verify set transactions
-        let txns = crc.set_transactions.unwrap();
+        let txns = crc.set_transactions.as_ref().unwrap();
         assert_eq!(txns.len(), 2);
         assert_eq!(txns["spark-app-1"].version, 42);
         assert_eq!(txns["spark-app-1"].last_updated, Some(1694758250000));
@@ -124,7 +125,7 @@ mod tests {
         assert_eq!(txns["streaming-job-abc"].last_updated, Some(1694758255000));
 
         // Verify file size histogram was deserialized (all 10 files in bin 0, < 8KB)
-        let hist = crc.file_size_histogram.as_ref().unwrap();
+        let hist = stats.file_size_histogram().unwrap();
         assert_eq!(hist.sorted_bin_boundaries.len(), 95);
         assert_eq!(hist.file_counts[0], 10);
         assert_eq!(hist.total_bytes[0], 5259);

--- a/kernel/src/crc/state.rs
+++ b/kernel/src/crc/state.rs
@@ -1,0 +1,125 @@
+//! Typed state enums for CRC tracking.
+//!
+//! Each enum encodes both *what we know* about a slice of CRC state and *the trustworthiness*
+//! of those values. Variants carry data exactly when it makes sense for that state, making
+//! invalid reads unrepresentable: the compiler prevents reading an absolute count from a
+//! degraded state because the field does not exist there.
+//!
+//! Today this module hosts [`FileStatsState`]; follow-up PRs add `DomainMetadataState` and
+//! `SetTransactionState` (Complete / Partial variants).
+
+use super::file_stats::FileStats;
+
+/// The state of file statistics for a CRC.
+///
+/// # State transitions during `Crc::apply`
+///
+/// | Current       | + safe op     | + unsafe op or missing remove.size |
+/// |---------------|---------------|------------------------------------|
+/// | Complete      | Complete      | Indeterminate                      |
+/// | Indeterminate | Indeterminate | Indeterminate                      |
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FileStatsState {
+    /// File stats are known-correct absolute totals. The carried [`FileStats`]'s
+    /// `file_size_histogram` is optional: `Some` when the CRC source had a histogram (or full
+    /// replay produced one), `None` when the source lacked one. Safe to write to disk (with or
+    /// without histogram).
+    Complete(FileStats),
+    /// File stats cannot be determined incrementally. Reasons include a non-incremental
+    /// operation (like `ANALYZE STATS`) that re-adds files without corresponding removes,
+    /// or a remove action with a missing `size` field. A full add/remove reconciliation pass
+    /// can recover `Complete`.
+    Indeterminate,
+}
+
+impl FileStatsState {
+    /// Returns absolute file stats only when `Complete`. Returns `None` for `Indeterminate`.
+    pub fn file_stats(&self) -> Option<&FileStats> {
+        match self {
+            Self::Complete(stats) => Some(stats),
+            _ => None,
+        }
+    }
+
+    /// Returns `true` if file stats are known-correct absolute totals. Also gates whether
+    /// the CRC is safe to write to disk: only `Complete` CRCs have well-defined on-disk
+    /// representations.
+    pub fn is_complete(&self) -> bool {
+        matches!(self, Self::Complete(_))
+    }
+
+    /// Returns `true` if file stats cannot be determined incrementally and require a full
+    /// add/remove reconciliation pass to recover.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn is_indeterminate(&self) -> bool {
+        self == &Self::Indeterminate
+    }
+}
+
+// TODO(#2568): make `Default` test-only. `Crc::default()` produces a Complete-zero CRC
+//              that passes `is_complete()` and could be silently written.
+impl Default for FileStatsState {
+    fn default() -> Self {
+        Self::Complete(FileStats::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crc::FileSizeHistogram;
+
+    #[test]
+    fn complete_with_histogram_returns_file_stats_with_histogram() {
+        let state = FileStatsState::Complete(FileStats {
+            num_files: 10,
+            table_size_bytes: 5000,
+            file_size_histogram: Some(FileSizeHistogram::create_default()),
+        });
+        let stats = state.file_stats().unwrap();
+        assert_eq!(stats.num_files(), 10);
+        assert_eq!(stats.table_size_bytes(), 5000);
+        assert!(stats.file_size_histogram().is_some());
+    }
+
+    #[test]
+    fn complete_without_histogram_returns_file_stats_without_histogram() {
+        let state = FileStatsState::Complete(FileStats {
+            num_files: 10,
+            table_size_bytes: 5000,
+            file_size_histogram: None,
+        });
+        let stats = state.file_stats().unwrap();
+        assert_eq!(stats.num_files(), 10);
+        assert_eq!(stats.table_size_bytes(), 5000);
+        assert!(stats.file_size_histogram().is_none());
+    }
+
+    #[test]
+    fn indeterminate_returns_none_for_file_stats() {
+        assert!(FileStatsState::Indeterminate.file_stats().is_none());
+    }
+
+    #[test]
+    fn is_predicates_match_variants() {
+        let complete = FileStatsState::default();
+        assert!(complete.is_complete());
+        assert!(!complete.is_indeterminate());
+
+        let indet = FileStatsState::Indeterminate;
+        assert!(!indet.is_complete());
+        assert!(indet.is_indeterminate());
+    }
+
+    #[test]
+    fn default_is_complete_zero() {
+        assert_eq!(
+            FileStatsState::default(),
+            FileStatsState::Complete(FileStats {
+                num_files: 0,
+                table_size_bytes: 0,
+                file_size_histogram: None,
+            })
+        );
+    }
+}

--- a/kernel/src/crc/writer.rs
+++ b/kernel/src/crc/writer.rs
@@ -2,23 +2,24 @@
 
 use url::Url;
 
-use super::{Crc, FileStatsValidity};
+use super::Crc;
 use crate::utils::require;
 use crate::{DeltaResult, Engine, Error};
 
 /// Serialize and write a CRC file to storage.
 ///
 /// Serializes the [`Crc`] to JSON via serde and writes the raw bytes using the storage
-/// handler. Returns [`Error::ChecksumWriteUnsupported`] if file stats are not valid (a CRC file
-/// on disk must have correct stats). Per the Delta protocol, writers MUST NOT overwrite existing
-/// CRC files, so this always writes with `overwrite = false`. If the file already exists, returns
+/// handler. Returns [`Error::ChecksumWriteUnsupported`] if `file_stats_state` is not
+/// `Complete` (only `Complete` CRCs have a well-defined on-disk representation). Per the
+/// Delta protocol, writers MUST NOT overwrite existing CRC files, so this always writes
+/// with `overwrite = false`. If the file already exists, returns
 /// `Err(Error::FileAlreadyExists)`.
 pub(crate) fn try_write_crc_file(engine: &dyn Engine, path: &Url, crc: &Crc) -> DeltaResult<()> {
     require!(
-        crc.file_stats_validity == FileStatsValidity::Valid,
+        crc.file_stats_state.is_complete(),
         Error::ChecksumWriteUnsupported(format!(
             "Cannot write CRC file with {:?} file stats",
-            crc.file_stats_validity
+            crc.file_stats_state
         ))
     );
     let data = serde_json::to_vec(crc)?;
@@ -35,7 +36,7 @@ mod tests {
     use super::*;
     use crate::actions::{DomainMetadata, Protocol, SetTransaction};
     use crate::crc::reader::try_read_crc_file;
-    use crate::crc::{FileSizeHistogram, FileStatsValidity};
+    use crate::crc::{FileSizeHistogram, FileStats, FileStatsState};
     use crate::engine::sync::SyncEngine;
     use crate::object_store::memory::InMemory;
     use crate::path::{AsUrl, ParsedLogPath};
@@ -73,14 +74,16 @@ mod tests {
             histogram.insert(size).unwrap(); // 5 files, 1024 bytes total
         }
         Crc {
-            table_size_bytes: 1024,
-            num_files: 5,
+            file_stats_state: FileStatsState::Complete(FileStats {
+                num_files: 5,
+                table_size_bytes: 1024,
+                file_size_histogram: Some(histogram),
+            }),
             protocol,
             txn_id: None,
             in_commit_timestamp_opt: Some(ict),
             set_transactions: Some(set_transactions),
             domain_metadata: Some(domain_metadata),
-            file_size_histogram: Some(histogram),
             ..Default::default()
         }
     }
@@ -199,24 +202,15 @@ mod tests {
     }
 
     #[test]
-    fn test_write_rejects_invalid_file_stats_with_checksum_write_unsupported() {
+    fn test_write_rejects_indeterminate_file_stats_with_checksum_write_unsupported() {
         let store = Arc::new(InMemory::new());
         let engine = SyncEngine::new_with_store(store);
         let table_root = url::Url::parse("memory:///test_table/").unwrap();
         let crc_path = ParsedLogPath::create_parsed_crc(&table_root, 0);
 
-        for invalid_validity in [
-            FileStatsValidity::RequiresCheckpointRead,
-            FileStatsValidity::Indeterminate,
-            FileStatsValidity::Untrackable,
-        ] {
-            let mut crc = test_crc();
-            crc.file_stats_validity = invalid_validity;
-            let result = try_write_crc_file(&engine, crc_path.location.as_url(), &crc);
-            assert!(
-                matches!(result, Err(Error::ChecksumWriteUnsupported(_))),
-                "should reject {invalid_validity:?} with ChecksumWriteUnsupported"
-            );
-        }
+        let mut crc = test_crc();
+        crc.file_stats_state = FileStatsState::Indeterminate;
+        let result = try_write_crc_file(&engine, crc_path.location.as_url(), &crc);
+        assert!(matches!(result, Err(Error::ChecksumWriteUnsupported(_))));
     }
 }

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -1046,20 +1046,20 @@ impl Snapshot {
         self.log_segment().scan_domain_metadatas(domains, engine)
     }
 
-    /// Returns file-level statistics, or `None` if no CRC with valid stats exists at this
-    /// snapshot's version. Attempts to load the CRC from storage if not already cached.
+    /// Returns file-level statistics, or `None` if no CRC at this snapshot's version has
+    /// `Complete` file stats. Attempts to load the CRC from storage if not already cached.
     pub fn get_or_load_file_stats(&self, engine: &dyn Engine) -> Option<FileStats> {
         let crc = self
             .lazy_crc
             .get_or_load_if_at_version(engine, self.version())?;
-        crc.file_stats()
+        crc.file_stats().cloned()
     }
 
     /// Returns file-level statistics if the CRC is already loaded at this snapshot's version.
     /// This method performs no I/O; it returns `None` if the CRC has not already been loaded.
     pub fn get_file_stats_if_loaded(&self) -> Option<FileStats> {
         let crc = self.lazy_crc.get_if_loaded_at_version(self.version())?;
-        crc.file_stats()
+        crc.file_stats().cloned()
     }
 
     /// Returns the CRC if one has been loaded at this snapshot's version (no I/O).
@@ -1096,11 +1096,10 @@ impl Snapshot {
     /// # Errors
     ///
     /// - [`Error::ChecksumWriteUnsupported`] if no in-memory CRC is available at this snapshot's
-    ///   version (e.g. a snapshot loaded from disk that has no CRC file), or if the CRC's file
-    ///   stats are not valid. File stats can be invalid for two reasons: (a) a non-incremental
-    ///   operation like ANALYZE STATS was encountered, which is recoverable with a full state
-    ///   reconstruction in the future; (b) a file action had a missing size (e.g. `remove.size` is
-    ///   null), which is permanently unrecoverable.
+    ///   version (e.g. a snapshot loaded from disk that has no CRC file), or if the CRC's
+    ///   `file_stats_state` is `Indeterminate` (a non-incremental operation like ANALYZE STATS was
+    ///   encountered, or a file action had a missing size). Recoverable with a full state
+    ///   reconstruction in the future.
     /// - I/O errors from the engine's storage handler if the write fails.
     ///
     /// [`CommittedTransaction::post_commit_snapshot`]: crate::transaction::CommittedTransaction::post_commit_snapshot
@@ -1135,7 +1134,7 @@ impl Snapshot {
 
         let crc_path = ParsedLogPath::new_crc(self.table_root(), self.version())?;
 
-        // Note: try_write_crc_file validates file stats validity before writing.
+        // Note: try_write_crc_file validates that file_stats_state is Complete before writing.
         match try_write_crc_file(engine, &crc_path.location, crc) {
             Ok(()) => {
                 info!("Wrote CRC file at {}", crc_path.location);

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use delta_kernel::arrow::array::{ArrayRef, Int32Array, StringArray};
 use delta_kernel::committer::FileSystemCommitter;
-use delta_kernel::crc::{Crc, FileStatsValidity};
+use delta_kernel::crc::Crc;
 use delta_kernel::engine::default::DefaultEngineBuilder;
 use delta_kernel::object_store::local::LocalFileSystem;
 use delta_kernel::schema::{DataType, StructField, StructType};
@@ -388,7 +388,7 @@ async fn test_post_commit_crc_non_incremental_op_makes_file_stats_indeterminate(
     assert_eq!(committed.commit_version(), 2);
     let snapshot_v2 = committed.post_commit_snapshot().unwrap();
     let crc_v2 = snapshot_v2.get_current_crc_if_loaded_for_testing().unwrap();
-    assert_eq!(crc_v2.file_stats_validity, FileStatsValidity::Indeterminate);
+    assert!(crc_v2.file_stats_state().is_indeterminate());
 
     Ok(())
 }
@@ -487,7 +487,7 @@ async fn test_in_memory_crc_chains_across_multiple_commits_then_writes() -> Delt
     // Verify histogram totals match disk ground truth
     let disk_sizes = parquet_file_sizes_on_disk(&table_path);
     assert_eq!(disk_sizes.len(), 5);
-    assert_histogram_totals(&crc_stats, 5, disk_sizes.iter().sum());
+    assert_histogram_totals(crc_stats, 5, disk_sizes.iter().sum());
 
     Ok(())
 }
@@ -1054,7 +1054,7 @@ async fn test_file_histogram_tracks_adds_and_removes_across_bins() -> DeltaResul
         .unwrap_committed();
     let snapshot = committed.post_commit_snapshot().unwrap();
     let crc_v0 = write_and_verify_crc(snapshot, &table_path, engine.as_ref());
-    assert_histogram_totals(&crc_v0.file_stats().unwrap(), 0, 0);
+    assert_histogram_totals(crc_v0.file_stats().unwrap(), 0, 0);
 
     // ===== v1: insert small file (< 8KB -> bin 0) =====
     let ids: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
@@ -1067,7 +1067,7 @@ async fn test_file_histogram_tracks_adds_and_removes_across_bins() -> DeltaResul
     assert_eq!(disk_sizes.len(), 1);
     let crc_v1 = write_and_verify_crc(snapshot, &table_path, engine.as_ref());
     let stats_v1 = crc_v1.file_stats().unwrap();
-    assert_histogram_totals(&stats_v1, 1, disk_sizes.iter().sum());
+    assert_histogram_totals(stats_v1, 1, disk_sizes.iter().sum());
 
     // Verify boundary metadata via public getters
     let hist = stats_v1.file_size_histogram().unwrap();
@@ -1135,7 +1135,7 @@ async fn test_file_histogram_tracks_adds_and_removes_across_bins() -> DeltaResul
     assert!(parquet_file_sizes_on_disk(&table_path).is_empty());
 
     let crc_v3 = write_and_verify_crc(snapshot, &table_path, engine.as_ref());
-    assert_histogram_totals(&crc_v3.file_stats().unwrap(), 0, 0);
+    assert_histogram_totals(crc_v3.file_stats().unwrap(), 0, 0);
 
     Ok(())
 }
@@ -1183,7 +1183,7 @@ async fn test_file_histogram_survives_disk_round_trip_then_delta_merge() -> Delt
     let disk_sizes = parquet_file_sizes_on_disk(&table_path);
     assert_eq!(disk_sizes.len(), 2);
     assert!(disk_sizes.iter().sum::<i64>() > v1_bytes);
-    assert_histogram_totals(&crc_v2.file_stats().unwrap(), 2, disk_sizes.iter().sum());
+    assert_histogram_totals(crc_v2.file_stats().unwrap(), 2, disk_sizes.iter().sum());
 
     Ok(())
 }
@@ -1276,7 +1276,7 @@ async fn test_file_histogram_with_bin_type_and_operation_type(
 
     if !incremental {
         // Non-incremental operations drop the histogram regardless of bin type
-        assert_eq!(crc_v2.file_stats_validity, FileStatsValidity::Indeterminate);
+        assert!(crc_v2.file_stats_state().is_indeterminate());
         assert!(crc_v2.file_stats().is_none());
         return Ok(());
     }
@@ -1302,7 +1302,7 @@ async fn test_file_histogram_with_bin_type_and_operation_type(
     } else {
         // Default 95-bin boundaries: all small test files land in bin 0 ([0, 8KB))
         assert_eq!(counts.len(), 95, "default bins should have 95 bins");
-        assert_histogram_totals(&stats_v2, 2, total_disk_bytes);
+        assert_histogram_totals(stats_v2, 2, total_disk_bytes);
     }
 
     Ok(())


### PR DESCRIPTION
Part of #1781 (CRC tracking issue) -- see there for the subsequent `incremental_crc_*` PRs in this series.

## What changes are proposed in this pull request?

Remove the decoupled table_size_bytes, num_files, histogram, file_stats, FileStatsValidity types and replace with a single FileStatsState type. 

Now it is impossible to access incorrect file stats.

Most of this PR is just comment + variable renaming and updating to this new type system. A bit of logic changes in how we do the validity state transitions.

## How was this change tested?

Primarily just a refactor. Existing UTs.
