### PR TITLE
ci: disable rust-cache cache-bin to fix macOS runner

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -45,9 +45,11 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
           cache: false
-      # See build.yml top-level comment for why save-if is restricted to main.
+      # See build.yml top-level comment for why save-if is restricted to main and why
+      # cache-bin is disabled.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-bin: false
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: Run benchmarks
         # The comment is posted in the post-comment job after this job completes.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,13 @@ env:
 # Note: actions-rust-lang/setup-rust-toolchain has built-in Swatinem/rust-cache that
 # writes on every run with no save-if support. We disable it with cache: false and
 # manage caching explicitly via the Swatinem/rust-cache steps below.
+#
+# cache-bin: false disables caching of ~/.cargo/bin to work around
+# https://github.com/Swatinem/rust-cache/issues/341, where the cached rustup binary
+# breaks cargo on the new macOS runner image. Drop the cache-bin: false lines once
+# that issue is resolved and we've bumped to a fixed version. Skipping this cache is
+# essentially free for us: all cargo tools (cargo-nextest, cargo-msrv, cargo-llvm-cov)
+# are installed via taiki-e/install-action, which fetches prebuilt binaries.
 
 jobs:
   format:
@@ -60,6 +67,7 @@ jobs:
           cache: false
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-bin: false
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@7bc99eee1f1b8902a125006cf790a1f4c8461e63 # v2.69.8
         with:
@@ -80,6 +88,7 @@ jobs:
           cache: false
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-bin: false
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@7bc99eee1f1b8902a125006cf790a1f4c8461e63 # v2.69.8
         with:
@@ -111,6 +120,7 @@ jobs:
           cache: false
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-bin: false
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: build docs
         run: cargo doc --locked --workspace --all-features --no-deps
@@ -153,6 +163,7 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-bin: false
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: build and lint with clippy
         run: cargo clippy --locked --benches --tests --all-features -- -D warnings
@@ -191,6 +202,7 @@ jobs:
           cache: false
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-bin: false
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@98ec31d284eb962f41c14065e9391a955aa810cf # nextest
       - name: test
@@ -243,6 +255,7 @@ jobs:
           cache: false
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-bin: false
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: Set output on fail
         run: echo "CTEST_OUTPUT_ON_FAILURE=1" >> "$GITHUB_ENV"
@@ -320,6 +333,7 @@ jobs:
           cargo miri setup
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-bin: false
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@98ec31d284eb962f41c14065e9391a955aa810cf # nextest
       - name: Test with Miri
@@ -339,6 +353,7 @@ jobs:
           cache: false
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-bin: false
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@2d15d02e710b40b6332201aba6af30d595b5cd96 # cargo-llvm-cov

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -15,9 +15,11 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
           cache: false
-      # See build.yml top-level comment for why save-if is restricted to main.
+      # See build.yml top-level comment for why save-if is restricted to main and why
+      # cache-bin is disabled.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-bin: false
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Run all examples

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -32,9 +32,11 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
           cache: false
-      # See build.yml top-level comment for why save-if is restricted to main.
+      # See build.yml top-level comment for why save-if is restricted to main and why
+      # cache-bin is disabled.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-bin: false
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: Install cargo-semver-checks
         uses: taiki-e/install-action@7bc99eee1f1b8902a125006cf790a1f4c8461e63 # v2.69.8

--- a/.github/workflows/user-guide.yml
+++ b/.github/workflows/user-guide.yml
@@ -15,9 +15,11 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
           cache: false
-      # See build.yml top-level comment for why save-if is restricted to main.
+      # See build.yml top-level comment for why save-if is restricted to main and why
+      # cache-bin is disabled.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-bin: false
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       # mdbook: builds and serves the book.
       # mdbook-mermaid: preprocessor that renders ```mermaid blocks as diagrams.


### PR DESCRIPTION
## What changes are proposed in this pull request?

The new GitHub macOS runner image (`macos-15-arm64/20260511.0048`) is broken by `Swatinem/rust-cache` with `cache-bin: true` (the default since rust-cache#325). The cached `~/.cargo/bin` shadows the runner-image rustup install, leaving `cargo` symlinked to `rustup-init`, which fails with:

```
error: unexpected argument 'clippy' found
Usage: rustup-init[EXE] [OPTIONS]
```

This blocks every macOS job in `build.yml` and has been failing PRs for the last day (e.g. #2519).

Workaround: set `cache-bin: false` on every `Swatinem/rust-cache@v2` invocation. The cost is negligible for us: all cargo tools (`cargo-nextest`, `cargo-msrv`, `cargo-llvm-cov`, etc.) are installed via `taiki-e/install-action`, which fetches prebuilt binaries rather than compiling.

Tracking issue: https://github.com/Swatinem/rust-cache/issues/341

### When to re-enable

Drop the `cache-bin: false` lines once https://github.com/Swatinem/rust-cache/issues/341 is fixed and we've bumped to the fixed version of \`Swatinem/rust-cache\`.

## How was this change tested?

CI on this PR exercises every affected workflow on the new macOS runner image.