### PR TITLE
refactor!: introduce DomainMetadataState typed enum

### DIFF
--- a/kernel/src/crc/delta.rs
+++ b/kernel/src/crc/delta.rs
@@ -16,7 +16,7 @@
 use tracing::warn;
 
 use super::file_stats::FileStatsDelta;
-use super::{Crc, FileSizeHistogram, FileStats, FileStatsState};
+use super::{Crc, DomainMetadataState, FileSizeHistogram, FileStats, FileStatsState};
 use crate::actions::{DomainMetadata, Metadata, Protocol, SetTransaction};
 
 /// The CRC-relevant changes ("delta") from a single commit. Produced either by reading a
@@ -53,10 +53,9 @@ impl CrcDelta {
     pub(crate) fn into_crc_for_version_zero(self) -> Option<Crc> {
         let protocol = self.protocol?;
         let metadata = self.metadata?;
-        // For CREATE TABLE we always know the full domain metadata state: the transaction
-        // either included domain metadata actions or it didn't. So this is always `Some` --
-        // an empty map means "no domain metadata", not "unknown".
-        let domain_metadata = Some(
+        // For CREATE TABLE we know the full domain metadata state: the transaction either
+        // included domain metadata actions or it didn't. Always Complete.
+        let domain_metadata_state = DomainMetadataState::Complete(
             self.domain_metadata_changes
                 .into_iter()
                 .filter(|dm| !dm.is_removed())
@@ -90,7 +89,7 @@ impl CrcDelta {
             }),
             protocol,
             metadata,
-            domain_metadata,
+            domain_metadata_state,
             set_transactions,
             in_commit_timestamp_opt: self.in_commit_timestamp,
             ..Default::default()
@@ -112,19 +111,17 @@ impl Crc {
             self.metadata = m;
         }
 
-        // Domain metadata: insert or remove by domain name. Only update if the base CRC
-        // tracks domain metadata (Some). If None ("not tracked"), leave it as None --
-        // applying partial changes would create an incomplete map.
-        if !delta.domain_metadata_changes.is_empty() {
-            if let Some(map) = &mut self.domain_metadata {
-                for dm in delta.domain_metadata_changes {
-                    if dm.is_removed() {
-                        map.remove(dm.domain());
-                    } else {
-                        let domain = dm.domain().to_string();
-                        map.insert(domain, dm);
-                    }
-                }
+        // Apply the delta onto the CRC's existing map: upsert each non-removed entry
+        // (newest wins), drop each tombstone. The variant (Complete or Partial) stays the
+        // same since a delta never changes whether the base was authoritative.
+        let map = match &mut self.domain_metadata_state {
+            DomainMetadataState::Complete(m) | DomainMetadataState::Partial(m) => m,
+        };
+        for dm in delta.domain_metadata_changes {
+            if dm.is_removed() {
+                map.remove(dm.domain());
+            } else {
+                map.insert(dm.domain().to_string(), dm);
             }
         }
 
@@ -374,9 +371,9 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_adds_domain_metadata_to_tracked_map() {
+    fn test_apply_adds_domain_metadata_to_complete_map() {
         let mut crc = base_crc();
-        crc.domain_metadata = Some(HashMap::new());
+        crc.domain_metadata_state = DomainMetadataState::Complete(HashMap::new());
         let dm = DomainMetadata::new("my.domain".to_string(), "config1".to_string());
         let delta = CrcDelta {
             domain_metadata_changes: vec![dm],
@@ -384,15 +381,18 @@ mod tests {
         };
         crc.apply(delta);
 
-        let map = crc.domain_metadata.as_ref().unwrap();
+        assert!(crc.domain_metadata_state.is_complete());
+        let map = crc.domain_metadata_state.data();
         assert_eq!(map.len(), 1);
         assert_eq!(map["my.domain"].configuration(), "config1");
     }
 
     #[test]
-    fn test_apply_with_untracked_domain_metadata_skips_changes() {
+    fn test_apply_adds_domain_metadata_to_partial_map_stays_partial() {
+        // Default is Partial(empty). Apply observes entries; map fills but variant stays
+        // Partial (we did not gain authoritative knowledge of older history).
         let mut crc = base_crc();
-        assert!(crc.domain_metadata.is_none()); // Not tracked (default)
+        assert_eq!(crc.domain_metadata_state, DomainMetadataState::default());
         let dm = DomainMetadata::new("my.domain".to_string(), "config1".to_string());
         let delta = CrcDelta {
             domain_metadata_changes: vec![dm],
@@ -400,14 +400,16 @@ mod tests {
         };
         crc.apply(delta);
 
-        // domain_metadata stays None -- apply() must not create a partial map.
-        assert!(crc.domain_metadata.is_none());
+        assert!(!crc.domain_metadata_state.is_complete());
+        let map = crc.domain_metadata_state.data();
+        assert_eq!(map.len(), 1);
+        assert_eq!(map["my.domain"].configuration(), "config1");
     }
 
     #[test]
-    fn test_apply_upserts_domain_metadata() {
+    fn test_apply_upserts_domain_metadata_in_complete_map() {
         let mut crc = base_crc();
-        crc.domain_metadata = Some(HashMap::from([(
+        crc.domain_metadata_state = DomainMetadataState::Complete(HashMap::from([(
             "my.domain".to_string(),
             DomainMetadata::new("my.domain".to_string(), "old_config".to_string()),
         )]));
@@ -419,15 +421,37 @@ mod tests {
         };
         crc.apply(delta);
 
-        let map = crc.domain_metadata.as_ref().unwrap();
+        assert!(crc.domain_metadata_state.is_complete());
+        let map = crc.domain_metadata_state.data();
         assert_eq!(map.len(), 1);
         assert_eq!(map["my.domain"].configuration(), "new_config");
     }
 
     #[test]
-    fn test_apply_removes_domain_metadata() {
+    fn test_apply_upserts_domain_metadata_in_partial_map() {
         let mut crc = base_crc();
-        crc.domain_metadata = Some(HashMap::from([(
+        crc.domain_metadata_state = DomainMetadataState::Partial(HashMap::from([(
+            "my.domain".to_string(),
+            DomainMetadata::new("my.domain".to_string(), "old_config".to_string()),
+        )]));
+
+        let dm = DomainMetadata::new("my.domain".to_string(), "new_config".to_string());
+        let delta = CrcDelta {
+            domain_metadata_changes: vec![dm],
+            ..write_delta(0, 0)
+        };
+        crc.apply(delta);
+
+        // Partial stays Partial.
+        assert!(!crc.domain_metadata_state.is_complete());
+        let map = crc.domain_metadata_state.data();
+        assert_eq!(map["my.domain"].configuration(), "new_config");
+    }
+
+    #[test]
+    fn test_apply_removes_domain_metadata_from_complete_map() {
+        let mut crc = base_crc();
+        crc.domain_metadata_state = DomainMetadataState::Complete(HashMap::from([(
             "my.domain".to_string(),
             DomainMetadata::new("my.domain".to_string(), "config1".to_string()),
         )]));
@@ -439,8 +463,8 @@ mod tests {
         };
         crc.apply(delta);
 
-        let map = crc.domain_metadata.as_ref().unwrap();
-        assert!(map.is_empty());
+        assert!(crc.domain_metadata_state.is_complete());
+        assert!(crc.domain_metadata_state.data().is_empty());
     }
 
     #[test]
@@ -496,7 +520,10 @@ mod tests {
         assert_eq!(stats.num_files(), 5);
         assert_eq!(stats.table_size_bytes(), 1000);
         assert!(crc.file_stats_state.is_complete());
-        assert_eq!(crc.domain_metadata, Some(HashMap::new()));
+        assert_eq!(
+            crc.domain_metadata_state,
+            DomainMetadataState::Complete(HashMap::new())
+        );
         assert_eq!(crc.in_commit_timestamp_opt, None);
     }
 
@@ -528,7 +555,8 @@ mod tests {
             ..write_delta(0, 0)
         };
         let crc = delta.into_crc_for_version_zero().unwrap();
-        let map = crc.domain_metadata.as_ref().unwrap();
+        assert!(crc.domain_metadata_state.is_complete());
+        let map = crc.domain_metadata_state.data();
         assert_eq!(map.len(), 1);
         assert_eq!(map["my.domain"].configuration(), "config1");
     }

--- a/kernel/src/crc/delta.rs
+++ b/kernel/src/crc/delta.rs
@@ -402,7 +402,10 @@ mod tests {
     #[test]
     fn test_apply_does_not_upgrade_partial_to_complete() {
         let mut crc = base_crc();
-        assert_eq!(crc.domain_metadata_state, DomainMetadataState::default());
+        assert_eq!(
+            crc.domain_metadata_state,
+            DomainMetadataState::Partial(HashMap::new())
+        );
         let dm = DomainMetadata::new("my.domain".to_string(), "config1".to_string());
         let delta = CrcDelta {
             domain_metadata_changes: vec![dm],

--- a/kernel/src/crc/delta.rs
+++ b/kernel/src/crc/delta.rs
@@ -29,8 +29,9 @@ pub(crate) struct CrcDelta {
     pub(crate) protocol: Option<Protocol>,
     /// New metadata action, if this commit changed it.
     pub(crate) metadata: Option<Metadata>,
-    /// All DM actions in this commit (additions and removals). `apply()` only processes these
-    /// when the base CRC's `domain_metadata` is `Some` (tracked).
+    /// All DM actions in this commit (additions and removals). `apply()` processes these
+    /// unconditionally; the base CRC's `DomainMetadataState` variant (`Complete` or
+    /// `Partial`) is preserved.
     pub(crate) domain_metadata_changes: Vec<DomainMetadata>,
     /// All SetTransaction actions in this commit. `apply()` only processes these when the base
     /// CRC's `set_transactions` is `Some` (tracked).
@@ -99,9 +100,10 @@ impl CrcDelta {
 
 /// Commit delta application for [`Crc`]. See the [module-level docs](self) for details.
 impl Crc {
-    /// Apply a commit delta. Protocol, metadata, and ICT update unconditionally; domain
-    /// metadata and set transactions update only when already tracked (`Some`); file stats
-    /// follow the [`FileStatsState`] state machine.
+    /// Apply a commit delta. Protocol, metadata, ICT, and domain metadata update
+    /// unconditionally (DM preserves its `Complete`/`Partial` variant); set transactions
+    /// update only when already tracked (`Some`); file stats follow the [`FileStatsState`]
+    /// state machine.
     pub(crate) fn apply(&mut self, delta: CrcDelta) {
         // Protocol and metadata: replace if present.
         if let Some(p) = delta.protocol {
@@ -221,6 +223,19 @@ mod tests {
             }),
             ..Default::default()
         }
+    }
+
+    fn seed_dm_map() -> HashMap<String, DomainMetadata> {
+        HashMap::from([
+            (
+                "keep".to_string(),
+                DomainMetadata::new("keep".to_string(), "old".to_string()),
+            ),
+            (
+                "drop".to_string(),
+                DomainMetadata::new("drop".to_string(), "x".to_string()),
+            ),
+        ])
     }
 
     fn write_delta(net_files: i64, net_bytes: i64) -> CrcDelta {
@@ -381,16 +396,17 @@ mod tests {
         };
         crc.apply(delta);
 
-        assert!(crc.domain_metadata_state.is_complete());
-        let map = crc.domain_metadata_state.data();
+        let DomainMetadataState::Complete(map) = &crc.domain_metadata_state else {
+            panic!("expected Complete, got {:?}", crc.domain_metadata_state);
+        };
         assert_eq!(map.len(), 1);
         assert_eq!(map["my.domain"].configuration(), "config1");
     }
 
+    /// `apply` never upgrades `Partial` to `Complete`: the variant only changes when the
+    /// caller has full knowledge, which a single delta does not provide.
     #[test]
-    fn test_apply_adds_domain_metadata_to_partial_map_stays_partial() {
-        // Default is Partial(empty). Apply observes entries; map fills but variant stays
-        // Partial (we did not gain authoritative knowledge of older history).
+    fn test_apply_does_not_upgrade_partial_to_complete() {
         let mut crc = base_crc();
         assert_eq!(crc.domain_metadata_state, DomainMetadataState::default());
         let dm = DomainMetadata::new("my.domain".to_string(), "config1".to_string());
@@ -400,8 +416,9 @@ mod tests {
         };
         crc.apply(delta);
 
-        assert!(!crc.domain_metadata_state.is_complete());
-        let map = crc.domain_metadata_state.data();
+        let DomainMetadataState::Partial(map) = &crc.domain_metadata_state else {
+            panic!("expected Partial, got {:?}", crc.domain_metadata_state);
+        };
         assert_eq!(map.len(), 1);
         assert_eq!(map["my.domain"].configuration(), "config1");
     }
@@ -421,14 +438,15 @@ mod tests {
         };
         crc.apply(delta);
 
-        assert!(crc.domain_metadata_state.is_complete());
-        let map = crc.domain_metadata_state.data();
+        let DomainMetadataState::Complete(map) = &crc.domain_metadata_state else {
+            panic!("expected Complete, got {:?}", crc.domain_metadata_state);
+        };
         assert_eq!(map.len(), 1);
         assert_eq!(map["my.domain"].configuration(), "new_config");
     }
 
     #[test]
-    fn test_apply_upserts_domain_metadata_in_partial_map() {
+    fn test_apply_upserts_domain_metadata_in_partial_map_stays_partial() {
         let mut crc = base_crc();
         crc.domain_metadata_state = DomainMetadataState::Partial(HashMap::from([(
             "my.domain".to_string(),
@@ -442,9 +460,9 @@ mod tests {
         };
         crc.apply(delta);
 
-        // Partial stays Partial.
-        assert!(!crc.domain_metadata_state.is_complete());
-        let map = crc.domain_metadata_state.data();
+        let DomainMetadataState::Partial(map) = &crc.domain_metadata_state else {
+            panic!("expected Partial, got {:?}", crc.domain_metadata_state);
+        };
         assert_eq!(map["my.domain"].configuration(), "new_config");
     }
 
@@ -463,8 +481,64 @@ mod tests {
         };
         crc.apply(delta);
 
-        assert!(crc.domain_metadata_state.is_complete());
-        assert!(crc.domain_metadata_state.data().is_empty());
+        let DomainMetadataState::Complete(map) = &crc.domain_metadata_state else {
+            panic!("expected Complete, got {:?}", crc.domain_metadata_state);
+        };
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_apply_removes_domain_metadata_from_partial_map_stays_partial() {
+        let mut crc = base_crc();
+        crc.domain_metadata_state = DomainMetadataState::Partial(HashMap::from([(
+            "my.domain".to_string(),
+            DomainMetadata::new("my.domain".to_string(), "config1".to_string()),
+        )]));
+
+        let dm = DomainMetadata::remove("my.domain".to_string(), "config1".to_string());
+        let delta = CrcDelta {
+            domain_metadata_changes: vec![dm],
+            ..write_delta(0, 0)
+        };
+        crc.apply(delta);
+
+        let DomainMetadataState::Partial(map) = &crc.domain_metadata_state else {
+            panic!("expected Partial, got {:?}", crc.domain_metadata_state);
+        };
+        assert!(map.is_empty());
+    }
+
+    /// A single delta carrying both adds and tombstones is the realistic shape of a commit.
+    /// Applied to either `Complete` or `Partial`, upserts and removals coexist correctly and
+    /// the variant is preserved.
+    #[rstest]
+    #[case::complete(DomainMetadataState::Complete(seed_dm_map()))]
+    #[case::partial(DomainMetadataState::Partial(seed_dm_map()))]
+    fn test_apply_mixed_changes_upserts_and_drops_in_one_delta(
+        #[case] base: DomainMetadataState,
+    ) {
+        let was_complete = matches!(base, DomainMetadataState::Complete(_));
+        let mut crc = base_crc();
+        crc.domain_metadata_state = base;
+        let delta = CrcDelta {
+            domain_metadata_changes: vec![
+                DomainMetadata::new("keep".to_string(), "new".to_string()),
+                DomainMetadata::new("add".to_string(), "y".to_string()),
+                DomainMetadata::remove("drop".to_string(), "x".to_string()),
+            ],
+            ..write_delta(0, 0)
+        };
+        crc.apply(delta);
+
+        let map = match &crc.domain_metadata_state {
+            DomainMetadataState::Complete(m) if was_complete => m,
+            DomainMetadataState::Partial(m) if !was_complete => m,
+            other => panic!("variant changed unexpectedly: {other:?}"),
+        };
+        assert_eq!(map.len(), 2);
+        assert_eq!(map["keep"].configuration(), "new");
+        assert_eq!(map["add"].configuration(), "y");
+        assert!(!map.contains_key("drop"));
     }
 
     #[test]
@@ -555,10 +629,33 @@ mod tests {
             ..write_delta(0, 0)
         };
         let crc = delta.into_crc_for_version_zero().unwrap();
-        assert!(crc.domain_metadata_state.is_complete());
-        let map = crc.domain_metadata_state.data();
+        let DomainMetadataState::Complete(map) = &crc.domain_metadata_state else {
+            panic!("expected Complete, got {:?}", crc.domain_metadata_state);
+        };
         assert_eq!(map.len(), 1);
         assert_eq!(map["my.domain"].configuration(), "config1");
+    }
+
+    /// Defensive contract: even a v0 delta carrying tombstones (degenerate but possible)
+    /// drops them before materializing the Complete map.
+    #[test]
+    fn test_into_crc_for_version_zero_drops_tombstones() {
+        let delta = CrcDelta {
+            protocol: Some(test_protocol()),
+            metadata: Some(Metadata::default()),
+            domain_metadata_changes: vec![
+                DomainMetadata::new("keep".to_string(), "x".to_string()),
+                DomainMetadata::remove("ghost".to_string(), "y".to_string()),
+            ],
+            ..write_delta(0, 0)
+        };
+        let crc = delta.into_crc_for_version_zero().unwrap();
+        let DomainMetadataState::Complete(map) = &crc.domain_metadata_state else {
+            panic!("expected Complete, got {:?}", crc.domain_metadata_state);
+        };
+        assert_eq!(map.len(), 1);
+        assert!(map.contains_key("keep"));
+        assert!(!map.contains_key("ghost"));
     }
 
     #[test]

--- a/kernel/src/crc/delta.rs
+++ b/kernel/src/crc/delta.rs
@@ -394,15 +394,11 @@ mod tests {
         };
         crc.apply(delta);
 
-        let DomainMetadataState::Complete(map) = &crc.domain_metadata_state else {
-            panic!("expected Complete, got {:?}", crc.domain_metadata_state);
-        };
+        let map = crc.domain_metadata_state.expect_complete();
         assert_eq!(map.len(), 1);
         assert_eq!(map["my.domain"].configuration(), "config1");
     }
 
-    /// `apply` never upgrades `Partial` to `Complete`: the variant only changes when the
-    /// caller has full knowledge, which a single delta does not provide.
     #[test]
     fn test_apply_does_not_upgrade_partial_to_complete() {
         let mut crc = base_crc();
@@ -414,9 +410,7 @@ mod tests {
         };
         crc.apply(delta);
 
-        let DomainMetadataState::Partial(map) = &crc.domain_metadata_state else {
-            panic!("expected Partial, got {:?}", crc.domain_metadata_state);
-        };
+        let map = crc.domain_metadata_state.expect_partial();
         assert_eq!(map.len(), 1);
         assert_eq!(map["my.domain"].configuration(), "config1");
     }
@@ -436,9 +430,7 @@ mod tests {
         };
         crc.apply(delta);
 
-        let DomainMetadataState::Complete(map) = &crc.domain_metadata_state else {
-            panic!("expected Complete, got {:?}", crc.domain_metadata_state);
-        };
+        let map = crc.domain_metadata_state.expect_complete();
         assert_eq!(map.len(), 1);
         assert_eq!(map["my.domain"].configuration(), "new_config");
     }
@@ -458,9 +450,7 @@ mod tests {
         };
         crc.apply(delta);
 
-        let DomainMetadataState::Partial(map) = &crc.domain_metadata_state else {
-            panic!("expected Partial, got {:?}", crc.domain_metadata_state);
-        };
+        let map = crc.domain_metadata_state.expect_partial();
         assert_eq!(map["my.domain"].configuration(), "new_config");
     }
 
@@ -479,9 +469,7 @@ mod tests {
         };
         crc.apply(delta);
 
-        let DomainMetadataState::Complete(map) = &crc.domain_metadata_state else {
-            panic!("expected Complete, got {:?}", crc.domain_metadata_state);
-        };
+        let map = crc.domain_metadata_state.expect_complete();
         assert!(map.is_empty());
     }
 
@@ -500,9 +488,7 @@ mod tests {
         };
         crc.apply(delta);
 
-        let DomainMetadataState::Partial(map) = &crc.domain_metadata_state else {
-            panic!("expected Partial, got {:?}", crc.domain_metadata_state);
-        };
+        let map = crc.domain_metadata_state.expect_partial();
         assert!(map.is_empty());
     }
 
@@ -625,9 +611,7 @@ mod tests {
             ..write_delta(0, 0)
         };
         let crc = delta.into_crc_for_version_zero().unwrap();
-        let DomainMetadataState::Complete(map) = &crc.domain_metadata_state else {
-            panic!("expected Complete, got {:?}", crc.domain_metadata_state);
-        };
+        let map = crc.domain_metadata_state.expect_complete();
         assert_eq!(map.len(), 1);
         assert_eq!(map["my.domain"].configuration(), "config1");
     }

--- a/kernel/src/crc/delta.rs
+++ b/kernel/src/crc/delta.rs
@@ -383,125 +383,13 @@ mod tests {
         assert_eq!(crc.metadata, Metadata::default()); // unchanged
     }
 
-    #[test]
-    fn test_apply_adds_domain_metadata_to_complete_map() {
-        let mut crc = base_crc();
-        crc.domain_metadata_state = DomainMetadataState::Complete(HashMap::new());
-        let dm = DomainMetadata::new("my.domain".to_string(), "config1".to_string());
-        let delta = CrcDelta {
-            domain_metadata_changes: vec![dm],
-            ..write_delta(0, 0)
-        };
-        crc.apply(delta);
-
-        let map = crc.domain_metadata_state.expect_complete();
-        assert_eq!(map.len(), 1);
-        assert_eq!(map["my.domain"].configuration(), "config1");
-    }
-
-    #[test]
-    fn test_apply_does_not_upgrade_partial_to_complete() {
-        let mut crc = base_crc();
-        assert_eq!(
-            crc.domain_metadata_state,
-            DomainMetadataState::Partial(HashMap::new())
-        );
-        let dm = DomainMetadata::new("my.domain".to_string(), "config1".to_string());
-        let delta = CrcDelta {
-            domain_metadata_changes: vec![dm],
-            ..write_delta(0, 0)
-        };
-        crc.apply(delta);
-
-        let map = crc.domain_metadata_state.expect_partial();
-        assert_eq!(map.len(), 1);
-        assert_eq!(map["my.domain"].configuration(), "config1");
-    }
-
-    #[test]
-    fn test_apply_upserts_domain_metadata_in_complete_map() {
-        let mut crc = base_crc();
-        crc.domain_metadata_state = DomainMetadataState::Complete(HashMap::from([(
-            "my.domain".to_string(),
-            DomainMetadata::new("my.domain".to_string(), "old_config".to_string()),
-        )]));
-
-        let dm = DomainMetadata::new("my.domain".to_string(), "new_config".to_string());
-        let delta = CrcDelta {
-            domain_metadata_changes: vec![dm],
-            ..write_delta(0, 0)
-        };
-        crc.apply(delta);
-
-        let map = crc.domain_metadata_state.expect_complete();
-        assert_eq!(map.len(), 1);
-        assert_eq!(map["my.domain"].configuration(), "new_config");
-    }
-
-    #[test]
-    fn test_apply_upserts_domain_metadata_in_partial_map_stays_partial() {
-        let mut crc = base_crc();
-        crc.domain_metadata_state = DomainMetadataState::Partial(HashMap::from([(
-            "my.domain".to_string(),
-            DomainMetadata::new("my.domain".to_string(), "old_config".to_string()),
-        )]));
-
-        let dm = DomainMetadata::new("my.domain".to_string(), "new_config".to_string());
-        let delta = CrcDelta {
-            domain_metadata_changes: vec![dm],
-            ..write_delta(0, 0)
-        };
-        crc.apply(delta);
-
-        let map = crc.domain_metadata_state.expect_partial();
-        assert_eq!(map["my.domain"].configuration(), "new_config");
-    }
-
-    #[test]
-    fn test_apply_removes_domain_metadata_from_complete_map() {
-        let mut crc = base_crc();
-        crc.domain_metadata_state = DomainMetadataState::Complete(HashMap::from([(
-            "my.domain".to_string(),
-            DomainMetadata::new("my.domain".to_string(), "config1".to_string()),
-        )]));
-
-        let dm = DomainMetadata::remove("my.domain".to_string(), "config1".to_string());
-        let delta = CrcDelta {
-            domain_metadata_changes: vec![dm],
-            ..write_delta(0, 0)
-        };
-        crc.apply(delta);
-
-        let map = crc.domain_metadata_state.expect_complete();
-        assert!(map.is_empty());
-    }
-
-    #[test]
-    fn test_apply_removes_domain_metadata_from_partial_map_stays_partial() {
-        let mut crc = base_crc();
-        crc.domain_metadata_state = DomainMetadataState::Partial(HashMap::from([(
-            "my.domain".to_string(),
-            DomainMetadata::new("my.domain".to_string(), "config1".to_string()),
-        )]));
-
-        let dm = DomainMetadata::remove("my.domain".to_string(), "config1".to_string());
-        let delta = CrcDelta {
-            domain_metadata_changes: vec![dm],
-            ..write_delta(0, 0)
-        };
-        crc.apply(delta);
-
-        let map = crc.domain_metadata_state.expect_partial();
-        assert!(map.is_empty());
-    }
-
-    /// A single delta carrying both adds and tombstones is the realistic shape of a commit.
-    /// Applied to either `Complete` or `Partial`, upserts and removals coexist correctly and
-    /// the variant is preserved.
+    /// A delta carrying an upsert, an insert, and a tombstone exercises every apply
+    /// semantic for domain metadata. Applied to either `Complete` or `Partial`, the map
+    /// updates correctly and the variant is preserved.
     #[rstest]
     #[case::complete(DomainMetadataState::Complete(seed_dm_map()))]
     #[case::partial(DomainMetadataState::Partial(seed_dm_map()))]
-    fn test_apply_mixed_changes_upserts_and_drops_in_one_delta(#[case] base: DomainMetadataState) {
+    fn test_apply_dm_upserts_inserts_and_removes(#[case] base: DomainMetadataState) {
         let was_complete = matches!(base, DomainMetadataState::Complete(_));
         let mut crc = base_crc();
         crc.domain_metadata_state = base;
@@ -515,6 +403,7 @@ mod tests {
         };
         crc.apply(delta);
 
+        // Bind the inner map AND panic if the variant flipped during apply.
         let map = match &crc.domain_metadata_state {
             DomainMetadataState::Complete(m) if was_complete => m,
             DomainMetadataState::Partial(m) if !was_complete => m,

--- a/kernel/src/crc/delta.rs
+++ b/kernel/src/crc/delta.rs
@@ -29,9 +29,7 @@ pub(crate) struct CrcDelta {
     pub(crate) protocol: Option<Protocol>,
     /// New metadata action, if this commit changed it.
     pub(crate) metadata: Option<Metadata>,
-    /// All DM actions in this commit (additions and removals). `apply()` processes these
-    /// unconditionally; the base CRC's `DomainMetadataState` variant (`Complete` or
-    /// `Partial`) is preserved.
+    /// All DM actions in this commit, including tombstones (`removed=true`).
     pub(crate) domain_metadata_changes: Vec<DomainMetadata>,
     /// All SetTransaction actions in this commit. `apply()` only processes these when the base
     /// CRC's `set_transactions` is `Some` (tracked).
@@ -514,9 +512,7 @@ mod tests {
     #[rstest]
     #[case::complete(DomainMetadataState::Complete(seed_dm_map()))]
     #[case::partial(DomainMetadataState::Partial(seed_dm_map()))]
-    fn test_apply_mixed_changes_upserts_and_drops_in_one_delta(
-        #[case] base: DomainMetadataState,
-    ) {
+    fn test_apply_mixed_changes_upserts_and_drops_in_one_delta(#[case] base: DomainMetadataState) {
         let was_complete = matches!(base, DomainMetadataState::Complete(_));
         let mut crc = base_crc();
         crc.domain_metadata_state = base;
@@ -634,28 +630,6 @@ mod tests {
         };
         assert_eq!(map.len(), 1);
         assert_eq!(map["my.domain"].configuration(), "config1");
-    }
-
-    /// Defensive contract: even a v0 delta carrying tombstones (degenerate but possible)
-    /// drops them before materializing the Complete map.
-    #[test]
-    fn test_into_crc_for_version_zero_drops_tombstones() {
-        let delta = CrcDelta {
-            protocol: Some(test_protocol()),
-            metadata: Some(Metadata::default()),
-            domain_metadata_changes: vec![
-                DomainMetadata::new("keep".to_string(), "x".to_string()),
-                DomainMetadata::remove("ghost".to_string(), "y".to_string()),
-            ],
-            ..write_delta(0, 0)
-        };
-        let crc = delta.into_crc_for_version_zero().unwrap();
-        let DomainMetadataState::Complete(map) = &crc.domain_metadata_state else {
-            panic!("expected Complete, got {:?}", crc.domain_metadata_state);
-        };
-        assert_eq!(map.len(), 1);
-        assert!(map.contains_key("keep"));
-        assert!(!map.contains_key("ghost"));
     }
 
     #[test]

--- a/kernel/src/crc/mod.rs
+++ b/kernel/src/crc/mod.rs
@@ -3,10 +3,10 @@
 //! A [CRC file] contains a snapshot of table state at a specific version, which can be used to
 //! optimize log replay operations like reading Protocol/Metadata, domain metadata, and ICT.
 //!
-//! [`Crc`] holds the in-memory state using shapes that make kernel queries easy: a typed
-//! state enum (`FileStatsState`) and `HashMap`s keyed by id, instead of the flat scalars and
-//! arrays of the on-disk format. It (de)serializes to/from JSON via the private `CrcRaw`
-//! serde intermediate, which mirrors the wire format exactly.
+//! [`Crc`] holds the in-memory state using shapes that make kernel queries easy: typed
+//! state enums (`FileStatsState`, `DomainMetadataState`) and `HashMap`s keyed by id, instead
+//! of the flat scalars and arrays of the on-disk format. It (de)serializes to/from JSON via
+//! the private `CrcRaw` serde intermediate, which mirrors the wire format exactly.
 //!
 //! [CRC file]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#version-checksum-file
 
@@ -85,7 +85,11 @@ pub struct Crc {
     /// Active (non-removed) [`DomainMetadata`] actions at this version, as a typed
     /// [`DomainMetadataState`]. Tombstones (`removed=true`) are never stored. `Complete(map)`
     /// is authoritative for misses; `Partial(map)` carries known-correct entries but requires
-    /// log replay for misses. Only the `Complete` variant is materialized to the file.
+    /// log replay for misses. Only the `Complete` variant is persisted to the CRC file.
+    ///
+    /// TODO: when the table protocol does not enable the `domainMetadata` feature, no DM
+    /// action can exist, so `Partial(_)` is semantically equivalent to `Complete(empty)` and
+    /// both serde paths could collapse the distinction.
     pub domain_metadata_state: DomainMetadataState,
 
     // ===== Not yet supported fields =====
@@ -196,9 +200,6 @@ impl TryFrom<CrcRaw> for Crc {
                 .map(|v| v.into_iter().map(|t| (t.app_id.clone(), t)).collect()),
             // Present array (including empty `[]`) deserializes as Complete; absent or null
             // deserializes as Partial(empty).
-            // TODO: if the table protocol does not support the domainMetadata feature, an
-            //       absent field is equivalent to `Complete(empty)` (no domains can exist),
-            //       so we could deserialize to Complete here too.
             domain_metadata_state: match raw.domain_metadata {
                 Some(v) => DomainMetadataState::Complete(
                     v.into_iter().map(|d| (d.domain().to_string(), d)).collect(),
@@ -239,9 +240,6 @@ impl TryFrom<&Crc> for CrcRaw {
                 .map(|m| m.values().cloned().collect()),
             // Only Complete survives the round-trip; Partial drops to absent so the next
             // read does not mistake it for an authoritative Complete cache.
-            // TODO: if the table protocol does not support the domainMetadata feature,
-            //       `Partial(_)` is equivalent to `Complete(empty)` (no domains can exist),
-            //       so we could serialize an empty `[]` here too.
             domain_metadata: match &crc.domain_metadata_state {
                 DomainMetadataState::Complete(m) => Some(m.values().cloned().collect()),
                 DomainMetadataState::Partial(_) => None,
@@ -308,7 +306,8 @@ mod tests {
     use super::{Crc, CrcRaw, DomainMetadataState, FileStats, FileStatsState};
     use crate::actions::{DomainMetadata, SetTransaction};
 
-    /// Helper to create a minimal `Crc` with only set_transactions and domain_metadata populated.
+    /// Helper to create a minimal `Crc` with only set_transactions and domain_metadata_state
+    /// populated.
     fn crc_with(
         txns: Option<HashMap<String, SetTransaction>>,
         domains: DomainMetadataState,
@@ -362,8 +361,9 @@ mod tests {
         assert_eq!(txn2.last_updated, None);
 
         // A present `domainMetadata` array deserializes as `Complete` (authoritative).
-        assert!(crc.domain_metadata_state.is_complete());
-        let domains = crc.domain_metadata_state.data();
+        let DomainMetadataState::Complete(domains) = &crc.domain_metadata_state else {
+            panic!("expected Complete, got {:?}", crc.domain_metadata_state);
+        };
         assert_eq!(domains.len(), 2);
         assert!(domains.contains_key("delta.rowTracking"));
         assert!(domains.contains_key("delta.clustering"));
@@ -572,8 +572,12 @@ mod tests {
         assert_eq!(txns["etl-pipeline"].version, 7);
 
         // Verify all domain metadatas
-        assert!(deserialized.domain_metadata_state.is_complete());
-        let domains = deserialized.domain_metadata_state.data();
+        let DomainMetadataState::Complete(domains) = &deserialized.domain_metadata_state else {
+            panic!(
+                "expected Complete, got {:?}",
+                deserialized.domain_metadata_state
+            );
+        };
         assert_eq!(domains.len(), 3);
         assert!(domains.contains_key("delta.rowTracking"));
         assert!(domains.contains_key("delta.clustering"));

--- a/kernel/src/crc/mod.rs
+++ b/kernel/src/crc/mod.rs
@@ -420,7 +420,7 @@ mod tests {
 
     #[test]
     fn ser_partial_dm_and_none_txns_serialize_to_null() {
-        let crc = crc_with(None, DomainMetadataState::default());
+        let crc = crc_with(None, DomainMetadataState::Partial(HashMap::new()));
         let json = serde_json::to_value(&crc).unwrap();
         assert!(json["setTransactions"].is_null());
         // Partial is not authoritative for misses; persisting it would falsely promote

--- a/kernel/src/crc/mod.rs
+++ b/kernel/src/crc/mod.rs
@@ -88,8 +88,8 @@ pub struct Crc {
     /// log replay for misses. Only the `Complete` variant is persisted to the CRC file.
     ///
     /// TODO: when the table protocol does not enable the `domainMetadata` feature, no DM
-    /// action can exist, so `Partial(_)` is semantically equivalent to `Complete(empty)` and
-    /// both serde paths could collapse the distinction.
+    ///       action can exist, so `Partial(_)` is semantically equivalent to
+    ///       `Complete(empty)` and both serde paths could collapse the distinction.
     pub domain_metadata_state: DomainMetadataState,
 
     // ===== Not yet supported fields =====
@@ -360,9 +360,7 @@ mod tests {
         assert_eq!(txn2.last_updated, None);
 
         // A present `domainMetadata` array deserializes as `Complete` (authoritative).
-        let DomainMetadataState::Complete(domains) = &crc.domain_metadata_state else {
-            panic!("expected Complete, got {:?}", crc.domain_metadata_state);
-        };
+        let domains = crc.domain_metadata_state.expect_complete();
         assert_eq!(domains.len(), 2);
         assert!(domains.contains_key("delta.rowTracking"));
         assert!(domains.contains_key("delta.clustering"));
@@ -488,7 +486,7 @@ mod tests {
     }
 
     #[test]
-    fn round_trip_partial_dm_drops_entries_back_to_empty_partial() {
+    fn round_trip_partial_dm_becomes_empty_partial() {
         let mut partial = HashMap::new();
         partial.insert(
             "delta.rowTracking".to_string(),
@@ -568,12 +566,7 @@ mod tests {
         assert_eq!(txns["etl-pipeline"].version, 7);
 
         // Verify all domain metadatas
-        let DomainMetadataState::Complete(domains) = &deserialized.domain_metadata_state else {
-            panic!(
-                "expected Complete, got {:?}",
-                deserialized.domain_metadata_state
-            );
-        };
+        let domains = deserialized.domain_metadata_state.expect_complete();
         assert_eq!(domains.len(), 3);
         assert!(domains.contains_key("delta.rowTracking"));
         assert!(domains.contains_key("delta.clustering"));

--- a/kernel/src/crc/mod.rs
+++ b/kernel/src/crc/mod.rs
@@ -238,8 +238,7 @@ impl TryFrom<&Crc> for CrcRaw {
                 .set_transactions
                 .as_ref()
                 .map(|m| m.values().cloned().collect()),
-            // Only Complete survives the round-trip; Partial drops to absent so the next
-            // read does not mistake it for an authoritative Complete cache.
+            // Only `Complete` is written; `Partial` is dropped.
             domain_metadata: match &crc.domain_metadata_state {
                 DomainMetadataState::Complete(m) => Some(m.values().cloned().collect()),
                 DomainMetadataState::Partial(_) => None,
@@ -310,11 +309,11 @@ mod tests {
     /// populated.
     fn crc_with(
         txns: Option<HashMap<String, SetTransaction>>,
-        domains: DomainMetadataState,
+        domain_metadata_state: DomainMetadataState,
     ) -> Crc {
         Crc {
             set_transactions: txns,
-            domain_metadata_state: domains,
+            domain_metadata_state,
             ..Default::default()
         }
     }
@@ -488,9 +487,6 @@ mod tests {
         assert_eq!(json_value["domainMetadata"], serde_json::json!([]));
     }
 
-    /// Round-tripping a Partial DM through serde drops the field on serialize and produces
-    /// `Partial(empty)` on the next deserialize, regardless of the Partial cache's contents.
-    /// This is the deliberate "Partial is not persisted" contract.
     #[test]
     fn round_trip_partial_dm_drops_entries_back_to_empty_partial() {
         let mut partial = HashMap::new();

--- a/kernel/src/crc/mod.rs
+++ b/kernel/src/crc/mod.rs
@@ -34,7 +34,7 @@ pub(crate) use lazy::{CrcLoadResult, LazyCrc};
 pub(crate) use reader::try_read_crc_file;
 use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
-pub use state::FileStatsState;
+pub use state::{DomainMetadataState, FileStatsState};
 #[allow(unused)]
 pub(crate) use writer::try_write_crc_file;
 
@@ -82,16 +82,11 @@ pub struct Crc {
     /// Stored as a HashMap keyed by `app_id` for efficient lookup. The CRC JSON format uses
     /// a Vec, which is converted via the `CrcRaw` serde intermediate.
     pub set_transactions: Option<HashMap<String, SetTransaction>>,
-    // TODO: introduce `DomainMetadataState` (Complete / Partial) to disambiguate "no
-    //       observations" from "fully tracked but empty".
-    /// Active (non-removed) [`DomainMetadata`] actions at this version. Tombstones
-    /// (`removed=true`) are never stored. `None` = not tracked (field absent in CRC JSON or not
-    /// computed). `Some(empty_map)` = tracked, no active domain metadata. `Crc::apply`
-    /// skips updates when `None`.
-    ///
-    /// Stored as a HashMap keyed by domain name for efficient lookup. The CRC JSON format uses
-    /// a Vec, which is converted via the `CrcRaw` serde intermediate.
-    pub domain_metadata: Option<HashMap<String, DomainMetadata>>,
+    /// Active (non-removed) [`DomainMetadata`] actions at this version, as a typed
+    /// [`DomainMetadataState`]. Tombstones (`removed=true`) are never stored. `Complete(map)`
+    /// is authoritative for misses; `Partial(map)` carries known-correct entries but requires
+    /// log replay for misses. Only the `Complete` variant is materialized to the file.
+    pub domain_metadata_state: DomainMetadataState,
 
     // ===== Not yet supported fields =====
     /// A unique identifier for the transaction that produced this commit.
@@ -199,9 +194,17 @@ impl TryFrom<CrcRaw> for Crc {
             set_transactions: raw
                 .set_transactions
                 .map(|v| v.into_iter().map(|t| (t.app_id.clone(), t)).collect()),
-            domain_metadata: raw
-                .domain_metadata
-                .map(|v| v.into_iter().map(|d| (d.domain().to_string(), d)).collect()),
+            // Present array (including empty `[]`) deserializes as Complete; absent or null
+            // deserializes as Partial(empty).
+            // TODO: if the table protocol does not support the domainMetadata feature, an
+            //       absent field is equivalent to `Complete(empty)` (no domains can exist),
+            //       so we could deserialize to Complete here too.
+            domain_metadata_state: match raw.domain_metadata {
+                Some(v) => DomainMetadataState::Complete(
+                    v.into_iter().map(|d| (d.domain().to_string(), d)).collect(),
+                ),
+                None => DomainMetadataState::Partial(HashMap::new()),
+            },
             // Not yet round-tripped through CrcRaw; see the "not yet supported" fields on Crc.
             txn_id: None,
             all_files: None,
@@ -234,10 +237,15 @@ impl TryFrom<&Crc> for CrcRaw {
                 .set_transactions
                 .as_ref()
                 .map(|m| m.values().cloned().collect()),
-            domain_metadata: crc
-                .domain_metadata
-                .as_ref()
-                .map(|m| m.values().cloned().collect()),
+            // Only Complete survives the round-trip; Partial drops to absent so the next
+            // read does not mistake it for an authoritative Complete cache.
+            // TODO: if the table protocol does not support the domainMetadata feature,
+            //       `Partial(_)` is equivalent to `Complete(empty)` (no domains can exist),
+            //       so we could serialize an empty `[]` here too.
+            domain_metadata: match &crc.domain_metadata_state {
+                DomainMetadataState::Complete(m) => Some(m.values().cloned().collect()),
+                DomainMetadataState::Partial(_) => None,
+            },
             file_size_histogram: stats.file_size_histogram.clone(),
         })
     }
@@ -297,17 +305,17 @@ mod tests {
 
     use rstest::rstest;
 
-    use super::{Crc, CrcRaw, FileStats, FileStatsState};
+    use super::{Crc, CrcRaw, DomainMetadataState, FileStats, FileStatsState};
     use crate::actions::{DomainMetadata, SetTransaction};
 
     /// Helper to create a minimal `Crc` with only set_transactions and domain_metadata populated.
     fn crc_with(
         txns: Option<HashMap<String, SetTransaction>>,
-        domains: Option<HashMap<String, DomainMetadata>>,
+        domains: DomainMetadataState,
     ) -> Crc {
         Crc {
             set_transactions: txns,
-            domain_metadata: domains,
+            domain_metadata_state: domains,
             ..Default::default()
         }
     }
@@ -353,14 +361,16 @@ mod tests {
         assert_eq!(txn2.version, 7);
         assert_eq!(txn2.last_updated, None);
 
-        let domains = crc.domain_metadata.as_ref().unwrap();
+        // A present `domainMetadata` array deserializes as `Complete` (authoritative).
+        assert!(crc.domain_metadata_state.is_complete());
+        let domains = crc.domain_metadata_state.data();
         assert_eq!(domains.len(), 2);
         assert!(domains.contains_key("delta.rowTracking"));
         assert!(domains.contains_key("delta.clustering"));
     }
 
     #[test]
-    fn de_null_deserializes_to_none() {
+    fn de_null_dm_deserializes_to_partial_empty_and_null_txns_deserializes_to_none() {
         let json = r#"{
             "tableSizeBytes": 0,
             "numFiles": 0,
@@ -380,11 +390,14 @@ mod tests {
         }"#;
         let crc: Crc = serde_json::from_str(json).unwrap();
         assert!(crc.set_transactions.is_none());
-        assert!(crc.domain_metadata.is_none());
+        assert_eq!(
+            crc.domain_metadata_state,
+            DomainMetadataState::Partial(HashMap::new())
+        );
     }
 
     #[test]
-    fn de_missing_field_deserializes_to_none() {
+    fn de_missing_dm_field_deserializes_to_partial_empty_and_missing_txns_to_none() {
         let json = r#"{
             "tableSizeBytes": 0,
             "numFiles": 0,
@@ -402,14 +415,32 @@ mod tests {
         }"#;
         let crc: Crc = serde_json::from_str(json).unwrap();
         assert!(crc.set_transactions.is_none());
-        assert!(crc.domain_metadata.is_none());
+        assert_eq!(
+            crc.domain_metadata_state,
+            DomainMetadataState::Partial(HashMap::new())
+        );
     }
 
     #[test]
-    fn ser_none_serializes_to_null() {
-        let crc = crc_with(None, None);
+    fn ser_partial_dm_and_none_txns_serialize_to_null() {
+        let crc = crc_with(None, DomainMetadataState::default());
         let json = serde_json::to_value(&crc).unwrap();
         assert!(json["setTransactions"].is_null());
+        // Partial is not authoritative for misses; persisting it would falsely promote
+        // to `Complete(empty)` on the next read.
+        assert!(json["domainMetadata"].is_null());
+    }
+
+    #[test]
+    fn ser_non_empty_partial_dm_still_serializes_to_null() {
+        let mut partial = HashMap::new();
+        partial.insert(
+            "delta.rowTracking".to_string(),
+            DomainMetadata::new("delta.rowTracking".to_string(), "{}".to_string()),
+        );
+        let crc = crc_with(None, DomainMetadataState::Partial(partial));
+        let json = serde_json::to_value(&crc).unwrap();
+        // Even non-empty Partial maps drop on serialize.
         assert!(json["domainMetadata"].is_null());
     }
 
@@ -431,7 +462,7 @@ mod tests {
             DomainMetadata::new("delta.rowTracking".to_string(), "{}".to_string()),
         );
 
-        let original = crc_with(Some(txns), Some(domains));
+        let original = crc_with(Some(txns), DomainMetadataState::Complete(domains));
 
         let json_str = serde_json::to_string(&original).unwrap();
         let deserialized: Crc = serde_json::from_str(&json_str).unwrap();
@@ -440,8 +471,11 @@ mod tests {
     }
 
     #[test]
-    fn round_trip_empty_maps() {
-        let original = crc_with(Some(HashMap::new()), Some(HashMap::new()));
+    fn round_trip_empty_complete_dm_and_empty_txns() {
+        let original = crc_with(
+            Some(HashMap::new()),
+            DomainMetadataState::Complete(HashMap::new()),
+        );
 
         let json_str = serde_json::to_string(&original).unwrap();
         let deserialized: Crc = serde_json::from_str(&json_str).unwrap();
@@ -452,6 +486,27 @@ mod tests {
         let json_value = serde_json::to_value(&original).unwrap();
         assert_eq!(json_value["setTransactions"], serde_json::json!([]));
         assert_eq!(json_value["domainMetadata"], serde_json::json!([]));
+    }
+
+    /// Round-tripping a Partial DM through serde drops the field on serialize and produces
+    /// `Partial(empty)` on the next deserialize, regardless of the Partial cache's contents.
+    /// This is the deliberate "Partial is not persisted" contract.
+    #[test]
+    fn round_trip_partial_dm_drops_entries_back_to_empty_partial() {
+        let mut partial = HashMap::new();
+        partial.insert(
+            "delta.rowTracking".to_string(),
+            DomainMetadata::new("delta.rowTracking".to_string(), "{}".to_string()),
+        );
+        let original = crc_with(None, DomainMetadataState::Partial(partial));
+
+        let json_str = serde_json::to_string(&original).unwrap();
+        let deserialized: Crc = serde_json::from_str(&json_str).unwrap();
+
+        assert_eq!(
+            deserialized.domain_metadata_state,
+            DomainMetadataState::Partial(HashMap::new())
+        );
     }
 
     #[test]
@@ -494,7 +549,7 @@ mod tests {
                 file_size_histogram: None,
             }),
             set_transactions: Some(txns),
-            domain_metadata: Some(domains),
+            domain_metadata_state: DomainMetadataState::Complete(domains),
             ..Default::default()
         };
 
@@ -517,7 +572,8 @@ mod tests {
         assert_eq!(txns["etl-pipeline"].version, 7);
 
         // Verify all domain metadatas
-        let domains = deserialized.domain_metadata.as_ref().unwrap();
+        assert!(deserialized.domain_metadata_state.is_complete());
+        let domains = deserialized.domain_metadata_state.data();
         assert_eq!(domains.len(), 3);
         assert!(domains.contains_key("delta.rowTracking"));
         assert!(domains.contains_key("delta.clustering"));

--- a/kernel/src/crc/reader.rs
+++ b/kernel/src/crc/reader.rs
@@ -105,7 +105,8 @@ mod tests {
         assert_eq!(crc.metadata, expected_metadata);
 
         // Verify domain metadatas
-        let dms = crc.domain_metadata.as_ref().unwrap();
+        assert!(crc.domain_metadata_state.is_complete());
+        let dms = crc.domain_metadata_state.data();
         assert_eq!(dms.len(), 3);
 
         assert!(dms["delta.clustering"]

--- a/kernel/src/crc/reader.rs
+++ b/kernel/src/crc/reader.rs
@@ -31,6 +31,7 @@ mod tests {
 
     use super::*;
     use crate::actions::{Format, Metadata, Protocol};
+    use crate::crc::DomainMetadataState;
     use crate::engine::sync::SyncEngine;
     use crate::path::ParsedLogPath;
     use crate::table_features::TableFeature;
@@ -105,8 +106,9 @@ mod tests {
         assert_eq!(crc.metadata, expected_metadata);
 
         // Verify domain metadatas
-        assert!(crc.domain_metadata_state.is_complete());
-        let dms = crc.domain_metadata_state.data();
+        let DomainMetadataState::Complete(dms) = &crc.domain_metadata_state else {
+            panic!("expected Complete, got {:?}", crc.domain_metadata_state);
+        };
         assert_eq!(dms.len(), 3);
 
         assert!(dms["delta.clustering"]

--- a/kernel/src/crc/reader.rs
+++ b/kernel/src/crc/reader.rs
@@ -31,7 +31,6 @@ mod tests {
 
     use super::*;
     use crate::actions::{Format, Metadata, Protocol};
-    use crate::crc::DomainMetadataState;
     use crate::engine::sync::SyncEngine;
     use crate::path::ParsedLogPath;
     use crate::table_features::TableFeature;
@@ -106,9 +105,7 @@ mod tests {
         assert_eq!(crc.metadata, expected_metadata);
 
         // Verify domain metadatas
-        let DomainMetadataState::Complete(dms) = &crc.domain_metadata_state else {
-            panic!("expected Complete, got {:?}", crc.domain_metadata_state);
-        };
+        let dms = crc.domain_metadata_state.expect_complete();
         assert_eq!(dms.len(), 3);
 
         assert!(dms["delta.clustering"]

--- a/kernel/src/crc/state.rs
+++ b/kernel/src/crc/state.rs
@@ -7,6 +7,8 @@
 //!
 //! - [`FileStatsState`] tracks file-stat validity (Complete / Indeterminate / Untrackable).
 //! - [`DomainMetadataState`] tracks domain-metadata completeness (Complete / Partial).
+//!
+//! TODO: introduce `SetTransactionState` with the same shape as `DomainMetadataState`.
 
 use std::collections::HashMap;
 
@@ -89,6 +91,26 @@ pub enum DomainMetadataState {
 impl Default for DomainMetadataState {
     fn default() -> Self {
         Self::Partial(HashMap::new())
+    }
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+#[allow(clippy::panic)]
+impl DomainMetadataState {
+    /// Test-only: returns the map if `Complete`, panics otherwise.
+    pub fn expect_complete(&self) -> &HashMap<String, DomainMetadata> {
+        match self {
+            Self::Complete(map) => map,
+            other => panic!("expected Complete, got {other:?}"),
+        }
+    }
+
+    /// Test-only: returns the map if `Partial`, panics otherwise.
+    pub fn expect_partial(&self) -> &HashMap<String, DomainMetadata> {
+        match self {
+            Self::Partial(map) => map,
+            other => panic!("expected Partial, got {other:?}"),
+        }
     }
 }
 

--- a/kernel/src/crc/state.rs
+++ b/kernel/src/crc/state.rs
@@ -5,10 +5,14 @@
 //! invalid reads unrepresentable: the compiler prevents reading an absolute count from a
 //! degraded state because the field does not exist there.
 //!
-//! Today this module hosts [`FileStatsState`]; follow-up PRs add `DomainMetadataState` and
-//! `SetTransactionState` (Complete / Partial variants).
+//! - [`FileStatsState`] tracks file-stat validity (Complete / Indeterminate / Untrackable).
+//! - [`DomainMetadataState`] tracks domain-metadata completeness (Complete / Partial). A
+//!   follow-up PR adds `SetTransactionState` with the same shape.
+
+use std::collections::HashMap;
 
 use super::file_stats::FileStats;
+use crate::actions::DomainMetadata;
 
 /// The state of file statistics for a CRC.
 ///
@@ -61,6 +65,44 @@ impl FileStatsState {
 impl Default for FileStatsState {
     fn default() -> Self {
         Self::Complete(FileStats::default())
+    }
+}
+
+// ============================================================================
+// Domain metadata state
+// ============================================================================
+
+/// The completeness state of cached domain metadata in a CRC.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DomainMetadataState {
+    /// The CRC file had the `domainMetadata` field (possibly as an empty array). The map
+    /// is the full set of active (non-removed) domains at this version; a domain not in the
+    /// map does not exist.
+    Complete(HashMap<String, DomainMetadata>),
+
+    /// The CRC file did not have the `domainMetadata` field. The map starts empty and gets
+    /// populated by incremental CRC replay over the JSON commits after the latest stale CRC.
+    /// Hits are authoritative (definitely present at this version); misses are NOT
+    /// (the domain may exist in older commits), so callers must do a further log scan.
+    Partial(HashMap<String, DomainMetadata>),
+}
+
+impl Default for DomainMetadataState {
+    fn default() -> Self {
+        Self::Partial(HashMap::new())
+    }
+}
+
+impl DomainMetadataState {
+    /// Returns the underlying map. Both variants own one.
+    pub fn data(&self) -> &HashMap<String, DomainMetadata> {
+        match self {
+            Self::Complete(map) | Self::Partial(map) => map,
+        }
+    }
+
+    pub fn is_complete(&self) -> bool {
+        matches!(self, Self::Complete(_))
     }
 }
 
@@ -120,6 +162,34 @@ mod tests {
                 table_size_bytes: 0,
                 file_size_histogram: None,
             })
+        );
+    }
+
+    // ===== DomainMetadataState =====
+
+    #[test]
+    fn dm_state_data_accessor_returns_underlying_map_for_both_variants() {
+        let map = HashMap::from([(
+            "d".to_string(),
+            DomainMetadata::new("d".to_string(), "{}".to_string()),
+        )]);
+        assert_eq!(DomainMetadataState::Complete(map.clone()).data().len(), 1);
+        assert_eq!(DomainMetadataState::Partial(map).data().len(), 1);
+        assert_eq!(DomainMetadataState::default().data().len(), 0);
+    }
+
+    #[test]
+    fn dm_state_is_complete_only_for_complete_variant() {
+        assert!(DomainMetadataState::Complete(HashMap::new()).is_complete());
+        assert!(!DomainMetadataState::Partial(HashMap::new()).is_complete());
+        assert!(!DomainMetadataState::default().is_complete());
+    }
+
+    #[test]
+    fn dm_state_default_is_empty_partial() {
+        assert_eq!(
+            DomainMetadataState::default(),
+            DomainMetadataState::Partial(HashMap::new())
         );
     }
 }

--- a/kernel/src/crc/state.rs
+++ b/kernel/src/crc/state.rs
@@ -6,8 +6,7 @@
 //! degraded state because the field does not exist there.
 //!
 //! - [`FileStatsState`] tracks file-stat validity (Complete / Indeterminate / Untrackable).
-//! - [`DomainMetadataState`] tracks domain-metadata completeness (Complete / Partial). A
-//!   follow-up PR adds `SetTransactionState` with the same shape.
+//! - [`DomainMetadataState`] tracks domain-metadata completeness (Complete / Partial).
 
 use std::collections::HashMap;
 
@@ -93,19 +92,6 @@ impl Default for DomainMetadataState {
     }
 }
 
-impl DomainMetadataState {
-    /// Returns the underlying map. Both variants own one.
-    pub fn data(&self) -> &HashMap<String, DomainMetadata> {
-        match self {
-            Self::Complete(map) | Self::Partial(map) => map,
-        }
-    }
-
-    pub fn is_complete(&self) -> bool {
-        matches!(self, Self::Complete(_))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -166,24 +152,6 @@ mod tests {
     }
 
     // ===== DomainMetadataState =====
-
-    #[test]
-    fn dm_state_data_accessor_returns_underlying_map_for_both_variants() {
-        let map = HashMap::from([(
-            "d".to_string(),
-            DomainMetadata::new("d".to_string(), "{}".to_string()),
-        )]);
-        assert_eq!(DomainMetadataState::Complete(map.clone()).data().len(), 1);
-        assert_eq!(DomainMetadataState::Partial(map).data().len(), 1);
-        assert_eq!(DomainMetadataState::default().data().len(), 0);
-    }
-
-    #[test]
-    fn dm_state_is_complete_only_for_complete_variant() {
-        assert!(DomainMetadataState::Complete(HashMap::new()).is_complete());
-        assert!(!DomainMetadataState::Partial(HashMap::new()).is_complete());
-        assert!(!DomainMetadataState::default().is_complete());
-    }
 
     #[test]
     fn dm_state_default_is_empty_partial() {

--- a/kernel/src/crc/state.rs
+++ b/kernel/src/crc/state.rs
@@ -5,7 +5,7 @@
 //! invalid reads unrepresentable: the compiler prevents reading an absolute count from a
 //! degraded state because the field does not exist there.
 //!
-//! - [`FileStatsState`] tracks file-stat validity (Complete / Indeterminate / Untrackable).
+//! - [`FileStatsState`] tracks file-stat validity (Complete / Indeterminate).
 //! - [`DomainMetadataState`] tracks domain-metadata completeness (Complete / Partial).
 //!
 //! TODO: introduce `SetTransactionState` with the same shape as `DomainMetadataState`.

--- a/kernel/src/crc/writer.rs
+++ b/kernel/src/crc/writer.rs
@@ -213,26 +213,4 @@ mod tests {
         let result = try_write_crc_file(&engine, crc_path.location.as_url(), &crc);
         assert!(matches!(result, Err(Error::ChecksumWriteUnsupported(_))));
     }
-
-    #[test]
-    fn test_write_with_partial_dm_succeeds_and_persists_no_dm_field() {
-        let store = Arc::new(InMemory::new());
-        let engine = SyncEngine::new_with_store(store.clone());
-        let table_root = url::Url::parse("memory:///test_table/").unwrap();
-        let path = ParsedLogPath::create_parsed_crc(&table_root, 0);
-
-        let mut crc = test_crc();
-        crc.domain_metadata_state = DomainMetadataState::Partial(HashMap::from([(
-            "k".to_string(),
-            DomainMetadata::new("k".to_string(), "v".to_string()),
-        )]));
-
-        try_write_crc_file(&engine, path.location.as_url(), &crc).unwrap();
-
-        let read_back = try_read_crc_file(&engine, &path).unwrap();
-        assert_eq!(
-            read_back.domain_metadata_state,
-            DomainMetadataState::Partial(HashMap::new())
-        );
-    }
 }

--- a/kernel/src/crc/writer.rs
+++ b/kernel/src/crc/writer.rs
@@ -214,10 +214,6 @@ mod tests {
         assert!(matches!(result, Err(Error::ChecksumWriteUnsupported(_))));
     }
 
-    /// Pins the current writer contract: a `Partial` DM does NOT block the write. The CRC
-    /// lands on disk with `domainMetadata` absent (Partial is non-authoritative, so the
-    /// serializer drops it), and the next read deserializes back to `Partial(empty)`.
-    /// Any future change that gates writes on DM completeness must update this test.
     #[test]
     fn test_write_with_partial_dm_succeeds_and_persists_no_dm_field() {
         let store = Arc::new(InMemory::new());

--- a/kernel/src/crc/writer.rs
+++ b/kernel/src/crc/writer.rs
@@ -213,4 +213,30 @@ mod tests {
         let result = try_write_crc_file(&engine, crc_path.location.as_url(), &crc);
         assert!(matches!(result, Err(Error::ChecksumWriteUnsupported(_))));
     }
+
+    /// Pins the current writer contract: a `Partial` DM does NOT block the write. The CRC
+    /// lands on disk with `domainMetadata` absent (Partial is non-authoritative, so the
+    /// serializer drops it), and the next read deserializes back to `Partial(empty)`.
+    /// Any future change that gates writes on DM completeness must update this test.
+    #[test]
+    fn test_write_with_partial_dm_succeeds_and_persists_no_dm_field() {
+        let store = Arc::new(InMemory::new());
+        let engine = SyncEngine::new_with_store(store.clone());
+        let table_root = url::Url::parse("memory:///test_table/").unwrap();
+        let path = ParsedLogPath::create_parsed_crc(&table_root, 0);
+
+        let mut crc = test_crc();
+        crc.domain_metadata_state = DomainMetadataState::Partial(HashMap::from([(
+            "k".to_string(),
+            DomainMetadata::new("k".to_string(), "v".to_string()),
+        )]));
+
+        try_write_crc_file(&engine, path.location.as_url(), &crc).unwrap();
+
+        let read_back = try_read_crc_file(&engine, &path).unwrap();
+        assert_eq!(
+            read_back.domain_metadata_state,
+            DomainMetadataState::Partial(HashMap::new())
+        );
+    }
 }

--- a/kernel/src/crc/writer.rs
+++ b/kernel/src/crc/writer.rs
@@ -36,7 +36,7 @@ mod tests {
     use super::*;
     use crate::actions::{DomainMetadata, Protocol, SetTransaction};
     use crate::crc::reader::try_read_crc_file;
-    use crate::crc::{FileSizeHistogram, FileStats, FileStatsState};
+    use crate::crc::{DomainMetadataState, FileSizeHistogram, FileStats, FileStatsState};
     use crate::engine::sync::SyncEngine;
     use crate::object_store::memory::InMemory;
     use crate::path::{AsUrl, ParsedLogPath};
@@ -83,7 +83,7 @@ mod tests {
             txn_id: None,
             in_commit_timestamp_opt: Some(ict),
             set_transactions: Some(set_transactions),
-            domain_metadata: Some(domain_metadata),
+            domain_metadata_state: DomainMetadataState::Complete(domain_metadata),
             ..Default::default()
         }
     }

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -18,7 +18,7 @@ use crate::clustering::{parse_clustering_columns, CLUSTERING_DOMAIN_NAME};
 use crate::committer::{Committer, PublishMetadata};
 #[cfg(any(test, feature = "test-utils"))]
 use crate::crc::Crc;
-use crate::crc::{try_write_crc_file, CrcDelta, FileStats, LazyCrc};
+use crate::crc::{try_write_crc_file, CrcDelta, DomainMetadataState, FileStats, LazyCrc};
 use crate::expressions::ColumnName;
 use crate::incremental_scan::IncrementalScanBuilder;
 use crate::log_segment::{DomainMetadataMap, LogSegment};
@@ -1015,11 +1015,9 @@ impl Snapshot {
         }
     }
 
-    /// Load domain metadata from this snapshot. If `domains` is `Some`, only load the specified
-    /// domains (with early termination). If `None`, load all domains.
-    ///
-    /// This is the single entry point for all domain metadata reads on a snapshot. All public
-    /// and internal domain metadata APIs delegate to this method.
+    /// Load domain metadata: if Complete in the CRC, answer from the cache; else if every
+    /// requested domain is in a Partial cache, also answer from the cache; else full log
+    /// replay. `domains == None` means load all.
     #[internal_api]
     pub(crate) fn get_domain_metadatas_internal(
         &self,
@@ -1031,18 +1029,40 @@ impl Snapshot {
             .lazy_crc
             .get_or_load_if_at_version(engine, self.version())
         {
-            if let Some(dm_map) = &crc.domain_metadata {
-                return Ok(match domains {
-                    None => dm_map.clone(),
-                    Some(filter) => dm_map
-                        .iter()
-                        .filter(|(k, _)| filter.contains(k.as_str()))
-                        .map(|(k, v)| (k.clone(), v.clone()))
-                        .collect(),
-                });
+            match &crc.domain_metadata_state {
+                DomainMetadataState::Complete(map) => {
+                    return Ok(match domains {
+                        None => map.clone(),
+                        // Look up each filter key. A miss means the domain does not exist
+                        // at this version (Complete is authoritative for misses), so skip
+                        // it and return whatever hits we found.
+                        Some(filter) => filter
+                            .iter()
+                            .filter_map(|&k| map.get(k).map(|v| (k.to_string(), v.clone())))
+                            .collect(),
+                    });
+                }
+                DomainMetadataState::Partial(map) => {
+                    if let Some(filter) = domains {
+                        // Look up each filter key. A miss means we do not know whether the
+                        // domain exists, so abandon the cache and fall through to log
+                        // replay. `collect::<Option<_>>` short-circuits on the first None.
+                        let hits: Option<DomainMetadataMap> = filter
+                            .iter()
+                            .map(|&k| map.get(k).map(|v| (k.to_string(), v.clone())))
+                            .collect();
+                        if let Some(hits) = hits {
+                            return Ok(hits);
+                        }
+                    }
+                }
             }
         }
-        // Fallback: full log replay.
+        // Fallback: scan the log_segment from scratch.
+        // TODO: a Partial cache already covers the commits read during snapshot load. A
+        //       miss search could skip that range and only scan the older commits, then
+        //       union those results with the Partial cache's entries to produce the final
+        //       answer.
         self.log_segment().scan_domain_metadatas(domains, engine)
     }
 

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -1047,6 +1047,9 @@ impl Snapshot {
                         // Look up each filter key. A miss means we do not know whether the
                         // domain exists, so abandon the cache and fall through to log
                         // replay. `collect::<Option<_>>` short-circuits on the first None.
+                        // TODO(#2572): track tombstoned domains in `Partial` so removals
+                        //              observed during apply can return authoritative
+                        //              `None` instead of falling through.
                         let hits: Option<DomainMetadataMap> = filter
                             .iter()
                             .map(|&k| map.get(k).map(|v| (k.to_string(), v.clone())))

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -1,5 +1,6 @@
 //! Integration tests for CRC (version checksum) file-based APIs on Snapshot.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -123,7 +124,8 @@ async fn test_get_current_crc_if_loaded_returns_loaded_crc() -> DeltaResult<()> 
     assert_eq!(crc.metadata, *snapshot.table_configuration().metadata());
 
     // Domain metadata
-    let dms = crc.domain_metadata.as_ref().unwrap();
+    assert!(crc.domain_metadata_state.is_complete());
+    let dms = crc.domain_metadata_state.data();
     assert_eq!(dms.len(), 3);
     assert!(dms.contains_key("delta.clustering"));
     assert!(dms.contains_key("delta.rowTracking"));
@@ -191,7 +193,7 @@ async fn test_create_table_produces_post_commit_crc() -> DeltaResult<()> {
     assert_eq!(file_stats.table_size_bytes(), 0);
     assert_eq!(crc.protocol, *snapshot.table_configuration().protocol());
     assert_eq!(crc.metadata, *snapshot.table_configuration().metadata());
-    let dms = crc.domain_metadata.as_ref().unwrap();
+    let dms = crc.domain_metadata_state.data();
     assert_eq!(dms["zip"].configuration(), "zap0");
 
     Ok(())
@@ -330,7 +332,7 @@ async fn test_post_commit_crc_tracks_domain_metadata_changes() -> DeltaResult<()
 
     // ===== THEN: should have CRC at v0 with zip -> zap0 =====
     let crc_v0 = write_and_verify_crc(snapshot_v0, &table_path, engine.as_ref());
-    let dms = crc_v0.domain_metadata.as_ref().unwrap();
+    let dms = crc_v0.domain_metadata_state.data();
     assert_eq!(dms["zip"].configuration(), "zap0");
 
     // ===== WHEN: update zip -> zap1, add foo -> bar =====
@@ -343,7 +345,7 @@ async fn test_post_commit_crc_tracks_domain_metadata_changes() -> DeltaResult<()
     // ===== THEN: should have CRC at v1 with zip -> zap1, foo -> bar =====
     let snapshot_v1 = committed.post_commit_snapshot().unwrap();
     let crc_v1 = write_and_verify_crc(snapshot_v1, &table_path, engine.as_ref());
-    let dms = crc_v1.domain_metadata.as_ref().unwrap();
+    let dms = crc_v1.domain_metadata_state.data();
     assert_eq!(dms["zip"].configuration(), "zap1"); // <-- must be zap1
     assert_eq!(dms["foo"].configuration(), "bar"); // <-- must be bar
 
@@ -356,7 +358,7 @@ async fn test_post_commit_crc_tracks_domain_metadata_changes() -> DeltaResult<()
     // ===== THEN: should have CRC at v2 with zip gone, foo still there =====
     let snapshot_v2 = committed.post_commit_snapshot().unwrap();
     let crc_v2 = write_and_verify_crc(snapshot_v2, &table_path, engine.as_ref());
-    let dms = crc_v2.domain_metadata.as_ref().unwrap();
+    let dms = crc_v2.domain_metadata_state.data();
     assert!(!dms.contains_key("zip")); // <-- must be gone
     assert_eq!(dms["foo"].configuration(), "bar"); // <-- must still be bar
 
@@ -639,7 +641,11 @@ async fn test_write_checksum_with_no_dms_writes_empty_list(
         .get_all_domain_metadata(engine.as_ref())?
         .is_empty());
     let crc = write_and_verify_crc(snapshot, &table_path, engine.as_ref());
-    assert_eq!(crc.domain_metadata, Some(Default::default()));
+    // CREATE TABLE without any DM actions produces an authoritative empty map.
+    assert_eq!(
+        crc.domain_metadata_state,
+        delta_kernel::crc::DomainMetadataState::Complete(HashMap::new())
+    );
 
     Ok(())
 }
@@ -692,6 +698,11 @@ async fn test_get_domain_metadata_with_crc_skips_log_replay() -> DeltaResult<()>
             snapshot.get_domain_metadata("foo", engine).unwrap(),
             Some("bar".to_string())
         );
+        // Miss on a Complete cache: served as authoritative None without log replay.
+        assert_eq!(
+            snapshot.get_domain_metadata("nonexistent", engine).unwrap(),
+            None
+        );
         assert!(snapshot
             .get_domain_metadata_internal("delta.clustering", engine)
             .unwrap()
@@ -729,6 +740,86 @@ async fn test_get_domain_metadata_with_crc_skips_log_replay() -> DeltaResult<()>
         .get_current_crc_if_loaded_for_testing()
         .is_some());
     assert_domain_metadata(&fresh_snapshot_with_crc, &FailingEngine);
+
+    Ok(())
+}
+
+/// Rewrites the on-disk CRC at `version` with its `domainMetadata` field stripped, leaving
+/// every other field (notably protocol and metadata) intact.
+fn strip_dm_from_crc(table_path: &str, version: u64) {
+    let crc_path = format!(
+        "{}/_delta_log/{:020}.crc",
+        table_path.trim_end_matches('/'),
+        version
+    );
+    let bytes = std::fs::read(&crc_path).unwrap();
+    let mut value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    value.as_object_mut().unwrap().remove("domainMetadata");
+    std::fs::write(&crc_path, serde_json::to_vec(&value).unwrap()).unwrap();
+}
+
+#[tokio::test]
+async fn test_partial_dm_serves_hits_and_falls_through_for_misses() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    // v0: CREATE TABLE with zip -> zap0 (post-commit writes CRC with full DM).
+    let committed = create_table_and_commit(&table_path, engine.as_ref())?;
+    let snapshot_v0_orig = committed.post_commit_snapshot().unwrap();
+    snapshot_v0_orig.write_checksum(engine.as_ref())?;
+
+    // Strip DM from v0 CRC, then reload: base snapshot has `Partial(empty)` DM rather than
+    // the post-commit `Complete(...)` state.
+    strip_dm_from_crc(&table_path, 0);
+    let snapshot_v0 = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert_eq!(
+        snapshot_v0
+            .get_current_crc_if_loaded_for_testing()
+            .unwrap()
+            .domain_metadata_state,
+        delta_kernel::crc::DomainMetadataState::Partial(HashMap::new())
+    );
+
+    // v1: post-commit chain accumulates DM into `Partial(map)`.
+    let committed = begin_transaction(snapshot_v0.clone(), engine.as_ref())?
+        .with_operation("WRITE".to_string())
+        .with_domain_metadata("foo".to_string(), "bar".to_string())
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+    let snapshot_v1 = committed.post_commit_snapshot().unwrap();
+
+    let crc_v1 = snapshot_v1.get_current_crc_if_loaded_for_testing().unwrap();
+    assert!(matches!(
+        crc_v1.domain_metadata_state,
+        delta_kernel::crc::DomainMetadataState::Partial(_)
+    ));
+    assert!(crc_v1.domain_metadata_state.data().contains_key("foo"));
+
+    // Hit: "foo" is in the Partial cache, so served without log replay.
+    assert_eq!(
+        snapshot_v1.get_domain_metadata("foo", &FailingEngine)?,
+        Some("bar".to_string())
+    );
+
+    // Miss on a domain present in older commits: "zip" is NOT in this Partial cache; falls
+    // through to log replay, which returns the entry from v0.
+    assert_eq!(
+        snapshot_v1.get_domain_metadata("zip", engine.as_ref())?,
+        Some("zap0".to_string())
+    );
+
+    // Miss on a domain that does not exist anywhere: falls through, returns None.
+    assert_eq!(
+        snapshot_v1.get_domain_metadata("nonexistent", engine.as_ref())?,
+        None
+    );
+
+    // "All" queries against Partial always fall through. The replay-derived set must
+    // include BOTH entries.
+    let mut all = snapshot_v1.get_all_domain_metadata(engine.as_ref())?;
+    all.sort_by(|a, b| a.domain().cmp(b.domain()));
+    assert_eq!(all.len(), 2);
+    assert_eq!(all[0].domain(), "foo");
+    assert_eq!(all[1].domain(), "zip");
 
     Ok(())
 }

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -124,9 +124,7 @@ async fn test_get_current_crc_if_loaded_returns_loaded_crc() -> DeltaResult<()> 
     assert_eq!(crc.metadata, *snapshot.table_configuration().metadata());
 
     // Domain metadata
-    let DomainMetadataState::Complete(dms) = &crc.domain_metadata_state else {
-        panic!("expected Complete, got {:?}", crc.domain_metadata_state);
-    };
+    let dms = crc.domain_metadata_state.expect_complete();
     assert_eq!(dms.len(), 3);
     assert!(dms.contains_key("delta.clustering"));
     assert!(dms.contains_key("delta.rowTracking"));
@@ -194,9 +192,7 @@ async fn test_create_table_produces_post_commit_crc() -> DeltaResult<()> {
     assert_eq!(file_stats.table_size_bytes(), 0);
     assert_eq!(crc.protocol, *snapshot.table_configuration().protocol());
     assert_eq!(crc.metadata, *snapshot.table_configuration().metadata());
-    let DomainMetadataState::Complete(dms) = &crc.domain_metadata_state else {
-        panic!("expected Complete, got {:?}", crc.domain_metadata_state);
-    };
+    let dms = crc.domain_metadata_state.expect_complete();
     assert_eq!(dms["zip"].configuration(), "zap0");
 
     Ok(())
@@ -335,9 +331,7 @@ async fn test_post_commit_crc_tracks_domain_metadata_changes() -> DeltaResult<()
 
     // ===== THEN: should have CRC at v0 with zip -> zap0 =====
     let crc_v0 = write_and_verify_crc(snapshot_v0, &table_path, engine.as_ref());
-    let DomainMetadataState::Complete(dms) = &crc_v0.domain_metadata_state else {
-        panic!("expected Complete, got {:?}", crc_v0.domain_metadata_state);
-    };
+    let dms = crc_v0.domain_metadata_state.expect_complete();
     assert_eq!(dms["zip"].configuration(), "zap0");
 
     // ===== WHEN: update zip -> zap1, add foo -> bar =====
@@ -350,9 +344,7 @@ async fn test_post_commit_crc_tracks_domain_metadata_changes() -> DeltaResult<()
     // ===== THEN: should have CRC at v1 with zip -> zap1, foo -> bar =====
     let snapshot_v1 = committed.post_commit_snapshot().unwrap();
     let crc_v1 = write_and_verify_crc(snapshot_v1, &table_path, engine.as_ref());
-    let DomainMetadataState::Complete(dms) = &crc_v1.domain_metadata_state else {
-        panic!("expected Complete, got {:?}", crc_v1.domain_metadata_state);
-    };
+    let dms = crc_v1.domain_metadata_state.expect_complete();
     assert_eq!(dms["zip"].configuration(), "zap1"); // <-- must be zap1
     assert_eq!(dms["foo"].configuration(), "bar"); // <-- must be bar
 
@@ -365,9 +357,7 @@ async fn test_post_commit_crc_tracks_domain_metadata_changes() -> DeltaResult<()
     // ===== THEN: should have CRC at v2 with zip gone, foo still there =====
     let snapshot_v2 = committed.post_commit_snapshot().unwrap();
     let crc_v2 = write_and_verify_crc(snapshot_v2, &table_path, engine.as_ref());
-    let DomainMetadataState::Complete(dms) = &crc_v2.domain_metadata_state else {
-        panic!("expected Complete, got {:?}", crc_v2.domain_metadata_state);
-    };
+    let dms = crc_v2.domain_metadata_state.expect_complete();
     assert!(!dms.contains_key("zip")); // <-- must be gone
     assert_eq!(dms["foo"].configuration(), "bar"); // <-- must still be bar
 
@@ -797,9 +787,7 @@ async fn test_partial_dm_serves_hits_and_falls_through_for_misses() -> DeltaResu
     let snapshot_v1 = committed.post_commit_snapshot().unwrap();
 
     let crc_v1 = snapshot_v1.get_current_crc_if_loaded_for_testing().unwrap();
-    let DomainMetadataState::Partial(map) = &crc_v1.domain_metadata_state else {
-        panic!("expected Partial, got {:?}", crc_v1.domain_metadata_state);
-    };
+    let map = crc_v1.domain_metadata_state.expect_partial();
     assert!(map.contains_key("foo"));
 
     // Hit: "foo" is in the Partial cache, so served without log replay.

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use delta_kernel::arrow::array::{ArrayRef, Int32Array, StringArray};
 use delta_kernel::committer::FileSystemCommitter;
-use delta_kernel::crc::Crc;
+use delta_kernel::crc::{Crc, DomainMetadataState};
 use delta_kernel::engine::default::DefaultEngineBuilder;
 use delta_kernel::object_store::local::LocalFileSystem;
 use delta_kernel::schema::{DataType, StructField, StructType};
@@ -124,8 +124,9 @@ async fn test_get_current_crc_if_loaded_returns_loaded_crc() -> DeltaResult<()> 
     assert_eq!(crc.metadata, *snapshot.table_configuration().metadata());
 
     // Domain metadata
-    assert!(crc.domain_metadata_state.is_complete());
-    let dms = crc.domain_metadata_state.data();
+    let DomainMetadataState::Complete(dms) = &crc.domain_metadata_state else {
+        panic!("expected Complete, got {:?}", crc.domain_metadata_state);
+    };
     assert_eq!(dms.len(), 3);
     assert!(dms.contains_key("delta.clustering"));
     assert!(dms.contains_key("delta.rowTracking"));
@@ -193,7 +194,9 @@ async fn test_create_table_produces_post_commit_crc() -> DeltaResult<()> {
     assert_eq!(file_stats.table_size_bytes(), 0);
     assert_eq!(crc.protocol, *snapshot.table_configuration().protocol());
     assert_eq!(crc.metadata, *snapshot.table_configuration().metadata());
-    let dms = crc.domain_metadata_state.data();
+    let DomainMetadataState::Complete(dms) = &crc.domain_metadata_state else {
+        panic!("expected Complete, got {:?}", crc.domain_metadata_state);
+    };
     assert_eq!(dms["zip"].configuration(), "zap0");
 
     Ok(())
@@ -332,7 +335,9 @@ async fn test_post_commit_crc_tracks_domain_metadata_changes() -> DeltaResult<()
 
     // ===== THEN: should have CRC at v0 with zip -> zap0 =====
     let crc_v0 = write_and_verify_crc(snapshot_v0, &table_path, engine.as_ref());
-    let dms = crc_v0.domain_metadata_state.data();
+    let DomainMetadataState::Complete(dms) = &crc_v0.domain_metadata_state else {
+        panic!("expected Complete, got {:?}", crc_v0.domain_metadata_state);
+    };
     assert_eq!(dms["zip"].configuration(), "zap0");
 
     // ===== WHEN: update zip -> zap1, add foo -> bar =====
@@ -345,7 +350,9 @@ async fn test_post_commit_crc_tracks_domain_metadata_changes() -> DeltaResult<()
     // ===== THEN: should have CRC at v1 with zip -> zap1, foo -> bar =====
     let snapshot_v1 = committed.post_commit_snapshot().unwrap();
     let crc_v1 = write_and_verify_crc(snapshot_v1, &table_path, engine.as_ref());
-    let dms = crc_v1.domain_metadata_state.data();
+    let DomainMetadataState::Complete(dms) = &crc_v1.domain_metadata_state else {
+        panic!("expected Complete, got {:?}", crc_v1.domain_metadata_state);
+    };
     assert_eq!(dms["zip"].configuration(), "zap1"); // <-- must be zap1
     assert_eq!(dms["foo"].configuration(), "bar"); // <-- must be bar
 
@@ -358,7 +365,9 @@ async fn test_post_commit_crc_tracks_domain_metadata_changes() -> DeltaResult<()
     // ===== THEN: should have CRC at v2 with zip gone, foo still there =====
     let snapshot_v2 = committed.post_commit_snapshot().unwrap();
     let crc_v2 = write_and_verify_crc(snapshot_v2, &table_path, engine.as_ref());
-    let dms = crc_v2.domain_metadata_state.data();
+    let DomainMetadataState::Complete(dms) = &crc_v2.domain_metadata_state else {
+        panic!("expected Complete, got {:?}", crc_v2.domain_metadata_state);
+    };
     assert!(!dms.contains_key("zip")); // <-- must be gone
     assert_eq!(dms["foo"].configuration(), "bar"); // <-- must still be bar
 
@@ -644,7 +653,7 @@ async fn test_write_checksum_with_no_dms_writes_empty_list(
     // CREATE TABLE without any DM actions produces an authoritative empty map.
     assert_eq!(
         crc.domain_metadata_state,
-        delta_kernel::crc::DomainMetadataState::Complete(HashMap::new())
+        DomainMetadataState::Complete(HashMap::new())
     );
 
     Ok(())
@@ -776,7 +785,7 @@ async fn test_partial_dm_serves_hits_and_falls_through_for_misses() -> DeltaResu
             .get_current_crc_if_loaded_for_testing()
             .unwrap()
             .domain_metadata_state,
-        delta_kernel::crc::DomainMetadataState::Partial(HashMap::new())
+        DomainMetadataState::Partial(HashMap::new())
     );
 
     // v1: post-commit chain accumulates DM into `Partial(map)`.
@@ -788,11 +797,10 @@ async fn test_partial_dm_serves_hits_and_falls_through_for_misses() -> DeltaResu
     let snapshot_v1 = committed.post_commit_snapshot().unwrap();
 
     let crc_v1 = snapshot_v1.get_current_crc_if_loaded_for_testing().unwrap();
-    assert!(matches!(
-        crc_v1.domain_metadata_state,
-        delta_kernel::crc::DomainMetadataState::Partial(_)
-    ));
-    assert!(crc_v1.domain_metadata_state.data().contains_key("foo"));
+    let DomainMetadataState::Partial(map) = &crc_v1.domain_metadata_state else {
+        panic!("expected Partial, got {:?}", crc_v1.domain_metadata_state);
+    };
+    assert!(map.contains_key("foo"));
 
     // Hit: "foo" is in the Partial cache, so served without log replay.
     assert_eq!(

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -1,6 +1,6 @@
 //! Integration tests for CRC (version checksum) file-based APIs on Snapshot.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -796,18 +796,31 @@ async fn test_partial_dm_serves_hits_and_falls_through_for_misses() -> DeltaResu
         Some("bar".to_string())
     );
 
-    // Miss on a domain present in older commits: "zip" is NOT in this Partial cache; falls
-    // through to log replay, which returns the entry from v0.
+    // Miss: "zip" is not in this Partial cache; FailingEngine panics, real engine finds it.
+    assert!(
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            snapshot_v1.get_domain_metadata("zip", &FailingEngine).ok()
+        }))
+        .is_err()
+    );
     assert_eq!(
         snapshot_v1.get_domain_metadata("zip", engine.as_ref())?,
         Some("zap0".to_string())
     );
 
-    // Miss on a domain that does not exist anywhere: falls through, returns None.
+    // Miss on a nonexistent domain falls through and returns None.
     assert_eq!(
         snapshot_v1.get_domain_metadata("nonexistent", engine.as_ref())?,
         None
     );
+
+    // Multi-key filter with a mixed hit ("foo") and miss ("zip"): the first miss
+    // short-circuits the cache lookup and the full result comes from log replay.
+    let filter = HashSet::from(["foo", "zip"]);
+    let map = snapshot_v1.get_domain_metadatas_internal(engine.as_ref(), Some(&filter))?;
+    assert_eq!(map.len(), 2);
+    assert_eq!(map["foo"].configuration(), "bar");
+    assert_eq!(map["zip"].configuration(), "zap0");
 
     // "All" queries against Partial always fall through. The replay-derived set must
     // include BOTH entries.

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -797,12 +797,10 @@ async fn test_partial_dm_serves_hits_and_falls_through_for_misses() -> DeltaResu
     );
 
     // Miss: "zip" is not in this Partial cache; FailingEngine panics, real engine finds it.
-    assert!(
-        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            snapshot_v1.get_domain_metadata("zip", &FailingEngine).ok()
-        }))
-        .is_err()
-    );
+    assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        snapshot_v1.get_domain_metadata("zip", &FailingEngine).ok()
+    }))
+    .is_err());
     assert_eq!(
         snapshot_v1.get_domain_metadata("zip", engine.as_ref())?,
         Some("zap0".to_string())


### PR DESCRIPTION
See tracking issue https://github.com/delta-io/delta-kernel-rs/issues/1781.

## What changes are proposed in this pull request?

Refactor `CRC.domain_metadata` (an optional HashMap) into a `DomainMetadataState` enum that has `Complete(data)` and `Partial(data)` enums.

This will be useful when we fully build incremental CRC replay:
- Suppose latest version is 100 and we have a stale CRC at 90
- DMs absent from base CRC? -- then we have the partial set of any DMs from 91 until 100
- DMs present in base CRC? -- then we have the complete set of DMs at the table as of 90 + all DMs from 91 until 100

Misc. refactors and cleanup along the way

## How was this change tested?

Primarily just a refactor. A few new UTs for the partial case that we now support.
