### PR TITLE
refactor: introduce SetTransactionState typed enum

### DIFF
--- a/kernel/src/crc/delta.rs
+++ b/kernel/src/crc/delta.rs
@@ -16,7 +16,9 @@
 use tracing::warn;
 
 use super::file_stats::FileStatsDelta;
-use super::{Crc, DomainMetadataState, FileSizeHistogram, FileStats, FileStatsState};
+use super::{
+    Crc, DomainMetadataState, FileSizeHistogram, FileStats, FileStatsState, SetTransactionState,
+};
 use crate::actions::{DomainMetadata, Metadata, Protocol, SetTransaction};
 
 /// The CRC-relevant changes ("delta") from a single commit. Produced either by reading a
@@ -31,8 +33,7 @@ pub(crate) struct CrcDelta {
     pub(crate) metadata: Option<Metadata>,
     /// All DM actions in this commit, including tombstones (`removed=true`).
     pub(crate) domain_metadata_changes: Vec<DomainMetadata>,
-    /// All SetTransaction actions in this commit. `apply()` only processes these when the base
-    /// CRC's `set_transactions` is `Some` (tracked).
+    /// All [`SetTransaction`] actions in this commit.
     pub(crate) set_transaction_changes: Vec<SetTransaction>,
     /// In-commit timestamp, if present in this commit.
     pub(crate) in_commit_timestamp: Option<i64>,
@@ -61,9 +62,8 @@ impl CrcDelta {
                 .map(|dm| (dm.domain().to_string(), dm))
                 .collect(),
         );
-        // CREATE TABLE starts with a known-complete set of transactions (possibly empty),
-        // so we always track them.
-        let set_transactions = Some(
+        // CREATE TABLE starts with a known-complete set of transactions (possibly empty).
+        let set_transaction_state = SetTransactionState::Complete(
             self.set_transaction_changes
                 .into_iter()
                 .map(|txn| (txn.app_id.clone(), txn))
@@ -89,7 +89,7 @@ impl CrcDelta {
             protocol,
             metadata,
             domain_metadata_state,
-            set_transactions,
+            set_transaction_state,
             in_commit_timestamp_opt: self.in_commit_timestamp,
             ..Default::default()
         })
@@ -98,10 +98,9 @@ impl CrcDelta {
 
 /// Commit delta application for [`Crc`]. See the [module-level docs](self) for details.
 impl Crc {
-    /// Apply a commit delta. Protocol, metadata, ICT, and domain metadata update
-    /// unconditionally (DM preserves its `Complete`/`Partial` variant); set transactions
-    /// update only when already tracked (`Some`); file stats follow the [`FileStatsState`]
-    /// state machine.
+    /// Apply a commit delta. Protocol, metadata, ICT, domain metadata, and set transactions
+    /// update unconditionally (each preserves its `Complete`/`Partial` variant); file stats
+    /// follow the [`FileStatsState`] state machine.
     pub(crate) fn apply(&mut self, delta: CrcDelta) {
         // Protocol and metadata: replace if present.
         if let Some(p) = delta.protocol {
@@ -125,16 +124,18 @@ impl Crc {
             }
         }
 
-        // Set transactions: upsert by app_id. Only update if the base CRC tracks set
-        // transactions (Some). If None ("not tracked"), leave it as None.
-        if let Some(map) = &mut self.set_transactions {
-            map.extend(
-                delta
-                    .set_transaction_changes
-                    .into_iter()
-                    .map(|txn| (txn.app_id.clone(), txn)),
-            );
-        }
+        // Apply the delta onto the CRC's existing map: upsert each entry (newest wins).
+        // The variant (Complete or Partial) stays the same since a delta never changes whether
+        // the base was authoritative.
+        let map = match &mut self.set_transaction_state {
+            SetTransactionState::Complete(m) | SetTransactionState::Partial(m) => m,
+        };
+        map.extend(
+            delta
+                .set_transaction_changes
+                .into_iter()
+                .map(|txn| (txn.app_id.clone(), txn)),
+        );
 
         // In-commit timestamp: unconditional replace (not guarded by `if let Some`).
         // If ICT was disabled after being enabled, the delta carries None, which correctly
@@ -210,7 +211,7 @@ mod tests {
 
     use super::*;
     use crate::actions::{DomainMetadata, Metadata, Protocol};
-    use crate::crc::FileSizeHistogram;
+    use crate::crc::{FileSizeHistogram, SetTransactionState};
 
     fn base_crc() -> Crc {
         Crc {
@@ -472,6 +473,10 @@ mod tests {
             crc.domain_metadata_state,
             DomainMetadataState::Complete(HashMap::new())
         );
+        assert_eq!(
+            crc.set_transaction_state,
+            SetTransactionState::Complete(HashMap::new())
+        );
         assert_eq!(crc.in_commit_timestamp_opt, None);
     }
 
@@ -523,9 +528,9 @@ mod tests {
     // ===== apply: set transaction tests =====
 
     #[test]
-    fn test_apply_adds_set_transaction_to_tracked_map() {
+    fn test_apply_adds_set_transaction_to_complete_map() {
         let mut crc = base_crc();
-        crc.set_transactions = Some(HashMap::new());
+        crc.set_transaction_state = SetTransactionState::Complete(HashMap::new());
         let txn = SetTransaction::new("my-app".to_string(), 1, Some(1000));
         let delta = CrcDelta {
             set_transaction_changes: vec![txn],
@@ -533,16 +538,19 @@ mod tests {
         };
         crc.apply(delta);
 
-        let map = crc.set_transactions.as_ref().unwrap();
+        let map = crc.set_transaction_state.expect_complete();
         assert_eq!(map.len(), 1);
         assert_eq!(map["my-app"].version, 1);
         assert_eq!(map["my-app"].last_updated, Some(1000));
     }
 
     #[test]
-    fn test_apply_with_untracked_set_transactions_skips_changes() {
+    fn test_apply_adds_set_transaction_to_partial_map_stays_partial() {
         let mut crc = base_crc();
-        assert!(crc.set_transactions.is_none()); // Not tracked (default)
+        assert_eq!(
+            crc.set_transaction_state,
+            SetTransactionState::Partial(HashMap::new())
+        );
         let txn = SetTransaction::new("my-app".to_string(), 1, Some(1000));
         let delta = CrcDelta {
             set_transaction_changes: vec![txn],
@@ -550,14 +558,15 @@ mod tests {
         };
         crc.apply(delta);
 
-        // set_transactions stays None -- apply() must not create a partial map.
-        assert!(crc.set_transactions.is_none());
+        let map = crc.set_transaction_state.expect_partial();
+        assert_eq!(map.len(), 1);
+        assert_eq!(map["my-app"].version, 1);
     }
 
     #[test]
-    fn test_apply_upserts_set_transaction() {
+    fn test_apply_upserts_set_transaction_in_complete_map() {
         let mut crc = base_crc();
-        crc.set_transactions = Some(HashMap::from([(
+        crc.set_transaction_state = SetTransactionState::Complete(HashMap::from([(
             "my-app".to_string(),
             SetTransaction::new("my-app".to_string(), 1, Some(1000)),
         )]));
@@ -569,10 +578,30 @@ mod tests {
         };
         crc.apply(delta);
 
-        let map = crc.set_transactions.as_ref().unwrap();
+        let map = crc.set_transaction_state.expect_complete();
         assert_eq!(map.len(), 1);
         assert_eq!(map["my-app"].version, 2);
         assert_eq!(map["my-app"].last_updated, Some(2000));
+    }
+
+    #[test]
+    fn test_apply_upserts_set_transaction_in_partial_map_stays_partial() {
+        let mut crc = base_crc();
+        crc.set_transaction_state = SetTransactionState::Partial(HashMap::from([(
+            "my-app".to_string(),
+            SetTransaction::new("my-app".to_string(), 1, Some(1000)),
+        )]));
+
+        let txn = SetTransaction::new("my-app".to_string(), 2, Some(2000));
+        let delta = CrcDelta {
+            set_transaction_changes: vec![txn],
+            ..write_delta(0, 0)
+        };
+        crc.apply(delta);
+
+        let map = crc.set_transaction_state.expect_partial();
+        assert_eq!(map.len(), 1);
+        assert_eq!(map["my-app"].version, 2);
     }
 
     // ===== into_crc_for_version_zero: set transaction tests =====
@@ -587,7 +616,7 @@ mod tests {
             ..write_delta(0, 0)
         };
         let crc = delta.into_crc_for_version_zero().unwrap();
-        let map = crc.set_transactions.as_ref().unwrap();
+        let map = crc.set_transaction_state.expect_complete();
         assert_eq!(map.len(), 1);
         assert_eq!(map["my-app"].version, 5);
         assert_eq!(map["my-app"].last_updated, Some(3000));
@@ -601,8 +630,11 @@ mod tests {
             ..write_delta(0, 0)
         };
         let crc = delta.into_crc_for_version_zero().unwrap();
-        // Empty map, not None -- we always know the full state at version zero.
-        assert_eq!(crc.set_transactions, Some(HashMap::new()));
+        // Empty Complete map -- we always know the full state at version zero.
+        assert_eq!(
+            crc.set_transaction_state,
+            SetTransactionState::Complete(HashMap::new())
+        );
     }
 
     // ===== Histogram tests =====

--- a/kernel/src/crc/delta.rs
+++ b/kernel/src/crc/delta.rs
@@ -530,81 +530,41 @@ mod tests {
 
     // ===== apply: set transaction tests =====
 
-    #[test]
-    fn test_apply_adds_set_transaction_to_complete_map() {
-        let mut crc = base_crc();
-        crc.set_transaction_state = SetTransactionState::Complete(HashMap::new());
-        let txn = SetTransaction::new("my-app".to_string(), 1, Some(1000));
-        let delta = CrcDelta {
-            set_transaction_changes: vec![txn],
-            ..write_delta(0, 0)
-        };
-        crc.apply(delta);
-
-        let map = crc.set_transaction_state.expect_complete();
-        assert_eq!(map.len(), 1);
-        assert_eq!(map["my-app"].version, 1);
-        assert_eq!(map["my-app"].last_updated, Some(1000));
+    fn seed_txn_map() -> HashMap<String, SetTransaction> {
+        HashMap::from([(
+            "existing".to_string(),
+            SetTransaction::new("existing".to_string(), 1, Some(1000)),
+        )])
     }
 
-    #[test]
-    fn test_apply_adds_set_transaction_to_partial_map_stays_partial() {
+    /// A delta carrying both an upsert and a new entry exercises all the apply semantics for
+    /// set transactions (SetTransaction has no tombstone). Applied to either `Complete` or
+    /// `Partial`, the map updates correctly and the variant is preserved.
+    #[rstest]
+    #[case::complete(SetTransactionState::Complete(seed_txn_map()))]
+    #[case::partial(SetTransactionState::Partial(seed_txn_map()))]
+    fn test_apply_upserts_and_inserts_set_transactions(#[case] base: SetTransactionState) {
+        let was_complete = matches!(base, SetTransactionState::Complete(_));
         let mut crc = base_crc();
-        assert_eq!(
-            crc.set_transaction_state,
-            SetTransactionState::Partial(HashMap::new())
-        );
-        let txn = SetTransaction::new("my-app".to_string(), 1, Some(1000));
+        crc.set_transaction_state = base;
         let delta = CrcDelta {
-            set_transaction_changes: vec![txn],
+            set_transaction_changes: vec![
+                SetTransaction::new("existing".to_string(), 2, Some(2000)),
+                SetTransaction::new("new".to_string(), 1, Some(1500)),
+            ],
             ..write_delta(0, 0)
         };
         crc.apply(delta);
 
-        let map = crc.set_transaction_state.expect_partial();
-        assert_eq!(map.len(), 1);
-        assert_eq!(map["my-app"].version, 1);
-    }
-
-    #[test]
-    fn test_apply_upserts_set_transaction_in_complete_map() {
-        let mut crc = base_crc();
-        crc.set_transaction_state = SetTransactionState::Complete(HashMap::from([(
-            "my-app".to_string(),
-            SetTransaction::new("my-app".to_string(), 1, Some(1000)),
-        )]));
-
-        let txn = SetTransaction::new("my-app".to_string(), 2, Some(2000));
-        let delta = CrcDelta {
-            set_transaction_changes: vec![txn],
-            ..write_delta(0, 0)
+        let map = match &crc.set_transaction_state {
+            SetTransactionState::Complete(m) if was_complete => m,
+            SetTransactionState::Partial(m) if !was_complete => m,
+            other => panic!("variant changed unexpectedly: {other:?}"),
         };
-        crc.apply(delta);
-
-        let map = crc.set_transaction_state.expect_complete();
-        assert_eq!(map.len(), 1);
-        assert_eq!(map["my-app"].version, 2);
-        assert_eq!(map["my-app"].last_updated, Some(2000));
-    }
-
-    #[test]
-    fn test_apply_upserts_set_transaction_in_partial_map_stays_partial() {
-        let mut crc = base_crc();
-        crc.set_transaction_state = SetTransactionState::Partial(HashMap::from([(
-            "my-app".to_string(),
-            SetTransaction::new("my-app".to_string(), 1, Some(1000)),
-        )]));
-
-        let txn = SetTransaction::new("my-app".to_string(), 2, Some(2000));
-        let delta = CrcDelta {
-            set_transaction_changes: vec![txn],
-            ..write_delta(0, 0)
-        };
-        crc.apply(delta);
-
-        let map = crc.set_transaction_state.expect_partial();
-        assert_eq!(map.len(), 1);
-        assert_eq!(map["my-app"].version, 2);
+        assert_eq!(map.len(), 2);
+        assert_eq!(map["existing"].version, 2);
+        assert_eq!(map["existing"].last_updated, Some(2000));
+        assert_eq!(map["new"].version, 1);
     }
 
     // ===== into_crc_for_version_zero: set transaction tests =====
@@ -623,21 +583,6 @@ mod tests {
         assert_eq!(map.len(), 1);
         assert_eq!(map["my-app"].version, 5);
         assert_eq!(map["my-app"].last_updated, Some(3000));
-    }
-
-    #[test]
-    fn test_into_crc_for_version_zero_with_no_set_transactions() {
-        let delta = CrcDelta {
-            protocol: Some(test_protocol()),
-            metadata: Some(Metadata::default()),
-            ..write_delta(0, 0)
-        };
-        let crc = delta.into_crc_for_version_zero().unwrap();
-        // Empty Complete map -- we always know the full state at version zero.
-        assert_eq!(
-            crc.set_transaction_state,
-            SetTransactionState::Complete(HashMap::new())
-        );
     }
 
     // ===== Histogram tests =====

--- a/kernel/src/crc/delta.rs
+++ b/kernel/src/crc/delta.rs
@@ -98,9 +98,12 @@ impl CrcDelta {
 
 /// Commit delta application for [`Crc`]. See the [module-level docs](self) for details.
 impl Crc {
-    /// Apply a commit delta. Protocol, metadata, ICT, domain metadata, and set transactions
-    /// update unconditionally (each preserves its `Complete`/`Partial` variant); file stats
-    /// follow the [`FileStatsState`] state machine.
+    /// Apply a commit delta.
+    /// - Protocol / metadata: replaced when present in the delta, kept otherwise.
+    /// - ICT: unconditional replace (None correctly clears a previously-enabled value).
+    /// - Domain metadata / set transactions: upserted by key into the existing map; the
+    ///   `Complete`/`Partial` variant is preserved.
+    /// - File stats: governed by the [`FileStatsState`] state machine.
     pub(crate) fn apply(&mut self, delta: CrcDelta) {
         // Protocol and metadata: replace if present.
         if let Some(p) = delta.protocol {

--- a/kernel/src/crc/mod.rs
+++ b/kernel/src/crc/mod.rs
@@ -1,12 +1,14 @@
 //! CRC (version checksum) file support.
 //!
 //! A [CRC file] contains a snapshot of table state at a specific version, which can be used to
-//! optimize log replay operations like reading Protocol/Metadata, domain metadata, and ICT.
+//! optimize log replay operations like reading Protocol/Metadata, domain metadata, set
+//! transactions, and ICT.
 //!
 //! [`Crc`] holds the in-memory state using shapes that make kernel queries easy: typed
-//! state enums (`FileStatsState`, `DomainMetadataState`) and `HashMap`s keyed by id, instead
-//! of the flat scalars and arrays of the on-disk format. It (de)serializes to/from JSON via
-//! the private `CrcRaw` serde intermediate, which mirrors the wire format exactly.
+//! state enums (`FileStatsState`, `DomainMetadataState`, `SetTransactionState`) and `HashMap`s
+//! keyed by id, instead of the flat scalars and arrays of the on-disk format. It (de)serializes
+//! to/from JSON via the private `CrcRaw` serde intermediate, which mirrors the wire format
+//! exactly.
 //!
 //! [CRC file]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#version-checksum-file
 

--- a/kernel/src/crc/mod.rs
+++ b/kernel/src/crc/mod.rs
@@ -34,7 +34,7 @@ pub(crate) use lazy::{CrcLoadResult, LazyCrc};
 pub(crate) use reader::try_read_crc_file;
 use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
-pub use state::{DomainMetadataState, FileStatsState};
+pub use state::{DomainMetadataState, FileStatsState, SetTransactionState};
 #[allow(unused)]
 pub(crate) use writer::try_write_crc_file;
 
@@ -73,15 +73,11 @@ pub struct Crc {
     // ===== Optional fields =====
     /// The in-commit timestamp of this version. Present iff In-Commit Timestamps are enabled.
     pub in_commit_timestamp_opt: Option<i64>,
-    // TODO: introduce `SetTransactionState` (Complete / Partial) to disambiguate "no
-    //       observations" from "fully tracked but empty".
-    /// Live transaction identifier ([`SetTransaction`]) actions at this version. `None` = not
-    /// tracked (field absent in CRC JSON or not computed). `Some(empty_map)` = tracked, no
-    /// active set transactions. `Crc::apply` skips updates when `None`.
-    ///
-    /// Stored as a HashMap keyed by `app_id` for efficient lookup. The CRC JSON format uses
-    /// a Vec, which is converted via the `CrcRaw` serde intermediate.
-    pub set_transactions: Option<HashMap<String, SetTransaction>>,
+    /// Active [`SetTransaction`] actions at this version, as a typed [`SetTransactionState`].
+    /// `Complete(map)` is authoritative for misses; `Partial(map)` carries known-correct entries
+    /// but requires log replay for misses. Only the `Complete` variant is persisted to the CRC
+    /// file.
+    pub set_transaction_state: SetTransactionState,
     /// Active (non-removed) [`DomainMetadata`] actions at this version, as a typed
     /// [`DomainMetadataState`]. Tombstones (`removed=true`) are never stored. `Complete(map)`
     /// is authoritative for misses; `Partial(map)` carries known-correct entries but requires
@@ -195,9 +191,14 @@ impl TryFrom<CrcRaw> for Crc {
             protocol: raw.protocol,
             file_stats_state,
             in_commit_timestamp_opt: raw.in_commit_timestamp_opt,
-            set_transactions: raw
-                .set_transactions
-                .map(|v| v.into_iter().map(|t| (t.app_id.clone(), t)).collect()),
+            // Present array (including empty `[]`) deserializes as Complete; absent or null
+            // deserializes as Partial(empty).
+            set_transaction_state: match raw.set_transactions {
+                Some(v) => SetTransactionState::Complete(
+                    v.into_iter().map(|t| (t.app_id.clone(), t)).collect(),
+                ),
+                None => SetTransactionState::Partial(HashMap::new()),
+            },
             // Present array (including empty `[]`) deserializes as Complete; absent or null
             // deserializes as Partial(empty).
             domain_metadata_state: match raw.domain_metadata {
@@ -234,10 +235,11 @@ impl TryFrom<&Crc> for CrcRaw {
             metadata: crc.metadata.clone(),
             protocol: crc.protocol.clone(),
             in_commit_timestamp_opt: crc.in_commit_timestamp_opt,
-            set_transactions: crc
-                .set_transactions
-                .as_ref()
-                .map(|m| m.values().cloned().collect()),
+            // Only `Complete` is written; `Partial` is dropped.
+            set_transactions: match &crc.set_transaction_state {
+                SetTransactionState::Complete(m) => Some(m.values().cloned().collect()),
+                SetTransactionState::Partial(_) => None,
+            },
             // Only `Complete` is written; `Partial` is dropped.
             domain_metadata: match &crc.domain_metadata_state {
                 DomainMetadataState::Complete(m) => Some(m.values().cloned().collect()),
@@ -302,17 +304,17 @@ mod tests {
 
     use rstest::rstest;
 
-    use super::{Crc, CrcRaw, DomainMetadataState, FileStats, FileStatsState};
+    use super::{Crc, CrcRaw, DomainMetadataState, FileStats, FileStatsState, SetTransactionState};
     use crate::actions::{DomainMetadata, SetTransaction};
 
-    /// Helper to create a minimal `Crc` with only set_transactions and domain_metadata_state
-    /// populated.
+    /// Helper to create a minimal `Crc` with only `set_transaction_state` and
+    /// `domain_metadata_state` populated.
     fn crc_with(
-        txns: Option<HashMap<String, SetTransaction>>,
+        set_transaction_state: SetTransactionState,
         domain_metadata_state: DomainMetadataState,
     ) -> Crc {
         Crc {
-            set_transactions: txns,
+            set_transaction_state,
             domain_metadata_state,
             ..Default::default()
         }
@@ -346,7 +348,8 @@ mod tests {
 
         let crc: Crc = serde_json::from_str(json).unwrap();
 
-        let txns = crc.set_transactions.as_ref().unwrap();
+        // A present `setTransactions` array deserializes as `Complete` (authoritative).
+        let txns = crc.set_transaction_state.expect_complete();
         assert_eq!(txns.len(), 2);
 
         let txn1 = &txns["app-1"];
@@ -367,7 +370,7 @@ mod tests {
     }
 
     #[test]
-    fn de_null_dm_deserializes_to_partial_empty_and_null_txns_deserializes_to_none() {
+    fn de_null_dm_and_txns_deserialize_to_partial_empty() {
         let json = r#"{
             "tableSizeBytes": 0,
             "numFiles": 0,
@@ -386,7 +389,10 @@ mod tests {
             "domainMetadata": null
         }"#;
         let crc: Crc = serde_json::from_str(json).unwrap();
-        assert!(crc.set_transactions.is_none());
+        assert_eq!(
+            crc.set_transaction_state,
+            SetTransactionState::Partial(HashMap::new())
+        );
         assert_eq!(
             crc.domain_metadata_state,
             DomainMetadataState::Partial(HashMap::new())
@@ -394,7 +400,7 @@ mod tests {
     }
 
     #[test]
-    fn de_missing_dm_field_deserializes_to_partial_empty_and_missing_txns_to_none() {
+    fn de_missing_dm_and_txns_fields_deserialize_to_partial_empty() {
         let json = r#"{
             "tableSizeBytes": 0,
             "numFiles": 0,
@@ -411,7 +417,10 @@ mod tests {
             "protocol": {"minReaderVersion": 1, "minWriterVersion": 1}
         }"#;
         let crc: Crc = serde_json::from_str(json).unwrap();
-        assert!(crc.set_transactions.is_none());
+        assert_eq!(
+            crc.set_transaction_state,
+            SetTransactionState::Partial(HashMap::new())
+        );
         assert_eq!(
             crc.domain_metadata_state,
             DomainMetadataState::Partial(HashMap::new())
@@ -419,12 +428,15 @@ mod tests {
     }
 
     #[test]
-    fn ser_partial_dm_and_none_txns_serialize_to_null() {
-        let crc = crc_with(None, DomainMetadataState::Partial(HashMap::new()));
+    fn ser_partial_dm_and_partial_txns_serialize_to_null() {
+        let crc = crc_with(
+            SetTransactionState::Partial(HashMap::new()),
+            DomainMetadataState::Partial(HashMap::new()),
+        );
         let json = serde_json::to_value(&crc).unwrap();
-        assert!(json["setTransactions"].is_null());
         // Partial is not authoritative for misses; persisting it would falsely promote
         // to `Complete(empty)` on the next read.
+        assert!(json["setTransactions"].is_null());
         assert!(json["domainMetadata"].is_null());
     }
 
@@ -435,10 +447,29 @@ mod tests {
             "delta.rowTracking".to_string(),
             DomainMetadata::new("delta.rowTracking".to_string(), "{}".to_string()),
         );
-        let crc = crc_with(None, DomainMetadataState::Partial(partial));
+        let crc = crc_with(
+            SetTransactionState::Partial(HashMap::new()),
+            DomainMetadataState::Partial(partial),
+        );
         let json = serde_json::to_value(&crc).unwrap();
         // Even non-empty Partial maps drop on serialize.
         assert!(json["domainMetadata"].is_null());
+    }
+
+    #[test]
+    fn ser_non_empty_partial_txns_still_serializes_to_null() {
+        let mut partial = HashMap::new();
+        partial.insert(
+            "my-app".to_string(),
+            SetTransaction::new("my-app".to_string(), 1, None),
+        );
+        let crc = crc_with(
+            SetTransactionState::Partial(partial),
+            DomainMetadataState::Partial(HashMap::new()),
+        );
+        let json = serde_json::to_value(&crc).unwrap();
+        // Even non-empty Partial maps drop on serialize.
+        assert!(json["setTransactions"].is_null());
     }
 
     #[test]
@@ -459,7 +490,10 @@ mod tests {
             DomainMetadata::new("delta.rowTracking".to_string(), "{}".to_string()),
         );
 
-        let original = crc_with(Some(txns), DomainMetadataState::Complete(domains));
+        let original = crc_with(
+            SetTransactionState::Complete(txns),
+            DomainMetadataState::Complete(domains),
+        );
 
         let json_str = serde_json::to_string(&original).unwrap();
         let deserialized: Crc = serde_json::from_str(&json_str).unwrap();
@@ -470,7 +504,7 @@ mod tests {
     #[test]
     fn round_trip_empty_complete_dm_and_empty_txns() {
         let original = crc_with(
-            Some(HashMap::new()),
+            SetTransactionState::Complete(HashMap::new()),
             DomainMetadataState::Complete(HashMap::new()),
         );
 
@@ -492,7 +526,10 @@ mod tests {
             "delta.rowTracking".to_string(),
             DomainMetadata::new("delta.rowTracking".to_string(), "{}".to_string()),
         );
-        let original = crc_with(None, DomainMetadataState::Partial(partial));
+        let original = crc_with(
+            SetTransactionState::Partial(HashMap::new()),
+            DomainMetadataState::Partial(partial),
+        );
 
         let json_str = serde_json::to_string(&original).unwrap();
         let deserialized: Crc = serde_json::from_str(&json_str).unwrap();
@@ -500,6 +537,27 @@ mod tests {
         assert_eq!(
             deserialized.domain_metadata_state,
             DomainMetadataState::Partial(HashMap::new())
+        );
+    }
+
+    #[test]
+    fn partial_txns_written_as_null_reads_back_as_empty_partial() {
+        let mut partial = HashMap::new();
+        partial.insert(
+            "my-app".to_string(),
+            SetTransaction::new("my-app".to_string(), 7, Some(1000)),
+        );
+        let original = crc_with(
+            SetTransactionState::Partial(partial),
+            DomainMetadataState::Partial(HashMap::new()),
+        );
+
+        let json_str = serde_json::to_string(&original).unwrap();
+        let deserialized: Crc = serde_json::from_str(&json_str).unwrap();
+
+        assert_eq!(
+            deserialized.set_transaction_state,
+            SetTransactionState::Partial(HashMap::new())
         );
     }
 
@@ -542,7 +600,7 @@ mod tests {
                 table_size_bytes: 1024 * 1024,
                 file_size_histogram: None,
             }),
-            set_transactions: Some(txns),
+            set_transaction_state: SetTransactionState::Complete(txns),
             domain_metadata_state: DomainMetadataState::Complete(domains),
             ..Default::default()
         };
@@ -557,7 +615,7 @@ mod tests {
         assert_eq!(stats.num_files(), 10);
 
         // Verify all set transactions
-        let txns = deserialized.set_transactions.as_ref().unwrap();
+        let txns = deserialized.set_transaction_state.expect_complete();
         assert_eq!(txns.len(), 3);
         assert_eq!(txns["streaming-app"].version, 42);
         assert_eq!(txns["streaming-app"].last_updated, Some(1700000000));

--- a/kernel/src/crc/reader.rs
+++ b/kernel/src/crc/reader.rs
@@ -117,7 +117,7 @@ mod tests {
         assert!(dms["myApp.metadata"].configuration().contains("key"));
 
         // Verify set transactions
-        let txns = crc.set_transactions.as_ref().unwrap();
+        let txns = crc.set_transaction_state.expect_complete();
         assert_eq!(txns.len(), 2);
         assert_eq!(txns["spark-app-1"].version, 42);
         assert_eq!(txns["spark-app-1"].last_updated, Some(1694758250000));

--- a/kernel/src/crc/state.rs
+++ b/kernel/src/crc/state.rs
@@ -237,27 +237,4 @@ mod tests {
             SetTransactionState::Partial(HashMap::new())
         );
     }
-
-    #[test]
-    fn set_txn_state_complete_expect_complete_returns_map() {
-        let mut map = HashMap::new();
-        map.insert(
-            "my-app".to_string(),
-            SetTransaction::new("my-app".to_string(), 1, Some(1000)),
-        );
-        let state = SetTransactionState::Complete(map.clone());
-        assert_eq!(state.expect_complete().len(), 1);
-        assert_eq!(state.expect_complete()["my-app"].version, 1);
-    }
-
-    #[test]
-    fn set_txn_state_partial_expect_partial_returns_map() {
-        let mut map = HashMap::new();
-        map.insert(
-            "my-app".to_string(),
-            SetTransaction::new("my-app".to_string(), 2, None),
-        );
-        let state = SetTransactionState::Partial(map);
-        assert_eq!(state.expect_partial().len(), 1);
-    }
 }

--- a/kernel/src/crc/state.rs
+++ b/kernel/src/crc/state.rs
@@ -230,8 +230,6 @@ mod tests {
 
     // ===== SetTransactionState =====
 
-    use crate::actions::SetTransaction;
-
     #[test]
     fn set_txn_state_default_is_empty_partial() {
         assert_eq!(

--- a/kernel/src/crc/state.rs
+++ b/kernel/src/crc/state.rs
@@ -7,13 +7,12 @@
 //!
 //! - [`FileStatsState`] tracks file-stat validity (Complete / Indeterminate).
 //! - [`DomainMetadataState`] tracks domain-metadata completeness (Complete / Partial).
-//!
-//! TODO: introduce `SetTransactionState` with the same shape as `DomainMetadataState`.
+//! - [`SetTransactionState`] tracks set-transaction completeness (Complete / Partial).
 
 use std::collections::HashMap;
 
 use super::file_stats::FileStats;
-use crate::actions::DomainMetadata;
+use crate::actions::{DomainMetadata, SetTransaction};
 
 /// The state of file statistics for a CRC.
 ///
@@ -114,6 +113,52 @@ impl DomainMetadataState {
     }
 }
 
+// ============================================================================
+// Set transaction state
+// ============================================================================
+
+/// The completeness state of cached set transactions in a CRC.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SetTransactionState {
+    /// The CRC file had the `setTransactions` field (possibly as an empty array). The map is
+    /// the full set of active transactions at this version; an `app_id` not in the map has no
+    /// active transaction.
+    Complete(HashMap<String, SetTransaction>),
+
+    /// The CRC file did not have the `setTransactions` field. The map starts empty and gets
+    /// populated by incremental CRC replay over the JSON commits after the latest stale CRC.
+    /// Hits are authoritative (definitely present at this version); misses are NOT
+    /// (the app_id may have a transaction in older commits), so callers must do a further log
+    /// scan.
+    Partial(HashMap<String, SetTransaction>),
+}
+
+impl Default for SetTransactionState {
+    fn default() -> Self {
+        Self::Partial(HashMap::new())
+    }
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+#[allow(clippy::panic)]
+impl SetTransactionState {
+    /// Test-only: returns the map if `Complete`, panics otherwise.
+    pub fn expect_complete(&self) -> &HashMap<String, SetTransaction> {
+        match self {
+            Self::Complete(map) => map,
+            other => panic!("expected Complete, got {other:?}"),
+        }
+    }
+
+    /// Test-only: returns the map if `Partial`, panics otherwise.
+    pub fn expect_partial(&self) -> &HashMap<String, SetTransaction> {
+        match self {
+            Self::Partial(map) => map,
+            other => panic!("expected Partial, got {other:?}"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -181,5 +226,40 @@ mod tests {
             DomainMetadataState::default(),
             DomainMetadataState::Partial(HashMap::new())
         );
+    }
+
+    // ===== SetTransactionState =====
+
+    use crate::actions::SetTransaction;
+
+    #[test]
+    fn set_txn_state_default_is_empty_partial() {
+        assert_eq!(
+            SetTransactionState::default(),
+            SetTransactionState::Partial(HashMap::new())
+        );
+    }
+
+    #[test]
+    fn set_txn_state_complete_expect_complete_returns_map() {
+        let mut map = HashMap::new();
+        map.insert(
+            "my-app".to_string(),
+            SetTransaction::new("my-app".to_string(), 1, Some(1000)),
+        );
+        let state = SetTransactionState::Complete(map.clone());
+        assert_eq!(state.expect_complete().len(), 1);
+        assert_eq!(state.expect_complete()["my-app"].version, 1);
+    }
+
+    #[test]
+    fn set_txn_state_partial_expect_partial_returns_map() {
+        let mut map = HashMap::new();
+        map.insert(
+            "my-app".to_string(),
+            SetTransaction::new("my-app".to_string(), 2, None),
+        );
+        let state = SetTransactionState::Partial(map);
+        assert_eq!(state.expect_partial().len(), 1);
     }
 }

--- a/kernel/src/crc/writer.rs
+++ b/kernel/src/crc/writer.rs
@@ -36,7 +36,9 @@ mod tests {
     use super::*;
     use crate::actions::{DomainMetadata, Protocol, SetTransaction};
     use crate::crc::reader::try_read_crc_file;
-    use crate::crc::{DomainMetadataState, FileSizeHistogram, FileStats, FileStatsState};
+    use crate::crc::{
+        DomainMetadataState, FileSizeHistogram, FileStats, FileStatsState, SetTransactionState,
+    };
     use crate::engine::sync::SyncEngine;
     use crate::object_store::memory::InMemory;
     use crate::path::{AsUrl, ParsedLogPath};
@@ -82,7 +84,7 @@ mod tests {
             protocol,
             txn_id: None,
             in_commit_timestamp_opt: Some(ict),
-            set_transactions: Some(set_transactions),
+            set_transaction_state: SetTransactionState::Complete(set_transactions),
             domain_metadata_state: DomainMetadataState::Complete(domain_metadata),
             ..Default::default()
         }

--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -376,6 +376,7 @@ impl ParsedLogPath<Url> {
     }
 
     /// Create a new `ParsedLogPath<Url>` for a version checksum (CRC) file.
+    #[internal_api]
     pub(crate) fn new_crc(table_root: &Url, version: Version) -> DeltaResult<Self> {
         let filename = format!("{version:020}.crc");
         let path = Self::create_path(table_root, filename)?;

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -904,16 +904,29 @@ impl Snapshot {
         let expiration_timestamp =
             calculate_transaction_expiration_timestamp(self.table_properties())?;
 
-        // Fast path: serve from CRC if it tracks set transactions at this version.
+        // Fast path: serve from CRC if available at this version.
         if let Some(crc) = self
             .lazy_crc
             .get_or_load_if_at_version(engine, self.version())
         {
-            if let Some(txn_map) = &crc.set_transactions {
-                return Ok(txn_map
-                    .get(application_id)
-                    .filter(|txn| !is_set_txn_expired(expiration_timestamp, txn.last_updated))
-                    .map(|txn| txn.version));
+            match &crc.set_transaction_state {
+                crate::crc::SetTransactionState::Complete(map) => {
+                    // Complete is authoritative: a miss means the app_id has no transaction.
+                    return Ok(map
+                        .get(application_id)
+                        .filter(|txn| !is_set_txn_expired(expiration_timestamp, txn.last_updated))
+                        .map(|txn| txn.version));
+                }
+                crate::crc::SetTransactionState::Partial(map) => {
+                    // Hit is authoritative; miss requires log replay.
+                    if let Some(txn) = map.get(application_id) {
+                        return Ok(Some(txn)
+                            .filter(|txn| {
+                                !is_set_txn_expired(expiration_timestamp, txn.last_updated)
+                            })
+                            .map(|txn| txn.version));
+                    }
+                }
             }
         }
 

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -18,7 +18,9 @@ use crate::clustering::{parse_clustering_columns, CLUSTERING_DOMAIN_NAME};
 use crate::committer::{Committer, PublishMetadata};
 #[cfg(any(test, feature = "test-utils"))]
 use crate::crc::Crc;
-use crate::crc::{try_write_crc_file, CrcDelta, DomainMetadataState, FileStats, LazyCrc};
+use crate::crc::{
+    try_write_crc_file, CrcDelta, DomainMetadataState, FileStats, LazyCrc, SetTransactionState,
+};
 use crate::expressions::ColumnName;
 use crate::incremental_scan::IncrementalScanBuilder;
 use crate::log_segment::{DomainMetadataMap, LogSegment};
@@ -910,21 +912,19 @@ impl Snapshot {
             .get_or_load_if_at_version(engine, self.version())
         {
             match &crc.set_transaction_state {
-                crate::crc::SetTransactionState::Complete(map) => {
+                SetTransactionState::Complete(map) => {
                     // Complete is authoritative: a miss means the app_id has no transaction.
                     return Ok(map
                         .get(application_id)
                         .filter(|txn| !is_set_txn_expired(expiration_timestamp, txn.last_updated))
                         .map(|txn| txn.version));
                 }
-                crate::crc::SetTransactionState::Partial(map) => {
-                    // Hit is authoritative; miss requires log replay.
+                SetTransactionState::Partial(map) => {
+                    // Hit is authoritative; miss falls through to log replay below.
                     if let Some(txn) = map.get(application_id) {
-                        return Ok(Some(txn)
-                            .filter(|txn| {
-                                !is_set_txn_expired(expiration_timestamp, txn.last_updated)
-                            })
-                            .map(|txn| txn.version));
+                        let version = (!is_set_txn_expired(expiration_timestamp, txn.last_updated))
+                            .then_some(txn.version);
+                        return Ok(version);
                     }
                 }
             }

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -743,9 +743,9 @@ async fn test_get_domain_metadata_with_crc_skips_log_replay() -> DeltaResult<()>
     Ok(())
 }
 
-/// Rewrites the on-disk CRC at `version` with its `domainMetadata` field stripped, leaving
-/// every other field (notably protocol and metadata) intact.
-fn strip_txns_from_crc(table_path: &str, version: u64) {
+/// Rewrites the on-disk CRC at `version` to drop the named top-level field, leaving every
+/// other field intact.
+fn strip_field_from_crc(table_path: &str, version: u64, field: &str) {
     let crc_path = format!(
         "{}/_delta_log/{:020}.crc",
         table_path.trim_end_matches('/'),
@@ -753,19 +753,7 @@ fn strip_txns_from_crc(table_path: &str, version: u64) {
     );
     let bytes = std::fs::read(&crc_path).unwrap();
     let mut value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-    value.as_object_mut().unwrap().remove("setTransactions");
-    std::fs::write(&crc_path, serde_json::to_vec(&value).unwrap()).unwrap();
-}
-
-fn strip_dm_from_crc(table_path: &str, version: u64) {
-    let crc_path = format!(
-        "{}/_delta_log/{:020}.crc",
-        table_path.trim_end_matches('/'),
-        version
-    );
-    let bytes = std::fs::read(&crc_path).unwrap();
-    let mut value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-    value.as_object_mut().unwrap().remove("domainMetadata");
+    value.as_object_mut().unwrap().remove(field);
     std::fs::write(&crc_path, serde_json::to_vec(&value).unwrap()).unwrap();
 }
 
@@ -780,7 +768,7 @@ async fn test_partial_dm_serves_hits_and_falls_through_for_misses() -> DeltaResu
 
     // Strip DM from v0 CRC, then reload: base snapshot has `Partial(empty)` DM rather than
     // the post-commit `Complete(...)` state.
-    strip_dm_from_crc(&table_path, 0);
+    strip_field_from_crc(&table_path, 0, "domainMetadata");
     let snapshot_v0 = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
     assert_eq!(
         snapshot_v0
@@ -980,7 +968,7 @@ async fn test_partial_set_txn_serves_hits_and_falls_through_for_misses() -> Delt
     snapshot_v1.write_checksum(engine.as_ref())?;
 
     // Strip setTransactions from the v1 CRC so it reloads as Partial(empty).
-    strip_txns_from_crc(&table_path, 1);
+    strip_field_from_crc(&table_path, 1, "setTransactions");
 
     let snapshot_v1_reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
     assert_eq!(
@@ -1014,12 +1002,12 @@ async fn test_partial_set_txn_serves_hits_and_falls_through_for_misses() -> Delt
     );
 
     // Miss: "v1-app" is NOT in the Partial cache; FailingEngine panics, real engine finds it.
-    assert!(
-        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            snapshot_v2.get_app_id_version("v1-app", &FailingEngine).ok()
-        }))
-        .is_err()
-    );
+    assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        snapshot_v2
+            .get_app_id_version("v1-app", &FailingEngine)
+            .ok()
+    }))
+    .is_err());
     assert_eq!(
         snapshot_v2.get_app_id_version("v1-app", engine.as_ref())?,
         Some(1)
@@ -1090,6 +1078,67 @@ async fn test_set_txn_expiration_via_crc_fast_path(
             .get_app_id_version("my-app", &FailingEngine)
             .unwrap(),
         expected
+    );
+
+    Ok(())
+}
+
+/// Mirrors `test_set_txn_expiration_via_crc_fast_path` for the `Partial` branch: a cached
+/// transaction whose `lastUpdated` is older than retention must return `None` via the fast path,
+/// without falling through to log replay.
+#[tokio::test]
+async fn test_partial_set_txn_expired_hit_returns_none_via_fast_path() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
+        "id",
+        DataType::INTEGER,
+    )])?);
+
+    // v0: create the table with zero-second retention so any past lastUpdated expires.
+    let committed = create_table(&table_path, schema, "test_engine")
+        .with_table_properties([(
+            "delta.setTransactionRetentionDuration",
+            "interval 0 seconds",
+        )])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    // v1: commit my-app=1, write CRC at v1.
+    let snapshot_v0 = committed.post_commit_snapshot().unwrap().clone();
+    let committed = begin_transaction(snapshot_v0, engine.as_ref())?
+        .with_operation("WRITE".to_string())
+        .with_transaction_id("my-app".to_string(), 1)
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+    committed
+        .post_commit_snapshot()
+        .unwrap()
+        .write_checksum(engine.as_ref())?;
+
+    // Strip setTransactions from the v1 CRC so it reloads as Partial(empty).
+    strip_field_from_crc(&table_path, 1, "setTransactions");
+    let snapshot_v1_reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+
+    // v2: commit my-app=2 from the Partial base; post-commit CRC is Partial(map) containing my-app.
+    let committed = begin_transaction(snapshot_v1_reloaded, engine.as_ref())?
+        .with_operation("WRITE".to_string())
+        .with_transaction_id("my-app".to_string(), 2)
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+    let snapshot_v2 = committed.post_commit_snapshot().unwrap();
+
+    let map = snapshot_v2
+        .get_current_crc_if_loaded_for_testing()
+        .unwrap()
+        .set_transaction_state
+        .expect_partial();
+    assert!(map.contains_key("my-app"));
+
+    // FailingEngine proves the Partial fast path is used; the expiration filter drops the txn.
+    assert_eq!(
+        snapshot_v2.get_app_id_version("my-app", &FailingEngine)?,
+        None
     );
 
     Ok(())

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use delta_kernel::arrow::array::{ArrayRef, Int32Array, StringArray};
 use delta_kernel::committer::FileSystemCommitter;
-use delta_kernel::crc::{Crc, DomainMetadataState};
+use delta_kernel::crc::{Crc, DomainMetadataState, SetTransactionState};
 use delta_kernel::engine::default::DefaultEngineBuilder;
 use delta_kernel::object_store::local::LocalFileSystem;
 use delta_kernel::schema::{DataType, StructField, StructType};
@@ -745,6 +745,18 @@ async fn test_get_domain_metadata_with_crc_skips_log_replay() -> DeltaResult<()>
 
 /// Rewrites the on-disk CRC at `version` with its `domainMetadata` field stripped, leaving
 /// every other field (notably protocol and metadata) intact.
+fn strip_txns_from_crc(table_path: &str, version: u64) {
+    let crc_path = format!(
+        "{}/_delta_log/{:020}.crc",
+        table_path.trim_end_matches('/'),
+        version
+    );
+    let bytes = std::fs::read(&crc_path).unwrap();
+    let mut value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    value.as_object_mut().unwrap().remove("setTransactions");
+    std::fs::write(&crc_path, serde_json::to_vec(&value).unwrap()).unwrap();
+}
+
 fn strip_dm_from_crc(table_path: &str, version: u64) {
     let crc_path = format!(
         "{}/_delta_log/{:020}.crc",
@@ -846,9 +858,12 @@ async fn test_set_transaction_crc_tracking_and_fast_path() -> DeltaResult<()> {
     let committed = create_table_and_commit(&table_path, engine.as_ref())?;
     let snapshot_v0 = committed.post_commit_snapshot().unwrap();
 
-    // Post-commit CRC has empty set_transactions (not null)
+    // Post-commit CRC has empty Complete set_transaction_state (not Partial).
     let crc_v0 = write_and_verify_crc(snapshot_v0, &table_path, engine.as_ref());
-    assert_eq!(crc_v0.set_transactions, Some(Default::default()));
+    assert_eq!(
+        crc_v0.set_transaction_state,
+        SetTransactionState::Complete(HashMap::new())
+    );
 
     // Fresh snapshot with CRC on disk serves queries via fast path (no log replay)
     let fresh_v0 = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
@@ -884,7 +899,7 @@ async fn test_set_transaction_crc_tracking_and_fast_path() -> DeltaResult<()> {
 
     // Write CRC to disk, reload, verify round-trip and fast path
     let crc_v1 = write_and_verify_crc(snapshot_v1, &table_path, engine.as_ref());
-    let txns_v1 = crc_v1.set_transactions.as_ref().unwrap();
+    let txns_v1 = crc_v1.set_transaction_state.expect_complete();
     assert_eq!(txns_v1.len(), 1);
     assert!(txns_v1.contains_key("my-app"));
 
@@ -928,7 +943,7 @@ async fn test_set_transaction_crc_tracking_and_fast_path() -> DeltaResult<()> {
 
     // Write CRC to disk, reload, verify round-trip and fast path
     let crc_v2 = write_and_verify_crc(snapshot_v2, &table_path, engine.as_ref());
-    let txns_v2 = crc_v2.set_transactions.as_ref().unwrap();
+    let txns_v2 = crc_v2.set_transaction_state.expect_complete();
     assert_eq!(txns_v2.len(), 2);
 
     let fresh_v2 = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
@@ -944,6 +959,76 @@ async fn test_set_transaction_crc_tracking_and_fast_path() -> DeltaResult<()> {
             .get_app_id_version("other-app", &FailingEngine)
             .unwrap(),
         Some(1)
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_partial_set_txn_serves_hits_and_falls_through_for_misses() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    // v0: CREATE TABLE. v1: commit with v1-app=1, then write CRC to disk.
+    let committed = create_table_and_commit(&table_path, engine.as_ref())?;
+    let snapshot_v0 = committed.post_commit_snapshot().unwrap();
+    let committed = begin_transaction(snapshot_v0.clone(), engine.as_ref())?
+        .with_operation("WRITE".to_string())
+        .with_transaction_id("v1-app".to_string(), 1)
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+    let snapshot_v1 = committed.post_commit_snapshot().unwrap();
+    snapshot_v1.write_checksum(engine.as_ref())?;
+
+    // Strip setTransactions from the v1 CRC so it reloads as Partial(empty).
+    strip_txns_from_crc(&table_path, 1);
+
+    let snapshot_v1_reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert_eq!(
+        snapshot_v1_reloaded
+            .get_current_crc_if_loaded_for_testing()
+            .unwrap()
+            .set_transaction_state,
+        SetTransactionState::Partial(HashMap::new())
+    );
+
+    // v2: commit with my-app=1; post-commit CRC accumulates into Partial.
+    let committed = begin_transaction(snapshot_v1_reloaded.clone(), engine.as_ref())?
+        .with_operation("WRITE".to_string())
+        .with_transaction_id("my-app".to_string(), 1)
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+    let snapshot_v2 = committed.post_commit_snapshot().unwrap();
+
+    let map = snapshot_v2
+        .get_current_crc_if_loaded_for_testing()
+        .unwrap()
+        .set_transaction_state
+        .expect_partial();
+    assert!(map.contains_key("my-app"));
+    assert!(!map.contains_key("v1-app"));
+
+    // Hit: "my-app" is in the Partial cache -- served without log replay.
+    assert_eq!(
+        snapshot_v2.get_app_id_version("my-app", &FailingEngine)?,
+        Some(1)
+    );
+
+    // Miss: "v1-app" is NOT in the Partial cache; FailingEngine panics, real engine finds it.
+    assert!(
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            snapshot_v2.get_app_id_version("v1-app", &FailingEngine).ok()
+        }))
+        .is_err()
+    );
+    assert_eq!(
+        snapshot_v2.get_app_id_version("v1-app", engine.as_ref())?,
+        Some(1)
+    );
+
+    // Miss: completely absent app_id falls through and returns None.
+    assert_eq!(
+        snapshot_v2.get_app_id_version("nonexistent", engine.as_ref())?,
+        None
     );
 
     Ok(())

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -9,13 +9,15 @@ use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::crc::{Crc, DomainMetadataState, SetTransactionState};
 use delta_kernel::engine::default::DefaultEngineBuilder;
 use delta_kernel::object_store::local::LocalFileSystem;
+use delta_kernel::path::ParsedLogPath;
 use delta_kernel::schema::{DataType, StructField, StructType};
 use delta_kernel::snapshot::{ChecksumWriteResult, Snapshot, SnapshotRef};
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
-use delta_kernel::{DeltaResult, Engine, FileStats};
+use delta_kernel::{DeltaResult, Engine, FileStats, Version};
 use rstest::rstest;
 use test_utils::{add_commit, begin_transaction, insert_data, test_table_setup};
+use url::Url;
 
 // ============================================================================
 // File stats from CRC on disk
@@ -743,18 +745,27 @@ async fn test_get_domain_metadata_with_crc_skips_log_replay() -> DeltaResult<()>
     Ok(())
 }
 
+fn crc_file_path(table_path: &str, version: Version) -> PathBuf {
+    let url = Url::from_directory_path(table_path).unwrap();
+    ParsedLogPath::new_crc(&url, version)
+        .unwrap()
+        .location
+        .to_file_path()
+        .unwrap()
+}
+
+fn read_crc_json(table_path: &str, version: Version) -> serde_json::Value {
+    let bytes = std::fs::read(crc_file_path(table_path, version)).unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
 /// Rewrites the on-disk CRC at `version` to drop the named top-level field, leaving every
 /// other field intact.
-fn strip_field_from_crc(table_path: &str, version: u64, field: &str) {
-    let crc_path = format!(
-        "{}/_delta_log/{:020}.crc",
-        table_path.trim_end_matches('/'),
-        version
-    );
-    let bytes = std::fs::read(&crc_path).unwrap();
-    let mut value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+fn strip_field_from_crc(table_path: &str, version: Version, field: &str) {
+    let mut value = read_crc_json(table_path, version);
     value.as_object_mut().unwrap().remove(field);
-    std::fs::write(&crc_path, serde_json::to_vec(&value).unwrap()).unwrap();
+    let path = crc_file_path(table_path, version);
+    std::fs::write(&path, serde_json::to_vec(&value).unwrap()).unwrap();
 }
 
 #[tokio::test]
@@ -1018,6 +1029,11 @@ async fn test_partial_set_txn_serves_hits_and_falls_through_for_misses() -> Delt
         snapshot_v2.get_app_id_version("nonexistent", engine.as_ref())?,
         None
     );
+
+    // Writing the v2 CRC must drop the Partial setTransactions map on serialize: the on-disk
+    // file has a `null` setTransactions field even though the in-memory map has entries.
+    snapshot_v2.write_checksum(engine.as_ref())?;
+    assert!(read_crc_json(&table_path, 2)["setTransactions"].is_null());
 
     Ok(())
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Similar to PR #2567, which added DomainMetadataState enum to CRC, this PR adds SetTransactionState enum with Complete and Partial variants.

PR is lots of just updating callsites, variable names, and comments.

## How was this change tested?

New UTs + refactor some existing UTs.
