### PR TITLE
feat!(ffi): expose clustering column infos read path

### DIFF
--- a/ffi/CLAUDE.md
+++ b/ffi/CLAUDE.md
@@ -54,6 +54,14 @@ Snapshot accessors (`ffi/src/lib.rs`) read a built `SharedSnapshot` without I/O 
 `num_files` / `table_size_bytes` from the CRC; `None` when the snapshot has no CRC, or its CRC lacks
 complete file stats).
 
+Domain-metadata reads live in `ffi/src/domain_metadata.rs`: `get_domain_metadata` /
+`visit_domain_metadata` for user domains, and `visit_clustering_columns`, which reports one
+descriptor per clustering column -- logical name, physical name (what per-file stats are keyed on),
+and a type tag -- without exposing the guarded `delta.*` domain JSON directly. It returns
+`OptionalValue<usize>`: `None` means not clustered, `Some(0)` means clustered on no columns. The
+type tag reuses the `visit_expression_literal_null` encoding, with 255 for types that don't fit a
+compact tag (struct, array, map, variant, void, and geometry/geography).
+
 ## Commit Range Flow
 
 A `CommitRange` describes a contiguous range of a table's commits. Build one via the commit range

--- a/ffi/src/domain_metadata.rs
+++ b/ffi/src/domain_metadata.rs
@@ -2,10 +2,11 @@ use delta_kernel::snapshot::Snapshot;
 use delta_kernel::DeltaResult;
 
 use crate::error::{ExternResult, IntoExternResult};
+use crate::expressions::kernel_visitor::NullTypeTag;
 use crate::handle::Handle;
 use crate::{
     kernel_string_slice, AllocateStringFn, ExternEngine, KernelStringSlice, NullableCvoid,
-    SharedExternEngine, SharedSnapshot, TryFromStringSlice,
+    OptionalValue, SharedExternEngine, SharedSnapshot, TryFromStringSlice,
 };
 
 /// Get the domain metadata as an optional string allocated by `AllocatedStringFn` for a specific
@@ -36,7 +37,89 @@ fn get_domain_metadata_impl(
 ) -> DeltaResult<NullableCvoid> {
     Ok(snapshot
         .get_domain_metadata(&domain?, extern_engine.engine().as_ref())?
-        .and_then(|config: String| allocate_fn(kernel_string_slice!(config))))
+        .and_then(|config| allocate_fn(kernel_string_slice!(config))))
+}
+
+/// Signature of the callback invoked once per clustering column by
+/// [`visit_clustering_columns`], in the order the columns appear in the `delta.clustering`
+/// domain. Each invocation describes one column:
+///   - `logical_column`: the column path resolved against the table schema. When column mapping is
+///     enabled this is the logical name, not the physical identifier stored in the domain.
+///   - `physical_column`: the column path as stored in the domain. Use this to correlate a
+///     clustering column with per-file statistics, which are keyed on physical names.
+///   - `type_tag`: the column's data type, encoded with the same tag values as
+///     `visit_expression_literal_null`. Complex types (struct, array, map, variant) and void report
+///     the non-primitive sentinel (255); use a schema visitor for their full details.
+///   - `precision` / `scale`: meaningful only when `type_tag` is the `decimal` tag (12); zero
+///     otherwise.
+///
+/// Both column paths are dotted strings with individual fields backtick-escaped when they
+/// contain special characters, losslessly parseable back into a multi-part column reference.
+/// Note that column-mapping physical identifiers (e.g. `col-<uuid>`) contain hyphens and so
+/// arrive backtick-quoted; parse the path rather than comparing the raw string.
+///
+/// Resolving a domain-listed column against the schema matches names case-sensitively, so a
+/// domain entry whose casing differs from the schema's is reported as an error rather than
+/// resolved. Java kernel matches case-insensitively here.
+pub type ClusteringColumnVisitor = extern "C" fn(
+    engine_context: NullableCvoid,
+    logical_column: KernelStringSlice,
+    physical_column: KernelStringSlice,
+    type_tag: u8,
+    precision: u8,
+    scale: u8,
+);
+
+/// Visit the table's clustering columns, invoking `visitor` once per column. See
+/// [`ClusteringColumnVisitor`] for what each invocation reports.
+///
+/// Returns the number of columns visited when the table has the `clustering` feature with a
+/// current `delta.clustering` domain entry -- `Some(0)` means the table is clustered but the
+/// entry lists no columns. Returns `None` when the feature is absent or the domain has no
+/// current entry; the visitor does not run in that case. This distinction mirrors kernel's
+/// `Option<Vec<_>>`: `None` is "not clustered", `Some(0)` is "clustered on nothing".
+///
+/// # Safety
+///
+/// Caller is responsible for passing in a valid snapshot and engine handle, a valid
+/// `engine_context` opaque pointer forwarded to each `visitor` invocation, and a valid
+/// `visitor` function pointer.
+#[no_mangle]
+pub unsafe extern "C" fn visit_clustering_columns(
+    snapshot: Handle<SharedSnapshot>,
+    engine: Handle<SharedExternEngine>,
+    engine_context: NullableCvoid,
+    visitor: ClusteringColumnVisitor,
+) -> ExternResult<OptionalValue<usize>> {
+    let snapshot = unsafe { snapshot.as_ref() };
+    let engine = unsafe { engine.as_ref() };
+    visit_clustering_columns_impl(snapshot, engine, engine_context, visitor)
+        .into_extern_result(&engine)
+}
+
+fn visit_clustering_columns_impl(
+    snapshot: &Snapshot,
+    extern_engine: &dyn ExternEngine,
+    engine_context: NullableCvoid,
+    visitor: ClusteringColumnVisitor,
+) -> DeltaResult<OptionalValue<usize>> {
+    let Some(infos) = snapshot.get_clustering_column_infos(extern_engine.engine().as_ref())? else {
+        return Ok(OptionalValue::None);
+    };
+    for info in &infos {
+        let logical = info.logical_column().to_string();
+        let physical = info.physical_column().to_string();
+        let (tag, precision, scale) = NullTypeTag::from_data_type(info.data_type());
+        visitor(
+            engine_context,
+            kernel_string_slice!(logical),
+            kernel_string_slice!(physical),
+            tag as u8,
+            precision,
+            scale,
+        );
+    }
+    Ok(OptionalValue::Some(infos.len()))
 }
 
 /// Get the domain metadata as an optional string allocated by `AllocatedStringFn` for a specific
@@ -96,6 +179,7 @@ mod tests {
     use delta_kernel::object_store::memory::InMemory;
     use delta_kernel::DeltaResult;
     use delta_kernel_default_engine::DefaultEngineBuilder;
+    use rstest::rstest;
     use serde_json::json;
     use test_utils::add_commit;
 
@@ -118,7 +202,7 @@ mod tests {
         // commit0
         // - domain1: not removed
         // - domain2: not removed
-        let commit = [
+        let commit = join_actions(&[
             json!({
                 "protocol": {
                     "minReaderVersion": 1,
@@ -149,11 +233,9 @@ mod tests {
                     "removed": false
                 }
             }),
-        ]
-            .map(|json| json.to_string())
-            .join("\n");
+        ]);
 
-        add_commit(table_root, storage.clone().as_ref(), 0, commit)
+        add_commit(table_root, storage.as_ref(), 0, commit)
             .await
             .unwrap();
 
@@ -161,7 +243,7 @@ mod tests {
         // - domain1: removed
         // - domain2: not-removed
         // - internal domain
-        let commit = [
+        let commit = join_actions(&[
             json!({
                 "domainMetadata": {
                     "domain": "domain1",
@@ -183,9 +265,7 @@ mod tests {
                     "removed": false
                 }
             }),
-        ]
-        .map(|json| json.to_string())
-        .join("\n");
+        ]);
 
         add_commit(table_root, storage.as_ref(), 1, commit)
             .await
@@ -259,6 +339,477 @@ mod tests {
             collected_metadata.get("domain2").unwrap(),
             "domain2_commit1"
         );
+
+        unsafe { free_snapshot(snapshot) }
+        unsafe { free_engine(engine) }
+
+        Ok(())
+    }
+
+    // === visit_clustering_columns tests ===
+
+    fn protocol_action(clustering: bool) -> serde_json::Value {
+        if clustering {
+            json!({
+                "protocol": {
+                    "minReaderVersion": 1,
+                    "minWriterVersion": 7,
+                    "writerFeatures": ["domainMetadata", "clustering"]
+                }
+            })
+        } else {
+            json!({
+                "protocol": {
+                    "minReaderVersion": 1,
+                    "minWriterVersion": 1
+                }
+            })
+        }
+    }
+
+    fn metadata_action(schema_json: &str) -> serde_json::Value {
+        json!({
+            "metaData": {
+                "id": "5fba94ed-9794-4965-ba6e-6ee3c0d22af9",
+                "format": { "provider": "parquet", "options": {} },
+                "schemaString": schema_json,
+                "partitionColumns": [],
+                "configuration": {},
+                "createdTime": 1587968585495i64
+            }
+        })
+    }
+
+    // Schema with two top-level columns (`id: integer`, `val: string`) plus a nested
+    // `addr: struct<city: string>` so clustering on `["addr", "city"]` resolves.
+    fn clustering_test_schema_json() -> String {
+        let addr = json!({
+            "type": "struct",
+            "fields": [
+                {"name": "city", "type": "string", "nullable": true, "metadata": {}}
+            ]
+        });
+        json!({
+            "type": "struct",
+            "fields": [
+                {"name": "id", "type": "integer", "nullable": true, "metadata": {}},
+                {"name": "val", "type": "string", "nullable": true, "metadata": {}},
+                {"name": "addr", "type": addr, "nullable": true, "metadata": {}}
+            ]
+        })
+        .to_string()
+    }
+
+    fn clustering_domain_action(config: &str, removed: bool) -> serde_json::Value {
+        json!({
+            "domainMetadata": {
+                "domain": "delta.clustering",
+                "configuration": config,
+                "removed": removed
+            }
+        })
+    }
+
+    fn join_actions(actions: &[serde_json::Value]) -> String {
+        actions
+            .iter()
+            .map(|j| j.to_string())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// One visited clustering column: `(logical, physical, type_tag, precision, scale)`.
+    type VisitedColumn = (String, String, u8, u8, u8);
+
+    /// Drive `visit_clustering_columns`, collecting every visited column. Returns the count the
+    /// FFI symbol reported alongside the visited descriptors.
+    unsafe fn collect_clustering_columns(
+        snapshot: &crate::Handle<crate::SharedSnapshot>,
+        engine: &crate::Handle<crate::SharedExternEngine>,
+    ) -> (Option<usize>, Vec<VisitedColumn>) {
+        let collected: Box<Vec<VisitedColumn>> = Box::default();
+        let collected_ptr = Box::into_raw(collected);
+
+        extern "C" fn visitor(
+            state: NullableCvoid,
+            logical_column: KernelStringSlice,
+            physical_column: KernelStringSlice,
+            type_tag: u8,
+            precision: u8,
+            scale: u8,
+        ) {
+            let mut columns =
+                unsafe { Box::from_raw(state.unwrap().as_ptr() as *mut Vec<VisitedColumn>) };
+            let logical: DeltaResult<String> =
+                unsafe { TryFromStringSlice::try_from_slice(&logical_column) };
+            let physical: DeltaResult<String> =
+                unsafe { TryFromStringSlice::try_from_slice(&physical_column) };
+            columns.push((
+                logical.unwrap(),
+                physical.unwrap(),
+                type_tag,
+                precision,
+                scale,
+            ));
+            Box::leak(columns);
+        }
+
+        let count: Option<usize> = ok_or_panic(unsafe {
+            visit_clustering_columns(
+                snapshot.shallow_copy(),
+                engine.shallow_copy(),
+                Some(NonNull::new_unchecked(collected_ptr).cast()),
+                visitor,
+            )
+        })
+        .into();
+
+        let columns = *unsafe { Box::from_raw(collected_ptr) };
+        (count, columns)
+    }
+
+    async fn build_clustering_snapshot(
+        table_root: &str,
+        clustering_feature: bool,
+        domain_config: Option<&str>,
+        follow_up_commits: &[serde_json::Value],
+    ) -> (
+        crate::Handle<crate::SharedExternEngine>,
+        crate::Handle<crate::SharedSnapshot>,
+    ) {
+        let storage = Arc::new(InMemory::new());
+        let engine = DefaultEngineBuilder::new(storage.clone()).build();
+        let engine = engine_to_handle(Arc::new(engine), allocate_err);
+
+        let mut actions = vec![
+            protocol_action(clustering_feature),
+            metadata_action(&clustering_test_schema_json()),
+        ];
+        if let Some(config) = domain_config {
+            actions.push(clustering_domain_action(config, false));
+        }
+        add_commit(table_root, storage.as_ref(), 0, join_actions(&actions))
+            .await
+            .unwrap();
+
+        for (version, commit_actions) in follow_up_commits.iter().enumerate() {
+            add_commit(
+                table_root,
+                storage.as_ref(),
+                version as u64 + 1,
+                commit_actions.to_string(),
+            )
+            .await
+            .unwrap();
+        }
+
+        let snapshot =
+            unsafe { build_snapshot(kernel_string_slice!(table_root), engine.shallow_copy()) };
+        (engine, snapshot)
+    }
+
+    #[tokio::test]
+    async fn test_get_clustering_domain_metadata_user_facing_path_still_rejects() -> DeltaResult<()>
+    {
+        let table_root = "memory:///test_clustering_user_facing_rejected/";
+        let (engine, snapshot) = build_clustering_snapshot(
+            table_root,
+            true,
+            Some(r#"{"clusteringColumns":[["id"]]}"#),
+            &[],
+        )
+        .await;
+
+        let domain = "delta.clustering";
+        let rejected = unsafe {
+            get_domain_metadata(
+                snapshot.shallow_copy(),
+                kernel_string_slice!(domain),
+                engine.shallow_copy(),
+                allocate_str,
+            )
+        };
+        assert_extern_result_error_with_message(
+            rejected,
+            KernelError::GenericError,
+            Some(
+                "Generic delta kernel error: User DomainMetadata are not allowed to use \
+                 system-controlled 'delta.*' domain",
+            ),
+        );
+
+        unsafe { free_snapshot(snapshot) }
+        unsafe { free_engine(engine) }
+
+        Ok(())
+    }
+
+    // Type tags mirror `visit_expression_literal_null`'s encoding.
+    const TAG_INTEGER: u8 = 3;
+    const TAG_STRING: u8 = 7;
+
+    // `follow_up` is an optional second `delta.clustering` write `(config, removed)`, letting
+    // one case exercise tombstone and latest-write-wins reconciliation. Expectations are
+    // `(logical, physical, type_tag)`; without column mapping logical == physical.
+    #[rstest]
+    #[case::clustered_single_column(
+        true,
+        Some(r#"{"clusteringColumns":[["id"]]}"#),
+        None,
+        Some(vec![("id", "id", TAG_INTEGER)]),
+        "memory:///test_clustering_single/"
+    )]
+    #[case::clustered_multi_column(
+        true,
+        Some(r#"{"clusteringColumns":[["id"],["val"]]}"#),
+        None,
+        Some(vec![("id", "id", TAG_INTEGER), ("val", "val", TAG_STRING)]),
+        "memory:///test_clustering_multi/"
+    )]
+    // Nested paths render as dotted, backtick-escaped `ColumnName` strings.
+    #[case::clustered_nested_path(
+        true,
+        Some(r#"{"clusteringColumns":[["addr","city"]]}"#),
+        None,
+        Some(vec![("addr.city", "addr.city", TAG_STRING)]),
+        "memory:///test_clustering_nested/"
+    )]
+    // Domain entry present but lists no columns: clustered on nothing -- Some(0), no visits.
+    #[case::clustered_empty_column_list(
+        true,
+        Some(r#"{"clusteringColumns":[]}"#),
+        None,
+        Some(vec![]),
+        "memory:///test_clustering_empty_list/"
+    )]
+    // Not clustered: None, and the visitor never runs.
+    #[case::unclustered_returns_none(
+        false,
+        None,
+        None,
+        None,
+        "memory:///test_clustering_unclustered/"
+    )]
+    #[case::clustered_feature_with_no_domain_entry(
+        true,
+        None,
+        None,
+        None,
+        "memory:///test_clustering_feature_no_entry/"
+    )]
+    #[case::no_clustering_feature_but_domain_present(
+        false,
+        Some(r#"{"clusteringColumns":[["id"]]}"#),
+        None,
+        None,
+        "memory:///test_clustering_no_feature_domain_present/"
+    )]
+    // A tombstone (`removed: true`) clears the domain: None, and the visitor never runs.
+    #[case::tombstoned_returns_none(
+        true,
+        Some(r#"{"clusteringColumns":[["id"]]}"#),
+        Some((r#"{"clusteringColumns":[["id"]]}"#, true)),
+        None,
+        "memory:///test_clustering_tombstoned/"
+    )]
+    // A later non-removed write wins over the earlier one.
+    #[case::latest_write_wins(
+        true,
+        Some(r#"{"clusteringColumns":[["id"]]}"#),
+        Some((r#"{"clusteringColumns":[["val"]]}"#, false)),
+        Some(vec![("val", "val", TAG_STRING)]),
+        "memory:///test_clustering_latest_wins/"
+    )]
+    #[tokio::test]
+    async fn test_visit_clustering_columns(
+        #[case] clustering_feature: bool,
+        #[case] domain_config: Option<&str>,
+        #[case] follow_up: Option<(&str, bool)>,
+        #[case] expected: Option<Vec<(&str, &str, u8)>>,
+        #[case] table_root: &str,
+    ) -> DeltaResult<()> {
+        let follow_up_commits: Vec<serde_json::Value> = follow_up
+            .into_iter()
+            .map(|(config, removed)| clustering_domain_action(config, removed))
+            .collect();
+        let (engine, snapshot) = build_clustering_snapshot(
+            table_root,
+            clustering_feature,
+            domain_config,
+            &follow_up_commits,
+        )
+        .await;
+
+        let (count, columns) = unsafe { collect_clustering_columns(&snapshot, &engine) };
+
+        match expected {
+            Some(want) => {
+                // Non-decimal types report zero precision/scale.
+                let want: Vec<VisitedColumn> = want
+                    .into_iter()
+                    .map(|(logical, physical, tag)| {
+                        (logical.to_string(), physical.to_string(), tag, 0, 0)
+                    })
+                    .collect();
+                assert_eq!(count, Some(want.len()));
+                assert_eq!(columns, want);
+            }
+            None => {
+                assert_eq!(count, None);
+                assert!(columns.is_empty());
+            }
+        }
+
+        unsafe { free_snapshot(snapshot) }
+        unsafe { free_engine(engine) }
+
+        Ok(())
+    }
+
+    // Decimal is the only tag carrying a payload, so pin precision/scale explicitly.
+    #[tokio::test]
+    async fn test_visit_clustering_columns_decimal_reports_precision_and_scale() -> DeltaResult<()>
+    {
+        const TAG_DECIMAL: u8 = 12;
+        let storage = Arc::new(InMemory::new());
+        let engine = DefaultEngineBuilder::new(storage.clone()).build();
+        let engine = engine_to_handle(Arc::new(engine), allocate_err);
+        let table_root = "memory:///test_clustering_decimal/";
+
+        let schema = json!({
+            "type": "struct",
+            "fields": [
+                {"name": "amt", "type": "decimal(12,3)", "nullable": true, "metadata": {}}
+            ]
+        })
+        .to_string();
+        let commit = join_actions(&[
+            protocol_action(true),
+            metadata_action(&schema),
+            clustering_domain_action(r#"{"clusteringColumns":[["amt"]]}"#, false),
+        ]);
+        add_commit(table_root, storage.as_ref(), 0, commit)
+            .await
+            .unwrap();
+
+        let snapshot =
+            unsafe { build_snapshot(kernel_string_slice!(table_root), engine.shallow_copy()) };
+
+        let (count, columns) = unsafe { collect_clustering_columns(&snapshot, &engine) };
+        assert_eq!(count, Some(1));
+        assert_eq!(
+            columns,
+            vec![("amt".to_string(), "amt".to_string(), TAG_DECIMAL, 12, 3)]
+        );
+
+        unsafe { free_snapshot(snapshot) }
+        unsafe { free_engine(engine) }
+
+        Ok(())
+    }
+
+    // With column mapping the domain stores physical identifiers, so the visitor must report the
+    // schema-resolved logical name alongside the physical one the domain (and per-file stats) use.
+    #[tokio::test]
+    async fn test_visit_clustering_columns_column_mapping_reports_both_names() -> DeltaResult<()> {
+        let storage = Arc::new(InMemory::new());
+        let engine = DefaultEngineBuilder::new(storage.clone()).build();
+        let engine = engine_to_handle(Arc::new(engine), allocate_err);
+        let table_root = "memory:///test_clustering_column_mapping/";
+
+        // `region` is stored physically as `col-region-phys`; clustering names the physical id.
+        let schema = json!({
+            "type": "struct",
+            "fields": [{
+                "name": "region",
+                "type": "string",
+                "nullable": true,
+                "metadata": {
+                    "delta.columnMapping.id": 1,
+                    "delta.columnMapping.physicalName": "col-region-phys"
+                }
+            }]
+        })
+        .to_string();
+        let commit = join_actions(&[
+            json!({
+                "protocol": {
+                    "minReaderVersion": 2,
+                    "minWriterVersion": 7,
+                    "writerFeatures": ["domainMetadata", "clustering", "columnMapping"]
+                }
+            }),
+            json!({
+                "metaData": {
+                    "id": "5fba94ed-9794-4965-ba6e-6ee3c0d22af9",
+                    "format": { "provider": "parquet", "options": {} },
+                    "schemaString": schema,
+                    "partitionColumns": [],
+                    "configuration": { "delta.columnMapping.mode": "name" },
+                    "createdTime": 1587968585495i64
+                }
+            }),
+            clustering_domain_action(r#"{"clusteringColumns":[["col-region-phys"]]}"#, false),
+        ]);
+        add_commit(table_root, storage.as_ref(), 0, commit)
+            .await
+            .unwrap();
+
+        let snapshot =
+            unsafe { build_snapshot(kernel_string_slice!(table_root), engine.shallow_copy()) };
+
+        let (count, columns) = unsafe { collect_clustering_columns(&snapshot, &engine) };
+        assert_eq!(count, Some(1));
+        // Physical identifiers contain hyphens, which `ColumnName` renders backtick-quoted.
+        assert_eq!(
+            columns,
+            vec![(
+                "region".to_string(),
+                "`col-region-phys`".to_string(),
+                TAG_STRING,
+                0,
+                0
+            )]
+        );
+
+        unsafe { free_snapshot(snapshot) }
+        unsafe { free_engine(engine) }
+
+        Ok(())
+    }
+
+    // A clustering column absent from the schema cannot resolve to a logical name, so the
+    // symbol surfaces an `ExternResult::Err` rather than reporting the table as unclustered.
+    #[tokio::test]
+    async fn test_visit_clustering_columns_column_not_in_schema_errors() -> DeltaResult<()> {
+        let table_root = "memory:///test_clustering_col_missing/";
+        // "ghost" is not one of id/val/addr in clustering_test_schema_json().
+        let (engine, snapshot) = build_clustering_snapshot(
+            table_root,
+            true,
+            Some(r#"{"clusteringColumns":[["ghost"]]}"#),
+            &[],
+        )
+        .await;
+
+        extern "C" fn visitor(
+            _: NullableCvoid,
+            _: KernelStringSlice,
+            _: KernelStringSlice,
+            _: u8,
+            _: u8,
+            _: u8,
+        ) {
+        }
+        let res = unsafe {
+            visit_clustering_columns(
+                snapshot.shallow_copy(),
+                engine.shallow_copy(),
+                None,
+                visitor,
+            )
+        };
+        assert_extern_result_error_with_message(res, KernelError::GenericError, None);
 
         unsafe { free_snapshot(snapshot) }
         unsafe { free_engine(engine) }

--- a/ffi/src/domain_metadata.rs
+++ b/ffi/src/domain_metadata.rs
@@ -107,9 +107,9 @@ fn visit_clustering_columns_impl(
         return Ok(OptionalValue::None);
     };
     for info in &infos {
-        let logical = info.logical_column().to_string();
-        let physical = info.physical_column().to_string();
-        let (tag, precision, scale) = NullTypeTag::from_data_type(info.data_type());
+        let logical = info.logical_column.to_string();
+        let physical = info.physical_column.to_string();
+        let (tag, precision, scale) = NullTypeTag::from_data_type(&info.data_type);
         visitor(
             engine_context,
             kernel_string_slice!(logical),

--- a/kernel/src/clustering.rs
+++ b/kernel/src/clustering.rs
@@ -47,48 +47,16 @@ pub(crate) const CLUSTERING_DOMAIN_NAME: &str = "delta.clustering";
 /// nested-field clustering.
 ///
 /// Callers needing to correlate a clustering column with per-file statistics must use
-/// [`Self::physical_column`]: stats are keyed on physical names.
+/// [`physical_column`]: stats are keyed on physical names.
 #[derive(Debug, Clone, PartialEq)]
 #[internal_api]
-#[cfg_attr(not(feature = "internal-api"), allow(dead_code))]
 pub(crate) struct ClusteringColumnInfo {
-    physical_column: ColumnName,
-    logical_column: ColumnName,
-    data_type: DataType,
-}
-
-#[cfg_attr(not(feature = "internal-api"), allow(dead_code))]
-impl ClusteringColumnInfo {
-    #[internal_api]
-    pub(crate) fn new(
-        physical_column: ColumnName,
-        logical_column: ColumnName,
-        data_type: DataType,
-    ) -> Self {
-        Self {
-            physical_column,
-            logical_column,
-            data_type,
-        }
-    }
-
     /// The physical column reference as stored in the `delta.clustering` domain.
-    #[internal_api]
-    pub(crate) fn physical_column(&self) -> &ColumnName {
-        &self.physical_column
-    }
-
+    pub physical_column: ColumnName,
     /// The logical column reference, resolved against the snapshot's schema.
-    #[internal_api]
-    pub(crate) fn logical_column(&self) -> &ColumnName {
-        &self.logical_column
-    }
-
+    pub logical_column: ColumnName,
     /// The data type of the column at the resolved path.
-    #[internal_api]
-    pub(crate) fn data_type(&self) -> &DataType {
-        &self.data_type
-    }
+    pub data_type: DataType,
 }
 
 /// Validates clustering columns against the table schema.

--- a/kernel/src/clustering.rs
+++ b/kernel/src/clustering.rs
@@ -8,6 +8,7 @@
 //! as a JSON object with a `clusteringColumns` field containing an array of column paths,
 //! where each path is an array of field names (to handle nested columns).
 
+use delta_kernel_derive::internal_api;
 use serde::{Deserialize, Serialize};
 
 use crate::actions::DomainMetadata;
@@ -37,6 +38,58 @@ struct ClusteringDomainMetadata {
 
 /// The domain name for clustering metadata.
 pub(crate) const CLUSTERING_DOMAIN_NAME: &str = "delta.clustering";
+
+/// A resolved descriptor for one clustering column on a snapshot.
+///
+/// Pairs the physical column reference (as stored in the `delta.clustering` domain) with the
+/// logical reference resolved against the snapshot's schema, plus the data type at that path.
+/// The two references differ only when column mapping is enabled. Both are multi-part for
+/// nested-field clustering.
+///
+/// Callers needing to correlate a clustering column with per-file statistics must use
+/// [`Self::physical_column`]: stats are keyed on physical names.
+#[derive(Debug, Clone, PartialEq)]
+#[internal_api]
+#[cfg_attr(not(feature = "internal-api"), allow(dead_code))]
+pub(crate) struct ClusteringColumnInfo {
+    physical_column: ColumnName,
+    logical_column: ColumnName,
+    data_type: DataType,
+}
+
+#[cfg_attr(not(feature = "internal-api"), allow(dead_code))]
+impl ClusteringColumnInfo {
+    #[internal_api]
+    pub(crate) fn new(
+        physical_column: ColumnName,
+        logical_column: ColumnName,
+        data_type: DataType,
+    ) -> Self {
+        Self {
+            physical_column,
+            logical_column,
+            data_type,
+        }
+    }
+
+    /// The physical column reference as stored in the `delta.clustering` domain.
+    #[internal_api]
+    pub(crate) fn physical_column(&self) -> &ColumnName {
+        &self.physical_column
+    }
+
+    /// The logical column reference, resolved against the snapshot's schema.
+    #[internal_api]
+    pub(crate) fn logical_column(&self) -> &ColumnName {
+        &self.logical_column
+    }
+
+    /// The data type of the column at the resolved path.
+    #[internal_api]
+    pub(crate) fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+}
 
 /// Validates clustering columns against the table schema.
 ///

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -549,11 +549,11 @@ impl Snapshot {
                     &physical_col,
                     column_mapping_mode,
                 )?;
-                Ok(ClusteringColumnInfo::new(
-                    physical_col,
-                    logical_col,
+                Ok(ClusteringColumnInfo {
+                    physical_column: physical_col,
+                    logical_column: logical_col,
                     data_type,
-                ))
+                })
             })
             .collect::<DeltaResult<Vec<_>>>()?;
         Ok(Some(infos))
@@ -2354,12 +2354,12 @@ mod tests {
                 let infos = result.expect("clustering infos should be present");
                 assert_eq!(infos.len(), 1);
                 let info = &infos[0];
-                assert_eq!(info.logical_column(), &ColumnName::new([logical]));
-                assert_eq!(info.data_type(), &DataType::STRING);
+                assert_eq!(info.logical_column, ColumnName::new([logical]));
+                assert_eq!(info.data_type, DataType::STRING);
                 if physical_differs {
-                    assert_ne!(info.physical_column(), info.logical_column());
+                    assert_ne!(info.physical_column, info.logical_column);
                 } else {
-                    assert_eq!(info.physical_column(), info.logical_column());
+                    assert_eq!(info.physical_column, info.logical_column);
                 }
             }
         }

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -2306,17 +2306,29 @@ mod tests {
     /// predictable and the physical one must merely differ from it.
     #[rstest::rstest]
     #[case::no_clustering(None, None, None, false)]
-    #[case::clustered_no_column_mapping(Some(vec!["region"]), None, Some("region"), false)]
+    #[case::clustered_no_column_mapping(Some(vec![vec!["region"]]), None, Some(vec!["region"]), false)]
     #[case::clustered_with_column_mapping(
-        Some(vec!["region"]),
+        Some(vec![vec!["region"]]),
         Some("name"),
-        Some("region"),
+        Some(vec!["region"]),
+        true
+    )]
+    #[case::nested_no_column_mapping(
+        Some(vec![vec!["address", "city"]]),
+        None,
+        Some(vec!["address", "city"]),
+        false
+    )]
+    #[case::nested_with_column_mapping(
+        Some(vec![vec!["address", "city"]]),
+        Some("name"),
+        Some(vec!["address", "city"]),
         true
     )]
     fn test_get_clustering_column_infos(
-        #[case] clustering_cols: Option<Vec<&str>>,
+        #[case] clustering_cols: Option<Vec<Vec<&str>>>,
         #[case] column_mapping_mode: Option<&str>,
-        #[case] expected_logical: Option<&str>,
+        #[case] expected_logical: Option<Vec<&str>>,
         #[case] physical_differs: bool,
     ) {
         use crate::transaction::create_table::create_table;
@@ -2326,14 +2338,26 @@ mod tests {
         let engine = SyncEngine::new_with_store(storage);
         let schema = Arc::new(
             crate::schema::StructType::try_new(vec![
-                crate::schema::StructField::new("id", crate::schema::DataType::INTEGER, true),
-                crate::schema::StructField::new("region", crate::schema::DataType::STRING, true),
+                crate::schema::StructField::nullable("id", DataType::INTEGER),
+                crate::schema::StructField::nullable("region", DataType::STRING),
+                crate::schema::StructField::nullable(
+                    "address",
+                    crate::schema::StructType::try_new(vec![
+                        crate::schema::StructField::nullable("city", DataType::STRING),
+                        crate::schema::StructField::nullable("zip", DataType::INTEGER),
+                    ])
+                    .unwrap(),
+                ),
             ])
             .unwrap(),
         );
         let _ = create_table("memory:///", schema, "test")
             .fold_with(clustering_cols.as_ref(), |builder, cols| {
-                builder.with_data_layout(DataLayout::clustered(cols.clone()))
+                let columns = cols
+                    .iter()
+                    .map(|path| ColumnName::new(path.iter().copied()))
+                    .collect();
+                builder.with_data_layout(DataLayout::Clustered { columns })
             })
             .fold_with(column_mapping_mode, |builder, mode| {
                 builder.with_table_properties([("delta.columnMapping.mode", mode)])
@@ -2354,10 +2378,20 @@ mod tests {
                 let infos = result.expect("clustering infos should be present");
                 assert_eq!(infos.len(), 1);
                 let info = &infos[0];
-                assert_eq!(info.logical_column, ColumnName::new([logical]));
+                assert_eq!(
+                    info.logical_column,
+                    ColumnName::new(logical.iter().copied())
+                );
                 assert_eq!(info.data_type, DataType::STRING);
+                assert_eq!(info.physical_column.path().len(), logical.len());
                 if physical_differs {
                     assert_ne!(info.physical_column, info.logical_column);
+                    for part in info.physical_column.path() {
+                        assert!(
+                            part.starts_with("col-"),
+                            "physical path segment '{part}' should be a column-mapping id"
+                        );
+                    }
                 } else {
                     assert_eq!(info.physical_column, info.logical_column);
                 }

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -14,7 +14,7 @@ use crate::actions::{DomainMetadata, INTERNAL_DOMAIN_PREFIX};
 use crate::checkpoint::{
     CheckpointSpec, CheckpointWriter, V2CheckpointConfig, DEFAULT_FILE_ACTIONS_PER_SIDECAR_HINT,
 };
-use crate::clustering::{parse_clustering_columns, CLUSTERING_DOMAIN_NAME};
+use crate::clustering::{parse_clustering_columns, ClusteringColumnInfo, CLUSTERING_DOMAIN_NAME};
 use crate::committer::{Committer, PublishMetadata};
 use crate::crc::{
     try_write_crc_file, Crc, CrcDelta, DomainMetadataState, FileSizeHistogram, FileStats,
@@ -31,7 +31,7 @@ use crate::path::ParsedLogPath;
 use crate::scan::ScanBuilder;
 use crate::schema::SchemaRef;
 use crate::table_configuration::{InCommitTimestampEnablement, TableConfiguration};
-use crate::table_features::{physical_to_logical_column_name, ColumnMappingMode, TableFeature};
+use crate::table_features::{physical_to_logical_column_name_and_type, TableFeature};
 use crate::table_properties::TableProperties;
 use crate::transaction::builder::alter_table::AlterTableTransactionBuilder;
 use crate::transaction::Transaction;
@@ -514,15 +514,16 @@ impl Snapshot {
         self.get_domain_metadata_internal(domain, engine)
     }
 
-    /// Get the logical clustering columns for this snapshot, if clustering is enabled.
+    /// Get per-clustering-column descriptors for this snapshot, if clustering is enabled.
     ///
-    /// Returns `Ok(Some(columns))` if the ClusteredTable feature is enabled and clustering
-    /// columns are defined, `Ok(None)` if clustering is not enabled, or an error if the
-    /// clustering metadata is malformed.
+    /// Returns `Ok(Some(infos))` when the ClusteredTable feature is enabled and the
+    /// `delta.clustering` domain has a current entry (`infos` may be empty if the entry lists
+    /// none), `Ok(None)` when the feature is absent or the domain has no current entry, or an
+    /// error if the clustering metadata is malformed. Descriptors are returned in the order the
+    /// columns appear in the domain.
     ///
-    /// The columns are returned as logical [`ColumnName`]s. When column mapping is enabled,
-    /// this converts the physical names stored in domain metadata back to logical names using
-    /// the table schema.
+    /// Each `ClusteringColumnInfo` carries the physical reference (as stored in the domain), the
+    /// logical reference resolved against the table schema, and the column's data type.
     ///
     /// Note that this method performs log replay (fetches and processes metadata from storage).
     ///
@@ -530,39 +531,40 @@ impl Snapshot {
     ///
     /// Returns an error if the clustering domain metadata is malformed, or if a physical
     /// column name cannot be resolved to a logical name in the schema.
-    ///
-    /// [`ColumnName`]: crate::expressions::ColumnName
-    #[allow(unused)]
     #[internal_api]
-    pub(crate) fn get_logical_clustering_columns(
+    pub(crate) fn get_clustering_column_infos(
         &self,
         engine: &dyn Engine,
-    ) -> DeltaResult<Option<Vec<ColumnName>>> {
-        let physical_columns = match self.get_physical_clustering_columns(engine)? {
-            Some(cols) => cols,
-            None => return Ok(None),
+    ) -> DeltaResult<Option<Vec<ClusteringColumnInfo>>> {
+        let Some(physical_columns) = self.get_physical_clustering_columns(engine)? else {
+            return Ok(None);
         };
         let column_mapping_mode = self.table_configuration.column_mapping_mode();
-        if column_mapping_mode == ColumnMappingMode::None {
-            // No column mapping: physical = logical
-            return Ok(Some(physical_columns));
-        }
-        // Convert physical column names to logical names by walking the schema
         let logical_schema = self.table_configuration.logical_schema();
-        let logical_columns = physical_columns
-            .iter()
+        let infos = physical_columns
+            .into_iter()
             .map(|physical_col| {
-                physical_to_logical_column_name(&logical_schema, physical_col, column_mapping_mode)
+                let (logical_col, data_type) = physical_to_logical_column_name_and_type(
+                    &logical_schema,
+                    &physical_col,
+                    column_mapping_mode,
+                )?;
+                Ok(ClusteringColumnInfo::new(
+                    physical_col,
+                    logical_col,
+                    data_type,
+                ))
             })
             .collect::<DeltaResult<Vec<_>>>()?;
-        Ok(Some(logical_columns))
+        Ok(Some(infos))
     }
 
     /// Get the clustering columns for this snapshot, if the table has clustering enabled.
     ///
-    /// Returns `Ok(Some(columns))` if the ClusteredTable feature is enabled and clustering
-    /// columns are defined, `Ok(None)` if clustering is not enabled, or an error if the
-    /// clustering metadata is malformed.
+    /// Returns `Ok(Some(columns))` when the ClusteredTable feature is enabled and the
+    /// `delta.clustering` domain has a current entry (`columns` may be empty if the entry lists
+    /// none), `Ok(None)` when the feature is absent or the domain has no current entry, or an
+    /// error if the clustering metadata is malformed.
     ///
     /// The columns are returned as physical column names, respecting the column mapping mode.
     /// Note that this method performs log replay (fetches and processes metadata from storage).
@@ -571,6 +573,21 @@ impl Snapshot {
         &self,
         engine: &dyn Engine,
     ) -> DeltaResult<Option<Vec<ColumnName>>> {
+        match self.get_clustering_domain_metadata(engine)? {
+            Some(config) => Ok(Some(parse_clustering_columns(&config)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Read the raw JSON configuration of the `delta.clustering` domain.
+    ///
+    /// Returns `Ok(None)` when the `ClusteredTable` feature is absent on the protocol, or when
+    /// the domain has no current entry. The JSON has the shape
+    /// `{"clusteringColumns":[["col1"],["addr","city"], ...]}` with physical column names.
+    pub(crate) fn get_clustering_domain_metadata(
+        &self,
+        engine: &dyn Engine,
+    ) -> DeltaResult<Option<String>> {
         if !self
             .table_configuration
             .protocol()
@@ -578,10 +595,7 @@ impl Snapshot {
         {
             return Ok(None);
         }
-        match self.get_domain_metadata_internal(CLUSTERING_DOMAIN_NAME, engine)? {
-            Some(config) => Ok(Some(parse_clustering_columns(&config)?)),
-            None => Ok(None),
-        }
+        self.get_domain_metadata_internal(CLUSTERING_DOMAIN_NAME, engine)
     }
 
     /// Load domain metadata: if Complete in the CRC, answer from the cache; else if every
@@ -2287,22 +2301,23 @@ mod tests {
         assert_eq!(config.get("myapp.setting"), Some(&"value".to_string()));
     }
 
+    /// `physical_differs` records whether column mapping is expected to rename the column: with
+    /// mapping on, the domain stores a generated identifier, so only the logical name is
+    /// predictable and the physical one must merely differ from it.
     #[rstest::rstest]
-    #[case::no_clustering(None, None, None)]
-    #[case::clustered_no_column_mapping(
-        Some(vec!["region"]),
-        None,
-        Some(vec![ColumnName::new(["region"])])
-    )]
+    #[case::no_clustering(None, None, None, false)]
+    #[case::clustered_no_column_mapping(Some(vec!["region"]), None, Some("region"), false)]
     #[case::clustered_with_column_mapping(
         Some(vec!["region"]),
         Some("name"),
-        Some(vec![ColumnName::new(["region"])])
+        Some("region"),
+        true
     )]
-    fn test_get_logical_clustering_columns(
+    fn test_get_clustering_column_infos(
         #[case] clustering_cols: Option<Vec<&str>>,
         #[case] column_mapping_mode: Option<&str>,
-        #[case] expected: Option<Vec<ColumnName>>,
+        #[case] expected_logical: Option<&str>,
+        #[case] physical_differs: bool,
     ) {
         use crate::transaction::create_table::create_table;
         use crate::transaction::data_layout::DataLayout;
@@ -2331,8 +2346,23 @@ mod tests {
             .commit(&engine)
             .unwrap();
         let snapshot = Snapshot::builder_for("memory:///").build(&engine).unwrap();
-        let result = snapshot.get_logical_clustering_columns(&engine).unwrap();
-        assert_eq!(result, expected);
+        let result = snapshot.get_clustering_column_infos(&engine).unwrap();
+
+        match expected_logical {
+            None => assert_eq!(result, None),
+            Some(logical) => {
+                let infos = result.expect("clustering infos should be present");
+                assert_eq!(infos.len(), 1);
+                let info = &infos[0];
+                assert_eq!(info.logical_column(), &ColumnName::new([logical]));
+                assert_eq!(info.data_type(), &DataType::STRING);
+                if physical_differs {
+                    assert_ne!(info.physical_column(), info.logical_column());
+                } else {
+                    assert_eq!(info.physical_column(), info.logical_column());
+                }
+            }
+        }
     }
 
     // === estimated_owned_heap_size ===

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -874,15 +874,16 @@ pub(crate) fn get_any_level_column_physical_name(
     Ok(ColumnName::new(physical_path))
 }
 
-/// Convert a physical column name to a logical column name by walking the schema.
+/// Convert a physical column name to a logical column name (with the leaf field's [`DataType`])
+/// by walking the schema.
 ///
-/// For each path component in the physical column, finds the field in the schema whose
-/// `physical_name(mode)` matches, and returns the field's logical name instead.
-pub(crate) fn physical_to_logical_column_name(
+/// Walks the schema once, matching each path component by `physical_name(mode)`, and returns the
+/// resolved logical [`ColumnName`] together with the data type of the final (leaf) field.
+pub(crate) fn physical_to_logical_column_name_and_type(
     logical_schema: &StructType,
     physical_col: &ColumnName,
     column_mapping_mode: ColumnMappingMode,
-) -> DeltaResult<ColumnName> {
+) -> DeltaResult<(ColumnName, DataType)> {
     let mut fields = vec![];
     logical_schema.visit_fields_of_path_by(
         physical_col,
@@ -892,7 +893,14 @@ pub(crate) fn physical_to_logical_column_name(
         },
         |field| fields.push(field),
     )?;
-    Ok(ColumnName::new(fields.iter().map(|f| &f.name)))
+    // `visit_fields_of_path_by` rejects an empty path and otherwise pushes one field per
+    // component, so on success `fields` is non-empty and its last element is the leaf.
+    let leaf_type = fields
+        .last()
+        .ok_or_else(|| Error::generic(format!("Column path '{physical_col}' resolved no fields")))?
+        .data_type()
+        .clone();
+    Ok((ColumnName::new(fields.iter().map(|f| &f.name)), leaf_type))
 }
 
 #[cfg(test)]
@@ -2245,10 +2253,14 @@ mod tests {
             StructField::new("name", DataType::STRING, true),
         ]);
         let physical_col = ColumnName::new(["id"]);
-        let result =
-            physical_to_logical_column_name(&schema, &physical_col, ColumnMappingMode::None)
-                .unwrap();
-        assert_eq!(result, ColumnName::new(["id"]));
+        let (logical, data_type) = physical_to_logical_column_name_and_type(
+            &schema,
+            &physical_col,
+            ColumnMappingMode::None,
+        )
+        .unwrap();
+        assert_eq!(logical, ColumnName::new(["id"]));
+        assert_eq!(data_type, DataType::INTEGER);
     }
 
     #[test]
@@ -2260,10 +2272,14 @@ mod tests {
         let schema = StructType::new_unchecked(vec![field]);
 
         let physical_col = ColumnName::new(["col-abc-123"]);
-        let result =
-            physical_to_logical_column_name(&schema, &physical_col, ColumnMappingMode::Name)
-                .unwrap();
-        assert_eq!(result, ColumnName::new(["user_id"]));
+        let (logical, data_type) = physical_to_logical_column_name_and_type(
+            &schema,
+            &physical_col,
+            ColumnMappingMode::Name,
+        )
+        .unwrap();
+        assert_eq!(logical, ColumnName::new(["user_id"]));
+        assert_eq!(data_type, DataType::INTEGER);
     }
 
     #[test]
@@ -2271,8 +2287,11 @@ mod tests {
         let schema =
             StructType::new_unchecked(vec![StructField::new("id", DataType::INTEGER, false)]);
         let physical_col = ColumnName::new(["nonexistent"]);
-        let result =
-            physical_to_logical_column_name(&schema, &physical_col, ColumnMappingMode::None);
+        let result = physical_to_logical_column_name_and_type(
+            &schema,
+            &physical_col,
+            ColumnMappingMode::None,
+        );
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -2294,10 +2313,14 @@ mod tests {
         let schema = StructType::new_unchecked(vec![outer_field]);
 
         let physical_col = ColumnName::new(["col-outer-123", "col-inner-456"]);
-        let result =
-            physical_to_logical_column_name(&schema, &physical_col, ColumnMappingMode::Name)
-                .unwrap();
-        assert_eq!(result, ColumnName::new(["address", "city"]));
+        let (logical, data_type) = physical_to_logical_column_name_and_type(
+            &schema,
+            &physical_col,
+            ColumnMappingMode::Name,
+        )
+        .unwrap();
+        assert_eq!(logical, ColumnName::new(["address", "city"]));
+        assert_eq!(data_type, DataType::STRING);
     }
 
     #[test]
@@ -2305,8 +2328,11 @@ mod tests {
         let schema =
             StructType::new_unchecked(vec![StructField::new("id", DataType::INTEGER, false)]);
         let physical_col = ColumnName::new(["id", "nested"]);
-        let result =
-            physical_to_logical_column_name(&schema, &physical_col, ColumnMappingMode::None);
+        let result = physical_to_logical_column_name_and_type(
+            &schema,
+            &physical_col,
+            ColumnMappingMode::None,
+        );
         assert!(result.is_err());
         assert!(result
             .unwrap_err()

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -6,10 +6,11 @@ pub use column_mapping::ColumnMappingMode;
 #[internal_api]
 pub(crate) use column_mapping::{assign_column_mapping_metadata, find_max_column_id_in_schema};
 pub(crate) use column_mapping::{
-    column_mapping_mode, get_column_mapping_mode_from_properties, physical_to_logical_column_name,
-    schema_has_column_mapping_metadata, strip_stray_column_mapping_metadata,
-    try_assign_flat_column_mapping_info, validate_and_extract_column_mapping_annotations,
-    validate_column_mapping_id, StaleAnnotationPolicy,
+    column_mapping_mode, get_column_mapping_mode_from_properties,
+    physical_to_logical_column_name_and_type, schema_has_column_mapping_metadata,
+    strip_stray_column_mapping_metadata, try_assign_flat_column_mapping_info,
+    validate_and_extract_column_mapping_annotations, validate_column_mapping_id,
+    StaleAnnotationPolicy,
 };
 use delta_kernel_derive::internal_api;
 #[cfg(feature = "geo-type-in-dev")]


### PR DESCRIPTION
Expose `visit_clustering_columns`, an FFI symbol reporting one descriptor per clustering column, mirroring the shape of Java kernel's `getClusteringColumnInfos`. Each visitor invocation carries:

the **logical** column path, resolved against the table schema,
the **physical** column path as stored in the `delta.clustering` domain (what per-file statistics are keyed on), and
a structured **type tag** (plus decimal precision/scale) reusing the `visit_expression_literal_null` encoding.

The symbol returns `OptionalValue<usize>`, so "not clustered" (`None`) stays distinct from "clustered on no columns" (`Some(0)`).

## What changes are proposed in this pull request?

### This PR affects the following public APIs

**Breaking (FFI ABI):** new symbol `visit_clustering_columns(snapshot, engine, engine_context, visitor)` with the `ClusteringColumnVisitor` callback type; returns `ExternResult<OptionalValue<usize>>`.

Kernel: new `ClusteringColumnInfo` (physical + logical column, data type) and `Snapshot::get_clustering_column_infos` (internal API), resolved via a single column-mapping-aware schema walk. The `delta.clustering` read stays gated on the `ClusteredTable` writer feature.

Known divergence from Java: resolving a domain-listed column against the schema is case-sensitive here, where Java matches case-insensitively. Documented on the visitor type.

## How was this change tested?

- `cargo nextest run -p delta_kernel_ffi --lib visit_clustering_columns` (15 tests: single/multi/nested/empty-list, absent feature/domain, tombstone, latest-write-wins, column mapping reporting both names, decimal precision/scale, and the schema-resolution error path)
- Kernel unit + integration clustering / column-mapping tests
- Pre-commit: fmt, clippy, workspace tests
