### PR TITLE
fix: drop predicate refs to non-stats columns during rewrite

### DIFF
--- a/kernel/src/kernel_predicates/tests.rs
+++ b/kernel/src/kernel_predicates/tests.rs
@@ -849,20 +849,38 @@ fn test_eval_opaque_predicate() {
     let pred = Pred::opaque(OpaqueAndOp, vec![column_expr!("x"), Expr::literal(true)]);
     let skipping_pred = as_data_skipping_predicate(&pred).unwrap();
 
-    // Test direct evaluation and indirect data skipping
+    // Direct evaluation works for any column type.
     let filter = DefaultKernelPredicateEvaluator::from(Scalar::from(true));
     assert_eq!(filter.eval(&pred), Some(true), "AND(x, TRUE)");
-    assert_eq!(filter.eval(&skipping_pred), Some(true), "AND(x, TRUE)");
 
     let filter = DefaultKernelPredicateEvaluator::from(Scalar::from(false));
     assert_eq!(filter.eval(&pred), Some(false), "AND(x, TRUE)");
-    assert_eq!(filter.eval(&skipping_pred), Some(false), "AND(x, TRUE)");
 
     let filter = DefaultKernelPredicateEvaluator::from(Scalar::Null(DataType::BOOLEAN));
     assert_eq!(filter.eval(&pred), None, "AND(x, TRUE)");
-    assert_eq!(filter.eval(&skipping_pred), None, "AND(x, TRUE)");
 
-    // Test direct data skipping
+    // Indirect data skipping: `x` is Boolean and Boolean columns carry no min/max stats
+    // per the Delta protocol (see `is_skipping_eligible_datatype`). The rewrite therefore
+    // drops the `x` arm, leaving `AND(NULL, TRUE)` which evaluates to NULL for every filter.
+    assert_eq!(
+        DefaultKernelPredicateEvaluator::from(Scalar::from(true)).eval(&skipping_pred),
+        None,
+        "AND(x, TRUE) -- Boolean min/max unsupported"
+    );
+    assert_eq!(
+        DefaultKernelPredicateEvaluator::from(Scalar::from(false)).eval(&skipping_pred),
+        None,
+        "AND(x, TRUE) -- Boolean min/max unsupported"
+    );
+    assert_eq!(
+        DefaultKernelPredicateEvaluator::from(Scalar::Null(DataType::BOOLEAN)).eval(&skipping_pred),
+        None,
+        "AND(x, TRUE) -- Boolean min/max unsupported"
+    );
+
+    // Direct evaluation through a `ParquetStatsProvider` still works because that path
+    // doesn't go through min/max rewriting -- `OpaqueAndOp::eval_pred_scalar` evaluates
+    // each arm directly against the provider.
     let filter = OneStatsValue(Scalar::from(true));
     assert_eq!(filter.eval(&pred), Some(true), "AND(x, TRUE)");
 
@@ -909,10 +927,13 @@ fn test_eval_opaque_complex() {
         Some(false),
         "AND(x < TRUE, x < (2 < 5))"
     );
+    // Post-fold, `x < TRUE` no longer produces a stats-based skipping arm because Boolean
+    // columns carry no min/max stats per the Delta protocol. Combined with the already-NULL
+    // opaque-expression arm, `complex_skipping_pred` evaluates to NULL for every filter.
     assert_eq!(
         filter.eval(&complex_skipping_pred),
-        Some(false),
-        "AND(x < TRUE, x < (2 < 5))"
+        None,
+        "AND(x < TRUE, x < (2 < 5)) -- Boolean min/max unsupported"
     );
 }
 

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -16,6 +16,7 @@ use crate::expressions::{
 use crate::kernel_predicates::{
     DataSkippingPredicateEvaluator, KernelPredicateEvaluator, KernelPredicateEvaluatorDefaults,
 };
+use crate::scan::data_skipping::stats_schema::is_skipping_eligible_datatype;
 use crate::scan::metrics::ScanMetrics;
 use crate::schema::{DataType, SchemaRef, StructField, StructType};
 use crate::utils::require;
@@ -45,7 +46,14 @@ use delta_kernel_derive::internal_api;
 ///   predicate is dropped.
 #[cfg(test)]
 pub(crate) fn as_data_skipping_predicate(pred: &Pred) -> Option<Pred> {
-    DataSkippingPredicateCreator::new(&Default::default()).eval(pred)
+    let stats_columns = all_referenced_columns(pred);
+    DataSkippingPredicateCreator::new(&Default::default(), &stats_columns).eval(pred)
+}
+
+/// Permissive stats-columns set for tests that exercise rewrite mechanics, not the gate.
+#[cfg(test)]
+pub(crate) fn all_referenced_columns(pred: &Pred) -> HashSet<ColumnName> {
+    pred.references().into_iter().cloned().collect()
 }
 
 #[cfg(test)]
@@ -53,16 +61,30 @@ pub(crate) fn as_data_skipping_predicate_with_partitions(
     pred: &Pred,
     partition_columns: &HashSet<String>,
 ) -> Option<Pred> {
-    DataSkippingPredicateCreator::new(partition_columns).eval(pred)
+    let stats_columns = all_referenced_columns(pred);
+    DataSkippingPredicateCreator::new(partition_columns, &stats_columns).eval(pred)
 }
 
-/// Like `as_data_skipping_predicate`, but invokes [`KernelPredicateEvaluator::eval_sql_where`]
-/// instead of [`KernelPredicateEvaluator::eval`].
+/// Like [`as_data_skipping_predicate_with_partitions`] but invokes
+/// [`KernelPredicateEvaluator::eval_sql_where`] instead of [`KernelPredicateEvaluator::eval`].
+#[cfg(test)]
 fn as_sql_data_skipping_predicate(
     pred: &Pred,
     partition_columns: &HashSet<String>,
 ) -> Option<Pred> {
-    DataSkippingPredicateCreator::new(partition_columns).eval_sql_where(pred)
+    let stats_columns = all_referenced_columns(pred);
+    as_sql_data_skipping_predicate_with_stats_columns(pred, partition_columns, &stats_columns)
+}
+
+/// Like [`as_sql_data_skipping_predicate`] but only rewrites references to columns in
+/// `stats_columns`; other columns return `None` from the `get_*_stat` methods and
+/// junction-fold into NULL literals.
+pub(crate) fn as_sql_data_skipping_predicate_with_stats_columns(
+    pred: &Pred,
+    partition_columns: &HashSet<String>,
+    stats_columns: &HashSet<ColumnName>,
+) -> Option<Pred> {
+    DataSkippingPredicateCreator::new(partition_columns, stats_columns).eval_sql_where(pred)
 }
 
 #[internal_api]
@@ -102,6 +124,10 @@ impl DataSkippingFilter {
     ///   `partitionValues` string map into a typed struct. Only used when `partition_schema` is
     ///   `Some`.
     /// - `input_schema`: Schema of the batch that will be passed to [`apply()`](Self::apply)
+    /// - `stats_columns`: Physical leaf paths whose stats are in `stats_schema`. References to
+    ///   other data columns fold to NULL (keeping the file). Must line up with `stats_schema` --
+    ///   otherwise the rewritten predicate references columns the unified schema doesn't have and
+    ///   evaluator construction fails.
     /// - `metrics`: Optional metrics to record data skipping statistics.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
@@ -112,6 +138,7 @@ impl DataSkippingFilter {
         partition_schema: Option<&SchemaRef>,
         partition_expr: ExpressionRef,
         input_schema: SchemaRef,
+        stats_columns: &HashSet<ColumnName>,
         metrics: Option<Arc<ScanMetrics>>,
     ) -> Option<Self> {
         static FILTER_PRED: LazyLock<PredicateRef> =
@@ -163,9 +190,10 @@ impl DataSkippingFilter {
             .evaluation_handler()
             .new_predicate_evaluator(
                 unified_schema.clone(),
-                Arc::new(as_sql_data_skipping_predicate(
+                Arc::new(as_sql_data_skipping_predicate_with_stats_columns(
                     &predicate,
                     &partition_columns,
+                    stats_columns,
                 )?),
             )
             .inspect_err(|e| error!("Failed to create skipping evaluator: {e}"))
@@ -323,13 +351,27 @@ impl DataSkippingFilter {
 /// ```
 ///
 /// Partition columns are excluded since their values live in `add.partitionValues_parsed`,
-/// not `add.stats_parsed`.
+/// not `add.stats_parsed`. `physical_partition_columns` is the table's full partition list;
+/// pass an empty slice for unpartitioned tables.
+///
+/// `physical_stats_columns` restricts rewrites to columns which are expected to have stats
+/// collected; other references fold to NULL (keeps the file). Must match the column set
+/// used to build `physical_stats_schema`, otherwise the row-group filter sees a missing
+/// field.
 pub(crate) fn as_checkpoint_skipping_predicate(
     pred: &Pred,
-    partition_columns: &[String],
+    physical_partition_columns: &[String],
+    physical_stats_columns: &HashSet<ColumnName>,
 ) -> Option<Pred> {
-    let partition_columns: HashSet<&str> = partition_columns.iter().map(String::as_str).collect();
-    NullGuardedDataSkippingPredicateCreator { partition_columns }.eval(pred)
+    let partition_columns: HashSet<&str> = physical_partition_columns
+        .iter()
+        .map(String::as_str)
+        .collect();
+    NullGuardedDataSkippingPredicateCreator {
+        partition_columns,
+        stats_columns: physical_stats_columns,
+    }
+    .eval(pred)
 }
 
 /// Maps an ordering and inversion flag to the corresponding comparison predicate.
@@ -390,6 +432,15 @@ fn adjust_scalar_for_max_stat_truncation(val: &Scalar) -> Scalar {
     }
 }
 
+/// A column carries min/max stats iff it's a primitive whose type supports min/max skipping.
+/// Boolean / Binary, Array, Map, and Variant leaves carry nullCount only. Struct columns
+/// have no per-struct stats; only their primitive leaves do, recursively.
+/// Must match `MinMaxStatsTransform`'s acceptance rule. Otherwise the predicate creator
+/// emits refs to min/max fields the stats schema doesn't contain.
+fn has_min_max_stats(data_type: &DataType) -> bool {
+    matches!(data_type, DataType::Primitive(ptype) if is_skipping_eligible_datatype(ptype))
+}
+
 /// Rewrites user predicates into stats-based predicates for data skipping.
 ///
 /// For data columns, rewrites to `stats_parsed.minValues.*`/`stats_parsed.maxValues.*`/
@@ -400,16 +451,32 @@ struct DataSkippingPredicateCreator<'a> {
     /// Physical names of partition columns. For these columns, stats come from
     /// `partitionValues.<col>` (exact values) instead of min/max ranges.
     partition_columns: &'a HashSet<String>,
+    /// Physical leaf paths whose stats are present in `stats_parsed` (honors
+    /// `delta.dataSkippingNumIndexedCols`, `delta.dataSkippingStatsColumns`, and required
+    /// columns). References to data columns not in this set return `None` from the
+    /// `get_*_stat` methods, which junction-folds to NULL.
+    ///
+    /// Must match the column set used to build `physical_stats_schema`; otherwise the
+    /// rewritten predicate references columns absent from the unified schema.
+    stats_columns: &'a HashSet<ColumnName>,
 }
 
 impl<'a> DataSkippingPredicateCreator<'a> {
-    fn new(partition_columns: &'a HashSet<String>) -> Self {
-        Self { partition_columns }
+    fn new(partition_columns: &'a HashSet<String>, stats_columns: &'a HashSet<ColumnName>) -> Self {
+        Self {
+            partition_columns,
+            stats_columns,
+        }
     }
 
     fn is_partition_column(&self, col: &ColumnName) -> bool {
         let path = col.path();
         path.len() == 1 && self.partition_columns.contains(path[0].as_str())
+    }
+
+    /// Returns `true` when `col` is in `stats_columns`.
+    fn is_stats_column(&self, col: &ColumnName) -> bool {
+        self.stats_columns.contains(col)
     }
 
     /// Wraps a partition predicate with `OR(NOT is_add, pred)` to protect Remove rows from
@@ -426,10 +493,13 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
     type ColumnStat = Expr;
 
     /// Retrieves the minimum value of a column. For partition columns, returns the exact
-    /// partition value (which serves as both min and max).
-    fn get_min_stat(&self, col: &ColumnName, _data_type: &DataType) -> Option<Expr> {
+    /// partition value (which serves as both min and max). Returns `None` for data columns
+    /// outside the stat-columns set or whose type is not min/max-eligible.
+    fn get_min_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
         if self.is_partition_column(col) {
             Some(joined_column_expr!("partitionValues_parsed", col))
+        } else if !self.is_stats_column(col) || !has_min_max_stats(data_type) {
+            None
         } else {
             Some(Expr::from(
                 ColumnName::new(["stats_parsed", MIN_VALUES]).join(col),
@@ -438,10 +508,13 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
     }
 
     /// Retrieves the maximum value of a column. For partition columns, returns the exact
-    /// partition value.
-    fn get_max_stat(&self, col: &ColumnName, _data_type: &DataType) -> Option<Expr> {
+    /// partition value. Returns `None` for data columns outside the stat-columns set or whose
+    /// type is not min/max-eligible.
+    fn get_max_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
         if self.is_partition_column(col) {
             Some(joined_column_expr!("partitionValues_parsed", col))
+        } else if !self.is_stats_column(col) || !has_min_max_stats(data_type) {
+            None
         } else {
             Some(Expr::from(
                 ColumnName::new(["stats_parsed", MAX_VALUES]).join(col),
@@ -468,9 +541,10 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
         self.eval_partial_cmp(ord, max, &adjusted, inverted)
     }
 
-    /// Retrieves the null count of a column. Partition columns don't have nullCount stats.
+    /// Retrieves the null count of a column. Partition columns don't have nullCount stats,
+    /// nor do data columns outside the stat-columns set.
     fn get_nullcount_stat(&self, col: &ColumnName) -> Option<Expr> {
-        if self.is_partition_column(col) {
+        if self.is_partition_column(col) || !self.is_stats_column(col) {
             None
         } else {
             Some(Expr::from(
@@ -568,6 +642,10 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
 /// live in `add.partitionValues_parsed`, not `add.stats_parsed`.
 struct NullGuardedDataSkippingPredicateCreator<'a> {
     partition_columns: HashSet<&'a str>,
+    /// Physical leaf paths whose stats are present in `stats_parsed`. Same contract as
+    /// `DataSkippingPredicateCreator::stats_columns`. Must match the column set used to
+    /// build `physical_stats_schema`, or the row-group filter sees a missing field.
+    stats_columns: &'a HashSet<ColumnName>,
 }
 
 impl NullGuardedDataSkippingPredicateCreator<'_> {
@@ -575,6 +653,11 @@ impl NullGuardedDataSkippingPredicateCreator<'_> {
     fn is_partition_column(&self, col: &ColumnName) -> bool {
         let path = col.path();
         path.len() == 1 && self.partition_columns.contains(path[0].as_str())
+    }
+
+    /// Returns `true` when `col` is in `stats_columns`.
+    fn is_stats_column(&self, col: &ColumnName) -> bool {
+        self.stats_columns.contains(col)
     }
 }
 
@@ -586,22 +669,28 @@ impl DataSkippingPredicateEvaluator for NullGuardedDataSkippingPredicateCreator<
     // the checkpoint skipping path applies its own `add.stats_parsed` prefix afterward.
     // Partition columns return None since their values live in `add.partitionValues_parsed`.
 
-    fn get_min_stat(&self, col: &ColumnName, _data_type: &DataType) -> Option<Expr> {
-        if self.is_partition_column(col) {
+    fn get_min_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
+        if self.is_partition_column(col)
+            || !self.is_stats_column(col)
+            || !has_min_max_stats(data_type)
+        {
             return None;
         }
         Some(Expr::from(ColumnName::new([MIN_VALUES]).join(col)))
     }
 
-    fn get_max_stat(&self, col: &ColumnName, _data_type: &DataType) -> Option<Expr> {
-        if self.is_partition_column(col) {
+    fn get_max_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
+        if self.is_partition_column(col)
+            || !self.is_stats_column(col)
+            || !has_min_max_stats(data_type)
+        {
             return None;
         }
         Some(Expr::from(ColumnName::new([MAX_VALUES]).join(col)))
     }
 
     fn get_nullcount_stat(&self, col: &ColumnName) -> Option<Expr> {
-        if self.is_partition_column(col) {
+        if self.is_partition_column(col) || !self.is_stats_column(col) {
             return None;
         }
         Some(Expr::from(ColumnName::new([NULL_COUNT]).join(col)))

--- a/kernel/src/scan/data_skipping/stats_schema/mod.rs
+++ b/kernel/src/scan/data_skipping/stats_schema/mod.rs
@@ -3,15 +3,13 @@
 mod column_filter;
 
 use std::borrow::Cow;
-use std::sync::Arc;
 
 use column_filter::StatsColumnFilter;
 pub(crate) use column_filter::StatsConfig;
 
 use crate::actions::{MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS, TIGHT_BOUNDS};
 use crate::schema::{
-    ArrayType, ColumnName, DataType, MapType, PrimitiveType, Schema, SchemaRef, StructField,
-    StructType,
+    ArrayType, ColumnName, DataType, MapType, PrimitiveType, Schema, StructField, StructType,
 };
 use crate::transforms::{transform_output_type, SchemaTransform};
 use crate::DeltaResult;
@@ -191,31 +189,6 @@ pub(crate) fn stats_column_names(
     let mut columns = Vec::new();
     filter.collect_columns(data_schema, &mut columns);
     columns
-}
-
-/// Creates a stats schema from a referenced schema (e.g. columns from a predicate).
-/// Returns schema: `{ numRecords, nullCount, minValues, maxValues }`
-///
-/// This is used to build the schema for parsing JSON stats and for reading stats_parsed
-/// from checkpoints when only a subset of columns is needed (e.g. predicate-referenced columns).
-pub(crate) fn build_stats_schema(referenced_schema: &StructType) -> Option<SchemaRef> {
-    let stats_schema = schema_with_all_fields_nullable(referenced_schema);
-
-    let nullcount_schema = NullCountStatsTransform
-        .transform_struct(&stats_schema)
-        .into_owned();
-
-    let schema = StructType::new_unchecked([
-        StructField::nullable(NUM_RECORDS, DataType::LONG),
-        StructField::nullable(NULL_COUNT, nullcount_schema),
-        StructField::nullable(MIN_VALUES, stats_schema.clone()),
-        StructField::nullable(MAX_VALUES, stats_schema),
-    ]);
-
-    // Strip field metadata. The stats types are derived from the table schema, but the metadata on
-    // the fields should not be included in the stats fields
-    let schema = StripFieldMetadataTransform.transform_struct(&schema);
-    Some(Arc::new(schema.into_owned()))
 }
 
 /// Strips all field metadata from a schema.

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -365,8 +365,10 @@ fn test_sql_where() {
 #[test]
 fn test_timestamp_stats_enabled() {
     let empty = HashSet::new();
+    let stats_columns: HashSet<ColumnName> = [column_name!("timestamp_col")].into_iter().collect();
     let creator = DataSkippingPredicateCreator {
         partition_columns: &empty,
+        stats_columns: &stats_columns,
     };
     let col = &column_name!("timestamp_col");
 
@@ -439,7 +441,8 @@ fn test_checkpoint_skipping_semantic(
     #[case] description: &str,
 ) {
     let pred = Pred::gt(column_expr!("x"), Scalar::from(100));
-    let skipping_pred = as_checkpoint_skipping_predicate(&pred, &[]).unwrap();
+    let stats = all_referenced_columns(&pred);
+    let skipping_pred = as_checkpoint_skipping_predicate(&pred, &[], &stats).unwrap();
     let resolver = HashMap::from_iter([(column_name!("maxValues.x"), max_val)]);
     let filter = DefaultKernelPredicateEvaluator::from(resolver);
     expect_eq!(filter.eval(&skipping_pred), expected, "{description}");
@@ -454,7 +457,8 @@ fn test_checkpoint_skipping_null_guard_vs_regular() {
         HashMap::from_iter([(column_name!("maxValues.x"), Scalar::Null(DataType::INTEGER))]);
     let filter = DefaultKernelPredicateEvaluator::from(resolver);
 
-    let guarded = as_checkpoint_skipping_predicate(&pred, &[]).unwrap();
+    let stats = all_referenced_columns(&pred);
+    let guarded = as_checkpoint_skipping_predicate(&pred, &[], &stats).unwrap();
     expect_eq!(
         filter.eval(&guarded),
         TRUE,
@@ -484,7 +488,8 @@ fn test_checkpoint_skipping_conjunction_partial_null_stats() {
         Pred::gt(column_expr!("col_a"), Scalar::from(100)),
         Pred::lt(column_expr!("col_b"), Scalar::from(50)),
     );
-    let skipping_pred = as_checkpoint_skipping_predicate(&pred, &[]).unwrap();
+    let stats = all_referenced_columns(&pred);
+    let skipping_pred = as_checkpoint_skipping_predicate(&pred, &[], &stats).unwrap();
 
     // Both stats present and both allow pruning -> skip
     let resolver = HashMap::from_iter([
@@ -539,7 +544,8 @@ fn test_checkpoint_skipping_timestamp_adjustment(
 
     // GT: should produce OR(maxValues.ts_col IS NULL, maxValues.ts_col > 999001)
     let pred = Pred::gt(col.clone(), timestamp.clone());
-    let skipping_pred = as_checkpoint_skipping_predicate(&pred, &[]).unwrap();
+    let stats = all_referenced_columns(&pred);
+    let skipping_pred = as_checkpoint_skipping_predicate(&pred, &[], &stats).unwrap();
     assert_eq!(
         skipping_pred.to_string(),
         "OR(Column(maxValues.ts_col) IS NULL, Column(maxValues.ts_col) > 999001)"
@@ -547,7 +553,8 @@ fn test_checkpoint_skipping_timestamp_adjustment(
 
     // EQ: max stat leg should use adjusted literal
     let pred = Pred::eq(col.clone(), timestamp.clone());
-    let skipping_pred = as_checkpoint_skipping_predicate(&pred, &[]).unwrap();
+    let stats = all_referenced_columns(&pred);
+    let skipping_pred = as_checkpoint_skipping_predicate(&pred, &[], &stats).unwrap();
     assert_eq!(
         skipping_pred.to_string(),
         "AND(OR(Column(minValues.ts_col) IS NULL, NOT(Column(minValues.ts_col) > 1000000)), \
@@ -1085,7 +1092,8 @@ fn multiple_partition_columns_rewrite_and_evaluation() {
 #[test]
 fn single_unsupported_pred_in_junction_disables_checkpoint_pushdown() {
     let pred = Pred::and_from([Pred::unknown("unsupported")]);
-    let skipping_pred = as_checkpoint_skipping_predicate(&pred, &[]);
+    let stats = all_referenced_columns(&pred);
+    let skipping_pred = as_checkpoint_skipping_predicate(&pred, &[], &stats);
     assert!(
         skipping_pred.is_none(),
         "Single unsupported predicate in a junction should disable pushdown, got: {skipping_pred:?}"
@@ -1361,4 +1369,134 @@ fn timestamp_predicate_skipping(#[case] pred: Pred, #[case] expected: usize) {
 )]
 fn unsupported_predicate_skipping(#[case] pred: Pred, #[case] expected: usize) {
     assert_eq!(count_selected(STATS_TABLE, Arc::new(pred)), expected);
+}
+
+// === Stats-columns gate: non-stat refs collapse to NULL ===
+//
+// Covers the predicate-rewrite half of the gate. The upstream column-selection half
+// (numIndexedCols cap, statsColumns, struct prefixes, etc.) is in
+// `stats_schema::column_filter::tests`.
+
+/// Builds a stats-column set from leaf paths spelled as dotted strings.
+fn stats_cols(cols: &[&str]) -> HashSet<ColumnName> {
+    cols.iter().map(|s| ColumnName::new(s.split('.'))).collect()
+}
+
+/// Rewrite shape for the production `DataSkippingPredicateCreator` SQL-WHERE path.
+///
+/// Each case is a `(SQL predicate, partition columns, stats_parsed contents, expected
+/// rewrite)` row. `expected` is the exact display form of the rewrite. The SQL-WHERE
+/// wrapping adds a per-column not-all-null guard (`NOT(nullCount = numRecords)`) and a
+/// `true` filler around each stat comparison; non-stat refs fold to a `null` literal
+/// inside a `AND(null, true)` 2-arg group, evaluating to NULL ("keep the file").
+///
+/// Companion semantic test: `mixed_and_non_stat_arm_still_prunes_via_stat_arm` (below)
+/// shows the rewrite from `stat_and_non_stat_folds_non_stat` actually prunes a file
+/// when the stat arm's min/max bounds rule it out.
+#[rstest]
+#[case::non_stat_only_folds_to_trivial_null(
+    Pred::gt(column_expr!("non_stat"), Scalar::from(1)),
+    HashSet::<String>::new(),
+    stats_cols(&["stat"]),
+    "AND(null, true)",
+)]
+#[case::stat_and_non_stat_folds_non_stat(
+    Pred::and(
+        Pred::gt(column_expr!("stat"), Scalar::from(100)),
+        Pred::gt(column_expr!("non_stat"), Scalar::from(50)),
+    ),
+    HashSet::<String>::new(),
+    stats_cols(&["stat"]),
+    "AND(AND(NOT(Column(stats_parsed.nullCount.stat) = Column(stats_parsed.numRecords)), \
+     true, Column(stats_parsed.maxValues.stat) > 100), AND(null, true))",
+)]
+#[case::nested_stat_leaf_kept(
+    Pred::and(
+        Pred::gt(column_expr!("user.email"), Scalar::from(100)),
+        Pred::gt(column_expr!("user.password"), Scalar::from(200)),
+    ),
+    HashSet::<String>::new(),
+    stats_cols(&["user.email"]),
+    "AND(AND(NOT(Column(stats_parsed.nullCount.user.email) = Column(stats_parsed.numRecords)), \
+     true, Column(stats_parsed.maxValues.user.email) > 100), AND(null, true))",
+)]
+#[case::partition_stat_non_stat_three_way(
+    Pred::and(
+        Pred::gt(column_expr!("part"), Scalar::from("p")),
+        Pred::and(
+            Pred::gt(column_expr!("stat"), Scalar::from(100)),
+            Pred::gt(column_expr!("non_stat"), Scalar::from(50)),
+        ),
+    ),
+    HashSet::from(["part".to_string()]),
+    stats_cols(&["stat"]),
+    "AND(AND(OR(NOT(Column(is_add)), NOT(Column(partitionValues_parsed.part) IS NULL)), \
+     true, OR(NOT(Column(is_add)), Column(partitionValues_parsed.part) > 'p')), \
+     AND(AND(NOT(Column(stats_parsed.nullCount.stat) = Column(stats_parsed.numRecords)), \
+     true, Column(stats_parsed.maxValues.stat) > 100), AND(null, true)))",
+)]
+#[case::both_in_stats_set_keeps_both_arms(
+    Pred::and(
+        Pred::gt(column_expr!("stat"), Scalar::from(100)),
+        Pred::gt(column_expr!("non_stat"), Scalar::from(50)),
+    ),
+    HashSet::<String>::new(),
+    stats_cols(&["stat", "non_stat"]),
+    "AND(AND(NOT(Column(stats_parsed.nullCount.stat) = Column(stats_parsed.numRecords)), \
+     true, Column(stats_parsed.maxValues.stat) > 100), \
+     AND(NOT(Column(stats_parsed.nullCount.non_stat) = Column(stats_parsed.numRecords)), \
+     true, Column(stats_parsed.maxValues.non_stat) > 50))",
+)]
+fn stats_columns_gate_rewrite(
+    #[case] pred: Pred,
+    #[case] partition_columns: HashSet<String>,
+    #[case] stats: HashSet<ColumnName>,
+    #[case] expected: &str,
+) {
+    let result =
+        as_sql_data_skipping_predicate_with_stats_columns(&pred, &partition_columns, &stats)
+            .expect("SQL-WHERE rewrite always returns Some for these cases");
+    assert_eq!(result.to_string(), expected);
+}
+
+/// Semantic companion to `stat_and_non_stat_folds_non_stat`. When `max(stat) < 100` the
+/// stat arm evaluates to false, the AND short-circuits, and the file is pruned despite
+/// the non-stat NULL fold.
+#[test]
+fn mixed_and_non_stat_arm_still_prunes_via_stat_arm() {
+    let pred = Pred::and(
+        Pred::gt(column_expr!("stat"), Scalar::from(100)),
+        Pred::gt(column_expr!("non_stat"), Scalar::from(50)),
+    );
+    let stats = stats_cols(&["stat"]);
+    let result =
+        as_sql_data_skipping_predicate_with_stats_columns(&pred, &Default::default(), &stats)
+            .unwrap();
+    let resolver = HashMap::from_iter([(
+        column_name!("stats_parsed.maxValues.stat"),
+        Scalar::from(50i32),
+    )]);
+    let filter = DefaultKernelPredicateEvaluator::from(resolver);
+    expect_eq!(
+        filter.eval(&result),
+        FALSE,
+        "stat arm prunes despite non-stat NULL fold"
+    );
+}
+
+/// Same scenario as `stat_and_non_stat_folds_non_stat` but through the checkpoint-pushdown
+/// (NullGuarded) creator, which adds an `IS NULL` guard on each stat ref for safe parquet
+/// row-group filtering. The non-stat arm still folds to NULL.
+#[test]
+fn checkpoint_pushdown_non_stat_arm_folds_to_null_literal() {
+    let pred = Pred::and(
+        Pred::gt(column_expr!("stat"), Scalar::from(100)),
+        Pred::gt(column_expr!("non_stat"), Scalar::from(50)),
+    );
+    let stats = stats_cols(&["stat"]);
+    let result = as_checkpoint_skipping_predicate(&pred, &[], &stats).unwrap();
+    assert_eq!(
+        result.to_string(),
+        "AND(OR(Column(maxValues.stat) IS NULL, Column(maxValues.stat) > 100), null)"
+    );
 }

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -46,6 +46,13 @@ struct InternalScanState {
     skip_stats: bool,
     /// Physical partition schema for checkpoint partition pruning via `partitionValues_parsed`
     physical_partition_schema: Option<SchemaRef>,
+    /// Physical leaf paths which are expected to have stats collected. Carried alongside
+    /// `physical_stats_schema` so the distributed `DataSkippingFilter` rebuilds the same
+    /// filter the sequential phase used. `#[serde(default)]` keeps older blobs readable:
+    /// an empty set drops every data-column reference, which means no skipping but is
+    /// still correct.
+    #[serde(default)]
+    physical_stats_columns: HashSet<ColumnName>,
 }
 
 /// Serializable processor state for distributed processing. This can be serialized using the
@@ -224,6 +231,7 @@ impl ScanLogReplayProcessor {
                 partition_schema_for_transform.as_ref(),
                 column_expr_ref!("partitionValues_parsed"),
                 output_schema.clone(),
+                &state_info.physical_stats_columns,
                 Some(metrics.clone()),
             )
         };
@@ -295,6 +303,7 @@ impl ScanLogReplayProcessor {
             column_mapping_mode,
             physical_stats_schema,
             physical_partition_schema,
+            physical_stats_columns,
         } = self.state_info.as_ref().clone();
 
         // Extract predicate from PhysicalPredicate
@@ -313,6 +322,7 @@ impl ScanLogReplayProcessor {
             physical_stats_schema,
             skip_stats: self.skip_stats,
             physical_partition_schema,
+            physical_stats_columns,
         };
         let internal_state_blob = serde_json::to_vec(&internal_state)
             .map_err(|e| Error::generic(format!("Failed to serialize internal state: {e}")))?;
@@ -369,6 +379,7 @@ impl ScanLogReplayProcessor {
             column_mapping_mode: internal_state.column_mapping_mode,
             physical_stats_schema: internal_state.physical_stats_schema,
             physical_partition_schema: internal_state.physical_partition_schema,
+            physical_stats_columns: internal_state.physical_stats_columns,
         });
 
         Self::new_with_seen_files(
@@ -1036,6 +1047,7 @@ mod tests {
             column_mapping_mode: ColumnMappingMode::None,
             physical_stats_schema: None,
             physical_partition_schema: None,
+            physical_stats_columns: HashSet::new(),
         });
         let (iter, _metrics) = scan_action_iter(
             &SyncEngine::new(),
@@ -1364,6 +1376,7 @@ mod tests {
                 column_mapping_mode: mode,
                 physical_stats_schema: None,
                 physical_partition_schema: None,
+                physical_stats_columns: HashSet::new(),
             });
             let checkpoint_info = test_checkpoint_info();
             let processor =
@@ -1396,6 +1409,7 @@ mod tests {
             column_mapping_mode: ColumnMappingMode::None,
             physical_stats_schema: None,
             physical_partition_schema: None,
+            physical_stats_columns: HashSet::new(),
         });
         let processor =
             ScanLogReplayProcessor::new(&engine, state_info, checkpoint_info.clone(), false)
@@ -1441,6 +1455,7 @@ mod tests {
             physical_stats_schema: None,
             skip_stats: false,
             physical_partition_schema: None,
+            physical_stats_columns: HashSet::new(),
         };
         let predicate = Arc::new(crate::expressions::Predicate::column(["id"]));
         let invalid_blob = serde_json::to_vec(&invalid_internal_state).unwrap();
@@ -1473,6 +1488,7 @@ mod tests {
             physical_stats_schema: None,
             skip_stats: false,
             physical_partition_schema: None,
+            physical_stats_columns: HashSet::new(),
         };
         let blob = serde_json::to_string(&invalid_internal_state).unwrap();
         let mut obj: serde_json::Value = serde_json::from_str(&blob).unwrap();

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -858,7 +858,11 @@ impl Scan {
             .table_configuration()
             .metadata()
             .partition_columns();
-        let skipping_pred = as_checkpoint_skipping_predicate(predicate, partition_columns)?;
+        let skipping_pred = as_checkpoint_skipping_predicate(
+            predicate,
+            partition_columns,
+            &self.state_info.physical_stats_columns,
+        )?;
 
         let mut prefixer = PrefixColumns {
             prefix: ColumnName::new(["add", "stats_parsed"]),

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -4,10 +4,10 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use tracing::{debug, warn};
+use tracing::{debug, enabled, warn, Level};
 
+use crate::actions::NULL_COUNT;
 use crate::expressions::ColumnName;
-use crate::scan::data_skipping::stats_schema::build_stats_schema;
 use crate::scan::field_classifiers::TransformFieldClassifier;
 use crate::scan::transform_spec::{FieldTransformSpec, TransformSpec};
 use crate::scan::{PhysicalPredicate, StatsOutputMode};
@@ -36,6 +36,14 @@ pub(crate) struct StateInfo {
     /// `partitionValues_parsed`. Fields use physical column names (for column mapping).
     /// Only present when the table has partition columns and a predicate is provided.
     pub(crate) physical_partition_schema: Option<SchemaRef>,
+    /// Physical leaf paths which are expected to have stats collected.
+    ///
+    /// Differs from `physical_stats_schema` in that this is the per-table membership set
+    /// (predicate-independent). `physical_stats_schema` is the per-scan projection shape
+    /// (predicate-trimmed).
+    ///
+    /// Read-path mirror of `SharedWriteState.stats_columns`.
+    pub(crate) physical_stats_columns: HashSet<ColumnName>,
 }
 
 /// Validating the metadata columns also extracts information needed to properly construct the full
@@ -108,8 +116,11 @@ fn validate_metadata_columns<'a>(
 /// - `physical_stats_schema` contains data-column stats for `stats_parsed`.
 /// - `physical_partition_schema` contains typed partition values for `partitionValues_parsed`.
 ///
-/// In predicate-only mode, predicate-referenced columns are split into data columns
-/// (stats-based pruning) and partition columns (partition-value pruning).
+/// All three arms route through `TableConfiguration::build_expected_stats_schemas`: the
+/// `AllColumns` arm with no `requested_physical_columns` filter, and the two scoped arms
+/// with the union of requested + predicate-referenced columns. That path applies the same
+/// `BaseStatsTransform` -> `MinMaxStatsTransform` pipeline writers use, so the read-side
+/// stats schema's shape matches the write-side exactly.
 fn build_data_skipping_schemas(
     stats_output_mode: &StatsOutputMode,
     physical_predicate: &PhysicalPredicate,
@@ -136,69 +147,75 @@ fn build_data_skipping_schemas(
         _ => None,
     };
 
-    match (stats_output_mode, physical_predicate) {
-        // Output all table stats columns in stats_parsed. The DataSkippingFilter
-        // reads stats_parsed from the transformed batch, which uses this schema.
-        (StatsOutputMode::AllColumns, _) => {
-            let expected_stats_schemas =
-                table_configuration.build_expected_stats_schemas(None, None)?;
-            Ok((
-                Some(expected_stats_schemas.physical),
-                predicate_partition_schema,
-            ))
-        }
-        // Non-empty requested columns -- include predicate-referenced columns
-        // alongside the user-requested stats columns so that the DataSkippingFilter
-        // has the stats it needs. Both sources are logical names that must be
-        // converted to physical before passing to build_expected_stats_schemas.
-        (StatsOutputMode::Columns(requested_columns), _) if !requested_columns.is_empty() => {
-            let existing: HashSet<&ColumnName> = requested_columns.iter().collect();
-            let mut all_needed_logical = requested_columns.clone();
-            for col in predicate_column_names_logical {
-                if !existing.contains(col) {
-                    all_needed_logical.push(col.clone());
-                }
+    // `DataSkippingFilter` needs stats for every column its predicate references. Refs
+    // without stats fold to NULL and pruning collapses to "keep every file", even when
+    // the caller separately requested stats for some other set of columns via
+    // `StatsOutputMode::Columns`. Union the two so the schema serves both. Unresolvable
+    // refs (e.g. a predicate typo) are dropped here.
+    let union_to_physical = |requested_logical: &[ColumnName]| -> Vec<ColumnName> {
+        let mut union_logical: Vec<ColumnName> = requested_logical.to_vec();
+        let existing: HashSet<&ColumnName> = requested_logical.iter().collect();
+        for col in predicate_column_names_logical {
+            if !existing.contains(col) {
+                union_logical.push(col.clone());
             }
-            let logical_schema = table_configuration.logical_schema();
-            let column_mapping_mode = table_configuration.column_mapping_mode();
-            let all_needed_physical: Vec<ColumnName> = all_needed_logical
-                .iter()
-                .filter_map(|col| {
-                    // Columns not found in the logical schema (e.g. predicate references a
-                    // column that doesn't exist in the table) are safe to skip.
-                    get_any_level_column_physical_name(&logical_schema, col, column_mapping_mode)
-                        .inspect_err(|e| {
-                            warn!("Failed to resolve physical name for column {col}: {e}")
-                        })
-                        .ok()
-                })
-                .collect();
-            let expected_stats_schemas = table_configuration
-                .build_expected_stats_schemas(None, Some(&all_needed_physical))?;
-            Ok((
-                Some(expected_stats_schemas.physical),
-                predicate_partition_schema,
-            ))
         }
-        // Columns(empty) or Skip with a physical predicate -- build stats directly
-        // from the physical predicate's referenced schema for internal data skipping
-        // only (no logical schema needed for output).
-        // Split referenced columns into data columns and partition columns.
-        // Data columns get min/max/nullCount stats; partition columns get exact values.
-        (_, PhysicalPredicate::Some(_, schema)) => {
-            let data_stats = schema
-                .with_fields_filtered_nonempty(|f| {
-                    predicate_partition_schema
-                        .as_ref()
-                        .is_none_or(|partition_schema| partition_schema.field(f.name()).is_none())
-                })?
-                .as_ref()
-                .and_then(build_stats_schema);
-            Ok((data_stats, predicate_partition_schema))
+        let logical_schema = table_configuration.logical_schema();
+        let column_mapping_mode = table_configuration.column_mapping_mode();
+        union_logical
+            .iter()
+            .filter_map(|col| {
+                get_any_level_column_physical_name(&logical_schema, col, column_mapping_mode)
+                    .inspect_err(|e| warn!("Failed to resolve physical name for column {col}: {e}"))
+                    .ok()
+            })
+            .collect()
+    };
+
+    // A stats schema with only `numRecords` and `tightBounds` (the bookkeeping fields
+    // `build_expected_stats_schemas` always emits) has nothing to prune by. Return `None`
+    // in that case so the caller skips building a `DataSkippingFilter`. `nullCount` is the
+    // per-column stats wrapper, so its presence is the signal that at least one data
+    // column survived. The Delta protocol allows `minValues` / `maxValues` without
+    // `nullCount`, but `build_expected_stats_schemas` always emits `nullCount` whenever it
+    // emits min/max; this check relies on that implementation property.
+    let with_data_cols = |stats_schema: SchemaRef| -> Option<SchemaRef> {
+        stats_schema
+            .field(NULL_COUNT)
+            .is_some()
+            .then_some(stats_schema)
+    };
+
+    let stats_schema = match (stats_output_mode, physical_predicate) {
+        // Full table stats schema for stats_parsed.
+        (StatsOutputMode::AllColumns, _) => with_data_cols(
+            table_configuration
+                .build_expected_stats_schemas(None, None)?
+                .physical,
+        ),
+        // Explicit requested columns. Union in predicate refs so the stats schema covers
+        // both sources.
+        (StatsOutputMode::Columns(requested_columns), _) if !requested_columns.is_empty() => {
+            let requested_physical = union_to_physical(requested_columns);
+            with_data_cols(
+                table_configuration
+                    .build_expected_stats_schemas(None, Some(&requested_physical))?
+                    .physical,
+            )
         }
-        // No stats output and no predicate
-        (_, _) => Ok((None, None)),
-    }
+        // No explicit requested columns, but a predicate is present. Use just the predicate
+        // refs so the stats schema is trimmed to what the rewritten predicate needs.
+        (_, PhysicalPredicate::Some(_, _)) => {
+            let predicate_refs_physical = union_to_physical(&[]);
+            with_data_cols(
+                table_configuration
+                    .build_expected_stats_schemas(None, Some(&predicate_refs_physical))?
+                    .physical,
+            )
+        }
+        (_, _) => None,
+    };
+    Ok((stats_schema, predicate_partition_schema))
 }
 
 impl StateInfo {
@@ -309,9 +326,8 @@ impl StateInfo {
 
         let physical_schema = Arc::new(StructType::try_new(read_fields)?);
 
-        // Extract column names referenced by the predicate so we can include them
-        // in the stats schema when stats_columns is requested. This ensures the
-        // DataSkippingFilter has the stats it needs for data skipping.
+        // Logical column names referenced by the predicate. Fed into the stats schema
+        // build below and into the dropped-refs observability log.
         let predicate_column_names: Vec<ColumnName> = predicate
             .as_ref()
             .map(|p| p.references().into_iter().cloned().collect())
@@ -321,6 +337,30 @@ impl StateInfo {
             Some(pred) => PhysicalPredicate::try_new(&pred, &logical_schema, column_mapping_mode)?,
             None => PhysicalPredicate::None,
         };
+
+        // Stats-eligible column set. Partition columns are excluded; they flow through
+        // `partitionValues_parsed` instead.
+        let physical_stats_columns = table_configuration.physical_stats_columns_set(None);
+        // Observability: predicate refs outside `physical_stats_columns` get folded to NULL
+        // by the gate. Surface the dropped set so an engine operator can see what got folded.
+        // The filter walk is bounded by predicate width but still does a physical-name
+        // resolution per ref, so gate it on the log level to skip the work when DEBUG is off.
+        if enabled!(Level::DEBUG) && matches!(physical_predicate, PhysicalPredicate::Some(_, _)) {
+            let dropped: Vec<&ColumnName> = predicate_column_names
+                .iter()
+                .filter(|c| {
+                    get_any_level_column_physical_name(&logical_schema, c, column_mapping_mode)
+                        .ok()
+                        .is_some_and(|physical| !physical_stats_columns.contains(&physical))
+                })
+                .collect();
+            if !dropped.is_empty() {
+                debug!(
+                    "Checkpoint pushdown: predicate refs to non-stats columns folded to NULL: {:?}",
+                    dropped
+                );
+            }
+        }
 
         // Build partition schema with physical names for partition pruning in data skipping.
         // Only needed when we have a predicate and partition columns.
@@ -372,6 +412,7 @@ impl StateInfo {
             column_mapping_mode,
             physical_stats_schema,
             physical_partition_schema,
+            physical_stats_columns,
         })
     }
 
@@ -398,11 +439,12 @@ pub(crate) mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
 
+    use rstest::rstest;
     use url::Url;
 
     use super::*;
     use crate::actions::{Metadata, Protocol, MAX_VALUES, MIN_VALUES};
-    use crate::expressions::{column_expr, column_name, Expression as Expr};
+    use crate::expressions::{column_expr, column_name, Expression as Expr, Predicate as Pred};
     use crate::schema::{ColumnMetadataKey, MetadataValue};
     use crate::table_features::{FeatureType, TableFeature};
     use crate::utils::test_utils::assert_result_error_with_message;
@@ -1175,5 +1217,304 @@ pub(crate) mod tests {
                 );
             }
         }
+    }
+
+    // === physical_stats_columns trims the predicate-derived stats schema ===
+
+    /// Flat schema with `n` long columns named `c0..c{n-1}`.
+    fn flat_long_schema(n: usize) -> SchemaRef {
+        Arc::new(StructType::new_unchecked(
+            (0..n)
+                .map(|i| StructField::nullable(format!("c{i}"), DataType::LONG))
+                .collect::<Vec<_>>(),
+        ))
+    }
+
+    /// `delta.dataSkippingNumIndexedCols=<n>` configuration map.
+    fn num_indexed_cols_config(n: i32) -> HashMap<String, String> {
+        let mut m = HashMap::new();
+        m.insert(
+            "delta.dataSkippingNumIndexedCols".to_string(),
+            n.to_string(),
+        );
+        m
+    }
+
+    /// `delta.dataSkippingStatsColumns=<cols joined by ",">` configuration map.
+    fn stats_columns_config(cols: &[&str]) -> HashMap<String, String> {
+        let mut m = HashMap::new();
+        m.insert("delta.dataSkippingStatsColumns".to_string(), cols.join(","));
+        m
+    }
+
+    /// Both `delta.dataSkippingStatsColumns` and `delta.dataSkippingNumIndexedCols` set
+    /// simultaneously. Per the Delta protocol, the explicit list takes precedence over the
+    /// cap; this helper exists for tests that exercise that precedence.
+    fn both_configs(stats_cols: &[&str], num_indexed: i32) -> HashMap<String, String> {
+        let mut m = stats_columns_config(stats_cols);
+        m.insert(
+            "delta.dataSkippingNumIndexedCols".to_string(),
+            num_indexed.to_string(),
+        );
+        m
+    }
+
+    /// `delta.dataSkippingNumIndexedCols` caps the `physical_stats_columns` set to the
+    /// first N leaves.
+    #[test]
+    fn stats_columns_honors_num_indexed_cols() {
+        let schema = flat_long_schema(5);
+        let state_info = get_state_info(
+            schema,
+            vec![],
+            None, // no predicate; just check the cached set
+            &[],
+            num_indexed_cols_config(2),
+            vec![],
+        )
+        .unwrap();
+        let cols: HashSet<ColumnName> =
+            ["c0", "c1"].iter().map(|s| ColumnName::new([*s])).collect();
+        assert_eq!(state_info.physical_stats_columns, cols);
+    }
+
+    /// Predicate on a past-cap column: stats schema goes to `None` (no skipping), but
+    /// the physical predicate is retained so engines can still apply it per-row.
+    #[test]
+    fn predicate_on_past_cap_column_drops_stats_schema() {
+        let schema = flat_long_schema(5);
+        let predicate = Arc::new(column_expr!("c4").gt(Expr::literal(10i64)));
+        let state_info = get_state_info(
+            schema,
+            vec![],
+            Some(predicate),
+            &[],
+            num_indexed_cols_config(2),
+            vec![],
+        )
+        .unwrap();
+        assert!(
+            state_info.physical_stats_schema.is_none(),
+            "Predicate on a past-cap column should produce no stats schema, got {:?}",
+            state_info.physical_stats_schema
+        );
+        assert!(
+            matches!(state_info.physical_predicate, PhysicalPredicate::Some(_, _)),
+            "User predicate must be retained even when stats schema is dropped"
+        );
+    }
+
+    /// Indexed AND past-cap: indexed leaf survives in the stats schema, past-cap leaf
+    /// is dropped.
+    #[test]
+    fn predicate_on_mixed_indexed_and_past_cap_keeps_indexed_only() {
+        let schema = flat_long_schema(5);
+        let predicate = Arc::new(Pred::and(
+            column_expr!("c0").gt(Expr::literal(10i64)),
+            column_expr!("c4").gt(Expr::literal(10i64)),
+        ));
+        let state_info = get_state_info(
+            schema,
+            vec![],
+            Some(predicate),
+            &[],
+            num_indexed_cols_config(2),
+            vec![],
+        )
+        .unwrap();
+        let stats_schema = state_info
+            .physical_stats_schema
+            .as_ref()
+            .expect("should have stats schema (indexed arm survives)");
+        for stats_field in [MIN_VALUES, MAX_VALUES] {
+            let DataType::Struct(inner) = stats_schema
+                .field(stats_field)
+                .unwrap_or_else(|| panic!("should have {stats_field}"))
+                .data_type()
+            else {
+                panic!("{stats_field} should be a struct");
+            };
+            assert!(
+                inner.field("c0").is_some(),
+                "{stats_field} should contain c0 (indexed)"
+            );
+            assert!(
+                inner.field("c4").is_none(),
+                "{stats_field} should NOT contain c4 (past cap)"
+            );
+        }
+    }
+
+    /// `numIndexedCols=2` against `{ a, b, s: { c, d } }` keeps `a, b` and drops the
+    /// entire `s` struct, so a predicate on `s.c` produces no stats schema.
+    #[test]
+    fn predicate_on_nested_past_cap_leaf_drops_parent_struct() {
+        let schema = Arc::new(StructType::new_unchecked(vec![
+            StructField::nullable("a", DataType::LONG),
+            StructField::nullable("b", DataType::LONG),
+            StructField::nullable(
+                "s",
+                DataType::Struct(Box::new(StructType::new_unchecked(vec![
+                    StructField::nullable("c", DataType::LONG),
+                    StructField::nullable("d", DataType::LONG),
+                ]))),
+            ),
+        ]));
+        // Predicate only on the past-cap leaf -> stats schema goes empty -> None.
+        let predicate = Arc::new(column_expr!("s.c").gt(Expr::literal(10i64)));
+        let state_info = get_state_info(
+            schema,
+            vec![],
+            Some(predicate),
+            &[],
+            num_indexed_cols_config(2),
+            vec![],
+        )
+        .unwrap();
+        assert!(state_info.physical_stats_schema.is_none());
+        assert!(!state_info.physical_stats_columns.is_empty());
+        assert!(!state_info
+            .physical_stats_columns
+            .contains(&ColumnName::new(["s", "c"])));
+    }
+
+    /// `delta.dataSkippingStatsColumns` selects exactly the listed leaves, regardless of
+    /// their position relative to the (default) cap.
+    #[rstest]
+    #[case::single(&["c2"], &["c2"])]
+    #[case::sparse_subset(&["c0", "c3"], &["c0", "c3"])]
+    #[case::all_listed(&["c0", "c1", "c2", "c3", "c4"], &["c0", "c1", "c2", "c3", "c4"])]
+    fn stats_columns_honors_explicit_stats_columns(
+        #[case] listed: &[&str],
+        #[case] expected: &[&str],
+    ) {
+        let schema = flat_long_schema(5);
+        let state_info = get_state_info(
+            schema,
+            vec![],
+            None,
+            &[],
+            stats_columns_config(listed),
+            vec![],
+        )
+        .unwrap();
+        let expected_cols: HashSet<ColumnName> =
+            expected.iter().map(|s| ColumnName::new([*s])).collect();
+        assert_eq!(state_info.physical_stats_columns, expected_cols);
+    }
+
+    /// `numIndexedCols=3` against `{ a, b, s: { c, d } }` keeps `a, b, s.c` and drops
+    /// `s.d`. A predicate on both `s.c` and `s.d` keeps the `s` struct under
+    /// `minValues` / `maxValues` with `c` only.
+    #[test]
+    fn predicate_on_nested_mixed_keeps_intersection_under_parent_struct() {
+        let schema = Arc::new(StructType::new_unchecked(vec![
+            StructField::nullable("a", DataType::LONG),
+            StructField::nullable("b", DataType::LONG),
+            StructField::nullable(
+                "s",
+                DataType::Struct(Box::new(StructType::new_unchecked(vec![
+                    StructField::nullable("c", DataType::LONG),
+                    StructField::nullable("d", DataType::LONG),
+                ]))),
+            ),
+        ]));
+        let predicate = Arc::new(Pred::and(
+            column_expr!("s.c").gt(Expr::literal(10i64)),
+            column_expr!("s.d").gt(Expr::literal(10i64)),
+        ));
+        let state_info = get_state_info(
+            schema,
+            vec![],
+            Some(predicate),
+            &[],
+            num_indexed_cols_config(3),
+            vec![],
+        )
+        .unwrap();
+        let stats_schema = state_info
+            .physical_stats_schema
+            .as_ref()
+            .expect("indexed arm survives");
+        for stats_field in [MIN_VALUES, MAX_VALUES] {
+            let DataType::Struct(outer) = stats_schema
+                .field(stats_field)
+                .unwrap_or_else(|| panic!("should have {stats_field}"))
+                .data_type()
+            else {
+                panic!("{stats_field} should be a struct");
+            };
+            let DataType::Struct(inner) = outer
+                .field("s")
+                .unwrap_or_else(|| panic!("{stats_field} should have s"))
+                .data_type()
+            else {
+                panic!("{stats_field}.s should be a struct");
+            };
+            assert!(
+                inner.field("c").is_some(),
+                "{stats_field}.s should keep c (indexed)"
+            );
+            assert!(
+                inner.field("d").is_none(),
+                "{stats_field}.s should drop d (past cap)"
+            );
+        }
+    }
+
+    /// `dataSkippingStatsColumns` with a parent struct path admits every leaf under that
+    /// parent (the trie matches by prefix). `{ a, s: { c, d } }` with the property set to
+    /// `"s"` should produce `{ s.c, s.d }` (and exclude `a`, which is not in the list).
+    #[test]
+    fn stats_columns_admits_all_children_of_nested_parent_in_explicit_list() {
+        let schema = Arc::new(StructType::new_unchecked(vec![
+            StructField::nullable("a", DataType::LONG),
+            StructField::nullable(
+                "s",
+                DataType::Struct(Box::new(StructType::new_unchecked(vec![
+                    StructField::nullable("c", DataType::LONG),
+                    StructField::nullable("d", DataType::LONG),
+                ]))),
+            ),
+        ]));
+        let state_info = get_state_info(
+            schema,
+            vec![],
+            None,
+            &[],
+            stats_columns_config(&["s"]),
+            vec![],
+        )
+        .unwrap();
+        let expected: HashSet<ColumnName> =
+            [ColumnName::new(["s", "c"]), ColumnName::new(["s", "d"])]
+                .into_iter()
+                .collect();
+        assert_eq!(state_info.physical_stats_columns, expected);
+    }
+
+    /// `dataSkippingStatsColumns` ("A") takes precedence over `dataSkippingNumIndexedCols`
+    /// ("B") whether A wants more columns than B allows or fewer.
+    #[rstest]
+    #[case::a_broader_than_b(&["c0", "c3", "c4"], 2, &["c0", "c3", "c4"])]
+    #[case::a_narrower_than_b(&["c0"], 3, &["c0"])]
+    fn stats_columns_explicit_list_overrides_num_indexed_cols(
+        #[case] listed: &[&str],
+        #[case] num_indexed: i32,
+        #[case] expected: &[&str],
+    ) {
+        let schema = flat_long_schema(5);
+        let state_info = get_state_info(
+            schema,
+            vec![],
+            None,
+            &[],
+            both_configs(listed, num_indexed),
+            vec![],
+        )
+        .unwrap();
+        let expected_cols: HashSet<ColumnName> =
+            expected.iter().map(|s| ColumnName::new([*s])).collect();
+        assert_eq!(state_info.physical_stats_columns, expected_cols);
     }
 }

--- a/kernel/src/scan/test_utils.rs
+++ b/kernel/src/scan/test_utils.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use itertools::Itertools;
@@ -165,6 +166,7 @@ pub(crate) fn run_with_validate_callback<T: Clone>(
         column_mapping_mode: ColumnMappingMode::None,
         physical_stats_schema: None,
         physical_partition_schema: None,
+        physical_stats_columns: HashSet::new(),
     });
     let checkpoint_info = CheckpointReadInfo::without_stats_parsed();
     let (iter, _metrics) = scan_action_iter(

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -18,7 +18,7 @@ use crate::expressions::{
 };
 use crate::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use crate::parquet::arrow::arrow_writer::ArrowWriter;
-use crate::scan::data_skipping::as_checkpoint_skipping_predicate;
+use crate::scan::data_skipping::{all_referenced_columns, as_checkpoint_skipping_predicate};
 use crate::scan::state::ScanFile;
 use crate::schema::{ColumnMetadataKey, DataType, StructField, StructType};
 use crate::{
@@ -1038,7 +1038,8 @@ impl CheckpointParquetBuilder {
 
 /// Builds a checkpoint skipping predicate and prefixes column references with `add.stats_parsed`.
 fn build_prefixed_checkpoint_predicate(pred: &Pred) -> Option<Pred> {
-    let skipping_pred = as_checkpoint_skipping_predicate(pred, &[])?;
+    let stats = all_referenced_columns(pred);
+    let skipping_pred = as_checkpoint_skipping_predicate(pred, &[], &stats)?;
     let mut prefixer = PrefixColumns {
         prefix: ColumnName::new(["add", "stats_parsed"]),
     };

--- a/kernel/src/table_changes/log_replay.rs
+++ b/kernel/src/table_changes/log_replay.rs
@@ -16,7 +16,6 @@ use crate::actions::{
 use crate::engine_data::{GetData, TypedGetData};
 use crate::expressions::{column_expr, column_expr_ref, column_name, ColumnName, Expression};
 use crate::path::{AsUrl, ParsedLogPath};
-use crate::scan::data_skipping::stats_schema::build_stats_schema;
 use crate::scan::data_skipping::DataSkippingFilter;
 use crate::scan::state::DvInfo;
 use crate::schema::{
@@ -58,25 +57,43 @@ pub(crate) fn table_changes_action_iter(
     table_schema: SchemaRef,
     physical_predicate: Option<(PredicateRef, SchemaRef)>,
 ) -> DeltaResult<impl Iterator<Item = DeltaResult<TableChangesScanMetadata>>> {
+    // Stats-eligible columns for the DataSkippingFilter below. Roughly parallels the scan
+    // path's `StateInfo::physical_stats_columns`. Clustering columns are deliberately not
+    // passed here, for the same reason the scan path leaves them out (see #2588):
+    // loading clustering domain metadata on the table-changes path would add an unbounded
+    // log replay to setup. If #2588 lands a writer-side fix that keeps
+    // `dataSkippingStatsColumns` in sync with clustering, both call sites stay simple.
+    let physical_stats_columns = start_table_configuration.physical_stats_columns_set(None);
+
     let filter = physical_predicate
-        .and_then(|(predicate, ref_schema)| {
-            let stats_schema = build_stats_schema(&ref_schema)?;
+        .and_then(|(predicate, _ref_schema)| {
+            // Build the stats schema via the same path the scan side uses
+            // (`build_expected_stats_schemas`), so the read-side shape matches the write-side
+            // exactly. Predicate refs become the `requested_physical_columns` filter; refs
+            // outside `physical_stats_columns` fold to NULL via `DataSkippingFilter`'s gate.
+            let predicate_refs: Vec<ColumnName> =
+                predicate.references().into_iter().cloned().collect();
+            let physical_stats_schema = start_table_configuration
+                .build_expected_stats_schemas(None, Some(&predicate_refs))
+                .ok()?
+                .physical;
 
             // Parse JSON stats from the raw action batch's `add.stats` column. Unlike the scan
             // path (which transforms first and reads pre-parsed stats), table_changes must
             // resolve deletion vector pairs before filtering, so it operates on raw batches.
             let stats_expr = Arc::new(Expression::parse_json(
                 column_expr!("add.stats"),
-                stats_schema.clone(),
+                physical_stats_schema.clone(),
             ));
             DataSkippingFilter::new(
                 engine.as_ref(),
                 Some(predicate),
-                Some(&stats_schema),
+                Some(&physical_stats_schema),
                 stats_expr,
                 None, // no partition columns for table changes (partition_expr unused)
                 column_expr_ref!("partitionValues_parsed"),
                 get_log_add_schema().clone(),
+                &physical_stats_columns,
                 None, // Table changes doesn't use metrics yet
             )
         })

--- a/kernel/src/table_changes/physical_to_logical.rs
+++ b/kernel/src/table_changes/physical_to_logical.rs
@@ -127,7 +127,7 @@ pub(crate) fn get_cdf_transform_expr(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
     use std::sync::Arc;
 
     use super::*;
@@ -188,6 +188,7 @@ mod tests {
             column_mapping_mode: ColumnMappingMode::None,
             physical_stats_schema: None,
             physical_partition_schema: None,
+            physical_stats_columns: HashSet::new(),
         }
     }
 
@@ -409,6 +410,7 @@ mod tests {
             column_mapping_mode: ColumnMappingMode::None,
             physical_stats_schema: None,
             physical_partition_schema: None,
+            physical_stats_columns: HashSet::new(),
         };
 
         let result = get_cdf_transform_expr(&scan_file, &state_info, &physical_schema);

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -335,6 +335,19 @@ impl TableConfiguration {
         )
     }
 
+    /// Stats-column set for `DataSkippingFilter`'s predicate-rewrite gate. The gate tests
+    /// every column reference in the rewritten predicate against this set, so the two
+    /// callers (`StateInfo::try_new` and `table_changes_action_iter`) share this entry
+    /// point to keep their gate input in lockstep.
+    pub(crate) fn physical_stats_columns_set(
+        &self,
+        required_columns: Option<&[ColumnName]>,
+    ) -> HashSet<ColumnName> {
+        self.physical_stats_column_names(required_columns)
+            .into_iter()
+            .collect()
+    }
+
     /// Returns the physical partition schema for `partitionValues_parsed`.
     ///
     /// Field names are physical column names (respecting column mapping mode),

--- a/kernel/tests/integration/data_skipping.rs
+++ b/kernel/tests/integration/data_skipping.rs
@@ -1,0 +1,245 @@
+//! Integration tests for past-cap data-skipping behavior.
+//!
+//! Covers a table with `delta.dataSkippingNumIndexedCols=N` plus a predicate referencing a
+//! past-cap column. The rewritten predicate must drop refs to columns missing from the
+//! unified stats schema (and from the checkpoint parquet projection); otherwise scan setup
+//! fails with "Schema error: No such field". The tests exercise three code paths that all
+//! share that rewrite:
+//!
+//! - `Scan::scan_metadata` (in-memory `DataSkippingFilter`)
+//! - `Scan::parallel_scan_metadata` (worker rebuilds `DataSkippingFilter` from `InternalScanState`)
+//! - `Scan::build_actions_meta_predicate` (`as_checkpoint_skipping_predicate` pushed down to the
+//!   checkpoint parquet row-group filter)
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use delta_kernel::arrow::array::{Int64Array, RecordBatch};
+use delta_kernel::arrow::datatypes::Schema as ArrowSchema;
+use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
+use delta_kernel::engine::default::executor::tokio::TokioMultiThreadExecutor;
+use delta_kernel::engine::default::DefaultEngine;
+use delta_kernel::expressions::{column_expr, Expression as Expr, Predicate as Pred, PredicateRef};
+use delta_kernel::scan::{AfterSequentialScanMetadata, ParallelScanMetadata};
+use delta_kernel::schema::{DataType, SchemaRef, StructField, StructType};
+use delta_kernel::{Snapshot, SnapshotRef};
+use rstest::rstest;
+use test_utils::{create_table_and_load_snapshot, test_table_setup_mt, write_batch_to_table};
+use url::Url;
+
+use crate::common::write_utils::set_table_properties;
+
+type TestEngine = DefaultEngine<TokioMultiThreadExecutor>;
+
+/// Flat schema with `c0..c4`. `delta.dataSkippingNumIndexedCols=2` keeps stats on `c0` and
+/// `c1`; `c2..c4` are past-cap.
+fn capped_schema() -> SchemaRef {
+    Arc::new(
+        StructType::try_new((0..5).map(|i| StructField::nullable(format!("c{i}"), DataType::LONG)))
+            .unwrap(),
+    )
+}
+
+/// Builds one `RecordBatch` of `rows` rows. `c0` ranges over `c0_start..c0_start+rows`, with
+/// `c1 = c0 + 100` so `c1` ranges share the same width but at higher values. `c2..c4` are
+/// filled with constant `c0_start` so they have no useful min/max even if they were indexed.
+fn long_batch(schema: &SchemaRef, c0_start: i64, rows: i64) -> RecordBatch {
+    let arrow_schema: ArrowSchema = schema.as_ref().try_into_arrow().unwrap();
+    let c0 = Int64Array::from_iter_values(c0_start..c0_start + rows);
+    let c1 = Int64Array::from_iter_values(c0_start + 100..c0_start + 100 + rows);
+    let cn = Int64Array::from_iter_values(std::iter::repeat_n(c0_start, rows as usize));
+    RecordBatch::try_new(
+        Arc::new(arrow_schema),
+        vec![
+            Arc::new(c0),
+            Arc::new(c1),
+            Arc::new(cn.clone()),
+            Arc::new(cn.clone()),
+            Arc::new(cn),
+        ],
+    )
+    .unwrap()
+}
+
+/// Creates a fresh table with `dataSkippingNumIndexedCols=2`, writes three add-files with
+/// disjoint `c0`/`c1` ranges, then checkpoints. Returns `(temp_dir, table_path, engine)`.
+/// The `temp_dir` keeps the on-disk table alive for the duration of the test.
+async fn build_capped_table_with_checkpoint(
+) -> Result<(tempfile::TempDir, String, Arc<TestEngine>), Box<dyn std::error::Error>> {
+    let schema = capped_schema();
+    let (tmp_dir, table_path, engine) = test_table_setup_mt()?;
+    let table_url = Url::from_directory_path(&table_path)
+        .map_err(|_| "table_path should be a valid file URL")?;
+    // `create_table_and_load_snapshot` rejects `delta.dataSkippingNumIndexedCols` at CREATE
+    // TABLE time, so backfill it via a v0-rewrite metadata commit.
+    let snapshot =
+        create_table_and_load_snapshot(&table_path, schema.clone(), engine.as_ref(), &[])?;
+    let mut snapshot = set_table_properties(
+        &table_path,
+        &table_url,
+        engine.as_ref(),
+        snapshot.version(),
+        &[("delta.dataSkippingNumIndexedCols", "2")],
+    )?;
+
+    // file A: c0 in [10, 19], c1 in [110, 119]
+    // file B: c0 in [50, 59], c1 in [150, 159]
+    // file C: c0 in [100, 109], c1 in [200, 209]
+    for c0_start in [10, 50, 100] {
+        snapshot = write_batch_to_table(
+            &snapshot,
+            engine.as_ref(),
+            long_batch(&schema, c0_start, 10),
+            HashMap::new(),
+        )
+        .await?;
+    }
+
+    snapshot.checkpoint(engine.as_ref(), None)?;
+    Ok((tmp_dir, table_path, engine))
+}
+
+/// Counts the files surviving data skipping. Exercises the sequential
+/// `Scan::scan_metadata` path when `use_parallel` is `false`, or the two-phase
+/// `Scan::parallel_scan_metadata` + `ParallelScanMetadata` path when `true`. The parallel
+/// branch dispatches one file per `ParallelScanMetadata` to maximize coverage of the worker
+/// rebuild path.
+fn count_selected_files(
+    snapshot: SnapshotRef,
+    engine: Arc<TestEngine>,
+    predicate: PredicateRef,
+    use_parallel: bool,
+) -> Result<usize, Box<dyn std::error::Error>> {
+    let scan = snapshot.scan_builder().with_predicate(predicate).build()?;
+
+    fn push_path(paths: &mut Vec<String>, scan_file: delta_kernel::scan::state::ScanFile) {
+        paths.push(scan_file.path);
+    }
+
+    let mut paths: Vec<String> = Vec::new();
+
+    if use_parallel {
+        let mut sequential = scan.parallel_scan_metadata(engine.clone())?;
+        for sm in sequential.by_ref() {
+            paths = sm?.visit_scan_files(paths, push_path)?;
+        }
+        if let AfterSequentialScanMetadata::Parallel { state, files } = sequential.finish()? {
+            let state = Arc::from(state);
+            for file in files {
+                let parallel =
+                    ParallelScanMetadata::try_new(engine.clone(), Arc::clone(&state), vec![file])?;
+                for sm in parallel {
+                    paths = sm?.visit_scan_files(paths, push_path)?;
+                }
+            }
+        }
+    } else {
+        for sm in scan.scan_metadata(engine.as_ref())? {
+            paths = sm?.visit_scan_files(paths, push_path)?;
+        }
+    }
+
+    Ok(paths.len())
+}
+
+/// Loads a fresh snapshot off the same on-disk table and returns the surviving file count
+/// for `predicate` along both the sequential and parallel scan-metadata paths.
+fn surviving_files(
+    table_path: &str,
+    engine: Arc<TestEngine>,
+    predicate: PredicateRef,
+    use_parallel: bool,
+) -> Result<usize, Box<dyn std::error::Error>> {
+    let url = delta_kernel::try_parse_uri(table_path)?;
+    let snapshot = Snapshot::builder_for(url).build(engine.as_ref())?;
+    count_selected_files(snapshot, engine, predicate, use_parallel)
+}
+
+// === Predicate matrix ===
+//
+// Table layout (3 files, `dataSkippingNumIndexedCols=2`):
+//   file A: c0 in [10, 19],  c1 in [110, 119]
+//   file B: c0 in [50, 59],  c1 in [150, 159]
+//   file C: c0 in [100, 109], c1 in [200, 209]
+//   c2/c3/c4: past-cap, no stats.
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn all_in_cap_prunes(
+    #[values(false, true)] use_parallel: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_tmp_dir, table_path, engine) = build_capped_table_with_checkpoint().await?;
+    let pred = Arc::new(Pred::gt(column_expr!("c0"), Expr::literal(60i64)));
+    assert_eq!(surviving_files(&table_path, engine, pred, use_parallel)?, 1);
+    Ok(())
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn all_in_cap_keeps_all(
+    #[values(false, true)] use_parallel: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_tmp_dir, table_path, engine) = build_capped_table_with_checkpoint().await?;
+    let pred = Arc::new(Pred::gt(column_expr!("c0"), Expr::literal(0i64)));
+    assert_eq!(surviving_files(&table_path, engine, pred, use_parallel)?, 3);
+    Ok(())
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn all_past_cap_keeps_all(
+    #[values(false, true)] use_parallel: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_tmp_dir, table_path, engine) = build_capped_table_with_checkpoint().await?;
+    let pred = Arc::new(Pred::gt(column_expr!("c4"), Expr::literal(1_000_000i64)));
+    assert_eq!(surviving_files(&table_path, engine, pred, use_parallel)?, 3);
+    Ok(())
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mixed_and_in_cap_prunes(
+    #[values(false, true)] use_parallel: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_tmp_dir, table_path, engine) = build_capped_table_with_checkpoint().await?;
+    // c0 > 60 prunes files A and B; c4 > 50 is past-cap and folds to NULL.
+    // AND(false, NULL) = false keeps the prune; AND(true, NULL) = NULL keeps file C.
+    let pred = Arc::new(Pred::and(
+        Pred::gt(column_expr!("c0"), Expr::literal(60i64)),
+        Pred::gt(column_expr!("c4"), Expr::literal(50i64)),
+    ));
+    assert_eq!(surviving_files(&table_path, engine, pred, use_parallel)?, 1);
+    Ok(())
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mixed_or_keeps_all(
+    #[values(false, true)] use_parallel: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_tmp_dir, table_path, engine) = build_capped_table_with_checkpoint().await?;
+    // c0 > 1000 would prune all 3 by max; c4 > 50 is past-cap and folds to NULL.
+    // OR(false, NULL) = NULL keeps every file.
+    let pred = Arc::new(Pred::or(
+        Pred::gt(column_expr!("c0"), Expr::literal(1000i64)),
+        Pred::gt(column_expr!("c4"), Expr::literal(50i64)),
+    ));
+    assert_eq!(surviving_files(&table_path, engine, pred, use_parallel)?, 3);
+    Ok(())
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn boundary_c1_prunes_all(
+    #[values(false, true)] use_parallel: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_tmp_dir, table_path, engine) = build_capped_table_with_checkpoint().await?;
+    // c1 max across files is 209 < 250 so the in-cap arm rules out everything.
+    // c2 > 50 is past-cap and folds to NULL; AND(false, NULL) = false everywhere.
+    let pred = Arc::new(Pred::and(
+        Pred::gt(column_expr!("c1"), Expr::literal(250i64)),
+        Pred::gt(column_expr!("c2"), Expr::literal(50i64)),
+    ));
+    assert_eq!(surviving_files(&table_path, engine, pred, use_parallel)?, 0);
+    Ok(())
+}

--- a/kernel/tests/integration/main.rs
+++ b/kernel/tests/integration/main.rs
@@ -8,6 +8,7 @@
 mod common;
 
 mod create_table;
+mod data_skipping;
 mod features;
 mod golden_tables;
 mod hdfs;


### PR DESCRIPTION
## What changes are proposed in this pull request?

1/ Predicates that reference columns whose stats aren't in `stats_parsed` used to fail
scan setup with `Schema error: No such field`. This affects tables that set
`delta.dataSkippingNumIndexedCols` or `delta.dataSkippingStatsColumns`.

Checkpoint pushdown  meta_predicates were rewritten against every column the user
predicate referenced, but the trimmed stats schema only contained leaves with stats,
so the row-group filter resolved to fields the parquet projection didn't have causing the
Arrow based engine to error out due to a schema mismatch.

2/ The fix caches the table's stats-eligible physical leaf paths in StateInfo by reading the table configuration. The set is threaded through every consumer that rewrites a predicate against stats.
The schema-trimming half goes through a new `StatsSchemaFilter` SchemaTransform that also
records the dropped paths for the observability log.

## How was this change tested?

1/ Integration and unit tests added to exercise the data skipping scenarios being fixed
with columns beyond num indexed columns and mixed ones.

2/ Existing tests for table_changes log replay, scan log_replay distributed
serialization, and the legacy `as_checkpoint_skipping_predicate` callers continue
to pass.