### PR TITLE
feat: allow fields with same physical name and different physical path

### DIFF
--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -2647,7 +2647,7 @@ mod tests {
     }
 
     #[rstest]
-    #[case::accepted_same_phy_name_diffrent_paths(fixtures::same_phy_name_diffrent_paths(), /*expected_error_substring*/None)]
+    #[case::accepted_same_phy_name_different_paths(fixtures::same_phy_name_different_paths(), /*expected_error_substring*/None)]
     #[case::rejected_deeply_nested_repeat_physical_paths(
         fixtures::deeply_nested_repeat_physical_paths(),
         Some({

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -2177,7 +2177,7 @@ impl<'a> SchemaTransform<'a> for GetSchemaLeaves {
 
 struct MakePhysical<'a> {
     column_mapping_mode: ColumnMappingMode,
-    /// Logical parent path of current field's parent, used for error messages.
+    /// Logical path of current field's parent, used for error messages.
     logical_path: Vec<&'a str>,
     /// CM ids and physical names already claimed during the walk, with the first claimer.
     seen: SeenColumnMappingAnnotations<'a>,
@@ -2647,7 +2647,7 @@ mod tests {
     }
 
     #[rstest]
-    #[case::accepted_same_phy_name_diffrent_paths(fixtures::same_phy_name_diffrent_paths(), None)]
+    #[case::accepted_same_phy_name_diffrent_paths(fixtures::same_phy_name_diffrent_paths(), /*expected_error_substring*/None)]
     #[case::rejected_deeply_nested_repeat_physical_paths(
         fixtures::deeply_nested_repeat_physical_paths(),
         Some({
@@ -2667,7 +2667,7 @@ mod tests {
         let result = schema.make_physical(ColumnMappingMode::Name);
         match expected_error_substring {
             None => {
-                result.expect("schema must validate");
+                result.expect("The input schema should be valid");
             }
             Some(substr) => {
                 assert_result_error_with_message(result.as_ref().map(|_| ()), &substr);

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -2664,18 +2664,21 @@ mod tests {
         #[case] schema: StructType,
         #[case] expected_error_substring: Option<String>,
     ) {
-        let result = schema.make_physical(ColumnMappingMode::Name);
-        match expected_error_substring {
-            None => {
-                result.expect("The input schema should be valid");
-            }
-            Some(substr) => {
-                assert_result_error_with_message(result.as_ref().map(|_| ()), &substr);
-                if let Err(e) = &result {
-                    assert!(
-                        !e.to_string().contains("'q'"),
-                        "walker must short-circuit on first collision; got: {e}"
-                    );
+        // The same dedup rules should apply under both CM modes.
+        for mode in [ColumnMappingMode::Name, ColumnMappingMode::Id] {
+            let result = schema.make_physical(mode);
+            match &expected_error_substring {
+                None => {
+                    result.expect("The input schema should be valid");
+                }
+                Some(substr) => {
+                    assert_result_error_with_message(result.as_ref().map(|_| ()), substr);
+                    if let Err(e) = &result {
+                        assert!(
+                            !e.to_string().contains("'q'"),
+                            "walker must short-circuit on first collision under {mode:?}; got: {e}"
+                        );
+                    }
                 }
             }
         }

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -2177,34 +2177,40 @@ impl<'a> SchemaTransform<'a> for GetSchemaLeaves {
 
 struct MakePhysical<'a> {
     column_mapping_mode: ColumnMappingMode,
-    path: Vec<&'a str>,
+    /// Logical parent path of current field's parent, used for error messages.
+    logical_path: Vec<&'a str>,
     /// CM ids and physical names already claimed during the walk, with the first claimer.
-    /// Threaded into `validate_and_extract_column_mapping_annotations` so duplicate IDs and
-    /// duplicate `physicalName` values are rejected at the first collision.
     seen: SeenColumnMappingAnnotations<'a>,
 }
 impl<'a> MakePhysical<'a> {
     fn new(column_mapping_mode: ColumnMappingMode) -> Self {
         Self {
             column_mapping_mode,
-            path: vec![],
+            logical_path: vec![],
             seen: SeenColumnMappingAnnotations::default(),
         }
     }
 
     fn transform_inner<T>(
         &mut self,
-        field_name: &'a str,
+        logical_name: &'a str,
         transform: impl FnOnce(&mut Self) -> DeltaResult<T>,
     ) -> DeltaResult<T> {
-        self.path.push(field_name);
+        self.logical_path.push(logical_name);
         let result = transform(self);
-        self.path.pop();
+        self.logical_path.pop();
         result
     }
 }
 impl<'a> SchemaTransform<'a> for MakePhysical<'a> {
     transform_output_type!(|'a, T| DeltaResult<Cow<'a, T>>);
+
+    fn transform_struct(&mut self, stype: &'a StructType) -> DeltaResult<Cow<'a, StructType>> {
+        self.seen.enter_struct();
+        let result = self.recurse_into_struct(stype);
+        self.seen.leave_struct();
+        result
+    }
 
     fn transform_array_element(&mut self, etype: &'a DataType) -> DeltaResult<Cow<'a, DataType>> {
         self.transform_inner("<array element>", |this| this.transform(etype))
@@ -2219,18 +2225,18 @@ impl<'a> SchemaTransform<'a> for MakePhysical<'a> {
         &mut self,
         field: &'a StructField,
     ) -> DeltaResult<Cow<'a, StructField>> {
+        let (physical_name, _id) = validate_and_extract_column_mapping_annotations(
+            field,
+            self.column_mapping_mode,
+            &self.logical_path,
+            Some(&mut self.seen),
+        )?;
+
+        if field.is_metadata_column() {
+            return Ok(Cow::Borrowed(field));
+        }
+
         self.transform_inner(field.name(), |this| {
-            let (physical_name, _id) = validate_and_extract_column_mapping_annotations(
-                field,
-                this.column_mapping_mode,
-                &this.path,
-                Some(&mut this.seen),
-            )?;
-
-            if field.is_metadata_column() {
-                return Ok(Cow::Borrowed(field));
-            }
-
             let field = this.recurse_into_struct_field(field)?;
 
             let metadata = field.logical_to_physical_metadata(this.column_mapping_mode);
@@ -2255,7 +2261,8 @@ mod tests {
     use super::*;
     use crate::table_features::ColumnMappingMode;
     use crate::utils::test_utils::{
-        assert_result_error_with_message, test_deep_nested_schema_missing_leaf_cm,
+        assert_result_error_with_message, column_mapping_physical_name_dedup_fixtures as fixtures,
+        test_deep_nested_schema_missing_leaf_cm,
     };
 
     fn example_schema_metadata() -> &'static str {
@@ -2639,68 +2646,39 @@ mod tests {
         );
     }
 
-    /// Two fields sharing the same `delta.columnMapping.physicalName` (at top level OR across
-    /// nesting depth) must be rejected during `make_physical`. PROTOCOL.md requires
-    /// `physicalName` to be a "globally unique identifier"; without dedup, two columns sharing
-    /// a physical name would resolve ambiguously in parquet under `ColumnMappingMode::Name`.
-    /// The walk runs from `TableConfiguration::try_new` so both CREATE and ALTER hit it.
     #[rstest]
-    #[case::same_level("a", "a")]
-    #[case::nested("a", "x")]
-    fn test_make_physical_rejects_duplicate_physical_names(
-        #[case] outer_name: &str,
-        #[case] inner_name: &str,
+    #[case::accepted_same_phy_name_diffrent_paths(fixtures::same_phy_name_diffrent_paths(), None)]
+    #[case::rejected_deeply_nested_repeat_physical_paths(
+        fixtures::deeply_nested_repeat_physical_paths(),
+        Some({
+            let (a, b) =
+                fixtures::deeply_nested_collider_paths();
+            format!("assigned to both '{a}' and '{b}'")
+        }),
+    )]
+    #[case::multiple_physical_name_collisions_reports_first(
+        fixtures::multiple_physical_name_collisions(),
+        Some("'p' assigned to both 'a' and 'b'".to_string()),
+    )]
+    fn test_make_physical_dup_physical_name(
+        #[case] schema: StructType,
+        #[case] expected_error_substring: Option<String>,
     ) {
-        use crate::schema::ColumnMetadataKey;
-
-        // Both fields advertise the SAME physicalName ("col-shared") with distinct ids
-        // (so the duplicate-ID check doesn't fire first). For `same_level` both fields are
-        // top-level siblings; for `nested` the second field lives one struct deeper to prove
-        // the walker checks across nesting boundaries.
-        fn cm_field(
-            name: &str,
-            id: i64,
-            physical: &str,
-            data_type: impl Into<DataType>,
-        ) -> StructField {
-            StructField::not_null(name, data_type).with_metadata([
-                (
-                    ColumnMetadataKey::ColumnMappingId.as_ref(),
-                    MetadataValue::Number(id),
-                ),
-                (
-                    ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
-                    MetadataValue::String(physical.to_string()),
-                ),
-            ])
+        let result = schema.make_physical(ColumnMappingMode::Name);
+        match expected_error_substring {
+            None => {
+                result.expect("schema must validate");
+            }
+            Some(substr) => {
+                assert_result_error_with_message(result.as_ref().map(|_| ()), &substr);
+                if let Err(e) = &result {
+                    assert!(
+                        !e.to_string().contains("'q'"),
+                        "walker must short-circuit on first collision; got: {e}"
+                    );
+                }
+            }
         }
-
-        let schema = if outer_name == inner_name {
-            StructType::new_unchecked([
-                cm_field(outer_name, 1, "col-shared", DataType::INTEGER),
-                cm_field("sibling", 2, "col-shared", DataType::STRING),
-            ])
-        } else {
-            let inner = StructType::new_unchecked([cm_field(
-                inner_name,
-                2,
-                "col-shared",
-                DataType::INTEGER,
-            )]);
-            StructType::new_unchecked([
-                cm_field(outer_name, 1, "col-shared", DataType::INTEGER),
-                cm_field(
-                    "nested_holder",
-                    3,
-                    "col-nested-holder",
-                    DataType::Struct(Box::new(inner)),
-                ),
-            ])
-        };
-        assert_result_error_with_message(
-            schema.make_physical(ColumnMappingMode::Name),
-            "Duplicate `delta.columnMapping.physicalName` 'col-shared'",
-        );
     }
 
     #[test]

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -18,7 +18,6 @@ pub(crate) use crate::expressions::{column_name, ColumnName};
 use crate::reserved_field_ids::FILE_NAME;
 use crate::table_features::{
     validate_and_extract_column_mapping_annotations, validate_column_mapping_id, ColumnMappingMode,
-    SeenColumnMappingAnnotations,
 };
 use crate::transforms::{transform_output_type, SchemaTransform};
 use crate::utils::require;
@@ -2179,15 +2178,22 @@ struct MakePhysical<'a> {
     column_mapping_mode: ColumnMappingMode,
     /// Logical path of current field's parent, used for error messages.
     logical_path: Vec<&'a str>,
-    /// CM ids and physical names already claimed during the walk, with the first claimer.
-    seen: SeenColumnMappingAnnotations<'a>,
+    /// `delta.columnMapping.id` -> first claimer logical name.
+    seen_ids: HashMap<i64, &'a str>,
+    /// Stack of sibling-`physicalName` maps. The top of the stack holds the current field's
+    /// siblings: key is the sibling's physical name, value is its logical name. Frames are
+    /// pushed in `transform_struct` (root struct included) and popped after iterating its
+    /// fields. Only structs introduce siblings; arrays/maps don't push frames since their
+    /// elements / keys / values are anonymous.
+    sibling_names_stack: Vec<HashMap<&'a str, &'a str>>,
 }
 impl<'a> MakePhysical<'a> {
     fn new(column_mapping_mode: ColumnMappingMode) -> Self {
         Self {
             column_mapping_mode,
             logical_path: vec![],
-            seen: SeenColumnMappingAnnotations::default(),
+            seen_ids: HashMap::new(),
+            sibling_names_stack: vec![],
         }
     }
 
@@ -2206,9 +2212,9 @@ impl<'a> SchemaTransform<'a> for MakePhysical<'a> {
     transform_output_type!(|'a, T| DeltaResult<Cow<'a, T>>);
 
     fn transform_struct(&mut self, stype: &'a StructType) -> DeltaResult<Cow<'a, StructType>> {
-        self.seen.enter_struct();
+        self.sibling_names_stack.push(HashMap::new());
         let result = self.recurse_into_struct(stype);
-        self.seen.leave_struct();
+        self.sibling_names_stack.pop();
         result
     }
 
@@ -2229,7 +2235,8 @@ impl<'a> SchemaTransform<'a> for MakePhysical<'a> {
             field,
             self.column_mapping_mode,
             &self.logical_path,
-            Some(&mut self.seen),
+            Some(&mut self.seen_ids),
+            self.sibling_names_stack.last_mut(),
         )?;
 
         if field.is_metadata_column() {

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -74,29 +74,17 @@ pub(crate) fn column_mapping_mode(
     }
 }
 
-/// When column mapping mode is enabled, verify that each field in the schema is annotated with a
-/// physical name and field_id, and that no two fields share the same `delta.columnMapping.id`
-/// value. When not enabled, verifies that no fields are annotated.
-pub fn validate_schema_column_mapping(schema: &Schema, mode: ColumnMappingMode) -> DeltaResult<()> {
-    let mut validator = ValidateColumnMappings {
-        mode,
-        logical_path: vec![],
-        seen: SeenColumnMappingAnnotations::default(),
-    };
-    validator.transform_struct(schema)
-}
-
-/// Tracks `delta.columnMapping.id` and `delta.columnMapping.physicalName` values that have
-/// already been claimed during a single schema walk, so duplicates can be rejected at the
-/// first collision (with both offending field names in the error) rather than letting the
-/// duplicate slip through to a downstream parquet read where field ids resolve ambiguously.
+/// Validates `delta.columnMapping.id` and `delta.columnMapping.physicalName` annotations across
+/// every field in `schema`. Aligns with delta-spark's validation logic.
 ///
-/// `delta.columnMapping.id` must be unique across the entire schema.
+/// When `mode` is [`ColumnMappingMode::Id`] or [`ColumnMappingMode::Name`]: each field must
+/// carry both annotations, no two fields may share a `delta.columnMapping.id`, and no two
+/// fields may share a *full physical column path*. Two fields may share the same leaf
+/// `physicalName` if they live at different physical column paths.
 ///
-/// `delta.columnMapping.physicalName` must be unique by *full physical column path*. Two
-/// fields may share the same physical name if they are at different struct paths.
+/// When `mode` is [`ColumnMappingMode::None`]: verifies no field carries either annotation.
 ///
-/// Example:
+/// Examples for physical name validation:
 /// Rejected (two siblings share `delta.columnMapping.physicalName="x"`):
 /// ```json
 /// {"type":"struct","fields":[
@@ -107,7 +95,7 @@ pub fn validate_schema_column_mapping(schema: &Schema, mode: ColumnMappingMode) 
 /// ]}
 /// ```
 ///
-/// Accepted (same `delta.columnMapping.physicalName="x"` at different struct paths):
+/// Accepted (same `delta.columnMapping.physicalName="x"` at different physical column paths):
 /// ```json
 /// {"type":"struct","fields":[
 ///   {"name":"a","type":"long","nullable":true,
@@ -120,24 +108,38 @@ pub fn validate_schema_column_mapping(schema: &Schema, mode: ColumnMappingMode) 
 ///   ]}}
 /// ]}
 /// ```
+pub fn validate_schema_column_mapping(schema: &Schema, mode: ColumnMappingMode) -> DeltaResult<()> {
+    let mut validator = ValidateColumnMappings {
+        mode,
+        logical_path: vec![],
+        seen: SeenColumnMappingAnnotations::default(),
+    };
+    validator.transform_struct(schema)
+}
+
+/// Tracks `delta.columnMapping.id` and `delta.columnMapping.physicalName` values that have
+/// already been claimed during a single schema walk.
+///
+/// See [`validate_schema_column_mapping`] for the uniqueness rules and examples.
 #[derive(Default, Debug)]
 pub(crate) struct SeenColumnMappingAnnotations<'a> {
     /// `delta.columnMapping.id` -> first field name that claimed it.
     pub ids: HashMap<i64, &'a str>,
-    /// Stack of per-struct direct-children maps. Key is the direct child's physical name;
-    /// value is the direct child's logical name.
-    direct_children_physical_names: Vec<HashMap<&'a str, &'a str>>,
+    /// Stack of per-struct sibling maps, one per struct currently being walked (root included).
+    /// Each map holds the physicalNames already claimed by that struct's children: key is the
+    /// child's physical name, value is its logical name.
+    sibling_physical_names: Vec<HashMap<&'a str, &'a str>>,
 }
 
 impl<'a> SeenColumnMappingAnnotations<'a> {
     /// Walkers call this before iterating a struct's fields.
     pub(crate) fn enter_struct(&mut self) {
-        self.direct_children_physical_names.push(HashMap::new());
+        self.sibling_physical_names.push(HashMap::new());
     }
 
     /// Walkers call this after finishing a struct's fields.
     pub(crate) fn leave_struct(&mut self) {
-        self.direct_children_physical_names.pop();
+        self.sibling_physical_names.pop();
     }
 }
 
@@ -256,7 +258,7 @@ pub(crate) fn validate_and_extract_column_mapping_annotations<'a>(
             // columns with the same full physical path must diverge at some ancestor struct,
             // where they take different child branches sharing a `physicalName`, so a
             // per-struct direct-children check catches all full-path collisions.
-            if let Some(siblings) = seen.direct_children_physical_names.last_mut() {
+            if let Some(siblings) = seen.sibling_physical_names.last_mut() {
                 siblings
                     .insert(physical_name.as_str(), field.name().as_str())
                     .map_or(Ok(()), |prev| {
@@ -278,7 +280,7 @@ pub(crate) fn validate_and_extract_column_mapping_annotations<'a>(
 
 struct ValidateColumnMappings<'a> {
     mode: ColumnMappingMode,
-    /// Logical parent path of current field's parent, used for error messages.
+    /// Logical path of current field's parent, used for error messages.
     logical_path: Vec<&'a str>,
     /// CM ids and physical names already claimed during the walk, with the first claimer.
     seen: SeenColumnMappingAnnotations<'a>,
@@ -1114,7 +1116,7 @@ mod tests {
             format!("assigned to both '{a}' and '{b}'")
         }),
     )]
-    #[case::rejected_multiple_violations_reports_first(
+    #[case::multiple_violations_reports_first(
         fixtures::multiple_physical_name_collisions(),
         Some("'p' assigned to both 'a' and 'b'".to_string()),
     )]
@@ -1130,7 +1132,7 @@ mod tests {
             Some(substr) => {
                 assert_result_error_with_message(result.as_ref().map(|_| ()), &substr);
                 // For the multiple-violations case, also confirm the deeper site was never
-                // reported (would imply the walker kept going past the first error).
+                // reported.
                 if let Err(e) = &result {
                     assert!(
                         !e.to_string().contains("'q'"),

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -134,14 +134,46 @@ pub fn validate_schema_column_mapping(schema: &Schema, mode: ColumnMappingMode) 
 /// and `None`. In `None` mode no dedup is performed (the returned "physical name" is just the
 /// logical field name and is only schema-unique within its parent struct, not globally).
 ///
-/// `parent_field_logical_path` is the field's parent path, used to render full paths in error
-/// messages (e.g. parent `&["a", "b"]` and field `c` renders as `a.b.c`).
+/// # Parameters
 ///
-/// `seen_ids` is the global map of `delta.columnMapping.id` -> first claimer logical name.
-/// `None` skips the ID-dedup check.
+/// - `field`: The field to validate.
+/// - `mode`: Column mapping mode.
+/// - `parent_field_logical_path`: The field's parent path, used to render full paths in error
+///   messages (e.g. parent `&["a", "b"]` and field `c` renders as `a.b.c`).
+/// - `seen_ids`: Global map of `delta.columnMapping.id` -> first claimer logical name. `None` skips
+///   the ID-dedup check.
+/// - `current_field_siblings`: Map of `delta.columnMapping.physicalName` -> first claimer logical
+///   name *for the current field's siblings only*. `None` skips the sibling-dedup check.
 ///
-/// `current_field_siblings` is the map of `delta.columnMapping.physicalName` -> first claimer
-/// logical name *for the current field's siblings only*. `None` skips the sibling-dedup check.
+/// # Errors
+///
+/// - The field is a metadata column carrying any CM annotation.
+/// - CM is enabled but `delta.columnMapping.physicalName` is missing or non-string.
+/// - CM is enabled but `delta.columnMapping.id` is missing or non-numeric.
+/// - CM is disabled but either annotation is present.
+/// - `seen_ids` is provided and the current field's `delta.columnMapping.id` is already in the map.
+///   Example rejection (two fields share `delta.columnMapping.id=1`):
+///
+///   ```json
+///   {"type":"struct","fields":[
+///     {"name":"a","type":"long","nullable":true,
+///      "metadata":{"delta.columnMapping.id":1,"delta.columnMapping.physicalName":"col-a"}},
+///     {"name":"b","type":"long","nullable":true,
+///      "metadata":{"delta.columnMapping.id":1,"delta.columnMapping.physicalName":"col-b"}}
+///   ]}
+///   ```
+/// - `current_field_siblings` is provided and the current field's
+///   `delta.columnMapping.physicalName` is already claimed by a sibling. Example rejection (two
+///   siblings share `delta.columnMapping.physicalName="x"`):
+///
+///   ```json
+///   {"type":"struct","fields":[
+///     {"name":"a","type":"long","nullable":true,
+///      "metadata":{"delta.columnMapping.id":1,"delta.columnMapping.physicalName":"x"}},
+///     {"name":"b","type":"long","nullable":true,
+///      "metadata":{"delta.columnMapping.id":2,"delta.columnMapping.physicalName":"x"}}
+///   ]}
+///   ```
 pub(crate) fn validate_and_extract_column_mapping_annotations<'a>(
     field: &'a StructField,
     mode: ColumnMappingMode,

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -1107,7 +1107,7 @@ mod tests {
     }
 
     #[rstest::rstest]
-    #[case::accepted_distinct_paths(fixtures::same_phy_name_diffrent_paths(), None)]
+    #[case::accepted_distinct_paths(fixtures::same_phy_name_different_paths(), None)]
     #[case::rejected_deeply_nested_repeat(
         fixtures::deeply_nested_repeat_physical_paths(),
         Some({

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -126,8 +126,11 @@ pub(crate) struct SeenColumnMappingAnnotations<'a> {
     /// `delta.columnMapping.id` -> first field name that claimed it.
     pub ids: HashMap<i64, &'a str>,
     /// Stack of per-struct sibling maps, one per struct currently being walked (root included).
-    /// Each map holds the physical names already claimed by that struct's children: key is the
-    /// child's physical name, value is its logical name.
+    /// Structs-only (not arrays or maps, since their elements / keys / values are anonymous in
+    /// delta). Call [`enter_struct`](Self::enter_struct) before iterating a struct's fields
+    /// and [`leave_struct`](Self::leave_struct) after finishing them. Each map holds the
+    /// physical names already claimed by that struct's children: key is the child's physical
+    /// name, value is its logical name.
     sibling_physical_names: Vec<HashMap<&'a str, &'a str>>,
 }
 
@@ -1124,20 +1127,23 @@ mod tests {
         #[case] schema: StructType,
         #[case] expected_error_substring: Option<String>,
     ) {
-        let result = validate_schema_column_mapping(&schema, ColumnMappingMode::Name);
-        match expected_error_substring {
-            None => {
-                result.expect("schema must validate");
-            }
-            Some(substr) => {
-                assert_result_error_with_message(result.as_ref().map(|_| ()), &substr);
-                // For the multiple-violations case, also confirm the deeper site was never
-                // reported.
-                if let Err(e) = &result {
-                    assert!(
-                        !e.to_string().contains("'q'"),
-                        "walker must short-circuit on first collision; got: {e}"
-                    );
+        // The same dedup rules should apply under both CM modes.
+        for mode in [ColumnMappingMode::Name, ColumnMappingMode::Id] {
+            let result = validate_schema_column_mapping(&schema, mode);
+            match &expected_error_substring {
+                None => {
+                    result.expect("schema must validate");
+                }
+                Some(substr) => {
+                    assert_result_error_with_message(result.as_ref().map(|_| ()), substr);
+                    // For the multiple-violations case, also confirm the deeper site was never
+                    // reported.
+                    if let Err(e) = &result {
+                        assert!(
+                            !e.to_string().contains("'q'"),
+                            "walker must short-circuit on first collision under {mode:?}; got: {e}"
+                        );
+                    }
                 }
             }
         }

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -112,43 +112,16 @@ pub fn validate_schema_column_mapping(schema: &Schema, mode: ColumnMappingMode) 
     let mut validator = ValidateColumnMappings {
         mode,
         logical_path: vec![],
-        seen: SeenColumnMappingAnnotations::default(),
+        seen_ids: HashMap::new(),
+        sibling_names_stack: vec![],
     };
     validator.transform_struct(schema)
 }
 
-/// Tracks `delta.columnMapping.id` and `delta.columnMapping.physicalName` values that have
-/// already been claimed during a single schema walk.
-///
-/// See [`validate_schema_column_mapping`] for the uniqueness rules and examples.
-#[derive(Default, Debug)]
-pub(crate) struct SeenColumnMappingAnnotations<'a> {
-    /// `delta.columnMapping.id` -> first field name that claimed it.
-    pub ids: HashMap<i64, &'a str>,
-    /// Stack of per-struct sibling maps, one per struct currently being walked (root included).
-    /// Structs-only (not arrays or maps, since their elements / keys / values are anonymous in
-    /// delta). Call [`enter_struct`](Self::enter_struct) before iterating a struct's fields
-    /// and [`leave_struct`](Self::leave_struct) after finishing them. Each map holds the
-    /// physical names already claimed by that struct's children: key is the child's physical
-    /// name, value is its logical name.
-    sibling_physical_names: Vec<HashMap<&'a str, &'a str>>,
-}
-
-impl<'a> SeenColumnMappingAnnotations<'a> {
-    /// Walkers call this before iterating a struct's fields.
-    pub(crate) fn enter_struct(&mut self) {
-        self.sibling_physical_names.push(HashMap::new());
-    }
-
-    /// Walkers call this after finishing a struct's fields.
-    pub(crate) fn leave_struct(&mut self) {
-        self.sibling_physical_names.pop();
-    }
-}
-
 /// Validates a field's column mapping annotations and extracts the physical name and column
-/// mapping id. If `seen` is provided, also checks for duplicate column mapping IDs (globally)
-/// and duplicate physical names among the siblings.
+/// mapping id. If `seen_ids` is provided, also checks that this field's
+/// `delta.columnMapping.id` is globally unique. If `current_field_siblings` is provided, also
+/// checks that this field's `delta.columnMapping.physicalName` is unique among its siblings.
 ///
 /// Metadata columns are not subject to column mapping and must not carry column mapping
 /// annotations. Returns the logical field name and `None` for such fields.
@@ -163,11 +136,18 @@ impl<'a> SeenColumnMappingAnnotations<'a> {
 ///
 /// `parent_field_logical_path` is the field's parent path, used to render full paths in error
 /// messages (e.g. parent `&["a", "b"]` and field `c` renders as `a.b.c`).
+///
+/// `seen_ids` is the global map of `delta.columnMapping.id` -> first claimer logical name.
+/// `None` skips the ID-dedup check.
+///
+/// `current_field_siblings` is the map of `delta.columnMapping.physicalName` -> first claimer
+/// logical name *for the current field's siblings only*. `None` skips the sibling-dedup check.
 pub(crate) fn validate_and_extract_column_mapping_annotations<'a>(
     field: &'a StructField,
     mode: ColumnMappingMode,
     parent_field_logical_path: &[&'a str],
-    seen: Option<&mut SeenColumnMappingAnnotations<'a>>,
+    seen_ids: Option<&mut HashMap<i64, &'a str>>,
+    current_field_siblings: Option<&mut HashMap<&'a str, &'a str>>,
 ) -> DeltaResult<(&'a str, Option<i64>)> {
     let logical_field_path = || {
         ColumnName::new(
@@ -248,33 +228,28 @@ pub(crate) fn validate_and_extract_column_mapping_annotations<'a>(
     // within its parent struct, not globally -- so dedup is gated on CM being enabled. ID dedup
     // additionally requires `Some(id)` because `id` is `None` outside CM-enabled mode.
     if mode != ColumnMappingMode::None {
-        if let Some(seen) = seen {
-            if let Some(id) = id {
-                seen.ids.insert(id, field.name()).map_or(Ok(()), |prev| {
+        if let (Some(id), Some(seen_ids)) = (id, seen_ids) {
+            seen_ids.insert(id, field.name()).map_or(Ok(()), |prev| {
+                Err(Error::schema(format!(
+                    "Duplicate column mapping ID {id} assigned to both '{prev}' and '{}'",
+                    field.name()
+                )))
+            })?;
+        }
+        // Dedup `physicalName` among siblings. Two distinct columns with the same full
+        // physical path must diverge at some ancestor struct, where two siblings share
+        // the same `physicalName`.
+        if let Some(siblings) = current_field_siblings {
+            siblings
+                .insert(physical_name.as_str(), field.name().as_str())
+                .map_or(Ok(()), |prev| {
                     Err(Error::schema(format!(
-                        "Duplicate column mapping ID {id} assigned to both '{prev}' and '{}'",
-                        field.name()
+                        "Duplicate `delta.columnMapping.physicalName` '{physical_name}' \
+                         assigned to both '{}' and '{}'",
+                        ColumnName::new(parent_field_logical_path.iter().copied().chain([prev])),
+                        logical_field_path(),
                     )))
                 })?;
-            }
-            // Dedup `physicalName` among the parent struct's direct children. Two distinct
-            // columns with the same full physical path must diverge at some ancestor struct,
-            // where they take different child branches sharing a `physicalName`, so a
-            // per-struct direct-children check catches all full-path collisions.
-            if let Some(siblings) = seen.sibling_physical_names.last_mut() {
-                siblings
-                    .insert(physical_name.as_str(), field.name().as_str())
-                    .map_or(Ok(()), |prev| {
-                        Err(Error::schema(format!(
-                            "Duplicate `delta.columnMapping.physicalName` '{physical_name}' \
-                             assigned to both '{}' and '{}'",
-                            ColumnName::new(
-                                parent_field_logical_path.iter().copied().chain([prev])
-                            ),
-                            logical_field_path(),
-                        )))
-                    })?;
-            }
         }
     }
 
@@ -285,8 +260,14 @@ struct ValidateColumnMappings<'a> {
     mode: ColumnMappingMode,
     /// Logical path of current field's parent, used for error messages.
     logical_path: Vec<&'a str>,
-    /// CM ids and physical names already claimed during the walk, with the first claimer.
-    seen: SeenColumnMappingAnnotations<'a>,
+    /// `delta.columnMapping.id` -> first claimer logical name.
+    seen_ids: HashMap<i64, &'a str>,
+    /// Stack of sibling-`physicalName` maps. The top of the stack holds the current field's
+    /// siblings: key is the sibling's physical name, value is its logical name. Frames are
+    /// pushed in `transform_struct` (root struct included) and popped after iterating its
+    /// fields. Only structs introduce siblings; arrays/maps don't push frames since their
+    /// elements / keys / values are anonymous.
+    sibling_names_stack: Vec<HashMap<&'a str, &'a str>>,
 }
 
 impl<'a> ValidateColumnMappings<'a> {
@@ -305,9 +286,9 @@ impl<'a> SchemaTransform<'a> for ValidateColumnMappings<'a> {
     transform_output_type!(|'a, T| DeltaResult<()>);
 
     fn transform_struct(&mut self, stype: &'a StructType) -> DeltaResult<()> {
-        self.seen.enter_struct();
+        self.sibling_names_stack.push(HashMap::new());
         let result = self.recurse_into_struct(stype);
-        self.seen.leave_struct();
+        self.sibling_names_stack.pop();
         result
     }
 
@@ -326,7 +307,8 @@ impl<'a> SchemaTransform<'a> for ValidateColumnMappings<'a> {
             field,
             self.mode,
             &self.logical_path,
-            Some(&mut self.seen),
+            Some(&mut self.seen_ids),
+            self.sibling_names_stack.last_mut(),
         )?;
         self.transform_inner(field.name(), |this| this.recurse_into_struct_field(field))
     }

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -80,7 +80,7 @@ pub(crate) fn column_mapping_mode(
 pub fn validate_schema_column_mapping(schema: &Schema, mode: ColumnMappingMode) -> DeltaResult<()> {
     let mut validator = ValidateColumnMappings {
         mode,
-        path: vec![],
+        logical_path: vec![],
         seen: SeenColumnMappingAnnotations::default(),
     };
     validator.transform_struct(schema)
@@ -91,22 +91,59 @@ pub fn validate_schema_column_mapping(schema: &Schema, mode: ColumnMappingMode) 
 /// first collision (with both offending field names in the error) rather than letting the
 /// duplicate slip through to a downstream parquet read where field ids resolve ambiguously.
 ///
-/// Both maps key the duplicate value to the first field name that claimed it, so the error
-/// can name *both* fields. Tracking physical names addresses delta-spark parity (their
-/// `checkColumnIdAndPhysicalNameAssignments` rejects both kinds of collision) and matches the
-/// PROTOCOL.md "globally unique identifier" requirement for `physicalName` -- duplicate
-/// physical names would break parquet column resolution under `ColumnMappingMode::Name`.
+/// `delta.columnMapping.id` must be unique across the entire schema.
+///
+/// `delta.columnMapping.physicalName` must be unique by *full physical column path*. Two
+/// fields may share the same physical name if they are at different struct paths.
+///
+/// Example:
+/// Rejected (two siblings share `delta.columnMapping.physicalName="x"`):
+/// ```json
+/// {"type":"struct","fields":[
+///   {"name":"a","type":"long","nullable":true,
+///    "metadata":{"delta.columnMapping.id":1,"delta.columnMapping.physicalName":"x"}},
+///   {"name":"b","type":"long","nullable":true,
+///    "metadata":{"delta.columnMapping.id":2,"delta.columnMapping.physicalName":"x"}}
+/// ]}
+/// ```
+///
+/// Accepted (same `delta.columnMapping.physicalName="x"` at different struct paths):
+/// ```json
+/// {"type":"struct","fields":[
+///   {"name":"a","type":"long","nullable":true,
+///    "metadata":{"delta.columnMapping.id":1,"delta.columnMapping.physicalName":"x"}},
+///   {"name":"nested","nullable":true,
+///    "metadata":{"delta.columnMapping.id":2,"delta.columnMapping.physicalName":"nested"},
+///    "type":{"type":"struct","fields":[
+///      {"name":"a","type":"long","nullable":true,
+///       "metadata":{"delta.columnMapping.id":3,"delta.columnMapping.physicalName":"x"}}
+///   ]}}
+/// ]}
+/// ```
 #[derive(Default, Debug)]
 pub(crate) struct SeenColumnMappingAnnotations<'a> {
     /// `delta.columnMapping.id` -> first field name that claimed it.
     pub ids: HashMap<i64, &'a str>,
-    /// `delta.columnMapping.physicalName` -> first field name that claimed it.
-    pub physical_names: HashMap<&'a str, &'a str>,
+    /// Stack of per-struct direct-children maps. Key is the direct child's physical name;
+    /// value is the direct child's logical name.
+    direct_children_physical_names: Vec<HashMap<&'a str, &'a str>>,
+}
+
+impl<'a> SeenColumnMappingAnnotations<'a> {
+    /// Walkers call this before iterating a struct's fields.
+    pub(crate) fn enter_struct(&mut self) {
+        self.direct_children_physical_names.push(HashMap::new());
+    }
+
+    /// Walkers call this after finishing a struct's fields.
+    pub(crate) fn leave_struct(&mut self) {
+        self.direct_children_physical_names.pop();
+    }
 }
 
 /// Validates a field's column mapping annotations and extracts the physical name and column
-/// mapping id. If `seen` is provided, also checks for duplicate column mapping IDs and
-/// duplicate `physicalName` values across the schema walk.
+/// mapping id. If `seen` is provided, also checks for duplicate column mapping IDs (globally)
+/// and duplicate physical names among the siblings.
 ///
 /// Metadata columns are not subject to column mapping and must not carry column mapping
 /// annotations. Returns the logical field name and `None` for such fields.
@@ -119,14 +156,22 @@ pub(crate) struct SeenColumnMappingAnnotations<'a> {
 /// and `None`. In `None` mode no dedup is performed (the returned "physical name" is just the
 /// logical field name and is only schema-unique within its parent struct, not globally).
 ///
-/// `path` identifies the field in error messages (e.g. `&["a", "b"]` renders as `a.b`).
+/// `parent_field_logical_path` is the field's parent path, used to render full paths in error
+/// messages (e.g. parent `&["a", "b"]` and field `c` renders as `a.b.c`).
 pub(crate) fn validate_and_extract_column_mapping_annotations<'a>(
     field: &'a StructField,
     mode: ColumnMappingMode,
-    path: &[&str],
+    parent_field_logical_path: &[&'a str],
     seen: Option<&mut SeenColumnMappingAnnotations<'a>>,
 ) -> DeltaResult<(&'a str, Option<i64>)> {
-    let field_path = || ColumnName::new(path.iter().copied());
+    let logical_field_path = || {
+        ColumnName::new(
+            parent_field_logical_path
+                .iter()
+                .copied()
+                .chain([field.name().as_str()]),
+        )
+    };
     let physical_name_meta = field
         .metadata
         .get(ColumnMetadataKey::ColumnMappingPhysicalName.as_ref());
@@ -151,19 +196,19 @@ pub(crate) fn validate_and_extract_column_mapping_annotations<'a>(
         (ColumnMappingMode::Name | ColumnMappingMode::Id, Some(_)) => {
             return Err(Error::schema(format!(
                 "The {annotation} annotation on field '{}' must be a string",
-                field_path(),
+                logical_field_path(),
             )));
         }
         (ColumnMappingMode::Name | ColumnMappingMode::Id, None) => {
             return Err(Error::schema(format!(
                 "Column mapping is enabled but field '{}' lacks the {annotation} annotation",
-                field_path(),
+                logical_field_path(),
             )));
         }
         (ColumnMappingMode::None, Some(_)) => {
             return Err(Error::schema(format!(
                 "Column mapping is not enabled but field '{}' is annotated with {annotation}",
-                field_path(),
+                logical_field_path(),
             )));
         }
     };
@@ -177,19 +222,19 @@ pub(crate) fn validate_and_extract_column_mapping_annotations<'a>(
         (ColumnMappingMode::Name | ColumnMappingMode::Id, Some(_)) => {
             return Err(Error::schema(format!(
                 "The {annotation} annotation on field '{}' must be a number",
-                field_path(),
+                logical_field_path(),
             )));
         }
         (ColumnMappingMode::Name | ColumnMappingMode::Id, None) => {
             return Err(Error::schema(format!(
                 "Column mapping is enabled but field '{}' lacks the {annotation} annotation",
-                field_path(),
+                logical_field_path(),
             )));
         }
         (ColumnMappingMode::None, Some(_)) => {
             return Err(Error::schema(format!(
                 "Column mapping is not enabled but field '{}' is annotated with {annotation}",
-                field_path(),
+                logical_field_path(),
             )));
         }
     };
@@ -207,15 +252,24 @@ pub(crate) fn validate_and_extract_column_mapping_annotations<'a>(
                     )))
                 })?;
             }
-            seen.physical_names
-                .insert(physical_name, field.name())
-                .map_or(Ok(()), |prev| {
-                    Err(Error::schema(format!(
-                        "Duplicate `delta.columnMapping.physicalName` '{physical_name}' \
-                         assigned to both '{prev}' and '{}'",
-                        field.name(),
-                    )))
-                })?;
+            // Dedup `physicalName` among the parent struct's direct children. Two distinct
+            // columns with the same full physical path must diverge at some ancestor struct,
+            // where they take different child branches sharing a `physicalName`, so a
+            // per-struct direct-children check catches all full-path collisions.
+            if let Some(siblings) = seen.direct_children_physical_names.last_mut() {
+                siblings
+                    .insert(physical_name.as_str(), field.name().as_str())
+                    .map_or(Ok(()), |prev| {
+                        Err(Error::schema(format!(
+                            "Duplicate `delta.columnMapping.physicalName` '{physical_name}' \
+                             assigned to both '{}' and '{}'",
+                            ColumnName::new(
+                                parent_field_logical_path.iter().copied().chain([prev])
+                            ),
+                            logical_field_path(),
+                        )))
+                    })?;
+            }
         }
     }
 
@@ -224,25 +278,33 @@ pub(crate) fn validate_and_extract_column_mapping_annotations<'a>(
 
 struct ValidateColumnMappings<'a> {
     mode: ColumnMappingMode,
-    path: Vec<&'a str>,
+    /// Logical parent path of current field's parent, used for error messages.
+    logical_path: Vec<&'a str>,
     /// CM ids and physical names already claimed during the walk, with the first claimer.
     seen: SeenColumnMappingAnnotations<'a>,
 }
 
 impl<'a> ValidateColumnMappings<'a> {
-    fn transform_inner<V>(&mut self, field_name: &'a str, validate: V) -> DeltaResult<()>
+    fn transform_inner<V>(&mut self, logical_name: &'a str, validate: V) -> DeltaResult<()>
     where
         V: FnOnce(&mut Self) -> DeltaResult<()>,
     {
-        self.path.push(field_name);
+        self.logical_path.push(logical_name);
         let result = validate(self);
-        self.path.pop();
+        self.logical_path.pop();
         result
     }
 }
 
 impl<'a> SchemaTransform<'a> for ValidateColumnMappings<'a> {
     transform_output_type!(|'a, T| DeltaResult<()>);
+
+    fn transform_struct(&mut self, stype: &'a StructType) -> DeltaResult<()> {
+        self.seen.enter_struct();
+        let result = self.recurse_into_struct(stype);
+        self.seen.leave_struct();
+        result
+    }
 
     // Override array element and map key/value for better error messages
     fn transform_array_element(&mut self, etype: &'a DataType) -> DeltaResult<()> {
@@ -255,15 +317,13 @@ impl<'a> SchemaTransform<'a> for ValidateColumnMappings<'a> {
         self.transform_inner("<map value>", |this| this.transform(vtype))
     }
     fn transform_struct_field(&mut self, field: &'a StructField) -> DeltaResult<()> {
-        self.transform_inner(field.name(), |this| {
-            validate_and_extract_column_mapping_annotations(
-                field,
-                this.mode,
-                &this.path,
-                Some(&mut this.seen),
-            )?;
-            this.recurse_into_struct_field(field)
-        })
+        validate_and_extract_column_mapping_annotations(
+            field,
+            self.mode,
+            &self.logical_path,
+            Some(&mut self.seen),
+        )?;
+        self.transform_inner(field.name(), |this| this.recurse_into_struct_field(field))
     }
     fn transform_variant(&mut self, _stype: &'a StructType) -> DeltaResult<()> {
         // don't recurse into variant's fields, as they are not expected to have column mapping
@@ -761,7 +821,8 @@ mod tests {
     use crate::expressions::ColumnName;
     use crate::schema::{DataType, MetadataValue, StructField, StructType};
     use crate::utils::test_utils::{
-        assert_result_error_with_message, make_test_tc, test_deep_nested_schema_missing_leaf_cm,
+        assert_result_error_with_message, column_mapping_physical_name_dedup_fixtures as fixtures,
+        make_test_tc, test_deep_nested_schema_missing_leaf_cm,
     };
 
     #[test]
@@ -1041,6 +1102,43 @@ mod tests {
             ),
             "Duplicate column mapping ID",
         );
+    }
+
+    #[rstest::rstest]
+    #[case::accepted_distinct_paths(fixtures::same_phy_name_diffrent_paths(), None)]
+    #[case::rejected_deeply_nested_repeat(
+        fixtures::deeply_nested_repeat_physical_paths(),
+        Some({
+            let (a, b) =
+                fixtures::deeply_nested_collider_paths();
+            format!("assigned to both '{a}' and '{b}'")
+        }),
+    )]
+    #[case::rejected_multiple_violations_reports_first(
+        fixtures::multiple_physical_name_collisions(),
+        Some("'p' assigned to both 'a' and 'b'".to_string()),
+    )]
+    fn test_dup_physical_name(
+        #[case] schema: StructType,
+        #[case] expected_error_substring: Option<String>,
+    ) {
+        let result = validate_schema_column_mapping(&schema, ColumnMappingMode::Name);
+        match expected_error_substring {
+            None => {
+                result.expect("schema must validate");
+            }
+            Some(substr) => {
+                assert_result_error_with_message(result.as_ref().map(|_| ()), &substr);
+                // For the multiple-violations case, also confirm the deeper site was never
+                // reported (would imply the walker kept going past the first error).
+                if let Err(e) = &result {
+                    assert!(
+                        !e.to_string().contains("'q'"),
+                        "walker must short-circuit on first collision; got: {e}"
+                    );
+                }
+            }
+        }
     }
 
     // =========================================================================

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -126,7 +126,7 @@ pub(crate) struct SeenColumnMappingAnnotations<'a> {
     /// `delta.columnMapping.id` -> first field name that claimed it.
     pub ids: HashMap<i64, &'a str>,
     /// Stack of per-struct sibling maps, one per struct currently being walked (root included).
-    /// Each map holds the physicalNames already claimed by that struct's children: key is the
+    /// Each map holds the physical names already claimed by that struct's children: key is the
     /// child's physical name, value is its logical name.
     sibling_physical_names: Vec<HashMap<&'a str, &'a str>>,
 }

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -7,7 +7,7 @@ pub(crate) use column_mapping::{
     assign_column_mapping_metadata, column_mapping_mode, find_max_column_id_in_schema,
     get_column_mapping_mode_from_properties, physical_to_logical_column_name,
     try_assign_flat_column_mapping_info, validate_and_extract_column_mapping_annotations,
-    validate_column_mapping_id, SeenColumnMappingAnnotations,
+    validate_column_mapping_id,
 };
 use delta_kernel_derive::internal_api;
 use itertools::Itertools;

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -1206,7 +1206,7 @@ pub(crate) mod test_utils {
         };
 
         /// Two fields with the same physical name at different physical paths should be accepted.
-        pub(crate) fn same_phy_name_diffrent_paths() -> StructType {
+        pub(crate) fn same_phy_name_different_paths() -> StructType {
             let nested = StructType::new_unchecked([cm_field("id", 3, "id", DataType::INTEGER)]);
             StructType::new_unchecked([
                 cm_field("id", 1, "id", DataType::INTEGER),

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -1242,13 +1242,15 @@ pub(crate) mod test_utils {
         ///
         /// Dedup must error at the shallower site and never report the deeper one.
         pub(crate) fn multiple_physical_name_collisions() -> StructType {
+            let a_struct = StructType::new_unchecked([cm_field("aa", 6, "aa", DataType::INTEGER)]);
+            let b_struct = StructType::new_unchecked([cm_field("bb", 7, "bb", DataType::INTEGER)]);
             let nested = StructType::new_unchecked([
                 cm_field("x", 4, "q", DataType::INTEGER),
                 cm_field("y", 5, "q", DataType::INTEGER),
             ]);
             StructType::new_unchecked([
-                cm_field("a", 1, "p", DataType::INTEGER),
-                cm_field("b", 2, "p", DataType::INTEGER),
+                cm_field("a", 1, "p", DataType::Struct(Box::new(a_struct))),
+                cm_field("b", 2, "p", DataType::Struct(Box::new(b_struct))),
                 cm_field("nested", 3, "nested", DataType::Struct(Box::new(nested))),
             ])
         }

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -1199,6 +1199,73 @@ pub(crate) mod test_utils {
         let snapshot = Snapshot::builder_for(url).build(engine.as_ref())?;
         Ok((engine, snapshot, tempdir))
     }
+
+    pub(crate) mod column_mapping_physical_name_dedup_fixtures {
+        use crate::schema::{
+            ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, StructField, StructType,
+        };
+
+        /// Two fields with the same physical name at different physical paths should be accepted.
+        pub(crate) fn same_phy_name_diffrent_paths() -> StructType {
+            let nested = StructType::new_unchecked([cm_field("id", 3, "id", DataType::INTEGER)]);
+            StructType::new_unchecked([
+                cm_field("id", 1, "id", DataType::INTEGER),
+                cm_field("nested", 2, "nested", DataType::Struct(Box::new(nested))),
+            ])
+        }
+
+        /// Two nested fields with same physical path should be rejected.
+        pub(crate) fn deeply_nested_repeat_physical_paths() -> StructType {
+            let inner = StructType::new_unchecked([
+                cm_field("a", 2, "x", DataType::INTEGER),
+                cm_field("b", 3, "x", DataType::INTEGER),
+            ]);
+            let arr_of_struct = ArrayType::new(DataType::Struct(Box::new(inner)), true);
+            let map_to_arr = MapType::new(DataType::STRING, arr_of_struct, true);
+            StructType::new_unchecked([cm_field("outer", 1, "outer", map_to_arr)])
+        }
+
+        /// Full logical paths of the two colliding fields in
+        /// [`deeply_nested_repeat_physical_paths`], in the order the walker visits them.
+        pub(crate) fn deeply_nested_collider_paths() -> (&'static str, &'static str) {
+            (
+                "outer.`<map value>`.`<array element>`.a",
+                "outer.`<map value>`.`<array element>`.b",
+            )
+        }
+
+        /// Two collision sites in the same schema:
+        /// - **shallower** (visited first by DFS): top-level siblings `a` and `b`, both have
+        ///   physical name "p".
+        /// - **deeper** (never reached): inside `nested` struct, siblings `x` and `y`, both have
+        ///   physical name "q".
+        ///
+        /// Dedup must error at the shallower site and never report the deeper one.
+        pub(crate) fn multiple_physical_name_collisions() -> StructType {
+            let nested = StructType::new_unchecked([
+                cm_field("x", 4, "q", DataType::INTEGER),
+                cm_field("y", 5, "q", DataType::INTEGER),
+            ]);
+            StructType::new_unchecked([
+                cm_field("a", 1, "p", DataType::INTEGER),
+                cm_field("b", 2, "p", DataType::INTEGER),
+                cm_field("nested", 3, "nested", DataType::Struct(Box::new(nested))),
+            ])
+        }
+
+        fn cm_field(name: &str, id: i64, phys: &str, ty: impl Into<DataType>) -> StructField {
+            StructField::new(name, ty, true).with_metadata([
+                (
+                    ColumnMetadataKey::ColumnMappingId.as_ref(),
+                    MetadataValue::Number(id),
+                ),
+                (
+                    ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
+                    MetadataValue::String(phys.to_string()),
+                ),
+            ])
+        }
+    }
 }
 
 #[cfg(test)]

--- a/kernel/tests/integration/create_table/column_mapping.rs
+++ b/kernel/tests/integration/create_table/column_mapping.rs
@@ -633,10 +633,11 @@ fn test_partitioned_table_stores_logical_column_names_with_column_mapping(
 fn test_create_table_dup_physical_name(
     #[case] schema: StructType,
     #[case] expected_error_substring: Option<&str>,
+    #[values("name", "id")] cm_mode: &str,
 ) -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
     let result = create_table(&table_path, Arc::new(schema), "Test/1.0")
-        .with_table_properties([("delta.columnMapping.mode", "name")])
+        .with_table_properties([("delta.columnMapping.mode", cm_mode)])
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()));
 
     match expected_error_substring {
@@ -649,7 +650,7 @@ fn test_create_table_dup_physical_name(
                 .to_string();
             assert!(
                 msg.contains(substr) && msg.contains(".a'") && msg.contains(".b'"),
-                "expected path-aware dedup error naming colliding leaves, got: {msg}"
+                "expected path-aware dedup error naming colliding leaves under {cm_mode}, got: {msg}"
             );
         }
     }

--- a/kernel/tests/integration/create_table/column_mapping.rs
+++ b/kernel/tests/integration/create_table/column_mapping.rs
@@ -619,15 +619,11 @@ fn test_partitioned_table_stores_logical_column_names_with_column_mapping(
     Ok(())
 }
 
-/// `create_table` with pre-existing `delta.columnMapping.physicalName` annotations under CM
-/// `name` mode: the builder preserves the caller's annotations (see
-/// `assign_column_mapping_metadata`), then `TableConfiguration::try_new` runs the path-aware
-/// dedup before any commit is written.
+/// Create table with pre-existing `delta.columnMapping.physicalName` annotations,
+/// verify the physical name duplicate validation logic.
 ///
-/// - **accept**: same leaf `physicalName` under two different parent structs -> distinct full
-///   physical paths -> dedup accepts -> commit succeeds.
-/// - **reject**: two siblings inside `struct -> map -> array -> struct` share a `physicalName` ->
-///   identical full physical path -> dedup rejects at build time, before any commit.
+/// - **accept**: same leaf physical name under two different parent structs.
+/// - **reject**: two siblings inside `struct -> map -> array -> struct` share same physical name.
 #[rstest::rstest]
 #[case::accept(fixtures::same_leaf_phy_name_under_different_parents(), None)]
 #[case::reject(

--- a/kernel/tests/integration/create_table/column_mapping.rs
+++ b/kernel/tests/integration/create_table/column_mapping.rs
@@ -16,7 +16,9 @@ use delta_kernel::table_features::{ColumnMappingMode, TableFeature};
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::DeltaResult;
-use test_utils::{create_table_and_load_snapshot, test_table_setup};
+use test_utils::{
+    column_mapping_fixtures as fixtures, create_table_and_load_snapshot, test_table_setup,
+};
 
 use super::simple_schema;
 
@@ -614,5 +616,46 @@ fn test_partitioned_table_stores_logical_column_names_with_column_mapping(
         "Partitioned table should not have clustering columns"
     );
 
+    Ok(())
+}
+
+/// `create_table` with pre-existing `delta.columnMapping.physicalName` annotations under CM
+/// `name` mode: the builder preserves the caller's annotations (see
+/// `assign_column_mapping_metadata`), then `TableConfiguration::try_new` runs the path-aware
+/// dedup before any commit is written.
+///
+/// - **accept**: same leaf `physicalName` under two different parent structs -> distinct full
+///   physical paths -> dedup accepts -> commit succeeds.
+/// - **reject**: two siblings inside `struct -> map -> array -> struct` share a `physicalName` ->
+///   identical full physical path -> dedup rejects at build time, before any commit.
+#[rstest::rstest]
+#[case::accept(fixtures::same_leaf_phy_name_under_different_parents(), None)]
+#[case::reject(
+    fixtures::nested_field_with_same_phy_path(),
+    Some("Duplicate `delta.columnMapping.physicalName`")
+)]
+fn test_create_table_dup_physical_name(
+    #[case] schema: StructType,
+    #[case] expected_error_substring: Option<&str>,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let result = create_table(&table_path, Arc::new(schema), "Test/1.0")
+        .with_table_properties([("delta.columnMapping.mode", "name")])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()));
+
+    match expected_error_substring {
+        None => {
+            let _commit = result?.commit(engine.as_ref())?;
+        }
+        Some(substr) => {
+            let msg = result
+                .expect_err("dup physicalName must be rejected at create-table build")
+                .to_string();
+            assert!(
+                msg.contains(substr) && msg.contains(".a'") && msg.contains(".b'"),
+                "expected path-aware dedup error naming colliding leaves, got: {msg}"
+            );
+        }
+    }
     Ok(())
 }

--- a/kernel/tests/integration/write/column_mapping.rs
+++ b/kernel/tests/integration/write/column_mapping.rs
@@ -390,8 +390,11 @@ async fn test_column_mapping_partitioned_write(
 
 // Two fields with same physical name at different physical paths is valid. Write
 // should succeed.
+#[rstest::rstest]
 #[tokio::test(flavor = "multi_thread")]
-async fn test_same_phy_name_different_path() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_same_phy_name_different_path(
+    #[values("name", "id")] cm_mode: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
     let (_tmp_dir, table_path, _) = test_table_setup()?;
     let table_url = Url::from_directory_path(&table_path).unwrap();
     let store: Arc<DynObjectStore> = Arc::new(LocalFileSystem::new());
@@ -405,7 +408,7 @@ async fn test_same_phy_name_different_path() -> Result<(), Box<dyn std::error::E
 
     let logical_schema = Arc::new(fixtures::same_leaf_phy_name_under_different_parents());
     let snapshot = create_table(table_url.as_str(), logical_schema.clone(), "Test/1.0")
-        .with_table_properties([("delta.columnMapping.mode", "name")])
+        .with_table_properties([("delta.columnMapping.mode", cm_mode)])
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?
         .unwrap_post_commit_snapshot();
@@ -448,8 +451,11 @@ async fn test_same_phy_name_different_path() -> Result<(), Box<dyn std::error::E
 }
 
 /// A schema with two fields sharing same physical path should be rejected.
+#[rstest::rstest]
 #[tokio::test]
-async fn test_duplicated_phy_path_rejected() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_duplicated_phy_path_rejected(
+    #[values("name", "id")] cm_mode: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
     let (store, engine, table_url) = engine_store_setup("dup_phys_path", None);
     let schema = fixtures::nested_field_with_same_phy_path();
     let schema_json = serde_json::to_string(&schema)?;
@@ -457,7 +463,7 @@ async fn test_duplicated_phy_path_rejected() -> Result<(), Box<dyn std::error::E
     // Create a v0 commit in a hack way to bypass create_table validation.
     let v0 = format!(
         r#"{{"protocol":{{"minReaderVersion":3,"minWriterVersion":7,"readerFeatures":["columnMapping"],"writerFeatures":["columnMapping"]}}}}
-{{"metaData":{{"id":"test-id","format":{{"provider":"parquet","options":{{}}}},"schemaString":{escaped},"partitionColumns":[],"configuration":{{"delta.columnMapping.mode":"name","delta.columnMapping.maxColumnId":"4"}},"createdTime":1700000000000}}}}
+{{"metaData":{{"id":"test-id","format":{{"provider":"parquet","options":{{}}}},"schemaString":{escaped},"partitionColumns":[],"configuration":{{"delta.columnMapping.mode":"{cm_mode}","delta.columnMapping.maxColumnId":"4"}},"createdTime":1700000000000}}}}
 "#
     );
     add_commit(table_url.as_str(), store.as_ref(), 0, v0).await?;

--- a/kernel/tests/integration/write/column_mapping.rs
+++ b/kernel/tests/integration/write/column_mapping.rs
@@ -388,7 +388,8 @@ async fn test_column_mapping_partitioned_write(
     Ok(())
 }
 
-// Two fields with same physical name at different physical paths should be accepted.
+// Two fields with same physical name at different physical paths is valid. Write
+// should succeed.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_same_phy_name_different_path() -> Result<(), Box<dyn std::error::Error>> {
     let (_tmp_dir, table_path, _) = test_table_setup()?;

--- a/kernel/tests/integration/write/column_mapping.rs
+++ b/kernel/tests/integration/write/column_mapping.rs
@@ -4,8 +4,10 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use delta_kernel::arrow::array::{
-    Array, Int32Array, Int64Array, RecordBatch, StringArray, StructArray,
+    Array, ArrayRef, Int32Array, Int64Array, RecordBatch, StringArray, StructArray,
 };
+use delta_kernel::arrow::datatypes::{DataType as ArrowDataType, Schema as ArrowSchema};
+use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::engine::default::executor::tokio::TokioMultiThreadExecutor;
@@ -16,11 +18,13 @@ use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::{DynObjectStore, ObjectStoreExt as _};
 use delta_kernel::schema::{DataType, StructField, StructType};
 use delta_kernel::table_features::{get_any_level_column_physical_name, ColumnMappingMode};
+use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::{Engine, FileMeta, Snapshot};
 use test_utils::{
-    assert_partition_values, assert_schema_has_field, copy_directory,
-    create_table_and_load_snapshot, nested_batches, nested_schema, read_actions_from_commit,
-    read_add_infos, remove_all_and_get_remove_actions, resolve_field, test_table_setup,
+    add_commit, assert_partition_values, assert_schema_has_field,
+    column_mapping_fixtures as fixtures, copy_directory, create_table_and_load_snapshot,
+    engine_store_setup, nested_batches, nested_schema, read_actions_from_commit, read_add_infos,
+    read_scan, remove_all_and_get_remove_actions, resolve_field, test_table_setup,
     write_batch_to_table,
 };
 use url::Url;
@@ -381,5 +385,91 @@ async fn test_column_mapping_partitioned_write(
         assert_partition_values(remove, &physical_name, "A");
     }
 
+    Ok(())
+}
+
+// Two fields with same physical name at different physical paths should be accepted.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_same_phy_name_different_path() -> Result<(), Box<dyn std::error::Error>> {
+    let (_tmp_dir, table_path, _) = test_table_setup()?;
+    let table_url = Url::from_directory_path(&table_path).unwrap();
+    let store: Arc<DynObjectStore> = Arc::new(LocalFileSystem::new());
+    let engine = Arc::new(
+        DefaultEngineBuilder::new(store.clone())
+            .with_task_executor(Arc::new(TokioMultiThreadExecutor::new(
+                tokio::runtime::Handle::current(),
+            )))
+            .build(),
+    );
+
+    let logical_schema = Arc::new(fixtures::same_leaf_phy_name_under_different_parents());
+    let snapshot = create_table(table_url.as_str(), logical_schema.clone(), "Test/1.0")
+        .with_table_properties([("delta.columnMapping.mode", "name")])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?
+        .unwrap_post_commit_snapshot();
+
+    // Build a RecordBatch matching the logical schema.
+    let arrow_schema: ArrowSchema = logical_schema.as_ref().try_into_arrow()?;
+    let inner_fields_of =
+        |outer: &str| match arrow_schema.field_with_name(outer).unwrap().data_type() {
+            ArrowDataType::Struct(fields) => fields.clone(),
+            _ => panic!("expected struct for {outer}"),
+        };
+    let outer1_array = StructArray::new(
+        inner_fields_of("outer1"),
+        vec![Arc::new(Int32Array::from(vec![10, 20])) as ArrayRef],
+        None,
+    );
+    let outer2_array = StructArray::new(
+        inner_fields_of("outer2"),
+        vec![Arc::new(Int32Array::from(vec![100, 200])) as ArrayRef],
+        None,
+    );
+    let batch = RecordBatch::try_new(
+        Arc::new(arrow_schema),
+        vec![Arc::new(outer1_array), Arc::new(outer2_array)],
+    )?;
+
+    let snapshot = write_batch_to_table(&snapshot, engine.as_ref(), batch, HashMap::new()).await?;
+
+    // Scan back and verify the round-tripped rows.
+    let scan = snapshot.scan_builder().build()?;
+    let batches = read_scan(&scan, engine.clone())?;
+    let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total_rows, 2, "expected 2 rows back");
+    let combined = StructArray::from(batches[0].clone());
+    let outer1_a: &Int32Array = resolve_struct_field(&combined, &["outer1".into(), "a".into()]);
+    let outer2_a: &Int32Array = resolve_struct_field(&combined, &["outer2".into(), "a".into()]);
+    assert_eq!(outer1_a.values(), &[10, 20]);
+    assert_eq!(outer2_a.values(), &[100, 200]);
+    Ok(())
+}
+
+/// A schema with two fields sharing same physical path should be rejected.
+#[tokio::test]
+async fn test_duplicated_phy_path_rejected() -> Result<(), Box<dyn std::error::Error>> {
+    let (store, engine, table_url) = engine_store_setup("dup_phys_path", None);
+    let schema = fixtures::nested_field_with_same_phy_path();
+    let schema_json = serde_json::to_string(&schema)?;
+    let escaped = serde_json::to_string(&schema_json)?;
+    // Create a v0 commit in a hack way to bypass create_table validation.
+    let v0 = format!(
+        r#"{{"protocol":{{"minReaderVersion":3,"minWriterVersion":7,"readerFeatures":["columnMapping"],"writerFeatures":["columnMapping"]}}}}
+{{"metaData":{{"id":"test-id","format":{{"provider":"parquet","options":{{}}}},"schemaString":{escaped},"partitionColumns":[],"configuration":{{"delta.columnMapping.mode":"name","delta.columnMapping.maxColumnId":"4"}},"createdTime":1700000000000}}}}
+"#
+    );
+    add_commit(table_url.as_str(), store.as_ref(), 0, v0).await?;
+
+    let msg = Snapshot::builder_for(table_url)
+        .build(&engine)
+        .expect_err("dup physicalName must be rejected at snapshot load")
+        .to_string();
+    assert!(
+        msg.contains("Duplicate `delta.columnMapping.physicalName`")
+            && msg.contains(".a'")
+            && msg.contains(".b'"),
+        "expected path-aware dedup error naming colliding leaves, got: {msg}"
+    );
     Ok(())
 }

--- a/test-utils/src/column_mapping_fixtures.rs
+++ b/test-utils/src/column_mapping_fixtures.rs
@@ -1,0 +1,52 @@
+//! Schema fixtures for column mappings.
+use delta_kernel::schema::{
+    ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, StructField, StructType,
+};
+
+pub fn same_leaf_phy_name_under_different_parents() -> StructType {
+    let parent1_children = StructType::new_unchecked([cm_field("a", 2, "x", DataType::INTEGER)]);
+    let parent2_children = StructType::new_unchecked([cm_field("a", 4, "x", DataType::INTEGER)]);
+    StructType::new_unchecked([
+        cm_field(
+            "outer1",
+            1,
+            "outer1",
+            DataType::Struct(Box::new(parent1_children)),
+        ),
+        cm_field(
+            "outer2",
+            3,
+            "outer2",
+            DataType::Struct(Box::new(parent2_children)),
+        ),
+    ])
+}
+
+pub fn nested_field_with_same_phy_path() -> StructType {
+    let innermost = StructType::new_unchecked([
+        cm_field("a", 3, "x", DataType::INTEGER),
+        cm_field("b", 4, "x", DataType::INTEGER),
+    ]);
+    let arr_of_struct = ArrayType::new(DataType::Struct(Box::new(innermost)), true);
+    let map_to_arr = MapType::new(DataType::STRING, arr_of_struct, true);
+    let inner_struct = StructType::new_unchecked([cm_field("inner", 2, "inner", map_to_arr)]);
+    StructType::new_unchecked([cm_field(
+        "outer",
+        1,
+        "outer",
+        DataType::Struct(Box::new(inner_struct)),
+    )])
+}
+
+fn cm_field(name: &str, id: i64, phys: &str, ty: impl Into<DataType>) -> StructField {
+    StructField::new(name, ty, true).with_metadata([
+        (
+            ColumnMetadataKey::ColumnMappingId.as_ref(),
+            MetadataValue::Number(id),
+        ),
+        (
+            ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
+            MetadataValue::String(phys.to_string()),
+        ),
+    ])
+}

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -1,5 +1,6 @@
 //! A number of utilities useful for testing that we want to use in multiple crates
 
+pub mod column_mapping_fixtures;
 pub mod counting_reporter;
 pub mod table_builder;
 use std::collections::HashMap;


### PR DESCRIPTION
## What changes are proposed in this pull request?
In the past, when two fields have same physical name, kernel raises error. There are some tables with fields which have same physical names, but different physical paths. An example:
```json
{"type":"struct","fields":[
   {"name":"a","type":"long","nullable":true,
    "metadata":{"delta.columnMapping.id":1,"delta.columnMapping.physicalName":"x"}},
   {"name":"nested","nullable":true,
    "metadata":{"delta.columnMapping.id":2,"delta.columnMapping.physicalName":"nested"},
   "type":{"type":"struct","fields":[
     {"name":"a","type":"long","nullable":true,
      "metadata":{"delta.columnMapping.id":3,"delta.columnMapping.physicalName":"x"}}
   ]}}
]}
```
Logical field `a` and `nested.a` have same physical name(`x`) but different physical paths(`x` vs `nested.x`).

This PR allows such tables, it aligns with delta-spark, [ref](https://github.com/delta-io/delta/blob/9af0a6ab69b944b85f8c8add72bd770a402b043e/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala#L406-L413)
<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

## How was this change tested?
Tested:
Unit tests:
1. Two fields with different physical paths and same physical names are allowed
2. Two fields with same physical paths are rejected
3. Only error on first violation

Integration tests:
Two test schemas:
1. Two fields with different physical paths and same physical names
2. Two fields with same physical paths


Test the two schemas in both create table and writes