### PR TITLE
refactor: move apply_schema out of arrow_expression

### DIFF
--- a/kernel/src/engine/arrow_expression/mod.rs
+++ b/kernel/src/engine/arrow_expression/mod.rs
@@ -1,7 +1,6 @@
 //! Expression handling based on arrow-rs compute kernels.
 use std::sync::Arc;
 
-use apply_schema::{apply_schema, apply_schema_to};
 use evaluate_expression::{evaluate_expression, evaluate_predicate, extract_column};
 use itertools::Itertools;
 use tracing::debug;
@@ -12,14 +11,13 @@ use crate::arrow::datatypes::{
     DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
 };
 use crate::engine::arrow_data::{extract_record_batch, ArrowEngineData};
+use crate::engine::arrow_utils::apply_schema::{apply_schema, apply_schema_to};
 use crate::error::{DeltaResult, Error};
 use crate::expressions::{ArrayData, Expression, ExpressionRef, PredicateRef, Scalar};
 use crate::schema::{DataType, PrimitiveType, SchemaRef};
 use crate::utils::require;
 use crate::{EngineData, EvaluationHandler, ExpressionEvaluator, PredicateEvaluator};
 
-mod apply_schema;
-pub(crate) use apply_schema::apply_schema_to_struct;
 pub mod evaluate_expression;
 pub mod opaque;
 

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -4,7 +4,6 @@ use rstest::rstest;
 use Expression as Expr;
 use Predicate as Pred;
 
-use super::apply_schema::apply_schema;
 use super::*;
 use crate::arrow::array::{
     create_array, Array, ArrayRef, BinaryViewArray, BooleanArray, GenericStringArray, Int32Array,
@@ -20,6 +19,7 @@ use crate::engine::arrow_expression::opaque::{
     ArrowOpaqueExpression as _, ArrowOpaqueExpressionOp, ArrowOpaquePredicate as _,
     ArrowOpaquePredicateOp,
 };
+use crate::engine::arrow_utils::apply_schema::apply_schema;
 use crate::expressions::*;
 use crate::kernel_predicates::{
     DirectDataSkippingPredicateEvaluator, DirectPredicateEvaluator,

--- a/kernel/src/engine/arrow_utils/apply_schema.rs
+++ b/kernel/src/engine/arrow_utils/apply_schema.rs
@@ -8,7 +8,7 @@ use super::super::arrow_conversion::{
     kernel_flat_parquet_id_to_arrow_metadata, lookup_nested_field_id, parquet_field_id_metadata,
     LIST_ARRAY_ROOT, MAP_KEY_DEFAULT, MAP_VALUE_DEFAULT,
 };
-use super::super::arrow_utils::make_arrow_error;
+use super::make_arrow_error;
 use crate::arrow::array::{
     Array, ArrayRef, AsArray, ListArray, MapArray, RecordBatch, StructArray,
 };

--- a/kernel/src/engine/arrow_utils/mod.rs
+++ b/kernel/src/engine/arrow_utils/mod.rs
@@ -1,5 +1,7 @@
 //! Some utilities for working with arrow data types
 
+pub(crate) mod apply_schema;
+
 use std::collections::{HashMap, HashSet};
 use std::ops::Range;
 use std::sync::{Arc, OnceLock};
@@ -8,6 +10,7 @@ use delta_kernel_derive::internal_api;
 use itertools::Itertools;
 use tracing::debug;
 
+use self::apply_schema::apply_schema_to_struct;
 use crate::arrow::array::cast::AsArray;
 use crate::arrow::array::{
     make_array, new_null_array, Array as ArrowArray, GenericListArray, MapArray, OffsetSizeTrait,
@@ -22,7 +25,6 @@ use crate::arrow::json::writer::{make_encoder, LineDelimited, NullableEncoder};
 use crate::arrow::json::{Encoder, EncoderFactory, EncoderOptions, ReaderBuilder, WriterBuilder};
 use crate::engine::arrow_conversion::{TryFromKernel as _, TryIntoArrow as _};
 use crate::engine::arrow_data::ArrowEngineData;
-use crate::engine::arrow_expression::apply_schema_to_struct;
 use crate::engine::ensure_data_types::DataTypeCompat;
 use crate::engine_data::FilteredEngineData;
 use crate::parquet::arrow::{ProjectionMask, PARQUET_FIELD_ID_META_KEY};


### PR DESCRIPTION
## What changes are proposed in this pull request?

Follow-up to #2558. apply_schema is consumed by the parquet read path (arrow_utils) as well as the expression evaluator. 

  - arrow_utils.rs to arrow_utils/mod.rs is a pure directory promotion with no visibility change
  - apply_schema is added as a pub(crate) submodule of arrow_utils

## How was this change tested?

Existing tests