### PR TITLE
feat: added get_earliest_delta_file function

### DIFF
--- a/kernel/src/history_manager/error.rs
+++ b/kernel/src/history_manager/error.rs
@@ -1,11 +1,19 @@
 //! Error types for the history manager module.
 
+use url::Url;
+
 use super::Timestamp;
 use crate::Version;
 
 /// Represents errors that can occur when converting commit timestamps to versions.
 #[derive(Debug, thiserror::Error)]
 pub enum LogHistoryError {
+    /// No published commit files were found in the log directory.
+    #[error("no published commits found in log directory {log_root}")]
+    NoPublishedCommits {
+        /// The log directory URL that was searched.
+        log_root: Url,
+    },
     /// The provided timestamp range is invalid (start > end).
     #[error("Invalid timestamp range: ({start_timestamp}, {end_timestamp})")]
     InvalidTimestampRange {

--- a/kernel/src/history_manager/error.rs
+++ b/kernel/src/history_manager/error.rs
@@ -39,9 +39,9 @@ impl NearestTimestamp {
 /// Represents errors that can occur when converting commit timestamps to versions.
 #[derive(Debug, thiserror::Error)]
 pub enum LogHistoryError {
-    /// No published commit files were found in the log directory.
-    #[error("No published commits found in log directory {log_root}")]
-    NoPublishedCommits {
+    /// No commit files were found in the log directory.
+    #[error("No commits found in log directory {log_root}")]
+    NoCommitsFound {
         /// The log directory URL that was searched.
         log_root: Url,
     },

--- a/kernel/src/history_manager/error.rs
+++ b/kernel/src/history_manager/error.rs
@@ -9,7 +9,7 @@ use crate::Version;
 #[derive(Debug, thiserror::Error)]
 pub enum LogHistoryError {
     /// No published commit files were found in the log directory.
-    #[error("no published commits found in log directory {log_root}")]
+    #[error("No published commits found in log directory {log_root}")]
     NoPublishedCommits {
         /// The log directory URL that was searched.
         log_root: Url,

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -562,32 +562,35 @@ pub fn timestamp_range_to_versions(
 /// - `engine`: kernel engine used to list `log_root`.
 /// - `log_root`: URL of the table's `_delta_log/` directory (must end with `/`).
 /// - `earliest_ratified_commit_version`: For catalog-managed tables, the earliest version the
-///   catalog has ratified. Pass `None` for filesystem-only tables. When `Some(0)` is passed this
-///   function returns `0` immediately without listing storage, since for a catalog-managed table
-///   the only way no published commits exist on the filesystem is when v0 has not yet been
-///   published (commits ratify in order).
+///   catalog has ratified commit. Pass `None` for filesystem-only tables.
 ///
 /// # Errors
 /// - Propagates any error from listing the log directory.
-/// - Returns [`LogHistoryError::NoPublishedCommits`] when the log directory contains no published
-///   commit files and the caller did not pass `earliest_ratified_commit_version == Some(0)`.
+/// - [`LogHistoryError::NoPublishedCommits`] when the log directory contains no published commit
+///   files
+/// - [`DeltaError::GenericError`] when there is no file-system commit when the earliest CCv2 commit
+///   is v0.
+#[allow(unused)]
 #[tracing::instrument(skip(engine), ret)]
-pub fn get_earliest_published_commit_version(
+fn get_earliest_published_commit_version(
     engine: &dyn Engine,
     log_root: &Url,
     earliest_ratified_commit_version: Option<Version>,
 ) -> DeltaResult<Version> {
-    // v0 not yet published on a catalog-managed table: short-circuit before listing.
-    if earliest_ratified_commit_version == Some(0) {
-        return Ok(0);
-    }
-
     list_from_storage(engine.storage_handler().as_ref(), log_root, 0, Version::MAX)?
         .filter_ok(|f| f.file_type == LogPathFileType::Commit)
         .next()
         .transpose()?
         .map(|f| f.version)
         .ok_or_else(|| {
+            if earliest_ratified_commit_version == Some(0) {
+                return DeltaError::generic(format!(
+                    "The catalog-managed table commit v0 should be a file-system commit, \
+                    but listing the log for table {} return an empty. \
+                    Please check the CCv2 catalog commit server",
+                    log_root,
+                ));
+            }
             DeltaError::from(LogHistoryError::NoPublishedCommits {
                 log_root: log_root.clone(),
             })
@@ -1500,20 +1503,36 @@ mod tests {
         }
     }
 
+    enum Expected {
+        Version(Version),
+        NoPublishedCommits,
+        CCv2MissingV0FilesystemCommit,
+    }
+
     #[tokio::test]
     #[rstest::rstest]
-    #[case::no_ratified_commit(3, None, None, Ok(0))]
-    #[case::ratified_commit_version_0(3, Some(0), None, Ok(0))]
-    #[case::ratified_commit_version_greater_than_0(3, Some(2), None, Ok(0))]
-    #[case::log_listing_empty_no_ratified_commit(0, None, None, Err(()))]
-    #[case::log_listing_empty_ratified_commit(0, Some(2), None, Err(()))]
-    #[case::log_listing_empty_ratified_commit_v0(0, Some(0), None, Ok(0))]
-    #[case::cleanup_v0_with_catalog_hint_returns_next_published(4, Some(2), Some(0), Ok(1))]
+    #[case::no_ratified_commit(3, None, None, Expected::Version(0))]
+    #[case::ratified_commit_version_0(3, Some(0), None, Expected::Version(0))]
+    #[case::ratified_commit_version_greater_than_0(3, Some(2), None, Expected::Version(0))]
+    #[case::log_listing_empty_no_ratified_commit(0, None, None, Expected::NoPublishedCommits)]
+    #[case::log_listing_empty_ratified_commit(0, Some(2), None, Expected::NoPublishedCommits)]
+    #[case::log_listing_empty_ratified_commit_v0(
+        0,
+        Some(0),
+        None,
+        Expected::CCv2MissingV0FilesystemCommit
+    )]
+    #[case::cleanup_v0_with_catalog_hint_returns_next_published(
+        4,
+        Some(2),
+        Some(0),
+        Expected::Version(1)
+    )]
     async fn test_get_earliest_published_commit_version(
         #[case] num_commits: usize,
         #[case] earliest_ratified_commit_version: Option<Version>,
         #[case] last_cleanup_version: Option<Version>,
-        #[case] expected: Result<Version, ()>,
+        #[case] expected: Expected,
     ) {
         let timestamps = (0..num_commits)
             .map(|i| (i as i64, None))
@@ -1535,10 +1554,14 @@ mod tests {
             earliest_ratified_commit_version,
         );
         match expected {
-            Ok(v) => assert_eq!(res.unwrap(), v),
-            Err(()) => assert!(
-                matches!(res, Err(DeltaError::LogHistory(ref e)) if matches!(**e, LogHistoryError::NoPublishedCommits { .. }))
+            Expected::Version(v) => assert_eq!(res.unwrap(), v),
+            Expected::NoPublishedCommits => assert!(
+                matches!(res, Err(DeltaError::LogHistory(ref e)) if matches!(**e, LogHistoryError::NoPublishedCommits { .. })),
+                "{res:?}"
             ),
+            Expected::CCv2MissingV0FilesystemCommit => {
+                assert!(matches!(res, Err(DeltaError::Generic(_))), "{res:?}")
+            }
         }
     }
 

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -20,15 +20,15 @@
 //! not guaranteed to be monotonically increasing across commits.
 
 use std::cmp::Ordering;
-use std::collections::HashSet;
 
 use error::LogHistoryError;
+use itertools::Itertools;
 use search::{binary_search_by_key_with_bounds, Bound, SearchError};
 use tracing::{info, trace};
 use url::Url;
 
 use crate::log_segment::LogSegment;
-use crate::log_segment_files::iter_log_files;
+use crate::log_segment_files::list_from_storage;
 use crate::path::{LogPathFileType, ParsedLogPath};
 use crate::snapshot::Snapshot;
 use crate::table_configuration::InCommitTimestampEnablement;
@@ -582,22 +582,16 @@ pub fn get_earliest_published_commit_version(
         return Ok(0);
     }
 
-    let commit_only = HashSet::from([LogPathFileType::Commit]);
-    let first = iter_log_files(
-        engine.storage_handler().as_ref(),
-        log_root,
-        0,
-        Version::MAX,
-        &commit_only,
-    )?
-    .next()
-    .transpose()?;
-
-    first.map(|f| f.version).ok_or_else(|| {
-        DeltaError::from(LogHistoryError::NoPublishedCommits {
-            log_root: log_root.clone(),
+    list_from_storage(engine.storage_handler().as_ref(), log_root, 0, Version::MAX)?
+        .filter_ok(|f| f.file_type == LogPathFileType::Commit)
+        .next()
+        .transpose()?
+        .map(|f| f.version)
+        .ok_or_else(|| {
+            DeltaError::from(LogHistoryError::NoPublishedCommits {
+                log_root: log_root.clone(),
+            })
         })
-    })
 }
 
 #[cfg(test)]

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -20,6 +20,7 @@
 //! not guaranteed to be monotonically increasing across commits.
 
 use std::cmp::Ordering;
+use std::collections::HashSet;
 
 use error::LogHistoryError;
 use search::{binary_search_by_key_with_bounds, Bound, SearchError};
@@ -27,8 +28,8 @@ use tracing::{info, trace};
 use url::Url;
 
 use crate::log_segment::LogSegment;
-use crate::log_segment_files::list_commits_iter;
-use crate::path::ParsedLogPath;
+use crate::log_segment_files::iter_log_files;
+use crate::path::{LogPathFileType, ParsedLogPath};
 use crate::snapshot::Snapshot;
 use crate::table_configuration::InCommitTimestampEnablement;
 use crate::utils::require;
@@ -557,11 +558,6 @@ pub fn timestamp_range_to_versions(
 /// `log_root`. The returned version is not guaranteed to still exist by the time the caller
 /// acts on it: a concurrent log-cleanup operation may delete the file.
 ///
-/// Note: this function returns the earliest **published commit file**, not the earliest
-/// *reachable* version. On a cleaned-up table a checkpoint may be retained for a version
-/// whose commit file has been deleted; in that case the snapshot is still loadable from the
-/// checkpoint, but this function will not return that checkpoint-only version.
-///
 /// # Parameters
 /// - `engine`: kernel engine used to list `log_root`.
 /// - `log_root`: URL of the table's `_delta_log/` directory (must end with `/`).
@@ -569,8 +565,7 @@ pub fn timestamp_range_to_versions(
 ///   catalog has ratified. Pass `None` for filesystem-only tables. When `Some(0)` is passed this
 ///   function returns `0` immediately without listing storage, since for a catalog-managed table
 ///   the only way no published commits exist on the filesystem is when v0 has not yet been
-///   published (commits ratify in order). In that short-circuit case the returned version `0` does
-///   not correspond to a commit file on disk.
+///   published (commits ratify in order).
 ///
 /// # Errors
 /// - Propagates any error from listing the log directory.
@@ -587,15 +582,22 @@ pub fn get_earliest_published_commit_version(
         return Ok(0);
     }
 
-    list_commits_iter(engine.storage_handler().as_ref(), log_root, 0, Version::MAX)?
-        .next()
-        .transpose()?
-        .map(|f| f.version)
-        .ok_or_else(|| {
-            DeltaError::from(LogHistoryError::NoPublishedCommits {
-                log_root: log_root.clone(),
-            })
+    let commit_only = HashSet::from([LogPathFileType::Commit]);
+    let first = iter_log_files(
+        engine.storage_handler().as_ref(),
+        log_root,
+        0,
+        Version::MAX,
+        &commit_only,
+    )?
+    .next()
+    .transpose()?;
+
+    first.map(|f| f.version).ok_or_else(|| {
+        DeltaError::from(LogHistoryError::NoPublishedCommits {
+            log_root: log_root.clone(),
         })
+    })
 }
 
 #[cfg(test)]
@@ -1519,8 +1521,9 @@ mod tests {
         #[case] last_cleanup_version: Option<Version>,
         #[case] expected: Result<Version, ()>,
     ) {
-        let timestamps: Vec<(Timestamp, Option<Timestamp>)> =
-            (0..num_commits).map(|_| (0, None)).collect();
+        let timestamps = (0..num_commits)
+            .map(|i| (i as i64, None))
+            .collect::<Vec<_>>();
         let table = mock_table_with_timestamps(&timestamps, None).await;
         let engine = SyncEngine::new();
         let log_root = Url::from_directory_path(table.table_root().join("_delta_log")).unwrap();
@@ -1539,7 +1542,9 @@ mod tests {
         );
         match expected {
             Ok(v) => assert_eq!(res.unwrap(), v),
-            Err(()) => assert!(res.is_err(), "{res:?}"),
+            Err(()) => assert!(
+                matches!(res, Err(DeltaError::LogHistory(ref e)) if matches!(**e, LogHistoryError::NoPublishedCommits { .. }))
+            ),
         }
     }
 
@@ -1547,7 +1552,7 @@ mod tests {
     /// listing is forward-scanning and the lowest commit version remains v0.
     #[tokio::test]
     async fn test_get_earliest_published_commit_version_with_gap_in_middle() {
-        let timestamps: Vec<(Timestamp, Option<Timestamp>)> = (0..4).map(|_| (0, None)).collect();
+        let timestamps = (0..4).map(|_| (0, None)).collect::<Vec<_>>();
         let table = mock_table_with_timestamps(&timestamps, None).await;
         let engine = SyncEngine::new();
         let log_root = Url::from_directory_path(table.table_root().join("_delta_log")).unwrap();
@@ -1565,11 +1570,9 @@ mod tests {
         assert_eq!(res.unwrap(), 0);
     }
 
-    /// Staged commits live under `_delta_log/_staged_commits/` and must be ignored by the
-    /// listing -- only published commit files (e.g. `00000000000000000000.json`) count.
     #[tokio::test]
     async fn test_get_earliest_published_commit_version_ignores_staged_commits() {
-        let timestamps: Vec<(Timestamp, Option<Timestamp>)> = vec![(0, None)];
+        let timestamps = vec![(0, None)];
         let table = mock_table_with_timestamps(&timestamps, None).await;
         let engine = SyncEngine::new();
         let log_dir = table.table_root().join("_delta_log");

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -27,8 +27,8 @@ use tracing::{info, trace};
 use url::Url;
 
 use crate::log_segment::LogSegment;
-use crate::log_segment_files::list_from_storage;
-use crate::path::{LogPathFileType, ParsedLogPath};
+use crate::log_segment_files::list_commits_iter;
+use crate::path::ParsedLogPath;
 use crate::snapshot::Snapshot;
 use crate::table_configuration::InCommitTimestampEnablement;
 use crate::utils::require;
@@ -551,34 +551,51 @@ pub fn timestamp_range_to_versions(
     Ok((start_version, end_version))
 }
 
-/// Get the earliest commit available for this table. Note that this version is not guaranteed to
-/// exist when performing an action as a concurrent operation can delete the file during cleanup.
-pub fn get_earliest_delta_file(
+/// Returns the earliest published commit version available on the file system for this table.
+///
+/// The returned version is the version of the lowest-numbered `*.json` commit file present in
+/// `log_root`. The returned version is not guaranteed to still exist by the time the caller
+/// acts on it: a concurrent log-cleanup operation may delete the file.
+///
+/// Note: this function returns the earliest **published commit file**, not the earliest
+/// *reachable* version. On a cleaned-up table a checkpoint may be retained for a version
+/// whose commit file has been deleted; in that case the snapshot is still loadable from the
+/// checkpoint, but this function will not return that checkpoint-only version.
+///
+/// # Parameters
+/// - `engine`: kernel engine used to list `log_root`.
+/// - `log_root`: URL of the table's `_delta_log/` directory (must end with `/`).
+/// - `earliest_ratified_commit_version`: For catalog-managed tables, the earliest version the
+///   catalog has ratified. Pass `None` for filesystem-only tables. When `Some(0)` is passed this
+///   function returns `0` immediately without listing storage, since for a catalog-managed table
+///   the only way no published commits exist on the filesystem is when v0 has not yet been
+///   published (commits ratify in order). In that short-circuit case the returned version `0` does
+///   not correspond to a commit file on disk.
+///
+/// # Errors
+/// - Propagates any error from listing the log directory.
+/// - Returns [`LogHistoryError::NoPublishedCommits`] when the log directory contains no published
+///   commit files and the caller did not pass `earliest_ratified_commit_version == Some(0)`.
+#[tracing::instrument(skip(engine), ret)]
+pub fn get_earliest_published_commit_version(
     engine: &dyn Engine,
     log_root: &Url,
-    earliest_ratified_commit_version: Option<u64>,
+    earliest_ratified_commit_version: Option<Version>,
 ) -> DeltaResult<Version> {
-    // For a catalogManaged table, the only time no published commits exist is when v0 has not yet
-    // been published. Otherwise, since checkpoints must have a published delta file, and log clean
-    // up must always preserve a checkpoint, there must be published commits present on the
-    // file-system.
+    // v0 not yet published on a catalog-managed table: short-circuit before listing.
     if earliest_ratified_commit_version == Some(0) {
         return Ok(0);
     }
 
-    for file_result in
-        list_from_storage(engine.storage_handler().as_ref(), log_root, 0, Version::MAX)?
-    {
-        let file = file_result?;
-        if file.file_type == LogPathFileType::Commit {
-            return Ok(file.version);
-        }
-    }
-
-    Err(DeltaError::generic(format!(
-        "No commit files found in the directory: {}",
-        log_root.as_str()
-    )))
+    list_commits_iter(engine.storage_handler().as_ref(), log_root, 0, Version::MAX)?
+        .next()
+        .transpose()?
+        .map(|f| f.version)
+        .ok_or_else(|| {
+            DeltaError::from(LogHistoryError::NoPublishedCommits {
+                log_root: log_root.clone(),
+            })
+        })
 }
 
 #[cfg(test)]
@@ -1489,39 +1506,84 @@ mod tests {
 
     #[tokio::test]
     #[rstest::rstest]
-    #[case::no_ratified_commit(&[10, 20, 30], None, None, Ok(0))]
-    #[case::ratified_commit_version_0(&[10, 20, 30], Some(0), None, Ok(0))]
-    #[case::ratified_commit_version_greater_than_0(&[10, 20, 30], Some(2), None, Ok(0))]
-    #[case::log_listing_empty_no_ratified_commit(&[], None, None, Err(()))]
-    #[case::log_listing_empty_ratified_commit(&[], Some(2), None, Err(()))]
-    #[case::log_listing_empty_ratified_commit_v0(&[], Some(0), None, Ok(0))]
-    #[case::log_listing_with_cleanup_commit(&[10, 20, 30, 40], Some(4), Some(1), Ok(2))]
-    async fn test_get_earliest_delta_file(
-        #[case] commit_file_modification_ts: &[Timestamp],
+    #[case::no_ratified_commit(3, None, None, Ok(0))]
+    #[case::ratified_commit_version_0(3, Some(0), None, Ok(0))]
+    #[case::ratified_commit_version_greater_than_0(3, Some(2), None, Ok(0))]
+    #[case::log_listing_empty_no_ratified_commit(0, None, None, Err(()))]
+    #[case::log_listing_empty_ratified_commit(0, Some(2), None, Err(()))]
+    #[case::log_listing_empty_ratified_commit_v0(0, Some(0), None, Ok(0))]
+    #[case::cleanup_v0_with_catalog_hint_returns_next_published(4, Some(2), Some(0), Ok(1))]
+    async fn test_get_earliest_published_commit_version(
+        #[case] num_commits: usize,
         #[case] earliest_ratified_commit_version: Option<Version>,
         #[case] last_cleanup_version: Option<Version>,
         #[case] expected: Result<Version, ()>,
     ) {
-        let timestamps = commit_file_modification_ts
-            .iter()
-            .map(|ts| (*ts, None))
-            .collect::<Vec<_>>();
+        let timestamps: Vec<(Timestamp, Option<Timestamp>)> =
+            (0..num_commits).map(|_| (0, None)).collect();
         let table = mock_table_with_timestamps(&timestamps, None).await;
         let engine = SyncEngine::new();
-        let log_root = Url::from_directory_path(table.table_root()).unwrap();
+        let log_root = Url::from_directory_path(table.table_root().join("_delta_log")).unwrap();
 
-        if last_cleanup_version.is_some() {
-            let delta_log_path = table.table_root().join("_delta_log");
-            for version in 0..=last_cleanup_version.unwrap() {
-                let filename = format!("{:020}.json", version);
-                remove_file(delta_log_path.join(filename)).unwrap();
+        if let Some(last_cleanup_version) = last_cleanup_version {
+            for version in 0..=last_cleanup_version {
+                let filename = format!("{version:020}.json");
+                remove_file(log_root.to_file_path().unwrap().join(filename)).unwrap();
             }
         }
 
-        let res = get_earliest_delta_file(&engine, &log_root, earliest_ratified_commit_version);
+        let res = get_earliest_published_commit_version(
+            &engine,
+            &log_root,
+            earliest_ratified_commit_version,
+        );
         match expected {
             Ok(v) => assert_eq!(res.unwrap(), v),
             Err(()) => assert!(res.is_err(), "{res:?}"),
         }
+    }
+
+    /// Commits v0..v3 are written, v1 is deleted. The function should still return v0 since
+    /// listing is forward-scanning and the lowest commit version remains v0.
+    #[tokio::test]
+    async fn test_get_earliest_published_commit_version_with_gap_in_middle() {
+        let timestamps: Vec<(Timestamp, Option<Timestamp>)> = (0..4).map(|_| (0, None)).collect();
+        let table = mock_table_with_timestamps(&timestamps, None).await;
+        let engine = SyncEngine::new();
+        let log_root = Url::from_directory_path(table.table_root().join("_delta_log")).unwrap();
+
+        // Delete v1, leaving v0, v2, v3 on disk
+        remove_file(
+            log_root
+                .to_file_path()
+                .unwrap()
+                .join("00000000000000000001.json"),
+        )
+        .unwrap();
+
+        let res = get_earliest_published_commit_version(&engine, &log_root, None);
+        assert_eq!(res.unwrap(), 0);
+    }
+
+    /// Staged commits live under `_delta_log/_staged_commits/` and must be ignored by the
+    /// listing -- only published commit files (e.g. `00000000000000000000.json`) count.
+    #[tokio::test]
+    async fn test_get_earliest_published_commit_version_ignores_staged_commits() {
+        let timestamps: Vec<(Timestamp, Option<Timestamp>)> = vec![(0, None)];
+        let table = mock_table_with_timestamps(&timestamps, None).await;
+        let engine = SyncEngine::new();
+        let log_dir = table.table_root().join("_delta_log");
+        let log_root = Url::from_directory_path(&log_dir).unwrap();
+
+        // Write a staged commit at v1 with a fixed UUID. Staged commits should NOT influence
+        // the earliest-published-commit result.
+        let staged_dir = log_dir.join("_staged_commits");
+        std::fs::create_dir_all(&staged_dir).unwrap();
+        let staged_file =
+            staged_dir.join("00000000000000000001.01234567-89ab-cdef-0123-456789abcdef.json");
+        std::fs::write(&staged_file, "{}").unwrap();
+
+        let res = get_earliest_published_commit_version(&engine, &log_root, None);
+        assert_eq!(res.unwrap(), 0);
     }
 }

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -26,8 +26,9 @@ use search::{binary_search_by_key_with_bounds, Bound, SearchError};
 use tracing::{info, trace};
 use url::Url;
 
-use crate::log_segment::{LogSegment, LogSegmentFiles};
-use crate::path::ParsedLogPath;
+use crate::log_segment::LogSegment;
+use crate::log_segment_files::list_from_storage;
+use crate::path::{LogPathFileType, ParsedLogPath};
 use crate::snapshot::Snapshot;
 use crate::table_configuration::InCommitTimestampEnablement;
 use crate::utils::require;
@@ -561,16 +562,19 @@ pub fn get_earliest_delta_file(
         return Ok(0);
     }
 
-    let commits =
-        LogSegmentFiles::list_commits(engine.storage_handler().as_ref(), log_root, Some(0), None)?;
-    commits
-        .ascending_commit_files
-        .first()
-        .map(|f| f.version)
-        .ok_or(DeltaError::generic(format!(
-            "No commit files found in the directory: {}",
-            log_root.as_str()
-        )))
+    for file_result in
+        list_from_storage(engine.storage_handler().as_ref(), log_root, 0, Version::MAX)?
+    {
+        let file = file_result?;
+        if file.file_type == LogPathFileType::Commit {
+            return Ok(file.version);
+        }
+    }
+
+    Err(DeltaError::generic(format!(
+        "No commit files found in the directory: {}",
+        log_root.as_str()
+    )))
 }
 
 #[cfg(test)]

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -603,11 +603,11 @@ pub fn timestamp_range_to_versions(
 /// - Propagates any error from listing the log directory.
 /// - [`LogHistoryError::NoPublishedCommits`] when the log directory contains no published commit
 ///   files
-/// - [`DeltaError::Generic`] when there is no file-system commit and the earliest CCv2 commit is
-///   v0. For a catalog-managed table, v0 must be a published file-system commit before the catalog
-///   exposes the table. Otherwise a filesystem-only client could list an empty `_delta_log/` and
-///   "create" a table at the same location. An empty listing here therefore indicates a broken
-///   invariant rather than a normal missing version.
+/// - [`DeltaError::Generic`] when there is no publised file-system commit and the earliest ratified
+///   CCv2 commit is v0. For a catalog-managed table, v0 must be a published file-system commit
+///   before the catalog exposes the table. Otherwise a filesystem-only client could list an empty
+///   `_delta_log/` and "create" a table at the same location. An empty listing here therefore
+///   indicates a broken invariant rather than a normal missing version.
 // TODO: remove the `#[allow(unused)]` once the public earliest-commit-version API that calls
 // this helper lands.
 #[allow(unused)]
@@ -625,9 +625,8 @@ fn get_earliest_published_commit_version(
         .ok_or_else(|| {
             if earliest_ratified_commit_version == Some(0) {
                 return DeltaError::generic(format!(
-                    "The catalog-managed table commit v0 should be a file-system commit, \
-                    but listing the log for table {log_root} returned no commits. \
-                    Please check the CCv2 catalog server."
+                    "expected a published v0 commit for catalog-managed table {log_root}, \
+                       but the log listing returned no commits"
                 ));
             }
             DeltaError::from(LogHistoryError::NoPublishedCommits {

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -558,6 +558,10 @@ pub fn get_earliest_delta_file(
     log_root: &Url,
     earliest_ratified_commit_version: Option<u64>,
 ) -> DeltaResult<Version> {
+    // For a catalogManaged table, the only time no published commits exist is when v0 has not yet
+    // been published. Otherwise, since checkpoints must have a published delta file, and log clean
+    // up must always preserve a checkpoint, there must be published commits present on the
+    // file-system.
     if earliest_ratified_commit_version == Some(0) {
         return Ok(0);
     }

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -601,8 +601,7 @@ pub fn timestamp_range_to_versions(
 ///
 /// # Errors
 /// - Propagates any error from listing the log directory.
-/// - [`LogHistoryError::NoPublishedCommits`] when the log directory contains no published commit
-///   files
+/// - [`LogHistoryError::NoCommitsFound`] when the log directory contains no commits.
 /// - [`DeltaError::Generic`] when there is no publised file-system commit and the earliest ratified
 ///   CCv2 commit is v0. For a catalog-managed table, v0 must be a published file-system commit
 ///   before the catalog exposes the table. Otherwise a filesystem-only client could list an empty
@@ -629,7 +628,7 @@ fn get_earliest_published_commit_version(
                        but the log listing returned no commits"
                 ));
             }
-            DeltaError::from(LogHistoryError::NoPublishedCommits {
+            DeltaError::from(LogHistoryError::NoCommitsFound {
                 log_root: log_root.clone(),
             })
         })
@@ -1594,7 +1593,7 @@ mod tests {
 
     enum Expected {
         Version(Version),
-        NoPublishedCommits,
+        NoCommitsFound,
         CCv2MissingV0FilesystemCommit,
     }
 
@@ -1603,8 +1602,8 @@ mod tests {
     #[case::no_ratified_commit(3, None, None, Expected::Version(0))]
     #[case::ratified_commit_version_0(3, Some(0), None, Expected::Version(0))]
     #[case::ratified_commit_version_greater_than_0(3, Some(2), None, Expected::Version(0))]
-    #[case::log_listing_empty_no_ratified_commit(0, None, None, Expected::NoPublishedCommits)]
-    #[case::log_listing_empty_ratified_commit(0, Some(2), None, Expected::NoPublishedCommits)]
+    #[case::log_listing_empty_no_ratified_commit(0, None, None, Expected::NoCommitsFound)]
+    #[case::log_listing_empty_ratified_commit(0, Some(2), None, Expected::NoCommitsFound)]
     #[case::log_listing_empty_ratified_commit_v0(
         0,
         Some(0),
@@ -1638,8 +1637,8 @@ mod tests {
         );
         match expected {
             Expected::Version(v) => assert_eq!(res.unwrap(), v),
-            Expected::NoPublishedCommits => assert!(
-                matches!(res, Err(DeltaError::LogHistory(ref e)) if matches!(**e, LogHistoryError::NoPublishedCommits { .. })),
+            Expected::NoCommitsFound => assert!(
+                matches!(res, Err(DeltaError::LogHistory(ref e)) if matches!(**e, LogHistoryError::NoCommitsFound { .. })),
                 "{res:?}"
             ),
             Expected::CCv2MissingV0FilesystemCommit => {

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -1647,28 +1647,6 @@ mod tests {
         }
     }
 
-    /// Commits v0..v3 are written, v1 is deleted. The function should still return v0 since
-    /// listing is forward-scanning and the lowest commit version remains v0.
-    #[tokio::test]
-    async fn test_get_earliest_published_commit_version_with_gap_in_middle() {
-        let timestamps = (0..4).map(|_| (0, None)).collect::<Vec<_>>();
-        let table = mock_table_with_timestamps(&timestamps, None).await;
-        let engine = SyncEngine::new();
-        let log_root = Url::from_directory_path(table.table_root().join("_delta_log")).unwrap();
-
-        // Delete v1, leaving v0, v2, v3 on disk
-        remove_file(
-            log_root
-                .to_file_path()
-                .unwrap()
-                .join("00000000000000000001.json"),
-        )
-        .unwrap();
-
-        let res = get_earliest_published_commit_version(&engine, &log_root, None);
-        assert_eq!(res.unwrap(), 0);
-    }
-
     #[tokio::test]
     async fn test_get_earliest_published_commit_version_ignores_staged_commits() {
         let timestamps = vec![(0, None)];

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -24,8 +24,9 @@ use std::cmp::Ordering;
 use error::LogHistoryError;
 use search::{binary_search_by_key_with_bounds, Bound, SearchError};
 use tracing::{info, trace};
+use url::Url;
 
-use crate::log_segment::LogSegment;
+use crate::log_segment::{LogSegment, LogSegmentFiles};
 use crate::path::ParsedLogPath;
 use crate::snapshot::Snapshot;
 use crate::table_configuration::InCommitTimestampEnablement;
@@ -549,10 +550,33 @@ pub fn timestamp_range_to_versions(
     Ok((start_version, end_version))
 }
 
+/// Get the earliest commit available for this table. Note that this version is not guaranteed to
+/// exist when performing an action as a concurrent operation can delete the file during cleanup.
+pub fn get_earliest_delta_file(
+    engine: &dyn Engine,
+    log_root: &Url,
+    earliest_ratified_commit_version: Option<u64>,
+) -> DeltaResult<Version> {
+    if earliest_ratified_commit_version == Some(0) {
+        return Ok(0);
+    }
+
+    let commits =
+        LogSegmentFiles::list_commits(engine.storage_handler().as_ref(), log_root, Some(0), None)?;
+    commits
+        .ascending_commit_files
+        .first()
+        .map(|f| f.version)
+        .ok_or(DeltaError::generic(format!(
+            "No commit files found in the directory: {}",
+            log_root.as_str()
+        )))
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::fs::OpenOptions;
+    use std::fs::{remove_file, OpenOptions};
     use std::sync::Arc;
     use std::time::{Duration, SystemTime};
 
@@ -1449,6 +1473,44 @@ mod tests {
         let snapshot = Snapshot::builder_for(path).build(&engine).unwrap();
 
         let res = timestamp_range_to_versions(&snapshot, &engine, start, end);
+        match expected {
+            Ok(v) => assert_eq!(res.unwrap(), v),
+            Err(()) => assert!(res.is_err(), "{res:?}"),
+        }
+    }
+
+    #[tokio::test]
+    #[rstest::rstest]
+    #[case::no_ratified_commit(&[10, 20, 30], None, None, Ok(0))]
+    #[case::ratified_commit_version_0(&[10, 20, 30], Some(0), None, Ok(0))]
+    #[case::ratified_commit_version_greater_than_0(&[10, 20, 30], Some(2), None, Ok(0))]
+    #[case::log_listing_empty_no_ratified_commit(&[], None, None, Err(()))]
+    #[case::log_listing_empty_ratified_commit(&[], Some(2), None, Err(()))]
+    #[case::log_listing_empty_ratified_commit_v0(&[], Some(0), None, Ok(0))]
+    #[case::log_listing_with_cleanup_commit(&[10, 20, 30, 40], Some(4), Some(1), Ok(2))]
+    async fn test_get_earliest_delta_file(
+        #[case] commit_file_modification_ts: &[Timestamp],
+        #[case] earliest_ratified_commit_version: Option<Version>,
+        #[case] last_cleanup_version: Option<Version>,
+        #[case] expected: Result<Version, ()>,
+    ) {
+        let timestamps = commit_file_modification_ts
+            .iter()
+            .map(|ts| (*ts, None))
+            .collect::<Vec<_>>();
+        let table = mock_table_with_timestamps(&timestamps, None).await;
+        let engine = SyncEngine::new();
+        let log_root = Url::from_directory_path(table.table_root()).unwrap();
+
+        if last_cleanup_version.is_some() {
+            let delta_log_path = table.table_root().join("_delta_log");
+            for version in 0..=last_cleanup_version.unwrap() {
+                let filename = format!("{:020}.json", version);
+                remove_file(delta_log_path.join(filename)).unwrap();
+            }
+        }
+
+        let res = get_earliest_delta_file(&engine, &log_root, earliest_ratified_commit_version);
         match expected {
             Ok(v) => assert_eq!(res.unwrap(), v),
             Err(()) => assert!(res.is_err(), "{res:?}"),

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -555,21 +555,26 @@ pub fn timestamp_range_to_versions(
 /// Returns the earliest published commit version available on the file system for this table.
 ///
 /// The returned version is the version of the lowest-numbered `*.json` commit file present in
-/// `log_root`. The returned version is not guaranteed to still exist by the time the caller
+/// `log_root`. The returned version is not guaranteed to exist by the time the caller
 /// acts on it: a concurrent log-cleanup operation may delete the file.
 ///
 /// # Parameters
 /// - `engine`: kernel engine used to list `log_root`.
 /// - `log_root`: URL of the table's `_delta_log/` directory (must end with `/`).
-/// - `earliest_ratified_commit_version`: For catalog-managed tables, the earliest version the
+/// - `earliest_ratified_commit_version`: For catalog-managed tables, it is the earliest version the
 ///   catalog has ratified commit. Pass `None` for filesystem-only tables.
 ///
 /// # Errors
 /// - Propagates any error from listing the log directory.
 /// - [`LogHistoryError::NoPublishedCommits`] when the log directory contains no published commit
 ///   files
-/// - [`DeltaError::GenericError`] when there is no file-system commit when the earliest CCv2 commit
-///   is v0.
+/// - [`DeltaError::Generic`] when there is no file-system commit and the earliest CCv2 commit is
+///   v0. For a catalog-managed table, v0 must be a published file-system commit before the catalog
+///   exposes the table. Otherwise a filesystem-only client could list an empty `_delta_log/` and
+///   "create" a table at the same location. An empty listing here therefore indicates a broken
+///   invariant rather than a normal missing version.
+// TODO: remove the `#[allow(unused)]` once the public earliest-commit-version API that calls
+// this helper lands.
 #[allow(unused)]
 #[tracing::instrument(skip(engine), ret)]
 fn get_earliest_published_commit_version(
@@ -586,9 +591,8 @@ fn get_earliest_published_commit_version(
             if earliest_ratified_commit_version == Some(0) {
                 return DeltaError::generic(format!(
                     "The catalog-managed table commit v0 should be a file-system commit, \
-                    but listing the log for table {} return an empty. \
-                    Please check the CCv2 catalog commit server",
-                    log_root,
+                    but listing the log for table {log_root} returned no commits. \
+                    Please check the CCv2 catalog server."
                 ));
             }
             DeltaError::from(LogHistoryError::NoPublishedCommits {
@@ -1521,12 +1525,6 @@ mod tests {
         Some(0),
         None,
         Expected::CCv2MissingV0FilesystemCommit
-    )]
-    #[case::cleanup_v0_with_catalog_hint_returns_next_published(
-        4,
-        Some(2),
-        Some(0),
-        Expected::Version(1)
     )]
     async fn test_get_earliest_published_commit_version(
         #[case] num_commits: usize,

--- a/kernel/src/log_segment_files/mod.rs
+++ b/kernel/src/log_segment_files/mod.rs
@@ -64,7 +64,7 @@ pub(crate) struct LogSegmentFiles {
 /// This is a thin wrapper around [`StorageHandler::list_from`] that provides the standard
 /// Delta log file discovery pipeline. Callers are responsible for handling the `log_tail`
 /// (catalog-provided commits) and tracking `max_published_version`.
-fn list_from_storage(
+pub(crate) fn list_from_storage(
     storage: &dyn StorageHandler,
     log_root: &Url,
     start_version: Version,

--- a/kernel/src/log_segment_files/mod.rs
+++ b/kernel/src/log_segment_files/mod.rs
@@ -64,7 +64,7 @@ pub(crate) struct LogSegmentFiles {
 /// This is a thin wrapper around [`StorageHandler::list_from`] that provides the standard
 /// Delta log file discovery pipeline. Callers are responsible for handling the `log_tail`
 /// (catalog-provided commits) and tracking `max_published_version`.
-pub(crate) fn list_from_storage(
+fn list_from_storage(
     storage: &dyn StorageHandler,
     log_root: &Url,
     start_version: Version,
@@ -87,6 +87,22 @@ pub(crate) fn list_from_storage(
             Err(_) => true,
         });
     Ok(files)
+}
+
+/// Returns a lazy iterator over published commit files in `log_root` in ascending order,
+/// starting from `start_version` up to and including `end_version`. Filters out checkpoints,
+/// compactions, CRCs, and staged commits -- only [`LogPathFileType::Commit`] entries are
+/// yielded.
+pub(crate) fn list_commits_iter(
+    storage: &dyn StorageHandler,
+    log_root: &Url,
+    start_version: Version,
+    end_version: Version,
+) -> DeltaResult<impl Iterator<Item = DeltaResult<ParsedLogPath>>> {
+    Ok(
+        list_from_storage(storage, log_root, start_version, end_version)?
+            .filter_ok(|f| f.file_type == LogPathFileType::Commit),
+    )
 }
 
 /// Groups all checkpoint parts according to the checkpoint they belong to.

--- a/kernel/src/log_segment_files/mod.rs
+++ b/kernel/src/log_segment_files/mod.rs
@@ -16,7 +16,7 @@
 //! [`list_with_checkpoint_hint`]: Self::list_with_checkpoint_hint
 //! [`LogSegment`]: crate::log_segment::LogSegment
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use delta_kernel_derive::internal_api;
 use itertools::Itertools;
@@ -64,7 +64,7 @@ pub(crate) struct LogSegmentFiles {
 /// This is a thin wrapper around [`StorageHandler::list_from`] that provides the standard
 /// Delta log file discovery pipeline. Callers are responsible for handling the `log_tail`
 /// (catalog-provided commits) and tracking `max_published_version`.
-fn list_from_storage(
+pub(crate) fn list_from_storage(
     storage: &dyn StorageHandler,
     log_root: &Url,
     start_version: Version,
@@ -87,23 +87,6 @@ fn list_from_storage(
             Err(_) => true,
         });
     Ok(files)
-}
-
-/// Returns a lazy iterator over log files in `log_root` whose [`LogPathFileType`] is
-/// contained in `file_types`, in ascending version order from `start_version` up to and
-/// including `end_version`. Staged commits are always excluded (filtered upstream by
-/// [`ParsedLogPath::should_list`]).
-pub(crate) fn iter_log_files<'a>(
-    storage: &dyn StorageHandler,
-    log_root: &Url,
-    start_version: Version,
-    end_version: Version,
-    file_types: &'a HashSet<LogPathFileType>,
-) -> DeltaResult<impl Iterator<Item = DeltaResult<ParsedLogPath>> + 'a> {
-    Ok(
-        list_from_storage(storage, log_root, start_version, end_version)?
-            .filter_ok(|f| file_types.contains(&f.file_type)),
-    )
 }
 
 /// Groups all checkpoint parts according to the checkpoint they belong to.

--- a/kernel/src/log_segment_files/mod.rs
+++ b/kernel/src/log_segment_files/mod.rs
@@ -16,7 +16,7 @@
 //! [`list_with_checkpoint_hint`]: Self::list_with_checkpoint_hint
 //! [`LogSegment`]: crate::log_segment::LogSegment
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use delta_kernel_derive::internal_api;
 use itertools::Itertools;
@@ -89,19 +89,20 @@ fn list_from_storage(
     Ok(files)
 }
 
-/// Returns a lazy iterator over published commit files in `log_root` in ascending order,
-/// starting from `start_version` up to and including `end_version`. Filters out checkpoints,
-/// compactions, CRCs, and staged commits -- only [`LogPathFileType::Commit`] entries are
-/// yielded.
-pub(crate) fn list_commits_iter(
+/// Returns a lazy iterator over log files in `log_root` whose [`LogPathFileType`] is
+/// contained in `file_types`, in ascending version order from `start_version` up to and
+/// including `end_version`. Staged commits are always excluded (filtered upstream by
+/// [`ParsedLogPath::should_list`]).
+pub(crate) fn iter_log_files<'a>(
     storage: &dyn StorageHandler,
     log_root: &Url,
     start_version: Version,
     end_version: Version,
-) -> DeltaResult<impl Iterator<Item = DeltaResult<ParsedLogPath>>> {
+    file_types: &'a HashSet<LogPathFileType>,
+) -> DeltaResult<impl Iterator<Item = DeltaResult<ParsedLogPath>> + 'a> {
     Ok(
         list_from_storage(storage, log_root, start_version, end_version)?
-            .filter_ok(|f| f.file_type == LogPathFileType::Commit),
+            .filter_ok(|f| file_types.contains(&f.file_type)),
     )
 }
 

--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -29,7 +29,7 @@ const STAGED_COMMITS_DIR: &str = "_staged_commits/";
 /// The subdirectory name within the delta log where checkpoint sidecars reside
 const SIDECAR_DIR_WITH_SLASH: &str = "_sidecars/";
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[internal_api]
 pub(crate) enum LogPathFileType {
     Commit,

--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -29,7 +29,7 @@ const STAGED_COMMITS_DIR: &str = "_staged_commits/";
 /// The subdirectory name within the delta log where checkpoint sidecars reside
 const SIDECAR_DIR_WITH_SLASH: &str = "_sidecars/";
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[internal_api]
 pub(crate) enum LogPathFileType {
     Commit,


### PR DESCRIPTION
## What changes are proposed in this pull request?

The java kernel's DeltaHistoryManager has a public method [getEarliestDeltaFile](https://github.com/delta-io/delta/blob/master/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaHistoryManager.java#L456) that allows client to get the earliest commit's json version available in the tables which rust currently lacks. This PR add an implementation of the `getEarliestDeltaFile` to the kernel rust. 

In the future, a public API will use this helper function to retrieve the earliest delta file.

## How was this change tested?

New unit test was added.