### PR TITLE
feat: enforce CRC ICT consistency on write

### DIFF
--- a/kernel/src/crc/writer.rs
+++ b/kernel/src/crc/writer.rs
@@ -9,10 +9,13 @@ use crate::{DeltaResult, Engine, Error};
 /// Serialize and write a CRC file to storage.
 ///
 /// Serializes the [`Crc`] to JSON via serde and writes the raw bytes using the storage
-/// handler. Returns [`Error::ChecksumWriteUnsupported`] if `file_stats_state` is not
-/// `Complete` (only `Complete` CRCs have a well-defined on-disk representation). Per the
-/// Delta protocol, writers MUST NOT overwrite existing CRC files, so this always writes
-/// with `overwrite = false`. If the file already exists, returns
+/// handler. Returns [`Error::ChecksumWriteUnsupported`] if:
+/// - `file_stats_state` is not `Complete` (only `Complete` CRCs have a well-defined on-disk
+///   representation); or
+/// - `inCommitTimestampOpt` presence does not match `delta.enableInCommitTimestamps`.
+///
+/// Per the Delta protocol, writers MUST NOT overwrite existing CRC files, so this always
+/// writes with `overwrite = false`. If the file already exists, returns
 /// `Err(Error::FileAlreadyExists)`.
 pub(crate) fn try_write_crc_file(engine: &dyn Engine, path: &Url, crc: &Crc) -> DeltaResult<()> {
     require!(
@@ -20,6 +23,19 @@ pub(crate) fn try_write_crc_file(engine: &dyn Engine, path: &Url, crc: &Crc) -> 
         Error::ChecksumWriteUnsupported(format!(
             "Cannot write CRC file with {:?} file stats",
             crc.file_stats_state
+        ))
+    );
+    let ict_enabled = crc
+        .metadata
+        .parse_table_properties()
+        .enable_in_commit_timestamps
+        == Some(true);
+    let ict_value_present = crc.in_commit_timestamp_opt.is_some();
+    require!(
+        ict_enabled == ict_value_present,
+        Error::ChecksumWriteUnsupported(format!(
+            "Cannot write CRC file: inCommitTimestampOpt present={ict_value_present} \
+             but In-Commit Timestamps enabled={ict_enabled}"
         ))
     );
     let data = serde_json::to_vec(crc)?;
@@ -33,8 +49,10 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
 
+    use rstest::rstest;
+
     use super::*;
-    use crate::actions::{DomainMetadata, Protocol, SetTransaction};
+    use crate::actions::{DomainMetadata, Metadata, Protocol, SetTransaction};
     use crate::crc::reader::try_read_crc_file;
     use crate::crc::{
         DomainMetadataState, FileSizeHistogram, FileStats, FileStatsState, SetTransactionState,
@@ -44,7 +62,14 @@ mod tests {
     use crate::path::{AsUrl, ParsedLogPath};
     use crate::table_features::TableFeature;
 
-    fn test_crc() -> Crc {
+    fn writer_test_env() -> (SyncEngine, ParsedLogPath) {
+        let engine = SyncEngine::new_with_store(Arc::new(InMemory::new()));
+        let table_root = Url::parse("memory:///test_table/").unwrap();
+        let crc_path = ParsedLogPath::create_parsed_crc(&table_root, 0);
+        (engine, crc_path)
+    }
+
+    fn test_crc(ict_enabled: bool) -> Crc {
         let protocol = Protocol::try_new_modern(
             [TableFeature::ColumnMapping],
             [
@@ -55,8 +80,13 @@ mod tests {
             ],
         )
         .unwrap();
+        let metadata = if ict_enabled {
+            Metadata::default().with_configuration_entry("delta.enableInCommitTimestamps", "true")
+        } else {
+            Metadata::default()
+        };
         // NOTE: Adding more entries here will break test_crc_serialized_json_content because
-        // domain_metadata is backed by an unsorted HashMap -- the serialized array order is
+        // domain_metadata is backed by an unsorted HashMap. The serialized array order is
         // non-deterministic. If you need multiple entries, either make the test order-independent
         // (e.g. sort both sides by domain name) or switch to a BTreeMap.
         let domain_metadata = HashMap::from([(
@@ -82,6 +112,7 @@ mod tests {
                 file_size_histogram: Some(histogram),
             }),
             protocol,
+            metadata,
             txn_id: None,
             in_commit_timestamp_opt: Some(ict),
             set_transaction_state: SetTransactionState::Complete(set_transactions),
@@ -92,7 +123,7 @@ mod tests {
 
     #[test]
     fn test_serde_round_trip() {
-        let crc = test_crc();
+        let crc = test_crc(true);
         let json_bytes = serde_json::to_vec(&crc).unwrap();
         let round_tripped: Crc = serde_json::from_slice(&json_bytes).unwrap();
 
@@ -101,23 +132,19 @@ mod tests {
 
     #[test]
     fn test_write_then_read_crc_file() {
-        let store = Arc::new(InMemory::new());
-        let engine = SyncEngine::new_with_store(store);
-        let table_root = url::Url::parse("memory:///test_table/").unwrap();
-        let write_path = ParsedLogPath::create_parsed_crc(&table_root, 0);
-        let read_path = ParsedLogPath::create_parsed_crc(&table_root, 0);
-        let crc = test_crc();
+        let (engine, crc_path) = writer_test_env();
+        let crc = test_crc(true);
 
-        try_write_crc_file(&engine, write_path.location.as_url(), &crc).unwrap();
+        try_write_crc_file(&engine, crc_path.location.as_url(), &crc).unwrap();
 
-        let read_back = try_read_crc_file(&engine, &read_path).unwrap();
+        let read_back = try_read_crc_file(&engine, &crc_path).unwrap();
         assert_eq!(read_back, crc);
     }
 
     /// Verify JSON content produced by CRC serialization via serde_json::Value comparison.
     #[test]
     fn test_crc_serialized_json_content() {
-        let crc = test_crc();
+        let crc = test_crc(true);
         let actual: serde_json::Value = serde_json::to_value(&crc).unwrap();
 
         // Verify non-histogram fields match exactly.
@@ -138,7 +165,9 @@ mod tests {
                 "schemaString": "",
                 "partitionColumns": [],
                 "createdTime": null,
-                "configuration": {}
+                "configuration": {
+                    "delta.enableInCommitTimestamps": "true"
+                }
             },
             "protocol": {
                 "minReaderVersion": 3,
@@ -190,29 +219,47 @@ mod tests {
 
     #[test]
     fn test_write_crc_file_already_exists() {
-        let store = Arc::new(InMemory::new());
-        let engine = SyncEngine::new_with_store(store);
-        let table_root = url::Url::parse("memory:///test_table/").unwrap();
-        let crc_path = ParsedLogPath::create_parsed_crc(&table_root, 0);
-        let crc = test_crc();
+        let (engine, crc_path) = writer_test_env();
+        let crc = test_crc(true);
 
         try_write_crc_file(&engine, crc_path.location.as_url(), &crc).unwrap();
 
         // Second write should fail (never overwrites)
         let result = try_write_crc_file(&engine, crc_path.location.as_url(), &crc);
-        assert!(result.is_err());
+        assert!(matches!(result, Err(Error::FileAlreadyExists(_))));
     }
 
     #[test]
     fn test_write_rejects_indeterminate_file_stats_with_checksum_write_unsupported() {
-        let store = Arc::new(InMemory::new());
-        let engine = SyncEngine::new_with_store(store);
-        let table_root = url::Url::parse("memory:///test_table/").unwrap();
-        let crc_path = ParsedLogPath::create_parsed_crc(&table_root, 0);
-
-        let mut crc = test_crc();
+        let (engine, crc_path) = writer_test_env();
+        let mut crc = test_crc(true);
         crc.file_stats_state = FileStatsState::Indeterminate;
         let result = try_write_crc_file(&engine, crc_path.location.as_url(), &crc);
         assert!(matches!(result, Err(Error::ChecksumWriteUnsupported(_))));
+    }
+
+    #[rstest]
+    fn test_write_enforces_ict_enablement_value_consistency(
+        #[values(false, true)] ict_enabled: bool,
+        #[values(false, true)] ict_value_present: bool,
+    ) {
+        let (engine, crc_path) = writer_test_env();
+
+        let mut crc = test_crc(ict_enabled);
+        if !ict_value_present {
+            crc.in_commit_timestamp_opt = None;
+        }
+
+        let should_succeed = ict_enabled == ict_value_present;
+        let result = try_write_crc_file(&engine, crc_path.location.as_url(), &crc);
+        if should_succeed {
+            result.unwrap();
+        } else {
+            let err = result.unwrap_err();
+            assert!(
+                matches!(err, Error::ChecksumWriteUnsupported(_)),
+                "expected ChecksumWriteUnsupported, got: {err:?}"
+            );
+        }
     }
 }

--- a/kernel/src/crc/writer.rs
+++ b/kernel/src/crc/writer.rs
@@ -3,6 +3,7 @@
 use url::Url;
 
 use super::Crc;
+use crate::table_properties::ENABLE_IN_COMMIT_TIMESTAMPS;
 use crate::utils::require;
 use crate::{DeltaResult, Engine, Error};
 
@@ -12,7 +13,7 @@ use crate::{DeltaResult, Engine, Error};
 /// handler. Returns [`Error::ChecksumWriteUnsupported`] if:
 /// - `file_stats_state` is not `Complete` (only `Complete` CRCs have a well-defined on-disk
 ///   representation); or
-/// - `inCommitTimestampOpt` presence does not match `delta.enableInCommitTimestamps`.
+/// - `delta.enableInCommitTimestamps` is `true` but `inCommitTimestampOpt` is absent.
 ///
 /// Per the Delta protocol, writers MUST NOT overwrite existing CRC files, so this always
 /// writes with `overwrite = false`. If the file already exists, returns
@@ -25,18 +26,19 @@ pub(crate) fn try_write_crc_file(engine: &dyn Engine, path: &Url, crc: &Crc) -> 
             crc.file_stats_state
         ))
     );
+    // If ICT is enabled, the CRC must carry an ICT value.
     let ict_enabled = crc
         .metadata
-        .parse_table_properties()
-        .enable_in_commit_timestamps
-        == Some(true);
+        .configuration()
+        .get(ENABLE_IN_COMMIT_TIMESTAMPS)
+        .is_some_and(|v| v == "true");
     let ict_value_present = crc.in_commit_timestamp_opt.is_some();
     require!(
-        ict_enabled == ict_value_present,
-        Error::ChecksumWriteUnsupported(format!(
-            "Cannot write CRC file: inCommitTimestampOpt present={ict_value_present} \
-             but In-Commit Timestamps enabled={ict_enabled}"
-        ))
+        !ict_enabled || ict_value_present,
+        Error::ChecksumWriteUnsupported(
+            "Cannot write CRC file: In-Commit Timestamps enabled but inCommitTimestampOpt is absent"
+                .to_string()
+        )
     );
     let data = serde_json::to_vec(crc)?;
     engine
@@ -69,19 +71,19 @@ mod tests {
         (engine, crc_path)
     }
 
-    fn test_crc(ict_enabled: bool) -> Crc {
-        let protocol = Protocol::try_new_modern(
-            [TableFeature::ColumnMapping],
-            [
-                TableFeature::ColumnMapping,
-                TableFeature::RowTracking,
-                TableFeature::DomainMetadata,
-                TableFeature::InCommitTimestamp,
-            ],
-        )
-        .unwrap();
+    fn test_crc(ict_supported: bool, ict_enabled: bool) -> Crc {
+        let mut writer_features = vec![
+            TableFeature::ColumnMapping,
+            TableFeature::RowTracking,
+            TableFeature::DomainMetadata,
+        ];
+        if ict_supported {
+            writer_features.push(TableFeature::InCommitTimestamp);
+        }
+        let protocol =
+            Protocol::try_new_modern([TableFeature::ColumnMapping], writer_features).unwrap();
         let metadata = if ict_enabled {
-            Metadata::default().with_configuration_entry("delta.enableInCommitTimestamps", "true")
+            Metadata::default().with_configuration_entry(ENABLE_IN_COMMIT_TIMESTAMPS, "true")
         } else {
             Metadata::default()
         };
@@ -123,7 +125,7 @@ mod tests {
 
     #[test]
     fn test_serde_round_trip() {
-        let crc = test_crc(true);
+        let crc = test_crc(/* ict_supported */ true, /* ict_enabled */ true);
         let json_bytes = serde_json::to_vec(&crc).unwrap();
         let round_tripped: Crc = serde_json::from_slice(&json_bytes).unwrap();
 
@@ -133,7 +135,7 @@ mod tests {
     #[test]
     fn test_write_then_read_crc_file() {
         let (engine, crc_path) = writer_test_env();
-        let crc = test_crc(true);
+        let crc = test_crc(/* ict_supported */ true, /* ict_enabled */ true);
 
         try_write_crc_file(&engine, crc_path.location.as_url(), &crc).unwrap();
 
@@ -144,7 +146,7 @@ mod tests {
     /// Verify JSON content produced by CRC serialization via serde_json::Value comparison.
     #[test]
     fn test_crc_serialized_json_content() {
-        let crc = test_crc(true);
+        let crc = test_crc(/* ict_supported */ true, /* ict_enabled */ true);
         let actual: serde_json::Value = serde_json::to_value(&crc).unwrap();
 
         // Verify non-histogram fields match exactly.
@@ -220,7 +222,7 @@ mod tests {
     #[test]
     fn test_write_crc_file_already_exists() {
         let (engine, crc_path) = writer_test_env();
-        let crc = test_crc(true);
+        let crc = test_crc(/* ict_supported */ true, /* ict_enabled */ true);
 
         try_write_crc_file(&engine, crc_path.location.as_url(), &crc).unwrap();
 
@@ -232,25 +234,30 @@ mod tests {
     #[test]
     fn test_write_rejects_indeterminate_file_stats_with_checksum_write_unsupported() {
         let (engine, crc_path) = writer_test_env();
-        let mut crc = test_crc(true);
+        let mut crc = test_crc(/* ict_supported */ true, /* ict_enabled */ true);
         crc.file_stats_state = FileStatsState::Indeterminate;
         let result = try_write_crc_file(&engine, crc_path.location.as_url(), &crc);
         assert!(matches!(result, Err(Error::ChecksumWriteUnsupported(_))));
     }
 
     #[rstest]
+    #[case::not_supported(false, false)]
+    #[case::supported_not_enabled(true, false)]
+    #[case::supported_and_enabled(true, true)]
     fn test_write_enforces_ict_enablement_value_consistency(
-        #[values(false, true)] ict_enabled: bool,
+        #[case] ict_supported: bool,
+        #[case] ict_enabled: bool,
         #[values(false, true)] ict_value_present: bool,
     ) {
         let (engine, crc_path) = writer_test_env();
 
-        let mut crc = test_crc(ict_enabled);
+        let mut crc = test_crc(ict_supported, ict_enabled);
         if !ict_value_present {
             crc.in_commit_timestamp_opt = None;
         }
 
-        let should_succeed = ict_enabled == ict_value_present;
+        // If ICT is enabled, then the ICT value must be present.
+        let should_succeed = !ict_enabled || ict_value_present;
         let result = try_write_crc_file(&engine, crc_path.location.as_url(), &crc);
         if should_succeed {
             result.unwrap();

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -1135,8 +1135,8 @@ impl Snapshot {
     ///   version (e.g. a snapshot loaded from disk that has no CRC file), if the CRC's
     ///   `file_stats_state` is `Indeterminate` (a non-incremental operation like ANALYZE STATS was
     ///   encountered, or a file action had a missing size; recoverable with a full state
-    ///   reconstruction in the future), or if `inCommitTimestampOpt` presence does not match
-    ///   `delta.enableInCommitTimestamps`.
+    ///   reconstruction in the future), or if `delta.enableInCommitTimestamps` is `true` but
+    ///   `inCommitTimestampOpt` is absent.
     /// - I/O errors from the engine's storage handler if the write fails.
     ///
     /// [`CommittedTransaction::post_commit_snapshot`]: crate::transaction::CommittedTransaction::post_commit_snapshot

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -1132,10 +1132,11 @@ impl Snapshot {
     /// # Errors
     ///
     /// - [`Error::ChecksumWriteUnsupported`] if no in-memory CRC is available at this snapshot's
-    ///   version (e.g. a snapshot loaded from disk that has no CRC file), or if the CRC's
+    ///   version (e.g. a snapshot loaded from disk that has no CRC file), if the CRC's
     ///   `file_stats_state` is `Indeterminate` (a non-incremental operation like ANALYZE STATS was
-    ///   encountered, or a file action had a missing size). Recoverable with a full state
-    ///   reconstruction in the future.
+    ///   encountered, or a file action had a missing size; recoverable with a full state
+    ///   reconstruction in the future), or if `inCommitTimestampOpt` presence does not match
+    ///   `delta.enableInCommitTimestamps`.
     /// - I/O errors from the engine's storage handler if the write fails.
     ///
     /// [`CommittedTransaction::post_commit_snapshot`]: crate::transaction::CommittedTransaction::post_commit_snapshot
@@ -1170,7 +1171,6 @@ impl Snapshot {
 
         let crc_path = ParsedLogPath::new_crc(self.table_root(), self.version())?;
 
-        // Note: try_write_crc_file validates that file_stats_state is Complete before writing.
         match try_write_crc_file(engine, &crc_path.location, crc) {
             Ok(()) => {
                 info!("Wrote CRC file at {}", crc_path.location);


### PR DESCRIPTION
## What changes are proposed in this pull request?

It's _possible_ to load a Snapshot with slightly invalid state: somehow the latest commit was _missing_ an ICT despite the table feature being enabled.

For now, Kernel only fails when we _ask_ for the timestamp of such a Snapshot.

Soon, we will be able to incrementally load a CRC at that Snapshot version, too.

This PR prevents us from _writing_ out that in-memory CRC at that Snapshot version, which would yield an invalid CRC!

## How was this change tested?

Simple new tests.

