### PR TITLE
refactor: create stat field name constants

### DIFF
--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -62,15 +62,15 @@ pub(crate) const INTERNAL_DOMAIN_PREFIX: &str = "delta.";
 // === Sub-fields of an AddFile's `stats` struct ===
 // See the Delta protocol spec, "Per-file Statistics".
 /// Total number of rows in the file.
-pub const STATS_NUM_RECORDS: &str = "numRecords";
+pub const NUM_RECORDS: &str = "numRecords";
 /// Per-column count of null values.
-pub const STATS_NULL_COUNT: &str = "nullCount";
+pub const NULL_COUNT: &str = "nullCount";
 /// Per-column smallest non-null value (truncated for strings; omitted for all-null columns).
-pub const STATS_MIN_VALUES: &str = "minValues";
+pub const MIN_VALUES: &str = "minValues";
 /// Per-column largest non-null value (truncated for strings; omitted for all-null columns).
-pub const STATS_MAX_VALUES: &str = "maxValues";
+pub const MAX_VALUES: &str = "maxValues";
 /// Whether the min/max values are tight bounds (vs. lower/upper bounds).
-pub const STATS_TIGHT_BOUNDS: &str = "tightBounds";
+pub const TIGHT_BOUNDS: &str = "tightBounds";
 
 static COMMIT_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
     Arc::new(StructType::new_unchecked([

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -60,17 +60,23 @@ pub(crate) const DOMAIN_METADATA_NAME: &str = "domainMetadata";
 pub(crate) const INTERNAL_DOMAIN_PREFIX: &str = "delta.";
 
 // === Sub-fields of an AddFile's `stats` struct ===
-// See the Delta protocol spec, "Per-file Statistics".
-/// Total number of rows in the file.
-pub const NUM_RECORDS: &str = "numRecords";
-/// Per-column count of null values.
-pub const NULL_COUNT: &str = "nullCount";
-/// Per-column smallest non-null value (truncated for strings; omitted for all-null columns).
-pub const MIN_VALUES: &str = "minValues";
-/// Per-column largest non-null value (truncated for strings; omitted for all-null columns).
-pub const MAX_VALUES: &str = "maxValues";
-/// Whether the min/max values are tight bounds (vs. lower/upper bounds).
-pub const TIGHT_BOUNDS: &str = "tightBounds";
+// See the Delta protocol spec, "Per-file Statistics", and `expected_stats_schema` in
+// `scan/data_skipping/stats_schema/mod.rs` for the full semantics.
+/// Logical (post-DV) row count, stored as a `long`.
+#[internal_api]
+pub(crate) const NUM_RECORDS: &str = "numRecords";
+/// Per-column null counts, as a nested struct mirroring the table schema.
+#[internal_api]
+pub(crate) const NULL_COUNT: &str = "nullCount";
+/// Per-column lower bounds, as a nested struct mirroring the table schema.
+#[internal_api]
+pub(crate) const MIN_VALUES: &str = "minValues";
+/// Per-column upper bounds, as a nested struct mirroring the table schema.
+#[internal_api]
+pub(crate) const MAX_VALUES: &str = "maxValues";
+/// Whether the min/max/nullCount stats are tight or wide. Defaults to `true` when absent.
+#[internal_api]
+pub(crate) const TIGHT_BOUNDS: &str = "tightBounds";
 
 static COMMIT_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
     Arc::new(StructType::new_unchecked([

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -59,6 +59,20 @@ pub(crate) const DOMAIN_METADATA_NAME: &str = "domainMetadata";
 
 pub(crate) const INTERNAL_DOMAIN_PREFIX: &str = "delta.";
 
+// === Sub-fields of an AddFile's `stats` struct ===
+// See the Delta protocol spec, "Per-file Statistics".
+
+/// Total number of rows in the file.
+pub(crate) const STATS_NUM_RECORDS: &str = "numRecords";
+/// Per-column count of null values.
+pub(crate) const STATS_NULL_COUNT: &str = "nullCount";
+/// Per-column smallest non-null value (truncated for strings; omitted for all-null columns).
+pub(crate) const STATS_MIN_VALUES: &str = "minValues";
+/// Per-column largest non-null value (truncated for strings; omitted for all-null columns).
+pub(crate) const STATS_MAX_VALUES: &str = "maxValues";
+/// Whether the min/max values are tight bounds (vs. lower/upper bounds).
+pub(crate) const STATS_TIGHT_BOUNDS: &str = "tightBounds";
+
 static COMMIT_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
     Arc::new(StructType::new_unchecked([
         StructField::nullable(ADD_NAME, Add::to_schema()),

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -61,17 +61,16 @@ pub(crate) const INTERNAL_DOMAIN_PREFIX: &str = "delta.";
 
 // === Sub-fields of an AddFile's `stats` struct ===
 // See the Delta protocol spec, "Per-file Statistics".
-
 /// Total number of rows in the file.
-pub(crate) const STATS_NUM_RECORDS: &str = "numRecords";
+pub const STATS_NUM_RECORDS: &str = "numRecords";
 /// Per-column count of null values.
-pub(crate) const STATS_NULL_COUNT: &str = "nullCount";
+pub const STATS_NULL_COUNT: &str = "nullCount";
 /// Per-column smallest non-null value (truncated for strings; omitted for all-null columns).
-pub(crate) const STATS_MIN_VALUES: &str = "minValues";
+pub const STATS_MIN_VALUES: &str = "minValues";
 /// Per-column largest non-null value (truncated for strings; omitted for all-null columns).
-pub(crate) const STATS_MAX_VALUES: &str = "maxValues";
+pub const STATS_MAX_VALUES: &str = "maxValues";
 /// Whether the min/max values are tight bounds (vs. lower/upper bounds).
-pub(crate) const STATS_TIGHT_BOUNDS: &str = "tightBounds";
+pub const STATS_TIGHT_BOUNDS: &str = "tightBounds";
 
 static COMMIT_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
     Arc::new(StructType::new_unchecked([

--- a/kernel/src/checkpoint/checkpoint_transform.rs
+++ b/kernel/src/checkpoint/checkpoint_transform.rs
@@ -331,7 +331,7 @@ fn build_add_output_schema(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::actions::STATS_NUM_RECORDS;
+    use crate::actions::NUM_RECORDS;
 
     #[test]
     fn test_config_defaults() {
@@ -581,7 +581,7 @@ mod tests {
         ]);
 
         let injected_schema =
-            StructType::new_unchecked([StructField::nullable(STATS_NUM_RECORDS, DataType::LONG)]);
+            StructType::new_unchecked([StructField::nullable(NUM_RECORDS, DataType::LONG)]);
 
         let result = add_schema
             .with_field_inserted_after(
@@ -635,7 +635,7 @@ mod tests {
         ]);
 
         let stats_schema =
-            StructType::new_unchecked([StructField::nullable(STATS_NUM_RECORDS, DataType::LONG)]);
+            StructType::new_unchecked([StructField::nullable(NUM_RECORDS, DataType::LONG)]);
 
         let result = build_add_output_schema(&config, &add_schema, &stats_schema, None)
             .expect("build add output schema should produce a valid schema");
@@ -658,7 +658,7 @@ mod tests {
         ]);
 
         let stats_schema =
-            StructType::new_unchecked([StructField::nullable(STATS_NUM_RECORDS, DataType::LONG)]);
+            StructType::new_unchecked([StructField::nullable(NUM_RECORDS, DataType::LONG)]);
 
         let result = build_add_output_schema(&config, &add_schema, &stats_schema, None)
             .expect("build add output schema should produce a valid schema");
@@ -689,7 +689,7 @@ mod tests {
         ]);
 
         let stats_schema =
-            StructType::new_unchecked([StructField::nullable(STATS_NUM_RECORDS, DataType::LONG)]);
+            StructType::new_unchecked([StructField::nullable(NUM_RECORDS, DataType::LONG)]);
         let pv_schema = StructType::new_unchecked([
             StructField::nullable("year", DataType::INTEGER),
             StructField::nullable("month", DataType::INTEGER),

--- a/kernel/src/checkpoint/checkpoint_transform.rs
+++ b/kernel/src/checkpoint/checkpoint_transform.rs
@@ -331,6 +331,7 @@ fn build_add_output_schema(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::actions::STATS_NUM_RECORDS;
 
     #[test]
     fn test_config_defaults() {
@@ -580,7 +581,7 @@ mod tests {
         ]);
 
         let injected_schema =
-            StructType::new_unchecked([StructField::nullable("numRecords", DataType::LONG)]);
+            StructType::new_unchecked([StructField::nullable(STATS_NUM_RECORDS, DataType::LONG)]);
 
         let result = add_schema
             .with_field_inserted_after(
@@ -634,7 +635,7 @@ mod tests {
         ]);
 
         let stats_schema =
-            StructType::new_unchecked([StructField::nullable("numRecords", DataType::LONG)]);
+            StructType::new_unchecked([StructField::nullable(STATS_NUM_RECORDS, DataType::LONG)]);
 
         let result = build_add_output_schema(&config, &add_schema, &stats_schema, None)
             .expect("build add output schema should produce a valid schema");
@@ -657,7 +658,7 @@ mod tests {
         ]);
 
         let stats_schema =
-            StructType::new_unchecked([StructField::nullable("numRecords", DataType::LONG)]);
+            StructType::new_unchecked([StructField::nullable(STATS_NUM_RECORDS, DataType::LONG)]);
 
         let result = build_add_output_schema(&config, &add_schema, &stats_schema, None)
             .expect("build add output schema should produce a valid schema");
@@ -688,7 +689,7 @@ mod tests {
         ]);
 
         let stats_schema =
-            StructType::new_unchecked([StructField::nullable("numRecords", DataType::LONG)]);
+            StructType::new_unchecked([StructField::nullable(STATS_NUM_RECORDS, DataType::LONG)]);
         let pv_schema = StructType::new_unchecked([
             StructField::nullable("year", DataType::INTEGER),
             StructField::nullable("month", DataType::INTEGER),

--- a/kernel/src/checkpoint/sidecar/tests.rs
+++ b/kernel/src/checkpoint/sidecar/tests.rs
@@ -7,9 +7,7 @@ use url::Url;
 use crate::action_reconciliation::{
     ActionReconciliationIterator, ActionReconciliationIteratorState,
 };
-use crate::actions::{
-    Add, ADD_NAME, MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS,
-};
+use crate::actions::{Add, ADD_NAME, MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS};
 use crate::arrow::array::{Array, ArrayRef, AsArray, RecordBatch, StructArray};
 use crate::arrow::datatypes::{ArrowPrimitiveType, Int32Type, Int64Type};
 use crate::checkpoint::sidecar::{SidecarSplitter, SingleSidecarDataIterator};
@@ -628,10 +626,7 @@ async fn test_generate_sidecars_stats_and_partition_values() -> DeltaResult<()> 
                 .column_by_name("stats_parsed")
                 .unwrap()
                 .as_struct();
-            assert_eq!(
-                struct_field_value::<Int64Type>(stats, NUM_RECORDS, row),
-                42
-            );
+            assert_eq!(struct_field_value::<Int64Type>(stats, NUM_RECORDS, row), 42);
             let min_vals = stats.column_by_name(MIN_VALUES).unwrap().as_struct();
             assert_eq!(struct_field_value::<Int64Type>(min_vals, "id", row), 1);
             assert_eq!(struct_field_string(min_vals, "name", row), "alice");

--- a/kernel/src/checkpoint/sidecar/tests.rs
+++ b/kernel/src/checkpoint/sidecar/tests.rs
@@ -7,7 +7,9 @@ use url::Url;
 use crate::action_reconciliation::{
     ActionReconciliationIterator, ActionReconciliationIteratorState,
 };
-use crate::actions::{Add, ADD_NAME};
+use crate::actions::{
+    Add, ADD_NAME, STATS_MAX_VALUES, STATS_MIN_VALUES, STATS_NULL_COUNT, STATS_NUM_RECORDS,
+};
 use crate::arrow::array::{Array, ArrayRef, AsArray, RecordBatch, StructArray};
 use crate::arrow::datatypes::{ArrowPrimitiveType, Int32Type, Int64Type};
 use crate::checkpoint::sidecar::{SidecarSplitter, SingleSidecarDataIterator};
@@ -627,16 +629,16 @@ async fn test_generate_sidecars_stats_and_partition_values() -> DeltaResult<()> 
                 .unwrap()
                 .as_struct();
             assert_eq!(
-                struct_field_value::<Int64Type>(stats, "numRecords", row),
+                struct_field_value::<Int64Type>(stats, STATS_NUM_RECORDS, row),
                 42
             );
-            let min_vals = stats.column_by_name("minValues").unwrap().as_struct();
+            let min_vals = stats.column_by_name(STATS_MIN_VALUES).unwrap().as_struct();
             assert_eq!(struct_field_value::<Int64Type>(min_vals, "id", row), 1);
             assert_eq!(struct_field_string(min_vals, "name", row), "alice");
-            let max_vals = stats.column_by_name("maxValues").unwrap().as_struct();
+            let max_vals = stats.column_by_name(STATS_MAX_VALUES).unwrap().as_struct();
             assert_eq!(struct_field_value::<Int64Type>(max_vals, "id", row), 100);
             assert_eq!(struct_field_string(max_vals, "name", row), "zoe");
-            let null_count = stats.column_by_name("nullCount").unwrap().as_struct();
+            let null_count = stats.column_by_name(STATS_NULL_COUNT).unwrap().as_struct();
             assert_eq!(struct_field_value::<Int64Type>(null_count, "id", row), 0);
             assert_eq!(struct_field_value::<Int64Type>(null_count, "name", row), 5);
         }

--- a/kernel/src/checkpoint/sidecar/tests.rs
+++ b/kernel/src/checkpoint/sidecar/tests.rs
@@ -8,7 +8,7 @@ use crate::action_reconciliation::{
     ActionReconciliationIterator, ActionReconciliationIteratorState,
 };
 use crate::actions::{
-    Add, ADD_NAME, STATS_MAX_VALUES, STATS_MIN_VALUES, STATS_NULL_COUNT, STATS_NUM_RECORDS,
+    Add, ADD_NAME, MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS,
 };
 use crate::arrow::array::{Array, ArrayRef, AsArray, RecordBatch, StructArray};
 use crate::arrow::datatypes::{ArrowPrimitiveType, Int32Type, Int64Type};
@@ -629,16 +629,16 @@ async fn test_generate_sidecars_stats_and_partition_values() -> DeltaResult<()> 
                 .unwrap()
                 .as_struct();
             assert_eq!(
-                struct_field_value::<Int64Type>(stats, STATS_NUM_RECORDS, row),
+                struct_field_value::<Int64Type>(stats, NUM_RECORDS, row),
                 42
             );
-            let min_vals = stats.column_by_name(STATS_MIN_VALUES).unwrap().as_struct();
+            let min_vals = stats.column_by_name(MIN_VALUES).unwrap().as_struct();
             assert_eq!(struct_field_value::<Int64Type>(min_vals, "id", row), 1);
             assert_eq!(struct_field_string(min_vals, "name", row), "alice");
-            let max_vals = stats.column_by_name(STATS_MAX_VALUES).unwrap().as_struct();
+            let max_vals = stats.column_by_name(MAX_VALUES).unwrap().as_struct();
             assert_eq!(struct_field_value::<Int64Type>(max_vals, "id", row), 100);
             assert_eq!(struct_field_string(max_vals, "name", row), "zoe");
-            let null_count = stats.column_by_name(STATS_NULL_COUNT).unwrap().as_struct();
+            let null_count = stats.column_by_name(NULL_COUNT).unwrap().as_struct();
             assert_eq!(struct_field_value::<Int64Type>(null_count, "id", row), 0);
             assert_eq!(struct_field_value::<Int64Type>(null_count, "name", row), 5);
         }

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -583,7 +583,7 @@ mod tests {
     use url::Url;
 
     use super::*;
-    use crate::actions::{STATS_NUM_RECORDS, STATS_TIGHT_BOUNDS};
+    use crate::actions::{NUM_RECORDS, TIGHT_BOUNDS};
     use crate::arrow::array::{
         Array, BinaryArray, BooleanArray, Date32Array, Decimal128Array, Float32Array, Float64Array,
         Int16Array, Int32Array, Int64Array, Int8Array, RecordBatch, StringArray,
@@ -720,8 +720,8 @@ mod tests {
         let file_metadata = FileMeta::new(location.clone(), last_modified, size);
         let stats = StructArray::try_new(
             vec![
-                Field::new(STATS_NUM_RECORDS, ArrowDataType::Int64, true),
-                Field::new(STATS_TIGHT_BOUNDS, ArrowDataType::Boolean, true),
+                Field::new(NUM_RECORDS, ArrowDataType::Int64, true),
+                Field::new(TIGHT_BOUNDS, ArrowDataType::Boolean, true),
             ]
             .into(),
             vec![
@@ -845,7 +845,7 @@ mod tests {
 
         // Check numRecords from stats
         let num_records = stats
-            .column_by_name(STATS_NUM_RECORDS)
+            .column_by_name(NUM_RECORDS)
             .unwrap()
             .as_any()
             .downcast_ref::<Int64Array>()

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -583,6 +583,7 @@ mod tests {
     use url::Url;
 
     use super::*;
+    use crate::actions::{STATS_NUM_RECORDS, STATS_TIGHT_BOUNDS};
     use crate::arrow::array::{
         Array, BinaryArray, BooleanArray, Date32Array, Decimal128Array, Float32Array, Float64Array,
         Int16Array, Int32Array, Int64Array, Int8Array, RecordBatch, StringArray,
@@ -719,8 +720,8 @@ mod tests {
         let file_metadata = FileMeta::new(location.clone(), last_modified, size);
         let stats = StructArray::try_new(
             vec![
-                Field::new("numRecords", ArrowDataType::Int64, true),
-                Field::new("tightBounds", ArrowDataType::Boolean, true),
+                Field::new(STATS_NUM_RECORDS, ArrowDataType::Int64, true),
+                Field::new(STATS_TIGHT_BOUNDS, ArrowDataType::Boolean, true),
             ]
             .into(),
             vec![
@@ -844,7 +845,7 @@ mod tests {
 
         // Check numRecords from stats
         let num_records = stats
-            .column_by_name("numRecords")
+            .column_by_name(STATS_NUM_RECORDS)
             .unwrap()
             .as_any()
             .downcast_ref::<Int64Array>()

--- a/kernel/src/engine/default/stats.rs
+++ b/kernel/src/engine/default/stats.rs
@@ -8,6 +8,9 @@ use std::sync::Arc;
 
 use delta_kernel_derive::internal_api;
 
+use crate::actions::{
+    STATS_MAX_VALUES, STATS_MIN_VALUES, STATS_NULL_COUNT, STATS_NUM_RECORDS, STATS_TIGHT_BOUNDS,
+};
 use crate::arrow::array::{
     new_null_array, Array, ArrayRef, AsArray, BooleanArray, Decimal128Array, Int64Array,
     LargeStringArray, PrimitiveArray, RecordBatch, StringArray, StringViewArray, StructArray,
@@ -511,9 +514,9 @@ pub(crate) fn collect_stats(
     let schema = batch.schema();
 
     // Collect all stats in a single traversal
-    let mut null_counts = StatsAccumulator::new("nullCount");
-    let mut min_values = StatsAccumulator::new("minValues");
-    let mut max_values = StatsAccumulator::new("maxValues");
+    let mut null_counts = StatsAccumulator::new(STATS_NULL_COUNT);
+    let mut min_values = StatsAccumulator::new(STATS_MIN_VALUES);
+    let mut max_values = StatsAccumulator::new(STATS_MAX_VALUES);
 
     for (col_idx, field) in schema.fields().iter().enumerate() {
         let mut path = vec![field.name().to_string()];
@@ -534,7 +537,7 @@ pub(crate) fn collect_stats(
     }
 
     // Build output struct
-    let mut fields = vec![Field::new("numRecords", DataType::Int64, true)];
+    let mut fields = vec![Field::new(STATS_NUM_RECORDS, DataType::Int64, true)];
     let mut arrays: Vec<Arc<dyn Array>> =
         vec![Arc::new(Int64Array::from(vec![batch.num_rows() as i64]))];
 
@@ -546,7 +549,7 @@ pub(crate) fn collect_stats(
     }
 
     // tightBounds
-    fields.push(Field::new("tightBounds", DataType::Boolean, true));
+    fields.push(Field::new(STATS_TIGHT_BOUNDS, DataType::Boolean, true));
     arrays.push(Arc::new(BooleanArray::from(vec![true])));
 
     StructArray::try_new(fields.into(), arrays, None)

--- a/kernel/src/engine/default/stats.rs
+++ b/kernel/src/engine/default/stats.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use delta_kernel_derive::internal_api;
 
 use crate::actions::{
-    STATS_MAX_VALUES, STATS_MIN_VALUES, STATS_NULL_COUNT, STATS_NUM_RECORDS, STATS_TIGHT_BOUNDS,
+    MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS, TIGHT_BOUNDS,
 };
 use crate::arrow::array::{
     new_null_array, Array, ArrayRef, AsArray, BooleanArray, Decimal128Array, Int64Array,
@@ -514,9 +514,9 @@ pub(crate) fn collect_stats(
     let schema = batch.schema();
 
     // Collect all stats in a single traversal
-    let mut null_counts = StatsAccumulator::new(STATS_NULL_COUNT);
-    let mut min_values = StatsAccumulator::new(STATS_MIN_VALUES);
-    let mut max_values = StatsAccumulator::new(STATS_MAX_VALUES);
+    let mut null_counts = StatsAccumulator::new(NULL_COUNT);
+    let mut min_values = StatsAccumulator::new(MIN_VALUES);
+    let mut max_values = StatsAccumulator::new(MAX_VALUES);
 
     for (col_idx, field) in schema.fields().iter().enumerate() {
         let mut path = vec![field.name().to_string()];
@@ -537,7 +537,7 @@ pub(crate) fn collect_stats(
     }
 
     // Build output struct
-    let mut fields = vec![Field::new(STATS_NUM_RECORDS, DataType::Int64, true)];
+    let mut fields = vec![Field::new(NUM_RECORDS, DataType::Int64, true)];
     let mut arrays: Vec<Arc<dyn Array>> =
         vec![Arc::new(Int64Array::from(vec![batch.num_rows() as i64]))];
 
@@ -549,7 +549,7 @@ pub(crate) fn collect_stats(
     }
 
     // tightBounds
-    fields.push(Field::new(STATS_TIGHT_BOUNDS, DataType::Boolean, true));
+    fields.push(Field::new(TIGHT_BOUNDS, DataType::Boolean, true));
     arrays.push(Arc::new(BooleanArray::from(vec![true])));
 
     StructArray::try_new(fields.into(), arrays, None)
@@ -580,7 +580,7 @@ mod tests {
 
         assert_eq!(stats.len(), 1);
         let num_records = stats
-            .column_by_name(STATS_NUM_RECORDS)
+            .column_by_name(NUM_RECORDS)
             .unwrap()
             .as_any()
             .downcast_ref::<Int64Array>()
@@ -608,7 +608,7 @@ mod tests {
 
         // Check nullCount struct
         let null_count = stats
-            .column_by_name(STATS_NULL_COUNT)
+            .column_by_name(NULL_COUNT)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -653,7 +653,7 @@ mod tests {
         let stats = collect_stats(&batch, &[column_name!("id")]).unwrap();
 
         let null_count = stats
-            .column_by_name(STATS_NULL_COUNT)
+            .column_by_name(NULL_COUNT)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -689,7 +689,7 @@ mod tests {
 
         // Check minValues
         let min_values = stats
-            .column_by_name(STATS_MIN_VALUES)
+            .column_by_name(MIN_VALUES)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -713,7 +713,7 @@ mod tests {
 
         // Check maxValues
         let max_values = stats
-            .column_by_name(STATS_MAX_VALUES)
+            .column_by_name(MAX_VALUES)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -758,7 +758,7 @@ mod tests {
 
         // numRecords should be 3
         let num_records = stats
-            .column_by_name(STATS_NUM_RECORDS)
+            .column_by_name(NUM_RECORDS)
             .unwrap()
             .as_any()
             .downcast_ref::<Int64Array>()
@@ -767,7 +767,7 @@ mod tests {
 
         // nullCount should be 3
         let null_count = stats
-            .column_by_name(STATS_NULL_COUNT)
+            .column_by_name(NULL_COUNT)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -785,7 +785,7 @@ mod tests {
         // check nullCount == numRecords. The JSON serializer omits null fields, so
         // the on-disk format still matches Spark's ignoreNullFields behavior.
         let min_values = stats
-            .column_by_name(STATS_MIN_VALUES)
+            .column_by_name(MIN_VALUES)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -794,7 +794,7 @@ mod tests {
         assert!(min_col.is_null(0));
 
         let max_values = stats
-            .column_by_name(STATS_MAX_VALUES)
+            .column_by_name(MAX_VALUES)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -814,13 +814,13 @@ mod tests {
         let stats = collect_stats(&batch, &[]).unwrap();
 
         // Should still have numRecords and tightBounds
-        assert!(stats.column_by_name(STATS_NUM_RECORDS).is_some());
-        assert!(stats.column_by_name(STATS_TIGHT_BOUNDS).is_some());
+        assert!(stats.column_by_name(NUM_RECORDS).is_some());
+        assert!(stats.column_by_name(TIGHT_BOUNDS).is_some());
 
         // Should not have nullCount, minValues, maxValues
-        assert!(stats.column_by_name(STATS_NULL_COUNT).is_none());
-        assert!(stats.column_by_name(STATS_MIN_VALUES).is_none());
-        assert!(stats.column_by_name(STATS_MAX_VALUES).is_none());
+        assert!(stats.column_by_name(NULL_COUNT).is_none());
+        assert!(stats.column_by_name(MIN_VALUES).is_none());
+        assert!(stats.column_by_name(MAX_VALUES).is_none());
     }
 
     #[test]
@@ -839,7 +839,7 @@ mod tests {
 
         // Check minValues - should be truncated to exactly 32 chars
         let min_values = stats
-            .column_by_name(STATS_MIN_VALUES)
+            .column_by_name(MIN_VALUES)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -857,7 +857,7 @@ mod tests {
 
         // Check maxValues - should be 32 chars + 0x7F tie-breaker (since 'a' < 0x7F)
         let max_values = stats
-            .column_by_name(STATS_MAX_VALUES)
+            .column_by_name(MAX_VALUES)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -892,7 +892,7 @@ mod tests {
 
         // Check maxValues - should use UTF8_MAX_CHAR since 'À' (the truncated char) >= 0x7F
         let max_values = stats
-            .column_by_name(STATS_MAX_VALUES)
+            .column_by_name(MAX_VALUES)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -925,7 +925,7 @@ mod tests {
         let stats = collect_stats(&batch, &[column_name!("text")]).unwrap();
 
         let min_values = stats
-            .column_by_name(STATS_MIN_VALUES)
+            .column_by_name(MIN_VALUES)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -941,7 +941,7 @@ mod tests {
         assert_eq!(text_min.value(0), short_string);
 
         let max_values = stats
-            .column_by_name(STATS_MAX_VALUES)
+            .column_by_name(MAX_VALUES)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -1047,7 +1047,7 @@ mod tests {
 
         // Check nullCount.nested.a = 0, nullCount.nested.b = 1
         let null_count = stats
-            .column_by_name(STATS_NULL_COUNT)
+            .column_by_name(NULL_COUNT)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -1078,7 +1078,7 @@ mod tests {
 
         // Check minValues.nested.a = 5, minValues.nested.b = "apple"
         let min_values = stats
-            .column_by_name(STATS_MIN_VALUES)
+            .column_by_name(MIN_VALUES)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -1109,7 +1109,7 @@ mod tests {
 
         // Check maxValues.nested.a = 20, maxValues.nested.b = "zebra"
         let max_values = stats
-            .column_by_name(STATS_MAX_VALUES)
+            .column_by_name(MAX_VALUES)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -1174,7 +1174,7 @@ mod tests {
         let stats = collect_stats(&batch, &[column_name!("id"), column_name!("list_col")]).unwrap();
 
         let null_count = stats
-            .column_by_name(STATS_NULL_COUNT)
+            .column_by_name(NULL_COUNT)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -1200,7 +1200,7 @@ mod tests {
 
         // minValues should have id but NOT list_col
         let min_values = stats
-            .column_by_name(STATS_MIN_VALUES)
+            .column_by_name(MIN_VALUES)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -1210,7 +1210,7 @@ mod tests {
 
         // maxValues should have id but NOT list_col
         let max_values = stats
-            .column_by_name(STATS_MAX_VALUES)
+            .column_by_name(MAX_VALUES)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -1268,14 +1268,14 @@ mod tests {
         let stats = collect_stats(&batch, &[column_name!("id"), column_name!("map_col")]).unwrap();
 
         // === THEN: map_col has nullCount=1 but no min/max ===
-        let null_count = child_struct(&stats, STATS_NULL_COUNT);
+        let null_count = child_struct(&stats, NULL_COUNT);
         let map_nulls = null_count
             .column_by_name("map_col")
             .unwrap()
             .as_primitive::<Int64Type>();
         assert_eq!(map_nulls.value(0), 1);
 
-        let min_values = child_struct(&stats, STATS_MIN_VALUES);
+        let min_values = child_struct(&stats, MIN_VALUES);
         assert!(min_values.column_by_name("id").is_some());
         assert!(min_values.column_by_name("map_col").is_none());
     }
@@ -1325,7 +1325,7 @@ mod tests {
         let stats = collect_stats(&batch, &[column_name!("id"), column_name!("v")]).unwrap();
 
         // === THEN: v has nullCount=1 at the struct level, no recursion, no min/max ===
-        let null_count = child_struct(&stats, STATS_NULL_COUNT);
+        let null_count = child_struct(&stats, NULL_COUNT);
         let v_nulls = null_count
             .column_by_name("v")
             .unwrap()
@@ -1336,7 +1336,7 @@ mod tests {
         assert!(null_count.column_by_name("metadata").is_none());
         assert!(null_count.column_by_name("value").is_none());
 
-        let min_values = child_struct(&stats, STATS_MIN_VALUES);
+        let min_values = child_struct(&stats, MIN_VALUES);
         assert!(min_values.column_by_name("id").is_some());
         assert!(min_values.column_by_name("v").is_none());
     }
@@ -1394,31 +1394,31 @@ mod tests {
 
         // nullCount includes struct-level nulls
         assert_eq!(
-            get_stat::<Int64Type>(&stats, STATS_NULL_COUNT, "my_struct", "a"),
+            get_stat::<Int64Type>(&stats, NULL_COUNT, "my_struct", "a"),
             2
         );
         assert_eq!(
-            get_stat::<Int64Type>(&stats, STATS_NULL_COUNT, "my_struct", "b"),
+            get_stat::<Int64Type>(&stats, NULL_COUNT, "my_struct", "b"),
             3
         );
 
         // minValues excludes values from null struct rows
         assert_eq!(
-            get_stat::<Int32Type>(&stats, STATS_MIN_VALUES, "my_struct", "a"),
+            get_stat::<Int32Type>(&stats, MIN_VALUES, "my_struct", "a"),
             2
         );
         assert_eq!(
-            get_stat::<Int32Type>(&stats, STATS_MIN_VALUES, "my_struct", "b"),
+            get_stat::<Int32Type>(&stats, MIN_VALUES, "my_struct", "b"),
             20
         );
 
         // maxValues excludes values from null struct rows
         assert_eq!(
-            get_stat::<Int32Type>(&stats, STATS_MAX_VALUES, "my_struct", "a"),
+            get_stat::<Int32Type>(&stats, MAX_VALUES, "my_struct", "a"),
             3
         );
         assert_eq!(
-            get_stat::<Int32Type>(&stats, STATS_MAX_VALUES, "my_struct", "b"),
+            get_stat::<Int32Type>(&stats, MAX_VALUES, "my_struct", "b"),
             20
         );
     }
@@ -1673,12 +1673,12 @@ mod tests {
         // ===== THEN =====
         // Kernel stats must match Spark's numRecords, nullCount, minValues, and maxValues.
         assert_eq!(
-            spark_stats[STATS_NUM_RECORDS], kernel_stats[STATS_NUM_RECORDS],
+            spark_stats[NUM_RECORDS], kernel_stats[NUM_RECORDS],
             "numRecords mismatch"
         );
 
         // Compare nullCount, minValues, maxValues (only keys present in Spark's stats)
-        for section in &[STATS_NULL_COUNT, STATS_MIN_VALUES, STATS_MAX_VALUES] {
+        for section in &[NULL_COUNT, MIN_VALUES, MAX_VALUES] {
             if let Some(spark_section) = spark_stats.get(*section) {
                 let kernel_section = kernel_stats
                     .get(*section)

--- a/kernel/src/engine/default/stats.rs
+++ b/kernel/src/engine/default/stats.rs
@@ -580,7 +580,7 @@ mod tests {
 
         assert_eq!(stats.len(), 1);
         let num_records = stats
-            .column_by_name("numRecords")
+            .column_by_name(STATS_NUM_RECORDS)
             .unwrap()
             .as_any()
             .downcast_ref::<Int64Array>()
@@ -608,7 +608,7 @@ mod tests {
 
         // Check nullCount struct
         let null_count = stats
-            .column_by_name("nullCount")
+            .column_by_name(STATS_NULL_COUNT)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -653,7 +653,7 @@ mod tests {
         let stats = collect_stats(&batch, &[column_name!("id")]).unwrap();
 
         let null_count = stats
-            .column_by_name("nullCount")
+            .column_by_name(STATS_NULL_COUNT)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -689,7 +689,7 @@ mod tests {
 
         // Check minValues
         let min_values = stats
-            .column_by_name("minValues")
+            .column_by_name(STATS_MIN_VALUES)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -713,7 +713,7 @@ mod tests {
 
         // Check maxValues
         let max_values = stats
-            .column_by_name("maxValues")
+            .column_by_name(STATS_MAX_VALUES)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -758,7 +758,7 @@ mod tests {
 
         // numRecords should be 3
         let num_records = stats
-            .column_by_name("numRecords")
+            .column_by_name(STATS_NUM_RECORDS)
             .unwrap()
             .as_any()
             .downcast_ref::<Int64Array>()
@@ -767,7 +767,7 @@ mod tests {
 
         // nullCount should be 3
         let null_count = stats
-            .column_by_name("nullCount")
+            .column_by_name(STATS_NULL_COUNT)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -785,7 +785,7 @@ mod tests {
         // check nullCount == numRecords. The JSON serializer omits null fields, so
         // the on-disk format still matches Spark's ignoreNullFields behavior.
         let min_values = stats
-            .column_by_name("minValues")
+            .column_by_name(STATS_MIN_VALUES)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -794,7 +794,7 @@ mod tests {
         assert!(min_col.is_null(0));
 
         let max_values = stats
-            .column_by_name("maxValues")
+            .column_by_name(STATS_MAX_VALUES)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -814,13 +814,13 @@ mod tests {
         let stats = collect_stats(&batch, &[]).unwrap();
 
         // Should still have numRecords and tightBounds
-        assert!(stats.column_by_name("numRecords").is_some());
-        assert!(stats.column_by_name("tightBounds").is_some());
+        assert!(stats.column_by_name(STATS_NUM_RECORDS).is_some());
+        assert!(stats.column_by_name(STATS_TIGHT_BOUNDS).is_some());
 
         // Should not have nullCount, minValues, maxValues
-        assert!(stats.column_by_name("nullCount").is_none());
-        assert!(stats.column_by_name("minValues").is_none());
-        assert!(stats.column_by_name("maxValues").is_none());
+        assert!(stats.column_by_name(STATS_NULL_COUNT).is_none());
+        assert!(stats.column_by_name(STATS_MIN_VALUES).is_none());
+        assert!(stats.column_by_name(STATS_MAX_VALUES).is_none());
     }
 
     #[test]
@@ -839,7 +839,7 @@ mod tests {
 
         // Check minValues - should be truncated to exactly 32 chars
         let min_values = stats
-            .column_by_name("minValues")
+            .column_by_name(STATS_MIN_VALUES)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -857,7 +857,7 @@ mod tests {
 
         // Check maxValues - should be 32 chars + 0x7F tie-breaker (since 'a' < 0x7F)
         let max_values = stats
-            .column_by_name("maxValues")
+            .column_by_name(STATS_MAX_VALUES)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -892,7 +892,7 @@ mod tests {
 
         // Check maxValues - should use UTF8_MAX_CHAR since 'À' (the truncated char) >= 0x7F
         let max_values = stats
-            .column_by_name("maxValues")
+            .column_by_name(STATS_MAX_VALUES)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -925,7 +925,7 @@ mod tests {
         let stats = collect_stats(&batch, &[column_name!("text")]).unwrap();
 
         let min_values = stats
-            .column_by_name("minValues")
+            .column_by_name(STATS_MIN_VALUES)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -941,7 +941,7 @@ mod tests {
         assert_eq!(text_min.value(0), short_string);
 
         let max_values = stats
-            .column_by_name("maxValues")
+            .column_by_name(STATS_MAX_VALUES)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -1047,7 +1047,7 @@ mod tests {
 
         // Check nullCount.nested.a = 0, nullCount.nested.b = 1
         let null_count = stats
-            .column_by_name("nullCount")
+            .column_by_name(STATS_NULL_COUNT)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -1078,7 +1078,7 @@ mod tests {
 
         // Check minValues.nested.a = 5, minValues.nested.b = "apple"
         let min_values = stats
-            .column_by_name("minValues")
+            .column_by_name(STATS_MIN_VALUES)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -1109,7 +1109,7 @@ mod tests {
 
         // Check maxValues.nested.a = 20, maxValues.nested.b = "zebra"
         let max_values = stats
-            .column_by_name("maxValues")
+            .column_by_name(STATS_MAX_VALUES)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -1174,7 +1174,7 @@ mod tests {
         let stats = collect_stats(&batch, &[column_name!("id"), column_name!("list_col")]).unwrap();
 
         let null_count = stats
-            .column_by_name("nullCount")
+            .column_by_name(STATS_NULL_COUNT)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -1200,7 +1200,7 @@ mod tests {
 
         // minValues should have id but NOT list_col
         let min_values = stats
-            .column_by_name("minValues")
+            .column_by_name(STATS_MIN_VALUES)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -1210,7 +1210,7 @@ mod tests {
 
         // maxValues should have id but NOT list_col
         let max_values = stats
-            .column_by_name("maxValues")
+            .column_by_name(STATS_MAX_VALUES)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -1268,14 +1268,14 @@ mod tests {
         let stats = collect_stats(&batch, &[column_name!("id"), column_name!("map_col")]).unwrap();
 
         // === THEN: map_col has nullCount=1 but no min/max ===
-        let null_count = child_struct(&stats, "nullCount");
+        let null_count = child_struct(&stats, STATS_NULL_COUNT);
         let map_nulls = null_count
             .column_by_name("map_col")
             .unwrap()
             .as_primitive::<Int64Type>();
         assert_eq!(map_nulls.value(0), 1);
 
-        let min_values = child_struct(&stats, "minValues");
+        let min_values = child_struct(&stats, STATS_MIN_VALUES);
         assert!(min_values.column_by_name("id").is_some());
         assert!(min_values.column_by_name("map_col").is_none());
     }
@@ -1325,7 +1325,7 @@ mod tests {
         let stats = collect_stats(&batch, &[column_name!("id"), column_name!("v")]).unwrap();
 
         // === THEN: v has nullCount=1 at the struct level, no recursion, no min/max ===
-        let null_count = child_struct(&stats, "nullCount");
+        let null_count = child_struct(&stats, STATS_NULL_COUNT);
         let v_nulls = null_count
             .column_by_name("v")
             .unwrap()
@@ -1336,7 +1336,7 @@ mod tests {
         assert!(null_count.column_by_name("metadata").is_none());
         assert!(null_count.column_by_name("value").is_none());
 
-        let min_values = child_struct(&stats, "minValues");
+        let min_values = child_struct(&stats, STATS_MIN_VALUES);
         assert!(min_values.column_by_name("id").is_some());
         assert!(min_values.column_by_name("v").is_none());
     }
@@ -1394,31 +1394,31 @@ mod tests {
 
         // nullCount includes struct-level nulls
         assert_eq!(
-            get_stat::<Int64Type>(&stats, "nullCount", "my_struct", "a"),
+            get_stat::<Int64Type>(&stats, STATS_NULL_COUNT, "my_struct", "a"),
             2
         );
         assert_eq!(
-            get_stat::<Int64Type>(&stats, "nullCount", "my_struct", "b"),
+            get_stat::<Int64Type>(&stats, STATS_NULL_COUNT, "my_struct", "b"),
             3
         );
 
         // minValues excludes values from null struct rows
         assert_eq!(
-            get_stat::<Int32Type>(&stats, "minValues", "my_struct", "a"),
+            get_stat::<Int32Type>(&stats, STATS_MIN_VALUES, "my_struct", "a"),
             2
         );
         assert_eq!(
-            get_stat::<Int32Type>(&stats, "minValues", "my_struct", "b"),
+            get_stat::<Int32Type>(&stats, STATS_MIN_VALUES, "my_struct", "b"),
             20
         );
 
         // maxValues excludes values from null struct rows
         assert_eq!(
-            get_stat::<Int32Type>(&stats, "maxValues", "my_struct", "a"),
+            get_stat::<Int32Type>(&stats, STATS_MAX_VALUES, "my_struct", "a"),
             3
         );
         assert_eq!(
-            get_stat::<Int32Type>(&stats, "maxValues", "my_struct", "b"),
+            get_stat::<Int32Type>(&stats, STATS_MAX_VALUES, "my_struct", "b"),
             20
         );
     }
@@ -1673,12 +1673,12 @@ mod tests {
         // ===== THEN =====
         // Kernel stats must match Spark's numRecords, nullCount, minValues, and maxValues.
         assert_eq!(
-            spark_stats["numRecords"], kernel_stats["numRecords"],
+            spark_stats[STATS_NUM_RECORDS], kernel_stats[STATS_NUM_RECORDS],
             "numRecords mismatch"
         );
 
         // Compare nullCount, minValues, maxValues (only keys present in Spark's stats)
-        for section in &["nullCount", "minValues", "maxValues"] {
+        for section in &[STATS_NULL_COUNT, STATS_MIN_VALUES, STATS_MAX_VALUES] {
             if let Some(spark_section) = spark_stats.get(*section) {
                 let kernel_section = kernel_stats
                     .get(*section)

--- a/kernel/src/engine/default/stats.rs
+++ b/kernel/src/engine/default/stats.rs
@@ -8,9 +8,7 @@ use std::sync::Arc;
 
 use delta_kernel_derive::internal_api;
 
-use crate::actions::{
-    MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS, TIGHT_BOUNDS,
-};
+use crate::actions::{MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS, TIGHT_BOUNDS};
 use crate::arrow::array::{
     new_null_array, Array, ArrayRef, AsArray, BooleanArray, Decimal128Array, Int64Array,
     LargeStringArray, PrimitiveArray, RecordBatch, StringArray, StringViewArray, StructArray,

--- a/kernel/src/engine/parquet_row_group_skipping.rs
+++ b/kernel/src/engine/parquet_row_group_skipping.rs
@@ -6,7 +6,7 @@ use chrono::{DateTime, Days};
 use delta_kernel_derive::internal_api;
 use tracing::debug;
 
-use crate::actions::{STATS_MAX_VALUES, STATS_MIN_VALUES, STATS_NULL_COUNT};
+use crate::actions::{MAX_VALUES, MIN_VALUES, NULL_COUNT};
 use crate::engine::arrow_utils::RowIndexBuilder;
 use crate::expressions::{ColumnName, DecimalData, Predicate, Scalar};
 use crate::kernel_predicates::parquet_stats_skipping::ParquetStatsProvider;
@@ -549,9 +549,9 @@ fn compute_checkpoint_field_indices(
             }
             let entry = stats_indices.entry(col_name).or_default();
             match stat_type {
-                STATS_MIN_VALUES => entry.min_index = Some(i),
-                STATS_MAX_VALUES => entry.max_index = Some(i),
-                STATS_NULL_COUNT => entry.nullcount_index = Some(i),
+                MIN_VALUES => entry.min_index = Some(i),
+                MAX_VALUES => entry.max_index = Some(i),
+                NULL_COUNT => entry.nullcount_index = Some(i),
                 _ => {}
             }
         }

--- a/kernel/src/engine/parquet_row_group_skipping.rs
+++ b/kernel/src/engine/parquet_row_group_skipping.rs
@@ -6,6 +6,7 @@ use chrono::{DateTime, Days};
 use delta_kernel_derive::internal_api;
 use tracing::debug;
 
+use crate::actions::{STATS_MAX_VALUES, STATS_MIN_VALUES, STATS_NULL_COUNT};
 use crate::engine::arrow_utils::RowIndexBuilder;
 use crate::expressions::{ColumnName, DecimalData, Predicate, Scalar};
 use crate::kernel_predicates::parquet_stats_skipping::ParquetStatsProvider;
@@ -548,9 +549,9 @@ fn compute_checkpoint_field_indices(
             }
             let entry = stats_indices.entry(col_name).or_default();
             match stat_type {
-                "minValues" => entry.min_index = Some(i),
-                "maxValues" => entry.max_index = Some(i),
-                "nullCount" => entry.nullcount_index = Some(i),
+                STATS_MIN_VALUES => entry.min_index = Some(i),
+                STATS_MAX_VALUES => entry.max_index = Some(i),
+                STATS_NULL_COUNT => entry.nullcount_index = Some(i),
                 _ => {}
             }
         }

--- a/kernel/src/engine/parquet_row_group_skipping/tests.rs
+++ b/kernel/src/engine/parquet_row_group_skipping/tests.rs
@@ -518,17 +518,17 @@ fn write_checkpoint_parquet(
     part_values: Option<&[Option<&str>]>,
 ) -> tempfile::NamedTempFile {
     let (min_f, min_a) = build_stat_column(
-        "minValues",
+        STATS_MIN_VALUES,
         col_path,
         Arc::new(Int64Array::from(min_values.to_vec())),
     );
     let (max_f, max_a) = build_stat_column(
-        "maxValues",
+        STATS_MAX_VALUES,
         col_path,
         Arc::new(Int64Array::from(max_values.to_vec())),
     );
     let (nc_f, nc_a) = build_stat_column(
-        "nullCount",
+        STATS_NULL_COUNT,
         col_path,
         Arc::new(Int64Array::from(null_counts.to_vec())),
     );
@@ -1037,17 +1037,17 @@ fn checkpoint_filter_multi_row_group_skipping() {
     // Build schema: add.stats_parsed.{minValues,maxValues,nullCount}.x (INT64)
     let col_field = Arc::new(Field::new("x", ArrowDataType::Int64, true));
     let min_field = Arc::new(Field::new(
-        "minValues",
+        STATS_MIN_VALUES,
         ArrowDataType::Struct(Fields::from(vec![col_field.clone()])),
         true,
     ));
     let max_field = Arc::new(Field::new(
-        "maxValues",
+        STATS_MAX_VALUES,
         ArrowDataType::Struct(Fields::from(vec![col_field.clone()])),
         true,
     ));
     let nc_field = Arc::new(Field::new(
-        "nullCount",
+        STATS_NULL_COUNT,
         ArrowDataType::Struct(Fields::from(vec![col_field.clone()])),
         true,
     ));

--- a/kernel/src/engine/parquet_row_group_skipping/tests.rs
+++ b/kernel/src/engine/parquet_row_group_skipping/tests.rs
@@ -518,17 +518,17 @@ fn write_checkpoint_parquet(
     part_values: Option<&[Option<&str>]>,
 ) -> tempfile::NamedTempFile {
     let (min_f, min_a) = build_stat_column(
-        STATS_MIN_VALUES,
+        MIN_VALUES,
         col_path,
         Arc::new(Int64Array::from(min_values.to_vec())),
     );
     let (max_f, max_a) = build_stat_column(
-        STATS_MAX_VALUES,
+        MAX_VALUES,
         col_path,
         Arc::new(Int64Array::from(max_values.to_vec())),
     );
     let (nc_f, nc_a) = build_stat_column(
-        STATS_NULL_COUNT,
+        NULL_COUNT,
         col_path,
         Arc::new(Int64Array::from(null_counts.to_vec())),
     );
@@ -1037,17 +1037,17 @@ fn checkpoint_filter_multi_row_group_skipping() {
     // Build schema: add.stats_parsed.{minValues,maxValues,nullCount}.x (INT64)
     let col_field = Arc::new(Field::new("x", ArrowDataType::Int64, true));
     let min_field = Arc::new(Field::new(
-        STATS_MIN_VALUES,
+        MIN_VALUES,
         ArrowDataType::Struct(Fields::from(vec![col_field.clone()])),
         true,
     ));
     let max_field = Arc::new(Field::new(
-        STATS_MAX_VALUES,
+        MAX_VALUES,
         ArrowDataType::Struct(Fields::from(vec![col_field.clone()])),
         true,
     ));
     let nc_field = Arc::new(Field::new(
-        STATS_NULL_COUNT,
+        NULL_COUNT,
         ArrowDataType::Struct(Fields::from(vec![col_field.clone()])),
         true,
     ));

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -10,8 +10,8 @@ use url::Url;
 
 use crate::actions::visitors::SidecarVisitor;
 use crate::actions::{
-    get_log_add_schema, schema_contains_file_actions, Sidecar, DOMAIN_METADATA_NAME, METADATA_NAME,
-    PROTOCOL_NAME, SET_TRANSACTION_NAME, SIDECAR_NAME, MAX_VALUES, MIN_VALUES,
+    get_log_add_schema, schema_contains_file_actions, Sidecar, DOMAIN_METADATA_NAME, MAX_VALUES,
+    METADATA_NAME, MIN_VALUES, PROTOCOL_NAME, SET_TRANSACTION_NAME, SIDECAR_NAME,
 };
 use crate::committer::CatalogCommit;
 use crate::expressions::ColumnName;

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -11,7 +11,7 @@ use url::Url;
 use crate::actions::visitors::SidecarVisitor;
 use crate::actions::{
     get_log_add_schema, schema_contains_file_actions, Sidecar, DOMAIN_METADATA_NAME, METADATA_NAME,
-    PROTOCOL_NAME, SET_TRANSACTION_NAME, SIDECAR_NAME, STATS_MAX_VALUES, STATS_MIN_VALUES,
+    PROTOCOL_NAME, SET_TRANSACTION_NAME, SIDECAR_NAME, MAX_VALUES, MIN_VALUES,
 };
 use crate::committer::CatalogCommit;
 use crate::expressions::ColumnName;
@@ -1241,7 +1241,7 @@ impl LogSegment {
         // Check type compatibility for both minValues and maxValues structs.
         // While these typically have the same schema, the protocol doesn't guarantee it,
         // so we check both to be safe.
-        for field_name in [STATS_MIN_VALUES, STATS_MAX_VALUES] {
+        for field_name in [MIN_VALUES, MAX_VALUES] {
             let Some(checkpoint_values_field) = stats_struct.field(field_name) else {
                 // stats_parsed exists but no minValues/maxValues - unusual but valid
                 continue;

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -11,7 +11,7 @@ use url::Url;
 use crate::actions::visitors::SidecarVisitor;
 use crate::actions::{
     get_log_add_schema, schema_contains_file_actions, Sidecar, DOMAIN_METADATA_NAME, METADATA_NAME,
-    PROTOCOL_NAME, SET_TRANSACTION_NAME, SIDECAR_NAME,
+    PROTOCOL_NAME, SET_TRANSACTION_NAME, SIDECAR_NAME, STATS_MAX_VALUES, STATS_MIN_VALUES,
 };
 use crate::committer::CatalogCommit;
 use crate::expressions::ColumnName;
@@ -1241,7 +1241,7 @@ impl LogSegment {
         // Check type compatibility for both minValues and maxValues structs.
         // While these typically have the same schema, the protocol doesn't guarantee it,
         // so we check both to be safe.
-        for field_name in ["minValues", "maxValues"] {
+        for field_name in [STATS_MIN_VALUES, STATS_MAX_VALUES] {
             let Some(checkpoint_values_field) = stats_struct.field(field_name) else {
                 // stats_parsed exists but no minValues/maxValues - unusual but valid
                 continue;

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -12,6 +12,7 @@ use crate::actions::visitors::{AddVisitor, SidecarVisitor};
 use crate::actions::{
     get_all_actions_schema, get_commit_schema, Add, Sidecar, ADD_NAME, DOMAIN_METADATA_NAME,
     METADATA_NAME, PROTOCOL_NAME, REMOVE_NAME, SET_TRANSACTION_NAME, SIDECAR_NAME,
+    STATS_MAX_VALUES, STATS_MIN_VALUES, STATS_NUM_RECORDS,
 };
 use crate::arrow::array::StringArray;
 use crate::engine::arrow_data::ArrowEngineData;
@@ -2869,13 +2870,13 @@ async fn test_get_file_actions_schema_multi_part_v1(#[case] use_hint: bool) -> D
 
     // Build a V1 checkpoint schema with stats_parsed containing an integer column.
     let stats_parsed = StructType::new_unchecked([
-        StructField::nullable("numRecords", DataType::LONG),
+        StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
         StructField::nullable(
-            "minValues",
+            STATS_MIN_VALUES,
             StructType::new_unchecked([StructField::nullable("id", DataType::LONG)]),
         ),
         StructField::nullable(
-            "maxValues",
+            STATS_MAX_VALUES,
             StructType::new_unchecked([StructField::nullable("id", DataType::LONG)]),
         ),
     ]);
@@ -3053,12 +3054,12 @@ async fn test_max_published_version_checkpoint_only() {
 // Helper to create a checkpoint schema with stats_parsed for testing
 fn create_checkpoint_schema_with_stats_parsed(min_values_fields: Vec<StructField>) -> StructType {
     let stats_parsed = StructType::new_unchecked([
-        StructField::nullable("numRecords", DataType::LONG),
+        StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
         StructField::nullable(
-            "minValues",
+            STATS_MIN_VALUES,
             StructType::new_unchecked(min_values_fields.clone()),
         ),
-        StructField::nullable("maxValues", StructType::new_unchecked(min_values_fields)),
+        StructField::nullable(STATS_MAX_VALUES, StructType::new_unchecked(min_values_fields)),
     ]);
 
     let add_schema = StructType::new_unchecked([
@@ -3072,12 +3073,12 @@ fn create_checkpoint_schema_with_stats_parsed(min_values_fields: Vec<StructField
 // Helper to create a stats_schema with proper structure (numRecords, minValues, maxValues)
 fn create_stats_schema(column_fields: Vec<StructField>) -> StructType {
     StructType::new_unchecked([
-        StructField::nullable("numRecords", DataType::LONG),
+        StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
         StructField::nullable(
-            "minValues",
+            STATS_MIN_VALUES,
             StructType::new_unchecked(column_fields.clone()),
         ),
-        StructField::nullable("maxValues", StructType::new_unchecked(column_fields)),
+        StructField::nullable(STATS_MAX_VALUES, StructType::new_unchecked(column_fields)),
     ])
 }
 
@@ -3220,7 +3221,7 @@ fn test_schema_has_compatible_stats_parsed_multiple_columns() {
 fn test_schema_has_compatible_stats_parsed_missing_min_max_values() {
     // stats_parsed exists but has no minValues/maxValues fields - unusual but valid (continue case)
     let stats_parsed = StructType::new_unchecked([
-        StructField::nullable("numRecords", DataType::LONG),
+        StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
         // No minValues or maxValues fields
     ]);
 
@@ -3244,10 +3245,10 @@ fn test_schema_has_compatible_stats_parsed_missing_min_max_values() {
 fn test_schema_has_compatible_stats_parsed_min_values_not_struct() {
     // minValues/maxValues exist but are not Struct types - malformed schema (return false case)
     let stats_parsed = StructType::new_unchecked([
-        StructField::nullable("numRecords", DataType::LONG),
+        StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
         // minValues is a primitive type instead of a Struct
-        StructField::nullable("minValues", DataType::STRING),
-        StructField::nullable("maxValues", DataType::STRING),
+        StructField::nullable(STATS_MIN_VALUES, DataType::STRING),
+        StructField::nullable(STATS_MAX_VALUES, DataType::STRING),
     ]);
 
     let add_schema = StructType::new_unchecked([

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -12,7 +12,7 @@ use crate::actions::visitors::{AddVisitor, SidecarVisitor};
 use crate::actions::{
     get_all_actions_schema, get_commit_schema, Add, Sidecar, ADD_NAME, DOMAIN_METADATA_NAME,
     METADATA_NAME, PROTOCOL_NAME, REMOVE_NAME, SET_TRANSACTION_NAME, SIDECAR_NAME,
-    STATS_MAX_VALUES, STATS_MIN_VALUES, STATS_NUM_RECORDS,
+    MAX_VALUES, MIN_VALUES, NUM_RECORDS,
 };
 use crate::arrow::array::StringArray;
 use crate::engine::arrow_data::ArrowEngineData;
@@ -2870,13 +2870,13 @@ async fn test_get_file_actions_schema_multi_part_v1(#[case] use_hint: bool) -> D
 
     // Build a V1 checkpoint schema with stats_parsed containing an integer column.
     let stats_parsed = StructType::new_unchecked([
-        StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
+        StructField::nullable(NUM_RECORDS, DataType::LONG),
         StructField::nullable(
-            STATS_MIN_VALUES,
+            MIN_VALUES,
             StructType::new_unchecked([StructField::nullable("id", DataType::LONG)]),
         ),
         StructField::nullable(
-            STATS_MAX_VALUES,
+            MAX_VALUES,
             StructType::new_unchecked([StructField::nullable("id", DataType::LONG)]),
         ),
     ]);
@@ -3054,12 +3054,12 @@ async fn test_max_published_version_checkpoint_only() {
 // Helper to create a checkpoint schema with stats_parsed for testing
 fn create_checkpoint_schema_with_stats_parsed(min_values_fields: Vec<StructField>) -> StructType {
     let stats_parsed = StructType::new_unchecked([
-        StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
+        StructField::nullable(NUM_RECORDS, DataType::LONG),
         StructField::nullable(
-            STATS_MIN_VALUES,
+            MIN_VALUES,
             StructType::new_unchecked(min_values_fields.clone()),
         ),
-        StructField::nullable(STATS_MAX_VALUES, StructType::new_unchecked(min_values_fields)),
+        StructField::nullable(MAX_VALUES, StructType::new_unchecked(min_values_fields)),
     ]);
 
     let add_schema = StructType::new_unchecked([
@@ -3073,12 +3073,12 @@ fn create_checkpoint_schema_with_stats_parsed(min_values_fields: Vec<StructField
 // Helper to create a stats_schema with proper structure (numRecords, minValues, maxValues)
 fn create_stats_schema(column_fields: Vec<StructField>) -> StructType {
     StructType::new_unchecked([
-        StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
+        StructField::nullable(NUM_RECORDS, DataType::LONG),
         StructField::nullable(
-            STATS_MIN_VALUES,
+            MIN_VALUES,
             StructType::new_unchecked(column_fields.clone()),
         ),
-        StructField::nullable(STATS_MAX_VALUES, StructType::new_unchecked(column_fields)),
+        StructField::nullable(MAX_VALUES, StructType::new_unchecked(column_fields)),
     ])
 }
 
@@ -3221,7 +3221,7 @@ fn test_schema_has_compatible_stats_parsed_multiple_columns() {
 fn test_schema_has_compatible_stats_parsed_missing_min_max_values() {
     // stats_parsed exists but has no minValues/maxValues fields - unusual but valid (continue case)
     let stats_parsed = StructType::new_unchecked([
-        StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
+        StructField::nullable(NUM_RECORDS, DataType::LONG),
         // No minValues or maxValues fields
     ]);
 
@@ -3245,10 +3245,10 @@ fn test_schema_has_compatible_stats_parsed_missing_min_max_values() {
 fn test_schema_has_compatible_stats_parsed_min_values_not_struct() {
     // minValues/maxValues exist but are not Struct types - malformed schema (return false case)
     let stats_parsed = StructType::new_unchecked([
-        StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
+        StructField::nullable(NUM_RECORDS, DataType::LONG),
         // minValues is a primitive type instead of a Struct
-        StructField::nullable(STATS_MIN_VALUES, DataType::STRING),
-        StructField::nullable(STATS_MAX_VALUES, DataType::STRING),
+        StructField::nullable(MIN_VALUES, DataType::STRING),
+        StructField::nullable(MAX_VALUES, DataType::STRING),
     ]);
 
     let add_schema = StructType::new_unchecked([

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -11,8 +11,8 @@ use super::*;
 use crate::actions::visitors::{AddVisitor, SidecarVisitor};
 use crate::actions::{
     get_all_actions_schema, get_commit_schema, Add, Sidecar, ADD_NAME, DOMAIN_METADATA_NAME,
-    METADATA_NAME, PROTOCOL_NAME, REMOVE_NAME, SET_TRANSACTION_NAME, SIDECAR_NAME,
-    MAX_VALUES, MIN_VALUES, NUM_RECORDS,
+    MAX_VALUES, METADATA_NAME, MIN_VALUES, NUM_RECORDS, PROTOCOL_NAME, REMOVE_NAME,
+    SET_TRANSACTION_NAME, SIDECAR_NAME,
 };
 use crate::arrow::array::StringArray;
 use crate::engine::arrow_data::ArrowEngineData;
@@ -3074,10 +3074,7 @@ fn create_checkpoint_schema_with_stats_parsed(min_values_fields: Vec<StructField
 fn create_stats_schema(column_fields: Vec<StructField>) -> StructType {
     StructType::new_unchecked([
         StructField::nullable(NUM_RECORDS, DataType::LONG),
-        StructField::nullable(
-            MIN_VALUES,
-            StructType::new_unchecked(column_fields.clone()),
-        ),
+        StructField::nullable(MIN_VALUES, StructType::new_unchecked(column_fields.clone())),
         StructField::nullable(MAX_VALUES, StructType::new_unchecked(column_fields)),
     ])
 }

--- a/kernel/src/row_tracking.rs
+++ b/kernel/src/row_tracking.rs
@@ -6,7 +6,7 @@ use std::sync::LazyLock;
 
 use serde::{Deserialize, Serialize};
 
-use crate::actions::DomainMetadata;
+use crate::actions::{DomainMetadata, STATS_NUM_RECORDS};
 use crate::engine_data::{GetData, RowVisitor, TypedGetData as _};
 use crate::schema::{ColumnName, ColumnNamesAndTypes, DataType};
 use crate::utils::require;
@@ -113,7 +113,7 @@ impl RowVisitor for RowTrackingVisitor {
     fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
         static NAMES_AND_TYPES: LazyLock<ColumnNamesAndTypes> = LazyLock::new(|| {
             (
-                vec![ColumnName::new(["stats", "numRecords"])],
+                vec![ColumnName::new(["stats", STATS_NUM_RECORDS])],
                 vec![DataType::LONG],
             )
                 .into()
@@ -135,11 +135,10 @@ impl RowVisitor for RowTrackingVisitor {
 
         let mut current_hwm = self.row_id_high_water_mark;
         for i in 0..row_count {
-            let num_records: i64 = getters[0].get_opt(i, "numRecords")?.ok_or_else(|| {
-                Error::InternalError(
-                    "numRecords must be present in Add actions when row tracking is enabled."
-                        .to_string(),
-                )
+            let num_records: i64 = getters[0].get_opt(i, STATS_NUM_RECORDS)?.ok_or_else(|| {
+                Error::InternalError(format!(
+                    "{STATS_NUM_RECORDS} must be present in Add actions when row tracking is enabled."
+                ))
             })?;
             batch_base_row_ids.push(current_hwm + 1);
             current_hwm += num_records;

--- a/kernel/src/row_tracking.rs
+++ b/kernel/src/row_tracking.rs
@@ -300,7 +300,7 @@ mod tests {
         let result = visitor.visit(1, &getters);
         assert_result_error_with_message(
             result,
-            "numRecords must be present in Add actions when row tracking is enabled",
+            &format!("{NUM_RECORDS} must be present in Add actions when row tracking is enabled"),
         );
 
         Ok(())

--- a/kernel/src/row_tracking.rs
+++ b/kernel/src/row_tracking.rs
@@ -6,7 +6,7 @@ use std::sync::LazyLock;
 
 use serde::{Deserialize, Serialize};
 
-use crate::actions::{DomainMetadata, STATS_NUM_RECORDS};
+use crate::actions::{DomainMetadata, NUM_RECORDS};
 use crate::engine_data::{GetData, RowVisitor, TypedGetData as _};
 use crate::schema::{ColumnName, ColumnNamesAndTypes, DataType};
 use crate::utils::require;
@@ -113,7 +113,7 @@ impl RowVisitor for RowTrackingVisitor {
     fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
         static NAMES_AND_TYPES: LazyLock<ColumnNamesAndTypes> = LazyLock::new(|| {
             (
-                vec![ColumnName::new(["stats", STATS_NUM_RECORDS])],
+                vec![ColumnName::new(["stats", NUM_RECORDS])],
                 vec![DataType::LONG],
             )
                 .into()
@@ -135,9 +135,9 @@ impl RowVisitor for RowTrackingVisitor {
 
         let mut current_hwm = self.row_id_high_water_mark;
         for i in 0..row_count {
-            let num_records: i64 = getters[0].get_opt(i, STATS_NUM_RECORDS)?.ok_or_else(|| {
+            let num_records: i64 = getters[0].get_opt(i, NUM_RECORDS)?.ok_or_else(|| {
                 Error::InternalError(format!(
-                    "{STATS_NUM_RECORDS} must be present in Add actions when row tracking is enabled."
+                    "{NUM_RECORDS} must be present in Add actions when row tracking is enabled."
                 ))
             })?;
             batch_base_row_ids.push(current_hwm + 1);
@@ -169,7 +169,7 @@ mod tests {
 
     impl<'a> GetData<'a> for MockGetData {
         fn get_long(&'a self, row_index: usize, field_name: &str) -> DeltaResult<Option<i64>> {
-            if field_name == STATS_NUM_RECORDS {
+            if field_name == NUM_RECORDS {
                 Ok(self.num_records_values.get(row_index).copied().flatten())
             } else {
                 Ok(None)
@@ -311,7 +311,7 @@ mod tests {
         let visitor = RowTrackingVisitor::new(Some(0), None);
         let (names, types) = visitor.selected_column_names_and_types();
 
-        assert_eq!(names, (vec![ColumnName::new(["stats", STATS_NUM_RECORDS])]));
+        assert_eq!(names, (vec![ColumnName::new(["stats", NUM_RECORDS])]));
         assert_eq!(types, vec![DataType::LONG]);
     }
 

--- a/kernel/src/row_tracking.rs
+++ b/kernel/src/row_tracking.rs
@@ -169,7 +169,7 @@ mod tests {
 
     impl<'a> GetData<'a> for MockGetData {
         fn get_long(&'a self, row_index: usize, field_name: &str) -> DeltaResult<Option<i64>> {
-            if field_name == "numRecords" {
+            if field_name == STATS_NUM_RECORDS {
                 Ok(self.num_records_values.get(row_index).copied().flatten())
             } else {
                 Ok(None)
@@ -311,7 +311,7 @@ mod tests {
         let visitor = RowTrackingVisitor::new(Some(0), None);
         let (names, types) = visitor.selected_column_names_and_types();
 
-        assert_eq!(names, (vec![ColumnName::new(["stats", "numRecords"])]));
+        assert_eq!(names, (vec![ColumnName::new(["stats", STATS_NUM_RECORDS])]));
         assert_eq!(types, vec![DataType::LONG]);
     }
 

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 use tracing::{debug, error};
 
 use crate::actions::visitors::SelectionVectorVisitor;
-use crate::actions::{STATS_MAX_VALUES, STATS_MIN_VALUES, STATS_NULL_COUNT, STATS_NUM_RECORDS};
+use crate::actions::{MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS};
 use crate::error::DeltaResult;
 use crate::expressions::{
     column_expr, column_name, joined_column_expr, BinaryPredicateOp, ColumnName,
@@ -432,7 +432,7 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
             Some(joined_column_expr!("partitionValues_parsed", col))
         } else {
             Some(Expr::from(
-                ColumnName::new(["stats_parsed", STATS_MIN_VALUES]).join(col),
+                ColumnName::new(["stats_parsed", MIN_VALUES]).join(col),
             ))
         }
     }
@@ -444,7 +444,7 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
             Some(joined_column_expr!("partitionValues_parsed", col))
         } else {
             Some(Expr::from(
-                ColumnName::new(["stats_parsed", STATS_MAX_VALUES]).join(col),
+                ColumnName::new(["stats_parsed", MAX_VALUES]).join(col),
             ))
         }
     }
@@ -474,7 +474,7 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
             None
         } else {
             Some(Expr::from(
-                ColumnName::new(["stats_parsed", STATS_NULL_COUNT]).join(col),
+                ColumnName::new(["stats_parsed", NULL_COUNT]).join(col),
             ))
         }
     }
@@ -483,7 +483,7 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
     fn get_rowcount_stat(&self) -> Option<Expr> {
         Some(Expr::from(ColumnName::new([
             "stats_parsed",
-            STATS_NUM_RECORDS,
+            NUM_RECORDS,
         ])))
     }
 
@@ -593,25 +593,25 @@ impl DataSkippingPredicateEvaluator for NullGuardedDataSkippingPredicateCreator<
         if self.is_partition_column(col) {
             return None;
         }
-        Some(Expr::from(ColumnName::new([STATS_MIN_VALUES]).join(col)))
+        Some(Expr::from(ColumnName::new([MIN_VALUES]).join(col)))
     }
 
     fn get_max_stat(&self, col: &ColumnName, _data_type: &DataType) -> Option<Expr> {
         if self.is_partition_column(col) {
             return None;
         }
-        Some(Expr::from(ColumnName::new([STATS_MAX_VALUES]).join(col)))
+        Some(Expr::from(ColumnName::new([MAX_VALUES]).join(col)))
     }
 
     fn get_nullcount_stat(&self, col: &ColumnName) -> Option<Expr> {
         if self.is_partition_column(col) {
             return None;
         }
-        Some(Expr::from(ColumnName::new([STATS_NULL_COUNT]).join(col)))
+        Some(Expr::from(ColumnName::new([NULL_COUNT]).join(col)))
     }
 
     fn get_rowcount_stat(&self) -> Option<Expr> {
-        Some(Expr::from(ColumnName::new([STATS_NUM_RECORDS])))
+        Some(Expr::from(ColumnName::new([NUM_RECORDS])))
     }
 
     /// Compares a column's max stat against a literal value, adjusting for timestamp

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -481,10 +481,7 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
 
     /// Retrieves the row count statistic.
     fn get_rowcount_stat(&self) -> Option<Expr> {
-        Some(Expr::from(ColumnName::new([
-            "stats_parsed",
-            NUM_RECORDS,
-        ])))
+        Some(Expr::from(ColumnName::new(["stats_parsed", NUM_RECORDS])))
     }
 
     /// For partition columns, wraps the comparison with `OR(NOT is_add, comparison)` so that

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -6,6 +6,7 @@ use std::time::Instant;
 use tracing::{debug, error};
 
 use crate::actions::visitors::SelectionVectorVisitor;
+use crate::actions::{STATS_MAX_VALUES, STATS_MIN_VALUES, STATS_NULL_COUNT, STATS_NUM_RECORDS};
 use crate::error::DeltaResult;
 use crate::expressions::{
     column_expr, column_name, joined_column_expr, BinaryPredicateOp, ColumnName,
@@ -430,7 +431,9 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
         if self.is_partition_column(col) {
             Some(joined_column_expr!("partitionValues_parsed", col))
         } else {
-            Some(Expr::from(column_name!("stats_parsed.minValues").join(col)))
+            Some(Expr::from(
+                ColumnName::new(["stats_parsed", STATS_MIN_VALUES]).join(col),
+            ))
         }
     }
 
@@ -440,7 +443,9 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
         if self.is_partition_column(col) {
             Some(joined_column_expr!("partitionValues_parsed", col))
         } else {
-            Some(Expr::from(column_name!("stats_parsed.maxValues").join(col)))
+            Some(Expr::from(
+                ColumnName::new(["stats_parsed", STATS_MAX_VALUES]).join(col),
+            ))
         }
     }
 
@@ -468,13 +473,18 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
         if self.is_partition_column(col) {
             None
         } else {
-            Some(Expr::from(column_name!("stats_parsed.nullCount").join(col)))
+            Some(Expr::from(
+                ColumnName::new(["stats_parsed", STATS_NULL_COUNT]).join(col),
+            ))
         }
     }
 
     /// Retrieves the row count statistic.
     fn get_rowcount_stat(&self) -> Option<Expr> {
-        Some(column_expr!("stats_parsed.numRecords"))
+        Some(Expr::from(ColumnName::new([
+            "stats_parsed",
+            STATS_NUM_RECORDS,
+        ])))
     }
 
     /// For partition columns, wraps the comparison with `OR(NOT is_add, comparison)` so that
@@ -583,25 +593,25 @@ impl DataSkippingPredicateEvaluator for NullGuardedDataSkippingPredicateCreator<
         if self.is_partition_column(col) {
             return None;
         }
-        Some(joined_column_expr!("minValues", col))
+        Some(Expr::from(ColumnName::new([STATS_MIN_VALUES]).join(col)))
     }
 
     fn get_max_stat(&self, col: &ColumnName, _data_type: &DataType) -> Option<Expr> {
         if self.is_partition_column(col) {
             return None;
         }
-        Some(joined_column_expr!("maxValues", col))
+        Some(Expr::from(ColumnName::new([STATS_MAX_VALUES]).join(col)))
     }
 
     fn get_nullcount_stat(&self, col: &ColumnName) -> Option<Expr> {
         if self.is_partition_column(col) {
             return None;
         }
-        Some(joined_column_expr!("nullCount", col))
+        Some(Expr::from(ColumnName::new([STATS_NULL_COUNT]).join(col)))
     }
 
     fn get_rowcount_stat(&self) -> Option<Expr> {
-        Some(column_expr!("numRecords"))
+        Some(Expr::from(ColumnName::new([STATS_NUM_RECORDS])))
     }
 
     /// Compares a column's max stat against a literal value, adjusting for timestamp

--- a/kernel/src/scan/data_skipping/stats_schema/mod.rs
+++ b/kernel/src/scan/data_skipping/stats_schema/mod.rs
@@ -9,7 +9,7 @@ use column_filter::StatsColumnFilter;
 pub(crate) use column_filter::StatsConfig;
 
 use crate::actions::{
-    STATS_MAX_VALUES, STATS_MIN_VALUES, STATS_NULL_COUNT, STATS_NUM_RECORDS, STATS_TIGHT_BOUNDS,
+    MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS, TIGHT_BOUNDS,
 };
 use crate::schema::{
     ArrayType, ColumnName, DataType, MapType, PrimitiveType, Schema, SchemaRef, StructField,
@@ -140,7 +140,7 @@ pub(crate) fn expected_stats_schema(
     requested_columns: Option<&[ColumnName]>,
 ) -> DeltaResult<Schema> {
     let mut fields = Vec::with_capacity(5);
-    fields.push(StructField::nullable(STATS_NUM_RECORDS, DataType::LONG));
+    fields.push(StructField::nullable(NUM_RECORDS, DataType::LONG));
 
     // generate the base stats schema:
     // - make all fields nullable
@@ -155,7 +155,7 @@ pub(crate) fn expected_stats_schema(
         let mut null_count_transform = NullCountStatsTransform;
         let null_count_schema = null_count_transform.transform_struct(&base_schema);
         fields.push(StructField::nullable(
-            STATS_NULL_COUNT,
+            NULL_COUNT,
             null_count_schema.into_owned(),
         ));
 
@@ -164,16 +164,16 @@ pub(crate) fn expected_stats_schema(
         if let Some(min_max_schema) = min_max_transform.transform_struct(&base_schema) {
             let min_max_schema = min_max_schema.into_owned();
             fields.push(StructField::nullable(
-                STATS_MIN_VALUES,
+                MIN_VALUES,
                 min_max_schema.clone(),
             ));
-            fields.push(StructField::nullable(STATS_MAX_VALUES, min_max_schema));
+            fields.push(StructField::nullable(MAX_VALUES, min_max_schema));
         }
     }
 
     // tightBounds indicates whether min/max statistics are accurate (true) or potentially
     // outdated due to deletion vectors (false)
-    fields.push(StructField::nullable(STATS_TIGHT_BOUNDS, DataType::BOOLEAN));
+    fields.push(StructField::nullable(TIGHT_BOUNDS, DataType::BOOLEAN));
 
     StructType::try_new(fields)
 }
@@ -211,10 +211,10 @@ pub(crate) fn build_stats_schema(referenced_schema: &StructType) -> Option<Schem
         .into_owned();
 
     let schema = StructType::new_unchecked([
-        StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
-        StructField::nullable(STATS_NULL_COUNT, nullcount_schema),
-        StructField::nullable(STATS_MIN_VALUES, stats_schema.clone()),
-        StructField::nullable(STATS_MAX_VALUES, stats_schema),
+        StructField::nullable(NUM_RECORDS, DataType::LONG),
+        StructField::nullable(NULL_COUNT, nullcount_schema),
+        StructField::nullable(MIN_VALUES, stats_schema.clone()),
+        StructField::nullable(MAX_VALUES, stats_schema),
     ]);
 
     // Strip field metadata. The stats types are derived from the table schema, but the metadata on
@@ -439,11 +439,11 @@ mod tests {
     /// Builds an expected stats schema from the given null count and min/max nested schemas.
     fn expected_stats(null_count: StructType, min_max: StructType) -> StructType {
         StructType::new_unchecked([
-            StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
-            StructField::nullable(STATS_NULL_COUNT, null_count),
-            StructField::nullable(STATS_MIN_VALUES, min_max.clone()),
-            StructField::nullable(STATS_MAX_VALUES, min_max),
-            StructField::nullable(STATS_TIGHT_BOUNDS, DataType::BOOLEAN),
+            StructField::nullable(NUM_RECORDS, DataType::LONG),
+            StructField::nullable(NULL_COUNT, null_count),
+            StructField::nullable(MIN_VALUES, min_max.clone()),
+            StructField::nullable(MAX_VALUES, min_max),
+            StructField::nullable(TIGHT_BOUNDS, DataType::BOOLEAN),
         ])
     }
 
@@ -643,11 +643,11 @@ mod tests {
             StructType::new_unchecked([StructField::nullable("id", DataType::LONG)]);
 
         let expected = StructType::new_unchecked([
-            StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
-            StructField::nullable(STATS_NULL_COUNT, expected_null_count),
-            StructField::nullable(STATS_MIN_VALUES, expected_min_max.clone()),
-            StructField::nullable(STATS_MAX_VALUES, expected_min_max),
-            StructField::nullable(STATS_TIGHT_BOUNDS, DataType::BOOLEAN),
+            StructField::nullable(NUM_RECORDS, DataType::LONG),
+            StructField::nullable(NULL_COUNT, expected_null_count),
+            StructField::nullable(MIN_VALUES, expected_min_max.clone()),
+            StructField::nullable(MAX_VALUES, expected_min_max),
+            StructField::nullable(TIGHT_BOUNDS, DataType::BOOLEAN),
         ]);
 
         assert_eq!(&expected, &stats_schema);
@@ -809,9 +809,9 @@ mod tests {
 
         // minValues/maxValues: no fields are eligible (boolean/binary/array excluded)
         let expected = StructType::new_unchecked([
-            StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
-            StructField::nullable(STATS_NULL_COUNT, expected_null_count),
-            StructField::nullable(STATS_TIGHT_BOUNDS, DataType::BOOLEAN),
+            StructField::nullable(NUM_RECORDS, DataType::LONG),
+            StructField::nullable(NULL_COUNT, expected_null_count),
+            StructField::nullable(TIGHT_BOUNDS, DataType::BOOLEAN),
         ]);
 
         assert_eq!(&expected, &stats_schema);
@@ -867,9 +867,9 @@ mod tests {
         // minValues/maxValues: all 3 complex types are excluded by MinMaxStatsTransform,
         // and col1/col2 are past the limit, so no min/max fields at all.
         let expected = StructType::new_unchecked([
-            StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
-            StructField::nullable(STATS_NULL_COUNT, expected_null_count),
-            StructField::nullable(STATS_TIGHT_BOUNDS, DataType::BOOLEAN),
+            StructField::nullable(NUM_RECORDS, DataType::LONG),
+            StructField::nullable(NULL_COUNT, expected_null_count),
+            StructField::nullable(TIGHT_BOUNDS, DataType::BOOLEAN),
         ]);
 
         assert_eq!(&expected, &stats_schema);
@@ -914,11 +914,11 @@ mod tests {
             StructType::new_unchecked([StructField::nullable("id", DataType::LONG)]);
 
         let expected = StructType::new_unchecked([
-            StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
-            StructField::nullable(STATS_NULL_COUNT, expected_null_count),
-            StructField::nullable(STATS_MIN_VALUES, expected_min_max.clone()),
-            StructField::nullable(STATS_MAX_VALUES, expected_min_max),
-            StructField::nullable(STATS_TIGHT_BOUNDS, DataType::BOOLEAN),
+            StructField::nullable(NUM_RECORDS, DataType::LONG),
+            StructField::nullable(NULL_COUNT, expected_null_count),
+            StructField::nullable(MIN_VALUES, expected_min_max.clone()),
+            StructField::nullable(MAX_VALUES, expected_min_max),
+            StructField::nullable(TIGHT_BOUNDS, DataType::BOOLEAN),
         ]);
 
         assert_eq!(&expected, &stats_schema);
@@ -1144,7 +1144,7 @@ mod tests {
         .unwrap();
 
         // Should include both columns
-        let min_values = with_none.field(STATS_MIN_VALUES).expect("should have minValues");
+        let min_values = with_none.field(MIN_VALUES).expect("should have minValues");
         if let DataType::Struct(inner) = min_values.data_type() {
             assert!(inner.field("id").is_some());
             assert!(inner.field("name").is_some());
@@ -1174,8 +1174,8 @@ mod tests {
 
         // No data columns pass both filters, so only numRecords + tightBounds
         let expected = StructType::new_unchecked([
-            StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
-            StructField::nullable(STATS_TIGHT_BOUNDS, DataType::BOOLEAN),
+            StructField::nullable(NUM_RECORDS, DataType::LONG),
+            StructField::nullable(TIGHT_BOUNDS, DataType::BOOLEAN),
         ]);
 
         assert_eq!(&expected, &stats_schema);

--- a/kernel/src/scan/data_skipping/stats_schema/mod.rs
+++ b/kernel/src/scan/data_skipping/stats_schema/mod.rs
@@ -8,15 +8,15 @@ use std::sync::Arc;
 use column_filter::StatsColumnFilter;
 pub(crate) use column_filter::StatsConfig;
 
+use crate::actions::{
+    STATS_MAX_VALUES, STATS_MIN_VALUES, STATS_NULL_COUNT, STATS_NUM_RECORDS, STATS_TIGHT_BOUNDS,
+};
 use crate::schema::{
     ArrayType, ColumnName, DataType, MapType, PrimitiveType, Schema, SchemaRef, StructField,
     StructType,
 };
 use crate::transforms::{transform_output_type, SchemaTransform};
 use crate::DeltaResult;
-
-/// Sub-field of an AddFile's `stats` struct: total number of rows in the file.
-pub(crate) const STATS_NUM_RECORDS: &str = "numRecords";
 
 /// Generates the expected schema for file statistics.
 ///
@@ -140,7 +140,7 @@ pub(crate) fn expected_stats_schema(
     requested_columns: Option<&[ColumnName]>,
 ) -> DeltaResult<Schema> {
     let mut fields = Vec::with_capacity(5);
-    fields.push(StructField::nullable("numRecords", DataType::LONG));
+    fields.push(StructField::nullable(STATS_NUM_RECORDS, DataType::LONG));
 
     // generate the base stats schema:
     // - make all fields nullable
@@ -155,7 +155,7 @@ pub(crate) fn expected_stats_schema(
         let mut null_count_transform = NullCountStatsTransform;
         let null_count_schema = null_count_transform.transform_struct(&base_schema);
         fields.push(StructField::nullable(
-            "nullCount",
+            STATS_NULL_COUNT,
             null_count_schema.into_owned(),
         ));
 
@@ -163,14 +163,17 @@ pub(crate) fn expected_stats_schema(
         let mut min_max_transform = MinMaxStatsTransform;
         if let Some(min_max_schema) = min_max_transform.transform_struct(&base_schema) {
             let min_max_schema = min_max_schema.into_owned();
-            fields.push(StructField::nullable("minValues", min_max_schema.clone()));
-            fields.push(StructField::nullable("maxValues", min_max_schema));
+            fields.push(StructField::nullable(
+                STATS_MIN_VALUES,
+                min_max_schema.clone(),
+            ));
+            fields.push(StructField::nullable(STATS_MAX_VALUES, min_max_schema));
         }
     }
 
     // tightBounds indicates whether min/max statistics are accurate (true) or potentially
     // outdated due to deletion vectors (false)
-    fields.push(StructField::nullable("tightBounds", DataType::BOOLEAN));
+    fields.push(StructField::nullable(STATS_TIGHT_BOUNDS, DataType::BOOLEAN));
 
     StructType::try_new(fields)
 }
@@ -208,10 +211,10 @@ pub(crate) fn build_stats_schema(referenced_schema: &StructType) -> Option<Schem
         .into_owned();
 
     let schema = StructType::new_unchecked([
-        StructField::nullable("numRecords", DataType::LONG),
-        StructField::nullable("nullCount", nullcount_schema),
-        StructField::nullable("minValues", stats_schema.clone()),
-        StructField::nullable("maxValues", stats_schema),
+        StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
+        StructField::nullable(STATS_NULL_COUNT, nullcount_schema),
+        StructField::nullable(STATS_MIN_VALUES, stats_schema.clone()),
+        StructField::nullable(STATS_MAX_VALUES, stats_schema),
     ]);
 
     // Strip field metadata. The stats types are derived from the table schema, but the metadata on

--- a/kernel/src/scan/data_skipping/stats_schema/mod.rs
+++ b/kernel/src/scan/data_skipping/stats_schema/mod.rs
@@ -8,9 +8,7 @@ use std::sync::Arc;
 use column_filter::StatsColumnFilter;
 pub(crate) use column_filter::StatsConfig;
 
-use crate::actions::{
-    MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS, TIGHT_BOUNDS,
-};
+use crate::actions::{MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS, TIGHT_BOUNDS};
 use crate::schema::{
     ArrayType, ColumnName, DataType, MapType, PrimitiveType, Schema, SchemaRef, StructField,
     StructType,
@@ -163,10 +161,7 @@ pub(crate) fn expected_stats_schema(
         let mut min_max_transform = MinMaxStatsTransform;
         if let Some(min_max_schema) = min_max_transform.transform_struct(&base_schema) {
             let min_max_schema = min_max_schema.into_owned();
-            fields.push(StructField::nullable(
-                MIN_VALUES,
-                min_max_schema.clone(),
-            ));
+            fields.push(StructField::nullable(MIN_VALUES, min_max_schema.clone()));
             fields.push(StructField::nullable(MAX_VALUES, min_max_schema));
         }
     }

--- a/kernel/src/scan/data_skipping/stats_schema/mod.rs
+++ b/kernel/src/scan/data_skipping/stats_schema/mod.rs
@@ -439,11 +439,11 @@ mod tests {
     /// Builds an expected stats schema from the given null count and min/max nested schemas.
     fn expected_stats(null_count: StructType, min_max: StructType) -> StructType {
         StructType::new_unchecked([
-            StructField::nullable("numRecords", DataType::LONG),
-            StructField::nullable("nullCount", null_count),
-            StructField::nullable("minValues", min_max.clone()),
-            StructField::nullable("maxValues", min_max),
-            StructField::nullable("tightBounds", DataType::BOOLEAN),
+            StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
+            StructField::nullable(STATS_NULL_COUNT, null_count),
+            StructField::nullable(STATS_MIN_VALUES, min_max.clone()),
+            StructField::nullable(STATS_MAX_VALUES, min_max),
+            StructField::nullable(STATS_TIGHT_BOUNDS, DataType::BOOLEAN),
         ])
     }
 
@@ -643,11 +643,11 @@ mod tests {
             StructType::new_unchecked([StructField::nullable("id", DataType::LONG)]);
 
         let expected = StructType::new_unchecked([
-            StructField::nullable("numRecords", DataType::LONG),
-            StructField::nullable("nullCount", expected_null_count),
-            StructField::nullable("minValues", expected_min_max.clone()),
-            StructField::nullable("maxValues", expected_min_max),
-            StructField::nullable("tightBounds", DataType::BOOLEAN),
+            StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
+            StructField::nullable(STATS_NULL_COUNT, expected_null_count),
+            StructField::nullable(STATS_MIN_VALUES, expected_min_max.clone()),
+            StructField::nullable(STATS_MAX_VALUES, expected_min_max),
+            StructField::nullable(STATS_TIGHT_BOUNDS, DataType::BOOLEAN),
         ]);
 
         assert_eq!(&expected, &stats_schema);
@@ -809,9 +809,9 @@ mod tests {
 
         // minValues/maxValues: no fields are eligible (boolean/binary/array excluded)
         let expected = StructType::new_unchecked([
-            StructField::nullable("numRecords", DataType::LONG),
-            StructField::nullable("nullCount", expected_null_count),
-            StructField::nullable("tightBounds", DataType::BOOLEAN),
+            StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
+            StructField::nullable(STATS_NULL_COUNT, expected_null_count),
+            StructField::nullable(STATS_TIGHT_BOUNDS, DataType::BOOLEAN),
         ]);
 
         assert_eq!(&expected, &stats_schema);
@@ -867,9 +867,9 @@ mod tests {
         // minValues/maxValues: all 3 complex types are excluded by MinMaxStatsTransform,
         // and col1/col2 are past the limit, so no min/max fields at all.
         let expected = StructType::new_unchecked([
-            StructField::nullable("numRecords", DataType::LONG),
-            StructField::nullable("nullCount", expected_null_count),
-            StructField::nullable("tightBounds", DataType::BOOLEAN),
+            StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
+            StructField::nullable(STATS_NULL_COUNT, expected_null_count),
+            StructField::nullable(STATS_TIGHT_BOUNDS, DataType::BOOLEAN),
         ]);
 
         assert_eq!(&expected, &stats_schema);
@@ -914,11 +914,11 @@ mod tests {
             StructType::new_unchecked([StructField::nullable("id", DataType::LONG)]);
 
         let expected = StructType::new_unchecked([
-            StructField::nullable("numRecords", DataType::LONG),
-            StructField::nullable("nullCount", expected_null_count),
-            StructField::nullable("minValues", expected_min_max.clone()),
-            StructField::nullable("maxValues", expected_min_max),
-            StructField::nullable("tightBounds", DataType::BOOLEAN),
+            StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
+            StructField::nullable(STATS_NULL_COUNT, expected_null_count),
+            StructField::nullable(STATS_MIN_VALUES, expected_min_max.clone()),
+            StructField::nullable(STATS_MAX_VALUES, expected_min_max),
+            StructField::nullable(STATS_TIGHT_BOUNDS, DataType::BOOLEAN),
         ]);
 
         assert_eq!(&expected, &stats_schema);
@@ -1144,7 +1144,7 @@ mod tests {
         .unwrap();
 
         // Should include both columns
-        let min_values = with_none.field("minValues").expect("should have minValues");
+        let min_values = with_none.field(STATS_MIN_VALUES).expect("should have minValues");
         if let DataType::Struct(inner) = min_values.data_type() {
             assert!(inner.field("id").is_some());
             assert!(inner.field("name").is_some());
@@ -1174,8 +1174,8 @@ mod tests {
 
         // No data columns pass both filters, so only numRecords + tightBounds
         let expected = StructType::new_unchecked([
-            StructField::nullable("numRecords", DataType::LONG),
-            StructField::nullable("tightBounds", DataType::BOOLEAN),
+            StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
+            StructField::nullable(STATS_TIGHT_BOUNDS, DataType::BOOLEAN),
         ]);
 
         assert_eq!(&expected, &stats_schema);

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -663,7 +663,7 @@ fn test_partition_column_rewrite() {
     assert!(
         pred_str
             .as_ref()
-            .is_some_and(|s| !s.contains(STATS_MIN_VALUES) && !s.contains(STATS_MAX_VALUES)),
+            .is_some_and(|s| !s.contains(MIN_VALUES) && !s.contains(MAX_VALUES)),
         "Should not contain minValues/maxValues for partition columns"
     );
 

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -663,7 +663,7 @@ fn test_partition_column_rewrite() {
     assert!(
         pred_str
             .as_ref()
-            .is_some_and(|s| !s.contains("minValues") && !s.contains("maxValues")),
+            .is_some_and(|s| !s.contains(STATS_MIN_VALUES) && !s.contains(STATS_MAX_VALUES)),
         "Should not contain minValues/maxValues for partition columns"
     );
 

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -401,7 +401,7 @@ pub(crate) mod tests {
     use url::Url;
 
     use super::*;
-    use crate::actions::{Metadata, Protocol, STATS_MAX_VALUES, STATS_MIN_VALUES};
+    use crate::actions::{Metadata, Protocol, MAX_VALUES, MIN_VALUES};
     use crate::expressions::{column_expr, column_name, Expression as Expr};
     use crate::schema::{ColumnMetadataKey, MetadataValue};
     use crate::table_features::{FeatureType, TableFeature};
@@ -963,7 +963,7 @@ pub(crate) mod tests {
             .expect("should have physical stats schema");
 
         let min_values = stats_schema
-            .field(STATS_MIN_VALUES)
+            .field(MIN_VALUES)
             .expect("should have minValues");
         if let DataType::Struct(inner) = min_values.data_type() {
             assert!(
@@ -1007,7 +1007,7 @@ pub(crate) mod tests {
 
         // Check that minValues/maxValues only contain 'value', not 'id'
         let min_values = stats_schema
-            .field(STATS_MIN_VALUES)
+            .field(MIN_VALUES)
             .expect("should have minValues");
         if let DataType::Struct(inner) = min_values.data_type() {
             assert!(
@@ -1154,7 +1154,7 @@ pub(crate) mod tests {
 
         let present = ["phys_a", "phys_b"];
         let absent = ["col_a", "col_b", "phys_c"];
-        for stats_field in [STATS_MIN_VALUES, STATS_MAX_VALUES] {
+        for stats_field in [MIN_VALUES, MAX_VALUES] {
             let DataType::Struct(inner) = stats_schema
                 .field(stats_field)
                 .unwrap_or_else(|| panic!("should have {stats_field}"))

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -401,7 +401,7 @@ pub(crate) mod tests {
     use url::Url;
 
     use super::*;
-    use crate::actions::{Metadata, Protocol};
+    use crate::actions::{Metadata, Protocol, STATS_MAX_VALUES, STATS_MIN_VALUES};
     use crate::expressions::{column_expr, column_name, Expression as Expr};
     use crate::schema::{ColumnMetadataKey, MetadataValue};
     use crate::table_features::{FeatureType, TableFeature};
@@ -963,7 +963,7 @@ pub(crate) mod tests {
             .expect("should have physical stats schema");
 
         let min_values = stats_schema
-            .field("minValues")
+            .field(STATS_MIN_VALUES)
             .expect("should have minValues");
         if let DataType::Struct(inner) = min_values.data_type() {
             assert!(
@@ -1007,7 +1007,7 @@ pub(crate) mod tests {
 
         // Check that minValues/maxValues only contain 'value', not 'id'
         let min_values = stats_schema
-            .field("minValues")
+            .field(STATS_MIN_VALUES)
             .expect("should have minValues");
         if let DataType::Struct(inner) = min_values.data_type() {
             assert!(
@@ -1154,7 +1154,7 @@ pub(crate) mod tests {
 
         let present = ["phys_a", "phys_b"];
         let absent = ["col_a", "col_b", "phys_c"];
-        for stats_field in ["minValues", "maxValues"] {
+        for stats_field in [STATS_MIN_VALUES, STATS_MAX_VALUES] {
             let DataType::Struct(inner) = stats_schema
                 .field(stats_field)
                 .unwrap_or_else(|| panic!("should have {stats_field}"))

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -5,9 +5,7 @@ use bytes::Bytes;
 use rstest::rstest;
 
 use super::*;
-use crate::actions::{
-    MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS,
-};
+use crate::actions::{MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS};
 use crate::arrow::array::{Array, BooleanArray, Int64Array, StringArray, StructArray};
 use crate::arrow::compute::filter_record_batch;
 use crate::arrow::datatypes::{DataType as ArrowDataType, Field, Fields, Schema as ArrowSchema};

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -5,6 +5,9 @@ use bytes::Bytes;
 use rstest::rstest;
 
 use super::*;
+use crate::actions::{
+    STATS_MAX_VALUES, STATS_MIN_VALUES, STATS_NULL_COUNT, STATS_NUM_RECORDS,
+};
 use crate::arrow::array::{Array, BooleanArray, Int64Array, StringArray, StructArray};
 use crate::arrow::compute::filter_record_batch;
 use crate::arrow::datatypes::{DataType as ArrowDataType, Field, Fields, Schema as ArrowSchema};
@@ -712,10 +715,10 @@ fn test_scan_metadata_with_stats_columns() {
 
         // Extract stats_parsed struct array
         let stats_parsed = get_column!(filtered_batch, STATS_PARSED_COL, StructArray);
-        let num_records = get_column!(stats_parsed, "numRecords", Int64Array);
-        let min_values = get_column!(stats_parsed, "minValues", StructArray);
-        let max_values = get_column!(stats_parsed, "maxValues", StructArray);
-        let null_count = get_column!(stats_parsed, "nullCount", StructArray);
+        let num_records = get_column!(stats_parsed, STATS_NUM_RECORDS, Int64Array);
+        let min_values = get_column!(stats_parsed, STATS_MIN_VALUES, StructArray);
+        let max_values = get_column!(stats_parsed, STATS_MAX_VALUES, StructArray);
+        let null_count = get_column!(stats_parsed, STATS_NULL_COUNT, StructArray);
 
         // Extract JSON stats column
         let stats_json = get_column!(filtered_batch, "stats", StringArray);
@@ -730,7 +733,7 @@ fn test_scan_metadata_with_stats_columns() {
                 serde_json::from_str(stats_json.value(i)).expect("stats JSON should be valid");
 
             // Validate numRecords
-            if let Some(json_num) = json_stats.get("numRecords").and_then(|v| v.as_i64()) {
+            if let Some(json_num) = json_stats.get(STATS_NUM_RECORDS).and_then(|v| v.as_i64()) {
                 assert_eq!(
                     json_num,
                     num_records.value(i),
@@ -739,14 +742,14 @@ fn test_scan_metadata_with_stats_columns() {
             }
 
             // Validate minValues, maxValues, nullCount
-            if let Some(obj) = json_stats.get("minValues").and_then(|v| v.as_object()) {
-                assert_stats_struct_matches_json(min_values, obj, i, "minValues");
+            if let Some(obj) = json_stats.get(STATS_MIN_VALUES).and_then(|v| v.as_object()) {
+                assert_stats_struct_matches_json(min_values, obj, i, STATS_MIN_VALUES);
             }
-            if let Some(obj) = json_stats.get("maxValues").and_then(|v| v.as_object()) {
-                assert_stats_struct_matches_json(max_values, obj, i, "maxValues");
+            if let Some(obj) = json_stats.get(STATS_MAX_VALUES).and_then(|v| v.as_object()) {
+                assert_stats_struct_matches_json(max_values, obj, i, STATS_MAX_VALUES);
             }
-            if let Some(obj) = json_stats.get("nullCount").and_then(|v| v.as_object()) {
-                assert_stats_struct_matches_json(null_count, obj, i, "nullCount");
+            if let Some(obj) = json_stats.get(STATS_NULL_COUNT).and_then(|v| v.as_object()) {
+                assert_stats_struct_matches_json(null_count, obj, i, STATS_NULL_COUNT);
             }
 
             total_num_records += num_records.value(i);
@@ -821,7 +824,7 @@ fn test_scan_metadata_stats_columns_with_predicate() {
 
         // Verify stats_parsed has data
         let stats_parsed = get_column!(filtered_batch, STATS_PARSED_COL, StructArray);
-        let num_records = get_column!(stats_parsed, "numRecords", Int64Array);
+        let num_records = get_column!(stats_parsed, STATS_NUM_RECORDS, Int64Array);
         for i in 0..filtered_batch.num_rows() {
             if !stats_parsed.is_null(i) {
                 assert!(num_records.value(i) > 0, "numRecords should be positive");
@@ -942,10 +945,10 @@ impl CheckpointParquetBuilder {
     fn new() -> Self {
         let id_fields = Fields::from(vec![Field::new("id", ArrowDataType::Int64, true)]);
         let stats_fields = Fields::from(vec![
-            Field::new("maxValues", ArrowDataType::Struct(id_fields.clone()), true),
-            Field::new("minValues", ArrowDataType::Struct(id_fields.clone()), true),
-            Field::new("nullCount", ArrowDataType::Struct(id_fields.clone()), true),
-            Field::new("numRecords", ArrowDataType::Int64, true),
+            Field::new(STATS_MAX_VALUES, ArrowDataType::Struct(id_fields.clone()), true),
+            Field::new(STATS_MIN_VALUES, ArrowDataType::Struct(id_fields.clone()), true),
+            Field::new(STATS_NULL_COUNT, ArrowDataType::Struct(id_fields.clone()), true),
+            Field::new(STATS_NUM_RECORDS, ArrowDataType::Int64, true),
         ]);
         let add_fields = Fields::from(vec![Field::new(
             "stats_parsed",
@@ -986,7 +989,7 @@ impl CheckpointParquetBuilder {
         let stats_parsed = StructArray::from(vec![
             (
                 Arc::new(Field::new(
-                    "maxValues",
+                    STATS_MAX_VALUES,
                     ArrowDataType::Struct(self.id_fields.clone()),
                     true,
                 )),
@@ -994,7 +997,7 @@ impl CheckpointParquetBuilder {
             ),
             (
                 Arc::new(Field::new(
-                    "minValues",
+                    STATS_MIN_VALUES,
                     ArrowDataType::Struct(self.id_fields.clone()),
                     true,
                 )),
@@ -1002,14 +1005,14 @@ impl CheckpointParquetBuilder {
             ),
             (
                 Arc::new(Field::new(
-                    "nullCount",
+                    STATS_NULL_COUNT,
                     ArrowDataType::Struct(self.id_fields.clone()),
                     true,
                 )),
                 Arc::new(make_id_struct(null_counts)) as Arc<dyn Array>,
             ),
             (
-                Arc::new(Field::new("numRecords", ArrowDataType::Int64, true)),
+                Arc::new(Field::new(STATS_NUM_RECORDS, ArrowDataType::Int64, true)),
                 Arc::new(Int64Array::from(num_records.to_vec())) as Arc<dyn Array>,
             ),
         ]);
@@ -1281,9 +1284,9 @@ fn test_scan_metadata_with_specific_stats_columns() {
             filter_record_batch(&batch, &BooleanArray::from(selection_vector)).unwrap();
 
         let stats_parsed = get_column!(filtered_batch, "stats_parsed", StructArray);
-        let min_values = get_column!(stats_parsed, "minValues", StructArray);
-        let max_values = get_column!(stats_parsed, "maxValues", StructArray);
-        let null_count = get_column!(stats_parsed, "nullCount", StructArray);
+        let min_values = get_column!(stats_parsed, STATS_MIN_VALUES, StructArray);
+        let max_values = get_column!(stats_parsed, STATS_MAX_VALUES, StructArray);
+        let null_count = get_column!(stats_parsed, STATS_NULL_COUNT, StructArray);
 
         // Check minValues/maxValues/nullCount only have "id"
         assert_eq!(
@@ -1339,9 +1342,9 @@ fn test_scan_metadata_with_multiple_stats_columns() {
             filter_record_batch(&batch, &BooleanArray::from(selection_vector)).unwrap();
 
         let stats_parsed = get_column!(filtered_batch, "stats_parsed", StructArray);
-        let min_values = get_column!(stats_parsed, "minValues", StructArray);
-        let max_values = get_column!(stats_parsed, "maxValues", StructArray);
-        let null_count = get_column!(stats_parsed, "nullCount", StructArray);
+        let min_values = get_column!(stats_parsed, STATS_MIN_VALUES, StructArray);
+        let max_values = get_column!(stats_parsed, STATS_MAX_VALUES, StructArray);
+        let null_count = get_column!(stats_parsed, STATS_NULL_COUNT, StructArray);
 
         // Check minValues/maxValues/nullCount have "id" and "name"
         let expected = vec!["id", "name"];
@@ -1412,7 +1415,7 @@ fn test_scan_metadata_with_nonexistent_stats_columns() {
         // Should have numRecords but no minValues/maxValues/nullCount
         // (or they exist but are empty structs)
         assert!(
-            stats_parsed.column_by_name("numRecords").is_some(),
+            stats_parsed.column_by_name(STATS_NUM_RECORDS).is_some(),
             "Should still have numRecords"
         );
     }

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -6,7 +6,7 @@ use rstest::rstest;
 
 use super::*;
 use crate::actions::{
-    STATS_MAX_VALUES, STATS_MIN_VALUES, STATS_NULL_COUNT, STATS_NUM_RECORDS,
+    MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS,
 };
 use crate::arrow::array::{Array, BooleanArray, Int64Array, StringArray, StructArray};
 use crate::arrow::compute::filter_record_batch;
@@ -715,10 +715,10 @@ fn test_scan_metadata_with_stats_columns() {
 
         // Extract stats_parsed struct array
         let stats_parsed = get_column!(filtered_batch, STATS_PARSED_COL, StructArray);
-        let num_records = get_column!(stats_parsed, STATS_NUM_RECORDS, Int64Array);
-        let min_values = get_column!(stats_parsed, STATS_MIN_VALUES, StructArray);
-        let max_values = get_column!(stats_parsed, STATS_MAX_VALUES, StructArray);
-        let null_count = get_column!(stats_parsed, STATS_NULL_COUNT, StructArray);
+        let num_records = get_column!(stats_parsed, NUM_RECORDS, Int64Array);
+        let min_values = get_column!(stats_parsed, MIN_VALUES, StructArray);
+        let max_values = get_column!(stats_parsed, MAX_VALUES, StructArray);
+        let null_count = get_column!(stats_parsed, NULL_COUNT, StructArray);
 
         // Extract JSON stats column
         let stats_json = get_column!(filtered_batch, "stats", StringArray);
@@ -733,7 +733,7 @@ fn test_scan_metadata_with_stats_columns() {
                 serde_json::from_str(stats_json.value(i)).expect("stats JSON should be valid");
 
             // Validate numRecords
-            if let Some(json_num) = json_stats.get(STATS_NUM_RECORDS).and_then(|v| v.as_i64()) {
+            if let Some(json_num) = json_stats.get(NUM_RECORDS).and_then(|v| v.as_i64()) {
                 assert_eq!(
                     json_num,
                     num_records.value(i),
@@ -742,14 +742,14 @@ fn test_scan_metadata_with_stats_columns() {
             }
 
             // Validate minValues, maxValues, nullCount
-            if let Some(obj) = json_stats.get(STATS_MIN_VALUES).and_then(|v| v.as_object()) {
-                assert_stats_struct_matches_json(min_values, obj, i, STATS_MIN_VALUES);
+            if let Some(obj) = json_stats.get(MIN_VALUES).and_then(|v| v.as_object()) {
+                assert_stats_struct_matches_json(min_values, obj, i, MIN_VALUES);
             }
-            if let Some(obj) = json_stats.get(STATS_MAX_VALUES).and_then(|v| v.as_object()) {
-                assert_stats_struct_matches_json(max_values, obj, i, STATS_MAX_VALUES);
+            if let Some(obj) = json_stats.get(MAX_VALUES).and_then(|v| v.as_object()) {
+                assert_stats_struct_matches_json(max_values, obj, i, MAX_VALUES);
             }
-            if let Some(obj) = json_stats.get(STATS_NULL_COUNT).and_then(|v| v.as_object()) {
-                assert_stats_struct_matches_json(null_count, obj, i, STATS_NULL_COUNT);
+            if let Some(obj) = json_stats.get(NULL_COUNT).and_then(|v| v.as_object()) {
+                assert_stats_struct_matches_json(null_count, obj, i, NULL_COUNT);
             }
 
             total_num_records += num_records.value(i);
@@ -824,7 +824,7 @@ fn test_scan_metadata_stats_columns_with_predicate() {
 
         // Verify stats_parsed has data
         let stats_parsed = get_column!(filtered_batch, STATS_PARSED_COL, StructArray);
-        let num_records = get_column!(stats_parsed, STATS_NUM_RECORDS, Int64Array);
+        let num_records = get_column!(stats_parsed, NUM_RECORDS, Int64Array);
         for i in 0..filtered_batch.num_rows() {
             if !stats_parsed.is_null(i) {
                 assert!(num_records.value(i) > 0, "numRecords should be positive");
@@ -945,10 +945,10 @@ impl CheckpointParquetBuilder {
     fn new() -> Self {
         let id_fields = Fields::from(vec![Field::new("id", ArrowDataType::Int64, true)]);
         let stats_fields = Fields::from(vec![
-            Field::new(STATS_MAX_VALUES, ArrowDataType::Struct(id_fields.clone()), true),
-            Field::new(STATS_MIN_VALUES, ArrowDataType::Struct(id_fields.clone()), true),
-            Field::new(STATS_NULL_COUNT, ArrowDataType::Struct(id_fields.clone()), true),
-            Field::new(STATS_NUM_RECORDS, ArrowDataType::Int64, true),
+            Field::new(MAX_VALUES, ArrowDataType::Struct(id_fields.clone()), true),
+            Field::new(MIN_VALUES, ArrowDataType::Struct(id_fields.clone()), true),
+            Field::new(NULL_COUNT, ArrowDataType::Struct(id_fields.clone()), true),
+            Field::new(NUM_RECORDS, ArrowDataType::Int64, true),
         ]);
         let add_fields = Fields::from(vec![Field::new(
             "stats_parsed",
@@ -989,7 +989,7 @@ impl CheckpointParquetBuilder {
         let stats_parsed = StructArray::from(vec![
             (
                 Arc::new(Field::new(
-                    STATS_MAX_VALUES,
+                    MAX_VALUES,
                     ArrowDataType::Struct(self.id_fields.clone()),
                     true,
                 )),
@@ -997,7 +997,7 @@ impl CheckpointParquetBuilder {
             ),
             (
                 Arc::new(Field::new(
-                    STATS_MIN_VALUES,
+                    MIN_VALUES,
                     ArrowDataType::Struct(self.id_fields.clone()),
                     true,
                 )),
@@ -1005,14 +1005,14 @@ impl CheckpointParquetBuilder {
             ),
             (
                 Arc::new(Field::new(
-                    STATS_NULL_COUNT,
+                    NULL_COUNT,
                     ArrowDataType::Struct(self.id_fields.clone()),
                     true,
                 )),
                 Arc::new(make_id_struct(null_counts)) as Arc<dyn Array>,
             ),
             (
-                Arc::new(Field::new(STATS_NUM_RECORDS, ArrowDataType::Int64, true)),
+                Arc::new(Field::new(NUM_RECORDS, ArrowDataType::Int64, true)),
                 Arc::new(Int64Array::from(num_records.to_vec())) as Arc<dyn Array>,
             ),
         ]);
@@ -1284,9 +1284,9 @@ fn test_scan_metadata_with_specific_stats_columns() {
             filter_record_batch(&batch, &BooleanArray::from(selection_vector)).unwrap();
 
         let stats_parsed = get_column!(filtered_batch, "stats_parsed", StructArray);
-        let min_values = get_column!(stats_parsed, STATS_MIN_VALUES, StructArray);
-        let max_values = get_column!(stats_parsed, STATS_MAX_VALUES, StructArray);
-        let null_count = get_column!(stats_parsed, STATS_NULL_COUNT, StructArray);
+        let min_values = get_column!(stats_parsed, MIN_VALUES, StructArray);
+        let max_values = get_column!(stats_parsed, MAX_VALUES, StructArray);
+        let null_count = get_column!(stats_parsed, NULL_COUNT, StructArray);
 
         // Check minValues/maxValues/nullCount only have "id"
         assert_eq!(
@@ -1342,9 +1342,9 @@ fn test_scan_metadata_with_multiple_stats_columns() {
             filter_record_batch(&batch, &BooleanArray::from(selection_vector)).unwrap();
 
         let stats_parsed = get_column!(filtered_batch, "stats_parsed", StructArray);
-        let min_values = get_column!(stats_parsed, STATS_MIN_VALUES, StructArray);
-        let max_values = get_column!(stats_parsed, STATS_MAX_VALUES, StructArray);
-        let null_count = get_column!(stats_parsed, STATS_NULL_COUNT, StructArray);
+        let min_values = get_column!(stats_parsed, MIN_VALUES, StructArray);
+        let max_values = get_column!(stats_parsed, MAX_VALUES, StructArray);
+        let null_count = get_column!(stats_parsed, NULL_COUNT, StructArray);
 
         // Check minValues/maxValues/nullCount have "id" and "name"
         let expected = vec!["id", "name"];
@@ -1415,7 +1415,7 @@ fn test_scan_metadata_with_nonexistent_stats_columns() {
         // Should have numRecords but no minValues/maxValues/nullCount
         // (or they exist but are empty structs)
         assert!(
-            stats_parsed.column_by_name(STATS_NUM_RECORDS).is_some(),
+            stats_parsed.column_by_name(NUM_RECORDS).is_some(),
             "Should still have numRecords"
         );
     }

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -895,7 +895,7 @@ mod test {
     use url::Url;
 
     use super::{InCommitTimestampEnablement, TableConfiguration};
-    use crate::actions::{Metadata, Protocol};
+    use crate::actions::{Metadata, Protocol, STATS_MIN_VALUES};
     use crate::schema::{ColumnName, DataType, SchemaRef, StructField, StructType};
     use crate::table_features::{
         ColumnMappingMode, FeatureType, Operation, TableFeature, TABLE_FEATURES_MIN_READER_VERSION,
@@ -1864,7 +1864,7 @@ mod test {
         // Verify field names are logical names
         let min_values = stats_schemas
             .physical
-            .field("minValues")
+            .field(STATS_MIN_VALUES)
             .unwrap()
             .data_type();
         if let DataType::Struct(inner) = min_values {
@@ -1888,7 +1888,7 @@ mod test {
         // Verify physical schema has physical names
         let physical_min_values = stats_schemas
             .physical
-            .field("minValues")
+            .field(STATS_MIN_VALUES)
             .unwrap()
             .data_type();
         if let DataType::Struct(inner) = physical_min_values {
@@ -1924,7 +1924,7 @@ mod test {
         // Verify physical schema has physical names
         let physical_min_values = stats_schemas
             .physical
-            .field("minValues")
+            .field(STATS_MIN_VALUES)
             .unwrap()
             .data_type();
         let DataType::Struct(inner) = physical_min_values else {
@@ -2020,7 +2020,7 @@ mod test {
 
         let DataType::Struct(inner) = stats_schemas
             .physical
-            .field("minValues")
+            .field(STATS_MIN_VALUES)
             .unwrap()
             .data_type()
         else {

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -895,7 +895,7 @@ mod test {
     use url::Url;
 
     use super::{InCommitTimestampEnablement, TableConfiguration};
-    use crate::actions::{Metadata, Protocol, STATS_MIN_VALUES};
+    use crate::actions::{Metadata, Protocol, MIN_VALUES};
     use crate::schema::{ColumnName, DataType, SchemaRef, StructField, StructType};
     use crate::table_features::{
         ColumnMappingMode, FeatureType, Operation, TableFeature, TABLE_FEATURES_MIN_READER_VERSION,
@@ -1864,7 +1864,7 @@ mod test {
         // Verify field names are logical names
         let min_values = stats_schemas
             .physical
-            .field(STATS_MIN_VALUES)
+            .field(MIN_VALUES)
             .unwrap()
             .data_type();
         if let DataType::Struct(inner) = min_values {
@@ -1888,7 +1888,7 @@ mod test {
         // Verify physical schema has physical names
         let physical_min_values = stats_schemas
             .physical
-            .field(STATS_MIN_VALUES)
+            .field(MIN_VALUES)
             .unwrap()
             .data_type();
         if let DataType::Struct(inner) = physical_min_values {
@@ -1924,7 +1924,7 @@ mod test {
         // Verify physical schema has physical names
         let physical_min_values = stats_schemas
             .physical
-            .field(STATS_MIN_VALUES)
+            .field(MIN_VALUES)
             .unwrap()
             .data_type();
         let DataType::Struct(inner) = physical_min_values else {
@@ -2020,7 +2020,7 @@ mod test {
 
         let DataType::Struct(inner) = stats_schemas
             .physical
-            .field(STATS_MIN_VALUES)
+            .field(MIN_VALUES)
             .unwrap()
             .data_type()
         else {

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -10,7 +10,7 @@ use tracing::{info, instrument};
 use crate::actions::{
     as_log_add_schema, get_commit_schema, get_log_remove_schema, get_log_txn_schema, CommitInfo,
     DomainMetadata, Metadata, Protocol, SetTransaction, METADATA_NAME, PROTOCOL_NAME,
-    STATS_MAX_VALUES, STATS_MIN_VALUES, STATS_NULL_COUNT, STATS_NUM_RECORDS, STATS_TIGHT_BOUNDS,
+    MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS, TIGHT_BOUNDS,
 };
 use crate::committer::{
     CommitMetadata, CommitProtocolMetadata, CommitResponse, CommitType, Committer,
@@ -113,14 +113,14 @@ pub(crate) static BASE_ADD_FILES_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| 
     let stats = StructField::nullable(
         "stats",
         DataType::struct_type_unchecked(vec![
-            StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
+            StructField::nullable(NUM_RECORDS, DataType::LONG),
             // nullCount, minValues, maxValues are dynamic based on data schema.
             // Empty struct placeholders indicate these fields exist but their inner
             // structure depends on the table schema and stats column configuration.
-            StructField::nullable(STATS_NULL_COUNT, DataType::struct_type_unchecked(vec![])),
-            StructField::nullable(STATS_MIN_VALUES, DataType::struct_type_unchecked(vec![])),
-            StructField::nullable(STATS_MAX_VALUES, DataType::struct_type_unchecked(vec![])),
-            StructField::nullable(STATS_TIGHT_BOUNDS, DataType::BOOLEAN),
+            StructField::nullable(NULL_COUNT, DataType::struct_type_unchecked(vec![])),
+            StructField::nullable(MIN_VALUES, DataType::struct_type_unchecked(vec![])),
+            StructField::nullable(MAX_VALUES, DataType::struct_type_unchecked(vec![])),
+            StructField::nullable(TIGHT_BOUNDS, DataType::BOOLEAN),
         ]),
     );
 
@@ -1740,11 +1740,11 @@ mod tests {
             StructField::nullable(
                 "stats",
                 DataType::struct_type_unchecked(vec![
-                    StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
-                    StructField::nullable(STATS_NULL_COUNT, DataType::struct_type_unchecked(vec![])),
-                    StructField::nullable(STATS_MIN_VALUES, DataType::struct_type_unchecked(vec![])),
-                    StructField::nullable(STATS_MAX_VALUES, DataType::struct_type_unchecked(vec![])),
-                    StructField::nullable(STATS_TIGHT_BOUNDS, DataType::BOOLEAN),
+                    StructField::nullable(NUM_RECORDS, DataType::LONG),
+                    StructField::nullable(NULL_COUNT, DataType::struct_type_unchecked(vec![])),
+                    StructField::nullable(MIN_VALUES, DataType::struct_type_unchecked(vec![])),
+                    StructField::nullable(MAX_VALUES, DataType::struct_type_unchecked(vec![])),
+                    StructField::nullable(TIGHT_BOUNDS, DataType::BOOLEAN),
                 ]),
             ),
         ]);
@@ -2513,16 +2513,16 @@ mod tests {
         let value_fields = vec![StructField::nullable("value", DataType::LONG)];
         let value_struct_type = DataType::struct_type_unchecked(value_fields.clone());
         let stats_type = DataType::struct_type_unchecked(vec![
-            StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
-            StructField::nullable(STATS_NULL_COUNT, value_struct_type.clone()),
-            StructField::nullable(STATS_MIN_VALUES, value_struct_type.clone()),
-            StructField::nullable(STATS_MAX_VALUES, value_struct_type.clone()),
+            StructField::nullable(NUM_RECORDS, DataType::LONG),
+            StructField::nullable(NULL_COUNT, value_struct_type.clone()),
+            StructField::nullable(MIN_VALUES, value_struct_type.clone()),
+            StructField::nullable(MAX_VALUES, value_struct_type.clone()),
         ]);
         let stats_fields = vec![
-            StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
-            StructField::nullable(STATS_NULL_COUNT, value_struct_type.clone()),
-            StructField::nullable(STATS_MIN_VALUES, value_struct_type.clone()),
-            StructField::nullable(STATS_MAX_VALUES, value_struct_type),
+            StructField::nullable(NUM_RECORDS, DataType::LONG),
+            StructField::nullable(NULL_COUNT, value_struct_type.clone()),
+            StructField::nullable(MIN_VALUES, value_struct_type.clone()),
+            StructField::nullable(MAX_VALUES, value_struct_type),
         ];
         let schema = Arc::new(StructType::new_unchecked(vec![
             StructField::not_null("path", DataType::STRING),

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -9,8 +9,8 @@ use tracing::{info, instrument};
 
 use crate::actions::{
     as_log_add_schema, get_commit_schema, get_log_remove_schema, get_log_txn_schema, CommitInfo,
-    DomainMetadata, Metadata, Protocol, SetTransaction, METADATA_NAME, PROTOCOL_NAME,
-    MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS, TIGHT_BOUNDS,
+    DomainMetadata, Metadata, Protocol, SetTransaction, MAX_VALUES, METADATA_NAME, MIN_VALUES,
+    NULL_COUNT, NUM_RECORDS, PROTOCOL_NAME, TIGHT_BOUNDS,
 };
 use crate::committer::{
     CommitMetadata, CommitProtocolMetadata, CommitResponse, CommitType, Committer,

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -1740,11 +1740,11 @@ mod tests {
             StructField::nullable(
                 "stats",
                 DataType::struct_type_unchecked(vec![
-                    StructField::nullable("numRecords", DataType::LONG),
-                    StructField::nullable("nullCount", DataType::struct_type_unchecked(vec![])),
-                    StructField::nullable("minValues", DataType::struct_type_unchecked(vec![])),
-                    StructField::nullable("maxValues", DataType::struct_type_unchecked(vec![])),
-                    StructField::nullable("tightBounds", DataType::BOOLEAN),
+                    StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
+                    StructField::nullable(STATS_NULL_COUNT, DataType::struct_type_unchecked(vec![])),
+                    StructField::nullable(STATS_MIN_VALUES, DataType::struct_type_unchecked(vec![])),
+                    StructField::nullable(STATS_MAX_VALUES, DataType::struct_type_unchecked(vec![])),
+                    StructField::nullable(STATS_TIGHT_BOUNDS, DataType::BOOLEAN),
                 ]),
             ),
         ]);
@@ -2513,16 +2513,16 @@ mod tests {
         let value_fields = vec![StructField::nullable("value", DataType::LONG)];
         let value_struct_type = DataType::struct_type_unchecked(value_fields.clone());
         let stats_type = DataType::struct_type_unchecked(vec![
-            StructField::nullable("numRecords", DataType::LONG),
-            StructField::nullable("nullCount", value_struct_type.clone()),
-            StructField::nullable("minValues", value_struct_type.clone()),
-            StructField::nullable("maxValues", value_struct_type.clone()),
+            StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
+            StructField::nullable(STATS_NULL_COUNT, value_struct_type.clone()),
+            StructField::nullable(STATS_MIN_VALUES, value_struct_type.clone()),
+            StructField::nullable(STATS_MAX_VALUES, value_struct_type.clone()),
         ]);
         let stats_fields = vec![
-            StructField::nullable("numRecords", DataType::LONG),
-            StructField::nullable("nullCount", value_struct_type.clone()),
-            StructField::nullable("minValues", value_struct_type.clone()),
-            StructField::nullable("maxValues", value_struct_type),
+            StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
+            StructField::nullable(STATS_NULL_COUNT, value_struct_type.clone()),
+            StructField::nullable(STATS_MIN_VALUES, value_struct_type.clone()),
+            StructField::nullable(STATS_MAX_VALUES, value_struct_type),
         ];
         let schema = Arc::new(StructType::new_unchecked(vec![
             StructField::not_null("path", DataType::STRING),

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -10,6 +10,7 @@ use tracing::{info, instrument};
 use crate::actions::{
     as_log_add_schema, get_commit_schema, get_log_remove_schema, get_log_txn_schema, CommitInfo,
     DomainMetadata, Metadata, Protocol, SetTransaction, METADATA_NAME, PROTOCOL_NAME,
+    STATS_MAX_VALUES, STATS_MIN_VALUES, STATS_NULL_COUNT, STATS_NUM_RECORDS, STATS_TIGHT_BOUNDS,
 };
 use crate::committer::{
     CommitMetadata, CommitProtocolMetadata, CommitResponse, CommitType, Committer,
@@ -112,14 +113,14 @@ pub(crate) static BASE_ADD_FILES_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| 
     let stats = StructField::nullable(
         "stats",
         DataType::struct_type_unchecked(vec![
-            StructField::nullable("numRecords", DataType::LONG),
+            StructField::nullable(STATS_NUM_RECORDS, DataType::LONG),
             // nullCount, minValues, maxValues are dynamic based on data schema.
             // Empty struct placeholders indicate these fields exist but their inner
             // structure depends on the table schema and stats column configuration.
-            StructField::nullable("nullCount", DataType::struct_type_unchecked(vec![])),
-            StructField::nullable("minValues", DataType::struct_type_unchecked(vec![])),
-            StructField::nullable("maxValues", DataType::struct_type_unchecked(vec![])),
-            StructField::nullable("tightBounds", DataType::BOOLEAN),
+            StructField::nullable(STATS_NULL_COUNT, DataType::struct_type_unchecked(vec![])),
+            StructField::nullable(STATS_MIN_VALUES, DataType::struct_type_unchecked(vec![])),
+            StructField::nullable(STATS_MAX_VALUES, DataType::struct_type_unchecked(vec![])),
+            StructField::nullable(STATS_TIGHT_BOUNDS, DataType::BOOLEAN),
         ]),
     );
 

--- a/kernel/src/transaction/stats_verifier.rs
+++ b/kernel/src/transaction/stats_verifier.rs
@@ -7,7 +7,7 @@
 
 use std::sync::LazyLock;
 
-use crate::actions::{STATS_MAX_VALUES, STATS_MIN_VALUES, STATS_NULL_COUNT, STATS_NUM_RECORDS};
+use crate::actions::{MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS};
 use crate::engine_data::{GetData, RowVisitor, TypedGetData as _};
 use crate::error::Error;
 use crate::expressions::{column_name, ColumnName};
@@ -56,10 +56,10 @@ impl StatsColumnVerifier {
     ) -> DeltaResult<()> {
         let column_names = vec![
             ColumnName::new(["path"]),
-            ColumnName::new(["stats", STATS_NUM_RECORDS]),
-            build_stat_path(column, STATS_NULL_COUNT),
-            build_stat_path(column, STATS_MIN_VALUES),
-            build_stat_path(column, STATS_MAX_VALUES),
+            ColumnName::new(["stats", NUM_RECORDS]),
+            build_stat_path(column, NULL_COUNT),
+            build_stat_path(column, MIN_VALUES),
+            build_stat_path(column, MAX_VALUES),
         ];
         let types = column_types_for(data_type)?;
 
@@ -251,8 +251,8 @@ impl RowVisitor for ColumnStatsValidator<'_> {
 
         for row_idx in 0..row_count {
             let path: String = getters[0].get(row_idx, "path")?;
-            let num_records = getters[1].get_long(row_idx, STATS_NUM_RECORDS)?;
-            let null_count = getters[2].get_long(row_idx, STATS_NULL_COUNT)?;
+            let num_records = getters[1].get_long(row_idx, NUM_RECORDS)?;
+            let null_count = getters[2].get_long(row_idx, NULL_COUNT)?;
 
             // When all rows are null (or the file is empty), minValues/maxValues are
             // expected to be null since there are no non-null values to aggregate.
@@ -280,7 +280,7 @@ pub(crate) fn verify_num_records_present(
 ) -> DeltaResult<()> {
     let column_names = vec![
         ColumnName::new(["path"]),
-        ColumnName::new(["stats", STATS_NUM_RECORDS]),
+        ColumnName::new(["stats", NUM_RECORDS]),
     ];
     let mut first_missing: Option<String> = None;
     for batch in add_files {
@@ -321,7 +321,7 @@ impl RowVisitor for NumRecordsValidator<'_> {
             ))
         );
         for row_idx in 0..row_count {
-            if getters[1].get_long(row_idx, STATS_NUM_RECORDS)?.is_none() {
+            if getters[1].get_long(row_idx, NUM_RECORDS)?.is_none() {
                 *self.first_missing = Some(getters[0].get(row_idx, "path")?);
                 return Ok(());
             }
@@ -399,10 +399,10 @@ mod tests {
         };
 
         let stats_fields = Fields::from(vec![
-            ArrowField::new(STATS_NUM_RECORDS, ArrowDataType::Int64, true),
-            inner_struct_type(STATS_NULL_COUNT),
-            inner_struct_type(STATS_MIN_VALUES),
-            inner_struct_type(STATS_MAX_VALUES),
+            ArrowField::new(NUM_RECORDS, ArrowDataType::Int64, true),
+            inner_struct_type(NULL_COUNT),
+            inner_struct_type(MIN_VALUES),
+            inner_struct_type(MAX_VALUES),
         ]);
         let stats_struct = StructArray::new(
             stats_fields.clone(),
@@ -454,9 +454,9 @@ mod tests {
     #[test]
     fn test_verify_missing_stat_category() {
         let cases = [
-            (STATS_NULL_COUNT, vec![None], vec![Some(1)], vec![Some(100)]),
-            (STATS_MIN_VALUES, vec![Some(0)], vec![None], vec![Some(100)]),
-            (STATS_MAX_VALUES, vec![Some(0)], vec![Some(1)], vec![None]),
+            (NULL_COUNT, vec![None], vec![Some(1)], vec![Some(100)]),
+            (MIN_VALUES, vec![Some(0)], vec![None], vec![Some(100)]),
+            (MAX_VALUES, vec![Some(0)], vec![Some(1)], vec![None]),
         ];
         for (category, null_counts, min_values, max_values) in cases {
             let batch = create_add_file_batch(
@@ -548,7 +548,7 @@ mod tests {
         let result = verifier.verify(&[batch]);
         assert!(matches!(result, Err(Error::StatsValidation(_))));
         let err = result.unwrap_err().to_string();
-        assert!(err.contains(STATS_MIN_VALUES));
+        assert!(err.contains(MIN_VALUES));
     }
 
     /// Creates test data with two columns (col_a, col_b) in stats, both LONG.
@@ -589,10 +589,10 @@ mod tests {
             ArrowField::new("col_b", ArrowDataType::Int64, true),
         ]));
         let stats_fields = Fields::from(vec![
-            ArrowField::new(STATS_NUM_RECORDS, ArrowDataType::Int64, true),
-            ArrowField::new(STATS_NULL_COUNT, inner_type.clone(), true),
-            ArrowField::new(STATS_MIN_VALUES, inner_type.clone(), true),
-            ArrowField::new(STATS_MAX_VALUES, inner_type, true),
+            ArrowField::new(NUM_RECORDS, ArrowDataType::Int64, true),
+            ArrowField::new(NULL_COUNT, inner_type.clone(), true),
+            ArrowField::new(MIN_VALUES, inner_type.clone(), true),
+            ArrowField::new(MAX_VALUES, inner_type, true),
         ]);
         let stats_struct = StructArray::new(
             stats_fields.clone(),
@@ -654,7 +654,7 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err_msg.contains("col_b"));
-        assert!(err_msg.contains(STATS_MIN_VALUES));
+        assert!(err_msg.contains(MIN_VALUES));
         assert!(!err_msg.contains("col_a"));
     }
 
@@ -715,7 +715,7 @@ mod tests {
 
         // numRecords should match row count
         let num_records = stats
-            .column_by_name(STATS_NUM_RECORDS)
+            .column_by_name(NUM_RECORDS)
             .unwrap()
             .as_any()
             .downcast_ref::<Int64Array>()
@@ -724,7 +724,7 @@ mod tests {
 
         // All-null/empty columns are present in minValues/maxValues with null values
         let min_values = stats
-            .column_by_name(STATS_MIN_VALUES)
+            .column_by_name(MIN_VALUES)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -732,7 +732,7 @@ mod tests {
         assert!(min_values.column_by_name("col").unwrap().is_null(0));
 
         let max_values = stats
-            .column_by_name(STATS_MAX_VALUES)
+            .column_by_name(MAX_VALUES)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -991,10 +991,10 @@ mod tests {
             )
         };
         let stats_fields = Fields::from(vec![
-            ArrowField::new(STATS_NUM_RECORDS, ArrowDataType::Int64, true),
-            inner_struct_type(STATS_NULL_COUNT),
-            inner_struct_type(STATS_MIN_VALUES),
-            inner_struct_type(STATS_MAX_VALUES),
+            ArrowField::new(NUM_RECORDS, ArrowDataType::Int64, true),
+            inner_struct_type(NULL_COUNT),
+            inner_struct_type(MIN_VALUES),
+            inner_struct_type(MAX_VALUES),
         ]);
         let zero_inner_struct_array = StructArray::new(
             Fields::from(vec![col_field]),

--- a/kernel/src/transaction/stats_verifier.rs
+++ b/kernel/src/transaction/stats_verifier.rs
@@ -7,10 +7,10 @@
 
 use std::sync::LazyLock;
 
+use crate::actions::{STATS_MAX_VALUES, STATS_MIN_VALUES, STATS_NULL_COUNT, STATS_NUM_RECORDS};
 use crate::engine_data::{GetData, RowVisitor, TypedGetData as _};
 use crate::error::Error;
 use crate::expressions::{column_name, ColumnName};
-use crate::scan::data_skipping::stats_schema::STATS_NUM_RECORDS;
 use crate::schema::{ColumnNamesAndTypes, DataType, DecimalType, PrimitiveType};
 use crate::utils::require;
 use crate::DeltaResult;
@@ -56,10 +56,10 @@ impl StatsColumnVerifier {
     ) -> DeltaResult<()> {
         let column_names = vec![
             ColumnName::new(["path"]),
-            ColumnName::new(["stats", "numRecords"]),
-            build_stat_path(column, "nullCount"),
-            build_stat_path(column, "minValues"),
-            build_stat_path(column, "maxValues"),
+            ColumnName::new(["stats", STATS_NUM_RECORDS]),
+            build_stat_path(column, STATS_NULL_COUNT),
+            build_stat_path(column, STATS_MIN_VALUES),
+            build_stat_path(column, STATS_MAX_VALUES),
         ];
         let types = column_types_for(data_type)?;
 
@@ -251,8 +251,8 @@ impl RowVisitor for ColumnStatsValidator<'_> {
 
         for row_idx in 0..row_count {
             let path: String = getters[0].get(row_idx, "path")?;
-            let num_records = getters[1].get_long(row_idx, "numRecords")?;
-            let null_count = getters[2].get_long(row_idx, "nullCount")?;
+            let num_records = getters[1].get_long(row_idx, STATS_NUM_RECORDS)?;
+            let null_count = getters[2].get_long(row_idx, STATS_NULL_COUNT)?;
 
             // When all rows are null (or the file is empty), minValues/maxValues are
             // expected to be null since there are no non-null values to aggregate.

--- a/kernel/src/transaction/stats_verifier.rs
+++ b/kernel/src/transaction/stats_verifier.rs
@@ -399,10 +399,10 @@ mod tests {
         };
 
         let stats_fields = Fields::from(vec![
-            ArrowField::new("numRecords", ArrowDataType::Int64, true),
-            inner_struct_type("nullCount"),
-            inner_struct_type("minValues"),
-            inner_struct_type("maxValues"),
+            ArrowField::new(STATS_NUM_RECORDS, ArrowDataType::Int64, true),
+            inner_struct_type(STATS_NULL_COUNT),
+            inner_struct_type(STATS_MIN_VALUES),
+            inner_struct_type(STATS_MAX_VALUES),
         ]);
         let stats_struct = StructArray::new(
             stats_fields.clone(),
@@ -454,9 +454,9 @@ mod tests {
     #[test]
     fn test_verify_missing_stat_category() {
         let cases = [
-            ("nullCount", vec![None], vec![Some(1)], vec![Some(100)]),
-            ("minValues", vec![Some(0)], vec![None], vec![Some(100)]),
-            ("maxValues", vec![Some(0)], vec![Some(1)], vec![None]),
+            (STATS_NULL_COUNT, vec![None], vec![Some(1)], vec![Some(100)]),
+            (STATS_MIN_VALUES, vec![Some(0)], vec![None], vec![Some(100)]),
+            (STATS_MAX_VALUES, vec![Some(0)], vec![Some(1)], vec![None]),
         ];
         for (category, null_counts, min_values, max_values) in cases {
             let batch = create_add_file_batch(
@@ -548,7 +548,7 @@ mod tests {
         let result = verifier.verify(&[batch]);
         assert!(matches!(result, Err(Error::StatsValidation(_))));
         let err = result.unwrap_err().to_string();
-        assert!(err.contains("minValues"));
+        assert!(err.contains(STATS_MIN_VALUES));
     }
 
     /// Creates test data with two columns (col_a, col_b) in stats, both LONG.
@@ -589,10 +589,10 @@ mod tests {
             ArrowField::new("col_b", ArrowDataType::Int64, true),
         ]));
         let stats_fields = Fields::from(vec![
-            ArrowField::new("numRecords", ArrowDataType::Int64, true),
-            ArrowField::new("nullCount", inner_type.clone(), true),
-            ArrowField::new("minValues", inner_type.clone(), true),
-            ArrowField::new("maxValues", inner_type, true),
+            ArrowField::new(STATS_NUM_RECORDS, ArrowDataType::Int64, true),
+            ArrowField::new(STATS_NULL_COUNT, inner_type.clone(), true),
+            ArrowField::new(STATS_MIN_VALUES, inner_type.clone(), true),
+            ArrowField::new(STATS_MAX_VALUES, inner_type, true),
         ]);
         let stats_struct = StructArray::new(
             stats_fields.clone(),
@@ -654,7 +654,7 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err_msg.contains("col_b"));
-        assert!(err_msg.contains("minValues"));
+        assert!(err_msg.contains(STATS_MIN_VALUES));
         assert!(!err_msg.contains("col_a"));
     }
 
@@ -715,7 +715,7 @@ mod tests {
 
         // numRecords should match row count
         let num_records = stats
-            .column_by_name("numRecords")
+            .column_by_name(STATS_NUM_RECORDS)
             .unwrap()
             .as_any()
             .downcast_ref::<Int64Array>()
@@ -724,7 +724,7 @@ mod tests {
 
         // All-null/empty columns are present in minValues/maxValues with null values
         let min_values = stats
-            .column_by_name("minValues")
+            .column_by_name(STATS_MIN_VALUES)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -732,7 +732,7 @@ mod tests {
         assert!(min_values.column_by_name("col").unwrap().is_null(0));
 
         let max_values = stats
-            .column_by_name("maxValues")
+            .column_by_name(STATS_MAX_VALUES)
             .unwrap()
             .as_any()
             .downcast_ref::<StructArray>()
@@ -991,10 +991,10 @@ mod tests {
             )
         };
         let stats_fields = Fields::from(vec![
-            ArrowField::new("numRecords", ArrowDataType::Int64, true),
-            inner_struct_type("nullCount"),
-            inner_struct_type("minValues"),
-            inner_struct_type("maxValues"),
+            ArrowField::new(STATS_NUM_RECORDS, ArrowDataType::Int64, true),
+            inner_struct_type(STATS_NULL_COUNT),
+            inner_struct_type(STATS_MIN_VALUES),
+            inner_struct_type(STATS_MAX_VALUES),
         ]);
         let zero_inner_struct_array = StructArray::new(
             Fields::from(vec![col_field]),

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -18,7 +18,7 @@ use tracing::instrument;
 
 use super::Transaction;
 use crate::actions::deletion_vector::DeletionVectorDescriptor;
-use crate::actions::get_log_add_schema;
+use crate::actions::{get_log_add_schema, STATS_NUM_RECORDS};
 use crate::committer::Committer;
 use crate::engine_data::{
     FilteredEngineData, FilteredRowVisitor, GetData, RowIndexIterator, TypedGetData,
@@ -601,7 +601,7 @@ impl FilteredRowVisitor for DvMatchVisitor<'_> {
                 let stats = stats.ok_or_else(|| {
                     Error::generic(format!(
                         "update_deletion_vectors: file {path} has no stats; \
-                         deletion vectors require an accurate numRecords"
+                         deletion vectors require an accurate {STATS_NUM_RECORDS}"
                     ))
                 })?;
                 let parsed: serde_json::Value = serde_json::from_str(&stats).map_err(|e| {
@@ -610,12 +610,12 @@ impl FilteredRowVisitor for DvMatchVisitor<'_> {
                     ))
                 })?;
                 if parsed
-                    .get("numRecords")
+                    .get(STATS_NUM_RECORDS)
                     .and_then(serde_json::Value::as_u64)
                     .is_none()
                 {
                     return Err(Error::generic(format!(
-                        "update_deletion_vectors: stats for {path} is missing numRecords \
+                        "update_deletion_vectors: stats for {path} is missing {STATS_NUM_RECORDS} \
                          or it is not a non-negative integer"
                     )));
                 }

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -711,7 +711,7 @@ mod tests {
         let result = visitor.visit_rows_of(&data);
         if expect_error {
             let msg = result.expect_err("expected error").to_string();
-            assert!(msg.contains("numRecords"), "message was: {msg}");
+            assert!(msg.contains(STATS_NUM_RECORDS), "message was: {msg}");
             assert!(msg.contains(TEST_PATH), "message was: {msg}");
         } else {
             result.expect("validation should pass");

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -18,7 +18,7 @@ use tracing::instrument;
 
 use super::Transaction;
 use crate::actions::deletion_vector::DeletionVectorDescriptor;
-use crate::actions::{get_log_add_schema, STATS_NUM_RECORDS};
+use crate::actions::{get_log_add_schema, NUM_RECORDS};
 use crate::committer::Committer;
 use crate::engine_data::{
     FilteredEngineData, FilteredRowVisitor, GetData, RowIndexIterator, TypedGetData,
@@ -601,7 +601,7 @@ impl FilteredRowVisitor for DvMatchVisitor<'_> {
                 let stats = stats.ok_or_else(|| {
                     Error::generic(format!(
                         "update_deletion_vectors: file {path} has no stats; \
-                         deletion vectors require an accurate {STATS_NUM_RECORDS}"
+                         deletion vectors require an accurate {NUM_RECORDS}"
                     ))
                 })?;
                 let parsed: serde_json::Value = serde_json::from_str(&stats).map_err(|e| {
@@ -610,12 +610,12 @@ impl FilteredRowVisitor for DvMatchVisitor<'_> {
                     ))
                 })?;
                 if parsed
-                    .get(STATS_NUM_RECORDS)
+                    .get(NUM_RECORDS)
                     .and_then(serde_json::Value::as_u64)
                     .is_none()
                 {
                     return Err(Error::generic(format!(
-                        "update_deletion_vectors: stats for {path} is missing {STATS_NUM_RECORDS} \
+                        "update_deletion_vectors: stats for {path} is missing {NUM_RECORDS} \
                          or it is not a non-negative integer"
                     )));
                 }
@@ -711,7 +711,7 @@ mod tests {
         let result = visitor.visit_rows_of(&data);
         if expect_error {
             let msg = result.expect_err("expected error").to_string();
-            assert!(msg.contains(STATS_NUM_RECORDS), "message was: {msg}");
+            assert!(msg.contains(NUM_RECORDS), "message was: {msg}");
             assert!(msg.contains(TEST_PATH), "message was: {msg}");
         } else {
             result.expect("validation should pass");

--- a/kernel/tests/integration/common/write_utils.rs
+++ b/kernel/tests/integration/common/write_utils.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use delta_kernel::actions::{STATS_MAX_VALUES, STATS_MIN_VALUES};
 use delta_kernel::arrow::array::{Int32Array, StructArray};
 use delta_kernel::arrow::record_batch::RecordBatch;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
@@ -345,11 +346,11 @@ pub fn assert_min_max_stats(
     expected_max: impl Into<serde_json::Value>,
 ) {
     assert_eq!(
-        *resolve_json_path(&stats["minValues"], physical_path),
+        *resolve_json_path(&stats[STATS_MIN_VALUES], physical_path),
         expected_min.into()
     );
     assert_eq!(
-        *resolve_json_path(&stats["maxValues"], physical_path),
+        *resolve_json_path(&stats[STATS_MAX_VALUES], physical_path),
         expected_max.into()
     );
 }

--- a/kernel/tests/integration/common/write_utils.rs
+++ b/kernel/tests/integration/common/write_utils.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use delta_kernel::actions::{STATS_MAX_VALUES, STATS_MIN_VALUES};
+use delta_kernel::actions::{MAX_VALUES, MIN_VALUES};
 use delta_kernel::arrow::array::{Int32Array, StructArray};
 use delta_kernel::arrow::record_batch::RecordBatch;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
@@ -346,11 +346,11 @@ pub fn assert_min_max_stats(
     expected_max: impl Into<serde_json::Value>,
 ) {
     assert_eq!(
-        *resolve_json_path(&stats[STATS_MIN_VALUES], physical_path),
+        *resolve_json_path(&stats[MIN_VALUES], physical_path),
         expected_min.into()
     );
     assert_eq!(
-        *resolve_json_path(&stats[STATS_MAX_VALUES], physical_path),
+        *resolve_json_path(&stats[MAX_VALUES], physical_path),
         expected_max.into()
     );
 }

--- a/kernel/tests/integration/create_table/ctas.rs
+++ b/kernel/tests/integration/create_table/ctas.rs
@@ -7,6 +7,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use delta_kernel::actions::STATS_MIN_VALUES;
 use delta_kernel::arrow::array::{Array, Int64Array, StringArray, StructArray};
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
@@ -70,10 +71,10 @@ fn verify_column_names_in_stats(
     let stats = add_actions
         .iter()
         .filter_map(|a| a.stats.as_ref())
-        .find(|s| s.get("minValues").is_some());
+        .find(|s| s.get(STATS_MIN_VALUES).is_some());
 
     if let Some(stats) = stats {
-        let min_values = &stats["minValues"];
+        let min_values = &stats[STATS_MIN_VALUES];
         for logical_path in VERIFIED_PATHS {
             let col = ColumnName::new(logical_path.iter().copied());
             let expected =

--- a/kernel/tests/integration/create_table/ctas.rs
+++ b/kernel/tests/integration/create_table/ctas.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use delta_kernel::actions::STATS_MIN_VALUES;
+use delta_kernel::actions::MIN_VALUES;
 use delta_kernel::arrow::array::{Array, Int64Array, StringArray, StructArray};
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
@@ -71,10 +71,10 @@ fn verify_column_names_in_stats(
     let stats = add_actions
         .iter()
         .filter_map(|a| a.stats.as_ref())
-        .find(|s| s.get(STATS_MIN_VALUES).is_some());
+        .find(|s| s.get(MIN_VALUES).is_some());
 
     if let Some(stats) = stats {
-        let min_values = &stats[STATS_MIN_VALUES];
+        let min_values = &stats[MIN_VALUES];
         for logical_path in VERIFIED_PATHS {
             let col = ColumnName::new(logical_path.iter().copied());
             let expected =

--- a/kernel/tests/integration/features/clustering_e2e.rs
+++ b/kernel/tests/integration/features/clustering_e2e.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use delta_kernel::actions::{
-    STATS_MAX_VALUES, STATS_MIN_VALUES, STATS_NULL_COUNT, STATS_NUM_RECORDS,
+    MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS,
 };
 use delta_kernel::arrow::array::{ArrayRef, Int32Array};
 use delta_kernel::committer::FileSystemCommitter;
@@ -93,11 +93,11 @@ async fn test_clustered_table_write_and_checkpoint(
         for col in &expected_clustering {
             let col_name = col.to_string();
             assert!(
-                stats[STATS_MIN_VALUES].get(&col_name).is_some(),
+                stats[MIN_VALUES].get(&col_name).is_some(),
                 "Stats should include minValues for clustering column '{col_name}'"
             );
             assert!(
-                stats[STATS_MAX_VALUES].get(&col_name).is_some(),
+                stats[MAX_VALUES].get(&col_name).is_some(),
                 "Stats should include maxValues for clustering column '{col_name}'"
             );
         }
@@ -129,11 +129,11 @@ async fn test_clustered_table_write_and_checkpoint(
         for col in &expected_clustering {
             let col_name = col.to_string();
             assert!(
-                stats[STATS_MIN_VALUES].get(&col_name).is_some(),
+                stats[MIN_VALUES].get(&col_name).is_some(),
                 "Stats should include minValues for clustering column '{col_name}' after checkpoint"
             );
             assert!(
-                stats[STATS_MAX_VALUES].get(&col_name).is_some(),
+                stats[MAX_VALUES].get(&col_name).is_some(),
                 "Stats should include maxValues for clustering column '{col_name}' after checkpoint"
             );
         }
@@ -203,14 +203,14 @@ async fn test_clustered_table_write_all_null_clustering_column() {
     let add_infos = read_add_infos(&snapshot, engine.as_ref()).unwrap();
     assert_eq!(add_infos.len(), 1);
     let stats = add_infos[0].stats.as_ref().expect("should have stats");
-    assert_eq!(stats[STATS_NUM_RECORDS], 3);
-    assert_eq!(stats[STATS_NULL_COUNT]["region_id"], 3);
+    assert_eq!(stats[NUM_RECORDS], 3);
+    assert_eq!(stats[NULL_COUNT]["region_id"], 3);
     assert!(
-        stats[STATS_MIN_VALUES].get("region_id").is_none(),
+        stats[MIN_VALUES].get("region_id").is_none(),
         "JSON minValues should omit region_id when all values are null"
     );
     assert!(
-        stats[STATS_MAX_VALUES].get("region_id").is_none(),
+        stats[MAX_VALUES].get("region_id").is_none(),
         "JSON maxValues should omit region_id when all values are null"
     );
 }

--- a/kernel/tests/integration/features/clustering_e2e.rs
+++ b/kernel/tests/integration/features/clustering_e2e.rs
@@ -7,6 +7,9 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use delta_kernel::actions::{
+    STATS_MAX_VALUES, STATS_MIN_VALUES, STATS_NULL_COUNT, STATS_NUM_RECORDS,
+};
 use delta_kernel::arrow::array::{ArrayRef, Int32Array};
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::expressions::ColumnName;
@@ -90,11 +93,11 @@ async fn test_clustered_table_write_and_checkpoint(
         for col in &expected_clustering {
             let col_name = col.to_string();
             assert!(
-                stats["minValues"].get(&col_name).is_some(),
+                stats[STATS_MIN_VALUES].get(&col_name).is_some(),
                 "Stats should include minValues for clustering column '{col_name}'"
             );
             assert!(
-                stats["maxValues"].get(&col_name).is_some(),
+                stats[STATS_MAX_VALUES].get(&col_name).is_some(),
                 "Stats should include maxValues for clustering column '{col_name}'"
             );
         }
@@ -126,11 +129,11 @@ async fn test_clustered_table_write_and_checkpoint(
         for col in &expected_clustering {
             let col_name = col.to_string();
             assert!(
-                stats["minValues"].get(&col_name).is_some(),
+                stats[STATS_MIN_VALUES].get(&col_name).is_some(),
                 "Stats should include minValues for clustering column '{col_name}' after checkpoint"
             );
             assert!(
-                stats["maxValues"].get(&col_name).is_some(),
+                stats[STATS_MAX_VALUES].get(&col_name).is_some(),
                 "Stats should include maxValues for clustering column '{col_name}' after checkpoint"
             );
         }
@@ -200,14 +203,14 @@ async fn test_clustered_table_write_all_null_clustering_column() {
     let add_infos = read_add_infos(&snapshot, engine.as_ref()).unwrap();
     assert_eq!(add_infos.len(), 1);
     let stats = add_infos[0].stats.as_ref().expect("should have stats");
-    assert_eq!(stats["numRecords"], 3);
-    assert_eq!(stats["nullCount"]["region_id"], 3);
+    assert_eq!(stats[STATS_NUM_RECORDS], 3);
+    assert_eq!(stats[STATS_NULL_COUNT]["region_id"], 3);
     assert!(
-        stats["minValues"].get("region_id").is_none(),
+        stats[STATS_MIN_VALUES].get("region_id").is_none(),
         "JSON minValues should omit region_id when all values are null"
     );
     assert!(
-        stats["maxValues"].get("region_id").is_none(),
+        stats[STATS_MAX_VALUES].get("region_id").is_none(),
         "JSON maxValues should omit region_id when all values are null"
     );
 }

--- a/kernel/tests/integration/features/clustering_e2e.rs
+++ b/kernel/tests/integration/features/clustering_e2e.rs
@@ -7,9 +7,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use delta_kernel::actions::{
-    MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS,
-};
+use delta_kernel::actions::{MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS};
 use delta_kernel::arrow::array::{ArrayRef, Int32Array};
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::expressions::ColumnName;

--- a/kernel/tests/integration/log/v2_checkpoints.rs
+++ b/kernel/tests/integration/log/v2_checkpoints.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use delta_kernel::actions::deletion_vector::{DeletionVectorDescriptor, DeletionVectorStorageType};
-use delta_kernel::actions::{STATS_MAX_VALUES, STATS_MIN_VALUES, STATS_NUM_RECORDS};
+use delta_kernel::actions::{MAX_VALUES, MIN_VALUES, NUM_RECORDS};
 use delta_kernel::arrow::array::{
     Array, ArrayRef, AsArray, Int32Array, Int64Array, RecordBatch, RecordBatchReader, StringArray,
     StructArray,
@@ -623,7 +623,7 @@ async fn test_v2_checkpoint_partition_values_parsed_and_stats(
         let stats_parsed = get_struct_column_from_struct_array(add_col, "stats_parsed");
 
         let num_records_col = stats_parsed
-            .column_by_name(STATS_NUM_RECORDS)
+            .column_by_name(NUM_RECORDS)
             .expect("stats_parsed should have numRecords");
         for &row in &add_rows {
             all_record_counts.push(
@@ -633,7 +633,7 @@ async fn test_v2_checkpoint_partition_values_parsed_and_stats(
             );
         }
 
-        let min_values = get_struct_column_from_struct_array(stats_parsed, STATS_MIN_VALUES);
+        let min_values = get_struct_column_from_struct_array(stats_parsed, MIN_VALUES);
         let min_id_col = min_values
             .column_by_name("id")
             .expect("minValues should have id");
@@ -645,7 +645,7 @@ async fn test_v2_checkpoint_partition_values_parsed_and_stats(
             );
         }
 
-        let max_values = get_struct_column_from_struct_array(stats_parsed, STATS_MAX_VALUES);
+        let max_values = get_struct_column_from_struct_array(stats_parsed, MAX_VALUES);
         let max_id_col = max_values
             .column_by_name("id")
             .expect("maxValues should have id");
@@ -699,7 +699,7 @@ async fn test_v2_checkpoint_partition_values_parsed_and_stats(
         .iter()
         .map(|s| serde_json::from_str(s).expect("add.stats should be valid JSON"))
         .collect();
-    parsed_stats.sort_by_key(|v| v[STATS_NUM_RECORDS].as_i64().unwrap());
+    parsed_stats.sort_by_key(|v| v[NUM_RECORDS].as_i64().unwrap());
     assert_eq!(
         parsed_stats,
         vec![

--- a/kernel/tests/integration/log/v2_checkpoints.rs
+++ b/kernel/tests/integration/log/v2_checkpoints.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use delta_kernel::actions::deletion_vector::{DeletionVectorDescriptor, DeletionVectorStorageType};
+use delta_kernel::actions::{STATS_MAX_VALUES, STATS_MIN_VALUES, STATS_NUM_RECORDS};
 use delta_kernel::arrow::array::{
     Array, ArrayRef, AsArray, Int32Array, Int64Array, RecordBatch, RecordBatchReader, StringArray,
     StructArray,
@@ -622,7 +623,7 @@ async fn test_v2_checkpoint_partition_values_parsed_and_stats(
         let stats_parsed = get_struct_column_from_struct_array(add_col, "stats_parsed");
 
         let num_records_col = stats_parsed
-            .column_by_name("numRecords")
+            .column_by_name(STATS_NUM_RECORDS)
             .expect("stats_parsed should have numRecords");
         for &row in &add_rows {
             all_record_counts.push(
@@ -632,7 +633,7 @@ async fn test_v2_checkpoint_partition_values_parsed_and_stats(
             );
         }
 
-        let min_values = get_struct_column_from_struct_array(stats_parsed, "minValues");
+        let min_values = get_struct_column_from_struct_array(stats_parsed, STATS_MIN_VALUES);
         let min_id_col = min_values
             .column_by_name("id")
             .expect("minValues should have id");
@@ -644,7 +645,7 @@ async fn test_v2_checkpoint_partition_values_parsed_and_stats(
             );
         }
 
-        let max_values = get_struct_column_from_struct_array(stats_parsed, "maxValues");
+        let max_values = get_struct_column_from_struct_array(stats_parsed, STATS_MAX_VALUES);
         let max_id_col = max_values
             .column_by_name("id")
             .expect("maxValues should have id");
@@ -698,7 +699,7 @@ async fn test_v2_checkpoint_partition_values_parsed_and_stats(
         .iter()
         .map(|s| serde_json::from_str(s).expect("add.stats should be valid JSON"))
         .collect();
-    parsed_stats.sort_by_key(|v| v["numRecords"].as_i64().unwrap());
+    parsed_stats.sort_by_key(|v| v[STATS_NUM_RECORDS].as_i64().unwrap());
     assert_eq!(
         parsed_stats,
         vec![

--- a/kernel/tests/integration/write/clustered.rs
+++ b/kernel/tests/integration/write/clustered.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use delta_kernel::actions::{STATS_MAX_VALUES, STATS_MIN_VALUES};
+use delta_kernel::actions::{MAX_VALUES, MIN_VALUES};
 use delta_kernel::arrow::array::{Array, Int64Array, StringArray, StructArray};
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::engine::default::executor::tokio::TokioMultiThreadExecutor;
@@ -221,7 +221,7 @@ async fn test_clustered_table_write_has_stats(
             assert_min_max_stats(&stats, &physical_paths[1], *min_st, *max_st);
 
             // Non-clustering column "name" should NOT have stats
-            let non_cluster_min = resolve_json_path(&stats[STATS_MIN_VALUES], &non_clustering_physical);
+            let non_cluster_min = resolve_json_path(&stats[MIN_VALUES], &non_clustering_physical);
             assert!(
                 non_cluster_min.is_null(),
                 "v{version}: non-clustering column 'name' should not have stats"
@@ -308,8 +308,8 @@ async fn test_clustered_table_write_has_stats_parsed(
     let file = std::fs::File::open(&ckpt_path)?;
     let reader = ParquetRecordBatchReaderBuilder::try_new(file)?.build()?;
 
-    let min_path = |field: &[String]| -> Vec<String> { [&[STATS_MIN_VALUES.into()], field].concat() };
-    let max_path = |field: &[String]| -> Vec<String> { [&[STATS_MAX_VALUES.into()], field].concat() };
+    let min_path = |field: &[String]| -> Vec<String> { [&[MIN_VALUES.into()], field].concat() };
+    let max_path = |field: &[String]| -> Vec<String> { [&[MAX_VALUES.into()], field].concat() };
 
     let mut stats_rows: Vec<(i64, i64, String, String)> = Vec::new();
     for batch in reader {
@@ -319,7 +319,7 @@ async fn test_clustered_table_write_has_stats_parsed(
         let stats_parsed: &StructArray = resolve_struct_field(add, &["stats_parsed".into()]);
 
         // Non-clustering column should not appear in stats_parsed
-        let min_values: &StructArray = resolve_struct_field(stats_parsed, &[STATS_MIN_VALUES.into()]);
+        let min_values: &StructArray = resolve_struct_field(stats_parsed, &[MIN_VALUES.into()]);
         assert!(
             min_values
                 .column_by_name(&non_clustering_physical[0])

--- a/kernel/tests/integration/write/clustered.rs
+++ b/kernel/tests/integration/write/clustered.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use delta_kernel::actions::{STATS_MAX_VALUES, STATS_MIN_VALUES};
 use delta_kernel::arrow::array::{Array, Int64Array, StringArray, StructArray};
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::engine::default::executor::tokio::TokioMultiThreadExecutor;
@@ -220,7 +221,7 @@ async fn test_clustered_table_write_has_stats(
             assert_min_max_stats(&stats, &physical_paths[1], *min_st, *max_st);
 
             // Non-clustering column "name" should NOT have stats
-            let non_cluster_min = resolve_json_path(&stats["minValues"], &non_clustering_physical);
+            let non_cluster_min = resolve_json_path(&stats[STATS_MIN_VALUES], &non_clustering_physical);
             assert!(
                 non_cluster_min.is_null(),
                 "v{version}: non-clustering column 'name' should not have stats"
@@ -307,8 +308,8 @@ async fn test_clustered_table_write_has_stats_parsed(
     let file = std::fs::File::open(&ckpt_path)?;
     let reader = ParquetRecordBatchReaderBuilder::try_new(file)?.build()?;
 
-    let min_path = |field: &[String]| -> Vec<String> { [&["minValues".into()], field].concat() };
-    let max_path = |field: &[String]| -> Vec<String> { [&["maxValues".into()], field].concat() };
+    let min_path = |field: &[String]| -> Vec<String> { [&[STATS_MIN_VALUES.into()], field].concat() };
+    let max_path = |field: &[String]| -> Vec<String> { [&[STATS_MAX_VALUES.into()], field].concat() };
 
     let mut stats_rows: Vec<(i64, i64, String, String)> = Vec::new();
     for batch in reader {
@@ -318,7 +319,7 @@ async fn test_clustered_table_write_has_stats_parsed(
         let stats_parsed: &StructArray = resolve_struct_field(add, &["stats_parsed".into()]);
 
         // Non-clustering column should not appear in stats_parsed
-        let min_values: &StructArray = resolve_struct_field(stats_parsed, &["minValues".into()]);
+        let min_values: &StructArray = resolve_struct_field(stats_parsed, &[STATS_MIN_VALUES.into()]);
         assert!(
             min_values
                 .column_by_name(&non_clustering_physical[0])

--- a/kernel/tests/integration/write/column_mapping.rs
+++ b/kernel/tests/integration/write/column_mapping.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use delta_kernel::actions::{STATS_MAX_VALUES, STATS_MIN_VALUES};
+use delta_kernel::actions::{MAX_VALUES, MIN_VALUES};
 use delta_kernel::arrow::array::{
     Array, Int32Array, Int64Array, RecordBatch, StringArray, StructArray,
 };
@@ -114,10 +114,10 @@ async fn test_column_mapping_write(
     let mut all_stats: Vec<_> = add_actions
         .iter()
         .filter_map(|a| a.stats.as_ref())
-        .filter(|s| s.get(STATS_MIN_VALUES).is_some())
+        .filter(|s| s.get(MIN_VALUES).is_some())
         .collect();
     assert_eq!(all_stats.len(), 2, "should have stats for 2 files");
-    all_stats.sort_by_key(|s| s[STATS_MIN_VALUES][&row_number_physical[0]].as_i64().unwrap());
+    all_stats.sort_by_key(|s| s[MIN_VALUES][&row_number_physical[0]].as_i64().unwrap());
 
     // Batch 1: row_number 1..3, address.street "st1".."st3"
     assert_min_max_stats(all_stats[0], &row_number_physical, 1, 3);
@@ -147,10 +147,10 @@ async fn test_column_mapping_write(
                 resolve_struct_field(&batch_struct, &["stats_parsed".into()]);
 
             let min_path = |field: &[String]| -> Vec<String> {
-                [&["stats_parsed".into(), STATS_MIN_VALUES.into()], field].concat()
+                [&["stats_parsed".into(), MIN_VALUES.into()], field].concat()
             };
             let max_path = |field: &[String]| -> Vec<String> {
-                [&["stats_parsed".into(), STATS_MAX_VALUES.into()], field].concat()
+                [&["stats_parsed".into(), MAX_VALUES.into()], field].concat()
             };
             let min_row_num: &Int64Array =
                 resolve_struct_field(&batch_struct, &min_path(&row_number_physical));

--- a/kernel/tests/integration/write/column_mapping.rs
+++ b/kernel/tests/integration/write/column_mapping.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use delta_kernel::actions::{STATS_MAX_VALUES, STATS_MIN_VALUES};
 use delta_kernel::arrow::array::{
     Array, Int32Array, Int64Array, RecordBatch, StringArray, StructArray,
 };
@@ -113,10 +114,10 @@ async fn test_column_mapping_write(
     let mut all_stats: Vec<_> = add_actions
         .iter()
         .filter_map(|a| a.stats.as_ref())
-        .filter(|s| s.get("minValues").is_some())
+        .filter(|s| s.get(STATS_MIN_VALUES).is_some())
         .collect();
     assert_eq!(all_stats.len(), 2, "should have stats for 2 files");
-    all_stats.sort_by_key(|s| s["minValues"][&row_number_physical[0]].as_i64().unwrap());
+    all_stats.sort_by_key(|s| s[STATS_MIN_VALUES][&row_number_physical[0]].as_i64().unwrap());
 
     // Batch 1: row_number 1..3, address.street "st1".."st3"
     assert_min_max_stats(all_stats[0], &row_number_physical, 1, 3);
@@ -146,10 +147,10 @@ async fn test_column_mapping_write(
                 resolve_struct_field(&batch_struct, &["stats_parsed".into()]);
 
             let min_path = |field: &[String]| -> Vec<String> {
-                [&["stats_parsed".into(), "minValues".into()], field].concat()
+                [&["stats_parsed".into(), STATS_MIN_VALUES.into()], field].concat()
             };
             let max_path = |field: &[String]| -> Vec<String> {
-                [&["stats_parsed".into(), "maxValues".into()], field].concat()
+                [&["stats_parsed".into(), STATS_MAX_VALUES.into()], field].concat()
             };
             let min_row_num: &Int64Array =
                 resolve_struct_field(&batch_struct, &min_path(&row_number_physical));

--- a/kernel/tests/integration/write/partitioned.rs
+++ b/kernel/tests/integration/write/partitioned.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use chrono::{NaiveDate, NaiveDateTime, TimeZone, Utc};
+use delta_kernel::actions::{STATS_MAX_VALUES, STATS_MIN_VALUES, STATS_NULL_COUNT};
 use delta_kernel::arrow::array::{
     Array, ArrayRef, BinaryArray, BooleanArray, Date32Array, Decimal128Array, Float32Array,
     Float64Array, Int16Array, Int32Array, Int64Array, Int8Array, RecordBatch, StringArray,
@@ -807,23 +808,23 @@ async fn test_materialized_partition_columns_excluded_from_stats(
 
     // Stats should contain the data column but NOT the partition column.
     assert!(
-        stats["minValues"].get("number").is_some(),
+        stats[STATS_MIN_VALUES].get("number").is_some(),
         "data column 'number' should have minValues"
     );
     assert!(
-        stats["maxValues"].get("number").is_some(),
+        stats[STATS_MAX_VALUES].get("number").is_some(),
         "data column 'number' should have maxValues"
     );
     assert!(
-        stats["minValues"].get(partition_col).is_none(),
+        stats[STATS_MIN_VALUES].get(partition_col).is_none(),
         "partition column should not have minValues even when materialized"
     );
     assert!(
-        stats["maxValues"].get(partition_col).is_none(),
+        stats[STATS_MAX_VALUES].get(partition_col).is_none(),
         "partition column should not have maxValues even when materialized"
     );
     assert!(
-        stats["nullCount"].get(partition_col).is_none(),
+        stats[STATS_NULL_COUNT].get(partition_col).is_none(),
         "partition column should not have nullCount even when materialized"
     );
 

--- a/kernel/tests/integration/write/partitioned.rs
+++ b/kernel/tests/integration/write/partitioned.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use chrono::{NaiveDate, NaiveDateTime, TimeZone, Utc};
-use delta_kernel::actions::{STATS_MAX_VALUES, STATS_MIN_VALUES, STATS_NULL_COUNT};
+use delta_kernel::actions::{MAX_VALUES, MIN_VALUES, NULL_COUNT};
 use delta_kernel::arrow::array::{
     Array, ArrayRef, BinaryArray, BooleanArray, Date32Array, Decimal128Array, Float32Array,
     Float64Array, Int16Array, Int32Array, Int64Array, Int8Array, RecordBatch, StringArray,
@@ -808,23 +808,23 @@ async fn test_materialized_partition_columns_excluded_from_stats(
 
     // Stats should contain the data column but NOT the partition column.
     assert!(
-        stats[STATS_MIN_VALUES].get("number").is_some(),
+        stats[MIN_VALUES].get("number").is_some(),
         "data column 'number' should have minValues"
     );
     assert!(
-        stats[STATS_MAX_VALUES].get("number").is_some(),
+        stats[MAX_VALUES].get("number").is_some(),
         "data column 'number' should have maxValues"
     );
     assert!(
-        stats[STATS_MIN_VALUES].get(partition_col).is_none(),
+        stats[MIN_VALUES].get(partition_col).is_none(),
         "partition column should not have minValues even when materialized"
     );
     assert!(
-        stats[STATS_MAX_VALUES].get(partition_col).is_none(),
+        stats[MAX_VALUES].get(partition_col).is_none(),
         "partition column should not have maxValues even when materialized"
     );
     assert!(
-        stats[STATS_NULL_COUNT].get(partition_col).is_none(),
+        stats[NULL_COUNT].get(partition_col).is_none(),
         "partition column should not have nullCount even when materialized"
     );
 

--- a/kernel/tests/integration/write/remove_dv.rs
+++ b/kernel/tests/integration/write/remove_dv.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use delta_kernel::actions::deletion_vector::{DeletionVectorDescriptor, DeletionVectorStorageType};
-use delta_kernel::actions::STATS_NUM_RECORDS;
+use delta_kernel::actions::NUM_RECORDS;
 use delta_kernel::arrow::array::{Int32Array, RecordBatch};
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
@@ -149,7 +149,7 @@ async fn test_remove_files_adds_expected_entries() -> Result<(), Box<dyn std::er
             // stats (optional)
             let stats = remove["stats"].as_str().expect("Missing stats");
             let stats_json: serde_json::Value = serde_json::from_str(stats)?;
-            assert_eq!(stats_json[STATS_NUM_RECORDS], 10);
+            assert_eq!(stats_json[NUM_RECORDS], 10);
 
             // tags (optional)
             let tags = remove["tags"].as_object().expect("Missing tags");
@@ -978,7 +978,7 @@ async fn test_remove_files_after_predicate_scan_includes_stats_parsed(
                 .expect("stats field should be a non-null JSON string");
             let stats: serde_json::Value = serde_json::from_str(stats_str)?;
             assert!(
-                stats[STATS_NUM_RECORDS].as_i64().unwrap_or(0) > 0,
+                stats[NUM_RECORDS].as_i64().unwrap_or(0) > 0,
                 "stats.numRecords should be populated, got: {stats}"
             );
         }
@@ -1116,7 +1116,7 @@ async fn test_remove_files_partitioned_with_parsed_columns(
                 .expect("stats field should be a non-null JSON string");
             let stats: serde_json::Value = serde_json::from_str(stats_str)?;
             assert!(
-                stats[STATS_NUM_RECORDS].as_i64().unwrap_or(0) > 0,
+                stats[NUM_RECORDS].as_i64().unwrap_or(0) > 0,
                 "stats.numRecords should be populated, got: {stats}"
             );
         }

--- a/kernel/tests/integration/write/remove_dv.rs
+++ b/kernel/tests/integration/write/remove_dv.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use delta_kernel::actions::deletion_vector::{DeletionVectorDescriptor, DeletionVectorStorageType};
+use delta_kernel::actions::STATS_NUM_RECORDS;
 use delta_kernel::arrow::array::{Int32Array, RecordBatch};
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
@@ -148,7 +149,7 @@ async fn test_remove_files_adds_expected_entries() -> Result<(), Box<dyn std::er
             // stats (optional)
             let stats = remove["stats"].as_str().expect("Missing stats");
             let stats_json: serde_json::Value = serde_json::from_str(stats)?;
-            assert_eq!(stats_json["numRecords"], 10);
+            assert_eq!(stats_json[STATS_NUM_RECORDS], 10);
 
             // tags (optional)
             let tags = remove["tags"].as_object().expect("Missing tags");
@@ -977,7 +978,7 @@ async fn test_remove_files_after_predicate_scan_includes_stats_parsed(
                 .expect("stats field should be a non-null JSON string");
             let stats: serde_json::Value = serde_json::from_str(stats_str)?;
             assert!(
-                stats["numRecords"].as_i64().unwrap_or(0) > 0,
+                stats[STATS_NUM_RECORDS].as_i64().unwrap_or(0) > 0,
                 "stats.numRecords should be populated, got: {stats}"
             );
         }
@@ -1115,7 +1116,7 @@ async fn test_remove_files_partitioned_with_parsed_columns(
                 .expect("stats field should be a non-null JSON string");
             let stats: serde_json::Value = serde_json::from_str(stats_str)?;
             assert!(
-                stats["numRecords"].as_i64().unwrap_or(0) > 0,
+                stats[STATS_NUM_RECORDS].as_i64().unwrap_or(0) > 0,
                 "stats.numRecords should be populated, got: {stats}"
             );
         }

--- a/kernel/tests/integration/write/stats.rs
+++ b/kernel/tests/integration/write/stats.rs
@@ -3,9 +3,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use delta_kernel::actions::{
-    MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS,
-};
+use delta_kernel::actions::{MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS};
 use delta_kernel::arrow::array::{
     ArrayRef, BinaryArray, Int64Array, ListArray, MapArray, RecordBatch, StringArray, StructArray,
 };

--- a/kernel/tests/integration/write/stats.rs
+++ b/kernel/tests/integration/write/stats.rs
@@ -3,6 +3,9 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use delta_kernel::actions::{
+    STATS_MAX_VALUES, STATS_MIN_VALUES, STATS_NULL_COUNT, STATS_NUM_RECORDS,
+};
 use delta_kernel::arrow::array::{
     ArrayRef, BinaryArray, Int64Array, ListArray, MapArray, RecordBatch, StringArray, StructArray,
 };
@@ -199,24 +202,24 @@ async fn test_write_stats_for_complex_type_columns(
             .expect("add action should have stats"),
     )?;
 
-    assert_eq!(stats["numRecords"], 3);
+    assert_eq!(stats[STATS_NUM_RECORDS], 3);
 
     // nullCount should be present for all columns including array, map, and variant
-    assert_eq!(stats["nullCount"][&id_phys], 0);
-    assert_eq!(stats["nullCount"][&tags_phys], 1);
-    assert_eq!(stats["nullCount"][&props_phys], 1);
-    assert_eq!(stats["nullCount"][&v_phys], 1);
+    assert_eq!(stats[STATS_NULL_COUNT][&id_phys], 0);
+    assert_eq!(stats[STATS_NULL_COUNT][&tags_phys], 1);
+    assert_eq!(stats[STATS_NULL_COUNT][&props_phys], 1);
+    assert_eq!(stats[STATS_NULL_COUNT][&v_phys], 1);
 
     // minValues/maxValues should have id but NOT complex types
-    assert!(stats["minValues"][&id_phys].is_number());
-    assert!(stats["maxValues"][&id_phys].is_number());
+    assert!(stats[STATS_MIN_VALUES][&id_phys].is_number());
+    assert!(stats[STATS_MAX_VALUES][&id_phys].is_number());
     for col in [&tags_phys, &props_phys, &v_phys] {
         assert!(
-            stats["minValues"].get(col).is_none(),
+            stats[STATS_MIN_VALUES].get(col).is_none(),
             "minValues should not contain {col}"
         );
         assert!(
-            stats["maxValues"].get(col).is_none(),
+            stats[STATS_MAX_VALUES].get(col).is_none(),
             "maxValues should not contain {col}"
         );
     }
@@ -404,23 +407,23 @@ async fn test_write_stats_nested_complex_types_respect_column_limit(
             .expect("add action should have stats"),
     )?;
 
-    assert_eq!(stats["numRecords"], 3);
+    assert_eq!(stats[STATS_NUM_RECORDS], 3);
 
     // First 3 leaves: id, data.name, data.tags all get nullCount
-    assert_eq!(stats["nullCount"]["id"], 0);
-    assert_eq!(stats["nullCount"]["data"]["name"], 0);
-    assert_eq!(stats["nullCount"]["data"]["tags"], 1);
+    assert_eq!(stats[STATS_NULL_COUNT]["id"], 0);
+    assert_eq!(stats[STATS_NULL_COUNT]["data"]["name"], 0);
+    assert_eq!(stats[STATS_NULL_COUNT]["data"]["tags"], 1);
 
     // 4th leaf data.props is excluded by the column limit
     assert!(
-        stats["nullCount"]["data"].get("props").is_none(),
+        stats[STATS_NULL_COUNT]["data"].get("props").is_none(),
         "props should be excluded by numIndexedCols=3"
     );
 
     // id and data.name get min/max; data.tags does not (complex type)
-    assert!(stats["minValues"]["id"].is_number());
-    assert!(stats["minValues"]["data"]["name"].is_string());
-    assert!(stats["minValues"]["data"].get("tags").is_none());
+    assert!(stats[STATS_MIN_VALUES]["id"].is_number());
+    assert!(stats[STATS_MIN_VALUES]["data"]["name"].is_string());
+    assert!(stats[STATS_MIN_VALUES]["data"].get("tags").is_none());
 
     Ok(())
 }

--- a/kernel/tests/integration/write/stats.rs
+++ b/kernel/tests/integration/write/stats.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use delta_kernel::actions::{
-    STATS_MAX_VALUES, STATS_MIN_VALUES, STATS_NULL_COUNT, STATS_NUM_RECORDS,
+    MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS,
 };
 use delta_kernel::arrow::array::{
     ArrayRef, BinaryArray, Int64Array, ListArray, MapArray, RecordBatch, StringArray, StructArray,
@@ -202,24 +202,24 @@ async fn test_write_stats_for_complex_type_columns(
             .expect("add action should have stats"),
     )?;
 
-    assert_eq!(stats[STATS_NUM_RECORDS], 3);
+    assert_eq!(stats[NUM_RECORDS], 3);
 
     // nullCount should be present for all columns including array, map, and variant
-    assert_eq!(stats[STATS_NULL_COUNT][&id_phys], 0);
-    assert_eq!(stats[STATS_NULL_COUNT][&tags_phys], 1);
-    assert_eq!(stats[STATS_NULL_COUNT][&props_phys], 1);
-    assert_eq!(stats[STATS_NULL_COUNT][&v_phys], 1);
+    assert_eq!(stats[NULL_COUNT][&id_phys], 0);
+    assert_eq!(stats[NULL_COUNT][&tags_phys], 1);
+    assert_eq!(stats[NULL_COUNT][&props_phys], 1);
+    assert_eq!(stats[NULL_COUNT][&v_phys], 1);
 
     // minValues/maxValues should have id but NOT complex types
-    assert!(stats[STATS_MIN_VALUES][&id_phys].is_number());
-    assert!(stats[STATS_MAX_VALUES][&id_phys].is_number());
+    assert!(stats[MIN_VALUES][&id_phys].is_number());
+    assert!(stats[MAX_VALUES][&id_phys].is_number());
     for col in [&tags_phys, &props_phys, &v_phys] {
         assert!(
-            stats[STATS_MIN_VALUES].get(col).is_none(),
+            stats[MIN_VALUES].get(col).is_none(),
             "minValues should not contain {col}"
         );
         assert!(
-            stats[STATS_MAX_VALUES].get(col).is_none(),
+            stats[MAX_VALUES].get(col).is_none(),
             "maxValues should not contain {col}"
         );
     }
@@ -407,23 +407,23 @@ async fn test_write_stats_nested_complex_types_respect_column_limit(
             .expect("add action should have stats"),
     )?;
 
-    assert_eq!(stats[STATS_NUM_RECORDS], 3);
+    assert_eq!(stats[NUM_RECORDS], 3);
 
     // First 3 leaves: id, data.name, data.tags all get nullCount
-    assert_eq!(stats[STATS_NULL_COUNT]["id"], 0);
-    assert_eq!(stats[STATS_NULL_COUNT]["data"]["name"], 0);
-    assert_eq!(stats[STATS_NULL_COUNT]["data"]["tags"], 1);
+    assert_eq!(stats[NULL_COUNT]["id"], 0);
+    assert_eq!(stats[NULL_COUNT]["data"]["name"], 0);
+    assert_eq!(stats[NULL_COUNT]["data"]["tags"], 1);
 
     // 4th leaf data.props is excluded by the column limit
     assert!(
-        stats[STATS_NULL_COUNT]["data"].get("props").is_none(),
+        stats[NULL_COUNT]["data"].get("props").is_none(),
         "props should be excluded by numIndexedCols=3"
     );
 
     // id and data.name get min/max; data.tags does not (complex type)
-    assert!(stats[STATS_MIN_VALUES]["id"].is_number());
-    assert!(stats[STATS_MIN_VALUES]["data"]["name"].is_string());
-    assert!(stats[STATS_MIN_VALUES]["data"].get("tags").is_none());
+    assert!(stats[MIN_VALUES]["id"].is_number());
+    assert!(stats[MIN_VALUES]["data"]["name"].is_string());
+    assert!(stats[MIN_VALUES]["data"].get("tags").is_none());
 
     Ok(())
 }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -9,7 +9,10 @@ pub use counting_reporter::{
     ensure_metrics_compatible_global_subscriber, install_thread_local_metrics_reporter,
     CountingReporter, RelaxedCounter,
 };
-use delta_kernel::actions::get_log_add_schema;
+use delta_kernel::actions::{
+    get_log_add_schema, STATS_MAX_VALUES, STATS_MIN_VALUES, STATS_NULL_COUNT, STATS_NUM_RECORDS,
+    STATS_TIGHT_BOUNDS,
+};
 use delta_kernel::arrow::array::{
     Array, ArrayRef, BooleanArray, Float64Array, Int32Array, Int64Array, MapArray, RecordBatch,
     StringArray, StructArray,
@@ -985,12 +988,12 @@ pub fn create_add_files_metadata(
 
     let stats_struct = StructArray::from(vec![
         (
-            Arc::new(Field::new("numRecords", ArrowDataType::Int64, true)),
+            Arc::new(Field::new(STATS_NUM_RECORDS, ArrowDataType::Int64, true)),
             Arc::new(num_records_array) as ArrayRef,
         ),
         (
             Arc::new(Field::new(
-                "nullCount",
+                STATS_NULL_COUNT,
                 ArrowDataType::Struct(empty_struct_fields.clone()),
                 true,
             )),
@@ -998,7 +1001,7 @@ pub fn create_add_files_metadata(
         ),
         (
             Arc::new(Field::new(
-                "minValues",
+                STATS_MIN_VALUES,
                 ArrowDataType::Struct(empty_struct_fields.clone()),
                 true,
             )),
@@ -1006,14 +1009,14 @@ pub fn create_add_files_metadata(
         ),
         (
             Arc::new(Field::new(
-                "maxValues",
+                STATS_MAX_VALUES,
                 ArrowDataType::Struct(empty_struct_fields),
                 true,
             )),
             Arc::new(empty_struct) as ArrayRef,
         ),
         (
-            Arc::new(Field::new("tightBounds", ArrowDataType::Boolean, true)),
+            Arc::new(Field::new(STATS_TIGHT_BOUNDS, ArrowDataType::Boolean, true)),
             Arc::new(tight_bounds_array) as ArrayRef,
         ),
     ]);

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -10,8 +10,8 @@ pub use counting_reporter::{
     CountingReporter, RelaxedCounter,
 };
 use delta_kernel::actions::{
-    get_log_add_schema, STATS_MAX_VALUES, STATS_MIN_VALUES, STATS_NULL_COUNT, STATS_NUM_RECORDS,
-    STATS_TIGHT_BOUNDS,
+    get_log_add_schema, MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS,
+    TIGHT_BOUNDS,
 };
 use delta_kernel::arrow::array::{
     Array, ArrayRef, BooleanArray, Float64Array, Int32Array, Int64Array, MapArray, RecordBatch,
@@ -988,12 +988,12 @@ pub fn create_add_files_metadata(
 
     let stats_struct = StructArray::from(vec![
         (
-            Arc::new(Field::new(STATS_NUM_RECORDS, ArrowDataType::Int64, true)),
+            Arc::new(Field::new(NUM_RECORDS, ArrowDataType::Int64, true)),
             Arc::new(num_records_array) as ArrayRef,
         ),
         (
             Arc::new(Field::new(
-                STATS_NULL_COUNT,
+                NULL_COUNT,
                 ArrowDataType::Struct(empty_struct_fields.clone()),
                 true,
             )),
@@ -1001,7 +1001,7 @@ pub fn create_add_files_metadata(
         ),
         (
             Arc::new(Field::new(
-                STATS_MIN_VALUES,
+                MIN_VALUES,
                 ArrowDataType::Struct(empty_struct_fields.clone()),
                 true,
             )),
@@ -1009,14 +1009,14 @@ pub fn create_add_files_metadata(
         ),
         (
             Arc::new(Field::new(
-                STATS_MAX_VALUES,
+                MAX_VALUES,
                 ArrowDataType::Struct(empty_struct_fields),
                 true,
             )),
             Arc::new(empty_struct) as ArrayRef,
         ),
         (
-            Arc::new(Field::new(STATS_TIGHT_BOUNDS, ArrowDataType::Boolean, true)),
+            Arc::new(Field::new(TIGHT_BOUNDS, ArrowDataType::Boolean, true)),
             Arc::new(tight_bounds_array) as ArrayRef,
         ),
     ]);

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -10,8 +10,7 @@ pub use counting_reporter::{
     CountingReporter, RelaxedCounter,
 };
 use delta_kernel::actions::{
-    get_log_add_schema, MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS,
-    TIGHT_BOUNDS,
+    get_log_add_schema, MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS, TIGHT_BOUNDS,
 };
 use delta_kernel::arrow::array::{
     Array, ArrayRef, BooleanArray, Float64Array, Int32Array, Int64Array, MapArray, RecordBatch,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Create stat field name constants (address [issue 1976](https://github.com/delta-io/delta-kernel-rs/issues/1976)). These replace existing string literals `"nullCount"`, `"minValues"`, `"maxValues"`, `"tightBounds"`, and `"numRecords"` (which was originally already a constant in `kernel/src/scan/data_skipping/stats_schema/mod.rs`, but all of these were added to `kernel/src/actions/mod.rs`).

## How was this change tested?

All CI tests pass. This doesn't change any functionality, just a refactor.
