### PR TITLE
feat: Add type allowlist for icebergCompatV3

### DIFF
--- a/kernel/src/schema/validation.rs
+++ b/kernel/src/schema/validation.rs
@@ -4,9 +4,8 @@
 
 use std::collections::HashSet;
 
-use crate::schema::{ColumnMetadataKey, StructField, StructType};
-use crate::table_configuration::TableConfiguration;
-use crate::table_features::{ColumnMappingMode, TableFeature};
+use crate::schema::{StructField, StructType};
+use crate::table_features::ColumnMappingMode;
 use crate::transforms::SchemaTransform;
 use crate::{transform_output_type, DeltaResult, Error};
 
@@ -121,56 +120,6 @@ impl<'a> SchemaTransform<'a> for SchemaValidator {
 
         self.recurse_into_struct_field(field);
         self.current_path.pop();
-    }
-}
-
-/// `parquet.field.nested.ids` is to be deprecated in favor of `delta.columnMapping.nested.ids`.
-/// Validates that no fields in the schema have `parquet.field.nested.ids` metadata.
-///
-/// Tracking issue: <https://github.com/delta-io/delta/issues/6688>
-pub(crate) fn validate_iceberg_compat_v3_no_legacy_nested_id(
-    tc: &TableConfiguration,
-) -> DeltaResult<()> {
-    if !tc.is_feature_enabled(&TableFeature::IcebergCompatV3) {
-        return Ok(());
-    }
-    let mut v = LegacyNestedIdsVisitor {
-        path: vec![],
-        offender: None,
-    };
-    v.transform_struct(&tc.logical_schema());
-    let Some(offender) = v.offender else {
-        return Ok(());
-    };
-    Err(Error::generic(format!(
-        "field `{offender}` carries deprecated `{}` metadata; use `{}` instead. \
-         See https://github.com/delta-io/delta/issues/6688",
-        ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
-        ColumnMetadataKey::ColumnMappingNestedIds.as_ref(),
-    )))
-}
-
-struct LegacyNestedIdsVisitor {
-    path: Vec<String>,
-    offender: Option<String>,
-}
-
-impl<'a> SchemaTransform<'a> for LegacyNestedIdsVisitor {
-    transform_output_type!(|'a, T| ());
-
-    fn transform_struct_field(&mut self, f: &'a StructField) {
-        if self.offender.is_some() {
-            return;
-        }
-        self.path.push(f.name().to_string());
-        if f.metadata()
-            .contains_key(ColumnMetadataKey::ParquetFieldNestedIds.as_ref())
-        {
-            self.offender = Some(self.path.join("."));
-            return;
-        }
-        self.recurse_into_struct_field(f);
-        self.path.pop();
     }
 }
 
@@ -474,110 +423,5 @@ mod tests {
             msg.contains(expected_path),
             "Expected path '{expected_path}' in error, got: {msg}"
         );
-    }
-
-    // === LegacyNestedIdsVisitor: parquet.field.nested.ids detection ===
-
-    #[rstest]
-    #[case::clean_schema(simple_schema(), None)]
-    #[case::column_mapping_nested_id_key_only(schema_with_good_nested_ids(), None)]
-    #[case::top_level_legacy(schema_with_legacy_at("top"), Some("top".to_string()))]
-    #[case::nested_struct_legacy(schema_struct_with_legacy_at_inner(), Some("parent.inner".to_string()))]
-    #[case::array_struct_legacy(schema_array_struct_with_legacy_at_inner(), Some("arr.inner".to_string()))]
-    #[case::map_value_struct_legacy(schema_map_value_struct_with_legacy_at_inner(), Some("m.inner".to_string()))]
-    #[case::first_offender_wins(schema_two_legacy_fields(), Some("a".to_string()))]
-    fn legacy_nested_ids_visitor_finds_first_offender(
-        #[case] schema: StructType,
-        #[case] expected: Option<String>,
-    ) {
-        let mut v = LegacyNestedIdsVisitor {
-            path: vec![],
-            offender: None,
-        };
-        v.transform_struct(&schema);
-        assert_eq!(v.offender, expected);
-    }
-
-    fn field_with_metadata(name: &str, dtype: DataType, key: &str) -> StructField {
-        let mut f = StructField::nullable(name, dtype);
-        f.metadata.insert(
-            key.to_string(),
-            MetadataValue::Other(serde_json::json!({ "x.element": 1 })),
-        );
-        f
-    }
-
-    fn schema_with_good_nested_ids() -> StructType {
-        StructType::new_unchecked(vec![field_with_metadata(
-            "x",
-            DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
-            ColumnMetadataKey::ColumnMappingNestedIds.as_ref(),
-        )])
-    }
-
-    fn schema_with_legacy_at(name: &str) -> StructType {
-        StructType::new_unchecked(vec![field_with_metadata(
-            name,
-            DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
-            ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
-        )])
-    }
-
-    fn schema_struct_with_legacy_at_inner() -> StructType {
-        let inner = StructType::new_unchecked(vec![field_with_metadata(
-            "inner",
-            DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
-            ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
-        )]);
-        StructType::new_unchecked(vec![StructField::nullable(
-            "parent",
-            DataType::Struct(Box::new(inner)),
-        )])
-    }
-
-    fn schema_array_struct_with_legacy_at_inner() -> StructType {
-        let inner = StructType::new_unchecked(vec![field_with_metadata(
-            "inner",
-            DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
-            ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
-        )]);
-        StructType::new_unchecked(vec![StructField::nullable(
-            "arr",
-            DataType::Array(Box::new(ArrayType::new(
-                DataType::Struct(Box::new(inner)),
-                true,
-            ))),
-        )])
-    }
-
-    fn schema_map_value_struct_with_legacy_at_inner() -> StructType {
-        let inner = StructType::new_unchecked(vec![field_with_metadata(
-            "inner",
-            DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
-            ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
-        )]);
-        StructType::new_unchecked(vec![StructField::nullable(
-            "m",
-            DataType::Map(Box::new(MapType::new(
-                DataType::STRING,
-                DataType::Struct(Box::new(inner)),
-                true,
-            ))),
-        )])
-    }
-
-    fn schema_two_legacy_fields() -> StructType {
-        StructType::new_unchecked(vec![
-            field_with_metadata(
-                "a",
-                DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
-                ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
-            ),
-            field_with_metadata(
-                "b",
-                DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
-                ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
-            ),
-        ])
     }
 }

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -21,15 +21,15 @@ use crate::expressions::ColumnName;
 use crate::scan::data_skipping::stats_schema::{
     expected_stats_schema, stats_column_names, StatsConfig, StripFieldMetadataTransform,
 };
-use crate::schema::validation::validate_iceberg_compat_v3_no_legacy_nested_id;
 pub(crate) use crate::schema::variant_utils::validate_variant_type_feature_support;
 use crate::schema::{schema_has_invariants, SchemaRef, StructField, StructType};
 use crate::table_features::{
-    column_mapping_mode, get_any_level_column_physical_name,
+    column_mapping_mode, get_any_level_column_physical_name, validate_iceberg_compat_if_needed,
     validate_timestamp_ntz_feature_support, ColumnMappingMode, EnablementCheck, FeatureRequirement,
     FeatureType, KernelSupport, Operation, TableFeature, LEGACY_READER_FEATURES,
     LEGACY_WRITER_FEATURES, MAX_VALID_READER_VERSION, MAX_VALID_WRITER_VERSION,
     MIN_VALID_RW_VERSION, TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION,
+    V3_VALIDATOR,
 };
 use crate::table_properties::TableProperties;
 use crate::transforms::SchemaTransform as _;
@@ -204,7 +204,7 @@ impl TableConfiguration {
         // Validate schema against protocol features now that we have a TC instance.
         validate_timestamp_ntz_feature_support(&table_config)?;
         validate_variant_type_feature_support(&table_config)?;
-        validate_iceberg_compat_v3_no_legacy_nested_id(&table_config)?;
+        validate_iceberg_compat_if_needed(&table_config, &V3_VALIDATOR)?;
 
         Ok(table_config)
     }

--- a/kernel/src/table_features/iceberg_compat/mod.rs
+++ b/kernel/src/table_features/iceberg_compat/mod.rs
@@ -19,7 +19,6 @@ pub(crate) enum IcebergCompatVersion {
 }
 
 impl IcebergCompatVersion {
-    /// Maps the version to the `TableFeature`.
     pub(super) fn as_table_feature(&self) -> TableFeature {
         match self {
             Self::V3 => TableFeature::IcebergCompatV3,
@@ -77,6 +76,15 @@ struct TypeAllowlistVisitor {
     path: Vec<String>,
 }
 
+impl TypeAllowlistVisitor {
+    /// If `dt` isn't allowed, record it as the offender. No-op if an offender is already set.
+    fn check(&mut self, dt: &DataType) {
+        if self.offender.is_none() && !(self.is_supported)(dt) {
+            self.offender = Some(format!("{} ({})", self.path.join("."), dt));
+        }
+    }
+}
+
 impl<'a> SchemaTransform<'a> for TypeAllowlistVisitor {
     transform_output_type!(|'a, T| ());
 
@@ -85,11 +93,38 @@ impl<'a> SchemaTransform<'a> for TypeAllowlistVisitor {
             return;
         }
         self.path.push(f.name().to_string());
-        if !(self.is_supported)(f.data_type()) {
-            self.offender = Some(format!("{} ({})", self.path.join("."), f.data_type()));
+        self.check(f.data_type());
+        self.recurse_into_struct_field(f);
+        self.path.pop();
+    }
+
+    fn transform_array_element(&mut self, etype: &'a DataType) {
+        if self.offender.is_some() {
             return;
         }
-        self.recurse_into_struct_field(f);
+        self.path.push("element".to_string());
+        self.check(etype);
+        self.transform(etype);
+        self.path.pop();
+    }
+
+    fn transform_map_key(&mut self, etype: &'a DataType) {
+        if self.offender.is_some() {
+            return;
+        }
+        self.path.push("key".to_string());
+        self.check(etype);
+        self.transform(etype);
+        self.path.pop();
+    }
+
+    fn transform_map_value(&mut self, etype: &'a DataType) {
+        if self.offender.is_some() {
+            return;
+        }
+        self.path.push("value".to_string());
+        self.check(etype);
+        self.transform(etype);
         self.path.pop();
     }
 }
@@ -143,7 +178,7 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::schema::{ArrayType, MapType, MetadataValue, StructType};
+    use crate::schema::{ArrayType, MapType, MetadataValue, PrimitiveType, StructType};
 
     // === LegacyNestedIdsVisitor: parquet.field.nested.ids detection ===
 
@@ -257,42 +292,111 @@ mod tests {
         assert_eq!(v.offender, expected);
     }
 
-    // === TypeAllowlistVisitor tests  ===
-    //
+    // === TypeAllowlistVisitor tests ===
+
     /// Narrow allowlist: Integer, String, and Struct.
     fn narrow_allowlist(dt: &DataType) -> bool {
-        use crate::schema::PrimitiveType::*;
         matches!(
             dt,
-            DataType::Primitive(Integer | String) | DataType::Struct(_)
+            DataType::Primitive(PrimitiveType::Integer | PrimitiveType::String)
+                | DataType::Struct(_)
+        )
+    }
+
+    /// Wide allowlist: Integer, String, Struct, Array, Map.
+    fn wide_allowlist(dt: &DataType) -> bool {
+        matches!(
+            dt,
+            DataType::Primitive(PrimitiveType::Integer | PrimitiveType::String)
+                | DataType::Struct(_)
+                | DataType::Array(_)
+                | DataType::Map(_)
         )
     }
 
     fn schema_struct_with_float_inner() -> StructType {
-        let inner = StructType::new_unchecked(vec![StructField::new("f", DataType::FLOAT, true)]);
-        StructType::new_unchecked(vec![StructField::new(
+        let inner = StructType::new_unchecked(vec![StructField::nullable("f", DataType::FLOAT)]);
+        StructType::new_unchecked(vec![StructField::nullable(
             "s",
             DataType::Struct(Box::new(inner)),
-            true,
         )])
     }
 
+    fn schema_array_of_float() -> StructType {
+        StructType::new_unchecked(vec![StructField::nullable(
+            "arr",
+            DataType::Array(Box::new(ArrayType::new(DataType::FLOAT, true))),
+        )])
+    }
+
+    fn schema_map_key_float() -> StructType {
+        StructType::new_unchecked(vec![StructField::nullable(
+            "m",
+            DataType::Map(Box::new(MapType::new(
+                DataType::FLOAT,
+                DataType::STRING,
+                true,
+            ))),
+        )])
+    }
+
+    fn schema_map_value_float() -> StructType {
+        StructType::new_unchecked(vec![StructField::nullable(
+            "m",
+            DataType::Map(Box::new(MapType::new(
+                DataType::STRING,
+                DataType::FLOAT,
+                true,
+            ))),
+        )])
+    }
+
+    fn schema_float_long() -> StructType {
+        StructType::new_unchecked(vec![
+            StructField::nullable("a", DataType::LONG),
+            StructField::nullable("b", DataType::FLOAT),
+        ])
+    }
+
     #[rstest]
-    #[case::accept_int_string(simple_schema(), None)]
+    #[case::accept_int_string(narrow_allowlist, simple_schema(), None)]
     #[case::reject_top_level_array(
+        narrow_allowlist,
         schema_with_legacy_at("top"),
         Some("top (array<integer>)".to_string()),
     )]
-    #[case::reject_nested_primitive(
+    #[case::reject_nested_primitive_in_struct(
+        narrow_allowlist,
         schema_struct_with_float_inner(),
         Some("s.f (float)".to_string()),
     )]
-    fn type_allowlist_visitor_under_narrow_allowlist(
+    #[case::reject_primitive_inside_array(
+        wide_allowlist,
+        schema_array_of_float(),
+        Some("arr.element (float)".to_string()),
+    )]
+    #[case::reject_primitive_inside_map_key(
+        wide_allowlist,
+        schema_map_key_float(),
+        Some("m.key (float)".to_string()),
+    )]
+    #[case::reject_primitive_inside_map_value(
+        wide_allowlist,
+        schema_map_value_float(),
+        Some("m.value (float)".to_string()),
+    )]
+    #[case::first_offender_wins(
+        wide_allowlist,
+        schema_float_long(),
+        Some("a (long)".to_string()),
+    )]
+    fn type_allowlist_visitor(
+        #[case] is_supported: fn(&DataType) -> bool,
         #[case] schema: StructType,
         #[case] expected: Option<String>,
     ) {
         let mut v = TypeAllowlistVisitor {
-            is_supported: narrow_allowlist,
+            is_supported,
             offender: None,
             path: vec![],
         };

--- a/kernel/src/table_features/iceberg_compat/mod.rs
+++ b/kernel/src/table_features/iceberg_compat/mod.rs
@@ -1,0 +1,301 @@
+//! IcebergCompat invariant checks shared across versions.
+//!
+//! Each `delta.enableIcebergCompatV{N}` version owns a submodule (currently only
+//! [`v3`]), and exposes a single
+//! `pub(crate) const V{N}_VALIDATOR: IcebergCompatValidator`. Callers feed that
+//! constant to [`validate_iceberg_compat_if_needed`], the shared dispatcher.
+
+pub(crate) mod v3;
+
+use crate::schema::{ColumnMetadataKey, DataType, StructField};
+use crate::table_configuration::TableConfiguration;
+use crate::table_features::TableFeature;
+use crate::transforms::{transform_output_type, SchemaTransform};
+use crate::{DeltaResult, Error};
+
+pub(crate) enum IcebergCompatVersion {
+    // TODO: Add V1, V2 when kernel supports them.
+    V3,
+}
+
+impl IcebergCompatVersion {
+    /// Maps the version to the `TableFeature`.
+    pub(super) fn as_table_feature(&self) -> TableFeature {
+        match self {
+            Self::V3 => TableFeature::IcebergCompatV3,
+        }
+    }
+}
+
+/// A single invariant that must hold when an icebergCompat version is enabled.
+pub(crate) type IcebergCompatCheck = fn(&TableConfiguration) -> DeltaResult<()>;
+
+/// Pairs an [`IcebergCompatVersion`] with the ordered list of invariants that
+/// run when that version is enabled.
+pub(crate) struct IcebergCompatValidator {
+    pub(super) version: IcebergCompatVersion,
+    pub(super) checks: &'static [IcebergCompatCheck],
+}
+
+pub(crate) fn validate_iceberg_compat_if_needed(
+    tc: &TableConfiguration,
+    validator: &IcebergCompatValidator,
+) -> DeltaResult<()> {
+    if !tc.is_feature_enabled(&validator.version.as_table_feature()) {
+        return Ok(());
+    }
+    for check in validator.checks {
+        check(tc)?;
+    }
+    Ok(())
+}
+
+/// Walks `tc.logical_schema()` and errors on the first field whose data type
+/// fails `is_supported`. Reports the offending column path + type in the error.
+pub(super) fn has_only_supported_types(
+    tc: &TableConfiguration,
+    is_supported: fn(&DataType) -> bool,
+    feature_label: &str,
+) -> DeltaResult<()> {
+    let mut v = TypeAllowlistVisitor {
+        is_supported,
+        offender: None,
+        path: vec![],
+    };
+    v.transform_struct(&tc.logical_schema());
+    let Some(offender) = v.offender else {
+        return Ok(());
+    };
+    Err(Error::generic(format!(
+        "{feature_label} does not support type at column: {offender}",
+    )))
+}
+
+struct TypeAllowlistVisitor {
+    is_supported: fn(&DataType) -> bool,
+    offender: Option<String>,
+    path: Vec<String>,
+}
+
+impl<'a> SchemaTransform<'a> for TypeAllowlistVisitor {
+    transform_output_type!(|'a, T| ());
+
+    fn transform_struct_field(&mut self, f: &'a StructField) {
+        if self.offender.is_some() {
+            return;
+        }
+        self.path.push(f.name().to_string());
+        if !(self.is_supported)(f.data_type()) {
+            self.offender = Some(format!("{} ({})", self.path.join("."), f.data_type()));
+            return;
+        }
+        self.recurse_into_struct_field(f);
+        self.path.pop();
+    }
+}
+
+/// Rejects fields carrying the deprecated `parquet.field.nested.ids` metadata,
+/// which is superseded by `delta.columnMapping.nested.ids`.
+///
+/// Tracking: <https://github.com/delta-io/delta/issues/6688>
+pub(super) fn check_no_legacy_nested_ids(tc: &TableConfiguration) -> DeltaResult<()> {
+    let mut v = LegacyNestedIdsVisitor {
+        path: vec![],
+        offender: None,
+    };
+    v.transform_struct(&tc.logical_schema());
+    let Some(offender) = v.offender else {
+        return Ok(());
+    };
+    Err(Error::generic(format!(
+        "field `{offender}` carries deprecated `{}` metadata; use `{}` instead. \
+         See https://github.com/delta-io/delta/issues/6688",
+        ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
+        ColumnMetadataKey::ColumnMappingNestedIds.as_ref(),
+    )))
+}
+
+struct LegacyNestedIdsVisitor {
+    path: Vec<String>,
+    offender: Option<String>,
+}
+
+impl<'a> SchemaTransform<'a> for LegacyNestedIdsVisitor {
+    transform_output_type!(|'a, T| ());
+
+    fn transform_struct_field(&mut self, f: &'a StructField) {
+        if self.offender.is_some() {
+            return;
+        }
+        self.path.push(f.name().to_string());
+        if f.metadata()
+            .contains_key(ColumnMetadataKey::ParquetFieldNestedIds.as_ref())
+        {
+            self.offender = Some(self.path.join("."));
+            return;
+        }
+        self.recurse_into_struct_field(f);
+        self.path.pop();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+    use crate::schema::{ArrayType, MapType, MetadataValue, StructType};
+
+    fn field_with_metadata(name: &str, dtype: DataType, key: &str) -> StructField {
+        let mut f = StructField::nullable(name, dtype);
+        f.metadata.insert(
+            key.to_string(),
+            MetadataValue::Other(serde_json::json!({ "x.element": 1 })),
+        );
+        f
+    }
+
+    fn simple_schema() -> StructType {
+        StructType::new_unchecked(vec![
+            StructField::new("id", DataType::INTEGER, false),
+            StructField::new("name", DataType::STRING, true),
+        ])
+    }
+
+    fn schema_with_good_nested_ids() -> StructType {
+        StructType::new_unchecked(vec![field_with_metadata(
+            "x",
+            DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+            ColumnMetadataKey::ColumnMappingNestedIds.as_ref(),
+        )])
+    }
+
+    fn schema_with_legacy_at(name: &str) -> StructType {
+        StructType::new_unchecked(vec![field_with_metadata(
+            name,
+            DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+            ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
+        )])
+    }
+
+    fn schema_struct_with_legacy_at_inner() -> StructType {
+        let inner = StructType::new_unchecked(vec![field_with_metadata(
+            "inner",
+            DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+            ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
+        )]);
+        StructType::new_unchecked(vec![StructField::nullable(
+            "parent",
+            DataType::Struct(Box::new(inner)),
+        )])
+    }
+
+    fn schema_array_struct_with_legacy_at_inner() -> StructType {
+        let inner = StructType::new_unchecked(vec![field_with_metadata(
+            "inner",
+            DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+            ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
+        )]);
+        StructType::new_unchecked(vec![StructField::nullable(
+            "arr",
+            DataType::Array(Box::new(ArrayType::new(
+                DataType::Struct(Box::new(inner)),
+                true,
+            ))),
+        )])
+    }
+
+    fn schema_map_value_struct_with_legacy_at_inner() -> StructType {
+        let inner = StructType::new_unchecked(vec![field_with_metadata(
+            "inner",
+            DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+            ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
+        )]);
+        StructType::new_unchecked(vec![StructField::nullable(
+            "m",
+            DataType::Map(Box::new(MapType::new(
+                DataType::STRING,
+                DataType::Struct(Box::new(inner)),
+                true,
+            ))),
+        )])
+    }
+
+    fn schema_two_legacy_fields() -> StructType {
+        StructType::new_unchecked(vec![
+            field_with_metadata(
+                "a",
+                DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+                ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
+            ),
+            field_with_metadata(
+                "b",
+                DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+                ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
+            ),
+        ])
+    }
+
+    #[rstest]
+    #[case::clean_schema(simple_schema(), None)]
+    #[case::column_mapping_nested_id_key_only(schema_with_good_nested_ids(), None)]
+    #[case::top_level_legacy(schema_with_legacy_at("top"), Some("top".to_string()))]
+    #[case::nested_struct_legacy(schema_struct_with_legacy_at_inner(), Some("parent.inner".to_string()))]
+    #[case::array_struct_legacy(schema_array_struct_with_legacy_at_inner(), Some("arr.inner".to_string()))]
+    #[case::map_value_struct_legacy(schema_map_value_struct_with_legacy_at_inner(), Some("m.inner".to_string()))]
+    #[case::first_offender_wins(schema_two_legacy_fields(), Some("a".to_string()))]
+    fn legacy_nested_ids_visitor_finds_first_offender(
+        #[case] schema: StructType,
+        #[case] expected: Option<String>,
+    ) {
+        let mut v = LegacyNestedIdsVisitor {
+            path: vec![],
+            offender: None,
+        };
+        v.transform_struct(&schema);
+        assert_eq!(v.offender, expected);
+    }
+
+    // === TypeAllowlistVisitor tests  ===
+    //
+    /// Narrow allowlist: Integer, String, and Struct.
+    fn narrow_allowlist(dt: &DataType) -> bool {
+        use crate::schema::PrimitiveType::*;
+        matches!(
+            dt,
+            DataType::Primitive(Integer | String) | DataType::Struct(_)
+        )
+    }
+
+    fn schema_struct_with_float_inner() -> StructType {
+        let inner = StructType::new_unchecked(vec![StructField::new("f", DataType::FLOAT, true)]);
+        StructType::new_unchecked(vec![StructField::new(
+            "s",
+            DataType::Struct(Box::new(inner)),
+            true,
+        )])
+    }
+
+    #[rstest]
+    #[case::accept_int_string(simple_schema(), None)]
+    #[case::reject_top_level_array(
+        schema_with_legacy_at("top"),
+        Some("top (array<integer>)".to_string()),
+    )]
+    #[case::reject_nested_primitive(
+        schema_struct_with_float_inner(),
+        Some("s.f (float)".to_string()),
+    )]
+    fn type_allowlist_visitor_under_narrow_allowlist(
+        #[case] schema: StructType,
+        #[case] expected: Option<String>,
+    ) {
+        let mut v = TypeAllowlistVisitor {
+            is_supported: narrow_allowlist,
+            offender: None,
+            path: vec![],
+        };
+        v.transform_struct(&schema);
+        assert_eq!(v.offender, expected);
+    }
+}

--- a/kernel/src/table_features/iceberg_compat/mod.rs
+++ b/kernel/src/table_features/iceberg_compat/mod.rs
@@ -94,10 +94,10 @@ impl<'a> SchemaTransform<'a> for TypeAllowlistVisitor {
     }
 }
 
-/// Rejects fields carrying the deprecated `parquet.field.nested.ids` metadata,
-/// which is superseded by `delta.columnMapping.nested.ids`.
+/// `parquet.field.nested.ids` is to be deprecated in favor of `delta.columnMapping.nested.ids`.
+/// Validates that no fields in the schema have `parquet.field.nested.ids` metadata.
 ///
-/// Tracking: <https://github.com/delta-io/delta/issues/6688>
+/// Tracking issue: <https://github.com/delta-io/delta/issues/6688>
 pub(super) fn check_no_legacy_nested_ids(tc: &TableConfiguration) -> DeltaResult<()> {
     let mut v = LegacyNestedIdsVisitor {
         path: vec![],

--- a/kernel/src/table_features/iceberg_compat/mod.rs
+++ b/kernel/src/table_features/iceberg_compat/mod.rs
@@ -51,7 +51,7 @@ pub(crate) fn validate_iceberg_compat_if_needed(
 
 /// Walks `tc.logical_schema()` and errors on the first field whose data type
 /// fails `is_supported`. Reports the offending column path + type in the error.
-pub(super) fn has_only_supported_types(
+pub(super) fn check_only_supported_types(
     tc: &TableConfiguration,
     is_supported: fn(&DataType) -> bool,
     feature_label: &str,
@@ -83,6 +83,17 @@ impl TypeAllowlistVisitor {
             self.offender = Some(format!("{} ({})", self.path.join("."), dt));
         }
     }
+
+    /// Descend into a nested element type (array element, map key, or map value).
+    fn visit_nested(&mut self, seg: &str, ele_type: &DataType) {
+        if self.offender.is_some() {
+            return;
+        }
+        self.path.push(seg.to_string());
+        self.check(ele_type);
+        self.transform(ele_type);
+        self.path.pop();
+    }
 }
 
 impl<'a> SchemaTransform<'a> for TypeAllowlistVisitor {
@@ -99,33 +110,15 @@ impl<'a> SchemaTransform<'a> for TypeAllowlistVisitor {
     }
 
     fn transform_array_element(&mut self, etype: &'a DataType) {
-        if self.offender.is_some() {
-            return;
-        }
-        self.path.push("element".to_string());
-        self.check(etype);
-        self.transform(etype);
-        self.path.pop();
+        self.visit_nested("element", etype);
     }
 
     fn transform_map_key(&mut self, etype: &'a DataType) {
-        if self.offender.is_some() {
-            return;
-        }
-        self.path.push("key".to_string());
-        self.check(etype);
-        self.transform(etype);
-        self.path.pop();
+        self.visit_nested("key", etype);
     }
 
     fn transform_map_value(&mut self, etype: &'a DataType) {
-        if self.offender.is_some() {
-            return;
-        }
-        self.path.push("value".to_string());
-        self.check(etype);
-        self.transform(etype);
-        self.path.pop();
+        self.visit_nested("value", etype);
     }
 }
 
@@ -358,6 +351,27 @@ mod tests {
         ])
     }
 
+    /// `a: array<map<string, array<float>>>` followed by a sibling `b: array<float>`.
+    fn schema_deep_nesting_with_sibling() -> StructType {
+        StructType::new_unchecked(vec![
+            StructField::nullable(
+                "a",
+                DataType::Array(Box::new(ArrayType::new(
+                    DataType::Map(Box::new(MapType::new(
+                        DataType::STRING,
+                        DataType::Array(Box::new(ArrayType::new(DataType::FLOAT, true))),
+                        true,
+                    ))),
+                    true,
+                ))),
+            ),
+            StructField::nullable(
+                "b",
+                DataType::Array(Box::new(ArrayType::new(DataType::FLOAT, true))),
+            ),
+        ])
+    }
+
     #[rstest]
     #[case::accept_int_string(narrow_allowlist, simple_schema(), None)]
     #[case::reject_top_level_array(
@@ -389,6 +403,11 @@ mod tests {
         wide_allowlist,
         schema_float_long(),
         Some("a (long)".to_string()),
+    )]
+    #[case::reject_deep_then_short_circuits_sibling(
+        wide_allowlist,
+        schema_deep_nesting_with_sibling(),
+        Some("a.element.value.element (float)".to_string()),
     )]
     fn type_allowlist_visitor(
         #[case] is_supported: fn(&DataType) -> bool,

--- a/kernel/src/table_features/iceberg_compat/mod.rs
+++ b/kernel/src/table_features/iceberg_compat/mod.rs
@@ -146,6 +146,8 @@ mod tests {
     use super::*;
     use crate::schema::{ArrayType, MapType, MetadataValue, StructType};
 
+    // === LegacyNestedIdsVisitor: parquet.field.nested.ids detection ===
+
     fn field_with_metadata(name: &str, dtype: DataType, key: &str) -> StructField {
         let mut f = StructField::nullable(name, dtype);
         f.metadata.insert(

--- a/kernel/src/table_features/iceberg_compat/mod.rs
+++ b/kernel/src/table_features/iceberg_compat/mod.rs
@@ -3,7 +3,7 @@
 //! Each `delta.enableIcebergCompatV{N}` version owns a submodule (currently only
 //! [`v3`]), and exposes a single
 //! `pub(crate) const V{N}_VALIDATOR: IcebergCompatValidator`. Callers feed that
-//! constant to [`validate_iceberg_compat_if_needed`], the shared dispatcher.
+//! constant to [`validate_iceberg_compat_if_needed`].
 
 pub(crate) mod v3;
 
@@ -352,7 +352,7 @@ mod tests {
     }
 
     /// `a: array<map<string, array<float>>>` followed by a sibling `b: array<float>`.
-    fn schema_deep_nesting_with_sibling() -> StructType {
+    fn schema_deep_nested_float() -> StructType {
         StructType::new_unchecked(vec![
             StructField::nullable(
                 "a",
@@ -406,7 +406,7 @@ mod tests {
     )]
     #[case::reject_deep_then_short_circuits_sibling(
         wide_allowlist,
-        schema_deep_nesting_with_sibling(),
+        schema_deep_nested_float(),
         Some("a.element.value.element (float)".to_string()),
     )]
     fn type_allowlist_visitor(

--- a/kernel/src/table_features/iceberg_compat/mod.rs
+++ b/kernel/src/table_features/iceberg_compat/mod.rs
@@ -56,7 +56,7 @@ pub(super) fn check_only_supported_types(
     is_supported: fn(&DataType) -> bool,
     feature_label: &str,
 ) -> DeltaResult<()> {
-    let mut v = TypeAllowlistVisitor {
+    let mut v = TypeAllowListVisitor {
         is_supported,
         offender: None,
         path: vec![],
@@ -70,13 +70,18 @@ pub(super) fn check_only_supported_types(
     )))
 }
 
-struct TypeAllowlistVisitor {
+struct TypeAllowListVisitor {
     is_supported: fn(&DataType) -> bool,
+    /// The first unsupported field encountered, rendered as `<dotted.path> (<type>)`, or `None`
+    /// if every field is supported.
+    ///
+    /// For example, given schema `struct<events: array<struct<ts: timestamp>>>` (and assuming
+    /// `timestamp` is unsupported), the offender is `events.element.ts (timestamp)`.
     offender: Option<String>,
     path: Vec<String>,
 }
 
-impl TypeAllowlistVisitor {
+impl TypeAllowListVisitor {
     /// If `dt` isn't allowed, record it as the offender. No-op if an offender is already set.
     fn check(&mut self, dt: &DataType) {
         if self.offender.is_none() && !(self.is_supported)(dt) {
@@ -96,7 +101,7 @@ impl TypeAllowlistVisitor {
     }
 }
 
-impl<'a> SchemaTransform<'a> for TypeAllowlistVisitor {
+impl<'a> SchemaTransform<'a> for TypeAllowListVisitor {
     transform_output_type!(|'a, T| ());
 
     fn transform_struct_field(&mut self, f: &'a StructField) {
@@ -414,7 +419,7 @@ mod tests {
         #[case] schema: StructType,
         #[case] expected: Option<String>,
     ) {
-        let mut v = TypeAllowlistVisitor {
+        let mut v = TypeAllowListVisitor {
             is_supported,
             offender: None,
             path: vec![],

--- a/kernel/src/table_features/iceberg_compat/mod.rs
+++ b/kernel/src/table_features/iceberg_compat/mod.rs
@@ -94,10 +94,9 @@ impl<'a> SchemaTransform<'a> for TypeAllowlistVisitor {
     }
 }
 
-/// `parquet.field.nested.ids` is to be deprecated in favor of `delta.columnMapping.nested.ids`.
-/// Validates that no fields in the schema have `parquet.field.nested.ids` metadata.
+/// Rejects fields carrying the legacy `parquet.field.nested.ids` metadata.
 ///
-/// Tracking issue: <https://github.com/delta-io/delta/issues/6688>
+/// See <https://github.com/delta-io/delta/issues/6688>.
 pub(super) fn check_no_legacy_nested_ids(tc: &TableConfiguration) -> DeltaResult<()> {
     let mut v = LegacyNestedIdsVisitor {
         path: vec![],

--- a/kernel/src/table_features/iceberg_compat/v3.rs
+++ b/kernel/src/table_features/iceberg_compat/v3.rs
@@ -5,6 +5,7 @@ use super::{
     IcebergCompatVersion,
 };
 use crate::schema::DataType;
+use crate::schema::PrimitiveType::*;
 use crate::table_configuration::TableConfiguration;
 use crate::DeltaResult;
 
@@ -17,7 +18,6 @@ pub(crate) const V3_VALIDATOR: IcebergCompatValidator = IcebergCompatValidator {
 
 /// Returns `true` if `dt` is allowed at any level of the schema under V3.
 fn is_v3_supported_type(dt: &DataType) -> bool {
-    use crate::schema::PrimitiveType::*;
     matches!(
         dt,
         DataType::Primitive(
@@ -68,6 +68,7 @@ mod tests {
             DataType::DATE,
             DataType::TIMESTAMP,
             DataType::TIMESTAMP_NTZ,
+            DataType::decimal(10, 2).unwrap(),
         ];
         for dt in primitives {
             assert!(

--- a/kernel/src/table_features/iceberg_compat/v3.rs
+++ b/kernel/src/table_features/iceberg_compat/v3.rs
@@ -1,7 +1,7 @@
 //! IcebergCompatV3 checks.
 
 use super::{
-    check_no_legacy_nested_ids, has_only_supported_types, IcebergCompatValidator,
+    check_no_legacy_nested_ids, check_only_supported_types, IcebergCompatValidator,
     IcebergCompatVersion,
 };
 use crate::schema::DataType;
@@ -41,7 +41,7 @@ fn is_v3_supported_type(dt: &DataType) -> bool {
 }
 
 fn check_v3_supported_types(tc: &TableConfiguration) -> DeltaResult<()> {
-    has_only_supported_types(
+    check_only_supported_types(
         tc,
         is_v3_supported_type,
         IcebergCompatVersion::V3.as_table_feature().as_ref(),

--- a/kernel/src/table_features/iceberg_compat/v3.rs
+++ b/kernel/src/table_features/iceberg_compat/v3.rs
@@ -16,7 +16,6 @@ pub(crate) const V3_VALIDATOR: IcebergCompatValidator = IcebergCompatValidator {
     checks: &[check_v3_supported_types, check_no_legacy_nested_ids],
 };
 
-/// Returns `true` if `dt` is allowed at any level of the schema under V3.
 fn is_v3_supported_type(dt: &DataType) -> bool {
     matches!(
         dt,
@@ -54,7 +53,7 @@ mod tests {
     use crate::schema::{ArrayType, MapType, StructField, StructType};
 
     #[test]
-    fn is_v3_supported_type_accepts_every_current_datatype() {
+    fn is_v3_supported_type_accepted_datatypes() {
         let primitives = [
             DataType::STRING,
             DataType::LONG,

--- a/kernel/src/table_features/iceberg_compat/v3.rs
+++ b/kernel/src/table_features/iceberg_compat/v3.rs
@@ -1,0 +1,97 @@
+//! IcebergCompatV3 checks.
+
+use super::{
+    check_no_legacy_nested_ids, has_only_supported_types, IcebergCompatValidator,
+    IcebergCompatVersion,
+};
+use crate::schema::DataType;
+use crate::table_configuration::TableConfiguration;
+use crate::DeltaResult;
+
+/// V3 invariants paired with the version constant. Fed to
+/// [`super::validate_iceberg_compat_if_needed`].
+pub(crate) const V3_VALIDATOR: IcebergCompatValidator = IcebergCompatValidator {
+    version: IcebergCompatVersion::V3,
+    checks: &[check_v3_supported_types, check_no_legacy_nested_ids],
+};
+
+/// Returns `true` if `dt` is allowed at any level of the schema under V3.
+fn is_v3_supported_type(dt: &DataType) -> bool {
+    use crate::schema::PrimitiveType::*;
+    matches!(
+        dt,
+        DataType::Primitive(
+            Byte | Short
+                | Integer
+                | Long
+                | Float
+                | Double
+                | Boolean
+                | Binary
+                | String
+                | Date
+                | Timestamp
+                | TimestampNtz
+                | Decimal(_)
+        ) | DataType::Array(_)
+            | DataType::Map(_)
+            | DataType::Struct(_)
+            | DataType::Variant(_)
+    )
+}
+
+fn check_v3_supported_types(tc: &TableConfiguration) -> DeltaResult<()> {
+    has_only_supported_types(
+        tc,
+        is_v3_supported_type,
+        IcebergCompatVersion::V3.as_table_feature().as_ref(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::{ArrayType, MapType, StructField, StructType};
+
+    #[test]
+    fn is_v3_supported_type_accepts_every_current_datatype() {
+        let primitives = [
+            DataType::STRING,
+            DataType::LONG,
+            DataType::INTEGER,
+            DataType::SHORT,
+            DataType::BYTE,
+            DataType::FLOAT,
+            DataType::DOUBLE,
+            DataType::BOOLEAN,
+            DataType::BINARY,
+            DataType::DATE,
+            DataType::TIMESTAMP,
+            DataType::TIMESTAMP_NTZ,
+        ];
+        for dt in primitives {
+            assert!(
+                is_v3_supported_type(&dt),
+                "primitive {dt} should be V3-supported"
+            );
+        }
+        let nested = [
+            DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+            DataType::Map(Box::new(MapType::new(
+                DataType::STRING,
+                DataType::INTEGER,
+                true,
+            ))),
+            DataType::Struct(Box::new(StructType::new_unchecked([
+                StructField::nullable("x", DataType::INTEGER),
+            ]))),
+            DataType::unshredded_variant(),
+        ];
+        for dt in nested {
+            assert!(
+                is_v3_supported_type(&dt),
+                "nested {dt} should be V3-supported"
+            );
+        }
+    }
+}

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -432,8 +432,8 @@ static ICEBERG_COMPAT_V2_INFO: FeatureInfo = FeatureInfo {
 ///   always use INT64; INT96 is forbidden.
 /// - ALTER TABLE SET/UNSET TBLPROPERTIES: when supported, reject any property change that would
 ///   disable IcebergCompatV3 on an existing table.
-/// - Void type: when delta-spark supports VOID type on icebergCompatV3 tables, add it to the V3
-///   type allowlist (`iceberg_compat/v3.rs::is_v3_supported_type`).
+/// - Void type: when delta-spark supports VOID type on icebergCompatV3 tables, add it to V3's type
+///   allowlist (see the predicate fed to `has_only_supported_types` in `iceberg_compat::v3`).
 ///
 /// Tracking issue: <https://github.com/delta-io/delta-kernel-rs/issues/2492>
 static ICEBERG_COMPAT_V3_INFO: FeatureInfo = FeatureInfo {

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -432,7 +432,8 @@ static ICEBERG_COMPAT_V2_INFO: FeatureInfo = FeatureInfo {
 ///   always use INT64; INT96 is forbidden.
 /// - ALTER TABLE SET/UNSET TBLPROPERTIES: when supported, reject any property change that would
 ///   disable IcebergCompatV3 on an existing table.
-/// - Void type: when supported, it must not appear inside map or array types.
+/// - Void type: when delta-spark supports VOID type on icebergCompatV3 tables, add it to the V3
+///   type allowlist (`iceberg_compat/v3.rs::is_v3_supported_type`).
 ///
 /// Tracking issue: <https://github.com/delta-io/delta-kernel-rs/issues/2492>
 static ICEBERG_COMPAT_V3_INFO: FeatureInfo = FeatureInfo {

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -10,6 +10,8 @@ pub(crate) use column_mapping::{
     validate_column_mapping_id, SeenColumnMappingAnnotations,
 };
 use delta_kernel_derive::internal_api;
+pub(crate) use iceberg_compat::v3::V3_VALIDATOR;
+pub(crate) use iceberg_compat::validate_iceberg_compat_if_needed;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use strum::{AsRefStr, Display as StrumDisplay, EnumCount, EnumIter, EnumString};
@@ -25,6 +27,7 @@ use crate::table_properties::TableProperties;
 use crate::{DeltaResult, Error};
 
 mod column_mapping;
+mod iceberg_compat;
 mod timestamp_ntz;
 
 /// Minimum reader/writer protocol version that the kernel can handle.

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -433,7 +433,7 @@ static ICEBERG_COMPAT_V2_INFO: FeatureInfo = FeatureInfo {
 /// - ALTER TABLE SET/UNSET TBLPROPERTIES: when supported, reject any property change that would
 ///   disable IcebergCompatV3 on an existing table.
 /// - Void type: when delta-spark supports VOID type on icebergCompatV3 tables, add it to V3's type
-///   allowlist (see the predicate fed to `has_only_supported_types` in `iceberg_compat::v3`).
+///   allowlist (`is_v3_supported_type` in `iceberg_compat::v3`).
 ///
 /// Tracking issue: <https://github.com/delta-io/delta-kernel-rs/issues/2492>
 static ICEBERG_COMPAT_V3_INFO: FeatureInfo = FeatureInfo {


### PR DESCRIPTION
## What changes are proposed in this pull request?
Added a type allowlist for `icebergCompatV3` aligning with delta-spark and kernel-java, and an abstraction `IcebergCompatValidator` which is similar to kernel java.

This will disallow VOID type on `icebergCompatV3` tables, when we support VOID type. VOID type support PR just FYI: https://github.com/delta-io/delta-kernel-rs/pull/1858

<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

## How was this change tested?
`icebergCompatV3` is already covered by existing integration tests. Added unit tests for the allowlist
