### PR TITLE
feat: introduce PlanExecutor trait + basic plan IR

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -118,6 +118,9 @@ arrow-expression = ["need-arrow"]
 # Schema diffing functionality (experimental)
 schema-diff = []
 
+# Declarative plan execution via PlanExecutor trait (experimental)
+declarative-plans = []
+
 # this is an 'internal' feature flag which has all the shared bits from default-engine-native-tls
 # and default-engine-rustls
 default-engine-base = [

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -16,6 +16,12 @@ use crate::Version;
 /// A [`std::result::Result`] that has the kernel [`Error`] as the error variant
 pub type DeltaResult<T, E = Error> = std::result::Result<T, E>;
 
+/// A boxed, `Send` iterator of [`DeltaResult<T>`] items.
+///
+/// Convenience alias for the common pattern of returning a streaming, fallible iterator from
+/// kernel APIs.
+pub type DeltaResultIterator<T> = Box<dyn Iterator<Item = DeltaResult<T>> + Send>;
+
 /// All the types of errors that the kernel can run into
 #[non_exhaustive]
 #[derive(thiserror::Error, Debug)]

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -186,8 +186,7 @@ pub use expressions::{Expression, ExpressionRef, Predicate, PredicateRef};
 pub use log_compaction::{should_compact, LogCompactionWriter};
 #[cfg(feature = "declarative-plans")]
 pub use plans::{
-    IOOperation, Plan, PlanExecutor, PlanResult, QueryPlan, QueryPlanBuilder, QueryPlanNode,
-    ScanFileFormat,
+    IoOperation, Plan, PlanExecutor, PlanResult, QueryPlan, QueryPlanBuilder, QueryPlanNode,
 };
 use schema::{StructField, StructType};
 pub use snapshot::{Snapshot, SnapshotRef};

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -104,6 +104,8 @@ mod log_path;
 mod log_reader;
 pub mod metrics;
 pub mod partition;
+#[cfg(feature = "declarative-plans")]
+pub mod plans;
 pub mod scan;
 pub mod schema;
 pub mod snapshot;
@@ -178,10 +180,15 @@ use delta_kernel_derive::internal_api;
 pub use engine_data::{
     EngineData, FilteredEngineData, FilteredRowVisitor, GetData, RowIndexIterator, RowVisitor,
 };
-pub use error::{DeltaResult, Error};
+pub use error::{DeltaResult, DeltaResultIterator, Error};
 use expressions::{literal_expression_transform, Scalar};
 pub use expressions::{Expression, ExpressionRef, Predicate, PredicateRef};
 pub use log_compaction::{should_compact, LogCompactionWriter};
+#[cfg(feature = "declarative-plans")]
+pub use plans::{
+    IOOperation, Plan, PlanExecutor, PlanResult, QueryPlan, QueryPlanBuilder, QueryPlanNode,
+    ScanFileFormat,
+};
 use schema::{StructField, StructType};
 pub use snapshot::{Snapshot, SnapshotRef};
 
@@ -205,8 +212,7 @@ pub type FileSlice = (Url, Option<Range<FileIndex>>);
 pub type FileDataReadResult = (FileMeta, Box<dyn EngineData>);
 
 /// An iterator of data read from specified files
-pub type FileDataReadResultIterator =
-    Box<dyn Iterator<Item = DeltaResult<Box<dyn EngineData>>> + Send>;
+pub type FileDataReadResultIterator = DeltaResultIterator<Box<dyn EngineData>>;
 
 /// The metadata that describes an object.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -956,6 +962,15 @@ pub trait Engine: AsAny {
 
     /// Get the connector provided [`ParquetHandler`].
     fn parquet_handler(&self) -> Arc<dyn ParquetHandler>;
+
+    /// Get the connector provided [`PlanExecutor`].
+    ///
+    /// The default implementation panics for now because the feature is still under development.
+    #[cfg(feature = "declarative-plans")]
+    #[allow(clippy::panic)]
+    fn plan_executor(&self) -> Arc<dyn PlanExecutor> {
+        unimplemented!("this engine does not provide a PlanExecutor")
+    }
 }
 
 // we have an 'internal' feature flag: default-engine-base, which is actually just the shared

--- a/kernel/src/plans/ir.rs
+++ b/kernel/src/plans/ir.rs
@@ -1,0 +1,153 @@
+//! Intermediate representation (IR) for declarative plans.
+//!
+//! The top-level type is a [`Plan`], which communicates to the
+//! [`PlanExecutor`](super::PlanExecutor) what to do.
+
+use bytes::Bytes;
+use url::Url;
+
+use crate::schema::SchemaRef;
+use crate::{FileMeta, FileSlice, PredicateRef};
+
+/// Represents a set of instructions that the [`PlanExecutor`](super::PlanExecutor) should perform.
+///
+/// It can either be an IO operation or a declarative query.
+#[derive(Debug)]
+pub enum Plan {
+    /// A singular I/O operation that returns concretely typed data such as bytes or file metadata.
+    IOOperation(IOOperation),
+    /// A data-intensive query on relational data, expressed through a SQL-like plan algebra.
+    QueryPlan(QueryPlan),
+}
+
+/// A singular I/O operation that returns typed data such as raw bytes or file metadata.
+///
+/// Each variant describes an operation and its parameters. The shape of the result it produces
+/// is documented on the variant in terms of [`PlanResult`](super::PlanResult).
+#[derive(Debug)]
+pub enum IOOperation {
+    /// List files at the given URL.
+    ///
+    /// Should return a [`PlanResult::FileMetaIter`](super::PlanResult::FileMetaIter) with one
+    /// entry per file. Files are returned sorted lexicographically by path. If the URL is
+    /// directory-like (ends with '/'), all files in that directory are listed. Otherwise,
+    /// files lexicographically greater than the given path are listed.
+    FileListing {
+        /// The URL to list from.
+        url: Url,
+    },
+    /// Read raw bytes from one or more files (or byte ranges within files).
+    ///
+    /// Each [`FileSlice`] specifies a file URL and an optional byte range. Results are returned
+    /// as [`PlanResult::BytesIter`](super::PlanResult::BytesIter) in the same order as the
+    /// input slices, with one Bytes buffer per file slice.
+    ReadBytes {
+        /// The file slices to read.
+        files: Vec<FileSlice>,
+    },
+    /// Write raw bytes to a file at the given URL.
+    ///
+    /// Returns [`PlanResult::Unit`](super::PlanResult::Unit) on success. If `overwrite` is false
+    /// and the file already exists, the executor should return
+    /// [`Error::FileAlreadyExists`](crate::Error::FileAlreadyExists).
+    WriteBytes {
+        /// The destination URL.
+        url: Url,
+        /// The data to write.
+        data: Bytes,
+        /// Whether to overwrite an existing file.
+        overwrite: bool,
+    },
+    /// Retrieve metadata for a single file (HEAD request).
+    ///
+    /// Returns [`PlanResult::FileMeta`](super::PlanResult::FileMeta). If the file does not
+    /// exist, the executor should return an error.
+    HeadFile {
+        /// The URL of the file to inspect.
+        url: Url,
+    },
+    /// Atomically copy a file from `source` to `destination`.
+    ///
+    /// The copy must be atomic: if `destination` already exists, the executor should return
+    /// [`Error::FileAlreadyExists`](crate::Error::FileAlreadyExists) without modifying it.
+    /// Returns [`PlanResult::Unit`](super::PlanResult::Unit) on success.
+    AtomicCopy {
+        /// The URL of the file to copy from.
+        source: Url,
+        /// The URL to copy to. Must not already exist.
+        destination: Url,
+    },
+}
+
+impl IOOperation {
+    /// Construct a [`Self::FileListing`] over the given URL.
+    pub fn file_listing(url: Url) -> Self {
+        Self::FileListing { url }
+    }
+
+    /// Construct a [`Self::ReadBytes`] over the given file slices.
+    pub fn read_bytes(files: Vec<FileSlice>) -> Self {
+        Self::ReadBytes { files }
+    }
+
+    /// Construct a [`Self::WriteBytes`] for the given URL.
+    pub fn write_bytes(url: Url, data: Bytes, overwrite: bool) -> Self {
+        Self::WriteBytes {
+            url,
+            data,
+            overwrite,
+        }
+    }
+
+    /// Construct a [`Self::HeadFile`] for the given URL.
+    pub fn head_file(url: Url) -> Self {
+        Self::HeadFile { url }
+    }
+
+    /// Construct a [`Self::AtomicCopy`] from `source` to `destination`.
+    pub fn atomic_copy(source: Url, destination: Url) -> Self {
+        Self::AtomicCopy {
+            source,
+            destination,
+        }
+    }
+}
+
+/// Representation of a SQL-like query on relational data.
+///
+/// TODO: We expect this to evolve as we flesh out the plan algebra (e.g. towards SSA form
+/// with multiple linked nodes), but for now a [`QueryPlan`] holds a single [`QueryPlanNode`].
+pub type QueryPlan = QueryPlanNode;
+
+/// A single node in a [`QueryPlan`]. Each variant describes a relational operation.
+#[derive(Debug)]
+pub enum QueryPlanNode {
+    /// Read and parse structured data files (Parquet or JSON), returning columnar data.
+    ///
+    /// Returns [`PlanResult::UnboundedData`](super::PlanResult::UnboundedData) with columns
+    /// matching the provided `physical_schema`. See [`JsonHandler::read_json_files`] and
+    /// [`ParquetHandler::read_parquet_files`] for more details on column resolution rules and
+    /// ordering contracts.
+    ///
+    /// [`JsonHandler::read_json_files`]: crate::JsonHandler::read_json_files
+    /// [`ParquetHandler::read_parquet_files`]: crate::ParquetHandler::read_parquet_files
+    Scan {
+        /// The format of the files to read.
+        format: ScanFileFormat,
+        /// Metadata for each file to read.
+        files: Vec<FileMeta>,
+        /// Select list and order of columns to read.
+        physical_schema: SchemaRef,
+        /// Optional push-down predicate hint (the executor is free to ignore it)
+        predicate: Option<PredicateRef>,
+    },
+}
+
+/// The file format for a Scan operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScanFileFormat {
+    /// Apache Parquet format.
+    Parquet,
+    /// Newline-delimited JSON format.
+    Json,
+}

--- a/kernel/src/plans/ir.rs
+++ b/kernel/src/plans/ir.rs
@@ -16,7 +16,7 @@ use crate::{FileMeta, FileSlice, PredicateRef};
 pub enum Plan {
     /// A singular I/O operation that returns concretely typed data such as bytes or file metadata.
     IOOperation(IOOperation),
-    /// A data-intensive query on relational data, expressed through a SQL-like plan algebra.
+    /// A query on relational-like data, expressed through a plan algebra.
     QueryPlan(QueryPlan),
 }
 
@@ -26,12 +26,12 @@ pub enum Plan {
 /// is documented on the variant in terms of [`PlanResult`](super::PlanResult).
 #[derive(Debug)]
 pub enum IOOperation {
-    /// List files at the given URL.
+    /// Recursively list files at the given URL.
     ///
     /// Should return a [`PlanResult::FileMetaIter`](super::PlanResult::FileMetaIter) with one
     /// entry per file. Files are returned sorted lexicographically by path. If the URL is
-    /// directory-like (ends with '/'), all files in that directory are listed. Otherwise,
-    /// files lexicographically greater than the given path are listed.
+    /// directory-like (ends with '/'), all files (recursively)in that directory are listed.
+    /// Otherwise, files lexicographically greater than the given path are listed.
     FileListing {
         /// The URL to list from.
         url: Url,
@@ -113,7 +113,7 @@ impl IOOperation {
     }
 }
 
-/// Representation of a SQL-like query on relational data.
+/// Representation of a query on relational data.
 ///
 /// TODO: We expect this to evolve as we flesh out the plan algebra (e.g. towards SSA form
 /// with multiple linked nodes), but for now a [`QueryPlan`] holds a single [`QueryPlanNode`].

--- a/kernel/src/plans/ir.rs
+++ b/kernel/src/plans/ir.rs
@@ -36,7 +36,7 @@ pub enum IoOperation {
     /// Read raw bytes from one or more files (or byte ranges within files).
     ///
     /// Each [`FileSlice`] specifies a file URL and an optional byte range. Results are returned
-    /// as [`PlanResult::BytesIter`](super::PlanResult::BytesIter) in the same order as the
+    /// as [`PlanResult::Bytes`](super::PlanResult::Bytes) in the same order as the
     /// input slices, with one Bytes buffer per file slice.
     ReadBytes { files: Vec<FileSlice> },
     /// Write raw bytes to a file at the given URL.

--- a/kernel/src/plans/ir.rs
+++ b/kernel/src/plans/ir.rs
@@ -15,7 +15,7 @@ use crate::{FileMeta, FileSlice, PredicateRef};
 #[derive(Debug)]
 pub enum Plan {
     /// A singular I/O operation that returns concretely typed data such as bytes or file metadata.
-    IOOperation(IOOperation),
+    IoOperation(IoOperation),
     /// A query on relational-like data, expressed through a plan algebra.
     QueryPlan(QueryPlan),
 }
@@ -25,72 +25,52 @@ pub enum Plan {
 /// Each variant describes an operation and its parameters. The shape of the result it produces
 /// is documented on the variant in terms of [`PlanResult`](super::PlanResult).
 #[derive(Debug)]
-pub enum IOOperation {
+pub enum IoOperation {
     /// Recursively list files at the given URL.
     ///
-    /// Should return a [`PlanResult::FileMetaIter`](super::PlanResult::FileMetaIter) with one
-    /// entry per file. Files are returned sorted lexicographically by path. If the URL is
-    /// directory-like (ends with '/'), all files (recursively)in that directory are listed.
-    /// Otherwise, files lexicographically greater than the given path are listed.
-    FileListing {
-        /// The URL to list from.
-        url: Url,
-    },
+    /// Should return a [`PlanResult::FileMeta`](super::PlanResult::FileMeta) with one entry per
+    /// file. See [`StorageHandler::list_from`] for more details on the ordering contract.
+    ///
+    /// [`StorageHandler::list_from`]: crate::StorageHandler::list_from
+    FileListing { url: Url },
     /// Read raw bytes from one or more files (or byte ranges within files).
     ///
     /// Each [`FileSlice`] specifies a file URL and an optional byte range. Results are returned
     /// as [`PlanResult::BytesIter`](super::PlanResult::BytesIter) in the same order as the
     /// input slices, with one Bytes buffer per file slice.
-    ReadBytes {
-        /// The file slices to read.
-        files: Vec<FileSlice>,
-    },
+    ReadBytes { files: Vec<FileSlice> },
     /// Write raw bytes to a file at the given URL.
     ///
     /// Returns [`PlanResult::Unit`](super::PlanResult::Unit) on success. If `overwrite` is false
     /// and the file already exists, the executor should return
     /// [`Error::FileAlreadyExists`](crate::Error::FileAlreadyExists).
     WriteBytes {
-        /// The destination URL.
         url: Url,
-        /// The data to write.
         data: Bytes,
-        /// Whether to overwrite an existing file.
         overwrite: bool,
     },
     /// Retrieve metadata for a single file (HEAD request).
     ///
-    /// Returns [`PlanResult::FileMeta`](super::PlanResult::FileMeta). If the file does not
-    /// exist, the executor should return an error.
-    HeadFile {
-        /// The URL of the file to inspect.
-        url: Url,
-    },
+    /// Returns [`PlanResult::FileMeta`](super::PlanResult::FileMeta) with a single entry.
+    /// If the file does not exist, the executor should return an error.
+    HeadFile { url: Url },
     /// Atomically copy a file from `source` to `destination`.
     ///
     /// The copy must be atomic: if `destination` already exists, the executor should return
     /// [`Error::FileAlreadyExists`](crate::Error::FileAlreadyExists) without modifying it.
     /// Returns [`PlanResult::Unit`](super::PlanResult::Unit) on success.
-    AtomicCopy {
-        /// The URL of the file to copy from.
-        source: Url,
-        /// The URL to copy to. Must not already exist.
-        destination: Url,
-    },
+    AtomicCopy { source: Url, destination: Url },
 }
 
-impl IOOperation {
-    /// Construct a [`Self::FileListing`] over the given URL.
+impl IoOperation {
     pub fn file_listing(url: Url) -> Self {
         Self::FileListing { url }
     }
 
-    /// Construct a [`Self::ReadBytes`] over the given file slices.
     pub fn read_bytes(files: Vec<FileSlice>) -> Self {
         Self::ReadBytes { files }
     }
 
-    /// Construct a [`Self::WriteBytes`] for the given URL.
     pub fn write_bytes(url: Url, data: Bytes, overwrite: bool) -> Self {
         Self::WriteBytes {
             url,
@@ -99,12 +79,10 @@ impl IOOperation {
         }
     }
 
-    /// Construct a [`Self::HeadFile`] for the given URL.
     pub fn head_file(url: Url) -> Self {
         Self::HeadFile { url }
     }
 
-    /// Construct a [`Self::AtomicCopy`] from `source` to `destination`.
     pub fn atomic_copy(source: Url, destination: Url) -> Self {
         Self::AtomicCopy {
             source,
@@ -122,32 +100,28 @@ pub type QueryPlan = QueryPlanNode;
 /// A single node in a [`QueryPlan`]. Each variant describes a relational operation.
 #[derive(Debug)]
 pub enum QueryPlanNode {
-    /// Read and parse structured data files (Parquet or JSON), returning columnar data.
+    /// Read and parse newline-delimited JSON files, returning columnar data.
     ///
-    /// Returns [`PlanResult::UnboundedData`](super::PlanResult::UnboundedData) with columns
-    /// matching the provided `physical_schema`. See [`JsonHandler::read_json_files`] and
-    /// [`ParquetHandler::read_parquet_files`] for more details on column resolution rules and
-    /// ordering contracts.
+    /// Returns [`PlanResult::Data`](super::PlanResult::Data) with columns matching the provided
+    /// `physical_schema`. See [`JsonHandler::read_json_files`] for more details on column
+    /// resolution rules and ordering contracts.
     ///
     /// [`JsonHandler::read_json_files`]: crate::JsonHandler::read_json_files
-    /// [`ParquetHandler::read_parquet_files`]: crate::ParquetHandler::read_parquet_files
-    Scan {
-        /// The format of the files to read.
-        format: ScanFileFormat,
-        /// Metadata for each file to read.
+    ScanJson {
         files: Vec<FileMeta>,
-        /// Select list and order of columns to read.
         physical_schema: SchemaRef,
-        /// Optional push-down predicate hint (the executor is free to ignore it)
         predicate: Option<PredicateRef>,
     },
-}
-
-/// The file format for a Scan operation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ScanFileFormat {
-    /// Apache Parquet format.
-    Parquet,
-    /// Newline-delimited JSON format.
-    Json,
+    /// Read and parse Apache Parquet files, returning columnar data.
+    ///
+    /// Returns [`PlanResult::Data`](super::PlanResult::Data) with columns matching the provided
+    /// `physical_schema`. See [`ParquetHandler::read_parquet_files`] for more details on column
+    /// resolution rules and ordering contracts.
+    ///
+    /// [`ParquetHandler::read_parquet_files`]: crate::ParquetHandler::read_parquet_files
+    ScanParquet {
+        files: Vec<FileMeta>,
+        physical_schema: SchemaRef,
+        predicate: Option<PredicateRef>,
+    },
 }

--- a/kernel/src/plans/mod.rs
+++ b/kernel/src/plans/mod.rs
@@ -5,7 +5,7 @@ mod ir;
 mod query_builder;
 
 use bytes::Bytes;
-pub use ir::{IOOperation, Plan, QueryPlan, QueryPlanNode, ScanFileFormat};
+pub use ir::{IoOperation, Plan, QueryPlan, QueryPlanNode};
 pub use query_builder::QueryPlanBuilder;
 
 use crate::{AsAny, DeltaResult, DeltaResultIterator, EngineData, FileMeta};
@@ -13,7 +13,7 @@ use crate::{AsAny, DeltaResult, DeltaResultIterator, EngineData, FileMeta};
 /// Provides the ability to execute declarative plans to the Delta Kernel.
 ///
 /// This gives the kernel the ability to execute data-intensive operations by constructing a
-/// declarative, SQL-like plan algebra, without prescribing *how* to do it.
+/// declarative, relational plan algebra, without prescribing *how* to do it.
 pub trait PlanExecutor: AsAny {
     /// Executes the given declarative plan and return the result.
     fn execute_plan(&self, plan: Plan) -> DeltaResult<PlanResult>;
@@ -23,16 +23,12 @@ pub trait PlanExecutor: AsAny {
 ///
 /// Each variant describes a different shape of output that a plan can possibly produce.
 pub enum PlanResult {
-    /// A single data batch (as an EngineData) produced by the plan.
-    BoundedData(Box<dyn EngineData>),
-    /// An unbounded iterator of data batches (as EngineData) produced by the plan.
-    UnboundedData(DeltaResultIterator<Box<dyn EngineData>>),
-    /// A single file's metadata.
-    FileMeta(FileMeta),
-    /// An unbounded iterator of file metadata entries.
-    FileMetaIter(DeltaResultIterator<FileMeta>),
-    /// An unbounded iterator of raw byte buffers.
-    BytesIter(DeltaResultIterator<Bytes>),
+    /// A stream of columnar data batches (as [`EngineData`]) produced by the plan.
+    Data(DeltaResultIterator<Box<dyn EngineData>>),
+    /// A stream of file metadata entries.
+    FileMeta(DeltaResultIterator<FileMeta>),
+    /// A stream of raw byte buffers.
+    Bytes(DeltaResultIterator<Bytes>),
     /// Represents the successful completion of a plan, but with no return value.
     Unit,
 }

--- a/kernel/src/plans/mod.rs
+++ b/kernel/src/plans/mod.rs
@@ -1,0 +1,38 @@
+//! This module defines the concept of a PlanExecutor and its associated input + output types.
+//!
+//! This module is opt-in behind the `declarative-plans` feature flag.
+mod ir;
+mod query_builder;
+
+use bytes::Bytes;
+pub use ir::{IOOperation, Plan, QueryPlan, QueryPlanNode, ScanFileFormat};
+pub use query_builder::QueryPlanBuilder;
+
+use crate::{AsAny, DeltaResult, DeltaResultIterator, EngineData, FileMeta};
+
+/// Provides the ability to execute declarative plans to the Delta Kernel.
+///
+/// This gives the kernel the ability to execute data-intensive operations by constructing a
+/// declarative, SQL-like plan algebra, without prescribing *how* to do it.
+pub trait PlanExecutor: AsAny {
+    /// Executes the given declarative plan and return the result.
+    fn execute_plan(&self, plan: Plan) -> DeltaResult<PlanResult>;
+}
+
+/// The result of executing a [`Plan`].
+///
+/// Each variant describes a different shape of output that a plan can possibly produce.
+pub enum PlanResult {
+    /// A single data batch (as an EngineData) produced by the plan.
+    BoundedData(Box<dyn EngineData>),
+    /// An unbounded iterator of data batches (as EngineData) produced by the plan.
+    UnboundedData(DeltaResultIterator<Box<dyn EngineData>>),
+    /// A single file's metadata.
+    FileMeta(FileMeta),
+    /// An unbounded iterator of file metadata entries.
+    FileMetaIter(DeltaResultIterator<FileMeta>),
+    /// An unbounded iterator of raw byte buffers
+    BytesIter(DeltaResultIterator<Bytes>),
+    /// Represents the successful completion of a plan, but with no return value
+    Unit,
+}

--- a/kernel/src/plans/mod.rs
+++ b/kernel/src/plans/mod.rs
@@ -31,8 +31,8 @@ pub enum PlanResult {
     FileMeta(FileMeta),
     /// An unbounded iterator of file metadata entries.
     FileMetaIter(DeltaResultIterator<FileMeta>),
-    /// An unbounded iterator of raw byte buffers
+    /// An unbounded iterator of raw byte buffers.
     BytesIter(DeltaResultIterator<Bytes>),
-    /// Represents the successful completion of a plan, but with no return value
+    /// Represents the successful completion of a plan, but with no return value.
     Unit,
 }

--- a/kernel/src/plans/query_builder.rs
+++ b/kernel/src/plans/query_builder.rs
@@ -1,6 +1,6 @@
 //! Builder API for constructing a [`QueryPlan`].
 
-use super::ir::{QueryPlanNode, ScanFileFormat};
+use super::ir::QueryPlanNode;
 use crate::schema::SchemaRef;
 use crate::{DeltaResult, FileMeta, PredicateRef, QueryPlan};
 
@@ -14,18 +14,33 @@ pub struct QueryPlanBuilder {
 }
 
 impl QueryPlanBuilder {
-    /// Construct a [`QueryPlanNode::Scan`] over the given files.
+    /// Construct a [`QueryPlanNode::ScanJson`] over the given files.
     ///
-    /// See [`QueryPlanNode::Scan`] for the parameter semantics.
-    pub fn scan(
-        format: ScanFileFormat,
+    /// See [`QueryPlanNode::ScanJson`] for the parameter semantics.
+    pub fn scan_json(
         files: Vec<FileMeta>,
         physical_schema: SchemaRef,
         predicate: Option<PredicateRef>,
     ) -> Self {
         Self {
-            node: QueryPlanNode::Scan {
-                format,
+            node: QueryPlanNode::ScanJson {
+                files,
+                physical_schema,
+                predicate,
+            },
+        }
+    }
+
+    /// Construct a [`QueryPlanNode::ScanParquet`] over the given files.
+    ///
+    /// See [`QueryPlanNode::ScanParquet`] for the parameter semantics.
+    pub fn scan_parquet(
+        files: Vec<FileMeta>,
+        physical_schema: SchemaRef,
+        predicate: Option<PredicateRef>,
+    ) -> Self {
+        Self {
+            node: QueryPlanNode::ScanParquet {
                 files,
                 physical_schema,
                 predicate,
@@ -65,25 +80,47 @@ mod tests {
     }
 
     #[test]
-    fn scan_constructs_scan_node() {
+    fn scan_parquet_constructs_scan_parquet_node() {
         let schema = test_schema();
         let files = vec![
             test_file("file:///a.parquet"),
             test_file("file:///b.parquet"),
         ];
 
-        let node =
-            QueryPlanBuilder::scan(ScanFileFormat::Parquet, files.clone(), schema.clone(), None)
-                .build()
-                .unwrap();
+        let node = QueryPlanBuilder::scan_parquet(files.clone(), schema.clone(), None)
+            .build()
+            .unwrap();
 
-        let QueryPlanNode::Scan {
-            format,
+        let QueryPlanNode::ScanParquet {
             files: scan_files,
             physical_schema,
             predicate,
-        } = node;
-        assert_eq!(format, ScanFileFormat::Parquet);
+        } = node
+        else {
+            panic!("expected ScanParquet, got {node:?}");
+        };
+        assert_eq!(scan_files, files);
+        assert!(Arc::ptr_eq(&physical_schema, &schema));
+        assert!(predicate.is_none());
+    }
+
+    #[test]
+    fn scan_json_constructs_scan_json_node() {
+        let schema = test_schema();
+        let files = vec![test_file("file:///a.json"), test_file("file:///b.json")];
+
+        let node = QueryPlanBuilder::scan_json(files.clone(), schema.clone(), None)
+            .build()
+            .unwrap();
+
+        let QueryPlanNode::ScanJson {
+            files: scan_files,
+            physical_schema,
+            predicate,
+        } = node
+        else {
+            panic!("expected ScanJson, got {node:?}");
+        };
         assert_eq!(scan_files, files);
         assert!(Arc::ptr_eq(&physical_schema, &schema));
         assert!(predicate.is_none());

--- a/kernel/src/plans/query_builder.rs
+++ b/kernel/src/plans/query_builder.rs
@@ -1,50 +1,41 @@
 //! Builder API for constructing a [`QueryPlan`].
 
-use super::ir::{QueryPlan, QueryPlanNode, ScanFileFormat};
+use super::ir::{QueryPlanNode, ScanFileFormat};
 use crate::schema::SchemaRef;
-use crate::{DeltaResult, Error, FileMeta, PredicateRef};
+use crate::{DeltaResult, FileMeta, PredicateRef, QueryPlan};
 
 /// Builder for constructing a [`QueryPlan`].
 ///
 /// TODO: We expect this to evolve to support multi-node plans. For now it just supports a
 /// single node.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct QueryPlanBuilder {
-    node: Option<QueryPlanNode>,
+    node: QueryPlanNode,
 }
 
 impl QueryPlanBuilder {
-    /// Create a new, empty builder.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Set the builder's node to a [`QueryPlanNode::Scan`] over the given files.
+    /// Construct a [`QueryPlanNode::Scan`] over the given files.
     ///
-    /// See [`QueryPlanNode::Scan`] for the parameter semantics. Calling this method overwrites
-    /// any previously configured node.
+    /// See [`QueryPlanNode::Scan`] for the parameter semantics.
     pub fn scan(
-        mut self,
         format: ScanFileFormat,
         files: Vec<FileMeta>,
         physical_schema: SchemaRef,
         predicate: Option<PredicateRef>,
     ) -> Self {
-        self.node = Some(QueryPlanNode::Scan {
-            format,
-            files,
-            physical_schema,
-            predicate,
-        });
-        self
+        Self {
+            node: QueryPlanNode::Scan {
+                format,
+                files,
+                physical_schema,
+                predicate,
+            },
+        }
     }
 
     /// Consume the builder and produce a [`QueryPlan`].
-    ///
-    /// Returns [`Error::Generic`] if no node was configured on the builder.
     pub fn build(self) -> DeltaResult<QueryPlan> {
-        self.node
-            .ok_or_else(|| Error::generic("QueryPlanBuilder: no node configured"))
+        Ok(self.node)
     }
 }
 
@@ -52,7 +43,6 @@ impl QueryPlanBuilder {
 mod tests {
     use std::sync::Arc;
 
-    use test_utils::assert_result_error_with_message;
     use url::Url;
 
     use super::*;
@@ -75,30 +65,24 @@ mod tests {
     }
 
     #[test]
-    fn build_without_node_errors() {
-        let result = QueryPlanBuilder::new().build();
-        assert_result_error_with_message(result, "no node configured");
-    }
-
-    #[test]
-    fn build_scan_node() {
+    fn scan_constructs_scan_node() {
         let schema = test_schema();
         let files = vec![
             test_file("file:///a.parquet"),
             test_file("file:///b.parquet"),
         ];
 
-        let plan = QueryPlanBuilder::new()
-            .scan(ScanFileFormat::Parquet, files.clone(), schema.clone(), None)
-            .build()
-            .unwrap();
+        let node =
+            QueryPlanBuilder::scan(ScanFileFormat::Parquet, files.clone(), schema.clone(), None)
+                .build()
+                .unwrap();
 
         let QueryPlanNode::Scan {
             format,
             files: scan_files,
             physical_schema,
             predicate,
-        } = plan;
+        } = node;
         assert_eq!(format, ScanFileFormat::Parquet);
         assert_eq!(scan_files, files);
         assert!(Arc::ptr_eq(&physical_schema, &schema));

--- a/kernel/src/plans/query_builder.rs
+++ b/kernel/src/plans/query_builder.rs
@@ -1,0 +1,107 @@
+//! Builder API for constructing a [`QueryPlan`].
+
+use super::ir::{QueryPlan, QueryPlanNode, ScanFileFormat};
+use crate::schema::SchemaRef;
+use crate::{DeltaResult, Error, FileMeta, PredicateRef};
+
+/// Builder for constructing a [`QueryPlan`].
+///
+/// TODO: We expect this to evolve to support multi-node plans. For now it just supports a
+/// single node.
+#[derive(Debug, Default)]
+pub struct QueryPlanBuilder {
+    node: Option<QueryPlanNode>,
+}
+
+impl QueryPlanBuilder {
+    /// Create a new, empty builder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the builder's node to a [`QueryPlanNode::Scan`] over the given files.
+    ///
+    /// See [`QueryPlanNode::Scan`] for the parameter semantics. Calling this method overwrites
+    /// any previously configured node.
+    pub fn scan(
+        mut self,
+        format: ScanFileFormat,
+        files: Vec<FileMeta>,
+        physical_schema: SchemaRef,
+        predicate: Option<PredicateRef>,
+    ) -> Self {
+        self.node = Some(QueryPlanNode::Scan {
+            format,
+            files,
+            physical_schema,
+            predicate,
+        });
+        self
+    }
+
+    /// Consume the builder and produce a [`QueryPlan`].
+    ///
+    /// Returns [`Error::Generic`] if no node was configured on the builder.
+    pub fn build(self) -> DeltaResult<QueryPlan> {
+        self.node
+            .ok_or_else(|| Error::generic("QueryPlanBuilder: no node configured"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use test_utils::assert_result_error_with_message;
+    use url::Url;
+
+    use super::*;
+    use crate::schema::{DataType, StructField, StructType};
+    use crate::FileMeta;
+
+    fn test_schema() -> SchemaRef {
+        Arc::new(StructType::new_unchecked([StructField::not_null(
+            "id",
+            DataType::LONG,
+        )]))
+    }
+
+    fn test_file(path: &str) -> FileMeta {
+        FileMeta {
+            location: Url::parse(path).unwrap(),
+            last_modified: 0,
+            size: 0,
+        }
+    }
+
+    #[test]
+    fn build_without_node_errors() {
+        let result = QueryPlanBuilder::new().build();
+        assert_result_error_with_message(result, "no node configured");
+    }
+
+    #[test]
+    fn build_scan_node() {
+        let schema = test_schema();
+        let files = vec![
+            test_file("file:///a.parquet"),
+            test_file("file:///b.parquet"),
+        ];
+
+        let plan = QueryPlanBuilder::new()
+            .scan(ScanFileFormat::Parquet, files.clone(), schema.clone(), None)
+            .build()
+            .unwrap();
+
+        let QueryPlanNode::Scan {
+            format,
+            files: scan_files,
+            physical_schema,
+            predicate,
+        } = plan;
+        assert_eq!(format, ScanFileFormat::Parquet);
+        assert_eq!(scan_files, files);
+        assert!(Arc::ptr_eq(&physical_schema, &schema));
+        assert!(predicate.is_none());
+    }
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR introduces a `PlanExecutor` trait which will allow the Engine to provide an implementation for executing "logical plans". It also introduces a basic IR for representing plans. All of this is gated behind a `declarative-plans` feature flag. We expect the IR to evolve still, but this PR just introduces the pieces needed for single-node plans (to support existing Engine handler functions)

Other minor changes:
- Added a `DeltaResultIterator` type alias since it is a common pattern to want an iterator over DeltaResult items
- Added a `QueryPlanBuilder` for constructing plan nodes. Eventually, this will evolve to construct more complex multi-node plans.

Key decisions to review:
1. `PlanResult` return type - uses typed results (FileMeta, Bytes) for IO operations to avoid roundtrip translation overhead. Uses EngineData (either singular or iterator) for output of QueryPlans.
2. `Plan` enum - splits into either single node `IOOperation` or multi-node `QueryPlan`. This keeps operations which return typed data (bytes, file meta) separate from relational operations (which operate on EngineData). 
    - One future consideration is that we may want a FileListing op to return file meta as EngineData. In that case, we can support both `IOOperation::FileListing` and `QueryPlanNode::FileListing`

I'm open to any naming changes that would make the concepts more clear.

## How was this change tested?
Simple unit test for `QueryPlanBuilder`, but otherwise this PR only adds new traits and structs which will be used/tested in subsequent PRs.