### PR TITLE
feat(log_segment): CrcReplayAccumulator + visitor for stale-CRC reverse replay

### DIFF
--- a/kernel/src/crc/delta.rs
+++ b/kernel/src/crc/delta.rs
@@ -1,17 +1,10 @@
 //! Incremental CRC state updates via commit deltas.
 //!
-//! A [`CrcDelta`] captures CRC-relevant changes from a single commit (produced by reading a
-//! `.json` commit file during log replay, or from in-memory transaction state during writes).
-//! [`Crc::apply`] advances a CRC forward one commit at a time by applying a delta.
-//!
-//! A CRC tracks two categories of fields, updated differently:
-//! - **Metadata fields** (protocol, metadata, domain metadata, set transactions, in-commit
-//!   timestamp): always kept up-to-date -- every `apply` unconditionally merges these from the
-//!   delta.
-//! - **File stats** ([`FileStatsState`]): only updated when the state is `Complete` and the
-//!   commit's operation is incremental-safe. Once the state degrades (e.g. a non-incremental
-//!   operation like ANALYZE STATS, or a missing file size), file stats stop updating for the
-//!   lifetime of that CRC.
+//! A [`CrcDelta`] aggregates the CRC-relevant changes from commits `(X, Y]`. Applying it to a
+//! base CRC at `X` yields the CRC at `Y`: `Crc[X] + CrcDelta = Crc[Y]`. [`Crc::apply`] is the
+//! consumer.
+
+use std::collections::HashMap;
 
 use tracing::warn;
 
@@ -21,28 +14,27 @@ use super::{
 };
 use crate::actions::{DomainMetadata, Metadata, Protocol, SetTransaction};
 
-/// The CRC-relevant changes ("delta") from a single commit. Produced either by reading a
-/// `.json` commit file during log replay, or from in-memory transaction state during writes.
+/// CRC-relevant changes aggregated over commits `(X, Y]`.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct CrcDelta {
     /// Net file count, size changes and histograms.
     pub(crate) file_stats: FileStatsDelta,
-    /// New protocol action, if this commit changed it.
+    /// Newest protocol over `(X, Y]`, if any.
     pub(crate) protocol: Option<Protocol>,
-    /// New metadata action, if this commit changed it.
+    /// Newest metadata over `(X, Y]`, if any.
     pub(crate) metadata: Option<Metadata>,
-    /// All DM actions in this commit, including tombstones (`removed=true`).
-    pub(crate) domain_metadata_changes: Vec<DomainMetadata>,
-    /// All [`SetTransaction`] actions in this commit.
-    pub(crate) set_transaction_changes: Vec<SetTransaction>,
-    /// In-commit timestamp, if present in this commit.
+    /// DomainMetadata actions keyed by domain, including tombstones (`removed=true`).
+    pub(crate) domain_metadata: HashMap<String, DomainMetadata>,
+    /// SetTransaction actions keyed by app_id.
+    pub(crate) set_transactions: HashMap<String, SetTransaction>,
+    /// In-commit timestamp at `Y`. Replaces the base's ICT unconditionally
+    /// (whether `Some` or `None`).
     pub(crate) in_commit_timestamp: Option<i64>,
-    /// Must be `Some` with an incremental-safe value for file stats to update. `None` or
-    /// unrecognized values transition the [`FileStatsState`] to `Indeterminate`.
-    pub(crate) operation: Option<String>,
-    /// A file action in this commit had a missing `size` field, making byte-level file stats
-    /// impossible to compute.
-    pub(crate) has_missing_file_size: bool,
+    /// Whether the file-stats portion of this delta can be applied incrementally. When `false`,
+    /// [`Crc::apply`] transitions [`FileStatsState`] to `Indeterminate`. Producers set this to
+    /// `false` whenever they observe a signal that makes incremental tracking unsound (for
+    /// example, a non-incremental operation such as `ANALYZE STATS`).
+    pub(crate) is_incremental_safe: bool,
 }
 
 impl CrcDelta {
@@ -54,21 +46,16 @@ impl CrcDelta {
         let protocol = self.protocol?;
         let metadata = self.metadata?;
         // For CREATE TABLE we know the full domain metadata state: the transaction either
-        // included domain metadata actions or it didn't. Always Complete.
+        // included domain metadata actions or it didn't. Always Complete. Drop tombstones
+        // (a fresh table has no domains to remove).
         let domain_metadata_state = DomainMetadataState::Complete(
-            self.domain_metadata_changes
+            self.domain_metadata
                 .into_iter()
-                .filter(|dm| !dm.is_removed())
-                .map(|dm| (dm.domain().to_string(), dm))
+                .filter(|(_, dm)| !dm.is_removed())
                 .collect(),
         );
         // CREATE TABLE starts with a known-complete set of transactions (possibly empty).
-        let set_transaction_state = SetTransactionState::Complete(
-            self.set_transaction_changes
-                .into_iter()
-                .map(|txn| (txn.app_id.clone(), txn))
-                .collect(),
-        );
+        let set_transaction_state = SetTransactionState::Complete(self.set_transactions);
         // For version zero the delta IS the full table histogram. Validate that all bins
         // are non-negative (a real table can't have negative file counts). If validation
         // fails, drop the histogram.
@@ -100,9 +87,10 @@ impl CrcDelta {
 impl Crc {
     /// Apply a commit delta.
     /// - Protocol / metadata: replaced when present in the delta, kept otherwise.
-    /// - ICT: unconditional replace (None correctly clears a previously-enabled value).
-    /// - Domain metadata / set transactions: upserted by key into the existing map; the
-    ///   `Complete`/`Partial` variant is preserved.
+    /// - ICT: unconditional replace; the delta carries ICT at `Y` (whether `Some` or `None`).
+    /// - Domain metadata: tombstones (`is_removed()`) drop the key from the base map; all others
+    ///   upsert by domain. Set transactions: upsert by app_id. The `Complete`/`Partial` variant is
+    ///   preserved in both cases.
     /// - File stats: governed by the [`FileStatsState`] state machine.
     pub(crate) fn apply(&mut self, delta: CrcDelta) {
         // Protocol and metadata: replace if present.
@@ -119,11 +107,11 @@ impl Crc {
         let map = match &mut self.domain_metadata_state {
             DomainMetadataState::Complete(m) | DomainMetadataState::Partial(m) => m,
         };
-        for dm in delta.domain_metadata_changes {
+        for (domain, dm) in delta.domain_metadata {
             if dm.is_removed() {
-                map.remove(dm.domain());
+                map.remove(&domain);
             } else {
-                map.insert(dm.domain().to_string(), dm);
+                map.insert(domain, dm);
             }
         }
 
@@ -133,27 +121,16 @@ impl Crc {
         let map = match &mut self.set_transaction_state {
             SetTransactionState::Complete(m) | SetTransactionState::Partial(m) => m,
         };
-        map.extend(
-            delta
-                .set_transaction_changes
-                .into_iter()
-                .map(|txn| (txn.app_id.clone(), txn)),
-        );
+        map.extend(delta.set_transactions);
 
-        // In-commit timestamp: unconditional replace (not guarded by `if let Some`).
-        // If ICT was disabled after being enabled, the delta carries None, which correctly
-        // clears the previous value.
+        // In-commit timestamp at `Y` (end of the range). Unconditional replace; `None` is a
+        // legal value (ICT disabled at `Y`).
         self.in_commit_timestamp_opt = delta.in_commit_timestamp;
 
-        let is_incremental_safe = delta
-            .operation
-            .as_deref()
-            .is_some_and(FileStatsDelta::is_incremental_safe);
         self.file_stats_state = transition_file_stats(
             &self.file_stats_state,
             &delta.file_stats,
-            is_incremental_safe,
-            delta.has_missing_file_size,
+            delta.is_incremental_safe,
         );
     }
 }
@@ -165,15 +142,14 @@ fn transition_file_stats(
     current: &FileStatsState,
     delta: &FileStatsDelta,
     is_incremental_safe: bool,
-    has_missing_file_size: bool,
 ) -> FileStatsState {
     match current {
         // Indeterminate is terminal in incremental replay. A future full add/remove dedup
         // pass could recover Complete.
         FileStatsState::Indeterminate => FileStatsState::Indeterminate,
-        // Either a non-incremental op (e.g. ANALYZE STATS) or a missing remove.size makes
-        // incremental tracking impossible: a full add/remove reconciliation can recover.
-        _ if !is_incremental_safe || has_missing_file_size => FileStatsState::Indeterminate,
+        // A non-incremental delta makes incremental tracking impossible; a full
+        // reconciliation can recover.
+        _ if !is_incremental_safe => FileStatsState::Indeterminate,
         FileStatsState::Complete(stats) => FileStatsState::Complete(FileStats {
             // Counts and bytes have no non-negative check.
             num_files: stats.num_files + delta.net_files,
@@ -214,7 +190,7 @@ mod tests {
 
     use super::*;
     use crate::actions::{DomainMetadata, Metadata, Protocol};
-    use crate::crc::{FileSizeHistogram, SetTransactionState};
+    use crate::crc::{is_incremental_safe_operation, FileSizeHistogram, SetTransactionState};
 
     fn base_crc() -> Crc {
         Crc {
@@ -227,17 +203,33 @@ mod tests {
         }
     }
 
+    fn dm_entry(domain: &str, config: &str) -> (String, DomainMetadata) {
+        (
+            domain.to_string(),
+            DomainMetadata::new(domain.to_string(), config.to_string()),
+        )
+    }
+
+    fn dm_remove_entry(domain: &str, config: &str) -> (String, DomainMetadata) {
+        (
+            domain.to_string(),
+            DomainMetadata::remove(domain.to_string(), config.to_string()),
+        )
+    }
+
+    fn txn_entry(
+        app_id: &str,
+        version: i64,
+        last_updated: Option<i64>,
+    ) -> (String, SetTransaction) {
+        (
+            app_id.to_string(),
+            SetTransaction::new(app_id.to_string(), version, last_updated),
+        )
+    }
+
     fn seed_dm_map() -> HashMap<String, DomainMetadata> {
-        HashMap::from([
-            (
-                "keep".to_string(),
-                DomainMetadata::new("keep".to_string(), "old".to_string()),
-            ),
-            (
-                "drop".to_string(),
-                DomainMetadata::new("drop".to_string(), "x".to_string()),
-            ),
-        ])
+        HashMap::from([dm_entry("keep", "old"), dm_entry("drop", "x")])
     }
 
     fn write_delta(net_files: i64, net_bytes: i64) -> CrcDelta {
@@ -247,7 +239,7 @@ mod tests {
                 net_bytes,
                 ..Default::default()
             },
-            operation: Some("WRITE".to_string()),
+            is_incremental_safe: true,
             ..Default::default()
         }
     }
@@ -269,7 +261,7 @@ mod tests {
             "CREATE OR REPLACE TABLE AS SELECT",
         ] {
             assert!(
-                FileStatsDelta::is_incremental_safe(op),
+                is_incremental_safe_operation(op),
                 "{op} should be incremental-safe"
             );
         }
@@ -277,8 +269,8 @@ mod tests {
 
     #[test]
     fn test_non_incremental_safe_operations() {
-        assert!(!FileStatsDelta::is_incremental_safe("ANALYZE STATS"));
-        assert!(!FileStatsDelta::is_incremental_safe("UNKNOWN"));
+        assert!(!is_incremental_safe_operation("ANALYZE STATS"));
+        assert!(!is_incremental_safe_operation("UNKNOWN"));
     }
 
     // ===== Crc deserialized from CRC file (default state) =====
@@ -317,24 +309,13 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_unsafe_op_transitions_to_indeterminate() {
+    fn test_apply_not_incremental_safe_transitions_to_indeterminate() {
         let mut crc = base_crc();
         let unsafe_change = CrcDelta {
-            operation: Some("ANALYZE STATS".to_string()),
+            is_incremental_safe: false,
             ..write_delta(1, 100)
         };
         crc.apply(unsafe_change);
-        assert!(crc.file_stats_state.is_indeterminate());
-    }
-
-    #[test]
-    fn test_apply_none_op_transitions_to_indeterminate() {
-        let mut crc = base_crc();
-        let unknown_delta = CrcDelta {
-            operation: None,
-            ..write_delta(1, 100)
-        };
-        crc.apply(unknown_delta);
         assert!(crc.file_stats_state.is_indeterminate());
     }
 
@@ -342,7 +323,7 @@ mod tests {
     fn test_indeterminate_stays_indeterminate() {
         let mut crc = base_crc();
         let unsafe_change = CrcDelta {
-            operation: Some("ANALYZE STATS".to_string()),
+            is_incremental_safe: false,
             ..write_delta(1, 100)
         };
         crc.apply(unsafe_change);
@@ -350,19 +331,6 @@ mod tests {
 
         // Subsequent safe op doesn't recover the state.
         crc.apply(write_delta(5, 500));
-        assert!(crc.file_stats_state.is_indeterminate());
-    }
-
-    // ===== apply: missing-file-size tests =====
-
-    #[test]
-    fn test_missing_file_size_transitions_to_indeterminate() {
-        let mut crc = base_crc();
-        let delta = CrcDelta {
-            has_missing_file_size: true,
-            ..write_delta(1, 100)
-        };
-        crc.apply(delta);
         assert!(crc.file_stats_state.is_indeterminate());
     }
 
@@ -398,11 +366,11 @@ mod tests {
         let mut crc = base_crc();
         crc.domain_metadata_state = base;
         let delta = CrcDelta {
-            domain_metadata_changes: vec![
-                DomainMetadata::new("keep".to_string(), "new".to_string()),
-                DomainMetadata::new("add".to_string(), "y".to_string()),
-                DomainMetadata::remove("drop".to_string(), "x".to_string()),
-            ],
+            domain_metadata: HashMap::from([
+                dm_entry("keep", "new"),
+                dm_entry("add", "y"),
+                dm_remove_entry("drop", "x"),
+            ]),
             ..write_delta(0, 0)
         };
         crc.apply(delta);
@@ -431,11 +399,9 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_clears_in_commit_timestamp_when_ict_disabled() {
+    fn test_apply_clears_in_commit_timestamp_when_delta_is_none() {
         let mut crc = base_crc();
         crc.in_commit_timestamp_opt = Some(1000);
-
-        // Delta without ICT (e.g. ICT was disabled) clears the previous value.
         let delta = CrcDelta {
             in_commit_timestamp: None,
             ..write_delta(0, 0)
@@ -507,7 +473,7 @@ mod tests {
         let delta = CrcDelta {
             protocol: Some(test_protocol()),
             metadata: Some(Metadata::default()),
-            domain_metadata_changes: vec![dm],
+            domain_metadata: HashMap::from([("my.domain".to_string(), dm)]),
             ..write_delta(0, 0)
         };
         let crc = delta.into_crc_for_version_zero().unwrap();
@@ -531,10 +497,7 @@ mod tests {
     // ===== apply: set transaction tests =====
 
     fn seed_txn_map() -> HashMap<String, SetTransaction> {
-        HashMap::from([(
-            "existing".to_string(),
-            SetTransaction::new("existing".to_string(), 1, Some(1000)),
-        )])
+        HashMap::from([txn_entry("existing", 1, Some(1000))])
     }
 
     /// A delta carrying both an upsert and a new entry exercises all the apply semantics for
@@ -548,10 +511,10 @@ mod tests {
         let mut crc = base_crc();
         crc.set_transaction_state = base;
         let delta = CrcDelta {
-            set_transaction_changes: vec![
-                SetTransaction::new("existing".to_string(), 2, Some(2000)),
-                SetTransaction::new("new".to_string(), 1, Some(1500)),
-            ],
+            set_transactions: HashMap::from([
+                txn_entry("existing", 2, Some(2000)),
+                txn_entry("new", 1, Some(1500)),
+            ]),
             ..write_delta(0, 0)
         };
         crc.apply(delta);
@@ -575,7 +538,7 @@ mod tests {
         let delta = CrcDelta {
             protocol: Some(test_protocol()),
             metadata: Some(Metadata::default()),
-            set_transaction_changes: vec![txn],
+            set_transactions: HashMap::from([("my-app".to_string(), txn)]),
             ..write_delta(0, 0)
         };
         let crc = delta.into_crc_for_version_zero().unwrap();
@@ -626,7 +589,7 @@ mod tests {
                 net_bytes,
                 net_histogram: Some(hist),
             },
-            operation: Some("WRITE".to_string()),
+            is_incremental_safe: true,
             ..Default::default()
         }
     }
@@ -685,7 +648,7 @@ mod tests {
                 net_bytes: 100,
                 net_histogram: None,
             },
-            operation: Some("WRITE".to_string()),
+            is_incremental_safe: true,
             ..Default::default()
         };
         crc.apply(delta);
@@ -700,25 +663,11 @@ mod tests {
     fn apply_drops_histogram_on_indeterminate() {
         let mut crc = base_crc_with_histogram(&[100, 200]);
         let unsafe_delta = CrcDelta {
-            operation: Some("ANALYZE STATS".to_string()),
+            is_incremental_safe: false,
             ..write_delta(1, 100)
         };
         crc.apply(unsafe_delta);
         // Indeterminate has no histogram field; the histogram data is gone.
-        assert!(crc.file_stats_state.is_indeterminate());
-        assert!(crc.file_stats().is_none());
-    }
-
-    #[test]
-    fn apply_remove_without_size_transitions_to_indeterminate() {
-        // A remove action with missing size makes incremental tracking impossible;
-        // file_stats returns None because Indeterminate carries no data.
-        let mut crc = base_crc_with_histogram(&[100, 200]);
-        let delta = CrcDelta {
-            has_missing_file_size: true,
-            ..write_delta(1, 100)
-        };
-        crc.apply(delta);
         assert!(crc.file_stats_state.is_indeterminate());
         assert!(crc.file_stats().is_none());
     }
@@ -734,7 +683,7 @@ mod tests {
                 net_bytes: 1500,
                 net_histogram: Some(delta_hist),
             },
-            operation: Some("WRITE".to_string()),
+            is_incremental_safe: true,
             ..Default::default()
         };
         let crc = delta.into_crc_for_version_zero().unwrap();
@@ -789,7 +738,7 @@ mod tests {
                 net_bytes: 1450, // (100 + 1500) - 150
                 net_histogram: Some(delta_hist),
             },
-            operation: Some("WRITE".to_string()),
+            is_incremental_safe: true,
             ..Default::default()
         };
 

--- a/kernel/src/crc/file_stats.rs
+++ b/kernel/src/crc/file_stats.rs
@@ -68,30 +68,30 @@ pub(crate) struct FileStatsDelta {
     pub(crate) net_histogram: Option<FileSizeHistogram>,
 }
 
+const INCREMENTAL_SAFE_OPS: &[&str] = &[
+    "WRITE",
+    "MERGE",
+    "UPDATE",
+    "DELETE",
+    "OPTIMIZE",
+    "CREATE TABLE",
+    "REPLACE TABLE",
+    "CREATE TABLE AS SELECT",
+    "REPLACE TABLE AS SELECT",
+    "CREATE OR REPLACE TABLE AS SELECT",
+];
+
+/// Returns `true` if the given operation can be safely tracked by incremental file stats.
+///
+/// Incremental-safe operations produce add/remove actions whose net counts give correct file
+/// stats. Unknown or missing operations are treated as unsafe. For example, ANALYZE STATS
+/// re-adds existing files with updated statistics; naively counting those adds would
+/// double-count file stats.
+pub(crate) fn is_incremental_safe_operation(operation: &str) -> bool {
+    INCREMENTAL_SAFE_OPS.contains(&operation)
+}
+
 impl FileStatsDelta {
-    /// Returns `true` if the given operation can be safely tracked by incremental file stats.
-    ///
-    /// Incremental-safe operations produce add/remove actions whose net counts give correct
-    /// file stats. Unknown or missing operations are treated as unsafe. For example, ANALYZE
-    /// STATS re-adds existing files with updated statistics -- if we naively counted those
-    /// adds, we'd double count file stats.
-    const INCREMENTAL_SAFE_OPS: &[&str] = &[
-        "WRITE",
-        "MERGE",
-        "UPDATE",
-        "DELETE",
-        "OPTIMIZE",
-        "CREATE TABLE",
-        "REPLACE TABLE",
-        "CREATE TABLE AS SELECT",
-        "REPLACE TABLE AS SELECT",
-        "CREATE OR REPLACE TABLE AS SELECT",
-    ];
-
-    pub(crate) fn is_incremental_safe(operation: &str) -> bool {
-        Self::INCREMENTAL_SAFE_OPS.contains(&operation)
-    }
-
     /// Compute file stats and a delta histogram from a transaction's staged add and remove
     /// metadata.
     ///

--- a/kernel/src/crc/mod.rs
+++ b/kernel/src/crc/mod.rs
@@ -31,7 +31,7 @@ pub(crate) use delta::CrcDelta;
 pub use file_size_histogram::FileSizeHistogram;
 pub use file_stats::FileStats;
 #[allow(unused)]
-pub(crate) use file_stats::FileStatsDelta;
+pub(crate) use file_stats::{is_incremental_safe_operation, FileStatsDelta};
 pub(crate) use lazy::{CrcLoadResult, LazyCrc};
 pub(crate) use reader::try_read_crc_file;
 use serde::de::Deserializer;

--- a/kernel/src/crc/mod.rs
+++ b/kernel/src/crc/mod.rs
@@ -41,7 +41,7 @@ pub use state::{DomainMetadataState, FileStatsState, SetTransactionState};
 pub(crate) use writer::try_write_crc_file;
 
 use crate::actions::{Add, DomainMetadata, Metadata, Protocol, SetTransaction};
-use crate::Error;
+use crate::{Error, Version};
 
 // ============================================================================
 // Crc: in-memory representation
@@ -65,6 +65,10 @@ use crate::Error;
 #[serde(try_from = "CrcRaw")]
 pub struct Crc {
     // ===== Required fields =====
+    /// The table version this CRC describes. Loaded from the `.crc` filename, not from the
+    /// file's JSON body, so this is the source of truth for "what version is `self`".
+    #[serde(skip)]
+    pub version: Version,
     /// The table [`Metadata`] at this version.
     pub metadata: Metadata,
     /// The table [`Protocol`] at this version.
@@ -189,6 +193,9 @@ impl TryFrom<CrcRaw> for Crc {
             file_size_histogram: raw.file_size_histogram,
         });
         Ok(Crc {
+            // CrcRaw does not carry a version field; [`try_read_crc_file`] overwrites this
+            // with the version parsed from the `.crc` filename.
+            version: 0,
             metadata: raw.metadata,
             protocol: raw.protocol,
             file_stats_state,

--- a/kernel/src/crc/reader.rs
+++ b/kernel/src/crc/reader.rs
@@ -18,7 +18,10 @@ pub(crate) fn try_read_crc_file(engine: &dyn Engine, crc_path: &ParsedLogPath) -
         .read_files(vec![(url, None)])?
         .next()
         .ok_or_else(|| Error::generic("CRC file read returned no data"))??;
-    let crc: Crc = serde_json::from_slice(&data)?;
+    let mut crc: Crc = serde_json::from_slice(&data)?;
+    // The wire format does not carry a version; the filename does. Populate it here so
+    // `crc.version` is the source of truth for downstream callers.
+    crc.version = crc_path.version;
     Ok(crc)
 }
 
@@ -139,6 +142,16 @@ mod tests {
         assert!(crc.num_deleted_records_opt.is_none());
         assert!(crc.num_deletion_vectors_opt.is_none());
         assert!(crc.deleted_record_counts_histogram_opt.is_none());
+    }
+
+    #[test]
+    fn test_read_crc_file_populates_version_from_filename() {
+        let engine = SyncEngine::new();
+        let table_root = test_table_root("./tests/data/crc-full/");
+        let crc_path = ParsedLogPath::create_parsed_crc(&table_root, 0);
+        let crc = try_read_crc_file(&engine, &crc_path).unwrap();
+        // Body has no version; reader populates it from the `.crc` filename.
+        assert_eq!(crc.version, 0);
     }
 
     #[test]

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -1,0 +1,785 @@
+// `build_crc_delta_from_stale` and its supporting types are exercised by the in-file test
+// module but have no production caller yet. Snapshot wiring lands in a follow-up PR.
+#![cfg_attr(not(test), allow(dead_code))]
+
+//! Reverse log replay for stale-CRC catch-up.
+//!
+//! A [`CrcDelta`] aggregates the CRC-relevant changes from commits `(X, N]`. Applying it to a
+//! base CRC at `X` yields the CRC at `N`: `Crc[X] + CrcDelta = Crc[N]`. This module produces
+//! such a delta by reverse-replaying a log segment's commit files. [`Crc::apply`] is the
+//! consumer.
+//!
+//! Entry point: [`LogSegment::build_crc_delta_from_stale`].
+//
+// TODO: see if we can support log compaction files.
+
+use std::collections::hash_map::Entry;
+use std::sync::{Arc, LazyLock};
+
+use tracing::{instrument, warn};
+
+use super::LogSegment;
+use crate::actions::{
+    get_commit_schema, DomainMetadata, Metadata, Protocol, SetTransaction, ADD_NAME,
+    COMMIT_INFO_NAME, DOMAIN_METADATA_NAME, METADATA_NAME, PROTOCOL_NAME, REMOVE_NAME,
+    SET_TRANSACTION_NAME,
+};
+use crate::crc::{is_incremental_safe_operation, Crc, CrcDelta, FileSizeHistogram};
+use crate::engine_data::{GetData, TypedGetData as _};
+use crate::schema::{ColumnName, ColumnNamesAndTypes, DataType, MetadataColumnSpec, SchemaRef};
+use crate::utils::require;
+use crate::{DeltaResult, Engine, Error, RowVisitor};
+
+#[allow(clippy::expect_used)]
+static REPLAY_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
+    let projected = get_commit_schema()
+        .project_as_struct(&[
+            ADD_NAME,
+            REMOVE_NAME,
+            PROTOCOL_NAME,
+            METADATA_NAME,
+            SET_TRANSACTION_NAME,
+            DOMAIN_METADATA_NAME,
+            COMMIT_INFO_NAME,
+        ])
+        .expect("project_as_struct on commit schema");
+    let with_file = projected
+        .add_metadata_column("_file", MetadataColumnSpec::FilePath)
+        .expect("add _file metadata column");
+    Arc::new(with_file)
+});
+
+impl LogSegment {
+    /// Reverse-replay this log segment, producing a [`CrcDelta`] that advances `base` from
+    /// `base.version` to `self.end_version`.
+    ///
+    /// The strategy: hand all commit files in `(base.version, self.end_version]` to
+    /// [`Engine`] for streaming reads (newest first), then build up a [`CrcDelta`] in one
+    /// shared [`CrcReplayAccumulator`] across all batches. Per batch, a transient
+    /// [`CrcReplayVisitor`] pulls leaf values from the row data and forwards them to the
+    /// accumulator's `on_*` methods. For per-key fields (Protocol, Metadata, DomainMetadata,
+    /// SetTransaction) the first observation wins; older commits cannot override it. ICT is
+    /// special: it is captured only from the newest commit.
+    ///
+    /// # Preconditions
+    ///
+    /// 1. The caller must skip calling this when `base.version == self.end_version` (the delta
+    ///    would be empty; just clone the base).
+    /// 2. `self.listed.ascending_commit_files` must cover every commit in `(base.version,
+    ///    self.end_version]`. The typical caller arranges this with
+    ///    [`LogSegment::segment_after_crc`] when a checkpoint sits above `base.version`.
+    ///
+    /// Returns `Error::InternalError` when either precondition fails.
+    #[instrument(name = "log_seg.build_crc_delta_from_stale", skip_all, err)]
+    pub(crate) fn build_crc_delta_from_stale(
+        &self,
+        engine: &dyn Engine,
+        base: &Crc,
+    ) -> DeltaResult<CrcDelta> {
+        require!(
+            base.version < self.end_version,
+            Error::internal_error(format!(
+                "build_crc_delta_from_stale: base.version ({}) must be strictly less than \
+                 end_version ({})",
+                base.version, self.end_version,
+            ))
+        );
+        let filtered: Vec<_> = self
+            .listed
+            .ascending_commit_files
+            .iter()
+            .filter(|c| c.version > base.version)
+            .collect();
+        // The first commit above base.version must be base.version + 1; otherwise the
+        // segment is missing intermediate commits and we'd produce an incorrect delta.
+        let first_above = filtered.first().map(|c| c.version);
+        require!(
+            first_above == Some(base.version + 1),
+            Error::internal_error(format!(
+                "build_crc_delta_from_stale: segment is missing commit {} (lowest commit \
+                 above base.version is {:?})",
+                base.version + 1,
+                first_above,
+            ))
+        );
+
+        // Empty histogram seeded with the base's bin boundaries so it merges cleanly in
+        // `Crc::apply`. If the base has no histogram, we use None and skip histogram
+        // tracking on the delta.
+        let seed_histogram = base
+            .file_stats()
+            .and_then(|s| s.file_size_histogram())
+            .map(|h| {
+                FileSizeHistogram::create_empty_with_boundaries(h.sorted_bin_boundaries().to_vec())
+            })
+            .transpose()?;
+        let mut acc = CrcReplayAccumulator::new(seed_histogram);
+
+        let files: Vec<_> = filtered.iter().rev().map(|c| c.location.clone()).collect();
+        let batches = engine
+            .json_handler()
+            .read_json_files(&files, REPLAY_SCHEMA.clone(), None)?;
+
+        for batch_result in batches {
+            let data = batch_result?;
+            let data = data.as_ref();
+
+            if acc.delta.protocol.is_none() {
+                acc.delta.protocol = Protocol::try_new_from_data(data)?;
+            }
+            if acc.delta.metadata.is_none() {
+                acc.delta.metadata = Metadata::try_new_from_data(data)?;
+            }
+
+            // Transient visitor borrows the shared accumulator for the duration of the
+            // batch; same pattern as `ActionReconciliationVisitor`.
+            let mut visitor = CrcReplayVisitor { acc: &mut acc };
+            visitor.visit_rows_of(data)?;
+        }
+
+        // Run the per-commit invariant on the final (oldest) commit; no successor batch
+        // will trigger it.
+        acc.process_commit_file_end();
+
+        Ok(acc.into_crc_delta())
+    }
+}
+
+// ============================================================================
+// Accumulator
+// ============================================================================
+
+/// In-progress [`CrcDelta`] plus the scaffolding needed to build it correctly during reverse
+/// replay. The visitor calls `process_batch_start` on each batch and the `on_*` methods on
+/// each row. After all batches have been folded in and `process_commit_file_end` has run for
+/// the final commit, [`Self::into_crc_delta`] returns the result.
+struct CrcReplayAccumulator {
+    delta: CrcDelta,
+
+    /// True while the visitor is still on the newest commit. Used to gate ICT capture
+    /// (only the newest commit contributes to [`CrcDelta::in_commit_timestamp`]). Cannot
+    /// be derived from `current_file_url` alone, since after the first batch the URL is
+    /// `Some` but we're still on the newest commit until a transition.
+    is_first_commit: bool,
+
+    /// URL of the commit file currently being processed. Drives commit-boundary detection:
+    /// a different URL on a later batch means we've moved to an older commit.
+    current_file_url: Option<String>,
+    /// True if the current commit had at least one add/remove row. Combined with
+    /// `current_commit_saw_commit_info` for the per-commit invariant check.
+    current_commit_saw_file_action: bool,
+    /// True if the current commit had a commitInfo row. Without one we can't classify the
+    /// operation as incremental-safe, so the per-commit invariant defaults the delta to
+    /// non-incremental-safe.
+    current_commit_saw_commit_info: bool,
+}
+
+impl CrcReplayAccumulator {
+    fn new(seed_histogram: Option<FileSizeHistogram>) -> Self {
+        Self {
+            delta: CrcDelta {
+                is_incremental_safe: true,
+                file_stats: crate::crc::FileStatsDelta {
+                    net_histogram: seed_histogram,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            is_first_commit: true,
+            current_file_url: None,
+            current_commit_saw_file_action: false,
+            current_commit_saw_commit_info: false,
+        }
+    }
+
+    fn process_batch_start(&mut self, batch_file_url: &str) {
+        if self.current_file_url.as_deref() == Some(batch_file_url) {
+            return; // same file, still inside the current commit
+        }
+        if self.current_file_url.is_some() {
+            // commit boundary: finalize the previous one, drop "newest" status
+            self.process_commit_file_end();
+            self.is_first_commit = false;
+        }
+        self.current_file_url = Some(batch_file_url.to_owned());
+    }
+
+    fn process_commit_file_end(&mut self) {
+        // File actions without a commitInfo: we can't classify the operation, so the
+        // delta is no longer incremental-safe. `is_incremental_safe` is one-way (once
+        // false, never restored).
+        if self.current_commit_saw_file_action && !self.current_commit_saw_commit_info {
+            warn!(
+                "CRC reverse-replay: commit at {} carried file actions but no commitInfo; \
+                 defaulting to non-incremental-safe",
+                self.current_file_url.as_deref().unwrap_or("?")
+            );
+            self.delta.is_incremental_safe = false;
+        }
+        self.current_commit_saw_file_action = false;
+        self.current_commit_saw_commit_info = false;
+    }
+
+    // === Row-level updates -- These accessors also make testing easier ===
+
+    fn on_commit_info(&mut self, operation: Option<&str>, ict: Option<i64>) {
+        self.current_commit_saw_commit_info = true;
+        if let Some(op) = operation {
+            if !is_incremental_safe_operation(op) {
+                warn!("CRC reverse-replay: non-incremental op {op}");
+                self.delta.is_incremental_safe = false;
+            }
+        }
+        if self.is_first_commit {
+            self.delta.in_commit_timestamp = ict;
+        }
+    }
+
+    fn on_add(&mut self, size: i64) -> DeltaResult<()> {
+        self.current_commit_saw_file_action = true;
+        let fs = &mut self.delta.file_stats;
+        fs.net_files += 1;
+        fs.net_bytes += size;
+        if let Some(hist) = fs.net_histogram.as_mut() {
+            hist.insert(size)?;
+        }
+        Ok(())
+    }
+
+    /// `size = None` means the remove row had a path but no size, which makes incremental
+    /// tracking impossible.
+    fn on_remove(&mut self, path: &str, size: Option<i64>) -> DeltaResult<()> {
+        self.current_commit_saw_file_action = true;
+        match size {
+            Some(s) => {
+                let fs = &mut self.delta.file_stats;
+                fs.net_files -= 1;
+                fs.net_bytes -= s;
+                if let Some(hist) = fs.net_histogram.as_mut() {
+                    hist.remove(s)?;
+                }
+            }
+            None => {
+                warn!("CRC reverse-replay: remove action at {path} has missing size");
+                self.delta.is_incremental_safe = false;
+            }
+        }
+        Ok(())
+    }
+
+    /// Tombstones (`removed=true`) are kept in the delta; [`Crc::apply`] consumes them as
+    /// removals from the base map.
+    fn on_domain_metadata(&mut self, domain: String, configuration: String, removed: bool) {
+        if let Entry::Vacant(e) = self.delta.domain_metadata.entry(domain.clone()) {
+            let dm = if removed {
+                DomainMetadata::remove(domain, configuration)
+            } else {
+                DomainMetadata::new(domain, configuration)
+            };
+            e.insert(dm);
+        }
+    }
+
+    fn on_set_transaction(&mut self, app_id: String, version: i64, last_updated: Option<i64>) {
+        if let Entry::Vacant(e) = self.delta.set_transactions.entry(app_id.clone()) {
+            e.insert(SetTransaction::new(app_id, version, last_updated));
+        }
+    }
+
+    fn into_crc_delta(self) -> CrcDelta {
+        self.delta
+    }
+}
+
+// ============================================================================
+// Visitor
+// ============================================================================
+
+// === Visitor column indices ===
+// Must match the order in `selected_column_names_and_types` below.
+const COL_FILE: usize = 0;
+const COL_OP: usize = 1;
+const COL_ICT: usize = 2;
+const COL_ADD_SIZE: usize = 3;
+const COL_REMOVE_PATH: usize = 4;
+const COL_REMOVE_SIZE: usize = 5;
+const COL_DM_DOMAIN: usize = 6;
+const COL_DM_CONFIG: usize = 7;
+const COL_DM_REMOVED: usize = 8;
+const COL_TXN_APP_ID: usize = 9;
+const COL_TXN_VERSION: usize = 10;
+const COL_TXN_LAST_UPDATED: usize = 11;
+
+/// Thin shim that pulls leaf values from `getters` and forwards them to the accumulator's
+/// `on_*` methods. All behavior lives in [`CrcReplayAccumulator`].
+struct CrcReplayVisitor<'a> {
+    acc: &'a mut CrcReplayAccumulator,
+}
+
+impl RowVisitor for CrcReplayVisitor<'_> {
+    fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
+        static NAMES_AND_TYPES: LazyLock<ColumnNamesAndTypes> = LazyLock::new(|| {
+            (
+                vec![
+                    ColumnName::new(["_file"]),
+                    ColumnName::new(["commitInfo", "operation"]),
+                    ColumnName::new(["commitInfo", "inCommitTimestamp"]),
+                    ColumnName::new(["add", "size"]),
+                    ColumnName::new(["remove", "path"]),
+                    ColumnName::new(["remove", "size"]),
+                    ColumnName::new(["domainMetadata", "domain"]),
+                    ColumnName::new(["domainMetadata", "configuration"]),
+                    ColumnName::new(["domainMetadata", "removed"]),
+                    ColumnName::new(["txn", "appId"]),
+                    ColumnName::new(["txn", "version"]),
+                    ColumnName::new(["txn", "lastUpdated"]),
+                ],
+                vec![
+                    DataType::STRING,
+                    DataType::STRING,
+                    DataType::LONG,
+                    DataType::LONG,
+                    DataType::STRING,
+                    DataType::LONG,
+                    DataType::STRING,
+                    DataType::STRING,
+                    DataType::BOOLEAN,
+                    DataType::STRING,
+                    DataType::LONG,
+                    DataType::LONG,
+                ],
+            )
+                .into()
+        });
+        NAMES_AND_TYPES.as_ref()
+    }
+
+    fn visit<'a>(&mut self, row_count: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
+        if row_count == 0 {
+            return Ok(());
+        }
+        // `_file` is constant across all rows of a batch per the JsonHandler contract. Read
+        // once from row 0 and signal a potential file (commit) transition.
+        let file_url: String = getters[COL_FILE].get(0, "_file")?;
+        self.acc.process_batch_start(&file_url);
+
+        for i in 0..row_count {
+            let operation: Option<String> = getters[COL_OP].get_opt(i, "commitInfo.operation")?;
+            let ict: Option<i64> = getters[COL_ICT].get_opt(i, "commitInfo.inCommitTimestamp")?;
+            if operation.is_some() || ict.is_some() {
+                self.acc.on_commit_info(operation.as_deref(), ict);
+            }
+
+            if let Some(size) = getters[COL_ADD_SIZE].get_opt(i, "add.size")? {
+                self.acc.on_add(size)?;
+            }
+
+            let remove_path: Option<String> = getters[COL_REMOVE_PATH].get_opt(i, "remove.path")?;
+            if let Some(path) = remove_path {
+                let remove_size: Option<i64> =
+                    getters[COL_REMOVE_SIZE].get_opt(i, "remove.size")?;
+                self.acc.on_remove(&path, remove_size)?;
+            }
+
+            let dm_domain: Option<String> =
+                getters[COL_DM_DOMAIN].get_opt(i, "domainMetadata.domain")?;
+            if let Some(domain) = dm_domain {
+                let configuration: String =
+                    getters[COL_DM_CONFIG].get(i, "domainMetadata.configuration")?;
+                let removed: bool = getters[COL_DM_REMOVED].get(i, "domainMetadata.removed")?;
+                self.acc.on_domain_metadata(domain, configuration, removed);
+            }
+
+            let txn_app_id: Option<String> = getters[COL_TXN_APP_ID].get_opt(i, "txn.appId")?;
+            if let Some(app_id) = txn_app_id {
+                let version: i64 = getters[COL_TXN_VERSION].get(i, "txn.version")?;
+                let last_updated: Option<i64> =
+                    getters[COL_TXN_LAST_UPDATED].get_opt(i, "txn.lastUpdated")?;
+                self.acc.on_set_transaction(app_id, version, last_updated);
+            }
+        }
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use serde_json::{json, Value};
+    use test_utils::delta_path_for_version;
+    use url::Url;
+
+    use super::*;
+    use crate::crc::FileSizeHistogram;
+    use crate::engine::sync::SyncEngine;
+    use crate::object_store::memory::InMemory;
+    use crate::object_store::ObjectStoreExt as _;
+    use crate::Snapshot;
+
+    // === Tier 1: narrow unit tests on `on_*` methods (no engine) ===
+
+    #[test]
+    fn on_add_increments_files_and_bytes() {
+        let mut acc = CrcReplayAccumulator::new(None);
+        acc.on_add(100).unwrap();
+        acc.on_add(200).unwrap();
+        assert_eq!(acc.delta.file_stats.net_files, 2);
+        assert_eq!(acc.delta.file_stats.net_bytes, 300);
+        assert!(acc.delta.is_incremental_safe);
+    }
+
+    #[test]
+    fn on_remove_with_size_decrements_files_and_bytes() {
+        let mut acc = CrcReplayAccumulator::new(None);
+        acc.on_remove("p", Some(50)).unwrap();
+        assert_eq!(acc.delta.file_stats.net_files, -1);
+        assert_eq!(acc.delta.file_stats.net_bytes, -50);
+        assert!(acc.delta.is_incremental_safe);
+    }
+
+    #[test]
+    fn on_remove_missing_size_trips_is_incremental_safe() {
+        let mut acc = CrcReplayAccumulator::new(None);
+        acc.on_remove("p", None).unwrap();
+        assert!(!acc.delta.is_incremental_safe);
+        assert!(acc.current_commit_saw_file_action);
+    }
+
+    #[test]
+    fn on_commit_info_unsafe_op_trips_is_incremental_safe() {
+        let mut acc = CrcReplayAccumulator::new(None);
+        acc.on_commit_info(Some("ANALYZE STATS"), None);
+        assert!(!acc.delta.is_incremental_safe);
+        assert!(acc.current_commit_saw_commit_info);
+    }
+
+    #[test]
+    fn on_commit_info_safe_op_keeps_is_incremental_safe_true() {
+        let mut acc = CrcReplayAccumulator::new(None);
+        acc.on_commit_info(Some("WRITE"), None);
+        assert!(acc.delta.is_incremental_safe);
+    }
+
+    #[test]
+    fn on_commit_info_ict_only_no_operation_still_marks_seen() {
+        let mut acc = CrcReplayAccumulator::new(None);
+        acc.on_commit_info(None, Some(1234));
+        assert!(acc.current_commit_saw_commit_info);
+        assert!(acc.delta.is_incremental_safe);
+        assert_eq!(acc.delta.in_commit_timestamp, Some(1234));
+    }
+
+    #[test]
+    fn on_commit_info_captures_ict_only_on_first_commit() {
+        let mut acc = CrcReplayAccumulator::new(None);
+        acc.process_batch_start("v2.json");
+        acc.on_commit_info(Some("WRITE"), Some(2000));
+        assert_eq!(acc.delta.in_commit_timestamp, Some(2000));
+        acc.process_batch_start("v1.json");
+        acc.on_commit_info(Some("WRITE"), Some(1000));
+        assert_eq!(acc.delta.in_commit_timestamp, Some(2000));
+    }
+
+    #[test]
+    fn on_commit_info_first_commit_none_ict_does_not_get_overwritten_by_older() {
+        let mut acc = CrcReplayAccumulator::new(None);
+        acc.process_batch_start("v2.json");
+        acc.on_commit_info(Some("WRITE"), None);
+        assert_eq!(acc.delta.in_commit_timestamp, None);
+        acc.process_batch_start("v1.json");
+        acc.on_commit_info(Some("WRITE"), Some(1000));
+        assert_eq!(acc.delta.in_commit_timestamp, None);
+    }
+
+    #[test]
+    fn on_domain_metadata_first_seen_in_reverse_wins() {
+        let mut acc = CrcReplayAccumulator::new(None);
+        acc.on_domain_metadata("d".into(), "new".into(), false);
+        acc.on_domain_metadata("d".into(), "old".into(), false);
+        assert_eq!(acc.delta.domain_metadata["d"].configuration(), "new");
+        assert!(!acc.delta.domain_metadata["d"].is_removed());
+    }
+
+    #[test]
+    fn on_domain_metadata_tombstone_is_kept() {
+        let mut acc = CrcReplayAccumulator::new(None);
+        acc.on_domain_metadata("d".into(), "v".into(), true);
+        assert!(acc.delta.domain_metadata["d"].is_removed());
+    }
+
+    #[test]
+    fn on_set_transaction_first_seen_in_reverse_wins() {
+        let mut acc = CrcReplayAccumulator::new(None);
+        acc.on_set_transaction("a".into(), 99, Some(123));
+        acc.on_set_transaction("a".into(), 1, Some(0));
+        assert_eq!(acc.delta.set_transactions["a"].version, 99);
+    }
+
+    #[test]
+    fn histogram_inherits_seed_boundaries() {
+        let seed = FileSizeHistogram::create_empty_with_boundaries(vec![0, 200, 1000]).unwrap();
+        let mut acc = CrcReplayAccumulator::new(Some(seed));
+        acc.on_add(150).unwrap();
+        let hist = acc.delta.file_stats.net_histogram.as_ref().unwrap();
+        assert_eq!(hist.sorted_bin_boundaries(), &[0, 200, 1000]);
+        assert_eq!(hist.file_counts()[0], 1);
+        assert_eq!(hist.total_bytes()[0], 150);
+    }
+
+    #[test]
+    fn no_seed_histogram_means_no_delta_histogram() {
+        let mut acc = CrcReplayAccumulator::new(None);
+        acc.on_add(150).unwrap();
+        assert!(acc.delta.file_stats.net_histogram.is_none());
+    }
+
+    #[test]
+    fn into_crc_delta_transfers_accumulated_state() {
+        let mut acc = CrcReplayAccumulator::new(None);
+        acc.on_add(42).unwrap();
+        let delta = acc.into_crc_delta();
+        assert_eq!(delta.file_stats.net_files, 1);
+        assert_eq!(delta.file_stats.net_bytes, 42);
+    }
+
+    // === Tier 2: per-commit invariant + is_first_commit (rstest, no engine) ===
+    //
+    // Each step is `(file_url, actions)` where `actions` is a string containing `'F'` (this
+    // batch carries a file action) and/or `'C'` (this batch carries a commitInfo). The
+    // SyncEngine emits one batch per file, so multi-batch-per-file coverage is reachable
+    // only via these direct tests.
+
+    type Step<'a> = (&'a str, &'a str);
+
+    fn drive(steps: &[Step<'_>]) -> CrcReplayAccumulator {
+        let mut acc = CrcReplayAccumulator::new(None);
+        for (url, actions) in steps {
+            acc.process_batch_start(url);
+            if actions.contains('F') {
+                acc.on_add(0).unwrap();
+            }
+            if actions.contains('C') {
+                acc.on_commit_info(Some("WRITE"), None);
+            }
+        }
+        acc.process_commit_file_end();
+        acc
+    }
+
+    #[rstest]
+    // 1 file x 1 batch
+    #[case::one_file_complete(&[("a", "FC")], true)]
+    #[case::one_file_no_commit_info(&[("a", "F")], false)]
+    #[case::one_file_no_file_action(&[("a", "C")], true)]
+    // 1 file x M batches: per-commit flags persist across same-URL batches.
+    #[case::one_file_actions_split(&[("a", "F"), ("a", ""), ("a", "C")], true)]
+    #[case::one_file_no_commit_info_split(&[("a", "F"), ("a", ""), ("a", "")], false)]
+    // N files x 1 batch each
+    #[case::two_files_both_complete(&[("b", "FC"), ("a", "FC")], true)]
+    #[case::two_files_second_missing_ci(&[("b", "FC"), ("a", "F")], false)]
+    #[case::two_files_first_missing_ci(&[("b", "F"), ("a", "FC")], false)]
+    // N files x M batches each
+    #[case::two_files_split_batches(&[("b", "F"), ("b", "C"), ("a", "F"), ("a", "C")], true)]
+    fn per_commit_invariant_across_files_and_batches(
+        #[case] steps: &[Step<'_>],
+        #[case] expected_is_incremental_safe: bool,
+    ) {
+        let acc = drive(steps);
+        assert_eq!(acc.delta.is_incremental_safe, expected_is_incremental_safe);
+    }
+
+    #[rstest]
+    #[case::single_file_one_batch(&[("a", "")], true)]
+    #[case::single_file_multi_batches(&[("a", ""), ("a", ""), ("a", "")], true)]
+    #[case::two_files(&[("b", ""), ("a", "")], false)]
+    #[case::two_files_multi_batches(&[("b", ""), ("b", ""), ("a", ""), ("a", "")], false)]
+    #[case::many_files(&[("c", ""), ("b", ""), ("a", "")], false)]
+    fn is_first_commit_flips_on_first_file_boundary(
+        #[case] steps: &[Step<'_>],
+        #[case] expected_is_first_commit_at_end: bool,
+    ) {
+        let acc = drive(steps);
+        assert_eq!(acc.is_first_commit, expected_is_first_commit_at_end);
+    }
+
+    // === Tier 3: engine smoke tests + precondition test ===
+
+    async fn put_commit(store: &InMemory, version: u64, actions: &[Value]) {
+        let body = actions
+            .iter()
+            .map(|a| a.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        store
+            .put(
+                &delta_path_for_version(version, "json"),
+                body.into_bytes().into(),
+            )
+            .await
+            .unwrap();
+    }
+
+    fn create_table_actions() -> Vec<Value> {
+        vec![
+            json!({"protocol": {
+                "minReaderVersion": 1,
+                "minWriterVersion": 7,
+                "writerFeatures": ["domainMetadata", "inCommitTimestamp"]
+            }}),
+            json!({"metaData": {
+                "id": "t",
+                "format": {"provider": "parquet", "options": {}},
+                "schemaString": r#"{"type":"struct","fields":[]}"#,
+                "partitionColumns": [],
+                "configuration": {},
+                "createdTime": 0
+            }}),
+            json!({"commitInfo": {"timestamp": 0, "operation": "CREATE TABLE"}}),
+        ]
+    }
+
+    /// One commit with a mix of actions exercises every visitor column plus the `_file`
+    /// metadata wiring. The asserted delta values prove each `on_*` method received the
+    /// right leaf value from real `EngineData`.
+    #[tokio::test]
+    async fn end_to_end_mixed_commit_through_engine() {
+        let store = Arc::new(InMemory::new());
+        put_commit(&store, 0, &create_table_actions()).await;
+        put_commit(
+            &store,
+            1,
+            &[
+                json!({"protocol": {
+                    "minReaderVersion": 1, "minWriterVersion": 7,
+                    "writerFeatures": ["domainMetadata", "inCommitTimestamp"]
+                }}),
+                json!({"metaData": {
+                    "id": "t-updated",
+                    "format": {"provider": "parquet", "options": {}},
+                    "schemaString": r#"{"type":"struct","fields":[]}"#,
+                    "partitionColumns": [], "configuration": {}, "createdTime": 0
+                }}),
+                json!({"add": {
+                    "path": "a", "size": 100, "partitionValues": {},
+                    "modificationTime": 0, "dataChange": true
+                }}),
+                json!({"remove": {
+                    "path": "old", "size": 30,
+                    "dataChange": true, "deletionTimestamp": 0
+                }}),
+                json!({"domainMetadata": {
+                    "domain": "d", "configuration": "v", "removed": false
+                }}),
+                json!({"domainMetadata": {
+                    "domain": "gone", "configuration": "pre", "removed": true
+                }}),
+                json!({"txn": {"appId": "app", "version": 42, "lastUpdated": 0}}),
+                json!({"commitInfo": {
+                    "timestamp": 0, "operation": "WRITE", "inCommitTimestamp": 9999
+                }}),
+            ],
+        )
+        .await;
+
+        let engine = SyncEngine::new_with_store(store);
+        let snapshot = Snapshot::builder_for(Url::parse("memory:///").unwrap())
+            .build(&engine)
+            .unwrap();
+
+        let base = Crc::default();
+        let delta = snapshot
+            .log_segment()
+            .build_crc_delta_from_stale(&engine, &base)
+            .unwrap();
+
+        assert_eq!(delta.file_stats.net_files, 0); // +1 add, -1 remove
+        assert_eq!(delta.file_stats.net_bytes, 70); // +100 -30
+        assert_eq!(delta.domain_metadata["d"].configuration(), "v");
+        assert!(!delta.domain_metadata["d"].is_removed());
+        assert!(delta.domain_metadata["gone"].is_removed());
+        assert_eq!(delta.set_transactions["app"].version, 42);
+        assert_eq!(delta.set_transactions["app"].last_updated, Some(0));
+        assert_eq!(delta.in_commit_timestamp, Some(9999));
+        assert!(delta.is_incremental_safe);
+        assert_eq!(delta.protocol.as_ref().unwrap().min_writer_version(), 7);
+        assert_eq!(delta.metadata.as_ref().unwrap().id(), "t-updated");
+    }
+
+    /// Two commits each carry distinct protocol/metadata. The `is_none()` guards in the
+    /// entry point must select the newest values (v2). Without the engine going through
+    /// multiple commits this path would only be covered at the accumulator level.
+    #[tokio::test]
+    async fn end_to_end_newest_protocol_and_metadata_win() {
+        let store = Arc::new(InMemory::new());
+        put_commit(&store, 0, &create_table_actions()).await;
+        put_commit(
+            &store,
+            1,
+            &[
+                json!({"protocol": {"minReaderVersion": 1, "minWriterVersion": 2}}),
+                json!({"metaData": {
+                    "id": "old",
+                    "format": {"provider": "parquet", "options": {}},
+                    "schemaString": r#"{"type":"struct","fields":[]}"#,
+                    "partitionColumns": [], "configuration": {}, "createdTime": 0
+                }}),
+                json!({"commitInfo": {"timestamp": 0, "operation": "WRITE"}}),
+            ],
+        )
+        .await;
+        put_commit(
+            &store,
+            2,
+            &[
+                json!({"protocol": {
+                    "minReaderVersion": 1, "minWriterVersion": 7,
+                    "writerFeatures": ["domainMetadata"]
+                }}),
+                json!({"metaData": {
+                    "id": "new",
+                    "format": {"provider": "parquet", "options": {}},
+                    "schemaString": r#"{"type":"struct","fields":[]}"#,
+                    "partitionColumns": [], "configuration": {}, "createdTime": 0
+                }}),
+                json!({"commitInfo": {"timestamp": 0, "operation": "WRITE"}}),
+            ],
+        )
+        .await;
+        let engine = SyncEngine::new_with_store(store);
+        let snapshot = Snapshot::builder_for(Url::parse("memory:///").unwrap())
+            .build(&engine)
+            .unwrap();
+        let delta = snapshot
+            .log_segment()
+            .build_crc_delta_from_stale(&engine, &Crc::default())
+            .unwrap();
+        assert_eq!(delta.metadata.as_ref().unwrap().id(), "new");
+        assert_eq!(delta.protocol.as_ref().unwrap().min_writer_version(), 7);
+    }
+
+    #[rstest]
+    #[case::equal(0_u64)]
+    #[case::greater(5_u64)]
+    #[tokio::test]
+    async fn base_version_at_or_above_end_version_errors(#[case] base_version: u64) {
+        let store = Arc::new(InMemory::new());
+        put_commit(&store, 0, &create_table_actions()).await;
+        let engine = SyncEngine::new_with_store(store);
+        let snapshot = Snapshot::builder_for(Url::parse("memory:///").unwrap())
+            .build(&engine)
+            .unwrap();
+        let base = Crc {
+            version: base_version,
+            ..Default::default()
+        };
+        let err = snapshot
+            .log_segment()
+            .build_crc_delta_from_stale(&engine, &base)
+            .unwrap_err();
+        assert!(matches!(err, Error::InternalError(_)));
+    }
+}

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -1,15 +1,14 @@
-// `build_crc_delta_from_stale` and its supporting types are exercised by the in-file test
-// module but have no production caller yet. Snapshot wiring lands in a follow-up PR.
+// `build_crc_from_stale` is exercised by the in-file test module but has no production
+// caller yet. Snapshot wiring lands in a follow-up PR.
 #![cfg_attr(not(test), allow(dead_code))]
 
 //! Reverse log replay for stale-CRC catch-up.
 //!
-//! A [`CrcDelta`] aggregates the CRC-relevant changes from commits `(X, N]`. Applying it to a
-//! base CRC at `X` yields the CRC at `N`: `Crc[X] + CrcDelta = Crc[N]`. This module produces
-//! such a delta by reverse-replaying a log segment's commit files. [`Crc::apply`] is the
-//! consumer.
+//! Given a stale `Crc` at version `X`, this module builds the `Crc` at version `N` by
+//! reverse-replaying a log segment's commit files. Internally it accumulates a [`CrcDelta`]
+//! over commits `(X, N]`, then applies it via [`Crc::apply`].
 //!
-//! Entry point: [`LogSegment::build_crc_delta_from_stale`].
+//! Entry point: [`LogSegment::build_crc_from_stale`].
 //
 // TODO: see if we can support log compaction files.
 
@@ -50,8 +49,8 @@ static REPLAY_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
 });
 
 impl LogSegment {
-    /// Reverse-replay this log segment, producing a [`CrcDelta`] that advances `base` from
-    /// `base.version` to `self.end_version`.
+    /// Reverse-replay this log segment, producing a fresh `Crc` at `self.end_version` by
+    /// applying the changes in commits `(base.version, self.end_version]` to `base`.
     ///
     /// The strategy: hand all commit files in `(base.version, self.end_version]` to
     /// [`Engine`] for streaming reads (newest first), then build up a [`CrcDelta`] in one
@@ -59,27 +58,25 @@ impl LogSegment {
     /// [`CrcReplayVisitor`] pulls leaf values from the row data and forwards them to the
     /// accumulator's `on_*` methods. For per-key fields (Protocol, Metadata, DomainMetadata,
     /// SetTransaction) the first observation wins; older commits cannot override it. ICT is
-    /// special: it is captured only from the newest commit.
+    /// special: it is captured only from the newest commit. Once the delta is built, it is
+    /// applied to a clone of `base` via [`Crc::apply`] and the result's `version` is
+    /// stamped to `self.end_version`.
     ///
     /// # Preconditions
     ///
-    /// 1. The caller must skip calling this when `base.version == self.end_version` (the delta
-    ///    would be empty; just clone the base).
+    /// 1. The caller must skip calling this when `base.version == self.end_version` (the resulting
+    ///    `Crc` would just be a clone of `base`).
     /// 2. `self.listed.ascending_commit_files` must cover every commit in `(base.version,
     ///    self.end_version]`. The typical caller arranges this with
     ///    [`LogSegment::segment_after_crc`] when a checkpoint sits above `base.version`.
     ///
     /// Returns `Error::InternalError` when either precondition fails.
-    #[instrument(name = "log_seg.build_crc_delta_from_stale", skip_all, err)]
-    pub(crate) fn build_crc_delta_from_stale(
-        &self,
-        engine: &dyn Engine,
-        base: &Crc,
-    ) -> DeltaResult<CrcDelta> {
+    #[instrument(name = "log_seg.build_crc_from_stale", skip_all, err)]
+    pub(crate) fn build_crc_from_stale(&self, engine: &dyn Engine, base: &Crc) -> DeltaResult<Crc> {
         require!(
             base.version < self.end_version,
             Error::internal_error(format!(
-                "build_crc_delta_from_stale: base.version ({}) must be strictly less than \
+                "build_crc_from_stale: base.version ({}) must be strictly less than \
                  end_version ({})",
                 base.version, self.end_version,
             ))
@@ -91,12 +88,12 @@ impl LogSegment {
             .filter(|c| c.version > base.version)
             .collect();
         // The first commit above base.version must be base.version + 1; otherwise the
-        // segment is missing intermediate commits and we'd produce an incorrect delta.
+        // segment is missing intermediate commits and we'd produce an incorrect result.
         let first_above = filtered.first().map(|c| c.version);
         require!(
             first_above == Some(base.version + 1),
             Error::internal_error(format!(
-                "build_crc_delta_from_stale: segment is missing commit {} (lowest commit \
+                "build_crc_from_stale: segment is missing commit {} (lowest commit \
                  above base.version is {:?})",
                 base.version + 1,
                 first_above,
@@ -141,7 +138,10 @@ impl LogSegment {
         // will trigger it.
         acc.process_commit_file_end();
 
-        Ok(acc.into_crc_delta())
+        let mut crc = base.clone();
+        crc.apply(acc.into_crc_delta());
+        crc.version = self.end_version;
+        Ok(crc)
     }
 }
 
@@ -408,45 +408,18 @@ impl RowVisitor for CrcReplayVisitor<'_> {
 
 #[cfg(test)]
 mod tests {
-    use rstest::rstest;
-    use serde_json::{json, Value};
-    use test_utils::delta_path_for_version;
-    use url::Url;
-
     use super::*;
     use crate::crc::FileSizeHistogram;
-    use crate::engine::sync::SyncEngine;
-    use crate::object_store::memory::InMemory;
-    use crate::object_store::ObjectStoreExt as _;
-    use crate::Snapshot;
 
-    // === Tier 1: narrow unit tests on `on_*` methods (no engine) ===
+    // === Unit tests on `on_*` methods, in visitor column order ===
+
+    // commitInfo
 
     #[test]
-    fn on_add_increments_files_and_bytes() {
+    fn on_commit_info_safe_op_keeps_is_incremental_safe_true() {
         let mut acc = CrcReplayAccumulator::new(None);
-        acc.on_add(100).unwrap();
-        acc.on_add(200).unwrap();
-        assert_eq!(acc.delta.file_stats.net_files, 2);
-        assert_eq!(acc.delta.file_stats.net_bytes, 300);
+        acc.on_commit_info(Some("WRITE"), None);
         assert!(acc.delta.is_incremental_safe);
-    }
-
-    #[test]
-    fn on_remove_with_size_decrements_files_and_bytes() {
-        let mut acc = CrcReplayAccumulator::new(None);
-        acc.on_remove("p", Some(50)).unwrap();
-        assert_eq!(acc.delta.file_stats.net_files, -1);
-        assert_eq!(acc.delta.file_stats.net_bytes, -50);
-        assert!(acc.delta.is_incremental_safe);
-    }
-
-    #[test]
-    fn on_remove_missing_size_trips_is_incremental_safe() {
-        let mut acc = CrcReplayAccumulator::new(None);
-        acc.on_remove("p", None).unwrap();
-        assert!(!acc.delta.is_incremental_safe);
-        assert!(acc.current_commit_saw_file_action);
     }
 
     #[test]
@@ -455,13 +428,6 @@ mod tests {
         acc.on_commit_info(Some("ANALYZE STATS"), None);
         assert!(!acc.delta.is_incremental_safe);
         assert!(acc.current_commit_saw_commit_info);
-    }
-
-    #[test]
-    fn on_commit_info_safe_op_keeps_is_incremental_safe_true() {
-        let mut acc = CrcReplayAccumulator::new(None);
-        acc.on_commit_info(Some("WRITE"), None);
-        assert!(acc.delta.is_incremental_safe);
     }
 
     #[test]
@@ -495,6 +461,39 @@ mod tests {
         assert_eq!(acc.delta.in_commit_timestamp, None);
     }
 
+    // add
+
+    #[test]
+    fn on_add_increments_files_and_bytes() {
+        let mut acc = CrcReplayAccumulator::new(None);
+        acc.on_add(100).unwrap();
+        acc.on_add(200).unwrap();
+        assert_eq!(acc.delta.file_stats.net_files, 2);
+        assert_eq!(acc.delta.file_stats.net_bytes, 300);
+        assert!(acc.delta.is_incremental_safe);
+    }
+
+    // remove
+
+    #[test]
+    fn on_remove_with_size_decrements_files_and_bytes() {
+        let mut acc = CrcReplayAccumulator::new(None);
+        acc.on_remove("p", Some(50)).unwrap();
+        assert_eq!(acc.delta.file_stats.net_files, -1);
+        assert_eq!(acc.delta.file_stats.net_bytes, -50);
+        assert!(acc.delta.is_incremental_safe);
+    }
+
+    #[test]
+    fn on_remove_missing_size_trips_is_incremental_safe() {
+        let mut acc = CrcReplayAccumulator::new(None);
+        acc.on_remove("p", None).unwrap();
+        assert!(!acc.delta.is_incremental_safe);
+        assert!(acc.current_commit_saw_file_action);
+    }
+
+    // domainMetadata
+
     #[test]
     fn on_domain_metadata_first_seen_in_reverse_wins() {
         let mut acc = CrcReplayAccumulator::new(None);
@@ -511,6 +510,8 @@ mod tests {
         assert!(acc.delta.domain_metadata["d"].is_removed());
     }
 
+    // txn
+
     #[test]
     fn on_set_transaction_first_seen_in_reverse_wins() {
         let mut acc = CrcReplayAccumulator::new(None);
@@ -518,6 +519,8 @@ mod tests {
         acc.on_set_transaction("a".into(), 1, Some(0));
         assert_eq!(acc.delta.set_transactions["a"].version, 99);
     }
+
+    // auxiliary
 
     #[test]
     fn histogram_inherits_seed_boundaries() {
@@ -546,240 +549,47 @@ mod tests {
         assert_eq!(delta.file_stats.net_bytes, 42);
     }
 
-    // === Tier 2: per-commit invariant + is_first_commit (rstest, no engine) ===
+    // === Commit-boundary state machine — direct accumulator tests ===
     //
-    // Each step is `(file_url, actions)` where `actions` is a string containing `'F'` (this
-    // batch carries a file action) and/or `'C'` (this batch carries a commitInfo). The
-    // SyncEngine emits one batch per file, so multi-batch-per-file coverage is reachable
-    // only via these direct tests.
+    // `SyncEngine` emits one batch per file, so multi-batch-per-file scenarios are only
+    // reachable by driving the accumulator directly.
 
-    type Step<'a> = (&'a str, &'a str);
-
-    fn drive(steps: &[Step<'_>]) -> CrcReplayAccumulator {
+    #[test]
+    fn per_commit_invariant_holds_when_file_action_and_commit_info_split_across_batches_of_one_file(
+    ) {
         let mut acc = CrcReplayAccumulator::new(None);
-        for (url, actions) in steps {
-            acc.process_batch_start(url);
-            if actions.contains('F') {
-                acc.on_add(0).unwrap();
-            }
-            if actions.contains('C') {
-                acc.on_commit_info(Some("WRITE"), None);
-            }
-        }
+        acc.process_batch_start("v1.json");
+        acc.on_add(0).unwrap();
+        acc.process_batch_start("v1.json");
+        acc.on_commit_info(Some("WRITE"), None);
         acc.process_commit_file_end();
-        acc
+        assert!(acc.delta.is_incremental_safe);
     }
 
-    #[rstest]
-    // 1 file x 1 batch
-    #[case::one_file_complete(&[("a", "FC")], true)]
-    #[case::one_file_no_commit_info(&[("a", "F")], false)]
-    #[case::one_file_no_file_action(&[("a", "C")], true)]
-    // 1 file x M batches: per-commit flags persist across same-URL batches.
-    #[case::one_file_actions_split(&[("a", "F"), ("a", ""), ("a", "C")], true)]
-    #[case::one_file_no_commit_info_split(&[("a", "F"), ("a", ""), ("a", "")], false)]
-    // N files x 1 batch each
-    #[case::two_files_both_complete(&[("b", "FC"), ("a", "FC")], true)]
-    #[case::two_files_second_missing_ci(&[("b", "FC"), ("a", "F")], false)]
-    #[case::two_files_first_missing_ci(&[("b", "F"), ("a", "FC")], false)]
-    // N files x M batches each
-    #[case::two_files_split_batches(&[("b", "F"), ("b", "C"), ("a", "F"), ("a", "C")], true)]
-    fn per_commit_invariant_across_files_and_batches(
-        #[case] steps: &[Step<'_>],
-        #[case] expected_is_incremental_safe: bool,
-    ) {
-        let acc = drive(steps);
-        assert_eq!(acc.delta.is_incremental_safe, expected_is_incremental_safe);
+    #[test]
+    fn per_commit_invariant_trips_when_file_action_has_no_commit_info_across_batches() {
+        let mut acc = CrcReplayAccumulator::new(None);
+        acc.process_batch_start("v1.json");
+        acc.on_add(0).unwrap();
+        acc.process_batch_start("v1.json");
+        acc.process_commit_file_end();
+        assert!(!acc.delta.is_incremental_safe);
     }
 
-    #[rstest]
-    #[case::single_file_one_batch(&[("a", "")], true)]
-    #[case::single_file_multi_batches(&[("a", ""), ("a", ""), ("a", "")], true)]
-    #[case::two_files(&[("b", ""), ("a", "")], false)]
-    #[case::two_files_multi_batches(&[("b", ""), ("b", ""), ("a", ""), ("a", "")], false)]
-    #[case::many_files(&[("c", ""), ("b", ""), ("a", "")], false)]
-    fn is_first_commit_flips_on_first_file_boundary(
-        #[case] steps: &[Step<'_>],
-        #[case] expected_is_first_commit_at_end: bool,
-    ) {
-        let acc = drive(steps);
-        assert_eq!(acc.is_first_commit, expected_is_first_commit_at_end);
+    #[test]
+    fn is_first_commit_stays_true_across_batches_of_same_file() {
+        let mut acc = CrcReplayAccumulator::new(None);
+        acc.process_batch_start("v2.json");
+        acc.process_batch_start("v2.json");
+        acc.process_batch_start("v2.json");
+        assert!(acc.is_first_commit);
     }
 
-    // === Tier 3: engine smoke tests + precondition test ===
-
-    async fn put_commit(store: &InMemory, version: u64, actions: &[Value]) {
-        let body = actions
-            .iter()
-            .map(|a| a.to_string())
-            .collect::<Vec<_>>()
-            .join("\n");
-        store
-            .put(
-                &delta_path_for_version(version, "json"),
-                body.into_bytes().into(),
-            )
-            .await
-            .unwrap();
-    }
-
-    fn create_table_actions() -> Vec<Value> {
-        vec![
-            json!({"protocol": {
-                "minReaderVersion": 1,
-                "minWriterVersion": 7,
-                "writerFeatures": ["domainMetadata", "inCommitTimestamp"]
-            }}),
-            json!({"metaData": {
-                "id": "t",
-                "format": {"provider": "parquet", "options": {}},
-                "schemaString": r#"{"type":"struct","fields":[]}"#,
-                "partitionColumns": [],
-                "configuration": {},
-                "createdTime": 0
-            }}),
-            json!({"commitInfo": {"timestamp": 0, "operation": "CREATE TABLE"}}),
-        ]
-    }
-
-    /// One commit with a mix of actions exercises every visitor column plus the `_file`
-    /// metadata wiring. The asserted delta values prove each `on_*` method received the
-    /// right leaf value from real `EngineData`.
-    #[tokio::test]
-    async fn end_to_end_mixed_commit_through_engine() {
-        let store = Arc::new(InMemory::new());
-        put_commit(&store, 0, &create_table_actions()).await;
-        put_commit(
-            &store,
-            1,
-            &[
-                json!({"protocol": {
-                    "minReaderVersion": 1, "minWriterVersion": 7,
-                    "writerFeatures": ["domainMetadata", "inCommitTimestamp"]
-                }}),
-                json!({"metaData": {
-                    "id": "t-updated",
-                    "format": {"provider": "parquet", "options": {}},
-                    "schemaString": r#"{"type":"struct","fields":[]}"#,
-                    "partitionColumns": [], "configuration": {}, "createdTime": 0
-                }}),
-                json!({"add": {
-                    "path": "a", "size": 100, "partitionValues": {},
-                    "modificationTime": 0, "dataChange": true
-                }}),
-                json!({"remove": {
-                    "path": "old", "size": 30,
-                    "dataChange": true, "deletionTimestamp": 0
-                }}),
-                json!({"domainMetadata": {
-                    "domain": "d", "configuration": "v", "removed": false
-                }}),
-                json!({"domainMetadata": {
-                    "domain": "gone", "configuration": "pre", "removed": true
-                }}),
-                json!({"txn": {"appId": "app", "version": 42, "lastUpdated": 0}}),
-                json!({"commitInfo": {
-                    "timestamp": 0, "operation": "WRITE", "inCommitTimestamp": 9999
-                }}),
-            ],
-        )
-        .await;
-
-        let engine = SyncEngine::new_with_store(store);
-        let snapshot = Snapshot::builder_for(Url::parse("memory:///").unwrap())
-            .build(&engine)
-            .unwrap();
-
-        let base = Crc::default();
-        let delta = snapshot
-            .log_segment()
-            .build_crc_delta_from_stale(&engine, &base)
-            .unwrap();
-
-        assert_eq!(delta.file_stats.net_files, 0); // +1 add, -1 remove
-        assert_eq!(delta.file_stats.net_bytes, 70); // +100 -30
-        assert_eq!(delta.domain_metadata["d"].configuration(), "v");
-        assert!(!delta.domain_metadata["d"].is_removed());
-        assert!(delta.domain_metadata["gone"].is_removed());
-        assert_eq!(delta.set_transactions["app"].version, 42);
-        assert_eq!(delta.set_transactions["app"].last_updated, Some(0));
-        assert_eq!(delta.in_commit_timestamp, Some(9999));
-        assert!(delta.is_incremental_safe);
-        assert_eq!(delta.protocol.as_ref().unwrap().min_writer_version(), 7);
-        assert_eq!(delta.metadata.as_ref().unwrap().id(), "t-updated");
-    }
-
-    /// Two commits each carry distinct protocol/metadata. The `is_none()` guards in the
-    /// entry point must select the newest values (v2). Without the engine going through
-    /// multiple commits this path would only be covered at the accumulator level.
-    #[tokio::test]
-    async fn end_to_end_newest_protocol_and_metadata_win() {
-        let store = Arc::new(InMemory::new());
-        put_commit(&store, 0, &create_table_actions()).await;
-        put_commit(
-            &store,
-            1,
-            &[
-                json!({"protocol": {"minReaderVersion": 1, "minWriterVersion": 2}}),
-                json!({"metaData": {
-                    "id": "old",
-                    "format": {"provider": "parquet", "options": {}},
-                    "schemaString": r#"{"type":"struct","fields":[]}"#,
-                    "partitionColumns": [], "configuration": {}, "createdTime": 0
-                }}),
-                json!({"commitInfo": {"timestamp": 0, "operation": "WRITE"}}),
-            ],
-        )
-        .await;
-        put_commit(
-            &store,
-            2,
-            &[
-                json!({"protocol": {
-                    "minReaderVersion": 1, "minWriterVersion": 7,
-                    "writerFeatures": ["domainMetadata"]
-                }}),
-                json!({"metaData": {
-                    "id": "new",
-                    "format": {"provider": "parquet", "options": {}},
-                    "schemaString": r#"{"type":"struct","fields":[]}"#,
-                    "partitionColumns": [], "configuration": {}, "createdTime": 0
-                }}),
-                json!({"commitInfo": {"timestamp": 0, "operation": "WRITE"}}),
-            ],
-        )
-        .await;
-        let engine = SyncEngine::new_with_store(store);
-        let snapshot = Snapshot::builder_for(Url::parse("memory:///").unwrap())
-            .build(&engine)
-            .unwrap();
-        let delta = snapshot
-            .log_segment()
-            .build_crc_delta_from_stale(&engine, &Crc::default())
-            .unwrap();
-        assert_eq!(delta.metadata.as_ref().unwrap().id(), "new");
-        assert_eq!(delta.protocol.as_ref().unwrap().min_writer_version(), 7);
-    }
-
-    #[rstest]
-    #[case::equal(0_u64)]
-    #[case::greater(5_u64)]
-    #[tokio::test]
-    async fn base_version_at_or_above_end_version_errors(#[case] base_version: u64) {
-        let store = Arc::new(InMemory::new());
-        put_commit(&store, 0, &create_table_actions()).await;
-        let engine = SyncEngine::new_with_store(store);
-        let snapshot = Snapshot::builder_for(Url::parse("memory:///").unwrap())
-            .build(&engine)
-            .unwrap();
-        let base = Crc {
-            version: base_version,
-            ..Default::default()
-        };
-        let err = snapshot
-            .log_segment()
-            .build_crc_delta_from_stale(&engine, &base)
-            .unwrap_err();
-        assert!(matches!(err, Error::InternalError(_)));
+    #[test]
+    fn is_first_commit_becomes_false_after_file_transition() {
+        let mut acc = CrcReplayAccumulator::new(None);
+        acc.process_batch_start("v2.json");
+        acc.process_batch_start("v1.json");
+        assert!(!acc.is_first_commit);
     }
 }

--- a/kernel/src/log_segment/crc_replay_tests.rs
+++ b/kernel/src/log_segment/crc_replay_tests.rs
@@ -1,0 +1,351 @@
+//! Tests for `LogSegment::build_crc_from_stale` (incremental CRC catch-up via reverse log
+//! replay). Uses the fluent builder from `crc_tests` to write log files and construct a
+//! `LogSegment` directly (no `Snapshot` involvement).
+
+use super::crc_tests::{
+    metadata_a, metadata_b, metadata_ict, protocol_v2, protocol_v2_dv, protocol_v2_ict, CrcReadTest,
+};
+use crate::crc::Crc;
+use crate::Error;
+
+// === Protocol / metadata ===
+
+#[tokio::test]
+async fn test_incrementally_build_crc_newest_protocol_and_metadata_win() {
+    let crc = CrcReadTest::new()
+        .delta_with_p_m(0, protocol_v2(), metadata_a())
+        .delta_with_p_m(1, protocol_v2_dv(), metadata_b())
+        .build()
+        .await
+        .incrementally_build_crc(&Crc::default(), None)
+        .unwrap();
+    assert_eq!(crc.protocol, protocol_v2_dv());
+    assert_eq!(crc.metadata, metadata_b());
+}
+
+#[tokio::test]
+async fn test_incrementally_build_crc_preserves_base_protocol_when_segment_has_none() {
+    // Segment has no protocol action in (0, latest]; result keeps the base's protocol.
+    let base = Crc {
+        protocol: protocol_v2(),
+        metadata: metadata_a(),
+        ..Default::default()
+    };
+    let crc = CrcReadTest::new()
+        .delta_with_p_m(0, protocol_v2(), metadata_a())
+        .delta(1)
+        .build()
+        .await
+        .incrementally_build_crc(&base, None)
+        .unwrap();
+    assert_eq!(crc.protocol, protocol_v2());
+    assert_eq!(crc.metadata, metadata_a());
+}
+
+// === ICT ===
+
+#[tokio::test]
+async fn test_incrementally_build_crc_ict_captured_from_newest_commit_only() {
+    let crc = CrcReadTest::new()
+        .delta_with_p_m(0, protocol_v2_ict(), metadata_ict())
+        .delta_with_ict(1, 1000)
+        .delta_with_ict(2, 2000)
+        .build()
+        .await
+        .incrementally_build_crc(&Crc::default(), None)
+        .unwrap();
+    assert_eq!(crc.in_commit_timestamp_opt, Some(2000));
+}
+
+#[tokio::test]
+async fn test_incrementally_build_crc_ict_none_when_newest_commit_has_no_commit_info() {
+    let crc = CrcReadTest::new()
+        .delta_with_p_m(0, protocol_v2_ict(), metadata_ict())
+        .delta_with_ict(1, 1000)
+        .delta_with_txn(2, "app", 1, None)
+        .build()
+        .await
+        .incrementally_build_crc(&Crc::default(), None)
+        .unwrap();
+    assert_eq!(crc.in_commit_timestamp_opt, None);
+}
+
+// === Domain metadata ===
+
+#[tokio::test]
+async fn test_incrementally_build_crc_dm_newest_wins() {
+    let crc = CrcReadTest::new()
+        .delta_with_p_m(0, protocol_v2(), metadata_a())
+        .delta_with_dm(1, "d", "old", false)
+        .delta_with_dm(2, "d", "new", false)
+        .build()
+        .await
+        .incrementally_build_crc(&Crc::default(), None)
+        .unwrap();
+    let map = crc.domain_metadata_state.expect_partial();
+    assert_eq!(map["d"].configuration(), "new");
+    assert!(!map["d"].is_removed());
+}
+
+#[tokio::test]
+async fn test_incrementally_build_crc_dm_tombstone_removes_entry_from_base() {
+    use crate::actions::DomainMetadata;
+    use crate::crc::DomainMetadataState;
+
+    // Base has "d" in its DM map; the tombstone in the segment must remove it.
+    let base = Crc {
+        domain_metadata_state: DomainMetadataState::Complete(
+            [(
+                "d".to_string(),
+                DomainMetadata::new("d".to_string(), "stale".to_string()),
+            )]
+            .into(),
+        ),
+        ..Default::default()
+    };
+    let crc = CrcReadTest::new()
+        .delta_with_p_m(0, protocol_v2(), metadata_a())
+        .delta_with_dm(1, "d", "", true)
+        .build()
+        .await
+        .incrementally_build_crc(&base, None)
+        .unwrap();
+    // The tombstone consumed the entry; the (still Complete) map no longer contains "d".
+    assert!(!crc
+        .domain_metadata_state
+        .expect_complete()
+        .contains_key("d"));
+}
+
+// === SetTransaction ===
+
+#[tokio::test]
+async fn test_incrementally_build_crc_txn_newest_wins() {
+    let crc = CrcReadTest::new()
+        .delta_with_p_m(0, protocol_v2(), metadata_a())
+        .delta_with_txn(1, "app", 1, Some(100))
+        .delta_with_txn(2, "app", 42, Some(200))
+        .build()
+        .await
+        .incrementally_build_crc(&Crc::default(), None)
+        .unwrap();
+    let map = crc.set_transaction_state.expect_partial();
+    assert_eq!(map["app"].version, 42);
+    assert_eq!(map["app"].last_updated, Some(200));
+}
+
+// === File stats ===
+
+#[tokio::test]
+async fn test_incrementally_build_crc_adds_accumulate() {
+    let crc = CrcReadTest::new()
+        .delta_with_p_m(0, protocol_v2(), metadata_a())
+        .delta_with_add(1, "a", 100)
+        .delta_with_add(2, "b", 200)
+        .build()
+        .await
+        .incrementally_build_crc(&Crc::default(), None)
+        .unwrap();
+    let stats = crc.file_stats().unwrap();
+    assert_eq!(stats.num_files(), 2);
+    assert_eq!(stats.table_size_bytes(), 300);
+}
+
+#[tokio::test]
+async fn test_incrementally_build_crc_adds_and_removes_net_out() {
+    let crc = CrcReadTest::new()
+        .delta_with_p_m(0, protocol_v2(), metadata_a())
+        .delta_with_add(1, "a", 100)
+        .delta_with_remove(2, "old", Some(30))
+        .build()
+        .await
+        .incrementally_build_crc(&Crc::default(), None)
+        .unwrap();
+    let stats = crc.file_stats().unwrap();
+    assert_eq!(stats.num_files(), 0); // +1 -1
+    assert_eq!(stats.table_size_bytes(), 70); // +100 -30
+}
+
+#[tokio::test]
+async fn test_incrementally_build_crc_remove_with_no_size_trips_indeterminate() {
+    let crc = CrcReadTest::new()
+        .delta_with_p_m(0, protocol_v2(), metadata_a())
+        .delta_with_remove(1, "orphan", None)
+        .build()
+        .await
+        .incrementally_build_crc(&Crc::default(), None)
+        .unwrap();
+    assert!(crc.file_stats_state().is_indeterminate());
+}
+
+#[tokio::test]
+async fn test_incrementally_build_crc_unsafe_op_with_add_in_same_commit_trips_indeterminate() {
+    // Single commit carrying an add AND an unsafe operation. Without `delta_with_add_and_op`,
+    // separate `delta_with_add(1, ...)` + `delta_with_op(1, ...)` calls would collide on
+    // file `001.json` and the builder's clobber-detection would panic.
+    let crc = CrcReadTest::new()
+        .delta_with_p_m(0, protocol_v2(), metadata_a())
+        .delta_with_add_and_op(1, "a", 100, "ANALYZE STATS")
+        .build()
+        .await
+        .incrementally_build_crc(&Crc::default(), None)
+        .unwrap();
+    assert!(crc.file_stats_state().is_indeterminate());
+}
+
+// === Stale CRC on disk (real histogram, no mocking) ===
+//
+// Pattern: write a CRC at version V (file_sizes drives a real on-disk `FileSizeHistogram`),
+// then more commits at V+1..N without writing CRCs.
+// `incrementally_build_crc_from_disk_crc_at(V, None)` loads the v=V CRC from disk (real
+// `Crc` with real histogram) and advances it to the latest version.
+
+#[tokio::test]
+async fn test_incrementally_build_crc_from_disk_advances_file_stats() {
+    let built = CrcReadTest::new()
+        .delta_with_p_m(0, protocol_v2(), metadata_a())
+        .crc_with_files(0, protocol_v2(), metadata_a(), None, &[100, 200])
+        .delta_with_add(1, "c", 300)
+        .delta_with_add(2, "d", 400)
+        .build()
+        .await;
+
+    let crc = built
+        .incrementally_build_crc_from_disk_crc_at(0, None)
+        .unwrap();
+    let stats = crc.file_stats().unwrap();
+    assert_eq!(stats.num_files(), 4); // 2 from disk + 2 from replay
+    assert_eq!(stats.table_size_bytes(), 1000); // 300 + 700
+                                                // Histogram boundaries are inherited from the base on disk.
+    use crate::crc::{try_read_crc_file, FileSizeHistogram};
+    use crate::path::ParsedLogPath;
+    let base_path = ParsedLogPath::create_parsed_crc(&built.url, 0);
+    let base = try_read_crc_file(&built.engine, &base_path).unwrap();
+    let base_bins: Vec<i64> = base
+        .file_stats()
+        .unwrap()
+        .file_size_histogram()
+        .unwrap()
+        .sorted_bin_boundaries()
+        .to_vec();
+    let merged = stats.file_size_histogram().unwrap();
+    assert_eq!(merged.sorted_bin_boundaries(), base_bins.as_slice());
+    // Boundaries match the kernel default (95 bins, see `FileSizeHistogram::create_default`).
+    assert_eq!(
+        base_bins.len(),
+        FileSizeHistogram::create_default()
+            .sorted_bin_boundaries()
+            .len()
+    );
+}
+
+#[tokio::test]
+async fn test_incrementally_build_crc_from_disk_chain_stale_crc_at_v1() {
+    // v0: create + CRC ([100])
+    // v1: add + CRC ([100, 200])  -- stale base
+    // v2: add (no CRC)
+    // v3: add (no CRC)
+    let crc = CrcReadTest::new()
+        .delta_with_p_m(0, protocol_v2(), metadata_a())
+        .crc_with_files(0, protocol_v2(), metadata_a(), None, &[100])
+        .delta_with_add(1, "b", 200)
+        .crc_with_files(1, protocol_v2(), metadata_a(), None, &[100, 200])
+        .delta_with_add(2, "c", 300)
+        .delta_with_add(3, "d", 400)
+        .build()
+        .await
+        .incrementally_build_crc_from_disk_crc_at(1, None)
+        .unwrap();
+    let stats = crc.file_stats().unwrap();
+    assert_eq!(stats.num_files(), 4); // 2 from disk + 2 from replay
+    assert_eq!(stats.table_size_bytes(), 1000); // 300 + 700
+    assert_eq!(crc.version, 3);
+}
+
+#[tokio::test]
+async fn test_incrementally_build_crc_from_disk_remove_decrements_real_histogram() {
+    // Stale CRC at v0 carries [100, 200, 300]; the segment removes one of those files.
+    let built = CrcReadTest::new()
+        .delta_with_p_m(0, protocol_v2(), metadata_a())
+        .crc_with_files(0, protocol_v2(), metadata_a(), None, &[100, 200, 300])
+        .delta_with_remove(1, "x", Some(200))
+        .build()
+        .await;
+
+    let crc = built
+        .incrementally_build_crc_from_disk_crc_at(0, None)
+        .unwrap();
+    let stats = crc.file_stats().unwrap();
+    assert_eq!(stats.num_files(), 2); // 3 from disk - 1 from replay
+    assert_eq!(stats.table_size_bytes(), 400); // 600 - 200
+    assert!(stats.file_size_histogram().is_some());
+}
+
+#[tokio::test]
+async fn test_incrementally_build_crc_from_disk_no_histogram_means_no_result_histogram() {
+    let crc = CrcReadTest::new()
+        .delta_with_p_m(0, protocol_v2(), metadata_a())
+        .crc(0, protocol_v2(), metadata_a(), None) // empty file_sizes -> no histogram on disk
+        .delta_with_add(1, "a", 100)
+        .build()
+        .await
+        .incrementally_build_crc_from_disk_crc_at(0, None)
+        .unwrap();
+    assert!(crc.file_stats().unwrap().file_size_histogram().is_none());
+}
+
+// === Result version stamping ===
+
+#[tokio::test]
+async fn test_incrementally_build_crc_stamps_version_with_segment_end() {
+    let crc = CrcReadTest::new()
+        .delta_with_p_m(0, protocol_v2(), metadata_a())
+        .delta(1)
+        .delta(2)
+        .build()
+        .await
+        .incrementally_build_crc(&Crc::default(), None)
+        .unwrap();
+    assert_eq!(crc.version, 2);
+}
+
+// === Preconditions ===
+
+#[tokio::test]
+async fn test_incrementally_build_crc_errors_when_base_version_at_end_version() {
+    let test = CrcReadTest::new()
+        .delta_with_p_m(0, protocol_v2(), metadata_a())
+        .build()
+        .await;
+    let err = test
+        .incrementally_build_crc(&Crc::default(), Some(0))
+        .unwrap_err();
+    assert!(matches!(err, Error::InternalError(_)));
+}
+
+#[tokio::test]
+async fn test_incrementally_build_crc_errors_when_base_version_above_end_version() {
+    let test = CrcReadTest::new()
+        .delta_with_p_m(0, protocol_v2(), metadata_a())
+        .build()
+        .await;
+    let base = Crc {
+        version: 5,
+        ..Default::default()
+    };
+    let err = test.incrementally_build_crc(&base, Some(0)).unwrap_err();
+    assert!(matches!(err, Error::InternalError(_)));
+}
+
+#[tokio::test]
+async fn test_incrementally_build_crc_errors_when_segment_has_gap_above_base_version() {
+    // Builder writes v0 and v2 only — v1 is missing. `for_snapshot_impl`'s listing layer
+    // catches this gap before `build_crc_from_stale` is even invoked, so the resulting
+    // error isn't from our own gap check. We just want the call to fail.
+    let test = CrcReadTest::new()
+        .delta_with_p_m(0, protocol_v2(), metadata_a())
+        .delta_with_p_m(2, protocol_v2(), metadata_a())
+        .build()
+        .await;
+    assert!(test.incrementally_build_crc(&Crc::default(), None).is_err());
+}

--- a/kernel/src/log_segment/crc_tests.rs
+++ b/kernel/src/log_segment/crc_tests.rs
@@ -3,18 +3,21 @@
 //! Each test sets up an in-memory Delta log with V2 checkpoint JSONs, commit files, and CRC files,
 //! then verifies that Protocol & Metadata loading and ICT reads resolve correctly.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use serde_json::json;
 use test_utils::{assert_result_error_with_message, delta_path_for_version};
 use url::Url;
 
+use super::LogSegment;
 use crate::actions::{CommitInfo, Format, Metadata, Protocol};
+use crate::crc::{try_read_crc_file, Crc, FileSizeHistogram};
 use crate::engine::sync::SyncEngine;
 use crate::object_store::memory::InMemory;
 use crate::object_store::ObjectStoreExt as _;
-use crate::Snapshot;
+use crate::path::ParsedLogPath;
+use crate::{DeltaResult, Engine, Snapshot};
 
 // ============================================================================
 // Expected values
@@ -22,11 +25,11 @@ use crate::Snapshot;
 
 const SCHEMA_STRING: &str = r#"{"type":"struct","fields":[{"name":"id","type":"integer","nullable":true,"metadata":{}},{"name":"val","type":"string","nullable":true,"metadata":{}}]}"#;
 
-fn protocol_v2() -> Protocol {
+pub(super) fn protocol_v2() -> Protocol {
     Protocol::try_new_modern(["v2Checkpoint"], ["v2Checkpoint"]).unwrap()
 }
 
-fn protocol_v2_dv() -> Protocol {
+pub(super) fn protocol_v2_dv() -> Protocol {
     Protocol::try_new_modern(
         ["v2Checkpoint", "deletionVectors"],
         ["v2Checkpoint", "deletionVectors"],
@@ -34,7 +37,7 @@ fn protocol_v2_dv() -> Protocol {
     .unwrap()
 }
 
-fn protocol_v2_dv_ntz() -> Protocol {
+pub(super) fn protocol_v2_dv_ntz() -> Protocol {
     Protocol::try_new_modern(
         ["v2Checkpoint", "deletionVectors", "timestampNtz"],
         ["v2Checkpoint", "deletionVectors", "timestampNtz"],
@@ -42,7 +45,7 @@ fn protocol_v2_dv_ntz() -> Protocol {
     .unwrap()
 }
 
-fn protocol_v2_ict() -> Protocol {
+pub(super) fn protocol_v2_ict() -> Protocol {
     Protocol::try_new(
         3,
         7,
@@ -52,7 +55,7 @@ fn protocol_v2_ict() -> Protocol {
     .unwrap()
 }
 
-fn metadata_a() -> Metadata {
+pub(super) fn metadata_a() -> Metadata {
     Metadata::new_unchecked(
         "aaa",
         None,
@@ -65,7 +68,7 @@ fn metadata_a() -> Metadata {
     )
 }
 
-fn metadata_b() -> Metadata {
+pub(super) fn metadata_b() -> Metadata {
     Metadata::new_unchecked(
         "bbb",
         None,
@@ -78,7 +81,7 @@ fn metadata_b() -> Metadata {
     )
 }
 
-fn metadata_ict() -> Metadata {
+pub(super) fn metadata_ict() -> Metadata {
     Metadata::new_unchecked(
         "5fba94ed-9794-4965-ba6e-6ee3c0d22af9",
         None,
@@ -128,19 +131,79 @@ fn commit_info_json_with_ict(ict: i64) -> serde_json::Value {
     }})
 }
 
-fn crc_json(protocol: &Protocol, metadata: &Metadata, ict: Option<i64>) -> serde_json::Value {
+fn crc_json(
+    protocol: &Protocol,
+    metadata: &Metadata,
+    ict: Option<i64>,
+    file_sizes: &[i64],
+) -> serde_json::Value {
+    let total_bytes: i64 = file_sizes.iter().sum();
+    let num_files = file_sizes.len() as i64;
     let mut v = json!({
-        "tableSizeBytes": 0,
-        "numFiles": 0,
+        "tableSizeBytes": total_bytes,
+        "numFiles": num_files,
         "numMetadata": 1,
         "numProtocol": 1,
         "metadata": serde_json::to_value(metadata).unwrap(),
         "protocol": serde_json::to_value(protocol).unwrap(),
     });
+    if !file_sizes.is_empty() {
+        let mut hist = FileSizeHistogram::create_default();
+        for &s in file_sizes {
+            hist.insert(s).unwrap();
+        }
+        v["fileSizeHistogram"] = serde_json::to_value(&hist).unwrap();
+    }
     if let Some(ict) = ict {
         v["inCommitTimestampOpt"] = json!(ict);
     }
     v
+}
+
+fn add_action_json(path: &str, size: i64) -> serde_json::Value {
+    json!({"add": {
+        "path": path, "size": size, "partitionValues": {},
+        "modificationTime": 0, "dataChange": true,
+    }})
+}
+
+fn remove_action_json(path: &str, size: Option<i64>) -> serde_json::Value {
+    match size {
+        Some(s) => json!({"remove": {
+            "path": path, "size": s,
+            "dataChange": true, "deletionTimestamp": 0,
+        }}),
+        None => json!({"remove": {
+            "path": path,
+            "dataChange": true, "deletionTimestamp": 0,
+        }}),
+    }
+}
+
+fn domain_metadata_action_json(
+    domain: &str,
+    configuration: &str,
+    removed: bool,
+) -> serde_json::Value {
+    json!({"domainMetadata": {
+        "domain": domain, "configuration": configuration, "removed": removed,
+    }})
+}
+
+fn set_transaction_action_json(
+    app_id: &str,
+    txn_version: i64,
+    last_updated: Option<i64>,
+) -> serde_json::Value {
+    let mut v = json!({"txn": {"appId": app_id, "version": txn_version}});
+    if let Some(lu) = last_updated {
+        v["txn"]["lastUpdated"] = json!(lu);
+    }
+    v
+}
+
+fn commit_info_json_with_op(operation: &str) -> serde_json::Value {
+    json!({"commitInfo": {"timestamp": 1587968586154i64, "operation": operation}})
 }
 
 // ============================================================================
@@ -148,7 +211,7 @@ fn crc_json(protocol: &Protocol, metadata: &Metadata, ict: Option<i64>) -> serde
 // ============================================================================
 
 /// Operations that can be applied to an in-memory Delta log.
-enum Op {
+pub(super) enum Op {
     V2Checkpoint {
         version: u64,
         protocol: Protocol,
@@ -164,27 +227,61 @@ enum Op {
         version: u64,
         ict: i64,
     },
+    DeltaWithAdd {
+        version: u64,
+        path: String,
+        size: i64,
+    },
+    DeltaWithAddAndOperation {
+        version: u64,
+        path: String,
+        size: i64,
+        operation: String,
+    },
+    DeltaWithRemove {
+        version: u64,
+        path: String,
+        size: Option<i64>,
+    },
+    DeltaWithDomainMetadata {
+        version: u64,
+        domain: String,
+        configuration: String,
+        removed: bool,
+    },
+    DeltaWithTxn {
+        version: u64,
+        app_id: String,
+        txn_version: i64,
+        last_updated: Option<i64>,
+    },
     Crc {
         version: u64,
         protocol: Protocol,
         metadata: Metadata,
         ict: Option<i64>,
+        file_sizes: Vec<i64>,
     },
     CorruptCrc(u64),
 }
 
 /// Declarative test builder: accumulate log operations, then build and assert.
-struct CrcReadTest {
+pub(super) struct CrcReadTest {
     ops: Vec<Op>,
 }
 
 impl CrcReadTest {
-    fn new() -> Self {
+    pub(super) fn new() -> Self {
         Self { ops: vec![] }
     }
 
     /// Write a V2 checkpoint at the given version.
-    fn v2_checkpoint(mut self, version: u64, protocol: Protocol, metadata: Metadata) -> Self {
+    pub(super) fn v2_checkpoint(
+        mut self,
+        version: u64,
+        protocol: Protocol,
+        metadata: Metadata,
+    ) -> Self {
         self.ops.push(Op::V2Checkpoint {
             version,
             protocol,
@@ -194,13 +291,13 @@ impl CrcReadTest {
     }
 
     /// Write a plain delta (commitInfo only, no protocol or metadata).
-    fn delta(mut self, version: u64) -> Self {
+    pub(super) fn delta(mut self, version: u64) -> Self {
         self.ops.push(Op::Delta(version));
         self
     }
 
     /// Write a delta with optional protocol and/or metadata overrides.
-    fn delta_with_p_m(
+    pub(super) fn delta_with_p_m(
         mut self,
         version: u64,
         protocol: impl Into<Option<Protocol>>,
@@ -215,13 +312,85 @@ impl CrcReadTest {
     }
 
     /// Write a delta with an in-commit timestamp in commitInfo.
-    fn delta_with_ict(mut self, version: u64, ict: i64) -> Self {
+    pub(super) fn delta_with_ict(mut self, version: u64, ict: i64) -> Self {
         self.ops.push(Op::DeltaWithIct { version, ict });
         self
     }
 
-    /// Write a CRC file with the given protocol, metadata, and optional ICT.
-    fn crc(
+    /// Write a delta containing an `add` action.
+    pub(super) fn delta_with_add(mut self, version: u64, path: &str, size: i64) -> Self {
+        self.ops.push(Op::DeltaWithAdd {
+            version,
+            path: path.to_string(),
+            size,
+        });
+        self
+    }
+
+    /// Write a delta containing an `add` action AND a commitInfo with the given operation
+    /// (e.g., `"ANALYZE STATS"`). Single commit, two action rows.
+    pub(super) fn delta_with_add_and_op(
+        mut self,
+        version: u64,
+        path: &str,
+        size: i64,
+        operation: &str,
+    ) -> Self {
+        self.ops.push(Op::DeltaWithAddAndOperation {
+            version,
+            path: path.to_string(),
+            size,
+            operation: operation.to_string(),
+        });
+        self
+    }
+
+    /// Write a delta containing a `remove` action. `size = None` omits the field on disk.
+    pub(super) fn delta_with_remove(mut self, version: u64, path: &str, size: Option<i64>) -> Self {
+        self.ops.push(Op::DeltaWithRemove {
+            version,
+            path: path.to_string(),
+            size,
+        });
+        self
+    }
+
+    /// Write a delta containing a `domainMetadata` action.
+    pub(super) fn delta_with_dm(
+        mut self,
+        version: u64,
+        domain: &str,
+        configuration: &str,
+        removed: bool,
+    ) -> Self {
+        self.ops.push(Op::DeltaWithDomainMetadata {
+            version,
+            domain: domain.to_string(),
+            configuration: configuration.to_string(),
+            removed,
+        });
+        self
+    }
+
+    /// Write a delta containing a `txn` action.
+    pub(super) fn delta_with_txn(
+        mut self,
+        version: u64,
+        app_id: &str,
+        txn_version: i64,
+        last_updated: Option<i64>,
+    ) -> Self {
+        self.ops.push(Op::DeltaWithTxn {
+            version,
+            app_id: app_id.to_string(),
+            txn_version,
+            last_updated,
+        });
+        self
+    }
+
+    /// Write a CRC file with the given protocol, metadata, and optional ICT. No file stats.
+    pub(super) fn crc(
         mut self,
         version: u64,
         protocol: Protocol,
@@ -233,21 +402,52 @@ impl CrcReadTest {
             protocol,
             metadata,
             ict: ict.into(),
+            file_sizes: vec![],
+        });
+        self
+    }
+
+    /// Write a CRC file with a real on-disk `FileSizeHistogram` computed from `file_sizes`.
+    pub(super) fn crc_with_files(
+        mut self,
+        version: u64,
+        protocol: Protocol,
+        metadata: Metadata,
+        ict: impl Into<Option<i64>>,
+        file_sizes: &[i64],
+    ) -> Self {
+        self.ops.push(Op::Crc {
+            version,
+            protocol,
+            metadata,
+            ict: ict.into(),
+            file_sizes: file_sizes.to_vec(),
         });
         self
     }
 
     /// Write a corrupt CRC file.
-    fn corrupt_crc(mut self, version: u64) -> Self {
+    pub(super) fn corrupt_crc(mut self, version: u64) -> Self {
         self.ops.push(Op::CorruptCrc(version));
         self
     }
 
     /// Execute all operations, returning a built test that can be asserted against.
-    async fn build(self) -> BuiltCrcTest {
+    pub(super) async fn build(self) -> BuiltCrcTest {
         let store = Arc::new(InMemory::new());
         let url = Url::parse("memory:///").unwrap();
         let engine = SyncEngine::new_with_store(store.clone());
+
+        // Catch the footgun where two ops resolve to the same `(version, suffix)` on disk,
+        // because `put` is last-writer-wins and would silently clobber the earlier write.
+        let mut seen: HashSet<(u64, &'static str)> = HashSet::new();
+        let mut claim = |v: u64, suffix: &'static str| {
+            assert!(
+                seen.insert((v, suffix)),
+                "CrcReadTest: two ops both write to version={v} suffix={suffix:?}; \
+                 the later one silently overwrites the earlier one"
+            );
+        };
 
         for op in self.ops {
             match op {
@@ -256,6 +456,7 @@ impl CrcReadTest {
                     ref protocol,
                     ref metadata,
                 } => {
+                    claim(v, V2_CKPT_SUFFIX);
                     let content = format!(
                         "{}\n{}\n{}",
                         protocol_action_json(protocol),
@@ -265,6 +466,7 @@ impl CrcReadTest {
                     put(&store, v, V2_CKPT_SUFFIX, &content).await;
                 }
                 Op::Delta(v) => {
+                    claim(v, "json");
                     put(&store, v, "json", &commit_info_json().to_string()).await;
                 }
                 Op::DeltaWithPM {
@@ -272,6 +474,7 @@ impl CrcReadTest {
                     protocol,
                     metadata,
                 } => {
+                    claim(v, "json");
                     let mut lines = vec![commit_info_json().to_string()];
                     if let Some(ref p) = protocol {
                         lines.push(protocol_action_json(p).to_string());
@@ -282,6 +485,7 @@ impl CrcReadTest {
                     put(&store, v, "json", &lines.join("\n")).await;
                 }
                 Op::DeltaWithIct { version: v, ict } => {
+                    claim(v, "json");
                     put(
                         &store,
                         v,
@@ -290,21 +494,85 @@ impl CrcReadTest {
                     )
                     .await;
                 }
+                Op::DeltaWithAdd {
+                    version: v,
+                    ref path,
+                    size,
+                } => {
+                    claim(v, "json");
+                    let content =
+                        format!("{}\n{}", add_action_json(path, size), commit_info_json());
+                    put(&store, v, "json", &content).await;
+                }
+                Op::DeltaWithAddAndOperation {
+                    version: v,
+                    ref path,
+                    size,
+                    ref operation,
+                } => {
+                    claim(v, "json");
+                    let content = format!(
+                        "{}\n{}",
+                        add_action_json(path, size),
+                        commit_info_json_with_op(operation)
+                    );
+                    put(&store, v, "json", &content).await;
+                }
+                Op::DeltaWithRemove {
+                    version: v,
+                    ref path,
+                    size,
+                } => {
+                    claim(v, "json");
+                    let content =
+                        format!("{}\n{}", remove_action_json(path, size), commit_info_json());
+                    put(&store, v, "json", &content).await;
+                }
+                Op::DeltaWithDomainMetadata {
+                    version: v,
+                    ref domain,
+                    ref configuration,
+                    removed,
+                } => {
+                    claim(v, "json");
+                    let content = format!(
+                        "{}\n{}",
+                        domain_metadata_action_json(domain, configuration, removed),
+                        commit_info_json()
+                    );
+                    put(&store, v, "json", &content).await;
+                }
+                Op::DeltaWithTxn {
+                    version: v,
+                    ref app_id,
+                    txn_version,
+                    last_updated,
+                } => {
+                    claim(v, "json");
+                    // No commitInfo: an ICT replay test exercises "newest commit has no
+                    // commitInfo" via a txn-only commit.
+                    let content =
+                        set_transaction_action_json(app_id, txn_version, last_updated).to_string();
+                    put(&store, v, "json", &content).await;
+                }
                 Op::Crc {
                     version: v,
                     ref protocol,
                     ref metadata,
                     ict,
+                    ref file_sizes,
                 } => {
+                    claim(v, "crc");
                     put(
                         &store,
                         v,
                         "crc",
-                        &crc_json(protocol, metadata, ict).to_string(),
+                        &crc_json(protocol, metadata, ict, file_sizes).to_string(),
                     )
                     .await;
                 }
                 Op::CorruptCrc(v) => {
+                    claim(v, "crc");
                     put(&store, v, "crc", "CORRUPT_CRC_DATA").await;
                 }
             }
@@ -314,12 +582,42 @@ impl CrcReadTest {
     }
 }
 
-struct BuiltCrcTest {
-    engine: SyncEngine,
-    url: Url,
+pub(super) struct BuiltCrcTest {
+    pub(super) engine: SyncEngine,
+    pub(super) url: Url,
 }
 
 impl BuiltCrcTest {
+    /// Construct a `LogSegment` directly from the store state (no `Snapshot`) and run
+    /// `build_crc_from_stale` against `base`. `target_version = None` means latest.
+    pub(super) fn incrementally_build_crc(
+        &self,
+        base: &Crc,
+        target_version: impl Into<Option<u64>>,
+    ) -> DeltaResult<Crc> {
+        let storage = self.engine.storage_handler();
+        let log_root = self.url.join("_delta_log/").unwrap();
+        let log_segment = LogSegment::for_snapshot_impl(
+            storage.as_ref(),
+            log_root,
+            vec![],
+            None,
+            target_version.into(),
+        )?;
+        log_segment.build_crc_from_stale(&self.engine, base)
+    }
+
+    /// Load the on-disk CRC at `crc_version` and use it as the replay base.
+    pub(super) fn incrementally_build_crc_from_disk_crc_at(
+        &self,
+        crc_version: u64,
+        target_version: impl Into<Option<u64>>,
+    ) -> DeltaResult<Crc> {
+        let crc_path = ParsedLogPath::create_parsed_crc(&self.url, crc_version);
+        let base = try_read_crc_file(&self.engine, &crc_path)?;
+        self.incrementally_build_crc(&base, target_version)
+    }
+
     fn assert_p_m(
         &self,
         version: impl Into<Option<u64>>,

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -31,6 +31,7 @@ use crate::{
     StorageHandler, Version,
 };
 
+mod crc_replay;
 mod domain_metadata_replay;
 mod protocol_metadata_replay;
 

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -38,6 +38,8 @@ mod protocol_metadata_replay;
 pub(crate) use domain_metadata_replay::DomainMetadataMap;
 
 #[cfg(test)]
+mod crc_replay_tests;
+#[cfg(test)]
 mod crc_tests;
 #[cfg(test)]
 mod tests;

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -591,6 +591,7 @@ impl Snapshot {
             .map(|base| {
                 let mut crc = base.as_ref().clone();
                 crc.apply(crc_delta);
+                crc.version = new_version;
                 crc
             });
 

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -14,7 +14,7 @@ use crate::actions::{
 use crate::committer::{
     CommitMetadata, CommitProtocolMetadata, CommitResponse, CommitType, Committer,
 };
-use crate::crc::{CrcDelta, FileStatsDelta, LazyCrc};
+use crate::crc::{is_incremental_safe_operation, CrcDelta, FileStatsDelta, LazyCrc};
 use crate::engine_data::FilteredEngineData;
 use crate::error::Error;
 use crate::expressions::UnaryExpressionOp::ToJson;
@@ -1216,6 +1216,28 @@ impl<S> Transaction<S> {
             &self.remove_files_metadata,
             bin_boundaries,
         )?;
+        // TODO: drop these conversions by migrating the upstream chain
+        //       (`CommitMetadata.domain_metadata_changes`, `Transaction.set_transactions`)
+        //       to `HashMap<String, _>`, lifting protocol-mandated uniqueness from runtime
+        //       checks into the type system.
+        let domain_metadata = dm_changes
+            .into_iter()
+            .map(|dm| (dm.domain().to_string(), dm))
+            .collect();
+        let set_transactions = self
+            .set_transactions
+            .iter()
+            .map(|txn| (txn.app_id.clone(), txn.clone()))
+            .collect();
+        // Although `remove.size` is optional per the Delta protocol, the kernel write path
+        // enforces presence: `try_compute_for_txn` above errors with `MissingData` if any
+        // add or remove row lacks `size` (see `FileStatsVisitor::visit` in
+        // `kernel/src/crc/file_stats.rs`). So at this point every size is known to be
+        // present, and only operation classification can flip `is_incremental_safe`.
+        let is_incremental_safe = self
+            .operation
+            .as_deref()
+            .is_some_and(is_incremental_safe_operation);
         Ok(CrcDelta {
             file_stats,
             protocol: self
@@ -1224,11 +1246,10 @@ impl<S> Transaction<S> {
             metadata: self
                 .should_emit_metadata
                 .then(|| self.effective_table_config.metadata().clone()),
-            domain_metadata_changes: dm_changes,
-            set_transaction_changes: self.set_transactions.clone(),
+            domain_metadata,
+            set_transactions,
             in_commit_timestamp,
-            operation: self.operation.clone(),
-            has_missing_file_size: false, // writes always have sizes
+            is_incremental_safe,
         })
     }
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2592/files/6df5f512a4065311578f32496a04cbef1d89489b..8d9145a4e089af83d8ed696c88a5cff85da47d13) to review incremental changes.
- [stack/incremental_crc_5a](https://github.com/delta-io/delta-kernel-rs/pull/2583) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2583/files)]
  - [**stack/incremental_crc_5c**](https://github.com/delta-io/delta-kernel-rs/pull/2592) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2592/files/6df5f512a4065311578f32496a04cbef1d89489b..8d9145a4e089af83d8ed696c88a5cff85da47d13)]

---------
## What changes are proposed in this pull request?

Adds `LogSegment::build_crc_delta_from_stale`, which reverse-replays the
commits in `(base.version, end_version]` and produces a `CrcDelta`. Applying
the delta to a stale base CRC advances it to the target version without
re-reading the entire log.

Also adds a `version` field to `Crc` (populated from the `.crc` filename in
the reader; chained through `compute_post_commit_crc`) so callers can use
`base.version` as the source of truth for "what version is this CRC at."

No production caller yet; the entry point is gated by `dead_code` until the
Snapshot wiring lands in a follow-up PR.

## How was this change tested?
