### PR TITLE
feat: support variantShredding as a feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,7 +228,8 @@ is the source of truth. Key concepts:
   `clustering`, `inCommitTimestamp`
 - Reader + writer: `catalogManaged`, `catalogOwned-preview`, `columnMapping`,
   `deletionVectors`, `timestampNtz`, `v2Checkpoint`, `vacuumProtocolCheck`,
-  `variantType`, `variantType-preview`, `typeWidening`
+  `variantType`, `variantType-preview`, `variantShredding`, `variantShredding-preview`,
+  `typeWidening`
 
 Keep this list updated when new protocol features are added to kernel.
 

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -155,6 +155,7 @@ pub(crate) enum TableFeature {
     #[strum(serialize = "variantType-preview")]
     #[serde(rename = "variantType-preview")]
     VariantTypePreview,
+    VariantShredding,
     #[strum(serialize = "variantShredding-preview")]
     #[serde(rename = "variantShredding-preview")]
     VariantShreddingPreview,
@@ -597,6 +598,14 @@ static VARIANT_TYPE_PREVIEW_INFO: FeatureInfo = FeatureInfo {
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 
+static VARIANT_SHREDDING_INFO: FeatureInfo = FeatureInfo {
+    feature_type: FeatureType::ReaderWriter,
+    min_legacy_version: None,
+    feature_requirements: &[],
+    kernel_support: KernelSupport::Supported,
+    enablement_check: EnablementCheck::AlwaysIfSupported,
+};
+
 static VARIANT_SHREDDING_PREVIEW_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::ReaderWriter,
     min_legacy_version: None,
@@ -635,6 +644,7 @@ impl TableFeature {
             | TableFeature::VacuumProtocolCheck
             | TableFeature::VariantType
             | TableFeature::VariantTypePreview
+            | TableFeature::VariantShredding
             | TableFeature::VariantShreddingPreview => FeatureType::ReaderWriter,
             TableFeature::AppendOnly
             | TableFeature::DomainMetadata
@@ -698,6 +708,7 @@ impl TableFeature {
             TableFeature::VacuumProtocolCheck => &VACUUM_PROTOCOL_CHECK_INFO,
             TableFeature::VariantType => &VARIANT_TYPE_INFO,
             TableFeature::VariantTypePreview => &VARIANT_TYPE_PREVIEW_INFO,
+            TableFeature::VariantShredding => &VARIANT_SHREDDING_INFO,
             TableFeature::VariantShreddingPreview => &VARIANT_SHREDDING_PREVIEW_INFO,
 
             // Unknown features: not supported by kernel, no legacy version inference.
@@ -835,6 +846,7 @@ mod tests {
                 TableFeature::VacuumProtocolCheck => "vacuumProtocolCheck",
                 TableFeature::VariantType => "variantType",
                 TableFeature::VariantTypePreview => "variantType-preview",
+                TableFeature::VariantShredding => "variantShredding",
                 TableFeature::VariantShreddingPreview => "variantShredding-preview",
                 TableFeature::Unknown(_) => continue, // tested in test_unknown_features
             };

--- a/kernel/tests/integration/write/types.rs
+++ b/kernel/tests/integration/write/types.rs
@@ -113,8 +113,13 @@ async fn test_append_timestamp_ntz() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[rstest]
+#[case::shredding_preview(vec!["variantType", "variantShredding-preview"])]
+#[case::shredding(vec!["variantType", "variantShredding"])]
 #[tokio::test]
-async fn test_append_variant() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_append_variant(
+    #[case] features: Vec<&str>,
+) -> Result<(), Box<dyn std::error::Error>> {
     // setup tracing
     let _ = tracing_subscriber::fmt::try_init();
     fn unshredded_variant_schema_flipped() -> DataType {
@@ -162,8 +167,8 @@ async fn test_append_variant() -> Result<(), Box<dyn std::error::Error>> {
         table_schema.clone(),
         &[],
         true,
-        vec!["variantType", "variantShredding-preview"],
-        vec!["variantType", "variantShredding-preview"],
+        features.clone(),
+        features,
     )
     .await?;
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Just duplicates the existing support for `variantShredding-preview`.

## How was this change tested?

Added to the round-trip test, and made the existing preview enabled on a table test test both features.