### PR TITLE
feat: Two tiny CRC refactors

### DIFF
--- a/kernel/src/crc/delta.rs
+++ b/kernel/src/crc/delta.rs
@@ -95,7 +95,7 @@ impl Crc {
     ///   upsert by domain. Set transactions: upsert by app_id. The `Complete`/`Partial` variant is
     ///   preserved in both cases.
     /// - File stats: governed by the [`FileStatsState`] state machine.
-    pub(crate) fn apply(&mut self, delta: CrcDelta, new_version: Version) {
+    pub(crate) fn apply(mut self, delta: CrcDelta, new_version: Version) -> Self {
         debug_assert!(
             new_version > self.version,
             "Crc::apply must advance version: self.version={}, new_version={}",
@@ -143,6 +143,7 @@ impl Crc {
         );
 
         self.version = new_version;
+        self
     }
 }
 
@@ -299,8 +300,7 @@ mod tests {
 
     #[test]
     fn test_apply_updates_file_stats() {
-        let mut crc = base_crc();
-        crc.apply(write_delta(3, 600), 1);
+        let crc = base_crc().apply(write_delta(3, 600), 1);
         let stats = crc.file_stats().unwrap();
         assert_eq!(stats.num_files(), 13); // 10 + 3
         assert_eq!(stats.table_size_bytes(), 1600); // 1000 + 600
@@ -311,9 +311,9 @@ mod tests {
     /// Applies multiple commit deltas sequentially.
     #[test]
     fn test_apply_multiple_deltas() {
-        let mut crc = base_crc();
-        crc.apply(write_delta(3, 600), 1);
-        crc.apply(write_delta(-2, -400), 2);
+        let crc = base_crc()
+            .apply(write_delta(3, 600), 1)
+            .apply(write_delta(-2, -400), 2);
         let stats = crc.file_stats().unwrap();
         assert_eq!(stats.num_files(), 11); // 10 + 3 - 2
         assert_eq!(stats.table_size_bytes(), 1200); // 1000 + 600 - 400
@@ -323,27 +323,25 @@ mod tests {
 
     #[test]
     fn test_apply_not_incremental_safe_transitions_to_indeterminate() {
-        let mut crc = base_crc();
         let unsafe_change = CrcDelta {
             is_incremental_safe: false,
             ..write_delta(1, 100)
         };
-        crc.apply(unsafe_change, 1);
+        let crc = base_crc().apply(unsafe_change, 1);
         assert!(crc.file_stats_state.is_indeterminate());
     }
 
     #[test]
     fn test_indeterminate_stays_indeterminate() {
-        let mut crc = base_crc();
         let unsafe_change = CrcDelta {
             is_incremental_safe: false,
             ..write_delta(1, 100)
         };
-        crc.apply(unsafe_change, 1);
+        let crc = base_crc().apply(unsafe_change, 1);
         assert!(crc.file_stats_state.is_indeterminate());
 
         // Subsequent safe op doesn't recover the state. Version still advances.
-        crc.apply(write_delta(5, 500), 2);
+        let crc = crc.apply(write_delta(5, 500), 2);
         assert!(crc.file_stats_state.is_indeterminate());
         assert_eq!(crc.version, 2);
     }
@@ -352,7 +350,6 @@ mod tests {
 
     #[test]
     fn test_apply_replaces_protocol() {
-        let mut crc = base_crc();
         let new_protocol = Protocol::try_new(
             2,
             5,
@@ -364,7 +361,7 @@ mod tests {
             protocol: Some(new_protocol.clone()),
             ..write_delta(0, 0)
         };
-        crc.apply(delta, 1);
+        let crc = base_crc().apply(delta, 1);
         assert_eq!(crc.protocol, new_protocol);
         assert_eq!(crc.metadata, Metadata::default()); // unchanged
     }
@@ -377,8 +374,6 @@ mod tests {
     #[case::partial(DomainMetadataState::Partial(seed_dm_map()))]
     fn test_apply_dm_upserts_inserts_and_removes(#[case] base: DomainMetadataState) {
         let was_complete = matches!(base, DomainMetadataState::Complete(_));
-        let mut crc = base_crc();
-        crc.domain_metadata_state = base;
         let delta = CrcDelta {
             domain_metadata: HashMap::from([
                 dm_entry("keep", "new"),
@@ -387,7 +382,11 @@ mod tests {
             ]),
             ..write_delta(0, 0)
         };
-        crc.apply(delta, 1);
+        let crc = Crc {
+            domain_metadata_state: base,
+            ..base_crc()
+        }
+        .apply(delta, 1);
 
         // Bind the inner map AND panic if the variant flipped during apply.
         let map = match &crc.domain_metadata_state {
@@ -403,24 +402,25 @@ mod tests {
 
     #[test]
     fn test_apply_replaces_in_commit_timestamp() {
-        let mut crc = base_crc();
         let delta = CrcDelta {
             in_commit_timestamp: Some(9999),
             ..write_delta(0, 0)
         };
-        crc.apply(delta, 1);
+        let crc = base_crc().apply(delta, 1);
         assert_eq!(crc.in_commit_timestamp_opt, Some(9999));
     }
 
     #[test]
     fn test_apply_clears_in_commit_timestamp_when_delta_is_none() {
-        let mut crc = base_crc();
-        crc.in_commit_timestamp_opt = Some(1000);
         let delta = CrcDelta {
             in_commit_timestamp: None,
             ..write_delta(0, 0)
         };
-        crc.apply(delta, 1);
+        let crc = Crc {
+            in_commit_timestamp_opt: Some(1000),
+            ..base_crc()
+        }
+        .apply(delta, 1);
         assert_eq!(crc.in_commit_timestamp_opt, None);
     }
 
@@ -523,8 +523,6 @@ mod tests {
     #[case::partial(SetTransactionState::Partial(seed_txn_map()))]
     fn test_apply_upserts_and_inserts_set_transactions(#[case] base: SetTransactionState) {
         let was_complete = matches!(base, SetTransactionState::Complete(_));
-        let mut crc = base_crc();
-        crc.set_transaction_state = base;
         let delta = CrcDelta {
             set_transactions: HashMap::from([
                 txn_entry("existing", 2, Some(2000)),
@@ -532,7 +530,11 @@ mod tests {
             ]),
             ..write_delta(0, 0)
         };
-        crc.apply(delta, 1);
+        let crc = Crc {
+            set_transaction_state: base,
+            ..base_crc()
+        }
+        .apply(delta, 1);
 
         let map = match &crc.set_transaction_state {
             SetTransactionState::Complete(m) if was_complete => m,
@@ -637,9 +639,8 @@ mod tests {
         #[case] remove: &[i64],
         #[case] expected_bins: &[(usize, i64, i64)],
     ) {
-        let mut crc = base_crc_with_histogram(base);
         let delta = write_delta_with_histograms(add, remove);
-        crc.apply(delta, 1);
+        let crc = base_crc_with_histogram(base).apply(delta, 1);
 
         let stats = crc.file_stats().unwrap();
         let hist = stats.file_size_histogram().unwrap();
@@ -653,7 +654,7 @@ mod tests {
     #[case::base_none_delta_none(None)]
     #[case::base_some_delta_none(Some(vec![100i64, 200]))]
     fn apply_drops_histogram_when_delta_missing_histogram(#[case] base_files: Option<Vec<i64>>) {
-        let mut crc = match &base_files {
+        let base = match &base_files {
             Some(sizes) => base_crc_with_histogram(sizes),
             None => base_crc(),
         };
@@ -666,7 +667,7 @@ mod tests {
             is_incremental_safe: true,
             ..Default::default()
         };
-        crc.apply(delta, 1);
+        let crc = base.apply(delta, 1);
         let stats = crc.file_stats().unwrap();
         assert!(
             stats.file_size_histogram().is_none(),
@@ -676,12 +677,11 @@ mod tests {
 
     #[test]
     fn apply_drops_histogram_on_indeterminate() {
-        let mut crc = base_crc_with_histogram(&[100, 200]);
         let unsafe_delta = CrcDelta {
             is_incremental_safe: false,
             ..write_delta(1, 100)
         };
-        crc.apply(unsafe_delta, 1);
+        let crc = base_crc_with_histogram(&[100, 200]).apply(unsafe_delta, 1);
         // Indeterminate has no histogram field; the histogram data is gone.
         assert!(crc.file_stats_state.is_indeterminate());
         assert!(crc.file_stats().is_none());
@@ -732,7 +732,7 @@ mod tests {
             vec![300, 500, 0],
         )
         .unwrap();
-        let mut crc = Crc {
+        let base = Crc {
             file_stats_state: FileStatsState::Complete(FileStats {
                 num_files: 3,
                 table_size_bytes: 800,
@@ -757,7 +757,7 @@ mod tests {
             ..Default::default()
         };
 
-        crc.apply(delta, 1);
+        let crc = base.apply(delta, 1);
 
         // Histogram should be preserved (boundaries match)
         let stats = crc.file_stats().unwrap();

--- a/kernel/src/crc/delta.rs
+++ b/kernel/src/crc/delta.rs
@@ -13,6 +13,7 @@ use super::{
     Crc, DomainMetadataState, FileSizeHistogram, FileStats, FileStatsState, SetTransactionState,
 };
 use crate::actions::{DomainMetadata, Metadata, Protocol, SetTransaction};
+use crate::Version;
 
 /// CRC-relevant changes aggregated over commits `(X, Y]`.
 #[derive(Debug, Clone, Default)]
@@ -68,6 +69,7 @@ impl CrcDelta {
                 .ok()
         });
         Some(Crc {
+            version: 0,
             file_stats_state: FileStatsState::Complete(FileStats {
                 num_files: self.file_stats.net_files,
                 table_size_bytes: self.file_stats.net_bytes,
@@ -85,14 +87,21 @@ impl CrcDelta {
 
 /// Commit delta application for [`Crc`]. See the [module-level docs](self) for details.
 impl Crc {
-    /// Apply a commit delta.
+    /// Apply a commit delta and advance to `new_version`.
+    ///
     /// - Protocol / metadata: replaced when present in the delta, kept otherwise.
     /// - ICT: unconditional replace; the delta carries ICT at `Y` (whether `Some` or `None`).
     /// - Domain metadata: tombstones (`is_removed()`) drop the key from the base map; all others
     ///   upsert by domain. Set transactions: upsert by app_id. The `Complete`/`Partial` variant is
     ///   preserved in both cases.
     /// - File stats: governed by the [`FileStatsState`] state machine.
-    pub(crate) fn apply(&mut self, delta: CrcDelta) {
+    pub(crate) fn apply(&mut self, delta: CrcDelta, new_version: Version) {
+        debug_assert!(
+            new_version > self.version,
+            "Crc::apply must advance version: self.version={}, new_version={}",
+            self.version,
+            new_version
+        );
         // Protocol and metadata: replace if present.
         if let Some(p) = delta.protocol {
             self.protocol = p;
@@ -132,6 +141,8 @@ impl Crc {
             &delta.file_stats,
             delta.is_incremental_safe,
         );
+
+        self.version = new_version;
     }
 }
 
@@ -289,23 +300,25 @@ mod tests {
     #[test]
     fn test_apply_updates_file_stats() {
         let mut crc = base_crc();
-        crc.apply(write_delta(3, 600));
+        crc.apply(write_delta(3, 600), 1);
         let stats = crc.file_stats().unwrap();
         assert_eq!(stats.num_files(), 13); // 10 + 3
         assert_eq!(stats.table_size_bytes(), 1600); // 1000 + 600
         assert!(crc.file_stats_state.is_complete());
+        assert_eq!(crc.version, 1);
     }
 
     /// Applies multiple commit deltas sequentially.
     #[test]
     fn test_apply_multiple_deltas() {
         let mut crc = base_crc();
-        crc.apply(write_delta(3, 600));
-        crc.apply(write_delta(-2, -400));
+        crc.apply(write_delta(3, 600), 1);
+        crc.apply(write_delta(-2, -400), 2);
         let stats = crc.file_stats().unwrap();
         assert_eq!(stats.num_files(), 11); // 10 + 3 - 2
         assert_eq!(stats.table_size_bytes(), 1200); // 1000 + 600 - 400
         assert!(crc.file_stats_state.is_complete());
+        assert_eq!(crc.version, 2);
     }
 
     #[test]
@@ -315,7 +328,7 @@ mod tests {
             is_incremental_safe: false,
             ..write_delta(1, 100)
         };
-        crc.apply(unsafe_change);
+        crc.apply(unsafe_change, 1);
         assert!(crc.file_stats_state.is_indeterminate());
     }
 
@@ -326,12 +339,13 @@ mod tests {
             is_incremental_safe: false,
             ..write_delta(1, 100)
         };
-        crc.apply(unsafe_change);
+        crc.apply(unsafe_change, 1);
         assert!(crc.file_stats_state.is_indeterminate());
 
-        // Subsequent safe op doesn't recover the state.
-        crc.apply(write_delta(5, 500));
+        // Subsequent safe op doesn't recover the state. Version still advances.
+        crc.apply(write_delta(5, 500), 2);
         assert!(crc.file_stats_state.is_indeterminate());
+        assert_eq!(crc.version, 2);
     }
 
     // ===== apply: non-file-stats field updates =====
@@ -350,7 +364,7 @@ mod tests {
             protocol: Some(new_protocol.clone()),
             ..write_delta(0, 0)
         };
-        crc.apply(delta);
+        crc.apply(delta, 1);
         assert_eq!(crc.protocol, new_protocol);
         assert_eq!(crc.metadata, Metadata::default()); // unchanged
     }
@@ -373,7 +387,7 @@ mod tests {
             ]),
             ..write_delta(0, 0)
         };
-        crc.apply(delta);
+        crc.apply(delta, 1);
 
         // Bind the inner map AND panic if the variant flipped during apply.
         let map = match &crc.domain_metadata_state {
@@ -394,7 +408,7 @@ mod tests {
             in_commit_timestamp: Some(9999),
             ..write_delta(0, 0)
         };
-        crc.apply(delta);
+        crc.apply(delta, 1);
         assert_eq!(crc.in_commit_timestamp_opt, Some(9999));
     }
 
@@ -406,7 +420,7 @@ mod tests {
             in_commit_timestamp: None,
             ..write_delta(0, 0)
         };
-        crc.apply(delta);
+        crc.apply(delta, 1);
         assert_eq!(crc.in_commit_timestamp_opt, None);
     }
 
@@ -433,6 +447,7 @@ mod tests {
         };
         let crc = delta.into_crc_for_version_zero().unwrap();
         let stats = crc.file_stats().unwrap();
+        assert_eq!(crc.version, 0);
         assert_eq!(crc.protocol, protocol);
         assert_eq!(crc.metadata, metadata);
         assert_eq!(stats.num_files(), 5);
@@ -517,7 +532,7 @@ mod tests {
             ]),
             ..write_delta(0, 0)
         };
-        crc.apply(delta);
+        crc.apply(delta, 1);
 
         let map = match &crc.set_transaction_state {
             SetTransactionState::Complete(m) if was_complete => m,
@@ -624,7 +639,7 @@ mod tests {
     ) {
         let mut crc = base_crc_with_histogram(base);
         let delta = write_delta_with_histograms(add, remove);
-        crc.apply(delta);
+        crc.apply(delta, 1);
 
         let stats = crc.file_stats().unwrap();
         let hist = stats.file_size_histogram().unwrap();
@@ -651,7 +666,7 @@ mod tests {
             is_incremental_safe: true,
             ..Default::default()
         };
-        crc.apply(delta);
+        crc.apply(delta, 1);
         let stats = crc.file_stats().unwrap();
         assert!(
             stats.file_size_histogram().is_none(),
@@ -666,7 +681,7 @@ mod tests {
             is_incremental_safe: false,
             ..write_delta(1, 100)
         };
-        crc.apply(unsafe_delta);
+        crc.apply(unsafe_delta, 1);
         // Indeterminate has no histogram field; the histogram data is gone.
         assert!(crc.file_stats_state.is_indeterminate());
         assert!(crc.file_stats().is_none());
@@ -742,7 +757,7 @@ mod tests {
             ..Default::default()
         };
 
-        crc.apply(delta);
+        crc.apply(delta, 1);
 
         // Histogram should be preserved (boundaries match)
         let stats = crc.file_stats().unwrap();

--- a/kernel/src/crc/lazy.rs
+++ b/kernel/src/crc/lazy.rs
@@ -40,6 +40,9 @@ impl CrcLoadResult {
 ///
 /// Uses `OnceLock` to ensure thread-safe initialization that happens at most once.
 /// Can also hold a precomputed CRC (e.g. from post-commit CRC merge) without a backing file.
+// TODO: remove `LazyCrc`. We will soon be doing incremental CRC replay, in which we always
+//       read the CRC if available. Note: in the meantime, `LazyCrc` and `Crc` both duplicate
+//       the version.
 #[derive(Debug)]
 pub(crate) struct LazyCrc {
     /// The CRC file path, if one exists in the log segment.

--- a/kernel/src/crc/mod.rs
+++ b/kernel/src/crc/mod.rs
@@ -41,7 +41,7 @@ pub use state::{DomainMetadataState, FileStatsState, SetTransactionState};
 pub(crate) use writer::try_write_crc_file;
 
 use crate::actions::{Add, DomainMetadata, Metadata, Protocol, SetTransaction};
-use crate::Error;
+use crate::{DeltaResult, Error, Version};
 
 // ============================================================================
 // Crc: in-memory representation
@@ -61,10 +61,11 @@ use crate::Error;
 /// This struct and its fields are marked `pub`, but the `crc` module is only re-exported as `pub`
 /// when the `test-utils` feature is enabled (otherwise `pub(crate)`). See `kernel/src/lib.rs`.
 // TODO: rename `Crc` to `CrcState` to align with `FileStatsState`, `SetTransactionState`, etc.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
-#[serde(try_from = "CrcRaw")]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Crc {
     // ===== Required fields =====
+    /// The table version this CRC describes.
+    pub version: Version,
     /// The table [`Metadata`] at this version.
     pub metadata: Metadata,
     /// The table [`Protocol`] at this version.
@@ -166,10 +167,10 @@ struct CrcRaw {
     file_size_histogram: Option<FileSizeHistogram>,
 }
 
-impl TryFrom<CrcRaw> for Crc {
-    type Error = Error;
-
-    fn try_from(raw: CrcRaw) -> Result<Self, Self::Error> {
+impl Crc {
+    /// Parse a `.crc` file body. `version` comes from the filename (the body does not carry it).
+    pub(crate) fn try_from_json_bytes(bytes: &[u8], version: Version) -> DeltaResult<Self> {
+        let raw: CrcRaw = serde_json::from_slice(bytes)?;
         // Per the Delta protocol spec, numMetadata and numProtocol MUST be 1 in any CRC file.
         // Reject malformed files at the deserialization boundary so callers can trust the value.
         for (name, value) in [
@@ -189,6 +190,7 @@ impl TryFrom<CrcRaw> for Crc {
             file_size_histogram: raw.file_size_histogram,
         });
         Ok(Crc {
+            version,
             metadata: raw.metadata,
             protocol: raw.protocol,
             file_stats_state,
@@ -348,7 +350,7 @@ mod tests {
             ]
         }"#;
 
-        let crc: Crc = serde_json::from_str(json).unwrap();
+        let crc = Crc::try_from_json_bytes(json.as_bytes(), 0).unwrap();
 
         // A present `setTransactions` array deserializes as `Complete` (authoritative).
         let txns = crc.set_transaction_state.expect_complete();
@@ -390,7 +392,7 @@ mod tests {
             "setTransactions": null,
             "domainMetadata": null
         }"#;
-        let crc: Crc = serde_json::from_str(json).unwrap();
+        let crc = Crc::try_from_json_bytes(json.as_bytes(), 0).unwrap();
         assert_eq!(
             crc.set_transaction_state,
             SetTransactionState::Partial(HashMap::new())
@@ -418,7 +420,7 @@ mod tests {
             },
             "protocol": {"minReaderVersion": 1, "minWriterVersion": 1}
         }"#;
-        let crc: Crc = serde_json::from_str(json).unwrap();
+        let crc = Crc::try_from_json_bytes(json.as_bytes(), 0).unwrap();
         assert_eq!(
             crc.set_transaction_state,
             SetTransactionState::Partial(HashMap::new())
@@ -498,7 +500,7 @@ mod tests {
         );
 
         let json_str = serde_json::to_string(&original).unwrap();
-        let deserialized: Crc = serde_json::from_str(&json_str).unwrap();
+        let deserialized = Crc::try_from_json_bytes(json_str.as_bytes(), 0).unwrap();
 
         assert_eq!(original, deserialized);
     }
@@ -511,7 +513,7 @@ mod tests {
         );
 
         let json_str = serde_json::to_string(&original).unwrap();
-        let deserialized: Crc = serde_json::from_str(&json_str).unwrap();
+        let deserialized = Crc::try_from_json_bytes(json_str.as_bytes(), 0).unwrap();
 
         assert_eq!(original, deserialized);
 
@@ -534,7 +536,7 @@ mod tests {
         );
 
         let json_str = serde_json::to_string(&original).unwrap();
-        let deserialized: Crc = serde_json::from_str(&json_str).unwrap();
+        let deserialized = Crc::try_from_json_bytes(json_str.as_bytes(), 0).unwrap();
 
         assert_eq!(
             deserialized.domain_metadata_state,
@@ -555,7 +557,7 @@ mod tests {
         );
 
         let json_str = serde_json::to_string(&original).unwrap();
-        let deserialized: Crc = serde_json::from_str(&json_str).unwrap();
+        let deserialized = Crc::try_from_json_bytes(json_str.as_bytes(), 0).unwrap();
 
         assert_eq!(
             deserialized.set_transaction_state,
@@ -609,7 +611,7 @@ mod tests {
 
         // Round-trip through JSON
         let json_str = serde_json::to_string(&crc).unwrap();
-        let deserialized: Crc = serde_json::from_str(&json_str).unwrap();
+        let deserialized = Crc::try_from_json_bytes(json_str.as_bytes(), 0).unwrap();
 
         // Verify scalar fields survive the round-trip
         let stats = deserialized.file_stats().unwrap();
@@ -676,7 +678,9 @@ mod tests {
     ) {
         let (m, p) = counts(bad);
         let json = crc_json_with_counts(m, p);
-        let err = serde_json::from_str::<Crc>(&json).unwrap_err().to_string();
+        let err = Crc::try_from_json_bytes(json.as_bytes(), 0)
+            .unwrap_err()
+            .to_string();
         assert!(
             err.contains(field),
             "expected error to mention {field} for value {bad}, got: {err}"
@@ -744,7 +748,7 @@ mod tests {
             field_name,
             r#"{"sortedBinBoundaries": [0, 100, 200], "fileCounts": [1, 2, 3], "totalBytes": [10, 200, 300]}"#,
         );
-        let crc: Crc = serde_json::from_str(&json).unwrap();
+        let crc = Crc::try_from_json_bytes(json.as_bytes(), 0).unwrap();
         assert!(crc.file_stats().unwrap().file_size_histogram().is_some());
     }
 
@@ -753,7 +757,7 @@ mod tests {
     #[case::legacy_name("histogramOpt")]
     fn de_null_file_size_histogram_deserializes_to_none(#[case] field_name: &str) {
         let json = crc_json_with_histogram(field_name, "null");
-        let crc: Crc = serde_json::from_str(&json).unwrap();
+        let crc = Crc::try_from_json_bytes(json.as_bytes(), 0).unwrap();
         assert!(crc.file_stats().unwrap().file_size_histogram().is_none());
     }
 
@@ -777,7 +781,7 @@ mod tests {
         #[values("fileSizeHistogram", "histogramOpt")] field_name: &str,
     ) {
         let json = crc_json_with_histogram(field_name, histogram_json);
-        assert!(serde_json::from_str::<Crc>(&json).is_err());
+        assert!(Crc::try_from_json_bytes(json.as_bytes(), 0).is_err());
     }
 
     /// CRC files written by kernel always use the spec-correct field name `fileSizeHistogram`,
@@ -789,7 +793,7 @@ mod tests {
             "histogramOpt",
             r#"{"sortedBinBoundaries": [0, 100], "fileCounts": [1, 0], "totalBytes": [50, 0]}"#,
         );
-        let crc: Crc = serde_json::from_str(&legacy_json).unwrap();
+        let crc = Crc::try_from_json_bytes(legacy_json.as_bytes(), 0).unwrap();
 
         let serialized = serde_json::to_value(&crc).unwrap();
         assert!(serialized.get("fileSizeHistogram").is_some());
@@ -851,7 +855,7 @@ mod tests {
                 "{second_name}": {second_payload}
             }}"#
         );
-        let err = serde_json::from_str::<Crc>(&json).unwrap_err();
+        let err = Crc::try_from_json_bytes(json.as_bytes(), 0).unwrap_err();
         assert!(
             err.to_string().contains("duplicate field"),
             "expected duplicate-field error, got: {err}"

--- a/kernel/src/crc/reader.rs
+++ b/kernel/src/crc/reader.rs
@@ -25,8 +25,7 @@ pub(crate) fn try_read_crc_file(engine: &dyn Engine, crc_path: &ParsedLogPath) -
         .next()
         .ok_or_else(|| Error::generic("CRC file read returned no data"))??;
     tracing::Span::current().record("bytes_read", data.len() as u64);
-    let crc: Crc = serde_json::from_slice(&data)?;
-    Ok(crc)
+    Crc::try_from_json_bytes(&data, crc_path.version)
 }
 
 #[cfg(test)]

--- a/kernel/src/crc/writer.rs
+++ b/kernel/src/crc/writer.rs
@@ -64,10 +64,10 @@ mod tests {
     use crate::path::{AsUrl, ParsedLogPath};
     use crate::table_features::TableFeature;
 
-    fn writer_test_env() -> (SyncEngine, ParsedLogPath) {
+    fn writer_test_env(version: u64) -> (SyncEngine, ParsedLogPath) {
         let engine = SyncEngine::new_with_store(Arc::new(InMemory::new()));
         let table_root = Url::parse("memory:///test_table/").unwrap();
-        let crc_path = ParsedLogPath::create_parsed_crc(&table_root, 0);
+        let crc_path = ParsedLogPath::create_parsed_crc(&table_root, version);
         (engine, crc_path)
     }
 
@@ -127,20 +127,25 @@ mod tests {
     fn test_serde_round_trip() {
         let crc = test_crc(/* ict_supported */ true, /* ict_enabled */ true);
         let json_bytes = serde_json::to_vec(&crc).unwrap();
-        let round_tripped: Crc = serde_json::from_slice(&json_bytes).unwrap();
+        let round_tripped = Crc::try_from_json_bytes(&json_bytes, crc.version).unwrap();
 
         assert_eq!(round_tripped, crc);
     }
 
-    #[test]
-    fn test_write_then_read_crc_file() {
-        let (engine, crc_path) = writer_test_env();
-        let crc = test_crc(/* ict_supported */ true, /* ict_enabled */ true);
+    #[rstest]
+    #[case(0)]
+    #[case(7)]
+    #[case(1_000_000)]
+    fn test_write_then_read_crc_file_round_trips_version_from_filename(#[case] version: u64) {
+        let (engine, crc_path) = writer_test_env(version);
+        let mut crc = test_crc(/* ict_supported */ true, /* ict_enabled */ true);
+        crc.version = version;
 
         try_write_crc_file(&engine, crc_path.location.as_url(), &crc).unwrap();
 
         let read_back = try_read_crc_file(&engine, &crc_path).unwrap();
         assert_eq!(read_back, crc);
+        assert_eq!(read_back.version, version);
     }
 
     /// Verify JSON content produced by CRC serialization via serde_json::Value comparison.
@@ -221,7 +226,7 @@ mod tests {
 
     #[test]
     fn test_write_crc_file_already_exists() {
-        let (engine, crc_path) = writer_test_env();
+        let (engine, crc_path) = writer_test_env(0);
         let crc = test_crc(/* ict_supported */ true, /* ict_enabled */ true);
 
         try_write_crc_file(&engine, crc_path.location.as_url(), &crc).unwrap();
@@ -233,7 +238,7 @@ mod tests {
 
     #[test]
     fn test_write_rejects_indeterminate_file_stats_with_checksum_write_unsupported() {
-        let (engine, crc_path) = writer_test_env();
+        let (engine, crc_path) = writer_test_env(0);
         let mut crc = test_crc(/* ict_supported */ true, /* ict_enabled */ true);
         crc.file_stats_state = FileStatsState::Indeterminate;
         let result = try_write_crc_file(&engine, crc_path.location.as_url(), &crc);
@@ -249,7 +254,7 @@ mod tests {
         #[case] ict_enabled: bool,
         #[values(false, true)] ict_value_present: bool,
     ) {
-        let (engine, crc_path) = writer_test_env();
+        let (engine, crc_path) = writer_test_env(0);
 
         let mut crc = test_crc(ict_supported, ict_enabled);
         if !ict_value_present {

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -590,7 +590,7 @@ impl Snapshot {
             .get_if_loaded_at_version(self.version())
             .map(|base| {
                 let mut crc = base.as_ref().clone();
-                crc.apply(crc_delta);
+                crc.apply(crc_delta, new_version);
                 crc
             });
 

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -588,11 +588,7 @@ impl Snapshot {
         let crc = self
             .lazy_crc
             .get_if_loaded_at_version(self.version())
-            .map(|base| {
-                let mut crc = base.as_ref().clone();
-                crc.apply(crc_delta, new_version);
-                crc
-            });
+            .map(|base| base.as_ref().clone().apply(crc_delta, new_version));
 
         match crc {
             Some(c) => Arc::new(LazyCrc::new_precomputed(c, new_version)),


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR contains two tiny changes:

1. Embed the CRC version into our CRC struct. Note that version is not in the on disk CRC representation. That's why we have our CRC struct which represents our custom in-memory state, and we have CrcRaw which represents the actual on-disk format.

This is a convenience API + state that will be helpful for subsequent PRs.

2. Make crc.apply(delta) return a new CRC -- Cleaner approach

## How was this change tested?

Update existing UTs; a few new UTs, pretty trivial.
