### PR TITLE
refactor: unify column mapping validations to `MakePhysical`

### DIFF
--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -2174,7 +2174,7 @@ impl<'a> SchemaTransform<'a> for GetSchemaLeaves {
     }
 }
 
-struct MakePhysical<'a> {
+pub(crate) struct MakePhysical<'a> {
     column_mapping_mode: ColumnMappingMode,
     /// Logical path of current field's parent, used for error messages.
     logical_path: Vec<&'a str>,
@@ -2186,6 +2186,9 @@ struct MakePhysical<'a> {
     /// fields. Only structs introduce siblings; arrays/maps don't push frames since their
     /// elements / keys / values are anonymous.
     sibling_names_stack: Vec<HashMap<&'a str, &'a str>>,
+    /// When `true`, skips the physical-name + metadata rewrite, only validates the column
+    /// mapping annotations.
+    validation_only: bool,
 }
 impl<'a> MakePhysical<'a> {
     fn new(column_mapping_mode: ColumnMappingMode) -> Self {
@@ -2194,7 +2197,20 @@ impl<'a> MakePhysical<'a> {
             logical_path: vec![],
             seen_ids: HashMap::new(),
             sibling_names_stack: vec![],
+            validation_only: false,
         }
+    }
+
+    /// Walks `schema` and validates its column-mapping annotations.
+    pub(crate) fn validate_struct(
+        mode: ColumnMappingMode,
+        schema: &'a StructType,
+    ) -> DeltaResult<()> {
+        let mut walker = Self {
+            validation_only: true,
+            ..Self::new(mode)
+        };
+        walker.transform_struct(schema).map(|_| ())
     }
 
     fn transform_inner<T>(
@@ -2245,10 +2261,11 @@ impl<'a> SchemaTransform<'a> for MakePhysical<'a> {
 
         self.transform_inner(field.name(), |this| {
             let field = this.recurse_into_struct_field(field)?;
-
+            if this.validation_only {
+                return Ok(field);
+            }
             let metadata = field.logical_to_physical_metadata(this.column_mapping_mode);
             let name = physical_name.to_owned();
-
             Ok(Cow::Owned(field.with_name(name).with_metadata(metadata)))
         })
     }

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -2202,7 +2202,7 @@ impl<'a> MakePhysical<'a> {
     }
 
     /// Walks `schema` and validates its column-mapping annotations.
-    pub(crate) fn validate_struct(
+    pub(crate) fn validate_schema_column_mapping(
         mode: ColumnMappingMode,
         schema: &'a StructType,
     ) -> DeltaResult<()> {

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -109,7 +109,7 @@ pub(crate) fn column_mapping_mode(
 /// ]}
 /// ```
 pub fn validate_schema_column_mapping(schema: &Schema, mode: ColumnMappingMode) -> DeltaResult<()> {
-    MakePhysical::validate_struct(mode, schema)
+    MakePhysical::validate_schema_column_mapping(mode, schema)
 }
 
 /// Validates a field's column mapping annotations and extracts the physical name and column

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -12,8 +12,8 @@ use uuid::Uuid;
 use super::TableFeature;
 use crate::actions::Protocol;
 use crate::schema::{
-    ArrayType, ColumnMetadataKey, ColumnName, DataType, ExistingColumnMappingAnnotations, MapType,
-    MetadataValue, Schema, StructField, StructType,
+    ArrayType, ColumnMetadataKey, ColumnName, DataType, ExistingColumnMappingAnnotations,
+    MakePhysical, MapType, MetadataValue, Schema, StructField, StructType,
 };
 use crate::table_properties::{TableProperties, COLUMN_MAPPING_MODE};
 use crate::transforms::{transform_output_type, SchemaTransform};
@@ -109,13 +109,7 @@ pub(crate) fn column_mapping_mode(
 /// ]}
 /// ```
 pub fn validate_schema_column_mapping(schema: &Schema, mode: ColumnMappingMode) -> DeltaResult<()> {
-    let mut validator = ValidateColumnMappings {
-        mode,
-        logical_path: vec![],
-        seen_ids: HashMap::new(),
-        sibling_names_stack: vec![],
-    };
-    validator.transform_struct(schema)
+    MakePhysical::validate_struct(mode, schema)
 }
 
 /// Validates a field's column mapping annotations and extracts the physical name and column
@@ -286,70 +280,6 @@ pub(crate) fn validate_and_extract_column_mapping_annotations<'a>(
     }
 
     Ok((physical_name, id))
-}
-
-struct ValidateColumnMappings<'a> {
-    mode: ColumnMappingMode,
-    /// Logical path of current field's parent, used for error messages.
-    logical_path: Vec<&'a str>,
-    /// `delta.columnMapping.id` -> first claimer logical name.
-    seen_ids: HashMap<i64, &'a str>,
-    /// Stack of sibling-`physicalName` maps. The top of the stack holds the current field's
-    /// siblings: key is the sibling's physical name, value is its logical name. Frames are
-    /// pushed in `transform_struct` (root struct included) and popped after iterating its
-    /// fields. Only structs introduce siblings; arrays/maps don't push frames since their
-    /// elements / keys / values are anonymous.
-    sibling_names_stack: Vec<HashMap<&'a str, &'a str>>,
-}
-
-impl<'a> ValidateColumnMappings<'a> {
-    fn transform_inner<V>(&mut self, logical_name: &'a str, validate: V) -> DeltaResult<()>
-    where
-        V: FnOnce(&mut Self) -> DeltaResult<()>,
-    {
-        self.logical_path.push(logical_name);
-        let result = validate(self);
-        self.logical_path.pop();
-        result
-    }
-}
-
-impl<'a> SchemaTransform<'a> for ValidateColumnMappings<'a> {
-    transform_output_type!(|'a, T| DeltaResult<()>);
-
-    fn transform_struct(&mut self, stype: &'a StructType) -> DeltaResult<()> {
-        self.sibling_names_stack.push(HashMap::new());
-        let result = self.recurse_into_struct(stype);
-        self.sibling_names_stack.pop();
-        result
-    }
-
-    // Override array element and map key/value for better error messages
-    fn transform_array_element(&mut self, etype: &'a DataType) -> DeltaResult<()> {
-        self.transform_inner("<array element>", |this| this.transform(etype))
-    }
-    fn transform_map_key(&mut self, ktype: &'a DataType) -> DeltaResult<()> {
-        self.transform_inner("<map key>", |this| this.transform(ktype))
-    }
-    fn transform_map_value(&mut self, vtype: &'a DataType) -> DeltaResult<()> {
-        self.transform_inner("<map value>", |this| this.transform(vtype))
-    }
-    fn transform_struct_field(&mut self, field: &'a StructField) -> DeltaResult<()> {
-        validate_and_extract_column_mapping_annotations(
-            field,
-            self.mode,
-            &self.logical_path,
-            Some(&mut self.seen_ids),
-            self.sibling_names_stack.last_mut(),
-        )?;
-        self.transform_inner(field.name(), |this| this.recurse_into_struct_field(field))
-    }
-    fn transform_variant(&mut self, _stype: &'a StructType) -> DeltaResult<()> {
-        // don't recurse into variant's fields, as they are not expected to have column mapping
-        // annotations
-        // TODO: this changes with icebergcompat right? see issue#1125 for icebergcompat.
-        Ok(())
-    }
 }
 
 // ============================================================================


### PR DESCRIPTION
## What changes are proposed in this pull request?
Currently we have `ValidateColumnMappings` and `MakePhysical`, they shared a lot of similar logics, this PR unifies them to one struct.

Address https://github.com/delta-io/delta-kernel-rs/issues/2589
<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

## How was this change tested?
Existing