### PR TITLE
feat!: re-add nearest_timestamp to LogHistoryError

### DIFF
--- a/kernel/src/history_manager/error.rs
+++ b/kernel/src/history_manager/error.rs
@@ -38,12 +38,16 @@ pub enum LogHistoryError {
         /// Description of why the timestamp is out of range.
         reason: &'static str,
         /// The nearest retained commit's timestamp on the side of the search
-        /// bound closest to `timestamp` (e.g. the earliest commit's timestamp
-        /// for a `GreatestLower` search whose input is below retention).
+        /// bound closest to `timestamp`. Engines surface this to users so the
+        /// error message can point at a valid timestamp.
+        ///
+        /// For a `GreatestLower` search this is the earliest commit's
+        /// timestamp; for `LeastUpper` it is the latest's. For example, given a
+        /// retained range `[100, 500]` and a `GreatestLower` search at
+        /// timestamp `50`, this is `Some(100)`.
+        ///
         /// `None` when no commits were available (empty log) or when reading
         /// the boundary commit's In-Commit Timestamp failed at the error site.
-        ///
-        /// Engines surface this to users to point them at a valid timestamp.
         nearest_timestamp: Option<Timestamp>,
     },
     /// An internal error occurred during timestamp conversion.

--- a/kernel/src/history_manager/error.rs
+++ b/kernel/src/history_manager/error.rs
@@ -37,6 +37,14 @@ pub enum LogHistoryError {
         timestamp: Timestamp,
         /// Description of why the timestamp is out of range.
         reason: &'static str,
+        /// The nearest retained commit's timestamp on the side of the search
+        /// bound closest to `timestamp` (e.g. the earliest commit's timestamp
+        /// for a `GreatestLower` search whose input is below retention).
+        /// `None` when no commits were available (empty log) or when reading
+        /// the boundary commit's In-Commit Timestamp failed at the error site.
+        ///
+        /// Engines surface this to users to point them at a valid timestamp.
+        nearest_timestamp: Option<Timestamp>,
     },
     /// An internal error occurred during timestamp conversion.
     #[error("{context}{}", source.as_ref().map(|e| format!(": {e}")).unwrap_or_default())]

--- a/kernel/src/history_manager/error.rs
+++ b/kernel/src/history_manager/error.rs
@@ -1,7 +1,38 @@
 //! Error types for the history manager module.
 
+use super::search::Bound;
 use super::Timestamp;
 use crate::Version;
+
+/// The nearest retained timestamp on the side of the search bound that an
+/// out-of-range search failed against. Engines surface this to users so the
+/// error message can point at a valid timestamp.
+///
+/// `Earliest` and `Latest` carry the boundary commit's timestamp. `Unknown`
+/// means no boundary timestamp was available, e.g. empty log or a failure
+/// reading the boundary commit's In-Commit Timestamp at the error site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum NearestTimestamp {
+    /// The earliest retained commit's timestamp. Returned for a
+    /// `GreatestLower` search whose input fell below the retained range.
+    Earliest(Timestamp),
+    /// The latest retained commit's timestamp. Returned for a `LeastUpper`
+    /// search whose input fell above the retained range.
+    Latest(Timestamp),
+    /// No boundary timestamp could be determined.
+    Unknown,
+}
+
+impl NearestTimestamp {
+    /// Tags `ts` with the variant matching `bound`.
+    pub(crate) fn from_boundary(bound: Bound, ts: Timestamp) -> Self {
+        match bound {
+            Bound::GreatestLower => Self::Earliest(ts),
+            Bound::LeastUpper => Self::Latest(ts),
+        }
+    }
+}
 
 /// Represents errors that can occur when converting commit timestamps to versions.
 #[derive(Debug, thiserror::Error)]
@@ -38,17 +69,10 @@ pub enum LogHistoryError {
         /// Description of why the timestamp is out of range.
         reason: &'static str,
         /// The nearest retained commit's timestamp on the side of the search
-        /// bound closest to `timestamp`. Engines surface this to users so the
-        /// error message can point at a valid timestamp.
-        ///
-        /// For a `GreatestLower` search this is the earliest commit's
-        /// timestamp; for `LeastUpper` it is the latest's. For example, given a
-        /// retained range `[100, 500]` and a `GreatestLower` search at
-        /// timestamp `50`, this is `Some(100)`.
-        ///
-        /// `None` when no commits were available (empty log) or when reading
-        /// the boundary commit's In-Commit Timestamp failed at the error site.
-        nearest_timestamp: Option<Timestamp>,
+        /// bound. For example, given a retained range `[100, 500]` and a
+        /// `GreatestLower` search at timestamp `50`, this is
+        /// `NearestTimestamp::Earliest(100)`.
+        nearest_timestamp: NearestTimestamp,
     },
     /// An internal error occurred during timestamp conversion.
     #[error("{context}{}", source.as_ref().map(|e| format!(": {e}")).unwrap_or_default())]
@@ -75,6 +99,19 @@ impl LogHistoryError {
         Self::Internal {
             context,
             source: None,
+        }
+    }
+
+    /// Creates a `TimestampOutOfRange` error. The reason is derived from `bound`.
+    pub(crate) fn out_of_range(
+        timestamp: Timestamp,
+        bound: Bound,
+        nearest_timestamp: NearestTimestamp,
+    ) -> Self {
+        Self::TimestampOutOfRange {
+            timestamp,
+            reason: bound.out_of_range_reason(),
+            nearest_timestamp,
         }
     }
 }

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -21,7 +21,7 @@
 
 use std::cmp::Ordering;
 
-use error::LogHistoryError;
+use error::{LogHistoryError, NearestTimestamp};
 use search::{binary_search_by_key_with_bounds, Bound, SearchError};
 use tracing::{info, trace, warn};
 
@@ -189,11 +189,11 @@ fn linear_search_file_mod_timestamps(
     bound: Bound,
 ) -> Result<Version, LogHistoryError> {
     if commits.is_empty() {
-        return Err(LogHistoryError::TimestampOutOfRange {
+        return Err(LogHistoryError::out_of_range(
             timestamp,
-            reason: bound.out_of_range_reason(),
-            nearest_timestamp: None,
-        });
+            bound,
+            NearestTimestamp::Unknown,
+        ));
     }
 
     let lo_version = commits[0].version;
@@ -232,11 +232,11 @@ fn linear_search_file_mod_timestamps(
         // Exiting with `result == None` means either (GreatestLower) every commit
         // is after `timestamp`, so the earliest commit is the nearest, or
         // (LeastUpper) every commit is before `timestamp`, so the latest is.
-        LogHistoryError::TimestampOutOfRange {
-            timestamp,
-            reason: bound.out_of_range_reason(),
-            nearest_timestamp: bound.boundary_of(commits).map(|c| c.location.last_modified),
-        }
+        let nearest = bound
+            .boundary_of(commits)
+            .map(|c| NearestTimestamp::from_boundary(bound, c.location.last_modified))
+            .unwrap_or(NearestTimestamp::Unknown);
+        LogHistoryError::out_of_range(timestamp, bound, nearest)
     })
 }
 
@@ -250,11 +250,11 @@ fn binary_search_ict_timestamps(
     engine: &dyn Engine,
 ) -> Result<Version, LogHistoryError> {
     if commits.is_empty() {
-        return Err(LogHistoryError::TimestampOutOfRange {
+        return Err(LogHistoryError::out_of_range(
             timestamp,
-            reason: bound.out_of_range_reason(),
-            nearest_timestamp: None,
-        });
+            bound,
+            NearestTimestamp::Unknown,
+        ));
     }
 
     let lo_version = commits[0].version;
@@ -277,24 +277,24 @@ fn binary_search_ict_timestamps(
             // OutOfRange under `GreatestLower` means timestamp < commits[0]'s
             // ICT; under `LeastUpper` it means timestamp > commits.last()'s
             // ICT. The boundary timestamp is read via `commit_to_ict`; on
-            // engine failure we degrade to `None` so the original out-of-range
-            // error is preserved.
-            let nearest_timestamp = bound.boundary_of(commits).and_then(|boundary| {
-                commit_to_ict(boundary)
-                    .inspect_err(|e| {
-                        warn!(
-                            error = ?e,
-                            version = boundary.version,
-                            "failed to read boundary ICT for nearest_timestamp hint",
-                        );
-                    })
-                    .ok()
-            });
-            Err(LogHistoryError::TimestampOutOfRange {
-                timestamp,
-                reason: bound.out_of_range_reason(),
-                nearest_timestamp,
-            })
+            // engine failure we degrade to `Unknown` so the original
+            // out-of-range error is preserved.
+            let nearest = bound
+                .boundary_of(commits)
+                .and_then(|boundary| {
+                    commit_to_ict(boundary)
+                        .inspect_err(|e| {
+                            warn!(
+                                error = ?e,
+                                version = boundary.version,
+                                "failed to read boundary ICT for nearest_timestamp hint",
+                            );
+                        })
+                        .ok()
+                        .map(|ts| NearestTimestamp::from_boundary(bound, ts))
+                })
+                .unwrap_or(NearestTimestamp::Unknown);
+            Err(LogHistoryError::out_of_range(timestamp, bound, nearest))
         }
     }
 }
@@ -347,11 +347,11 @@ pub(crate) fn timestamp_to_version(
         (Ordering::Greater, Bound::GreatestLower) => return Ok(snapshot.version()),
         // Timestamp after snapshot: for LeastUpper, no version exists
         (Ordering::Greater, Bound::LeastUpper) => {
-            return Err(LogHistoryError::TimestampOutOfRange {
+            return Err(LogHistoryError::out_of_range(
                 timestamp,
-                reason: bound.out_of_range_reason(),
-                nearest_timestamp: Some(snap_ts),
-            });
+                bound,
+                NearestTimestamp::Latest(snap_ts),
+            ));
         }
         // Timestamp before snapshot: need to search the log
         _ => {}
@@ -1054,13 +1054,13 @@ mod tests {
     /// ICT binary-search out-of-range, and the snapshot short-circuit.
     #[rstest::rstest]
     // Linear file-mod GLB: timestamp below earliest commit on the standard table.
-    // nearest = commits[0].last_modified = 50.
+    // nearest = Earliest(commits[0].last_modified) = Earliest(50).
     #[case::linear_glb_below_earliest(
         &[(50, None), (150, None), (250, None), (350, Some(300)), (450, Some(400))],
         Some(3),
         0,
         Bound::GreatestLower,
-        Some(50),
+        NearestTimestamp::Earliest(50),
     )]
     // Snapshot short-circuit LUB: timestamp above the snapshot's ICT (snap_ts = 400).
     #[case::short_circuit_lub_after_snapshot(
@@ -1068,16 +1068,16 @@ mod tests {
         Some(3),
         1000,
         Bound::LeastUpper,
-        Some(400),
+        NearestTimestamp::Latest(400),
     )]
     // ICT binary-search GLB: timestamp below earliest ICT on an ICT-from-creation
-    // table. nearest = ICT(v0) = 100.
+    // table. nearest = Earliest(ICT(v0)) = Earliest(100).
     #[case::ict_glb_below_earliest(
         &[(0, Some(100)), (0, Some(200)), (0, Some(300))],
         Some(0),
         50,
         Bound::GreatestLower,
-        Some(100),
+        NearestTimestamp::Earliest(100),
     )]
     #[tokio::test]
     async fn test_timestamp_out_of_range_nearest_timestamp(
@@ -1085,7 +1085,7 @@ mod tests {
         #[case] ict_enablement: Option<Version>,
         #[case] timestamp: Timestamp,
         #[case] bound: Bound,
-        #[case] expected_nearest: Option<Timestamp>,
+        #[case] expected_nearest: NearestTimestamp,
     ) {
         let (_table, engine, snapshot, _log_segment) =
             build_test_snapshot(timestamps, ict_enablement, None).await;

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -23,7 +23,7 @@ use std::cmp::Ordering;
 
 use error::LogHistoryError;
 use search::{binary_search_by_key_with_bounds, Bound, SearchError};
-use tracing::{info, trace};
+use tracing::{info, trace, warn};
 
 use crate::log_segment::LogSegment;
 use crate::path::ParsedLogPath;
@@ -280,13 +280,22 @@ fn binary_search_ict_timestamps(
         Err(SearchError::OutOfRange) => {
             // OutOfRange under `GreatestLower` means timestamp < commits[0]'s
             // ICT; under `LeastUpper` it means timestamp > commits.last()'s
-            // ICT. Either side is read via `commit_to_ict`; on engine failure
-            // we degrade to `None` rather than mask the original error.
+            // ICT. The boundary timestamp is read via `commit_to_ict`; on
+            // engine failure we degrade to `None` so the original out-of-range
+            // error is preserved.
             let boundary = match bound {
                 Bound::GreatestLower => &commits[0],
                 Bound::LeastUpper => &commits[commits.len() - 1],
             };
-            let nearest_timestamp = commit_to_ict(boundary).ok();
+            let nearest_timestamp = commit_to_ict(boundary)
+                .inspect_err(|e| {
+                    warn!(
+                        error = ?e,
+                        version = boundary.version,
+                        "failed to read boundary ICT for nearest_timestamp hint",
+                    );
+                })
+                .ok();
             Err(LogHistoryError::TimestampOutOfRange {
                 timestamp,
                 reason: bound.out_of_range_reason(),

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -229,14 +229,21 @@ fn linear_search_file_mod_timestamps(
     }
 
     result.ok_or_else(|| {
-        // Exiting with `result == None` means either (GreatestLower) every commit
-        // is after `timestamp`, so the earliest commit is the nearest, or
-        // (LeastUpper) every commit is before `timestamp`, so the latest is.
-        let nearest = bound
-            .boundary_of(commits)
-            .map(|c| NearestTimestamp::from_boundary(bound, c.location.last_modified))
-            .unwrap_or(NearestTimestamp::Unknown);
-        LogHistoryError::out_of_range(timestamp, bound, nearest)
+        // OOR with non-empty commits: under GreatestLower, `timestamp` is below
+        // the first commit's monotonic ts (which equals its raw `last_modified`
+        // since no prior commit affects it). Under LeastUpper, `timestamp` is
+        // above the last commit's monotonic ts (held in `prev_monotonic_ts`).
+        // Using the monotonized values means a re-query at the suggested
+        // `nearest` round-trips to the same boundary version.
+        let nearest_ts = match bound {
+            Bound::GreatestLower => commits[0].location.last_modified,
+            Bound::LeastUpper => prev_monotonic_ts,
+        };
+        LogHistoryError::out_of_range(
+            timestamp,
+            bound,
+            NearestTimestamp::from_boundary(bound, nearest_ts),
+        )
     })
 }
 

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -192,6 +192,7 @@ fn linear_search_file_mod_timestamps(
         return Err(LogHistoryError::TimestampOutOfRange {
             timestamp,
             reason: bound.out_of_range_reason(),
+            nearest_timestamp: None,
         });
     }
 
@@ -227,9 +228,19 @@ fn linear_search_file_mod_timestamps(
         prev_monotonic_ts = monotonic_ts;
     }
 
-    result.ok_or(LogHistoryError::TimestampOutOfRange {
-        timestamp,
-        reason: bound.out_of_range_reason(),
+    result.ok_or_else(|| {
+        // Exiting with `result == None` means either (GreatestLower) every commit
+        // is after `timestamp`, so the earliest commit is the nearest, or
+        // (LeastUpper) every commit is before `timestamp`, so the latest is.
+        let nearest = match bound {
+            Bound::GreatestLower => commits[0].location.last_modified,
+            Bound::LeastUpper => commits[commits.len() - 1].location.last_modified,
+        };
+        LogHistoryError::TimestampOutOfRange {
+            timestamp,
+            reason: bound.out_of_range_reason(),
+            nearest_timestamp: Some(nearest),
+        }
     })
 }
 
@@ -246,6 +257,7 @@ fn binary_search_ict_timestamps(
         return Err(LogHistoryError::TimestampOutOfRange {
             timestamp,
             reason: bound.out_of_range_reason(),
+            nearest_timestamp: None,
         });
     }
 
@@ -265,10 +277,22 @@ fn binary_search_ict_timestamps(
     match binary_search_by_key_with_bounds(commits, timestamp, commit_to_ict, bound) {
         Ok(idx) => Ok(commits[idx].version),
         Err(SearchError::KeyFunctionError(error)) => Err(error),
-        Err(SearchError::OutOfRange) => Err(LogHistoryError::TimestampOutOfRange {
-            timestamp,
-            reason: bound.out_of_range_reason(),
-        }),
+        Err(SearchError::OutOfRange) => {
+            // OutOfRange under `GreatestLower` means timestamp < commits[0]'s
+            // ICT; under `LeastUpper` it means timestamp > commits.last()'s
+            // ICT. Either side is read via `commit_to_ict`; on engine failure
+            // we degrade to `None` rather than mask the original error.
+            let boundary = match bound {
+                Bound::GreatestLower => &commits[0],
+                Bound::LeastUpper => &commits[commits.len() - 1],
+            };
+            let nearest_timestamp = commit_to_ict(boundary).ok();
+            Err(LogHistoryError::TimestampOutOfRange {
+                timestamp,
+                reason: bound.out_of_range_reason(),
+                nearest_timestamp,
+            })
+        }
     }
 }
 
@@ -323,6 +347,7 @@ pub(crate) fn timestamp_to_version(
             return Err(LogHistoryError::TimestampOutOfRange {
                 timestamp,
                 reason: bound.out_of_range_reason(),
+                nearest_timestamp: Some(snap_ts),
             });
         }
         // Timestamp before snapshot: need to search the log

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -232,14 +232,10 @@ fn linear_search_file_mod_timestamps(
         // Exiting with `result == None` means either (GreatestLower) every commit
         // is after `timestamp`, so the earliest commit is the nearest, or
         // (LeastUpper) every commit is before `timestamp`, so the latest is.
-        let nearest = match bound {
-            Bound::GreatestLower => commits[0].location.last_modified,
-            Bound::LeastUpper => commits[commits.len() - 1].location.last_modified,
-        };
         LogHistoryError::TimestampOutOfRange {
             timestamp,
             reason: bound.out_of_range_reason(),
-            nearest_timestamp: Some(nearest),
+            nearest_timestamp: bound.boundary_of(commits).map(|c| c.location.last_modified),
         }
     })
 }
@@ -283,19 +279,17 @@ fn binary_search_ict_timestamps(
             // ICT. The boundary timestamp is read via `commit_to_ict`; on
             // engine failure we degrade to `None` so the original out-of-range
             // error is preserved.
-            let boundary = match bound {
-                Bound::GreatestLower => &commits[0],
-                Bound::LeastUpper => &commits[commits.len() - 1],
-            };
-            let nearest_timestamp = commit_to_ict(boundary)
-                .inspect_err(|e| {
-                    warn!(
-                        error = ?e,
-                        version = boundary.version,
-                        "failed to read boundary ICT for nearest_timestamp hint",
-                    );
-                })
-                .ok();
+            let nearest_timestamp = bound.boundary_of(commits).and_then(|boundary| {
+                commit_to_ict(boundary)
+                    .inspect_err(|e| {
+                        warn!(
+                            error = ?e,
+                            version = boundary.version,
+                            "failed to read boundary ICT for nearest_timestamp hint",
+                        );
+                    })
+                    .ok()
+            });
             Err(LogHistoryError::TimestampOutOfRange {
                 timestamp,
                 reason: bound.out_of_range_reason(),

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -1046,6 +1046,57 @@ mod tests {
         }
     }
 
+    /// Verifies `nearest_timestamp` is populated on `TimestampOutOfRange`. Covers
+    /// the three reachable populate sites: linear file-mod search out-of-range,
+    /// ICT binary-search out-of-range, and the snapshot short-circuit.
+    #[rstest::rstest]
+    // Linear file-mod GLB: timestamp below earliest commit on the standard table.
+    // nearest = commits[0].last_modified = 50.
+    #[case::linear_glb_below_earliest(
+        &[(50, None), (150, None), (250, None), (350, Some(300)), (450, Some(400))],
+        Some(3),
+        0,
+        Bound::GreatestLower,
+        Some(50),
+    )]
+    // Snapshot short-circuit LUB: timestamp above the snapshot's ICT (snap_ts = 400).
+    #[case::short_circuit_lub_after_snapshot(
+        &[(50, None), (150, None), (250, None), (350, Some(300)), (450, Some(400))],
+        Some(3),
+        1000,
+        Bound::LeastUpper,
+        Some(400),
+    )]
+    // ICT binary-search GLB: timestamp below earliest ICT on an ICT-from-creation
+    // table. nearest = ICT(v0) = 100.
+    #[case::ict_glb_below_earliest(
+        &[(0, Some(100)), (0, Some(200)), (0, Some(300))],
+        Some(0),
+        50,
+        Bound::GreatestLower,
+        Some(100),
+    )]
+    #[tokio::test]
+    async fn test_timestamp_out_of_range_nearest_timestamp(
+        #[case] timestamps: &[(Timestamp, Option<Timestamp>)],
+        #[case] ict_enablement: Option<Version>,
+        #[case] timestamp: Timestamp,
+        #[case] bound: Bound,
+        #[case] expected_nearest: Option<Timestamp>,
+    ) {
+        let (_table, engine, snapshot, _log_segment) =
+            build_test_snapshot(timestamps, ict_enablement, None).await;
+
+        let err = timestamp_to_version(&snapshot, &engine, timestamp, bound).unwrap_err();
+        let LogHistoryError::TimestampOutOfRange {
+            nearest_timestamp, ..
+        } = err
+        else {
+            panic!("expected TimestampOutOfRange, got {err:?}");
+        };
+        assert_eq!(nearest_timestamp, expected_nearest);
+    }
+
     /// ICT enabled at v3 but v4 is missing its ICT timestamp (error case).
     /// Table: v0=50, v1=150, v2=250 (file mod), v3=300 (ICT), v4=450 (missing ICT)
     #[tokio::test]

--- a/kernel/src/history_manager/search.rs
+++ b/kernel/src/history_manager/search.rs
@@ -28,6 +28,17 @@ impl Bound {
             Bound::GreatestLower => "no version exists at or before this timestamp",
         }
     }
+
+    /// Returns the boundary element of `slice` on the side an out-of-range
+    /// search failed against: the first element for `GreatestLower` (search
+    /// key was below it) and the last for `LeastUpper` (search key was above
+    /// it). Returns `None` when `slice` is empty.
+    pub(crate) fn boundary_of<'a, T>(&self, slice: &'a [T]) -> Option<&'a T> {
+        match self {
+            Bound::GreatestLower => slice.first(),
+            Bound::LeastUpper => slice.last(),
+        }
+    }
 }
 
 /// Represents the errors that can occur when performing binary search using


### PR DESCRIPTION
## What changes are proposed in this pull request?

Re-adds the `nearest_timestamp` field to `LogHistoryError::TimestampOutOfRange`. Engines surface this to users as the retention boundary in time-travel errors. Without it, error messages collapse to the user's input timestamp ("X is before retention; please use a timestamp at or after X."), which is a Spark-parity UX regression.


## How was this change tested?

Existing `history_manager` unit tests pass.