### PR TITLE
feat: [PROTOTYPE] codify feature × operation support matrix

### DIFF
--- a/kernel/src/incremental_scan/mod.rs
+++ b/kernel/src/incremental_scan/mod.rs
@@ -11,7 +11,7 @@ use crate::log_replay::deduplicator::Deduplicator;
 use crate::log_replay::{FileActionDeduplicator, FileActionKey};
 use crate::schema::{ColumnNamesAndTypes, DataType, SchemaRef, StructField, StructType, ToSchema};
 use crate::snapshot::SnapshotRef;
-use crate::table_features::Operation;
+use crate::table_features::{Operation, ReadOp};
 use crate::utils::require;
 use crate::{
     DeltaResult, Engine, EngineData, Error, FileDataReadResultIterator, FileMeta, Version,
@@ -52,7 +52,7 @@ impl IncrementalScanBuilder {
     /// that's important — the snapshot's `log_tail` carries staged commits that a fresh
     /// storage listing would miss.
     ///
-    /// Validates only the target's reader features via [`Operation::Scan`]. By the protocol's
+    /// Validates only the target's reader features via [`ReadOp::Scan`]. By the protocol's
     /// feature-immutability rule, the target's `readerFeatures` is a superset of every
     /// reader feature used in any commit in `(base_version, target_version]`. Of the fields
     /// kernel itself decodes from each row (path + deletionVector.*), only
@@ -87,7 +87,7 @@ impl IncrementalScanBuilder {
         // TODO(#2552): surface in-range protocol/metadata changes to the consumer.
         self.target_snapshot
             .table_configuration()
-            .ensure_operation_supported(Operation::Scan)?;
+            .ensure_operation_supported(Operation::Read(ReadOp::Scan))?;
 
         // TODO(#2493): replace this block with `CommitRange` once it exists.
         // Today we use the snapshot's already-validated commit list rather than re-listing

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -37,7 +37,7 @@ use crate::schema::{
     ArrayType, DataType, MapType, PrimitiveType, Schema, SchemaRef, StructField, StructType,
     ToSchema as _,
 };
-use crate::table_features::{ColumnMappingMode, Operation};
+use crate::table_features::{ColumnMappingMode, Operation, ReadOp};
 use crate::transforms::{transform_output_type, ExpressionTransform, SchemaTransform};
 use crate::utils::IteratorExt;
 use crate::{DeltaResult, Engine, EngineData, Error, FileMeta, SnapshotRef, Version};
@@ -256,7 +256,7 @@ impl ScanBuilder {
 
         self.snapshot
             .table_configuration()
-            .ensure_operation_supported(Operation::Scan)?;
+            .ensure_operation_supported(Operation::Read(ReadOp::Scan))?;
 
         let state_info = StateInfo::try_new(
             logical_schema,

--- a/kernel/src/table_changes/log_replay.rs
+++ b/kernel/src/table_changes/log_replay.rs
@@ -23,7 +23,7 @@ use crate::schema::{
 };
 use crate::table_changes::scan_file::{cdf_scan_row_expression, cdf_scan_row_schema};
 use crate::table_configuration::TableConfiguration;
-use crate::table_features::{format_features, Operation, TableFeature};
+use crate::table_features::{format_features, Operation, ReadOp, TableFeature};
 use crate::utils::require;
 use crate::{DeltaResult, Engine, EngineData, Error, PredicateRef, RowVisitor};
 
@@ -294,7 +294,7 @@ impl LogReplayScanner {
             // If protocol is updated, check if Change Data Feed is supported
             if has_protocol_update {
                 table_configuration
-                    .ensure_operation_supported(Operation::Cdf)
+                    .ensure_operation_supported(Operation::Read(ReadOp::Cdf))
                     .map_err(|_| Error::change_data_feed_unsupported(commit_file.version))?;
             }
         }

--- a/kernel/src/table_changes/mod.rs
+++ b/kernel/src/table_changes/mod.rs
@@ -41,7 +41,7 @@ use crate::path::AsUrl;
 use crate::schema::{DataType, Schema, StructField, StructType};
 use crate::snapshot::{Snapshot, SnapshotRef};
 use crate::table_configuration::TableConfiguration;
-use crate::table_features::{Operation, TableFeature};
+use crate::table_features::{Operation, ReadOp, TableFeature};
 use crate::{DeltaResult, Engine, Error, Version};
 
 mod log_replay;
@@ -155,7 +155,7 @@ impl TableChanges {
             .build(engine)?;
         start_snapshot
             .table_configuration()
-            .ensure_operation_supported(Operation::Cdf)?;
+            .ensure_operation_supported(Operation::Read(ReadOp::Cdf))?;
 
         let end_snapshot = match end_version {
             Some(version) => Snapshot::builder_from(start_snapshot.clone())
@@ -165,7 +165,7 @@ impl TableChanges {
         };
         end_snapshot
             .table_configuration()
-            .ensure_operation_supported(Operation::Cdf)?;
+            .ensure_operation_supported(Operation::Read(ReadOp::Cdf))?;
 
         // Verify CDF is enabled at the beginning and end of the interval using
         // [`check_cdf_table_properties`] to fail early. This also ensures that column mapping is

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -23,13 +23,14 @@ use crate::scan::data_skipping::stats_schema::{
 };
 use crate::schema::validation::validate_iceberg_compat_v3_no_legacy_nested_id;
 pub(crate) use crate::schema::variant_utils::validate_variant_type_feature_support;
-use crate::schema::{schema_has_invariants, SchemaRef, StructField, StructType};
+use crate::schema::{SchemaRef, StructField, StructType};
 use crate::table_features::{
     column_mapping_mode, get_any_level_column_physical_name,
-    validate_timestamp_ntz_feature_support, ColumnMappingMode, EnablementCheck, FeatureRequirement,
-    FeatureType, KernelSupport, Operation, TableFeature, LEGACY_READER_FEATURES,
-    LEGACY_WRITER_FEATURES, MAX_VALID_READER_VERSION, MAX_VALID_WRITER_VERSION,
-    MIN_VALID_RW_VERSION, TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION,
+    validate_timestamp_ntz_feature_support, ColumnMappingMode, CreatePath, CreateSupport,
+    DataWriteOp, DdlOp, EnablementCheck, FeatureInfo, FeatureRequirement, FeatureType, OpSupport,
+    Operation, ReadOp, TableFeature, LEGACY_READER_FEATURES, LEGACY_WRITER_FEATURES,
+    MAX_VALID_READER_VERSION, MAX_VALID_WRITER_VERSION, MIN_VALID_RW_VERSION,
+    TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION,
 };
 use crate::table_properties::TableProperties;
 use crate::transforms::SchemaTransform as _;
@@ -587,33 +588,37 @@ impl TableConfiguration {
         Ok(())
     }
 
-    /// Checks that kernel supports a feature for the given operation.
-    /// Returns an error if the feature is unknown, not supported, or fails validation.
-    fn check_feature_support(
-        &self,
-        feature: &TableFeature,
-        operation: Operation,
-    ) -> DeltaResult<()> {
-        let info = feature.info();
-        match &info.kernel_support {
-            KernelSupport::Supported => {}
-            KernelSupport::NotSupported => {
-                return Err(Error::unsupported(format!(
-                    "Feature '{feature}' is not supported"
-                )))
+    /// Applies a per-cell [`OpSupport`] policy to the given feature.
+    ///
+    /// Returns `Ok` if the operation is allowed for this feature; otherwise an `unsupported`
+    /// error of the form `"Feature 'X': <cell's static suffix>"`.
+    fn apply_cell(&self, feature: &TableFeature, cell: &OpSupport) -> DeltaResult<()> {
+        let blocked_msg = match cell {
+            OpSupport::Allowed => None,
+            OpSupport::NotApplicable => {
+                debug_assert!(
+                    false,
+                    "Feature '{feature}': NotApplicable cell reached at runtime; dispatcher \
+                     invariant has broken (writer-only feature's read cell should be unreachable)"
+                );
+                None
             }
-            KernelSupport::Custom(check) => {
-                check(&self.protocol, &self.table_properties, operation)?;
-            }
+            OpSupport::ForbiddenIfSupported(msg) => Some(*msg),
+            OpSupport::ForbiddenIfEnabled(msg) if self.is_feature_enabled(feature) => Some(*msg),
+            OpSupport::ForbiddenIfEnabled(_) => None,
+            OpSupport::ForbiddenIf { msg, predicate } if predicate(self) => Some(*msg),
+            OpSupport::ForbiddenIf { .. } => None,
         };
-
-        self.validate_feature_requirements(feature)
+        match blocked_msg {
+            Some(msg) => Err(Error::unsupported(format!("Feature '{feature}': {msg}"))),
+            None => Ok(()),
+        }
     }
 
-    /// Returns all reader features enabled for this table based on protocol version.
+    /// Returns all reader features supported by this table based on protocol version.
     /// For table features protocol (v3), returns the explicit reader_features list.
     /// For legacy protocol (v1-2), infers features from the version number.
-    fn get_enabled_reader_features(&self) -> Vec<TableFeature> {
+    fn get_supported_reader_features(&self) -> Vec<TableFeature> {
         match self.protocol.min_reader_version() {
             TABLE_FEATURES_MIN_READER_VERSION => {
                 // Table features reader: use explicit reader_features list
@@ -634,10 +639,10 @@ impl TableConfiguration {
         }
     }
 
-    /// Returns all writer features enabled for this table based on protocol version.
+    /// Returns all writer features supported by this table based on protocol version.
     /// For table features protocol (v7), returns the explicit writer_features list.
     /// For legacy protocol (v1-6), infers features from the version number.
-    fn get_enabled_writer_features(&self) -> Vec<TableFeature> {
+    fn get_supported_writer_features(&self) -> Vec<TableFeature> {
         match self.protocol.min_writer_version() {
             TABLE_FEATURES_MIN_WRITER_VERSION => {
                 // Table features writer: use explicit writer_features list
@@ -661,18 +666,59 @@ impl TableConfiguration {
     /// Returns `Ok` if the kernel supports the given operation on this table. This checks that
     /// the protocol's features are all supported for the requested operation type.
     ///
-    /// - For `Scan` and `Cdf` operations: checks reader version and reader features
-    /// - For `Write` operations: checks writer version and writer features
+    /// - [`Operation::Read`] operations iterate over reader features.
+    /// - [`Operation::DataWrite`] and [`Operation::Ddl`] operations iterate over writer features.
+    /// - [`Operation::Read`] also validates the reader version is within the kernel's supported
+    ///   range.
+    /// - [`Operation::DataWrite`] and [`Operation::Ddl`] also validate the writer version is within
+    ///   the kernel's supported range.
     #[internal_api]
     pub(crate) fn ensure_operation_supported(&self, operation: Operation) -> DeltaResult<()> {
         match operation {
-            Operation::Scan | Operation::Cdf => self.ensure_read_supported(operation),
-            Operation::Write => self.ensure_write_supported(),
+            Operation::Read(read_op) => {
+                self.check_reader_version()?;
+                self.gate(self.get_supported_reader_features(), |info| match read_op {
+                    ReadOp::Scan => &info.operation_support.read.scan,
+                    ReadOp::Cdf => &info.operation_support.read.cdf,
+                })
+            }
+            Operation::DataWrite(data_write_op) => {
+                self.check_writer_version()?;
+                self.gate(
+                    self.get_supported_writer_features(),
+                    |info| match data_write_op {
+                        DataWriteOp::Append => &info.operation_support.data_write.append,
+                        DataWriteOp::Dml => &info.operation_support.data_write.dml,
+                        DataWriteOp::Maintenance => &info.operation_support.data_write.maintenance,
+                    },
+                )
+            }
+            Operation::Ddl(ddl_op) => {
+                self.check_writer_version()?;
+                self.gate(self.get_supported_writer_features(), |info| match ddl_op {
+                    DdlOp::AddColumn => &info.operation_support.ddl.add_column,
+                    DdlOp::SetNullable => &info.operation_support.ddl.set_nullable,
+                    DdlOp::DropColumn => &info.operation_support.ddl.drop_column,
+                    DdlOp::RenameColumn => &info.operation_support.ddl.rename_column,
+                })
+            }
         }
     }
 
-    /// Internal helper for read operations (Scan, Cdf)
-    fn ensure_read_supported(&self, operation: Operation) -> DeltaResult<()> {
+    /// Walks the given supported-feature list and gates each via the per-feature cell that
+    /// `select` returns. Each feature's `feature_requirements` are validated after its cell.
+    fn gate<F>(&self, features: Vec<TableFeature>, select: F) -> DeltaResult<()>
+    where
+        F: Fn(&FeatureInfo) -> &OpSupport,
+    {
+        for feature in features {
+            self.apply_cell(&feature, select(feature.info()))?;
+            self.validate_feature_requirements(&feature)?;
+        }
+        Ok(())
+    }
+
+    fn check_reader_version(&self) -> DeltaResult<()> {
         require!(
             self.protocol.min_reader_version() >= MIN_VALID_RW_VERSION,
             Error::InvalidProtocol(format!(
@@ -680,26 +726,16 @@ impl TableConfiguration {
                 self.protocol.min_reader_version()
             ))
         );
-        // Version check: kernel supports reader versions 1..=MAX_VALID_READER_VERSION
         if self.protocol.min_reader_version() > MAX_VALID_READER_VERSION {
             return Err(Error::unsupported(format!(
                 "Unsupported minimum reader version {}",
                 self.protocol.min_reader_version()
             )));
         }
-
-        // Check all enabled reader features have kernel support
-        for feature in self.get_enabled_reader_features() {
-            self.check_feature_support(&feature, operation)?;
-        }
-
         Ok(())
     }
 
-    /// Internal helper for write operations
-    fn ensure_write_supported(&self) -> DeltaResult<()> {
-        // Version check: kernel supports writer versions
-        // MIN_VALID_RW_VERSION..=MAX_VALID_WRITER_VERSION
+    fn check_writer_version(&self) -> DeltaResult<()> {
         require!(
             self.protocol.min_writer_version() >= MIN_VALID_RW_VERSION,
             Error::InvalidProtocol(format!(
@@ -707,30 +743,57 @@ impl TableConfiguration {
                 self.protocol.min_writer_version()
             ))
         );
-        // Version check: kernel supports writer versions 1..=MAX_VALID_WRITER_VERSION
         if self.protocol.min_writer_version() > MAX_VALID_WRITER_VERSION {
             return Err(Error::unsupported(format!(
                 "Unsupported minimum writer version {}",
                 self.protocol.min_writer_version()
             )));
         }
-
-        // Check all enabled writer features have kernel support
-        for feature in self.get_enabled_writer_features() {
-            self.check_feature_support(&feature, Operation::Write)?;
-        }
-
-        // Schema-dependent validation for Invariants (can't be in FeatureInfo)
-        // TODO: Better story for schema validation for Invariants and other features
-        if self.is_feature_supported(&TableFeature::Invariants)
-            && schema_has_invariants(self.logical_schema.as_ref())
-        {
-            return Err(Error::unsupported(
-                "Column invariants are not yet supported",
-            ));
-        }
-
         Ok(())
+    }
+
+    /// Returns `Ok` if the given `feature` is allowed to land in the protocol via the given
+    /// `path` at table creation time.
+    ///
+    /// Path-based create validation is separate from [`Self::ensure_operation_supported`] because
+    /// CREATE needs origin information (user opt-in vs kernel inference) that the unified
+    /// dispatcher does not have.
+    #[internal_api]
+    pub(crate) fn ensure_create_supported(
+        &self,
+        feature: &TableFeature,
+        path: CreatePath,
+    ) -> DeltaResult<()> {
+        match (&feature.info().operation_support.create, path) {
+            (CreateSupport::Allowed, _) => Ok(()),
+            (CreateSupport::AllowedOnlyViaKernelInference(_), CreatePath::KernelInference) => {
+                Ok(())
+            }
+            (CreateSupport::AllowedOnlyViaKernelInference(msg), CreatePath::UserOptIn) => {
+                Err(Error::unsupported(format!("Feature '{feature}': {msg}")))
+            }
+            (CreateSupport::Forbidden(msg), _) => {
+                Err(Error::unsupported(format!("Feature '{feature}': {msg}")))
+            }
+        }
+    }
+
+    /// Returns an iterator over all features supported by this table's protocol (union of
+    /// reader and writer feature lists, deduplicated).
+    pub(crate) fn all_supported_features(&self) -> impl Iterator<Item = TableFeature> {
+        let mut seen: HashSet<TableFeature> = HashSet::new();
+        let mut out: Vec<TableFeature> = Vec::new();
+        for f in self.get_supported_reader_features() {
+            if seen.insert(f.clone()) {
+                out.push(f);
+            }
+        }
+        for f in self.get_supported_writer_features() {
+            if seen.insert(f.clone()) {
+                out.push(f);
+            }
+        }
+        out.into_iter()
     }
 
     /// Returns information about in-commit timestamp enablement state.
@@ -877,25 +940,6 @@ impl TableConfiguration {
         // TODO(#1125): Add icebergCompatV2 to the list when it is supported.
         self.is_feature_enabled(&TableFeature::IcebergCompatV3)
     }
-
-    /// TODO(#2538): Row-tracking is not fully supported for removeFile currently.
-    /// See `crate::table_features::ROW_TRACKING_INFO` for more details.
-    pub(crate) fn validate_feature_support_for_remove(&self) -> DeltaResult<()> {
-        // RowTracking is a prerequisite for IcebergCompatV3, so the IcebergCompatV3 arm is
-        // technically redundant. Just be conservative here to check both.
-        if self.should_write_row_tracking() {
-            return Err(Error::unsupported(
-                "Remove actions are not yet supported on tables with rowTracking supported \
-                 and not suspended",
-            ));
-        }
-        if self.is_feature_enabled(&TableFeature::IcebergCompatV3) {
-            return Err(Error::unsupported(
-                "Remove actions are not yet supported on tables with icebergCompatV3 enabled",
-            ));
-        }
-        Ok(())
-    }
 }
 
 #[cfg(test)]
@@ -911,8 +955,8 @@ mod test {
     use crate::actions::{Metadata, Protocol, MIN_VALUES};
     use crate::schema::{ColumnName, DataType, SchemaRef, StructField, StructType};
     use crate::table_features::{
-        ColumnMappingMode, FeatureType, Operation, TableFeature, TABLE_FEATURES_MIN_READER_VERSION,
-        TABLE_FEATURES_MIN_WRITER_VERSION,
+        ColumnMappingMode, DataWriteOp, FeatureType, Operation, ReadOp, TableFeature,
+        TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION,
     };
     use crate::table_properties::{
         TableProperties, COLUMN_MAPPING_MODE, ENABLE_ICEBERG_COMPAT_V1, ENABLE_ICEBERG_COMPAT_V2,
@@ -1057,8 +1101,8 @@ mod test {
     }
 
     #[rstest]
-    #[case(-1, 2, Operation::Scan)]
-    #[case(1, -1, Operation::Write)]
+    #[case(-1, 2, Operation::Read(ReadOp::Scan))]
+    #[case(1, -1, Operation::DataWrite(DataWriteOp::Append))]
     fn reject_protocol_version_below_minimum(
         #[case] rv: i32,
         #[case] wv: i32,
@@ -1144,7 +1188,8 @@ mod test {
 
         for (table_configuration, result) in cases {
             match (
-                table_configuration.ensure_operation_supported(Operation::Write),
+                table_configuration
+                    .ensure_operation_supported(Operation::DataWrite(DataWriteOp::Append)),
                 result,
             ) {
                 (Ok(()), Ok(())) => { /* Correct result */ }
@@ -1300,7 +1345,7 @@ mod test {
         let table_root = Url::try_from("file:///").unwrap();
         let table_config = TableConfiguration::try_new(metadata, protocol, table_root, 0).unwrap();
         table_config
-            .ensure_operation_supported(Operation::Scan)
+            .ensure_operation_supported(Operation::Read(ReadOp::Scan))
             .expect_err("Unknown feature is not supported in kernel");
     }
     #[test]
@@ -1561,12 +1606,19 @@ mod test {
             UnknownFeatureShape::ReaderWriter
         )]
         shape: UnknownFeatureShape,
-        #[values(Operation::Scan, Operation::Cdf, Operation::Write)] operation: Operation,
+        #[values(
+            Operation::Read(ReadOp::Scan),
+            Operation::Read(ReadOp::Cdf),
+            Operation::DataWrite(DataWriteOp::Append)
+        )]
+        operation: Operation,
     ) {
         let (_, config) = create_unknown_feature_config(shape);
         let expected_ok = match shape {
             UnknownFeatureShape::NotListed => true,
-            UnknownFeatureShape::WriterOnly => operation != Operation::Write,
+            UnknownFeatureShape::WriterOnly => {
+                operation != Operation::DataWrite(DataWriteOp::Append)
+            }
             UnknownFeatureShape::ReaderWriter => false,
         };
         assert_eq!(
@@ -1686,13 +1738,19 @@ mod test {
     #[test]
     fn test_ensure_operation_supported_reads() {
         let config = create_mock_table_config(&[], &[]);
-        assert!(config.ensure_operation_supported(Operation::Scan).is_ok());
+        assert!(config
+            .ensure_operation_supported(Operation::Read(ReadOp::Scan))
+            .is_ok());
 
         let config = create_mock_table_config(&[], &[TableFeature::V2Checkpoint]);
-        assert!(config.ensure_operation_supported(Operation::Scan).is_ok());
+        assert!(config
+            .ensure_operation_supported(Operation::Read(ReadOp::Scan))
+            .is_ok());
 
         let config = create_mock_table_config_with_version(&[], None, 1, 2);
-        assert!(config.ensure_operation_supported(Operation::Scan).is_ok());
+        assert!(config
+            .ensure_operation_supported(Operation::Read(ReadOp::Scan))
+            .is_ok());
 
         let config = create_mock_table_config_with_version(
             &[],
@@ -1700,7 +1758,9 @@ mod test {
             2,
             7,
         );
-        assert!(config.ensure_operation_supported(Operation::Scan).is_ok());
+        assert!(config
+            .ensure_operation_supported(Operation::Read(ReadOp::Scan))
+            .is_ok());
     }
 
     #[test]
@@ -1715,13 +1775,15 @@ mod test {
                 TableFeature::RowTracking,
             ],
         );
-        assert!(config.ensure_operation_supported(Operation::Write).is_ok());
+        assert!(config
+            .ensure_operation_supported(Operation::DataWrite(DataWriteOp::Append))
+            .is_ok());
 
         // Type Widening is not supported for writes
         let config = create_mock_table_config(&[], &[TableFeature::TypeWidening]);
         assert_result_error_with_message(
-            config.ensure_operation_supported(Operation::Write),
-            r#"Feature 'typeWidening' is not supported for writes"#,
+            config.ensure_operation_supported(Operation::DataWrite(DataWriteOp::Append)),
+            r#"Feature 'typeWidening': is not supported for writes"#,
         );
     }
 
@@ -1738,7 +1800,7 @@ mod test {
         let table_root = Url::try_from("file:///").unwrap();
         let config = TableConfiguration::try_new(metadata, protocol, table_root, 0).unwrap();
         assert_result_error_with_message(
-            config.ensure_operation_supported(Operation::Write),
+            config.ensure_operation_supported(Operation::DataWrite(DataWriteOp::Append)),
             "Feature 'rowTracking' requires 'domainMetadata' to be supported",
         );
     }
@@ -1758,7 +1820,9 @@ mod test {
         let table_root = Url::try_from("file:///").unwrap();
         let config = TableConfiguration::try_new(metadata, protocol, table_root, 0).unwrap();
         assert!(
-            config.ensure_operation_supported(Operation::Write).is_ok(),
+            config
+                .ensure_operation_supported(Operation::DataWrite(DataWriteOp::Append))
+                .is_ok(),
             "RowTracking with DomainMetadata should be supported for writes"
         );
     }
@@ -1773,7 +1837,9 @@ mod test {
                 TableFeature::InCommitTimestamp,
             ],
         );
-        assert!(config.ensure_operation_supported(Operation::Write).is_ok());
+        assert!(config
+            .ensure_operation_supported(Operation::DataWrite(DataWriteOp::Append))
+            .is_ok());
 
         let config = create_mock_table_config(
             &[(ENABLE_IN_COMMIT_TIMESTAMPS, "true")],
@@ -1782,7 +1848,9 @@ mod test {
                 TableFeature::InCommitTimestamp,
             ],
         );
-        assert!(config.ensure_operation_supported(Operation::Write).is_ok());
+        assert!(config
+            .ensure_operation_supported(Operation::DataWrite(DataWriteOp::Append))
+            .is_ok());
     }
 
     /// Helper to create a schema with column mapping metadata using JSON deserialization
@@ -2348,7 +2416,9 @@ mod test {
             &[TableFeature::ClusteredTable, TableFeature::DomainMetadata],
         );
         assert!(
-            config.ensure_operation_supported(Operation::Write).is_ok(),
+            config
+                .ensure_operation_supported(Operation::DataWrite(DataWriteOp::Append))
+                .is_ok(),
             "ClusteredTable with DomainMetadata should be supported for writes"
         );
     }
@@ -2419,7 +2489,7 @@ mod test {
             ],
         );
         config
-            .ensure_operation_supported(Operation::Write)
+            .ensure_operation_supported(Operation::DataWrite(DataWriteOp::Append))
             .expect("V3 write should be supported once kernel_support flips to Supported");
     }
 
@@ -2643,22 +2713,90 @@ mod test {
         );
     }
 
-    /// `validate_feature_support_for_remove` must fire whenever row tracking is _supported_
-    /// and not _suspended_, which is broader than _enabled_.
+    /// The RowTracking `data_write` matrix cells must reject `Dml` and `Maintenance` whenever
+    /// row tracking is _supported_ and not _suspended_, which is broader than just _enabled_.
+    /// Append is always allowed. See
+    /// [`crate::table_features::row_tracking_supported_and_not_suspended_predicate`]
+    /// for the rationale.
     #[rstest]
     #[case::supported_only(&[], Some("rowTracking"))]
     #[case::supported_and_enabled(&[(ENABLE_ROW_TRACKING, "true")], Some("rowTracking"))]
-    #[case::supported_and_suspended(&[(ROW_TRACKING_SUSPENDED, "true")], None /*expected_error_substring */)]
-    fn test_validate_feature_support_for_remove_row_tracking(
+    #[case::supported_and_suspended(&[(ROW_TRACKING_SUSPENDED, "true")], None)]
+    fn test_row_tracking_blocks_data_changing_writes(
         #[case] props: &[(&str, &str)],
         #[case] expected_error_substring: Option<&str>,
     ) {
-        let config = create_mock_table_config(props, &[TableFeature::RowTracking]);
-        let result = config.validate_feature_support_for_remove();
-        match expected_error_substring {
-            Some(msg) => assert_result_error_with_message(result, msg),
-            None => assert!(result.is_ok(), "expected Ok, got {result:?}"),
+        let config = create_mock_table_config(
+            props,
+            &[TableFeature::RowTracking, TableFeature::DomainMetadata],
+        );
+        for op in [DataWriteOp::Dml, DataWriteOp::Maintenance] {
+            let result = config.ensure_operation_supported(Operation::DataWrite(op));
+            match expected_error_substring {
+                Some(msg) => assert_result_error_with_message(result, msg),
+                None => assert!(result.is_ok(), "{op:?}: expected Ok, got {result:?}"),
+            }
         }
+        // Append is always allowed regardless of row tracking state.
+        assert!(config
+            .ensure_operation_supported(Operation::DataWrite(DataWriteOp::Append))
+            .is_ok());
+    }
+
+    /// The IcebergCompatV3 `data_write` matrix cells must reject `Dml` and `Maintenance`
+    /// whenever V3 is enabled. On a typical V3 table the RowTracking cell would also fire
+    /// and could mask the V3-specific message. This test orders V3 first in the writer
+    /// feature list so the V3 cell is the one observed; V3's dependency cascade
+    /// (ColumnMapping, RowTracking, DomainMetadata) is still satisfied by including those
+    /// features in the protocol so `validate_feature_requirements` passes for the Append
+    /// case.
+    #[test]
+    fn test_iceberg_compat_v3_blocks_removes_with_specific_message() {
+        let config = create_mock_table_config_with_cm(
+            &[
+                (ENABLE_ICEBERG_COMPAT_V3, "true"),
+                (ENABLE_ROW_TRACKING, "true"),
+            ],
+            Some(ColumnMappingMode::Name),
+            &[TableFeature::ColumnMapping],
+            // V3 listed first so its cell fires before RowTracking's.
+            &[
+                TableFeature::IcebergCompatV3,
+                TableFeature::RowTracking,
+                TableFeature::DomainMetadata,
+                TableFeature::ColumnMapping,
+            ],
+        );
+        for op in [DataWriteOp::Dml, DataWriteOp::Maintenance] {
+            assert_result_error_with_message(
+                config.ensure_operation_supported(Operation::DataWrite(op)),
+                "Remove actions are not yet supported on icebergCompatV3-enabled tables",
+            );
+        }
+        // Append must still succeed (V3 doesn't restrict append-shaped writes).
+        assert!(config
+            .ensure_operation_supported(Operation::DataWrite(DataWriteOp::Append))
+            .is_ok());
+    }
+
+    /// CatalogManaged and CatalogOwnedPreview's `read.cdf` cell must block CDF reads
+    /// whenever the feature is in the protocol's reader features. Reads of regular table
+    /// data (`Scan`) must still succeed.
+    #[rstest]
+    #[case(TableFeature::CatalogManaged, "Feature 'catalogManaged'")]
+    #[case(TableFeature::CatalogOwnedPreview, "Feature 'catalogOwned-preview'")]
+    fn test_catalog_features_block_cdf_reads(
+        #[case] feature: TableFeature,
+        #[case] expected_substring: &str,
+    ) {
+        let config = create_mock_table_config(&[], &[feature]);
+        assert_result_error_with_message(
+            config.ensure_operation_supported(Operation::Read(ReadOp::Cdf)),
+            expected_substring,
+        );
+        assert!(config
+            .ensure_operation_supported(Operation::Read(ReadOp::Scan))
+            .is_ok());
     }
 
     /// Test helper: variant of `create_mock_table_config` that also takes an optional

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -20,9 +20,9 @@ pub(crate) use timestamp_ntz::{
 use crate::actions::Protocol;
 use crate::expressions::Scalar;
 use crate::schema::derive_macro_utils::ToDataType;
-use crate::schema::DataType;
+use crate::schema::{schema_has_invariants, DataType};
 use crate::table_properties::TableProperties;
-use crate::{DeltaResult, Error};
+use crate::DeltaResult;
 
 mod column_mapping;
 mod timestamp_ntz;
@@ -204,28 +204,256 @@ pub(crate) enum EnablementCheck {
     EnabledIf(fn(&TableProperties) -> bool),
 }
 
-/// Represents the type of operation being performed on a table
+/// Read sub-operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[internal_api]
+pub(crate) enum ReadOp {
+    /// Regular table data read (scan).
+    Scan,
+    /// Change data feed read.
+    Cdf,
+}
+
+/// Data-writing sub-operations. A "data write" commits add and/or remove file actions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[internal_api]
+pub(crate) enum DataWriteOp {
+    /// Append-only data write: only add file actions are staged (no removes), with
+    /// `data_change=true`. Also covers metadata-only commits routed through the data-write
+    /// path (e.g. `SetTransaction` / `DomainMetadata`-only commits with no file actions);
+    /// those have no file-level effect and are treated as Append for gating purposes.
+    /// Schema-modifying DDL (`AlterTable`) goes through `Operation::Ddl`, not this op.
+    Append,
+    /// DML data write (UPDATE / DELETE / MERGE-shaped commit, with remove actions or
+    /// mixed add+remove with `data_change=true`).
+    Dml,
+    /// Maintenance (any data-preserving commit with `data_change=false`). Covers OPTIMIZE
+    /// and ZORDER file compaction, statistics updates, row-id / row-commit-version
+    /// backfill, and any other file-action commit that does not change the logical
+    /// row content of the table.
+    Maintenance,
+}
+
+/// DDL (schema-modifying) sub-operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[internal_api]
+pub(crate) enum DdlOp {
+    /// Add a new top-level column.
+    AddColumn,
+    /// Relax a column from NOT NULL to nullable.
+    SetNullable,
+    /// Drop an existing column.
+    DropColumn,
+    /// Rename an existing column.
+    RenameColumn,
+}
+
+/// Represents the type of operation being performed on a table.
+///
+/// CREATE is intentionally not represented here. CREATE needs an "origin" distinction
+/// (user opt-in vs kernel inference) that the unified operation dispatcher does not have;
+/// see [`ensure_create_supported`](crate::table_configuration::TableConfiguration::ensure_create_supported).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[internal_api]
 pub(crate) enum Operation {
-    /// Read operations on regular table data
-    Scan,
-    /// Read operations on change data feed data
-    Cdf,
-    /// Write operations on regular table data
-    Write,
+    /// Read path operations.
+    Read(ReadOp),
+    /// Data-writing operations (commits that produce add/remove file actions).
+    DataWrite(DataWriteOp),
+    /// Schema-modifying (DDL) operations.
+    Ddl(DdlOp),
 }
 
-/// Defines whether the Rust kernel has implementation support for a feature's operation
-pub(crate) enum KernelSupport {
-    /// Kernel has full support for any operation on this feature
-    Supported,
-    /// Kernel does not support this operation on this feature
-    NotSupported,
-    /// Custom logic to determine support based on operation type and table properties.
-    /// For example: Column Mapping may support Scan but not CDF, or CDF writes may only
-    /// be supported when AppendOnly is true.
-    Custom(fn(&Protocol, &TableProperties, Operation) -> DeltaResult<()>),
+/// Distinguishes how a feature came to be in the protocol at CREATE time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[internal_api]
+pub(crate) enum CreatePath {
+    /// The user explicitly opted in (e.g. via `delta.feature.X=supported`, or a property
+    /// that drives auto-enablement like `delta.enableRowTracking=true`).
+    UserOptIn,
+    /// The kernel inferred the feature was needed (e.g. from a `timestampNtz` schema
+    /// column, a clustering layout, or a dependency cascade).
+    KernelInference,
+}
+
+/// Per-cell policy for Read / DataWrite / DDL operations.
+///
+/// On rejection every variant produces an error of the form `"Feature 'X': <msg>"` where
+/// `<msg>` is the cell's static suffix and the dispatcher (`apply_cell`) prepends the
+/// feature name.
+pub(crate) enum OpSupport {
+    /// Operation is allowed.
+    Allowed,
+    /// Cell is not reachable from the dispatcher under the current design. Used at the
+    /// definition site to make intent explicit (e.g. the `read.scan` / `read.cdf` cells on
+    /// a writer-only feature, which are never iterated because the read path only walks
+    /// reader features). The dispatcher treats `NotApplicable` as `Allowed` at runtime;
+    /// debug builds `debug_assert!(false)` to fail loud if a refactor ever reaches this
+    /// cell.
+    NotApplicable,
+    /// Blocks whenever the feature is in the protocol (writerFeatures / readerFeatures),
+    /// regardless of active state. Use when kernel cannot safely handle the op even when
+    /// the feature is "idle". The `&'static str` is the error message suffix.
+    ForbiddenIfSupported(&'static str),
+    /// Blocks only when the feature is active per its [`EnablementCheck`] (i.e. the
+    /// relevant property is set). The `&'static str` is the error message suffix.
+    ForbiddenIfEnabled(&'static str),
+    /// Blocks when the predicate returns `true`. Use for schema- or property-state-dependent
+    /// checks that can't be expressed as `ForbiddenIfSupported`/`ForbiddenIfEnabled`. The
+    /// `&'static str` is the error message suffix. Used sparingly.
+    ForbiddenIf {
+        msg: &'static str,
+        predicate: fn(&crate::table_configuration::TableConfiguration) -> bool,
+    },
+}
+
+/// Per-cell policy for the CREATE path. CREATE has its own origin (user opt-in vs kernel
+/// inference) and therefore a different cell enum from [`OpSupport`].
+pub(crate) enum CreateSupport {
+    /// Feature may land in protocol via either path (user opt-in or kernel inference).
+    Allowed,
+    /// Feature may only land via kernel inference (e.g. schema-implied, dep cascade,
+    /// or `with_data_layout`). User opt-in is rejected.
+    AllowedOnlyViaKernelInference(&'static str),
+    /// Feature cannot land in protocol via any path.
+    Forbidden(&'static str),
+}
+
+/// Read-side policy for a feature.
+pub(crate) struct ReadSupport {
+    pub(crate) scan: OpSupport,
+    pub(crate) cdf: OpSupport,
+}
+
+impl ReadSupport {
+    pub(crate) const ALL_ALLOWED: Self = Self {
+        scan: OpSupport::Allowed,
+        cdf: OpSupport::Allowed,
+    };
+
+    /// For writer-only features whose `read` cells are unreachable. The dispatcher only
+    /// iterates reader features for read ops, so a writer-only feature's read cells should
+    /// never run. Definition-site documentation only; runtime behavior is `Allowed` with a
+    /// `debug_assert!(false)` in `apply_cell` if the invariant ever breaks.
+    pub(crate) const NOT_APPLICABLE: Self = Self {
+        scan: OpSupport::NotApplicable,
+        cdf: OpSupport::NotApplicable,
+    };
+}
+
+/// Data-write policy for a feature.
+pub(crate) struct DataWriteSupport {
+    pub(crate) append: OpSupport,
+    pub(crate) dml: OpSupport,
+    pub(crate) maintenance: OpSupport,
+}
+
+impl DataWriteSupport {
+    pub(crate) const ALL_ALLOWED: Self = Self {
+        append: OpSupport::Allowed,
+        dml: OpSupport::Allowed,
+        maintenance: OpSupport::Allowed,
+    };
+
+    /// All data-write cells forbidden whenever the feature is supported by the protocol.
+    pub(crate) const fn all_forbidden_if_supported(msg: &'static str) -> Self {
+        Self {
+            append: OpSupport::ForbiddenIfSupported(msg),
+            dml: OpSupport::ForbiddenIfSupported(msg),
+            maintenance: OpSupport::ForbiddenIfSupported(msg),
+        }
+    }
+
+    /// Restrict data writes to Append-only when the feature is active. DML (UPDATE / DELETE /
+    /// MERGE) and Maintenance (OPTIMIZE, stats updates, row-id backfill, etc.) are forbidden;
+    /// blind append remains allowed.
+    pub(crate) const fn restrict_to_appends_when_enabled(msg: &'static str) -> Self {
+        Self {
+            append: OpSupport::Allowed,
+            dml: OpSupport::ForbiddenIfEnabled(msg),
+            maintenance: OpSupport::ForbiddenIfEnabled(msg),
+        }
+    }
+}
+
+/// DDL (schema-modifying) policy for a feature.
+pub(crate) struct DdlSupport {
+    pub(crate) add_column: OpSupport,
+    pub(crate) set_nullable: OpSupport,
+    pub(crate) drop_column: OpSupport,
+    pub(crate) rename_column: OpSupport,
+}
+
+impl DdlSupport {
+    pub(crate) const ALL_ALLOWED: Self = Self {
+        add_column: OpSupport::Allowed,
+        set_nullable: OpSupport::Allowed,
+        drop_column: OpSupport::Allowed,
+        rename_column: OpSupport::Allowed,
+    };
+
+    /// All DDL cells forbidden whenever the feature is supported by the protocol.
+    pub(crate) const fn all_forbidden_if_supported(msg: &'static str) -> Self {
+        Self {
+            add_column: OpSupport::ForbiddenIfSupported(msg),
+            set_nullable: OpSupport::ForbiddenIfSupported(msg),
+            drop_column: OpSupport::ForbiddenIfSupported(msg),
+            rename_column: OpSupport::ForbiddenIfSupported(msg),
+        }
+    }
+
+    /// All DDL cells forbidden whenever the feature is active.
+    pub(crate) const fn all_forbidden_if_enabled(msg: &'static str) -> Self {
+        Self {
+            add_column: OpSupport::ForbiddenIfEnabled(msg),
+            set_nullable: OpSupport::ForbiddenIfEnabled(msg),
+            drop_column: OpSupport::ForbiddenIfEnabled(msg),
+            rename_column: OpSupport::ForbiddenIfEnabled(msg),
+        }
+    }
+}
+
+/// Full per-feature operation support matrix. Every (feature, operation) pair has a
+/// dedicated cell, so the question "does feature X support operation Y?" answers as a
+/// single field lookup.
+pub(crate) struct OperationSupport {
+    pub(crate) read: ReadSupport,
+    pub(crate) data_write: DataWriteSupport,
+    pub(crate) ddl: DdlSupport,
+    pub(crate) create: CreateSupport,
+}
+
+impl OperationSupport {
+    pub(crate) const ALL_ALLOWED: Self = Self {
+        read: ReadSupport::ALL_ALLOWED,
+        data_write: DataWriteSupport::ALL_ALLOWED,
+        ddl: DdlSupport::ALL_ALLOWED,
+        create: CreateSupport::Allowed,
+    };
+}
+
+/// `ForbiddenIf` predicate for the Invariants cells: returns `true` when the schema actually
+/// carries `delta.invariants` metadata on any field. The static feature presence in the
+/// protocol alone does not block writes; only an in-use invariant does.
+fn schema_has_invariants_predicate(
+    table_config: &crate::table_configuration::TableConfiguration,
+) -> bool {
+    schema_has_invariants(table_config.logical_schema().as_ref())
+}
+
+/// `ForbiddenIf` predicate for [`ROW_TRACKING_INFO`]'s remove-producing cells.
+///
+/// Fires whenever the table may carry row IDs that kernel cannot preserve through the
+/// commit. Broader than `is_feature_enabled`: it fires whenever row tracking is supported
+/// by the protocol AND not suspended, even if `delta.enableRowTracking` is `false`. See
+/// [`crate::table_configuration::TableConfiguration::should_write_row_tracking`] for the
+/// authoritative definition. Kernel cannot yet preserve stable row IDs across removes
+/// (#2538), so the predicate conservatively reports `true` whenever the table may have
+/// row IDs.
+fn row_tracking_supported_and_not_suspended_predicate(
+    table_config: &crate::table_configuration::TableConfiguration,
+) -> bool {
+    table_config.should_write_row_tracking()
 }
 
 /// Types of requirements for feature dependencies
@@ -269,16 +497,44 @@ pub(crate) struct FeatureInfo {
     pub min_legacy_version: Option<MinReaderWriterVersion>,
     /// Requirements this feature has (features + custom validations)
     pub feature_requirements: &'static [FeatureRequirement],
-    /// Rust kernel's support for this feature (may vary by Operation type)
+    /// Per-operation support matrix for this feature.
     ///
-    /// Note: `kernel_support` validation depends on `feature_type`:
-    /// WriterOnly features: Only checked during `Operation::Write`
-    /// ReaderWriter features: Checked during all operations (Scan/Write/CDF)
-    /// Read operations (Scan/CDF) only validate reader features, so `kernel_support` for
-    /// WriterOnly features are never invoked for Scan/CDF regardless of the custom check logic.
-    pub kernel_support: KernelSupport,
+    /// Read cells (`read.scan`, `read.cdf`) only apply to ReaderWriter features; for
+    /// WriterOnly features they are unreachable because the read path iterates only
+    /// reader features. DataWrite and DDL cells apply to both WriterOnly and ReaderWriter
+    /// features.
+    pub operation_support: OperationSupport,
     /// How to check if this feature is enabled in a table
     pub enablement_check: EnablementCheck,
+}
+
+// === Shared error message suffixes ===
+//
+// The dispatcher prepends "Feature 'X': " to every error message, so per-cell strings
+// here are *suffixes* describing the failure, not full sentences.
+mod msg {
+    pub(super) const NOT_SUPPORTED: &str = "is not supported";
+    pub(super) const NOT_SUPPORTED_FOR_WRITES: &str = "is not supported for writes";
+    pub(super) const NOT_SUPPORTED_FOR_CDF: &str = "is not supported for CDF";
+    pub(super) const CREATE_FORBIDDEN: &str = "cannot be enabled at table create time";
+    pub(super) const CREATE_FORBIDDEN_KERNEL_CANNOT_WRITE: &str =
+        "cannot be enabled at table create time: kernel cannot write to tables with this feature";
+    pub(super) const CREATE_KERNEL_INFERENCE_ONLY_SCHEMA: &str =
+        "is enabled by schema column type; do not set the corresponding delta.feature.* signal at create time";
+    pub(super) const CREATE_KERNEL_INFERENCE_ONLY_CLUSTERING: &str =
+        "is enabled by with_data_layout(clustered(...)); do not set delta.feature.clustering at create time";
+    pub(super) const CATALOG_OWNED_PREVIEW_DEPRECATED_FOR_CREATE: &str =
+        "is deprecated for CREATE TABLE; use 'catalogManaged' instead";
+
+    pub(super) const CDF_DML_NOT_YET_SUPPORTED: &str =
+        "CDF writes not yet supported for UPDATE/DELETE/MERGE-shaped commits";
+    pub(super) const INVARIANTS_IN_SCHEMA: &str = "Column invariants are not yet supported";
+    pub(super) const ROW_TRACKING_BLOCKS_REMOVES: &str =
+        "Remove actions are not yet supported when rowTracking is supported and not suspended (#2538)";
+    pub(super) const V3_BLOCKS_REMOVES: &str =
+        "Remove actions are not yet supported on icebergCompatV3-enabled tables";
+    pub(super) const V3_BLOCKS_ALTER: &str =
+        "ALTER TABLE not yet supported on icebergCompatV3-enabled tables";
 }
 
 // Static FeatureInfo instances for each table feature
@@ -286,19 +542,54 @@ static APPEND_ONLY_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::WriterOnly,
     min_legacy_version: Some(MinReaderWriterVersion::new(1, 2)),
     feature_requirements: &[],
-    kernel_support: KernelSupport::Supported,
+    operation_support: OperationSupport::ALL_ALLOWED,
     enablement_check: EnablementCheck::EnabledIf(|props| props.append_only == Some(true)),
 };
 
-// Although kernel marks invariants as "Supported", invariants must NOT actually be present in the
-// table schema. Kernel will fail to write to any table that actually uses invariants (see check in
-// TableConfiguration::ensure_write_supported). This is to allow legacy tables with the Invariants
-// feature enabled but not in use.
+// Invariants must NOT actually be present in the table schema. Kernel will fail any data write or
+// DDL on a table whose schema contains invariants. The `Conditional` cells run a schema scan to
+// enforce that, while still allowing legacy tables that list the Invariants feature but do not
+// use it.
 static INVARIANTS_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::WriterOnly,
     min_legacy_version: Some(MinReaderWriterVersion::new(1, 2)),
     feature_requirements: &[],
-    kernel_support: KernelSupport::Supported,
+    operation_support: OperationSupport {
+        data_write: DataWriteSupport {
+            append: OpSupport::ForbiddenIf {
+                msg: msg::INVARIANTS_IN_SCHEMA,
+                predicate: schema_has_invariants_predicate,
+            },
+            dml: OpSupport::ForbiddenIf {
+                msg: msg::INVARIANTS_IN_SCHEMA,
+                predicate: schema_has_invariants_predicate,
+            },
+            maintenance: OpSupport::ForbiddenIf {
+                msg: msg::INVARIANTS_IN_SCHEMA,
+                predicate: schema_has_invariants_predicate,
+            },
+        },
+        ddl: DdlSupport {
+            add_column: OpSupport::ForbiddenIf {
+                msg: msg::INVARIANTS_IN_SCHEMA,
+                predicate: schema_has_invariants_predicate,
+            },
+            set_nullable: OpSupport::ForbiddenIf {
+                msg: msg::INVARIANTS_IN_SCHEMA,
+                predicate: schema_has_invariants_predicate,
+            },
+            drop_column: OpSupport::ForbiddenIf {
+                msg: msg::INVARIANTS_IN_SCHEMA,
+                predicate: schema_has_invariants_predicate,
+            },
+            rename_column: OpSupport::ForbiddenIf {
+                msg: msg::INVARIANTS_IN_SCHEMA,
+                predicate: schema_has_invariants_predicate,
+            },
+        },
+        read: ReadSupport::NOT_APPLICABLE,
+        create: CreateSupport::Allowed,
+    },
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 
@@ -306,7 +597,12 @@ static CHECK_CONSTRAINTS_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::WriterOnly,
     min_legacy_version: Some(MinReaderWriterVersion::new(1, 3)),
     feature_requirements: &[],
-    kernel_support: KernelSupport::NotSupported,
+    operation_support: OperationSupport {
+        data_write: DataWriteSupport::all_forbidden_if_supported(msg::NOT_SUPPORTED),
+        ddl: DdlSupport::all_forbidden_if_supported(msg::NOT_SUPPORTED),
+        read: ReadSupport::NOT_APPLICABLE,
+        create: CreateSupport::Forbidden(msg::CREATE_FORBIDDEN),
+    },
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 
@@ -314,7 +610,13 @@ static CHANGE_DATA_FEED_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::WriterOnly,
     min_legacy_version: Some(MinReaderWriterVersion::new(1, 4)),
     feature_requirements: &[],
-    kernel_support: KernelSupport::Supported,
+    operation_support: OperationSupport {
+        data_write: DataWriteSupport {
+            dml: OpSupport::ForbiddenIfEnabled(msg::CDF_DML_NOT_YET_SUPPORTED),
+            ..DataWriteSupport::ALL_ALLOWED
+        },
+        ..OperationSupport::ALL_ALLOWED
+    },
     enablement_check: EnablementCheck::EnabledIf(|props| {
         props.enable_change_data_feed == Some(true)
     }),
@@ -324,7 +626,12 @@ static GENERATED_COLUMNS_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::WriterOnly,
     min_legacy_version: Some(MinReaderWriterVersion::new(1, 4)),
     feature_requirements: &[],
-    kernel_support: KernelSupport::NotSupported,
+    operation_support: OperationSupport {
+        data_write: DataWriteSupport::all_forbidden_if_supported(msg::NOT_SUPPORTED),
+        ddl: DdlSupport::all_forbidden_if_supported(msg::NOT_SUPPORTED),
+        read: ReadSupport::NOT_APPLICABLE,
+        create: CreateSupport::Forbidden(msg::CREATE_FORBIDDEN),
+    },
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 
@@ -332,7 +639,12 @@ static IDENTITY_COLUMNS_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::WriterOnly,
     min_legacy_version: Some(MinReaderWriterVersion::new(1, 6)),
     feature_requirements: &[],
-    kernel_support: KernelSupport::NotSupported,
+    operation_support: OperationSupport {
+        data_write: DataWriteSupport::all_forbidden_if_supported(msg::NOT_SUPPORTED),
+        ddl: DdlSupport::all_forbidden_if_supported(msg::NOT_SUPPORTED),
+        read: ReadSupport::NOT_APPLICABLE,
+        create: CreateSupport::Forbidden(msg::CREATE_FORBIDDEN),
+    },
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 
@@ -340,9 +652,7 @@ static IN_COMMIT_TIMESTAMP_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::WriterOnly,
     min_legacy_version: None,
     feature_requirements: &[],
-    kernel_support: KernelSupport::Custom(|_protocol, _properties, operation| match operation {
-        Operation::Scan | Operation::Write | Operation::Cdf => Ok(()),
-    }),
+    operation_support: OperationSupport::ALL_ALLOWED,
     enablement_check: EnablementCheck::EnabledIf(|props| {
         props.enable_in_commit_timestamps == Some(true)
     }),
@@ -362,7 +672,22 @@ static ROW_TRACKING_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::WriterOnly,
     min_legacy_version: None,
     feature_requirements: &[FeatureRequirement::Supported(TableFeature::DomainMetadata)],
-    kernel_support: KernelSupport::Supported,
+    operation_support: OperationSupport {
+        // Gate fires whenever row tracking is *supported and not suspended* (broader than
+        // just *enabled*). See [`row_tracking_supported_and_not_suspended_predicate`].
+        data_write: DataWriteSupport {
+            append: OpSupport::Allowed,
+            dml: OpSupport::ForbiddenIf {
+                msg: msg::ROW_TRACKING_BLOCKS_REMOVES,
+                predicate: row_tracking_supported_and_not_suspended_predicate,
+            },
+            maintenance: OpSupport::ForbiddenIf {
+                msg: msg::ROW_TRACKING_BLOCKS_REMOVES,
+                predicate: row_tracking_supported_and_not_suspended_predicate,
+            },
+        },
+        ..OperationSupport::ALL_ALLOWED
+    },
     enablement_check: EnablementCheck::EnabledIf(|props| {
         props.enable_row_tracking == Some(true) && props.row_tracking_suspended != Some(true)
     }),
@@ -372,12 +697,12 @@ static DOMAIN_METADATA_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::WriterOnly,
     min_legacy_version: None,
     feature_requirements: &[],
-    kernel_support: KernelSupport::Supported,
+    operation_support: OperationSupport::ALL_ALLOWED,
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 
 // TODO(#1125): IcebergCompatV1 requires schema type validation to block Map, Array, and Void types.
-// This validation is not yet implemented. The feature is marked as NotSupported for writes until
+// This validation is not yet implemented. The feature is marked as not supported for writes until
 // proper validation is added.
 //
 // See Delta Spark: IcebergCompat.scala CheckNoListMapNullType (lines 422-433)
@@ -392,7 +717,12 @@ static ICEBERG_COMPAT_V1_INFO: FeatureInfo = FeatureInfo {
         FeatureRequirement::NotEnabled(TableFeature::IcebergCompatV2),
         FeatureRequirement::NotEnabled(TableFeature::IcebergCompatV3),
     ],
-    kernel_support: KernelSupport::NotSupported,
+    operation_support: OperationSupport {
+        data_write: DataWriteSupport::all_forbidden_if_supported(msg::NOT_SUPPORTED),
+        ddl: DdlSupport::all_forbidden_if_supported(msg::NOT_SUPPORTED),
+        read: ReadSupport::NOT_APPLICABLE,
+        create: CreateSupport::Forbidden(msg::CREATE_FORBIDDEN),
+    },
     enablement_check: EnablementCheck::EnabledIf(|props| {
         props.enable_iceberg_compat_v1 == Some(true)
     }),
@@ -400,7 +730,7 @@ static ICEBERG_COMPAT_V1_INFO: FeatureInfo = FeatureInfo {
 
 // TODO(#1125): IcebergCompatV2 requires schema type validation. Unlike V1, V2 allows Map and Array
 // types but needs validation against an allowlist of supported types.
-// This validation is not yet implemented. The feature is marked as NotSupported for writes until
+// This validation is not yet implemented. The feature is marked as not supported for writes until
 // proper validation is added.
 
 // See Delta Spark: IcebergCompat.scala CheckTypeInV2AllowList (lines 450-459)
@@ -415,7 +745,12 @@ static ICEBERG_COMPAT_V2_INFO: FeatureInfo = FeatureInfo {
         FeatureRequirement::NotEnabled(TableFeature::DeletionVectors),
         FeatureRequirement::NotEnabled(TableFeature::IcebergCompatV3),
     ],
-    kernel_support: KernelSupport::NotSupported,
+    operation_support: OperationSupport {
+        data_write: DataWriteSupport::all_forbidden_if_supported(msg::NOT_SUPPORTED),
+        ddl: DdlSupport::all_forbidden_if_supported(msg::NOT_SUPPORTED),
+        read: ReadSupport::NOT_APPLICABLE,
+        create: CreateSupport::Forbidden(msg::CREATE_FORBIDDEN),
+    },
     enablement_check: EnablementCheck::EnabledIf(|props| {
         props.enable_iceberg_compat_v2 == Some(true)
     }),
@@ -454,7 +789,12 @@ static ICEBERG_COMPAT_V3_INFO: FeatureInfo = FeatureInfo {
         FeatureRequirement::NotEnabled(TableFeature::IcebergCompatV1),
         FeatureRequirement::NotEnabled(TableFeature::IcebergCompatV2),
     ],
-    kernel_support: KernelSupport::Supported,
+    operation_support: OperationSupport {
+        data_write: DataWriteSupport::restrict_to_appends_when_enabled(msg::V3_BLOCKS_REMOVES),
+        ddl: DdlSupport::all_forbidden_if_enabled(msg::V3_BLOCKS_ALTER),
+        read: ReadSupport::NOT_APPLICABLE,
+        create: CreateSupport::Allowed,
+    },
     enablement_check: EnablementCheck::EnabledIf(|props| {
         props.enable_iceberg_compat_v3 == Some(true)
     }),
@@ -464,7 +804,12 @@ static CLUSTERED_TABLE_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::WriterOnly,
     min_legacy_version: None,
     feature_requirements: &[FeatureRequirement::Supported(TableFeature::DomainMetadata)],
-    kernel_support: KernelSupport::Supported,
+    operation_support: OperationSupport {
+        create: CreateSupport::AllowedOnlyViaKernelInference(
+            msg::CREATE_KERNEL_INFERENCE_ONLY_CLUSTERING,
+        ),
+        ..OperationSupport::ALL_ALLOWED
+    },
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 
@@ -472,7 +817,7 @@ static MATERIALIZE_PARTITION_COLUMNS_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::WriterOnly,
     min_legacy_version: None,
     feature_requirements: &[],
-    kernel_support: KernelSupport::Supported,
+    operation_support: OperationSupport::ALL_ALLOWED,
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 
@@ -480,12 +825,13 @@ static CATALOG_MANAGED_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::ReaderWriter,
     min_legacy_version: None,
     feature_requirements: &[],
-    kernel_support: KernelSupport::Custom(|_, _, op| match op {
-        Operation::Scan | Operation::Write => Ok(()),
-        Operation::Cdf => Err(Error::unsupported(
-            "Feature 'catalogManaged' is not supported for CDF",
-        )),
-    }),
+    operation_support: OperationSupport {
+        read: ReadSupport {
+            cdf: OpSupport::ForbiddenIfSupported(msg::NOT_SUPPORTED_FOR_CDF),
+            ..ReadSupport::ALL_ALLOWED
+        },
+        ..OperationSupport::ALL_ALLOWED
+    },
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 
@@ -493,12 +839,14 @@ static CATALOG_OWNED_PREVIEW_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::ReaderWriter,
     min_legacy_version: None,
     feature_requirements: &[],
-    kernel_support: KernelSupport::Custom(|_, _, op| match op {
-        Operation::Scan | Operation::Write => Ok(()),
-        Operation::Cdf => Err(Error::unsupported(
-            "Feature 'catalogOwned-preview' is not supported for CDF",
-        )),
-    }),
+    operation_support: OperationSupport {
+        read: ReadSupport {
+            cdf: OpSupport::ForbiddenIfSupported(msg::NOT_SUPPORTED_FOR_CDF),
+            ..ReadSupport::ALL_ALLOWED
+        },
+        create: CreateSupport::Forbidden(msg::CATALOG_OWNED_PREVIEW_DEPRECATED_FOR_CREATE),
+        ..OperationSupport::ALL_ALLOWED
+    },
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 
@@ -506,7 +854,7 @@ static COLUMN_MAPPING_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::ReaderWriter,
     min_legacy_version: Some(MinReaderWriterVersion::new(2, 5)),
     feature_requirements: &[],
-    kernel_support: KernelSupport::Supported,
+    operation_support: OperationSupport::ALL_ALLOWED,
     enablement_check: EnablementCheck::EnabledIf(|props| {
         props.column_mapping_mode.is_some()
             && props.column_mapping_mode != Some(ColumnMappingMode::None)
@@ -520,7 +868,7 @@ static DELETION_VECTORS_INFO: FeatureInfo = FeatureInfo {
     // The kernel can read DV-bearing tables and install connector-authored DV descriptors via
     // `Transaction::update_deletion_vectors`, including through the FFI
     // `transaction_update_deletion_vectors` path.
-    kernel_support: KernelSupport::Supported,
+    operation_support: OperationSupport::ALL_ALLOWED,
     enablement_check: EnablementCheck::EnabledIf(|props| {
         props.enable_deletion_vectors == Some(true)
     }),
@@ -530,7 +878,12 @@ static TIMESTAMP_WITHOUT_TIMEZONE_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::ReaderWriter,
     min_legacy_version: None,
     feature_requirements: &[],
-    kernel_support: KernelSupport::Supported,
+    operation_support: OperationSupport {
+        create: CreateSupport::AllowedOnlyViaKernelInference(
+            msg::CREATE_KERNEL_INFERENCE_ONLY_SCHEMA,
+        ),
+        ..OperationSupport::ALL_ALLOWED
+    },
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 
@@ -541,12 +894,12 @@ static TYPE_WIDENING_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::ReaderWriter,
     min_legacy_version: None,
     feature_requirements: &[],
-    kernel_support: KernelSupport::Custom(|_, _, op| match op {
-        Operation::Scan | Operation::Cdf => Ok(()),
-        Operation::Write => Err(Error::unsupported(
-            "Feature 'typeWidening' is not supported for writes",
-        )),
-    }),
+    operation_support: OperationSupport {
+        data_write: DataWriteSupport::all_forbidden_if_supported(msg::NOT_SUPPORTED_FOR_WRITES),
+        ddl: DdlSupport::all_forbidden_if_supported(msg::NOT_SUPPORTED_FOR_WRITES),
+        read: ReadSupport::ALL_ALLOWED,
+        create: CreateSupport::Forbidden(msg::CREATE_FORBIDDEN_KERNEL_CANNOT_WRITE),
+    },
     enablement_check: EnablementCheck::EnabledIf(|props| props.enable_type_widening == Some(true)),
 };
 
@@ -557,12 +910,12 @@ static TYPE_WIDENING_PREVIEW_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::ReaderWriter,
     min_legacy_version: None,
     feature_requirements: &[],
-    kernel_support: KernelSupport::Custom(|_, _, op| match op {
-        Operation::Scan | Operation::Cdf => Ok(()),
-        Operation::Write => Err(Error::unsupported(
-            "Feature 'typeWidening-preview' is not supported for writes",
-        )),
-    }),
+    operation_support: OperationSupport {
+        data_write: DataWriteSupport::all_forbidden_if_supported(msg::NOT_SUPPORTED_FOR_WRITES),
+        ddl: DdlSupport::all_forbidden_if_supported(msg::NOT_SUPPORTED_FOR_WRITES),
+        read: ReadSupport::ALL_ALLOWED,
+        create: CreateSupport::Forbidden(msg::CREATE_FORBIDDEN_KERNEL_CANNOT_WRITE),
+    },
     enablement_check: EnablementCheck::EnabledIf(|props| props.enable_type_widening == Some(true)),
 };
 
@@ -570,7 +923,7 @@ static V2_CHECKPOINT_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::ReaderWriter,
     min_legacy_version: None,
     feature_requirements: &[],
-    kernel_support: KernelSupport::Supported,
+    operation_support: OperationSupport::ALL_ALLOWED,
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 
@@ -578,7 +931,7 @@ static VACUUM_PROTOCOL_CHECK_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::ReaderWriter,
     min_legacy_version: None,
     feature_requirements: &[],
-    kernel_support: KernelSupport::Supported,
+    operation_support: OperationSupport::ALL_ALLOWED,
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 
@@ -586,7 +939,12 @@ static VARIANT_TYPE_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::ReaderWriter,
     min_legacy_version: None,
     feature_requirements: &[],
-    kernel_support: KernelSupport::Supported,
+    operation_support: OperationSupport {
+        create: CreateSupport::AllowedOnlyViaKernelInference(
+            msg::CREATE_KERNEL_INFERENCE_ONLY_SCHEMA,
+        ),
+        ..OperationSupport::ALL_ALLOWED
+    },
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 
@@ -594,7 +952,12 @@ static VARIANT_TYPE_PREVIEW_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::ReaderWriter,
     min_legacy_version: None,
     feature_requirements: &[],
-    kernel_support: KernelSupport::Supported,
+    operation_support: OperationSupport {
+        create: CreateSupport::AllowedOnlyViaKernelInference(
+            msg::CREATE_KERNEL_INFERENCE_ONLY_SCHEMA,
+        ),
+        ..OperationSupport::ALL_ALLOWED
+    },
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 
@@ -602,7 +965,12 @@ static VARIANT_SHREDDING_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::ReaderWriter,
     min_legacy_version: None,
     feature_requirements: &[],
-    kernel_support: KernelSupport::Supported,
+    operation_support: OperationSupport {
+        create: CreateSupport::AllowedOnlyViaKernelInference(
+            msg::CREATE_KERNEL_INFERENCE_ONLY_SCHEMA,
+        ),
+        ..OperationSupport::ALL_ALLOWED
+    },
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 
@@ -610,7 +978,12 @@ static VARIANT_SHREDDING_PREVIEW_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::ReaderWriter,
     min_legacy_version: None,
     feature_requirements: &[],
-    kernel_support: KernelSupport::Supported,
+    operation_support: OperationSupport {
+        create: CreateSupport::AllowedOnlyViaKernelInference(
+            msg::CREATE_KERNEL_INFERENCE_ONLY_SCHEMA,
+        ),
+        ..OperationSupport::ALL_ALLOWED
+    },
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 
@@ -621,7 +994,15 @@ static UNKNOWN_FEATURE_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::Unknown,
     min_legacy_version: None,
     feature_requirements: &[],
-    kernel_support: KernelSupport::NotSupported,
+    operation_support: OperationSupport {
+        read: ReadSupport {
+            scan: OpSupport::ForbiddenIfSupported(msg::NOT_SUPPORTED),
+            cdf: OpSupport::ForbiddenIfSupported(msg::NOT_SUPPORTED),
+        },
+        data_write: DataWriteSupport::all_forbidden_if_supported(msg::NOT_SUPPORTED),
+        ddl: DdlSupport::all_forbidden_if_supported(msg::NOT_SUPPORTED),
+        create: CreateSupport::Forbidden(msg::CREATE_FORBIDDEN),
+    },
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 
@@ -677,7 +1058,7 @@ impl TableFeature {
     }
 
     /// Returns rich metadata about this table feature including protocol version requirements,
-    /// dependencies, and kernel support status.
+    /// dependencies, and per-operation support matrix.
     pub(crate) fn info(&self) -> &FeatureInfo {
         match self {
             // Writer-only features

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -24,6 +24,7 @@
 //! snapshot.alter_table().build(engine, committer)?;  // compile error
 //! ```
 
+use std::collections::HashSet;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
@@ -32,13 +33,13 @@ use crate::expressions::ColumnName;
 use crate::schema::StructField;
 use crate::snapshot::SnapshotRef;
 use crate::table_configuration::TableConfiguration;
-use crate::table_features::{Operation, TableFeature};
+use crate::table_features::{DdlOp, Operation};
 use crate::table_properties::COLUMN_MAPPING_MAX_COLUMN_ID;
 use crate::transaction::alter_table::AlterTableTransaction;
 use crate::transaction::schema_evolution::{
     apply_schema_operations, SchemaEvolutionResult, SchemaOperation,
 };
-use crate::{DeltaResult, Engine, Error};
+use crate::{DeltaResult, Engine};
 
 /// Initial state: `build()` is not yet available (at least one operation is required).
 /// See [`Chainable`] for the operations available on this state.
@@ -133,7 +134,9 @@ impl AlterTableTransactionBuilder<Modifying> {
     /// Validate and apply schema operations, then build the [`AlterTableTransaction`].
     ///
     /// This method:
-    /// 1. Validates the table supports writes
+    /// 1. Gates each queued schema operation (e.g. add-column, set-nullable) against the table's
+    ///    writer features and the matching per-DDL-op cell of each feature's `OperationSupport`
+    ///    matrix.
     /// 2. Applies each operation sequentially against the evolving schema
     /// 3. Constructs new Metadata action with evolved schema
     /// 4. Builds the evolved table configuration
@@ -142,7 +145,7 @@ impl AlterTableTransactionBuilder<Modifying> {
     /// # Errors
     ///
     /// - Any individual operation fails validation (see per-method errors above)
-    /// - Table does not support writes (unsupported features)
+    /// - A queued DDL op is blocked by an enabled writer feature (e.g. `icebergCompatV3`)
     /// - The evolved schema requires protocol features not enabled on the table (e.g. adding a
     ///   `timestampNtz` column without the `timestampNtz` feature)
     pub fn build(
@@ -151,18 +154,24 @@ impl AlterTableTransactionBuilder<Modifying> {
         committer: Box<dyn Committer>,
     ) -> DeltaResult<AlterTableTransaction> {
         let table_config = self.snapshot.table_configuration();
-        // We don't support ALTER TABLE on tables with icebergCompatV3 enabled yet. See
-        // [`crate::table_features::ICEBERG_COMPAT_V3_INFO`] for the tracking issue.
-        if table_config.is_feature_enabled(&TableFeature::IcebergCompatV3) {
-            return Err(Error::unsupported(
-                "ALTER TABLE is not yet supported on tables with icebergCompatV3 enabled",
-            ));
-        }
-        // Rejects writes to tables kernel can't safely commit to: writer version out of
-        // kernel's supported range, unsupported writer features, or schemas with SQL-expression
+        // Rejects DDLs to tables kernel can't safely modify: writer version out of kernel's
+        // supported range, unsupported writer features, or schemas with SQL-expression
         // invariants. Runs on the pre-alter snapshot; future ALTER variants that change the
         // protocol must also re-check this on the evolved `TableConfiguration`.
-        table_config.ensure_operation_supported(Operation::Write)?;
+        //
+        // Gate every queued schema operation. Today AddColumn and SetNullable share matrix
+        // cells on every feature, but future per-DDL-op divergence (e.g. when DropColumn
+        // lands) must not be silently skipped.
+        let mut seen_ddl_ops = HashSet::new();
+        for op in &self.operations {
+            let ddl_op = match op {
+                SchemaOperation::AddColumn { .. } => DdlOp::AddColumn,
+                SchemaOperation::SetNullable { .. } => DdlOp::SetNullable,
+            };
+            if seen_ddl_ops.insert(ddl_op) {
+                table_config.ensure_operation_supported(Operation::Ddl(ddl_op))?;
+            }
+        }
 
         let schema = Arc::unwrap_or_clone(table_config.logical_schema());
         let column_mapping_mode = table_config.column_mapping_mode();

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -10,6 +10,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use itertools::Itertools;
+use strum::IntoEnumIterator as _;
 use url::Url;
 use uuid::Uuid;
 
@@ -27,8 +28,8 @@ use crate::table_configuration::TableConfiguration;
 use crate::table_features::{
     assign_column_mapping_metadata, find_max_column_id_in_schema,
     get_any_level_column_physical_name, get_column_mapping_mode_from_properties,
-    schema_contains_timestamp_ntz, ColumnMappingMode, EnablementCheck, FeatureType, TableFeature,
-    SET_TABLE_FEATURE_SUPPORTED_PREFIX, SET_TABLE_FEATURE_SUPPORTED_VALUE,
+    schema_contains_timestamp_ntz, ColumnMappingMode, CreatePath, EnablementCheck, FeatureType,
+    TableFeature, SET_TABLE_FEATURE_SUPPORTED_PREFIX, SET_TABLE_FEATURE_SUPPORTED_VALUE,
 };
 use crate::table_properties::{
     TableProperties, APPEND_ONLY, CHECKPOINT_WRITE_STATS_AS_JSON, CHECKPOINT_WRITE_STATS_AS_STRUCT,
@@ -44,49 +45,6 @@ use crate::transaction::data_layout::DataLayout;
 use crate::transaction::Transaction;
 use crate::utils::{current_time_ms, try_parse_uri};
 use crate::{DeltaResult, Engine, Error, StorageHandler};
-
-/// Table features allowed to be enabled via `delta.feature.*=supported` during CREATE TABLE.
-///
-/// Feature signals (`delta.feature.X=supported`) are validated against this list.
-/// Only features in this list can be enabled via feature signals.
-const ALLOWED_DELTA_FEATURES: &[TableFeature] = &[
-    // DomainMetadata is required for clustering and other system domain operations
-    TableFeature::DomainMetadata,
-    // ColumnMapping enables column mapping (name/id mode)
-    TableFeature::ColumnMapping,
-    // InCommitTimestamp enables in-commit timestamps (writer-only)
-    TableFeature::InCommitTimestamp,
-    // VacuumProtocolCheck ensures consistent protocol checks during VACUUM
-    TableFeature::VacuumProtocolCheck,
-    // CatalogManaged enables catalog-managed table support
-    TableFeature::CatalogManaged,
-    // Note: Clustering is NOT included here. Users should not enable clustering via
-    // `delta.feature.clustering = supported`. Instead, clustering is enabled by
-    // specifying clustering columns via `with_data_layout()`.
-    TableFeature::DeletionVectors,
-    TableFeature::V2Checkpoint,
-    // Simple protocol-only features: enabling these only updates the protocol action.
-    // They can also be auto-enabled via their enablement properties (e.g. delta.appendOnly=true)
-    // through `maybe_auto_enable_property_driven_features`.
-    TableFeature::AppendOnly,
-    TableFeature::ChangeDataFeed,
-    TableFeature::TypeWidening,
-    TableFeature::RowTracking,
-    // Invariants is auto-enabled by `maybe_enable_invariants` when the schema has non-null
-    // fields. Allowing explicit `delta.feature.invariants=supported` lets users pre-enable
-    // the feature on an all-nullable table so a later ALTER TABLE ADD COLUMN NOT NULL does
-    // not need a protocol upgrade.
-    TableFeature::Invariants,
-    // MaterializePartitionColumns keeps partition columns in the data files instead of
-    // dropping them on write. There is no `delta.*` enablement property; the only opt-in at
-    // create time is the explicit feature signal
-    // `delta.feature.materializePartitionColumns=supported`.
-    TableFeature::MaterializePartitionColumns,
-    // IcebergCompatV3 is a writer-only feature that gates Iceberg V3 conversion compatibility.
-    // Dependent features (ColumnMapping, RowTracking, DomainMetadata) are auto-added during
-    // create table.
-    TableFeature::IcebergCompatV3,
-];
 
 /// Delta properties allowed to be set during CREATE TABLE.
 ///
@@ -176,6 +134,13 @@ struct ValidatedTableProperties {
     reader_features: Vec<TableFeature>,
     /// Writer features extracted from feature signals (for all features)
     writer_features: Vec<TableFeature>,
+    /// Features the user explicitly opted into. Includes:
+    ///   - Each `delta.feature.X=supported` signal.
+    ///   - Each feature whose property the user set and which therefore auto-enables (e.g.
+    ///     `delta.enableRowTracking=true` opts the user into `rowTracking`).
+    ///
+    /// Schema-driven, layout-driven, and dependency-cascade additions are NOT included.
+    user_opt_in: HashSet<TableFeature>,
 }
 
 impl ValidatedTableProperties {
@@ -427,28 +392,45 @@ fn maybe_enable_invariants(schema: &SchemaRef, validated: &mut ValidatedTablePro
     }
 }
 
-/// Auto-enables allowed features whose [`EnablementCheck::EnabledIf`] check is satisfied by the
-/// table properties. Features with [`EnablementCheck::AlwaysIfSupported`] are skipped since they
-/// don't require property-driven enablement.
-fn maybe_auto_enable_property_driven_features(validated: &mut ValidatedTableProperties) {
-    let table_properties = TableProperties::from(validated.properties.iter());
-    for feature in ALLOWED_DELTA_FEATURES {
-        if let EnablementCheck::EnabledIf(check) = feature.info().enablement_check {
-            if check(&table_properties) {
-                add_feature_to_lists(
-                    feature.clone(),
-                    &mut validated.reader_features,
-                    &mut validated.writer_features,
-                );
-                // RowTracking requires DomainMetadata as a dependency
-                if *feature == TableFeature::RowTracking {
-                    add_feature_to_lists(
-                        TableFeature::DomainMetadata,
-                        &mut validated.reader_features,
-                        &mut validated.writer_features,
-                    );
-                }
-            }
+/// Auto-enables features whose [`EnablementCheck::EnabledIf`] check is satisfied by the
+/// table properties (e.g. `delta.enableRowTracking=true` auto-enables `rowTracking`).
+/// Features with [`EnablementCheck::AlwaysIfSupported`] are skipped: they have no
+/// property-driven enablement story.
+///
+/// A feature is recorded in `user_opt_in` only when its enablement-check is satisfied by the
+/// `user_provided_properties` snapshot. If the check passes against the current properties
+/// but NOT against the user snapshot, the feature was added by an earlier kernel-driven
+/// dependency cascade (e.g. `delta.enableIcebergCompatV3=true` setting `enableRowTracking`)
+/// and is therefore kernel inference, not user opt-in.
+fn maybe_auto_enable_property_driven_features(
+    validated: &mut ValidatedTableProperties,
+    user_provided_properties: &HashMap<String, String>,
+) {
+    let current_properties = TableProperties::from(validated.properties.iter());
+    let user_properties = TableProperties::from(user_provided_properties.iter());
+    for feature in TableFeature::iter() {
+        let EnablementCheck::EnabledIf(check) = feature.info().enablement_check else {
+            continue;
+        };
+        if !check(&current_properties) {
+            continue;
+        }
+        if check(&user_properties) {
+            validated.user_opt_in.insert(feature.clone());
+        }
+        let needs_domain_metadata = feature == TableFeature::RowTracking;
+        add_feature_to_lists(
+            feature,
+            &mut validated.reader_features,
+            &mut validated.writer_features,
+        );
+        // RowTracking requires DomainMetadata; the dependency is always kernel inference.
+        if needs_domain_metadata {
+            add_feature_to_lists(
+                TableFeature::DomainMetadata,
+                &mut validated.reader_features,
+                &mut validated.writer_features,
+            );
         }
     }
 }
@@ -664,10 +646,12 @@ fn maybe_apply_column_mapping_for_table_create(
 /// Validates and transforms table properties for CREATE TABLE.
 ///
 /// This function:
-/// 1. Validates feature signals (`delta.feature.*`) against `ALLOWED_DELTA_FEATURES`
+/// 1. Records each `delta.feature.X=supported` signal into `user_opt_in`; per-feature
+///    rejection happens later in `CreateTableTransactionBuilder::build` via
+///    [`TableConfiguration::ensure_create_supported`](crate::table_configuration::TableConfiguration::ensure_create_supported).
 /// 2. Validates delta properties (`delta.*`) against `ALLOWED_DELTA_PROPERTIES`
 /// 3. Removes feature signals from properties (they shouldn't be stored in metadata)
-/// 4. Extracts reader/writer features from validated feature signals
+/// 4. Extracts reader/writer features from feature signals
 ///
 /// Non-delta properties (user/application properties) are always allowed.
 ///
@@ -681,6 +665,7 @@ fn validate_extract_table_features_and_properties(
 ) -> DeltaResult<ValidatedTableProperties> {
     let mut reader_features = Vec::new();
     let mut writer_features = Vec::new();
+    let mut user_opt_in = HashSet::new();
 
     // Partition properties into feature signals and regular properties
     // Feature signals (delta.feature.X=supported) are processed but not stored in metadata
@@ -689,7 +674,9 @@ fn validate_extract_table_features_and_properties(
         .into_iter()
         .partition(|(k, _)| k.starts_with(SET_TABLE_FEATURE_SUPPORTED_PREFIX));
 
-    // Process and validate feature signals
+    // Process and validate feature signals. We accept each signal here; the actual policy
+    // check against `CreateSupport` runs once the full set of features is known, after all
+    // auto-enable passes, in `CreateTableTransactionBuilder::build`.
     for (key, value) in &feature_signals {
         // Safe: we partitioned for keys starting with this prefix above
         let Some(feature_name) = key.strip_prefix(SET_TABLE_FEATURE_SUPPORTED_PREFIX) else {
@@ -708,16 +695,15 @@ fn validate_extract_table_features_and_properties(
             .parse()
             .unwrap_or_else(|_| TableFeature::Unknown(feature_name.to_string()));
 
-        if !ALLOWED_DELTA_FEATURES.contains(&feature) {
-            return Err(Error::generic(format!(
-                "Enabling feature '{feature_name}' via '{key}' is not supported during CREATE TABLE"
-            )));
-        }
+        // Record that the user explicitly opted in to this feature.
+        user_opt_in.insert(feature.clone());
 
         // Add to appropriate feature lists based on feature type
         let needs_domain_metadata = feature == TableFeature::RowTracking;
         add_feature_to_lists(feature, &mut reader_features, &mut writer_features);
-        // RowTracking requires DomainMetadata as a dependency
+        // RowTracking requires DomainMetadata as a dependency. DomainMetadata is not the
+        // user's opt-in here -- it's an inferred dependency, so we don't add it to
+        // `user_opt_in`.
         if needs_domain_metadata {
             add_feature_to_lists(
                 TableFeature::DomainMetadata,
@@ -742,6 +728,7 @@ fn validate_extract_table_features_and_properties(
         properties,
         reader_features,
         writer_features,
+        user_opt_in,
     })
 }
 
@@ -778,8 +765,12 @@ impl CreateTableTransactionBuilder {
     ///
     /// Custom application properties (those not starting with `delta.`) are always allowed.
     /// Delta properties (`delta.*`) are validated against an allow list during [`build()`].
-    /// Feature flags (`delta.feature.*=supported`) are supported for the subset of features
-    /// listed in `ALLOWED_DELTA_FEATURES`.
+    /// Feature flags (`delta.feature.*=supported`) are recorded as user opt-in and gated
+    /// per feature in [`build()`] via each feature's `CreateSupport` cell. Some features
+    /// cannot be enabled at create time at all (e.g. `typeWidening`, `checkConstraints`,
+    /// `generatedColumns`, `identityColumns`, `icebergCompatV1`, `icebergCompatV2`); others
+    /// must be enabled by kernel inference only (e.g. `clustering` via `with_data_layout`,
+    /// `timestampNtz` / `variantType` via the schema column type).
     ///
     /// This method can be called multiple times. If a property key already exists from a
     /// previous call, the new value will overwrite the old one.
@@ -909,6 +900,13 @@ impl CreateTableTransactionBuilder {
         // - Returns reader/writer features to add to protocol
         let mut validated = validate_extract_table_features_and_properties(self.table_properties)?;
 
+        // Snapshot the user-provided properties before any kernel-driven cascade mutates them.
+        // The property-driven auto-enable pass below uses this snapshot to distinguish user
+        // opt-in from kernel inference: a feature whose enablement-check passes against the
+        // *current* (post-cascade) properties but NOT against the *user-provided* snapshot was
+        // added by the kernel, not the user.
+        let user_provided_properties = validated.properties.clone();
+
         // When IcebergCompatV3 is enabled, fill in / validate required dependencies before
         // column mapping is applied so the CM mode is in place. The returned witness is
         // required by `maybe_apply_column_mapping_for_table_create` below.
@@ -936,8 +934,9 @@ impl CreateTableTransactionBuilder {
         maybe_enable_timestamp_ntz(&effective_schema, &mut validated);
         maybe_enable_invariants(&effective_schema, &mut validated);
 
-        // Property-driven auto-enablement: check enablement properties
-        maybe_auto_enable_property_driven_features(&mut validated);
+        // Property-driven auto-enablement: check enablement properties. The snapshot lets
+        // the pass distinguish "user opt-in" from "kernel inference via dependency cascade".
+        maybe_auto_enable_property_driven_features(&mut validated, &user_provided_properties);
 
         // Auto-enable inCommitTimestamp for catalogManaged tables
         maybe_enable_ict_for_catalog_managed(&mut validated)?;
@@ -968,6 +967,17 @@ impl CreateTableTransactionBuilder {
 
         // Build TableConfiguration directly for the new table
         let table_configuration = TableConfiguration::try_new(metadata, protocol, table_url, 0)?;
+
+        // Validate every feature that landed in the protocol against its `CreateSupport`
+        // cell using the path it took (user opt-in vs kernel inference).
+        for feature in table_configuration.all_supported_features() {
+            let path = if validated.user_opt_in.contains(&feature) {
+                CreatePath::UserOptIn
+            } else {
+                CreatePath::KernelInference
+            };
+            table_configuration.ensure_create_supported(&feature, path)?;
+        }
 
         // Create Transaction<CreateTable> with the effective table configuration
         Transaction::try_new_create_table(
@@ -1106,7 +1116,8 @@ mod tests {
 
     #[test]
     fn test_validate_unsupported_properties() {
-        // Delta properties not on allow list are rejected
+        // Property whitelist: delta.* properties not in `ALLOWED_DELTA_PROPERTIES` are rejected
+        // at parse time, before any feature-level validation.
         let mut properties = HashMap::new();
         properties.insert(ENABLE_ICEBERG_COMPAT_V1.to_string(), "true".to_string());
         assert_result_error_with_message(
@@ -1114,27 +1125,29 @@ mod tests {
             "Setting delta property 'delta.enableIcebergCompatV1' is not supported",
         );
 
-        // Feature signals for features not in ALLOWED_DELTA_FEATURES are rejected
+        // Feature signals are accepted by the property extractor (the per-feature
+        // `CreateSupport::Forbidden` gate runs later, in `build()` via
+        // `ensure_create_supported`). The extractor records the signaled feature in
+        // `user_opt_in` and leaves rejection to the gate.
         let properties = HashMap::from([(
             "delta.feature.identityColumns".to_string(),
             "supported".to_string(),
         )]);
-        assert_result_error_with_message(
-            validate_extract_table_features_and_properties(properties),
-            "Enabling feature 'identityColumns' via 'delta.feature.identityColumns' is not supported",
-        );
+        let validated = validate_extract_table_features_and_properties(properties).unwrap();
+        assert!(validated
+            .user_opt_in
+            .contains(&TableFeature::IdentityColumns));
 
-        // Clustering feature signal is rejected - users must use with_clustering_columns() instead
         let properties = HashMap::from([(
             "delta.feature.clustering".to_string(),
             "supported".to_string(),
         )]);
-        assert_result_error_with_message(
-            validate_extract_table_features_and_properties(properties),
-            "Enabling feature 'clustering' via 'delta.feature.clustering' is not supported",
-        );
+        let validated = validate_extract_table_features_and_properties(properties).unwrap();
+        assert!(validated
+            .user_opt_in
+            .contains(&TableFeature::ClusteredTable));
 
-        // Mixed properties with unsupported delta property are rejected
+        // Mixed properties with unsupported delta property are still rejected at parse time.
         let mut properties = HashMap::new();
         properties.insert("myapp.version".to_string(), "1.0".to_string());
         properties.insert(ENABLE_ICEBERG_COMPAT_V1.to_string(), "true".to_string());
@@ -1142,6 +1155,46 @@ mod tests {
             validate_extract_table_features_and_properties(properties),
             "Setting delta property 'delta.enableIcebergCompatV1' is not supported",
         );
+    }
+
+    /// IcebergCompatV3's dependency cascade auto-adds `delta.enableRowTracking=true` and
+    /// `delta.columnMapping.mode=name` into the property map. The downstream
+    /// `maybe_auto_enable_property_driven_features` pass would otherwise see those
+    /// properties and incorrectly mark RowTracking/ColumnMapping as user opt-in. The fix
+    /// is the `user_provided_properties` snapshot: the property-driven pass evaluates
+    /// each enablement check against both the current and the user-snapshot properties,
+    /// and only marks user_opt_in when the user-snapshot answer is `true`.
+    ///
+    /// Today every `CreateSupport` cell for the cascaded features is `Allowed`, so a
+    /// misclassification has no externally visible effect. This test pins the invariant
+    /// so any future tightening (e.g. `RowTracking.create =
+    /// AllowedOnlyViaKernelInference(...)`) does not silently break V3 creation.
+    #[test]
+    fn test_v3_cascade_does_not_mark_deps_as_user_opt_in() {
+        let mut properties = HashMap::new();
+        properties.insert(ENABLE_ICEBERG_COMPAT_V3.to_string(), "true".to_string());
+        let mut validated = validate_extract_table_features_and_properties(properties).unwrap();
+
+        let user_snapshot = validated.properties.clone();
+        let _ = maybe_enable_iceberg_compat_v3_dependencies(&mut validated).unwrap();
+        maybe_auto_enable_property_driven_features(&mut validated, &user_snapshot);
+
+        assert!(
+            validated
+                .user_opt_in
+                .contains(&TableFeature::IcebergCompatV3),
+            "V3 was user-opted-in; should remain in user_opt_in",
+        );
+        for feature in [
+            TableFeature::ColumnMapping,
+            TableFeature::RowTracking,
+            TableFeature::DomainMetadata,
+        ] {
+            assert!(
+                !validated.user_opt_in.contains(&feature),
+                "{feature:?} was kernel-inferred via V3 cascade and must NOT be in user_opt_in",
+            );
+        }
     }
 
     #[test]
@@ -1338,6 +1391,7 @@ mod tests {
             properties: HashMap::new(),
             reader_features: vec![],
             writer_features: vec![],
+            user_opt_in: HashSet::new(),
         };
 
         maybe_enable_variant_type(&schema, &mut validated);
@@ -1406,6 +1460,7 @@ mod tests {
             properties: HashMap::new(),
             reader_features: vec![],
             writer_features: vec![],
+            user_opt_in: HashSet::new(),
         };
 
         maybe_enable_invariants(&schema, &mut validated);
@@ -1439,7 +1494,8 @@ mod tests {
             .collect();
         let mut validated = validate_extract_table_features_and_properties(properties).unwrap();
 
-        maybe_auto_enable_property_driven_features(&mut validated);
+        let snapshot = validated.properties.clone();
+        maybe_auto_enable_property_driven_features(&mut validated, &snapshot);
 
         assert_eq!(
             validated
@@ -1547,6 +1603,7 @@ mod tests {
             properties: HashMap::new(),
             reader_features: vec![],
             writer_features: vec![],
+            user_opt_in: HashSet::new(),
         };
 
         let result = apply_data_layout(
@@ -1593,6 +1650,7 @@ mod tests {
             properties: HashMap::new(),
             reader_features: vec![],
             writer_features: vec![],
+            user_opt_in: HashSet::new(),
         };
 
         let result = apply_data_layout(&layout, &schema, ColumnMappingMode::None, &mut validated);
@@ -1680,7 +1738,8 @@ mod tests {
             "supported".to_string(),
         )]);
         let mut validated = validate_extract_table_features_and_properties(properties).unwrap();
-        maybe_auto_enable_property_driven_features(&mut validated);
+        let snapshot = validated.properties.clone();
+        maybe_auto_enable_property_driven_features(&mut validated, &snapshot);
         maybe_enable_ict_for_catalog_managed(&mut validated).unwrap();
 
         assert!(
@@ -1709,7 +1768,8 @@ mod tests {
             ),
         ]);
         let mut validated = validate_extract_table_features_and_properties(properties).unwrap();
-        maybe_auto_enable_property_driven_features(&mut validated);
+        let snapshot = validated.properties.clone();
+        maybe_auto_enable_property_driven_features(&mut validated, &snapshot);
         maybe_enable_ict_for_catalog_managed(&mut validated).unwrap();
 
         assert!(validated
@@ -1738,7 +1798,8 @@ mod tests {
         #[case] expect_enablement_property: bool,
     ) {
         let mut validated = validate_extract_table_features_and_properties(properties).unwrap();
-        maybe_auto_enable_property_driven_features(&mut validated);
+        let snapshot = validated.properties.clone();
+        maybe_auto_enable_property_driven_features(&mut validated, &snapshot);
 
         assert!(
             validated
@@ -1772,7 +1833,8 @@ mod tests {
             ),
         ]);
         let mut validated = validate_extract_table_features_and_properties(properties).unwrap();
-        maybe_auto_enable_property_driven_features(&mut validated);
+        let snapshot = validated.properties.clone();
+        maybe_auto_enable_property_driven_features(&mut validated, &snapshot);
         let err = maybe_enable_ict_for_catalog_managed(&mut validated).unwrap_err();
         assert!(
             err.to_string().contains("enableInCommitTimestamps"),
@@ -1931,7 +1993,8 @@ mod tests {
 
         // === Property-driven feature enablement + Invariants ===
         maybe_enable_invariants(&effective_schema, &mut validated);
-        maybe_auto_enable_property_driven_features(&mut validated);
+        let snapshot = validated.properties.clone();
+        maybe_auto_enable_property_driven_features(&mut validated, &snapshot);
 
         for f in expected_features {
             assert!(
@@ -1989,6 +2052,7 @@ mod tests {
             properties,
             reader_features: Vec::new(),
             writer_features: Vec::new(),
+            user_opt_in: HashSet::new(),
         };
         let err = maybe_enable_iceberg_compat_v3_dependencies(&mut validated).unwrap_err();
         assert!(

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -34,7 +34,7 @@ use crate::scan::scan_row_schema;
 use crate::schema::{ArrayType, MapType, SchemaRef, StructField, StructType, StructTypeBuilder};
 use crate::snapshot::{Snapshot, SnapshotRef};
 use crate::table_configuration::TableConfiguration;
-use crate::table_features::TableFeature;
+use crate::table_features::{DataWriteOp, Operation, TableFeature};
 use crate::utils::require;
 use crate::{
     DataType, DeltaResult, Engine, EngineData, Expression, FileMeta, IntoEngineData, RowVisitor,
@@ -348,12 +348,6 @@ impl<S> Transaction<S> {
             num_dv_updates = self.dv_matched_files.len(),
         );
 
-        // Some table features don't yet support removeFiles. Reject here.
-        if !self.remove_files_metadata.is_empty() {
-            self.effective_table_config
-                .validate_feature_support_for_remove()?;
-        }
-
         // Step 1: Check for duplicate app_ids and generate set transactions (`txn`)
         // Note: The commit info must always be the first action in the commit but we generate it in
         // step 2 to fail early on duplicate transaction appIds
@@ -374,29 +368,11 @@ impl<S> Transaction<S> {
         self.validate_blind_append_semantics()?;
         self.ensure_schema_non_empty_for_data_writes()?;
 
-        // CDF check only applies to existing tables (not create table)
-        // If there are add and remove files with data change in the same transaction, we block it.
-        // This is because kernel does not yet have a way to discern DML operations. For DML
-        // operations that perform updates on rows, ChangeDataFeed requires that a `cdc` file be
-        // written to the delta log.
-        if !self.is_create_table()
-            && !self.add_files_metadata.is_empty()
-            && !self.remove_files_metadata.is_empty()
-            && self.data_change
-        {
-            let cdf_enabled = self
-                .effective_table_config
-                .table_properties()
-                .enable_change_data_feed
-                .unwrap_or(false);
-            require!(
-                !cdf_enabled,
-                Error::generic(
-                    "Cannot add and remove data in the same transaction when Change Data Feed is enabled (delta.enableChangeDataFeed = true). \
-                     This would require writing CDC files for DML operations, which is not yet supported. \
-                     Consider using separate transactions: one to add files, another to remove files."
-                )
-            );
+        // CREATE TABLE handles its own gating via
+        // `TableConfiguration::ensure_create_supported` in `CreateTableTransactionBuilder::build`.
+        if !self.is_create_table() {
+            self.effective_table_config
+                .ensure_operation_supported(Operation::DataWrite(self.classify_data_write_op()))?;
         }
 
         // Validate clustering column stats if ClusteredTable feature is enabled
@@ -740,6 +716,36 @@ impl<S> Transaction<S> {
             "CREATE TABLE operation should not have a read snapshot"
         );
         self.read_snapshot_opt.is_none()
+    }
+
+    /// Classifies this transaction as one of [`DataWriteOp::Append`], [`DataWriteOp::Dml`], or
+    /// [`DataWriteOp::Maintenance`] based on the staged file actions and the `data_change` flag.
+    ///
+    /// Three reachable buckets:
+    /// - `Append`: pure add-only commits, or commits with no file actions at all (e.g.
+    ///   `SetTransaction`-only or `DomainMetadata`-only). These have no remove-shaped or
+    ///   data-changing effect, so feature gates that care about remove preservation or row-data
+    ///   stability are not relevant.
+    /// - `Dml`: any commit that stages explicit remove file actions with `data_change=true`. Covers
+    ///   DELETE, UPDATE, MERGE.
+    /// - `Maintenance`: any commit that stages explicit remove file actions with
+    ///   `data_change=false`. Covers OPTIMIZE / ZORDER compaction, stats updates that rewrite add
+    ///   files, row-id / row-commit-version backfill, and any other data-preserving file rewrite.
+    ///
+    /// **DV-only updates are intentionally classified as `Append`** even though they produce
+    /// remove+add action pairs at commit time. The DV-update path (`update_deletion_vectors`)
+    /// preserves `baseRowId` and `defaultRowCommitVersion` on the new add by construction,
+    /// so it is safe under row tracking. CDF correctness for DV updates is a separate gap
+    /// kernel does not currently address (#TODO); the matrix does not block this path.
+    fn classify_data_write_op(&self) -> DataWriteOp {
+        let has_adds = !self.add_files_metadata.is_empty();
+        let has_removes = !self.remove_files_metadata.is_empty();
+        match (has_adds || has_removes, has_removes, self.data_change) {
+            (false, _, _) => DataWriteOp::Append, // no file actions (or DV-only)
+            (true, false, _) => DataWriteOp::Append, // add-only, data_change irrelevant
+            (true, true, true) => DataWriteOp::Dml, // UPDATE / DELETE / MERGE
+            (true, true, false) => DataWriteOp::Maintenance, // OPTIMIZE-shape
+        }
     }
 
     /// True iff this transaction stages any data-file action (add, remove, or DV update).
@@ -2297,6 +2303,53 @@ mod tests {
         txn.dv_matched_files.push(dv_data);
         let result = txn.validate_blind_append_semantics();
         assert!(matches!(result, Err(Error::InvalidTransactionState(_))));
+        Ok(())
+    }
+
+    /// `classify_data_write_op` truth table. The classifier is the source of truth for
+    /// which gating cell fires on `Transaction::commit`, so the eight reachable input
+    /// shapes deserve direct coverage independent of any feature-level gate.
+    #[rstest]
+    // No file actions: metadata-only commit, classifies as Append.
+    #[case::no_actions_dc(false, false, false, true, DataWriteOp::Append)]
+    #[case::no_actions_no_dc(false, false, false, false, DataWriteOp::Append)]
+    // Adds only: classifies as Append (data_change irrelevant for gating).
+    #[case::adds_only_dc(true, false, false, true, DataWriteOp::Append)]
+    #[case::adds_only_no_dc(true, false, false, false, DataWriteOp::Append)]
+    // Removes (or DV updates) staged: Dml when data_change=true, Maintenance otherwise.
+    #[case::removes_dc(false, true, false, true, DataWriteOp::Dml)]
+    #[case::removes_no_dc(false, true, false, false, DataWriteOp::Maintenance)]
+    #[case::adds_and_removes_dc(true, true, false, true, DataWriteOp::Dml)]
+    #[case::adds_and_removes_no_dc(true, true, false, false, DataWriteOp::Maintenance)]
+    // DV updates are intentionally classified as Append; see `classify_data_write_op` doc.
+    #[case::dv_only_dc(false, false, true, true, DataWriteOp::Append)]
+    #[case::dv_only_no_dc(false, false, true, false, DataWriteOp::Append)]
+    #[case::adds_and_dv_dc(true, false, true, true, DataWriteOp::Append)]
+    fn test_classify_data_write_op(
+        #[case] has_adds: bool,
+        #[case] has_removes: bool,
+        #[case] has_dv_updates: bool,
+        #[case] data_change: bool,
+        #[case] expected: DataWriteOp,
+    ) -> DeltaResult<()> {
+        let (_engine, mut txn, _tempdir) = create_existing_table_txn()?;
+        txn.set_data_change(data_change);
+        if has_adds {
+            add_dummy_file(&mut txn);
+        }
+        if has_removes {
+            let remove_data = FilteredEngineData::with_all_rows_selected(
+                string_array_to_engine_data(StringArray::from(vec!["remove"])),
+            );
+            txn.remove_files(remove_data);
+        }
+        if has_dv_updates {
+            let dv_data = FilteredEngineData::with_all_rows_selected(string_array_to_engine_data(
+                StringArray::from(vec!["dv"]),
+            ));
+            txn.dv_matched_files.push(dv_data);
+        }
+        assert_eq!(txn.classify_data_write_op(), expected);
         Ok(())
     }
 

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -30,7 +30,7 @@ use crate::scan::log_replay::get_scan_metadata_transform_expr;
 use crate::scan::{restored_add_schema, scan_row_schema};
 use crate::schema::{ArrayType, SchemaRef, StructField, StructType, ToSchema};
 use crate::snapshot::SnapshotRef;
-use crate::table_features::{Operation, TableFeature};
+use crate::table_features::{DataWriteOp, Operation, TableFeature};
 use crate::utils::current_time_ms;
 use crate::{DataType, DeltaResult, Engine, Expression};
 
@@ -55,10 +55,11 @@ impl Transaction {
     ) -> DeltaResult<Self> {
         let read_snapshot = snapshot.into();
 
-        // important! before writing to the table we must check it is supported
+        // Fail fast on writer features that block any data write. The commit-time op-specific
+        // re-check happens in `commit()` once the op shape is known.
         read_snapshot
             .table_configuration()
-            .ensure_operation_supported(Operation::Write)?;
+            .ensure_operation_supported(Operation::DataWrite(DataWriteOp::Append))?;
 
         // Read clustering columns from snapshot (returns None if clustering not enabled)
         let clustering_columns = read_snapshot.get_physical_clustering_columns(engine)?;

--- a/kernel/tests/integration/create_table/mod.rs
+++ b/kernel/tests/integration/create_table/mod.rs
@@ -534,7 +534,8 @@ async fn test_create_table_txn_debug() -> DeltaResult<()> {
 #[case("v2Checkpoint", TableFeature::V2Checkpoint, true, true)]
 // ReaderWriter features (EnabledIf -- feature signal alone does not enable)
 #[case("deletionVectors", TableFeature::DeletionVectors, true, false)]
-#[case("typeWidening", TableFeature::TypeWidening, true, false)]
+// `typeWidening` cannot be enabled at create time (kernel cannot write to such tables);
+// see `test_create_table_rejects_unsupported_feature_signals` for the rejection assertion.
 // WriterOnly features (EnabledIf -- feature signal alone does not enable)
 #[case("appendOnly", TableFeature::AppendOnly, false, false)]
 #[case("changeDataFeed", TableFeature::ChangeDataFeed, false, false)]
@@ -591,6 +592,106 @@ fn test_create_table_with_feature_signal(
     Ok(())
 }
 
+/// Kernel cannot write to tables with certain features (`typeWidening`, `checkConstraints`,
+/// `generatedColumns`, `identityColumns`, `icebergCompatV1`, `icebergCompatV2`,
+/// `catalogOwned-preview`). Accepting the corresponding `delta.feature.*=supported` signal at
+/// create time would produce an immediately-unwritable table; the signal is rejected up front.
+#[rstest]
+#[case::feature_signal_type_widening(
+    "delta.feature.typeWidening",
+    "supported",
+    "cannot be enabled at table create time"
+)]
+#[case::feature_signal_type_widening_preview(
+    "delta.feature.typeWidening-preview",
+    "supported",
+    "cannot be enabled at table create time"
+)]
+#[case::feature_signal_check_constraints(
+    "delta.feature.checkConstraints",
+    "supported",
+    "cannot be enabled at table create time"
+)]
+#[case::feature_signal_generated_columns(
+    "delta.feature.generatedColumns",
+    "supported",
+    "cannot be enabled at table create time"
+)]
+#[case::feature_signal_identity_columns(
+    "delta.feature.identityColumns",
+    "supported",
+    "cannot be enabled at table create time"
+)]
+#[case::feature_signal_iceberg_compat_v1(
+    "delta.feature.icebergCompatV1",
+    "supported",
+    "cannot be enabled at table create time"
+)]
+#[case::feature_signal_iceberg_compat_v2(
+    "delta.feature.icebergCompatV2",
+    "supported",
+    "cannot be enabled at table create time"
+)]
+#[case::feature_signal_catalog_owned_preview(
+    "delta.feature.catalogOwned-preview",
+    "supported",
+    "deprecated for CREATE TABLE; use 'catalogManaged' instead"
+)]
+#[case::enablement_property_type_widening(
+    "delta.enableTypeWidening",
+    "true",
+    "cannot be enabled at table create time"
+)]
+fn test_create_table_rejects_unsupported_feature_signals(
+    #[case] property: &str,
+    #[case] value: &str,
+    #[case] expected_substring: &str,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    let result = create_table(&table_path, simple_schema()?, "Test/1.0")
+        .with_table_properties([(property, value)])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()));
+
+    assert_result_error_with_message(result, expected_substring);
+
+    Ok(())
+}
+
+/// Some features can only land in protocol via kernel inference (schema-implied or
+/// `with_data_layout`). An explicit `delta.feature.*=supported` signal must be rejected with
+/// a message pointing to the correct inference mechanism.
+#[rstest]
+#[case::feature_signal_timestamp_ntz("delta.feature.timestampNtz", "enabled by schema column type")]
+#[case::feature_signal_variant_type("delta.feature.variantType", "enabled by schema column type")]
+#[case::feature_signal_variant_type_preview(
+    "delta.feature.variantType-preview",
+    "enabled by schema column type"
+)]
+#[case::feature_signal_variant_shredding(
+    "delta.feature.variantShredding",
+    "enabled by schema column type"
+)]
+#[case::feature_signal_variant_shredding_preview(
+    "delta.feature.variantShredding-preview",
+    "enabled by schema column type"
+)]
+#[case::feature_signal_clustering("delta.feature.clustering", "with_data_layout")]
+fn test_create_table_rejects_kernel_inference_only_feature_signals(
+    #[case] property: &str,
+    #[case] expected_substring: &str,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    let result = create_table(&table_path, simple_schema()?, "Test/1.0")
+        .with_table_properties([(property, "supported")])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()));
+
+    assert_result_error_with_message(result, expected_substring);
+
+    Ok(())
+}
+
 #[rstest]
 fn test_create_table_with_checkpoint_stats_properties(
     #[values(true, false)] write_stats_as_json: bool,
@@ -623,7 +724,8 @@ fn test_create_table_with_checkpoint_stats_properties(
 #[rstest]
 // ReaderWriter features
 #[case("delta.enableDeletionVectors", TableFeature::DeletionVectors, true)]
-#[case("delta.enableTypeWidening", TableFeature::TypeWidening, true)]
+// `delta.enableTypeWidening=true` is rejected at create time; see
+// `test_create_table_rejects_unsupported_feature_signals`.
 // WriterOnly features
 #[case("delta.enableChangeDataFeed", TableFeature::ChangeDataFeed, false)]
 #[case("delta.appendOnly", TableFeature::AppendOnly, false)]

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -846,8 +846,16 @@ async fn add_column_with_stray_cm_metadata_on_non_cm_table_fails(
     Ok(())
 }
 
+/// IcebergCompatV3's `ddl` cells must block every ALTER sub-op (today: AddColumn and
+/// SetNullable). The `Operation::Ddl(DdlOp::*)` gate fires per-op, so each variant gets a
+/// case to confirm the dispatcher routes the cell correctly for every DdlOp.
+#[rstest::rstest]
+#[case::add_column(AlterCase::AddColumn)]
+#[case::set_nullable(AlterCase::SetNullable)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn alter_blocked_when_iceberg_compat_v3_enabled() -> Result<(), Box<dyn std::error::Error>> {
+async fn alter_blocked_when_iceberg_compat_v3_enabled(
+    #[case] alter: AlterCase,
+) -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
     let snapshot = create_table_and_load_snapshot(
         &table_path,
@@ -856,16 +864,27 @@ async fn alter_blocked_when_iceberg_compat_v3_enabled() -> Result<(), Box<dyn st
         &[("delta.enableIcebergCompatV3", "true")],
     )?;
 
-    let msg = snapshot
-        .alter_table()
-        .add_column(StructField::nullable("new_col", DataType::STRING))
+    let builder = snapshot.alter_table();
+    let builder = match alter {
+        AlterCase::AddColumn => {
+            builder.add_column(StructField::nullable("new_col", DataType::STRING))
+        }
+        AlterCase::SetNullable => builder.set_nullable(column_name!("id")),
+    };
+    let msg = builder
         .build(engine.as_ref(), committer())
         .unwrap_err()
         .to_string();
     assert!(
-        msg.contains("ALTER TABLE is not yet supported on tables with icebergCompatV3 enabled"),
-        "unexpected error: {msg}",
+        msg.contains("ALTER TABLE not yet supported on icebergCompatV3-enabled tables"),
+        "{alter:?}: unexpected error: {msg}",
     );
 
     Ok(())
+}
+
+#[derive(Debug, Clone, Copy)]
+enum AlterCase {
+    AddColumn,
+    SetNullable,
 }

--- a/kernel/tests/integration/write/cdf.rs
+++ b/kernel/tests/integration/write/cdf.rs
@@ -103,8 +103,11 @@ async fn test_cdf_write_all_adds_succeeds() -> Result<(), Box<dyn std::error::Er
 }
 
 #[tokio::test]
-async fn test_cdf_write_all_removes_succeeds() -> Result<(), Box<dyn std::error::Error>> {
-    // This test verifies that remove-only transactions work with CDF enabled
+async fn test_cdf_write_all_removes_fails_with_data_change(
+) -> Result<(), Box<dyn std::error::Error>> {
+    // A remove-only commit with `data_change=true` is a DELETE. A CDF-enabled table requires
+    // a CDC file to record the deleted rows, and kernel cannot generate one yet, so the
+    // commit is rejected.
     let _ = tracing_subscriber::fmt::try_init();
 
     let schema = get_simple_int_schema();
@@ -115,7 +118,7 @@ async fn test_cdf_write_all_removes_succeeds() -> Result<(), Box<dyn std::error:
     // First, add some data
     write_data_to_table(&table_url, &engine, schema, vec![1, 2, 3]).await?;
 
-    // Now remove the files
+    // Now remove the files with data_change=true.
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
     let mut txn = begin_transaction(snapshot.clone(), engine.as_ref())?
         .with_engine_info("cdf remove test")
@@ -126,14 +129,10 @@ async fn test_cdf_write_all_removes_succeeds() -> Result<(), Box<dyn std::error:
     let (data, selection_vector) = scan_metadata.scan_files.into_parts();
     txn.remove_files(FilteredEngineData::try_new(data, selection_vector)?);
 
-    // This should succeed - remove-only transactions are allowed with CDF
-    let result = txn.commit(engine.as_ref())?;
-    match result {
-        CommitResult::CommittedTransaction(committed) => {
-            assert_eq!(committed.commit_version(), 2);
-        }
-        _ => panic!("Transaction should be committed"),
-    }
+    assert_result_error_with_message(
+        txn.commit(engine.as_ref()),
+        "CDF writes not yet supported for UPDATE/DELETE/MERGE-shaped commits",
+    );
 
     Ok(())
 }
@@ -209,12 +208,9 @@ async fn test_cdf_write_mixed_with_data_change_fails() -> Result<(), Box<dyn std
     let (data, selection_vector) = scan_metadata.scan_files.into_parts();
     txn.remove_files(FilteredEngineData::try_new(data, selection_vector)?);
 
-    // This should fail with our new error message
     assert_result_error_with_message(
         txn.commit(engine.as_ref()),
-        "Cannot add and remove data in the same transaction when Change Data Feed is enabled (delta.enableChangeDataFeed = true). \
-         This would require writing CDC files for DML operations, which is not yet supported. \
-         Consider using separate transactions: one to add files, another to remove files."
+        "CDF writes not yet supported for UPDATE/DELETE/MERGE-shaped commits",
     );
 
     Ok(())


### PR DESCRIPTION
## What changes are proposed in this pull request?

Replace scattered feature-vs-operation gates with a per-feature `OperationSupport` matrix
(read / data_write / ddl / create cells). Splits `Operation::Write` into granular `Append` /
`Dml` / `Maintenance` sub-ops, adds `CreateSupport` with a user-opt-in-vs-kernel-inference
path distinction, and collapses three scattered checks (`validate_feature_support_for_remove`,
the inline CDF mixed add+remove block, and the `ALLOWED_DELTA_FEATURES` whitelist) into
declarative cells in `kernel/src/table_features/mod.rs`.

## How was this change tested?
