### PR TITLE
refactor: add path-keyed nested-field helpers; close #1820

### DIFF
--- a/kernel/src/checkpoint/checkpoint_transform.rs
+++ b/kernel/src/checkpoint/checkpoint_transform.rs
@@ -19,7 +19,7 @@ use crate::actions::ADD_NAME;
 use crate::expressions::{Expression, ExpressionRef, Transform, UnaryExpressionOp};
 use crate::schema::{DataType, SchemaRef, StructField, StructType};
 use crate::table_properties::TableProperties;
-use crate::{DeltaResult, Error};
+use crate::DeltaResult;
 
 pub(crate) const STATS_FIELD: &str = "stats";
 pub(crate) const STATS_PARSED_FIELD: &str = "stats_parsed";
@@ -146,36 +146,25 @@ pub(crate) fn build_checkpoint_read_schema(
     stats_schema: &StructType,
     partition_schema: Option<&StructType>,
 ) -> DeltaResult<SchemaRef> {
-    transform_add_schema(base_schema, |add_struct| {
-        // Validate fields aren't already present
-        if add_struct.field(STATS_PARSED_FIELD).is_some() {
-            return Err(Error::generic(
-                "stats_parsed field already exists in Add schema",
-            ));
-        }
-        if partition_schema.is_some() && add_struct.field(PARTITION_VALUES_PARSED_FIELD).is_some() {
-            return Err(Error::generic(
-                "partitionValues_parsed field already exists in Add schema",
-            ));
-        }
-        let mut result = add_struct.clone().with_field_inserted_after(
-            Some(STATS_FIELD),
+    let mut new_struct = base_schema.clone().with_nested_field_inserted_after(
+        &[ADD_NAME],
+        Some(STATS_FIELD),
+        StructField::nullable(
+            STATS_PARSED_FIELD,
+            DataType::Struct(Box::new(stats_schema.clone())),
+        ),
+    )?;
+    if let Some(pv_schema) = partition_schema {
+        new_struct = new_struct.with_nested_field_inserted_after(
+            &[ADD_NAME],
+            Some(PARTITION_VALUES_FIELD),
             StructField::nullable(
-                STATS_PARSED_FIELD,
-                DataType::Struct(Box::new(stats_schema.clone())),
+                PARTITION_VALUES_PARSED_FIELD,
+                DataType::Struct(Box::new(pv_schema.clone())),
             ),
         )?;
-        if let Some(pv_schema) = partition_schema {
-            result = result.with_field_inserted_after(
-                Some(PARTITION_VALUES_FIELD),
-                StructField::nullable(
-                    PARTITION_VALUES_PARSED_FIELD,
-                    DataType::Struct(Box::new(pv_schema.clone())),
-                ),
-            )?;
-        }
-        Ok(result)
-    })
+    }
+    Ok(Arc::new(new_struct))
 }
 
 /// Builds the output schema based on configuration.
@@ -193,9 +182,12 @@ pub(crate) fn build_checkpoint_output_schema(
     stats_schema: &StructType,
     partition_schema: Option<&StructType>,
 ) -> DeltaResult<SchemaRef> {
-    transform_add_schema(base_schema, |add_struct| {
-        build_add_output_schema(config, add_struct, stats_schema, partition_schema)
-    })
+    base_schema
+        .clone()
+        .map_struct_at(&[ADD_NAME], |add_struct| {
+            build_add_output_schema(config, &add_struct, stats_schema, partition_schema)
+        })
+        .map(Arc::new)
 }
 
 // ========================
@@ -252,48 +244,6 @@ static STATS_JSON_EXPR: LazyLock<ExpressionRef> = LazyLock::new(|| {
         ),
     ]))
 });
-
-/// Transforms the Add action schema within a checkpoint schema.
-///
-/// This helper applies a transformation function to the Add struct and returns
-/// a new schema with the modified Add field.
-// TODO(https://github.com/delta-io/delta-kernel-rs/issues/1820): Replace manual field
-// iteration with StructType helper methods (e.g., with_field_inserted, with_field_removed).
-///
-/// # Errors
-///
-/// Returns an error if:
-/// - The `add` field is not found in the schema
-/// - The `add` field is not a struct type
-fn transform_add_schema(
-    base_schema: &StructType,
-    transform_fn: impl FnOnce(&StructType) -> DeltaResult<StructType>,
-) -> DeltaResult<SchemaRef> {
-    // Find and validate the add field
-    let add_field = base_schema
-        .field(ADD_NAME)
-        .ok_or_else(|| Error::generic("Expected 'add' field in checkpoint schema"))?;
-
-    let DataType::Struct(add_struct) = &add_field.data_type else {
-        return Err(Error::generic(format!(
-            "Expected 'add' field to be a struct type, got {:?}",
-            add_field.data_type
-        )));
-    };
-
-    let modified_add = transform_fn(add_struct)?;
-    let new_schema = base_schema.clone().with_field_replaced(
-        ADD_NAME,
-        StructField {
-            name: ADD_NAME.to_string(),
-            data_type: DataType::Struct(Box::new(modified_add)),
-            nullable: add_field.nullable,
-            metadata: add_field.metadata.clone(),
-        },
-    )?;
-
-    Ok(Arc::new(new_schema))
-}
 
 fn build_add_output_schema(
     config: &StatsTransformConfig,

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -1128,6 +1128,8 @@ impl StructType {
     /// If `new_field`  already presents in the schema, an error is returned.
     /// If `after` is None, `new_field` is appended to the end.
     /// If `after` is not found, an error is returned.
+    // TODO(https://github.com/delta-io/delta-kernel-rs/issues/2610): change `None`
+    // semantics from "append to end" to "insert at front".
     pub fn with_field_inserted_after(
         mut self,
         after: Option<&str>,
@@ -1223,20 +1225,124 @@ impl StructType {
         }
     }
 
-    /// Returns a StructType with the named field replaced.
-    /// Returns an error if field doesn't exist.
+    /// Returns a [`StructType`] with the field at key `name` replaced by `new_field`. When
+    /// `new_field.name() != name` this renames the entry: `new_field` lands at the same
+    /// index as the original, the old key is removed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `name` is not present, or if the new field name would collide with an
+    /// existing field.
     pub fn with_field_replaced(
         mut self,
         name: &str,
         new_field: StructField,
     ) -> DeltaResult<StructType> {
-        let replace_field = self
+        let idx = self
             .fields
-            .get_mut(name)
-            .ok_or_else(|| Error::generic(format!("Field {name} not found")))?;
-
-        *replace_field = new_field;
+            .get_index_of(name)
+            .ok_or_else(|| Error::generic(format!("Field `{name}` not found")))?;
+        if name == new_field.name() {
+            self.fields[idx] = new_field;
+        } else {
+            // Ensure that the new field name is not already in the schema. This is to prevent the
+            // following bad case:
+            // * initial schema: add.{stats, parsed_stats}
+            // * replace add.stats with parsed_stats
+            // * this would result in a schema with add.{parsed_stats, parsed_stats}, which is not
+            //   valid.
+            if self.fields.contains_key(new_field.name()) {
+                return Err(Error::generic(format!(
+                    "Field `{}` already exists",
+                    new_field.name()
+                )));
+            }
+            self.fields.shift_remove_index(idx);
+            self.fields
+                .insert_before(idx, new_field.name.clone(), new_field);
+        }
         Ok(self)
+    }
+
+    /// Insert `field` after `after` in the nested struct at `path` (empty path = self).
+    /// `after = None` appends to the end (see TODO on
+    /// [`Self::with_field_inserted_after`] re: [#2610]). Ancestor [`StructField`]s
+    /// along `path` keep their nullability and metadata; only their inner
+    /// [`StructType`] is rebuilt.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any path component is missing or is not a struct type, or if
+    /// the inner [`Self::with_field_inserted_after`] fails (e.g. `after` does not name an
+    /// existing field, or `field.name()` collides with an existing one).
+    ///
+    /// [#2610]: https://github.com/delta-io/delta-kernel-rs/issues/2610
+    pub fn with_nested_field_inserted_after(
+        self,
+        path: &[&str],
+        after: Option<&str>,
+        field: StructField,
+    ) -> DeltaResult<Self> {
+        self.map_struct_at(path, move |s| s.with_field_inserted_after(after, field))
+    }
+
+    /// Replace the field named `name` in the nested struct at `path` (empty path = self)
+    /// with `new_field`. When `new_field.name() != name` this renames the entry in place
+    /// (see [`Self::with_field_replaced`]). Ancestor [`StructField`]s along `path` keep
+    /// their nullability and metadata; only their inner [`StructType`] is rebuilt.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any path component is missing or is not a struct type, if
+    /// `name` is not present in the target struct, or if a rename would collide with an
+    /// existing sibling field.
+    pub fn with_nested_field_replaced(
+        self,
+        path: &[&str],
+        name: &str,
+        new_field: StructField,
+    ) -> DeltaResult<Self> {
+        self.map_struct_at(path, move |s| s.with_field_replaced(name, new_field))
+    }
+
+    /// Remove the field named `name` from the nested struct at `path` (empty path = self).
+    /// Ancestor [`StructField`]s along `path` keep their nullability and metadata; only
+    /// their inner [`StructType`] is rebuilt. Removing a missing leaf field is a no-op
+    /// (matches [`Self::with_field_removed`]).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any path component is missing or is not a struct type.
+    pub fn with_nested_field_removed(self, path: &[&str], name: &str) -> DeltaResult<Self> {
+        self.map_struct_at(path, move |s| Ok(s.with_field_removed(name)))
+    }
+
+    /// Recursive walker shared by `with_nested_field_*`: descend into the struct at `path`
+    /// and apply `f` to it. Ancestor [`StructField`]s are rebuilt preserving their original
+    /// nullability and metadata.
+    pub(crate) fn map_struct_at<F>(self, path: &[&str], f: F) -> DeltaResult<Self>
+    where
+        F: FnOnce(StructType) -> DeltaResult<StructType>,
+    {
+        let Some((head, rest)) = path.split_first() else {
+            return f(self);
+        };
+        let field = self
+            .field(head)
+            .ok_or_else(|| Error::generic(format!("Field `{head}` not found")))?;
+        let DataType::Struct(inner) = field.data_type() else {
+            return Err(Error::generic(format!(
+                "Field `{head}` is not a struct type"
+            )));
+        };
+        let new_inner = (**inner).clone().map_struct_at(rest, f)?;
+        let new_field = StructField {
+            name: field.name.clone(),
+            data_type: DataType::Struct(Box::new(new_inner)),
+            nullable: field.nullable,
+            metadata: field.metadata.clone(),
+        };
+        self.with_field_replaced(head, new_field)
     }
 }
 
@@ -4108,27 +4214,66 @@ mod tests {
         assert_eq!(new_schema.field_at_index(0).unwrap().name(), "id");
     }
 
-    #[test]
-    fn test_with_field_replaced() {
-        let schema =
-            StructType::try_new([StructField::new("id", DataType::INTEGER, false)]).unwrap();
-        let new_schema = schema
-            .with_field_replaced("id", StructField::new("name", DataType::STRING, true))
-            .unwrap();
-
-        assert_eq!(new_schema.num_fields(), 1);
-        assert_eq!(new_schema.field_at_index(0).unwrap().name(), "name");
+    /// Schema with both top-level fields (a/b/c) and a nested `outer` struct that mirrors
+    /// them, so the same rstest can exercise root and nested replace cases over one fixture.
+    fn replace_test_schema() -> StructType {
+        let abc = StructType::try_new([
+            StructField::new("a", DataType::STRING, false),
+            StructField::new("b", DataType::INTEGER, false),
+            StructField::new("c", DataType::DOUBLE, false),
+        ])
+        .unwrap();
+        StructType::try_new([
+            StructField::new("a", DataType::STRING, false),
+            StructField::new("b", DataType::INTEGER, false),
+            StructField::new("c", DataType::DOUBLE, false),
+            StructField::nullable("outer", abc),
+        ])
+        .unwrap()
     }
 
-    #[test]
-    fn test_with_field_replaced_non_existent_field() {
-        let schema =
-            StructType::try_new([StructField::new("id", DataType::INTEGER, false)]).unwrap();
-        let new_schema = schema.with_field_replaced(
-            "nonexistent",
-            StructField::new("name", DataType::STRING, true),
+    #[rstest]
+    #[case::overwrite_same_name(vec![], "b", "b", vec!["a", "b", "c", "outer"])]
+    #[case::rename(vec![], "b", "renamed", vec!["a", "renamed", "c", "outer"])]
+    #[case::nested_rename(vec!["outer"], "b", "renamed", vec!["a", "renamed", "c"])]
+    fn test_with_field_replaced(
+        #[case] path: Vec<&str>,
+        #[case] target: &str,
+        #[case] new_name: &str,
+        #[case] expected_names: Vec<&str>,
+    ) {
+        let new_schema = replace_test_schema()
+            .with_nested_field_replaced(
+                &path,
+                target,
+                StructField::nullable(new_name, DataType::STRING),
+            )
+            .unwrap();
+        let leaf = descend_to(&new_schema, &path);
+        let names: Vec<&str> = leaf.fields().map(|f| f.name().as_str()).collect();
+        assert_eq!(names, expected_names);
+        assert_eq!(leaf.field(new_name).unwrap().data_type(), &DataType::STRING);
+        if target != new_name {
+            assert!(leaf.field(target).is_none());
+        }
+    }
+
+    #[rstest]
+    #[case::not_found(vec![], "nonexistent", "x", "Field `nonexistent` not found")]
+    #[case::rename_collision(vec![], "a", "b", "Field `b` already exists")]
+    #[case::nested_leaf_missing(vec!["outer"], "absent", "absent", "Field `absent` not found")]
+    fn test_with_field_replaced_errors(
+        #[case] path: Vec<&str>,
+        #[case] target: &str,
+        #[case] new_name: &str,
+        #[case] msg: &str,
+    ) {
+        let result = replace_test_schema().with_nested_field_replaced(
+            &path,
+            target,
+            StructField::nullable(new_name, DataType::STRING),
         );
-        assert!(new_schema.is_err(), "Expected error for non-existent field");
+        assert_result_error_with_message(result, msg);
     }
 
     /// Schema: { a: { b: { c: double } } } — supports walks at depths 1, 2, and 3.
@@ -4217,6 +4362,109 @@ mod tests {
         assert_eq!(
             normalize_column_names_to_schema_casing(&schema, &cols)[0].path(),
             ["nonexistent"]
+        );
+    }
+
+    // === with_nested_field_* ===
+
+    /// Walks `path` through `schema` and returns the (possibly nested) struct at that path.
+    fn descend_to<'a>(schema: &'a StructType, path: &[&str]) -> &'a StructType {
+        let mut cursor = schema;
+        for name in path {
+            let DataType::Struct(inner) = cursor.field(name).unwrap().data_type() else {
+                panic!("expected struct at {name}");
+            };
+            cursor = inner.as_ref();
+        }
+        cursor
+    }
+
+    #[rstest]
+    #[case::root(vec![])]
+    #[case::depth_one(vec!["a"])]
+    #[case::depth_two(vec!["a", "b"])]
+    fn test_with_nested_field_inserted_after_at_path(#[case] path: Vec<&str>) {
+        let new_schema = walk_test_schema()
+            .with_nested_field_inserted_after(
+                &path,
+                None,
+                StructField::nullable("x", DataType::INTEGER),
+            )
+            .unwrap();
+        let expected_leaf = StructField::nullable("x", DataType::INTEGER);
+        assert_eq!(
+            descend_to(&new_schema, &path).field("x"),
+            Some(&expected_leaf)
+        );
+    }
+
+    #[rstest]
+    #[case::missing_component(vec!["a", "missing"], "Field `missing` not found")]
+    // `c` is a DOUBLE leaf, so traversing past it fails.
+    #[case::intermediate_not_struct(vec!["a", "b", "c", "d"], "not a struct type")]
+    fn test_with_nested_field_inserted_after_path_errors(
+        #[case] path: Vec<&str>,
+        #[case] msg: &str,
+    ) {
+        let result = walk_test_schema().with_nested_field_inserted_after(
+            &path,
+            None,
+            StructField::nullable("x", DataType::INTEGER),
+        );
+        assert_result_error_with_message(result, msg);
+    }
+
+    #[rstest]
+    #[case::after_not_found(Some("nonexistent"), "x", "Field nonexistent not found")]
+    #[case::collision(None, "c", "Field c already exists")]
+    fn test_with_nested_field_inserted_after_leaf_errors(
+        #[case] after: Option<&str>,
+        #[case] new_name: &str,
+        #[case] msg: &str,
+    ) {
+        let result = walk_test_schema().with_nested_field_inserted_after(
+            &["a", "b"],
+            after,
+            StructField::nullable(new_name, DataType::INTEGER),
+        );
+        assert_result_error_with_message(result, msg);
+    }
+
+    #[rstest]
+    #[case::root(vec![], "a")]
+    #[case::depth_one(vec!["a"], "b")]
+    #[case::depth_two(vec!["a", "b"], "c")]
+    fn test_with_nested_field_removed_at_path(#[case] path: Vec<&str>, #[case] field_name: &str) {
+        let new_schema = walk_test_schema()
+            .with_nested_field_removed(&path, field_name)
+            .unwrap();
+        assert!(descend_to(&new_schema, &path).field(field_name).is_none());
+    }
+
+    #[test]
+    fn test_with_nested_field_preserves_intermediate_metadata_and_nullability() {
+        let leaf = StructType::new_unchecked([StructField::new("c", DataType::DOUBLE, false)]);
+        let inner = StructType::new_unchecked([StructField::new(
+            "b",
+            DataType::Struct(Box::new(leaf)),
+            false,
+        )]);
+        let outer_field = StructField::new("a", DataType::Struct(Box::new(inner)), true)
+            .with_metadata([("k".to_string(), "v".to_string())]);
+        let schema = StructType::new_unchecked([outer_field]);
+
+        let new_schema = schema
+            .with_nested_field_inserted_after(
+                &["a", "b"],
+                None,
+                StructField::nullable("d", DataType::INTEGER),
+            )
+            .unwrap();
+        let a_field = new_schema.field("a").unwrap();
+        assert!(a_field.is_nullable());
+        assert_eq!(
+            a_field.metadata.get("k"),
+            Some(&MetadataValue::String("v".to_string()))
         );
     }
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2606/files) to review incremental changes.
- [**stack/a1**](https://github.com/delta-io/delta-kernel-rs/pull/2606) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2606/files)]

---------
## What changes are proposed in this pull request?

Adds three named helpers on `StructType` that mirror the existing root-level field-edit methods but accept a path to descend into a nested struct, closing [#1820](https://github.com/delta-io/delta-kernel-rs/issues/1820):

```rust
pub fn with_nested_field_inserted_after(
    self, path: &[&str], after: Option<&str>, field: StructField,
) -> DeltaResult<Self>;

pub fn with_nested_field_replaced(
    self, path: &[&str], name: &str, new_field: StructField,
) -> DeltaResult<Self>;

pub fn with_nested_field_removed(
    self, path: &[&str], name: &str,
) -> DeltaResult<Self>;
```

All three take `path` as the parent struct (empty path = self) and the second `&str` arg names the target within it (the `after` anchor for insert, the field-to-replace for replace, the field-to-remove for remove). Any non-empty path component must resolve to a struct field; ancestor `StructField`s are rebuilt preserving their nullability and metadata, only their inner `StructType` is replaced.

A single private recursive walker (`map_struct_at`, `pub(crate)`) backs all three methods; kernel-internal callers can reach for it when a single path needs multiple state-dependent edits in one closure.

### Also: fix latent bug in `with_field_replaced`

Previously `with_field_replaced` used `IndexMap::get_mut(name); *replace_field = new_field`. If the caller passed `new_field` with a different `.name()`, the IndexMap key stayed as `name` while the `StructField`'s own `.name` became `new_field.name()` — leaving the map's keys out of sync with each field's name. Lookups by the old name returned the renamed field; lookups by the new name returned `None`.

The fix uses `get_index_of` + `shift_remove_index` + `insert_before`:
- same-name case: overwrites in place (no change)
- rename case: removes old key, re-inserts at the same index under the new key, rejecting collisions

This kept working on `main` only because no existing caller renamed. The new `with_nested_field_replaced(path, name, new_field)` signature exposes the same trap to the public API, which is why this PR fixes the underlying root helper.

### Refactor

Removes the `transform_add_schema` helper in `checkpoint/checkpoint_transform.rs` (specialized "modify the add substruct" wrapper that carried the #1820 TODO comment); the two call sites use the new helpers directly:

- `build_checkpoint_read_schema`: two `with_nested_field_inserted_after(&[ADD_NAME], ...)` calls.
- `build_checkpoint_output_schema`: `map_struct_at(&[ADD_NAME], ...)` with a closure that calls `build_add_output_schema`.

### This PR affects the following public APIs

Adds three new public methods on `StructType`: `with_nested_field_inserted_after`, `with_nested_field_replaced`, `with_nested_field_removed`. All non-breaking additions. `with_field_replaced` gains correct rename semantics — pre-existing callers (all of which pass `new_field.name() == name`) see no behavior change.

## How was this change tested?

- New rstest-parameterized unit tests covering the three nested methods at depths 0/1/2, plus path-walk errors (missing component, non-struct intermediate) and leaf-level errors (collision, missing target, missing `after`).
- New tests pin the rename + collision branches of `with_field_replaced` at both root level (`test_with_field_replaced_rename_preserves_position_and_syncs_key`, `test_with_field_replaced_rename_collision_errors`) and through the nested API (`test_with_nested_field_replaced_renames_in_place`).
- Existing `checkpoint/` integration tests cover the two refactored call sites end-to-end.
- Full pre-commit: `cargo +nightly fmt`, `cargo clippy --workspace --benches --tests --all-features -- -D warnings`, `cargo clippy --workspace --no-default-features --features arrow ... -- -D warnings`, `cargo doc --workspace --all-features --no-deps`, and `cargo nextest run -p delta_kernel --all-features` (3609 tests pass).