### PR TITLE
  feat(ffi): opaque-predicate file pruning via Arrow C Data Interface

### DIFF
--- a/ffi/CLAUDE.md
+++ b/ffi/CLAUDE.md
@@ -29,6 +29,12 @@ the caller's memory space.
 - `src/handle.rs` -- opaque handle system for passing Rust objects across FFI
 - `src/scan.rs` -- scan FFI interface
 - `src/schema_visitor.rs` -- visitor pattern for schema traversal
+- `src/expressions/kernel_visitor.rs` -- engine-to-kernel expression visitor;
+  hosts `visit_predicate_opaque*` for engine-defined ops
+- `src/expressions/pruning.rs` -- engine-callback framework for opaque-predicate
+  file pruning (`OpaquePruningCallbacks`, child / batch-stats accessors)
+- `src/expressions/arrow_pruning.rs` -- `ArrowOpaquePredicateOp` impl on
+  `NamedOpaquePredicateOp` for stats-based file pruning (default-engine-base only)
 
 ## Read Flow
 

--- a/ffi/examples/visit-expression/engine_to_kernel_expression.h
+++ b/ffi/examples/visit-expression/engine_to_kernel_expression.h
@@ -234,8 +234,8 @@ uintptr_t convert_engine_to_kernel_expression_item(
       }
       return result.ok;
     }
-    case Unknown: {
-      struct Unknown* unknown = (struct Unknown*)item.ref;
+    case UnknownExpr: {
+      struct UnknownExpr* unknown = (struct UnknownExpr*)item.ref;
       KernelStringSlice str_slice = {
         .ptr = unknown->name,
         .len = strlen(unknown->name)

--- a/ffi/examples/visit-expression/expression.h
+++ b/ffi/examples/visit-expression/expression.h
@@ -63,7 +63,7 @@ enum ExpressionType {
   FieldTransform,
   OpaqueExpression,
   OpaquePredicate,
-  Unknown,
+  UnknownExpr,
   MapToStruct,
 };
 enum VariadicType {
@@ -109,7 +109,7 @@ struct OpaquePredicate {
   HandleSharedOpaquePredicateOp op;
   ExpressionItemList exprs;
 };
-struct Unknown {
+struct UnknownExpr {
   char* name;
 };
 struct MapToStructExpr {
@@ -393,9 +393,9 @@ void visit_opaque_pred(
 }
 
 void visit_unknown(void *data, uintptr_t sibling_list_id, struct KernelStringSlice name) {
-  struct Unknown* unknown = malloc(sizeof(struct Unknown));
+  struct UnknownExpr* unknown = malloc(sizeof(struct UnknownExpr));
   unknown->name = allocate_string(name);
-  put_expr_item(data, sibling_list_id, unknown, Unknown);
+  put_expr_item(data, sibling_list_id, unknown, UnknownExpr);
 }
 
 void visit_map_to_struct_expr(void* data,
@@ -611,8 +611,8 @@ void free_expression_item(ExpressionItem ref) {
       free(opaque);
       break;
     };
-    case Unknown: {
-      struct Unknown* unknown = ref.ref;
+    case UnknownExpr: {
+      struct UnknownExpr* unknown = ref.ref;
       free(unknown->name);
       free(unknown);
       break;

--- a/ffi/examples/visit-expression/expression_print.h
+++ b/ffi/examples/visit-expression/expression_print.h
@@ -117,8 +117,8 @@ void print_tree_helper(ExpressionItem ref, int depth) {
       print_expression_item_list(opaque->exprs, depth + 1);
       break;
     }
-    case Unknown: {
-      struct Unknown* unknown = ref.ref;
+    case UnknownExpr: {
+      struct UnknownExpr* unknown = ref.ref;
       printf("Unknown(%s)\n", unknown->name);
       break;
     }

--- a/ffi/src/engine_data.rs
+++ b/ffi/src/engine_data.rs
@@ -79,7 +79,14 @@ impl ArrowFFIData {
     /// `FFI_ArrowArray`/`FFI_ArrowSchema` call their release callbacks).
     pub fn try_from_engine_data(data: Box<dyn EngineData>) -> DeltaResult<Self> {
         let record_batch = data.try_into_record_batch()?;
-        let sa: StructArray = record_batch.into();
+        Self::try_from_record_batch(&record_batch)
+    }
+
+    /// Export a [`RecordBatch`] as Arrow C Data Interface structs. The
+    /// returned `ArrowFFIData` owns the exported buffers; the input batch
+    /// is only borrowed (its `Arc`'d column buffers are referenced).
+    pub fn try_from_record_batch(batch: &RecordBatch) -> DeltaResult<Self> {
+        let sa: StructArray = batch.clone().into();
         let array_data: ArrayData = sa.into();
         let array = FFI_ArrowArray::new(&array_data);
         let schema = FFI_ArrowSchema::try_from(array_data.data_type())?;

--- a/ffi/src/expressions/arrow_pruning.rs
+++ b/ffi/src/expressions/arrow_pruning.rs
@@ -1,0 +1,554 @@
+//! Arrow-backed batched evaluation of [`NamedOpaquePredicateOp`].
+//!
+//! Adds an [`ArrowOpaquePredicateOp`] impl so the default engine's batch
+//! evaluator can run an opaque op against a stats metadata batch with a
+//! single FFI upcall per batch.
+
+use delta_kernel::arrow::array::{BooleanArray, RecordBatch};
+use delta_kernel::engine::arrow_expression::opaque::{
+    ArrowOpaquePredicate, ArrowOpaquePredicateOp,
+};
+use delta_kernel::expressions::{Expression, Predicate, ScalarExpressionEvaluator};
+use delta_kernel::kernel_predicates::{
+    DirectDataSkippingPredicateEvaluator, DirectPredicateEvaluator,
+    IndirectDataSkippingPredicateEvaluator,
+};
+use delta_kernel::DeltaResult;
+
+use super::pruning::{
+    invoke_eval_against_stats, BatchStatsAccessor, ChildAccessor, OpaquePruneVerdict,
+};
+use super::NamedOpaquePredicateOp;
+use crate::engine_data::ArrowFFIData;
+
+impl ArrowOpaquePredicateOp for NamedOpaquePredicateOp {
+    fn eval_pred(
+        &self,
+        args: &[Expression],
+        batch: &RecordBatch,
+        inverted: bool,
+    ) -> DeltaResult<BooleanArray> {
+        let n_rows = batch.num_rows();
+        let Some(cb) = self.callbacks_clone() else {
+            // No callbacks -- yield all-null so kernel keeps every file.
+            return Ok(BooleanArray::from(vec![None; n_rows]));
+        };
+
+        // None on export failure: engines that imported successfully read
+        // stats from their own runtime; the rest leave verdicts at Unknown.
+        let arrow_ffi = ArrowFFIData::try_from_record_batch(batch).ok();
+        let stats = BatchStatsAccessor::new().with_arrow_ffi(arrow_ffi);
+        let children = ChildAccessor::new(args);
+        let mut verdicts = vec![OpaquePruneVerdict::Unknown; n_rows];
+        invoke_eval_against_stats(
+            &cb,
+            self.op_name(),
+            &children,
+            &stats,
+            inverted,
+            &mut verdicts,
+        );
+
+        let bools: Vec<Option<bool>> = verdicts
+            .iter()
+            .map(|v| match *v {
+                OpaquePruneVerdict::Keep => Some(true),
+                OpaquePruneVerdict::Skip => Some(false),
+                OpaquePruneVerdict::Unknown => None,
+            })
+            .collect();
+        Ok(BooleanArray::from(bools))
+    }
+
+    fn name(&self) -> &str {
+        self.op_name()
+    }
+
+    fn eval_pred_scalar(
+        &self,
+        eval_expr: &ScalarExpressionEvaluator<'_>,
+        eval_pred: &DirectPredicateEvaluator<'_>,
+        exprs: &[Expression],
+        inverted: bool,
+    ) -> DeltaResult<Option<bool>> {
+        <Self as delta_kernel::expressions::OpaquePredicateOp>::eval_pred_scalar(
+            self, eval_expr, eval_pred, exprs, inverted,
+        )
+    }
+
+    fn eval_as_data_skipping_predicate(
+        &self,
+        predicate_evaluator: &DirectDataSkippingPredicateEvaluator<'_>,
+        exprs: &[Expression],
+        inverted: bool,
+    ) -> Option<bool> {
+        <Self as delta_kernel::expressions::OpaquePredicateOp>::eval_as_data_skipping_predicate(
+            self,
+            predicate_evaluator,
+            exprs,
+            inverted,
+        )
+    }
+
+    fn as_data_skipping_predicate(
+        &self,
+        _predicate_evaluator: &IndirectDataSkippingPredicateEvaluator<'_>,
+        exprs: &[Expression],
+        inverted: bool,
+    ) -> Option<Predicate> {
+        // Wrap with `Not` so the batch evaluator flips `inverted` when
+        // descending; the engine callback then sees `inverted` exactly once.
+        if !self.has_callbacks() {
+            return None;
+        }
+        let pred = Predicate::arrow_opaque(self.clone(), exprs.iter().cloned());
+        Some(if inverted { Predicate::not(pred) } else { pred })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::panic)]
+
+    use std::cell::Cell;
+    use std::sync::Arc;
+
+    use delta_kernel::arrow::array::{Array, ArrayRef, Int64Array, StringArray, StructArray};
+    use delta_kernel::arrow::datatypes::{DataType as ArrowDataType, Field, Schema};
+    use delta_kernel::expressions::column_expr;
+
+    use super::*;
+    use crate::expressions::pruning::OpaquePruningCallbacks;
+
+    fn three_file_batch() -> RecordBatch {
+        let min = StructArray::from(vec![(
+            Arc::new(Field::new("name", ArrowDataType::Utf8, true)),
+            Arc::new(StringArray::from(vec!["apple", "foo", "zebra"])) as ArrayRef,
+        )]);
+        let max = StructArray::from(vec![(
+            Arc::new(Field::new("name", ArrowDataType::Utf8, true)),
+            Arc::new(StringArray::from(vec!["banana", "foozzz", "zoo"])) as ArrayRef,
+        )]);
+        let nullcount = StructArray::from(vec![(
+            Arc::new(Field::new("name", ArrowDataType::Int64, true)),
+            Arc::new(Int64Array::from(vec![0_i64, 0, 0])) as ArrayRef,
+        )]);
+        let stats_parsed = StructArray::from(vec![
+            (
+                Arc::new(Field::new("numRecords", ArrowDataType::Int64, true)),
+                Arc::new(Int64Array::from(vec![10_i64, 20, 30])) as ArrayRef,
+            ),
+            (
+                Arc::new(Field::new(
+                    "nullCount",
+                    ArrowDataType::Struct(
+                        vec![Field::new("name", ArrowDataType::Int64, true)].into(),
+                    ),
+                    true,
+                )),
+                Arc::new(nullcount) as ArrayRef,
+            ),
+            (
+                Arc::new(Field::new(
+                    "minValues",
+                    ArrowDataType::Struct(
+                        vec![Field::new("name", ArrowDataType::Utf8, true)].into(),
+                    ),
+                    true,
+                )),
+                Arc::new(min) as ArrayRef,
+            ),
+            (
+                Arc::new(Field::new(
+                    "maxValues",
+                    ArrowDataType::Struct(
+                        vec![Field::new("name", ArrowDataType::Utf8, true)].into(),
+                    ),
+                    true,
+                )),
+                Arc::new(max) as ArrayRef,
+            ),
+        ]);
+        let schema = Schema::new(vec![Field::new(
+            "stats_parsed",
+            stats_parsed.data_type().clone(),
+            true,
+        )]);
+        RecordBatch::try_new(Arc::new(schema), vec![Arc::new(stats_parsed)]).unwrap()
+    }
+
+    extern "C" fn no_op_free(_state: *mut std::ffi::c_void) {}
+
+    #[test]
+    fn batch_stats_as_arrow_exports_a_valid_ffi_struct() {
+        thread_local! {
+            static SAW_NON_NULL: Cell<bool> = const { Cell::new(false) };
+            static SAW_ROW_COUNT: Cell<i64> = const { Cell::new(-1) };
+        }
+
+        extern "C" fn capture_arrow_eval(
+            _state: *mut std::ffi::c_void,
+            _op_name: crate::KernelStringSlice,
+            _children: *const ChildAccessor<'_>,
+            stats: *const BatchStatsAccessor<'_>,
+            _n_rows: usize,
+            _inverted: bool,
+            _verdicts: *mut OpaquePruneVerdict,
+        ) {
+            let ffi = unsafe { crate::expressions::pruning::batch_stats_as_arrow(stats) };
+            if ffi.is_null() {
+                return;
+            }
+            SAW_NON_NULL.with(|c| c.set(true));
+            let len = unsafe { (*ffi).array.len() } as i64;
+            SAW_ROW_COUNT.with(|c| c.set(len));
+        }
+
+        let cb = Arc::new(OpaquePruningCallbacks {
+            engine_state: std::ptr::null_mut(),
+            eval_against_stats: capture_arrow_eval,
+            free_state: no_op_free,
+        });
+        let op = NamedOpaquePredicateOp::with_callbacks("STARTS_WITH", cb);
+        let args = vec![column_expr!("name"), Expression::literal("foo")];
+        let batch = three_file_batch();
+        let _ = ArrowOpaquePredicateOp::eval_pred(&op, &args, &batch, false).unwrap();
+
+        assert!(SAW_NON_NULL.with(Cell::get));
+        assert_eq!(SAW_ROW_COUNT.with(Cell::get), 3);
+    }
+
+    #[test]
+    fn batch_stats_as_arrow_returns_null_on_null_accessor() {
+        let p = unsafe { crate::expressions::pruning::batch_stats_as_arrow(std::ptr::null()) };
+        assert!(p.is_null());
+    }
+
+    #[test]
+    fn eval_pred_on_empty_batch_does_not_panic() {
+        thread_local! {
+            static SAW_CALLBACK: Cell<bool> = const { Cell::new(false) };
+        }
+
+        extern "C" fn note_eval(
+            _state: *mut std::ffi::c_void,
+            _op_name: crate::KernelStringSlice,
+            _children: *const ChildAccessor<'_>,
+            _stats: *const BatchStatsAccessor<'_>,
+            _n_rows: usize,
+            _inverted: bool,
+            _verdicts: *mut OpaquePruneVerdict,
+        ) {
+            SAW_CALLBACK.with(|c| c.set(true));
+        }
+
+        let empty_nullcount = StructArray::from(vec![(
+            Arc::new(Field::new("size", ArrowDataType::Int64, true)),
+            Arc::new(Int64Array::from(Vec::<i64>::new())) as ArrayRef,
+        )]);
+        let stats_parsed = StructArray::from(vec![(
+            Arc::new(Field::new(
+                "nullCount",
+                ArrowDataType::Struct(vec![Field::new("size", ArrowDataType::Int64, true)].into()),
+                true,
+            )),
+            Arc::new(empty_nullcount) as ArrayRef,
+        )]);
+        let schema = Schema::new(vec![Field::new(
+            "stats_parsed",
+            stats_parsed.data_type().clone(),
+            true,
+        )]);
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(stats_parsed)]).unwrap();
+
+        let cb = Arc::new(OpaquePruningCallbacks {
+            engine_state: std::ptr::null_mut(),
+            eval_against_stats: note_eval,
+            free_state: no_op_free,
+        });
+        let op = NamedOpaquePredicateOp::with_callbacks("FOO", cb);
+        let result = ArrowOpaquePredicateOp::eval_pred(&op, &[], &batch, false).unwrap();
+        assert_eq!(result.len(), 0);
+        assert!(SAW_CALLBACK.with(Cell::get));
+    }
+
+    #[test]
+    fn eval_pred_without_callbacks_returns_all_unknown() {
+        let op = NamedOpaquePredicateOp::new("STARTS_WITH");
+        let args = vec![column_expr!("name"), Expression::literal("foo")];
+        let batch = three_file_batch();
+
+        let result = ArrowOpaquePredicateOp::eval_pred(&op, &args, &batch, false).unwrap();
+        assert_eq!(result.len(), 3);
+        assert!(result.is_null(0));
+        assert!(result.is_null(1));
+        assert!(result.is_null(2));
+    }
+
+    // Records the `inverted` flag and writes Skip on every row.
+    extern "C" fn inverted_recording_eval(
+        _state: *mut std::ffi::c_void,
+        _op_name: crate::KernelStringSlice,
+        _children: *const ChildAccessor<'_>,
+        _stats: *const BatchStatsAccessor<'_>,
+        n_rows: usize,
+        inverted: bool,
+        verdicts: *mut OpaquePruneVerdict,
+    ) {
+        SAW_INVERTED.with(|c| c.set(c.get() || inverted));
+        let slots = unsafe { std::slice::from_raw_parts_mut(verdicts, n_rows) };
+        for slot in slots.iter_mut() {
+            *slot = OpaquePruneVerdict::Skip;
+        }
+    }
+
+    thread_local! {
+        static SAW_INVERTED: Cell<bool> = const { Cell::new(false) };
+    }
+
+    fn inverted_recording_callbacks() -> Arc<OpaquePruningCallbacks> {
+        Arc::new(OpaquePruningCallbacks {
+            engine_state: std::ptr::null_mut(),
+            eval_against_stats: inverted_recording_eval,
+            free_state: no_op_free,
+        })
+    }
+
+    #[test]
+    fn eval_pred_forwards_inverted_flag_to_engine() {
+        SAW_INVERTED.with(|c| c.set(false));
+        let op =
+            NamedOpaquePredicateOp::with_callbacks("STARTS_WITH", inverted_recording_callbacks());
+        let args = vec![column_expr!("name"), Expression::literal("foo")];
+        let batch = three_file_batch();
+
+        let result = ArrowOpaquePredicateOp::eval_pred(&op, &args, &batch, true).unwrap();
+        assert_eq!(result.len(), 3);
+        for row in 0..3 {
+            assert!(!result.value(row), "row {row} should be skipped");
+        }
+        assert!(SAW_INVERTED.with(Cell::get));
+    }
+
+    #[test]
+    fn eval_pred_inverted_false_does_not_set_flag() {
+        SAW_INVERTED.with(|c| c.set(false));
+        let op =
+            NamedOpaquePredicateOp::with_callbacks("STARTS_WITH", inverted_recording_callbacks());
+        let args = vec![column_expr!("name"), Expression::literal("foo")];
+        let batch = three_file_batch();
+
+        ArrowOpaquePredicateOp::eval_pred(&op, &args, &batch, false).unwrap();
+        assert!(!SAW_INVERTED.with(Cell::get));
+    }
+
+    // === Verdict -> Option<bool> mapping ========================================
+
+    fn make_verdict_callbacks(verdict: OpaquePruneVerdict) -> Arc<OpaquePruningCallbacks> {
+        // Per-test verdict via a thread-local so the extern callback can read it.
+        VERDICT_TO_WRITE.with(|c| c.set(verdict));
+        Arc::new(OpaquePruningCallbacks {
+            engine_state: std::ptr::null_mut(),
+            eval_against_stats: verdict_eval,
+            free_state: no_op_free,
+        })
+    }
+
+    thread_local! {
+        static VERDICT_TO_WRITE: Cell<OpaquePruneVerdict> = const { Cell::new(OpaquePruneVerdict::Unknown) };
+    }
+
+    extern "C" fn verdict_eval(
+        _state: *mut std::ffi::c_void,
+        _op_name: crate::KernelStringSlice,
+        _children: *const ChildAccessor<'_>,
+        _stats: *const BatchStatsAccessor<'_>,
+        n_rows: usize,
+        _inverted: bool,
+        verdicts: *mut OpaquePruneVerdict,
+    ) {
+        let v = VERDICT_TO_WRITE.with(Cell::get);
+        let slots = unsafe { std::slice::from_raw_parts_mut(verdicts, n_rows) };
+        for slot in slots.iter_mut() {
+            *slot = v;
+        }
+    }
+
+    #[test]
+    fn eval_pred_maps_keep_verdict_to_true() {
+        let op = NamedOpaquePredicateOp::with_callbacks(
+            "STARTS_WITH",
+            make_verdict_callbacks(OpaquePruneVerdict::Keep),
+        );
+        let args = vec![column_expr!("name"), Expression::literal("foo")];
+        let batch = three_file_batch();
+
+        let result = ArrowOpaquePredicateOp::eval_pred(&op, &args, &batch, false).unwrap();
+        assert_eq!(result.len(), 3);
+        for row in 0..3 {
+            assert!(!result.is_null(row));
+            assert!(result.value(row));
+        }
+    }
+
+    #[test]
+    fn eval_pred_maps_unknown_verdict_to_null() {
+        let op = NamedOpaquePredicateOp::with_callbacks(
+            "STARTS_WITH",
+            make_verdict_callbacks(OpaquePruneVerdict::Unknown),
+        );
+        let args = vec![column_expr!("name"), Expression::literal("foo")];
+        let batch = three_file_batch();
+
+        let result = ArrowOpaquePredicateOp::eval_pred(&op, &args, &batch, false).unwrap();
+        assert_eq!(result.len(), 3);
+        for row in 0..3 {
+            assert!(result.is_null(row));
+        }
+    }
+
+    // === as_data_skipping_predicate branches ====================================
+    //
+    // The impl ignores the evaluator argument; we provide a stub that panics on
+    // any trait method to make that contract explicit.
+    struct PanickingEvaluator;
+    impl delta_kernel::kernel_predicates::DataSkippingPredicateEvaluator for PanickingEvaluator {
+        type Output = delta_kernel::expressions::Predicate;
+        type ColumnStat = delta_kernel::expressions::Expression;
+
+        fn get_min_stat(
+            &self,
+            _col: &delta_kernel::expressions::ColumnName,
+            _data_type: &delta_kernel::schema::DataType,
+        ) -> Option<Self::ColumnStat> {
+            unimplemented!()
+        }
+        fn get_max_stat(
+            &self,
+            _col: &delta_kernel::expressions::ColumnName,
+            _data_type: &delta_kernel::schema::DataType,
+        ) -> Option<Self::ColumnStat> {
+            unimplemented!()
+        }
+        fn get_nullcount_stat(
+            &self,
+            _col: &delta_kernel::expressions::ColumnName,
+        ) -> Option<Self::ColumnStat> {
+            unimplemented!()
+        }
+        fn get_rowcount_stat(&self) -> Option<Self::ColumnStat> {
+            unimplemented!()
+        }
+        fn eval_pred_scalar(
+            &self,
+            _val: &delta_kernel::expressions::Scalar,
+            _inverted: bool,
+        ) -> Option<Self::Output> {
+            unimplemented!()
+        }
+        fn eval_pred_scalar_is_null(
+            &self,
+            _val: &delta_kernel::expressions::Scalar,
+            _inverted: bool,
+        ) -> Option<Self::Output> {
+            unimplemented!()
+        }
+        fn eval_pred_is_null(
+            &self,
+            _col: &delta_kernel::expressions::ColumnName,
+            _inverted: bool,
+        ) -> Option<Self::Output> {
+            unimplemented!()
+        }
+        fn eval_pred_binary_scalars(
+            &self,
+            _op: delta_kernel::expressions::BinaryPredicateOp,
+            _left: &delta_kernel::expressions::Scalar,
+            _right: &delta_kernel::expressions::Scalar,
+            _inverted: bool,
+        ) -> Option<Self::Output> {
+            unimplemented!()
+        }
+        fn eval_pred_opaque(
+            &self,
+            _op: &delta_kernel::expressions::OpaquePredicateOpRef,
+            _exprs: &[delta_kernel::expressions::Expression],
+            _inverted: bool,
+        ) -> Option<Self::Output> {
+            unimplemented!()
+        }
+        fn finish_eval_pred_junction(
+            &self,
+            _op: delta_kernel::expressions::JunctionPredicateOp,
+            _preds: &mut dyn Iterator<Item = Option<Self::Output>>,
+            _inverted: bool,
+        ) -> Option<Self::Output> {
+            unimplemented!()
+        }
+        fn eval_partial_cmp(
+            &self,
+            _ord: std::cmp::Ordering,
+            _col: Self::ColumnStat,
+            _val: &delta_kernel::expressions::Scalar,
+            _inverted: bool,
+        ) -> Option<Self::Output> {
+            unimplemented!()
+        }
+    }
+
+    #[test]
+    fn as_data_skipping_predicate_without_callbacks_returns_none() {
+        let op = NamedOpaquePredicateOp::new("STARTS_WITH");
+        let evaluator: &dyn delta_kernel::kernel_predicates::DataSkippingPredicateEvaluator<
+            Output = delta_kernel::expressions::Predicate,
+            ColumnStat = delta_kernel::expressions::Expression,
+        > = &PanickingEvaluator;
+        let args = vec![column_expr!("name"), Expression::literal("foo")];
+        let result = <NamedOpaquePredicateOp as ArrowOpaquePredicateOp>::as_data_skipping_predicate(
+            &op, evaluator, &args, false,
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn as_data_skipping_predicate_not_inverted_returns_arrow_opaque() {
+        let op =
+            NamedOpaquePredicateOp::with_callbacks("STARTS_WITH", inverted_recording_callbacks());
+        let evaluator: &dyn delta_kernel::kernel_predicates::DataSkippingPredicateEvaluator<
+            Output = delta_kernel::expressions::Predicate,
+            ColumnStat = delta_kernel::expressions::Expression,
+        > = &PanickingEvaluator;
+        let args = vec![column_expr!("name"), Expression::literal("foo")];
+        let result =
+            <NamedOpaquePredicateOp as ArrowOpaquePredicateOp>::as_data_skipping_predicate(
+                &op, evaluator, &args, false,
+            )
+            .unwrap();
+        // `Predicate::arrow_opaque` produces an `Opaque` variant wrapping the
+        // arrow adaptor. Confirm the outer shape; the inner adaptor is module-private.
+        assert!(matches!(result, Predicate::Opaque(_)));
+    }
+
+    #[test]
+    fn as_data_skipping_predicate_inverted_wraps_with_not() {
+        let op =
+            NamedOpaquePredicateOp::with_callbacks("STARTS_WITH", inverted_recording_callbacks());
+        let evaluator: &dyn delta_kernel::kernel_predicates::DataSkippingPredicateEvaluator<
+            Output = delta_kernel::expressions::Predicate,
+            ColumnStat = delta_kernel::expressions::Expression,
+        > = &PanickingEvaluator;
+        let args = vec![column_expr!("name"), Expression::literal("foo")];
+        let result =
+            <NamedOpaquePredicateOp as ArrowOpaquePredicateOp>::as_data_skipping_predicate(
+                &op, evaluator, &args, true,
+            )
+            .unwrap();
+        // Inverted should wrap with `Not(Opaque(_))`.
+        match result {
+            Predicate::Not(inner) => {
+                assert!(matches!(*inner, Predicate::Opaque(_)));
+            }
+            other => panic!("expected Predicate::Not(Opaque(_)), got {other:?}"),
+        }
+    }
+}

--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -2,14 +2,19 @@
 //! engine's native expressions into kernel's [`Expression`] and [`Predicate`] types.
 use std::sync::Arc;
 
+#[cfg(feature = "default-engine-base")]
+use delta_kernel::engine::arrow_expression::opaque::ArrowOpaquePredicate;
 use delta_kernel::expressions::{
-    BinaryExpressionOp, BinaryPredicateOp, ColumnName, Expression, Predicate, Scalar,
-    UnaryPredicateOp,
+    BinaryExpressionOp, BinaryPredicateOp, ColumnName, Expression, JunctionPredicateOp, Predicate,
+    Scalar, UnaryPredicateOp,
 };
 use delta_kernel::schema::{DataType, PrimitiveType};
 use delta_kernel::DeltaResult;
 
-use crate::expressions::{SharedExpression, SharedPredicate};
+use crate::expressions::pruning::{OpaquePruningCallbacks, SharedOpaquePruningContext};
+use crate::expressions::{
+    NamedOpaqueExpressionOp, NamedOpaquePredicateOp, SharedExpression, SharedPredicate,
+};
 use crate::handle::Handle;
 use crate::scan::{EngineExpression, EnginePredicate};
 use crate::{
@@ -593,12 +598,170 @@ pub extern "C" fn visit_predicate_in(
     visit_predicate_binary(state, BinaryPredicateOp::In, a, b)
 }
 
+/// Build an opaque predicate `Predicate::Opaque(NamedOpaquePredicateOp(name), exprs)` from a
+/// name and a list of child expression IDs. Allows engines to push engine-defined predicates
+/// (e.g. `STARTS_WITH`, `LIKE`) through the kernel without registering a native Rust-side
+/// evaluator.
+///
+/// The resulting op opts out of every kernel-side pruning pass; the engine is responsible
+/// for filtering at row time. Engines that want kernel-side pruning should use
+/// [`visit_predicate_opaque_with_pruning`], which attaches [`OpaquePruningCallbacks`] to
+/// the op. Under `default-engine-base` the predicate is built so the default engine's
+/// Arrow batch evaluator dispatches `eval_pred`; without it, engines dispatch through
+/// their own `EvaluationHandler`.
+///
+/// [`OpaquePruningCallbacks`]: crate::expressions::pruning::OpaquePruningCallbacks
+///
+/// Each child ID is consumed from the visitor state (an ID can only be used once). Predicate
+/// IDs are auto-promoted into expressions, mirroring `Expression::from_pred`. Returns 0 if
+/// any child ID is invalid (already consumed, never created, or zero), matching the invariant
+/// of the binary `visit_predicate_*` builders. Remaining valid IDs are still drained from
+/// state in that case.
+///
+/// # Safety
+/// The string slice must be valid for the duration of the call.
+#[no_mangle]
+pub unsafe extern "C" fn visit_predicate_opaque(
+    state: &mut KernelExpressionVisitorState,
+    name: KernelStringSlice,
+    children: &mut EngineIterator,
+    allocate_error: AllocateErrorFn,
+) -> ExternResult<usize> {
+    let name = unsafe { String::try_from_slice(&name) };
+    visit_predicate_opaque_impl(state, name, children).into_extern_result(&allocate_error)
+}
+
+fn visit_predicate_opaque_impl(
+    state: &mut KernelExpressionVisitorState,
+    name: DeltaResult<String>,
+    children: &mut EngineIterator,
+) -> DeltaResult<usize> {
+    wrap_opaque_predicate_with_callbacks(state, name?, children.map(|child| child as usize), None)
+}
+
+/// Resolve child IDs in order and drain every one of them from the visitor
+/// state. Returns `None` if any id failed to resolve (already consumed,
+/// never created, or zero) -- opaque ops are not variadic, and silently
+/// shrinking the arity would corrupt the predicate.
+fn resolve_opaque_children<I: IntoIterator<Item = usize>>(
+    state: &mut KernelExpressionVisitorState,
+    child_ids: I,
+) -> Option<Vec<Expression>> {
+    let resolved: Vec<Option<Expression>> = child_ids
+        .into_iter()
+        .map(|id| unwrap_kernel_expression(state, id))
+        .collect();
+    if resolved.iter().any(Option::is_none) {
+        return None;
+    }
+    Some(resolved.into_iter().flatten().collect())
+}
+
+fn wrap_opaque_predicate_with_callbacks<I: IntoIterator<Item = usize>>(
+    state: &mut KernelExpressionVisitorState,
+    name: String,
+    child_ids: I,
+    callbacks: Option<Arc<OpaquePruningCallbacks>>,
+) -> DeltaResult<usize> {
+    let Some(exprs) = resolve_opaque_children(state, child_ids) else {
+        return Ok(0);
+    };
+    let op = match callbacks {
+        Some(cb) => NamedOpaquePredicateOp::with_callbacks(name, cb),
+        None => NamedOpaquePredicateOp::new(name),
+    };
+    Ok(wrap_predicate(state, Predicate::opaque(op, exprs)))
+}
+
+/// Build an opaque predicate with engine pruning callbacks attached.
+/// Kernel invokes `eval_against_stats` once per stats metadata batch during
+/// file pruning. The context is arc-cloned; multiple opaque ops in one
+/// query can share a single context handle.
+///
+/// # Safety
+/// The string slice must be valid for the duration of the call. `ctx` must
+/// be a valid handle produced by [`create_opaque_pruning_context`].
+///
+/// [`create_opaque_pruning_context`]: crate::expressions::pruning::create_opaque_pruning_context
+#[no_mangle]
+pub unsafe extern "C" fn visit_predicate_opaque_with_pruning(
+    state: &mut KernelExpressionVisitorState,
+    name: KernelStringSlice,
+    children: &mut EngineIterator,
+    ctx: Handle<SharedOpaquePruningContext>,
+    allocate_error: AllocateErrorFn,
+) -> ExternResult<usize> {
+    let name_str = unsafe { String::try_from_slice(&name) };
+    let callbacks = unsafe { ctx.clone_as_arc() };
+    visit_predicate_opaque_with_pruning_impl(state, name_str, children, callbacks)
+        .into_extern_result(&allocate_error)
+}
+
+fn visit_predicate_opaque_with_pruning_impl(
+    state: &mut KernelExpressionVisitorState,
+    name: DeltaResult<String>,
+    children: &mut EngineIterator,
+    callbacks: Arc<OpaquePruningCallbacks>,
+) -> DeltaResult<usize> {
+    let name = name?;
+    let child_ids: Vec<usize> = children.map(|child| child as usize).collect();
+    let Some(exprs) = resolve_opaque_children(state, child_ids) else {
+        return Ok(0);
+    };
+    let op = NamedOpaquePredicateOp::with_callbacks(name, callbacks);
+    // Default engine takes the `arrow_opaque` path so its batch evaluator can
+    // dispatch `eval_pred`; other engines fall back to plain `Opaque` and
+    // dispatch via their own `EvaluationHandler`.
+    #[cfg(feature = "default-engine-base")]
+    let pred = Predicate::arrow_opaque(op, exprs);
+    #[cfg(not(feature = "default-engine-base"))]
+    let pred = Predicate::opaque(op, exprs);
+    Ok(wrap_predicate(state, pred))
+}
+
+/// Build an opaque expression `Expression::Opaque(NamedOpaqueExpressionOp(name), exprs)`
+/// from a name and a list of child expression IDs. See [`NamedOpaqueExpressionOp`] for
+/// the partition-pruning / row-time evaluation contract.
+///
+/// Each child ID is consumed from the visitor state (an ID can only be used once).
+/// Predicate IDs are auto-promoted into expressions via `Expression::from_pred`.
+/// Returns 0 if any child ID is invalid (already consumed, never created, or zero);
+/// remaining valid IDs are still drained from state in that case.
+///
+/// # Safety
+/// `state`, `children`, and `allocate_error` must all be valid for the duration of the
+/// call. The `name` slice must be valid UTF-8 and live for the duration of the call.
+#[no_mangle]
+pub unsafe extern "C" fn visit_expression_opaque(
+    state: &mut KernelExpressionVisitorState,
+    name: KernelStringSlice,
+    children: &mut EngineIterator,
+    allocate_error: AllocateErrorFn,
+) -> ExternResult<usize> {
+    let name = unsafe { String::try_from_slice(&name) };
+    visit_expression_opaque_impl(state, name, children).into_extern_result(&allocate_error)
+}
+
+fn visit_expression_opaque_impl(
+    state: &mut KernelExpressionVisitorState,
+    name: DeltaResult<String>,
+    children: &mut EngineIterator,
+) -> DeltaResult<usize> {
+    let name = name?;
+    let Some(exprs) = resolve_opaque_children(state, children.map(|child| child as usize)) else {
+        return Ok(0);
+    };
+    Ok(wrap_expression(
+        state,
+        Expression::opaque(NamedOpaqueExpressionOp::new(name), exprs),
+    ))
+}
+
 #[no_mangle]
 pub extern "C" fn visit_predicate_or(
     state: &mut KernelExpressionVisitorState,
     children: &mut EngineIterator,
 ) -> usize {
-    use delta_kernel::expressions::JunctionPredicateOp;
     let result = Predicate::junction(
         JunctionPredicateOp::Or,
         children.flat_map(|child| unwrap_kernel_predicate(state, child as usize)),
@@ -909,5 +1072,209 @@ mod tests {
             visit_expression_literal_null_impl(&mut state, tag as u8, precision, scale).unwrap();
         let expr = unwrap_kernel_expression(&mut state, id).unwrap();
         assert_eq!(expr, Expression::literal(Scalar::Null(dt)));
+    }
+
+    // ============================================================================
+    // wrap_opaque_predicate_with_callbacks
+    // ============================================================================
+
+    fn wrap_opaque(
+        state: &mut KernelExpressionVisitorState,
+        name: &str,
+        child_ids: impl IntoIterator<Item = usize>,
+    ) -> usize {
+        wrap_opaque_predicate_with_callbacks(state, name.to_string(), child_ids, None).unwrap()
+    }
+
+    #[test]
+    fn opaque_predicate_round_trips_with_children() {
+        let mut state = KernelExpressionVisitorState::default();
+        let col_id = visit_expression_column_impl(&mut state, Ok("name")).unwrap();
+        let lit_id = wrap_expression(&mut state, Expression::literal("test"));
+
+        let pred_id = wrap_opaque(&mut state, "STARTS_WITH", [col_id, lit_id]);
+
+        let pred = unwrap_kernel_predicate(&mut state, pred_id).unwrap();
+        match pred {
+            Predicate::Opaque(opaque) => {
+                assert_eq!(opaque.op.name(), "STARTS_WITH");
+                assert_eq!(opaque.exprs.len(), 2);
+            }
+            other => panic!("expected Predicate::Opaque, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn opaque_predicate_returns_zero_on_invalid_child_id() {
+        let mut state = KernelExpressionVisitorState::default();
+        let col_id = visit_expression_column_impl(&mut state, Ok("name")).unwrap();
+        let bogus_id = 9999usize;
+
+        let pred_id = wrap_opaque(&mut state, "LIKE", [col_id, bogus_id]);
+        assert_eq!(
+            pred_id, 0,
+            "any invalid child must invalidate the predicate"
+        );
+    }
+
+    #[test]
+    fn opaque_predicate_accepts_empty_children() {
+        let mut state = KernelExpressionVisitorState::default();
+        let pred_id = wrap_opaque(&mut state, "ALWAYS_TRUE_OPAQUE", []);
+        let pred = unwrap_kernel_predicate(&mut state, pred_id).unwrap();
+        match pred {
+            Predicate::Opaque(opaque) => {
+                assert_eq!(opaque.op.name(), "ALWAYS_TRUE_OPAQUE");
+                assert!(opaque.exprs.is_empty());
+            }
+            other => panic!("expected Predicate::Opaque, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn opaque_predicate_promotes_predicate_typed_child_to_expression() {
+        // Mirrors unwrap_kernel_expression's Predicate -> Expression::from_pred arm: a
+        // predicate-typed child id is accepted as an expression child. We use
+        // `Predicate::eq` (a BinaryPredicate, not a BooleanExpression) so that
+        // Expression::from_pred wraps it as Expression::Predicate(Box(_)) instead of
+        // unwrapping it back to a literal.
+        let mut state = KernelExpressionVisitorState::default();
+        let inner_pred_id = wrap_predicate(
+            &mut state,
+            Predicate::eq(Expression::literal(1), Expression::literal(2)),
+        );
+        let pred_id = wrap_opaque(&mut state, "WRAPS_PRED", [inner_pred_id]);
+        let pred = unwrap_kernel_predicate(&mut state, pred_id).unwrap();
+        match pred {
+            Predicate::Opaque(opaque) => {
+                assert_eq!(opaque.exprs.len(), 1);
+                assert!(matches!(&opaque.exprs[0], Expression::Predicate(_)));
+            }
+            other => panic!("expected Predicate::Opaque, got {other:?}"),
+        }
+    }
+
+    // ============================================================================
+    // visit_expression_opaque_impl
+    // ============================================================================
+
+    fn wrap_opaque_expression(
+        state: &mut KernelExpressionVisitorState,
+        name: &str,
+        child_ids: impl IntoIterator<Item = usize>,
+    ) -> usize {
+        let Some(exprs) = resolve_opaque_children(state, child_ids) else {
+            return 0;
+        };
+        wrap_expression(
+            state,
+            Expression::opaque(NamedOpaqueExpressionOp::new(name), exprs),
+        )
+    }
+
+    #[test]
+    fn opaque_expression_round_trips_with_children() {
+        let mut state = KernelExpressionVisitorState::default();
+        let col_id = visit_expression_column_impl(&mut state, Ok("name")).unwrap();
+        let expr_id = wrap_opaque_expression(&mut state, "LOWER", [col_id]);
+
+        let expr = unwrap_kernel_expression(&mut state, expr_id).unwrap();
+        match expr {
+            Expression::Opaque(opaque) => {
+                assert_eq!(opaque.op.name(), "LOWER");
+                assert_eq!(opaque.exprs.len(), 1);
+            }
+            other => panic!("expected Expression::Opaque, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn opaque_expression_returns_zero_on_invalid_child_id() {
+        let mut state = KernelExpressionVisitorState::default();
+        let col_id = visit_expression_column_impl(&mut state, Ok("name")).unwrap();
+        let bogus_id = 9999usize;
+
+        let expr_id = wrap_opaque_expression(&mut state, "LOWER", [col_id, bogus_id]);
+        assert_eq!(
+            expr_id, 0,
+            "any invalid child must invalidate the expression"
+        );
+    }
+
+    #[test]
+    fn opaque_expression_accepts_empty_children() {
+        let mut state = KernelExpressionVisitorState::default();
+        let expr_id = wrap_opaque_expression(&mut state, "NOW", []);
+        let expr = unwrap_kernel_expression(&mut state, expr_id).unwrap();
+        match expr {
+            Expression::Opaque(opaque) => {
+                assert_eq!(opaque.op.name(), "NOW");
+                assert!(opaque.exprs.is_empty());
+            }
+            other => panic!("expected Expression::Opaque, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn opaque_expression_promotes_predicate_typed_child_to_expression() {
+        let mut state = KernelExpressionVisitorState::default();
+        let inner_pred_id = wrap_predicate(
+            &mut state,
+            Predicate::eq(Expression::literal(1), Expression::literal(2)),
+        );
+        let expr_id = wrap_opaque_expression(&mut state, "IF_TRUE_ELSE", [inner_pred_id]);
+        let expr = unwrap_kernel_expression(&mut state, expr_id).unwrap();
+        match expr {
+            Expression::Opaque(opaque) => {
+                assert_eq!(opaque.exprs.len(), 1);
+                assert!(matches!(&opaque.exprs[0], Expression::Predicate(_)));
+            }
+            other => panic!("expected Expression::Opaque, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn opaque_expression_nests_inside_opaque_expression() {
+        let mut state = KernelExpressionVisitorState::default();
+        let col_id = visit_expression_column_impl(&mut state, Ok("name")).unwrap();
+        let inner_id = wrap_opaque_expression(&mut state, "LOWER", [col_id]);
+        let outer_id = wrap_opaque_expression(&mut state, "LOWER", [inner_id]);
+
+        let expr = unwrap_kernel_expression(&mut state, outer_id).unwrap();
+        match expr {
+            Expression::Opaque(outer) => {
+                assert_eq!(outer.op.name(), "LOWER");
+                assert_eq!(outer.exprs.len(), 1);
+                match &outer.exprs[0] {
+                    Expression::Opaque(inner) => {
+                        assert_eq!(inner.op.name(), "LOWER");
+                        assert_eq!(inner.exprs.len(), 1);
+                        assert!(matches!(&inner.exprs[0], Expression::Column(_)));
+                    }
+                    other => panic!("expected inner Expression::Opaque, got {other:?}"),
+                }
+            }
+            other => panic!("expected outer Expression::Opaque, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn opaque_expression_can_nest_inside_opaque_predicate() {
+        // STARTS_WITH(LOWER(col), "foo")
+        let mut state = KernelExpressionVisitorState::default();
+        let col_id = visit_expression_column_impl(&mut state, Ok("name")).unwrap();
+        let lower_id = wrap_opaque_expression(&mut state, "LOWER", [col_id]);
+        let lit_id = wrap_expression(&mut state, Expression::literal("foo"));
+
+        let pred_id = wrap_opaque(&mut state, "STARTS_WITH", [lower_id, lit_id]);
+        let pred = unwrap_kernel_predicate(&mut state, pred_id).unwrap();
+        match pred {
+            Predicate::Opaque(opaque) => {
+                assert_eq!(opaque.op.name(), "STARTS_WITH");
+                assert_eq!(opaque.exprs.len(), 2);
+                assert!(matches!(&opaque.exprs[0], Expression::Opaque(_)));
+            }
+            other => panic!("expected Predicate::Opaque, got {other:?}"),
+        }
     }
 }

--- a/ffi/src/expressions/mod.rs
+++ b/ffi/src/expressions/mod.rs
@@ -1,9 +1,16 @@
 //! This module holds functionality for moving expressions across the FFI boundary, both from
 //! engine to kernel, and from kernel to engine.
 use std::ffi::c_void;
+use std::sync::Arc;
 
-use delta_kernel::expressions::{OpaqueExpressionOp, OpaquePredicateOp};
-use delta_kernel::{Expression, Predicate};
+use delta_kernel::expressions::{
+    OpaqueExpressionOp, OpaquePredicateOp, Scalar, ScalarExpressionEvaluator,
+};
+use delta_kernel::kernel_predicates::{
+    DirectDataSkippingPredicateEvaluator, DirectPredicateEvaluator,
+    IndirectDataSkippingPredicateEvaluator,
+};
+use delta_kernel::{DeltaResult, Error, Expression, Predicate};
 use delta_kernel_ffi_macros::handle_descriptor;
 
 use crate::handle::Handle;
@@ -11,6 +18,12 @@ use crate::{kernel_string_slice, KernelStringSlice};
 
 pub mod engine_visitor;
 pub mod kernel_visitor;
+pub mod pruning;
+
+#[cfg(feature = "default-engine-base")]
+mod arrow_pruning;
+
+use pruning::OpaquePruningCallbacks;
 
 #[handle_descriptor(target=Expression, mutable=false, sized=true)]
 pub struct SharedExpression;
@@ -88,4 +101,289 @@ pub unsafe extern "C" fn visit_kernel_opaque_predicate_op_name(
     let op = unsafe { op.as_ref() };
     let name = op.name();
     visit(data, kernel_string_slice!(name));
+}
+
+// === NamedOpaquePredicateOp ====================================================
+
+/// An [`OpaquePredicateOp`] that carries an engine-defined name and an
+/// optional reference to the engine's [`OpaquePruningCallbacks`].
+///
+/// Engine-side row-level evaluation is always required: kernel has no way
+/// to evaluate the op itself. With callbacks registered, kernel invokes
+/// `eval_against_stats` once per stats metadata batch during file pruning;
+/// without callbacks, the engine handles every row.
+///
+/// Partition pruning and parquet row-group skipping abstain for opaque ops
+/// -- kernel keeps every partition / row group.
+///
+/// [`OpaquePruningCallbacks`]: pruning::OpaquePruningCallbacks
+#[derive(Debug, Clone)]
+pub struct NamedOpaquePredicateOp {
+    name: String,
+    #[allow(dead_code)] // used under default-engine-base
+    callbacks: Option<Arc<OpaquePruningCallbacks>>,
+}
+
+impl NamedOpaquePredicateOp {
+    /// Build an op without callbacks. The engine is responsible for
+    /// row-time evaluation.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            callbacks: None,
+        }
+    }
+
+    /// Build an op that consults `callbacks` during file pruning.
+    pub(crate) fn with_callbacks(
+        name: impl Into<String>,
+        callbacks: Arc<OpaquePruningCallbacks>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            callbacks: Some(callbacks),
+        }
+    }
+
+    /// Op name as a `&str`.
+    #[cfg(feature = "default-engine-base")]
+    pub(crate) fn op_name(&self) -> &str {
+        &self.name
+    }
+
+    /// `true` if engine callbacks are registered.
+    #[cfg(feature = "default-engine-base")]
+    pub(crate) fn has_callbacks(&self) -> bool {
+        self.callbacks.is_some()
+    }
+
+    /// Clone the callback `Arc`, if any.
+    #[cfg(feature = "default-engine-base")]
+    pub(crate) fn callbacks_clone(&self) -> Option<Arc<OpaquePruningCallbacks>> {
+        self.callbacks.clone()
+    }
+}
+
+impl PartialEq for NamedOpaquePredicateOp {
+    fn eq(&self, other: &Self) -> bool {
+        // Identity is the op name; callbacks are engine-side bookkeeping.
+        self.name == other.name
+    }
+}
+
+impl Eq for NamedOpaquePredicateOp {}
+
+impl OpaquePredicateOp for NamedOpaquePredicateOp {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn eval_pred_scalar(
+        &self,
+        _eval_expr: &ScalarExpressionEvaluator<'_>,
+        _eval_pred: &DirectPredicateEvaluator<'_>,
+        _exprs: &[Expression],
+        _inverted: bool,
+    ) -> DeltaResult<Option<bool>> {
+        Ok(None)
+    }
+
+    fn eval_as_data_skipping_predicate(
+        &self,
+        _evaluator: &DirectDataSkippingPredicateEvaluator<'_>,
+        _exprs: &[Expression],
+        _inverted: bool,
+    ) -> Option<bool> {
+        None
+    }
+
+    fn as_data_skipping_predicate(
+        &self,
+        _evaluator: &IndirectDataSkippingPredicateEvaluator<'_>,
+        _exprs: &[Expression],
+        _inverted: bool,
+    ) -> Option<Predicate> {
+        // File pruning dispatch lives in arrow_pruning.rs (default-engine-base).
+        None
+    }
+}
+
+// === NamedOpaqueExpressionOp ===================================================
+
+/// An [`OpaqueExpressionOp`] that carries an engine-defined function name
+/// (e.g. `LOWER`, `UPPER`). Engines build these to push function calls
+/// through to their pruning callback, where the recursive
+/// [`OpaqueExpressionView`] accessor exposes the op's name and args.
+///
+/// `eval_expr_scalar` always returns `Err`, which is the spec-defined
+/// "abstain" shape per the [`OpaqueExpressionOp`] trait doc: kernel
+/// disqualifies the op from partition-level scalar evaluation, logs a
+/// `warn!`, and treats the expression as unknown. Row-time evaluation
+/// still routes through the engine's `EvaluationHandler`. Engines that
+/// need partition-level pruning for such functions must pre-evaluate on
+/// their side before handing the predicate to kernel.
+///
+/// [`OpaqueExpressionView`]: pruning::OpaqueExpressionView
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NamedOpaqueExpressionOp {
+    name: String,
+}
+
+impl NamedOpaqueExpressionOp {
+    /// Build an op identified by `name`.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self { name: name.into() }
+    }
+}
+
+impl OpaqueExpressionOp for NamedOpaqueExpressionOp {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn eval_expr_scalar(
+        &self,
+        _eval_expr: &ScalarExpressionEvaluator<'_>,
+        _exprs: &[Expression],
+    ) -> DeltaResult<Scalar> {
+        // Trait spec: `Err` disqualifies the op from partition pruning.
+        // Callers (kernel_predicates::mod) swallow this with `warn!`, so it
+        // does not propagate as a query error.
+        Err(Error::generic(format!(
+            "opaque FFI expression `{}` does not support scalar evaluation",
+            self.name,
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+    use std::cell::RefCell;
+    use std::ffi::c_void;
+
+    use super::*;
+    use crate::TryFromStringSlice;
+
+    #[test]
+    fn named_opaque_op_carries_name() {
+        let op = NamedOpaquePredicateOp::new("STARTS_WITH");
+        assert_eq!(op.name(), "STARTS_WITH");
+    }
+
+    #[test]
+    fn named_opaque_op_equality() {
+        let a = NamedOpaquePredicateOp::new("LIKE");
+        let b = NamedOpaquePredicateOp::new("LIKE");
+        let c = NamedOpaquePredicateOp::new("OTHER");
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn named_opaque_op_predicate_eq_compares_op_and_exprs() {
+        let pred_a = Predicate::opaque(
+            NamedOpaquePredicateOp::new("STARTS_WITH"),
+            [Expression::literal("a"), Expression::literal("b")],
+        );
+        let pred_b = Predicate::opaque(
+            NamedOpaquePredicateOp::new("STARTS_WITH"),
+            [Expression::literal("a"), Expression::literal("b")],
+        );
+        let pred_c = Predicate::opaque(
+            NamedOpaquePredicateOp::new("STARTS_WITH"),
+            [Expression::literal("a")],
+        );
+        let pred_d = Predicate::opaque(
+            NamedOpaquePredicateOp::new("LIKE"),
+            [Expression::literal("a"), Expression::literal("b")],
+        );
+        assert_eq!(pred_a, pred_b);
+        assert_ne!(pred_a, pred_c);
+        assert_ne!(pred_a, pred_d);
+    }
+
+    #[test]
+    fn named_opaque_op_round_trips_through_shared_handle() {
+        let pred = Predicate::opaque(
+            NamedOpaquePredicateOp::new("STARTS_WITH"),
+            [Expression::literal("test")],
+        );
+        let op_ref = match pred {
+            Predicate::Opaque(opaque) => opaque.op.clone(),
+            other => panic!("expected Predicate::Opaque, got {other:?}"),
+        };
+        let handle: Handle<SharedOpaquePredicateOp> = op_ref.into();
+
+        thread_local! {
+            static CAPTURED: RefCell<Option<String>> = const { RefCell::new(None) };
+        }
+        extern "C" fn capture(_data: *mut c_void, name: KernelStringSlice) {
+            // SAFETY: kernel guarantees `name` is valid for the duration of this call.
+            let s = unsafe { String::try_from_slice(&name) }.unwrap();
+            CAPTURED.with(|c| *c.borrow_mut() = Some(s));
+        }
+
+        // SAFETY: the handle is a valid SharedOpaquePredicateOp built above.
+        // `clone_handle` bumps the Arc so the visitor can consume one handle
+        // while we retain another to free.
+        unsafe {
+            let visit_copy = handle.clone_handle();
+            visit_kernel_opaque_predicate_op_name(visit_copy, std::ptr::null_mut(), capture);
+            free_kernel_opaque_predicate_op(handle);
+        }
+
+        let captured = CAPTURED.with(|c| c.borrow().clone());
+        assert_eq!(captured.as_deref(), Some("STARTS_WITH"));
+    }
+
+    #[test]
+    fn named_opaque_expression_op_carries_name() {
+        let op = NamedOpaqueExpressionOp::new("LOWER");
+        assert_eq!(op.name(), "LOWER");
+    }
+
+    #[test]
+    fn named_opaque_expression_op_equality() {
+        let a = NamedOpaqueExpressionOp::new("LOWER");
+        let b = NamedOpaqueExpressionOp::new("LOWER");
+        let c = NamedOpaqueExpressionOp::new("UPPER");
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn named_opaque_expression_op_round_trips_in_expression() {
+        let expr = Expression::opaque(
+            NamedOpaqueExpressionOp::new("LOWER"),
+            [Expression::column(["col"])],
+        );
+        let op_ref = match expr {
+            Expression::Opaque(opaque) => opaque.op.clone(),
+            other => panic!("expected Expression::Opaque, got {other:?}"),
+        };
+        let handle: Handle<SharedOpaqueExpressionOp> = op_ref.into();
+
+        thread_local! {
+            static CAPTURED: RefCell<Option<String>> = const { RefCell::new(None) };
+        }
+        extern "C" fn capture(_data: *mut c_void, name: KernelStringSlice) {
+            // SAFETY: kernel guarantees `name` is valid for the duration of this call.
+            let s = unsafe { String::try_from_slice(&name) }.unwrap();
+            CAPTURED.with(|c| *c.borrow_mut() = Some(s));
+        }
+
+        // SAFETY: the handle is a valid SharedOpaqueExpressionOp built above.
+        // `clone_handle` bumps the Arc so the visitor can consume one handle
+        // while we retain another to free.
+        unsafe {
+            let visit_copy = handle.clone_handle();
+            visit_kernel_opaque_expression_op_name(visit_copy, std::ptr::null_mut(), capture);
+            free_kernel_opaque_expression_op(handle);
+        }
+
+        let captured = CAPTURED.with(|c| c.borrow().clone());
+        assert_eq!(captured.as_deref(), Some("LOWER"));
+    }
 }

--- a/ffi/src/expressions/pruning/child.rs
+++ b/ffi/src/expressions/pruning/child.rs
@@ -1,0 +1,344 @@
+//! Child accessor for opaque-predicate arguments.
+//!
+//! The engine receives a [`ChildAccessor`] during pruning callbacks and uses
+//! [`child_accessor_kind`] to dispatch on shape, then the typed
+//! `child_accessor_*` getters to read the value.
+
+use delta_kernel::expressions::{Expression, Scalar};
+
+use crate::{kernel_string_slice, KernelStringSlice};
+
+/// Tag for the shape of an [`OpaqueExpressionView`].
+///
+/// Leaf kinds (`Column`, `Literal*`) can be read directly with the flat
+/// `child_accessor_*` getters or via the `expression_*_literal_*` /
+/// `expression_column_name` family. Compound kinds (`UnaryExpression`,
+/// `BinaryExpression`, `OpaqueExpression`, `Unknown`) carry a sub-tree --
+/// engines fetch it via [`child_accessor_subtree`] and walk with
+/// [`expression_kind`] and the shape-specific `expression_*` getters.
+///
+/// The enum is intentionally a closed set: variants kernel cannot map to a
+/// shape engines know how to read (e.g. `Expression::Predicate`,
+/// `Expression::Variadic`, struct/array/map literals) fall back to
+/// [`ExpressionKind::Unsupported`]. Engines treat `Unsupported` as
+/// "abstain" -- new variants can be added later without forcing a C-side
+/// recompile of engines that already opt out of unknown shapes.
+///
+/// [`OpaqueExpressionView`]: super::expression::OpaqueExpressionView
+/// [`child_accessor_subtree`]: super::expression::child_accessor_subtree
+/// [`expression_kind`]: super::expression::expression_kind
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExpressionKind {
+    /// Shape not recognized: multi-segment column refs, scalar types not
+    /// enumerated here, predicate-typed children, struct/array/map literals,
+    /// or compound shapes not yet wired through.
+    Unsupported = 0,
+    /// Single-segment column reference; read via
+    /// [`child_accessor_column_name`].
+    Column = 1,
+    /// String literal; read via [`child_accessor_literal_string`].
+    LiteralString = 2,
+    /// Integer literal widened to `i64`; read via
+    /// [`child_accessor_literal_long`].
+    LiteralLong = 3,
+    /// Floating-point literal widened to `f64`; read via
+    /// [`child_accessor_literal_double`].
+    LiteralDouble = 4,
+    /// Boolean literal; read via [`child_accessor_literal_bool`].
+    LiteralBool = 5,
+    /// SQL NULL literal of any type; no value to read.
+    LiteralNull = 6,
+    /// Unary expression (e.g. `to_json(...)`). Descend via
+    /// [`super::expression::child_accessor_subtree`].
+    UnaryExpression = 7,
+    /// Binary arithmetic expression (`+`, `-`, `*`, `/`). Descend via
+    /// [`super::expression::child_accessor_subtree`].
+    BinaryExpression = 8,
+    /// Engine-defined function call. Descend via
+    /// [`super::expression::child_accessor_subtree`].
+    OpaqueExpression = 9,
+    /// Placeholder kernel uses for engine-defined nodes it cannot
+    /// introspect. Read the carrier name via
+    /// [`super::expression::expression_unknown_name`].
+    Unknown = 10,
+}
+
+/// Read accessor over an opaque op's child expressions. Borrowed for the
+/// duration of the callback; engines must not retain it.
+pub struct ChildAccessor<'a> {
+    children: &'a [Expression],
+}
+
+impl<'a> ChildAccessor<'a> {
+    #[allow(dead_code)] // used under default-engine-base
+    pub(crate) fn new(children: &'a [Expression]) -> Self {
+        Self { children }
+    }
+
+    pub(super) fn child(&self, idx: usize) -> Option<&Expression> {
+        self.children.get(idx)
+    }
+}
+
+/// Borrow child `idx` from `acc`. Returns `None` for a null pointer or
+/// out-of-range index.
+///
+/// # Safety
+/// `acc` must either be null or point to a [`ChildAccessor`] valid for the
+/// surrounding callback.
+unsafe fn acc_child<'a>(acc: *const ChildAccessor<'a>, idx: usize) -> Option<&'a Expression> {
+    unsafe { acc.as_ref() }?.child(idx)
+}
+
+/// Map an [`Expression`] to its [`ExpressionKind`] tag.
+pub(super) fn expression_kind_of(expr: &Expression) -> ExpressionKind {
+    match expr {
+        Expression::Column(c) if c.path().len() == 1 => ExpressionKind::Column,
+        Expression::Literal(Scalar::String(_)) => ExpressionKind::LiteralString,
+        Expression::Literal(Scalar::Long(_) | Scalar::Integer(_))
+        | Expression::Literal(Scalar::Short(_) | Scalar::Byte(_)) => ExpressionKind::LiteralLong,
+        Expression::Literal(Scalar::Double(_) | Scalar::Float(_)) => ExpressionKind::LiteralDouble,
+        Expression::Literal(Scalar::Boolean(_)) => ExpressionKind::LiteralBool,
+        Expression::Literal(Scalar::Null(_)) => ExpressionKind::LiteralNull,
+        Expression::Unary(_) => ExpressionKind::UnaryExpression,
+        Expression::Binary(_) => ExpressionKind::BinaryExpression,
+        Expression::Opaque(_) => ExpressionKind::OpaqueExpression,
+        Expression::Unknown(_) => ExpressionKind::Unknown,
+        _ => ExpressionKind::Unsupported,
+    }
+}
+
+/// Number of children carried by the opaque op.
+///
+/// # Safety
+/// `acc` must be a valid pointer to a [`ChildAccessor`] valid for the
+/// current callback.
+#[no_mangle]
+pub unsafe extern "C" fn child_accessor_count(acc: *const ChildAccessor<'_>) -> usize {
+    unsafe { acc.as_ref() }.map_or(0, |a| a.children.len())
+}
+
+/// Returns the kind of the child at `idx`. Returns
+/// [`ExpressionKind::Unsupported`] if `idx` is out of range or the shape
+/// isn't recognized.
+///
+/// # Safety
+/// `acc` must be a valid pointer to a [`ChildAccessor`].
+#[no_mangle]
+pub unsafe extern "C" fn child_accessor_kind(acc: *const ChildAccessor<'_>, idx: usize) -> u32 {
+    let Some(child) = (unsafe { acc_child(acc, idx) }) else {
+        return ExpressionKind::Unsupported as u32;
+    };
+    expression_kind_of(child) as u32
+}
+
+/// Read the single-segment column name of child `idx`. Returns `false` if
+/// the child isn't a column or `idx` is out of range.
+///
+/// # Safety
+/// `acc` valid, `out` valid pointer.
+#[no_mangle]
+pub unsafe extern "C" fn child_accessor_column_name(
+    acc: *const ChildAccessor<'_>,
+    idx: usize,
+    out: *mut KernelStringSlice,
+) -> bool {
+    if out.is_null() {
+        return false;
+    }
+    let Some(Expression::Column(c)) = (unsafe { acc_child(acc, idx) }) else {
+        return false;
+    };
+    let path = c.path();
+    if path.len() != 1 {
+        return false;
+    }
+    let name = path[0].as_str();
+    unsafe { *out = kernel_string_slice!(name) };
+    true
+}
+
+/// Read a string-literal child.
+///
+/// # Safety
+/// `acc` valid, `out` valid pointer. The returned slice points into
+/// kernel-owned data valid for the callback's lifetime.
+#[no_mangle]
+pub unsafe extern "C" fn child_accessor_literal_string(
+    acc: *const ChildAccessor<'_>,
+    idx: usize,
+    out: *mut KernelStringSlice,
+) -> bool {
+    if out.is_null() {
+        return false;
+    }
+    let Some(Expression::Literal(Scalar::String(s))) = (unsafe { acc_child(acc, idx) }) else {
+        return false;
+    };
+    let view = s.as_str();
+    unsafe { *out = kernel_string_slice!(view) };
+    true
+}
+
+/// Read an integer-literal child as i64. Accepts any signed integer scalar
+/// (`Long`, `Integer`, `Short`, `Byte`), widened to i64.
+///
+/// # Safety
+/// `acc` valid, `out` valid pointer.
+#[no_mangle]
+pub unsafe extern "C" fn child_accessor_literal_long(
+    acc: *const ChildAccessor<'_>,
+    idx: usize,
+    out: *mut i64,
+) -> bool {
+    if out.is_null() {
+        return false;
+    }
+    let Some(value) = (unsafe { acc_child(acc, idx) }).and_then(literal_as_i64) else {
+        return false;
+    };
+    unsafe { *out = value };
+    true
+}
+
+/// Read a floating-point literal child as f64.
+///
+/// # Safety
+/// `acc` valid, `out` valid pointer.
+#[no_mangle]
+pub unsafe extern "C" fn child_accessor_literal_double(
+    acc: *const ChildAccessor<'_>,
+    idx: usize,
+    out: *mut f64,
+) -> bool {
+    if out.is_null() {
+        return false;
+    }
+    let Some(value) = (unsafe { acc_child(acc, idx) }).and_then(literal_as_f64) else {
+        return false;
+    };
+    unsafe { *out = value };
+    true
+}
+
+/// Read a boolean-literal child.
+///
+/// # Safety
+/// `acc` valid, `out` valid pointer.
+#[no_mangle]
+pub unsafe extern "C" fn child_accessor_literal_bool(
+    acc: *const ChildAccessor<'_>,
+    idx: usize,
+    out: *mut bool,
+) -> bool {
+    if out.is_null() {
+        return false;
+    }
+    let Some(Expression::Literal(Scalar::Boolean(v))) = (unsafe { acc_child(acc, idx) }) else {
+        return false;
+    };
+    unsafe { *out = *v };
+    true
+}
+
+/// Widen any signed integer literal to i64. Returns `None` for non-integer
+/// or non-literal expressions.
+pub(super) fn literal_as_i64(expr: &Expression) -> Option<i64> {
+    match expr {
+        Expression::Literal(Scalar::Long(v)) => Some(*v),
+        Expression::Literal(Scalar::Integer(v)) => Some(i64::from(*v)),
+        Expression::Literal(Scalar::Short(v)) => Some(i64::from(*v)),
+        Expression::Literal(Scalar::Byte(v)) => Some(i64::from(*v)),
+        _ => None,
+    }
+}
+
+/// Widen a floating-point literal to f64. Returns `None` for non-float
+/// or non-literal expressions.
+pub(super) fn literal_as_f64(expr: &Expression) -> Option<f64> {
+    match expr {
+        Expression::Literal(Scalar::Double(v)) => Some(*v),
+        Expression::Literal(Scalar::Float(v)) => Some(f64::from(*v)),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::panic)]
+
+    use std::ptr;
+
+    use delta_kernel::expressions::{column_expr, Expression};
+
+    use super::*;
+    use crate::TryFromStringSlice;
+
+    fn empty_slice() -> KernelStringSlice {
+        KernelStringSlice {
+            ptr: ptr::null(),
+            len: 0,
+        }
+    }
+
+    #[test]
+    fn child_accessor_reads_column_and_literal() {
+        let exprs = [column_expr!("name"), Expression::literal("foo")];
+        let acc = ChildAccessor::new(&exprs);
+
+        assert_eq!(unsafe { child_accessor_count(&acc) }, 2);
+        assert_eq!(
+            unsafe { child_accessor_kind(&acc, 0) },
+            ExpressionKind::Column as u32
+        );
+        assert_eq!(
+            unsafe { child_accessor_kind(&acc, 1) },
+            ExpressionKind::LiteralString as u32
+        );
+
+        let mut col_out = empty_slice();
+        assert!(unsafe { child_accessor_column_name(&acc, 0, &mut col_out) });
+        assert_eq!(unsafe { String::try_from_slice(&col_out) }.unwrap(), "name");
+
+        let mut lit_out = empty_slice();
+        assert!(unsafe { child_accessor_literal_string(&acc, 1, &mut lit_out) });
+        assert_eq!(unsafe { String::try_from_slice(&lit_out) }.unwrap(), "foo");
+    }
+
+    #[test]
+    fn child_accessor_rejects_wrong_kind() {
+        let exprs = [column_expr!("name"), Expression::literal("foo")];
+        let acc = ChildAccessor::new(&exprs);
+
+        let mut out = empty_slice();
+        assert!(!unsafe { child_accessor_column_name(&acc, 1, &mut out) });
+        assert!(!unsafe { child_accessor_literal_string(&acc, 0, &mut out) });
+        assert_eq!(
+            unsafe { child_accessor_kind(&acc, 99) },
+            ExpressionKind::Unsupported as u32
+        );
+    }
+
+    #[test]
+    fn child_accessor_reads_long_and_double() {
+        let exprs = [
+            Expression::literal(42_i64),
+            Expression::literal(2.5_f64),
+            Expression::literal(true),
+        ];
+        let acc = ChildAccessor::new(&exprs);
+
+        let mut long_out = 0_i64;
+        assert!(unsafe { child_accessor_literal_long(&acc, 0, &mut long_out) });
+        assert_eq!(long_out, 42);
+
+        let mut double_out = 0_f64;
+        assert!(unsafe { child_accessor_literal_double(&acc, 1, &mut double_out) });
+        assert_eq!(double_out, 2.5);
+
+        let mut bool_out = false;
+        assert!(unsafe { child_accessor_literal_bool(&acc, 2, &mut bool_out) });
+        assert!(bool_out);
+    }
+}

--- a/ffi/src/expressions/pruning/expression.rs
+++ b/ffi/src/expressions/pruning/expression.rs
@@ -1,0 +1,581 @@
+//! Recursive [`OpaqueExpressionView`] accessor for opaque-predicate sub-trees.
+//!
+//! Engines that need to introspect compound expressions (`Unary`, `Binary`,
+//! `Opaque`, `Unknown`) fetch a sub-tree pointer via
+//! [`child_accessor_subtree`] and walk it with [`expression_kind`] and the
+//! shape-specific `expression_*` getters.
+
+use delta_kernel::expressions::{BinaryExpressionOp, Expression, Scalar, UnaryExpressionOp};
+
+use super::child::{
+    expression_kind_of, literal_as_f64, literal_as_i64, ChildAccessor, ExpressionKind,
+};
+use crate::{kernel_string_slice, KernelStringSlice};
+
+/// Opaque pointer to a single [`Expression`] sub-tree. Valid only for the
+/// duration of the surrounding `eval_against_stats` callback; engines must
+/// not retain it.
+///
+/// Layout note: this type is `#[repr(transparent)]` over `Expression`
+/// *itself*, not over a reference. A prior shape
+/// `OpaqueExpressionView<'a>(&'a Expression)` segfaulted because
+/// `*const OpaqueExpressionView` then carried pointer-sized data, so the
+/// FFI deref read garbage instead of the `Expression`. Keep this struct
+/// transparent over the owned `Expression`.
+#[repr(transparent)]
+pub struct OpaqueExpressionView {
+    inner: Expression,
+}
+
+impl OpaqueExpressionView {
+    fn as_expr(&self) -> &Expression {
+        &self.inner
+    }
+}
+
+/// Cast a borrowed [`Expression`] to a `*const OpaqueExpressionView`.
+fn as_view(expr: &Expression) -> *const OpaqueExpressionView {
+    expr as *const Expression as *const OpaqueExpressionView
+}
+
+/// Borrow the wrapped [`Expression`]. Returns `None` for a null pointer.
+///
+/// # Safety
+/// `view` must either be null or point to a valid [`OpaqueExpressionView`]
+/// for the surrounding callback's lifetime.
+unsafe fn view_expr<'a>(view: *const OpaqueExpressionView) -> Option<&'a Expression> {
+    unsafe { view.as_ref() }.map(OpaqueExpressionView::as_expr)
+}
+
+/// Unary expression op tag. `Unsupported = 0` is the catch-all returned for
+/// null inputs, shape mismatches, or new kernel-side ops the engine hasn't
+/// been recompiled for -- engines treat it as opt-out, not a stable signal.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FfiUnaryExpressionOp {
+    Unsupported = 0,
+    ToJson = 1,
+}
+
+/// Binary expression op tag. See [`FfiUnaryExpressionOp`] for `Unsupported`
+/// semantics.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FfiBinaryExpressionOp {
+    Unsupported = 0,
+    Plus = 1,
+    Minus = 2,
+    Multiply = 3,
+    Divide = 4,
+}
+
+/// Hand back an [`OpaqueExpressionView`] for child `idx`. Returns null if
+/// the index is out of range or the accessor is null.
+///
+/// # Safety
+/// `acc` must be a valid [`ChildAccessor`] pointer if non-null. The
+/// returned pointer is valid for the surrounding callback's lifetime.
+#[no_mangle]
+pub unsafe extern "C" fn child_accessor_subtree(
+    acc: *const ChildAccessor<'_>,
+    idx: usize,
+) -> *const OpaqueExpressionView {
+    let Some(acc) = (unsafe { acc.as_ref() }) else {
+        return std::ptr::null();
+    };
+    acc.child(idx).map_or(std::ptr::null(), as_view)
+}
+
+/// Kind of the [`Expression`] referenced by `view`. Returns
+/// [`ExpressionKind::Unsupported`] for null input.
+///
+/// # Safety
+/// `view` must be a valid [`OpaqueExpressionView`] pointer if non-null.
+#[no_mangle]
+pub unsafe extern "C" fn expression_kind(view: *const OpaqueExpressionView) -> u32 {
+    let Some(expr) = (unsafe { view_expr(view) }) else {
+        return ExpressionKind::Unsupported as u32;
+    };
+    expression_kind_of(expr) as u32
+}
+
+/// Read a single-segment column name from `view` (if `expression_kind` is
+/// `Column`).
+///
+/// # Safety
+/// `view` valid, `out` valid pointer. The returned slice points into
+/// kernel-owned data valid for the callback's lifetime.
+#[no_mangle]
+pub unsafe extern "C" fn expression_column_name(
+    view: *const OpaqueExpressionView,
+    out: *mut KernelStringSlice,
+) -> bool {
+    if out.is_null() {
+        return false;
+    }
+    let Some(Expression::Column(c)) = (unsafe { view_expr(view) }) else {
+        return false;
+    };
+    let path = c.path();
+    if path.len() != 1 {
+        return false;
+    }
+    let name = path[0].as_str();
+    unsafe { *out = kernel_string_slice!(name) };
+    true
+}
+
+/// Read a string literal from `view`.
+///
+/// # Safety
+/// See [`expression_column_name`].
+#[no_mangle]
+pub unsafe extern "C" fn expression_literal_string(
+    view: *const OpaqueExpressionView,
+    out: *mut KernelStringSlice,
+) -> bool {
+    if out.is_null() {
+        return false;
+    }
+    let Some(Expression::Literal(Scalar::String(s))) = (unsafe { view_expr(view) }) else {
+        return false;
+    };
+    let view = s.as_str();
+    unsafe { *out = kernel_string_slice!(view) };
+    true
+}
+
+/// Read an integer literal as `i64`, widening narrower signed integer
+/// scalars.
+///
+/// # Safety
+/// See [`expression_column_name`].
+#[no_mangle]
+pub unsafe extern "C" fn expression_literal_long(
+    view: *const OpaqueExpressionView,
+    out: *mut i64,
+) -> bool {
+    if out.is_null() {
+        return false;
+    }
+    let Some(value) = (unsafe { view_expr(view) }).and_then(literal_as_i64) else {
+        return false;
+    };
+    unsafe { *out = value };
+    true
+}
+
+/// Read a floating-point literal as `f64`.
+///
+/// # Safety
+/// See [`expression_column_name`].
+#[no_mangle]
+pub unsafe extern "C" fn expression_literal_double(
+    view: *const OpaqueExpressionView,
+    out: *mut f64,
+) -> bool {
+    if out.is_null() {
+        return false;
+    }
+    let Some(value) = (unsafe { view_expr(view) }).and_then(literal_as_f64) else {
+        return false;
+    };
+    unsafe { *out = value };
+    true
+}
+
+/// Read a boolean literal.
+///
+/// # Safety
+/// See [`expression_column_name`].
+#[no_mangle]
+pub unsafe extern "C" fn expression_literal_bool(
+    view: *const OpaqueExpressionView,
+    out: *mut bool,
+) -> bool {
+    if out.is_null() {
+        return false;
+    }
+    let Some(Expression::Literal(Scalar::Boolean(v))) = (unsafe { view_expr(view) }) else {
+        return false;
+    };
+    unsafe { *out = *v };
+    true
+}
+
+/// Unary op tag for an `Expression::Unary`. Returns `Unsupported` for
+/// non-unary expressions or unrecognized ops.
+///
+/// # Safety
+/// `view` valid pointer.
+#[no_mangle]
+pub unsafe extern "C" fn expression_unary_op(view: *const OpaqueExpressionView) -> u32 {
+    let Some(Expression::Unary(u)) = (unsafe { view_expr(view) }) else {
+        return FfiUnaryExpressionOp::Unsupported as u32;
+    };
+    let op = match u.op {
+        UnaryExpressionOp::ToJson => FfiUnaryExpressionOp::ToJson,
+    };
+    op as u32
+}
+
+/// Sub-tree pointer for the child of an `Expression::Unary`. Returns null
+/// if `view` isn't unary.
+///
+/// # Safety
+/// `view` valid pointer.
+#[no_mangle]
+pub unsafe extern "C" fn expression_unary_child(
+    view: *const OpaqueExpressionView,
+) -> *const OpaqueExpressionView {
+    let Some(Expression::Unary(u)) = (unsafe { view_expr(view) }) else {
+        return std::ptr::null();
+    };
+    as_view(&u.expr)
+}
+
+/// Binary op tag for an `Expression::Binary`. Returns `Unsupported` for
+/// non-binary expressions.
+///
+/// # Safety
+/// `view` valid pointer.
+#[no_mangle]
+pub unsafe extern "C" fn expression_binary_op(view: *const OpaqueExpressionView) -> u32 {
+    let Some(Expression::Binary(b)) = (unsafe { view_expr(view) }) else {
+        return FfiBinaryExpressionOp::Unsupported as u32;
+    };
+    let op = match b.op {
+        BinaryExpressionOp::Plus => FfiBinaryExpressionOp::Plus,
+        BinaryExpressionOp::Minus => FfiBinaryExpressionOp::Minus,
+        BinaryExpressionOp::Multiply => FfiBinaryExpressionOp::Multiply,
+        BinaryExpressionOp::Divide => FfiBinaryExpressionOp::Divide,
+    };
+    op as u32
+}
+
+/// Left sub-tree of an `Expression::Binary`.
+///
+/// # Safety
+/// `view` valid pointer.
+#[no_mangle]
+pub unsafe extern "C" fn expression_binary_left(
+    view: *const OpaqueExpressionView,
+) -> *const OpaqueExpressionView {
+    let Some(Expression::Binary(b)) = (unsafe { view_expr(view) }) else {
+        return std::ptr::null();
+    };
+    as_view(&b.left)
+}
+
+/// Right sub-tree of an `Expression::Binary`.
+///
+/// # Safety
+/// `view` valid pointer.
+#[no_mangle]
+pub unsafe extern "C" fn expression_binary_right(
+    view: *const OpaqueExpressionView,
+) -> *const OpaqueExpressionView {
+    let Some(Expression::Binary(b)) = (unsafe { view_expr(view) }) else {
+        return std::ptr::null();
+    };
+    as_view(&b.right)
+}
+
+/// Read the op name of an `Expression::Opaque` (engine-defined function).
+///
+/// # Safety
+/// `view` valid, `out` valid pointer.
+#[no_mangle]
+pub unsafe extern "C" fn expression_opaque_name(
+    view: *const OpaqueExpressionView,
+    out: *mut KernelStringSlice,
+) -> bool {
+    if out.is_null() {
+        return false;
+    }
+    let Some(Expression::Opaque(o)) = (unsafe { view_expr(view) }) else {
+        return false;
+    };
+    let name = o.op.name();
+    unsafe { *out = kernel_string_slice!(name) };
+    true
+}
+
+/// Number of args carried by an `Expression::Opaque`.
+///
+/// # Safety
+/// `view` valid pointer.
+#[no_mangle]
+pub unsafe extern "C" fn expression_opaque_arg_count(view: *const OpaqueExpressionView) -> usize {
+    let Some(Expression::Opaque(o)) = (unsafe { view_expr(view) }) else {
+        return 0;
+    };
+    o.exprs.len()
+}
+
+/// Fetch arg `idx` of an `Expression::Opaque` as an [`OpaqueExpressionView`].
+/// Returns null if out of range or the expression isn't opaque.
+///
+/// # Safety
+/// `view` valid pointer.
+#[no_mangle]
+pub unsafe extern "C" fn expression_opaque_arg(
+    view: *const OpaqueExpressionView,
+    idx: usize,
+) -> *const OpaqueExpressionView {
+    let Some(Expression::Opaque(o)) = (unsafe { view_expr(view) }) else {
+        return std::ptr::null();
+    };
+    o.exprs.get(idx).map_or(std::ptr::null(), as_view)
+}
+
+/// Read the carrier name of an `Expression::Unknown`.
+///
+/// # Safety
+/// `view` valid, `out` valid pointer.
+#[no_mangle]
+pub unsafe extern "C" fn expression_unknown_name(
+    view: *const OpaqueExpressionView,
+    out: *mut KernelStringSlice,
+) -> bool {
+    if out.is_null() {
+        return false;
+    }
+    let Some(Expression::Unknown(name)) = (unsafe { view_expr(view) }) else {
+        return false;
+    };
+    let view = name.as_str();
+    unsafe { *out = kernel_string_slice!(view) };
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::panic)]
+
+    use std::ptr;
+
+    use delta_kernel::expressions::{column_expr, BinaryExpressionOp, Expression, Scalar};
+    use delta_kernel::schema::DataType;
+    use rstest::rstest;
+
+    use super::*;
+    use crate::TryFromStringSlice;
+
+    fn empty_slice() -> KernelStringSlice {
+        KernelStringSlice {
+            ptr: ptr::null(),
+            len: 0,
+        }
+    }
+
+    #[test]
+    fn child_accessor_recurses_into_binary_expression() {
+        let plus = Expression::binary(
+            BinaryExpressionOp::Plus,
+            column_expr!("col1"),
+            column_expr!("col2"),
+        );
+        let exprs = [plus, Expression::literal("foo")];
+        let acc = ChildAccessor::new(&exprs);
+
+        assert_eq!(
+            unsafe { super::super::child::child_accessor_kind(&acc, 0) },
+            ExpressionKind::BinaryExpression as u32
+        );
+
+        let sub = unsafe { child_accessor_subtree(&acc, 0) };
+        assert!(!sub.is_null());
+        assert_eq!(
+            unsafe { expression_kind(sub) },
+            ExpressionKind::BinaryExpression as u32
+        );
+        assert_eq!(
+            unsafe { expression_binary_op(sub) },
+            FfiBinaryExpressionOp::Plus as u32
+        );
+
+        let left = unsafe { expression_binary_left(sub) };
+        assert!(!left.is_null());
+        assert_eq!(
+            unsafe { expression_kind(left) },
+            ExpressionKind::Column as u32
+        );
+        let mut name = empty_slice();
+        assert!(unsafe { expression_column_name(left, &mut name) });
+        assert_eq!(unsafe { String::try_from_slice(&name) }.unwrap(), "col1");
+
+        let right = unsafe { expression_binary_right(sub) };
+        assert!(!right.is_null());
+        assert!(unsafe { expression_column_name(right, &mut name) });
+        assert_eq!(unsafe { String::try_from_slice(&name) }.unwrap(), "col2");
+    }
+
+    #[test]
+    fn child_accessor_subtree_returns_null_for_out_of_range() {
+        let exprs = [column_expr!("c")];
+        let acc = ChildAccessor::new(&exprs);
+        assert!(unsafe { child_accessor_subtree(&acc, 99) }.is_null());
+        assert!(unsafe { child_accessor_subtree(std::ptr::null(), 0) }.is_null());
+    }
+
+    #[test]
+    fn expression_unknown_carries_name() {
+        let exprs = [Expression::Unknown("mystery".to_string())];
+        let acc = ChildAccessor::new(&exprs);
+        let sub = unsafe { child_accessor_subtree(&acc, 0) };
+        assert_eq!(
+            unsafe { expression_kind(sub) },
+            ExpressionKind::Unknown as u32
+        );
+        let mut name = empty_slice();
+        assert!(unsafe { expression_unknown_name(sub, &mut name) });
+        assert_eq!(unsafe { String::try_from_slice(&name) }.unwrap(), "mystery");
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct FakeLowerOp;
+
+    impl delta_kernel::expressions::OpaqueExpressionOp for FakeLowerOp {
+        fn name(&self) -> &str {
+            "LOWER"
+        }
+        fn eval_expr_scalar(
+            &self,
+            _eval_expr: &delta_kernel::expressions::ScalarExpressionEvaluator<'_>,
+            _exprs: &[Expression],
+        ) -> delta_kernel::DeltaResult<Scalar> {
+            Ok(Scalar::Null(DataType::STRING))
+        }
+    }
+
+    #[test]
+    fn child_accessor_recurses_into_opaque_function_call() {
+        let lower_col = Expression::opaque(FakeLowerOp, [column_expr!("col")]);
+        let exprs = [lower_col, Expression::literal("abc")];
+        let acc = ChildAccessor::new(&exprs);
+
+        assert_eq!(
+            unsafe { super::super::child::child_accessor_kind(&acc, 0) },
+            ExpressionKind::OpaqueExpression as u32
+        );
+
+        let sub = unsafe { child_accessor_subtree(&acc, 0) };
+        assert!(!sub.is_null());
+        let mut name = empty_slice();
+        assert!(unsafe { expression_opaque_name(sub, &mut name) });
+        assert_eq!(unsafe { String::try_from_slice(&name) }.unwrap(), "LOWER");
+        assert_eq!(unsafe { expression_opaque_arg_count(sub) }, 1);
+
+        let inner = unsafe { expression_opaque_arg(sub, 0) };
+        assert!(!inner.is_null());
+        assert_eq!(
+            unsafe { expression_kind(inner) },
+            ExpressionKind::Column as u32
+        );
+        assert!(unsafe { expression_column_name(inner, &mut name) });
+        assert_eq!(unsafe { String::try_from_slice(&name) }.unwrap(), "col");
+    }
+
+    #[test]
+    fn expression_getters_reject_null_and_shape_mismatch() {
+        assert_eq!(
+            unsafe { expression_kind(ptr::null()) },
+            ExpressionKind::Unsupported as u32
+        );
+        assert!(unsafe { expression_binary_left(ptr::null()).is_null() });
+        assert!(unsafe { expression_opaque_arg(ptr::null(), 0).is_null() });
+        let mut name = empty_slice();
+        assert!(!unsafe { expression_column_name(ptr::null(), &mut name) });
+
+        let exprs = [column_expr!("c")];
+        let acc = ChildAccessor::new(&exprs);
+        let sub = unsafe { child_accessor_subtree(&acc, 0) };
+        assert!(unsafe { expression_binary_left(sub).is_null() });
+        assert_eq!(
+            unsafe { expression_binary_op(sub) },
+            FfiBinaryExpressionOp::Unsupported as u32
+        );
+        assert!(!unsafe { expression_opaque_name(sub, &mut name) });
+    }
+
+    // == widening: every signed integer scalar widens to i64 via the same getter ==
+
+    #[rstest]
+    #[case::long(Scalar::Long(i64::MIN), i64::MIN)]
+    #[case::integer(Scalar::Integer(-42), -42)]
+    #[case::short(Scalar::Short(-1), -1)]
+    #[case::byte(Scalar::Byte(-128), -128)]
+    fn expression_literal_long_widens_signed_integer_scalars(
+        #[case] scalar: Scalar,
+        #[case] expected: i64,
+    ) {
+        let exprs = [Expression::Literal(scalar)];
+        let acc = ChildAccessor::new(&exprs);
+        let sub = unsafe { child_accessor_subtree(&acc, 0) };
+        let mut out = 0_i64;
+        assert!(unsafe { expression_literal_long(sub, &mut out) });
+        assert_eq!(out, expected);
+    }
+
+    // == binary op tag: every BinaryExpressionOp variant maps to a distinct FFI tag ==
+
+    #[rstest]
+    #[case(BinaryExpressionOp::Plus, FfiBinaryExpressionOp::Plus)]
+    #[case(BinaryExpressionOp::Minus, FfiBinaryExpressionOp::Minus)]
+    #[case(BinaryExpressionOp::Multiply, FfiBinaryExpressionOp::Multiply)]
+    #[case(BinaryExpressionOp::Divide, FfiBinaryExpressionOp::Divide)]
+    fn expression_binary_op_round_trips_every_variant(
+        #[case] kernel_op: BinaryExpressionOp,
+        #[case] ffi_op: FfiBinaryExpressionOp,
+    ) {
+        let expr = Expression::binary(kernel_op, column_expr!("a"), column_expr!("b"));
+        let exprs = [expr];
+        let acc = ChildAccessor::new(&exprs);
+        let sub = unsafe { child_accessor_subtree(&acc, 0) };
+        assert_eq!(unsafe { expression_binary_op(sub) }, ffi_op as u32);
+    }
+
+    // == unary positive path: ToJson maps and the child sub-tree resolves ==
+
+    #[test]
+    fn expression_unary_to_json_round_trips_with_child() {
+        let inner = column_expr!("payload");
+        let unary = Expression::unary(UnaryExpressionOp::ToJson, inner);
+        let exprs = [unary];
+        let acc = ChildAccessor::new(&exprs);
+        let sub = unsafe { child_accessor_subtree(&acc, 0) };
+
+        assert_eq!(
+            unsafe { expression_kind(sub) },
+            ExpressionKind::UnaryExpression as u32
+        );
+        assert_eq!(
+            unsafe { expression_unary_op(sub) },
+            FfiUnaryExpressionOp::ToJson as u32
+        );
+
+        let child = unsafe { expression_unary_child(sub) };
+        assert!(!child.is_null());
+        assert_eq!(
+            unsafe { expression_kind(child) },
+            ExpressionKind::Column as u32
+        );
+        let mut name = empty_slice();
+        assert!(unsafe { expression_column_name(child, &mut name) });
+        assert_eq!(unsafe { String::try_from_slice(&name) }.unwrap(), "payload");
+    }
+
+    // == opaque arg out-of-range: returns null without UB ==
+
+    #[test]
+    fn expression_opaque_arg_returns_null_for_out_of_range() {
+        let opaque = Expression::opaque(FakeLowerOp, [column_expr!("c")]);
+        let exprs = [opaque];
+        let acc = ChildAccessor::new(&exprs);
+        let sub = unsafe { child_accessor_subtree(&acc, 0) };
+        assert_eq!(unsafe { expression_opaque_arg_count(sub) }, 1);
+        assert!(unsafe { expression_opaque_arg(sub, 1) }.is_null());
+        assert!(unsafe { expression_opaque_arg(sub, usize::MAX) }.is_null());
+    }
+}

--- a/ffi/src/expressions/pruning/mod.rs
+++ b/ffi/src/expressions/pruning/mod.rs
@@ -1,0 +1,301 @@
+//! Engine callback framework for opaque-predicate data skipping.
+//!
+//! Engines fill [`OpaquePruningCallbacks`] with an
+//! `eval_against_stats` callback, register them through
+//! [`create_opaque_pruning_context`], and attach the context to an opaque
+//! predicate via [`visit_predicate_opaque_with_pruning`]. Kernel invokes
+//! the callback once per stats metadata batch during file pruning; the
+//! engine writes one verdict per row.
+//!
+//! ## Contract
+//!
+//! - **Column names are physical.** Engines that build predicates from a logical (column-mapped)
+//!   schema must resolve to physical names before constructing the children, otherwise lookups
+//!   silently miss.
+//! - **Single-segment columns only.** [`ChildAccessor`] reports nested column refs (`a.b.c`) as
+//!   [`ExpressionKind::Unsupported`].
+//!
+//! [`visit_predicate_opaque_with_pruning`]: crate::expressions::kernel_visitor::visit_predicate_opaque_with_pruning
+
+use std::ffi::c_void;
+use std::sync::Arc;
+
+use delta_kernel_ffi_macros::handle_descriptor;
+
+use crate::handle::Handle;
+use crate::{kernel_string_slice, KernelStringSlice};
+
+mod child;
+mod expression;
+mod stats;
+
+pub use child::*;
+pub use expression::*;
+pub use stats::*;
+
+// === Verdict =================================================================
+
+/// Pruning verdict written by the engine.
+///
+/// `Unknown` is the zero value, so a default-initialized verdicts buffer is
+/// already "I don't know" -- engines that cannot evaluate the op leave the
+/// slot alone and kernel keeps the file conservatively.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpaquePruneVerdict {
+    /// Engine could not determine; keep conservatively.
+    Unknown = 0,
+    /// Predicate evaluates true; keep the file.
+    Keep = 1,
+    /// Predicate evaluates false; skip.
+    Skip = 2,
+}
+
+// === Callback ================================================================
+
+/// Per-batch file-pruning callback. Engine writes one verdict per row into
+/// `verdicts[0..n_rows]`. Slots are pre-initialized to
+/// [`OpaquePruneVerdict::Unknown`].
+pub type EvalAgainstStatsFn = extern "C" fn(
+    engine_state: *mut c_void,
+    op_name: KernelStringSlice,
+    children: *const ChildAccessor<'_>,
+    stats: *const BatchStatsAccessor<'_>,
+    n_rows: usize,
+    inverted: bool,
+    verdicts: *mut OpaquePruneVerdict,
+);
+
+/// Bundle of engine callbacks for opaque-predicate pruning.
+///
+/// If the same `engine_state` is shared across multiple
+/// [`create_opaque_pruning_context`] calls, the engine is responsible for
+/// ref-counting it so `free_state` only releases the underlying resource
+/// when the last context drops.
+#[repr(C)]
+#[derive(Debug)]
+pub struct OpaquePruningCallbacks {
+    /// Opaque engine state; passed back as the first argument to the
+    /// callback.
+    pub engine_state: *mut c_void,
+    /// File-pruning callback.
+    pub eval_against_stats: EvalAgainstStatsFn,
+    /// Destructor for `engine_state`. Called once when the last reference
+    /// to the pruning context is dropped; may run on any kernel thread.
+    pub free_state: extern "C" fn(engine_state: *mut c_void),
+}
+
+// SAFETY: `engine_state` and the function pointers may be touched from any
+// kernel thread. The struct lives behind `Arc<...>` via
+// `SharedOpaquePruningContext`, and `SharedHandle` requires `T: Sync`.
+unsafe impl Send for OpaquePruningCallbacks {}
+unsafe impl Sync for OpaquePruningCallbacks {}
+
+impl Drop for OpaquePruningCallbacks {
+    fn drop(&mut self) {
+        (self.free_state)(self.engine_state);
+    }
+}
+
+// === Shared context handle ===================================================
+
+#[handle_descriptor(target=OpaquePruningCallbacks, mutable=false, sized=true)]
+pub struct SharedOpaquePruningContext;
+
+/// Create a shared pruning context from a callback bundle.
+///
+/// # Safety
+/// All function pointers in `callbacks` must be valid. `engine_state` must
+/// be valid until `free_state` is invoked.
+#[no_mangle]
+pub unsafe extern "C" fn create_opaque_pruning_context(
+    callbacks: OpaquePruningCallbacks,
+) -> Handle<SharedOpaquePruningContext> {
+    Arc::new(callbacks).into()
+}
+
+/// Drop a pruning context handle. The engine's `free_state` fires when the
+/// last reference is released.
+///
+/// # Safety
+/// `ctx` must be a valid handle produced by `create_opaque_pruning_context`.
+#[no_mangle]
+pub unsafe extern "C" fn free_opaque_pruning_context(ctx: Handle<SharedOpaquePruningContext>) {
+    ctx.drop_handle();
+}
+
+// === Used by NamedOpaquePredicateOp ==========================================
+
+/// Invoke the engine's batched file-pruning callback once for an entire
+/// metadata batch.
+#[allow(dead_code)] // used under default-engine-base
+pub(crate) fn invoke_eval_against_stats(
+    cb: &OpaquePruningCallbacks,
+    op_name: &str,
+    children: &ChildAccessor<'_>,
+    stats: &BatchStatsAccessor<'_>,
+    inverted: bool,
+    verdicts: &mut [OpaquePruneVerdict],
+) {
+    (cb.eval_against_stats)(
+        cb.engine_state,
+        kernel_string_slice!(op_name),
+        children,
+        stats,
+        verdicts.len(),
+        inverted,
+        verdicts.as_mut_ptr(),
+    );
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    #![allow(clippy::unwrap_used, clippy::panic)]
+
+    use std::cell::Cell;
+    use std::ptr;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use delta_kernel::expressions::Expression;
+
+    use super::*;
+    use crate::TryFromStringSlice;
+
+    thread_local! {
+        pub(crate) static CALLBACK_LOG: Cell<Option<(String, bool)>> = const { Cell::new(None) };
+        pub(crate) static CALLBACK_VERDICT: Cell<OpaquePruneVerdict> = const { Cell::new(OpaquePruneVerdict::Unknown) };
+    }
+
+    pub(crate) extern "C" fn test_eval_against_stats(
+        _state: *mut c_void,
+        op_name: KernelStringSlice,
+        _children: *const ChildAccessor<'_>,
+        _stats: *const BatchStatsAccessor<'_>,
+        n_rows: usize,
+        inverted: bool,
+        verdicts: *mut OpaquePruneVerdict,
+    ) {
+        let name = unsafe { String::try_from_slice(&op_name) }.unwrap();
+        CALLBACK_LOG.with(|c| c.set(Some((name, inverted))));
+        let verdict = CALLBACK_VERDICT.with(Cell::get);
+        let slots = unsafe { std::slice::from_raw_parts_mut(verdicts, n_rows) };
+        for slot in slots.iter_mut() {
+            *slot = verdict;
+        }
+    }
+
+    pub(crate) extern "C" fn test_free_state(_state: *mut c_void) {}
+
+    pub(crate) fn build_test_callbacks() -> OpaquePruningCallbacks {
+        OpaquePruningCallbacks {
+            engine_state: ptr::null_mut(),
+            eval_against_stats: test_eval_against_stats,
+            free_state: test_free_state,
+        }
+    }
+
+    fn invoke_with_verdict(
+        op_name: &str,
+        inverted: bool,
+        n_rows: usize,
+    ) -> Vec<OpaquePruneVerdict> {
+        let cb = build_test_callbacks();
+        let stats = BatchStatsAccessor::new();
+        let exprs: Vec<Expression> = vec![];
+        let mut verdicts = vec![OpaquePruneVerdict::Unknown; n_rows];
+        invoke_eval_against_stats(
+            &cb,
+            op_name,
+            &ChildAccessor::new(&exprs),
+            &stats,
+            inverted,
+            &mut verdicts,
+        );
+        verdicts
+    }
+
+    #[test]
+    fn invoke_eval_against_stats_round_trips_name_and_inverted() {
+        CALLBACK_LOG.with(|c| c.set(None));
+        CALLBACK_VERDICT.with(|c| c.set(OpaquePruneVerdict::Skip));
+
+        let verdicts = invoke_with_verdict("STARTS_WITH", true, 1);
+        let logged = CALLBACK_LOG.with(Cell::take);
+        assert_eq!(logged, Some(("STARTS_WITH".to_string(), true)));
+        assert_eq!(verdicts[0], OpaquePruneVerdict::Skip);
+    }
+
+    #[test]
+    fn invoke_eval_against_stats_keep_verdict() {
+        CALLBACK_VERDICT.with(|c| c.set(OpaquePruneVerdict::Keep));
+        let verdicts = invoke_with_verdict("FOO", false, 1);
+        assert_eq!(verdicts[0], OpaquePruneVerdict::Keep);
+    }
+
+    #[test]
+    fn invoke_eval_against_stats_unknown_verdict_passes_through() {
+        CALLBACK_VERDICT.with(|c| c.set(OpaquePruneVerdict::Unknown));
+        let verdicts = invoke_with_verdict("FOO", false, 1);
+        assert_eq!(verdicts[0], OpaquePruneVerdict::Unknown);
+    }
+
+    // === Lifecycle tests for OpaquePruningCallbacks ============================
+
+    static FREE_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+    extern "C" fn counting_free_state(_state: *mut c_void) {
+        FREE_COUNT.fetch_add(1, Ordering::SeqCst);
+    }
+
+    extern "C" fn noop_eval(
+        _state: *mut c_void,
+        _op_name: KernelStringSlice,
+        _children: *const ChildAccessor<'_>,
+        _stats: *const BatchStatsAccessor<'_>,
+        _n_rows: usize,
+        _inverted: bool,
+        _verdicts: *mut OpaquePruneVerdict,
+    ) {
+    }
+
+    fn build_counting_callbacks() -> OpaquePruningCallbacks {
+        OpaquePruningCallbacks {
+            engine_state: ptr::null_mut(),
+            eval_against_stats: noop_eval,
+            free_state: counting_free_state,
+        }
+    }
+
+    #[test]
+    fn drop_callbacks_fires_free_state() {
+        FREE_COUNT.store(0, Ordering::SeqCst);
+        {
+            let _cb = build_counting_callbacks();
+            assert_eq!(FREE_COUNT.load(Ordering::SeqCst), 0);
+        }
+        assert_eq!(FREE_COUNT.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn create_then_free_pruning_context_fires_free_state_once() {
+        FREE_COUNT.store(0, Ordering::SeqCst);
+        let cb = build_counting_callbacks();
+        // SAFETY: callbacks are valid and engine_state is null.
+        let ctx = unsafe { create_opaque_pruning_context(cb) };
+        assert_eq!(FREE_COUNT.load(Ordering::SeqCst), 0);
+        // SAFETY: ctx was just produced by create_opaque_pruning_context.
+        unsafe { free_opaque_pruning_context(ctx) };
+        assert_eq!(FREE_COUNT.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn arc_shared_pruning_context_frees_only_on_last_drop() {
+        FREE_COUNT.store(0, Ordering::SeqCst);
+        let cb = Arc::new(build_counting_callbacks());
+        let cloned = Arc::clone(&cb);
+        drop(cb);
+        assert_eq!(FREE_COUNT.load(Ordering::SeqCst), 0);
+        drop(cloned);
+        assert_eq!(FREE_COUNT.load(Ordering::SeqCst), 1);
+    }
+}

--- a/ffi/src/expressions/pruning/stats.rs
+++ b/ffi/src/expressions/pruning/stats.rs
@@ -1,0 +1,57 @@
+//! Batch stats accessor handed to the engine during file pruning.
+//!
+//! Exposes the per-batch stats payload to the engine callback. Currently the
+//! only view is an Arrow-C-Data interface, gated on `default-engine-base`.
+
+#[cfg(feature = "default-engine-base")]
+use crate::engine_data::ArrowFFIData;
+
+/// Accessor handed to the engine during batched file pruning. Exposes an
+/// Arrow-C-Data view of the stats batch via [`batch_stats_as_arrow`]
+/// (`default-engine-base` only).
+pub struct BatchStatsAccessor<'a> {
+    /// Optional Arrow-C-Data view; consumed via [`batch_stats_as_arrow`].
+    #[cfg(feature = "default-engine-base")]
+    arrow_ffi: Option<ArrowFFIData>,
+    _phantom: std::marker::PhantomData<&'a ()>,
+}
+
+impl<'a> BatchStatsAccessor<'a> {
+    #[allow(dead_code)] // used under default-engine-base
+    pub(crate) fn new() -> Self {
+        Self {
+            #[cfg(feature = "default-engine-base")]
+            arrow_ffi: None,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    /// Attach the Arrow-C-Data view exposed via [`batch_stats_as_arrow`].
+    /// `None` leaves it unset.
+    #[cfg(feature = "default-engine-base")]
+    pub(crate) fn with_arrow_ffi(mut self, arrow_ffi: Option<ArrowFFIData>) -> Self {
+        self.arrow_ffi = arrow_ffi;
+        self
+    }
+}
+
+/// Arrow C Data Interface view of the stats batch. Pointer is valid for the
+/// surrounding `eval_against_stats` callback. Release callbacks are
+/// idempotent, so importing or not importing is both safe.
+///
+/// Returns null when the accessor isn't Arrow-backed.
+///
+/// # Safety
+/// `acc` must be a valid [`BatchStatsAccessor`] pointer if non-null.
+#[cfg(feature = "default-engine-base")]
+#[no_mangle]
+pub unsafe extern "C" fn batch_stats_as_arrow(
+    acc: *const BatchStatsAccessor<'_>,
+) -> *const ArrowFFIData {
+    let Some(acc) = (unsafe { acc.as_ref() }) else {
+        return std::ptr::null();
+    };
+    acc.arrow_ffi
+        .as_ref()
+        .map_or(std::ptr::null(), |d| d as *const _)
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds FFI surface for opaque predicate pruning for Arrow based connectors.

Providing a visit_predicate_opaque_with_pruning function that allows connectors to create a opaque predicate node and providing the relevant callback required for stats evaluation during log replay.

During stats eval on predicate op node, kernel exposes stats metadata batch as an `ArrowFFIData *` to the connector and the connector is responsible to write per-row verdicts back after evaluation. This preserves the EngineData batching mechanism and minimizes FFI crossing (one per batch).

Partition pruning and parquet row-group skipping abstain for opaque ops in this version — kernel keeps every partition / row group.

<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

## How was this change tested?
unit tests added