### PR TITLE
refactor: bundle kernel test helpers and small public-API additions

### DIFF
--- a/kernel/src/checkpoint/checkpoint_transform.rs
+++ b/kernel/src/checkpoint/checkpoint_transform.rs
@@ -138,8 +138,7 @@ pub(crate) fn build_checkpoint_read_schema(
     stats_schema: &StructType,
     partition_schema: Option<&StructType>,
 ) -> DeltaResult<SchemaRef> {
-    transform_add_schema(base_schema, |add_struct| {
-        // Validate fields aren't already present
+    let new_struct = base_schema.with_struct_at(&[ADD_NAME], |add_struct| {
         if add_struct.field(STATS_PARSED_FIELD).is_some() {
             return Err(Error::generic(
                 "stats_parsed field already exists in Add schema",
@@ -150,7 +149,7 @@ pub(crate) fn build_checkpoint_read_schema(
                 "partitionValues_parsed field already exists in Add schema",
             ));
         }
-        let mut result = add_struct.clone().with_field_inserted_after(
+        let mut result = add_struct.with_field_inserted_after(
             Some(STATS_FIELD),
             StructField::nullable(
                 STATS_PARSED_FIELD,
@@ -167,7 +166,8 @@ pub(crate) fn build_checkpoint_read_schema(
             )?;
         }
         Ok(result)
-    })
+    })?;
+    Ok(Arc::new(new_struct))
 }
 
 /// Builds the output schema based on configuration.
@@ -185,9 +185,10 @@ pub(crate) fn build_checkpoint_output_schema(
     stats_schema: &StructType,
     partition_schema: Option<&StructType>,
 ) -> DeltaResult<SchemaRef> {
-    transform_add_schema(base_schema, |add_struct| {
-        build_add_output_schema(config, add_struct, stats_schema, partition_schema)
-    })
+    let new_struct = base_schema.with_struct_at(&[ADD_NAME], |add_struct| {
+        build_add_output_schema(config, &add_struct, stats_schema, partition_schema)
+    })?;
+    Ok(Arc::new(new_struct))
 }
 
 // ========================
@@ -244,48 +245,6 @@ static STATS_JSON_EXPR: LazyLock<ExpressionRef> = LazyLock::new(|| {
         ),
     ]))
 });
-
-/// Transforms the Add action schema within a checkpoint schema.
-///
-/// This helper applies a transformation function to the Add struct and returns
-/// a new schema with the modified Add field.
-// TODO(https://github.com/delta-io/delta-kernel-rs/issues/1820): Replace manual field
-// iteration with StructType helper methods (e.g., with_field_inserted, with_field_removed).
-///
-/// # Errors
-///
-/// Returns an error if:
-/// - The `add` field is not found in the schema
-/// - The `add` field is not a struct type
-fn transform_add_schema(
-    base_schema: &StructType,
-    transform_fn: impl FnOnce(&StructType) -> DeltaResult<StructType>,
-) -> DeltaResult<SchemaRef> {
-    // Find and validate the add field
-    let add_field = base_schema
-        .field(ADD_NAME)
-        .ok_or_else(|| Error::generic("Expected 'add' field in checkpoint schema"))?;
-
-    let DataType::Struct(add_struct) = &add_field.data_type else {
-        return Err(Error::generic(format!(
-            "Expected 'add' field to be a struct type, got {:?}",
-            add_field.data_type
-        )));
-    };
-
-    let modified_add = transform_fn(add_struct)?;
-    let new_schema = base_schema.clone().with_field_replaced(
-        ADD_NAME,
-        StructField {
-            name: ADD_NAME.to_string(),
-            data_type: DataType::Struct(Box::new(modified_add)),
-            nullable: add_field.nullable,
-            metadata: add_field.metadata.clone(),
-        },
-    )?;
-
-    Ok(Arc::new(new_schema))
-}
 
 fn build_add_output_schema(
     config: &StatsTransformConfig,

--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -331,6 +331,23 @@ impl CheckpointWriter {
             checkpoint_output_schema: OnceLock::new(),
         })
     }
+
+    /// Returns the Arrow/engine checkpoint row schema after stats transforms for this snapshot.
+    ///
+    /// This matches the schema of rows yielded by [`Self::checkpoint_data`] after each batch has
+    /// [`crate::engine_data::FilteredEngineData::apply_selection_vector`] applied.
+    pub fn checkpoint_output_schema(&self, engine: &dyn Engine) -> DeltaResult<SchemaRef> {
+        let schema_context = self.checkpoint_schema_context(engine)?;
+        self.get_or_init_output_schema(|| {
+            build_checkpoint_output_schema(
+                &schema_context.stats_config,
+                &schema_context.checkpoint_base_schema,
+                &schema_context.stats_schema,
+                schema_context.partition_schema.as_deref(),
+            )
+        })
+    }
+
     /// Returns the cached output schema, initializing it with `f` on first call.
     ///
     /// `OnceLock::get_or_try_init` is unstable, so we use a custom implementation.

--- a/kernel/src/engine/arrow_utils.rs
+++ b/kernel/src/engine/arrow_utils.rs
@@ -1572,6 +1572,48 @@ pub(crate) fn json_arrow_schema(schema: &StructType) -> DeltaResult<ArrowSchema>
     Ok(ArrowSchema::try_from_kernel(&json_fields)?)
 }
 
+/// Walks `schema` along a dot-segment column path (e.g. `["add", "stats", "minValues"]`) and
+/// returns the resolved Arrow [`crate::arrow::datatypes::FieldRef`]. Each non-terminal segment must
+/// resolve to a struct type; mismatches or missing names produce an error containing the path
+/// traversed so far. Returns an error on an empty path, a missing top-level segment, a non-struct
+/// intermediate segment, or a missing child segment.
+pub fn resolve_field_path(
+    schema: &ArrowSchema,
+    path: &[&str],
+) -> DeltaResult<crate::arrow::datatypes::FieldRef> {
+    let Some((first, rest)) = path.split_first() else {
+        return Err(Error::generic("resolve_field_path: empty path"));
+    };
+    let first_field = schema
+        .field_with_name(first)
+        .map_err(|_| Error::generic(format!("resolve_field_path: schema has no field `{first}`")))?
+        .clone();
+    let mut current_ref: crate::arrow::datatypes::FieldRef = Arc::new(first_field);
+    let mut traversed: Vec<&str> = vec![first];
+    for segment in rest {
+        let crate::arrow::datatypes::DataType::Struct(fields) = current_ref.data_type() else {
+            return Err(Error::generic(format!(
+                "resolve_field_path: segment `{}` is not a struct at path `{}`",
+                traversed.last().copied().unwrap_or(""),
+                traversed.join(".")
+            )));
+        };
+        let child = fields
+            .iter()
+            .find(|f| f.name() == segment)
+            .ok_or_else(|| {
+                Error::generic(format!(
+                    "resolve_field_path: struct at `{}` has no child `{segment}`",
+                    traversed.join(".")
+                ))
+            })?
+            .clone();
+        traversed.push(segment);
+        current_ref = child;
+    }
+    Ok(current_ref)
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -1691,6 +1733,61 @@ mod tests {
             .set_column_metadata(vec![column_chunk])
             .build()
             .unwrap()
+    }
+
+    #[test]
+    fn test_resolve_field_path_walks_struct_chain() {
+        use crate::arrow::datatypes::{DataType as ADataType, Field as AField, Fields as AFields};
+        let expected_leaf = AField::new("minValues", ADataType::Int64, true);
+        let stats_fields = AFields::from(vec![expected_leaf.clone()]);
+        let add_fields = AFields::from(vec![AField::new(
+            "stats",
+            ADataType::Struct(stats_fields),
+            true,
+        )]);
+        let schema =
+            ArrowSchema::new(vec![AField::new("add", ADataType::Struct(add_fields), true)]);
+        let resolved = resolve_field_path(&schema, &["add", "stats", "minValues"]).unwrap();
+        // Compare the full Field (name + data_type + nullability + metadata): a partial
+        // (name, type)-only check would silently miss a regression that flipped nullability
+        // or stripped metadata while walking the chain.
+        assert_eq!(resolved.as_ref(), &expected_leaf);
+    }
+
+    #[test]
+    fn test_resolve_field_path_rejects_empty_path() {
+        let schema = ArrowSchema::empty();
+        let err = resolve_field_path(&schema, &[]).unwrap_err().to_string();
+        assert!(err.contains("empty path"), "got: {err}");
+    }
+
+    #[test]
+    fn test_resolve_field_path_reports_missing_top_level() {
+        use crate::arrow::datatypes::{DataType as ADataType, Field as AField};
+        let schema = ArrowSchema::new(vec![AField::new("present", ADataType::Int64, true)]);
+        let err = resolve_field_path(&schema, &["missing"]).unwrap_err().to_string();
+        assert!(err.contains("no field `missing`"), "got: {err}");
+    }
+
+    #[test]
+    fn test_resolve_field_path_rejects_non_struct_intermediate() {
+        use crate::arrow::datatypes::{DataType as ADataType, Field as AField};
+        let schema = ArrowSchema::new(vec![AField::new("leaf", ADataType::Int64, true)]);
+        let err = resolve_field_path(&schema, &["leaf", "child"])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("not a struct"), "got: {err}");
+    }
+
+    #[test]
+    fn test_resolve_field_path_reports_missing_struct_child() {
+        use crate::arrow::datatypes::{DataType as ADataType, Field as AField, Fields as AFields};
+        let inner = AFields::from(vec![AField::new("a", ADataType::Int64, true)]);
+        let schema = ArrowSchema::new(vec![AField::new("s", ADataType::Struct(inner), true)]);
+        let err = resolve_field_path(&schema, &["s", "missing"])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("no child `missing`"), "got: {err}");
     }
 
     #[test]

--- a/kernel/src/log_compaction/tests.rs
+++ b/kernel/src/log_compaction/tests.rs
@@ -2,24 +2,15 @@ use super::{should_compact, LogCompactionWriter, COMPACTION_ACTIONS_SCHEMA};
 use crate::action_reconciliation::RetentionCalculator;
 use crate::engine::sync::SyncEngine;
 use crate::snapshot::Snapshot;
+use crate::utils::test_utils::sync_engine_and_snapshot;
 use crate::SnapshotRef;
 
 fn create_mock_snapshot() -> SnapshotRef {
-    let path = std::fs::canonicalize(std::path::PathBuf::from(
-        "./tests/data/table-with-dv-small/",
-    ))
-    .unwrap();
-    let url = url::Url::from_directory_path(path).unwrap();
-    let engine = SyncEngine::new();
-    Snapshot::builder_for(url).build(&engine).unwrap()
+    sync_engine_and_snapshot("./tests/data/table-with-dv-small/").1
 }
 
 fn create_multi_version_snapshot() -> SnapshotRef {
-    let path =
-        std::fs::canonicalize(std::path::PathBuf::from("./tests/data/basic_partitioned/")).unwrap();
-    let url = url::Url::from_directory_path(path).unwrap();
-    let engine = SyncEngine::new();
-    Snapshot::builder_for(url).build(&engine).unwrap()
+    sync_engine_and_snapshot("./tests/data/basic_partitioned/").1
 }
 
 #[test]

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -889,58 +889,57 @@ impl LogSegment {
         let needs_sidecar = need_file_actions && !sidecar_files.is_empty();
         let needs_add_augmentation = has_stats_parsed || has_partition_values_parsed;
         let augmented_checkpoint_read_schema = if needs_add_augmentation || needs_sidecar {
-            let mut new_fields: Vec<StructField> = if let (true, Some(add_field)) =
-                (needs_add_augmentation, action_schema.field("add"))
-            {
-                let DataType::Struct(add_struct) = add_field.data_type() else {
-                    return Err(Error::internal_error(
-                        "add field in action schema must be a struct",
-                    ));
-                };
-                let mut add_fields: Vec<StructField> = add_struct.fields().cloned().collect();
-
-                if let (true, Some(ss)) = (has_stats_parsed, stats_schema) {
-                    add_fields.push(StructField::nullable(
-                        "stats_parsed",
-                        DataType::Struct(Box::new(ss.clone())),
-                    ));
-                }
-
-                if let (true, Some(ps)) = (has_partition_values_parsed, partition_schema) {
-                    add_fields.push(StructField::nullable(
-                        "partitionValues_parsed",
-                        DataType::Struct(Box::new(ps.clone())),
-                    ));
-                }
-
-                // Rebuild schema with modified add field
-                action_schema
-                    .fields()
-                    .map(|f| {
-                        if f.name() == "add" {
-                            StructField::new(
-                                add_field.name(),
-                                StructType::new_unchecked(add_fields.clone()),
-                                add_field.is_nullable(),
-                            )
-                            .with_metadata(add_field.metadata.clone())
-                        } else {
-                            f.clone()
+            let mut schema = action_schema.as_ref().clone();
+            // Augment the `add` child struct with parsed stats / partition values when the
+            // checkpoint advertises native typed columns. Schemas without an `add` field
+            // skip augmentation silently (sidecar still appends below). Schemas that
+            // already declare the parsed fields (e.g. the caller projected them in) reuse
+            // the existing definition rather than re-inserting; matches sidecar handling
+            // below and preserves idempotency on pre-augmented inputs.
+            if needs_add_augmentation {
+                if let Some(add_field) = action_schema.field("add") {
+                    if !matches!(add_field.data_type(), DataType::Struct(_)) {
+                        return Err(Error::internal_error(
+                            "add field in action schema must be a struct",
+                        ));
+                    }
+                    schema = schema.with_struct_at(&["add"], |mut add| {
+                        if let (true, Some(ss)) = (has_stats_parsed, stats_schema) {
+                            if add.field("stats_parsed").is_none() {
+                                add = add.with_field_inserted_after(
+                                    None,
+                                    StructField::nullable(
+                                        "stats_parsed",
+                                        DataType::Struct(Box::new(ss.clone())),
+                                    ),
+                                )?;
+                            }
                         }
-                    })
-                    .collect()
-            } else {
-                action_schema.fields().cloned().collect()
-            };
-
-            // Add sidecar column at top-level for V2 checkpoints
-            if needs_sidecar {
-                new_fields.push(StructField::nullable(SIDECAR_NAME, Sidecar::to_schema()));
+                        if let (true, Some(ps)) = (has_partition_values_parsed, partition_schema) {
+                            if add.field("partitionValues_parsed").is_none() {
+                                add = add.with_field_inserted_after(
+                                    None,
+                                    StructField::nullable(
+                                        "partitionValues_parsed",
+                                        DataType::Struct(Box::new(ps.clone())),
+                                    ),
+                                )?;
+                            }
+                        }
+                        Ok(add)
+                    })?;
+                }
             }
-
-            Arc::new(StructType::new_unchecked(new_fields))
+            // Schemas that already declare `sidecar` (e.g. when the caller projected
+            // it in) reuse the existing field; otherwise append it at the end.
+            if needs_sidecar && schema.field(SIDECAR_NAME).is_none() {
+                schema = schema.with_field_inserted_after(
+                    None,
+                    StructField::nullable(SIDECAR_NAME, Sidecar::to_schema()),
+                )?;
+            }
+            Arc::new(schema)
         } else {
-            // No modifications needed, use schema as-is
             action_schema.clone()
         };
 

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -3696,6 +3696,114 @@ async fn test_checkpoint_stream_sets_has_partition_values_parsed() -> DeltaResul
 }
 
 #[tokio::test]
+async fn test_checkpoint_stream_preserves_pre_augmented_add_fields() -> DeltaResult<()> {
+    // When the caller projects `add.stats_parsed` / `add.partitionValues_parsed` /
+    // `sidecar` into the read schema themselves, `create_checkpoint_stream` must
+    // reuse those fields instead of re-inserting (which would duplicate the column
+    // or last-writer-win their type definition). Pin the idempotent behavior so the
+    // augmentation loop can't regress to the pre-`with_struct_at` overwrite path.
+    let (store, log_root) = new_in_memory_store();
+    let engine = DefaultEngineBuilder::new(store.clone()).build();
+
+    let partition_parsed_struct =
+        StructType::new_unchecked([StructField::nullable("id", DataType::INTEGER)]);
+    let stats_parsed_struct = StructType::new_unchecked([
+        StructField::nullable("numRecords", DataType::LONG),
+    ]);
+    let add_struct = StructType::new_unchecked([
+        StructField::nullable("path", DataType::STRING),
+        StructField::nullable(
+            "partitionValues",
+            crate::schema::MapType::new(DataType::STRING, DataType::STRING, true),
+        ),
+        StructField::nullable("partitionValues_parsed", partition_parsed_struct.clone()),
+        StructField::nullable("stats_parsed", stats_parsed_struct.clone()),
+        StructField::nullable("size", DataType::LONG),
+        StructField::nullable("modificationTime", DataType::LONG),
+        StructField::nullable("dataChange", DataType::BOOLEAN),
+    ]);
+    let metadata_struct = StructType::new_unchecked([
+        StructField::nullable("id", DataType::STRING),
+        StructField::nullable(
+            "format",
+            StructType::new_unchecked([StructField::nullable("provider", DataType::STRING)]),
+        ),
+        StructField::nullable("schemaString", DataType::STRING),
+        StructField::nullable(
+            "partitionColumns",
+            crate::schema::ArrayType::new(DataType::STRING, false),
+        ),
+        StructField::nullable(
+            "configuration",
+            crate::schema::MapType::new(DataType::STRING, DataType::STRING, true),
+        ),
+        StructField::nullable("createdTime", DataType::LONG),
+    ]);
+    let checkpoint_schema: SchemaRef = Arc::new(StructType::new_unchecked([
+        StructField::nullable("add", add_struct.clone()),
+        StructField::nullable("metaData", metadata_struct),
+    ]));
+
+    add_checkpoint_to_store(
+        &store,
+        add_batch_with_partition_values_parsed(checkpoint_schema.clone()),
+        "00000000000000000001.checkpoint.parquet",
+    )
+    .await?;
+
+    let checkpoint_file = log_root
+        .join("00000000000000000001.checkpoint.parquet")?
+        .to_string();
+    let checkpoint_size =
+        get_file_size(&store, "_delta_log/00000000000000000001.checkpoint.parquet").await;
+
+    // Build a read schema that ALREADY contains `add.partitionValues_parsed` and
+    // `add.stats_parsed`. Augmentation must observe the pre-existing fields and
+    // skip the with_field_inserted_after call.
+    let read_schema: SchemaRef = Arc::new(StructType::new_unchecked([StructField::nullable(
+        "add",
+        add_struct,
+    )]));
+
+    let log_segment = LogSegment::try_new(
+        LogSegmentFiles {
+            checkpoint_parts: vec![create_log_path_with_size(&checkpoint_file, checkpoint_size)],
+            latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
+            ..Default::default()
+        },
+        log_root,
+        None,
+        None,
+    )?;
+
+    let checkpoint_result = log_segment.create_checkpoint_stream(
+        &engine,
+        read_schema,
+        None,
+        Some(&stats_parsed_struct),
+        Some(&partition_parsed_struct),
+    )?;
+
+    let schema = &checkpoint_result.checkpoint_info.checkpoint_read_schema;
+    let add_field = schema.field("add").expect("schema should have 'add' field");
+    let DataType::Struct(out_add) = add_field.data_type() else {
+        panic!("add field should be a struct");
+    };
+    // Both parsed fields appear exactly once and keep their caller-provided definitions.
+    let parsed_partition = out_add.fields().filter(|f| f.name == "partitionValues_parsed").count();
+    let parsed_stats = out_add.fields().filter(|f| f.name == "stats_parsed").count();
+    assert_eq!(
+        parsed_partition, 1,
+        "partitionValues_parsed must be deduplicated when already present"
+    );
+    assert_eq!(
+        parsed_stats, 1,
+        "stats_parsed must be deduplicated when already present"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_checkpoint_stream_no_partition_values_parsed_when_incompatible() -> DeltaResult<()> {
     let (store, log_root) = new_in_memory_store();
     let engine = DefaultEngineBuilder::new(store.clone()).build();

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -322,32 +322,16 @@ impl StateInfo {
             None => PhysicalPredicate::None,
         };
 
-        // Build partition schema with physical names for partition pruning in data skipping.
-        // Only needed when we have a predicate and partition columns.
-        // partition_columns stores logical names (per Delta protocol), so we zip the table's
-        // logical and physical schemas (same field ordering, guaranteed by `make_physical`)
-        // to match logical names and extract the corresponding physical fields without
-        // per-field metadata lookups.
-        let table_partition_schema = if !matches!(
+        // Partition schema for predicate-driven data skipping (`partitionValues_parsed`):
+        // gated on a non-empty physical predicate. The shared
+        // `partition_schema_with_physical_names` builder zips the logical/physical schemas
+        // by ordering (guaranteed by `make_physical`) and keeps partition-column fields.
+        let table_partition_schema = (!matches!(
             physical_predicate,
             PhysicalPredicate::None | PhysicalPredicate::StaticSkipAll
-        ) && !partition_columns.is_empty()
-        {
-            let partition_fields: Vec<StructField> = table_configuration
-                .logical_schema()
-                .fields()
-                .zip(table_configuration.physical_schema().fields())
-                .filter(|(logical_f, _)| partition_columns.contains(logical_f.name()))
-                .map(|(_, physical_f)| physical_f.clone())
-                .collect();
-            if partition_fields.is_empty() {
-                None
-            } else {
-                Some(Arc::new(StructType::new_unchecked(partition_fields)))
-            }
-        } else {
-            None
-        };
+        ))
+        .then(|| table_configuration.partition_schema_with_physical_names())
+        .flatten();
 
         let (physical_stats_schema, physical_partition_schema) = build_data_skipping_schemas(
             &stats_output_mode,

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -20,6 +20,7 @@ use crate::parquet::arrow::arrow_writer::ArrowWriter;
 use crate::scan::data_skipping::as_checkpoint_skipping_predicate;
 use crate::scan::state::ScanFile;
 use crate::schema::{ColumnMetadataKey, DataType, StructField, StructType};
+use crate::utils::test_utils::{sync_engine_and_snapshot, sync_engine_arc_and_snapshot};
 use crate::{
     Engine, EngineData, EvaluationHandler, FileDataReadResultIterator, FileMeta, JsonHandler,
     ParquetFooter, ParquetHandler, PredicateRef, Snapshot, StorageHandler,
@@ -353,12 +354,7 @@ fn get_files_for_scan(scan: Scan, engine: &dyn Engine) -> DeltaResult<Vec<String
 
 #[test]
 fn test_scan_metadata_paths() {
-    let path =
-        std::fs::canonicalize(PathBuf::from("./tests/data/table-without-dv-small/")).unwrap();
-    let url = url::Url::from_directory_path(path).unwrap();
-    let engine = SyncEngine::new();
-
-    let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
+    let (engine, snapshot) = sync_engine_and_snapshot("./tests/data/table-without-dv-small/");
     let scan = snapshot.scan_builder().build().unwrap();
     let files = get_files_for_scan(scan, &engine).unwrap();
     assert_eq!(files.len(), 1);
@@ -370,12 +366,7 @@ fn test_scan_metadata_paths() {
 
 #[test_log::test]
 fn test_scan_metadata() {
-    let path =
-        std::fs::canonicalize(PathBuf::from("./tests/data/table-without-dv-small/")).unwrap();
-    let url = url::Url::from_directory_path(path).unwrap();
-    let engine = Arc::new(SyncEngine::new());
-
-    let snapshot = Snapshot::builder_for(url).build(engine.as_ref()).unwrap();
+    let (engine, snapshot) = sync_engine_arc_and_snapshot("./tests/data/table-without-dv-small/");
     let scan = snapshot.scan_builder().build().unwrap();
     let files: Vec<Box<dyn EngineData>> = scan.execute(engine).unwrap().try_collect().unwrap();
 
@@ -386,12 +377,7 @@ fn test_scan_metadata() {
 
 #[test_log::test]
 fn test_scan_metadata_from_same_version() {
-    let path =
-        std::fs::canonicalize(PathBuf::from("./tests/data/table-without-dv-small/")).unwrap();
-    let url = url::Url::from_directory_path(path).unwrap();
-    let engine = Arc::new(SyncEngine::new());
-
-    let snapshot = Snapshot::builder_for(url).build(engine.as_ref()).unwrap();
+    let (engine, snapshot) = sync_engine_arc_and_snapshot("./tests/data/table-without-dv-small/");
     let version = snapshot.version();
     let scan = snapshot.scan_builder().build().unwrap();
     let files: Vec<_> = scan
@@ -517,11 +503,7 @@ fn test_get_partition_value() {
 
 #[test]
 fn test_replay_for_scan_metadata() {
-    let path = std::fs::canonicalize(PathBuf::from("./tests/data/parquet_row_group_skipping/"));
-    let url = url::Url::from_directory_path(path.unwrap()).unwrap();
-    let engine = SyncEngine::new();
-
-    let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
+    let (engine, snapshot) = sync_engine_and_snapshot("./tests/data/parquet_row_group_skipping/");
     let scan = snapshot.scan_builder().build().unwrap();
     let result = scan.replay_for_scan_metadata(&engine).unwrap();
     let data: Vec<_> = result.actions.try_collect().unwrap();
@@ -534,11 +516,8 @@ fn test_replay_for_scan_metadata() {
 
 #[test]
 fn test_data_row_group_skipping() {
-    let path = std::fs::canonicalize(PathBuf::from("./tests/data/parquet_row_group_skipping/"));
-    let url = url::Url::from_directory_path(path.unwrap()).unwrap();
-    let engine = Arc::new(SyncEngine::new());
-
-    let snapshot = Snapshot::builder_for(url).build(engine.as_ref()).unwrap();
+    let (engine, snapshot) =
+        sync_engine_arc_and_snapshot("./tests/data/parquet_row_group_skipping/");
 
     // No predicate pushdown attempted, so the one data file should be returned.
     //
@@ -577,11 +556,8 @@ fn test_data_row_group_skipping() {
 
 #[test]
 fn test_missing_column_row_group_skipping() {
-    let path = std::fs::canonicalize(PathBuf::from("./tests/data/parquet_row_group_skipping/"));
-    let url = url::Url::from_directory_path(path.unwrap()).unwrap();
-    let engine = Arc::new(SyncEngine::new());
-
-    let snapshot = Snapshot::builder_for(url).build(engine.as_ref()).unwrap();
+    let (engine, snapshot) =
+        sync_engine_arc_and_snapshot("./tests/data/parquet_row_group_skipping/");
 
     // Predicate over a logically valid but physically missing column. No data files should be
     // returned because the column is inferred to be all-null.
@@ -609,14 +585,8 @@ fn test_missing_column_row_group_skipping() {
 
 #[test_log::test]
 fn test_scan_with_checkpoint() -> DeltaResult<()> {
-    let path = std::fs::canonicalize(PathBuf::from(
-        "./tests/data/with_checkpoint_no_last_checkpoint/",
-    ))?;
-
-    let url = url::Url::from_directory_path(path).unwrap();
-    let engine = SyncEngine::new();
-
-    let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
+    let (engine, snapshot) =
+        sync_engine_and_snapshot("./tests/data/with_checkpoint_no_last_checkpoint/");
     let scan = snapshot.scan_builder().build()?;
     let files = get_files_for_scan(scan, &engine)?;
     // test case:
@@ -666,10 +636,7 @@ fn assert_stats_struct_matches_json(
 fn test_scan_metadata_with_stats_columns() {
     const STATS_PARSED_COL: &str = "stats_parsed";
 
-    let path = std::fs::canonicalize(PathBuf::from("./tests/data/parsed-stats/")).unwrap();
-    let url = url::Url::from_directory_path(path).unwrap();
-    let engine = Arc::new(SyncEngine::new());
-    let snapshot = Snapshot::builder_for(url).build(engine.as_ref()).unwrap();
+    let (engine, snapshot) = sync_engine_arc_and_snapshot("./tests/data/parsed-stats/");
 
     let scan = snapshot
         .scan_builder()
@@ -767,11 +734,7 @@ fn test_scan_metadata_with_stats_columns() {
 fn test_scan_metadata_stats_columns_with_predicate() {
     const STATS_PARSED_COL: &str = "stats_parsed";
 
-    let path = std::fs::canonicalize(PathBuf::from("./tests/data/parsed-stats/")).unwrap();
-    let url = url::Url::from_directory_path(path).unwrap();
-    let engine = Arc::new(SyncEngine::new());
-
-    let snapshot = Snapshot::builder_for(url).build(engine.as_ref()).unwrap();
+    let (engine, snapshot) = sync_engine_arc_and_snapshot("./tests/data/parsed-stats/");
 
     // Build scan with both a predicate and stats_columns
     let predicate = Arc::new(column_expr!("id").gt(Expr::literal(0i64)));
@@ -853,10 +816,7 @@ fn test_prefix_columns_simple() {
 
 #[test]
 fn test_build_actions_meta_predicate_with_predicate() {
-    let path = std::fs::canonicalize(PathBuf::from("./tests/data/parsed-stats/")).unwrap();
-    let url = url::Url::from_directory_path(path).unwrap();
-    let engine = SyncEngine::new();
-    let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
+    let (_engine, snapshot) = sync_engine_and_snapshot("./tests/data/parsed-stats/");
 
     // Build a scan with a predicate eligible for data skipping
     let predicate = Arc::new(Pred::gt(column_expr!("id"), Expr::literal(400i64)));
@@ -889,10 +849,7 @@ fn test_build_actions_meta_predicate_with_predicate() {
 
 #[test]
 fn test_build_actions_meta_predicate_no_predicate() {
-    let path = std::fs::canonicalize(PathBuf::from("./tests/data/parsed-stats/")).unwrap();
-    let url = url::Url::from_directory_path(path).unwrap();
-    let engine = SyncEngine::new();
-    let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
+    let (_engine, snapshot) = sync_engine_and_snapshot("./tests/data/parsed-stats/");
 
     // Build a scan with no predicate
     let scan = snapshot.scan_builder().build().unwrap();
@@ -905,10 +862,7 @@ fn test_build_actions_meta_predicate_no_predicate() {
 
 #[test]
 fn test_build_actions_meta_predicate_static_skip_all() {
-    let path = std::fs::canonicalize(PathBuf::from("./tests/data/parsed-stats/")).unwrap();
-    let url = url::Url::from_directory_path(path).unwrap();
-    let engine = SyncEngine::new();
-    let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
+    let (_engine, snapshot) = sync_engine_and_snapshot("./tests/data/parsed-stats/");
 
     // A predicate that statically evaluates to false should produce StaticSkipAll,
     // which means build_actions_meta_predicate returns None.
@@ -1143,10 +1097,7 @@ fn test_checkpoint_row_group_skipping(
 
 #[test]
 fn test_skip_stats_disables_data_skipping() {
-    let path = std::fs::canonicalize(PathBuf::from("./tests/data/parsed-stats/")).unwrap();
-    let url = url::Url::from_directory_path(path).unwrap();
-    let engine = Arc::new(SyncEngine::new());
-    let snapshot = Snapshot::builder_for(url).build(engine.as_ref()).unwrap();
+    let (engine, snapshot) = sync_engine_arc_and_snapshot("./tests/data/parsed-stats/");
 
     let predicate = Arc::new(Pred::gt(column_expr!("id"), Expr::literal(400i64)));
     let scan = snapshot
@@ -1178,10 +1129,7 @@ fn test_skip_stats_disables_data_skipping() {
 fn test_skip_stats_after_include_all_stats_columns_wins() {
     // With StatsOutputMode enum, last call wins. Calling with_skip_stats(true) after
     // include_all_stats_columns() should result in stats being skipped.
-    let path = std::fs::canonicalize(PathBuf::from("./tests/data/parsed-stats/")).unwrap();
-    let url = url::Url::from_directory_path(path).unwrap();
-    let engine = Arc::new(SyncEngine::new());
-    let snapshot = Snapshot::builder_for(url).build(engine.as_ref()).unwrap();
+    let (engine, snapshot) = sync_engine_arc_and_snapshot("./tests/data/parsed-stats/");
 
     let predicate = Arc::new(Pred::gt(column_expr!("id"), Expr::literal(400i64)));
     let scan = snapshot
@@ -1214,10 +1162,7 @@ fn test_skip_stats_after_include_all_stats_columns_wins() {
 #[test]
 fn test_with_stats_columns_empty_no_stats_output() {
     // with_stats_columns(vec![]) should produce no stats output
-    let path = std::fs::canonicalize(PathBuf::from("./tests/data/parsed-stats/")).unwrap();
-    let url = url::Url::from_directory_path(path).unwrap();
-    let engine = Arc::new(SyncEngine::new());
-    let snapshot = Snapshot::builder_for(url).build(engine.as_ref()).unwrap();
+    let (engine, snapshot) = sync_engine_arc_and_snapshot("./tests/data/parsed-stats/");
 
     let scan = snapshot
         .scan_builder()
@@ -1254,10 +1199,7 @@ fn test_with_stats_columns_empty_no_stats_output() {
 /// Verifies that requesting `vec![col!("id")]` only includes `id` in minValues/maxValues/nullCount.
 #[test]
 fn test_scan_metadata_with_specific_stats_columns() {
-    let path = std::fs::canonicalize(PathBuf::from("./tests/data/parsed-stats/")).unwrap();
-    let url = url::Url::from_directory_path(path).unwrap();
-    let engine = Arc::new(SyncEngine::new());
-    let snapshot = Snapshot::builder_for(url).build(engine.as_ref()).unwrap();
+    let (engine, snapshot) = sync_engine_arc_and_snapshot("./tests/data/parsed-stats/");
 
     // Request only "id" column stats
     let scan = snapshot
@@ -1312,10 +1254,7 @@ fn test_scan_metadata_with_specific_stats_columns() {
 /// Test that `with_stats_columns` with multiple specific columns returns stats for all of them.
 #[test]
 fn test_scan_metadata_with_multiple_stats_columns() {
-    let path = std::fs::canonicalize(PathBuf::from("./tests/data/parsed-stats/")).unwrap();
-    let url = url::Url::from_directory_path(path).unwrap();
-    let engine = Arc::new(SyncEngine::new());
-    let snapshot = Snapshot::builder_for(url).build(engine.as_ref()).unwrap();
+    let (engine, snapshot) = sync_engine_arc_and_snapshot("./tests/data/parsed-stats/");
 
     // Request "id" and "name" column stats (not "age" or "salary")
     let scan = snapshot
@@ -1382,10 +1321,7 @@ fn test_scan_metadata_with_multiple_stats_columns() {
 /// column.
 #[test]
 fn test_scan_metadata_with_nonexistent_stats_columns() {
-    let path = std::fs::canonicalize(PathBuf::from("./tests/data/parsed-stats/")).unwrap();
-    let url = url::Url::from_directory_path(path).unwrap();
-    let engine = Arc::new(SyncEngine::new());
-    let snapshot = Snapshot::builder_for(url).build(engine.as_ref()).unwrap();
+    let (engine, snapshot) = sync_engine_arc_and_snapshot("./tests/data/parsed-stats/");
 
     let scan = snapshot
         .scan_builder()

--- a/kernel/src/scan/transform_spec.rs
+++ b/kernel/src/scan/transform_spec.rs
@@ -109,6 +109,24 @@ pub(crate) fn parse_partition_values(
         .try_collect()
 }
 
+/// Canonical RowId materialization shape: `coalesce(materialized_col, base_row_id +
+/// row_index_col)`. Shared by [`get_transform_expr`] (visitor path, `base_row_id` as a literal)
+/// and the scan SM data stage (`base_row_id` as a per-file file-constant column reference).
+pub(crate) fn row_id_coalesce_expr(
+    materialized_col_name: &str,
+    row_index_col_name: &str,
+    base_row_id: impl Into<Expression>,
+) -> Expression {
+    Expression::coalesce([
+        Expression::column([materialized_col_name]),
+        Expression::binary(
+            BinaryExpressionOp::Plus,
+            base_row_id.into(),
+            Expression::column([row_index_col_name]),
+        ),
+    ])
+}
+
 /// Build a transform expression that converts physical data to the logical schema.
 ///
 /// An empty `transform_spec` is valid and represents the case where only column mapping is needed.
@@ -136,14 +154,11 @@ pub(crate) fn get_transform_expr(
                 let base_row_id = base_row_id.ok_or_else(|| {
                     Error::generic("Asked to generate RowIds, but no baseRowId found.")
                 })?;
-                let expr = Arc::new(Expression::coalesce([
-                    Expression::column([field_name]),
-                    Expression::binary(
-                        BinaryExpressionOp::Plus,
-                        Expression::literal(base_row_id),
-                        Expression::column([row_index_field_name]),
-                    ),
-                ]));
+                let expr = Arc::new(row_id_coalesce_expr(
+                    field_name,
+                    row_index_field_name,
+                    Expression::literal(base_row_id),
+                ));
                 transform.with_replaced_field(field_name.clone(), expr)
             }
             MetadataDerivedColumn {

--- a/kernel/src/schema/builder.rs
+++ b/kernel/src/schema/builder.rs
@@ -1,0 +1,142 @@
+//! Fluent [`SchemaBuilder`] for incrementally constructing or augmenting [`StructType`] /
+//! [`SchemaRef`] values.
+//!
+//! Plan builders frequently start from a kernel-defined action schema and add or replace one or
+//! two fields (`__fsr_join_k`, `version`, `partitionValues_parsed`, `stats_parsed`). The
+//! builder collapses the otherwise-verbose `Vec::collect().push().push().try_new()` ritual to
+//! a method chain:
+//!
+//! ```ignore
+//! let augmented = FSR_BASE
+//!     .build_on()
+//!     .with_nullable(FSR_JOIN_KEY_COL, DataType::Array(Box::new(ArrayType::new(
+//!         DataType::STRING, true))))
+//!     .with_not_null("version", DataType::LONG)
+//!     .build()?;
+//! ```
+//!
+//! Finalize via [`SchemaBuilder::build`] (validating) or [`SchemaBuilder::build_unchecked`]
+//! (when the caller knows there are no duplicates).
+
+use std::sync::Arc;
+
+use crate::error::Error;
+use crate::schema::{DataType, SchemaRef, StructField, StructType};
+
+/// Append-only builder used to construct a [`StructType`] / [`SchemaRef`]. Open one via
+/// [`SchemaBuilder::new`] or [`StructType::build_on`]; finalize via [`Self::build`]
+/// (validated) or [`Self::build_unchecked`] (caller-asserted unique names).
+pub struct SchemaBuilder {
+    fields: Vec<StructField>,
+}
+
+impl SchemaBuilder {
+    /// Open an empty [`SchemaBuilder`]. Equivalent to calling [`StructType::build_on`] on an
+    /// empty struct but reads better when constructing a schema from scratch.
+    pub fn new() -> Self {
+        Self { fields: Vec::new() }
+    }
+
+    /// Open a builder seeded with the fields of `schema`.
+    pub fn from_schema(schema: &StructType) -> Self {
+        Self {
+            fields: schema.fields().cloned().collect(),
+        }
+    }
+
+    /// Add a field. The field's nullability is taken from the [`StructField`] itself; this is
+    /// the lowest-level append.
+    pub fn with_field(mut self, field: StructField) -> Self {
+        self.fields.push(field);
+        self
+    }
+
+    /// Shorthand for [`Self::with_field`]`(StructField::nullable(name, ty))`.
+    pub fn with_nullable(self, name: impl Into<String>, ty: impl Into<DataType>) -> Self {
+        self.with_field(StructField::nullable(name, ty))
+    }
+
+    /// Shorthand for [`Self::with_field`]`(StructField::not_null(name, ty))`.
+    pub fn with_not_null(self, name: impl Into<String>, ty: impl Into<DataType>) -> Self {
+        self.with_field(StructField::not_null(name, ty))
+    }
+
+    /// Append every field from `other` in order. Useful for "this schema plus those columns".
+    pub fn extend_from(mut self, other: &StructType) -> Self {
+        self.fields.extend(other.fields().cloned());
+        self
+    }
+
+    /// Validating finalize -- fails if field names are duplicated. Returns an [`Arc`]-wrapped
+    /// schema so the result is directly assignable to [`SchemaRef`] slots.
+    pub fn build(self) -> Result<SchemaRef, Error> {
+        StructType::try_new(self.fields).map(Arc::new)
+    }
+
+    /// Unchecked finalize. Use only when the field set is known-unique at the call site
+    /// (e.g. all field names are local consts that don't collide).
+    pub fn build_unchecked(self) -> SchemaRef {
+        Arc::new(StructType::new_unchecked(self.fields))
+    }
+}
+
+impl Default for SchemaBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base() -> SchemaRef {
+        Arc::new(StructType::new_unchecked([
+            StructField::not_null("a", DataType::LONG),
+            StructField::nullable("b", DataType::STRING),
+        ]))
+    }
+
+    #[test]
+    fn build_on_extends_existing_schema_fields() {
+        let schema = base()
+            .build_on()
+            .with_not_null("c", DataType::LONG)
+            .build()
+            .unwrap();
+        assert_eq!(schema.fields().count(), 3);
+        assert_eq!(schema.field("c").unwrap().data_type(), &DataType::LONG);
+    }
+
+    #[test]
+    fn build_unchecked_dedups_duplicate_field_names() {
+        // `StructType::new_unchecked` silently deduplicates (last writer wins).
+        let schema = SchemaBuilder::new()
+            .with_not_null("x", DataType::LONG)
+            .with_not_null("x", DataType::STRING)
+            .build_unchecked();
+        assert_eq!(schema.fields().count(), 1);
+        assert_eq!(schema.field("x").unwrap().data_type(), &DataType::STRING);
+    }
+
+    #[test]
+    fn build_validates_duplicate_field_names() {
+        let err = base()
+            .build_on()
+            .with_not_null("a", DataType::LONG)
+            .build()
+            .unwrap_err();
+        assert!(format!("{err}").contains("a"), "{err}");
+    }
+
+    #[test]
+    fn extend_from_appends_all_fields_in_order() {
+        let extra = StructType::new_unchecked([
+            StructField::not_null("c", DataType::LONG),
+            StructField::not_null("d", DataType::LONG),
+        ]);
+        let schema = base().build_on().extend_from(&extra).build().unwrap();
+        let names: Vec<_> = schema.fields().map(|f| f.name().as_str()).collect();
+        assert_eq!(names, vec!["a", "b", "c", "d"]);
+    }
+}

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -21,6 +21,8 @@ use crate::transforms::SchemaTransform;
 use crate::utils::require;
 use crate::{DeltaResult, Error};
 
+pub mod builder;
+pub use builder::SchemaBuilder;
 pub(crate) mod compare;
 #[cfg(feature = "schema-diff")]
 pub(crate) mod diff;
@@ -34,6 +36,25 @@ pub(crate) mod variant_utils;
 
 pub type Schema = StructType;
 pub type SchemaRef = Arc<StructType>;
+
+/// Build a [`SchemaRef`] from a sequence of [`StructField`]s without going through
+/// `Arc::new(StructType::new_unchecked(...))`.
+///
+/// Use when assembling a schema entirely from known-distinct field names; the
+/// underlying constructor is unchecked, so callers must guarantee the field set
+/// is unique (otherwise later entries silently overwrite earlier ones with the
+/// same name). For validating construction, prefer [`SchemaBuilder::build`].
+///
+/// ```ignore
+/// use delta_kernel::schema::{arc_schema, DataType, StructField};
+/// let schema = arc_schema([
+///     StructField::not_null("path", DataType::STRING),
+///     StructField::not_null("size", DataType::LONG),
+/// ]);
+/// ```
+pub fn arc_schema<I: IntoIterator<Item = StructField>>(fields: I) -> SchemaRef {
+    Arc::new(StructType::new_unchecked(fields))
+}
 
 /// Converts a type to a [`Schema`] that represents that type. Derivable for struct types using the
 /// [`delta_kernel_derive::ToSchema`] derive macro.
@@ -653,6 +674,13 @@ impl StructType {
         StructTypeBuilder::new()
     }
 
+    /// Open a fluent [`SchemaBuilder`] seeded with the fields of this struct. Use this when
+    /// you want to add a few extra columns to an existing schema and finalize as a
+    /// [`SchemaRef`].
+    pub fn build_on(&self) -> SchemaBuilder {
+        SchemaBuilder::from_schema(self)
+    }
+
     /// Creates a new [`StructType`] from the given fields without validating them.
     ///
     /// This should only be used when you are sure that the fields are valid.
@@ -1044,20 +1072,75 @@ impl StructType {
         }
     }
 
-    /// Returns a StructType with the named field replaced.
-    /// Returns an error if field doesn't exist.
+    /// Returns a StructType with the field at key `name` replaced by `new_field`. When
+    /// `new_field.name() != name` this also renames the entry: `new_field` lands at the
+    /// same index as the original, the old key is removed, and a duplicate-name collision
+    /// (with any unrelated existing field) is rejected so the schema stays consistent.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `name` is not present, or if a rename would collide with an
+    /// existing field.
     pub fn with_field_replaced(
         mut self,
         name: &str,
         new_field: StructField,
     ) -> DeltaResult<StructType> {
-        let replace_field = self
+        let idx = self
             .fields
-            .get_mut(name)
+            .get_index_of(name)
             .ok_or_else(|| Error::generic(format!("Field {name} not found")))?;
-
-        *replace_field = new_field;
+        if name == new_field.name() {
+            self.fields[idx] = new_field;
+        } else {
+            if self.fields.contains_key(new_field.name()) {
+                return Err(Error::generic(format!(
+                    "Field {} already exists",
+                    new_field.name()
+                )));
+            }
+            self.fields.shift_remove_index(idx);
+            self.fields
+                .insert_before(idx, new_field.name.clone(), new_field);
+        }
         Ok(self)
+    }
+
+    /// Replaces the nested [`StructType`] at `path` with the result of `f`, rebuilding the
+    /// ancestor [`StructField`] chain along the way. Each path component must resolve to a
+    /// struct field; the last component identifies the [`StructType`] passed (by ownership)
+    /// to `f`. An empty `path` invokes `f` on a clone of `self` directly.
+    ///
+    /// Intermediate fields' nullability and metadata are preserved verbatim; only their
+    /// inner [`StructType`] is replaced.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a path component is missing, a non-leaf component is not a struct
+    /// type, or `f` returns an error.
+    pub fn with_struct_at<S, F>(&self, path: &[S], f: F) -> DeltaResult<Self>
+    where
+        S: AsRef<str>,
+        F: FnOnce(StructType) -> DeltaResult<StructType>,
+    {
+        let Some((first, rest)) = path.split_first() else {
+            return f(self.clone());
+        };
+        let name = first.as_ref();
+        let field = self
+            .field(name)
+            .ok_or_else(|| Error::generic(format!("Field {name} not found")))?;
+        let DataType::Struct(inner) = field.data_type() else {
+            return Err(Error::generic(format!("Field {name} is not a struct type")));
+        };
+        let new_inner = inner.with_struct_at(rest, f)?;
+        let new_field = StructField {
+            name: field.name.clone(),
+            data_type: DataType::Struct(Box::new(new_inner)),
+            nullable: field.nullable,
+            metadata: field.metadata.clone(),
+        };
+        self.clone().with_field_replaced(name, new_field)
     }
 }
 
@@ -1773,6 +1856,12 @@ impl From<StructType> for DataType {
     }
 }
 
+impl From<&StructType> for DataType {
+    fn from(struct_type: &StructType) -> Self {
+        struct_type.clone().into()
+    }
+}
+
 impl From<ArrayType> for DataType {
     fn from(array_type: ArrayType) -> Self {
         DataType::Array(Box::new(array_type))
@@ -1782,6 +1871,16 @@ impl From<ArrayType> for DataType {
 impl From<SchemaRef> for DataType {
     fn from(schema: SchemaRef) -> Self {
         Arc::unwrap_or_clone(schema).into()
+    }
+}
+
+/// Borrowed counterpart to [`From<SchemaRef>`]: clones the inner [`StructType`] (i.e. it
+/// does the same deep clone as `(&*schema).clone().into()`). Lets call sites pass an
+/// `&SchemaRef` directly into any `impl Into<DataType>` parameter without first
+/// `Arc::clone`-ing or `.as_ref().clone()`-ing.
+impl From<&SchemaRef> for DataType {
+    fn from(schema: &SchemaRef) -> Self {
+        (**schema).clone().into()
     }
 }
 
@@ -3900,8 +3999,45 @@ mod tests {
             .with_field_replaced("id", StructField::new("name", DataType::STRING, true))
             .unwrap();
 
-        assert_eq!(new_schema.num_fields(), 1);
-        assert_eq!(new_schema.field_at_index(0).unwrap().name(), "name");
+        // Rename keeps a single field at the original index AND keys the IndexMap entry
+        // by the new name so lookups via `field(new_name)` work.
+        let expected = StructType::try_new([StructField::new("name", DataType::STRING, true)])
+            .expect("rename should produce a well-formed schema");
+        assert_eq!(new_schema, expected);
+        assert_eq!(new_schema.field("name"), expected.field("name"));
+        assert!(
+            new_schema.field("id").is_none(),
+            "original key `id` must be removed after rename, got {:?}",
+            new_schema.field("id")
+        );
+    }
+
+    #[test]
+    fn test_with_field_replaced_rename_preserves_position() {
+        // Replacement preserves the original field's index even when renaming.
+        let schema = StructType::try_new([
+            StructField::new("a", DataType::STRING, false),
+            StructField::new("b", DataType::INTEGER, false),
+            StructField::new("c", DataType::DOUBLE, false),
+        ])
+        .unwrap();
+        let new_schema = schema
+            .with_field_replaced("b", StructField::nullable("renamed", DataType::LONG))
+            .unwrap();
+        let names: Vec<&str> = new_schema.fields().map(|f| f.name().as_str()).collect();
+        assert_eq!(names, ["a", "renamed", "c"]);
+    }
+
+    #[test]
+    fn test_with_field_replaced_rename_collision_errors() {
+        // Renaming to a name already used by an unrelated field is rejected.
+        let schema = StructType::try_new([
+            StructField::new("a", DataType::STRING, false),
+            StructField::new("b", DataType::INTEGER, false),
+        ])
+        .unwrap();
+        let result = schema.with_field_replaced("a", StructField::nullable("b", DataType::LONG));
+        assert_result_error_with_message(result, "already exists");
     }
 
     #[test]
@@ -4001,6 +4137,83 @@ mod tests {
         assert_eq!(
             normalize_column_names_to_schema_casing(&schema, &cols)[0].path(),
             ["nonexistent"]
+        );
+    }
+
+    // === with_struct_at ===
+
+    /// Walk a path, append a leaf field via the closure, assert the leaf struct gained it
+    /// while every ancestor on the path is rebuilt cleanly. Empty path operates on root.
+    #[rstest]
+    #[case::root(vec![], vec![])]
+    #[case::depth_one(vec!["a"], vec!["a"])]
+    #[case::depth_two(vec!["a", "b"], vec!["a", "b"])]
+    fn test_with_struct_at_appends_field_at_path(
+        #[case] path: Vec<&str>,
+        #[case] inspect: Vec<&str>,
+    ) {
+        let new_schema = walk_test_schema()
+            .with_struct_at(&path, |s| {
+                s.with_field_inserted_after(None, StructField::nullable("x", DataType::INTEGER))
+            })
+            .unwrap();
+        // Walk `inspect` to retrieve the (possibly nested) struct that received the new field.
+        let mut cursor = &new_schema;
+        for name in &inspect {
+            let DataType::Struct(inner) = cursor.field(name).unwrap().data_type() else {
+                panic!("expected struct at {name}");
+            };
+            cursor = inner.as_ref();
+        }
+        // Assert against the exact expected leaf shape rather than just "x exists": this
+        // catches accidental drift in nullability or data type that the existence check
+        // would silently miss.
+        let expected_leaf = StructField::nullable("x", DataType::INTEGER);
+        assert_eq!(
+            cursor.field("x"),
+            Some(&expected_leaf),
+            "leaf `x` mismatch at path {path:?}",
+        );
+    }
+
+    #[rstest]
+    #[case::missing_component(vec!["a", "missing"], "Field missing not found")]
+    // `c` is a DOUBLE leaf, so traversing past it fails.
+    #[case::intermediate_not_struct(vec!["a", "b", "c", "d"], "not a struct type")]
+    fn test_with_struct_at_path_errors(#[case] path: Vec<&str>, #[case] msg: &str) {
+        let result = walk_test_schema().with_struct_at(&path, Ok);
+        assert_result_error_with_message(result, msg);
+    }
+
+    #[test]
+    fn test_with_struct_at_closure_error_propagates() {
+        let result = walk_test_schema()
+            .with_struct_at(&["a"], |_| Err(Error::generic("closure error".to_string())));
+        assert_result_error_with_message(result, "closure error");
+    }
+
+    #[test]
+    fn test_with_struct_at_preserves_intermediate_metadata_and_nullability() {
+        let leaf = StructType::new_unchecked([StructField::new("c", DataType::DOUBLE, false)]);
+        let inner = StructType::new_unchecked([StructField::new(
+            "b",
+            DataType::Struct(Box::new(leaf)),
+            false,
+        )]);
+        let outer_field = StructField::new("a", DataType::Struct(Box::new(inner)), true)
+            .with_metadata([("k".to_string(), "v".to_string())]);
+        let schema = StructType::new_unchecked([outer_field]);
+
+        let new_schema = schema
+            .with_struct_at(&["a", "b"], |b| {
+                b.with_field_inserted_after(None, StructField::nullable("d", DataType::INTEGER))
+            })
+            .unwrap();
+        let a_field = new_schema.field("a").unwrap();
+        assert!(a_field.is_nullable());
+        assert_eq!(
+            a_field.metadata.get("k"),
+            Some(&MetadataValue::String("v".to_string()))
         );
     }
 }

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -10,7 +10,7 @@ use url::Url;
 
 use crate::action_reconciliation::calculate_transaction_expiration_timestamp;
 use crate::actions::set_transaction::{is_set_txn_expired, SetTransactionScanner};
-use crate::actions::{DomainMetadata, INTERNAL_DOMAIN_PREFIX};
+use crate::actions::{DomainMetadata, Metadata, Protocol, INTERNAL_DOMAIN_PREFIX};
 use crate::checkpoint::{CheckpointWriter, LastCheckpointHintStats};
 use crate::clustering::{parse_clustering_columns, CLUSTERING_DOMAIN_NAME};
 use crate::committer::{Committer, PublishMetadata};
@@ -603,6 +603,24 @@ impl Snapshot {
     /// Get the [`TableProperties`] for this [`Snapshot`].
     pub fn table_properties(&self) -> &TableProperties {
         self.table_configuration().table_properties()
+    }
+
+    /// Get the validated [`Protocol`] for this [`Snapshot`].
+    ///
+    /// This reflects the canonical protocol selected by snapshot construction
+    /// (including checkpoint/CRC-assisted reconstruction when available), not
+    /// merely the latest raw protocol action in commit JSON files.
+    pub fn protocol(&self) -> &Protocol {
+        self.table_configuration().protocol()
+    }
+
+    /// Get the validated [`Metadata`] for this [`Snapshot`].
+    ///
+    /// This reflects the canonical metadata selected by snapshot construction
+    /// (including checkpoint/CRC-assisted reconstruction when available), not
+    /// merely the latest raw metadata action in commit JSON files.
+    pub fn metadata(&self) -> &Metadata {
+        self.table_configuration().metadata()
     }
 
     /// Returns the protocol-derived table properties as a map of key-value pairs.

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -305,6 +305,13 @@ impl TableConfiguration {
     /// Field names are physical column names (respecting column mapping mode),
     /// and field types are the actual partition column data types with their original nullability.
     /// Returns `None` if the table has no partition columns.
+    ///
+    /// Field order follows `metadata().partition_columns()` (the order Spark recorded the
+    /// partition columns in). Used by the checkpoint augmentation path, where the parquet
+    /// schema is keyed by metadata order. This differs from
+    /// [`Self::partition_schema_with_physical_names`], which preserves logical/physical
+    /// schema order and is used by the scan-side data stage; the two intentionally produce
+    /// the same set of fields but in different orders.
     pub(crate) fn build_partition_values_parsed_schema(&self) -> Option<SchemaRef> {
         let partition_columns = self.metadata().partition_columns();
         if partition_columns.is_empty() {
@@ -468,6 +475,37 @@ impl TableConfiguration {
     #[internal_api]
     pub(crate) fn partition_columns(&self) -> &[String] {
         self.metadata().partition_columns()
+    }
+
+    /// Partition schema with **physical** field names (and types), built from the table's
+    /// logical/physical schema pair. `None` when the table has no partition columns or none
+    /// of the declared partition columns resolve in the schema.
+    ///
+    /// Used by the scan SM data stage to materialize `partitionValues_parsed` and by the
+    /// data-skipping setup to narrow stats schemas to partition-referenced fields. Both
+    /// sites used to inline this filter+zip; consolidating here keeps the construction
+    /// (zip logical/physical fields, filter by partition column name) in one place.
+    ///
+    /// Field order follows the table's logical/physical schema (i.e. user-declared column
+    /// order). This differs from [`Self::build_partition_values_parsed_schema`], which orders
+    /// by `metadata().partition_columns()` for checkpoint-side parity. Callers needing
+    /// `partitionValues_parsed`-keyed reads must use the build_ variant; callers projecting
+    /// against the user schema (scan / data-skipping) use this variant.
+    #[internal_api]
+    pub(crate) fn partition_schema_with_physical_names(&self) -> Option<SchemaRef> {
+        let partition_columns = self.partition_columns();
+        if partition_columns.is_empty() {
+            return None;
+        }
+        let partition_fields: Vec<StructField> = self
+            .logical_schema()
+            .fields()
+            .zip(self.physical_schema().fields())
+            .filter(|(lf, _)| partition_columns.contains(lf.name()))
+            .map(|(_, pf)| pf.clone())
+            .collect();
+        (!partition_fields.is_empty())
+            .then(|| Arc::new(StructType::new_unchecked(partition_fields)))
     }
 
     /// The [`Url`] of the table this [`TableConfiguration`] belongs to

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -1490,7 +1490,6 @@ pub struct RetryableTransaction<S = ExistingTable> {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::path::PathBuf;
     use std::sync::Mutex;
 
     use rstest::rstest;
@@ -1516,8 +1515,9 @@ mod tests {
     use crate::table_features::ColumnMappingMode;
     use crate::transaction::create_table::create_table;
     use crate::utils::test_utils::{
-        load_test_table, string_array_to_engine_data, test_schema_flat, test_schema_nested,
-        test_schema_with_array, test_schema_with_map,
+        load_test_table, string_array_to_engine_data, sync_engine_and_snapshot,
+        sync_engine_and_snapshot_at, test_schema_flat, test_schema_nested, test_schema_with_array,
+        test_schema_with_map,
     };
     use crate::{EvaluationHandler, Snapshot};
 
@@ -1581,24 +1581,11 @@ mod tests {
 
     /// Sets up a snapshot for a table with deletion vector support at version 1
     fn setup_dv_enabled_table() -> (SyncEngine, Arc<Snapshot>) {
-        let engine = SyncEngine::new();
-        let path =
-            std::fs::canonicalize(PathBuf::from("./tests/data/table-with-dv-small/")).unwrap();
-        let url = url::Url::from_directory_path(path).unwrap();
-        let snapshot = Snapshot::builder_for(url)
-            .at_version(1)
-            .build(&engine)
-            .unwrap();
-        (engine, snapshot)
+        sync_engine_and_snapshot_at("./tests/data/table-with-dv-small/", Some(1))
     }
 
     fn setup_non_dv_table() -> (SyncEngine, Arc<Snapshot>) {
-        let engine = SyncEngine::new();
-        let path =
-            std::fs::canonicalize(PathBuf::from("./tests/data/table-without-dv-small/")).unwrap();
-        let url = url::Url::from_directory_path(path).unwrap();
-        let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
-        (engine, snapshot)
+        sync_engine_and_snapshot("./tests/data/table-without-dv-small/")
     }
 
     /// Creates a test deletion vector descriptor with default values (the DV might not exist on
@@ -1629,14 +1616,8 @@ mod tests {
     // TODO: create a finer-grained unit tests for transactions (issue#1091)
     #[test]
     fn test_add_files_schema() -> Result<(), Box<dyn std::error::Error>> {
-        let engine = SyncEngine::new();
-        let path =
-            std::fs::canonicalize(PathBuf::from("./tests/data/table-with-dv-small/")).unwrap();
-        let url = url::Url::from_directory_path(path).unwrap();
-        let snapshot = Snapshot::builder_for(url)
-            .at_version(1)
-            .build(&engine)
-            .unwrap();
+        let (engine, snapshot) =
+            sync_engine_and_snapshot_at("./tests/data/table-with-dv-small/", Some(1));
         let txn = snapshot
             .transaction(Box::new(FileSystemCommitter::new()), &engine)?
             .with_engine_info("default engine");
@@ -1667,14 +1648,9 @@ mod tests {
 
     #[test]
     fn test_new_deletion_vector_path() -> Result<(), Box<dyn std::error::Error>> {
-        let engine = SyncEngine::new();
-        let path =
-            std::fs::canonicalize(PathBuf::from("./tests/data/table-with-dv-small/")).unwrap();
-        let url = url::Url::from_directory_path(path).unwrap();
-        let snapshot = Snapshot::builder_for(url.clone())
-            .at_version(1)
-            .build(&engine)
-            .unwrap();
+        let (engine, snapshot) =
+            sync_engine_and_snapshot_at("./tests/data/table-with-dv-small/", Some(1));
+        let url_str = snapshot.table_root().as_str().to_string();
         let txn = snapshot
             .transaction(Box::new(FileSystemCommitter::new()), &engine)?
             .with_engine_info("default engine");
@@ -1683,13 +1659,13 @@ mod tests {
         // Test with empty prefix
         let dv_path1 = write_context.new_deletion_vector_path(String::from(""));
         let abs_path1 = dv_path1.absolute_path()?;
-        assert!(abs_path1.as_str().contains(url.as_str()));
+        assert!(abs_path1.as_str().contains(&url_str));
 
         // Test with non-empty prefix
         let prefix = String::from("dv_test");
         let dv_path2 = write_context.new_deletion_vector_path(prefix.clone());
         let abs_path2 = dv_path2.absolute_path()?;
-        assert!(abs_path2.as_str().contains(url.as_str()));
+        assert!(abs_path2.as_str().contains(&url_str));
         assert!(abs_path2.as_str().contains(&prefix));
 
         // Test that two paths with same prefix are different (unique UUIDs)
@@ -1702,10 +1678,7 @@ mod tests {
 
     #[test]
     fn test_physical_schema_excludes_partition_columns() -> Result<(), Box<dyn std::error::Error>> {
-        let engine = SyncEngine::new();
-        let path = std::fs::canonicalize(PathBuf::from("./tests/data/basic_partitioned/")).unwrap();
-        let url = url::Url::from_directory_path(path).unwrap();
-        let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
+        let (engine, snapshot) = sync_engine_and_snapshot("./tests/data/basic_partitioned/");
         let txn = snapshot
             .transaction(Box::new(FileSystemCommitter::new()), &engine)?
             .with_engine_info("default engine");
@@ -1750,10 +1723,7 @@ mod tests {
     fn snapshot_and_partitioned_write_context(
         table_path: &str,
     ) -> Result<(Arc<Snapshot>, WriteContext), Box<dyn std::error::Error>> {
-        let engine = SyncEngine::new();
-        let path = std::fs::canonicalize(PathBuf::from(table_path)).unwrap();
-        let url = url::Url::from_directory_path(path).unwrap();
-        let snapshot = Snapshot::builder_for(url).build(&engine)?;
+        let (engine, snapshot) = sync_engine_and_snapshot(table_path);
         let txn = snapshot
             .clone()
             .transaction(Box::new(FileSystemCommitter::new()), &engine)?;
@@ -1845,13 +1815,10 @@ mod tests {
     #[test]
     fn test_physical_schema_includes_partition_columns_when_materialized(
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let engine = SyncEngine::new();
-        let path = std::fs::canonicalize(PathBuf::from(
+        let (engine, snapshot) = sync_engine_and_snapshot_at(
             "./tests/data/partitioned_with_materialize_feature/",
-        ))
-        .unwrap();
-        let url = url::Url::from_directory_path(path).unwrap();
-        let snapshot = Snapshot::builder_for(url).at_version(1).build(&engine)?;
+            Some(1),
+        );
 
         let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
         let write_context = txn.partitioned_write_context(HashMap::from([(
@@ -1888,10 +1855,7 @@ mod tests {
         #[case] call_partitioned: bool,
         #[case] expected_msg: &str,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let engine = SyncEngine::new();
-        let path = std::fs::canonicalize(PathBuf::from(table_path)).unwrap();
-        let url = url::Url::from_directory_path(path).unwrap();
-        let snapshot = Snapshot::builder_for(url).build(&engine)?;
+        let (engine, snapshot) = sync_engine_and_snapshot(table_path);
         let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
         let result = if call_partitioned {
             txn.partitioned_write_context(HashMap::from([("x".to_string(), Scalar::Integer(1))]))

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -802,6 +802,59 @@ pub(crate) mod test_utils {
         }
     }
 
+    /// Build a [`SyncEngine`] and snapshot for a test table referenced by relative path
+    /// (e.g. `"./tests/data/basic_partitioned/"`). Pinning the version is optional.
+    /// Panics on any error -- intended for unit-test setup.
+    pub(crate) fn sync_engine_and_snapshot_at(
+        table_rel_path: &str,
+        version: Option<crate::Version>,
+    ) -> (SyncEngine, SnapshotRef) {
+        let path = std::fs::canonicalize(PathBuf::from(table_rel_path)).unwrap();
+        let url = Url::from_directory_path(path).unwrap();
+        let engine = SyncEngine::new();
+        let mut builder = Snapshot::builder_for(url);
+        if let Some(v) = version {
+            builder = builder.at_version(v);
+        }
+        let snapshot = builder.build(&engine).unwrap();
+        (engine, snapshot)
+    }
+
+    /// Build a [`SyncEngine`] and snapshot at the latest version for a test table referenced
+    /// by relative path. See [`sync_engine_and_snapshot_at`].
+    pub(crate) fn sync_engine_and_snapshot(table_rel_path: &str) -> (SyncEngine, SnapshotRef) {
+        sync_engine_and_snapshot_at(table_rel_path, None)
+    }
+
+    /// Like [`sync_engine_and_snapshot`] but returns an `Arc<SyncEngine>` for callers that
+    /// need to clone the engine across multiple uses.
+    pub(crate) fn sync_engine_arc_and_snapshot(
+        table_rel_path: &str,
+    ) -> (Arc<SyncEngine>, SnapshotRef) {
+        let (engine, snapshot) = sync_engine_and_snapshot_at(table_rel_path, None);
+        (Arc::new(engine), snapshot)
+    }
+
+    /// Parse a `StringArray` of JSON rows against the given schema using a [`SyncEngine`],
+    /// and return the resulting Arrow `RecordBatch`. Convenience for tests that build a
+    /// small fixture batch from JSON literals. Used by reconciliation / FSR tests that need
+    /// to construct fixture batches against an explicit kernel schema.
+    #[allow(dead_code)] // consumer (reconciliation FSR fixtures) lives in a sibling stack
+    pub(crate) fn parse_json_to_record_batch(
+        rows: StringArray,
+        schema: crate::schema::SchemaRef,
+    ) -> RecordBatch {
+        let engine = SyncEngine::new();
+        let parsed = engine
+            .json_handler()
+            .parse_json(string_array_to_engine_data(rows), schema)
+            .unwrap();
+        ArrowEngineData::try_from_engine_data(parsed)
+            .unwrap()
+            .record_batch()
+            .clone()
+    }
+
     /// Load a test table from tests/data directory.
     /// Tries compressed (tar.zst) first, falls back to extracted.
     /// Returns (engine, snapshot, optional tempdir). The TempDir must be kept alive


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2609/files/74fcce3c23c6a0eb615af1ddf747f32bc1ce4842..108e605445c7789b7a05418eb528f4edb71e9490) to review incremental changes.
- [stack/a1](https://github.com/delta-io/delta-kernel-rs/pull/2606) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2606/files)]
  - [**stack/a2**](https://github.com/delta-io/delta-kernel-rs/pull/2609) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2609/files/74fcce3c23c6a0eb615af1ddf747f32bc1ce4842..108e605445c7789b7a05418eb528f4edb71e9490)]

---------
## What changes are proposed in this pull request?

Stacked on top of #2606 — the diff shown will include that PR's changes until #2606 merges.

Bundles six independent micro-changes that have no internal dependencies on each other and are not large enough to warrant their own PRs:

- `TableConfiguration::partition_schema_with_physical_names` + refactor `scan/state_info.rs` onto it (consolidates physical-name resolution).
- Extract `row_id_coalesce_expr` in `scan/transform_spec.rs` (named helper for an expression that was previously inlined and hard to grep).
- Public `Snapshot::protocol`/`metadata` getters + public `CheckpointWriter::checkpoint_output_schema` (callers outside kernel need these to drive checkpoints and read snapshot state directly).
- `sync_engine_and_snapshot{,_at,_arc_and}` + `parse_json_to_record_batch` test helpers in `utils.rs`; refactor `scan/tests.rs`, `log_compaction/tests.rs`, and `transaction/mod.rs` tests onto them.
- `resolve_field_path` in `engine/arrow_utils.rs` (used by the DataFusion engine crate; lands here so the engine crate doesn't have to vendor its own copy).

Each sub-change is reviewable independently.

### This PR affects the following public APIs

New public APIs only (non-breaking):
- `Snapshot::protocol`, `Snapshot::metadata`
- `CheckpointWriter::checkpoint_output_schema`
- `TableConfiguration::partition_schema_with_physical_names`

## How was this change tested?

Existing test suite continues to pass; refactored tests exercise the new helpers.