### PR TITLE
feat!: add Expression::If with Arrow evaluator

### DIFF
--- a/ffi/examples/visit-expression/expression.h
+++ b/ffi/examples/visit-expression/expression.h
@@ -65,6 +65,7 @@ enum ExpressionType {
   OpaquePredicate,
   Unknown,
   MapToStruct,
+  If,
 };
 enum VariadicType {
   And,
@@ -114,6 +115,10 @@ struct Unknown {
 };
 struct MapToStructExpr {
   ExpressionItemList child_expr;
+};
+struct IfExpr {
+  // Three-element list: [condition, then_expr, else_expr].
+  ExpressionItemList branches;
 };
 struct BinaryData {
   uint8_t* buf;
@@ -310,6 +315,12 @@ DEFINE_VARIADIC(visit_expr_and, And)
 DEFINE_VARIADIC(visit_expr_or, Or)
 DEFINE_VARIADIC(visit_expr_struct_expr, StructExpression)
 #undef DEFINE_VARIADIC
+
+void visit_expr_if(void* data, uintptr_t sibling_list_id, uintptr_t child_list_id) {
+  struct IfExpr* if_expr = malloc(sizeof(struct IfExpr));
+  if_expr->branches = get_expr_list(data, child_list_id);
+  put_expr_item(data, sibling_list_id, if_expr, If);
+}
 
 // Sort by field name, breaking ties by pointer address to ensure stability.
 int transform_op_cmp(const void* a, const void* b) {
@@ -514,6 +525,7 @@ ExpressionItemList construct_expression(SharedExpression* expression) {
     .visit_opaque_expr = visit_opaque_expr,
     .visit_unknown = visit_unknown,
     .visit_map_to_struct = visit_map_to_struct_expr,
+    .visit_if = visit_expr_if,
   };
   uintptr_t top_level_id = visit_expression(&expression, &visitor);
   ExpressionItemList top_level_expr = data.lists[top_level_id];
@@ -561,6 +573,7 @@ ExpressionItemList construct_predicate(SharedPredicate* predicate) {
     .visit_opaque_expr = visit_opaque_expr,
     .visit_unknown = visit_unknown,
     .visit_map_to_struct = visit_map_to_struct_expr,
+    .visit_if = visit_expr_if,
   };
   uintptr_t top_level_id = visit_predicate(&predicate, &visitor);
   ExpressionItemList top_level_expr = data.lists[top_level_id];
@@ -677,6 +690,12 @@ void free_expression_item(ExpressionItem ref) {
       struct MapToStructExpr* m2s = ref.ref;
       free_expression_list(m2s->child_expr);
       free(m2s);
+      break;
+    }
+    case If: {
+      struct IfExpr* if_expr = ref.ref;
+      free_expression_list(if_expr->branches);
+      free(if_expr);
       break;
     }
   }

--- a/ffi/examples/visit-expression/expression_print.h
+++ b/ffi/examples/visit-expression/expression_print.h
@@ -261,6 +261,12 @@ void print_tree_helper(ExpressionItem ref, int depth) {
       print_expression_item_list(m2s->child_expr, depth + 1);
       break;
     }
+    case If: {
+      struct IfExpr* if_expr = ref.ref;
+      printf("If\n");
+      print_expression_item_list(if_expr->branches, depth + 1);
+      break;
+    }
   }
 }
 

--- a/ffi/src/expressions/engine_visitor.rs
+++ b/ffi/src/expressions/engine_visitor.rs
@@ -4,8 +4,8 @@ use std::ffi::c_void;
 
 use delta_kernel::expressions::{
     ArrayData, BinaryExpression, BinaryExpressionOp, BinaryPredicate, BinaryPredicateOp,
-    ColumnName, Expression, ExpressionRef, JunctionPredicate, JunctionPredicateOp, MapData,
-    MapToStructExpression, OpaqueExpression, OpaqueExpressionOpRef, OpaquePredicate,
+    ColumnName, Expression, ExpressionRef, IfExpression, JunctionPredicate, JunctionPredicateOp,
+    MapData, MapToStructExpression, OpaqueExpression, OpaqueExpressionOpRef, OpaquePredicate,
     OpaquePredicateOpRef, ParseJsonExpression, Predicate, Scalar, StructData, Transform,
     UnaryExpression, UnaryExpressionOp, UnaryPredicate, UnaryPredicateOp, VariadicExpression,
     VariadicExpressionOp,
@@ -272,6 +272,14 @@ pub struct EngineExpressionVisitor {
     /// list identified by `sibling_list_id`.
     pub visit_unknown:
         extern "C" fn(data: *mut c_void, sibling_list_id: usize, name: KernelStringSlice),
+    /// Visits the conditional `If(condition, then_expr, else_expr)` expression belonging to
+    /// the list identified by `sibling_list_id`. The three operands will be in a three-element
+    /// child list identified by `child_list_id`, in order: condition (a predicate),
+    /// then-expression, else-expression.
+    ///
+    /// Engines MUST provide a non-null callback for this slot; kernel dispatches to it
+    /// whenever an `If` expression is encountered.
+    pub visit_if: VisitVariadicFn,
 }
 
 /// Visit the expression of the passed [`SharedExpression`] Handle using the provided `visitor`.
@@ -667,6 +675,17 @@ fn visit_expression_impl(
                 VariadicExpressionOp::Coalesce => visitor.visit_coalesce,
             };
             visit_fn(visitor.data, sibling_list_id, child_list_id);
+        }
+        Expression::If(IfExpression {
+            condition,
+            then_expr,
+            else_expr,
+        }) => {
+            let child_list_id = call!(visitor, make_field_list, 3);
+            visit_predicate_impl(visitor, condition, child_list_id);
+            visit_expression_impl(visitor, then_expr, child_list_id);
+            visit_expression_impl(visitor, else_expr, child_list_id);
+            call!(visitor, visit_if, sibling_list_id, child_list_id);
         }
         Expression::Opaque(OpaqueExpression { op, exprs }) => {
             visit_expression_opaque(visitor, op, exprs, sibling_list_id)

--- a/ffi/src/test_ffi.rs
+++ b/ffi/src/test_ffi.rs
@@ -160,6 +160,11 @@ pub unsafe extern "C" fn get_testing_kernel_expression() -> Handle<SharedExpress
         ),
         Expr::unknown("mystery"),
         Expr::map_to_struct(column_expr!("pv")),
+        Expr::if_then_else(
+            column_pred!("flag"),
+            Expr::literal(10_i32),
+            Expr::literal(20_i32),
+        ),
     ];
     sub_exprs.extend(
         [

--- a/ffi/tests/test-expression-visitor/expected.txt
+++ b/ffi/tests/test-expression-visitor/expected.txt
@@ -68,6 +68,10 @@ StructExpression
   Unknown(mystery)
   MapToStruct
     Column(pv)
+  If
+    Column(flag)
+    Integer(10)
+    Integer(20)
   Divide
     Integer(0)
     Integer(0)

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -16,6 +16,7 @@ use crate::arrow::buffer::{NullBuffer, OffsetBuffer};
 use crate::arrow::compute::kernels::cmp::{distinct, eq, gt, gt_eq, lt, lt_eq, neq, not_distinct};
 use crate::arrow::compute::kernels::comparison::in_list_utf8;
 use crate::arrow::compute::kernels::numeric::{add, div, mul, sub};
+use crate::arrow::compute::kernels::zip::zip;
 use crate::arrow::compute::{and_kleene, cast, is_not_null, is_null, not, or_kleene};
 use crate::arrow::datatypes::{
     DataType as ArrowDataType, Field as ArrowField, Fields as ArrowFields, IntervalUnit,
@@ -33,9 +34,9 @@ use crate::engine::ensure_data_types::{ensure_data_types, ValidationMode};
 use crate::error::{DeltaResult, Error};
 use crate::expressions::{
     BinaryExpression, BinaryExpressionOp, BinaryPredicate, BinaryPredicateOp, Expression,
-    ExpressionRef, JunctionPredicate, JunctionPredicateOp, OpaqueExpression, OpaquePredicate,
-    Predicate, Scalar, Transform, UnaryExpression, UnaryExpressionOp, UnaryPredicate,
-    UnaryPredicateOp, VariadicExpression, VariadicExpressionOp,
+    ExpressionRef, IfExpression, JunctionPredicate, JunctionPredicateOp, OpaqueExpression,
+    OpaquePredicate, Predicate, Scalar, Transform, UnaryExpression, UnaryExpressionOp,
+    UnaryPredicate, UnaryPredicateOp, VariadicExpression, VariadicExpressionOp,
 };
 use crate::schema::{DataType, PrimitiveType, StructField, StructType};
 
@@ -371,6 +372,47 @@ pub fn evaluate_expression(
             "MapToStruct expression requires a DataType::Struct result type, but got {dt:?}"
         ))),
         (Unknown(name), _) => Err(Error::unsupported(format!("Unknown expression: {name:?}"))),
+        (
+            If(IfExpression {
+                condition,
+                then_expr,
+                else_expr,
+            }),
+            result_type,
+        ) => {
+            let cond = evaluate_predicate(condition, batch, false)?;
+            // Skip evaluating the unselected branch when one side covers every row. NULL
+            // entries select `else_expr` per the IR contract, so "every row picks then"
+            // means `true_count == len` AND `null_count == 0`; "no row picks then" just
+            // means `true_count == 0` (nulls already get else).
+            if cond.true_count() == cond.len() && cond.null_count() == 0 {
+                return validate_array_type(
+                    evaluate_expression(then_expr, batch, result_type)?,
+                    result_type,
+                );
+            }
+            if cond.true_count() == 0 {
+                return validate_array_type(
+                    evaluate_expression(else_expr, batch, result_type)?,
+                    result_type,
+                );
+            }
+            let then_arr = evaluate_expression(then_expr, batch, result_type)?;
+            let else_arr = evaluate_expression(else_expr, batch, result_type)?;
+            // Shadow Arrow's "data types differ" error from `zip` with a clearer message that
+            // identifies the kernel-side construct. `zip` itself would also reject this.
+            if then_arr.data_type() != else_arr.data_type() {
+                return Err(Error::generic(format!(
+                    "If branches must have the same type: then={:?}, else={:?}",
+                    then_arr.data_type(),
+                    else_arr.data_type()
+                )));
+            }
+            // `zip` selects truthy where mask is true, falsy where mask is false or NULL --
+            // matches the IR contract that NULL conditions fall through to `else_expr`
+            // (see `IfExpression`).
+            validate_array_type(zip(&cond, &then_arr, &else_arr)?, result_type)
+        }
     }
 }
 
@@ -2560,5 +2602,206 @@ mod tests {
 
         let result = evaluate_expression(&expr, &batch, Some(&output_type));
         assert_result_error_with_message(result, "Missing Struct fields");
+    }
+
+    /// Single-column Int32 batch (column `a`) of arbitrary length / nullability. Used to
+    /// drive the `num_rows == 0` boundary and the multi-row clamp pattern.
+    fn int_a_batch(values: Vec<Option<i32>>, nullable: bool) -> RecordBatch {
+        let schema = ArrowSchema::new(vec![ArrowField::new("a", ArrowDataType::Int32, nullable)]);
+        RecordBatch::try_new(Arc::new(schema), vec![Arc::new(Int32Array::from(values))]).unwrap()
+    }
+
+    /// Single-column nullable Boolean batch (column `flag`) with mixed true/null/false rows
+    /// -- exercises the IR contract that NULL conditions select `else_expr`.
+    fn flag_batch() -> RecordBatch {
+        let schema = ArrowSchema::new(vec![ArrowField::new("flag", ArrowDataType::Boolean, true)]);
+        let flag = BooleanArray::from(vec![Some(true), None, Some(false)]);
+        RecordBatch::try_new(Arc::new(schema), vec![Arc::new(flag)]).unwrap()
+    }
+
+    // Happy-path If evaluation over Int32: each case checks one contract.
+    // - `mixed_cond_per_row_select` drives the `zip` path.
+    // - The two short-circuit cases use a sentinel string literal in the unselected branch to prove
+    //   it is never evaluated (eager evaluation would fail the type-mismatch check).
+    // - `null_condition_selects_else` exercises the NULL-as-false contract.
+    // - `nested_clamp` is the canonical `IF(a < 0, 0, IF(a > 100, 100, a))` shape.
+    // - `arithmetic_branches` is the realistic FSR shape: condition and branches are arbitrary
+    //   expression trees (binary ops + nested If).
+    // - `empty_batch` is the `num_rows = 0` boundary.
+    #[rstest]
+    #[case::mixed_cond_per_row_select(
+        create_test_batch(),
+        Expr::if_then_else(
+            column_expr!("a").gt(Expr::literal(2_i32)),
+            Expr::literal(10_i32),
+            Expr::literal(20_i32),
+        ),
+        vec![20, 20, 10],
+    )]
+    #[case::short_circuit_all_true_skips_else(
+        create_test_batch(),
+        Expr::if_then_else(
+            column_expr!("a").gt(Expr::literal(0_i32)),
+            Expr::literal(7_i32),
+            Expr::literal("would-error-if-eager"),
+        ),
+        vec![7, 7, 7],
+    )]
+    #[case::short_circuit_all_false_skips_then(
+        create_test_batch(),
+        Expr::if_then_else(
+            column_expr!("a").lt(Expr::literal(0_i32)),
+            Expr::literal("would-error-if-eager"),
+            Expr::literal(9_i32),
+        ),
+        vec![9, 9, 9],
+    )]
+    #[case::null_condition_selects_else(
+        flag_batch(),
+        Expr::if_then_else(
+            Predicate::BooleanExpression(column_expr!("flag")),
+            Expr::literal(1_i32),
+            Expr::literal(2_i32),
+        ),
+        vec![1, 2, 2],
+    )]
+    #[case::nested_clamp(
+        int_a_batch(vec![Some(-5), Some(0), Some(50), Some(150)], false),
+        Expr::if_then_else(
+            column_expr!("a").lt(Expr::literal(0_i32)),
+            Expr::literal(0_i32),
+            Expr::if_then_else(
+                column_expr!("a").gt(Expr::literal(100_i32)),
+                Expr::literal(100_i32),
+                column_expr!("a"),
+            ),
+        ),
+        vec![0, 0, 50, 100],
+    )]
+    // batch.a = [1, 2, 3], batch.b = [10, 20, 30], batch.c = [100, 200, 300].
+    // IF(a + b > 20, a * c, b - a) -- arithmetic in condition and both branches; this is
+    // the realistic FSR dedup-key shape where If is part of a larger expression tree.
+    #[case::arithmetic_branches(
+        create_test_batch(),
+        Expr::if_then_else(
+            (column_expr!("a") + column_expr!("b")).gt(Expr::literal(20_i32)),
+            column_expr!("a") * column_expr!("c"),
+            column_expr!("b") - column_expr!("a"),
+        ),
+        vec![9, 400, 900], // 1+10=11<=20 -> b-a=9; 2+20=22>20 -> a*c=400; 3+30=33>20 -> 900
+    )]
+    #[case::empty_batch(
+        int_a_batch(vec![], false),
+        Expr::if_then_else(
+            column_expr!("a").gt(Expr::literal(0_i32)),
+            Expr::literal(1_i32),
+            Expr::literal(2_i32),
+        ),
+        vec![],
+    )]
+    fn test_evaluate_if_int_per_row(
+        #[case] batch: RecordBatch,
+        #[case] expr: Expr,
+        #[case] expected: Vec<i32>,
+    ) {
+        let result = evaluate_expression(&expr, &batch, Some(&DataType::INTEGER)).unwrap();
+        let arr = result.as_primitive::<Int32Type>();
+        assert_eq!(arr.values(), expected.as_slice());
+        assert_eq!(arr.data_type(), &ArrowDataType::Int32);
+    }
+
+    #[test]
+    fn test_evaluate_if_branch_type_mismatch_errors() {
+        // Condition `a > 2` is mixed (false, false, true), so both branches must evaluate
+        // -- the type-mismatch check fires only when neither short-circuit applies.
+        let batch = create_test_batch();
+        let expr = Expr::if_then_else(
+            column_expr!("a").gt(Expr::literal(2_i32)),
+            Expr::literal(1_i32),
+            Expr::literal("text"),
+        );
+        let result = evaluate_expression(&expr, &batch, None);
+        assert_result_error_with_message(result, "If branches must have the same type");
+    }
+
+    #[test]
+    fn test_evaluate_if_preserves_element_nulls() {
+        // a = [1, 2, 3] (non-null); b = [Some(10), None, Some(30)] (nullable). Condition
+        // a >= 2 is mixed, so both branches evaluate; the row where the chosen branch is
+        // itself NULL must produce NULL in the output. Kept separate from the rstest above
+        // because the assertion shape uses `Vec<Option<i32>>` rather than `Vec<i32>`.
+        let schema = ArrowSchema::new(vec![
+            ArrowField::new("a", ArrowDataType::Int32, false),
+            ArrowField::new("b", ArrowDataType::Int32, true),
+        ]);
+        let batch = RecordBatch::try_new(
+            Arc::new(schema),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(Int32Array::from(vec![Some(10), None, Some(30)])),
+            ],
+        )
+        .unwrap();
+        let expr = Expr::if_then_else(
+            column_expr!("a").ge(Expr::literal(2_i32)),
+            column_expr!("b"),
+            Expr::literal(0_i32),
+        );
+        let result = evaluate_expression(&expr, &batch, Some(&DataType::INTEGER)).unwrap();
+        // a=1 -> else (0); a=2 -> then (b=NULL); a=3 -> then (b=30)
+        assert_eq!(
+            result
+                .as_primitive::<Int32Type>()
+                .iter()
+                .collect::<Vec<_>>(),
+            vec![Some(0), None, Some(30)]
+        );
+    }
+
+    #[test]
+    fn test_evaluate_if_struct_branch_preserves_inner_null_field() {
+        // The chosen branch is a Struct whose struct-level value is always non-null, but
+        // whose single nullable field can carry a null. `zip` must preserve the inner null
+        // through to the output -- it operates per-row on the struct-level validity, while
+        // inner field validity flows through the struct's own child buffers.
+        let schema = ArrowSchema::new(vec![
+            ArrowField::new("a", ArrowDataType::Int32, false),
+            ArrowField::new("b", ArrowDataType::Int32, true),
+        ]);
+        let batch = RecordBatch::try_new(
+            Arc::new(schema),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(Int32Array::from(vec![Some(10), None, Some(30)])),
+            ],
+        )
+        .unwrap();
+        let struct_ty = DataType::Struct(Box::new(
+            StructType::try_new([StructField::nullable("value", DataType::INTEGER)]).unwrap(),
+        ));
+        // Cond a >= 2 -> row 0 picks else, rows 1+2 pick then. Row 1's chosen branch carries
+        // a null in the `value` field.
+        let expr = Expr::if_then_else(
+            column_expr!("a").ge(Expr::literal(2_i32)),
+            Expr::struct_from([column_expr!("b")]),
+            Expr::struct_from([Expr::literal(0_i32)]),
+        );
+        let result = evaluate_expression(&expr, &batch, Some(&struct_ty)).unwrap();
+        let structs = result.as_any().downcast_ref::<StructArray>().unwrap();
+
+        // Every struct row is struct-level non-null.
+        assert_eq!(structs.len(), 3);
+        for row in 0..3 {
+            assert!(structs.is_valid(row));
+        }
+        // Inner field: row 0 = 0 (else), row 1 = NULL (then=b[1]), row 2 = 30 (then=b[2]).
+        assert_eq!(
+            structs
+                .column(0)
+                .as_primitive::<Int32Type>()
+                .iter()
+                .collect::<Vec<_>>(),
+            vec![Some(0), None, Some(30)]
+        );
     }
 }

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -236,6 +236,22 @@ pub struct VariadicExpression {
     pub exprs: Vec<Expression>,
 }
 
+/// A conditional expression: `IF(condition, then_expr, else_expr)`.
+///
+/// Equivalent to SQL's `CASE WHEN condition THEN then_expr ELSE else_expr END` for a single
+/// branch. The condition is a [`Predicate`] (boolean-typed); NULL conditions are treated as
+/// false (SQL standard), so a NULL condition selects `else_expr`. Multi-branch CASE
+/// expressions desugar into nested `If` expressions.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct IfExpression {
+    /// The boolean condition.
+    pub condition: Box<Predicate>,
+    /// The expression evaluated when `condition` is true.
+    pub then_expr: Box<Expression>,
+    /// The expression evaluated when `condition` is false or NULL.
+    pub else_expr: Box<Expression>,
+}
+
 /// An expression that parses a JSON string into a struct with the given schema.
 /// This is the inverse of `ToJson` - it converts a JSON-encoded string column into a
 /// struct column.
@@ -465,6 +481,8 @@ pub enum Expression {
     Binary(BinaryExpression),
     /// An expression that takes a variable number of expressions as input.
     Variadic(VariadicExpression),
+    /// A conditional expression: `IF(condition, then_expr, else_expr)`.
+    If(IfExpression),
     /// An expression that the engine defines and implements. Kernel interacts with the expression
     /// only through methods provided by the [`OpaqueExpressionOp`] trait.
     #[serde(serialize_with = "fail_serialize_opaque_expression")]
@@ -594,6 +612,20 @@ impl VariadicExpression {
     ) -> Self {
         let exprs = exprs.into_iter().map(Into::into).collect();
         Self { op, exprs }
+    }
+}
+
+impl IfExpression {
+    pub(crate) fn new(
+        condition: impl Into<Predicate>,
+        then_expr: impl Into<Expression>,
+        else_expr: impl Into<Expression>,
+    ) -> Self {
+        Self {
+            condition: Box::new(condition.into()),
+            then_expr: Box::new(then_expr.into()),
+            else_expr: Box::new(else_expr.into()),
+        }
     }
 }
 
@@ -773,6 +805,17 @@ impl Expression {
     /// If all expressions evaluate to null, the result is null.
     pub fn coalesce(exprs: impl IntoIterator<Item = impl Into<Expression>>) -> Self {
         Self::variadic(VariadicExpressionOp::Coalesce, exprs)
+    }
+
+    /// Creates a new conditional expression `IF(condition, then_expr, else_expr)`.
+    ///
+    /// See [`IfExpression`] for the semantic contract (notably, how NULL conditions are handled).
+    pub fn if_then_else(
+        condition: impl Into<Predicate>,
+        then_expr: impl Into<Expression>,
+        else_expr: impl Into<Expression>,
+    ) -> Self {
+        Self::If(IfExpression::new(condition, then_expr, else_expr))
     }
 
     /// Creates a new opaque expression
@@ -1066,6 +1109,11 @@ impl Display for Expression {
             Variadic(VariadicExpression { op, exprs }) => {
                 write!(f, "{op}({})", format_child_list(exprs))
             }
+            If(IfExpression {
+                condition,
+                then_expr,
+                else_expr,
+            }) => write!(f, "IF({condition}, {then_expr}, {else_expr})"),
             Opaque(OpaqueExpression { op, exprs }) => {
                 write!(f, "{op:?}({})", format_child_list(exprs))
             }
@@ -1208,6 +1256,14 @@ mod tests {
             (
                 Expr::struct_from([column_expr!("x"), Expr::literal(2), Expr::literal(10)]),
                 "Struct(Column(x), 2, 10)",
+            ),
+            (
+                Expr::if_then_else(
+                    column_expr!("x").is_null(),
+                    Expr::literal(0),
+                    column_expr!("x"),
+                ),
+                "IF(Column(x) IS NULL, 0, Column(x))",
             ),
         ];
 
@@ -1411,6 +1467,26 @@ mod tests {
                 column_expr!("b"),
                 Expression::literal("default"),
             ]);
+            assert_roundtrip(&expr);
+        }
+
+        #[rstest::rstest]
+        #[case::if_simple(Expression::if_then_else(
+            column_expr!("flag").is_null(),
+            Expression::literal(0i64),
+            column_expr!("value"),
+        ))]
+        // IF(a IS NULL, 0, IF(a > 100, 100, a)) -- a typical clamp pattern.
+        #[case::if_nested(Expression::if_then_else(
+            column_expr!("a").is_null(),
+            Expression::literal(0i64),
+            Expression::if_then_else(
+                column_expr!("a").gt(Expression::literal(100i64)),
+                Expression::literal(100i64),
+                column_expr!("a"),
+            ),
+        ))]
+        fn test_if_expression_roundtrip(#[case] expr: Expression) {
             assert_roundtrip(&expr);
         }
 

--- a/kernel/src/kernel_predicates/mod.rs
+++ b/kernel/src/kernel_predicates/mod.rs
@@ -184,6 +184,7 @@ pub trait KernelPredicateEvaluator {
             | Expr::Unary(_)
             | Expr::Binary(_)
             | Expr::Variadic(_)
+            | Expr::If(_)
             | Expr::ParseJson(_)
             | Expr::MapToStruct(_)
             | Expr::Unknown(_) => None,
@@ -213,6 +214,7 @@ pub trait KernelPredicateEvaluator {
                 | Expr::Unary(_)
                 | Expr::Binary(_)
                 | Expr::Variadic(_)
+                | Expr::If(_)
                 | Expr::Opaque(_)
                 | Expr::ParseJson { .. }
                 | Expr::MapToStruct(_)
@@ -641,7 +643,7 @@ impl<R: ResolveColumnAsScalar> DefaultKernelPredicateEvaluator<R> {
                 };
                 op_fn(&self.eval_expr(left)?, &self.eval_expr(right)?)
             }
-            Expr::Variadic(_) => None, // TODO
+            Expr::Variadic(_) | Expr::If(_) => None, // TODO
             Expr::Opaque(OpaqueExpression { op, exprs }) => op
                 .eval_expr_scalar(&|expr| self.eval_expr(expr), exprs)
                 .inspect_err(|err| {

--- a/kernel/src/kernel_predicates/tests.rs
+++ b/kernel/src/kernel_predicates/tests.rs
@@ -1048,3 +1048,16 @@ fn test_sql_where() {
     expect_eq!(null_filter.eval_sql_where(pred), Some(false), "{pred}");
     expect_eq!(empty_filter.eval_sql_where(pred), None, "{pred}");
 }
+
+// Pin the contract: kernel predicate evaluator does not push `If` down -- regardless of the
+// condition shape (simple column, compound predicate, literal-true) -- it must return None.
+#[rstest::rstest]
+#[case::simple_column_cond(column_pred!("flag"))]
+#[case::compound_cond(Pred::and(column_pred!("a"), column_pred!("b")))]
+#[case::literal_true(Pred::literal(true))]
+#[case::literal_false(Pred::literal(false))]
+fn test_eval_expr_if_returns_none(#[case] cond: Pred) {
+    let empty_filter = DefaultKernelPredicateEvaluator::from(EmptyColumnResolver);
+    let if_expr = Expr::if_then_else(cond, Expr::literal(1i64), Expr::literal(2i64));
+    expect_eq!(empty_filter.eval_expr(&if_expr), None, "If(...) => None");
+}

--- a/kernel/src/transforms/expression.rs
+++ b/kernel/src/transforms/expression.rs
@@ -2,13 +2,14 @@ use std::borrow::{Cow, ToOwned};
 use std::sync::Arc;
 
 use crate::expressions::{
-    BinaryExpression, BinaryPredicate, ColumnName, Expression, ExpressionRef, JunctionPredicate,
-    MapToStructExpression, OpaqueExpression, OpaquePredicate, ParseJsonExpression, Predicate,
-    Scalar, Transform, UnaryExpression, UnaryPredicate, VariadicExpression,
+    BinaryExpression, BinaryPredicate, ColumnName, Expression, ExpressionRef, IfExpression,
+    JunctionPredicate, MapToStructExpression, OpaqueExpression, OpaquePredicate,
+    ParseJsonExpression, Predicate, Scalar, Transform, UnaryExpression, UnaryPredicate,
+    VariadicExpression,
 };
 use crate::transforms::{
-    map_owned_children_or_else, map_owned_or_else, map_owned_pair_or_else, transform_output_type,
-    Carrier,
+    map_owned_children_or_else, map_owned_or_else, map_owned_pair_or_else, map_owned_trio_or_else,
+    transform_output_type, Carrier,
 };
 use crate::{DeltaResult, Error};
 
@@ -37,6 +38,10 @@ use crate::{DeltaResult, Error};
 ///
 /// * Binary (two children) - If either child was filtered out, filter out the parent. If at least
 ///   one child changed, build a new parent around them. Otherwise, return the parent unchanged.
+///
+/// * Ternary (three children) - If any child was filtered out, filter out the parent. If at least
+///   one child changed, build a new parent around them. Otherwise, return the parent unchanged.
+///   Children may have heterogeneous types (e.g. `If(Predicate, Expression, Expression)`).
 ///
 /// * Variadic (0+ children) - If no children remain (all filtered out), filter out the parent.
 ///   Otherwise, if at least one child changed or was filtered out, build a new parent around the
@@ -186,6 +191,12 @@ pub trait ExpressionTransform<'a> {
         self.recurse_into_expr_variadic(expr)
     }
 
+    /// Called for each conditional `If` expression encountered during the traversal. The provided
+    /// implementation just forwards to [`Self::recurse_into_expr_if`].
+    fn transform_expr_if(&mut self, expr: &'a IfExpression) -> Self::Output<IfExpression> {
+        self.recurse_into_expr_if(expr)
+    }
+
     /// Called for each junction predicate encountered during the traversal. The provided
     /// implementation just forwards to [`Self::recurse_into_pred_junction`].
     fn transform_pred_junction(
@@ -245,6 +256,10 @@ pub trait ExpressionTransform<'a> {
             Expression::Variadic(v) => {
                 let child = self.transform_expr_variadic(v);
                 map_owned_or_else(expr, child, Expression::Variadic)
+            }
+            Expression::If(i) => {
+                let child = self.transform_expr_if(i);
+                map_owned_or_else(expr, child, Expression::If)
             }
             Expression::Opaque(o) => {
                 let child = self.transform_expr_opaque(o);
@@ -394,6 +409,15 @@ pub trait ExpressionTransform<'a> {
     ) -> Self::Output<VariadicExpression> {
         let children = v.exprs.iter().map(|e| self.transform_expr(e));
         map_owned_children_or_else(v, children, |exprs| VariadicExpression::new(v.op, exprs))
+    }
+
+    /// Recursively transforms an `If` expression's three children (ternary). If any child is
+    /// filtered out the whole expression is filtered out -- a partial `If` is not meaningful.
+    fn recurse_into_expr_if(&mut self, i: &'a IfExpression) -> Self::Output<IfExpression> {
+        let condition = self.transform_pred(&i.condition);
+        let then_expr = self.transform_expr(&i.then_expr);
+        let else_expr = self.transform_expr(&i.else_expr);
+        map_owned_trio_or_else(i, condition, then_expr, else_expr, IfExpression::new)
     }
 
     /// Recursively transforms a junction predicate's children (variadic).
@@ -632,6 +656,92 @@ mod tests {
         if let Cow::Borrowed(result_expr) = result {
             assert_eq!(result_expr, &variadic_expr);
         }
+    }
+
+    // Pin the contract that `If` recurses into condition / then / else arms and that each arm
+    // participates in the column rewrite. Without this guard, a transform pass that handles
+    // `Variadic` but forgets `If` would silently leave references un-rewritten in the
+    // conditional, which is a real footgun for FSR-style filter-out semantics.
+    #[rstest::rstest]
+    #[case::no_match_returns_borrowed(
+        Expr::if_then_else(column_pred!("x"), column_expr!("y"), Expr::literal(42)),
+        Expr::if_then_else(column_pred!("x"), column_expr!("y"), Expr::literal(42)),
+        true,
+    )]
+    #[case::all_arms_rewritten(
+        Expr::if_then_else(
+            column_pred!("old_col"),
+            column_expr!("old_col"),
+            column_expr!("old_col"),
+        ),
+        Expr::if_then_else(
+            column_pred!("new_col"),
+            column_expr!("new_col"),
+            column_expr!("new_col"),
+        ),
+        false,
+    )]
+    #[case::condition_arm_only(
+        Expr::if_then_else(column_pred!("old_col"), Expr::literal(1), Expr::literal(0)),
+        Expr::if_then_else(column_pred!("new_col"), Expr::literal(1), Expr::literal(0)),
+        false,
+    )]
+    #[case::then_arm_only(
+        Expr::if_then_else(column_pred!("flag"), column_expr!("old_col"), Expr::literal(0)),
+        Expr::if_then_else(column_pred!("flag"), column_expr!("new_col"), Expr::literal(0)),
+        false,
+    )]
+    #[case::else_arm_only(
+        Expr::if_then_else(column_pred!("flag"), Expr::literal(1), column_expr!("old_col")),
+        Expr::if_then_else(column_pred!("flag"), Expr::literal(1), column_expr!("new_col")),
+        false,
+    )]
+    fn test_transform_expr_if_recursion(
+        #[case] input: Expr,
+        #[case] expected: Expr,
+        #[case] expect_borrowed: bool,
+    ) {
+        let result = ColumnReplacer.transform_expr(&input);
+        if expect_borrowed {
+            assert!(matches!(result, Cow::Borrowed(_)));
+        } else {
+            assert!(matches!(result, Cow::Owned(_)));
+        }
+        assert_eq!(result.into_owned(), expected);
+    }
+
+    // The "any child filtered out drops the parent" contract must hold for any of the three
+    // arms -- condition, then, or else. A filtering carrier that drops column references
+    // verifies this independent of arm position.
+    #[rstest::rstest]
+    #[case::dropped_in_condition(Expr::if_then_else(
+        column_pred!("dropped_col"),
+        Expr::literal(1),
+        Expr::literal(0),
+    ))]
+    #[case::dropped_in_then(Expr::if_then_else(
+        column_pred!("flag"),
+        column_expr!("dropped_col"),
+        Expr::literal(0),
+    ))]
+    #[case::dropped_in_else(Expr::if_then_else(
+        column_pred!("flag"),
+        Expr::literal(1),
+        column_expr!("dropped_col"),
+    ))]
+    fn test_transform_expr_if_arm_filter_drops_expression(#[case] if_expr: Expr) {
+        struct ColumnRemover;
+        impl<'a> ExpressionTransform<'a> for ColumnRemover {
+            transform_output_type!(|'a, T| Option<Cow<'a, T>>);
+            fn transform_expr_column(
+                &mut self,
+                _name: &'a ColumnName,
+            ) -> Option<Cow<'a, ColumnName>> {
+                None
+            }
+        }
+        let result = ColumnRemover.transform_expr(&if_expr);
+        assert!(result.is_none());
     }
 
     #[test]

--- a/kernel/src/transforms/mod.rs
+++ b/kernel/src/transforms/mod.rs
@@ -131,6 +131,48 @@ where
     })
 }
 
+/// Rebuilds a three-child parent from transformed children only when needed.
+///
+/// Children may have three different types (e.g. `Predicate` + two `Expression`s for an
+/// `IfExpression`); each child has its own carrier. If any child is filtered out (`None`),
+/// filter out the parent by returning `None`. If all three children survive as borrowed
+/// values, this returns a borrowed parent. Otherwise, it uses the provided `map_owned`
+/// function to rebuild and return an owned parent.
+pub(crate) fn map_owned_trio_or_else<'a, Parent, C1, C2, C3, CC1, CC2, CC3, ParentCarrier, R>(
+    parent: &'a Parent,
+    first: CC1,
+    second: CC2,
+    third: CC3,
+    map_owned: impl FnOnce(C1::Owned, C2::Owned, C3::Owned) -> Parent,
+) -> ParentCarrier
+where
+    Parent: Clone,
+    C1: ToOwned + ?Sized + 'a,
+    C2: ToOwned + ?Sized + 'a,
+    C3: ToOwned + ?Sized + 'a,
+    CC1: Carrier<'a, C1, Residual = R>,
+    CC2: Carrier<'a, C2, Residual = R>,
+    CC3: Carrier<'a, C3, Residual = R>,
+    ParentCarrier: Carrier<'a, Parent, Residual = R>,
+{
+    let first = carrier_into_inner_opt!(first);
+    let second = carrier_into_inner_opt!(second);
+    let third = carrier_into_inner_opt!(third);
+    let (Some(first), Some(second), Some(third)) = (first, second, third) else {
+        // SAFETY: Only a filtering carrier could produce None => try_none must succeed.
+        carrier_try_none!();
+        unreachable!();
+    };
+    Carrier::from_inner(match (first, second, third) {
+        (Cow::Borrowed(_), Cow::Borrowed(_), Cow::Borrowed(_)) => Cow::Borrowed(parent),
+        (first, second, third) => Cow::Owned(map_owned(
+            first.into_owned(),
+            second.into_owned(),
+            third.into_owned(),
+        )),
+    })
+}
+
 /// Rebuilds a single-child parent from a transformed child only when needed.
 ///
 /// If the child is filtered out (`None`), filter out the parent by returning `None`. If the child


### PR DESCRIPTION
## Motivation

Full state reconstruction (FSR) needs a per-row dedup key so that the latest action for each identity wins. Today the key is built imperatively in kernel (`extract_dv_unique_id` and friends). The plan-based engine moves that work out of kernel: kernel emits a plan whose dedup-key column is an `Expression` evaluated by the engine. That requires the key construction to be expressible in the kernel IR.

The key is a CASE-WHEN over action kinds (file rows vs protocol vs metaData vs domainMetadata vs txn), with each branch producing the appropriate `ARRAY<STRING?>` key. `If(...)` is the primitive that selects the right arm per row; the multi-arm CASE-WHEN desugars into nested `If` expressions. `Array(...)` (sibling PR #2639) constructs the per-arm key values.

## What changes are proposed in this pull request?

Adds the conditional expression.

- `Expression::If(IfExpression)` variant with `condition: Box<Predicate>` + `then_expr: Box<Expression>` + `else_expr: Box<Expression>`. NULL conditions are treated as false (SQL standard), so a NULL condition selects `else_expr`.
- `Expression::if_then_else(cond, then, else)` constructor.
- Arrow evaluator that short-circuits when every row picks the same branch (skipping the unselected branch entirely), then falls back to a row-wise `zip` for mixed conditions.
- `transforms::map_owned_trio_or_else` helper for heterogeneous-typed ternary children; `transform_expr_if` recurses into all three arms and filters out the parent if any child is dropped.
- FFI `EngineExpressionVisitor::visit_if` callback. **Breaking ABI**: every C consumer must populate the new field. The `visit-expression` C example wires `ExpressionType::If` end-to-end (struct, visitor, print/free arms, golden output) so dispatch is exercised in CI.

### Public API changes

A new expression variant is added: `Expression::If`, `IfExpression`, `Expression::if_then_else`. The FFI struct gains one non-null `extern "C" fn` field, hence `feat!`.

## How was this change tested?

- `cargo +nightly fmt && cargo clippy --workspace --benches --tests --all-features -- -D warnings && cargo doc --workspace --all-features --no-deps`
- Arrow evaluator:
  - Mixed-condition per-row select
  - Short-circuit on all-true / all-false (sentinel string literal in the unselected branch proves it is never evaluated)
  - NULL conditions select `else_expr`
  - Branch type-mismatch error
  - Nested `If` clamp pattern
  - Arithmetic conditions + branches (the realistic dedup-key shape)
  - Null preservation through `zip` for nullable column inputs
  - Struct-typed branches: outer struct is non-null but the inner field carries a null (verifies `zip` propagates struct-level validity and inner-field nulls correctly)
  - Empty batch (`num_rows == 0`) boundary
- KernelPredicate evaluator: pins `If` as unsupported (returns `None`)
- Transform recursion: per-arm rewrite, no-op, and filter-out semantics across all three arms
- FFI: the C `visit-expression` example evaluates a kernel-built `If` end-to-end against a golden output