### PR TITLE
feat: add col/lit constructors + relax Transform field setters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,6 +264,14 @@ Keep this list updated when new protocol features are added to kernel.
   Reserve `StructField::new` for cases where nullability is a runtime value.
 - Prefer the `DeltaResultIterator<'a, T>` / `DeltaResultIteratorStatic<T>` aliases over
   hand-rolled `Box<dyn Iterator<Item = DeltaResult<T>> + Send (+ 'a)>`.
+- Prefer the free constructors `col(name)` and `lit(value)` over
+  `Expression::column(...)` / `Expression::literal(...)` when building expressions
+  inline. Use `col(["a", "b"])` for explicit multi-segment paths (segments are
+  taken as-is, no dot-splitting). When the path is a known string literal that
+  should be split on dots, use the compile-time `column_expr!("a.b")` /
+  `column_name!("a.b")` macros instead. Chain `.to_json()` for the
+  `Unary(ToJson, _)` pattern and the standard `+ - * /` operators for binary
+  arithmetic on `Expression`.
 - NEVER panic in production code -- use errors instead. Panicking
   (including `unwrap()`, `expect()`, `panic!()`, `unreachable!()`, etc) is acceptable in test code only.
 

--- a/ffi/src/test_ffi.rs
+++ b/ffi/src/test_ffi.rs
@@ -113,19 +113,16 @@ pub unsafe extern "C" fn get_testing_kernel_expression() -> Handle<SharedExpress
 
     let nested_patch = ExpressionStructPatch::new_top_level()
         .with_dropped_field("gone")
-        .with_replaced_field("stub", Expr::literal("replaced").into())
-        .with_inserted_field(Some("x".to_string()), Expr::literal(true).into())
-        .with_inserted_field(Some("y".to_string()), Expr::literal(false).into());
+        .with_replaced_field("stub", Expr::literal("replaced"))
+        .with_inserted_field(Some("x".to_string()), Expr::literal(true))
+        .with_inserted_field(Some("y".to_string()), Expr::literal(false));
     let top_level_patch = ExpressionStructPatch::new_nested(column_name!("foo.bar.baz"))
         .with_dropped_field("dropme")
-        .with_replaced_field("replaceme", Expr::literal(42).into())
-        .with_inserted_field(None::<&str>, Expr::literal("prepended").into())
-        .with_inserted_field(Some("a".to_string()), Expr::literal("first").into())
-        .with_inserted_field(
-            Some("a".to_string()),
-            Expr::struct_patch(nested_patch).into(),
-        )
-        .with_inserted_field(Some("a".to_string()), Expr::literal("third").into());
+        .with_replaced_field("replaceme", Expr::literal(42))
+        .with_inserted_field(None::<&str>, Expr::literal("prepended"))
+        .with_inserted_field(Some("a".to_string()), Expr::literal("first"))
+        .with_inserted_field(Some("a".to_string()), Expr::struct_patch(nested_patch))
+        .with_inserted_field(Some("a".to_string()), Expr::literal("third"));
 
     let mut sub_exprs = vec![
         column_expr!("col"),

--- a/kernel/src/checkpoint/checkpoint_transform.rs
+++ b/kernel/src/checkpoint/checkpoint_transform.rs
@@ -16,7 +16,7 @@
 use std::sync::{Arc, LazyLock};
 
 use crate::actions::ADD_NAME;
-use crate::expressions::{Expression, ExpressionRef, ExpressionStructPatch, UnaryExpressionOp};
+use crate::expressions::{col, Expression, ExpressionRef, ExpressionStructPatch};
 use crate::schema::{DataType, SchemaRef, StructField, StructType};
 use crate::table_properties::TableProperties;
 use crate::{DeltaResult, Error};
@@ -212,11 +212,8 @@ pub(crate) fn build_checkpoint_output_schema(
 /// ["add", "stats"] instead of just ["stats"].
 fn build_stats_parsed_expr(stats_schema: &SchemaRef) -> ExpressionRef {
     Arc::new(Expression::coalesce([
-        Expression::column([ADD_NAME, STATS_PARSED_FIELD]),
-        Expression::parse_json(
-            Expression::column([ADD_NAME, STATS_FIELD]),
-            stats_schema.clone(),
-        ),
+        col([ADD_NAME, STATS_PARSED_FIELD]),
+        Expression::parse_json(col([ADD_NAME, STATS_FIELD]), stats_schema.clone()),
     ]))
 }
 
@@ -233,8 +230,8 @@ fn build_stats_parsed_expr(stats_schema: &SchemaRef) -> ExpressionRef {
 /// `["add", "partitionValues"]` instead of just `["partitionValues"]`.
 fn build_partition_values_parsed_expr() -> ExpressionRef {
     Arc::new(Expression::coalesce([
-        Expression::column([ADD_NAME, PARTITION_VALUES_PARSED_FIELD]),
-        Expression::map_to_struct(Expression::column([ADD_NAME, PARTITION_VALUES_FIELD])),
+        col([ADD_NAME, PARTITION_VALUES_PARSED_FIELD]),
+        Expression::map_to_struct(col([ADD_NAME, PARTITION_VALUES_FIELD])),
     ]))
 }
 
@@ -245,11 +242,8 @@ fn build_partition_values_parsed_expr() -> ExpressionRef {
 /// ["add", "stats"] instead of just ["stats"].
 static STATS_JSON_EXPR: LazyLock<ExpressionRef> = LazyLock::new(|| {
     Arc::new(Expression::coalesce([
-        Expression::column([ADD_NAME, STATS_FIELD]),
-        Expression::unary(
-            UnaryExpressionOp::ToJson,
-            Expression::column([ADD_NAME, STATS_PARSED_FIELD]),
-        ),
+        col([ADD_NAME, STATS_FIELD]),
+        col([ADD_NAME, STATS_PARSED_FIELD]).to_json(),
     ]))
 });
 

--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -116,7 +116,7 @@ use crate::actions::{
     SET_TRANSACTION_NAME, SIDECAR_NAME,
 };
 use crate::engine_data::FilteredEngineData;
-use crate::expressions::{Expression, ExpressionStructPatch, Scalar, StructData};
+use crate::expressions::{lit, Expression, ExpressionStructPatch, Scalar, StructData};
 use crate::last_checkpoint_hint::LastCheckpointHint;
 use crate::log_replay::LogReplayProcessor;
 use crate::path::{self, ParsedLogPath};
@@ -742,10 +742,8 @@ impl CheckpointWriter {
         )?);
 
         // Use a struct patch to set just the checkpointMetadata field, keeping others null
-        let patch = ExpressionStructPatch::new_top_level().with_replaced_field(
-            CHECKPOINT_METADATA_NAME,
-            Arc::new(Expression::literal(checkpoint_metadata_value)),
-        );
+        let patch = ExpressionStructPatch::new_top_level()
+            .with_replaced_field(CHECKPOINT_METADATA_NAME, lit(checkpoint_metadata_value));
 
         let evaluator = engine.evaluation_handler().new_expression_evaluator(
             schema.clone(),

--- a/kernel/src/checkpoint/sidecar/mod.rs
+++ b/kernel/src/checkpoint/sidecar/mod.rs
@@ -203,13 +203,10 @@ impl SidecarSplitter {
             checkpoint_data_schema.clone(),
             Arc::new(Expression::struct_patch(
                 ExpressionStructPatch::new_top_level()
-                    .with_replaced_field(
-                        ADD_NAME,
-                        Arc::new(lit(Scalar::Null(add_field.data_type.clone()))),
-                    )
+                    .with_replaced_field(ADD_NAME, lit(Scalar::Null(add_field.data_type.clone())))
                     .with_replaced_field(
                         REMOVE_NAME,
-                        Arc::new(lit(Scalar::Null(remove_field.data_type.clone()))),
+                        lit(Scalar::Null(remove_field.data_type.clone())),
                     ),
             )),
             checkpoint_data_schema.clone().into(),

--- a/kernel/src/checkpoint/sidecar/mod.rs
+++ b/kernel/src/checkpoint/sidecar/mod.rs
@@ -5,7 +5,9 @@ use itertools::Itertools;
 use crate::action_reconciliation::ActionReconciliationIterator;
 use crate::actions::{ADD_NAME, REMOVE_NAME, SIDECAR_NAME};
 use crate::engine_data::filter_by_predicate;
-use crate::expressions::{Expression, ExpressionStructPatch, Predicate, Scalar, StructData};
+use crate::expressions::{
+    col, lit, Expression, ExpressionStructPatch, Predicate, Scalar, StructData,
+};
 use crate::schema::{DataType, SchemaRef, StructField, StructType};
 use crate::{
     DeltaResult, Engine, EngineData, Error, EvaluationHandler, ExpressionEvaluator, FileMeta,
@@ -182,10 +184,7 @@ impl SidecarSplitter {
         // Sidecar projector: select only add/remove columns.
         let file_action_projector = eval_handler.new_expression_evaluator(
             checkpoint_data_schema.clone(),
-            Arc::new(Expression::struct_from([
-                Expression::column([ADD_NAME]),
-                Expression::column([REMOVE_NAME]),
-            ])),
+            Arc::new(Expression::struct_from([col(ADD_NAME), col(REMOVE_NAME)])),
             sidecar_output_schema.clone().into(),
         )?;
 
@@ -193,8 +192,8 @@ impl SidecarSplitter {
         let file_actions_null_row_filter = eval_handler.new_predicate_evaluator(
             sidecar_output_schema,
             Arc::new(Predicate::or(
-                Predicate::is_not_null(Expression::column([ADD_NAME])),
-                Predicate::is_not_null(Expression::column([REMOVE_NAME])),
+                Predicate::is_not_null(col(ADD_NAME)),
+                Predicate::is_not_null(col(REMOVE_NAME)),
             )),
         )?;
 
@@ -206,15 +205,11 @@ impl SidecarSplitter {
                 ExpressionStructPatch::new_top_level()
                     .with_replaced_field(
                         ADD_NAME,
-                        Arc::new(Expression::literal(Scalar::Null(
-                            add_field.data_type.clone(),
-                        ))),
+                        Arc::new(lit(Scalar::Null(add_field.data_type.clone()))),
                     )
                     .with_replaced_field(
                         REMOVE_NAME,
-                        Arc::new(Expression::literal(Scalar::Null(
-                            remove_field.data_type.clone(),
-                        ))),
+                        Arc::new(lit(Scalar::Null(remove_field.data_type.clone()))),
                     ),
             )),
             checkpoint_data_schema.clone().into(),
@@ -226,7 +221,7 @@ impl SidecarSplitter {
                 checkpoint_data_schema
                     .fields()
                     .filter(|f| f.name != ADD_NAME && f.name != REMOVE_NAME)
-                    .map(|f| Predicate::is_not_null(Expression::column([f.name.as_str()]))),
+                    .map(|f| Predicate::is_not_null(col(f.name.as_str()))),
             );
             eval_handler.new_predicate_evaluator(checkpoint_data_schema, Arc::new(predicate))?
         };

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -1189,8 +1189,8 @@ mod tests {
         let batch = create_test_batch();
 
         // Test unused replacement keys
-        let patch = ExpressionStructPatch::new_top_level()
-            .with_replaced_field("missing", Expr::literal(1));
+        let patch =
+            ExpressionStructPatch::new_top_level().with_replaced_field("missing", Expr::literal(1));
         let output_schema = StructType::new_unchecked(vec![
             StructField::not_null("a", DataType::INTEGER),
             StructField::not_null("b", DataType::INTEGER),

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -1064,12 +1064,12 @@ mod tests {
         let patch = ExpressionStructPatch::new_top_level()
             .with_replaced_field("a", column_expr_ref!("b"))
             .with_dropped_field("b")
-            .with_inserted_field(None::<&str>, Expr::literal(1).into())
-            .with_inserted_field(None::<&str>, Expr::literal(2).into())
+            .with_inserted_field(None::<&str>, Expr::literal(1))
+            .with_inserted_field(None::<&str>, Expr::literal(2))
             .with_inserted_field(None::<&str>, column_expr_ref!("c"))
-            .with_inserted_field(Some("c"), Expr::literal(42).into())
+            .with_inserted_field(Some("c"), Expr::literal(42))
             .with_inserted_field(Some("c"), column_expr_ref!("a"))
-            .with_inserted_field(Some("c"), Expr::literal(99).into());
+            .with_inserted_field(Some("c"), Expr::literal(99));
 
         let output_schema = StructType::new_unchecked(vec![
             StructField::new("pre1", DataType::INTEGER, false), // prepend 1
@@ -1149,8 +1149,8 @@ mod tests {
 
         // Test 2: Modify nested struct and relocate it
         let modify_patch = ExpressionStructPatch::new_nested(["nested"])
-            .with_replaced_field("x".to_string(), Expr::literal(777).into())
-            .with_inserted_field(Some("y"), Expr::literal(555).into());
+            .with_replaced_field("x".to_string(), Expr::literal(777))
+            .with_inserted_field(Some("y"), Expr::literal(555));
 
         let modify_output_schema = StructType::new_unchecked(vec![
             StructField::new("x", DataType::INTEGER, false), // replaced with literal 777
@@ -1189,7 +1189,7 @@ mod tests {
 
         // Test unused replacement keys
         let patch = ExpressionStructPatch::new_top_level()
-            .with_replaced_field("missing", Expr::literal(1).into());
+            .with_replaced_field("missing", Expr::literal(1));
         let output_schema = StructType::new_unchecked(vec![
             StructField::not_null("a", DataType::INTEGER),
             StructField::not_null("b", DataType::INTEGER),
@@ -1209,7 +1209,7 @@ mod tests {
 
         // Test unused insertion keys
         let insertion_patch = ExpressionStructPatch::new_top_level()
-            .with_inserted_field(Some("nonexistent"), Expr::literal(1).into());
+            .with_inserted_field(Some("nonexistent"), Expr::literal(1));
 
         let expr2 = Expr::StructPatch(insertion_patch);
         let result2 = evaluate_expression(
@@ -1598,10 +1598,10 @@ mod tests {
 
         // Simple nested patch - replace a field in the nested struct
         let nested_patch = ExpressionStructPatch::new_nested(["nested"])
-            .with_replaced_field("x", Expr::literal(999).into());
+            .with_replaced_field("x", Expr::literal(999));
 
         let outer_patch = ExpressionStructPatch::new_top_level()
-            .with_inserted_field(Some("a"), Expr::StructPatch(nested_patch).into());
+            .with_inserted_field(Some("a"), Expr::StructPatch(nested_patch));
 
         let nested_output_schema = StructType::new_unchecked(vec![
             StructField::not_null("x", DataType::INTEGER),

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -928,7 +928,8 @@ mod tests {
         DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
     };
     use crate::expressions::{
-        column_expr, column_expr_ref, BinaryExpressionOp, Expression as Expr, ExpressionStructPatch,
+        col, column_expr, column_expr_ref, BinaryExpressionOp, Expression as Expr,
+        ExpressionStructPatch,
     };
     use crate::schema::{DataType, StructField, StructType};
     use crate::utils::test_utils::assert_result_error_with_message;
@@ -1535,8 +1536,8 @@ mod tests {
         // a reference to a non-existent column. If short-circuit works, the
         // non-existent column is never evaluated and no error occurs.
         let expr = Expression::coalesce([
-            Expression::column(["a"]),
-            Expression::column(["nonexistent"]), // Would fail if evaluated
+            col("a"),
+            col("nonexistent"), // Would fail if evaluated
         ]);
 
         // Should return column "a" directly (short-circuit skips evaluating "nonexistent")
@@ -1563,9 +1564,9 @@ mod tests {
         // Create coalesce expression: a has nulls, b has none, c doesn't exist.
         // Short-circuit should stop after evaluating b.
         let expr = Expression::coalesce([
-            Expression::column(["a"]),
-            Expression::column(["b"]),
-            Expression::column(["nonexistent"]), // Would fail if evaluated
+            col("a"),
+            col("b"),
+            col("nonexistent"), // Would fail if evaluated
         ]);
 
         // Should coalesce a and b, never evaluate "nonexistent"
@@ -1585,7 +1586,7 @@ mod tests {
         let a_values = Int32Array::from(vec![1, 2, 3]); // No nulls - would short-circuit
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a_values)]).unwrap();
 
-        let expr = Expression::coalesce([Expression::column(["a"])]);
+        let expr = Expression::coalesce([col("a")]);
 
         // Request STRING type but array is INT32 - should fail even with short-circuit
         let result = evaluate_expression(&expr, &batch, Some(&DataType::STRING));

--- a/kernel/src/engine/parquet_row_group_skipping/tests.rs
+++ b/kernel/src/engine/parquet_row_group_skipping/tests.rs
@@ -7,7 +7,8 @@ use super::*;
 use crate::arrow::array::{Int64Array, RecordBatch, StringArray, StructArray};
 use crate::arrow::datatypes::{DataType as ArrowDataType, Field, Fields, Schema as ArrowSchema};
 use crate::expressions::{
-    column_expr, column_name, column_pred, Expression, OpaquePredicateOp, ScalarExpressionEvaluator,
+    column_expr, column_name, column_pred, lit, Expression, OpaquePredicateOp,
+    ScalarExpressionEvaluator,
 };
 use crate::kernel_predicates::{
     DataSkippingPredicateEvaluator as _, DirectDataSkippingPredicateEvaluator,
@@ -958,10 +959,7 @@ fn checkpoint_filter_opaque_predicate_with_null_guarded_stats() {
 
     // OpaqueLessThanOp(x, 5) -> "x < 5". Data skipping checks min(x) < 5.
     // min(x) = 10, so 10 < 5 is false -> can skip the row group.
-    let predicate = Predicate::opaque(
-        OpaqueLessThanOp,
-        vec![column_expr!("x"), Expression::literal(5i64)],
-    );
+    let predicate = Predicate::opaque(OpaqueLessThanOp, vec![column_expr!("x"), lit(5i64)]);
     assert!(!CheckpointRowGroupFilter::apply(
         row_group,
         &predicate,
@@ -969,10 +967,7 @@ fn checkpoint_filter_opaque_predicate_with_null_guarded_stats() {
     ));
 
     // OpaqueLessThanOp(x, 50) -> "x < 50". min(x) = 10, so 10 < 50 is true -> keep.
-    let predicate = Predicate::opaque(
-        OpaqueLessThanOp,
-        vec![column_expr!("x"), Expression::literal(50i64)],
-    );
+    let predicate = Predicate::opaque(OpaqueLessThanOp, vec![column_expr!("x"), lit(50i64)]);
     assert!(CheckpointRowGroupFilter::apply(
         row_group,
         &predicate,
@@ -996,10 +991,7 @@ fn checkpoint_filter_opaque_predicate_with_missing_stats() {
     // OpaqueLessThanOp(x, 5) -> "x < 5". The stat column has nulls, so the null-guarded
     // provider returns None for min(x). The opaque op gets None and returns None,
     // which means the row group cannot be pruned. This is the safe behavior.
-    let predicate = Predicate::opaque(
-        OpaqueLessThanOp,
-        vec![column_expr!("x"), Expression::literal(5i64)],
-    );
+    let predicate = Predicate::opaque(OpaqueLessThanOp, vec![column_expr!("x"), lit(5i64)]);
     assert!(CheckpointRowGroupFilter::apply(
         row_group,
         &predicate,

--- a/kernel/src/expressions/column_names.rs
+++ b/kernel/src/expressions/column_names.rs
@@ -130,7 +130,7 @@ impl ColumnName {
 /// [`column_name!`]: crate::expressions::column_name
 /// [`column_expr!`]: crate::expressions::column_expr
 pub trait IntoColumnName {
-    /// Consume `self` and produce the [`ColumnName`] it represents.
+    /// Consumes `self` and produces the [`ColumnName`] it represents.
     fn into_column_name(self) -> ColumnName;
 }
 
@@ -159,6 +159,12 @@ impl IntoColumnName for &String {
 }
 
 impl<A: Into<String>, const N: usize> IntoColumnName for [A; N] {
+    fn into_column_name(self) -> ColumnName {
+        ColumnName::new(self.into_iter().map(Into::into))
+    }
+}
+
+impl<A: Into<String>> IntoColumnName for Vec<A> {
     fn into_column_name(self) -> ColumnName {
         ColumnName::new(self.into_iter().map(Into::into))
     }
@@ -784,14 +790,14 @@ mod test {
 
     #[test]
     fn into_column_name_str_is_single_segment_with_no_split() {
-        // Strings (`&str` / `String`) build a single segment containing the input verbatim;
-        // dots are not path separators. For dot-separated literals, callers should use the
-        // `column_name!` / `column_expr!` macros (which split via a proc macro at compile time).
+        // Strings (`&str` / `String` / `&String`) build a single segment containing the input
+        // verbatim; dots are not path separators. For dot-separated literals, callers should
+        // use the `column_name!` / `column_expr!` macros (which split via a proc macro at
+        // compile time).
         assert_eq!("a.b".into_column_name(), ColumnName::new(["a.b"]));
-        assert_eq!(
-            "name".to_string().into_column_name(),
-            ColumnName::new(["name"])
-        );
+        let owned = "name".to_string();
+        assert_eq!(owned.clone().into_column_name(), ColumnName::new(["name"]));
+        assert_eq!((&owned).into_column_name(), ColumnName::new(["name"]));
     }
 
     #[test]
@@ -800,6 +806,7 @@ mod test {
         assert_eq!(["a", "b", "c"].into_column_name(), expected);
         let slice: &[&str] = &["a", "b", "c"];
         assert_eq!(slice.into_column_name(), expected);
+        assert_eq!(vec!["a", "b", "c"].into_column_name(), expected);
         assert_eq!(("a", "b", "c").into_column_name(), expected);
         // Identity round-trip on `ColumnName` itself.
         assert_eq!(expected.clone().into_column_name(), expected);

--- a/kernel/src/expressions/column_names.rs
+++ b/kernel/src/expressions/column_names.rs
@@ -119,6 +119,71 @@ impl ColumnName {
     }
 }
 
+/// Conversion into a [`ColumnName`] from common builder shapes.
+///
+/// String inputs (`&str`, `String`) produce a **single-segment** column whose name is the input
+/// verbatim. Dots are **not** path separators -- `"a.b".into_column_name()` is one segment named
+/// `"a.b"`. For dot-separated path literals known at compile time, prefer the [`column_name!`]
+/// or [`column_expr!`] macros, which split via a proc macro at compile time. For runtime
+/// multi-segment paths, pass an array, slice, or tuple: `["add", "path"].into_column_name()`.
+///
+/// [`column_name!`]: crate::expressions::column_name
+/// [`column_expr!`]: crate::expressions::column_expr
+pub trait IntoColumnName {
+    /// Consume `self` and produce the [`ColumnName`] it represents.
+    fn into_column_name(self) -> ColumnName;
+}
+
+impl IntoColumnName for ColumnName {
+    fn into_column_name(self) -> ColumnName {
+        self
+    }
+}
+
+impl IntoColumnName for &str {
+    fn into_column_name(self) -> ColumnName {
+        ColumnName::new([self])
+    }
+}
+
+impl IntoColumnName for String {
+    fn into_column_name(self) -> ColumnName {
+        ColumnName::new([self])
+    }
+}
+
+impl<A: Into<String>, const N: usize> IntoColumnName for [A; N] {
+    fn into_column_name(self) -> ColumnName {
+        ColumnName::new(self.into_iter().map(Into::into))
+    }
+}
+
+impl IntoColumnName for &[&str] {
+    fn into_column_name(self) -> ColumnName {
+        ColumnName::new(self.iter().copied())
+    }
+}
+
+impl<A: Into<String>, B: Into<String>> IntoColumnName for (A, B) {
+    fn into_column_name(self) -> ColumnName {
+        ColumnName::new([self.0.into(), self.1.into()])
+    }
+}
+
+impl<A: Into<String>, B: Into<String>, C: Into<String>> IntoColumnName for (A, B, C) {
+    fn into_column_name(self) -> ColumnName {
+        ColumnName::new([self.0.into(), self.1.into(), self.2.into()])
+    }
+}
+
+impl<A: Into<String>, B: Into<String>, C: Into<String>, D: Into<String>> IntoColumnName
+    for (A, B, C, D)
+{
+    fn into_column_name(self) -> ColumnName {
+        ColumnName::new([self.0.into(), self.1.into(), self.2.into(), self.3.into()])
+    }
+}
+
 /// Creates a new column name from a path of field names. Each field name is taken as-is, and may
 /// contain arbitrary characters (including periods, spaces, etc.).
 impl<A: Into<String>> FromIterator<A> for ColumnName {
@@ -709,5 +774,35 @@ mod test {
                 _ => panic!("Expected {input} to parse as {expected_output:?}, got {output:?}"),
             }
         }
+    }
+
+    #[test]
+    fn into_column_name_str_is_single_segment_with_no_split() {
+        // Strings (`&str` / `String`) build a single segment containing the input verbatim;
+        // dots are not path separators. For dot-separated literals, callers should use the
+        // `column_name!` / `column_expr!` macros (which split via a proc macro at compile time).
+        assert_eq!("a.b".into_column_name(), ColumnName::new(["a.b"]));
+        assert_eq!(
+            "name".to_string().into_column_name(),
+            ColumnName::new(["name"])
+        );
+    }
+
+    #[test]
+    fn into_column_name_multi_segment_shapes() {
+        let expected = ColumnName::new(["a", "b", "c"]);
+        assert_eq!(["a", "b", "c"].into_column_name(), expected);
+        let slice: &[&str] = &["a", "b", "c"];
+        assert_eq!(slice.into_column_name(), expected);
+        assert_eq!(("a", "b", "c").into_column_name(), expected);
+        // Identity round-trip on `ColumnName` itself.
+        assert_eq!(expected.clone().into_column_name(), expected);
+    }
+
+    #[test]
+    fn into_column_name_tuple_arity_four() {
+        // Exercises the (A, B, C, D) impl explicitly to lock down the 4-element field order.
+        let expected = ColumnName::new(["w", "x", "y", "z"]);
+        assert_eq!(("w", "x", "y", "z").into_column_name(), expected);
     }
 }

--- a/kernel/src/expressions/column_names.rs
+++ b/kernel/src/expressions/column_names.rs
@@ -152,6 +152,12 @@ impl IntoColumnName for String {
     }
 }
 
+impl IntoColumnName for &String {
+    fn into_column_name(self) -> ColumnName {
+        ColumnName::new([self.as_str()])
+    }
+}
+
 impl<A: Into<String>, const N: usize> IntoColumnName for [A; N] {
     fn into_column_name(self) -> ColumnName {
         ColumnName::new(self.into_iter().map(Into::into))

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -796,6 +796,11 @@ impl Expression {
         Self::Unary(UnaryExpression::new(op, expr))
     }
 
+    /// Serializes `self` to a JSON string. Inverse of [`Expression::parse_json`].
+    pub fn to_json(self) -> Self {
+        Self::unary(UnaryExpressionOp::ToJson, self)
+    }
+
     /// Creates a new binary expression lhs OP rhs
     pub fn binary(
         op: BinaryExpressionOp,

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -9,7 +9,7 @@ use serde::{de, ser, Deserialize, Deserializer, Serialize, Serializer};
 
 pub use self::column_names::{
     column_expr, column_expr_ref, column_name, column_pred, joined_column_expr, joined_column_name,
-    ColumnName,
+    ColumnName, IntoColumnName,
 };
 pub use self::scalars::{ArrayData, DecimalData, MapData, Scalar, StructData};
 use crate::kernel_predicates::{
@@ -27,6 +27,41 @@ mod scalars;
 
 pub type ExpressionRef = std::sync::Arc<Expression>;
 pub type PredicateRef = std::sync::Arc<Predicate>;
+
+/// Build an [`Expression::Column`] from anything that converts into a [`ColumnName`].
+///
+/// Concise alternative to `Expression::column([name])` for plan builders. Accepts the same
+/// shapes as [`IntoColumnName`]: a bare `&str` (single-segment, no dot splitting), an array
+/// or slice (`col(["add", "path"])`), a tuple (`col(("add", "path"))`), or a prebuilt
+/// [`ColumnName`].
+///
+/// Strings are **not** split on `.`. For dot-separated path literals known at compile time,
+/// prefer [`column_expr!`] which splits via a proc macro:
+/// `column_expr!("add.path")` produces a 2-segment column, while `col("add.path")` produces
+/// a 1-segment column named `"add.path"`.
+///
+/// ```
+/// use delta_kernel::expressions::col;
+/// let _ = col(["add", "path"]).is_not_null();
+/// ```
+///
+/// [`column_expr!`]: crate::expressions::column_expr
+pub fn col<N: IntoColumnName>(name: N) -> Expression {
+    Expression::Column(name.into_column_name())
+}
+
+/// Build an [`Expression::Literal`] from anything that converts into a [`Scalar`].
+///
+/// Concise alternative to [`Expression::literal`] for plan builders. Accepts the same value
+/// types [`Scalar`] does (`i32`, `i64`, `&str`, `bool`, ...).
+///
+/// ```
+/// use delta_kernel::expressions::lit;
+/// let _zero = lit(0i64);
+/// ```
+pub fn lit(value: impl Into<Scalar>) -> Expression {
+    Expression::literal(value)
+}
 
 ////////////////////////////////////////////////////////////////////////
 // Operators
@@ -402,22 +437,30 @@ impl ExpressionStructPatch {
         self
     }
 
-    /// Specifies an expression to replace a field with.
-    pub fn with_replaced_field(mut self, name: impl Into<String>, expr: ExpressionRef) -> Self {
+    /// Specifies an expression to replace a field with. `expr` accepts a bare [`Expression`]
+    /// or an existing [`ExpressionRef`] (`Arc<Expression>`); the bare form is auto-wrapped via
+    /// the std `impl<T> From<T> for Arc<T>` blanket.
+    pub fn with_replaced_field(
+        mut self,
+        name: impl Into<String>,
+        expr: impl Into<ExpressionRef>,
+    ) -> Self {
         let field_patch = self.field_patch(name);
-        field_patch.exprs.push(expr);
+        field_patch.exprs.push(expr.into());
         field_patch.is_replace = true;
         self
     }
 
     /// Specifies an expression to insert after an optional predecessor (None = prepend, emit the
     /// expression before the first input field). Multiple fields can be inserted after the same
-    /// predecessor, and they will be emitted in the same order they were registered.
+    /// predecessor, and they will be emitted in the same order they were registered. `expr`
+    /// accepts a bare [`Expression`] or an existing [`ExpressionRef`].
     pub fn with_inserted_field(
         mut self,
         after: Option<impl Into<String>>,
-        expr: ExpressionRef,
+        expr: impl Into<ExpressionRef>,
     ) -> Self {
+        let expr = expr.into();
         match after {
             Some(field_name) => self.field_patch(field_name).exprs.push(expr),
             None => self.prepended_fields.push(expr),
@@ -1187,11 +1230,15 @@ impl<'a> ExpressionTransform<'a> for GetColumnReferences<'a> {
 #[cfg(test)]
 mod tests {
     use std::fmt::Debug;
+    use std::sync::Arc;
 
     use serde::de::DeserializeOwned;
     use serde::Serialize;
 
-    use super::{column_expr, column_pred, Expression as Expr, Predicate as Pred};
+    use super::{
+        col, column_expr, column_pred, lit, Expression as Expr, ExpressionStructPatch,
+        Predicate as Pred,
+    };
 
     /// Helper function to verify roundtrip serialization/deserialization
     fn assert_roundtrip<T: Serialize + DeserializeOwned + PartialEq + Debug>(value: &T) {
@@ -1759,5 +1806,31 @@ mod tests {
     fn empty_or_from_returns_identity_literal() {
         let result = Pred::or_from(std::iter::empty());
         assert_eq!(result, Pred::literal(false));
+    }
+
+    #[test]
+    fn col_and_lit_produce_same_shape_as_explicit_constructors() {
+        assert_eq!(col("name"), Expr::column(["name"]));
+        assert_eq!(col(["add", "path"]), Expr::column(["add", "path"]));
+        assert_eq!(col(("add", "path")), Expr::column(["add", "path"]));
+        assert_eq!(lit(0i64), Expr::literal(0i64));
+        // Compose with a predicate to exercise the public surface end-to-end.
+        assert_eq!(
+            col(["add", "path"]).is_not_null(),
+            Expr::column(["add", "path"]).is_not_null(),
+        );
+    }
+
+    #[test]
+    fn transform_field_setters_accept_expression_and_expression_ref() {
+        // `impl Into<ExpressionRef>` lets callers pass either form. Both shapes must produce
+        // structurally equivalent transforms.
+        let by_value = ExpressionStructPatch::new_top_level()
+            .with_replaced_field("a", Expr::literal(1))
+            .with_inserted_field(Some("a"), Expr::literal(2));
+        let by_ref = ExpressionStructPatch::new_top_level()
+            .with_replaced_field("a", Arc::new(Expr::literal(1)))
+            .with_inserted_field(Some("a"), Arc::new(Expr::literal(2)));
+        assert_eq!(format!("{by_value:?}"), format!("{by_ref:?}"));
     }
 }

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -30,10 +30,9 @@ pub type PredicateRef = std::sync::Arc<Predicate>;
 
 /// Build an [`Expression::Column`] from anything that converts into a [`ColumnName`].
 ///
-/// Concise alternative to `Expression::column([name])` for plan builders. Accepts the same
-/// shapes as [`IntoColumnName`]: a bare `&str` (single-segment, no dot splitting), an array
-/// or slice (`col(["add", "path"])`), a tuple (`col(("add", "path"))`), or a prebuilt
-/// [`ColumnName`].
+/// Concise alternative to [`Expression::column`] for plan builders. See [`IntoColumnName`]
+/// for the full set of accepted input shapes (single-segment strings, arrays, slices,
+/// vectors, tuples, and pre-built [`ColumnName`]s).
 ///
 /// Strings are **not** split on `.`. For dot-separated path literals known at compile time,
 /// prefer [`column_expr!`] which splits via a proc macro:
@@ -796,7 +795,8 @@ impl Expression {
         Self::Unary(UnaryExpression::new(op, expr))
     }
 
-    /// Serializes `self` to a JSON string. Inverse of [`Expression::parse_json`].
+    /// Serializes `self` to a JSON string. See [`Expression::parse_json`] for the parsing
+    /// direction (which also requires the output schema).
     pub fn to_json(self) -> Self {
         Self::unary(UnaryExpressionOp::ToJson, self)
     }
@@ -1242,7 +1242,7 @@ mod tests {
 
     use super::{
         col, column_expr, column_pred, lit, Expression as Expr, ExpressionStructPatch,
-        Predicate as Pred,
+        Predicate as Pred, UnaryExpressionOp,
     };
 
     /// Helper function to verify roundtrip serialization/deserialization
@@ -1818,11 +1818,20 @@ mod tests {
         assert_eq!(col("name"), Expr::column(["name"]));
         assert_eq!(col(["add", "path"]), Expr::column(["add", "path"]));
         assert_eq!(col(("add", "path")), Expr::column(["add", "path"]));
+        assert_eq!(col(vec!["add", "path"]), Expr::column(["add", "path"]));
         assert_eq!(lit(0i64), Expr::literal(0i64));
         // Compose with a predicate to exercise the public surface end-to-end.
         assert_eq!(
             col(["add", "path"]).is_not_null(),
             Expr::column(["add", "path"]).is_not_null(),
+        );
+    }
+
+    #[test]
+    fn to_json_chains_unary_tojson() {
+        assert_eq!(
+            col("x").to_json(),
+            Expr::unary(UnaryExpressionOp::ToJson, col("x")),
         );
     }
 

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -14,7 +14,7 @@ use crate::actions::{
     METADATA_NAME, MIN_VALUES, PROTOCOL_NAME, SET_TRANSACTION_NAME, SIDECAR_NAME,
 };
 use crate::committer::CatalogCommit;
-use crate::expressions::ColumnName;
+use crate::expressions::{col, ColumnName};
 use crate::last_checkpoint_hint::{LastCheckpointHint, LastCheckpointHintSummary};
 use crate::log_reader::commit::CommitReader;
 use crate::log_replay::ActionsBatch;
@@ -28,8 +28,8 @@ use crate::schema::compare::SchemaComparison;
 use crate::schema::{DataType, SchemaRef, StructField, StructType, ToSchema as _};
 use crate::utils::require;
 use crate::{
-    DeltaResult, Engine, Error, Expression, FileMeta, Predicate, PredicateRef, RowVisitor,
-    StorageHandler, Version,
+    DeltaResult, Engine, Error, FileMeta, Predicate, PredicateRef, RowVisitor, StorageHandler,
+    Version,
 };
 
 mod crc_replay;
@@ -146,9 +146,7 @@ fn schema_to_is_not_null_predicate(schema: &StructType) -> Option<PredicateRef> 
         .fields()
         .map(|f| action_identifying_column(f.name()))
         .collect::<Option<_>>()?;
-    let mut predicates = columns
-        .into_iter()
-        .map(|col| Expression::column(col).is_not_null());
+    let mut predicates = columns.into_iter().map(|name| col(name).is_not_null());
     let first = predicates.next()?;
     Some(Arc::new(predicates.fold(first, Predicate::or)))
 }

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -18,7 +18,7 @@ use crate::arrow::array::StringArray;
 use crate::engine::arrow_data::ArrowEngineData;
 use crate::engine::sync::json::SyncJsonHandler;
 use crate::engine::sync::SyncEngine;
-use crate::expressions::ColumnName;
+use crate::expressions::col;
 use crate::last_checkpoint_hint::{LastCheckpointHint, LastCheckpointHintSummary};
 use crate::log_replay::ActionsBatch;
 use crate::log_segment::LogSegment;
@@ -37,8 +37,8 @@ use crate::utils::test_utils::{
     assert_batch_matches, assert_result_error_with_message, string_array_to_engine_data, Action,
 };
 use crate::{
-    DeltaResult, EngineData, Expression, FileMeta, JsonHandler, ParquetHandler, Predicate,
-    PredicateRef, RowVisitor, StorageHandler,
+    DeltaResult, EngineData, FileMeta, JsonHandler, ParquetHandler, Predicate, PredicateRef,
+    RowVisitor, StorageHandler,
 };
 
 /// Processes sidecar files for the given checkpoint batch.
@@ -1147,11 +1147,8 @@ async fn test_reading_sidecar_files_with_predicate() -> DeltaResult<()> {
     );
 
     // Filter out sidecar files that do not contain remove actions
-    let remove_predicate: LazyLock<Option<PredicateRef>> = LazyLock::new(|| {
-        Some(Arc::new(
-            Expression::column([REMOVE_NAME, "path"]).is_not_null(),
-        ))
-    });
+    let remove_predicate: LazyLock<Option<PredicateRef>> =
+        LazyLock::new(|| Some(Arc::new(col([REMOVE_NAME, "path"]).is_not_null())));
 
     let mut iter = process_sidecars(
         engine.parquet_handler(),
@@ -4328,7 +4325,7 @@ async fn test_segment_crc_filtering(#[case] case: CrcPruningCase) {
         StructType::new_unchecked([]),
     )]),
     Some(Arc::new(
-        Expression::column(ColumnName::new([METADATA_NAME, "id"])).is_not_null(),
+        col([METADATA_NAME, "id"]).is_not_null(),
     )),
 )]
 #[case::protocol_field(
@@ -4337,7 +4334,7 @@ async fn test_segment_crc_filtering(#[case] case: CrcPruningCase) {
         StructType::new_unchecked([]),
     )]),
     Some(Arc::new(
-        Expression::column(ColumnName::new([PROTOCOL_NAME, "minReaderVersion"])).is_not_null(),
+        col([PROTOCOL_NAME, "minReaderVersion"]).is_not_null(),
     )),
 )]
 #[case::txn_field(
@@ -4346,7 +4343,7 @@ async fn test_segment_crc_filtering(#[case] case: CrcPruningCase) {
         StructType::new_unchecked([]),
     )]),
     Some(Arc::new(
-        Expression::column(ColumnName::new([SET_TRANSACTION_NAME, "appId"])).is_not_null(),
+        col([SET_TRANSACTION_NAME, "appId"]).is_not_null(),
     )),
 )]
 #[case::domain_metadata_field(
@@ -4355,7 +4352,7 @@ async fn test_segment_crc_filtering(#[case] case: CrcPruningCase) {
         StructType::new_unchecked([]),
     )]),
     Some(Arc::new(
-        Expression::column(ColumnName::new([DOMAIN_METADATA_NAME, "domain"])).is_not_null(),
+        col([DOMAIN_METADATA_NAME, "domain"]).is_not_null(),
     )),
 )]
 #[case::unknown_field_returns_none(
@@ -4368,8 +4365,8 @@ async fn test_segment_crc_filtering(#[case] case: CrcPruningCase) {
         StructField::nullable(PROTOCOL_NAME, StructType::new_unchecked([])),
     ]),
     Some(Arc::new(Predicate::or(
-        Expression::column(ColumnName::new([METADATA_NAME, "id"])).is_not_null(),
-        Expression::column(ColumnName::new([PROTOCOL_NAME, "minReaderVersion"])).is_not_null(),
+        col([METADATA_NAME, "id"]).is_not_null(),
+        col([PROTOCOL_NAME, "minReaderVersion"]).is_not_null(),
     ))),
 )]
 #[case::known_and_unknown_field_returns_none(

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -12,8 +12,8 @@ use super::{PhysicalPredicate, ScanMetadata};
 use crate::actions::deletion_vector::DeletionVectorDescriptor;
 use crate::engine_data::{GetData, RowVisitor, TypedGetData as _};
 use crate::expressions::{
-    column_expr, column_expr_ref, column_name, ColumnName, Expression, ExpressionRef, PredicateRef,
-    UnaryExpressionOp,
+    col, column_expr, column_expr_ref, column_name, lit, ColumnName, Expression, ExpressionRef,
+    PredicateRef,
 };
 use crate::log_replay::deduplicator::{CheckpointDeduplicator, Deduplicator, FileActionInfo};
 use crate::log_replay::{
@@ -656,16 +656,13 @@ fn get_add_transform_expr(
     has_partition_values_parsed: bool,
 ) -> ExpressionRef {
     let stats_expr = if skip_stats {
-        Arc::new(Expression::Literal(Scalar::Null(DataType::STRING)))
+        Arc::new(lit(Scalar::Null(DataType::STRING)))
     } else if has_stats_parsed {
         // Checkpoint may lack JSON stats when writeStatsAsJson=false. Fall back to
         // serializing stats_parsed so ScanFile.stats is populated either way.
         Arc::new(Expression::coalesce([
-            Expression::column(["add", "stats"]),
-            Expression::unary(
-                UnaryExpressionOp::ToJson,
-                Expression::column(["add", "stats_parsed"]),
-            ),
+            col(["add", "stats"]),
+            col(["add", "stats_parsed"]).to_json(),
         ]))
     } else {
         column_expr_ref!("add.stats")
@@ -941,7 +938,7 @@ mod tests {
     use crate::actions::get_commit_schema;
     use crate::engine::sync::SyncEngine;
     use crate::expressions::{
-        BinaryExpressionOp, Expression, OpaquePredicateOp, Predicate, Scalar,
+        col, lit, BinaryExpressionOp, OpaquePredicateOp, Predicate, Scalar,
         ScalarExpressionEvaluator,
     };
     use crate::kernel_predicates::{
@@ -1600,7 +1597,7 @@ mod tests {
             StructField::new("value", DataType::INTEGER, true),
         ])),
         vec![],
-        Arc::new(Expression::column(["value"]).gt(Expression::literal(5i32))),
+        Arc::new(col("value").gt(lit(5i32))),
         false, // use batch without partition column
     )]
     #[case::partition_predicate(
@@ -1609,7 +1606,7 @@ mod tests {
             StructField::new("date", DataType::DATE, true),
         ])),
         vec!["date".to_string()],
-        Arc::new(Expression::column(["date"]).eq(Expression::literal(Scalar::Date(17_510)))),
+        Arc::new(col("date").eq(lit(Scalar::Date(17_510)))),
         true, // use batch with partition column
     )]
     #[case::mixed_stats_and_partition(
@@ -1619,8 +1616,8 @@ mod tests {
         ])),
         vec!["date".to_string()],
         Arc::new(Predicate::and(
-            Expression::column(["value"]).gt(Expression::literal(5i32)),
-            Expression::column(["date"]).eq(Expression::literal(Scalar::Date(17_510))),
+            col("value").gt(lit(5i32)),
+            col("date").eq(lit(Scalar::Date(17_510))),
         )),
         true, // use batch with partition column
     )]

--- a/kernel/src/scan/transform_spec.rs
+++ b/kernel/src/scan/transform_spec.rs
@@ -173,7 +173,7 @@ pub(crate) fn get_transform_expr(
                     // This ensures consistent column ordering across file types
                     patch = patch
                         .with_dropped_field(physical_name.clone())
-                        .with_inserted_field(insert_after.clone(), Arc::new(col(physical_name)));
+                        .with_inserted_field(insert_after.clone(), col(physical_name));
                     patch
                 } else {
                     // Column doesn't exist physically - treat as partition column

--- a/kernel/src/scan/transform_spec.rs
+++ b/kernel/src/scan/transform_spec.rs
@@ -10,9 +10,7 @@ use std::sync::Arc;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
-use crate::expressions::{
-    BinaryExpressionOp, Expression, ExpressionRef, ExpressionStructPatch, Scalar,
-};
+use crate::expressions::{col, lit, Expression, ExpressionRef, ExpressionStructPatch, Scalar};
 use crate::schema::{DataType, SchemaRef, StructType};
 use crate::table_features::ColumnMappingMode;
 use crate::{DeltaResult, Error};
@@ -144,12 +142,8 @@ pub(crate) fn get_transform_expr(
                     Error::generic("Asked to generate RowIds, but no baseRowId found.")
                 })?;
                 let expr = Arc::new(Expression::coalesce([
-                    Expression::column([field_name]),
-                    Expression::binary(
-                        BinaryExpressionOp::Plus,
-                        Expression::literal(base_row_id),
-                        Expression::column([row_index_field_name]),
-                    ),
+                    col(field_name),
+                    lit(base_row_id) + col(row_index_field_name),
                 ]));
                 patch.with_replaced_field(field_name.clone(), expr)
             }
@@ -179,10 +173,7 @@ pub(crate) fn get_transform_expr(
                     // This ensures consistent column ordering across file types
                     patch = patch
                         .with_dropped_field(physical_name.clone())
-                        .with_inserted_field(
-                            insert_after.clone(),
-                            Arc::new(Expression::column([physical_name.clone()])),
-                        );
+                        .with_inserted_field(insert_after.clone(), Arc::new(col(physical_name)));
                     patch
                 } else {
                     // Column doesn't exist physically - treat as partition column
@@ -368,7 +359,7 @@ mod tests {
 
     #[test]
     fn test_get_transform_expr_static_transforms() {
-        let expr = Arc::new(Expression::literal(42));
+        let expr = Arc::new(lit(42));
         let transform_spec = vec![
             FieldTransformSpec::StaticInsert {
                 insert_after: Some("col1".to_string()),
@@ -595,12 +586,8 @@ mod tests {
         assert!(row_id_patch.is_replace);
 
         let expeceted_expr = Arc::new(Expression::coalesce([
-            Expression::column(["row_id_col"]),
-            Expression::binary(
-                BinaryExpressionOp::Plus,
-                Expression::literal(4i64),
-                Expression::column(["row_index_col"]),
-            ),
+            col("row_id_col"),
+            lit(4i64) + col("row_index_col"),
         ]));
         assert_eq!(row_id_patch.exprs.len(), 1);
         let expr = &row_id_patch.exprs[0];

--- a/kernel/src/table_changes/scan_file.rs
+++ b/kernel/src/table_changes/scan_file.rs
@@ -11,7 +11,7 @@ use itertools::Itertools;
 use super::log_replay::TableChangesScanMetadata;
 use crate::actions::visitors::visit_deletion_vector_at;
 use crate::engine_data::{GetData, TypedGetData};
-use crate::expressions::{column_expr, Expression};
+use crate::expressions::{column_expr, lit, Expression};
 use crate::scan::state::DvInfo;
 use crate::schema::{
     ColumnName, ColumnNamesAndTypes, DataType, MapType, SchemaRef, StructField, StructType,
@@ -255,8 +255,8 @@ pub(crate) fn cdf_scan_row_expression(commit_timestamp: i64, commit_number: i64)
             Expression::struct_from([column_expr!("cdc.partitionValues")]),
             column_expr!("cdc.size"),
         ]),
-        Expression::literal(commit_timestamp),
-        Expression::literal(commit_number),
+        lit(commit_timestamp),
+        lit(commit_number),
     ])
 }
 

--- a/kernel/src/transaction/commit_info.rs
+++ b/kernel/src/transaction/commit_info.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use super::Transaction;
 use crate::actions::{get_log_commit_info_schema, CommitInfo, COMMIT_INFO_NAME};
-use crate::expressions::{ExpressionStructPatch, MapData, Scalar};
+use crate::expressions::{lit, ExpressionStructPatch, MapData, Scalar};
 use crate::schema::{MapType, StructField, StructType, ToSchema};
 use crate::{DataType, Engine, EngineData, Error, Expression, ExpressionRef, IntoEngineData};
 
@@ -15,44 +15,28 @@ fn commit_info_literal_exprs(
 ) -> Result<Vec<(&'static str, ExpressionRef)>, Error> {
     let op_params_map_type = MapType::new(DataType::STRING, DataType::STRING, true);
     let literal_exprs = vec![
-        (
-            "timestamp",
-            Arc::new(Expression::literal(commit_info.timestamp)),
-        ),
+        ("timestamp", Arc::new(lit(commit_info.timestamp))),
         (
             "inCommitTimestamp",
-            Arc::new(Expression::literal(commit_info.in_commit_timestamp)),
+            Arc::new(lit(commit_info.in_commit_timestamp)),
         ),
-        (
-            "operation",
-            Arc::new(Expression::literal(commit_info.operation)),
-        ),
+        ("operation", Arc::new(lit(commit_info.operation))),
         (
             "operationParameters",
-            Arc::new(Expression::literal(
-                match commit_info.operation_parameters {
-                    Some(map) => Scalar::Map(MapData::try_new(
-                        op_params_map_type,
-                        map.into_iter()
-                            .map(|(k, v)| (Scalar::String(k), Scalar::String(v))),
-                    )?),
-                    None => Scalar::Null(DataType::Map(Box::new(op_params_map_type))),
-                },
-            )),
+            match commit_info.operation_parameters {
+                Some(map) => lit(Scalar::Map(MapData::try_new(
+                    op_params_map_type,
+                    map.into_iter()
+                        .map(|(k, v)| (Scalar::String(k), Scalar::String(v))),
+                )?))
+                .into(),
+                None => lit(Scalar::Null(DataType::Map(Box::new(op_params_map_type)))).into(),
+            },
         ),
-        (
-            "kernelVersion",
-            Arc::new(Expression::literal(commit_info.kernel_version)),
-        ),
-        (
-            "isBlindAppend",
-            Arc::new(Expression::literal(commit_info.is_blind_append)),
-        ),
-        (
-            "engineInfo",
-            Arc::new(Expression::literal(commit_info.engine_info)),
-        ),
-        ("txnId", Arc::new(Expression::literal(commit_info.txn_id))),
+        ("kernelVersion", Arc::new(lit(commit_info.kernel_version))),
+        ("isBlindAppend", Arc::new(lit(commit_info.is_blind_append))),
+        ("engineInfo", Arc::new(lit(commit_info.engine_info))),
+        ("txnId", Arc::new(lit(commit_info.txn_id))),
     ];
     let expected_expr_len = CommitInfo::to_schema().fields().len();
     if literal_exprs.len() != expected_expr_len {

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -18,8 +18,7 @@ use crate::committer::{
 use crate::crc::{is_incremental_safe_operation, CrcDelta, FileStatsDelta, LazyCrc};
 use crate::engine_data::FilteredEngineData;
 use crate::error::Error;
-use crate::expressions::UnaryExpressionOp::ToJson;
-use crate::expressions::{ArrayData, ColumnName, ExpressionStructPatch, Scalar};
+use crate::expressions::{col, lit, ArrayData, ColumnName, ExpressionStructPatch, Scalar};
 use crate::log_segment::LogSegment;
 use crate::partition::serialization::serialize_partition_value;
 use crate::partition::validation::validate_partition_values;
@@ -304,14 +303,8 @@ where
     add_files_metadata.map(move |add_files_batch| {
         let patch_expr = Expression::struct_patch(
             ExpressionStructPatch::new_top_level()
-                .with_inserted_field(
-                    Some("modificationTime"),
-                    Expression::literal(data_change),
-                )
-                .with_replaced_field(
-                    "stats",
-                    Expression::unary(ToJson, Expression::column(["stats"])),
-                ),
+                .with_inserted_field(Some("modificationTime"), lit(data_change))
+                .with_replaced_field("stats", col("stats").to_json()),
         );
         let adds_expr = Expression::struct_from([patch_expr]);
         let adds_evaluator = evaluation_handler.new_expression_evaluator(
@@ -1404,47 +1397,39 @@ fn build_remove_struct_patch(
 ) -> ExpressionStructPatch {
     let mut patch = ExpressionStructPatch::new_top_level()
         // deletionTimestamp
-        .with_inserted_field(Some("path"), Expression::literal(commit_timestamp))
+        .with_inserted_field(Some("path"), lit(commit_timestamp))
         // dataChange
-        .with_inserted_field(Some("path"), Expression::literal(data_change))
+        .with_inserted_field(Some("path"), lit(data_change))
         // extended_file_metadata
-        .with_inserted_field(Some("path"), Expression::literal(true))
+        .with_inserted_field(Some("path"), lit(true))
         .with_inserted_field(
             Some("path"),
-            Expression::column([FILE_CONSTANT_VALUES_NAME, "partitionValues"]),
+            col([FILE_CONSTANT_VALUES_NAME, "partitionValues"]),
         );
 
     if coalesce_stats_with_parsed {
         // Replace stats with COALESCE(stats, TO_JSON(stats_parsed)), then insert tags after.
         // Both expressions are registered on the "stats" field_patch (is_replace=true),
         // so the evaluator emits [coalesced_stats, tags] in place of the original stats field.
-        let coalesce_stats = Expression::coalesce([
-            Expression::column(["stats"]),
-            Expression::unary(ToJson, Expression::column([STATS_PARSED_NAME])),
-        ]);
+        let coalesce_stats = Expression::coalesce([col("stats"), col(STATS_PARSED_NAME).to_json()]);
         patch = patch
             .with_replaced_field("stats", coalesce_stats)
-            .with_inserted_field(
-                Some("stats"),
-                Expression::column([FILE_CONSTANT_VALUES_NAME, TAGS_NAME]),
-            )
+            .with_inserted_field(Some("stats"), col([FILE_CONSTANT_VALUES_NAME, TAGS_NAME]))
             .with_dropped_field_if_exists(STATS_PARSED_NAME);
     } else {
         // tags inserted after stats; stats passes through unchanged
-        patch = patch.with_inserted_field(
-            Some("stats"),
-            Expression::column([FILE_CONSTANT_VALUES_NAME, TAGS_NAME]),
-        );
+        patch = patch
+            .with_inserted_field(Some("stats"), col([FILE_CONSTANT_VALUES_NAME, TAGS_NAME]));
     }
 
     patch = patch
         .with_inserted_field(
             Some("deletionVector"),
-            Expression::column([FILE_CONSTANT_VALUES_NAME, BASE_ROW_ID_NAME]),
+            col([FILE_CONSTANT_VALUES_NAME, BASE_ROW_ID_NAME]),
         )
         .with_inserted_field(
             Some("deletionVector"),
-            Expression::column([FILE_CONSTANT_VALUES_NAME, DEFAULT_ROW_COMMIT_VERSION_NAME]),
+            col([FILE_CONSTANT_VALUES_NAME, DEFAULT_ROW_COMMIT_VERSION_NAME]),
         )
         .with_dropped_field(FILE_CONSTANT_VALUES_NAME)
         .with_dropped_field("modificationTime")

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -1418,8 +1418,8 @@ fn build_remove_struct_patch(
             .with_dropped_field_if_exists(STATS_PARSED_NAME);
     } else {
         // tags inserted after stats; stats passes through unchanged
-        patch = patch
-            .with_inserted_field(Some("stats"), col([FILE_CONSTANT_VALUES_NAME, TAGS_NAME]));
+        patch =
+            patch.with_inserted_field(Some("stats"), col([FILE_CONSTANT_VALUES_NAME, TAGS_NAME]));
     }
 
     patch = patch

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -306,11 +306,11 @@ where
             ExpressionStructPatch::new_top_level()
                 .with_inserted_field(
                     Some("modificationTime"),
-                    Expression::literal(data_change).into(),
+                    Expression::literal(data_change),
                 )
                 .with_replaced_field(
                     "stats",
-                    Expression::unary(ToJson, Expression::column(["stats"])).into(),
+                    Expression::unary(ToJson, Expression::column(["stats"])),
                 ),
         );
         let adds_expr = Expression::struct_from([patch_expr]);
@@ -1404,14 +1404,14 @@ fn build_remove_struct_patch(
 ) -> ExpressionStructPatch {
     let mut patch = ExpressionStructPatch::new_top_level()
         // deletionTimestamp
-        .with_inserted_field(Some("path"), Expression::literal(commit_timestamp).into())
+        .with_inserted_field(Some("path"), Expression::literal(commit_timestamp))
         // dataChange
-        .with_inserted_field(Some("path"), Expression::literal(data_change).into())
+        .with_inserted_field(Some("path"), Expression::literal(data_change))
         // extended_file_metadata
-        .with_inserted_field(Some("path"), Expression::literal(true).into())
+        .with_inserted_field(Some("path"), Expression::literal(true))
         .with_inserted_field(
             Some("path"),
-            Expression::column([FILE_CONSTANT_VALUES_NAME, "partitionValues"]).into(),
+            Expression::column([FILE_CONSTANT_VALUES_NAME, "partitionValues"]),
         );
 
     if coalesce_stats_with_parsed {
@@ -1423,28 +1423,28 @@ fn build_remove_struct_patch(
             Expression::unary(ToJson, Expression::column([STATS_PARSED_NAME])),
         ]);
         patch = patch
-            .with_replaced_field("stats", coalesce_stats.into())
+            .with_replaced_field("stats", coalesce_stats)
             .with_inserted_field(
                 Some("stats"),
-                Expression::column([FILE_CONSTANT_VALUES_NAME, TAGS_NAME]).into(),
+                Expression::column([FILE_CONSTANT_VALUES_NAME, TAGS_NAME]),
             )
             .with_dropped_field_if_exists(STATS_PARSED_NAME);
     } else {
         // tags inserted after stats; stats passes through unchanged
         patch = patch.with_inserted_field(
             Some("stats"),
-            Expression::column([FILE_CONSTANT_VALUES_NAME, TAGS_NAME]).into(),
+            Expression::column([FILE_CONSTANT_VALUES_NAME, TAGS_NAME]),
         );
     }
 
     patch = patch
         .with_inserted_field(
             Some("deletionVector"),
-            Expression::column([FILE_CONSTANT_VALUES_NAME, BASE_ROW_ID_NAME]).into(),
+            Expression::column([FILE_CONSTANT_VALUES_NAME, BASE_ROW_ID_NAME]),
         )
         .with_inserted_field(
             Some("deletionVector"),
-            Expression::column([FILE_CONSTANT_VALUES_NAME, DEFAULT_ROW_COMMIT_VERSION_NAME]).into(),
+            Expression::column([FILE_CONSTANT_VALUES_NAME, DEFAULT_ROW_COMMIT_VERSION_NAME]),
         )
         .with_dropped_field(FILE_CONSTANT_VALUES_NAME)
         .with_dropped_field("modificationTime")

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -25,7 +25,7 @@ use crate::engine_data::{
 };
 use crate::error::Error;
 use crate::expressions::{
-    column_name, ArrayData, ColumnName, ExpressionStructPatch, Scalar, StructData,
+    col, column_name, lit, ArrayData, ColumnName, ExpressionStructPatch, Scalar, StructData,
 };
 use crate::scan::data_skipping::stats_schema::schema_with_all_fields_nullable;
 use crate::scan::log_replay::get_scan_metadata_transform_expr;
@@ -478,10 +478,7 @@ impl<S> Transaction<S> {
         // expect only the scan row schema fields.
         let with_new_dv_expr = Expression::struct_patch(
             ExpressionStructPatch::new_top_level()
-                .with_replaced_field(
-                    "deletionVector",
-                    Expression::column([NEW_DELETION_VECTOR_NAME]),
-                )
+                .with_replaced_field("deletionVector", col(NEW_DELETION_VECTOR_NAME))
                 .with_dropped_field(NEW_DELETION_VECTOR_NAME),
         );
         let with_new_dv_eval = evaluation_handler.new_expression_evaluator(
@@ -495,10 +492,8 @@ impl<S> Transaction<S> {
             nullable_restored_add_schema().clone().into(),
         )?;
         let with_data_change_expr = Arc::new(Expression::struct_from([Expression::struct_patch(
-            ExpressionStructPatch::new_nested(["add"]).with_inserted_field(
-                Some("modificationTime"),
-                Expression::literal(self.data_change),
-            ),
+            ExpressionStructPatch::new_nested(["add"])
+                .with_inserted_field(Some("modificationTime"), lit(self.data_change)),
         )]));
         let with_data_change_eval = evaluation_handler.new_expression_evaluator(
             nullable_restored_add_schema().clone(),

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -480,7 +480,7 @@ impl<S> Transaction<S> {
             ExpressionStructPatch::new_top_level()
                 .with_replaced_field(
                     "deletionVector",
-                    Expression::column([NEW_DELETION_VECTOR_NAME]).into(),
+                    Expression::column([NEW_DELETION_VECTOR_NAME]),
                 )
                 .with_dropped_field(NEW_DELETION_VECTOR_NAME),
         );
@@ -497,7 +497,7 @@ impl<S> Transaction<S> {
         let with_data_change_expr = Arc::new(Expression::struct_from([Expression::struct_patch(
             ExpressionStructPatch::new_nested(["add"]).with_inserted_field(
                 Some("modificationTime"),
-                Expression::literal(self.data_change).into(),
+                Expression::literal(self.data_change),
             ),
         )]));
         let with_data_change_eval = evaluation_handler.new_expression_evaluator(

--- a/kernel/src/transaction/write_context.rs
+++ b/kernel/src/transaction/write_context.rs
@@ -303,7 +303,7 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::expressions::Expression;
+    use crate::expressions::lit;
     use crate::schema::{DataType, StructField, StructType};
 
     fn make_write_context(
@@ -321,7 +321,7 @@ mod tests {
             table_root: Url::parse("s3://bucket/table/").unwrap(),
             logical_schema: schema.clone(),
             physical_schema: schema.clone(),
-            logical_to_physical: Arc::new(Expression::literal(true)),
+            logical_to_physical: Arc::new(lit(true)),
             column_mapping_mode: cm_mode,
             stats_columns: vec![],
             logical_partition_columns: partition_columns,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Ergonomic helpers for building expressions, plus their adoption across the kernel.

- Add free `col(name)` and `lit(value)` constructors (backed by a new `IntoColumnName` trait) so plan builders can write `col("path").is_not_null()` / `lit(0i64)` instead of `Expression::column(["path"])` / `Expression::literal(0i64)`.
- Relax `Transform::with_replaced_field` / `with_inserted_field` to accept `impl Into<ExpressionRef>`, dropping the `.into()` boilerplate at call sites.
- Adopt the helpers across the in-tree expression-construction sites and document the convention in `CLAUDE.md` (prefer `col`/`lit` inline; use the `column_expr!` / `column_name!` macros when a literal path should be split on dots at compile time).

### This PR affects the following public APIs

- New: `expressions::IntoColumnName`, `expressions::col`, `expressions::lit`, `Expression::to_json`.
- `Expression::column` / `Predicate::column` now accept `impl IntoColumnName` (previously `impl IntoIterator<Item: Into<String>>`).
- `Transform::with_replaced_field` / `with_inserted_field` widened from `ExpressionRef` to `impl Into<ExpressionRef>` (backwards compatible).

## How was this change tested?

Existing kernel and FFI tests exercise the relaxed signatures and the rewritten call sites; full `fmt` / `clippy` / `doc` / `nextest` gate passes.
