### PR TITLE
test: incremental crc replay integration tests

### DIFF
--- a/kernel/src/log_segment/crc_tests.rs
+++ b/kernel/src/log_segment/crc_tests.rs
@@ -52,13 +52,7 @@ fn protocol_v2_dv_ntz() -> Protocol {
 }
 
 fn protocol_v2_ict() -> Protocol {
-    Protocol::try_new(
-        3,
-        7,
-        Some(["v2Checkpoint"]),
-        Some(["v2Checkpoint", "inCommitTimestamp"]),
-    )
-    .unwrap()
+    Protocol::try_new_modern(["v2Checkpoint"], ["v2Checkpoint", "inCommitTimestamp"]).unwrap()
 }
 
 fn metadata_a() -> Metadata {
@@ -107,7 +101,7 @@ fn metadata_ict() -> Metadata {
 // Action JSON helpers
 // ============================================================================
 
-fn bootstrap() -> Vec<serde_json::Value> {
+fn create_table_actions() -> Vec<serde_json::Value> {
     vec![
         commit_info("CREATE", None),
         protocol(protocol_v2()),
@@ -115,7 +109,7 @@ fn bootstrap() -> Vec<serde_json::Value> {
     ]
 }
 
-fn bootstrap_ict() -> Vec<serde_json::Value> {
+fn create_table_actions_with_ict() -> Vec<serde_json::Value> {
     vec![
         commit_info("CREATE", None),
         protocol(protocol_v2_ict()),
@@ -162,11 +156,19 @@ fn remove(path: &str, size: Option<i64>) -> serde_json::Value {
     obj
 }
 
-fn domain_metadata(domain: &str, configuration: &str, removed: bool) -> serde_json::Value {
+fn domain_metadata(domain: &str, configuration: &str) -> serde_json::Value {
     json!({"domainMetadata": {
         "domain": domain,
         "configuration": configuration,
-        "removed": removed,
+        "removed": false,
+    }})
+}
+
+fn domain_metadata_tombstone(domain: &str) -> serde_json::Value {
+    json!({"domainMetadata": {
+        "domain": domain,
+        "configuration": "",
+        "removed": true,
     }})
 }
 
@@ -810,7 +812,7 @@ async fn test_p_m_propagation(
         ..crc_complete_empty_dm_set_txn()
     };
     let crc = CrcReadTest::new()
-        .commit(0, bootstrap())
+        .commit(0, create_table_actions())
         .commit(1, v1_actions)
         .build()
         .await
@@ -836,7 +838,7 @@ async fn test_ict_from_newest_commit_only_replaces_base(
         ..crc_complete_empty_dm_set_txn()
     };
     let crc = CrcReadTest::new()
-        .commit(0, bootstrap_ict())
+        .commit(0, create_table_actions_with_ict())
         .commit(1, [commit_info("WRITE", Some(1000))])
         .commit(2, v2_actions)
         .build()
@@ -859,13 +861,10 @@ async fn test_ict_from_newest_commit_only_replaces_base(
 async fn test_dm_overrides_base_and_preserves_completeness(#[case] base_dm: DomainMetadataState) {
     let base = crc_with_dm_and_txn_states(base_dm, SetTransactionState::Complete(HashMap::new()));
     let crc = CrcReadTest::new()
-        .commit(0, bootstrap())
+        .commit(0, create_table_actions())
         .commit(
             1, // <-- updates "a"; "b" stays at base value
-            [
-                domain_metadata("a", "new_a", /* removed */ false),
-                commit_info("WRITE", None),
-            ],
+            [commit_info("WRITE", None), domain_metadata("a", "new_a")],
         )
         .build()
         .await
@@ -891,13 +890,10 @@ async fn test_dm_overrides_base_and_preserves_completeness(#[case] base_dm: Doma
 async fn test_dm_tombstone_removes_entry_from_base(#[case] base_dm: DomainMetadataState) {
     let base = crc_with_dm_and_txn_states(base_dm, SetTransactionState::Complete(HashMap::new()));
     let crc = CrcReadTest::new()
-        .commit(0, bootstrap())
+        .commit(0, create_table_actions())
         .commit(
             1, // <-- tombstone removes "a" from the base map
-            [
-                domain_metadata("a", "", /* removed */ true),
-                commit_info("WRITE", None),
-            ],
+            [commit_info("WRITE", None), domain_metadata_tombstone("a")],
         )
         .build()
         .await
@@ -914,20 +910,11 @@ async fn test_dm_tombstone_removes_entry_from_base(#[case] base_dm: DomainMetada
 #[tokio::test]
 async fn test_dm_newer_commit_wins_over_older_commit_for_same_domain() {
     let crc = CrcReadTest::new()
-        .commit(0, bootstrap())
-        .commit(
-            1,
-            [
-                domain_metadata("d", "old", /* removed */ false),
-                commit_info("WRITE", None),
-            ],
-        )
+        .commit(0, create_table_actions())
+        .commit(1, [commit_info("WRITE", None), domain_metadata("d", "old")])
         .commit(
             2, // <-- same domain in two commits; newest wins
-            [
-                domain_metadata("d", "new", /* removed */ false),
-                commit_info("WRITE", None),
-            ],
+            [commit_info("WRITE", None), domain_metadata("d", "new")],
         )
         .build()
         .await
@@ -952,7 +939,7 @@ async fn test_dm_newer_commit_wins_over_older_commit_for_same_domain() {
 async fn test_txn_overrides_base_and_preserves_completeness(#[case] base_txn: SetTransactionState) {
     let base = crc_with_dm_and_txn_states(DomainMetadataState::Complete(HashMap::new()), base_txn);
     let crc = CrcReadTest::new()
-        .commit(0, bootstrap())
+        .commit(0, create_table_actions())
         .commit(
             1,
             [set_txn("app_a", 42, Some(999)), commit_info("WRITE", None)],
@@ -974,7 +961,7 @@ async fn test_txn_overrides_base_and_preserves_completeness(#[case] base_txn: Se
 #[tokio::test]
 async fn test_txn_newer_commit_wins_over_older_commit_for_same_app() {
     let crc = CrcReadTest::new()
-        .commit(0, bootstrap())
+        .commit(0, create_table_actions())
         .commit(
             1,
             [set_txn("app", 1, Some(100)), commit_info("WRITE", None)],
@@ -997,12 +984,12 @@ async fn test_txn_newer_commit_wins_over_older_commit_for_same_app() {
 #[tokio::test]
 async fn test_adds_and_removes_accumulate() {
     let crc = CrcReadTest::new()
-        .commit(0, bootstrap())
-        .commit(1, [add("a", 100), commit_info("WRITE", None)])
-        .commit(2, [add("b", 200), commit_info("WRITE", None)])
-        .commit(3, [add("c", 300), commit_info("WRITE", None)])
+        .commit(0, create_table_actions())
+        .commit(1, [commit_info("WRITE", None), add("a", 100)])
+        .commit(2, [commit_info("WRITE", None), add("b", 200)])
+        .commit(3, [commit_info("WRITE", None), add("c", 300)])
         .commit(4, [remove("a", Some(100)), commit_info("WRITE", None)])
-        .commit(5, [add("d", 400), commit_info("WRITE", None)])
+        .commit(5, [commit_info("WRITE", None), add("d", 400)])
         .commit(6, [remove("b", Some(200)), commit_info("WRITE", None)])
         .build()
         .await
@@ -1018,8 +1005,8 @@ async fn test_adds_and_removes_accumulate() {
 
 // Three distinct ways a single commit can lose incremental safety.
 #[rstest]
-#[case::remove_no_size(vec![remove("orphan", None), commit_info("WRITE", None)])]
-#[case::add_with_unsafe_op(vec![add("a", 100), commit_info("ANALYZE STATS", None)])]
+#[case::remove_no_size(vec![commit_info("WRITE", None), remove("orphan", None)])]
+#[case::add_with_unsafe_op(vec![commit_info("ANALYZE STATS", None), add("a", 100)])]
 #[case::add_with_no_commit_info(vec![add("a", 100)])]
 #[tokio::test]
 async fn test_trips_indeterminate(#[case] v1_actions: Vec<Value>) {
@@ -1030,7 +1017,7 @@ async fn test_trips_indeterminate(#[case] v1_actions: Vec<Value>) {
         SetTransactionState::Complete(HashMap::from([txn_entry("app", 5, Some(100))])),
     );
     let crc = CrcReadTest::new()
-        .commit(0, bootstrap())
+        .commit(0, create_table_actions())
         .commit(1, v1_actions)
         .build()
         .await
@@ -1052,10 +1039,10 @@ async fn test_trips_indeterminate(#[case] v1_actions: Vec<Value>) {
 #[tokio::test]
 async fn test_from_disk_advances_file_stats() {
     let built = CrcReadTest::new()
-        .commit(0, bootstrap())
+        .commit(0, create_table_actions())
         // Base CRC: a (100 B, bin 0) + b (10_000 B, bin 1).
         .crc_with_files(0, protocol_v2(), metadata_a(), None, &[100, 10_000])
-        .commit(1, [add("c", 20_000), commit_info("WRITE", None)]) // c lands in bin 2
+        .commit(1, [commit_info("WRITE", None), add("c", 20_000)]) // c lands in bin 2
         .commit(2, [remove("a", Some(100)), commit_info("WRITE", None)]) // a removed from bin 0
         .build()
         .await;
@@ -1078,9 +1065,9 @@ async fn test_from_disk_advances_file_stats() {
 async fn test_from_disk_no_histogram_means_no_result_histogram() {
     // Empty file_sizes => no histogram persisted on disk.
     let built = CrcReadTest::new()
-        .commit(0, bootstrap())
+        .commit(0, create_table_actions())
         .crc(0, protocol_v2(), metadata_a(), None)
-        .commit(1, [add("a", 100), commit_info("WRITE", None)])
+        .commit(1, [commit_info("WRITE", None), add("a", 100)])
         .build()
         .await;
     let base = built.read_crc_at(0).unwrap();
@@ -1092,11 +1079,11 @@ async fn test_from_disk_no_histogram_means_no_result_histogram() {
 async fn test_from_disk_with_non_zero_crc_version() {
     // Stale CRC is at v2, not v0. Replay covers (2, 3].
     let built = CrcReadTest::new()
-        .commit(0, bootstrap())
-        .commit(1, [add("a", 100), commit_info("WRITE", None)])
-        .commit(2, [add("b", 200), commit_info("WRITE", None)])
+        .commit(0, create_table_actions())
+        .commit(1, [commit_info("WRITE", None), add("a", 100)])
+        .commit(2, [commit_info("WRITE", None), add("b", 200)])
         .crc_with_files(2, protocol_v2(), metadata_a(), None, &[100, 200])
-        .commit(3, [add("c", 300), commit_info("WRITE", None)])
+        .commit(3, [commit_info("WRITE", None), add("c", 300)])
         .build()
         .await;
     let base = built.read_crc_at(2).unwrap();
@@ -1111,7 +1098,7 @@ async fn test_from_disk_with_non_zero_crc_version() {
 #[tokio::test]
 async fn test_full_replay_across_two_commits_propagates_all_state() {
     // Realistic shape: a table evolves over two commits. v=1 initial activity; v=2 adds
-    // more, removes an older file, updates metadata, and stamps an ICT. The bootstrap
+    // more, removes an older file, updates metadata, and stamps an ICT. The create_table_actions
     // (and the base) use an ICT-enabled protocol so the v=2 ICT is well-formed.
     let base = Crc {
         protocol: protocol_v2_ict(),
@@ -1119,14 +1106,14 @@ async fn test_full_replay_across_two_commits_propagates_all_state() {
         ..crc_complete_empty_dm_set_txn()
     };
     let crc = CrcReadTest::new()
-        .commit(0, bootstrap_ict())
+        .commit(0, create_table_actions_with_ict())
         .commit(
             1,
             [
-                add("a", 100),
-                domain_metadata("kept", "v1_value", /* removed */ false),
-                set_txn("app_a", 1, Some(100)),
                 commit_info("WRITE", None),
+                add("a", 100),
+                domain_metadata("kept", "v1_value"),
+                set_txn("app_a", 1, Some(100)),
             ],
         )
         .commit(
@@ -1136,7 +1123,7 @@ async fn test_full_replay_across_two_commits_propagates_all_state() {
                 metadata(metadata_b()),
                 add("b", 200),
                 remove("a", Some(100)),
-                domain_metadata("d", "x", /* removed */ false),
+                domain_metadata("d", "x"),
                 set_txn("app_b", 5, Some(200)),
             ],
         )
@@ -1145,7 +1132,7 @@ async fn test_full_replay_across_two_commits_propagates_all_state() {
         .incrementally_build_crc(&base)
         .unwrap();
 
-    // Newest commit's M and ICT win; protocol stays at bootstrap's ICT-enabled choice.
+    // Newest commit's M and ICT win; protocol stays at create_table_actions's ICT-enabled choice.
     assert_eq!(crc.protocol, protocol_v2_ict());
     assert_eq!(crc.metadata, metadata_b());
     assert_eq!(crc.in_commit_timestamp_opt, Some(9999));

--- a/kernel/src/log_segment/crc_tests.rs
+++ b/kernel/src/log_segment/crc_tests.rs
@@ -6,15 +6,21 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use serde_json::json;
+use rstest::rstest;
+use serde_json::{json, Value};
 use test_utils::{assert_result_error_with_message, delta_path_for_version};
 use url::Url;
 
-use crate::actions::{Format, Metadata, Protocol};
+use super::LogSegment;
+use crate::actions::{DomainMetadata, Format, Metadata, Protocol, SetTransaction};
+use crate::crc::{
+    try_read_crc_file, Crc, DomainMetadataState, FileSizeHistogram, SetTransactionState,
+};
 use crate::engine::sync::SyncEngine;
 use crate::object_store::memory::InMemory;
 use crate::object_store::ObjectStoreExt as _;
-use crate::Snapshot;
+use crate::path::ParsedLogPath;
+use crate::{DeltaResult, Engine, Snapshot};
 
 // ============================================================================
 // Expected values
@@ -101,18 +107,29 @@ fn metadata_ict() -> Metadata {
 // Action JSON helpers
 // ============================================================================
 
-/// Default commitInfo: operation `"TEST_OP"`, no ICT.
-fn commit_info() -> serde_json::Value {
-    json!({"commitInfo": {"timestamp": COMMIT_INFO_TIMESTAMP, "operation": DEFAULT_OPERATION}})
+fn bootstrap() -> Vec<serde_json::Value> {
+    vec![
+        commit_info("CREATE", None),
+        protocol(protocol_v2()),
+        metadata(metadata_a()),
+    ]
 }
 
-/// commitInfo with the default `"TEST_OP"` operation and an in-commit timestamp.
-fn commit_info_with_ict(ict: i64) -> serde_json::Value {
-    json!({"commitInfo": {
-        "timestamp": COMMIT_INFO_TIMESTAMP,
-        "operation": DEFAULT_OPERATION,
-        "inCommitTimestamp": ict,
-    }})
+fn bootstrap_ict() -> Vec<serde_json::Value> {
+    vec![
+        commit_info("CREATE", None),
+        protocol(protocol_v2_ict()),
+        metadata(metadata_a()),
+    ]
+}
+
+/// A commitInfo action with the given operation and optional in-commit timestamp.
+fn commit_info(op: &str, ict: Option<i64>) -> serde_json::Value {
+    let mut obj = json!({"commitInfo": {"timestamp": COMMIT_INFO_TIMESTAMP, "operation": op}});
+    if let Some(ict) = ict {
+        obj["commitInfo"]["inCommitTimestamp"] = json!(ict);
+    }
+    obj
 }
 
 fn protocol(p: Protocol) -> serde_json::Value {
@@ -123,7 +140,6 @@ fn metadata(m: Metadata) -> serde_json::Value {
     json!({"metaData": serde_json::to_value(&m).unwrap()})
 }
 
-#[allow(dead_code)] // Usage coming in next PR
 fn add(path: &str, size: i64) -> serde_json::Value {
     json!({"add": {
         "path": path,
@@ -134,7 +150,6 @@ fn add(path: &str, size: i64) -> serde_json::Value {
     }})
 }
 
-#[allow(dead_code)] // Usage coming in next PR
 fn remove(path: &str, size: Option<i64>) -> serde_json::Value {
     let mut obj = json!({"remove": {
         "path": path,
@@ -147,7 +162,6 @@ fn remove(path: &str, size: Option<i64>) -> serde_json::Value {
     obj
 }
 
-#[allow(dead_code)] // Usage coming in next PR
 fn domain_metadata(domain: &str, configuration: &str, removed: bool) -> serde_json::Value {
     json!({"domainMetadata": {
         "domain": domain,
@@ -156,7 +170,6 @@ fn domain_metadata(domain: &str, configuration: &str, removed: bool) -> serde_js
     }})
 }
 
-#[allow(dead_code)] // Usage coming in next PR
 fn set_txn(app_id: &str, version: i64, last_updated: Option<i64>) -> serde_json::Value {
     let mut obj = json!({"txn": {"appId": app_id, "version": version}});
     if let Some(lu) = last_updated {
@@ -165,15 +178,29 @@ fn set_txn(app_id: &str, version: i64, last_updated: Option<i64>) -> serde_json:
     obj
 }
 
-fn crc_json(protocol: &Protocol, metadata: &Metadata, ict: Option<i64>) -> serde_json::Value {
+fn crc_json(
+    protocol: &Protocol,
+    metadata: &Metadata,
+    ict: Option<i64>,
+    file_sizes: &[i64],
+) -> serde_json::Value {
+    let total_bytes: i64 = file_sizes.iter().sum();
+    let num_files = file_sizes.len() as i64;
     let mut obj = json!({
-        "tableSizeBytes": 0,
-        "numFiles": 0,
+        "tableSizeBytes": total_bytes,
+        "numFiles": num_files,
         "numMetadata": 1,
         "numProtocol": 1,
         "metadata": serde_json::to_value(metadata).unwrap(),
         "protocol": serde_json::to_value(protocol).unwrap(),
     });
+    if !file_sizes.is_empty() {
+        let mut hist = FileSizeHistogram::create_default();
+        for &s in file_sizes {
+            hist.insert(s).unwrap();
+        }
+        obj["fileSizeHistogram"] = serde_json::to_value(&hist).unwrap();
+    }
     if let Some(ict) = ict {
         obj["inCommitTimestampOpt"] = json!(ict);
     }
@@ -200,6 +227,7 @@ enum Op {
         protocol: Protocol,
         metadata: Metadata,
         ict: Option<i64>,
+        file_sizes: Vec<i64>,
     },
     CorruptCrc {
         version: u64,
@@ -237,17 +265,30 @@ impl CrcReadTest {
     }
 
     fn crc(
+        self,
+        version: u64,
+        protocol: Protocol,
+        metadata: Metadata,
+        ict: impl Into<Option<i64>>,
+    ) -> Self {
+        self.crc_with_files(version, protocol, metadata, ict, &[])
+    }
+
+    /// Write a CRC file whose on-disk `fileSizeHistogram` is built from `file_sizes`.
+    fn crc_with_files(
         mut self,
         version: u64,
         protocol: Protocol,
         metadata: Metadata,
         ict: impl Into<Option<i64>>,
+        file_sizes: &[i64],
     ) -> Self {
         self.ops.push(Op::Crc {
             version,
             protocol,
             metadata,
             ict: ict.into(),
+            file_sizes: file_sizes.to_vec(),
         });
         self
     }
@@ -280,12 +321,13 @@ impl CrcReadTest {
                     ref protocol,
                     ref metadata,
                     ict,
+                    ref file_sizes,
                 } => {
                     put(
                         &store,
                         version,
                         "crc",
-                        &crc_json(protocol, metadata, ict).to_string(),
+                        &crc_json(protocol, metadata, ict, file_sizes).to_string(),
                     )
                     .await;
                 }
@@ -343,6 +385,24 @@ struct BuiltCrcTest {
 }
 
 impl BuiltCrcTest {
+    /// Construct a `LogSegment` directly from the store state (no `Snapshot`) and run
+    /// `build_incremental_crc_from_base` against `base`.
+    fn incrementally_build_crc(&self, base: &Crc) -> DeltaResult<Crc> {
+        let storage = self.engine.storage_handler();
+        let log_root = self.url.join("_delta_log/").unwrap();
+        let log_segment =
+            LogSegment::for_snapshot_impl(storage.as_ref(), log_root, vec![], None, None)?;
+        log_segment.build_incremental_crc_from_base(&self.engine, base)
+    }
+
+    /// Read the on-disk CRC at `version` from this test's log.
+    fn read_crc_at(&self, version: u64) -> DeltaResult<Crc> {
+        try_read_crc_file(
+            &self.engine,
+            &ParsedLogPath::create_parsed_crc(&self.url, version),
+        )
+    }
+
     /// Build a snapshot at `version` (or latest if `None`) and return it
     /// alongside a human-readable label like `"v2"` or `"latest"`.
     fn snapshot_at(&self, version: Option<u64>) -> (crate::snapshot::SnapshotRef, String) {
@@ -407,13 +467,13 @@ async fn test_get_p_m_from_delta_no_checkpoint() {
         .commit(
             0, // <-- P & M from here
             [
-                commit_info(),
+                commit_info(DEFAULT_OPERATION, None),
                 protocol(protocol_v2()),
                 metadata(metadata_a()),
             ],
         )
-        .commit(1, [commit_info()])
-        .commit(2, [commit_info()])
+        .commit(1, [commit_info(DEFAULT_OPERATION, None)])
+        .commit(2, [commit_info(DEFAULT_OPERATION, None)])
         .build()
         .await
         .assert_p_m(None, &protocol_v2(), &metadata_a());
@@ -423,8 +483,17 @@ async fn test_get_p_m_from_delta_no_checkpoint() {
 async fn test_get_p_and_m_from_different_deltas() {
     CrcReadTest::new()
         .v2_checkpoint(0, protocol_v2(), metadata_a())
-        .commit(1, [commit_info(), protocol(protocol_v2_dv())]) // <-- P from here
-        .commit(2, [commit_info(), metadata(metadata_b())]) // <-- M from here
+        .commit(
+            1, // <-- P from here
+            [
+                commit_info(DEFAULT_OPERATION, None),
+                protocol(protocol_v2_dv()),
+            ],
+        )
+        .commit(
+            2, // <-- M from here
+            [commit_info(DEFAULT_OPERATION, None), metadata(metadata_b())],
+        )
         .build()
         .await
         .assert_p_m(None, &protocol_v2_dv(), &metadata_b());
@@ -434,8 +503,8 @@ async fn test_get_p_and_m_from_different_deltas() {
 async fn test_get_p_m_from_checkpoint() {
     CrcReadTest::new()
         .v2_checkpoint(0, protocol_v2(), metadata_a()) // <-- P & M from here
-        .commit(1, [commit_info()])
-        .commit(2, [commit_info()])
+        .commit(1, [commit_info(DEFAULT_OPERATION, None)])
+        .commit(2, [commit_info(DEFAULT_OPERATION, None)])
         .build()
         .await
         .assert_p_m(None, &protocol_v2(), &metadata_a());
@@ -448,12 +517,12 @@ async fn test_get_p_m_from_delta_after_checkpoint() {
         .commit(
             1, // <-- P & M from here
             [
-                commit_info(),
+                commit_info(DEFAULT_OPERATION, None),
                 protocol(protocol_v2_dv()),
                 metadata(metadata_b()),
             ],
         )
-        .commit(2, [commit_info()])
+        .commit(2, [commit_info(DEFAULT_OPERATION, None)])
         .build()
         .await
         .assert_p_m(None, &protocol_v2_dv(), &metadata_b());
@@ -467,8 +536,8 @@ async fn test_get_p_m_from_delta_after_checkpoint() {
 async fn test_get_p_m_from_crc_at_target() {
     CrcReadTest::new()
         .v2_checkpoint(0, protocol_v2(), metadata_a())
-        .commit(1, [commit_info()])
-        .commit(2, [commit_info()])
+        .commit(1, [commit_info(DEFAULT_OPERATION, None)])
+        .commit(2, [commit_info(DEFAULT_OPERATION, None)])
         .crc(2, protocol_v2_dv(), metadata_b(), None) // <-- P & M from here
         .build()
         .await
@@ -481,11 +550,11 @@ async fn test_crc_preferred_over_delta_at_target() {
     // We only do this for this test so we can differentiate which P & M is used.
     CrcReadTest::new()
         .v2_checkpoint(0, protocol_v2(), metadata_a())
-        .commit(1, [commit_info()])
+        .commit(1, [commit_info(DEFAULT_OPERATION, None)])
         .commit(
-            2,
+            2, // <-- P from here
             [
-                commit_info(),
+                commit_info(DEFAULT_OPERATION, None),
                 protocol(protocol_v2_dv()),
                 metadata(metadata_a()),
             ],
@@ -500,8 +569,8 @@ async fn test_crc_preferred_over_delta_at_target() {
 async fn test_corrupt_crc_at_target_falls_back() {
     CrcReadTest::new()
         .v2_checkpoint(0, protocol_v2(), metadata_a()) // <-- P & M from here
-        .commit(1, [commit_info()])
-        .commit(2, [commit_info()])
+        .commit(1, [commit_info(DEFAULT_OPERATION, None)])
+        .commit(2, [commit_info(DEFAULT_OPERATION, None)])
         .corrupt_crc(2) // <-- Corrupt! Fall back to replay.
         .build()
         .await
@@ -514,8 +583,8 @@ async fn test_crc_wins_over_checkpoint() {
     // We only do this for this test so we can differentiate which P & M is used.
     CrcReadTest::new()
         .v2_checkpoint(0, protocol_v2(), metadata_a())
-        .commit(1, [commit_info()])
-        .commit(2, [commit_info()])
+        .commit(1, [commit_info(DEFAULT_OPERATION, None)])
+        .commit(2, [commit_info(DEFAULT_OPERATION, None)])
         .v2_checkpoint(2, protocol_v2(), metadata_a())
         .crc(2, protocol_v2_dv(), metadata_b(), None) // <-- P & M from here
         .build()
@@ -527,8 +596,8 @@ async fn test_crc_wins_over_checkpoint() {
 async fn test_checkpoint_on_corrupt_crc() {
     CrcReadTest::new()
         .v2_checkpoint(0, protocol_v2(), metadata_a())
-        .commit(1, [commit_info()])
-        .commit(2, [commit_info()])
+        .commit(1, [commit_info(DEFAULT_OPERATION, None)])
+        .commit(2, [commit_info(DEFAULT_OPERATION, None)])
         .v2_checkpoint(2, protocol_v2(), metadata_a()) // <-- P & M from here
         .corrupt_crc(2) // <-- Corrupt! Fall back to replay.
         .build()
@@ -544,9 +613,9 @@ async fn test_checkpoint_on_corrupt_crc() {
 async fn test_crc_at_earlier_version() {
     CrcReadTest::new()
         .v2_checkpoint(0, protocol_v2(), metadata_a())
-        .commit(1, [commit_info()])
+        .commit(1, [commit_info(DEFAULT_OPERATION, None)])
         .crc(1, protocol_v2_dv(), metadata_b(), None) // <-- P & M from here
-        .commit(2, [commit_info()])
+        .commit(2, [commit_info(DEFAULT_OPERATION, None)])
         .build()
         .await
         .assert_p_m(None, &protocol_v2_dv(), &metadata_b());
@@ -556,9 +625,15 @@ async fn test_crc_at_earlier_version() {
 async fn test_get_p_from_newer_delta_over_older_crc() {
     CrcReadTest::new()
         .v2_checkpoint(0, protocol_v2(), metadata_a())
-        .commit(1, [commit_info()])
+        .commit(1, [commit_info(DEFAULT_OPERATION, None)])
         .crc(1, protocol_v2_dv(), metadata_b(), None) // <-- M from here
-        .commit(2, [commit_info(), protocol(protocol_v2_dv_ntz())]) // <-- P from here
+        .commit(
+            2,
+            [
+                commit_info(DEFAULT_OPERATION, None),
+                protocol(protocol_v2_dv_ntz()),
+            ],
+        )
         .build()
         .await
         .assert_p_m(None, &protocol_v2_dv_ntz(), &metadata_b());
@@ -568,9 +643,12 @@ async fn test_get_p_from_newer_delta_over_older_crc() {
 async fn test_get_m_from_newer_delta_over_older_crc() {
     CrcReadTest::new()
         .v2_checkpoint(0, protocol_v2(), metadata_a())
-        .commit(1, [commit_info()])
+        .commit(1, [commit_info(DEFAULT_OPERATION, None)])
         .crc(1, protocol_v2_dv(), metadata_b(), None) // <-- P from here
-        .commit(2, [commit_info(), metadata(metadata_a())]) // <-- M from here
+        .commit(
+            2, // <-- M from here
+            [commit_info(DEFAULT_OPERATION, None), metadata(metadata_a())],
+        )
         .build()
         .await
         .assert_p_m(None, &protocol_v2_dv(), &metadata_a());
@@ -580,9 +658,9 @@ async fn test_get_m_from_newer_delta_over_older_crc() {
 async fn test_corrupt_crc_at_non_target_version_falls_back() {
     CrcReadTest::new()
         .v2_checkpoint(0, protocol_v2(), metadata_a()) // <-- P & M from here
-        .commit(1, [commit_info()])
+        .commit(1, [commit_info(DEFAULT_OPERATION, None)])
         .corrupt_crc(1) // <-- Corrupt! Fall back to replay.
-        .commit(2, [commit_info()])
+        .commit(2, [commit_info(DEFAULT_OPERATION, None)])
         .build()
         .await
         .assert_p_m(None, &protocol_v2(), &metadata_a());
@@ -594,15 +672,15 @@ async fn test_crc_before_checkpoint_is_ignored() {
         .commit(
             0,
             [
-                commit_info(),
+                commit_info(DEFAULT_OPERATION, None),
                 protocol(protocol_v2()),
                 metadata(metadata_a()),
             ],
         )
-        .commit(1, [commit_info()])
+        .commit(1, [commit_info(DEFAULT_OPERATION, None)])
         .crc(1, protocol_v2_dv_ntz(), metadata_b(), None)
         .v2_checkpoint(2, protocol_v2_dv(), metadata_a()) // <-- P & M from here
-        .commit(3, [commit_info()])
+        .commit(3, [commit_info(DEFAULT_OPERATION, None)])
         .build()
         .await
         .assert_p_m(None, &protocol_v2_dv(), &metadata_a());
@@ -616,7 +694,7 @@ async fn test_crc_before_checkpoint_is_ignored() {
 async fn test_ict_from_crc_at_snapshot_version() {
     CrcReadTest::new()
         .v2_checkpoint(0, protocol_v2_ict(), metadata_ict())
-        .commit(1, [commit_info_with_ict(2000)])
+        .commit(1, [commit_info(DEFAULT_OPERATION, Some(2000))])
         .crc(1, protocol_v2_ict(), metadata_ict(), 1000) // <-- ICT from here
         .build()
         .await
@@ -627,7 +705,7 @@ async fn test_ict_from_crc_at_snapshot_version() {
 async fn test_ict_errors_when_crc_has_no_ict() {
     let setup = CrcReadTest::new()
         .v2_checkpoint(0, protocol_v2_ict(), metadata_ict())
-        .commit(1, [commit_info_with_ict(2000)])
+        .commit(1, [commit_info(DEFAULT_OPERATION, Some(2000))])
         .crc(1, protocol_v2_ict(), metadata_ict(), None)
         .build()
         .await;
@@ -649,7 +727,7 @@ async fn test_ict_errors_when_crc_has_no_ict() {
 async fn build_with_commit_versions(versions: &[u64]) -> BuiltCrcTest {
     let mut t = CrcReadTest::new();
     for &v in versions {
-        t = t.commit(v, [commit_info()]);
+        t = t.commit(v, [commit_info(DEFAULT_OPERATION, None)]);
     }
     t.build().await
 }
@@ -679,4 +757,410 @@ async fn test_commit_versions_not_increasing_panics(#[case] versions: &[u64]) {
 #[should_panic(expected = "at least one action")]
 async fn test_commit_empty_actions_panics() {
     CrcReadTest::new().commit(0, []).build().await;
+}
+
+// ============================================================================
+// Integration tests for incremental CRC replay
+// ============================================================================
+
+fn crc_with_dm_and_txn_states(dm: DomainMetadataState, txn: SetTransactionState) -> Crc {
+    Crc {
+        domain_metadata_state: dm,
+        set_transaction_state: txn,
+        ..Default::default()
+    }
+}
+
+fn crc_complete_empty_dm_set_txn() -> Crc {
+    crc_with_dm_and_txn_states(
+        DomainMetadataState::Complete(HashMap::new()),
+        SetTransactionState::Complete(HashMap::new()),
+    )
+}
+
+fn dm_entry(domain: &str, configuration: &str) -> (String, DomainMetadata) {
+    (
+        domain.to_string(),
+        DomainMetadata::new(domain.to_string(), configuration.to_string()),
+    )
+}
+
+fn txn_entry(app_id: &str, version: i64, last_updated: Option<i64>) -> (String, SetTransaction) {
+    (
+        app_id.to_string(),
+        SetTransaction::new(app_id.to_string(), version, last_updated),
+    )
+}
+
+// === Protocol / metadata ===
+
+#[rstest]
+#[case::newest_p_wins(vec![protocol(protocol_v2_dv()), commit_info("WRITE", None)], protocol_v2_dv(), metadata_a())]
+#[case::newest_m_wins(vec![metadata(metadata_b()), commit_info("WRITE", None)], protocol_v2(), metadata_b())]
+#[case::base_preserved_when_segment_has_none(vec![commit_info("WRITE", None)], protocol_v2(), metadata_a())]
+#[tokio::test]
+async fn test_p_m_propagation(
+    #[case] v1_actions: Vec<Value>,
+    #[case] expected_p: Protocol,
+    #[case] expected_m: Metadata,
+) {
+    let base = Crc {
+        protocol: protocol_v2(),
+        metadata: metadata_a(),
+        ..crc_complete_empty_dm_set_txn()
+    };
+    let crc = CrcReadTest::new()
+        .commit(0, bootstrap())
+        .commit(1, v1_actions)
+        .build()
+        .await
+        .incrementally_build_crc(&base)
+        .unwrap();
+    assert_eq!(crc.protocol, expected_p);
+    assert_eq!(crc.metadata, expected_m);
+}
+
+// === ICT ===
+
+#[rstest]
+#[case::captures_newest(vec![commit_info("WRITE", Some(2000))], Some(2000))]
+#[case::none_when_newest_has_no_commit_info(vec![set_txn("app", 1, None)], None)]
+#[tokio::test]
+async fn test_ict_from_newest_commit_only_replaces_base(
+    #[case] v2_actions: Vec<Value>,
+    #[case] expected_ict: Option<i64>,
+) {
+    // Base carries an ICT so each case proves the delta's ICT replaces the base's
+    let base = Crc {
+        in_commit_timestamp_opt: Some(500),
+        ..crc_complete_empty_dm_set_txn()
+    };
+    let crc = CrcReadTest::new()
+        .commit(0, bootstrap_ict())
+        .commit(1, [commit_info("WRITE", Some(1000))])
+        .commit(2, v2_actions)
+        .build()
+        .await
+        .incrementally_build_crc(&base)
+        .unwrap();
+    assert_eq!(crc.in_commit_timestamp_opt, expected_ict);
+}
+
+// === Domain metadata ===
+
+#[rstest]
+#[case::complete_base(DomainMetadataState::Complete(
+    HashMap::from([dm_entry("a", "base_a"), dm_entry("b", "base_b")])
+))]
+#[case::partial_base(DomainMetadataState::Partial(
+    HashMap::from([dm_entry("a", "base_a"), dm_entry("b", "base_b")])
+))]
+#[tokio::test]
+async fn test_dm_overrides_base_and_preserves_completeness(#[case] base_dm: DomainMetadataState) {
+    let base = crc_with_dm_and_txn_states(base_dm, SetTransactionState::Complete(HashMap::new()));
+    let crc = CrcReadTest::new()
+        .commit(0, bootstrap())
+        .commit(
+            1, // <-- updates "a"; "b" stays at base value
+            [
+                domain_metadata("a", "new_a", /* removed */ false),
+                commit_info("WRITE", None),
+            ],
+        )
+        .build()
+        .await
+        .incrementally_build_crc(&base)
+        .unwrap();
+    // Variant preservation: `expect_*` panics if the base's variant did not survive.
+    let map = match &base.domain_metadata_state {
+        DomainMetadataState::Complete(_) => crc.domain_metadata_state.expect_complete(),
+        DomainMetadataState::Partial(_) => crc.domain_metadata_state.expect_partial(),
+    };
+    assert_eq!(map["a"].configuration(), "new_a");
+    assert_eq!(map["b"].configuration(), "base_b");
+}
+
+#[rstest]
+#[case::complete_base(DomainMetadataState::Complete(
+    HashMap::from([dm_entry("a", "base_a"), dm_entry("b", "base_b")])
+))]
+#[case::partial_base(DomainMetadataState::Partial(
+    HashMap::from([dm_entry("a", "base_a"), dm_entry("b", "base_b")])
+))]
+#[tokio::test]
+async fn test_dm_tombstone_removes_entry_from_base(#[case] base_dm: DomainMetadataState) {
+    let base = crc_with_dm_and_txn_states(base_dm, SetTransactionState::Complete(HashMap::new()));
+    let crc = CrcReadTest::new()
+        .commit(0, bootstrap())
+        .commit(
+            1, // <-- tombstone removes "a" from the base map
+            [
+                domain_metadata("a", "", /* removed */ true),
+                commit_info("WRITE", None),
+            ],
+        )
+        .build()
+        .await
+        .incrementally_build_crc(&base)
+        .unwrap();
+    let map = match &base.domain_metadata_state {
+        DomainMetadataState::Complete(_) => crc.domain_metadata_state.expect_complete(),
+        DomainMetadataState::Partial(_) => crc.domain_metadata_state.expect_partial(),
+    };
+    assert!(!map.contains_key("a"));
+    assert_eq!(map["b"].configuration(), "base_b"); // <-- untouched entry preserved
+}
+
+#[tokio::test]
+async fn test_dm_newer_commit_wins_over_older_commit_for_same_domain() {
+    let crc = CrcReadTest::new()
+        .commit(0, bootstrap())
+        .commit(
+            1,
+            [
+                domain_metadata("d", "old", /* removed */ false),
+                commit_info("WRITE", None),
+            ],
+        )
+        .commit(
+            2, // <-- same domain in two commits; newest wins
+            [
+                domain_metadata("d", "new", /* removed */ false),
+                commit_info("WRITE", None),
+            ],
+        )
+        .build()
+        .await
+        .incrementally_build_crc(&crc_complete_empty_dm_set_txn())
+        .unwrap();
+    let map = crc.domain_metadata_state.expect_complete();
+    assert_eq!(map["d"].configuration(), "new");
+}
+
+// === SetTransaction ===
+
+#[rstest]
+#[case::complete_base(SetTransactionState::Complete(HashMap::from([
+    txn_entry("app_a", 1, Some(100)),
+    txn_entry("app_b", 2, Some(200)),
+])))]
+#[case::partial_base(SetTransactionState::Partial(HashMap::from([
+    txn_entry("app_a", 1, Some(100)),
+    txn_entry("app_b", 2, Some(200)),
+])))]
+#[tokio::test]
+async fn test_txn_overrides_base_and_preserves_completeness(#[case] base_txn: SetTransactionState) {
+    let base = crc_with_dm_and_txn_states(DomainMetadataState::Complete(HashMap::new()), base_txn);
+    let crc = CrcReadTest::new()
+        .commit(0, bootstrap())
+        .commit(
+            1,
+            [set_txn("app_a", 42, Some(999)), commit_info("WRITE", None)],
+        )
+        .build()
+        .await
+        .incrementally_build_crc(&base)
+        .unwrap();
+    let map = match &base.set_transaction_state {
+        SetTransactionState::Complete(_) => crc.set_transaction_state.expect_complete(),
+        SetTransactionState::Partial(_) => crc.set_transaction_state.expect_partial(),
+    };
+    assert_eq!(map["app_a"].version, 42);
+    assert_eq!(map["app_a"].last_updated, Some(999));
+    assert_eq!(map["app_b"].version, 2);
+    assert_eq!(map["app_b"].last_updated, Some(200));
+}
+
+#[tokio::test]
+async fn test_txn_newer_commit_wins_over_older_commit_for_same_app() {
+    let crc = CrcReadTest::new()
+        .commit(0, bootstrap())
+        .commit(
+            1,
+            [set_txn("app", 1, Some(100)), commit_info("WRITE", None)],
+        )
+        .commit(
+            2, // <-- same app in two commits; newest wins
+            [set_txn("app", 42, Some(999)), commit_info("WRITE", None)],
+        )
+        .build()
+        .await
+        .incrementally_build_crc(&crc_complete_empty_dm_set_txn())
+        .unwrap();
+    let map = crc.set_transaction_state.expect_complete();
+    assert_eq!(map["app"].version, 42);
+    assert_eq!(map["app"].last_updated, Some(999));
+}
+
+// === File stats (in-memory base) ===
+
+#[tokio::test]
+async fn test_adds_and_removes_accumulate() {
+    let crc = CrcReadTest::new()
+        .commit(0, bootstrap())
+        .commit(1, [add("a", 100), commit_info("WRITE", None)])
+        .commit(2, [add("b", 200), commit_info("WRITE", None)])
+        .commit(3, [add("c", 300), commit_info("WRITE", None)])
+        .commit(4, [remove("a", Some(100)), commit_info("WRITE", None)])
+        .commit(5, [add("d", 400), commit_info("WRITE", None)])
+        .commit(6, [remove("b", Some(200)), commit_info("WRITE", None)])
+        .build()
+        .await
+        .incrementally_build_crc(&crc_complete_empty_dm_set_txn())
+        .unwrap();
+    assert!(crc.file_stats_state().is_complete());
+    let stats = crc.file_stats().unwrap();
+    assert_eq!(stats.num_files(), 2); // a and b removed; c and d remain
+    assert_eq!(stats.table_size_bytes(), 700); // c (300) + d (400)
+}
+
+// === Indeterminate trips ===
+
+// Three distinct ways a single commit can lose incremental safety.
+#[rstest]
+#[case::remove_no_size(vec![remove("orphan", None), commit_info("WRITE", None)])]
+#[case::add_with_unsafe_op(vec![add("a", 100), commit_info("ANALYZE STATS", None)])]
+#[case::add_with_no_commit_info(vec![add("a", 100)])]
+#[tokio::test]
+async fn test_trips_indeterminate(#[case] v1_actions: Vec<Value>) {
+    // Base carries DM + txn entries so we can verify the indeterminate trip is scoped
+    // to file stats and leaves other state alone.
+    let base = crc_with_dm_and_txn_states(
+        DomainMetadataState::Complete(HashMap::from([dm_entry("d", "base_d")])),
+        SetTransactionState::Complete(HashMap::from([txn_entry("app", 5, Some(100))])),
+    );
+    let crc = CrcReadTest::new()
+        .commit(0, bootstrap())
+        .commit(1, v1_actions)
+        .build()
+        .await
+        .incrementally_build_crc(&base)
+        .unwrap();
+    assert!(crc.file_stats_state().is_indeterminate());
+    assert_eq!(
+        crc.domain_metadata_state.expect_complete()["d"].configuration(),
+        "base_d",
+    );
+    assert_eq!(
+        crc.set_transaction_state.expect_complete()["app"].version,
+        5
+    );
+}
+
+// === On-disk base CRC (exercises serde round-trip) ===
+
+#[tokio::test]
+async fn test_from_disk_advances_file_stats() {
+    let built = CrcReadTest::new()
+        .commit(0, bootstrap())
+        // Base CRC: a (100 B, bin 0) + b (10_000 B, bin 1).
+        .crc_with_files(0, protocol_v2(), metadata_a(), None, &[100, 10_000])
+        .commit(1, [add("c", 20_000), commit_info("WRITE", None)]) // c lands in bin 2
+        .commit(2, [remove("a", Some(100)), commit_info("WRITE", None)]) // a removed from bin 0
+        .build()
+        .await;
+    let base = built.read_crc_at(0).unwrap();
+    let crc = built.incrementally_build_crc(&base).unwrap();
+    assert!(crc.file_stats_state().is_complete());
+    let stats = crc.file_stats().unwrap();
+    assert_eq!(stats.num_files(), 2);
+    assert_eq!(stats.table_size_bytes(), 30_000); // b (10_000) + c (20_000)
+
+    let hist = stats.file_size_histogram().unwrap();
+    assert_eq!(hist.file_counts()[0], 0); // a was removed
+    assert_eq!(hist.file_counts()[1], 1); // b
+    assert_eq!(hist.total_bytes()[1], 10_000);
+    assert_eq!(hist.file_counts()[2], 1); // c
+    assert_eq!(hist.total_bytes()[2], 20_000);
+}
+
+#[tokio::test]
+async fn test_from_disk_no_histogram_means_no_result_histogram() {
+    // Empty file_sizes => no histogram persisted on disk.
+    let built = CrcReadTest::new()
+        .commit(0, bootstrap())
+        .crc(0, protocol_v2(), metadata_a(), None)
+        .commit(1, [add("a", 100), commit_info("WRITE", None)])
+        .build()
+        .await;
+    let base = built.read_crc_at(0).unwrap();
+    let crc = built.incrementally_build_crc(&base).unwrap();
+    assert!(crc.file_stats().unwrap().file_size_histogram().is_none());
+}
+
+#[tokio::test]
+async fn test_from_disk_with_non_zero_crc_version() {
+    // Stale CRC is at v2, not v0. Replay covers (2, 3].
+    let built = CrcReadTest::new()
+        .commit(0, bootstrap())
+        .commit(1, [add("a", 100), commit_info("WRITE", None)])
+        .commit(2, [add("b", 200), commit_info("WRITE", None)])
+        .crc_with_files(2, protocol_v2(), metadata_a(), None, &[100, 200])
+        .commit(3, [add("c", 300), commit_info("WRITE", None)])
+        .build()
+        .await;
+    let base = built.read_crc_at(2).unwrap();
+    let crc = built.incrementally_build_crc(&base).unwrap();
+    assert!(crc.file_stats_state().is_complete());
+    let stats = crc.file_stats().unwrap();
+    // Base CRC at v=2 has a (100), b (200); replay over (2, 3] adds c (300).
+    assert_eq!(stats.num_files(), 3); // a, b, c
+    assert_eq!(stats.table_size_bytes(), 600); // a (100) + b (200) + c (300)
+}
+
+#[tokio::test]
+async fn test_full_replay_across_two_commits_propagates_all_state() {
+    // Realistic shape: a table evolves over two commits. v=1 initial activity; v=2 adds
+    // more, removes an older file, updates metadata, and stamps an ICT. The bootstrap
+    // (and the base) use an ICT-enabled protocol so the v=2 ICT is well-formed.
+    let base = Crc {
+        protocol: protocol_v2_ict(),
+        metadata: metadata_a(),
+        ..crc_complete_empty_dm_set_txn()
+    };
+    let crc = CrcReadTest::new()
+        .commit(0, bootstrap_ict())
+        .commit(
+            1,
+            [
+                add("a", 100),
+                domain_metadata("kept", "v1_value", /* removed */ false),
+                set_txn("app_a", 1, Some(100)),
+                commit_info("WRITE", None),
+            ],
+        )
+        .commit(
+            2,
+            [
+                commit_info("WRITE", Some(9999)),
+                metadata(metadata_b()),
+                add("b", 200),
+                remove("a", Some(100)),
+                domain_metadata("d", "x", /* removed */ false),
+                set_txn("app_b", 5, Some(200)),
+            ],
+        )
+        .build()
+        .await
+        .incrementally_build_crc(&base)
+        .unwrap();
+
+    // Newest commit's M and ICT win; protocol stays at bootstrap's ICT-enabled choice.
+    assert_eq!(crc.protocol, protocol_v2_ict());
+    assert_eq!(crc.metadata, metadata_b());
+    assert_eq!(crc.in_commit_timestamp_opt, Some(9999));
+
+    // File stats accumulated across both commits: a added then removed; b remains.
+    assert!(crc.file_stats_state().is_complete());
+    let stats = crc.file_stats().unwrap();
+    assert_eq!(stats.num_files(), 1); // only b remains
+    assert_eq!(stats.table_size_bytes(), 200); // b (200)
+
+    // DM and txn entries from BOTH commits land in the result map.
+    let dm = crc.domain_metadata_state.expect_complete();
+    assert_eq!(dm["kept"].configuration(), "v1_value");
+    assert_eq!(dm["d"].configuration(), "x");
+    let txn = crc.set_transaction_state.expect_complete();
+    assert_eq!(txn["app_a"].version, 1);
+    assert_eq!(txn["app_b"].version, 5);
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR changes no production code. Incremental CRC replay is still not yet hooked up into snapshot loading. That comes next!

This PR adds the bulk of the core integration tests for our incremental CRC replay logic. We test:
- Protocol + Metadata -> newest wins
- ICT -> only from latest commit
- DomainMetadata + SetTxn -> newest wins, and we preserve the original base CRC's Complete / Partial state
- non-incremental commits which change the file stats state from Complete to Indeterminate

## How was this change tested?

See above.