### PR TITLE
feat: introduce PlanBasedEngine and a SyncPlanExecutor

### DIFF
--- a/kernel/src/engine/mod.rs
+++ b/kernel/src/engine/mod.rs
@@ -40,6 +40,9 @@ pub use self::arrow_utils::{parse_json, to_json_bytes};
 #[cfg(feature = "default-engine-base")]
 pub mod default;
 
+#[cfg(feature = "declarative-plans")]
+pub mod plans;
+
 #[cfg(test)]
 pub(crate) mod sync;
 

--- a/kernel/src/engine/plans/json.rs
+++ b/kernel/src/engine/plans/json.rs
@@ -7,8 +7,8 @@ use url::Url;
 use crate::plans::{Plan, PlanExecutor, QueryPlanBuilder};
 use crate::schema::SchemaRef;
 use crate::{
-    DeltaResult, EngineData, FileDataReadResultIterator, FileMeta, FilteredEngineData, JsonHandler,
-    PredicateRef,
+    DeltaResult, EngineData, Error, FileDataReadResultIterator, FileMeta, FilteredEngineData,
+    JsonHandler, PredicateRef,
 };
 
 /// A [`JsonHandler`] that delegates to a [`PlanExecutor`].
@@ -30,7 +30,9 @@ impl JsonHandler for PlanBasedJsonHandler {
         _json_strings: Box<dyn EngineData>,
         _output_schema: SchemaRef,
     ) -> DeltaResult<Box<dyn EngineData>> {
-        todo!("PlanBasedJsonHandler does not support parse_json yet");
+        Err(Error::unsupported(
+            "PlanBasedJsonHandler does not support parse_json yet",
+        ))
     }
 
     fn read_json_files(
@@ -52,7 +54,9 @@ impl JsonHandler for PlanBasedJsonHandler {
         _data: Box<dyn Iterator<Item = DeltaResult<FilteredEngineData>> + Send + '_>,
         _overwrite: bool,
     ) -> DeltaResult<()> {
-        todo!("PlanBasedJsonHandler does not support write_json_file yet");
+        Err(Error::unsupported(
+            "PlanBasedJsonHandler does not support write_json_file yet",
+        ))
     }
 }
 

--- a/kernel/src/engine/plans/json.rs
+++ b/kernel/src/engine/plans/json.rs
@@ -1,0 +1,109 @@
+//! A [`JsonHandler`] implementation backed by a [`PlanExecutor`].
+
+use std::sync::Arc;
+
+use url::Url;
+
+use crate::plans::{Plan, PlanExecutor, QueryPlanBuilder};
+use crate::schema::SchemaRef;
+use crate::{
+    DeltaResult, EngineData, FileDataReadResultIterator, FileMeta, FilteredEngineData, JsonHandler,
+    PredicateRef,
+};
+
+/// A [`JsonHandler`] that delegates to a [`PlanExecutor`].
+pub struct PlanBasedJsonHandler {
+    executor: Arc<dyn PlanExecutor>,
+}
+
+impl PlanBasedJsonHandler {
+    pub fn new(plan_executor: Arc<dyn PlanExecutor>) -> Self {
+        Self {
+            executor: plan_executor,
+        }
+    }
+}
+
+impl JsonHandler for PlanBasedJsonHandler {
+    fn parse_json(
+        &self,
+        _json_strings: Box<dyn EngineData>,
+        _output_schema: SchemaRef,
+    ) -> DeltaResult<Box<dyn EngineData>> {
+        todo!("PlanBasedJsonHandler does not support parse_json yet");
+    }
+
+    fn read_json_files(
+        &self,
+        files: &[FileMeta],
+        physical_schema: SchemaRef,
+        predicate: Option<PredicateRef>,
+    ) -> DeltaResult<FileDataReadResultIterator> {
+        let query =
+            QueryPlanBuilder::scan_json(files.to_vec(), physical_schema, predicate).build()?;
+        self.executor
+            .execute_plan(Plan::QueryPlan(query))?
+            .into_data()
+    }
+
+    fn write_json_file(
+        &self,
+        _path: &Url,
+        _data: Box<dyn Iterator<Item = DeltaResult<FilteredEngineData>> + Send + '_>,
+        _overwrite: bool,
+    ) -> DeltaResult<()> {
+        todo!("PlanBasedJsonHandler does not support write_json_file yet");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // TODO(#2618): Refactor and share a test suite with sync engine tests.
+
+    use std::sync::Arc;
+
+    use super::PlanBasedJsonHandler;
+    use crate::arrow::array::{Int32Array, RecordBatch};
+    use crate::engine::arrow_data::ArrowEngineData;
+    use crate::engine::sync::plan::SyncPlanExecutor;
+    use crate::engine::tests::{make_temp_json_file, test_json_handler_file_path_contract};
+    use crate::schema::{DataType, StructField, StructType};
+    use crate::JsonHandler as _;
+
+    fn make_handler() -> PlanBasedJsonHandler {
+        PlanBasedJsonHandler::new(Arc::new(SyncPlanExecutor::new()))
+    }
+
+    #[test]
+    fn test_read_json_files() {
+        let (_temp, file_meta) =
+            make_temp_json_file(&[r#"{"x": 1}"#, r#"{"x": 2}"#, r#"{"x": 3}"#]);
+        let schema =
+            Arc::new(StructType::try_new([StructField::not_null("x", DataType::INTEGER)]).unwrap());
+
+        let mut iter = make_handler()
+            .read_json_files(&[file_meta], schema, None)
+            .unwrap();
+
+        let batch = iter.next().expect("expected at least one batch").unwrap();
+        let record_batch: RecordBatch =
+            ArrowEngineData::try_from_engine_data(batch).unwrap().into();
+        assert_eq!(record_batch.num_rows(), 3);
+        assert_eq!(record_batch.num_columns(), 1);
+        assert_eq!(
+            record_batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap()
+                .values(),
+            &[1, 2, 3]
+        );
+        assert!(iter.next().is_none(), "expected exactly one batch");
+    }
+
+    #[test]
+    fn test_file_path_contract() {
+        test_json_handler_file_path_contract(&make_handler());
+    }
+}

--- a/kernel/src/engine/plans/mod.rs
+++ b/kernel/src/engine/plans/mod.rs
@@ -1,0 +1,72 @@
+//! This module contains an implementation of the Engine trait that is
+//! backed by a PlanExecutor. The engine delegates handler operations
+//! (e.g. storage, JSON, parquet) to declarative plan execution rather than implementing
+//! each handler independently.
+//!
+//! This allows a PlanExecutor to become the single surface for connector optimizations, while
+//! still allowing kernel to use existing Engine trait APIs.
+
+use std::sync::Arc;
+
+pub mod json;
+pub mod parquet;
+pub mod storage;
+
+use json::PlanBasedJsonHandler;
+use parquet::PlanBasedParquetHandler;
+use storage::PlanBasedStorageHandler;
+
+use crate::plans::PlanExecutor;
+use crate::{Engine, EvaluationHandler, JsonHandler, ParquetHandler, StorageHandler};
+
+/// An [`Engine`] that routes operations through a [`PlanExecutor`].
+///
+/// Storage, JSON file reads, and Parquet file reads are converted into
+/// [`Plan`](crate::plans::Plan)s and delegated to the plan executor.
+///
+/// EvaluationHandler capabilities are not supported under plan execution,
+/// so the engine must provide an EvaluationHandler as well.
+pub struct PlanBasedEngine {
+    executor: Arc<dyn PlanExecutor>,
+    evaluation: Arc<dyn EvaluationHandler>,
+    storage: Arc<PlanBasedStorageHandler>,
+    json: Arc<PlanBasedJsonHandler>,
+    parquet: Arc<PlanBasedParquetHandler>,
+}
+
+impl PlanBasedEngine {
+    pub fn new(
+        evaluation_handler: Arc<dyn EvaluationHandler>,
+        plan_executor: Arc<dyn PlanExecutor>,
+    ) -> Self {
+        Self {
+            evaluation: evaluation_handler,
+            storage: Arc::new(PlanBasedStorageHandler::new(plan_executor.clone())),
+            json: Arc::new(PlanBasedJsonHandler::new(plan_executor.clone())),
+            parquet: Arc::new(PlanBasedParquetHandler::new(plan_executor.clone())),
+            executor: plan_executor,
+        }
+    }
+}
+
+impl Engine for PlanBasedEngine {
+    fn evaluation_handler(&self) -> Arc<dyn EvaluationHandler> {
+        self.evaluation.clone()
+    }
+
+    fn storage_handler(&self) -> Arc<dyn StorageHandler> {
+        self.storage.clone()
+    }
+
+    fn json_handler(&self) -> Arc<dyn JsonHandler> {
+        self.json.clone()
+    }
+
+    fn parquet_handler(&self) -> Arc<dyn ParquetHandler> {
+        self.parquet.clone()
+    }
+
+    fn plan_executor(&self) -> Arc<dyn PlanExecutor> {
+        self.executor.clone()
+    }
+}

--- a/kernel/src/engine/plans/parquet.rs
+++ b/kernel/src/engine/plans/parquet.rs
@@ -7,8 +7,8 @@ use url::Url;
 use crate::plans::{Plan, PlanExecutor, QueryPlanBuilder};
 use crate::schema::SchemaRef;
 use crate::{
-    DeltaResult, EngineData, FileDataReadResultIterator, FileMeta, ParquetFooter, ParquetHandler,
-    PredicateRef,
+    DeltaResult, EngineData, Error, FileDataReadResultIterator, FileMeta, ParquetFooter,
+    ParquetHandler, PredicateRef,
 };
 
 /// A [`ParquetHandler`] that delegates to a [`PlanExecutor`].
@@ -43,11 +43,15 @@ impl ParquetHandler for PlanBasedParquetHandler {
         _location: Url,
         _data: Box<dyn Iterator<Item = DeltaResult<Box<dyn EngineData>>> + Send>,
     ) -> DeltaResult<()> {
-        todo!("PlanBasedParquetHandler does not support write_parquet_file");
+        Err(Error::unsupported(
+            "PlanBasedParquetHandler does not support write_parquet_file yet",
+        ))
     }
 
     fn read_parquet_footer(&self, _file: &FileMeta) -> DeltaResult<ParquetFooter> {
-        todo!("PlanBasedParquetHandler does not support read_parquet_footer");
+        Err(Error::unsupported(
+            "PlanBasedParquetHandler does not support read_parquet_footer yet",
+        ))
     }
 }
 

--- a/kernel/src/engine/plans/parquet.rs
+++ b/kernel/src/engine/plans/parquet.rs
@@ -1,0 +1,127 @@
+//! A [`ParquetHandler`] implementation backed by a [`PlanExecutor`].
+
+use std::sync::Arc;
+
+use url::Url;
+
+use crate::plans::{Plan, PlanExecutor, QueryPlanBuilder};
+use crate::schema::SchemaRef;
+use crate::{
+    DeltaResult, EngineData, FileDataReadResultIterator, FileMeta, ParquetFooter, ParquetHandler,
+    PredicateRef,
+};
+
+/// A [`ParquetHandler`] that delegates to a [`PlanExecutor`].
+pub struct PlanBasedParquetHandler {
+    executor: Arc<dyn PlanExecutor>,
+}
+
+impl PlanBasedParquetHandler {
+    pub fn new(plan_executor: Arc<dyn PlanExecutor>) -> Self {
+        Self {
+            executor: plan_executor,
+        }
+    }
+}
+
+impl ParquetHandler for PlanBasedParquetHandler {
+    fn read_parquet_files(
+        &self,
+        files: &[FileMeta],
+        physical_schema: SchemaRef,
+        predicate: Option<PredicateRef>,
+    ) -> DeltaResult<FileDataReadResultIterator> {
+        let query =
+            QueryPlanBuilder::scan_parquet(files.to_vec(), physical_schema, predicate).build()?;
+        self.executor
+            .execute_plan(Plan::QueryPlan(query))?
+            .into_data()
+    }
+
+    fn write_parquet_file(
+        &self,
+        _location: Url,
+        _data: Box<dyn Iterator<Item = DeltaResult<Box<dyn EngineData>>> + Send>,
+    ) -> DeltaResult<()> {
+        todo!("PlanBasedParquetHandler does not support write_parquet_file");
+    }
+
+    fn read_parquet_footer(&self, _file: &FileMeta) -> DeltaResult<ParquetFooter> {
+        todo!("PlanBasedParquetHandler does not support read_parquet_footer");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // TODO(#2618): Refactor and share a test suite with sync engine tests.
+
+    use std::path::Path;
+    use std::sync::Arc;
+
+    use tempfile::tempdir;
+
+    use super::PlanBasedParquetHandler;
+    use crate::arrow::array::{Array, Int64Array, RecordBatch};
+    use crate::engine::arrow_conversion::TryIntoKernel as _;
+    use crate::engine::arrow_data::ArrowEngineData;
+    use crate::engine::sync::plan::SyncPlanExecutor;
+    use crate::engine::tests::{file_meta_for, test_parquet_handler_reads_file_with_arrow_schema};
+    use crate::parquet::arrow::arrow_writer::ArrowWriter;
+    use crate::schema::SchemaRef;
+    use crate::{FileMeta, ParquetHandler as _};
+
+    fn make_handler() -> PlanBasedParquetHandler {
+        PlanBasedParquetHandler::new(Arc::new(SyncPlanExecutor::new()))
+    }
+
+    fn make_test_parquet_file(path: &Path, batch: &RecordBatch) -> (FileMeta, SchemaRef) {
+        let mut writer =
+            ArrowWriter::try_new(std::fs::File::create(path).unwrap(), batch.schema(), None)
+                .unwrap();
+        writer.write(batch).unwrap();
+        writer.close().unwrap();
+
+        let file_meta = file_meta_for(path);
+        let schema = Arc::new(batch.schema().as_ref().try_into_kernel().unwrap());
+        (file_meta, schema)
+    }
+
+    #[test]
+    fn test_read_parquet_files() {
+        let temp_dir = tempdir().unwrap();
+        let file_path = temp_dir.path().join("data.parquet");
+        let batch = RecordBatch::try_from_iter(vec![(
+            "value",
+            Arc::new(Int64Array::from(vec![10, 20, 30])) as Arc<dyn Array>,
+        )])
+        .unwrap();
+        let (file_meta, schema) = make_test_parquet_file(&file_path, &batch);
+
+        let batches: Vec<RecordBatch> = make_handler()
+            .read_parquet_files(&[file_meta], schema, None)
+            .unwrap()
+            .map(|r| {
+                ArrowEngineData::try_from_engine_data(r.unwrap())
+                    .unwrap()
+                    .into()
+            })
+            .collect();
+
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].num_rows(), 3);
+        assert_eq!(
+            batches[0]
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .values(),
+            &[10, 20, 30]
+        );
+    }
+
+    #[test]
+    fn test_parquet_handler_reads_contract() {
+        test_parquet_handler_reads_file_with_arrow_schema(&make_handler());
+    }
+}

--- a/kernel/src/engine/plans/storage.rs
+++ b/kernel/src/engine/plans/storage.rs
@@ -1,0 +1,167 @@
+//! A [`StorageHandler`] implementation backed by a [`PlanExecutor`].
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use itertools::Itertools;
+use url::Url;
+
+use crate::plans::{IoOperation, Plan, PlanExecutor, PlanResult};
+use crate::{DeltaResult, Error, FileMeta, FileSlice, StorageHandler};
+
+/// A [`StorageHandler`] that delegates to a [`PlanExecutor`].
+pub struct PlanBasedStorageHandler {
+    executor: Arc<dyn PlanExecutor>,
+}
+
+impl PlanBasedStorageHandler {
+    pub fn new(executor: Arc<dyn PlanExecutor>) -> Self {
+        Self { executor }
+    }
+
+    fn execute_io(&self, op: IoOperation) -> DeltaResult<PlanResult> {
+        self.executor.execute_plan(Plan::IoOperation(op))
+    }
+}
+
+impl StorageHandler for PlanBasedStorageHandler {
+    fn list_from(
+        &self,
+        path: &Url,
+    ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<FileMeta>>>> {
+        let iter = self
+            .execute_io(IoOperation::file_listing(path.clone()))?
+            .into_file_meta()?;
+        Ok(iter)
+    }
+
+    fn read_files(
+        &self,
+        files: Vec<FileSlice>,
+    ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<Bytes>>>> {
+        let iter = self
+            .execute_io(IoOperation::read_bytes(files))?
+            .into_bytes()?;
+        Ok(iter)
+    }
+
+    fn copy_atomic(&self, src: &Url, dest: &Url) -> DeltaResult<()> {
+        self.execute_io(IoOperation::atomic_copy(src.clone(), dest.clone()))?
+            .into_unit()
+    }
+
+    fn put(&self, path: &Url, data: Bytes, overwrite: bool) -> DeltaResult<()> {
+        self.execute_io(IoOperation::write_bytes(path.clone(), data, overwrite))?
+            .into_unit()
+    }
+
+    fn head(&self, path: &Url) -> DeltaResult<FileMeta> {
+        self.execute_io(IoOperation::head_file(path.clone()))?
+            .into_file_meta()?
+            .exactly_one()
+            .map_err(|e| Error::generic(format!("Expected exactly one file meta: {e}")))?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // TODO(#2618): Refactor and share a test suite with sync engine tests.
+
+    use std::fs::File;
+    use std::io::Write as _;
+    use std::sync::Arc;
+
+    use itertools::Itertools as _;
+    use tempfile::tempdir;
+    use url::Url;
+
+    use super::PlanBasedStorageHandler;
+    use crate::engine::sync::plan::SyncPlanExecutor;
+    use crate::{Error, StorageHandler as _};
+
+    fn make_handler() -> PlanBasedStorageHandler {
+        PlanBasedStorageHandler::new(Arc::new(SyncPlanExecutor::new()))
+    }
+
+    #[test]
+    fn test_list_from() {
+        let tmp = tempdir().unwrap();
+        for i in 0..3 {
+            let path = tmp.path().join(format!("{i:020}.json"));
+            let mut f = File::create(&path).unwrap();
+            writeln!(f, "null").unwrap();
+        }
+
+        let storage = make_handler();
+
+        // Listing from a file URL is exclusive of the offset itself, so listing from index 1
+        // returns only index 2.
+        let from = Url::from_file_path(tmp.path().join("00000000000000000001.json")).unwrap();
+        let files: Vec<_> = storage.list_from(&from).unwrap().try_collect().unwrap();
+        assert_eq!(files.len(), 1);
+        let expected = Url::from_file_path(tmp.path().join("00000000000000000002.json")).unwrap();
+        assert_eq!(files[0].location, expected);
+
+        // Listing the directory returns all 3 files.
+        let dir = Url::from_directory_path(tmp.path()).unwrap();
+        let all: Vec<_> = storage.list_from(&dir).unwrap().try_collect().unwrap();
+        assert_eq!(all.len(), 3);
+    }
+
+    #[test]
+    fn test_put_then_read_round_trip() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("blob.bin");
+        let url = Url::from_file_path(&path).unwrap();
+
+        let storage = make_handler();
+
+        storage
+            .put(&url, bytes::Bytes::from_static(b"hello"), false)
+            .unwrap();
+
+        let files = vec![(url.clone(), None)];
+        let bytes: Vec<_> = storage.read_files(files).unwrap().try_collect().unwrap();
+        assert_eq!(bytes.len(), 1);
+        assert_eq!(bytes[0].as_ref(), b"hello");
+    }
+
+    #[test]
+    fn test_put_without_overwrite() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("blob.bin");
+        let url = Url::from_file_path(&path).unwrap();
+
+        let storage = make_handler();
+
+        storage
+            .put(&url, bytes::Bytes::from_static(b"first"), false)
+            .unwrap();
+        let err = storage
+            .put(&url, bytes::Bytes::from_static(b"second"), false)
+            .unwrap_err();
+        assert!(matches!(err, Error::FileAlreadyExists(_)));
+
+        // With `overwrite = true`, the second write succeeds.
+        storage
+            .put(&url, bytes::Bytes::from_static(b"second"), true)
+            .unwrap();
+    }
+
+    #[test]
+    fn test_head() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("file.json");
+        std::fs::write(&path, b"hello").unwrap();
+        let url = Url::from_file_path(&path).unwrap();
+
+        let meta = make_handler().head(&url).unwrap();
+        assert_eq!(meta.location, url);
+        assert_eq!(meta.size, 5);
+
+        // Errors on missing file
+        let url = Url::from_file_path(tmp.path().join("missing.json")).unwrap();
+        let err = make_handler().head(&url).unwrap_err();
+        assert!(matches!(err, Error::FileNotFound(_)));
+    }
+}

--- a/kernel/src/engine/plans/storage.rs
+++ b/kernel/src/engine/plans/storage.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use bytes::Bytes;
-use itertools::Itertools;
+use itertools::Itertools as _;
 use url::Url;
 
 use crate::plans::{IoOperation, Plan, PlanExecutor, PlanResult};
@@ -29,20 +29,18 @@ impl StorageHandler for PlanBasedStorageHandler {
         &self,
         path: &Url,
     ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<FileMeta>>>> {
-        let iter = self
+        Ok(self
             .execute_io(IoOperation::file_listing(path.clone()))?
-            .into_file_meta()?;
-        Ok(iter)
+            .into_file_meta()?)
     }
 
     fn read_files(
         &self,
         files: Vec<FileSlice>,
     ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<Bytes>>>> {
-        let iter = self
+        Ok(self
             .execute_io(IoOperation::read_bytes(files))?
-            .into_bytes()?;
-        Ok(iter)
+            .into_bytes()?)
     }
 
     fn copy_atomic(&self, src: &Url, dest: &Url) -> DeltaResult<()> {

--- a/kernel/src/engine/sync/mod.rs
+++ b/kernel/src/engine/sync/mod.rs
@@ -40,6 +40,9 @@ pub(crate) mod json;
 mod parquet;
 mod storage;
 
+#[cfg(feature = "declarative-plans")]
+pub(crate) mod plan;
+
 /// A simple (test-only) implementation of [`Engine`]. See module docs for supported stores.
 pub(crate) struct SyncEngine {
     storage_handler: Arc<storage::SyncStorageHandler>,

--- a/kernel/src/engine/sync/plan.rs
+++ b/kernel/src/engine/sync/plan.rs
@@ -1,0 +1,123 @@
+//! A synchronous, test-only [`PlanExecutor`] backed by [`SyncEngine`] handlers.
+//!
+//! [`SyncEngine`]: super::SyncEngine
+//
+// TODO: Not used yet, but will eventually be used to replace SyncEngine with a
+// PlanBasedEngine (backed by this PlanExecutor)
+#![allow(dead_code)]
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+
+use super::json::SyncJsonHandler;
+use super::parquet::SyncParquetHandler;
+use super::storage::SyncStorageHandler;
+use crate::object_store::DynObjectStore;
+use crate::plans::{IoOperation, Plan, PlanExecutor, PlanResult, QueryPlanNode};
+use crate::{DeltaResult, FileMeta, JsonHandler as _, ParquetHandler as _, StorageHandler as _};
+
+/// A synchronous, test-only [`PlanExecutor`] that delegates to [`SyncStorageHandler`],
+/// [`SyncJsonHandler`], and [`SyncParquetHandler`].
+///
+/// All I/O is performed synchronously via [`futures::executor::block_on`]; cloud-backed
+/// stores are not supported (see [`super`] module docs).
+pub(crate) struct SyncPlanExecutor {
+    storage: SyncStorageHandler,
+    json: SyncJsonHandler,
+    parquet: SyncParquetHandler,
+}
+
+impl SyncPlanExecutor {
+    /// Create a `SyncPlanExecutor` that resolves URLs against LocalFileSystem
+    pub(crate) fn new() -> Self {
+        Self::new_inner(None)
+    }
+
+    /// Create a `SyncPlanExecutor` backed by an explicit object store.
+    pub(crate) fn new_with_store(store: Arc<DynObjectStore>) -> Self {
+        Self::new_inner(Some(store))
+    }
+
+    fn new_inner(store: Option<Arc<DynObjectStore>>) -> Self {
+        Self {
+            storage: SyncStorageHandler::new(store.clone()),
+            json: SyncJsonHandler::new(store.clone()),
+            parquet: SyncParquetHandler::new(store),
+        }
+    }
+}
+
+impl PlanExecutor for SyncPlanExecutor {
+    fn execute_plan(&self, plan: Plan) -> DeltaResult<PlanResult> {
+        match plan {
+            Plan::IoOperation(op) => self.execute_io(op),
+            Plan::QueryPlan(query) => self.execute_query(query),
+        }
+    }
+}
+
+impl SyncPlanExecutor {
+    fn execute_io(&self, op: IoOperation) -> DeltaResult<PlanResult> {
+        match op {
+            IoOperation::FileListing { url } => {
+                // `StorageHandler::list_from` returns a non-`Send` iterator, so we collect into
+                // a `Vec` first to convert into a `Send` iterator.
+                // TODO(#2619): Evaluate whether StorageHandler should just return `Send` iterators
+                let metas: Vec<DeltaResult<FileMeta>> = self.storage.list_from(&url)?.collect();
+                Ok(PlanResult::FileMeta(Box::new(metas.into_iter())))
+            }
+            IoOperation::ReadBytes { files } => {
+                // `StorageHandler::read_files` returns a non-`Send` iterator, so we collect into
+                // a `Vec` first to convert into a `Send` iterator.
+                // TODO(#2619): Evaluate whether StorageHandler should just return `Send` iterators
+                let bytes: Vec<DeltaResult<Bytes>> = self.storage.read_files(files)?.collect();
+                Ok(PlanResult::Bytes(Box::new(bytes.into_iter())))
+            }
+            IoOperation::WriteBytes {
+                url,
+                data,
+                overwrite,
+            } => {
+                self.storage.put(&url, data, overwrite)?;
+                Ok(PlanResult::Unit)
+            }
+            IoOperation::HeadFile { url } => {
+                let meta = self.storage.head(&url)?;
+                Ok(PlanResult::FileMeta(Box::new(std::iter::once(Ok(meta)))))
+            }
+            IoOperation::AtomicCopy {
+                source,
+                destination,
+            } => {
+                self.storage.copy_atomic(&source, &destination)?;
+                Ok(PlanResult::Unit)
+            }
+        }
+    }
+
+    fn execute_query(&self, query: QueryPlanNode) -> DeltaResult<PlanResult> {
+        match query {
+            QueryPlanNode::ScanJson {
+                files,
+                physical_schema,
+                predicate,
+            } => {
+                let iter = self
+                    .json
+                    .read_json_files(&files, physical_schema, predicate)?;
+                Ok(PlanResult::Data(iter))
+            }
+            QueryPlanNode::ScanParquet {
+                files,
+                physical_schema,
+                predicate,
+            } => {
+                let iter = self
+                    .parquet
+                    .read_parquet_files(&files, physical_schema, predicate)?;
+                Ok(PlanResult::Data(iter))
+            }
+        }
+    }
+}

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -235,6 +235,13 @@ pub enum Error {
     /// Error during log history operations (timestamp queries, version lookups)
     #[error(transparent)]
     LogHistory(#[from] Box<crate::history_manager::error::LogHistoryError>),
+
+    #[cfg(feature = "declarative-plans")]
+    #[error("Declarative plan execution yielded the incorrect type: expected PlanResult::{expected}, got PlanResult::{actual}")]
+    PlanResultTypeMismatch {
+        expected: &'static str,
+        actual: &'static str,
+    },
 }
 
 // Convenience constructors for Error types that take a String argument
@@ -329,6 +336,11 @@ impl Error {
 
     pub fn stats_validation(msg: impl ToString) -> Self {
         Self::StatsValidation(msg.to_string())
+    }
+
+    #[cfg(feature = "declarative-plans")]
+    pub fn plan_result_type_mismatch(expected: &'static str, actual: &'static str) -> Self {
+        Self::PlanResultTypeMismatch { expected, actual }
     }
 
     // Capture a backtrace when the error is constructed.

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -194,7 +194,8 @@ pub use snapshot::{Snapshot, SnapshotRef};
 #[cfg(any(
     feature = "default-engine-native-tls",
     feature = "default-engine-rustls",
-    feature = "arrow-conversion"
+    feature = "arrow-conversion",
+    feature = "declarative-plans"
 ))]
 pub mod engine;
 

--- a/kernel/src/plans/mod.rs
+++ b/kernel/src/plans/mod.rs
@@ -8,7 +8,7 @@ use bytes::Bytes;
 pub use ir::{IoOperation, Plan, QueryPlan, QueryPlanNode};
 pub use query_builder::QueryPlanBuilder;
 
-use crate::{AsAny, DeltaResult, DeltaResultIterator, EngineData, FileMeta};
+use crate::{AsAny, DeltaResult, DeltaResultIterator, EngineData, Error, FileMeta};
 
 /// Provides the ability to execute declarative plans to the Delta Kernel.
 ///
@@ -31,4 +31,48 @@ pub enum PlanResult {
     Bytes(DeltaResultIterator<Bytes>),
     /// Represents the successful completion of a plan, but with no return value.
     Unit,
+}
+
+impl PlanResult {
+    pub fn into_data(self) -> DeltaResult<DeltaResultIterator<Box<dyn EngineData>>> {
+        match self {
+            Self::Data(iter) => Ok(iter),
+            other => Err(other.type_mismatch("Data")),
+        }
+    }
+
+    pub fn into_file_meta(self) -> DeltaResult<DeltaResultIterator<FileMeta>> {
+        match self {
+            Self::FileMeta(iter) => Ok(iter),
+            other => Err(other.type_mismatch("FileMeta")),
+        }
+    }
+
+    pub fn into_bytes(self) -> DeltaResult<DeltaResultIterator<Bytes>> {
+        match self {
+            Self::Bytes(iter) => Ok(iter),
+            other => Err(other.type_mismatch("Bytes")),
+        }
+    }
+
+    pub fn into_unit(self) -> DeltaResult<()> {
+        match self {
+            Self::Unit => Ok(()),
+            other => Err(other.type_mismatch("Unit")),
+        }
+    }
+
+    fn variant_name(&self) -> &'static str {
+        match self {
+            Self::Data(_) => "Data",
+            Self::FileMeta(_) => "FileMeta",
+            Self::Bytes(_) => "Bytes",
+            Self::Unit => "Unit",
+        }
+    }
+
+    /// Build an [`Error::PlanResultTypeMismatch`] reporting `self`'s variant as the actual one.
+    fn type_mismatch(&self, expected: &'static str) -> Error {
+        Error::plan_result_type_mismatch(expected, self.variant_name())
+    }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR introduces two new constructs that will be useful for the migration towards logical plans:
1. A `PlanBasedEngine` which implements the Engine APIs by delegating to a PlanExecutor. This provides a facade for kernel to continue using existing engine APIs, while underneath, we are actually executing logical plans.
2. A `SyncPlanExecutor` which can eventually be used (along with PlanBasedEngine) to migrate all kernel tests to logical plan execution.

For FFI, we expect Java connectors to only provide a PlanExecutor and then construct a PlanBasedEngine on the Rust side.

Note: there are still a few APIs (marked with `todo!` that need to be discussed and handled separately (write_json/write_parquet, parquet_footer, and parse_json)

## How was this change tested?
Added unit tests for PlanBased handlers using SyncPlanExecutor (SyncPlanExecutor itself is not unit tested).
