### PR TITLE
fix: allow predicates to reference columns outside scan projection

### DIFF
--- a/docs/user-guide/src/reading/change_data_feed.md
+++ b/docs/user-guide/src/reading/change_data_feed.md
@@ -125,9 +125,10 @@ If you skip `with_predicate`, no filtering is applied.
 
 > [!NOTE]
 > Predicates on the CDF metadata columns (`_change_type`, `_commit_version`,
-> `_commit_timestamp`) are not currently supported. Apply predicates only to regular table
-> columns. Filtering on CDF columns after the scan returns is still possible in your
-> connector code.
+> `_commit_timestamp`) are accepted but have no effect. Kernel doesn't apply them during
+> file pruning because CDF metadata is synthesized during scan execution, not read from
+> data files. Apply such filters in your connector code after the scan returns. See
+> [issue #525](https://github.com/delta-io/delta-kernel-rs/issues/525).
 
 > [!NOTE]
 > Like regular scans, CDF filtering is best-effort. The scan may return rows that do not

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -146,8 +146,8 @@ impl ScanBuilder {
     ///
     /// [`Schema`]: crate::schema::Schema
     /// [`Snapshot`]: crate::snapshot::Snapshot
-    pub fn with_schema(mut self, schema: SchemaRef) -> Self {
-        self.schema = Some(schema);
+    pub fn with_schema(mut self, logical_read_schema: SchemaRef) -> Self {
+        self.schema = Some(logical_read_schema);
         self
     }
 
@@ -166,10 +166,7 @@ impl ScanBuilder {
     /// 4` to return a subset of the rows in the scan which satisfy the filter. If `predicate_opt`
     /// is `None`, this is a no-op.
     ///
-    /// The predicate may reference any column in the table's schema, including columns that
-    /// [`with_schema`] narrows out of the output projection.
-    ///
-    /// NOTE: The filtering is best-effort and can produce false positives (rows that should should
+    /// NOTE: The filtering is best-effort and can produce false positives (rows that should
     /// have been filtered out but were kept).
     ///
     /// NOTE: Predicates referencing metadata columns the caller added to the projection via
@@ -249,10 +246,8 @@ impl ScanBuilder {
     /// [`Scan`] type itself can be used to fetch the files and associated metadata required to
     /// perform actual data reads.
     pub fn build(self) -> DeltaResult<Scan> {
-        // The output schema can be narrowed by `with_schema`, but predicates may still reference
-        // any column in the full table schema (SQL semantics: projection narrows output, predicates
-        // don't). Keep the full schema separately so predicate validation doesn't reject valid
-        // references to unprojected columns.
+        // Predicates may reference columns outside with_schema, so resolve against the full table
+        // schema
         let table_schema = self.snapshot.schema();
         // Reject scans of empty-schema tables. CREATE TABLE accepts an empty schema as
         // a transient state, but a scan over zero columns has no way to derive row
@@ -266,15 +261,15 @@ impl ScanBuilder {
         }
 
         // if no schema is provided, use snapshot's entire schema (e.g. SELECT *)
-        let logical_schema = self.schema.unwrap_or_else(|| table_schema.clone());
+        let logical_read_schema = self.schema.unwrap_or_else(|| table_schema.clone());
 
         self.snapshot
             .table_configuration()
             .ensure_operation_supported(Operation::Scan)?;
 
         let state_info = StateInfo::try_new(
-            logical_schema,
-            &table_schema,
+            logical_read_schema,
+            table_schema,
             self.snapshot.table_configuration(),
             self.predicate,
             self.stats_output_mode.clone(),

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -113,7 +113,7 @@ impl Default for StatsOutputMode {
 /// Builder to scan a snapshot of a table.
 pub struct ScanBuilder {
     snapshot: SnapshotRef,
-    schema: Option<SchemaRef>,
+    logical_read_schema: Option<SchemaRef>,
     predicate: Option<PredicateRef>,
     stats_output_mode: StatsOutputMode,
 }
@@ -121,7 +121,7 @@ pub struct ScanBuilder {
 impl std::fmt::Debug for ScanBuilder {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         f.debug_struct("ScanBuilder")
-            .field("schema", &self.schema)
+            .field("logical_read_schema", &self.logical_read_schema)
             .field("predicate", &self.predicate)
             .field("stats_output_mode", &self.stats_output_mode)
             .finish()
@@ -133,7 +133,7 @@ impl ScanBuilder {
     pub fn new(snapshot: impl Into<SnapshotRef>) -> Self {
         Self {
             snapshot: snapshot.into(),
-            schema: None,
+            logical_read_schema: None,
             predicate: None,
             stats_output_mode: StatsOutputMode::default(),
         }
@@ -147,7 +147,7 @@ impl ScanBuilder {
     /// [`Schema`]: crate::schema::Schema
     /// [`Snapshot`]: crate::snapshot::Snapshot
     pub fn with_schema(mut self, logical_read_schema: SchemaRef) -> Self {
-        self.schema = Some(logical_read_schema);
+        self.logical_read_schema = Some(logical_read_schema);
         self
     }
 
@@ -246,8 +246,8 @@ impl ScanBuilder {
     /// [`Scan`] type itself can be used to fetch the files and associated metadata required to
     /// perform actual data reads.
     pub fn build(self) -> DeltaResult<Scan> {
-        // Predicates may reference columns outside with_schema, so resolve against the full table
-        // schema
+        // Predicates may reference columns outside self.logical_read_schema, so resolve against the
+        // full table schema
         let table_schema = self.snapshot.schema();
         // Reject scans of empty-schema tables. CREATE TABLE accepts an empty schema as
         // a transient state, but a scan over zero columns has no way to derive row
@@ -261,7 +261,9 @@ impl ScanBuilder {
         }
 
         // if no schema is provided, use snapshot's entire schema (e.g. SELECT *)
-        let logical_read_schema = self.schema.unwrap_or_else(|| table_schema.clone());
+        let logical_read_schema = self
+            .logical_read_schema
+            .unwrap_or_else(|| table_schema.clone());
 
         self.snapshot
             .table_configuration()

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -166,14 +166,23 @@ impl ScanBuilder {
     /// 4` to return a subset of the rows in the scan which satisfy the filter. If `predicate_opt`
     /// is `None`, this is a no-op.
     ///
+    /// The predicate may reference any column in the table's schema, including columns that
+    /// [`with_schema`] narrows out of the output projection.
+    ///
     /// NOTE: The filtering is best-effort and can produce false positives (rows that should should
     /// have been filtered out but were kept).
+    ///
+    /// NOTE: Predicates referencing metadata columns the caller added to the projection via
+    /// [`StructType::add_metadata_column`] (row indexes, row ids, file paths) are not supported
+    /// and will error at build time.
     ///
     /// This method can be combined with [`include_all_stats_columns`]. When both are used, the
     /// kernel performs data skipping internally using the predicate AND outputs parsed
     /// statistics to the engine via the `stats_parsed` column in scan metadata.
     ///
     /// [`include_all_stats_columns`]: ScanBuilder::include_all_stats_columns
+    /// [`with_schema`]: ScanBuilder::with_schema
+    /// [`StructType::add_metadata_column`]: crate::schema::StructType::add_metadata_column
     pub fn with_predicate(mut self, predicate: impl Into<Option<PredicateRef>>) -> Self {
         self.predicate = predicate.into();
         self
@@ -240,8 +249,12 @@ impl ScanBuilder {
     /// [`Scan`] type itself can be used to fetch the files and associated metadata required to
     /// perform actual data reads.
     pub fn build(self) -> DeltaResult<Scan> {
-        // if no schema is provided, use snapshot's entire schema (e.g. SELECT *)
-        let logical_schema = self.schema.unwrap_or_else(|| self.snapshot.schema());
+        // The output schema can be narrowed by `with_schema`, but predicates may still reference
+        // any column in the full table schema (SQL semantics: projection narrows output, predicates
+        // don't). Keep the full schema separately so predicate validation doesn't reject valid
+        // references to unprojected columns.
+        let table_schema = self.snapshot.schema();
+        let logical_schema = self.schema.unwrap_or_else(|| table_schema.clone());
 
         self.snapshot
             .table_configuration()
@@ -249,6 +262,7 @@ impl ScanBuilder {
 
         let state_info = StateInfo::try_new(
             logical_schema,
+            &table_schema,
             self.snapshot.table_configuration(),
             self.predicate,
             self.stats_output_mode.clone(),

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -222,12 +222,13 @@ impl StateInfo {
     /// Create StateInfo with a custom field classifier for different scan types.
     /// Get the state needed to process a scan.
     ///
-    /// `logical_read_schema` - The logical schema of the scan output, which includes partition
-    /// columns `table_schema` - The schema predicate column references are resolved against.
-    /// Should contain every column the predicate may legitimately reference (typically the full
+    /// `logical_read_schema` - The logical schema of the scan output
+    /// `table_schema` - The schema against which predicate column references are resolved.
+    /// Must contain every column the predicate may legitimately reference (typically the full
     /// table schema, or full CDF-extended schema for CDF scans). Currently, we do not carry
     /// over any metadata columns from the `logical_read_schema` to the `table_schema` (issue
-    /// 2633). `table_configuration` - The TableConfiguration for this table
+    /// 2633).
+    /// `table_configuration` - The TableConfiguration for this table
     /// `predicate` - Optional predicate to filter data during the scan
     /// `stats_output_mode` - Controls how file statistics are handled during the scan
     /// `classifier` - The classifier to use for different scan types. Use `()` if not needed
@@ -338,6 +339,7 @@ impl StateInfo {
             .map(|p| p.references().into_iter().cloned().collect())
             .unwrap_or_default();
 
+        //we use table_schema here as predicate can reference columns outside projection
         let physical_predicate = match predicate {
             Some(pred) => PhysicalPredicate::try_new(&pred, &table_schema, column_mapping_mode)?,
             None => PhysicalPredicate::None,

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -339,7 +339,7 @@ impl StateInfo {
             .map(|p| p.references().into_iter().cloned().collect())
             .unwrap_or_default();
 
-        // we use table_schema here as predicate can reference columns outside projection
+        // We use table_schema here as predicate can reference columns outside projection.
         let physical_predicate = match predicate {
             Some(pred) => PhysicalPredicate::try_new(&pred, &table_schema, column_mapping_mode)?,
             None => PhysicalPredicate::None,

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -339,7 +339,7 @@ impl StateInfo {
             .map(|p| p.references().into_iter().cloned().collect())
             .unwrap_or_default();
 
-        //we use table_schema here as predicate can reference columns outside projection
+        // we use table_schema here as predicate can reference columns outside projection
         let physical_predicate = match predicate {
             Some(pred) => PhysicalPredicate::try_new(&pred, &table_schema, column_mapping_mode)?,
             None => PhysicalPredicate::None,

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -11,7 +11,7 @@ use crate::expressions::ColumnName;
 use crate::scan::field_classifiers::TransformFieldClassifier;
 use crate::scan::transform_spec::{FieldTransformSpec, TransformSpec};
 use crate::scan::{PhysicalPredicate, StatsOutputMode};
-use crate::schema::{DataType, MetadataColumnSpec, Schema, SchemaRef, StructType};
+use crate::schema::{DataType, MetadataColumnSpec, SchemaRef, StructType};
 use crate::table_configuration::TableConfiguration;
 use crate::table_features::{get_any_level_column_physical_name, ColumnMappingMode};
 use crate::{DeltaResult, Error, PredicateRef, StructField};
@@ -222,20 +222,18 @@ impl StateInfo {
     /// Create StateInfo with a custom field classifier for different scan types.
     /// Get the state needed to process a scan.
     ///
-    /// `logical_schema` - The logical schema of the scan output, which includes partition columns
-    /// `predicate_schema` - The schema predicate column references are resolved against. Should
-    /// contain every column the predicate may legitimately reference (typically the full table
-    /// schema, or full CDF-extended schema for CDF scans). The caller is responsible for this
-    /// invariant; it is not validated. Caller-applied augmentations of `logical_schema` (e.g.,
-    /// metadata columns added via `StructType::add_metadata_column`) are NOT carried into
-    /// `predicate_schema`, so predicates referencing those columns are rejected at build time.
-    /// `table_configuration` - The TableConfiguration for this table
+    /// `logical_read_schema` - The logical schema of the scan output, which includes partition
+    /// columns `table_schema` - The schema predicate column references are resolved against.
+    /// Should contain every column the predicate may legitimately reference (typically the full
+    /// table schema, or full CDF-extended schema for CDF scans). Currently, we do not carry
+    /// over any metadata columns from the `logical_read_schema` to the `table_schema` (issue
+    /// 2633). `table_configuration` - The TableConfiguration for this table
     /// `predicate` - Optional predicate to filter data during the scan
     /// `stats_output_mode` - Controls how file statistics are handled during the scan
     /// `classifier` - The classifier to use for different scan types. Use `()` if not needed
     pub(crate) fn try_new<C: TransformFieldClassifier>(
-        logical_schema: SchemaRef,
-        predicate_schema: &Schema,
+        logical_read_schema: SchemaRef,
+        table_schema: SchemaRef,
         table_configuration: &TableConfiguration,
         predicate: Option<PredicateRef>,
         stats_output_mode: StatsOutputMode,
@@ -243,14 +241,14 @@ impl StateInfo {
     ) -> DeltaResult<Self> {
         let partition_columns = table_configuration.partition_columns();
         let column_mapping_mode = table_configuration.column_mapping_mode();
-        let mut read_fields = Vec::with_capacity(logical_schema.num_fields());
-        let mut transform_spec = Vec::with_capacity(logical_schema.num_fields());
+        let mut read_fields = Vec::with_capacity(logical_read_schema.num_fields());
+        let mut transform_spec = Vec::with_capacity(logical_read_schema.num_fields());
         let mut last_physical_field: Option<String> = None;
 
-        let metadata_info = validate_metadata_columns(&logical_schema, table_configuration)?;
+        let metadata_info = validate_metadata_columns(&logical_read_schema, table_configuration)?;
 
         // Loop over all selected fields and build both the physical schema and transform spec
-        for (index, logical_field) in logical_schema.fields().enumerate() {
+        for (index, logical_field) in logical_read_schema.fields().enumerate() {
             if let Some(spec) =
                 classifier.classify_field(logical_field, index, &last_physical_field)
             {
@@ -276,7 +274,7 @@ impl StateInfo {
                                 // ensure we have a column name that isn't already in our schema
                                 let index_column_name = (0..)
                                     .map(|i| format!("row_indexes_for_row_id_{i}"))
-                                    .find(|name| logical_schema.field(name).is_none())
+                                    .find(|name| logical_read_schema.field(name).is_none())
                                     .ok_or(Error::generic(
                                         "Couldn't generate row index column name",
                                     ))?;
@@ -341,7 +339,7 @@ impl StateInfo {
             .unwrap_or_default();
 
         let physical_predicate = match predicate {
-            Some(pred) => PhysicalPredicate::try_new(&pred, predicate_schema, column_mapping_mode)?,
+            Some(pred) => PhysicalPredicate::try_new(&pred, &table_schema, column_mapping_mode)?,
             None => PhysicalPredicate::None,
         };
 
@@ -356,7 +354,7 @@ impl StateInfo {
             let dropped: Vec<&ColumnName> = predicate_column_names
                 .iter()
                 .filter(|c| {
-                    get_any_level_column_physical_name(&logical_schema, c, column_mapping_mode)
+                    get_any_level_column_physical_name(&table_schema, c, column_mapping_mode)
                         .ok()
                         .is_some_and(|physical| !physical_stats_columns.contains(&physical))
                 })
@@ -412,7 +410,7 @@ impl StateInfo {
             };
 
         Ok(StateInfo {
-            logical_schema,
+            logical_schema: logical_read_schema,
             physical_schema,
             physical_predicate,
             transform_spec,
@@ -536,7 +534,7 @@ pub(crate) mod tests {
 
         StateInfo::try_new(
             schema.clone(),
-            &schema,
+            table_configuration.logical_schema(),
             &table_configuration,
             predicate,
             stats_output_mode,

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -11,7 +11,7 @@ use crate::scan::data_skipping::stats_schema::build_stats_schema;
 use crate::scan::field_classifiers::TransformFieldClassifier;
 use crate::scan::transform_spec::{FieldTransformSpec, TransformSpec};
 use crate::scan::{PhysicalPredicate, StatsOutputMode};
-use crate::schema::{DataType, MetadataColumnSpec, SchemaRef, StructType};
+use crate::schema::{DataType, MetadataColumnSpec, Schema, SchemaRef, StructType};
 use crate::table_configuration::TableConfiguration;
 use crate::table_features::{get_any_level_column_physical_name, ColumnMappingMode};
 use crate::{DeltaResult, Error, PredicateRef, StructField};
@@ -206,12 +206,19 @@ impl StateInfo {
     /// Get the state needed to process a scan.
     ///
     /// `logical_schema` - The logical schema of the scan output, which includes partition columns
+    /// `predicate_schema` - The schema predicate column references are resolved against. Should
+    /// contain every column the predicate may legitimately reference (typically the full table
+    /// schema, or full CDF-extended schema for CDF scans). The caller is responsible for this
+    /// invariant; it is not validated. Caller-applied augmentations of `logical_schema` (e.g.,
+    /// metadata columns added via `StructType::add_metadata_column`) are NOT carried into
+    /// `predicate_schema`, so predicates referencing those columns are rejected at build time.
     /// `table_configuration` - The TableConfiguration for this table
     /// `predicate` - Optional predicate to filter data during the scan
     /// `stats_output_mode` - Controls how file statistics are handled during the scan
     /// `classifier` - The classifier to use for different scan types. Use `()` if not needed
     pub(crate) fn try_new<C: TransformFieldClassifier>(
         logical_schema: SchemaRef,
+        predicate_schema: &Schema,
         table_configuration: &TableConfiguration,
         predicate: Option<PredicateRef>,
         stats_output_mode: StatsOutputMode,
@@ -318,7 +325,7 @@ impl StateInfo {
             .unwrap_or_default();
 
         let physical_predicate = match predicate {
-            Some(pred) => PhysicalPredicate::try_new(&pred, &logical_schema, column_mapping_mode)?,
+            Some(pred) => PhysicalPredicate::try_new(&pred, predicate_schema, column_mapping_mode)?,
             None => PhysicalPredicate::None,
         };
 
@@ -487,6 +494,7 @@ pub(crate) mod tests {
 
         StateInfo::try_new(
             schema.clone(),
+            &schema,
             &table_configuration,
             predicate,
             stats_output_mode,

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -20,7 +20,7 @@ use crate::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use crate::parquet::arrow::arrow_writer::ArrowWriter;
 use crate::scan::data_skipping::{all_referenced_columns, as_checkpoint_skipping_predicate};
 use crate::scan::state::ScanFile;
-use crate::schema::{ColumnMetadataKey, DataType, StructField, StructType};
+use crate::schema::{ColumnMetadataKey, DataType, MetadataColumnSpec, StructField, StructType};
 use crate::{
     Engine, EngineData, EvaluationHandler, FileDataReadResultIterator, FileMeta, JsonHandler,
     ParquetFooter, ParquetHandler, PredicateRef, Snapshot, StorageHandler,
@@ -336,6 +336,44 @@ fn test_physical_predicate_case_insensitive_unknown_column() {
         ColumnMappingMode::None,
     );
     assert!(result.is_err());
+}
+
+/// `ScanBuilder` decouples the projection (`with_schema`) from the schema predicate
+/// references resolve against (the snapshot's table schema). A caller-added metadata
+/// column lives only in the projection: it is not mirrored into the table schema. A
+/// predicate referencing such a column therefore has no resolution target and must be
+/// rejected at build time. This pins that contract on the public API surface so future
+/// refactors to the wiring inside `ScanBuilder::build` cannot silently regress it.
+#[test]
+fn test_scan_builder_rejects_predicate_on_projection_only_metadata_column() {
+    let path =
+        std::fs::canonicalize(PathBuf::from("./tests/data/table-without-dv-small/")).unwrap();
+    let url = url::Url::from_directory_path(path).unwrap();
+    let engine = SyncEngine::new();
+    let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
+
+    // Augment the projection with a `RowIndex` metadata column. The snapshot's
+    // `schema()` -- which `ScanBuilder::build` passes as the predicate-resolution
+    // schema -- is untouched, so `my_row_index` exists only in the projection.
+    let projection = Arc::new(
+        snapshot
+            .schema()
+            .add_metadata_column("my_row_index", MetadataColumnSpec::RowIndex)
+            .unwrap(),
+    );
+    let predicate = Arc::new(column_expr!("my_row_index").gt(Expr::literal(5_i64)));
+
+    let err = snapshot
+        .scan_builder()
+        .with_schema(projection)
+        .with_predicate(predicate)
+        .build()
+        .expect_err("build should reject predicate referencing a projection-only metadata column");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Predicate references unknown column") && msg.contains("my_row_index"),
+        "unexpected error: {msg}"
+    );
 }
 
 fn get_files_for_scan(scan: Scan, engine: &dyn Engine) -> DeltaResult<Vec<String>> {

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -366,8 +366,8 @@ fn test_scan_builder_rejects_predicate_on_projection_only_metadata_column() {
     let engine = SyncEngine::new();
     let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
 
-    //`my_row_index` is computed during the scan, not stored in the table,
-    //so a predicate can't filter on it
+    // `my_row_index` is computed during the scan, not stored in the table,
+    // so a predicate can't filter on it
     let projection = Arc::new(
         snapshot
             .schema()

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -20,7 +20,9 @@ use crate::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use crate::parquet::arrow::arrow_writer::ArrowWriter;
 use crate::scan::data_skipping::{all_referenced_columns, as_checkpoint_skipping_predicate};
 use crate::scan::state::ScanFile;
-use crate::schema::{self, ColumnMetadataKey, DataType, StructField, StructType};
+use crate::schema::{
+    self, ColumnMetadataKey, DataType, MetadataColumnSpec, StructField, StructType,
+};
 use crate::{
     DeltaResultIteratorStatic, Engine, EngineData, EvaluationHandler, FileDataReadResultIterator,
     FileMeta, JsonHandler, ParquetFooter, ParquetHandler, PredicateRef, Snapshot, StorageHandler,

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -338,12 +338,26 @@ fn test_physical_predicate_case_insensitive_unknown_column() {
     assert!(result.is_err());
 }
 
-/// `ScanBuilder` decouples the projection (`with_schema`) from the schema predicate
-/// references resolve against (the snapshot's table schema). A caller-added metadata
-/// column lives only in the projection: it is not mirrored into the table schema. A
-/// predicate referencing such a column therefore has no resolution target and must be
-/// rejected at build time. This pins that contract on the public API surface so future
-/// refactors to the wiring inside `ScanBuilder::build` cannot silently regress it.
+#[test]
+fn test_scan_builder_accepts_predicate_on_unprojected_data_column() {
+    let path = std::fs::canonicalize(PathBuf::from("./tests/data/basic_partitioned/")).unwrap();
+    let url = url::Url::from_directory_path(path).unwrap();
+    let engine = SyncEngine::new();
+    let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
+
+    let projection = snapshot.schema().project(&["a_float"]).unwrap();
+    let predicate = Arc::new(column_expr!("number").gt(Expr::literal(5_i64)));
+
+    let scan = snapshot
+        .scan_builder()
+        .with_schema(projection)
+        .with_predicate(predicate)
+        .build()
+        .expect("build should accept a predicate referencing a non-projection table column");
+
+    assert_eq!(scan.logical_schema().fields().len(), 1);
+}
+
 #[test]
 fn test_scan_builder_rejects_predicate_on_projection_only_metadata_column() {
     let path =
@@ -352,9 +366,8 @@ fn test_scan_builder_rejects_predicate_on_projection_only_metadata_column() {
     let engine = SyncEngine::new();
     let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
 
-    // Augment the projection with a `RowIndex` metadata column. The snapshot's
-    // `schema()` -- which `ScanBuilder::build` passes as the predicate-resolution
-    // schema -- is untouched, so `my_row_index` exists only in the projection.
+    //`my_row_index` is computed during the scan, not stored in the table,
+    //so a predicate can't filter on it
     let projection = Arc::new(
         snapshot
             .schema()

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -10,12 +10,14 @@ use crate::arrow::array::{Array, BooleanArray, Int64Array, StringArray, StructAr
 use crate::arrow::compute::filter_record_batch;
 use crate::arrow::datatypes::{DataType as ArrowDataType, Field, Fields, Schema as ArrowSchema};
 use crate::arrow::record_batch::RecordBatch;
+use crate::committer::FileSystemCommitter;
 use crate::engine::arrow_data::ArrowEngineData;
 use crate::engine::parquet_row_group_skipping::ParquetRowGroupSkipping;
 use crate::engine::sync::SyncEngine;
 use crate::expressions::{
     column_expr, column_name, column_pred, ColumnName, Expression as Expr, Predicate as Pred,
 };
+use crate::object_store::memory::InMemory;
 use crate::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use crate::parquet::arrow::arrow_writer::ArrowWriter;
 use crate::scan::data_skipping::{all_referenced_columns, as_checkpoint_skipping_predicate};
@@ -23,6 +25,7 @@ use crate::scan::state::ScanFile;
 use crate::schema::{
     self, ColumnMetadataKey, DataType, MetadataColumnSpec, StructField, StructType,
 };
+use crate::transaction::create_table::create_table;
 use crate::{
     DeltaResultIteratorStatic, Engine, EngineData, EvaluationHandler, FileDataReadResultIterator,
     FileMeta, JsonHandler, ParquetFooter, ParquetHandler, PredicateRef, Snapshot, StorageHandler,
@@ -342,10 +345,24 @@ fn test_physical_predicate_case_insensitive_unknown_column() {
 
 #[test]
 fn test_scan_builder_accepts_predicate_on_unprojected_data_column() {
-    let path = std::fs::canonicalize(PathBuf::from("./tests/data/basic_partitioned/")).unwrap();
-    let url = url::Url::from_directory_path(path).unwrap();
-    let engine = SyncEngine::new();
-    let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
+    let url = "memory:///test_table/";
+    let store = Arc::new(InMemory::new());
+    let engine = SyncEngine::new_with_store(store);
+
+    let schema = Arc::new(StructType::new_unchecked([
+        StructField::nullable("number", DataType::LONG),
+        StructField::nullable("a_float", DataType::FLOAT),
+    ]));
+    create_table(url, schema, "DefaultEngine")
+        .build(&engine, Box::new(FileSystemCommitter::new()))
+        .unwrap()
+        .commit(&engine)
+        .unwrap()
+        .unwrap_committed();
+
+    let snapshot = Snapshot::builder_for(url::Url::parse(url).unwrap())
+        .build(&engine)
+        .unwrap();
 
     let projection = snapshot.schema().project(&["a_float"]).unwrap();
     let predicate = Arc::new(column_expr!("number").gt(Expr::literal(5_i64)));
@@ -362,11 +379,24 @@ fn test_scan_builder_accepts_predicate_on_unprojected_data_column() {
 
 #[test]
 fn test_scan_builder_rejects_predicate_on_projection_only_metadata_column() {
-    let path =
-        std::fs::canonicalize(PathBuf::from("./tests/data/table-without-dv-small/")).unwrap();
-    let url = url::Url::from_directory_path(path).unwrap();
-    let engine = SyncEngine::new();
-    let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
+    let url = "memory:///test_table/";
+    let store = Arc::new(InMemory::new());
+    let engine = SyncEngine::new_with_store(store);
+
+    let schema = Arc::new(StructType::new_unchecked([StructField::nullable(
+        "id",
+        DataType::LONG,
+    )]));
+    create_table(url, schema, "DefaultEngine")
+        .build(&engine, Box::new(FileSystemCommitter::new()))
+        .unwrap()
+        .commit(&engine)
+        .unwrap()
+        .unwrap_committed();
+
+    let snapshot = Snapshot::builder_for(url::Url::parse(url).unwrap())
+        .build(&engine)
+        .unwrap();
 
     // `my_row_index` is computed during the scan, not stored in the table,
     // so a predicate can't filter on it

--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -111,17 +111,15 @@ impl TableChangesScanBuilder {
         // Predicates may reference any column in the full CDF-extended schema even when
         // `with_schema` narrows the output. Resolve predicate columns against the full schema
         // so valid references to unprojected columns aren't rejected.
-        let predicate_schema = self.table_changes.schema().clone().into();
+        let table_schema: SchemaRef = self.table_changes.schema().clone().into();
         // If no projection is supplied, default to the full CDF-extended schema (SELECT *).
-        let logical_schema = self
-            .schema
-            .unwrap_or_else(|| self.table_changes.schema.clone().into());
+        let logical_read_schema = self.schema.unwrap_or_else(|| table_schema.clone());
 
         // Create StateInfo using CDF field classifier
         // CDF doesn't support stats output
         let state_info = StateInfo::try_new(
-            logical_schema,
-            predicate_schema,
+            logical_read_schema,
+            table_schema,
             self.table_changes.end_snapshot.table_configuration(),
             self.predicate,
             StatsOutputMode::default(),
@@ -464,11 +462,9 @@ mod tests {
         ));
     }
 
-    // Regression for issue #2468 on the CDF path: a predicate may reference columns in the
-    // full CDF-extended schema even when `with_schema` narrows the output. Build must succeed
-    // and the predicate must be carried through to the scan state.
+    // Regression for issue #2468 on the CDF path
     #[test]
-    fn cdf_predicate_on_unprojected_data_column() {
+    fn cdf_predicate_on_unprojected_data_column_in_table_schema_succeeds() {
         let path = "./tests/data/table-with-cdf";
         let engine = Box::new(SyncEngine::new());
         let url = delta_kernel::try_parse_uri(path).unwrap();
@@ -489,12 +485,9 @@ mod tests {
             PhysicalPredicate::Some(pred, _) if pred == &predicate));
     }
 
-    // The CDF builder docstring documents that predicates over `_change_type`,
-    // `_commit_version`, `_commit_timestamp` are accepted but have no filtering effect (the
-    // kernel does not apply them; see issue #525). This pins the "accepted at build time"
-    // half of that contract on the unprojected path.
+    // github issue #525
     #[test]
-    fn cdf_predicate_on_unprojected_cdf_metadata_column() {
+    fn cdf_predicate_on_unprojected_cdf_metadata_column_builds_but_is_no_op() {
         let path = "./tests/data/table-with-cdf";
         let engine = Box::new(SyncEngine::new());
         let url = delta_kernel::try_parse_uri(path).unwrap();

--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -111,7 +111,7 @@ impl TableChangesScanBuilder {
         // Predicates may reference any column in the full CDF-extended schema even when
         // `with_schema` narrows the output. Resolve predicate columns against the full schema
         // so valid references to unprojected columns aren't rejected.
-        let predicate_schema = self.table_changes.schema();
+        let predicate_schema = self.table_changes.schema().clone().into();
         // If no projection is supplied, default to the full CDF-extended schema (SELECT *).
         let logical_schema = self
             .schema

--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -29,9 +29,11 @@ pub struct TableChangesScan {
 
 /// This builder constructs a [`TableChangesScan`] that can be used to read the [`TableChanges`]
 /// of a table. [`TableChangesScanBuilder`] allows you to specify a schema to project the columns
-/// or specify a predicate to filter rows in the Change Data Feed. Note that predicates containing
-/// Change Data Feed columns `_change_type`, `_commit_version`, and `_commit_timestamp` are not
-/// currently allowed. See issue [#525](https://github.com/delta-io/delta-kernel-rs/issues/525).
+/// or specify a predicate to filter rows in the Change Data Feed. Predicates referencing the
+/// Change Data Feed columns `_change_type`, `_commit_version`, and `_commit_timestamp` are
+/// accepted but have no filtering effect, because those columns are synthesized during scan
+/// execution rather than read from data files; apply such filters in connector code after the
+/// scan returns. See issue [#525](https://github.com/delta-io/delta-kernel-rs/issues/525).
 ///
 /// Note: There is a lot of shared functionality between [`TableChangesScanBuilder`] and
 /// [`ScanBuilder`].
@@ -106,7 +108,11 @@ impl TableChangesScanBuilder {
     /// [`TableChangesScan`] type itself can be used to fetch the files and associated metadata
     /// required to perform actual data reads.
     pub fn build(self) -> DeltaResult<TableChangesScan> {
-        // if no schema is provided, use `TableChanges`'s entire (logical) schema (e.g. SELECT *)
+        // Predicates may reference any column in the full CDF-extended schema even when
+        // `with_schema` narrows the output. Resolve predicate columns against the full schema
+        // so valid references to unprojected columns aren't rejected.
+        let predicate_schema = self.table_changes.schema();
+        // If no projection is supplied, default to the full CDF-extended schema (SELECT *).
         let logical_schema = self
             .schema
             .unwrap_or_else(|| self.table_changes.schema.clone().into());
@@ -115,6 +121,7 @@ impl TableChangesScanBuilder {
         // CDF doesn't support stats output
         let state_info = StateInfo::try_new(
             logical_schema,
+            predicate_schema,
             self.table_changes.end_snapshot.table_configuration(),
             self.predicate,
             StatsOutputMode::default(),
@@ -454,6 +461,63 @@ mod tests {
         assert!(matches!(&scan.state_info.physical_predicate,
             PhysicalPredicate::Some(pred, pred_schema)
             if pred == &predicate && pred_schema.fields().len() == 1
+        ));
+    }
+
+    // Regression for issue #2468 on the CDF path: a predicate may reference columns in the
+    // full CDF-extended schema even when `with_schema` narrows the output. Build must succeed
+    // and the predicate must be carried through to the scan state.
+    #[test]
+    fn cdf_predicate_on_unprojected_data_column() {
+        let path = "./tests/data/table-with-cdf";
+        let engine = Box::new(SyncEngine::new());
+        let url = delta_kernel::try_parse_uri(path).unwrap();
+        let table_changes = TableChanges::try_new(url, engine.as_ref(), 0, Some(1)).unwrap();
+
+        // Project only "part"; predicate references unprojected "id".
+        let schema = table_changes.schema().project(&["part"]).unwrap();
+        let predicate = Arc::new(Predicate::gt(column_expr!("id"), Scalar::from(10)));
+        let scan = table_changes
+            .into_scan_builder()
+            .with_schema(schema)
+            .with_predicate(predicate.clone())
+            .build()
+            .unwrap();
+
+        assert_eq!(scan.logical_schema().fields().len(), 1);
+        assert!(matches!(&scan.state_info.physical_predicate,
+            PhysicalPredicate::Some(pred, _) if pred == &predicate));
+    }
+
+    // The CDF builder docstring documents that predicates over `_change_type`,
+    // `_commit_version`, `_commit_timestamp` are accepted but have no filtering effect (the
+    // kernel does not apply them; see issue #525). This pins the "accepted at build time"
+    // half of that contract on the unprojected path.
+    #[test]
+    fn cdf_predicate_on_unprojected_cdf_metadata_column() {
+        let path = "./tests/data/table-with-cdf";
+        let engine = Box::new(SyncEngine::new());
+        let url = delta_kernel::try_parse_uri(path).unwrap();
+        let table_changes = TableChanges::try_new(url, engine.as_ref(), 0, Some(1)).unwrap();
+
+        // Project only "id"; predicate references unprojected `_commit_version`.
+        let schema = table_changes.schema().project(&["id"]).unwrap();
+        let predicate = Arc::new(Predicate::ge(
+            column_expr!("_commit_version"),
+            Scalar::from(0_i64),
+        ));
+        let scan = table_changes
+            .into_scan_builder()
+            .with_schema(schema)
+            .with_predicate(predicate)
+            .build()
+            .unwrap();
+
+        // Predicate must pass build-time validation. Downstream behavior (no-op for CDF
+        // metadata predicates) is enforced elsewhere.
+        assert!(matches!(
+            &scan.state_info.physical_predicate,
+            PhysicalPredicate::Some(_, _)
         ));
     }
 }

--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -334,12 +334,15 @@ fn read_scan_file(
 mod tests {
     use std::sync::Arc;
 
+    use crate::committer::FileSystemCommitter;
     use crate::engine::sync::SyncEngine;
     use crate::expressions::{column_expr, Scalar};
+    use crate::object_store::memory::InMemory;
     use crate::scan::transform_spec::FieldTransformSpec;
     use crate::scan::PhysicalPredicate;
     use crate::schema::{DataType, StructField, StructType};
     use crate::table_changes::{TableChanges, COMMIT_VERSION_COL_NAME};
+    use crate::transaction::create_table::create_table;
     use crate::Predicate;
 
     #[test]
@@ -465,10 +468,27 @@ mod tests {
     // Regression for issue #2468 on the CDF path
     #[test]
     fn cdf_predicate_on_unprojected_data_column_in_table_schema_succeeds() {
-        let path = "./tests/data/table-with-cdf";
-        let engine = Box::new(SyncEngine::new());
-        let url = delta_kernel::try_parse_uri(path).unwrap();
-        let table_changes = TableChanges::try_new(url, engine.as_ref(), 0, Some(1)).unwrap();
+        let url_str = "memory:///test_table/";
+        let store = Arc::new(InMemory::new());
+        let engine = SyncEngine::new_with_store(store);
+
+        let schema = Arc::new(StructType::new_unchecked([
+            StructField::nullable("id", DataType::INTEGER),
+            StructField::nullable("part", DataType::STRING),
+        ]));
+        create_table(url_str, schema, "DefaultEngine")
+            .with_table_properties([("delta.enableChangeDataFeed", "true")])
+            .build(&engine, Box::new(FileSystemCommitter::new()))
+            .unwrap()
+            .commit(&engine)
+            .unwrap()
+            .unwrap_committed();
+
+        let url = url::Url::parse(url_str).unwrap();
+        // This regression validates predicate resolution at build time, which is independent
+        // of the CDF version span. A wider range would require a second commit with real
+        // change data (see LocalMockTable).
+        let table_changes = TableChanges::try_new(url, &engine, 0, Some(0)).unwrap();
 
         // Project only "part"; predicate references unprojected "id".
         let schema = table_changes.schema().project(&["part"]).unwrap();
@@ -485,7 +505,7 @@ mod tests {
             PhysicalPredicate::Some(pred, _) if pred == &predicate));
     }
 
-    // github issue #525
+    // See delta-io/delta-kernel-rs#525
     #[test]
     fn cdf_predicate_on_unprojected_cdf_metadata_column_builds_but_is_no_op() {
         let path = "./tests/data/table-with-cdf";

--- a/kernel/tests/integration/read.rs
+++ b/kernel/tests/integration/read.rs
@@ -762,11 +762,9 @@ fn predicate_on_letter_and_number(
     Ok(())
 }
 
-// Regression test for issue #2468: a predicate may reference table-schema columns that are
-// outside the `with_schema` projection. The scan must build successfully, return only the
-// projected columns, and still apply data/partition skipping driven by the unprojected predicate.
+// Regression test for issue #2468
 #[rstest::rstest]
-#[case::data_column_not_in_projection(
+#[case::predicate_on_unprojected_data_column_in_table_schema_succeeds(
     // `number` is a data column not present in the projected schema (`a_float`).
     column_expr!("number").gt(Expr::literal(4i64)),
     vec![
@@ -781,9 +779,7 @@ fn predicate_on_letter_and_number(
     .map(String::from)
     .collect()
 )]
-#[case::partition_column_not_in_projection(
-    // `letter` is the partition column. Projection drops it from output, but partition
-    // pruning still resolves against it.
+#[case::predicate_on_partition_column_in_table_schema_succeeds(
     column_expr!("letter").eq(Expr::literal("a")),
     vec![
         "+---------+",
@@ -797,11 +793,8 @@ fn predicate_on_letter_and_number(
     .map(String::from)
     .collect()
 )]
-#[case::mixed_projected_and_unprojected(
-    // Combines the projected data column `a_float` with the unprojected data column
-    // `number`. Both refs must resolve: `a_float` via the projected output schema and
-    // `number` via the full table schema. Matching rows are (4.4, 4, letter=a) and
-    // (5.5, 5, letter=b); files for letter=c are pruned by the `number < 6` bound.
+#[case::predicate_on_mixed_projected_and_unprojected_columns_succeeds(
+    // a_float is projected, number is unprojected
     Pred::and(
         column_expr!("a_float").gt(Expr::literal(4.0)),
         column_expr!("number").lt(Expr::literal(6i64)),
@@ -1066,7 +1059,7 @@ fn mixed_predicate_with_checkpoint_parsed_columns(
     1
 )]
 #[tokio::test]
-async fn partition_pruning_with_column_mapping(
+async fn test_partition_pruning_with_column_mapping(
     #[case] predicate: Arc<Pred>,
     #[case] select_cols: Option<Vec<&'static str>>,
     #[case] expected_files: usize,

--- a/kernel/tests/integration/read.rs
+++ b/kernel/tests/integration/read.rs
@@ -1121,15 +1121,30 @@ async fn test_partition_pruning_with_column_mapping(
 
     let stream = scan.execute(engine)?;
     let mut files_scanned = 0;
+    // "category" is in the output iff there's no projection (SELECT *) or the projection
+    // explicitly includes it.
+    let expect_category = select_cols
+        .as_ref()
+        .is_none_or(|cols| cols.contains(&"category"));
     for engine_data in stream {
         let result_batch = into_record_batch(engine_data?);
-        // The "category" partition column (when included in the projection) should be 'A'
-        // for every surviving row.
-        if let Ok(category_idx) = result_batch.schema().index_of("category") {
-            let category_col = result_batch.column(category_idx).as_string::<i32>();
-            for i in 0..result_batch.num_rows() {
-                assert_eq!(category_col.value(i), "A");
+        // The "category" partition column should be present exactly when projected, and
+        // should be 'A' for every surviving row.
+        match result_batch.schema().index_of("category") {
+            Ok(category_idx) => {
+                assert!(
+                    expect_category,
+                    "category present but not expected in projection"
+                );
+                let category_col = result_batch.column(category_idx).as_string::<i32>();
+                for i in 0..result_batch.num_rows() {
+                    assert_eq!(category_col.value(i), "A");
+                }
             }
+            Err(_) => assert!(
+                !expect_category,
+                "category missing but expected in projection"
+            ),
         }
         files_scanned += 1;
     }

--- a/kernel/tests/integration/read.rs
+++ b/kernel/tests/integration/read.rs
@@ -797,6 +797,27 @@ fn predicate_on_letter_and_number(
     .map(String::from)
     .collect()
 )]
+#[case::mixed_projected_and_unprojected(
+    // Combines the projected data column `a_float` with the unprojected data column
+    // `number`. Both refs must resolve: `a_float` via the projected output schema and
+    // `number` via the full table schema. Matching rows are (4.4, 4, letter=a) and
+    // (5.5, 5, letter=b); files for letter=c are pruned by the `number < 6` bound.
+    Pred::and(
+        column_expr!("a_float").gt(Expr::literal(4.0)),
+        column_expr!("number").lt(Expr::literal(6i64)),
+    ),
+    vec![
+        "+---------+",
+        "| a_float |",
+        "+---------+",
+        "| 4.4     |",
+        "| 5.5     |",
+        "+---------+",
+    ]
+    .into_iter()
+    .map(String::from)
+    .collect()
+)]
 fn predicate_on_unprojected_column(
     #[case] pred: Pred,
     #[case] expected: Vec<String>,
@@ -1011,11 +1032,6 @@ fn mixed_predicate_with_checkpoint_parsed_columns(
 /// column "category" has physical name "phys_category". With column mapping, `partitionValues`
 /// in the log uses physical column names, and the partition schema + predicate must also use
 /// physical names for `MapToStruct` extraction and data skipping to work correctly.
-///
-/// The `predicate_on_unprojected_*` cases also exercise issue #2468: when `with_schema`
-/// narrows the projection but the predicate references a column outside that projection
-/// (and column mapping is on), kernel must still resolve the column's physical name from
-/// the full table schema for stats- and partition-based skipping to work.
 #[rstest::rstest]
 #[case::partition_only(
     // Partition-only predicate: category = 'A' prunes the category=B file
@@ -1099,7 +1115,7 @@ async fn partition_pruning_with_column_mapping(
 
     // Predicates use logical column names -- kernel must map to physical names. The
     // optional projection narrows the output schema; when set, the predicate may still
-    // reference columns outside it (issue #2468 contract).
+    // reference columns outside it
     let projection = select_cols
         .as_ref()
         .map(|cols| snapshot.schema().project(cols))

--- a/kernel/tests/integration/read.rs
+++ b/kernel/tests/integration/read.rs
@@ -762,6 +762,54 @@ fn predicate_on_letter_and_number(
     Ok(())
 }
 
+// Regression test for issue #2468: a predicate may reference table-schema columns that are
+// outside the `with_schema` projection. The scan must build successfully, return only the
+// projected columns, and still apply data/partition skipping driven by the unprojected predicate.
+#[rstest::rstest]
+#[case::data_column_not_in_projection(
+    // `number` is a data column not present in the projected schema (`a_float`).
+    column_expr!("number").gt(Expr::literal(4i64)),
+    vec![
+        "+---------+",
+        "| a_float |",
+        "+---------+",
+        "| 5.5     |",
+        "| 6.6     |",
+        "+---------+",
+    ]
+    .into_iter()
+    .map(String::from)
+    .collect()
+)]
+#[case::partition_column_not_in_projection(
+    // `letter` is the partition column. Projection drops it from output, but partition
+    // pruning still resolves against it.
+    column_expr!("letter").eq(Expr::literal("a")),
+    vec![
+        "+---------+",
+        "| a_float |",
+        "+---------+",
+        "| 1.1     |",
+        "| 4.4     |",
+        "+---------+",
+    ]
+    .into_iter()
+    .map(String::from)
+    .collect()
+)]
+fn predicate_on_unprojected_column(
+    #[case] pred: Pred,
+    #[case] expected: Vec<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    read_table_data(
+        "./tests/data/basic_partitioned",
+        Some(&["a_float"]),
+        Some(pred),
+        expected,
+    )?;
+    Ok(())
+}
+
 /// Test partition pruning on a table with a checkpoint containing `partitionValues_parsed`.
 /// This exercises the checkpoint code path where typed partition values are read directly
 /// from the parquet column rather than parsed from the string map via `MapToStruct`.
@@ -963,10 +1011,16 @@ fn mixed_predicate_with_checkpoint_parsed_columns(
 /// column "category" has physical name "phys_category". With column mapping, `partitionValues`
 /// in the log uses physical column names, and the partition schema + predicate must also use
 /// physical names for `MapToStruct` extraction and data skipping to work correctly.
+///
+/// The `predicate_on_unprojected_*` cases also exercise issue #2468: when `with_schema`
+/// narrows the projection but the predicate references a column outside that projection
+/// (and column mapping is on), kernel must still resolve the column's physical name from
+/// the full table schema for stats- and partition-based skipping to work.
 #[rstest::rstest]
 #[case::partition_only(
     // Partition-only predicate: category = 'A' prunes the category=B file
     Arc::new(Pred::eq(column_expr!("category"), Expr::literal("A"))),
+    None,
     1
 )]
 #[case::mixed_partition_and_data(
@@ -976,11 +1030,29 @@ fn mixed_predicate_with_checkpoint_parsed_columns(
         Pred::eq(column_expr!("category"), Expr::literal("A")),
         Pred::gt(column_expr!("val"), Expr::literal("z")),
     )),
+    None,
+    1
+)]
+#[case::predicate_on_unprojected_data_column(
+    // Project only "category"; predicate references unprojected "val" (logical) whose
+    // physical name is "phys_val". Kernel must resolve to phys_val via the full table
+    // schema and prune both files: max(phys_val)='z' is NOT > 'z'.
+    Arc::new(Pred::gt(column_expr!("val"), Expr::literal("z"))),
+    Some(vec!["category"]),
+    0
+)]
+#[case::predicate_on_unprojected_partition_column(
+    // Project only "val"; predicate references unprojected partition column "category"
+    // (logical, physical name "phys_category"). Partition pruning must still kick in
+    // using the physical partition name, keeping only the category=A file.
+    Arc::new(Pred::eq(column_expr!("category"), Expr::literal("A"))),
+    Some(vec!["val"]),
     1
 )]
 #[tokio::test]
 async fn partition_pruning_with_column_mapping(
     #[case] predicate: Arc<Pred>,
+    #[case] select_cols: Option<Vec<&'static str>>,
     #[case] expected_files: usize,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let batch = generate_batch(vec![("phys_val", vec!["x", "y", "z"].into_array())])?;
@@ -1025,18 +1097,30 @@ async fn partition_pruning_with_column_mapping(
     let engine = Arc::new(DefaultEngineBuilder::new(storage.clone()).build());
     let snapshot = Snapshot::builder_for(table_root).build(engine.as_ref())?;
 
-    // Predicates use logical column names -- kernel must map to physical names
-    let scan = snapshot.scan_builder().with_predicate(predicate).build()?;
+    // Predicates use logical column names -- kernel must map to physical names. The
+    // optional projection narrows the output schema; when set, the predicate may still
+    // reference columns outside it (issue #2468 contract).
+    let projection = select_cols
+        .as_ref()
+        .map(|cols| snapshot.schema().project(cols))
+        .transpose()?;
+    let scan = snapshot
+        .scan_builder()
+        .with_schema_opt(projection)
+        .with_predicate(predicate)
+        .build()?;
 
     let stream = scan.execute(engine)?;
     let mut files_scanned = 0;
     for engine_data in stream {
         let result_batch = into_record_batch(engine_data?);
-        // The "category" partition column should be filled with "A"
-        let category_idx = result_batch.schema().index_of("category")?;
-        let category_col = result_batch.column(category_idx).as_string::<i32>();
-        for i in 0..result_batch.num_rows() {
-            assert_eq!(category_col.value(i), "A");
+        // The "category" partition column (when included in the projection) should be 'A'
+        // for every surviving row.
+        if let Ok(category_idx) = result_batch.schema().index_of("category") {
+            let category_col = result_batch.column(category_idx).as_string::<i32>();
+            for i in 0..result_batch.num_rows() {
+                assert_eq!(category_col.value(i), "A");
+            }
         }
         files_scanned += 1;
     }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Modifies mod.rs, state_info.rs, and scan.rs primarily. 

Previously ScanBuilder::build rejected predicates referencing columns that were outside with_schema projection (those that were not retrieved in the end). This PR addresses this by adding a new predicate_schema argument to decouple the logic there. 

Closes #2468.

Limitations from before: user metadata columns are still rejected at build time, References to CDF metadata columns do not contribute to kernel filtering; apply those filters in the connector after the scan.

## How was this change tested?

unit and integration tests
