### PR TITLE
fix: per-cell NULL on stats JSON parse failure for error prone types

### DIFF
--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -343,18 +343,19 @@ pub fn evaluate_expression(
             }
         }
         (ParseJson(p), _) => {
-            // Evaluate the JSON string expression
             let json_arr = evaluate_expression(&p.json_expr, batch, Some(&DataType::STRING))?;
-
-            // Convert kernel schema to Arrow schema and parse
-            let arrow_schema = Arc::new(ArrowSchema::try_from_kernel(p.output_schema.as_ref())?);
-            match parse_json_impl(json_arr.as_ref(), arrow_schema.clone()) {
+            // Coarser backstop for genuinely malformed JSON (incomplete records, unmatched
+            // braces, etc.). Cell-level type-parse failures in failure-prone leaves
+            // (Timestamp/Date/Decimal) are handled inside `parse_json_impl` itself, which
+            // converts them to per-cell NULL rather than failing the batch.
+            match parse_json_impl(json_arr.as_ref(), p.output_schema.clone()) {
                 Ok(batch) => Ok(Arc::new(StructArray::from(batch)) as ArrayRef),
                 Err(e) => {
                     warn!(
                         "Failed to parse JSON stats as {}: {e}. Using null stats.",
                         p.output_schema,
                     );
+                    let arrow_schema = ArrowSchema::try_from_kernel(p.output_schema.as_ref())?;
                     Ok(new_null_array(
                         &ArrowDataType::Struct(arrow_schema.fields().clone()),
                         json_arr.len(),
@@ -1966,47 +1967,29 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_json_errors_return_nulls() {
-        // ParseJson is used for stats parsing. Corrupt or unparseable values should produce
-        // null output rather than failing the query -- files with null stats simply skip data
-        // skipping and are always included in scan results.
+    fn test_parse_json_strict_leaf_errors_fall_back_to_all_null_struct() {
+        // ParseJson is used for stats parsing. Type-parse failures on strict leaves still hit
+        // the coarse swallow inside the ParseJson arm, which returns an all-null struct so
+        // data skipping degrades to "include the file" rather than failing the query.
+        // Per-cell NULLs on failure-prone leaves (Timestamp/Date/Decimal) are tested in
+        // `engine::arrow_utils::tests::test_parse_json_safe_cast_*` and do NOT go through
+        // this fallback.
+        let schema = ArrowSchema::new(vec![ArrowField::new("json_col", ArrowDataType::Utf8, true)]);
+        let json_strings: Vec<Option<&str>> = vec![Some(r#"{"a": "not_a_number"}"#)];
+        let len = json_strings.len();
+        let json_arr = StringArray::from(json_strings);
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(json_arr)]).unwrap();
 
-        fn assert_parse_json_result_all_nulls(
-            json_strings: Vec<Option<&str>>,
-            output_schema: Arc<StructType>,
-        ) {
-            let schema =
-                ArrowSchema::new(vec![ArrowField::new("json_col", ArrowDataType::Utf8, true)]);
-            let len = json_strings.len();
-            let json_arr = StringArray::from(json_strings);
-            let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(json_arr)]).unwrap();
+        let output_schema = Arc::new(StructType::new_unchecked(vec![StructField::new(
+            "a",
+            DataType::LONG,
+            true,
+        )]));
+        let expr = Expr::parse_json(column_expr!("json_col"), output_schema);
+        let result = evaluate_expression(&expr, &batch, None).unwrap();
 
-            let expr = Expr::parse_json(column_expr!("json_col"), output_schema);
-            let result = evaluate_expression(&expr, &batch, None).unwrap();
-
-            assert_eq!(result.len(), len);
-            assert_eq!(result.null_count(), len);
-        }
-
-        // Type mismatch: string value where integer is expected
-        assert_parse_json_result_all_nulls(
-            vec![Some(r#"{"a": "not_a_number"}"#)],
-            Arc::new(StructType::new_unchecked(vec![StructField::new(
-                "a",
-                DataType::LONG,
-                true,
-            )])),
-        );
-
-        // Value overflow: 99999 doesn't fit in decimal(4,2) (max 99.99)
-        assert_parse_json_result_all_nulls(
-            vec![Some(r#"{"a": 99999}"#)],
-            Arc::new(StructType::new_unchecked(vec![StructField::new(
-                "a",
-                DataType::decimal(4, 2).unwrap(),
-                true,
-            )])),
-        );
+        assert_eq!(result.len(), len);
+        assert_eq!(result.null_count(), len);
     }
 
     // ==================== MapToStruct Tests ====================

--- a/kernel/src/engine/arrow_utils/mod.rs
+++ b/kernel/src/engine/arrow_utils/mod.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod apply_schema;
 
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::ops::Range;
 use std::sync::{Arc, OnceLock};
@@ -13,10 +14,11 @@ use tracing::debug;
 use self::apply_schema::apply_schema_to_struct;
 use crate::arrow::array::cast::AsArray;
 use crate::arrow::array::{
-    make_array, new_null_array, Array as ArrowArray, GenericListArray, MapArray, OffsetSizeTrait,
-    PrimitiveArray, RecordBatch, StringArray, StructArray,
+    make_array, new_null_array, Array as ArrowArray, ArrayRef as ArrowArrayRef, GenericListArray,
+    MapArray, OffsetSizeTrait, PrimitiveArray, RecordBatch, StringArray, StructArray,
 };
 use crate::arrow::buffer::NullBuffer;
+use crate::arrow::compute::{cast_with_options, CastOptions};
 use crate::arrow::datatypes::{
     DataType as ArrowDataType, Field as ArrowField, FieldRef as ArrowFieldRef,
     Fields as ArrowFields, Int64Type, Schema as ArrowSchema, SchemaRef as ArrowSchemaRef,
@@ -31,9 +33,10 @@ use crate::parquet::arrow::{ProjectionMask, PARQUET_FIELD_ID_META_KEY};
 use crate::parquet::file::metadata::RowGroupMetaData;
 use crate::parquet::schema::types::SchemaDescriptor;
 use crate::schema::{
-    ColumnMetadataKey, DataType, MetadataColumnSpec, MetadataValue, Schema, SchemaRef, StructField,
-    StructType,
+    ArrayType, ColumnMetadataKey, DataType, MapType, MetadataColumnSpec, MetadataValue,
+    PrimitiveType, Schema, SchemaRef, StructField, StructType,
 };
+use crate::transforms::{transform_output_type, SchemaTransform};
 use crate::utils::require;
 use crate::{DeltaResult, EngineData, Error};
 
@@ -1143,36 +1146,30 @@ pub(crate) fn parse_json(
     schema: SchemaRef,
 ) -> DeltaResult<Box<dyn EngineData>> {
     let json_strings: RecordBatch = ArrowEngineData::try_from_engine_data(json_strings)?.into();
-    let schema = Arc::new(ArrowSchema::try_from_kernel(schema.as_ref())?);
     let result = parse_json_impl(json_strings.column(0).as_ref(), schema)?;
     Ok(Box::new(ArrowEngineData::new(result)))
 }
 
-/// Raw arrow implementation of the json parsing. Separate from the public function for testing.
+/// Raw implementation of the JSON parsing. Separate from the public function for testing.
 /// Also used by ParseJson expression evaluation.
 ///
 /// Accepts any string array type (`StringArray`, `LargeStringArray`, `StringViewArray`) to avoid
 /// narrowing casts that could overflow (e.g. `LargeStringArray` -> `StringArray`).
 pub(crate) fn parse_json_impl(
     json_strings: &dyn ArrowArray,
-    schema: ArrowSchemaRef,
+    schema: SchemaRef,
 ) -> DeltaResult<RecordBatch> {
+    let num_rows = json_strings.len();
     match json_strings.data_type() {
-        ArrowDataType::Utf8 => parse_json_inner(
-            json_strings.as_string::<i32>().iter(),
-            json_strings.len(),
-            schema,
-        ),
-        ArrowDataType::LargeUtf8 => parse_json_inner(
-            json_strings.as_string::<i64>().iter(),
-            json_strings.len(),
-            schema,
-        ),
-        ArrowDataType::Utf8View => parse_json_inner(
-            json_strings.as_string_view().iter(),
-            json_strings.len(),
-            schema,
-        ),
+        ArrowDataType::Utf8 => {
+            parse_json_inner(json_strings.as_string::<i32>().iter(), num_rows, schema)
+        }
+        ArrowDataType::LargeUtf8 => {
+            parse_json_inner(json_strings.as_string::<i64>().iter(), num_rows, schema)
+        }
+        ArrowDataType::Utf8View => {
+            parse_json_inner(json_strings.as_string_view().iter(), num_rows, schema)
+        }
         dt => Err(Error::generic(format!(
             "Expected string array for JSON parsing, got {dt}"
         ))),
@@ -1182,13 +1179,41 @@ pub(crate) fn parse_json_impl(
 fn parse_json_inner<'a>(
     json_strings: impl Iterator<Item = Option<&'a str>>,
     num_rows: usize,
+    schema: SchemaRef,
+) -> DeltaResult<RecordBatch> {
+    // arrow-json's typed Timestamp/Date/Decimal decoders fail the entire batch on a single
+    // bad cell. `StringifyFailureProneLeaves` rewrites those leaves to `String` so the
+    // typed decode accepts any well-formed JSON string; `safe_cast_back` then casts each
+    // string cell back to the target type with `safe: true`, producing per-cell NULL on
+    // parse failure. `Cow::Borrowed` from the transform means no failure-prone leaves
+    // were present, so we can skip the safe-cast pass entirely.
+    match StringifyFailureProneLeaves.transform_struct(schema.as_ref()) {
+        Cow::Borrowed(_) => {
+            let arrow_target = Arc::new(ArrowSchema::try_from_kernel(schema.as_ref())?);
+            decode_with_arrow_json(json_strings, num_rows, arrow_target)
+        }
+        Cow::Owned(relaxed) => {
+            let arrow_target = Arc::new(ArrowSchema::try_from_kernel(schema.as_ref())?);
+            let arrow_relaxed = Arc::new(ArrowSchema::try_from_kernel(&relaxed)?);
+            let decoded = decode_with_arrow_json(json_strings, num_rows, arrow_relaxed)?;
+            safe_cast_back(decoded, &arrow_target)
+        }
+    }
+}
+
+/// Runs arrow-json's typed `Decoder` against the given schema and returns the resulting
+/// `RecordBatch`. Each input string must contain exactly one JSON object; missing inputs
+/// (`None`) decode as `{}` so the row stays present with all-NULL fields.
+fn decode_with_arrow_json<'a>(
+    json_strings: impl Iterator<Item = Option<&'a str>>,
+    num_rows: usize,
     schema: ArrowSchemaRef,
 ) -> DeltaResult<RecordBatch> {
     if num_rows == 0 {
         return Ok(RecordBatch::new_empty(schema));
     }
 
-    let mut decoder = ReaderBuilder::new(schema.clone())
+    let mut decoder = ReaderBuilder::new(schema)
         .with_batch_size(num_rows)
         .with_coerce_primitive(true)
         .build_decoder()?;
@@ -1223,6 +1248,100 @@ fn parse_json_inner<'a>(
     Err(Error::generic(
         "Malformed JSON: exited parse_json_impl without deserializing anything useful",
     ))
+}
+
+/// Rewrites the four arrow-json-failure-prone primitive types (`Timestamp`, `TimestampNtz`,
+/// `Date`, `Decimal`) to `String` so the typed decoder will accept any well-formed JSON
+/// string instead of failing the whole batch on cells the typed parsers reject. The
+/// post-decode safe-cast pass converts each string cell back to the original type,
+/// producing per-cell NULL on parse failure.
+///
+/// `Array`/`Map`/`Variant` are NOT visited because the Delta protocol does not record
+/// min/max stats for those types (see `MinMaxStatsTransform` in
+/// `scan::data_skipping::stats_schema`), so a failure-prone leaf can only ever appear
+/// inside a `Struct` for our callers. If a future caller passes a schema with
+/// failure-prone leaves nested inside `Array`/`Map`/`Variant`, drop these no-op overrides
+/// (the default recursion will then walk into them) and add the matching arms to
+/// [`safe_cast_array`].
+struct StringifyFailureProneLeaves;
+
+impl<'a> SchemaTransform<'a> for StringifyFailureProneLeaves {
+    transform_output_type!(|'a, T| Cow<'a, T>);
+
+    fn transform_primitive(&mut self, ptype: &'a PrimitiveType) -> Cow<'a, PrimitiveType> {
+        match ptype {
+            PrimitiveType::Timestamp
+            | PrimitiveType::TimestampNtz
+            | PrimitiveType::Date
+            | PrimitiveType::Decimal(_) => Cow::Owned(PrimitiveType::String),
+            _ => Cow::Borrowed(ptype),
+        }
+    }
+
+    fn transform_array(&mut self, atype: &'a ArrayType) -> Cow<'a, ArrayType> {
+        Cow::Borrowed(atype)
+    }
+
+    fn transform_map(&mut self, mtype: &'a MapType) -> Cow<'a, MapType> {
+        Cow::Borrowed(mtype)
+    }
+
+    fn transform_variant(&mut self, stype: &'a StructType) -> Cow<'a, StructType> {
+        Cow::Borrowed(stype)
+    }
+}
+
+/// Walks the decoded `RecordBatch` against the original target schema in lockstep and
+/// safe-casts every leaf back to its target type. `safe: true` produces per-cell NULL on
+/// parse failure instead of erroring out the whole batch.
+fn safe_cast_back(decoded: RecordBatch, target: &ArrowSchemaRef) -> DeltaResult<RecordBatch> {
+    let opts = CastOptions {
+        safe: true,
+        ..Default::default()
+    };
+    let columns = decoded
+        .columns()
+        .iter()
+        .zip(target.fields().iter())
+        .map(|(arr, field)| safe_cast_array(arr.clone(), field.data_type(), &opts))
+        .collect::<DeltaResult<Vec<_>>>()?;
+    Ok(RecordBatch::try_new(target.clone(), columns)?)
+}
+
+/// Recursive worker for [`safe_cast_back`]. Recurses through `Struct` containers
+/// preserving the parent null buffer, and applies `cast_with_options` at the leaves.
+///
+/// Delta protocol does not record min/max stats for `Array`/`Map`/`Variant` columns (see
+/// `MinMaxStatsTransform` in `scan::data_skipping::stats_schema`), so a failure-prone leaf
+/// can only ever reach this function nested inside a `Struct`. If that invariant ever
+/// changes, drop the no-op overrides on [`StringifyFailureProneLeaves`] and add the
+/// matching arms here.
+fn safe_cast_array(
+    array: ArrowArrayRef,
+    target: &ArrowDataType,
+    opts: &CastOptions<'_>,
+) -> DeltaResult<ArrowArrayRef> {
+    if array.data_type() == target {
+        return Ok(array);
+    }
+    match target {
+        ArrowDataType::Struct(target_fields) => {
+            let s = array.as_struct();
+            let nulls = s.nulls().cloned();
+            let new_children = s
+                .columns()
+                .iter()
+                .zip(target_fields.iter())
+                .map(|(c, f)| safe_cast_array(c.clone(), f.data_type(), opts))
+                .collect::<DeltaResult<Vec<_>>>()?;
+            Ok(Arc::new(StructArray::try_new(
+                target_fields.clone(),
+                new_children,
+                nulls,
+            )?))
+        }
+        _ => Ok(cast_with_options(&array, target, opts)?),
+    }
 }
 
 pub(crate) fn filter_to_record_batch(
@@ -1498,11 +1617,7 @@ mod tests {
     #[test]
     fn test_json_parsing() {
         static EXPECTED_JSON_ERR_STR: &str = "Generic delta kernel error: Malformed JSON: Multiple, partial, or 0 JSON objects on row";
-        fn check_parse_fails(
-            input: Vec<Option<&str>>,
-            schema: ArrowSchemaRef,
-            expected_start: &str,
-        ) {
+        fn check_parse_fails(input: Vec<Option<&str>>, schema: SchemaRef, expected_start: &str) {
             let result = parse_json_impl(&StringArray::from(input), schema);
             let err = result.expect_err("Expected an error");
             let msg = err.to_string();
@@ -1512,11 +1627,14 @@ mod tests {
             );
         }
 
-        let requested_schema = Arc::new(ArrowSchema::new(vec![
-            ArrowField::new("a", ArrowDataType::Int32, true),
-            ArrowField::new("b", ArrowDataType::Utf8, true),
-            ArrowField::new("c", ArrowDataType::Int32, true),
-        ]));
+        let requested_schema = Arc::new(
+            StructType::try_new(vec![
+                StructField::nullable("a", DataType::INTEGER),
+                StructField::nullable("b", DataType::STRING),
+                StructField::nullable("c", DataType::INTEGER),
+            ])
+            .unwrap(),
+        );
         let input: Vec<&str> = vec![];
         let result = parse_json_impl(&StringArray::from(input), requested_schema.clone()).unwrap();
         assert_eq!(result.num_rows(), 0);
@@ -1541,7 +1659,7 @@ mod tests {
         );
 
         let input: Vec<Option<&str>> = vec![None, Some(r#"{"a": 1, "b": "2", "c": 3}"#), None];
-        let result = parse_json_impl(&StringArray::from(input), requested_schema.clone()).unwrap();
+        let result = parse_json_impl(&StringArray::from(input), requested_schema).unwrap();
         assert_eq!(result.num_rows(), 3);
         assert_eq!(result.column(0).null_count(), 2);
         assert_eq!(result.column(1).null_count(), 2);
@@ -1551,16 +1669,14 @@ mod tests {
     #[test]
     fn test_parse_json_with_long_strings() {
         // See issue#1139: https://github.com/delta-io/delta-kernel-rs/issues/1139
-        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
-            "long_val",
-            ArrowDataType::Utf8,
-            true,
-        )]));
+        let schema = Arc::new(
+            StructType::try_new(vec![StructField::nullable("long_val", DataType::STRING)]).unwrap(),
+        );
         let long_string = "a".repeat(1_000_000); // 1MB string
         let json_string = format!(r#"{{"long_val": "{long_string}"}}"#);
         let input: Vec<Option<&str>> = vec![Some(&json_string)];
 
-        let batch = parse_json_impl(&StringArray::from(input), schema.clone()).unwrap();
+        let batch = parse_json_impl(&StringArray::from(input), schema).unwrap();
         assert_eq!(batch.num_rows(), 1);
         let long_col = batch.column(0).as_string::<i32>();
         assert_eq!(long_col.value(0), long_string);
@@ -1650,27 +1766,223 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_json_impl_propagates_type_errors() {
-        // Verify that parse_json_impl surfaces errors for values that don't match the schema,
-        // so the expression-level caller can catch them and return nulls.
-
-        // Value overflow: 99999 doesn't fit in decimal(4,2) (max 99.99)
-        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
-            "a",
-            ArrowDataType::Decimal128(4, 2),
-            true,
-        )]));
-        let input: Vec<Option<&str>> = vec![Some(r#"{"a": 99999}"#)];
-        assert!(parse_json_impl(&StringArray::from(input), schema).is_err());
-
-        // Type mismatch: string where integer expected
-        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
-            "a",
-            ArrowDataType::Int64,
-            true,
-        )]));
+    fn test_parse_json_impl_strict_leaf_errors_propagate() {
+        // Type mismatches on strict (non-failure-prone) leaves still surface as batch-level
+        // errors, so the expression-level caller can fall back to its all-null backstop.
+        let schema = Arc::new(
+            StructType::try_new(vec![StructField::nullable("a", DataType::LONG)]).unwrap(),
+        );
         let input: Vec<Option<&str>> = vec![Some(r#"{"a": "not_a_number"}"#)];
         assert!(parse_json_impl(&StringArray::from(input), schema).is_err());
+    }
+
+    // === Per-cell NULL on failure-prone leaf parse failures ===
+
+    /// Parses `inputs` against a single-column schema `{column_name: leaf_type}` and asserts
+    /// that rows in `expected_null_rows` are NULL while every other row is non-null.
+    fn assert_per_cell_null_isolation(
+        column_name: &str,
+        leaf_type: DataType,
+        inputs: &[&str],
+        expected_null_rows: &[usize],
+    ) {
+        let schema = Arc::new(
+            StructType::try_new(vec![StructField::nullable(column_name, leaf_type)]).unwrap(),
+        );
+        let inputs: Vec<Option<&str>> = inputs.iter().copied().map(Some).collect();
+        let batch = parse_json_impl(&StringArray::from(inputs.clone()), schema)
+            .expect("parse_json_impl should not error on failure-prone leaf parse failures");
+        assert_eq!(batch.num_rows(), inputs.len());
+        let col = batch.column(0);
+        assert_eq!(
+            col.null_count(),
+            expected_null_rows.len(),
+            "unexpected null count for column {column_name}",
+        );
+        for row in 0..inputs.len() {
+            let want_null = expected_null_rows.contains(&row);
+            assert_eq!(
+                col.is_null(row),
+                want_null,
+                "row {row} of column {column_name}: expected is_null={want_null}",
+            );
+        }
+    }
+
+    /// Per-cell NULL isolation across the four failure-prone leaf types. Each case feeds
+    /// a 3-row single-column batch where row 1 is malformed in a way that defeats
+    /// arrow-json's typed decoder; rows 0 and 2 must round-trip to valid typed cells.
+    #[rstest]
+    #[case::timestamp_extended_year(
+        DataType::TIMESTAMP,
+        &[
+            r#"{"v": "2024-01-01T00:00:00Z"}"#,
+            r#"{"v": "+48690-07-02T22:50:38.211Z"}"#,
+            r#"{"v": "2025-06-01T00:00:00Z"}"#,
+        ],
+    )]
+    #[case::timestamp_ntz_garbage(
+        DataType::TIMESTAMP_NTZ,
+        &[
+            r#"{"v": "2024-01-01T00:00:00"}"#,
+            r#"{"v": "not-a-timestamp"}"#,
+            r#"{"v": "2025-06-01T00:00:00"}"#,
+        ],
+    )]
+    #[case::date_out_of_range_month(
+        DataType::DATE,
+        &[
+            r#"{"v": "2024-01-01"}"#,
+            r#"{"v": "2024-13-01"}"#,
+            r#"{"v": "2025-06-30"}"#,
+        ],
+    )]
+    #[case::decimal_overflow(
+        DataType::decimal(10, 2).unwrap(),
+        &[
+            r#"{"v": "10.50"}"#,
+            r#"{"v": "99999999999.99"}"#,
+            r#"{"v": "5.25"}"#,
+        ],
+    )]
+    fn test_parse_json_safe_cast_per_cell_null(
+        #[case] leaf_type: DataType,
+        #[case] inputs: &[&str],
+    ) {
+        assert_per_cell_null_isolation("v", leaf_type, inputs, &[1]);
+    }
+
+    #[test]
+    fn test_parse_json_safe_cast_intermixed_struct_per_cell_isolation() {
+        // Single struct with mixed failure-prone and strict leaves. The bad EventTime on row 1
+        // must not contaminate IngestTime / Price / UserId on the same row, nor any field on
+        // rows 0 / 2. This is the per-cell isolation property end-to-end.
+        let schema = Arc::new(
+            StructType::try_new(vec![
+                StructField::nullable("EventTime", DataType::TIMESTAMP),
+                StructField::nullable("IngestTime", DataType::TIMESTAMP),
+                StructField::nullable("Price", DataType::decimal(10, 2).unwrap()),
+                StructField::nullable("UserId", DataType::LONG),
+            ])
+            .unwrap(),
+        );
+        let inputs: Vec<Option<&str>> = vec![
+            Some(
+                r#"{"EventTime": "2024-01-01T00:00:00Z", "IngestTime": "2024-01-01T00:00:01Z", "Price": "10.50", "UserId": 1}"#,
+            ),
+            Some(
+                r#"{"EventTime": "+48690-07-02T22:50:38.211Z", "IngestTime": "2024-06-01T00:00:01Z", "Price": "20.00", "UserId": 2}"#,
+            ),
+            Some(
+                r#"{"EventTime": "2025-06-01T00:00:00Z", "IngestTime": "2025-06-01T00:00:01Z", "Price": "30.75", "UserId": 3}"#,
+            ),
+        ];
+        let batch = parse_json_impl(&StringArray::from(inputs.clone()), schema).unwrap();
+        assert_eq!(batch.num_rows(), 3);
+
+        let event_time = batch.column_by_name("EventTime").unwrap();
+        let ingest_time = batch.column_by_name("IngestTime").unwrap();
+        let price = batch.column_by_name("Price").unwrap();
+        let user_id = batch.column_by_name("UserId").unwrap();
+
+        assert!(!event_time.is_null(0) && event_time.is_null(1) && !event_time.is_null(2));
+        assert_eq!(event_time.null_count(), 1);
+
+        for col in [&ingest_time, &price, &user_id] {
+            assert_eq!(
+                col.null_count(),
+                0,
+                "row 1's bad EventTime should not contaminate other fields in the same row"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_json_safe_cast_nested_stats_shape() {
+        // Mirrors the Delta stats StructType:
+        //   { numRecords: Long, nullCount: { EventTime: Long, UserId: Long },
+        //     minValues: { EventTime: Timestamp, UserId: Long },
+        //     maxValues: { EventTime: Timestamp, UserId: Long },
+        //     tightBounds: Bool }
+        let null_count_struct = StructType::try_new(vec![
+            StructField::nullable("EventTime", DataType::LONG),
+            StructField::nullable("UserId", DataType::LONG),
+        ])
+        .unwrap();
+        let min_max_struct = StructType::try_new(vec![
+            StructField::nullable("EventTime", DataType::TIMESTAMP),
+            StructField::nullable("UserId", DataType::LONG),
+        ])
+        .unwrap();
+        let schema = Arc::new(
+            StructType::try_new(vec![
+                StructField::nullable("numRecords", DataType::LONG),
+                StructField::nullable("nullCount", null_count_struct),
+                StructField::nullable("minValues", min_max_struct.clone()),
+                StructField::nullable("maxValues", min_max_struct),
+                StructField::nullable("tightBounds", DataType::BOOLEAN),
+            ])
+            .unwrap(),
+        );
+
+        let inputs: Vec<Option<&str>> = vec![
+            Some(
+                r#"{"numRecords": 10, "nullCount": {"EventTime": 0, "UserId": 0},
+                    "minValues": {"EventTime": "2024-01-01T00:00:00Z", "UserId": 1},
+                    "maxValues": {"EventTime": "2024-01-31T00:00:00Z", "UserId": 100},
+                    "tightBounds": true}"#,
+            ),
+            Some(
+                r#"{"numRecords": 20, "nullCount": {"EventTime": 0, "UserId": 0},
+                    "minValues": {"EventTime": "+48690-07-02T22:50:38.211Z", "UserId": 5},
+                    "maxValues": {"EventTime": "+48690-07-02T22:50:38.211Z", "UserId": 200},
+                    "tightBounds": true}"#,
+            ),
+            Some(
+                r#"{"numRecords": 30, "nullCount": {"EventTime": 0, "UserId": 0},
+                    "minValues": {"EventTime": "2025-01-01T00:00:00Z", "UserId": 10},
+                    "maxValues": {"EventTime": "2025-12-31T00:00:00Z", "UserId": 300},
+                    "tightBounds": true}"#,
+            ),
+        ];
+        let batch = parse_json_impl(&StringArray::from(inputs), schema).unwrap();
+        assert_eq!(batch.num_rows(), 3);
+
+        let num_records = batch.column_by_name("numRecords").unwrap();
+        assert_eq!(num_records.null_count(), 0);
+
+        let min_values = batch.column_by_name("minValues").unwrap().as_struct();
+        let max_values = batch.column_by_name("maxValues").unwrap().as_struct();
+        let min_event = min_values.column_by_name("EventTime").unwrap();
+        let max_event = max_values.column_by_name("EventTime").unwrap();
+        let min_user = min_values.column_by_name("UserId").unwrap();
+        let max_user = max_values.column_by_name("UserId").unwrap();
+
+        // EventTime min/max for row 1 must be NULL; rows 0 and 2 must be populated.
+        assert!(!min_event.is_null(0) && min_event.is_null(1) && !min_event.is_null(2));
+        assert!(!max_event.is_null(0) && max_event.is_null(1) && !max_event.is_null(2));
+        // UserId min/max stay populated on every row even when the sibling EventTime fails.
+        assert_eq!(min_user.null_count(), 0);
+        assert_eq!(max_user.null_count(), 0);
+    }
+
+    #[test]
+    fn test_parse_json_safe_cast_all_null_input() {
+        // Every row decodes to `{}` (the unwrap_or default for `None`), so every output cell
+        // is NULL and no error surfaces from the safe-cast pass.
+        let schema = Arc::new(
+            StructType::try_new(vec![
+                StructField::nullable("ts", DataType::TIMESTAMP),
+                StructField::nullable("n", DataType::LONG),
+            ])
+            .unwrap(),
+        );
+        let inputs: Vec<Option<&str>> = vec![None, None, None];
+        let batch = parse_json_impl(&StringArray::from(inputs), schema).unwrap();
+        assert_eq!(batch.num_rows(), 3);
+        for col in batch.columns() {
+            assert_eq!(col.null_count(), 3);
+        }
     }
 
     #[test]

--- a/kernel/src/engine/arrow_utils/mod.rs
+++ b/kernel/src/engine/arrow_utils/mod.rs
@@ -1140,6 +1140,9 @@ fn compute_nested_null_masks(sa: StructArray, parent_nulls: Option<&NullBuffer>)
 /// Parse a column of JSON strings into a typed `RecordBatch` matching `schema`. N input
 /// rows produce N output rows.
 ///
+/// Arrow lacks the functionality to json-parse a string column into a struct column, so we
+/// implement it here.
+///
 /// Failure-prone primitive leaves (`Timestamp`, `TimestampNtz`, `Date`, `Decimal`) produce
 /// per-cell NULL when the typed decoder rejects a value (extended-year timestamps,
 /// decimals that overflow the declared precision, etc.). Other leaf type mismatches still

--- a/kernel/src/engine/arrow_utils/mod.rs
+++ b/kernel/src/engine/arrow_utils/mod.rs
@@ -15,7 +15,8 @@ use self::apply_schema::apply_schema_to_struct;
 use crate::arrow::array::cast::AsArray;
 use crate::arrow::array::{
     make_array, new_null_array, Array as ArrowArray, ArrayRef as ArrowArrayRef, GenericListArray,
-    MapArray, OffsetSizeTrait, PrimitiveArray, RecordBatch, StringArray, StructArray,
+    MapArray, OffsetSizeTrait, PrimitiveArray, RecordBatch, RecordBatchOptions, StringArray,
+    StructArray,
 };
 use crate::arrow::buffer::NullBuffer;
 use crate::arrow::compute::{cast_with_options, CastOptions};
@@ -1136,10 +1137,13 @@ fn compute_nested_null_masks(sa: StructArray, parent_nulls: Option<&NullBuffer>)
     unsafe { StructArray::new_unchecked(fields, columns, nulls) }
 }
 
-/// Arrow lacks the functionality to json-parse a string column into a struct column, so we
-/// implement it here. This method is for json-parsing each string in a column of strings (add.stats
-/// to be specific) to produce a nested column of strongly typed values. We require that N rows in
-/// means N rows out.
+/// Parse a column of JSON strings into a typed `RecordBatch` matching `schema`. N input
+/// rows produce N output rows.
+///
+/// Failure-prone primitive leaves (`Timestamp`, `TimestampNtz`, `Date`, `Decimal`) produce
+/// per-cell NULL when the typed decoder rejects a value (extended-year timestamps,
+/// decimals that overflow the declared precision, etc.). Other leaf type mismatches still
+/// surface as batch-level errors.
 #[internal_api]
 pub(crate) fn parse_json(
     json_strings: Box<dyn EngineData>,
@@ -1150,11 +1154,10 @@ pub(crate) fn parse_json(
     Ok(Box::new(ArrowEngineData::new(result)))
 }
 
-/// Raw implementation of the JSON parsing. Separate from the public function for testing.
-/// Also used by ParseJson expression evaluation.
+/// Raw implementation of [`parse_json`]; see there for the per-cell NULL contract.
 ///
-/// Accepts any string array type (`StringArray`, `LargeStringArray`, `StringViewArray`) to avoid
-/// narrowing casts that could overflow (e.g. `LargeStringArray` -> `StringArray`).
+/// Accepts any string array type (`StringArray`, `LargeStringArray`, `StringViewArray`) to
+/// avoid narrowing casts that could overflow.
 pub(crate) fn parse_json_impl(
     json_strings: &dyn ArrowArray,
     schema: SchemaRef,
@@ -1181,12 +1184,9 @@ fn parse_json_inner<'a>(
     num_rows: usize,
     schema: SchemaRef,
 ) -> DeltaResult<RecordBatch> {
-    // arrow-json's typed Timestamp/Date/Decimal decoders fail the entire batch on a single
-    // bad cell. `StringifyFailureProneLeaves` rewrites those leaves to `String` so the
-    // typed decode accepts any well-formed JSON string; `safe_cast_back` then casts each
-    // string cell back to the target type with `safe: true`, producing per-cell NULL on
-    // parse failure. `Cow::Borrowed` from the transform means no failure-prone leaves
-    // were present, so we can skip the safe-cast pass entirely.
+    // arrow-json's typed Timestamp/TimestampNtz/Date/Decimal decoders fail the entire batch
+    // on a single bad cell, so rewrite those leaves to `String` first and safe-cast back to
+    // the target type. `Cow::Borrowed` means nothing was rewritten; skip the cast pass.
     match StringifyFailureProneLeaves.transform_struct(schema.as_ref()) {
         Cow::Borrowed(_) => {
             let arrow_target = Arc::new(ArrowSchema::try_from_kernel(schema.as_ref())?);
@@ -1250,30 +1250,20 @@ fn decode_with_arrow_json<'a>(
     ))
 }
 
-/// Rewrites the four arrow-json-failure-prone primitive types (`Timestamp`, `TimestampNtz`,
-/// `Date`, `Decimal`) to `String` so the typed decoder will accept any well-formed JSON
-/// string instead of failing the whole batch on cells the typed parsers reject. The
-/// post-decode safe-cast pass converts each string cell back to the original type,
-/// producing per-cell NULL on parse failure.
+/// Rewrites failure-prone primitives (`Timestamp`, `TimestampNtz`, `Date`, `Decimal`) to
+/// `String` so the typed decoder accepts any well-formed JSON string for those cells.
 ///
-/// `Array`/`Map`/`Variant` are NOT visited because the Delta protocol does not record
-/// min/max stats for those types (see `MinMaxStatsTransform` in
-/// `scan::data_skipping::stats_schema`), so a failure-prone leaf can only ever appear
-/// inside a `Struct` for our callers. If a future caller passes a schema with
-/// failure-prone leaves nested inside `Array`/`Map`/`Variant`, drop these no-op overrides
-/// (the default recursion will then walk into them) and add the matching arms to
-/// [`safe_cast_array`].
+/// `Array`/`Map`/`Variant` are not visited: Delta doesn't track min/max stats for them,
+/// so a failure-prone leaf only ever shows up inside a `Struct` for our callers.
 struct StringifyFailureProneLeaves;
 
 impl<'a> SchemaTransform<'a> for StringifyFailureProneLeaves {
     transform_output_type!(|'a, T| Cow<'a, T>);
 
     fn transform_primitive(&mut self, ptype: &'a PrimitiveType) -> Cow<'a, PrimitiveType> {
+        use PrimitiveType::*;
         match ptype {
-            PrimitiveType::Timestamp
-            | PrimitiveType::TimestampNtz
-            | PrimitiveType::Date
-            | PrimitiveType::Decimal(_) => Cow::Owned(PrimitiveType::String),
+            Timestamp | TimestampNtz | Date | Decimal(_) => Cow::Owned(String),
             _ => Cow::Borrowed(ptype),
         }
     }
@@ -1291,31 +1281,31 @@ impl<'a> SchemaTransform<'a> for StringifyFailureProneLeaves {
     }
 }
 
-/// Walks the decoded `RecordBatch` against the original target schema in lockstep and
-/// safe-casts every leaf back to its target type. `safe: true` produces per-cell NULL on
-/// parse failure instead of erroring out the whole batch.
+/// Safe-casts each column of `decoded` back to its target type. `safe: true` produces
+/// per-cell NULL on parse failure rather than failing the whole batch.
 fn safe_cast_back(decoded: RecordBatch, target: &ArrowSchemaRef) -> DeltaResult<RecordBatch> {
     let opts = CastOptions {
         safe: true,
         ..Default::default()
     };
-    let columns = decoded
-        .columns()
-        .iter()
+    let (_, columns, row_count) = decoded.into_parts();
+    let columns = columns
+        .into_iter()
         .zip(target.fields().iter())
-        .map(|(arr, field)| safe_cast_array(arr.clone(), field.data_type(), &opts))
+        .map(|(arr, field)| safe_cast_array(arr, field.data_type(), &opts))
         .collect::<DeltaResult<Vec<_>>>()?;
-    Ok(RecordBatch::try_new(target.clone(), columns)?)
+    Ok(RecordBatch::try_new_with_options(
+        target.clone(),
+        columns,
+        &RecordBatchOptions::new().with_row_count(Some(row_count)),
+    )?)
 }
 
-/// Recursive worker for [`safe_cast_back`]. Recurses through `Struct` containers
-/// preserving the parent null buffer, and applies `cast_with_options` at the leaves.
+/// Recursive worker for [`safe_cast_back`]. Recurses through `Struct` containers preserving
+/// the parent null buffer; applies `cast_with_options` at the leaves.
 ///
-/// Delta protocol does not record min/max stats for `Array`/`Map`/`Variant` columns (see
-/// `MinMaxStatsTransform` in `scan::data_skipping::stats_schema`), so a failure-prone leaf
-/// can only ever reach this function nested inside a `Struct`. If that invariant ever
-/// changes, drop the no-op overrides on [`StringifyFailureProneLeaves`] and add the
-/// matching arms here.
+/// Delta doesn't track min/max stats for `Array`/`Map`/`Variant`, so a failure-prone leaf
+/// only ever reaches here inside a `Struct`.
 fn safe_cast_array(
     array: ArrowArrayRef,
     target: &ArrowDataType,

--- a/kernel/tests/integration/data_skipping.rs
+++ b/kernel/tests/integration/data_skipping.rs
@@ -321,7 +321,9 @@ async fn extended_year_timestamp_stats_dont_collapse_skipping(
     // at the same on-disk root the kernel-managed engine uses. The kernel only reads commit
     // files during scan_metadata, so a fake Add (no backing parquet) is fine for this test.
     let store: Arc<delta_kernel::object_store::DynObjectStore> = Arc::new(LocalFileSystem::new());
-    let table_url_string = format!("file://{}/", std::path::Path::new(&table_path).display());
+    let table_url = Url::from_directory_path(&table_path)
+        .map_err(|_| "table_path should be a valid file URL")?;
+    let table_url_string = table_url.to_string();
 
     // Co-locate the malformed `file_B` with a valid `file_D` (Sep 2024, out of predicate
     // range) in the same commit. If the parse error all-nulled the batch, file_D would

--- a/kernel/tests/integration/data_skipping.rs
+++ b/kernel/tests/integration/data_skipping.rs
@@ -19,12 +19,17 @@ use delta_kernel::arrow::datatypes::Schema as ArrowSchema;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::engine::default::executor::tokio::TokioMultiThreadExecutor;
 use delta_kernel::engine::default::DefaultEngine;
-use delta_kernel::expressions::{column_expr, Expression as Expr, Predicate as Pred, PredicateRef};
+use delta_kernel::expressions::{
+    column_expr, Expression as Expr, Predicate as Pred, PredicateRef, Scalar,
+};
+use delta_kernel::object_store::local::LocalFileSystem;
 use delta_kernel::scan::{AfterSequentialScanMetadata, ParallelScanMetadata};
 use delta_kernel::schema::{DataType, SchemaRef, StructField, StructType};
 use delta_kernel::{Snapshot, SnapshotRef};
 use rstest::rstest;
-use test_utils::{create_table_and_load_snapshot, test_table_setup_mt, write_batch_to_table};
+use test_utils::{
+    add_commit, create_table_and_load_snapshot, test_table_setup_mt, write_batch_to_table,
+};
 use url::Url;
 
 use crate::common::write_utils::set_table_properties;
@@ -241,5 +246,319 @@ async fn boundary_c1_prunes_all(
         Pred::gt(column_expr!("c2"), Expr::literal(50i64)),
     ));
     assert_eq!(surviving_files(&table_path, engine, pred, use_parallel)?, 0);
+    Ok(())
+}
+
+// === Per-cell NULL on malformed stats ===
+//
+// A Delta producer can emit an Add whose `stats` JSON contains an extended-year ISO 8601
+// timestamp like `+48690-07-02T22:50:38.211Z`. Arrow's `TimestampParser` rejects such
+// strings. With per-cell NULL only the bad cell becomes NULL, so other files in the same
+// batch keep their stats and the predicate prunes them correctly.
+
+fn timestamp_stats_schema() -> SchemaRef {
+    Arc::new(
+        StructType::try_new(vec![
+            StructField::nullable("EventTime", DataType::TIMESTAMP),
+            StructField::nullable("UserId", DataType::LONG),
+        ])
+        .unwrap(),
+    )
+}
+
+/// Builds a stringified Delta `stats` JSON given EventTime/UserId min/max bounds.
+fn stats_json(
+    num_records: i64,
+    event_time_min: &str,
+    event_time_max: &str,
+    user_id_min: i64,
+    user_id_max: i64,
+) -> String {
+    format!(
+        r#"{{"numRecords":{num_records},"minValues":{{"EventTime":"{event_time_min}","UserId":{user_id_min}}},"maxValues":{{"EventTime":"{event_time_max}","UserId":{user_id_max}}},"nullCount":{{"EventTime":0,"UserId":0}},"tightBounds":true}}"#
+    )
+}
+
+/// Builds a Delta commit body containing a `commitInfo` plus one Add per `(path, stats)`.
+fn commit_with_adds(version: u64, adds: &[(&str, String)]) -> String {
+    let mut lines = vec![format!(
+        r#"{{"commitInfo":{{"timestamp":1700000000000,"operation":"WRITE","version":{version}}}}}"#
+    )];
+    for (path, stats) in adds {
+        let stats_escaped = serde_json::Value::String(stats.clone()).to_string();
+        lines.push(format!(
+            r#"{{"add":{{"path":"{path}","size":1024,"modificationTime":1700000000000,"dataChange":true,"partitionValues":{{}},"stats":{stats_escaped}}}}}"#
+        ));
+    }
+    lines.join("\n")
+}
+
+/// Builds a Delta commit body containing a `commitInfo` plus a single `remove` action.
+fn commit_with_remove(version: u64, path: &str, deletion_timestamp: i64) -> String {
+    let commit_info = format!(
+        r#"{{"commitInfo":{{"timestamp":{deletion_timestamp},"operation":"DELETE","version":{version}}}}}"#
+    );
+    let remove = format!(
+        r#"{{"remove":{{"path":"{path}","deletionTimestamp":{deletion_timestamp},"dataChange":true,"extendedFileMetadata":false}}}}"#
+    );
+    format!("{commit_info}\n{remove}")
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn extended_year_timestamp_stats_dont_collapse_skipping(
+    #[values(false, true)] use_parallel: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_tmp_dir, table_path, engine) = test_table_setup_mt()?;
+    let _ = create_table_and_load_snapshot(
+        &table_path,
+        timestamp_stats_schema(),
+        engine.as_ref(),
+        &[],
+    )?;
+
+    // Inject Adds via raw JSON commits using a separate `LocalFileSystem` instance pointing
+    // at the same on-disk root the kernel-managed engine uses. The kernel only reads commit
+    // files during scan_metadata, so a fake Add (no backing parquet) is fine for this test.
+    let store: Arc<delta_kernel::object_store::DynObjectStore> = Arc::new(LocalFileSystem::new());
+    let table_url_string = format!("file://{}/", std::path::Path::new(&table_path).display());
+
+    // Co-locate the malformed `file_B` with a valid `file_D` (Sep 2024, out of predicate
+    // range) in the same commit. If the parse error all-nulled the batch, file_D would
+    // survive too; with per-cell NULL its stats are preserved and the predicate prunes it.
+    add_commit(
+        &table_url_string,
+        store.as_ref(),
+        1,
+        commit_with_adds(
+            1,
+            &[(
+                "file_A.parquet",
+                stats_json(
+                    10,
+                    "2024-01-15T00:00:00.000Z",
+                    "2024-01-31T00:00:00.000Z",
+                    1,
+                    100,
+                ),
+            )],
+        ),
+    )
+    .await?;
+    add_commit(
+        &table_url_string,
+        store.as_ref(),
+        2,
+        commit_with_adds(
+            2,
+            &[
+                (
+                    "file_B.parquet",
+                    stats_json(
+                        20,
+                        "+48690-07-02T22:50:38.211Z",
+                        "+48690-07-02T22:50:38.211Z",
+                        5,
+                        200,
+                    ),
+                ),
+                (
+                    "file_D.parquet",
+                    stats_json(
+                        40,
+                        "2024-09-01T00:00:00.000Z",
+                        "2024-09-30T00:00:00.000Z",
+                        7,
+                        70,
+                    ),
+                ),
+            ],
+        ),
+    )
+    .await?;
+    add_commit(
+        &table_url_string,
+        store.as_ref(),
+        3,
+        commit_with_adds(
+            3,
+            &[(
+                "file_C.parquet",
+                stats_json(
+                    30,
+                    "2025-01-01T00:00:00.000Z",
+                    "2025-12-31T00:00:00.000Z",
+                    10,
+                    300,
+                ),
+            )],
+        ),
+    )
+    .await?;
+
+    // Predicate: EventTime < 2024-06-01T00:00:00Z AND UserId > 0.
+    // 2024-06-01T00:00:00 UTC = 1_717_200_000 seconds since epoch = 1_717_200_000_000_000 us.
+    let june_first_2024_us: i64 = 1_717_200_000_000_000;
+    let predicate = Arc::new(Pred::and(
+        Pred::lt(
+            column_expr!("EventTime"),
+            Expr::literal(Scalar::Timestamp(june_first_2024_us)),
+        ),
+        Pred::gt(column_expr!("UserId"), Expr::literal(0i64)),
+    ));
+
+    // Expected survivors:
+    //   file_A: EventTime min Jan 15 < Jun 1, UserId max 100 > 0, kept.
+    //   file_B: EventTime min/max NULL from safe-cast, conservatively kept; UserId max 200 > 0.
+    //   file_C: EventTime min Jan 2025 > Jun 2024, pruned.
+    //   file_D: EventTime min Sep 2024 > Jun 2024, pruned. Would survive if file_B's bad
+    //           stats had collapsed the whole v2 batch to NULL stats.
+    assert_eq!(
+        surviving_files(&table_path, engine, predicate, use_parallel)?,
+        2
+    );
+    Ok(())
+}
+
+/// Round-trip the safe-cast through checkpoint materialization + post-checkpoint JSON +
+/// Remove honoring.
+///
+/// Sequence:
+///   v0: CREATE TABLE with `delta.checkpoint.writeStatsAsStruct = true`.
+///   v1: One commit containing file_A (valid Jan 2024, would-survive),
+///       file_B (malformed extended-year EventTime), and
+///       file_E (valid Jan-Dec 2025, would-be-pruned by the predicate).
+///       Co-locating them forces the checkpoint-write `parse_json` call to see all three
+///       in one batch, which is where the per-cell NULL property matters.
+///   checkpoint at v1: `build_stats_parsed_expr` evaluates
+///       `COALESCE(stats_parsed, ParseJson(stats))`; safe-cast preserves file_A and file_E
+///       stats and NULLs only file_B's `EventTime` min/max.
+///   v2: file_C added via JSON (post-checkpoint), exercises
+///       `scan/log_replay.rs` `parse_json` on a normal JSON commit.
+///   v3: Remove for file_C, exercises Remove reconciliation against a post-checkpoint Add.
+///
+/// Predicate: `EventTime < 2024-06-01 AND UserId > 0`.
+///
+/// Expected survivors (driven by both sources):
+///   file_A: kept via checkpoint `stats_parsed` (Jan 2024 satisfies predicate).
+///   file_B: kept via checkpoint `stats_parsed` (NULL EventTime, conservative).
+///   file_E: pruned via checkpoint `stats_parsed` (Jan 2025+). Would survive if file_B's
+///           bad stats had blanked the whole v1 batch during checkpoint write.
+///   file_C: would-survive predicate via JSON `parse_json`, but the v3 Remove suppresses
+///           it during log replay.
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn extended_year_timestamp_round_trip_via_checkpoint_and_remove(
+    #[values(false, true)] use_parallel: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_tmp_dir, table_path, engine) = test_table_setup_mt()?;
+    let table_url = Url::from_directory_path(&table_path)
+        .map_err(|_| "table_path should be a valid file URL")?;
+    let table_url_string = table_url.to_string();
+    let store: Arc<delta_kernel::object_store::DynObjectStore> = Arc::new(LocalFileSystem::new());
+
+    // v0: create table with writeStatsAsStruct enabled so the checkpoint materializes
+    // stats_parsed (the column where the safe-cast result lands).
+    let _v0 = create_table_and_load_snapshot(
+        &table_path,
+        timestamp_stats_schema(),
+        engine.as_ref(),
+        &[("delta.checkpoint.writeStatsAsStruct", "true")],
+    )?;
+
+    // v1: file_A + file_B + file_E in one commit. The shared batch is what makes the
+    // per-cell NULL property observable during checkpoint write.
+    add_commit(
+        &table_url_string,
+        store.as_ref(),
+        1,
+        commit_with_adds(
+            1,
+            &[
+                (
+                    "file_A.parquet",
+                    stats_json(
+                        10,
+                        "2024-01-15T00:00:00.000Z",
+                        "2024-01-31T00:00:00.000Z",
+                        1,
+                        100,
+                    ),
+                ),
+                (
+                    "file_B.parquet",
+                    stats_json(
+                        20,
+                        "+48690-07-02T22:50:38.211Z",
+                        "+48690-07-02T22:50:38.211Z",
+                        5,
+                        200,
+                    ),
+                ),
+                (
+                    "file_E.parquet",
+                    stats_json(
+                        50,
+                        "2025-01-01T00:00:00.000Z",
+                        "2025-12-31T00:00:00.000Z",
+                        10,
+                        300,
+                    ),
+                ),
+            ],
+        ),
+    )
+    .await?;
+
+    // Checkpoint at v1: build_stats_parsed_expr COALESCE evaluates parse_json on the v1
+    // batch and materializes stats_parsed with file_B's EventTime safe-cast to NULL.
+    let snapshot_v1 = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
+    snapshot_v1.checkpoint(engine.as_ref(), None)?;
+
+    // v2: file_C via JSON commit, post-checkpoint. Reads still see this as JSON stats and
+    // run parse_json at scan time.
+    add_commit(
+        &table_url_string,
+        store.as_ref(),
+        2,
+        commit_with_adds(
+            2,
+            &[(
+                "file_C.parquet",
+                stats_json(
+                    15,
+                    "2024-02-01T00:00:00.000Z",
+                    "2024-02-29T00:00:00.000Z",
+                    50,
+                    80,
+                ),
+            )],
+        ),
+    )
+    .await?;
+
+    // v3: Remove file_C. Log replay must reconcile the v2 Add with this Remove so that
+    // file_C does not appear in the scan output, regardless of predicate.
+    add_commit(
+        &table_url_string,
+        store.as_ref(),
+        3,
+        commit_with_remove(3, "file_C.parquet", 1_700_000_001_000),
+    )
+    .await?;
+
+    let june_first_2024_us: i64 = 1_717_200_000_000_000;
+    let predicate = Arc::new(Pred::and(
+        Pred::lt(
+            column_expr!("EventTime"),
+            Expr::literal(Scalar::Timestamp(june_first_2024_us)),
+        ),
+        Pred::gt(column_expr!("UserId"), Expr::literal(0i64)),
+    ));
+
+    assert_eq!(
+        surviving_files(&table_path, engine, predicate, use_parallel)?,
+        2
+    );
     Ok(())
 }

--- a/kernel/tests/integration/features/cdf.rs
+++ b/kernel/tests/integration/features/cdf.rs
@@ -1,13 +1,19 @@
 use std::error;
+use std::sync::Arc;
 
 use delta_kernel::arrow::array::RecordBatch;
 use delta_kernel::arrow::datatypes::Schema as ArrowSchema;
 use delta_kernel::engine::arrow_conversion::TryFromKernel as _;
 use delta_kernel::engine::arrow_data::EngineDataArrowExt as _;
+use delta_kernel::expressions::{column_expr, Expression as Expr, Predicate as Pred};
+use delta_kernel::schema::{DataType, StructField, StructType};
 use delta_kernel::table_changes::TableChanges;
 use delta_kernel::{DeltaResult, Error, PredicateRef, Version};
 use itertools::Itertools;
-use test_utils::load_test_data;
+use test_utils::{
+    add_commit, create_default_engine, create_table, engine_store_setup, load_test_data,
+};
+use url::Url;
 
 fn read_cdf_for_table(
     test_name: impl AsRef<str>,
@@ -577,6 +583,71 @@ fn cdf_with_column_mapping_name_mode() -> Result<(), Box<dyn error::Error>> {
     sort_lines!(expected);
     assert_batches_sorted_eq!(expected, &batches);
 
+    Ok(())
+}
+
+/// CDF over a commit whose Add carries an extended-year ISO 8601 timestamp in `stats`.
+/// The bad `EventTime` cell becomes a per-cell NULL while sibling `UserId` stats survive;
+/// the `UserId > 1000` predicate then prunes the file inside the `DataSkippingFilter` in
+/// `table_changes` log-replay, so `execute()` never tries to read the phantom parquet
+/// file and returns zero rows.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cdf_per_cell_null_on_malformed_stats() -> Result<(), Box<dyn error::Error>> {
+    let schema = Arc::new(
+        StructType::try_new(vec![
+            StructField::nullable("EventTime", DataType::TIMESTAMP),
+            StructField::nullable("UserId", DataType::LONG),
+        ])
+        .unwrap(),
+    );
+
+    let tmp_dir = tempfile::tempdir()?;
+    let tmp_url = Url::from_directory_path(tmp_dir.path()).unwrap();
+    let (store, _engine, table_url) = engine_store_setup("cdf_per_cell_null", Some(&tmp_url));
+
+    create_table(
+        store.clone(),
+        table_url.clone(),
+        schema.clone(),
+        &[],
+        true,
+        vec![],
+        vec!["changeDataFeed"],
+    )
+    .await?;
+
+    let stats = r#"{"numRecords":20,"minValues":{"EventTime":"+48690-07-02T22:50:38.211Z","UserId":5},"maxValues":{"EventTime":"+48690-07-02T22:50:38.211Z","UserId":200},"nullCount":{"EventTime":0,"UserId":0},"tightBounds":true}"#;
+    let stats_escaped = serde_json::Value::String(stats.to_string()).to_string();
+    let commit_info =
+        r#"{"commitInfo":{"timestamp":1700000000000,"operation":"WRITE","version":1}}"#;
+    let add = format!(
+        r#"{{"add":{{"path":"phantom_file.parquet","size":1024,"modificationTime":1700000000000,"dataChange":true,"partitionValues":{{}},"stats":{stats_escaped}}}}}"#
+    );
+    let commit_body = format!("{commit_info}\n{add}");
+    add_commit(table_url.as_str(), store.as_ref(), 1, commit_body).await?;
+
+    let engine = create_default_engine(&table_url)?;
+    let table_changes = TableChanges::try_new(table_url.clone(), engine.as_ref(), 1, Some(1))?;
+
+    let predicate: PredicateRef =
+        Arc::new(Pred::gt(column_expr!("UserId"), Expr::literal(1000i64)));
+    let scan = table_changes
+        .into_scan_builder()
+        .with_predicate(predicate)
+        .build()?;
+
+    // execute() must succeed and yield zero rows. The phantom file would crash an actual
+    // parquet read; the test passing means the per-cell NULL kept UserId stats valid and
+    // the predicate pruned the file before reading.
+    let batches: Vec<RecordBatch> = scan
+        .execute(engine)?
+        .map(|data| -> DeltaResult<_> { data?.try_into_record_batch() })
+        .try_collect()?;
+    let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(
+        total_rows, 0,
+        "predicate should have pruned the phantom file"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

A Delta producer can emit an `add` whose `stats` JSON contains a value that arrow-json's typed decoder rejects — e.g. an extended-year ISO 8601 timestamp like `+48690-07-02T22:50:38.211Z`, which arrow's `TimestampParser` refuses for years with more than four digits (see [apache/arrow#7208](https://github.com/apache/arrow/issues/7208)).

1/ Currently, a single bad cell fails the typed decoder for the entire batch. The expression-level error code swallow in `evaluate_expression.rs` then substitutes a whole-batch NULL stats struct, collapsing data skipping for every file in that batch including the well-formed neighbors. This results in more files getting skipped.

2/ With this change, `parse_json_inner` does a two-phase decode. Failure-prone leaves (`Timestamp`, `Date32`, `Date64`, `Decimal128`, `Decimal256`) are decoded as `Utf8`, then safe-cast back with `safe: true` so cell-level parse failures become per-cell NULL. Sibling files and sibling columns keep their stats. The coarser expression-level swallow stays as a backstop for genuinely malformed JSON. 

## How was this change tested?
1/ Module unit tests verify the leaf-level contract i.e each failure-prone leaf type produces per-cell NULL on a bad cell while sibling rows/columns survive. 

2/  Data skipping integration tests cover both read paths with JSON-commit `parse_json` path during scan, and the `COALESCE(stats_parsed, parse_json(stats))` path during checkpoint write. The second variant also includes a Remove against a post-checkpoint Add. The read from both a checkpoint and delta log are validated.

3/ The CDF integration test validates that the safe cast fix works for the table changes log replay = data skipping path as well.