### PR TITLE
feat: add proto wire format for declarative-plans IR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,6 +186,10 @@ jobs:
         run: cargo clippy --locked --workspace --no-default-features --exclude delta_kernel --exclude delta_kernel_ffi --exclude delta_kernel_derive --exclude delta_kernel_ffi_macros -- -D warnings
       - name: lint without default features - packages which don't depend on kernel with features enabled
         run: cargo clippy --locked --no-default-features --package delta_kernel --package delta_kernel_ffi --package delta_kernel_derive --package delta_kernel_ffi_macros -- -D warnings
+      - name: check kernel declarative-plans feature-only build
+        run: cargo check --locked -p delta_kernel --no-default-features --features declarative-plans
+      - name: lint kernel declarative-plans feature-only build
+        run: cargo clippy --locked -p delta_kernel --no-default-features --features declarative-plans --tests -- -D warnings
       - name: check kernel builds with default-engine-native-tls
         run: cargo build --locked -p feature_tests --features default-engine-native-tls
       - name: test native-tls backend has no crypto provider conflict

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,9 @@ Some noteworthy ones (see `[features]` in `kernel/Cargo.toml` for the full list)
   cargo feature off, writes to tables listing this feature are blocked.
 - `internal-api` -- unstable APIs like `parallel_scan_metadata`. Items are marked with the
   `#[internal_api]` proc macro attribute.
-- `test-utils`, `integration-test` -- development only
+- `declarative-plans` -- experimental declarative-plan IR (`kernel/src/plans/`) and the prost
+  proto wire format mirroring it (`kernel/proto/`). Auto-enables `internal-api` and `arrow`.
+- `test-utils`, `integration-test` -- development only (`test-utils` enables `prettyprint`)
 
 ## Architecture at a Glance
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,6 +1288,9 @@ dependencies = [
  "parquet 58.1.0",
  "paste",
  "percent-encoding",
+ "prost 0.13.5",
+ "prost-build",
+ "protoc-bin-vendored",
  "rand 0.9.2",
  "reqwest 0.13.2",
  "roaring",
@@ -1579,6 +1582,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flatbuffers"
@@ -1902,8 +1911,8 @@ dependencies = [
  "md-5",
  "num-traits",
  "once_cell",
- "prost",
- "prost-types",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
  "rand 0.9.2",
  "regex",
  "roxmltree",
@@ -2620,6 +2629,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2949,6 +2964,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "phf"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3081,12 +3106,55 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.14.3",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "regex",
+ "syn",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3104,12 +3172,85 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost 0.13.5",
+]
+
+[[package]]
+name = "prost-types"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
- "prost",
+ "prost 0.14.3",
 ]
+
+[[package]]
+name = "protoc-bin-vendored"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c381df33c98266b5f08186583660090a4ffa0889e76c7e9a5e175f645a67fa"
+dependencies = [
+ "protoc-bin-vendored-linux-aarch_64",
+ "protoc-bin-vendored-linux-ppcle_64",
+ "protoc-bin-vendored-linux-s390_64",
+ "protoc-bin-vendored-linux-x86_32",
+ "protoc-bin-vendored-linux-x86_64",
+ "protoc-bin-vendored-macos-aarch_64",
+ "protoc-bin-vendored-macos-x86_64",
+ "protoc-bin-vendored-win32",
+]
+
+[[package]]
+name = "protoc-bin-vendored-linux-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c350df4d49b5b9e3ca79f7e646fde2377b199e13cfa87320308397e1f37e1a4c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-ppcle_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55a63e6c7244f19b5c6393f025017eb5d793fd5467823a099740a7a4222440c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-s390_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dba5565db4288e935d5330a07c264a4ee8e4a5b4a4e6f4e83fad824cc32f3b0"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8854774b24ee28b7868cd71dccaae8e02a2365e67a4a87a6cd11ee6cdbdf9cf5"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38b07546580df720fa464ce124c4b03630a6fb83e05c336fea2a241df7e5d78"
+
+[[package]]
+name = "protoc-bin-vendored-macos-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89278a9926ce312e51f1d999fee8825d324d603213344a9a706daa009f1d8092"
+
+[[package]]
+name = "protoc-bin-vendored-macos-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81745feda7ccfb9471d7a4de888f0652e806d5795b61480605d4943176299756"
+
+[[package]]
+name = "protoc-bin-vendored-win32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
 
 [[package]]
 name = "psm"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -52,6 +52,7 @@ serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 strum = { version = "0.27", features = ["derive"] }
 thiserror = "2"
+prost = { version = "0.13", optional = true }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = "0.3"
 url = "2"
@@ -114,9 +115,8 @@ arrow-expression = ["need-arrow"]
 # Schema diffing functionality (experimental)
 schema-diff = []
 
-# Declarative plan IR (experimental). The IR uses kernel-internal types hidden 
-# under `#[internal_api]` 
-declarative-plans = ["internal-api"]
+# Declarative plan IR (experimental).
+declarative-plans = ["internal-api", "dep:prost", "dep:prost-build", "dep:protoc-bin-vendored"]
 
 # Experimental, temporary, test-only feature flag guarding the in-progress column-defaults
 # work. TODO(#2630): remove once full column-defaults support ships.
@@ -134,6 +134,9 @@ default-engine-base = [
 
 [build-dependencies]
 rustc_version = "0.4.1"
+# Proto codegen, only pulled in / run under the `declarative-plans` feature.
+prost-build = { version = "0.13", optional = true }
+protoc-bin-vendored = { version = "3.2", optional = true }
 
 [dev-dependencies]
 delta_kernel = { path = ".", features = ["test-utils"] }

--- a/kernel/build.rs
+++ b/kernel/build.rs
@@ -6,4 +6,37 @@ fn main() {
     if let Channel::Nightly = version_meta().unwrap().channel {
         println!("cargo:rustc-cfg=NIGHTLY_CHANNEL");
     }
+
+    // Generate prost bindings for the declarative-plans proto schema only when the feature is
+    // enabled. Off-by-default consumers don't pay the protoc / codegen cost and don't pull in
+    // prost-build / protoc-bin-vendored.
+    #[cfg(feature = "declarative-plans")]
+    compile_proto_definitions();
+}
+
+#[cfg(feature = "declarative-plans")]
+fn compile_proto_definitions() {
+    let proto_dir = "proto";
+    let proto_files = ["schema.proto", "expressions.proto", "plan.proto"];
+
+    for file in &proto_files {
+        println!("cargo:rerun-if-changed={proto_dir}/{file}");
+    }
+
+    let files: Vec<String> = proto_files
+        .iter()
+        .map(|f| format!("{proto_dir}/{f}"))
+        .collect();
+
+    // Point prost-build at a vendored `protoc` so the build doesn't require a system install.
+    let protoc = protoc_bin_vendored::protoc_bin_path().expect("vendored protoc binary");
+    std::env::set_var("PROTOC", protoc);
+
+    // Don't propagate `.proto` comments into the generated code as doc comments: they contain
+    // angle-bracket generics (`Vec<...>`, `Option<...>`) that rustdoc would parse as unclosed
+    // HTML tags. The `.proto` files stay the canonical reference for the wire format.
+    prost_build::Config::new()
+        .disable_comments(["."])
+        .compile_protos(&files, &[proto_dir])
+        .expect("failed to compile .proto files");
 }

--- a/kernel/proto/expressions.proto
+++ b/kernel/proto/expressions.proto
@@ -1,0 +1,236 @@
+// Proto mirror of `kernel/src/expressions/mod.rs` + `scalars.rs` (the Rust IR is the source
+// of truth for these shapes).
+//
+// Opaque{Expression,Predicate} and Unknown are escape hatches: kernel-rs can't serialise the
+// opaque trait objects, and Unknown is the "do not silently interpret" marker. They appear
+// here so the grammar is total, but engines MUST error on them, not produce NULL.
+
+syntax = "proto3";
+
+package delta.kernel.expressions;
+
+import "schema.proto";
+
+// ============================================================================
+// Operator enums
+// ============================================================================
+
+enum UnaryPredicateOp {
+  UNARY_PREDICATE_OP_UNSPECIFIED = 0;
+  UNARY_PREDICATE_OP_IS_NULL = 1;
+}
+
+enum BinaryPredicateOp {
+  BINARY_PREDICATE_OP_UNSPECIFIED = 0;
+  BINARY_PREDICATE_OP_LESS_THAN = 1;
+  BINARY_PREDICATE_OP_GREATER_THAN = 2;
+  BINARY_PREDICATE_OP_EQUAL = 3;
+  BINARY_PREDICATE_OP_DISTINCT = 4;
+  BINARY_PREDICATE_OP_IN = 5;
+}
+
+enum UnaryExpressionOp {
+  UNARY_EXPRESSION_OP_UNSPECIFIED = 0;
+  UNARY_EXPRESSION_OP_TO_JSON = 1;
+}
+
+enum BinaryExpressionOp {
+  BINARY_EXPRESSION_OP_UNSPECIFIED = 0;
+  BINARY_EXPRESSION_OP_PLUS = 1;
+  BINARY_EXPRESSION_OP_MINUS = 2;
+  BINARY_EXPRESSION_OP_MULTIPLY = 3;
+  BINARY_EXPRESSION_OP_DIVIDE = 4;
+}
+
+enum VariadicExpressionOp {
+  VARIADIC_EXPRESSION_OP_UNSPECIFIED = 0;
+  VARIADIC_EXPRESSION_OP_COALESCE = 1;
+  VARIADIC_EXPRESSION_OP_ARRAY = 2;
+}
+
+enum JunctionPredicateOp {
+  JUNCTION_PREDICATE_OP_UNSPECIFIED = 0;
+  JUNCTION_PREDICATE_OP_AND = 1;
+  JUNCTION_PREDICATE_OP_OR = 2;
+}
+
+// ============================================================================
+// Scalar payloads
+// ============================================================================
+
+// `bits` is the unscaled integer, big-endian two's-complement; pair with `decimal_type` to
+// materialise a language-native decimal.
+message DecimalData {
+  bytes bits = 1;
+  delta.kernel.schema.DecimalType decimal_type = 2;
+}
+
+message ArrayData {
+  delta.kernel.schema.ArrayType array_type = 1;
+  repeated Scalar elements = 2;
+}
+
+// Modeled as repeated key/value pairs because proto map keys must be scalar, but Delta map
+// keys can be any `Scalar` (including structs).
+message MapEntry {
+  Scalar key = 1;
+  Scalar value = 2;
+}
+message MapData {
+  delta.kernel.schema.MapType map_type = 1;
+  repeated MapEntry pairs = 2;
+}
+
+// `fields` and `values` are pairwise indexed: `values[i]` is the value for `fields[i]`.
+message StructData {
+  repeated delta.kernel.schema.StructField fields = 1;
+  repeated Scalar values = 2;
+}
+
+// `Null` carries a `DataType` so the evaluator can produce a NULL of the right type.
+message Scalar {
+  oneof value {
+    int32 integer = 1;
+    int64 long = 2;
+    int32 short = 3;            // i16 narrowed at decode (proto has no i16)
+    int32 byte = 4;             // i8 narrowed at decode (proto has no i8)
+    float float = 5;
+    double double = 6;
+    string string = 7;
+    bool boolean = 8;
+    int64 timestamp = 9;        // micros since epoch, UTC
+    int64 timestamp_ntz = 10;   // micros since epoch, no tz
+    int32 date = 11;            // days since epoch
+    bytes binary = 12;
+    DecimalData decimal = 13;
+    delta.kernel.schema.DataType null = 14;
+    StructData struct = 15;
+    ArrayData array = 16;
+    MapData map = 17;
+  }
+}
+
+message ColumnName {
+  repeated string path = 1;
+}
+
+// ============================================================================
+// Composite expression bodies
+// ============================================================================
+
+message UnaryExpression {
+  UnaryExpressionOp op = 1;
+  Expression expr = 2;
+}
+
+message BinaryExpression {
+  BinaryExpressionOp op = 1;
+  Expression left = 2;
+  Expression right = 3;
+}
+
+message VariadicExpression {
+  VariadicExpressionOp op = 1;
+  repeated Expression exprs = 2;
+}
+
+message IfExpression {
+  Predicate condition = 1;
+  Expression then_expr = 2;
+  Expression else_expr = 3;
+}
+
+message ParseJsonExpression {
+  Expression json_expr = 1;
+  delta.kernel.schema.StructType output_schema = 2;
+}
+
+message MapToStructExpression {
+  Expression map_expr = 1;
+}
+
+// `nullability_predicate` is optional: when set and it evaluates to false/null, the whole
+// struct is null.
+message StructExpression {
+  repeated Expression exprs = 1;
+  Expression nullability_predicate = 2;
+}
+
+message FieldTransform {
+  repeated Expression exprs = 1;
+  bool is_replace = 2;
+  bool optional = 3;
+}
+
+message Transform {
+  // `input_path` is optional: absent means a top-level transform (no input path).
+  ColumnName input_path = 1;
+  map<string, FieldTransform> field_transforms = 2;
+  repeated Expression prepended_fields = 3;
+}
+
+// The opaque op carries only its `name()` because the Rust trait object can't be serialised;
+// engines resolve `name` against a local op registry or hard-error (never NULL).
+message OpaqueExpression {
+  string name = 1;
+  repeated Expression exprs = 2;
+}
+
+message OpaquePredicate {
+  string name = 1;
+  repeated Expression exprs = 2;
+}
+
+// ============================================================================
+// Predicate
+// ============================================================================
+
+message UnaryPredicate {
+  UnaryPredicateOp op = 1;
+  Expression expr = 2;
+}
+
+message BinaryPredicate {
+  BinaryPredicateOp op = 1;
+  Expression left = 2;
+  Expression right = 3;
+}
+
+message JunctionPredicate {
+  JunctionPredicateOp op = 1;
+  repeated Predicate preds = 2;
+}
+
+message Predicate {
+  oneof kind {
+    Expression boolean_expression = 1;
+    Predicate not = 2;
+    UnaryPredicate unary = 3;
+    BinaryPredicate binary = 4;
+    JunctionPredicate junction = 5;
+    OpaquePredicate opaque = 6;
+    string unknown = 7;
+  }
+}
+
+// ============================================================================
+// Expression
+// ============================================================================
+
+message Expression {
+  oneof kind {
+    Scalar literal = 1;
+    ColumnName column = 2;
+    Predicate predicate = 3;
+    StructExpression struct_expr = 4;
+    Transform transform = 5;
+    UnaryExpression unary = 6;
+    BinaryExpression binary = 7;
+    VariadicExpression variadic = 8;
+    IfExpression if_expr = 9;
+    OpaqueExpression opaque = 10;
+    ParseJsonExpression parse_json = 11;
+    MapToStructExpression map_to_struct = 12;
+    string unknown = 13;
+  }
+}

--- a/kernel/proto/plan.proto
+++ b/kernel/proto/plan.proto
@@ -1,0 +1,134 @@
+// Proto mirror of `kernel/src/plans/ir/{plan,nodes}.rs` (the Rust IR is the source of truth).
+//
+// A plan is a DAG of plan nodes: `Plan` is a flat list of `PlanNode`s, and each node wires
+// into the DAG by referencing other nodes' `output` RefIds in its `inputs`. RefIds are opaque
+// keys. Field numbers are never reused once published, so the wire stays compatible.
+
+syntax = "proto3";
+
+package delta.kernel.plan;
+
+import "expressions.proto";
+import "schema.proto";
+
+message RefId {
+  uint32 id = 1;
+}
+
+message FileMeta {
+  string location = 1;
+  uint64 size = 2;
+  optional int64 last_modified = 3;  // milliseconds since epoch
+}
+
+// ============================================================================
+// Source payloads (0 inputs)
+// ============================================================================
+
+message ScanFile {
+  FileMeta meta = 1;
+  repeated delta.kernel.expressions.Scalar file_constants = 2;
+}
+
+message ScanParquetNode {
+  repeated ScanFile files = 1;
+  repeated delta.kernel.expressions.ColumnName file_constant_columns = 2;
+  delta.kernel.schema.StructType schema = 3;
+}
+
+message ScanJsonNode {
+  repeated ScanFile files = 1;
+  repeated delta.kernel.expressions.ColumnName file_constant_columns = 2;
+  delta.kernel.schema.StructType schema = 3;
+}
+
+message ValuesRow {
+  repeated delta.kernel.expressions.Scalar values = 1;
+}
+message ValuesNode {
+  delta.kernel.schema.StructType schema = 1;
+  repeated ValuesRow rows = 2;
+}
+
+// ============================================================================
+// Transform payloads (1+ inputs)
+// ============================================================================
+
+message ProjectNode {
+  repeated delta.kernel.expressions.Expression exprs = 1;
+  delta.kernel.schema.StructType schema = 2;
+}
+
+message FilterNode {
+  delta.kernel.expressions.Predicate predicate = 1;
+}
+
+message UnionAllNode {}
+
+message LoadColumnFileMeta {
+  delta.kernel.expressions.ColumnName path_column = 1;
+  delta.kernel.expressions.ColumnName file_size_column = 2;
+  delta.kernel.expressions.ColumnName num_records_column = 3;
+}
+
+enum FileType {
+  FILE_TYPE_UNSPECIFIED = 0;
+  FILE_TYPE_PARQUET = 1;
+  FILE_TYPE_JSON = 2;
+}
+
+message LoadNode {
+  delta.kernel.schema.StructType schema = 1;
+  FileType file_type = 2;
+  optional string base_url = 3;
+  repeated delta.kernel.expressions.ColumnName file_constant_columns = 4;
+  LoadColumnFileMeta file_meta = 5;
+  delta.kernel.expressions.ColumnName dv_column = 6;
+}
+
+message MaxByVersionNode {
+  repeated delta.kernel.expressions.Expression group_by = 1;
+  delta.kernel.expressions.ColumnName version_column = 2;
+  delta.kernel.schema.StructType schema = 3;
+}
+
+message SemiJoinNode {
+  bool inverted = 1;
+  repeated delta.kernel.expressions.ColumnName probe_keys = 2;
+  repeated delta.kernel.expressions.ColumnName build_keys = 3;
+}
+
+// ============================================================================
+// NodeKind
+// ============================================================================
+
+message NodeKind {
+  oneof kind {
+    // Sources (0 inputs)
+    ScanParquetNode scan_parquet = 1;
+    ScanJsonNode scan_json = 2;
+    ValuesNode values = 3;
+    // Transforms (1+ inputs)
+    ProjectNode project = 4;
+    FilterNode filter = 5;
+    UnionAllNode union_all = 6;
+    LoadNode load = 7;
+    MaxByVersionNode max_by_version = 8;
+    SemiJoinNode semi_join = 9;
+  }
+}
+
+// ============================================================================
+// PlanNode / Plan
+// ============================================================================
+
+message PlanNode {
+  NodeKind kind = 1;
+  repeated RefId inputs = 2;
+  RefId output = 3;
+}
+
+// The plan's terminal node is its last entry; the engine streams that node's rows.
+message Plan {
+  repeated PlanNode nodes = 1;
+}

--- a/kernel/proto/schema.proto
+++ b/kernel/proto/schema.proto
@@ -1,0 +1,82 @@
+// Proto mirror of `kernel/src/schema/mod.rs` 
+
+syntax = "proto3";
+
+package delta.kernel.schema;
+
+// ============================================================================
+// Primitive types
+// ============================================================================
+
+enum SimplePrimitiveType {
+  SIMPLE_PRIMITIVE_TYPE_UNSPECIFIED = 0;
+  SIMPLE_PRIMITIVE_TYPE_STRING = 1;
+  SIMPLE_PRIMITIVE_TYPE_LONG = 2;
+  SIMPLE_PRIMITIVE_TYPE_INTEGER = 3;
+  SIMPLE_PRIMITIVE_TYPE_SHORT = 4;
+  SIMPLE_PRIMITIVE_TYPE_BYTE = 5;
+  SIMPLE_PRIMITIVE_TYPE_FLOAT = 6;
+  SIMPLE_PRIMITIVE_TYPE_DOUBLE = 7;
+  SIMPLE_PRIMITIVE_TYPE_BOOLEAN = 8;
+  SIMPLE_PRIMITIVE_TYPE_BINARY = 9;
+  SIMPLE_PRIMITIVE_TYPE_DATE = 10;
+  SIMPLE_PRIMITIVE_TYPE_TIMESTAMP = 11;
+  SIMPLE_PRIMITIVE_TYPE_TIMESTAMP_NTZ = 12;
+}
+
+// Rust uses `u8` (precision in [1,38], scale in [0,precision]); widened to uint32 because
+// proto has no smaller integer type, so consumers must validate the range.
+message DecimalType {
+  uint32 precision = 1;
+  uint32 scale = 2;
+}
+
+message PrimitiveType {
+  oneof kind {
+    SimplePrimitiveType simple = 1;
+    DecimalType decimal = 2;
+  }
+}
+
+message ArrayType {
+  DataType element_type = 1;
+  bool contains_null = 2;
+}
+
+message MapType {
+  DataType key_type = 1;
+  DataType value_type = 2;
+  bool value_contains_null = 3;
+}
+
+message StructType {
+  repeated StructField fields = 1;
+}
+
+message VariantType {}
+
+message MetadataValue {
+  oneof value {
+    int64 number = 1;
+    string string = 2;
+    bool boolean = 3;
+    string other_json = 4;
+  }
+}
+
+message StructField {
+  string name = 1;
+  DataType data_type = 2;
+  bool nullable = 3;
+  map<string, MetadataValue> metadata = 4;
+}
+
+message DataType {
+  oneof kind {
+    PrimitiveType primitive = 1;
+    ArrayType array = 2;
+    StructType struct = 3;
+    MapType map = 4;
+    VariantType variant = 5;
+  }
+}

--- a/kernel/src/engine/mod.rs
+++ b/kernel/src/engine/mod.rs
@@ -43,7 +43,9 @@ pub(crate) mod arrow_utils;
 #[cfg(all(feature = "internal-api", feature = "arrow-expression"))]
 pub use self::arrow_utils::{parse_json, to_json_bytes};
 
-#[cfg(feature = "declarative-plans")]
+// The plan executor support modules read Arrow data (`arrow_utils`, `arrow_data`), so they
+// require the Arrow engine base in addition to the declarative-plans IR.
+#[cfg(all(feature = "declarative-plans", feature = "default-engine-base"))]
 pub mod plans;
 
 #[cfg(test)]

--- a/kernel/src/plans/mod.rs
+++ b/kernel/src/plans/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! This module is opt-in behind the `declarative-plans` feature flag.
 pub mod ir;
+pub mod proto;
 mod query_builder;
 
 use bytes::Bytes;

--- a/kernel/src/plans/proto/mod.rs
+++ b/kernel/src/plans/proto/mod.rs
@@ -1,0 +1,24 @@
+//! Protobuf wire format mirroring the kernel's plan / schema / expression IR.
+//!
+//! Each submodule wraps the prost-generated code for one `.proto` file in
+//! `kernel/proto/`. Consumers can serialise a kernel-built plan and ship it
+//! across a process / language boundary (Rust kernel -> JVM engine, etc.).
+//!
+//! - [`schema`] -- mirror of `kernel/src/schema/mod.rs` (`DataType`, `PrimitiveType`, `StructType`,
+//!   ...).
+//! - [`expressions`] -- mirror of `kernel/src/expressions/mod.rs` and `scalars.rs` (`Expression`,
+//!   `Predicate`, `Scalar`, `ColumnName`, ...).
+//! - [`plan`] -- mirror of `kernel/src/plans/ir/{plan,nodes}.rs` (`Plan`, `PlanNode`, `NodeKind`,
+//!   `RefId`, per-variant payload messages).
+
+pub mod schema {
+    include!(concat!(env!("OUT_DIR"), "/delta.kernel.schema.rs"));
+}
+
+pub mod expressions {
+    include!(concat!(env!("OUT_DIR"), "/delta.kernel.expressions.rs"));
+}
+
+pub mod plan {
+    include!(concat!(env!("OUT_DIR"), "/delta.kernel.plan.rs"));
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds a prost-generated protobuf layer mirroring the kernel's plan, schema, and expression IR, so engines can ship plans across a process or language boundary. The `.proto` files (`schema`, `expressions`, `plan`) mirror the Rust enums one-to-one; `build.rs` runs prost-build only under `declarative-plans`, and `plans/proto/mod.rs` re-exports the generated modules. The kernel produces these messages but does not interpret them.

A follow-up PR adds `From` / `TryFrom` conversions between the kernel IR and the proto messages.

Tracking: #2679 weighs this proto wire format against the existing FFI schema/expression visitors as the mechanism for the IR boundary.

## How was this change tested?

`cargo build`, `cargo clippy --tests`, and `cargo doc` are clean with `--features declarative-plans`.

