### PR TITLE
refactor: rename ScopedDeltaResultIterator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,6 +276,8 @@ Keep this list updated when new protocol features are added to kernel.
 - Prefer `StructField::nullable` / `StructField::not_null` over
   `StructField::new(name, type, bool)` when nullability is known at compile time.
   Reserve `StructField::new` for cases where nullability is a runtime value.
+- Prefer the `DeltaResultIterator<'a, T>` / `DeltaResultIteratorStatic<T>` aliases over
+  hand-rolled `Box<dyn Iterator<Item = DeltaResult<T>> + Send (+ 'a)>`.
 - NEVER panic in production code -- use errors instead. Panicking
   (including `unwrap()`, `expect()`, `panic!()`, `unreachable!()`, etc) is acceptable in test code only.
 

--- a/delta-kernel-unity-catalog/src/committer.rs
+++ b/delta-kernel-unity-catalog/src/committer.rs
@@ -4,7 +4,7 @@ use delta_kernel::committer::{
     CommitMetadata, CommitResponse, CommitType, Committer, PublishMetadata,
 };
 use delta_kernel::{
-    DeltaResult, Engine, Error as DeltaError, FilteredEngineData, ScopedDeltaResultIterator,
+    DeltaResult, DeltaResultIterator, Engine, Error as DeltaError, FilteredEngineData,
 };
 use tracing::{debug, info};
 use unity_catalog_delta_client_api::{Commit, CommitClient, CommitRequest};
@@ -125,7 +125,7 @@ impl<C: CommitClient> UCCommitter<C> {
     fn commit_version_0(
         &self,
         engine: &dyn Engine,
-        actions: ScopedDeltaResultIterator<'_, FilteredEngineData>,
+        actions: DeltaResultIterator<'_, FilteredEngineData>,
         commit_metadata: &CommitMetadata,
     ) -> DeltaResult<CommitResponse> {
         debug_assert!(
@@ -158,7 +158,7 @@ impl<C: CommitClient> UCCommitter<C> {
     fn commit_version_non_zero(
         &self,
         engine: &dyn Engine,
-        actions: ScopedDeltaResultIterator<'_, FilteredEngineData>,
+        actions: DeltaResultIterator<'_, FilteredEngineData>,
         commit_metadata: CommitMetadata,
     ) -> DeltaResult<CommitResponse>
     where
@@ -239,7 +239,7 @@ impl<C: CommitClient + 'static> Committer for UCCommitter<C> {
     fn commit(
         &self,
         engine: &dyn Engine,
-        actions: ScopedDeltaResultIterator<'_, FilteredEngineData>,
+        actions: DeltaResultIterator<'_, FilteredEngineData>,
         commit_metadata: CommitMetadata,
     ) -> DeltaResult<CommitResponse> {
         if commit_metadata.version() == 0 {

--- a/delta-kernel-unity-catalog/src/utils/create_table.rs
+++ b/delta-kernel-unity-catalog/src/utils/create_table.rs
@@ -126,9 +126,7 @@ mod tests {
     use delta_kernel::snapshot::Snapshot;
     use delta_kernel::transaction::create_table::create_table;
     use delta_kernel::transaction::data_layout::DataLayout;
-    use delta_kernel::{
-        DeltaResult, Engine, FileMeta, FilteredEngineData, ScopedDeltaResultIterator,
-    };
+    use delta_kernel::{DeltaResult, DeltaResultIterator, Engine, FileMeta, FilteredEngineData};
 
     use super::*;
 
@@ -138,7 +136,7 @@ mod tests {
         fn commit(
             &self,
             engine: &dyn Engine,
-            actions: ScopedDeltaResultIterator<'_, FilteredEngineData>,
+            actions: DeltaResultIterator<'_, FilteredEngineData>,
             commit_metadata: CommitMetadata,
         ) -> DeltaResult<CommitResponse> {
             let path = commit_metadata.published_commit_path()?;

--- a/docs/user-guide/src/catalog_managed/committer.md
+++ b/docs/user-guide/src/catalog_managed/committer.md
@@ -18,7 +18,7 @@ pub trait Committer: Send {
     fn commit(
         &self,
         engine: &dyn Engine,
-        actions: ScopedDeltaResultIterator<'_, FilteredEngineData>,
+        actions: DeltaResultIterator<'_, FilteredEngineData>,
         commit_metadata: CommitMetadata,
     ) -> DeltaResult<CommitResponse>;
 
@@ -118,7 +118,7 @@ Write the actions to a staged commit file in `_staged_commits/`:
 fn commit(
     &self,
     engine: &dyn Engine,
-    actions: ScopedDeltaResultIterator<'_, FilteredEngineData>,
+    actions: DeltaResultIterator<'_, FilteredEngineData>,
     commit_metadata: CommitMetadata,
 ) -> DeltaResult<CommitResponse> {
     // Write actions to _staged_commits/<version>.<uuid>.json. `actions` is
@@ -232,7 +232,7 @@ impl Committer for MyCatalogCommitter {
     fn commit(
         &self,
         engine: &dyn Engine,
-        actions: ScopedDeltaResultIterator<'_, FilteredEngineData>,
+        actions: DeltaResultIterator<'_, FilteredEngineData>,
         commit_metadata: CommitMetadata,
     ) -> DeltaResult<CommitResponse> {
         // 1. Stage: write actions to _staged_commits/

--- a/docs/user-guide/src/connector/implementing_engine.md
+++ b/docs/user-guide/src/connector/implementing_engine.md
@@ -91,7 +91,7 @@ pub trait JsonHandler {
     fn write_json_file(
         &self,
         path: &Url,
-        data: ScopedDeltaResultIterator<'_, FilteredEngineData>,
+        data: DeltaResultIterator<'_, FilteredEngineData>,
         overwrite: bool,
     ) -> DeltaResult<()>;
 }
@@ -131,7 +131,7 @@ pub trait ParquetHandler {
     fn write_parquet_file(
         &self,
         location: Url,
-        data: DeltaResultIterator<Box<dyn EngineData>>,
+        data: DeltaResultIteratorStatic<Box<dyn EngineData>>,
     ) -> DeltaResult<()>;
 
     fn read_parquet_footer(&self, file: &FileMeta) -> DeltaResult<ParquetFooter>;

--- a/ffi/src/scan.rs
+++ b/ffi/src/scan.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex};
 use delta_kernel::scan::state::{DvInfo, ScanFile};
 use delta_kernel::scan::{Scan, ScanBuilder, ScanMetadata};
 use delta_kernel::snapshot::SnapshotRef;
-use delta_kernel::{DeltaResult, DeltaResultIterator, Error, Expression, ExpressionRef};
+use delta_kernel::{DeltaResult, DeltaResultIteratorStatic, Error, Expression, ExpressionRef};
 use delta_kernel_ffi_macros::handle_descriptor;
 use tracing::debug;
 use url::Url;
@@ -32,7 +32,7 @@ pub struct SharedScan;
 pub struct SharedScanMetadata;
 
 /// Boxed scan metadata iterator stored behind [`ScanMetadataIterator`]'s mutex.
-type ScanMetadataIter = DeltaResultIterator<ScanMetadata>;
+type ScanMetadataIter = DeltaResultIteratorStatic<ScanMetadata>;
 
 /// An opaque, exclusive handle owning a [`ScanBuilder`].
 ///

--- a/ffi/src/table_changes.rs
+++ b/ffi/src/table_changes.rs
@@ -7,7 +7,7 @@ use delta_kernel::arrow::ffi::to_ffi;
 use delta_kernel::engine::arrow_data::EngineDataArrowExt;
 use delta_kernel::table_changes::scan::TableChangesScan;
 use delta_kernel::table_changes::TableChanges;
-use delta_kernel::{DeltaResult, DeltaResultIterator, EngineData, Error, Version};
+use delta_kernel::{DeltaResult, DeltaResultIteratorStatic, EngineData, Error, Version};
 use delta_kernel_ffi_macros::handle_descriptor;
 use tracing::debug;
 use url::Url;
@@ -233,7 +233,7 @@ pub unsafe extern "C" fn table_changes_scan_physical_schema(
     table_changes_scan.physical_schema().clone().into()
 }
 
-type TableChangesData = Mutex<DeltaResultIterator<Box<dyn EngineData>>>;
+type TableChangesData = Mutex<DeltaResultIteratorStatic<Box<dyn EngineData>>>;
 
 pub struct ScanTableChangesIterator {
     data: TableChangesData,

--- a/kernel/src/action_reconciliation/log_replay.rs
+++ b/kernel/src/action_reconciliation/log_replay.rs
@@ -41,7 +41,7 @@ use crate::log_replay::{
 use crate::scan::data_skipping::DataSkippingFilter;
 use crate::schema::{column_name, ColumnName, ColumnNamesAndTypes, DataType};
 use crate::utils::require;
-use crate::{DeltaResult, DeltaResultIterator, Error};
+use crate::{DeltaResult, DeltaResultIteratorStatic, Error};
 
 /// The [`ActionReconciliationProcessor`] is an implementation of the [`LogReplayProcessor`]
 /// trait that filters log segment actions.
@@ -129,13 +129,13 @@ impl ActionReconciliationIteratorState {
 /// This iterator yields a stream of [`FilteredEngineData`] items while, tracking action
 /// counts. Used by both checkpoint and log compaction workflows.
 pub struct ActionReconciliationIterator {
-    inner: DeltaResultIterator<ActionReconciliationBatch>,
+    inner: DeltaResultIteratorStatic<ActionReconciliationBatch>,
     state: Arc<ActionReconciliationIteratorState>,
 }
 
 impl ActionReconciliationIterator {
     /// Create a new iterator with counters initialized to 0
-    pub(crate) fn new(inner: DeltaResultIterator<ActionReconciliationBatch>) -> Self {
+    pub(crate) fn new(inner: DeltaResultIteratorStatic<ActionReconciliationBatch>) -> Self {
         Self {
             inner,
             state: Arc::new(ActionReconciliationIteratorState::default()),

--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -125,7 +125,7 @@ use crate::snapshot::SnapshotRef;
 use crate::table_features::TableFeature;
 use crate::table_properties::TableProperties;
 use crate::{
-    DeltaResult, DeltaResultIterator, Engine, EngineData, Error, EvaluationHandlerExtension,
+    DeltaResult, DeltaResultIteratorStatic, Engine, EngineData, Error, EvaluationHandlerExtension,
     FileMeta, Version,
 };
 
@@ -663,7 +663,7 @@ impl CheckpointWriter {
 
         // Write main checkpoint file: non-file actions + sidecar references
         let checkpoint_path = self.checkpoint_path()?;
-        let main_data: DeltaResultIterator<Box<dyn EngineData>> =
+        let main_data: DeltaResultIteratorStatic<Box<dyn EngineData>> =
             Box::new(non_file_batches.into_iter().chain(sidecar_batch).map(Ok));
         engine
             .parquet_handler()

--- a/kernel/src/committer/filesystem.rs
+++ b/kernel/src/committer/filesystem.rs
@@ -5,7 +5,7 @@ use tracing::{info, instrument};
 use super::commit_types::{CommitMetadata, CommitResponse};
 use super::publish_types::PublishMetadata;
 use super::Committer;
-use crate::{DeltaResult, Engine, Error, FileMeta, FilteredEngineData, ScopedDeltaResultIterator};
+use crate::{DeltaResult, DeltaResultIterator, Engine, Error, FileMeta, FilteredEngineData};
 
 /// The `FileSystemCommitter` is an internal implementation of the `Committer` trait which
 /// commits to a file system directly via `Engine::json_handler().write_json_file` for
@@ -31,7 +31,7 @@ impl Committer for FileSystemCommitter {
     fn commit(
         &self,
         engine: &dyn Engine,
-        actions: ScopedDeltaResultIterator<'_, FilteredEngineData>,
+        actions: DeltaResultIterator<'_, FilteredEngineData>,
         commit_metadata: CommitMetadata,
     ) -> DeltaResult<CommitResponse> {
         let version = commit_metadata.version();

--- a/kernel/src/committer/mod.rs
+++ b/kernel/src/committer/mod.rs
@@ -34,7 +34,7 @@ pub use commit_types::{CommitMetadata, CommitResponse, CommitType};
 pub use filesystem::FileSystemCommitter;
 pub use publish_types::{CatalogCommit, PublishMetadata};
 
-use crate::{DeltaResult, Engine, FilteredEngineData, ScopedDeltaResultIterator};
+use crate::{DeltaResult, DeltaResultIterator, Engine, FilteredEngineData};
 
 /// A Committer is the system by which transactions are committed to a table. Transactions are
 /// effectively a collection of actions performed on the table at a specific version. The kernel
@@ -63,7 +63,7 @@ pub trait Committer: Send {
     fn commit(
         &self,
         engine: &dyn Engine,
-        actions: ScopedDeltaResultIterator<'_, FilteredEngineData>,
+        actions: DeltaResultIterator<'_, FilteredEngineData>,
         commit_metadata: CommitMetadata,
     ) -> DeltaResult<CommitResponse>;
 

--- a/kernel/src/engine/default/json.rs
+++ b/kernel/src/engine/default/json.rs
@@ -23,8 +23,8 @@ use crate::object_store::path::Path;
 use crate::object_store::{self, DynObjectStore, GetResultPayload, ObjectStoreExt as _, PutMode};
 use crate::schema::SchemaRef;
 use crate::{
-    DeltaResult, EngineData, Error, FileDataReadResultIterator, FileMeta, JsonHandler,
-    PredicateRef, ScopedDeltaResultIterator,
+    DeltaResult, DeltaResultIterator, EngineData, Error, FileDataReadResultIterator, FileMeta,
+    JsonHandler, PredicateRef,
 };
 
 #[derive(Debug)]
@@ -186,7 +186,7 @@ impl<E: TaskExecutor> JsonHandler for DefaultJsonHandler<E> {
     fn write_json_file(
         &self,
         path: &Url,
-        data: ScopedDeltaResultIterator<'_, FilteredEngineData>,
+        data: DeltaResultIterator<'_, FilteredEngineData>,
         overwrite: bool,
     ) -> DeltaResult<()> {
         self.task_executor.block_on(write_json_file_impl(

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -34,8 +34,8 @@ use crate::parquet::arrow::async_writer::{AsyncArrowWriter, ParquetObjectWriter}
 use crate::schema::{SchemaRef, StructType};
 use crate::transaction::WriteContext;
 use crate::{
-    DeltaResult, DeltaResultIterator, EngineData, Error, FileDataReadResultIterator, FileMeta,
-    ParquetFooter, ParquetHandler, PredicateRef,
+    DeltaResult, DeltaResultIteratorStatic, EngineData, Error, FileDataReadResultIterator,
+    FileMeta, ParquetFooter, ParquetHandler, PredicateRef,
 };
 
 #[derive(Debug)]
@@ -340,7 +340,7 @@ impl<E: TaskExecutor> ParquetHandler for DefaultParquetHandler<E> {
     fn write_parquet_file(
         &self,
         location: url::Url,
-        mut data: DeltaResultIterator<Box<dyn EngineData>>,
+        mut data: DeltaResultIteratorStatic<Box<dyn EngineData>>,
     ) -> DeltaResult<()> {
         let store = self.store.clone();
 
@@ -922,7 +922,7 @@ mod tests {
         ));
 
         // Create iterator with single batch
-        let data_iter: DeltaResultIterator<Box<dyn EngineData>> =
+        let data_iter: DeltaResultIteratorStatic<Box<dyn EngineData>> =
             Box::new(std::iter::once(Ok(engine_data)));
 
         // Test writing through the trait method
@@ -1071,7 +1071,7 @@ mod tests {
         ));
 
         // Create iterator with single batch
-        let data_iter: DeltaResultIterator<Box<dyn EngineData>> =
+        let data_iter: DeltaResultIteratorStatic<Box<dyn EngineData>> =
             Box::new(std::iter::once(Ok(engine_data)));
 
         // Write the data
@@ -1458,7 +1458,7 @@ mod tests {
             )])
             .unwrap(),
         ));
-        let data_iter: DeltaResultIterator<Box<dyn EngineData>> =
+        let data_iter: DeltaResultIteratorStatic<Box<dyn EngineData>> =
             Box::new(std::iter::once(Ok(engine_data)));
 
         // WHEN we write a parquet file to that path

--- a/kernel/src/engine/plans/json.rs
+++ b/kernel/src/engine/plans/json.rs
@@ -7,8 +7,8 @@ use url::Url;
 use crate::plans::{Plan, PlanExecutor, QueryPlanBuilder};
 use crate::schema::SchemaRef;
 use crate::{
-    DeltaResult, EngineData, Error, FileDataReadResultIterator, FileMeta, FilteredEngineData,
-    JsonHandler, PredicateRef,
+    DeltaResult, DeltaResultIterator, EngineData, Error, FileDataReadResultIterator, FileMeta,
+    FilteredEngineData, JsonHandler, PredicateRef,
 };
 
 /// A [`JsonHandler`] that delegates to a [`PlanExecutor`].
@@ -51,7 +51,7 @@ impl JsonHandler for PlanBasedJsonHandler {
     fn write_json_file(
         &self,
         _path: &Url,
-        _data: Box<dyn Iterator<Item = DeltaResult<FilteredEngineData>> + Send + '_>,
+        _data: DeltaResultIterator<'_, FilteredEngineData>,
         _overwrite: bool,
     ) -> DeltaResult<()> {
         Err(Error::unsupported(

--- a/kernel/src/engine/plans/parquet.rs
+++ b/kernel/src/engine/plans/parquet.rs
@@ -7,8 +7,8 @@ use url::Url;
 use crate::plans::{Plan, PlanExecutor, QueryPlanBuilder};
 use crate::schema::SchemaRef;
 use crate::{
-    DeltaResult, EngineData, Error, FileDataReadResultIterator, FileMeta, ParquetFooter,
-    ParquetHandler, PredicateRef,
+    DeltaResult, DeltaResultIteratorStatic, EngineData, Error, FileDataReadResultIterator,
+    FileMeta, ParquetFooter, ParquetHandler, PredicateRef,
 };
 
 /// A [`ParquetHandler`] that delegates to a [`PlanExecutor`].
@@ -41,7 +41,7 @@ impl ParquetHandler for PlanBasedParquetHandler {
     fn write_parquet_file(
         &self,
         _location: Url,
-        _data: Box<dyn Iterator<Item = DeltaResult<Box<dyn EngineData>>> + Send>,
+        _data: DeltaResultIteratorStatic<Box<dyn EngineData>>,
     ) -> DeltaResult<()> {
         Err(Error::unsupported(
             "PlanBasedParquetHandler does not support write_parquet_file yet",

--- a/kernel/src/engine/sync/json.rs
+++ b/kernel/src/engine/sync/json.rs
@@ -15,8 +15,8 @@ use crate::engine_data::FilteredEngineData;
 use crate::object_store::DynObjectStore;
 use crate::schema::SchemaRef;
 use crate::{
-    DeltaResult, EngineData, Error, FileDataReadResultIterator, FileMeta, JsonHandler,
-    PredicateRef, ScopedDeltaResultIterator,
+    DeltaResult, DeltaResultIterator, EngineData, Error, FileDataReadResultIterator, FileMeta,
+    JsonHandler, PredicateRef,
 };
 
 pub(crate) struct SyncJsonHandler {
@@ -71,7 +71,7 @@ impl JsonHandler for SyncJsonHandler {
     fn write_json_file(
         &self,
         path: &Url,
-        data: ScopedDeltaResultIterator<'_, FilteredEngineData>,
+        data: DeltaResultIterator<'_, FilteredEngineData>,
         overwrite: bool,
     ) -> DeltaResult<()> {
         let buf = to_json_bytes(data)?;

--- a/kernel/src/engine/sync/parquet.rs
+++ b/kernel/src/engine/sync/parquet.rs
@@ -22,8 +22,8 @@ use crate::parquet::arrow::arrow_reader::{ArrowReaderMetadata, ParquetRecordBatc
 use crate::parquet::arrow::arrow_writer::ArrowWriter;
 use crate::schema::{SchemaRef, StructType};
 use crate::{
-    DeltaResult, DeltaResultIterator, EngineData, Error, FileDataReadResultIterator, FileMeta,
-    ParquetFooter, ParquetHandler, PredicateRef,
+    DeltaResult, DeltaResultIteratorStatic, EngineData, Error, FileDataReadResultIterator,
+    FileMeta, ParquetFooter, ParquetHandler, PredicateRef,
 };
 
 pub(crate) struct SyncParquetHandler {
@@ -99,7 +99,7 @@ impl ParquetHandler for SyncParquetHandler {
     fn write_parquet_file(
         &self,
         location: Url,
-        mut data: DeltaResultIterator<Box<dyn EngineData>>,
+        mut data: DeltaResultIteratorStatic<Box<dyn EngineData>>,
     ) -> DeltaResult<()> {
         let first_batch = data.next().ok_or_else(|| {
             crate::Error::generic("Cannot write parquet file with empty data iterator")
@@ -148,7 +148,7 @@ mod tests {
     use crate::engine::arrow_conversion::TryIntoKernel as _;
     use crate::EngineData;
 
-    fn test_data_iter() -> DeltaResultIterator<Box<dyn EngineData>> {
+    fn test_data_iter() -> DeltaResultIteratorStatic<Box<dyn EngineData>> {
         let engine_data: Box<dyn EngineData> = Box::new(ArrowEngineData::new(
             RecordBatch::try_from_iter(vec![
                 (
@@ -254,7 +254,8 @@ mod tests {
         ));
 
         let batches = vec![Ok(batch1), Ok(batch2), Ok(batch3)];
-        let data_iter: DeltaResultIterator<Box<dyn EngineData>> = Box::new(batches.into_iter());
+        let data_iter: DeltaResultIteratorStatic<Box<dyn EngineData>> =
+            Box::new(batches.into_iter());
 
         handler.write_parquet_file(url.clone(), data_iter).unwrap();
         assert!(file_path.exists());

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -20,11 +20,11 @@ pub type DeltaResult<T, E = Error> = std::result::Result<T, E>;
 ///
 /// Convenience alias for the common pattern of returning a streaming, fallible iterator from
 /// kernel APIs.
-pub type DeltaResultIterator<T> = Box<dyn Iterator<Item = DeltaResult<T>> + Send>;
+pub type DeltaResultIterator<'a, T> = Box<dyn Iterator<Item = DeltaResult<T>> + Send + 'a>;
 
-/// Lifetime-bounded counterpart to [`DeltaResultIterator`] for cases where the iterator may
+/// `'static` counterpart to [`DeltaResultIterator`] for cases where the iterator does not
 /// reference borrowed data.
-pub type ScopedDeltaResultIterator<'a, T> = Box<dyn Iterator<Item = DeltaResult<T>> + Send + 'a>;
+pub type DeltaResultIteratorStatic<T> = DeltaResultIterator<'static, T>;
 
 /// All the types of errors that the kernel can run into
 #[non_exhaustive]

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -180,7 +180,7 @@ use delta_kernel_derive::internal_api;
 pub use engine_data::{
     EngineData, FilteredEngineData, FilteredRowVisitor, GetData, RowIndexIterator, RowVisitor,
 };
-pub use error::{DeltaResult, DeltaResultIterator, Error, ScopedDeltaResultIterator};
+pub use error::{DeltaResult, DeltaResultIterator, DeltaResultIteratorStatic, Error};
 use expressions::{literal_expression_transform, Scalar};
 pub use expressions::{Expression, ExpressionRef, Predicate, PredicateRef};
 pub use log_compaction::{should_compact, LogCompactionWriter};
@@ -212,7 +212,7 @@ pub type FileSlice = (Url, Option<Range<FileIndex>>);
 pub type FileDataReadResult = (FileMeta, Box<dyn EngineData>);
 
 /// An iterator of data read from specified files
-pub type FileDataReadResultIterator = DeltaResultIterator<Box<dyn EngineData>>;
+pub type FileDataReadResultIterator = DeltaResultIteratorStatic<Box<dyn EngineData>>;
 
 /// The metadata that describes an object.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -699,7 +699,7 @@ pub trait JsonHandler: AsAny {
     fn write_json_file(
         &self,
         path: &Url,
-        data: ScopedDeltaResultIterator<'_, FilteredEngineData>,
+        data: DeltaResultIterator<'_, FilteredEngineData>,
         overwrite: bool,
     ) -> DeltaResult<()>;
 }
@@ -905,7 +905,7 @@ pub trait ParquetHandler: AsAny {
     fn write_parquet_file(
         &self,
         location: url::Url,
-        data: DeltaResultIterator<Box<dyn EngineData>>,
+        data: DeltaResultIteratorStatic<Box<dyn EngineData>>,
     ) -> DeltaResult<()>;
 
     /// Read the footer metadata from a Parquet file without reading the data.

--- a/kernel/src/log_reader/checkpoint_manifest.rs
+++ b/kernel/src/log_reader/checkpoint_manifest.rs
@@ -11,13 +11,13 @@ use crate::log_replay::ActionsBatch;
 use crate::path::ParsedLogPath;
 use crate::schema::{SchemaRef, StructField, StructType, ToSchema};
 use crate::utils::require;
-use crate::{DeltaResult, DeltaResultIterator, Engine, Error, FileMeta, RowVisitor};
+use crate::{DeltaResult, DeltaResultIteratorStatic, Engine, Error, FileMeta, RowVisitor};
 
 /// Phase that processes single-part checkpoint. This also treats the checkpoint as a manifest file
 /// and extracts the sidecar actions during iteration.
 #[allow(unused)]
 pub(crate) struct CheckpointManifestReader {
-    actions: DeltaResultIterator<ActionsBatch>,
+    actions: DeltaResultIteratorStatic<ActionsBatch>,
     sidecar_visitor: SidecarVisitor,
     log_root: Url,
     is_complete: bool,

--- a/kernel/src/log_reader/commit.rs
+++ b/kernel/src/log_reader/commit.rs
@@ -5,11 +5,11 @@ use itertools::Itertools;
 use crate::log_replay::ActionsBatch;
 use crate::log_segment::LogSegment;
 use crate::schema::SchemaRef;
-use crate::{DeltaResult, DeltaResultIterator, Engine};
+use crate::{DeltaResult, DeltaResultIteratorStatic, Engine};
 
 /// Phase that processes JSON commit files into [`ActionsBatch`]s
 pub(crate) struct CommitReader {
-    actions: DeltaResultIterator<ActionsBatch>,
+    actions: DeltaResultIteratorStatic<ActionsBatch>,
 }
 
 impl CommitReader {

--- a/kernel/src/plans/mod.rs
+++ b/kernel/src/plans/mod.rs
@@ -8,7 +8,7 @@ use bytes::Bytes;
 pub use ir::{IoOperation, Plan, QueryPlan, QueryPlanNode};
 pub use query_builder::QueryPlanBuilder;
 
-use crate::{AsAny, DeltaResult, DeltaResultIterator, EngineData, Error, FileMeta};
+use crate::{AsAny, DeltaResult, DeltaResultIteratorStatic, EngineData, Error, FileMeta};
 
 /// Provides the ability to execute declarative plans to the Delta Kernel.
 ///
@@ -24,31 +24,31 @@ pub trait PlanExecutor: AsAny {
 /// Each variant describes a different shape of output that a plan can possibly produce.
 pub enum PlanResult {
     /// A stream of columnar data batches (as [`EngineData`]) produced by the plan.
-    Data(DeltaResultIterator<Box<dyn EngineData>>),
+    Data(DeltaResultIteratorStatic<Box<dyn EngineData>>),
     /// A stream of file metadata entries.
-    FileMeta(DeltaResultIterator<FileMeta>),
+    FileMeta(DeltaResultIteratorStatic<FileMeta>),
     /// A stream of raw byte buffers.
-    Bytes(DeltaResultIterator<Bytes>),
+    Bytes(DeltaResultIteratorStatic<Bytes>),
     /// Represents the successful completion of a plan, but with no return value.
     Unit,
 }
 
 impl PlanResult {
-    pub fn into_data(self) -> DeltaResult<DeltaResultIterator<Box<dyn EngineData>>> {
+    pub fn into_data(self) -> DeltaResult<DeltaResultIteratorStatic<Box<dyn EngineData>>> {
         match self {
             Self::Data(iter) => Ok(iter),
             other => Err(other.type_mismatch("Data")),
         }
     }
 
-    pub fn into_file_meta(self) -> DeltaResult<DeltaResultIterator<FileMeta>> {
+    pub fn into_file_meta(self) -> DeltaResult<DeltaResultIteratorStatic<FileMeta>> {
         match self {
             Self::FileMeta(iter) => Ok(iter),
             other => Err(other.type_mismatch("FileMeta")),
         }
     }
 
-    pub fn into_bytes(self) -> DeltaResult<DeltaResultIterator<Bytes>> {
+    pub fn into_bytes(self) -> DeltaResult<DeltaResultIteratorStatic<Bytes>> {
         match self {
             Self::Bytes(iter) => Ok(iter),
             other => Err(other.type_mismatch("Bytes")),

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -20,10 +20,10 @@ use crate::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use crate::parquet::arrow::arrow_writer::ArrowWriter;
 use crate::scan::data_skipping::{all_referenced_columns, as_checkpoint_skipping_predicate};
 use crate::scan::state::ScanFile;
-use crate::schema::{ColumnMetadataKey, DataType, StructField, StructType};
+use crate::schema::{self, ColumnMetadataKey, DataType, StructField, StructType};
 use crate::{
-    Engine, EngineData, EvaluationHandler, FileDataReadResultIterator, FileMeta, JsonHandler,
-    ParquetFooter, ParquetHandler, PredicateRef, Snapshot, StorageHandler,
+    DeltaResultIteratorStatic, Engine, EngineData, EvaluationHandler, FileDataReadResultIterator,
+    FileMeta, JsonHandler, ParquetFooter, ParquetHandler, PredicateRef, Snapshot, StorageHandler,
 };
 
 /// Helper macro to extract a typed column from a RecordBatch or StructArray.
@@ -1428,21 +1428,21 @@ impl ParquetHandler for EmptyParquetHandler {
     fn read_parquet_files(
         &self,
         _files: &[FileMeta],
-        _schema: crate::schema::SchemaRef,
+        _schema: schema::SchemaRef,
         _predicate: Option<PredicateRef>,
-    ) -> crate::DeltaResult<FileDataReadResultIterator> {
+    ) -> DeltaResult<FileDataReadResultIterator> {
         Ok(Box::new(std::iter::empty()))
     }
 
-    fn read_parquet_footer(&self, _file: &FileMeta) -> crate::DeltaResult<ParquetFooter> {
+    fn read_parquet_footer(&self, _file: &FileMeta) -> DeltaResult<ParquetFooter> {
         unimplemented!()
     }
 
     fn write_parquet_file(
         &self,
         _location: url::Url,
-        _data: Box<dyn Iterator<Item = crate::DeltaResult<Box<dyn EngineData>>> + Send>,
-    ) -> crate::DeltaResult<()> {
+        _data: DeltaResultIteratorStatic<Box<dyn EngineData>>,
+    ) -> DeltaResult<()> {
         unimplemented!()
     }
 }

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -1627,7 +1627,7 @@ mod tests {
         load_test_table, string_array_to_engine_data, test_schema_flat, test_schema_nested,
         test_schema_with_array, test_schema_with_map,
     };
-    use crate::{EvaluationHandler, ScopedDeltaResultIterator, Snapshot};
+    use crate::{DeltaResultIterator, EvaluationHandler, Snapshot};
 
     impl Transaction {
         /// Set clustering columns for testing purposes without needing a table
@@ -1645,7 +1645,7 @@ mod tests {
         fn commit(
             &self,
             _engine: &dyn Engine,
-            _actions: ScopedDeltaResultIterator<'_, FilteredEngineData>,
+            _actions: DeltaResultIterator<'_, FilteredEngineData>,
             _commit_metadata: CommitMetadata,
         ) -> DeltaResult<CommitResponse> {
             Err(Error::IOError(std::io::Error::other("simulated IO error")))
@@ -1669,7 +1669,7 @@ mod tests {
         fn commit(
             &self,
             _engine: &dyn Engine,
-            _actions: ScopedDeltaResultIterator<'_, FilteredEngineData>,
+            _actions: DeltaResultIterator<'_, FilteredEngineData>,
             _commit_metadata: CommitMetadata,
         ) -> DeltaResult<CommitResponse> {
             // This won't be reached in tests — the validation error fires before commit.
@@ -2815,7 +2815,7 @@ mod tests {
         fn commit(
             &self,
             _engine: &dyn Engine,
-            _actions: ScopedDeltaResultIterator<'_, FilteredEngineData>,
+            _actions: DeltaResultIterator<'_, FilteredEngineData>,
             commit_metadata: CommitMetadata,
         ) -> DeltaResult<CommitResponse> {
             *self.captured.lock().unwrap() = Some(commit_metadata.in_commit_timestamp());

--- a/kernel/tests/integration/write/nested_field_ids.rs
+++ b/kernel/tests/integration/write/nested_field_ids.rs
@@ -121,7 +121,7 @@ fn write_via_default_engine(record_batch: RecordBatch) -> std::path::PathBuf {
 
     let store = Arc::new(LocalFileSystem::new());
     let handler = DefaultParquetHandler::new(store, Arc::new(TokioBackgroundExecutor::new()));
-    let data: Box<dyn Iterator<Item = delta_kernel::DeltaResult<Box<dyn EngineData>>> + Send> =
+    let data: delta_kernel::DeltaResultIteratorStatic<Box<dyn EngineData>> =
         Box::new(std::iter::once(Ok(
             Box::new(ArrowEngineData::new(record_batch)) as Box<dyn EngineData>,
         )));


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR is primarily just renaming type aliases (as a followup to https://github.com/delta-io/delta-kernel-rs/pull/2622). Specifically, it renames `ScopedDeltaResultIterator<'a, T>` -> `DeltaResultIterator<'a, T>` and `DeltaResultIterator<T>` -> `DeltaResultIteratorStatic<T>`.

Even though the static variant is slightly more common than the the lifetime-bounded variant, the naming is more clear. See `kernel/src/error.rs` for the refactored type aliases, the rest of the files are just updating usages.

## How was this change tested?
`cargo nextest --all-features`
