### PR TITLE
refactor!: Rename Expression::Transform as Expression::StructPatch

### DIFF
--- a/ffi/examples/visit-expression/engine_to_kernel_expression.h
+++ b/ffi/examples/visit-expression/engine_to_kernel_expression.h
@@ -249,8 +249,8 @@ uintptr_t convert_engine_to_kernel_expression_item(
           state, m2s->child_expr.list[0]);
       return visit_expression_map_to_struct(state, child);
     }
-    case Transform:
-    case FieldTransform:
+    case StructPatch:
+    case FieldPatch:
     case OpaqueExpression:
     case OpaquePredicate:
       fprintf(stderr,

--- a/ffi/examples/visit-expression/expression.h
+++ b/ffi/examples/visit-expression/expression.h
@@ -59,8 +59,8 @@ enum ExpressionType {
   Literal,
   Unary,
   Column,
-  Transform,
-  FieldTransform,
+  StructPatch,
+  FieldPatch,
   OpaqueExpression,
   OpaquePredicate,
   Unknown,
@@ -92,11 +92,11 @@ struct Unary {
   enum UnaryType type;
   ExpressionItemList sub_expr;
 };
-struct TransformExpression {
+struct StructPatchExpression {
   ExpressionItemList input_path;
-  ExpressionItemList field_transforms;
+  ExpressionItemList field_patches;
 };
-struct FieldTransform {
+struct FieldPatch {
   char* field_name;
   ExpressionItemList exprs;
   bool is_replace;
@@ -312,9 +312,9 @@ DEFINE_VARIADIC(visit_expr_struct_expr, StructExpression)
 #undef DEFINE_VARIADIC
 
 // Sort by field name, breaking ties by pointer address to ensure stability.
-int transform_op_cmp(const void* a, const void* b) {
-  const struct FieldTransform* op_a = ((ExpressionItem*)a)->ref;
-  const struct FieldTransform* op_b = ((ExpressionItem*)b)->ref;
+int patch_op_cmp(const void* a, const void* b) {
+  const struct FieldPatch* op_a = ((ExpressionItem*)a)->ref;
+  const struct FieldPatch* op_b = ((ExpressionItem*)b)->ref;
   if (op_a->field_name == NULL && op_b->field_name == NULL) {
     // break tie below
   } else if (op_a->field_name == NULL) {
@@ -336,37 +336,37 @@ int transform_op_cmp(const void* a, const void* b) {
   }
 }
 
-void visit_transform_expr(
+void visit_struct_patch_expr(
     void* data,
     uintptr_t sibling_list_id,
     uintptr_t input_path_list_id,
     uintptr_t child_list_id)
 {
-  struct TransformExpression* transform = malloc(sizeof(struct TransformExpression));
-  transform->input_path = get_expr_list(data, input_path_list_id);
-  transform->field_transforms = get_expr_list(data, child_list_id);
+  struct StructPatchExpression* patch = malloc(sizeof(struct StructPatchExpression));
+  patch->input_path = get_expr_list(data, input_path_list_id);
+  patch->field_patches = get_expr_list(data, child_list_id);
 
   // stable sort the ops by field name to ensure deterministic output
   qsort(
-      transform->field_transforms.list,
-      transform->field_transforms.len,
+      patch->field_patches.list,
+      patch->field_patches.len,
       sizeof(ExpressionItem),
-      transform_op_cmp);
+      patch_op_cmp);
 
-  put_expr_item(data, sibling_list_id, transform, Transform);
+  put_expr_item(data, sibling_list_id, patch, StructPatch);
 }
-void visit_field_transform(
+void visit_field_patch(
     void* data,
     uintptr_t sibling_list_id,
     const KernelStringSlice* field_name,
     uintptr_t child_list_id,
     bool is_replace)
 {
-  struct FieldTransform* field_transform = malloc(sizeof(struct FieldTransform));
-  field_transform->field_name = field_name? allocate_string(*field_name) : NULL;
-  field_transform->exprs = get_expr_list(data, child_list_id);
-  field_transform->is_replace = is_replace;
-  put_expr_item(data, sibling_list_id, field_transform, FieldTransform);
+  struct FieldPatch* field_patch = malloc(sizeof(struct FieldPatch));
+  field_patch->field_name = field_name? allocate_string(*field_name) : NULL;
+  field_patch->exprs = get_expr_list(data, child_list_id);
+  field_patch->is_replace = is_replace;
+  put_expr_item(data, sibling_list_id, field_patch, FieldPatch);
 }
 void visit_opaque_expr(
     void *data,
@@ -508,8 +508,8 @@ ExpressionItemList construct_expression(SharedExpression* expression) {
     .visit_divide = visit_expr_divide,
     .visit_column = visit_expr_column,
     .visit_struct_expr = visit_expr_struct_expr,
-    .visit_transform_expr = visit_transform_expr,
-    .visit_field_transform = visit_field_transform,
+    .visit_struct_patch_expr = visit_struct_patch_expr,
+    .visit_field_patch = visit_field_patch,
     .visit_opaque_pred = visit_opaque_pred,
     .visit_opaque_expr = visit_opaque_expr,
     .visit_unknown = visit_unknown,
@@ -583,18 +583,18 @@ void free_expression_item(ExpressionItem ref) {
       free(var);
       break;
     };
-    case Transform: {
-      struct TransformExpression* transform = ref.ref;
-      free_expression_list(transform->input_path);
-      free_expression_list(transform->field_transforms);
-      free(transform);
+    case StructPatch: {
+      struct StructPatchExpression* patch = ref.ref;
+      free_expression_list(patch->input_path);
+      free_expression_list(patch->field_patches);
+      free(patch);
       break;
     }
-    case FieldTransform: {
-      struct FieldTransform* field_transform = ref.ref;
-      free(field_transform->field_name);
-      free_expression_list(field_transform->exprs);
-      free(field_transform);
+    case FieldPatch: {
+      struct FieldPatch* field_patch = ref.ref;
+      free(field_patch->field_name);
+      free_expression_list(field_patch->exprs);
+      free(field_patch);
       break;
     }
     case OpaqueExpression: {

--- a/ffi/examples/visit-expression/expression_print.h
+++ b/ffi/examples/visit-expression/expression_print.h
@@ -84,25 +84,25 @@ void print_tree_helper(ExpressionItem ref, int depth) {
       print_expression_item_list(var->exprs, depth + 1);
       break;
     }
-    case Transform: {
-      struct TransformExpression* transform = ref.ref;
-      printf("Transform\n");
-      print_expression_item_list(transform->input_path, depth + 1);
-      print_expression_item_list(transform->field_transforms, depth + 1);
+    case StructPatch: {
+      struct StructPatchExpression* patch = ref.ref;
+      printf("StructPatch\n");
+      print_expression_item_list(patch->input_path, depth + 1);
+      print_expression_item_list(patch->field_patches, depth + 1);
       break;
     }
-    case FieldTransform: {
-      struct FieldTransform* field_transform = ref.ref;
-      if (!field_transform->field_name) {
+    case FieldPatch: {
+      struct FieldPatch* field_patch = ref.ref;
+      if (!field_patch->field_name) {
         printf("Prepend\n");
-      } else if (!field_transform->is_replace) {
-        printf("Insert(%s)\n", field_transform->field_name);
-      } else if (!field_transform->exprs.len) {
-        printf("Drop(%s)\n", field_transform->field_name);
+      } else if (!field_patch->is_replace) {
+        printf("Insert(%s)\n", field_patch->field_name);
+      } else if (!field_patch->exprs.len) {
+        printf("Drop(%s)\n", field_patch->field_name);
       } else {
-        printf("Replace(%s)\n", field_transform->field_name);
+        printf("Replace(%s)\n", field_patch->field_name);
       }
-      print_expression_item_list(field_transform->exprs, depth + 1);
+      print_expression_item_list(field_patch->exprs, depth + 1);
       break;
     }
     case OpaqueExpression: {

--- a/ffi/examples/visit-expression/visit_expression.c
+++ b/ffi/examples/visit-expression/visit_expression.c
@@ -91,7 +91,7 @@ int main() {
         "This test demonstrates the full range of expression types.\n"
         "Some types are not yet supported in round-trip reconstruction:\n"
         "  - Struct/Array/Map literals (nested data structures)\n"
-        "  - Transform expressions (schema evolution operations)\n"
+        "  - StructPatch expressions (schema evolution operations)\n"
         "  - Opaque expressions (custom user-defined expressions)"
     },
     {

--- a/ffi/src/expressions/engine_visitor.rs
+++ b/ffi/src/expressions/engine_visitor.rs
@@ -4,9 +4,9 @@ use std::ffi::c_void;
 
 use delta_kernel::expressions::{
     ArrayData, BinaryExpression, BinaryExpressionOp, BinaryPredicate, BinaryPredicateOp,
-    ColumnName, Expression, ExpressionRef, JunctionPredicate, JunctionPredicateOp, MapData,
-    MapToStructExpression, OpaqueExpression, OpaqueExpressionOpRef, OpaquePredicate,
-    OpaquePredicateOpRef, ParseJsonExpression, Predicate, Scalar, StructData, Transform,
+    ColumnName, Expression, ExpressionRef, ExpressionStructPatch, JunctionPredicate,
+    JunctionPredicateOp, MapData, MapToStructExpression, OpaqueExpression, OpaqueExpressionOpRef,
+    OpaquePredicate, OpaquePredicateOpRef, ParseJsonExpression, Predicate, Scalar, StructData,
     UnaryExpression, UnaryExpressionOp, UnaryPredicate, UnaryPredicateOp, VariadicExpression,
     VariadicExpressionOp,
 };
@@ -208,22 +208,22 @@ pub struct EngineExpressionVisitor {
     /// The sub-expressions (fields) of the struct are in a list identified by `child_list_id`
     pub visit_struct_expr:
         extern "C" fn(data: *mut c_void, sibling_list_id: usize, child_list_id: usize),
-    /// Visits a `Transform` expression belonging to the list identified by `sibling_list_id`. The
-    /// `input_path_list_id` is a single-item list containing transform's input path as a column
-    /// reference (0 = no path). The `field_transform_list_id` identifies the list of field
-    /// transforms to apply (0 = identity transform). See also [`Self::visit_field_transform`].
-    pub visit_transform_expr: extern "C" fn(
+    /// Visits a `StructPatch` expression belonging to the list identified by `sibling_list_id`.
+    /// The `input_path_list_id` is a single-item list containing the patch's input path as a
+    /// column reference (0 = no path). The `field_patch_list_id` identifies the list of field
+    /// patches to apply (0 = empty patch). See also [`Self::visit_field_patch`].
+    pub visit_struct_patch_expr: extern "C" fn(
         data: *mut c_void,
         sibling_list_id: usize,
         input_path_list_id: usize,
-        field_transform_list_id: usize,
+        field_patch_list_id: usize,
     ),
-    /// Visits one field transform of a `Transform` expression that owns the list identified by
-    /// `sibling_list_id`. Each field transform has a different insertion point (no duplicates).
+    /// Visits one field patch of a `StructPatch` expression that owns the list identified by
+    /// `sibling_list_id`. Each field patch has a different insertion point (no duplicates).
     ///
-    /// A field transform is modeled as the triple `(field_name, expr_list, is_replace)`, as
+    /// A field patch is modeled as the triple `(field_name, expr_list, is_replace)`, as
     /// described by the truth table below. The `expr_list_id` identifies the list of expressions
-    /// the field transform should emit. The field name (if present) always references a field of
+    /// the field patch should emit. The field name (if present) always references a field of
     /// the input struct. Both the field name and the expression list are optional:
     ///
     /// |field_name? |expr_list? |is_replace? |meaning|
@@ -243,9 +243,9 @@ pub struct EngineExpressionVisitor {
     /// | YES | NO  | Insert a (possibly empty)  list of expressions after the named input field
     /// | YES | YES | Replace the named input field with a (possibly empty) list of expressions
     ///
-    /// NOTE: The expressions of each field transform must be emitted in order at the insertion
+    /// NOTE: The expressions of each field patch must be emitted in order at the insertion
     /// point.
-    pub visit_field_transform: extern "C" fn(
+    pub visit_field_patch: extern "C" fn(
         data: *mut c_void,
         sibling_list_id: usize,
         field_name: *const KernelStringSlice,
@@ -428,16 +428,16 @@ fn visit_expression_struct(
     call!(visitor, visit_struct_expr, sibling_list_id, child_list_id)
 }
 
-fn visit_expression_transform(
+fn visit_expression_struct_patch(
     visitor: &mut EngineExpressionVisitor,
-    transform: &Transform,
+    patch: &ExpressionStructPatch,
     sibling_list_id: usize,
 ) {
-    let Transform {
+    let ExpressionStructPatch {
         input_path,
-        field_transforms,
+        field_patches,
         prepended_fields,
-    } = transform;
+    } = patch;
 
     // Treat the input path like a column expression
     let mut path_list_id = 0;
@@ -446,11 +446,11 @@ fn visit_expression_transform(
         visit_expression_column(visitor, column_name, path_list_id);
     };
 
-    // Emit one field transform for each named input field (ignoring no-ops), plus one more for the
+    // Emit one field patch for each named input field (ignoring no-ops), plus one more for the
     // prepended field list (if any).
     let prepended_count = if prepended_fields.is_empty() { 0 } else { 1 };
-    let field_transform_count = prepended_count + field_transforms.len();
-    let field_transform_list_id = call!(visitor, make_field_list, field_transform_count);
+    let field_patch_count = prepended_count + field_patches.len();
+    let field_patch_list_id = call!(visitor, make_field_list, field_patch_count);
 
     // Process the prepend first (if any)
     if !prepended_fields.is_empty() {
@@ -460,38 +460,38 @@ fn visit_expression_transform(
         }
         call!(
             visitor,
-            visit_field_transform,
-            field_transform_list_id,
+            visit_field_patch,
+            field_patch_list_id,
             std::ptr::null(),
             child_list_id,
             false // doesn't matter, no field name
         );
     }
 
-    // Process each field transform in turn
-    for (field_name, field_transform) in field_transforms {
-        let child_list_id = call!(visitor, make_field_list, field_transform.exprs.len());
-        for expr in &field_transform.exprs {
+    // Process each field patch in turn
+    for (field_name, field_patch) in field_patches {
+        let child_list_id = call!(visitor, make_field_list, field_patch.exprs.len());
+        for expr in &field_patch.exprs {
             visit_expression_impl(visitor, expr, child_list_id);
         }
 
         call!(
             visitor,
-            visit_field_transform,
-            field_transform_list_id,
+            visit_field_patch,
+            field_patch_list_id,
             &kernel_string_slice!(field_name),
             child_list_id,
-            field_transform.is_replace
+            field_patch.is_replace
         );
     }
 
-    // Attach the field transforms to the parent transform
+    // Attach the field patches to the parent struct patch.
     call!(
         visitor,
-        visit_transform_expr,
+        visit_struct_patch_expr,
         sibling_list_id,
         path_list_id,
-        field_transform_list_id
+        field_patch_list_id
     );
 }
 
@@ -634,8 +634,8 @@ fn visit_expression_impl(
         Expression::Literal(scalar) => visit_expression_scalar(visitor, scalar, sibling_list_id),
         Expression::Column(name) => visit_expression_column(visitor, name, sibling_list_id),
         Expression::Struct(exprs, _) => visit_expression_struct(visitor, exprs, sibling_list_id),
-        Expression::Transform(transform) => {
-            visit_expression_transform(visitor, transform, sibling_list_id)
+        Expression::StructPatch(patch) => {
+            visit_expression_struct_patch(visitor, patch, sibling_list_id)
         }
         Expression::Predicate(pred) => visit_predicate_impl(visitor, pred, sibling_list_id),
         Expression::Unary(UnaryExpression { op, expr }) => {

--- a/ffi/src/test_ffi.rs
+++ b/ffi/src/test_ffi.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 
 use delta_kernel::expressions::{
     column_expr, column_name, column_pred, ArrayData, BinaryExpressionOp, BinaryPredicateOp,
-    Expression as Expr, MapData, OpaqueExpressionOp, OpaquePredicateOp, Predicate as Pred, Scalar,
-    ScalarExpressionEvaluator, StructData, Transform,
+    Expression as Expr, ExpressionStructPatch, MapData, OpaqueExpressionOp, OpaquePredicateOp,
+    Predicate as Pred, Scalar, ScalarExpressionEvaluator, StructData,
 };
 use delta_kernel::kernel_predicates::{
     DirectDataSkippingPredicateEvaluator, DirectPredicateEvaluator,
@@ -111,19 +111,19 @@ pub unsafe extern "C" fn get_testing_kernel_expression() -> Handle<SharedExpress
     )
     .unwrap();
 
-    let nested_transform = Transform::new_top_level()
+    let nested_patch = ExpressionStructPatch::new_top_level()
         .with_dropped_field("gone")
         .with_replaced_field("stub", Expr::literal("replaced").into())
         .with_inserted_field(Some("x".to_string()), Expr::literal(true).into())
         .with_inserted_field(Some("y".to_string()), Expr::literal(false).into());
-    let top_level_transform = Transform::new_nested(column_name!("foo.bar.baz"))
+    let top_level_patch = ExpressionStructPatch::new_nested(column_name!("foo.bar.baz"))
         .with_dropped_field("dropme")
         .with_replaced_field("replaceme", Expr::literal(42).into())
         .with_inserted_field(None::<&str>, Expr::literal("prepended").into())
         .with_inserted_field(Some("a".to_string()), Expr::literal("first").into())
         .with_inserted_field(
             Some("a".to_string()),
-            Expr::transform(nested_transform).into(),
+            Expr::struct_patch(nested_patch).into(),
         )
         .with_inserted_field(Some("a".to_string()), Expr::literal("third").into());
 
@@ -150,7 +150,7 @@ pub unsafe extern "C" fn get_testing_kernel_expression() -> Handle<SharedExpress
         Scalar::decimal((1i128 << 64) + 1, 20, 3).unwrap().into(),
         Expr::null_literal(DataType::SHORT),
         Scalar::Struct(top_level_struct).into(),
-        Expr::Transform(top_level_transform),
+        Expr::StructPatch(top_level_patch),
         Scalar::Array(array_data).into(),
         Scalar::Map(map_data).into(),
         Expr::struct_from([Expr::literal(5_i32), Expr::literal(20_i64)]),

--- a/ffi/tests/test-expression-visitor/expected.txt
+++ b/ffi/tests/test-expression-visitor/expected.txt
@@ -2,7 +2,7 @@
 This test demonstrates the full range of expression types.
 Some types are not yet supported in round-trip reconstruction:
   - Struct/Array/Map literals (nested data structures)
-  - Transform expressions (schema evolution operations)
+  - StructPatch expressions (schema evolution operations)
   - Opaque expressions (custom user-defined expressions)
 
 StructExpression
@@ -35,13 +35,13 @@ StructExpression
           Array
             Short(5)
             Short(0)
-  Transform
+  StructPatch
     Column(foo.bar.baz)
     Prepend
       String(prepended)
     Insert(a)
       String(first)
-      Transform
+      StructPatch
         Drop(gone)
         Replace(stub)
           String(replaced)

--- a/kernel/src/checkpoint/checkpoint_transform.rs
+++ b/kernel/src/checkpoint/checkpoint_transform.rs
@@ -16,7 +16,7 @@
 use std::sync::{Arc, LazyLock};
 
 use crate::actions::ADD_NAME;
-use crate::expressions::{Expression, ExpressionRef, Transform, UnaryExpressionOp};
+use crate::expressions::{Expression, ExpressionRef, ExpressionStructPatch, UnaryExpressionOp};
 use crate::schema::{DataType, SchemaRef, StructField, StructType};
 use crate::table_properties::TableProperties;
 use crate::{DeltaResult, Error};
@@ -83,16 +83,16 @@ pub(crate) fn build_checkpoint_transform(
     stats_schema: &SchemaRef,
     partition_schema: Option<&SchemaRef>,
 ) -> ExpressionRef {
-    let mut add_transform = Transform::new_nested([ADD_NAME]);
+    let mut add_patch = ExpressionStructPatch::new_nested([ADD_NAME]);
 
     // Handle stats field
     if config.write_stats_as_json {
         // Populate stats from stats_parsed if needed (for old checkpoints that only had
         // stats_parsed)
-        add_transform = add_transform.with_replaced_field(STATS_FIELD, STATS_JSON_EXPR.clone());
+        add_patch = add_patch.with_replaced_field(STATS_FIELD, STATS_JSON_EXPR.clone());
     } else {
         // Drop stats field when not writing as JSON
-        add_transform = add_transform.with_dropped_field(STATS_FIELD);
+        add_patch = add_patch.with_dropped_field(STATS_FIELD);
     }
 
     // Handle stats_parsed field
@@ -101,30 +101,30 @@ pub(crate) fn build_checkpoint_transform(
     if config.write_stats_as_struct {
         // Populate stats_parsed from JSON stats (for commits that only have JSON stats)
         let stats_parsed_expr = build_stats_parsed_expr(stats_schema);
-        add_transform = add_transform.with_replaced_field(STATS_PARSED_FIELD, stats_parsed_expr);
+        add_patch = add_patch.with_replaced_field(STATS_PARSED_FIELD, stats_parsed_expr);
     } else {
         // Drop stats_parsed field when not writing as struct
-        add_transform = add_transform.with_dropped_field(STATS_PARSED_FIELD);
+        add_patch = add_patch.with_dropped_field(STATS_PARSED_FIELD);
     }
 
     // Handle partitionValues_parsed field (only for partitioned tables)
     if partition_schema.is_some() {
         if config.write_stats_as_struct {
             let pv_parsed_expr = build_partition_values_parsed_expr();
-            add_transform =
-                add_transform.with_replaced_field(PARTITION_VALUES_PARSED_FIELD, pv_parsed_expr);
+            add_patch =
+                add_patch.with_replaced_field(PARTITION_VALUES_PARSED_FIELD, pv_parsed_expr);
         } else {
             // Drop partitionValues_parsed since it was added to read schema
-            add_transform = add_transform.with_dropped_field(PARTITION_VALUES_PARSED_FIELD);
+            add_patch = add_patch.with_dropped_field(PARTITION_VALUES_PARSED_FIELD);
         }
     }
 
-    // Wrap the nested Add transform in a top-level transform that replaces the Add field
-    let add_transform_expr: ExpressionRef = Arc::new(Expression::transform(add_transform));
-    let outer_transform =
-        Transform::new_top_level().with_replaced_field(ADD_NAME, add_transform_expr);
+    // Wrap the nested Add patch in a top-level patch that replaces the Add field.
+    let add_patch_expr: ExpressionRef = Arc::new(Expression::struct_patch(add_patch));
+    let outer_patch =
+        ExpressionStructPatch::new_top_level().with_replaced_field(ADD_NAME, add_patch_expr);
 
-    Arc::new(Expression::transform(outer_transform))
+    Arc::new(Expression::struct_patch(outer_patch))
 }
 
 /// Builds a read schema that includes `stats_parsed` and optionally `partitionValues_parsed`
@@ -353,59 +353,59 @@ mod tests {
         assert!(config.write_stats_as_struct);
     }
 
-    /// Helper to extract the outer and inner transforms from a stats transform expression.
-    /// Returns (outer_transform, inner_transform).
-    fn extract_transforms(expr: &Expression) -> (&Transform, &Transform) {
-        let Expression::Transform(outer) = expr else {
-            panic!("Expected outer Transform expression");
+    /// Helper to extract the outer and inner patches from a stats transform expression.
+    /// Returns (outer_patch, inner_patch).
+    fn extract_patches(expr: &Expression) -> (&ExpressionStructPatch, &ExpressionStructPatch) {
+        let Expression::StructPatch(outer) = expr else {
+            panic!("Expected outer StructPatch expression");
         };
 
         // Outer should be top-level (no input path)
         assert!(
             outer.input_path.is_none(),
-            "Outer transform should be top-level"
+            "Outer patch should be top-level"
         );
 
         // Outer should replace "add" field
-        let add_field_transform = outer
-            .field_transforms
+        let add_field_patch = outer
+            .field_patches
             .get(ADD_NAME)
-            .expect("Outer transform should have 'add' field transform");
-        assert!(add_field_transform.is_replace, "Should replace 'add' field");
+            .expect("Outer patch should have 'add' field patch");
+        assert!(add_field_patch.is_replace, "Should replace 'add' field");
         assert_eq!(
-            add_field_transform.exprs.len(),
+            add_field_patch.exprs.len(),
             1,
             "Should have exactly one replacement expression"
         );
 
-        // Extract inner transform
-        let Expression::Transform(inner) = add_field_transform.exprs[0].as_ref() else {
-            panic!("Expected inner Transform expression for 'add' field");
+        // Extract inner patch
+        let Expression::StructPatch(inner) = add_field_patch.exprs[0].as_ref() else {
+            panic!("Expected inner StructPatch expression for 'add' field");
         };
 
         // Inner should target "add" path
         assert_eq!(
             inner.input_path.as_ref().map(|p| p.to_string()),
             Some("add".to_string()),
-            "Inner transform should target 'add' path"
+            "Inner patch should target 'add' path"
         );
 
         (outer, inner)
     }
 
-    /// Helper to check if a field transform is a drop (replace with nothing).
-    fn is_drop(transform: &Transform, field: &str) -> bool {
-        transform
-            .field_transforms
+    /// Helper to check if a field patch is a drop (replace with nothing).
+    fn is_drop(patch: &ExpressionStructPatch, field: &str) -> bool {
+        patch
+            .field_patches
             .get(field)
             .map(|ft| ft.is_replace && ft.exprs.is_empty())
             .unwrap_or(false)
     }
 
-    /// Helper to check if a field transform is a replacement with an expression.
-    fn is_replacement(transform: &Transform, field: &str) -> bool {
-        transform
-            .field_transforms
+    /// Helper to check if a field patch is a replacement with an expression.
+    fn is_replacement(patch: &ExpressionStructPatch, field: &str) -> bool {
+        patch
+            .field_patches
             .get(field)
             .map(|ft| ft.is_replace && ft.exprs.len() == 1)
             .unwrap_or(false)
@@ -414,7 +414,7 @@ mod tests {
     #[test]
     fn test_build_transform_with_json_only() {
         // writeStatsAsJson=true, writeStatsAsStruct=false (default)
-        // Inner transform: stats=COALESCE, stats_parsed=drop
+        // Inner patch: stats=COALESCE, stats_parsed=drop
         let config = StatsTransformConfig {
             write_stats_as_json: true,
             write_stats_as_struct: false,
@@ -422,7 +422,7 @@ mod tests {
         let stats_schema = Arc::new(StructType::new_unchecked([]));
         let transform_expr = build_checkpoint_transform(&config, &stats_schema, None);
 
-        let (_, inner) = extract_transforms(&transform_expr);
+        let (_, inner) = extract_patches(&transform_expr);
 
         // stats should be replaced with COALESCE expression
         assert!(
@@ -440,7 +440,7 @@ mod tests {
     #[test]
     fn test_build_transform_drops_both_when_false() {
         // writeStatsAsJson=false, writeStatsAsStruct=false
-        // Inner transform: stats=drop, stats_parsed=drop
+        // Inner patch: stats=drop, stats_parsed=drop
         let config = StatsTransformConfig {
             write_stats_as_json: false,
             write_stats_as_struct: false,
@@ -448,7 +448,7 @@ mod tests {
         let stats_schema = Arc::new(StructType::new_unchecked([]));
         let transform_expr = build_checkpoint_transform(&config, &stats_schema, None);
 
-        let (_, inner) = extract_transforms(&transform_expr);
+        let (_, inner) = extract_patches(&transform_expr);
 
         // Both fields should be dropped
         assert!(is_drop(inner, STATS_FIELD), "stats should be dropped");
@@ -461,7 +461,7 @@ mod tests {
     #[test]
     fn test_build_transform_with_both_enabled() {
         // writeStatsAsJson=true, writeStatsAsStruct=true
-        // Inner transform: stats=COALESCE, stats_parsed=COALESCE
+        // Inner patch: stats=COALESCE, stats_parsed=COALESCE
         let config = StatsTransformConfig {
             write_stats_as_json: true,
             write_stats_as_struct: true,
@@ -469,7 +469,7 @@ mod tests {
         let stats_schema = Arc::new(StructType::new_unchecked([]));
         let transform_expr = build_checkpoint_transform(&config, &stats_schema, None);
 
-        let (_, inner) = extract_transforms(&transform_expr);
+        let (_, inner) = extract_patches(&transform_expr);
 
         // Both fields should be replaced with COALESCE expressions
         assert!(
@@ -485,7 +485,7 @@ mod tests {
     #[test]
     fn test_build_transform_struct_only() {
         // writeStatsAsJson=false, writeStatsAsStruct=true
-        // Inner transform: stats=drop, stats_parsed=COALESCE
+        // Inner patch: stats=drop, stats_parsed=COALESCE
         let config = StatsTransformConfig {
             write_stats_as_json: false,
             write_stats_as_struct: true,
@@ -493,7 +493,7 @@ mod tests {
         let stats_schema = Arc::new(StructType::new_unchecked([]));
         let transform_expr = build_checkpoint_transform(&config, &stats_schema, None);
 
-        let (_, inner) = extract_transforms(&transform_expr);
+        let (_, inner) = extract_patches(&transform_expr);
 
         // stats should be dropped
         assert!(is_drop(inner, STATS_FIELD), "stats should be dropped");
@@ -519,7 +519,7 @@ mod tests {
         ]));
         let transform_expr = build_checkpoint_transform(&config, &stats_schema, Some(&pv_schema));
 
-        let (_, inner) = extract_transforms(&transform_expr);
+        let (_, inner) = extract_patches(&transform_expr);
 
         // partitionValues_parsed should be replaced with COALESCE expression
         assert!(
@@ -542,7 +542,7 @@ mod tests {
         )]));
         let transform_expr = build_checkpoint_transform(&config, &stats_schema, Some(&pv_schema));
 
-        let (_, inner) = extract_transforms(&transform_expr);
+        let (_, inner) = extract_patches(&transform_expr);
 
         // partitionValues_parsed should be dropped
         assert!(
@@ -561,12 +561,12 @@ mod tests {
         let stats_schema = Arc::new(StructType::new_unchecked([]));
         let transform_expr = build_checkpoint_transform(&config, &stats_schema, None);
 
-        let (_, inner) = extract_transforms(&transform_expr);
+        let (_, inner) = extract_patches(&transform_expr);
 
         // No partitionValues_parsed transform should exist
         assert!(
             !inner
-                .field_transforms
+                .field_patches
                 .contains_key(PARTITION_VALUES_PARSED_FIELD),
             "non-partitioned table should not have partitionValues_parsed transform"
         );

--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -116,7 +116,7 @@ use crate::actions::{
     SET_TRANSACTION_NAME, SIDECAR_NAME,
 };
 use crate::engine_data::FilteredEngineData;
-use crate::expressions::{Expression, Scalar, StructData, Transform};
+use crate::expressions::{Expression, ExpressionStructPatch, Scalar, StructData};
 use crate::last_checkpoint_hint::LastCheckpointHint;
 use crate::log_replay::LogReplayProcessor;
 use crate::path::{self, ParsedLogPath};
@@ -741,15 +741,15 @@ impl CheckpointWriter {
             vec![Scalar::from(self.version)],
         )?);
 
-        // Use a Transform to set just the checkpointMetadata field, keeping others null
-        let transform = Transform::new_top_level().with_replaced_field(
+        // Use a struct patch to set just the checkpointMetadata field, keeping others null
+        let patch = ExpressionStructPatch::new_top_level().with_replaced_field(
             CHECKPOINT_METADATA_NAME,
             Arc::new(Expression::literal(checkpoint_metadata_value)),
         );
 
         let evaluator = engine.evaluation_handler().new_expression_evaluator(
             schema.clone(),
-            Arc::new(Expression::transform(transform)),
+            Arc::new(Expression::struct_patch(patch)),
             schema.clone().into(),
         )?;
 

--- a/kernel/src/checkpoint/sidecar/mod.rs
+++ b/kernel/src/checkpoint/sidecar/mod.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use crate::action_reconciliation::ActionReconciliationIterator;
 use crate::actions::{ADD_NAME, REMOVE_NAME, SIDECAR_NAME};
 use crate::engine_data::filter_by_predicate;
-use crate::expressions::{Expression, Predicate, Scalar, StructData, Transform};
+use crate::expressions::{Expression, ExpressionStructPatch, Predicate, Scalar, StructData};
 use crate::schema::{DataType, SchemaRef, StructField, StructType};
 use crate::{
     DeltaResult, Engine, EngineData, Error, EvaluationHandler, ExpressionEvaluator, FileMeta,
@@ -202,8 +202,8 @@ impl SidecarSplitter {
         // same as checkpoint_data_schema (add/remove columns are already nullable).
         let non_file_action_nullifier = eval_handler.new_expression_evaluator(
             checkpoint_data_schema.clone(),
-            Arc::new(Expression::transform(
-                Transform::new_top_level()
+            Arc::new(Expression::struct_patch(
+                ExpressionStructPatch::new_top_level()
                     .with_replaced_field(
                         ADD_NAME,
                         Arc::new(Expression::literal(Scalar::Null(

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -152,9 +152,9 @@ fn evaluate_struct_expression(
     Ok(Arc::new(data))
 }
 
-/// Evaluates a transform expression by building expressions in input schema order
-fn evaluate_transform_expression(
-    transform: &Transform,
+/// Evaluates a struct patch expression by building expressions in input schema order.
+fn evaluate_struct_patch_expression(
+    patch: &ExpressionStructPatch,
     batch: &RecordBatch,
     output_schema: &StructType,
 ) -> DeltaResult<ArrayRef> {

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -33,8 +33,8 @@ use crate::engine::ensure_data_types::{ensure_data_types, ValidationMode};
 use crate::error::{DeltaResult, Error};
 use crate::expressions::{
     BinaryExpression, BinaryExpressionOp, BinaryPredicate, BinaryPredicateOp, Expression,
-    ExpressionRef, JunctionPredicate, JunctionPredicateOp, OpaqueExpression, OpaquePredicate,
-    Predicate, Scalar, Transform, UnaryExpression, UnaryExpressionOp, UnaryPredicate,
+    ExpressionRef, ExpressionStructPatch, JunctionPredicate, JunctionPredicateOp, OpaqueExpression,
+    OpaquePredicate, Predicate, Scalar, UnaryExpression, UnaryExpressionOp, UnaryPredicate,
     UnaryPredicateOp, VariadicExpression, VariadicExpressionOp,
 };
 use crate::schema::{DataType, PrimitiveType, StructField, StructType};
@@ -158,7 +158,7 @@ fn evaluate_transform_expression(
     batch: &RecordBatch,
     output_schema: &StructType,
 ) -> DeltaResult<ArrayRef> {
-    let mut used_field_transforms = 0;
+    let mut used_field_patches = 0;
 
     // Collect output columns directly to avoid creating intermediate Expr::Column instances.
     let mut output_cols = Vec::with_capacity(output_schema.num_fields());
@@ -173,17 +173,17 @@ fn evaluate_transform_expression(
     };
 
     // Handle prepends (insertions before any field)
-    for expr in &transform.prepended_fields {
+    for expr in &patch.prepended_fields {
         output_cols.push(evaluate_expression(expr, batch, Some(next_output_type()?))?);
     }
 
     // Extract the input path, if any
-    let source_array = transform
+    let source_array = patch
         .input_path()
         .map(|path| extract_column(batch, path))
         .transpose()?;
 
-    // For nested transforms, get the source struct's null bitmap to preserve null rows
+    // For nested patches, get the source struct's null bitmap to preserve null rows
     let source_null_buffer = source_array.as_ref().and_then(|arr| {
         arr.as_any()
             .downcast_ref::<StructArray>()
@@ -203,30 +203,30 @@ fn evaluate_transform_expression(
         let field_name: &str = input_field.name();
 
         // Any field that isn't replaced passes through unchanged
-        let field_transform = transform.field_transforms.get(field_name);
-        if !field_transform.is_some_and(|t| t.is_replace) {
+        let field_patch = patch.field_patches.get(field_name);
+        if !field_patch.is_some_and(|t| t.is_replace) {
             output_cols.push(extract_column(source_data, &[field_name])?);
             let _ = next_output_type()?; // consume and discard the output schema field
         }
 
         // Process any insertions that come after this field
-        if let Some(field_transform) = field_transform {
-            for expr in &field_transform.exprs {
+        if let Some(field_patch) = field_patch {
+            for expr in &field_patch.exprs {
                 output_cols.push(evaluate_expression(expr, batch, Some(next_output_type()?))?);
             }
-            used_field_transforms += 1;
+            used_field_patches += 1;
         }
     }
 
-    // Verify that all non-optional field transforms were used
-    let required_count = transform
-        .field_transforms
+    // Verify that all non-optional field patches were used
+    let required_count = patch
+        .field_patches
         .values()
         .filter(|ft| !ft.optional)
         .count();
-    if used_field_transforms < required_count {
+    if used_field_patches < required_count {
         return Err(Error::generic(
-            "Some non-optional field transforms reference invalid input field names",
+            "Some non-optional field patches reference invalid input field names",
         ));
     }
 
@@ -235,7 +235,7 @@ fn evaluate_transform_expression(
         return Err(Error::generic("Too many fields in output schema"));
     }
 
-    // Build the final struct, preserving null bitmap for nested transforms
+    // Build the final struct, preserving null bitmap for nested patches
     let output_fields: Vec<ArrowField> = output_cols
         .iter()
         .zip(output_schema.fields())
@@ -272,11 +272,11 @@ pub fn evaluate_expression(
         (Struct(..), dt) => Err(Error::Generic(format!(
             "Struct expression expects a DataType::Struct result, but got {dt:?}"
         ))),
-        (Transform(transform), Some(DataType::Struct(output_schema))) => {
-            evaluate_transform_expression(transform, batch, output_schema)
+        (StructPatch(patch), Some(DataType::Struct(output_schema))) => {
+            evaluate_struct_patch_expression(patch, batch, output_schema)
         }
-        (Transform(_), _) => Err(Error::generic(
-            "Data type is required to evaluate transform expressions",
+        (StructPatch(_), _) => Err(Error::generic(
+            "Data type is required to evaluate struct patch expressions",
         )),
         (Predicate(pred), None | Some(&DataType::BOOLEAN)) => {
             let result = evaluate_predicate(pred, batch, false)?;
@@ -928,7 +928,7 @@ mod tests {
         DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
     };
     use crate::expressions::{
-        column_expr, column_expr_ref, BinaryExpressionOp, Expression as Expr, Transform,
+        column_expr, column_expr_ref, BinaryExpressionOp, Expression as Expr, ExpressionStructPatch,
     };
     use crate::schema::{DataType, StructField, StructType};
     use crate::utils::test_utils::assert_result_error_with_message;
@@ -995,15 +995,15 @@ mod tests {
     fn test_identity_transforms() {
         let batch = create_test_batch();
 
-        // Test 1: Empty transform (identity) - should be exactly equal to input
-        let transform = Transform::new_top_level();
+        // Test 1: Empty patch (identity) - should be exactly equal to input
+        let patch = ExpressionStructPatch::new_top_level();
         let output_schema = StructType::new_unchecked(vec![
             StructField::new("a", DataType::INTEGER, false),
             StructField::new("b", DataType::INTEGER, false),
             StructField::new("c", DataType::INTEGER, false),
         ]);
 
-        let expr = Expr::Transform(transform);
+        let expr = Expr::StructPatch(patch);
         let result = evaluate_expression(
             &expr,
             &batch,
@@ -1011,7 +1011,7 @@ mod tests {
         )
         .unwrap();
 
-        // For identity transform, output should be identical to input
+        // For empty patch, output should be identical to input
         let struct_result = result.as_any().downcast_ref::<StructArray>().unwrap();
 
         // Compare each column directly with original batch columns
@@ -1021,14 +1021,14 @@ mod tests {
 
         // Test 2: Nested path identity (struct relocation without modification)
         let nested_batch = create_nested_test_batch();
-        let transform_nested = Transform::new_nested(["nested"]);
+        let nested_patch = ExpressionStructPatch::new_nested(["nested"]);
 
         let nested_output_schema = StructType::new_unchecked(vec![
             StructField::new("x", DataType::INTEGER, false),
             StructField::new("y", DataType::INTEGER, false),
         ]);
 
-        let expr_nested = Expr::Transform(transform_nested);
+        let expr_nested = Expr::StructPatch(nested_patch);
         let result_nested = evaluate_expression(
             &expr_nested,
             &nested_batch,
@@ -1061,7 +1061,7 @@ mod tests {
     fn test_field_operations_and_multiple_insertions() {
         let batch = create_test_batch();
 
-        let transform = Transform::new_top_level()
+        let patch = ExpressionStructPatch::new_top_level()
             .with_replaced_field("a", column_expr_ref!("b"))
             .with_dropped_field("b")
             .with_inserted_field(None::<&str>, Expr::literal(1).into())
@@ -1082,7 +1082,7 @@ mod tests {
             StructField::new("after_c3", DataType::INTEGER, false), // third insertion after c
         ]);
 
-        let expr = Expr::Transform(transform);
+        let expr = Expr::StructPatch(patch);
         let result = evaluate_expression(
             &expr,
             &batch,
@@ -1116,14 +1116,14 @@ mod tests {
         let nested_batch = create_nested_test_batch();
 
         // Test 1: Simple struct relocation (copy nested struct to top level unchanged)
-        let transform_copy = Transform::new_nested(["nested"]);
+        let copy_patch = ExpressionStructPatch::new_nested(["nested"]);
 
         let copy_output_schema = StructType::new_unchecked(vec![
             StructField::new("x", DataType::INTEGER, false),
             StructField::new("y", DataType::INTEGER, false),
         ]);
 
-        let expr_copy = Expr::Transform(transform_copy);
+        let expr_copy = Expr::StructPatch(copy_patch);
         let result_copy = evaluate_expression(
             &expr_copy,
             &nested_batch,
@@ -1148,7 +1148,7 @@ mod tests {
         }
 
         // Test 2: Modify nested struct and relocate it
-        let transform_modify = Transform::new_nested(["nested"])
+        let modify_patch = ExpressionStructPatch::new_nested(["nested"])
             .with_replaced_field("x".to_string(), Expr::literal(777).into())
             .with_inserted_field(Some("y"), Expr::literal(555).into());
 
@@ -1158,7 +1158,7 @@ mod tests {
             StructField::new("new_field", DataType::INTEGER, false), // inserted after y
         ]);
 
-        let expr_modify = Expr::Transform(transform_modify);
+        let expr_modify = Expr::StructPatch(modify_patch);
         let result_modify = evaluate_expression(
             &expr_modify,
             &nested_batch,
@@ -1188,15 +1188,15 @@ mod tests {
         let batch = create_test_batch();
 
         // Test unused replacement keys
-        let transform =
-            Transform::new_top_level().with_replaced_field("missing", Expr::literal(1).into());
+        let patch = ExpressionStructPatch::new_top_level()
+            .with_replaced_field("missing", Expr::literal(1).into());
         let output_schema = StructType::new_unchecked(vec![
             StructField::not_null("a", DataType::INTEGER),
             StructField::not_null("b", DataType::INTEGER),
             StructField::not_null("c", DataType::INTEGER),
         ]);
 
-        let expr = Expr::Transform(transform);
+        let expr = Expr::StructPatch(patch);
         let result = evaluate_expression(
             &expr,
             &batch,
@@ -1208,10 +1208,10 @@ mod tests {
             .contains("reference invalid input field names"));
 
         // Test unused insertion keys
-        let transform2 = Transform::new_top_level()
+        let insertion_patch = ExpressionStructPatch::new_top_level()
             .with_inserted_field(Some("nonexistent"), Expr::literal(1).into());
 
-        let expr2 = Expr::Transform(transform2);
+        let expr2 = Expr::StructPatch(insertion_patch);
         let result2 = evaluate_expression(
             &expr2,
             &batch,
@@ -1224,7 +1224,7 @@ mod tests {
             .contains("reference invalid input field names"));
 
         // Test column count mismatch -- too many output schema fields
-        let transform3 = Transform::new_top_level().with_dropped_field("a");
+        let drop_patch = ExpressionStructPatch::new_top_level().with_dropped_field("a");
 
         let wrong_output_schema = StructType::new_unchecked(vec![
             StructField::not_null("a", DataType::INTEGER), // expects a field that was dropped
@@ -1232,7 +1232,7 @@ mod tests {
             StructField::not_null("c", DataType::INTEGER),
         ]);
 
-        let expr3 = Expr::Transform(transform3);
+        let expr3 = Expr::StructPatch(drop_patch);
         let result3 = evaluate_expression(
             &expr3,
             &batch,
@@ -1245,12 +1245,12 @@ mod tests {
             .contains("Too many fields in output schema"));
 
         // Test column count mismatch -- too few output schema fields
-        let transform3 = Transform::new_top_level().with_dropped_field("a");
+        let drop_patch = ExpressionStructPatch::new_top_level().with_dropped_field("a");
 
         let wrong_output_schema =
             StructType::new_unchecked(vec![StructField::not_null("c", DataType::INTEGER)]);
 
-        let expr3 = Expr::Transform(transform3);
+        let expr3 = Expr::StructPatch(drop_patch);
         let result3 = evaluate_expression(
             &expr3,
             &batch,
@@ -1263,8 +1263,8 @@ mod tests {
             .contains("Too few fields in output schema"));
 
         // Test missing output schema
-        let transform4 = Transform::new_top_level();
-        let expr4 = Expr::Transform(transform4);
+        let patch = ExpressionStructPatch::new_top_level();
+        let expr4 = Expr::StructPatch(patch);
         let result4 = evaluate_expression(&expr4, &batch, None);
         assert!(result4.is_err());
         assert!(result4
@@ -1276,12 +1276,12 @@ mod tests {
     #[test]
     fn test_drop_field_if_exists_present() {
         let batch = create_test_batch();
-        let transform = Transform::new_top_level().with_dropped_field_if_exists("a");
+        let patch = ExpressionStructPatch::new_top_level().with_dropped_field_if_exists("a");
         let output_schema = StructType::new_unchecked(vec![
             StructField::not_null("b", DataType::INTEGER),
             StructField::not_null("c", DataType::INTEGER),
         ]);
-        let expr = Expr::Transform(transform);
+        let expr = Expr::StructPatch(patch);
         let result = evaluate_expression(
             &expr,
             &batch,
@@ -1296,13 +1296,14 @@ mod tests {
     #[test]
     fn test_drop_field_if_exists_missing() {
         let batch = create_test_batch();
-        let transform = Transform::new_top_level().with_dropped_field_if_exists("nonexistent");
+        let patch =
+            ExpressionStructPatch::new_top_level().with_dropped_field_if_exists("nonexistent");
         let output_schema = StructType::new_unchecked(vec![
             StructField::not_null("a", DataType::INTEGER),
             StructField::not_null("b", DataType::INTEGER),
             StructField::not_null("c", DataType::INTEGER),
         ]);
-        let expr = Expr::Transform(transform);
+        let expr = Expr::StructPatch(patch);
         let result = evaluate_expression(
             &expr,
             &batch,
@@ -1318,13 +1319,13 @@ mod tests {
     #[test]
     fn test_drop_field_non_optional_missing_still_errors() {
         let batch = create_test_batch();
-        let transform = Transform::new_top_level().with_dropped_field("nonexistent");
+        let patch = ExpressionStructPatch::new_top_level().with_dropped_field("nonexistent");
         let output_schema = StructType::new_unchecked(vec![
             StructField::not_null("a", DataType::INTEGER),
             StructField::not_null("b", DataType::INTEGER),
             StructField::not_null("c", DataType::INTEGER),
         ]);
-        let expr = Expr::Transform(transform);
+        let expr = Expr::StructPatch(patch);
         let result = evaluate_expression(
             &expr,
             &batch,
@@ -1592,15 +1593,15 @@ mod tests {
     }
 
     #[test]
-    fn test_nested_transforms() {
+    fn test_nested_patches() {
         let nested_batch = create_nested_test_batch();
 
-        // Simple nested transform - replace a field in the nested struct
-        let nested_transform =
-            Transform::new_nested(["nested"]).with_replaced_field("x", Expr::literal(999).into());
+        // Simple nested patch - replace a field in the nested struct
+        let nested_patch = ExpressionStructPatch::new_nested(["nested"])
+            .with_replaced_field("x", Expr::literal(999).into());
 
-        let outer_transform = Transform::new_top_level()
-            .with_inserted_field(Some("a"), Expr::Transform(nested_transform).into());
+        let outer_patch = ExpressionStructPatch::new_top_level()
+            .with_inserted_field(Some("a"), Expr::StructPatch(nested_patch).into());
 
         let nested_output_schema = StructType::new_unchecked(vec![
             StructField::not_null("x", DataType::INTEGER),
@@ -1612,7 +1613,7 @@ mod tests {
             StructField::not_null("nested", nested_output_schema),
         ]);
 
-        let expr = Expr::Transform(outer_transform);
+        let expr = Expr::StructPatch(outer_patch);
         let result = evaluate_expression(
             &expr,
             &nested_batch,
@@ -1627,7 +1628,7 @@ mod tests {
         // Verify original field 'a' (should be [100, 200, 300])
         validate_i32_column(struct_result, 0, &[100, 200, 300]);
 
-        // Verify nested transform replaced 'x' with literal 999 and passed through 'y' unchanged.
+        // Verify nested patch replaced 'x' with literal 999 and passed through 'y' unchanged.
         let nested_struct_result = struct_result
             .column(1)
             .as_any()
@@ -1636,7 +1637,7 @@ mod tests {
         validate_i32_column(nested_struct_result, 0, &[999, 999, 999]);
         validate_i32_column(nested_struct_result, 1, &[10, 20, 30]);
 
-        // Verify nested transform passed both 'x' and 'y' unchanged.
+        // Verify nested patch passed both 'x' and 'y' unchanged.
         let nested_struct_result = struct_result
             .column(2)
             .as_any()

--- a/kernel/src/engine/arrow_expression/mod.rs
+++ b/kernel/src/engine/arrow_expression/mod.rs
@@ -348,7 +348,7 @@ impl ExpressionEvaluator for DefaultExpressionEvaluator {
         //     )));
         // };
         let batch = match (self.expression.as_ref(), &self.output_type) {
-            (Expression::StructPatch(patch), DataType::Struct(_)) if patch.is_identity() => {
+            (Expression::StructPatch(patch), DataType::Struct(_)) if patch.is_empty() => {
                 // Empty patch optimization: Skip expression evaluation and directly apply the
                 // output schema to the input RecordBatch. This is used to cheaply apply a new
                 // output schema to existing data without changing it, e.g. for column mapping.

--- a/kernel/src/engine/arrow_expression/mod.rs
+++ b/kernel/src/engine/arrow_expression/mod.rs
@@ -348,11 +348,11 @@ impl ExpressionEvaluator for DefaultExpressionEvaluator {
         //     )));
         // };
         let batch = match (self.expression.as_ref(), &self.output_type) {
-            (Expression::Transform(transform), DataType::Struct(_)) if transform.is_identity() => {
-                // Empty transform optimization: Skip expression evaluation and directly apply the
+            (Expression::StructPatch(patch), DataType::Struct(_)) if patch.is_identity() => {
+                // Empty patch optimization: Skip expression evaluation and directly apply the
                 // output schema to the input RecordBatch. This is used to cheaply apply a new
                 // output schema to existing data without changing it, e.g. for column mapping.
-                let array = match transform.input_path() {
+                let array = match patch.input_path() {
                     None => Arc::new(StructArray::from(batch.clone())),
                     Some(path) => extract_column(batch, path)?,
                 };

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -1281,7 +1281,7 @@ fn mixed_string_kernel_fields() -> [StructField; 3] {
 }
 
 /// Evaluator must succeed when a struct contains Utf8, LargeUtf8, and Utf8View columns in the
-/// identity transform branch. The output schema is derived from actual column types, so
+/// empty patch branch. The output schema is derived from actual column types, so
 /// `LargeUtf8` and `Utf8View` columns remain valid even though the kernel type is `STRING`.
 #[test]
 fn test_evaluator_mixed_string_types_identity_transform() {

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -1291,7 +1291,9 @@ fn test_evaluator_mixed_string_types_identity_transform() {
     let output_type = KernelDataType::Struct(Box::new(StructType::new_unchecked(fields)));
 
     let handler = ArrowEvaluationHandler;
-    let expression: ExpressionRef = Arc::new(Expression::Transform(Transform::new_top_level()));
+    let expression: ExpressionRef = Arc::new(Expression::StructPatch(
+        ExpressionStructPatch::new_top_level(),
+    ));
     handler
         .new_expression_evaluator(input_schema, expression, output_type)
         .unwrap()

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -386,24 +386,24 @@ impl Transform {
 
     /// Specifies a field to drop.
     pub fn with_dropped_field(mut self, name: impl Into<String>) -> Self {
-        let field_transform = self.field_transform(name);
-        field_transform.is_replace = true;
+        let field_patch = self.field_patch(name);
+        field_patch.is_replace = true;
         self
     }
 
     /// Like [`Self::with_dropped_field`], but silently ignored if the field does not exist.
     pub fn with_dropped_field_if_exists(mut self, name: impl Into<String>) -> Self {
-        let field_transform = self.field_transform(name);
-        field_transform.is_replace = true;
-        field_transform.optional = true;
+        let field_patch = self.field_patch(name);
+        field_patch.is_replace = true;
+        field_patch.optional = true;
         self
     }
 
     /// Specifies an expression to replace a field with.
     pub fn with_replaced_field(mut self, name: impl Into<String>, expr: ExpressionRef) -> Self {
-        let field_transform = self.field_transform(name);
-        field_transform.exprs.push(expr);
-        field_transform.is_replace = true;
+        let field_patch = self.field_patch(name);
+        field_patch.exprs.push(expr);
+        field_patch.is_replace = true;
         self
     }
 
@@ -416,7 +416,7 @@ impl Transform {
         expr: ExpressionRef,
     ) -> Self {
         match after {
-            Some(field_name) => self.field_transform(field_name).exprs.push(expr),
+            Some(field_name) => self.field_patch(field_name).exprs.push(expr),
             None => self.prepended_fields.push(expr),
         }
         self
@@ -425,10 +425,10 @@ impl Transform {
     /// True if this is the identity transform (all input fields pass through unchanged, with no new
     /// fields inserted).
     pub fn is_identity(&self) -> bool {
-        self.prepended_fields.is_empty() && self.field_transforms.is_empty()
+        self.prepended_fields.is_empty() && self.field_patches.is_empty()
     }
 
-    /// None, if this is a top-level transform. Otherwise, the path of this nested transform.
+    /// None, if this is a top-level patch. Otherwise, the path of this nested patch.
     pub fn input_path(&self) -> Option<&ColumnName> {
         self.input_path.as_ref()
     }
@@ -1033,25 +1033,25 @@ impl Display for Expression {
             Column(name) => write!(f, "Column({name})"),
             Predicate(p) => write!(f, "{p}"),
             Struct(exprs, _) => write!(f, "Struct({})", format_child_list(exprs)),
-            Transform(transform) => {
-                write!(f, "Transform(")?;
+            StructPatch(patch) => {
+                write!(f, "StructPatch(")?;
                 let mut sep = "";
-                if !transform.prepended_fields.is_empty() {
-                    let prepended_fields = format_child_list(&transform.prepended_fields);
+                if !patch.prepended_fields.is_empty() {
+                    let prepended_fields = format_child_list(&patch.prepended_fields);
                     write!(f, "prepend [{prepended_fields}]")?;
                     sep = ", ";
                 }
-                for (field_name, field_transform) in &transform.field_transforms {
-                    let insertions = &field_transform.exprs;
+                for (field_name, field_patch) in &patch.field_patches {
+                    let insertions = &field_patch.exprs;
                     if insertions.is_empty() {
-                        if field_transform.is_replace {
+                        if field_patch.is_replace {
                             write!(f, "{sep}drop {field_name}")?;
                         } else {
                             continue; // no-op; ignore it and don't change `sep` below
                         }
                     } else {
                         let insertions = format_child_list(insertions);
-                        if field_transform.is_replace {
+                        if field_patch.is_replace {
                             write!(f, "{sep}replace {field_name} with [{insertions}]")?;
                         } else {
                             write!(f, "{sep}after {field_name} insert [{insertions}]")?;
@@ -1269,7 +1269,7 @@ mod tests {
         use crate::expressions::scalars::{ArrayData, DecimalData, MapData, StructData};
         use crate::expressions::{
             column_expr, column_name, BinaryExpressionOp, BinaryPredicateOp, ColumnName,
-            Expression, Predicate, Scalar, Transform, UnaryExpressionOp,
+            Expression, ExpressionStructPatch, Predicate, Scalar, UnaryExpressionOp,
         };
         use crate::schema::{ArrayType, DataType, DecimalType, MapType, StructField};
         use crate::utils::test_utils::assert_result_error_with_message;
@@ -1432,7 +1432,7 @@ mod tests {
             assert_roundtrip(&expr);
         }
 
-        // ==================== Expression::Struct/Transform/Other Tests ====================
+        // ==================== Expression::Struct/StructPatch/Other Tests ====================
 
         #[test]
         fn test_struct_expression_roundtrip() {
@@ -1448,17 +1448,19 @@ mod tests {
         fn test_transform_expressions_roundtrip() {
             let cases: Vec<Expression> = vec![
                 // Identity transform
-                Expression::transform(Transform::new_top_level()),
+                Expression::struct_patch(ExpressionStructPatch::new_top_level()),
                 // Drop field
-                Expression::transform(Transform::new_top_level().with_dropped_field("old_column")),
+                Expression::struct_patch(
+                    ExpressionStructPatch::new_top_level().with_dropped_field("old_column"),
+                ),
                 // Replace field
-                Expression::transform(
-                    Transform::new_top_level()
+                Expression::struct_patch(
+                    ExpressionStructPatch::new_top_level()
                         .with_replaced_field("original", Arc::new(Expression::literal(0))),
                 ),
                 // Insert fields
-                Expression::transform(
-                    Transform::new_top_level()
+                Expression::struct_patch(
+                    ExpressionStructPatch::new_top_level()
                         .with_inserted_field(Some("after_col"), Arc::new(column_expr!("new_col")))
                         .with_inserted_field(
                             None::<String>,
@@ -1466,8 +1468,9 @@ mod tests {
                         ),
                 ),
                 // Nested transform
-                Expression::transform(
-                    Transform::new_nested(["parent", "child"]).with_dropped_field("to_drop"),
+                Expression::struct_patch(
+                    ExpressionStructPatch::new_nested(["parent", "child"])
+                        .with_dropped_field("to_drop"),
                 ),
             ];
 

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -334,46 +334,49 @@ where
     Err(de::Error::custom("Cannot deserialize an Opaque Expression"))
 }
 
-/// A transformation affecting a single field (one pieces of a [`Transform`]). The transformation
-/// could insert 0+ new fields after the target, or could replace the target with 0+ a new fields).
+/// A patch affecting a single input field.
+///
+/// A field patch can insert zero or more expressions after its input field, or it can replace the
+/// input field with zero or more expressions.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
-pub struct FieldTransform {
-    /// The list of expressions this field transform emits at the target location.
+pub struct ExpressionFieldPatch {
+    /// The expressions this field patch emits at the input field's output position.
     pub exprs: Vec<ExpressionRef>,
     /// If true, the output expressions replace the input field instead of following after it.
     pub is_replace: bool,
-    /// If true, this transform is silently ignored when the target field does not exist in the
-    /// input. Otherwise, a missing target field produces an error.
+    /// If true, this patch is silently ignored when the input field does not exist. Otherwise, a
+    /// missing input field produces an error.
     pub optional: bool,
 }
 
-/// A transformation that efficiently represents sparse modifications to struct schemas.
+/// A sparse expression patch over the fields of one input struct.
 ///
-/// `Transform` achieves `O(changes)` space complexity instead of `O(schema_width)` by only
-/// specifying those fields that actually change (inserted, replaced, or deleted). Any input field
-/// not specifically mentioned by the transform is passed through, unmodified and with the same
-/// relative field ordering. This is particularly useful for wide schemas where only a few columns
-/// need to be modified and/or dropped, or where a small number of columns need to be injected.
+/// `ExpressionStructPatch` achieves `O(changes)` space complexity instead of `O(schema_width)` by
+/// only specifying fields that actually change (inserted, replaced, or deleted). Any input field
+/// not specifically mentioned by the patch is passed through, unmodified and with the same relative
+/// field ordering. This is particularly useful for wide schemas where only a few columns need to be
+/// modified and/or dropped, or where a small number of columns need to be injected.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
-pub struct Transform {
-    /// The path to the nested input struct this transform operates on (if any). If no path is
-    /// given, the transform operates directly on top-level columns.
+pub struct ExpressionStructPatch {
+    /// The path to the nested input struct this patch operates on (if any). If no path is given,
+    /// the patch operates directly on top-level columns.
     pub input_path: Option<ColumnName>,
-    /// A mapping from named input fields to the transform to be performed on each field.
-    pub field_transforms: HashMap<String, FieldTransform>,
+    /// A mapping from named input fields to the patch to be performed on each field.
+    #[serde(alias = "field_transforms")]
+    pub field_patches: HashMap<String, ExpressionFieldPatch>,
     /// A list of new fields to emit before processing the first input field.
     pub prepended_fields: Vec<ExpressionRef>,
 }
 
-impl Transform {
-    /// Creates a new top-level identity transform. The various `with_xxx` helper methods can be
-    /// used to add specific field transforms.
+impl ExpressionStructPatch {
+    /// Creates a new empty top-level patch. The various `with_xxx` helper methods can be
+    /// used to add specific field patches.
     pub fn new_top_level() -> Self {
         Self::default()
     }
 
-    /// Creates a new identity transform that operates on fields of a nested struct identified by
-    /// `path`. The various `with_xxx` helper methods can be used to add specific field transforms.
+    /// Creates a new empty patch that operates on fields of a nested struct identified by
+    /// `path`. The various `with_xxx` helper methods can be used to add specific field patches.
     pub fn new_nested<A>(path: impl IntoIterator<Item = A>) -> Self
     where
         ColumnName: FromIterator<A>,
@@ -422,9 +425,8 @@ impl Transform {
         self
     }
 
-    /// True if this is the identity transform (all input fields pass through unchanged, with no new
-    /// fields inserted).
-    pub fn is_identity(&self) -> bool {
+    /// True if this patch makes no changes.
+    pub fn is_empty(&self) -> bool {
         self.prepended_fields.is_empty() && self.field_patches.is_empty()
     }
 
@@ -433,9 +435,9 @@ impl Transform {
         self.input_path.as_ref()
     }
 
-    // Gets or creates the field transform for a named input field
-    fn field_transform(&mut self, field_name: impl Into<String>) -> &mut FieldTransform {
-        self.field_transforms.entry(field_name.into()).or_default()
+    // Gets or creates the field patch for a named input field.
+    fn field_patch(&mut self, field_name: impl Into<String>) -> &mut ExpressionFieldPatch {
+        self.field_patches.entry(field_name.into()).or_default()
     }
 }
 
@@ -456,9 +458,10 @@ pub enum Expression {
     /// The optional nullability predicate, if provided and evaluates to false/null, makes the
     /// entire struct null.
     Struct(Vec<ExpressionRef>, Option<ExpressionRef>),
-    /// A sparse transformation of a struct schema. More efficient than `Struct` for wide schemas
+    /// A sparse patch of a struct. More efficient than `Struct` for wide schemas
     /// where only a few fields change, achieving O(changes) instead of O(schema_width) complexity.
-    Transform(Transform),
+    #[serde(alias = "Transform")]
+    StructPatch(ExpressionStructPatch),
     /// An expression that takes one expression as input.
     Unary(UnaryExpression),
     /// An expression that takes two expressions as input.
@@ -695,9 +698,9 @@ impl Expression {
         )
     }
 
-    /// Create a new transform expression
-    pub fn transform(transform: Transform) -> Self {
-        Self::Transform(transform)
+    /// Create a new struct patch expression.
+    pub fn struct_patch(patch: ExpressionStructPatch) -> Self {
+        Self::StructPatch(patch)
     }
 
     /// Create a new predicate `self IS NULL`

--- a/kernel/src/kernel_predicates/mod.rs
+++ b/kernel/src/kernel_predicates/mod.rs
@@ -180,7 +180,7 @@ pub trait KernelPredicateEvaluator {
                 self.eval_pred_expr_opaque(op, exprs, inverted)
             }
             Expr::Struct(..)
-            | Expr::Transform(_)
+            | Expr::StructPatch(_)
             | Expr::Unary(_)
             | Expr::Binary(_)
             | Expr::Variadic(_)
@@ -209,7 +209,7 @@ pub trait KernelPredicateEvaluator {
                 Expr::Column(col) => self.eval_pred_is_null(col, inverted),
                 Expr::Predicate(_)
                 | Expr::Struct(..)
-                | Expr::Transform(_)
+                | Expr::StructPatch(_)
                 | Expr::Unary(_)
                 | Expr::Binary(_)
                 | Expr::Variadic(_)
@@ -631,7 +631,7 @@ impl<R: ResolveColumnAsScalar> DefaultKernelPredicateEvaluator<R> {
             Expr::Literal(value) => Some(value.clone()),
             Expr::Column(name) => self.resolve_column(name),
             Expr::Predicate(pred) => self.eval_pred(pred, false).map(Scalar::from),
-            Expr::Struct(..) | Expr::Transform(_) | Expr::Unary(_) => None, // TODO?
+            Expr::Struct(..) | Expr::StructPatch(_) | Expr::Unary(_) => None, // TODO?
             Expr::Binary(BinaryExpression { op, left, right }) => {
                 let op_fn = match op {
                     BinaryExpressionOp::Plus => Scalar::try_add,

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -105,9 +105,9 @@ pub struct SerializableScanState {
 /// - Transformation: Applies a built-in transformation (`log_transform` or `checkpoint_transform`)
 ///   to convert selected Add actions into [`ScanMetadata`], the intermediate format passed to the
 ///   engine.
-/// - Row Transform Passthrough: Any user-provided row-level transformation expressions (e.g. those
-///   derived from projection or filters) are preserved and passed through to the engine, which
-///   applies them as part of its scan execution logic.
+/// - Row StructPatch passthrough: Any user-provided row-level transformation expressions (e.g.
+///   those derived from projection or filters) are preserved and passed through to the engine,
+///   which applies them as part of its scan execution logic.
 ///
 /// As an implementation of [`LogReplayProcessor`], [`ScanLogReplayProcessor`] provides the
 /// `process_actions_batch` method, which applies these steps to each batch of log actions and
@@ -117,10 +117,10 @@ pub struct SerializableScanState {
 #[allow(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
 pub struct ScanLogReplayProcessor {
     data_skipping_filter: Option<DataSkippingFilter>,
-    /// Transform for log batches (commit files) - uses ParseJson for stats and MapToStruct
+    /// StructPatch for log batches (commit files) - uses ParseJson for stats and MapToStruct
     /// for partition values
     log_transform: Arc<dyn ExpressionEvaluator>,
-    /// Transform for checkpoint batches - reads pre-parsed stats_parsed and
+    /// StructPatch for checkpoint batches - reads pre-parsed stats_parsed and
     /// partitionValues_parsed directly when available, otherwise parses from raw columns
     checkpoint_transform: Arc<dyn ExpressionEvaluator>,
     state_info: Arc<StateInfo>,
@@ -480,23 +480,23 @@ impl<'a, D: Deduplicator> AddRemoveDedupVisitor<'a, D> {
         }
         let base_row_id: Option<i64> =
             getters[ScanLogReplayProcessor::BASE_ROW_ID_INDEX].get_opt(row, "add.baseRowId")?;
-        let transform = self
+        let patch_expr = self
             .state_info
             .transform_spec
             .as_ref()
-            .map(|transform| {
+            .map(|transform_spec| {
                 get_transform_expr(
-                    transform,
+                    transform_spec,
                     partition_values,
                     &self.state_info.physical_schema,
                     base_row_id,
                 )
             })
             .transpose()?;
-        if transform.is_some() {
+        if patch_expr.is_some() {
             // fill in any needed `None`s for previous rows
             self.row_transform_exprs.resize_with(row, Default::default);
-            self.row_transform_exprs.push(transform);
+            self.row_transform_exprs.push(patch_expr);
         }
         self.metrics.record_active_add_file(size);
         Ok(true)
@@ -1101,26 +1101,26 @@ mod tests {
         )
         .unwrap();
 
-        fn validate_transform(transform: Option<&ExpressionRef>, expected_date_offset: i32) {
-            assert!(transform.is_some());
-            let Expr::Transform(transform) = transform.unwrap().as_ref() else {
-                panic!("Transform should always be a Transform expr");
+        fn validate_patch(patch_expr: Option<&ExpressionRef>, expected_date_offset: i32) {
+            assert!(patch_expr.is_some());
+            let Expr::StructPatch(patch) = patch_expr.unwrap().as_ref() else {
+                panic!("Expression should always be a StructPatch expr");
             };
 
-            // With sparse transforms, we expect only one insertion for the partition column
-            assert!(transform.prepended_fields.is_empty());
-            let mut field_transforms = transform.field_transforms.iter();
-            let (field_name, field_transform) = field_transforms.next().unwrap();
+            // With sparse patches, we expect only one insertion for the partition column.
+            assert!(patch.prepended_fields.is_empty());
+            let mut field_patches = patch.field_patches.iter();
+            let (field_name, field_patch) = field_patches.next().unwrap();
             assert_eq!(field_name, "value");
-            assert!(!field_transform.is_replace);
-            let [expr] = &field_transform.exprs[..] else {
+            assert!(!field_patch.is_replace);
+            let [expr] = &field_patch.exprs[..] else {
                 panic!("Expected a single insertion");
             };
             let Expr::Literal(Scalar::Date(date_offset)) = expr.as_ref() else {
                 panic!("Expected a literal date");
             };
             assert_eq!(*date_offset, expected_date_offset);
-            assert!(field_transforms.next().is_none());
+            assert!(field_patches.next().is_none());
         }
 
         for res in iter {
@@ -1131,13 +1131,13 @@ mod tests {
             assert_eq!(transforms.len(), 4, "Should have 4 transforms");
             assert!(transforms[0].is_none(), "transform at [0] should be None");
             assert!(transforms[2].is_none(), "transform at [2] should be None");
-            validate_transform(transforms[1].as_ref(), 17511);
-            validate_transform(transforms[3].as_ref(), 17510);
+            validate_patch(transforms[1].as_ref(), 17511);
+            validate_patch(transforms[3].as_ref(), 17510);
         }
     }
 
     #[test]
-    fn test_row_id_transform() {
+    fn test_row_id_patch() {
         let schema: SchemaRef = Arc::new(StructType::new_unchecked([StructField::new(
             "value",
             DataType::INTEGER,
@@ -1190,15 +1190,15 @@ mod tests {
             let scan_metadata = res.unwrap();
             let transforms = scan_metadata.scan_file_transforms;
             assert_eq!(transforms.len(), 1, "Should have 1 transform");
-            if let Some(Expr::Transform(transform_expr)) = transforms[0].as_ref().map(Arc::as_ref) {
-                assert!(transform_expr.input_path.is_none());
-                let row_id_transform = transform_expr
-                    .field_transforms
+            if let Some(Expr::StructPatch(patch)) = transforms[0].as_ref().map(Arc::as_ref) {
+                assert!(patch.input_path.is_none());
+                let row_id_patch = patch
+                    .field_patches
                     .get("row_id_col")
-                    .expect("Should have row_id_col transform");
-                assert!(row_id_transform.is_replace);
-                assert_eq!(row_id_transform.exprs.len(), 1);
-                let expr = &row_id_transform.exprs[0];
+                    .expect("Should have row_id_col patch");
+                assert!(row_id_patch.is_replace);
+                assert_eq!(row_id_patch.exprs.len(), 1);
+                let expr = &row_id_patch.exprs[0];
                 let expeceted_expr = Arc::new(Expr::coalesce([
                     Expr::column(["row_id_col"]),
                     Expr::binary(
@@ -1209,7 +1209,7 @@ mod tests {
                 ]));
                 assert_eq!(expr, &expeceted_expr);
             } else {
-                panic!("Should have been a transform expression");
+                panic!("Should have been a StructPatch expression");
             }
         }
     }

--- a/kernel/src/scan/transform_spec.rs
+++ b/kernel/src/scan/transform_spec.rs
@@ -1,8 +1,8 @@
 //! Transform-related types and utilities for Delta Kernel.
 //!
-//! This module contains the types and functions needed to handle transforms
-//! during scan and table changes operations, including partition value processing
-//! and expression generation.
+//! This module contains specs and helpers for translating physical file data into the logical scan
+//! output shape, including partition value processing and expression generation. The current
+//! implementation lowers those specs into `Expression::StructPatch` expressions.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -10,19 +10,26 @@ use std::sync::Arc;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
-use crate::expressions::{BinaryExpressionOp, Expression, ExpressionRef, Scalar, Transform};
+use crate::expressions::{
+    BinaryExpressionOp, Expression, ExpressionRef, ExpressionStructPatch, Scalar,
+};
 use crate::schema::{DataType, SchemaRef, StructType};
 use crate::table_features::ColumnMappingMode;
 use crate::{DeltaResult, Error};
 
-/// A list of field transforms that describes a transform expression to be created at scan time.
+/// A list of field transforms used to convert physical file data to logical scan output.
+// TODO: Rename this physical-to-logical read fixup concept in a follow-up PR. "Transform" used to
+// refer partly to the `Expression::Transform` implementation detail (now
+// `Expression::StructPatch`), but also to the fact that this spec describes how to transform
+// physical file data into logical scan output. Neither "transform" nor "patch" is an ideal
+// description for that concept.
 pub(crate) type TransformSpec = Vec<FieldTransformSpec>;
 
 /// Describes a single field transformation to apply when converting physical data to logical
 /// schema.
 ///
-/// These transformations are "sparse" - they only specify what changes, while unchanged fields
-/// pass through implicitly in their original order.
+/// These transformations are sparse: they only specify what changes, while unchanged fields pass
+/// through implicitly in their original order.
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub(crate) enum FieldTransformSpec {
     /// Insert the given expression after the named input column (None = prepend instead)
@@ -109,26 +116,26 @@ pub(crate) fn parse_partition_values(
         .try_collect()
 }
 
-/// Build a transform expression that converts physical data to the logical schema.
+/// Build an expression that converts physical data to the logical schema.
 ///
 /// An empty `transform_spec` is valid and represents the case where only column mapping is needed.
-/// The resulting empty `Expression::Transform` will pass all input fields through unchanged
-/// while applying the output schema for name mapping.
+/// The resulting empty `Expression::StructPatch` passes all input fields through unchanged while
+/// applying the output schema for name mapping.
 pub(crate) fn get_transform_expr(
     transform_spec: &TransformSpec,
     mut metadata_values: HashMap<usize, (String, Scalar)>,
     physical_schema: &StructType,
     base_row_id: Option<i64>,
 ) -> DeltaResult<ExpressionRef> {
-    let mut transform = Transform::new_top_level();
+    let mut patch = ExpressionStructPatch::new_top_level();
 
     for field_transform in transform_spec {
         use FieldTransformSpec::*;
-        transform = match field_transform {
+        patch = match field_transform {
             StaticInsert { insert_after, expr } => {
-                transform.with_inserted_field(insert_after.clone(), expr.clone())
+                patch.with_inserted_field(insert_after.clone(), expr.clone())
             }
-            StaticDrop { field_name } => transform.with_dropped_field(field_name.clone()),
+            StaticDrop { field_name } => patch.with_dropped_field(field_name.clone()),
             GenerateRowId {
                 field_name,
                 row_index_field_name,
@@ -144,7 +151,7 @@ pub(crate) fn get_transform_expr(
                         Expression::column([row_index_field_name]),
                     ),
                 ]));
-                transform.with_replaced_field(field_name.clone(), expr)
+                patch.with_replaced_field(field_name.clone(), expr)
             }
             MetadataDerivedColumn {
                 field_index,
@@ -157,7 +164,7 @@ pub(crate) fn get_transform_expr(
                 };
 
                 let partition_value = Arc::new(partition_value.into());
-                transform.with_inserted_field(insert_after.clone(), partition_value)
+                patch.with_inserted_field(insert_after.clone(), partition_value)
             }
             DynamicColumn {
                 field_index,
@@ -170,13 +177,13 @@ pub(crate) fn get_transform_expr(
                 if exists_physically {
                     // Column exists physically - reorder it via drop+insert
                     // This ensures consistent column ordering across file types
-                    transform = transform
+                    patch = patch
                         .with_dropped_field(physical_name.clone())
                         .with_inserted_field(
                             insert_after.clone(),
                             Arc::new(Expression::column([physical_name.clone()])),
                         );
-                    transform
+                    patch
                 } else {
                     // Column doesn't exist physically - treat as partition column
                     let Some((_, partition_value)) = metadata_values.remove(field_index) else {
@@ -186,13 +193,13 @@ pub(crate) fn get_transform_expr(
                     };
 
                     let partition_value = Arc::new(partition_value.into());
-                    transform.with_inserted_field(insert_after.clone(), partition_value)
+                    patch.with_inserted_field(insert_after.clone(), partition_value)
                 }
             }
         }
     }
 
-    Ok(Arc::new(Expression::Transform(transform)))
+    Ok(Arc::new(Expression::StructPatch(patch)))
 }
 
 /// Parse a partition value from the raw string representation
@@ -386,24 +393,23 @@ mod tests {
         )
         .unwrap();
 
-        let Expression::Transform(transform) = result.as_ref() else {
-            panic!("Expected Transform expression");
+        let Expression::StructPatch(patch) = result.as_ref() else {
+            panic!("Expected StructPatch expression");
         };
 
         // Verify StaticInsert: should insert after col1
-        assert!(transform.field_transforms.contains_key("col1"));
-        assert!(!transform.field_transforms["col1"].is_replace);
-        assert_eq!(transform.field_transforms["col1"].exprs.len(), 1);
-        let Expression::Literal(scalar) = transform.field_transforms["col1"].exprs[0].as_ref()
-        else {
+        assert!(patch.field_patches.contains_key("col1"));
+        assert!(!patch.field_patches["col1"].is_replace);
+        assert_eq!(patch.field_patches["col1"].exprs.len(), 1);
+        let Expression::Literal(scalar) = patch.field_patches["col1"].exprs[0].as_ref() else {
             panic!("Expected literal expression for insert");
         };
         assert_eq!(scalar, &Scalar::Integer(42));
 
         // Verify StaticDrop: should drop col2 (empty expressions and is_replace = true)
-        assert!(transform.field_transforms.contains_key("col2"));
-        assert!(transform.field_transforms["col2"].is_replace);
-        assert!(transform.field_transforms["col2"].exprs.is_empty());
+        assert!(patch.field_patches.contains_key("col2"));
+        assert!(patch.field_patches["col2"].is_replace);
+        assert!(patch.field_patches["col2"].exprs.is_empty());
     }
 
     #[test]
@@ -427,23 +433,22 @@ mod tests {
             &physical_schema,
             None, /* base_row_id */
         );
-        let transform_expr = result.expect("Transform expression should be created successfully");
+        let patch_expr = result.expect("StructPatch expression should be created successfully");
 
-        let Expression::Transform(transform) = transform_expr.as_ref() else {
-            panic!("Expected Transform expression");
+        let Expression::StructPatch(patch) = patch_expr.as_ref() else {
+            panic!("Expected StructPatch expression");
         };
 
         // Should drop _change_type and insert it after id
-        assert!(transform.field_transforms.contains_key("_change_type"));
-        assert!(transform.field_transforms["_change_type"].is_replace);
-        assert!(transform.field_transforms["_change_type"].exprs.is_empty());
+        assert!(patch.field_patches.contains_key("_change_type"));
+        assert!(patch.field_patches["_change_type"].is_replace);
+        assert!(patch.field_patches["_change_type"].exprs.is_empty());
 
-        assert!(transform.field_transforms.contains_key("id"));
-        assert!(!transform.field_transforms["id"].is_replace);
-        assert_eq!(transform.field_transforms["id"].exprs.len(), 1);
+        assert!(patch.field_patches.contains_key("id"));
+        assert!(!patch.field_patches["id"].is_replace);
+        assert_eq!(patch.field_patches["id"].exprs.len(), 1);
 
-        let Expression::Column(column_name) = transform.field_transforms["id"].exprs[0].as_ref()
-        else {
+        let Expression::Column(column_name) = patch.field_patches["id"].exprs[0].as_ref() else {
             panic!("Expected column reference");
         };
         assert_eq!(column_name.as_ref(), &["_change_type"]);
@@ -475,21 +480,21 @@ mod tests {
             &physical_schema,
             None, /* base_row_id */
         );
-        let transform_expr = result.expect("Transform expression should be created successfully");
+        let patch_expr = result.expect("StructPatch expression should be created successfully");
 
-        let Expression::Transform(transform) = transform_expr.as_ref() else {
-            panic!("Expected Transform expression");
+        let Expression::StructPatch(patch) = patch_expr.as_ref() else {
+            panic!("Expected StructPatch expression");
         };
 
         // Should not drop _change_type (doesn't exist physically) and insert metadata value after
         // id
-        assert!(!transform.field_transforms.contains_key("_change_type"));
+        assert!(!patch.field_patches.contains_key("_change_type"));
 
-        assert!(transform.field_transforms.contains_key("id"));
-        assert!(!transform.field_transforms["id"].is_replace);
-        assert_eq!(transform.field_transforms["id"].exprs.len(), 1);
+        assert!(patch.field_patches.contains_key("id"));
+        assert!(!patch.field_patches["id"].is_replace);
+        assert_eq!(patch.field_patches["id"].exprs.len(), 1);
 
-        let Expression::Literal(scalar) = transform.field_transforms["id"].exprs[0].as_ref() else {
+        let Expression::Literal(scalar) = patch.field_patches["id"].exprs[0].as_ref() else {
             panic!("Expected literal");
         };
         assert_eq!(scalar, &Scalar::String("insert".to_string()));
@@ -513,18 +518,18 @@ mod tests {
             &physical_schema,
             None, /* base_row_id */
         );
-        let transform_expr = result.expect("Transform expression should be created successfully");
+        let patch_expr = result.expect("StructPatch expression should be created successfully");
 
-        let Expression::Transform(transform) = transform_expr.as_ref() else {
-            panic!("Expected Transform expression");
+        let Expression::StructPatch(patch) = patch_expr.as_ref() else {
+            panic!("Expected StructPatch expression");
         };
 
         // Should insert metadata value after id
-        assert!(transform.field_transforms.contains_key("id"));
-        assert!(!transform.field_transforms["id"].is_replace);
-        assert_eq!(transform.field_transforms["id"].exprs.len(), 1);
+        assert!(patch.field_patches.contains_key("id"));
+        assert!(!patch.field_patches["id"].is_replace);
+        assert_eq!(patch.field_patches["id"].exprs.len(), 1);
 
-        let Expression::Literal(scalar) = transform.field_transforms["id"].exprs[0].as_ref() else {
+        let Expression::Literal(scalar) = patch.field_patches["id"].exprs[0].as_ref() else {
             panic!("Expected literal");
         };
         assert_eq!(scalar, &Scalar::Integer(2024));
@@ -576,18 +581,18 @@ mod tests {
             &physical_schema,
             Some(4), /* base_row_id */
         );
-        let transform_expr = result.expect("Transform expression should be created successfully");
+        let patch_expr = result.expect("StructPatch expression should be created successfully");
 
-        let Expression::Transform(transform) = transform_expr.as_ref() else {
-            panic!("Expected Transform expression");
+        let Expression::StructPatch(patch) = patch_expr.as_ref() else {
+            panic!("Expected StructPatch expression");
         };
 
-        assert!(transform.input_path.is_none());
-        let row_id_transform = transform
-            .field_transforms
+        assert!(patch.input_path.is_none());
+        let row_id_patch = patch
+            .field_patches
             .get("row_id_col")
-            .expect("Should have row_id_col transform");
-        assert!(row_id_transform.is_replace);
+            .expect("Should have row_id_col patch");
+        assert!(row_id_patch.is_replace);
 
         let expeceted_expr = Arc::new(Expression::coalesce([
             Expression::column(["row_id_col"]),
@@ -597,8 +602,8 @@ mod tests {
                 Expression::column(["row_index_col"]),
             ),
         ]));
-        assert_eq!(row_id_transform.exprs.len(), 1);
-        let expr = &row_id_transform.exprs[0];
+        assert_eq!(row_id_patch.exprs.len(), 1);
+        let expr = &row_id_patch.exprs[0];
         assert_eq!(expr, &expeceted_expr);
     }
 

--- a/kernel/src/table_changes/physical_to_logical.rs
+++ b/kernel/src/table_changes/physical_to_logical.rs
@@ -73,7 +73,7 @@ pub(crate) fn scan_file_physical_schema(
 
 // Get the transform expression for a CDF scan file
 //
-// Returns None when no transformation is needed (identity transform), otherwise returns Some(expr).
+// Returns None when no transformation is needed, otherwise returns Some(expr).
 //
 // Note: parse_partition_values returns null values for missing partition columns,
 // and CDF metadata columns (commit_timestamp, commit_version, change_type) are then
@@ -98,7 +98,7 @@ pub(crate) fn get_cdf_transform_expr(
         .map(|ts| ts.as_ref())
         .unwrap_or(&empty_spec);
 
-    // Return None for identity transforms to avoid unnecessary expression evaluation
+    // Return None for an empty transform spec to avoid unnecessary expression evaluation.
     if transform_spec.is_empty() {
         return Ok(None);
     }
@@ -221,24 +221,24 @@ mod tests {
         let expr_opt = result.unwrap();
         assert!(expr_opt.is_some(), "Expected Some(expr) but got None");
         let expr = expr_opt.unwrap();
-        let Expression::Transform(transform) = expr.as_ref() else {
-            panic!("Expected Transform expression");
+        let Expression::StructPatch(patch) = expr.as_ref() else {
+            panic!("Expected StructPatch expression");
         };
 
-        // Should have transform for "id" field with CDF metadata
-        assert!(transform.field_transforms.contains_key("id"));
-        let id_transform = &transform.field_transforms["id"];
-        assert!(!id_transform.is_replace);
-        assert_eq!(id_transform.exprs.len(), 2);
+        // Should have a patch for the "id" field with CDF metadata
+        assert!(patch.field_patches.contains_key("id"));
+        let id_patch = &patch.field_patches["id"];
+        assert!(!id_patch.is_replace);
+        assert_eq!(id_patch.exprs.len(), 2);
 
         // Verify _change_type is "insert" for Add files
-        let Expression::Literal(change_type) = id_transform.exprs[0].as_ref() else {
+        let Expression::Literal(change_type) = id_patch.exprs[0].as_ref() else {
             panic!("Expected literal for _change_type");
         };
         assert_eq!(change_type, &Scalar::String("insert".to_string()));
 
         // Verify _commit_version
-        let Expression::Literal(version) = id_transform.exprs[1].as_ref() else {
+        let Expression::Literal(version) = id_patch.exprs[1].as_ref() else {
             panic!("Expected literal for _commit_version");
         };
         assert_eq!(version, &Scalar::Long(100));
@@ -267,15 +267,15 @@ mod tests {
         let expr_opt = result.unwrap();
         assert!(expr_opt.is_some(), "Expected Some(expr) but got None");
         let expr = expr_opt.unwrap();
-        let Expression::Transform(transform) = expr.as_ref() else {
-            panic!("Expected Transform expression");
+        let Expression::StructPatch(patch) = expr.as_ref() else {
+            panic!("Expected StructPatch expression");
         };
 
-        let name_transform = &transform.field_transforms["name"];
-        assert_eq!(name_transform.exprs.len(), 1);
+        let name_patch = &patch.field_patches["name"];
+        assert_eq!(name_patch.exprs.len(), 1);
 
         // Verify _change_type is "delete" for Remove files
-        let Expression::Literal(change_type) = name_transform.exprs[0].as_ref() else {
+        let Expression::Literal(change_type) = name_patch.exprs[0].as_ref() else {
             panic!("Expected literal for _change_type");
         };
         assert_eq!(change_type, &Scalar::String("delete".to_string()));
@@ -316,14 +316,14 @@ mod tests {
         let expr_opt = result.unwrap();
         assert!(expr_opt.is_some(), "Expected Some(expr) but got None");
         let expr = expr_opt.unwrap();
-        let Expression::Transform(transform) = expr.as_ref() else {
-            panic!("Expected Transform expression");
+        let Expression::StructPatch(patch) = expr.as_ref() else {
+            panic!("Expected StructPatch expression");
         };
 
         // Should have age partition value
-        let id_transform = &transform.field_transforms["id"];
-        assert_eq!(id_transform.exprs.len(), 1);
-        let Expression::Literal(age_value) = id_transform.exprs[0].as_ref() else {
+        let id_patch = &patch.field_patches["id"];
+        assert_eq!(id_patch.exprs.len(), 1);
+        let Expression::Literal(age_value) = id_patch.exprs[0].as_ref() else {
             panic!("Expected literal for age");
         };
         assert_eq!(age_value, &Scalar::Long(30));
@@ -331,11 +331,11 @@ mod tests {
         // For CDC files with DynamicColumn, _change_type is handled as physical
         // The transform spec has DynamicColumn which becomes a Column expression for CDC files
         // (not a literal metadata value)
-        let name_transform = &transform.field_transforms["name"];
-        assert_eq!(name_transform.exprs.len(), 1);
+        let name_patch = &patch.field_patches["name"];
+        assert_eq!(name_patch.exprs.len(), 1);
         // Should be a Column expression, not a Literal
         assert!(matches!(
-            name_transform.exprs[0].as_ref(),
+            name_patch.exprs[0].as_ref(),
             Expression::Column(_)
         ));
     }
@@ -376,7 +376,7 @@ mod tests {
     #[test]
     fn test_get_cdf_transform_expr_returns_none_for_identity() {
         // When there's no transform spec and no CDF metadata columns in the schema,
-        // the function should return None (identity transform)
+        // the function should return None.
         let scan_file = CdfScanFile {
             path: "test/file.parquet".to_string(),
             partition_values: HashMap::new(),
@@ -399,7 +399,7 @@ mod tests {
             StructField::nullable("name", DataType::STRING),
         ]);
 
-        // Empty transform spec - no transformations needed
+        // Empty transform spec - no transformation needed.
         let transform_spec = vec![];
 
         let state_info = StateInfo {
@@ -419,7 +419,7 @@ mod tests {
         let expr_opt = result.unwrap();
         assert!(
             expr_opt.is_none(),
-            "Expected None for identity transform but got Some(expr)"
+            "Expected None for empty transform spec but got Some(expr)"
         );
     }
 }

--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -277,7 +277,7 @@ fn read_scan_file(
 
     let result = read_result_iter.map(move |batch| -> DeltaResult<_> {
         let batch = batch?;
-        // Transform the physical data into the correct logical form, or pass through unchanged
+        // Transform the physical data into the correct logical form, or pass through unchanged.
         let logical = if let Some(ref eval) = phys_to_logical_eval {
             eval.evaluate(batch.as_ref())
         } else {

--- a/kernel/src/transaction/commit_info.rs
+++ b/kernel/src/transaction/commit_info.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use super::Transaction;
 use crate::actions::{get_log_commit_info_schema, CommitInfo, COMMIT_INFO_NAME};
-use crate::expressions::{MapData, Scalar, Transform};
+use crate::expressions::{ExpressionStructPatch, MapData, Scalar};
 use crate::schema::{MapType, StructField, StructType, ToSchema};
 use crate::{DataType, Engine, EngineData, Error, Expression, ExpressionRef, IntoEngineData};
 
@@ -91,32 +91,33 @@ impl<S> Transaction<S> {
                 // Step 2: Build literal expressions for each CommitInfo field.
                 let literal_exprs = commit_info_literal_exprs(kernel_commit_info)?;
 
-                // Step 3: Build Transform. Replacements must be registered before insertions so
-                // that for the last engine field (which may itself be replaced), exprs is ordered
-                // as [replace_expr, insert_exprs...]. The evaluator emits exprs in declaration
-                // order, so the replace value must come first.
+                // Step 3: Build ExpressionStructPatch. Replacements must be registered before
+                // insertions so that for the last engine field (which may itself be
+                // replaced), exprs is ordered as [replace_expr, insert_exprs...].
+                // The evaluator emits exprs in declaration order, so the replace
+                // value must come first.
                 let last_engine_field = engine_commit_info_schema.field_names().last().cloned();
-                let mut transform = Transform::new_top_level();
+                let mut patch = ExpressionStructPatch::new_top_level();
 
                 // First pass: replace fields that already exist in the engine schema.
                 for (field_name, expr_ref) in &literal_exprs {
                     if engine_commit_info_schema.contains(*field_name) {
-                        transform = transform.with_replaced_field(*field_name, expr_ref.clone());
+                        patch = patch.with_replaced_field(*field_name, expr_ref.clone());
                     }
                 }
                 // Second pass: append kernel-only fields after the last engine field.
                 for (field_name, expr_ref) in &literal_exprs {
                     if !engine_commit_info_schema.contains(*field_name) {
-                        transform = transform
+                        patch = patch
                             .with_inserted_field(last_engine_field.as_deref(), expr_ref.clone());
                     }
                 }
 
-                // Step 4: Wrap the transform in a struct expression so the output matches the
+                // Step 4: Wrap the patch in a struct expression so the output matches the
                 // Delta log action format `{ "commitInfo": { merged fields... } }`, consistent
                 // with the None branch which uses `get_log_commit_info_schema()`.
                 let wrapped_expr =
-                    Expression::struct_from([Arc::new(Expression::transform(transform))]);
+                    Expression::struct_from([Arc::new(Expression::struct_patch(patch))]);
                 let wrapped_schema = Arc::new(StructType::new_unchecked([StructField::nullable(
                     COMMIT_INFO_NAME,
                     output_schema,

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -1385,7 +1385,7 @@ impl<S> Transaction<S> {
     }
 }
 
-/// Builds the transform expression for converting scan row metadata into a Remove action.
+/// Builds the struct patch for converting scan row metadata into a Remove action.
 ///
 /// Handles two "parsed" columns that predicate-based scans add to scan metadata:
 ///
@@ -1396,7 +1396,7 @@ impl<S> Transaction<S> {
 /// - `partitionValues_parsed`: dropped if present. Unlike stats, no reconstruction is needed: the
 ///   Remove action's `partitionValues` is sourced from `fileConstantValues.partitionValues`, which
 ///   scans always populate from `add.partitionValues`.
-fn build_remove_transform(
+fn build_remove_struct_patch(
     commit_timestamp: i64,
     data_change: bool,
     columns_to_drop: &[&str],
@@ -1964,7 +1964,7 @@ mod tests {
             "Partition column 'letter' should be dropped. Expression: {expr_str}"
         );
 
-        // With materializePartitionColumns, no columns should be dropped (identity transform)
+        // With materializePartitionColumns, no columns should be dropped (empty patch)
         let (snap_with, wc_with) = snapshot_and_partitioned_write_context(
             "./tests/data/partitioned_with_materialize_feature/",
         )?;

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -19,7 +19,7 @@ use crate::crc::{is_incremental_safe_operation, CrcDelta, FileStatsDelta, LazyCr
 use crate::engine_data::FilteredEngineData;
 use crate::error::Error;
 use crate::expressions::UnaryExpressionOp::ToJson;
-use crate::expressions::{ArrayData, ColumnName, Scalar, Transform};
+use crate::expressions::{ArrayData, ColumnName, ExpressionStructPatch, Scalar};
 use crate::log_segment::LogSegment;
 use crate::partition::serialization::serialize_partition_value;
 use crate::partition::validation::validate_partition_values;
@@ -302,8 +302,8 @@ where
 {
     let evaluation_handler = engine.evaluation_handler();
     add_files_metadata.map(move |add_files_batch| {
-        let transform = Expression::transform(
-            Transform::new_top_level()
+        let patch_expr = Expression::struct_patch(
+            ExpressionStructPatch::new_top_level()
                 .with_inserted_field(
                     Some("modificationTime"),
                     Expression::literal(data_change).into(),
@@ -313,7 +313,7 @@ where
                     Expression::unary(ToJson, Expression::column(["stats"])).into(),
                 ),
         );
-        let adds_expr = Expression::struct_from([transform]);
+        let adds_expr = Expression::struct_from([patch_expr]);
         let adds_evaluator = evaluation_handler.new_expression_evaluator(
             input_schema.clone(),
             Arc::new(adds_expr),
@@ -881,15 +881,15 @@ impl<S: SupportsDataFiles> Transaction<S> {
         let should_materialize_partition_columns = self
             .effective_table_config
             .should_materialize_partition_columns();
-        // Build a Transform expression that drops partition columns from the input
+        // Build a StructPatch expression that drops partition columns from the input
         // (unless they should be materialized).
-        let mut transform = Transform::new_top_level();
+        let mut patch = ExpressionStructPatch::new_top_level();
         if !should_materialize_partition_columns {
             for col in &partition_cols {
-                transform = transform.with_dropped_field_if_exists(col);
+                patch = patch.with_dropped_field_if_exists(col);
             }
         }
-        Expression::transform(transform)
+        Expression::struct_patch(patch)
     }
 
     /// Returns the logical partition column names for this table.
@@ -1346,13 +1346,13 @@ impl<S> Transaction<S> {
         let evaluation_handler = engine.evaluation_handler();
 
         let make_eval = |coalesce_stats_with_parsed: bool| -> DeltaResult<_> {
-            let transform = build_remove_transform(
+            let patch = build_remove_struct_patch(
                 self.commit_timestamp,
                 self.data_change,
                 columns_to_drop,
                 coalesce_stats_with_parsed,
             );
-            let expr = Arc::new(Expression::struct_from([Expression::transform(transform)]));
+            let expr = Arc::new(Expression::struct_from([Expression::struct_patch(patch)]));
             evaluation_handler.new_expression_evaluator(
                 input_schema.clone(),
                 expr,
@@ -1401,8 +1401,8 @@ fn build_remove_transform(
     data_change: bool,
     columns_to_drop: &[&str],
     coalesce_stats_with_parsed: bool,
-) -> Transform {
-    let mut transform = Transform::new_top_level()
+) -> ExpressionStructPatch {
+    let mut patch = ExpressionStructPatch::new_top_level()
         // deletionTimestamp
         .with_inserted_field(Some("path"), Expression::literal(commit_timestamp).into())
         // dataChange
@@ -1416,13 +1416,13 @@ fn build_remove_transform(
 
     if coalesce_stats_with_parsed {
         // Replace stats with COALESCE(stats, TO_JSON(stats_parsed)), then insert tags after.
-        // Both expressions are registered on the "stats" field_transform (is_replace=true),
+        // Both expressions are registered on the "stats" field_patch (is_replace=true),
         // so the evaluator emits [coalesced_stats, tags] in place of the original stats field.
         let coalesce_stats = Expression::coalesce([
             Expression::column(["stats"]),
             Expression::unary(ToJson, Expression::column([STATS_PARSED_NAME])),
         ]);
-        transform = transform
+        patch = patch
             .with_replaced_field("stats", coalesce_stats.into())
             .with_inserted_field(
                 Some("stats"),
@@ -1431,13 +1431,13 @@ fn build_remove_transform(
             .with_dropped_field_if_exists(STATS_PARSED_NAME);
     } else {
         // tags inserted after stats; stats passes through unchanged
-        transform = transform.with_inserted_field(
+        patch = patch.with_inserted_field(
             Some("stats"),
             Expression::column([FILE_CONSTANT_VALUES_NAME, TAGS_NAME]).into(),
         );
     }
 
-    transform = transform
+    patch = patch
         .with_inserted_field(
             Some("deletionVector"),
             Expression::column([FILE_CONSTANT_VALUES_NAME, BASE_ROW_ID_NAME]).into(),
@@ -1452,10 +1452,10 @@ fn build_remove_transform(
         .with_dropped_field_if_exists(PARTITION_VALUES_PARSED_NAME);
 
     for column_to_drop in columns_to_drop {
-        transform = transform.with_dropped_field(*column_to_drop);
+        patch = patch.with_dropped_field(*column_to_drop);
     }
 
-    transform
+    patch
 }
 
 /// Kernel exposes information about the state of the table that engines might want to use to

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -24,7 +24,9 @@ use crate::engine_data::{
     FilteredEngineData, FilteredRowVisitor, GetData, RowIndexIterator, TypedGetData,
 };
 use crate::error::Error;
-use crate::expressions::{column_name, ArrayData, ColumnName, Scalar, StructData, Transform};
+use crate::expressions::{
+    column_name, ArrayData, ColumnName, ExpressionStructPatch, Scalar, StructData,
+};
 use crate::scan::data_skipping::stats_schema::schema_with_all_fields_nullable;
 use crate::scan::log_replay::get_scan_metadata_transform_expr;
 use crate::scan::{restored_add_schema, scan_row_schema};
@@ -469,13 +471,13 @@ impl<S> Transaction<S> {
         file_metadata_batch: impl Iterator<Item = &'a FilteredEngineData> + Send + 'a,
     ) -> DeltaResult<impl Iterator<Item = DeltaResult<FilteredEngineData>> + Send + 'a> {
         let evaluation_handler = engine.evaluation_handler();
-        // Transform to replace the deletionVector field with the new DV from
+        // Struct patch to replace the deletionVector field with the new DV from
         // NEW_DELETION_VECTOR_NAME, then drop the NEW_DELETION_VECTOR_NAME column. The
         // engine data has this temporary column appended by update_deletion_vectors(), but
         // it is not expected by the transforms used in generate_remove_actions() which
         // expect only the scan row schema fields.
-        let with_new_dv_transform = Expression::transform(
-            Transform::new_top_level()
+        let with_new_dv_expr = Expression::struct_patch(
+            ExpressionStructPatch::new_top_level()
                 .with_replaced_field(
                     "deletionVector",
                     Expression::column([NEW_DELETION_VECTOR_NAME]).into(),
@@ -484,7 +486,7 @@ impl<S> Transaction<S> {
         );
         let with_new_dv_eval = evaluation_handler.new_expression_evaluator(
             intermediate_dv_schema().clone(),
-            Arc::new(with_new_dv_transform),
+            Arc::new(with_new_dv_expr),
             nullable_scan_rows_schema().clone().into(),
         )?;
         let restored_add_eval = evaluation_handler.new_expression_evaluator(
@@ -492,16 +494,15 @@ impl<S> Transaction<S> {
             get_scan_metadata_transform_expr(),
             nullable_restored_add_schema().clone().into(),
         )?;
-        let with_data_change_transform =
-            Arc::new(Expression::struct_from([Expression::transform(
-                Transform::new_nested(["add"]).with_inserted_field(
-                    Some("modificationTime"),
-                    Expression::literal(self.data_change).into(),
-                ),
-            )]));
+        let with_data_change_expr = Arc::new(Expression::struct_from([Expression::struct_patch(
+            ExpressionStructPatch::new_nested(["add"]).with_inserted_field(
+                Some("modificationTime"),
+                Expression::literal(self.data_change).into(),
+            ),
+        )]));
         let with_data_change_eval = evaluation_handler.new_expression_evaluator(
             nullable_restored_add_schema().clone(),
-            with_data_change_transform,
+            with_data_change_expr,
             nullable_add_log_schema().clone().into(),
         )?;
         Ok(file_metadata_batch.map(

--- a/kernel/src/transforms/expression.rs
+++ b/kernel/src/transforms/expression.rs
@@ -2,9 +2,10 @@ use std::borrow::{Cow, ToOwned};
 use std::sync::Arc;
 
 use crate::expressions::{
-    BinaryExpression, BinaryPredicate, ColumnName, Expression, ExpressionRef, JunctionPredicate,
-    MapToStructExpression, OpaqueExpression, OpaquePredicate, ParseJsonExpression, Predicate,
-    Scalar, Transform, UnaryExpression, UnaryPredicate, VariadicExpression,
+    BinaryExpression, BinaryPredicate, ColumnName, Expression, ExpressionRef,
+    ExpressionStructPatch, JunctionPredicate, MapToStructExpression, OpaqueExpression,
+    OpaquePredicate, ParseJsonExpression, Predicate, Scalar, UnaryExpression, UnaryPredicate,
+    VariadicExpression,
 };
 use crate::transforms::{
     map_owned_children_or_else, map_owned_or_else, map_owned_pair_or_else, transform_output_type,
@@ -230,9 +231,9 @@ pub trait ExpressionTransform<'a> {
                 let map_owned = |exprs| Expression::Struct(exprs, nullability.clone());
                 map_owned_or_else(expr, self.transform_expr_struct(s), map_owned)
             }
-            Expression::Transform(t) => {
-                let child = self.transform_expr_transform(t);
-                map_owned_or_else(expr, child, Expression::Transform)
+            Expression::StructPatch(t) => {
+                let child = self.transform_expr_struct_patch(t);
+                map_owned_or_else(expr, child, Expression::StructPatch)
             }
             Expression::Unary(u) => {
                 let child = self.transform_expr_unary(u);

--- a/kernel/src/transforms/expression.rs
+++ b/kernel/src/transforms/expression.rs
@@ -111,11 +111,14 @@ pub trait ExpressionTransform<'a> {
         Carrier::from_inner(Cow::Borrowed(name))
     }
 
-    /// Called for each transform expression encountered during the traversal (leaf).
+    /// Called for each struct patch expression encountered during the traversal (leaf).
     ///
     /// The provided implementation does _NOT_ recurse into its children.
-    fn transform_expr_transform(&mut self, transform: &'a Transform) -> Self::Output<Transform> {
-        Carrier::from_inner(Cow::Borrowed(transform))
+    fn transform_expr_struct_patch(
+        &mut self,
+        patch: &'a ExpressionStructPatch,
+    ) -> Self::Output<ExpressionStructPatch> {
+        Carrier::from_inner(Cow::Borrowed(patch))
     }
 
     /// Called for each parse-json expression encountered during the traversal. The provided


### PR DESCRIPTION
## What changes are proposed in this pull request?

`Expression::Transform` and `ExpressionTransform` have very similar names but are not at all the same thing. Rename the former as `Expression::StructPatch` to clearly differentiate it from a recursive transform. Also change nomenclature from "identity transform" to "empty patch" as more readable.

NOTE: Future work will introduce a `SchemaStructPatch` that can describe sparse changes to fields of a schema in the same way that `ExpressionStructPatch` can describe sparse changes to fields of a projected struct. 

### This PR affects the following public APIs

Several closely related renames: 
* `Expression::Transform` -> `Expression::StructPatch`
* `Expression::transform` -> `Expression::struct_patch`
* `Transform` -> `ExpressionStructPatch`
* `Transform::is_identity` -> `ExpressionStructPatch::is_empty`
* `Transform::field_transform` -> `ExpressionStructPatch::field_patch`
* `FieldTransform` -> `ExpressionFieldPatch`
* `ExpressionTransform::transform_expr_transform` -> `ExpressionTransform::transform_expr_struct_patch`

## How was this change tested?

Renaming operation. Updating call sites so they compile suffices.