### PR TITLE
refactor!: rename Plan enum to Operation

### DIFF
--- a/kernel/src/engine/plans/json.rs
+++ b/kernel/src/engine/plans/json.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use url::Url;
 
-use crate::plans::{Plan, PlanExecutor, QueryPlanBuilder};
+use crate::plans::{Operation, PlanExecutor, QueryPlanBuilder};
 use crate::schema::SchemaRef;
 use crate::{
     DeltaResult, DeltaResultIterator, EngineData, Error, FileDataReadResultIterator, FileMeta,
@@ -44,7 +44,7 @@ impl JsonHandler for PlanBasedJsonHandler {
         let query =
             QueryPlanBuilder::scan_json(files.to_vec(), physical_schema, predicate).build()?;
         self.executor
-            .execute_plan(Plan::QueryPlan(query))?
+            .execute_op(Operation::QueryPlan(query))?
             .into_data()
     }
 

--- a/kernel/src/engine/plans/mod.rs
+++ b/kernel/src/engine/plans/mod.rs
@@ -3,8 +3,8 @@
 //! (e.g. storage, JSON, parquet) to declarative plan execution rather than implementing
 //! each handler independently.
 //!
-//! This allows a PlanExecutor to become the single surface for connector optimizations, while
-//! still allowing kernel to use existing Engine trait APIs.
+//! This allows a PlanExecutor to become the single surface for connector optimizations,
+//! while still allowing kernel to use existing Engine trait APIs.
 
 use std::sync::Arc;
 
@@ -22,7 +22,7 @@ use crate::{Engine, EvaluationHandler, JsonHandler, ParquetHandler, StorageHandl
 /// An [`Engine`] that routes operations through a [`PlanExecutor`].
 ///
 /// Storage, JSON file reads, and Parquet file reads are converted into
-/// [`Plan`](crate::plans::Plan)s and delegated to the plan executor.
+/// [`Operation`](crate::plans::Operation)s and delegated to the plan executor.
 ///
 /// EvaluationHandler capabilities are not supported under plan execution,
 /// so the engine must provide an EvaluationHandler as well.

--- a/kernel/src/engine/plans/parquet.rs
+++ b/kernel/src/engine/plans/parquet.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use url::Url;
 
-use crate::plans::{Plan, PlanExecutor, QueryPlanBuilder};
+use crate::plans::{Operation, PlanExecutor, QueryPlanBuilder};
 use crate::schema::SchemaRef;
 use crate::{
     DeltaResult, DeltaResultIteratorStatic, EngineData, Error, FileDataReadResultIterator,
@@ -34,7 +34,7 @@ impl ParquetHandler for PlanBasedParquetHandler {
         let query =
             QueryPlanBuilder::scan_parquet(files.to_vec(), physical_schema, predicate).build()?;
         self.executor
-            .execute_plan(Plan::QueryPlan(query))?
+            .execute_op(Operation::QueryPlan(query))?
             .into_data()
     }
 

--- a/kernel/src/engine/plans/storage.rs
+++ b/kernel/src/engine/plans/storage.rs
@@ -6,7 +6,7 @@ use bytes::Bytes;
 use itertools::Itertools as _;
 use url::Url;
 
-use crate::plans::{IoOperation, Plan, PlanExecutor, PlanResult};
+use crate::plans::{IoOperation, Operation, PlanExecutor, PlanResult};
 use crate::{DeltaResult, Error, FileMeta, FileSlice, StorageHandler};
 
 /// A [`StorageHandler`] that delegates to a [`PlanExecutor`].
@@ -20,7 +20,7 @@ impl PlanBasedStorageHandler {
     }
 
     fn execute_io(&self, op: IoOperation) -> DeltaResult<PlanResult> {
-        self.executor.execute_plan(Plan::IoOperation(op))
+        self.executor.execute_op(Operation::IoOperation(op))
     }
 }
 

--- a/kernel/src/engine/sync/plan.rs
+++ b/kernel/src/engine/sync/plan.rs
@@ -2,7 +2,7 @@
 //!
 //! [`SyncEngine`]: super::SyncEngine
 //
-// TODO: Not used yet, but will eventually be used to replace SyncEngine with a
+// TODO: Not used yet, but will eventually be used to replace SyncEngine with an
 // PlanBasedEngine (backed by this PlanExecutor)
 #![allow(dead_code)]
 
@@ -14,7 +14,7 @@ use super::json::SyncJsonHandler;
 use super::parquet::SyncParquetHandler;
 use super::storage::SyncStorageHandler;
 use crate::object_store::DynObjectStore;
-use crate::plans::{IoOperation, Plan, PlanExecutor, PlanResult, QueryPlanNode};
+use crate::plans::{IoOperation, Operation, PlanExecutor, PlanResult, QueryPlanNode};
 use crate::{DeltaResult, FileMeta, JsonHandler as _, ParquetHandler as _, StorageHandler as _};
 
 /// A synchronous, test-only [`PlanExecutor`] that delegates to [`SyncStorageHandler`],
@@ -49,10 +49,10 @@ impl SyncPlanExecutor {
 }
 
 impl PlanExecutor for SyncPlanExecutor {
-    fn execute_plan(&self, plan: Plan) -> DeltaResult<PlanResult> {
-        match plan {
-            Plan::IoOperation(op) => self.execute_io(op),
-            Plan::QueryPlan(query) => self.execute_query(query),
+    fn execute_op(&self, op: Operation) -> DeltaResult<PlanResult> {
+        match op {
+            Operation::IoOperation(io_op) => self.execute_io(io_op),
+            Operation::QueryPlan(query) => self.execute_query(query),
         }
     }
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -186,7 +186,7 @@ pub use expressions::{Expression, ExpressionRef, Predicate, PredicateRef};
 pub use log_compaction::{should_compact, LogCompactionWriter};
 #[cfg(feature = "declarative-plans")]
 pub use plans::{
-    IoOperation, Plan, PlanExecutor, PlanResult, QueryPlan, QueryPlanBuilder, QueryPlanNode,
+    IoOperation, Operation, PlanExecutor, PlanResult, QueryPlan, QueryPlanBuilder, QueryPlanNode,
 };
 use schema::{StructField, StructType};
 pub use snapshot::{Snapshot, SnapshotRef};

--- a/kernel/src/plans/ir.rs
+++ b/kernel/src/plans/ir.rs
@@ -1,6 +1,6 @@
 //! Intermediate representation (IR) for declarative plans.
 //!
-//! The top-level type is a [`Plan`], which communicates to the
+//! The top-level type is an [`Operation`], which communicates to the
 //! [`PlanExecutor`](super::PlanExecutor) what to do.
 
 use bytes::Bytes;
@@ -9,11 +9,12 @@ use url::Url;
 use crate::schema::SchemaRef;
 use crate::{FileMeta, FileSlice, PredicateRef};
 
-/// Represents a set of instructions that the [`PlanExecutor`](super::PlanExecutor) should perform.
+/// Represents a set of instructions that the [`PlanExecutor`](super::PlanExecutor)
+/// should perform.
 ///
 /// It can either be an IO operation or a declarative query.
 #[derive(Debug)]
-pub enum Plan {
+pub enum Operation {
     /// A singular I/O operation that returns concretely typed data such as bytes or file metadata.
     IoOperation(IoOperation),
     /// A query on relational-like data, expressed through a plan algebra.
@@ -28,8 +29,9 @@ pub enum Plan {
 pub enum IoOperation {
     /// Recursively list files at the given URL.
     ///
-    /// Should return a [`PlanResult::FileMeta`](super::PlanResult::FileMeta) with one entry per
-    /// file. See [`StorageHandler::list_from`] for more details on the ordering contract.
+    /// Should return a [`PlanResult::FileMeta`](super::PlanResult::FileMeta) with one
+    /// entry per file. See [`StorageHandler::list_from`] for more details on the ordering
+    /// contract.
     ///
     /// [`StorageHandler::list_from`]: crate::StorageHandler::list_from
     FileListing { url: Url },
@@ -41,8 +43,8 @@ pub enum IoOperation {
     ReadBytes { files: Vec<FileSlice> },
     /// Write raw bytes to a file at the given URL.
     ///
-    /// Returns [`PlanResult::Unit`](super::PlanResult::Unit) on success. If `overwrite` is false
-    /// and the file already exists, the executor should return
+    /// Returns [`PlanResult::Unit`](super::PlanResult::Unit) on success. If `overwrite`
+    /// is false and the file already exists, the executor should return
     /// [`Error::FileAlreadyExists`](crate::Error::FileAlreadyExists).
     WriteBytes {
         url: Url,
@@ -51,8 +53,8 @@ pub enum IoOperation {
     },
     /// Retrieve metadata for a single file (HEAD request).
     ///
-    /// Returns [`PlanResult::FileMeta`](super::PlanResult::FileMeta) with a single entry.
-    /// If the file does not exist, the executor should return an error.
+    /// Returns [`PlanResult::FileMeta`](super::PlanResult::FileMeta) with a single
+    /// entry. If the file does not exist, the executor should return an error.
     HeadFile { url: Url },
     /// Atomically copy a file from `source` to `destination`.
     ///
@@ -102,8 +104,8 @@ pub type QueryPlan = QueryPlanNode;
 pub enum QueryPlanNode {
     /// Read and parse newline-delimited JSON files, returning columnar data.
     ///
-    /// Returns [`PlanResult::Data`](super::PlanResult::Data) with columns matching the provided
-    /// `physical_schema`. See [`JsonHandler::read_json_files`] for more details on column
+    /// Returns [`PlanResult::Data`](super::PlanResult::Data) with columns matching the
+    /// provided `physical_schema`. See [`JsonHandler::read_json_files`] for more details on column
     /// resolution rules and ordering contracts.
     ///
     /// [`JsonHandler::read_json_files`]: crate::JsonHandler::read_json_files
@@ -114,9 +116,9 @@ pub enum QueryPlanNode {
     },
     /// Read and parse Apache Parquet files, returning columnar data.
     ///
-    /// Returns [`PlanResult::Data`](super::PlanResult::Data) with columns matching the provided
-    /// `physical_schema`. See [`ParquetHandler::read_parquet_files`] for more details on column
-    /// resolution rules and ordering contracts.
+    /// Returns [`PlanResult::Data`](super::PlanResult::Data) with columns matching the
+    /// provided `physical_schema`. See [`ParquetHandler::read_parquet_files`] for more details on
+    /// column resolution rules and ordering contracts.
     ///
     /// [`ParquetHandler::read_parquet_files`]: crate::ParquetHandler::read_parquet_files
     ScanParquet {

--- a/kernel/src/plans/mod.rs
+++ b/kernel/src/plans/mod.rs
@@ -5,7 +5,7 @@ mod ir;
 mod query_builder;
 
 use bytes::Bytes;
-pub use ir::{IoOperation, Plan, QueryPlan, QueryPlanNode};
+pub use ir::{IoOperation, Operation, QueryPlan, QueryPlanNode};
 pub use query_builder::QueryPlanBuilder;
 
 use crate::{AsAny, DeltaResult, DeltaResultIteratorStatic, EngineData, Error, FileMeta};
@@ -15,11 +15,11 @@ use crate::{AsAny, DeltaResult, DeltaResultIteratorStatic, EngineData, Error, Fi
 /// This gives the kernel the ability to execute data-intensive operations by constructing a
 /// declarative, relational plan algebra, without prescribing *how* to do it.
 pub trait PlanExecutor: AsAny {
-    /// Executes the given declarative plan and return the result.
-    fn execute_plan(&self, plan: Plan) -> DeltaResult<PlanResult>;
+    /// Executes the given declarative plan and returns the result.
+    fn execute_op(&self, op: Operation) -> DeltaResult<PlanResult>;
 }
 
-/// The result of executing a [`Plan`].
+/// The result of executing an [`Operation`].
 ///
 /// Each variant describes a different shape of output that a plan can possibly produce.
 pub enum PlanResult {


### PR DESCRIPTION
Renames just the top-level dispatch enum in declarative-plans to make
room for a richer SSA-DAG `Plan` struct that will land in a follow-up.

- `Plan` (enum) -> `Operation`. The variant names `IoOperation` and
  `QueryPlan` are unchanged.

Everything else keeps upstream's vocabulary: `PlanExecutor` trait,
`PlanResult` enum, `PlanResultTypeMismatch` error variant, `PlanBased*`
engine/handler shims, `SyncPlanExecutor`, `Engine::plan_executor`
method, and the `execute_plan` method on `PlanExecutor`.

## How was this change tested?

Existing tests in `kernel/src/plans/query_builder.rs` and
`kernel/src/engine/{plans,sync/plan}.rs` pass unchanged; the rename is
mechanical.