### PR TITLE
feat!: implement additional plan-based handler APIs

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -118,8 +118,10 @@ arrow-expression = ["need-arrow"]
 # Schema diffing functionality (experimental)
 schema-diff = []
 
-# Declarative plan execution via PlanExecutor trait (experimental)
-declarative-plans = []
+# Declarative plan execution via PlanExecutor trait (experimental).
+# note: there is a dependency on arrow because PlanBasedEngine assumes the use of Arrow EngineData
+#       for JSON parsing
+declarative-plans = ["arrow-conversion", "arrow-expression"]
 
 # this is an 'internal' feature flag which has all the shared bits from default-engine-native-tls
 # and default-engine-rustls

--- a/kernel/src/engine/plans/json.rs
+++ b/kernel/src/engine/plans/json.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use url::Url;
 
+use crate::engine::arrow_utils;
 use crate::plans::{Operation, PlanExecutor, QueryPlanBuilder};
 use crate::schema::SchemaRef;
 use crate::{
@@ -27,12 +28,10 @@ impl PlanBasedJsonHandler {
 impl JsonHandler for PlanBasedJsonHandler {
     fn parse_json(
         &self,
-        _json_strings: Box<dyn EngineData>,
-        _output_schema: SchemaRef,
+        json_strings: Box<dyn EngineData>,
+        output_schema: SchemaRef,
     ) -> DeltaResult<Box<dyn EngineData>> {
-        Err(Error::unsupported(
-            "PlanBasedJsonHandler does not support parse_json yet",
-        ))
+        arrow_utils::parse_json(json_strings, output_schema)
     }
 
     fn read_json_files(
@@ -67,12 +66,12 @@ mod tests {
     use std::sync::Arc;
 
     use super::PlanBasedJsonHandler;
-    use crate::arrow::array::{Int32Array, RecordBatch};
+    use crate::arrow::array::{Int32Array, RecordBatch, StringArray};
     use crate::engine::arrow_data::ArrowEngineData;
     use crate::engine::sync::plan::SyncPlanExecutor;
     use crate::engine::tests::{make_temp_json_file, test_json_handler_file_path_contract};
     use crate::schema::{DataType, StructField, StructType};
-    use crate::JsonHandler as _;
+    use crate::{EngineData, JsonHandler as _};
 
     fn make_handler() -> PlanBasedJsonHandler {
         PlanBasedJsonHandler::new(Arc::new(SyncPlanExecutor::new()))
@@ -104,6 +103,36 @@ mod tests {
             &[1, 2, 3]
         );
         assert!(iter.next().is_none(), "expected exactly one batch");
+    }
+
+    #[test]
+    fn test_parse_json() {
+        let json_strings = StringArray::from(vec![r#"{"x": 1}"#, r#"{"x": 2}"#, r#"{"x": 3}"#]);
+        let input_batch = RecordBatch::try_from_iter(vec![(
+            "json",
+            Arc::new(json_strings) as Arc<dyn crate::arrow::array::Array>,
+        )])
+        .unwrap();
+        let input: Box<dyn EngineData> = Box::new(ArrowEngineData::new(input_batch));
+
+        let output_schema =
+            Arc::new(StructType::try_new([StructField::not_null("x", DataType::INTEGER)]).unwrap());
+
+        let parsed = make_handler().parse_json(input, output_schema).unwrap();
+        let record_batch: RecordBatch = ArrowEngineData::try_from_engine_data(parsed)
+            .unwrap()
+            .into();
+        assert_eq!(record_batch.num_rows(), 3);
+        assert_eq!(record_batch.num_columns(), 1);
+        assert_eq!(
+            record_batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap()
+                .values(),
+            &[1, 2, 3]
+        );
     }
 
     #[test]

--- a/kernel/src/engine/plans/mod.rs
+++ b/kernel/src/engine/plans/mod.rs
@@ -5,6 +5,10 @@
 //!
 //! This allows a PlanExecutor to become the single surface for connector optimizations,
 //! while still allowing kernel to use existing Engine trait APIs.
+//!
+//! ### Arrow Requirement:
+//! The PlanBasedEngine implementation assumes the use of ArrowEngineData during JSON parsing, so it
+//! is only compatible with `PlanExecutor`'s which return ArrowEngineData.
 
 use std::sync::Arc;
 

--- a/kernel/src/engine/plans/parquet.rs
+++ b/kernel/src/engine/plans/parquet.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use url::Url;
 
-use crate::plans::{Operation, PlanExecutor, QueryPlanBuilder};
+use crate::plans::{IoOperation, Operation, PlanExecutor, QueryPlanBuilder};
 use crate::schema::SchemaRef;
 use crate::{
     DeltaResult, DeltaResultIteratorStatic, EngineData, Error, FileDataReadResultIterator,
@@ -48,10 +48,13 @@ impl ParquetHandler for PlanBasedParquetHandler {
         ))
     }
 
-    fn read_parquet_footer(&self, _file: &FileMeta) -> DeltaResult<ParquetFooter> {
-        Err(Error::unsupported(
-            "PlanBasedParquetHandler does not support read_parquet_footer yet",
-        ))
+    fn read_parquet_footer(&self, file: &FileMeta) -> DeltaResult<ParquetFooter> {
+        let op = IoOperation::parquet_schema(file.clone());
+        let schema = self
+            .executor
+            .execute_op(Operation::IoOperation(op))?
+            .into_schema()?;
+        Ok(ParquetFooter { schema })
     }
 }
 
@@ -69,7 +72,11 @@ mod tests {
     use crate::engine::arrow_conversion::TryIntoKernel as _;
     use crate::engine::arrow_data::ArrowEngineData;
     use crate::engine::sync::plan::SyncPlanExecutor;
-    use crate::engine::tests::{file_meta_for, test_parquet_handler_reads_file_with_arrow_schema};
+    use crate::engine::tests::{
+        file_meta_for, test_parquet_handler_footer_errors_on_missing_file,
+        test_parquet_handler_footer_preserves_field_ids,
+        test_parquet_handler_reads_file_with_arrow_schema, test_parquet_handler_reads_footer,
+    };
     use crate::parquet::arrow::arrow_writer::ArrowWriter;
     use crate::schema::SchemaRef;
     use crate::{FileMeta, ParquetHandler as _};
@@ -127,5 +134,20 @@ mod tests {
     #[test]
     fn test_parquet_handler_reads_contract() {
         test_parquet_handler_reads_file_with_arrow_schema(&make_handler());
+    }
+
+    #[test]
+    fn test_read_parquet_footer_contract() {
+        test_parquet_handler_reads_footer(&make_handler());
+    }
+
+    #[test]
+    fn test_read_parquet_footer_missing_file_contract() {
+        test_parquet_handler_footer_errors_on_missing_file(&make_handler());
+    }
+
+    #[test]
+    fn test_read_parquet_footer_preserves_field_ids_contract() {
+        test_parquet_handler_footer_preserves_field_ids(&make_handler());
     }
 }

--- a/kernel/src/engine/plans/parquet.rs
+++ b/kernel/src/engine/plans/parquet.rs
@@ -49,12 +49,10 @@ impl ParquetHandler for PlanBasedParquetHandler {
     }
 
     fn read_parquet_footer(&self, file: &FileMeta) -> DeltaResult<ParquetFooter> {
-        let op = IoOperation::parquet_schema(file.clone());
-        let schema = self
-            .executor
+        let op = IoOperation::parquet_footer(file.clone());
+        self.executor
             .execute_op(Operation::IoOperation(op))?
-            .into_schema()?;
-        Ok(ParquetFooter { schema })
+            .into_parquet_footer()
     }
 }
 

--- a/kernel/src/engine/sync/plan.rs
+++ b/kernel/src/engine/sync/plan.rs
@@ -93,6 +93,10 @@ impl SyncPlanExecutor {
                 self.storage.copy_atomic(&source, &destination)?;
                 Ok(PlanResult::Unit)
             }
+            IoOperation::ParquetSchema { file } => {
+                let footer = self.parquet.read_parquet_footer(&file)?;
+                Ok(PlanResult::Schema(footer.schema))
+            }
         }
     }
 

--- a/kernel/src/engine/sync/plan.rs
+++ b/kernel/src/engine/sync/plan.rs
@@ -93,9 +93,9 @@ impl SyncPlanExecutor {
                 self.storage.copy_atomic(&source, &destination)?;
                 Ok(PlanResult::Unit)
             }
-            IoOperation::ParquetSchema { file } => {
+            IoOperation::ParquetFooter { file } => {
                 let footer = self.parquet.read_parquet_footer(&file)?;
-                Ok(PlanResult::Schema(footer.schema))
+                Ok(PlanResult::ParquetFooter(footer))
             }
         }
     }

--- a/kernel/src/plans/ir.rs
+++ b/kernel/src/plans/ir.rs
@@ -73,14 +73,17 @@ pub enum IoOperation {
 }
 
 impl IoOperation {
+    /// Constructs an [`IoOperation::FileListing`] for the given URL.
     pub fn file_listing(url: Url) -> Self {
         Self::FileListing { url }
     }
 
+    /// Constructs an [`IoOperation::ReadBytes`] for the given file slices.
     pub fn read_bytes(files: Vec<FileSlice>) -> Self {
         Self::ReadBytes { files }
     }
 
+    /// Constructs an [`IoOperation::WriteBytes`] for the given URL, data, and overwrite flag.
     pub fn write_bytes(url: Url, data: Bytes, overwrite: bool) -> Self {
         Self::WriteBytes {
             url,
@@ -89,10 +92,12 @@ impl IoOperation {
         }
     }
 
+    /// Constructs an [`IoOperation::HeadFile`] for the given URL.
     pub fn head_file(url: Url) -> Self {
         Self::HeadFile { url }
     }
 
+    /// Constructs an [`IoOperation::AtomicCopy`] for the given source and destination URLs.
     pub fn atomic_copy(source: Url, destination: Url) -> Self {
         Self::AtomicCopy {
             source,
@@ -100,6 +105,7 @@ impl IoOperation {
         }
     }
 
+    /// Constructs an [`IoOperation::ParquetFooter`] for the given file metadata.
     pub fn parquet_footer(file: FileMeta) -> Self {
         Self::ParquetFooter { file }
     }

--- a/kernel/src/plans/ir.rs
+++ b/kernel/src/plans/ir.rs
@@ -62,6 +62,14 @@ pub enum IoOperation {
     /// [`Error::FileAlreadyExists`](crate::Error::FileAlreadyExists) without modifying it.
     /// Returns [`PlanResult::Unit`](super::PlanResult::Unit) on success.
     AtomicCopy { source: Url, destination: Url },
+    /// Read the schema from the footer of a Parquet file.
+    ///
+    /// Returns [`PlanResult::Schema`](super::PlanResult::Schema) containing the file's schema
+    /// converted to Delta Kernel's format. See [`ParquetHandler::read_parquet_footer`] for the
+    /// full contract.
+    ///
+    /// [`ParquetHandler::read_parquet_footer`]: crate::ParquetHandler::read_parquet_footer
+    ParquetSchema { file: FileMeta },
 }
 
 impl IoOperation {
@@ -90,6 +98,10 @@ impl IoOperation {
             source,
             destination,
         }
+    }
+
+    pub fn parquet_schema(file: FileMeta) -> Self {
+        Self::ParquetSchema { file }
     }
 }
 

--- a/kernel/src/plans/ir.rs
+++ b/kernel/src/plans/ir.rs
@@ -62,14 +62,14 @@ pub enum IoOperation {
     /// [`Error::FileAlreadyExists`](crate::Error::FileAlreadyExists) without modifying it.
     /// Returns [`PlanResult::Unit`](super::PlanResult::Unit) on success.
     AtomicCopy { source: Url, destination: Url },
-    /// Read the schema from the footer of a Parquet file.
+    /// Read the footer of a Parquet file.
     ///
-    /// Returns [`PlanResult::Schema`](super::PlanResult::Schema) containing the file's schema
-    /// converted to Delta Kernel's format. See [`ParquetHandler::read_parquet_footer`] for the
-    /// full contract.
+    /// Returns [`PlanResult::ParquetFooter`](super::PlanResult::ParquetFooter) containing the
+    /// file's footer metadata (schema and any future extensions). See
+    /// [`ParquetHandler::read_parquet_footer`] for the full contract.
     ///
     /// [`ParquetHandler::read_parquet_footer`]: crate::ParquetHandler::read_parquet_footer
-    ParquetSchema { file: FileMeta },
+    ParquetFooter { file: FileMeta },
 }
 
 impl IoOperation {
@@ -100,8 +100,8 @@ impl IoOperation {
         }
     }
 
-    pub fn parquet_schema(file: FileMeta) -> Self {
-        Self::ParquetSchema { file }
+    pub fn parquet_footer(file: FileMeta) -> Self {
+        Self::ParquetFooter { file }
     }
 }
 

--- a/kernel/src/plans/mod.rs
+++ b/kernel/src/plans/mod.rs
@@ -8,8 +8,9 @@ use bytes::Bytes;
 pub use ir::{IoOperation, Operation, QueryPlan, QueryPlanNode};
 pub use query_builder::QueryPlanBuilder;
 
-use crate::schema::SchemaRef;
-use crate::{AsAny, DeltaResult, DeltaResultIteratorStatic, EngineData, Error, FileMeta};
+use crate::{
+    AsAny, DeltaResult, DeltaResultIteratorStatic, EngineData, Error, FileMeta, ParquetFooter,
+};
 
 /// Provides the ability to execute declarative plans to the Delta Kernel.
 ///
@@ -30,13 +31,15 @@ pub enum PlanResult {
     FileMeta(DeltaResultIteratorStatic<FileMeta>),
     /// A stream of raw byte buffers.
     Bytes(DeltaResultIteratorStatic<Bytes>),
-    /// The schema of a file (e.g. a Parquet footer schema).
-    Schema(SchemaRef),
+    /// Metadata extracted from a Parquet file footer.
+    ParquetFooter(ParquetFooter),
     /// Represents the successful completion of a plan, but with no return value.
     Unit,
 }
 
 impl PlanResult {
+    /// Consumes the PlanResult and extracts the inner iterator of EngineData (assuming that it is a
+    /// PlanResult::Data variant). Returns an error if the PlanResult is not the expected variant.
     pub fn into_data(self) -> DeltaResult<DeltaResultIteratorStatic<Box<dyn EngineData>>> {
         match self {
             Self::Data(iter) => Ok(iter),
@@ -44,6 +47,9 @@ impl PlanResult {
         }
     }
 
+    /// Consumes the PlanResult and extracts the inner iterator of FileMeta (assuming that it is a
+    /// PlanResult::FileMeta variant). Returns an error if the PlanResult is not the expected
+    /// variant.
     pub fn into_file_meta(self) -> DeltaResult<DeltaResultIteratorStatic<FileMeta>> {
         match self {
             Self::FileMeta(iter) => Ok(iter),
@@ -51,6 +57,9 @@ impl PlanResult {
         }
     }
 
+    /// Consumes the PlanResult and extracts the inner iterator of Bytes (assuming that it is a
+    /// PlanResult::Bytes variant). Returns an error if the PlanResult is not a PlanResult::Bytes
+    /// variant.
     pub fn into_bytes(self) -> DeltaResult<DeltaResultIteratorStatic<Bytes>> {
         match self {
             Self::Bytes(iter) => Ok(iter),
@@ -58,13 +67,18 @@ impl PlanResult {
         }
     }
 
-    pub fn into_schema(self) -> DeltaResult<SchemaRef> {
+    /// Consumes the PlanResult and extracts the inner [`ParquetFooter`] (assuming that it is a
+    /// PlanResult::ParquetFooter variant). Returns an error if the PlanResult is not the expected
+    /// variant.
+    pub fn into_parquet_footer(self) -> DeltaResult<ParquetFooter> {
         match self {
-            Self::Schema(schema) => Ok(schema),
-            other => Err(other.type_mismatch("Schema")),
+            Self::ParquetFooter(footer) => Ok(footer),
+            other => Err(other.type_mismatch("ParquetFooter")),
         }
     }
 
+    /// Consumes the PlanResult, verifying that it is a PlanResult::Unit variant. Returns an error
+    /// if the PlanResult is not the expected variant.
     pub fn into_unit(self) -> DeltaResult<()> {
         match self {
             Self::Unit => Ok(()),
@@ -77,7 +91,7 @@ impl PlanResult {
             Self::Data(_) => "Data",
             Self::FileMeta(_) => "FileMeta",
             Self::Bytes(_) => "Bytes",
-            Self::Schema(_) => "Schema",
+            Self::ParquetFooter(_) => "ParquetFooter",
             Self::Unit => "Unit",
         }
     }

--- a/kernel/src/plans/mod.rs
+++ b/kernel/src/plans/mod.rs
@@ -8,6 +8,7 @@ use bytes::Bytes;
 pub use ir::{IoOperation, Operation, QueryPlan, QueryPlanNode};
 pub use query_builder::QueryPlanBuilder;
 
+use crate::schema::SchemaRef;
 use crate::{AsAny, DeltaResult, DeltaResultIteratorStatic, EngineData, Error, FileMeta};
 
 /// Provides the ability to execute declarative plans to the Delta Kernel.
@@ -29,6 +30,8 @@ pub enum PlanResult {
     FileMeta(DeltaResultIteratorStatic<FileMeta>),
     /// A stream of raw byte buffers.
     Bytes(DeltaResultIteratorStatic<Bytes>),
+    /// The schema of a file (e.g. a Parquet footer schema).
+    Schema(SchemaRef),
     /// Represents the successful completion of a plan, but with no return value.
     Unit,
 }
@@ -55,6 +58,13 @@ impl PlanResult {
         }
     }
 
+    pub fn into_schema(self) -> DeltaResult<SchemaRef> {
+        match self {
+            Self::Schema(schema) => Ok(schema),
+            other => Err(other.type_mismatch("Schema")),
+        }
+    }
+
     pub fn into_unit(self) -> DeltaResult<()> {
         match self {
             Self::Unit => Ok(()),
@@ -67,6 +77,7 @@ impl PlanResult {
             Self::Data(_) => "Data",
             Self::FileMeta(_) => "FileMeta",
             Self::Bytes(_) => "Bytes",
+            Self::Schema(_) => "Schema",
             Self::Unit => "Unit",
         }
     }


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR handles a few more of the unsupported operations for PlanBasedEngine - namely `parse_json` and `read_parquet_footer`.

For JSON parsing, we take a dependency on Arrow and just implement it using the existing `arrow_utils::parse_json` utility. The implication is that PlanExecutors must return and understand ArrowEngineData (which must be true over FFI anyway).

To support Parquet footer read, we add a `ParquetSchema` IoOperation variant. Kernel's `ParquetFooter` only consists of schema right now, so I felt it made more sense to have `PlanResult` use a generic "schema" variant rather than a `PlanResult::ParquetFooter`. But let me know if there is strong motivation for returning the full footer struct.

Note: `write_json` and `write_parquet` is more complicated and so will continue to be deferred.

## How was this change tested?
Added unit tests
