### PR TITLE
feat!: add VariadicExpressionOp::Array with Arrow evaluator

### DIFF
--- a/ffi/examples/visit-expression/expression.h
+++ b/ffi/examples/visit-expression/expression.h
@@ -70,6 +70,8 @@ enum VariadicType {
   And,
   Or,
   StructExpression,
+  Coalesce,
+  ArrayConstructor,
 };
 enum UnaryType { Not, IsNull };
 typedef struct {
@@ -309,6 +311,8 @@ void visit_expr_variadic(void* data,
 DEFINE_VARIADIC(visit_expr_and, And)
 DEFINE_VARIADIC(visit_expr_or, Or)
 DEFINE_VARIADIC(visit_expr_struct_expr, StructExpression)
+DEFINE_VARIADIC(visit_expr_coalesce, Coalesce)
+DEFINE_VARIADIC(visit_expr_array, ArrayConstructor)
 #undef DEFINE_VARIADIC
 
 // Sort by field name, breaking ties by pointer address to ensure stability.
@@ -514,6 +518,8 @@ ExpressionItemList construct_expression(SharedExpression* expression) {
     .visit_opaque_expr = visit_opaque_expr,
     .visit_unknown = visit_unknown,
     .visit_map_to_struct = visit_map_to_struct_expr,
+    .visit_coalesce = visit_expr_coalesce,
+    .visit_array = visit_expr_array,
   };
   uintptr_t top_level_id = visit_expression(&expression, &visitor);
   ExpressionItemList top_level_expr = data.lists[top_level_id];
@@ -561,6 +567,8 @@ ExpressionItemList construct_predicate(SharedPredicate* predicate) {
     .visit_opaque_expr = visit_opaque_expr,
     .visit_unknown = visit_unknown,
     .visit_map_to_struct = visit_map_to_struct_expr,
+    .visit_coalesce = visit_expr_coalesce,
+    .visit_array = visit_expr_array,
   };
   uintptr_t top_level_id = visit_predicate(&predicate, &visitor);
   ExpressionItemList top_level_expr = data.lists[top_level_id];

--- a/ffi/examples/visit-expression/expression_print.h
+++ b/ffi/examples/visit-expression/expression_print.h
@@ -80,6 +80,12 @@ void print_tree_helper(ExpressionItem ref, int depth) {
         case StructExpression:
           printf("StructExpression\n");
           break;
+        case Coalesce:
+          printf("Coalesce\n");
+          break;
+        case ArrayConstructor:
+          printf("ArrayConstructor\n");
+          break;
       }
       print_expression_item_list(var->exprs, depth + 1);
       break;

--- a/ffi/src/expressions/engine_visitor.rs
+++ b/ffi/src/expressions/engine_visitor.rs
@@ -201,6 +201,10 @@ pub struct EngineExpressionVisitor {
     /// Visits the `Coalesce` variadic operator belonging to the list identified by
     /// `sibling_list_id`. The operands will be in a list identified by `child_list_id`
     pub visit_coalesce: VisitVariadicFn,
+    /// Visits the `Array` variadic constructor belonging to the list identified by
+    /// `sibling_list_id`. The element expressions will be in a list identified by
+    /// `child_list_id`.
+    pub visit_array: VisitVariadicFn,
     /// Visits the `column` belonging to the list identified by `sibling_list_id`.
     pub visit_column:
         extern "C" fn(data: *mut c_void, sibling_list_id: usize, name: KernelStringSlice),
@@ -665,6 +669,7 @@ fn visit_expression_impl(
             }
             let visit_fn = match op {
                 VariadicExpressionOp::Coalesce => visitor.visit_coalesce,
+                VariadicExpressionOp::Array => visitor.visit_array,
             };
             visit_fn(visitor.data, sibling_list_id, child_list_id);
         }

--- a/ffi/src/test_ffi.rs
+++ b/ffi/src/test_ffi.rs
@@ -160,6 +160,8 @@ pub unsafe extern "C" fn get_testing_kernel_expression() -> Handle<SharedExpress
         ),
         Expr::unknown("mystery"),
         Expr::map_to_struct(column_expr!("pv")),
+        Expr::coalesce([column_expr!("col"), Expr::literal(0_i32)]),
+        Expr::array([Expr::literal(1_i32), Expr::literal(2_i32)]),
     ];
     sub_exprs.extend(
         [

--- a/ffi/tests/test-expression-visitor/expected.txt
+++ b/ffi/tests/test-expression-visitor/expected.txt
@@ -68,6 +68,12 @@ StructExpression
   Unknown(mystery)
   MapToStruct
     Column(pv)
+  Coalesce
+    Column(col)
+    Integer(0)
+  ArrayConstructor
+    Integer(1)
+    Integer(2)
   Divide
     Integer(0)
     Integer(0)

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -9,8 +9,8 @@ use tracing::warn;
 use crate::arrow::array::types::*;
 use crate::arrow::array::{
     self as arrow_array, make_array, new_null_array, Array, ArrayBuilder, ArrayData, ArrayRef,
-    AsArray, BooleanArray, Datum, MapArray, MutableArrayData, NullBufferBuilder, RecordBatch,
-    StringArray, StructArray,
+    AsArray, BooleanArray, Datum, ListArray, MapArray, MutableArrayData, NullBufferBuilder,
+    RecordBatch, StringArray, StructArray,
 };
 use crate::arrow::buffer::{NullBuffer, OffsetBuffer};
 use crate::arrow::compute::kernels::cmp::{distinct, eq, gt, gt_eq, lt, lt_eq, neq, not_distinct};
@@ -24,7 +24,7 @@ use crate::arrow::datatypes::{
 use crate::arrow::error::ArrowError;
 use crate::arrow::json::writer::{make_encoder, EncoderOptions};
 use crate::arrow::json::StructMode;
-use crate::engine::arrow_conversion::{TryFromKernel, TryIntoArrow};
+use crate::engine::arrow_conversion::{TryFromKernel, TryIntoArrow, LIST_ARRAY_ROOT};
 use crate::engine::arrow_expression::opaque::{
     ArrowOpaqueExpressionOpAdaptor, ArrowOpaquePredicateOpAdaptor,
 };
@@ -331,6 +331,9 @@ pub fn evaluate_expression(
             // Coalesce accumulated arrays
             Ok(coalesce_arrays(&arrays, result_type)?)
         }
+        (Variadic(VariadicExpression { op: Array, exprs }), result_type) => {
+            evaluate_array_expression(exprs, batch, result_type)
+        }
         (Opaque(OpaqueExpression { op, exprs }), _) => {
             match op
                 .any_ref()
@@ -372,6 +375,107 @@ pub fn evaluate_expression(
         ))),
         (Unknown(name), _) => Err(Error::unsupported(format!("Unknown expression: {name:?}"))),
     }
+}
+
+/// Evaluate an `ARRAY(e0, e1, ..., eN-1)` constructor expression into an Arrow `ListArray`.
+///
+/// Each input expression produces one column of length M (rows in the batch); the output
+/// is an `Array<element_type>` column of length M where row i holds
+/// `[arr_0[i], ..., arr_{N-1}[i]]`. The element type is inferred from the inputs (which must
+/// all evaluate to the same Arrow element type); at least one input is required.
+///
+/// When provided, `result_type` must be a [`DataType::Array`]. Its element type is forwarded
+/// to the children as a schema hint (struct/nested-array elements need their schema to
+/// evaluate, the same way a bare struct expression does), and when it declares the element
+/// field non-nullable, no input may contain nulls. See [`VariadicExpressionOp::Array`] for
+/// the expression contract.
+fn evaluate_array_expression(
+    exprs: &[Expression],
+    batch: &RecordBatch,
+    result_type: Option<&DataType>,
+) -> DeltaResult<ArrayRef> {
+    let num_rows = batch.num_rows();
+
+    let array_type = match result_type {
+        Some(DataType::Array(arr_ty)) => Some(arr_ty.as_ref()),
+        Some(other) => {
+            return Err(Error::generic(format!(
+                "Array expression requires a DataType::Array result type, but got {other:?}"
+            )));
+        }
+        None => None,
+    };
+    let element_kernel_type = array_type.map(|a| a.element_type());
+    let contains_null = array_type.is_none_or(|a| a.contains_null());
+
+    let element_arrays: Vec<ArrayRef> = exprs
+        .iter()
+        .map(|expr| evaluate_expression(expr, batch, element_kernel_type))
+        .try_collect()?;
+
+    let element_type = element_arrays
+        .first()
+        .ok_or_else(|| Error::generic("Array expression requires at least one element"))?
+        .data_type()
+        .clone();
+    // Single pass over the evaluated inputs: every input must evaluate to the shared element
+    // type, and (when the element field is declared non-nullable) must not contain nulls --
+    // otherwise the output's field metadata would lie about the values it holds.
+    for (i, arr) in element_arrays.iter().enumerate() {
+        if arr.data_type() != &element_type {
+            return Err(Error::generic(format!(
+                "Array expression inputs must share the same element type; input 0 evaluates \
+                 to {element_type:?} but input {i} evaluates to {:?}",
+                arr.data_type()
+            )));
+        }
+        if !contains_null && arr.null_count() > 0 {
+            return Err(Error::generic(format!(
+                "Array expression declares non-nullable elements (result_type contains_null \
+                 is false) but input {i} contains {} null value(s)",
+                arr.null_count()
+            )));
+        }
+    }
+
+    let n = element_arrays.len();
+    // Build the flat values buffer in row-major order: row r is [arr_0[r], ..., arr_{n-1}[r]].
+    // `MutableArrayData` is type-erased (works for any element type) and avoids the
+    // (num_rows * n)-sized indices buffer that `arrow_select::interleave` would require.
+    let array_data: Vec<ArrayData> = element_arrays.iter().map(|a| a.to_data()).collect();
+    let total_len = num_rows.checked_mul(n).ok_or_else(|| {
+        Error::generic(format!(
+            "Array expression length overflows usize: num_rows={num_rows} * inputs={n}"
+        ))
+    })?;
+    let mut mutable = MutableArrayData::new(array_data.iter().collect(), false, total_len);
+    for row in 0..num_rows {
+        for col in 0..n {
+            mutable.extend(col, row, row + 1);
+        }
+    }
+    let values = make_array(mutable.freeze());
+
+    // Every row's list has exactly `n` elements. `from_lengths` builds `[0, n, 2n, ..., M*n]`
+    // but panics on i32 overflow, so guard first (`LargeListArray` would be needed beyond
+    // i32::MAX). `total_len == num_rows * n` was overflow-checked as usize above.
+    i32::try_from(total_len).map_err(|_| {
+        Error::generic(format!(
+            "Array expression offsets overflow i32: num_rows={num_rows} * inputs={n}; \
+             LargeListArray would be required"
+        ))
+    })?;
+    let offsets = OffsetBuffer::<i32>::from_lengths(std::iter::repeat_n(n, num_rows));
+    let field = Arc::new(ArrowField::new(
+        LIST_ARRAY_ROOT,
+        element_type,
+        contains_null,
+    ));
+    let list = ListArray::try_new(field, offsets, values, None)?;
+    // Validate the assembled array's element type against the caller-declared result type,
+    // consistent with the other expression arms. (Element nullability is enforced above, since
+    // `validate_array_type` runs in TypesAndNames mode where nullability checks are a no-op.)
+    validate_array_type(Arc::new(list), result_type)
 }
 
 /// Direction for casting between Arrow view and non-view string/binary types.
@@ -2560,5 +2664,287 @@ mod tests {
 
         let result = evaluate_expression(&expr, &batch, Some(&output_type));
         assert_result_error_with_message(result, "Missing Struct fields");
+    }
+
+    fn int_array_ty(contains_null: bool) -> DataType {
+        DataType::Array(Box::new(crate::schema::ArrayType::new(
+            DataType::INTEGER,
+            contains_null,
+        )))
+    }
+
+    /// Single-column int batch of arbitrary length (column `a`). Used to drive both the
+    /// `num_rows == 0` boundary and a column with nulls.
+    fn int_a_batch(values: Vec<Option<i32>>, nullable: bool) -> RecordBatch {
+        let schema = ArrowSchema::new(vec![ArrowField::new("a", ArrowDataType::Int32, nullable)]);
+        RecordBatch::try_new(Arc::new(schema), vec![Arc::new(Int32Array::from(values))]).unwrap()
+    }
+
+    /// Two-column int batch with `a` non-null and `b` nullable. Used for null-propagation
+    /// and the non-nullable-rejection tests.
+    fn ab_batch_with_b_nulls() -> RecordBatch {
+        let schema = ArrowSchema::new(vec![
+            ArrowField::new("a", ArrowDataType::Int32, false),
+            ArrowField::new("b", ArrowDataType::Int32, true),
+        ]);
+        RecordBatch::try_new(
+            Arc::new(schema),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(Int32Array::from(vec![Some(10), None, Some(30)])),
+            ],
+        )
+        .unwrap()
+    }
+
+    // Happy-path Array over Int32: parameterized over (batch, inputs, expected_rows). Cases
+    // cover single/multi-input row-major construction (n1..n3), mixed column+literal inputs,
+    // arbitrary expression-tree children, and an empty batch (0 rows).
+    #[rstest]
+    #[case::n1(create_test_batch(), vec![column_expr!("a")], vec![vec![1], vec![2], vec![3]])]
+    #[case::n2(create_test_batch(), vec![column_expr!("a"), column_expr!("b")],
+               vec![vec![1, 10], vec![2, 20], vec![3, 30]])]
+    #[case::n3(create_test_batch(), vec![column_expr!("a"), column_expr!("b"), column_expr!("c")],
+               vec![vec![1, 10, 100], vec![2, 20, 200], vec![3, 30, 300]])]
+    #[case::mixed_col_and_literal(create_test_batch(),
+                                  vec![column_expr!("a"), Expr::literal(99_i32)],
+                                  vec![vec![1, 99], vec![2, 99], vec![3, 99]])]
+    // Inputs can be arbitrary expression trees (columns, arithmetic, sibling variadics) --
+    // the realistic shape FSR dedup-key construction will use.
+    #[case::arithmetic_and_coalesce_children(create_test_batch(),
+        vec![column_expr!("a") + column_expr!("b"),
+             column_expr!("b") - column_expr!("a"),
+             column_expr!("a") * column_expr!("b"),
+             Expr::coalesce([column_expr!("a"), column_expr!("b")])],
+        vec![vec![11, 9, 10, 1], vec![22, 18, 40, 2], vec![33, 27, 90, 3]])]
+    #[case::empty_batch_n1(int_a_batch(vec![], false), vec![column_expr!("a")], vec![])]
+    #[case::empty_batch_n2(int_a_batch(vec![], false),
+                           vec![column_expr!("a"), Expr::literal(7_i32)], vec![])]
+    fn test_evaluate_array_int_per_row(
+        #[case] batch: RecordBatch,
+        #[case] inputs: Vec<Expr>,
+        #[case] expected: Vec<Vec<i32>>,
+    ) {
+        let expr = Expr::array(inputs);
+        let ty = int_array_ty(true);
+        let result = evaluate_expression(&expr, &batch, Some(&ty)).unwrap();
+        let list = result.as_list::<i32>();
+        assert_eq!(list.len(), expected.len());
+        for (row, want) in expected.iter().enumerate() {
+            let element = list.value(row);
+            assert_eq!(
+                element.as_primitive::<Int32Type>().values(),
+                want.as_slice()
+            );
+        }
+    }
+
+    // `contains_null` from the caller-supplied `result_type` must be reflected in the
+    // produced `ListArray`'s element-field metadata, for inputs without nulls and inputs
+    // WITH nulls (the realistic case where a nullable input column flows through to a
+    // nullable element field).
+    #[rstest]
+    #[case::nullable(create_test_batch(), vec![column_expr!("a")], true)]
+    #[case::non_nullable(create_test_batch(), vec![column_expr!("a")], false)]
+    #[case::with_nulls_nullable(ab_batch_with_b_nulls(), vec![column_expr!("b")], true)]
+    fn test_evaluate_array_field_nullability_matches_result_type(
+        #[case] batch: RecordBatch,
+        #[case] inputs: Vec<Expr>,
+        #[case] contains_null: bool,
+    ) {
+        let expr = Expr::array(inputs);
+        let ty = int_array_ty(contains_null);
+        let result = evaluate_expression(&expr, &batch, Some(&ty)).unwrap();
+        let ArrowDataType::List(field) = result.data_type() else {
+            panic!("expected ListArray, got {:?}", result.data_type())
+        };
+        assert_eq!(field.name(), LIST_ARRAY_ROOT);
+        assert_eq!(field.is_nullable(), contains_null);
+    }
+
+    // All validation paths in `evaluate_array_expression` share the shape "expr + batch +
+    // result_type -> error containing substring". Each case targets a different guard.
+    #[rstest]
+    // Empty Array() is rejected regardless of result_type -- the element type is inferred
+    // from the inputs, so there must be at least one.
+    #[case::empty_inputs(
+        create_test_batch(),
+        Expr::array(Vec::<Expr>::new()),
+        None,
+        "requires at least one element",
+    )]
+    #[case::non_array_result_type(
+        create_test_batch(),
+        Expr::array([column_expr!("a")]),
+        Some(DataType::INTEGER),
+        "requires a DataType::Array result type",
+    )]
+    // The mismatch error must identify which input differs (index 2). We avoid matching
+    // the Arrow Debug formatter for `DataType` since that may change.
+    #[case::input_type_mismatch(
+        create_test_batch(),
+        Expr::array([Expr::literal(1_i32), Expr::literal(2_i32), Expr::literal("text")]),
+        None,
+        "input 2",
+    )]
+    // Caller declared `contains_null=false`, but the input column has a NULL at row 1. The
+    // evaluator must refuse rather than emit a `ListArray` whose field claims non-nullable
+    // while the values array contains a null.
+    #[case::null_in_non_nullable(
+        ab_batch_with_b_nulls(),
+        Expr::array([column_expr!("b")]),
+        Some(int_array_ty(false)),
+        "non-nullable elements",
+    )]
+    fn test_evaluate_array_errors(
+        #[case] batch: RecordBatch,
+        #[case] expr: Expr,
+        #[case] result_type: Option<DataType>,
+        #[case] expected_substring: &str,
+    ) {
+        let result = evaluate_expression(&expr, &batch, result_type.as_ref());
+        assert_result_error_with_message(result, expected_substring);
+    }
+
+    #[test]
+    fn test_evaluate_array_preserves_element_nulls() {
+        // a = [1, 2, 3] (non-null), b = [Some(10), None, Some(30)] (nullable).
+        // ARRAY(a, b) -> [[1, 10], [2, NULL], [3, 30]] -- per-row array itself non-null.
+        let batch = ab_batch_with_b_nulls();
+        let expr = Expr::array([column_expr!("a"), column_expr!("b")]);
+        let ty = int_array_ty(true);
+        let result = evaluate_expression(&expr, &batch, Some(&ty)).unwrap();
+        let list = result.as_list::<i32>();
+        assert_eq!(list.null_count(), 0); // outer arrays are non-null
+        assert_eq!(list.len(), 3);
+        let row1 = list.value(1);
+        let row1_vals = row1.as_primitive::<Int32Type>();
+        assert_eq!(row1_vals.value(0), 2);
+        assert!(row1_vals.is_null(1));
+    }
+
+    // ARRAY over struct elements: plain ARRAY of two-field structs, plus COALESCE of two
+    // ARRAYs of single-field structs (the realistic FSR dedup-key shape with diverse
+    // expression trees -- column refs, arithmetic, literals -- inside the struct fields).
+    // `expected` is indexed as `expected[row][element_in_list][field_in_struct]`.
+    #[rstest]
+    #[case::array_of_two_field_structs(
+        StructType::try_new([
+            StructField::not_null("x", DataType::INTEGER),
+            StructField::not_null("y", DataType::INTEGER),
+        ]).unwrap(),
+        Expr::array([
+            Expr::struct_from([column_expr!("a"), column_expr!("b")]),
+            Expr::struct_from([column_expr!("b"), column_expr!("c")]),
+        ]),
+        vec![
+            vec![vec![1, 10], vec![10, 100]],
+            vec![vec![2, 20], vec![20, 200]],
+            vec![vec![3, 30], vec![30, 300]],
+        ],
+    )]
+    #[case::coalesce_of_arrays_of_structs(
+        StructType::try_new([StructField::not_null("x", DataType::INTEGER)]).unwrap(),
+        Expr::coalesce([
+            Expr::array([
+                Expr::struct_from([column_expr!("a")]),
+                Expr::struct_from([column_expr!("a") + column_expr!("b")]),
+                Expr::struct_from([Expr::literal(42_i32)]),
+            ]),
+            Expr::array([
+                Expr::struct_from([column_expr!("b")]),
+                Expr::struct_from([column_expr!("a") * column_expr!("b")]),
+                Expr::struct_from([Expr::literal(0_i32)]),
+            ]),
+        ]),
+        vec![
+            vec![vec![1], vec![11], vec![42]],
+            vec![vec![2], vec![22], vec![42]],
+            vec![vec![3], vec![33], vec![42]],
+        ],
+    )]
+    fn test_evaluate_array_of_structs(
+        #[case] struct_schema: StructType,
+        #[case] expr: Expr,
+        #[case] expected: Vec<Vec<Vec<i32>>>,
+    ) {
+        let batch = create_test_batch();
+        let array_ty = DataType::Array(Box::new(crate::schema::ArrayType::new(
+            DataType::Struct(Box::new(struct_schema)),
+            false,
+        )));
+        let result = evaluate_expression(&expr, &batch, Some(&array_ty)).unwrap();
+        let list = result.as_list::<i32>();
+        assert_eq!(list.len(), expected.len());
+        for (row, row_expected) in expected.iter().enumerate() {
+            let elements = list.value(row);
+            let structs = elements.as_any().downcast_ref::<StructArray>().unwrap();
+            assert_eq!(structs.len(), row_expected.len());
+            for (i, struct_expected) in row_expected.iter().enumerate() {
+                for (field_idx, &want) in struct_expected.iter().enumerate() {
+                    let arr = structs.column(field_idx).as_primitive::<Int32Type>();
+                    assert_eq!(arr.value(i), want);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_evaluate_array_of_non_null_struct_with_inner_null_field() {
+        // Result type asks for non-nullable struct elements (Array `contains_null=false`),
+        // and the struct itself IS non-null at every row -- but its single `value` field
+        // is nullable and contains a null at row 1. The evaluator's `contains_null=false`
+        // guard operates on struct-level nulls only, so this must succeed and pass the
+        // inner null through to the output.
+        let batch = ab_batch_with_b_nulls();
+        let inner_field_schema =
+            StructType::try_new([StructField::nullable("value", DataType::INTEGER)]).unwrap();
+        let array_ty = DataType::Array(Box::new(crate::schema::ArrayType::new(
+            DataType::Struct(Box::new(inner_field_schema)),
+            /* contains_null = */ false,
+        )));
+        let expr = Expr::array([Expr::struct_from([column_expr!("b")])]);
+        let result = evaluate_expression(&expr, &batch, Some(&array_ty)).unwrap();
+        let list = result.as_list::<i32>();
+
+        // Outer Array element field reflects the declared non-nullability of the struct.
+        let ArrowDataType::List(field) = list.data_type() else {
+            panic!("expected ListArray")
+        };
+        assert!(!field.is_nullable(), "struct element must be non-nullable");
+
+        // Each row's array has exactly one struct element, all struct-level non-null.
+        assert_eq!(list.len(), 3);
+        for row in 0..3 {
+            let elements = list.value(row);
+            let structs = elements.as_any().downcast_ref::<StructArray>().unwrap();
+            assert_eq!(structs.len(), 1);
+            assert!(structs.is_valid(0));
+        }
+        // The inner `value` field carries the null at row 1 through.
+        let row0_value = list.value(0);
+        let row0_inner = row0_value
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap()
+            .column(0)
+            .as_primitive::<Int32Type>();
+        assert_eq!(row0_inner.value(0), 10);
+        let row1_value = list.value(1);
+        let row1_inner = row1_value
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap()
+            .column(0)
+            .as_primitive::<Int32Type>();
+        assert!(row1_inner.is_null(0), "inner field must preserve the null");
+        let row2_value = list.value(2);
+        let row2_inner = row2_value
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap()
+            .column(0)
+            .as_primitive::<Int32Type>();
+        assert_eq!(row2_inner.value(0), 30);
     }
 }

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -79,6 +79,15 @@ pub enum BinaryExpressionOp {
 pub enum VariadicExpressionOp {
     /// Collapse multiple values into one by taking the first non-null value
     Coalesce,
+    /// Construct an Array by evaluating each input expression. For example, the expression
+    /// `Array(1, (1 + 2), col("my_int_col"))` evaluates to the array
+    /// `[1, 3, <my_int_col value>]` per row. All inputs must share the same element type.
+    /// Requires at least one element; the element type is inferred from the inputs.
+    ///
+    /// For static array literals whose elements are all compile-time constants, use
+    /// [`Scalar::Array`] instead. The difference is that `Array` is evaluated at runtime, while
+    /// `Scalar::Array` is evaluated at compile time.
+    Array,
 }
 
 /// A junction (AND/OR) predicate operator.
@@ -775,6 +784,11 @@ impl Expression {
         Self::variadic(VariadicExpressionOp::Coalesce, exprs)
     }
 
+    /// Creates a new Array constructor expression. See [`VariadicExpressionOp::Array`].
+    pub fn array(exprs: impl IntoIterator<Item = impl Into<Expression>>) -> Self {
+        Self::variadic(VariadicExpressionOp::Array, exprs)
+    }
+
     /// Creates a new opaque expression
     pub fn opaque(
         op: impl OpaqueExpressionOp,
@@ -1000,6 +1014,7 @@ impl Display for VariadicExpressionOp {
         use VariadicExpressionOp::*;
         match self {
             Coalesce => write!(f, "COALESCE"),
+            Array => write!(f, "ARRAY"),
         }
     }
 }
@@ -1209,6 +1224,10 @@ mod tests {
                 Expr::struct_from([column_expr!("x"), Expr::literal(2), Expr::literal(10)]),
                 "Struct(Column(x), 2, 10)",
             ),
+            (
+                Expr::array([column_expr!("x"), column_expr!("y"), Expr::literal(0)]),
+                "ARRAY(Column(x), Column(y), 0)",
+            ),
         ];
 
         for (expr, expected) in cases {
@@ -1411,6 +1430,17 @@ mod tests {
                 column_expr!("b"),
                 Expression::literal("default"),
             ]);
+            assert_roundtrip(&expr);
+        }
+
+        #[rstest::rstest]
+        #[case::array_single(Expression::array([Expression::literal(7i32)]))]
+        #[case::array_mixed(Expression::array([
+            column_expr!("a"),
+            column_expr!("b"),
+            Expression::literal(42i64),
+        ]))]
+        fn test_array_expression_roundtrip(#[case] expr: Expression) {
             assert_roundtrip(&expr);
         }
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2639/files) to review incremental changes.
- [**stack/b2**](https://github.com/delta-io/delta-kernel-rs/pull/2639) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2639/files)]

---------
## Motivation

Full state reconstruction (FSR) needs a per-row dedup key so that the latest action for each identity wins. Today the key is built imperatively in kernel (`extract_dv_unique_id` and friends). The plan-based engine moves that work out of kernel: kernel emits a plan whose dedup-key column is an `Expression` evaluated by the engine. That requires the key construction to be expressible in the kernel IR.

Each Delta action kind (add/remove, protocol, metaData, domainMetadata, txn) maps to a uniformly-shaped `ARRAY<STRING?>` whose first element identifies the kind — e.g. `[coalesce(add.path, remove.path), dv_storage, dv_inline_id]`, `["domainMetadata", domain]`, `["appTxn", appId]`. `Array(...)` is the primitive that constructs those per-row keys.

## What changes are proposed in this pull request?

Adds the per-row array constructor.

- `VariadicExpressionOp::Array` variant + `Expression::array(exprs)` constructor. Each input contributes one element per output row; all inputs must share the same element type. Requires at least one element — the element type is inferred from the inputs.
- Arrow evaluator that produces a `ListArray` from the per-row evaluation of each input expression.
- FFI `EngineExpressionVisitor::visit_array` callback. The `visit-expression` C example wires `Coalesce` + `ArrayConstructor` enum members (the prior `visit_coalesce` field was unwired in the C example — drive-by fix) so dispatch is exercised end-to-end in CI.

### Public API changes

A new expression variant `VariadicExpressionOp::Array` and constructor `Expression::array`. Adding a variant to the exhaustive `VariadicExpressionOp` enum is a breaking change on its own (cargo-semver-checks `enum_variant_added`); the new non-null `visit_array` field on the `EngineExpressionVisitor` FFI struct is breaking too. Hence `feat!`.

## How was this change tested?

- `cargo +nightly fmt && cargo clippy --workspace --benches --tests --all-features -- -D warnings && cargo doc --workspace --all-features --no-deps`
- Arrow evaluator:
  - Arity sweep (N=1/2/3, mixed col+literal)
  - Output field nullability propagation (including the realistic "nullable input column → nullable element field" path)
  - Empty-batch (0 rows) boundary
  - Struct-typed elements
  - Non-null struct element with a null inner field (verifies `contains_null=false` operates on struct-level validity, not inner field nulls)
  - Null propagation
  - Complex children (arithmetic + sibling-variadic `COALESCE` as inputs; `COALESCE` of two `ARRAY`-of-structs in the realistic dedup-key shape)
  - Error paths (empty inputs, wrong `result_type`, type mismatch, null in non-nullable)
- FFI: the C `visit-expression` example evaluates kernel-built `Coalesce` and `Array` end-to-end against a golden output