### PR TITLE
feat: add kernel_reducers, framework engine_error, and Sidecar Clone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,6 +1277,7 @@ dependencies = [
  "criterion",
  "delta_kernel",
  "delta_kernel_derive",
+ "dyn-clone",
  "futures",
  "hdfs-native",
  "hdfs-native-object-store",
@@ -1478,6 +1479,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -53,6 +53,8 @@ serde_json = "1"
 strum = { version = "0.27", features = ["derive"] }
 thiserror = "2"
 prost = { version = "0.13", optional = true }
+# Object-safe `Clone` for the `KernelReducer` trait. Gated by `declarative-plans`.
+dyn-clone = { version = "1.0", optional = true }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = "0.3"
 url = "2"
@@ -116,7 +118,7 @@ arrow-expression = ["need-arrow"]
 schema-diff = []
 
 # Declarative plan IR (experimental).
-declarative-plans = ["internal-api", "dep:prost", "dep:prost-build", "dep:protoc-bin-vendored"]
+declarative-plans = ["internal-api", "dep:prost", "dep:prost-build", "dep:protoc-bin-vendored", "dep:dyn-clone"]
 
 # Experimental, temporary, test-only feature flag guarding the in-progress column-defaults
 # work. TODO(#2630): remove once full column-defaults support ships.

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -639,6 +639,7 @@ impl Protocol {
 
     /// Create a new Protocol by visiting the EngineData and extracting the first protocol row into
     /// a Protocol instance. If no protocol row is found, returns Ok(None).
+    #[internal_api]
     pub(crate) fn try_new_from_data(data: &dyn EngineData) -> DeltaResult<Option<Protocol>> {
         let mut visitor = ProtocolVisitor::default();
         visitor.visit_rows_of(data)?;
@@ -951,7 +952,7 @@ impl SetTransaction {
 /// file actions. This action is only allowed in checkpoints following the V2 spec.
 ///
 /// [More info]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#sidecar-file-information
-#[derive(ToSchema, Debug, PartialEq)]
+#[derive(ToSchema, Debug, Clone, PartialEq)]
 #[internal_api]
 pub(crate) struct Sidecar {
     /// A path to a sidecar file that can be either:

--- a/kernel/src/actions/visitors.rs
+++ b/kernel/src/actions/visitors.rs
@@ -377,7 +377,7 @@ impl RowVisitor for SetTransactionVisitor {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug, Clone)]
 #[internal_api]
 pub(crate) struct SidecarVisitor {
     pub(crate) sidecars: Vec<Sidecar>,

--- a/kernel/src/plans/errors/mod.rs
+++ b/kernel/src/plans/errors/mod.rs
@@ -1,0 +1,337 @@
+//! Typed error surface for the declarative plans layer.
+//!
+//! [`DeltaError`] is the error type used by state machines and the plan executor. It coexists
+//! with [`Error`]; lifting an [`Error`] into a [`DeltaError`] goes through the named bridge
+//! [`KernelErrAsDelta`] -- deliberately no `From<Error>` impl, so the conversion sites are
+//! grep-able. (A `From<BoxedSource>` does exist for the catch-all `dyn Error + Send + Sync`
+//! shape used by Delta-agnostic helpers; that path tags every lifted error with
+//! [`DeltaErrorCode::DeltaCommandInvariantViolation`].)
+//!
+//! # Construction
+//!
+//! Every error is built through a named constructor on [`DeltaError`], one per
+//! [`DeltaErrorCode`]. The human message is fixed per code ([`DeltaErrorCode::message`]); the
+//! constructor takes only the runtime detail / underlying cause, which becomes the error's
+//! [`source`](DeltaError::source). The detail is `impl Into<BoxedSource>`, so it accepts a bare
+//! string (auto-wrapped as a trivial error) or any real error (kept with its type and chain).
+//!
+//! [`DeltaResultExt::or_delta`] does the same at a `?` site: it attaches a code and keeps the
+//! original error as the source.
+//!
+//! ```ignore
+//! use delta_kernel::plans::errors::{DeltaError, DeltaErrorCode, DeltaResultExt};
+//!
+//! return Err(DeltaError::table_not_found(format!("{name}")));
+//! let v: u64 = "42".parse().or_delta(DeltaErrorCode::DeltaVersionInvalid)?;
+//! let e = DeltaError::file_not_found(io_err);
+//! ```
+
+use std::backtrace::Backtrace;
+
+use crate::Error;
+
+// ============================================================================
+// DeltaErrorCode -- macro-driven declaration
+// ============================================================================
+
+/// Declarative table of Delta error codes. Each row binds a variant to its FFI-stable
+/// discriminant, SCREAMING_SNAKE name, SQLSTATE, and a static human message.
+///
+/// The message is fixed per code; runtime detail (the offending path, version, cause, ...) is
+/// never formatted into it -- it lives in [`DeltaError::source`].
+///
+/// Discriminants are explicit because the enum is `#[repr(u32)]` for FFI ABI stability.
+/// Reassigning or reusing a discriminant is a breaking change; pick the next unused integer.
+macro_rules! delta_codes {
+    (
+        $(
+            $( #[$meta:meta] )*
+            $variant:ident = $disc:literal,
+            $name:literal,
+            $sqlstate:literal,
+            $message:literal
+        ),+
+        $(,)?
+    ) => {
+        /// Typed identifier for a Delta error.
+        ///
+        /// `#[repr(u32)]` pins the integer layout for FFI; `#[non_exhaustive]` reserves space
+        /// for additional codes -- downstream consumers must treat unknown integers as opaque.
+        #[repr(u32)]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[non_exhaustive]
+        pub enum DeltaErrorCode {
+            $( $( #[$meta] )* $variant = $disc ),+
+        }
+
+        impl DeltaErrorCode {
+            /// SCREAMING_SNAKE name for this error code.
+            pub fn name(&self) -> &'static str {
+                match self { $( Self::$variant => $name ),+ }
+            }
+
+            /// 5-character SQLSTATE classifying the error (SQL-standard class + subclass).
+            pub fn sqlstate(&self) -> &'static str {
+                match self { $( Self::$variant => $sqlstate ),+ }
+            }
+
+            /// Static human-readable message for this code. Carries no runtime detail.
+            pub fn message(&self) -> &'static str {
+                match self { $( Self::$variant => $message ),+ }
+            }
+        }
+    };
+}
+
+delta_codes! {
+    /// `DELTA_COMMAND_INVARIANT_VIOLATION` -- internal-error catch-all for SMs detecting an
+    /// impossible state. Discriminant `0` is deliberate: a zero-initialized wire value decodes
+    /// to "invariant violation" so engines that fail to populate the code slot still surface
+    /// a meaningful error.
+    DeltaCommandInvariantViolation = 0, "DELTA_COMMAND_INVARIANT_VIOLATION", "XXKDS",
+        "internal invariant violated",
+    /// Delta table does not exist.
+    DeltaTableNotFound = 1, "DELTA_TABLE_NOT_FOUND", "42P01", "Delta table not found",
+    /// Path is not a Delta table.
+    DeltaMissingDeltaTable = 2, "DELTA_MISSING_DELTA_TABLE", "42P01", "not a Delta table",
+    /// Path doesn't exist, or is not a Delta table.
+    DeltaPathDoesNotExist = 3, "DELTA_PATH_DOES_NOT_EXIST", "42K03", "path does not exist",
+    /// Requested version is outside the available range.
+    DeltaVersionNotFound = 4, "DELTA_VERSION_NOT_FOUND", "22003", "version not found",
+    /// A provided version string / number is not parseable.
+    DeltaVersionInvalid = 5, "DELTA_VERSION_INVALID", "42815", "invalid version",
+    /// A commit file needed to reconstruct state is missing.
+    DeltaLogFileNotFound = 6, "DELTA_LOG_FILE_NOT_FOUND", "42K03", "commit log file not found",
+    /// A data file referenced by the log is missing.
+    DeltaFileNotFound = 7, "DELTA_FILE_NOT_FOUND", "42K03", "file not found",
+    /// A multipart checkpoint is missing shards.
+    DeltaMissingPartFiles = 8, "DELTA_MISSING_PART_FILES", "42KD6", "checkpoint is missing part files",
+    /// Protocol / metadata could not be reconstructed.
+    DeltaStateRecoverError = 9, "DELTA_STATE_RECOVER_ERROR", "XXKDS",
+        "failed to reconstruct table state",
+    /// The table requires a protocol the kernel doesn't support.
+    DeltaInvalidProtocolVersion = 10, "DELTA_INVALID_PROTOCOL_VERSION", "KD004",
+        "unsupported protocol version",
+    /// A commit raced with another transaction.
+    DeltaConcurrentWrite = 11, "DELTA_CONCURRENT_WRITE", "2D521",
+        "commit failed due to a concurrent write",
+    /// Attempt to create a Delta log that already exists.
+    DeltaLogAlreadyExists = 12, "DELTA_LOG_ALREADY_EXISTS", "42K04", "Delta log already exists",
+}
+
+// ============================================================================
+// DeltaError
+// ============================================================================
+
+/// Boxed, sendable source error held by [`DeltaError::source`].
+pub type BoxedSource = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// Typed Delta error.
+///
+/// The human message is static per [`DeltaErrorCode`] ([`DeltaErrorCode::message`]); all runtime
+/// detail (the offending path, version, underlying cause) lives in [`source`](Self::source).
+/// `Display` emits `[<CODE_NAME>] <static message>`, and `source` is forwarded via
+/// `std::error::Error::source()` so standard ecosystem walkers see the detail.
+#[derive(Debug, thiserror::Error)]
+#[error("[{}] {}", self.code.name(), self.code.message())]
+pub struct DeltaError {
+    /// Stable typed identifier; also determines the human message.
+    pub code: DeltaErrorCode,
+    /// Runtime detail / underlying cause, forwarded via `std::error::Error::source()`. A bare
+    /// `String`/`&str` is accepted and wrapped as a trivial error (stdlib `From`).
+    #[source]
+    pub source: Option<BoxedSource>,
+    /// `Some(Backtrace::capture())` -- a no-op without `RUST_BACKTRACE=1`, so the "always on"
+    /// default is free in production.
+    pub backtrace: Option<Backtrace>,
+}
+
+impl DeltaError {
+    /// Crate-internal primitive: build an error from a code and its runtime detail / cause. The
+    /// per-code constructors below and [`DeltaResultExt::or_delta`] funnel through here.
+    pub(crate) fn new(code: DeltaErrorCode, source: impl Into<BoxedSource>) -> Self {
+        Self {
+            code,
+            source: Some(source.into()),
+            backtrace: Some(Backtrace::capture()),
+        }
+    }
+
+    // === Per-code constructors ==========================================================
+    //
+    // Each takes the runtime detail as `impl Into<BoxedSource>`: a bare string (auto-wrapped)
+    // or any underlying error (kept with its type and source chain). The human message is the
+    // code's static one.
+
+    /// `DELTA_COMMAND_INVARIANT_VIOLATION` -- an internal "this should never happen" failure.
+    pub fn invariant(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaCommandInvariantViolation, detail)
+    }
+
+    /// `DELTA_TABLE_NOT_FOUND` -- the Delta table does not exist.
+    pub fn table_not_found(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaTableNotFound, detail)
+    }
+
+    /// `DELTA_MISSING_DELTA_TABLE` -- the path is not a Delta table.
+    pub fn missing_delta_table(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaMissingDeltaTable, detail)
+    }
+
+    /// `DELTA_PATH_DOES_NOT_EXIST` -- the path does not exist.
+    pub fn path_does_not_exist(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaPathDoesNotExist, detail)
+    }
+
+    /// `DELTA_VERSION_NOT_FOUND` -- the requested version is outside the available range.
+    pub fn version_not_found(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaVersionNotFound, detail)
+    }
+
+    /// `DELTA_VERSION_INVALID` -- a version string/number is not parseable.
+    pub fn version_invalid(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaVersionInvalid, detail)
+    }
+
+    /// `DELTA_LOG_FILE_NOT_FOUND` -- a commit file needed to reconstruct state is missing.
+    pub fn log_file_not_found(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaLogFileNotFound, detail)
+    }
+
+    /// `DELTA_FILE_NOT_FOUND` -- a data file referenced by the log is missing.
+    pub fn file_not_found(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaFileNotFound, detail)
+    }
+
+    /// `DELTA_MISSING_PART_FILES` -- a multipart checkpoint is missing shards.
+    pub fn missing_part_files(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaMissingPartFiles, detail)
+    }
+
+    /// `DELTA_STATE_RECOVER_ERROR` -- protocol/metadata could not be reconstructed.
+    pub fn state_recover_error(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaStateRecoverError, detail)
+    }
+
+    /// `DELTA_INVALID_PROTOCOL_VERSION` -- the table requires an unsupported protocol.
+    pub fn invalid_protocol_version(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaInvalidProtocolVersion, detail)
+    }
+
+    /// `DELTA_CONCURRENT_WRITE` -- a commit raced with another transaction.
+    pub fn concurrent_write(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaConcurrentWrite, detail)
+    }
+
+    /// `DELTA_LOG_ALREADY_EXISTS` -- attempt to create a Delta log that already exists.
+    pub fn log_already_exists(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaLogAlreadyExists, detail)
+    }
+}
+
+/// Auto-convert a [`BoxedSource`] (the boxed `dyn Error` shape used by Delta-agnostic helpers
+/// like `schema_expr` and `plan_context`) into a [`DeltaError`] tagged with the catch-all
+/// [`DeltaErrorCode::DeltaCommandInvariantViolation`]. Lets `?` propagate these errors into
+/// `Result<_, DeltaError>` functions without an explicit `.or_delta(...)` wrap.
+///
+/// Use [`DeltaResultExt::or_delta`] when a more specific code is appropriate -- this impl is
+/// intentionally the catch-all path.
+impl From<BoxedSource> for DeltaError {
+    fn from(source: BoxedSource) -> Self {
+        Self::new(DeltaErrorCode::DeltaCommandInvariantViolation, source)
+    }
+}
+
+// ============================================================================
+// Bridges -- kernel::Error <-> DeltaError
+// ============================================================================
+
+/// Lift an [`Error`] into a [`DeltaError`] tagged with
+/// [`DeltaErrorCode::DeltaCommandInvariantViolation`]. Use when a more specific code is not
+/// known; upgrading to a specific constructor (e.g. `DeltaError::file_not_found(path)`) is a
+/// drop-in refactor.
+pub trait KernelErrAsDelta {
+    fn into_delta_internal(self) -> DeltaError;
+}
+
+impl KernelErrAsDelta for Error {
+    fn into_delta_internal(self) -> DeltaError {
+        DeltaError::invariant(self)
+    }
+}
+
+// ============================================================================
+// or_delta at ? sites
+// ============================================================================
+
+/// Attach a [`DeltaErrorCode`] to any `Result<T, E>` whose error can be lifted into a
+/// [`BoxedSource`]. The original error is preserved as [`DeltaError::source`] (walkable via
+/// `std::error::Error::source()`); the message comes from the code.
+///
+/// The bound `E: Into<BoxedSource>` covers two cases without an extra `Box` layer:
+/// - any concrete `E: Error + Send + Sync + 'static` (stdlib's blanket `From` impl), and
+/// - errors that are already a [`BoxedSource`] (low-level modules that return a `Box<dyn Error +
+///   Send + Sync + 'static>` directly to stay Delta-agnostic).
+pub trait DeltaResultExt<T> {
+    fn or_delta(self, code: DeltaErrorCode) -> Result<T, DeltaError>;
+}
+
+impl<T, E> DeltaResultExt<T> for Result<T, E>
+where
+    E: Into<BoxedSource>,
+{
+    fn or_delta(self, code: DeltaErrorCode) -> Result<T, DeltaError> {
+        self.map_err(|e| DeltaError::new(code, e))
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error;
+
+    use super::*;
+
+    #[test]
+    fn display_is_code_name_plus_static_message() {
+        let err = DeltaError::table_not_found("my_table");
+        assert_eq!(err.code, DeltaErrorCode::DeltaTableNotFound);
+        let s = err.to_string();
+        assert!(s.contains("DELTA_TABLE_NOT_FOUND"), "got: {s}");
+        assert!(s.contains("Delta table not found"), "got: {s}");
+    }
+
+    #[test]
+    fn string_detail_becomes_source() {
+        let err = DeltaError::invariant("snapshot.rebuild: protocol missing");
+        assert_eq!(err.code, DeltaErrorCode::DeltaCommandInvariantViolation);
+        assert_eq!(err.code.message(), "internal invariant violated");
+        let src = err.source().expect("string detail preserved as source");
+        assert_eq!(src.to_string(), "snapshot.rebuild: protocol missing");
+    }
+
+    #[test]
+    fn error_detail_keeps_its_type_in_source() {
+        let io = std::io::Error::other("boom");
+        let err = DeltaError::file_not_found(io);
+        assert_eq!(err.code, DeltaErrorCode::DeltaFileNotFound);
+        let src = err.source().expect("source");
+        assert!(src.is::<std::io::Error>());
+        assert!(src.to_string().contains("boom"));
+    }
+
+    #[test]
+    fn or_delta_preserves_original_error_in_source() {
+        fn parse_version(s: &str) -> Result<u64, DeltaError> {
+            s.parse::<u64>()
+                .or_delta(DeltaErrorCode::DeltaVersionInvalid)
+        }
+        let err = parse_version("not-a-number").unwrap_err();
+        assert_eq!(err.code, DeltaErrorCode::DeltaVersionInvalid);
+        let src = err.source().expect("parse error preserved");
+        assert!(src.is::<std::num::ParseIntError>());
+    }
+}

--- a/kernel/src/plans/kernel_reducers/checkpoint_hint.rs
+++ b/kernel/src/plans/kernel_reducers/checkpoint_hint.rs
@@ -1,0 +1,171 @@
+//! `CheckpointHintReader` -- reducer KDF that reads a `_last_checkpoint`
+//! JSON scan and extracts the hint record.
+//!
+//! The file contains a single row. The reader captures it on the first
+//! batch, returns [`KdfControl::Break`] to stop further input, and reduces
+//! to `Option<CheckpointHintRecord>` -- `None` when the file was absent (zero
+//! rows), `Some` when the hint was extracted.
+
+use std::sync::LazyLock;
+
+use delta_kernel_derive::ToSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::engine_data::{GetData, RowVisitor, TypedGetData as _};
+use crate::plans::errors::DeltaError;
+use crate::plans::kernel_reducers::{
+    KdfControl, KernelReducer, KernelReducerKind, KernelReducerOutput,
+};
+use crate::schema::{ColumnName, ColumnNamesAndTypes, DataType, ToSchema};
+use crate::{DeltaResult, EngineData};
+
+/// `_last_checkpoint` JSON hint file record. Parsed by [`CheckpointHintReader`] from
+/// the single-row hint file; deriving [`ToSchema`] lets the reader source the row
+/// visitor's column schema from the struct definition.
+///
+/// Intentionally a subset of [`crate::last_checkpoint_hint::LastCheckpointHint`]: only
+/// the fields the plans layer currently consumes (`version`, `size`, `parts`,
+/// `sizeInBytes`, `numOfAddFiles`) are projected. `checkpointSchema`, `checksum`, and
+/// `tags` are omitted; if the plans layer ever needs them (e.g. for footer skipping based
+/// on the checkpoint schema), extend this record rather than reading them ad-hoc.
+#[derive(ToSchema, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CheckpointHintRecord {
+    /// Commit version the checkpoint covers.
+    pub version: i64,
+    /// Total logical size of the checkpoint (bytes), if known.
+    pub size: Option<i64>,
+    /// Number of parts for multipart checkpoints, if any. Stored as `i64` to keep the
+    /// JSON deserialization aligned with [`LastCheckpointHint::parts`] (`Option<usize>`)
+    /// on 64-bit targets.
+    pub parts: Option<i64>,
+    /// Total on-disk size of the checkpoint (bytes), if known.
+    pub size_in_bytes: Option<i64>,
+    /// Count of add-file actions in the checkpoint, if tracked.
+    pub num_of_add_files: Option<i64>,
+}
+
+/// Reader state: holds the extracted record. `record.is_some()` doubles as the
+/// "already processed" flag to short-circuit subsequent batches.
+#[derive(Debug, Clone, Default)]
+pub struct CheckpointHintReader {
+    record: Option<CheckpointHintRecord>,
+}
+
+impl KernelReducer for CheckpointHintReader {
+    fn kind(&self) -> KernelReducerKind {
+        KernelReducerKind::CheckpointHint
+    }
+
+    fn finish(self: Box<Self>) -> Box<dyn std::any::Any + Send> {
+        Box::new(*self)
+    }
+
+    fn apply(&mut self, batch: &dyn EngineData) -> DeltaResult<KdfControl> {
+        if self.record.is_none() {
+            self.visit_rows_of(batch)?;
+        }
+        Ok(if self.record.is_some() {
+            KdfControl::Break
+        } else {
+            KdfControl::Continue
+        })
+    }
+}
+
+impl KernelReducerOutput for CheckpointHintReader {
+    type Output = Option<CheckpointHintRecord>;
+
+    fn into_output(self) -> Result<Self::Output, DeltaError> {
+        Ok(self.record)
+    }
+}
+
+impl RowVisitor for CheckpointHintReader {
+    fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
+        static NAMES_AND_TYPES: LazyLock<ColumnNamesAndTypes> =
+            LazyLock::new(|| CheckpointHintRecord::to_schema().leaves(None));
+        NAMES_AND_TYPES.as_ref()
+    }
+
+    fn visit<'a>(&mut self, row_count: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
+        if self.record.is_some() || row_count == 0 {
+            return Ok(());
+        }
+        // The `_last_checkpoint` file is a single row per the protocol. Reject extra rows
+        // loudly instead of silently consuming only row 0 -- the kernel may otherwise miss
+        // a corrupt/multi-row hint file produced by a buggy writer or a different format.
+        if row_count > 1 {
+            return Err(crate::Error::generic(format!(
+                "_last_checkpoint hint reader expected 1 row, got {row_count}"
+            )));
+        }
+        // Column order matches the leaf traversal of `CheckpointHintRecord`.
+        self.record = Some(CheckpointHintRecord {
+            version: getters[0].get(0, "version")?,
+            size: getters[1].get_opt(0, "size")?,
+            parts: getters[2].get_opt(0, "parts")?,
+            size_in_bytes: getters[3].get_opt(0, "sizeInBytes")?,
+            num_of_add_files: getters[4].get_opt(0, "numOfAddFiles")?,
+        });
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::arrow::array::{ArrayRef, Int64Array, RecordBatch};
+    use crate::arrow::datatypes::{
+        DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
+    };
+    use crate::engine::arrow_data::ArrowEngineData;
+
+    #[test]
+    fn empty_partition_produces_none() {
+        let reader = CheckpointHintReader::default();
+        let out = reader.into_output().unwrap();
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn apply_reads_first_row_and_breaks() {
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("version", ArrowDataType::Int64, false),
+            ArrowField::new("size", ArrowDataType::Int64, true),
+            ArrowField::new("parts", ArrowDataType::Int64, true),
+            ArrowField::new("sizeInBytes", ArrowDataType::Int64, true),
+            ArrowField::new("numOfAddFiles", ArrowDataType::Int64, true),
+        ]));
+        let columns: Vec<ArrayRef> = vec![
+            Arc::new(Int64Array::from(vec![42])),
+            Arc::new(Int64Array::from(vec![Some(100)])),
+            Arc::new(Int64Array::from(vec![None])),
+            Arc::new(Int64Array::from(vec![Some(2048)])),
+            Arc::new(Int64Array::from(vec![Some(7)])),
+        ];
+        let batch = RecordBatch::try_new(schema, columns).unwrap();
+        let engine_data = ArrowEngineData::new(batch);
+
+        let mut reader = CheckpointHintReader::default();
+        assert_eq!(reader.apply(&engine_data).unwrap(), KdfControl::Break);
+        assert_eq!(reader.apply(&engine_data).unwrap(), KdfControl::Break);
+
+        let out = reader.into_output().unwrap();
+        let rec = out.expect("record");
+        // Assert every projected field (full structural equality). Spot-checking only
+        // `version` + `num_of_add_files` would silently miss a regression in `size`,
+        // `parts`, or `size_in_bytes` decoding.
+        assert_eq!(
+            rec,
+            CheckpointHintRecord {
+                version: 42,
+                size: Some(100),
+                parts: None,
+                size_in_bytes: Some(2048),
+                num_of_add_files: Some(7),
+            },
+        );
+    }
+}

--- a/kernel/src/plans/kernel_reducers/handle.rs
+++ b/kernel/src/plans/kernel_reducers/handle.rs
@@ -1,0 +1,224 @@
+//! Runtime state for KDF reducers.
+//!
+//! [`ReducerHandle`] is the executor's working buffer for one Reduce step: created when a
+//! phase starts, fed batches via [`ReducerHandle::apply`], finalized via
+//! [`ReducerHandle::finish`] when the child is exhausted. Type-erased into [`FinishedHandle`]
+//! and returned to the state machine as the Reduce response.
+//!
+//! Handles dispatch in-process and never cross a serialization boundary.
+//!
+//! Callers recover typed output from a [`FinishedHandle`] via the paired [`Extractor`], minted
+//! at plan-build time and threaded through to the SM body.
+// Intra-doc links to the state-machine framework / IR sink types intentionally degrade to
+// plain text in this module slice (the linked items live in sibling stacks).
+#![allow(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
+
+use std::any::Any;
+
+use super::reducer::{KdfControl, KernelReducer, KernelReducerOutput, KernelReducerToken};
+use crate::plans::errors::DeltaError;
+use crate::plans::state_machines::framework::engine_error::EngineError;
+use crate::{DeltaResult, EngineData};
+
+/// Runtime state carrier. Holds the mutable reducer working buffer and the token that joins
+/// its eventual finalized state back to the plan-tree node.
+#[derive(Debug)]
+pub struct ReducerHandle {
+    token: KernelReducerToken,
+    inner: Box<dyn KernelReducer>,
+}
+
+impl ReducerHandle {
+    /// Construct a handle from a fresh token and a cloned initial state.
+    pub fn new(token: KernelReducerToken, inner: Box<dyn KernelReducer>) -> Self {
+        Self { token, inner }
+    }
+
+    /// Apply the reducer to a batch.
+    #[tracing::instrument(
+        level = "trace",
+        name = "kernel_reducer.apply",
+        skip(self, batch),
+        ret,
+        fields(kind = %self.inner.kind(), token_id = %self.token.id),
+    )]
+    pub fn apply(&mut self, batch: &dyn EngineData) -> DeltaResult<KdfControl> {
+        self.inner.apply(batch)
+    }
+
+    /// Consume the handle, returning the finalized token-stamped state.
+    #[tracing::instrument(
+        level = "debug",
+        name = "kernel_reducer.finish",
+        skip(self),
+        fields(kind = %self.inner.kind(), token_id = %self.token.id),
+    )]
+    pub fn finish(self) -> FinishedHandle {
+        tracing::debug!("kernel reducer handle finished");
+        FinishedHandle {
+            token: self.token,
+            erased: self.inner.finish(),
+        }
+    }
+}
+
+/// Output of [`ReducerHandle::finish`] -- carries the token and the type-erased final state.
+#[derive(Debug)]
+pub struct FinishedHandle {
+    pub token: KernelReducerToken,
+    pub erased: Box<dyn Any + Send>,
+}
+
+// === Typed extraction ===
+
+/// A typed adapter for pulling the typed output of a single reduce sink
+/// out of a [`FinishedHandle`].
+///
+/// SM bodies build an `Extractor` while planting an [`EngineRequest::Reduce`] (via
+/// [`Context::reduce`]) and feed the engine's [`FinishedHandle`] back through
+/// [`Self::extract`] on resume.
+///
+/// [`EngineRequest::Reduce`]: crate::plans::state_machines::framework::state_machine::EngineRequest::Reduce
+/// [`Context::reduce`]: crate::plans::state_machines::framework::plan_context::Context::reduce
+pub struct Extractor<O> {
+    token: KernelReducerToken,
+    extract: fn(Box<dyn Any + Send>) -> Result<O, DeltaError>,
+}
+
+impl<O: Send + 'static> Extractor<O> {
+    /// Build an `Extractor` for KDF state `S` at `token`. The stored function pointer
+    /// downcasts the erased payload back to `S` and runs `S::into_output`.
+    // Consumer (Context::reduce dispatch) lands in the StateMachine follow-up PR.
+    #[allow(dead_code)]
+    pub(crate) fn for_reducer<S>(token: KernelReducerToken) -> Self
+    where
+        S: KernelReducerOutput<Output = O> + 'static,
+    {
+        Self {
+            token,
+            extract: extract_reducer::<S>,
+        }
+    }
+
+    /// Decode `handle`'s payload into the typed output `O`.
+    ///
+    /// Sanity-checks that `handle.token` matches this extractor's token (cross-wired
+    /// finished handles surface as an internal error) and runs the typed reduction.
+    /// Decoding failures are wrapped in [`EngineError::internal`] so SM bodies can
+    /// uniformly handle them on the engine-error path.
+    pub fn extract(self, handle: FinishedHandle) -> Result<O, EngineError> {
+        if handle.token != self.token {
+            return Err(EngineError::internal(DeltaError::invariant(format!(
+                "kernel_reducer::extract: token mismatch -- handle token `{}` vs expected `{}`",
+                handle.token, self.token,
+            ))));
+        }
+        (self.extract)(handle.erased).map_err(EngineError::internal)
+    }
+}
+
+impl<O> std::fmt::Debug for Extractor<O> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Extractor")
+            .field("token", &self.token)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Downcast the erased payload back to `S` and run its typed reduction. Bound to a
+/// concrete `S` via `Extractor::for_reducer`'s generic fn-pointer coercion.
+#[allow(dead_code)] // only consumer is for_reducer, gated above
+fn extract_reducer<S>(erased: Box<dyn Any + Send>) -> Result<S::Output, DeltaError>
+where
+    S: KernelReducerOutput + 'static,
+{
+    let single = erased.downcast::<S>().map(|b| *b).map_err(|_| {
+        DeltaError::invariant(format!(
+            "kernel_reducer::extract: expected `{}`",
+            std::any::type_name::<S>(),
+        ))
+    })?;
+    single.into_output()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{CheckpointHintReader, KernelReducerKind, KernelReducerToken};
+    use super::*;
+
+    /// Exercise the Extractor round-trip end-to-end: build a CheckpointHintReader, drive it
+    /// through ReducerHandle, finish it, hand the FinishedHandle to a matching Extractor,
+    /// and assert the typed output. Catches any drift between token wiring, downcast typing,
+    /// and KernelReducerOutput::into_output.
+    #[test]
+    fn extractor_round_trip_returns_typed_state() {
+        // Construct a populated reader via the visit path so we don't need to peek at
+        // private fields. We feed it a synthetic single-row batch shaped like
+        // `_last_checkpoint`.
+        use crate::arrow::array::{ArrayRef, Int64Array, RecordBatch};
+        use crate::arrow::datatypes::{
+            DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
+        };
+        use crate::engine::arrow_data::ArrowEngineData;
+        let schema = std::sync::Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("version", ArrowDataType::Int64, false),
+            ArrowField::new("size", ArrowDataType::Int64, true),
+            ArrowField::new("parts", ArrowDataType::Int64, true),
+            ArrowField::new("sizeInBytes", ArrowDataType::Int64, true),
+            ArrowField::new("numOfAddFiles", ArrowDataType::Int64, true),
+        ]));
+        let columns: Vec<ArrayRef> = vec![
+            std::sync::Arc::new(Int64Array::from(vec![7])),
+            std::sync::Arc::new(Int64Array::from(vec![Some(1024)])),
+            std::sync::Arc::new(Int64Array::from(vec![None])),
+            std::sync::Arc::new(Int64Array::from(vec![Some(2048)])),
+            std::sync::Arc::new(Int64Array::from(vec![Some(3)])),
+        ];
+        let batch = RecordBatch::try_new(schema, columns).unwrap();
+        let engine_data = ArrowEngineData::new(batch);
+
+        let token = KernelReducerToken::new(KernelReducerKind::CheckpointHint);
+        let reader = CheckpointHintReader::default();
+        let mut handle = ReducerHandle::new(token.clone(), Box::new(reader));
+        assert_eq!(handle.apply(&engine_data).unwrap(), KdfControl::Break);
+        let finished = handle.finish();
+
+        let extractor =
+            Extractor::<<CheckpointHintReader as KernelReducerOutput>::Output>::for_reducer::<
+                CheckpointHintReader,
+            >(token);
+        let out = extractor
+            .extract(finished)
+            .expect("typed extract must succeed");
+        let rec = out.expect("record");
+        assert_eq!(rec.version, 7);
+        assert_eq!(rec.num_of_add_files, Some(3));
+    }
+
+    /// Mismatched tokens MUST surface as an EngineError::internal -- the extractor's whole
+    /// raison d'etre is to detect cross-wired handles between phases of a plan.
+    #[test]
+    fn extractor_rejects_mismatched_token() {
+        let token_a = KernelReducerToken::new(KernelReducerKind::CheckpointHint);
+        let token_b = KernelReducerToken::new(KernelReducerKind::CheckpointHint);
+        let reader = CheckpointHintReader::default();
+        let handle = ReducerHandle::new(token_a, Box::new(reader));
+        let finished = handle.finish();
+
+        let extractor =
+            Extractor::<<CheckpointHintReader as KernelReducerOutput>::Output>::for_reducer::<
+                CheckpointHintReader,
+            >(token_b);
+        let err = extractor
+            .extract(finished)
+            .expect_err("mismatched tokens must error");
+        // EngineError::internal hides the source in Display; assert the source chain
+        // (which is what SM bodies surface via display_with_source_chain) contains the
+        // diagnostic message.
+        let chain = err.display_with_source_chain();
+        assert!(
+            chain.contains("token mismatch"),
+            "source chain missing token mismatch: {chain}"
+        );
+    }
+}

--- a/kernel/src/plans/kernel_reducers/metadata_protocol.rs
+++ b/kernel/src/plans/kernel_reducers/metadata_protocol.rs
@@ -1,0 +1,177 @@
+//! `MetadataProtocolReader` -- reducer KDF that extracts the table's
+//! [`Protocol`] and [`Metadata`] actions from a log / checkpoint scan.
+//!
+//! Uses the existing [`Protocol::try_new_from_data`] and
+//! [`Metadata::try_new_from_data`] helpers, which guarantee atomic
+//! extraction -- either a full valid action is returned or `None`. The
+//! reader stops once both have been seen.
+//!
+//! # Caller invariant: newest-first ordering
+//!
+//! The reader captures the FIRST `Some(Protocol)` / `Some(Metadata)` it sees and ignores
+//! subsequent ones, so the caller MUST feed batches in `version DESC` order (newer commits
+//! first, then checkpoints, oldest last). Mirrors the contract that
+//! [`crate::log_segment::LogSegment::replay_for_pm`] establishes for the visitor path. If
+//! batches are fed in chronological order, the reader will silently return the wrong
+//! (oldest, not newest) action -- which is why we surface the contract here AND assert it
+//! via `debug_assert!` on every batch when the reducer can prove the order.
+
+use crate::actions::{Metadata, Protocol};
+use crate::plans::errors::DeltaError;
+use crate::plans::kernel_reducers::{
+    KdfControl, KernelReducer, KernelReducerKind, KernelReducerOutput,
+};
+use crate::{DeltaResult, EngineData};
+
+/// Captures the first `Some(Protocol)` / `Some(Metadata)` seen under the
+/// declared row ordering.
+#[derive(Debug, Clone, Default)]
+pub struct MetadataProtocolReader {
+    protocol: Option<Protocol>,
+    metadata: Option<Metadata>,
+}
+
+impl KernelReducer for MetadataProtocolReader {
+    fn kind(&self) -> KernelReducerKind {
+        KernelReducerKind::MetadataProtocol
+    }
+
+    fn finish(self: Box<Self>) -> Box<dyn std::any::Any + Send> {
+        Box::new(*self)
+    }
+
+    fn apply(&mut self, batch: &dyn EngineData) -> DeltaResult<KdfControl> {
+        if self.protocol.is_none() {
+            if let Some(p) = Protocol::try_new_from_data(batch)? {
+                self.protocol = Some(p);
+            }
+        }
+        if self.metadata.is_none() {
+            if let Some(m) = Metadata::try_new_from_data(batch)? {
+                self.metadata = Some(m);
+            }
+        }
+        if self.protocol.is_some() && self.metadata.is_some() {
+            Ok(KdfControl::Break)
+        } else {
+            Ok(KdfControl::Continue)
+        }
+    }
+}
+
+impl KernelReducerOutput for MetadataProtocolReader {
+    /// `(Metadata, Protocol)` matches the existing kernel convention used by
+    /// `LogSegment::read_protocol_metadata` and its underlying `replay_for_pm` helper.
+    type Output = (Metadata, Protocol);
+
+    fn into_output(self) -> Result<Self::Output, DeltaError> {
+        let missing = |what: &str| {
+            DeltaError::invariant(format!(
+                "metadata_protocol.into_output: missing {what} after scan completed"
+            ))
+        };
+        let protocol = self.protocol.ok_or_else(|| missing("protocol"))?;
+        let metadata = self.metadata.ok_or_else(|| missing("metadata"))?;
+        Ok((metadata, protocol))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::actions::Format;
+    use crate::table_features::TableFeature;
+    use crate::table_properties::{
+        COLUMN_MAPPING_MODE, ENABLE_CHANGE_DATA_FEED, ENABLE_DELETION_VECTORS,
+    };
+    use crate::utils::test_utils::action_batch;
+
+    /// The full `Protocol` carried by `crate::utils::test_utils::action_batch()`. Kept in sync
+    /// with the JSON fixture inline below so a fixture drift is loud rather than silent.
+    fn expected_action_batch_protocol() -> Protocol {
+        Protocol::try_new(
+            3,
+            7,
+            Some([TableFeature::DeletionVectors]),
+            Some([TableFeature::DeletionVectors]),
+        )
+        .expect("test fixture protocol should be valid")
+    }
+
+    /// The full `Metadata` carried by `crate::utils::test_utils::action_batch()`. Mirrors
+    /// `actions::visitors::tests::test_parse_metadata`'s expected struct so any drift in the
+    /// shared fixture surfaces in both tests.
+    fn expected_action_batch_metadata() -> Metadata {
+        let configuration = HashMap::from_iter([
+            (ENABLE_DELETION_VECTORS.to_string(), "true".to_string()),
+            (COLUMN_MAPPING_MODE.to_string(), "none".to_string()),
+            (ENABLE_CHANGE_DATA_FEED.to_string(), "true".to_string()),
+        ]);
+        Metadata::new_unchecked(
+            "testId",
+            None,
+            None,
+            Format {
+                provider: "parquet".into(),
+                options: HashMap::new(),
+            },
+            r#"{"type":"struct","fields":[{"name":"value","type":"integer","nullable":true,"metadata":{}}]}"#,
+            Vec::new(),
+            Some(1677811175819),
+            configuration,
+        )
+    }
+
+    #[test]
+    fn kind_is_stable() {
+        let r = MetadataProtocolReader::default();
+        assert_eq!(KernelReducer::kind(&r), KernelReducerKind::MetadataProtocol);
+    }
+
+    #[test]
+    fn missing_protocol_errors() {
+        let r = MetadataProtocolReader::default();
+        let err = r.into_output().unwrap_err();
+        // Detail now lives in the source (the message is static per code).
+        let src = std::error::Error::source(&err).expect("detail in source");
+        assert!(src.to_string().contains("missing protocol"), "got: {src}");
+    }
+
+    #[test]
+    fn apply_extracts_protocol_and_metadata_then_breaks() {
+        // `action_batch()` is the canonical test fixture used by the visitor unit tests; it
+        // contains a single batch with both Protocol and Metadata actions, plus some adds.
+        let batch = action_batch();
+        let mut r = MetadataProtocolReader::default();
+        assert_eq!(
+            r.apply(batch.as_ref()).unwrap(),
+            KdfControl::Break,
+            "both actions present -> Break on first batch"
+        );
+
+        let (metadata, protocol) = r.into_output().unwrap();
+        // Compare against the full expected structs, not just one field each: this catches
+        // silent drift in any of the version, feature, schema, partition, configuration, or
+        // created-time fields produced by the reducer.
+        assert_eq!(protocol, expected_action_batch_protocol());
+        assert_eq!(metadata, expected_action_batch_metadata());
+    }
+
+    #[test]
+    fn apply_ignores_subsequent_actions_per_newest_first_contract() {
+        // The reader captures the FIRST Protocol/Metadata it sees and silently ignores any
+        // subsequent ones (because the caller is expected to feed newest-first). Pin that
+        // contract here so a regression that started overwriting on later batches surfaces.
+        let first = action_batch();
+        let second = action_batch();
+
+        let mut r = MetadataProtocolReader::default();
+        assert_eq!(r.apply(first.as_ref()).unwrap(), KdfControl::Break);
+        let snapshot = (r.protocol.clone(), r.metadata.clone());
+        // Subsequent apply is a no-op for state; result is still Break.
+        assert_eq!(r.apply(second.as_ref()).unwrap(), KdfControl::Break);
+        assert_eq!((r.protocol, r.metadata), snapshot);
+    }
+}

--- a/kernel/src/plans/kernel_reducers/mod.rs
+++ b/kernel/src/plans/kernel_reducers/mod.rs
@@ -1,0 +1,33 @@
+//! Kernel-Defined Functions (KDFs) -- stateful per-row logic the kernel owns.
+//!
+//! KDFs encapsulate Delta-specific per-row work (checkpoint hint extraction,
+//! protocol/metadata harvesting, sidecar collection) that engines can't interpret.
+//!
+//! The IR exposes one KDF shape: [`KernelReducer`], an observer over batches
+//! returning `Continue` / `Break`. The reducer is wired into a plan via the
+//! `Reduce` request handled by the state-machine framework (declared in a
+//! consumer module); the reducer drains the terminal row stream and accumulates
+//! finalized state for the engine to harvest.
+//!
+//! KDFs dispatch in-process and never cross a serialization boundary.
+//!
+//! Each [`ReducerHandle`] carries a [`KernelReducerToken`] (`{ kind, id }`, stamped at
+//! plan-build time, keys the executor's state table and the paired [`Extractor`]).
+// Intra-doc links to the state-machine framework / IR sink types are intentionally not
+// resolvable in this module slice (consumers live in sibling stacks). Plain-text
+// references above keep `cargo doc -D warnings` happy until those modules land.
+#![allow(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
+
+mod checkpoint_hint;
+mod handle;
+mod metadata_protocol;
+mod reducer;
+mod sidecar_collector;
+
+pub use checkpoint_hint::{CheckpointHintReader, CheckpointHintRecord};
+pub use handle::{Extractor, FinishedHandle, ReducerHandle};
+pub use metadata_protocol::MetadataProtocolReader;
+pub use reducer::{
+    KdfControl, KernelReducer, KernelReducerKind, KernelReducerOutput, KernelReducerToken,
+};
+pub use sidecar_collector::SidecarCollector;

--- a/kernel/src/plans/kernel_reducers/reducer.rs
+++ b/kernel/src/plans/kernel_reducers/reducer.rs
@@ -1,0 +1,153 @@
+//! Core `KernelReducer` trait, identity types, and typed-output companion.
+//!
+//! Adding a new KDF: declare the struct, derive `Clone`, write
+//! `impl KernelReducer for T { ... }` with `kind`, `apply`, `finish`, and pair it with a
+//! `KernelReducerOutput` impl declaring the typed output. KDFs ride on the
+//! `Reduce` engine request defined by the state-machine framework (consumer module);
+//! the request is dispatched in-process and never serialized.
+// Intra-doc links to the state-machine framework intentionally degrade to plain text in
+// this slice; consumer types live in sibling stacks.
+#![allow(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
+
+//! # Object-safety notes
+//!
+//! - Associated types are NOT on [`KernelReducer`] -- `Box<dyn KernelReducer>` must be
+//!   heterogeneous across concrete reducer implementations (the executor mixes reducers with
+//!   different state types). Typed output lives on the [`KernelReducerOutput`] companion trait via
+//!   static dispatch.
+//! - `finish(self: Box<Self>) -> Box<dyn Any + Send>` erases the per-impl state type to keep the
+//!   trait object-safe. Typed factories downcast inside their extract closure.
+
+use std::any::Any;
+
+use dyn_clone::DynClone;
+use strum::Display as StrumDisplay;
+use uuid::Uuid;
+
+use crate::plans::errors::DeltaError;
+use crate::{DeltaResult, EngineData};
+
+// === Control flow ===
+
+/// Loop control returned by a reducer after each batch.
+///
+/// `Break` lets a reducer stop driving more input once it has everything
+/// it needs (e.g. `CheckpointHintReader` after the first row).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KdfControl {
+    Continue,
+    Break,
+}
+
+// === Identity ===
+
+/// Stable diagnostic identifier per reducer impl. Used in tracing spans, metrics labels,
+/// panic messages, and [`KernelReducerToken`] construction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, StrumDisplay)]
+#[strum(serialize_all = "snake_case")]
+pub enum KernelReducerKind {
+    CheckpointHint,
+    MetadataProtocol,
+    SidecarCollector,
+}
+
+/// Identity for a kernel-reducer entry on a finished handle.
+///
+/// Stamped at plan-build time when an [`EngineRequest::Reduce`] step is constructed. The fresh
+/// UUID `id` ensures stale handles from a prior plan can't be confused with current
+/// ones -- a [`FinishedHandle`] arriving with a token from a dead plan fails the
+/// [`Extractor`] sanity check at decode time.
+///
+/// `Display` emits `<kind>#<id>`.
+///
+/// [`EngineRequest::Reduce`]: crate::plans::state_machines::framework::state_machine::EngineRequest::Reduce
+/// [`FinishedHandle`]: super::handle::FinishedHandle
+/// [`Extractor`]: super::handle::Extractor
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct KernelReducerToken {
+    pub kind: KernelReducerKind,
+    pub id: Uuid,
+}
+
+impl KernelReducerToken {
+    /// Mint a fresh token for a kernel reducer with a UUID id.
+    pub fn new(kind: KernelReducerKind) -> Self {
+        Self {
+            kind,
+            id: Uuid::new_v4(),
+        }
+    }
+}
+
+impl std::fmt::Display for KernelReducerToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}#{}", self.kind, self.id)
+    }
+}
+
+// === Reducer trait ===
+
+/// Stateful observer over batches. Returns [`KdfControl`] per batch for
+/// early termination.
+///
+/// Useful for accumulating log segments, reading hint files, collecting
+/// sidecar references, etc.
+///
+/// `Box<dyn KernelReducer>` is cloneable via the [`DynClone`] supertrait -- the
+/// blanket `impl<T: Clone> DynClone for T` covers every concrete KDF state
+/// that derives `Clone`, so impls never write their own `clone_boxed`.
+pub trait KernelReducer: DynClone + Send + Sync + std::fmt::Debug {
+    /// Diagnostic identifier, stamped into the [`KernelReducerToken`] at plan-build time.
+    fn kind(&self) -> KernelReducerKind;
+
+    /// Observe one batch. Return [`KdfControl::Break`] to stop driving
+    /// further input; the kernel treats it as "child exhausted."
+    ///
+    /// TODO: enforce cardinality of applied rows. Each reducer impl should declare an
+    /// expected per-batch (or total) row-count contract so the runtime can assert that
+    /// the engine isn't incorrectly providing rows (e.g. `CheckpointHintReader` is
+    /// single-row, `MetadataProtocolReader` short-circuits on Break, etc.). Impls
+    /// silently accept whatever the engine hands them.
+    fn apply(&mut self, batch: &dyn EngineData) -> DeltaResult<KdfControl>;
+
+    /// Consume the finalized KDF, returning its state erased to
+    /// `Box<dyn Any + Send>`. Typed factories downcast inside their extract
+    /// closure back to the concrete state type.
+    ///
+    /// Signature takes `Box<Self>` rather than `self` so it's object-safe;
+    /// concrete impls are usually `fn finish(self: Box<Self>) -> Box<dyn Any + Send> {
+    /// Box::new(*self) }`.
+    fn finish(self: Box<Self>) -> Box<dyn Any + Send>;
+}
+
+// `Clone` for `Box<dyn KernelReducer>` -- delegates to `DynClone` (which every
+// concrete `Clone` impl gets for free via the blanket).
+dyn_clone::clone_trait_object!(KernelReducer);
+
+// === Typed-output companion ===
+
+/// Typed-output companion. Each KDF state impls this once, declaring the
+/// typed output callers receive and how the finalized state reduces to it.
+///
+/// ```ignore
+/// impl KernelReducerOutput for SidecarCollector {
+///     type Output = Vec<FileMeta>;
+///     fn into_output(self) -> Result<Self::Output, DeltaError> {
+///         /* project on self */
+///     }
+/// }
+/// ```
+pub trait KernelReducerOutput: KernelReducer + Any + Sized + 'static {
+    /// What downstream callers receive after `phase.execute(...)` completes.
+    type Output: Send + 'static;
+
+    /// Reduce the finalized state to [`Self::Output`].
+    ///
+    /// Each reduce sink is single-partition by construction (the executor
+    /// drains one root partition; the planner pins `target_partitions = 1`),
+    /// so this consumes `Self` directly. Token-keyed identity validation
+    /// happens upstream in [`Extractor::for_reducer`]'s closure.
+    ///
+    /// [`Extractor::for_reducer`]: super::handle::Extractor::for_reducer
+    fn into_output(self) -> Result<Self::Output, DeltaError>;
+}

--- a/kernel/src/plans/kernel_reducers/sidecar_collector.rs
+++ b/kernel/src/plans/kernel_reducers/sidecar_collector.rs
@@ -1,0 +1,108 @@
+//! `SidecarCollector` -- reducer KDF that collects sidecar file references
+//! from a V2 checkpoint manifest scan.
+//!
+//! Delegates row visiting to the existing [`SidecarVisitor`] and
+//! resolves the captured sidecars against `log_root` into `Vec<FileMeta>`
+//! via [`Sidecar::to_filemeta`] in [`KernelReducerOutput::into_output`].
+//!
+//! [`Sidecar::to_filemeta`]: crate::actions::Sidecar::to_filemeta
+
+use url::Url;
+
+use crate::actions::visitors::SidecarVisitor;
+use crate::engine_data::RowVisitor;
+use crate::plans::errors::DeltaError;
+use crate::plans::kernel_reducers::{
+    KdfControl, KernelReducer, KernelReducerKind, KernelReducerOutput,
+};
+use crate::{DeltaResult, EngineData, FileMeta};
+
+/// Accumulates sidecars as batches stream in.
+#[derive(Debug, Clone)]
+pub struct SidecarCollector {
+    log_root: Url,
+    visitor: SidecarVisitor,
+}
+
+impl SidecarCollector {
+    /// Construct a collector that resolves sidecar paths under `log_root`.
+    pub fn new(log_root: Url) -> Self {
+        Self {
+            log_root,
+            visitor: SidecarVisitor::default(),
+        }
+    }
+}
+
+impl KernelReducer for SidecarCollector {
+    fn kind(&self) -> KernelReducerKind {
+        KernelReducerKind::SidecarCollector
+    }
+
+    fn finish(self: Box<Self>) -> Box<dyn std::any::Any + Send> {
+        Box::new(*self)
+    }
+
+    fn apply(&mut self, batch: &dyn EngineData) -> DeltaResult<KdfControl> {
+        self.visitor.visit_rows_of(batch)?;
+        Ok(KdfControl::Continue)
+    }
+}
+
+impl KernelReducerOutput for SidecarCollector {
+    type Output = Vec<FileMeta>;
+
+    fn into_output(self) -> Result<Self::Output, DeltaError> {
+        let log_root = self.log_root;
+        self.visitor
+            .sidecars
+            .into_iter()
+            .map(|sidecar| {
+                sidecar
+                    .to_filemeta(&log_root)
+                    .map_err(DeltaError::invariant)
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::actions::Sidecar;
+
+    fn log_root() -> Url {
+        Url::parse("file:///test/_delta_log/").unwrap()
+    }
+
+    #[test]
+    fn kind_is_stable() {
+        let s = SidecarCollector::new(log_root());
+        assert_eq!(KernelReducer::kind(&s), KernelReducerKind::SidecarCollector);
+    }
+
+    #[test]
+    fn empty_partition_produces_empty_vec() {
+        let out = SidecarCollector::new(log_root()).into_output().unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn into_output_resolves_sidecar_paths() {
+        let mut s = SidecarCollector::new(log_root());
+        s.visitor.sidecars.push(Sidecar {
+            path: "sidecar1.parquet".to_string(),
+            size_in_bytes: 1000,
+            modification_time: 42,
+            tags: None,
+        });
+        let out = s.into_output().unwrap();
+        assert_eq!(out.len(), 1);
+        assert!(out[0]
+            .location
+            .as_str()
+            .ends_with("/_sidecars/sidecar1.parquet"));
+        assert_eq!(out[0].size, 1000);
+        assert_eq!(out[0].last_modified, 42);
+    }
+}

--- a/kernel/src/plans/mod.rs
+++ b/kernel/src/plans/mod.rs
@@ -3,8 +3,10 @@
 //! This module is opt-in behind the `declarative-plans` feature flag.
 pub mod errors;
 pub mod ir;
+pub mod kernel_reducers;
 pub mod proto;
 mod query_builder;
+pub mod state_machines;
 
 use bytes::Bytes;
 pub use ir::{IoOperation, Operation};

--- a/kernel/src/plans/mod.rs
+++ b/kernel/src/plans/mod.rs
@@ -1,6 +1,7 @@
 //! This module defines the concept of a PlanExecutor and its associated input + output types.
 //!
 //! This module is opt-in behind the `declarative-plans` feature flag.
+pub mod errors;
 pub mod ir;
 pub mod proto;
 mod query_builder;

--- a/kernel/src/plans/state_machines/framework/engine_error.rs
+++ b/kernel/src/plans/state_machines/framework/engine_error.rs
@@ -1,0 +1,165 @@
+//! Structured execution errors returned by engine plan execution.
+//!
+//! [`EngineError`] is **engine-facing**: the engine produces one when plan execution fails in a
+//! well-understood way, and SM bodies match on [`EngineError::kind`] to react. Crossing into the
+//! kernel-facing `DeltaError` happens at the call site (e.g. `DeltaError::invariant(engine_err)`),
+//! which keeps the `EngineError` as the source.
+//!
+//! Kernel code MUST NOT gate control flow on the *text* of `message` fields inside variants:
+//! those strings are non-semantic and exist only for display.
+
+use std::error::Error;
+
+use crate::plans::errors::BoxedSource;
+use crate::Version;
+
+/// A structured error from executing a `Plan`. Pairs a typed [`EngineErrorKind`] (the semantic
+/// signal SMs match on) with an optional source chain forwarded through
+/// `Error::source()`.
+#[derive(Debug, thiserror::Error)]
+#[error("{kind}")]
+pub struct EngineError {
+    /// The semantic variant. Kernel SMs match on this.
+    pub kind: EngineErrorKind,
+    /// Optional in-process-only source chain.
+    pub source: Option<BoxedSource>,
+}
+
+/// Semantic tag of an [`EngineError`].
+///
+/// Adding a new variant is the preferred way to express a new engine failure -- string-matching
+/// on `message` fields is explicitly forbidden. `#[non_exhaustive]` reserves space for additional
+/// variants without breaking callers.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum EngineErrorKind {
+    /// A required input relation was empty when the plan expected at least one row.
+    #[error("empty input for sink: {sink_description}")]
+    EmptyInput { sink_description: String },
+
+    /// A file path referenced by the plan was not found in storage.
+    #[error("file not found: {path}")]
+    FileNotFound { path: String },
+
+    /// A generic I/O failure that doesn't fit a more specific variant. `message` is
+    /// non-semantic -- for display only.
+    #[error("I/O error: {message}")]
+    IoError { message: String },
+
+    /// Engine-side failure the kernel does not classify further. Diagnostic detail lives in
+    /// [`EngineError::source`]; construct via [`EngineError::internal`].
+    #[error("internal engine error")]
+    Internal,
+
+    /// Commit lost a put-if-absent race or catalog ratify reported a conflicting table version.
+    #[error("commit conflict at version {version}")]
+    CommitConflict { version: Version },
+}
+
+impl EngineError {
+    /// Build a sourceless [`EngineError`]. The fast path when the engine
+    /// has no underlying error to attach.
+    pub fn new(kind: EngineErrorKind) -> Self {
+        Self { kind, source: None }
+    }
+
+    /// Render this error together with its full source chain. Formatted as
+    /// `"{kind}: {source}: {source_of_source}: ..."`.
+    ///
+    /// Distinct from [`ToString::to_string`] (which only renders `kind`):
+    /// [`EngineErrorKind::Internal`] carries its entire diagnostic payload in `source`, so
+    /// `to_string()` collapses to the static `"internal engine error"`. Use this method for
+    /// any diagnostic detail derived from an `Internal`.
+    pub fn display_with_source_chain(&self) -> String {
+        let mut out = self.kind.to_string();
+        let mut cur: Option<&(dyn Error + 'static)> = self.source();
+        while let Some(s) = cur {
+            out.push_str(": ");
+            out.push_str(&s.to_string());
+            cur = s.source();
+        }
+        out
+    }
+
+    /// Construct an [`EngineErrorKind::Internal`] with the originating
+    /// error attached as `source`. Use this whenever the engine has a
+    /// failure that doesn't fit a typed variant -- kernel call sites
+    /// inspect `source` (via `Error::source()`) if they need
+    /// the underlying message or type.
+    ///
+    /// Adding a dedicated typed variant is preferred whenever a given
+    /// cause starts recurring.
+    pub fn internal<E>(err: E) -> Self
+    where
+        E: Error + Send + Sync + 'static,
+    {
+        Self {
+            kind: EngineErrorKind::Internal,
+            source: Some(Box::new(err)),
+        }
+    }
+}
+
+impl From<EngineErrorKind> for EngineError {
+    fn from(kind: EngineErrorKind) -> Self {
+        Self::new(kind)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error;
+    use std::io;
+
+    use super::*;
+
+    #[test]
+    fn display_delegates_to_kind() {
+        let err = EngineError::new(EngineErrorKind::FileNotFound {
+            path: "/tmp/x".into(),
+        });
+        assert_eq!(err.to_string(), "file not found: /tmp/x");
+    }
+
+    #[test]
+    fn display_with_source_chain_renders_internal_payload() {
+        let err = EngineError::internal(io::Error::other(
+            "Non-Results plan failed: IllegalStateException: boom",
+        ));
+        let rendered = err.display_with_source_chain();
+        assert!(
+            rendered.contains("internal engine error"),
+            "kind prefix missing: {rendered}"
+        );
+        assert!(
+            rendered.contains("Non-Results plan failed: IllegalStateException: boom"),
+            "source payload missing: {rendered}"
+        );
+    }
+
+    #[test]
+    fn display_with_source_chain_is_stable_when_no_source() {
+        let err = EngineError::new(EngineErrorKind::FileNotFound {
+            path: "/tmp/x".into(),
+        });
+        assert_eq!(err.display_with_source_chain(), err.to_string());
+    }
+
+    #[test]
+    fn internal_tags_kind_and_preserves_source() {
+        let io = io::Error::other("boom");
+        let err = EngineError::internal(io);
+        assert_eq!(err.kind, EngineErrorKind::Internal);
+        let src = err.source().expect("source preserved");
+        assert!(src.to_string().contains("boom"));
+    }
+
+    #[test]
+    fn from_kind_produces_sourceless_error() {
+        let err: EngineError = EngineErrorKind::EmptyInput {
+            sink_description: "sink".into(),
+        }
+        .into();
+        assert!(err.source.is_none());
+    }
+}

--- a/kernel/src/plans/state_machines/framework/mod.rs
+++ b/kernel/src/plans/state_machines/framework/mod.rs
@@ -1,0 +1,9 @@
+//! State-machine framework: the shared infrastructure every kernel SM uses.
+//!
+//! - [`engine_error`] -- [`EngineError`](engine_error::EngineError), the typed failure the engine
+//!   surfaces to the SM (distinct from [`DeltaError`](crate::plans::errors::DeltaError), the
+//!   kernel-to-caller error).
+//!
+//! Additional modules (`state_machine`, `coroutine`, `plan_context`) land in follow-up PRs.
+
+pub mod engine_error;

--- a/kernel/src/plans/state_machines/mod.rs
+++ b/kernel/src/plans/state_machines/mod.rs
@@ -1,0 +1,8 @@
+//! State machines -- kernel-authored coroutine bodies that orchestrate plan execution.
+//!
+//! - [`framework`] -- the framework SMs are built on. Successive PRs flesh out the `StateMachine`
+//!   trait, the `CoroutineSM` driver, the typed `Context`/`EngineResponse` surface, and the
+//!   `Extractor<O>` typed adapter; this PR seeds it with the typed engine-side failure type
+//!   ([`framework::engine_error::EngineError`]).
+
+pub mod framework;


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2642/files/b15494a017628f925e9b16f64da0765896c6aed0..0deb5e63fd987023701791fafa1a77973f78c334) to review incremental changes.
- [stack/c8](https://github.com/delta-io/delta-kernel-rs/pull/2629) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2629/files)] [MERGED]
  - [stack/c1](https://github.com/delta-io/delta-kernel-rs/pull/2641) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2641/files)]
    - [**stack/c3**](https://github.com/delta-io/delta-kernel-rs/pull/2642) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2642/files/b15494a017628f925e9b16f64da0765896c6aed0..0deb5e63fd987023701791fafa1a77973f78c334)]
      - [stack/c5](https://github.com/delta-io/delta-kernel-rs/pull/2643) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2643/files/bddc0b4418b69e29388d241fae97ba479c57defc..eba0ab0291ec5f0fae1d076286d205da375c2f82)]
        - [stack/c2](https://github.com/delta-io/delta-kernel-rs/pull/2644) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2644/files/eba0ab0291ec5f0fae1d076286d205da375c2f82..70458623c98684dd4286510aadbd393a9716b021)]
          - [stack/c6](https://github.com/delta-io/delta-kernel-rs/pull/2645) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2645/files/70458623c98684dd4286510aadbd393a9716b021..e19189d969cad8b0366575a53288aa6f05b1447f)]
            - [stack/c7](https://github.com/delta-io/delta-kernel-rs/pull/2646) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2646/files/e19189d969cad8b0366575a53288aa6f05b1447f..19fb518e8f9f88fe8563b840f6c08a320527a7e9)]

---------
## What changes are proposed in this pull request?

Adds the KernelReducer trait and the four canonical reducers (MetadataProtocol, CheckpointHint, SidecarCollector, and Handle) that drive log-replay aggregations. Each reducer is a small stateful visitor over a partition of input rows; KernelReducerToken plus the FinishedHandle/Extractor pair give the executor a typed channel for shipping finished reductions back to the SM driver.

Also lands:
- framework/engine_error.rs: the EngineError typed failure the engine surfaces to the SM (distinct from the kernel-to-caller DeltaError). Bundled here because handle.rs depends on it.
- actions/mod.rs + actions/visitors.rs: Sidecar: Clone, SidecarVisitor: Debug + Clone, and Protocol::try_new_from_data annotated
  #[internal_api]. Folded in because the kernel reducers depend on these (separating them out would be three trivial-LOC PRs).

Cross-sub-chain plans/mod.rs conflict expected when the basic-IR PR lands first: resolve by syncing this sub-chain after that lands. The state_machines module here declares only `framework::engine_error`; the remaining framework members (state_machine, coroutine, plan_context) land in follow-up PRs.

Depends on the errors PR for DeltaError (in chain ancestry).

## How was this change tested?
