### PR TITLE
feat: add StateMachine trait, CoroutineSM driver, and ReduceSink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,7 +644,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -830,7 +830,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.117",
  "tempfile",
  "toml 0.9.12+spec-1.1.0",
 ]
@@ -984,7 +984,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1279,6 +1279,7 @@ dependencies = [
  "delta_kernel_derive",
  "dyn-clone",
  "futures",
+ "genawaiter2",
  "hdfs-native",
  "hdfs-native-object-store",
  "indexmap",
@@ -1375,7 +1376,7 @@ version = "0.24.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1412,7 +1413,7 @@ version = "0.24.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1459,7 +1460,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1715,7 +1716,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1762,7 +1763,7 @@ dependencies = [
  "g2poly",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1780,6 +1781,34 @@ name = "g2poly"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "312d2295c7302019c395cfb90dacd00a82a2eabd700429bba9c7a3f38dbbe11b"
+
+[[package]]
+name = "genawaiter2"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a954504d991886b6891c97b37ca1bf87ad2174c2126d52cdb52bebea7b1c89e3"
+dependencies = [
+ "genawaiter2-macro",
+ "genawaiter2-proc-macro",
+]
+
+[[package]]
+name = "genawaiter2-macro"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5cc2b187655aae60ff27f3978ffd192b9252c1a5905f53d3340e5836d8a539b"
+
+[[package]]
+name = "genawaiter2-proc-macro"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91467b1ef9d0b102db5ebf041238f26879f49ac323459e16725991ef73e61d2d"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "generic-array"
@@ -2352,7 +2381,7 @@ checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2832,7 +2861,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3090,7 +3119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3100,6 +3129,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "syn-mid",
+ "version_check",
 ]
 
 [[package]]
@@ -3147,7 +3202,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-types 0.13.5",
  "regex",
- "syn",
+ "syn 2.0.117",
  "tempfile",
 ]
 
@@ -3161,7 +3216,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3174,7 +3229,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3515,7 +3570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3715,7 +3770,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
  "unicode-ident",
 ]
 
@@ -3727,7 +3782,7 @@ checksum = "b3a8fb4672e840a587a66fc577a5491375df51ddb88f2a2c2a792598c326fe14"
 dependencies = [
  "quote",
  "rand 0.8.5",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3954,7 +4009,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4128,7 +4183,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4140,7 +4195,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4151,6 +4206,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -4158,6 +4224,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn-mid"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea305d57546cc8cd04feb14b62ec84bf17f50e3f7b12560d7bfa9265f39d9ed"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4177,7 +4254,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4258,7 +4335,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4269,7 +4346,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "test-case-core",
 ]
 
@@ -4291,7 +4368,7 @@ checksum = "be35209fd0781c5401458ab66e4f98accf63553e8fae7425503e92fdd319783b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4340,7 +4417,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4351,7 +4428,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4449,7 +4526,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4625,7 +4702,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4950,7 +5027,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -5098,7 +5175,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5109,7 +5186,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5423,7 +5500,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -5439,7 +5516,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -5533,7 +5610,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5560,7 +5637,7 @@ checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5580,7 +5657,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5620,7 +5697,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,6 +1277,7 @@ dependencies = [
  "criterion",
  "delta_kernel",
  "delta_kernel_derive",
+ "dyn-clone",
  "futures",
  "hdfs-native",
  "hdfs-native-object-store",
@@ -1478,6 +1479,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -53,6 +53,8 @@ serde_json = "1"
 strum = { version = "0.27", features = ["derive"] }
 thiserror = "2"
 prost = { version = "0.13", optional = true }
+# Object-safe `Clone` for the `KernelReducer` trait. Gated by `declarative-plans`.
+dyn-clone = { version = "1.0", optional = true }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = "0.3"
 url = "2"
@@ -116,7 +118,7 @@ arrow-expression = ["need-arrow"]
 schema-diff = []
 
 # Declarative plan IR (experimental).
-declarative-plans = ["internal-api", "dep:prost", "dep:prost-build", "dep:protoc-bin-vendored"]
+declarative-plans = ["internal-api", "dep:prost", "dep:prost-build", "dep:protoc-bin-vendored", "dep:dyn-clone"]
 
 # Experimental, temporary, test-only feature flag guarding the in-progress column-defaults
 # work. TODO(#2630): remove once full column-defaults support ships.

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -55,6 +55,14 @@ thiserror = "2"
 prost = { version = "0.13", optional = true }
 # Object-safe `Clone` for the `KernelReducer` trait. Gated by `declarative-plans`.
 dyn-clone = { version = "1.0", optional = true }
+# Stackless coroutines for the SM driver. Gated by `declarative-plans`.
+# default-features can't be disabled in 0.100.1 -- an unconditional
+# `pub use genawaiter2_proc_macro::stack_producer;` in genawaiter2's lib.rs
+# leaks the proc-macro crate as a hard dependency even when the `proc_macro`
+# feature is off (upstream bug). This drags in `proc-macro-error 0.4.12`
+# (unmaintained). Track for replacement when genawaiter2 patches the gate or
+# we switch to a different stackless-coroutine crate.
+genawaiter2 = { version = "0.100", optional = true }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = "0.3"
 url = "2"
@@ -118,7 +126,7 @@ arrow-expression = ["need-arrow"]
 schema-diff = []
 
 # Declarative plan IR (experimental).
-declarative-plans = ["internal-api", "dep:prost", "dep:prost-build", "dep:protoc-bin-vendored", "dep:dyn-clone"]
+declarative-plans = ["internal-api", "dep:prost", "dep:prost-build", "dep:protoc-bin-vendored", "dep:dyn-clone", "dep:genawaiter2"]
 
 # Experimental, temporary, test-only feature flag guarding the in-progress column-defaults
 # work. TODO(#2630): remove once full column-defaults support ships.

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -639,6 +639,7 @@ impl Protocol {
 
     /// Create a new Protocol by visiting the EngineData and extracting the first protocol row into
     /// a Protocol instance. If no protocol row is found, returns Ok(None).
+    #[internal_api]
     pub(crate) fn try_new_from_data(data: &dyn EngineData) -> DeltaResult<Option<Protocol>> {
         let mut visitor = ProtocolVisitor::default();
         visitor.visit_rows_of(data)?;
@@ -951,7 +952,7 @@ impl SetTransaction {
 /// file actions. This action is only allowed in checkpoints following the V2 spec.
 ///
 /// [More info]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#sidecar-file-information
-#[derive(ToSchema, Debug, PartialEq)]
+#[derive(ToSchema, Debug, Clone, PartialEq)]
 #[internal_api]
 pub(crate) struct Sidecar {
     /// A path to a sidecar file that can be either:

--- a/kernel/src/actions/visitors.rs
+++ b/kernel/src/actions/visitors.rs
@@ -377,7 +377,7 @@ impl RowVisitor for SetTransactionVisitor {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug, Clone)]
 #[internal_api]
 pub(crate) struct SidecarVisitor {
     pub(crate) sidecars: Vec<Sidecar>,

--- a/kernel/src/plans/errors/mod.rs
+++ b/kernel/src/plans/errors/mod.rs
@@ -1,0 +1,337 @@
+//! Typed error surface for the declarative plans layer.
+//!
+//! [`DeltaError`] is the error type used by state machines and the plan executor. It coexists
+//! with [`Error`]; lifting an [`Error`] into a [`DeltaError`] goes through the named bridge
+//! [`KernelErrAsDelta`] -- deliberately no `From<Error>` impl, so the conversion sites are
+//! grep-able. (A `From<BoxedSource>` does exist for the catch-all `dyn Error + Send + Sync`
+//! shape used by Delta-agnostic helpers; that path tags every lifted error with
+//! [`DeltaErrorCode::DeltaCommandInvariantViolation`].)
+//!
+//! # Construction
+//!
+//! Every error is built through a named constructor on [`DeltaError`], one per
+//! [`DeltaErrorCode`]. The human message is fixed per code ([`DeltaErrorCode::message`]); the
+//! constructor takes only the runtime detail / underlying cause, which becomes the error's
+//! [`source`](DeltaError::source). The detail is `impl Into<BoxedSource>`, so it accepts a bare
+//! string (auto-wrapped as a trivial error) or any real error (kept with its type and chain).
+//!
+//! [`DeltaResultExt::or_delta`] does the same at a `?` site: it attaches a code and keeps the
+//! original error as the source.
+//!
+//! ```ignore
+//! use delta_kernel::plans::errors::{DeltaError, DeltaErrorCode, DeltaResultExt};
+//!
+//! return Err(DeltaError::table_not_found(format!("{name}")));
+//! let v: u64 = "42".parse().or_delta(DeltaErrorCode::DeltaVersionInvalid)?;
+//! let e = DeltaError::file_not_found(io_err);
+//! ```
+
+use std::backtrace::Backtrace;
+
+use crate::Error;
+
+// ============================================================================
+// DeltaErrorCode -- macro-driven declaration
+// ============================================================================
+
+/// Declarative table of Delta error codes. Each row binds a variant to its FFI-stable
+/// discriminant, SCREAMING_SNAKE name, SQLSTATE, and a static human message.
+///
+/// The message is fixed per code; runtime detail (the offending path, version, cause, ...) is
+/// never formatted into it -- it lives in [`DeltaError::source`].
+///
+/// Discriminants are explicit because the enum is `#[repr(u32)]` for FFI ABI stability.
+/// Reassigning or reusing a discriminant is a breaking change; pick the next unused integer.
+macro_rules! delta_codes {
+    (
+        $(
+            $( #[$meta:meta] )*
+            $variant:ident = $disc:literal,
+            $name:literal,
+            $sqlstate:literal,
+            $message:literal
+        ),+
+        $(,)?
+    ) => {
+        /// Typed identifier for a Delta error.
+        ///
+        /// `#[repr(u32)]` pins the integer layout for FFI; `#[non_exhaustive]` reserves space
+        /// for additional codes -- downstream consumers must treat unknown integers as opaque.
+        #[repr(u32)]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[non_exhaustive]
+        pub enum DeltaErrorCode {
+            $( $( #[$meta] )* $variant = $disc ),+
+        }
+
+        impl DeltaErrorCode {
+            /// SCREAMING_SNAKE name for this error code.
+            pub fn name(&self) -> &'static str {
+                match self { $( Self::$variant => $name ),+ }
+            }
+
+            /// 5-character SQLSTATE classifying the error (SQL-standard class + subclass).
+            pub fn sqlstate(&self) -> &'static str {
+                match self { $( Self::$variant => $sqlstate ),+ }
+            }
+
+            /// Static human-readable message for this code. Carries no runtime detail.
+            pub fn message(&self) -> &'static str {
+                match self { $( Self::$variant => $message ),+ }
+            }
+        }
+    };
+}
+
+delta_codes! {
+    /// `DELTA_COMMAND_INVARIANT_VIOLATION` -- internal-error catch-all for SMs detecting an
+    /// impossible state. Discriminant `0` is deliberate: a zero-initialized wire value decodes
+    /// to "invariant violation" so engines that fail to populate the code slot still surface
+    /// a meaningful error.
+    DeltaCommandInvariantViolation = 0, "DELTA_COMMAND_INVARIANT_VIOLATION", "XXKDS",
+        "internal invariant violated",
+    /// Delta table does not exist.
+    DeltaTableNotFound = 1, "DELTA_TABLE_NOT_FOUND", "42P01", "Delta table not found",
+    /// Path is not a Delta table.
+    DeltaMissingDeltaTable = 2, "DELTA_MISSING_DELTA_TABLE", "42P01", "not a Delta table",
+    /// Path doesn't exist, or is not a Delta table.
+    DeltaPathDoesNotExist = 3, "DELTA_PATH_DOES_NOT_EXIST", "42K03", "path does not exist",
+    /// Requested version is outside the available range.
+    DeltaVersionNotFound = 4, "DELTA_VERSION_NOT_FOUND", "22003", "version not found",
+    /// A provided version string / number is not parseable.
+    DeltaVersionInvalid = 5, "DELTA_VERSION_INVALID", "42815", "invalid version",
+    /// A commit file needed to reconstruct state is missing.
+    DeltaLogFileNotFound = 6, "DELTA_LOG_FILE_NOT_FOUND", "42K03", "commit log file not found",
+    /// A data file referenced by the log is missing.
+    DeltaFileNotFound = 7, "DELTA_FILE_NOT_FOUND", "42K03", "file not found",
+    /// A multipart checkpoint is missing shards.
+    DeltaMissingPartFiles = 8, "DELTA_MISSING_PART_FILES", "42KD6", "checkpoint is missing part files",
+    /// Protocol / metadata could not be reconstructed.
+    DeltaStateRecoverError = 9, "DELTA_STATE_RECOVER_ERROR", "XXKDS",
+        "failed to reconstruct table state",
+    /// The table requires a protocol the kernel doesn't support.
+    DeltaInvalidProtocolVersion = 10, "DELTA_INVALID_PROTOCOL_VERSION", "KD004",
+        "unsupported protocol version",
+    /// A commit raced with another transaction.
+    DeltaConcurrentWrite = 11, "DELTA_CONCURRENT_WRITE", "2D521",
+        "commit failed due to a concurrent write",
+    /// Attempt to create a Delta log that already exists.
+    DeltaLogAlreadyExists = 12, "DELTA_LOG_ALREADY_EXISTS", "42K04", "Delta log already exists",
+}
+
+// ============================================================================
+// DeltaError
+// ============================================================================
+
+/// Boxed, sendable source error held by [`DeltaError::source`].
+pub type BoxedSource = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// Typed Delta error.
+///
+/// The human message is static per [`DeltaErrorCode`] ([`DeltaErrorCode::message`]); all runtime
+/// detail (the offending path, version, underlying cause) lives in [`source`](Self::source).
+/// `Display` emits `[<CODE_NAME>] <static message>`, and `source` is forwarded via
+/// `std::error::Error::source()` so standard ecosystem walkers see the detail.
+#[derive(Debug, thiserror::Error)]
+#[error("[{}] {}", self.code.name(), self.code.message())]
+pub struct DeltaError {
+    /// Stable typed identifier; also determines the human message.
+    pub code: DeltaErrorCode,
+    /// Runtime detail / underlying cause, forwarded via `std::error::Error::source()`. A bare
+    /// `String`/`&str` is accepted and wrapped as a trivial error (stdlib `From`).
+    #[source]
+    pub source: Option<BoxedSource>,
+    /// `Some(Backtrace::capture())` -- a no-op without `RUST_BACKTRACE=1`, so the "always on"
+    /// default is free in production.
+    pub backtrace: Option<Backtrace>,
+}
+
+impl DeltaError {
+    /// Crate-internal primitive: build an error from a code and its runtime detail / cause. The
+    /// per-code constructors below and [`DeltaResultExt::or_delta`] funnel through here.
+    pub(crate) fn new(code: DeltaErrorCode, source: impl Into<BoxedSource>) -> Self {
+        Self {
+            code,
+            source: Some(source.into()),
+            backtrace: Some(Backtrace::capture()),
+        }
+    }
+
+    // === Per-code constructors ==========================================================
+    //
+    // Each takes the runtime detail as `impl Into<BoxedSource>`: a bare string (auto-wrapped)
+    // or any underlying error (kept with its type and source chain). The human message is the
+    // code's static one.
+
+    /// `DELTA_COMMAND_INVARIANT_VIOLATION` -- an internal "this should never happen" failure.
+    pub fn invariant(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaCommandInvariantViolation, detail)
+    }
+
+    /// `DELTA_TABLE_NOT_FOUND` -- the Delta table does not exist.
+    pub fn table_not_found(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaTableNotFound, detail)
+    }
+
+    /// `DELTA_MISSING_DELTA_TABLE` -- the path is not a Delta table.
+    pub fn missing_delta_table(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaMissingDeltaTable, detail)
+    }
+
+    /// `DELTA_PATH_DOES_NOT_EXIST` -- the path does not exist.
+    pub fn path_does_not_exist(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaPathDoesNotExist, detail)
+    }
+
+    /// `DELTA_VERSION_NOT_FOUND` -- the requested version is outside the available range.
+    pub fn version_not_found(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaVersionNotFound, detail)
+    }
+
+    /// `DELTA_VERSION_INVALID` -- a version string/number is not parseable.
+    pub fn version_invalid(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaVersionInvalid, detail)
+    }
+
+    /// `DELTA_LOG_FILE_NOT_FOUND` -- a commit file needed to reconstruct state is missing.
+    pub fn log_file_not_found(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaLogFileNotFound, detail)
+    }
+
+    /// `DELTA_FILE_NOT_FOUND` -- a data file referenced by the log is missing.
+    pub fn file_not_found(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaFileNotFound, detail)
+    }
+
+    /// `DELTA_MISSING_PART_FILES` -- a multipart checkpoint is missing shards.
+    pub fn missing_part_files(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaMissingPartFiles, detail)
+    }
+
+    /// `DELTA_STATE_RECOVER_ERROR` -- protocol/metadata could not be reconstructed.
+    pub fn state_recover_error(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaStateRecoverError, detail)
+    }
+
+    /// `DELTA_INVALID_PROTOCOL_VERSION` -- the table requires an unsupported protocol.
+    pub fn invalid_protocol_version(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaInvalidProtocolVersion, detail)
+    }
+
+    /// `DELTA_CONCURRENT_WRITE` -- a commit raced with another transaction.
+    pub fn concurrent_write(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaConcurrentWrite, detail)
+    }
+
+    /// `DELTA_LOG_ALREADY_EXISTS` -- attempt to create a Delta log that already exists.
+    pub fn log_already_exists(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaLogAlreadyExists, detail)
+    }
+}
+
+/// Auto-convert a [`BoxedSource`] (the boxed `dyn Error` shape used by Delta-agnostic helpers
+/// like `schema_expr` and `plan_context`) into a [`DeltaError`] tagged with the catch-all
+/// [`DeltaErrorCode::DeltaCommandInvariantViolation`]. Lets `?` propagate these errors into
+/// `Result<_, DeltaError>` functions without an explicit `.or_delta(...)` wrap.
+///
+/// Use [`DeltaResultExt::or_delta`] when a more specific code is appropriate -- this impl is
+/// intentionally the catch-all path.
+impl From<BoxedSource> for DeltaError {
+    fn from(source: BoxedSource) -> Self {
+        Self::new(DeltaErrorCode::DeltaCommandInvariantViolation, source)
+    }
+}
+
+// ============================================================================
+// Bridges -- kernel::Error <-> DeltaError
+// ============================================================================
+
+/// Lift an [`Error`] into a [`DeltaError`] tagged with
+/// [`DeltaErrorCode::DeltaCommandInvariantViolation`]. Use when a more specific code is not
+/// known; upgrading to a specific constructor (e.g. `DeltaError::file_not_found(path)`) is a
+/// drop-in refactor.
+pub trait KernelErrAsDelta {
+    fn into_delta_internal(self) -> DeltaError;
+}
+
+impl KernelErrAsDelta for Error {
+    fn into_delta_internal(self) -> DeltaError {
+        DeltaError::invariant(self)
+    }
+}
+
+// ============================================================================
+// or_delta at ? sites
+// ============================================================================
+
+/// Attach a [`DeltaErrorCode`] to any `Result<T, E>` whose error can be lifted into a
+/// [`BoxedSource`]. The original error is preserved as [`DeltaError::source`] (walkable via
+/// `std::error::Error::source()`); the message comes from the code.
+///
+/// The bound `E: Into<BoxedSource>` covers two cases without an extra `Box` layer:
+/// - any concrete `E: Error + Send + Sync + 'static` (stdlib's blanket `From` impl), and
+/// - errors that are already a [`BoxedSource`] (low-level modules that return a `Box<dyn Error +
+///   Send + Sync + 'static>` directly to stay Delta-agnostic).
+pub trait DeltaResultExt<T> {
+    fn or_delta(self, code: DeltaErrorCode) -> Result<T, DeltaError>;
+}
+
+impl<T, E> DeltaResultExt<T> for Result<T, E>
+where
+    E: Into<BoxedSource>,
+{
+    fn or_delta(self, code: DeltaErrorCode) -> Result<T, DeltaError> {
+        self.map_err(|e| DeltaError::new(code, e))
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error;
+
+    use super::*;
+
+    #[test]
+    fn display_is_code_name_plus_static_message() {
+        let err = DeltaError::table_not_found("my_table");
+        assert_eq!(err.code, DeltaErrorCode::DeltaTableNotFound);
+        let s = err.to_string();
+        assert!(s.contains("DELTA_TABLE_NOT_FOUND"), "got: {s}");
+        assert!(s.contains("Delta table not found"), "got: {s}");
+    }
+
+    #[test]
+    fn string_detail_becomes_source() {
+        let err = DeltaError::invariant("snapshot.rebuild: protocol missing");
+        assert_eq!(err.code, DeltaErrorCode::DeltaCommandInvariantViolation);
+        assert_eq!(err.code.message(), "internal invariant violated");
+        let src = err.source().expect("string detail preserved as source");
+        assert_eq!(src.to_string(), "snapshot.rebuild: protocol missing");
+    }
+
+    #[test]
+    fn error_detail_keeps_its_type_in_source() {
+        let io = std::io::Error::other("boom");
+        let err = DeltaError::file_not_found(io);
+        assert_eq!(err.code, DeltaErrorCode::DeltaFileNotFound);
+        let src = err.source().expect("source");
+        assert!(src.is::<std::io::Error>());
+        assert!(src.to_string().contains("boom"));
+    }
+
+    #[test]
+    fn or_delta_preserves_original_error_in_source() {
+        fn parse_version(s: &str) -> Result<u64, DeltaError> {
+            s.parse::<u64>()
+                .or_delta(DeltaErrorCode::DeltaVersionInvalid)
+        }
+        let err = parse_version("not-a-number").unwrap_err();
+        assert_eq!(err.code, DeltaErrorCode::DeltaVersionInvalid);
+        let src = err.source().expect("parse error preserved");
+        assert!(src.is::<std::num::ParseIntError>());
+    }
+}

--- a/kernel/src/plans/ir/nodes.rs
+++ b/kernel/src/plans/ir/nodes.rs
@@ -7,6 +7,7 @@ use strum::Display;
 use url::Url;
 
 use crate::expressions::{ColumnName, ExpressionRef, PredicateRef, Scalar};
+use crate::plans::kernel_reducers::{KernelReducer, KernelReducerToken, ReducerHandle};
 use crate::schema::SchemaRef;
 use crate::FileMeta;
 
@@ -536,3 +537,50 @@ pub struct SemiJoin {
 /// ```
 #[derive(Debug, Clone)]
 pub struct UnionAll;
+
+// ============================================================================
+// Reducer-drain sink (referenced by `EngineRequest::Reduce`)
+// ============================================================================
+
+/// Template for draining a row stream into a [`KernelReducer`] via [`EngineRequest::Reduce`].
+///
+/// - `initial_state`: cloned per partition via [`DynClone`](dyn_clone::DynClone) into a
+///   [`ReducerHandle`].
+/// - `token`: keys the finished handle returned from the executor and validated at decode time by
+///   the paired [`Extractor`].
+///
+/// [`EngineRequest::Reduce`]: crate::plans::state_machines::framework::state_machine::EngineRequest::Reduce
+/// [`Extractor`]: crate::plans::kernel_reducers::Extractor
+#[derive(Debug, Clone)]
+pub struct ReduceSink {
+    pub initial_state: Box<dyn KernelReducer>,
+    pub token: KernelReducerToken,
+}
+
+impl ReduceSink {
+    /// Construct from a concrete reducer and mint a fresh token from its `kind`.
+    pub fn new<R: KernelReducer + 'static>(state: R) -> Self {
+        let token = KernelReducerToken::new(state.kind());
+        Self {
+            initial_state: Box::new(state),
+            token,
+        }
+    }
+
+    /// Mint a runtime [`ReducerHandle`] for this sink template by cloning the initial state.
+    pub fn new_handle(&self) -> ReducerHandle {
+        ReducerHandle::new(self.token.clone(), self.initial_state.clone())
+    }
+}
+
+// Token identity drives equality: tokens are process-unique by id, and the
+// `initial_state` trait object (`Box<dyn KernelReducer>`) is not `Eq`-able. Two
+// sinks sharing a token were constructed from the same plan node and therefore
+// describe the same reducer.
+impl PartialEq for ReduceSink {
+    fn eq(&self, other: &Self) -> bool {
+        self.token == other.token
+    }
+}
+
+impl Eq for ReduceSink {}

--- a/kernel/src/plans/kernel_reducers/checkpoint_hint.rs
+++ b/kernel/src/plans/kernel_reducers/checkpoint_hint.rs
@@ -35,7 +35,7 @@ pub struct CheckpointHintRecord {
     /// Total logical size of the checkpoint (bytes), if known.
     pub size: Option<i64>,
     /// Number of parts for multipart checkpoints, if any. Stored as `i64` to keep the
-    /// JSON deserialization aligned with [`LastCheckpointHint::parts`] (`Option<usize>`)
+    /// JSON deserialization aligned with `LastCheckpointHint::parts` (`Option<usize>`)
     /// on 64-bit targets.
     pub parts: Option<i64>,
     /// Total on-disk size of the checkpoint (bytes), if known.

--- a/kernel/src/plans/kernel_reducers/checkpoint_hint.rs
+++ b/kernel/src/plans/kernel_reducers/checkpoint_hint.rs
@@ -1,0 +1,171 @@
+//! `CheckpointHintReader` -- reducer KDF that reads a `_last_checkpoint`
+//! JSON scan and extracts the hint record.
+//!
+//! The file contains a single row. The reader captures it on the first
+//! batch, returns [`KdfControl::Break`] to stop further input, and reduces
+//! to `Option<CheckpointHintRecord>` -- `None` when the file was absent (zero
+//! rows), `Some` when the hint was extracted.
+
+use std::sync::LazyLock;
+
+use delta_kernel_derive::ToSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::engine_data::{GetData, RowVisitor, TypedGetData as _};
+use crate::plans::errors::DeltaError;
+use crate::plans::kernel_reducers::{
+    KdfControl, KernelReducer, KernelReducerKind, KernelReducerOutput,
+};
+use crate::schema::{ColumnName, ColumnNamesAndTypes, DataType, ToSchema};
+use crate::{DeltaResult, EngineData};
+
+/// `_last_checkpoint` JSON hint file record. Parsed by [`CheckpointHintReader`] from
+/// the single-row hint file; deriving [`ToSchema`] lets the reader source the row
+/// visitor's column schema from the struct definition.
+///
+/// Intentionally a subset of [`crate::last_checkpoint_hint::LastCheckpointHint`]: only
+/// the fields the plans layer currently consumes (`version`, `size`, `parts`,
+/// `sizeInBytes`, `numOfAddFiles`) are projected. `checkpointSchema`, `checksum`, and
+/// `tags` are omitted; if the plans layer ever needs them (e.g. for footer skipping based
+/// on the checkpoint schema), extend this record rather than reading them ad-hoc.
+#[derive(ToSchema, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CheckpointHintRecord {
+    /// Commit version the checkpoint covers.
+    pub version: i64,
+    /// Total logical size of the checkpoint (bytes), if known.
+    pub size: Option<i64>,
+    /// Number of parts for multipart checkpoints, if any. Stored as `i64` to keep the
+    /// JSON deserialization aligned with [`LastCheckpointHint::parts`] (`Option<usize>`)
+    /// on 64-bit targets.
+    pub parts: Option<i64>,
+    /// Total on-disk size of the checkpoint (bytes), if known.
+    pub size_in_bytes: Option<i64>,
+    /// Count of add-file actions in the checkpoint, if tracked.
+    pub num_of_add_files: Option<i64>,
+}
+
+/// Reader state: holds the extracted record. `record.is_some()` doubles as the
+/// "already processed" flag to short-circuit subsequent batches.
+#[derive(Debug, Clone, Default)]
+pub struct CheckpointHintReader {
+    record: Option<CheckpointHintRecord>,
+}
+
+impl KernelReducer for CheckpointHintReader {
+    fn kind(&self) -> KernelReducerKind {
+        KernelReducerKind::CheckpointHint
+    }
+
+    fn finish(self: Box<Self>) -> Box<dyn std::any::Any + Send> {
+        Box::new(*self)
+    }
+
+    fn apply(&mut self, batch: &dyn EngineData) -> DeltaResult<KdfControl> {
+        if self.record.is_none() {
+            self.visit_rows_of(batch)?;
+        }
+        Ok(if self.record.is_some() {
+            KdfControl::Break
+        } else {
+            KdfControl::Continue
+        })
+    }
+}
+
+impl KernelReducerOutput for CheckpointHintReader {
+    type Output = Option<CheckpointHintRecord>;
+
+    fn into_output(self) -> Result<Self::Output, DeltaError> {
+        Ok(self.record)
+    }
+}
+
+impl RowVisitor for CheckpointHintReader {
+    fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
+        static NAMES_AND_TYPES: LazyLock<ColumnNamesAndTypes> =
+            LazyLock::new(|| CheckpointHintRecord::to_schema().leaves(None));
+        NAMES_AND_TYPES.as_ref()
+    }
+
+    fn visit<'a>(&mut self, row_count: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
+        if self.record.is_some() || row_count == 0 {
+            return Ok(());
+        }
+        // The `_last_checkpoint` file is a single row per the protocol. Reject extra rows
+        // loudly instead of silently consuming only row 0 -- the kernel may otherwise miss
+        // a corrupt/multi-row hint file produced by a buggy writer or a different format.
+        if row_count > 1 {
+            return Err(crate::Error::generic(format!(
+                "_last_checkpoint hint reader expected 1 row, got {row_count}"
+            )));
+        }
+        // Column order matches the leaf traversal of `CheckpointHintRecord`.
+        self.record = Some(CheckpointHintRecord {
+            version: getters[0].get(0, "version")?,
+            size: getters[1].get_opt(0, "size")?,
+            parts: getters[2].get_opt(0, "parts")?,
+            size_in_bytes: getters[3].get_opt(0, "sizeInBytes")?,
+            num_of_add_files: getters[4].get_opt(0, "numOfAddFiles")?,
+        });
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::arrow::array::{ArrayRef, Int64Array, RecordBatch};
+    use crate::arrow::datatypes::{
+        DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
+    };
+    use crate::engine::arrow_data::ArrowEngineData;
+
+    #[test]
+    fn empty_partition_produces_none() {
+        let reader = CheckpointHintReader::default();
+        let out = reader.into_output().unwrap();
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn apply_reads_first_row_and_breaks() {
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("version", ArrowDataType::Int64, false),
+            ArrowField::new("size", ArrowDataType::Int64, true),
+            ArrowField::new("parts", ArrowDataType::Int64, true),
+            ArrowField::new("sizeInBytes", ArrowDataType::Int64, true),
+            ArrowField::new("numOfAddFiles", ArrowDataType::Int64, true),
+        ]));
+        let columns: Vec<ArrayRef> = vec![
+            Arc::new(Int64Array::from(vec![42])),
+            Arc::new(Int64Array::from(vec![Some(100)])),
+            Arc::new(Int64Array::from(vec![None])),
+            Arc::new(Int64Array::from(vec![Some(2048)])),
+            Arc::new(Int64Array::from(vec![Some(7)])),
+        ];
+        let batch = RecordBatch::try_new(schema, columns).unwrap();
+        let engine_data = ArrowEngineData::new(batch);
+
+        let mut reader = CheckpointHintReader::default();
+        assert_eq!(reader.apply(&engine_data).unwrap(), KdfControl::Break);
+        assert_eq!(reader.apply(&engine_data).unwrap(), KdfControl::Break);
+
+        let out = reader.into_output().unwrap();
+        let rec = out.expect("record");
+        // Assert every projected field (full structural equality). Spot-checking only
+        // `version` + `num_of_add_files` would silently miss a regression in `size`,
+        // `parts`, or `size_in_bytes` decoding.
+        assert_eq!(
+            rec,
+            CheckpointHintRecord {
+                version: 42,
+                size: Some(100),
+                parts: None,
+                size_in_bytes: Some(2048),
+                num_of_add_files: Some(7),
+            },
+        );
+    }
+}

--- a/kernel/src/plans/kernel_reducers/handle.rs
+++ b/kernel/src/plans/kernel_reducers/handle.rs
@@ -1,0 +1,224 @@
+//! Runtime state for KDF reducers.
+//!
+//! [`ReducerHandle`] is the executor's working buffer for one Reduce step: created when a
+//! phase starts, fed batches via [`ReducerHandle::apply`], finalized via
+//! [`ReducerHandle::finish`] when the child is exhausted. Type-erased into [`FinishedHandle`]
+//! and returned to the state machine as the Reduce response.
+//!
+//! Handles dispatch in-process and never cross a serialization boundary.
+//!
+//! Callers recover typed output from a [`FinishedHandle`] via the paired [`Extractor`], minted
+//! at plan-build time and threaded through to the SM body.
+// Intra-doc links to the state-machine framework / IR sink types intentionally degrade to
+// plain text in this module slice (the linked items live in sibling stacks).
+#![allow(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
+
+use std::any::Any;
+
+use super::reducer::{KdfControl, KernelReducer, KernelReducerOutput, KernelReducerToken};
+use crate::plans::errors::DeltaError;
+use crate::plans::state_machines::framework::engine_error::EngineError;
+use crate::{DeltaResult, EngineData};
+
+/// Runtime state carrier. Holds the mutable reducer working buffer and the token that joins
+/// its eventual finalized state back to the plan-tree node.
+#[derive(Debug)]
+pub struct ReducerHandle {
+    token: KernelReducerToken,
+    inner: Box<dyn KernelReducer>,
+}
+
+impl ReducerHandle {
+    /// Construct a handle from a fresh token and a cloned initial state.
+    pub fn new(token: KernelReducerToken, inner: Box<dyn KernelReducer>) -> Self {
+        Self { token, inner }
+    }
+
+    /// Apply the reducer to a batch.
+    #[tracing::instrument(
+        level = "trace",
+        name = "kernel_reducer.apply",
+        skip(self, batch),
+        ret,
+        fields(kind = %self.inner.kind(), token_id = %self.token.id),
+    )]
+    pub fn apply(&mut self, batch: &dyn EngineData) -> DeltaResult<KdfControl> {
+        self.inner.apply(batch)
+    }
+
+    /// Consume the handle, returning the finalized token-stamped state.
+    #[tracing::instrument(
+        level = "debug",
+        name = "kernel_reducer.finish",
+        skip(self),
+        fields(kind = %self.inner.kind(), token_id = %self.token.id),
+    )]
+    pub fn finish(self) -> FinishedHandle {
+        tracing::debug!("kernel reducer handle finished");
+        FinishedHandle {
+            token: self.token,
+            erased: self.inner.finish(),
+        }
+    }
+}
+
+/// Output of [`ReducerHandle::finish`] -- carries the token and the type-erased final state.
+#[derive(Debug)]
+pub struct FinishedHandle {
+    pub token: KernelReducerToken,
+    pub erased: Box<dyn Any + Send>,
+}
+
+// === Typed extraction ===
+
+/// A typed adapter for pulling the typed output of a single reduce sink
+/// out of a [`FinishedHandle`].
+///
+/// SM bodies build an `Extractor` while planting an [`EngineRequest::Reduce`] (via
+/// [`Context::reduce`]) and feed the engine's [`FinishedHandle`] back through
+/// [`Self::extract`] on resume.
+///
+/// [`EngineRequest::Reduce`]: crate::plans::state_machines::framework::state_machine::EngineRequest::Reduce
+/// [`Context::reduce`]: crate::plans::state_machines::framework::plan_context::Context::reduce
+pub struct Extractor<O> {
+    token: KernelReducerToken,
+    extract: fn(Box<dyn Any + Send>) -> Result<O, DeltaError>,
+}
+
+impl<O: Send + 'static> Extractor<O> {
+    /// Build an `Extractor` for KDF state `S` at `token`. The stored function pointer
+    /// downcasts the erased payload back to `S` and runs `S::into_output`.
+    // Consumer (Context::reduce dispatch) lands in the StateMachine follow-up PR.
+    #[allow(dead_code)]
+    pub(crate) fn for_reducer<S>(token: KernelReducerToken) -> Self
+    where
+        S: KernelReducerOutput<Output = O> + 'static,
+    {
+        Self {
+            token,
+            extract: extract_reducer::<S>,
+        }
+    }
+
+    /// Decode `handle`'s payload into the typed output `O`.
+    ///
+    /// Sanity-checks that `handle.token` matches this extractor's token (cross-wired
+    /// finished handles surface as an internal error) and runs the typed reduction.
+    /// Decoding failures are wrapped in [`EngineError::internal`] so SM bodies can
+    /// uniformly handle them on the engine-error path.
+    pub fn extract(self, handle: FinishedHandle) -> Result<O, EngineError> {
+        if handle.token != self.token {
+            return Err(EngineError::internal(DeltaError::invariant(format!(
+                "kernel_reducer::extract: token mismatch -- handle token `{}` vs expected `{}`",
+                handle.token, self.token,
+            ))));
+        }
+        (self.extract)(handle.erased).map_err(EngineError::internal)
+    }
+}
+
+impl<O> std::fmt::Debug for Extractor<O> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Extractor")
+            .field("token", &self.token)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Downcast the erased payload back to `S` and run its typed reduction. Bound to a
+/// concrete `S` via `Extractor::for_reducer`'s generic fn-pointer coercion.
+#[allow(dead_code)] // only consumer is for_reducer, gated above
+fn extract_reducer<S>(erased: Box<dyn Any + Send>) -> Result<S::Output, DeltaError>
+where
+    S: KernelReducerOutput + 'static,
+{
+    let single = erased.downcast::<S>().map(|b| *b).map_err(|_| {
+        DeltaError::invariant(format!(
+            "kernel_reducer::extract: expected `{}`",
+            std::any::type_name::<S>(),
+        ))
+    })?;
+    single.into_output()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{CheckpointHintReader, KernelReducerKind, KernelReducerToken};
+    use super::*;
+
+    /// Exercise the Extractor round-trip end-to-end: build a CheckpointHintReader, drive it
+    /// through ReducerHandle, finish it, hand the FinishedHandle to a matching Extractor,
+    /// and assert the typed output. Catches any drift between token wiring, downcast typing,
+    /// and KernelReducerOutput::into_output.
+    #[test]
+    fn extractor_round_trip_returns_typed_state() {
+        // Construct a populated reader via the visit path so we don't need to peek at
+        // private fields. We feed it a synthetic single-row batch shaped like
+        // `_last_checkpoint`.
+        use crate::arrow::array::{ArrayRef, Int64Array, RecordBatch};
+        use crate::arrow::datatypes::{
+            DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
+        };
+        use crate::engine::arrow_data::ArrowEngineData;
+        let schema = std::sync::Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("version", ArrowDataType::Int64, false),
+            ArrowField::new("size", ArrowDataType::Int64, true),
+            ArrowField::new("parts", ArrowDataType::Int64, true),
+            ArrowField::new("sizeInBytes", ArrowDataType::Int64, true),
+            ArrowField::new("numOfAddFiles", ArrowDataType::Int64, true),
+        ]));
+        let columns: Vec<ArrayRef> = vec![
+            std::sync::Arc::new(Int64Array::from(vec![7])),
+            std::sync::Arc::new(Int64Array::from(vec![Some(1024)])),
+            std::sync::Arc::new(Int64Array::from(vec![None])),
+            std::sync::Arc::new(Int64Array::from(vec![Some(2048)])),
+            std::sync::Arc::new(Int64Array::from(vec![Some(3)])),
+        ];
+        let batch = RecordBatch::try_new(schema, columns).unwrap();
+        let engine_data = ArrowEngineData::new(batch);
+
+        let token = KernelReducerToken::new(KernelReducerKind::CheckpointHint);
+        let reader = CheckpointHintReader::default();
+        let mut handle = ReducerHandle::new(token.clone(), Box::new(reader));
+        assert_eq!(handle.apply(&engine_data).unwrap(), KdfControl::Break);
+        let finished = handle.finish();
+
+        let extractor =
+            Extractor::<<CheckpointHintReader as KernelReducerOutput>::Output>::for_reducer::<
+                CheckpointHintReader,
+            >(token);
+        let out = extractor
+            .extract(finished)
+            .expect("typed extract must succeed");
+        let rec = out.expect("record");
+        assert_eq!(rec.version, 7);
+        assert_eq!(rec.num_of_add_files, Some(3));
+    }
+
+    /// Mismatched tokens MUST surface as an EngineError::internal -- the extractor's whole
+    /// raison d'etre is to detect cross-wired handles between phases of a plan.
+    #[test]
+    fn extractor_rejects_mismatched_token() {
+        let token_a = KernelReducerToken::new(KernelReducerKind::CheckpointHint);
+        let token_b = KernelReducerToken::new(KernelReducerKind::CheckpointHint);
+        let reader = CheckpointHintReader::default();
+        let handle = ReducerHandle::new(token_a, Box::new(reader));
+        let finished = handle.finish();
+
+        let extractor =
+            Extractor::<<CheckpointHintReader as KernelReducerOutput>::Output>::for_reducer::<
+                CheckpointHintReader,
+            >(token_b);
+        let err = extractor
+            .extract(finished)
+            .expect_err("mismatched tokens must error");
+        // EngineError::internal hides the source in Display; assert the source chain
+        // (which is what SM bodies surface via display_with_source_chain) contains the
+        // diagnostic message.
+        let chain = err.display_with_source_chain();
+        assert!(
+            chain.contains("token mismatch"),
+            "source chain missing token mismatch: {chain}"
+        );
+    }
+}

--- a/kernel/src/plans/kernel_reducers/handle.rs
+++ b/kernel/src/plans/kernel_reducers/handle.rs
@@ -74,12 +74,11 @@ pub struct FinishedHandle {
 /// A typed adapter for pulling the typed output of a single reduce sink
 /// out of a [`FinishedHandle`].
 ///
-/// SM bodies build an `Extractor` while planting an [`EngineRequest::Reduce`] (via
-/// [`Context::reduce`]) and feed the engine's [`FinishedHandle`] back through
-/// [`Self::extract`] on resume.
+/// SM bodies build an `Extractor` while planting an [`EngineRequest::Reduce`] (via the
+/// `Context::reduce` helper, added in a sibling submodule) and feed the engine's
+/// [`FinishedHandle`] back through [`Self::extract`] on resume.
 ///
 /// [`EngineRequest::Reduce`]: crate::plans::state_machines::framework::state_machine::EngineRequest::Reduce
-/// [`Context::reduce`]: crate::plans::state_machines::framework::plan_context::Context::reduce
 pub struct Extractor<O> {
     token: KernelReducerToken,
     extract: fn(Box<dyn Any + Send>) -> Result<O, DeltaError>,
@@ -88,7 +87,7 @@ pub struct Extractor<O> {
 impl<O: Send + 'static> Extractor<O> {
     /// Build an `Extractor` for KDF state `S` at `token`. The stored function pointer
     /// downcasts the erased payload back to `S` and runs `S::into_output`.
-    // Consumer (Context::reduce dispatch) lands in the StateMachine follow-up PR.
+    // Consumer (`Context::reduce` dispatch) lives in a sibling state-machine module.
     #[allow(dead_code)]
     pub(crate) fn for_reducer<S>(token: KernelReducerToken) -> Self
     where

--- a/kernel/src/plans/kernel_reducers/metadata_protocol.rs
+++ b/kernel/src/plans/kernel_reducers/metadata_protocol.rs
@@ -1,0 +1,177 @@
+//! `MetadataProtocolReader` -- reducer KDF that extracts the table's
+//! [`Protocol`] and [`Metadata`] actions from a log / checkpoint scan.
+//!
+//! Uses the existing [`Protocol::try_new_from_data`] and
+//! [`Metadata::try_new_from_data`] helpers, which guarantee atomic
+//! extraction -- either a full valid action is returned or `None`. The
+//! reader stops once both have been seen.
+//!
+//! # Caller invariant: newest-first ordering
+//!
+//! The reader captures the FIRST `Some(Protocol)` / `Some(Metadata)` it sees and ignores
+//! subsequent ones, so the caller MUST feed batches in `version DESC` order (newer commits
+//! first, then checkpoints, oldest last). Mirrors the contract that
+//! [`crate::log_segment::LogSegment::replay_for_pm`] establishes for the visitor path. If
+//! batches are fed in chronological order, the reader will silently return the wrong
+//! (oldest, not newest) action -- which is why we surface the contract here AND assert it
+//! via `debug_assert!` on every batch when the reducer can prove the order.
+
+use crate::actions::{Metadata, Protocol};
+use crate::plans::errors::DeltaError;
+use crate::plans::kernel_reducers::{
+    KdfControl, KernelReducer, KernelReducerKind, KernelReducerOutput,
+};
+use crate::{DeltaResult, EngineData};
+
+/// Captures the first `Some(Protocol)` / `Some(Metadata)` seen under the
+/// declared row ordering.
+#[derive(Debug, Clone, Default)]
+pub struct MetadataProtocolReader {
+    protocol: Option<Protocol>,
+    metadata: Option<Metadata>,
+}
+
+impl KernelReducer for MetadataProtocolReader {
+    fn kind(&self) -> KernelReducerKind {
+        KernelReducerKind::MetadataProtocol
+    }
+
+    fn finish(self: Box<Self>) -> Box<dyn std::any::Any + Send> {
+        Box::new(*self)
+    }
+
+    fn apply(&mut self, batch: &dyn EngineData) -> DeltaResult<KdfControl> {
+        if self.protocol.is_none() {
+            if let Some(p) = Protocol::try_new_from_data(batch)? {
+                self.protocol = Some(p);
+            }
+        }
+        if self.metadata.is_none() {
+            if let Some(m) = Metadata::try_new_from_data(batch)? {
+                self.metadata = Some(m);
+            }
+        }
+        if self.protocol.is_some() && self.metadata.is_some() {
+            Ok(KdfControl::Break)
+        } else {
+            Ok(KdfControl::Continue)
+        }
+    }
+}
+
+impl KernelReducerOutput for MetadataProtocolReader {
+    /// `(Metadata, Protocol)` matches the existing kernel convention used by
+    /// `LogSegment::read_protocol_metadata` and its underlying `replay_for_pm` helper.
+    type Output = (Metadata, Protocol);
+
+    fn into_output(self) -> Result<Self::Output, DeltaError> {
+        let missing = |what: &str| {
+            DeltaError::invariant(format!(
+                "metadata_protocol.into_output: missing {what} after scan completed"
+            ))
+        };
+        let protocol = self.protocol.ok_or_else(|| missing("protocol"))?;
+        let metadata = self.metadata.ok_or_else(|| missing("metadata"))?;
+        Ok((metadata, protocol))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::actions::Format;
+    use crate::table_features::TableFeature;
+    use crate::table_properties::{
+        COLUMN_MAPPING_MODE, ENABLE_CHANGE_DATA_FEED, ENABLE_DELETION_VECTORS,
+    };
+    use crate::utils::test_utils::action_batch;
+
+    /// The full `Protocol` carried by `crate::utils::test_utils::action_batch()`. Kept in sync
+    /// with the JSON fixture inline below so a fixture drift is loud rather than silent.
+    fn expected_action_batch_protocol() -> Protocol {
+        Protocol::try_new(
+            3,
+            7,
+            Some([TableFeature::DeletionVectors]),
+            Some([TableFeature::DeletionVectors]),
+        )
+        .expect("test fixture protocol should be valid")
+    }
+
+    /// The full `Metadata` carried by `crate::utils::test_utils::action_batch()`. Mirrors
+    /// `actions::visitors::tests::test_parse_metadata`'s expected struct so any drift in the
+    /// shared fixture surfaces in both tests.
+    fn expected_action_batch_metadata() -> Metadata {
+        let configuration = HashMap::from_iter([
+            (ENABLE_DELETION_VECTORS.to_string(), "true".to_string()),
+            (COLUMN_MAPPING_MODE.to_string(), "none".to_string()),
+            (ENABLE_CHANGE_DATA_FEED.to_string(), "true".to_string()),
+        ]);
+        Metadata::new_unchecked(
+            "testId",
+            None,
+            None,
+            Format {
+                provider: "parquet".into(),
+                options: HashMap::new(),
+            },
+            r#"{"type":"struct","fields":[{"name":"value","type":"integer","nullable":true,"metadata":{}}]}"#,
+            Vec::new(),
+            Some(1677811175819),
+            configuration,
+        )
+    }
+
+    #[test]
+    fn kind_is_stable() {
+        let r = MetadataProtocolReader::default();
+        assert_eq!(KernelReducer::kind(&r), KernelReducerKind::MetadataProtocol);
+    }
+
+    #[test]
+    fn missing_protocol_errors() {
+        let r = MetadataProtocolReader::default();
+        let err = r.into_output().unwrap_err();
+        // Detail now lives in the source (the message is static per code).
+        let src = std::error::Error::source(&err).expect("detail in source");
+        assert!(src.to_string().contains("missing protocol"), "got: {src}");
+    }
+
+    #[test]
+    fn apply_extracts_protocol_and_metadata_then_breaks() {
+        // `action_batch()` is the canonical test fixture used by the visitor unit tests; it
+        // contains a single batch with both Protocol and Metadata actions, plus some adds.
+        let batch = action_batch();
+        let mut r = MetadataProtocolReader::default();
+        assert_eq!(
+            r.apply(batch.as_ref()).unwrap(),
+            KdfControl::Break,
+            "both actions present -> Break on first batch"
+        );
+
+        let (metadata, protocol) = r.into_output().unwrap();
+        // Compare against the full expected structs, not just one field each: this catches
+        // silent drift in any of the version, feature, schema, partition, configuration, or
+        // created-time fields produced by the reducer.
+        assert_eq!(protocol, expected_action_batch_protocol());
+        assert_eq!(metadata, expected_action_batch_metadata());
+    }
+
+    #[test]
+    fn apply_ignores_subsequent_actions_per_newest_first_contract() {
+        // The reader captures the FIRST Protocol/Metadata it sees and silently ignores any
+        // subsequent ones (because the caller is expected to feed newest-first). Pin that
+        // contract here so a regression that started overwriting on later batches surfaces.
+        let first = action_batch();
+        let second = action_batch();
+
+        let mut r = MetadataProtocolReader::default();
+        assert_eq!(r.apply(first.as_ref()).unwrap(), KdfControl::Break);
+        let snapshot = (r.protocol.clone(), r.metadata.clone());
+        // Subsequent apply is a no-op for state; result is still Break.
+        assert_eq!(r.apply(second.as_ref()).unwrap(), KdfControl::Break);
+        assert_eq!((r.protocol, r.metadata), snapshot);
+    }
+}

--- a/kernel/src/plans/kernel_reducers/mod.rs
+++ b/kernel/src/plans/kernel_reducers/mod.rs
@@ -1,0 +1,33 @@
+//! Kernel-Defined Functions (KDFs) -- stateful per-row logic the kernel owns.
+//!
+//! KDFs encapsulate Delta-specific per-row work (checkpoint hint extraction,
+//! protocol/metadata harvesting, sidecar collection) that engines can't interpret.
+//!
+//! The IR exposes one KDF shape: [`KernelReducer`], an observer over batches
+//! returning `Continue` / `Break`. The reducer is wired into a plan via the
+//! `Reduce` request handled by the state-machine framework (declared in a
+//! consumer module); the reducer drains the terminal row stream and accumulates
+//! finalized state for the engine to harvest.
+//!
+//! KDFs dispatch in-process and never cross a serialization boundary.
+//!
+//! Each [`ReducerHandle`] carries a [`KernelReducerToken`] (`{ kind, id }`, stamped at
+//! plan-build time, keys the executor's state table and the paired [`Extractor`]).
+// Intra-doc links to the state-machine framework / IR sink types are intentionally not
+// resolvable in this module slice (consumers live in sibling stacks). Plain-text
+// references above keep `cargo doc -D warnings` happy until those modules land.
+#![allow(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
+
+mod checkpoint_hint;
+mod handle;
+mod metadata_protocol;
+mod reducer;
+mod sidecar_collector;
+
+pub use checkpoint_hint::{CheckpointHintReader, CheckpointHintRecord};
+pub use handle::{Extractor, FinishedHandle, ReducerHandle};
+pub use metadata_protocol::MetadataProtocolReader;
+pub use reducer::{
+    KdfControl, KernelReducer, KernelReducerKind, KernelReducerOutput, KernelReducerToken,
+};
+pub use sidecar_collector::SidecarCollector;

--- a/kernel/src/plans/kernel_reducers/reducer.rs
+++ b/kernel/src/plans/kernel_reducers/reducer.rs
@@ -1,0 +1,153 @@
+//! Core `KernelReducer` trait, identity types, and typed-output companion.
+//!
+//! Adding a new KDF: declare the struct, derive `Clone`, write
+//! `impl KernelReducer for T { ... }` with `kind`, `apply`, `finish`, and pair it with a
+//! `KernelReducerOutput` impl declaring the typed output. KDFs ride on the
+//! `Reduce` engine request defined by the state-machine framework (consumer module);
+//! the request is dispatched in-process and never serialized.
+// Intra-doc links to the state-machine framework intentionally degrade to plain text in
+// this slice; consumer types live in sibling stacks.
+#![allow(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
+
+//! # Object-safety notes
+//!
+//! - Associated types are NOT on [`KernelReducer`] -- `Box<dyn KernelReducer>` must be
+//!   heterogeneous across concrete reducer implementations (the executor mixes reducers with
+//!   different state types). Typed output lives on the [`KernelReducerOutput`] companion trait via
+//!   static dispatch.
+//! - `finish(self: Box<Self>) -> Box<dyn Any + Send>` erases the per-impl state type to keep the
+//!   trait object-safe. Typed factories downcast inside their extract closure.
+
+use std::any::Any;
+
+use dyn_clone::DynClone;
+use strum::Display as StrumDisplay;
+use uuid::Uuid;
+
+use crate::plans::errors::DeltaError;
+use crate::{DeltaResult, EngineData};
+
+// === Control flow ===
+
+/// Loop control returned by a reducer after each batch.
+///
+/// `Break` lets a reducer stop driving more input once it has everything
+/// it needs (e.g. `CheckpointHintReader` after the first row).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KdfControl {
+    Continue,
+    Break,
+}
+
+// === Identity ===
+
+/// Stable diagnostic identifier per reducer impl. Used in tracing spans, metrics labels,
+/// panic messages, and [`KernelReducerToken`] construction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, StrumDisplay)]
+#[strum(serialize_all = "snake_case")]
+pub enum KernelReducerKind {
+    CheckpointHint,
+    MetadataProtocol,
+    SidecarCollector,
+}
+
+/// Identity for a kernel-reducer entry on a finished handle.
+///
+/// Stamped at plan-build time when an [`EngineRequest::Reduce`] step is constructed. The fresh
+/// UUID `id` ensures stale handles from a prior plan can't be confused with current
+/// ones -- a [`FinishedHandle`] arriving with a token from a dead plan fails the
+/// [`Extractor`] sanity check at decode time.
+///
+/// `Display` emits `<kind>#<id>`.
+///
+/// [`EngineRequest::Reduce`]: crate::plans::state_machines::framework::state_machine::EngineRequest::Reduce
+/// [`FinishedHandle`]: super::handle::FinishedHandle
+/// [`Extractor`]: super::handle::Extractor
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct KernelReducerToken {
+    pub kind: KernelReducerKind,
+    pub id: Uuid,
+}
+
+impl KernelReducerToken {
+    /// Mint a fresh token for a kernel reducer with a UUID id.
+    pub fn new(kind: KernelReducerKind) -> Self {
+        Self {
+            kind,
+            id: Uuid::new_v4(),
+        }
+    }
+}
+
+impl std::fmt::Display for KernelReducerToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}#{}", self.kind, self.id)
+    }
+}
+
+// === Reducer trait ===
+
+/// Stateful observer over batches. Returns [`KdfControl`] per batch for
+/// early termination.
+///
+/// Useful for accumulating log segments, reading hint files, collecting
+/// sidecar references, etc.
+///
+/// `Box<dyn KernelReducer>` is cloneable via the [`DynClone`] supertrait -- the
+/// blanket `impl<T: Clone> DynClone for T` covers every concrete KDF state
+/// that derives `Clone`, so impls never write their own `clone_boxed`.
+pub trait KernelReducer: DynClone + Send + Sync + std::fmt::Debug {
+    /// Diagnostic identifier, stamped into the [`KernelReducerToken`] at plan-build time.
+    fn kind(&self) -> KernelReducerKind;
+
+    /// Observe one batch. Return [`KdfControl::Break`] to stop driving
+    /// further input; the kernel treats it as "child exhausted."
+    ///
+    /// TODO: enforce cardinality of applied rows. Each reducer impl should declare an
+    /// expected per-batch (or total) row-count contract so the runtime can assert that
+    /// the engine isn't incorrectly providing rows (e.g. `CheckpointHintReader` is
+    /// single-row, `MetadataProtocolReader` short-circuits on Break, etc.). Impls
+    /// silently accept whatever the engine hands them.
+    fn apply(&mut self, batch: &dyn EngineData) -> DeltaResult<KdfControl>;
+
+    /// Consume the finalized KDF, returning its state erased to
+    /// `Box<dyn Any + Send>`. Typed factories downcast inside their extract
+    /// closure back to the concrete state type.
+    ///
+    /// Signature takes `Box<Self>` rather than `self` so it's object-safe;
+    /// concrete impls are usually `fn finish(self: Box<Self>) -> Box<dyn Any + Send> {
+    /// Box::new(*self) }`.
+    fn finish(self: Box<Self>) -> Box<dyn Any + Send>;
+}
+
+// `Clone` for `Box<dyn KernelReducer>` -- delegates to `DynClone` (which every
+// concrete `Clone` impl gets for free via the blanket).
+dyn_clone::clone_trait_object!(KernelReducer);
+
+// === Typed-output companion ===
+
+/// Typed-output companion. Each KDF state impls this once, declaring the
+/// typed output callers receive and how the finalized state reduces to it.
+///
+/// ```ignore
+/// impl KernelReducerOutput for SidecarCollector {
+///     type Output = Vec<FileMeta>;
+///     fn into_output(self) -> Result<Self::Output, DeltaError> {
+///         /* project on self */
+///     }
+/// }
+/// ```
+pub trait KernelReducerOutput: KernelReducer + Any + Sized + 'static {
+    /// What downstream callers receive after `phase.execute(...)` completes.
+    type Output: Send + 'static;
+
+    /// Reduce the finalized state to [`Self::Output`].
+    ///
+    /// Each reduce sink is single-partition by construction (the executor
+    /// drains one root partition; the planner pins `target_partitions = 1`),
+    /// so this consumes `Self` directly. Token-keyed identity validation
+    /// happens upstream in [`Extractor::for_reducer`]'s closure.
+    ///
+    /// [`Extractor::for_reducer`]: super::handle::Extractor::for_reducer
+    fn into_output(self) -> Result<Self::Output, DeltaError>;
+}

--- a/kernel/src/plans/kernel_reducers/sidecar_collector.rs
+++ b/kernel/src/plans/kernel_reducers/sidecar_collector.rs
@@ -1,0 +1,108 @@
+//! `SidecarCollector` -- reducer KDF that collects sidecar file references
+//! from a V2 checkpoint manifest scan.
+//!
+//! Delegates row visiting to the existing [`SidecarVisitor`] and
+//! resolves the captured sidecars against `log_root` into `Vec<FileMeta>`
+//! via [`Sidecar::to_filemeta`] in [`KernelReducerOutput::into_output`].
+//!
+//! [`Sidecar::to_filemeta`]: crate::actions::Sidecar::to_filemeta
+
+use url::Url;
+
+use crate::actions::visitors::SidecarVisitor;
+use crate::engine_data::RowVisitor;
+use crate::plans::errors::DeltaError;
+use crate::plans::kernel_reducers::{
+    KdfControl, KernelReducer, KernelReducerKind, KernelReducerOutput,
+};
+use crate::{DeltaResult, EngineData, FileMeta};
+
+/// Accumulates sidecars as batches stream in.
+#[derive(Debug, Clone)]
+pub struct SidecarCollector {
+    log_root: Url,
+    visitor: SidecarVisitor,
+}
+
+impl SidecarCollector {
+    /// Construct a collector that resolves sidecar paths under `log_root`.
+    pub fn new(log_root: Url) -> Self {
+        Self {
+            log_root,
+            visitor: SidecarVisitor::default(),
+        }
+    }
+}
+
+impl KernelReducer for SidecarCollector {
+    fn kind(&self) -> KernelReducerKind {
+        KernelReducerKind::SidecarCollector
+    }
+
+    fn finish(self: Box<Self>) -> Box<dyn std::any::Any + Send> {
+        Box::new(*self)
+    }
+
+    fn apply(&mut self, batch: &dyn EngineData) -> DeltaResult<KdfControl> {
+        self.visitor.visit_rows_of(batch)?;
+        Ok(KdfControl::Continue)
+    }
+}
+
+impl KernelReducerOutput for SidecarCollector {
+    type Output = Vec<FileMeta>;
+
+    fn into_output(self) -> Result<Self::Output, DeltaError> {
+        let log_root = self.log_root;
+        self.visitor
+            .sidecars
+            .into_iter()
+            .map(|sidecar| {
+                sidecar
+                    .to_filemeta(&log_root)
+                    .map_err(DeltaError::invariant)
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::actions::Sidecar;
+
+    fn log_root() -> Url {
+        Url::parse("file:///test/_delta_log/").unwrap()
+    }
+
+    #[test]
+    fn kind_is_stable() {
+        let s = SidecarCollector::new(log_root());
+        assert_eq!(KernelReducer::kind(&s), KernelReducerKind::SidecarCollector);
+    }
+
+    #[test]
+    fn empty_partition_produces_empty_vec() {
+        let out = SidecarCollector::new(log_root()).into_output().unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn into_output_resolves_sidecar_paths() {
+        let mut s = SidecarCollector::new(log_root());
+        s.visitor.sidecars.push(Sidecar {
+            path: "sidecar1.parquet".to_string(),
+            size_in_bytes: 1000,
+            modification_time: 42,
+            tags: None,
+        });
+        let out = s.into_output().unwrap();
+        assert_eq!(out.len(), 1);
+        assert!(out[0]
+            .location
+            .as_str()
+            .ends_with("/_sidecars/sidecar1.parquet"));
+        assert_eq!(out[0].size, 1000);
+        assert_eq!(out[0].last_modified, 42);
+    }
+}

--- a/kernel/src/plans/mod.rs
+++ b/kernel/src/plans/mod.rs
@@ -3,8 +3,10 @@
 //! This module is opt-in behind the `declarative-plans` feature flag.
 pub mod errors;
 pub mod ir;
+pub mod kernel_reducers;
 pub mod proto;
 mod query_builder;
+pub mod state_machines;
 
 use bytes::Bytes;
 pub use ir::{IoOperation, Operation};

--- a/kernel/src/plans/mod.rs
+++ b/kernel/src/plans/mod.rs
@@ -1,5 +1,3 @@
-//! This module defines the concept of a PlanExecutor and its associated input + output types.
-//!
 //! This module is opt-in behind the `declarative-plans` feature flag.
 pub mod errors;
 pub mod ir;

--- a/kernel/src/plans/mod.rs
+++ b/kernel/src/plans/mod.rs
@@ -1,6 +1,7 @@
 //! This module defines the concept of a PlanExecutor and its associated input + output types.
 //!
 //! This module is opt-in behind the `declarative-plans` feature flag.
+pub mod errors;
 pub mod ir;
 pub mod proto;
 mod query_builder;

--- a/kernel/src/plans/state_machines/framework/coroutine.rs
+++ b/kernel/src/plans/state_machines/framework/coroutine.rs
@@ -1,0 +1,341 @@
+//! CoroutineSM-backed [`StateMachine`] implementation.
+//!
+//! Holds the internal yield/resume protocol shared between SM bodies and the
+//! [`CoroutineSM`] driver:
+//!
+//! - `StepYield` / `StepResume` (both `pub(crate)`) -- the value pair shuttled through the
+//!   genawaiter trampoline at each phase boundary.
+//! - `Engine` (`pub(crate)`) -- the SM-internal yield-channel handle, aliased over
+//!   [`genawaiter2::rc::Co`]. SM bodies emit yields through the `Context` `reduce` / `schema_query`
+//!   plan-construction helpers (sibling submodule); this module never exposes raw yields.
+//! - [`CoroutineSM<R>`] -- the driver that compiles `StepYield` sequences into the [`StateMachine`]
+//!   contract.
+//!
+//! # `!Send` design
+//!
+//! The driver uses [`genawaiter2::rc`] (not `sync`). State machines are CPU-only
+//! sequencers that never perform I/O or `await` real futures -- every
+//! `engine.yield_(step).await` is just the genawaiter2 trampoline, polled synchronously by
+//! the driver. There is no concurrent access to an SM, so the `Send` bound from
+//! `sync::GenBoxed` is unnecessary load on the API. Callers that need to drive an SM from
+//! a multi-threaded async runtime use `block_on` (which does not require `Send`) or
+//! `LocalSet` / `spawn_local`.
+//!
+//! # No-panic policy
+//!
+//! Built on [`genawaiter2`], which panics on coroutine protocol misuse (awaiting a
+//! non-yield future, retaining a `Co` after return). The no-panic rule is preserved
+//! because the only path to `Co::yield_` is through the `Context` plan-construction
+//! dispatch helpers; SM bodies are `pub(crate)`-only and FFI sees them through
+//! `Box<dyn StateMachine>`, so the panic paths are unreachable externally.
+//!
+//! # Naming note
+//!
+//! The `Engine` alias below shares its name with the kernel's connector-facing `Engine`
+//! trait. They are unrelated -- this `Engine` is the SM-internal yield channel, lives
+//! behind `pub(crate)`, and is never exposed in the public API. If a single scope ever
+//! needs both names, alias one at the use site (e.g. `use crate::Engine as EngineTrait;`).
+
+use std::future::Future;
+use std::pin::Pin;
+use std::{fmt, mem};
+
+use genawaiter2::rc::{Co, Gen};
+use genawaiter2::GeneratorState;
+use uuid::Uuid;
+
+use super::engine_error::EngineError;
+use super::state_machine::{EngineRequest, EngineResponse, NextStep, StateMachine};
+use crate::plans::errors::DeltaError;
+
+// ============================================================================
+// Yield/resume protocol
+// ============================================================================
+
+/// Value yielded by a coroutine at each phase boundary. Carries the operation envelope and
+/// the phase name.
+pub(crate) struct StepYield {
+    pub operation: EngineRequest,
+    pub step_name: &'static str,
+}
+
+/// Value the driver passes back to the coroutine on resume. Wraps the engine outcome for
+/// the most recent [`StepYield::operation`].
+pub(crate) struct StepResume(pub Result<EngineResponse, EngineError>);
+
+impl fmt::Debug for StepResume {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.0 {
+            Ok(_) => f.write_str("StepResume(Ok(..))"),
+            Err(e) => write!(f, "StepResume(Err({:?}))", e.kind),
+        }
+    }
+}
+
+/// CoroutineSM handle used inside phase bodies. Alias over [`genawaiter2::rc::Co`].
+///
+/// `genawaiter2::rc` (not `sync`) is intentional: the [`CoroutineSM`] driver does not need
+/// a `Send` future bound (see the module docs for why), and `rc::Co` is `!Send` -- the SM
+/// body's future inherits that, which is the correct architectural shape for a CPU-only
+/// sequencer.
+#[allow(dead_code)] // primary consumer is Context::dispatch (sibling state-machine framework module)
+pub(crate) type Engine = Co<StepYield, StepResume>;
+
+// ============================================================================
+// CoroutineSM driver
+// ============================================================================
+
+type InnerGen<R> = Gen<StepYield, StepResume, Pin<Box<dyn Future<Output = Result<R, DeltaError>>>>>;
+
+/// A state machine driven by a stackless coroutine (via [`genawaiter2`]).
+///
+/// At each phase the body yields a single `StepYield` (operation + static phase name)
+/// and awaits the engine outcome. The driver shuttles operations to
+/// [`StateMachine::get_step`] and resumes the body with the matching `StepResume` on
+/// [`StateMachine::submit`]. Protocol is strictly 1:1: each yield carries one
+/// [`EngineRequest`], the driver hands it to the engine, and the engine outcome flows back
+/// as a `StepResume` on submit. Zero-yield coroutines are allowed; they return
+/// [`NextStep::Done`] on the first submit.
+///
+/// # Identity
+///
+/// Every `CoroutineSM` carries a fresh `sm_id: Uuid` and a static `sm_kind` label (the
+/// kernel SM's logical kind: `"scan_metadata"`, `"full_state"`, ...). Together with the
+/// per-phase name available via [`StateMachine::step_name`] these form the
+/// `(sm_id, sm_kind, step_name)` identity tuple used to correlate engine activity across
+/// the SM boundary.
+///
+/// `sm_id` is generated by the driver and passed into the producer closure for any
+/// SM-rooted identity stamping (e.g. reducer handles emitted by [`EngineRequest::Reduce`]).
+pub struct CoroutineSM<R: 'static> {
+    gen: InnerGen<R>,
+    /// Where the SM is positioned. `Yielded` while engine work is pending; `ResultReady`
+    /// when the body completed without ever yielding (the next `submit` hands the stored
+    /// result back); `Done` once `submit` has returned the terminal result.
+    state: SmPosition<R>,
+    sm_id: Uuid,
+    sm_kind: &'static str,
+}
+
+/// Internal positioning of a [`CoroutineSM`]. Drives the [`StateMachine`] contract.
+#[allow(dead_code)] // Yielded/ResultReady are only constructed by ::new; consumer is Context::dispatch
+enum SmPosition<R> {
+    /// A phase is queued; engine work pending.
+    Yielded(StepYield),
+    /// Body has produced its terminal result; awaiting `submit` to hand it back. Reached
+    /// only by zero-yield SMs (multi-yield SMs skip through this state inside `submit` and
+    /// transition straight to `Done`).
+    ResultReady(Result<R, DeltaError>),
+    /// Result has been consumed; terminal sink.
+    Done,
+}
+
+impl<R: 'static> CoroutineSM<R> {
+    /// Construct a coroutine state machine and run the producer to its first yield (or to
+    /// completion).
+    ///
+    /// `sm_kind` labels the SM's logical kind for diagnostics (e.g. `"scan_metadata"`); the
+    /// driver mints a fresh `sm_id` and threads it into the producer closure for any
+    /// SM-rooted identity stamping the body needs.
+    ///
+    /// If the producer yields, the first yield becomes the initial `StepYield` returned
+    /// by [`StateMachine::get_step`]. If it completes without yielding, the terminal
+    /// result is stored and handed back from the first [`StateMachine::submit`] call --
+    /// callers don't need to special-case zero-yield SMs.
+    #[allow(dead_code)] // Context::dispatch is the consumer (sibling module)
+    pub(crate) fn new<F, Fut>(sm_kind: &'static str, producer: F) -> Self
+    where
+        F: FnOnce(Engine, Uuid) -> Fut + 'static,
+        Fut: Future<Output = Result<R, DeltaError>> + 'static,
+    {
+        let sm_id = Uuid::new_v4();
+        let mut gen: InnerGen<R> = Gen::new(move |engine| {
+            Box::pin(producer(engine, sm_id))
+                as Pin<Box<dyn Future<Output = Result<R, DeltaError>>>>
+        });
+        // genawaiter2's `Gen<Y, R, F>` exposes only `resume_with(R)`; the first resume arg
+        // is discarded because nothing is awaiting it. We pass an inert
+        // `Ok(EngineResponse::Empty)` sentinel that the body never observes (a yield
+        // always precedes any awaited resume, and zero-yield bodies terminate before
+        // inspection).
+        let state = match gen.resume_with(StepResume(Ok(EngineResponse::Empty))) {
+            GeneratorState::Yielded(phase) => SmPosition::Yielded(phase),
+            GeneratorState::Complete(result) => SmPosition::ResultReady(result),
+        };
+        Self {
+            gen,
+            state,
+            sm_id,
+            sm_kind,
+        }
+    }
+
+    /// `true` once the coroutine has terminated and [`submit`](Self::submit) has handed
+    /// out its final result.
+    pub fn is_done(&self) -> bool {
+        matches!(self.state, SmPosition::Done)
+    }
+
+    /// Fresh per-instance identifier. Stable across the lifetime of this SM and embedded
+    /// in SM-rooted artifacts (reducer handles, diagnostic logs).
+    pub fn sm_id(&self) -> Uuid {
+        self.sm_id
+    }
+
+    /// Static label for the SM's logical kind (e.g. `"scan_metadata"`, `"full_state"`).
+    pub fn sm_kind(&self) -> &'static str {
+        self.sm_kind
+    }
+}
+
+impl<R: 'static> StateMachine for CoroutineSM<R> {
+    type Result = R;
+
+    fn get_step(&mut self) -> Result<EngineRequest, DeltaError> {
+        match &self.state {
+            SmPosition::Yielded(phase) => Ok(phase.operation.clone()),
+            SmPosition::ResultReady(_) => Err(DeltaError::invariant(
+                "CoroutineSM::get_step: zero-yield SM has no pending operation; \
+                 call submit() to receive the terminal result",
+            )),
+            SmPosition::Done => Err(DeltaError::invariant(
+                "CoroutineSM::get_step: state machine already completed",
+            )),
+        }
+    }
+
+    fn submit(
+        &mut self,
+        result: Result<EngineResponse, EngineError>,
+    ) -> Result<NextStep<R>, DeltaError> {
+        match mem::replace(&mut self.state, SmPosition::Done) {
+            SmPosition::ResultReady(value) => {
+                // Zero-yield SMs hand back their terminal result on the first `submit`.
+                // The input is ignored because the body never awaited it, but a caller-
+                // supplied `Err(EngineError)` would indicate the executor wrapped an
+                // operation around a no-op SM and observed a real failure -- escalate
+                // rather than silently dropping it.
+                if let Err(err) = result {
+                    return Err(DeltaError::invariant(err));
+                }
+                value.map(NextStep::Done)
+            }
+            SmPosition::Done => Err(DeltaError::invariant(
+                "CoroutineSM::submit: cannot submit, already completed",
+            )),
+            SmPosition::Yielded(_) => match self.gen.resume_with(StepResume(result)) {
+                GeneratorState::Yielded(next) => {
+                    self.state = SmPosition::Yielded(next);
+                    Ok(NextStep::Continue)
+                }
+                GeneratorState::Complete(final_result) => final_result.map(NextStep::Done),
+            },
+        }
+    }
+
+    fn step_name(&self) -> &'static str {
+        match &self.state {
+            SmPosition::Yielded(phase) => phase.step_name,
+            SmPosition::ResultReady(_) | SmPosition::Done => "done",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plans::state_machines::framework::engine_error::EngineErrorKind;
+    use crate::plans::state_machines::framework::state_machine::SchemaQuery;
+
+    fn toy_step() -> EngineRequest {
+        EngineRequest::SchemaQuery(SchemaQuery::new("/toy"))
+    }
+
+    fn toy_schema() -> crate::schema::SchemaRef {
+        std::sync::Arc::new(crate::schema::StructType::new_unchecked(Vec::<
+            crate::schema::StructField,
+        >::new()))
+    }
+
+    /// Drive a two-phase SM: yield op A, observe a SchemaQuery response, yield op B, complete.
+    ///
+    /// The 1:1 pairing in `state_machine.rs` is SchemaQuery -> Schema; submitting
+    /// `EngineResponse::Schema(_)` (and not `EngineResponse::Empty`, which is a driver
+    /// sentinel only) exercises the documented protocol end-to-end.
+    #[test]
+    fn two_phase_sm_executes_in_sequence() {
+        let mut sm = CoroutineSM::<i64>::new("test", |mut engine, _sm_id| async move {
+            let phase_a = StepYield {
+                operation: toy_step(),
+                step_name: "phase_a",
+            };
+            let phase_b = StepYield {
+                operation: toy_step(),
+                step_name: "phase_b",
+            };
+            let _ = engine.yield_(phase_a).await;
+            let _ = engine.yield_(phase_b).await;
+            Ok(42)
+        });
+
+        assert_eq!(sm.sm_kind(), "test");
+
+        assert_eq!(sm.step_name(), "phase_a");
+        let op = sm.get_step().unwrap();
+        assert!(matches!(op, EngineRequest::SchemaQuery(_)));
+
+        let r = sm.submit(Ok(EngineResponse::Schema(toy_schema()))).unwrap();
+        assert!(matches!(r, NextStep::Continue));
+        assert_eq!(sm.step_name(), "phase_b");
+
+        let op = sm.get_step().unwrap();
+        assert!(matches!(op, EngineRequest::SchemaQuery(_)));
+
+        let r = sm.submit(Ok(EngineResponse::Schema(toy_schema()))).unwrap();
+        match r {
+            NextStep::Done(v) => assert_eq!(v, 42),
+            _ => panic!("expected Done"),
+        }
+        assert!(sm.is_done());
+    }
+
+    /// Engine errors flow through as `Err(EngineError)` on resume; the SM body receives
+    /// them and decides what to do.
+    #[test]
+    fn engine_error_flows_to_body_as_resume_err() {
+        let mut sm = CoroutineSM::<String>::new("test", |mut engine, _sm_id| async move {
+            let step = StepYield {
+                operation: toy_step(),
+                step_name: "p",
+            };
+            let resume = engine.yield_(step).await;
+            match resume.0 {
+                Err(e) => Ok(format!("got: {}", e.kind)),
+                Ok(_) => panic!("expected engine error"),
+            }
+        });
+
+        let _ = sm.get_step().unwrap();
+        let err = EngineError::new(EngineErrorKind::FileNotFound { path: "/x".into() });
+        let r = sm.submit(Err(err)).unwrap();
+        match r {
+            NextStep::Done(s) => assert!(s.contains("file not found: /x")),
+            _ => panic!("expected Done"),
+        }
+    }
+
+    /// Zero-yield coroutines are allowed: the first `submit` call hands the stored
+    /// terminal value back. Useful for SMs that compute their plans entirely up-front and
+    /// have no intermediate engine work.
+    #[test]
+    fn zero_phase_coroutine_returns_value_on_first_submit() {
+        let mut sm = CoroutineSM::<i32>::new("test", |_co, _sm_id| async move { Ok(7) });
+        assert!(sm.get_step().is_err());
+        let r = sm.submit(Ok(EngineResponse::Empty)).unwrap();
+        match r {
+            NextStep::Done(v) => assert_eq!(v, 7),
+            _ => panic!("expected Done"),
+        }
+        assert!(sm.is_done());
+    }
+}

--- a/kernel/src/plans/state_machines/framework/engine_error.rs
+++ b/kernel/src/plans/state_machines/framework/engine_error.rs
@@ -1,0 +1,165 @@
+//! Structured execution errors returned by engine plan execution.
+//!
+//! [`EngineError`] is **engine-facing**: the engine produces one when plan execution fails in a
+//! well-understood way, and SM bodies match on [`EngineError::kind`] to react. Crossing into the
+//! kernel-facing `DeltaError` happens at the call site (e.g. `DeltaError::invariant(engine_err)`),
+//! which keeps the `EngineError` as the source.
+//!
+//! Kernel code MUST NOT gate control flow on the *text* of `message` fields inside variants:
+//! those strings are non-semantic and exist only for display.
+
+use std::error::Error;
+
+use crate::plans::errors::BoxedSource;
+use crate::Version;
+
+/// A structured error from executing a `Plan`. Pairs a typed [`EngineErrorKind`] (the semantic
+/// signal SMs match on) with an optional source chain forwarded through
+/// `Error::source()`.
+#[derive(Debug, thiserror::Error)]
+#[error("{kind}")]
+pub struct EngineError {
+    /// The semantic variant. Kernel SMs match on this.
+    pub kind: EngineErrorKind,
+    /// Optional in-process-only source chain.
+    pub source: Option<BoxedSource>,
+}
+
+/// Semantic tag of an [`EngineError`].
+///
+/// Adding a new variant is the preferred way to express a new engine failure -- string-matching
+/// on `message` fields is explicitly forbidden. `#[non_exhaustive]` reserves space for additional
+/// variants without breaking callers.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum EngineErrorKind {
+    /// A required input relation was empty when the plan expected at least one row.
+    #[error("empty input for sink: {sink_description}")]
+    EmptyInput { sink_description: String },
+
+    /// A file path referenced by the plan was not found in storage.
+    #[error("file not found: {path}")]
+    FileNotFound { path: String },
+
+    /// A generic I/O failure that doesn't fit a more specific variant. `message` is
+    /// non-semantic -- for display only.
+    #[error("I/O error: {message}")]
+    IoError { message: String },
+
+    /// Engine-side failure the kernel does not classify further. Diagnostic detail lives in
+    /// [`EngineError::source`]; construct via [`EngineError::internal`].
+    #[error("internal engine error")]
+    Internal,
+
+    /// Commit lost a put-if-absent race or catalog ratify reported a conflicting table version.
+    #[error("commit conflict at version {version}")]
+    CommitConflict { version: Version },
+}
+
+impl EngineError {
+    /// Build a sourceless [`EngineError`]. The fast path when the engine
+    /// has no underlying error to attach.
+    pub fn new(kind: EngineErrorKind) -> Self {
+        Self { kind, source: None }
+    }
+
+    /// Render this error together with its full source chain. Formatted as
+    /// `"{kind}: {source}: {source_of_source}: ..."`.
+    ///
+    /// Distinct from [`ToString::to_string`] (which only renders `kind`):
+    /// [`EngineErrorKind::Internal`] carries its entire diagnostic payload in `source`, so
+    /// `to_string()` collapses to the static `"internal engine error"`. Use this method for
+    /// any diagnostic detail derived from an `Internal`.
+    pub fn display_with_source_chain(&self) -> String {
+        let mut out = self.kind.to_string();
+        let mut cur: Option<&(dyn Error + 'static)> = self.source();
+        while let Some(s) = cur {
+            out.push_str(": ");
+            out.push_str(&s.to_string());
+            cur = s.source();
+        }
+        out
+    }
+
+    /// Construct an [`EngineErrorKind::Internal`] with the originating
+    /// error attached as `source`. Use this whenever the engine has a
+    /// failure that doesn't fit a typed variant -- kernel call sites
+    /// inspect `source` (via `Error::source()`) if they need
+    /// the underlying message or type.
+    ///
+    /// Adding a dedicated typed variant is preferred whenever a given
+    /// cause starts recurring.
+    pub fn internal<E>(err: E) -> Self
+    where
+        E: Error + Send + Sync + 'static,
+    {
+        Self {
+            kind: EngineErrorKind::Internal,
+            source: Some(Box::new(err)),
+        }
+    }
+}
+
+impl From<EngineErrorKind> for EngineError {
+    fn from(kind: EngineErrorKind) -> Self {
+        Self::new(kind)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error;
+    use std::io;
+
+    use super::*;
+
+    #[test]
+    fn display_delegates_to_kind() {
+        let err = EngineError::new(EngineErrorKind::FileNotFound {
+            path: "/tmp/x".into(),
+        });
+        assert_eq!(err.to_string(), "file not found: /tmp/x");
+    }
+
+    #[test]
+    fn display_with_source_chain_renders_internal_payload() {
+        let err = EngineError::internal(io::Error::other(
+            "Non-Results plan failed: IllegalStateException: boom",
+        ));
+        let rendered = err.display_with_source_chain();
+        assert!(
+            rendered.contains("internal engine error"),
+            "kind prefix missing: {rendered}"
+        );
+        assert!(
+            rendered.contains("Non-Results plan failed: IllegalStateException: boom"),
+            "source payload missing: {rendered}"
+        );
+    }
+
+    #[test]
+    fn display_with_source_chain_is_stable_when_no_source() {
+        let err = EngineError::new(EngineErrorKind::FileNotFound {
+            path: "/tmp/x".into(),
+        });
+        assert_eq!(err.display_with_source_chain(), err.to_string());
+    }
+
+    #[test]
+    fn internal_tags_kind_and_preserves_source() {
+        let io = io::Error::other("boom");
+        let err = EngineError::internal(io);
+        assert_eq!(err.kind, EngineErrorKind::Internal);
+        let src = err.source().expect("source preserved");
+        assert!(src.to_string().contains("boom"));
+    }
+
+    #[test]
+    fn from_kind_produces_sourceless_error() {
+        let err: EngineError = EngineErrorKind::EmptyInput {
+            sink_description: "sink".into(),
+        }
+        .into();
+        assert!(err.source.is_none());
+    }
+}

--- a/kernel/src/plans/state_machines/framework/mod.rs
+++ b/kernel/src/plans/state_machines/framework/mod.rs
@@ -1,9 +1,20 @@
 //! State-machine framework: the shared infrastructure every kernel SM uses.
 //!
+//! - [`state_machine`] -- the [`StateMachine`](state_machine::StateMachine) trait,
+//!   [`NextStep`](state_machine::NextStep), and the typed
+//!   [`EngineRequest`](state_machine::EngineRequest) /
+//!   [`EngineResponse`](state_machine::EngineResponse) protocol the executor and SM exchange each
+//!   tick.
 //! - [`engine_error`] -- [`EngineError`](engine_error::EngineError), the typed failure the engine
 //!   surfaces to the SM (distinct from [`DeltaError`](crate::plans::errors::DeltaError), the
 //!   kernel-to-caller error).
+//! - [`coroutine`] -- [`CoroutineSM`](coroutine::CoroutineSM), the async-fn-backed `StateMachine`
+//!   impl. Wraps `genawaiter2::rc::Gen` to translate the typed `StepYield` / `StepResume` protocol
+//!   (both `pub(crate)`) into the `StateMachine` trait the executor drives.
 //!
-//! Additional modules (`state_machine`, `coroutine`, `plan_context`) land in follow-up PRs.
+//! The `plan_context` module (Context + PlanBuilder) lives in a sibling stack and is
+//! intentionally not declared here.
 
+pub mod coroutine;
 pub mod engine_error;
+pub mod state_machine;

--- a/kernel/src/plans/state_machines/framework/mod.rs
+++ b/kernel/src/plans/state_machines/framework/mod.rs
@@ -1,0 +1,9 @@
+//! State-machine framework: the shared infrastructure every kernel SM uses.
+//!
+//! - [`engine_error`] -- [`EngineError`](engine_error::EngineError), the typed failure the engine
+//!   surfaces to the SM (distinct from [`DeltaError`](crate::plans::errors::DeltaError), the
+//!   kernel-to-caller error).
+//!
+//! Additional modules (`state_machine`, `coroutine`, `plan_context`) land in follow-up PRs.
+
+pub mod engine_error;

--- a/kernel/src/plans/state_machines/framework/state_machine.rs
+++ b/kernel/src/plans/state_machines/framework/state_machine.rs
@@ -1,0 +1,171 @@
+//! The [`StateMachine`] trait kernel SMs implement and engine-side executors drive, along
+//! with the [`EngineRequest`] / [`EngineResponse`] protocol they exchange each tick.
+//!
+//! Engines drive every SM through the same three methods: ask for the next step's work,
+//! execute it, hand back the outcome. The SM decides whether to continue to another step
+//! or terminate with a typed result.
+//!
+//! ```text
+//! loop {
+//!     let op = sm.get_step()?;
+//!     let result = executor.execute(op);
+//!     match sm.submit(result)? {
+//!         NextStep::Continue => continue,
+//!         NextStep::Done(r) => return Ok(r),
+//!     }
+//! }
+//! ```
+//!
+//! The [`EngineRequest`] / [`EngineResponse`] pair is the *protocol*: each request variant
+//! maps to exactly one response variant on resume:
+//!
+//! - [`EngineRequest::Reduce`] -> [`EngineResponse::Reducer`]
+//! - [`EngineRequest::SchemaQuery`] -> [`EngineResponse::Schema`]
+//!
+//! [`EngineResponse::Empty`] is a driver-internal priming sentinel SM bodies never observe.
+
+use super::engine_error::EngineError;
+use crate::plans::errors::DeltaError;
+#[cfg(doc)]
+use crate::plans::errors::DeltaErrorCode;
+use crate::plans::ir::nodes::ReduceSink;
+use crate::plans::ir::plan::{PlanNode, RefId};
+use crate::plans::kernel_reducers::FinishedHandle;
+use crate::schema::SchemaRef;
+
+// ============================================================================
+// Engine request: kernel -> engine, the "do this work" envelope
+// ============================================================================
+
+/// A metadata-only read: ask the engine to open a parquet file, read its schema from the
+/// footer, and deliver it back as [`EngineResponse::Schema`].
+///
+/// Distinct from a data-carrying [`EngineRequest::Reduce`]: no row stream, no sink, no
+/// KDF-producing pipeline -- the executor just does a footer read.
+#[derive(Debug, Clone)]
+pub struct SchemaQuery {
+    /// Path to the parquet file whose schema the kernel wants.
+    pub file_path: String,
+}
+
+impl SchemaQuery {
+    /// Construct a schema query for `file_path`.
+    pub fn new(file_path: impl Into<String>) -> Self {
+        Self {
+            file_path: file_path.into(),
+        }
+    }
+}
+
+/// What [`StateMachine::get_step`] hands to the executor.
+///
+/// Separates the concerns the executor understands:
+///
+/// - [`SchemaQuery`](Self::SchemaQuery) -- metadata-only footer read.
+/// - [`Reduce`](Self::Reduce) -- plan dataflow drained into a [`ReduceSink`]. The engine compiles
+///   `stmts` (a flat plan), runs the DAG, and feeds the rows produced at `terminal` into `sink`.
+///   The reducer's typed output flows back as [`EngineResponse::Reducer`] carrying the
+///   `FinishedHandle`, and the SM body recovers the typed value via the paired `Extractor`.
+#[derive(Debug, Clone)]
+pub enum EngineRequest {
+    /// Read a file's schema without reading data.
+    SchemaQuery(SchemaQuery),
+    /// Plan dataflow + reducer drain. The engine evaluates `stmts` as a DAG and pipes the
+    /// stream produced at `terminal` into `sink`.
+    Reduce {
+        stmts: Vec<PlanNode>,
+        terminal: RefId,
+        sink: ReduceSink,
+    },
+}
+
+// ============================================================================
+// Engine response: engine -> kernel, the success payload returned on resume
+// ============================================================================
+
+/// Engine -> SM success payload for a single phase yield.
+///
+/// Travels through [`StateMachine::submit`] on the success arm. Variant mismatches
+/// (executor returned the wrong shape for the preceding yield) surface as internal errors
+/// in the `Context` dispatch helpers (added under `plans::state_machines::framework`).
+#[derive(Debug)]
+pub enum EngineResponse {
+    /// A [`EngineRequest::Reduce`] finished and is handing back its drained reducer state.
+    Reducer(FinishedHandle),
+    /// A [`EngineRequest::SchemaQuery`] finished and is handing back the resolved schema.
+    Schema(SchemaRef),
+    /// Driver-internal sentinel for the genawaiter trampoline's first `resume_with` (the
+    /// one that runs the producer up to its first await). SM bodies never observe this
+    /// variant: a yield always precedes any awaited resume, and zero-yield SMs terminate
+    /// before inspecting the priming value.
+    Empty,
+}
+
+// ============================================================================
+// StateMachine trait: the contract the executor drives
+// ============================================================================
+
+/// Result of submitting a step result to a state machine.
+#[derive(Debug)]
+pub enum NextStep<R> {
+    /// SM advanced to the next step; the driver should loop back to
+    /// [`StateMachine::get_step`].
+    Continue,
+    /// SM completed with the given result. The driver must stop.
+    Done(R),
+}
+
+/// The contract kernel state machines implement and engine-side executors drive.
+///
+/// Each SM-visible "step" is one tick of this loop: the executor asks
+/// [`StateMachine::get_step`] for what to run, executes it, then calls
+/// [`StateMachine::submit`] with the outcome ([`EngineResponse`] on success, an
+/// [`EngineError`] on engine failure).
+///
+/// # Error layering
+///
+/// Both `get_step` and `submit` return [`DeltaError`] -- the typed,
+/// template-parameterized kernel error surface. Engine failures arrive via the
+/// `Err(EngineError)` arm of `submit`'s input; the SM chooses whether to lift them into
+/// its own terminal result or propagate them as a [`DeltaError`].
+pub trait StateMachine {
+    /// What the SM returns when it finishes.
+    type Result;
+
+    /// Return the next step's work.
+    ///
+    /// Takes `&mut self` so the SM can lazily construct plans and move internal state.
+    ///
+    /// Returns `Err(DeltaError)` for unrecoverable kernel bugs hit while *building* the
+    /// next step (plan construction can fail on e.g. a malformed schema projection). These
+    /// are typically tagged [`DeltaErrorCode::DeltaCommandInvariantViolation`].
+    fn get_step(&mut self) -> Result<EngineRequest, DeltaError>;
+
+    /// Receive the step outcome from the driver.
+    ///
+    /// - `Ok(EngineResponse)` -- the executor ran the step and produced its single typed payload (a
+    ///   finished reducer handle, a schema, or [`EngineResponse::Empty`] for the driver-internal
+    ///   priming case). The SM body destructures the variant matching its preceding yield; any
+    ///   other variant is an executor bug surfaced as an internal error.
+    /// - `Err(EngineError)` -- a typed engine-side failure; the SM matches on [`EngineError::kind`]
+    ///   and decides how to surface it.
+    fn submit(
+        &mut self,
+        result: Result<EngineResponse, EngineError>,
+    ) -> Result<NextStep<Self::Result>, DeltaError>;
+
+    /// Static label for logging / diagnostics. Drivers use this in span names and error
+    /// contexts; implementations return the currently-active step name, or `"done"`
+    /// once the SM has finished.
+    fn step_name(&self) -> &'static str;
+
+    /// Sorted snapshot of logical relation names currently registered with the SM at the
+    /// boundary of the most recent yield.
+    ///
+    /// Surfaces diagnostics / span context, parallel scheduling info, and cross-phase
+    /// relation tracking. Returns the empty vector for SMs that do not surface relations,
+    /// and for terminal states (after the SM completes).
+    fn live_relations(&self) -> Vec<String> {
+        Vec::new()
+    }
+}

--- a/kernel/src/plans/state_machines/mod.rs
+++ b/kernel/src/plans/state_machines/mod.rs
@@ -1,8 +1,10 @@
 //! State machines -- kernel-authored coroutine bodies that orchestrate plan execution.
 //!
-//! - [`framework`] -- the framework SMs are built on. Successive PRs flesh out the `StateMachine`
-//!   trait, the `CoroutineSM` driver, the typed `Context`/`EngineResponse` surface, and the
-//!   `Extractor<O>` typed adapter; this PR seeds it with the typed engine-side failure type
-//!   ([`framework::engine_error::EngineError`]).
+//! - [`framework`] -- the framework SMs are built on. Currently provides the typed engine-side
+//!   failure type ([`framework::engine_error::EngineError`]), the
+//!   [`framework::state_machine::StateMachine`] trait that the executor drives, and the
+//!   [`framework::coroutine::CoroutineSM`] driver that compiles `async fn` SM bodies into that
+//!   trait. The `Context` plan-construction surface lives in a sibling submodule added under the
+//!   same `declarative-plans` feature gate.
 
 pub mod framework;

--- a/kernel/src/plans/state_machines/mod.rs
+++ b/kernel/src/plans/state_machines/mod.rs
@@ -1,0 +1,8 @@
+//! State machines -- kernel-authored coroutine bodies that orchestrate plan execution.
+//!
+//! - [`framework`] -- the framework SMs are built on. Successive PRs flesh out the `StateMachine`
+//!   trait, the `CoroutineSM` driver, the typed `Context`/`EngineResponse` surface, and the
+//!   `Extractor<O>` typed adapter; this PR seeds it with the typed engine-side failure type
+//!   ([`framework::engine_error::EngineError`]).
+
+pub mod framework;


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2643/files/0deb5e63fd987023701791fafa1a77973f78c334..3293e815d0e47c5677d0f78ce1c675a9883c712b) to review incremental changes.
- [stack/c8](https://github.com/delta-io/delta-kernel-rs/pull/2629) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2629/files)] [MERGED]
  - [stack/c1](https://github.com/delta-io/delta-kernel-rs/pull/2641) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2641/files)]
    - [stack/c3](https://github.com/delta-io/delta-kernel-rs/pull/2642) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2642/files/b15494a017628f925e9b16f64da0765896c6aed0..0deb5e63fd987023701791fafa1a77973f78c334)]
      - [**stack/c5**](https://github.com/delta-io/delta-kernel-rs/pull/2643) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2643/files/0deb5e63fd987023701791fafa1a77973f78c334..3293e815d0e47c5677d0f78ce1c675a9883c712b)]
        - [stack/c2](https://github.com/delta-io/delta-kernel-rs/pull/2644) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2644/files/eba0ab0291ec5f0fae1d076286d205da375c2f82..70458623c98684dd4286510aadbd393a9716b021)]
          - [stack/c6](https://github.com/delta-io/delta-kernel-rs/pull/2645) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2645/files/70458623c98684dd4286510aadbd393a9716b021..e19189d969cad8b0366575a53288aa6f05b1447f)]
            - [stack/c7](https://github.com/delta-io/delta-kernel-rs/pull/2646) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2646/files/e19189d969cad8b0366575a53288aa6f05b1447f..19fb518e8f9f88fe8563b840f6c08a320527a7e9)]

---------
## What changes are proposed in this pull request?

Wires together the runtime that drives every kernel state machine.

Adds:
- framework/state_machine.rs: StateMachine trait + NextStep<R> + EngineRequest (SchemaQuery, Reduce(ReduceSink)) + EngineResponse (Reducer(FinishedHandle), Schema, Empty) + SchemaQuery payload. The driver-protocol the executor and SM exchange every tick; request/response variants are strictly 1:1 paired (SchemaQuery is matched with Schema; Reduce with Reducer; Empty is a driver- internal priming sentinel SM bodies never observe).
- framework/coroutine.rs: CoroutineSM, an async-fn-backed StateMachine impl. Wraps genawaiter2::rc::Gen to translate the typed StepYield / StepResume protocol (both pub(crate)) into the StateMachine trait the executor drives.
- plans/ir/nodes.rs: the ReduceSink struct (initial_state + KernelReducerToken). Co-located with the IR but referenced as an engine-request attachment (not as an in-graph DAG node), so the basic IR stays free of `kernel_reducers` knowledge.

This sub-chain (errors -> reducers -> state_machine) depends on the basic-IR sub-chain via plans/ir; the chain is created day 1 but held back from publication until basic-IR lands in main, at which point git stack sync absorbs the IR types and git stack push publishes this branch.

Unit tests: a two-phase coroutine driven through SchemaQuery yields with EngineResponse::Schema replies (exercising the documented 1:1 pairing); an error-flow test where the engine submits an EngineError back; and a zero-yield coroutine confirming the synchronous-completion path. Reduce-step round-trips are exercised by Context::dispatch in the consuming sibling stack.

## How was this change tested?
