### PR TITLE
feat: add Context and PlanBuilder over the coroutine state machine

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,6 +186,10 @@ jobs:
         run: cargo clippy --locked --workspace --no-default-features --exclude delta_kernel --exclude delta_kernel_ffi --exclude delta_kernel_derive --exclude delta_kernel_ffi_macros -- -D warnings
       - name: lint without default features - packages which don't depend on kernel with features enabled
         run: cargo clippy --locked --no-default-features --package delta_kernel --package delta_kernel_ffi --package delta_kernel_derive --package delta_kernel_ffi_macros -- -D warnings
+      - name: check kernel declarative-plans feature-only build
+        run: cargo check --locked -p delta_kernel --no-default-features --features declarative-plans
+      - name: lint kernel declarative-plans feature-only build
+        run: cargo clippy --locked -p delta_kernel --no-default-features --features declarative-plans --tests -- -D warnings
       - name: check kernel builds with default-engine-native-tls
         run: cargo build --locked -p feature_tests --features default-engine-native-tls
       - name: test native-tls backend has no crypto provider conflict

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,9 @@ Some noteworthy ones (see `[features]` in `kernel/Cargo.toml` for the full list)
   cargo feature off, writes to tables listing this feature are blocked.
 - `internal-api` -- unstable APIs like `parallel_scan_metadata`. Items are marked with the
   `#[internal_api]` proc macro attribute.
-- `test-utils`, `integration-test` -- development only
+- `declarative-plans` -- experimental declarative-plan IR (`kernel/src/plans/`) and the prost
+  proto wire format mirroring it (`kernel/proto/`). Auto-enables `internal-api` and `arrow`.
+- `test-utils`, `integration-test` -- development only (`test-utils` enables `prettyprint`)
 
 ## Architecture at a Glance
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,7 +644,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -830,7 +830,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.117",
  "tempfile",
  "toml 0.9.12+spec-1.1.0",
 ]
@@ -984,7 +984,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1279,6 +1279,7 @@ dependencies = [
  "delta_kernel_derive",
  "dyn-clone",
  "futures",
+ "genawaiter2",
  "hdfs-native",
  "hdfs-native-object-store",
  "indexmap",
@@ -1375,7 +1376,7 @@ version = "0.24.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1412,7 +1413,7 @@ version = "0.24.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1459,7 +1460,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1715,7 +1716,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1762,7 +1763,7 @@ dependencies = [
  "g2poly",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1780,6 +1781,34 @@ name = "g2poly"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "312d2295c7302019c395cfb90dacd00a82a2eabd700429bba9c7a3f38dbbe11b"
+
+[[package]]
+name = "genawaiter2"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a954504d991886b6891c97b37ca1bf87ad2174c2126d52cdb52bebea7b1c89e3"
+dependencies = [
+ "genawaiter2-macro",
+ "genawaiter2-proc-macro",
+]
+
+[[package]]
+name = "genawaiter2-macro"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5cc2b187655aae60ff27f3978ffd192b9252c1a5905f53d3340e5836d8a539b"
+
+[[package]]
+name = "genawaiter2-proc-macro"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91467b1ef9d0b102db5ebf041238f26879f49ac323459e16725991ef73e61d2d"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "generic-array"
@@ -2352,7 +2381,7 @@ checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2832,7 +2861,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3090,7 +3119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3100,6 +3129,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "syn-mid",
+ "version_check",
 ]
 
 [[package]]
@@ -3147,7 +3202,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-types 0.13.5",
  "regex",
- "syn",
+ "syn 2.0.117",
  "tempfile",
 ]
 
@@ -3161,7 +3216,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3174,7 +3229,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3515,7 +3570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3715,7 +3770,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
  "unicode-ident",
 ]
 
@@ -3727,7 +3782,7 @@ checksum = "b3a8fb4672e840a587a66fc577a5491375df51ddb88f2a2c2a792598c326fe14"
 dependencies = [
  "quote",
  "rand 0.8.5",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3954,7 +4009,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4128,7 +4183,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4140,7 +4195,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4151,6 +4206,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -4158,6 +4224,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn-mid"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea305d57546cc8cd04feb14b62ec84bf17f50e3f7b12560d7bfa9265f39d9ed"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4177,7 +4254,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4258,7 +4335,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4269,7 +4346,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "test-case-core",
 ]
 
@@ -4291,7 +4368,7 @@ checksum = "be35209fd0781c5401458ab66e4f98accf63553e8fae7425503e92fdd319783b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4340,7 +4417,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4351,7 +4428,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4449,7 +4526,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4625,7 +4702,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4950,7 +5027,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -5098,7 +5175,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5109,7 +5186,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5423,7 +5500,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -5439,7 +5516,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -5533,7 +5610,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5560,7 +5637,7 @@ checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5580,7 +5657,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5620,7 +5697,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,6 +1277,7 @@ dependencies = [
  "criterion",
  "delta_kernel",
  "delta_kernel_derive",
+ "dyn-clone",
  "futures",
  "hdfs-native",
  "hdfs-native-object-store",
@@ -1478,6 +1479,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,6 +1288,9 @@ dependencies = [
  "parquet 58.1.0",
  "paste",
  "percent-encoding",
+ "prost 0.13.5",
+ "prost-build",
+ "protoc-bin-vendored",
  "rand 0.9.2",
  "reqwest 0.13.2",
  "roaring",
@@ -1579,6 +1582,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flatbuffers"
@@ -1902,8 +1911,8 @@ dependencies = [
  "md-5",
  "num-traits",
  "once_cell",
- "prost",
- "prost-types",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
  "rand 0.9.2",
  "regex",
  "roxmltree",
@@ -2620,6 +2629,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2949,6 +2964,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "phf"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3081,12 +3106,55 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.14.3",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "regex",
+ "syn",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3104,12 +3172,85 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost 0.13.5",
+]
+
+[[package]]
+name = "prost-types"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
- "prost",
+ "prost 0.14.3",
 ]
+
+[[package]]
+name = "protoc-bin-vendored"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c381df33c98266b5f08186583660090a4ffa0889e76c7e9a5e175f645a67fa"
+dependencies = [
+ "protoc-bin-vendored-linux-aarch_64",
+ "protoc-bin-vendored-linux-ppcle_64",
+ "protoc-bin-vendored-linux-s390_64",
+ "protoc-bin-vendored-linux-x86_32",
+ "protoc-bin-vendored-linux-x86_64",
+ "protoc-bin-vendored-macos-aarch_64",
+ "protoc-bin-vendored-macos-x86_64",
+ "protoc-bin-vendored-win32",
+]
+
+[[package]]
+name = "protoc-bin-vendored-linux-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c350df4d49b5b9e3ca79f7e646fde2377b199e13cfa87320308397e1f37e1a4c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-ppcle_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55a63e6c7244f19b5c6393f025017eb5d793fd5467823a099740a7a4222440c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-s390_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dba5565db4288e935d5330a07c264a4ee8e4a5b4a4e6f4e83fad824cc32f3b0"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8854774b24ee28b7868cd71dccaae8e02a2365e67a4a87a6cd11ee6cdbdf9cf5"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38b07546580df720fa464ce124c4b03630a6fb83e05c336fea2a241df7e5d78"
+
+[[package]]
+name = "protoc-bin-vendored-macos-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89278a9926ce312e51f1d999fee8825d324d603213344a9a706daa009f1d8092"
+
+[[package]]
+name = "protoc-bin-vendored-macos-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81745feda7ccfb9471d7a4de888f0652e806d5795b61480605d4943176299756"
+
+[[package]]
+name = "protoc-bin-vendored-win32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
 
 [[package]]
 name = "psm"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -52,6 +52,7 @@ serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 strum = { version = "0.27", features = ["derive"] }
 thiserror = "2"
+prost = { version = "0.13", optional = true }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = "0.3"
 url = "2"
@@ -114,9 +115,8 @@ arrow-expression = ["need-arrow"]
 # Schema diffing functionality (experimental)
 schema-diff = []
 
-# Declarative plan IR (experimental). The IR uses kernel-internal types hidden 
-# under `#[internal_api]` 
-declarative-plans = ["internal-api"]
+# Declarative plan IR + proto wire format (experimental).
+declarative-plans = ["internal-api", "dep:prost", "dep:prost-build", "dep:protoc-bin-vendored"]
 
 # Experimental, temporary, test-only feature flag guarding the in-progress column-defaults
 # work. TODO(#2630): remove once full column-defaults support ships.
@@ -134,6 +134,9 @@ default-engine-base = [
 
 [build-dependencies]
 rustc_version = "0.4.1"
+# Proto codegen, only pulled in / run under the `declarative-plans` feature.
+prost-build = { version = "0.13", optional = true }
+protoc-bin-vendored = { version = "3.2", optional = true }
 
 [dev-dependencies]
 delta_kernel = { path = ".", features = ["test-utils"] }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -53,6 +53,8 @@ serde_json = "1"
 strum = { version = "0.27", features = ["derive"] }
 thiserror = "2"
 prost = { version = "0.13", optional = true }
+# Object-safe `Clone` for the `KernelReducer` trait. Gated by `declarative-plans`.
+dyn-clone = { version = "1.0", optional = true }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = "0.3"
 url = "2"
@@ -116,7 +118,7 @@ arrow-expression = ["need-arrow"]
 schema-diff = []
 
 # Declarative plan IR + proto wire format (experimental).
-declarative-plans = ["internal-api", "dep:prost", "dep:prost-build", "dep:protoc-bin-vendored"]
+declarative-plans = ["internal-api", "dep:prost", "dep:prost-build", "dep:protoc-bin-vendored", "dep:dyn-clone"]
 
 # Experimental, temporary, test-only feature flag guarding the in-progress column-defaults
 # work. TODO(#2630): remove once full column-defaults support ships.

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -55,6 +55,14 @@ thiserror = "2"
 prost = { version = "0.13", optional = true }
 # Object-safe `Clone` for the `KernelReducer` trait. Gated by `declarative-plans`.
 dyn-clone = { version = "1.0", optional = true }
+# Stackless coroutines for the SM driver. Gated by `declarative-plans`.
+# default-features can't be disabled in 0.100.1 -- an unconditional
+# `pub use genawaiter2_proc_macro::stack_producer;` in genawaiter2's lib.rs
+# leaks the proc-macro crate as a hard dependency even when the `proc_macro`
+# feature is off (upstream bug). This drags in `proc-macro-error 0.4.12`
+# (unmaintained). Track for replacement when genawaiter2 patches the gate or
+# we switch to a different stackless-coroutine crate.
+genawaiter2 = { version = "0.100", optional = true }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = "0.3"
 url = "2"
@@ -118,7 +126,7 @@ arrow-expression = ["need-arrow"]
 schema-diff = []
 
 # Declarative plan IR + proto wire format (experimental).
-declarative-plans = ["internal-api", "dep:prost", "dep:prost-build", "dep:protoc-bin-vendored", "dep:dyn-clone"]
+declarative-plans = ["internal-api", "dep:prost", "dep:prost-build", "dep:protoc-bin-vendored", "dep:dyn-clone", "dep:genawaiter2"]
 
 # Experimental, temporary, test-only feature flag guarding the in-progress column-defaults
 # work. TODO(#2630): remove once full column-defaults support ships.

--- a/kernel/build.rs
+++ b/kernel/build.rs
@@ -6,4 +6,37 @@ fn main() {
     if let Channel::Nightly = version_meta().unwrap().channel {
         println!("cargo:rustc-cfg=NIGHTLY_CHANNEL");
     }
+
+    // Generate prost bindings for the declarative-plans proto schema only when the feature is
+    // enabled. Off-by-default consumers don't pay the protoc / codegen cost and don't pull in
+    // prost-build / protoc-bin-vendored.
+    #[cfg(feature = "declarative-plans")]
+    compile_proto_definitions();
+}
+
+#[cfg(feature = "declarative-plans")]
+fn compile_proto_definitions() {
+    let proto_dir = "proto";
+    let proto_files = ["schema.proto", "expressions.proto", "plan.proto"];
+
+    for file in &proto_files {
+        println!("cargo:rerun-if-changed={proto_dir}/{file}");
+    }
+
+    let files: Vec<String> = proto_files
+        .iter()
+        .map(|f| format!("{proto_dir}/{f}"))
+        .collect();
+
+    // Point prost-build at a vendored `protoc` so the build doesn't require a system install.
+    let protoc = protoc_bin_vendored::protoc_bin_path().expect("vendored protoc binary");
+    std::env::set_var("PROTOC", protoc);
+
+    // Don't propagate `.proto` comments into the generated code as doc comments: they contain
+    // angle-bracket generics (`Vec<...>`, `Option<...>`) that rustdoc would parse as unclosed
+    // HTML tags. The `.proto` files stay the canonical reference for the wire format.
+    prost_build::Config::new()
+        .disable_comments(["."])
+        .compile_protos(&files, &[proto_dir])
+        .expect("failed to compile .proto files");
 }

--- a/kernel/proto/expressions.proto
+++ b/kernel/proto/expressions.proto
@@ -1,0 +1,236 @@
+// Proto mirror of `kernel/src/expressions/mod.rs` + `scalars.rs` (the Rust IR is the source
+// of truth for these shapes).
+//
+// Opaque{Expression,Predicate} and Unknown are escape hatches: kernel-rs can't serialise the
+// opaque trait objects, and Unknown is the "do not silently interpret" marker. They appear
+// here so the grammar is total, but engines MUST error on them, not produce NULL.
+
+syntax = "proto3";
+
+package delta.kernel.expressions;
+
+import "schema.proto";
+
+// ============================================================================
+// Operator enums
+// ============================================================================
+
+enum UnaryPredicateOp {
+  UNARY_PREDICATE_OP_UNSPECIFIED = 0;
+  UNARY_PREDICATE_OP_IS_NULL = 1;
+}
+
+enum BinaryPredicateOp {
+  BINARY_PREDICATE_OP_UNSPECIFIED = 0;
+  BINARY_PREDICATE_OP_LESS_THAN = 1;
+  BINARY_PREDICATE_OP_GREATER_THAN = 2;
+  BINARY_PREDICATE_OP_EQUAL = 3;
+  BINARY_PREDICATE_OP_DISTINCT = 4;
+  BINARY_PREDICATE_OP_IN = 5;
+}
+
+enum UnaryExpressionOp {
+  UNARY_EXPRESSION_OP_UNSPECIFIED = 0;
+  UNARY_EXPRESSION_OP_TO_JSON = 1;
+}
+
+enum BinaryExpressionOp {
+  BINARY_EXPRESSION_OP_UNSPECIFIED = 0;
+  BINARY_EXPRESSION_OP_PLUS = 1;
+  BINARY_EXPRESSION_OP_MINUS = 2;
+  BINARY_EXPRESSION_OP_MULTIPLY = 3;
+  BINARY_EXPRESSION_OP_DIVIDE = 4;
+}
+
+enum VariadicExpressionOp {
+  VARIADIC_EXPRESSION_OP_UNSPECIFIED = 0;
+  VARIADIC_EXPRESSION_OP_COALESCE = 1;
+  VARIADIC_EXPRESSION_OP_ARRAY = 2;
+}
+
+enum JunctionPredicateOp {
+  JUNCTION_PREDICATE_OP_UNSPECIFIED = 0;
+  JUNCTION_PREDICATE_OP_AND = 1;
+  JUNCTION_PREDICATE_OP_OR = 2;
+}
+
+// ============================================================================
+// Scalar payloads
+// ============================================================================
+
+// `bits` is the unscaled integer, big-endian two's-complement; pair with `decimal_type` to
+// materialise a language-native decimal.
+message DecimalData {
+  bytes bits = 1;
+  delta.kernel.schema.DecimalType decimal_type = 2;
+}
+
+message ArrayData {
+  delta.kernel.schema.ArrayType array_type = 1;
+  repeated Scalar elements = 2;
+}
+
+// Modeled as repeated key/value pairs because proto map keys must be scalar, but Delta map
+// keys can be any `Scalar` (including structs).
+message MapEntry {
+  Scalar key = 1;
+  Scalar value = 2;
+}
+message MapData {
+  delta.kernel.schema.MapType map_type = 1;
+  repeated MapEntry pairs = 2;
+}
+
+// `fields` and `values` are pairwise indexed: `values[i]` is the value for `fields[i]`.
+message StructData {
+  repeated delta.kernel.schema.StructField fields = 1;
+  repeated Scalar values = 2;
+}
+
+// `Null` carries a `DataType` so the evaluator can produce a NULL of the right type.
+message Scalar {
+  oneof value {
+    int32 integer = 1;
+    int64 long = 2;
+    int32 short = 3;            // i16 narrowed at decode (proto has no i16)
+    int32 byte = 4;             // i8 narrowed at decode (proto has no i8)
+    float float = 5;
+    double double = 6;
+    string string = 7;
+    bool boolean = 8;
+    int64 timestamp = 9;        // micros since epoch, UTC
+    int64 timestamp_ntz = 10;   // micros since epoch, no tz
+    int32 date = 11;            // days since epoch
+    bytes binary = 12;
+    DecimalData decimal = 13;
+    delta.kernel.schema.DataType null = 14;
+    StructData struct = 15;
+    ArrayData array = 16;
+    MapData map = 17;
+  }
+}
+
+message ColumnName {
+  repeated string path = 1;
+}
+
+// ============================================================================
+// Composite expression bodies
+// ============================================================================
+
+message UnaryExpression {
+  UnaryExpressionOp op = 1;
+  Expression expr = 2;
+}
+
+message BinaryExpression {
+  BinaryExpressionOp op = 1;
+  Expression left = 2;
+  Expression right = 3;
+}
+
+message VariadicExpression {
+  VariadicExpressionOp op = 1;
+  repeated Expression exprs = 2;
+}
+
+message IfExpression {
+  Predicate condition = 1;
+  Expression then_expr = 2;
+  Expression else_expr = 3;
+}
+
+message ParseJsonExpression {
+  Expression json_expr = 1;
+  delta.kernel.schema.StructType output_schema = 2;
+}
+
+message MapToStructExpression {
+  Expression map_expr = 1;
+}
+
+// `nullability_predicate` is optional: when set and it evaluates to false/null, the whole
+// struct is null.
+message StructExpression {
+  repeated Expression exprs = 1;
+  Expression nullability_predicate = 2;
+}
+
+message FieldTransform {
+  repeated Expression exprs = 1;
+  bool is_replace = 2;
+  bool optional = 3;
+}
+
+message Transform {
+  // `input_path` is optional: absent means a top-level transform (no input path).
+  ColumnName input_path = 1;
+  map<string, FieldTransform> field_transforms = 2;
+  repeated Expression prepended_fields = 3;
+}
+
+// The opaque op carries only its `name()` because the Rust trait object can't be serialised;
+// engines resolve `name` against a local op registry or hard-error (never NULL).
+message OpaqueExpression {
+  string name = 1;
+  repeated Expression exprs = 2;
+}
+
+message OpaquePredicate {
+  string name = 1;
+  repeated Expression exprs = 2;
+}
+
+// ============================================================================
+// Predicate
+// ============================================================================
+
+message UnaryPredicate {
+  UnaryPredicateOp op = 1;
+  Expression expr = 2;
+}
+
+message BinaryPredicate {
+  BinaryPredicateOp op = 1;
+  Expression left = 2;
+  Expression right = 3;
+}
+
+message JunctionPredicate {
+  JunctionPredicateOp op = 1;
+  repeated Predicate preds = 2;
+}
+
+message Predicate {
+  oneof kind {
+    Expression boolean_expression = 1;
+    Predicate not = 2;
+    UnaryPredicate unary = 3;
+    BinaryPredicate binary = 4;
+    JunctionPredicate junction = 5;
+    OpaquePredicate opaque = 6;
+    string unknown = 7;
+  }
+}
+
+// ============================================================================
+// Expression
+// ============================================================================
+
+message Expression {
+  oneof kind {
+    Scalar literal = 1;
+    ColumnName column = 2;
+    Predicate predicate = 3;
+    StructExpression struct_expr = 4;
+    Transform transform = 5;
+    UnaryExpression unary = 6;
+    BinaryExpression binary = 7;
+    VariadicExpression variadic = 8;
+    IfExpression if_expr = 9;
+    OpaqueExpression opaque = 10;
+    ParseJsonExpression parse_json = 11;
+    MapToStructExpression map_to_struct = 12;
+    string unknown = 13;
+  }
+}

--- a/kernel/proto/plan.proto
+++ b/kernel/proto/plan.proto
@@ -1,0 +1,140 @@
+// Proto mirror of `kernel/src/plans/ir/{plan,nodes}.rs` (the Rust IR is the source of truth).
+//
+// A plan is a DAG of plan nodes: `Plan` is a flat list of `PlanNode`s, and each node wires
+// into the DAG by referencing other nodes' `output` RefIds in its `inputs`. RefIds are opaque
+// keys. Field numbers are never reused once published, so the wire stays compatible.
+
+syntax = "proto3";
+
+package delta.kernel.plan;
+
+import "expressions.proto";
+import "schema.proto";
+
+message RefId {
+  uint32 id = 1;
+}
+
+message FileMeta {
+  string location = 1;
+  uint64 size = 2;
+  optional int64 last_modified = 3;  // milliseconds since epoch
+}
+
+// ============================================================================
+// Source payloads (0 inputs)
+// ============================================================================
+
+// One file to scan plus the per-file literal values broadcast to every row read from it
+// (one per entry in the parent scan node's `file_constant_columns`, same order).
+message ScanFile {
+  FileMeta meta = 1;
+  repeated delta.kernel.expressions.Scalar file_constants = 2;
+}
+
+message ScanParquetNode {
+  repeated ScanFile files = 1;
+  repeated delta.kernel.expressions.ColumnName file_constant_columns = 2;
+  delta.kernel.schema.StructType schema = 3;
+}
+
+message ScanJsonNode {
+  repeated ScanFile files = 1;
+  repeated delta.kernel.expressions.ColumnName file_constant_columns = 2;
+  delta.kernel.schema.StructType schema = 3;
+}
+
+message ValuesRow {
+  repeated delta.kernel.expressions.Scalar values = 1;
+}
+message ValuesNode {
+  delta.kernel.schema.StructType schema = 1;
+  repeated ValuesRow rows = 2;
+}
+
+// ============================================================================
+// Transform payloads (1+ inputs)
+// ============================================================================
+
+message ProjectNode {
+  repeated delta.kernel.expressions.Expression exprs = 1;
+  delta.kernel.schema.StructType schema = 2;
+}
+
+message FilterNode {
+  delta.kernel.expressions.Predicate predicate = 1;
+}
+
+message UnionAllNode {}
+
+message LoadColumnFileMeta {
+  delta.kernel.expressions.ColumnName path_column = 1;
+  delta.kernel.expressions.ColumnName file_size_column = 2;
+  delta.kernel.expressions.ColumnName num_records_column = 3;
+}
+
+enum FileType {
+  FILE_TYPE_UNSPECIFIED = 0;
+  FILE_TYPE_PARQUET = 1;
+  FILE_TYPE_JSON = 2;
+}
+
+message LoadNode {
+  delta.kernel.schema.StructType schema = 1;
+  FileType file_type = 2;
+  optional string base_url = 3;
+  repeated delta.kernel.expressions.ColumnName file_constant_columns = 4;
+  LoadColumnFileMeta file_meta = 5;
+  // `dv_column` is optional: set when the load applies a deletion vector (the named column
+  // holds a DeletionVectorDescriptor).
+  delta.kernel.expressions.ColumnName dv_column = 6;
+}
+
+message MaxByVersionNode {
+  repeated delta.kernel.expressions.Expression group_by = 1;
+  delta.kernel.expressions.ColumnName version_column = 2;
+  delta.kernel.schema.StructType schema = 3;
+}
+
+// Semi join (`inverted = false`) or anti join (`inverted = true`) of `[probe, build]`. The
+// build side filters but never contributes columns; the output schema is the probe schema.
+message SemiJoinNode {
+  bool inverted = 1;
+  repeated delta.kernel.expressions.ColumnName probe_keys = 2;
+  repeated delta.kernel.expressions.ColumnName build_keys = 3;
+}
+
+// ============================================================================
+// NodeKind
+// ============================================================================
+
+message NodeKind {
+  oneof kind {
+    // Sources (0 inputs)
+    ScanParquetNode scan_parquet = 1;
+    ScanJsonNode scan_json = 2;
+    ValuesNode values = 3;
+    // Transforms (1+ inputs)
+    ProjectNode project = 4;
+    FilterNode filter = 5;
+    UnionAllNode union_all = 6;
+    LoadNode load = 7;
+    MaxByVersionNode max_by_version = 8;
+    SemiJoinNode semi_join = 9;
+  }
+}
+
+// ============================================================================
+// PlanNode / Plan
+// ============================================================================
+
+message PlanNode {
+  NodeKind kind = 1;
+  repeated RefId inputs = 2;
+  RefId output = 3;
+}
+
+// The plan's terminal node is its last entry; the engine streams that node's rows.
+message Plan {
+  repeated PlanNode nodes = 1;
+}

--- a/kernel/proto/schema.proto
+++ b/kernel/proto/schema.proto
@@ -1,0 +1,103 @@
+// Proto mirror of `kernel/src/schema/mod.rs` (the Rust types are the source of truth).
+//
+// One intentional divergence from the Rust shape: `DataType::Variant(Box<StructType>)` is a
+// payloadless `variant` marker -- the inner struct is the canonical, known shape, so it is not
+// sent.
+//
+// Field numbers are never reused once published, so the wire format stays compatible.
+
+syntax = "proto3";
+
+package delta.kernel.schema;
+
+// ============================================================================
+// Primitive types
+// ============================================================================
+
+// Decimal is excluded: it carries precision/scale, so it is its own `decimal` case on
+// `PrimitiveType` rather than a valueless enum entry.
+enum SimplePrimitiveType {
+  SIMPLE_PRIMITIVE_TYPE_UNSPECIFIED = 0;
+  SIMPLE_PRIMITIVE_TYPE_STRING = 1;
+  SIMPLE_PRIMITIVE_TYPE_LONG = 2;
+  SIMPLE_PRIMITIVE_TYPE_INTEGER = 3;
+  SIMPLE_PRIMITIVE_TYPE_SHORT = 4;
+  SIMPLE_PRIMITIVE_TYPE_BYTE = 5;
+  SIMPLE_PRIMITIVE_TYPE_FLOAT = 6;
+  SIMPLE_PRIMITIVE_TYPE_DOUBLE = 7;
+  SIMPLE_PRIMITIVE_TYPE_BOOLEAN = 8;
+  SIMPLE_PRIMITIVE_TYPE_BINARY = 9;
+  SIMPLE_PRIMITIVE_TYPE_DATE = 10;
+  SIMPLE_PRIMITIVE_TYPE_TIMESTAMP = 11;
+  SIMPLE_PRIMITIVE_TYPE_TIMESTAMP_NTZ = 12;
+}
+
+// Rust uses `u8` (precision in [1,38], scale in [0,precision]); widened to uint32 because
+// proto has no smaller integer type, so consumers must validate the range.
+message DecimalType {
+  uint32 precision = 1;
+  uint32 scale = 2;
+}
+
+// Mirror of Rust's `PrimitiveType`. `simple` is an enum (not individual oneof cases) because
+// proto oneof cases each need a payload, which the valueless primitives don't have.
+message PrimitiveType {
+  oneof kind {
+    SimplePrimitiveType simple = 1;
+    DecimalType decimal = 2;
+  }
+}
+
+// ============================================================================
+// Composite types
+// ============================================================================
+
+message ArrayType {
+  DataType element_type = 1;
+  bool contains_null = 2;
+}
+
+message MapType {
+  DataType key_type = 1;
+  DataType value_type = 2;
+  bool value_contains_null = 3;
+}
+
+message StructType {
+  repeated StructField fields = 1;
+}
+
+// Payloadless: the variant's inner struct is the canonical, known shape, so it is not sent.
+message VariantType {}
+
+// `other_json` holds `MetadataValue::Other` as a serialized JSON string so engines without a
+// native JSON value type can still round-trip it.
+message MetadataValue {
+  oneof value {
+    int64 number = 1;
+    string string = 2;
+    bool boolean = 3;
+    string other_json = 4;
+  }
+}
+
+message StructField {
+  string name = 1;
+  DataType data_type = 2;
+  bool nullable = 3;
+  map<string, MetadataValue> metadata = 4;
+}
+
+// ============================================================================
+// DataType
+// ============================================================================
+
+message DataType {
+  oneof kind {
+    PrimitiveType primitive = 1;
+    ArrayType array = 2;
+    StructType struct = 3;
+    MapType map = 4;
+    VariantType variant = 5;
+  }
+}

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -635,6 +635,7 @@ impl Protocol {
 
     /// Create a new Protocol by visiting the EngineData and extracting the first protocol row into
     /// a Protocol instance. If no protocol row is found, returns Ok(None).
+    #[internal_api]
     pub(crate) fn try_new_from_data(data: &dyn EngineData) -> DeltaResult<Option<Protocol>> {
         let mut visitor = ProtocolVisitor::default();
         visitor.visit_rows_of(data)?;
@@ -947,7 +948,7 @@ impl SetTransaction {
 /// file actions. This action is only allowed in checkpoints following the V2 spec.
 ///
 /// [More info]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#sidecar-file-information
-#[derive(ToSchema, Debug, PartialEq)]
+#[derive(ToSchema, Debug, Clone, PartialEq)]
 #[internal_api]
 pub(crate) struct Sidecar {
     /// A path to a sidecar file that can be either:

--- a/kernel/src/actions/visitors.rs
+++ b/kernel/src/actions/visitors.rs
@@ -377,7 +377,7 @@ impl RowVisitor for SetTransactionVisitor {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug, Clone)]
 #[internal_api]
 pub(crate) struct SidecarVisitor {
     pub(crate) sidecars: Vec<Sidecar>,

--- a/kernel/src/engine/mod.rs
+++ b/kernel/src/engine/mod.rs
@@ -43,7 +43,7 @@ pub(crate) mod arrow_utils;
 #[cfg(all(feature = "internal-api", feature = "arrow-expression"))]
 pub use self::arrow_utils::{parse_json, to_json_bytes};
 
-#[cfg(feature = "declarative-plans")]
+#[cfg(all(feature = "default-engine-base", feature = "declarative-plans"))]
 pub mod plans;
 
 #[cfg(test)]

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -102,6 +102,7 @@ mod log_path;
 mod log_reader;
 pub mod metrics;
 pub mod partition;
+/// Declarative plan IR and proto wire format. Opt-in behind `declarative-plans`.
 #[cfg(feature = "declarative-plans")]
 pub mod plans;
 pub mod scan;

--- a/kernel/src/plans/errors/mod.rs
+++ b/kernel/src/plans/errors/mod.rs
@@ -1,0 +1,337 @@
+//! Typed error surface for the declarative plans layer.
+//!
+//! [`DeltaError`] is the error type used by state machines and the plan executor. It coexists
+//! with [`Error`]; lifting an [`Error`] into a [`DeltaError`] goes through the named bridge
+//! [`KernelErrAsDelta`] -- deliberately no `From<Error>` impl, so the conversion sites are
+//! grep-able. (A `From<BoxedSource>` does exist for the catch-all `dyn Error + Send + Sync`
+//! shape used by Delta-agnostic helpers; that path tags every lifted error with
+//! [`DeltaErrorCode::DeltaCommandInvariantViolation`].)
+//!
+//! # Construction
+//!
+//! Every error is built through a named constructor on [`DeltaError`], one per
+//! [`DeltaErrorCode`]. The human message is fixed per code ([`DeltaErrorCode::message`]); the
+//! constructor takes only the runtime detail / underlying cause, which becomes the error's
+//! [`source`](DeltaError::source). The detail is `impl Into<BoxedSource>`, so it accepts a bare
+//! string (auto-wrapped as a trivial error) or any real error (kept with its type and chain).
+//!
+//! [`DeltaResultExt::or_delta`] does the same at a `?` site: it attaches a code and keeps the
+//! original error as the source.
+//!
+//! ```ignore
+//! use delta_kernel::plans::errors::{DeltaError, DeltaErrorCode, DeltaResultExt};
+//!
+//! return Err(DeltaError::table_not_found(format!("{name}")));
+//! let v: u64 = "42".parse().or_delta(DeltaErrorCode::DeltaVersionInvalid)?;
+//! let e = DeltaError::file_not_found(io_err);
+//! ```
+
+use std::backtrace::Backtrace;
+
+use crate::Error;
+
+// ============================================================================
+// DeltaErrorCode -- macro-driven declaration
+// ============================================================================
+
+/// Declarative table of Delta error codes. Each row binds a variant to its FFI-stable
+/// discriminant, SCREAMING_SNAKE name, SQLSTATE, and a static human message.
+///
+/// The message is fixed per code; runtime detail (the offending path, version, cause, ...) is
+/// never formatted into it -- it lives in [`DeltaError::source`].
+///
+/// Discriminants are explicit because the enum is `#[repr(u32)]` for FFI ABI stability.
+/// Reassigning or reusing a discriminant is a breaking change; pick the next unused integer.
+macro_rules! delta_codes {
+    (
+        $(
+            $( #[$meta:meta] )*
+            $variant:ident = $disc:literal,
+            $name:literal,
+            $sqlstate:literal,
+            $message:literal
+        ),+
+        $(,)?
+    ) => {
+        /// Typed identifier for a Delta error.
+        ///
+        /// `#[repr(u32)]` pins the integer layout for FFI; `#[non_exhaustive]` reserves space
+        /// for additional codes -- downstream consumers must treat unknown integers as opaque.
+        #[repr(u32)]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[non_exhaustive]
+        pub enum DeltaErrorCode {
+            $( $( #[$meta] )* $variant = $disc ),+
+        }
+
+        impl DeltaErrorCode {
+            /// SCREAMING_SNAKE name for this error code.
+            pub fn name(&self) -> &'static str {
+                match self { $( Self::$variant => $name ),+ }
+            }
+
+            /// 5-character SQLSTATE classifying the error (SQL-standard class + subclass).
+            pub fn sqlstate(&self) -> &'static str {
+                match self { $( Self::$variant => $sqlstate ),+ }
+            }
+
+            /// Static human-readable message for this code. Carries no runtime detail.
+            pub fn message(&self) -> &'static str {
+                match self { $( Self::$variant => $message ),+ }
+            }
+        }
+    };
+}
+
+delta_codes! {
+    /// `DELTA_COMMAND_INVARIANT_VIOLATION` -- internal-error catch-all for SMs detecting an
+    /// impossible state. Discriminant `0` is deliberate: a zero-initialized wire value decodes
+    /// to "invariant violation" so engines that fail to populate the code slot still surface
+    /// a meaningful error.
+    DeltaCommandInvariantViolation = 0, "DELTA_COMMAND_INVARIANT_VIOLATION", "XXKDS",
+        "internal invariant violated",
+    /// Delta table does not exist.
+    DeltaTableNotFound = 1, "DELTA_TABLE_NOT_FOUND", "42P01", "Delta table not found",
+    /// Path is not a Delta table.
+    DeltaMissingDeltaTable = 2, "DELTA_MISSING_DELTA_TABLE", "42P01", "not a Delta table",
+    /// Path doesn't exist, or is not a Delta table.
+    DeltaPathDoesNotExist = 3, "DELTA_PATH_DOES_NOT_EXIST", "42K03", "path does not exist",
+    /// Requested version is outside the available range.
+    DeltaVersionNotFound = 4, "DELTA_VERSION_NOT_FOUND", "22003", "version not found",
+    /// A provided version string / number is not parseable.
+    DeltaVersionInvalid = 5, "DELTA_VERSION_INVALID", "42815", "invalid version",
+    /// A commit file needed to reconstruct state is missing.
+    DeltaLogFileNotFound = 6, "DELTA_LOG_FILE_NOT_FOUND", "42K03", "commit log file not found",
+    /// A data file referenced by the log is missing.
+    DeltaFileNotFound = 7, "DELTA_FILE_NOT_FOUND", "42K03", "file not found",
+    /// A multipart checkpoint is missing shards.
+    DeltaMissingPartFiles = 8, "DELTA_MISSING_PART_FILES", "42KD6", "checkpoint is missing part files",
+    /// Protocol / metadata could not be reconstructed.
+    DeltaStateRecoverError = 9, "DELTA_STATE_RECOVER_ERROR", "XXKDS",
+        "failed to reconstruct table state",
+    /// The table requires a protocol the kernel doesn't support.
+    DeltaInvalidProtocolVersion = 10, "DELTA_INVALID_PROTOCOL_VERSION", "KD004",
+        "unsupported protocol version",
+    /// A commit raced with another transaction.
+    DeltaConcurrentWrite = 11, "DELTA_CONCURRENT_WRITE", "2D521",
+        "commit failed due to a concurrent write",
+    /// Attempt to create a Delta log that already exists.
+    DeltaLogAlreadyExists = 12, "DELTA_LOG_ALREADY_EXISTS", "42K04", "Delta log already exists",
+}
+
+// ============================================================================
+// DeltaError
+// ============================================================================
+
+/// Boxed, sendable source error held by [`DeltaError::source`].
+pub type BoxedSource = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// Typed Delta error.
+///
+/// The human message is static per [`DeltaErrorCode`] ([`DeltaErrorCode::message`]); all runtime
+/// detail (the offending path, version, underlying cause) lives in [`source`](Self::source).
+/// `Display` emits `[<CODE_NAME>] <static message>`, and `source` is forwarded via
+/// `std::error::Error::source()` so standard ecosystem walkers see the detail.
+#[derive(Debug, thiserror::Error)]
+#[error("[{}] {}", self.code.name(), self.code.message())]
+pub struct DeltaError {
+    /// Stable typed identifier; also determines the human message.
+    pub code: DeltaErrorCode,
+    /// Runtime detail / underlying cause, forwarded via `std::error::Error::source()`. A bare
+    /// `String`/`&str` is accepted and wrapped as a trivial error (stdlib `From`).
+    #[source]
+    pub source: Option<BoxedSource>,
+    /// `Some(Backtrace::capture())` -- a no-op without `RUST_BACKTRACE=1`, so the "always on"
+    /// default is free in production.
+    pub backtrace: Option<Backtrace>,
+}
+
+impl DeltaError {
+    /// Crate-internal primitive: build an error from a code and its runtime detail / cause. The
+    /// per-code constructors below and [`DeltaResultExt::or_delta`] funnel through here.
+    pub(crate) fn new(code: DeltaErrorCode, source: impl Into<BoxedSource>) -> Self {
+        Self {
+            code,
+            source: Some(source.into()),
+            backtrace: Some(Backtrace::capture()),
+        }
+    }
+
+    // === Per-code constructors ==========================================================
+    //
+    // Each takes the runtime detail as `impl Into<BoxedSource>`: a bare string (auto-wrapped)
+    // or any underlying error (kept with its type and source chain). The human message is the
+    // code's static one.
+
+    /// `DELTA_COMMAND_INVARIANT_VIOLATION` -- an internal "this should never happen" failure.
+    pub fn invariant(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaCommandInvariantViolation, detail)
+    }
+
+    /// `DELTA_TABLE_NOT_FOUND` -- the Delta table does not exist.
+    pub fn table_not_found(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaTableNotFound, detail)
+    }
+
+    /// `DELTA_MISSING_DELTA_TABLE` -- the path is not a Delta table.
+    pub fn missing_delta_table(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaMissingDeltaTable, detail)
+    }
+
+    /// `DELTA_PATH_DOES_NOT_EXIST` -- the path does not exist.
+    pub fn path_does_not_exist(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaPathDoesNotExist, detail)
+    }
+
+    /// `DELTA_VERSION_NOT_FOUND` -- the requested version is outside the available range.
+    pub fn version_not_found(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaVersionNotFound, detail)
+    }
+
+    /// `DELTA_VERSION_INVALID` -- a version string/number is not parseable.
+    pub fn version_invalid(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaVersionInvalid, detail)
+    }
+
+    /// `DELTA_LOG_FILE_NOT_FOUND` -- a commit file needed to reconstruct state is missing.
+    pub fn log_file_not_found(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaLogFileNotFound, detail)
+    }
+
+    /// `DELTA_FILE_NOT_FOUND` -- a data file referenced by the log is missing.
+    pub fn file_not_found(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaFileNotFound, detail)
+    }
+
+    /// `DELTA_MISSING_PART_FILES` -- a multipart checkpoint is missing shards.
+    pub fn missing_part_files(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaMissingPartFiles, detail)
+    }
+
+    /// `DELTA_STATE_RECOVER_ERROR` -- protocol/metadata could not be reconstructed.
+    pub fn state_recover_error(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaStateRecoverError, detail)
+    }
+
+    /// `DELTA_INVALID_PROTOCOL_VERSION` -- the table requires an unsupported protocol.
+    pub fn invalid_protocol_version(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaInvalidProtocolVersion, detail)
+    }
+
+    /// `DELTA_CONCURRENT_WRITE` -- a commit raced with another transaction.
+    pub fn concurrent_write(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaConcurrentWrite, detail)
+    }
+
+    /// `DELTA_LOG_ALREADY_EXISTS` -- attempt to create a Delta log that already exists.
+    pub fn log_already_exists(detail: impl Into<BoxedSource>) -> Self {
+        Self::new(DeltaErrorCode::DeltaLogAlreadyExists, detail)
+    }
+}
+
+/// Auto-convert a [`BoxedSource`] (the boxed `dyn Error` shape used by Delta-agnostic helpers
+/// like `schema_expr` and `plan_context`) into a [`DeltaError`] tagged with the catch-all
+/// [`DeltaErrorCode::DeltaCommandInvariantViolation`]. Lets `?` propagate these errors into
+/// `Result<_, DeltaError>` functions without an explicit `.or_delta(...)` wrap.
+///
+/// Use [`DeltaResultExt::or_delta`] when a more specific code is appropriate -- this impl is
+/// intentionally the catch-all path.
+impl From<BoxedSource> for DeltaError {
+    fn from(source: BoxedSource) -> Self {
+        Self::new(DeltaErrorCode::DeltaCommandInvariantViolation, source)
+    }
+}
+
+// ============================================================================
+// Bridges -- kernel::Error <-> DeltaError
+// ============================================================================
+
+/// Lift an [`Error`] into a [`DeltaError`] tagged with
+/// [`DeltaErrorCode::DeltaCommandInvariantViolation`]. Use when a more specific code is not
+/// known; upgrading to a specific constructor (e.g. `DeltaError::file_not_found(path)`) is a
+/// drop-in refactor.
+pub trait KernelErrAsDelta {
+    fn into_delta_internal(self) -> DeltaError;
+}
+
+impl KernelErrAsDelta for Error {
+    fn into_delta_internal(self) -> DeltaError {
+        DeltaError::invariant(self)
+    }
+}
+
+// ============================================================================
+// or_delta at ? sites
+// ============================================================================
+
+/// Attach a [`DeltaErrorCode`] to any `Result<T, E>` whose error can be lifted into a
+/// [`BoxedSource`]. The original error is preserved as [`DeltaError::source`] (walkable via
+/// `std::error::Error::source()`); the message comes from the code.
+///
+/// The bound `E: Into<BoxedSource>` covers two cases without an extra `Box` layer:
+/// - any concrete `E: Error + Send + Sync + 'static` (stdlib's blanket `From` impl), and
+/// - errors that are already a [`BoxedSource`] (low-level modules that return a `Box<dyn Error +
+///   Send + Sync + 'static>` directly to stay Delta-agnostic).
+pub trait DeltaResultExt<T> {
+    fn or_delta(self, code: DeltaErrorCode) -> Result<T, DeltaError>;
+}
+
+impl<T, E> DeltaResultExt<T> for Result<T, E>
+where
+    E: Into<BoxedSource>,
+{
+    fn or_delta(self, code: DeltaErrorCode) -> Result<T, DeltaError> {
+        self.map_err(|e| DeltaError::new(code, e))
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error;
+
+    use super::*;
+
+    #[test]
+    fn display_is_code_name_plus_static_message() {
+        let err = DeltaError::table_not_found("my_table");
+        assert_eq!(err.code, DeltaErrorCode::DeltaTableNotFound);
+        let s = err.to_string();
+        assert!(s.contains("DELTA_TABLE_NOT_FOUND"), "got: {s}");
+        assert!(s.contains("Delta table not found"), "got: {s}");
+    }
+
+    #[test]
+    fn string_detail_becomes_source() {
+        let err = DeltaError::invariant("snapshot.rebuild: protocol missing");
+        assert_eq!(err.code, DeltaErrorCode::DeltaCommandInvariantViolation);
+        assert_eq!(err.code.message(), "internal invariant violated");
+        let src = err.source().expect("string detail preserved as source");
+        assert_eq!(src.to_string(), "snapshot.rebuild: protocol missing");
+    }
+
+    #[test]
+    fn error_detail_keeps_its_type_in_source() {
+        let io = std::io::Error::other("boom");
+        let err = DeltaError::file_not_found(io);
+        assert_eq!(err.code, DeltaErrorCode::DeltaFileNotFound);
+        let src = err.source().expect("source");
+        assert!(src.is::<std::io::Error>());
+        assert!(src.to_string().contains("boom"));
+    }
+
+    #[test]
+    fn or_delta_preserves_original_error_in_source() {
+        fn parse_version(s: &str) -> Result<u64, DeltaError> {
+            s.parse::<u64>()
+                .or_delta(DeltaErrorCode::DeltaVersionInvalid)
+        }
+        let err = parse_version("not-a-number").unwrap_err();
+        assert_eq!(err.code, DeltaErrorCode::DeltaVersionInvalid);
+        let src = err.source().expect("parse error preserved");
+        assert!(src.is::<std::num::ParseIntError>());
+    }
+}

--- a/kernel/src/plans/ir/nodes.rs
+++ b/kernel/src/plans/ir/nodes.rs
@@ -7,6 +7,7 @@ use strum::Display;
 use url::Url;
 
 use crate::expressions::{ColumnName, ExpressionRef, PredicateRef, Scalar};
+use crate::plans::kernel_reducers::{KernelReducer, KernelReducerToken, ReducerHandle};
 use crate::schema::SchemaRef;
 use crate::FileMeta;
 
@@ -536,3 +537,50 @@ pub struct SemiJoin {
 /// ```
 #[derive(Debug, Clone)]
 pub struct UnionAll;
+
+// ============================================================================
+// Reducer-drain sink (referenced by `EngineRequest::Reduce`)
+// ============================================================================
+
+/// Template for draining a row stream into a [`KernelReducer`] via [`EngineRequest::Reduce`].
+///
+/// - `initial_state`: cloned per partition via [`DynClone`](dyn_clone::DynClone) into a
+///   [`ReducerHandle`].
+/// - `token`: keys the finished handle returned from the executor and validated at decode time by
+///   the paired [`Extractor`].
+///
+/// [`EngineRequest::Reduce`]: crate::plans::state_machines::framework::state_machine::EngineRequest::Reduce
+/// [`Extractor`]: crate::plans::kernel_reducers::Extractor
+#[derive(Debug, Clone)]
+pub struct ReduceSink {
+    pub initial_state: Box<dyn KernelReducer>,
+    pub token: KernelReducerToken,
+}
+
+impl ReduceSink {
+    /// Construct from a concrete reducer and mint a fresh token from its `kind`.
+    pub fn new<R: KernelReducer + 'static>(state: R) -> Self {
+        let token = KernelReducerToken::new(state.kind());
+        Self {
+            initial_state: Box::new(state),
+            token,
+        }
+    }
+
+    /// Mint a runtime [`ReducerHandle`] for this sink template by cloning the initial state.
+    pub fn new_handle(&self) -> ReducerHandle {
+        ReducerHandle::new(self.token.clone(), self.initial_state.clone())
+    }
+}
+
+// Token identity drives equality: tokens are process-unique by id, and the
+// `initial_state` trait object (`Box<dyn KernelReducer>`) is not `Eq`-able. Two
+// sinks sharing a token were constructed from the same plan node and therefore
+// describe the same reducer.
+impl PartialEq for ReduceSink {
+    fn eq(&self, other: &Self) -> bool {
+        self.token == other.token
+    }
+}
+
+impl Eq for ReduceSink {}

--- a/kernel/src/plans/kernel_reducers/checkpoint_hint.rs
+++ b/kernel/src/plans/kernel_reducers/checkpoint_hint.rs
@@ -35,7 +35,7 @@ pub struct CheckpointHintRecord {
     /// Total logical size of the checkpoint (bytes), if known.
     pub size: Option<i64>,
     /// Number of parts for multipart checkpoints, if any. Stored as `i64` to keep the
-    /// JSON deserialization aligned with [`LastCheckpointHint::parts`] (`Option<usize>`)
+    /// JSON deserialization aligned with `LastCheckpointHint::parts` (`Option<usize>`)
     /// on 64-bit targets.
     pub parts: Option<i64>,
     /// Total on-disk size of the checkpoint (bytes), if known.

--- a/kernel/src/plans/kernel_reducers/checkpoint_hint.rs
+++ b/kernel/src/plans/kernel_reducers/checkpoint_hint.rs
@@ -1,0 +1,171 @@
+//! `CheckpointHintReader` -- reducer KDF that reads a `_last_checkpoint`
+//! JSON scan and extracts the hint record.
+//!
+//! The file contains a single row. The reader captures it on the first
+//! batch, returns [`KdfControl::Break`] to stop further input, and reduces
+//! to `Option<CheckpointHintRecord>` -- `None` when the file was absent (zero
+//! rows), `Some` when the hint was extracted.
+
+use std::sync::LazyLock;
+
+use delta_kernel_derive::ToSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::engine_data::{GetData, RowVisitor, TypedGetData as _};
+use crate::plans::errors::DeltaError;
+use crate::plans::kernel_reducers::{
+    KdfControl, KernelReducer, KernelReducerKind, KernelReducerOutput,
+};
+use crate::schema::{ColumnName, ColumnNamesAndTypes, DataType, ToSchema};
+use crate::{DeltaResult, EngineData};
+
+/// `_last_checkpoint` JSON hint file record. Parsed by [`CheckpointHintReader`] from
+/// the single-row hint file; deriving [`ToSchema`] lets the reader source the row
+/// visitor's column schema from the struct definition.
+///
+/// Intentionally a subset of [`crate::last_checkpoint_hint::LastCheckpointHint`]: only
+/// the fields the plans layer currently consumes (`version`, `size`, `parts`,
+/// `sizeInBytes`, `numOfAddFiles`) are projected. `checkpointSchema`, `checksum`, and
+/// `tags` are omitted; if the plans layer ever needs them (e.g. for footer skipping based
+/// on the checkpoint schema), extend this record rather than reading them ad-hoc.
+#[derive(ToSchema, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CheckpointHintRecord {
+    /// Commit version the checkpoint covers.
+    pub version: i64,
+    /// Total logical size of the checkpoint (bytes), if known.
+    pub size: Option<i64>,
+    /// Number of parts for multipart checkpoints, if any. Stored as `i64` to keep the
+    /// JSON deserialization aligned with [`LastCheckpointHint::parts`] (`Option<usize>`)
+    /// on 64-bit targets.
+    pub parts: Option<i64>,
+    /// Total on-disk size of the checkpoint (bytes), if known.
+    pub size_in_bytes: Option<i64>,
+    /// Count of add-file actions in the checkpoint, if tracked.
+    pub num_of_add_files: Option<i64>,
+}
+
+/// Reader state: holds the extracted record. `record.is_some()` doubles as the
+/// "already processed" flag to short-circuit subsequent batches.
+#[derive(Debug, Clone, Default)]
+pub struct CheckpointHintReader {
+    record: Option<CheckpointHintRecord>,
+}
+
+impl KernelReducer for CheckpointHintReader {
+    fn kind(&self) -> KernelReducerKind {
+        KernelReducerKind::CheckpointHint
+    }
+
+    fn finish(self: Box<Self>) -> Box<dyn std::any::Any + Send> {
+        Box::new(*self)
+    }
+
+    fn apply(&mut self, batch: &dyn EngineData) -> DeltaResult<KdfControl> {
+        if self.record.is_none() {
+            self.visit_rows_of(batch)?;
+        }
+        Ok(if self.record.is_some() {
+            KdfControl::Break
+        } else {
+            KdfControl::Continue
+        })
+    }
+}
+
+impl KernelReducerOutput for CheckpointHintReader {
+    type Output = Option<CheckpointHintRecord>;
+
+    fn into_output(self) -> Result<Self::Output, DeltaError> {
+        Ok(self.record)
+    }
+}
+
+impl RowVisitor for CheckpointHintReader {
+    fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
+        static NAMES_AND_TYPES: LazyLock<ColumnNamesAndTypes> =
+            LazyLock::new(|| CheckpointHintRecord::to_schema().leaves(None));
+        NAMES_AND_TYPES.as_ref()
+    }
+
+    fn visit<'a>(&mut self, row_count: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
+        if self.record.is_some() || row_count == 0 {
+            return Ok(());
+        }
+        // The `_last_checkpoint` file is a single row per the protocol. Reject extra rows
+        // loudly instead of silently consuming only row 0 -- the kernel may otherwise miss
+        // a corrupt/multi-row hint file produced by a buggy writer or a different format.
+        if row_count > 1 {
+            return Err(crate::Error::generic(format!(
+                "_last_checkpoint hint reader expected 1 row, got {row_count}"
+            )));
+        }
+        // Column order matches the leaf traversal of `CheckpointHintRecord`.
+        self.record = Some(CheckpointHintRecord {
+            version: getters[0].get(0, "version")?,
+            size: getters[1].get_opt(0, "size")?,
+            parts: getters[2].get_opt(0, "parts")?,
+            size_in_bytes: getters[3].get_opt(0, "sizeInBytes")?,
+            num_of_add_files: getters[4].get_opt(0, "numOfAddFiles")?,
+        });
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::arrow::array::{ArrayRef, Int64Array, RecordBatch};
+    use crate::arrow::datatypes::{
+        DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
+    };
+    use crate::engine::arrow_data::ArrowEngineData;
+
+    #[test]
+    fn empty_partition_produces_none() {
+        let reader = CheckpointHintReader::default();
+        let out = reader.into_output().unwrap();
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn apply_reads_first_row_and_breaks() {
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("version", ArrowDataType::Int64, false),
+            ArrowField::new("size", ArrowDataType::Int64, true),
+            ArrowField::new("parts", ArrowDataType::Int64, true),
+            ArrowField::new("sizeInBytes", ArrowDataType::Int64, true),
+            ArrowField::new("numOfAddFiles", ArrowDataType::Int64, true),
+        ]));
+        let columns: Vec<ArrayRef> = vec![
+            Arc::new(Int64Array::from(vec![42])),
+            Arc::new(Int64Array::from(vec![Some(100)])),
+            Arc::new(Int64Array::from(vec![None])),
+            Arc::new(Int64Array::from(vec![Some(2048)])),
+            Arc::new(Int64Array::from(vec![Some(7)])),
+        ];
+        let batch = RecordBatch::try_new(schema, columns).unwrap();
+        let engine_data = ArrowEngineData::new(batch);
+
+        let mut reader = CheckpointHintReader::default();
+        assert_eq!(reader.apply(&engine_data).unwrap(), KdfControl::Break);
+        assert_eq!(reader.apply(&engine_data).unwrap(), KdfControl::Break);
+
+        let out = reader.into_output().unwrap();
+        let rec = out.expect("record");
+        // Assert every projected field (full structural equality). Spot-checking only
+        // `version` + `num_of_add_files` would silently miss a regression in `size`,
+        // `parts`, or `size_in_bytes` decoding.
+        assert_eq!(
+            rec,
+            CheckpointHintRecord {
+                version: 42,
+                size: Some(100),
+                parts: None,
+                size_in_bytes: Some(2048),
+                num_of_add_files: Some(7),
+            },
+        );
+    }
+}

--- a/kernel/src/plans/kernel_reducers/handle.rs
+++ b/kernel/src/plans/kernel_reducers/handle.rs
@@ -1,0 +1,224 @@
+//! Runtime state for KDF reducers.
+//!
+//! [`ReducerHandle`] is the executor's working buffer for one Reduce step: created when a
+//! phase starts, fed batches via [`ReducerHandle::apply`], finalized via
+//! [`ReducerHandle::finish`] when the child is exhausted. Type-erased into [`FinishedHandle`]
+//! and returned to the state machine as the Reduce response.
+//!
+//! Handles dispatch in-process and never cross a serialization boundary.
+//!
+//! Callers recover typed output from a [`FinishedHandle`] via the paired [`Extractor`], minted
+//! at plan-build time and threaded through to the SM body.
+// Intra-doc links to the state-machine framework / IR sink types intentionally degrade to
+// plain text in this module slice (the linked items live in sibling stacks).
+#![allow(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
+
+use std::any::Any;
+
+use super::reducer::{KdfControl, KernelReducer, KernelReducerOutput, KernelReducerToken};
+use crate::plans::errors::DeltaError;
+use crate::plans::state_machines::framework::engine_error::EngineError;
+use crate::{DeltaResult, EngineData};
+
+/// Runtime state carrier. Holds the mutable reducer working buffer and the token that joins
+/// its eventual finalized state back to the plan-tree node.
+#[derive(Debug)]
+pub struct ReducerHandle {
+    token: KernelReducerToken,
+    inner: Box<dyn KernelReducer>,
+}
+
+impl ReducerHandle {
+    /// Construct a handle from a fresh token and a cloned initial state.
+    pub fn new(token: KernelReducerToken, inner: Box<dyn KernelReducer>) -> Self {
+        Self { token, inner }
+    }
+
+    /// Apply the reducer to a batch.
+    #[tracing::instrument(
+        level = "trace",
+        name = "kernel_reducer.apply",
+        skip(self, batch),
+        ret,
+        fields(kind = %self.inner.kind(), token_id = %self.token.id),
+    )]
+    pub fn apply(&mut self, batch: &dyn EngineData) -> DeltaResult<KdfControl> {
+        self.inner.apply(batch)
+    }
+
+    /// Consume the handle, returning the finalized token-stamped state.
+    #[tracing::instrument(
+        level = "debug",
+        name = "kernel_reducer.finish",
+        skip(self),
+        fields(kind = %self.inner.kind(), token_id = %self.token.id),
+    )]
+    pub fn finish(self) -> FinishedHandle {
+        tracing::debug!("kernel reducer handle finished");
+        FinishedHandle {
+            token: self.token,
+            erased: self.inner.finish(),
+        }
+    }
+}
+
+/// Output of [`ReducerHandle::finish`] -- carries the token and the type-erased final state.
+#[derive(Debug)]
+pub struct FinishedHandle {
+    pub token: KernelReducerToken,
+    pub erased: Box<dyn Any + Send>,
+}
+
+// === Typed extraction ===
+
+/// A typed adapter for pulling the typed output of a single reduce sink
+/// out of a [`FinishedHandle`].
+///
+/// SM bodies build an `Extractor` while planting an [`EngineRequest::Reduce`] (via
+/// [`Context::reduce`]) and feed the engine's [`FinishedHandle`] back through
+/// [`Self::extract`] on resume.
+///
+/// [`EngineRequest::Reduce`]: crate::plans::state_machines::framework::state_machine::EngineRequest::Reduce
+/// [`Context::reduce`]: crate::plans::state_machines::framework::plan_context::Context::reduce
+pub struct Extractor<O> {
+    token: KernelReducerToken,
+    extract: fn(Box<dyn Any + Send>) -> Result<O, DeltaError>,
+}
+
+impl<O: Send + 'static> Extractor<O> {
+    /// Build an `Extractor` for KDF state `S` at `token`. The stored function pointer
+    /// downcasts the erased payload back to `S` and runs `S::into_output`.
+    // Consumer (Context::reduce dispatch) lands in the StateMachine follow-up PR.
+    #[allow(dead_code)]
+    pub(crate) fn for_reducer<S>(token: KernelReducerToken) -> Self
+    where
+        S: KernelReducerOutput<Output = O> + 'static,
+    {
+        Self {
+            token,
+            extract: extract_reducer::<S>,
+        }
+    }
+
+    /// Decode `handle`'s payload into the typed output `O`.
+    ///
+    /// Sanity-checks that `handle.token` matches this extractor's token (cross-wired
+    /// finished handles surface as an internal error) and runs the typed reduction.
+    /// Decoding failures are wrapped in [`EngineError::internal`] so SM bodies can
+    /// uniformly handle them on the engine-error path.
+    pub fn extract(self, handle: FinishedHandle) -> Result<O, EngineError> {
+        if handle.token != self.token {
+            return Err(EngineError::internal(DeltaError::invariant(format!(
+                "kernel_reducer::extract: token mismatch -- handle token `{}` vs expected `{}`",
+                handle.token, self.token,
+            ))));
+        }
+        (self.extract)(handle.erased).map_err(EngineError::internal)
+    }
+}
+
+impl<O> std::fmt::Debug for Extractor<O> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Extractor")
+            .field("token", &self.token)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Downcast the erased payload back to `S` and run its typed reduction. Bound to a
+/// concrete `S` via `Extractor::for_reducer`'s generic fn-pointer coercion.
+#[allow(dead_code)] // only consumer is for_reducer, gated above
+fn extract_reducer<S>(erased: Box<dyn Any + Send>) -> Result<S::Output, DeltaError>
+where
+    S: KernelReducerOutput + 'static,
+{
+    let single = erased.downcast::<S>().map(|b| *b).map_err(|_| {
+        DeltaError::invariant(format!(
+            "kernel_reducer::extract: expected `{}`",
+            std::any::type_name::<S>(),
+        ))
+    })?;
+    single.into_output()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{CheckpointHintReader, KernelReducerKind, KernelReducerToken};
+    use super::*;
+
+    /// Exercise the Extractor round-trip end-to-end: build a CheckpointHintReader, drive it
+    /// through ReducerHandle, finish it, hand the FinishedHandle to a matching Extractor,
+    /// and assert the typed output. Catches any drift between token wiring, downcast typing,
+    /// and KernelReducerOutput::into_output.
+    #[test]
+    fn extractor_round_trip_returns_typed_state() {
+        // Construct a populated reader via the visit path so we don't need to peek at
+        // private fields. We feed it a synthetic single-row batch shaped like
+        // `_last_checkpoint`.
+        use crate::arrow::array::{ArrayRef, Int64Array, RecordBatch};
+        use crate::arrow::datatypes::{
+            DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
+        };
+        use crate::engine::arrow_data::ArrowEngineData;
+        let schema = std::sync::Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("version", ArrowDataType::Int64, false),
+            ArrowField::new("size", ArrowDataType::Int64, true),
+            ArrowField::new("parts", ArrowDataType::Int64, true),
+            ArrowField::new("sizeInBytes", ArrowDataType::Int64, true),
+            ArrowField::new("numOfAddFiles", ArrowDataType::Int64, true),
+        ]));
+        let columns: Vec<ArrayRef> = vec![
+            std::sync::Arc::new(Int64Array::from(vec![7])),
+            std::sync::Arc::new(Int64Array::from(vec![Some(1024)])),
+            std::sync::Arc::new(Int64Array::from(vec![None])),
+            std::sync::Arc::new(Int64Array::from(vec![Some(2048)])),
+            std::sync::Arc::new(Int64Array::from(vec![Some(3)])),
+        ];
+        let batch = RecordBatch::try_new(schema, columns).unwrap();
+        let engine_data = ArrowEngineData::new(batch);
+
+        let token = KernelReducerToken::new(KernelReducerKind::CheckpointHint);
+        let reader = CheckpointHintReader::default();
+        let mut handle = ReducerHandle::new(token.clone(), Box::new(reader));
+        assert_eq!(handle.apply(&engine_data).unwrap(), KdfControl::Break);
+        let finished = handle.finish();
+
+        let extractor =
+            Extractor::<<CheckpointHintReader as KernelReducerOutput>::Output>::for_reducer::<
+                CheckpointHintReader,
+            >(token);
+        let out = extractor
+            .extract(finished)
+            .expect("typed extract must succeed");
+        let rec = out.expect("record");
+        assert_eq!(rec.version, 7);
+        assert_eq!(rec.num_of_add_files, Some(3));
+    }
+
+    /// Mismatched tokens MUST surface as an EngineError::internal -- the extractor's whole
+    /// raison d'etre is to detect cross-wired handles between phases of a plan.
+    #[test]
+    fn extractor_rejects_mismatched_token() {
+        let token_a = KernelReducerToken::new(KernelReducerKind::CheckpointHint);
+        let token_b = KernelReducerToken::new(KernelReducerKind::CheckpointHint);
+        let reader = CheckpointHintReader::default();
+        let handle = ReducerHandle::new(token_a, Box::new(reader));
+        let finished = handle.finish();
+
+        let extractor =
+            Extractor::<<CheckpointHintReader as KernelReducerOutput>::Output>::for_reducer::<
+                CheckpointHintReader,
+            >(token_b);
+        let err = extractor
+            .extract(finished)
+            .expect_err("mismatched tokens must error");
+        // EngineError::internal hides the source in Display; assert the source chain
+        // (which is what SM bodies surface via display_with_source_chain) contains the
+        // diagnostic message.
+        let chain = err.display_with_source_chain();
+        assert!(
+            chain.contains("token mismatch"),
+            "source chain missing token mismatch: {chain}"
+        );
+    }
+}

--- a/kernel/src/plans/kernel_reducers/handle.rs
+++ b/kernel/src/plans/kernel_reducers/handle.rs
@@ -74,12 +74,11 @@ pub struct FinishedHandle {
 /// A typed adapter for pulling the typed output of a single reduce sink
 /// out of a [`FinishedHandle`].
 ///
-/// SM bodies build an `Extractor` while planting an [`EngineRequest::Reduce`] (via
-/// [`Context::reduce`]) and feed the engine's [`FinishedHandle`] back through
-/// [`Self::extract`] on resume.
+/// SM bodies build an `Extractor` while planting an [`EngineRequest::Reduce`] (via the
+/// `Context::reduce` helper, added in a sibling submodule) and feed the engine's
+/// [`FinishedHandle`] back through [`Self::extract`] on resume.
 ///
 /// [`EngineRequest::Reduce`]: crate::plans::state_machines::framework::state_machine::EngineRequest::Reduce
-/// [`Context::reduce`]: crate::plans::state_machines::framework::plan_context::Context::reduce
 pub struct Extractor<O> {
     token: KernelReducerToken,
     extract: fn(Box<dyn Any + Send>) -> Result<O, DeltaError>,
@@ -88,7 +87,7 @@ pub struct Extractor<O> {
 impl<O: Send + 'static> Extractor<O> {
     /// Build an `Extractor` for KDF state `S` at `token`. The stored function pointer
     /// downcasts the erased payload back to `S` and runs `S::into_output`.
-    // Consumer (Context::reduce dispatch) lands in the StateMachine follow-up PR.
+    // Consumer (`Context::reduce` dispatch) lives in a sibling state-machine module.
     #[allow(dead_code)]
     pub(crate) fn for_reducer<S>(token: KernelReducerToken) -> Self
     where

--- a/kernel/src/plans/kernel_reducers/metadata_protocol.rs
+++ b/kernel/src/plans/kernel_reducers/metadata_protocol.rs
@@ -1,0 +1,177 @@
+//! `MetadataProtocolReader` -- reducer KDF that extracts the table's
+//! [`Protocol`] and [`Metadata`] actions from a log / checkpoint scan.
+//!
+//! Uses the existing [`Protocol::try_new_from_data`] and
+//! [`Metadata::try_new_from_data`] helpers, which guarantee atomic
+//! extraction -- either a full valid action is returned or `None`. The
+//! reader stops once both have been seen.
+//!
+//! # Caller invariant: newest-first ordering
+//!
+//! The reader captures the FIRST `Some(Protocol)` / `Some(Metadata)` it sees and ignores
+//! subsequent ones, so the caller MUST feed batches in `version DESC` order (newer commits
+//! first, then checkpoints, oldest last). Mirrors the contract that
+//! [`crate::log_segment::LogSegment::replay_for_pm`] establishes for the visitor path. If
+//! batches are fed in chronological order, the reader will silently return the wrong
+//! (oldest, not newest) action -- which is why we surface the contract here AND assert it
+//! via `debug_assert!` on every batch when the reducer can prove the order.
+
+use crate::actions::{Metadata, Protocol};
+use crate::plans::errors::DeltaError;
+use crate::plans::kernel_reducers::{
+    KdfControl, KernelReducer, KernelReducerKind, KernelReducerOutput,
+};
+use crate::{DeltaResult, EngineData};
+
+/// Captures the first `Some(Protocol)` / `Some(Metadata)` seen under the
+/// declared row ordering.
+#[derive(Debug, Clone, Default)]
+pub struct MetadataProtocolReader {
+    protocol: Option<Protocol>,
+    metadata: Option<Metadata>,
+}
+
+impl KernelReducer for MetadataProtocolReader {
+    fn kind(&self) -> KernelReducerKind {
+        KernelReducerKind::MetadataProtocol
+    }
+
+    fn finish(self: Box<Self>) -> Box<dyn std::any::Any + Send> {
+        Box::new(*self)
+    }
+
+    fn apply(&mut self, batch: &dyn EngineData) -> DeltaResult<KdfControl> {
+        if self.protocol.is_none() {
+            if let Some(p) = Protocol::try_new_from_data(batch)? {
+                self.protocol = Some(p);
+            }
+        }
+        if self.metadata.is_none() {
+            if let Some(m) = Metadata::try_new_from_data(batch)? {
+                self.metadata = Some(m);
+            }
+        }
+        if self.protocol.is_some() && self.metadata.is_some() {
+            Ok(KdfControl::Break)
+        } else {
+            Ok(KdfControl::Continue)
+        }
+    }
+}
+
+impl KernelReducerOutput for MetadataProtocolReader {
+    /// `(Metadata, Protocol)` matches the existing kernel convention used by
+    /// `LogSegment::read_protocol_metadata` and its underlying `replay_for_pm` helper.
+    type Output = (Metadata, Protocol);
+
+    fn into_output(self) -> Result<Self::Output, DeltaError> {
+        let missing = |what: &str| {
+            DeltaError::invariant(format!(
+                "metadata_protocol.into_output: missing {what} after scan completed"
+            ))
+        };
+        let protocol = self.protocol.ok_or_else(|| missing("protocol"))?;
+        let metadata = self.metadata.ok_or_else(|| missing("metadata"))?;
+        Ok((metadata, protocol))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::actions::Format;
+    use crate::table_features::TableFeature;
+    use crate::table_properties::{
+        COLUMN_MAPPING_MODE, ENABLE_CHANGE_DATA_FEED, ENABLE_DELETION_VECTORS,
+    };
+    use crate::utils::test_utils::action_batch;
+
+    /// The full `Protocol` carried by `crate::utils::test_utils::action_batch()`. Kept in sync
+    /// with the JSON fixture inline below so a fixture drift is loud rather than silent.
+    fn expected_action_batch_protocol() -> Protocol {
+        Protocol::try_new(
+            3,
+            7,
+            Some([TableFeature::DeletionVectors]),
+            Some([TableFeature::DeletionVectors]),
+        )
+        .expect("test fixture protocol should be valid")
+    }
+
+    /// The full `Metadata` carried by `crate::utils::test_utils::action_batch()`. Mirrors
+    /// `actions::visitors::tests::test_parse_metadata`'s expected struct so any drift in the
+    /// shared fixture surfaces in both tests.
+    fn expected_action_batch_metadata() -> Metadata {
+        let configuration = HashMap::from_iter([
+            (ENABLE_DELETION_VECTORS.to_string(), "true".to_string()),
+            (COLUMN_MAPPING_MODE.to_string(), "none".to_string()),
+            (ENABLE_CHANGE_DATA_FEED.to_string(), "true".to_string()),
+        ]);
+        Metadata::new_unchecked(
+            "testId",
+            None,
+            None,
+            Format {
+                provider: "parquet".into(),
+                options: HashMap::new(),
+            },
+            r#"{"type":"struct","fields":[{"name":"value","type":"integer","nullable":true,"metadata":{}}]}"#,
+            Vec::new(),
+            Some(1677811175819),
+            configuration,
+        )
+    }
+
+    #[test]
+    fn kind_is_stable() {
+        let r = MetadataProtocolReader::default();
+        assert_eq!(KernelReducer::kind(&r), KernelReducerKind::MetadataProtocol);
+    }
+
+    #[test]
+    fn missing_protocol_errors() {
+        let r = MetadataProtocolReader::default();
+        let err = r.into_output().unwrap_err();
+        // Detail now lives in the source (the message is static per code).
+        let src = std::error::Error::source(&err).expect("detail in source");
+        assert!(src.to_string().contains("missing protocol"), "got: {src}");
+    }
+
+    #[test]
+    fn apply_extracts_protocol_and_metadata_then_breaks() {
+        // `action_batch()` is the canonical test fixture used by the visitor unit tests; it
+        // contains a single batch with both Protocol and Metadata actions, plus some adds.
+        let batch = action_batch();
+        let mut r = MetadataProtocolReader::default();
+        assert_eq!(
+            r.apply(batch.as_ref()).unwrap(),
+            KdfControl::Break,
+            "both actions present -> Break on first batch"
+        );
+
+        let (metadata, protocol) = r.into_output().unwrap();
+        // Compare against the full expected structs, not just one field each: this catches
+        // silent drift in any of the version, feature, schema, partition, configuration, or
+        // created-time fields produced by the reducer.
+        assert_eq!(protocol, expected_action_batch_protocol());
+        assert_eq!(metadata, expected_action_batch_metadata());
+    }
+
+    #[test]
+    fn apply_ignores_subsequent_actions_per_newest_first_contract() {
+        // The reader captures the FIRST Protocol/Metadata it sees and silently ignores any
+        // subsequent ones (because the caller is expected to feed newest-first). Pin that
+        // contract here so a regression that started overwriting on later batches surfaces.
+        let first = action_batch();
+        let second = action_batch();
+
+        let mut r = MetadataProtocolReader::default();
+        assert_eq!(r.apply(first.as_ref()).unwrap(), KdfControl::Break);
+        let snapshot = (r.protocol.clone(), r.metadata.clone());
+        // Subsequent apply is a no-op for state; result is still Break.
+        assert_eq!(r.apply(second.as_ref()).unwrap(), KdfControl::Break);
+        assert_eq!((r.protocol, r.metadata), snapshot);
+    }
+}

--- a/kernel/src/plans/kernel_reducers/mod.rs
+++ b/kernel/src/plans/kernel_reducers/mod.rs
@@ -1,0 +1,33 @@
+//! Kernel-Defined Functions (KDFs) -- stateful per-row logic the kernel owns.
+//!
+//! KDFs encapsulate Delta-specific per-row work (checkpoint hint extraction,
+//! protocol/metadata harvesting, sidecar collection) that engines can't interpret.
+//!
+//! The IR exposes one KDF shape: [`KernelReducer`], an observer over batches
+//! returning `Continue` / `Break`. The reducer is wired into a plan via the
+//! `Reduce` request handled by the state-machine framework (declared in a
+//! consumer module); the reducer drains the terminal row stream and accumulates
+//! finalized state for the engine to harvest.
+//!
+//! KDFs dispatch in-process and never cross a serialization boundary.
+//!
+//! Each [`ReducerHandle`] carries a [`KernelReducerToken`] (`{ kind, id }`, stamped at
+//! plan-build time, keys the executor's state table and the paired [`Extractor`]).
+// Intra-doc links to the state-machine framework / IR sink types are intentionally not
+// resolvable in this module slice (consumers live in sibling stacks). Plain-text
+// references above keep `cargo doc -D warnings` happy until those modules land.
+#![allow(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
+
+mod checkpoint_hint;
+mod handle;
+mod metadata_protocol;
+mod reducer;
+mod sidecar_collector;
+
+pub use checkpoint_hint::{CheckpointHintReader, CheckpointHintRecord};
+pub use handle::{Extractor, FinishedHandle, ReducerHandle};
+pub use metadata_protocol::MetadataProtocolReader;
+pub use reducer::{
+    KdfControl, KernelReducer, KernelReducerKind, KernelReducerOutput, KernelReducerToken,
+};
+pub use sidecar_collector::SidecarCollector;

--- a/kernel/src/plans/kernel_reducers/reducer.rs
+++ b/kernel/src/plans/kernel_reducers/reducer.rs
@@ -1,0 +1,153 @@
+//! Core `KernelReducer` trait, identity types, and typed-output companion.
+//!
+//! Adding a new KDF: declare the struct, derive `Clone`, write
+//! `impl KernelReducer for T { ... }` with `kind`, `apply`, `finish`, and pair it with a
+//! `KernelReducerOutput` impl declaring the typed output. KDFs ride on the
+//! `Reduce` engine request defined by the state-machine framework (consumer module);
+//! the request is dispatched in-process and never serialized.
+// Intra-doc links to the state-machine framework intentionally degrade to plain text in
+// this slice; consumer types live in sibling stacks.
+#![allow(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
+
+//! # Object-safety notes
+//!
+//! - Associated types are NOT on [`KernelReducer`] -- `Box<dyn KernelReducer>` must be
+//!   heterogeneous across concrete reducer implementations (the executor mixes reducers with
+//!   different state types). Typed output lives on the [`KernelReducerOutput`] companion trait via
+//!   static dispatch.
+//! - `finish(self: Box<Self>) -> Box<dyn Any + Send>` erases the per-impl state type to keep the
+//!   trait object-safe. Typed factories downcast inside their extract closure.
+
+use std::any::Any;
+
+use dyn_clone::DynClone;
+use strum::Display as StrumDisplay;
+use uuid::Uuid;
+
+use crate::plans::errors::DeltaError;
+use crate::{DeltaResult, EngineData};
+
+// === Control flow ===
+
+/// Loop control returned by a reducer after each batch.
+///
+/// `Break` lets a reducer stop driving more input once it has everything
+/// it needs (e.g. `CheckpointHintReader` after the first row).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KdfControl {
+    Continue,
+    Break,
+}
+
+// === Identity ===
+
+/// Stable diagnostic identifier per reducer impl. Used in tracing spans, metrics labels,
+/// panic messages, and [`KernelReducerToken`] construction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, StrumDisplay)]
+#[strum(serialize_all = "snake_case")]
+pub enum KernelReducerKind {
+    CheckpointHint,
+    MetadataProtocol,
+    SidecarCollector,
+}
+
+/// Identity for a kernel-reducer entry on a finished handle.
+///
+/// Stamped at plan-build time when an [`EngineRequest::Reduce`] step is constructed. The fresh
+/// UUID `id` ensures stale handles from a prior plan can't be confused with current
+/// ones -- a [`FinishedHandle`] arriving with a token from a dead plan fails the
+/// [`Extractor`] sanity check at decode time.
+///
+/// `Display` emits `<kind>#<id>`.
+///
+/// [`EngineRequest::Reduce`]: crate::plans::state_machines::framework::state_machine::EngineRequest::Reduce
+/// [`FinishedHandle`]: super::handle::FinishedHandle
+/// [`Extractor`]: super::handle::Extractor
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct KernelReducerToken {
+    pub kind: KernelReducerKind,
+    pub id: Uuid,
+}
+
+impl KernelReducerToken {
+    /// Mint a fresh token for a kernel reducer with a UUID id.
+    pub fn new(kind: KernelReducerKind) -> Self {
+        Self {
+            kind,
+            id: Uuid::new_v4(),
+        }
+    }
+}
+
+impl std::fmt::Display for KernelReducerToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}#{}", self.kind, self.id)
+    }
+}
+
+// === Reducer trait ===
+
+/// Stateful observer over batches. Returns [`KdfControl`] per batch for
+/// early termination.
+///
+/// Useful for accumulating log segments, reading hint files, collecting
+/// sidecar references, etc.
+///
+/// `Box<dyn KernelReducer>` is cloneable via the [`DynClone`] supertrait -- the
+/// blanket `impl<T: Clone> DynClone for T` covers every concrete KDF state
+/// that derives `Clone`, so impls never write their own `clone_boxed`.
+pub trait KernelReducer: DynClone + Send + Sync + std::fmt::Debug {
+    /// Diagnostic identifier, stamped into the [`KernelReducerToken`] at plan-build time.
+    fn kind(&self) -> KernelReducerKind;
+
+    /// Observe one batch. Return [`KdfControl::Break`] to stop driving
+    /// further input; the kernel treats it as "child exhausted."
+    ///
+    /// TODO: enforce cardinality of applied rows. Each reducer impl should declare an
+    /// expected per-batch (or total) row-count contract so the runtime can assert that
+    /// the engine isn't incorrectly providing rows (e.g. `CheckpointHintReader` is
+    /// single-row, `MetadataProtocolReader` short-circuits on Break, etc.). Impls
+    /// silently accept whatever the engine hands them.
+    fn apply(&mut self, batch: &dyn EngineData) -> DeltaResult<KdfControl>;
+
+    /// Consume the finalized KDF, returning its state erased to
+    /// `Box<dyn Any + Send>`. Typed factories downcast inside their extract
+    /// closure back to the concrete state type.
+    ///
+    /// Signature takes `Box<Self>` rather than `self` so it's object-safe;
+    /// concrete impls are usually `fn finish(self: Box<Self>) -> Box<dyn Any + Send> {
+    /// Box::new(*self) }`.
+    fn finish(self: Box<Self>) -> Box<dyn Any + Send>;
+}
+
+// `Clone` for `Box<dyn KernelReducer>` -- delegates to `DynClone` (which every
+// concrete `Clone` impl gets for free via the blanket).
+dyn_clone::clone_trait_object!(KernelReducer);
+
+// === Typed-output companion ===
+
+/// Typed-output companion. Each KDF state impls this once, declaring the
+/// typed output callers receive and how the finalized state reduces to it.
+///
+/// ```ignore
+/// impl KernelReducerOutput for SidecarCollector {
+///     type Output = Vec<FileMeta>;
+///     fn into_output(self) -> Result<Self::Output, DeltaError> {
+///         /* project on self */
+///     }
+/// }
+/// ```
+pub trait KernelReducerOutput: KernelReducer + Any + Sized + 'static {
+    /// What downstream callers receive after `phase.execute(...)` completes.
+    type Output: Send + 'static;
+
+    /// Reduce the finalized state to [`Self::Output`].
+    ///
+    /// Each reduce sink is single-partition by construction (the executor
+    /// drains one root partition; the planner pins `target_partitions = 1`),
+    /// so this consumes `Self` directly. Token-keyed identity validation
+    /// happens upstream in [`Extractor::for_reducer`]'s closure.
+    ///
+    /// [`Extractor::for_reducer`]: super::handle::Extractor::for_reducer
+    fn into_output(self) -> Result<Self::Output, DeltaError>;
+}

--- a/kernel/src/plans/kernel_reducers/sidecar_collector.rs
+++ b/kernel/src/plans/kernel_reducers/sidecar_collector.rs
@@ -1,0 +1,108 @@
+//! `SidecarCollector` -- reducer KDF that collects sidecar file references
+//! from a V2 checkpoint manifest scan.
+//!
+//! Delegates row visiting to the existing [`SidecarVisitor`] and
+//! resolves the captured sidecars against `log_root` into `Vec<FileMeta>`
+//! via [`Sidecar::to_filemeta`] in [`KernelReducerOutput::into_output`].
+//!
+//! [`Sidecar::to_filemeta`]: crate::actions::Sidecar::to_filemeta
+
+use url::Url;
+
+use crate::actions::visitors::SidecarVisitor;
+use crate::engine_data::RowVisitor;
+use crate::plans::errors::DeltaError;
+use crate::plans::kernel_reducers::{
+    KdfControl, KernelReducer, KernelReducerKind, KernelReducerOutput,
+};
+use crate::{DeltaResult, EngineData, FileMeta};
+
+/// Accumulates sidecars as batches stream in.
+#[derive(Debug, Clone)]
+pub struct SidecarCollector {
+    log_root: Url,
+    visitor: SidecarVisitor,
+}
+
+impl SidecarCollector {
+    /// Construct a collector that resolves sidecar paths under `log_root`.
+    pub fn new(log_root: Url) -> Self {
+        Self {
+            log_root,
+            visitor: SidecarVisitor::default(),
+        }
+    }
+}
+
+impl KernelReducer for SidecarCollector {
+    fn kind(&self) -> KernelReducerKind {
+        KernelReducerKind::SidecarCollector
+    }
+
+    fn finish(self: Box<Self>) -> Box<dyn std::any::Any + Send> {
+        Box::new(*self)
+    }
+
+    fn apply(&mut self, batch: &dyn EngineData) -> DeltaResult<KdfControl> {
+        self.visitor.visit_rows_of(batch)?;
+        Ok(KdfControl::Continue)
+    }
+}
+
+impl KernelReducerOutput for SidecarCollector {
+    type Output = Vec<FileMeta>;
+
+    fn into_output(self) -> Result<Self::Output, DeltaError> {
+        let log_root = self.log_root;
+        self.visitor
+            .sidecars
+            .into_iter()
+            .map(|sidecar| {
+                sidecar
+                    .to_filemeta(&log_root)
+                    .map_err(DeltaError::invariant)
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::actions::Sidecar;
+
+    fn log_root() -> Url {
+        Url::parse("file:///test/_delta_log/").unwrap()
+    }
+
+    #[test]
+    fn kind_is_stable() {
+        let s = SidecarCollector::new(log_root());
+        assert_eq!(KernelReducer::kind(&s), KernelReducerKind::SidecarCollector);
+    }
+
+    #[test]
+    fn empty_partition_produces_empty_vec() {
+        let out = SidecarCollector::new(log_root()).into_output().unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn into_output_resolves_sidecar_paths() {
+        let mut s = SidecarCollector::new(log_root());
+        s.visitor.sidecars.push(Sidecar {
+            path: "sidecar1.parquet".to_string(),
+            size_in_bytes: 1000,
+            modification_time: 42,
+            tags: None,
+        });
+        let out = s.into_output().unwrap();
+        assert_eq!(out.len(), 1);
+        assert!(out[0]
+            .location
+            .as_str()
+            .ends_with("/_sidecars/sidecar1.parquet"));
+        assert_eq!(out[0].size, 1000);
+        assert_eq!(out[0].last_modified, 42);
+    }
+}

--- a/kernel/src/plans/mod.rs
+++ b/kernel/src/plans/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! This module is opt-in behind the `declarative-plans` feature flag.
 pub mod ir;
+pub mod proto;
 mod query_builder;
 
 use bytes::Bytes;

--- a/kernel/src/plans/mod.rs
+++ b/kernel/src/plans/mod.rs
@@ -3,8 +3,10 @@
 //! This module is opt-in behind the `declarative-plans` feature flag.
 pub mod errors;
 pub mod ir;
+pub mod kernel_reducers;
 pub mod proto;
 mod query_builder;
+pub mod state_machines;
 
 use bytes::Bytes;
 pub use ir::{IoOperation, Operation};

--- a/kernel/src/plans/mod.rs
+++ b/kernel/src/plans/mod.rs
@@ -1,5 +1,3 @@
-//! This module defines the concept of a PlanExecutor and its associated input + output types.
-//!
 //! This module is opt-in behind the `declarative-plans` feature flag.
 pub mod errors;
 pub mod ir;

--- a/kernel/src/plans/mod.rs
+++ b/kernel/src/plans/mod.rs
@@ -4,6 +4,7 @@ pub mod ir;
 pub mod kernel_reducers;
 pub mod proto;
 mod query_builder;
+pub mod schema_expr;
 pub mod state_machines;
 
 use bytes::Bytes;

--- a/kernel/src/plans/mod.rs
+++ b/kernel/src/plans/mod.rs
@@ -1,6 +1,7 @@
 //! This module defines the concept of a PlanExecutor and its associated input + output types.
 //!
 //! This module is opt-in behind the `declarative-plans` feature flag.
+pub mod errors;
 pub mod ir;
 pub mod proto;
 mod query_builder;

--- a/kernel/src/plans/proto/mod.rs
+++ b/kernel/src/plans/proto/mod.rs
@@ -1,0 +1,31 @@
+//! Protobuf wire format mirroring the kernel's plan / schema / expression IR.
+//!
+//! Each submodule wraps the prost-generated code for one `.proto` file in
+//! `kernel/proto/`. Consumers can serialise a kernel-built plan and ship it
+//! across a process / language boundary (Rust kernel -> JVM engine, etc.); the
+//! Rust kernel produces these messages but does not interpret them on receipt.
+//!
+//! - [`schema`] -- mirror of `kernel/src/schema/mod.rs` (`DataType`, `PrimitiveType`, `StructType`,
+//!   ...).
+//! - [`expressions`] -- mirror of `kernel/src/expressions/mod.rs` and `scalars.rs` (`Expression`,
+//!   `Predicate`, `Scalar`, `ColumnName`, ...).
+//! - [`plan`] -- mirror of `kernel/src/plans/ir/{plan,nodes}.rs` (`Plan`, `PlanNode`, `NodeKind`,
+//!   `RefId`, per-variant payload messages).
+//!
+//! # Stability
+//!
+//! Wire compatibility follows the per-file conventions in each `.proto` file: new IR
+//! variants get the next unused `oneof` field number, and once published a field number is
+//! never reused. There is no top-level wire version field.
+
+pub mod schema {
+    include!(concat!(env!("OUT_DIR"), "/delta.kernel.schema.rs"));
+}
+
+pub mod expressions {
+    include!(concat!(env!("OUT_DIR"), "/delta.kernel.expressions.rs"));
+}
+
+pub mod plan {
+    include!(concat!(env!("OUT_DIR"), "/delta.kernel.plan.rs"));
+}

--- a/kernel/src/plans/schema_expr/check.rs
+++ b/kernel/src/plans/schema_expr/check.rs
@@ -1,0 +1,467 @@
+//! Bidirectional expression type checker for builder schema derivation. Each public helper
+//! corresponds 1:1 to a `PlanBuilder` method so schema derivation lives in one named place:
+//!
+//! - [`check_expression`] -- bidirectional `(expr, expected)` check with strict [`DataType::eq`]
+//!   comparison; the primitive behind `field_op` and [`check_select`].
+//! - [`infer_projection_schema`] -- inference for `PlanBuilder::project`.
+//! - [`check_projection`] -- arity + per-expression well-formedness for
+//!   `PlanBuilder::project_with_schema`. Per-expression types are *not* compared to the declared
+//!   output schema; the caller's schema is authoritative and the runtime engine validates the
+//!   actual values. This is what lets `project_with_schema` carry column-mapping renames without
+//!   faking up a "structural" leaf comparator.
+//! - [`check_select`] -- identity-projection for `PlanBuilder::select`, strict-checked
+//!   field-by-field via [`check_expression`].
+//! - [`validate_exprs`] -- well-formedness check for operator-internal expressions that don't
+//!   contribute to the output schema (e.g. `PlanBuilder::max_by_version` group-by).
+//!
+//! Errors return [`SchemaExprResult`] (boxed `dyn Error`) -- this is a generic type checker that
+//! knows nothing about Delta. The plan-builder boundary wraps these via
+//! [`DeltaResultExt::or_delta`][crate::plans::errors::DeltaResultExt::or_delta].
+
+use std::borrow::Cow;
+
+use itertools::Itertools;
+
+use crate::expressions::{
+    ColumnName, Expression, ExpressionRef, Scalar, UnaryExpressionOp, VariadicExpressionOp,
+};
+use crate::plans::schema_expr::field_op::{arc_struct_or_invariant, identity_named_expr};
+use crate::plans::schema_expr::{SchemaExprError, SchemaExprResult};
+use crate::schema::{ArrayType, DataType, SchemaRef, StructField, StructType};
+use crate::transforms::ExpressionTransform;
+
+/// Shorthand for `SchemaExprError::from(format!(...))`.
+macro_rules! type_err {
+    ($($arg:tt)*) => {
+        $crate::plans::schema_expr::SchemaExprError::from(::std::format!($($arg)*))
+    };
+}
+
+/// Pure type synthesis: derive `(data_type, nullable)` from `expr` against `input_schema`.
+///
+/// Per-variant rules: `Literal` is null iff `Scalar::Null`; `Column` inherits the leaf field;
+/// `Predicate` and `ParseJson` are conservatively nullable; `ToJson` propagates the operand's
+/// nullability; `Coalesce` is non-null iff *any* arm is non-null; `If` ORs the arm nullabilities;
+/// `Array` is outer-non-null with `contains_null = true` (a precise OR would collide with the
+/// strict equality used to unify `If`/`Coalesce`/`Array` arms).
+///
+/// Errors on `Struct`, `Transform`, `Binary`, `MapToStruct`, `Opaque`, `Unknown` -- those need a
+/// target field; route through [`check_expression`] instead.
+fn synthesize(expr: &Expression, input_schema: &StructType) -> SchemaExprResult<(DataType, bool)> {
+    Ok(match expr {
+        Expression::Literal(s) => (s.data_type(), matches!(s, Scalar::Null(_))),
+        Expression::Column(c) => {
+            // walk_column_fields guarantees a non-empty result on success.
+            let leaf = *input_schema
+                .walk_column_fields(c)?
+                .last()
+                .ok_or_else(|| type_err!("walk_column_fields returned empty path for {c}"))?;
+            (leaf.data_type().clone(), leaf.nullable)
+        }
+        Expression::Predicate(_) => (DataType::BOOLEAN, true),
+        Expression::Unary(u) => match u.op {
+            UnaryExpressionOp::ToJson => (DataType::STRING, synthesize(&u.expr, input_schema)?.1),
+        },
+        Expression::Variadic(v) => {
+            let arms: Vec<_> = v
+                .exprs
+                .iter()
+                .map(|e| synthesize(e, input_schema))
+                .collect::<SchemaExprResult<_>>()?;
+            let elem_ty = unify_types(arms.iter().map(|(t, _)| t.clone()), &v.op.to_string())?;
+            match v.op {
+                VariadicExpressionOp::Coalesce => (elem_ty, arms.iter().all(|(_, n)| *n)),
+                VariadicExpressionOp::Array => (ArrayType::new(elem_ty, true).into(), false),
+            }
+        }
+        Expression::ParseJson(p) => ((*p.output_schema).clone().into(), true),
+        Expression::Struct(..)
+        | Expression::StructPatch(_)
+        | Expression::Binary(_)
+        | Expression::MapToStruct(_)
+        | Expression::Opaque(_)
+        | Expression::Unknown(_) => {
+            return Err(type_err!(
+                "expression variant has no type rule without a target field; \
+                 route through check_expression",
+            ))
+        }
+    })
+}
+
+/// Bidirectional type check for `expr` against `input_schema`. Returns `expected.clone()` on
+/// success -- the caller's declared `name`/`data_type`/`nullable` are authoritative (synthesized
+/// nullability is *not* enforced against `expected.nullable`; callers often tighten based on
+/// invariants the type system cannot see).
+///
+/// Leaf-type comparison is strict [`DataType::eq`]: nested struct field names must match. Callers
+/// that need to accept renames (e.g. column-mapping in `project_with_schema`) skip this helper
+/// and go through [`check_projection`] instead, which only validates arity + well-formedness.
+///
+/// Bidirectional-only variants:
+/// - `MapToStruct`: `expected.data_type()` must be `Struct`; input must produce `Map<String,
+///   String>`.
+/// - `Struct`: `expected.data_type()` must be `Struct` with matching arity; recurses on fields.
+/// - `StructPatch` / `Opaque` / `Unknown`: no type rule -- column refs validated, `expected` trusted.
+///
+/// All other variants synthesize and compare to `expected.data_type()` via `DataType::eq`.
+pub(crate) fn check_expression(
+    expr: &Expression,
+    input_schema: &StructType,
+    expected: &StructField,
+) -> SchemaExprResult<StructField> {
+    let want = expected.data_type();
+    match expr {
+        Expression::MapToStruct(m) => {
+            if !matches!(want, DataType::Struct(_)) {
+                return Err(type_err!("map_to_struct: expected Struct, got {want:?}"));
+            }
+            match synthesize(&m.map_expr, input_schema)?.0 {
+                DataType::Map(m)
+                    if m.key_type == DataType::STRING && m.value_type == DataType::STRING => {}
+                bad => {
+                    return Err(type_err!(
+                        "map_to_struct: input must produce Map<String, String>, got {bad:?}",
+                    ))
+                }
+            }
+        }
+        Expression::Struct(fields, _) => {
+            let DataType::Struct(target) = want else {
+                return Err(type_err!("struct: expected Struct, got {want:?}"));
+            };
+            let target_fields: Vec<_> = target.fields().collect();
+            if fields.len() != target_fields.len() {
+                return Err(type_err!(
+                    "struct: arity mismatch -- {got} expressions, {want_n} expected fields",
+                    got = fields.len(),
+                    want_n = target_fields.len(),
+                ));
+            }
+            for (e, f) in fields.iter().zip(target_fields) {
+                check_expression(e.as_ref(), input_schema, f)?;
+            }
+        }
+        Expression::StructPatch(_) | Expression::Opaque(_) | Expression::Unknown(_) => {
+            walk_column_refs(expr, input_schema)?;
+        }
+        _ => {
+            let (ty, _) = synthesize(expr, input_schema)?;
+            if ty != *want {
+                return Err(type_err!(
+                    "expression type mismatch for {name:?}: inferred {ty:?}, expected {want:?}",
+                    name = expected.name(),
+                ));
+            }
+        }
+    }
+    Ok(expected.clone())
+}
+
+/// Inference variant for `PlanBuilder::project`: each `(name, expr)` becomes a field whose
+/// `(data_type, nullable)` come from [`synthesize`]. Returns `(output_schema, pairs)`. Errors on
+/// non-inferrable expressions -- route through [`check_projection`] with a declared schema.
+pub(crate) fn infer_projection_schema(
+    input_schema: &StructType,
+    named_exprs: impl IntoIterator<Item = (impl Into<String>, impl Into<ExpressionRef>)>,
+) -> SchemaExprResult<(SchemaRef, Vec<(String, ExpressionRef)>)> {
+    let pairs: Vec<(String, ExpressionRef)> = named_exprs
+        .into_iter()
+        .map(|(n, e)| (n.into(), e.into()))
+        .collect();
+    let fields: Vec<StructField> = pairs
+        .iter()
+        .map(|(name, expr)| {
+            let (ty, nullable) = synthesize(expr.as_ref(), input_schema)?;
+            Ok(StructField::new(name.clone(), ty, nullable))
+        })
+        .collect::<SchemaExprResult<_>>()?;
+    Ok((arc_struct_or_invariant(fields)?, pairs))
+}
+
+/// Positional pair-up for `PlanBuilder::project_with_schema`: zips `exprs` with `target.fields()`
+/// and validates each expression's column references resolve in `input_schema`. The caller's
+/// `target` schema is taken as authoritative for the output -- per-expression types are *not*
+/// compared against it, which is what lets column-mapping renames and opaque rewrites
+/// (`Transform`/`Opaque`/`Unknown`) flow through unchallenged. The runtime engine catches any
+/// actual type mismatch.
+pub(crate) fn check_projection(
+    input_schema: &StructType,
+    exprs: impl IntoIterator<Item = impl Into<ExpressionRef>>,
+    target: &StructType,
+) -> SchemaExprResult<Vec<(String, ExpressionRef)>> {
+    let exprs: Vec<ExpressionRef> = exprs.into_iter().map(Into::into).collect();
+    let target_fields: Vec<_> = target.fields().collect();
+    if exprs.len() != target_fields.len() {
+        return Err(type_err!(
+            "projection arity mismatch: {got} expressions, {want} target fields",
+            got = exprs.len(),
+            want = target_fields.len(),
+        ));
+    }
+    for expr in &exprs {
+        walk_column_refs(expr.as_ref(), input_schema)?;
+    }
+    Ok(exprs
+        .into_iter()
+        .zip(target_fields)
+        .map(|(expr, field)| (field.name().clone(), expr))
+        .collect())
+}
+
+/// Well-formedness check for operator-internal expressions (group-by, sort keys, ...) whose
+/// inferred types are discarded. Mirrors `check_projection` semantics: we only verify that every
+/// column reference resolves; arbitrary `Binary` / `Transform` / `Opaque` shapes are accepted
+/// because their result type does not flow into a target field. Use [`check_expression`] when
+/// the inferred type must equal a declared target type, and [`synthesize`] when callers need
+/// the result type back.
+pub(crate) fn validate_exprs(
+    input_schema: &StructType,
+    exprs: impl IntoIterator<Item = impl Into<ExpressionRef>>,
+) -> SchemaExprResult<()> {
+    for expr in exprs {
+        walk_column_refs(expr.into().as_ref(), input_schema)?;
+    }
+    Ok(())
+}
+
+/// Identity projection for `PlanBuilder::select`: pairs each target field with `col(name)` and
+/// [`check_expression`]-checks each against the input.
+pub(crate) fn check_select(
+    input_schema: &StructType,
+    target: &StructType,
+) -> SchemaExprResult<Vec<(String, ExpressionRef)>> {
+    target
+        .fields()
+        .map(|f| {
+            let pair = identity_named_expr(f.name().clone());
+            check_expression(pair.1.as_ref(), input_schema, f)?;
+            Ok(pair)
+        })
+        .collect()
+}
+
+/// Verify every column reference in `expr` resolves in `schema`. Module-scoped because
+/// [`ExpressionTransform`] requires a named type.
+fn walk_column_refs(expr: &Expression, schema: &StructType) -> SchemaExprResult<()> {
+    struct Validator<'a> {
+        schema: &'a StructType,
+        err: Option<SchemaExprError>,
+    }
+    impl<'a> ExpressionTransform<'a> for Validator<'a> {
+        fn transform_expr_column(&mut self, name: &'a ColumnName) -> Option<Cow<'a, ColumnName>> {
+            if self.err.is_none() {
+                if let Err(e) = self.schema.walk_column_fields(name) {
+                    self.err = Some(type_err!("unresolved column reference {name}: {e}"));
+                }
+            }
+            Some(Cow::Borrowed(name))
+        }
+    }
+    let mut v = Validator { schema, err: None };
+    let _ = v.transform_expr(expr);
+    v.err.map_or(Ok(()), Err)
+}
+
+/// Strict-equality unification of N inferred types. Empty input is rejected (operators always
+/// build with >=1 arm).
+fn unify_types(mut types: impl Iterator<Item = DataType>, op: &str) -> SchemaExprResult<DataType> {
+    types.all_equal_value().map_err(|d| match d {
+        None => type_err!("{op}: cannot infer type with zero arms"),
+        Some((a, b)) => type_err!("{op}: arm types disagree -- got {a:?} and {b:?}"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use rstest::rstest;
+
+    use super::*;
+    use crate::expressions::{col, lit, Expression, Predicate};
+    use crate::schema::{MapType, StructField, StructType};
+
+    fn input_schema() -> StructType {
+        let map = DataType::Map(Box::new(MapType::new(
+            DataType::STRING,
+            DataType::STRING,
+            true,
+        )));
+        StructType::try_new(vec![
+            StructField::nullable("id", DataType::STRING),
+            StructField::nullable("ts", DataType::LONG),
+            StructField::nullable("flag", DataType::BOOLEAN),
+            StructField::nullable("tags", map),
+        ])
+        .unwrap()
+    }
+
+    /// Build a Struct `DataType` from `(name, type)` pairs.
+    fn make_struct<const N: usize>(fields: [(&str, DataType); N]) -> DataType {
+        let fields: Vec<_> = fields
+            .into_iter()
+            .map(|(n, t)| StructField::nullable(n, t))
+            .collect();
+        DataType::Struct(Box::new(StructType::try_new(fields).unwrap()))
+    }
+
+    fn long_long_struct() -> DataType {
+        make_struct([("a", DataType::LONG), ("b", DataType::LONG)])
+    }
+
+    fn long_string_struct(a: &str, b: &str) -> DataType {
+        make_struct([(a, DataType::LONG), (b, DataType::STRING)])
+    }
+
+    /// Build a nullable target field named `"out"` of the given type.
+    fn target(ty: DataType) -> StructField {
+        StructField::nullable("out", ty)
+    }
+
+    // === synthesize: happy paths ===
+    #[rstest]
+    #[case::literal_long(lit(42i64), DataType::LONG, false)]
+    #[case::literal_null(Expression::null_literal(DataType::STRING), DataType::STRING, true)]
+    #[case::column_string(col("id"), DataType::STRING, true)]
+    #[case::column_long(col("ts"), DataType::LONG, true)]
+    #[case::predicate_boolean(Expression::from_pred(Predicate::column(["flag"])), DataType::BOOLEAN, true)]
+    #[case::to_json_propagates_nullable(col("id").to_json(), DataType::STRING, true)]
+    #[case::coalesce_all_nullable(Expression::coalesce([col("id"), col("id")]), DataType::STRING, true)]
+    #[case::coalesce_with_literal_non_null(Expression::coalesce([col("id"), lit("default")]), DataType::STRING, false)]
+    fn synthesize_happy(#[case] expr: Expression, #[case] ty: DataType, #[case] nullable: bool) {
+        assert_eq!(synthesize(&expr, &input_schema()).unwrap(), (ty, nullable));
+    }
+
+    // === synthesize: errors ===
+    #[rstest]
+    #[case::unknown_column(col("missing"), "missing")]
+    #[case::coalesce_disagree(Expression::coalesce([col("id"), col("ts")]), "disagree")]
+    #[case::bidirectional_only(Expression::unknown("opaque"), "target field")]
+    fn synthesize_errors(#[case] expr: Expression, #[case] needle: &str) {
+        let err = synthesize(&expr, &input_schema()).unwrap_err().to_string();
+        assert!(err.contains(needle), "expected {needle:?}, got: {err}");
+    }
+
+    #[test]
+    fn array_outer_non_null_inner_contains_null_conservative() {
+        let (ty, nullable) =
+            synthesize(&Expression::array([col("id"), lit("x")]), &input_schema()).unwrap();
+        assert!(!nullable);
+        let DataType::Array(arr) = ty else {
+            panic!("expected Array")
+        };
+        assert_eq!(arr.element_type, DataType::STRING);
+        assert!(arr.contains_null);
+    }
+
+    // === check_expression: bidirectional rules ===
+    //
+    // Each case runs `check_expression(expr, input_schema, target(ty))` and either expects
+    // success (`None`) or an error containing the given substring.
+    #[rstest]
+    #[case::col_match_ok(col("ts"), DataType::LONG, None)]
+    #[case::col_type_mismatch(col("ts"), DataType::STRING, Some("expression type mismatch"))]
+    #[case::map_to_struct_ok(Expression::map_to_struct(col("tags")), long_long_struct(), None)]
+    #[case::map_to_struct_bad_input(
+        Expression::map_to_struct(col("id")),
+        long_long_struct(),
+        Some("Map<String, String>")
+    )]
+    #[case::map_to_struct_bad_target(
+        Expression::map_to_struct(col("tags")),
+        DataType::LONG,
+        Some("expected Struct")
+    )]
+    #[case::struct_arity(Expression::struct_from([Arc::new(col("ts"))]), long_long_struct(), Some("arity mismatch"))]
+    #[case::struct_ok(Expression::struct_from([Arc::new(col("ts")), Arc::new(col("ts"))]), long_long_struct(), None)]
+    #[case::struct_field_mismatch(Expression::struct_from([Arc::new(col("ts")), Arc::new(col("id"))]), long_long_struct(), Some("expression type mismatch"))]
+    #[case::unknown_accepts_any(Expression::unknown("opaque"), DataType::LONG, None)]
+    fn check_expression_cases(
+        #[case] expr: Expression,
+        #[case] ty: DataType,
+        #[case] err: Option<&str>,
+    ) {
+        let s = input_schema();
+        let t = target(ty);
+        let result = check_expression(&expr, &s, &t);
+        match err {
+            None => assert_eq!(result.unwrap().name(), "out"),
+            Some(needle) => {
+                let e = result.unwrap_err().to_string();
+                assert!(e.contains(needle), "expected {needle:?}, got: {e}");
+            }
+        }
+    }
+
+    /// The caller's `nullable` is authoritative -- the returned field mirrors `expected.nullable`
+    /// even when the expression itself synthesizes as nullable.
+    #[test]
+    fn check_expression_returns_caller_nullable() {
+        let got = check_expression(
+            &col("ts"),
+            &input_schema(),
+            &StructField::not_null("out", DataType::LONG),
+        )
+        .unwrap();
+        assert!(!got.nullable);
+    }
+
+    // === infer_projection_schema ===
+    #[test]
+    fn infer_projection_schema_builds_inferred_fields() {
+        let pairs_in = [("out_id", col("id")), ("out_ts", col("ts"))];
+        let (out, pairs) = infer_projection_schema(&input_schema(), pairs_in).unwrap();
+        assert_eq!(out.field("out_id").unwrap().data_type(), &DataType::STRING);
+        assert!(out.field("out_id").unwrap().nullable);
+        assert_eq!(out.field("out_ts").unwrap().data_type(), &DataType::LONG);
+        assert!(out.field("out_ts").unwrap().nullable);
+        let names: Vec<&str> = pairs.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(names, ["out_id", "out_ts"]);
+    }
+
+    /// Non-null literals + `coalesce(nullable, non_null)` both produce non-null projected fields.
+    #[test]
+    fn infer_projection_schema_propagates_nullability() {
+        let pairs = [
+            ("from_literal", lit(42i64)),
+            (
+                "from_coalesce",
+                Expression::coalesce([col("id"), lit("default")]),
+            ),
+        ];
+        let (out, _) = infer_projection_schema(&input_schema(), pairs).unwrap();
+        assert!(!out.field("from_literal").unwrap().nullable);
+        assert!(!out.field("from_coalesce").unwrap().nullable);
+    }
+
+    // === check_projection ===
+    #[test]
+    fn check_projection_arity_mismatch_is_caught() {
+        let t = StructType::try_new(vec![StructField::nullable("only", DataType::STRING)]).unwrap();
+        let exprs: Vec<ExpressionRef> = vec![Arc::new(col("id")), Arc::new(col("ts"))];
+        let err = check_projection(&input_schema(), exprs, &t)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("projection arity mismatch"));
+    }
+
+    #[test]
+    fn check_projection_returns_target_named_pairs() {
+        let s = StructType::try_new(vec![StructField::nullable(
+            "src",
+            long_string_struct("phys_a", "phys_b"),
+        )])
+        .unwrap();
+        let t = StructType::try_new(vec![StructField::nullable(
+            "renamed",
+            long_string_struct("log_a", "log_b"),
+        )])
+        .unwrap();
+        let pairs = check_projection(&s, [Arc::new(col("src")) as ExpressionRef], &t).unwrap();
+        assert_eq!(
+            pairs.iter().map(|(n, _)| n.as_str()).collect::<Vec<_>>(),
+            ["renamed"]
+        );
+    }
+}

--- a/kernel/src/plans/schema_expr/field_op.rs
+++ b/kernel/src/plans/schema_expr/field_op.rs
@@ -284,7 +284,9 @@ fn schema_after_field_op(
                 // Mirror the `op:` prefix that `with_field_replaced` /
                 // `with_field_inserted_after` errors carry, so `drop_col:` shows up at the
                 // top of the chain when the closure error bubbles out of with_struct_at.
-                return Err(Error::generic(format!("drop_col: field {leaf:?} not found")));
+                return Err(Error::generic(format!(
+                    "drop_col: field {leaf:?} not found"
+                )));
             }
             Ok(s.with_field_removed(leaf))
         }
@@ -478,7 +480,9 @@ mod tests {
         let op = FieldOp::Drop {
             target: col_path(&["s", "missing"]),
         };
-        let err = compile_field_op(&input, &op).err().expect("missing leaf must error");
+        let err = compile_field_op(&input, &op)
+            .err()
+            .expect("missing leaf must error");
         // `drop_col:` is the prefix the closure attaches via Error::generic(format!).
         assert!(
             err.to_string().contains("drop_col:"),

--- a/kernel/src/plans/schema_expr/field_op.rs
+++ b/kernel/src/plans/schema_expr/field_op.rs
@@ -1,0 +1,506 @@
+//! Field-level schema edits and matching projection expressions.
+//!
+//! The kernel `PlanBuilder` exposes point-edit primitives (`replace_col`, `insert_col_after`,
+//! `drop_col`, `append_col_typed`) that all reduce to one operation: walk a parent struct
+//! inside the input schema, apply an edit (replace / insert / drop), then emit the projection
+//! expression list that produces the edited output from the input.
+//!
+//! `FieldOp` captures the edit; `compile_field_op` applies it, returning both the output
+//! schema and the per-leaf projection expressions. Construction helpers (`FieldOp::replace`,
+//! `FieldOp::drop_`, `FieldOp::insert_after`) absorb up-front argument validation so call
+//! sites stay one line.
+//!
+//! A few unrelated schema/expression conveniences live here too -- they're used by both
+//! `field_op`'s internals and by other `PlanBuilder` methods:
+//! - `arc_struct_or_invariant` -- wrap a field list as `SchemaRef`, surfacing the constructor error
+//!   verbatim.
+//! - `identity_named_expr` -- `(name, col(name))` pair for identity projections.
+//! - [`load_output_schema`] -- `NodeKind::Load`'s output type rule, shared between
+//!   `PlanBuilder::load` and the datafusion lowering path. Publicly re-exported so engines can
+//!   share the kernel's computation rather than duplicate it.
+//!
+//! # Errors
+//!
+//! All public functions return `SchemaExprResult` -- an anyhow-style boxed `dyn Error`.
+//! Boundary callers (the [`PlanBuilder`] methods and the engine-side lowering path) attach the
+//! appropriate `DeltaErrorCode` via
+//! [`DeltaResultExt::or_delta`][crate::plans::errors::DeltaResultExt::or_delta]; engines that
+//! don't speak `DeltaError` (e.g. the datafusion lowering) consume the boxed source directly.
+//!
+//! [`PlanBuilder`]: crate::plans::state_machines::framework::plan_context::PlanBuilder
+
+use std::sync::Arc;
+
+use crate::expressions::{ColumnName, Expression, ExpressionRef};
+use crate::plans::schema_expr::{check, SchemaExprResult};
+use crate::schema::{DataType, SchemaRef, StructField, StructType};
+use crate::Error;
+
+/// Build a [`SchemaExprError`] from a `format!`-style message. See `check.rs`'s `type_err!` for
+/// the rationale.
+macro_rules! field_err {
+    ($($arg:tt)*) => {
+        $crate::plans::schema_expr::SchemaExprError::from(::std::format!($($arg)*))
+    };
+}
+
+// ============================================================================
+// Schema / expression conveniences
+// ============================================================================
+
+/// Build a `SchemaRef` from a field list, propagating [`StructType::try_new`] errors as the
+/// module's boxed error (the boundary caller attaches the Delta error code).
+pub(crate) fn arc_struct_or_invariant(fields: Vec<StructField>) -> SchemaExprResult<SchemaRef> {
+    Ok(Arc::new(StructType::try_new(fields)?))
+}
+
+/// `(name, col(name))` -- one identity entry for a top-level projection list.
+pub(crate) fn identity_named_expr(name: impl Into<String>) -> (String, ExpressionRef) {
+    let name = name.into();
+    let expr = Arc::new(Expression::column([&name]));
+    (name, expr)
+}
+
+/// Subset `input_schema` to the fields named in `names`, preserving each field's full
+/// `StructField` (type + nullability + metadata) as it appears in the input. Used by
+/// builder methods that narrow the row shape to a caller-named subset (e.g.
+/// [`PlanBuilder::max_by_version`]'s `value_columns`). Errors if any name does not
+/// resolve in `input_schema`. `op_name` is embedded in the error so the failure points
+/// back at the original public method.
+///
+/// [`PlanBuilder::max_by_version`]:
+///     crate::plans::state_machines::framework::plan_context::PlanBuilder::max_by_version
+pub(crate) fn narrow_schema_to(
+    input_schema: &StructType,
+    names: &[String],
+    op_name: &'static str,
+) -> SchemaExprResult<SchemaRef> {
+    let fields: Vec<StructField> = names
+        .iter()
+        .map(|name| {
+            input_schema
+                .field(name)
+                .cloned()
+                .ok_or_else(|| field_err!("{op_name}: column {name:?} not in input schema"))
+        })
+        .collect::<SchemaExprResult<_>>()?;
+    arc_struct_or_invariant(fields)
+}
+
+/// Build the output schema for a `NodeKind::Load`: `file_schema`'s fields followed by one
+/// field per `passthrough_columns` entry, with the passthrough type resolved by walking
+/// `input_schema` and the passthrough name taken from the column path's leaf.
+///
+/// Used by both kernel-side builder validation (`PlanBuilder::load`) and engine-side
+/// lowering (`delta-kernel-datafusion-engine`'s `lower_load`) so the rule stays one place.
+pub fn load_output_schema(
+    file_schema: &StructType,
+    passthrough_columns: &[ColumnName],
+    input_schema: &StructType,
+) -> SchemaExprResult<SchemaRef> {
+    let mut fields: Vec<StructField> = file_schema.fields().cloned().collect();
+    for col in passthrough_columns {
+        let leaf_name = col
+            .path()
+            .last()
+            .ok_or_else(|| field_err!("load: passthrough column path is empty"))?
+            .clone();
+        let walk = input_schema.walk_column_fields(col)?;
+        let leaf = walk
+            .last()
+            .ok_or_else(|| field_err!("load: passthrough column resolved to empty path"))?;
+        fields.push(StructField::nullable(leaf_name, leaf.data_type().clone()));
+    }
+    arc_struct_or_invariant(fields)
+}
+
+// ============================================================================
+// FieldOp
+// ============================================================================
+
+/// Field-level edit applied to the parent struct identified by a path prefix.
+///
+/// Each variant carries the schema-level edit and the per-leaf expression that will populate
+/// the new column at the matching position in the projection list. Construct via the
+/// position-specific constructors -- [`Self::append`], [`Self::insert_after_sibling`],
+/// [`Self::replace`], [`Self::drop_`] -- which absorb argument validation so
+/// [`compile_field_op`] takes a well-formed op.
+pub(crate) enum FieldOp {
+    /// Insert `new_field` into the struct at `parent`. `after = Some(name)` places it
+    /// immediately after the named sibling; `after = None` appends at the end. Mirrors
+    /// [`StructType::with_field_inserted_after`]'s `after: Option<&str>` contract.
+    /// Constructed only via [`Self::append`] (root/parent-append) or
+    /// [`Self::insert_after_sibling`] (insert-after-sibling).
+    InsertAfter {
+        parent: ColumnName,
+        after: Option<String>,
+        new_field: StructField,
+        new_expr: ExpressionRef,
+    },
+    /// Replace the field at `target` (full path, leaf included) with `new_field`.
+    /// Constructed only via [`Self::replace`], which validates `target` is non-empty.
+    Replace {
+        target: ColumnName,
+        new_field: StructField,
+        new_expr: ExpressionRef,
+    },
+    /// Remove the field at `target` (full path, leaf included) from its parent struct.
+    /// Constructed only via [`Self::drop_`], which validates `target` is non-empty.
+    Drop { target: ColumnName },
+}
+
+impl FieldOp {
+    /// Append `new_field` at the end of the struct at `parent`. `parent` may be empty (root).
+    pub(crate) fn append(
+        parent: ColumnName,
+        new_field: StructField,
+        new_expr: ExpressionRef,
+    ) -> Self {
+        Self::InsertAfter {
+            parent,
+            after: None,
+            new_field,
+            new_expr,
+        }
+    }
+
+    /// Insert `new_field` immediately after `sibling`'s position within its parent
+    /// struct. Splits `sibling` into `(parent, leaf)` internally so call sites
+    /// don't have to. Errors if `sibling` is empty (a sibling at the root is
+    /// meaningless because the root is a struct, not a field).
+    pub(crate) fn insert_after_sibling(
+        sibling: ColumnName,
+        new_field: StructField,
+        new_expr: ExpressionRef,
+    ) -> SchemaExprResult<Self> {
+        let (leaf, parent) = sibling
+            .path()
+            .split_last()
+            .ok_or_else(|| field_err!("insert_col_after: sibling path is empty"))?;
+        Ok(Self::InsertAfter {
+            parent: ColumnName::new(parent),
+            after: Some(leaf.clone()),
+            new_field,
+            new_expr,
+        })
+    }
+
+    /// Replace the field at `target` (full path, leaf included). Errors if `target`
+    /// is empty (a replace at the root is meaningless because the input is always a
+    /// struct, not a single field).
+    pub(crate) fn replace(
+        target: ColumnName,
+        new_field: StructField,
+        new_expr: ExpressionRef,
+    ) -> SchemaExprResult<Self> {
+        let target = ensure_nonempty_path(target, "replace_col")?;
+        Ok(Self::Replace {
+            target,
+            new_field,
+            new_expr,
+        })
+    }
+
+    /// Drop the field at `target` (full path, leaf included). Errors if `target` is empty.
+    pub(crate) fn drop_(target: ColumnName) -> SchemaExprResult<Self> {
+        let target = ensure_nonempty_path(target, "drop_col")?;
+        Ok(Self::Drop { target })
+    }
+
+    /// The parent struct path where the edit takes effect. For `Replace` / `Drop` this is
+    /// the target's path with the leaf stripped; for `InsertAfter` it is the carried
+    /// `parent` directly. Empty slice = root of the input schema.
+    fn parent_path(&self) -> &[String] {
+        match self {
+            Self::InsertAfter { parent, .. } => parent.path(),
+            Self::Replace { target, .. } | Self::Drop { target, .. } => target
+                .path()
+                .split_last()
+                .map(|(_, parent)| parent)
+                .unwrap_or(&[]),
+        }
+    }
+
+    /// Bidirectionally check the op's `new_expr` against `input_schema` with
+    /// `new_field.data_type()` as the expected output type. `Drop` has no expression to
+    /// validate.
+    fn validate_new_expr(&self, input_schema: &StructType) -> SchemaExprResult<()> {
+        let (new_field, new_expr) = match self {
+            Self::InsertAfter {
+                new_field,
+                new_expr,
+                ..
+            }
+            | Self::Replace {
+                new_field,
+                new_expr,
+                ..
+            } => (new_field, new_expr),
+            Self::Drop { .. } => return Ok(()),
+        };
+        check::check_expression(new_expr.as_ref(), input_schema, new_field).map(drop)
+    }
+}
+
+/// Apply `op` to `input_schema` and return both halves a `NodeKind::Project` needs: the
+/// output schema and the per-output-field projection expressions.
+///
+/// Validates `op.new_expr` against `input_schema` up front via
+/// [`check::check_expression`]. Schema-level existence/collision checks are deferred to
+/// kernel's `with_field_*` constructors.
+pub(crate) fn compile_field_op(
+    input_schema: &StructType,
+    op: &FieldOp,
+) -> SchemaExprResult<(SchemaRef, Vec<(String, ExpressionRef)>)> {
+    op.validate_new_expr(input_schema)?;
+    let parent_path = op.parent_path();
+    let output_schema = schema_after_field_op(input_schema, parent_path, op)?;
+    let named_exprs = projection_for_path(&output_schema, &[], parent_path, op)?;
+    Ok((output_schema, named_exprs))
+}
+
+// ============================================================================
+// FieldOp internals (private)
+// ============================================================================
+
+/// Schema half of a [`FieldOp`]: walk `parent_path` into `input_schema` via
+/// [`StructType::with_struct_at`] and apply the schema-level edit at the leaf parent.
+/// Defers existence and collision checks to the underlying `with_field_*` methods.
+fn schema_after_field_op(
+    input_schema: &StructType,
+    parent_path: &[String],
+    op: &FieldOp,
+) -> SchemaExprResult<SchemaRef> {
+    let new_struct = input_schema.with_struct_at(parent_path, |s| match op {
+        FieldOp::InsertAfter {
+            after, new_field, ..
+        } => s.with_field_inserted_after(after.as_deref(), new_field.clone()),
+        FieldOp::Replace {
+            target, new_field, ..
+        } => s.with_field_replaced(target_leaf(target)?, new_field.clone()),
+        FieldOp::Drop { target } => {
+            let leaf = target_leaf(target)?;
+            if s.field(leaf).is_none() {
+                // Mirror the `op:` prefix that `with_field_replaced` /
+                // `with_field_inserted_after` errors carry, so `drop_col:` shows up at the
+                // top of the chain when the closure error bubbles out of with_struct_at.
+                return Err(Error::generic(format!("drop_col: field {leaf:?} not found")));
+            }
+            Ok(s.with_field_removed(leaf))
+        }
+    })?;
+    Ok(Arc::new(new_struct))
+}
+
+/// Last component of a non-empty target path. Returns a kernel error (not a `DeltaError`)
+/// so it can be returned from inside `with_struct_at`'s closure. Callers of
+/// [`compile_field_op`] are expected to validate non-emptiness up front, so this is a
+/// defensive guard against a misconstructed [`FieldOp::Replace`] / [`FieldOp::Drop`].
+fn target_leaf(target: &ColumnName) -> Result<&str, Error> {
+    target
+        .path()
+        .last()
+        .map(String::as_str)
+        .ok_or_else(|| Error::generic("FieldOp target path is empty"))
+}
+
+/// Validate `path` is non-empty and return it for use as a `Replace` / `Drop` target.
+/// `op_name` is embedded in the error message so the failure points back at the original
+/// public method.
+fn ensure_nonempty_path(path: ColumnName, op_name: &'static str) -> SchemaExprResult<ColumnName> {
+    if path.path().is_empty() {
+        return Err(field_err!("{op_name}: path is empty"));
+    }
+    Ok(path)
+}
+
+/// Projection half of a [`FieldOp`]: walk the *output* schema along `remaining`. Drops,
+/// inserts, and renames are already baked into the output, so each output field needs
+/// exactly one expression: a freshly-introduced field uses the op's `new_expr`; the
+/// on-path ancestor recurses and re-emits via [`Expression::struct_from`]; everything
+/// else identity-projects from the input via [`col_ref_at`].
+///
+/// `path_so_far` accumulates the absolute prefix so identity references resolve from the
+/// data root rather than the inner struct.
+fn projection_for_path(
+    output: &StructType,
+    path_so_far: &[String],
+    remaining: &[String],
+    op: &FieldOp,
+) -> SchemaExprResult<Vec<(String, ExpressionRef)>> {
+    output
+        .fields()
+        .map(|f| {
+            let fname = f.name();
+            match (remaining.split_first(), op) {
+                // On the path inward: descend into the matching struct field.
+                (Some((target, rest)), _) if fname == target => {
+                    let DataType::Struct(sub) = f.data_type() else {
+                        return Err(field_err!(
+                            "projection_for_path: field {fname:?} is not a struct",
+                        ));
+                    };
+                    let mut sub_path = path_so_far.to_vec();
+                    sub_path.push(fname.clone());
+                    let exprs: Vec<ExpressionRef> = projection_for_path(sub, &sub_path, rest, op)?
+                        .into_iter()
+                        .map(|(_, e)| e)
+                        .collect();
+                    Ok((fname.clone(), Arc::new(Expression::struct_from(exprs))))
+                }
+                // At the target struct: Replace/InsertAfter introduce `new_expr` for the
+                // freshly-named field at this level.
+                (
+                    None,
+                    FieldOp::Replace {
+                        new_field,
+                        new_expr,
+                        ..
+                    }
+                    | FieldOp::InsertAfter {
+                        new_field,
+                        new_expr,
+                        ..
+                    },
+                ) if fname == new_field.name() => Ok((fname.clone(), Arc::clone(new_expr))),
+                // Identity passthrough: off-path field, or at target but not the new one.
+                _ => Ok((fname.clone(), col_ref_at(path_so_far, fname))),
+            }
+        })
+        .collect()
+}
+
+/// Build a `col(...)` reference to `leaf` within the struct rooted at `prefix`. When
+/// `prefix` is empty this is a top-level column reference.
+fn col_ref_at(prefix: &[String], leaf: &str) -> ExpressionRef {
+    let mut path: Vec<String> = Vec::with_capacity(prefix.len() + 1);
+    path.extend(prefix.iter().cloned());
+    path.push(leaf.to_string());
+    Arc::new(Expression::column(path))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use rstest::rstest;
+
+    use super::*;
+    use crate::expressions::{col, lit, Expression};
+    use crate::schema::{DataType, StructField, StructType};
+
+    fn input_schema() -> StructType {
+        StructType::new_unchecked([
+            StructField::nullable("a", DataType::INTEGER),
+            StructField::nullable(
+                "s",
+                DataType::Struct(Box::new(StructType::new_unchecked([
+                    StructField::nullable("x", DataType::STRING),
+                    StructField::nullable("y", DataType::INTEGER),
+                ]))),
+            ),
+        ])
+    }
+
+    fn col_path(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|p| p.to_string()).collect()
+    }
+
+    #[test]
+    fn compile_field_op_root_append_returns_extended_schema_and_identity_projection() {
+        let input = input_schema();
+        let op = FieldOp::InsertAfter {
+            after: None,
+            new_field: StructField::nullable("c", DataType::INTEGER),
+            new_expr: Arc::new(lit(0i32)),
+        };
+        let (out_schema, named_exprs) = compile_field_op(&input, &op).unwrap();
+        let names: Vec<_> = out_schema.fields().map(|f| f.name().as_str()).collect();
+        assert_eq!(names, vec!["a", "s", "c"]);
+        // Identity projection for unchanged columns, expression for the new one.
+        let new_proj = named_exprs.iter().find(|(n, _)| n == "c").unwrap();
+        assert_eq!(new_proj.1.as_ref(), &Expression::literal(0i32));
+        assert!(named_exprs.iter().any(|(n, _)| n == "a"));
+        assert!(named_exprs.iter().any(|(n, _)| n == "s"));
+    }
+
+    #[test]
+    fn compile_field_op_nested_replace_keeps_outer_passthrough() {
+        let input = input_schema();
+        let op = FieldOp::Replace {
+            target: col_path(&["s", "x"]),
+            new_field: StructField::nullable("x", DataType::STRING),
+            new_expr: Arc::new(col(["s", "x"])),
+        };
+        let (out_schema, named_exprs) = compile_field_op(&input, &op).unwrap();
+        // Top-level fields unchanged.
+        let names: Vec<_> = out_schema.fields().map(|f| f.name().as_str()).collect();
+        assert_eq!(names, vec!["a", "s"]);
+        // Top-level projection still references `a` and `s` (struct rewritten under s).
+        assert!(named_exprs.iter().any(|(n, _)| n == "a"));
+        assert!(named_exprs.iter().any(|(n, _)| n == "s"));
+    }
+
+    #[test]
+    fn compile_field_op_nested_drop_removes_only_target_leaf() {
+        let input = input_schema();
+        let op = FieldOp::Drop {
+            target: col_path(&["s", "y"]),
+        };
+        let (out_schema, _named_exprs) = compile_field_op(&input, &op).unwrap();
+        let s_field = out_schema.field("s").unwrap();
+        let DataType::Struct(s_type) = s_field.data_type() else {
+            panic!("s should still be a struct");
+        };
+        let s_field_names: Vec<_> = s_type.fields().map(|f| f.name().as_str()).collect();
+        assert_eq!(s_field_names, vec!["x"]);
+    }
+
+    #[test]
+    fn compile_field_op_insert_after_sibling_orders_correctly() {
+        let input = input_schema();
+        let op = FieldOp::InsertAfter {
+            after: Some(col_path(&["s", "x"])),
+            new_field: StructField::nullable("x_alias", DataType::STRING),
+            new_expr: Arc::new(col(["s", "x"])),
+        };
+        let (out_schema, _) = compile_field_op(&input, &op).unwrap();
+        let DataType::Struct(s_type) = out_schema.field("s").unwrap().data_type() else {
+            panic!("s should be a struct");
+        };
+        let s_names: Vec<_> = s_type.fields().map(|f| f.name().as_str()).collect();
+        assert_eq!(s_names, vec!["x", "x_alias", "y"]);
+    }
+
+    #[test]
+    fn compile_field_op_drop_missing_leaf_carries_op_prefix() {
+        let input = input_schema();
+        let op = FieldOp::Drop {
+            target: col_path(&["s", "missing"]),
+        };
+        let err = compile_field_op(&input, &op).err().expect("missing leaf must error");
+        // `drop_col:` is the prefix the closure attaches via Error::generic(format!).
+        assert!(
+            err.to_string().contains("drop_col:"),
+            "expected drop_col: prefix on error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn compile_field_op_replace_missing_root_reports_unresolved_column() {
+        let input = input_schema();
+        // `col(["missing"])` won't resolve via check_expression's walk_column_refs.
+        let op = FieldOp::Replace {
+            target: vec!["missing".to_string()],
+            new_field: StructField::nullable("missing", DataType::INTEGER),
+            new_expr: Arc::new(col(["missing"])),
+        };
+        let err = compile_field_op(&input, &op)
+            .err()
+            .expect("missing root must error");
+        assert!(
+            err.to_string().contains("unresolved column reference"),
+            "got: {err}"
+        );
+    }
+}

--- a/kernel/src/plans/schema_expr/mod.rs
+++ b/kernel/src/plans/schema_expr/mod.rs
@@ -1,0 +1,43 @@
+//! Schema/expression utilities shared by plan builders.
+//!
+//! These tools operate on [`StructType`][crate::schema::StructType] and
+//! [`Expression`][crate::expressions::Expression] without depending on the plan-construction
+//! state machinery. They live here -- separate from `ir` (IR data types) and the SM framework
+//! -- because they're builder-time helpers reused by multiple call sites (the kernel
+//! [`PlanBuilder`][crate::plans::state_machines::framework::plan_context::PlanBuilder] *and*
+//! engine-side lowering).
+//!
+//! - `check` -- bidirectional type checker for builder schema derivation (`check_expression`
+//!   under strict structural [`DataType`][crate::schema::DataType] equality, plus the
+//!   operator-aligned helpers `infer_projection_schema`, `check_projection`, `check_select`,
+//!   `validate_exprs`). Kernel-internal.
+//! - [`field_op`] -- nested struct edits (`FieldOp` + `compile_field_op`) plus a small set of
+//!   schema/expression conveniences (`arc_struct_or_invariant`, `identity_named_expr`, plus the
+//!   publicly re-exported [`field_op::load_output_schema`] shared with engine-side lowering).
+//!
+//! # Errors
+//!
+//! These modules are deliberately Delta-agnostic: they're generic schema/expression utilities
+//! and shouldn't know about [`DeltaError`][crate::plans::errors::DeltaError] /
+//! [`DeltaErrorCode`][crate::plans::errors::DeltaErrorCode]. Instead they return
+//! `SchemaExprResult` -- an anyhow-style boxed `dyn Error` -- and callers at the plan-builder
+//! boundary wrap that into a `DeltaError` with the appropriate code via
+//! [`DeltaResultExt::or_delta`][crate::plans::errors::DeltaResultExt::or_delta]. The boxed
+//! source is preserved through `std::error::Error::source()`.
+
+// schema_expr is the type-checker that `PlanBuilder::project` / `select` / `field_op` rely on
+// (see `state_machines::framework::plan_context`). The consumer module is intentionally not
+// declared in this slice; the module-wide allow keeps the diff quiet on its own and is
+// expected to be removed when the consumer is added.
+#![allow(dead_code)]
+
+pub(crate) mod check;
+pub mod field_op;
+
+/// Boxed, sendable error type returned by the `check` and `field_op` primitives. Identical
+/// to [`crate::plans::errors::BoxedSource`]; aliased here so call sites read as "schema-expr's
+/// error" without leaking the Delta error vocabulary into a generic type-checker.
+pub(crate) type SchemaExprError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// `Result` alias paired with `SchemaExprError`.
+pub(crate) type SchemaExprResult<T> = std::result::Result<T, SchemaExprError>;

--- a/kernel/src/plans/schema_expr/mod.rs
+++ b/kernel/src/plans/schema_expr/mod.rs
@@ -7,10 +7,10 @@
 //! [`PlanBuilder`][crate::plans::state_machines::framework::plan_context::PlanBuilder] *and*
 //! engine-side lowering).
 //!
-//! - `check` -- bidirectional type checker for builder schema derivation (`check_expression`
-//!   under strict structural [`DataType`][crate::schema::DataType] equality, plus the
-//!   operator-aligned helpers `infer_projection_schema`, `check_projection`, `check_select`,
-//!   `validate_exprs`). Kernel-internal.
+//! - `check` -- bidirectional type checker for builder schema derivation (`check_expression` under
+//!   strict structural [`DataType`][crate::schema::DataType] equality, plus the operator-aligned
+//!   helpers `infer_projection_schema`, `check_projection`, `check_select`, `validate_exprs`).
+//!   Kernel-internal.
 //! - [`field_op`] -- nested struct edits (`FieldOp` + `compile_field_op`) plus a small set of
 //!   schema/expression conveniences (`arc_struct_or_invariant`, `identity_named_expr`, plus the
 //!   publicly re-exported [`field_op::load_output_schema`] shared with engine-side lowering).
@@ -24,12 +24,6 @@
 //! boundary wrap that into a `DeltaError` with the appropriate code via
 //! [`DeltaResultExt::or_delta`][crate::plans::errors::DeltaResultExt::or_delta]. The boxed
 //! source is preserved through `std::error::Error::source()`.
-
-// schema_expr is the type-checker that `PlanBuilder::project` / `select` / `field_op` rely on
-// (see `state_machines::framework::plan_context`). The consumer module is intentionally not
-// declared in this slice; the module-wide allow keeps the diff quiet on its own and is
-// expected to be removed when the consumer is added.
-#![allow(dead_code)]
 
 pub(crate) mod check;
 pub mod field_op;

--- a/kernel/src/plans/state_machines/framework/coroutine.rs
+++ b/kernel/src/plans/state_machines/framework/coroutine.rs
@@ -1,0 +1,341 @@
+//! CoroutineSM-backed [`StateMachine`] implementation.
+//!
+//! Holds the internal yield/resume protocol shared between SM bodies and the
+//! [`CoroutineSM`] driver:
+//!
+//! - `StepYield` / `StepResume` (both `pub(crate)`) -- the value pair shuttled through the
+//!   genawaiter trampoline at each phase boundary.
+//! - `Engine` (`pub(crate)`) -- the SM-internal yield-channel handle, aliased over
+//!   [`genawaiter2::rc::Co`]. SM bodies emit yields through the `Context` `reduce` / `schema_query`
+//!   plan-construction helpers (sibling submodule); this module never exposes raw yields.
+//! - [`CoroutineSM<R>`] -- the driver that compiles `StepYield` sequences into the [`StateMachine`]
+//!   contract.
+//!
+//! # `!Send` design
+//!
+//! The driver uses [`genawaiter2::rc`] (not `sync`). State machines are CPU-only
+//! sequencers that never perform I/O or `await` real futures -- every
+//! `engine.yield_(step).await` is just the genawaiter2 trampoline, polled synchronously by
+//! the driver. There is no concurrent access to an SM, so the `Send` bound from
+//! `sync::GenBoxed` is unnecessary load on the API. Callers that need to drive an SM from
+//! a multi-threaded async runtime use `block_on` (which does not require `Send`) or
+//! `LocalSet` / `spawn_local`.
+//!
+//! # No-panic policy
+//!
+//! Built on [`genawaiter2`], which panics on coroutine protocol misuse (awaiting a
+//! non-yield future, retaining a `Co` after return). The no-panic rule is preserved
+//! because the only path to `Co::yield_` is through the `Context` plan-construction
+//! dispatch helpers; SM bodies are `pub(crate)`-only and FFI sees them through
+//! `Box<dyn StateMachine>`, so the panic paths are unreachable externally.
+//!
+//! # Naming note
+//!
+//! The `Engine` alias below shares its name with the kernel's connector-facing `Engine`
+//! trait. They are unrelated -- this `Engine` is the SM-internal yield channel, lives
+//! behind `pub(crate)`, and is never exposed in the public API. If a single scope ever
+//! needs both names, alias one at the use site (e.g. `use crate::Engine as EngineTrait;`).
+
+use std::future::Future;
+use std::pin::Pin;
+use std::{fmt, mem};
+
+use genawaiter2::rc::{Co, Gen};
+use genawaiter2::GeneratorState;
+use uuid::Uuid;
+
+use super::engine_error::EngineError;
+use super::state_machine::{EngineRequest, EngineResponse, NextStep, StateMachine};
+use crate::plans::errors::DeltaError;
+
+// ============================================================================
+// Yield/resume protocol
+// ============================================================================
+
+/// Value yielded by a coroutine at each phase boundary. Carries the operation envelope and
+/// the phase name.
+pub(crate) struct StepYield {
+    pub operation: EngineRequest,
+    pub step_name: &'static str,
+}
+
+/// Value the driver passes back to the coroutine on resume. Wraps the engine outcome for
+/// the most recent [`StepYield::operation`].
+pub(crate) struct StepResume(pub Result<EngineResponse, EngineError>);
+
+impl fmt::Debug for StepResume {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.0 {
+            Ok(_) => f.write_str("StepResume(Ok(..))"),
+            Err(e) => write!(f, "StepResume(Err({:?}))", e.kind),
+        }
+    }
+}
+
+/// CoroutineSM handle used inside phase bodies. Alias over [`genawaiter2::rc::Co`].
+///
+/// `genawaiter2::rc` (not `sync`) is intentional: the [`CoroutineSM`] driver does not need
+/// a `Send` future bound (see the module docs for why), and `rc::Co` is `!Send` -- the SM
+/// body's future inherits that, which is the correct architectural shape for a CPU-only
+/// sequencer.
+#[allow(dead_code)] // primary consumer is Context::dispatch (sibling state-machine framework module)
+pub(crate) type Engine = Co<StepYield, StepResume>;
+
+// ============================================================================
+// CoroutineSM driver
+// ============================================================================
+
+type InnerGen<R> = Gen<StepYield, StepResume, Pin<Box<dyn Future<Output = Result<R, DeltaError>>>>>;
+
+/// A state machine driven by a stackless coroutine (via [`genawaiter2`]).
+///
+/// At each phase the body yields a single `StepYield` (operation + static phase name)
+/// and awaits the engine outcome. The driver shuttles operations to
+/// [`StateMachine::get_step`] and resumes the body with the matching `StepResume` on
+/// [`StateMachine::submit`]. Protocol is strictly 1:1: each yield carries one
+/// [`EngineRequest`], the driver hands it to the engine, and the engine outcome flows back
+/// as a `StepResume` on submit. Zero-yield coroutines are allowed; they return
+/// [`NextStep::Done`] on the first submit.
+///
+/// # Identity
+///
+/// Every `CoroutineSM` carries a fresh `sm_id: Uuid` and a static `sm_kind` label (the
+/// kernel SM's logical kind: `"scan_metadata"`, `"full_state"`, ...). Together with the
+/// per-phase name available via [`StateMachine::step_name`] these form the
+/// `(sm_id, sm_kind, step_name)` identity tuple used to correlate engine activity across
+/// the SM boundary.
+///
+/// `sm_id` is generated by the driver and passed into the producer closure for any
+/// SM-rooted identity stamping (e.g. reducer handles emitted by [`EngineRequest::Reduce`]).
+pub struct CoroutineSM<R: 'static> {
+    gen: InnerGen<R>,
+    /// Where the SM is positioned. `Yielded` while engine work is pending; `ResultReady`
+    /// when the body completed without ever yielding (the next `submit` hands the stored
+    /// result back); `Done` once `submit` has returned the terminal result.
+    state: SmPosition<R>,
+    sm_id: Uuid,
+    sm_kind: &'static str,
+}
+
+/// Internal positioning of a [`CoroutineSM`]. Drives the [`StateMachine`] contract.
+#[allow(dead_code)] // Yielded/ResultReady are only constructed by ::new; consumer is Context::dispatch
+enum SmPosition<R> {
+    /// A phase is queued; engine work pending.
+    Yielded(StepYield),
+    /// Body has produced its terminal result; awaiting `submit` to hand it back. Reached
+    /// only by zero-yield SMs (multi-yield SMs skip through this state inside `submit` and
+    /// transition straight to `Done`).
+    ResultReady(Result<R, DeltaError>),
+    /// Result has been consumed; terminal sink.
+    Done,
+}
+
+impl<R: 'static> CoroutineSM<R> {
+    /// Construct a coroutine state machine and run the producer to its first yield (or to
+    /// completion).
+    ///
+    /// `sm_kind` labels the SM's logical kind for diagnostics (e.g. `"scan_metadata"`); the
+    /// driver mints a fresh `sm_id` and threads it into the producer closure for any
+    /// SM-rooted identity stamping the body needs.
+    ///
+    /// If the producer yields, the first yield becomes the initial `StepYield` returned
+    /// by [`StateMachine::get_step`]. If it completes without yielding, the terminal
+    /// result is stored and handed back from the first [`StateMachine::submit`] call --
+    /// callers don't need to special-case zero-yield SMs.
+    #[allow(dead_code)] // Context::dispatch is the consumer (sibling module)
+    pub(crate) fn new<F, Fut>(sm_kind: &'static str, producer: F) -> Self
+    where
+        F: FnOnce(Engine, Uuid) -> Fut + 'static,
+        Fut: Future<Output = Result<R, DeltaError>> + 'static,
+    {
+        let sm_id = Uuid::new_v4();
+        let mut gen: InnerGen<R> = Gen::new(move |engine| {
+            Box::pin(producer(engine, sm_id))
+                as Pin<Box<dyn Future<Output = Result<R, DeltaError>>>>
+        });
+        // genawaiter2's `Gen<Y, R, F>` exposes only `resume_with(R)`; the first resume arg
+        // is discarded because nothing is awaiting it. We pass an inert
+        // `Ok(EngineResponse::Empty)` sentinel that the body never observes (a yield
+        // always precedes any awaited resume, and zero-yield bodies terminate before
+        // inspection).
+        let state = match gen.resume_with(StepResume(Ok(EngineResponse::Empty))) {
+            GeneratorState::Yielded(phase) => SmPosition::Yielded(phase),
+            GeneratorState::Complete(result) => SmPosition::ResultReady(result),
+        };
+        Self {
+            gen,
+            state,
+            sm_id,
+            sm_kind,
+        }
+    }
+
+    /// `true` once the coroutine has terminated and [`submit`](Self::submit) has handed
+    /// out its final result.
+    pub fn is_done(&self) -> bool {
+        matches!(self.state, SmPosition::Done)
+    }
+
+    /// Fresh per-instance identifier. Stable across the lifetime of this SM and embedded
+    /// in SM-rooted artifacts (reducer handles, diagnostic logs).
+    pub fn sm_id(&self) -> Uuid {
+        self.sm_id
+    }
+
+    /// Static label for the SM's logical kind (e.g. `"scan_metadata"`, `"full_state"`).
+    pub fn sm_kind(&self) -> &'static str {
+        self.sm_kind
+    }
+}
+
+impl<R: 'static> StateMachine for CoroutineSM<R> {
+    type Result = R;
+
+    fn get_step(&mut self) -> Result<EngineRequest, DeltaError> {
+        match &self.state {
+            SmPosition::Yielded(phase) => Ok(phase.operation.clone()),
+            SmPosition::ResultReady(_) => Err(DeltaError::invariant(
+                "CoroutineSM::get_step: zero-yield SM has no pending operation; \
+                 call submit() to receive the terminal result",
+            )),
+            SmPosition::Done => Err(DeltaError::invariant(
+                "CoroutineSM::get_step: state machine already completed",
+            )),
+        }
+    }
+
+    fn submit(
+        &mut self,
+        result: Result<EngineResponse, EngineError>,
+    ) -> Result<NextStep<R>, DeltaError> {
+        match mem::replace(&mut self.state, SmPosition::Done) {
+            SmPosition::ResultReady(value) => {
+                // Zero-yield SMs hand back their terminal result on the first `submit`.
+                // The input is ignored because the body never awaited it, but a caller-
+                // supplied `Err(EngineError)` would indicate the executor wrapped an
+                // operation around a no-op SM and observed a real failure -- escalate
+                // rather than silently dropping it.
+                if let Err(err) = result {
+                    return Err(DeltaError::invariant(err));
+                }
+                value.map(NextStep::Done)
+            }
+            SmPosition::Done => Err(DeltaError::invariant(
+                "CoroutineSM::submit: cannot submit, already completed",
+            )),
+            SmPosition::Yielded(_) => match self.gen.resume_with(StepResume(result)) {
+                GeneratorState::Yielded(next) => {
+                    self.state = SmPosition::Yielded(next);
+                    Ok(NextStep::Continue)
+                }
+                GeneratorState::Complete(final_result) => final_result.map(NextStep::Done),
+            },
+        }
+    }
+
+    fn step_name(&self) -> &'static str {
+        match &self.state {
+            SmPosition::Yielded(phase) => phase.step_name,
+            SmPosition::ResultReady(_) | SmPosition::Done => "done",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plans::state_machines::framework::engine_error::EngineErrorKind;
+    use crate::plans::state_machines::framework::state_machine::SchemaQuery;
+
+    fn toy_step() -> EngineRequest {
+        EngineRequest::SchemaQuery(SchemaQuery::new("/toy"))
+    }
+
+    fn toy_schema() -> crate::schema::SchemaRef {
+        std::sync::Arc::new(crate::schema::StructType::new_unchecked(Vec::<
+            crate::schema::StructField,
+        >::new()))
+    }
+
+    /// Drive a two-phase SM: yield op A, observe a SchemaQuery response, yield op B, complete.
+    ///
+    /// The 1:1 pairing in `state_machine.rs` is SchemaQuery -> Schema; submitting
+    /// `EngineResponse::Schema(_)` (and not `EngineResponse::Empty`, which is a driver
+    /// sentinel only) exercises the documented protocol end-to-end.
+    #[test]
+    fn two_phase_sm_executes_in_sequence() {
+        let mut sm = CoroutineSM::<i64>::new("test", |mut engine, _sm_id| async move {
+            let phase_a = StepYield {
+                operation: toy_step(),
+                step_name: "phase_a",
+            };
+            let phase_b = StepYield {
+                operation: toy_step(),
+                step_name: "phase_b",
+            };
+            let _ = engine.yield_(phase_a).await;
+            let _ = engine.yield_(phase_b).await;
+            Ok(42)
+        });
+
+        assert_eq!(sm.sm_kind(), "test");
+
+        assert_eq!(sm.step_name(), "phase_a");
+        let op = sm.get_step().unwrap();
+        assert!(matches!(op, EngineRequest::SchemaQuery(_)));
+
+        let r = sm.submit(Ok(EngineResponse::Schema(toy_schema()))).unwrap();
+        assert!(matches!(r, NextStep::Continue));
+        assert_eq!(sm.step_name(), "phase_b");
+
+        let op = sm.get_step().unwrap();
+        assert!(matches!(op, EngineRequest::SchemaQuery(_)));
+
+        let r = sm.submit(Ok(EngineResponse::Schema(toy_schema()))).unwrap();
+        match r {
+            NextStep::Done(v) => assert_eq!(v, 42),
+            _ => panic!("expected Done"),
+        }
+        assert!(sm.is_done());
+    }
+
+    /// Engine errors flow through as `Err(EngineError)` on resume; the SM body receives
+    /// them and decides what to do.
+    #[test]
+    fn engine_error_flows_to_body_as_resume_err() {
+        let mut sm = CoroutineSM::<String>::new("test", |mut engine, _sm_id| async move {
+            let step = StepYield {
+                operation: toy_step(),
+                step_name: "p",
+            };
+            let resume = engine.yield_(step).await;
+            match resume.0 {
+                Err(e) => Ok(format!("got: {}", e.kind)),
+                Ok(_) => panic!("expected engine error"),
+            }
+        });
+
+        let _ = sm.get_step().unwrap();
+        let err = EngineError::new(EngineErrorKind::FileNotFound { path: "/x".into() });
+        let r = sm.submit(Err(err)).unwrap();
+        match r {
+            NextStep::Done(s) => assert!(s.contains("file not found: /x")),
+            _ => panic!("expected Done"),
+        }
+    }
+
+    /// Zero-yield coroutines are allowed: the first `submit` call hands the stored
+    /// terminal value back. Useful for SMs that compute their plans entirely up-front and
+    /// have no intermediate engine work.
+    #[test]
+    fn zero_phase_coroutine_returns_value_on_first_submit() {
+        let mut sm = CoroutineSM::<i32>::new("test", |_co, _sm_id| async move { Ok(7) });
+        assert!(sm.get_step().is_err());
+        let r = sm.submit(Ok(EngineResponse::Empty)).unwrap();
+        match r {
+            NextStep::Done(v) => assert_eq!(v, 7),
+            _ => panic!("expected Done"),
+        }
+        assert!(sm.is_done());
+    }
+}

--- a/kernel/src/plans/state_machines/framework/engine_error.rs
+++ b/kernel/src/plans/state_machines/framework/engine_error.rs
@@ -1,0 +1,165 @@
+//! Structured execution errors returned by engine plan execution.
+//!
+//! [`EngineError`] is **engine-facing**: the engine produces one when plan execution fails in a
+//! well-understood way, and SM bodies match on [`EngineError::kind`] to react. Crossing into the
+//! kernel-facing `DeltaError` happens at the call site (e.g. `DeltaError::invariant(engine_err)`),
+//! which keeps the `EngineError` as the source.
+//!
+//! Kernel code MUST NOT gate control flow on the *text* of `message` fields inside variants:
+//! those strings are non-semantic and exist only for display.
+
+use std::error::Error;
+
+use crate::plans::errors::BoxedSource;
+use crate::Version;
+
+/// A structured error from executing a `Plan`. Pairs a typed [`EngineErrorKind`] (the semantic
+/// signal SMs match on) with an optional source chain forwarded through
+/// `Error::source()`.
+#[derive(Debug, thiserror::Error)]
+#[error("{kind}")]
+pub struct EngineError {
+    /// The semantic variant. Kernel SMs match on this.
+    pub kind: EngineErrorKind,
+    /// Optional in-process-only source chain.
+    pub source: Option<BoxedSource>,
+}
+
+/// Semantic tag of an [`EngineError`].
+///
+/// Adding a new variant is the preferred way to express a new engine failure -- string-matching
+/// on `message` fields is explicitly forbidden. `#[non_exhaustive]` reserves space for additional
+/// variants without breaking callers.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum EngineErrorKind {
+    /// A required input relation was empty when the plan expected at least one row.
+    #[error("empty input for sink: {sink_description}")]
+    EmptyInput { sink_description: String },
+
+    /// A file path referenced by the plan was not found in storage.
+    #[error("file not found: {path}")]
+    FileNotFound { path: String },
+
+    /// A generic I/O failure that doesn't fit a more specific variant. `message` is
+    /// non-semantic -- for display only.
+    #[error("I/O error: {message}")]
+    IoError { message: String },
+
+    /// Engine-side failure the kernel does not classify further. Diagnostic detail lives in
+    /// [`EngineError::source`]; construct via [`EngineError::internal`].
+    #[error("internal engine error")]
+    Internal,
+
+    /// Commit lost a put-if-absent race or catalog ratify reported a conflicting table version.
+    #[error("commit conflict at version {version}")]
+    CommitConflict { version: Version },
+}
+
+impl EngineError {
+    /// Build a sourceless [`EngineError`]. The fast path when the engine
+    /// has no underlying error to attach.
+    pub fn new(kind: EngineErrorKind) -> Self {
+        Self { kind, source: None }
+    }
+
+    /// Render this error together with its full source chain. Formatted as
+    /// `"{kind}: {source}: {source_of_source}: ..."`.
+    ///
+    /// Distinct from [`ToString::to_string`] (which only renders `kind`):
+    /// [`EngineErrorKind::Internal`] carries its entire diagnostic payload in `source`, so
+    /// `to_string()` collapses to the static `"internal engine error"`. Use this method for
+    /// any diagnostic detail derived from an `Internal`.
+    pub fn display_with_source_chain(&self) -> String {
+        let mut out = self.kind.to_string();
+        let mut cur: Option<&(dyn Error + 'static)> = self.source();
+        while let Some(s) = cur {
+            out.push_str(": ");
+            out.push_str(&s.to_string());
+            cur = s.source();
+        }
+        out
+    }
+
+    /// Construct an [`EngineErrorKind::Internal`] with the originating
+    /// error attached as `source`. Use this whenever the engine has a
+    /// failure that doesn't fit a typed variant -- kernel call sites
+    /// inspect `source` (via `Error::source()`) if they need
+    /// the underlying message or type.
+    ///
+    /// Adding a dedicated typed variant is preferred whenever a given
+    /// cause starts recurring.
+    pub fn internal<E>(err: E) -> Self
+    where
+        E: Error + Send + Sync + 'static,
+    {
+        Self {
+            kind: EngineErrorKind::Internal,
+            source: Some(Box::new(err)),
+        }
+    }
+}
+
+impl From<EngineErrorKind> for EngineError {
+    fn from(kind: EngineErrorKind) -> Self {
+        Self::new(kind)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error;
+    use std::io;
+
+    use super::*;
+
+    #[test]
+    fn display_delegates_to_kind() {
+        let err = EngineError::new(EngineErrorKind::FileNotFound {
+            path: "/tmp/x".into(),
+        });
+        assert_eq!(err.to_string(), "file not found: /tmp/x");
+    }
+
+    #[test]
+    fn display_with_source_chain_renders_internal_payload() {
+        let err = EngineError::internal(io::Error::other(
+            "Non-Results plan failed: IllegalStateException: boom",
+        ));
+        let rendered = err.display_with_source_chain();
+        assert!(
+            rendered.contains("internal engine error"),
+            "kind prefix missing: {rendered}"
+        );
+        assert!(
+            rendered.contains("Non-Results plan failed: IllegalStateException: boom"),
+            "source payload missing: {rendered}"
+        );
+    }
+
+    #[test]
+    fn display_with_source_chain_is_stable_when_no_source() {
+        let err = EngineError::new(EngineErrorKind::FileNotFound {
+            path: "/tmp/x".into(),
+        });
+        assert_eq!(err.display_with_source_chain(), err.to_string());
+    }
+
+    #[test]
+    fn internal_tags_kind_and_preserves_source() {
+        let io = io::Error::other("boom");
+        let err = EngineError::internal(io);
+        assert_eq!(err.kind, EngineErrorKind::Internal);
+        let src = err.source().expect("source preserved");
+        assert!(src.to_string().contains("boom"));
+    }
+
+    #[test]
+    fn from_kind_produces_sourceless_error() {
+        let err: EngineError = EngineErrorKind::EmptyInput {
+            sink_description: "sink".into(),
+        }
+        .into();
+        assert!(err.source.is_none());
+    }
+}

--- a/kernel/src/plans/state_machines/framework/mod.rs
+++ b/kernel/src/plans/state_machines/framework/mod.rs
@@ -1,9 +1,20 @@
 //! State-machine framework: the shared infrastructure every kernel SM uses.
 //!
+//! - [`state_machine`] -- the [`StateMachine`](state_machine::StateMachine) trait,
+//!   [`NextStep`](state_machine::NextStep), and the typed
+//!   [`EngineRequest`](state_machine::EngineRequest) /
+//!   [`EngineResponse`](state_machine::EngineResponse) protocol the executor and SM exchange each
+//!   tick.
 //! - [`engine_error`] -- [`EngineError`](engine_error::EngineError), the typed failure the engine
 //!   surfaces to the SM (distinct from [`DeltaError`](crate::plans::errors::DeltaError), the
 //!   kernel-to-caller error).
+//! - [`coroutine`] -- [`CoroutineSM`](coroutine::CoroutineSM), the async-fn-backed `StateMachine`
+//!   impl. Wraps `genawaiter2::rc::Gen` to translate the typed `StepYield` / `StepResume` protocol
+//!   (both `pub(crate)`) into the `StateMachine` trait the executor drives.
 //!
-//! Additional modules (`state_machine`, `coroutine`, `plan_context`) land in follow-up PRs.
+//! The `plan_context` module (Context + PlanBuilder) lives in a sibling stack and is
+//! intentionally not declared here.
 
+pub mod coroutine;
 pub mod engine_error;
+pub mod state_machine;

--- a/kernel/src/plans/state_machines/framework/mod.rs
+++ b/kernel/src/plans/state_machines/framework/mod.rs
@@ -1,0 +1,9 @@
+//! State-machine framework: the shared infrastructure every kernel SM uses.
+//!
+//! - [`engine_error`] -- [`EngineError`](engine_error::EngineError), the typed failure the engine
+//!   surfaces to the SM (distinct from [`DeltaError`](crate::plans::errors::DeltaError), the
+//!   kernel-to-caller error).
+//!
+//! Additional modules (`state_machine`, `coroutine`, `plan_context`) land in follow-up PRs.
+
+pub mod engine_error;

--- a/kernel/src/plans/state_machines/framework/mod.rs
+++ b/kernel/src/plans/state_machines/framework/mod.rs
@@ -11,10 +11,11 @@
 //! - [`coroutine`] -- [`CoroutineSM`](coroutine::CoroutineSM), the async-fn-backed `StateMachine`
 //!   impl. Wraps `genawaiter2::rc::Gen` to translate the typed `StepYield` / `StepResume` protocol
 //!   (both `pub(crate)`) into the `StateMachine` trait the executor drives.
-//!
-//! The `plan_context` module (Context + PlanBuilder) lives in a sibling stack and is
-//! intentionally not declared here.
+//! - [`plan_context`] -- [`Context`](plan_context::Context) and
+//!   [`PlanBuilder`](plan_context::PlanBuilder), the ergonomic surface SM bodies use to build
+//!   [`Plan`](crate::plans::ir::plan::Plan) graphs.
 
 pub mod coroutine;
 pub mod engine_error;
+pub mod plan_context;
 pub mod state_machine;

--- a/kernel/src/plans/state_machines/framework/plan_context.rs
+++ b/kernel/src/plans/state_machines/framework/plan_context.rs
@@ -1,0 +1,1322 @@
+//! Plan-construction context and builder.
+//!
+//! [`Context`] owns the in-flight plan and a per-Ref schema table. [`PlanBuilder`] is a
+//! shared handle to a specific [`Ref`] in that program; builder methods append new
+//! `PlanNode`s and return new [`PlanBuilder`]s threading the freshly minted Refs. Cursors are
+//! [`Clone`] (cheap `Rc` clone) so branching is explicit.
+//!
+//! State is shared via `Rc<RefCell<ContextState>>` so transform methods can mutate without
+//! requiring `&mut Context`. SMs are CPU-only sequencers and never need to cross thread
+//! boundaries, so `Rc` (vs. `Arc`) is the right shape. See the
+//! `CoroutineSM` module docs for the `!Send` rationale.
+//!
+//! # Stale-builder protection
+//!
+//! Two checks gate every dispatch site:
+//!
+//! 1. *Cross-context identity* -- [`Context::reduce`] and [`Context::into_result_plan`] call
+//!    `ensure_same_context(&builder)` (uses [`Rc::ptr_eq`]) before any state access. Two fresh
+//!    `Context`s would both start at `session_id = 0`, so a builder from a different context would
+//!    silently pass the session check and dispatch against the wrong accumulator.
+//! 2. *Cross-yield freshness* -- each builder captures the context's `session_id` at mint time.
+//!    Dispatch methods ([`Context::reduce`], [`Context::schema_query`]) bump the id after the yield
+//!    to invalidate cursors held across the boundary; [`Context::into_result_plan`] consumes
+//!    `self`, mooting the concern for terminal dispatch.
+//!
+//! # `RefCell` discipline
+//!
+//! PlanBuilder methods borrow_mut, mutate state, and drop the guard before returning. Dispatch
+//! methods drop the borrow before any `engine.yield_(...).await`. Holding a `Ref` / `RefMut`
+//! across an await would panic at runtime; this is structurally avoided by every method
+//! in this module.
+//!
+//! [`CoroutineSM`]: crate::plans::state_machines::framework::coroutine::CoroutineSM
+//! [`PlanNode`]: crate::plans::ir::plan::PlanNode
+//! [`Ref`]: crate::plans::ir::plan::Ref
+
+use std::cell::RefCell;
+use std::mem;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use url::Url;
+
+use crate::expressions::{ColumnName, ExpressionRef, IntoColumnName, PredicateRef, Scalar};
+use crate::plans::errors::DeltaError;
+use crate::plans::ir::nodes::{
+    EquiJoinNode, FilterNode, ListFilesNode, LoadNode, MaxByVersionNode, ProjectNode, ReduceSink,
+    ScanJsonNode, ScanParquetNode, UnionNode, ValuesNode,
+};
+use crate::plans::ir::plan::{JoinKind, NodeKind, Plan, PlanNode, Ref, ResultPlan};
+use crate::plans::kernel_reducers::{Extractor, KernelReducer, KernelReducerOutput};
+use crate::plans::schema_expr::check::{
+    check_projection, check_select, infer_projection_schema, validate_exprs,
+};
+use crate::plans::schema_expr::field_op::{
+    compile_field_op, load_output_schema, narrow_schema_to, FieldOp,
+};
+use crate::plans::state_machines::framework::coroutine::{Engine, StepResume, StepYield};
+use crate::plans::state_machines::framework::state_machine::{
+    EngineRequest, EngineResponse, SchemaQuery,
+};
+use crate::schema::{SchemaRef, StructField};
+use crate::FileMeta;
+
+// ============================================================================
+// Local error shorthand
+// ============================================================================
+
+/// Build a Delta-agnostic [`BoxedSource`][crate::plans::errors::BoxedSource] from a
+/// `format!`-style message. The plan builder is a generic plan-construction tool that knows
+/// nothing about Delta error codes -- every internal sanity check produces a boxed error here
+/// and relies on `impl From<BoxedSource> for DeltaError` to lift it at the `?` boundary with
+/// the catch-all [`DeltaCommandInvariantViolation`][crate::plans::errors::DeltaErrorCode] code.
+///
+/// Use [`DeltaResultExt::or_delta`][crate::plans::errors::DeltaResultExt::or_delta] when a more
+/// specific code is appropriate.
+macro_rules! pb_err {
+    ($($arg:tt)*) => {
+        <$crate::plans::errors::BoxedSource as ::std::convert::From<::std::string::String>>::from(
+            ::std::format!($($arg)*),
+        )
+    };
+}
+
+// ============================================================================
+// Shared state
+// ============================================================================
+
+/// In-flight plan being built, the per-Ref schema table, and a session counter.
+///
+/// Ref ids are derived directly from `plan.stmts.len()` at push time: each node's
+/// output Ref equals its index in `stmts`, so the counter and the vector length are
+/// always in lockstep. No separate `next_ref` field is needed.
+#[derive(Debug, Default)]
+struct ContextState {
+    plan: Plan,
+    /// Per-Ref output schemas. `ref_schemas[i]` is the output schema of `plan.stmts[i]`.
+    ref_schemas: Vec<SchemaRef>,
+    /// Bumped by dispatch methods to invalidate cursors held across yields.
+    session_id: u32,
+}
+
+impl ContextState {
+    /// Append a node to the in-flight plan, mint its output Ref, and record
+    /// `schema` for the new Ref.
+    fn push_node(&mut self, kind: NodeKind, inputs: Vec<Ref>, schema: SchemaRef) -> Ref {
+        let output = Ref(self.plan.stmts.len() as u32);
+        self.plan.stmts.push(PlanNode {
+            kind,
+            inputs,
+            output,
+        });
+        self.ref_schemas.push(schema);
+        debug_assert_eq!(self.ref_schemas.len(), self.plan.stmts.len());
+        output
+    }
+
+    /// Validates that `builder` was minted in the current session (not stale across dispatch).
+    fn ensure_fresh(&self, builder: &PlanBuilder) -> Result<(), DeltaError> {
+        if self.session_id != builder.session_id {
+            return Err(pb_err!(
+                "stale builder: builder session={cs} expected {ss}",
+                cs = builder.session_id,
+                ss = self.session_id,
+            )
+            .into());
+        }
+        Ok(())
+    }
+
+    /// Bump the session counter, invalidating any `PlanBuilder` minted before this
+    /// call. Cursors held across the next [`Self::ensure_fresh`] will error. Called
+    /// at every dispatch boundary.
+    fn invalidate_cursors(&mut self) {
+        self.session_id = self.session_id.wrapping_add(1);
+    }
+
+    /// Drain the in-flight plan for shipment to the engine. Empties the per-Ref
+    /// schema table and invalidates cursors (so the Refs in the returned plan, which
+    /// restart from 0 on the next push, can't collide with any stale handle). The
+    /// caller pipes the returned plan through DCE before yielding it.
+    fn take_plan_for_dispatch(&mut self) -> Plan {
+        self.ref_schemas.clear();
+        self.invalidate_cursors();
+        mem::take(&mut self.plan)
+    }
+}
+
+// ============================================================================
+// Context
+// ============================================================================
+
+/// Plan-construction context.
+///
+/// Source methods mint root [`PlanBuilder`]s, dispatch methods
+/// ([`Self::reduce`] / [`Self::schema_query`]) yield steps through a coroutine, and
+/// [`Self::into_result_plan`] is the terminal sync drain (backward-reachability DCE).
+#[derive(Default)]
+pub struct Context {
+    state: Rc<RefCell<ContextState>>,
+}
+
+impl Context {
+    /// Construct a fresh context with an empty plan. Equivalent to
+    /// [`Context::default()`]; provided for idiomatic call-site phrasing.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append a source node with no inputs and return a handle to its output Ref.
+    fn push_source(&self, kind: NodeKind, schema: SchemaRef) -> Result<PlanBuilder, DeltaError> {
+        let state = &self.state;
+        let mut s = state.borrow_mut();
+        let r = s.push_node(kind, vec![], schema);
+        Ok(PlanBuilder::new(state, r, s.session_id))
+    }
+
+    /// Append a `NodeKind::ListFiles` source. Output schema is the engine-canonical listing
+    /// shape supplied by the caller (the kernel does not pin it; consumers wire to the
+    /// engine's listing schema).
+    pub fn list_files(
+        &self,
+        start_from: Url,
+        listing_schema: impl Into<SchemaRef>,
+    ) -> Result<PlanBuilder, DeltaError> {
+        self.push_source(
+            NodeKind::ListFiles(ListFilesNode { start_from }),
+            listing_schema.into(),
+        )
+    }
+
+    /// Append a `NodeKind::ScanParquet` source over Parquet `files`. Output schema
+    /// is the caller-declared `schema`.
+    pub fn scan_parquet(
+        &self,
+        files: Vec<FileMeta>,
+        schema: impl Into<SchemaRef>,
+    ) -> Result<PlanBuilder, DeltaError> {
+        let schema = schema.into();
+        let node = ScanParquetNode {
+            files,
+            schema: Arc::clone(&schema),
+        };
+        self.push_source(NodeKind::ScanParquet(node), schema)
+    }
+
+    /// Append a `NodeKind::ScanJson` source over newline-delimited JSON `files`. Output
+    /// schema is the caller-declared `schema`.
+    pub fn scan_json(
+        &self,
+        files: Vec<FileMeta>,
+        schema: impl Into<SchemaRef>,
+    ) -> Result<PlanBuilder, DeltaError> {
+        let schema = schema.into();
+        let node = ScanJsonNode {
+            files,
+            schema: Arc::clone(&schema),
+        };
+        self.push_source(NodeKind::ScanJson(node), schema)
+    }
+
+    /// Append a `NodeKind::Values` source. Rows accept any nested iterable whose leaf
+    /// values are convertible into [`Scalar`]: e.g. `[[1i64, 2], [3, 4]]` or a
+    /// `Vec<Vec<Scalar>>`. Combined with the per-leaf [`Into<Scalar>`] conversions
+    /// for primitive types, callers seldom need a `vec!` or explicit `Scalar::Long`.
+    /// For empty rows, pass `Vec::<Vec<Scalar>>::new()` (or a typed helper) so the
+    /// item type can be inferred.
+    pub fn values<R, S>(
+        &self,
+        schema: impl Into<SchemaRef>,
+        rows: impl IntoIterator<Item = R>,
+    ) -> Result<PlanBuilder, DeltaError>
+    where
+        R: IntoIterator<Item = S>,
+        S: Into<Scalar>,
+    {
+        let schema = schema.into();
+        let rows: Vec<Vec<Scalar>> = rows
+            .into_iter()
+            .map(|r| r.into_iter().map(Into::into).collect())
+            .collect();
+        let node = ValuesNode {
+            schema: Arc::clone(&schema),
+            rows,
+        };
+        self.push_source(NodeKind::Values(node), schema)
+    }
+
+    /// Verifies that `builder` was minted by `self` (not by some other `Context`). The
+    /// session_id check inside `ensure_fresh` is necessary but not sufficient: two
+    /// contexts will both start at session 0 and a freshly-built builder from another
+    /// context would silently pass the session check while reading/draining the wrong
+    /// state. The Rc identity check rules that out.
+    fn ensure_same_context(&self, builder: &PlanBuilder) -> Result<(), DeltaError> {
+        if !Rc::ptr_eq(&self.state, &builder.state) {
+            return Err(pb_err!(
+                "builder was minted by a different Context; only the originating Context \
+                 may dispatch or drain it",
+            )
+            .into());
+        }
+        Ok(())
+    }
+
+    /// Drain the accumulator into a [`EngineRequest::Reduce`] yielded through `engine` and recover
+    /// the reducer's typed output via [`Extractor`].
+    ///
+    /// Backward-reachability DCE narrows the plan to stmts transitively reachable
+    /// from `builder`. After the yield resumes, the accumulator is reset (empty plan +
+    /// empty schema table) and `session_id` is bumped so any cursors held across the
+    /// boundary fail at runtime.
+    ///
+    /// Borrows the shared state only briefly (mutation + drain) and drops the borrow
+    /// before the awaited yield, so the await never holds a `RefMut`.
+    #[allow(dead_code)]
+    pub(crate) async fn reduce<S>(
+        &self,
+        engine: &mut Engine,
+        builder: PlanBuilder,
+        reducer: S,
+        step_name: &'static str,
+    ) -> Result<S::Output, DeltaError>
+    where
+        S: KernelReducer + KernelReducerOutput + 'static,
+    {
+        self.ensure_same_context(&builder)?;
+        let sink = ReduceSink::new_reducer(reducer);
+        let extractor = Extractor::for_reducer::<S>(sink.token.clone());
+        let terminal = builder.ref_id;
+        let stmts: Vec<PlanNode> = {
+            let mut s = self.state.borrow_mut();
+            s.ensure_fresh(&builder)?;
+            s.take_plan_for_dispatch().reachable_from(terminal).stmts
+        };
+        // Drop the builder handle so the only remaining Rc on `state` is `self`'s.
+        drop(builder);
+
+        let operation = EngineRequest::Reduce {
+            stmts,
+            terminal,
+            sink,
+        };
+        let StepResume(result) = engine
+            .yield_(StepYield {
+                operation,
+                step_name,
+            })
+            .await;
+        let payload = result.map_err(DeltaError::invariant)?;
+        let EngineResponse::Reducer(handle) = payload else {
+            return Err(pb_err!(
+                "reduce: executor returned non-Reducer payload `{payload:?}` for \
+                 EngineRequest::Reduce",
+            )
+            .into());
+        };
+        extractor.extract(handle).map_err(DeltaError::invariant)
+    }
+
+    /// Yield a [`EngineRequest::SchemaQuery`] and return the schema delivered by the engine.
+    ///
+    /// Bumps `session_id` so any cursors held across the boundary fail at runtime.
+    /// The accumulator is preserved -- callers typically use the returned schema to
+    /// build fresh sources, and old refs become unreachable from new cursors (the next
+    /// `reduce`'s DCE prunes them).
+    #[allow(dead_code)]
+    pub(crate) async fn schema_query(
+        &self,
+        engine: &mut Engine,
+        path: impl Into<String>,
+        step_name: &'static str,
+    ) -> Result<SchemaRef, DeltaError> {
+        self.state.borrow_mut().invalidate_cursors();
+        let operation = EngineRequest::SchemaQuery(SchemaQuery::new(path.into()));
+        let StepResume(result) = engine
+            .yield_(StepYield {
+                operation,
+                step_name,
+            })
+            .await;
+        let payload = result.map_err(DeltaError::invariant)?;
+        let EngineResponse::Schema(schema) = payload else {
+            return Err(pb_err!(
+                "schema_query: executor returned non-Schema payload `{payload:?}` for \
+                 EngineRequest::SchemaQuery",
+            )
+            .into());
+        };
+        Ok(schema)
+    }
+
+    /// Drain the accumulator into a [`ResultPlan`] keyed at `builder`. Performs
+    /// backward-reachability DCE; only stmts transitively reachable from
+    /// `builder.ref_id()` survive.
+    ///
+    /// Returns an error if `builder` is from a different context (or stale across a
+    /// dispatch). All cursors must be dropped before this call -- the context state is
+    /// solely owned at terminal time.
+    pub fn into_result_plan(self, builder: PlanBuilder) -> Result<ResultPlan, DeltaError> {
+        self.ensure_same_context(&builder)?;
+        // Validate session before tearing down. Drop the borrow before `Rc::try_unwrap`.
+        {
+            let s = self.state.borrow();
+            s.ensure_fresh(&builder)?;
+        }
+        // Drop the builder's Rc handle so try_unwrap can succeed.
+        drop(builder.state);
+        let result = builder.ref_id;
+        let inner = Rc::try_unwrap(self.state)
+            .map(|cell| cell.into_inner())
+            .map_err(|_| {
+                pb_err!(
+                    "into_result_plan: outstanding PlanBuilder handles -- drop other Cursors before \
+                     calling this method",
+                )
+            })?;
+        let plan = inner.plan.reachable_from(result);
+        Ok(ResultPlan { plan, result })
+    }
+}
+
+// ============================================================================
+// PlanBuilder
+// ============================================================================
+
+/// Handle to a Ref in the in-flight plan. PlanBuilder methods append further
+/// stmts and return new Cursors threading the minted Refs.
+#[derive(Clone, Debug)]
+pub struct PlanBuilder {
+    state: Rc<RefCell<ContextState>>,
+    ref_id: Ref,
+    session_id: u32,
+}
+
+impl PlanBuilder {
+    /// Mint a fresh handle for `ref_id` against `state`. Captures `session_id` so the
+    /// handle can be invalidated by dispatch methods (see module-level docs).
+    fn new(state: &Rc<RefCell<ContextState>>, ref_id: Ref, session_id: u32) -> Self {
+        Self {
+            state: Rc::clone(state),
+            ref_id,
+            session_id,
+        }
+    }
+
+    /// The Ref this builder points at.
+    pub fn ref_id(&self) -> Ref {
+        self.ref_id
+    }
+
+    /// The schema of the value at this Ref.
+    ///
+    /// Returns an error if the builder is stale.
+    pub fn schema(&self) -> Result<SchemaRef, DeltaError> {
+        let state = self.state.borrow();
+        state.ensure_fresh(self)?;
+        Ok(state
+            .ref_schemas
+            .get(self.ref_id.0 as usize)
+            .cloned()
+            .ok_or_else(|| {
+                pb_err!(
+                    "schema: ref {ref_id} has no recorded schema",
+                    ref_id = self.ref_id.0
+                )
+            })?)
+    }
+
+    /// Validates that `other` shares the same underlying context state.
+    fn ensure_same_context(&self, other: &PlanBuilder) -> Result<(), DeltaError> {
+        if !Rc::ptr_eq(&self.state, &other.state) {
+            return Err(pb_err!("builder from a different context cannot be combined").into());
+        }
+        Ok(())
+    }
+
+    /// Append a unary node (`self` as sole input) and return a handle to its output Ref.
+    fn push_unary(self, kind: NodeKind, schema: SchemaRef) -> Result<Self, DeltaError> {
+        self.push_nary(kind, &[], schema)
+    }
+
+    /// Append an n-ary node over `self` and `others`, returning a handle to its output Ref.
+    fn push_nary(
+        self,
+        kind: NodeKind,
+        others: &[&PlanBuilder],
+        schema: SchemaRef,
+    ) -> Result<Self, DeltaError> {
+        let state = &self.state;
+        for other in others {
+            self.ensure_same_context(other)?;
+        }
+        let mut s = state.borrow_mut();
+        s.ensure_fresh(&self)?;
+        for other in others {
+            s.ensure_fresh(other)?;
+        }
+        let mut input_refs = vec![self.ref_id];
+        input_refs.extend(others.iter().map(|b| b.ref_id));
+        let r = s.push_node(kind, input_refs, schema);
+        Ok(PlanBuilder::new(state, r, s.session_id))
+    }
+
+    /// Single plumbing primitive for every projection-emitting method. Each caller
+    /// hands us the validated `(output_schema, named_exprs)` -- this just packages
+    /// them into `NodeKind::Project` and pushes the node.
+    fn push_project(
+        self,
+        output_schema: SchemaRef,
+        named_exprs: Vec<(String, ExpressionRef)>,
+    ) -> Result<Self, DeltaError> {
+        let node = ProjectNode {
+            named_exprs,
+            output_schema: Arc::clone(&output_schema),
+        };
+        self.push_unary(NodeKind::Project(node), output_schema)
+    }
+
+    /// Apply a nested field edit and append the resulting projection node.
+    fn apply_field_op(self, op: FieldOp) -> Result<Self, DeltaError> {
+        let input_schema = self.schema()?;
+        let (output_schema, pairs) = compile_field_op(&input_schema, &op)?;
+        self.push_project(output_schema, pairs)
+    }
+
+    // === Filter / Project ====================================================
+
+    /// Append a `NodeKind::Filter`. Output schema is unchanged.
+    pub fn filter(self, predicate: impl Into<PredicateRef>) -> Result<Self, DeltaError> {
+        let predicate = predicate.into();
+        let schema = self.schema()?;
+        self.push_unary(NodeKind::Filter(FilterNode { predicate }), schema)
+    }
+
+    /// Append a `NodeKind::Project` with inferred output schema.
+    ///
+    /// Each pair becomes one output field `(name, infer_type(expr))`. Inference is
+    /// narrow -- unsupported expressions error out and direct callers to
+    /// [`Self::project_with_schema`]. Schema derivation lives in
+    /// `schema_expr::check::infer_projection_schema`.
+    pub fn project(
+        self,
+        named_exprs: impl IntoIterator<Item = (impl Into<String>, impl Into<ExpressionRef>)>,
+    ) -> Result<Self, DeltaError> {
+        let input_schema = self.schema()?;
+        let (output_schema, pairs) = infer_projection_schema(&input_schema, named_exprs)?;
+        self.push_project(output_schema, pairs)
+    }
+
+    /// Append a `NodeKind::Project` with caller-supplied output schema. Positional:
+    /// the i-th expression becomes `schema.fields()[i]`. Validation lives in
+    /// `schema_expr::check::check_projection`: arity + per-expression bidirectional
+    /// type check against the target field's type, with **structural** type
+    /// equivalence (struct field names of nested types are ignored) so column-mapping
+    /// physical -> logical renames are accepted.
+    pub fn project_with_schema(
+        self,
+        exprs: impl IntoIterator<Item = impl Into<ExpressionRef>>,
+        schema: SchemaRef,
+    ) -> Result<Self, DeltaError> {
+        let input_schema = self.schema()?;
+        let pairs = check_projection(&input_schema, exprs, &schema)?;
+        self.push_project(schema, pairs)
+    }
+
+    // === Schema-edit sugar (over project) ====================================
+
+    /// Identity-by-name projection: every field in `schema` becomes `col(name)` against
+    /// the input, strict-type-checked field by field. Validation + pair construction
+    /// live in `schema_expr::check::check_select`.
+    pub fn select(self, schema: SchemaRef) -> Result<Self, DeltaError> {
+        let input_schema = self.schema()?;
+        let pairs = check_select(&input_schema, &schema)?;
+        self.push_project(schema, pairs)
+    }
+
+    /// Append a caller-typed `(field, expr)` after the existing fields. The supplied
+    /// [`StructField`] declares both the new column's name and its full nullability +
+    /// data type. The expression is bidirectionally checked against the input schema
+    /// with `field.data_type()` as the expected output -- see
+    /// `schema_expr::check::check_expression` for the supported rules (including
+    /// `MapToStruct` and `Struct`, which require an expected type from context).
+    pub fn append_col_typed(
+        self,
+        field: StructField,
+        expr: impl Into<ExpressionRef>,
+    ) -> Result<Self, DeltaError> {
+        self.apply_field_op(FieldOp::append(ColumnName::default(), field, expr.into()))
+    }
+
+    /// Insert `leaf` immediately after `sibling`'s position in its parent struct.
+    ///
+    /// `sibling`'s prefix (all components except the last) names the parent struct;
+    /// `leaf.name()` is the new column's name. Errors if `sibling` doesn't resolve, if
+    /// the parent isn't a struct, or if `leaf.name()` collides with an existing sibling.
+    /// `sibling` accepts any [`IntoColumnName`] value -- a `&str` for top-level fields,
+    /// a tuple/array or `column_name!` macro for nested paths.
+    pub fn insert_col_after(
+        self,
+        sibling: impl IntoColumnName,
+        leaf: StructField,
+        expr: impl Into<ExpressionRef>,
+    ) -> Result<Self, DeltaError> {
+        self.apply_field_op(FieldOp::insert_after_sibling(
+            sibling.into_column_name(),
+            leaf,
+            expr.into(),
+        )?)
+    }
+
+    /// Replace the field at `path` with `new_field` (allowing rename + retype) and
+    /// substitute `new_expr` in its place.
+    ///
+    /// The path's leaf and `new_field.name()` may differ (rename) or match (in-place
+    /// retype). Errors if `path` doesn't resolve, if its parent isn't a struct, or if a
+    /// rename would collide with an existing sibling. `path` accepts any
+    /// [`IntoColumnName`] value.
+    pub fn replace_col(
+        self,
+        path: impl IntoColumnName,
+        new_field: StructField,
+        new_expr: impl Into<ExpressionRef>,
+    ) -> Result<Self, DeltaError> {
+        self.apply_field_op(FieldOp::replace(
+            path.into_column_name(),
+            new_field,
+            new_expr.into(),
+        )?)
+    }
+
+    /// Remove the field at `path` from its parent struct.
+    ///
+    /// Errors if `path` doesn't resolve or if its parent isn't a struct. `path` accepts
+    /// any [`IntoColumnName`] value -- a `&str` for top-level fields, a tuple/array or
+    /// `column_name!` macro for nested paths.
+    pub fn drop_col(self, path: impl IntoColumnName) -> Result<Self, DeltaError> {
+        self.apply_field_op(FieldOp::drop_(path.into_column_name())?)
+    }
+
+    // === Load / aggregate / join / union =====================================
+
+    /// File-reader transform. Output schema is `node.file_schema` plus a field per
+    /// `passthrough_columns` entry (each field's type is taken from the input schema).
+    /// Computation is shared with the datafusion lowering path via
+    /// `schema_expr::field_op::load_output_schema`.
+    pub fn load(self, node: LoadNode) -> Result<Self, DeltaError> {
+        let input_schema = self.schema()?;
+        let output_schema =
+            load_output_schema(&node.file_schema, &node.passthrough_columns, &input_schema)?;
+        self.push_unary(NodeKind::Load(node), output_schema)
+    }
+
+    /// Top-1-per-group aggregate ordered by `version` descending. The group-by expressions
+    /// and the version column are aggregation-internal: the output projects only the
+    /// listed `value_columns`, lifted from the input schema in declared order.
+    ///
+    /// The validator ensures every name in `value_columns` resolves in the input.
+    /// Group-by expressions and `version` are type-checked against the input schema
+    /// (well-formedness + column-ref resolution) via
+    /// [`schema_expr::check::validate_exprs`]; their inferred types are discarded
+    /// since they do not contribute to the output.
+    ///
+    /// [`schema_expr::check::validate_exprs`]: crate::plans::schema_expr::check::validate_exprs
+    pub fn max_by_version(
+        self,
+        group_by: impl IntoIterator<Item = impl Into<ExpressionRef>>,
+        version: impl Into<ExpressionRef>,
+        value_columns: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Result<Self, DeltaError> {
+        let group_by: Vec<ExpressionRef> = group_by.into_iter().map(Into::into).collect();
+        let version_column: ExpressionRef = version.into();
+        let value_columns: Vec<String> = value_columns.into_iter().map(Into::into).collect();
+        let input_schema = self.schema()?;
+        validate_exprs(
+            &input_schema,
+            group_by.iter().cloned().chain([version_column.clone()]),
+        )?;
+        let output_schema = narrow_schema_to(&input_schema, &value_columns, "max_by_version")?;
+        let node = MaxByVersionNode {
+            group_by,
+            version_column,
+            value_columns,
+        };
+        self.push_unary(NodeKind::MaxByVersion(node), output_schema)
+    }
+
+    /// Left-anti join: rows of `self` whose key matches no row of `other`. Output schema
+    /// mirrors `self`.
+    pub fn left_anti_join(
+        self,
+        other: PlanBuilder,
+        key_pairs: impl IntoIterator<Item = (impl Into<ExpressionRef>, impl Into<ExpressionRef>)>,
+    ) -> Result<Self, DeltaError> {
+        let key_pairs: Vec<(ExpressionRef, ExpressionRef)> = key_pairs
+            .into_iter()
+            .map(|(l, r)| (l.into(), r.into()))
+            .collect();
+        // Validate each key pair against its source schema up front. This is a hot path
+        // for reconciliation (one anti-join per FSR plan) so catching bad column refs at
+        // plan-build time avoids a confusing runtime error from the executor.
+        let left_schema = self.schema()?;
+        let right_schema = other.schema()?;
+        validate_exprs(&left_schema, key_pairs.iter().map(|(l, _)| l.clone()))?;
+        validate_exprs(&right_schema, key_pairs.iter().map(|(_, r)| r.clone()))?;
+        let output_schema = left_schema;
+        let node = EquiJoinNode {
+            kind: JoinKind::LeftAnti,
+            key_pairs,
+        };
+        self.push_nary(NodeKind::EquiJoin(node), &[&other], output_schema)
+    }
+
+    /// Unordered union with one or more other cursors. All inputs must share the same
+    /// schema (strict equality).
+    pub fn union_all(self, others: &[PlanBuilder]) -> Result<Self, DeltaError> {
+        self.union(others, false)
+    }
+
+    /// Order-preserving union with one or more other cursors. All inputs must share the
+    /// same schema.
+    pub fn union_ordered(self, others: &[PlanBuilder]) -> Result<Self, DeltaError> {
+        self.union(others, true)
+    }
+
+    /// Shared body: validate per-input schema equality, then push `NodeKind::Union`.
+    fn union(self, others: &[PlanBuilder], ordered: bool) -> Result<Self, DeltaError> {
+        let first_schema = self.schema()?;
+        for o in others {
+            if o.schema()? != first_schema {
+                return Err(pb_err!("union: input schemas disagree").into());
+            }
+        }
+        let others_refs: Vec<&PlanBuilder> = others.iter().collect();
+        self.push_nary(
+            NodeKind::Union(UnionNode { ordered }),
+            &others_refs,
+            first_schema,
+        )
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use std::any::Any;
+
+    use rstest::rstest;
+
+    use super::*;
+    use crate::expressions::{col, lit, Expression, Predicate};
+    use crate::plans::ir::plan::JoinKind;
+    use crate::plans::kernel_reducers::{
+        FinishedHandle, KdfControl, KernelReducerKind, KernelReducerOutput,
+    };
+    use crate::plans::state_machines::framework::coroutine::CoroutineSM;
+    use crate::plans::state_machines::framework::state_machine::{
+        EngineResponse, NextStep, StateMachine,
+    };
+    use crate::schema::{DataType, StructType};
+    use crate::{DeltaResult, EngineData};
+
+    #[derive(Debug, Clone, Copy)]
+    enum FieldOpRejectCase {
+        InsertAfterMissingSibling,
+        InsertAfterNameCollision,
+        ReplaceColMissingPath,
+        DropColMissingPath,
+        SelectMissingField,
+        MaxByVersionUnknownValueColumn,
+    }
+
+    /// Type-annotated empty rows literal for `Context::values` in tests that exercise
+    /// builder shape only (and don't care about row data). Avoids the
+    /// generic-inference failure of bare `vec![]` against `values`'s `impl IntoIterator`
+    /// signature.
+    fn no_rows() -> Vec<Vec<Scalar>> {
+        vec![]
+    }
+
+    fn id_ts_schema() -> SchemaRef {
+        Arc::new(
+            StructType::try_new(vec![
+                StructField::nullable("id", DataType::STRING),
+                StructField::nullable("ts", DataType::LONG),
+            ])
+            .unwrap(),
+        )
+    }
+
+    /// Sources mint sequential Refs with the declared output schema.
+    #[test]
+    fn sources_mint_refs_and_record_schemas() {
+        let ctx = Context::new();
+        let v = ctx.values(id_ts_schema(), no_rows()).unwrap();
+        let j = ctx.scan_json(vec![], id_ts_schema()).unwrap();
+        let p = ctx.scan_parquet(vec![], id_ts_schema()).unwrap();
+        assert_eq!(v.ref_id(), Ref(0));
+        assert_eq!(j.ref_id(), Ref(1));
+        assert_eq!(p.ref_id(), Ref(2));
+        assert_eq!(*v.schema().unwrap(), *id_ts_schema());
+    }
+
+    /// `into_result_plan` runs DCE and returns ResultPlan with the surviving stmts.
+    #[test]
+    fn into_result_plan_runs_dce() {
+        let ctx = Context::new();
+        let src = ctx.values(id_ts_schema(), no_rows()).unwrap();
+        let dead = ctx.values(id_ts_schema(), no_rows()).unwrap(); // unreachable
+        let kept = src.filter(col("id").is_not_null()).unwrap();
+        // Drop the dead branch handle so try_unwrap works and DCE removes it.
+        drop(dead);
+        let result_plan = ctx.into_result_plan(kept).unwrap();
+        let outputs: Vec<u32> = result_plan.plan.stmts.iter().map(|s| s.output.0).collect();
+        assert_eq!(outputs, vec![0, 2]); // src=0 + filter=2; dead values=1 dropped
+        assert_eq!(result_plan.result, Ref(2));
+    }
+
+    /// Filter passes through schema unchanged.
+    #[test]
+    fn filter_preserves_schema() {
+        let ctx = Context::new();
+        let src = ctx.values(id_ts_schema(), no_rows()).unwrap();
+        let f = src.filter(Arc::new(Predicate::column(["id"]))).unwrap();
+        assert_eq!(*f.schema().unwrap(), *id_ts_schema());
+    }
+
+    /// `project` derives output schema from inferred expression types.
+    #[test]
+    fn project_infers_output_schema() {
+        let ctx = Context::new();
+        let src = ctx.values(id_ts_schema(), no_rows()).unwrap();
+        let projected = src
+            .project([("id_out", col("id")), ("ts_out", col("ts"))])
+            .unwrap();
+        let schema = projected.schema().unwrap();
+        let names: Vec<&str> = schema.fields().map(|f| f.name().as_str()).collect();
+        assert_eq!(names, ["id_out", "ts_out"]);
+        assert_eq!(
+            schema.field("id_out").unwrap().data_type(),
+            &DataType::STRING
+        );
+        assert_eq!(schema.field("ts_out").unwrap().data_type(), &DataType::LONG);
+    }
+
+    /// `project_with_schema` honors the caller-supplied output schema and reports a
+    /// length mismatch when exprs vs fields disagree.
+    #[test]
+    fn project_with_schema_validates_length_and_uses_caller_schema() {
+        let ctx = Context::new();
+        let src = ctx.values(id_ts_schema(), no_rows()).unwrap();
+
+        let target = Arc::new(
+            StructType::try_new(vec![StructField::nullable("only", DataType::STRING)]).unwrap(),
+        );
+        let p = src
+            .clone()
+            .project_with_schema([col("id")], Arc::clone(&target))
+            .unwrap();
+        assert_eq!(*p.schema().unwrap(), *target);
+
+        let err = src
+            .project_with_schema([col("id"), col("ts")], target)
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("projection arity mismatch"),
+            "got: {err}"
+        );
+    }
+
+    // === Point-edit primitives over nested paths ============================
+
+    /// Schema with an `add` struct, used to exercise nested point-edits.
+    fn nested_add_schema() -> SchemaRef {
+        let add = StructType::try_new(vec![
+            StructField::nullable("path", DataType::STRING),
+            StructField::nullable("stats", DataType::STRING),
+        ])
+        .unwrap();
+        Arc::new(
+            StructType::try_new(vec![
+                StructField::nullable("commitInfo", DataType::STRING),
+                StructField::nullable("add", add),
+                StructField::nullable("remove", DataType::STRING),
+            ])
+            .unwrap(),
+        )
+    }
+
+    /// Top-level `insert_col_after` keeps existing fields and appends the new leaf
+    /// immediately after the sibling.
+    #[test]
+    fn insert_col_after_top_level_inserts_after_sibling() {
+        let ctx = Context::new();
+        let src = ctx.values(id_ts_schema(), no_rows()).unwrap();
+        let out = src
+            .insert_col_after(
+                "id",
+                StructField::nullable("mid", DataType::LONG),
+                col("ts"),
+            )
+            .unwrap();
+        let schema = out.schema().unwrap();
+        let names: Vec<&str> = schema.fields().map(|f| f.name().as_str()).collect();
+        assert_eq!(names, ["id", "mid", "ts"]);
+        assert_eq!(schema.field("mid").unwrap().data_type(), &DataType::LONG);
+    }
+
+    /// `insert_col_after` walks into a nested struct and inserts `add.stats_parsed`
+    /// after `add.stats`. The expression is a `Struct` whose output type the builder
+    /// derives bidirectionally from `parsed_field.data_type()`.
+    #[test]
+    fn insert_col_after_nested_inserts_in_parent_struct() {
+        let ctx = Context::new();
+        let src = ctx.values(nested_add_schema(), no_rows()).unwrap();
+        let stats_struct =
+            StructType::try_new(vec![StructField::nullable("numRecords", DataType::LONG)]).unwrap();
+        let parsed_field = StructField::nullable("stats_parsed", stats_struct.clone());
+        let parsed_expr = Expression::struct_from([lit(0i64)]);
+        let out = src
+            .insert_col_after(["add", "stats"], parsed_field, parsed_expr)
+            .unwrap();
+        let schema = out.schema().unwrap();
+        let DataType::Struct(add) = schema.field("add").unwrap().data_type() else {
+            panic!("expected struct");
+        };
+        let names: Vec<&str> = add.fields().map(|f| f.name().as_str()).collect();
+        assert_eq!(names, ["path", "stats", "stats_parsed"]);
+        assert_eq!(
+            add.field("stats_parsed").unwrap().data_type(),
+            &DataType::from(stats_struct),
+        );
+    }
+
+    /// `insert_col_after` errors when the sibling does not exist at the requested path,
+    /// when the new leaf collides with an existing sibling, when `replace_col` / `drop_col`
+    /// paths do not resolve, when `select` targets a missing field, or when
+    /// `max_by_version` lists an unknown value column.
+    #[rstest]
+    #[case::insert_after_missing_sibling(FieldOpRejectCase::InsertAfterMissingSibling, "missing")]
+    #[case::insert_after_name_collision(
+        FieldOpRejectCase::InsertAfterNameCollision,
+        "already exists"
+    )]
+    #[case::replace_col_missing_path(FieldOpRejectCase::ReplaceColMissingPath, "missing")]
+    #[case::drop_col_missing_path(FieldOpRejectCase::DropColMissingPath, "missing")]
+    #[case::select_missing_field(FieldOpRejectCase::SelectMissingField, "missing")]
+    #[case::max_by_version_unknown_value_column(
+        FieldOpRejectCase::MaxByVersionUnknownValueColumn,
+        "missing"
+    )]
+    fn field_op_rejects_invalid(#[case] case: FieldOpRejectCase, #[case] needle: &str) {
+        let ctx = Context::new();
+        let err = match case {
+            FieldOpRejectCase::InsertAfterMissingSibling => {
+                let src = ctx.values(nested_add_schema(), no_rows()).unwrap();
+                src.insert_col_after(
+                    ["add", "missing"],
+                    StructField::nullable("x", DataType::LONG),
+                    lit(0i64),
+                )
+                .unwrap_err()
+            }
+            FieldOpRejectCase::InsertAfterNameCollision => {
+                let src = ctx.values(id_ts_schema(), no_rows()).unwrap();
+                src.insert_col_after("id", StructField::nullable("ts", DataType::LONG), lit(0i64))
+                    .unwrap_err()
+            }
+            FieldOpRejectCase::ReplaceColMissingPath => {
+                let src = ctx.values(nested_add_schema(), no_rows()).unwrap();
+                src.replace_col(
+                    ["add", "missing"],
+                    StructField::nullable("missing", DataType::STRING),
+                    col(["add", "path"]),
+                )
+                .unwrap_err()
+            }
+            FieldOpRejectCase::DropColMissingPath => {
+                let src = ctx.values(id_ts_schema(), no_rows()).unwrap();
+                src.drop_col("missing").unwrap_err()
+            }
+            FieldOpRejectCase::SelectMissingField => {
+                let src = ctx.values(id_ts_schema(), no_rows()).unwrap();
+                let target = Arc::new(
+                    StructType::try_new(vec![StructField::nullable("missing", DataType::STRING)])
+                        .unwrap(),
+                );
+                src.select(target).unwrap_err()
+            }
+            FieldOpRejectCase::MaxByVersionUnknownValueColumn => {
+                let src = ctx.values(id_ts_schema(), no_rows()).unwrap();
+                src.max_by_version([col("id")], col("ts"), ["missing"])
+                    .unwrap_err()
+            }
+        };
+        assert!(err.to_string().contains(needle), "got: {err}");
+    }
+
+    /// `replace_col` retypes a field in place when the new field's name matches.
+    #[test]
+    fn replace_col_in_place_retypes_field() {
+        let ctx = Context::new();
+        let src = ctx.values(id_ts_schema(), no_rows()).unwrap();
+        let out = src
+            .replace_col(
+                "ts",
+                StructField::nullable("ts", DataType::STRING),
+                col("id"),
+            )
+            .unwrap();
+        let schema = out.schema().unwrap();
+        let names: Vec<&str> = schema.fields().map(|f| f.name().as_str()).collect();
+        assert_eq!(names, ["id", "ts"]);
+        assert_eq!(schema.field("ts").unwrap().data_type(), &DataType::STRING);
+    }
+
+    /// `replace_col` with a nested path renames + retypes a child field, walking the
+    /// parent struct with `col(...)` references for unchanged siblings.
+    #[test]
+    fn replace_col_nested_renames_and_retypes() {
+        let ctx = Context::new();
+        let src = ctx.values(nested_add_schema(), no_rows()).unwrap();
+        let stats_struct =
+            StructType::try_new(vec![StructField::nullable("numRecords", DataType::LONG)]).unwrap();
+        let new_field = StructField::nullable("stats_parsed", stats_struct.clone());
+        let new_expr = Expression::struct_from([lit(0i64)]);
+        let out = src
+            .replace_col(["add", "stats"], new_field, new_expr)
+            .unwrap();
+        let schema = out.schema().unwrap();
+        let DataType::Struct(add) = schema.field("add").unwrap().data_type() else {
+            panic!("expected struct");
+        };
+        let names: Vec<&str> = add.fields().map(|f| f.name().as_str()).collect();
+        assert_eq!(names, ["path", "stats_parsed"]);
+        assert_eq!(
+            add.field("stats_parsed").unwrap().data_type(),
+            &DataType::from(stats_struct),
+        );
+    }
+
+    /// `drop_col` removes a top-level field.
+    #[test]
+    fn drop_col_top_level_removes_field() {
+        let ctx = Context::new();
+        let src = ctx.values(id_ts_schema(), no_rows()).unwrap();
+        let out = src.drop_col("ts").unwrap();
+        let schema = out.schema().unwrap();
+        let names: Vec<&str> = schema.fields().map(|f| f.name().as_str()).collect();
+        assert_eq!(names, ["id"]);
+    }
+
+    /// `left_anti_join` output schema mirrors the left input.
+    #[test]
+    fn left_anti_join_output_mirrors_left() {
+        let ctx = Context::new();
+        let l = ctx.values(id_ts_schema(), no_rows()).unwrap();
+        let r_schema = Arc::new(
+            StructType::try_new(vec![
+                StructField::nullable("rid", DataType::STRING),
+                StructField::nullable("rts", DataType::LONG),
+            ])
+            .unwrap(),
+        );
+        let r = ctx.values(r_schema, no_rows()).unwrap();
+
+        let anti = l.left_anti_join(r, [(col("id"), col("rid"))]).unwrap();
+        assert_eq!(*anti.schema().unwrap(), *id_ts_schema());
+    }
+
+    /// `union_all` validates all input schemas match.
+    #[test]
+    fn union_all_requires_matching_schemas() {
+        let ctx = Context::new();
+        let a = ctx.values(id_ts_schema(), no_rows()).unwrap();
+        let b = ctx.values(id_ts_schema(), no_rows()).unwrap();
+        let unioned = a.clone().union_all(&[b]).unwrap();
+        assert_eq!(*unioned.schema().unwrap(), *id_ts_schema());
+
+        let other_schema = Arc::new(
+            StructType::try_new(vec![StructField::nullable("x", DataType::STRING)]).unwrap(),
+        );
+        let bad = ctx.values(other_schema, no_rows()).unwrap();
+        let err = a.union_all(&[bad]).unwrap_err();
+        assert!(err.to_string().contains("disagree"), "got: {err}");
+    }
+
+    /// Cursors from different contexts cannot be combined.
+    #[test]
+    fn cross_context_cursors_rejected() {
+        let ctx_a = Context::new();
+        let ctx_b = Context::new();
+        let a = ctx_a.values(id_ts_schema(), no_rows()).unwrap();
+        let b = ctx_b.values(id_ts_schema(), no_rows()).unwrap();
+        let err = a.left_anti_join(b, [(col("id"), col("id"))]).unwrap_err();
+        assert!(err.to_string().contains("different context"), "got: {err}");
+    }
+
+    /// `into_result_plan` fails when other cursors still hold the state Rc.
+    #[test]
+    fn into_result_plan_fails_with_outstanding_cursor() {
+        let ctx = Context::new();
+        let src = ctx.values(id_ts_schema(), no_rows()).unwrap();
+        let _other = ctx.values(id_ts_schema(), no_rows()).unwrap();
+        let err = ctx.into_result_plan(src).unwrap_err();
+        assert!(
+            err.to_string().contains("outstanding PlanBuilder"),
+            "got: {err}",
+        );
+    }
+
+    /// `max_by_version` output schema is exactly `value_columns` lifted from the input
+    /// (group_by exprs and version are aggregation-internal and not surfaced).
+    #[test]
+    fn max_by_version_output_schema_is_value_columns_only() {
+        let ctx = Context::new();
+        let src = ctx.values(id_ts_schema(), no_rows()).unwrap();
+        let out = src.max_by_version([col("id")], col("ts"), ["ts"]).unwrap();
+        let schema = out.schema().unwrap();
+        let names: Vec<&str> = schema.fields().map(|f| f.name().as_str()).collect();
+        assert_eq!(names, ["ts"]);
+        assert_eq!(schema.field("ts").unwrap().data_type(), &DataType::LONG);
+    }
+
+    // === CoroutineSM dispatch tests ============================================
+
+    /// Test KernelReducer that echoes its constructor input as the output value.
+    #[derive(Debug, Clone)]
+    struct EchoReducer {
+        value: i64,
+    }
+
+    impl KernelReducer for EchoReducer {
+        fn kind(&self) -> KernelReducerKind {
+            KernelReducerKind::CheckpointHint
+        }
+        fn finish(self: Box<Self>) -> Box<dyn Any + Send> {
+            Box::new(*self)
+        }
+        fn apply(&mut self, _batch: &dyn EngineData) -> DeltaResult<KdfControl> {
+            Ok(KdfControl::Break)
+        }
+    }
+
+    impl KernelReducerOutput for EchoReducer {
+        type Output = i64;
+        fn into_output(self) -> Result<i64, DeltaError> {
+            Ok(self.value)
+        }
+    }
+
+    /// `reduce` yields a `EngineRequest::Reduce` with the DCE'd stmts and the builder's terminal
+    /// Ref, the engine resumes with the reducer's finished handle, and the SM body
+    /// recovers the typed output.
+    #[test]
+    fn reduce_yields_step_reduce_and_recovers_typed_output() {
+        let mut sm = CoroutineSM::<i64>::new("test", |mut engine, _sm_id| async move {
+            let ctx = Context::new();
+            let _dead = ctx.values(id_ts_schema(), no_rows()).unwrap();
+            let builder = ctx
+                .values(id_ts_schema(), no_rows())
+                .unwrap()
+                .filter(Arc::new(col("id").is_not_null()))
+                .unwrap();
+            ctx.reduce(&mut engine, builder, EchoReducer { value: 7 }, "drain")
+                .await
+        })
+        .unwrap();
+
+        // First yielded step is the Reduce.
+        assert_eq!(sm.step_name(), "drain");
+        let token = match sm.get_step().unwrap() {
+            EngineRequest::Reduce {
+                stmts,
+                terminal,
+                sink,
+            } => {
+                // DCE: only `values(reachable)` and `filter` remain; `_dead` is dropped.
+                let outputs: Vec<u32> = stmts.iter().map(|s| s.output.0).collect();
+                assert_eq!(outputs, vec![1, 2]);
+                assert_eq!(terminal, Ref(2));
+                sink.token.clone()
+            }
+            other => panic!("expected EngineRequest::Reduce, got {other:?}"),
+        };
+
+        // Engine drains the sink and resumes with a finished handle.
+        let payload = EngineResponse::Reducer(FinishedHandle {
+            token,
+            erased: Box::new(EchoReducer { value: 7 }),
+        });
+        let next = sm.submit(Ok(payload)).unwrap();
+        match next {
+            NextStep::Done(v) => assert_eq!(v, 7),
+            _ => panic!("expected Done"),
+        }
+        assert!(sm.is_done());
+    }
+
+    /// `Context::reduce` resets the Ref counter so the next source minted after
+    /// the reduce boundary starts at `Ref(0)` again. The full plan ships to the
+    /// engine and the session-id bump invalidates any held cursors, so reusing
+    /// Ref ids across the boundary is safe and keeps post-reduce Refs compact.
+    #[test]
+    fn reduce_resets_ref_counter() {
+        let mut sm = CoroutineSM::<u32>::new("test", |mut engine, _sm_id| async move {
+            let ctx = Context::new();
+            let v0 = ctx.values(id_ts_schema(), no_rows()).unwrap();
+            let v1 = v0.filter(Arc::new(col("id").is_not_null())).unwrap();
+            assert_eq!(v1.ref_id(), Ref(1));
+            let _: i64 = ctx
+                .reduce(&mut engine, v1, EchoReducer { value: 0 }, "drain")
+                .await?;
+            let post = ctx.values(id_ts_schema(), no_rows()).unwrap();
+            Ok(post.ref_id().0)
+        })
+        .unwrap();
+
+        let token = match sm.get_step().unwrap() {
+            EngineRequest::Reduce { sink, .. } => sink.token.clone(),
+            other => panic!("expected EngineRequest::Reduce, got {other:?}"),
+        };
+        let payload = EngineResponse::Reducer(FinishedHandle {
+            token,
+            erased: Box::new(EchoReducer { value: 0 }),
+        });
+        match sm.submit(Ok(payload)).unwrap() {
+            NextStep::Done(v) => assert_eq!(v, 0, "post-reduce Ref must be 0"),
+            other => panic!("expected Done, got {other:?}"),
+        }
+    }
+
+    /// Resuming a `EngineRequest::Reduce` with a non-Reducer payload surfaces an internal
+    /// error -- the executor produced a payload that doesn't match the yielded step.
+    #[test]
+    fn reduce_resume_with_wrong_payload_variant_errors() {
+        let mut sm = CoroutineSM::<i64>::new("test", |mut engine, _sm_id| async move {
+            let ctx = Context::new();
+            let builder = ctx.values(id_ts_schema(), no_rows()).unwrap();
+            ctx.reduce(&mut engine, builder, EchoReducer { value: 1 }, "drain")
+                .await
+        })
+        .unwrap();
+        let _ = sm.get_step().unwrap();
+        let err = sm
+            .submit(Ok(EngineResponse::Schema(id_ts_schema())))
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("non-Reducer payload"),
+            "got: {err}",
+        );
+    }
+
+    /// `schema_query` yields a `EngineRequest::SchemaQuery`, the engine resumes with a schema,
+    /// and the SM body receives it.
+    #[test]
+    fn schema_query_yields_step_schemaquery_and_returns_schema() {
+        let target_schema = id_ts_schema();
+        let target_clone = Arc::clone(&target_schema);
+        let mut sm = CoroutineSM::<bool>::new("test", move |mut engine, _sm_id| async move {
+            let ctx = Context::new();
+            let s = ctx
+                .schema_query(&mut engine, "/cp.parquet", "footer")
+                .await?;
+            Ok(s == target_clone)
+        })
+        .unwrap();
+
+        assert_eq!(sm.step_name(), "footer");
+        match sm.get_step().unwrap() {
+            EngineRequest::SchemaQuery(node) => assert_eq!(node.file_path, "/cp.parquet"),
+            other => panic!("expected SchemaQuery, got {other:?}"),
+        }
+
+        match sm
+            .submit(Ok(EngineResponse::Schema(target_schema)))
+            .unwrap()
+        {
+            NextStep::Done(v) => assert!(v),
+            _ => panic!("expected Done(true)"),
+        }
+    }
+
+    /// Resuming a `EngineRequest::SchemaQuery` with a non-Schema payload surfaces an internal
+    /// error -- the executor produced a payload that doesn't match the yielded step.
+    #[test]
+    fn schema_query_resume_with_wrong_payload_variant_errors() {
+        let mut sm = CoroutineSM::<()>::new("test", move |mut engine, _sm_id| async move {
+            let ctx = Context::new();
+            let _ = ctx
+                .schema_query(&mut engine, "/x.parquet", "footer")
+                .await?;
+            Ok(())
+        })
+        .unwrap();
+        let _ = sm.get_step().unwrap();
+        let err = sm.submit(Ok(EngineResponse::Empty)).unwrap_err();
+        assert!(err.to_string().contains("non-Schema payload"), "got: {err}",);
+    }
+
+    /// After `schema_query` bumps the session, cursors built before the dispatch are
+    /// stale and operations on them fail.
+    #[test]
+    fn schema_query_invalidates_pre_dispatch_cursors() {
+        let target_schema = id_ts_schema();
+        let mut sm = CoroutineSM::<()>::new("test", move |mut engine, _sm_id| async move {
+            let ctx = Context::new();
+            let pre = ctx.values(id_ts_schema(), no_rows()).unwrap();
+            let _ = ctx
+                .schema_query(&mut engine, "/x.parquet", "footer")
+                .await?;
+            // Using `pre` after dispatch must fail with a stale-builder error.
+            let err = pre.filter(Arc::new(Predicate::column(["id"]))).unwrap_err();
+            assert!(err.to_string().contains("stale builder"), "got: {err}");
+            Ok(())
+        })
+        .unwrap();
+
+        // Drive through the schema_query yield.
+        let _ = sm.get_step().unwrap();
+        match sm
+            .submit(Ok(EngineResponse::Schema(target_schema)))
+            .unwrap()
+        {
+            NextStep::Done(()) => {}
+            _ => panic!("expected Done"),
+        }
+    }
+
+    /// Plan stmt for `left_anti_join` records `[left, right]` as inputs in that order.
+    #[test]
+    fn left_anti_join_records_left_right_inputs() {
+        let ctx = Context::new();
+        let left = ctx.values(id_ts_schema(), no_rows()).unwrap();
+        let right_schema = Arc::new(
+            StructType::try_new(vec![
+                StructField::nullable("rid", DataType::STRING),
+                StructField::nullable("rts", DataType::LONG),
+            ])
+            .unwrap(),
+        );
+        let right = ctx.values(right_schema, no_rows()).unwrap();
+        let left_ref = left.ref_id();
+        let right_ref = right.ref_id();
+        let key: Vec<(ExpressionRef, ExpressionRef)> =
+            vec![(Arc::new(col("id")), Arc::new(col("rid")))];
+        let joined = left.left_anti_join(right, key).unwrap();
+        let joined_ref = joined.ref_id();
+        let plan = ctx.into_result_plan(joined).unwrap();
+        let stmt = plan.plan.node(joined_ref).unwrap();
+        assert_eq!(stmt.inputs, vec![left_ref, right_ref]);
+        assert!(matches!(
+            stmt.kind,
+            NodeKind::EquiJoin(EquiJoinNode {
+                kind: JoinKind::LeftAnti,
+                ..
+            })
+        ));
+    }
+}

--- a/kernel/src/plans/state_machines/framework/state_machine.rs
+++ b/kernel/src/plans/state_machines/framework/state_machine.rs
@@ -1,0 +1,171 @@
+//! The [`StateMachine`] trait kernel SMs implement and engine-side executors drive, along
+//! with the [`EngineRequest`] / [`EngineResponse`] protocol they exchange each tick.
+//!
+//! Engines drive every SM through the same three methods: ask for the next step's work,
+//! execute it, hand back the outcome. The SM decides whether to continue to another step
+//! or terminate with a typed result.
+//!
+//! ```text
+//! loop {
+//!     let op = sm.get_step()?;
+//!     let result = executor.execute(op);
+//!     match sm.submit(result)? {
+//!         NextStep::Continue => continue,
+//!         NextStep::Done(r) => return Ok(r),
+//!     }
+//! }
+//! ```
+//!
+//! The [`EngineRequest`] / [`EngineResponse`] pair is the *protocol*: each request variant
+//! maps to exactly one response variant on resume:
+//!
+//! - [`EngineRequest::Reduce`] -> [`EngineResponse::Reducer`]
+//! - [`EngineRequest::SchemaQuery`] -> [`EngineResponse::Schema`]
+//!
+//! [`EngineResponse::Empty`] is a driver-internal priming sentinel SM bodies never observe.
+
+use super::engine_error::EngineError;
+use crate::plans::errors::DeltaError;
+#[cfg(doc)]
+use crate::plans::errors::DeltaErrorCode;
+use crate::plans::ir::nodes::ReduceSink;
+use crate::plans::ir::plan::{PlanNode, RefId};
+use crate::plans::kernel_reducers::FinishedHandle;
+use crate::schema::SchemaRef;
+
+// ============================================================================
+// Engine request: kernel -> engine, the "do this work" envelope
+// ============================================================================
+
+/// A metadata-only read: ask the engine to open a parquet file, read its schema from the
+/// footer, and deliver it back as [`EngineResponse::Schema`].
+///
+/// Distinct from a data-carrying [`EngineRequest::Reduce`]: no row stream, no sink, no
+/// KDF-producing pipeline -- the executor just does a footer read.
+#[derive(Debug, Clone)]
+pub struct SchemaQuery {
+    /// Path to the parquet file whose schema the kernel wants.
+    pub file_path: String,
+}
+
+impl SchemaQuery {
+    /// Construct a schema query for `file_path`.
+    pub fn new(file_path: impl Into<String>) -> Self {
+        Self {
+            file_path: file_path.into(),
+        }
+    }
+}
+
+/// What [`StateMachine::get_step`] hands to the executor.
+///
+/// Separates the concerns the executor understands:
+///
+/// - [`SchemaQuery`](Self::SchemaQuery) -- metadata-only footer read.
+/// - [`Reduce`](Self::Reduce) -- plan dataflow drained into a [`ReduceSink`]. The engine compiles
+///   `stmts` (a flat plan), runs the DAG, and feeds the rows produced at `terminal` into `sink`.
+///   The reducer's typed output flows back as [`EngineResponse::Reducer`] carrying the
+///   `FinishedHandle`, and the SM body recovers the typed value via the paired `Extractor`.
+#[derive(Debug, Clone)]
+pub enum EngineRequest {
+    /// Read a file's schema without reading data.
+    SchemaQuery(SchemaQuery),
+    /// Plan dataflow + reducer drain. The engine evaluates `stmts` as a DAG and pipes the
+    /// stream produced at `terminal` into `sink`.
+    Reduce {
+        stmts: Vec<PlanNode>,
+        terminal: RefId,
+        sink: ReduceSink,
+    },
+}
+
+// ============================================================================
+// Engine response: engine -> kernel, the success payload returned on resume
+// ============================================================================
+
+/// Engine -> SM success payload for a single phase yield.
+///
+/// Travels through [`StateMachine::submit`] on the success arm. Variant mismatches
+/// (executor returned the wrong shape for the preceding yield) surface as internal errors
+/// in the `Context` dispatch helpers (added under `plans::state_machines::framework`).
+#[derive(Debug)]
+pub enum EngineResponse {
+    /// A [`EngineRequest::Reduce`] finished and is handing back its drained reducer state.
+    Reducer(FinishedHandle),
+    /// A [`EngineRequest::SchemaQuery`] finished and is handing back the resolved schema.
+    Schema(SchemaRef),
+    /// Driver-internal sentinel for the genawaiter trampoline's first `resume_with` (the
+    /// one that runs the producer up to its first await). SM bodies never observe this
+    /// variant: a yield always precedes any awaited resume, and zero-yield SMs terminate
+    /// before inspecting the priming value.
+    Empty,
+}
+
+// ============================================================================
+// StateMachine trait: the contract the executor drives
+// ============================================================================
+
+/// Result of submitting a step result to a state machine.
+#[derive(Debug)]
+pub enum NextStep<R> {
+    /// SM advanced to the next step; the driver should loop back to
+    /// [`StateMachine::get_step`].
+    Continue,
+    /// SM completed with the given result. The driver must stop.
+    Done(R),
+}
+
+/// The contract kernel state machines implement and engine-side executors drive.
+///
+/// Each SM-visible "step" is one tick of this loop: the executor asks
+/// [`StateMachine::get_step`] for what to run, executes it, then calls
+/// [`StateMachine::submit`] with the outcome ([`EngineResponse`] on success, an
+/// [`EngineError`] on engine failure).
+///
+/// # Error layering
+///
+/// Both `get_step` and `submit` return [`DeltaError`] -- the typed,
+/// template-parameterized kernel error surface. Engine failures arrive via the
+/// `Err(EngineError)` arm of `submit`'s input; the SM chooses whether to lift them into
+/// its own terminal result or propagate them as a [`DeltaError`].
+pub trait StateMachine {
+    /// What the SM returns when it finishes.
+    type Result;
+
+    /// Return the next step's work.
+    ///
+    /// Takes `&mut self` so the SM can lazily construct plans and move internal state.
+    ///
+    /// Returns `Err(DeltaError)` for unrecoverable kernel bugs hit while *building* the
+    /// next step (plan construction can fail on e.g. a malformed schema projection). These
+    /// are typically tagged [`DeltaErrorCode::DeltaCommandInvariantViolation`].
+    fn get_step(&mut self) -> Result<EngineRequest, DeltaError>;
+
+    /// Receive the step outcome from the driver.
+    ///
+    /// - `Ok(EngineResponse)` -- the executor ran the step and produced its single typed payload (a
+    ///   finished reducer handle, a schema, or [`EngineResponse::Empty`] for the driver-internal
+    ///   priming case). The SM body destructures the variant matching its preceding yield; any
+    ///   other variant is an executor bug surfaced as an internal error.
+    /// - `Err(EngineError)` -- a typed engine-side failure; the SM matches on [`EngineError::kind`]
+    ///   and decides how to surface it.
+    fn submit(
+        &mut self,
+        result: Result<EngineResponse, EngineError>,
+    ) -> Result<NextStep<Self::Result>, DeltaError>;
+
+    /// Static label for logging / diagnostics. Drivers use this in span names and error
+    /// contexts; implementations return the currently-active step name, or `"done"`
+    /// once the SM has finished.
+    fn step_name(&self) -> &'static str;
+
+    /// Sorted snapshot of logical relation names currently registered with the SM at the
+    /// boundary of the most recent yield.
+    ///
+    /// Surfaces diagnostics / span context, parallel scheduling info, and cross-phase
+    /// relation tracking. Returns the empty vector for SMs that do not surface relations,
+    /// and for terminal states (after the SM completes).
+    fn live_relations(&self) -> Vec<String> {
+        Vec::new()
+    }
+}

--- a/kernel/src/plans/state_machines/mod.rs
+++ b/kernel/src/plans/state_machines/mod.rs
@@ -1,8 +1,10 @@
 //! State machines -- kernel-authored coroutine bodies that orchestrate plan execution.
 //!
-//! - [`framework`] -- the framework SMs are built on. Successive PRs flesh out the `StateMachine`
-//!   trait, the `CoroutineSM` driver, the typed `Context`/`EngineResponse` surface, and the
-//!   `Extractor<O>` typed adapter; this PR seeds it with the typed engine-side failure type
-//!   ([`framework::engine_error::EngineError`]).
+//! - [`framework`] -- the framework SMs are built on. Currently provides the typed engine-side
+//!   failure type ([`framework::engine_error::EngineError`]), the
+//!   [`framework::state_machine::StateMachine`] trait that the executor drives, and the
+//!   [`framework::coroutine::CoroutineSM`] driver that compiles `async fn` SM bodies into that
+//!   trait. The `Context` plan-construction surface lives in a sibling submodule added under the
+//!   same `declarative-plans` feature gate.
 
 pub mod framework;

--- a/kernel/src/plans/state_machines/mod.rs
+++ b/kernel/src/plans/state_machines/mod.rs
@@ -1,0 +1,8 @@
+//! State machines -- kernel-authored coroutine bodies that orchestrate plan execution.
+//!
+//! - [`framework`] -- the framework SMs are built on. Successive PRs flesh out the `StateMachine`
+//!   trait, the `CoroutineSM` driver, the typed `Context`/`EngineResponse` surface, and the
+//!   `Extractor<O>` typed adapter; this PR seeds it with the typed engine-side failure type
+//!   ([`framework::engine_error::EngineError`]).
+
+pub mod framework;

--- a/kernel/src/plans/state_machines/mod.rs
+++ b/kernel/src/plans/state_machines/mod.rs
@@ -1,10 +1,9 @@
 //! State machines -- kernel-authored coroutine bodies that orchestrate plan execution.
 //!
-//! - [`framework`] -- the framework SMs are built on. Currently provides the typed engine-side
-//!   failure type ([`framework::engine_error::EngineError`]), the
-//!   [`framework::state_machine::StateMachine`] trait that the executor drives, and the
-//!   [`framework::coroutine::CoroutineSM`] driver that compiles `async fn` SM bodies into that
-//!   trait. The `Context` plan-construction surface lives in a sibling submodule added under the
-//!   same `declarative-plans` feature gate.
+//! - [`framework`] -- the framework SMs are built on. Provides the typed engine-side failure type
+//!   ([`framework::engine_error::EngineError`]), the [`framework::state_machine::StateMachine`]
+//!   trait that the executor drives, the [`framework::coroutine::CoroutineSM`] driver that compiles
+//!   `async fn` SM bodies into that trait, and the [`framework::plan_context::Context`] /
+//!   [`framework::plan_context::PlanBuilder`] plan-construction surface.
 
 pub mod framework;


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2645/files/70458623c98684dd4286510aadbd393a9716b021..e19189d969cad8b0366575a53288aa6f05b1447f) to review incremental changes.
- [stack/c8](https://github.com/delta-io/delta-kernel-rs/pull/2629) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2629/files)]
  - [stack/c1](https://github.com/delta-io/delta-kernel-rs/pull/2641) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2641/files/dda3aaf0f3f5e62fde9d065dda05caf3488e50a6..71ec45d108c7bf7bcf52f87080f8fab8390afa38)]
    - [stack/c3](https://github.com/delta-io/delta-kernel-rs/pull/2642) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2642/files/71ec45d108c7bf7bcf52f87080f8fab8390afa38..bddc0b4418b69e29388d241fae97ba479c57defc)]
      - [stack/c5](https://github.com/delta-io/delta-kernel-rs/pull/2643) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2643/files/bddc0b4418b69e29388d241fae97ba479c57defc..eba0ab0291ec5f0fae1d076286d205da375c2f82)]
        - [stack/c2](https://github.com/delta-io/delta-kernel-rs/pull/2644) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2644/files/eba0ab0291ec5f0fae1d076286d205da375c2f82..70458623c98684dd4286510aadbd393a9716b021)]
          - [**stack/c6**](https://github.com/delta-io/delta-kernel-rs/pull/2645) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2645/files/70458623c98684dd4286510aadbd393a9716b021..e19189d969cad8b0366575a53288aa6f05b1447f)]
            - [stack/c7](https://github.com/delta-io/delta-kernel-rs/pull/2646) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2646/files/e19189d969cad8b0366575a53288aa6f05b1447f..19fb518e8f9f88fe8563b840f6c08a320527a7e9)]

---------
## What changes are proposed in this pull request?

The architectural core of the declarative-plans framework. Context owns the in-flight Plan over an Rc<RefCell<ContextState>>; PlanBuilder is a thin per-relation cursor that participates via Clone + Rc.

Public surface:
- Sources: list_files, scan_parquet, scan_json, values.
- Transforms: filter, project, project_with_schema, select, append_col_typed, insert_col_after, replace_col, drop_col, union_all, union_ordered, left_anti_join, max_by_version.
- Dispatch: load, reduce, schema_query (the kernel-side wrappers around CoroutineSM yields), into_result_plan (terminal).
- session_id stale-builder protection: a PlanBuilder minted in one session_id is rejected as stale by Context methods after the session advances. Catches caller bugs that pass an old builder through a coroutine yield boundary.
- DCE: into_result_plan walks Plan::reachable_from from the terminal Ref so dead branches do not leak into the engine plan.

The PR ships its dedicated test harness: RefCell-not-held-across-await, session_id rejection, and DCE prune-unreachable.

Heaviest single PR in the rollout; plan for two review passes.

== Stack position ==

Currently parented on stack/c2 in the c-chain (c4 -> c1 -> c3 -> c5 -> c2 -> c6). c6 has hard code-level dependencies on every ancestor in this chain:

- stack/c4 (basic plan IR): NodeKind, Plan, PlanNode, Ref, ResultPlan, EquiJoinNode, FilterNode, ListFilesNode, LoadNode, MaxByVersionNode, ProjectNode, ReduceSink, JoinKind.
- stack/c1 (DeltaError): DeltaError, DeltaErrorCode, DeltaResultExt::or_delta -- the error type for every public method.
- stack/c3 (kernel_reducers): KernelReducer, KernelReducerOutput, Extractor -- threaded through reduce dispatch.
- stack/c5 (StateMachine framework): CoroutineSM, Engine, StepYield, StepResume, EngineRequest, EngineResponse, SchemaQuery -- the driver-protocol Context::load/reduce/schema_query orchestrate.
- stack/c2 (schema_expr): check_projection, check_select, infer_projection_schema, validate_exprs, compile_field_op, load_output_schema, narrow_schema_to, FieldOp -- builder-time schema derivation for project/select/field-op transforms.

NOTE: c6 cannot parent directly on stack/c5 -- the project / select / field-op builders consume schema_expr (c2), so c2 must be in the ancestry. The current c5 -> c2 -> c6 ordering is the minimal valid chain.

== Depends on (cross-sub-chain, must land in main first) ==

Inherited transitively from stack/c2:

- stack/a1 (SchemaBuilder): StructType::with_struct_at on both &StructType and &Arc<StructType> receivers.
- stack/b1 (Expression::If + VariadicExpressionOp::Array): Expression::If, IfExpression, Expression::if_then_else, VariadicExpressionOp::Array, Expression::array.

Held back from publication until c2's cross-sub-chain parents land in main; once they do, `git stack sync` rebases this branch onto fresh main and `git stack push` publishes the PR.

## How was this change tested?
