### PR TITLE
test: parsed-stats integration test covering nested structs via table-builder

### DIFF
--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -78,6 +78,10 @@ pub(crate) const MAX_VALUES: &str = "maxValues";
 #[internal_api]
 pub(crate) const TIGHT_BOUNDS: &str = "tightBounds";
 
+/// Struct-encoded per-file statistics column (checkpoints with `writeStatsAsStruct=true`).
+#[internal_api]
+pub(crate) const STATS_PARSED: &str = "stats_parsed";
+
 static COMMIT_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
     Arc::new(StructType::new_unchecked([
         StructField::nullable(ADD_NAME, Add::to_schema()),

--- a/kernel/src/checkpoint/checkpoint_transform.rs
+++ b/kernel/src/checkpoint/checkpoint_transform.rs
@@ -15,14 +15,13 @@
 
 use std::sync::{Arc, LazyLock};
 
-use crate::actions::ADD_NAME;
+use crate::actions::{ADD_NAME, STATS_PARSED as STATS_PARSED_FIELD};
 use crate::expressions::{Expression, ExpressionRef, ExpressionStructPatch, UnaryExpressionOp};
 use crate::schema::{DataType, SchemaRef, StructField, StructType};
 use crate::table_properties::TableProperties;
 use crate::{DeltaResult, Error};
 
 pub(crate) const STATS_FIELD: &str = "stats";
-pub(crate) const STATS_PARSED_FIELD: &str = "stats_parsed";
 pub(crate) const PARTITION_VALUES_FIELD: &str = "partitionValues";
 pub(crate) const PARTITION_VALUES_PARSED_FIELD: &str = "partitionValues_parsed";
 

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use ::test_utils::get_column;
 use bytes::Bytes;
 use rstest::rstest;
 
@@ -30,18 +31,6 @@ use crate::{
     DeltaResultIteratorStatic, Engine, EngineData, EvaluationHandler, FileDataReadResultIterator,
     FileMeta, JsonHandler, ParquetFooter, ParquetHandler, PredicateRef, Snapshot, StorageHandler,
 };
-
-/// Helper macro to extract a typed column from a RecordBatch or StructArray.
-macro_rules! get_column {
-    ($source:expr, $name:expr, $ty:ty) => {
-        $source
-            .column_by_name($name)
-            .unwrap_or_else(|| panic!("should have column '{}'", $name))
-            .as_any()
-            .downcast_ref::<$ty>()
-            .unwrap_or_else(|| panic!("column '{}' should be {}", $name, stringify!($ty)))
-    };
-}
 
 fn field_names(s: &StructArray) -> Vec<String> {
     s.fields().iter().map(|f| f.name().clone()).collect()

--- a/kernel/tests/integration/main.rs
+++ b/kernel/tests/integration/main.rs
@@ -15,5 +15,6 @@ mod golden_tables;
 mod hdfs;
 mod log;
 mod metrics;
+mod parsed_stats;
 mod read;
 mod write;

--- a/kernel/tests/integration/parsed_stats.rs
+++ b/kernel/tests/integration/parsed_stats.rs
@@ -6,11 +6,11 @@ use delta_kernel::arrow::array::{
 };
 use delta_kernel::arrow::compute::filter_record_batch;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
-use delta_kernel::engine::default::DefaultEngineBuilder;
 use delta_kernel::scan::StatsOptions;
 use delta_kernel::table_features::ColumnMappingMode;
 use delta_kernel::Snapshot;
 use rstest::rstest;
+use test_utils::delta_kernel_default_engine::DefaultEngineBuilder;
 use test_utils::table_builder::{unpartitioned, version_latest, FeatureSet, LogState, TableConfig};
 use test_utils::{get_column, test_context};
 

--- a/kernel/tests/integration/parsed_stats.rs
+++ b/kernel/tests/integration/parsed_stats.rs
@@ -3,7 +3,7 @@
 //! Builds a table with `delta.checkpoint.writeStatsAsStruct=true` and a nested schema,
 //! then verifies the parsed-stats struct column matches the JSON `stats` string.
 
-use delta_kernel::actions::{MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS};
+use delta_kernel::actions::{MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS, STATS_PARSED};
 use delta_kernel::arrow::array::{
     Array, BooleanArray, Int64Array, RecordBatch, StringArray, StructArray,
 };
@@ -85,6 +85,7 @@ fn assert_stats_struct_matches_json(
 }
 
 /// Validate only nested-struct entries, not primitives.
+// TODO(#2673): also validate primitive stats.
 fn validate_struct_stats(
     parsed: &StructArray,
     json_obj: &serde_json::Map<String, serde_json::Value>,
@@ -110,8 +111,6 @@ fn scan_metadata_with_stats_columns_kernel_written(
     )]
     cm_mode: ColumnMappingMode,
 ) {
-    const STATS_PARSED_COL: &str = "stats_parsed";
-
     let cm_str = match cm_mode {
         ColumnMappingMode::None => "none",
         ColumnMappingMode::Id => "id",
@@ -153,7 +152,7 @@ fn scan_metadata_with_stats_columns_kernel_written(
         let filtered_batch =
             filter_record_batch(&batch, &BooleanArray::from(selection_vector)).unwrap();
 
-        let stats_parsed = get_column!(filtered_batch, STATS_PARSED_COL, StructArray);
+        let stats_parsed = get_column!(filtered_batch, STATS_PARSED, StructArray);
         let num_records = get_column!(stats_parsed, NUM_RECORDS, Int64Array);
         let min_values = get_column!(stats_parsed, MIN_VALUES, StructArray);
         let max_values = get_column!(stats_parsed, MAX_VALUES, StructArray);

--- a/kernel/tests/integration/parsed_stats.rs
+++ b/kernel/tests/integration/parsed_stats.rs
@@ -1,4 +1,4 @@
-//! Integration test for `Scan::include_all_stats_columns`.
+//! Integration test for `StatsOptions::all` parsed-stats output.
 //!
 //! Builds a table with `delta.checkpoint.writeStatsAsStruct=true` and a nested schema,
 //! then verifies the parsed-stats struct column matches the JSON `stats` string.
@@ -10,6 +10,7 @@ use delta_kernel::arrow::array::{
 use delta_kernel::arrow::compute::filter_record_batch;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::engine::default::DefaultEngineBuilder;
+use delta_kernel::scan::StatsOptions;
 use delta_kernel::table_features::ColumnMappingMode;
 use delta_kernel::Snapshot;
 use rstest::rstest;
@@ -126,7 +127,7 @@ fn scan_metadata_with_stats_columns_kernel_written(
 
     let scan = snapshot
         .scan_builder()
-        .include_all_stats_columns()
+        .with_stats(StatsOptions::all())
         .build()
         .unwrap();
 

--- a/kernel/tests/integration/parsed_stats.rs
+++ b/kernel/tests/integration/parsed_stats.rs
@@ -1,22 +1,13 @@
-//! Integration test for `Scan::include_all_stats_columns` across column-mapping modes.
+//! Integration test for `Scan::include_all_stats_columns`.
 //!
-//! Builds a table at runtime via the `test_utils` table-builder with
-//! `delta.checkpoint.writeStatsAsStruct=true` so the checkpoint carries `stats_parsed`,
-//! then verifies the parsed-stats struct column matches the JSON `stats` string row-by-row.
-//! The table-builder's `default_schema` includes a nested struct column, so each case
-//! exercises the recursive nested-stats path called out in issue #1766 (paths like
-//! `minValues.nested_col.a`).
-//!
-//! Complementary to the unit test `test_scan_metadata_with_stats_columns` in
-//! `kernel/src/scan/tests.rs`, which exercises a different code path: reading a
-//! pre-existing Spark-written checkpoint with `stats_parsed` already on disk.
+//! Builds a table with `delta.checkpoint.writeStatsAsStruct=true` and a nested schema,
+//! then verifies the parsed-stats struct column matches the JSON `stats` string.
 
 use delta_kernel::actions::{MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS};
 use delta_kernel::arrow::array::{
     Array, BooleanArray, Int64Array, RecordBatch, StringArray, StructArray,
 };
 use delta_kernel::arrow::compute::filter_record_batch;
-use delta_kernel::arrow::datatypes::DataType as ArrowDataType;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::engine::default::DefaultEngineBuilder;
 use delta_kernel::table_features::ColumnMappingMode;
@@ -27,9 +18,6 @@ use test_utils::{get_column, test_context};
 
 /// Validate that JSON stats object values match the corresponding parsed struct array.
 ///
-/// Recurses into nested struct sub-fields so paths like `minValues.info.age` are checked.
-/// `field_path` is the dotted path used in assertion messages at this recursion
-/// level (e.g. `"minValues"` at the top level; `"minValues.info.age"` when recursing).
 /// Panics on missing fields to surface regressions where the parsed-stats schema drops a column.
 fn assert_stats_struct_matches_json(
     struct_array: &StructArray,
@@ -97,7 +85,7 @@ fn assert_stats_struct_matches_json(
 }
 
 /// Validate only nested-struct entries, not primitives.
-fn validate_nested_columns(
+fn validate_struct_stats(
     parsed: &StructArray,
     json_obj: &serde_json::Map<String, serde_json::Value>,
     row_idx: usize,
@@ -165,52 +153,12 @@ fn scan_metadata_with_stats_columns_kernel_written(
         let filtered_batch =
             filter_record_batch(&batch, &BooleanArray::from(selection_vector)).unwrap();
 
-        let schema = filtered_batch.schema();
-        let field = schema
-            .field_with_name(STATS_PARSED_COL)
-            .expect("Schema should contain stats_parsed column");
-        assert!(
-            matches!(field.data_type(), ArrowDataType::Struct(_)),
-            "stats_parsed should be a struct type, got: {:?}",
-            field.data_type()
-        );
-
-        let stats_parsed = filtered_batch
-            .column_by_name(STATS_PARSED_COL)
-            .expect("stats_parsed column")
-            .as_any()
-            .downcast_ref::<StructArray>()
-            .expect("stats_parsed is a StructArray");
-        let num_records = stats_parsed
-            .column_by_name(NUM_RECORDS)
-            .expect("numRecords sub-field")
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .expect("numRecords is Int64Array");
-        let min_values = stats_parsed
-            .column_by_name(MIN_VALUES)
-            .expect("minValues sub-field")
-            .as_any()
-            .downcast_ref::<StructArray>()
-            .expect("minValues is StructArray");
-        let max_values = stats_parsed
-            .column_by_name(MAX_VALUES)
-            .expect("maxValues sub-field")
-            .as_any()
-            .downcast_ref::<StructArray>()
-            .expect("maxValues is StructArray");
-        let null_count = stats_parsed
-            .column_by_name(NULL_COUNT)
-            .expect("nullCount sub-field")
-            .as_any()
-            .downcast_ref::<StructArray>()
-            .expect("nullCount is StructArray");
-        let stats_json = filtered_batch
-            .column_by_name("stats")
-            .expect("stats column")
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .expect("stats is StringArray");
+        let stats_parsed = get_column!(filtered_batch, STATS_PARSED_COL, StructArray);
+        let num_records = get_column!(stats_parsed, NUM_RECORDS, Int64Array);
+        let min_values = get_column!(stats_parsed, MIN_VALUES, StructArray);
+        let max_values = get_column!(stats_parsed, MAX_VALUES, StructArray);
+        let null_count = get_column!(stats_parsed, NULL_COUNT, StructArray);
+        let stats_json = get_column!(filtered_batch, "stats", StringArray);
 
         for i in 0..stats_json.len() {
             if stats_parsed.is_null(i) || stats_json.is_null(i) {
@@ -234,25 +182,27 @@ fn scan_metadata_with_stats_columns_kernel_written(
                 .get(MIN_VALUES)
                 .and_then(|v| v.as_object())
                 .expect("stats JSON must contain minValues object");
-            validate_nested_columns(min_values, min_obj, i, MIN_VALUES);
+            validate_struct_stats(min_values, min_obj, i, MIN_VALUES);
 
             let max_obj = json_stats
                 .get(MAX_VALUES)
                 .and_then(|v| v.as_object())
                 .expect("stats JSON must contain maxValues object");
-            validate_nested_columns(max_values, max_obj, i, MAX_VALUES);
+            validate_struct_stats(max_values, max_obj, i, MAX_VALUES);
 
             let null_obj = json_stats
                 .get(NULL_COUNT)
                 .and_then(|v| v.as_object())
                 .expect("stats JSON must contain nullCount object");
-            validate_nested_columns(null_count, null_obj, i, NULL_COUNT);
+            validate_struct_stats(null_count, null_obj, i, NULL_COUNT);
 
             total_num_records += num_records.value(i);
             file_count += 1;
         }
     }
 
-    assert!(file_count > 0, "Should have processed at least one file");
-    assert!(total_num_records > 0, "Should have non-zero numRecords");
+    // The builder writes one data commit (v=1; v=0 is create-table with no data) of one
+    // file with the default 10 rows.
+    assert_eq!(file_count, 1, "Should have processed exactly one file");
+    assert_eq!(total_num_records, 10, "Should have exactly 10 numRecords");
 }

--- a/kernel/tests/integration/parsed_stats.rs
+++ b/kernel/tests/integration/parsed_stats.rs
@@ -23,7 +23,7 @@ use delta_kernel::table_features::ColumnMappingMode;
 use delta_kernel::Snapshot;
 use rstest::rstest;
 use test_utils::table_builder::{unpartitioned, version_latest, FeatureSet, LogState, TableConfig};
-use test_utils::test_context;
+use test_utils::{get_column, test_context};
 
 /// Validate that JSON stats object values match the corresponding parsed struct array.
 ///
@@ -108,12 +108,7 @@ fn validate_nested_columns(
             continue;
         };
         let path = format!("{field_prefix}.{key}");
-        let sub_struct = parsed
-            .column_by_name(key)
-            .unwrap_or_else(|| panic!("{path}: present in JSON but missing from parsed struct"))
-            .as_any()
-            .downcast_ref::<StructArray>()
-            .unwrap_or_else(|| panic!("{path}: expected StructArray for nested column"));
+        let sub_struct = get_column!(parsed, key, StructArray);
         assert_stats_struct_matches_json(sub_struct, sub_obj, row_idx, &path);
     }
 }

--- a/kernel/tests/integration/parsed_stats.rs
+++ b/kernel/tests/integration/parsed_stats.rs
@@ -1,0 +1,263 @@
+//! Integration test for `Scan::include_all_stats_columns` across column-mapping modes.
+//!
+//! Builds a table at runtime via the `test_utils` table-builder with
+//! `delta.checkpoint.writeStatsAsStruct=true` so the checkpoint carries `stats_parsed`,
+//! then verifies the parsed-stats struct column matches the JSON `stats` string row-by-row.
+//! The table-builder's `default_schema` includes a nested struct column, so each case
+//! exercises the recursive nested-stats path called out in issue #1766 (paths like
+//! `minValues.nested_col.a`).
+//!
+//! Complementary to the unit test `test_scan_metadata_with_stats_columns` in
+//! `kernel/src/scan/tests.rs`, which exercises a different code path: reading a
+//! pre-existing Spark-written checkpoint with `stats_parsed` already on disk.
+
+use delta_kernel::actions::{MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS};
+use delta_kernel::arrow::array::{
+    Array, BooleanArray, Int64Array, RecordBatch, StringArray, StructArray,
+};
+use delta_kernel::arrow::compute::filter_record_batch;
+use delta_kernel::arrow::datatypes::DataType as ArrowDataType;
+use delta_kernel::engine::arrow_data::ArrowEngineData;
+use delta_kernel::engine::default::DefaultEngineBuilder;
+use delta_kernel::table_features::ColumnMappingMode;
+use delta_kernel::Snapshot;
+use rstest::rstest;
+use test_utils::table_builder::{unpartitioned, version_latest, FeatureSet, LogState, TableConfig};
+use test_utils::test_context;
+
+/// Validate that JSON stats object values match the corresponding parsed struct array.
+///
+/// Recurses into nested struct sub-fields so paths like `minValues.info.age` are checked.
+/// `field_path` is the dotted path used in assertion messages at this recursion
+/// level (e.g. `"minValues"` at the top level; `"minValues.info.age"` when recursing).
+/// Panics on missing fields to surface regressions where the parsed-stats schema drops a column.
+fn assert_stats_struct_matches_json(
+    struct_array: &StructArray,
+    json_object: &serde_json::Map<String, serde_json::Value>,
+    row_idx: usize,
+    field_path: &str,
+) {
+    for (col_name, json_val) in json_object {
+        let path = format!("{field_path}.{col_name}");
+        let col = struct_array
+            .column_by_name(col_name)
+            .unwrap_or_else(|| panic!("{path}: present in JSON but missing from parsed struct"));
+        if col.is_null(row_idx) {
+            assert!(
+                json_val.is_null(),
+                "{path}: parsed is null but JSON is {json_val:?} at row {row_idx}"
+            );
+            continue;
+        }
+        match json_val {
+            serde_json::Value::Number(_) => {
+                let int_col = col
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .unwrap_or_else(|| {
+                        panic!("{path}: expected Int64Array, got {:?}", col.data_type())
+                    });
+                assert_eq!(
+                    json_val.as_i64().unwrap(),
+                    int_col.value(row_idx),
+                    "{path} mismatch at row {row_idx}"
+                );
+            }
+            serde_json::Value::String(s) => {
+                let str_col = col
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .unwrap_or_else(|| {
+                        panic!("{path}: expected StringArray, got {:?}", col.data_type())
+                    });
+                assert_eq!(
+                    str_col.value(row_idx),
+                    s.as_str(),
+                    "{path} mismatch at row {row_idx}"
+                );
+            }
+            serde_json::Value::Object(sub_obj) => {
+                let sub_struct = col
+                    .as_any()
+                    .downcast_ref::<StructArray>()
+                    .unwrap_or_else(|| {
+                        panic!("{path}: expected StructArray, got {:?}", col.data_type())
+                    });
+                assert_stats_struct_matches_json(sub_struct, sub_obj, row_idx, &path);
+            }
+            serde_json::Value::Null => {
+                assert!(
+                    col.is_null(row_idx),
+                    "{path}: JSON is null but parsed is non-null at row {row_idx}"
+                );
+            }
+            other => panic!("{path}: unsupported JSON variant {other:?} at row {row_idx}"),
+        }
+    }
+}
+
+/// Validate only nested-struct entries, not primitives.
+fn validate_nested_columns(
+    parsed: &StructArray,
+    json_obj: &serde_json::Map<String, serde_json::Value>,
+    row_idx: usize,
+    field_prefix: &str,
+) {
+    for (key, val) in json_obj {
+        let serde_json::Value::Object(sub_obj) = val else {
+            continue;
+        };
+        let path = format!("{field_prefix}.{key}");
+        let sub_struct = parsed
+            .column_by_name(key)
+            .unwrap_or_else(|| panic!("{path}: present in JSON but missing from parsed struct"))
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap_or_else(|| panic!("{path}: expected StructArray for nested column"));
+        assert_stats_struct_matches_json(sub_struct, sub_obj, row_idx, &path);
+    }
+}
+
+#[rstest]
+fn scan_metadata_with_stats_columns_kernel_written(
+    #[values(
+        ColumnMappingMode::None,
+        ColumnMappingMode::Id,
+        ColumnMappingMode::Name
+    )]
+    cm_mode: ColumnMappingMode,
+) {
+    const STATS_PARSED_COL: &str = "stats_parsed";
+
+    let cm_str = match cm_mode {
+        ColumnMappingMode::None => "none",
+        ColumnMappingMode::Id => "id",
+        ColumnMappingMode::Name => "name",
+    };
+    let (engine, snapshot, _table) = test_context!(
+        LogState::with_latest_version(1).with_checkpoint_at([1]),
+        FeatureSet::empty().column_mapping(cm_str),
+        unpartitioned(),
+        TableConfig::new().write_stats_as_struct(true),
+        version_latest(),
+    );
+
+    let scan = snapshot
+        .scan_builder()
+        .include_all_stats_columns()
+        .build()
+        .unwrap();
+
+    let scan_metadata_results: Vec<_> = scan
+        .scan_metadata(&engine)
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+    assert!(
+        !scan_metadata_results.is_empty(),
+        "Should have scan metadata"
+    );
+
+    let mut total_num_records: i64 = 0;
+    let mut file_count = 0;
+
+    for scan_metadata in scan_metadata_results {
+        let (underlying_data, selection_vector) = scan_metadata.scan_files.into_parts();
+        let batch: RecordBatch = ArrowEngineData::try_from_engine_data(underlying_data)
+            .unwrap()
+            .into();
+        let filtered_batch =
+            filter_record_batch(&batch, &BooleanArray::from(selection_vector)).unwrap();
+
+        let schema = filtered_batch.schema();
+        let field = schema
+            .field_with_name(STATS_PARSED_COL)
+            .expect("Schema should contain stats_parsed column");
+        assert!(
+            matches!(field.data_type(), ArrowDataType::Struct(_)),
+            "stats_parsed should be a struct type, got: {:?}",
+            field.data_type()
+        );
+
+        let stats_parsed = filtered_batch
+            .column_by_name(STATS_PARSED_COL)
+            .expect("stats_parsed column")
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .expect("stats_parsed is a StructArray");
+        let num_records = stats_parsed
+            .column_by_name(NUM_RECORDS)
+            .expect("numRecords sub-field")
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("numRecords is Int64Array");
+        let min_values = stats_parsed
+            .column_by_name(MIN_VALUES)
+            .expect("minValues sub-field")
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .expect("minValues is StructArray");
+        let max_values = stats_parsed
+            .column_by_name(MAX_VALUES)
+            .expect("maxValues sub-field")
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .expect("maxValues is StructArray");
+        let null_count = stats_parsed
+            .column_by_name(NULL_COUNT)
+            .expect("nullCount sub-field")
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .expect("nullCount is StructArray");
+        let stats_json = filtered_batch
+            .column_by_name("stats")
+            .expect("stats column")
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("stats is StringArray");
+
+        for i in 0..stats_json.len() {
+            if stats_parsed.is_null(i) || stats_json.is_null(i) {
+                continue;
+            }
+
+            let json_stats: serde_json::Value =
+                serde_json::from_str(stats_json.value(i)).expect("stats JSON should be valid");
+
+            let json_num = json_stats
+                .get(NUM_RECORDS)
+                .and_then(|v| v.as_i64())
+                .expect("stats JSON must contain numRecords");
+            assert_eq!(
+                json_num,
+                num_records.value(i),
+                "numRecords mismatch at row {i}"
+            );
+
+            let min_obj = json_stats
+                .get(MIN_VALUES)
+                .and_then(|v| v.as_object())
+                .expect("stats JSON must contain minValues object");
+            validate_nested_columns(min_values, min_obj, i, MIN_VALUES);
+
+            let max_obj = json_stats
+                .get(MAX_VALUES)
+                .and_then(|v| v.as_object())
+                .expect("stats JSON must contain maxValues object");
+            validate_nested_columns(max_values, max_obj, i, MAX_VALUES);
+
+            let null_obj = json_stats
+                .get(NULL_COUNT)
+                .and_then(|v| v.as_object())
+                .expect("stats JSON must contain nullCount object");
+            validate_nested_columns(null_count, null_obj, i, NULL_COUNT);
+
+            total_num_records += num_records.value(i);
+            file_count += 1;
+        }
+    }
+
+    assert!(file_count > 0, "Should have processed at least one file");
+    assert!(total_num_records > 0, "Should have non-zero numRecords");
+}

--- a/kernel/tests/integration/parsed_stats.rs
+++ b/kernel/tests/integration/parsed_stats.rs
@@ -1,7 +1,4 @@
-//! Integration test for `StatsOptions::all` parsed-stats output.
-//!
-//! Builds a table with `delta.checkpoint.writeStatsAsStruct=true` and a nested schema,
-//! then verifies the parsed-stats struct column matches the JSON `stats` string.
+//! Integration tests for parsed-stats output.
 
 use delta_kernel::actions::{MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS, STATS_PARSED};
 use delta_kernel::arrow::array::{
@@ -103,6 +100,8 @@ fn validate_struct_stats(
     }
 }
 
+/// Builds a table with `delta.checkpoint.writeStatsAsStruct=true` and a nested schema,
+/// then verifies the parsed-stats struct column matches the JSON `stats` string.
 #[rstest]
 fn scan_metadata_with_stats_columns_kernel_written(
     #[values(

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -5,6 +5,19 @@ pub mod counting_reporter;
 pub mod engine_contract;
 pub mod table_builder;
 
+/// Helper macro to extract a typed column from a RecordBatch or StructArray.
+#[macro_export]
+macro_rules! get_column {
+    ($source:expr, $name:expr, $ty:ty) => {
+        $source
+            .column_by_name($name)
+            .unwrap_or_else(|| panic!("should have column '{}'", $name))
+            .as_any()
+            .downcast_ref::<$ty>()
+            .unwrap_or_else(|| panic!("column '{}' should be {}", $name, stringify!($ty)))
+    };
+}
+
 // `rstest` and the `table_builder` factories appear inside the `define_sweeps!`
 // invocation below. Macro bodies are token streams that are only resolved when
 // consumer crates apply the emitted templates, so rustc doesn't see these uses.


### PR DESCRIPTION
## What changes are proposed in this pull request?

Addressing https://github.com/delta-io/delta-kernel-rs/issues/1766. Adds a new integration test to test nested struct parsing with the proposed schema from the issue. Design choices:

- Used functionality from https://github.com/delta-io/delta-kernel-rs/pull/1643 to write parsed stats in checkpoints for testing
- Left the original test_scan_metadata_with_stats_columns unchanged
- moved the `get_column` macro from unit tests to `test_utils` for accessibility from integration tests

## How was this change tested?

This change doesn't affect production code.
