### PR TITLE
refactor!: Clean up struct expression patching API

### DIFF
--- a/ffi/examples/visit-expression/expression.h
+++ b/ffi/examples/visit-expression/expression.h
@@ -94,12 +94,16 @@ struct Unary {
 };
 struct StructPatchExpression {
   ExpressionItemList input_path;
+  ExpressionItemList prepended_fields;
   ExpressionItemList field_patches;
+  ExpressionItemList appended_fields;
 };
 struct FieldPatch {
   char* field_name;
-  ExpressionItemList exprs;
-  bool is_replace;
+  ExpressionItemList replacement_expr;
+  ExpressionItemList insertions;
+  bool is_drop;
+  bool optional;
 };
 struct OpaqueExpression {
   HandleSharedOpaqueExpressionOp op;
@@ -176,6 +180,7 @@ void put_expr_item(void* data, size_t sibling_list_id, void* ref, enum Expressio
 }
 ExpressionItemList get_expr_list(void* data, size_t list_id) {
   ExpressionBuilder* data_ptr = (ExpressionBuilder*)data;
+  assert(list_id != 0);
   assert(list_id < data_ptr->list_count);
   return data_ptr->lists[list_id];
 }
@@ -315,17 +320,9 @@ DEFINE_VARIADIC(visit_expr_struct_expr, StructExpression)
 int patch_op_cmp(const void* a, const void* b) {
   const struct FieldPatch* op_a = ((ExpressionItem*)a)->ref;
   const struct FieldPatch* op_b = ((ExpressionItem*)b)->ref;
-  if (op_a->field_name == NULL && op_b->field_name == NULL) {
-    // break tie below
-  } else if (op_a->field_name == NULL) {
-    return -1;
-  } else if (op_b->field_name == NULL) {
-    return 1;
-  } else {
-    int cmp = strcmp(op_a->field_name, op_b->field_name);
-    if (cmp != 0) {
-      return cmp;
-    } // else break tie below
+  int cmp = strcmp(op_a->field_name, op_b->field_name);
+  if (cmp != 0) {
+    return cmp;
   }
   if (op_a < op_b) {
     return -1;
@@ -340,11 +337,15 @@ void visit_struct_patch_expr(
     void* data,
     uintptr_t sibling_list_id,
     uintptr_t input_path_list_id,
-    uintptr_t child_list_id)
+    uintptr_t prepended_field_list_id,
+    uintptr_t field_patch_list_id,
+    uintptr_t appended_field_list_id)
 {
   struct StructPatchExpression* patch = malloc(sizeof(struct StructPatchExpression));
   patch->input_path = get_expr_list(data, input_path_list_id);
-  patch->field_patches = get_expr_list(data, child_list_id);
+  patch->prepended_fields = get_expr_list(data, prepended_field_list_id);
+  patch->field_patches = get_expr_list(data, field_patch_list_id);
+  patch->appended_fields = get_expr_list(data, appended_field_list_id);
 
   // stable sort the ops by field name to ensure deterministic output
   qsort(
@@ -358,14 +359,18 @@ void visit_struct_patch_expr(
 void visit_field_patch(
     void* data,
     uintptr_t sibling_list_id,
-    const KernelStringSlice* field_name,
-    uintptr_t child_list_id,
-    bool is_replace)
+    KernelStringSlice field_name,
+    uintptr_t replacement_expr_list_id,
+    uintptr_t insertion_expr_list_id,
+    bool is_drop,
+    bool optional)
 {
   struct FieldPatch* field_patch = malloc(sizeof(struct FieldPatch));
-  field_patch->field_name = field_name? allocate_string(*field_name) : NULL;
-  field_patch->exprs = get_expr_list(data, child_list_id);
-  field_patch->is_replace = is_replace;
+  field_patch->field_name = allocate_string(field_name);
+  field_patch->replacement_expr = get_expr_list(data, replacement_expr_list_id);
+  field_patch->insertions = get_expr_list(data, insertion_expr_list_id);
+  field_patch->is_drop = is_drop;
+  field_patch->optional = optional;
   put_expr_item(data, sibling_list_id, field_patch, FieldPatch);
 }
 void visit_opaque_expr(
@@ -470,8 +475,7 @@ uintptr_t make_field_list(void* data, uintptr_t reserve) {
 }
 
 ExpressionItemList construct_expression(SharedExpression* expression) {
-  ExpressionBuilder data = { 0 };
-  make_field_list(&data, 0); // list id 0 is the invalid/missing/empty list
+  ExpressionBuilder data = { .list_count = 1 };
 
   EngineExpressionVisitor visitor = {
     .data = &data,
@@ -522,7 +526,7 @@ ExpressionItemList construct_expression(SharedExpression* expression) {
 }
 
 ExpressionItemList construct_predicate(SharedPredicate* predicate) {
-  ExpressionBuilder data = { 0 };
+  ExpressionBuilder data = { .list_count = 1 };
   EngineExpressionVisitor visitor = {
     .data = &data,
     .make_field_list = make_field_list,
@@ -586,14 +590,17 @@ void free_expression_item(ExpressionItem ref) {
     case StructPatch: {
       struct StructPatchExpression* patch = ref.ref;
       free_expression_list(patch->input_path);
+      free_expression_list(patch->prepended_fields);
       free_expression_list(patch->field_patches);
+      free_expression_list(patch->appended_fields);
       free(patch);
       break;
     }
     case FieldPatch: {
       struct FieldPatch* field_patch = ref.ref;
       free(field_patch->field_name);
-      free_expression_list(field_patch->exprs);
+      free_expression_list(field_patch->replacement_expr);
+      free_expression_list(field_patch->insertions);
       free(field_patch);
       break;
     }

--- a/ffi/examples/visit-expression/expression_print.h
+++ b/ffi/examples/visit-expression/expression_print.h
@@ -23,6 +23,13 @@ void print_expression_item_list_field(const char* field_name, ExpressionItemList
   printf("%s\n", field_name);
   print_expression_item_list(list, depth + 1);
 }
+void print_non_empty_expression_item_list_field(
+    const char* field_name, ExpressionItemList list, int depth) {
+  if (list.len == 0) {
+    return;
+  }
+  print_expression_item_list_field(field_name, list, depth);
+}
 void print_bool_field(const char* field_name, bool value, int depth) {
   print_n_spaces(depth);
   printf("%s: %s\n", field_name, value ? "true" : "false");
@@ -96,10 +103,14 @@ void print_tree_helper(ExpressionItem ref, int depth) {
     case StructPatch: {
       struct StructPatchExpression* patch = ref.ref;
       printf("StructPatch\n");
-      print_expression_item_list_field("input_path", patch->input_path, depth + 1);
-      print_expression_item_list_field("prepended_fields", patch->prepended_fields, depth + 1);
-      print_expression_item_list_field("field_patches", patch->field_patches, depth + 1);
-      print_expression_item_list_field("appended_fields", patch->appended_fields, depth + 1);
+      print_non_empty_expression_item_list_field(
+          "input_path", patch->input_path, depth + 1);
+      print_non_empty_expression_item_list_field(
+          "prepended_fields", patch->prepended_fields, depth + 1);
+      print_non_empty_expression_item_list_field(
+          "field_patches", patch->field_patches, depth + 1);
+      print_non_empty_expression_item_list_field(
+          "appended_fields", patch->appended_fields, depth + 1);
       break;
     }
     case FieldPatch: {
@@ -107,8 +118,10 @@ void print_tree_helper(ExpressionItem ref, int depth) {
       printf("FieldPatch\n");
       print_n_spaces(depth + 1);
       printf("field_name: %s\n", field_patch->field_name);
-      print_expression_item_list_field("replacement_expr", field_patch->replacement_expr, depth + 1);
-      print_expression_item_list_field("insertions", field_patch->insertions, depth + 1);
+      print_non_empty_expression_item_list_field(
+          "replacement_expr", field_patch->replacement_expr, depth + 1);
+      print_non_empty_expression_item_list_field(
+          "insertions", field_patch->insertions, depth + 1);
       print_bool_field("is_drop", field_patch->is_drop, depth + 1);
       print_bool_field("optional", field_patch->optional, depth + 1);
       break;

--- a/ffi/examples/visit-expression/expression_print.h
+++ b/ffi/examples/visit-expression/expression_print.h
@@ -18,6 +18,15 @@ void print_expression_item_list(ExpressionItemList list, int depth) {
     print_tree_helper(list.list[i], depth);
   }
 }
+void print_expression_item_list_field(const char* field_name, ExpressionItemList list, int depth) {
+  print_n_spaces(depth);
+  printf("%s\n", field_name);
+  print_expression_item_list(list, depth + 1);
+}
+void print_bool_field(const char* field_name, bool value, int depth) {
+  print_n_spaces(depth);
+  printf("%s: %s\n", field_name, value ? "true" : "false");
+}
 void print_opaque_op_name(void* op_type, KernelStringSlice name) {
   int len = name.len & 0x7fffffff; // truncate to 31 bits to ensure a positive value
   printf("%s(%.*s)\n", (char*) op_type, len, name.ptr);
@@ -87,22 +96,21 @@ void print_tree_helper(ExpressionItem ref, int depth) {
     case StructPatch: {
       struct StructPatchExpression* patch = ref.ref;
       printf("StructPatch\n");
-      print_expression_item_list(patch->input_path, depth + 1);
-      print_expression_item_list(patch->field_patches, depth + 1);
+      print_expression_item_list_field("input_path", patch->input_path, depth + 1);
+      print_expression_item_list_field("prepended_fields", patch->prepended_fields, depth + 1);
+      print_expression_item_list_field("field_patches", patch->field_patches, depth + 1);
+      print_expression_item_list_field("appended_fields", patch->appended_fields, depth + 1);
       break;
     }
     case FieldPatch: {
       struct FieldPatch* field_patch = ref.ref;
-      if (!field_patch->field_name) {
-        printf("Prepend\n");
-      } else if (!field_patch->is_replace) {
-        printf("Insert(%s)\n", field_patch->field_name);
-      } else if (!field_patch->exprs.len) {
-        printf("Drop(%s)\n", field_patch->field_name);
-      } else {
-        printf("Replace(%s)\n", field_patch->field_name);
-      }
-      print_expression_item_list(field_patch->exprs, depth + 1);
+      printf("FieldPatch\n");
+      print_n_spaces(depth + 1);
+      printf("field_name: %s\n", field_patch->field_name);
+      print_expression_item_list_field("replacement_expr", field_patch->replacement_expr, depth + 1);
+      print_expression_item_list_field("insertions", field_patch->insertions, depth + 1);
+      print_bool_field("is_drop", field_patch->is_drop, depth + 1);
+      print_bool_field("optional", field_patch->optional, depth + 1);
       break;
     }
     case OpaqueExpression: {

--- a/ffi/src/expressions/engine_visitor.rs
+++ b/ffi/src/expressions/engine_visitor.rs
@@ -209,48 +209,35 @@ pub struct EngineExpressionVisitor {
     pub visit_struct_expr:
         extern "C" fn(data: *mut c_void, sibling_list_id: usize, child_list_id: usize),
     /// Visits a `StructPatch` expression belonging to the list identified by `sibling_list_id`.
-    /// The `input_path_list_id` is a single-item list containing the patch's input path as a
-    /// column reference (0 = no path). The `field_patch_list_id` identifies the list of field
-    /// patches to apply (0 = empty patch). See also [`Self::visit_field_patch`].
+    /// The `input_path_list_id` is a zero-or-one item list containing the patch's input path as a
+    /// column reference. The `prepended_field_list_id` and `appended_field_list_id` identify
+    /// expression lists to emit before and after the named input fields. The
+    /// `field_patch_list_id` identifies the list of named field patches to apply. See also
+    /// [`Self::visit_field_patch`].
     pub visit_struct_patch_expr: extern "C" fn(
         data: *mut c_void,
         sibling_list_id: usize,
         input_path_list_id: usize,
+        prepended_field_list_id: usize,
         field_patch_list_id: usize,
+        appended_field_list_id: usize,
     ),
-    /// Visits one field patch of a `StructPatch` expression that owns the list identified by
-    /// `sibling_list_id`. Each field patch has a different insertion point (no duplicates).
+    /// Visits one named field patch of a `StructPatch` expression that owns the list identified by
+    /// `sibling_list_id`.
     ///
-    /// A field patch is modeled as the triple `(field_name, expr_list, is_replace)`, as
-    /// described by the truth table below. The `expr_list_id` identifies the list of expressions
-    /// the field patch should emit. The field name (if present) always references a field of
-    /// the input struct. Both the field name and the expression list are optional:
-    ///
-    /// |field_name? |expr_list? |is_replace? |meaning|
-    /// |-|-|-|-|
-    /// | NO  | NO  | *   | NO-OP (prepend an empty list of expressions to the output)
-    /// | NO  | YES | *   | Prepend a list of expressions to the output
-    /// | YES | NO  | NO  | NO-OP (insert an empty list of expressions after the named input field)
-    /// | YES | NO  | YES | Drop the named input field
-    /// | YES | YES | NO  | Insert a list of expressions after the named input field
-    /// | YES | YES | YES | Replace the named input field with a list of expressions
-    ///
-    /// NOTE: Treating list id 0 as an empty list yields a simplified truth table:
-    ///
-    /// |field_name? |is_replace? |meaning|
-    /// |-|-|-|
-    /// | NO  | *   | Prepend a (possibly empty) list of expressions to the output
-    /// | YES | NO  | Insert a (possibly empty)  list of expressions after the named input field
-    /// | YES | YES | Replace the named input field with a (possibly empty) list of expressions
-    ///
-    /// NOTE: The expressions of each field patch must be emitted in order at the insertion
-    /// point.
+    /// The `replacement_expr_list_id` identifies a zero-or-one expression list used to replace the
+    /// original field. If no replacement was specified but `is_drop` is true, the original field
+    /// is dropped without replacement. The `insertion_expr_list_id` identifies expressions to
+    /// emit after this field's output position. The `optional` flag indicates that the patch
+    /// is silently ignored when the input field does not exist.
     pub visit_field_patch: extern "C" fn(
         data: *mut c_void,
         sibling_list_id: usize,
-        field_name: *const KernelStringSlice,
-        expr_list_id: usize,
-        is_replace: bool,
+        field_name: KernelStringSlice,
+        replacement_expr_list_id: usize,
+        insertion_expr_list_id: usize,
+        is_drop: bool,
+        optional: bool,
     ),
     /// Visits the operator (`op`) and children (`child_list_id`) of an opaque expression belonging
     /// to the list identified by `sibling_list_id`.
@@ -421,11 +408,16 @@ fn visit_expression_struct(
     exprs: &[ExpressionRef],
     sibling_list_id: usize,
 ) {
+    let child_list_id = visit_expression_list(visitor, exprs);
+    call!(visitor, visit_struct_expr, sibling_list_id, child_list_id)
+}
+
+fn visit_expression_list(visitor: &mut EngineExpressionVisitor, exprs: &[ExpressionRef]) -> usize {
     let child_list_id = call!(visitor, make_field_list, exprs.len());
     for expr in exprs {
         visit_expression_impl(visitor, expr, child_list_id);
     }
-    call!(visitor, visit_struct_expr, sibling_list_id, child_list_id)
+    child_list_id
 }
 
 fn visit_expression_struct_patch(
@@ -433,55 +425,32 @@ fn visit_expression_struct_patch(
     patch: &ExpressionStructPatch,
     sibling_list_id: usize,
 ) {
-    let ExpressionStructPatch {
-        input_path,
-        field_patches,
-        prepended_fields,
-    } = patch;
-
-    // Treat the input path like a column expression
-    let mut path_list_id = 0;
-    if let Some(ref column_name) = input_path {
-        path_list_id = call!(visitor, make_field_list, 1);
+    // Treat the input path like a zero-or-one column expression list.
+    let path_len = usize::from(patch.input_path.is_some());
+    let path_list_id = call!(visitor, make_field_list, path_len);
+    if let Some(ref column_name) = patch.input_path {
         visit_expression_column(visitor, column_name, path_list_id);
     };
 
-    // Emit one field patch for each named input field (ignoring no-ops), plus one more for the
-    // prepended field list (if any).
-    let prepended_count = if prepended_fields.is_empty() { 0 } else { 1 };
-    let field_patch_count = prepended_count + field_patches.len();
-    let field_patch_list_id = call!(visitor, make_field_list, field_patch_count);
+    let prepended_field_list_id = visit_expression_list(visitor, &patch.prepended_fields);
+    let appended_field_list_id = visit_expression_list(visitor, &patch.appended_fields);
 
-    // Process the prepend first (if any)
-    if !prepended_fields.is_empty() {
-        let child_list_id = call!(visitor, make_field_list, prepended_fields.len());
-        for expr in prepended_fields {
-            visit_expression_impl(visitor, expr, child_list_id);
-        }
+    // Process each named field patch in turn. Field patch order is not semantically meaningful;
+    // engines should apply field patches according to input schema order.
+    let field_patch_list_id = call!(visitor, make_field_list, patch.field_patches.len());
+    for (field_name, field_patch) in &patch.field_patches {
+        let replacement_exprs = field_patch.replacement_expr.as_slice();
+        let replacement_expr_list_id = visit_expression_list(visitor, replacement_exprs);
+        let insertion_expr_list_id = visit_expression_list(visitor, &field_patch.insertions);
         call!(
             visitor,
             visit_field_patch,
             field_patch_list_id,
-            std::ptr::null(),
-            child_list_id,
-            false // doesn't matter, no field name
-        );
-    }
-
-    // Process each field patch in turn
-    for (field_name, field_patch) in field_patches {
-        let child_list_id = call!(visitor, make_field_list, field_patch.exprs.len());
-        for expr in &field_patch.exprs {
-            visit_expression_impl(visitor, expr, child_list_id);
-        }
-
-        call!(
-            visitor,
-            visit_field_patch,
-            field_patch_list_id,
-            &kernel_string_slice!(field_name),
-            child_list_id,
-            field_patch.is_replace
+            kernel_string_slice!(field_name),
+            replacement_expr_list_id,
+            insertion_expr_list_id,
+            field_patch.is_drop,
+            field_patch.optional
         );
     }
 
@@ -491,7 +460,9 @@ fn visit_expression_struct_patch(
         visit_struct_patch_expr,
         sibling_list_id,
         path_list_id,
-        field_patch_list_id
+        prepended_field_list_id,
+        field_patch_list_id,
+        appended_field_list_id
     );
 }
 

--- a/ffi/src/test_ffi.rs
+++ b/ffi/src/test_ffi.rs
@@ -114,18 +114,16 @@ pub unsafe extern "C" fn get_testing_kernel_expression() -> Handle<SharedExpress
     let nested_patch = ExpressionStructPatch::new_top_level()
         .with_dropped_field("gone")
         .with_replaced_field("stub", Expr::literal("replaced").into())
-        .with_inserted_field(Some("x".to_string()), Expr::literal(true).into())
-        .with_inserted_field(Some("y".to_string()), Expr::literal(false).into());
+        .with_inserted_field_after("x", Expr::literal(true).into())
+        .with_inserted_field_after("y", Expr::literal(false).into());
     let top_level_patch = ExpressionStructPatch::new_nested(column_name!("foo.bar.baz"))
         .with_dropped_field("dropme")
         .with_replaced_field("replaceme", Expr::literal(42).into())
-        .with_inserted_field(None::<&str>, Expr::literal("prepended").into())
-        .with_inserted_field(Some("a".to_string()), Expr::literal("first").into())
-        .with_inserted_field(
-            Some("a".to_string()),
-            Expr::struct_patch(nested_patch).into(),
-        )
-        .with_inserted_field(Some("a".to_string()), Expr::literal("third").into());
+        .with_prepended_field(Expr::literal("prepended").into())
+        .with_inserted_field_after("a", Expr::literal("first").into())
+        .with_inserted_field_after("a", Expr::struct_patch(nested_patch).into())
+        .with_inserted_field_after("a", Expr::literal("third").into())
+        .with_appended_field(Expr::literal("appended").into());
 
     let mut sub_exprs = vec![
         column_expr!("col"),

--- a/ffi/tests/test-expression-visitor/expected.txt
+++ b/ffi/tests/test-expression-visitor/expected.txt
@@ -43,55 +43,43 @@ StructExpression
     field_patches
       FieldPatch
         field_name: a
-        replacement_expr
         insertions
           String(first)
           StructPatch
-            input_path
-            prepended_fields
             field_patches
               FieldPatch
                 field_name: gone
-                replacement_expr
-                insertions
                 is_drop: true
                 optional: false
               FieldPatch
                 field_name: stub
                 replacement_expr
                   String(replaced)
-                insertions
                 is_drop: false
                 optional: false
               FieldPatch
                 field_name: x
-                replacement_expr
                 insertions
                   Boolean(1)
                 is_drop: false
                 optional: false
               FieldPatch
                 field_name: y
-                replacement_expr
                 insertions
                   Boolean(0)
                 is_drop: false
                 optional: false
-            appended_fields
           String(third)
         is_drop: false
         optional: false
       FieldPatch
         field_name: dropme
-        replacement_expr
-        insertions
         is_drop: true
         optional: false
       FieldPatch
         field_name: replaceme
         replacement_expr
           Integer(42)
-        insertions
         is_drop: false
         optional: false
     appended_fields

--- a/ffi/tests/test-expression-visitor/expected.txt
+++ b/ffi/tests/test-expression-visitor/expected.txt
@@ -36,23 +36,66 @@ StructExpression
             Short(5)
             Short(0)
   StructPatch
-    Column(foo.bar.baz)
-    Prepend
+    input_path
+      Column(foo.bar.baz)
+    prepended_fields
       String(prepended)
-    Insert(a)
-      String(first)
-      StructPatch
-        Drop(gone)
-        Replace(stub)
-          String(replaced)
-        Insert(x)
-          Boolean(1)
-        Insert(y)
-          Boolean(0)
-      String(third)
-    Drop(dropme)
-    Replace(replaceme)
-      Integer(42)
+    field_patches
+      FieldPatch
+        field_name: a
+        replacement_expr
+        insertions
+          String(first)
+          StructPatch
+            input_path
+            prepended_fields
+            field_patches
+              FieldPatch
+                field_name: gone
+                replacement_expr
+                insertions
+                is_drop: true
+                optional: false
+              FieldPatch
+                field_name: stub
+                replacement_expr
+                  String(replaced)
+                insertions
+                is_drop: false
+                optional: false
+              FieldPatch
+                field_name: x
+                replacement_expr
+                insertions
+                  Boolean(1)
+                is_drop: false
+                optional: false
+              FieldPatch
+                field_name: y
+                replacement_expr
+                insertions
+                  Boolean(0)
+                is_drop: false
+                optional: false
+            appended_fields
+          String(third)
+        is_drop: false
+        optional: false
+      FieldPatch
+        field_name: dropme
+        replacement_expr
+        insertions
+        is_drop: true
+        optional: false
+      FieldPatch
+        field_name: replaceme
+        replacement_expr
+          Integer(42)
+        insertions
+        is_drop: false
+        optional: false
+    appended_fields
+      String(appended)
   Array
     Short(5)
     Short(0)

--- a/kernel/src/checkpoint/checkpoint_transform.rs
+++ b/kernel/src/checkpoint/checkpoint_transform.rs
@@ -371,15 +371,14 @@ mod tests {
             .field_patches
             .get(ADD_NAME)
             .expect("Outer patch should have 'add' field patch");
-        assert!(add_field_patch.is_replace, "Should replace 'add' field");
-        assert_eq!(
-            add_field_patch.exprs.len(),
-            1,
-            "Should have exactly one replacement expression"
+        assert!(
+            add_field_patch.replacement_expr.is_some(),
+            "Should replace 'add' field"
         );
 
         // Extract inner patch
-        let Expression::StructPatch(inner) = add_field_patch.exprs[0].as_ref() else {
+        let Some(Expression::StructPatch(inner)) = add_field_patch.replacement_expr.as_deref()
+        else {
             panic!("Expected inner StructPatch expression for 'add' field");
         };
 
@@ -398,8 +397,7 @@ mod tests {
         patch
             .field_patches
             .get(field)
-            .map(|ft| ft.is_replace && ft.exprs.is_empty())
-            .unwrap_or(false)
+            .is_some_and(|ft| ft.is_drop && ft.replacement_expr.is_none())
     }
 
     /// Helper to check if a field patch is a replacement with an expression.
@@ -407,8 +405,7 @@ mod tests {
         patch
             .field_patches
             .get(field)
-            .map(|ft| ft.is_replace && ft.exprs.len() == 1)
-            .unwrap_or(false)
+            .is_some_and(|ft| ft.replacement_expr.is_some() && !ft.is_drop)
     }
 
     #[test]

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -158,6 +158,7 @@ fn evaluate_struct_patch_expression(
     batch: &RecordBatch,
     output_schema: &StructType,
 ) -> DeltaResult<ArrayRef> {
+    patch.validate()?;
     let mut used_field_patches = 0;
 
     // Collect output columns directly to avoid creating intermediate Expr::Column instances.
@@ -183,13 +184,6 @@ fn evaluate_struct_patch_expression(
         .map(|path| extract_column(batch, path))
         .transpose()?;
 
-    // For nested patches, get the source struct's null bitmap to preserve null rows
-    let source_null_buffer = source_array.as_ref().and_then(|arr| {
-        arr.as_any()
-            .downcast_ref::<StructArray>()
-            .and_then(|s| s.nulls().cloned())
-    });
-
     let source_data: &dyn ProvidesColumnByName = match source_array {
         Some(ref array) => array
             .as_any()
@@ -202,16 +196,18 @@ fn evaluate_struct_patch_expression(
     for input_field in source_data.schema_fields() {
         let field_name: &str = input_field.name();
 
-        // Any field that isn't replaced passes through unchanged
+        // Any field that isn't replaced or dropped passes through unchanged
         let field_patch = patch.field_patches.get(field_name);
-        if !field_patch.is_some_and(|t| t.is_replace) {
+        if let Some(expr) = field_patch.and_then(|patch| patch.replacement_expr.as_ref()) {
+            output_cols.push(evaluate_expression(expr, batch, Some(next_output_type()?))?);
+        } else if !field_patch.is_some_and(|patch| patch.is_drop) {
             output_cols.push(extract_column(source_data, &[field_name])?);
             let _ = next_output_type()?; // consume and discard the output schema field
         }
 
         // Process any insertions that come after this field
         if let Some(field_patch) = field_patch {
-            for expr in &field_patch.exprs {
+            for expr in &field_patch.insertions {
                 output_cols.push(evaluate_expression(expr, batch, Some(next_output_type()?))?);
             }
             used_field_patches += 1;
@@ -228,6 +224,11 @@ fn evaluate_struct_patch_expression(
         return Err(Error::generic(
             "Some non-optional field patches reference invalid input field names",
         ));
+    }
+
+    // Handle appends (insertions after all input fields and field-specific insertions)
+    for expr in &patch.appended_fields {
+        output_cols.push(evaluate_expression(expr, batch, Some(next_output_type()?))?);
     }
 
     // Verify we consumed all output schema fields
@@ -247,6 +248,14 @@ fn evaluate_struct_patch_expression(
             )
         })
         .collect();
+
+    // For nested patches, get the source struct's null bitmap to preserve null rows
+    let source_null_buffer = source_array.as_ref().and_then(|arr| {
+        arr.as_any()
+            .downcast_ref::<StructArray>()
+            .and_then(|s| s.nulls().cloned())
+    });
+
     let data = StructArray::try_new(output_fields.into(), output_cols, source_null_buffer)?;
     Ok(Arc::new(data))
 }
@@ -1064,12 +1073,13 @@ mod tests {
         let patch = ExpressionStructPatch::new_top_level()
             .with_replaced_field("a", column_expr_ref!("b"))
             .with_dropped_field("b")
-            .with_inserted_field(None::<&str>, Expr::literal(1).into())
-            .with_inserted_field(None::<&str>, Expr::literal(2).into())
-            .with_inserted_field(None::<&str>, column_expr_ref!("c"))
-            .with_inserted_field(Some("c"), Expr::literal(42).into())
-            .with_inserted_field(Some("c"), column_expr_ref!("a"))
-            .with_inserted_field(Some("c"), Expr::literal(99).into());
+            .with_prepended_field(Expr::literal(1).into())
+            .with_prepended_field(Expr::literal(2).into())
+            .with_prepended_field(column_expr_ref!("c"))
+            .with_inserted_field_after("c", Expr::literal(42).into())
+            .with_inserted_field_after("c", column_expr_ref!("a"))
+            .with_inserted_field_after("c", Expr::literal(99).into())
+            .with_appended_field(Expr::literal(7).into());
 
         let output_schema = StructType::new_unchecked(vec![
             StructField::new("pre1", DataType::INTEGER, false), // prepend 1
@@ -1080,6 +1090,7 @@ mod tests {
             StructField::new("after_c1", DataType::INTEGER, false), // first insertion after c
             StructField::new("after_c2", DataType::INTEGER, false), // second insertion after c
             StructField::new("after_c3", DataType::INTEGER, false), // third insertion after c
+            StructField::new("append1", DataType::INTEGER, false), // true append
         ]);
 
         let expr = Expr::StructPatch(patch);
@@ -1091,7 +1102,7 @@ mod tests {
         .unwrap();
 
         let struct_result = result.as_any().downcast_ref::<StructArray>().unwrap();
-        assert_eq!(struct_result.num_columns(), 8);
+        assert_eq!(struct_result.num_columns(), 9);
         assert_eq!(struct_result.len(), 3);
 
         // Verify multiple prepends (in order)
@@ -1109,6 +1120,39 @@ mod tests {
         validate_i32_column(struct_result, 5, &[42, 42, 42]);
         validate_i32_column(struct_result, 6, &[1, 2, 3]); // original column a
         validate_i32_column(struct_result, 7, &[99, 99, 99]);
+
+        // Verify true appends come after field-specific insertions
+        validate_i32_column(struct_result, 8, &[7, 7, 7]);
+    }
+
+    #[test]
+    fn test_replacement_position_is_independent_of_registration_order() {
+        let batch = create_test_batch();
+
+        let patch = ExpressionStructPatch::new_top_level()
+            .with_inserted_field_after("a", Expr::literal(42).into())
+            .with_replaced_field("a", column_expr_ref!("b"));
+
+        let output_schema = StructType::new_unchecked(vec![
+            StructField::new("a", DataType::INTEGER, false),
+            StructField::new("after_a", DataType::INTEGER, false),
+            StructField::new("b", DataType::INTEGER, false),
+            StructField::new("c", DataType::INTEGER, false),
+        ]);
+
+        let expr = Expr::StructPatch(patch);
+        let result = evaluate_expression(
+            &expr,
+            &batch,
+            Some(&DataType::Struct(Box::new(output_schema))),
+        )
+        .unwrap();
+
+        let struct_result = result.as_any().downcast_ref::<StructArray>().unwrap();
+        validate_i32_column(struct_result, 0, &[10, 20, 30]); // replacement column b
+        validate_i32_column(struct_result, 1, &[42, 42, 42]); // insertion after replacement
+        validate_i32_column(struct_result, 2, &[10, 20, 30]); // original column b
+        validate_i32_column(struct_result, 3, &[100, 200, 300]); // original column c
     }
 
     #[test]
@@ -1150,7 +1194,7 @@ mod tests {
         // Test 2: Modify nested struct and relocate it
         let modify_patch = ExpressionStructPatch::new_nested(["nested"])
             .with_replaced_field("x".to_string(), Expr::literal(777).into())
-            .with_inserted_field(Some("y"), Expr::literal(555).into());
+            .with_inserted_field_after("y", Expr::literal(555).into());
 
         let modify_output_schema = StructType::new_unchecked(vec![
             StructField::new("x", DataType::INTEGER, false), // replaced with literal 777
@@ -1209,7 +1253,7 @@ mod tests {
 
         // Test unused insertion keys
         let insertion_patch = ExpressionStructPatch::new_top_level()
-            .with_inserted_field(Some("nonexistent"), Expr::literal(1).into());
+            .with_inserted_field_after("nonexistent", Expr::literal(1).into());
 
         let expr2 = Expr::StructPatch(insertion_patch);
         let result2 = evaluate_expression(
@@ -1271,6 +1315,44 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("Data type is required"));
+    }
+
+    #[test]
+    fn test_conflicting_replacement_operations_error() {
+        let batch = create_test_batch();
+        let output_schema = StructType::new_unchecked(vec![
+            StructField::not_null("a", DataType::INTEGER),
+            StructField::not_null("b", DataType::INTEGER),
+            StructField::not_null("c", DataType::INTEGER),
+        ]);
+
+        let patch = ExpressionStructPatch::new_top_level()
+            .with_replaced_field("a", Expr::literal(1).into())
+            .with_dropped_field("a");
+        let expr = Expr::StructPatch(patch);
+        let result = evaluate_expression(
+            &expr,
+            &batch,
+            Some(&DataType::Struct(Box::new(output_schema.clone()))),
+        );
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("multiple replacement/drop operations"));
+
+        let patch = ExpressionStructPatch::new_top_level()
+            .with_dropped_field("a")
+            .with_replaced_field("a", Expr::literal(1).into());
+        let expr = Expr::StructPatch(patch);
+        let result = evaluate_expression(
+            &expr,
+            &batch,
+            Some(&DataType::Struct(Box::new(output_schema))),
+        );
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("multiple replacement/drop operations"));
     }
 
     #[test]
@@ -1601,7 +1683,7 @@ mod tests {
             .with_replaced_field("x", Expr::literal(999).into());
 
         let outer_patch = ExpressionStructPatch::new_top_level()
-            .with_inserted_field(Some("a"), Expr::StructPatch(nested_patch).into());
+            .with_inserted_field_after("a", Expr::StructPatch(nested_patch).into());
 
         let nested_output_schema = StructType::new_unchecked(vec![
             StructField::not_null("x", DataType::INTEGER),

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -158,7 +158,6 @@ fn evaluate_struct_patch_expression(
     batch: &RecordBatch,
     output_schema: &StructType,
 ) -> DeltaResult<ArrayRef> {
-    patch.validate()?;
     let mut used_field_patches = 0;
 
     // Collect output columns directly to avoid creating intermediate Expr::Column instances.
@@ -1318,7 +1317,7 @@ mod tests {
     }
 
     #[test]
-    fn test_conflicting_replacement_operations_error() {
+    fn test_replacement_takes_precedence_over_drop_and_older_replacements() {
         let batch = create_test_batch();
         let output_schema = StructType::new_unchecked(vec![
             StructField::not_null("a", DataType::INTEGER),
@@ -1334,25 +1333,28 @@ mod tests {
             &expr,
             &batch,
             Some(&DataType::Struct(Box::new(output_schema.clone()))),
-        );
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("multiple replacement/drop operations"));
+        )
+        .unwrap();
+        let result = result.as_any().downcast_ref::<StructArray>().unwrap();
+        validate_i32_column(result, 0, &[1, 1, 1]);
+        validate_i32_column(result, 1, &[10, 20, 30]);
+        validate_i32_column(result, 2, &[100, 200, 300]);
 
         let patch = ExpressionStructPatch::new_top_level()
             .with_dropped_field("a")
-            .with_replaced_field("a", Expr::literal(1).into());
+            .with_replaced_field("a", Expr::literal(1).into())
+            .with_replaced_field("a", Expr::literal(2).into());
         let expr = Expr::StructPatch(patch);
         let result = evaluate_expression(
             &expr,
             &batch,
             Some(&DataType::Struct(Box::new(output_schema))),
-        );
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("multiple replacement/drop operations"));
+        )
+        .unwrap();
+        let result = result.as_any().downcast_ref::<StructArray>().unwrap();
+        validate_i32_column(result, 0, &[2, 2, 2]);
+        validate_i32_column(result, 1, &[10, 20, 30]);
+        validate_i32_column(result, 2, &[100, 200, 300]);
     }
 
     #[test]

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -346,7 +346,7 @@ pub struct ExpressionFieldPatch {
     /// If true, and there is no replacement expression, the input field is omitted from the
     /// output.
     pub is_drop: bool,
-    /// Insertions provided by calls to [`Self::with_inserted_field_after`].
+    /// Insertions provided by calls to [`ExpressionStructPatch::with_inserted_field_after`].
     pub insertions: Vec<ExpressionRef>,
     /// If true, this patch is silently ignored when the input field does not exist. Otherwise, a
     /// missing input field produces an error.

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -18,7 +18,7 @@ use crate::kernel_predicates::{
 };
 use crate::schema::SchemaRef;
 use crate::transforms::{transform_output_type, ExpressionTransform};
-use crate::{DataType, DeltaResult, DynPartialEq};
+use crate::{DataType, DeltaResult, DynPartialEq, Error};
 
 mod column_names;
 pub(crate) mod literal_expression_transform;
@@ -336,17 +336,22 @@ where
 
 /// A patch affecting a single input field.
 ///
-/// A field patch can insert zero or more expressions after its input field, or it can replace the
-/// input field with zero or more expressions.
+/// A field patch can insert zero or more expressions after its input field, replace the input field
+/// with one expression, or drop the input field.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ExpressionFieldPatch {
-    /// The expressions this field patch emits at the input field's output position.
-    pub exprs: Vec<ExpressionRef>,
-    /// If true, the output expressions replace the input field instead of following after it.
-    pub is_replace: bool,
+    /// Set by a call to [`Self::with_replaced_field`]. Mutually incopatible with `is_drop`.
+    pub replacement_expr: Option<ExpressionRef>,
+    /// Set by a call to [`Self::with_dropped_field`]. Mutually incopatible with
+    /// `replacement_expr`.
+    pub is_drop: bool,
+    /// Insertions provided by calls to [`Self::with_inserted_field_after`].
+    pub insertions: Vec<ExpressionRef>,
     /// If true, this patch is silently ignored when the input field does not exist. Otherwise, a
     /// missing input field produces an error.
     pub optional: bool,
+    /// True if [`Self::with_replaced_field`] or [`Self::with_dropped_field`] was called twice.
+    pub replacement_conflict: bool,
 }
 
 /// A sparse expression patch over the fields of one input struct.
@@ -362,10 +367,11 @@ pub struct ExpressionStructPatch {
     /// the patch operates directly on top-level columns.
     pub input_path: Option<ColumnName>,
     /// A mapping from named input fields to the patch to be performed on each field.
-    #[serde(alias = "field_transforms")]
     pub field_patches: HashMap<String, ExpressionFieldPatch>,
     /// A list of new fields to emit before processing the first input field.
     pub prepended_fields: Vec<ExpressionRef>,
+    /// A list of new fields to emit after all input fields and field-specific insertions.
+    pub appended_fields: Vec<ExpressionRef>,
 }
 
 impl ExpressionStructPatch {
@@ -390,14 +396,14 @@ impl ExpressionStructPatch {
     /// Specifies a field to drop.
     pub fn with_dropped_field(mut self, name: impl Into<String>) -> Self {
         let field_patch = self.field_patch(name);
-        field_patch.is_replace = true;
+        field_patch.set_drop();
         self
     }
 
     /// Like [`Self::with_dropped_field`], but silently ignored if the field does not exist.
     pub fn with_dropped_field_if_exists(mut self, name: impl Into<String>) -> Self {
         let field_patch = self.field_patch(name);
-        field_patch.is_replace = true;
+        field_patch.set_drop();
         field_patch.optional = true;
         self
     }
@@ -405,29 +411,38 @@ impl ExpressionStructPatch {
     /// Specifies an expression to replace a field with.
     pub fn with_replaced_field(mut self, name: impl Into<String>, expr: ExpressionRef) -> Self {
         let field_patch = self.field_patch(name);
-        field_patch.exprs.push(expr);
-        field_patch.is_replace = true;
+        field_patch.set_replacement(expr);
         self
     }
 
-    /// Specifies an expression to insert after an optional predecessor (None = prepend, emit the
-    /// expression before the first input field). Multiple fields can be inserted after the same
-    /// predecessor, and they will be emitted in the same order they were registered.
-    pub fn with_inserted_field(
+    /// Specifies an expression to emit before processing the first input field.
+    pub fn with_prepended_field(mut self, expr: ExpressionRef) -> Self {
+        self.prepended_fields.push(expr);
+        self
+    }
+
+    /// Specifies an expression to insert after `predecessor`. Multiple fields can be inserted after
+    /// the same predecessor, and they will be emitted in the same order they were registered.
+    pub fn with_inserted_field_after(
         mut self,
-        after: Option<impl Into<String>>,
+        predecessor: impl Into<String>,
         expr: ExpressionRef,
     ) -> Self {
-        match after {
-            Some(field_name) => self.field_patch(field_name).exprs.push(expr),
-            None => self.prepended_fields.push(expr),
-        }
+        self.field_patch(predecessor).insertions.push(expr);
+        self
+    }
+
+    /// Specifies an expression to append after all input fields and field-specific insertions.
+    pub fn with_appended_field(mut self, expr: ExpressionRef) -> Self {
+        self.appended_fields.push(expr);
         self
     }
 
     /// True if this patch makes no changes.
     pub fn is_empty(&self) -> bool {
-        self.prepended_fields.is_empty() && self.field_patches.is_empty()
+        self.prepended_fields.is_empty()
+            && self.appended_fields.is_empty()
+            && self.field_patches.is_empty()
     }
 
     /// None, if this is a top-level patch. Otherwise, the path of this nested patch.
@@ -438,6 +453,39 @@ impl ExpressionStructPatch {
     // Gets or creates the field patch for a named input field.
     fn field_patch(&mut self, field_name: impl Into<String>) -> &mut ExpressionFieldPatch {
         self.field_patches.entry(field_name.into()).or_default()
+    }
+
+    /// Returns an error if this patch contains contradictory replacement/drop operations.
+    pub(crate) fn validate(&self) -> DeltaResult<()> {
+        for (field_name, field_patch) in &self.field_patches {
+            if field_patch.replacement_conflict {
+                return Err(Error::generic(format!(
+                    "Field patch for '{field_name}' has multiple replacement/drop operations"
+                )));
+            }
+            if field_patch.replacement_expr.is_some() && field_patch.is_drop {
+                return Err(Error::generic(format!(
+                    "Field patch for '{field_name}' cannot both replace and drop the field"
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl ExpressionFieldPatch {
+    fn check_for_conflict(&mut self) {
+        self.replacement_conflict = self.replacement_expr.is_some() || self.is_drop
+    }
+
+    fn set_drop(&mut self) {
+        self.check_for_conflict();
+        self.is_drop = true;
+    }
+
+    fn set_replacement(&mut self, expr: ExpressionRef) {
+        self.check_for_conflict();
+        self.replacement_expr = Some(expr);
     }
 }
 
@@ -1045,22 +1093,22 @@ impl Display for Expression {
                     sep = ", ";
                 }
                 for (field_name, field_patch) in &patch.field_patches {
-                    let insertions = &field_patch.exprs;
-                    if insertions.is_empty() {
-                        if field_patch.is_replace {
-                            write!(f, "{sep}drop {field_name}")?;
-                        } else {
-                            continue; // no-op; ignore it and don't change `sep` below
-                        }
-                    } else {
-                        let insertions = format_child_list(insertions);
-                        if field_patch.is_replace {
-                            write!(f, "{sep}replace {field_name} with [{insertions}]")?;
-                        } else {
-                            write!(f, "{sep}after {field_name} insert [{insertions}]")?;
-                        }
+                    if let Some(replacement_expr) = &field_patch.replacement_expr {
+                        write!(f, "{sep}replace {field_name} with [{replacement_expr}]")?;
+                        sep = ", ";
+                    } else if field_patch.is_drop {
+                        write!(f, "{sep}drop {field_name}")?;
+                        sep = ", ";
                     }
-                    sep = ", ";
+                    if !field_patch.insertions.is_empty() {
+                        let insertions = format_child_list(&field_patch.insertions);
+                        write!(f, "{sep}after {field_name} insert [{insertions}]")?;
+                        sep = ", ";
+                    }
+                }
+                if !patch.appended_fields.is_empty() {
+                    let appended_fields = format_child_list(&patch.appended_fields);
+                    write!(f, "{sep}append [{appended_fields}]")?;
                 }
                 write!(f, ")")
             }
@@ -1464,11 +1512,9 @@ mod tests {
                 // Insert fields
                 Expression::struct_patch(
                     ExpressionStructPatch::new_top_level()
-                        .with_inserted_field(Some("after_col"), Arc::new(column_expr!("new_col")))
-                        .with_inserted_field(
-                            None::<String>,
-                            Arc::new(Expression::literal("prepended")),
-                        ),
+                        .with_inserted_field_after("after_col", Arc::new(column_expr!("new_col")))
+                        .with_prepended_field(Arc::new(Expression::literal("prepended")))
+                        .with_appended_field(Arc::new(Expression::literal("appended"))),
                 ),
                 // Nested transform
                 Expression::struct_patch(

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -18,7 +18,7 @@ use crate::kernel_predicates::{
 };
 use crate::schema::SchemaRef;
 use crate::transforms::{transform_output_type, ExpressionTransform};
-use crate::{DataType, DeltaResult, DynPartialEq, Error};
+use crate::{DataType, DeltaResult, DynPartialEq};
 
 mod column_names;
 pub(crate) mod literal_expression_transform;
@@ -340,18 +340,16 @@ where
 /// with one expression, or drop the input field.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ExpressionFieldPatch {
-    /// Set by a call to [`Self::with_replaced_field`]. Mutually incopatible with `is_drop`.
+    /// The expression this field patch emits at the input field's output position instead of the
+    /// original input field.
     pub replacement_expr: Option<ExpressionRef>,
-    /// Set by a call to [`Self::with_dropped_field`]. Mutually incopatible with
-    /// `replacement_expr`.
+    /// If true, and there is no replacement expression, the input field is omitted from the output.
     pub is_drop: bool,
     /// Insertions provided by calls to [`Self::with_inserted_field_after`].
     pub insertions: Vec<ExpressionRef>,
     /// If true, this patch is silently ignored when the input field does not exist. Otherwise, a
     /// missing input field produces an error.
     pub optional: bool,
-    /// True if [`Self::with_replaced_field`] or [`Self::with_dropped_field`] was called twice.
-    pub replacement_conflict: bool,
 }
 
 /// A sparse expression patch over the fields of one input struct.
@@ -393,25 +391,25 @@ impl ExpressionStructPatch {
         }
     }
 
-    /// Specifies a field to drop.
+    /// Specifies a field to drop. Any past or future field replacement overrides a drop request.
     pub fn with_dropped_field(mut self, name: impl Into<String>) -> Self {
         let field_patch = self.field_patch(name);
-        field_patch.set_drop();
+        field_patch.is_drop = true;
         self
     }
 
     /// Like [`Self::with_dropped_field`], but silently ignored if the field does not exist.
     pub fn with_dropped_field_if_exists(mut self, name: impl Into<String>) -> Self {
         let field_patch = self.field_patch(name);
-        field_patch.set_drop();
+        field_patch.is_drop = true;
         field_patch.optional = true;
         self
     }
 
-    /// Specifies an expression to replace a field with.
+    /// Specifies an expression to replace a field with. This overrides any prior drop or replace calls.
     pub fn with_replaced_field(mut self, name: impl Into<String>, expr: ExpressionRef) -> Self {
         let field_patch = self.field_patch(name);
-        field_patch.set_replacement(expr);
+        field_patch.replacement_expr = Some(expr);
         self
     }
 
@@ -453,39 +451,6 @@ impl ExpressionStructPatch {
     // Gets or creates the field patch for a named input field.
     fn field_patch(&mut self, field_name: impl Into<String>) -> &mut ExpressionFieldPatch {
         self.field_patches.entry(field_name.into()).or_default()
-    }
-
-    /// Returns an error if this patch contains contradictory replacement/drop operations.
-    pub(crate) fn validate(&self) -> DeltaResult<()> {
-        for (field_name, field_patch) in &self.field_patches {
-            if field_patch.replacement_conflict {
-                return Err(Error::generic(format!(
-                    "Field patch for '{field_name}' has multiple replacement/drop operations"
-                )));
-            }
-            if field_patch.replacement_expr.is_some() && field_patch.is_drop {
-                return Err(Error::generic(format!(
-                    "Field patch for '{field_name}' cannot both replace and drop the field"
-                )));
-            }
-        }
-        Ok(())
-    }
-}
-
-impl ExpressionFieldPatch {
-    fn check_for_conflict(&mut self) {
-        self.replacement_conflict = self.replacement_expr.is_some() || self.is_drop
-    }
-
-    fn set_drop(&mut self) {
-        self.check_for_conflict();
-        self.is_drop = true;
-    }
-
-    fn set_replacement(&mut self, expr: ExpressionRef) {
-        self.check_for_conflict();
-        self.replacement_expr = Some(expr);
     }
 }
 

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -343,7 +343,8 @@ pub struct ExpressionFieldPatch {
     /// The expression this field patch emits at the input field's output position instead of the
     /// original input field.
     pub replacement_expr: Option<ExpressionRef>,
-    /// If true, and there is no replacement expression, the input field is omitted from the output.
+    /// If true, and there is no replacement expression, the input field is omitted from the
+    /// output.
     pub is_drop: bool,
     /// Insertions provided by calls to [`Self::with_inserted_field_after`].
     pub insertions: Vec<ExpressionRef>,
@@ -406,7 +407,8 @@ impl ExpressionStructPatch {
         self
     }
 
-    /// Specifies an expression to replace a field with. This overrides any prior drop or replace calls.
+    /// Specifies an expression to replace a field with. This overrides any prior drop or replace
+    /// calls.
     pub fn with_replaced_field(mut self, name: impl Into<String>, expr: ExpressionRef) -> Self {
         let field_patch = self.field_patch(name);
         field_patch.replacement_expr = Some(expr);

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -1109,11 +1109,13 @@ mod tests {
 
             // With sparse patches, we expect only one insertion for the partition column.
             assert!(patch.prepended_fields.is_empty());
+            assert!(patch.appended_fields.is_empty());
             let mut field_patches = patch.field_patches.iter();
             let (field_name, field_patch) = field_patches.next().unwrap();
             assert_eq!(field_name, "value");
-            assert!(!field_patch.is_replace);
-            let [expr] = &field_patch.exprs[..] else {
+            assert!(field_patch.replacement_expr.is_none());
+            assert!(!field_patch.is_drop);
+            let [expr] = &field_patch.insertions[..] else {
                 panic!("Expected a single insertion");
             };
             let Expr::Literal(Scalar::Date(date_offset)) = expr.as_ref() else {
@@ -1196,10 +1198,10 @@ mod tests {
                     .field_patches
                     .get("row_id_col")
                     .expect("Should have row_id_col patch");
-                assert!(row_id_patch.is_replace);
-                assert_eq!(row_id_patch.exprs.len(), 1);
-                let expr = &row_id_patch.exprs[0];
-                let expeceted_expr = Arc::new(Expr::coalesce([
+                assert!(row_id_patch.replacement_expr.is_some());
+                assert!(!row_id_patch.is_drop);
+                let expr = row_id_patch.replacement_expr.as_ref().unwrap();
+                let expected_expr = Arc::new(Expr::coalesce([
                     Expr::column(["row_id_col"]),
                     Expr::binary(
                         BinaryExpressionOp::Plus,
@@ -1207,7 +1209,7 @@ mod tests {
                         Expr::column(["row_indexes_for_row_id_0"]),
                     ),
                 ]));
-                assert_eq!(expr, &expeceted_expr);
+                assert_eq!(expr, &expected_expr);
             } else {
                 panic!("Should have been a StructPatch expression");
             }

--- a/kernel/src/scan/transform_spec.rs
+++ b/kernel/src/scan/transform_spec.rs
@@ -133,7 +133,7 @@ pub(crate) fn get_transform_expr(
         use FieldTransformSpec::*;
         patch = match field_transform {
             StaticInsert { insert_after, expr } => {
-                patch.with_inserted_field(insert_after.clone(), expr.clone())
+                apply_insert_after(patch, insert_after, expr.clone())
             }
             StaticDrop { field_name } => patch.with_dropped_field(field_name.clone()),
             GenerateRowId {
@@ -164,7 +164,7 @@ pub(crate) fn get_transform_expr(
                 };
 
                 let partition_value = Arc::new(partition_value.into());
-                patch.with_inserted_field(insert_after.clone(), partition_value)
+                apply_insert_after(patch, insert_after, partition_value)
             }
             DynamicColumn {
                 field_index,
@@ -177,13 +177,11 @@ pub(crate) fn get_transform_expr(
                 if exists_physically {
                     // Column exists physically - reorder it via drop+insert
                     // This ensures consistent column ordering across file types
-                    patch = patch
-                        .with_dropped_field(physical_name.clone())
-                        .with_inserted_field(
-                            insert_after.clone(),
-                            Arc::new(Expression::column([physical_name.clone()])),
-                        );
-                    patch
+                    apply_insert_after(
+                        patch.with_dropped_field(physical_name),
+                        insert_after,
+                        Arc::new(Expression::column([physical_name])),
+                    )
                 } else {
                     // Column doesn't exist physically - treat as partition column
                     let Some((_, partition_value)) = metadata_values.remove(field_index) else {
@@ -193,13 +191,25 @@ pub(crate) fn get_transform_expr(
                     };
 
                     let partition_value = Arc::new(partition_value.into());
-                    patch.with_inserted_field(insert_after.clone(), partition_value)
+                    apply_insert_after(patch, insert_after, partition_value)
                 }
             }
         }
     }
 
     Ok(Arc::new(Expression::StructPatch(patch)))
+}
+
+// Adapter that converts the insert_after option into a method call on the patch.
+fn apply_insert_after(
+    patch: ExpressionStructPatch,
+    insert_after: &Option<String>,
+    expr: ExpressionRef,
+) -> ExpressionStructPatch {
+    match insert_after {
+        Some(predecessor) => patch.with_inserted_field_after(predecessor, expr),
+        None => patch.with_prepended_field(expr),
+    }
 }
 
 /// Parse a partition value from the raw string representation
@@ -399,17 +409,19 @@ mod tests {
 
         // Verify StaticInsert: should insert after col1
         assert!(patch.field_patches.contains_key("col1"));
-        assert!(!patch.field_patches["col1"].is_replace);
-        assert_eq!(patch.field_patches["col1"].exprs.len(), 1);
-        let Expression::Literal(scalar) = patch.field_patches["col1"].exprs[0].as_ref() else {
+        assert!(patch.field_patches["col1"].replacement_expr.is_none());
+        assert!(!patch.field_patches["col1"].is_drop);
+        assert_eq!(patch.field_patches["col1"].insertions.len(), 1);
+        let Expression::Literal(scalar) = patch.field_patches["col1"].insertions[0].as_ref() else {
             panic!("Expected literal expression for insert");
         };
         assert_eq!(scalar, &Scalar::Integer(42));
 
-        // Verify StaticDrop: should drop col2 (empty expressions and is_replace = true)
+        // Verify StaticDrop: should drop col2
         assert!(patch.field_patches.contains_key("col2"));
-        assert!(patch.field_patches["col2"].is_replace);
-        assert!(patch.field_patches["col2"].exprs.is_empty());
+        assert!(patch.field_patches["col2"].is_drop);
+        assert!(patch.field_patches["col2"].replacement_expr.is_none());
+        assert!(patch.field_patches["col2"].insertions.is_empty());
     }
 
     #[test]
@@ -441,14 +453,19 @@ mod tests {
 
         // Should drop _change_type and insert it after id
         assert!(patch.field_patches.contains_key("_change_type"));
-        assert!(patch.field_patches["_change_type"].is_replace);
-        assert!(patch.field_patches["_change_type"].exprs.is_empty());
+        assert!(patch.field_patches["_change_type"].is_drop);
+        assert!(patch.field_patches["_change_type"]
+            .replacement_expr
+            .is_none());
+        assert!(patch.field_patches["_change_type"].insertions.is_empty());
 
         assert!(patch.field_patches.contains_key("id"));
-        assert!(!patch.field_patches["id"].is_replace);
-        assert_eq!(patch.field_patches["id"].exprs.len(), 1);
+        assert!(patch.field_patches["id"].replacement_expr.is_none());
+        assert!(!patch.field_patches["id"].is_drop);
+        assert_eq!(patch.field_patches["id"].insertions.len(), 1);
 
-        let Expression::Column(column_name) = patch.field_patches["id"].exprs[0].as_ref() else {
+        let Expression::Column(column_name) = patch.field_patches["id"].insertions[0].as_ref()
+        else {
             panic!("Expected column reference");
         };
         assert_eq!(column_name.as_ref(), &["_change_type"]);
@@ -491,10 +508,11 @@ mod tests {
         assert!(!patch.field_patches.contains_key("_change_type"));
 
         assert!(patch.field_patches.contains_key("id"));
-        assert!(!patch.field_patches["id"].is_replace);
-        assert_eq!(patch.field_patches["id"].exprs.len(), 1);
+        assert!(patch.field_patches["id"].replacement_expr.is_none());
+        assert!(!patch.field_patches["id"].is_drop);
+        assert_eq!(patch.field_patches["id"].insertions.len(), 1);
 
-        let Expression::Literal(scalar) = patch.field_patches["id"].exprs[0].as_ref() else {
+        let Expression::Literal(scalar) = patch.field_patches["id"].insertions[0].as_ref() else {
             panic!("Expected literal");
         };
         assert_eq!(scalar, &Scalar::String("insert".to_string()));
@@ -526,10 +544,11 @@ mod tests {
 
         // Should insert metadata value after id
         assert!(patch.field_patches.contains_key("id"));
-        assert!(!patch.field_patches["id"].is_replace);
-        assert_eq!(patch.field_patches["id"].exprs.len(), 1);
+        assert!(patch.field_patches["id"].replacement_expr.is_none());
+        assert!(!patch.field_patches["id"].is_drop);
+        assert_eq!(patch.field_patches["id"].insertions.len(), 1);
 
-        let Expression::Literal(scalar) = patch.field_patches["id"].exprs[0].as_ref() else {
+        let Expression::Literal(scalar) = patch.field_patches["id"].insertions[0].as_ref() else {
             panic!("Expected literal");
         };
         assert_eq!(scalar, &Scalar::Integer(2024));
@@ -592,9 +611,10 @@ mod tests {
             .field_patches
             .get("row_id_col")
             .expect("Should have row_id_col patch");
-        assert!(row_id_patch.is_replace);
+        assert!(row_id_patch.replacement_expr.is_some());
+        assert!(!row_id_patch.is_drop);
 
-        let expeceted_expr = Arc::new(Expression::coalesce([
+        let expected_expr = Arc::new(Expression::coalesce([
             Expression::column(["row_id_col"]),
             Expression::binary(
                 BinaryExpressionOp::Plus,
@@ -602,9 +622,8 @@ mod tests {
                 Expression::column(["row_index_col"]),
             ),
         ]));
-        assert_eq!(row_id_patch.exprs.len(), 1);
-        let expr = &row_id_patch.exprs[0];
-        assert_eq!(expr, &expeceted_expr);
+        let expr = row_id_patch.replacement_expr.as_ref().unwrap();
+        assert_eq!(expr, &expected_expr);
     }
 
     #[test]

--- a/kernel/src/table_changes/physical_to_logical.rs
+++ b/kernel/src/table_changes/physical_to_logical.rs
@@ -228,17 +228,18 @@ mod tests {
         // Should have a patch for the "id" field with CDF metadata
         assert!(patch.field_patches.contains_key("id"));
         let id_patch = &patch.field_patches["id"];
-        assert!(!id_patch.is_replace);
-        assert_eq!(id_patch.exprs.len(), 2);
+        assert!(id_patch.replacement_expr.is_none());
+        assert!(!id_patch.is_drop);
+        assert_eq!(id_patch.insertions.len(), 2);
 
         // Verify _change_type is "insert" for Add files
-        let Expression::Literal(change_type) = id_patch.exprs[0].as_ref() else {
+        let Expression::Literal(change_type) = id_patch.insertions[0].as_ref() else {
             panic!("Expected literal for _change_type");
         };
         assert_eq!(change_type, &Scalar::String("insert".to_string()));
 
         // Verify _commit_version
-        let Expression::Literal(version) = id_patch.exprs[1].as_ref() else {
+        let Expression::Literal(version) = id_patch.insertions[1].as_ref() else {
             panic!("Expected literal for _commit_version");
         };
         assert_eq!(version, &Scalar::Long(100));
@@ -272,10 +273,10 @@ mod tests {
         };
 
         let name_patch = &patch.field_patches["name"];
-        assert_eq!(name_patch.exprs.len(), 1);
+        assert_eq!(name_patch.insertions.len(), 1);
 
         // Verify _change_type is "delete" for Remove files
-        let Expression::Literal(change_type) = name_patch.exprs[0].as_ref() else {
+        let Expression::Literal(change_type) = name_patch.insertions[0].as_ref() else {
             panic!("Expected literal for _change_type");
         };
         assert_eq!(change_type, &Scalar::String("delete".to_string()));
@@ -322,8 +323,8 @@ mod tests {
 
         // Should have age partition value
         let id_patch = &patch.field_patches["id"];
-        assert_eq!(id_patch.exprs.len(), 1);
-        let Expression::Literal(age_value) = id_patch.exprs[0].as_ref() else {
+        assert_eq!(id_patch.insertions.len(), 1);
+        let Expression::Literal(age_value) = id_patch.insertions[0].as_ref() else {
             panic!("Expected literal for age");
         };
         assert_eq!(age_value, &Scalar::Long(30));
@@ -332,10 +333,10 @@ mod tests {
         // The transform spec has DynamicColumn which becomes a Column expression for CDC files
         // (not a literal metadata value)
         let name_patch = &patch.field_patches["name"];
-        assert_eq!(name_patch.exprs.len(), 1);
+        assert_eq!(name_patch.insertions.len(), 1);
         // Should be a Column expression, not a Literal
         assert!(matches!(
-            name_patch.exprs[0].as_ref(),
+            name_patch.insertions[0].as_ref(),
             Expression::Column(_)
         ));
     }

--- a/kernel/src/transaction/commit_info.rs
+++ b/kernel/src/transaction/commit_info.rs
@@ -91,12 +91,7 @@ impl<S> Transaction<S> {
                 // Step 2: Build literal expressions for each CommitInfo field.
                 let literal_exprs = commit_info_literal_exprs(kernel_commit_info)?;
 
-                // Step 3: Build ExpressionStructPatch. Replacements must be registered before
-                // insertions so that for the last engine field (which may itself be
-                // replaced), exprs is ordered as [replace_expr, insert_exprs...].
-                // The evaluator emits exprs in declaration order, so the replace
-                // value must come first.
-                let last_engine_field = engine_commit_info_schema.field_names().last().cloned();
+                // Step 3: Build ExpressionStructPatch.
                 let mut patch = ExpressionStructPatch::new_top_level();
 
                 // First pass: replace fields that already exist in the engine schema.
@@ -108,8 +103,7 @@ impl<S> Transaction<S> {
                 // Second pass: append kernel-only fields after the last engine field.
                 for (field_name, expr_ref) in &literal_exprs {
                     if !engine_commit_info_schema.contains(*field_name) {
-                        patch = patch
-                            .with_inserted_field(last_engine_field.as_deref(), expr_ref.clone());
+                        patch = patch.with_appended_field(expr_ref.clone());
                     }
                 }
 

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -304,8 +304,8 @@ where
     add_files_metadata.map(move |add_files_batch| {
         let patch_expr = Expression::struct_patch(
             ExpressionStructPatch::new_top_level()
-                .with_inserted_field(
-                    Some("modificationTime"),
+                .with_inserted_field_after(
+                    "modificationTime",
                     Expression::literal(data_change).into(),
                 )
                 .with_replaced_field(
@@ -1404,46 +1404,38 @@ fn build_remove_struct_patch(
 ) -> ExpressionStructPatch {
     let mut patch = ExpressionStructPatch::new_top_level()
         // deletionTimestamp
-        .with_inserted_field(Some("path"), Expression::literal(commit_timestamp).into())
+        .with_inserted_field_after("path", Expression::literal(commit_timestamp).into())
         // dataChange
-        .with_inserted_field(Some("path"), Expression::literal(data_change).into())
+        .with_inserted_field_after("path", Expression::literal(data_change).into())
         // extended_file_metadata
-        .with_inserted_field(Some("path"), Expression::literal(true).into())
-        .with_inserted_field(
-            Some("path"),
+        .with_inserted_field_after("path", Expression::literal(true).into())
+        .with_inserted_field_after(
+            "path",
             Expression::column([FILE_CONSTANT_VALUES_NAME, "partitionValues"]).into(),
         );
 
     if coalesce_stats_with_parsed {
-        // Replace stats with COALESCE(stats, TO_JSON(stats_parsed)), then insert tags after.
-        // Both expressions are registered on the "stats" field_patch (is_replace=true),
-        // so the evaluator emits [coalesced_stats, tags] in place of the original stats field.
+        // Replace stats with COALESCE(stats, TO_JSON(stats_parsed)) and drop stats_parsed.
         let coalesce_stats = Expression::coalesce([
             Expression::column(["stats"]),
             Expression::unary(ToJson, Expression::column([STATS_PARSED_NAME])),
         ]);
         patch = patch
             .with_replaced_field("stats", coalesce_stats.into())
-            .with_inserted_field(
-                Some("stats"),
-                Expression::column([FILE_CONSTANT_VALUES_NAME, TAGS_NAME]).into(),
-            )
-            .with_dropped_field_if_exists(STATS_PARSED_NAME);
-    } else {
-        // tags inserted after stats; stats passes through unchanged
-        patch = patch.with_inserted_field(
-            Some("stats"),
-            Expression::column([FILE_CONSTANT_VALUES_NAME, TAGS_NAME]).into(),
-        );
+            .with_dropped_field(STATS_PARSED_NAME);
     }
 
     patch = patch
-        .with_inserted_field(
-            Some("deletionVector"),
+        .with_inserted_field_after(
+            "stats",
+            Expression::column([FILE_CONSTANT_VALUES_NAME, TAGS_NAME]).into(),
+        )
+        .with_inserted_field_after(
+            "deletionVector",
             Expression::column([FILE_CONSTANT_VALUES_NAME, BASE_ROW_ID_NAME]).into(),
         )
-        .with_inserted_field(
-            Some("deletionVector"),
+        .with_inserted_field_after(
+            "deletionVector",
             Expression::column([FILE_CONSTANT_VALUES_NAME, DEFAULT_ROW_COMMIT_VERSION_NAME]).into(),
         )
         .with_dropped_field(FILE_CONSTANT_VALUES_NAME)

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -495,8 +495,8 @@ impl<S> Transaction<S> {
             nullable_restored_add_schema().clone().into(),
         )?;
         let with_data_change_expr = Arc::new(Expression::struct_from([Expression::struct_patch(
-            ExpressionStructPatch::new_nested(["add"]).with_inserted_field(
-                Some("modificationTime"),
+            ExpressionStructPatch::new_nested(["add"]).with_inserted_field_after(
+                "modificationTime",
                 Expression::literal(self.data_change).into(),
             ),
         )]));


### PR DESCRIPTION
## What changes are proposed in this pull request?

The current struct expression patching API has several warts including:
* No easy way to append a column at the end of the schema (must find/know last column and insert-after it)
* Weird semantics of field replace and drop operations that change depending on invocation order
* Awkward FFI support

Rework the API to be easier to use and less error-prone.

### This PR affects the following public APIs

`ExpressionStructPatch` gained changed/new members and methods

## How was this change tested?

Lots of updated unit tests, plus new ones.