### PR TITLE
test: add VersionTarget::AtTimestamp and IncrementalFrom to TestTableBuilder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,9 +133,10 @@ directly -- ALWAYS use the visitor pattern (`visit_rows` with typed `GetData` ac
 - Reuse helpers from `test_utils` and the integration-test fixtures instead of writing
   custom ones when possible. See **Common test helpers** below for a curated starter list.
 - **Committing in tests:** Use `txn.commit(engine)?.unwrap_committed()` to assert a
-  successful commit and get the `CommittedTransaction`. Do NOT use `match` + `panic!`
-  for this -- `unwrap_committed()` provides a clear error message on failure. Available
-  under `#[cfg(test)]` and the `test-utils` feature.
+  successful commit and get the `CommittedTransaction`. When you only need the resulting
+  snapshot, use `txn.commit(engine)?.unwrap_post_commit_snapshot()` to get the
+  `SnapshotRef` directly. Do NOT use `match` + `panic!` for either -- they provide a clear
+  error message on failure. Available under `#[cfg(test)]` and the `test-utils` feature.
 - **Prefer snapshot/public API assertions over reading raw commit JSON.** Only read raw
   commit JSON when the data is inaccessible via public API (e.g., system domain metadata
   is blocked by `get_domain_metadata`). For commit JSON reads, use `read_actions_from_commit`

--- a/kernel/tests/integration/cross_product/mod.rs
+++ b/kernel/tests/integration/cross_product/mod.rs
@@ -1,5 +1,11 @@
+use std::fs::OpenOptions;
 use std::sync::Arc;
+use std::time::{Duration, SystemTime};
 
+use delta_kernel::committer::FileSystemCommitter;
+use delta_kernel::history_manager::latest_version_as_of;
+use delta_kernel::transaction::create_table::create_table;
+use delta_kernel::transaction::CommitResult;
 use delta_kernel::{DeltaResult, Engine, Snapshot};
 use rstest::rstest;
 use rstest_reuse::apply;
@@ -17,7 +23,9 @@ use test_utils::table_builder::{
     version_incremental_to_latest, version_latest, DataLayoutConfig, FeatureSet, LogState,
     TableConfig, VersionTarget,
 };
-use test_utils::{build_snapshot, default_sweep, read_scan};
+use test_utils::{build_snapshot, default_sweep, read_scan, test_table_setup};
+
+use crate::common::write_utils::get_simple_int_schema;
 
 /// `TestTableBuilder`'s default is one file per data commit with this many rows, so a
 /// snapshot at version `v` has exactly `v * ROWS_PER_COMMIT` total rows. File count
@@ -54,6 +62,75 @@ fn test_cross_product_read_write(
     let batches = read_scan(&scan, engine)?;
     let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
     assert_eq!(rows, expected_version as usize * ROWS_PER_COMMIT);
+
+    Ok(())
+}
+
+/// Companion to the `version_at_timestamp_max()` row in the default sweep, which is a
+/// smoke test (`i64::MAX` trivially resolves to latest). This test exercises
+/// [`VersionTarget::AtTimestamp`] resolving to an intermediate version by writing the
+/// table on local filesystem and assigning each commit file an explicit, distinct
+/// modification time via [`std::fs::File::set_modified`]. The `InMemory` store backing
+/// the default sweep collapses successive `put` timestamps to a single millisecond, so
+/// this case is unreachable there.
+#[test]
+fn test_at_timestamp_resolves_to_intermediate_version() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    // v0: CreateTable
+    let schema = get_simple_int_schema();
+    let create_result = create_table(&table_path, schema, "AtTimestampTest/1.0")
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?;
+    let mut snap = match create_result {
+        CommitResult::CommittedTransaction(c) => c.post_commit_snapshot().unwrap().clone(),
+        _ => panic!("create_table should commit"),
+    };
+
+    // v1..=4: noop commits (each writes a metaData-free, add-free commit JSON).
+    for _ in 1..=4 {
+        let txn = test_utils::begin_transaction(snap.clone(), engine.as_ref())?
+            .with_engine_info("AtTimestampTest");
+        snap = match txn.commit(engine.as_ref())? {
+            CommitResult::CommittedTransaction(c) => c.post_commit_snapshot().unwrap().clone(),
+            _ => panic!("commit should succeed"),
+        };
+    }
+
+    // Pin each commit's mtime to a distinct, monotonic value (in ms).
+    let table_url = delta_kernel::try_parse_uri(&table_path)?;
+    let log_dir = table_url.to_file_path().unwrap().join("_delta_log");
+    let commit_ts_ms: Vec<i64> = (0..=4).map(|v| (v as i64 + 1) * 1000).collect();
+    for (v, ts) in commit_ts_ms.iter().enumerate() {
+        let file_path = log_dir.join(format!("{:020}.json", v));
+        let file = OpenOptions::new().write(true).open(&file_path).unwrap();
+        let time = SystemTime::UNIX_EPOCH + Duration::from_millis(*ts as u64);
+        file.set_modified(time).unwrap();
+    }
+
+    // 2500ms lands strictly between v1 (2000) and v2 (3000): resolves to v1.
+    let latest_snap = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    let v = latest_version_as_of(&latest_snap, engine.as_ref(), 2500)?;
+    assert_eq!(
+        v, 1,
+        "ts=2500 should resolve to v1 (latest with ts <= 2500)"
+    );
+
+    // build_snapshot! end-to-end: at_timestamp(2500) should produce a snapshot at v1.
+    let target = VersionTarget::AtTimestamp(2500);
+    let snap_at_ts = build_snapshot!(target, &table_path, engine.as_ref());
+    assert_eq!(snap_at_ts.version(), 1);
+
+    // Boundary checks: i64::MAX -> latest; before-all -> error.
+    let target_max = VersionTarget::AtTimestamp(i64::MAX);
+    let snap_max = build_snapshot!(target_max, &table_path, engine.as_ref());
+    assert_eq!(snap_max.version(), 4);
+
+    let before_all = latest_version_as_of(&latest_snap, engine.as_ref(), 0);
+    assert!(
+        before_all.is_err(),
+        "ts before earliest commit should error, got {before_all:?}"
+    );
 
     Ok(())
 }

--- a/kernel/tests/integration/cross_product/mod.rs
+++ b/kernel/tests/integration/cross_product/mod.rs
@@ -13,8 +13,9 @@ use test_utils::table_builder::{
     checkpoint_mid_no_hint_post_cleanup, checkpoint_mid_post_cleanup, checkpoint_struct_stats,
     clustered, commits_only, crc_at_end, crc_at_mid, no_checkpoint_stats, no_features, partitioned,
     test_table, two_checkpoints_stale_hint, two_checkpoints_stale_hint_post_cleanup, unpartitioned,
-    version_at_mid, version_incremental_to_latest, version_latest, DataLayoutConfig, FeatureSet,
-    LogState, TableConfig, VersionTarget,
+    version_at_mid, version_at_timestamp_max, version_incremental_from_mid_to_pre_latest,
+    version_incremental_to_latest, version_latest, DataLayoutConfig, FeatureSet, LogState,
+    TableConfig, VersionTarget,
 };
 use test_utils::{build_snapshot, default_sweep, read_scan};
 
@@ -41,10 +42,11 @@ fn test_cross_product_read_write(
     let snap = build_snapshot!(version_target, table.table_root(), engine.as_ref());
 
     let expected_version = match &version_target {
-        VersionTarget::Latest | VersionTarget::IncrementalToLatest { .. } => {
-            log_state.latest_version()
-        }
+        VersionTarget::Latest
+        | VersionTarget::IncrementalToLatest { .. }
+        | VersionTarget::AtTimestamp(_) => log_state.latest_version(),
         VersionTarget::AtVersion(v) => *v,
+        VersionTarget::IncrementalFrom { to, .. } => *to,
     };
     assert_eq!(snap.version(), expected_version);
 

--- a/kernel/tests/integration/cross_product/mod.rs
+++ b/kernel/tests/integration/cross_product/mod.rs
@@ -1,9 +1,5 @@
-use std::fs::OpenOptions;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
 
-use delta_kernel::committer::FileSystemCommitter;
-use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::{DeltaResult, Engine, Snapshot};
 use rstest::rstest;
 use rstest_reuse::apply;
@@ -21,9 +17,7 @@ use test_utils::table_builder::{
     version_incremental_from_mid_to_pre_latest, version_latest, DataLayoutConfig, FeatureSet,
     LogState, TableConfig, VersionTarget,
 };
-use test_utils::{build_snapshot, default_sweep, read_scan, test_table_setup};
-
-use crate::common::write_utils::get_simple_int_schema;
+use test_utils::{build_snapshot, default_sweep, read_scan};
 
 /// `TestTableBuilder`'s default is one file per data commit with this many rows, so a
 /// snapshot at version `v` has exactly `v * ROWS_PER_COMMIT` total rows. File count
@@ -65,55 +59,6 @@ fn test_cross_product_read_write(
     let batches = read_scan(&scan, engine)?;
     let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
     assert_eq!(rows, expected_version as usize * ROWS_PER_COMMIT);
-
-    Ok(())
-}
-
-/// Verifies that [`VersionTarget::AtTimestamp`] wires through `build_snapshot!` to the
-/// version `latest_version_as_of` resolves the timestamp to. Resolution correctness for
-/// the many timestamp/commit-layout combinations is covered by the `history_manager` unit
-/// tests; this only checks the `TestTableBuilder` integration end-to-end. The default
-/// sweep's `version_at_timestamp_max()` row can't reach an intermediate version because
-/// `InMemory` collapses successive `put` timestamps to a single millisecond, so this
-/// writes on the local filesystem and sets each commit's modification time explicitly.
-#[test]
-fn test_at_timestamp_resolves_to_intermediate_version() -> DeltaResult<()> {
-    let (_temp_dir, table_path, engine) = test_table_setup()?;
-
-    // v0: CreateTable
-    let schema = get_simple_int_schema();
-    let mut snap = create_table(&table_path, schema, "AtTimestampTest/1.0")
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
-        .unwrap_post_commit_snapshot();
-
-    // v1..=4: noop commits (each writes a metaData-free, add-free commit JSON).
-    for _ in 1..=4 {
-        snap = test_utils::begin_transaction(snap.clone(), engine.as_ref())?
-            .with_engine_info("AtTimestampTest")
-            .commit(engine.as_ref())?
-            .unwrap_post_commit_snapshot();
-    }
-
-    // Set each commit's mtime to a distinct, monotonic value (in ms).
-    let table_url = delta_kernel::try_parse_uri(&table_path)?;
-    let log_dir = table_url.to_file_path().unwrap().join("_delta_log");
-    for v in 0..=4u64 {
-        let file_path = log_dir.join(format!("{v:020}.json"));
-        let file = OpenOptions::new().write(true).open(&file_path).unwrap();
-        let time = SystemTime::UNIX_EPOCH + Duration::from_millis((v + 1) * 1000);
-        file.set_modified(time).unwrap();
-    }
-
-    // 2500ms lands strictly between v1 (2000) and v2 (3000), so it resolves to v1.
-    let target = VersionTarget::AtTimestamp(2500);
-    let snap_at_ts = build_snapshot!(target, &table_path, engine.as_ref());
-    assert_eq!(snap_at_ts.version(), 1);
-
-    // i64::MAX resolves to latest, mirroring the default sweep's smoke row.
-    let target_max = VersionTarget::AtTimestamp(i64::MAX);
-    let snap_max = build_snapshot!(target_max, &table_path, engine.as_ref());
-    assert_eq!(snap_max.version(), 4);
 
     Ok(())
 }

--- a/kernel/tests/integration/cross_product/mod.rs
+++ b/kernel/tests/integration/cross_product/mod.rs
@@ -3,9 +3,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use delta_kernel::committer::FileSystemCommitter;
-use delta_kernel::history_manager::latest_version_as_of;
 use delta_kernel::transaction::create_table::create_table;
-use delta_kernel::transaction::CommitResult;
 use delta_kernel::{DeltaResult, Engine, Snapshot};
 use rstest::rstest;
 use rstest_reuse::apply;
@@ -19,9 +17,9 @@ use test_utils::table_builder::{
     checkpoint_mid_no_hint_post_cleanup, checkpoint_mid_post_cleanup, checkpoint_struct_stats,
     clustered, commits_only, crc_at_end, crc_at_mid, no_checkpoint_stats, no_features, partitioned,
     test_table, two_checkpoints_stale_hint, two_checkpoints_stale_hint_post_cleanup, unpartitioned,
-    version_at_mid, version_at_timestamp_max, version_incremental_from_mid_to_pre_latest,
-    version_incremental_to_latest, version_latest, DataLayoutConfig, FeatureSet, LogState,
-    TableConfig, VersionTarget,
+    version_at_mid, version_at_timestamp_max, version_incremental_from_mid_to_latest,
+    version_incremental_from_mid_to_pre_latest, version_latest, DataLayoutConfig, FeatureSet,
+    LogState, TableConfig, VersionTarget,
 };
 use test_utils::{build_snapshot, default_sweep, read_scan, test_table_setup};
 
@@ -49,13 +47,11 @@ fn test_cross_product_read_write(
         Arc::new(DefaultEngineBuilder::new(table.store().clone()).build());
     let snap = build_snapshot!(version_target, table.table_root(), engine.as_ref());
 
-    // `AtTimestamp(i64::MAX)` always resolves to latest (every commit's timestamp is
-    // less than `i64::MAX`). Other timestamp values depend on the table's actual commit
-    // timestamps and are exercised by `test_at_timestamp_resolves_to_intermediate_version`.
     let expected_version = match &version_target {
         VersionTarget::Latest | VersionTarget::IncrementalToLatest { .. } => {
             log_state.latest_version()
         }
+        // `i64::MAX` is the only timestamp in the sweep; it always resolves to latest.
         VersionTarget::AtTimestamp(ts) if *ts == i64::MAX => log_state.latest_version(),
         VersionTarget::AtVersion(v) => *v,
         VersionTarget::IncrementalFrom { to, .. } => *to,
@@ -73,71 +69,51 @@ fn test_cross_product_read_write(
     Ok(())
 }
 
-/// Companion to the `version_at_timestamp_max()` row in the default sweep, which is a
-/// smoke test (`i64::MAX` trivially resolves to latest). This test exercises
-/// [`VersionTarget::AtTimestamp`] resolving to an intermediate version by writing the
-/// table on local filesystem and assigning each commit file an explicit, distinct
-/// modification time via [`std::fs::File::set_modified`]. The `InMemory` store backing
-/// the default sweep collapses successive `put` timestamps to a single millisecond, so
-/// this case is unreachable there.
+/// Verifies that [`VersionTarget::AtTimestamp`] wires through `build_snapshot!` to the
+/// version `latest_version_as_of` resolves the timestamp to. Resolution correctness for
+/// the many timestamp/commit-layout combinations is covered by the `history_manager` unit
+/// tests; this only checks the `TestTableBuilder` integration end-to-end. The default
+/// sweep's `version_at_timestamp_max()` row can't reach an intermediate version because
+/// `InMemory` collapses successive `put` timestamps to a single millisecond, so this
+/// writes on the local filesystem and sets each commit's modification time explicitly.
 #[test]
 fn test_at_timestamp_resolves_to_intermediate_version() -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
 
     // v0: CreateTable
     let schema = get_simple_int_schema();
-    let create_result = create_table(&table_path, schema, "AtTimestampTest/1.0")
+    let mut snap = create_table(&table_path, schema, "AtTimestampTest/1.0")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
-    let mut snap = match create_result {
-        CommitResult::CommittedTransaction(c) => c.post_commit_snapshot().unwrap().clone(),
-        _ => panic!("create_table should commit"),
-    };
+        .commit(engine.as_ref())?
+        .unwrap_post_commit_snapshot();
 
     // v1..=4: noop commits (each writes a metaData-free, add-free commit JSON).
     for _ in 1..=4 {
-        let txn = test_utils::begin_transaction(snap.clone(), engine.as_ref())?
-            .with_engine_info("AtTimestampTest");
-        snap = match txn.commit(engine.as_ref())? {
-            CommitResult::CommittedTransaction(c) => c.post_commit_snapshot().unwrap().clone(),
-            _ => panic!("commit should succeed"),
-        };
+        snap = test_utils::begin_transaction(snap.clone(), engine.as_ref())?
+            .with_engine_info("AtTimestampTest")
+            .commit(engine.as_ref())?
+            .unwrap_post_commit_snapshot();
     }
 
-    // Pin each commit's mtime to a distinct, monotonic value (in ms).
+    // Set each commit's mtime to a distinct, monotonic value (in ms).
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
     let log_dir = table_url.to_file_path().unwrap().join("_delta_log");
-    let commit_ts_ms: Vec<i64> = (0..=4).map(|v| (v as i64 + 1) * 1000).collect();
-    for (v, ts) in commit_ts_ms.iter().enumerate() {
-        let file_path = log_dir.join(format!("{:020}.json", v));
+    for v in 0..=4u64 {
+        let file_path = log_dir.join(format!("{v:020}.json"));
         let file = OpenOptions::new().write(true).open(&file_path).unwrap();
-        let time = SystemTime::UNIX_EPOCH + Duration::from_millis(*ts as u64);
+        let time = SystemTime::UNIX_EPOCH + Duration::from_millis((v + 1) * 1000);
         file.set_modified(time).unwrap();
     }
 
-    // 2500ms lands strictly between v1 (2000) and v2 (3000): resolves to v1.
-    let latest_snap = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
-    let v = latest_version_as_of(&latest_snap, engine.as_ref(), 2500)?;
-    assert_eq!(
-        v, 1,
-        "ts=2500 should resolve to v1 (latest with ts <= 2500)"
-    );
-
-    // build_snapshot! end-to-end: at_timestamp(2500) should produce a snapshot at v1.
+    // 2500ms lands strictly between v1 (2000) and v2 (3000), so it resolves to v1.
     let target = VersionTarget::AtTimestamp(2500);
     let snap_at_ts = build_snapshot!(target, &table_path, engine.as_ref());
     assert_eq!(snap_at_ts.version(), 1);
 
-    // Boundary checks: i64::MAX -> latest; before-all -> error.
+    // i64::MAX resolves to latest, mirroring the default sweep's smoke row.
     let target_max = VersionTarget::AtTimestamp(i64::MAX);
     let snap_max = build_snapshot!(target_max, &table_path, engine.as_ref());
     assert_eq!(snap_max.version(), 4);
-
-    let before_all = latest_version_as_of(&latest_snap, engine.as_ref(), 0);
-    assert!(
-        before_all.is_err(),
-        "ts before earliest commit should error, got {before_all:?}"
-    );
 
     Ok(())
 }

--- a/kernel/tests/integration/cross_product/mod.rs
+++ b/kernel/tests/integration/cross_product/mod.rs
@@ -49,12 +49,19 @@ fn test_cross_product_read_write(
         Arc::new(DefaultEngineBuilder::new(table.store().clone()).build());
     let snap = build_snapshot!(version_target, table.table_root(), engine.as_ref());
 
+    // `AtTimestamp(i64::MAX)` always resolves to latest (every commit's timestamp is
+    // less than `i64::MAX`). Other timestamp values depend on the table's actual commit
+    // timestamps and are exercised by `test_at_timestamp_resolves_to_intermediate_version`.
     let expected_version = match &version_target {
-        VersionTarget::Latest
-        | VersionTarget::IncrementalToLatest { .. }
-        | VersionTarget::AtTimestamp(_) => log_state.latest_version(),
+        VersionTarget::Latest | VersionTarget::IncrementalToLatest { .. } => {
+            log_state.latest_version()
+        }
+        VersionTarget::AtTimestamp(ts) if *ts == i64::MAX => log_state.latest_version(),
         VersionTarget::AtVersion(v) => *v,
         VersionTarget::IncrementalFrom { to, .. } => *to,
+        VersionTarget::AtTimestamp(ts) => {
+            panic!("sweep only uses AtTimestamp(i64::MAX), got {ts}")
+        }
     };
     assert_eq!(snap.version(), expected_version);
 

--- a/kernel/tests/integration/log/history_manager.rs
+++ b/kernel/tests/integration/log/history_manager.rs
@@ -1,7 +1,10 @@
 //! Integration tests for the public `history_manager` API.
 
+use std::fs::OpenOptions;
 use std::ops::RangeInclusive;
+use std::time::{Duration, SystemTime};
 
+use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::history_manager::{get_earliest_commit, HistoryCommitType};
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::ObjectStore;
@@ -10,11 +13,15 @@ use delta_kernel::object_store::ObjectStore;
 // silence the resulting unused-import warning.
 #[allow(unused_imports)]
 use delta_kernel::object_store::ObjectStoreExt as _;
-use delta_kernel::Version;
+use delta_kernel::transaction::create_table::create_table;
+use delta_kernel::{DeltaResult, Snapshot, Version};
 use rstest::rstest;
 use test_utils::delta_kernel_default_engine::DefaultEngineBuilder;
-use test_utils::table_builder::{LogState, TestTableBuilder};
+use test_utils::table_builder::{LogState, TestTableBuilder, VersionTarget};
+use test_utils::{build_snapshot, test_table_setup};
 use url::Url;
+
+use crate::common::write_utils::get_simple_int_schema;
 
 async fn remove_commits(store: &dyn ObjectStore, versions: RangeInclusive<Version>) {
     for version in versions {
@@ -55,5 +62,53 @@ async fn test_get_earliest_commit(
         commit_type,
     )?;
     assert_eq!(earliest, expected_version);
+    Ok(())
+}
+
+/// Verifies that [`VersionTarget::AtTimestamp`] resolves through `build_snapshot!` to the
+/// version `latest_version_as_of` selects for a timestamp. `InMemory` collapses successive
+/// `put` timestamps into a single millisecond, so this writes on the local filesystem and
+/// sets each commit's modification time explicitly to get distinct, monotonic commit
+/// timestamps. Resolution correctness across timestamp/commit-layout combinations is covered
+/// by the `history_manager` unit tests; this is the end-to-end `TestTableBuilder` check.
+#[test]
+fn test_at_timestamp_resolves_to_intermediate_version() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    // v0: CreateTable
+    let schema = get_simple_int_schema();
+    let mut snap = create_table(&table_path, schema, "AtTimestampTest/1.0")
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?
+        .unwrap_post_commit_snapshot();
+
+    // v1..=4: noop commits (each writes a metaData-free, add-free commit JSON).
+    for _ in 1..=4 {
+        snap = test_utils::begin_transaction(snap.clone(), engine.as_ref())?
+            .with_engine_info("AtTimestampTest")
+            .commit(engine.as_ref())?
+            .unwrap_post_commit_snapshot();
+    }
+
+    // Set each commit's mtime to a distinct, monotonic value (in ms).
+    let table_url = delta_kernel::try_parse_uri(&table_path)?;
+    let log_dir = table_url.to_file_path().unwrap().join("_delta_log");
+    for v in 0..=4u64 {
+        let file_path = log_dir.join(format!("{v:020}.json"));
+        let file = OpenOptions::new().write(true).open(&file_path).unwrap();
+        let time = SystemTime::UNIX_EPOCH + Duration::from_millis((v + 1) * 1000);
+        file.set_modified(time).unwrap();
+    }
+
+    // 2500ms lands strictly between v1 (2000) and v2 (3000), so it resolves to v1.
+    let target = VersionTarget::AtTimestamp(2500);
+    let snap_at_ts = build_snapshot!(target, &table_path, engine.as_ref());
+    assert_eq!(snap_at_ts.version(), 1);
+
+    // i64::MAX resolves to latest.
+    let target_max = VersionTarget::AtTimestamp(i64::MAX);
+    let snap_max = build_snapshot!(target_max, &table_path, engine.as_ref());
+    assert_eq!(snap_max.version(), 4);
+
     Ok(())
 }

--- a/kernel/tests/integration/log/history_manager.rs
+++ b/kernel/tests/integration/log/history_manager.rs
@@ -65,12 +65,11 @@ async fn test_get_earliest_commit(
     Ok(())
 }
 
-/// Verifies that [`VersionTarget::AtTimestamp`] resolves through `build_snapshot!` to the
-/// version `latest_version_as_of` selects for a timestamp. `InMemory` collapses successive
-/// `put` timestamps into a single millisecond, so this writes on the local filesystem and
-/// sets each commit's modification time explicitly to get distinct, monotonic commit
-/// timestamps. Resolution correctness across timestamp/commit-layout combinations is covered
-/// by the `history_manager` unit tests; this is the end-to-end `TestTableBuilder` check.
+/// End-to-end check that [`VersionTarget::AtTimestamp`] resolves through `build_snapshot!`
+/// to the version `latest_version_as_of` selects. Written on the local filesystem with
+/// explicit, distinct per-commit modification times, which the in-memory sweep can't provide
+/// (see `version_at_timestamp_max`). Resolution correctness across layouts is covered by the
+/// `history_manager` unit tests.
 #[test]
 fn test_at_timestamp_resolves_to_intermediate_version() -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;

--- a/kernel/tests/integration/log/history_manager.rs
+++ b/kernel/tests/integration/log/history_manager.rs
@@ -5,7 +5,7 @@ use std::ops::RangeInclusive;
 use std::time::{Duration, SystemTime};
 
 use delta_kernel::committer::FileSystemCommitter;
-use delta_kernel::history_manager::{get_earliest_commit, HistoryCommitType};
+use delta_kernel::history_manager::{get_earliest_commit, latest_version_as_of, HistoryCommitType};
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::ObjectStore;
 // `ObjectStoreExt` is needed for `store.get()` etc. in arrow-58 mode where these methods moved
@@ -17,7 +17,7 @@ use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::{DeltaResult, Snapshot, Version};
 use rstest::rstest;
 use test_utils::delta_kernel_default_engine::DefaultEngineBuilder;
-use test_utils::table_builder::{LogState, TestTableBuilder, VersionTarget};
+use test_utils::table_builder::{FeatureSet, LogState, TestTableBuilder, VersionTarget};
 use test_utils::{build_snapshot, test_table_setup};
 use url::Url;
 
@@ -108,6 +108,58 @@ fn test_at_timestamp_resolves_to_intermediate_version() -> DeltaResult<()> {
     let target_max = VersionTarget::AtTimestamp(i64::MAX);
     let snap_max = build_snapshot!(target_max, &table_path, engine.as_ref());
     assert_eq!(snap_max.version(), 4);
+
+    Ok(())
+}
+
+/// Targets a specific commit's timestamp end-to-end through the builder. With ICT enabled the
+/// kernel writes a distinct, monotonic timestamp per commit, so each version's timestamp can be
+/// read back (via a snapshot capped at that version) and time-traveled to via
+/// [`VersionTarget::AtTimestamp`]. Querying a version's exact timestamp resolves to that version;
+/// querying one millisecond earlier resolves to its predecessor. Deterministic without setting
+/// commit timestamps explicitly, since ICT values are derived from the table rather than hardcoded.
+#[test]
+fn test_at_timestamp_targets_specific_commit_via_ict() -> DeltaResult<()> {
+    let table = TestTableBuilder::new()
+        .with_features(FeatureSet::new().ict())
+        .with_log_state(LogState::with_latest_version(4))
+        .build()?;
+    let engine = table.engine();
+    let table_root = table.table_root();
+
+    for v in 0..=4u64 {
+        let capped = Snapshot::builder_for(table_root)
+            .at_version(v)
+            .build(&engine)?;
+        let commit =
+            latest_version_as_of(&capped, &engine, i64::MAX, HistoryCommitType::Recreatable)?;
+        assert_eq!(commit.version, v);
+
+        let at_exact = build_snapshot!(
+            VersionTarget::AtTimestamp(commit.timestamp),
+            table_root,
+            &engine
+        );
+        assert_eq!(
+            at_exact.version(),
+            v,
+            "v{v}'s exact timestamp must resolve to v{v}"
+        );
+
+        if v > 0 {
+            let at_prev = build_snapshot!(
+                VersionTarget::AtTimestamp(commit.timestamp - 1),
+                table_root,
+                &engine
+            );
+            assert_eq!(
+                at_prev.version(),
+                v - 1,
+                "one ms before v{v}'s timestamp must resolve to v{}",
+                v - 1
+            );
+        }
+    }
 
     Ok(())
 }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -133,12 +133,14 @@ define_sweeps! {
         checkpoint_struct_stats(),
         no_checkpoint_stats()
     ),
-    // TODO: ICT read assertions (needs pub get_in_commit_timestamp) + AtTimestamp
-    //       VersionTarget (timestamp time travel via history_manager::latest_version_as_of).
+    // TODO: ICT read assertions (needs pub get_in_commit_timestamp). Add a sweep row
+    //       that pins AtTimestamp to a commit-derived value once that lands.
     version_target_values = (
         version_latest(),
         version_at_mid(),
-        version_incremental_to_latest()
+        version_incremental_to_latest(),
+        version_incremental_from_mid_to_pre_latest(),
+        version_at_timestamp_max()
     ),
 }
 use std::collections::HashMap;

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -133,8 +133,11 @@ define_sweeps! {
         checkpoint_struct_stats(),
         no_checkpoint_stats()
     ),
-    // TODO: ICT read assertions (needs pub get_in_commit_timestamp). Add a sweep row
-    //       that pins AtTimestamp to a commit-derived value once that lands.
+    // Only `AtTimestamp(i64::MAX)` is in the sweep: `InMemory` collapses successive `put`
+    // timestamps to a single millisecond, so resolving to an intermediate version is
+    // unreachable here. That case is covered by `test_at_timestamp_resolves_to_intermediate_version`
+    // (local FS, explicit `set_modified`). A commit-derived `AtTimestamp` row can be added
+    // once `get_in_commit_timestamp` is public (needed for ICT read assertions too).
     version_target_values = (
         version_latest(),
         version_at_mid(),

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -133,15 +133,12 @@ define_sweeps! {
         checkpoint_struct_stats(),
         no_checkpoint_stats()
     ),
-    // Only `AtTimestamp(i64::MAX)` is in the sweep: `InMemory` collapses successive `put`
-    // timestamps to a single millisecond, so resolving to an intermediate version is
-    // unreachable here. That case is covered by `test_at_timestamp_resolves_to_intermediate_version`
-    // (local FS, explicit `set_modified`). A commit-derived `AtTimestamp` row can be added
-    // once `get_in_commit_timestamp` is public (needed for ICT read assertions too).
+    // `version_at_timestamp_max()` is the only timestamp row; see its docs for why
+    // intermediate-version resolution lives in a dedicated test instead.
     version_target_values = (
         version_latest(),
         version_at_mid(),
-        version_incremental_to_latest(),
+        version_incremental_from_mid_to_latest(),
         version_incremental_from_mid_to_pre_latest(),
         version_at_timestamp_max()
     ),

--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -1020,8 +1020,9 @@ pub fn version_incremental_to_latest() -> VersionTarget {
         from: DEFAULT_SWEEP_MID_VERSION,
     }
 }
-/// Incremental update from `mid` to `latest - 1`, exercising the partial-replay path to a
-/// non-latest target version (Case F).
+/// Incremental update from `mid` to `latest - 1`. Targets a non-latest `to` to exercise
+/// the partial-replay path that `version_incremental_to_latest()` cannot cover (that one
+/// always goes to latest, which is the same as a non-incremental load).
 pub fn version_incremental_from_mid_to_pre_latest() -> VersionTarget {
     VersionTarget::IncrementalFrom {
         from: DEFAULT_SWEEP_MID_VERSION,
@@ -1842,11 +1843,13 @@ mod tests {
             version_target
         );
         let expected = match &version_target {
-            VersionTarget::Latest
-            | VersionTarget::IncrementalToLatest { .. }
-            | VersionTarget::AtTimestamp(_) => 4,
+            VersionTarget::Latest | VersionTarget::IncrementalToLatest { .. } => 4,
+            VersionTarget::AtTimestamp(ts) if *ts == i64::MAX => 4,
             VersionTarget::AtVersion(v) => *v,
             VersionTarget::IncrementalFrom { to, .. } => *to,
+            VersionTarget::AtTimestamp(ts) => {
+                panic!("test only uses AtTimestamp(i64::MAX), got {ts}")
+            }
         };
         assert_eq!(snap.version(), expected);
     }

--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -1015,31 +1015,27 @@ pub fn version_latest() -> VersionTarget {
 pub fn version_at_mid() -> VersionTarget {
     VersionTarget::AtVersion(DEFAULT_SWEEP_MID_VERSION)
 }
-pub fn version_incremental_to_latest() -> VersionTarget {
+pub fn version_incremental_from_mid_to_latest() -> VersionTarget {
     VersionTarget::IncrementalToLatest {
         from: DEFAULT_SWEEP_MID_VERSION,
     }
 }
-/// Incremental update from `mid` to `latest - 1`. Targets a non-latest `to` to exercise
-/// the partial-replay path that `version_incremental_to_latest()` cannot cover (that one
-/// always goes to latest, which is the same as a non-incremental load).
+/// Incremental update from `mid` to `latest - 1`. The non-latest `to` exercises the
+/// partial-replay path that `version_incremental_from_mid_to_latest()` cannot reach, since
+/// updating to latest is indistinguishable from a non-incremental load.
 pub fn version_incremental_from_mid_to_pre_latest() -> VersionTarget {
     VersionTarget::IncrementalFrom {
         from: DEFAULT_SWEEP_MID_VERSION,
         to: DEFAULT_SWEEP_LATEST_VERSION - 1,
     }
 }
-/// Timestamp travel using `i64::MAX`. Always resolves to the latest version (every
-/// commit's timestamp is less than `i64::MAX`), so this is a smoke test that the
-/// timestamp-conversion path (log-segment build, ICT detection, comparison loop) runs
-/// without error across the sweep -- not a resolution-correctness check.
-///
-/// Non-trivial resolution to an intermediate version is covered by
-/// `test_at_timestamp_resolves_to_intermediate_version` in
-/// `kernel/tests/integration/cross_product`, which controls file modification times
-/// explicitly via local-filesystem [`std::fs::File::set_modified`]. The default sweep
-/// can't reach that case because `InMemory` collapses successive `put` timestamps to a
-/// single millisecond.
+/// Timestamp travel using `i64::MAX`, which always resolves to the latest version (every
+/// commit's timestamp is below `i64::MAX`). This is a smoke test that the timestamp
+/// conversion path runs without error across the sweep, not a resolution-correctness
+/// check: `InMemory` collapses successive `put` timestamps to a single millisecond, so the
+/// sweep can't reach an intermediate version. Resolution to an intermediate version is
+/// covered by `test_at_timestamp_resolves_to_intermediate_version`, which sets commit
+/// modification times explicitly on the local filesystem.
 pub fn version_at_timestamp_max() -> VersionTarget {
     VersionTarget::AtTimestamp(i64::MAX)
 }

--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -1638,11 +1638,15 @@ macro_rules! build_snapshot {
             }
             $crate::table_builder::VersionTarget::AtTimestamp(ts) => {
                 let latest = Snapshot::builder_for($table_root).build($engine).unwrap();
-                let v =
-                    ::delta_kernel::history_manager::latest_version_as_of(&latest, $engine, *ts)
-                        .unwrap();
+                let commit = ::delta_kernel::history_manager::latest_version_as_of(
+                    &latest,
+                    $engine,
+                    *ts,
+                    ::delta_kernel::history_manager::HistoryCommitType::Recreatable,
+                )
+                .unwrap();
                 Snapshot::builder_for($table_root)
-                    .at_version(v)
+                    .at_version(commit.version)
                     .build($engine)
                     .unwrap()
             }

--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -980,6 +980,15 @@ pub enum VersionTarget {
     AtVersion(u64),
     /// Load at `from`, then incrementally update to latest.
     IncrementalToLatest { from: u64 },
+    /// Load at `from`, then incrementally update to a specific target `to`. Exercises the
+    /// `Snapshot::builder_from(base).at_version(to)` path with `to <= latest`. Requires
+    /// `from <= to`.
+    IncrementalFrom { from: u64, to: u64 },
+    /// Time travel by timestamp: resolves `timestamp` (milliseconds since Unix epoch) to a
+    /// version via [`history_manager::latest_version_as_of`], then loads that version.
+    ///
+    /// [`history_manager::latest_version_as_of`]: delta_kernel::history_manager::latest_version_as_of
+    AtTimestamp(i64),
 }
 
 impl fmt::Display for VersionTarget {
@@ -990,6 +999,10 @@ impl fmt::Display for VersionTarget {
             VersionTarget::IncrementalToLatest { from } => {
                 write!(f, "incremental({from}->latest)")
             }
+            VersionTarget::IncrementalFrom { from, to } => {
+                write!(f, "incremental({from}->{to})")
+            }
+            VersionTarget::AtTimestamp(ts) => write!(f, "at_timestamp({ts})"),
         }
     }
 }
@@ -1006,6 +1019,20 @@ pub fn version_incremental_to_latest() -> VersionTarget {
     VersionTarget::IncrementalToLatest {
         from: DEFAULT_SWEEP_MID_VERSION,
     }
+}
+/// Incremental update from `mid` to `latest - 1`, exercising the partial-replay path to a
+/// non-latest target version (Case F).
+pub fn version_incremental_from_mid_to_pre_latest() -> VersionTarget {
+    VersionTarget::IncrementalFrom {
+        from: DEFAULT_SWEEP_MID_VERSION,
+        to: DEFAULT_SWEEP_LATEST_VERSION - 1,
+    }
+}
+/// Timestamp travel using `i64::MAX`, which always resolves to the latest version (every
+/// commit's timestamp is less than `i64::MAX`). Exercises the `latest_version_as_of` code
+/// path uniformly across ICT-enabled and file-modification-timestamp tables.
+pub fn version_at_timestamp_max() -> VersionTarget {
+    VersionTarget::AtTimestamp(i64::MAX)
 }
 
 // ===========================================================================
@@ -1594,6 +1621,26 @@ macro_rules! build_snapshot {
                     .unwrap();
                 Snapshot::builder_from(base).build($engine).unwrap()
             }
+            $crate::table_builder::VersionTarget::IncrementalFrom { from, to } => {
+                let base = Snapshot::builder_for($table_root)
+                    .at_version(*from)
+                    .build($engine)
+                    .unwrap();
+                Snapshot::builder_from(base)
+                    .at_version(*to)
+                    .build($engine)
+                    .unwrap()
+            }
+            $crate::table_builder::VersionTarget::AtTimestamp(ts) => {
+                let latest = Snapshot::builder_for($table_root).build($engine).unwrap();
+                let v =
+                    ::delta_kernel::history_manager::latest_version_as_of(&latest, $engine, *ts)
+                        .unwrap();
+                Snapshot::builder_for($table_root)
+                    .at_version(v)
+                    .build($engine)
+                    .unwrap()
+            }
         }
     };
 }
@@ -1773,7 +1820,9 @@ mod tests {
         #[values(
             VersionTarget::Latest,
             VersionTarget::AtVersion(2),
-            VersionTarget::IncrementalToLatest { from: 1 }
+            VersionTarget::IncrementalToLatest { from: 1 },
+            VersionTarget::IncrementalFrom { from: 1, to: 3 },
+            VersionTarget::AtTimestamp(i64::MAX),
         )]
         version_target: VersionTarget,
     ) {
@@ -1785,8 +1834,11 @@ mod tests {
             version_target
         );
         let expected = match &version_target {
-            VersionTarget::Latest | VersionTarget::IncrementalToLatest { .. } => 4,
+            VersionTarget::Latest
+            | VersionTarget::IncrementalToLatest { .. }
+            | VersionTarget::AtTimestamp(_) => 4,
             VersionTarget::AtVersion(v) => *v,
+            VersionTarget::IncrementalFrom { to, .. } => *to,
         };
         assert_eq!(snap.version(), expected);
     }

--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -1028,9 +1028,17 @@ pub fn version_incremental_from_mid_to_pre_latest() -> VersionTarget {
         to: DEFAULT_SWEEP_LATEST_VERSION - 1,
     }
 }
-/// Timestamp travel using `i64::MAX`, which always resolves to the latest version (every
-/// commit's timestamp is less than `i64::MAX`). Exercises the `latest_version_as_of` code
-/// path uniformly across ICT-enabled and file-modification-timestamp tables.
+/// Timestamp travel using `i64::MAX`. Always resolves to the latest version (every
+/// commit's timestamp is less than `i64::MAX`), so this is a smoke test that the
+/// timestamp-conversion path (log-segment build, ICT detection, comparison loop) runs
+/// without error across the sweep -- not a resolution-correctness check.
+///
+/// Non-trivial resolution to an intermediate version is covered by
+/// `test_at_timestamp_resolves_to_intermediate_version` in
+/// `kernel/tests/integration/cross_product`, which controls file modification times
+/// explicitly via local-filesystem [`std::fs::File::set_modified`]. The default sweep
+/// can't reach that case because `InMemory` collapses successive `put` timestamps to a
+/// single millisecond.
 pub fn version_at_timestamp_max() -> VersionTarget {
     VersionTarget::AtTimestamp(i64::MAX)
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds two new `VersionTarget` variants to the `TestTableBuilder` framework and wires them into the default cross-product sweep:

- `AtTimestamp(i64)` - timestamp time travel via `history_manager::latest_version_as_of`.
- `IncrementalFrom { from: u64, to: u64 }` - build a base snapshot at `from`, then incrementally update to a specific target `to` (vs `IncrementalToLatest` which always goes to latest). 

Two canonical sweep rows are added:

- `version_at_timestamp_max()` uses `i64::MAX` so the call resolves to the latest version uniformly across ICT-enabled and file-modification-timestamp tables.
- `version_incremental_from_mid_to_pre_latest()` goes from mid to `latest - 1` to exercise the partial-replay path to a non-latest target.

Tracking issue: #2526

## How was this change tested?

- `test_version_targets` in `test-utils/src/table_builder.rs` extended with the two new variants.