### PR TITLE
test: extend TableConfig with numIndexedCols and dataSkippingStatsColumns

### DIFF
--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -32,10 +32,11 @@ use crate::table_features::{
 };
 use crate::table_properties::{
     TableProperties, APPEND_ONLY, CHECKPOINT_WRITE_STATS_AS_JSON, CHECKPOINT_WRITE_STATS_AS_STRUCT,
-    COLUMN_MAPPING_MAX_COLUMN_ID, COLUMN_MAPPING_MODE, DELTA_PROPERTY_PREFIX,
-    ENABLE_CHANGE_DATA_FEED, ENABLE_DELETION_VECTORS, ENABLE_ICEBERG_COMPAT_V1,
-    ENABLE_ICEBERG_COMPAT_V2, ENABLE_ICEBERG_COMPAT_V3, ENABLE_IN_COMMIT_TIMESTAMPS,
-    ENABLE_ROW_TRACKING, ENABLE_TYPE_WIDENING, MATERIALIZED_ROW_COMMIT_VERSION_COLUMN_NAME,
+    COLUMN_MAPPING_MAX_COLUMN_ID, COLUMN_MAPPING_MODE, DATA_SKIPPING_NUM_INDEXED_COLS,
+    DATA_SKIPPING_STATS_COLUMNS, DELTA_PROPERTY_PREFIX, ENABLE_CHANGE_DATA_FEED,
+    ENABLE_DELETION_VECTORS, ENABLE_ICEBERG_COMPAT_V1, ENABLE_ICEBERG_COMPAT_V2,
+    ENABLE_ICEBERG_COMPAT_V3, ENABLE_IN_COMMIT_TIMESTAMPS, ENABLE_ROW_TRACKING,
+    ENABLE_TYPE_WIDENING, MATERIALIZED_ROW_COMMIT_VERSION_COLUMN_NAME,
     MATERIALIZED_ROW_ID_COLUMN_NAME, PARQUET_FORMAT_VERSION, ROW_TRACKING_SUSPENDED,
     SET_TRANSACTION_RETENTION_DURATION,
 };
@@ -101,6 +102,10 @@ const ALLOWED_DELTA_PROPERTIES: &[&str] = &[
     // Checkpoint stats format properties
     CHECKPOINT_WRITE_STATS_AS_JSON,
     CHECKPOINT_WRITE_STATS_AS_STRUCT,
+    // Data skipping stats configuration. Neither property enables a feature; both control
+    // the per-file stats schema the writer collects.
+    DATA_SKIPPING_NUM_INDEXED_COLS,
+    DATA_SKIPPING_STATS_COLUMNS,
     // Property-driven feature enablement properties
     ENABLE_DELETION_VECTORS,
     ENABLE_CHANGE_DATA_FEED,
@@ -1100,6 +1105,19 @@ mod tests {
             validated.properties.get(PARQUET_FORMAT_VERSION),
             Some(&"2.12.0".to_string()),
         );
+        assert!(validated.reader_features.is_empty());
+        assert!(validated.writer_features.is_empty());
+    }
+
+    #[rstest::rstest]
+    #[case::num_indexed_cols_cap(DATA_SKIPPING_NUM_INDEXED_COLS, "16")]
+    #[case::num_indexed_cols_all(DATA_SKIPPING_NUM_INDEXED_COLS, "-1")]
+    #[case::stats_columns_multi(DATA_SKIPPING_STATS_COLUMNS, "a,b,c")]
+    #[case::stats_columns_single(DATA_SKIPPING_STATS_COLUMNS, "a")]
+    fn test_data_skipping_properties_accepted(#[case] key: &str, #[case] value: &str) {
+        let properties = HashMap::from([(key.to_string(), value.to_string())]);
+        let validated = validate_extract_table_features_and_properties(properties).unwrap();
+        assert_eq!(validated.properties.get(key), Some(&value.to_string()));
         assert!(validated.reader_features.is_empty());
         assert!(validated.writer_features.is_empty());
     }

--- a/kernel/tests/integration/cross_product/mod.rs
+++ b/kernel/tests/integration/cross_product/mod.rs
@@ -8,15 +8,16 @@ use test_utils::delta_kernel_default_engine::DefaultEngineBuilder;
 use test_utils::table_builder::{
     all_features_cm_id, all_features_cm_name, checkpoint_at_end, checkpoint_at_end_crc_at_end,
     checkpoint_at_end_no_hint, checkpoint_at_end_no_hint_post_cleanup,
-    checkpoint_at_end_post_cleanup, checkpoint_json_stats, checkpoint_mid,
-    checkpoint_mid_crc_above_mid_post_cleanup, checkpoint_mid_crc_at_end_post_cleanup,
-    checkpoint_mid_crc_at_mid_post_cleanup, checkpoint_mid_no_hint,
-    checkpoint_mid_no_hint_post_cleanup, checkpoint_mid_post_cleanup, checkpoint_struct_stats,
-    clustered, commits_only, crc_at_end, crc_at_mid, no_checkpoint_stats, no_features, partitioned,
-    test_table, two_checkpoints_stale_hint, two_checkpoints_stale_hint_post_cleanup, unpartitioned,
-    version_at_mid, version_at_timestamp_max, version_incremental_from_mid_to_latest,
-    version_incremental_from_mid_to_pre_latest, version_latest, DataLayoutConfig, FeatureSet,
-    LogState, TableConfig, VersionTarget,
+    checkpoint_at_end_post_cleanup, checkpoint_mid, checkpoint_mid_crc_above_mid_post_cleanup,
+    checkpoint_mid_crc_at_end_post_cleanup, checkpoint_mid_crc_at_mid_post_cleanup,
+    checkpoint_mid_no_hint, checkpoint_mid_no_hint_post_cleanup, checkpoint_mid_post_cleanup,
+    clustered, commits_only, crc_at_end, crc_at_mid, no_checkpoint_stats, no_features,
+    num_indexed_cols_all, num_indexed_cols_narrow, num_indexed_cols_zero, partitioned,
+    stats_columns_empty, stats_columns_reordered, test_table, two_checkpoints_stale_hint,
+    two_checkpoints_stale_hint_post_cleanup, unpartitioned, version_at_mid,
+    version_at_timestamp_max, version_incremental_from_mid_to_latest,
+    version_incremental_from_mid_to_pre_latest, version_latest, with_json_stats, with_struct_stats,
+    DataLayoutConfig, FeatureSet, LogState, TableConfig, VersionTarget,
 };
 use test_utils::{assert_row_ids_unique, build_snapshot, default_sweep, read_scan};
 
@@ -25,18 +26,20 @@ use test_utils::{assert_row_ids_unique, build_snapshot, default_sweep, read_scan
 /// per commit isn't asserted because partitioned layouts may emit multiple files.
 const ROWS_PER_COMMIT: usize = 10;
 
-/// `default_sweep` is the canonical `{LogState x FeatureSet x DataLayoutConfig x
-/// TableConfig x VersionTarget}` cross-product defined in `test_utils`. Each
-/// combination expands into its own test runner case. Invoking `test_table` here also
-/// exercises the write path that produces each table state.
+/// `default_sweep` is the canonical `{LogState x FeatureSet x (DataLayoutConfig,
+/// TableConfig) x VersionTarget}` cross-product defined in `test_utils`. Data layout and
+/// stats config share one bundled axis (see `layout_config_values`) rather than being
+/// crossed, to keep the case count within budget. Each combination expands into its own
+/// test runner case. Invoking `test_table` here also exercises the write path that produces
+/// each table state.
 #[apply(default_sweep)]
 fn test_cross_product_read_write(
     log_state: LogState,
     feature_set: FeatureSet,
-    data_layout: DataLayoutConfig,
-    table_config: TableConfig,
+    layout_config: (DataLayoutConfig, TableConfig),
     version_target: VersionTarget,
 ) -> DeltaResult<()> {
+    let (data_layout, table_config) = layout_config;
     let table = test_table(log_state.clone(), feature_set, data_layout, table_config);
     let engine: Arc<dyn Engine> =
         Arc::new(DefaultEngineBuilder::new(table.store().clone()).build());

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -133,14 +133,10 @@ define_sweeps! {
         checkpoint_struct_stats(),
         no_checkpoint_stats()
     ),
-    // Data layout and stats config share one bundled axis instead of being crossed: the
-    // sweep only round-trips each pairing (no predicate, so the stats config can't change
-    // the row-count assertion), so a full layout x config cross would multiply the case
-    // count without adding coverage. The rows cover every (encoding x data-skipping knob)
-    // pairing -- json and struct each crossed with numIndexedCols 0/2/-1 and a
-    // dataSkippingStatsColumns list (empty and reordered) -- plus a no-stats row, with the
-    // layout rotated across rows. Skipping behavior itself is asserted in predicate-bearing
-    // unit tests.
+    // Data layout and stats config are bundled into one axis rather than crossed: this
+    // sweep round-trips each pairing with no predicate, so the stats config can't affect
+    // the version or row-count assertions, and crossing the two would add cases without
+    // adding coverage. Skipping behavior is asserted in predicate-bearing unit tests.
     layout_config_values = (
         (unpartitioned(), no_checkpoint_stats()),
         (partitioned(), with_json_stats(num_indexed_cols_zero())),

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -134,20 +134,24 @@ define_sweeps! {
         no_checkpoint_stats()
     ),
     // Data layout and stats config are bundled into one axis (rather than crossed) to keep
-    // the default sweep near its ~4k-case budget. Each row pairs a layout with one stats
-    // config; across the six rows every layout, every checkpoint encoding (json, struct,
-    // none), and a spread of data-skipping knobs (numIndexedCols 0/2/-1 and a
-    // dataSkippingStatsColumns list, empty and reordered) each appear. We deliberately give
-    // up the full layout x config cross product: skipping correctness is covered by
-    // predicate-bearing unit tests, so the sweep only needs round-trip coverage that each
-    // pairing writes and reads back.
+    // the default sweep within its ~4k-case budget. The rows cover every (encoding x
+    // data-skipping knob) pairing -- json and struct each crossed with numIndexedCols 0/2/-1
+    // and a dataSkippingStatsColumns list (empty and reordered) -- plus a no-stats row, with
+    // the layout rotated across rows. The sweep only round-trips each pairing (writes then
+    // reads back); it does not assert skipping behavior, which lives in predicate-bearing
+    // unit tests.
     layout_config_values = (
         (unpartitioned(), no_checkpoint_stats()),
         (partitioned(), with_json_stats(num_indexed_cols_zero())),
-        (clustered(), with_struct_stats(num_indexed_cols_narrow())),
-        (unpartitioned(), with_json_stats(num_indexed_cols_all())),
-        (partitioned(), with_struct_stats(stats_columns_empty())),
-        (clustered(), with_json_stats(stats_columns_reordered()))
+        (clustered(), with_struct_stats(num_indexed_cols_zero())),
+        (unpartitioned(), with_json_stats(num_indexed_cols_narrow())),
+        (partitioned(), with_struct_stats(num_indexed_cols_narrow())),
+        (clustered(), with_json_stats(num_indexed_cols_all())),
+        (unpartitioned(), with_struct_stats(num_indexed_cols_all())),
+        (partitioned(), with_json_stats(stats_columns_empty())),
+        (clustered(), with_struct_stats(stats_columns_empty())),
+        (unpartitioned(), with_json_stats(stats_columns_reordered())),
+        (partitioned(), with_struct_stats(stats_columns_reordered()))
     ),
     // `version_at_timestamp_max()` is the only timestamp row; see its docs for why
     // intermediate-version resolution lives in a dedicated test instead.
@@ -1562,8 +1566,8 @@ pub fn get_materialized_row_tracking_column_names(
 /// it bypasses [`read_actions_from_commit`]'s `to_file_path()` requirement.
 ///
 /// Returns an empty map when the commit contains no `metaData` action, or when the
-/// action has an empty/absent `configuration` field. Non-string config values are
-/// silently dropped (the spec requires all configuration entries to be strings).
+/// action has an empty/absent `configuration` field. Errors if any configuration value is
+/// not a string (the spec requires all configuration entries to be strings).
 /// Propagates object-store errors when the commit file is missing or unreadable.
 pub async fn read_metadata_configuration_from_store(
     store: &DynObjectStore,
@@ -1577,12 +1581,9 @@ pub async fn read_metadata_configuration_from_store(
     for line in std::str::from_utf8(&bytes)?.lines() {
         let v: serde_json::Value = serde_json::from_str(line)?;
         if let Some(c) = v.get("metaData").and_then(|m| m.get("configuration")) {
-            if let Some(obj) = c.as_object() {
-                for (k, val) in obj {
-                    if let Some(s) = val.as_str() {
-                        config.insert(k.clone(), s.to_string());
-                    }
-                }
+            if c.is_object() {
+                let entries: HashMap<String, String> = serde_json::from_value(c.clone())?;
+                config.extend(entries);
             }
         }
     }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -133,12 +133,13 @@ define_sweeps! {
         checkpoint_struct_stats(),
         no_checkpoint_stats()
     ),
-    // Data layout and stats config are bundled into one axis (rather than crossed) to keep
-    // the default sweep within its ~4k-case budget. The rows cover every (encoding x
-    // data-skipping knob) pairing -- json and struct each crossed with numIndexedCols 0/2/-1
-    // and a dataSkippingStatsColumns list (empty and reordered) -- plus a no-stats row, with
-    // the layout rotated across rows. The sweep only round-trips each pairing (writes then
-    // reads back); it does not assert skipping behavior, which lives in predicate-bearing
+    // Data layout and stats config share one bundled axis instead of being crossed: the
+    // sweep only round-trips each pairing (no predicate, so the stats config can't change
+    // the row-count assertion), so a full layout x config cross would multiply the case
+    // count without adding coverage. The rows cover every (encoding x data-skipping knob)
+    // pairing -- json and struct each crossed with numIndexedCols 0/2/-1 and a
+    // dataSkippingStatsColumns list (empty and reordered) -- plus a no-stats row, with the
+    // layout rotated across rows. Skipping behavior itself is asserted in predicate-bearing
     // unit tests.
     layout_config_values = (
         (unpartitioned(), no_checkpoint_stats()),

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -56,6 +56,7 @@ macro_rules! define_sweeps {
         feature_set_values = $fs:tt,
         data_layout_values = $dl:tt,
         table_config_values = $tc:tt,
+        layout_config_values = $lc:tt,
         version_target_values = $vt:tt $(,)?
     ) => {
         #[template]
@@ -64,8 +65,7 @@ macro_rules! define_sweeps {
         pub fn default_sweep(
             #[values $ls] log_state: LogState,
             #[values $fs] feature_set: FeatureSet,
-            #[values $dl] data_layout: DataLayoutConfig,
-            #[values $tc] table_config: TableConfig,
+            #[values $lc] layout_config: (DataLayoutConfig, TableConfig),
             #[values $vt] version_target: VersionTarget,
         ) {
         }
@@ -132,6 +132,22 @@ define_sweeps! {
         checkpoint_json_stats(),
         checkpoint_struct_stats(),
         no_checkpoint_stats()
+    ),
+    // Data layout and stats config are bundled into one axis (rather than crossed) to keep
+    // the default sweep near its ~4k-case budget. Each row pairs a layout with one stats
+    // config; across the six rows every layout, every checkpoint encoding (json, struct,
+    // none), and a spread of data-skipping knobs (numIndexedCols 0/2/-1 and a
+    // dataSkippingStatsColumns list, empty and reordered) each appear. We deliberately give
+    // up the full layout x config cross product: skipping correctness is covered by
+    // predicate-bearing unit tests, so the sweep only needs round-trip coverage that each
+    // pairing writes and reads back.
+    layout_config_values = (
+        (unpartitioned(), no_checkpoint_stats()),
+        (partitioned(), with_json_stats(num_indexed_cols_zero())),
+        (clustered(), with_struct_stats(num_indexed_cols_narrow())),
+        (unpartitioned(), with_json_stats(num_indexed_cols_all())),
+        (partitioned(), with_struct_stats(stats_columns_empty())),
+        (clustered(), with_json_stats(stats_columns_reordered()))
     ),
     // `version_at_timestamp_max()` is the only timestamp row; see its docs for why
     // intermediate-version resolution lives in a dedicated test instead.
@@ -1539,6 +1555,38 @@ pub fn get_materialized_row_tracking_column_names(
             .as_str()
             .map(str::to_owned),
     })
+}
+
+/// Reads the `metaData.configuration` map from commit `version` directly through a
+/// [`DynObjectStore`]. Works with any backing store (`file://`, `memory://`, etc.) since
+/// it bypasses [`read_actions_from_commit`]'s `to_file_path()` requirement.
+///
+/// Returns an empty map when the commit contains no `metaData` action, or when the
+/// action has an empty/absent `configuration` field. Non-string config values are
+/// silently dropped (the spec requires all configuration entries to be strings).
+/// Propagates object-store errors when the commit file is missing or unreadable.
+pub async fn read_metadata_configuration_from_store(
+    store: &DynObjectStore,
+    version: u64,
+) -> Result<HashMap<String, String>, Box<dyn std::error::Error>> {
+    let path =
+        delta_kernel::object_store::path::Path::from(format!("_delta_log/{version:020}.json"));
+    let get_result = store.get(&path).await?;
+    let bytes = get_result.bytes().await?;
+    let mut config = HashMap::new();
+    for line in std::str::from_utf8(&bytes)?.lines() {
+        let v: serde_json::Value = serde_json::from_str(line)?;
+        if let Some(c) = v.get("metaData").and_then(|m| m.get("configuration")) {
+            if let Some(obj) = c.as_object() {
+                for (k, val) in obj {
+                    if let Some(s) = val.as_str() {
+                        config.insert(k.clone(), s.to_string());
+                    }
+                }
+            }
+        }
+    }
+    Ok(config)
 }
 
 /// Removes all scan files from the snapshot, commits the transaction, and returns

--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -828,15 +828,12 @@ pub fn stats_columns_reordered() -> TableConfig {
 }
 
 // === Composers: enable a checkpoint stats encoding on a data-skipping config ===
+// Each enables only its own encoding, so composing both writes stats in both encodings.
 
-/// `cfg` with the JSON checkpoint encoding enabled (`writeStatsAsJson`). Leaves the struct
-/// encoding untouched, so composing both helpers writes stats in both encodings.
 pub fn with_json_stats(cfg: TableConfig) -> TableConfig {
     cfg.write_stats_as_json(true)
 }
 
-/// `cfg` with the struct checkpoint encoding enabled (`writeStatsAsStruct`). Leaves the JSON
-/// encoding untouched, so composing both helpers writes stats in both encodings.
 pub fn with_struct_stats(cfg: TableConfig) -> TableConfig {
     cfg.write_stats_as_struct(true)
 }

--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -827,16 +827,18 @@ pub fn stats_columns_reordered() -> TableConfig {
     TableConfig::new().data_skipping_stats_columns(STATS_COLUMNS_BY_NAME.iter().rev().copied())
 }
 
-// === Composers: wrap a data-skipping config with an explicit checkpoint encoding ===
+// === Composers: enable a checkpoint stats encoding on a data-skipping config ===
 
-/// `cfg` plus the JSON checkpoint encoding (`writeStatsAsJson` on, `writeStatsAsStruct` off).
+/// `cfg` with the JSON checkpoint encoding enabled (`writeStatsAsJson`). Leaves the struct
+/// encoding untouched, so composing both helpers writes stats in both encodings.
 pub fn with_json_stats(cfg: TableConfig) -> TableConfig {
-    cfg.write_stats_as_json(true).write_stats_as_struct(false)
+    cfg.write_stats_as_json(true)
 }
 
-/// `cfg` plus the struct checkpoint encoding (`writeStatsAsStruct` on, `writeStatsAsJson` off).
+/// `cfg` with the struct checkpoint encoding enabled (`writeStatsAsStruct`). Leaves the JSON
+/// encoding untouched, so composing both helpers writes stats in both encodings.
 pub fn with_struct_stats(cfg: TableConfig) -> TableConfig {
-    cfg.write_stats_as_json(false).write_stats_as_struct(true)
+    cfg.write_stats_as_struct(true)
 }
 
 // ===========================================================================

--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -713,6 +713,33 @@ impl TableConfig {
         ));
         self
     }
+
+    /// Set `delta.dataSkippingNumIndexedCols` to `n`: stats are capped to the first `n` leaf
+    /// columns. `-1` means all columns; the protocol default when unset is 32.
+    pub fn num_data_skipping_indexed_cols(mut self, n: i64) -> Self {
+        self.table_properties
+            .push(("delta.dataSkippingNumIndexedCols".into(), n.to_string()));
+        self
+    }
+
+    /// Set `delta.dataSkippingStatsColumns` to a comma-separated list of column names.
+    /// Per the Delta spec this takes precedence over `dataSkippingNumIndexedCols`. The
+    /// builder joins names verbatim and does not validate them; entries that don't
+    /// resolve in the active schema are silently skipped by kernel (with a warning).
+    pub fn data_skipping_stats_columns<I, S>(mut self, columns: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let joined = columns
+            .into_iter()
+            .map(Into::into)
+            .collect::<Vec<_>>()
+            .join(",");
+        self.table_properties
+            .push(("delta.dataSkippingStatsColumns".into(), joined));
+        self
+    }
 }
 
 impl fmt::Display for TableConfig {
@@ -735,8 +762,20 @@ impl fmt::Display for TableConfig {
     }
 }
 
-// Canonical sweep rows for the TableConfig axis. These toggle only the *checkpoint*
-// stats encoding -- per-commit add-file stats are always written and unaffected.
+// Canonical sweep rows for the `TableConfig` axis. The sweep covers three checkpoint
+// stats encodings plus six data-skipping rows: three count-based (`numIndexedCols`)
+// values and three named-columns (`dataSkippingStatsColumns`) shapes, so each knob
+// varies across the full LogState x FeatureSet x DataLayout x VersionTarget cross
+// product. Per-commit add-file stats are always written and unaffected by the
+// checkpoint format flags.
+
+/// Stats-column names that span the schemas used by [`DataLayoutConfig`]: `int_col`
+/// exists in [`default_schema`], `value` in [`partitioned_schema`] and
+/// [`clustered_schema`]. Kernel silently skips entries that don't exist in the active
+/// schema, so each layout collects stats on whichever entry matches.
+pub(crate) const STATS_COLUMNS_BY_NAME: &[&str] = &["int_col", "value"];
+
+// === Checkpoint stats encoding rows ===
 
 pub fn checkpoint_json_stats() -> TableConfig {
     TableConfig::new()
@@ -750,10 +789,54 @@ pub fn checkpoint_struct_stats() -> TableConfig {
         .write_stats_as_struct(true)
 }
 
+/// Disables both checkpoint stats encodings; per-commit add-file stats are still written.
 pub fn no_checkpoint_stats() -> TableConfig {
     TableConfig::new()
         .write_stats_as_json(false)
         .write_stats_as_struct(false)
+}
+
+// === numIndexedCols rows (count-based data skipping) ===
+
+/// `numIndexedCols = 0`: zero leaf columns get stats.
+pub fn num_indexed_cols_zero() -> TableConfig {
+    TableConfig::new().num_data_skipping_indexed_cols(0)
+}
+
+/// `numIndexedCols = 2`: cap stats to the first 2 leaf columns.
+pub fn num_indexed_cols_narrow() -> TableConfig {
+    TableConfig::new().num_data_skipping_indexed_cols(2)
+}
+
+/// `numIndexedCols = -1`: stats on every leaf column.
+pub fn num_indexed_cols_all() -> TableConfig {
+    TableConfig::new().num_data_skipping_indexed_cols(-1)
+}
+
+// === dataSkippingStatsColumns rows (named-cols data skipping) ===
+
+/// `dataSkippingStatsColumns = []`: named-cols knob set, no columns listed.
+pub fn stats_columns_empty() -> TableConfig {
+    TableConfig::new().data_skipping_stats_columns(std::iter::empty::<&str>())
+}
+
+/// `dataSkippingStatsColumns` listing names that match at least one column in every
+/// `DataLayoutConfig` schema (kernel silently skips entries that don't match), in reverse
+/// schema order to exercise list-order preservation through write + read.
+pub fn stats_columns_reordered() -> TableConfig {
+    TableConfig::new().data_skipping_stats_columns(STATS_COLUMNS_BY_NAME.iter().rev().copied())
+}
+
+// === Composers: wrap a data-skipping config with an explicit checkpoint encoding ===
+
+/// `cfg` plus the JSON checkpoint encoding (`writeStatsAsJson` on, `writeStatsAsStruct` off).
+pub fn with_json_stats(cfg: TableConfig) -> TableConfig {
+    cfg.write_stats_as_json(true).write_stats_as_struct(false)
+}
+
+/// `cfg` plus the struct checkpoint encoding (`writeStatsAsStruct` on, `writeStatsAsJson` off).
+pub fn with_struct_stats(cfg: TableConfig) -> TableConfig {
+    cfg.write_stats_as_json(false).write_stats_as_struct(true)
 }
 
 // ===========================================================================
@@ -1892,6 +1975,43 @@ mod tests {
         let snap = Snapshot::builder_for(table.table_root()).build(&engine)?;
         assert_eq!(snap.version(), 0);
         Ok(())
+    }
+
+    #[test]
+    fn test_data_skipping_table_properties_in_metadata() -> DeltaResult<()> {
+        let table = TestTableBuilder::new()
+            .with_table_config(
+                TableConfig::new()
+                    .num_data_skipping_indexed_cols(2)
+                    .data_skipping_stats_columns(["int_col", "long_col"]),
+            )
+            .build()?;
+        let config = read_metadata_configuration(table.store(), 0)?;
+        assert_eq!(
+            config
+                .get("delta.dataSkippingNumIndexedCols")
+                .map(|s| s.as_str()),
+            Some("2")
+        );
+        assert_eq!(
+            config
+                .get("delta.dataSkippingStatsColumns")
+                .map(|s| s.as_str()),
+            Some("int_col,long_col")
+        );
+        Ok(())
+    }
+
+    fn read_metadata_configuration(
+        store: &Arc<DynObjectStore>,
+        version: u64,
+    ) -> DeltaResult<std::collections::HashMap<String, String>> {
+        let store = store.clone();
+        block_on_sync(move || async move {
+            crate::read_metadata_configuration_from_store(store.as_ref(), version)
+                .await
+                .map_err(|e| delta_kernel::Error::generic(e.to_string()))
+        })
     }
 
     /// Verifies every common table config builds successfully.


### PR DESCRIPTION
## What changes are proposed in this pull request?

Extends `TableConfig` in `test-utils/` with two data-skipping knobs and folds them into the existing default-sweep `TableConfig` rows so the cross-product width

| Row | Stats encoding | Data-skipping knob |
|---|---|---|
| `checkpoint_json_stats` | `writeStatsAsJson=true` | `numIndexedCols=2` |
| `checkpoint_struct_stats` | `writeStatsAsStruct=true` | `dataSkippingStatsColumns=int_col,value` |
| `no_checkpoint_stats` | both false | (none) |

 `delta.dataSkippingNumIndexedCols` and `delta.dataSkippingStatsColumns` are added to `ALLOWED_DELTA_PROPERTIES` in `create_table.rs`. 

Tracking issue: #2526

## How was this change tested?

New unit tests