### PR TITLE
feat!: add metrics for SetTransaction and DomainMetadata loads

### DIFF
--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -76,6 +76,8 @@ pub enum MetricEvent {
     ProtocolMetadataLoaded(ProtocolMetadataLoaded),
     SnapshotCompleted(SnapshotCompleted),
     SnapshotFailed(SnapshotFailed),
+    DomainMetadataLoaded(DomainMetadataLoaded),
+    SetTransactionLoaded(SetTransactionLoaded),
     CrcReadCompleted(CrcReadCompleted),
     JsonReadCompleted(JsonReadCompleted),
     ParquetReadCompleted(ParquetReadCompleted),
@@ -94,6 +96,8 @@ impl MetricEvent {
             Self::ProtocolMetadataLoaded(e) => e.set_duration(d),
             Self::SnapshotCompleted(e) => e.set_duration(d),
             Self::SnapshotFailed(e) => e.set_duration(d),
+            Self::DomainMetadataLoaded(e) => e.set_duration(d),
+            Self::SetTransactionLoaded(e) => e.set_duration(d),
             Self::CrcReadCompleted(e) => e.set_duration(d),
 
             // Duration already set at construction.
@@ -112,11 +116,13 @@ impl MetricEvent {
             // Variants with u64 fields set during span lifetime.
             Self::LogSegmentLoaded(e) => e.record_u64(name, value),
             Self::SnapshotCompleted(e) => e.record_u64(name, value),
+            Self::DomainMetadataLoaded(e) => e.record_u64(name, value),
             Self::CrcReadCompleted(e) => e.record_u64(name, value),
 
             // No u64 fields set during span lifetime — a runtime record() on these is a bug.
             Self::ProtocolMetadataLoaded(_) => Err(ProtocolMetadataLoaded::SPAN_NAME),
             Self::SnapshotFailed(_) => Err(SnapshotCompleted::SPAN_NAME),
+            Self::SetTransactionLoaded(_) => Err(SetTransactionLoaded::SPAN_NAME),
             Self::ScanMetadataCompleted(_) => Err(ScanMetadataCompleted::SPAN_NAME),
             Self::JsonReadCompleted(_) => Err(JsonReadCompleted::SPAN_NAME),
             Self::ParquetReadCompleted(_) => Err(ParquetReadCompleted::SPAN_NAME),
@@ -130,6 +136,8 @@ impl MetricEvent {
         match self {
             // Variants with bool fields set during span lifetime.
             Self::LogSegmentLoaded(e) => e.record_bool(name, value),
+            Self::DomainMetadataLoaded(e) => e.record_bool(name, value),
+            Self::SetTransactionLoaded(e) => e.record_bool(name, value),
 
             // No bool fields set during span lifetime — a runtime record() on these is a bug.
             Self::ProtocolMetadataLoaded(_) => Err(ProtocolMetadataLoaded::SPAN_NAME),
@@ -153,6 +161,8 @@ impl fmt::Display for MetricEvent {
             Self::ProtocolMetadataLoaded(e) => e.fmt(f),
             Self::SnapshotCompleted(e) => e.fmt(f),
             Self::SnapshotFailed(e) => e.fmt(f),
+            Self::DomainMetadataLoaded(e) => e.fmt(f),
+            Self::SetTransactionLoaded(e) => e.fmt(f),
             Self::CrcReadCompleted(e) => e.fmt(f),
             Self::JsonReadCompleted(e) => e.fmt(f),
             Self::ParquetReadCompleted(e) => e.fmt(f),
@@ -387,6 +397,130 @@ impl fmt::Display for SnapshotFailed {
         write!(
             f,
             "SnapshotFailed(id={operation_id}, duration={duration:?})"
+        )
+    }
+}
+
+// ====================================================================
+// DomainMetadataLoaded
+// ====================================================================
+
+pub(crate) const DOMAIN_METADATA_LOADED_SPAN: &str = "domain_metadata_loaded";
+
+/// Emitted once per domain metadata load, whether served from the CRC cache (`from_cache`) or
+/// from a log replay. Covers connector-issued loads of user domains and kernel-internal loads of
+/// system (`delta.*`) domains such as clustering or row tracking.
+#[derive(Debug, Clone)]
+pub struct DomainMetadataLoaded {
+    // === Set during span lifetime ===
+    pub from_cache: bool,
+    pub num_domains_returned: u64,
+
+    // === Set on span close ===
+    pub duration: Duration,
+}
+
+impl DomainMetadataLoaded {
+    pub(crate) const SPAN_NAME: &'static str = DOMAIN_METADATA_LOADED_SPAN;
+
+    pub(crate) fn from_attrs(_attrs: &Attributes<'_>) -> Self {
+        Self {
+            from_cache: false,
+            num_domains_returned: 0,
+            duration: Duration::default(),
+        }
+    }
+
+    pub(crate) fn record_u64(&mut self, name: &str, value: u64) -> Result<(), &'static str> {
+        match name {
+            "num_domains_returned" => self.num_domains_returned = value,
+            _ => return Err(Self::SPAN_NAME),
+        }
+        Ok(())
+    }
+
+    pub(crate) fn record_bool(&mut self, name: &str, value: bool) -> Result<(), &'static str> {
+        match name {
+            "from_cache" => self.from_cache = value,
+            _ => return Err(Self::SPAN_NAME),
+        }
+        Ok(())
+    }
+
+    pub(crate) fn set_duration(&mut self, d: Duration) {
+        self.duration = d;
+    }
+}
+
+impl fmt::Display for DomainMetadataLoaded {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            from_cache,
+            num_domains_returned,
+            duration,
+        } = self;
+        write!(
+            f,
+            "DomainMetadataLoaded(duration={duration:?}, from_cache={from_cache}, \
+             domains_returned={num_domains_returned})"
+        )
+    }
+}
+
+// ====================================================================
+// SetTransactionLoaded
+// ====================================================================
+
+pub(crate) const SET_TRANSACTION_LOADED_SPAN: &str = "set_transaction_loaded";
+
+/// Emitted once per `SetTransaction` (app id) load, whether served from the CRC cache
+/// (`from_cache`) or from a log replay. `found` is true when the app id has a committed
+/// transaction version, false when no `SetTransaction` exists for it.
+#[derive(Debug, Clone)]
+pub struct SetTransactionLoaded {
+    // === Set during span lifetime ===
+    pub from_cache: bool,
+    pub found: bool,
+
+    // === Set on span close ===
+    pub duration: Duration,
+}
+
+impl SetTransactionLoaded {
+    pub(crate) const SPAN_NAME: &'static str = SET_TRANSACTION_LOADED_SPAN;
+
+    pub(crate) fn from_attrs(_attrs: &Attributes<'_>) -> Self {
+        Self {
+            from_cache: false,
+            found: false,
+            duration: Duration::default(),
+        }
+    }
+
+    pub(crate) fn record_bool(&mut self, name: &str, value: bool) -> Result<(), &'static str> {
+        match name {
+            "from_cache" => self.from_cache = value,
+            "found" => self.found = value,
+            _ => return Err(Self::SPAN_NAME),
+        }
+        Ok(())
+    }
+
+    pub(crate) fn set_duration(&mut self, d: Duration) {
+        self.duration = d;
+    }
+}
+
+impl fmt::Display for SetTransactionLoaded {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            from_cache,
+            found,
+            duration,
+        } = self;
+        write!(
+            f,
+            "SetTransactionLoaded(duration={duration:?}, from_cache={from_cache}, found={found})"
         )
     }
 }

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -405,7 +405,7 @@ impl fmt::Display for SnapshotFailed {
 // DomainMetadataLoaded
 // ====================================================================
 
-pub(crate) const DOMAIN_METADATA_LOADED_SPAN: &str = "domain_metadata_loaded";
+pub(crate) const DOMAIN_METADATA_LOADED_SPAN: &str = "snap.get_domain_metadata";
 
 /// Emitted once per domain metadata load, whether served from the CRC cache (`from_cache`) or
 /// from a log replay. Covers connector-issued loads of user domains and kernel-internal loads of
@@ -462,7 +462,7 @@ impl fmt::Display for DomainMetadataLoaded {
         write!(
             f,
             "DomainMetadataLoaded(duration={duration:?}, from_cache={from_cache}, \
-             domains_returned={num_domains_returned})"
+             num_domains_returned={num_domains_returned})"
         )
     }
 }
@@ -471,11 +471,11 @@ impl fmt::Display for DomainMetadataLoaded {
 // SetTransactionLoaded
 // ====================================================================
 
-pub(crate) const SET_TRANSACTION_LOADED_SPAN: &str = "set_transaction_loaded";
+pub(crate) const SET_TRANSACTION_LOADED_SPAN: &str = "snap.get_app_id_version";
 
 /// Emitted once per `SetTransaction` (app id) load, whether served from the CRC cache
 /// (`from_cache`) or from a log replay. `found` is true when the app id has a committed
-/// transaction version, false when no `SetTransaction` exists for it.
+/// transaction version, false when none exists or the existing one is expired.
 #[derive(Debug, Clone)]
 pub struct SetTransactionLoaded {
     // === Set during span lifetime ===

--- a/kernel/src/metrics/mod.rs
+++ b/kernel/src/metrics/mod.rs
@@ -72,10 +72,11 @@ pub(crate) mod reporter;
 use std::sync::Arc;
 
 pub use events::{
-    emit_json_read_completed, emit_parquet_read_completed, CrcReadCompleted, JsonReadCompleted,
-    LogSegmentLoaded, MetricEvent, MetricId, ParquetReadCompleted, ProtocolMetadataLoaded,
-    ScanMetadataCompleted, ScanType, SnapshotCompleted, SnapshotFailed, StorageCopyCompleted,
-    StorageListCompleted, StorageReadCompleted,
+    emit_json_read_completed, emit_parquet_read_completed, CrcReadCompleted, DomainMetadataLoaded,
+    JsonReadCompleted, LogSegmentLoaded, MetricEvent, MetricId, ParquetReadCompleted,
+    ProtocolMetadataLoaded, ScanMetadataCompleted, ScanType, SetTransactionLoaded,
+    SnapshotCompleted, SnapshotFailed, StorageCopyCompleted, StorageListCompleted,
+    StorageReadCompleted,
 };
 pub use reporter::{LoggingMetricsReporter, MetricsReporter, ReportGeneratorLayer};
 use tracing::Subscriber;

--- a/kernel/src/metrics/reporter.rs
+++ b/kernel/src/metrics/reporter.rs
@@ -246,11 +246,16 @@ impl Visit for EventVisitor {
             "return" => {} // default to the success case
             "error" => {
                 // `#[instrument(err)]` records `error` when the wrapped function returns Err.
-                // Flip SnapshotCompleted into SnapshotFailed.
                 self.event = match self.event.take() {
+                    // Flip SnapshotCompleted into SnapshotFailed.
                     Some(MetricEvent::SnapshotCompleted(snap)) => {
                         Some(MetricEvent::SnapshotFailed(snap.into_failed()))
                     }
+                    // A "Loaded" event represents a successful load. Drop it on error so a
+                    // failed load is not reported as an empty successful one.
+                    Some(
+                        MetricEvent::DomainMetadataLoaded(_) | MetricEvent::SetTransactionLoaded(_),
+                    ) => None,
                     other => other,
                 };
             }

--- a/kernel/src/metrics/reporter.rs
+++ b/kernel/src/metrics/reporter.rs
@@ -10,9 +10,9 @@ use tracing_subscriber::layer::Context;
 use tracing_subscriber::Layer;
 
 use super::events::{
-    storage_metric_from_attrs, CrcReadCompleted, JsonReadCompleted, LogSegmentLoaded, MetricEvent,
-    ParquetReadCompleted, ProtocolMetadataLoaded, ScanMetadataCompleted, SnapshotCompleted,
-    STORAGE_SPAN,
+    storage_metric_from_attrs, CrcReadCompleted, DomainMetadataLoaded, JsonReadCompleted,
+    LogSegmentLoaded, MetricEvent, ParquetReadCompleted, ProtocolMetadataLoaded,
+    ScanMetadataCompleted, SetTransactionLoaded, SnapshotCompleted, STORAGE_SPAN,
 };
 
 // ====================================================================
@@ -113,6 +113,12 @@ where
             )),
             SnapshotCompleted::SPAN_NAME => Some(MetricEvent::SnapshotCompleted(
                 SnapshotCompleted::from_attrs(attrs),
+            )),
+            DomainMetadataLoaded::SPAN_NAME => Some(MetricEvent::DomainMetadataLoaded(
+                DomainMetadataLoaded::from_attrs(attrs),
+            )),
+            SetTransactionLoaded::SPAN_NAME => Some(MetricEvent::SetTransactionLoaded(
+                SetTransactionLoaded::from_attrs(attrs),
             )),
             CrcReadCompleted::SPAN_NAME => Some(MetricEvent::CrcReadCompleted(
                 CrcReadCompleted::from_attrs(attrs),

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -24,6 +24,7 @@ use crate::crc::{
 use crate::expressions::ColumnName;
 use crate::incremental_scan::IncrementalScanBuilder;
 use crate::log_segment::{DomainMetadataMap, LogSegment};
+use crate::metrics::events::{DOMAIN_METADATA_LOADED_SPAN, SET_TRANSACTION_LOADED_SPAN};
 use crate::metrics::MetricId;
 use crate::path::ParsedLogPath;
 use crate::scan::ScanBuilder;
@@ -348,13 +349,27 @@ impl Snapshot {
     /// txn based on the delta.setTransactionRetentionDuration property and lastUpdated.
     ///
     /// Uses the CRC fast path when available, otherwise falls back to log replay.
+    ///
+    /// Reports metrics: `SetTransactionLoaded`.
     // TODO: add a get_app_id_versions to fetch all at once using SetTransactionScanner::get_all
-    #[instrument(parent = &self.span, name = "snap.get_app_id_version", skip_all, err)]
+    #[instrument(
+        parent = &self.span,
+        name = SET_TRANSACTION_LOADED_SPAN,
+        skip_all,
+        err,
+        fields(report, from_cache, found)
+    )]
     pub fn get_app_id_version(
         &self,
         application_id: &str,
         engine: &dyn Engine,
     ) -> DeltaResult<Option<i64>> {
+        fn record_metric(from_cache: bool, found: bool) {
+            let span = tracing::Span::current();
+            span.record("from_cache", from_cache);
+            span.record("found", found);
+        }
+
         let expiration_timestamp =
             calculate_transaction_expiration_timestamp(self.table_properties())?;
 
@@ -366,16 +381,19 @@ impl Snapshot {
             match &crc.set_transaction_state {
                 SetTransactionState::Complete(map) => {
                     // Complete is authoritative: a miss means the app_id has no transaction.
-                    return Ok(map
+                    let version = map
                         .get(application_id)
                         .filter(|txn| !is_set_txn_expired(expiration_timestamp, txn.last_updated))
-                        .map(|txn| txn.version));
+                        .map(|txn| txn.version);
+                    record_metric(true, version.is_some());
+                    return Ok(version);
                 }
                 SetTransactionState::Partial(map) => {
                     // Hit is authoritative; miss falls through to log replay below.
                     if let Some(txn) = map.get(application_id) {
                         let version = (!is_set_txn_expired(expiration_timestamp, txn.last_updated))
                             .then_some(txn.version);
+                        record_metric(true, version.is_some());
                         return Ok(version);
                     }
                 }
@@ -389,6 +407,7 @@ impl Snapshot {
             engine,
             expiration_timestamp,
         )?;
+        record_metric(false, txn.is_some());
         Ok(txn.map(|t| t.version))
     }
 
@@ -483,12 +502,27 @@ impl Snapshot {
     /// Load domain metadata: if Complete in the CRC, answer from the cache; else if every
     /// requested domain is in a Partial cache, also answer from the cache; else full log
     /// replay. `domains == None` means load all.
+    ///
+    /// Reports metrics: `DomainMetadataLoaded`.
+    #[instrument(
+        parent = &self.span,
+        name = DOMAIN_METADATA_LOADED_SPAN,
+        skip_all,
+        err,
+        fields(report, from_cache, num_domains_returned)
+    )]
     #[internal_api]
     pub(crate) fn get_domain_metadatas_internal(
         &self,
         engine: &dyn Engine,
         domains: Option<&HashSet<&str>>,
     ) -> DeltaResult<DomainMetadataMap> {
+        fn record_metric(from_cache: bool, num_domains_returned: usize) {
+            let span = tracing::Span::current();
+            span.record("from_cache", from_cache);
+            span.record("num_domains_returned", num_domains_returned as u64);
+        }
+
         // Fast path: serve from CRC if it tracks domain metadata at this version.
         if let Some(crc) = self
             .lazy_crc
@@ -496,7 +530,7 @@ impl Snapshot {
         {
             match &crc.domain_metadata_state {
                 DomainMetadataState::Complete(map) => {
-                    return Ok(match domains {
+                    let hits: DomainMetadataMap = match domains {
                         None => map.clone(),
                         // Look up each filter key. A miss means the domain does not exist
                         // at this version (Complete is authoritative for misses), so skip
@@ -505,7 +539,9 @@ impl Snapshot {
                             .iter()
                             .filter_map(|&k| map.get(k).map(|v| (k.to_string(), v.clone())))
                             .collect(),
-                    });
+                    };
+                    record_metric(true, hits.len());
+                    return Ok(hits);
                 }
                 DomainMetadataState::Partial(map) => {
                     if let Some(filter) = domains {
@@ -520,6 +556,7 @@ impl Snapshot {
                             .map(|&k| map.get(k).map(|v| (k.to_string(), v.clone())))
                             .collect();
                         if let Some(hits) = hits {
+                            record_metric(true, hits.len());
                             return Ok(hits);
                         }
                     }
@@ -531,7 +568,9 @@ impl Snapshot {
         //       miss search could skip that range and only scan the older commits, then
         //       union those results with the Partial cache's entries to produce the final
         //       answer.
-        self.log_segment().scan_domain_metadatas(domains, engine)
+        let replayed = self.log_segment().scan_domain_metadatas(domains, engine)?;
+        record_metric(false, replayed.len());
+        Ok(replayed)
     }
 
     /// Fetch both user-controlled and system-controlled domain metadata for a specific domain

--- a/kernel/tests/integration/metrics/snapshot_load.rs
+++ b/kernel/tests/integration/metrics/snapshot_load.rs
@@ -4,6 +4,7 @@
 //! fast-path, CRC at prior version, checkpoint with tail commits) plus on-demand API calls
 //! (`get_domain_metadata`) that incur additional I/O after a snapshot is already built.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -15,8 +16,10 @@ use delta_kernel::object_store::local::LocalFileSystem;
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::ObjectStoreExt as _;
 use delta_kernel::transaction::create_table::create_table;
+use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::{DeltaResult, Snapshot};
-use test_utils::{insert_data, test_table_setup_mt};
+use rstest::rstest;
+use test_utils::{insert_data, test_table_setup, test_table_setup_mt};
 use url::Url;
 
 use super::{
@@ -383,6 +386,98 @@ fn get_domain_metadata_when_no_latest_crc_incurs_additional_log_replay() -> Delt
         "get_domain_metadata replays the log, incurring one additional JSON read call"
     );
     assert!(reporter.json_files_read.get() > 0);
+
+    Ok(())
+}
+
+// ============================================================================
+// Scenario 9: domain metadata and set-transaction loads
+// ============================================================================
+
+// Creates a table with clustering and rowTracking enabled (two system domain metadatas), as well
+// as a SetTransaction.
+async fn setup_table_with_dms_and_set_txns(
+    write_crc: bool,
+) -> DeltaResult<(Url, tempfile::TempDir)> {
+    let (temp_dir, table_path, engine) = test_table_setup()?;
+    let table_url = delta_kernel::try_parse_uri(&table_path)?;
+    let committer = || Box::new(FileSystemCommitter::new());
+
+    let properties = HashMap::from([("delta.enableRowTracking".to_string(), "true".to_string())]);
+    let snap_v0 = create_table(&table_path, simple_schema(), "Test/1.0")
+        .with_table_properties(properties)
+        .with_data_layout(DataLayout::clustered(["id"]))
+        .build(engine.as_ref(), committer())?
+        .commit(engine.as_ref())?
+        .unwrap_post_commit_snapshot();
+
+    let snap_v1 = snap_v0
+        .transaction(committer(), engine.as_ref())?
+        .with_operation("WRITE".to_string())
+        .with_transaction_id("my-app".to_string(), 1)
+        .commit(engine.as_ref())?
+        .unwrap_post_commit_snapshot();
+
+    if write_crc {
+        snap_v1.write_checksum(engine.as_ref())?;
+    }
+    Ok((table_url, temp_dir))
+}
+
+#[rstest]
+#[case::log_replay(false)]
+#[case::crc_cache(true)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn write_transaction_loads_domain_metadata_internally(
+    #[case] with_crc: bool,
+) -> DeltaResult<()> {
+    let (table_url, _temp_dir) = setup_table_with_dms_and_set_txns(with_crc).await?;
+
+    let (engine, reporter, _guard) = measuring_engine(Arc::new(LocalFileSystem::new()));
+    let engine = Arc::new(engine);
+    let snap = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+
+    // Isolate the transaction's internal loads from the snapshot build.
+    reporter.reset();
+    insert_data(snap, &engine, vec![Arc::new(Int32Array::from(vec![1]))])
+        .await?
+        .unwrap_post_commit_snapshot();
+
+    // Clustering domain (creating the transaction) + row-tracking domain (committing the append).
+    assert_eq!(reporter.domain_metadata_loads.get(), 2);
+    assert_eq!(
+        reporter.domain_metadata_cache_hits.get(),
+        2 * with_crc as u64
+    );
+    assert_eq!(reporter.domain_metadata_domains_returned.get(), 2);
+
+    Ok(())
+}
+
+#[rstest]
+#[case::log_replay(false)]
+#[case::crc_cache(true)]
+#[tokio::test]
+async fn get_app_id_version_load_emits_loaded_metric(#[case] with_crc: bool) -> DeltaResult<()> {
+    let (table_url, _temp_dir) = setup_table_with_dms_and_set_txns(with_crc).await?;
+
+    let (engine, reporter, _guard) = measuring_engine(Arc::new(LocalFileSystem::new()));
+    let snap = Snapshot::builder_for(table_url).build(&engine)?;
+
+    // Hit on an app id with a committed transaction.
+    reporter.reset();
+    assert_eq!(snap.get_app_id_version("my-app", &engine)?, Some(1));
+    assert_eq!(reporter.set_transaction_loads.get(), 1);
+    assert_eq!(reporter.set_transaction_cache_hits.get(), with_crc as u64);
+    assert_eq!(reporter.set_transaction_found.get(), 1);
+
+    // Miss on an unknown app id. A Complete CRC answers the miss from cache; without a CRC it
+    // falls back to log replay.
+    reporter.reset();
+    assert_eq!(snap.get_app_id_version("no-such-app", &engine)?, None);
+    assert_eq!(reporter.set_transaction_loads.get(), 1);
+    assert_eq!(reporter.set_transaction_cache_hits.get(), with_crc as u64);
+    assert_eq!(reporter.set_transaction_found.get(), 0);
 
     Ok(())
 }

--- a/kernel/tests/integration/metrics/snapshot_load.rs
+++ b/kernel/tests/integration/metrics/snapshot_load.rs
@@ -1,8 +1,7 @@
-//! Snapshot-loading and on-demand API metrics tests.
+//! Metrics tests for snapshot loading and on-demand snapshot APIs.
 //!
-//! Covers all major log-segment shapes (delta-only, V1 checkpoint, log compaction, CRC
-//! fast-path, CRC at prior version, checkpoint with tail commits) plus on-demand API calls
-//! (`get_domain_metadata`) that incur additional I/O after a snapshot is already built.
+//! Each test builds a table in a known state, attaches a `CountingReporter`, and asserts the
+//! exact metric counters a real connector would observe.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -394,8 +393,8 @@ fn get_domain_metadata_when_no_latest_crc_incurs_additional_log_replay() -> Delt
 // Scenario 9: domain metadata and set-transaction loads
 // ============================================================================
 
-// Creates a table with clustering and rowTracking enabled (two system domain metadatas), as well
-// as a SetTransaction.
+// Creates a table with clustering and rowTracking enabled (two system domain metadatas), plus a
+// user domain metadata and a SetTransaction.
 async fn setup_table_with_dms_and_set_txns(
     write_crc: bool,
 ) -> DeltaResult<(Url, tempfile::TempDir)> {
@@ -414,6 +413,7 @@ async fn setup_table_with_dms_and_set_txns(
     let snap_v1 = snap_v0
         .transaction(committer(), engine.as_ref())?
         .with_operation("WRITE".to_string())
+        .with_domain_metadata("myapp.config".to_string(), "v1".to_string())
         .with_transaction_id("my-app".to_string(), 1)
         .commit(engine.as_ref())?
         .unwrap_post_commit_snapshot();
@@ -478,6 +478,56 @@ async fn get_app_id_version_load_emits_loaded_metric(#[case] with_crc: bool) -> 
     assert_eq!(reporter.set_transaction_loads.get(), 1);
     assert_eq!(reporter.set_transaction_cache_hits.get(), with_crc as u64);
     assert_eq!(reporter.set_transaction_found.get(), 0);
+
+    Ok(())
+}
+
+#[rstest]
+#[case::log_replay(false)]
+#[case::crc_cache(true)]
+#[tokio::test]
+async fn get_domain_metadata_load_emits_loaded_metric(#[case] with_crc: bool) -> DeltaResult<()> {
+    let (table_url, _temp_dir) = setup_table_with_dms_and_set_txns(with_crc).await?;
+
+    let (engine, reporter, _guard) = measuring_engine(Arc::new(LocalFileSystem::new()));
+    let snap = Snapshot::builder_for(table_url).build(&engine)?;
+
+    // Hit on the user domain.
+    reporter.reset();
+    assert!(snap.get_domain_metadata("myapp.config", &engine)?.is_some());
+    assert_eq!(reporter.domain_metadata_loads.get(), 1);
+    assert_eq!(reporter.domain_metadata_cache_hits.get(), with_crc as u64);
+    assert_eq!(reporter.domain_metadata_domains_returned.get(), 1);
+
+    // Miss on a nonexistent domain. A Complete CRC answers the miss from cache; without a CRC it
+    // falls back to log replay.
+    reporter.reset();
+    assert!(snap
+        .get_domain_metadata("does.not.exist", &engine)?
+        .is_none());
+    assert_eq!(reporter.domain_metadata_loads.get(), 1);
+    assert_eq!(reporter.domain_metadata_cache_hits.get(), with_crc as u64);
+    assert_eq!(reporter.domain_metadata_domains_returned.get(), 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn failed_loads_emit_no_metric() -> DeltaResult<()> {
+    let (table_url, _temp_dir) = setup_table_with_dms_and_set_txns(false).await?;
+
+    let (engine, reporter, _guard) = measuring_engine(Arc::new(LocalFileSystem::new()));
+    let snap = Snapshot::builder_for(table_url.clone()).build(&engine)?;
+
+    // Remove a commit so the log has a gap and the replay-based load fails.
+    let log_dir = table_url.to_file_path().unwrap().join("_delta_log");
+    std::fs::remove_file(log_dir.join("00000000000000000001.json")).unwrap();
+
+    reporter.reset();
+    assert!(snap.get_domain_metadata("myapp.config", &engine).is_err());
+    assert!(snap.get_app_id_version("my-app", &engine).is_err());
+    assert_eq!(reporter.domain_metadata_loads.get(), 0);
+    assert_eq!(reporter.set_transaction_loads.get(), 0);
 
     Ok(())
 }

--- a/test-utils/src/counting_reporter.rs
+++ b/test-utils/src/counting_reporter.rs
@@ -176,6 +176,16 @@ pub struct CountingReporter {
     pub crc_read_calls: RelaxedCounter,
     /// Total number of bytes read from CRC files, across all CRC read calls.
     pub crc_bytes_read: RelaxedCounter,
+
+    // Domain metadata load counters (Snapshot::get_domain_metadatas_internal)
+    pub domain_metadata_loads: RelaxedCounter,
+    pub domain_metadata_cache_hits: RelaxedCounter,
+    pub domain_metadata_domains_returned: RelaxedCounter,
+
+    // SetTransaction load counters (Snapshot::get_app_id_version)
+    pub set_transaction_loads: RelaxedCounter,
+    pub set_transaction_cache_hits: RelaxedCounter,
+    pub set_transaction_found: RelaxedCounter,
 }
 
 impl CountingReporter {
@@ -208,6 +218,12 @@ impl CountingReporter {
         self.latest_crc_files_found.reset();
         self.crc_read_calls.reset();
         self.crc_bytes_read.reset();
+        self.domain_metadata_loads.reset();
+        self.domain_metadata_cache_hits.reset();
+        self.domain_metadata_domains_returned.reset();
+        self.set_transaction_loads.reset();
+        self.set_transaction_cache_hits.reset();
+        self.set_transaction_found.reset();
     }
 
     /// Print a human-readable IO and operation summary.
@@ -285,6 +301,23 @@ impl MetricsReporter for CountingReporter {
                 self.crc_read_calls.inc();
                 self.crc_bytes_read.add(e.bytes_read);
             }
+            MetricEvent::DomainMetadataLoaded(e) => {
+                self.domain_metadata_loads.inc();
+                if e.from_cache {
+                    self.domain_metadata_cache_hits.inc();
+                }
+                self.domain_metadata_domains_returned
+                    .add(e.num_domains_returned);
+            }
+            MetricEvent::SetTransactionLoaded(e) => {
+                self.set_transaction_loads.inc();
+                if e.from_cache {
+                    self.set_transaction_cache_hits.inc();
+                }
+                if e.found {
+                    self.set_transaction_found.inc();
+                }
+            }
             // Intentionally not tracked. Add counters if needed.
             MetricEvent::ProtocolMetadataLoaded(_)
             | MetricEvent::SnapshotFailed(_)
@@ -299,8 +332,9 @@ mod tests {
     use std::time::Duration;
 
     use delta_kernel::metrics::{
-        CrcReadCompleted, LogSegmentLoaded, MetricId, ProtocolMetadataLoaded, SnapshotCompleted,
-        SnapshotFailed, StorageCopyCompleted, StorageListCompleted, StorageReadCompleted,
+        CrcReadCompleted, DomainMetadataLoaded, LogSegmentLoaded, MetricId, ProtocolMetadataLoaded,
+        SetTransactionLoaded, SnapshotCompleted, SnapshotFailed, StorageCopyCompleted,
+        StorageListCompleted, StorageReadCompleted,
     };
 
     use super::*;
@@ -406,6 +440,42 @@ mod tests {
     }
 
     #[test]
+    fn report_domain_metadata_loaded_increments_domain_metadata_counters() {
+        let reporter = CountingReporter::new();
+        reporter.report(MetricEvent::DomainMetadataLoaded(DomainMetadataLoaded {
+            from_cache: true,
+            num_domains_returned: 3,
+            duration: dur(),
+        }));
+        reporter.report(MetricEvent::DomainMetadataLoaded(DomainMetadataLoaded {
+            from_cache: false,
+            num_domains_returned: 1,
+            duration: dur(),
+        }));
+        assert_eq!(reporter.domain_metadata_loads.get(), 2);
+        assert_eq!(reporter.domain_metadata_cache_hits.get(), 1);
+        assert_eq!(reporter.domain_metadata_domains_returned.get(), 4);
+    }
+
+    #[test]
+    fn report_set_transaction_loaded_increments_set_transaction_counters() {
+        let reporter = CountingReporter::new();
+        reporter.report(MetricEvent::SetTransactionLoaded(SetTransactionLoaded {
+            from_cache: true,
+            found: true,
+            duration: dur(),
+        }));
+        reporter.report(MetricEvent::SetTransactionLoaded(SetTransactionLoaded {
+            from_cache: false,
+            found: false,
+            duration: dur(),
+        }));
+        assert_eq!(reporter.set_transaction_loads.get(), 2);
+        assert_eq!(reporter.set_transaction_cache_hits.get(), 1);
+        assert_eq!(reporter.set_transaction_found.get(), 1);
+    }
+
+    #[test]
     fn report_untracked_events_does_not_panic() {
         let reporter = CountingReporter::new();
         reporter.report(MetricEvent::ProtocolMetadataLoaded(
@@ -448,6 +518,16 @@ mod tests {
             duration: dur(),
             bytes_read: 512,
         }));
+        reporter.report(MetricEvent::DomainMetadataLoaded(DomainMetadataLoaded {
+            from_cache: true,
+            num_domains_returned: 2,
+            duration: dur(),
+        }));
+        reporter.report(MetricEvent::SetTransactionLoaded(SetTransactionLoaded {
+            from_cache: true,
+            found: true,
+            duration: dur(),
+        }));
 
         reporter.reset();
 
@@ -471,5 +551,11 @@ mod tests {
         assert_eq!(reporter.latest_crc_files_found.get(), 0);
         assert_eq!(reporter.crc_read_calls.get(), 0);
         assert_eq!(reporter.crc_bytes_read.get(), 0);
+        assert_eq!(reporter.domain_metadata_loads.get(), 0);
+        assert_eq!(reporter.domain_metadata_cache_hits.get(), 0);
+        assert_eq!(reporter.domain_metadata_domains_returned.get(), 0);
+        assert_eq!(reporter.set_transaction_loads.get(), 0);
+        assert_eq!(reporter.set_transaction_cache_hits.get(), 0);
+        assert_eq!(reporter.set_transaction_found.get(), 0);
     }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add `DomainMetadataLoaded` and `SetTransactionLoaded` metric events. Coupled this together since the PR isn't too big.

## How was this change tested?

A few new UTs.
