### PR TITLE
test: inject sparse nulls into table-builder data generation

### DIFF
--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -54,10 +54,11 @@ use std::fmt;
 use std::sync::Arc;
 
 use delta_kernel::arrow::array::{
-    ArrayRef, BinaryArray, BooleanArray, Date32Array, Decimal128Array, Float32Array, Float64Array,
-    Int16Array, Int32Array, Int64Array, Int8Array, RecordBatch, StringArray, StructArray,
-    TimestampMicrosecondArray,
+    Array, ArrayRef, BinaryArray, BooleanArray, Date32Array, Decimal128Array, Float32Array,
+    Float64Array, Int16Array, Int32Array, Int64Array, Int8Array, RecordBatch, StringArray,
+    StructArray, TimestampMicrosecondArray,
 };
+use delta_kernel::arrow::buffer::NullBuffer;
 use delta_kernel::arrow::datatypes::{DataType as ArrowDataType, Schema as ArrowSchema, TimeUnit};
 use delta_kernel::checkpoint::{CheckpointSpec, V2CheckpointConfig};
 use delta_kernel::committer::FileSystemCommitter;
@@ -834,7 +835,8 @@ pub fn table_configs(
 /// [`FeatureSet`], and [`TableConfig`].
 #[derive(Clone, Debug, PartialEq)]
 pub enum DataLayoutConfig {
-    /// No special data layout (default schema).
+    /// No partitioning or clustering. Uses an all-primitives schema including a
+    /// nested-struct column.
     Unpartitioned,
     /// Partition by every valid primitive type. Uses [`partitioned_schema`] with all columns
     /// as partition columns.
@@ -843,6 +845,12 @@ pub enum DataLayoutConfig {
     /// clustering-eligible columns. Boolean and Binary are excluded (not stats-eligible).
     ClusteredAllTypes,
 }
+
+/// Period for sparse null injection. Data generation emits a null every
+/// `NULL_RATE_EVERY_NTH` rows for each nullable, non-partition column, regardless of
+/// [`DataLayoutConfig`]. Partition and clustering values are never nulled so partition
+/// values stay well-defined.
+pub const NULL_RATE_EVERY_NTH: usize = 3;
 
 impl DataLayoutConfig {
     /// The layout column names (partition or clustering) for this config. Returns all
@@ -1338,7 +1346,13 @@ async fn write_data_commit<E: TaskExecutor>(
                 continue;
             }
             let data_type = arrow_field.data_type();
-            columns.push(generate_column(data_type, rows_per_file, base));
+            let values = generate_column(data_type, rows_per_file, base);
+            let values = if arrow_field.is_nullable() {
+                with_sparse_nulls(values, NULL_RATE_EVERY_NTH)
+            } else {
+                values
+            };
+            columns.push(values);
             data_fields.push(arrow_field.clone());
         }
         let data_arrow_schema = ArrowSchema::new(data_fields);
@@ -1442,12 +1456,36 @@ fn generate_column(arrow_type: &ArrowDataType, rows: usize, base: i32) -> ArrayR
         ArrowDataType::Struct(fields) => {
             let child_arrays: Vec<ArrayRef> = fields
                 .iter()
-                .map(|f| generate_column(f.data_type(), rows, base))
+                .map(|f| {
+                    let child = generate_column(f.data_type(), rows, base);
+                    if f.is_nullable() {
+                        with_sparse_nulls(child, NULL_RATE_EVERY_NTH)
+                    } else {
+                        child
+                    }
+                })
                 .collect();
             Arc::new(StructArray::new(fields.clone(), child_arrays, None))
         }
         other => panic!("unsupported Arrow type in test data generation: {other:?}"),
     }
+}
+
+/// Wrap `array` so that every `every_nth`-th row reads as null. Used by
+/// [`write_data_commit`] to make the default sweep exercise null-aware code paths
+/// (stats null counts, predicate evaluation under null, etc.) uniformly.
+fn with_sparse_nulls(array: ArrayRef, every_nth: usize) -> ArrayRef {
+    assert!(every_nth >= 1, "every_nth must be >= 1");
+    let n = array.len();
+    let valid: Vec<bool> = (0..n).map(|i| !i.is_multiple_of(every_nth)).collect();
+    let null_buffer = NullBuffer::from(valid);
+    let data = array
+        .to_data()
+        .into_builder()
+        .nulls(Some(null_buffer))
+        .build()
+        .expect("rebuilding array with null buffer");
+    delta_kernel::arrow::array::make_array(data)
 }
 
 // ===========================================================================
@@ -1990,6 +2028,39 @@ mod tests {
         let batches = crate::read_scan(&scan, engine)?;
         let total: usize = batches.iter().map(|b| b.num_rows()).sum();
         assert_eq!(total, 10);
+        Ok(())
+    }
+
+    /// Verifies the data generator injects sparse nulls into every nullable data column.
+    /// Uses `rows_per_file = NULL_RATE_EVERY_NTH * 3` so each file has exactly three null
+    /// rows per column.
+    #[test]
+    fn test_sparse_null_injection_in_generated_data() -> DeltaResult<()> {
+        let rows_per_file = NULL_RATE_EVERY_NTH * 3;
+        let table = TestTableBuilder::new()
+            .with_log_state(LogState::with_latest_version(1))
+            .with_data(1, rows_per_file)
+            .build()?;
+        let engine: Arc<dyn delta_kernel::Engine> =
+            Arc::new(DefaultEngineBuilder::new(table.store().clone()).build());
+        let snap = Snapshot::builder_for(table.table_root()).build(engine.as_ref())?;
+        let scan = snap.scan_builder().build()?;
+        let batches = crate::read_scan(&scan, engine)?;
+        assert!(!batches.is_empty(), "expected at least one batch");
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, rows_per_file);
+        let expected_nulls_per_col = rows_per_file / NULL_RATE_EVERY_NTH;
+        for batch in &batches {
+            for col_idx in 0..batch.num_columns() {
+                let null_count = batch.column(col_idx).null_count();
+                assert_eq!(
+                    null_count,
+                    expected_nulls_per_col,
+                    "column '{}' should have {expected_nulls_per_col} nulls, got {null_count}",
+                    batch.schema().field(col_idx).name(),
+                );
+            }
+        }
         Ok(())
     }
 

--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -1229,6 +1229,7 @@ impl TestTableBuilder {
                 self.num_data_files,
                 self.rows_per_file,
                 &self.partition_columns,
+                &self.clustering_columns,
                 v,
             )
             .await?
@@ -1316,13 +1317,15 @@ fn write_crc(snapshot: &Arc<Snapshot>, engine: &dyn Engine) -> DeltaResult<()> {
 /// Produces `num_files` parquet files with `rows_per_file` rows each. For partitioned
 /// tables, all rows in a file share the same partition values; for unpartitioned or
 /// clustered tables, uses `unpartitioned_write_context`. Non-partition columns get
-/// varying data derived from version and file index.
+/// varying data derived from version and file index. Partition and clustering columns
+/// are never nulled so their values stay well-defined.
 async fn write_data_commit<E: TaskExecutor>(
     snapshot: Arc<Snapshot>,
     engine: &DefaultEngine<E>,
     num_files: usize,
     rows_per_file: usize,
     partition_columns: &[String],
+    clustering_columns: &[String],
     version: u64,
 ) -> DeltaResult<delta_kernel::transaction::CommitResult> {
     let logical_schema = snapshot.schema().clone();
@@ -1342,12 +1345,14 @@ async fn write_data_commit<E: TaskExecutor>(
         let mut columns: Vec<ArrayRef> = Vec::new();
         for (arrow_field, kernel_field) in arrow_schema.fields().iter().zip(logical_schema.fields())
         {
-            if partition_columns.contains(&kernel_field.name().to_string()) {
+            let name = kernel_field.name();
+            if partition_columns.iter().any(|c| c == name) {
                 continue;
             }
             let data_type = arrow_field.data_type();
             let values = generate_column(data_type, rows_per_file, base);
-            let values = if arrow_field.is_nullable() {
+            let values = if arrow_field.is_nullable() && !clustering_columns.iter().any(|c| c == name)
+            {
                 with_sparse_nulls(values, NULL_RATE_EVERY_NTH)
             } else {
                 values
@@ -2059,6 +2064,49 @@ mod tests {
                     "column '{}' should have {expected_nulls_per_col} nulls, got {null_count}",
                     batch.schema().field(col_idx).name(),
                 );
+            }
+        }
+        Ok(())
+    }
+
+    /// Partition and clustering columns must never be nulled, even though the data
+    /// generator injects sparse nulls into every other nullable column. Clustered tables
+    /// write through the unpartitioned path, so the clustering case guards against the
+    /// generator treating clustering columns like ordinary data columns.
+    #[rstest::rstest]
+    #[case::partitioned(partitioned())]
+    #[case::clustered(clustered())]
+    fn test_layout_columns_are_never_nulled(#[case] config: DataLayoutConfig) -> DeltaResult<()> {
+        let rows_per_file = NULL_RATE_EVERY_NTH * 3;
+        let layout_columns = config.columns();
+        let table = TestTableBuilder::new()
+            .with_log_state(LogState::with_latest_version(1))
+            .with_data_layout(config)
+            .with_data(1, rows_per_file)
+            .build()?;
+        let engine: Arc<dyn delta_kernel::Engine> =
+            Arc::new(DefaultEngineBuilder::new(table.store().clone()).build());
+        let snap = Snapshot::builder_for(table.table_root()).build(engine.as_ref())?;
+        let scan = snap.scan_builder().build()?;
+        let batches = crate::read_scan(&scan, engine)?;
+        assert!(!batches.is_empty(), "expected at least one batch");
+        let expected_nulls_per_col = rows_per_file / NULL_RATE_EVERY_NTH;
+        for batch in &batches {
+            for col_idx in 0..batch.num_columns() {
+                let name = batch.schema().field(col_idx).name().to_string();
+                let null_count = batch.column(col_idx).null_count();
+                if layout_columns.contains(&name) {
+                    assert_eq!(
+                        null_count, 0,
+                        "layout column '{name}' must never be nulled, got {null_count}",
+                    );
+                } else {
+                    assert_eq!(
+                        null_count, expected_nulls_per_col,
+                        "data column '{name}' should have {expected_nulls_per_col} nulls, \
+                         got {null_count}",
+                    );
+                }
             }
         }
         Ok(())

--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -848,9 +848,10 @@ pub enum DataLayoutConfig {
 
 /// Period for sparse null injection. Data generation emits a null every
 /// `NULL_RATE_EVERY_NTH` rows for each nullable, non-partition column, regardless of
-/// [`DataLayoutConfig`]. The protocol permits null partition values, but the generator
-/// does not produce them: partition and clustering columns are left fully populated to
-/// keep their values well-defined for tests.
+/// [`DataLayoutConfig`]. Clustering columns are nulled like any other data column (kernel
+/// permits null clustering keys). Partition columns are left fully populated: the protocol
+/// permits null partition values, but the generator does not model them, so partition data
+/// stays well-defined and matches the declared partition value.
 pub const NULL_RATE_EVERY_NTH: usize = 3;
 
 impl DataLayoutConfig {
@@ -1230,7 +1231,6 @@ impl TestTableBuilder {
                 self.num_data_files,
                 self.rows_per_file,
                 &self.partition_columns,
-                &self.clustering_columns,
                 v,
             )
             .await?
@@ -1318,15 +1318,15 @@ fn write_crc(snapshot: &Arc<Snapshot>, engine: &dyn Engine) -> DeltaResult<()> {
 /// Produces `num_files` parquet files with `rows_per_file` rows each. For partitioned
 /// tables, all rows in a file share the same partition values; for unpartitioned or
 /// clustered tables, uses `unpartitioned_write_context`. Non-partition columns get
-/// varying data derived from version and file index. Partition and clustering columns
-/// are never nulled so their values stay well-defined.
+/// varying data derived from version and file index. Partition columns are never nulled
+/// so their data matches the declared partition value; all other nullable columns
+/// (including clustering columns, which kernel permits to be null) get sparse nulls.
 async fn write_data_commit<E: TaskExecutor>(
     snapshot: Arc<Snapshot>,
     engine: &DefaultEngine<E>,
     num_files: usize,
     rows_per_file: usize,
     partition_columns: &[String],
-    clustering_columns: &[String],
     version: u64,
 ) -> DeltaResult<delta_kernel::transaction::CommitResult> {
     let logical_schema = snapshot.schema().clone();
@@ -1339,7 +1339,6 @@ async fn write_data_commit<E: TaskExecutor>(
         .with_data_change(true);
 
     let partition_set: HashSet<&str> = partition_columns.iter().map(String::as_str).collect();
-    let clustering_set: HashSet<&str> = clustering_columns.iter().map(String::as_str).collect();
 
     for file_idx in 0..num_files {
         let base = (version as i32 * 1000) + (file_idx as i32 * 100);
@@ -1349,13 +1348,12 @@ async fn write_data_commit<E: TaskExecutor>(
         let mut columns: Vec<ArrayRef> = Vec::new();
         for (arrow_field, kernel_field) in arrow_schema.fields().iter().zip(logical_schema.fields())
         {
-            let name = kernel_field.name().as_str();
-            if partition_set.contains(name) {
+            if partition_set.contains(kernel_field.name().as_str()) {
                 continue;
             }
             let data_type = arrow_field.data_type();
             let values = generate_column(data_type, rows_per_file, base);
-            let values = if arrow_field.is_nullable() && !clustering_set.contains(name) {
+            let values = if arrow_field.is_nullable() {
                 with_sparse_nulls(values, NULL_RATE_EVERY_NTH)
             } else {
                 values
@@ -2072,16 +2070,21 @@ mod tests {
         Ok(())
     }
 
-    /// The generator leaves partition and clustering columns fully populated, even though
-    /// it injects sparse nulls into every other nullable column. Clustered tables write
-    /// through the unpartitioned path, so the clustering case guards against the generator
-    /// treating clustering columns like ordinary data columns.
+    /// Partition columns are never nulled so their data matches the declared partition
+    /// value. Clustering columns are ordinary data columns (kernel permits null clustering
+    /// keys), so they receive the same sparse nulls as any other nullable column -- the
+    /// clustered case guards against accidentally protecting them.
     #[rstest::rstest]
     #[case::partitioned(partitioned())]
     #[case::clustered(clustered())]
-    fn test_layout_columns_are_never_nulled(#[case] config: DataLayoutConfig) -> DeltaResult<()> {
+    fn test_layout_column_null_injection(#[case] config: DataLayoutConfig) -> DeltaResult<()> {
         let rows_per_file = NULL_RATE_EVERY_NTH * 3;
-        let layout_columns = config.columns();
+        // Only partition columns are protected from nulling; clustering columns are not.
+        let protected_columns = if config.is_partitioned() {
+            config.columns()
+        } else {
+            Vec::new()
+        };
         let table = TestTableBuilder::new()
             .with_log_state(LogState::with_latest_version(1))
             .with_data_layout(config)
@@ -2098,10 +2101,10 @@ mod tests {
             for col_idx in 0..batch.num_columns() {
                 let name = batch.schema().field(col_idx).name().to_string();
                 let null_count = batch.column(col_idx).null_count();
-                if layout_columns.contains(&name) {
+                if protected_columns.contains(&name) {
                     assert_eq!(
                         null_count, 0,
-                        "layout column '{name}' must never be nulled, got {null_count}",
+                        "partition column '{name}' must never be nulled, got {null_count}",
                     );
                 } else {
                     assert_eq!(

--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -848,8 +848,9 @@ pub enum DataLayoutConfig {
 
 /// Period for sparse null injection. Data generation emits a null every
 /// `NULL_RATE_EVERY_NTH` rows for each nullable, non-partition column, regardless of
-/// [`DataLayoutConfig`]. Partition and clustering values are never nulled so partition
-/// values stay well-defined.
+/// [`DataLayoutConfig`]. The protocol permits null partition values, but the generator
+/// does not produce them: partition and clustering columns are left fully populated to
+/// keep their values well-defined for tests.
 pub const NULL_RATE_EVERY_NTH: usize = 3;
 
 impl DataLayoutConfig {
@@ -1337,6 +1338,9 @@ async fn write_data_commit<E: TaskExecutor>(
         .with_operation("WRITE".to_string())
         .with_data_change(true);
 
+    let partition_set: HashSet<&str> = partition_columns.iter().map(String::as_str).collect();
+    let clustering_set: HashSet<&str> = clustering_columns.iter().map(String::as_str).collect();
+
     for file_idx in 0..num_files {
         let base = (version as i32 * 1000) + (file_idx as i32 * 100);
         let partition_seed = (version as usize) * 1000 + file_idx * 100;
@@ -1345,14 +1349,13 @@ async fn write_data_commit<E: TaskExecutor>(
         let mut columns: Vec<ArrayRef> = Vec::new();
         for (arrow_field, kernel_field) in arrow_schema.fields().iter().zip(logical_schema.fields())
         {
-            let name = kernel_field.name();
-            if partition_columns.iter().any(|c| c == name) {
+            let name = kernel_field.name().as_str();
+            if partition_set.contains(name) {
                 continue;
             }
             let data_type = arrow_field.data_type();
             let values = generate_column(data_type, rows_per_file, base);
-            let values = if arrow_field.is_nullable() && !clustering_columns.iter().any(|c| c == name)
-            {
+            let values = if arrow_field.is_nullable() && !clustering_set.contains(name) {
                 with_sparse_nulls(values, NULL_RATE_EVERY_NTH)
             } else {
                 values
@@ -2069,10 +2072,10 @@ mod tests {
         Ok(())
     }
 
-    /// Partition and clustering columns must never be nulled, even though the data
-    /// generator injects sparse nulls into every other nullable column. Clustered tables
-    /// write through the unpartitioned path, so the clustering case guards against the
-    /// generator treating clustering columns like ordinary data columns.
+    /// The generator leaves partition and clustering columns fully populated, even though
+    /// it injects sparse nulls into every other nullable column. Clustered tables write
+    /// through the unpartitioned path, so the clustering case guards against the generator
+    /// treating clustering columns like ordinary data columns.
     #[rstest::rstest]
     #[case::partitioned(partitioned())]
     #[case::clustered(clustered())]


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds sparse null injection to the `TestTableBuilder` data generator. Every nullable, non-partition column now emits a null every `NULL_RATE_EVERY_NTH = 3` rows. Partition and clustering values keep going through `generate_constant_column` so partition values stay well-defined.


Tracking issue: #2526

## How was this change tested?

Existing test