### PR TITLE
feat: catalog managed feature depends on ICT

### DIFF
--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -1783,6 +1783,13 @@ mod test {
             ],
         );
         assert!(config.ensure_operation_supported(Operation::Write).is_ok());
+
+        // Without ICT enabled, the catalog-managed feature requirement fails.
+        let config = create_mock_table_config(&[], &[TableFeature::CatalogManaged]);
+        assert_result_error_with_message(
+            config.ensure_operation_supported(Operation::Write),
+            "Feature 'catalogManaged' requires 'inCommitTimestamp' to be enabled",
+        );
     }
 
     /// Helper to create a schema with column mapping metadata using JSON deserialization

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -606,12 +606,7 @@ impl TableConfiguration {
                 check(&self.protocol, &self.table_properties, operation)?;
             }
         };
-
-        // Feature requirements are writer-side constraints, so only enforce them on writes.
-        match operation {
-            Operation::Write => self.validate_feature_requirements(feature),
-            Operation::Scan | Operation::Cdf => Ok(()),
-        }
+        self.validate_feature_requirements(feature)
     }
 
     /// Returns all reader features enabled for this table based on protocol version.
@@ -1789,31 +1784,23 @@ mod test {
         assert!(config.ensure_operation_supported(Operation::Write).is_ok());
     }
 
-    // The catalog-managed ICT requirement is enforced on writes but not reads.
+    // A catalog-managed table requires inCommitTimestamp to be enabled.
     #[rstest]
-    #[case::catalog_managed_write(
+    #[case::catalog_managed(
         TableFeature::CatalogManaged,
-        Operation::Write,
-        Some("Feature 'catalogManaged' requires 'inCommitTimestamp' to be enabled")
+        "Feature 'catalogManaged' requires 'inCommitTimestamp' to be enabled"
     )]
-    #[case::catalog_owned_preview_write(
+    #[case::catalog_owned_preview(
         TableFeature::CatalogOwnedPreview,
-        Operation::Write,
-        Some("Feature 'catalogOwned-preview' requires 'inCommitTimestamp' to be enabled")
+        "Feature 'catalogOwned-preview' requires 'inCommitTimestamp' to be enabled"
     )]
-    #[case::catalog_managed_scan(TableFeature::CatalogManaged, Operation::Scan, None)]
-    #[case::catalog_owned_preview_scan(TableFeature::CatalogOwnedPreview, Operation::Scan, None)]
     fn test_catalog_managed_requires_in_commit_timestamp(
         #[case] feature: TableFeature,
-        #[case] operation: Operation,
-        #[case] expected_error: Option<&str>,
+        #[case] expected_error: &str,
     ) {
         let config = create_mock_table_config(&[], &[feature]);
-        let result = config.ensure_operation_supported(operation);
-        match expected_error {
-            Some(msg) => assert_result_error_with_message(result, msg),
-            None => assert!(result.is_ok(), "expected Ok, got {result:?}"),
-        }
+        let result = config.ensure_operation_supported(Operation::Write);
+        assert_result_error_with_message(result, expected_error);
     }
 
     /// Helper to create a schema with column mapping metadata using JSON deserialization

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -1783,11 +1783,28 @@ mod test {
             ],
         );
         assert!(config.ensure_operation_supported(Operation::Write).is_ok());
+    }
 
+    #[test]
+    fn test_catalog_managed_requires_in_commit_timestamp() {
         // Without ICT enabled, the catalog-managed feature requirement fails.
         let config = create_mock_table_config(&[], &[TableFeature::CatalogManaged]);
         assert_result_error_with_message(
             config.ensure_operation_supported(Operation::Write),
+            "Feature 'catalogManaged' requires 'inCommitTimestamp' to be enabled",
+        );
+
+        // The same requirement applies to catalogOwned-preview.
+        let config = create_mock_table_config(&[], &[TableFeature::CatalogOwnedPreview]);
+        assert_result_error_with_message(
+            config.ensure_operation_supported(Operation::Write),
+            "Feature 'catalogOwned-preview' requires 'inCommitTimestamp' to be enabled",
+        );
+
+        // The requirement is enforced on the read path too, not just writes.
+        let config = create_mock_table_config(&[], &[TableFeature::CatalogManaged]);
+        assert_result_error_with_message(
+            config.ensure_operation_supported(Operation::Scan),
             "Feature 'catalogManaged' requires 'inCommitTimestamp' to be enabled",
         );
     }

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -607,7 +607,11 @@ impl TableConfiguration {
             }
         };
 
-        self.validate_feature_requirements(feature)
+        // Feature requirements are writer-side constraints, so only enforce them on writes.
+        match operation {
+            Operation::Write => self.validate_feature_requirements(feature),
+            Operation::Scan | Operation::Cdf => Ok(()),
+        }
     }
 
     /// Returns all reader features enabled for this table based on protocol version.
@@ -1785,28 +1789,31 @@ mod test {
         assert!(config.ensure_operation_supported(Operation::Write).is_ok());
     }
 
-    #[test]
-    fn test_catalog_managed_requires_in_commit_timestamp() {
-        // Without ICT enabled, the catalog-managed feature requirement fails.
-        let config = create_mock_table_config(&[], &[TableFeature::CatalogManaged]);
-        assert_result_error_with_message(
-            config.ensure_operation_supported(Operation::Write),
-            "Feature 'catalogManaged' requires 'inCommitTimestamp' to be enabled",
-        );
-
-        // The same requirement applies to catalogOwned-preview.
-        let config = create_mock_table_config(&[], &[TableFeature::CatalogOwnedPreview]);
-        assert_result_error_with_message(
-            config.ensure_operation_supported(Operation::Write),
-            "Feature 'catalogOwned-preview' requires 'inCommitTimestamp' to be enabled",
-        );
-
-        // The requirement is enforced on the read path too, not just writes.
-        let config = create_mock_table_config(&[], &[TableFeature::CatalogManaged]);
-        assert_result_error_with_message(
-            config.ensure_operation_supported(Operation::Scan),
-            "Feature 'catalogManaged' requires 'inCommitTimestamp' to be enabled",
-        );
+    // The catalog-managed ICT requirement is enforced on writes but not reads.
+    #[rstest]
+    #[case::catalog_managed_write(
+        TableFeature::CatalogManaged,
+        Operation::Write,
+        Some("Feature 'catalogManaged' requires 'inCommitTimestamp' to be enabled")
+    )]
+    #[case::catalog_owned_preview_write(
+        TableFeature::CatalogOwnedPreview,
+        Operation::Write,
+        Some("Feature 'catalogOwned-preview' requires 'inCommitTimestamp' to be enabled")
+    )]
+    #[case::catalog_managed_scan(TableFeature::CatalogManaged, Operation::Scan, None)]
+    #[case::catalog_owned_preview_scan(TableFeature::CatalogOwnedPreview, Operation::Scan, None)]
+    fn test_catalog_managed_requires_in_commit_timestamp(
+        #[case] feature: TableFeature,
+        #[case] operation: Operation,
+        #[case] expected_error: Option<&str>,
+    ) {
+        let config = create_mock_table_config(&[], &[feature]);
+        let result = config.ensure_operation_supported(operation);
+        match expected_error {
+            Some(msg) => assert_result_error_with_message(result, msg),
+            None => assert!(result.is_ok(), "expected Ok, got {result:?}"),
+        }
     }
 
     /// Helper to create a schema with column mapping metadata using JSON deserialization

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -479,7 +479,7 @@ static MATERIALIZE_PARTITION_COLUMNS_INFO: FeatureInfo = FeatureInfo {
 static CATALOG_MANAGED_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::ReaderWriter,
     min_legacy_version: None,
-    feature_requirements: &[],
+    feature_requirements: &[FeatureRequirement::Enabled(TableFeature::InCommitTimestamp)],
     kernel_support: KernelSupport::Custom(|_, _, op| match op {
         Operation::Scan | Operation::Write => Ok(()),
         Operation::Cdf => Err(Error::unsupported(
@@ -492,7 +492,7 @@ static CATALOG_MANAGED_INFO: FeatureInfo = FeatureInfo {
 static CATALOG_OWNED_PREVIEW_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::ReaderWriter,
     min_legacy_version: None,
-    feature_requirements: &[],
+    feature_requirements: &[FeatureRequirement::Enabled(TableFeature::InCommitTimestamp)],
     kernel_support: KernelSupport::Custom(|_, _, op| match op {
         Operation::Scan | Operation::Write => Ok(()),
         Operation::Cdf => Err(Error::unsupported(


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds ICT dependency in catalog managed tables (both `CATALOG_MANAGED_INFO` and `CATALOG_OWNED_PREVIEW_INFO`.

## How was this change tested?

Modified `test_catalog_managed_writes()` in `table_configuration.rs` to show that without ICT enabled, catalogue managed feature requirement fails.
