### PR TITLE
test: bless ffi trybuild stderr for current stable rustc

### DIFF
--- a/ffi/tests/invalid-handle-code/mut-clone-handle.stderr
+++ b/ffi/tests/invalid-handle-code/mut-clone-handle.stderr
@@ -2,13 +2,13 @@ error[E0599]: the method `clone_as_arc` exists for struct `Handle<MutFoo>`, but 
   --> tests/invalid-handle-code/mut-clone-handle.rs:13:15
    |
  8 | pub struct MutFoo;
-   | ----------------- doesn't satisfy `<_ as HandleDescriptor>::Mutable = False`
+   | ----------------- doesn't satisfy `<MutFoo as HandleDescriptor>::Mutable = False`
 ...
 13 |     let r = h.clone_as_arc();
    |               ^^^^^^^^^^^^ method cannot be called on `Handle<MutFoo>` due to unsatisfied trait bounds
    |
    = note: the following trait bounds were not satisfied:
-           `<MutFoo as HandleDescriptor>::Mutable = delta_kernel_ffi::handle::False`
+           `<MutFoo as HandleDescriptor>::Mutable = False`
 
 error[E0271]: type mismatch resolving `<MutFoo as HandleDescriptor>::Mutable == False`
   --> tests/invalid-handle-code/mut-clone-handle.rs:12:41
@@ -16,10 +16,10 @@ error[E0271]: type mismatch resolving `<MutFoo as HandleDescriptor>::Mutable == 
 12 |     let h: Handle<MutFoo> = Arc::new(s).into();
    |                                         ^^^^ type mismatch resolving `<MutFoo as HandleDescriptor>::Mutable == False`
    |
-note: expected this to be `delta_kernel_ffi::handle::False`
+note: expected this to be `False`
   --> tests/invalid-handle-code/mut-clone-handle.rs:7:1
    |
-7  | #[handle_descriptor(target=Foo, mutable=true, sized=true)]
+ 7 | #[handle_descriptor(target=Foo, mutable=true, sized=true)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: required for `Handle<MutFoo>` to implement `From<Arc<Foo>>`
    = note: required for `Arc<Foo>` to implement `Into<Handle<MutFoo>>`
@@ -29,10 +29,10 @@ error[E0599]: the method `clone_handle` exists for struct `Handle<MutFoo>`, but 
   --> tests/invalid-handle-code/mut-clone-handle.rs:14:15
    |
  8 | pub struct MutFoo;
-   | ----------------- doesn't satisfy `<_ as HandleDescriptor>::Mutable = False`
+   | ----------------- doesn't satisfy `<MutFoo as HandleDescriptor>::Mutable = False`
 ...
 14 |     let h = h.clone_handle();
    |               ^^^^^^^^^^^^
    |
    = note: the following trait bounds were not satisfied:
-           `<MutFoo as HandleDescriptor>::Mutable = delta_kernel_ffi::handle::False`
+           `<MutFoo as HandleDescriptor>::Mutable = False`

--- a/ffi/tests/invalid-handle-code/shared-as-mut.stderr
+++ b/ffi/tests/invalid-handle-code/shared-as-mut.stderr
@@ -2,13 +2,13 @@ error[E0599]: the method `as_mut` exists for struct `Handle<SharedFoo>`, but its
   --> tests/invalid-handle-code/shared-as-mut.rs:12:15
    |
  7 | pub struct SharedFoo;
-   | -------------------- doesn't satisfy `<_ as HandleDescriptor>::Mutable = True`
+   | -------------------- doesn't satisfy `<SharedFoo as HandleDescriptor>::Mutable = True`
 ...
 12 |     let r = h.as_mut();
    |               ^^^^^^ method cannot be called on `Handle<SharedFoo>` due to unsatisfied trait bounds
    |
    = note: the following trait bounds were not satisfied:
-           `<SharedFoo as HandleDescriptor>::Mutable = delta_kernel_ffi::handle::True`
+           `<SharedFoo as HandleDescriptor>::Mutable = True`
 
 error[E0271]: type mismatch resolving `<SharedFoo as HandleDescriptor>::Mutable == True`
   --> tests/invalid-handle-code/shared-as-mut.rs:11:44
@@ -16,10 +16,10 @@ error[E0271]: type mismatch resolving `<SharedFoo as HandleDescriptor>::Mutable 
 11 |     let h: Handle<SharedFoo> = Box::new(s).into();
    |                                            ^^^^ type mismatch resolving `<SharedFoo as HandleDescriptor>::Mutable == True`
    |
-note: expected this to be `delta_kernel_ffi::handle::True`
+note: expected this to be `True`
   --> tests/invalid-handle-code/shared-as-mut.rs:6:1
    |
-6  | #[handle_descriptor(target=Foo, mutable=false, sized=true)]
+ 6 | #[handle_descriptor(target=Foo, mutable=false, sized=true)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: required for `Handle<SharedFoo>` to implement `From<Box<Foo>>`
    = note: required for `Box<Foo>` to implement `Into<Handle<SharedFoo>>`

--- a/ffi/tests/invalid-handle-code/shared-not-sync.stderr
+++ b/ffi/tests/invalid-handle-code/shared-not-sync.stderr
@@ -9,7 +9,7 @@ error[E0599]: the method `clone_as_arc` exists for struct `Handle<SharedNotSync>
    |
    = note: the following trait bounds were not satisfied:
            `*mut u32: Sync`
-           which is required by `SharedNotSync: handle::private::SharedHandleOps<NotSync, delta_kernel_ffi::handle::True>`
+           which is required by `SharedNotSync: handle::private::SharedHandleOps<NotSync, True>`
 
 error[E0277]: `*mut u32` cannot be shared between threads safely
   --> tests/invalid-handle-code/shared-not-sync.rs:14:48
@@ -21,9 +21,9 @@ error[E0277]: `*mut u32` cannot be shared between threads safely
 note: required because it appears within the type `NotSync`
   --> tests/invalid-handle-code/shared-not-sync.rs:5:12
    |
-5  | pub struct NotSync(*mut u32);
+ 5 | pub struct NotSync(*mut u32);
    |            ^^^^^^^
-   = note: required for `SharedNotSync` to implement `handle::private::SharedHandleOps<NotSync, delta_kernel_ffi::handle::True>`
+   = note: required for `SharedNotSync` to implement `handle::private::SharedHandleOps<NotSync, True>`
    = note: required for `Handle<SharedNotSync>` to implement `From<Arc<NotSync>>`
    = note: required for `Arc<NotSync>` to implement `Into<Handle<SharedNotSync>>`
 
@@ -38,4 +38,4 @@ error[E0599]: the method `clone_handle` exists for struct `Handle<SharedNotSync>
    |
    = note: the following trait bounds were not satisfied:
            `*mut u32: Sync`
-           which is required by `SharedNotSync: handle::private::SharedHandleOps<NotSync, delta_kernel_ffi::handle::True>`
+           which is required by `SharedNotSync: handle::private::SharedHandleOps<NotSync, True>`


### PR DESCRIPTION
## What changes are proposed in this pull request?

The compile-fail UI tests in `ffi/tests/invalid-handle-code/` (driven by `trybuild`,
exercised by `handle::tests::invalid_handle_code`) compare the compiler's stderr against
committed `.stderr` snapshots. Current stable rustc (1.94.0) changed two cosmetic aspects
of diagnostic rendering, so the snapshots no longer match and the test fails on current
stable:

- fully-qualified paths in trait-bound notes are shortened (`delta_kernel_ffi::handle::True`
  -> `True`);
- single-digit line numbers are padded differently in the source gutter.

Regenerated the three affected `.stderr` files via `TRYBUILD=overwrite`. No source or
behavior change -- only the expected compiler-output snapshots.

## How was this change tested?

`cargo test -p delta_kernel_ffi --features internal-api --lib invalid_handle_code` passes
on rustc 1.94.0.

This pull request and its description were written by Isaac.
