### PR TITLE
chore: expose column mapping metadata generators via internal_api

### DIFF
--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -449,6 +449,7 @@ pub(crate) fn get_column_mapping_mode_from_properties(
 ///   "delta.columnMapping.physicalName": "<pname>"
 /// }
 /// ```
+#[delta_kernel_derive::internal_api]
 pub(crate) fn assign_column_mapping_metadata(
     schema: &StructType,
     max_id: &mut i64,
@@ -731,6 +732,7 @@ fn insert_nested_field_ids_metadata(field: &mut StructField, ids: NestedFieldIds
 /// Returns the largest column mapping id found anywhere in `schema`. This includes both
 /// per-field `delta.columnMapping.id` annotations and the nested ids in
 /// `delta.columnMapping.nested.ids` metadata.
+#[delta_kernel_derive::internal_api]
 pub(crate) fn find_max_column_id_in_schema(schema: &StructType) -> Option<i64> {
     let mut visitor = MaxColumnId(None);
     visitor.transform_struct(schema);

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -3,9 +3,10 @@ pub(crate) use column_mapping::get_any_level_column_physical_name;
 #[deprecated = "Enable internal-api and use TableConfiguration instead"]
 pub use column_mapping::validate_schema_column_mapping;
 pub use column_mapping::ColumnMappingMode;
+#[internal_api]
+pub(crate) use column_mapping::{assign_column_mapping_metadata, find_max_column_id_in_schema};
 pub(crate) use column_mapping::{
-    assign_column_mapping_metadata, column_mapping_mode, find_max_column_id_in_schema,
-    get_column_mapping_mode_from_properties, physical_to_logical_column_name,
+    column_mapping_mode, get_column_mapping_mode_from_properties, physical_to_logical_column_name,
     try_assign_flat_column_mapping_info, validate_and_extract_column_mapping_annotations,
     validate_column_mapping_id,
 };


### PR DESCRIPTION
## What changes are proposed in this pull request?
Expose some internal apis so we can add support for column mapping creation in delta-rs without going through kernels create table api, see PR https://github.com/delta-io/delta-rs/pull/4505

## How was this change tested?
Local fork with delta-rs to add support for ColumnMapping in create, while keep our own commit logic.