### PR TITLE
feat: use incremental CRC replay in Snapshot construction

### DIFF
--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -92,7 +92,7 @@ impl LogSegment {
             return Ok(Some(base_crc)); // Case 2
         }
         // Case 3: advance only within the caller's commit budget.
-        if !incremental_replay.should_advance(base_crc.version, self.end_version) {
+        if !incremental_replay.should_advance(base_crc.version, self.end_version)? {
             return Ok(None);
         }
         let advanced = self.build_incremental_crc_from_base(engine, &base_crc)?;

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -28,6 +28,7 @@ use crate::schema::{
     column_name, ColumnName, ColumnNamesAndTypes, DataType, MetadataColumnSpec, SchemaRef,
     StructField, StructType, ToSchema as _,
 };
+use crate::snapshot::IncrementalReplay;
 use crate::utils::require;
 use crate::{DeltaResult, Engine, Error, RowVisitor, Version};
 
@@ -74,10 +75,12 @@ impl LogSegment {
     /// Try to build the CRC at this segment's `end_version`. Handles three cases:
     /// - Case 1: CRC absent (1A) or read fails (1B) -> return None
     /// - Case 2: CRC at `end_version` -> return it as-is
-    /// - Case 3: Stale CRC older than `end_version` -> advance it to `end_version`
+    /// - Case 3: Stale CRC older than `end_version` -> advance it to `end_version` when
+    ///   `incremental_replay` permits, else fall back to normal log replay (return None)
     pub(crate) fn try_build_incremental_crc(
         &self,
         engine: &dyn Engine,
+        incremental_replay: IncrementalReplay,
     ) -> DeltaResult<Option<Arc<Crc>>> {
         let Some(crc_file) = self.listed.latest_crc_file.as_ref() else {
             return Ok(None); // Case 1A
@@ -88,8 +91,12 @@ impl LogSegment {
         if base_crc.version == self.end_version {
             return Ok(Some(base_crc)); // Case 2
         }
+        // Case 3: advance only within the caller's commit budget.
+        if !incremental_replay.should_advance(base_crc.version, self.end_version) {
+            return Ok(None);
+        }
         let advanced = self.build_incremental_crc_from_base(engine, &base_crc)?;
-        Ok(Some(Arc::new(advanced))) // Case 3
+        Ok(Some(Arc::new(advanced)))
     }
 
     /// Produce a fresh `Crc` at `self.end_version` by reverse-replaying the commits in

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -71,23 +71,25 @@ static REPLAY_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
 });
 
 impl LogSegment {
-    /// Try to build the CRC at this segment's `end_version`: read the on-disk CRC (absent or
-    /// unreadable -> `None`) and advance a stale one to `end_version`.
+    /// Try to build the CRC at this segment's `end_version`. Handles three cases:
+    /// - Case 1: CRC absent (1A) or read fails (1B) -> return None
+    /// - Case 2: CRC at `end_version` -> return it as-is
+    /// - Case 3: Stale CRC older than `end_version` -> advance it to `end_version`
     pub(crate) fn try_build_incremental_crc(
         &self,
         engine: &dyn Engine,
     ) -> DeltaResult<Option<Arc<Crc>>> {
         let Some(crc_file) = self.listed.latest_crc_file.as_ref() else {
-            return Ok(None);
+            return Ok(None); // Case 1A
         };
         let Some(base_crc) = read_crc_file_or_none(engine, crc_file) else {
-            return Ok(None);
+            return Ok(None); // Case 1B
         };
         if base_crc.version == self.end_version {
-            return Ok(Some(base_crc));
+            return Ok(Some(base_crc)); // Case 2
         }
         let advanced = self.build_incremental_crc_from_base(engine, &base_crc)?;
-        Ok(Some(Arc::new(advanced)))
+        Ok(Some(Arc::new(advanced))) // Case 3
     }
 
     /// Produce a fresh `Crc` at `self.end_version` by reverse-replaying the commits in
@@ -281,6 +283,8 @@ impl CrcReplayAccumulator {
         fs.net_files += 1;
         fs.net_bytes += size;
         if let Some(hist) = fs.net_histogram.as_mut() {
+            // TODO(#2676): a negative size errors here and fails the snapshot load; degrade to
+            //              Indeterminate instead, like a missing remove size.
             hist.insert(size)?;
         }
         Ok(())

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 //! Reverse log replay for incremental CRC construction.
 //!
 //! Reverse-replays a log segment's commit files to produce a [`CrcDelta`] covering
@@ -21,7 +19,10 @@ use crate::actions::{
     DomainMetadata, Metadata, Protocol, SetTransaction, ADD_NAME, COMMIT_INFO_NAME,
     DOMAIN_METADATA_NAME, METADATA_NAME, PROTOCOL_NAME, REMOVE_NAME, SET_TRANSACTION_NAME,
 };
-use crate::crc::{is_incremental_safe_operation, Crc, CrcDelta, FileSizeHistogram, FileStatsDelta};
+use crate::crc::{
+    is_incremental_safe_operation, read_crc_file_or_none, Crc, CrcDelta, FileSizeHistogram,
+    FileStatsDelta,
+};
 use crate::engine_data::{GetData, TypedGetData as _};
 use crate::schema::{
     column_name, ColumnName, ColumnNamesAndTypes, DataType, MetadataColumnSpec, SchemaRef,
@@ -70,6 +71,25 @@ static REPLAY_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
 });
 
 impl LogSegment {
+    /// Try to build the CRC at this segment's `end_version`: read the on-disk CRC (absent or
+    /// unreadable -> `None`) and advance a stale one to `end_version`.
+    pub(crate) fn try_build_incremental_crc(
+        &self,
+        engine: &dyn Engine,
+    ) -> DeltaResult<Option<Arc<Crc>>> {
+        let Some(crc_file) = self.listed.latest_crc_file.as_ref() else {
+            return Ok(None);
+        };
+        let Some(base_crc) = read_crc_file_or_none(engine, crc_file) else {
+            return Ok(None);
+        };
+        if base_crc.version == self.end_version {
+            return Ok(Some(base_crc));
+        }
+        let advanced = self.build_incremental_crc_from_base(engine, &base_crc)?;
+        Ok(Some(Arc::new(advanced)))
+    }
+
     /// Produce a fresh `Crc` at `self.end_version` by reverse-replaying the commits in
     /// `(base_crc.version, self.end_version]` and applying the resulting delta to
     /// `base_crc` via [`Crc::apply`].

--- a/kernel/src/log_segment/crc_tests.rs
+++ b/kernel/src/log_segment/crc_tests.rs
@@ -20,6 +20,7 @@ use crate::engine::sync::SyncEngine;
 use crate::object_store::memory::InMemory;
 use crate::object_store::ObjectStoreExt as _;
 use crate::path::ParsedLogPath;
+use crate::snapshot::IncrementalReplay;
 use crate::{DeltaResult, Engine, Snapshot};
 
 // ============================================================================
@@ -408,13 +409,21 @@ impl BuiltCrcTest {
     /// Build a snapshot at `version` (or latest if `None`) and return it
     /// alongside a human-readable label like `"v2"` or `"latest"`.
     fn snapshot_at(&self, version: Option<u64>) -> (crate::snapshot::SnapshotRef, String) {
-        let mut builder = Snapshot::builder_for(self.url.clone());
+        let mut builder = Snapshot::builder_for(self.url.clone())
+            .with_incremental_state_replay(IncrementalReplay::Unlimited);
         if let Some(v) = version {
             builder = builder.at_version(v);
         }
         let snapshot = builder.build(&self.engine).unwrap();
         let label = version.map_or("latest".to_string(), |v| format!("v{v}"));
         (snapshot, label)
+    }
+
+    fn snapshot_latest_with_replay(&self, mode: IncrementalReplay) -> crate::snapshot::SnapshotRef {
+        Snapshot::builder_for(self.url.clone())
+            .with_incremental_state_replay(mode)
+            .build(&self.engine)
+            .unwrap()
     }
 
     fn assert_p_m(
@@ -1150,4 +1159,33 @@ async fn test_full_replay_across_two_commits_propagates_all_state() {
     let txn = crc.set_transaction_state.expect_complete();
     assert_eq!(txn["app_a"].version, 1);
     assert_eq!(txn["app_b"].version, 5);
+}
+
+// ============================================================================
+// Tests: incremental-replay budget gate
+// ============================================================================
+
+#[rstest]
+#[case::disabled(IncrementalReplay::Disabled, None)]
+#[case::up_to_zero(IncrementalReplay::UpToCommits(0), None)]
+#[case::below_budget(IncrementalReplay::UpToCommits(1), None)]
+#[case::at_budget(IncrementalReplay::UpToCommits(2), Some(3))]
+#[case::unlimited(IncrementalReplay::Unlimited, Some(3))]
+#[tokio::test]
+async fn test_stale_crc_advanced_only_within_replay_budget(
+    #[case] mode: IncrementalReplay,
+    #[case] expected_crc_version: Option<u64>,
+) {
+    // CRC at v1, target v3: 2 commits stale, so only budgets >= 2 (or Unlimited) advance it.
+    let built = CrcReadTest::new()
+        .v2_checkpoint(0, protocol_v2(), metadata_a())
+        .commit(1, [commit_info(DEFAULT_OPERATION, None)])
+        .crc(1, protocol_v2(), metadata_a(), None)
+        .commit(2, [commit_info(DEFAULT_OPERATION, None)])
+        .commit(3, [commit_info(DEFAULT_OPERATION, None)])
+        .build()
+        .await;
+    let snapshot = built.snapshot_latest_with_replay(mode);
+    assert_eq!(snapshot.version(), 3);
+    assert_eq!(snapshot.crc().map(|c| c.version), expected_crc_version);
 }

--- a/kernel/src/log_segment/crc_tests.rs
+++ b/kernel/src/log_segment/crc_tests.rs
@@ -410,7 +410,7 @@ impl BuiltCrcTest {
     /// alongside a human-readable label like `"v2"` or `"latest"`.
     fn snapshot_at(&self, version: Option<u64>) -> (crate::snapshot::SnapshotRef, String) {
         let mut builder = Snapshot::builder_for(self.url.clone())
-            .with_incremental_state_replay(IncrementalReplay::Unlimited);
+            .with_incremental_crc_replay(IncrementalReplay::Unlimited);
         if let Some(v) = version {
             builder = builder.at_version(v);
         }
@@ -421,7 +421,7 @@ impl BuiltCrcTest {
 
     fn snapshot_latest_with_replay(&self, mode: IncrementalReplay) -> crate::snapshot::SnapshotRef {
         Snapshot::builder_for(self.url.clone())
-            .with_incremental_state_replay(mode)
+            .with_incremental_crc_replay(mode)
             .build(&self.engine)
             .unwrap()
     }
@@ -1165,24 +1165,29 @@ async fn test_full_replay_across_two_commits_propagates_all_state() {
 // Tests: incremental-replay budget gate
 // ============================================================================
 
+// Commits 0-3 (target v3) with a CRC at `crc_version`, so distance = 3 - crc_version.
 #[rstest]
-#[case::disabled(IncrementalReplay::Disabled, None)]
-#[case::up_to_zero(IncrementalReplay::UpToCommits(0), None)]
-#[case::below_budget(IncrementalReplay::UpToCommits(1), None)]
-#[case::at_budget(IncrementalReplay::UpToCommits(2), Some(3))]
-#[case::unlimited(IncrementalReplay::Unlimited, Some(3))]
+// CRC already at the target (distance 0): used regardless of mode, even Disabled.
+#[case::at_target_disabled(3, IncrementalReplay::Disabled, Some(3))]
+// Stale CRC (distance >= 1): advancement depends on the budget.
+#[case::disabled_stale(1, IncrementalReplay::Disabled, None)]
+#[case::up_to_zero(1, IncrementalReplay::UpToCommits(0), None)]
+#[case::interior(2, IncrementalReplay::UpToCommits(5), Some(3))] // distance 1 < 5
+#[case::at_budget(1, IncrementalReplay::UpToCommits(2), Some(3))] // distance 2 == 2
+#[case::over_budget(1, IncrementalReplay::UpToCommits(1), None)] // distance 2 > 1
+#[case::unlimited(0, IncrementalReplay::Unlimited, Some(3))] // distance 3
 #[tokio::test]
 async fn test_stale_crc_advanced_only_within_replay_budget(
+    #[case] crc_version: u64,
     #[case] mode: IncrementalReplay,
     #[case] expected_crc_version: Option<u64>,
 ) {
-    // CRC at v1, target v3: 2 commits stale, so only budgets >= 2 (or Unlimited) advance it.
     let built = CrcReadTest::new()
         .v2_checkpoint(0, protocol_v2(), metadata_a())
         .commit(1, [commit_info(DEFAULT_OPERATION, None)])
-        .crc(1, protocol_v2(), metadata_a(), None)
         .commit(2, [commit_info(DEFAULT_OPERATION, None)])
         .commit(3, [commit_info(DEFAULT_OPERATION, None)])
+        .crc(crc_version, protocol_v2(), metadata_a(), None)
         .build()
         .await;
     let snapshot = built.snapshot_latest_with_replay(mode);

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -1062,12 +1062,10 @@ impl LogSegment {
             .try_collect()
     }
 
-    /// Creates a pruned LogSegment for replay *after* a CRC at `start_v_exclusive`.
-    ///
-    /// The CRC covers protocol, metadata, and checkpoint state, so this segment drops
-    /// checkpoint files, CRC files, and last checkpoint metadata. Only commits and compactions
-    /// in `(start_v_exclusive, end_version]` are retained.
-    pub(crate) fn segment_after_crc(&self, start_v_exclusive: Version) -> Self {
+    /// Creates a pruned LogSegment of only the commits and compactions in
+    /// `(start_v_exclusive, end_version]`, dropping checkpoint files, CRC files, and
+    /// last-checkpoint metadata.
+    pub(crate) fn segment_after_version(&self, start_v_exclusive: Version) -> Self {
         let (commits, compactions) =
             self.filtered_commits_and_compactions(Some(start_v_exclusive), self.end_version);
         LogSegment {

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -1066,6 +1066,14 @@ impl LogSegment {
     /// `(start_v_exclusive, end_version]`, dropping checkpoint files, CRC files, and
     /// last-checkpoint metadata.
     pub(crate) fn segment_after_version(&self, start_v_exclusive: Version) -> Self {
+        // A checkpoint above start_v_exclusive would drop the commits between them, since the
+        // returned segment keeps only (start_v_exclusive, end] and no checkpoint.
+        debug_assert!(
+            self.checkpoint_version
+                .is_none_or(|ckpt| start_v_exclusive >= ckpt),
+            "segment_after_version: start_v_exclusive ({start_v_exclusive}) is below checkpoint {:?}",
+            self.checkpoint_version,
+        );
         let (commits, compactions) =
             self.filtered_commits_and_compactions(Some(start_v_exclusive), self.end_version);
         LogSegment {

--- a/kernel/src/log_segment/protocol_metadata_replay.rs
+++ b/kernel/src/log_segment/protocol_metadata_replay.rs
@@ -3,20 +3,17 @@
 //! This module contains the methods that perform a lightweight log replay to extract the latest
 //! Protocol and Metadata actions from a [`LogSegment`].
 
-use std::sync::Arc;
-
-use tracing::{info, instrument};
+use tracing::instrument;
 
 use super::LogSegment;
 use crate::actions::{get_commit_schema, Metadata, Protocol, METADATA_NAME, PROTOCOL_NAME};
-use crate::crc::Crc;
 use crate::log_replay::ActionsBatch;
 use crate::metrics::events::PROTOCOL_METADATA_LOADED_SPAN;
 use crate::metrics::MetricId;
 use crate::{DeltaResult, Engine, Error};
 
 impl LogSegment {
-    /// Read the latest Protocol and Metadata from this log segment, using CRC when available.
+    /// Read the latest Protocol and Metadata from this log segment via full log replay.
     /// Returns an error if either is missing.
     ///
     /// This is the checked variant of [`Self::read_protocol_metadata_opt`], used for fresh
@@ -25,10 +22,9 @@ impl LogSegment {
     pub(crate) fn read_protocol_metadata(
         &self,
         engine: &dyn Engine,
-        crc: Option<&Arc<Crc>>,
         operation_id: MetricId,
     ) -> DeltaResult<(Metadata, Protocol)> {
-        match self.read_protocol_metadata_opt(engine, crc)? {
+        match self.read_protocol_metadata_opt(engine)? {
             (Some(m), Some(p)) => Ok((m, p)),
             (None, Some(_)) => Err(Error::MissingMetadata),
             (Some(_), None) => Err(Error::MissingProtocol),
@@ -36,72 +32,19 @@ impl LogSegment {
         }
     }
 
-    /// Read the latest Protocol and Metadata from this log segment, using CRC when available.
-    /// Returns `None` for either if not found.
+    /// Read the latest Protocol and Metadata from this log segment via full log replay,
+    /// stopping early once both are found. Returns `None` for either if not found.
     ///
     /// This is the unchecked variant of [`Self::read_protocol_metadata`], used for incremental
     /// snapshot updates where the caller can fall back to an existing snapshot's Protocol and
     /// Metadata.
-    ///
-    /// The `crc` parameter is the CRC eagerly resolved by the caller; it is used to
-    /// short-circuit or seed the replay.
     #[instrument(name = "log_seg.load_p_m", skip_all, err)]
     pub(crate) fn read_protocol_metadata_opt(
         &self,
         engine: &dyn Engine,
-        crc: Option<&Arc<Crc>>,
     ) -> DeltaResult<(Option<Metadata>, Option<Protocol>)> {
-        // Case 1: If CRC at target version, use it directly and exit early.
-        if let Some(crc) = crc.filter(|c| c.version == self.end_version) {
-            info!("P&M from CRC at target version {}", self.end_version);
-            return Ok((Some(crc.metadata.clone()), Some(crc.protocol.clone())));
-        }
-
-        // We didn't return above, so we need to do log replay to find P&M.
-        //
-        // Case 2: CRC exists at an earlier version => Prune the log segment to only replay
-        //         commits *after* the CRC version.
-        //   (a) If we find new P&M in the pruned replay, return it.
-        //   (b) If we don't find new P&M, fall back to the CRC.
-        //
-        // Case 3: No CRC exists => Full P&M log replay.
-
-        if let Some(crc) = crc.filter(|c| c.version < self.end_version) {
-            // Case 2(a): Replay only commits after CRC version
-            info!(
-                "Pruning log segment to commits after CRC version {}",
-                crc.version
-            );
-            let pruned = self.segment_after_crc(crc.version);
-            let (metadata_opt, protocol_opt) = pruned.replay_for_pm(engine, None, None)?;
-
-            if metadata_opt.is_some() && protocol_opt.is_some() {
-                info!("Found P&M from pruned log replay");
-                return Ok((metadata_opt, protocol_opt));
-            }
-
-            // Case 2(b): P&M incomplete from pruned replay, use the CRC.
-            // Use `or_else` so any newer P or M found in the pruned replay takes priority
-            // over the (older) CRC values.
-            info!("P&M fallback to CRC (no P&M changes after CRC version)");
-            return Ok((
-                metadata_opt.or_else(|| Some(crc.metadata.clone())),
-                protocol_opt.or_else(|| Some(crc.protocol.clone())),
-            ));
-        }
-
-        // Case 3: Full P&M log replay.
-        self.replay_for_pm(engine, None, None)
-    }
-
-    /// Replays the log segment for Protocol and Metadata, merging with any already-found values.
-    /// Stops early once both are found.
-    fn replay_for_pm(
-        &self,
-        engine: &dyn Engine,
-        mut metadata_opt: Option<Metadata>,
-        mut protocol_opt: Option<Protocol>,
-    ) -> DeltaResult<(Option<Metadata>, Option<Protocol>)> {
+        let mut metadata_opt = None;
+        let mut protocol_opt = None;
         for actions_batch in self.read_pm_batches(engine)? {
             let actions = actions_batch?.actions;
             if metadata_opt.is_none() {

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -4179,7 +4179,7 @@ async fn test_get_unpublished_catalog_commits() {
 }
 
 // ============================================================================
-// Tests: segment_after_crc
+// Tests: segment_after_version
 // ============================================================================
 
 fn extract_commit_versions(seg: &LogSegment) -> Vec<u64> {
@@ -4286,7 +4286,7 @@ async fn test_segment_crc_filtering(#[case] case: CrcPruningCase) {
     })
     .await;
 
-    let after = seg.segment_after_crc(case.crc_version);
+    let after = seg.segment_after_version(case.crc_version);
     assert_eq!(extract_commit_versions(&after), case.after_commits);
     assert_eq!(extract_compaction_ranges(&after), case.after_compactions);
     assert!(after.checkpoint_version.is_none());

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -64,16 +64,25 @@ pub enum IncrementalReplay {
 
 impl IncrementalReplay {
     /// Whether the configured budget permits advancing a CRC at `crc_version` to `target_version`.
+    /// Errors if `crc_version` is ahead of `target_version`, which violates a caller invariant.
     ///
     /// Example: 95.crc with commits 96.json through 100.json is 5 commits, so `UpToCommits(5)`
     /// advances and `UpToCommits(4)` does not; `Unlimited` always advances.
-    pub(crate) fn should_advance(self, crc_version: Version, target_version: Version) -> bool {
-        let distance = target_version.saturating_sub(crc_version);
-        match self {
+    pub(crate) fn should_advance(
+        self,
+        crc_version: Version,
+        target_version: Version,
+    ) -> DeltaResult<bool> {
+        let distance = target_version.checked_sub(crc_version).ok_or_else(|| {
+            Error::internal_error(format!(
+                "CRC version {crc_version} is ahead of target version {target_version}"
+            ))
+        })?;
+        Ok(match self {
             IncrementalReplay::Disabled => false,
             IncrementalReplay::UpToCommits(n) => distance <= n,
             IncrementalReplay::Unlimited => true,
-        }
+        })
     }
 }
 
@@ -157,11 +166,12 @@ impl SnapshotBuilder {
     /// Writers should set this to [`IncrementalReplay::Unlimited`] for faster writes, as should
     /// readers that always want table-level file statistics for query optimization.
     ///
-    /// Only affects builds from a table root. Incremental updates from an existing snapshot
-    /// (via [`Snapshot::builder_from`]) do not yet advance stale CRCs (see #2674).
+    /// This setting applies only to builds from a table root; it does not carry into incremental
+    /// updates derived from the resulting snapshot. [`Snapshot::builder_from`] does not yet advance
+    /// stale CRCs regardless of this value (see #2674).
     ///
     /// [`Snapshot::builder_from`]: crate::Snapshot::builder_from
-    pub fn with_incremental_state_replay(mut self, mode: IncrementalReplay) -> Self {
+    pub fn with_incremental_crc_replay(mut self, mode: IncrementalReplay) -> Self {
         self.incremental_replay = mode;
         self
     }

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -40,6 +40,41 @@ pub struct SnapshotBuilder {
     version: Option<Version>,
     log_tail: Vec<LogPath>,
     max_catalog_version: Option<Version>,
+    incremental_replay: IncrementalReplay,
+}
+
+/// Controls whether kernel replays commits to advance a stale on-disk CRC to the target snapshot
+/// version on load. A CRC already at the target version is always used regardless of this
+/// setting; this only bounds the cost of advancing a *stale* CRC.
+///
+/// A resolved CRC gives the snapshot precomputed file statistics (file count and sizes, useful
+/// for query optimization and for writers producing a post-commit CRC) along with domain metadata
+/// and set transactions (useful for writers), all without extra log replay.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum IncrementalReplay {
+    /// Never advance a stale CRC; fall back to normal log replay. `UpToCommits(0)` is equivalent.
+    #[default]
+    Disabled,
+    /// Advance only when the CRC is within `n` commits of the target version, i.e.
+    /// `target_version - crc_version <= n`.
+    UpToCommits(u64),
+    /// Advance regardless of how stale the CRC is.
+    Unlimited,
+}
+
+impl IncrementalReplay {
+    /// Whether the configured budget permits advancing a CRC at `crc_version` to `target_version`.
+    ///
+    /// Example: 95.crc with commits 96.json through 100.json is 5 commits, so `UpToCommits(5)`
+    /// advances and `UpToCommits(4)` does not; `Unlimited` always advances.
+    pub(crate) fn should_advance(self, crc_version: Version, target_version: Version) -> bool {
+        let distance = target_version.saturating_sub(crc_version);
+        match self {
+            IncrementalReplay::Disabled => false,
+            IncrementalReplay::UpToCommits(n) => distance <= n,
+            IncrementalReplay::Unlimited => true,
+        }
+    }
 }
 
 impl SnapshotBuilder {
@@ -54,6 +89,7 @@ impl SnapshotBuilder {
             version: None,
             log_tail: Vec::new(),
             max_catalog_version: None,
+            incremental_replay: IncrementalReplay::default(),
         }
     }
 
@@ -64,6 +100,7 @@ impl SnapshotBuilder {
             version: None,
             log_tail: Vec::new(),
             max_catalog_version: None,
+            incremental_replay: IncrementalReplay::default(),
         }
     }
 
@@ -114,6 +151,21 @@ impl SnapshotBuilder {
         self
     }
 
+    /// Bound how many commits kernel will replay to advance a stale on-disk CRC to the target
+    /// version. See [`IncrementalReplay`]. Defaults to [`IncrementalReplay::Disabled`].
+    ///
+    /// Writers should set this to [`IncrementalReplay::Unlimited`] for faster writes, as should
+    /// readers that always want table-level file statistics for query optimization.
+    ///
+    /// Only affects builds from a table root. Incremental updates from an existing snapshot
+    /// (via [`Snapshot::builder_from`]) do not yet advance stale CRCs (see #2674).
+    ///
+    /// [`Snapshot::builder_from`]: crate::Snapshot::builder_from
+    pub fn with_incremental_state_replay(mut self, mode: IncrementalReplay) -> Self {
+        self.incremental_replay = mode;
+        self
+    }
+
     // ============================================================================
     // Terminal: build the Snapshot
     // ============================================================================
@@ -152,6 +204,7 @@ impl SnapshotBuilder {
             version,
             log_tail,
             max_catalog_version,
+            incremental_replay,
         } = self;
 
         let log_tail: Vec<_> = log_tail.into_iter().map(Into::into).collect();
@@ -178,8 +231,14 @@ impl SnapshotBuilder {
                     effective_version,
                     operation_id,
                 )?;
-                Snapshot::try_new_from_log_segment(table_url, log_segment, engine, operation_id)
-                    .map(Into::into)
+                Snapshot::try_new_from_log_segment(
+                    table_url,
+                    log_segment,
+                    engine,
+                    operation_id,
+                    incremental_replay,
+                )
+                .map(Into::into)
             })
         } else {
             existing_snapshot

--- a/kernel/src/snapshot/incremental.rs
+++ b/kernel/src/snapshot/incremental.rs
@@ -244,7 +244,7 @@ impl Snapshot {
         // Replay only the new commits (> existing_snapshot_version) for P&M, excluding the
         // checkpoint. The existing snapshot supplies the P&M baseline.
         let (new_metadata, new_protocol) = new_log_segment
-            .segment_after_crc(existing_snapshot_version)
+            .segment_after_version(existing_snapshot_version)
             .read_protocol_metadata_opt(engine)?;
         let table_configuration = TableConfiguration::try_new_from(
             existing_snapshot.table_configuration(),
@@ -330,11 +330,11 @@ impl Snapshot {
     /// if and only if its version is >= the new segment's checkpoint version. This preserves
     /// the [`LogSegmentFiles`] invariant `crc.version >= checkpoint.version`.
     ///
-    /// The returned `Crc` is read only when the resolved CRC file is newer than
-    /// `existing_snapshot_version` (so it can contribute P&M for the new commits) or at the new
-    /// end version (so it can back the new snapshot). An older CRC can do neither, so it is left
-    /// unread and only contributes its path to the combined segment. When the resolved CRC is
-    /// the one `existing_crc` already holds, it is reused instead of re-read.
+    /// The returned `Crc` is read when the resolved CRC file is newer than
+    /// `existing_snapshot_version` (currently unused; see #2674) or at the new end version (which
+    /// backs the new snapshot). An older CRC can do neither, so it is left unread and only
+    /// contributes its path to the combined segment. When the resolved CRC is the one
+    /// `existing_crc` already holds, it is reused instead of re-read.
     fn resolve_crc(
         new_log_segment: &LogSegment,
         existing_log_segment: &LogSegment,

--- a/kernel/src/snapshot/incremental.rs
+++ b/kernel/src/snapshot/incremental.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use tracing::instrument;
 
-use super::Snapshot;
+use super::{IncrementalReplay, Snapshot};
 use crate::crc::{read_crc_file_or_none, Crc};
 use crate::log_segment::LogSegment;
 use crate::log_segment_files::LogSegmentFiles;
@@ -181,6 +181,7 @@ impl Snapshot {
                     new_log_segment,
                     engine,
                     operation_id,
+                    IncrementalReplay::Disabled,
                 );
                 return Ok(Arc::new(snapshot?));
             }
@@ -1150,6 +1151,7 @@ mod tests {
 
         let snapshot_v3 = Snapshot::builder_for(ctx.url.as_str())
             .at_version(3)
+            .with_incremental_state_replay(IncrementalReplay::Unlimited)
             .build(ctx.engine.as_ref())?;
         // A fresh build advances the stale CRC via reverse-replay to a CRC at v3 (file stats
         // Indeterminate, since these synthetic commits carry no commitInfo). The segment's

--- a/kernel/src/snapshot/incremental.rs
+++ b/kernel/src/snapshot/incremental.rs
@@ -1151,7 +1151,7 @@ mod tests {
 
         let snapshot_v3 = Snapshot::builder_for(ctx.url.as_str())
             .at_version(3)
-            .with_incremental_state_replay(IncrementalReplay::Unlimited)
+            .with_incremental_crc_replay(IncrementalReplay::Unlimited)
             .build(ctx.engine.as_ref())?;
         // A fresh build advances the stale CRC via reverse-replay to a CRC at v3 (file stats
         // Indeterminate, since these synthetic commits carry no commitInfo). The segment's

--- a/kernel/src/snapshot/incremental.rs
+++ b/kernel/src/snapshot/incremental.rs
@@ -242,16 +242,10 @@ impl Snapshot {
         );
 
         // Replay only the new commits (> existing_snapshot_version) for P&M, excluding the
-        // checkpoint. Only pass a CRC newer than the existing snapshot: an older CRC's P&M
-        // could predate changes already in the existing snapshot.
+        // checkpoint. The existing snapshot supplies the P&M baseline.
         let (new_metadata, new_protocol) = new_log_segment
             .segment_after_crc(existing_snapshot_version)
-            .read_protocol_metadata_opt(
-                engine,
-                resolved_crc
-                    .as_ref()
-                    .filter(|c| c.version > existing_snapshot_version),
-            )?;
+            .read_protocol_metadata_opt(engine)?;
         let table_configuration = TableConfiguration::try_new_from(
             existing_snapshot.table_configuration(),
             new_metadata,
@@ -319,6 +313,8 @@ impl Snapshot {
             combined_log_segment,
             table_configuration,
             // The snapshot holds a CRC only when it is at the new end version.
+            // TODO(#2674): advance the existing snapshot's CRC over the new tail commits instead
+            //              of dropping a stale one and falling back to full log replay.
             resolved_crc.filter(|c| c.version == new_end_version),
         )?))
     }
@@ -1155,9 +1151,10 @@ mod tests {
         let snapshot_v3 = Snapshot::builder_for(ctx.url.as_str())
             .at_version(3)
             .build(ctx.engine.as_ref())?;
-        // The existing CRC at v2 is stale for the v3 snapshot, so it is not stored on the
-        // snapshot, though it still appears as the segment's latest CRC file.
-        assert!(snapshot_v3.crc().is_none());
+        // A fresh build advances the stale CRC via reverse-replay to a CRC at v3 (file stats
+        // Indeterminate, since these synthetic commits carry no commitInfo). The segment's
+        // latest CRC file still points at the on-disk CRC version.
+        assert_eq!(snapshot_v3.crc().map(|c| c.version), Some(3));
         assert_eq!(
             snapshot_v3
                 .log_segment

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -37,7 +37,7 @@ use crate::{DeltaResult, Engine, Error, LogCompactionWriter, Version};
 
 mod builder;
 mod incremental;
-pub use builder::SnapshotBuilder;
+pub use builder::{IncrementalReplay, SnapshotBuilder};
 
 /// A shared, thread-safe reference to a [`Snapshot`].
 pub type SnapshotRef = Arc<Snapshot>;
@@ -178,8 +178,9 @@ impl Snapshot {
         log_segment: LogSegment,
         engine: &dyn Engine,
         operation_id: MetricId,
+        incremental_replay: IncrementalReplay,
     ) -> DeltaResult<Self> {
-        let crc = log_segment.try_build_incremental_crc(engine)?;
+        let crc = log_segment.try_build_incremental_crc(engine, incremental_replay)?;
 
         // TODO(#2677): emit an `IncrementalCrcLoad` metric on the CRC branch; the
         //              `ProtocolMetadataLoaded` span only fires on the replay branch below.

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -181,6 +181,8 @@ impl Snapshot {
     ) -> DeltaResult<Self> {
         let crc = log_segment.try_build_incremental_crc(engine)?;
 
+        // TODO(#2677): emit an `IncrementalCrcLoad` metric on the CRC branch; the
+        //              `ProtocolMetadataLoaded` span only fires on the replay branch below.
         let (metadata, protocol) = match crc.as_deref() {
             Some(c) => (c.metadata.clone(), c.protocol.clone()),
             None => log_segment.read_protocol_metadata(engine, operation_id)?,

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -17,8 +17,7 @@ use crate::checkpoint::{
 use crate::clustering::{parse_clustering_columns, CLUSTERING_DOMAIN_NAME};
 use crate::committer::{Committer, PublishMetadata};
 use crate::crc::{
-    read_crc_file_or_none, try_write_crc_file, Crc, CrcDelta, DomainMetadataState, FileStats,
-    SetTransactionState,
+    try_write_crc_file, Crc, CrcDelta, DomainMetadataState, FileStats, SetTransactionState,
 };
 use crate::expressions::ColumnName;
 use crate::incremental_scan::IncrementalScanBuilder;
@@ -171,8 +170,8 @@ impl Snapshot {
         })
     }
 
-    /// Create a new [`Snapshot`] from a freshly-listed [`LogSegment`], eagerly resolving the
-    /// CRC at the segment's end version when one is present on disk.
+    /// Create a new [`Snapshot`] from a freshly-listed [`LogSegment`], taking Protocol and
+    /// Metadata from the resolved CRC when one is present.
     #[instrument(err, fields(version, operation_id = %operation_id), skip(engine))]
     fn try_new_from_log_segment(
         location: Url,
@@ -180,21 +179,18 @@ impl Snapshot {
         engine: &dyn Engine,
         operation_id: MetricId,
     ) -> DeltaResult<Self> {
-        let read_crc = log_segment
-            .listed
-            .latest_crc_file
-            .as_ref()
-            .and_then(|crc_file| read_crc_file_or_none(engine, crc_file));
+        let crc = log_segment.try_build_incremental_crc(engine)?;
 
-        let (metadata, protocol) =
-            log_segment.read_protocol_metadata(engine, read_crc.as_ref(), operation_id)?;
+        let (metadata, protocol) = match crc.as_deref() {
+            Some(c) => (c.metadata.clone(), c.protocol.clone()),
+            None => log_segment.read_protocol_metadata(engine, operation_id)?,
+        };
 
         let table_configuration =
             TableConfiguration::try_new(metadata, protocol, location, log_segment.end_version)?;
 
         tracing::Span::current().record("version", table_configuration.version());
 
-        let crc = read_crc.filter(|c| c.version == log_segment.end_version);
         Self::new_with_crc(log_segment, table_configuration, crc)
     }
 

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -12,7 +12,7 @@ use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::object_store::local::LocalFileSystem;
 use delta_kernel::path::ParsedLogPath;
 use delta_kernel::schema::{DataType, StructField, StructType};
-use delta_kernel::snapshot::{ChecksumWriteResult, Snapshot, SnapshotRef};
+use delta_kernel::snapshot::{ChecksumWriteResult, IncrementalReplay, Snapshot, SnapshotRef};
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::{DeltaResult, Engine, FileStats, Version};
@@ -96,7 +96,9 @@ async fn test_get_file_stats_stale_crc_advances_via_safe_commit_serves_stats() -
     // ===== THEN =====
     // The fresh v1 build advances the stale v0 CRC; the safe commit added no files, so file
     // stats stay Complete and are served at v1 unchanged.
-    let snapshot = Snapshot::builder_for(table_path).build(engine.as_ref())?;
+    let snapshot = Snapshot::builder_for(table_path)
+        .with_incremental_state_replay(IncrementalReplay::Unlimited)
+        .build(engine.as_ref())?;
     assert_eq!(snapshot.version(), 1);
     assert_eq!(snapshot.crc().unwrap().version, 1);
     let stats = snapshot.get_file_stats_if_present().unwrap();
@@ -1662,7 +1664,9 @@ async fn test_stale_crc_fresh_build_advance_matrix(
     }
 
     // === Step 4: A fresh Snapshot at the latest version. ===
-    let fresh = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    let fresh = Snapshot::builder_for(&table_path)
+        .with_incremental_state_replay(IncrementalReplay::Unlimited)
+        .build(engine.as_ref())?;
     assert_eq!(fresh.version() as i64, LATEST_VERSION);
 
     let expect_crc_present = crc_staleness != CrcStaleness::Absent;
@@ -1788,7 +1792,9 @@ async fn test_stale_crc_fresh_build_non_incremental_op_trips_indeterminate() -> 
 
     // ===== THEN: advancing the stale CRC trips file stats to Indeterminate, so they are not
     // served and write_checksum is rejected =====
-    let fresh = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    let fresh = Snapshot::builder_for(&table_path)
+        .with_incremental_state_replay(IncrementalReplay::Unlimited)
+        .build(engine.as_ref())?;
     assert_eq!(fresh.version(), 2);
     assert!(fresh.crc().unwrap().file_stats_state().is_indeterminate());
     assert_eq!(fresh.get_file_stats_if_present(), None);
@@ -1823,6 +1829,7 @@ async fn test_stale_crc_fresh_build_fails_load_when_advance_commit_is_corrupt() 
     std::fs::write(&commit_v1, b"}}} not valid commit json").unwrap();
 
     assert!(Snapshot::builder_for(&table_path)
+        .with_incremental_state_replay(IncrementalReplay::Unlimited)
         .build(engine.as_ref())
         .is_err());
 

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -97,7 +97,7 @@ async fn test_get_file_stats_stale_crc_advances_via_safe_commit_serves_stats() -
     // The fresh v1 build advances the stale v0 CRC; the safe commit added no files, so file
     // stats stay Complete and are served at v1 unchanged.
     let snapshot = Snapshot::builder_for(table_path)
-        .with_incremental_state_replay(IncrementalReplay::Unlimited)
+        .with_incremental_crc_replay(IncrementalReplay::Unlimited)
         .build(engine.as_ref())?;
     assert_eq!(snapshot.version(), 1);
     assert_eq!(snapshot.crc().unwrap().version, 1);
@@ -1593,7 +1593,7 @@ async fn commit_with_dm_and_txn<E: TaskExecutor>(
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum CrcStaleness {
-    Middle,
+    MidSegment,
     AtCheckpoint,
     Absent,
 }
@@ -1602,7 +1602,7 @@ enum CrcStaleness {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_stale_crc_fresh_build_advance_matrix(
     #[values(
-        CrcStaleness::Middle,
+        CrcStaleness::MidSegment,
         CrcStaleness::AtCheckpoint,
         CrcStaleness::Absent
     )]
@@ -1612,7 +1612,7 @@ async fn test_stale_crc_fresh_build_advance_matrix(
     const CHECKPOINT_VERSION: i64 = 10;
     const LATEST_VERSION: i64 = 20;
     let crc_version = match crc_staleness {
-        CrcStaleness::Middle => Some((CHECKPOINT_VERSION + LATEST_VERSION) / 2),
+        CrcStaleness::MidSegment => Some((CHECKPOINT_VERSION + LATEST_VERSION) / 2),
         CrcStaleness::AtCheckpoint => Some(CHECKPOINT_VERSION),
         CrcStaleness::Absent => None,
     };
@@ -1665,7 +1665,7 @@ async fn test_stale_crc_fresh_build_advance_matrix(
 
     // === Step 4: A fresh Snapshot at the latest version. ===
     let fresh = Snapshot::builder_for(&table_path)
-        .with_incremental_state_replay(IncrementalReplay::Unlimited)
+        .with_incremental_crc_replay(IncrementalReplay::Unlimited)
         .build(engine.as_ref())?;
     assert_eq!(fresh.version() as i64, LATEST_VERSION);
 
@@ -1793,7 +1793,7 @@ async fn test_stale_crc_fresh_build_non_incremental_op_trips_indeterminate() -> 
     // ===== THEN: advancing the stale CRC trips file stats to Indeterminate, so they are not
     // served and write_checksum is rejected =====
     let fresh = Snapshot::builder_for(&table_path)
-        .with_incremental_state_replay(IncrementalReplay::Unlimited)
+        .with_incremental_crc_replay(IncrementalReplay::Unlimited)
         .build(engine.as_ref())?;
     assert_eq!(fresh.version(), 2);
     assert!(fresh.crc().unwrap().file_stats_state().is_indeterminate());
@@ -1829,7 +1829,7 @@ async fn test_stale_crc_fresh_build_fails_load_when_advance_commit_is_corrupt() 
     std::fs::write(&commit_v1, b"}}} not valid commit json").unwrap();
 
     assert!(Snapshot::builder_for(&table_path)
-        .with_incremental_state_replay(IncrementalReplay::Unlimited)
+        .with_incremental_crc_replay(IncrementalReplay::Unlimited)
         .build(engine.as_ref())
         .is_err());
 

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -1747,15 +1747,16 @@ async fn test_stale_crc_fresh_build_advance_matrix(
     );
 
     // === Check: write_checksum ===
-    match crc_staleness {
-        CrcStaleness::Absent => assert!(matches!(
-            fresh.write_checksum(engine.as_ref()),
-            Err(delta_kernel::Error::ChecksumWriteUnsupported(_))
-        )),
-        _ => assert_eq!(
+    if expect_crc_present {
+        assert_eq!(
             fresh.write_checksum(engine.as_ref())?.0,
             ChecksumWriteResult::Written
-        ),
+        );
+    } else {
+        assert!(matches!(
+            fresh.write_checksum(engine.as_ref()),
+            Err(delta_kernel::Error::ChecksumWriteUnsupported(_))
+        ));
     }
 
     Ok(())
@@ -1795,6 +1796,35 @@ async fn test_stale_crc_fresh_build_non_incremental_op_trips_indeterminate() -> 
         fresh.write_checksum(engine.as_ref()),
         Err(delta_kernel::Error::ChecksumWriteUnsupported(_))
     ));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_stale_crc_fresh_build_fails_load_when_advance_commit_is_corrupt() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    let snap = create_table_and_commit(&table_path, engine.as_ref())?
+        .post_commit_snapshot()
+        .unwrap()
+        .clone();
+    snap.write_checksum(engine.as_ref())?;
+    insert_data(
+        snap,
+        &engine,
+        vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+    )
+    .await?
+    .unwrap_committed();
+
+    let commit_v1 = _temp_dir
+        .path()
+        .join("_delta_log/00000000000000000001.json");
+    std::fs::write(&commit_v1, b"}}} not valid commit json").unwrap();
+
+    assert!(Snapshot::builder_for(&table_path)
+        .build(engine.as_ref())
+        .is_err());
 
     Ok(())
 }

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -4,9 +4,11 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use delta_kernel::arrow::array::{ArrayRef, Int32Array, StringArray};
+use delta_kernel::arrow::array::{ArrayRef, Int32Array, RecordBatch, StringArray};
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::crc::{Crc, DomainMetadataState, SetTransactionState};
+use delta_kernel::engine::arrow_conversion::TryFromKernel;
+use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::object_store::local::LocalFileSystem;
 use delta_kernel::path::ParsedLogPath;
 use delta_kernel::schema::{DataType, StructField, StructType};
@@ -15,8 +17,11 @@ use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::{DeltaResult, Engine, FileStats, Version};
 use rstest::rstest;
-use test_utils::delta_kernel_default_engine::DefaultEngineBuilder;
-use test_utils::{add_commit, begin_transaction, insert_data, test_table_setup};
+use test_utils::delta_kernel_default_engine::executor::TaskExecutor;
+use test_utils::delta_kernel_default_engine::{DefaultEngine, DefaultEngineBuilder};
+use test_utils::{
+    add_commit, begin_transaction, insert_data, test_table_setup, test_table_setup_mt,
+};
 use url::Url;
 
 // ============================================================================
@@ -66,7 +71,7 @@ async fn test_get_file_stats_no_crc() -> DeltaResult<()> {
 }
 
 #[tokio::test]
-async fn test_get_file_stats_crc_not_at_snapshot_version() -> DeltaResult<()> {
+async fn test_get_file_stats_stale_crc_advances_via_safe_commit_serves_stats() -> DeltaResult<()> {
     use test_utils::copy_directory;
 
     // ===== GIVEN =====
@@ -82,17 +87,21 @@ async fn test_get_file_stats_crc_not_at_snapshot_version() -> DeltaResult<()> {
     assert!(snapshot.get_file_stats_if_present().is_some());
 
     // ===== WHEN =====
-    // Empty commit to advance to version 1 (no new CRC file written)
-    let _ = begin_transaction(snapshot, engine.as_ref())?.commit(engine.as_ref())?;
+    // Safe (WRITE) commit with no file actions advances to version 1 (no new CRC written).
+    begin_transaction(snapshot, engine.as_ref())?
+        .with_operation("WRITE".to_string())
+        .commit(engine.as_ref())?
+        .unwrap_committed();
 
     // ===== THEN =====
-    // Load a fresh snapshot at version 1
+    // The fresh v1 build advances the stale v0 CRC; the safe commit added no files, so file
+    // stats stay Complete and are served at v1 unchanged.
     let snapshot = Snapshot::builder_for(table_path).build(engine.as_ref())?;
     assert_eq!(snapshot.version(), 1);
-
-    // No CRC at version 1, so file stats should be None
-    let file_stats = snapshot.get_file_stats_if_present();
-    assert_eq!(file_stats, None);
+    assert_eq!(snapshot.crc().unwrap().version, 1);
+    let stats = snapshot.get_file_stats_if_present().unwrap();
+    assert_eq!(stats.num_files(), 10);
+    assert_eq!(stats.table_size_bytes(), 5259);
 
     Ok(())
 }
@@ -1545,6 +1554,247 @@ async fn test_file_histogram_with_bin_type_and_operation_type(
         assert_eq!(counts.len(), 95, "default bins should have 95 bins");
         assert_histogram_totals(stats_v2, 2, total_disk_bytes);
     }
+
+    Ok(())
+}
+
+// ============================================================================
+// Stale-CRC advance on fresh build (reverse-replay)
+// ============================================================================
+
+// Commit one data file plus DomainMetadata "domain"->"value_{v}" and SetTxn "app"->{v} where `v` is
+// the commit version.
+async fn commit_with_dm_and_txn<E: TaskExecutor>(
+    snapshot: SnapshotRef,
+    engine: &Arc<DefaultEngine<E>>,
+    v: i64,
+) -> DeltaResult<SnapshotRef> {
+    let arrow_schema = TryFromKernel::try_from_kernel(snapshot.schema().as_ref())?;
+    let batch = RecordBatch::try_new(
+        Arc::new(arrow_schema),
+        vec![Arc::new(Int32Array::from(vec![v as i32]))],
+    )
+    .map_err(|e| delta_kernel::Error::generic(e.to_string()))?;
+    let mut txn = snapshot
+        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .with_operation("WRITE".to_string())
+        .with_data_change(true)
+        .with_domain_metadata("domain".to_string(), format!("value_{v}"))
+        .with_transaction_id("app".to_string(), v);
+    let write_context = txn.unpartitioned_write_context()?;
+    let adds = engine
+        .write_parquet(&ArrowEngineData::new(batch), &write_context)
+        .await?;
+    txn.add_files(adds);
+    Ok(txn.commit(engine.as_ref())?.unwrap_post_commit_snapshot())
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CrcStaleness {
+    Middle,
+    AtCheckpoint,
+    Absent,
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_stale_crc_fresh_build_advance_matrix(
+    #[values(
+        CrcStaleness::Middle,
+        CrcStaleness::AtCheckpoint,
+        CrcStaleness::Absent
+    )]
+    crc_staleness: CrcStaleness,
+    #[values(false, true)] crc_missing_opt_fields: bool,
+) -> DeltaResult<()> {
+    const CHECKPOINT_VERSION: i64 = 10;
+    const LATEST_VERSION: i64 = 20;
+    let crc_version = match crc_staleness {
+        CrcStaleness::Middle => Some((CHECKPOINT_VERSION + LATEST_VERSION) / 2),
+        CrcStaleness::AtCheckpoint => Some(CHECKPOINT_VERSION),
+        CrcStaleness::Absent => None,
+    };
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+
+    // === Step 1: Create table with clustering, rowTracking, ICT ===
+    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
+        "id",
+        DataType::INTEGER,
+    )])?);
+    let mut snap = create_table(&table_path, schema, "test_engine")
+        .with_data_layout(DataLayout::clustered(["id"]))
+        .with_table_properties([
+            ("delta.enableRowTracking", "true"),
+            ("delta.enableInCommitTimestamps", "true"),
+        ])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .with_domain_metadata("domain_at_create".to_string(), "value_0".to_string())
+        .with_transaction_id("app_at_create".to_string(), 0)
+        .commit(engine.as_ref())?
+        .unwrap_post_commit_snapshot();
+
+    // === Step 2: Commits up to CHECKPOINT_VERSION, followed by a checkpoint. ===
+    for v in 1..=CHECKPOINT_VERSION {
+        snap = commit_with_dm_and_txn(snap, &engine, v).await?;
+    }
+    snap = snap.checkpoint(engine.as_ref(), None)?.1;
+
+    // === Step 3: Commit up to LATEST_VERSION, writing the CRC at its target version. ===
+    //
+    // Each commit will write:
+    // - DomainMetadata: "domain"->"value_{v}"
+    // - SetTxn: "app"->{v}
+    if crc_version == Some(CHECKPOINT_VERSION) {
+        snap.write_checksum(engine.as_ref())?;
+    }
+    for v in (CHECKPOINT_VERSION + 1)..=LATEST_VERSION {
+        snap = commit_with_dm_and_txn(snap, &engine, v).await?;
+        if crc_version == Some(v) {
+            snap.write_checksum(engine.as_ref())?;
+        }
+    }
+
+    // If test setup required missing CRC fields, then remove all optional ones.
+    if let Some(v) = crc_version.filter(|_| crc_missing_opt_fields) {
+        for field in ["fileSizeHistogram", "domainMetadata", "setTransactions"] {
+            strip_field_from_crc(&table_path, v as u64, field);
+        }
+    }
+
+    // === Step 4: A fresh Snapshot at the latest version. ===
+    let fresh = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert_eq!(fresh.version() as i64, LATEST_VERSION);
+
+    let expect_crc_present = crc_staleness != CrcStaleness::Absent;
+
+    // Define our engines that will be used below.
+    let real_engine_iff_crc_missing: &dyn Engine = if expect_crc_present {
+        &FailingEngine
+    } else {
+        engine.as_ref()
+    };
+    let real_engine_iff_crc_missing_or_crc_missing_opt_fields: &dyn Engine =
+        if expect_crc_present && !crc_missing_opt_fields {
+            &FailingEngine
+        } else {
+            engine.as_ref()
+        };
+
+    // === Check: CRC presence ===
+    assert_eq!(
+        fresh.crc().map(|c| c.version as i64),
+        expect_crc_present.then_some(LATEST_VERSION)
+    );
+
+    // === Check: file stats ===
+    let stats = fresh.get_file_stats_if_present();
+    assert_eq!(stats.is_some(), expect_crc_present);
+    if let Some(stats) = stats {
+        let disk = parquet_file_sizes_on_disk(&table_path);
+        assert_eq!(stats.num_files() as usize, disk.len());
+        assert_eq!(stats.table_size_bytes(), disk.iter().sum::<i64>());
+        assert_eq!(
+            stats.file_size_histogram().is_some(),
+            !crc_missing_opt_fields
+        );
+    }
+
+    // === Check: ICT ===
+    // - If no CRC, then we must re-read the latest commit -> need real engine.
+    // - Else, we did CRC replay and cached the result -> use fake engine.
+    assert!(fresh
+        .get_in_commit_timestamp(real_engine_iff_crc_missing)?
+        .is_some());
+
+    // For both domain metadata and set transaction checks below:
+    // - If no CRC, then we must read non-zero commits -> need real engine.
+    // - Else, there is a CRC:
+    //   - If we want a value set *before* the CRC was written (e.g. in create), then we need a real
+    //     engine only if the CRC is missing optional fields.
+    //   - If we want a value set *after* the CRC was written (e.g. in an insert), then we can use a
+    //     fake engine.
+
+    // === Check: domain metadata written *before* the CRC ===
+    for domain in ["domain_at_create", "delta.clustering"] {
+        assert!(fresh
+            .get_domain_metadata_internal(
+                domain,
+                real_engine_iff_crc_missing_or_crc_missing_opt_fields
+            )?
+            .is_some());
+    }
+
+    // === Check: domain metadata written *after* the CRC ===
+    for domain in ["domain", "delta.rowTracking"] {
+        assert!(fresh
+            .get_domain_metadata_internal(domain, real_engine_iff_crc_missing)?
+            .is_some());
+    }
+
+    // === Check: set transactions written *before* the CRC ===
+    assert_eq!(
+        fresh.get_app_id_version(
+            "app_at_create",
+            real_engine_iff_crc_missing_or_crc_missing_opt_fields
+        )?,
+        Some(0)
+    );
+
+    // === Check: set transactions written *after* the CRC ===
+    assert_eq!(
+        fresh.get_app_id_version("app", real_engine_iff_crc_missing)?,
+        Some(LATEST_VERSION)
+    );
+
+    // === Check: write_checksum ===
+    match crc_staleness {
+        CrcStaleness::Absent => assert!(matches!(
+            fresh.write_checksum(engine.as_ref()),
+            Err(delta_kernel::Error::ChecksumWriteUnsupported(_))
+        )),
+        _ => assert_eq!(
+            fresh.write_checksum(engine.as_ref())?.0,
+            ChecksumWriteResult::Written
+        ),
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_stale_crc_fresh_build_non_incremental_op_trips_indeterminate() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    // ===== GIVEN: a CRC at v0 (made stale by an insert at v1) =====
+    let snap = create_table_and_commit(&table_path, engine.as_ref())?
+        .post_commit_snapshot()
+        .unwrap()
+        .clone();
+    snap.write_checksum(engine.as_ref())?;
+    let snap = insert_data(
+        snap,
+        &engine,
+        vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+    )
+    .await?
+    .unwrap_post_commit_snapshot();
+
+    // ===== WHEN: a non-incremental operation (ANALYZE STATS) commits at v2 =====
+    begin_transaction(snap, engine.as_ref())?
+        .with_operation("ANALYZE STATS".to_string())
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    // ===== THEN: advancing the stale CRC trips file stats to Indeterminate, so they are not
+    // served and write_checksum is rejected =====
+    let fresh = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert_eq!(fresh.version(), 2);
+    assert!(fresh.crc().unwrap().file_stats_state().is_indeterminate());
+    assert_eq!(fresh.get_file_stats_if_present(), None);
+    assert!(matches!(
+        fresh.write_checksum(engine.as_ref()),
+        Err(delta_kernel::Error::ChecksumWriteUnsupported(_))
+    ));
 
     Ok(())
 }

--- a/kernel/tests/integration/metrics/snapshot_load.rs
+++ b/kernel/tests/integration/metrics/snapshot_load.rs
@@ -13,6 +13,7 @@ use delta_kernel::engine::to_json_bytes;
 use delta_kernel::object_store::local::LocalFileSystem;
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::ObjectStoreExt as _;
+use delta_kernel::snapshot::IncrementalReplay;
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::{DeltaResult, Snapshot};
@@ -286,7 +287,9 @@ async fn crc_at_prior_version_advances_via_reverse_replay() -> DeltaResult<()> {
 
     // Measurement: build snapshot at latest (v2); CRC is at v0 (two versions behind)
     let (measure_engine, reporter, _guard) = measuring_engine(Arc::new(LocalFileSystem::new()));
-    let snap = Snapshot::builder_for(table_url).build(&measure_engine)?;
+    let snap = Snapshot::builder_for(table_url)
+        .with_incremental_state_replay(IncrementalReplay::Unlimited)
+        .build(&measure_engine)?;
     assert_eq!(snap.crc().expect("stale CRC advanced to v2").version, 2);
 
     assert_eq!(reporter.snapshot_completions.get(), 1);

--- a/kernel/tests/integration/metrics/snapshot_load.rs
+++ b/kernel/tests/integration/metrics/snapshot_load.rs
@@ -288,7 +288,7 @@ async fn crc_at_prior_version_advances_via_reverse_replay() -> DeltaResult<()> {
     // Measurement: build snapshot at latest (v2); CRC is at v0 (two versions behind)
     let (measure_engine, reporter, _guard) = measuring_engine(Arc::new(LocalFileSystem::new()));
     let snap = Snapshot::builder_for(table_url)
-        .with_incremental_state_replay(IncrementalReplay::Unlimited)
+        .with_incremental_crc_replay(IncrementalReplay::Unlimited)
         .build(&measure_engine)?;
     assert_eq!(snap.crc().expect("stale CRC advanced to v2").version, 2);
 

--- a/kernel/tests/integration/metrics/snapshot_load.rs
+++ b/kernel/tests/integration/metrics/snapshot_load.rs
@@ -237,10 +237,10 @@ async fn snapshot_with_crc_at_target_version_skips_json_replay() -> DeltaResult<
 // ============================================================================
 // TODO: migrate to TestTableBuilder when CRC LogState variants land (#2284)
 
-/// When a CRC file exists at an older version than the snapshot, the kernel takes the
-/// partial-replay path: it replays only the tail commits (those after the CRC version)
-/// looking for Protocol/Metadata changes, then falls back to the CRC when none are
-/// found. This produces JSON reads for the tail commits AND a storage read for the CRC.
+/// When a CRC file exists at an older version than the snapshot, the kernel advances it to the
+/// target version via reverse-replay: it reads the tail commits (those after the CRC version)
+/// once and reads the base CRC from storage. P&M come from the advanced CRC, so there is no
+/// separate P&M scan.
 ///
 /// This is a normal, expected table state -- having a CRC from a previous version is
 /// not an error or degraded condition.
@@ -249,7 +249,7 @@ async fn snapshot_with_crc_at_target_version_skips_json_replay() -> DeltaResult<
 /// one), so this test uses `create_table` commit -> `post_commit_snapshot` ->
 /// `write_checksum` to write the CRC at v0.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn crc_at_prior_version_triggers_tail_replay_then_falls_back_to_crc() -> DeltaResult<()> {
+async fn crc_at_prior_version_advances_via_reverse_replay() -> DeltaResult<()> {
     let (_temp_dir, table_path, setup_engine) = test_table_setup_mt()?;
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
 
@@ -286,16 +286,17 @@ async fn crc_at_prior_version_triggers_tail_replay_then_falls_back_to_crc() -> D
 
     // Measurement: build snapshot at latest (v2); CRC is at v0 (two versions behind)
     let (measure_engine, reporter, _guard) = measuring_engine(Arc::new(LocalFileSystem::new()));
-    let _snap = Snapshot::builder_for(table_url).build(&measure_engine)?;
+    let snap = Snapshot::builder_for(table_url).build(&measure_engine)?;
+    assert_eq!(snap.crc().expect("stale CRC advanced to v2").version, 2);
 
     assert_eq!(reporter.snapshot_completions.get(), 1);
     assert_eq!(reporter.log_segment_loads.get(), 1);
     assert_eq!(reporter.commit_files.get(), 3); // v0, v1, v2
 
-    // Tail replay: commits v1 and v2 (after the CRC at v0) are replayed via JSON
+    // Reverse-replay reads the tail commits v1 and v2 (after the CRC at v0) in one JSON call.
     assert_eq!(reporter.json_read_calls.get(), 1);
     assert_eq!(reporter.json_files_read.get(), 2);
-    // CRC is loaded from storage as a fallback (P+M not found in the tail commits)
+    // The base CRC at v0 is read from storage.
     assert!(reporter.storage_read_calls.get() >= 1);
 
     Ok(())


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR connects the existing incremental CRC replay infrastructure into our Snapshot construction workflow.

New public API: `SnapshotBuilder::with_incremental_crc_replay(mode)` bounds how many commits kernel replays to advance a stale CRC to the target version on load. `IncrementalReplay` is `Disabled` (default), `UpToCommits(n)`, or `Unlimited`. Writers should use `Unlimited` for faster writes: a resolved CRC supplies file stats, domain metadata, and set transactions without extra log replay.

There are some important followups after this PR is merged:
- Metrics
- Better incremental Snapshot build support. That is: Snapshot at v15 with v15.crc. When we incrementally go to build a newer snapshot at v17 (no new CRC), we should be doing incremental CRC replay against that 15.crc. Out of scope of this current PR.

See the CRC tracking issue #1781 

## How was this change tested?

New UTs.
