### PR TITLE
feat: introduce FFI types for plan execution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -346,7 +346,7 @@ jobs:
       - name: Test with Miri
         run: |
           pushd ffi
-          MIRIFLAGS=-Zmiri-disable-isolation cargo miri nextest run --locked --features default-engine-rustls,delta-kernel-unity-catalog --partition slice:${{ matrix.partition }}/3
+          MIRIFLAGS=-Zmiri-disable-isolation cargo miri nextest run --locked --features default-engine-rustls,delta-kernel-unity-catalog,declarative-plans --partition slice:${{ matrix.partition }}/3
 
   coverage:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,6 +1344,7 @@ dependencies = [
 name = "delta_kernel_ffi"
 version = "0.24.0"
 dependencies = [
+ "bytes",
  "cbindgen",
  "delta-kernel-unity-catalog",
  "delta_kernel",

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -18,6 +18,7 @@ release = false
 crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
+bytes = "1.10"
 tracing = "0.1"
 tracing-core = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", optional = true, features = [ "json" ] }
@@ -58,6 +59,11 @@ arrow-57 = ["delta_kernel/arrow-57"]
 # default-engine-rustls. There is a check in kernel/lib.rs to ensure you have enabled one of
 # default-engine-native-tls or default-engine-rustls, so default-engine-base will not work by itself
 default-engine-base = ["delta_kernel/default-engine-base"]
+
+# Declarative plan execution via PlanExecutor trait (experimental).
+#
+# Requires `arrow` because iterators returned from plan execution use Arrow to pass along data batches.
+declarative-plans = ["delta_kernel/declarative-plans", "arrow"]
 
 tracing = [ "tracing-core", "tracing-subscriber" ]
 internal-api = []

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -53,6 +53,8 @@ pub mod expressions;
 #[cfg(feature = "tracing")]
 pub mod ffi_tracing;
 pub mod log_path;
+#[cfg(feature = "declarative-plans")]
+pub mod plans;
 pub mod scan;
 pub mod schema;
 pub mod schema_visitor;

--- a/ffi/src/plans/iter.rs
+++ b/ffi/src/plans/iter.rs
@@ -84,15 +84,17 @@ pub struct CBytesIterator {
     pub next: extern "C" fn(state: NullableCvoid) -> OptionalValue<ExternResult<FFI_ArrowArray>>,
 }
 
-/// An engine-owned iterator of [`FileMeta`](delta_kernel::FileMeta) entries.
+/// An engine-owned iterator of [`FileMeta`](delta_kernel::FileMeta) batches.
 ///
 /// See module level docs for memory management and safety requirements.
 ///
-/// Similar to `CBytesIterator`, CFileMetaIterator uses `FFI_ArrowArray`` as a convenient continer
-/// for passing FileMeta entries across the FFI boundary. Each FileMeta is passed as an
-/// a `StructArray` of length 1 whose fields are `{location: Utf8, last_modified: Int64, size:
-/// UInt64}`, all non-null. Kernel assumes this fixed schema when converting into FileMeta (the
-/// schema is NOT passed along through FFI).
+/// Similar to `CBytesIterator`, CFileMetaIterator uses `FFI_ArrowArray` as a convenient container
+/// for passing FileMeta entries across the FFI boundary. Each `next` invocation MUST yield a batch
+/// of one or more FileMeta rows as a `StructArray` whose fields are
+/// `{location: Utf8, last_modified: Int64, size: UInt64}`, all non-null. Kernel assumes this fixed
+/// schema when converting into FileMeta (the schema is NOT passed along through FFI).
+/// Empty or otherwise invalid batches surface as errors and permanently terminate iteration
+/// (kernel will not call `next` again).
 #[repr(C)]
 pub struct CFileMetaIterator {
     pub state: NullableCvoid,
@@ -204,8 +206,15 @@ unsafe impl Send for FfiBytesIter {}
 
 /// Provides the Rust `Iterator` trait for [`FileMeta`] entries on top of a
 /// [`CFileMetaIterator`].
+///
+/// Buffers each engine-yielded batch and surfaces one row per `Iterator::next` call. Permanantly
+/// terminates if the engine returns None or a batch fails to decode. Errors surfaced directly by
+/// the engine `next` callback are considered transient and do NOT terminate iteration.
 pub(crate) struct FfiFileMetaIter {
     iter: CFileMetaIterator,
+    // Decoded rows from the most recent engine batch
+    buffer: std::vec::IntoIter<delta_kernel::FileMeta>,
+    terminated: bool,
     _cleanup: PlanResultCleanup,
 }
 
@@ -213,6 +222,8 @@ impl FfiFileMetaIter {
     pub(crate) fn new(iter: CFileMetaIterator, cleanup: PlanResultCleanup) -> Self {
         Self {
             iter,
+            buffer: Vec::new().into_iter(),
+            terminated: false,
             _cleanup: cleanup,
         }
     }
@@ -228,7 +239,10 @@ impl FfiFileMetaIter {
         Ok(FFI_ArrowSchema::try_from(&schema)?)
     }
 
-    fn arrow_array_to_file_meta(array: FFI_ArrowArray) -> DeltaResult<delta_kernel::FileMeta> {
+    /// Decodes a single engine batch into a `Vec<FileMeta>`.
+    fn arrow_array_to_file_metas(
+        array: FFI_ArrowArray,
+    ) -> DeltaResult<Vec<delta_kernel::FileMeta>> {
         let schema = Self::arrow_schema()?;
         let array_data = unsafe { arrow_ffi::from_ffi(array, &schema) }?;
         let array = arrow_array::make_array(array_data);
@@ -239,11 +253,10 @@ impl FfiFileMetaIter {
                 array.data_type()
             )));
         };
-        if struct_array.len() != 1 {
-            return Err(Error::generic(format!(
-                "CFileMetaIterator array must contain exactly one row, got {}",
-                struct_array.len()
-            )));
+        if struct_array.is_empty() {
+            return Err(Error::generic(
+                "CFileMetaIterator batch must contain at least one row",
+            ));
         }
 
         // The fixed schema guarantees three columns in this order, all non-null. `from_ffi`
@@ -268,17 +281,26 @@ impl FfiFileMetaIter {
             .downcast_ref::<UInt64Array>()
             .ok_or_else(|| Error::generic("CFileMetaIterator: size column is not UInt64"))?;
 
-        if location_col.is_null(0) || last_modified_col.is_null(0) || size_col.is_null(0) {
+        // The fixed schema declares every column non-null; reject any batch that violates that
+        // contract up front so the per-row decode below can safely call `value(i)`.
+        if location_col.null_count() != 0
+            || last_modified_col.null_count() != 0
+            || size_col.null_count() != 0
+        {
             return Err(Error::generic(
-                "CFileMetaIterator row must not contain null fields",
+                "CFileMetaIterator batch must not contain null fields",
             ));
         }
 
-        Ok(delta_kernel::FileMeta {
-            location: Url::parse(location_col.value(0))?,
-            last_modified: last_modified_col.value(0),
-            size: size_col.value(0),
-        })
+        (0..struct_array.len())
+            .map(|i| {
+                Ok(delta_kernel::FileMeta {
+                    location: Url::parse(location_col.value(i))?,
+                    last_modified: last_modified_col.value(i),
+                    size: size_col.value(i),
+                })
+            })
+            .collect()
     }
 }
 
@@ -286,12 +308,36 @@ impl Iterator for FfiFileMetaIter {
     type Item = DeltaResult<delta_kernel::FileMeta>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        match (self.iter.next)(self.iter.state) {
-            OptionalValue::None => None,
-            // TODO: re-evaluate memory management; errors are currently freed by PlanResultCleanup
-            OptionalValue::Some(ExternResult::Err(err)) => Some(Err(engine_error_to_kernel(err))),
-            OptionalValue::Some(ExternResult::Ok(array)) => {
-                Some(Self::arrow_array_to_file_meta(array))
+        loop {
+            if self.terminated {
+                return None;
+            }
+
+            if let Some(meta) = self.buffer.next() {
+                return Some(Ok(meta));
+            }
+
+            // Buffer drained and iteration is still live; pull the next batch from the engine.
+            match (self.iter.next)(self.iter.state) {
+                OptionalValue::None => {
+                    self.terminated = true;
+                    return None;
+                }
+                // TODO: re-evaluate memory management; errors are currently freed by
+                // PlanResultCleanup
+                OptionalValue::Some(ExternResult::Err(err)) => {
+                    return Some(Err(engine_error_to_kernel(err)))
+                }
+                OptionalValue::Some(ExternResult::Ok(array)) => {
+                    match Self::arrow_array_to_file_metas(array) {
+                        Ok(batch) => self.buffer = batch.into_iter(),
+                        Err(e) => {
+                            // Decoder errors (including empty batches) are fatal
+                            self.terminated = true;
+                            return Some(Err(e));
+                        }
+                    }
+                }
             }
         }
     }
@@ -482,13 +528,16 @@ mod tests {
 
     // === FfiFileMetaIter Test ===
 
-    /// Helper for building each yielded FileMeta entry. Constructs a single-row `StructArray`
-    /// matching the fixed schema kernel synthesizes in `FfiFileMetaIter::arrow_data_type`.
-    fn make_file_meta_ffi_array(location: &str, last_modified: i64, size: u64) -> FFI_ArrowArray {
+    /// Helper for building a yielded FileMeta batch. `rows` may be empty to construct a malformed
+    /// batch for negative tests.
+    fn make_file_meta_ffi_array(rows: &[(&str, i64, u64)]) -> FFI_ArrowArray {
+        let locations: Vec<&str> = rows.iter().map(|(l, _, _)| *l).collect();
+        let last_modifieds: Vec<i64> = rows.iter().map(|(_, t, _)| *t).collect();
+        let sizes: Vec<u64> = rows.iter().map(|(_, _, s)| *s).collect();
         let struct_array = StructArray::from(vec![
             (
                 Arc::new(ArrowField::new("location", ArrowDataType::Utf8, false)),
-                Arc::new(StringArray::from(vec![location])) as ArrayRef,
+                Arc::new(StringArray::from(locations)) as ArrayRef,
             ),
             (
                 Arc::new(ArrowField::new(
@@ -496,69 +545,129 @@ mod tests {
                     ArrowDataType::Int64,
                     false,
                 )),
-                Arc::new(Int64Array::from(vec![last_modified])) as ArrayRef,
+                Arc::new(Int64Array::from(last_modifieds)) as ArrayRef,
             ),
             (
                 Arc::new(ArrowField::new("size", ArrowDataType::UInt64, false)),
-                Arc::new(UInt64Array::from(vec![size])) as ArrayRef,
+                Arc::new(UInt64Array::from(sizes)) as ArrayRef,
             ),
         ]);
         let (ffi_array, _ffi_schema) = arrow_ffi::to_ffi(&struct_array.into_data()).unwrap();
         ffi_array
     }
 
+    extern "C" fn file_meta_next(
+        state: NullableCvoid,
+    ) -> OptionalValue<ExternResult<FFI_ArrowArray>> {
+        let mock_iter = unsafe { &*(state.unwrap().as_ptr() as *const MockIter<FFI_ArrowArray>) };
+        mock_iter
+            .items
+            .lock()
+            .unwrap()
+            .pop_front()
+            .unwrap_or(OptionalValue::None)
+    }
+
+    /// Exercises batched yields with a multi-row batch, a transient engine error (which does not
+    /// terminate iteration), and a single-row batch. Verifies the Rust-side adapter buffers each
+    /// batch and surfaces one row per `Iterator::next` call.
     #[test]
     fn ffi_file_meta_iter_drains_and_runs_cleanup() {
         let err = EngineError {
             etype: KernelError::GenericError,
         };
         let (mock_iter, cleanup_called) = make_mock_iter::<FFI_ArrowArray>(vec![
-            OptionalValue::Some(ExternResult::Ok(make_file_meta_ffi_array(
-                "file:///a.parquet",
-                1,
-                100,
-            ))),
+            OptionalValue::Some(ExternResult::Ok(make_file_meta_ffi_array(&[
+                ("file:///a.parquet", 1, 100),
+                ("file:///b.parquet", 2, 200),
+            ]))),
             OptionalValue::Some(ExternResult::Err(err_ptr(&err))),
-            OptionalValue::Some(ExternResult::Ok(make_file_meta_ffi_array(
-                "file:///b.parquet",
-                2,
-                200,
-            ))),
+            OptionalValue::Some(ExternResult::Ok(make_file_meta_ffi_array(&[(
+                "file:///c.parquet",
+                3,
+                300,
+            )]))),
         ]);
         let state = NonNull::new(Box::into_raw(mock_iter) as *mut c_void);
 
-        extern "C" fn next(state: NullableCvoid) -> OptionalValue<ExternResult<FFI_ArrowArray>> {
-            let mock_iter =
-                unsafe { &*(state.unwrap().as_ptr() as *const MockIter<FFI_ArrowArray>) };
-            mock_iter
-                .items
-                .lock()
-                .unwrap()
-                .pop_front()
-                .unwrap_or(OptionalValue::None)
-        }
-
         let mut iter = FfiFileMetaIter::new(
-            CFileMetaIterator { state, next },
+            CFileMetaIterator {
+                state,
+                next: file_meta_next,
+            },
             PlanResultCleanup::new(state, free_mock_iter::<FFI_ArrowArray>),
         );
 
+        // First batch contributes two rows.
         let first = iter.next().expect("first item").expect("first ok");
         assert_eq!(first.location.as_str(), "file:///a.parquet");
         assert_eq!(first.last_modified, 1);
         assert_eq!(first.size, 100);
 
-        let second = iter.next().expect("second item");
-        assert!(second.is_err(), "second item should be Err");
+        let second = iter.next().expect("second item").expect("second ok");
+        assert_eq!(second.location.as_str(), "file:///b.parquet");
+        assert_eq!(second.last_modified, 2);
+        assert_eq!(second.size, 200);
 
-        let third = iter.next().expect("third item").expect("third ok");
-        assert_eq!(third.location.as_str(), "file:///b.parquet");
-        assert_eq!(third.last_modified, 2);
-        assert_eq!(third.size, 200);
+        // After draining the first batch the adapter pulls the transient engine error.
+        let third = iter.next().expect("third item");
+        assert!(third.is_err(), "third item should be Err");
+
+        // Transient engine errors do not terminate iteration; the fourth batch is still returned.
+        let fourth = iter.next().expect("fourth item").expect("fourth ok");
+        assert_eq!(fourth.location.as_str(), "file:///c.parquet");
+        assert_eq!(fourth.last_modified, 3);
+        assert_eq!(fourth.size, 300);
 
         assert!(iter.next().is_none(), "iterator should be exhausted");
         assert!(!cleanup_called.load(Ordering::SeqCst));
 
+        drop(iter);
+        assert!(cleanup_called.load(Ordering::SeqCst));
+    }
+
+    /// Verifies that an empty batch surfaces as an error and permanently terminates iteration
+    #[test]
+    fn ffi_file_meta_iter_rejects_empty_batch_and_terminates() {
+        let (mock_iter, cleanup_called) = make_mock_iter::<FFI_ArrowArray>(vec![
+            OptionalValue::Some(ExternResult::Ok(make_file_meta_ffi_array(&[]))),
+            OptionalValue::Some(ExternResult::Ok(make_file_meta_ffi_array(&[(
+                "file:///trap.parquet",
+                99,
+                999,
+            )]))),
+        ]);
+        // Hold a borrow of the queue so we can inspect it after iteration without recovering
+        // the box.
+        let items_ptr: *const Mutex<VecDeque<OptionalValue<ExternResult<FFI_ArrowArray>>>> =
+            &mock_iter.items;
+        let state = NonNull::new(Box::into_raw(mock_iter) as *mut c_void);
+
+        let mut iter = FfiFileMetaIter::new(
+            CFileMetaIterator {
+                state,
+                next: file_meta_next,
+            },
+            PlanResultCleanup::new(state, free_mock_iter::<FFI_ArrowArray>),
+        );
+
+        let first = iter.next().expect("first item");
+        assert!(first.is_err(), "empty batch must surface as Err");
+
+        // The final entry is still queued.
+        let remaining = unsafe { &*items_ptr }.lock().unwrap().len();
+        assert_eq!(remaining, 1, "final entry must remain unconsumed");
+
+        // Further polls return `None` without re-invoking the engine.
+        assert!(iter.next().is_none(), "iterator should be terminated");
+        assert!(iter.next().is_none(), "iterator should stay terminated");
+        let remaining_after = unsafe { &*items_ptr }.lock().unwrap().len();
+        assert_eq!(
+            remaining_after, 1,
+            "final entry must still be unconsumed after extra polls"
+        );
+
+        assert!(!cleanup_called.load(Ordering::SeqCst));
         drop(iter);
         assert!(cleanup_called.load(Ordering::SeqCst));
     }

--- a/ffi/src/plans/iter.rs
+++ b/ffi/src/plans/iter.rs
@@ -129,6 +129,7 @@ impl Iterator for FfiEngineDataIter {
     fn next(&mut self) -> Option<Self::Item> {
         match (self.iter.next)(self.iter.state) {
             OptionalValue::None => None,
+            // TODO: re-evaluate memory management; errors are currently freed by PlanResultCleanup
             OptionalValue::Some(ExternResult::Err(err)) => Some(Err(engine_error_to_kernel(err))),
             OptionalValue::Some(ExternResult::Ok(handle)) => {
                 // into_inner transfers ownership of the EngineData to kernel, and kernel
@@ -190,6 +191,7 @@ impl Iterator for FfiBytesIter {
     fn next(&mut self) -> Option<Self::Item> {
         match (self.iter.next)(self.iter.state) {
             OptionalValue::None => None,
+            // TODO: re-evaluate memory management; errors are currently freed by PlanResultCleanup
             OptionalValue::Some(ExternResult::Err(err)) => Some(Err(engine_error_to_kernel(err))),
             OptionalValue::Some(ExternResult::Ok(array)) => Some(Self::arrow_array_to_bytes(array)),
         }
@@ -286,6 +288,7 @@ impl Iterator for FfiFileMetaIter {
     fn next(&mut self) -> Option<Self::Item> {
         match (self.iter.next)(self.iter.state) {
             OptionalValue::None => None,
+            // TODO: re-evaluate memory management; errors are currently freed by PlanResultCleanup
             OptionalValue::Some(ExternResult::Err(err)) => Some(Err(engine_error_to_kernel(err))),
             OptionalValue::Some(ExternResult::Ok(array)) => {
                 Some(Self::arrow_array_to_file_meta(array))

--- a/ffi/src/plans/iter.rs
+++ b/ffi/src/plans/iter.rs
@@ -637,11 +637,14 @@ mod tests {
                 999,
             )]))),
         ]);
-        // Hold a borrow of the queue so we can inspect it after iteration without recovering
-        // the box.
-        let items_ptr: *const Mutex<VecDeque<OptionalValue<ExternResult<FFI_ArrowArray>>>> =
-            &mock_iter.items;
         let state = NonNull::new(Box::into_raw(mock_iter) as *mut c_void);
+
+        // Helper fn for checking the queue length from `state` pointer
+        let queue_len = || {
+            let mock_iter =
+                unsafe { &*(state.unwrap().as_ptr() as *const MockIter<FFI_ArrowArray>) };
+            mock_iter.items.lock().unwrap().len()
+        };
 
         let mut iter = FfiFileMetaIter::new(
             CFileMetaIterator {
@@ -655,15 +658,14 @@ mod tests {
         assert!(first.is_err(), "empty batch must surface as Err");
 
         // The final entry is still queued.
-        let remaining = unsafe { &*items_ptr }.lock().unwrap().len();
-        assert_eq!(remaining, 1, "final entry must remain unconsumed");
+        assert_eq!(queue_len(), 1, "final entry must remain unconsumed");
 
         // Further polls return `None` without re-invoking the engine.
         assert!(iter.next().is_none(), "iterator should be terminated");
         assert!(iter.next().is_none(), "iterator should stay terminated");
-        let remaining_after = unsafe { &*items_ptr }.lock().unwrap().len();
         assert_eq!(
-            remaining_after, 1,
+            queue_len(),
+            1,
             "final entry must still be unconsumed after extra polls"
         );
 

--- a/ffi/src/plans/iter.rs
+++ b/ffi/src/plans/iter.rs
@@ -2,8 +2,7 @@
 //! execution.
 //!
 //! Each `C*Iterator` type contains an opaque engine `state` pointer with a `next` function
-//! pointer that yields one iterator item per call. The state pointer and next function pointer must
-//! be threadsafe.
+//! pointer that yields one iterator item per call.
 //!
 //! //! # `next()` protocol
 //!
@@ -12,28 +11,43 @@
 //!     - The outer Option represents whether iteration is complete
 //!     - The inner Result represents the DeltaResult yielded by the iterator
 //!
-//! # Iterator State Cleanup
+//! # Iterator Memory Management
+//! There are 3 aspects to iterator memory management:
 //!
-//! The iterator state is owned by the engine and must be freed by the kernel when it is done with
-//! it. However the `C*Iterator` types do NOT contain their own release/free functions; instead,
-//! the Engine provides a single `free` function for the entire PlanResult (see
-//! [`super::result::CPlanResultWrapper`]). This is handled on the Rust side by
-//! embedding `PlanResultCleanup` inside of each `Ffi*Iter` adapter so that the free function is
-//! called when the adapter is dropped.
+//! 1. Iterator State - owned by the engine and must be freed by the kernel when it is done with it.
+//!    The kernel performs this cleanup by using the `free` function pointer associated with the
+//!    containing PlanResult (see [`super::result::CPlanResultWrapper`]). Each `Ffi*Iter` adapter
+//!    takes care of this by embedding `PlanResultCleanup`, which will invoke the `free` function
+//!    pointer when the adapter is dropped.
+//!
+//! 2. Iterator Items - each data item (e.g EngineData, Bytes, FileMeta) yielded by the iterator has
+//!    its own separate lifetime and may have its own memory management rules. However we generally
+//!    use FFI_ArrowArray as a carrier for the item (which internally manages its own release
+//!    callback).
+//!
+//! 3. Item Wrappers (i.e OptionalValue, ExternResult, EngineError) - each yielded item is wrapped
+//!    in an OptionalValue + ExternResult which must also be freed. We expect these to be released
+//!    when the entire iterator is dropped (through the same `PlanResultCleanup` guard that frees
+//!    the iterator state).
+//!
+//! # Safety
+//! The engine is responsible for ensuring that all `state`, `next`, and `free` pointers
+//! are safe to send between threads.
 
 use bytes::Bytes;
 use delta_kernel::arrow::array::ffi::{self as arrow_ffi, FFI_ArrowArray, FFI_ArrowSchema};
-use delta_kernel::arrow::array::{self as arrow_array, Array, BinaryArray};
-use delta_kernel::arrow::datatypes::DataType as ArrowDataType;
+use delta_kernel::arrow::array::{
+    self as arrow_array, Array, BinaryArray, Int64Array, StringArray, StructArray, UInt64Array,
+};
+use delta_kernel::arrow::datatypes::{DataType as ArrowDataType, Field as ArrowField, Fields};
 use delta_kernel::{DeltaResult, EngineData, Error};
 use url::Url;
 
 use super::result::PlanResultCleanup;
-use crate::engine_funcs::FileMeta as CFileMeta;
 use crate::error::ExternResult;
 use crate::handle::Handle;
 use crate::plans::result::engine_error_to_kernel;
-use crate::{ExclusiveEngineData, NullableCvoid, OptionalValue, TryFromStringSlice};
+use crate::{ExclusiveEngineData, NullableCvoid, OptionalValue};
 
 // ============================================================================
 // repr(C) iterator types
@@ -41,9 +55,7 @@ use crate::{ExclusiveEngineData, NullableCvoid, OptionalValue, TryFromStringSlic
 
 /// An engine-owned iterator of [`EngineData`] batches.
 ///
-/// Each EngineData batch has its own separate lifetime and must be freed. Once the iterator yields
-/// a batch, the ownership of it is transferred to the Kernel and Kernel is now responsible
-/// for freeing it (this is handled transparently by the `FfiEngineDataIter` adapter).
+/// See module level docs for memory management and safety requirements.
 #[repr(C)]
 pub struct CEngineDataIterator {
     pub state: NullableCvoid,
@@ -53,6 +65,8 @@ pub struct CEngineDataIterator {
 }
 
 /// An engine-owned iterator of byte buffers.
+///
+/// See module level docs for memory management and safety requirements.
 ///
 /// Each byte array is transferred across the FFI boundary as an [`FFI_ArrowArray`].
 /// Invocation of `next` MUST yield an Arrow array that is a `BinaryArray` containing a single
@@ -72,13 +86,17 @@ pub struct CBytesIterator {
 
 /// An engine-owned iterator of [`FileMeta`](delta_kernel::FileMeta) entries.
 ///
-/// Unlike `CEngineDataIterator` and `CBytesIterator`, CFileMeta does not maintain it's own `free`
-/// callback. Instead, we expect the engine to free the entire iterator of FileMeta entries when the
-/// iterator itself is dropped (through the `PlanResultCleanup` guard).
+/// See module level docs for memory management and safety requirements.
+///
+/// Similar to `CBytesIterator`, CFileMetaIterator uses `FFI_ArrowArray`` as a convenient continer
+/// for passing FileMeta entries across the FFI boundary. Each FileMeta is passed as an
+/// a `StructArray` of length 1 whose fields are `{location: Utf8, last_modified: Int64, size:
+/// UInt64}`, all non-null. Kernel assumes this fixed schema when converting into FileMeta (the
+/// schema is NOT passed along through FFI).
 #[repr(C)]
 pub struct CFileMetaIterator {
     pub state: NullableCvoid,
-    pub next: extern "C" fn(state: NullableCvoid) -> OptionalValue<ExternResult<CFileMeta>>,
+    pub next: extern "C" fn(state: NullableCvoid) -> OptionalValue<ExternResult<FFI_ArrowArray>>,
 }
 
 // ============================================================================
@@ -121,7 +139,8 @@ impl Iterator for FfiEngineDataIter {
     }
 }
 
-// SAFETY: the engine is expected to provide thread-safe state + free function pointers.
+// # Safety
+// The engine must ensure that all raw pointers sent are Send-safe (see module level docs)
 unsafe impl Send for FfiEngineDataIter {}
 
 /// Provides the Rust `Iterator` trait for [`Bytes`] buffers on top of a [`CBytesIterator`].
@@ -177,7 +196,8 @@ impl Iterator for FfiBytesIter {
     }
 }
 
-// SAFETY: the engine is expected to provide thread-safe state + free function pointers.
+// # Safety
+// The engine must ensure that all raw pointers sent are Send-safe (see module level docs)
 unsafe impl Send for FfiBytesIter {}
 
 /// Provides the Rust `Iterator` trait for [`FileMeta`] entries on top of a
@@ -195,16 +215,67 @@ impl FfiFileMetaIter {
         }
     }
 
-    fn convert_file_meta(raw: CFileMeta) -> DeltaResult<delta_kernel::FileMeta> {
-        let path: &str = unsafe { TryFromStringSlice::try_from_slice(&raw.path) }?;
-        let location = Url::parse(path)?;
-        let size: delta_kernel::FileSize = raw.size.try_into().map_err(|_| {
-            Error::generic("unable to convert CFileMeta.size (usize) to FileMeta.size (u64)")
-        })?;
+    /// The fixed Arrow type expected by [`CFileMetaIterator`]: a non-null struct of
+    /// `{location: Utf8, last_modified: Int64, size: UInt64}`, all non-null.
+    fn arrow_schema() -> DeltaResult<FFI_ArrowSchema> {
+        let schema = ArrowDataType::Struct(Fields::from(vec![
+            ArrowField::new("location", ArrowDataType::Utf8, false),
+            ArrowField::new("last_modified", ArrowDataType::Int64, false),
+            ArrowField::new("size", ArrowDataType::UInt64, false),
+        ]));
+        Ok(FFI_ArrowSchema::try_from(&schema)?)
+    }
+
+    fn arrow_array_to_file_meta(array: FFI_ArrowArray) -> DeltaResult<delta_kernel::FileMeta> {
+        let schema = Self::arrow_schema()?;
+        let array_data = unsafe { arrow_ffi::from_ffi(array, &schema) }?;
+        let array = arrow_array::make_array(array_data);
+
+        let Some(struct_array) = array.as_any().downcast_ref::<StructArray>() else {
+            return Err(Error::generic(format!(
+                "CFileMetaIterator must yield StructArray, got {:?}",
+                array.data_type()
+            )));
+        };
+        if struct_array.len() != 1 {
+            return Err(Error::generic(format!(
+                "CFileMetaIterator array must contain exactly one row, got {}",
+                struct_array.len()
+            )));
+        }
+
+        // The fixed schema guarantees three columns in this order, all non-null. `from_ffi`
+        // above already validated the per-column data types match what we synthesized, so the
+        // downcasts cannot fail; the `ok_or_else` arms exist only to keep the converter
+        // panic-free.
+        let location_col = struct_array
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| Error::generic("CFileMetaIterator: location column is not Utf8"))?;
+        let last_modified_col = struct_array
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .ok_or_else(|| {
+                Error::generic("CFileMetaIterator: last_modified column is not Int64")
+            })?;
+        let size_col = struct_array
+            .column(2)
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .ok_or_else(|| Error::generic("CFileMetaIterator: size column is not UInt64"))?;
+
+        if location_col.is_null(0) || last_modified_col.is_null(0) || size_col.is_null(0) {
+            return Err(Error::generic(
+                "CFileMetaIterator row must not contain null fields",
+            ));
+        }
+
         Ok(delta_kernel::FileMeta {
-            location,
-            last_modified: raw.last_modified,
-            size,
+            location: Url::parse(location_col.value(0))?,
+            last_modified: last_modified_col.value(0),
+            size: size_col.value(0),
         })
     }
 }
@@ -216,12 +287,15 @@ impl Iterator for FfiFileMetaIter {
         match (self.iter.next)(self.iter.state) {
             OptionalValue::None => None,
             OptionalValue::Some(ExternResult::Err(err)) => Some(Err(engine_error_to_kernel(err))),
-            OptionalValue::Some(ExternResult::Ok(raw)) => Some(Self::convert_file_meta(raw)),
+            OptionalValue::Some(ExternResult::Ok(array)) => {
+                Some(Self::arrow_array_to_file_meta(array))
+            }
         }
     }
 }
 
-// SAFETY: the engine is expected to provide thread-safe state + free function pointers.
+// # Safety
+// The engine must ensure that all raw pointers sent are Send-safe (see module level docs)
 unsafe impl Send for FfiFileMetaIter {}
 
 #[cfg(test)]
@@ -232,7 +306,10 @@ mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Arc, Mutex};
 
-    use delta_kernel::arrow::array::{ffi as arrow_ffi, BinaryArray, Int32Array, RecordBatch};
+    use delta_kernel::arrow::array::{
+        ffi as arrow_ffi, ArrayRef, BinaryArray, Int32Array, Int64Array, RecordBatch, StringArray,
+        StructArray, UInt64Array,
+    };
     use delta_kernel::arrow::datatypes::{
         DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
     };
@@ -244,28 +321,35 @@ mod tests {
 
     // === Shared Test Helpers ===
 
-    type MockIter<T> = Mutex<VecDeque<OptionalValue<ExternResult<T>>>>;
-
-    fn make_iter<T>(items: Vec<OptionalValue<ExternResult<T>>>) -> MockIter<T> {
-        Mutex::new(VecDeque::from(items))
+    struct MockIter<T> {
+        items: Mutex<VecDeque<OptionalValue<ExternResult<T>>>>,
+        cleanup_called: Arc<AtomicBool>,
     }
 
-    fn iter_state<T>(iter: &MockIter<T>) -> NullableCvoid {
-        NonNull::new(iter as *const MockIter<T> as *mut c_void)
+    impl<T> Drop for MockIter<T> {
+        fn drop(&mut self) {
+            let previously_set = self.cleanup_called.swap(true, Ordering::SeqCst);
+            assert!(!previously_set, "MockIter dropped more than once");
+        }
     }
 
-    // A mock cleanup function which sets a flag on an AtomicBool so tests can verify whether drop
-    // was called. Panics if invoked more than once, enforcing the contract that
-    // `PlanResultCleanup` fires `free` exactly once.
-    extern "C" fn set_cleanup_flag(state: NullableCvoid) {
-        let flag = unsafe { &*(state.unwrap().as_ptr() as *const AtomicBool) };
-        let previously_set = flag.swap(true, Ordering::SeqCst);
-        assert!(!previously_set, "set_cleanup_flag invoked more than once");
+    // Makes a mock iterator with the given items and returns the iterator + a cleanup flag for
+    // verifying that the iterator was dropped properly.
+    //
+    // Can be dropped using `free_mock_iter`.
+    fn make_mock_iter<T>(
+        items: Vec<OptionalValue<ExternResult<T>>>,
+    ) -> (Box<MockIter<T>>, Arc<AtomicBool>) {
+        let cleanup_called = Arc::new(AtomicBool::new(false));
+        let iter = Box::new(MockIter {
+            items: Mutex::new(VecDeque::from(items)),
+            cleanup_called: Arc::clone(&cleanup_called),
+        });
+        (iter, cleanup_called)
     }
 
-    fn make_cleanup(flag: &AtomicBool) -> PlanResultCleanup {
-        let cleanup_flag_state = NonNull::new(flag as *const AtomicBool as *mut c_void);
-        PlanResultCleanup::new(cleanup_flag_state, set_cleanup_flag)
+    extern "C" fn free_mock_iter<T>(state: NullableCvoid) {
+        let _ = unsafe { Box::from_raw(state.unwrap().as_ptr() as *mut MockIter<T>) };
     }
 
     fn err_ptr(err: &EngineError) -> *mut EngineError {
@@ -289,25 +373,24 @@ mod tests {
 
     #[test]
     fn ffi_engine_data_iter_drains_and_runs_cleanup() {
-        let cleanup_called = AtomicBool::new(false);
         let err = EngineError {
             etype: KernelError::GenericError,
         };
-        let mock_iter = make_iter::<Handle<ExclusiveEngineData>>(vec![
+        let (mock_iter, cleanup_called) = make_mock_iter::<Handle<ExclusiveEngineData>>(vec![
             OptionalValue::Some(ExternResult::Ok(make_data_handle(3))),
             OptionalValue::Some(ExternResult::Err(err_ptr(&err))),
             OptionalValue::Some(ExternResult::Ok(make_data_handle(5))),
         ]);
+        let state = NonNull::new(Box::into_raw(mock_iter) as *mut c_void);
 
         extern "C" fn next(
             state: NullableCvoid,
         ) -> OptionalValue<ExternResult<Handle<ExclusiveEngineData>>> {
-            // SAFETY: state aliases a `MockIter<Handle<ExclusiveEngineData>>` borrowed for the
-            // lifetime of the enclosing test.
             let mock_iter = unsafe {
                 &*(state.unwrap().as_ptr() as *const MockIter<Handle<ExclusiveEngineData>>)
             };
             mock_iter
+                .items
                 .lock()
                 .unwrap()
                 .pop_front()
@@ -315,11 +398,8 @@ mod tests {
         }
 
         let mut iter = FfiEngineDataIter::new(
-            CEngineDataIterator {
-                state: iter_state(&mock_iter),
-                next,
-            },
-            make_cleanup(&cleanup_called),
+            CEngineDataIterator { state, next },
+            PlanResultCleanup::new(state, free_mock_iter::<Handle<ExclusiveEngineData>>),
         );
 
         let first = iter.next().expect("first item").expect("first ok");
@@ -355,22 +435,21 @@ mod tests {
 
     #[test]
     fn ffi_bytes_iter_drains_and_runs_cleanup() {
-        let cleanup_called = AtomicBool::new(false);
         let err = EngineError {
             etype: KernelError::GenericError,
         };
-        let mock_iter = make_iter::<FFI_ArrowArray>(vec![
+        let (mock_iter, cleanup_called) = make_mock_iter::<FFI_ArrowArray>(vec![
             OptionalValue::Some(ExternResult::Ok(make_binary_ffi_array(b"hello"))),
             OptionalValue::Some(ExternResult::Err(err_ptr(&err))),
             OptionalValue::Some(ExternResult::Ok(make_binary_ffi_array(b"world!"))),
         ]);
+        let state = NonNull::new(Box::into_raw(mock_iter) as *mut c_void);
 
         extern "C" fn next(state: NullableCvoid) -> OptionalValue<ExternResult<FFI_ArrowArray>> {
-            // SAFETY: state aliases a `MockIter<FFI_ArrowArray>` borrowed for the lifetime of the
-            // enclosing test.
             let mock_iter =
                 unsafe { &*(state.unwrap().as_ptr() as *const MockIter<FFI_ArrowArray>) };
             mock_iter
+                .items
                 .lock()
                 .unwrap()
                 .pop_front()
@@ -378,11 +457,8 @@ mod tests {
         }
 
         let mut iter = FfiBytesIter::new(
-            CBytesIterator {
-                state: iter_state(&mock_iter),
-                next,
-            },
-            make_cleanup(&cleanup_called),
+            CBytesIterator { state, next },
+            PlanResultCleanup::new(state, free_mock_iter::<FFI_ArrowArray>),
         );
 
         let first = iter.next().expect("first item").expect("first ok");
@@ -403,41 +479,56 @@ mod tests {
 
     // === FfiFileMetaIter Test ===
 
-    /// Helper for building each yielded FileMeta entry
-    fn make_file_meta(path: &'static str, size: usize, last_modified: i64) -> CFileMeta {
-        let path_slice = unsafe { crate::KernelStringSlice::new_unsafe(path) };
-        CFileMeta {
-            path: path_slice,
-            last_modified,
-            size,
-        }
+    /// Helper for building each yielded FileMeta entry. Constructs a single-row `StructArray`
+    /// matching the fixed schema kernel synthesizes in `FfiFileMetaIter::arrow_data_type`.
+    fn make_file_meta_ffi_array(location: &str, last_modified: i64, size: u64) -> FFI_ArrowArray {
+        let struct_array = StructArray::from(vec![
+            (
+                Arc::new(ArrowField::new("location", ArrowDataType::Utf8, false)),
+                Arc::new(StringArray::from(vec![location])) as ArrayRef,
+            ),
+            (
+                Arc::new(ArrowField::new(
+                    "last_modified",
+                    ArrowDataType::Int64,
+                    false,
+                )),
+                Arc::new(Int64Array::from(vec![last_modified])) as ArrayRef,
+            ),
+            (
+                Arc::new(ArrowField::new("size", ArrowDataType::UInt64, false)),
+                Arc::new(UInt64Array::from(vec![size])) as ArrayRef,
+            ),
+        ]);
+        let (ffi_array, _ffi_schema) = arrow_ffi::to_ffi(&struct_array.into_data()).unwrap();
+        ffi_array
     }
 
     #[test]
     fn ffi_file_meta_iter_drains_and_runs_cleanup() {
-        let cleanup_called = AtomicBool::new(false);
         let err = EngineError {
             etype: KernelError::GenericError,
         };
-        let mock_iter = make_iter::<CFileMeta>(vec![
-            OptionalValue::Some(ExternResult::Ok(make_file_meta(
+        let (mock_iter, cleanup_called) = make_mock_iter::<FFI_ArrowArray>(vec![
+            OptionalValue::Some(ExternResult::Ok(make_file_meta_ffi_array(
                 "file:///a.parquet",
-                100,
                 1,
+                100,
             ))),
             OptionalValue::Some(ExternResult::Err(err_ptr(&err))),
-            OptionalValue::Some(ExternResult::Ok(make_file_meta(
+            OptionalValue::Some(ExternResult::Ok(make_file_meta_ffi_array(
                 "file:///b.parquet",
-                200,
                 2,
+                200,
             ))),
         ]);
+        let state = NonNull::new(Box::into_raw(mock_iter) as *mut c_void);
 
-        extern "C" fn next(state: NullableCvoid) -> OptionalValue<ExternResult<CFileMeta>> {
-            // SAFETY: state aliases a `MockIter<CFileMeta>` borrowed for the lifetime of the
-            // enclosing test.
-            let mock_iter = unsafe { &*(state.unwrap().as_ptr() as *const MockIter<CFileMeta>) };
+        extern "C" fn next(state: NullableCvoid) -> OptionalValue<ExternResult<FFI_ArrowArray>> {
+            let mock_iter =
+                unsafe { &*(state.unwrap().as_ptr() as *const MockIter<FFI_ArrowArray>) };
             mock_iter
+                .items
                 .lock()
                 .unwrap()
                 .pop_front()
@@ -445,25 +536,22 @@ mod tests {
         }
 
         let mut iter = FfiFileMetaIter::new(
-            CFileMetaIterator {
-                state: iter_state(&mock_iter),
-                next,
-            },
-            make_cleanup(&cleanup_called),
+            CFileMetaIterator { state, next },
+            PlanResultCleanup::new(state, free_mock_iter::<FFI_ArrowArray>),
         );
 
         let first = iter.next().expect("first item").expect("first ok");
         assert_eq!(first.location.as_str(), "file:///a.parquet");
-        assert_eq!(first.size, 100);
         assert_eq!(first.last_modified, 1);
+        assert_eq!(first.size, 100);
 
         let second = iter.next().expect("second item");
         assert!(second.is_err(), "second item should be Err");
 
         let third = iter.next().expect("third item").expect("third ok");
         assert_eq!(third.location.as_str(), "file:///b.parquet");
-        assert_eq!(third.size, 200);
         assert_eq!(third.last_modified, 2);
+        assert_eq!(third.size, 200);
 
         assert!(iter.next().is_none(), "iterator should be exhausted");
         assert!(!cleanup_called.load(Ordering::SeqCst));

--- a/ffi/src/plans/iter.rs
+++ b/ffi/src/plans/iter.rs
@@ -1,0 +1,474 @@
+//! This module contains types needed to implement Engine-owned iterators returned from plan
+//! execution.
+//!
+//! Each `C*Iterator` type contains an opaque engine `state` pointer with a `next` function
+//! pointer that yields one iterator item per call. The state pointer and next function pointer must
+//! be threadsafe.
+//!
+//! //! # `next()` protocol
+//!
+//! Each `next` callback returns `OptionalValue<ExternResult<T>>`, mirroring Rust's
+//! `Option<Result<T>>`. This allows us to implement `DeltaResultIterator<T>`:
+//!     - The outer Option represents whether iteration is complete
+//!     - The inner Result represents the DeltaResult yielded by the iterator
+//!
+//! # Iterator State Cleanup
+//!
+//! The iterator state is owned by the engine and must be freed by the kernel when it is done with
+//! it. However the `C*Iterator` types do NOT contain their own release/free functions; instead,
+//! the Engine provides a single `free` function for the entire PlanResult (see
+//! [`super::result::CPlanResultWrapper`]). This is handled on the Rust side by
+//! embedding `PlanResultCleanup` inside of each `Ffi*Iter` adapter so that the free function is
+//! called when the adapter is dropped.
+
+use bytes::Bytes;
+use delta_kernel::arrow::array::ffi::{self as arrow_ffi, FFI_ArrowArray, FFI_ArrowSchema};
+use delta_kernel::arrow::array::{self as arrow_array, Array, BinaryArray};
+use delta_kernel::arrow::datatypes::DataType as ArrowDataType;
+use delta_kernel::{DeltaResult, EngineData, Error};
+use url::Url;
+
+use super::result::PlanResultCleanup;
+use crate::engine_funcs::FileMeta as CFileMeta;
+use crate::error::ExternResult;
+use crate::handle::Handle;
+use crate::plans::result::engine_error_to_kernel;
+use crate::{ExclusiveEngineData, NullableCvoid, OptionalValue, TryFromStringSlice};
+
+// ============================================================================
+// repr(C) iterator types
+// ============================================================================
+
+/// An engine-owned iterator of [`EngineData`] batches.
+///
+/// Each EngineData batch has its own separate lifetime and must be freed. Once the iterator yields
+/// a batch, the ownership of it is transferred to the Kernel and Kernel is now responsible
+/// for freeing it (this is handled transparently by the `FfiEngineDataIter` adapter).
+#[repr(C)]
+pub struct CEngineDataIterator {
+    pub state: NullableCvoid,
+    pub next: extern "C" fn(
+        state: NullableCvoid,
+    ) -> OptionalValue<ExternResult<Handle<ExclusiveEngineData>>>,
+}
+
+/// An engine-owned iterator of byte buffers.
+///
+/// Each byte array is transferred across the FFI boundary as an [`FFI_ArrowArray`].
+/// Invocation of `next` MUST yield an Arrow array that is a `BinaryArray` containing a single
+/// row of non-null bytes. Kernel assumes the schema is [`ArrowDataType::Binary`] (the schema is NOT
+/// passed along through FFI).
+///
+/// FFI_ArrowArray serves as a convenient container for receiving bytes because it internally
+/// manages its own memory release callback.
+///
+/// TODO: ArrowDataType::Binary uses i32 offsets, so each byte array is limited to 2 GiB. If this is
+/// a problem, we need to support ArrowDataType::LargeBinary instead.
+#[repr(C)]
+pub struct CBytesIterator {
+    pub state: NullableCvoid,
+    pub next: extern "C" fn(state: NullableCvoid) -> OptionalValue<ExternResult<FFI_ArrowArray>>,
+}
+
+/// An engine-owned iterator of [`FileMeta`](delta_kernel::FileMeta) entries.
+///
+/// Unlike `CEngineDataIterator` and `CBytesIterator`, CFileMeta does not maintain it's own `free`
+/// callback. Instead, we expect the engine to free the entire iterator of FileMeta entries when the
+/// iterator itself is dropped (through the `PlanResultCleanup` guard).
+#[repr(C)]
+pub struct CFileMetaIterator {
+    pub state: NullableCvoid,
+    pub next: extern "C" fn(state: NullableCvoid) -> OptionalValue<ExternResult<CFileMeta>>,
+}
+
+// ============================================================================
+// Rust Iterator adapters
+// ============================================================================
+//
+// Each adapter wraps a `C*Iterator`, implementing the Rust `Iterator` trait, and embeds a
+// `PlanResultCleanup` guard for freeing all associated engine resources when the adapter is
+// dropped.
+
+/// Provides the Rust `Iterator` trait for [`EngineData`] batches on top of a
+/// [`CEngineDataIterator`].
+pub(crate) struct FfiEngineDataIter {
+    iter: CEngineDataIterator,
+    _cleanup: PlanResultCleanup,
+}
+
+impl FfiEngineDataIter {
+    pub(crate) fn new(iter: CEngineDataIterator, cleanup: PlanResultCleanup) -> Self {
+        Self {
+            iter,
+            _cleanup: cleanup,
+        }
+    }
+}
+
+impl Iterator for FfiEngineDataIter {
+    type Item = DeltaResult<Box<dyn EngineData>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match (self.iter.next)(self.iter.state) {
+            OptionalValue::None => None,
+            OptionalValue::Some(ExternResult::Err(err)) => Some(Err(engine_error_to_kernel(err))),
+            OptionalValue::Some(ExternResult::Ok(handle)) => {
+                // into_inner transfers ownership of the EngineData to kernel, and kernel
+                // will free it when the yielded EngineData is dropped.
+                Some(Ok(unsafe { handle.into_inner() }))
+            }
+        }
+    }
+}
+
+// SAFETY: the engine is expected to provide thread-safe state + free function pointers.
+unsafe impl Send for FfiEngineDataIter {}
+
+/// Provides the Rust `Iterator` trait for [`Bytes`] buffers on top of a [`CBytesIterator`].
+pub(crate) struct FfiBytesIter {
+    iter: CBytesIterator,
+    _cleanup: PlanResultCleanup,
+}
+
+impl FfiBytesIter {
+    pub(crate) fn new(iter: CBytesIterator, cleanup: PlanResultCleanup) -> Self {
+        Self {
+            iter,
+            _cleanup: cleanup,
+        }
+    }
+
+    fn arrow_array_to_bytes(array: FFI_ArrowArray) -> DeltaResult<Bytes> {
+        let schema = FFI_ArrowSchema::try_from(&ArrowDataType::Binary)?;
+        let array_data = unsafe { arrow_ffi::from_ffi(array, &schema) }?;
+        let array = arrow_array::make_array(array_data);
+
+        let Some(binary) = array.as_any().downcast_ref::<BinaryArray>() else {
+            return Err(Error::generic(format!(
+                "CBytesIterator must yield BinaryArray, got {:?}",
+                array.data_type()
+            )));
+        };
+        if binary.len() != 1 {
+            return Err(Error::generic(format!(
+                "CBytesIterator array must contain exactly one row, got {}",
+                binary.len()
+            )));
+        }
+        if binary.is_null(0) {
+            return Err(Error::generic("CBytesIterator array row must not be null"));
+        }
+
+        // TODO: this copies the payload bytes, but could be made zero-copy by
+        // using `Bytes::from_owner` on a custom struct that implements `AsRef<[u8]>`
+        Ok(Bytes::copy_from_slice(binary.value(0)))
+    }
+}
+
+impl Iterator for FfiBytesIter {
+    type Item = DeltaResult<Bytes>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match (self.iter.next)(self.iter.state) {
+            OptionalValue::None => None,
+            OptionalValue::Some(ExternResult::Err(err)) => Some(Err(engine_error_to_kernel(err))),
+            OptionalValue::Some(ExternResult::Ok(array)) => Some(Self::arrow_array_to_bytes(array)),
+        }
+    }
+}
+
+// SAFETY: the engine is expected to provide thread-safe state + free function pointers.
+unsafe impl Send for FfiBytesIter {}
+
+/// Provides the Rust `Iterator` trait for [`FileMeta`] entries on top of a
+/// [`CFileMetaIterator`].
+pub(crate) struct FfiFileMetaIter {
+    iter: CFileMetaIterator,
+    _cleanup: PlanResultCleanup,
+}
+
+impl FfiFileMetaIter {
+    pub(crate) fn new(iter: CFileMetaIterator, cleanup: PlanResultCleanup) -> Self {
+        Self {
+            iter,
+            _cleanup: cleanup,
+        }
+    }
+
+    fn convert_file_meta(raw: CFileMeta) -> DeltaResult<delta_kernel::FileMeta> {
+        let path: &str = unsafe { TryFromStringSlice::try_from_slice(&raw.path) }?;
+        let location = Url::parse(path)?;
+        let size: delta_kernel::FileSize = raw.size.try_into().map_err(|_| {
+            Error::generic("unable to convert CFileMeta.size (usize) to FileMeta.size (u64)")
+        })?;
+        Ok(delta_kernel::FileMeta {
+            location,
+            last_modified: raw.last_modified,
+            size,
+        })
+    }
+}
+
+impl Iterator for FfiFileMetaIter {
+    type Item = DeltaResult<delta_kernel::FileMeta>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match (self.iter.next)(self.iter.state) {
+            OptionalValue::None => None,
+            OptionalValue::Some(ExternResult::Err(err)) => Some(Err(engine_error_to_kernel(err))),
+            OptionalValue::Some(ExternResult::Ok(raw)) => Some(Self::convert_file_meta(raw)),
+        }
+    }
+}
+
+// SAFETY: the engine is expected to provide thread-safe state + free function pointers.
+unsafe impl Send for FfiFileMetaIter {}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::ffi::c_void;
+    use std::ptr::NonNull;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    use delta_kernel::arrow::array::{ffi as arrow_ffi, BinaryArray, Int32Array, RecordBatch};
+    use delta_kernel::arrow::datatypes::{
+        DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
+    };
+    use delta_kernel::engine::arrow_data::ArrowEngineData;
+
+    use super::*;
+    use crate::error::{EngineError, KernelError};
+    use crate::plans::result::PlanResultCleanup;
+
+    // === Shared Test Helpers ===
+
+    type MockIter<T> = Mutex<VecDeque<OptionalValue<ExternResult<T>>>>;
+
+    fn make_iter<T>(items: Vec<OptionalValue<ExternResult<T>>>) -> MockIter<T> {
+        Mutex::new(VecDeque::from(items))
+    }
+
+    fn iter_state<T>(iter: &MockIter<T>) -> NullableCvoid {
+        NonNull::new(iter as *const MockIter<T> as *mut c_void)
+    }
+
+    // A mock cleanup function which sets a flag on an AtomicBool so tests can verify whether drop
+    // was called. Panics if invoked more than once, enforcing the contract that
+    // `PlanResultCleanup` fires `free` exactly once.
+    extern "C" fn set_cleanup_flag(state: NullableCvoid) {
+        let flag = unsafe { &*(state.unwrap().as_ptr() as *const AtomicBool) };
+        let previously_set = flag.swap(true, Ordering::SeqCst);
+        assert!(!previously_set, "set_cleanup_flag invoked more than once");
+    }
+
+    fn make_cleanup(flag: &AtomicBool) -> PlanResultCleanup {
+        let cleanup_flag_state = NonNull::new(flag as *const AtomicBool as *mut c_void);
+        PlanResultCleanup::new(cleanup_flag_state, set_cleanup_flag)
+    }
+
+    fn err_ptr(err: &EngineError) -> *mut EngineError {
+        err as *const EngineError as *mut EngineError
+    }
+
+    // === FfiEngineDataIter Test ===
+
+    /// Helper for building each yielded EngineData batch
+    fn make_data_handle(rows: usize) -> Handle<ExclusiveEngineData> {
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "x",
+            ArrowDataType::Int32,
+            true,
+        )]));
+        let values: Vec<i32> = (0..rows as i32).collect();
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(values))]).unwrap();
+        let data: Box<dyn EngineData> = Box::new(ArrowEngineData::new(batch));
+        data.into()
+    }
+
+    #[test]
+    fn ffi_engine_data_iter_drains_and_runs_cleanup() {
+        let cleanup_called = AtomicBool::new(false);
+        let err = EngineError {
+            etype: KernelError::GenericError,
+        };
+        let mock_iter = make_iter::<Handle<ExclusiveEngineData>>(vec![
+            OptionalValue::Some(ExternResult::Ok(make_data_handle(3))),
+            OptionalValue::Some(ExternResult::Err(err_ptr(&err))),
+            OptionalValue::Some(ExternResult::Ok(make_data_handle(5))),
+        ]);
+
+        extern "C" fn next(
+            state: NullableCvoid,
+        ) -> OptionalValue<ExternResult<Handle<ExclusiveEngineData>>> {
+            // SAFETY: state aliases a `MockIter<Handle<ExclusiveEngineData>>` borrowed for the
+            // lifetime of the enclosing test.
+            let mock_iter = unsafe {
+                &*(state.unwrap().as_ptr() as *const MockIter<Handle<ExclusiveEngineData>>)
+            };
+            mock_iter
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or(OptionalValue::None)
+        }
+
+        let mut iter = FfiEngineDataIter::new(
+            CEngineDataIterator {
+                state: iter_state(&mock_iter),
+                next,
+            },
+            make_cleanup(&cleanup_called),
+        );
+
+        let first = iter.next().expect("first item").expect("first ok");
+        assert_eq!(first.len(), 3);
+
+        let second = iter.next().expect("second item");
+        assert!(second.is_err(), "second item should be Err");
+
+        let third = iter.next().expect("third item").expect("third ok");
+        assert_eq!(third.len(), 5);
+
+        assert!(iter.next().is_none(), "iterator should be exhausted");
+        assert!(
+            !cleanup_called.load(Ordering::SeqCst),
+            "cleanup must not run before the iterator is dropped"
+        );
+
+        drop(iter);
+        assert!(
+            cleanup_called.load(Ordering::SeqCst),
+            "cleanup must run when the iterator is dropped"
+        );
+    }
+
+    // === FfiBytesIter Test ===
+
+    // Helper for building each yielded Arrow bytes array
+    fn make_binary_ffi_array(payload: &[u8]) -> FFI_ArrowArray {
+        let array = BinaryArray::from(vec![payload]);
+        let (ffi_array, _ffi_schema) = arrow_ffi::to_ffi(&array.into_data()).unwrap();
+        ffi_array
+    }
+
+    #[test]
+    fn ffi_bytes_iter_drains_and_runs_cleanup() {
+        let cleanup_called = AtomicBool::new(false);
+        let err = EngineError {
+            etype: KernelError::GenericError,
+        };
+        let mock_iter = make_iter::<FFI_ArrowArray>(vec![
+            OptionalValue::Some(ExternResult::Ok(make_binary_ffi_array(b"hello"))),
+            OptionalValue::Some(ExternResult::Err(err_ptr(&err))),
+            OptionalValue::Some(ExternResult::Ok(make_binary_ffi_array(b"world!"))),
+        ]);
+
+        extern "C" fn next(state: NullableCvoid) -> OptionalValue<ExternResult<FFI_ArrowArray>> {
+            // SAFETY: state aliases a `MockIter<FFI_ArrowArray>` borrowed for the lifetime of the
+            // enclosing test.
+            let mock_iter =
+                unsafe { &*(state.unwrap().as_ptr() as *const MockIter<FFI_ArrowArray>) };
+            mock_iter
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or(OptionalValue::None)
+        }
+
+        let mut iter = FfiBytesIter::new(
+            CBytesIterator {
+                state: iter_state(&mock_iter),
+                next,
+            },
+            make_cleanup(&cleanup_called),
+        );
+
+        let first = iter.next().expect("first item").expect("first ok");
+        assert_eq!(first.as_ref(), b"hello");
+
+        let second = iter.next().expect("second item");
+        assert!(second.is_err(), "second item should be Err");
+
+        let third = iter.next().expect("third item").expect("third ok");
+        assert_eq!(third.as_ref(), b"world!");
+
+        assert!(iter.next().is_none(), "iterator should be exhausted");
+        assert!(!cleanup_called.load(Ordering::SeqCst));
+
+        drop(iter);
+        assert!(cleanup_called.load(Ordering::SeqCst));
+    }
+
+    // === FfiFileMetaIter Test ===
+
+    /// Helper for building each yielded FileMeta entry
+    fn make_file_meta(path: &'static str, size: usize, last_modified: i64) -> CFileMeta {
+        let path_slice = unsafe { crate::KernelStringSlice::new_unsafe(path) };
+        CFileMeta {
+            path: path_slice,
+            last_modified,
+            size,
+        }
+    }
+
+    #[test]
+    fn ffi_file_meta_iter_drains_and_runs_cleanup() {
+        let cleanup_called = AtomicBool::new(false);
+        let err = EngineError {
+            etype: KernelError::GenericError,
+        };
+        let mock_iter = make_iter::<CFileMeta>(vec![
+            OptionalValue::Some(ExternResult::Ok(make_file_meta(
+                "file:///a.parquet",
+                100,
+                1,
+            ))),
+            OptionalValue::Some(ExternResult::Err(err_ptr(&err))),
+            OptionalValue::Some(ExternResult::Ok(make_file_meta(
+                "file:///b.parquet",
+                200,
+                2,
+            ))),
+        ]);
+
+        extern "C" fn next(state: NullableCvoid) -> OptionalValue<ExternResult<CFileMeta>> {
+            // SAFETY: state aliases a `MockIter<CFileMeta>` borrowed for the lifetime of the
+            // enclosing test.
+            let mock_iter = unsafe { &*(state.unwrap().as_ptr() as *const MockIter<CFileMeta>) };
+            mock_iter
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or(OptionalValue::None)
+        }
+
+        let mut iter = FfiFileMetaIter::new(
+            CFileMetaIterator {
+                state: iter_state(&mock_iter),
+                next,
+            },
+            make_cleanup(&cleanup_called),
+        );
+
+        let first = iter.next().expect("first item").expect("first ok");
+        assert_eq!(first.location.as_str(), "file:///a.parquet");
+        assert_eq!(first.size, 100);
+        assert_eq!(first.last_modified, 1);
+
+        let second = iter.next().expect("second item");
+        assert!(second.is_err(), "second item should be Err");
+
+        let third = iter.next().expect("third item").expect("third ok");
+        assert_eq!(third.location.as_str(), "file:///b.parquet");
+        assert_eq!(third.size, 200);
+        assert_eq!(third.last_modified, 2);
+
+        assert!(iter.next().is_none(), "iterator should be exhausted");
+        assert!(!cleanup_called.load(Ordering::SeqCst));
+
+        drop(iter);
+        assert!(cleanup_called.load(Ordering::SeqCst));
+    }
+}

--- a/ffi/src/plans/mod.rs
+++ b/ffi/src/plans/mod.rs
@@ -1,0 +1,7 @@
+//! This module contains all types and functions needed to support declarative plan execution
+//! over the FFI boundary.
+
+#[allow(dead_code)] // will be used by subsequent changes introducing FfiPlanExecutor
+pub mod iter;
+#[allow(dead_code)] // will be used by subsequent changes introducing FfiPlanExecutor
+pub mod result;

--- a/ffi/src/plans/result.rs
+++ b/ffi/src/plans/result.rs
@@ -1,0 +1,131 @@
+//! FFI types for mimicking the kernel's `PlanResult` enum.
+
+use delta_kernel::Error;
+
+use super::iter::{CBytesIterator, CEngineDataIterator, CFileMetaIterator};
+use crate::error::EngineError;
+use crate::scan::EngineSchema;
+use crate::NullableCvoid;
+
+/// Helper function for converting an engine-allocated [`EngineError`] (handed to kernel as `*mut
+/// EngineError`) into a [`delta_kernel::Error`].
+///
+/// TODO: EngineError does not communicate the error message, so for now we just log a generic error
+/// with the error code.
+pub(crate) fn engine_error_to_kernel(err: *mut EngineError) -> Error {
+    Error::generic(format!(
+        "Engine error during plan execution: {:?}",
+        unsafe { &*err }.etype
+    ))
+}
+
+/// C-compatible equivalent of the kernel's `ParquetFooter` struct.
+///
+/// The schema is delivered as an [`EngineSchema`] - an opaque engine-owned schema which will be
+/// materialized on the kernel-side via vistor pattern.
+#[repr(C)]
+pub struct CParquetFooter {
+    pub schema: EngineSchema,
+}
+
+/// C-compatible equivalent of the kernel's `PlanResult` enum.
+#[repr(C)]
+pub enum CPlanResult {
+    Unit,
+    Data(CEngineDataIterator),
+    FileMeta(CFileMetaIterator),
+    Bytes(CBytesIterator),
+    ParquetFooter(CParquetFooter),
+}
+
+/// An engine-allocated wrapper around a [`CPlanResult`].
+///
+/// This wrapper allows the engine to attach an opaque `state` pointer and a `free` callback,
+/// letting the kernel free all associated engine resources (including nested iterator
+/// data) when the result is no longer needed. `state` is opaque to kernel and is passed verbatim
+/// back to `free`. Using a single wrapper + free callback allows the engine to conveniently
+/// maintain a single arena per plan execution, rather than tracking resources separately for each
+/// inner item of the PlanResult.
+///
+/// On the Rust-side, the wrapper should be converted into a `PlanResultCleanup` guard to
+/// ensure the free callback is invoked properly.
+#[repr(C)]
+pub struct CPlanResultWrapper {
+    pub result: CPlanResult,
+    pub state: NullableCvoid,
+    pub free: extern "C" fn(state: NullableCvoid),
+}
+
+/// RAII guard for invoking [`CPlanResultWrapper::free`] exactly once on drop.
+pub(crate) struct PlanResultCleanup {
+    state: NullableCvoid,
+    free: extern "C" fn(state: NullableCvoid),
+}
+
+impl PlanResultCleanup {
+    pub(crate) fn new(state: NullableCvoid, free: extern "C" fn(state: NullableCvoid)) -> Self {
+        Self { state, free }
+    }
+}
+
+impl Drop for PlanResultCleanup {
+    fn drop(&mut self) {
+        (self.free)(self.state);
+    }
+}
+
+// SAFETY: the engine is expected to provide thread-safe state + free function pointers.
+unsafe impl Send for PlanResultCleanup {}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::c_void;
+    use std::ptr::NonNull;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+    use crate::error::KernelError;
+
+    #[test]
+    fn engine_error_to_kernel_preserves_etype() {
+        let err = EngineError {
+            etype: KernelError::FileNotFoundError,
+        };
+        let kernel_err = engine_error_to_kernel(&err as *const _ as *mut _);
+        let Error::Generic(msg) = kernel_err else {
+            panic!("expected Error::Generic");
+        };
+        assert!(
+            msg.contains("FileNotFoundError"),
+            "etype should appear in the message, got {msg:?}",
+        );
+    }
+
+    #[test]
+    fn plan_result_cleanup_invokes_free_with_state_on_drop() {
+        extern "C" fn count_free_calls(state: NullableCvoid) {
+            // SAFETY: this test passes a pointer to a stack-allocated `AtomicUsize` that
+            // outlives the `PlanResultCleanup` drop.
+            let counter = unsafe { &*(state.unwrap().as_ptr() as *const AtomicUsize) };
+            counter.fetch_add(1, Ordering::SeqCst);
+        }
+
+        let counter = AtomicUsize::new(0);
+        let cleanup = PlanResultCleanup::new(
+            NonNull::new(&counter as *const AtomicUsize as *mut c_void),
+            count_free_calls,
+        );
+
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            0,
+            "free must not run before drop"
+        );
+        drop(cleanup);
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            1,
+            "free must run exactly once on drop"
+        );
+    }
+}

--- a/ffi/src/plans/result.rs
+++ b/ffi/src/plans/result.rs
@@ -3,7 +3,7 @@
 use delta_kernel::Error;
 
 use super::iter::{CBytesIterator, CEngineDataIterator, CFileMetaIterator};
-use crate::error::EngineError;
+use crate::error::{EngineError, ExternResult};
 use crate::scan::EngineSchema;
 use crate::NullableCvoid;
 
@@ -38,20 +38,29 @@ pub enum CPlanResult {
     ParquetFooter(CParquetFooter),
 }
 
-/// An engine-allocated wrapper around a [`CPlanResult`].
+/// An engine-allocated wrapper around an [`ExternResult<CPlanResult>`].
 ///
 /// This wrapper allows the engine to attach an opaque `state` pointer and a `free` callback,
-/// letting the kernel free all associated engine resources (including nested iterator
-/// data) when the result is no longer needed. `state` is opaque to kernel and is passed verbatim
+/// letting the kernel free all associated engine resources (i.e nested iterators and ExternResults)
+/// when the result is no longer needed. `state` is opaque to kernel and is passed verbatim
 /// back to `free`. Using a single wrapper + free callback allows the engine to conveniently
 /// maintain a single arena per plan execution, rather than tracking resources separately for each
 /// inner item of the PlanResult.
 ///
-/// On the Rust-side, the wrapper should be converted into a `PlanResultCleanup` guard to
-/// ensure the free callback is invoked properly.
+/// This wrapper additionally attaches an opaque `state` pointer and a `free` callback so kernel
+/// can release all engine-side resources (nested iterator state, error allocations, etc.) when the
+/// result is no longer needed. `state` is opaque to kernel and is passed verbatim to `free`.
+///
+/// A single wrapper + `free` callback lets the engine maintain one arena per plan execution rather
+/// than tracking resources separately for each inner item of the `CPlanResult`. On the Rust-side,
+/// the `state` + `free` pair should be converted into a `PlanResultCleanup` guard to ensure the
+/// free callback is invoked properly.
+///
+/// # Safety
+/// The engine must ensure that the `state` and `free` pointers are safe to send between threads.
 #[repr(C)]
 pub struct CPlanResultWrapper {
-    pub result: CPlanResult,
+    pub result: ExternResult<CPlanResult>,
     pub state: NullableCvoid,
     pub free: extern "C" fn(state: NullableCvoid),
 }
@@ -74,7 +83,8 @@ impl Drop for PlanResultCleanup {
     }
 }
 
-// SAFETY: the engine is expected to provide thread-safe state + free function pointers.
+// # Safety
+// The engine must ensure that all raw pointers sent are Send-safe
 unsafe impl Send for PlanResultCleanup {}
 
 #[cfg(test)]


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR implements FFI structs for `PlanResult` and associated iterator result types. Each PlanResult variant has an associated "C iter" struct and an "FFI adapter" struct. For example for `PlanResult::Data`, we introduce:
- `CEngineDataIterator` - a raw repr(c) struct that holds a `state` + `free` callback fn that can be used to implement an iterator over FFI.
- `FfiEngineDataIter` - wraps a `CEngineDataIterator` and implements the Rust iterator trait.

A few important callouts regarding memory management:
- We use a `CPlanResultWrapper` to provide a single `free` callback that will release all resources related to the plan result. This let's Java use a single shared arena for the entire plan result isntead of providing separate `free` fn for each nested item.
- Each iterator type has slightly different semantics:
  - For EngineData, we expect to use ArrowEngineData which will internally release memory for each batch (on drop of each item).
  - For Bytes, we use FFI_ArrowArray to pass bytes across FFI, which then also gives us the same memory management as ArrowEngineData (on drop of each item)
  - For FileMeta, we rely on the PlanResult cleanup to drop all FileMeta within the iterator at once (on drop of the iterator)

## How was this change tested?
Unit tests
