### PR TITLE
feat!: column constructors take impl Into<ColumnName>

### DIFF
--- a/benchmarks/src/predicate_parser.rs
+++ b/benchmarks/src/predicate_parser.rs
@@ -130,7 +130,7 @@ fn synthesize_expr(schema: &Schema, expr: &PExpr) -> Option<(KExpr, DataType)> {
                 .last()?
                 .data_type()
                 .clone();
-            let expr = KExpr::column(parts.iter().map(|p| p.value.clone()));
+            let expr = KExpr::column(col_name);
             Some((expr, ty))
         }
         PExpr::Value(v) => match &v.value {

--- a/kernel/src/expressions/column_names.rs
+++ b/kernel/src/expressions/column_names.rs
@@ -119,6 +119,37 @@ impl ColumnName {
     }
 }
 
+/// Builds a [`ColumnName`] from an explicit list of segments.
+///
+/// Each element is taken verbatim as one segment -- dots are **not** path separators, so
+/// `ColumnName::from(["a.b"])` is a single segment named `"a.b"`. To split a dot-separated literal
+/// known at compile time, use the [`column_name!`] / [`column_expr!`] macros instead.
+///
+/// There is deliberately no `From<&str>`/`From<String>`: a bare string has two equally reasonable
+/// readings (split into a path vs. a single verbatim segment), so it is not a canonical conversion.
+/// Callers must say which they mean -- `["a.b"]` for one segment, `column_name!("a.b")` to split.
+///
+/// [`column_name!`]: crate::expressions::column_name
+/// [`column_expr!`]: crate::expressions::column_expr
+impl<A: Into<String>, const N: usize> From<[A; N]> for ColumnName {
+    fn from(segments: [A; N]) -> Self {
+        ColumnName::new(segments)
+    }
+}
+
+impl<A: Into<String>> From<Vec<A>> for ColumnName {
+    fn from(segments: Vec<A>) -> Self {
+        ColumnName::new(segments)
+    }
+}
+
+// Borrowed slice of segments, cloning each into an owned segment.
+impl<A: Into<String> + Clone> From<&[A]> for ColumnName {
+    fn from(segments: &[A]) -> Self {
+        ColumnName::new(segments.iter().cloned())
+    }
+}
+
 /// Creates a new column name from a path of field names. Each field name is taken as-is, and may
 /// contain arbitrary characters (including periods, spaces, etc.).
 impl<A: Into<String>> FromIterator<A> for ColumnName {
@@ -709,5 +740,18 @@ mod test {
                 _ => panic!("Expected {input} to parse as {expected_output:?}, got {output:?}"),
             }
         }
+    }
+
+    #[test]
+    fn column_name_from_segment_shapes() {
+        let expected = ColumnName::new(["a", "b", "c"]);
+        // Arrays, `Vec`s, and borrowed slices of string-like segments convert via `From`.
+        assert_eq!(ColumnName::from(["a", "b", "c"]), expected);
+        assert_eq!(ColumnName::from(vec!["a", "b", "c"]), expected);
+        let slice: &[&str] = &["a", "b", "c"];
+        assert_eq!(ColumnName::from(slice), expected);
+        // The same shapes are reachable through the `Into<ColumnName>` bound on `column()`.
+        let via_into: ColumnName = ["a", "b", "c"].into();
+        assert_eq!(via_into, expected);
     }
 }

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -657,12 +657,9 @@ impl Expression {
         references.0
     }
 
-    /// Create a new column name expression from input satisfying `FromIterator for ColumnName`.
-    pub fn column<A>(field_names: impl IntoIterator<Item = A>) -> Expression
-    where
-        ColumnName: FromIterator<A>,
-    {
-        ColumnName::new(field_names).into()
+    /// Create a new column reference expression.
+    pub fn column(name: impl Into<ColumnName>) -> Expression {
+        Expression::Column(name.into())
     }
 
     /// Create a new expression for a literal value
@@ -828,11 +825,9 @@ impl Predicate {
     }
 
     /// Creates a new boolean column reference. See also [`Expression::column`].
-    pub fn column<A>(field_names: impl IntoIterator<Item = A>) -> Predicate
-    where
-        ColumnName: FromIterator<A>,
-    {
-        Self::from_expr(ColumnName::new(field_names))
+    pub fn column(name: impl Into<ColumnName>) -> Predicate {
+        let name: ColumnName = name.into();
+        Self::from_expr(name)
     }
 
     /// Create a new literal boolean value


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2683/files) to review incremental changes.
- [**stack/into-column-name**](https://github.com/delta-io/delta-kernel-rs/pull/2683) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2683/files)]
  - [stack/col-lit](https://github.com/delta-io/delta-kernel-rs/pull/2684) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2684/files/df15a59063aa0f85ab75879271f15ad9f30cbd93..bef377438c8ee2937b74996f76f77cf9689d5ce3)]

---------
## What changes are proposed in this pull request?

Change `Expression::column` / `Predicate::column` to accept `impl Into<ColumnName>` instead of `impl IntoIterator<Item: Into<String>>`, backed by canonical `From` impls on `ColumnName` (`From<[A; N]>`, `From<Vec<A>>`, `From<&[A]>`; the reflexive `From<ColumnName>` is automatic).

There is deliberately no `From<&str>` / `From<String>`: a bare string is ambiguous (split into a path vs. a single verbatim segment), so it is not a canonical conversion. Callers pass `["a.b"]` for a single verbatim segment, or `column_name!("a.b")` to split.

## How was this change tested?

Added `column_name_from_segment_shapes`, covering arrays, `Vec`, slices, and the `Into<ColumnName>` bound used by `column()`. Existing kernel and benchmark call sites (arrays / `ColumnName`) compile unchanged; `fmt` / `clippy` / `doc` / `nextest` all pass.
