### PR TITLE
feat: add col and lit expression builders

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,6 +269,11 @@ Keep this list updated when new protocol features are added to kernel.
   Reserve `StructField::new` for cases where nullability is a runtime value.
 - Prefer the `DeltaResultIterator<'a, T>` / `DeltaResultIteratorStatic<T>` aliases over
   hand-rolled `Box<dyn Iterator<Item = DeltaResult<T>> + Send (+ 'a)>`.
+- Prefer the `col!` macro and `lit(value)` constructor over `Expression::column(...)` /
+  `Expression::literal(...)` when building expressions inline. `col!` has two forms: a single
+  string literal splits on dots at compile time (`col!("a.b.c")` is a 3-segment nested column,
+  same as `column_expr!`); one or more comma-separated args build a column with each segment taken
+  verbatim (`col!("a.b", "c")` is two segments, `col!(name)` for a runtime string is one segment).
 - NEVER panic in production code -- use errors instead. Panicking
   (including `unwrap()`, `expect()`, `panic!()`, `unreachable!()`, etc) is acceptable in test code only.
 

--- a/kernel/src/expressions/column_names.rs
+++ b/kernel/src/expressions/column_names.rs
@@ -440,6 +440,49 @@ macro_rules! __column_expr {
 #[doc(inline)]
 pub use __column_expr as column_expr;
 
+/// Builds an [`Expression`] column reference. Accepts two forms:
+///
+/// - A single **string literal** is split on `.` at compile time into a (possibly nested) column
+///   reference: `col!("a.b.c")` is equivalent to `col!("a", "b", "c")`. This is the same
+///   compile-time splitting [`column_expr!`] performs.
+/// - One or more comma-separated arguments build a column whose segments are taken **verbatim**
+///   (never split on `.`). A single non-literal argument is one segment, so `col!(name)` for a
+///   runtime `&str`/`String` is a single-segment column; `col!("a.b", "c")` is two segments.
+///
+/// ```
+/// # use delta_kernel::expressions::{col, column_expr, ColumnName, Expression};
+/// // A string literal splits on dots at compile time (same as `column_expr!`).
+/// assert_eq!(col!("a.b.c"), Expression::Column(ColumnName::new(["a", "b", "c"])));
+/// assert_eq!(col!("a.b.c"), column_expr!("a.b.c"));
+///
+/// // A single dotless literal is one segment.
+/// assert_eq!(col!("x"), Expression::Column(ColumnName::new(["x"])));
+///
+/// // Multiple args build a multi-segment column, each segment verbatim (not split).
+/// assert_eq!(col!("a.b", "c"), Expression::Column(ColumnName::new(["a.b", "c"])));
+///
+/// // A single runtime value is one verbatim segment.
+/// let name = "runtime";
+/// assert_eq!(col!(name), Expression::Column(ColumnName::new(["runtime"])));
+/// ```
+///
+/// [`Expression`]: crate::expressions::Expression
+/// [`column_expr!`]: crate::expressions::column_expr
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __col {
+    // A single string literal: split on `.` at compile time (same as `column_expr!`).
+    ( $name:literal ) => {
+        $crate::expressions::column_expr!($name)
+    };
+    // One or more comma-separated segments, each taken verbatim (never split on `.`).
+    ( $($segments:expr),+ $(,)? ) => {
+        $crate::expressions::Expression::column([$($segments),+])
+    };
+}
+#[doc(inline)]
+pub use __col as col;
+
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __column_expr_ref {

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -8,8 +8,8 @@ use itertools::Itertools;
 use serde::{de, ser, Deserialize, Deserializer, Serialize, Serializer};
 
 pub use self::column_names::{
-    column_expr, column_expr_ref, column_name, column_pred, joined_column_expr, joined_column_name,
-    ColumnName,
+    col, column_expr, column_expr_ref, column_name, column_pred, joined_column_expr,
+    joined_column_name, ColumnName,
 };
 pub use self::scalars::{ArrayData, DecimalData, MapData, Scalar, StructData};
 use crate::kernel_predicates::{
@@ -27,6 +27,19 @@ mod scalars;
 
 pub type ExpressionRef = std::sync::Arc<Expression>;
 pub type PredicateRef = std::sync::Arc<Predicate>;
+
+/// Build an [`Expression::Literal`] from anything that converts into a [`Scalar`].
+///
+/// Concise alternative to [`Expression::literal`] for plan builders. Accepts the same value
+/// types [`Scalar`] does (`i32`, `i64`, `&str`, `bool`, ...).
+///
+/// ```
+/// use delta_kernel::expressions::lit;
+/// let _zero = lit(0i64);
+/// ```
+pub fn lit(value: impl Into<Scalar>) -> Expression {
+    Expression::literal(value)
+}
 
 ////////////////////////////////////////////////////////////////////////
 // Operators

--- a/kernel/src/scan/transform_spec.rs
+++ b/kernel/src/scan/transform_spec.rs
@@ -10,9 +10,7 @@ use std::sync::Arc;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
-use crate::expressions::{
-    BinaryExpressionOp, Expression, ExpressionRef, ExpressionStructPatch, Scalar,
-};
+use crate::expressions::{col, lit, Expression, ExpressionRef, ExpressionStructPatch, Scalar};
 use crate::schema::{DataType, SchemaRef, StructType};
 use crate::table_features::ColumnMappingMode;
 use crate::{DeltaResult, Error};
@@ -144,12 +142,8 @@ pub(crate) fn get_transform_expr(
                     Error::generic("Asked to generate RowIds, but no baseRowId found.")
                 })?;
                 let expr = Arc::new(Expression::coalesce([
-                    Expression::column([field_name]),
-                    Expression::binary(
-                        BinaryExpressionOp::Plus,
-                        Expression::literal(base_row_id),
-                        Expression::column([row_index_field_name]),
-                    ),
+                    col!(field_name),
+                    lit(base_row_id) + col!(row_index_field_name),
                 ]));
                 patch.with_replaced_field(field_name.clone(), expr)
             }
@@ -179,10 +173,7 @@ pub(crate) fn get_transform_expr(
                     // This ensures consistent column ordering across file types
                     patch = patch
                         .with_dropped_field(physical_name.clone())
-                        .with_inserted_field(
-                            insert_after.clone(),
-                            Arc::new(Expression::column([physical_name.clone()])),
-                        );
+                        .with_inserted_field(insert_after.clone(), Arc::new(col!(physical_name)));
                     patch
                 } else {
                     // Column doesn't exist physically - treat as partition column
@@ -221,6 +212,7 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
+    use crate::expressions::BinaryExpressionOp;
     use crate::schema::{DataType, PrimitiveType, StructField, StructType};
     use crate::utils::test_utils::assert_result_error_with_message;
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2684/files) to review incremental changes.
- [**stack/col-lit**](https://github.com/delta-io/delta-kernel-rs/pull/2684) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2684/files)]

---------
## What changes are proposed in this pull request?

Add the `col!` macro and `lit()` constructor for concise inline expression building. `col!` has two forms: a single string literal splits on dots at compile time (`col!("a.b.c")`), and one or more comma-separated args build a column with each segment taken verbatim (`col!("a.b", "c")` is two segments; `col!(name)` for a runtime string is one segment). A few `transform_spec` call sites are converted as a showcase, and the convention is documented in `CLAUDE.md`.

## How was this change tested?

The `col!` doctest covers both forms; the converted call sites are exercised by the existing scan/transaction tests. `fmt` / `clippy` / `doc` / `nextest` all pass.
