### PR TITLE
feat: add FFI-backed PlanExecutor impl

### DIFF
--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -62,8 +62,10 @@ default-engine-base = ["delta_kernel/default-engine-base", "dep:delta_kernel_def
 
 # Declarative plan execution via PlanExecutor trait (experimental).
 #
-# Requires `arrow` because iterators returned from plan execution use Arrow to pass along data batches.
-declarative-plans = ["delta_kernel/declarative-plans", "arrow"]
+# Requires `arrow` because iterators returned from plan execution use Arrow to pass along data
+# batches, and requires `default-engine-base` because the `PlanBasedEngine` FFI constructor pairs
+# the plan executor with `ArrowEvaluationHandler`
+declarative-plans = ["delta_kernel/declarative-plans", "arrow", "default-engine-base"]
 
 tracing = [ "tracing-core", "tracing-subscriber" ]
 internal-api = []

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -161,6 +161,7 @@ impl KernelBytesSlice {
     ///
     /// # Safety
     /// Caller must guarantee that the source will outlive the created KernelBytesSlice.
+    #[cfg(feature = "declarative-plans")]
     pub(crate) unsafe fn new_unsafe(source: &[u8]) -> Self {
         Self {
             ptr: source.as_ptr(),

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -209,6 +209,23 @@ macro_rules! kernel_string_slice {
 }
 pub(crate) use kernel_string_slice;
 
+/// Similar to [`kernel_string_slice!`](kernel_string_slice), this macro provides a safer way to
+/// construct a KernelBytesSlice.
+///
+/// Refer to [`kernel_string_slice!`](kernel_string_slice) for safety and implementation
+/// notes.
+#[cfg(feature = "declarative-plans")]
+macro_rules! kernel_bytes_slice {
+    ( $source:ident ) => {{
+        fn do_it(b: &[u8]) -> $crate::KernelBytesSlice {
+            unsafe { $crate::KernelBytesSlice::new_unsafe(b) }
+        }
+        do_it(&$source)
+    }};
+}
+#[cfg(feature = "declarative-plans")]
+pub(crate) use kernel_bytes_slice;
+
 trait TryFromStringSlice<'a>: Sized {
     unsafe fn try_from_slice(slice: &'a KernelStringSlice) -> DeltaResult<Self>;
 }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -146,6 +146,29 @@ impl KernelStringSlice {
     }
 }
 
+/// A kernel-owned slice of raw bytes, intended for arg-passing from kernel to engine.
+///
+/// Like [`KernelStringSlice`], the pointed-to data must outlive the slice itself, and the slice
+/// must not be retained beyond the foreign function call it was passed into.
+#[repr(C)]
+pub struct KernelBytesSlice {
+    ptr: *const u8,
+    len: usize,
+}
+
+impl KernelBytesSlice {
+    /// Creates a new bytes slice from a source byte slice.
+    ///
+    /// # Safety
+    /// Caller must guarantee that the source will outlive the created KernelBytesSlice.
+    pub(crate) unsafe fn new_unsafe(source: &[u8]) -> Self {
+        Self {
+            ptr: source.as_ptr(),
+            len: source.len(),
+        }
+    }
+}
+
 /// FFI-safe implementation for Rust's `Option<T>`
 #[derive(PartialEq, Debug)]
 #[repr(C)]

--- a/ffi/src/plans/executor.rs
+++ b/ffi/src/plans/executor.rs
@@ -11,7 +11,7 @@ use crate::plans::result::{
     engine_error_to_kernel, CParquetFooter, CPlanResult, CPlanResultWrapper, PlanResultCleanup,
 };
 use crate::schema_visitor::{extract_kernel_schema, KernelSchemaVisitorState};
-use crate::{KernelBytesSlice, NullableCvoid};
+use crate::{kernel_bytes_slice, KernelBytesSlice, NullableCvoid};
 
 /// A shared (`Arc`-like) handle to an [`PlanExecutor`].
 #[handle_descriptor(target=dyn PlanExecutor, mutable=false)]
@@ -55,7 +55,7 @@ impl PlanExecutor for FfiPlanExecutor {
     fn execute_op(&self, _op: Operation) -> DeltaResult<PlanResult> {
         // TODO: serialize `_op` to bytes once proto schema is checked in.
         let plan_proto_bytes: &[u8] = &[];
-        let plan_proto_slice = unsafe { KernelBytesSlice::new_unsafe(plan_proto_bytes) };
+        let plan_proto_slice = kernel_bytes_slice!(plan_proto_bytes);
 
         let result_wrapper = (self.callback)(self.context, plan_proto_slice);
 

--- a/ffi/src/plans/executor.rs
+++ b/ffi/src/plans/executor.rs
@@ -1,0 +1,264 @@
+//! This module provides an FFI-backed implementation of the [`PlanExecutor`] trait (allowing plan
+//! execution to happen outside of Rust).
+use std::sync::Arc;
+
+use delta_kernel::{DeltaResult, Operation, ParquetFooter, PlanExecutor, PlanResult};
+use delta_kernel_ffi_macros::handle_descriptor;
+
+use crate::error::ExternResult;
+use crate::plans::iter::{FfiBytesIter, FfiEngineDataIter, FfiFileMetaIter};
+use crate::plans::result::{
+    engine_error_to_kernel, CParquetFooter, CPlanResult, CPlanResultWrapper, PlanResultCleanup,
+};
+use crate::schema_visitor::{extract_kernel_schema, KernelSchemaVisitorState};
+use crate::{KernelBytesSlice, NullableCvoid};
+
+/// A shared (`Arc`-like) handle to an [`PlanExecutor`].
+#[handle_descriptor(target=dyn PlanExecutor, mutable=false)]
+pub struct SharedPlanExecutor;
+
+/// C callback, provided by the Engine, for executing an [`Operation`].
+///
+/// `context` - an opaque pointer, originally passed to
+/// [`get_plan_executor`](super::get_plan_executor).
+/// `plan_proto` - a byte slice containing the proto-serialized representation of an [`Operation`]
+///
+/// The returned [`CPlanResultWrapper`] is consumed by kernel and should be freed according to
+/// the rules documented on [`CPlanResult`] and [`CPlanResultWrapper`].
+pub type CExecuteOpFn =
+    extern "C" fn(context: NullableCvoid, plan_proto: KernelBytesSlice) -> CPlanResultWrapper;
+
+/// A [`PlanExecutor`] implementation that forwards each [`Operation`] to a C callback.
+///
+/// Constructed and managed via [`get_plan_executor`](super::get_plan_executor) and
+/// [`free_plan_executor`](super::free_plan_executor).
+pub struct FfiPlanExecutor {
+    context: NullableCvoid,
+    callback: CExecuteOpFn,
+}
+
+impl FfiPlanExecutor {
+    /// Construct an [`FfiPlanExecutor`] from a context pointer and C callback.
+    ///
+    /// The `context` pointer and `callback` must satisfy the thread-safety and lifetime
+    /// requirements documented on [`get_plan_executor`](super::get_plan_executor).
+    pub(crate) fn new(context: NullableCvoid, callback: CExecuteOpFn) -> Self {
+        Self { context, callback }
+    }
+}
+
+// SAFETY: the engine is expected to provide thread-safe context + callback function pointers.
+unsafe impl Send for FfiPlanExecutor {}
+unsafe impl Sync for FfiPlanExecutor {}
+
+impl PlanExecutor for FfiPlanExecutor {
+    fn execute_op(&self, _op: Operation) -> DeltaResult<PlanResult> {
+        // TODO: serialize `_op` to bytes once proto schema is checked in.
+        let plan_proto_bytes: &[u8] = &[];
+        let plan_proto_slice = unsafe { KernelBytesSlice::new_unsafe(plan_proto_bytes) };
+
+        let result_wrapper = (self.callback)(self.context, plan_proto_slice);
+
+        // Generate the cleanup guard immediately to guarantee that plan result resources are
+        // freed when either:
+        // - this fn returns (e.g. on the `Err` branch, or on the non-iterator `Ok` variants), or
+        // - the iterator adapters are dropped (by forwarding this guard to them)
+        let cleanup = PlanResultCleanup::new(result_wrapper.state, result_wrapper.free);
+        let plan_result = match result_wrapper.result {
+            ExternResult::Ok(plan) => plan,
+            ExternResult::Err(err) => return Err(engine_error_to_kernel(err)),
+        };
+        match plan_result {
+            CPlanResult::Unit => Ok(PlanResult::Unit),
+            CPlanResult::Data(it) => Ok(PlanResult::Data(Box::new(FfiEngineDataIter::new(
+                it, cleanup,
+            )))),
+            CPlanResult::FileMeta(it) => Ok(PlanResult::FileMeta(Box::new(FfiFileMetaIter::new(
+                it, cleanup,
+            )))),
+            CPlanResult::Bytes(it) => {
+                Ok(PlanResult::Bytes(Box::new(FfiBytesIter::new(it, cleanup))))
+            }
+            CPlanResult::ParquetFooter(footer) => {
+                Ok(PlanResult::ParquetFooter(decode_parquet_footer(footer)?))
+            }
+        }
+    }
+}
+
+/// Convert a [`CParquetFooter`] into a kernel [`ParquetFooter`]
+///
+/// Returns an error if schema visiting produces an invalid schema.
+fn decode_parquet_footer(footer: CParquetFooter) -> DeltaResult<ParquetFooter> {
+    let CParquetFooter { schema } = footer;
+    let mut visitor_state = KernelSchemaVisitorState::default();
+    let schema_id = (schema.visitor)(schema.schema, &mut visitor_state);
+    let schema = extract_kernel_schema(&mut visitor_state, schema_id)?;
+    Ok(ParquetFooter {
+        schema: Arc::new(schema),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::c_void;
+    use std::ptr::NonNull;
+    use std::sync::Mutex;
+
+    use delta_kernel::arrow::array::ffi::FFI_ArrowArray;
+    use delta_kernel::schema::DataType as KernelDataType;
+    use url::Url;
+
+    use super::*;
+    use crate::ffi_test_utils::{allocate_err, ok_or_panic};
+    use crate::handle::Handle;
+    use crate::plans::get_plan_executor;
+    use crate::plans::iter::{CBytesIterator, CEngineDataIterator, CFileMetaIterator};
+    use crate::plans::result::CParquetFooter;
+    use crate::scan::EngineSchema;
+    use crate::schema_visitor::{visit_field_integer, visit_field_struct};
+    use crate::{kernel_string_slice, ExclusiveEngineData, OptionalValue};
+
+    extern "C" fn noop_free(_state: NullableCvoid) {}
+
+    /// Mock callback that pulls a pre-configured `CPlanResult` out of a `Mutex<Option<_>>`
+    /// stashed in `context`. Hands back a no-op `free` since the tests aren't intended to validate
+    /// cleanup behavior.
+    extern "C" fn mock_execute_op(
+        context: NullableCvoid,
+        _plan_proto: KernelBytesSlice,
+    ) -> CPlanResultWrapper {
+        let cell = unsafe { &*(context.unwrap().as_ptr() as *const Mutex<Option<CPlanResult>>) };
+        let plan = cell
+            .lock()
+            .unwrap()
+            .take()
+            .expect("mock_execute_op invoked more than once");
+        CPlanResultWrapper {
+            result: ExternResult::Ok(plan),
+            state: None,
+            free: noop_free,
+        }
+    }
+
+    /// Executes a dummy plan operation against a `PlanExecutor` whose callback returns the given
+    /// `expected_plan_result`. Returns the resulting `PlanResult` for furhter validation.
+    fn execute_dummy_op(expected_plan_result: CPlanResult) -> PlanResult {
+        let cell: Mutex<Option<CPlanResult>> = Mutex::new(Some(expected_plan_result));
+        let context = NonNull::new(&cell as *const Mutex<Option<CPlanResult>> as *mut c_void);
+        let executor = unsafe { get_plan_executor(context, mock_execute_op) };
+        let plan_executor: Arc<dyn PlanExecutor> = unsafe { executor.into_inner() };
+
+        // Construct a dummy op because we don't actually care about the plan bytes here.
+        let url = Url::parse("memory:///table/").unwrap();
+        let op = Operation::IoOperation(delta_kernel::IoOperation::file_listing(url));
+
+        plan_executor.execute_op(op).expect("execute_op succeeds")
+    }
+
+    #[test]
+    fn execute_op_unit_variant() {
+        execute_dummy_op(CPlanResult::Unit)
+            .into_unit()
+            .expect("Unit variant");
+    }
+
+    #[test]
+    fn execute_op_data_variant() {
+        extern "C" fn empty_data_next(
+            _state: NullableCvoid,
+        ) -> OptionalValue<ExternResult<Handle<ExclusiveEngineData>>> {
+            OptionalValue::None
+        }
+
+        let iter = CEngineDataIterator {
+            state: None,
+            next: empty_data_next,
+        };
+        let mut data_iter = execute_dummy_op(CPlanResult::Data(iter))
+            .into_data()
+            .expect("Data variant");
+        assert!(data_iter.next().is_none(), "empty data iterator");
+    }
+
+    #[test]
+    fn execute_op_file_meta_variant() {
+        extern "C" fn empty_file_meta_next(
+            _state: NullableCvoid,
+        ) -> OptionalValue<ExternResult<FFI_ArrowArray>> {
+            OptionalValue::None
+        }
+
+        let iter = CFileMetaIterator {
+            state: None,
+            next: empty_file_meta_next,
+        };
+        let mut file_meta_iter = execute_dummy_op(CPlanResult::FileMeta(iter))
+            .into_file_meta()
+            .expect("FileMeta variant");
+        assert!(file_meta_iter.next().is_none(), "empty file meta iterator");
+    }
+
+    #[test]
+    fn execute_op_bytes_variant() {
+        extern "C" fn empty_bytes_next(
+            _state: NullableCvoid,
+        ) -> OptionalValue<ExternResult<FFI_ArrowArray>> {
+            OptionalValue::None
+        }
+
+        let iter = CBytesIterator {
+            state: None,
+            next: empty_bytes_next,
+        };
+        let mut bytes_iter = execute_dummy_op(CPlanResult::Bytes(iter))
+            .into_bytes()
+            .expect("Bytes variant");
+        assert!(bytes_iter.next().is_none(), "empty bytes iterator");
+    }
+
+    /// Schema visitor that produces `{id: integer (nullable)}`.
+    extern "C" fn visit_id_only_schema(
+        _schema_ptr: *mut c_void,
+        state: &mut KernelSchemaVisitorState,
+    ) -> usize {
+        let id = "id";
+        let id_field_id = unsafe {
+            ok_or_panic(visit_field_integer(
+                state,
+                kernel_string_slice!(id),
+                true,
+                allocate_err,
+            ))
+        };
+        let field_ids = [id_field_id];
+        let schema = "schema";
+        unsafe {
+            ok_or_panic(visit_field_struct(
+                state,
+                kernel_string_slice!(schema),
+                field_ids.as_ptr(),
+                1,
+                false,
+                allocate_err,
+            ))
+        }
+    }
+
+    #[test]
+    fn execute_op_parquet_footer_variant() {
+        let footer = CParquetFooter {
+            schema: EngineSchema {
+                schema: std::ptr::null_mut(),
+                visitor: visit_id_only_schema,
+            },
+        };
+        let footer = execute_dummy_op(CPlanResult::ParquetFooter(footer))
+            .into_parquet_footer()
+            .expect("ParquetFooter variant");
+        assert_eq!(footer.schema.fields().count(), 1);
+        let id_field = footer.schema.field("id").expect("id field");
+        assert_eq!(id_field.data_type(), &KernelDataType::INTEGER);
+        assert!(id_field.is_nullable());
+    }
+}

--- a/ffi/src/plans/executor.rs
+++ b/ffi/src/plans/executor.rs
@@ -93,6 +93,10 @@ fn decode_parquet_footer(footer: CParquetFooter) -> DeltaResult<ParquetFooter> {
     let CParquetFooter { schema } = footer;
     let mut visitor_state = KernelSchemaVisitorState::default();
     let schema_id = (schema.visitor)(schema.schema, &mut visitor_state);
+
+    // TODO: we currently use the existing visitor pattern for sending schema, but
+    // to be consistent with how we send the input plan (which includes schema), we could just use
+    // proto to serialize the schema here too.
     let schema = extract_kernel_schema(&mut visitor_state, schema_id)?;
     Ok(ParquetFooter {
         schema: Arc::new(schema),

--- a/ffi/src/plans/mod.rs
+++ b/ffi/src/plans/mod.rs
@@ -1,7 +1,95 @@
 //! This module contains all types and functions needed to support declarative plan execution
 //! over the FFI boundary.
 
-#[allow(dead_code)] // will be used by subsequent changes introducing FfiPlanExecutor
+use std::sync::Arc;
+
+use delta_kernel::engine::arrow_expression::ArrowEvaluationHandler;
+use delta_kernel::engine::plans::PlanBasedEngine;
+use delta_kernel::{Engine, EvaluationHandler, PlanExecutor};
+
+use crate::handle::Handle;
+use crate::plans::executor::{CExecuteOpFn, FfiPlanExecutor, SharedPlanExecutor};
+use crate::{engine_to_handle, AllocateErrorFn, NullableCvoid, SharedExternEngine};
+
+pub mod executor;
 pub mod iter;
-#[allow(dead_code)] // will be used by subsequent changes introducing FfiPlanExecutor
 pub mod result;
+
+/// Build a [`PlanExecutor`] backed by an engine-provided C callback.
+///
+/// # Safety
+/// The `context` pointer MUST be thread-safe and MUST remain valid for as long as the
+/// executor is used. It is valid to pass NULL as the context.
+#[no_mangle]
+pub unsafe extern "C" fn get_plan_executor(
+    context: NullableCvoid,
+    callback: CExecuteOpFn,
+) -> Handle<SharedPlanExecutor> {
+    let executor: Arc<dyn PlanExecutor> = Arc::new(FfiPlanExecutor::new(context, callback));
+    executor.into()
+}
+
+/// Free a plan executor obtained from [`get_plan_executor`].
+///
+/// Normally the handle is consumed by [`get_plan_based_engine`] and need not be explicitly freed by
+/// the caller. Use this only when discarding the executor without wrapping it in PlanBasedEngine.
+///
+/// # Safety
+///
+/// Caller must pass a valid handle previously obtained from [`get_plan_executor`] and must not use
+/// it again afterwards.
+#[no_mangle]
+pub unsafe extern "C" fn free_plan_executor(executor: Handle<SharedPlanExecutor>) {
+    executor.drop_handle();
+}
+
+/// Construct a [`PlanBasedEngine`] from the given [`SharedPlanExecutor`].
+///
+/// This method consumes the [`SharedPlanExecutor`] handle, which should be freed when the engine
+/// is dropped via `free_engine` (caller responsibility).
+///
+/// # Safety
+///
+/// Caller must pass a valid [`SharedPlanExecutor`] handle obtained from [`get_plan_executor`] and
+/// a valid [`AllocateErrorFn`].
+#[no_mangle]
+pub unsafe extern "C" fn get_plan_based_engine(
+    plan_executor: Handle<SharedPlanExecutor>,
+    allocate_error: AllocateErrorFn,
+) -> Handle<SharedExternEngine> {
+    let executor: Arc<dyn PlanExecutor> = unsafe { plan_executor.into_inner() };
+    let evaluation_handler: Arc<dyn EvaluationHandler> = Arc::new(ArrowEvaluationHandler);
+    let engine: Arc<dyn Engine> = Arc::new(PlanBasedEngine::new(evaluation_handler, executor));
+    engine_to_handle(engine, allocate_error)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ffi_test_utils::allocate_err;
+    use crate::free_engine;
+    use crate::plans::result::CPlanResultWrapper;
+
+    #[test]
+    fn get_plan_based_engine_returns_plan_based_engine() {
+        extern "C" fn unreachable_callback(
+            _context: NullableCvoid,
+            _plan_proto: crate::KernelBytesSlice,
+        ) -> CPlanResultWrapper {
+            unreachable!("callback should not run -- this test only constructs the engine");
+        }
+
+        let executor = unsafe { get_plan_executor(None, unreachable_callback) };
+        let engine_handle = unsafe { get_plan_based_engine(executor, allocate_err) };
+
+        // Confirm we got back a real `PlanBasedEngine`, not e.g. an accidental DefaultEngine.
+        let extern_engine = unsafe { engine_handle.as_ref() };
+        let engine = extern_engine.engine();
+        assert!(
+            engine.any_ref().downcast_ref::<PlanBasedEngine>().is_some(),
+            "engine handle must wrap a PlanBasedEngine",
+        );
+
+        unsafe { free_engine(engine_handle) };
+    }
+}

--- a/ffi/src/plans/mod.rs
+++ b/ffi/src/plans/mod.rs
@@ -18,7 +18,7 @@ pub mod result;
 /// Build a [`PlanExecutor`] backed by an engine-provided C callback.
 ///
 /// # Safety
-/// The `context` pointer MUST be thread-safe and MUST remain valid for as long as the
+/// The `context` pointer MUST be thread-safe (Send + Sync) and MUST remain valid for as long as the
 /// executor is used. It is valid to pass NULL as the context.
 #[no_mangle]
 pub unsafe extern "C" fn get_plan_executor(

--- a/ffi/src/plans/result.rs
+++ b/ffi/src/plans/result.rs
@@ -29,6 +29,11 @@ pub struct CParquetFooter {
 }
 
 /// C-compatible equivalent of the kernel's `PlanResult` enum.
+///
+/// We instruct cbindgen to prefix enum variants with enum name (e.g. `CPlanResult_Unit`)
+/// so they don't collide with other identifiers (e.g. with the `FileMeta` struct)
+///
+/// cbindgen:prefix-with-name=true
 #[repr(C)]
 pub enum CPlanResult {
     Unit,


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR adds an `FfiPlanExecutor` struct and associated FFI functions for creating / free'ing it. `FfiPlanExecutor` implements the `PlanExecutor` trait and enables foreign Engines (e.g Java-based) to implement PlanExecutor through a single callback.

We expect that `FfiPlanExecutor` will proto-serialize a given plan `Operation` and pass it to the callback fn as a byte array. However proto-serialization is still left as a TODO for now.

Builds on top of https://github.com/delta-io/delta-kernel-rs/pull/2680

## How was this change tested?
Unit tests