### PR TITLE
feat: add schema creation helper for column defaults

### DIFF
--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -130,6 +130,7 @@ pub enum ColumnMetadataKey {
     ParquetFieldId,
     ParquetFieldNestedIds,
     GenerationExpression,
+    CurrentDefault,
     IdentityStart,
     IdentityStep,
     IdentityHighWaterMark,
@@ -155,6 +156,7 @@ impl AsRef<str> for ColumnMetadataKey {
             // Tracking issue: <https://github.com/delta-io/delta/issues/6688>
             Self::ParquetFieldNestedIds => "parquet.field.nested.ids",
             Self::GenerationExpression => "delta.generationExpression",
+            Self::CurrentDefault => "CURRENT_DEFAULT",
             Self::IdentityAllowExplicitInsert => "delta.identity.allowExplicitInsert",
             Self::IdentityHighWaterMark => "delta.identity.highWaterMark",
             Self::IdentityStart => "delta.identity.start",
@@ -3941,6 +3943,14 @@ mod tests {
         assert_eq!(
             ColumnMetadataKey::ParquetFieldId.as_ref(),
             "parquet.field.id"
+        );
+    }
+
+    #[test]
+    fn test_current_default_key_value() {
+        assert_eq!(
+            ColumnMetadataKey::CurrentDefault.as_ref(),
+            "CURRENT_DEFAULT"
         );
     }
 

--- a/kernel/tests/integration/write/column_defaults.rs
+++ b/kernel/tests/integration/write/column_defaults.rs
@@ -1,24 +1,13 @@
 //! Integration tests for the `allowColumnDefaults` writer feature.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
-#[cfg(feature = "column-defaults-in-dev")]
-use delta_kernel::arrow::array::{ArrayRef, Int64Array, StringArray};
-#[cfg(feature = "column-defaults-in-dev")]
-use delta_kernel::arrow::record_batch::RecordBatch;
 use delta_kernel::committer::FileSystemCommitter;
-#[cfg(feature = "column-defaults-in-dev")]
-use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
-#[cfg(feature = "column-defaults-in-dev")]
-use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::schema::{DataType, StructField, StructType};
-#[cfg(feature = "column-defaults-in-dev")]
-use delta_kernel::table_features::TableFeature;
 use delta_kernel::transaction::create_table::create_table as kernel_create_table;
-use delta_kernel::{DeltaResult, Snapshot};
-use test_utils::{create_table, engine_store_setup, test_table_setup};
-#[cfg(feature = "column-defaults-in-dev")]
-use test_utils::{insert_data, test_read};
+use delta_kernel::DeltaResult;
+use test_utils::{schema_with_column_defaults, test_table_setup};
 
 // TODO(#2630): Allow create table to support column defaults
 #[test]
@@ -41,88 +30,207 @@ fn test_create_table_rejects_col_defaults() -> DeltaResult<()> {
     Ok(())
 }
 
-#[tokio::test]
-#[cfg(not(feature = "column-defaults-in-dev"))]
-async fn test_col_defaults_blocked_when_cargo_feature_off() -> Result<(), Box<dyn std::error::Error>>
-{
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("id", DataType::LONG),
-        StructField::nullable("name", DataType::STRING),
-    ])?);
+#[test]
+fn test_schema_with_column_defaults_errors_on_unknown_column() {
+    let schema = StructType::try_new(vec![StructField::nullable("c", DataType::INTEGER)]).unwrap();
 
-    let (store, engine, table_location) = engine_store_setup("test_col_defaults_off", None);
-    let table_url = create_table(
-        store.clone(),
-        table_location,
-        schema,
-        &[],
-        true,
-        vec![],
-        vec!["allowColumnDefaults"],
-    )
-    .await?;
-
-    let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
-    let err = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), &engine)
-        .expect_err("write must be blocked when allowColumnDefaults is unsupported");
-    let msg = err.to_string();
+    let err = schema_with_column_defaults(&schema, HashMap::from([("does_not_exist", "1")]))
+        .expect_err("unknown column must produce an error")
+        .to_string();
     assert!(
-        msg.contains("allowColumnDefaults"),
-        "error must name the unsupported feature; got: {msg}",
+        err.contains("does_not_exist"),
+        "error should name the unknown column; got: {err}",
     );
-
-    Ok(())
 }
 
-#[tokio::test]
+#[cfg(not(feature = "column-defaults-in-dev"))]
+mod feature_disabled {
+    use std::sync::Arc;
+
+    use delta_kernel::committer::FileSystemCommitter;
+    use delta_kernel::schema::{DataType, StructField, StructType};
+    use delta_kernel::Snapshot;
+    use test_utils::{create_table, engine_store_setup};
+
+    #[tokio::test]
+    async fn test_col_defaults_blocked_when_cargo_feature_off(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let schema = Arc::new(StructType::try_new(vec![
+            StructField::nullable("id", DataType::LONG),
+            StructField::nullable("name", DataType::STRING),
+        ])?);
+
+        let (store, engine, table_location) = engine_store_setup("test_col_defaults_off", None);
+        let table_url = create_table(
+            store.clone(),
+            table_location,
+            schema,
+            &[],
+            true,
+            vec![],
+            vec!["allowColumnDefaults"],
+        )
+        .await?;
+
+        let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
+        let err = snapshot
+            .transaction(Box::new(FileSystemCommitter::new()), &engine)
+            .expect_err("write must be blocked when allowColumnDefaults is unsupported");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("allowColumnDefaults"),
+            "error must name the unsupported feature; got: {msg}",
+        );
+
+        Ok(())
+    }
+}
+
 #[cfg(feature = "column-defaults-in-dev")]
-async fn test_blind_append_to_col_defaults_table_supported_when_cargo_feature_on(
-) -> Result<(), Box<dyn std::error::Error>> {
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("id", DataType::LONG),
-        StructField::nullable("name", DataType::STRING),
-    ])?);
+mod feature_enabled {
+    use std::collections::HashMap;
+    use std::sync::Arc;
 
-    let (store, engine, table_location) = engine_store_setup("test_table_col_defaults", None);
-    // Use the JSON helper instead of the kernel `create_table` builder because the
-    // latter does not whitelist this feature in `ALLOWED_DELTA_FEATURES`.
-    let table_url = create_table(
-        store.clone(),
-        table_location,
-        schema.clone(),
-        &[],
-        true,
-        vec![],
-        vec!["allowColumnDefaults"],
-    )
-    .await?;
-    let engine = Arc::new(engine);
+    use delta_kernel::arrow::array::{ArrayRef, Int64Array, StringArray};
+    use delta_kernel::arrow::record_batch::RecordBatch;
+    use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
+    use delta_kernel::engine::arrow_data::ArrowEngineData;
+    use delta_kernel::schema::{
+        ColumnMetadataKey, DataType, MetadataValue, StructField, StructType,
+    };
+    use delta_kernel::table_features::TableFeature;
+    use delta_kernel::Snapshot;
+    use rstest::rstest;
+    use test_utils::{
+        create_table, engine_store_setup, insert_data, schema_with_column_defaults, test_read,
+    };
 
-    let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
-    let writer_features = snapshot
-        .table_configuration()
-        .protocol()
-        .writer_features()
-        .expect("writer_features must be present on a writer v7 table");
-    assert!(
-        writer_features.contains(&TableFeature::AllowColumnDefaults),
-        "writer_features must include AllowColumnDefaults; got {writer_features:?}",
-    );
+    #[tokio::test]
+    async fn test_blind_append_to_col_defaults_table_supported_when_cargo_feature_on(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let schema = Arc::new(StructType::try_new(vec![
+            StructField::nullable("id", DataType::LONG),
+            StructField::nullable("name", DataType::STRING),
+        ])?);
 
-    // Blind-append a small batch. No column has a `CURRENT_DEFAULT` yet, so this is a plain
-    // append; we only assert the feature does not block the write path.
-    let columns: Vec<ArrayRef> = vec![
-        Arc::new(Int64Array::from(vec![1, 2, 3])),
-        Arc::new(StringArray::from(vec!["a", "b", "c"])),
-    ];
-    assert!(insert_data(snapshot, &engine, columns.clone())
-        .await?
-        .is_committed());
+        let (store, engine, table_location) = engine_store_setup("test_table_col_defaults", None);
+        // Use the JSON helper instead of the kernel `create_table` builder because the
+        // latter does not whitelist this feature in `ALLOWED_DELTA_FEATURES`.
+        let table_url = create_table(
+            store.clone(),
+            table_location,
+            schema.clone(),
+            &[],
+            true,
+            vec![],
+            vec!["allowColumnDefaults"],
+        )
+        .await?;
+        let engine = Arc::new(engine);
 
-    // Round-trip read.
-    let data = RecordBatch::try_new(Arc::new(schema.as_ref().try_into_arrow()?), columns)?;
-    test_read(&ArrowEngineData::new(data), &table_url, engine)?;
+        let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
+        let writer_features = snapshot
+            .table_configuration()
+            .protocol()
+            .writer_features()
+            .expect("writer_features must be present on a writer v7 table");
+        assert!(
+            writer_features.contains(&TableFeature::AllowColumnDefaults),
+            "writer_features must include AllowColumnDefaults; got {writer_features:?}",
+        );
 
-    Ok(())
+        // Blind-append a small batch. No column has a `CURRENT_DEFAULT` yet, so this is a plain
+        // append; we only assert the feature does not block the write path.
+        let columns: Vec<ArrayRef> = vec![
+            Arc::new(Int64Array::from(vec![1, 2, 3])),
+            Arc::new(StringArray::from(vec!["a", "b", "c"])),
+        ];
+        assert!(insert_data(snapshot, &engine, columns.clone())
+            .await?
+            .is_committed());
+
+        // Round-trip read.
+        let data = RecordBatch::try_new(Arc::new(schema.as_ref().try_into_arrow()?), columns)?;
+        test_read(&ArrowEngineData::new(data), &table_url, engine)?;
+
+        Ok(())
+    }
+
+    /// Creates a single-column table whose `c` column has `default_sql` as its `CURRENT_DEFAULT`,
+    /// then asserts the type and default round-trip through a freshly loaded snapshot.
+    ///
+    /// `extra_features` are reader+writer features the column type requires beyond
+    /// `allowColumnDefaults` (e.g. `timestampNtz` for a TIMESTAMP_NTZ column); they are added to
+    /// both the reader and writer feature lists.
+    async fn assert_column_default_persists(
+        data_type: DataType,
+        default_sql: &str,
+        extra_features: &[&str],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let base = StructType::try_new(vec![StructField::nullable("c", data_type.clone())])?;
+        let schema = schema_with_column_defaults(&base, HashMap::from([("c", default_sql)]))?;
+
+        let writer_features = [&["allowColumnDefaults"], extra_features].concat();
+        let (store, engine, table_location) = engine_store_setup("test_create_with_default", None);
+        let table_url = create_table(
+            store,
+            table_location,
+            schema,
+            &[],
+            true,
+            extra_features.to_vec(),
+            writer_features,
+        )
+        .await?;
+
+        let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
+        let schema = snapshot.schema();
+        let field = schema
+            .field("c")
+            .expect("c field must exist in loaded schema");
+
+        assert_eq!(field.data_type(), &data_type);
+        // TODO(#2630): replace this manual metadata read once StructField::column_default exists.
+        assert_eq!(
+            field.get_config_value(&ColumnMetadataKey::CurrentDefault),
+            Some(&MetadataValue::String(default_sql.to_string())),
+            "CURRENT_DEFAULT metadata must round-trip verbatim",
+        );
+
+        Ok(())
+    }
+
+    #[rstest]
+    #[case::integer(DataType::INTEGER, "42")]
+    #[case::long(DataType::LONG, "9876543210")]
+    #[case::short(DataType::SHORT, "7")]
+    #[case::byte(DataType::BYTE, "1")]
+    #[case::float(DataType::FLOAT, "1.5")]
+    #[case::double(DataType::DOUBLE, "3.14")]
+    #[case::string(DataType::STRING, "'hello'")]
+    #[case::boolean(DataType::BOOLEAN, "TRUE")]
+    #[case::binary(DataType::BINARY, "X'deadbeef'")]
+    #[case::date(DataType::DATE, "DATE '2024-01-01'")]
+    #[case::timestamp(DataType::TIMESTAMP, "TIMESTAMP '2024-01-01T12:00:00Z'")]
+    #[case::decimal(DataType::decimal(10, 2).unwrap(), "1.23")]
+    #[tokio::test]
+    async fn test_create_table_with_column_default_persists_metadata(
+        #[case] data_type: DataType,
+        #[case] default_sql: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        assert_column_default_persists(data_type, default_sql, &[]).await
+    }
+
+    // TIMESTAMP_NTZ is split out because it needs the orthogonal `timestampNtz` reader+writer
+    // feature, unlike every other primitive literal above.
+    #[tokio::test]
+    async fn test_create_table_with_timestamp_ntz_column_default_persists_metadata(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        assert_column_default_persists(
+            DataType::TIMESTAMP_NTZ,
+            "TIMESTAMP_NTZ '2024-01-01 12:00:00'",
+            &["timestampNtz"],
+        )
+        .await
+    }
 }

--- a/kernel/tests/integration/write/column_defaults.rs
+++ b/kernel/tests/integration/write/column_defaults.rs
@@ -65,10 +65,10 @@ mod feature_disabled {
             store.clone(),
             table_location,
             schema,
-            &[],
-            true,
-            vec![],
-            vec!["allowColumnDefaults"],
+            &[],                         /* partition_columns */
+            true,                        /* use_37_protocol */
+            vec![],                      /* reader_features */
+            vec!["allowColumnDefaults"], /* writer_features */
         )
         .await?;
 
@@ -120,10 +120,10 @@ mod feature_enabled {
             store.clone(),
             table_location,
             schema.clone(),
-            &[],
-            true,
-            vec![],
-            vec!["allowColumnDefaults"],
+            &[],                         /* partition_columns */
+            true,                        /* use_37_protocol */
+            vec![],                      /* reader_features */
+            vec!["allowColumnDefaults"], /* writer_features */
         )
         .await?;
         let engine = Arc::new(engine);
@@ -176,9 +176,9 @@ mod feature_enabled {
             store,
             table_location,
             schema,
-            &[],
-            true,
-            extra_features.to_vec(),
+            &[],                     /* partition_columns */
+            true,                    /* use_37_protocol */
+            extra_features.to_vec(), /* reader_features */
             writer_features,
         )
         .await?;
@@ -223,6 +223,8 @@ mod feature_enabled {
 
     // TIMESTAMP_NTZ is split out because it needs the orthogonal `timestampNtz` reader+writer
     // feature, unlike every other primitive literal above.
+    //
+    // TODO(#2630): Merge into the parameterized test once create supports column defaults
     #[tokio::test]
     async fn test_create_table_with_timestamp_ntz_column_default_persists_metadata(
     ) -> Result<(), Box<dyn std::error::Error>> {

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -172,10 +172,12 @@ use delta_kernel::object_store::{DynObjectStore, ObjectStoreExt as _};
 use delta_kernel::parquet::arrow::arrow_writer::ArrowWriter;
 use delta_kernel::parquet::file::properties::WriterProperties;
 use delta_kernel::scan::Scan;
-use delta_kernel::schema::{DataType, SchemaRef, StructField, StructType};
+use delta_kernel::schema::{
+    ColumnMetadataKey, DataType, MetadataValue, SchemaRef, StructField, StructType,
+};
 use delta_kernel::transaction::{CommitResult, Transaction};
 use delta_kernel::{
-    try_parse_uri, DeltaResult, DeltaResultIterator, Engine, EngineData, FileMeta,
+    try_parse_uri, DeltaResult, DeltaResultIterator, Engine, EngineData, Error, FileMeta,
     FilteredEngineData, LogPath, Snapshot,
 };
 // Re-export `delta_kernel_default_engine` so kernel's integration tests can access it without
@@ -725,6 +727,40 @@ pub async fn create_table(
         .put(&Path::from_url_path(path.path())?, data.into())
         .await?;
     Ok(table_path)
+}
+
+/// Returns a copy of `schema` with `CURRENT_DEFAULT` metadata attached to the named top-level
+/// fields.
+///
+/// `column_defaults` maps `column_name -> default_sql`. The raw SQL is stored verbatim; this
+/// helper does not parse or validate it.
+///
+/// # Errors
+///
+/// Returns an error if `column_defaults` names a column that is not a top-level field of `schema`.
+pub fn schema_with_column_defaults(
+    schema: &StructType,
+    mut column_defaults: HashMap<&str, &str>,
+) -> DeltaResult<SchemaRef> {
+    let mut augmented_fields = Vec::with_capacity(schema.fields().len());
+    for field in schema.fields() {
+        let augmented = match column_defaults.remove(field.name.as_str()) {
+            Some(sql) => field.clone().add_metadata([(
+                ColumnMetadataKey::CurrentDefault.as_ref().to_string(),
+                MetadataValue::String(sql.to_string()),
+            )]),
+            None => field.clone(),
+        };
+        augmented_fields.push(augmented);
+    }
+    if !column_defaults.is_empty() {
+        let unknown: Vec<&str> = column_defaults.into_keys().collect();
+        return Err(Error::generic(format!(
+            "column defaults reference unknown top-level columns: {unknown:?}"
+        )));
+    }
+
+    Ok(Arc::new(StructType::try_new(augmented_fields)?))
 }
 
 /// Creates two empty test tables, one with 37 protocol and one with 11 protocol.  the tables will


### PR DESCRIPTION
## Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2686/files) to review incremental changes.
- [stack/column-defaults-feature-flag](https://github.com/delta-io/delta-kernel-rs/pull/2636) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2636/files)] [MERGED]
  - [stack/column-defaults-sql-parser](https://github.com/delta-io/delta-kernel-rs/pull/2670) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2670/files)] [MERGED]
    - [**stack/column-defaults-create-helper**](https://github.com/delta-io/delta-kernel-rs/pull/2686) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2686/files)]
      - [stack/column-defaults-struct](https://github.com/delta-io/delta-kernel-rs/pull/2797) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2797/files/01cb238e8b534cd18f53e9027e6b7fac19e329dd..ec0951ad9fc241a6486ff6dd1c0f6a171ac60638)]
        - stack/column-defaults-schema-method
---------
## What changes are proposed in this pull request?
This PR introduces a test helper which adds column default metadata to an existing schema which can then be used in our test create table helper. Note that this method does no verification on metadata and serves only as a test helper.

## How was this change tested?
New unit tests.