### PR TITLE
ci: make title validator it run in merge queue

### DIFF
--- a/.github/workflows/pr-validator.yml
+++ b/.github/workflows/pr-validator.yml
@@ -3,6 +3,7 @@ name: Validate PR Title
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize, labeled, unlabeled]
+  merge_group:
   workflow_run:
     workflows: ["semver-label"] # we need this since auto-labels from jobs don't trigger a workflow
     types: [completed]


### PR DESCRIPTION
## What changes are proposed in this pull request?

We want to ensure titles are correct before merge, so make the title validator run in the merge queue, then we can make it a required test.

## How was this change tested?
