### PR TITLE
feat: add MeteredJsonHandler and MeteredParquetHandler

### DIFF
--- a/kernel/src/engine/default/json.rs
+++ b/kernel/src/engine/default/json.rs
@@ -18,7 +18,6 @@ use crate::engine::arrow_utils::{
     to_json_bytes,
 };
 use crate::engine_data::FilteredEngineData;
-use crate::metrics::{emit_json_read_completed, PrecountedMetricsIterator};
 use crate::object_store::path::Path;
 use crate::object_store::{self, DynObjectStore, GetResultPayload, ObjectStoreExt as _, PutMode};
 use crate::schema::SchemaRef;
@@ -163,8 +162,6 @@ impl<E: TaskExecutor> JsonHandler for DefaultJsonHandler<E> {
         physical_schema: SchemaRef,
         predicate: Option<PredicateRef>,
     ) -> DeltaResult<FileDataReadResultIterator> {
-        let num_files = files.len() as u64;
-        let bytes_read = files.iter().map(|f| f.size).sum();
         let future = read_json_files_impl(
             self.store.clone(),
             files.to_vec(),
@@ -173,13 +170,7 @@ impl<E: TaskExecutor> JsonHandler for DefaultJsonHandler<E> {
             self.batch_size,
             self.buffer_size,
         );
-        let inner = super::stream_future_to_iter(self.task_executor.clone(), future)?;
-        Ok(Box::new(PrecountedMetricsIterator::new(
-            inner,
-            num_files,
-            bytes_read,
-            emit_json_read_completed,
-        )))
+        super::stream_future_to_iter(self.task_executor.clone(), future)
     }
 
     // note: for now we just buffer all the data and write it out all at once

--- a/kernel/src/engine/default/mod.rs
+++ b/kernel/src/engine/default/mod.rs
@@ -91,10 +91,10 @@ pub struct DefaultEngine<E: TaskExecutor> {
     storage: Arc<MeteredStorageHandler>,
     json: Arc<MeteredJsonHandler>,
     parquet: Arc<MeteredParquetHandler>,
-    /// Concrete parquet handler retained so [`Self::write_parquet`] can call its
-    /// inherent `write_parquet_file` helper, which the [`ParquetHandler`] trait
-    /// surface doesn't expose.
-    parquet_raw: Arc<DefaultParquetHandler<E>>,
+    /// Concrete parquet handler retained so [`Self::write_parquet`] and
+    /// [`Self::default_parquet_handler`] can reach the inherent `write_parquet_file`
+    /// helper, which the [`ParquetHandler`] trait surface doesn't expose.
+    raw_parquet: Arc<DefaultParquetHandler<E>>,
     evaluation: Arc<ArrowEvaluationHandler>,
 }
 
@@ -186,15 +186,15 @@ impl<E: TaskExecutor> DefaultEngine<E> {
             object_store.clone(),
             task_executor.clone(),
         ));
-        let parquet_raw = Arc::new(DefaultParquetHandler::new(
+        let raw_parquet = Arc::new(DefaultParquetHandler::new(
             object_store.clone(),
             task_executor.clone(),
         ));
         Self {
             storage: Arc::new(MeteredStorageHandler::new(raw_storage)),
             json: Arc::new(MeteredJsonHandler::new(raw_json)),
-            parquet: Arc::new(MeteredParquetHandler::new(parquet_raw.clone())),
-            parquet_raw,
+            parquet: Arc::new(MeteredParquetHandler::new(raw_parquet.clone())),
+            raw_parquet,
             object_store,
             task_executor,
             evaluation: Arc::new(ArrowEvaluationHandler {}),
@@ -216,12 +216,11 @@ impl<E: TaskExecutor> DefaultEngine<E> {
         Some(self.object_store.clone())
     }
 
-    /// Returns the concrete [`DefaultParquetHandler`]. Use this when you need the
-    /// inherent async `write_parquet_file` helper (which is not part of the
-    /// [`ParquetHandler`] trait surface) -- e.g. tests and shredded-variant write paths.
-    /// Prefer [`Self::parquet_handler`] for the trait-level metered surface.
+    /// Returns the concrete [`DefaultParquetHandler`] for callers that need the inherent
+    /// async `write_parquet_file` helper not exposed by the [`ParquetHandler`] trait.
+    /// For the metered trait surface used by reads, use [`Self::parquet_handler`].
     pub fn default_parquet_handler(&self) -> Arc<DefaultParquetHandler<E>> {
-        self.parquet_raw.clone()
+        self.raw_parquet.clone()
     }
 
     /// Write `data` as a parquet file using the provided `write_context`.
@@ -246,7 +245,7 @@ impl<E: TaskExecutor> DefaultEngine<E> {
             output_schema.clone().into(),
         )?;
         let physical_data = logical_to_physical_expr.evaluate(data)?;
-        self.parquet_raw
+        self.raw_parquet
             .write_parquet_file(physical_data, write_context)
             .await
     }

--- a/kernel/src/engine/default/mod.rs
+++ b/kernel/src/engine/default/mod.rs
@@ -19,7 +19,7 @@ use self::parquet::DefaultParquetHandler;
 use super::arrow_conversion::TryFromArrow as _;
 use super::arrow_data::ArrowEngineData;
 use super::arrow_expression::ArrowEvaluationHandler;
-use crate::metrics::MeteredStorageHandler;
+use crate::metrics::{MeteredJsonHandler, MeteredParquetHandler, MeteredStorageHandler};
 use crate::object_store::DynObjectStore;
 use crate::schema::Schema;
 use crate::transaction::WriteContext;
@@ -89,8 +89,12 @@ pub struct DefaultEngine<E: TaskExecutor> {
     object_store: Arc<DynObjectStore>,
     task_executor: Arc<E>,
     storage: Arc<MeteredStorageHandler>,
-    json: Arc<DefaultJsonHandler<E>>,
-    parquet: Arc<DefaultParquetHandler<E>>,
+    json: Arc<MeteredJsonHandler>,
+    parquet: Arc<MeteredParquetHandler>,
+    /// Concrete parquet handler retained so [`Self::write_parquet`] can call its
+    /// inherent `write_parquet_file` helper, which the [`ParquetHandler`] trait
+    /// surface doesn't expose.
+    parquet_raw: Arc<DefaultParquetHandler<E>>,
     evaluation: Arc<ArrowEvaluationHandler>,
 }
 
@@ -178,16 +182,19 @@ impl<E: TaskExecutor> DefaultEngine<E> {
             object_store.clone(),
             task_executor.clone(),
         ));
+        let raw_json: Arc<dyn JsonHandler> = Arc::new(DefaultJsonHandler::new(
+            object_store.clone(),
+            task_executor.clone(),
+        ));
+        let parquet_raw = Arc::new(DefaultParquetHandler::new(
+            object_store.clone(),
+            task_executor.clone(),
+        ));
         Self {
             storage: Arc::new(MeteredStorageHandler::new(raw_storage)),
-            json: Arc::new(DefaultJsonHandler::new(
-                object_store.clone(),
-                task_executor.clone(),
-            )),
-            parquet: Arc::new(DefaultParquetHandler::new(
-                object_store.clone(),
-                task_executor.clone(),
-            )),
+            json: Arc::new(MeteredJsonHandler::new(raw_json)),
+            parquet: Arc::new(MeteredParquetHandler::new(parquet_raw.clone())),
+            parquet_raw,
             object_store,
             task_executor,
             evaluation: Arc::new(ArrowEvaluationHandler {}),
@@ -207,6 +214,14 @@ impl<E: TaskExecutor> DefaultEngine<E> {
 
     pub fn get_object_store_for_url(&self, _url: &Url) -> Option<Arc<DynObjectStore>> {
         Some(self.object_store.clone())
+    }
+
+    /// Returns the concrete [`DefaultParquetHandler`]. Use this when you need the
+    /// inherent async `write_parquet_file` helper (which is not part of the
+    /// [`ParquetHandler`] trait surface) -- e.g. tests and shredded-variant write paths.
+    /// Prefer [`Self::parquet_handler`] for the trait-level metered surface.
+    pub fn default_parquet_handler(&self) -> Arc<DefaultParquetHandler<E>> {
+        self.parquet_raw.clone()
     }
 
     /// Write `data` as a parquet file using the provided `write_context`.
@@ -231,7 +246,7 @@ impl<E: TaskExecutor> DefaultEngine<E> {
             output_schema.clone().into(),
         )?;
         let physical_data = logical_to_physical_expr.evaluate(data)?;
-        self.parquet
+        self.parquet_raw
             .write_parquet_file(physical_data, write_context)
             .await
     }

--- a/kernel/src/engine/default/mod.rs
+++ b/kernel/src/engine/default/mod.rs
@@ -220,8 +220,8 @@ impl<E: TaskExecutor> DefaultEngine<E> {
     /// async `write_parquet_file` helper not exposed by the [`ParquetHandler`] trait.
     /// For the metered trait surface used by reads, use [`Self::parquet_handler`].
     ///
-    /// TODO: lift the inherent helper onto [`DefaultEngine`] so this accessor (and the
-    /// `raw_parquet` field) can be removed.
+    /// TODO(#2701): lift the inherent helper onto [`DefaultEngine`] so this accessor
+    /// (and the `raw_parquet` field) can be removed.
     pub fn default_parquet_handler(&self) -> Arc<DefaultParquetHandler<E>> {
         self.raw_parquet.clone()
     }

--- a/kernel/src/engine/default/mod.rs
+++ b/kernel/src/engine/default/mod.rs
@@ -219,6 +219,9 @@ impl<E: TaskExecutor> DefaultEngine<E> {
     /// Returns the concrete [`DefaultParquetHandler`] for callers that need the inherent
     /// async `write_parquet_file` helper not exposed by the [`ParquetHandler`] trait.
     /// For the metered trait surface used by reads, use [`Self::parquet_handler`].
+    ///
+    /// TODO: lift the inherent helper onto [`DefaultEngine`] so this accessor (and the
+    /// `raw_parquet` field) can be removed.
     pub fn default_parquet_handler(&self) -> Arc<DefaultParquetHandler<E>> {
         self.raw_parquet.clone()
     }

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -24,7 +24,6 @@ use crate::engine::default::executor::TaskExecutor;
 use crate::engine::parquet_row_group_skipping::ParquetRowGroupSkipping;
 use crate::engine::{reader_options, writer_options};
 use crate::expressions::ColumnName;
-use crate::metrics::{emit_parquet_read_completed, PrecountedMetricsIterator};
 use crate::object_store::path::Path;
 use crate::object_store::{DynObjectStore, ObjectStoreExt as _};
 use crate::parquet::arrow::arrow_reader::{ArrowReaderMetadata, ParquetRecordBatchReaderBuilder};
@@ -306,21 +305,13 @@ impl<E: TaskExecutor> ParquetHandler for DefaultParquetHandler<E> {
         physical_schema: SchemaRef,
         predicate: Option<PredicateRef>,
     ) -> DeltaResult<FileDataReadResultIterator> {
-        let num_files = files.len() as u64;
-        let bytes_read = files.iter().map(|f| f.size).sum();
         let future = read_parquet_files_impl(
             self.store.clone(),
             files.to_vec(),
             physical_schema,
             predicate,
         );
-        let inner = super::stream_future_to_iter(self.task_executor.clone(), future)?;
-        Ok(Box::new(PrecountedMetricsIterator::new(
-            inner,
-            num_files,
-            bytes_read,
-            emit_parquet_read_completed,
-        )))
+        super::stream_future_to_iter(self.task_executor.clone(), future)
     }
 
     /// Writes engine data to a Parquet file at the specified location.

--- a/kernel/src/metrics/metered_engine.rs
+++ b/kernel/src/metrics/metered_engine.rs
@@ -1,6 +1,6 @@
-//! [`MeteredDeltaEngine`] wraps any [`Engine`] so its `storage_handler` emits the
-//! kernel's standard `"storage"` tracing spans. Other handler accessors pass through
-//! unchanged.
+//! [`MeteredDeltaEngine`] wraps any [`Engine`] so its `storage_handler`,
+//! `json_handler`, and `parquet_handler` emit the kernel's standard handler-completion
+//! tracing spans. `evaluation_handler` passes through unchanged.
 //!
 //! ```ignore
 //! let inner: Arc<dyn Engine> = Arc::new(MyEngine::build()?);
@@ -9,18 +9,21 @@
 
 use std::sync::Arc;
 
-use crate::metrics::MeteredStorageHandler;
+use crate::metrics::{MeteredJsonHandler, MeteredParquetHandler, MeteredStorageHandler};
 use crate::{Engine, EvaluationHandler, JsonHandler, ParquetHandler, StorageHandler};
 
-/// Decorator over any [`Engine`] that meters its storage handler. See module docs.
+/// Decorator over any [`Engine`] that meters its storage, JSON, and Parquet handlers.
+/// See module docs.
 pub struct MeteredDeltaEngine {
     inner: Arc<dyn Engine>,
     storage: Arc<dyn StorageHandler>,
+    json: Arc<dyn JsonHandler>,
+    parquet: Arc<dyn ParquetHandler>,
 }
 
 impl MeteredDeltaEngine {
-    /// Wrap `inner`. Debug-asserts that `inner`'s storage handler is not already
-    /// metered, so the resulting engine emits each storage span exactly once.
+    /// Wrap `inner`. Debug-asserts that none of `inner`'s metered handlers are already
+    /// metered wrappers, so the resulting engine emits each span exactly once.
     pub fn new(inner: Arc<dyn Engine>) -> Self {
         let inner_storage = inner.storage_handler();
         debug_assert!(
@@ -28,8 +31,27 @@ impl MeteredDeltaEngine {
             "MeteredDeltaEngine wraps an engine whose storage_handler is already a \
              MeteredStorageHandler; remove the outer wrap to avoid double-counting metrics",
         );
+        let inner_json = inner.json_handler();
+        debug_assert!(
+            !inner_json.any_ref().is::<MeteredJsonHandler>(),
+            "MeteredDeltaEngine wraps an engine whose json_handler is already a \
+             MeteredJsonHandler; remove the outer wrap to avoid double-counting metrics",
+        );
+        let inner_parquet = inner.parquet_handler();
+        debug_assert!(
+            !inner_parquet.any_ref().is::<MeteredParquetHandler>(),
+            "MeteredDeltaEngine wraps an engine whose parquet_handler is already a \
+             MeteredParquetHandler; remove the outer wrap to avoid double-counting metrics",
+        );
         let storage = Arc::new(MeteredStorageHandler::new(inner_storage));
-        Self { inner, storage }
+        let json = Arc::new(MeteredJsonHandler::new(inner_json));
+        let parquet = Arc::new(MeteredParquetHandler::new(inner_parquet));
+        Self {
+            inner,
+            storage,
+            json,
+            parquet,
+        }
     }
 }
 
@@ -49,11 +71,11 @@ impl Engine for MeteredDeltaEngine {
     }
 
     fn json_handler(&self) -> Arc<dyn JsonHandler> {
-        self.inner.json_handler()
+        Arc::clone(&self.json)
     }
 
     fn parquet_handler(&self) -> Arc<dyn ParquetHandler> {
-        self.inner.parquet_handler()
+        Arc::clone(&self.parquet)
     }
 }
 
@@ -174,42 +196,92 @@ mod tests {
     }
 
     #[test]
-    fn other_handlers_pass_through() {
+    fn evaluation_handler_passes_through() {
         let inner: Arc<dyn Engine> = Arc::new(StubEngine::new());
         let inner_eval = inner.evaluation_handler();
-        let inner_json = inner.json_handler();
-        let inner_parquet = inner.parquet_handler();
 
         let engine = MeteredDeltaEngine::new(inner);
         assert!(Arc::ptr_eq(&inner_eval, &engine.evaluation_handler()));
-        assert!(Arc::ptr_eq(&inner_json, &engine.json_handler()));
-        assert!(Arc::ptr_eq(&inner_parquet, &engine.parquet_handler()));
     }
 
-    /// Engine that returns an already-metered storage handler; used to verify the
-    /// debug-time double-wrap guard.
-    struct AlreadyMeteredEngine(StubEngine);
+    #[test]
+    fn json_and_parquet_handlers_are_metered() {
+        use crate::metrics::{MeteredJsonHandler, MeteredParquetHandler};
 
-    impl Engine for AlreadyMeteredEngine {
+        let engine = MeteredDeltaEngine::new(Arc::new(StubEngine::new()));
+        assert!(engine.json_handler().any_ref().is::<MeteredJsonHandler>());
+        assert!(engine
+            .parquet_handler()
+            .any_ref()
+            .is::<MeteredParquetHandler>());
+    }
+
+    /// Engine that pre-meters a single handler; lets each double-wrap test target one
+    /// guard without tripping the others.
+    struct PreMeteredEngine {
+        inner: StubEngine,
+        meter_storage: bool,
+        meter_json: bool,
+        meter_parquet: bool,
+    }
+
+    impl Engine for PreMeteredEngine {
         fn evaluation_handler(&self) -> Arc<dyn EvaluationHandler> {
-            self.0.evaluation_handler()
+            self.inner.evaluation_handler()
         }
         fn storage_handler(&self) -> Arc<dyn StorageHandler> {
-            Arc::new(crate::metrics::MeteredStorageHandler::new(
-                self.0.storage_handler(),
-            ))
+            if self.meter_storage {
+                Arc::new(crate::metrics::MeteredStorageHandler::new(
+                    self.inner.storage_handler(),
+                ))
+            } else {
+                self.inner.storage_handler()
+            }
         }
         fn json_handler(&self) -> Arc<dyn JsonHandler> {
-            self.0.json_handler()
+            if self.meter_json {
+                Arc::new(crate::metrics::MeteredJsonHandler::new(
+                    self.inner.json_handler(),
+                ))
+            } else {
+                self.inner.json_handler()
+            }
         }
         fn parquet_handler(&self) -> Arc<dyn ParquetHandler> {
-            self.0.parquet_handler()
+            if self.meter_parquet {
+                Arc::new(crate::metrics::MeteredParquetHandler::new(
+                    self.inner.parquet_handler(),
+                ))
+            } else {
+                self.inner.parquet_handler()
+            }
+        }
+    }
+
+    fn pre_metered(storage: bool, json: bool, parquet: bool) -> PreMeteredEngine {
+        PreMeteredEngine {
+            inner: StubEngine::new(),
+            meter_storage: storage,
+            meter_json: json,
+            meter_parquet: parquet,
         }
     }
 
     #[test]
     #[should_panic(expected = "storage_handler is already a MeteredStorageHandler")]
-    fn new_panics_when_inner_already_metered() {
-        let _ = MeteredDeltaEngine::new(Arc::new(AlreadyMeteredEngine(StubEngine::new())));
+    fn new_panics_when_inner_storage_already_metered() {
+        let _ = MeteredDeltaEngine::new(Arc::new(pre_metered(true, false, false)));
+    }
+
+    #[test]
+    #[should_panic(expected = "json_handler is already a MeteredJsonHandler")]
+    fn new_panics_when_inner_json_already_metered() {
+        let _ = MeteredDeltaEngine::new(Arc::new(pre_metered(false, true, false)));
+    }
+
+    #[test]
+    #[should_panic(expected = "parquet_handler is already a MeteredParquetHandler")]
+    fn new_panics_when_inner_parquet_already_metered() {
+        let _ = MeteredDeltaEngine::new(Arc::new(pre_metered(false, false, true)));
     }
 }

--- a/kernel/src/metrics/metered_engine.rs
+++ b/kernel/src/metrics/metered_engine.rs
@@ -92,10 +92,6 @@ mod tests {
     use crate::utils::test_utils::{install_thread_local_metrics_reporter, CapturingReporter};
     use crate::{DeltaResult, FileMeta, FileSlice};
 
-    // Use a stub engine so the wrapper sees an un-metered storage handler. `DefaultEngine`
-    // already exposes `MeteredStorageHandler` from `storage_handler()`, which would trip
-    // the double-wrap guard in `MeteredDeltaEngine::new`.
-
     /// Minimal storage handler used in tests: returns N preconfigured FileMeta items.
     #[derive(Debug)]
     struct StubStorageHandler {
@@ -206,8 +202,6 @@ mod tests {
 
     #[test]
     fn json_and_parquet_handlers_are_metered() {
-        use crate::metrics::{MeteredJsonHandler, MeteredParquetHandler};
-
         let engine = MeteredDeltaEngine::new(Arc::new(StubEngine::new()));
         assert!(engine.json_handler().any_ref().is::<MeteredJsonHandler>());
         assert!(engine

--- a/kernel/src/metrics/metered_engine.rs
+++ b/kernel/src/metrics/metered_engine.rs
@@ -22,8 +22,13 @@ pub struct MeteredDeltaEngine {
 }
 
 impl MeteredDeltaEngine {
-    /// Wrap `inner`. Debug-asserts that none of `inner`'s metered handlers are already
-    /// metered wrappers, so the resulting engine emits each span exactly once.
+    /// Wrap `inner`. Debug-asserts that none of `inner`'s handlers are already metered
+    /// wrappers, so the resulting engine emits each span exactly once.
+    ///
+    /// The check is shallow: it inspects the immediate concrete type returned by each
+    /// handler accessor and does not walk intermediate wrapper types. Wrapping a metered
+    /// handler behind a non-metered wrapper before re-wrapping (e.g.
+    /// `Metered(Foo(Metered(...)))`) silently double-counts.
     pub fn new(inner: Arc<dyn Engine>) -> Self {
         let inner_storage = inner.storage_handler();
         debug_assert!(
@@ -225,27 +230,21 @@ mod tests {
         }
         fn storage_handler(&self) -> Arc<dyn StorageHandler> {
             if self.meter_storage {
-                Arc::new(crate::metrics::MeteredStorageHandler::new(
-                    self.inner.storage_handler(),
-                ))
+                Arc::new(MeteredStorageHandler::new(self.inner.storage_handler()))
             } else {
                 self.inner.storage_handler()
             }
         }
         fn json_handler(&self) -> Arc<dyn JsonHandler> {
             if self.meter_json {
-                Arc::new(crate::metrics::MeteredJsonHandler::new(
-                    self.inner.json_handler(),
-                ))
+                Arc::new(MeteredJsonHandler::new(self.inner.json_handler()))
             } else {
                 self.inner.json_handler()
             }
         }
         fn parquet_handler(&self) -> Arc<dyn ParquetHandler> {
             if self.meter_parquet {
-                Arc::new(crate::metrics::MeteredParquetHandler::new(
-                    self.inner.parquet_handler(),
-                ))
+                Arc::new(MeteredParquetHandler::new(self.inner.parquet_handler()))
             } else {
                 self.inner.parquet_handler()
             }

--- a/kernel/src/metrics/metered_json.rs
+++ b/kernel/src/metrics/metered_json.rs
@@ -1,10 +1,7 @@
 //! [`MeteredJsonHandler`] wraps any [`JsonHandler`] so its `read_json_files` emits the
-//! kernel's standard `JsonReadCompleted` tracing span. `parse_json` and `write_json_file`
-//! pass through.
-//!
-//! Counts are known up-front from the `files: &[FileMeta]` argument, so the wrapper uses
-//! [`PrecountedMetricsIterator`] to emit `(num_files, bytes_read)` exactly once when the
-//! returned iterator is exhausted or dropped.
+//! kernel's standard `JsonReadCompleted` span, carrying `(num_files, bytes_read)` exactly
+//! once when the returned iterator is exhausted or dropped. `parse_json` and
+//! `write_json_file` pass through.
 
 use std::sync::Arc;
 
@@ -84,22 +81,20 @@ impl JsonHandler for MeteredJsonHandler {
 mod tests {
     use std::sync::Arc;
 
-    use bytes::Bytes;
     use url::Url;
 
     use super::*;
+    use crate::arrow::array::RecordBatch;
+    use crate::arrow::datatypes::Schema;
     use crate::engine::arrow_data::ArrowEngineData;
     use crate::metrics::MetricEvent;
+    use crate::schema::{DataType, StructField, StructType};
     use crate::utils::test_utils::{install_thread_local_metrics_reporter, CapturingReporter};
-    use crate::FileSlice;
 
-    /// Stub `JsonHandler` that returns a fixed number of empty batches from `read_json_files`.
     #[derive(Debug)]
     struct StubJsonHandler;
 
     fn empty_batch() -> Box<dyn EngineData> {
-        use crate::arrow::array::RecordBatch;
-        use crate::arrow::datatypes::Schema;
         Box::new(ArrowEngineData::new(RecordBatch::new_empty(Arc::new(
             Schema::empty(),
         ))))
@@ -148,7 +143,6 @@ mod tests {
     }
 
     fn delta_schema() -> SchemaRef {
-        use crate::schema::{DataType, StructField, StructType};
         Arc::new(StructType::try_new([StructField::nullable("x", DataType::INTEGER)]).unwrap())
     }
 
@@ -177,14 +171,56 @@ mod tests {
     }
 
     #[test]
+    fn read_json_files_emits_on_drop_without_consumption() {
+        let (reporter, _guard) = install_capture();
+        let inner: Arc<dyn JsonHandler> = Arc::new(StubJsonHandler);
+        let handler = MeteredJsonHandler::new(inner);
+
+        let files = vec![fake_file("0.json", 100), fake_file("1.json", 50)];
+        {
+            let _iter = handler
+                .read_json_files(&files, delta_schema(), None)
+                .unwrap();
+        }
+
+        let events = reporter.events();
+        let read = events
+            .iter()
+            .find(|e| matches!(e, MetricEvent::JsonReadCompleted(_)))
+            .expect("expected JsonReadCompleted event on drop");
+        let MetricEvent::JsonReadCompleted(e) = read else {
+            unreachable!();
+        };
+        assert_eq!(e.num_files, 2);
+        assert_eq!(e.bytes_read, 150);
+    }
+
+    #[test]
+    fn read_json_files_emits_zero_event_for_empty_input() {
+        let (reporter, _guard) = install_capture();
+        let inner: Arc<dyn JsonHandler> = Arc::new(StubJsonHandler);
+        let handler = MeteredJsonHandler::new(inner);
+
+        let iter = handler.read_json_files(&[], delta_schema(), None).unwrap();
+        let _: Vec<_> = iter.collect();
+
+        let events = reporter.events();
+        let read = events
+            .iter()
+            .find(|e| matches!(e, MetricEvent::JsonReadCompleted(_)))
+            .expect("expected zero-valued JsonReadCompleted");
+        let MetricEvent::JsonReadCompleted(e) = read else {
+            unreachable!();
+        };
+        assert_eq!(e.num_files, 0);
+        assert_eq!(e.bytes_read, 0);
+    }
+
+    #[test]
     #[should_panic(expected = "wraps another MeteredJsonHandler")]
     fn new_panics_on_double_wrap() {
         let inner: Arc<dyn JsonHandler> = Arc::new(StubJsonHandler);
         let once: Arc<dyn JsonHandler> = Arc::new(MeteredJsonHandler::new(inner));
         let _twice = MeteredJsonHandler::new(once);
     }
-
-    // Silences unused-warning in this `cfg(test)` module.
-    #[allow(dead_code)]
-    fn _force_use(_: Bytes, _: FileSlice) {}
 }

--- a/kernel/src/metrics/metered_json.rs
+++ b/kernel/src/metrics/metered_json.rs
@@ -1,0 +1,190 @@
+//! [`MeteredJsonHandler`] wraps any [`JsonHandler`] so its `read_json_files` emits the
+//! kernel's standard `JsonReadCompleted` tracing span. `parse_json` and `write_json_file`
+//! pass through.
+//!
+//! Counts are known up-front from the `files: &[FileMeta]` argument, so the wrapper uses
+//! [`PrecountedMetricsIterator`] to emit `(num_files, bytes_read)` exactly once when the
+//! returned iterator is exhausted or dropped.
+
+use std::sync::Arc;
+
+use crate::metrics::events::emit_json_read_completed;
+use crate::metrics::PrecountedMetricsIterator;
+use crate::schema::SchemaRef;
+use crate::{
+    DeltaResult, DeltaResultIterator, EngineData, FileDataReadResultIterator, FileMeta,
+    FilteredEngineData, JsonHandler, PredicateRef,
+};
+
+/// Decorator over an engine-provided `Arc<dyn JsonHandler>` that emits a
+/// `JsonReadCompleted` span on every `read_json_files` call. `parse_json` and
+/// `write_json_file` are pass-through and emit nothing.
+pub struct MeteredJsonHandler {
+    inner: Arc<dyn JsonHandler>,
+}
+
+impl MeteredJsonHandler {
+    /// Wrap `inner`. Debug-asserts that `inner` is not already a [`MeteredJsonHandler`]
+    /// so spans are emitted exactly once.
+    pub fn new(inner: Arc<dyn JsonHandler>) -> Self {
+        debug_assert!(
+            !inner.any_ref().is::<MeteredJsonHandler>(),
+            "MeteredJsonHandler wraps another MeteredJsonHandler; \
+             remove the outer wrap to avoid double-counting metrics",
+        );
+        Self { inner }
+    }
+}
+
+impl std::fmt::Debug for MeteredJsonHandler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MeteredJsonHandler").finish_non_exhaustive()
+    }
+}
+
+impl JsonHandler for MeteredJsonHandler {
+    fn parse_json(
+        &self,
+        json_strings: Box<dyn EngineData>,
+        output_schema: SchemaRef,
+    ) -> DeltaResult<Box<dyn EngineData>> {
+        self.inner.parse_json(json_strings, output_schema)
+    }
+
+    fn read_json_files(
+        &self,
+        files: &[FileMeta],
+        physical_schema: SchemaRef,
+        predicate: Option<PredicateRef>,
+    ) -> DeltaResult<FileDataReadResultIterator> {
+        let num_files = files.len() as u64;
+        let bytes_read = files.iter().map(|f| f.size).sum();
+        let inner = self
+            .inner
+            .read_json_files(files, physical_schema, predicate)?;
+        Ok(Box::new(PrecountedMetricsIterator::new(
+            inner,
+            num_files,
+            bytes_read,
+            emit_json_read_completed,
+        )))
+    }
+
+    fn write_json_file(
+        &self,
+        path: &url::Url,
+        data: DeltaResultIterator<'_, FilteredEngineData>,
+        overwrite: bool,
+    ) -> DeltaResult<()> {
+        self.inner.write_json_file(path, data, overwrite)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use bytes::Bytes;
+    use url::Url;
+
+    use super::*;
+    use crate::engine::arrow_data::ArrowEngineData;
+    use crate::metrics::MetricEvent;
+    use crate::utils::test_utils::{install_thread_local_metrics_reporter, CapturingReporter};
+    use crate::FileSlice;
+
+    /// Stub `JsonHandler` that returns a fixed number of empty batches from `read_json_files`.
+    #[derive(Debug)]
+    struct StubJsonHandler;
+
+    fn empty_batch() -> Box<dyn EngineData> {
+        use crate::arrow::array::RecordBatch;
+        use crate::arrow::datatypes::Schema;
+        Box::new(ArrowEngineData::new(RecordBatch::new_empty(Arc::new(
+            Schema::empty(),
+        ))))
+    }
+
+    impl JsonHandler for StubJsonHandler {
+        fn parse_json(
+            &self,
+            _json_strings: Box<dyn EngineData>,
+            _output_schema: SchemaRef,
+        ) -> DeltaResult<Box<dyn EngineData>> {
+            Ok(empty_batch())
+        }
+
+        fn read_json_files(
+            &self,
+            _files: &[FileMeta],
+            _physical_schema: SchemaRef,
+            _predicate: Option<PredicateRef>,
+        ) -> DeltaResult<FileDataReadResultIterator> {
+            Ok(Box::new(std::iter::empty()))
+        }
+
+        fn write_json_file(
+            &self,
+            _path: &Url,
+            _data: DeltaResultIterator<'_, FilteredEngineData>,
+            _overwrite: bool,
+        ) -> DeltaResult<()> {
+            Ok(())
+        }
+    }
+
+    fn fake_file(name: &str, size: u64) -> FileMeta {
+        FileMeta {
+            location: Url::parse(&format!("memory:///_delta_log/{name}")).unwrap(),
+            last_modified: 0,
+            size,
+        }
+    }
+
+    fn install_capture() -> (Arc<CapturingReporter>, tracing::subscriber::DefaultGuard) {
+        let reporter = Arc::new(CapturingReporter::default());
+        let guard = install_thread_local_metrics_reporter(reporter.clone());
+        (reporter, guard)
+    }
+
+    fn delta_schema() -> SchemaRef {
+        use crate::schema::{DataType, StructField, StructType};
+        Arc::new(StructType::try_new([StructField::nullable("x", DataType::INTEGER)]).unwrap())
+    }
+
+    #[test]
+    fn read_json_files_emits_json_read_completed() {
+        let (reporter, _guard) = install_capture();
+        let inner: Arc<dyn JsonHandler> = Arc::new(StubJsonHandler);
+        let handler = MeteredJsonHandler::new(inner);
+
+        let files = vec![fake_file("0.json", 100), fake_file("1.json", 50)];
+        let iter = handler
+            .read_json_files(&files, delta_schema(), None)
+            .unwrap();
+        let _: Vec<_> = iter.collect();
+
+        let events = reporter.events();
+        let read = events
+            .iter()
+            .find(|e| matches!(e, MetricEvent::JsonReadCompleted(_)))
+            .expect("expected JsonReadCompleted event");
+        let MetricEvent::JsonReadCompleted(e) = read else {
+            unreachable!();
+        };
+        assert_eq!(e.num_files, 2);
+        assert_eq!(e.bytes_read, 150);
+    }
+
+    #[test]
+    #[should_panic(expected = "wraps another MeteredJsonHandler")]
+    fn new_panics_on_double_wrap() {
+        let inner: Arc<dyn JsonHandler> = Arc::new(StubJsonHandler);
+        let once: Arc<dyn JsonHandler> = Arc::new(MeteredJsonHandler::new(inner));
+        let _twice = MeteredJsonHandler::new(once);
+    }
+
+    // Silences unused-warning in this `cfg(test)` module.
+    #[allow(dead_code)]
+    fn _force_use(_: Bytes, _: FileSlice) {}
+}

--- a/kernel/src/metrics/metered_parquet.rs
+++ b/kernel/src/metrics/metered_parquet.rs
@@ -1,0 +1,170 @@
+//! [`MeteredParquetHandler`] wraps any [`ParquetHandler`] so its `read_parquet_files`
+//! emits the kernel's standard `ParquetReadCompleted` tracing span.
+//! `read_parquet_footer` and `write_parquet_file` pass through.
+//!
+//! Counts are known up-front from the `files: &[FileMeta]` argument, so the wrapper uses
+//! [`PrecountedMetricsIterator`] to emit `(num_files, bytes_read)` exactly once when the
+//! returned iterator is exhausted or dropped.
+
+use std::sync::Arc;
+
+use crate::metrics::events::emit_parquet_read_completed;
+use crate::metrics::PrecountedMetricsIterator;
+use crate::schema::SchemaRef;
+use crate::{
+    DeltaResult, DeltaResultIteratorStatic, EngineData, FileDataReadResultIterator, FileMeta,
+    ParquetFooter, ParquetHandler, PredicateRef,
+};
+
+/// Decorator over an engine-provided `Arc<dyn ParquetHandler>` that emits a
+/// `ParquetReadCompleted` span on every `read_parquet_files` call.
+/// `read_parquet_footer` and `write_parquet_file` are pass-through and emit nothing.
+pub struct MeteredParquetHandler {
+    inner: Arc<dyn ParquetHandler>,
+}
+
+impl MeteredParquetHandler {
+    /// Wrap `inner`. Debug-asserts that `inner` is not already a [`MeteredParquetHandler`]
+    /// so spans are emitted exactly once.
+    pub fn new(inner: Arc<dyn ParquetHandler>) -> Self {
+        debug_assert!(
+            !inner.any_ref().is::<MeteredParquetHandler>(),
+            "MeteredParquetHandler wraps another MeteredParquetHandler; \
+             remove the outer wrap to avoid double-counting metrics",
+        );
+        Self { inner }
+    }
+}
+
+impl std::fmt::Debug for MeteredParquetHandler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MeteredParquetHandler")
+            .finish_non_exhaustive()
+    }
+}
+
+impl ParquetHandler for MeteredParquetHandler {
+    fn read_parquet_files(
+        &self,
+        files: &[FileMeta],
+        physical_schema: SchemaRef,
+        predicate: Option<PredicateRef>,
+    ) -> DeltaResult<FileDataReadResultIterator> {
+        let num_files = files.len() as u64;
+        let bytes_read = files.iter().map(|f| f.size).sum();
+        let inner = self
+            .inner
+            .read_parquet_files(files, physical_schema, predicate)?;
+        Ok(Box::new(PrecountedMetricsIterator::new(
+            inner,
+            num_files,
+            bytes_read,
+            emit_parquet_read_completed,
+        )))
+    }
+
+    fn write_parquet_file(
+        &self,
+        location: url::Url,
+        data: DeltaResultIteratorStatic<Box<dyn EngineData>>,
+    ) -> DeltaResult<()> {
+        self.inner.write_parquet_file(location, data)
+    }
+
+    fn read_parquet_footer(&self, file: &FileMeta) -> DeltaResult<ParquetFooter> {
+        self.inner.read_parquet_footer(file)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use url::Url;
+
+    use super::*;
+    use crate::engine::arrow_data::ArrowEngineData;
+    use crate::metrics::MetricEvent;
+    use crate::utils::test_utils::{install_thread_local_metrics_reporter, CapturingReporter};
+
+    #[derive(Debug)]
+    struct StubParquetHandler;
+
+    impl ParquetHandler for StubParquetHandler {
+        fn read_parquet_files(
+            &self,
+            _files: &[FileMeta],
+            _physical_schema: SchemaRef,
+            _predicate: Option<PredicateRef>,
+        ) -> DeltaResult<FileDataReadResultIterator> {
+            Ok(Box::new(std::iter::empty()))
+        }
+
+        fn write_parquet_file(
+            &self,
+            _location: Url,
+            _data: DeltaResultIteratorStatic<Box<dyn EngineData>>,
+        ) -> DeltaResult<()> {
+            Ok(())
+        }
+
+        fn read_parquet_footer(&self, _file: &FileMeta) -> DeltaResult<ParquetFooter> {
+            unreachable!("not exercised in these tests")
+        }
+    }
+
+    fn fake_file(name: &str, size: u64) -> FileMeta {
+        FileMeta {
+            location: Url::parse(&format!("memory:///_delta_log/{name}")).unwrap(),
+            last_modified: 0,
+            size,
+        }
+    }
+
+    fn install_capture() -> (Arc<CapturingReporter>, tracing::subscriber::DefaultGuard) {
+        let reporter = Arc::new(CapturingReporter::default());
+        let guard = install_thread_local_metrics_reporter(reporter.clone());
+        (reporter, guard)
+    }
+
+    fn delta_schema() -> SchemaRef {
+        use crate::schema::{DataType, StructField, StructType};
+        Arc::new(StructType::try_new([StructField::nullable("x", DataType::INTEGER)]).unwrap())
+    }
+
+    #[test]
+    fn read_parquet_files_emits_parquet_read_completed() {
+        let (reporter, _guard) = install_capture();
+        let inner: Arc<dyn ParquetHandler> = Arc::new(StubParquetHandler);
+        let handler = MeteredParquetHandler::new(inner);
+
+        let files = vec![fake_file("a.parquet", 256), fake_file("b.parquet", 1024)];
+        let iter = handler
+            .read_parquet_files(&files, delta_schema(), None)
+            .unwrap();
+        let _: Vec<_> = iter.collect();
+
+        let events = reporter.events();
+        let read = events
+            .iter()
+            .find(|e| matches!(e, MetricEvent::ParquetReadCompleted(_)))
+            .expect("expected ParquetReadCompleted event");
+        let MetricEvent::ParquetReadCompleted(e) = read else {
+            unreachable!();
+        };
+        assert_eq!(e.num_files, 2);
+        assert_eq!(e.bytes_read, 1280);
+    }
+
+    #[test]
+    #[should_panic(expected = "wraps another MeteredParquetHandler")]
+    fn new_panics_on_double_wrap() {
+        let inner: Arc<dyn ParquetHandler> = Arc::new(StubParquetHandler);
+        let once: Arc<dyn ParquetHandler> = Arc::new(MeteredParquetHandler::new(inner));
+        let _twice = MeteredParquetHandler::new(once);
+    }
+
+    // Silence unused-import warning.
+    #[allow(dead_code)]
+    fn _force_use(_: ArrowEngineData) {}
+}

--- a/kernel/src/metrics/metered_parquet.rs
+++ b/kernel/src/metrics/metered_parquet.rs
@@ -1,10 +1,7 @@
 //! [`MeteredParquetHandler`] wraps any [`ParquetHandler`] so its `read_parquet_files`
-//! emits the kernel's standard `ParquetReadCompleted` tracing span.
-//! `read_parquet_footer` and `write_parquet_file` pass through.
-//!
-//! Counts are known up-front from the `files: &[FileMeta]` argument, so the wrapper uses
-//! [`PrecountedMetricsIterator`] to emit `(num_files, bytes_read)` exactly once when the
-//! returned iterator is exhausted or dropped.
+//! emits the kernel's standard `ParquetReadCompleted` span, carrying
+//! `(num_files, bytes_read)` exactly once when the returned iterator is exhausted or
+//! dropped. `read_parquet_footer` and `write_parquet_file` pass through.
 
 use std::sync::Arc;
 
@@ -83,8 +80,8 @@ mod tests {
     use url::Url;
 
     use super::*;
-    use crate::engine::arrow_data::ArrowEngineData;
     use crate::metrics::MetricEvent;
+    use crate::schema::{DataType, StructField, StructType};
     use crate::utils::test_utils::{install_thread_local_metrics_reporter, CapturingReporter};
 
     #[derive(Debug)]
@@ -128,7 +125,6 @@ mod tests {
     }
 
     fn delta_schema() -> SchemaRef {
-        use crate::schema::{DataType, StructField, StructType};
         Arc::new(StructType::try_new([StructField::nullable("x", DataType::INTEGER)]).unwrap())
     }
 
@@ -157,14 +153,58 @@ mod tests {
     }
 
     #[test]
+    fn read_parquet_files_emits_on_drop_without_consumption() {
+        let (reporter, _guard) = install_capture();
+        let inner: Arc<dyn ParquetHandler> = Arc::new(StubParquetHandler);
+        let handler = MeteredParquetHandler::new(inner);
+
+        let files = vec![fake_file("a.parquet", 256), fake_file("b.parquet", 1024)];
+        {
+            let _iter = handler
+                .read_parquet_files(&files, delta_schema(), None)
+                .unwrap();
+        }
+
+        let events = reporter.events();
+        let read = events
+            .iter()
+            .find(|e| matches!(e, MetricEvent::ParquetReadCompleted(_)))
+            .expect("expected ParquetReadCompleted event on drop");
+        let MetricEvent::ParquetReadCompleted(e) = read else {
+            unreachable!();
+        };
+        assert_eq!(e.num_files, 2);
+        assert_eq!(e.bytes_read, 1280);
+    }
+
+    #[test]
+    fn read_parquet_files_emits_zero_event_for_empty_input() {
+        let (reporter, _guard) = install_capture();
+        let inner: Arc<dyn ParquetHandler> = Arc::new(StubParquetHandler);
+        let handler = MeteredParquetHandler::new(inner);
+
+        let iter = handler
+            .read_parquet_files(&[], delta_schema(), None)
+            .unwrap();
+        let _: Vec<_> = iter.collect();
+
+        let events = reporter.events();
+        let read = events
+            .iter()
+            .find(|e| matches!(e, MetricEvent::ParquetReadCompleted(_)))
+            .expect("expected zero-valued ParquetReadCompleted");
+        let MetricEvent::ParquetReadCompleted(e) = read else {
+            unreachable!();
+        };
+        assert_eq!(e.num_files, 0);
+        assert_eq!(e.bytes_read, 0);
+    }
+
+    #[test]
     #[should_panic(expected = "wraps another MeteredParquetHandler")]
     fn new_panics_on_double_wrap() {
         let inner: Arc<dyn ParquetHandler> = Arc::new(StubParquetHandler);
         let once: Arc<dyn ParquetHandler> = Arc::new(MeteredParquetHandler::new(inner));
         let _twice = MeteredParquetHandler::new(once);
     }
-
-    // Silence unused-import warning.
-    #[allow(dead_code)]
-    fn _force_use(_: ArrowEngineData) {}
 }

--- a/kernel/src/metrics/mod.rs
+++ b/kernel/src/metrics/mod.rs
@@ -58,12 +58,14 @@
 //!
 //! # Handler Metrics
 //!
-//! Storage, JSON, and Parquet handler operations emit one event per call:
+//! Storage, JSON, and Parquet handler operations emit one event per read or copy
+//! operation, fired when the returned iterator is exhausted or dropped:
 //! `StorageListCompleted` / `StorageReadCompleted` / `StorageCopyCompleted` for storage,
-//! `JsonReadCompleted` for JSON `read_*_files`, and `ParquetReadCompleted` for Parquet
-//! `read_*_files`. `DefaultEngine` wraps its three handlers in [`MeteredStorageHandler`],
-//! [`MeteredJsonHandler`], and [`MeteredParquetHandler`] at construction; any other
-//! engine gets the same coverage by wrapping its [`Engine`] in [`MeteredDeltaEngine`].
+//! `JsonReadCompleted` for `JsonHandler::read_json_files`, and `ParquetReadCompleted`
+//! for `ParquetHandler::read_parquet_files`. `DefaultEngine` wraps its three handlers
+//! in [`MeteredStorageHandler`], [`MeteredJsonHandler`], and [`MeteredParquetHandler`]
+//! at construction; any other engine gets the same coverage by wrapping its [`Engine`]
+//! in [`MeteredDeltaEngine`].
 //!
 //! These metrics are standalone and track aggregate handler performance without
 //! correlating to specific Snapshot/Transaction operations.

--- a/kernel/src/metrics/mod.rs
+++ b/kernel/src/metrics/mod.rs
@@ -56,23 +56,25 @@
 //! }
 //! ```
 //!
-//! # Storage Metrics
+//! # Handler Metrics
 //!
-//! Storage operations (list, read, copy) emit `StorageListCompleted`,
-//! `StorageReadCompleted`, and `StorageCopyCompleted` events tracking latencies at the
-//! storage layer. `DefaultEngine` wraps its storage handler in [`MeteredStorageHandler`]
-//! at construction; any other engine gets the same coverage by wrapping its [`Engine`]
-//! in [`MeteredDeltaEngine`] at construction.
+//! Storage, JSON, and Parquet handler operations emit one event per call:
+//! `StorageListCompleted` / `StorageReadCompleted` / `StorageCopyCompleted` for storage,
+//! `JsonReadCompleted` for JSON `read_*_files`, and `ParquetReadCompleted` for Parquet
+//! `read_*_files`. `DefaultEngine` wraps its three handlers in [`MeteredStorageHandler`],
+//! [`MeteredJsonHandler`], and [`MeteredParquetHandler`] at construction; any other
+//! engine gets the same coverage by wrapping its [`Engine`] in [`MeteredDeltaEngine`].
 //!
-//! These metrics are standalone and track aggregate storage performance without
+//! These metrics are standalone and track aggregate handler performance without
 //! correlating to specific Snapshot/Transaction operations.
 //!
 //! [`Engine`]: crate::Engine
 
 pub(crate) mod events;
 mod metered_engine;
+mod metered_json;
+mod metered_parquet;
 mod metered_storage;
-#[cfg(feature = "default-engine-base")]
 mod precounted_metrics_iterator;
 pub(crate) mod reporter;
 mod streaming_metrics_iterator;
@@ -87,8 +89,9 @@ pub use events::{
     StorageReadCompleted,
 };
 pub use metered_engine::MeteredDeltaEngine;
+pub use metered_json::MeteredJsonHandler;
+pub use metered_parquet::MeteredParquetHandler;
 pub use metered_storage::MeteredStorageHandler;
-#[cfg(feature = "default-engine-base")]
 pub(crate) use precounted_metrics_iterator::PrecountedMetricsIterator;
 pub use reporter::{LoggingMetricsReporter, MetricsReporter, ReportGeneratorLayer};
 pub(crate) use streaming_metrics_iterator::{emit_storage_span, MetricsIterator};

--- a/kernel/tests/integration/write/types.rs
+++ b/kernel/tests/integration/write/types.rs
@@ -12,14 +12,12 @@ use delta_kernel::arrow::record_batch::RecordBatch;
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::engine::arrow_conversion::{TryFromKernel, TryIntoArrow as _};
 use delta_kernel::engine::arrow_data::ArrowEngineData;
-use delta_kernel::engine::default::executor::tokio::TokioBackgroundExecutor;
-use delta_kernel::engine::default::parquet::DefaultParquetHandler;
 use delta_kernel::expressions::Scalar;
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::ObjectStoreExt as _;
 use delta_kernel::schema::{ArrayType, DataType, MapType, SchemaRef, StructField, StructType};
 use delta_kernel::transaction::create_table::create_table as kernel_create_table;
-use delta_kernel::{Engine, Error as KernelError, Snapshot};
+use delta_kernel::{Error as KernelError, Snapshot};
 use itertools::Itertools;
 use rstest::rstest;
 use serde_json::Deserializer;
@@ -267,10 +265,7 @@ async fn test_append_variant(
     let write_context = Arc::new(txn.unpartitioned_write_context().unwrap());
 
     let add_files_metadata = (*engine)
-        .parquet_handler()
-        .as_any()
-        .downcast_ref::<DefaultParquetHandler<TokioBackgroundExecutor>>()
-        .unwrap()
+        .default_parquet_handler()
         .write_parquet_file(Box::new(ArrowEngineData::new(data.clone())), &write_context)
         .await?;
 
@@ -434,10 +429,7 @@ async fn test_shredded_variant_read_rejection() -> Result<(), Box<dyn std::error
     let write_context = Arc::new(txn.unpartitioned_write_context().unwrap());
 
     let add_files_metadata = (*engine)
-        .parquet_handler()
-        .as_any()
-        .downcast_ref::<DefaultParquetHandler<TokioBackgroundExecutor>>()
-        .unwrap()
+        .default_parquet_handler()
         .write_parquet_file(Box::new(ArrowEngineData::new(data.clone())), &write_context)
         .await?;
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Follow-up to #2623. Same decorator pattern, now applied to JSON and Parquet.

- New `MeteredJsonHandler` and `MeteredParquetHandler` wrap any handler and emit `JsonReadCompleted` / `ParquetReadCompleted` once per `read_*_files` call. Other trait methods pass through.
- `MeteredDeltaEngine` now wraps all three handlers (storage + JSON + Parquet), each guarded against double-wrap.
- `DefaultJsonHandler` and `DefaultParquetHandler` no longer self-meter. `DefaultEngine` wraps them at construction, so default-engine users see no behavior change.

A custom-engine consumer gets all five events with`Arc::new(MeteredDeltaEngine::new(inner))`.

## How was this change tested?

New unit tests in `metered_json.rs` and `metered_parquet.rs`
