### PR TITLE
perf: use foldhash for log-replay file dedup set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,6 +1277,7 @@ dependencies = [
  "criterion",
  "delta_kernel",
  "delta_kernel_derive",
+ "foldhash",
  "futures",
  "hdfs-native",
  "hdfs-native-object-store",

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -43,6 +43,9 @@ delta_kernel_derive = { path = "../derive-macros", version = "0.24.0" }
 bytes = "1.10"
 chrono = "0.4.41"
 crc = "3.2.2"
+# Fast non-cryptographic hasher for log-replay dedup. Per-process random seeding
+# preserves HashDoS resistance for path keys read from the Delta log.
+foldhash = "0.1"
 indexmap = "2.10.0"
 itertools = "0.14"
 percent-encoding = "2"

--- a/kernel/src/action_reconciliation/log_replay.rs
+++ b/kernel/src/action_reconciliation/log_replay.rs
@@ -36,7 +36,7 @@ use std::sync::{Arc, LazyLock};
 use crate::engine_data::{FilteredEngineData, GetData, RowVisitor, TypedGetData as _};
 use crate::log_replay::deduplicator::{Deduplicator as _, FileActionInfo};
 use crate::log_replay::{
-    ActionsBatch, FileActionDeduplicator, FileActionKey, HasSelectionVector, LogReplayProcessor,
+    ActionsBatch, FileActionDeduplicator, HasSelectionVector, LogReplayProcessor, SeenFileKeys,
 };
 use crate::scan::data_skipping::DataSkippingFilter;
 use crate::schema::{column_name, ColumnName, ColumnNamesAndTypes, DataType};
@@ -48,7 +48,7 @@ use crate::{DeltaResult, DeltaResultIteratorStatic, Error};
 pub(crate) struct ActionReconciliationProcessor {
     /// Tracks file actions that have been seen during log replay to avoid duplicates.
     /// Contains (data file path, dv_unique_id) pairs as `FileActionKey` instances.
-    seen_file_keys: HashSet<FileActionKey>,
+    seen_file_keys: SeenFileKeys,
     /// Indicates whether a protocol action has been seen in the log.
     seen_protocol: bool,
     /// Indicates whether a metadata action has been seen in the log.
@@ -373,7 +373,7 @@ impl ActionReconciliationVisitor<'_> {
 
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new<'seen>(
-        seen_file_keys: &'seen mut HashSet<FileActionKey>,
+        seen_file_keys: &'seen mut SeenFileKeys,
         is_log_batch: bool,
         selection_vector: Vec<bool>,
         minimum_file_retention_timestamp: i64,
@@ -719,7 +719,7 @@ mod tests {
     #[test]
     fn test_action_reconciliation_visitor() -> DeltaResult<()> {
         let data = action_batch();
-        let mut seen_file_keys = HashSet::new();
+        let mut seen_file_keys = SeenFileKeys::default();
         let mut seen_txns = HashSet::new();
         let mut seen_domains = HashSet::new();
         let mut visitor = ActionReconciliationVisitor::new(
@@ -778,7 +778,7 @@ mod tests {
         .into();
         let batch = parse_json_batch(json_strings);
 
-        let mut seen_file_keys = HashSet::new();
+        let mut seen_file_keys = SeenFileKeys::default();
         let mut seen_txns = HashSet::new();
         let mut seen_domains = HashSet::new();
         let mut visitor = ActionReconciliationVisitor::new(
@@ -811,7 +811,7 @@ mod tests {
         .into();
         let batch = parse_json_batch(json_strings);
 
-        let mut seen_file_keys = HashSet::new();
+        let mut seen_file_keys = SeenFileKeys::default();
         let mut seen_txns = HashSet::new();
         let mut seen_domains = HashSet::new();
         let mut visitor = ActionReconciliationVisitor::new(
@@ -852,7 +852,7 @@ mod tests {
         .into();
         let batch = parse_json_batch(json_strings);
 
-        let mut seen_file_keys = HashSet::new();
+        let mut seen_file_keys = SeenFileKeys::default();
         let mut seen_txns = HashSet::new();
         let mut seen_domains = HashSet::new();
         let mut visitor = ActionReconciliationVisitor::new(
@@ -887,7 +887,7 @@ mod tests {
         let batch = parse_json_batch(json_strings);
 
         // Pre-populate with txn app1
-        let mut seen_file_keys = HashSet::new();
+        let mut seen_file_keys = SeenFileKeys::default();
         let mut seen_txns = HashSet::new();
         let mut seen_domains = HashSet::new();
         seen_txns.insert("app1".to_string());
@@ -929,7 +929,7 @@ mod tests {
         .into();
         let batch = parse_json_batch(json_strings);
 
-        let mut seen_file_keys = HashSet::new();
+        let mut seen_file_keys = SeenFileKeys::default();
         let mut seen_txns = HashSet::new();
         let mut seen_domains = HashSet::new();
         let mut visitor = ActionReconciliationVisitor::new(
@@ -1089,7 +1089,7 @@ mod tests {
         .into();
         let batch = parse_json_batch(json_strings);
 
-        let mut seen_file_keys = HashSet::new();
+        let mut seen_file_keys = SeenFileKeys::default();
         let mut seen_txns = HashSet::new();
         let mut seen_domains = HashSet::new();
         let mut visitor = ActionReconciliationVisitor::new(
@@ -1247,7 +1247,7 @@ mod tests {
 
     /// Helper function to create a standard action reconciliation visitor for error testing
     fn create_test_visitor<'a>(
-        seen_file_keys: &'a mut HashSet<FileActionKey>,
+        seen_file_keys: &'a mut SeenFileKeys,
         seen_txns: &'a mut HashSet<String>,
         seen_domains: &'a mut HashSet<String>,
         txn_expiration_timestamp: Option<i64>,
@@ -1285,7 +1285,7 @@ mod tests {
     #[test]
     fn test_action_reconciliation_visitor_validation_and_type_errors() {
         // Test 1: Wrong getter count validation
-        let mut seen_file_keys = HashSet::new();
+        let mut seen_file_keys = SeenFileKeys::default();
         let mut seen_txns = HashSet::new();
         let mut seen_domains = HashSet::new();
         let mut visitor =
@@ -1313,7 +1313,7 @@ mod tests {
         ];
 
         for (getter_index, field_name, error_type, expected_error_text) in test_cases {
-            let mut seen_file_keys = HashSet::new();
+            let mut seen_file_keys = SeenFileKeys::default();
             let mut seen_txns = HashSet::new();
             let mut seen_domains = HashSet::new();
             let mut visitor =
@@ -1333,7 +1333,7 @@ mod tests {
     #[test]
     fn test_action_reconciliation_visitor_complex_field_errors() {
         // Test txn.lastUpdated with retention enabled
-        let mut seen_file_keys = HashSet::new();
+        let mut seen_file_keys = SeenFileKeys::default();
         let mut seen_txns = HashSet::new();
         let mut seen_domains = HashSet::new();
         let mut visitor = create_test_visitor(
@@ -1362,7 +1362,7 @@ mod tests {
         assert!(err_str.contains("lastUpdated is not of type i64"));
 
         // Test remove.deletionTimestamp
-        let mut seen_file_keys = HashSet::new();
+        let mut seen_file_keys = SeenFileKeys::default();
         let mut seen_txns = HashSet::new();
         let mut seen_domains = HashSet::new();
         let mut visitor =

--- a/kernel/src/incremental_scan/mod.rs
+++ b/kernel/src/incremental_scan/mod.rs
@@ -8,7 +8,7 @@ use crate::actions::{Add, Remove, ADD_NAME, REMOVE_NAME};
 use crate::engine_data::{FilteredEngineData, GetData, RowVisitor};
 use crate::expressions::{column_name, ColumnName};
 use crate::log_replay::deduplicator::{Deduplicator, FileActionInfo};
-use crate::log_replay::{FileActionDeduplicator, FileActionKey};
+use crate::log_replay::{FileActionDeduplicator, FileActionKey, SeenFileKeys};
 use crate::schema::{ColumnNamesAndTypes, DataType, SchemaRef, StructField, StructType, ToSchema};
 use crate::snapshot::SnapshotRef;
 use crate::table_features::Operation;
@@ -132,7 +132,7 @@ impl IncrementalScanBuilder {
             base_version: self.base_version,
             target_version,
             actions,
-            seen_file_keys: HashSet::new(),
+            seen_file_keys: SeenFileKeys::default(),
             live_adds: HashSet::new(),
             removes: HashSet::new(),
             errored: false,
@@ -160,7 +160,7 @@ pub struct IncrementalScanStream {
     base_version: Version,
     target_version: Version,
     actions: FileDataReadResultIterator,
-    seen_file_keys: HashSet<FileActionKey>,
+    seen_file_keys: SeenFileKeys,
     live_adds: HashSet<FileActionKey>,
     removes: HashSet<FileActionKey>,
     errored: bool,
@@ -479,7 +479,7 @@ impl std::fmt::Debug for IncrementalListingAgainstBase {
 /// rows for this batch, or `None` if no Adds survived dedup in this batch.
 fn process_batch(
     batch: Box<dyn EngineData>,
-    seen_file_keys: &mut HashSet<FileActionKey>,
+    seen_file_keys: &mut SeenFileKeys,
     live_adds: &mut HashSet<FileActionKey>,
     removes: &mut HashSet<FileActionKey>,
 ) -> DeltaResult<Option<FilteredEngineData>> {

--- a/kernel/src/log_replay/deduplicator.rs
+++ b/kernel/src/log_replay/deduplicator.rs
@@ -10,13 +10,11 @@
 //!
 //! [`FileActionDeduplicator`]: crate::log_replay::FileActionDeduplicator
 
-use std::collections::HashSet;
-
 use tracing::warn;
 
 use crate::actions::deletion_vector::DeletionVectorDescriptor;
 use crate::engine_data::{GetData, TypedGetData};
-use crate::log_replay::FileActionKey;
+use crate::log_replay::{FileActionKey, SeenFileKeys};
 use crate::DeltaResult;
 
 /// Information we want to return to the add-dedup about file related actions
@@ -89,7 +87,7 @@ pub(crate) trait Deduplicator {
 /// [`FileActionDeduplicator`]: crate::log_replay::FileActionDeduplicator
 #[allow(unused)]
 pub(crate) struct CheckpointDeduplicator<'a> {
-    seen_file_keys: &'a HashSet<FileActionKey>,
+    seen_file_keys: &'a SeenFileKeys,
     add_path_index: usize,
     add_size_index: usize,
     add_dv_start_index: usize,
@@ -98,7 +96,7 @@ pub(crate) struct CheckpointDeduplicator<'a> {
 impl<'a> CheckpointDeduplicator<'a> {
     #[allow(unused)]
     pub(crate) fn try_new(
-        seen_file_keys: &'a HashSet<FileActionKey>,
+        seen_file_keys: &'a SeenFileKeys,
         add_path_index: usize,
         add_size_index: usize,
         add_dv_start_index: usize,

--- a/kernel/src/log_replay/mod.rs
+++ b/kernel/src/log_replay/mod.rs
@@ -54,6 +54,16 @@ impl FileActionKey {
     }
 }
 
+/// `HashSet` used to deduplicate file actions during log replay. Uses `foldhash`'s random
+/// state for ~2x faster hashing than the std default while keeping per-process seeding so
+/// path keys read from the Delta log remain HashDoS-resistant.
+///
+/// Crate-private so the alternate hasher type parameter does not leak into the public API
+/// (the serializable boundary still uses the std `HashSet<FileActionKey>`).
+///
+/// cbindgen:ignore
+pub(crate) type SeenFileKeys = HashSet<FileActionKey, foldhash::fast::RandomState>;
+
 /// Maintains state and provides functionality for deduplicating file actions during log replay.
 ///
 /// This struct is embedded in visitors to track which files have been seen across multiple
@@ -68,7 +78,7 @@ pub(crate) struct FileActionDeduplicator<'seen> {
     /// A set of (data file path, dv_unique_id) pairs that have been seen thus
     /// far in the log for deduplication. This is a mutable reference to the set
     /// of seen file keys that persists across multiple log batches.
-    seen_file_keys: &'seen mut HashSet<FileActionKey>,
+    seen_file_keys: &'seen mut SeenFileKeys,
     // TODO: Consider renaming to `is_commit_batch`, `deduplicate_batch`, or `save_batch`
     // to better reflect its role in deduplication logic.
     /// Whether we're processing a commit log JSON file (`true`) or a checkpoint file (`false`).
@@ -88,7 +98,7 @@ pub(crate) struct FileActionDeduplicator<'seen> {
 
 impl<'seen> FileActionDeduplicator<'seen> {
     pub(crate) fn new(
-        seen_file_keys: &'seen mut HashSet<FileActionKey>,
+        seen_file_keys: &'seen mut SeenFileKeys,
         is_log_batch: bool,
         add_path_index: usize,
         add_size_index: usize,
@@ -399,7 +409,7 @@ pub(crate) trait HasSelectionVector {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{HashMap, HashSet};
+    use std::collections::HashMap;
 
     use rstest::rstest;
 
@@ -474,7 +484,7 @@ mod tests {
 
     /// Helper to create a FileActionDeduplicator with standard indices
     fn create_deduplicator(
-        seen: &mut HashSet<FileActionKey>,
+        seen: &mut SeenFileKeys,
         is_log_batch: bool,
     ) -> FileActionDeduplicator<'_> {
         FileActionDeduplicator::new(
@@ -518,7 +528,7 @@ mod tests {
         #[case] raw_size: Option<i64>,
         #[case] expected_size: u64,
     ) -> DeltaResult<()> {
-        let mut seen = HashSet::new();
+        let mut seen = SeenFileKeys::default();
         let deduplicator = create_deduplicator(&mut seen, true);
 
         let mut mock_add = MockGetData::new();
@@ -540,7 +550,7 @@ mod tests {
 
     #[test]
     fn test_extract_file_action_remove() -> DeltaResult<()> {
-        let mut seen = HashSet::new();
+        let mut seen = SeenFileKeys::default();
         let deduplicator = create_deduplicator(&mut seen, true);
 
         let mut mock_remove = MockGetData::new();
@@ -558,7 +568,7 @@ mod tests {
 
     #[test]
     fn test_extract_file_action_with_deletion_vector() -> DeltaResult<()> {
-        let mut seen = HashSet::new();
+        let mut seen = SeenFileKeys::default();
         let deduplicator = create_deduplicator(&mut seen, true);
 
         let mut mock_dv = MockGetData::new();
@@ -582,7 +592,7 @@ mod tests {
 
     #[test]
     fn test_extract_file_action_skip_removes() -> DeltaResult<()> {
-        let mut seen = HashSet::new();
+        let mut seen = SeenFileKeys::default();
         let deduplicator = create_deduplicator(&mut seen, true);
 
         let mut mock_remove = MockGetData::new();
@@ -604,7 +614,7 @@ mod tests {
 
     #[test]
     fn test_extract_file_action_no_action_found() -> DeltaResult<()> {
-        let mut seen = HashSet::new();
+        let mut seen = SeenFileKeys::default();
         let deduplicator = create_deduplicator(&mut seen, true);
 
         let getters = create_getters_with_mocks(None, None);
@@ -617,7 +627,7 @@ mod tests {
 
     #[test]
     fn test_check_and_record_seen() {
-        let mut seen = HashSet::new();
+        let mut seen = SeenFileKeys::default();
 
         // Pre-populate with an existing key
         let pre_existing_key = FileActionKey::new("existing.parquet", None);
@@ -667,7 +677,7 @@ mod tests {
 
     #[test]
     fn test_is_log_batch() {
-        let mut seen = HashSet::new();
+        let mut seen = SeenFileKeys::default();
 
         // Test with is_log_batch = true
         let deduplicator_log = create_deduplicator(&mut seen, true);
@@ -682,7 +692,7 @@ mod tests {
 
     #[test]
     fn test_checkpoint_extract_file_action_add() -> DeltaResult<()> {
-        let seen = HashSet::new();
+        let seen = SeenFileKeys::default();
         let deduplicator = CheckpointDeduplicator::try_new(&seen, 0, 2, 3)?;
 
         let mut mock_add = MockGetData::new();
@@ -701,7 +711,7 @@ mod tests {
 
     #[test]
     fn test_checkpoint_extract_file_action_with_deletion_vector() -> DeltaResult<()> {
-        let seen = HashSet::new();
+        let seen = SeenFileKeys::default();
         let deduplicator = CheckpointDeduplicator::try_new(&seen, 0, 1, 2)?;
 
         let mut mock_dv = MockGetData::new();
@@ -726,7 +736,7 @@ mod tests {
 
     #[test]
     fn test_checkpoint_deduplicator_filters_commit_duplicates() -> DeltaResult<()> {
-        let mut seen = HashSet::new();
+        let mut seen = SeenFileKeys::default();
 
         // Files "seen" during commit processing
         seen.insert(FileActionKey::new("modified_in_commit.parquet", None));

--- a/kernel/src/parallel/parallel_phase.rs
+++ b/kernel/src/parallel/parallel_phase.rs
@@ -121,7 +121,6 @@ impl<P: ParallelLogReplayProcessor> Iterator for ParallelPhase<P> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
     use std::sync::Arc;
     use std::thread;
 
@@ -133,7 +132,7 @@ mod tests {
     use crate::actions::get_log_add_schema;
     use crate::engine::arrow_data::ArrowEngineData;
     use crate::engine::sync::SyncEngine;
-    use crate::log_replay::FileActionKey;
+    use crate::log_replay::{FileActionKey, SeenFileKeys};
     use crate::log_segment::CheckpointReadInfo;
     use crate::metrics::{MetricEvent, ScanType, WithMetricsReporterLayer};
     use crate::object_store::memory::InMemory;
@@ -197,7 +196,7 @@ mod tests {
     ) -> DeltaResult<ScanLogReplayProcessor> {
         let state_info = Arc::new(get_simple_state_info(test_schema(), vec![])?);
 
-        let seen_file_keys: HashSet<FileActionKey> = seen_paths
+        let seen_file_keys: SeenFileKeys = seen_paths
             .iter()
             .map(|path| FileActionKey::new(*path, None))
             .collect();

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -18,7 +18,7 @@ use crate::expressions::{
 use crate::log_replay::deduplicator::{CheckpointDeduplicator, Deduplicator, FileActionInfo};
 use crate::log_replay::{
     ActionsBatch, FileActionDeduplicator, FileActionKey, LogReplayProcessor,
-    ParallelLogReplayProcessor,
+    ParallelLogReplayProcessor, SeenFileKeys,
 };
 use crate::log_segment::CheckpointReadInfo;
 use crate::scan::transform_spec::{get_transform_expr, parse_partition_values, TransformSpec};
@@ -105,6 +105,11 @@ pub struct SerializableScanState {
     /// Opaque internal state blob
     pub internal_state_blob: Vec<u8>,
     /// Set of file action keys that have already been processed.
+    ///
+    /// Uses the standard `HashSet` (with the std random-state hasher) so that the serialized
+    /// wire format is stable across kernel builds and engines that hand-roll their own
+    /// serialization. The in-memory dedup set inside `ScanLogReplayProcessor` uses a faster
+    /// hasher; conversion happens at the phase boundary.
     pub seen_file_keys: HashSet<FileActionKey>,
     /// Information about checkpoint reading for stats optimization
     pub(crate) checkpoint_info: CheckpointReadInfo,
@@ -149,7 +154,7 @@ pub struct ScanLogReplayProcessor {
     /// A set of (data file path, dv_unique_id) pairs that have been seen thus
     /// far in the log. This is used to filter out files with Remove actions as
     /// well as duplicate entries in the log.
-    seen_file_keys: HashSet<FileActionKey>,
+    seen_file_keys: SeenFileKeys,
     /// Read-time stats options.
     stats_options: ScanStatsOptions,
     /// Information about checkpoint reading for stats optimization
@@ -181,7 +186,7 @@ impl ScanLogReplayProcessor {
             engine,
             state_info,
             checkpoint_info,
-            HashSet::with_capacity(dedup_capacity),
+            SeenFileKeys::with_capacity_and_hasher(dedup_capacity, Default::default()),
             stats_options,
         )
     }
@@ -201,7 +206,7 @@ impl ScanLogReplayProcessor {
         engine: &dyn Engine,
         state_info: Arc<StateInfo>,
         checkpoint_info: CheckpointReadInfo,
-        seen_file_keys: HashSet<FileActionKey>,
+        seen_file_keys: SeenFileKeys,
         stats_options: ScanStatsOptions,
     ) -> DeltaResult<Self> {
         let CheckpointReadInfo {
@@ -359,7 +364,7 @@ impl ScanLogReplayProcessor {
         Ok(SerializableScanState {
             predicate,
             internal_state_blob,
-            seen_file_keys: self.seen_file_keys,
+            seen_file_keys: self.seen_file_keys.into_iter().collect(),
             checkpoint_info: self.checkpoint_info,
         })
     }
@@ -415,7 +420,7 @@ impl ScanLogReplayProcessor {
             engine,
             state_info,
             state.checkpoint_info,
-            state.seen_file_keys,
+            state.seen_file_keys.into_iter().collect(),
             internal_state.stats_options,
         )
     }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2698/files) to review incremental changes.
- [**stack/swap-dedup-hasher**](https://github.com/delta-io/delta-kernel-rs/pull/2698) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2698/files)]

---------
## What changes are proposed in this pull request?

Swap the std `HashSet` used to track seen `(path, dv_unique_id)` pairs during log replay for a `HashSet` backed by `foldhash::fast::RandomState`. This is the hottest hash structure on the read path: every Add/Remove across every commit and every action in every checkpoint hits a `contains` and (for commit batches) an `insert`. SipHash-1-3 (the std default) is ~2x slower than foldhash on small keys for no functional benefit here.

The alternate hasher is hidden behind a crate-private `SeenFileKeys` type alias. `SerializableScanState.seen_file_keys` keeps its existing `HashSet<FileActionKey>` (std hasher) so the distributed-scan wire format and public API are unchanged; conversion happens once per phase boundary.

`foldhash::fast::RandomState` reseeds per-process, so HashDoS resistance for path keys read from the Delta log is preserved.

## How was this change tested?

- `cargo nextest run -p delta_kernel --all-features` (4704 tests pass)
- `cargo clippy --workspace --benches --tests --all-features -- -D warnings`
- `cargo doc --workspace --all-features --no-deps`