### PR TITLE
feat!: Define and use CollectInto trait

### DIFF
--- a/kernel/src/expressions/column_names.rs
+++ b/kernel/src/expressions/column_names.rs
@@ -4,6 +4,7 @@ use std::hash::{Hash, Hasher};
 use std::iter::Peekable;
 use std::ops::Deref;
 
+use crate::utils::CollectInto;
 use crate::{DeltaResult, Error};
 
 /// A (possibly nested) column name.
@@ -15,11 +16,8 @@ pub struct ColumnName {
 impl ColumnName {
     /// Creates a new column name from input satisfying `FromIterator for ColumnName`. The provided
     /// field names are concatenated into a single path.
-    pub fn new<A>(iter: impl IntoIterator<Item = A>) -> Self
-    where
-        Self: FromIterator<A>,
-    {
-        iter.into_iter().collect()
+    pub fn new(iter: impl CollectInto<Self>) -> Self {
+        iter.collect_into()
     }
 
     /// Naively splits a string at dots to create a column name.

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -18,6 +18,7 @@ use crate::kernel_predicates::{
 };
 use crate::schema::SchemaRef;
 use crate::transforms::{transform_output_type, ExpressionTransform};
+use crate::utils::CollectInto;
 use crate::{DataType, DeltaResult, DynPartialEq};
 
 mod column_names;
@@ -399,10 +400,7 @@ impl ExpressionStructPatch {
 
     /// Creates a new empty patch that operates on fields of a nested struct identified by
     /// `path`. The various `with_xxx` helper methods can be used to add specific field patches.
-    pub fn new_nested<A>(path: impl IntoIterator<Item = A>) -> Self
-    where
-        ColumnName: FromIterator<A>,
-    {
+    pub fn new_nested(path: impl CollectInto<ColumnName>) -> Self {
         Self {
             input_path: Some(ColumnName::new(path)),
             ..Default::default()
@@ -671,10 +669,7 @@ impl Expression {
     }
 
     /// Create a new column name expression from input satisfying `FromIterator for ColumnName`.
-    pub fn column<A>(field_names: impl IntoIterator<Item = A>) -> Expression
-    where
-        ColumnName: FromIterator<A>,
-    {
+    pub fn column(field_names: impl CollectInto<ColumnName>) -> Expression {
         ColumnName::new(field_names).into()
     }
 
@@ -841,10 +836,7 @@ impl Predicate {
     }
 
     /// Creates a new boolean column reference. See also [`Expression::column`].
-    pub fn column<A>(field_names: impl IntoIterator<Item = A>) -> Predicate
-    where
-        ColumnName: FromIterator<A>,
-    {
+    pub fn column(field_names: impl CollectInto<ColumnName>) -> Predicate {
         Self::from_expr(ColumnName::new(field_names))
     }
 
@@ -1408,7 +1400,7 @@ mod tests {
             let cases: Vec<ColumnName> = vec![
                 column_name!("simple"),
                 ColumnName::new(["a", "b", "c"]),
-                ColumnName::new::<&str>([]),
+                ColumnName::default(),
             ];
 
             for col in &cases {

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -137,7 +137,7 @@ pub mod kernel_predicates;
 pub(crate) mod utils;
 
 #[cfg(feature = "internal-api")]
-pub use utils::try_parse_uri;
+pub use utils::{try_parse_uri, CollectInto};
 
 // for the below modules, we cannot introduce a macro to clean this up. rustfmt doesn't follow into
 // macros, and so will not format the files associated with these modules if we get too clever. see:

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -25,6 +25,7 @@ pub(crate) use require;
 /// simplify type bounds. For example, `CollectInto` allows to write this:
 ///
 /// ```
+/// # use delta_kernel::utils::CollectInto;
 /// # struct Foo;
 /// fn foo(arg: impl CollectInto<Foo>) -> Foo {
 ///     arg.collect_into()
@@ -43,8 +44,7 @@ pub(crate) use require;
 /// }
 /// ```
 pub trait CollectInto<T>: IntoIterator + Sized {
-    /// Collects this iterable into a `T`; the dual of [`FromIterator`] just as [`Into`] is the dual
-    /// of [`From`].
+    /// Collects this iterable into a `T`
     fn collect_into(self) -> T;
 }
 

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -20,6 +20,41 @@ macro_rules! require {
 
 pub(crate) use require;
 
+/// Dual of the `FromIterator` trait, similar to how `Into` is the dual of `From`. It is
+/// automatically implemented for any iterable whose items collect into `T`, and can drastically
+/// simplify type bounds. For example, `CollectInto` allows to write this:
+///
+/// ```
+/// # struct Foo;
+/// fn foo(arg: impl CollectInto<Foo>) -> Foo {
+///     arg.collect_into()
+/// }
+/// ```
+///
+/// instead of the much more verbose:
+///
+/// ```
+/// # struct Foo;
+/// fn foo<T>(arg: impl IntoIterator<Item = T>) -> Foo
+/// where
+///     Foo: FromIterator<T>,
+/// {
+///     Foo::from_iter(arg)
+/// }
+/// ```
+pub trait CollectInto<T>: IntoIterator + Sized {
+    /// Collects this iterable into a `T`; the dual of [`FromIterator`] just as [`Into`] is the dual
+    /// of [`From`].
+    fn collect_into(self) -> T;
+}
+
+// blanket impl
+impl<I: IntoIterator, T: FromIterator<I::Item>> CollectInto<T> for I {
+    fn collect_into(self) -> T {
+        T::from_iter(self)
+    }
+}
+
 /// Try to parse string uri into a URL for a table path. This will do it's best to handle things
 /// like `/local/paths`, and even `../relative/paths`.
 #[allow(unused)]

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -25,7 +25,7 @@ pub(crate) use require;
 /// simplify type bounds. For example, `CollectInto` allows to write this:
 ///
 /// ```
-/// # use delta_kernel::utils::CollectInto;
+/// # use delta_kernel::CollectInto;
 /// # struct Foo;
 /// fn foo(arg: impl CollectInto<Foo>) -> Foo {
 ///     arg.collect_into()


### PR DESCRIPTION
## What changes are proposed in this pull request?

`ColumnName::new` takes an `impl FromIterator` arg, which requires a complicated type bound:
```rust
fn new<A>(arg: impl IntoIterator<Item = A>) -> Self
where
    Self: FromIterator<A>
{
    arg.into_iter().collect()
}
```

The same type bound messiness "poisons" any function that wants to forward args to `ColumnName::new`.

Observing that the same problem exists with `From`, and is solved by the `Into` trait, define a new `CollectInto` trait that is the analogue of `Into` but for `FromIterator`. It is defined automatically for all eligible types, and allows the much simpler type bound:
```rust
fn new(arg: impl CollectInto<Self>) -> Self {
    arg.collect_into()
}
```

### This PR affects the following public APIs

The switch to `CollectInto` is a breaking change for `ColumnName::new`, `Predicate::column`, `Expression::column`, and `ExpressionStructPatch::new_nested`. Even tho those methods accept all the same types as before (thanks to the trait's blanket impl), their signatures no longer have a template arg, which breaks turbofish call sites (see the updated unit test).

Note: 
* This is a potential alternative to https://github.com/delta-io/delta-kernel-rs/pull/2683
* The other achieves a similar result by changing `ColumnName::new` to take `impl Into<ColumnName>`
* This PR has the disadvantage that it requires a new type
* The other PR has the disadvantage that it narrows the set of types that `ColumnName::new` can accept, because both `Into` and `From` already have blanket impl that block us from adding a new blanket impl for all T: IntoIterator.

## How was this change tested?

Existing unit tests exercise these code paths.