### PR TITLE
chore!: Use type constructors to avoid Box::new and DataType::from boilerplate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,6 +267,18 @@ Keep this list updated when new protocol features are added to kernel.
 - Prefer `StructField::nullable` / `StructField::not_null` over
   `StructField::new(name, type, bool)` when nullability is known at compile time.
   Reserve `StructField::new` for cases where nullability is a runtime value.
+- Leverage `impl Into<DataType>` to avoid `DataType::Struct/Array/Map(Box::new(...))`
+  boilerplate. `StructType`, `ArrayType`, and `MapType` all implement `Into<DataType>`,
+  and constructors like `StructField::new`/`nullable`/`not_null`, `ArrayType::new`, and
+  `MapType::new` accept `impl Into<DataType>`. So:
+  - When passing to a parameter that accepts `impl Into<DataType>`, pass the container
+    type directly: `StructField::nullable("a", ArrayType::new(DataType::INTEGER, true))`
+    -- do NOT wrap in `DataType::from(...)` or `.into()` (redundant at best, and an
+    ambiguous-type compile error at worst).
+  - When a concrete `DataType` value is actually required (e.g. a `DataType`-typed
+    binding/field, a `[DataType]`/`Vec<DataType>` element, or a `&DataType` argument),
+    prefer `DataType::from(ArrayType::new(...))` over
+    `DataType::Array(Box::new(ArrayType::new(...)))`.
 - Prefer the `DeltaResultIterator<'a, T>` / `DeltaResultIteratorStatic<T>` aliases over
   hand-rolled `Box<dyn Iterator<Item = DeltaResult<T>> + Send (+ 'a)>`.
 - Prefer the `col!` macro and `lit(value)` constructor over `Expression::column(...)` /

--- a/benchmarks/src/predicate_parser.rs
+++ b/benchmarks/src/predicate_parser.rs
@@ -466,29 +466,17 @@ mod tests {
             StructField::new("cc8", DataType::STRING, true),
             StructField::new("s", DataType::STRING, true),
             StructField::new("time_col", DataType::TIMESTAMP, true),
-            StructField::new(
-                "items",
-                DataType::Array(Box::new(ArrayType::new(DataType::LONG, true))),
-                true,
-            ),
+            StructField::new("items", ArrayType::new(DataType::LONG, true), true),
             // Nested struct for upstream tests
             StructField::new(
                 "null_v_struct",
-                DataType::Struct(Box::new(StructType::new_unchecked(vec![StructField::new(
-                    "v",
-                    DataType::LONG,
-                    true,
-                )]))),
+                StructType::new_unchecked(vec![StructField::new("v", DataType::LONG, true)]),
                 true,
             ),
             // Nested structs for nested_columns tests (a.b, a.b.c, b.c.f.i, data.value)
             StructField::new(
                 "data",
-                DataType::Struct(Box::new(StructType::new_unchecked(vec![StructField::new(
-                    "value",
-                    DataType::LONG,
-                    true,
-                )]))),
+                StructType::new_unchecked(vec![StructField::new("value", DataType::LONG, true)]),
                 true,
             ),
             // Additional typed columns for type-checking tests
@@ -506,26 +494,18 @@ mod tests {
             // Struct type for nested tests
             StructField::new(
                 "struct_col",
-                DataType::Struct(Box::new(StructType::new_unchecked(vec![
+                StructType::new_unchecked(vec![
                     StructField::new("inner_int", DataType::INTEGER, true),
                     StructField::new("inner_str", DataType::STRING, true),
-                ]))),
+                ]),
                 true,
             ),
             // Array type
-            StructField::new(
-                "array_col",
-                DataType::Array(Box::new(ArrayType::new(DataType::LONG, true))),
-                true,
-            ),
+            StructField::new("array_col", ArrayType::new(DataType::LONG, true), true),
             // Map type
             StructField::new(
                 "map_col",
-                DataType::Map(Box::new(MapType::new(
-                    DataType::STRING,
-                    DataType::LONG,
-                    true,
-                ))),
+                MapType::new(DataType::STRING, DataType::LONG, true),
                 true,
             ),
         ])

--- a/delta-kernel-unity-catalog/src/utils/create_table.rs
+++ b/delta-kernel-unity-catalog/src/utils/create_table.rs
@@ -234,7 +234,7 @@ mod tests {
             StructType::try_new(vec![
                 StructField::new("id", DataType::INTEGER, true),
                 StructField::new("region", DataType::STRING, true),
-                StructField::new("address", DataType::Struct(Box::new(address_struct)), true),
+                StructField::new("address", address_struct, true),
             ])
             .unwrap(),
         );

--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -744,25 +744,21 @@ mod tests {
 
     #[test]
     fn from_data_type_non_primitive_produces_sentinel() {
-        let struct_type = DataType::Struct(Box::new(
+        let struct_type = DataType::from(
             StructType::try_new(vec![StructField::not_null("a", DataType::INTEGER)]).unwrap(),
-        ));
+        );
         assert_eq!(
             NullTypeTag::from_data_type(&struct_type),
             (NullTypeTag::NonPrimitive, 0, 0)
         );
 
-        let array_type = DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, false)));
+        let array_type = DataType::from(ArrayType::new(DataType::INTEGER, false));
         assert_eq!(
             NullTypeTag::from_data_type(&array_type),
             (NullTypeTag::NonPrimitive, 0, 0)
         );
 
-        let map_type = DataType::Map(Box::new(MapType::new(
-            DataType::STRING,
-            DataType::INTEGER,
-            false,
-        )));
+        let map_type = DataType::from(MapType::new(DataType::STRING, DataType::INTEGER, false));
         assert_eq!(
             NullTypeTag::from_data_type(&map_type),
             (NullTypeTag::NonPrimitive, 0, 0)

--- a/ffi/src/schema_visitor.rs
+++ b/ffi/src/schema_visitor.rs
@@ -393,7 +393,7 @@ fn create_struct_data_type(
         .collect::<DeltaResult<Vec<_>>>()?;
 
     let struct_type = StructType::try_new(field_vec)?;
-    Ok(DataType::Struct(Box::new(struct_type)))
+    Ok(DataType::from(struct_type))
 }
 
 fn visit_field_struct_impl(

--- a/ffi/src/test_ffi.rs
+++ b/ffi/src/test_ffi.rs
@@ -103,10 +103,7 @@ pub unsafe extern "C" fn get_testing_kernel_expression() -> Handle<SharedExpress
     let nested_struct_type = StructType::try_new(nested_fields).unwrap();
 
     let top_level_struct = StructData::try_new(
-        vec![StructField::nullable(
-            "top",
-            DataType::Struct(Box::new(nested_struct_type)),
-        )],
+        vec![StructField::nullable("top", nested_struct_type)],
         vec![Scalar::Struct(nested_struct)],
     )
     .unwrap();

--- a/kernel/src/checkpoint/checkpoint_transform.rs
+++ b/kernel/src/checkpoint/checkpoint_transform.rs
@@ -160,18 +160,12 @@ pub(crate) fn build_checkpoint_read_schema(
         }
         let mut result = add_struct.clone().with_field_inserted_after(
             Some(STATS_FIELD),
-            StructField::nullable(
-                STATS_PARSED_FIELD,
-                DataType::Struct(Box::new(stats_schema.clone())),
-            ),
+            StructField::nullable(STATS_PARSED_FIELD, stats_schema.clone()),
         )?;
         if let Some(pv_schema) = partition_schema {
             result = result.with_field_inserted_after(
                 Some(PARTITION_VALUES_FIELD),
-                StructField::nullable(
-                    PARTITION_VALUES_PARSED_FIELD,
-                    DataType::Struct(Box::new(pv_schema.clone())),
-                ),
+                StructField::nullable(PARTITION_VALUES_PARSED_FIELD, pv_schema.clone()),
             )?;
         }
         Ok(result)
@@ -286,7 +280,7 @@ fn transform_add_schema(
         ADD_NAME,
         StructField {
             name: ADD_NAME.to_string(),
-            data_type: DataType::Struct(Box::new(modified_add)),
+            data_type: DataType::from(modified_add),
             nullable: add_field.nullable,
             metadata: add_field.metadata.clone(),
         },
@@ -305,18 +299,12 @@ fn build_add_output_schema(
     if config.write_stats_as_struct {
         new_schema = new_schema.with_field_inserted_after(
             Some(STATS_FIELD),
-            StructField::nullable(
-                STATS_PARSED_FIELD,
-                DataType::Struct(Box::new(stats_schema.clone())),
-            ),
+            StructField::nullable(STATS_PARSED_FIELD, stats_schema.clone()),
         )?;
         if let Some(pv_schema) = partition_schema {
             new_schema = new_schema.with_field_inserted_after(
                 Some(PARTITION_VALUES_FIELD),
-                StructField::nullable(
-                    PARTITION_VALUES_PARSED_FIELD,
-                    DataType::Struct(Box::new(pv_schema.clone())),
-                ),
+                StructField::nullable(PARTITION_VALUES_PARSED_FIELD, pv_schema.clone()),
             )?;
         }
     }
@@ -586,10 +574,7 @@ mod tests {
         let result = add_schema
             .with_field_inserted_after(
                 Some(STATS_FIELD),
-                StructField::nullable(
-                    STATS_PARSED_FIELD,
-                    DataType::Struct(Box::new(injected_schema)),
-                ),
+                StructField::nullable(STATS_PARSED_FIELD, injected_schema),
             )
             .expect("inserting stats_parsed should succeed");
 
@@ -679,11 +664,7 @@ mod tests {
             StructField::not_null("path", DataType::STRING),
             StructField::nullable(
                 "partitionValues",
-                DataType::Map(Box::new(crate::schema::MapType::new(
-                    DataType::STRING,
-                    DataType::STRING,
-                    true,
-                ))),
+                crate::schema::MapType::new(DataType::STRING, DataType::STRING, true),
             ),
             StructField::nullable("stats", DataType::STRING),
         ]);
@@ -722,11 +703,7 @@ mod tests {
             StructField::not_null("path", DataType::STRING),
             StructField::nullable(
                 "partitionValues",
-                DataType::Map(Box::new(crate::schema::MapType::new(
-                    DataType::STRING,
-                    DataType::STRING,
-                    true,
-                ))),
+                crate::schema::MapType::new(DataType::STRING, DataType::STRING, true),
             ),
             StructField::nullable("stats", DataType::STRING),
         ]);

--- a/kernel/src/clustering.rs
+++ b/kernel/src/clustering.rs
@@ -196,11 +196,11 @@ mod tests {
         ]);
         let user_struct = StructType::new_unchecked(vec![
             StructField::new("name", DataType::STRING, true),
-            StructField::new("address", DataType::Struct(Box::new(address_struct)), true),
+            StructField::new("address", address_struct, true),
         ]);
         let schema = StructType::new_unchecked(vec![
             StructField::new("id", DataType::INTEGER, false),
-            StructField::new("user", DataType::Struct(Box::new(user_struct)), true),
+            StructField::new("user", user_struct, true),
         ]);
 
         // Nested leaf column with eligible type should succeed
@@ -212,11 +212,8 @@ mod tests {
     fn test_validate_clustering_nested_struct_leaf_rejected() {
         let inner_struct =
             StructType::new_unchecked(vec![StructField::new("field", DataType::STRING, false)]);
-        let schema = StructType::new_unchecked(vec![StructField::new(
-            "parent",
-            DataType::Struct(Box::new(inner_struct)),
-            false,
-        )]);
+        let schema =
+            StructType::new_unchecked(vec![StructField::new("parent", inner_struct, false)]);
 
         // Clustering on an entire struct (not a leaf primitive) should fail
         let columns = vec![ColumnName::new(["parent"])];
@@ -244,11 +241,8 @@ mod tests {
     fn test_validate_clustering_nested_path_not_found() {
         let inner_struct =
             StructType::new_unchecked(vec![StructField::new("field", DataType::STRING, false)]);
-        let schema = StructType::new_unchecked(vec![StructField::new(
-            "parent",
-            DataType::Struct(Box::new(inner_struct)),
-            false,
-        )]);
+        let schema =
+            StructType::new_unchecked(vec![StructField::new("parent", inner_struct, false)]);
 
         // Nested field that doesn't exist should fail
         let columns = vec![ColumnName::new(["parent", "nonexistent"])];
@@ -341,23 +335,11 @@ mod tests {
             StructType::new_unchecked(vec![StructField::new("inner", DataType::STRING, false)]);
 
         let schema = StructType::new_unchecked(vec![
-            StructField::new(
-                "struct_col",
-                DataType::Struct(Box::new(inner_struct)),
-                false,
-            ),
-            StructField::new(
-                "array_col",
-                DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, false))),
-                false,
-            ),
+            StructField::new("struct_col", inner_struct, false),
+            StructField::new("array_col", ArrayType::new(DataType::INTEGER, false), false),
             StructField::new(
                 "map_col",
-                DataType::Map(Box::new(MapType::new(
-                    DataType::STRING,
-                    DataType::INTEGER,
-                    false,
-                ))),
+                MapType::new(DataType::STRING, DataType::INTEGER, false),
                 false,
             ),
         ]);

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -591,27 +591,27 @@ impl TryFromArrow<&ArrowDataType> for DataType {
             )
             .map_err(|e| ArrowError::from_external_error(e.into())),
             ArrowDataType::List(field) => Ok(ArrayType::new(
-                (*field).data_type().try_into_kernel()?,
+                DataType::try_from_arrow((*field).data_type())?,
                 (*field).is_nullable(),
             )
             .into()),
             ArrowDataType::ListView(field) => Ok(ArrayType::new(
-                (*field).data_type().try_into_kernel()?,
+                DataType::try_from_arrow((*field).data_type())?,
                 (*field).is_nullable(),
             )
             .into()),
             ArrowDataType::LargeList(field) => Ok(ArrayType::new(
-                (*field).data_type().try_into_kernel()?,
+                DataType::try_from_arrow((*field).data_type())?,
                 (*field).is_nullable(),
             )
             .into()),
             ArrowDataType::LargeListView(field) => Ok(ArrayType::new(
-                (*field).data_type().try_into_kernel()?,
+                DataType::try_from_arrow((*field).data_type())?,
                 (*field).is_nullable(),
             )
             .into()),
             ArrowDataType::FixedSizeList(field, _) => Ok(ArrayType::new(
-                (*field).data_type().try_into_kernel()?,
+                DataType::try_from_arrow((*field).data_type())?,
                 (*field).is_nullable(),
             )
             .into()),
@@ -904,7 +904,7 @@ mod tests {
             ColumnMetadataKey::ParquetFieldId.as_ref(),
             MetadataValue::Number(5),
         )])])?;
-        let array_type = ArrayType::new(DataType::Struct(Box::new(array_item_struct)), false);
+        let array_type = ArrayType::new(array_item_struct, false);
 
         // Build map with struct key and struct value (both with field IDs)
         let map_key_struct = StructType::try_new(vec![StructField::new(
@@ -925,11 +925,7 @@ mod tests {
             ColumnMetadataKey::ParquetFieldId.as_ref(),
             MetadataValue::Number(8),
         )])])?;
-        let map_type = MapType::new(
-            DataType::Struct(Box::new(map_key_struct)),
-            DataType::Struct(Box::new(map_value_struct)),
-            false,
-        );
+        let map_type = MapType::new(map_key_struct, map_value_struct, false);
 
         // Build top-level struct
         let top_struct = StructType::try_new(vec![
@@ -937,26 +933,18 @@ mod tests {
                 ColumnMetadataKey::ParquetFieldId.as_ref(),
                 MetadataValue::Number(1),
             )]),
-            StructField::new(
-                "nested_struct",
-                DataType::Struct(Box::new(inner_struct_type)),
-                false,
-            )
-            .with_metadata([(
+            StructField::new("nested_struct", inner_struct_type, false).with_metadata([(
                 ColumnMetadataKey::ParquetFieldId.as_ref(),
                 MetadataValue::Number(2),
             )]),
-            StructField::new("array_field", DataType::Array(Box::new(array_type)), false)
-                .with_metadata([(
-                    ColumnMetadataKey::ParquetFieldId.as_ref(),
-                    MetadataValue::Number(4),
-                )]),
-            StructField::new("map_field", DataType::Map(Box::new(map_type)), false).with_metadata(
-                [(
-                    ColumnMetadataKey::ParquetFieldId.as_ref(),
-                    MetadataValue::Number(6),
-                )],
-            ),
+            StructField::new("array_field", array_type, false).with_metadata([(
+                ColumnMetadataKey::ParquetFieldId.as_ref(),
+                MetadataValue::Number(4),
+            )]),
+            StructField::new("map_field", map_type, false).with_metadata([(
+                ColumnMetadataKey::ParquetFieldId.as_ref(),
+                MetadataValue::Number(6),
+            )]),
         ])?;
 
         // Convert to Arrow schema

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -1109,12 +1109,8 @@ mod tests {
         ]);
 
         let expr = Expr::StructPatch(patch);
-        let result = evaluate_expression(
-            &expr,
-            &batch,
-            Some(&DataType::Struct(Box::new(output_schema))),
-        )
-        .unwrap();
+        let result =
+            evaluate_expression(&expr, &batch, Some(&DataType::from(output_schema))).unwrap();
 
         // For empty patch, output should be identical to input
         let struct_result = result.as_any().downcast_ref::<StructArray>().unwrap();
@@ -1137,7 +1133,7 @@ mod tests {
         let result_nested = evaluate_expression(
             &expr_nested,
             &nested_batch,
-            Some(&DataType::Struct(Box::new(nested_output_schema))),
+            Some(&DataType::from(nested_output_schema)),
         )
         .unwrap();
 
@@ -1188,12 +1184,8 @@ mod tests {
         ]);
 
         let expr = Expr::StructPatch(patch);
-        let result = evaluate_expression(
-            &expr,
-            &batch,
-            Some(&DataType::Struct(Box::new(output_schema))),
-        )
-        .unwrap();
+        let result =
+            evaluate_expression(&expr, &batch, Some(&DataType::from(output_schema))).unwrap();
 
         let struct_result = result.as_any().downcast_ref::<StructArray>().unwrap();
         assert_eq!(struct_result.num_columns(), 8);
@@ -1232,7 +1224,7 @@ mod tests {
         let result_copy = evaluate_expression(
             &expr_copy,
             &nested_batch,
-            Some(&DataType::Struct(Box::new(copy_output_schema))),
+            Some(&DataType::from(copy_output_schema)),
         )
         .unwrap();
 
@@ -1267,7 +1259,7 @@ mod tests {
         let result_modify = evaluate_expression(
             &expr_modify,
             &nested_batch,
-            Some(&DataType::Struct(Box::new(modify_output_schema))),
+            Some(&DataType::from(modify_output_schema)),
         )
         .unwrap();
 
@@ -1302,11 +1294,8 @@ mod tests {
         ]);
 
         let expr = Expr::StructPatch(patch);
-        let result = evaluate_expression(
-            &expr,
-            &batch,
-            Some(&DataType::Struct(Box::new(output_schema.clone()))),
-        );
+        let result =
+            evaluate_expression(&expr, &batch, Some(&DataType::from(output_schema.clone())));
         assert!(result
             .unwrap_err()
             .to_string()
@@ -1317,11 +1306,8 @@ mod tests {
             .with_inserted_field(Some("nonexistent"), Expr::literal(1).into());
 
         let expr2 = Expr::StructPatch(insertion_patch);
-        let result2 = evaluate_expression(
-            &expr2,
-            &batch,
-            Some(&DataType::Struct(Box::new(output_schema.clone()))),
-        );
+        let result2 =
+            evaluate_expression(&expr2, &batch, Some(&DataType::from(output_schema.clone())));
         assert!(result2.is_err());
         assert!(result2
             .unwrap_err()
@@ -1338,11 +1324,8 @@ mod tests {
         ]);
 
         let expr3 = Expr::StructPatch(drop_patch);
-        let result3 = evaluate_expression(
-            &expr3,
-            &batch,
-            Some(&DataType::Struct(Box::new(wrong_output_schema))),
-        );
+        let result3 =
+            evaluate_expression(&expr3, &batch, Some(&DataType::from(wrong_output_schema)));
         assert!(result3.is_err());
         assert!(result3
             .unwrap_err()
@@ -1356,11 +1339,8 @@ mod tests {
             StructType::new_unchecked(vec![StructField::not_null("c", DataType::INTEGER)]);
 
         let expr3 = Expr::StructPatch(drop_patch);
-        let result3 = evaluate_expression(
-            &expr3,
-            &batch,
-            Some(&DataType::Struct(Box::new(wrong_output_schema))),
-        );
+        let result3 =
+            evaluate_expression(&expr3, &batch, Some(&DataType::from(wrong_output_schema)));
         assert!(result3.is_err());
         assert!(result3
             .unwrap_err()
@@ -1387,12 +1367,8 @@ mod tests {
             StructField::not_null("c", DataType::INTEGER),
         ]);
         let expr = Expr::StructPatch(patch);
-        let result = evaluate_expression(
-            &expr,
-            &batch,
-            Some(&DataType::Struct(Box::new(output_schema))),
-        )
-        .unwrap();
+        let result =
+            evaluate_expression(&expr, &batch, Some(&DataType::from(output_schema))).unwrap();
         let result = result.as_any().downcast_ref::<StructArray>().unwrap();
         validate_i32_column(result, 0, &[10, 20, 30]);
         validate_i32_column(result, 1, &[100, 200, 300]);
@@ -1409,12 +1385,8 @@ mod tests {
             StructField::not_null("c", DataType::INTEGER),
         ]);
         let expr = Expr::StructPatch(patch);
-        let result = evaluate_expression(
-            &expr,
-            &batch,
-            Some(&DataType::Struct(Box::new(output_schema))),
-        )
-        .unwrap();
+        let result =
+            evaluate_expression(&expr, &batch, Some(&DataType::from(output_schema))).unwrap();
         let result = result.as_any().downcast_ref::<StructArray>().unwrap();
         validate_i32_column(result, 0, &[1, 2, 3]);
         validate_i32_column(result, 1, &[10, 20, 30]);
@@ -1431,11 +1403,7 @@ mod tests {
             StructField::not_null("c", DataType::INTEGER),
         ]);
         let expr = Expr::StructPatch(patch);
-        let result = evaluate_expression(
-            &expr,
-            &batch,
-            Some(&DataType::Struct(Box::new(output_schema))),
-        );
+        let result = evaluate_expression(&expr, &batch, Some(&DataType::from(output_schema)));
         assert!(result
             .unwrap_err()
             .to_string()
@@ -1471,8 +1439,7 @@ mod tests {
         ];
 
         for (name, expr, schema) in test_cases {
-            let result =
-                evaluate_expression(&expr, &batch, Some(&DataType::Struct(Box::new(schema))));
+            let result = evaluate_expression(&expr, &batch, Some(&DataType::from(schema)));
             assert!(result.is_err(), "Test case '{name}' should fail");
             assert!(
                 result
@@ -1719,12 +1686,9 @@ mod tests {
         ]);
 
         let expr = Expr::StructPatch(outer_patch);
-        let result = evaluate_expression(
-            &expr,
-            &nested_batch,
-            Some(&DataType::Struct(Box::new(output_schema))),
-        )
-        .unwrap();
+        let result =
+            evaluate_expression(&expr, &nested_batch, Some(&DataType::from(output_schema)))
+                .unwrap();
 
         let struct_result = result.as_any().downcast_ref::<StructArray>().unwrap();
         assert_eq!(struct_result.num_columns(), 3);
@@ -1902,7 +1866,7 @@ mod tests {
         ]);
         let output_schema = Arc::new(StructType::new_unchecked(vec![
             StructField::new("outer", DataType::LONG, true),
-            StructField::new("inner", DataType::Struct(Box::new(inner_schema)), true),
+            StructField::new("inner", inner_schema, true),
         ]));
 
         let expr = Expr::parse_json(column_expr!("json_col"), output_schema);
@@ -2143,7 +2107,7 @@ mod tests {
             StructField::nullable("id", DataType::INTEGER),
             StructField::nullable("date", DataType::DATE),
         ]);
-        let result_type = DataType::Struct(Box::new(output_schema));
+        let result_type = DataType::from(output_schema);
         let expr = Expr::map_to_struct(column_expr!("pv"));
         let result = evaluate_expression(&expr, &batch, Some(&result_type)).unwrap();
         let structs = result.as_any().downcast_ref::<StructArray>().unwrap();
@@ -2185,7 +2149,7 @@ mod tests {
         let batch = create_partition_map_batch();
         let output_schema =
             StructType::new_unchecked(vec![StructField::nullable("nonexistent", DataType::STRING)]);
-        let result_type = DataType::Struct(Box::new(output_schema));
+        let result_type = DataType::from(output_schema);
         let expr = Expr::map_to_struct(column_expr!("pv"));
         let result = evaluate_expression(&expr, &batch, Some(&result_type)).unwrap();
         let structs = result.as_any().downcast_ref::<StructArray>().unwrap();
@@ -2216,7 +2180,7 @@ mod tests {
 
         let output_schema =
             StructType::new_unchecked(vec![StructField::nullable("count", DataType::INTEGER)]);
-        let result_type = DataType::Struct(Box::new(output_schema));
+        let result_type = DataType::from(output_schema);
         let expr = Expr::map_to_struct(column_expr!("pv"));
         let result = evaluate_expression(&expr, &batch, Some(&result_type));
         assert!(result.is_err());
@@ -2241,7 +2205,7 @@ mod tests {
 
         let output_schema =
             StructType::new_unchecked(vec![StructField::nullable("x", DataType::STRING)]);
-        let result_type = DataType::Struct(Box::new(output_schema));
+        let result_type = DataType::from(output_schema);
         let expr = Expr::map_to_struct(column_expr!("pv"));
         let result = evaluate_expression(&expr, &batch, Some(&result_type)).unwrap();
         let structs = result.as_any().downcast_ref::<StructArray>().unwrap();
@@ -2295,7 +2259,7 @@ mod tests {
             StructField::new("region", DataType::STRING, false),
             StructField::new("id", DataType::INTEGER, false),
         ]);
-        let result_type = DataType::Struct(Box::new(output_schema));
+        let result_type = DataType::from(output_schema);
         let expr = Expr::map_to_struct(column_expr!("pv"));
         let result = evaluate_expression(&expr, &batch, Some(&result_type)).unwrap();
         let structs = result.as_any().downcast_ref::<StructArray>().unwrap();
@@ -2332,7 +2296,7 @@ mod tests {
 
         let output_schema =
             StructType::new_unchecked(vec![StructField::new("date", DataType::DATE, false)]);
-        let result_type = DataType::Struct(Box::new(output_schema));
+        let result_type = DataType::from(output_schema);
         let expr = Expr::coalesce([
             Expr::column(["pv_parsed"]),
             Expr::map_to_struct(column_expr!("pv")),
@@ -2354,7 +2318,7 @@ mod tests {
 
         let output_schema =
             StructType::new_unchecked(vec![StructField::nullable("x", DataType::STRING)]);
-        let result_type = DataType::Struct(Box::new(output_schema));
+        let result_type = DataType::from(output_schema);
         let expr = Expr::map_to_struct(column_expr!("s"));
         let result = evaluate_expression(&expr, &batch, Some(&result_type));
         assert!(result.is_err());
@@ -2393,11 +2357,11 @@ mod tests {
         #[case] expected_valid: Vec<bool>,
     ) {
         let batch = create_batch_with_bool_col(a_vals, pred_vals);
-        let schema = DataType::Struct(Box::new(StructType::new_unchecked(vec![StructField::new(
+        let schema = DataType::from(StructType::new_unchecked(vec![StructField::new(
             "a",
             DataType::INTEGER,
             true,
-        )])));
+        )]));
         let expr = Expr::struct_with_nullability_from(
             [column_expr_ref!("a")],
             column_expr_ref!("is_valid"),
@@ -2418,11 +2382,11 @@ mod tests {
         );
         let inner_schema =
             StructType::new_unchecked(vec![StructField::new("a", DataType::INTEGER, true)]);
-        let schema = DataType::Struct(Box::new(StructType::new_unchecked(vec![StructField::new(
+        let schema = DataType::from(StructType::new_unchecked(vec![StructField::new(
             "nested",
-            DataType::Struct(Box::new(inner_schema)),
+            inner_schema,
             true,
-        )])));
+        )]));
         let inner_expr = Expr::struct_from([column_expr_ref!("a")]);
         let expr = Expr::struct_with_nullability_from([inner_expr], column_expr_ref!("is_valid"));
         let result = evaluate_expression(&expr, &batch, Some(&schema)).unwrap();
@@ -2460,10 +2424,10 @@ mod tests {
             ],
         )
         .unwrap();
-        let schema = DataType::Struct(Box::new(StructType::new_unchecked(vec![
+        let schema = DataType::from(StructType::new_unchecked(vec![
             StructField::new("a", DataType::INTEGER, true),
             StructField::new("b", DataType::INTEGER, true),
-        ])));
+        ]));
         let expr = Expr::struct_with_nullability_from(
             [column_expr_ref!("a"), column_expr_ref!("b")],
             column_expr_ref!("is_valid"),
@@ -2484,11 +2448,11 @@ mod tests {
             vec![Some(1), Some(2), Some(3)],
             vec![Some(true), Some(false), Some(true)],
         );
-        let schema = DataType::Struct(Box::new(StructType::new_unchecked(vec![StructField::new(
+        let schema = DataType::from(StructType::new_unchecked(vec![StructField::new(
             "a",
             DataType::INTEGER,
             true,
-        )])));
+        )]));
         let expr =
             Expr::struct_with_nullability_from([column_expr_ref!("a")], column_expr_ref!("a"));
         let result = evaluate_expression(&expr, &batch, Some(&schema));
@@ -2651,10 +2615,10 @@ mod tests {
     }
 
     fn int_array_ty(contains_null: bool) -> DataType {
-        DataType::Array(Box::new(crate::schema::ArrayType::new(
+        DataType::from(crate::schema::ArrayType::new(
             DataType::INTEGER,
             contains_null,
-        )))
+        ))
     }
 
     /// Single-column int batch of arbitrary length (column `a`). Used to drive both the
@@ -2853,10 +2817,7 @@ mod tests {
         #[case] expected: Vec<Vec<Vec<i32>>>,
     ) {
         let batch = create_test_batch();
-        let array_ty = DataType::Array(Box::new(crate::schema::ArrayType::new(
-            DataType::Struct(Box::new(struct_schema)),
-            false,
-        )));
+        let array_ty = DataType::from(crate::schema::ArrayType::new(struct_schema, false));
         let result = evaluate_expression(&expr, &batch, Some(&array_ty)).unwrap();
         let list = result.as_list::<i32>();
         assert_eq!(list.len(), expected.len());
@@ -2883,10 +2844,10 @@ mod tests {
         let batch = ab_batch_with_b_nulls();
         let inner_field_schema =
             StructType::try_new([StructField::nullable("value", DataType::INTEGER)]).unwrap();
-        let array_ty = DataType::Array(Box::new(crate::schema::ArrayType::new(
-            DataType::Struct(Box::new(inner_field_schema)),
+        let array_ty = DataType::from(crate::schema::ArrayType::new(
+            inner_field_schema,
             /* contains_null = */ false,
-        )));
+        ));
         let expr = Expr::array([Expr::struct_from([column_expr!("b")])]);
         let result = evaluate_expression(&expr, &batch, Some(&array_ty)).unwrap();
         let list = result.as_list::<i32>();

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -292,10 +292,7 @@ fn test_literal_complex_type_array() {
             map_type.clone(),
             [
                 ("array".to_string(), array_value.clone()),
-                (
-                    "null_array".to_string(),
-                    Scalar::Null(array_type.clone().into()),
-                ),
+                ("null_array".to_string(), Scalar::null(array_type.clone())),
             ],
         )
         .unwrap(),
@@ -314,9 +311,9 @@ fn test_literal_complex_type_array() {
             vec![
                 Scalar::Integer(42),
                 array_value,
-                Scalar::Null(array_type.clone().into()),
+                Scalar::null(array_type.clone()),
                 map_value,
-                Scalar::Null(map_type.clone().into()),
+                Scalar::null(map_type.clone()),
             ],
         )
         .unwrap(),
@@ -327,7 +324,7 @@ fn test_literal_complex_type_array() {
             nested_array_type.clone(),
             vec![
                 struct_value.clone(),
-                Scalar::Null(struct_type.clone().into()),
+                Scalar::null(struct_type.clone()),
                 struct_value.clone(),
             ],
         )
@@ -1052,7 +1049,7 @@ fn test_scalar_map() -> DeltaResult<()> {
 #[test]
 fn test_null_scalar_map() -> DeltaResult<()> {
     let map_type = MapType::new(KernelDataType::STRING, KernelDataType::STRING, false);
-    let null_scalar_map = Scalar::Null(KernelDataType::from(map_type));
+    let null_scalar_map = Scalar::null(map_type);
     let arrow_array = null_scalar_map.to_array(1)?;
     let map_array = arrow_array.as_any().downcast_ref::<MapArray>().unwrap();
 

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -286,11 +286,7 @@ fn test_literal_complex_type_array() {
         )
         .unwrap(),
     );
-    let map_type = MapType::new(
-        KernelDataType::STRING,
-        KernelDataType::Array(Box::new(array_type.clone())),
-        true,
-    );
+    let map_type = MapType::new(KernelDataType::STRING, array_type.clone(), true);
     let map_value = Scalar::Map(
         MapData::try_new(
             map_type.clone(),
@@ -325,7 +321,7 @@ fn test_literal_complex_type_array() {
         )
         .unwrap(),
     );
-    let nested_array_type = ArrayType::new(struct_type.clone().into(), true);
+    let nested_array_type = ArrayType::new(struct_type.clone(), true);
     let nested_array_value = Scalar::Array(
         ArrayData::try_new(
             nested_array_type.clone(),
@@ -1056,7 +1052,7 @@ fn test_scalar_map() -> DeltaResult<()> {
 #[test]
 fn test_null_scalar_map() -> DeltaResult<()> {
     let map_type = MapType::new(KernelDataType::STRING, KernelDataType::STRING, false);
-    let null_scalar_map = Scalar::Null(KernelDataType::Map(Box::new(map_type)));
+    let null_scalar_map = Scalar::Null(KernelDataType::from(map_type));
     let arrow_array = null_scalar_map.to_array(1)?;
     let map_array = arrow_array.as_any().downcast_ref::<MapArray>().unwrap();
 
@@ -1086,10 +1082,10 @@ fn test_apply_schema_column_count_mismatch() {
     ]);
 
     // Create a schema with only 2 fields (mismatch)
-    let schema = KernelDataType::Struct(Box::new(StructType::new_unchecked([
+    let schema = KernelDataType::from(StructType::new_unchecked([
         StructField::not_null("a", KernelDataType::INTEGER),
         StructField::not_null("b", KernelDataType::INTEGER),
-    ])));
+    ]));
 
     let result = apply_schema(&struct_array, &schema);
 
@@ -1288,7 +1284,7 @@ fn test_evaluator_mixed_string_types_identity_transform() {
     let engine_data = ArrowEngineData::new(make_mixed_string_batch());
     let fields = mixed_string_kernel_fields();
     let input_schema = Arc::new(StructType::new_unchecked(fields.clone()));
-    let output_type = KernelDataType::Struct(Box::new(StructType::new_unchecked(fields)));
+    let output_type = KernelDataType::from(StructType::new_unchecked(fields));
 
     let handler = ArrowEvaluationHandler;
     let expression: ExpressionRef = Arc::new(Expression::StructPatch(
@@ -1320,7 +1316,7 @@ fn test_evaluator_mixed_string_types_struct_expression() {
         "st",
         KernelDataType::struct_type_unchecked(fields.clone()),
     )]));
-    let output_type = KernelDataType::Struct(Box::new(StructType::new_unchecked(fields)));
+    let output_type = KernelDataType::from(StructType::new_unchecked(fields));
 
     let handler = ArrowEvaluationHandler;
     let expression: ExpressionRef = Arc::new(column_expr!("st"));

--- a/kernel/src/engine/arrow_utils/apply_schema.rs
+++ b/kernel/src/engine/arrow_utils/apply_schema.rs
@@ -471,10 +471,10 @@ mod apply_schema_validation_tests {
         .unwrap();
 
         // Target schema with nullable fields
-        let target_schema = DataType::Struct(Box::new(StructType::new_unchecked([
+        let target_schema = DataType::from(StructType::new_unchecked([
             StructField::new("a", DataType::INTEGER, true),
             StructField::new("b", DataType::INTEGER, true),
-        ])));
+        ]));
 
         // Apply schema - should successfully convert to RecordBatch
         let result = apply_schema(&struct_array, &target_schema).unwrap();
@@ -602,7 +602,7 @@ mod apply_schema_validation_tests {
     fn test_apply_schema_threads_nested_ids_onto_arrow_schema() {
         let meta_key = ColumnMetadataKey::ColumnMappingNestedIds.as_ref();
         let fixture = complex_nested_with_field_ids(meta_key);
-        let kernel_type = DataType::Struct(Box::new(fixture.kernel_schema));
+        let kernel_type = DataType::from(fixture.kernel_schema);
         let result = apply_schema(&fixture.input_arrow_data, &kernel_type).unwrap();
 
         assert_eq!(
@@ -624,7 +624,7 @@ mod apply_schema_validation_tests {
         );
         let kernel_schema =
             array_in_map_with_field_ids(ColumnMetadataKey::ColumnMappingNestedIds.as_ref());
-        let result = apply_schema(&input, &DataType::Struct(Box::new(kernel_schema))).unwrap();
+        let result = apply_schema(&input, &DataType::from(kernel_schema)).unwrap();
 
         let result_schema = result.schema();
         let ArrowDataType::Map(entries_field, _) = result_schema.field(0).data_type() else {
@@ -673,7 +673,7 @@ mod apply_schema_validation_tests {
         #[case] schema: StructType,
         #[case] expected_field_ids: &[(&str, &str)],
     ) {
-        let kernel_type = DataType::Struct(Box::new(schema));
+        let kernel_type = DataType::from(schema);
         let result =
             apply_schema(&array_in_map_arrow_data_without_field_ids(), &kernel_type).unwrap();
         let field_ids: HashMap<String, String> =
@@ -709,7 +709,7 @@ mod apply_schema_validation_tests {
                 .to_string(),
             value,
         )]);
-        let kernel_type = DataType::Struct(Box::new(schema));
+        let kernel_type = DataType::from(schema);
 
         assert_result_error_with_message(
             apply_schema(&array_in_map_arrow_data_without_field_ids(), &kernel_type),

--- a/kernel/src/engine/arrow_utils/mod.rs
+++ b/kernel/src/engine/arrow_utils/mod.rs
@@ -2950,8 +2950,7 @@ mod tests {
                                 .with_metadata(column_mapping_metadata(3, mode)),
                             StructField::not_null(logical_name(4), DataType::STRING)
                                 .with_metadata(column_mapping_metadata(4, mode)),
-                        ])
-                        .into(),
+                        ]),
                         false,
                     ),
                 )
@@ -3060,8 +3059,7 @@ mod tests {
                             logical_name(4),
                             DataType::INTEGER,
                         )
-                        .with_metadata(column_mapping_metadata(4, mode))])
-                        .into(),
+                        .with_metadata(column_mapping_metadata(4, mode))]),
                         false,
                     ),
                 )
@@ -3123,8 +3121,7 @@ mod tests {
                                 .with_metadata(column_mapping_metadata(6, mode)),
                             StructField::not_null(logical_name(5), DataType::INTEGER)
                                 .with_metadata(column_mapping_metadata(5, mode)),
-                        ])
-                        .into(),
+                        ]),
                         false,
                     ),
                 )
@@ -4156,13 +4153,13 @@ mod tests {
         let target_schema: SchemaRef =
             Arc::new(StructType::new_unchecked([StructField::nullable(
                 "outer",
-                DataType::Struct(Box::new(StructType::new_unchecked([
+                StructType::new_unchecked([
                     StructField::nullable("lst", ArrayType::new(DataType::INTEGER, true)),
                     StructField::nullable(
                         "mp",
                         MapType::new(DataType::STRING, DataType::INTEGER, true),
                     ),
-                ]))),
+                ]),
             )]));
 
         let ordering = [ReorderIndex::identity(0)];
@@ -4249,15 +4246,16 @@ mod tests {
         let target_schema: SchemaRef =
             Arc::new(StructType::new_unchecked([StructField::not_null(
                 "outer",
-                DataType::Struct(Box::new(StructType::new_unchecked([
+                StructType::new_unchecked([
                     StructField::not_null("tgt_x", DataType::INTEGER),
                     StructField::not_null(
                         "tgt_y",
-                        DataType::Struct(Box::new(StructType::new_unchecked([
-                            StructField::not_null("tgt_z", DataType::INTEGER),
-                        ]))),
+                        StructType::new_unchecked([StructField::not_null(
+                            "tgt_z",
+                            DataType::INTEGER,
+                        )]),
                     ),
-                ]))),
+                ]),
             )]));
 
         let ordering = [ReorderIndex::identity(0)];

--- a/kernel/src/engine/ensure_data_types.rs
+++ b/kernel/src/engine/ensure_data_types.rs
@@ -437,11 +437,7 @@ mod tests {
             false,
         );
         assert!(ensure_data_types(
-            &DataType::Map(Box::new(MapType::new(
-                DataType::LONG,
-                DataType::STRING,
-                true
-            ))),
+            &DataType::from(MapType::new(DataType::LONG, DataType::STRING, true)),
             arrow_field.data_type(),
             ValidationMode::TypesAndNames
         )
@@ -449,11 +445,7 @@ mod tests {
 
         assert_result_error_with_message(
             ensure_data_types(
-                &DataType::Map(Box::new(MapType::new(
-                    DataType::LONG,
-                    DataType::STRING,
-                    false,
-                ))),
+                &DataType::from(MapType::new(DataType::LONG, DataType::STRING, false)),
                 arrow_field.data_type(),
                 ValidationMode::Full,
             ),
@@ -461,7 +453,7 @@ mod tests {
         );
         assert_result_error_with_message(
             ensure_data_types(
-                &DataType::Map(Box::new(MapType::new(DataType::LONG, DataType::LONG, true))),
+                &DataType::from(MapType::new(DataType::LONG, DataType::LONG, true)),
                 arrow_field.data_type(),
                 ValidationMode::TypesAndNames,
             ),
@@ -472,20 +464,20 @@ mod tests {
     #[test]
     fn ensure_list() {
         assert!(ensure_data_types(
-            &DataType::Array(Box::new(ArrayType::new(DataType::LONG, true))),
+            &DataType::from(ArrayType::new(DataType::LONG, true)),
             &ArrowDataType::new_list(ArrowDataType::Int64, true),
             ValidationMode::TypesAndNames
         )
         .is_ok());
         assert!(ensure_data_types(
-            &DataType::Array(Box::new(ArrayType::new(DataType::LONG, true))),
+            &DataType::from(ArrayType::new(DataType::LONG, true)),
             &ArrowDataType::new_large_list(ArrowDataType::Int64, true),
             ValidationMode::TypesAndNames
         )
         .is_ok());
         assert_result_error_with_message(
             ensure_data_types(
-                &DataType::Array(Box::new(ArrayType::new(DataType::STRING, true))),
+                &DataType::from(ArrayType::new(DataType::STRING, true)),
                 &ArrowDataType::new_list(ArrowDataType::Int64, true),
                 ValidationMode::TypesAndNames,
             ),
@@ -493,7 +485,7 @@ mod tests {
         );
         assert_result_error_with_message(
             ensure_data_types(
-                &DataType::Array(Box::new(ArrayType::new(DataType::LONG, true))),
+                &DataType::from(ArrayType::new(DataType::LONG, true)),
                 &ArrowDataType::new_list(ArrowDataType::Int64, false),
                 ValidationMode::Full,
             ),
@@ -601,7 +593,7 @@ mod tests {
         );
         assert_eq!(
             ensure_data_types(
-                &DataType::Array(Box::new(ArrayType::new(DataType::LONG, true))),
+                &DataType::from(ArrayType::new(DataType::LONG, true)),
                 &ArrowDataType::ListView(Arc::new(ArrowField::new_list_field(
                     ArrowDataType::Int64,
                     true
@@ -613,7 +605,7 @@ mod tests {
         );
         assert_eq!(
             ensure_data_types(
-                &DataType::Array(Box::new(ArrayType::new(DataType::LONG, true))),
+                &DataType::from(ArrayType::new(DataType::LONG, true)),
                 &ArrowDataType::LargeListView(Arc::new(ArrowField::new_list_field(
                     ArrowDataType::Int64,
                     true

--- a/kernel/src/expressions/literal_expression_transform.rs
+++ b/kernel/src/expressions/literal_expression_transform.rs
@@ -260,8 +260,8 @@ mod tests {
             Scalar::Array(array_data.clone()),
         ];
         let schema = Arc::new(StructType::new_unchecked([
-            StructField::nullable("map", DeltaDataTypes::Map(Box::new(map_type))),
-            StructField::nullable("array", DeltaDataTypes::Array(Box::new(array_type))),
+            StructField::nullable("map", map_type),
+            StructField::nullable("array", array_type),
         ]));
         let expected = Expr::struct_from(vec![
             Expr::literal(Scalar::Map(map_data)),

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -285,6 +285,17 @@ impl Scalar {
         matches!(self, Self::Null(_))
     }
 
+    /// Constructs a null `Scalar` of the given type. Accepts anything convertible into a
+    /// [`DataType`], so container types like [`StructType`], [`ArrayType`], and [`MapType`]
+    /// can be passed directly without an explicit `DataType::from(...)` wrapper.
+    ///
+    /// [`StructType`]: crate::schema::StructType
+    /// [`ArrayType`]: crate::schema::ArrayType
+    /// [`MapType`]: crate::schema::MapType
+    pub fn null(data_type: impl Into<DataType>) -> Self {
+        Self::Null(data_type.into())
+    }
+
     /// Constructs a Decimal value from raw parts
     pub fn decimal(bits: impl Into<i128>, precision: u8, scale: u8) -> DeltaResult<Self> {
         let dtype = DecimalType::try_new(precision, scale)?;

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -918,17 +918,11 @@ impl LogSegment {
                 let mut add_fields: Vec<StructField> = add_struct.fields().cloned().collect();
 
                 if let (true, Some(ss)) = (has_stats_parsed, stats_schema) {
-                    add_fields.push(StructField::nullable(
-                        "stats_parsed",
-                        DataType::Struct(Box::new(ss.clone())),
-                    ));
+                    add_fields.push(StructField::nullable("stats_parsed", ss.clone()));
                 }
 
                 if let (true, Some(ps)) = (has_partition_values_parsed, partition_schema) {
-                    add_fields.push(StructField::nullable(
-                        "partitionValues_parsed",
-                        DataType::Struct(Box::new(ps.clone())),
-                    ));
+                    add_fields.push(StructField::nullable("partitionValues_parsed", ps.clone()));
                 }
 
                 // Rebuild schema with modified add field

--- a/kernel/src/partition/serialization.rs
+++ b/kernel/src/partition/serialization.rs
@@ -257,10 +257,7 @@ mod tests {
     /// columns should be rejected by validation before reaching serialization.
     #[test]
     fn test_null_complex_type_returns_none() {
-        let val = Scalar::Null(DataType::Array(Box::new(ArrayType::new(
-            DataType::INTEGER,
-            false,
-        ))));
+        let val = Scalar::Null(DataType::from(ArrayType::new(DataType::INTEGER, false)));
         assert_eq!(serialize_partition_value(&val).unwrap(), None);
     }
 

--- a/kernel/src/partition/serialization.rs
+++ b/kernel/src/partition/serialization.rs
@@ -257,7 +257,7 @@ mod tests {
     /// columns should be rejected by validation before reaching serialization.
     #[test]
     fn test_null_complex_type_returns_none() {
-        let val = Scalar::Null(DataType::from(ArrayType::new(DataType::INTEGER, false)));
+        let val = Scalar::null(ArrayType::new(DataType::INTEGER, false));
         assert_eq!(serialize_partition_value(&val).unwrap(), None);
     }
 

--- a/kernel/src/partition/validation.rs
+++ b/kernel/src/partition/validation.rs
@@ -452,17 +452,15 @@ mod tests {
     /// Complex types (struct, array, map) are rejected as partition column types.
     #[rstest]
     #[case(
-        DataType::Struct(Box::new(StructType::new_unchecked(vec![
-            StructField::not_null("x", DataType::INTEGER),
-        ]))),
+        DataType::from(StructType::new_unchecked(vec![StructField::not_null("x", DataType::INTEGER)])),
         Scalar::Null(DataType::STRING)
     )]
     #[case(
-        DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, false))),
+        DataType::from(ArrayType::new(DataType::INTEGER, false)),
         Scalar::Null(DataType::STRING)
     )]
     #[case(
-        DataType::Map(Box::new(MapType::new(DataType::STRING, DataType::INTEGER, false))),
+        DataType::from(MapType::new(DataType::STRING, DataType::INTEGER, false)),
         Scalar::Null(DataType::STRING)
     )]
     fn test_validate_types_complex_type_returns_error(

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -236,18 +236,10 @@ impl DataSkippingFilter {
             .map(|s| s.fields().map(|f| f.name().to_string()).collect())
             .unwrap_or_default();
 
-        let stats_field = |stats: &SchemaRef| {
-            StructField::nullable(
-                "stats_parsed",
-                DataType::Struct(Box::new(stats.as_ref().clone())),
-            )
-        };
-        let partition_field = |ps: &SchemaRef| {
-            StructField::nullable(
-                "partitionValues_parsed",
-                DataType::Struct(Box::new(ps.as_ref().clone())),
-            )
-        };
+        let stats_field =
+            |stats: &SchemaRef| StructField::nullable("stats_parsed", stats.as_ref().clone());
+        let partition_field =
+            |ps: &SchemaRef| StructField::nullable("partitionValues_parsed", ps.as_ref().clone());
         let is_add_field = StructField::not_null("is_add", DataType::BOOLEAN);
 
         // When partition columns are present, include an `is_add` boolean so that partition

--- a/kernel/src/scan/data_skipping/stats_schema/column_filter.rs
+++ b/kernel/src/scan/data_skipping/stats_schema/column_filter.rs
@@ -367,7 +367,7 @@ mod tests {
         ]);
         let user_struct = StructType::new_unchecked([
             StructField::nullable("name", DataType::STRING),
-            StructField::nullable("address", DataType::Struct(Box::new(address_struct))),
+            StructField::nullable("address", address_struct),
         ]);
         let other_struct = StructType::new_unchecked([
             StructField::nullable("foo", DataType::STRING),
@@ -377,8 +377,8 @@ mod tests {
         let schema = StructType::new_unchecked([
             StructField::nullable("id", DataType::LONG),
             StructField::nullable("name", DataType::STRING),
-            StructField::nullable("user", DataType::Struct(Box::new(user_struct))),
-            StructField::nullable("other", DataType::Struct(Box::new(other_struct))),
+            StructField::nullable("user", user_struct),
+            StructField::nullable("other", other_struct),
             StructField::nullable("extra1", DataType::STRING),
             StructField::nullable("extra2", DataType::STRING),
         ]);

--- a/kernel/src/scan/data_skipping/stats_schema/mod.rs
+++ b/kernel/src/scan/data_skipping/stats_schema/mod.rs
@@ -446,7 +446,7 @@ mod tests {
         ]);
         let file_schema = StructType::new_unchecked([
             StructField::not_null("id", DataType::LONG),
-            StructField::not_null("user", DataType::Struct(Box::new(user_struct.clone()))),
+            StructField::not_null("user", user_struct.clone()),
         ]);
         let stats_schema = expected_stats_schema(
             &file_schema,
@@ -482,7 +482,7 @@ mod tests {
         //   - "score" (DOUBLE) - eligible for data skipping
 
         // Create array type for a field that's not eligible for data skipping
-        let array_type = DataType::Array(Box::new(ArrayType::new(DataType::STRING, false)));
+        let array_type = DataType::from(ArrayType::new(DataType::STRING, false));
         let metadata_struct = StructType::new_unchecked([
             StructField::nullable("name", DataType::STRING),
             StructField::nullable("tags", array_type),
@@ -490,10 +490,7 @@ mod tests {
         ]);
         let file_schema = StructType::new_unchecked([
             StructField::nullable("id", DataType::LONG),
-            StructField::nullable(
-                "metadata",
-                DataType::Struct(Box::new(metadata_struct.clone())),
-            ),
+            StructField::nullable("metadata", metadata_struct.clone()),
         ]);
 
         let stats_schema = expected_stats_schema(
@@ -512,7 +509,7 @@ mod tests {
         ]);
         let expected_null = StructType::new_unchecked([
             StructField::nullable("id", DataType::LONG),
-            StructField::nullable("metadata", DataType::Struct(Box::new(expected_null_nested))),
+            StructField::nullable("metadata", expected_null_nested),
         ]);
 
         let expected_nested = StructType::new_unchecked([
@@ -521,7 +518,7 @@ mod tests {
         ]);
         let expected_fields = StructType::new_unchecked([
             StructField::nullable("id", DataType::LONG),
-            StructField::nullable("metadata", DataType::Struct(Box::new(expected_nested))),
+            StructField::nullable("metadata", expected_nested),
         ]);
 
         let expected = expected_stats(expected_null, expected_fields);
@@ -543,7 +540,7 @@ mod tests {
         ]);
         let file_schema = StructType::new_unchecked([
             StructField::nullable("id", DataType::LONG),
-            StructField::nullable("user.info", DataType::Struct(Box::new(user_struct.clone()))),
+            StructField::nullable("user.info", user_struct.clone()),
         ]);
 
         let stats_schema = expected_stats_schema(
@@ -556,10 +553,8 @@ mod tests {
 
         let expected_nested =
             StructType::new_unchecked([StructField::nullable("name", DataType::STRING)]);
-        let expected_fields = StructType::new_unchecked([StructField::nullable(
-            "user.info",
-            DataType::Struct(Box::new(expected_nested)),
-        )]);
+        let expected_fields =
+            StructType::new_unchecked([StructField::nullable("user.info", expected_nested)]);
         let null_count = NullCountStatsTransform
             .transform_struct(&expected_fields)
             .into_owned();
@@ -581,17 +576,10 @@ mod tests {
 
         let file_schema = StructType::new_unchecked([
             StructField::nullable("id", DataType::LONG),
-            StructField::nullable(
-                "tags",
-                DataType::Array(Box::new(ArrayType::new(DataType::STRING, false))),
-            ),
+            StructField::nullable("tags", ArrayType::new(DataType::STRING, false)),
             StructField::nullable(
                 "metadata",
-                DataType::Map(Box::new(MapType::new(
-                    DataType::STRING,
-                    DataType::STRING,
-                    true,
-                ))),
+                MapType::new(DataType::STRING, DataType::STRING, true),
             ),
             StructField::nullable("name", DataType::STRING),
         ]);
@@ -710,7 +698,7 @@ mod tests {
 
         let file_schema = StructType::new_unchecked([
             StructField::nullable("id", DataType::LONG),
-            StructField::nullable("user", DataType::Struct(Box::new(user_struct.clone()))),
+            StructField::nullable("user", user_struct.clone()),
             StructField::nullable("is_deleted", DataType::BOOLEAN), // NOT eligible for min/max
         ]);
 
@@ -731,7 +719,7 @@ mod tests {
         ]);
         let expected_null_count = StructType::new_unchecked([
             StructField::nullable("id", DataType::LONG),
-            StructField::nullable("user", DataType::Struct(Box::new(expected_null_user))),
+            StructField::nullable("user", expected_null_user),
             StructField::nullable("is_deleted", DataType::LONG),
         ]);
 
@@ -742,7 +730,7 @@ mod tests {
         ]);
         let expected_min_max = StructType::new_unchecked([
             StructField::nullable("id", DataType::LONG),
-            StructField::nullable("user", DataType::Struct(Box::new(expected_minmax_user))),
+            StructField::nullable("user", expected_minmax_user),
         ]);
 
         let expected = expected_stats(expected_null_count, expected_min_max);
@@ -758,10 +746,7 @@ mod tests {
         let file_schema = StructType::new_unchecked([
             StructField::nullable("is_active", DataType::BOOLEAN),
             StructField::nullable("metadata", DataType::BINARY),
-            StructField::nullable(
-                "tags",
-                DataType::Array(Box::new(ArrayType::new(DataType::STRING, false))),
-            ),
+            StructField::nullable("tags", ArrayType::new(DataType::STRING, false)),
         ]);
 
         let stats_schema = expected_stats_schema(
@@ -803,17 +788,10 @@ mod tests {
         .into();
 
         let file_schema = StructType::new_unchecked([
-            StructField::nullable(
-                "tags",
-                DataType::Array(Box::new(ArrayType::new(DataType::STRING, false))),
-            ),
+            StructField::nullable("tags", ArrayType::new(DataType::STRING, false)),
             StructField::nullable(
                 "metadata",
-                DataType::Map(Box::new(MapType::new(
-                    DataType::STRING,
-                    DataType::STRING,
-                    true,
-                ))),
+                MapType::new(DataType::STRING, DataType::STRING, true),
             ),
             StructField::nullable("v", DataType::unshredded_variant()),
             StructField::nullable("col1", DataType::LONG),
@@ -860,10 +838,7 @@ mod tests {
 
         let file_schema = StructType::new_unchecked([
             StructField::nullable("id", DataType::LONG),
-            StructField::nullable(
-                "tags",
-                DataType::Array(Box::new(ArrayType::new(DataType::STRING, false))),
-            ),
+            StructField::nullable("tags", ArrayType::new(DataType::STRING, false)),
             StructField::nullable("name", DataType::STRING),
         ]);
 
@@ -908,7 +883,7 @@ mod tests {
         ]);
         let file_schema = StructType::new_unchecked([
             StructField::nullable("id", DataType::LONG),
-            StructField::nullable("user", DataType::Struct(Box::new(user_struct))),
+            StructField::nullable("user", user_struct),
         ]);
 
         let config = StatsConfig {
@@ -970,7 +945,7 @@ mod tests {
         ]);
         let file_schema = StructType::new_unchecked([
             StructField::nullable("id", DataType::LONG),
-            StructField::nullable("user", DataType::Struct(Box::new(user_struct))),
+            StructField::nullable("user", user_struct),
             StructField::nullable("extra", DataType::STRING),
         ]);
 
@@ -993,17 +968,10 @@ mod tests {
 
         let file_schema = StructType::new_unchecked([
             StructField::nullable("id", DataType::LONG),
-            StructField::nullable(
-                "tags",
-                DataType::Array(Box::new(ArrayType::new(DataType::STRING, false))),
-            ),
+            StructField::nullable("tags", ArrayType::new(DataType::STRING, false)),
             StructField::nullable(
                 "metadata",
-                DataType::Map(Box::new(MapType::new(
-                    DataType::STRING,
-                    DataType::STRING,
-                    true,
-                ))),
+                MapType::new(DataType::STRING, DataType::STRING, true),
             ),
             StructField::nullable("v", DataType::unshredded_variant()),
             StructField::nullable("name", DataType::STRING),
@@ -1255,7 +1223,7 @@ mod tests {
         ]);
         let file_schema = StructType::new_unchecked([
             StructField::nullable("id", DataType::LONG),
-            StructField::nullable("user", DataType::Struct(Box::new(user_struct))),
+            StructField::nullable("user", user_struct),
         ]);
 
         let columns = [ColumnName::new(["user", "name"])];
@@ -1269,17 +1237,13 @@ mod tests {
 
         let expected_user_nested =
             StructType::new_unchecked([StructField::nullable("name", DataType::STRING)]);
-        let expected_nested = StructType::new_unchecked([StructField::nullable(
-            "user",
-            DataType::Struct(Box::new(expected_user_nested)),
-        )]);
+        let expected_nested =
+            StructType::new_unchecked([StructField::nullable("user", expected_user_nested)]);
 
         let expected_user_null =
             StructType::new_unchecked([StructField::nullable("name", DataType::LONG)]);
-        let expected_null = StructType::new_unchecked([StructField::nullable(
-            "user",
-            DataType::Struct(Box::new(expected_user_null)),
-        )]);
+        let expected_null =
+            StructType::new_unchecked([StructField::nullable("user", expected_user_null)]);
 
         let expected = expected_stats(expected_null, expected_nested);
 
@@ -1323,7 +1287,7 @@ mod tests {
         ]);
         let file_schema = StructType::new_unchecked([
             StructField::nullable("id", DataType::LONG),
-            StructField::nullable("user", DataType::Struct(Box::new(user_struct))),
+            StructField::nullable("user", user_struct),
             StructField::nullable("value", DataType::DOUBLE),
         ]);
 
@@ -1340,17 +1304,14 @@ mod tests {
             StructType::new_unchecked([StructField::nullable("age", DataType::INTEGER)]);
         let expected_nested = StructType::new_unchecked([
             StructField::nullable("id", DataType::LONG),
-            StructField::nullable(
-                "user",
-                DataType::Struct(Box::new(expected_user_nested.clone())),
-            ),
+            StructField::nullable("user", expected_user_nested.clone()),
         ]);
 
         let expected_user_null =
             StructType::new_unchecked([StructField::nullable("age", DataType::LONG)]);
         let expected_null = StructType::new_unchecked([
             StructField::nullable("id", DataType::LONG),
-            StructField::nullable("user", DataType::Struct(Box::new(expected_user_null))),
+            StructField::nullable("user", expected_user_null),
         ]);
 
         let expected = expected_stats(expected_null, expected_nested);

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -1388,10 +1388,10 @@ pub(crate) mod tests {
             StructField::nullable("b", DataType::LONG),
             StructField::nullable(
                 "s",
-                DataType::Struct(Box::new(StructType::new_unchecked(vec![
+                StructType::new_unchecked(vec![
                     StructField::nullable("c", DataType::LONG),
                     StructField::nullable("d", DataType::LONG),
-                ]))),
+                ]),
             ),
         ]));
         // Predicate only on the past-cap leaf -> stats schema goes empty -> None.
@@ -1447,10 +1447,10 @@ pub(crate) mod tests {
             StructField::nullable("b", DataType::LONG),
             StructField::nullable(
                 "s",
-                DataType::Struct(Box::new(StructType::new_unchecked(vec![
+                StructType::new_unchecked(vec![
                     StructField::nullable("c", DataType::LONG),
                     StructField::nullable("d", DataType::LONG),
-                ]))),
+                ]),
             ),
         ]));
         let predicate = Arc::new(Pred::and(
@@ -1505,10 +1505,10 @@ pub(crate) mod tests {
             StructField::nullable("a", DataType::LONG),
             StructField::nullable(
                 "s",
-                DataType::Struct(Box::new(StructType::new_unchecked(vec![
+                StructType::new_unchecked(vec![
                     StructField::nullable("c", DataType::LONG),
                     StructField::nullable("d", DataType::LONG),
-                ]))),
+                ]),
             ),
         ]));
         let state_info = get_state_info(

--- a/kernel/src/schema/diff.rs
+++ b/kernel/src/schema/diff.rs
@@ -743,7 +743,7 @@ mod tests {
 
     fn create_field_with_id(
         name: &str,
-        data_type: DataType,
+        data_type: impl Into<DataType>,
         nullable: bool,
         id: i64,
     ) -> StructField {

--- a/kernel/src/schema/diff.rs
+++ b/kernel/src/schema/diff.rs
@@ -1123,7 +1123,7 @@ mod tests {
         let before = StructType::new_unchecked([]);
         let after = StructType::new_unchecked([create_field_with_id(
             "items",
-            DataType::Array(Box::new(ArrayType::new(
+            ArrayType::new(
                 DataType::try_struct_type([create_field_with_id(
                     "name",
                     DataType::STRING,
@@ -1132,7 +1132,7 @@ mod tests {
                 )])
                 .unwrap(),
                 false,
-            ))),
+            ),
             true,
             1,
         )]);
@@ -1250,7 +1250,7 @@ mod tests {
         // Test that array containers aren't reported as changed when their struct elements change
         let before = StructType::new_unchecked([create_field_with_id(
             "items",
-            DataType::Array(Box::new(ArrayType::new(
+            ArrayType::new(
                 DataType::try_struct_type([create_field_with_id(
                     "name",
                     DataType::STRING,
@@ -1259,20 +1259,20 @@ mod tests {
                 )])
                 .unwrap(),
                 true,
-            ))),
+            ),
             false,
             1,
         )]);
 
         let after = StructType::new_unchecked([create_field_with_id(
             "items",
-            DataType::Array(Box::new(ArrayType::new(
+            ArrayType::new(
                 DataType::try_struct_type([
                     create_field_with_id("title", DataType::STRING, false, 2), // Renamed
                 ])
                 .unwrap(),
                 true,
-            ))),
+            ),
             false,
             1,
         )]);
@@ -1597,28 +1597,28 @@ mod tests {
     fn test_array_element_struct_field_changes() {
         let before = StructType::new_unchecked([create_field_with_id(
             "items",
-            DataType::Array(Box::new(ArrayType::new(
+            ArrayType::new(
                 DataType::try_struct_type([
                     create_field_with_id("name", DataType::STRING, false, 2),
                     create_field_with_id("removed_field", DataType::INTEGER, true, 3),
                 ])
                 .unwrap(),
                 true,
-            ))),
+            ),
             false,
             1,
         )]);
 
         let after = StructType::new_unchecked([create_field_with_id(
             "items",
-            DataType::Array(Box::new(ArrayType::new(
+            ArrayType::new(
                 DataType::try_struct_type([
                     create_field_with_id("title", DataType::STRING, false, 2), // Renamed!
                     create_field_with_id("added_field", DataType::STRING, true, 4), // Added!
                 ])
                 .unwrap(),
                 true,
-            ))),
+            ),
             false,
             1,
         )]);
@@ -1655,20 +1655,14 @@ mod tests {
         // array<array<double>>
         let before = StructType::new_unchecked([create_field_with_id(
             "matrix",
-            DataType::Array(Box::new(ArrayType::new(
-                DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, false))),
-                false,
-            ))),
+            ArrayType::new(ArrayType::new(DataType::INTEGER, false), false),
             false,
             1,
         )]);
 
         let after = StructType::new_unchecked([create_field_with_id(
             "matrix",
-            DataType::Array(Box::new(ArrayType::new(
-                DataType::Array(Box::new(ArrayType::new(DataType::DOUBLE, false))),
-                false,
-            ))),
+            ArrayType::new(ArrayType::new(DataType::DOUBLE, false), false),
             false,
             1,
         )]);
@@ -1694,14 +1688,14 @@ mod tests {
         // Test direct primitive element type change: array<string> -> array<int>
         let before = StructType::new_unchecked([create_field_with_id(
             "items",
-            DataType::Array(Box::new(ArrayType::new(DataType::STRING, false))),
+            ArrayType::new(DataType::STRING, false),
             false,
             1,
         )]);
 
         let after = StructType::new_unchecked([create_field_with_id(
             "items",
-            DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, false))),
+            ArrayType::new(DataType::INTEGER, false),
             false,
             1,
         )]);
@@ -1725,20 +1719,20 @@ mod tests {
         // Outer array element nullability loosened (safe change)
         let before = StructType::new_unchecked([create_field_with_id(
             "matrix",
-            DataType::Array(Box::new(ArrayType::new(
-                DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, false))),
+            ArrayType::new(
+                ArrayType::new(DataType::INTEGER, false),
                 false, // Outer array elements are non-nullable
-            ))),
+            ),
             false,
             1,
         )]);
 
         let after = StructType::new_unchecked([create_field_with_id(
             "matrix",
-            DataType::Array(Box::new(ArrayType::new(
-                DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, false))),
+            ArrayType::new(
+                ArrayType::new(DataType::INTEGER, false),
                 true, // Outer array elements now nullable
-            ))),
+            ),
             false,
             1,
         )]);
@@ -1762,20 +1756,20 @@ mod tests {
         // Outer array element nullability tightened (breaking change)
         let before = StructType::new_unchecked([create_field_with_id(
             "matrix",
-            DataType::Array(Box::new(ArrayType::new(
-                DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, false))),
+            ArrayType::new(
+                ArrayType::new(DataType::INTEGER, false),
                 true, // Outer array elements are nullable
-            ))),
+            ),
             false,
             1,
         )]);
 
         let after = StructType::new_unchecked([create_field_with_id(
             "matrix",
-            DataType::Array(Box::new(ArrayType::new(
-                DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, false))),
+            ArrayType::new(
+                ArrayType::new(DataType::INTEGER, false),
                 false, // Outer array elements now non-nullable
-            ))),
+            ),
             false,
             1,
         )]);
@@ -1799,20 +1793,20 @@ mod tests {
         // Inner array element nullability loosened (safe change)
         let before = StructType::new_unchecked([create_field_with_id(
             "matrix",
-            DataType::Array(Box::new(ArrayType::new(
-                DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, false))), /* Inner elements non-nullable */
+            ArrayType::new(
+                ArrayType::new(DataType::INTEGER, false), /* Inner elements non-nullable */
                 false,
-            ))),
+            ),
             false,
             1,
         )]);
 
         let after = StructType::new_unchecked([create_field_with_id(
             "matrix",
-            DataType::Array(Box::new(ArrayType::new(
-                DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))), /* Inner elements now nullable */
+            ArrayType::new(
+                ArrayType::new(DataType::INTEGER, true), /* Inner elements now nullable */
                 false,
-            ))),
+            ),
             false,
             1,
         )]);
@@ -1836,20 +1830,20 @@ mod tests {
         // Inner array element nullability tightened (breaking change)
         let before = StructType::new_unchecked([create_field_with_id(
             "matrix",
-            DataType::Array(Box::new(ArrayType::new(
-                DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))), /* Inner elements nullable */
+            ArrayType::new(
+                ArrayType::new(DataType::INTEGER, true), /* Inner elements nullable */
                 false,
-            ))),
+            ),
             false,
             1,
         )]);
 
         let after = StructType::new_unchecked([create_field_with_id(
             "matrix",
-            DataType::Array(Box::new(ArrayType::new(
-                DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, false))), /* Inner elements now non-nullable */
+            ArrayType::new(
+                ArrayType::new(DataType::INTEGER, false), /* Inner elements now non-nullable */
                 false,
-            ))),
+            ),
             false,
             1,
         )]);
@@ -1871,15 +1865,15 @@ mod tests {
     fn test_array_nullability_loosened() {
         let before = StructType::new_unchecked([create_field_with_id(
             "items",
-            DataType::Array(Box::new(ArrayType::new(DataType::STRING, false))), /* Non-nullable
-                                                                                 * elements */
+            ArrayType::new(DataType::STRING, false), /* Non-nullable
+                                                      * elements */
             false,
             1,
         )]);
 
         let after = StructType::new_unchecked([create_field_with_id(
             "items",
-            DataType::Array(Box::new(ArrayType::new(DataType::STRING, true))), /* Nullable elements now */
+            ArrayType::new(DataType::STRING, true), /* Nullable elements now */
             false,
             1,
         )]);
@@ -1901,14 +1895,14 @@ mod tests {
     fn test_array_nullability_tightened() {
         let before = StructType::new_unchecked([create_field_with_id(
             "items",
-            DataType::Array(Box::new(ArrayType::new(DataType::STRING, true))), // Nullable elements
+            ArrayType::new(DataType::STRING, true), // Nullable elements
             false,
             1,
         )]);
 
         let after = StructType::new_unchecked([create_field_with_id(
             "items",
-            DataType::Array(Box::new(ArrayType::new(DataType::STRING, false))), // Non-nullable now
+            ArrayType::new(DataType::STRING, false), // Non-nullable now
             false,
             1,
         )]);
@@ -1929,7 +1923,7 @@ mod tests {
     fn test_map_value_struct_field_changes() {
         let before = StructType::new_unchecked([create_field_with_id(
             "lookup",
-            DataType::Map(Box::new(MapType::new(
+            MapType::new(
                 DataType::STRING,
                 DataType::try_struct_type([
                     create_field_with_id("value", DataType::INTEGER, false, 2),
@@ -1937,14 +1931,14 @@ mod tests {
                 ])
                 .unwrap(),
                 true,
-            ))),
+            ),
             false,
             1,
         )]);
 
         let after = StructType::new_unchecked([create_field_with_id(
             "lookup",
-            DataType::Map(Box::new(MapType::new(
+            MapType::new(
                 DataType::STRING,
                 DataType::try_struct_type([
                     create_field_with_id("count", DataType::INTEGER, false, 2), // Renamed!
@@ -1952,7 +1946,7 @@ mod tests {
                 ])
                 .unwrap(),
                 true,
-            ))),
+            ),
             false,
             1,
         )]);
@@ -1989,7 +1983,7 @@ mod tests {
         // Struct element nullability loosened (safe change)
         let before = StructType::new_unchecked([create_field_with_id(
             "items",
-            DataType::Array(Box::new(ArrayType::new(
+            ArrayType::new(
                 DataType::try_struct_type([create_field_with_id(
                     "name",
                     DataType::STRING,
@@ -1998,14 +1992,14 @@ mod tests {
                 )])
                 .unwrap(),
                 false, // Struct elements non-nullable
-            ))),
+            ),
             false,
             1,
         )]);
 
         let after = StructType::new_unchecked([create_field_with_id(
             "items",
-            DataType::Array(Box::new(ArrayType::new(
+            ArrayType::new(
                 DataType::try_struct_type([create_field_with_id(
                     "name",
                     DataType::STRING,
@@ -2014,7 +2008,7 @@ mod tests {
                 )])
                 .unwrap(),
                 true, // Struct elements now nullable
-            ))),
+            ),
             false,
             1,
         )]);
@@ -2036,22 +2030,22 @@ mod tests {
     fn test_map_nullability_loosened() {
         let before = StructType::new_unchecked([create_field_with_id(
             "lookup",
-            DataType::Map(Box::new(MapType::new(
+            MapType::new(
                 DataType::STRING,
                 DataType::INTEGER,
                 false, // Non-nullable values
-            ))),
+            ),
             false,
             1,
         )]);
 
         let after = StructType::new_unchecked([create_field_with_id(
             "lookup",
-            DataType::Map(Box::new(MapType::new(
+            MapType::new(
                 DataType::STRING,
                 DataType::INTEGER,
                 true, // Nullable values now
-            ))),
+            ),
             false,
             1,
         )]);
@@ -2075,7 +2069,7 @@ mod tests {
         // Struct element nullability tightened (breaking change)
         let before = StructType::new_unchecked([create_field_with_id(
             "items",
-            DataType::Array(Box::new(ArrayType::new(
+            ArrayType::new(
                 DataType::try_struct_type([create_field_with_id(
                     "name",
                     DataType::STRING,
@@ -2084,14 +2078,14 @@ mod tests {
                 )])
                 .unwrap(),
                 true, // Struct elements nullable
-            ))),
+            ),
             false,
             1,
         )]);
 
         let after = StructType::new_unchecked([create_field_with_id(
             "items",
-            DataType::Array(Box::new(ArrayType::new(
+            ArrayType::new(
                 DataType::try_struct_type([create_field_with_id(
                     "name",
                     DataType::STRING,
@@ -2100,7 +2094,7 @@ mod tests {
                 )])
                 .unwrap(),
                 false, // Struct elements now non-nullable
-            ))),
+            ),
             false,
             1,
         )]);
@@ -2122,22 +2116,22 @@ mod tests {
     fn test_map_nullability_tightened() {
         let before = StructType::new_unchecked([create_field_with_id(
             "lookup",
-            DataType::Map(Box::new(MapType::new(
+            MapType::new(
                 DataType::STRING,
                 DataType::INTEGER,
                 true, // Nullable values
-            ))),
+            ),
             false,
             1,
         )]);
 
         let after = StructType::new_unchecked([create_field_with_id(
             "lookup",
-            DataType::Map(Box::new(MapType::new(
+            MapType::new(
                 DataType::STRING,
                 DataType::INTEGER,
                 false, // Non-nullable now
-            ))),
+            ),
             false,
             1,
         )]);
@@ -2162,15 +2156,15 @@ mod tests {
         // After: items: array<int> (elements nullable, type changed)
         let before = StructType::new_unchecked([create_field_with_id(
             "items",
-            DataType::Array(Box::new(ArrayType::new(DataType::STRING, false))), /* Non-nullable
-                                                                                 * elements */
+            ArrayType::new(DataType::STRING, false), /* Non-nullable
+                                                      * elements */
             false,
             1,
         )]);
 
         let after = StructType::new_unchecked([create_field_with_id(
             "items",
-            DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))), /* Nullable, type changed */
+            ArrayType::new(DataType::INTEGER, true), /* Nullable, type changed */
             false,
             1,
         )]);
@@ -2193,7 +2187,7 @@ mod tests {
         // Test that maps with struct keys can be diffed
         let before = StructType::new_unchecked([create_field_with_id(
             "lookup",
-            DataType::Map(Box::new(MapType::new(
+            MapType::new(
                 DataType::try_struct_type([create_field_with_id(
                     "id",
                     DataType::INTEGER,
@@ -2203,14 +2197,14 @@ mod tests {
                 .unwrap(),
                 DataType::STRING,
                 true,
-            ))),
+            ),
             false,
             1,
         )]);
 
         let after = StructType::new_unchecked([create_field_with_id(
             "lookup",
-            DataType::Map(Box::new(MapType::new(
+            MapType::new(
                 DataType::try_struct_type([create_field_with_id(
                     "identifier", // Renamed key field
                     DataType::INTEGER,
@@ -2220,7 +2214,7 @@ mod tests {
                 .unwrap(),
                 DataType::STRING,
                 true,
-            ))),
+            ),
             false,
             1,
         )]);
@@ -2248,7 +2242,7 @@ mod tests {
             "data",
             DataType::try_struct_type([create_field_with_id(
                 "items",
-                DataType::Array(Box::new(ArrayType::new(
+                ArrayType::new(
                     DataType::try_struct_type([create_field_with_id(
                         "inner",
                         DataType::try_struct_type([
@@ -2261,7 +2255,7 @@ mod tests {
                     )])
                     .unwrap(),
                     false,
-                ))),
+                ),
                 false,
                 5,
             )])
@@ -2273,10 +2267,10 @@ mod tests {
         let after =
             StructType::new_unchecked([create_field_with_id(
                 "data",
-                DataType::try_struct_type([create_field_with_id(
-                    "items",
-                    DataType::Array(
-                        Box::new(
+                DataType::try_struct_type(
+                    [
+                        create_field_with_id(
+                            "items",
                             ArrayType::new(
                                 DataType::try_struct_type(
                                     [
@@ -2305,11 +2299,11 @@ mod tests {
                                 .unwrap(),
                                 false,
                             ),
+                            false,
+                            5,
                         ),
-                    ),
-                    false,
-                    5,
-                )])
+                    ],
+                )
                 .unwrap(),
                 false,
                 1,
@@ -2344,11 +2338,11 @@ mod tests {
         // map<string, struct<nested: map<int, struct<x int>>>>
         let before = StructType::new_unchecked([create_field_with_id(
             "lookup",
-            DataType::Map(Box::new(MapType::new(
+            MapType::new(
                 DataType::STRING,
                 DataType::try_struct_type([create_field_with_id(
                     "nested",
-                    DataType::Map(Box::new(MapType::new(
+                    MapType::new(
                         DataType::INTEGER,
                         DataType::try_struct_type([create_field_with_id(
                             "x",
@@ -2358,13 +2352,13 @@ mod tests {
                         )])
                         .unwrap(),
                         false,
-                    ))),
+                    ),
                     false,
                     2,
                 )])
                 .unwrap(),
                 false,
-            ))),
+            ),
             false,
             1,
         )]);
@@ -2372,12 +2366,12 @@ mod tests {
         let after =
             StructType::new_unchecked([create_field_with_id(
                 "lookup",
-                DataType::Map(Box::new(MapType::new(
+                MapType::new(
                     DataType::STRING,
-                    DataType::try_struct_type([create_field_with_id(
-                        "nested",
-                        DataType::Map(
-                            Box::new(
+                    DataType::try_struct_type(
+                        [
+                            create_field_with_id(
+                                "nested",
                                 MapType::new(
                                     DataType::INTEGER,
                                     DataType::try_struct_type([
@@ -2391,14 +2385,14 @@ mod tests {
                                     .unwrap(),
                                     false,
                                 ),
+                                false,
+                                2,
                             ),
-                        ),
-                        false,
-                        2,
-                    )])
+                        ],
+                    )
                     .unwrap(),
                     false,
-                ))),
+                ),
                 false,
                 1,
             )]);
@@ -2424,8 +2418,8 @@ mod tests {
         // array<array<struct<x int>>>
         let before = StructType::new_unchecked([create_field_with_id(
             "matrix",
-            DataType::Array(Box::new(ArrayType::new(
-                DataType::Array(Box::new(ArrayType::new(
+            ArrayType::new(
+                ArrayType::new(
                     DataType::try_struct_type([create_field_with_id(
                         "x",
                         DataType::INTEGER,
@@ -2434,50 +2428,29 @@ mod tests {
                     )])
                     .unwrap(),
                     false,
-                ))),
+                ),
                 false,
-            ))),
+            ),
             false,
             1,
         )]);
 
-        let after =
-            StructType::new_unchecked([
-                create_field_with_id(
-                    "matrix",
-                    DataType::Array(
-                        Box::new(
-                            ArrayType::new(
-                                DataType::Array(
-                                    Box::new(
-                                        ArrayType::new(
-                                            DataType::try_struct_type([
-                                                create_field_with_id(
-                                                    "renamed_x",
-                                                    DataType::INTEGER,
-                                                    false,
-                                                    2,
-                                                ), // Renamed!
-                                                create_field_with_id(
-                                                    "y",
-                                                    DataType::INTEGER,
-                                                    true,
-                                                    3,
-                                                ), // Added!
-                                            ])
-                                            .unwrap(),
-                                            false,
-                                        ),
-                                    ),
-                                ),
-                                false,
-                            ),
-                        ),
-                    ),
+        let after = StructType::new_unchecked([create_field_with_id(
+            "matrix",
+            ArrayType::new(
+                ArrayType::new(
+                    DataType::try_struct_type([
+                        create_field_with_id("renamed_x", DataType::INTEGER, false, 2), // Renamed!
+                        create_field_with_id("y", DataType::INTEGER, true, 3),          // Added!
+                    ])
+                    .unwrap(),
                     false,
-                    1,
                 ),
-            ]);
+                false,
+            ),
+            false,
+            1,
+        )]);
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -2504,8 +2477,8 @@ mod tests {
         // map<array<struct<a int>>, array<struct<b int>>>
         let before = StructType::new_unchecked([create_field_with_id(
             "complex_map",
-            DataType::Map(Box::new(MapType::new(
-                DataType::Array(Box::new(ArrayType::new(
+            MapType::new(
+                ArrayType::new(
                     DataType::try_struct_type([create_field_with_id(
                         "key_field",
                         DataType::INTEGER,
@@ -2514,8 +2487,8 @@ mod tests {
                     )])
                     .unwrap(),
                     false,
-                ))),
-                DataType::Array(Box::new(ArrayType::new(
+                ),
+                ArrayType::new(
                     DataType::try_struct_type([create_field_with_id(
                         "value_field",
                         DataType::STRING,
@@ -2524,18 +2497,18 @@ mod tests {
                     )])
                     .unwrap(),
                     false,
-                ))),
+                ),
                 false,
-            ))),
+            ),
             false,
             1,
         )]);
 
         let after =
-            StructType::new_unchecked([create_field_with_id(
-                "complex_map",
-                DataType::Map(Box::new(MapType::new(
-                    DataType::Array(Box::new(
+            StructType::new_unchecked([
+                create_field_with_id(
+                    "complex_map",
+                    MapType::new(
                         ArrayType::new(
                             DataType::try_struct_type([
                                 create_field_with_id(
@@ -2548,8 +2521,6 @@ mod tests {
                             .unwrap(),
                             false,
                         ),
-                    )),
-                    DataType::Array(Box::new(
                         ArrayType::new(
                             DataType::try_struct_type([
                                 create_field_with_id(
@@ -2562,12 +2533,12 @@ mod tests {
                             .unwrap(),
                             false,
                         ),
-                    )),
+                        false,
+                    ),
                     false,
-                ))),
-                false,
-                1,
-            )]);
+                    1,
+                ),
+            ]);
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -2596,7 +2567,7 @@ mod tests {
         // map<struct<id int>, map<struct<key int>, struct<data string>>>
         let before = StructType::new_unchecked([create_field_with_id(
             "nested_maps",
-            DataType::Map(Box::new(MapType::new(
+            MapType::new(
                 DataType::try_struct_type([create_field_with_id(
                     "outer_key",
                     DataType::INTEGER,
@@ -2604,7 +2575,7 @@ mod tests {
                     2,
                 )])
                 .unwrap(),
-                DataType::Map(Box::new(MapType::new(
+                MapType::new(
                     DataType::try_struct_type([create_field_with_id(
                         "inner_key",
                         DataType::INTEGER,
@@ -2618,9 +2589,9 @@ mod tests {
                     ])
                     .unwrap(),
                     false,
-                ))),
+                ),
                 false,
-            ))),
+            ),
             false,
             1,
         )]);
@@ -2629,48 +2600,30 @@ mod tests {
             StructType::new_unchecked([
                 create_field_with_id(
                     "nested_maps",
-                    DataType::Map(
-                        Box::new(
-                            MapType::new(
-                                DataType::try_struct_type([create_field_with_id(
-                                    "renamed_outer_key", // Renamed!
-                                    DataType::INTEGER,
-                                    false,
-                                    2,
-                                )])
-                                .unwrap(),
-                                DataType::Map(
-                                    Box::new(
-                                        MapType::new(
-                                            DataType::try_struct_type([create_field_with_id(
-                                                "renamed_inner_key", // Renamed!
-                                                DataType::INTEGER,
-                                                false,
-                                                3,
-                                            )])
-                                            .unwrap(),
-                                            DataType::try_struct_type([
-                                                create_field_with_id(
-                                                    "renamed_data",
-                                                    DataType::STRING,
-                                                    false,
-                                                    4,
-                                                ), // Renamed!
-                                                create_field_with_id(
-                                                    "added",
-                                                    DataType::LONG,
-                                                    true,
-                                                    6,
-                                                ), // Added!
-                                            ])
-                                            .unwrap(),
-                                            false,
-                                        ),
-                                    ),
-                                ),
+                    MapType::new(
+                        DataType::try_struct_type([create_field_with_id(
+                            "renamed_outer_key", // Renamed!
+                            DataType::INTEGER,
+                            false,
+                            2,
+                        )])
+                        .unwrap(),
+                        MapType::new(
+                            DataType::try_struct_type([create_field_with_id(
+                                "renamed_inner_key", // Renamed!
+                                DataType::INTEGER,
                                 false,
-                            ),
+                                3,
+                            )])
+                            .unwrap(),
+                            DataType::try_struct_type([
+                                create_field_with_id("renamed_data", DataType::STRING, false, 4), // Renamed!
+                                create_field_with_id("added", DataType::LONG, true, 6), // Added!
+                            ])
+                            .unwrap(),
+                            false,
                         ),
+                        false,
                     ),
                     false,
                     1,
@@ -2718,37 +2671,49 @@ mod tests {
     fn test_deeply_nested_nullability_tightening_is_breaking() {
         // array<struct<items: array<struct<value int nullable>>>> -> array<struct<items:
         // array<struct<value int not null>>>>
-        let before = StructType::new_unchecked([create_field_with_id(
-            "wrapper",
-            DataType::Array(Box::new(ArrayType::new(
-                DataType::try_struct_type([create_field_with_id(
-                    "items",
-                    DataType::Array(Box::new(ArrayType::new(
-                        DataType::try_struct_type([
-                            create_field_with_id("value", DataType::INTEGER, true, 3), // Nullable
-                        ])
+        let before =
+            StructType::new_unchecked([
+                create_field_with_id(
+                    "wrapper",
+                    ArrayType::new(
+                        DataType::try_struct_type(
+                            [
+                                create_field_with_id(
+                                    "items",
+                                    ArrayType::new(
+                                        DataType::try_struct_type([
+                                            create_field_with_id(
+                                                "value",
+                                                DataType::INTEGER,
+                                                true,
+                                                3,
+                                            ), // Nullable
+                                        ])
+                                        .unwrap(),
+                                        false,
+                                    ),
+                                    false,
+                                    2,
+                                ),
+                            ],
+                        )
                         .unwrap(),
                         false,
-                    ))),
+                    ),
                     false,
-                    2,
-                )])
-                .unwrap(),
-                false,
-            ))),
-            false,
-            1,
-        )]);
+                    1,
+                ),
+            ]);
 
         let after =
-            StructType::new_unchecked([create_field_with_id(
-                "wrapper",
-                DataType::Array(Box::new(ArrayType::new(
-                    DataType::try_struct_type([
-                        create_field_with_id(
-                            "items",
-                            DataType::Array(
-                                Box::new(
+            StructType::new_unchecked([
+                create_field_with_id(
+                    "wrapper",
+                    ArrayType::new(
+                        DataType::try_struct_type(
+                            [
+                                create_field_with_id(
+                                    "items",
                                     ArrayType::new(
                                         DataType::try_struct_type([
                                             create_field_with_id(
@@ -2761,18 +2726,18 @@ mod tests {
                                         .unwrap(),
                                         false,
                                     ),
+                                    false,
+                                    2,
                                 ),
-                            ),
-                            false,
-                            2,
-                        ),
-                    ])
-                    .unwrap(),
+                            ],
+                        )
+                        .unwrap(),
+                        false,
+                    ),
                     false,
-                ))),
-                false,
-                1,
-            )]);
+                    1,
+                ),
+            ]);
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -2796,10 +2761,10 @@ mod tests {
         // array<struct<value int> not null>>>
         let before = StructType::new_unchecked([create_field_with_id(
             "wrapper",
-            DataType::Array(Box::new(ArrayType::new(
+            ArrayType::new(
                 DataType::try_struct_type([create_field_with_id(
                     "items",
-                    DataType::Array(Box::new(ArrayType::new(
+                    ArrayType::new(
                         DataType::try_struct_type([create_field_with_id(
                             "value",
                             DataType::INTEGER,
@@ -2808,23 +2773,23 @@ mod tests {
                         )])
                         .unwrap(),
                         true, // Array elements are nullable
-                    ))),
+                    ),
                     false,
                     2,
                 )])
                 .unwrap(),
                 false,
-            ))),
+            ),
             false,
             1,
         )]);
 
         let after = StructType::new_unchecked([create_field_with_id(
             "wrapper",
-            DataType::Array(Box::new(ArrayType::new(
+            ArrayType::new(
                 DataType::try_struct_type([create_field_with_id(
                     "items",
-                    DataType::Array(Box::new(ArrayType::new(
+                    ArrayType::new(
                         DataType::try_struct_type([create_field_with_id(
                             "value",
                             DataType::INTEGER,
@@ -2833,13 +2798,13 @@ mod tests {
                         )])
                         .unwrap(),
                         false, // Array elements now non-nullable - BREAKING!
-                    ))),
+                    ),
                     false,
                     2,
                 )])
                 .unwrap(),
                 false,
-            ))),
+            ),
             false,
             1,
         )]);

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -1607,10 +1607,10 @@ pub struct ArrayType {
 }
 
 impl ArrayType {
-    pub fn new(element_type: DataType, contains_null: bool) -> Self {
+    pub fn new(element_type: impl Into<DataType>, contains_null: bool) -> Self {
         Self {
             type_name: "array".into(),
-            element_type,
+            element_type: element_type.into(),
             contains_null,
         }
     }

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -1998,13 +1998,13 @@ impl<'de> serde::Deserialize<'de> for DataType {
             if let Some(Value::String(type_str)) = map.get("type") {
                 return match type_str.as_str() {
                     "array" => ArrayType::deserialize(value)
-                        .map(|at| DataType::Array(Box::new(at)))
+                        .map(DataType::from)
                         .map_err(|e| Error::custom(e.to_string())),
                     "struct" => StructType::deserialize(value)
-                        .map(|st| DataType::Struct(Box::new(st)))
+                        .map(DataType::from)
                         .map_err(|e| Error::custom(e.to_string())),
                     "map" => MapType::deserialize(value)
-                        .map(|mt| DataType::Map(Box::new(mt)))
+                        .map(DataType::from)
                         .map_err(|e| Error::custom(e.to_string())),
                     _ => Err(Error::custom(format!("Unknown complex type: '{type_str}'"))),
                 };
@@ -2588,18 +2588,18 @@ mod tests {
     #[rstest]
     #[case(
         r#"{"type": "array", "elementType": "integer", "containsNull": false}"#,
-        DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, false)))
+        DataType::from(ArrayType::new(DataType::INTEGER, false))
     )]
     #[case(
         r#"{"type": "struct", "fields": [{"name": "a", "type": "integer", "nullable": false, "metadata": {}}, {"name": "b", "type": "string", "nullable": true, "metadata": {}}]}"#,
-        DataType::Struct(Box::new(StructType::new_unchecked([
+        DataType::from(StructType::new_unchecked([
             StructField::new("a", DataType::INTEGER, false),
             StructField::new("b", DataType::STRING, true),
-        ])))
+        ]))
     )]
     #[case(
         r#"{"type": "map", "keyType": "string", "valueType": "integer", "valueContainsNull": true}"#,
-        DataType::Map(Box::new(MapType::new(DataType::STRING, DataType::INTEGER, true)))
+        DataType::from(MapType::new(DataType::STRING, DataType::INTEGER, true))
     )]
     #[case("\"string\"", DataType::STRING)]
     #[case("\"long\"", DataType::LONG)]
@@ -2624,7 +2624,7 @@ mod tests {
         let field = StructField::nullable(
             "e",
             ArrayType::new(
-                StructType::new_unchecked([StructField::not_null("d", DataType::INTEGER)]).into(),
+                StructType::new_unchecked([StructField::not_null("d", DataType::INTEGER)]),
                 true,
             ),
         );
@@ -2692,11 +2692,7 @@ mod tests {
         ]);
         let schema = StructType::new_unchecked([
             cm_field("a", 1, DataType::INTEGER),
-            cm_field(
-                "b",
-                2,
-                ArrayType::new(DataType::Struct(Box::new(inner)), true),
-            ),
+            cm_field("b", 2, ArrayType::new(inner, true)),
             cm_field("c", 3, DataType::STRING),
         ]);
         assert_result_error_with_message(
@@ -3655,7 +3651,7 @@ mod tests {
 
         let result = StructType::try_new([
             StructField::nullable("regular_col", DataType::STRING),
-            StructField::nullable("nested", DataType::Struct(Box::new(nested_struct))),
+            StructField::nullable("nested", nested_struct),
         ]);
 
         assert_result_error_with_message(result, "only allowed at the top level");
@@ -3677,11 +3673,11 @@ mod tests {
             .collect(),
             metadata_columns: HashMap::new(),
         };
-        let array_type = ArrayType::new(DataType::Struct(Box::new(nested_struct)), true);
+        let array_type = ArrayType::new(nested_struct, true);
 
         let result = StructType::try_new([
             StructField::nullable("regular_col", DataType::STRING),
-            StructField::nullable("array_col", DataType::Array(Box::new(array_type))),
+            StructField::nullable("array_col", array_type),
         ]);
 
         assert_result_error_with_message(result, "only allowed at the top level");
@@ -3705,20 +3701,12 @@ mod tests {
         };
 
         for map_type in [
-            MapType::new(
-                DataType::Struct(Box::new(nested_struct.clone())),
-                DataType::STRING,
-                true,
-            ),
-            MapType::new(
-                DataType::STRING,
-                DataType::Struct(Box::new(nested_struct)),
-                true,
-            ),
+            MapType::new(nested_struct.clone(), DataType::STRING, true),
+            MapType::new(DataType::STRING, nested_struct, true),
         ] {
             let result = StructType::try_new([
                 StructField::nullable("regular_col", DataType::STRING),
-                StructField::nullable("map_col", DataType::Map(Box::new(map_type))),
+                StructField::nullable("map_col", map_type),
             ]);
 
             assert_result_error_with_message(result, "only allowed at the top level");
@@ -3889,16 +3877,12 @@ mod tests {
         let nested_struct = StructType::new_unchecked([
             nested_field_with_metadata,
             StructField::new("x", DataType::DOUBLE, true),
-            StructField::new(
-                "inner_struct",
-                DataType::Struct(Box::new(inner_struct)),
-                false,
-            ),
+            StructField::new("inner_struct", inner_struct, false),
         ]);
-        let array_type = ArrayType::new(DataType::Struct(Box::new(nested_struct.clone())), true);
+        let array_type = ArrayType::new(nested_struct.clone(), true);
         let map_type = MapType::new(
-            DataType::Struct(Box::new(nested_struct.clone())),
-            DataType::Struct(Box::new(nested_struct.clone())), // kek
+            nested_struct.clone(),
+            nested_struct.clone(), // kek
             true,
         );
         let fields = vec![
@@ -3906,8 +3890,8 @@ mod tests {
             StructField::new("y", DataType::FLOAT, false),
             StructField::new("z", DataType::LONG, true),
             StructField::new("s", nested_struct.clone(), false),
-            StructField::nullable("array_col", DataType::Array(Box::new(array_type))),
-            StructField::nullable("map_col", DataType::Map(Box::new(map_type))),
+            StructField::nullable("array_col", array_type),
+            StructField::nullable("map_col", map_type),
             StructField::new("a", DataType::LONG, true),
         ];
 
@@ -4186,23 +4170,19 @@ mod tests {
     /// Schema: { a: { b: { c: double } } } — supports walks at depths 1, 2, and 3.
     fn walk_test_schema() -> StructType {
         let l3 = StructType::new_unchecked([StructField::new("c", DataType::DOUBLE, false)]);
-        let l2 = StructType::new_unchecked([StructField::new(
-            "b",
-            DataType::Struct(Box::new(l3)),
-            false,
-        )]);
-        StructType::new_unchecked([StructField::new("a", DataType::Struct(Box::new(l2)), false)])
+        let l2 = StructType::new_unchecked([StructField::new("b", l3, false)]);
+        StructType::new_unchecked([StructField::new("a", l2, false)])
     }
 
     #[rstest::rstest]
-    #[case::single_level(vec!["a"], vec!["a"], DataType::Struct(Box::new(
-        StructType::new_unchecked([StructField::new("b", DataType::Struct(Box::new(
-            StructType::new_unchecked([StructField::new("c", DataType::DOUBLE, false)])
-        )), false)])
-    )))]
-    #[case::nested_2(vec!["a", "b"], vec!["a", "b"], DataType::Struct(Box::new(
-        StructType::new_unchecked([StructField::new("c", DataType::DOUBLE, false)])
-    )))]
+    #[case::single_level(vec!["a"], vec!["a"], DataType::from(StructType::new_unchecked([
+        StructField::new("b", StructType::new_unchecked([
+            StructField::new("c", DataType::DOUBLE, false)
+        ]), false)
+    ])))]
+    #[case::nested_2(vec!["a", "b"], vec!["a", "b"], DataType::from(StructType::new_unchecked([
+        StructField::new("c", DataType::DOUBLE, false)
+    ])))]
     #[case::nested_3(vec!["a", "b", "c"], vec!["a", "b", "c"], DataType::DOUBLE)]
     #[test]
     fn test_walk_column_fields_happy(
@@ -4240,7 +4220,7 @@ mod tests {
         let schema = StructType::new_unchecked(vec![
             StructField::new("id", DataType::INTEGER, false),
             StructField::new("EventDate", DataType::DATE, false),
-            StructField::new("Address", DataType::Struct(Box::new(inner)), false),
+            StructField::new("Address", inner, false),
         ]);
 
         // Mismatched casing -> normalized to schema

--- a/kernel/src/schema/validation.rs
+++ b/kernel/src/schema/validation.rs
@@ -194,8 +194,8 @@ mod tests {
         let inner_b =
             StructType::new_unchecked(vec![StructField::new("CHILD", DataType::STRING, true)]);
         StructType::new_unchecked(vec![
-            StructField::new("a", DataType::Struct(Box::new(inner_a)), false),
-            StructField::new("b", DataType::Struct(Box::new(inner_b)), false),
+            StructField::new("a", inner_a, false),
+            StructField::new("b", inner_b, false),
         ])
     }
 
@@ -229,11 +229,7 @@ mod tests {
             DataType::INTEGER,
             false,
         )]);
-        StructType::new_unchecked(vec![StructField::new(
-            "parent",
-            DataType::Struct(Box::new(inner)),
-            false,
-        )])
+        StructType::new_unchecked(vec![StructField::new("parent", inner, false)])
     }
 
     fn schema_array_bad_char() -> StructType {
@@ -241,10 +237,7 @@ mod tests {
             StructType::new_unchecked(vec![StructField::new("bad col", DataType::INTEGER, false)]);
         StructType::new_unchecked(vec![StructField::new(
             "arr",
-            DataType::Array(Box::new(ArrayType::new(
-                DataType::Struct(Box::new(inner)),
-                true,
-            ))),
+            ArrayType::new(inner, true),
             false,
         )])
     }
@@ -254,11 +247,7 @@ mod tests {
             StructType::new_unchecked(vec![StructField::new("bad;val", DataType::INTEGER, false)]);
         StructType::new_unchecked(vec![StructField::new(
             "m",
-            DataType::Map(Box::new(MapType::new(
-                DataType::STRING,
-                DataType::Struct(Box::new(inner)),
-                true,
-            ))),
+            MapType::new(DataType::STRING, inner, true),
             false,
         )])
     }
@@ -267,7 +256,7 @@ mod tests {
         let inner =
             StructType::new_unchecked(vec![StructField::new("x", DataType::INTEGER, false)]);
         StructType::new_unchecked(vec![
-            StructField::new("a", DataType::Struct(Box::new(inner)), false),
+            StructField::new("a", inner, false),
             StructField::new("A", DataType::STRING, true),
         ])
     }
@@ -279,10 +268,7 @@ mod tests {
         ]);
         StructType::new_unchecked(vec![StructField::new(
             "arr",
-            DataType::Array(Box::new(ArrayType::new(
-                DataType::Struct(Box::new(inner)),
-                true,
-            ))),
+            ArrayType::new(inner, true),
             false,
         )])
     }
@@ -322,11 +308,7 @@ mod tests {
     fn schema_nested_invariant() -> StructType {
         let inner =
             StructType::new_unchecked(vec![field_with_invariant("child", DataType::INTEGER, true)]);
-        StructType::new_unchecked(vec![StructField::new(
-            "parent",
-            DataType::Struct(Box::new(inner)),
-            true,
-        )])
+        StructType::new_unchecked(vec![StructField::new("parent", inner, true)])
     }
 
     fn schema_array_nested_invariant() -> StructType {
@@ -334,10 +316,7 @@ mod tests {
             StructType::new_unchecked(vec![field_with_invariant("child", DataType::INTEGER, true)]);
         StructType::new_unchecked(vec![StructField::new(
             "arr",
-            DataType::Array(Box::new(ArrayType::new(
-                DataType::Struct(Box::new(inner)),
-                true,
-            ))),
+            ArrayType::new(inner, true),
             true,
         )])
     }
@@ -347,11 +326,7 @@ mod tests {
             StructType::new_unchecked(vec![field_with_invariant("child", DataType::INTEGER, true)]);
         StructType::new_unchecked(vec![StructField::new(
             "map",
-            DataType::Map(Box::new(MapType::new(
-                DataType::STRING,
-                DataType::Struct(Box::new(inner)),
-                true,
-            ))),
+            MapType::new(DataType::STRING, inner, true),
             true,
         )])
     }

--- a/kernel/src/schema/variant_utils.rs
+++ b/kernel/src/schema/variant_utils.rs
@@ -85,11 +85,11 @@ mod tests {
             StructField::new("id", DataType::INTEGER, false),
             StructField::new(
                 "nested",
-                DataType::Struct(Box::new(StructType::new_unchecked([StructField::new(
+                StructType::new_unchecked([StructField::new(
                     "inner_v",
                     DataType::unshredded_variant(),
                     true,
-                )]))),
+                )]),
                 true,
             ),
         ]);

--- a/kernel/src/schema/void_utils.rs
+++ b/kernel/src/schema/void_utils.rs
@@ -254,10 +254,7 @@ mod tests {
         StructField::nullable(
             "outer",
             StructType::new_unchecked([
-                StructField::nullable(
-                    "inner",
-                    DataType::Array(Box::new(ArrayType::new(DataType::VOID, true))),
-                ),
+                StructField::nullable("inner", ArrayType::new(DataType::VOID, true)),
             ])
         ),
         "array element type"
@@ -266,10 +263,7 @@ mod tests {
         "void in map inside array",
         StructField::nullable(
             "col",
-            ArrayType::new(
-                DataType::Map(Box::new(MapType::new(DataType::STRING, DataType::VOID, true,))),
-                true,
-            ),
+            ArrayType::new(MapType::new(DataType::STRING, DataType::VOID, true), true,),
         ),
         "map value type"
     )]
@@ -278,10 +272,10 @@ mod tests {
         StructField::nullable(
             "arr",
             ArrayType::new(
-                DataType::Struct(Box::new(StructType::new_unchecked([
+                StructType::new_unchecked([
                     StructField::nullable("a", DataType::INTEGER),
                     StructField::nullable("b", DataType::VOID),
-                ]))),
+                ]),
                 true,
             ),
         ),
@@ -322,13 +316,13 @@ mod tests {
         StructField::nullable(
             "outer",
             ArrayType::new(
-                DataType::Array(Box::new(ArrayType::new(
-                    DataType::Struct(Box::new(StructType::new_unchecked([
+                ArrayType::new(
+                    StructType::new_unchecked([
                         StructField::nullable("a", DataType::INTEGER),
                         StructField::nullable("b", DataType::VOID),
-                    ]))),
+                    ]),
                     true,
-                ))),
+                ),
                 true,
             ),
         ),
@@ -339,16 +333,16 @@ mod tests {
         StructField::nullable(
             "arr",
             ArrayType::new(
-                DataType::Struct(Box::new(StructType::new_unchecked([
+                StructType::new_unchecked([
                     StructField::nullable("a", DataType::INTEGER),
                     StructField::nullable(
                         "b",
-                        DataType::Struct(Box::new(StructType::new_unchecked([
+                        StructType::new_unchecked([
                             StructField::nullable("x", DataType::INTEGER),
                             StructField::nullable("y", DataType::VOID),
-                        ]))),
+                        ]),
                     ),
-                ]))),
+                ]),
                 true,
             ),
         ),
@@ -359,15 +353,16 @@ mod tests {
         StructField::nullable(
             "outer",
             ArrayType::new(
-                DataType::Struct(Box::new(StructType::new_unchecked([StructField::nullable(
+                StructType::new_unchecked([StructField::nullable(
                     "inner",
-                    DataType::Array(Box::new(ArrayType::new(
-                        DataType::Struct(Box::new(StructType::new_unchecked([
-                            StructField::nullable("v", DataType::VOID),
-                        ]))),
+                    ArrayType::new(
+                        StructType::new_unchecked([StructField::nullable(
+                            "v",
+                            DataType::VOID,
+                        )]),
                         true,
-                    ))),
-                )]))),
+                    ),
+                )]),
                 true,
             ),
         ),
@@ -378,9 +373,7 @@ mod tests {
         StructField::nullable(
             "arr",
             ArrayType::new(
-                DataType::Struct(Box::new(StructType::new_unchecked(
-                    Vec::<StructField>::new(),
-                ))),
+                StructType::new_unchecked(Vec::<StructField>::new()),
                 true,
             ),
         ),
@@ -444,10 +437,10 @@ mod tests {
         StructType::new_unchecked([StructField::nullable(
             "arr",
             ArrayType::new(
-                DataType::Struct(Box::new(StructType::new_unchecked([
+                StructType::new_unchecked([
                     StructField::nullable("a", DataType::INTEGER),
                     StructField::nullable("b", DataType::STRING),
-                ]))),
+                ]),
                 true,
             ),
         )])
@@ -555,9 +548,7 @@ mod tests {
                 StructType::new_unchecked([
                     StructField::nullable(
                         "inner",
-                        DataType::Struct(Box::new(StructType::new_unchecked([
-                            StructField::nullable("x", DataType::VOID),
-                        ]))),
+                        StructType::new_unchecked([StructField::nullable("x", DataType::VOID)]),
                     ),
                 ]),
             ),
@@ -644,20 +635,17 @@ mod tests {
             "outer",
             StructType::new_unchecked([StructField::nullable(
                 "inner",
-                DataType::Struct(Box::new(StructType::new_unchecked([
+                StructType::new_unchecked([
                     StructField::nullable("a", DataType::INTEGER),
                     StructField::nullable("v", DataType::VOID),
-                ]))),
+                ]),
             )]),
         )]),
         StructType::new_unchecked([StructField::nullable(
             "outer",
             StructType::new_unchecked([StructField::nullable(
                 "inner",
-                DataType::Struct(Box::new(StructType::new_unchecked([StructField::nullable(
-                    "a",
-                    DataType::INTEGER,
-                )]))),
+                StructType::new_unchecked([StructField::nullable("a", DataType::INTEGER)]),
             )]),
         )])
     )]
@@ -674,17 +662,17 @@ mod tests {
     // primitive is filtered: ArrayType / MapType cannot be reconstructed without their
     // element / key / value, so the containing field disappears.
     #[rstest::rstest]
-    #[case::array_of_void(DataType::Array(Box::new(ArrayType::new(DataType::VOID, true))))]
-    #[case::map_with_void_value(DataType::Map(Box::new(MapType::new(
+    #[case::array_of_void(DataType::from(ArrayType::new(DataType::VOID, true)))]
+    #[case::map_with_void_value(DataType::from(MapType::new(
         DataType::STRING,
         DataType::VOID,
         true
-    ))))]
-    #[case::map_with_void_key(DataType::Map(Box::new(MapType::new(
+    )))]
+    #[case::map_with_void_key(DataType::from(MapType::new(
         DataType::VOID,
         DataType::STRING,
         true
-    ))))]
+    )))]
     fn test_strip_drops_container_with_void(#[case] field_type: DataType) {
         let schema = Arc::new(StructType::new_unchecked([
             StructField::nullable("id", DataType::INTEGER),

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -2072,7 +2072,7 @@ mod tests {
 
     // === find_max_column_id_in_schema tests ===
 
-    fn field_with_id(name: &str, ty: DataType, id: i64) -> StructField {
+    fn field_with_id(name: &str, ty: impl Into<DataType>, id: i64) -> StructField {
         let mut f = StructField::nullable(name, ty);
         f.metadata.insert(
             ColumnMetadataKey::ColumnMappingId.as_ref().to_string(),
@@ -2173,7 +2173,7 @@ mod tests {
     fn find_max_column_id_picks_up_nested_ids_metadata() {
         let mut field = field_with_id(
             "m",
-            DataType::from(MapType::new(DataType::INTEGER, DataType::INTEGER, false)),
+            MapType::new(DataType::INTEGER, DataType::INTEGER, false),
             1,
         );
         field.metadata.insert(

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -606,24 +606,24 @@ fn flat_cm_info_for_nested_data_type(
             let new_inner = assign_column_mapping_metadata(
                 inner, max_id, /* assign_nested_field_ids */ false,
             )?;
-            Ok(DataType::Struct(Box::new(new_inner)))
+            Ok(DataType::from(new_inner))
         }
         DataType::Array(array_type) => {
             let new_element_type =
                 flat_cm_info_for_nested_data_type(array_type.element_type(), max_id)?;
-            Ok(DataType::Array(Box::new(ArrayType::new(
+            Ok(DataType::from(ArrayType::new(
                 new_element_type,
                 array_type.contains_null(),
-            ))))
+            )))
         }
         DataType::Map(map_type) => {
             let new_key_type = flat_cm_info_for_nested_data_type(map_type.key_type(), max_id)?;
             let new_value_type = flat_cm_info_for_nested_data_type(map_type.value_type(), max_id)?;
-            Ok(DataType::Map(Box::new(MapType::new(
+            Ok(DataType::from(MapType::new(
                 new_key_type,
                 new_value_type,
                 map_type.value_contains_null(),
-            ))))
+            )))
         }
         // Primitive and Variant types don't contain nested struct fields - return as-is
         DataType::Primitive(_) | DataType::Variant(_) => Ok(data_type.clone()),
@@ -655,19 +655,17 @@ fn assign_nested_cm_ids(schema: &StructType, max_id: &mut i64) -> DeltaResult<St
         nested_ids: &mut NestedFieldIds,
     ) -> DeltaResult<DataType> {
         match data_type {
-            DataType::Struct(inner) => Ok(DataType::Struct(Box::new(assign_nested_cm_ids(
-                inner, max_id,
-            )?))),
+            DataType::Struct(inner) => Ok(DataType::from(assign_nested_cm_ids(inner, max_id)?)),
             DataType::Array(array_type) => {
                 let element_path = format!("{path}.element");
                 *max_id += 1;
                 nested_ids.insert(element_path.clone(), serde_json::Value::from(*max_id));
                 let new_element =
                     walk(array_type.element_type(), max_id, &element_path, nested_ids)?;
-                Ok(DataType::Array(Box::new(ArrayType::new(
+                Ok(DataType::from(ArrayType::new(
                     new_element,
                     array_type.contains_null(),
-                ))))
+                )))
             }
             DataType::Map(map_type) => {
                 let key_path = format!("{path}.key");
@@ -678,11 +676,11 @@ fn assign_nested_cm_ids(schema: &StructType, max_id: &mut i64) -> DeltaResult<St
                 *max_id += 1;
                 nested_ids.insert(value_path.clone(), serde_json::Value::from(*max_id));
                 let new_value = walk(map_type.value_type(), max_id, &value_path, nested_ids)?;
-                Ok(DataType::Map(Box::new(MapType::new(
+                Ok(DataType::from(MapType::new(
                     new_key,
                     new_value,
                     map_type.value_contains_null(),
-                ))))
+                )))
             }
             DataType::Primitive(_) | DataType::Variant(_) => Ok(data_type.clone()),
         }
@@ -1027,11 +1025,7 @@ mod tests {
         let schema = StructType::new_unchecked([make_cm_field(
             "b",
             1,
-            MapType::new(
-                DataType::STRING,
-                DataType::Struct(Box::new(unannotated)),
-                false,
-            ),
+            MapType::new(DataType::STRING, unannotated, false),
         )]);
         validate_schema_column_mapping(&schema, ColumnMappingMode::Id)
             .expect_err("missing annotation on struct field inside map value");
@@ -1062,18 +1056,14 @@ mod tests {
             make_cm_field("x", 5, DataType::INTEGER),
             make_cm_field("y", 5, DataType::INTEGER),
         ]);
-        StructType::new_unchecked([make_cm_field(
-            "outer",
-            10,
-            DataType::Struct(Box::new(nested)),
-        )])
+        StructType::new_unchecked([make_cm_field("outer", 10, nested)])
     }
 
     fn cm_schema_cross_level_duplicates() -> StructType {
         let nested = StructType::new_unchecked([make_cm_field("inner", 1, DataType::INTEGER)]);
         StructType::new_unchecked([
             make_cm_field("a", 1, DataType::INTEGER),
-            make_cm_field("b", 2, DataType::Struct(Box::new(nested))),
+            make_cm_field("b", 2, nested),
         ])
     }
 
@@ -1081,11 +1071,7 @@ mod tests {
         let element = StructType::new_unchecked([make_cm_field("x", 1, DataType::INTEGER)]);
         StructType::new_unchecked([
             make_cm_field("a", 1, DataType::INTEGER),
-            make_cm_field(
-                "b",
-                2,
-                ArrayType::new(DataType::Struct(Box::new(element)), false),
-            ),
+            make_cm_field("b", 2, ArrayType::new(element, false)),
         ])
     }
 
@@ -1093,11 +1079,7 @@ mod tests {
         let value = StructType::new_unchecked([make_cm_field("x", 1, DataType::INTEGER)]);
         StructType::new_unchecked([
             make_cm_field("a", 1, DataType::INTEGER),
-            make_cm_field(
-                "b",
-                2,
-                MapType::new(DataType::STRING, DataType::Struct(Box::new(value)), false),
-            ),
+            make_cm_field("b", 2, MapType::new(DataType::STRING, value, false)),
         ])
     }
 
@@ -1249,19 +1231,17 @@ mod tests {
                 let inner = StructType::new_unchecked([field_under_test]);
                 let schema = StructType::new_unchecked([
                     StructField::nullable("unannotated_sibling", DataType::STRING),
-                    StructField::nullable("outer", DataType::Struct(Box::new(inner))),
+                    StructField::nullable("outer", inner),
                 ]);
                 (schema, path(&["outer", FIELD_UNDER_TEST]))
             }
             SchemaShape::DeeplyNestedStruct => {
                 let innermost = StructType::new_unchecked([field_under_test]);
-                let middle = StructType::new_unchecked([StructField::nullable(
-                    "middle",
-                    DataType::Struct(Box::new(innermost)),
-                )]);
+                let middle =
+                    StructType::new_unchecked([StructField::nullable("middle", innermost)]);
                 let schema = StructType::new_unchecked([
                     StructField::nullable("unannotated_sibling", DataType::STRING),
-                    StructField::nullable("outer", DataType::Struct(Box::new(middle))),
+                    StructField::nullable("outer", middle),
                 ]);
                 (schema, path(&["outer", "middle", FIELD_UNDER_TEST]))
             }
@@ -1587,7 +1567,7 @@ mod tests {
 
         let schema = StructType::new_unchecked([
             StructField::new("a", DataType::INTEGER, false),
-            StructField::new("nested", DataType::Struct(Box::new(inner)), true),
+            StructField::new("nested", inner, true),
         ]);
 
         let mut max_id = 0;
@@ -1670,17 +1650,9 @@ mod tests {
         let value_struct =
             StructType::new_unchecked([StructField::new("v", DataType::INTEGER, false)]);
 
-        let map_type = MapType::new(
-            DataType::Struct(Box::new(key_struct)),
-            DataType::Struct(Box::new(value_struct)),
-            true,
-        );
+        let map_type = MapType::new(key_struct, value_struct, true);
 
-        let schema = StructType::new_unchecked([StructField::new(
-            "my_map",
-            DataType::Map(Box::new(map_type)),
-            true,
-        )]);
+        let schema = StructType::new_unchecked([StructField::new("my_map", map_type, true)]);
 
         let mut max_id = 0;
         let result = assign_column_mapping_metadata(&schema, &mut max_id, false).unwrap();
@@ -1720,13 +1692,9 @@ mod tests {
         let elem_struct =
             StructType::new_unchecked([StructField::new("elem", DataType::INTEGER, false)]);
 
-        let array_type = ArrayType::new(DataType::Struct(Box::new(elem_struct)), true);
+        let array_type = ArrayType::new(elem_struct, true);
 
-        let schema = StructType::new_unchecked([StructField::new(
-            "my_array",
-            DataType::Array(Box::new(array_type)),
-            true,
-        )]);
+        let schema = StructType::new_unchecked([StructField::new("my_array", array_type, true)]);
 
         let mut max_id = 0;
         let result = assign_column_mapping_metadata(&schema, &mut max_id, false).unwrap();
@@ -1761,14 +1729,11 @@ mod tests {
         let deep_struct =
             StructType::new_unchecked([StructField::new("deep", DataType::INTEGER, false)]);
 
-        let inner_array = ArrayType::new(DataType::Struct(Box::new(deep_struct)), true);
-        let outer_array = ArrayType::new(DataType::Array(Box::new(inner_array)), true);
+        let inner_array = ArrayType::new(deep_struct, true);
+        let outer_array = ArrayType::new(inner_array, true);
 
-        let schema = StructType::new_unchecked([StructField::new(
-            "nested_arrays",
-            DataType::Array(Box::new(outer_array)),
-            true,
-        )]);
+        let schema =
+            StructType::new_unchecked([StructField::new("nested_arrays", outer_array, true)]);
 
         let mut max_id = 0;
         let result = assign_column_mapping_metadata(&schema, &mut max_id, false).unwrap();
@@ -1808,22 +1773,14 @@ mod tests {
         let value_struct =
             StructType::new_unchecked([StructField::new("v", DataType::INTEGER, false)]);
 
-        let key_array = ArrayType::new(DataType::Struct(Box::new(key_struct)), true);
-        let value_array = ArrayType::new(DataType::Struct(Box::new(value_struct)), true);
+        let key_array = ArrayType::new(key_struct, true);
+        let value_array = ArrayType::new(value_struct, true);
 
-        let inner_map = MapType::new(
-            DataType::Array(Box::new(key_array)),
-            DataType::Array(Box::new(value_array)),
-            true,
-        );
+        let inner_map = MapType::new(key_array, value_array, true);
 
-        let outer_array = ArrayType::new(DataType::Map(Box::new(inner_map)), true);
+        let outer_array = ArrayType::new(inner_map, true);
 
-        let schema = StructType::new_unchecked([StructField::new(
-            "cursed",
-            DataType::Array(Box::new(outer_array)),
-            true,
-        )]);
+        let schema = StructType::new_unchecked([StructField::new("cursed", outer_array, true)]);
 
         let mut max_id = 0;
         let result = assign_column_mapping_metadata(&schema, &mut max_id, false).unwrap();
@@ -1881,21 +1838,17 @@ mod tests {
                 ),
             ])]);
 
-        let schema = StructType::new_unchecked([StructField::new(
-            "a",
-            DataType::Struct(Box::new(inner)),
-            true,
-        )
-        .add_metadata([
-            (
-                ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
-                MetadataValue::String("col-outer-a".to_string()),
-            ),
-            (
-                ColumnMetadataKey::ColumnMappingId.as_ref(),
-                MetadataValue::Number(1),
-            ),
-        ])]);
+        let schema =
+            StructType::new_unchecked([StructField::new("a", inner, true).add_metadata([
+                (
+                    ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
+                    MetadataValue::String("col-outer-a".to_string()),
+                ),
+                (
+                    ColumnMetadataKey::ColumnMappingId.as_ref(),
+                    MetadataValue::Number(1),
+                ),
+            ])]);
 
         // Top-level column
         let result = get_any_level_column_physical_name(
@@ -1976,21 +1929,17 @@ mod tests {
         }
 
         let inner = StructType::new_unchecked([inner_field]);
-        let schema = StructType::new_unchecked([StructField::new(
-            "a",
-            DataType::Struct(Box::new(inner)),
-            true,
-        )
-        .add_metadata([
-            (
-                ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
-                MetadataValue::String("col-outer-a".to_string()),
-            ),
-            (
-                ColumnMetadataKey::ColumnMappingId.as_ref(),
-                MetadataValue::Number(1),
-            ),
-        ])]);
+        let schema =
+            StructType::new_unchecked([StructField::new("a", inner, true).add_metadata([
+                (
+                    ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
+                    MetadataValue::String("col-outer-a".to_string()),
+                ),
+                (
+                    ColumnMetadataKey::ColumnMappingId.as_ref(),
+                    MetadataValue::Number(1),
+                ),
+            ])]);
 
         let err = get_any_level_column_physical_name(
             &schema,
@@ -2094,12 +2043,10 @@ mod tests {
             MetadataValue::String("col-inner-456".to_string()),
         )]);
         let inner_struct = StructType::new_unchecked(vec![inner_field]);
-        let outer_field =
-            StructField::new("address", DataType::Struct(Box::new(inner_struct)), true)
-                .with_metadata([(
-                    "delta.columnMapping.physicalName".to_string(),
-                    MetadataValue::String("col-outer-123".to_string()),
-                )]);
+        let outer_field = StructField::new("address", inner_struct, true).with_metadata([(
+            "delta.columnMapping.physicalName".to_string(),
+            MetadataValue::String("col-outer-123".to_string()),
+        )]);
         let schema = StructType::new_unchecked(vec![outer_field]);
 
         let physical_col = ColumnName::new(["col-outer-123", "col-inner-456"]);
@@ -2154,13 +2101,13 @@ mod tests {
 
     #[test]
     fn find_max_column_id_nested_struct() {
-        let inner = DataType::Struct(Box::new(
+        let inner = DataType::from(
             StructType::try_new(vec![
                 field_with_id("x", DataType::STRING, 7),
                 field_with_id("y", DataType::STRING, 5),
             ])
             .unwrap(),
-        ));
+        );
         let schema = StructType::try_new(vec![
             field_with_id("outer", inner, 2),
             field_with_id("sibling", DataType::STRING, 3),
@@ -2171,19 +2118,15 @@ mod tests {
 
     #[test]
     fn find_max_column_id_array_and_map_recurse_into_element_types() {
-        let array_elem_struct = DataType::Array(Box::new(ArrayType::new(
-            DataType::Struct(Box::new(
-                StructType::try_new(vec![field_with_id("deep", DataType::STRING, 42)]).unwrap(),
-            )),
+        let array_elem_struct = DataType::from(ArrayType::new(
+            StructType::try_new(vec![field_with_id("deep", DataType::STRING, 42)]).unwrap(),
             true,
-        )));
-        let map_ty = DataType::Map(Box::new(MapType::new(
+        ));
+        let map_ty = DataType::from(MapType::new(
             DataType::STRING,
-            DataType::Struct(Box::new(
-                StructType::try_new(vec![field_with_id("inside", DataType::STRING, 9)]).unwrap(),
-            )),
+            StructType::try_new(vec![field_with_id("inside", DataType::STRING, 9)]).unwrap(),
             false,
-        )));
+        ));
         let schema = StructType::try_new(vec![
             field_with_id("arr", array_elem_struct, 1),
             field_with_id("m", map_ty, 2),
@@ -2194,13 +2137,13 @@ mod tests {
 
     #[test]
     fn find_max_column_id_map_with_struct_key_recurses() {
-        let key_struct = DataType::Struct(Box::new(
+        let key_struct = DataType::from(
             StructType::try_new(vec![field_with_id("key_id", DataType::INTEGER, 17)]).unwrap(),
-        ));
-        let value_struct = DataType::Struct(Box::new(
+        );
+        let value_struct = DataType::from(
             StructType::try_new(vec![field_with_id("val_id", DataType::INTEGER, 11)]).unwrap(),
-        ));
-        let map_ty = DataType::Map(Box::new(MapType::new(key_struct, value_struct, false)));
+        );
+        let map_ty = DataType::from(MapType::new(key_struct, value_struct, false));
         let schema = StructType::try_new(vec![field_with_id("m", map_ty, 1)]).unwrap();
         // Max should come from the key struct's `key_id = 17`, beating value's 11 and
         // top-level's 1.
@@ -2230,11 +2173,7 @@ mod tests {
     fn find_max_column_id_picks_up_nested_ids_metadata() {
         let mut field = field_with_id(
             "m",
-            DataType::Map(Box::new(MapType::new(
-                DataType::INTEGER,
-                DataType::INTEGER,
-                false,
-            ))),
+            DataType::from(MapType::new(DataType::INTEGER, DataType::INTEGER, false)),
             1,
         );
         field.metadata.insert(

--- a/kernel/src/table_features/iceberg_compat/mod.rs
+++ b/kernel/src/table_features/iceberg_compat/mod.rs
@@ -199,7 +199,7 @@ mod tests {
     fn schema_with_good_nested_ids() -> StructType {
         StructType::new_unchecked(vec![field_with_metadata(
             "x",
-            DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+            DataType::from(ArrayType::new(DataType::INTEGER, true)),
             ColumnMetadataKey::ColumnMappingNestedIds.as_ref(),
         )])
     }
@@ -207,7 +207,7 @@ mod tests {
     fn schema_with_legacy_at(name: &str) -> StructType {
         StructType::new_unchecked(vec![field_with_metadata(
             name,
-            DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+            DataType::from(ArrayType::new(DataType::INTEGER, true)),
             ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
         )])
     }
@@ -215,43 +215,33 @@ mod tests {
     fn schema_struct_with_legacy_at_inner() -> StructType {
         let inner = StructType::new_unchecked(vec![field_with_metadata(
             "inner",
-            DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+            DataType::from(ArrayType::new(DataType::INTEGER, true)),
             ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
         )]);
-        StructType::new_unchecked(vec![StructField::nullable(
-            "parent",
-            DataType::Struct(Box::new(inner)),
-        )])
+        StructType::new_unchecked(vec![StructField::nullable("parent", inner)])
     }
 
     fn schema_array_struct_with_legacy_at_inner() -> StructType {
         let inner = StructType::new_unchecked(vec![field_with_metadata(
             "inner",
-            DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+            DataType::from(ArrayType::new(DataType::INTEGER, true)),
             ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
         )]);
         StructType::new_unchecked(vec![StructField::nullable(
             "arr",
-            DataType::Array(Box::new(ArrayType::new(
-                DataType::Struct(Box::new(inner)),
-                true,
-            ))),
+            ArrayType::new(inner, true),
         )])
     }
 
     fn schema_map_value_struct_with_legacy_at_inner() -> StructType {
         let inner = StructType::new_unchecked(vec![field_with_metadata(
             "inner",
-            DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+            DataType::from(ArrayType::new(DataType::INTEGER, true)),
             ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
         )]);
         StructType::new_unchecked(vec![StructField::nullable(
             "m",
-            DataType::Map(Box::new(MapType::new(
-                DataType::STRING,
-                DataType::Struct(Box::new(inner)),
-                true,
-            ))),
+            MapType::new(DataType::STRING, inner, true),
         )])
     }
 
@@ -259,12 +249,12 @@ mod tests {
         StructType::new_unchecked(vec![
             field_with_metadata(
                 "a",
-                DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+                DataType::from(ArrayType::new(DataType::INTEGER, true)),
                 ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
             ),
             field_with_metadata(
                 "b",
-                DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+                DataType::from(ArrayType::new(DataType::INTEGER, true)),
                 ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
             ),
         ])
@@ -314,38 +304,27 @@ mod tests {
 
     fn schema_struct_with_float_inner() -> StructType {
         let inner = StructType::new_unchecked(vec![StructField::nullable("f", DataType::FLOAT)]);
-        StructType::new_unchecked(vec![StructField::nullable(
-            "s",
-            DataType::Struct(Box::new(inner)),
-        )])
+        StructType::new_unchecked(vec![StructField::nullable("s", inner)])
     }
 
     fn schema_array_of_float() -> StructType {
         StructType::new_unchecked(vec![StructField::nullable(
             "arr",
-            DataType::Array(Box::new(ArrayType::new(DataType::FLOAT, true))),
+            ArrayType::new(DataType::FLOAT, true),
         )])
     }
 
     fn schema_map_key_float() -> StructType {
         StructType::new_unchecked(vec![StructField::nullable(
             "m",
-            DataType::Map(Box::new(MapType::new(
-                DataType::FLOAT,
-                DataType::STRING,
-                true,
-            ))),
+            MapType::new(DataType::FLOAT, DataType::STRING, true),
         )])
     }
 
     fn schema_map_value_float() -> StructType {
         StructType::new_unchecked(vec![StructField::nullable(
             "m",
-            DataType::Map(Box::new(MapType::new(
-                DataType::STRING,
-                DataType::FLOAT,
-                true,
-            ))),
+            MapType::new(DataType::STRING, DataType::FLOAT, true),
         )])
     }
 
@@ -361,19 +340,16 @@ mod tests {
         StructType::new_unchecked(vec![
             StructField::nullable(
                 "a",
-                DataType::Array(Box::new(ArrayType::new(
-                    DataType::Map(Box::new(MapType::new(
+                ArrayType::new(
+                    MapType::new(
                         DataType::STRING,
-                        DataType::Array(Box::new(ArrayType::new(DataType::FLOAT, true))),
+                        ArrayType::new(DataType::FLOAT, true),
                         true,
-                    ))),
+                    ),
                     true,
-                ))),
+                ),
             ),
-            StructField::nullable(
-                "b",
-                DataType::Array(Box::new(ArrayType::new(DataType::FLOAT, true))),
-            ),
+            StructField::nullable("b", ArrayType::new(DataType::FLOAT, true)),
         ])
     }
 

--- a/kernel/src/table_features/iceberg_compat/mod.rs
+++ b/kernel/src/table_features/iceberg_compat/mod.rs
@@ -180,7 +180,7 @@ mod tests {
 
     // === LegacyNestedIdsVisitor: parquet.field.nested.ids detection ===
 
-    fn field_with_metadata(name: &str, dtype: DataType, key: &str) -> StructField {
+    fn field_with_metadata(name: &str, dtype: impl Into<DataType>, key: &str) -> StructField {
         let mut f = StructField::nullable(name, dtype);
         f.metadata.insert(
             key.to_string(),
@@ -199,7 +199,7 @@ mod tests {
     fn schema_with_good_nested_ids() -> StructType {
         StructType::new_unchecked(vec![field_with_metadata(
             "x",
-            DataType::from(ArrayType::new(DataType::INTEGER, true)),
+            ArrayType::new(DataType::INTEGER, true),
             ColumnMetadataKey::ColumnMappingNestedIds.as_ref(),
         )])
     }
@@ -207,7 +207,7 @@ mod tests {
     fn schema_with_legacy_at(name: &str) -> StructType {
         StructType::new_unchecked(vec![field_with_metadata(
             name,
-            DataType::from(ArrayType::new(DataType::INTEGER, true)),
+            ArrayType::new(DataType::INTEGER, true),
             ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
         )])
     }
@@ -215,7 +215,7 @@ mod tests {
     fn schema_struct_with_legacy_at_inner() -> StructType {
         let inner = StructType::new_unchecked(vec![field_with_metadata(
             "inner",
-            DataType::from(ArrayType::new(DataType::INTEGER, true)),
+            ArrayType::new(DataType::INTEGER, true),
             ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
         )]);
         StructType::new_unchecked(vec![StructField::nullable("parent", inner)])
@@ -224,7 +224,7 @@ mod tests {
     fn schema_array_struct_with_legacy_at_inner() -> StructType {
         let inner = StructType::new_unchecked(vec![field_with_metadata(
             "inner",
-            DataType::from(ArrayType::new(DataType::INTEGER, true)),
+            ArrayType::new(DataType::INTEGER, true),
             ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
         )]);
         StructType::new_unchecked(vec![StructField::nullable(
@@ -236,7 +236,7 @@ mod tests {
     fn schema_map_value_struct_with_legacy_at_inner() -> StructType {
         let inner = StructType::new_unchecked(vec![field_with_metadata(
             "inner",
-            DataType::from(ArrayType::new(DataType::INTEGER, true)),
+            ArrayType::new(DataType::INTEGER, true),
             ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
         )]);
         StructType::new_unchecked(vec![StructField::nullable(
@@ -249,12 +249,12 @@ mod tests {
         StructType::new_unchecked(vec![
             field_with_metadata(
                 "a",
-                DataType::from(ArrayType::new(DataType::INTEGER, true)),
+                ArrayType::new(DataType::INTEGER, true),
                 ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
             ),
             field_with_metadata(
                 "b",
-                DataType::from(ArrayType::new(DataType::INTEGER, true)),
+                ArrayType::new(DataType::INTEGER, true),
                 ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
             ),
         ])

--- a/kernel/src/table_features/iceberg_compat/v3.rs
+++ b/kernel/src/table_features/iceberg_compat/v3.rs
@@ -76,15 +76,12 @@ mod tests {
             );
         }
         let nested = [
-            DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
-            DataType::Map(Box::new(MapType::new(
-                DataType::STRING,
+            DataType::from(ArrayType::new(DataType::INTEGER, true)),
+            DataType::from(MapType::new(DataType::STRING, DataType::INTEGER, true)),
+            DataType::from(StructType::new_unchecked([StructField::nullable(
+                "x",
                 DataType::INTEGER,
-                true,
-            ))),
-            DataType::Struct(Box::new(StructType::new_unchecked([
-                StructField::nullable("x", DataType::INTEGER),
-            ]))),
+            )])),
             DataType::unshredded_variant(),
         ];
         for dt in nested {

--- a/kernel/src/table_features/timestamp_ntz.rs
+++ b/kernel/src/table_features/timestamp_ntz.rs
@@ -62,11 +62,11 @@ mod tests {
             StructField::new("id", DataType::INTEGER, false),
             StructField::new(
                 "nested",
-                DataType::Struct(Box::new(StructType::new_unchecked([StructField::new(
+                StructType::new_unchecked([StructField::new(
                     "inner_ts",
                     DataType::Primitive(PrimitiveType::TimestampNtz),
                     true,
-                )]))),
+                )]),
                 true,
             ),
         ]);

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -1240,7 +1240,7 @@ mod tests {
         ]);
         let schema = Arc::new(StructType::new_unchecked(vec![
             StructField::new("id", DataType::INTEGER, false),
-            StructField::new("address", DataType::Struct(Box::new(address_struct)), true),
+            StructField::new("address", address_struct, true),
         ]));
 
         let mut reader_features = vec![];
@@ -1290,9 +1290,11 @@ mod tests {
             StructField::new("id", DataType::INTEGER, false),
             StructField::new(
                 "nested",
-                DataType::Struct(Box::new(StructType::new_unchecked(vec![
-                    StructField::new("inner_v", DataType::unshredded_variant(), true),
-                ]))),
+                StructType::new_unchecked(vec![StructField::new(
+                    "inner_v",
+                    DataType::unshredded_variant(),
+                    true,
+                )]),
                 true,
             ),
         ])),
@@ -1310,9 +1312,11 @@ mod tests {
             StructField::new("id", DataType::INTEGER, false),
             StructField::new(
                 "nested",
-                DataType::Struct(Box::new(StructType::new_unchecked(vec![
-                    StructField::new("inner_ts", DataType::TIMESTAMP_NTZ, true),
-                ]))),
+                StructType::new_unchecked(vec![StructField::new(
+                    "inner_ts",
+                    DataType::TIMESTAMP_NTZ,
+                    true,
+                )]),
                 true,
             ),
         ])),
@@ -1385,11 +1389,7 @@ mod tests {
     #[case::nested_non_null(
         Arc::new(StructType::new_unchecked(vec![StructField::new(
             "parent",
-            DataType::Struct(Box::new(StructType::new_unchecked(vec![StructField::new(
-                "child",
-                DataType::INTEGER,
-                false,
-            )]))),
+            StructType::new_unchecked(vec![StructField::new("child", DataType::INTEGER, false)]),
             true,
         )])),
         true,
@@ -1609,7 +1609,7 @@ mod tests {
             StructType::new_unchecked(vec![StructField::new("city", DataType::STRING, true)]);
         let schema = StructType::new_unchecked(vec![
             StructField::new("id", DataType::INTEGER, false),
-            StructField::new("address", DataType::Struct(Box::new(address_struct)), true),
+            StructField::new("address", address_struct, true),
         ]);
 
         let columns = vec![ColumnName::new(["address", "city"])];
@@ -1624,21 +1624,15 @@ mod tests {
     #[rstest::rstest]
     #[case::struct_type(
         "struct_col",
-        DataType::Struct(Box::new(StructType::new_unchecked(vec![
-            StructField::new("inner", DataType::STRING, false),
-        ]))),
+        DataType::from(StructType::new_unchecked(vec![StructField::new("inner", DataType::STRING, false)])),
     )]
     #[case::array_type(
         "array_col",
-        DataType::Array(Box::new(crate::schema::ArrayType::new(DataType::INTEGER, false)))
+        DataType::from(crate::schema::ArrayType::new(DataType::INTEGER, false))
     )]
     #[case::map_type(
         "map_col",
-        DataType::Map(Box::new(crate::schema::MapType::new(
-            DataType::STRING,
-            DataType::INTEGER,
-            false
-        )))
+        DataType::from(crate::schema::MapType::new(DataType::STRING, DataType::INTEGER, false))
     )]
     fn test_validate_partition_columns_complex_types_rejected(
         #[case] col_name: &str,

--- a/kernel/src/transaction/commit_info.rs
+++ b/kernel/src/transaction/commit_info.rs
@@ -36,7 +36,7 @@ fn commit_info_literal_exprs(
                         map.into_iter()
                             .map(|(k, v)| (Scalar::String(k), Scalar::String(v))),
                     )?),
-                    None => Scalar::Null(DataType::from(op_params_map_type)),
+                    None => Scalar::null(op_params_map_type),
                 },
             )),
         ),

--- a/kernel/src/transaction/commit_info.rs
+++ b/kernel/src/transaction/commit_info.rs
@@ -36,7 +36,7 @@ fn commit_info_literal_exprs(
                         map.into_iter()
                             .map(|(k, v)| (Scalar::String(k), Scalar::String(v))),
                     )?),
-                    None => Scalar::Null(DataType::Map(Box::new(op_params_map_type))),
+                    None => Scalar::Null(DataType::from(op_params_map_type)),
                 },
             )),
         ),

--- a/kernel/src/transaction/schema_evolution.rs
+++ b/kernel/src/transaction/schema_evolution.rs
@@ -602,13 +602,13 @@ mod tests {
     }
 
     fn struct_of_two_primitives() -> DataType {
-        DataType::Struct(Box::new(
+        DataType::from(
             StructType::try_new(vec![
                 StructField::nullable("a", DataType::STRING),
                 StructField::nullable("b", DataType::STRING),
             ])
             .unwrap(),
-        ))
+        )
     }
 
     /// Adding a complex column on a CM table: every inner struct field reachable through
@@ -616,32 +616,18 @@ mod tests {
     /// and `new_max_column_id` must advance to the largest assigned ID.
     #[rstest]
     #[case::nested_struct(struct_of_two_primitives(), 3)]
-    #[case::array_of_primitive(
-        DataType::Array(Box::new(ArrayType::new(DataType::STRING, true))),
-        1
-    )]
+    #[case::array_of_primitive(DataType::from(ArrayType::new(DataType::STRING, true)), 1)]
     #[case::map_of_primitives(
-        DataType::Map(Box::new(MapType::new(DataType::STRING, DataType::INTEGER, true))),
+        DataType::from(MapType::new(DataType::STRING, DataType::INTEGER, true)),
         1
     )]
-    #[case::array_of_struct(
-        DataType::Array(Box::new(ArrayType::new(struct_of_two_primitives(), true))),
-        3
-    )]
+    #[case::array_of_struct(DataType::from(ArrayType::new(struct_of_two_primitives(), true)), 3)]
     #[case::map_value_is_struct(
-        DataType::Map(Box::new(MapType::new(
-            DataType::STRING,
-            struct_of_two_primitives(),
-            true,
-        ))),
+        DataType::from(MapType::new(DataType::STRING, struct_of_two_primitives(), true,)),
         3
     )]
     #[case::map_key_is_struct(
-        DataType::Map(Box::new(MapType::new(
-            struct_of_two_primitives(),
-            DataType::INTEGER,
-            true,
-        ))),
+        DataType::from(MapType::new(struct_of_two_primitives(), DataType::INTEGER, true,)),
         3
     )]
     fn add_complex_column_with_column_mapping_assigns_ids_to_all_inner_fields(
@@ -688,9 +674,7 @@ mod tests {
     #[case::top_level(field_with_id_only("tainted", DataType::STRING, 99))]
     #[case::nested_in_struct(StructField::nullable(
         "outer",
-        DataType::Struct(Box::new(
-            StructType::try_new(vec![field_with_id_only("inner", DataType::STRING, 99)]).unwrap(),
-        )),
+        StructType::try_new(vec![field_with_id_only("inner", DataType::STRING, 99)]).unwrap(),
     ))]
     fn add_column_with_preexisting_cm_metadata_is_preserved_under_cm(#[case] field: StructField) {
         let ops = vec![SchemaOperation::AddColumn { field }];

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -576,7 +576,7 @@ impl FilteredRowVisitor for DvMatchVisitor<'_> {
         rows: RowIndexIterator<'_>,
     ) -> DeltaResult<()> {
         static NULL_DV: LazyLock<Scalar> =
-            LazyLock::new(|| Scalar::Null(DataType::from(DeletionVectorDescriptor::to_schema())));
+            LazyLock::new(|| Scalar::null(DeletionVectorDescriptor::to_schema()));
         static DV_SCHEMA_FIELDS: LazyLock<Vec<StructField>> = LazyLock::new(|| {
             DeletionVectorDescriptor::to_schema()
                 .into_fields()

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -407,7 +407,7 @@ fn nullable_add_log_schema() -> &'static SchemaRef {
 /// Used when appending DV columns to scan file data.
 #[cfg_attr(not(feature = "internal-api"), allow(dead_code))]
 static STRUCT_DELETION_VECTOR_SCHEMA: LazyLock<ArrayType> =
-    LazyLock::new(|| ArrayType::new(DeletionVectorDescriptor::to_schema().into(), true));
+    LazyLock::new(|| ArrayType::new(DeletionVectorDescriptor::to_schema(), true));
 
 /// Returns the schema for an array of deletion vector descriptors.
 #[cfg_attr(not(feature = "internal-api"), allow(dead_code))]

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -552,11 +552,11 @@ pub(crate) mod test_utils {
     ) -> StructType {
         let array_in_map = StructField::nullable(
             "array_in_map",
-            KernelDataType::Map(Box::new(MapType::new(
+            MapType::new(
                 KernelDataType::INTEGER,
-                KernelDataType::Array(Box::new(ArrayType::new(KernelDataType::INTEGER, true))),
+                ArrayType::new(KernelDataType::INTEGER, true),
                 true,
-            ))),
+            ),
         )
         .with_metadata(metadata);
         StructType::try_new(vec![array_in_map]).unwrap()
@@ -750,19 +750,19 @@ pub(crate) mod test_utils {
     }
 
     fn complex_nested_inner_map_type() -> KernelDataType {
-        KernelDataType::Map(Box::new(MapType::new(
+        KernelDataType::from(MapType::new(
             KernelDataType::INTEGER,
-            KernelDataType::Array(Box::new(ArrayType::new(KernelDataType::INTEGER, true))),
+            ArrayType::new(KernelDataType::INTEGER, true),
             true,
-        )))
+        ))
     }
 
     fn complex_nested_outer_map_type(struct_value: StructType) -> KernelDataType {
-        KernelDataType::Map(Box::new(MapType::new(
-            KernelDataType::Array(Box::new(ArrayType::new(KernelDataType::INTEGER, true))),
-            KernelDataType::Struct(Box::new(struct_value)),
+        KernelDataType::from(MapType::new(
+            ArrayType::new(KernelDataType::INTEGER, true),
+            struct_value,
             true,
-        )))
+        ))
     }
 
     /// Build the kernel schema described by [`complex_nested_with_field_ids`].
@@ -947,11 +947,7 @@ pub(crate) mod test_utils {
             StructField::new("id", KernelDataType::LONG, true),
             StructField::nullable(
                 "entries",
-                MapType::new(
-                    KernelDataType::STRING,
-                    KernelDataType::Struct(Box::new(value_struct)),
-                    true,
-                ),
+                MapType::new(KernelDataType::STRING, value_struct, true),
             ),
             StructField::nullable("name", KernelDataType::STRING),
         ]))
@@ -980,11 +976,7 @@ pub(crate) mod test_utils {
             with_column_mapping(
                 StructField::nullable(
                     "entries",
-                    MapType::new(
-                        KernelDataType::STRING,
-                        KernelDataType::Struct(Box::new(value_struct)),
-                        true,
-                    ),
+                    MapType::new(KernelDataType::STRING, value_struct, true),
                 ),
                 2,
                 "phys_entries",
@@ -1007,7 +999,7 @@ pub(crate) mod test_utils {
             StructField::new("id", KernelDataType::LONG, true),
             StructField::nullable(
                 "items",
-                ArrayType::new(KernelDataType::Struct(Box::new(item_struct)), true),
+                ArrayType::new(KernelDataType::from(item_struct), true),
             ),
             StructField::nullable("name", KernelDataType::STRING),
         ]))
@@ -1036,7 +1028,7 @@ pub(crate) mod test_utils {
             with_column_mapping(
                 StructField::nullable(
                     "items",
-                    ArrayType::new(KernelDataType::Struct(Box::new(item_struct)), true),
+                    ArrayType::new(KernelDataType::from(item_struct), true),
                 ),
                 2,
                 "phys_items",
@@ -1056,17 +1048,13 @@ pub(crate) mod test_utils {
     pub(crate) fn test_deep_nested_schema_missing_leaf_cm() -> StructType {
         let leaf_struct =
             StructType::new_unchecked([StructField::new("leaf", KernelDataType::INTEGER, false)]);
-        let map_type = MapType::new(
-            KernelDataType::STRING,
-            KernelDataType::Struct(Box::new(leaf_struct)),
-            true,
-        );
+        let map_type = MapType::new(KernelDataType::STRING, leaf_struct, true);
         let mid_struct = StructType::new_unchecked([with_column_mapping(
             StructField::nullable("mid_field", map_type),
             2,
             "phys_mid_field",
         )]);
-        let array_type = ArrayType::new(KernelDataType::Struct(Box::new(mid_struct)), true);
+        let array_type = ArrayType::new(KernelDataType::from(mid_struct), true);
         StructType::new_unchecked([with_column_mapping(
             StructField::nullable("top", array_type),
             1,
@@ -1210,7 +1198,7 @@ pub(crate) mod test_utils {
             let nested = StructType::new_unchecked([cm_field("id", 3, "id", DataType::INTEGER)]);
             StructType::new_unchecked([
                 cm_field("id", 1, "id", DataType::INTEGER),
-                cm_field("nested", 2, "nested", DataType::Struct(Box::new(nested))),
+                cm_field("nested", 2, "nested", nested),
             ])
         }
 
@@ -1220,7 +1208,7 @@ pub(crate) mod test_utils {
                 cm_field("a", 2, "x", DataType::INTEGER),
                 cm_field("b", 3, "x", DataType::INTEGER),
             ]);
-            let arr_of_struct = ArrayType::new(DataType::Struct(Box::new(inner)), true);
+            let arr_of_struct = ArrayType::new(inner, true);
             let map_to_arr = MapType::new(DataType::STRING, arr_of_struct, true);
             StructType::new_unchecked([cm_field("outer", 1, "outer", map_to_arr)])
         }
@@ -1249,9 +1237,9 @@ pub(crate) mod test_utils {
                 cm_field("y", 5, "q", DataType::INTEGER),
             ]);
             StructType::new_unchecked([
-                cm_field("a", 1, "p", DataType::Struct(Box::new(a_struct))),
-                cm_field("b", 2, "p", DataType::Struct(Box::new(b_struct))),
-                cm_field("nested", 3, "nested", DataType::Struct(Box::new(nested))),
+                cm_field("a", 1, "p", a_struct),
+                cm_field("b", 2, "p", b_struct),
+                cm_field("nested", 3, "nested", nested),
             ])
         }
 

--- a/kernel/tests/integration/create_table/clustering.rs
+++ b/kernel/tests/integration/create_table/clustering.rs
@@ -24,26 +24,14 @@ fn clustering_test_schema() -> DeltaResult<Arc<StructType>> {
         StructField::new("zip", DataType::STRING, true),
     ])?;
     let l4 = StructType::try_new(vec![StructField::new("value", DataType::DOUBLE, true)])?;
-    let l3 = StructType::try_new(vec![StructField::new(
-        "l4",
-        DataType::Struct(Box::new(l4)),
-        true,
-    )])?;
-    let l2 = StructType::try_new(vec![StructField::new(
-        "l3",
-        DataType::Struct(Box::new(l3)),
-        true,
-    )])?;
-    let l1 = StructType::try_new(vec![StructField::new(
-        "l2",
-        DataType::Struct(Box::new(l2)),
-        true,
-    )])?;
+    let l3 = StructType::try_new(vec![StructField::new("l4", l4, true)])?;
+    let l2 = StructType::try_new(vec![StructField::new("l3", l3, true)])?;
+    let l1 = StructType::try_new(vec![StructField::new("l2", l2, true)])?;
     Ok(Arc::new(StructType::try_new(vec![
         StructField::new("id", DataType::INTEGER, true),
         StructField::new("name", DataType::STRING, true),
-        StructField::new("address", DataType::Struct(Box::new(address)), true),
-        StructField::new("l1", DataType::Struct(Box::new(l1)), true),
+        StructField::new("address", address, true),
+        StructField::new("l1", l1, true),
     ])?))
 }
 

--- a/kernel/tests/integration/create_table/column_mapping.rs
+++ b/kernel/tests/integration/create_table/column_mapping.rs
@@ -41,7 +41,7 @@ pub(super) fn strip_column_mapping_metadata(schema: &StructType) -> StructType {
         match dt {
             DataType::Struct(s) => {
                 let fields: Vec<_> = s.fields().map(|f| strip_field(f, cm_id, cm_name)).collect();
-                DataType::Struct(Box::new(StructType::new_unchecked(fields)))
+                DataType::from(StructType::new_unchecked(fields))
             }
             DataType::Array(a) => DataType::from(ArrayType::new(
                 strip_data_type(a.element_type(), cm_id, cm_name),
@@ -344,7 +344,7 @@ fn test_column_mapping_nested_schema() -> DeltaResult<()> {
 
     let schema = Arc::new(StructType::try_new(vec![
         StructField::new("id", DataType::INTEGER, true),
-        StructField::new("address", DataType::Struct(Box::new(address_type)), true),
+        StructField::new("address", address_type, true),
     ])?);
 
     // Create table and load snapshot (validates column mapping for nested schema on read)
@@ -428,7 +428,7 @@ fn test_column_mapping_schema_with_maps_and_arrays() -> DeltaResult<()> {
             DataType::from(ArrayType::new(DataType::INTEGER, true)),
             true,
         ),
-        StructField::new("metadata", DataType::Struct(Box::new(metadata_type)), true),
+        StructField::new("metadata", metadata_type, true),
     ])?);
 
     // Create table with column mapping and read back the snapshot.
@@ -461,26 +461,14 @@ fn clustering_cm_test_schema() -> DeltaResult<Arc<StructType>> {
         StructField::new("zip", DataType::STRING, true),
     ])?;
     let l4 = StructType::try_new(vec![StructField::new("value", DataType::DOUBLE, true)])?;
-    let l3 = StructType::try_new(vec![StructField::new(
-        "l4",
-        DataType::Struct(Box::new(l4)),
-        true,
-    )])?;
-    let l2 = StructType::try_new(vec![StructField::new(
-        "l3",
-        DataType::Struct(Box::new(l3)),
-        true,
-    )])?;
-    let l1 = StructType::try_new(vec![StructField::new(
-        "l2",
-        DataType::Struct(Box::new(l2)),
-        true,
-    )])?;
+    let l3 = StructType::try_new(vec![StructField::new("l4", l4, true)])?;
+    let l2 = StructType::try_new(vec![StructField::new("l3", l3, true)])?;
+    let l1 = StructType::try_new(vec![StructField::new("l2", l2, true)])?;
     Ok(Arc::new(StructType::try_new(vec![
         StructField::new("id", DataType::INTEGER, true),
         StructField::new("name", DataType::STRING, true),
-        StructField::new("address", DataType::Struct(Box::new(address)), true),
-        StructField::new("l1", DataType::Struct(Box::new(l1)), true),
+        StructField::new("address", address, true),
+        StructField::new("l1", l1, true),
     ])?))
 }
 

--- a/kernel/tests/integration/create_table/iceberg_compat.rs
+++ b/kernel/tests/integration/create_table/iceberg_compat.rs
@@ -66,18 +66,12 @@ fn v3_create_table_rejects_incompatible_props(
 #[case::top_level(StructField::nullable("maybe", DataType::VOID))]
 #[case::in_struct(StructField::nullable(
     "s",
-    DataType::Struct(Box::new(StructType::new_unchecked([StructField::nullable(
-        "x",
-        DataType::VOID,
-    )]))),
+    StructType::new_unchecked([StructField::nullable("x", DataType::VOID)]),
 ))]
-#[case::in_array(StructField::nullable(
-    "arr",
-    DataType::Array(Box::new(ArrayType::new(DataType::VOID, true))),
-))]
+#[case::in_array(StructField::nullable("arr", ArrayType::new(DataType::VOID, true),))]
 #[case::in_map_value(StructField::nullable(
     "m",
-    DataType::Map(Box::new(MapType::new(DataType::STRING, DataType::VOID, true))),
+    MapType::new(DataType::STRING, DataType::VOID, true),
 ))]
 fn v3_create_table_rejects_void_column(#[case] void_field: StructField) -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
@@ -106,11 +100,11 @@ fn v3_supported_but_not_enabled_skips_cm_and_nested_ids() -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
     let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
         "data",
-        DataType::Map(Box::new(MapType::new(
+        MapType::new(
             DataType::INTEGER,
-            DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+            ArrayType::new(DataType::INTEGER, true),
             true,
-        ))),
+        ),
     )])?);
 
     let _ = create_table(&table_path, schema, "Test/1.0")

--- a/kernel/tests/integration/create_table/mod.rs
+++ b/kernel/tests/integration/create_table/mod.rs
@@ -277,11 +277,8 @@ fn nested_non_null_schema() -> Arc<StructType> {
     let nested = StructType::try_new(vec![StructField::not_null("child", DataType::INTEGER)])
         .expect("nested non-null schema should be valid");
     Arc::new(
-        StructType::try_new(vec![StructField::nullable(
-            "nested",
-            DataType::Struct(Box::new(nested)),
-        )])
-        .expect("top-level nested schema should be valid"),
+        StructType::try_new(vec![StructField::nullable("nested", nested)])
+            .expect("top-level nested schema should be valid"),
     )
 }
 

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -214,12 +214,11 @@ async fn add_columns_lifecycle(
     StructField::nullable(
         "items",
         ArrayType::new(
-            DataType::Struct(Box::new(
-                StructType::try_new(vec![
-                    StructField::nullable("a", DataType::STRING),
-                    StructField::nullable("b", DataType::INTEGER),
-                ]).unwrap(),
-            )),
+            StructType::try_new(vec![
+                StructField::nullable("a", DataType::STRING),
+                StructField::nullable("b", DataType::INTEGER),
+            ])
+            .unwrap(),
             true,
         ),
     ),
@@ -230,12 +229,11 @@ async fn add_columns_lifecycle(
         "by_id",
         MapType::new(
             DataType::STRING,
-            DataType::Struct(Box::new(
-                StructType::try_new(vec![
-                    StructField::nullable("a", DataType::STRING),
-                    StructField::nullable("b", DataType::INTEGER),
-                ]).unwrap(),
-            )),
+            StructType::try_new(vec![
+                StructField::nullable("a", DataType::STRING),
+                StructField::nullable("b", DataType::INTEGER),
+            ])
+            .unwrap(),
             true,
         ),
     ),
@@ -245,12 +243,11 @@ async fn add_columns_lifecycle(
     StructField::nullable(
         "lookup",
         MapType::new(
-            DataType::Struct(Box::new(
-                StructType::try_new(vec![
-                    StructField::nullable("a", DataType::STRING),
-                    StructField::nullable("b", DataType::INTEGER),
-                ]).unwrap(),
-            )),
+            StructType::try_new(vec![
+                StructField::nullable("a", DataType::STRING),
+                StructField::nullable("b", DataType::INTEGER),
+            ])
+            .unwrap(),
             DataType::INTEGER,
             true,
         ),

--- a/kernel/tests/integration/features/iceberg_compat.rs
+++ b/kernel/tests/integration/features/iceberg_compat.rs
@@ -55,11 +55,11 @@ async fn snapshot_blocked_when_v3_schema_has_legacy_nested_ids() {
     });
     let schema = StructType::try_new(vec![StructField::nullable(
         "data",
-        DataType::Map(Box::new(MapType::new(
+        MapType::new(
             DataType::INTEGER,
-            DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+            ArrayType::new(DataType::INTEGER, true),
             true,
-        ))),
+        ),
     )
     .with_metadata([
         (
@@ -398,20 +398,20 @@ fn complex_nested_data_type() -> DataType {
     let inner_struct = StructType::try_new(vec![
         StructField::nullable(
             "inner_map",
-            DataType::Map(Box::new(MapType::new(
-                DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+            MapType::new(
+                ArrayType::new(DataType::INTEGER, true),
                 DataType::INTEGER,
                 true,
-            ))),
+            ),
         ),
         StructField::nullable("n", DataType::INTEGER),
     ])
     .unwrap();
-    DataType::Map(Box::new(MapType::new(
-        DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
-        DataType::Struct(Box::new(inner_struct)),
+    DataType::from(MapType::new(
+        ArrayType::new(DataType::INTEGER, true),
+        inner_struct,
         true,
-    )))
+    ))
 }
 
 const ROWS_PER_PARTITION: i32 = 3;

--- a/kernel/tests/integration/write/nested_field_ids.rs
+++ b/kernel/tests/integration/write/nested_field_ids.rs
@@ -76,11 +76,11 @@ fn build_kernel_schema(nested_ids_meta_key: &str) -> StructType {
 
     let array_in_map = with_field_ids(
         "array_in_map",
-        DataType::Map(Box::new(MapType::new(
+        DataType::from(MapType::new(
             DataType::INTEGER,
-            DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true))),
+            ArrayType::new(DataType::INTEGER, true),
             true,
-        ))),
+        )),
         1,
         &[
             ("array_in_map.key", 100),
@@ -91,14 +91,10 @@ fn build_kernel_schema(nested_ids_meta_key: &str) -> StructType {
 
     let map_in_list = with_field_ids(
         "map_in_list",
-        DataType::Array(Box::new(ArrayType::new(
-            DataType::Map(Box::new(MapType::new(
-                DataType::INTEGER,
-                DataType::INTEGER,
-                true,
-            ))),
+        DataType::from(ArrayType::new(
+            MapType::new(DataType::INTEGER, DataType::INTEGER, true),
             true,
-        ))),
+        )),
         2,
         &[
             ("map_in_list.element", 200),

--- a/kernel/tests/integration/write/stats.rs
+++ b/kernel/tests/integration/write/stats.rs
@@ -133,17 +133,10 @@ async fn test_write_stats_for_complex_type_columns(
 
     let schema = Arc::new(StructType::try_new(vec![
         StructField::nullable("id", DataType::LONG),
-        StructField::nullable(
-            "tags",
-            DataType::Array(Box::new(ArrayType::new(DataType::STRING, true))),
-        ),
+        StructField::nullable("tags", ArrayType::new(DataType::STRING, true)),
         StructField::nullable(
             "props",
-            DataType::Map(Box::new(MapType::new(
-                DataType::STRING,
-                DataType::LONG,
-                true,
-            ))),
+            MapType::new(DataType::STRING, DataType::LONG, true),
         ),
         StructField::nullable("v", DataType::unshredded_variant()),
     ])?);
@@ -291,17 +284,10 @@ async fn test_write_stats_nested_complex_types_respect_column_limit(
             "data",
             DataType::try_struct_type(vec![
                 StructField::nullable("name", DataType::STRING),
-                StructField::nullable(
-                    "tags",
-                    DataType::Array(Box::new(ArrayType::new(DataType::STRING, true))),
-                ),
+                StructField::nullable("tags", ArrayType::new(DataType::STRING, true)),
                 StructField::nullable(
                     "props",
-                    DataType::Map(Box::new(MapType::new(
-                        DataType::STRING,
-                        DataType::LONG,
-                        true,
-                    ))),
+                    MapType::new(DataType::STRING, DataType::LONG, true),
                 ),
             ])?,
         ),

--- a/kernel/tests/integration/write/types.rs
+++ b/kernel/tests/integration/write/types.rs
@@ -625,10 +625,10 @@ async fn try_write_with_void_schema(schema: SchemaRef) -> KernelError {
         StructField::nullable(
             "arr",
             ArrayType::new(
-                DataType::Struct(Box::new(StructType::new_unchecked([
+                StructType::new_unchecked([
                     StructField::nullable("a", DataType::INTEGER),
                     StructField::nullable("b", DataType::VOID),
-                ]))),
+                ]),
                 true,
             ),
         ),
@@ -693,10 +693,7 @@ async fn try_write_with_void_schema(schema: SchemaRef) -> KernelError {
         StructField::nullable("id", DataType::INTEGER),
         StructField::nullable(
             "arr",
-            ArrayType::new(
-                DataType::Struct(Box::new(StructType::new_unchecked(Vec::<StructField>::new()))),
-                true,
-            ),
+            ArrayType::new(StructType::new_unchecked(Vec::<StructField>::new()), true),
         ),
     ])),
     "struct nested in Array or Map must contain at least one non-void field"

--- a/test-utils/src/column_mapping_fixtures.rs
+++ b/test-utils/src/column_mapping_fixtures.rs
@@ -7,18 +7,8 @@ pub fn same_leaf_phy_name_under_different_parents() -> StructType {
     let parent1_children = StructType::new_unchecked([cm_field("a", 2, "x", DataType::INTEGER)]);
     let parent2_children = StructType::new_unchecked([cm_field("a", 4, "x", DataType::INTEGER)]);
     StructType::new_unchecked([
-        cm_field(
-            "outer1",
-            1,
-            "outer1",
-            DataType::Struct(Box::new(parent1_children)),
-        ),
-        cm_field(
-            "outer2",
-            3,
-            "outer2",
-            DataType::Struct(Box::new(parent2_children)),
-        ),
+        cm_field("outer1", 1, "outer1", parent1_children),
+        cm_field("outer2", 3, "outer2", parent2_children),
     ])
 }
 
@@ -27,15 +17,10 @@ pub fn nested_field_with_same_phy_path() -> StructType {
         cm_field("a", 3, "x", DataType::INTEGER),
         cm_field("b", 4, "x", DataType::INTEGER),
     ]);
-    let arr_of_struct = ArrayType::new(DataType::Struct(Box::new(innermost)), true);
+    let arr_of_struct = ArrayType::new(innermost, true);
     let map_to_arr = MapType::new(DataType::STRING, arr_of_struct, true);
     let inner_struct = StructType::new_unchecked([cm_field("inner", 2, "inner", map_to_arr)]);
-    StructType::new_unchecked([cm_field(
-        "outer",
-        1,
-        "outer",
-        DataType::Struct(Box::new(inner_struct)),
-    )])
+    StructType::new_unchecked([cm_field("outer", 1, "outer", inner_struct)])
 }
 
 fn cm_field(name: &str, id: i64, phys: &str, ty: impl Into<DataType>) -> StructField {

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -953,9 +953,7 @@ pub fn nested_schema_with_type(dtype: DataType) -> SchemaRef {
         StructField::new("id", DataType::INTEGER, true),
         StructField::new(
             "nested",
-            DataType::Struct(Box::new(StructType::new_unchecked(vec![StructField::new(
-                "inner", dtype, true,
-            )]))),
+            StructType::new_unchecked(vec![StructField::new("inner", dtype, true)]),
             true,
         ),
     ]))


### PR DESCRIPTION
## What changes are proposed in this pull request?

Many (many) call sites that create new data types are doing it the hard way. Update them to use helper constructors that reduce boilerplate.

Also teach `ArrayType::new` to accept `impl Into<DataType>` (and update callers to leverage it).

As an extreme (but common) example, code like this:
```rust
        let array_ty = DataType::Array(Box::new(ArrayType::new(
            DataType::Struct(Box::new(inner_field_schema)),
            false,
        ))));
```
Can simplify down to just:
```rust
        let array_ty = DataType::from(ArrayType::new(inner_field_schema, false));
```

### This PR affects the following public APIs

The new `ArrayType::new` signature can cause compiler errors for callers who relied on un-annotated `.into()` to convert args into data types. Fix: remove those now-redundant `.into()` calls.

## How was this change tested?

Lots and lots of unit tests updated.