### PR TITLE
feat!: add failure metric events

### DIFF
--- a/docs/user-guide/src/observability/observability.md
+++ b/docs/user-guide/src/observability/observability.md
@@ -201,9 +201,13 @@ UUID that uniquely identifies an operation instance. All events from the same
 snapshot load share the same `MetricId`, so you can group them to reconstruct
 a timeline:
 
-1. `LogSegmentLoadSuccess` (how long listing took, how many files)
-2. `ProtocolMetadataLoadSuccess` (how long protocol/metadata parsing took)
+1. `LogSegmentLoadSuccess` or `LogSegmentLoadFailure` (listing the log segment)
+2. `ProtocolMetadataLoadSuccess` or `ProtocolMetadataLoadFailure` (reading protocol and metadata)
 3. `SnapshotBuildSuccess` or `SnapshotBuildFailure` (final outcome and total duration)
+
+Each step emits a success or failure variant carrying the shared `operation_id`. When a
+step fails, the snapshot build fails too, so the terminal `SnapshotBuildFailure` carries
+the same id and you can see which step broke from the buffered group.
 
 You can store the `MetricId` in your monitoring system as a trace ID or
 correlation key. Because everything flows through `tracing`, you can also
@@ -231,41 +235,49 @@ impl CorrelatingReporter {
     fn new() -> Self {
         Self { pending: Mutex::new(HashMap::new()) }
     }
+
+    // Buffer an intermediate step under its operation_id.
+    fn buffer(&self, operation_id: MetricId, event: MetricEvent) {
+        self.pending.lock().unwrap().entry(operation_id).or_default().push(event);
+    }
+
+    // Drain the buffered steps for a finished operation.
+    fn drain(&self, operation_id: MetricId) -> Vec<MetricEvent> {
+        self.pending.lock().unwrap().remove(&operation_id).unwrap_or_default()
+    }
 }
 
 impl MetricsReporter for CorrelatingReporter {
     fn report(&self, event: MetricEvent) {
         match event {
-            // 1. Buffer intermediate events, grouped by their shared operation_id. Bind with
-            //    `ref` so the event can still be moved into the buffer.
-            MetricEvent::LogSegmentLoadSuccess(ref e) => {
-                let id = e.operation_id;
-                self.pending.lock().unwrap().entry(id).or_default().push(event);
-            }
-            MetricEvent::ProtocolMetadataLoadSuccess(ref e) => {
-                let id = e.operation_id;
-                self.pending.lock().unwrap().entry(id).or_default().push(event);
-            }
-            // 2. When the terminal event arrives, drain the group and
-            //    compute aggregates (here, a count of sub-events).
+            // 1. Buffer each intermediate step, success OR failure, under its operation_id.
+            //    `ref e` borrows the id so `event` can still move into the buffer.
+            MetricEvent::LogSegmentLoadSuccess(ref e) => self.buffer(e.operation_id, event),
+            MetricEvent::LogSegmentLoadFailure(ref e) => self.buffer(e.operation_id, event),
+            MetricEvent::ProtocolMetadataLoadSuccess(ref e) => self.buffer(e.operation_id, event),
+            MetricEvent::ProtocolMetadataLoadFailure(ref e) => self.buffer(e.operation_id, event),
+
+            // 2. The terminal event drains the group. The buffered steps reconstruct the
+            //    timeline; on failure, the last step shows where the build broke.
             MetricEvent::SnapshotBuildSuccess(e) => {
-                let mut map = self.pending.lock().unwrap();
-                if let Some(events) = map.remove(&e.operation_id) {
-                    println!(
-                        "Snapshot v{} completed in {:?} ({} sub-events)",
-                        e.version,
-                        e.duration,
-                        events.len()
-                    );
-                }
+                let steps = self.drain(e.operation_id);
+                println!(
+                    "Snapshot v{} completed in {:?} ({} sub-events)",
+                    e.version,
+                    e.duration,
+                    steps.len()
+                );
             }
-            // On failure, discard the buffered group for this operation.
             MetricEvent::SnapshotBuildFailure(e) => {
-                let mut map = self.pending.lock().unwrap();
-                map.remove(&e.operation_id);
-                println!("Snapshot failed for operation {}", e.operation_id);
+                let steps = self.drain(e.operation_id);
+                println!(
+                    "Snapshot {} failed after {} sub-events; last step: {:?}",
+                    e.operation_id,
+                    steps.len(),
+                    steps.last()
+                );
             }
-            // Storage and scan events don't participate in snapshot correlation.
+            // Storage, scan, and post-build loads don't participate in snapshot correlation.
             _ => {}
         }
     }

--- a/docs/user-guide/src/observability/observability.md
+++ b/docs/user-guide/src/observability/observability.md
@@ -136,7 +136,7 @@ events from the same snapshot load together.
 | `LogSegmentLoadFailure` | `operation_id` | Log segment load failed. |
 | `ProtocolMetadataLoadSuccess` | `operation_id`, `duration` | Time to read protocol and metadata actions from the log. |
 | `ProtocolMetadataLoadFailure` | `operation_id` | Protocol/metadata load failed. |
-| `SnapshotBuildSuccess` | `operation_id`, `version`, `total_duration` | End-to-end snapshot creation, including the table version that was loaded. |
+| `SnapshotBuildSuccess` | `operation_id`, `version`, `duration` | End-to-end snapshot creation, including the table version that was loaded. |
 | `SnapshotBuildFailure` | `operation_id` | Snapshot creation failed. Use this to track error rates. |
 
 ### Scan metadata events
@@ -148,7 +148,7 @@ consumed. It provides detailed statistics about the log replay process:
 |-------|---------|
 | `operation_id` | Unique ID for this scan, useful for correlation. |
 | `scan_type` | Which scan path produced the event (see below). |
-| `total_duration` | Wall-clock time from scan start to iterator exhaustion. |
+| `duration` | Wall-clock time from scan start to iterator exhaustion. |
 | `num_add_files_seen` | Add actions that entered deduplication. Excludes files already eliminated by data skipping. |
 | `num_active_add_files` | Add files that survived log replay. These are the files your connector reads. |
 | `num_remove_files_seen` | Remove actions encountered in commit files. |
@@ -235,17 +235,16 @@ impl CorrelatingReporter {
 
 impl MetricsReporter for CorrelatingReporter {
     fn report(&self, event: MetricEvent) {
-        // Pull the operation_id out first so intermediate events can be buffered by group.
-        let operation_id = match &event {
-            MetricEvent::LogSegmentLoadSuccess(e) => Some(e.operation_id),
-            MetricEvent::ProtocolMetadataLoadSuccess(e) => Some(e.operation_id),
-            _ => None,
-        };
         match event {
-            // 1. Buffer intermediate events, grouped by their shared operation_id.
-            MetricEvent::LogSegmentLoadSuccess(_) | MetricEvent::ProtocolMetadataLoadSuccess(_) => {
-                let mut map = self.pending.lock().unwrap();
-                map.entry(operation_id.unwrap()).or_default().push(event);
+            // 1. Buffer intermediate events, grouped by their shared operation_id. Bind with
+            //    `ref` so the event can still be moved into the buffer.
+            MetricEvent::LogSegmentLoadSuccess(ref e) => {
+                let id = e.operation_id;
+                self.pending.lock().unwrap().entry(id).or_default().push(event);
+            }
+            MetricEvent::ProtocolMetadataLoadSuccess(ref e) => {
+                let id = e.operation_id;
+                self.pending.lock().unwrap().entry(id).or_default().push(event);
             }
             // 2. When the terminal event arrives, drain the group and
             //    compute aggregates (here, a count of sub-events).

--- a/docs/user-guide/src/observability/observability.md
+++ b/docs/user-guide/src/observability/observability.md
@@ -114,9 +114,9 @@ tracing_subscriber::registry()
 When a snapshot loads, you'll see output like:
 
 ```text
-[kernel-metrics] LogSegmentLoaded(id=a1b2c3d4-..., duration=12.34ms, commits=5, checkpoints=1, compactions=0, has_latest_crc=true)
-[kernel-metrics] ProtocolMetadataLoaded(id=a1b2c3d4-..., duration=3.21ms)
-[kernel-metrics] SnapshotCompleted(id=a1b2c3d4-..., version=5, duration=15.55ms)
+[kernel-metrics] LogSegmentLoadSuccess(id=a1b2c3d4-..., duration=12.34ms, commits=5, checkpoints=1, compactions=0, has_latest_crc=true)
+[kernel-metrics] ProtocolMetadataLoadSuccess(id=a1b2c3d4-..., duration=3.21ms)
+[kernel-metrics] SnapshotBuildSuccess(id=a1b2c3d4-..., version=5, duration=15.55ms)
 ```
 
 ## Metric events
@@ -132,10 +132,12 @@ events from the same snapshot load together.
 
 | Event | Fields | What it measures |
 |-------|--------|------------------|
-| `LogSegmentLoaded` | `operation_id`, `duration`, `num_commit_files`, `num_checkpoint_files`, `num_compaction_files`, `has_latest_crc_file` | Time to list and organize log files into a log segment. |
-| `ProtocolMetadataLoaded` | `operation_id`, `duration` | Time to read protocol and metadata actions from the log. |
-| `SnapshotCompleted` | `operation_id`, `version`, `total_duration` | End-to-end snapshot creation, including the table version that was loaded. |
-| `SnapshotFailed` | `operation_id`, `duration` | Snapshot creation failed. Use this to track error rates. |
+| `LogSegmentLoadSuccess` | `operation_id`, `duration`, `num_commit_files`, `num_checkpoint_files`, `num_compaction_files`, `has_latest_crc_file` | Time to list and organize log files into a log segment. |
+| `LogSegmentLoadFailure` | `operation_id` | Log segment load failed. |
+| `ProtocolMetadataLoadSuccess` | `operation_id`, `duration` | Time to read protocol and metadata actions from the log. |
+| `ProtocolMetadataLoadFailure` | `operation_id` | Protocol/metadata load failed. |
+| `SnapshotBuildSuccess` | `operation_id`, `version`, `total_duration` | End-to-end snapshot creation, including the table version that was loaded. |
+| `SnapshotBuildFailure` | `operation_id` | Snapshot creation failed. Use this to track error rates. |
 
 ### Scan metadata events
 
@@ -183,7 +185,8 @@ storage call may serve multiple higher-level operations.
 | `StorageCopyCompleted` | `duration` | A storage copy/rename call. |
 | `JsonReadCompleted` | `num_files`, `bytes_read` | One `JsonHandler::read_json_files` call completed. `bytes_read` is the sum of on-disk file sizes. |
 | `ParquetReadCompleted` | `num_files`, `bytes_read` | One `ParquetHandler::read_parquet_files` call completed. `bytes_read` is the sum of on-disk file sizes. |
-| `CrcReadCompleted` | `duration`, `bytes_read` | One CRC file read completed. `bytes_read` is the raw byte count from storage. |
+| `CrcReadSuccess` | `duration`, `bytes_read` | One CRC file read and parsed successfully. `bytes_read` is the raw byte count from storage. |
+| `CrcReadFailure` | none | A CRC file read or parse failed. The caller falls back to log replay. |
 
 > [!NOTE]
 > If you implement a custom `JsonHandler` or `ParquetHandler`, call
@@ -198,9 +201,9 @@ UUID that uniquely identifies an operation instance. All events from the same
 snapshot load share the same `MetricId`, so you can group them to reconstruct
 a timeline:
 
-1. `LogSegmentLoaded` (how long listing took, how many files)
-2. `ProtocolMetadataLoaded` (how long protocol/metadata parsing took)
-3. `SnapshotCompleted` or `SnapshotFailed` (final outcome and total duration)
+1. `LogSegmentLoadSuccess` (how long listing took, how many files)
+2. `ProtocolMetadataLoadSuccess` (how long protocol/metadata parsing took)
+3. `SnapshotBuildSuccess` or `SnapshotBuildFailure` (final outcome and total duration)
 
 You can store the `MetricId` in your monitoring system as a trace ID or
 correlation key. Because everything flows through `tracing`, you can also
@@ -232,33 +235,36 @@ impl CorrelatingReporter {
 
 impl MetricsReporter for CorrelatingReporter {
     fn report(&self, event: MetricEvent) {
-        match &event {
+        // Pull the operation_id out first so intermediate events can be buffered by group.
+        let operation_id = match &event {
+            MetricEvent::LogSegmentLoadSuccess(e) => Some(e.operation_id),
+            MetricEvent::ProtocolMetadataLoadSuccess(e) => Some(e.operation_id),
+            _ => None,
+        };
+        match event {
             // 1. Buffer intermediate events, grouped by their shared operation_id.
-            MetricEvent::LogSegmentLoaded { operation_id, .. }
-            | MetricEvent::ProtocolMetadataLoaded { operation_id, .. } => {
+            MetricEvent::LogSegmentLoadSuccess(_) | MetricEvent::ProtocolMetadataLoadSuccess(_) => {
                 let mut map = self.pending.lock().unwrap();
-                map.entry(*operation_id).or_default().push(event);
+                map.entry(operation_id.unwrap()).or_default().push(event);
             }
             // 2. When the terminal event arrives, drain the group and
             //    compute aggregates (here, a count of sub-events).
-            MetricEvent::SnapshotCompleted {
-                operation_id,
-                version,
-                total_duration,
-            } => {
+            MetricEvent::SnapshotBuildSuccess(e) => {
                 let mut map = self.pending.lock().unwrap();
-                if let Some(events) = map.remove(operation_id) {
+                if let Some(events) = map.remove(&e.operation_id) {
                     println!(
-                        "Snapshot v{version} completed in {total_duration:?} ({} sub-events)",
+                        "Snapshot v{} completed in {:?} ({} sub-events)",
+                        e.version,
+                        e.duration,
                         events.len()
                     );
                 }
             }
             // On failure, discard the buffered group for this operation.
-            MetricEvent::SnapshotFailed { operation_id, .. } => {
+            MetricEvent::SnapshotBuildFailure(e) => {
                 let mut map = self.pending.lock().unwrap();
-                map.remove(operation_id);
-                println!("Snapshot failed for operation {operation_id}");
+                map.remove(&e.operation_id);
+                println!("Snapshot failed for operation {}", e.operation_id);
             }
             // Storage and scan events don't participate in snapshot correlation.
             _ => {}

--- a/kernel/src/crc/reader.rs
+++ b/kernel/src/crc/reader.rs
@@ -17,8 +17,8 @@ use crate::{DeltaResult, Engine, Error};
 /// missing required fields). The caller should handle errors gracefully by falling back to log
 /// replay.
 ///
-/// Reports metrics: `CrcReadCompleted`.
-#[instrument(name = CRC_READ_COMPLETED_SPAN, skip_all, fields(report, bytes_read))]
+/// Reports metrics: `CrcReadSuccess` or `CrcReadFailure`.
+#[instrument(name = CRC_READ_COMPLETED_SPAN, err(level = "warn"), skip_all, fields(report, bytes_read))]
 pub(crate) fn try_read_crc_file(engine: &dyn Engine, crc_path: &ParsedLogPath) -> DeltaResult<Crc> {
     let storage = engine.storage_handler();
     let url = crc_path.location.as_url().clone();
@@ -174,18 +174,17 @@ mod tests {
         assert!(crc.num_deletion_vectors_opt.is_none());
         assert!(crc.deleted_record_counts_histogram_opt.is_none());
 
-        // Verify CrcReadCompleted metric was emitted
         let crc_events: Vec<_> = reporter
             .events()
             .into_iter()
-            .filter(|e| matches!(e, MetricEvent::CrcReadCompleted(_)))
+            .filter(|e| matches!(e, MetricEvent::CrcReadSuccess(_)))
             .collect();
         assert_eq!(crc_events.len(), 1);
-        assert!(matches!(&crc_events[0], MetricEvent::CrcReadCompleted(e) if e.bytes_read > 0));
+        assert!(matches!(&crc_events[0], MetricEvent::CrcReadSuccess(e) if e.bytes_read > 0));
     }
 
     #[test]
-    fn test_read_malformed_crc_file_emits_metric_then_fails() {
+    fn test_read_malformed_crc_file_emits_failure_metric() {
         let reporter = Arc::new(CapturingReporter::default());
         let _guard = install_thread_local_metrics_reporter(reporter.clone());
 
@@ -195,13 +194,18 @@ mod tests {
 
         assert_result_error_with_message(try_read_crc_file(&engine, &crc_path), "expected value");
 
-        // CrcReadCompleted is emitted after storage read, even when JSON parse fails
-        let crc_events: Vec<_> = reporter
-            .events()
-            .into_iter()
-            .filter(|e| matches!(e, MetricEvent::CrcReadCompleted(_)))
-            .collect();
-        assert_eq!(crc_events.len(), 1);
-        assert!(matches!(&crc_events[0], MetricEvent::CrcReadCompleted(e) if e.bytes_read > 0));
+        let events = reporter.events();
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, MetricEvent::CrcReadFailure)),
+            "expected CrcReadFailure when JSON parse fails"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, MetricEvent::CrcReadSuccess(_))),
+            "should not emit CrcReadSuccess when JSON parse fails"
+        );
     }
 }

--- a/kernel/src/crc/reader.rs
+++ b/kernel/src/crc/reader.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use tracing::{instrument, warn};
+use tracing::instrument;
 
 use super::Crc;
 use crate::metrics::events::CRC_READ_COMPLETED_SPAN;
@@ -18,7 +18,7 @@ use crate::{DeltaResult, Engine, Error};
 /// replay.
 ///
 /// Reports metrics: `CrcReadSuccess` or `CrcReadFailure`.
-#[instrument(name = CRC_READ_COMPLETED_SPAN, err(level = "warn"), skip_all, fields(report, bytes_read))]
+#[instrument(name = CRC_READ_COMPLETED_SPAN, err(level = "warn"), skip_all, fields(report, bytes_read, path = ?crc_path.location.location))]
 pub(crate) fn try_read_crc_file(engine: &dyn Engine, crc_path: &ParsedLogPath) -> DeltaResult<Crc> {
     let storage = engine.storage_handler();
     let url = crc_path.location.as_url().clone();
@@ -30,24 +30,15 @@ pub(crate) fn try_read_crc_file(engine: &dyn Engine, crc_path: &ParsedLogPath) -
     Crc::try_from_json_bytes(&data, crc_path.version)
 }
 
-/// Read a CRC file, returning `None` and logging a `warn` if it cannot be read.
+/// Read a CRC file, returning `None` if it cannot be read.
 ///
 /// CRC files are optional, so an unreadable one is not an error: the caller proceeds without
-/// it.
+/// it. The failure is logged and metered by [`try_read_crc_file`]'s instrumentation.
 pub(crate) fn read_crc_file_or_none(
     engine: &dyn Engine,
     crc_file: &ParsedLogPath,
 ) -> Option<Arc<Crc>> {
-    match try_read_crc_file(engine, crc_file) {
-        Ok(crc) => Some(Arc::new(crc)),
-        Err(e) => {
-            warn!(
-                "Failed to read CRC file {:?}: {e}.",
-                crc_file.location.location
-            );
-            None
-        }
-    }
+    try_read_crc_file(engine, crc_file).ok().map(Arc::new)
 }
 
 #[cfg(test)]

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -300,7 +300,7 @@ impl LogSegment {
     ///
     /// [`Snapshot`]: crate::snapshot::Snapshot
     ///
-    /// Reports metrics: `LogSegmentLoaded`.
+    /// Reports metrics: `LogSegmentLoadSuccess` or `LogSegmentLoadFailure`.
     #[instrument(
         name = LOG_SEGMENT_LOADED_SPAN,
         err,

--- a/kernel/src/log_segment/protocol_metadata_replay.rs
+++ b/kernel/src/log_segment/protocol_metadata_replay.rs
@@ -21,7 +21,9 @@ impl LogSegment {
     ///
     /// This is the checked variant of [`Self::read_protocol_metadata_opt`], used for fresh
     /// snapshot creation where both Protocol and Metadata must exist.
-    #[instrument(name = PROTOCOL_METADATA_LOADED_SPAN, fields(report, operation_id = %operation_id), skip(engine))]
+    ///
+    /// Reports metrics: `ProtocolMetadataLoadSuccess` or `ProtocolMetadataLoadFailure`.
+    #[instrument(name = PROTOCOL_METADATA_LOADED_SPAN, err, fields(report, operation_id = %operation_id), skip(engine))]
     pub(crate) fn read_protocol_metadata(
         &self,
         engine: &dyn Engine,

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -194,10 +194,21 @@ impl MetricEvent {
             Self::DomainMetadataLoadSuccess(_) => Self::DomainMetadataLoadFailure,
             Self::SetTransactionLoadSuccess(_) => Self::SetTransactionLoadFailure,
             Self::CrcReadSuccess(_) => Self::CrcReadFailure,
-            // Non-lifecycle events have no failure form and never fire an `error` field. A new
-            // event that adds `err` instrumentation without a failure mapping would silently
-            // pass through here as a success.
-            other => other,
+            // Events with no failure form pass through unchanged.
+            // Note: here we list explicitly so adding a lifecycle event without a failure mapping
+            //       fails to compile.
+            e @ (Self::LogSegmentLoadFailure(_)
+            | Self::ProtocolMetadataLoadFailure(_)
+            | Self::SnapshotBuildFailure(_)
+            | Self::DomainMetadataLoadFailure
+            | Self::SetTransactionLoadFailure
+            | Self::CrcReadFailure
+            | Self::JsonReadCompleted(_)
+            | Self::ParquetReadCompleted(_)
+            | Self::ScanMetadataCompleted(_)
+            | Self::StorageListCompleted(_)
+            | Self::StorageReadCompleted(_)
+            | Self::StorageCopyCompleted(_)) => e,
         }
     }
 }
@@ -238,6 +249,7 @@ impl fmt::Display for MetricEvent {
 // not a multi-segment path like `Type::SPAN_NAME`.
 pub(crate) const LOG_SEGMENT_LOADED_SPAN: &str = "segment.for_snapshot";
 
+/// A log segment was listed and assembled for a snapshot.
 #[derive(Debug, Clone)]
 pub struct LogSegmentLoadSuccess {
     // === Set on span creation ===
@@ -313,6 +325,7 @@ impl fmt::Display for LogSegmentLoadSuccess {
     }
 }
 
+/// Listing the log segment for a snapshot failed.
 #[derive(Debug, Clone)]
 pub struct LogSegmentLoadFailure {
     pub operation_id: MetricId,
@@ -330,6 +343,7 @@ impl fmt::Display for LogSegmentLoadFailure {
 
 pub(crate) const PROTOCOL_METADATA_LOADED_SPAN: &str = "segment.read_metadata";
 
+/// Protocol and metadata actions were read from the log.
 #[derive(Debug, Clone)]
 pub struct ProtocolMetadataLoadSuccess {
     // === Set on span creation ===
@@ -367,6 +381,7 @@ impl fmt::Display for ProtocolMetadataLoadSuccess {
     }
 }
 
+/// Reading protocol and metadata from the log failed.
 #[derive(Debug, Clone)]
 pub struct ProtocolMetadataLoadFailure {
     pub operation_id: MetricId,
@@ -384,6 +399,7 @@ impl fmt::Display for ProtocolMetadataLoadFailure {
 
 pub(crate) const SNAPSHOT_COMPLETED_SPAN: &str = "snap.build";
 
+/// A snapshot was built successfully.
 #[derive(Debug, Clone)]
 pub struct SnapshotBuildSuccess {
     // === Set on span creation ===
@@ -438,6 +454,7 @@ impl fmt::Display for SnapshotBuildSuccess {
 // SnapshotBuildFailure
 // ====================================================================
 
+/// Building a snapshot failed.
 #[derive(Debug, Clone)]
 pub struct SnapshotBuildFailure {
     pub operation_id: MetricId,
@@ -971,6 +988,7 @@ impl Visit for StorageAttrs {
 // StorageListCompleted
 // ============================
 
+/// A storage list operation completed.
 #[derive(Debug, Clone)]
 pub struct StorageListCompleted {
     // === Set on span creation ===
@@ -999,6 +1017,7 @@ impl fmt::Display for StorageListCompleted {
 // StorageReadCompleted
 // ============================
 
+/// A storage read operation completed.
 #[derive(Debug, Clone)]
 pub struct StorageReadCompleted {
     // === Set on span creation ===
@@ -1029,6 +1048,7 @@ impl fmt::Display for StorageReadCompleted {
 // StorageCopyCompleted
 // ============================
 
+/// A storage copy or rename operation completed.
 #[derive(Debug, Clone)]
 pub struct StorageCopyCompleted {
     // === Set on span creation ===

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -72,17 +72,17 @@ impl fmt::Display for MetricId {
 /// Metric events emitted during Delta Kernel operations.
 #[derive(Debug, Clone)]
 pub enum MetricEvent {
-    LogSegmentLoadSuccess(LogSegmentLoadStats),
+    LogSegmentLoadSuccess(LogSegmentLoadSuccess),
     LogSegmentLoadFailure(LogSegmentLoadFailure),
-    ProtocolMetadataLoadSuccess(ProtocolMetadataLoadStats),
+    ProtocolMetadataLoadSuccess(ProtocolMetadataLoadSuccess),
     ProtocolMetadataLoadFailure(ProtocolMetadataLoadFailure),
-    SnapshotBuildSuccess(SnapshotBuildStats),
+    SnapshotBuildSuccess(SnapshotBuildSuccess),
     SnapshotBuildFailure(SnapshotBuildFailure),
-    DomainMetadataLoadSuccess(DomainMetadataLoadStats),
+    DomainMetadataLoadSuccess(DomainMetadataLoadSuccess),
     DomainMetadataLoadFailure,
-    SetTransactionLoadSuccess(SetTransactionLoadStats),
+    SetTransactionLoadSuccess(SetTransactionLoadSuccess),
     SetTransactionLoadFailure,
-    CrcReadSuccess(CrcReadStats),
+    CrcReadSuccess(CrcReadSuccess),
     CrcReadFailure,
     JsonReadCompleted(JsonReadCompleted),
     ParquetReadCompleted(ParquetReadCompleted),
@@ -104,8 +104,8 @@ impl MetricEvent {
             Self::SetTransactionLoadSuccess(e) => e.set_duration(d),
             Self::CrcReadSuccess(e) => e.set_duration(d),
 
-            // Failure events carry no duration; storage/scan events set it at construction;
-            // read events have no duration field.
+            // For now, failure events carry no duration; storage/scan events set it at
+            // construction; read events have no duration field.
             Self::LogSegmentLoadFailure(_)
             | Self::ProtocolMetadataLoadFailure(_)
             | Self::SnapshotBuildFailure(_)
@@ -130,8 +130,8 @@ impl MetricEvent {
             Self::CrcReadSuccess(e) => e.record_u64(name, value),
 
             // No u64 fields set during span lifetime — a runtime record() on these is a bug.
-            Self::ProtocolMetadataLoadSuccess(_) => Err(ProtocolMetadataLoadStats::SPAN_NAME),
-            Self::SetTransactionLoadSuccess(_) => Err(SetTransactionLoadStats::SPAN_NAME),
+            Self::ProtocolMetadataLoadSuccess(_) => Err(ProtocolMetadataLoadSuccess::SPAN_NAME),
+            Self::SetTransactionLoadSuccess(_) => Err(SetTransactionLoadSuccess::SPAN_NAME),
             Self::ScanMetadataCompleted(_) => Err(ScanMetadataCompleted::SPAN_NAME),
             Self::JsonReadCompleted(_) => Err(JsonReadCompleted::SPAN_NAME),
             Self::ParquetReadCompleted(_) => Err(ParquetReadCompleted::SPAN_NAME),
@@ -140,12 +140,12 @@ impl MetricEvent {
             | Self::StorageCopyCompleted(_) => Err(STORAGE_SPAN),
 
             // Failure events are built at span close, after any runtime records.
-            Self::LogSegmentLoadFailure(_) => Err(LogSegmentLoadStats::SPAN_NAME),
-            Self::ProtocolMetadataLoadFailure(_) => Err(ProtocolMetadataLoadStats::SPAN_NAME),
-            Self::SnapshotBuildFailure(_) => Err(SnapshotBuildStats::SPAN_NAME),
-            Self::DomainMetadataLoadFailure => Err(DomainMetadataLoadStats::SPAN_NAME),
-            Self::SetTransactionLoadFailure => Err(SetTransactionLoadStats::SPAN_NAME),
-            Self::CrcReadFailure => Err(CrcReadStats::SPAN_NAME),
+            Self::LogSegmentLoadFailure(_) => Err(LogSegmentLoadSuccess::SPAN_NAME),
+            Self::ProtocolMetadataLoadFailure(_) => Err(ProtocolMetadataLoadSuccess::SPAN_NAME),
+            Self::SnapshotBuildFailure(_) => Err(SnapshotBuildSuccess::SPAN_NAME),
+            Self::DomainMetadataLoadFailure => Err(DomainMetadataLoadSuccess::SPAN_NAME),
+            Self::SetTransactionLoadFailure => Err(SetTransactionLoadSuccess::SPAN_NAME),
+            Self::CrcReadFailure => Err(CrcReadSuccess::SPAN_NAME),
         }
     }
 
@@ -157,9 +157,9 @@ impl MetricEvent {
             Self::SetTransactionLoadSuccess(e) => e.record_bool(name, value),
 
             // No bool fields set during span lifetime — a runtime record() on these is a bug.
-            Self::ProtocolMetadataLoadSuccess(_) => Err(ProtocolMetadataLoadStats::SPAN_NAME),
-            Self::SnapshotBuildSuccess(_) => Err(SnapshotBuildStats::SPAN_NAME),
-            Self::CrcReadSuccess(_) => Err(CrcReadStats::SPAN_NAME),
+            Self::ProtocolMetadataLoadSuccess(_) => Err(ProtocolMetadataLoadSuccess::SPAN_NAME),
+            Self::SnapshotBuildSuccess(_) => Err(SnapshotBuildSuccess::SPAN_NAME),
+            Self::CrcReadSuccess(_) => Err(CrcReadSuccess::SPAN_NAME),
             Self::ScanMetadataCompleted(_) => Err(ScanMetadataCompleted::SPAN_NAME),
             Self::JsonReadCompleted(_) => Err(JsonReadCompleted::SPAN_NAME),
             Self::ParquetReadCompleted(_) => Err(ParquetReadCompleted::SPAN_NAME),
@@ -168,15 +168,16 @@ impl MetricEvent {
             | Self::StorageCopyCompleted(_) => Err(STORAGE_SPAN),
 
             // Failure events are built at span close, after any runtime records.
-            Self::LogSegmentLoadFailure(_) => Err(LogSegmentLoadStats::SPAN_NAME),
-            Self::ProtocolMetadataLoadFailure(_) => Err(ProtocolMetadataLoadStats::SPAN_NAME),
-            Self::SnapshotBuildFailure(_) => Err(SnapshotBuildStats::SPAN_NAME),
-            Self::DomainMetadataLoadFailure => Err(DomainMetadataLoadStats::SPAN_NAME),
-            Self::SetTransactionLoadFailure => Err(SetTransactionLoadStats::SPAN_NAME),
-            Self::CrcReadFailure => Err(CrcReadStats::SPAN_NAME),
+            Self::LogSegmentLoadFailure(_) => Err(LogSegmentLoadSuccess::SPAN_NAME),
+            Self::ProtocolMetadataLoadFailure(_) => Err(ProtocolMetadataLoadSuccess::SPAN_NAME),
+            Self::SnapshotBuildFailure(_) => Err(SnapshotBuildSuccess::SPAN_NAME),
+            Self::DomainMetadataLoadFailure => Err(DomainMetadataLoadSuccess::SPAN_NAME),
+            Self::SetTransactionLoadFailure => Err(SetTransactionLoadSuccess::SPAN_NAME),
+            Self::CrcReadFailure => Err(CrcReadSuccess::SPAN_NAME),
         }
     }
 
+    /// Maps a lifecycle success event to its failure counterpart when the span errors.
     pub(crate) fn into_failure(self) -> Self {
         match self {
             Self::LogSegmentLoadSuccess(e) => Self::LogSegmentLoadFailure(LogSegmentLoadFailure {
@@ -193,6 +194,9 @@ impl MetricEvent {
             Self::DomainMetadataLoadSuccess(_) => Self::DomainMetadataLoadFailure,
             Self::SetTransactionLoadSuccess(_) => Self::SetTransactionLoadFailure,
             Self::CrcReadSuccess(_) => Self::CrcReadFailure,
+            // Non-lifecycle events have no failure form and never fire an `error` field. A new
+            // event that adds `err` instrumentation without a failure mapping would silently
+            // pass through here as a success.
             other => other,
         }
     }
@@ -235,7 +239,7 @@ impl fmt::Display for MetricEvent {
 pub(crate) const LOG_SEGMENT_LOADED_SPAN: &str = "segment.for_snapshot";
 
 #[derive(Debug, Clone)]
-pub struct LogSegmentLoadStats {
+pub struct LogSegmentLoadSuccess {
     // === Set on span creation ===
     pub operation_id: MetricId,
 
@@ -249,7 +253,7 @@ pub struct LogSegmentLoadStats {
     pub duration: Duration,
 }
 
-impl LogSegmentLoadStats {
+impl LogSegmentLoadSuccess {
     pub(crate) const SPAN_NAME: &'static str = LOG_SEGMENT_LOADED_SPAN;
 
     /// Construction-time channel. Extracts fields bound at span creation via
@@ -290,7 +294,7 @@ impl LogSegmentLoadStats {
     }
 }
 
-impl fmt::Display for LogSegmentLoadStats {
+impl fmt::Display for LogSegmentLoadSuccess {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self {
             operation_id,
@@ -309,8 +313,6 @@ impl fmt::Display for LogSegmentLoadStats {
     }
 }
 
-/// Log segment load failed. Emitted in place of [`LogSegmentLoadStats`] when the
-/// `segment.for_snapshot` span returns `Err`; carries the same `operation_id`.
 #[derive(Debug, Clone)]
 pub struct LogSegmentLoadFailure {
     pub operation_id: MetricId,
@@ -329,7 +331,7 @@ impl fmt::Display for LogSegmentLoadFailure {
 pub(crate) const PROTOCOL_METADATA_LOADED_SPAN: &str = "segment.read_metadata";
 
 #[derive(Debug, Clone)]
-pub struct ProtocolMetadataLoadStats {
+pub struct ProtocolMetadataLoadSuccess {
     // === Set on span creation ===
     pub operation_id: MetricId,
 
@@ -337,7 +339,7 @@ pub struct ProtocolMetadataLoadStats {
     pub duration: Duration,
 }
 
-impl ProtocolMetadataLoadStats {
+impl ProtocolMetadataLoadSuccess {
     pub(crate) const SPAN_NAME: &'static str = PROTOCOL_METADATA_LOADED_SPAN;
 
     pub(crate) fn from_attrs(attrs: &Attributes<'_>) -> Self {
@@ -352,7 +354,7 @@ impl ProtocolMetadataLoadStats {
     }
 }
 
-impl fmt::Display for ProtocolMetadataLoadStats {
+impl fmt::Display for ProtocolMetadataLoadSuccess {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self {
             operation_id,
@@ -365,8 +367,6 @@ impl fmt::Display for ProtocolMetadataLoadStats {
     }
 }
 
-/// Protocol/metadata load failed. Emitted in place of [`ProtocolMetadataLoadStats`] when the
-/// `segment.read_metadata` span returns `Err`; carries the same `operation_id`.
 #[derive(Debug, Clone)]
 pub struct ProtocolMetadataLoadFailure {
     pub operation_id: MetricId,
@@ -385,7 +385,7 @@ impl fmt::Display for ProtocolMetadataLoadFailure {
 pub(crate) const SNAPSHOT_COMPLETED_SPAN: &str = "snap.build";
 
 #[derive(Debug, Clone)]
-pub struct SnapshotBuildStats {
+pub struct SnapshotBuildSuccess {
     // === Set on span creation ===
     pub operation_id: MetricId,
 
@@ -396,7 +396,7 @@ pub struct SnapshotBuildStats {
     pub duration: Duration,
 }
 
-impl SnapshotBuildStats {
+impl SnapshotBuildSuccess {
     pub(crate) const SPAN_NAME: &'static str = SNAPSHOT_COMPLETED_SPAN;
 
     pub(crate) fn from_attrs(attrs: &Attributes<'_>) -> Self {
@@ -420,7 +420,7 @@ impl SnapshotBuildStats {
     }
 }
 
-impl fmt::Display for SnapshotBuildStats {
+impl fmt::Display for SnapshotBuildSuccess {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self {
             operation_id,
@@ -438,8 +438,6 @@ impl fmt::Display for SnapshotBuildStats {
 // SnapshotBuildFailure
 // ====================================================================
 
-/// Snapshot creation failed. Emitted in place of [`SnapshotBuildStats`] when the `snap.build`
-/// span returns `Err`; carries the same `operation_id`.
 #[derive(Debug, Clone)]
 pub struct SnapshotBuildFailure {
     pub operation_id: MetricId,
@@ -461,7 +459,7 @@ pub(crate) const DOMAIN_METADATA_LOADED_SPAN: &str = "snap.get_domain_metadata";
 /// from a log replay. Covers connector-issued loads of user domains and kernel-internal loads of
 /// system (`delta.*`) domains such as clustering or row tracking.
 #[derive(Debug, Clone)]
-pub struct DomainMetadataLoadStats {
+pub struct DomainMetadataLoadSuccess {
     // === Set during span lifetime ===
     pub from_cache: bool,
     pub num_domains_returned: u64,
@@ -470,7 +468,7 @@ pub struct DomainMetadataLoadStats {
     pub duration: Duration,
 }
 
-impl DomainMetadataLoadStats {
+impl DomainMetadataLoadSuccess {
     pub(crate) const SPAN_NAME: &'static str = DOMAIN_METADATA_LOADED_SPAN;
 
     pub(crate) fn from_attrs(_attrs: &Attributes<'_>) -> Self {
@@ -502,7 +500,7 @@ impl DomainMetadataLoadStats {
     }
 }
 
-impl fmt::Display for DomainMetadataLoadStats {
+impl fmt::Display for DomainMetadataLoadSuccess {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self {
             from_cache,
@@ -527,7 +525,7 @@ pub(crate) const SET_TRANSACTION_LOADED_SPAN: &str = "snap.get_app_id_version";
 /// (`from_cache`) or from a log replay. `found` is true when the app id has a committed
 /// transaction version, false when none exists or the existing one is expired.
 #[derive(Debug, Clone)]
-pub struct SetTransactionLoadStats {
+pub struct SetTransactionLoadSuccess {
     // === Set during span lifetime ===
     pub from_cache: bool,
     pub found: bool,
@@ -536,7 +534,7 @@ pub struct SetTransactionLoadStats {
     pub duration: Duration,
 }
 
-impl SetTransactionLoadStats {
+impl SetTransactionLoadSuccess {
     pub(crate) const SPAN_NAME: &'static str = SET_TRANSACTION_LOADED_SPAN;
 
     pub(crate) fn from_attrs(_attrs: &Attributes<'_>) -> Self {
@@ -561,7 +559,7 @@ impl SetTransactionLoadStats {
     }
 }
 
-impl fmt::Display for SetTransactionLoadStats {
+impl fmt::Display for SetTransactionLoadSuccess {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self {
             from_cache,
@@ -583,7 +581,7 @@ pub(crate) const CRC_READ_COMPLETED_SPAN: &str = "crc_read_completed";
 
 /// A CRC file was read and parsed successfully. `bytes_read` is the raw byte count from storage.
 #[derive(Debug, Clone)]
-pub struct CrcReadStats {
+pub struct CrcReadSuccess {
     // === Set during span lifetime ===
     pub bytes_read: u64,
 
@@ -591,7 +589,7 @@ pub struct CrcReadStats {
     pub duration: Duration,
 }
 
-impl CrcReadStats {
+impl CrcReadSuccess {
     pub(crate) const SPAN_NAME: &'static str = CRC_READ_COMPLETED_SPAN;
 
     pub(crate) fn from_attrs(_attrs: &Attributes<'_>) -> Self {
@@ -614,7 +612,7 @@ impl CrcReadStats {
     }
 }
 
-impl fmt::Display for CrcReadStats {
+impl fmt::Display for CrcReadSuccess {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self {
             duration,

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -72,13 +72,18 @@ impl fmt::Display for MetricId {
 /// Metric events emitted during Delta Kernel operations.
 #[derive(Debug, Clone)]
 pub enum MetricEvent {
-    LogSegmentLoaded(LogSegmentLoaded),
-    ProtocolMetadataLoaded(ProtocolMetadataLoaded),
-    SnapshotCompleted(SnapshotCompleted),
-    SnapshotFailed(SnapshotFailed),
-    DomainMetadataLoaded(DomainMetadataLoaded),
-    SetTransactionLoaded(SetTransactionLoaded),
-    CrcReadCompleted(CrcReadCompleted),
+    LogSegmentLoadSuccess(LogSegmentLoadStats),
+    LogSegmentLoadFailure(LogSegmentLoadFailure),
+    ProtocolMetadataLoadSuccess(ProtocolMetadataLoadStats),
+    ProtocolMetadataLoadFailure(ProtocolMetadataLoadFailure),
+    SnapshotBuildSuccess(SnapshotBuildStats),
+    SnapshotBuildFailure(SnapshotBuildFailure),
+    DomainMetadataLoadSuccess(DomainMetadataLoadStats),
+    DomainMetadataLoadFailure,
+    SetTransactionLoadSuccess(SetTransactionLoadStats),
+    SetTransactionLoadFailure,
+    CrcReadSuccess(CrcReadStats),
+    CrcReadFailure,
     JsonReadCompleted(JsonReadCompleted),
     ParquetReadCompleted(ParquetReadCompleted),
     ScanMetadataCompleted(ScanMetadataCompleted),
@@ -91,21 +96,26 @@ impl MetricEvent {
     /// Set the wall-clock duration on lifecycle events.
     pub(crate) fn set_duration_if_applicable(&mut self, d: Duration) {
         match self {
-            // Lifecycle: duration must be set by the tracing layer on span close.
-            Self::LogSegmentLoaded(e) => e.set_duration(d),
-            Self::ProtocolMetadataLoaded(e) => e.set_duration(d),
-            Self::SnapshotCompleted(e) => e.set_duration(d),
-            Self::SnapshotFailed(e) => e.set_duration(d),
-            Self::DomainMetadataLoaded(e) => e.set_duration(d),
-            Self::SetTransactionLoaded(e) => e.set_duration(d),
-            Self::CrcReadCompleted(e) => e.set_duration(d),
+            // Lifecycle success: duration must be set by the tracing layer on span close.
+            Self::LogSegmentLoadSuccess(e) => e.set_duration(d),
+            Self::ProtocolMetadataLoadSuccess(e) => e.set_duration(d),
+            Self::SnapshotBuildSuccess(e) => e.set_duration(d),
+            Self::DomainMetadataLoadSuccess(e) => e.set_duration(d),
+            Self::SetTransactionLoadSuccess(e) => e.set_duration(d),
+            Self::CrcReadSuccess(e) => e.set_duration(d),
 
-            // Duration already set at construction.
-            Self::ScanMetadataCompleted(_)
+            // Failure events carry no duration; storage/scan events set it at construction;
+            // read events have no duration field.
+            Self::LogSegmentLoadFailure(_)
+            | Self::ProtocolMetadataLoadFailure(_)
+            | Self::SnapshotBuildFailure(_)
+            | Self::DomainMetadataLoadFailure
+            | Self::SetTransactionLoadFailure
+            | Self::CrcReadFailure
+            | Self::ScanMetadataCompleted(_)
             | Self::StorageListCompleted(_)
             | Self::StorageReadCompleted(_)
             | Self::StorageCopyCompleted(_)
-            // No duration field.
             | Self::JsonReadCompleted(_)
             | Self::ParquetReadCompleted(_) => {}
         }
@@ -114,42 +124,76 @@ impl MetricEvent {
     pub(crate) fn record_u64(&mut self, name: &str, value: u64) -> Result<(), &'static str> {
         match self {
             // Variants with u64 fields set during span lifetime.
-            Self::LogSegmentLoaded(e) => e.record_u64(name, value),
-            Self::SnapshotCompleted(e) => e.record_u64(name, value),
-            Self::DomainMetadataLoaded(e) => e.record_u64(name, value),
-            Self::CrcReadCompleted(e) => e.record_u64(name, value),
+            Self::LogSegmentLoadSuccess(e) => e.record_u64(name, value),
+            Self::SnapshotBuildSuccess(e) => e.record_u64(name, value),
+            Self::DomainMetadataLoadSuccess(e) => e.record_u64(name, value),
+            Self::CrcReadSuccess(e) => e.record_u64(name, value),
 
             // No u64 fields set during span lifetime — a runtime record() on these is a bug.
-            Self::ProtocolMetadataLoaded(_) => Err(ProtocolMetadataLoaded::SPAN_NAME),
-            Self::SnapshotFailed(_) => Err(SnapshotCompleted::SPAN_NAME),
-            Self::SetTransactionLoaded(_) => Err(SetTransactionLoaded::SPAN_NAME),
+            Self::ProtocolMetadataLoadSuccess(_) => Err(ProtocolMetadataLoadStats::SPAN_NAME),
+            Self::SetTransactionLoadSuccess(_) => Err(SetTransactionLoadStats::SPAN_NAME),
             Self::ScanMetadataCompleted(_) => Err(ScanMetadataCompleted::SPAN_NAME),
             Self::JsonReadCompleted(_) => Err(JsonReadCompleted::SPAN_NAME),
             Self::ParquetReadCompleted(_) => Err(ParquetReadCompleted::SPAN_NAME),
             Self::StorageListCompleted(_)
             | Self::StorageReadCompleted(_)
             | Self::StorageCopyCompleted(_) => Err(STORAGE_SPAN),
+
+            // Failure events are built at span close, after any runtime records.
+            Self::LogSegmentLoadFailure(_) => Err(LogSegmentLoadStats::SPAN_NAME),
+            Self::ProtocolMetadataLoadFailure(_) => Err(ProtocolMetadataLoadStats::SPAN_NAME),
+            Self::SnapshotBuildFailure(_) => Err(SnapshotBuildStats::SPAN_NAME),
+            Self::DomainMetadataLoadFailure => Err(DomainMetadataLoadStats::SPAN_NAME),
+            Self::SetTransactionLoadFailure => Err(SetTransactionLoadStats::SPAN_NAME),
+            Self::CrcReadFailure => Err(CrcReadStats::SPAN_NAME),
         }
     }
 
     pub(crate) fn record_bool(&mut self, name: &str, value: bool) -> Result<(), &'static str> {
         match self {
             // Variants with bool fields set during span lifetime.
-            Self::LogSegmentLoaded(e) => e.record_bool(name, value),
-            Self::DomainMetadataLoaded(e) => e.record_bool(name, value),
-            Self::SetTransactionLoaded(e) => e.record_bool(name, value),
+            Self::LogSegmentLoadSuccess(e) => e.record_bool(name, value),
+            Self::DomainMetadataLoadSuccess(e) => e.record_bool(name, value),
+            Self::SetTransactionLoadSuccess(e) => e.record_bool(name, value),
 
             // No bool fields set during span lifetime — a runtime record() on these is a bug.
-            Self::ProtocolMetadataLoaded(_) => Err(ProtocolMetadataLoaded::SPAN_NAME),
-            Self::SnapshotCompleted(_) => Err(SnapshotCompleted::SPAN_NAME),
-            Self::SnapshotFailed(_) => Err(SnapshotCompleted::SPAN_NAME),
-            Self::CrcReadCompleted(_) => Err(CrcReadCompleted::SPAN_NAME),
+            Self::ProtocolMetadataLoadSuccess(_) => Err(ProtocolMetadataLoadStats::SPAN_NAME),
+            Self::SnapshotBuildSuccess(_) => Err(SnapshotBuildStats::SPAN_NAME),
+            Self::CrcReadSuccess(_) => Err(CrcReadStats::SPAN_NAME),
             Self::ScanMetadataCompleted(_) => Err(ScanMetadataCompleted::SPAN_NAME),
             Self::JsonReadCompleted(_) => Err(JsonReadCompleted::SPAN_NAME),
             Self::ParquetReadCompleted(_) => Err(ParquetReadCompleted::SPAN_NAME),
             Self::StorageListCompleted(_)
             | Self::StorageReadCompleted(_)
             | Self::StorageCopyCompleted(_) => Err(STORAGE_SPAN),
+
+            // Failure events are built at span close, after any runtime records.
+            Self::LogSegmentLoadFailure(_) => Err(LogSegmentLoadStats::SPAN_NAME),
+            Self::ProtocolMetadataLoadFailure(_) => Err(ProtocolMetadataLoadStats::SPAN_NAME),
+            Self::SnapshotBuildFailure(_) => Err(SnapshotBuildStats::SPAN_NAME),
+            Self::DomainMetadataLoadFailure => Err(DomainMetadataLoadStats::SPAN_NAME),
+            Self::SetTransactionLoadFailure => Err(SetTransactionLoadStats::SPAN_NAME),
+            Self::CrcReadFailure => Err(CrcReadStats::SPAN_NAME),
+        }
+    }
+
+    pub(crate) fn into_failure(self) -> Self {
+        match self {
+            Self::LogSegmentLoadSuccess(e) => Self::LogSegmentLoadFailure(LogSegmentLoadFailure {
+                operation_id: e.operation_id,
+            }),
+            Self::ProtocolMetadataLoadSuccess(e) => {
+                Self::ProtocolMetadataLoadFailure(ProtocolMetadataLoadFailure {
+                    operation_id: e.operation_id,
+                })
+            }
+            Self::SnapshotBuildSuccess(e) => Self::SnapshotBuildFailure(SnapshotBuildFailure {
+                operation_id: e.operation_id,
+            }),
+            Self::DomainMetadataLoadSuccess(_) => Self::DomainMetadataLoadFailure,
+            Self::SetTransactionLoadSuccess(_) => Self::SetTransactionLoadFailure,
+            Self::CrcReadSuccess(_) => Self::CrcReadFailure,
+            other => other,
         }
     }
 }
@@ -157,13 +201,18 @@ impl MetricEvent {
 impl fmt::Display for MetricEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::LogSegmentLoaded(e) => e.fmt(f),
-            Self::ProtocolMetadataLoaded(e) => e.fmt(f),
-            Self::SnapshotCompleted(e) => e.fmt(f),
-            Self::SnapshotFailed(e) => e.fmt(f),
-            Self::DomainMetadataLoaded(e) => e.fmt(f),
-            Self::SetTransactionLoaded(e) => e.fmt(f),
-            Self::CrcReadCompleted(e) => e.fmt(f),
+            Self::LogSegmentLoadSuccess(e) => e.fmt(f),
+            Self::LogSegmentLoadFailure(e) => e.fmt(f),
+            Self::ProtocolMetadataLoadSuccess(e) => e.fmt(f),
+            Self::ProtocolMetadataLoadFailure(e) => e.fmt(f),
+            Self::SnapshotBuildSuccess(e) => e.fmt(f),
+            Self::SnapshotBuildFailure(e) => e.fmt(f),
+            Self::DomainMetadataLoadSuccess(e) => e.fmt(f),
+            Self::DomainMetadataLoadFailure => f.write_str("DomainMetadataLoadFailure"),
+            Self::SetTransactionLoadSuccess(e) => e.fmt(f),
+            Self::SetTransactionLoadFailure => f.write_str("SetTransactionLoadFailure"),
+            Self::CrcReadSuccess(e) => e.fmt(f),
+            Self::CrcReadFailure => f.write_str("CrcReadFailure"),
             Self::JsonReadCompleted(e) => e.fmt(f),
             Self::ParquetReadCompleted(e) => e.fmt(f),
             Self::ScanMetadataCompleted(e) => e.fmt(f),
@@ -175,7 +224,7 @@ impl fmt::Display for MetricEvent {
 }
 
 // ====================================================================
-// LogSegmentLoaded
+// LogSegmentLoad
 // ====================================================================
 //
 // Canonical example for the per-event block pattern. Other events below follow the same
@@ -186,7 +235,7 @@ impl fmt::Display for MetricEvent {
 pub(crate) const LOG_SEGMENT_LOADED_SPAN: &str = "segment.for_snapshot";
 
 #[derive(Debug, Clone)]
-pub struct LogSegmentLoaded {
+pub struct LogSegmentLoadStats {
     // === Set on span creation ===
     pub operation_id: MetricId,
 
@@ -200,7 +249,7 @@ pub struct LogSegmentLoaded {
     pub duration: Duration,
 }
 
-impl LogSegmentLoaded {
+impl LogSegmentLoadStats {
     pub(crate) const SPAN_NAME: &'static str = LOG_SEGMENT_LOADED_SPAN;
 
     /// Construction-time channel. Extracts fields bound at span creation via
@@ -241,7 +290,7 @@ impl LogSegmentLoaded {
     }
 }
 
-impl fmt::Display for LogSegmentLoaded {
+impl fmt::Display for LogSegmentLoadStats {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self {
             operation_id,
@@ -253,21 +302,34 @@ impl fmt::Display for LogSegmentLoaded {
         } = self;
         write!(
             f,
-            "LogSegmentLoaded(id={operation_id}, duration={duration:?}, \
+            "LogSegmentLoadSuccess(id={operation_id}, duration={duration:?}, \
              commits={num_commit_files}, checkpoints={num_checkpoint_files}, \
              compactions={num_compaction_files}, has_latest_crc={has_latest_crc_file})"
         )
     }
 }
 
+/// Log segment load failed. Emitted in place of [`LogSegmentLoadStats`] when the
+/// `segment.for_snapshot` span returns `Err`; carries the same `operation_id`.
+#[derive(Debug, Clone)]
+pub struct LogSegmentLoadFailure {
+    pub operation_id: MetricId,
+}
+
+impl fmt::Display for LogSegmentLoadFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "LogSegmentLoadFailure(id={})", self.operation_id)
+    }
+}
+
 // ====================================================================
-// ProtocolMetadataLoaded
+// ProtocolMetadataLoad
 // ====================================================================
 
 pub(crate) const PROTOCOL_METADATA_LOADED_SPAN: &str = "segment.read_metadata";
 
 #[derive(Debug, Clone)]
-pub struct ProtocolMetadataLoaded {
+pub struct ProtocolMetadataLoadStats {
     // === Set on span creation ===
     pub operation_id: MetricId,
 
@@ -275,7 +337,7 @@ pub struct ProtocolMetadataLoaded {
     pub duration: Duration,
 }
 
-impl ProtocolMetadataLoaded {
+impl ProtocolMetadataLoadStats {
     pub(crate) const SPAN_NAME: &'static str = PROTOCOL_METADATA_LOADED_SPAN;
 
     pub(crate) fn from_attrs(attrs: &Attributes<'_>) -> Self {
@@ -290,7 +352,7 @@ impl ProtocolMetadataLoaded {
     }
 }
 
-impl fmt::Display for ProtocolMetadataLoaded {
+impl fmt::Display for ProtocolMetadataLoadStats {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self {
             operation_id,
@@ -298,19 +360,32 @@ impl fmt::Display for ProtocolMetadataLoaded {
         } = self;
         write!(
             f,
-            "ProtocolMetadataLoaded(id={operation_id}, duration={duration:?})"
+            "ProtocolMetadataLoadSuccess(id={operation_id}, duration={duration:?})"
         )
     }
 }
 
+/// Protocol/metadata load failed. Emitted in place of [`ProtocolMetadataLoadStats`] when the
+/// `segment.read_metadata` span returns `Err`; carries the same `operation_id`.
+#[derive(Debug, Clone)]
+pub struct ProtocolMetadataLoadFailure {
+    pub operation_id: MetricId,
+}
+
+impl fmt::Display for ProtocolMetadataLoadFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ProtocolMetadataLoadFailure(id={})", self.operation_id)
+    }
+}
+
 // ====================================================================
-// SnapshotCompleted
+// SnapshotBuild
 // ====================================================================
 
 pub(crate) const SNAPSHOT_COMPLETED_SPAN: &str = "snap.build";
 
 #[derive(Debug, Clone)]
-pub struct SnapshotCompleted {
+pub struct SnapshotBuildStats {
     // === Set on span creation ===
     pub operation_id: MetricId,
 
@@ -321,7 +396,7 @@ pub struct SnapshotCompleted {
     pub duration: Duration,
 }
 
-impl SnapshotCompleted {
+impl SnapshotBuildStats {
     pub(crate) const SPAN_NAME: &'static str = SNAPSHOT_COMPLETED_SPAN;
 
     pub(crate) fn from_attrs(attrs: &Attributes<'_>) -> Self {
@@ -343,17 +418,9 @@ impl SnapshotCompleted {
     pub(crate) fn set_duration(&mut self, d: Duration) {
         self.duration = d;
     }
-
-    /// Convert to a [`SnapshotFailed`] when the span fires an `error` field.
-    pub(crate) fn into_failed(self) -> SnapshotFailed {
-        SnapshotFailed {
-            operation_id: self.operation_id,
-            duration: self.duration,
-        }
-    }
 }
 
-impl fmt::Display for SnapshotCompleted {
+impl fmt::Display for SnapshotBuildStats {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self {
             operation_id,
@@ -362,47 +429,30 @@ impl fmt::Display for SnapshotCompleted {
         } = self;
         write!(
             f,
-            "SnapshotCompleted(id={operation_id}, version={version}, duration={duration:?})"
+            "SnapshotBuildSuccess(id={operation_id}, version={version}, duration={duration:?})"
         )
     }
 }
 
 // ====================================================================
-// SnapshotFailed
+// SnapshotBuildFailure
 // ====================================================================
 
-/// Snapshot creation failed. Emitted in place of [`SnapshotCompleted`] when the `snap.build`
+/// Snapshot creation failed. Emitted in place of [`SnapshotBuildStats`] when the `snap.build`
 /// span returns `Err`; carries the same `operation_id`.
 #[derive(Debug, Clone)]
-pub struct SnapshotFailed {
-    // === Carried over from `SnapshotCompleted` when the span errors ===
+pub struct SnapshotBuildFailure {
     pub operation_id: MetricId,
-
-    // === Set on span close ===
-    pub duration: Duration,
 }
 
-impl SnapshotFailed {
-    pub(crate) fn set_duration(&mut self, d: Duration) {
-        self.duration = d;
-    }
-}
-
-impl fmt::Display for SnapshotFailed {
+impl fmt::Display for SnapshotBuildFailure {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let Self {
-            operation_id,
-            duration,
-        } = self;
-        write!(
-            f,
-            "SnapshotFailed(id={operation_id}, duration={duration:?})"
-        )
+        write!(f, "SnapshotBuildFailure(id={})", self.operation_id)
     }
 }
 
 // ====================================================================
-// DomainMetadataLoaded
+// DomainMetadataLoad
 // ====================================================================
 
 pub(crate) const DOMAIN_METADATA_LOADED_SPAN: &str = "snap.get_domain_metadata";
@@ -411,7 +461,7 @@ pub(crate) const DOMAIN_METADATA_LOADED_SPAN: &str = "snap.get_domain_metadata";
 /// from a log replay. Covers connector-issued loads of user domains and kernel-internal loads of
 /// system (`delta.*`) domains such as clustering or row tracking.
 #[derive(Debug, Clone)]
-pub struct DomainMetadataLoaded {
+pub struct DomainMetadataLoadStats {
     // === Set during span lifetime ===
     pub from_cache: bool,
     pub num_domains_returned: u64,
@@ -420,7 +470,7 @@ pub struct DomainMetadataLoaded {
     pub duration: Duration,
 }
 
-impl DomainMetadataLoaded {
+impl DomainMetadataLoadStats {
     pub(crate) const SPAN_NAME: &'static str = DOMAIN_METADATA_LOADED_SPAN;
 
     pub(crate) fn from_attrs(_attrs: &Attributes<'_>) -> Self {
@@ -452,7 +502,7 @@ impl DomainMetadataLoaded {
     }
 }
 
-impl fmt::Display for DomainMetadataLoaded {
+impl fmt::Display for DomainMetadataLoadStats {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self {
             from_cache,
@@ -461,14 +511,14 @@ impl fmt::Display for DomainMetadataLoaded {
         } = self;
         write!(
             f,
-            "DomainMetadataLoaded(duration={duration:?}, from_cache={from_cache}, \
+            "DomainMetadataLoadSuccess(duration={duration:?}, from_cache={from_cache}, \
              num_domains_returned={num_domains_returned})"
         )
     }
 }
 
 // ====================================================================
-// SetTransactionLoaded
+// SetTransactionLoad
 // ====================================================================
 
 pub(crate) const SET_TRANSACTION_LOADED_SPAN: &str = "snap.get_app_id_version";
@@ -477,7 +527,7 @@ pub(crate) const SET_TRANSACTION_LOADED_SPAN: &str = "snap.get_app_id_version";
 /// (`from_cache`) or from a log replay. `found` is true when the app id has a committed
 /// transaction version, false when none exists or the existing one is expired.
 #[derive(Debug, Clone)]
-pub struct SetTransactionLoaded {
+pub struct SetTransactionLoadStats {
     // === Set during span lifetime ===
     pub from_cache: bool,
     pub found: bool,
@@ -486,7 +536,7 @@ pub struct SetTransactionLoaded {
     pub duration: Duration,
 }
 
-impl SetTransactionLoaded {
+impl SetTransactionLoadStats {
     pub(crate) const SPAN_NAME: &'static str = SET_TRANSACTION_LOADED_SPAN;
 
     pub(crate) fn from_attrs(_attrs: &Attributes<'_>) -> Self {
@@ -511,7 +561,7 @@ impl SetTransactionLoaded {
     }
 }
 
-impl fmt::Display for SetTransactionLoaded {
+impl fmt::Display for SetTransactionLoadStats {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self {
             from_cache,
@@ -520,21 +570,20 @@ impl fmt::Display for SetTransactionLoaded {
         } = self;
         write!(
             f,
-            "SetTransactionLoaded(duration={duration:?}, from_cache={from_cache}, found={found})"
+            "SetTransactionLoadSuccess(duration={duration:?}, from_cache={from_cache}, found={found})"
         )
     }
 }
 
 // ====================================================================
-// CrcReadCompleted
+// CrcRead
 // ====================================================================
 
 pub(crate) const CRC_READ_COMPLETED_SPAN: &str = "crc_read_completed";
 
-/// Emitted even when JSON parsing fails after a successful storage read.
-/// `bytes_read` is the raw byte count from storage (zero if the storage read itself failed).
+/// A CRC file was read and parsed successfully. `bytes_read` is the raw byte count from storage.
 #[derive(Debug, Clone)]
-pub struct CrcReadCompleted {
+pub struct CrcReadStats {
     // === Set during span lifetime ===
     pub bytes_read: u64,
 
@@ -542,7 +591,7 @@ pub struct CrcReadCompleted {
     pub duration: Duration,
 }
 
-impl CrcReadCompleted {
+impl CrcReadStats {
     pub(crate) const SPAN_NAME: &'static str = CRC_READ_COMPLETED_SPAN;
 
     pub(crate) fn from_attrs(_attrs: &Attributes<'_>) -> Self {
@@ -565,7 +614,7 @@ impl CrcReadCompleted {
     }
 }
 
-impl fmt::Display for CrcReadCompleted {
+impl fmt::Display for CrcReadStats {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self {
             duration,
@@ -573,7 +622,7 @@ impl fmt::Display for CrcReadCompleted {
         } = self;
         write!(
             f,
-            "CrcReadCompleted(duration={duration:?}, bytes={bytes_read})"
+            "CrcReadSuccess(duration={duration:?}, bytes={bytes_read})"
         )
     }
 }

--- a/kernel/src/metrics/mod.rs
+++ b/kernel/src/metrics/mod.rs
@@ -19,14 +19,14 @@
 //! impl MetricsReporter for LoggingReporter {
 //!     fn report(&self, event: MetricEvent) {
 //!         match event {
-//!             MetricEvent::LogSegmentLoaded(e) => {
+//!             MetricEvent::LogSegmentLoadSuccess(e) => {
 //!                 println!("Log segment loaded in {:?}: {} commits", e.duration, e.num_commit_files);
 //!             }
-//!             MetricEvent::SnapshotCompleted(e) => {
+//!             MetricEvent::SnapshotBuildSuccess(e) => {
 //!                 println!("Snapshot completed: v{} in {:?}", e.version, e.duration);
 //!             }
-//!             MetricEvent::SnapshotFailed(e) => {
-//!                 println!("Snapshot failed: {} after {:?}", e.operation_id, e.duration);
+//!             MetricEvent::SnapshotBuildFailure(e) => {
+//!                 println!("Snapshot failed: {}", e.operation_id);
 //!             }
 //!             _ => {}
 //!         }
@@ -80,11 +80,11 @@ mod streaming_metrics_iterator;
 use std::sync::Arc;
 
 pub use events::{
-    emit_json_read_completed, emit_parquet_read_completed, CrcReadCompleted, DomainMetadataLoaded,
-    JsonReadCompleted, LogSegmentLoaded, MetricEvent, MetricId, ParquetReadCompleted,
-    ProtocolMetadataLoaded, ScanMetadataCompleted, ScanType, SetTransactionLoaded,
-    SnapshotCompleted, SnapshotFailed, StorageCopyCompleted, StorageListCompleted,
-    StorageReadCompleted,
+    emit_json_read_completed, emit_parquet_read_completed, CrcReadStats, DomainMetadataLoadStats,
+    JsonReadCompleted, LogSegmentLoadFailure, LogSegmentLoadStats, MetricEvent, MetricId,
+    ParquetReadCompleted, ProtocolMetadataLoadFailure, ProtocolMetadataLoadStats,
+    ScanMetadataCompleted, ScanType, SetTransactionLoadStats, SnapshotBuildFailure,
+    SnapshotBuildStats, StorageCopyCompleted, StorageListCompleted, StorageReadCompleted,
 };
 pub use metered_engine::MeteredDeltaEngine;
 pub use metered_storage::MeteredStorageHandler;

--- a/kernel/src/metrics/mod.rs
+++ b/kernel/src/metrics/mod.rs
@@ -80,11 +80,12 @@ mod streaming_metrics_iterator;
 use std::sync::Arc;
 
 pub use events::{
-    emit_json_read_completed, emit_parquet_read_completed, CrcReadStats, DomainMetadataLoadStats,
-    JsonReadCompleted, LogSegmentLoadFailure, LogSegmentLoadStats, MetricEvent, MetricId,
-    ParquetReadCompleted, ProtocolMetadataLoadFailure, ProtocolMetadataLoadStats,
-    ScanMetadataCompleted, ScanType, SetTransactionLoadStats, SnapshotBuildFailure,
-    SnapshotBuildStats, StorageCopyCompleted, StorageListCompleted, StorageReadCompleted,
+    emit_json_read_completed, emit_parquet_read_completed, CrcReadSuccess,
+    DomainMetadataLoadSuccess, JsonReadCompleted, LogSegmentLoadFailure, LogSegmentLoadSuccess,
+    MetricEvent, MetricId, ParquetReadCompleted, ProtocolMetadataLoadFailure,
+    ProtocolMetadataLoadSuccess, ScanMetadataCompleted, ScanType, SetTransactionLoadSuccess,
+    SnapshotBuildFailure, SnapshotBuildSuccess, StorageCopyCompleted, StorageListCompleted,
+    StorageReadCompleted,
 };
 pub use metered_engine::MeteredDeltaEngine;
 pub use metered_storage::MeteredStorageHandler;

--- a/kernel/src/metrics/reporter.rs
+++ b/kernel/src/metrics/reporter.rs
@@ -10,9 +10,9 @@ use tracing_subscriber::layer::Context;
 use tracing_subscriber::Layer;
 
 use super::events::{
-    storage_metric_from_attrs, CrcReadStats, DomainMetadataLoadStats, JsonReadCompleted,
-    LogSegmentLoadStats, MetricEvent, ParquetReadCompleted, ProtocolMetadataLoadStats,
-    ScanMetadataCompleted, SetTransactionLoadStats, SnapshotBuildStats, STORAGE_SPAN,
+    storage_metric_from_attrs, CrcReadSuccess, DomainMetadataLoadSuccess, JsonReadCompleted,
+    LogSegmentLoadSuccess, MetricEvent, ParquetReadCompleted, ProtocolMetadataLoadSuccess,
+    ScanMetadataCompleted, SetTransactionLoadSuccess, SnapshotBuildSuccess, STORAGE_SPAN,
 };
 
 // ====================================================================
@@ -105,24 +105,26 @@ where
             return;
         };
         let event = match metadata.name() {
-            LogSegmentLoadStats::SPAN_NAME => Some(MetricEvent::LogSegmentLoadSuccess(
-                LogSegmentLoadStats::from_attrs(attrs),
+            LogSegmentLoadSuccess::SPAN_NAME => Some(MetricEvent::LogSegmentLoadSuccess(
+                LogSegmentLoadSuccess::from_attrs(attrs),
             )),
-            ProtocolMetadataLoadStats::SPAN_NAME => Some(MetricEvent::ProtocolMetadataLoadSuccess(
-                ProtocolMetadataLoadStats::from_attrs(attrs),
-            )),
-            SnapshotBuildStats::SPAN_NAME => Some(MetricEvent::SnapshotBuildSuccess(
-                SnapshotBuildStats::from_attrs(attrs),
-            )),
-            DomainMetadataLoadStats::SPAN_NAME => Some(MetricEvent::DomainMetadataLoadSuccess(
-                DomainMetadataLoadStats::from_attrs(attrs),
-            )),
-            SetTransactionLoadStats::SPAN_NAME => Some(MetricEvent::SetTransactionLoadSuccess(
-                SetTransactionLoadStats::from_attrs(attrs),
-            )),
-            CrcReadStats::SPAN_NAME => {
-                Some(MetricEvent::CrcReadSuccess(CrcReadStats::from_attrs(attrs)))
+            ProtocolMetadataLoadSuccess::SPAN_NAME => {
+                Some(MetricEvent::ProtocolMetadataLoadSuccess(
+                    ProtocolMetadataLoadSuccess::from_attrs(attrs),
+                ))
             }
+            SnapshotBuildSuccess::SPAN_NAME => Some(MetricEvent::SnapshotBuildSuccess(
+                SnapshotBuildSuccess::from_attrs(attrs),
+            )),
+            DomainMetadataLoadSuccess::SPAN_NAME => Some(MetricEvent::DomainMetadataLoadSuccess(
+                DomainMetadataLoadSuccess::from_attrs(attrs),
+            )),
+            SetTransactionLoadSuccess::SPAN_NAME => Some(MetricEvent::SetTransactionLoadSuccess(
+                SetTransactionLoadSuccess::from_attrs(attrs),
+            )),
+            CrcReadSuccess::SPAN_NAME => Some(MetricEvent::CrcReadSuccess(
+                CrcReadSuccess::from_attrs(attrs),
+            )),
             JsonReadCompleted::SPAN_NAME => Some(MetricEvent::JsonReadCompleted(
                 JsonReadCompleted::from_attrs(attrs),
             )),

--- a/kernel/src/metrics/reporter.rs
+++ b/kernel/src/metrics/reporter.rs
@@ -10,9 +10,9 @@ use tracing_subscriber::layer::Context;
 use tracing_subscriber::Layer;
 
 use super::events::{
-    storage_metric_from_attrs, CrcReadCompleted, DomainMetadataLoaded, JsonReadCompleted,
-    LogSegmentLoaded, MetricEvent, ParquetReadCompleted, ProtocolMetadataLoaded,
-    ScanMetadataCompleted, SetTransactionLoaded, SnapshotCompleted, STORAGE_SPAN,
+    storage_metric_from_attrs, CrcReadStats, DomainMetadataLoadStats, JsonReadCompleted,
+    LogSegmentLoadStats, MetricEvent, ParquetReadCompleted, ProtocolMetadataLoadStats,
+    ScanMetadataCompleted, SetTransactionLoadStats, SnapshotBuildStats, STORAGE_SPAN,
 };
 
 // ====================================================================
@@ -105,24 +105,24 @@ where
             return;
         };
         let event = match metadata.name() {
-            LogSegmentLoaded::SPAN_NAME => Some(MetricEvent::LogSegmentLoaded(
-                LogSegmentLoaded::from_attrs(attrs),
+            LogSegmentLoadStats::SPAN_NAME => Some(MetricEvent::LogSegmentLoadSuccess(
+                LogSegmentLoadStats::from_attrs(attrs),
             )),
-            ProtocolMetadataLoaded::SPAN_NAME => Some(MetricEvent::ProtocolMetadataLoaded(
-                ProtocolMetadataLoaded::from_attrs(attrs),
+            ProtocolMetadataLoadStats::SPAN_NAME => Some(MetricEvent::ProtocolMetadataLoadSuccess(
+                ProtocolMetadataLoadStats::from_attrs(attrs),
             )),
-            SnapshotCompleted::SPAN_NAME => Some(MetricEvent::SnapshotCompleted(
-                SnapshotCompleted::from_attrs(attrs),
+            SnapshotBuildStats::SPAN_NAME => Some(MetricEvent::SnapshotBuildSuccess(
+                SnapshotBuildStats::from_attrs(attrs),
             )),
-            DomainMetadataLoaded::SPAN_NAME => Some(MetricEvent::DomainMetadataLoaded(
-                DomainMetadataLoaded::from_attrs(attrs),
+            DomainMetadataLoadStats::SPAN_NAME => Some(MetricEvent::DomainMetadataLoadSuccess(
+                DomainMetadataLoadStats::from_attrs(attrs),
             )),
-            SetTransactionLoaded::SPAN_NAME => Some(MetricEvent::SetTransactionLoaded(
-                SetTransactionLoaded::from_attrs(attrs),
+            SetTransactionLoadStats::SPAN_NAME => Some(MetricEvent::SetTransactionLoadSuccess(
+                SetTransactionLoadStats::from_attrs(attrs),
             )),
-            CrcReadCompleted::SPAN_NAME => Some(MetricEvent::CrcReadCompleted(
-                CrcReadCompleted::from_attrs(attrs),
-            )),
+            CrcReadStats::SPAN_NAME => {
+                Some(MetricEvent::CrcReadSuccess(CrcReadStats::from_attrs(attrs)))
+            }
             JsonReadCompleted::SPAN_NAME => Some(MetricEvent::JsonReadCompleted(
                 JsonReadCompleted::from_attrs(attrs),
             )),
@@ -145,7 +145,7 @@ where
     // RUNTIME CHANNEL. Both on_event and on_record route Span::current().record(...) updates
     // (and info!() events within a span) through EventVisitor -> MetricEvent::record_u64 /
     // record_bool. The visitor's record_debug also handles `#[instrument(err)]`'s `error` field,
-    // flipping SnapshotCompleted into SnapshotFailed.
+    // flipping a success event into its failure counterpart.
     fn on_event(&self, event: &tracing::Event<'_>, ctx: Context<'_, S>) {
         Self::drain_into_visitor(ctx.event_span(event), |v| event.record(v));
     }
@@ -246,18 +246,7 @@ impl Visit for EventVisitor {
             "return" => {} // default to the success case
             "error" => {
                 // `#[instrument(err)]` records `error` when the wrapped function returns Err.
-                self.event = match self.event.take() {
-                    // Flip SnapshotCompleted into SnapshotFailed.
-                    Some(MetricEvent::SnapshotCompleted(snap)) => {
-                        Some(MetricEvent::SnapshotFailed(snap.into_failed()))
-                    }
-                    // A "Loaded" event represents a successful load. Drop it on error so a
-                    // failed load is not reported as an empty successful one.
-                    Some(
-                        MetricEvent::DomainMetadataLoaded(_) | MetricEvent::SetTransactionLoaded(_),
-                    ) => None,
-                    other => other,
-                };
+                self.event = self.event.take().map(MetricEvent::into_failure);
             }
             _ => {}
         }

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -505,6 +505,60 @@ mod tests {
     }
 
     #[test_log::test(tokio::test)]
+    async fn log_segment_load_failure_emits_metric_on_empty_log(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (engine, _store, table_root) = setup_test();
+        let (reporter, _guard) = measuring_reporter();
+
+        assert!(SnapshotBuilder::new_for(table_root)
+            .build(engine.as_ref())
+            .is_err());
+
+        assert!(
+            reporter
+                .events()
+                .iter()
+                .any(|e| matches!(e, MetricEvent::LogSegmentLoadFailure(_))),
+            "expected LogSegmentLoadFailure when the log has no commits"
+        );
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn protocol_metadata_load_failure_emits_metric_when_actions_absent(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (engine, store, table_root) = setup_test();
+        // A commit with no protocol/metadata: the segment lists fine, then the read fails.
+        add_commit(
+            &table_root,
+            store.as_ref(),
+            0,
+            actions_to_string(vec![TestAction::Add("part-00000-test.parquet".into())]),
+        )
+        .await?;
+        let (reporter, _guard) = measuring_reporter();
+
+        assert!(SnapshotBuilder::new_for(table_root)
+            .build(engine.as_ref())
+            .is_err());
+
+        let events = reporter.events();
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, MetricEvent::ProtocolMetadataLoadFailure(_))),
+            "expected ProtocolMetadataLoadFailure when protocol/metadata are absent"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, MetricEvent::ProtocolMetadataLoadSuccess(_))),
+            "must not emit ProtocolMetadataLoadSuccess when the load fails"
+        );
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
     async fn snapshot_update_from_existing_emits_metric() -> Result<(), Box<dyn std::error::Error>>
     {
         let (engine, store, table_root) = setup_test();

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -122,14 +122,15 @@ impl SnapshotBuilder {
     /// returning a reference to an existing snapshot if the request to build a new snapshot
     /// matches the version of an existing snapshot.
     ///
-    /// Reports metrics: [`MetricEvent::SnapshotCompleted`] or [`MetricEvent::SnapshotFailed`].
+    /// Reports metrics: [`MetricEvent::SnapshotBuildSuccess`] or
+    /// [`MetricEvent::SnapshotBuildFailure`].
     ///
     /// # Parameters
     ///
     /// - `engine`: Implementation of [`Engine`] apis.
     ///
-    /// [`MetricEvent::SnapshotCompleted`]: crate::metrics::MetricEvent::SnapshotCompleted
-    /// [`MetricEvent::SnapshotFailed`]: crate::metrics::MetricEvent::SnapshotFailed
+    /// [`MetricEvent::SnapshotBuildSuccess`]: crate::metrics::MetricEvent::SnapshotBuildSuccess
+    /// [`MetricEvent::SnapshotBuildFailure`]: crate::metrics::MetricEvent::SnapshotBuildFailure
     #[instrument(
         name = SNAPSHOT_COMPLETED_SPAN,
         skip_all,
@@ -157,7 +158,7 @@ impl SnapshotBuilder {
         let log_tail: Vec<_> = log_tail.into_iter().map(Into::into).collect();
         let operation_id = MetricId::new();
         // TODO(#2605): this late `record` is silently dropped by the metrics layer, so every
-        //              `SnapshotCompleted` event carries a nil operation_id. Bind eagerly via a
+        //              `SnapshotBuildSuccess` event carries a nil operation_id. Bind eagerly via a
         //              `build_inner(self, engine, operation_id)` helper instead.
         tracing::Span::current().record("operation_id", tracing::field::display(operation_id));
 
@@ -491,14 +492,14 @@ mod tests {
         assert!(
             events
                 .iter()
-                .any(|e| matches!(e, MetricEvent::SnapshotFailed(_))),
-            "expected SnapshotFailed event on build failure"
+                .any(|e| matches!(e, MetricEvent::SnapshotBuildFailure(_))),
+            "expected SnapshotBuildFailure event on build failure"
         );
         assert!(
             !events
                 .iter()
-                .any(|e| matches!(e, MetricEvent::SnapshotCompleted(_))),
-            "should not emit SnapshotCompleted on failure"
+                .any(|e| matches!(e, MetricEvent::SnapshotBuildSuccess(_))),
+            "should not emit SnapshotBuildSuccess on failure"
         );
         Ok(())
     }
@@ -524,10 +525,10 @@ mod tests {
         let (version, duration) = events
             .iter()
             .find_map(|e| match e {
-                MetricEvent::SnapshotCompleted(s) => Some((s.version, s.duration)),
+                MetricEvent::SnapshotBuildSuccess(s) => Some((s.version, s.duration)),
                 _ => None,
             })
-            .expect("expected SnapshotCompleted event");
+            .expect("expected SnapshotBuildSuccess event");
         assert_eq!(version, 1, "version should match the updated snapshot");
         assert!(duration > Duration::ZERO, "duration should be non-zero");
         Ok(())
@@ -557,14 +558,14 @@ mod tests {
         assert!(
             events
                 .iter()
-                .any(|e| matches!(e, MetricEvent::SnapshotFailed(_))),
-            "expected SnapshotFailed when version update goes backwards"
+                .any(|e| matches!(e, MetricEvent::SnapshotBuildFailure(_))),
+            "expected SnapshotBuildFailure when version update goes backwards"
         );
         assert!(
             !events
                 .iter()
-                .any(|e| matches!(e, MetricEvent::SnapshotCompleted(_))),
-            "should not emit SnapshotCompleted when version update fails"
+                .any(|e| matches!(e, MetricEvent::SnapshotBuildSuccess(_))),
+            "should not emit SnapshotBuildSuccess when version update fails"
         );
         Ok(())
     }
@@ -582,17 +583,17 @@ mod tests {
         let snap_duration = events
             .iter()
             .find_map(|e| match e {
-                MetricEvent::SnapshotCompleted(s) => Some(s.duration),
+                MetricEvent::SnapshotBuildSuccess(s) => Some(s.duration),
                 _ => None,
             })
-            .expect("expected SnapshotCompleted event");
+            .expect("expected SnapshotBuildSuccess event");
         let segment_duration = events
             .iter()
             .find_map(|e| match e {
-                MetricEvent::LogSegmentLoaded(s) => Some(s.duration),
+                MetricEvent::LogSegmentLoadSuccess(s) => Some(s.duration),
                 _ => None,
             })
-            .expect("expected LogSegmentLoaded event");
+            .expect("expected LogSegmentLoadSuccess event");
 
         assert!(
             snap_duration > Duration::ZERO,
@@ -600,7 +601,7 @@ mod tests {
         );
         assert!(
             snap_duration >= segment_duration,
-            "SnapshotCompleted.duration ({snap_duration:?}) should be >= LogSegmentLoaded.duration ({segment_duration:?})"
+            "SnapshotBuildSuccess.duration ({snap_duration:?}) should be >= LogSegmentLoadSuccess.duration ({segment_duration:?})"
         );
         Ok(())
     }

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -377,7 +377,7 @@ impl Snapshot {
     ///
     /// Uses the CRC fast path when available, otherwise falls back to log replay.
     ///
-    /// Reports metrics: `SetTransactionLoaded`.
+    /// Reports metrics: `SetTransactionLoadSuccess` or `SetTransactionLoadFailure`.
     // TODO: add a get_app_id_versions to fetch all at once using SetTransactionScanner::get_all
     #[instrument(
         parent = &self.span,
@@ -527,7 +527,7 @@ impl Snapshot {
     /// requested domain is in a Partial cache, also answer from the cache; else full log
     /// replay. `domains == None` means load all.
     ///
-    /// Reports metrics: `DomainMetadataLoaded`.
+    /// Reports metrics: `DomainMetadataLoadSuccess` or `DomainMetadataLoadFailure`.
     #[instrument(
         parent = &self.span,
         name = DOMAIN_METADATA_LOADED_SPAN,

--- a/kernel/tests/integration/metrics/snapshot_load.rs
+++ b/kernel/tests/integration/metrics/snapshot_load.rs
@@ -513,7 +513,7 @@ async fn get_domain_metadata_load_emits_loaded_metric(#[case] with_crc: bool) ->
 }
 
 #[tokio::test]
-async fn failed_loads_emit_no_metric() -> DeltaResult<()> {
+async fn failed_loads_emit_failure_metric() -> DeltaResult<()> {
     let (table_url, _temp_dir) = setup_table_with_dms_and_set_txns(false).await?;
 
     let (engine, reporter, _guard) = measuring_engine(Arc::new(LocalFileSystem::new()));
@@ -528,6 +528,8 @@ async fn failed_loads_emit_no_metric() -> DeltaResult<()> {
     assert!(snap.get_app_id_version("my-app", &engine).is_err());
     assert_eq!(reporter.domain_metadata_loads.get(), 0);
     assert_eq!(reporter.set_transaction_loads.get(), 0);
+    assert_eq!(reporter.domain_metadata_load_failures.get(), 1);
+    assert_eq!(reporter.set_transaction_load_failures.get(), 1);
 
     Ok(())
 }

--- a/test-utils/src/counting_reporter.rs
+++ b/test-utils/src/counting_reporter.rs
@@ -345,9 +345,9 @@ mod tests {
     use std::time::Duration;
 
     use delta_kernel::metrics::{
-        CrcReadStats, DomainMetadataLoadStats, LogSegmentLoadStats, MetricId,
-        ProtocolMetadataLoadStats, SetTransactionLoadStats, SnapshotBuildFailure,
-        SnapshotBuildStats, StorageCopyCompleted, StorageListCompleted, StorageReadCompleted,
+        CrcReadSuccess, DomainMetadataLoadSuccess, LogSegmentLoadSuccess, MetricId,
+        ProtocolMetadataLoadSuccess, SetTransactionLoadSuccess, SnapshotBuildFailure,
+        SnapshotBuildSuccess, StorageCopyCompleted, StorageListCompleted, StorageReadCompleted,
     };
 
     use super::*;
@@ -396,7 +396,7 @@ mod tests {
     #[test]
     fn report_snapshot_completed_increments_snapshot_counter() {
         let reporter = CountingReporter::new();
-        reporter.report(MetricEvent::SnapshotBuildSuccess(SnapshotBuildStats {
+        reporter.report(MetricEvent::SnapshotBuildSuccess(SnapshotBuildSuccess {
             operation_id: MetricId::new(),
             version: 0,
             duration: dur(),
@@ -407,7 +407,7 @@ mod tests {
     #[test]
     fn report_log_segment_loaded_increments_log_replay_counters() {
         let reporter = CountingReporter::new();
-        reporter.report(MetricEvent::LogSegmentLoadSuccess(LogSegmentLoadStats {
+        reporter.report(MetricEvent::LogSegmentLoadSuccess(LogSegmentLoadSuccess {
             operation_id: MetricId::new(),
             duration: dur(),
             num_commit_files: 7,
@@ -425,7 +425,7 @@ mod tests {
     #[test]
     fn report_log_segment_loaded_without_crc_does_not_increment_crc_counter() {
         let reporter = CountingReporter::new();
-        reporter.report(MetricEvent::LogSegmentLoadSuccess(LogSegmentLoadStats {
+        reporter.report(MetricEvent::LogSegmentLoadSuccess(LogSegmentLoadSuccess {
             operation_id: MetricId::new(),
             duration: dur(),
             num_commit_files: 3,
@@ -440,11 +440,11 @@ mod tests {
     #[test]
     fn report_crc_read_completed_increments_crc_counters() {
         let reporter = CountingReporter::new();
-        reporter.report(MetricEvent::CrcReadSuccess(CrcReadStats {
+        reporter.report(MetricEvent::CrcReadSuccess(CrcReadSuccess {
             duration: dur(),
             bytes_read: 512,
         }));
-        reporter.report(MetricEvent::CrcReadSuccess(CrcReadStats {
+        reporter.report(MetricEvent::CrcReadSuccess(CrcReadSuccess {
             duration: dur(),
             bytes_read: 256,
         }));
@@ -456,14 +456,14 @@ mod tests {
     fn report_domain_metadata_loaded_increments_domain_metadata_counters() {
         let reporter = CountingReporter::new();
         reporter.report(MetricEvent::DomainMetadataLoadSuccess(
-            DomainMetadataLoadStats {
+            DomainMetadataLoadSuccess {
                 from_cache: true,
                 num_domains_returned: 3,
                 duration: dur(),
             },
         ));
         reporter.report(MetricEvent::DomainMetadataLoadSuccess(
-            DomainMetadataLoadStats {
+            DomainMetadataLoadSuccess {
                 from_cache: false,
                 num_domains_returned: 1,
                 duration: dur(),
@@ -478,14 +478,14 @@ mod tests {
     fn report_set_transaction_loaded_increments_set_transaction_counters() {
         let reporter = CountingReporter::new();
         reporter.report(MetricEvent::SetTransactionLoadSuccess(
-            SetTransactionLoadStats {
+            SetTransactionLoadSuccess {
                 from_cache: true,
                 found: true,
                 duration: dur(),
             },
         ));
         reporter.report(MetricEvent::SetTransactionLoadSuccess(
-            SetTransactionLoadStats {
+            SetTransactionLoadSuccess {
                 from_cache: false,
                 found: false,
                 duration: dur(),
@@ -500,7 +500,7 @@ mod tests {
     fn report_untracked_events_does_not_panic() {
         let reporter = CountingReporter::new();
         reporter.report(MetricEvent::ProtocolMetadataLoadSuccess(
-            ProtocolMetadataLoadStats {
+            ProtocolMetadataLoadSuccess {
                 operation_id: MetricId::new(),
                 duration: dur(),
             },
@@ -526,7 +526,7 @@ mod tests {
         reporter.report(MetricEvent::StorageCopyCompleted(StorageCopyCompleted {
             duration: dur(),
         }));
-        reporter.report(MetricEvent::LogSegmentLoadSuccess(LogSegmentLoadStats {
+        reporter.report(MetricEvent::LogSegmentLoadSuccess(LogSegmentLoadSuccess {
             operation_id: MetricId::new(),
             duration: dur(),
             num_commit_files: 7,
@@ -534,19 +534,19 @@ mod tests {
             num_compaction_files: 1,
             has_latest_crc_file: true,
         }));
-        reporter.report(MetricEvent::CrcReadSuccess(CrcReadStats {
+        reporter.report(MetricEvent::CrcReadSuccess(CrcReadSuccess {
             duration: dur(),
             bytes_read: 512,
         }));
         reporter.report(MetricEvent::DomainMetadataLoadSuccess(
-            DomainMetadataLoadStats {
+            DomainMetadataLoadSuccess {
                 from_cache: true,
                 num_domains_returned: 2,
                 duration: dur(),
             },
         ));
         reporter.report(MetricEvent::SetTransactionLoadSuccess(
-            SetTransactionLoadStats {
+            SetTransactionLoadSuccess {
                 from_cache: true,
                 found: true,
                 duration: dur(),

--- a/test-utils/src/counting_reporter.rs
+++ b/test-utils/src/counting_reporter.rs
@@ -172,18 +172,20 @@ pub struct CountingReporter {
     pub latest_crc_files_found: RelaxedCounter,
 
     // CRC reader IO counters
-    /// Number of CRC read calls (one per [`MetricEvent::CrcReadCompleted`]).
+    /// Number of CRC read calls (one per [`MetricEvent::CrcReadSuccess`]).
     pub crc_read_calls: RelaxedCounter,
     /// Total number of bytes read from CRC files, across all CRC read calls.
     pub crc_bytes_read: RelaxedCounter,
 
     // Domain metadata load counters (Snapshot::get_domain_metadatas_internal)
     pub domain_metadata_loads: RelaxedCounter,
+    pub domain_metadata_load_failures: RelaxedCounter,
     pub domain_metadata_cache_hits: RelaxedCounter,
     pub domain_metadata_domains_returned: RelaxedCounter,
 
     // SetTransaction load counters (Snapshot::get_app_id_version)
     pub set_transaction_loads: RelaxedCounter,
+    pub set_transaction_load_failures: RelaxedCounter,
     pub set_transaction_cache_hits: RelaxedCounter,
     pub set_transaction_found: RelaxedCounter,
 }
@@ -219,9 +221,11 @@ impl CountingReporter {
         self.crc_read_calls.reset();
         self.crc_bytes_read.reset();
         self.domain_metadata_loads.reset();
+        self.domain_metadata_load_failures.reset();
         self.domain_metadata_cache_hits.reset();
         self.domain_metadata_domains_returned.reset();
         self.set_transaction_loads.reset();
+        self.set_transaction_load_failures.reset();
         self.set_transaction_cache_hits.reset();
         self.set_transaction_found.reset();
     }
@@ -286,10 +290,10 @@ impl MetricsReporter for CountingReporter {
                 self.parquet_files_read.add(e.num_files);
                 self.parquet_bytes_read.add(e.bytes_read);
             }
-            MetricEvent::SnapshotCompleted(_) => {
+            MetricEvent::SnapshotBuildSuccess(_) => {
                 self.snapshot_completions.inc();
             }
-            MetricEvent::LogSegmentLoaded(e) => {
+            MetricEvent::LogSegmentLoadSuccess(e) => {
                 self.log_segment_loads.inc();
                 self.commit_files.add(e.num_commit_files);
                 self.checkpoint_files.add(e.num_checkpoint_files);
@@ -297,11 +301,11 @@ impl MetricsReporter for CountingReporter {
                 self.latest_crc_files_found
                     .add(e.has_latest_crc_file as u64);
             }
-            MetricEvent::CrcReadCompleted(e) => {
+            MetricEvent::CrcReadSuccess(e) => {
                 self.crc_read_calls.inc();
                 self.crc_bytes_read.add(e.bytes_read);
             }
-            MetricEvent::DomainMetadataLoaded(e) => {
+            MetricEvent::DomainMetadataLoadSuccess(e) => {
                 self.domain_metadata_loads.inc();
                 if e.from_cache {
                     self.domain_metadata_cache_hits.inc();
@@ -309,7 +313,10 @@ impl MetricsReporter for CountingReporter {
                 self.domain_metadata_domains_returned
                     .add(e.num_domains_returned);
             }
-            MetricEvent::SetTransactionLoaded(e) => {
+            MetricEvent::DomainMetadataLoadFailure => {
+                self.domain_metadata_load_failures.inc();
+            }
+            MetricEvent::SetTransactionLoadSuccess(e) => {
                 self.set_transaction_loads.inc();
                 if e.from_cache {
                     self.set_transaction_cache_hits.inc();
@@ -318,9 +325,15 @@ impl MetricsReporter for CountingReporter {
                     self.set_transaction_found.inc();
                 }
             }
+            MetricEvent::SetTransactionLoadFailure => {
+                self.set_transaction_load_failures.inc();
+            }
             // Intentionally not tracked. Add counters if needed.
-            MetricEvent::ProtocolMetadataLoaded(_)
-            | MetricEvent::SnapshotFailed(_)
+            MetricEvent::ProtocolMetadataLoadSuccess(_)
+            | MetricEvent::ProtocolMetadataLoadFailure(_)
+            | MetricEvent::LogSegmentLoadFailure(_)
+            | MetricEvent::SnapshotBuildFailure(_)
+            | MetricEvent::CrcReadFailure
             | MetricEvent::ScanMetadataCompleted(_) => {}
         }
     }
@@ -332,9 +345,9 @@ mod tests {
     use std::time::Duration;
 
     use delta_kernel::metrics::{
-        CrcReadCompleted, DomainMetadataLoaded, LogSegmentLoaded, MetricId, ProtocolMetadataLoaded,
-        SetTransactionLoaded, SnapshotCompleted, SnapshotFailed, StorageCopyCompleted,
-        StorageListCompleted, StorageReadCompleted,
+        CrcReadStats, DomainMetadataLoadStats, LogSegmentLoadStats, MetricId,
+        ProtocolMetadataLoadStats, SetTransactionLoadStats, SnapshotBuildFailure,
+        SnapshotBuildStats, StorageCopyCompleted, StorageListCompleted, StorageReadCompleted,
     };
 
     use super::*;
@@ -383,7 +396,7 @@ mod tests {
     #[test]
     fn report_snapshot_completed_increments_snapshot_counter() {
         let reporter = CountingReporter::new();
-        reporter.report(MetricEvent::SnapshotCompleted(SnapshotCompleted {
+        reporter.report(MetricEvent::SnapshotBuildSuccess(SnapshotBuildStats {
             operation_id: MetricId::new(),
             version: 0,
             duration: dur(),
@@ -394,7 +407,7 @@ mod tests {
     #[test]
     fn report_log_segment_loaded_increments_log_replay_counters() {
         let reporter = CountingReporter::new();
-        reporter.report(MetricEvent::LogSegmentLoaded(LogSegmentLoaded {
+        reporter.report(MetricEvent::LogSegmentLoadSuccess(LogSegmentLoadStats {
             operation_id: MetricId::new(),
             duration: dur(),
             num_commit_files: 7,
@@ -412,7 +425,7 @@ mod tests {
     #[test]
     fn report_log_segment_loaded_without_crc_does_not_increment_crc_counter() {
         let reporter = CountingReporter::new();
-        reporter.report(MetricEvent::LogSegmentLoaded(LogSegmentLoaded {
+        reporter.report(MetricEvent::LogSegmentLoadSuccess(LogSegmentLoadStats {
             operation_id: MetricId::new(),
             duration: dur(),
             num_commit_files: 3,
@@ -427,11 +440,11 @@ mod tests {
     #[test]
     fn report_crc_read_completed_increments_crc_counters() {
         let reporter = CountingReporter::new();
-        reporter.report(MetricEvent::CrcReadCompleted(CrcReadCompleted {
+        reporter.report(MetricEvent::CrcReadSuccess(CrcReadStats {
             duration: dur(),
             bytes_read: 512,
         }));
-        reporter.report(MetricEvent::CrcReadCompleted(CrcReadCompleted {
+        reporter.report(MetricEvent::CrcReadSuccess(CrcReadStats {
             duration: dur(),
             bytes_read: 256,
         }));
@@ -442,16 +455,20 @@ mod tests {
     #[test]
     fn report_domain_metadata_loaded_increments_domain_metadata_counters() {
         let reporter = CountingReporter::new();
-        reporter.report(MetricEvent::DomainMetadataLoaded(DomainMetadataLoaded {
-            from_cache: true,
-            num_domains_returned: 3,
-            duration: dur(),
-        }));
-        reporter.report(MetricEvent::DomainMetadataLoaded(DomainMetadataLoaded {
-            from_cache: false,
-            num_domains_returned: 1,
-            duration: dur(),
-        }));
+        reporter.report(MetricEvent::DomainMetadataLoadSuccess(
+            DomainMetadataLoadStats {
+                from_cache: true,
+                num_domains_returned: 3,
+                duration: dur(),
+            },
+        ));
+        reporter.report(MetricEvent::DomainMetadataLoadSuccess(
+            DomainMetadataLoadStats {
+                from_cache: false,
+                num_domains_returned: 1,
+                duration: dur(),
+            },
+        ));
         assert_eq!(reporter.domain_metadata_loads.get(), 2);
         assert_eq!(reporter.domain_metadata_cache_hits.get(), 1);
         assert_eq!(reporter.domain_metadata_domains_returned.get(), 4);
@@ -460,16 +477,20 @@ mod tests {
     #[test]
     fn report_set_transaction_loaded_increments_set_transaction_counters() {
         let reporter = CountingReporter::new();
-        reporter.report(MetricEvent::SetTransactionLoaded(SetTransactionLoaded {
-            from_cache: true,
-            found: true,
-            duration: dur(),
-        }));
-        reporter.report(MetricEvent::SetTransactionLoaded(SetTransactionLoaded {
-            from_cache: false,
-            found: false,
-            duration: dur(),
-        }));
+        reporter.report(MetricEvent::SetTransactionLoadSuccess(
+            SetTransactionLoadStats {
+                from_cache: true,
+                found: true,
+                duration: dur(),
+            },
+        ));
+        reporter.report(MetricEvent::SetTransactionLoadSuccess(
+            SetTransactionLoadStats {
+                from_cache: false,
+                found: false,
+                duration: dur(),
+            },
+        ));
         assert_eq!(reporter.set_transaction_loads.get(), 2);
         assert_eq!(reporter.set_transaction_cache_hits.get(), 1);
         assert_eq!(reporter.set_transaction_found.get(), 1);
@@ -478,15 +499,14 @@ mod tests {
     #[test]
     fn report_untracked_events_does_not_panic() {
         let reporter = CountingReporter::new();
-        reporter.report(MetricEvent::ProtocolMetadataLoaded(
-            ProtocolMetadataLoaded {
+        reporter.report(MetricEvent::ProtocolMetadataLoadSuccess(
+            ProtocolMetadataLoadStats {
                 operation_id: MetricId::new(),
                 duration: dur(),
             },
         ));
-        reporter.report(MetricEvent::SnapshotFailed(SnapshotFailed {
+        reporter.report(MetricEvent::SnapshotBuildFailure(SnapshotBuildFailure {
             operation_id: MetricId::new(),
-            duration: dur(),
         }));
         assert_eq!(reporter.snapshot_completions.get(), 0);
     }
@@ -506,7 +526,7 @@ mod tests {
         reporter.report(MetricEvent::StorageCopyCompleted(StorageCopyCompleted {
             duration: dur(),
         }));
-        reporter.report(MetricEvent::LogSegmentLoaded(LogSegmentLoaded {
+        reporter.report(MetricEvent::LogSegmentLoadSuccess(LogSegmentLoadStats {
             operation_id: MetricId::new(),
             duration: dur(),
             num_commit_files: 7,
@@ -514,20 +534,24 @@ mod tests {
             num_compaction_files: 1,
             has_latest_crc_file: true,
         }));
-        reporter.report(MetricEvent::CrcReadCompleted(CrcReadCompleted {
+        reporter.report(MetricEvent::CrcReadSuccess(CrcReadStats {
             duration: dur(),
             bytes_read: 512,
         }));
-        reporter.report(MetricEvent::DomainMetadataLoaded(DomainMetadataLoaded {
-            from_cache: true,
-            num_domains_returned: 2,
-            duration: dur(),
-        }));
-        reporter.report(MetricEvent::SetTransactionLoaded(SetTransactionLoaded {
-            from_cache: true,
-            found: true,
-            duration: dur(),
-        }));
+        reporter.report(MetricEvent::DomainMetadataLoadSuccess(
+            DomainMetadataLoadStats {
+                from_cache: true,
+                num_domains_returned: 2,
+                duration: dur(),
+            },
+        ));
+        reporter.report(MetricEvent::SetTransactionLoadSuccess(
+            SetTransactionLoadStats {
+                from_cache: true,
+                found: true,
+                duration: dur(),
+            },
+        ));
 
         reporter.reset();
 
@@ -552,10 +576,23 @@ mod tests {
         assert_eq!(reporter.crc_read_calls.get(), 0);
         assert_eq!(reporter.crc_bytes_read.get(), 0);
         assert_eq!(reporter.domain_metadata_loads.get(), 0);
+        assert_eq!(reporter.domain_metadata_load_failures.get(), 0);
         assert_eq!(reporter.domain_metadata_cache_hits.get(), 0);
         assert_eq!(reporter.domain_metadata_domains_returned.get(), 0);
         assert_eq!(reporter.set_transaction_loads.get(), 0);
+        assert_eq!(reporter.set_transaction_load_failures.get(), 0);
         assert_eq!(reporter.set_transaction_cache_hits.get(), 0);
         assert_eq!(reporter.set_transaction_found.get(), 0);
+    }
+
+    #[test]
+    fn report_load_failures_increment_failure_counters() {
+        let reporter = CountingReporter::new();
+        reporter.report(MetricEvent::DomainMetadataLoadFailure);
+        reporter.report(MetricEvent::SetTransactionLoadFailure);
+        assert_eq!(reporter.domain_metadata_load_failures.get(), 1);
+        assert_eq!(reporter.set_transaction_load_failures.get(), 1);
+        assert_eq!(reporter.domain_metadata_loads.get(), 0);
+        assert_eq!(reporter.set_transaction_loads.get(), 0);
     }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Resolves #2658

Today _some_ metric events have success and failure variants, but most don't. On error, Kernel would emit (for example) a `LogSegmentLoaded` event with default-constructed values: a false "success" that pollutes downstream metrics.

This PR gives every lifecycle operation a flat success/failure pair, so a failure is never reported as a success.

### Heads up for downstream consumers

`MetricEvent` matches will need updating. The variant changes:

**Renamed**
- `LogSegmentLoaded` → `LogSegmentLoadSuccess`
- `ProtocolMetadataLoaded` → `ProtocolMetadataLoadSuccess`
- `SnapshotCompleted` → `SnapshotBuildSuccess`
- `DomainMetadataLoaded` → `DomainMetadataLoadSuccess`
- `SetTransactionLoaded` → `SetTransactionLoadSuccess`
- `CrcReadCompleted` → `CrcReadSuccess`
- `SnapshotFailed` → `SnapshotBuildFailure`

**Added (new failure variants)**
- `LogSegmentLoadFailure`
- `ProtocolMetadataLoadFailure`
- `DomainMetadataLoadFailure`
- `SetTransactionLoadFailure`
- `CrcReadFailure`

## How was this change tested?

New unit tests that force each lifecycle operation to fail and assert it emits the failure variant (not a success).
