### PR TITLE
refactor: update benchmark output format, update tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@
 target/
 integration-tests/Cargo.lock
 
+# Python
+__pycache__
+
 # Project
 acceptance/tests/dat/
 acceptance/workloads/

--- a/benchmarks/build.rs
+++ b/benchmarks/build.rs
@@ -9,8 +9,8 @@ use flate2::read::GzDecoder;
 use tar::Archive;
 use ureq::{Agent, Proxy};
 
-const VERSION: &str = "0.04-preview"; // release tag
-const WORKLOADS_VERSION: &str = "0.0.4"; // version in filename
+const VERSION: &str = "0.0.5-preview"; // release tag
+const WORKLOADS_VERSION: &str = "0.0.5"; // version in filename
 
 fn main() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");

--- a/benchmarks/ci/parse_critcmp.py
+++ b/benchmarks/ci/parse_critcmp.py
@@ -22,6 +22,10 @@ import sys
 # Significance threshold for slowdowns/speedups (2x in either direction).
 SIGNIFICANCE_THRESHOLD = 2.0
 
+# Ratios within this of 1.0 count as no change: rendered "1.00x" with no marker
+# and excluded from the summary's slowdown/speedup counts.
+NEUTRAL_THRESHOLD = 1e-3
+
 # Emoji markers for the Change cell, by side and severity.
 SIGNIFICANT_SLOWDOWN = '🐌'  # ratio >= SIGNIFICANCE_THRESHOLD
 SLIGHT_SLOWDOWN = '🚧'  # 1.0 < ratio < SIGNIFICANCE_THRESHOLD
@@ -118,7 +122,7 @@ def format_difference(ratio):
     """Render a ratio as e.g. '1.00x', '1.50x slower', or '2.00x faster'."""
     if ratio is None:
         return 'N/A'
-    if abs(ratio - 1.0) < 1e-9:
+    if abs(ratio - 1.0) < NEUTRAL_THRESHOLD:
         return '1.00x'
     if ratio > 1:
         return f'{ratio:.2f}x slower'
@@ -130,7 +134,7 @@ def change_emoji(ratio, significant):
     See the module-level emoji constants for the marker assignments. Returns
     an empty string for ratios near 1.0 or N/A rows.
     """
-    if ratio is None or abs(ratio - 1.0) < 1e-9:
+    if ratio is None or abs(ratio - 1.0) < NEUTRAL_THRESHOLD:
         return ''
     if ratio > 1.0:
         return SIGNIFICANT_SLOWDOWN if significant else SLIGHT_SLOWDOWN
@@ -142,11 +146,11 @@ def render_summary(rows):
     threshold; the per-row emoji marker is what distinguishes significant from
     slight changes.
 
-    Rows with ratio == 1.00 (or near-1) are excluded since they are neither slowdowns nor
-    speedups. N/A rows (ratio is None) are excluded for the same reason.
+    Rows within NEUTRAL_THRESHOLD of 1.0 are excluded since they are neither slowdowns
+    nor speedups. N/A rows (ratio is None) are excluded for the same reason.
     """
-    slow = [r for r in rows if r['ratio'] is not None and r['ratio'] > 1.0]
-    fast = [r for r in rows if r['ratio'] is not None and r['ratio'] < 1.0]
+    slow = [r for r in rows if r['ratio'] is not None and r['ratio'] - 1.0 >= NEUTRAL_THRESHOLD]
+    fast = [r for r in rows if r['ratio'] is not None and 1.0 - r['ratio'] >= NEUTRAL_THRESHOLD]
 
     if slow:
         worst = max(slow, key=lambda r: r['ratio'])

--- a/benchmarks/ci/parse_critcmp.py
+++ b/benchmarks/ci/parse_critcmp.py
@@ -9,8 +9,9 @@ Reads the output of `critcmp base changes` from stdin and writes:
      per-benchmark table with columns: Test | Base | PR | Change.
 
 A change is "significant" when it is at least 2x in either direction
-(ratio >= 2.0 for slowdown, ratio <= 0.5 for speedup). The summary counts
-only significant changes and the Change cell gets a 🐌/🚀 marker for them.
+(ratio >= 2.0 for slowdown, ratio <= 0.5 for speedup). The summary includes
+every slowdown and speedup; significant ones get a 🐌/🚀 marker in the
+Change cell.
 
 Usage:
     critcmp base changes | python3 benchmarks/ci/parse_critcmp.py
@@ -23,21 +24,28 @@ SIGNIFICANCE_THRESHOLD = 2.0
 
 # Emoji markers for the Change cell, by side and severity.
 SIGNIFICANT_SLOWDOWN = '🐌'  # ratio >= SIGNIFICANCE_THRESHOLD
-SLIGHT_SLOWDOWN = '⚠️&nbsp;'  # 1.0 < ratio < SIGNIFICANCE_THRESHOLD; nbsp pads U+FE0F variation selector
+SLIGHT_SLOWDOWN = '⚠️;'  # 1.0 < ratio < SIGNIFICANCE_THRESHOLD
 SLIGHT_SPEEDUP = '✅'        # 1.0 / SIGNIFICANCE_THRESHOLD < ratio < 1.0
 SIGNIFICANT_SPEEDUP = '🚀'   # ratio <= 1.0 / SIGNIFICANCE_THRESHOLD
 
 def to_ms(value, units):
+    """Convert a critcmp duration to milliseconds.
+
+    Matches exactly the units critcmp can emit (see `time()` in critcmp's
+    output.rs): ns, µs (U+00B5), ms, s. An unrecognized unit means the critcmp
+    output format changed; raise so the run fails loudly instead of rendering a
+    silently wrong table.
+    """
     u = units.strip()
     if u == 's':
         return value * 1e3
     if u == 'ms':
         return value
-    if u in ('µs', 'us', 'μs'):
+    if u == 'µs':
         return value / 1e3
     if u == 'ns':
         return value / 1e6
-    return value
+    raise ValueError(f'unrecognized critcmp time unit: {units!r}')
 
 def parse_duration(s):
     m = re.match(r'([0-9.]+)±([0-9.]+)(.+)', s.strip())
@@ -46,11 +54,16 @@ def parse_duration(s):
     return float(m.group(1)), float(m.group(2)), m.group(3).strip()
 
 def sanitize_name(raw):
-    """Sanitize an attacker-controllable benchmark name for safe markdown embedding.
+    """Escape a benchmark name so it renders cleanly inside a markdown table cell.
 
-    Strips backticks (so the name can't break out of the code span), then escapes pipes
-    (which would otherwise terminate a table cell). Returns the bare string. The
+    Strips backticks (which would terminate the code span), then escapes pipes
+    (which would otherwise terminate the table cell). Returns the bare string. The
     caller wraps in backticks where appropriate.
+
+    Rendering hygiene only, not a security boundary: the entire comment body is
+    produced by the untrusted bench run and posted verbatim (see
+    .github/SECURITY_MODEL.md), so escaping here cannot -- and does not need to --
+    prevent markdown injection.
     """
     return raw.replace('`', '').replace('|', r'\|')
 
@@ -132,16 +145,17 @@ def change_emoji(ratio, significant):
     See the module-level emoji constants for the marker assignments. Returns
     an empty string for ratios near 1.0 or N/A rows.
     """
-    if ratio is None or abs(ratio - 1.0) < 1e-9:
+    if ratio is None or abs(ratio - 1.0) < 1.0e-1:
         return ''
     if ratio > 1.0:
         return SIGNIFICANT_SLOWDOWN if significant else SLIGHT_SLOWDOWN
     return SIGNIFICANT_SPEEDUP if significant else SLIGHT_SPEEDUP
 
 def render_summary(rows):
-    """Render the summary block. Counts and extrema include every slowdown and speedup
-    regardless of the 2x significance threshold; the per-row emoji marker is the place
-    that distinguishes significant from slight changes.
+    """Render the summary block. The counts and the largest-slowdown/fastest-speedup
+    lines include every slowdown and speedup regardless of the 2x significance
+    threshold; the per-row emoji marker is what distinguishes significant from
+    slight changes.
 
     Rows with ratio == 1.00 (or near-1) are excluded since they are neither slowdowns nor
     speedups. N/A rows (ratio is None) are excluded for the same reason.

--- a/benchmarks/ci/parse_critcmp.py
+++ b/benchmarks/ci/parse_critcmp.py
@@ -24,9 +24,9 @@ SIGNIFICANCE_THRESHOLD = 2.0
 
 # Emoji markers for the Change cell, by side and severity.
 SIGNIFICANT_SLOWDOWN = '🐌'  # ratio >= SIGNIFICANCE_THRESHOLD
-SLIGHT_SLOWDOWN = '⚠️;'  # 1.0 < ratio < SIGNIFICANCE_THRESHOLD
-SLIGHT_SPEEDUP = '✅'        # 1.0 / SIGNIFICANCE_THRESHOLD < ratio < 1.0
-SIGNIFICANT_SPEEDUP = '🚀'   # ratio <= 1.0 / SIGNIFICANCE_THRESHOLD
+SLIGHT_SLOWDOWN = '🚧'  # 1.0 < ratio < SIGNIFICANCE_THRESHOLD
+SLIGHT_SPEEDUP = '✅'  # 1.0 / SIGNIFICANCE_THRESHOLD < ratio < 1.0
+SIGNIFICANT_SPEEDUP = '🚀'  # ratio <= 1.0 / SIGNIFICANCE_THRESHOLD
 
 def to_ms(value, units):
     """Convert a critcmp duration to milliseconds.
@@ -53,20 +53,6 @@ def parse_duration(s):
         return None
     return float(m.group(1)), float(m.group(2)), m.group(3).strip()
 
-def sanitize_name(raw):
-    """Escape a benchmark name so it renders cleanly inside a markdown table cell.
-
-    Strips backticks (which would terminate the code span), then escapes pipes
-    (which would otherwise terminate the table cell). Returns the bare string. The
-    caller wraps in backticks where appropriate.
-
-    Rendering hygiene only, not a security boundary: the entire comment body is
-    produced by the untrusted bench run and posted verbatim (see
-    .github/SECURITY_MODEL.md), so escaping here cannot -- and does not need to --
-    prevent markdown injection.
-    """
-    return raw.replace('`', '').replace('|', r'\|')
-
 def parse_rows(lines):
     """Parse critcmp stdout into a list of row dicts.
 
@@ -87,8 +73,7 @@ def parse_rows(lines):
         # Locate duration fields by the presence of "±" rather than hardcoding indices,
         # so the script works correctly regardless of whether bandwidth columns are present.
         fields = re.split(r'  +', line)
-        raw_name = fields[0].strip() if fields else ''
-        name = sanitize_name(raw_name)
+        name = fields[0].strip() if fields else ''
         dur_fields = [f.strip() for f in fields[1:] if '±' in f]
         base_dur_str = dur_fields[0] if len(dur_fields) > 0 else None
         chg_dur_str  = dur_fields[1] if len(dur_fields) > 1 else None
@@ -145,7 +130,7 @@ def change_emoji(ratio, significant):
     See the module-level emoji constants for the marker assignments. Returns
     an empty string for ratios near 1.0 or N/A rows.
     """
-    if ratio is None or abs(ratio - 1.0) < 1.0e-1:
+    if ratio is None or abs(ratio - 1.0) < 1e-9:
         return ''
     if ratio > 1.0:
         return SIGNIFICANT_SLOWDOWN if significant else SLIGHT_SLOWDOWN
@@ -192,9 +177,9 @@ def render_table(rows):
     out.append(f"<summary>Per-benchmark results ({len(rows)} rows)</summary>")
     out.append("")
     out.append(
-        f"**Legend:** {SIGNIFICANT_SLOWDOWN} ≥ 2x slower &nbsp;·&nbsp; "
-        f"{SLIGHT_SLOWDOWN} < 2x slower &nbsp;·&nbsp; "
-        f"{SLIGHT_SPEEDUP} < 2x faster &nbsp;·&nbsp; "
+        f"**Legend:** {SIGNIFICANT_SLOWDOWN} ≥ 2x slower &nbsp;·&nbsp;"
+        f"{SLIGHT_SLOWDOWN} < 2x slower &nbsp;·&nbsp;"
+        f"{SLIGHT_SPEEDUP} < 2x faster &nbsp;·&nbsp;"
         f"{SIGNIFICANT_SPEEDUP} ≥ 2x faster"
     )
     out.append("")
@@ -204,7 +189,9 @@ def render_table(rows):
         name_cell = f"`{r['name']}`" if r['name'] else ''
         difference = format_difference(r['ratio'])
         emoji = change_emoji(r['ratio'], r['significant'])
-        change_cell = f"{emoji} {difference}".lstrip()
+        # Non-breaking spaces keep the marker and ratio on one line so the
+        # Change cell renders without wrapping.
+        change_cell = f"{emoji} {difference}".strip().replace(" ", "&nbsp;")
         out.append(f"| {name_cell} | {r['base_display']} | {r['chg_display']} | {change_cell} |")
     out.append("")
     out.append("</details>")

--- a/benchmarks/ci/parse_critcmp.py
+++ b/benchmarks/ci/parse_critcmp.py
@@ -23,7 +23,7 @@ SIGNIFICANCE_THRESHOLD = 2.0
 
 # Emoji markers for the Change cell, by side and severity.
 SIGNIFICANT_SLOWDOWN = '🐌'  # ratio >= SIGNIFICANCE_THRESHOLD
-SLIGHT_SLOWDOWN = '⚠️'      # 1.0 < ratio < SIGNIFICANCE_THRESHOLD
+SLIGHT_SLOWDOWN = '⚠️&nbsp;'  # 1.0 < ratio < SIGNIFICANCE_THRESHOLD; nbsp pads U+FE0F variation selector
 SLIGHT_SPEEDUP = '✅'        # 1.0 / SIGNIFICANCE_THRESHOLD < ratio < 1.0
 SIGNIFICANT_SPEEDUP = '🚀'   # ratio <= 1.0 / SIGNIFICANCE_THRESHOLD
 
@@ -139,22 +139,24 @@ def change_emoji(ratio, significant):
     return SIGNIFICANT_SPEEDUP if significant else SLIGHT_SPEEDUP
 
 def render_summary(rows):
-    """Render the summary block. Counts and extrema use only statistically significant rows.
+    """Render the summary block. Counts and extrema include every slowdown and speedup
+    regardless of the 2x significance threshold; the per-row emoji marker is the place
+    that distinguishes significant from slight changes.
 
-    Rows with ratio == 1.00 (or near-1) are excluded from both counts and extrema
-    regardless of significance, since they are not slowdowns or speedups.
+    Rows with ratio == 1.00 (or near-1) are excluded since they are neither slowdowns nor
+    speedups. N/A rows (ratio is None) are excluded for the same reason.
     """
-    significant_slow = [r for r in rows if r['significant'] and r['ratio'] is not None and r['ratio'] > 1.0]
-    significant_fast = [r for r in rows if r['significant'] and r['ratio'] is not None and r['ratio'] < 1.0]
+    slow = [r for r in rows if r['ratio'] is not None and r['ratio'] > 1.0]
+    fast = [r for r in rows if r['ratio'] is not None and r['ratio'] < 1.0]
 
-    if significant_slow:
-        worst = max(significant_slow, key=lambda r: r['ratio'])
+    if slow:
+        worst = max(slow, key=lambda r: r['ratio'])
         largest_slowdown = f"`{worst['name']}` ({format_difference(worst['ratio'])})"
     else:
         largest_slowdown = "no benchmarks slowed down"
 
-    if significant_fast:
-        best = min(significant_fast, key=lambda r: r['ratio'])
+    if fast:
+        best = min(fast, key=lambda r: r['ratio'])
         fastest_speedup = f"`{best['name']}` ({format_difference(best['ratio'])})"
     else:
         fastest_speedup = "no benchmarks sped up"
@@ -164,8 +166,8 @@ def render_summary(rows):
         "",
         f"- Largest slowdown: {largest_slowdown}",
         f"- Fastest speedup: {fastest_speedup}",
-        f"- Benchmarks slowed down: {len(significant_slow)}",
-        f"- Benchmarks sped up: {len(significant_fast)}",
+        f"- Benchmarks slowed down: {len(slow)}",
+        f"- Benchmarks sped up: {len(fast)}",
     ]
     return "\n".join(lines)
 

--- a/benchmarks/ci/parse_critcmp.py
+++ b/benchmarks/ci/parse_critcmp.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python3
 """
-Parse critcmp output and format it as a GitHub-flavoured Markdown table.
+Parse critcmp output and format it as a GitHub-flavoured Markdown comment.
 
-Reads the output of `critcmp base changes` from stdin and writes a table
-with columns: Test | Base | PR | Change, where Change expresses the PR
-timing as a ratio of the base timing (e.g. `1.50x slower`, `2.00x faster`,
-`1.00x`). The Change cell is bolded when the difference is statistically
-significant (i.e. the error bounds do not overlap).
+Reads the output of `critcmp base changes` from stdin and writes:
+  1. A summary block listing the largest slowdown, the fastest speedup,
+     and the count of significant slowdowns/speedups.
+  2. A `<details>` block (closed by default) containing the full
+     per-benchmark table with columns: Test | Base | PR | Change.
+
+The Change cell is bolded when the difference is statistically significant
+(i.e. the error bounds do not overlap). The summary counts only significant
+changes -- non-significant deltas are noise.
 
 Usage:
     critcmp base changes | python3 benchmarks/ci/parse_critcmp.py
@@ -42,24 +46,26 @@ def parse_duration(s):
         return None
     return float(m.group(1)), float(m.group(2)), m.group(3).strip()
 
-def main():
-    # Expected critcmp input format (2-space-separated columns):
-    #
-    # group                               base                         changes
-    # -----                               ----                         -------
-    # bench_name                  1.00    1.2±0.01µs          1.05    1.3±0.02µs
-    # bench_name/with_throughput  1.00    1.2±0.01µs  1.2 MB/s  1.05  1.3±0.02µs  1.1 MB/s
-    #
-    # Expected output (GitHub-flavored markdown table):
-    # Throughput/bandwidth columns from critcmp are ignored; output is the same either way.
-    #
-    # | Test                       | Base       | PR          | Change             |
-    # |----------------------------|------------|-------------|--------------------|
-    # | bench_name                 | 1.2±0.01µs | 1.3±0.02µs  | **1.08x slower**   |
-    lines = sys.stdin.read().splitlines()
-    print("| Test | Base         | PR               | Change |")
-    print("|------|--------------|------------------|--------|")
+def sanitize_name(raw):
+    """Sanitize an attacker-controllable benchmark name for safe markdown embedding.
 
+    Strips backticks (so the name can't break out of the code span) then escapes pipes
+    (which would otherwise terminate a table cell). Returns the bare string -- the
+    caller wraps in backticks where appropriate.
+    """
+    return raw.replace('`', '').replace('|', r'\|')
+
+def parse_rows(lines):
+    """Parse critcmp stdout into a list of row dicts.
+
+    Each row dict contains:
+      name:         sanitized benchmark name (no backticks/pipes), unwrapped
+      base_display: base duration string or 'N/A'
+      chg_display:  changes duration string or 'N/A'
+      ratio:        chg_ms / base_ms, or None if either side is missing/zero
+      significant:  bool, False if ratio is None
+    """
+    rows = []
     for line in lines[2:]:  # skip critcmp header rows
         if not line.strip():
             continue
@@ -69,12 +75,8 @@ def main():
         # Locate duration fields by the presence of "±" rather than hardcoding indices,
         # so the script works correctly regardless of whether bandwidth columns are present.
         fields = re.split(r'  +', line)
-        # Benchmark names are attacker-controllable (PR can introduce workloads
-        # with crafted names). Strip backticks (so the name can't break out of
-        # the code span) then wrap in backticks so markdown link syntax inside
-        # the name doesn't render as a real link.
-        name = fields[0].strip().replace('`', '').replace('|', r'\|') if fields else ''
-        name = f'`{name}`' if name else ''
+        raw_name = fields[0].strip() if fields else ''
+        name = sanitize_name(raw_name)
         dur_fields = [f.strip() for f in fields[1:] if '±' in f]
         base_dur_str = dur_fields[0] if len(dur_fields) > 0 else None
         chg_dur_str  = dur_fields[1] if len(dur_fields) > 1 else None
@@ -85,14 +87,13 @@ def main():
         # N/A when a benchmark only exists in one of the two runs (added or removed).
         base_display = base_dur_str or 'N/A'
         chg_display  = chg_dur_str  or 'N/A'
-        difference   = 'N/A'
+        ratio = None
+        significant = False
 
         if base_dur_str and chg_dur_str:
-            # Parse each duration string into (mean, error, units), e.g. "1.2±0.01µs" -> (1.2, 0.01, "µs").
             base_p = parse_duration(base_dur_str)
             chg_p  = parse_duration(chg_dur_str)
             if base_p and chg_p:
-                # Normalise both measurements to milliseconds so they can be compared directly.
                 base_ms     = to_ms(base_p[0], base_p[2])
                 base_err_ms = to_ms(base_p[1], base_p[2])
                 chg_ms      = to_ms(chg_p[0],  chg_p[2])
@@ -102,21 +103,84 @@ def main():
                 # by powers of ten, so a zero output strictly implies a zero input.
                 # Do NOT replace with an epsilon -- that would tag legitimately fast
                 # benches (sub-nanosecond rounding) as N/A.
-                if base_ms == 0 or chg_ms == 0:
-                    difference = 'N/A'
-                else:
+                if base_ms != 0 and chg_ms != 0:
                     ratio = chg_ms / base_ms
-                    if abs(ratio - 1.0) < 1e-9:
-                        difference = '1.00x'
-                    elif ratio > 1:
-                        difference = f'{ratio:.2f}x slower'
-                    else:
-                        difference = f'{1.0 / ratio:.2f}x faster'
+                    significant = is_significant(chg_ms, chg_err_ms, base_ms, base_err_ms)
 
-                    if is_significant(chg_ms, chg_err_ms, base_ms, base_err_ms):
-                        difference = f'**{difference}**'
+        rows.append({
+            'name': name,
+            'base_display': base_display,
+            'chg_display': chg_display,
+            'ratio': ratio,
+            'significant': significant,
+        })
+    return rows
 
-        print(f'| {name} | {base_display} | {chg_display} | {difference} |')
+def format_difference(ratio):
+    """Render a ratio as e.g. '1.00x', '1.50x slower', or '2.00x faster'."""
+    if ratio is None:
+        return 'N/A'
+    if abs(ratio - 1.0) < 1e-9:
+        return '1.00x'
+    if ratio > 1:
+        return f'{ratio:.2f}x slower'
+    return f'{1.0 / ratio:.2f}x faster'
+
+def render_summary(rows):
+    """Render the summary block. Counts and extrema use only statistically significant rows.
+
+    Rows with ratio == 1.00 (or near-1) are excluded from both counts and extrema
+    regardless of significance, since they are not slowdowns or speedups.
+    """
+    significant_slow = [r for r in rows if r['significant'] and r['ratio'] is not None and r['ratio'] > 1.0]
+    significant_fast = [r for r in rows if r['significant'] and r['ratio'] is not None and r['ratio'] < 1.0]
+
+    if significant_slow:
+        worst = max(significant_slow, key=lambda r: r['ratio'])
+        largest_slowdown = f"`{worst['name']}` ({format_difference(worst['ratio'])})"
+    else:
+        largest_slowdown = "no benchmarks slowed down"
+
+    if significant_fast:
+        best = min(significant_fast, key=lambda r: r['ratio'])
+        fastest_speedup = f"`{best['name']}` ({format_difference(best['ratio'])})"
+    else:
+        fastest_speedup = "no benchmarks sped up"
+
+    lines = [
+        "**Summary**",
+        "",
+        f"- Largest slowdown: {largest_slowdown}",
+        f"- Fastest speedup: {fastest_speedup}",
+        f"- Benchmarks slowed down: {len(significant_slow)}",
+        f"- Benchmarks sped up: {len(significant_fast)}",
+    ]
+    return "\n".join(lines)
+
+def render_table(rows):
+    """Render the per-benchmark table wrapped in a closed-by-default <details> block."""
+    out = []
+    out.append(f"<details>")
+    out.append(f"<summary>Per-benchmark results ({len(rows)} rows)</summary>")
+    out.append("")
+    out.append("| Test | Base         | PR               | Change |")
+    out.append("|------|--------------|------------------|--------|")
+    for r in rows:
+        name_cell = f"`{r['name']}`" if r['name'] else ''
+        difference = format_difference(r['ratio'])
+        if r['significant'] and r['ratio'] is not None and abs(r['ratio'] - 1.0) >= 1e-9:
+            difference = f"**{difference}**"
+        out.append(f"| {name_cell} | {r['base_display']} | {r['chg_display']} | {difference} |")
+    out.append("")
+    out.append("</details>")
+    return "\n".join(out)
+
+def main():
+    lines = sys.stdin.read().splitlines()
+    rows = parse_rows(lines)
+    print(render_summary(rows))
+    print("")
+    print(render_table(rows))
 
 if __name__ == "__main__":
     main()

--- a/benchmarks/ci/parse_critcmp.py
+++ b/benchmarks/ci/parse_critcmp.py
@@ -8,37 +8,36 @@ Reads the output of `critcmp base changes` from stdin and writes:
   2. A `<details>` block (closed by default) containing the full
      per-benchmark table with columns: Test | Base | PR | Change.
 
-The Change cell is bolded when the difference is statistically significant
-(i.e. the error bounds do not overlap). The summary counts only significant
-changes -- non-significant deltas are noise.
+A change is "significant" when it is at least 2x in either direction
+(ratio >= 2.0 for slowdown, ratio <= 0.5 for speedup). The summary counts
+only significant changes and the Change cell gets a 🐌/🚀 marker for them.
 
 Usage:
     critcmp base changes | python3 benchmarks/ci/parse_critcmp.py
 """
-import sys, re
+import re
+import sys
+
+# Significance threshold for slowdowns/speedups (2x in either direction).
+SIGNIFICANCE_THRESHOLD = 2.0
+
+# Emoji markers for the Change cell, by side and severity.
+SIGNIFICANT_SLOWDOWN = '🐌'  # ratio >= SIGNIFICANCE_THRESHOLD
+SLIGHT_SLOWDOWN = '⚠️'      # 1.0 < ratio < SIGNIFICANCE_THRESHOLD
+SLIGHT_SPEEDUP = '✅'        # 1.0 / SIGNIFICANCE_THRESHOLD < ratio < 1.0
+SIGNIFICANT_SPEEDUP = '🚀'   # ratio <= 1.0 / SIGNIFICANCE_THRESHOLD
 
 def to_ms(value, units):
     u = units.strip()
-    if u == 's':   return value * 1e3
-    if u == 'ms':  return value
-    if u in ('µs', 'us', 'μs'): return value / 1e3
-    if u == 'ns':  return value / 1e6
+    if u == 's':
+        return value * 1e3
+    if u == 'ms':
+        return value
+    if u in ('µs', 'us', 'μs'):
+        return value / 1e3
+    if u == 'ns':
+        return value / 1e6
     return value
-
-def is_significant(chg_dur, chg_err, base_dur, base_err):
-    """Return True if the difference between two measurements is statistically significant.
-
-    Significance is determined by whether either center value (the `X` in `X±err`) lies outside the other's error bar.
-    Concretely, if chg is faster than base, the change is significant if:
-      - base's center value is above chg's entire error bar range (chg + chg_err < base), OR
-      - chg's center value is below base's entire error bar range (base - base_err > chg).
-    The symmetric conditions apply when chg is slower. This is an OR test: only one side
-    needs to show clear separation for the difference to be considered significant.
-    """
-    if chg_dur < base_dur:
-        return chg_dur + chg_err < base_dur or base_dur - base_err > chg_dur
-    else:
-        return chg_dur - chg_err > base_dur or base_dur + base_err < chg_dur
 
 def parse_duration(s):
     m = re.match(r'([0-9.]+)±([0-9.]+)(.+)', s.strip())
@@ -49,8 +48,8 @@ def parse_duration(s):
 def sanitize_name(raw):
     """Sanitize an attacker-controllable benchmark name for safe markdown embedding.
 
-    Strips backticks (so the name can't break out of the code span) then escapes pipes
-    (which would otherwise terminate a table cell). Returns the bare string -- the
+    Strips backticks (so the name can't break out of the code span), then escapes pipes
+    (which would otherwise terminate a table cell). Returns the bare string. The
     caller wraps in backticks where appropriate.
     """
     return raw.replace('`', '').replace('|', r'\|')
@@ -94,10 +93,8 @@ def parse_rows(lines):
             base_p = parse_duration(base_dur_str)
             chg_p  = parse_duration(chg_dur_str)
             if base_p and chg_p:
-                base_ms     = to_ms(base_p[0], base_p[2])
-                base_err_ms = to_ms(base_p[1], base_p[2])
-                chg_ms      = to_ms(chg_p[0],  chg_p[2])
-                chg_err_ms  = to_ms(chg_p[1],  chg_p[2])
+                base_ms = to_ms(base_p[0], base_p[2])
+                chg_ms  = to_ms(chg_p[0],  chg_p[2])
 
                 # Float-equality on zero is safe here: to_ms only multiplies/divides
                 # by powers of ten, so a zero output strictly implies a zero input.
@@ -105,7 +102,10 @@ def parse_rows(lines):
                 # benches (sub-nanosecond rounding) as N/A.
                 if base_ms != 0 and chg_ms != 0:
                     ratio = chg_ms / base_ms
-                    significant = is_significant(chg_ms, chg_err_ms, base_ms, base_err_ms)
+                    significant = (
+                        ratio >= SIGNIFICANCE_THRESHOLD
+                        or ratio <= 1.0 / SIGNIFICANCE_THRESHOLD
+                    )
 
         rows.append({
             'name': name,
@@ -125,6 +125,18 @@ def format_difference(ratio):
     if ratio > 1:
         return f'{ratio:.2f}x slower'
     return f'{1.0 / ratio:.2f}x faster'
+
+def change_emoji(ratio, significant):
+    """Pick an emoji indicator for the Change cell.
+
+    See the module-level emoji constants for the marker assignments. Returns
+    an empty string for ratios near 1.0 or N/A rows.
+    """
+    if ratio is None or abs(ratio - 1.0) < 1e-9:
+        return ''
+    if ratio > 1.0:
+        return SIGNIFICANT_SLOWDOWN if significant else SLIGHT_SLOWDOWN
+    return SIGNIFICANT_SPEEDUP if significant else SLIGHT_SPEEDUP
 
 def render_summary(rows):
     """Render the summary block. Counts and extrema use only statistically significant rows.
@@ -160,17 +172,24 @@ def render_summary(rows):
 def render_table(rows):
     """Render the per-benchmark table wrapped in a closed-by-default <details> block."""
     out = []
-    out.append(f"<details>")
+    out.append("<details>")
     out.append(f"<summary>Per-benchmark results ({len(rows)} rows)</summary>")
+    out.append("")
+    out.append(
+        f"**Legend:** {SIGNIFICANT_SLOWDOWN} ≥ 2x slower &nbsp;·&nbsp; "
+        f"{SLIGHT_SLOWDOWN} < 2x slower &nbsp;·&nbsp; "
+        f"{SLIGHT_SPEEDUP} < 2x faster &nbsp;·&nbsp; "
+        f"{SIGNIFICANT_SPEEDUP} ≥ 2x faster"
+    )
     out.append("")
     out.append("| Test | Base         | PR               | Change |")
     out.append("|------|--------------|------------------|--------|")
     for r in rows:
         name_cell = f"`{r['name']}`" if r['name'] else ''
         difference = format_difference(r['ratio'])
-        if r['significant'] and r['ratio'] is not None and abs(r['ratio'] - 1.0) >= 1e-9:
-            difference = f"**{difference}**"
-        out.append(f"| {name_cell} | {r['base_display']} | {r['chg_display']} | {difference} |")
+        emoji = change_emoji(r['ratio'], r['significant'])
+        change_cell = f"{emoji} {difference}".lstrip()
+        out.append(f"| {name_cell} | {r['base_display']} | {r['chg_display']} | {change_cell} |")
     out.append("")
     out.append("</details>")
     return "\n".join(out)

--- a/benchmarks/ci/run-benchmarks.sh
+++ b/benchmarks/ci/run-benchmarks.sh
@@ -84,11 +84,17 @@ git checkout FETCH_HEAD
 (cd benchmarks && cargo bench --locked --bench workload_bench -- --save-baseline base "$FILTER")
 
 # ---------------------------------------------------------------------------
-# 4. Compare baselines with critcmp and format as a markdown table.
+# 4. Compare baselines with critcmp and format as a markdown comment
+#    (summary block + collapsed per-benchmark table; see
+#    benchmarks/ci/parse_critcmp.py for the format and significance rules).
 #      - Parses actual duration values (not rank factors) to compute a ratio
-#      - Bolds the Change cell when the difference is statistically
-#        significant (error bounds do not overlap)
 # ---------------------------------------------------------------------------
+# Step 3 left the working tree on the base branch, so parse_critcmp.py on disk
+# is the base version. Restore the PR-head tree so the comment is formatted by
+# the PR's own formatter (a formatter change is then exercised on the PR that
+# introduces it). Only tracked sources move; the `base`/`changes` criterion
+# baselines live in gitignored benchmarks/target/ and survive the checkout.
+git checkout "$HEAD_SHA"
 # Use `critcmp` to compare the criterion output for `base` and `changes`. We use `critcmp` instead of manually
 # parsing criterion outputs because criterion may update its output format. By using `critcmp`, we inherit all
 # updated criterion output parsing.

--- a/benchmarks/src/runners.rs
+++ b/benchmarks/src/runners.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 use delta_kernel::expressions::PredicateRef;
 use delta_kernel::object_store::local::LocalFileSystem;
-use delta_kernel::scan::{AfterSequentialScanMetadata, ParallelScanMetadata};
+use delta_kernel::scan::{AfterSequentialScanMetadata, ParallelScanMetadata, StatsOptions};
 use delta_kernel::{Engine, Snapshot};
 use delta_kernel_default_engine::executor::tokio::TokioMultiThreadExecutor;
 use delta_kernel_default_engine::DefaultEngine;
@@ -271,6 +271,7 @@ impl ReadMetadataRunner {
             .clone()
             .scan_builder()
             .with_predicate(self.predicate.clone())
+            .with_stats(StatsOptions::all())
             .build()?;
         let metadata_iter = scan.scan_metadata(self.engine.as_ref())?;
         for result in metadata_iter {
@@ -290,6 +291,7 @@ impl ReadMetadataRunner {
             .clone()
             .scan_builder()
             .with_predicate(self.predicate.clone())
+            .with_stats(StatsOptions::all())
             .build()?;
 
         let mut phase1 = scan.parallel_scan_metadata(self.engine.clone())?;

--- a/benchmarks/src/runners.rs
+++ b/benchmarks/src/runners.rs
@@ -271,7 +271,7 @@ impl ReadMetadataRunner {
             .clone()
             .scan_builder()
             .with_predicate(self.predicate.clone())
-            .with_stats(StatsOptions::all())
+            .with_stats(StatsOptions::all_struct())
             .build()?;
         let metadata_iter = scan.scan_metadata(self.engine.as_ref())?;
         for result in metadata_iter {
@@ -291,7 +291,7 @@ impl ReadMetadataRunner {
             .clone()
             .scan_builder()
             .with_predicate(self.predicate.clone())
-            .with_stats(StatsOptions::all())
+            .with_stats(StatsOptions::all_struct())
             .build()?;
 
         let mut phase1 = scan.parallel_scan_metadata(self.engine.clone())?;

--- a/benchmarks/src/runners.rs
+++ b/benchmarks/src/runners.rs
@@ -235,10 +235,9 @@ impl ReadMetadataRunner {
             .map(Arc::new);
 
         let name = format!(
-            "{}/{}/{}/{}",
+            "{}/{}/{}",
             table_info.name,
             case_name,
-            ReadOperation::ReadMetadata.as_str(),
             config.name,
         );
 
@@ -383,10 +382,9 @@ impl SnapshotConstructionRunner {
         runtime: Arc<tokio::runtime::Runtime>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let name = format!(
-            "{}/{}/{}",
+            "{}/{}",
             table_info.name,
             case_name,
-            snapshot_spec.as_str()
         );
 
         let (engine, snapshot_strategy) = resolve_snapshot_strategy(table_info, runtime.clone())?;

--- a/benchmarks/src/runners.rs
+++ b/benchmarks/src/runners.rs
@@ -234,12 +234,7 @@ impl ReadMetadataRunner {
             .transpose()?
             .map(Arc::new);
 
-        let name = format!(
-            "{}/{}/{}",
-            table_info.name,
-            case_name,
-            config.name,
-        );
+        let name = format!("{}/{}/{}", table_info.name, case_name, config.name,);
 
         let thread_pool = match &config.parallel_scan {
             ParallelScan::Enabled { num_threads } => {
@@ -381,11 +376,7 @@ impl SnapshotConstructionRunner {
         snapshot_spec: &SnapshotConstructionSpec,
         runtime: Arc<tokio::runtime::Runtime>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        let name = format!(
-            "{}/{}",
-            table_info.name,
-            case_name,
-        );
+        let name = format!("{}/{}", table_info.name, case_name,);
 
         let (engine, snapshot_strategy) = resolve_snapshot_strategy(table_info, runtime.clone())?;
 
@@ -497,10 +488,7 @@ mod tests {
             test_runtime(),
         )
         .expect("setup should succeed");
-        assert_eq!(
-            runner.name(),
-            "basic_partitioned/testCase/readMetadata/serial"
-        );
+        assert_eq!(runner.name(), "basic_partitioned/testCase/serial");
         assert!(runner.execute().is_ok());
     }
 
@@ -514,10 +502,7 @@ mod tests {
             test_runtime(),
         )
         .expect("setup should succeed");
-        assert_eq!(
-            runner.name(),
-            "basic_partitioned/testCase/readMetadata/parallel2"
-        );
+        assert_eq!(runner.name(), "basic_partitioned/testCase/parallel2");
         assert!(runner.execute().is_ok());
     }
 
@@ -548,10 +533,7 @@ mod tests {
             test_runtime(),
         )
         .expect("setup should succeed");
-        assert_eq!(
-            runner.name(),
-            "basic_partitioned/testCase/snapshotConstruction"
-        );
+        assert_eq!(runner.name(), "basic_partitioned/testCase");
     }
 
     #[test]


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR changes the tables that we benchmark against and includes stats going forward. We also update some formatting such as making the the tests collapsable and adding a benchmark summary and add some emojis to make scanning the benchmark result much easier (🐌 -> 🚧 -> ✅ -> 🚀).


## How was this change tested?
Showed that benchmarks can run after pull request. Each scan looks like a regression because the base did not include stats in the scan.