### PR TITLE
ci: Fix dupliate CI runs

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -1,0 +1,62 @@
+# .github/CLAUDE.md
+
+Workflow-authoring rules for GitHub Actions.
+
+## Triggers: restrict `push` to long-lived branches
+
+The CI trigger events:
+
+- `pull_request`: a commit is pushed to a branch with an open PR. Runs CI on the
+  PR.
+- `merge_group`: the merge queue builds a temporary `gh-readonly-queue/*` branch
+  and tests the change as it would land on `main`.
+- `push`: a branch ref is updated. We only want this for the long-lived branches
+  (`main` and `release/**`), i.e. the post-merge run once a PR lands.
+
+We want CI on `pull_request`, on `merge_group`, and on `push` to a long-lived
+branch: one run per stage. A bare `push` trigger instead duplicates two of these:
+
+- `push` + `pull_request`: a branch pushed directly to this repo (a maintainer
+  branch, not a fork) fires both. Fork PRs avoid this because the `push` lands on
+  the fork, not on this repo.
+- `push` + `merge_group`: the merge queue's push to the `gh-readonly-queue/*`
+  branch fires both.
+
+Restricting `push` to long-lived branches drops the redundant `push` in each
+case:
+
+```yaml
+on:
+  push:
+    branches: [main, "release/**"]
+  pull_request:
+  merge_group:
+```
+
+## Supply chain security: `--locked`
+
+Every `cargo` command in CI that resolves dependencies MUST use `--locked` to
+enforce the committed `Cargo.lock`. This prevents CI from silently picking up a
+newer (potentially compromised) transitive dependency. If `Cargo.lock` is out of
+sync with `Cargo.toml`, the build fails immediately, forcing dependency changes to
+be explicit and reviewable. See the top-level comment in `build.yml` for full
+rationale. Commands exempt from `--locked`: `cargo +nightly fmt` (no dep
+resolution), `cargo msrv verify/show` (wrapper tool), `cargo miri setup` (tooling
+setup).
+
+## Action safety
+
+When writing any github action, consider safety including mitigating common attack
+vectors such as expression injection and pull request target attacks.
+
+```yaml
+# The code below is vulnerable to expression injection
+run: |
+    echo "Comment: ${{ github.event.comment.body }}"
+
+# To mitigate instead use environment variables
+env:
+    COMMENT_BODY: ${{ github.event.comment.body }}
+run: |
+    echo "Comment: $COMMENT_BODY"
+```

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,11 @@
 name: build
 
-on: [push, pull_request, merge_group]
+# Restrict push to long-lived branches to avoid duplicate CI runs. See .github/CLAUDE.md.
+on:
+  push:
+    branches: [main, "release/**"]
+  pull_request:
+  merge_group:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -1,6 +1,11 @@
 name: run-examples
 
-on: [push, pull_request, merge_group]
+# Restrict push to long-lived branches to avoid duplicate CI runs. See .github/CLAUDE.md.
+on:
+  push:
+    branches: [main, "release/**"]
+  pull_request:
+  merge_group:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/user-guide.yml
+++ b/.github/workflows/user-guide.yml
@@ -1,6 +1,11 @@
 name: user-guide
 
-on: [push, pull_request, merge_group]
+# Restrict push to long-lived branches to avoid duplicate CI runs. See .github/CLAUDE.md.
+on:
+  push:
+    branches: [main, "release/**"]
+  pull_request:
+  merge_group:
 
 env:
   CARGO_TERM_COLOR: always

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -330,32 +330,6 @@ Breaking change examples: `feat!: make_physical takes column mapping and sets pa
 side of simplicity -- don't list every change. Focus on key API changes, functionality,
 and data flow. Keep it concise.
 
-### CI Jobs and Github Actions
-
-**Supply chain security:** every `cargo` command in CI that resolves dependencies MUST use
-`--locked` to enforce the committed `Cargo.lock`. This prevents CI from silently picking up
-a newer (potentially compromised) transitive dependency. If `Cargo.lock` is out of sync with
-`Cargo.toml`, the build fails immediately, forcing dependency changes to be explicit and
-reviewable. See the top-level comment in `build.yml` for full rationale. Commands exempt from
-`--locked`: `cargo +nightly fmt` (no dep resolution), `cargo msrv verify/show` (wrapper tool),
-`cargo miri setup` (tooling setup).
-
-Ensure that when writing any github action you are considering safety including thinking of
-and mitigating common attack vectors such expression injection and pull request target attacks.
-
-Example:
-```yaml
-# The code below is vulnerable to expression injection
-run: |
-    echo "Comment: ${{ github.event.comment.body }}"
-
-# To mitigate instead use environment variables
-env:
-    COMMENT_BODY: ${{ github.event.comment.body }}
-run: |
-    echo "Comment: $COMMENT_BODY"
-```
-
 ## Deep Context
 
 Read these when relevant to the task at hand:
@@ -368,4 +342,5 @@ Read these when relevant to the task at hand:
 **Keeping docs current:** If you notice anything inaccurate in these docs -- renamed
 structs, traits, functions, modules, crates, APIs, stale data flows, wrong file paths --
 inform the user so they can be updated. After major changes, update this file,
-`CLAUDE/architecture.md`, `ffi/CLAUDE.md`, and any relevant `<crate>/CLAUDE.md` files.
+`CLAUDE/architecture.md`, `ffi/CLAUDE.md`, `.github/CLAUDE.md`, and any relevant
+`<crate>/CLAUDE.md` files.


### PR DESCRIPTION
## What changes are proposed in this pull request?

Previously we've had `on: [push, pull_request, merge_group]` in our CI workflows.

This allowed for duplicate CI runs in two cases:
- Case 1: PR added to merge gueue. This **pushes** to a new temp branch. Thus the **merge_group** and the **push** events were triggered, and 2 runs were executed
- Case 2: A branch in this repo (**not in a fork**) was pushed to. Again, **pull_request** and **push** events were triggered.

This PR changes this so that we only execute push against `main` and `release` branches.

Evidence:

Every merge-queue entry produced a matching `merge_group` + `push` pair of `build` runs on the same `gh-readonly-queue/*` temp branch and the same commit, created ~1 second apart:

| PR | temp-branch commit | `merge_group` run | `push` run (redundant) |
|----|--------------------|-------------------|------------------------|
| #2522 | `a4ff55919c` | [26986967449](https://github.com/delta-io/delta-kernel-rs/actions/runs/26986967449) | [26986967842](https://github.com/delta-io/delta-kernel-rs/actions/runs/26986967842) |
| #2613 | `0c0414abbb` | [27033496212](https://github.com/delta-io/delta-kernel-rs/actions/runs/27033496212) | [27033496903](https://github.com/delta-io/delta-kernel-rs/actions/runs/27033496903) |
| #2663 | `c67799f4d0` | [26986255295](https://github.com/delta-io/delta-kernel-rs/actions/runs/26986255295) | [26986255687](https://github.com/delta-io/delta-kernel-rs/actions/runs/26986255687) |
| #2666 | `3638ba8433` | [27035061234](https://github.com/delta-io/delta-kernel-rs/actions/runs/27035061234) | [27035061155](https://github.com/delta-io/delta-kernel-rs/actions/runs/27035061155) |
| #2680 | `b23ec52a24` | [27035546413](https://github.com/delta-io/delta-kernel-rs/actions/runs/27035546413) | [27035546610](https://github.com/delta-io/delta-kernel-rs/actions/runs/27035546610) |
| #2694 | `0ee0f738b7` | [27036278360](https://github.com/delta-io/delta-kernel-rs/actions/runs/27036278360) | [27036279320](https://github.com/delta-io/delta-kernel-rs/actions/runs/27036279320) |
| #2697 | `ae7a2b8c6e` | [27032663202](https://github.com/delta-io/delta-kernel-rs/actions/runs/27032663202) | [27032663624](https://github.com/delta-io/delta-kernel-rs/actions/runs/27032663624) |
| #2699 | `a4871e2836` | [27028497624](https://github.com/delta-io/delta-kernel-rs/actions/runs/27028497624) | [27028497786](https://github.com/delta-io/delta-kernel-rs/actions/runs/27028497786) |
| #2700 | `3ca5f50a02` | [27031189908](https://github.com/delta-io/delta-kernel-rs/actions/runs/27031189908) | [27031189924](https://github.com/delta-io/delta-kernel-rs/actions/runs/27031189924) |

Across the last 500 `build` runs this pairing was exact: 38 `merge_group` runs and 38 redundant `push` runs on `gh-readonly-queue/*` branches.

## How was this change tested?

CI.

