### PR TITLE
feat: support local DAT corpus override for acceptance workloads

### DIFF
--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -5,3 +5,45 @@ These tests have been implemented as a separate sub-project in the workspace to
 ensure that they are acting as a "connector" for the kernel APIs, thereby
 allowing us to test the exact same engine interfaces that any connector
 implemented on top of delta-kernel-rs would be using.
+
+## Authoring a DAT case locally
+
+CI downloads a published DAT corpus, pinned to a version in `build.rs`. To create
+a *new* DAT case without bumping that version, generate a corpus locally and point
+the build at it with `DELTA_ACCEPTANCE_WORKLOADS_PATH`. See
+https://github.com/delta-incubator/dat/blob/main/workload-generator/README.md for
+the full authoring guide.
+
+Add a case to a `*Suite.scala` in the DAT `workload-generator`. Each `test(...)`
+block is one case: build a table with `sql`, register it, then declare the specs to
+generate (`readSpec` for scans, `snapshotSpec` for protocol/metadata).
+
+```scala
+// in src/test/scala/io/delta/workload/tables/ReadsSuite.scala
+test("my_case") {
+  sql("CREATE TABLE tbl (id INT, price DECIMAL(10,2)) USING delta")
+  sql("INSERT INTO tbl VALUES (1, 9.99), (2, 100.00)")
+  val t = registerTable("tbl")
+  readSpec(t)                        // full scan
+  readSpec(t, predicate = "id > 1")  // predicate pushdown
+  snapshotSpec(t)                    // protocol + metadata
+}
+```
+
+Then generate just that case and run it. The `-z` filter generates one case instead
+of the whole suite (each case is a few seconds of Spark).
+
+```bash
+# 1. Generate the corpus locally (Spark needs JDK 17).
+export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64   # any JDK 17
+export PATH="$JAVA_HOME/bin:$PATH"
+cd <dat-clone>/workload-generator
+WORKLOAD_OUTPUT_DIR=/tmp/wl WORKLOAD_FORCE=true sbt 'testOnly *ReadsSuite -- -z "my_case"'
+
+# 2. Point kernel-rs at the local corpus and iterate.
+cd <delta-kernel-rs>
+DELTA_ACCEPTANCE_WORKLOADS_PATH=/tmp/wl cargo nextest run -p acceptance
+```
+
+Do **not** commit a generated corpus. Bump `ACCEPTANCE_WORKLOADS_VERSION`
+in `build.rs` once the case lands in a DAT release.

--- a/acceptance/build.rs
+++ b/acceptance/build.rs
@@ -88,6 +88,20 @@ fn extract_acceptance_workloads() {
     let dir = PathBuf::from(manifest_dir);
 
     let output_dir = dir.join("workloads");
+
+    // if DELTA_ACCEPTANCE_WORKLOADS_PATH is set, point `workloads/` at that locally-generated
+    // corpus instead of downloading the pinned release, so a dev can iterate against their own
+    // corpus.
+    println!("cargo::rerun-if-env-changed=DELTA_ACCEPTANCE_WORKLOADS_PATH");
+    if let Ok(local) = env::var("DELTA_ACCEPTANCE_WORKLOADS_PATH") {
+        link_local_workloads(&local, &output_dir);
+        return;
+    }
+    // Drop a stale override symlink (from a prior run) so we download into a real directory.
+    if output_dir.is_symlink() {
+        std::fs::remove_file(&output_dir).expect("Failed to remove stale workloads symlink");
+    }
+
     let done_marker = output_dir.join(".done");
 
     // Tell Cargo to re-run if the done marker changes
@@ -140,4 +154,44 @@ fn extract_acceptance_workloads() {
         File::create(&done_marker).expect("Failed to create acceptance workloads .done file"),
     );
     write!(done_file, "done").expect("Failed to write acceptance workloads .done file");
+}
+
+/// Point `workloads/` at a locally-generated corpus (`DELTA_ACCEPTANCE_WORKLOADS_PATH`) via a
+/// symlink, replacing any prior download.
+fn link_local_workloads(local: &str, output_dir: &Path) {
+    let local_path = std::fs::canonicalize(local).unwrap_or_else(|e| {
+        panic!("DELTA_ACCEPTANCE_WORKLOADS_PATH '{local}' is not accessible: {e}")
+    });
+    assert!(
+        local_path.is_dir(),
+        "DELTA_ACCEPTANCE_WORKLOADS_PATH '{}' is not a directory",
+        local_path.display()
+    );
+
+    // Replace whatever is at workloads/ (a prior download dir, or an old symlink).
+    if output_dir.is_symlink() || output_dir.is_file() {
+        std::fs::remove_file(output_dir).expect("Failed to remove existing workloads path");
+    } else if output_dir.is_dir() {
+        std::fs::remove_dir_all(output_dir).expect("Failed to remove existing workloads dir");
+    }
+
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&local_path, output_dir).unwrap_or_else(|e| {
+        panic!(
+            "Failed to symlink workloads -> {}: {e}",
+            local_path.display()
+        )
+    });
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(&local_path, output_dir).unwrap_or_else(|e| {
+        panic!(
+            "Failed to symlink workloads -> {}: {e}",
+            local_path.display()
+        )
+    });
+
+    println!(
+        "cargo::warning=acceptance: using local workloads from {}",
+        local_path.display()
+    );
 }

--- a/acceptance/tests/other.rs
+++ b/acceptance/tests/other.rs
@@ -3,6 +3,8 @@
 /// Since each new `.rs` file in this directory results in increased build and link time, it is
 /// important to only add new files if absolutely necessary for code readability or test
 /// performance.
+use std::path::Path;
+
 use delta_kernel::last_checkpoint_hint::LastCheckpointHint;
 
 #[test]
@@ -13,6 +15,19 @@ fn test_checkpoint_serde() {
     .unwrap();
     let cp: LastCheckpointHint = serde_json::from_reader(file).unwrap();
     assert_eq!(cp.version, 2)
+}
+
+/// Guards against mistaking local-override results for the pinned release.
+#[test]
+fn acceptance_workloads_is_not_a_local_override() {
+    let workloads = Path::new(env!("CARGO_MANIFEST_DIR")).join("workloads");
+    let meta = std::fs::symlink_metadata(&workloads).expect("workloads/ should exist after build");
+    assert!(
+        !meta.file_type().is_symlink(),
+        "acceptance/workloads is a symlink to a LOCAL corpus, so you are not testing the pinned \
+         release. Unset DELTA_ACCEPTANCE_WORKLOADS_PATH and rebuild (or remove acceptance/workloads) \
+         before trusting these results."
+    );
 }
 
 /*

--- a/benchmarks/src/models.rs
+++ b/benchmarks/src/models.rs
@@ -205,7 +205,7 @@ impl TimeTravel {
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum Spec {
     Read(ReadSpec),
-    #[serde(alias = "snapshot_construction")]
+    #[serde(alias = "snapshot_construction", alias = "snapshot")]
     SnapshotConstruction(Box<SnapshotConstructionSpec>),
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This change does three things:
(1) Allows devs to manually author new DAT cases. Previously `acceptance/build.rs` could only download pinned release tar files to run DAT. Now, when `DELTA_ACCEPTANCE_WORKLOADS_PATH` is set, devs can generate a DAT case using the workload generator in https://github.com/delta-incubator/dat/ to validate against Kernel.

(2) bug fix: Kernel accepted the snapshot spec type as `snapshotConstruction`, but the DAT workload generator emits `snapshot`.
(3) update `acceptance/README.md` to document the CUJ to write a DAT case and point `kernel-rs` at it.

## How was this change tested?
This script was tested locally against https://github.com/delta-incubator/dat.
