### PR TITLE
test: addressed failing invalid-handle-code

### DIFF
--- a/ffi/tests/invalid-handle-code/mut-clone-handle.stderr
+++ b/ffi/tests/invalid-handle-code/mut-clone-handle.stderr
@@ -19,7 +19,7 @@ error[E0271]: type mismatch resolving `<MutFoo as HandleDescriptor>::Mutable == 
 note: expected this to be `delta_kernel_ffi::handle::False`
   --> tests/invalid-handle-code/mut-clone-handle.rs:7:1
    |
-7  | #[handle_descriptor(target=Foo, mutable=true, sized=true)]
+ 7 | #[handle_descriptor(target=Foo, mutable=true, sized=true)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: required for `Handle<MutFoo>` to implement `From<Arc<Foo>>`
    = note: required for `Arc<Foo>` to implement `Into<Handle<MutFoo>>`

--- a/ffi/tests/invalid-handle-code/shared-as-mut.stderr
+++ b/ffi/tests/invalid-handle-code/shared-as-mut.stderr
@@ -19,7 +19,7 @@ error[E0271]: type mismatch resolving `<SharedFoo as HandleDescriptor>::Mutable 
 note: expected this to be `delta_kernel_ffi::handle::True`
   --> tests/invalid-handle-code/shared-as-mut.rs:6:1
    |
-6  | #[handle_descriptor(target=Foo, mutable=false, sized=true)]
+ 6 | #[handle_descriptor(target=Foo, mutable=false, sized=true)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: required for `Handle<SharedFoo>` to implement `From<Box<Foo>>`
    = note: required for `Box<Foo>` to implement `Into<Handle<SharedFoo>>`

--- a/ffi/tests/invalid-handle-code/shared-not-sync.stderr
+++ b/ffi/tests/invalid-handle-code/shared-not-sync.stderr
@@ -21,7 +21,7 @@ error[E0277]: `*mut u32` cannot be shared between threads safely
 note: required because it appears within the type `NotSync`
   --> tests/invalid-handle-code/shared-not-sync.rs:5:12
    |
-5  | pub struct NotSync(*mut u32);
+ 5 | pub struct NotSync(*mut u32);
    |            ^^^^^^^
    = note: required for `SharedNotSync` to implement `handle::private::SharedHandleOps<NotSync, delta_kernel_ffi::handle::True>`
    = note: required for `Handle<SharedNotSync>` to implement `From<Arc<NotSync>>`


### PR DESCRIPTION
## What changes are proposed in this pull request?

Addressing https://github.com/delta-io/delta-kernel-rs/issues/2624. The test `invalid-handle-code` was failing locally when running `cargo nextest run --workspace --all-features -- --skip read_table_version_hdfs`, but addressing the issue of stale expectation of compiler output fixes it when running locally.

This was the command I used:

```
cd /home/a.raj/delta-kernel-rs/ffi && TRYBUILD=overwrite cargo test -p delta_kernel_ffi --features internal-api invalid_handle_code
```

## How was this change tested?

No production code was changed and all tests pass (including `invalid-handle-code`)!