### PR TITLE
ci: various improvements

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -33,6 +33,13 @@ on:
   merge_group:
 ```
 
+## Never `paths`/`paths-ignore` a workflow whose jobs are required checks
+
+Do NOT add `paths` or `paths-ignore` filters to a workflow whose jobs are required
+status checks (most of `build.yml`). When a path filter skips the whole workflow,
+the required checks never report, and the PR stays blocked on "Expected, waiting
+for status" indefinitely. A skipped workflow is not the same as a passing one.
+
 ## Supply chain security: `--locked`
 
 Every `cargo` command in CI that resolves dependencies MUST use `--locked` to

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,19 @@ on:
   pull_request:
   merge_group:
 
+concurrency:
+  # A new push to a PR cancels that PR's in-flight run. On push to main/release, head_ref
+  # is empty, so run_id (always unique) is used and those runs never cancel each other.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # Strip debuginfo (debugger source-line/variable maps, type layouts) in CI: no debugger
+  # attaches here, so it is pure compile overhead. Test output, logs, and panics are unaffected.
+  CARGO_PROFILE_DEV_DEBUG: "0"
+  CARGO_PROFILE_TEST_DEBUG: "0"
 
 # Supply chain security: all cargo commands that resolve dependencies use --locked to
 # enforce the committed Cargo.lock. This prevents CI from silently resolving a newer
@@ -29,8 +39,8 @@ env:
 #
 # Without this, GHA's ref-scoped caching works against us: each PR writes ~6.3GB of
 # cache entries (14 jobs x ~450MB) that only that PR can read. A handful of active PRs
-# fills the 10GB cache budget, LRU evicts main's shared entries, and every subsequent
-# PR compiles from scratch.
+# fills the 50GB cache budget (as of 2026-06), LRU evicts main's shared entries, and
+# every subsequent PR compiles from scratch.
 #
 # The save-if condition checks both event_name == 'push' and ref == main because
 # pull_request_target events set github.ref to the base branch (main), not the PR
@@ -249,6 +259,8 @@ jobs:
               sudo apt install -y -V libarrow-glib-dev # For GLib (C)
               sudo apt install -y -V valgrind # For memory leak test
            fi
+      # TODO (#2707): This step's cache misses 100% of runs, wasting ~4.5 min per macOS run on a
+      #               fresh `brew install`. See the issue for root cause and fix options.
       - name: Install arrow-glib-macOS
         if: runner.os == 'macOS'
         uses: ./.github/actions/use-homebrew-tools

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -7,6 +7,12 @@ on:
   pull_request:
   merge_group:
 
+concurrency:
+  # A new push to a PR cancels that PR's in-flight run. Non-PR events (push, merge_group) have
+  # no head_ref, so run_id (always unique) is used and those runs never cancel each other.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -11,6 +11,12 @@ on:
       - reopened
   merge_group:
 
+concurrency:
+  # A new push to a PR cancels that PR's in-flight run. Non-PR events (merge_group) have no
+  # head_ref, so run_id (always unique) is used and those runs never cancel each other.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/.github/workflows/user-guide.yml
+++ b/.github/workflows/user-guide.yml
@@ -7,6 +7,12 @@ on:
   pull_request:
   merge_group:
 
+concurrency:
+  # A new push to a PR cancels that PR's in-flight run. Non-PR events (push, merge_group) have
+  # no head_ref, so run_id (always unique) is used and those runs never cancel each other.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2708/files) to review incremental changes.
- [**stack/more-ci-improvements**](https://github.com/delta-io/delta-kernel-rs/pull/2708) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2708/files)]
  - [stack/ci-dont-run-on-docs-only-prs](https://github.com/delta-io/delta-kernel-rs/pull/2710) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2710/files/4d0597feab32548805b242f99c0d421680f92598..30225ad9c4d9a6093233b023d7aa26037cafc602)]

---------
## What changes are proposed in this pull request?

Two CI fixes:
- Add `concurrency` to several jobs: pushing to your PR now cancels the previous run (no one looks at it anyways). This is what delta-rs and datafusion do.
- Run with `debuginfo` off (debugger source-line/variable maps, type layouts). Test output, logs, and panics are unaffected

## How was this change tested?

Ran CI on the branch: Concurrency cancellation works — pushing a new commit cancelled the in-flight run (2 superseded runs show `cancelled`).
