### PR TITLE
ci: skip `build` and `run-examples` jobs on docs-only PRs

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -40,6 +40,20 @@ status checks (most of `build.yml`). When a path filter skips the whole workflow
 the required checks never report, and the PR stays blocked on "Expected, waiting
 for status" indefinitely. A skipped workflow is not the same as a passing one.
 
+To skip expensive work on docs-only PRs, gate the jobs instead. A workflow contains `jobs:`;
+each job runs on its own runner and contains a sequence of `steps:`. Add a `detect_changes`
+job that `uses: ./.github/workflows/detect-changes.yml`, and have expensive jobs declare
+`needs: detect_changes`. How to gate depends on the job shape:
+
+- **Single (non-matrix) jobs** (`format`, `docs`, ...): gate the whole job with
+  `if: needs.detect_changes.outputs.docs_only == 'false'`. A skipped job reports its name as
+  "skipped", which satisfies the required check of the same name.
+- **Matrix jobs** (`build`, `test`, ...): gate the *steps*, not the job. A job-level skip
+  never expands the matrix, so its per-leg required checks (`build (ubuntu-latest)`, ...)
+  never report and the PR blocks. Keep `needs:`, drop the job `if:`, gate each work step.
+
+See `detect-changes.yml`, `build.yml`, and `run-examples.yml`.
+
 ## Supply chain security: `--locked`
 
 Every `cargo` command in CI that resolves dependencies MUST use `--locked` to

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,8 +59,17 @@ env:
 # are installed via taiki-e/install-action, which fetches prebuilt binaries.
 
 jobs:
+  # Detect docs-only PRs. Each job below declares `needs: detect_changes` and runs only
+  # `if: needs.detect_changes.outputs.docs_only == 'false'`, so on a docs-only PR it is
+  # skipped while still satisfying its required status check. Logic lives in the shared
+  # detect-changes reusable workflow. See .github/CLAUDE.md.
+  detect_changes:
+    uses: ./.github/workflows/detect-changes.yml
+
   format:
     runs-on: ubuntu-latest
+    needs: detect_changes
+    if: needs.detect_changes.outputs.docs_only == 'false'
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install nightly with rustfmt
@@ -74,6 +83,8 @@ jobs:
 
   msrv:
     runs-on: ubuntu-latest
+    needs: detect_changes
+    if: needs.detect_changes.outputs.docs_only == 'false'
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install minimal stable and cargo msrv
@@ -95,6 +106,8 @@ jobs:
           cargo msrv --path ffi-proc-macros/ verify --all-features
   msrv-run-tests:
     runs-on: ubuntu-latest
+    needs: detect_changes
+    if: needs.detect_changes.outputs.docs_only == 'false'
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install minimal stable and cargo msrv
@@ -125,6 +138,8 @@ jobs:
           cargo +$(cargo msrv show --output-format minimal) test --doc
   docs:
     runs-on: ubuntu-latest
+    needs: detect_changes
+    if: needs.detect_changes.outputs.docs_only == 'false'
     env:
       RUSTDOCFLAGS: -D warnings
     steps:
@@ -161,8 +176,11 @@ jobs:
   #    - delta_kernel_derive
   #    - delta_kernel_ffi
   #    - delta_kernel_ffi_macros
+  # Matrix jobs gate at the STEP level, not the job: a skipped matrix job never expands, so its
+  # per-leg required checks (e.g. `build (ubuntu-latest)`) never report and the PR blocks.
   build:
     runs-on: ${{ matrix.os }}
+    needs: detect_changes
     strategy:
       matrix:
         os:
@@ -181,21 +199,29 @@ jobs:
           cache-bin: false
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: build and lint with clippy
+        if: needs.detect_changes.outputs.docs_only == 'false'
         run: cargo clippy --locked --benches --tests --all-features -- -D warnings
       - name: lint without default features - packages which depend on kernel with features enabled
+        if: needs.detect_changes.outputs.docs_only == 'false'
         run: cargo clippy --locked --workspace --no-default-features --exclude delta_kernel --exclude delta_kernel_ffi --exclude delta_kernel_derive --exclude delta_kernel_ffi_macros -- -D warnings
       - name: lint without default features - packages which don't depend on kernel with features enabled
+        if: needs.detect_changes.outputs.docs_only == 'false'
         run: cargo clippy --locked --no-default-features --package delta_kernel --package delta_kernel_ffi --package delta_kernel_derive --package delta_kernel_ffi_macros -- -D warnings
       - name: check kernel builds with default-engine-native-tls
+        if: needs.detect_changes.outputs.docs_only == 'false'
         run: cargo build --locked -p feature_tests --features default-engine-native-tls
       - name: test native-tls backend has no crypto provider conflict
+        if: needs.detect_changes.outputs.docs_only == 'false'
         run: cargo test --locked -p feature_tests --features default-engine-native-tls
       - name: check kernel builds with default-engine-rustls
+        if: needs.detect_changes.outputs.docs_only == 'false'
         run: cargo build --locked -p feature_tests --features default-engine-rustls
       - name: test rustls TLS backend feature-tests
+        if: needs.detect_changes.outputs.docs_only == 'false'
         run: cargo test --locked -p feature_tests --features default-engine-rustls
   test:
     runs-on: ${{ matrix.os }}
+    needs: detect_changes
     strategy:
       matrix:
         os:
@@ -221,11 +247,13 @@ jobs:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@98ec31d284eb962f41c14065e9391a955aa810cf # nextest
       - name: test
+        if: needs.detect_changes.outputs.docs_only == 'false'
         run: cargo nextest run --locked --workspace --all-features -E 'not test(read_table_version_hdfs) and not test(invalid_handle_code)'
       - name: trybuild tests
-        if: steps.filter.outputs.ffi == 'true'
+        if: needs.detect_changes.outputs.docs_only == 'false' && steps.filter.outputs.ffi == 'true'
         run: cargo test --locked --package delta_kernel_ffi --features internal-api -- invalid_handle_code
       - name: metrics deadlock test
+        if: needs.detect_changes.outputs.docs_only == 'false'
         shell: bash
         run: |
           output=$(cargo run --profile test --example metrics-tester)
@@ -234,6 +262,7 @@ jobs:
 
   ffi_test:
     runs-on: ${{ matrix.os }}
+    needs: detect_changes
     strategy:
       matrix:
         os:
@@ -246,6 +275,7 @@ jobs:
         with:
           cmake-version: "3.30.x"
       - name: Install arrow-glib-linux
+        if: needs.detect_changes.outputs.docs_only == 'false'
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
               sudo apt update
@@ -262,7 +292,7 @@ jobs:
       # TODO (#2707): This step's cache misses 100% of runs, wasting ~4.5 min per macOS run on a
       #               fresh `brew install`. See the issue for root cause and fix options.
       - name: Install arrow-glib-macOS
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && needs.detect_changes.outputs.docs_only == 'false'
         uses: ./.github/actions/use-homebrew-tools
         with:
           tools: "apache-arrow apache-arrow-glib"
@@ -277,6 +307,7 @@ jobs:
       - name: Set output on fail
         run: echo "CTEST_OUTPUT_ON_FAILURE=1" >> "$GITHUB_ENV"
       - name: Build kernel
+        if: needs.detect_changes.outputs.docs_only == 'false'
         run: |
           pushd acceptance
           cargo build --locked
@@ -285,6 +316,7 @@ jobs:
           cargo build --locked --features default-engine-rustls,test-ffi,tracing,delta-kernel-unity-catalog
           popd
       - name: build and run read-table test
+        if: needs.detect_changes.outputs.docs_only == 'false'
         run: |
           pushd ffi/examples/read-table
           mkdir build
@@ -293,6 +325,7 @@ jobs:
           make
           make test
       - name: build and run visit-expression test
+        if: needs.detect_changes.outputs.docs_only == 'false'
         run: |
           pushd ffi/examples/visit-expression
           mkdir build
@@ -301,6 +334,7 @@ jobs:
           make
           make test
       - name: build and run delta-kernel-unity-catalog-ffi test
+        if: needs.detect_changes.outputs.docs_only == 'false'
         run: |
           pushd ffi/examples/delta-kernel-unity-catalog-example
           mkdir build
@@ -309,6 +343,7 @@ jobs:
           make
           make test
       - name: build and run create-table test
+        if: needs.detect_changes.outputs.docs_only == 'false'
         run: |
           pushd ffi/examples/create-table
           mkdir build
@@ -320,6 +355,7 @@ jobs:
       # binary, so create-table must be built first (its build/ dir is preserved by the
       # preceding step and write-table's CMakeLists references it via a relative path).
       - name: build and run write-table test
+        if: needs.detect_changes.outputs.docs_only == 'false'
         run: |
           pushd ffi/examples/write-table
           mkdir build
@@ -328,6 +364,7 @@ jobs:
           make
           make test
       - name: build update-dv example
+        if: needs.detect_changes.outputs.docs_only == 'false'
         run: |
           pushd ffi/examples/update-dv
           mkdir build
@@ -335,6 +372,7 @@ jobs:
           cmake ..
           make
       - name: build and run read-table-changes test
+        if: needs.detect_changes.outputs.docs_only == 'false'
         run: |
           pushd ffi/examples/read-table-changes
           mkdir build
@@ -342,15 +380,18 @@ jobs:
           cmake ..
           make
           make test
+  # Step-gated so the matrix expands into `Miri (shard 1/3)` etc.; a job-level skip would not.
   miri:
     name: "Miri (shard ${{ matrix.partition }}/3)"
     runs-on: ubuntu-latest
+    needs: detect_changes
     strategy:
       matrix:
         partition: [1, 2, 3]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install Miri
+        if: needs.detect_changes.outputs.docs_only == 'false'
         run: |
           rustup toolchain install nightly --component miri
           rustup override set nightly
@@ -361,12 +402,15 @@ jobs:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@98ec31d284eb962f41c14065e9391a955aa810cf # nextest
       - name: Test with Miri
+        if: needs.detect_changes.outputs.docs_only == 'false'
         run: |
           pushd ffi
           MIRIFLAGS=-Zmiri-disable-isolation cargo miri nextest run --locked --features default-engine-rustls,delta-kernel-unity-catalog,declarative-plans --partition slice:${{ matrix.partition }}/3
 
   coverage:
     runs-on: ubuntu-latest
+    needs: detect_changes
+    if: needs.detect_changes.outputs.docs_only == 'false'
     env:
       CARGO_TERM_COLOR: always
     steps:

--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -1,0 +1,40 @@
+name: detect-changes
+
+# Reusable detector shared by the CI workflows. A caller adds a `detect_changes` job that
+# `uses:` this file, then gates its expensive jobs with
+# `needs: detect_changes` + `if: needs.detect_changes.outputs.docs_only == 'false'`.
+#
+# Gating at the job level (not via `paths-ignore`) keeps each job reporting a status: a job
+# skipped by its own `if:` reports "skipped", which satisfies a required check, whereas a
+# skipped *workflow* would block the merge. See .github/CLAUDE.md.
+#
+# docs_only is meaningful only for pull_request events. On a pull_request it is 'true' when
+# paths-filter confirms every changed file is docs/markdown, so callers skip. On push,
+# merge_group, or any other event the filter does not run, so docs_only is 'false' and callers
+# always run their full work. (Fail-safe: we skip only on a confirmed docs-only PR.)
+on:
+  workflow_call:
+    outputs:
+      docs_only:
+        description: "'true' when a pull_request changed only docs/markdown; 'false' otherwise."
+        value: ${{ jobs.detect.outputs.docs_only }}
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.filter.outputs.code == 'false' }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          # 'every' means a file matches only if it satisfies ALL the negations below, so
+          # `code` is true when any changed file falls outside those docs paths.
+          predicate-quantifier: 'every'
+          filters: |
+            code:
+              - '!**.md'
+              - '!docs/**'
+              - '!.github/ISSUE_TEMPLATE/**'

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -18,8 +18,14 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  # Skip on docs-only PRs while still reporting a status. See .github/CLAUDE.md.
+  detect_changes:
+    uses: ./.github/workflows/detect-changes.yml
+
   run-examples:
     runs-on: ubuntu-latest
+    needs: detect_changes
+    if: needs.detect_changes.outputs.docs_only == 'false'
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install minimal stable


### PR DESCRIPTION
## What changes are proposed in this pull request?

Docs-only PRs (changes limited to `*.md`, `docs/`, or `.github/ISSUE_TEMPLATE/`) now skip the build/lint/test/coverage matrix and the examples.

Uses a shared `detect-changes` reusable workflow which reports whether a PR is docs-only.

## How was this change tested?

Validated the YAML, then exercised both paths with throwaway PRs based on this branch:
- **Docs-only PR** ([scottsand-db#1](https://github.com/scottsand-db/delta-kernel-rs/pull/1), a single `.md`): all required checks pass with no work run. The matrix jobs expand and report success per leg (`build (ubuntu-latest)`, `test (windows-latest)`, `Miri (shard 1/3)`, ...) with their steps skipped; the single jobs (`format`, `msrv`, `msrv-run-tests`, `docs`) report "skipped". The PR is mergeable.
- **Non-docs PR** ([scottsand-db#2](https://github.com/scottsand-db/delta-kernel-rs/pull/2), a single `.txt`): the full matrix runs.

Matrix jobs are step-gated rather than job-gated on purpose: a skipped matrix job never expands, so its required per-leg contexts would never report and the PR would block.
