### PR TITLE
ci: bump codecov-action to v7.0.0 to fix coverage uploads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -384,7 +384,7 @@ jobs:
       - name: Generate code coverage
         run: cargo llvm-cov --locked --all-features --workspace --codecov --output-path codecov.json -- --skip read_table_version_hdfs --skip handle::tests::invalid_handle_code
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5.5.3
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: codecov.json
           fail_ci_if_error: true


### PR DESCRIPTION
## What changes are proposed in this pull request?

The coverage job has been failing at the Codecov upload step ([example link](https://github.com/delta-io/delta-kernel-rs/actions/runs/27137413595/job/80109392728?pr=2665)).

The version of codecov-action we pin (v5.5.3) verifies the downloaded CLI against a GPG key it pulls from `keybase.io/codecovsecurity`, and that account now just returns `SELF-SIGNED PUBLIC KEY NOT FOUND`. So verification dies with `Can't check signature: No public key`. Codecov moved their signing key to a different keybase account and only pointed the action at it in a later release.

Bumping to v7.0.0 (the same version delta-rs runs) picks up the wrapper that reads from the working account. GPG verification stays on, no `skip_validation` or other workaround.

This should also unfreeze our coverage build cache as a side effect: the failing upload made the job fail, which skips Swatinem's cache-save step (`post-if: success()`), so the cache went stale and every coverage run was rebuilding from scratch.

## How was this change tested?

CI on this PR.

