### PR TITLE
feat: support incremental CRC reconstruction on snapshot `builder_from` API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,9 @@ This list is non-exhaustive -- when in doubt, browse the source files directly
 **Engine + table setup (from `test_utils`)**
 
 - `test_table_setup()` / `test_table_setup_mt()` -- engine + temp table path. Use the `_mt`
-  variant under `#[tokio::test(flavor = "multi_thread")]`.
+  variant under `#[tokio::test(flavor = "multi_thread")]`. Required whenever a test calls
+  `snapshot.checkpoint()`: it issues nested `block_on` calls that deadlock on a single-threaded
+  runtime / `TokioBackgroundExecutor`.
 - `engine_store_setup(name, opts)` -- returns `(store, engine, table_location)` when a test
   needs direct object-store access.
 - `setup_test_tables(...)` -- multiple pre-built tables for read/scan tests.

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -118,18 +118,15 @@ impl LogSegment {
         engine: &dyn Engine,
         in_memory_base: Option<&Arc<Crc>>,
     ) -> Option<Arc<Crc>> {
-        // The on-disk CRC is read only when strictly newer than the in-memory base, falling back
-        // to the in-memory base if that read fails.
-        let disk_crc = self.listed.latest_crc_file.as_ref();
-        let disk_is_newer =
-            disk_crc.is_some_and(|f| in_memory_base.is_none_or(|m| f.version > m.version));
-        if disk_is_newer {
-            disk_crc
-                .and_then(|f| read_crc_file_or_none(engine, f))
-                .or_else(|| in_memory_base.cloned())
-        } else {
-            in_memory_base.cloned()
-        }
+        // A failed on-disk read falls back to the in-memory base.
+        let preferred_disk_crc = self
+            .listed
+            .latest_crc_file
+            .as_ref()
+            .filter(|f| in_memory_base.is_none_or(|m| f.version > m.version));
+        preferred_disk_crc
+            .and_then(|f| read_crc_file_or_none(engine, f))
+            .or_else(|| in_memory_base.cloned())
     }
 
     /// Produce a fresh `Crc` at `self.end_version` by reverse-replaying the commits in

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -72,21 +72,31 @@ static REPLAY_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
 });
 
 impl LogSegment {
-    /// Try to build the CRC at this segment's `end_version`. Handles three cases:
-    /// - Case 1: CRC absent (1A) or read fails (1B) -> return None
-    /// - Case 2: CRC at `end_version` -> return it as-is
-    /// - Case 3: Stale CRC older than `end_version` -> advance it to `end_version` when
-    ///   `incremental_replay` permits, else fall back to normal log replay (return None)
+    /// Try to build the CRC at this segment's `end_version` from this segment's on-disk
+    /// `latest_crc_file`. See [`Self::try_build_incremental_crc_with_base`].
     pub(crate) fn try_build_incremental_crc(
         &self,
         engine: &dyn Engine,
         incremental_replay: IncrementalReplay,
     ) -> DeltaResult<Option<Arc<Crc>>> {
-        let Some(crc_file) = self.listed.latest_crc_file.as_ref() else {
-            return Ok(None); // Case 1A
-        };
-        let Some(base_crc) = read_crc_file_or_none(engine, crc_file) else {
-            return Ok(None); // Case 1B
+        self.try_build_incremental_crc_with_base(engine, None, incremental_replay)
+    }
+
+    /// Try to build the CRC at this segment's `end_version` from the best available base: the
+    /// in-memory base (e.g. the CRC the updating snapshot holds) or this segment's on-disk CRC.
+    /// Handles three cases:
+    /// - Case 1: no base CRC available -> return None
+    /// - Case 2: base CRC at `end_version` -> return it as-is
+    /// - Case 3: stale base CRC older than `end_version` -> advance it to `end_version` when
+    ///   `incremental_replay` permits, else fall back to normal log replay (return None)
+    pub(crate) fn try_build_incremental_crc_with_base(
+        &self,
+        engine: &dyn Engine,
+        in_memory_base: Option<&Arc<Crc>>,
+        incremental_replay: IncrementalReplay,
+    ) -> DeltaResult<Option<Arc<Crc>>> {
+        let Some(base_crc) = self.pick_best_base_crc(engine, in_memory_base) else {
+            return Ok(None); // Case 1 (1A: absent, 1B: read failed)
         };
         if base_crc.version == self.end_version {
             return Ok(Some(base_crc)); // Case 2
@@ -97,6 +107,26 @@ impl LogSegment {
         }
         let advanced = self.build_incremental_crc_from_base(engine, &base_crc)?;
         Ok(Some(Arc::new(advanced)))
+    }
+
+    /// Pick the higher-version of the in-memory base and this segment's on-disk CRC.
+    fn pick_best_base_crc(
+        &self,
+        engine: &dyn Engine,
+        in_memory_base: Option<&Arc<Crc>>,
+    ) -> Option<Arc<Crc>> {
+        // The on-disk CRC is read only when strictly newer than the in-memory base, falling back
+        // to the in-memory base if that read fails.
+        let disk_crc = self.listed.latest_crc_file.as_ref();
+        let disk_is_newer =
+            disk_crc.is_some_and(|f| in_memory_base.is_none_or(|m| f.version > m.version));
+        if disk_is_newer {
+            disk_crc
+                .and_then(|f| read_crc_file_or_none(engine, f))
+                .or_else(|| in_memory_base.cloned())
+        } else {
+            in_memory_base.cloned()
+        }
     }
 
     /// Produce a fresh `Crc` at `self.end_version` by reverse-replaying the commits in

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -79,10 +79,14 @@ impl LogSegment {
         engine: &dyn Engine,
         incremental_replay: IncrementalReplay,
     ) -> DeltaResult<Option<Arc<Crc>>> {
-        self.try_build_incremental_crc_with_base(engine, None, incremental_replay)
+        self.try_build_incremental_crc_with_base(
+            engine,
+            None, /* in_memory_base */
+            incremental_replay,
+        )
     }
 
-    /// Try to build the CRC at this segment's `end_version` from the best available base: the
+    /// Try to build the CRC at this segment's `end_version` from the latest available base: the
     /// in-memory base (e.g. the CRC the updating snapshot holds) or this segment's on-disk CRC.
     /// Handles three cases:
     /// - Case 1: no base CRC available -> return None
@@ -95,7 +99,7 @@ impl LogSegment {
         in_memory_base: Option<&Arc<Crc>>,
         incremental_replay: IncrementalReplay,
     ) -> DeltaResult<Option<Arc<Crc>>> {
-        let Some(base_crc) = self.pick_best_base_crc(engine, in_memory_base) else {
+        let Some(base_crc) = self.pick_latest_base_crc(engine, in_memory_base) else {
             return Ok(None); // Case 1 (1A: absent, 1B: read failed)
         };
         if base_crc.version == self.end_version {
@@ -109,8 +113,7 @@ impl LogSegment {
         Ok(Some(Arc::new(advanced)))
     }
 
-    /// Pick the higher-version of the in-memory base and this segment's on-disk CRC.
-    fn pick_best_base_crc(
+    fn pick_latest_base_crc(
         &self,
         engine: &dyn Engine,
         in_memory_base: Option<&Arc<Crc>>,

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -219,6 +219,19 @@ impl LogSegment {
                 None
             };
 
+        // A CRC describes the table state at its version, so it can never predate the checkpoint.
+        if let (Some(crc), Some(checkpoint_version)) =
+            (&listed_files.latest_crc_file, checkpoint_version)
+        {
+            require!(
+                crc.version >= checkpoint_version,
+                Error::internal_error(format!(
+                    "CRC file version {} is older than checkpoint version {checkpoint_version}",
+                    crc.version
+                ))
+            );
+        }
+
         validate_checkpoint_commit_gap(checkpoint_version, &listed_files.ascending_commit_files)?;
         let effective_version = validate_end_version(
             &listed_files.ascending_commit_files,

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -43,9 +43,10 @@ pub struct SnapshotBuilder {
     incremental_replay: IncrementalReplay,
 }
 
-/// Controls whether kernel replays commits to advance a stale on-disk CRC to the target snapshot
-/// version on load. A CRC already at the target version is always used regardless of this
-/// setting; this only bounds the cost of advancing a *stale* CRC.
+/// Controls whether kernel replays commits to advance a stale base CRC (the existing snapshot's
+/// in-memory CRC, or an on-disk CRC) to the target snapshot version on load. A CRC already at the
+/// target version is always used regardless of this setting; this only bounds the cost of
+/// advancing a *stale* CRC.
 ///
 /// A resolved CRC gives the snapshot precomputed file statistics (file count and sizes, useful
 /// for query optimization and for writers producing a post-commit CRC) along with domain metadata

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -160,17 +160,13 @@ impl SnapshotBuilder {
         self
     }
 
-    /// Bound how many commits kernel will replay to advance a stale on-disk CRC to the target
-    /// version. See [`IncrementalReplay`]. Defaults to [`IncrementalReplay::Disabled`].
+    /// Bound how many commits kernel will replay to advance a stale CRC to the target version.
+    /// See [`IncrementalReplay`]. Defaults to [`IncrementalReplay::Disabled`].
     ///
     /// Writers should set this to [`IncrementalReplay::Unlimited`] for faster writes, as should
     /// readers that always want table-level file statistics for query optimization.
     ///
-    /// This setting applies only to builds from a table root; it does not carry into incremental
-    /// updates derived from the resulting snapshot. [`Snapshot::builder_from`] does not yet advance
-    /// stale CRCs regardless of this value (see #2674).
-    ///
-    /// [`Snapshot::builder_from`]: crate::Snapshot::builder_from
+    /// Applies to both fresh and incremental builds.
     pub fn with_incremental_crc_replay(mut self, mode: IncrementalReplay) -> Self {
         self.incremental_replay = mode;
         self
@@ -264,6 +260,7 @@ impl SnapshotBuilder {
                         engine,
                         effective_version,
                         operation_id,
+                        incremental_replay,
                     )
                 })
         };

--- a/kernel/src/snapshot/incremental.rs
+++ b/kernel/src/snapshot/incremental.rs
@@ -8,7 +8,6 @@ use std::sync::Arc;
 use tracing::instrument;
 
 use super::{IncrementalReplay, Snapshot};
-use crate::crc::{read_crc_file_or_none, Crc};
 use crate::log_segment::LogSegment;
 use crate::log_segment_files::LogSegmentFiles;
 use crate::metrics::MetricId;
@@ -89,6 +88,7 @@ impl Snapshot {
         engine: &dyn Engine,
         target_version: impl Into<Option<Version>>,
         operation_id: MetricId,
+        incremental_replay: IncrementalReplay,
     ) -> DeltaResult<Arc<Self>> {
         let existing_log_segment = &existing_snapshot.log_segment;
         let existing_snapshot_version = existing_snapshot.version();
@@ -173,15 +173,15 @@ impl Snapshot {
             if new_checkpoint_version > existing_snapshot_version {
                 // Case D.1: checkpoint ahead of existing snapshot. Commits between
                 // existing_snapshot_version+1 and new_checkpoint_version were filtered out
-                // of the listing, so a full rebuild is required. The new segment's CRC (if
-                // any) is read fresh; the existing snapshot's CRC is older than the new
-                // checkpoint and cannot apply.
+                // of the listing, so a full rebuild is required. The existing snapshot's CRC
+                // is older than the new checkpoint and cannot apply, but a fresh on-disk CRC
+                // at or above the new checkpoint still advances per `incremental_replay`.
                 let snapshot = Self::try_new_from_log_segment(
                     existing_snapshot.table_root().clone(),
                     new_log_segment,
                     engine,
                     operation_id,
-                    IncrementalReplay::Disabled,
+                    incremental_replay,
                 );
                 return Ok(Arc::new(snapshot?));
             }
@@ -233,14 +233,8 @@ impl Snapshot {
             .ascending_compaction_files
             .retain(|log_path| existing_snapshot_version < log_path.version);
 
-        // `crc_file` is the CRC for the combined segment; `resolved_crc` is the read CRC
-        // (`None` when only a stale CRC applies).
-        let (crc_file, resolved_crc) = Self::resolve_crc(
-            &new_log_segment,
-            existing_log_segment,
-            existing_snapshot.crc(),
-            engine,
-        );
+        // The CRC file the combined segment carries on disk.
+        let crc_file = Self::resolve_crc_file(&new_log_segment, existing_log_segment);
 
         // Replay only the new commits (> existing_snapshot_version) for P&M, excluding the
         // checkpoint. The existing snapshot supplies the P&M baseline.
@@ -309,14 +303,20 @@ impl Snapshot {
             new_checkpoint_schema,
         )?;
 
+        // Advance the best available base (the existing snapshot's in-memory CRC, or a newer
+        // on-disk CRC the combined segment carries) to the new end version, subject to
+        // `incremental_replay`.
+        let crc = combined_log_segment.try_build_incremental_crc_with_base(
+            engine,
+            existing_snapshot.crc(),
+            incremental_replay,
+        )?;
+
         tracing::Span::current().record("version", table_configuration.version());
         Ok(Arc::new(Snapshot::new_with_crc(
             combined_log_segment,
             table_configuration,
-            // The snapshot holds a CRC only when it is at the new end version.
-            // TODO(#2674): advance the existing snapshot's CRC over the new tail commits instead
-            //              of dropping a stale one and falling back to full log replay.
-            resolved_crc.filter(|c| c.version == new_end_version),
+            crc,
         )?))
     }
 
@@ -324,26 +324,15 @@ impl Snapshot {
     // Helpers
     // ============================================================================
 
-    /// Determine the CRC file for the combined segment and eagerly read the CRC for an
-    /// incremental snapshot update.
+    /// Determine the on-disk CRC file the combined segment should carry.
     ///
-    /// The CRC file prefers the new segment's CRC; it falls back to the existing segment's CRC
-    /// if and only if its version is >= the new segment's checkpoint version. This preserves
-    /// the [`LogSegmentFiles`] invariant `crc.version >= checkpoint.version`.
-    ///
-    /// The returned `Crc` is read when the resolved CRC file is newer than
-    /// `existing_snapshot_version` (currently unused; see #2674) or at the new end version (which
-    /// backs the new snapshot). An older CRC can do neither, so it is left unread and only
-    /// contributes its path to the combined segment. When the resolved CRC is the one
-    /// `existing_crc` already holds, it is reused instead of re-read.
-    fn resolve_crc(
+    /// Prefers the new segment's CRC; falls back to the existing segment's CRC if and only if
+    /// its version is >= the new segment's checkpoint version. This preserves the
+    /// [`LogSegmentFiles`] invariant `crc.version >= checkpoint.version`.
+    fn resolve_crc_file(
         new_log_segment: &LogSegment,
         existing_log_segment: &LogSegment,
-        existing_crc: Option<&Arc<Crc>>,
-        engine: &dyn Engine,
-    ) -> (Option<ParsedLogPath>, Option<Arc<Crc>>) {
-        let existing_snapshot_version = existing_log_segment.end_version;
-        let new_crc_file = new_log_segment.listed.latest_crc_file.clone();
+    ) -> Option<ParsedLogPath> {
         let crc_satisfies_new_ckpt = |crc: &ParsedLogPath| {
             new_log_segment
                 .checkpoint_version
@@ -354,21 +343,11 @@ impl Snapshot {
             .latest_crc_file
             .clone()
             .filter(crc_satisfies_new_ckpt);
-        let crc_file = new_crc_file.or(existing_crc_file);
-
-        let crc = crc_file
-            .as_ref()
-            .filter(|f| {
-                f.version > existing_snapshot_version || f.version == new_log_segment.end_version
-            })
-            .and_then(|resolved| {
-                // Reuse the existing snapshot's CRC on a same-version refresh (Case D.2).
-                existing_crc
-                    .filter(|c| c.version == resolved.version)
-                    .map(Arc::clone)
-                    .or_else(|| read_crc_file_or_none(engine, resolved))
-            });
-        (crc_file, crc)
+        new_log_segment
+            .listed
+            .latest_crc_file
+            .clone()
+            .or(existing_crc_file)
     }
 
     /// Filters `files` to only those with version above `checkpoint_version`, or clones all if
@@ -550,6 +529,7 @@ mod tests {
             &engine,
             None,
             MetricId::default(),
+            IncrementalReplay::Disabled,
         )?;
         assert_eq!(result, base_snapshot);
 
@@ -626,6 +606,7 @@ mod tests {
             &engine,
             Some(2),
             MetricId::default(),
+            IncrementalReplay::Disabled,
         )?;
 
         // Latest commit should now be version 2
@@ -683,6 +664,7 @@ mod tests {
             &engine,
             Some(1),
             MetricId::default(),
+            IncrementalReplay::Disabled,
         )?;
         assert!(Arc::ptr_eq(&same_version, &base_snapshot));
 
@@ -693,6 +675,7 @@ mod tests {
             &engine,
             Some(0),
             MetricId::default(),
+            IncrementalReplay::Disabled,
         );
         assert!(matches!(
             older_version,
@@ -1106,27 +1089,24 @@ mod tests {
     // Tests: stale-CRC resolution on the incremental path
     // ============================================================================
 
-    // `resolve_crc` when the new listing discovers a checkpoint *at or below* the existing
-    // snapshot version must correctly decide which CRC file the combined segment carries, and
-    // whether the resolved CRC is at the snapshot version (and thus stored on the snapshot).
+    // `resolve_crc_file` when the new listing discovers a checkpoint *at or below* the existing
+    // snapshot version must correctly decide which CRC file the combined segment carries on disk.
     // Each case below sets up commits 0-3, writes an existing CRC, builds snapshot_v3, writes
     // a checkpoint, optionally writes a new CRC, then runs the incremental update and checks
-    // the outcome. (The checkpoint-*ahead* path is covered separately by
+    // the segment's `latest_crc_file`. (The checkpoint-*ahead* path is covered separately by
     // `test_incremental_snapshot_multi_hop_replay_then_rebuild_drops_stale_crc`.)
     //
-    // The snapshot ends at version 3, so `crc()` is `Some` only when the resolved CRC file is
-    // at version 3; an older resolved CRC still appears as the segment's `latest_crc_file`.
+    // The update lands at the same version (v3), so the existing snapshot's in-memory crc@v3
+    // always carries forward; only the on-disk `latest_crc_file` differs per case.
     //
     // Cases:
     //   keep_existing:    existing crc@v2 stays when new ckpt@v1 is below it (invariant OK)
-    //                     and no newer CRC was listed; segment carries crc@v2 but it is stale
-    //                     relative to v3, so `crc()` is None.
-    //   refresh_to_newer: existing crc@v2 is superseded by a newly-listed crc@v3; the new CRC
-    //                     is at v3, so `crc()` is Some(v3).
+    //                     and no newer CRC was listed; segment carries crc@v2.
+    //   refresh_to_newer: existing crc@v2 is superseded by a newly-listed crc@v3.
     //   crc_equals_ckpt:  existing crc@v2 and new ckpt@v2 sit at the same version; sanity
     //                     coverage for the invariant boundary `crc.version >= ckpt.version`.
     //   drop_below_ckpt:  existing crc@v1 would violate the LogSegmentFiles invariant with
-    //                     new ckpt@v2 (1 < 2), so it is filtered out; result has no CRC.
+    //                     new ckpt@v2 (1 < 2), so it is filtered out; segment has no CRC file.
     #[rstest]
     #[case::keep_existing(2, 1, None, Some(2))]
     #[case::refresh_to_newer(2, 1, Some(3), Some(3))]
@@ -1199,17 +1179,56 @@ mod tests {
                 .map(|f| f.version),
             expected_crc_file_v
         );
-        // The snapshot stores the CRC only when the resolved CRC file is at the snapshot
-        // version (3); an older resolved CRC is carried in the segment but not stored.
+        assert_eq!(updated.crc().map(|c| c.version), Some(3));
+
+        Ok(())
+    }
+
+    #[rstest]
+    #[case::disabled(IncrementalReplay::Disabled, None)]
+    #[case::unlimited(IncrementalReplay::Unlimited, Some(5))]
+    #[case::budget_exact(IncrementalReplay::UpToCommits(2), Some(5))]
+    #[case::budget_more_than_enough(IncrementalReplay::UpToCommits(5), Some(5))]
+    #[case::budget_too_small(IncrementalReplay::UpToCommits(1), None)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_incremental_update_advances_in_memory_crc_within_budget(
+        #[case] mode: IncrementalReplay,
+        #[case] expected_crc_v: Option<u64>,
+    ) -> DeltaResult<()> {
+        let ctx = setup_incremental_snapshot_test()?;
+        setup_test_table_with_commits(ctx.url.as_str(), &ctx.store, 6).await?;
+        ctx.store
+            .put(
+                &delta_path_for_version(1, "crc"),
+                make_test_crc_json(200, 2).to_string().into(),
+            )
+            .await?;
+
+        let snapshot_a = Snapshot::builder_for(ctx.url.as_str())
+            .at_version(3)
+            .with_incremental_crc_replay(IncrementalReplay::Unlimited)
+            .build(ctx.engine.as_ref())?;
+        assert_eq!(snapshot_a.crc().map(|c| c.version), Some(3));
+
+        let updated = Snapshot::builder_from(snapshot_a)
+            .with_incremental_crc_replay(mode)
+            .build(ctx.engine.as_ref())?;
+        assert_eq!(updated.version(), 5);
+        assert_eq!(updated.crc().map(|c| c.version), expected_crc_v);
         assert_eq!(
-            updated.crc().map(|c| c.version),
-            expected_crc_file_v.filter(|&v| v == updated.version())
+            updated
+                .log_segment
+                .listed
+                .latest_crc_file
+                .as_ref()
+                .map(|f| f.version),
+            Some(1)
         );
 
         Ok(())
     }
 
-    // Stronger regression for the `resolve_crc` invariant filter: set up a metadata change
+    // Stronger regression for the `resolve_crc_file` invariant filter: set up a metadata change
     // at the checkpoint version so that a stale inherited CRC would produce wrong
     // Metadata, not just wrong bookkeeping. Without the filter, the incremental update
     // would return Metadata from commit 0 (via Case 2(b) fallback on a below-checkpoint
@@ -1494,8 +1513,8 @@ mod tests {
 
         // Test CRC handling during incremental snapshot update (v0 -> v1).
         // The new log listing starts at v1, so the new log segment doesn't find 0.crc.
-        // a) Only 0.crc exists: resolve_crc falls back to old segment's 0.crc.
-        // b) Both 0.crc and 1.crc exist: resolve_crc picks up 1.crc.
+        // a) Only 0.crc exists: resolve_crc_file falls back to old segment's 0.crc.
+        // b) Both 0.crc and 1.crc exist: resolve_crc_file picks up 1.crc.
         let crc = json!({
             "table_size_bytes": 100,
             "num_files": 1,
@@ -1529,7 +1548,7 @@ mod tests {
             0
         );
 
-        // b) both 0.crc and 1.crc exist -- resolve_crc picks up 1.crc
+        // b) both 0.crc and 1.crc exist; resolve_crc_file picks up 1.crc
         let path = delta_path_for_version(1, "crc");
         let crc = json!({
             "table_size_bytes": 100,

--- a/kernel/src/snapshot/incremental.rs
+++ b/kernel/src/snapshot/incremental.rs
@@ -313,7 +313,7 @@ impl Snapshot {
             }
             None => {
                 // Incremental CRC replay wasn't applicable or failed (note: we have *not* yet
-                // scanned any log files) Perform normal P & M replay.
+                // scanned any log files). Perform normal P & M replay.
                 combined_log_segment
                     .segment_after_version(existing_snapshot_version)
                     .read_protocol_metadata_opt(engine)?
@@ -341,8 +341,9 @@ impl Snapshot {
     /// Determine the on-disk CRC file the combined segment should carry.
     ///
     /// Prefers the new segment's CRC; falls back to the existing segment's CRC if and only if
-    /// its version is >= the new segment's checkpoint version. This preserves the
-    /// [`LogSegmentFiles`] invariant `crc.version >= checkpoint.version`.
+    /// its version is >= the new segment's checkpoint version, so the fallback never violates the
+    /// [`LogSegmentFiles`] invariant `crc.version >= checkpoint.version` (enforced in
+    /// [`LogSegment::try_new`]).
     fn resolve_crc_file(
         new_log_segment: &LogSegment,
         existing_log_segment: &LogSegment,
@@ -1245,9 +1246,9 @@ mod tests {
     // Stronger regression for the `resolve_crc_file` invariant filter: set up a metadata change
     // at the checkpoint version so that a stale inherited CRC would produce wrong
     // Metadata, not just wrong bookkeeping. Without the filter, the incremental update
-    // would return Metadata from commit 0 (via Case 2(b) fallback on a below-checkpoint
-    // CRC); the fresh rebuild would return Metadata from commit 2. `compare_snapshots`
-    // catches that on `table_configuration`.
+    // would inherit the below-checkpoint CRC and return Metadata from commit 0; the fresh
+    // rebuild would return Metadata from commit 2. `compare_snapshots` catches that on
+    // `table_configuration`.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_incremental_snapshot_drops_stale_crc_preserves_correct_metadata(
     ) -> DeltaResult<()> {
@@ -1312,9 +1313,8 @@ mod tests {
             .checkpoint(ctx.engine.as_ref(), None)?;
 
         // Incremental update. With the filter: CRC@v1 dropped, log replay via checkpoint@v2
-        // returns the correct new metadata. Without the filter: Case 2(b) fallback returns
-        // CRC@v1's stale (empty) configuration, and compare_snapshots fails on
-        // table_configuration.
+        // returns the correct new metadata. Without the filter: the inherited CRC@v1 returns
+        // its stale (empty) configuration, and compare_snapshots fails on table_configuration.
         let updated = Snapshot::builder_from(snapshot_v3).build(ctx.engine.as_ref())?;
         let fresh = Snapshot::builder_for(table_root).build(ctx.engine.as_ref())?;
         compare_snapshots(&updated, &fresh);
@@ -1401,7 +1401,7 @@ mod tests {
 
         // Incremental update. The pruned replay on commits > 3 is empty. With the stale-
         // CRC skip, the replay returns (None, None) and `TableConfiguration::try_new_from`
-        // preserves existing P&M. Without the skip, Case 2(b) would load CRC@v1's stale
+        // preserves existing P&M. Without the skip, the inherited CRC@v1 would load its stale
         // metadata and overwrite the existing (correct) v2 configuration.
         let updated = Snapshot::builder_from(snapshot_v3).build(ctx.engine.as_ref())?;
         let fresh = Snapshot::builder_for(table_root).build(ctx.engine.as_ref())?;

--- a/kernel/src/snapshot/incremental.rs
+++ b/kernel/src/snapshot/incremental.rs
@@ -236,18 +236,6 @@ impl Snapshot {
         // The CRC file the combined segment carries on disk.
         let crc_file = Self::resolve_crc_file(&new_log_segment, existing_log_segment);
 
-        // Replay only the new commits (> existing_snapshot_version) for P&M, excluding the
-        // checkpoint. The existing snapshot supplies the P&M baseline.
-        let (new_metadata, new_protocol) = new_log_segment
-            .segment_after_version(existing_snapshot_version)
-            .read_protocol_metadata_opt(engine)?;
-        let table_configuration = TableConfiguration::try_new_from(
-            existing_snapshot.table_configuration(),
-            new_metadata,
-            new_protocol,
-            new_log_segment.end_version,
-        )?;
-
         // Combine existing and new log segments. When the new listing found a checkpoint at or
         // below the existing snapshot version, trim existing commits and compaction files
         // already covered by it; otherwise keep all existing files.
@@ -303,13 +291,39 @@ impl Snapshot {
             new_checkpoint_schema,
         )?;
 
-        // Advance the best available base (the existing snapshot's in-memory CRC, or a newer
+        // Advance the latest available base (the existing snapshot's in-memory CRC, or a newer
         // on-disk CRC the combined segment carries) to the new end version, subject to
         // `incremental_replay`.
         let crc = combined_log_segment.try_build_incremental_crc_with_base(
             engine,
             existing_snapshot.crc(),
             incremental_replay,
+        )?;
+
+        let existing_table_config = existing_snapshot.table_configuration();
+        let (new_metadata, new_protocol) = match &crc {
+            Some(crc) => {
+                // If we were able to build a new CRC, then re-use it for TableConfiguration
+                // creation.
+                let new_metadata = (crc.metadata != *existing_table_config.metadata())
+                    .then(|| crc.metadata.clone());
+                let new_protocol = (crc.protocol != *existing_table_config.protocol())
+                    .then(|| crc.protocol.clone());
+                (new_metadata, new_protocol)
+            }
+            None => {
+                // Incremental CRC replay wasn't applicable or failed (note: we have *not* yet
+                // scanned any log files) Perform normal P & M replay.
+                combined_log_segment
+                    .segment_after_version(existing_snapshot_version)
+                    .read_protocol_metadata_opt(engine)?
+            }
+        };
+        let table_configuration = TableConfiguration::try_new_from(
+            existing_table_config,
+            new_metadata,
+            new_protocol,
+            new_end_version,
         )?;
 
         tracing::Span::current().record("version", table_configuration.version());

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -108,6 +108,89 @@ async fn test_get_file_stats_stale_crc_advances_via_safe_commit_serves_stats() -
     Ok(())
 }
 
+// Tests incremental CRC replay when building a new snapshot from a base snapshot.
+// Base snapshot has a CRC at v3.
+#[rstest]
+// no checkpoint, no newer CRC -> advance the base snapshot's crc@v3.
+#[case::in_memory_base(None, None, Some(5))]
+// a newer crc@v4 lands on disk and beats the base snapshot's crc@v3 -> advance crc@v4.
+#[case::newer_disk_crc(None, Some(4), Some(5))]
+// a checkpoint at v2 (below the base snapshot version) appears; the base snapshot's crc@v3 still
+// applies (a CRC may sit above its checkpoint), so advance it.
+#[case::checkpoint_before_base_snap_reuses_crc(Some(2), None, Some(5))]
+// a checkpoint at v4 (above the base snapshot version) forces a rebuild; the base snapshot's
+// crc@v3 is below it and dropped, so the on-disk crc@v4 advances instead.
+#[case::checkpoint_after_base_snap_with_crc(Some(4), Some(4), Some(5))]
+// a checkpoint at v4 (above the base snapshot version) forces a rebuild with no CRC at or above it
+// -> no stats.
+#[case::checkpoint_after_base_snap_no_crc(Some(4), None, None)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_incremental_update_advances_crc_with_real_file_stats(
+    #[case] checkpoint_version: Option<Version>,
+    #[case] crc_version: Option<Version>,
+    #[case] expected_num_files: Option<i64>,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+
+    // ===== GIVEN: v0 (0 files, crc on disk), then five WRITE inserts (one file each) to v5 =====
+    let committed = create_table_and_commit(&table_path, engine.as_ref())?;
+    let mut snapshot = committed.post_commit_snapshot().unwrap().clone();
+    snapshot.write_checksum(engine.as_ref())?;
+    for i in 1..=5i32 {
+        snapshot = insert_data(snapshot, &engine, vec![Arc::new(Int32Array::from(vec![i]))])
+            .await?
+            .unwrap_committed()
+            .post_commit_snapshot()
+            .unwrap()
+            .clone();
+    }
+
+    // ===== AND: load the base snapshot from disk at v3 (will have in-memory CRC) =====
+    let base_snapshot = Snapshot::builder_for(&table_path)
+        .at_version(3)
+        .with_incremental_crc_replay(IncrementalReplay::Unlimited)
+        .build(engine.as_ref())?;
+    assert_eq!(base_snapshot.crc().unwrap().version, 3);
+
+    // ===== AND: conditionally write a CRC and/or checkpoint =====
+    if let Some(v) = crc_version {
+        Snapshot::builder_for(&table_path)
+            .at_version(v)
+            .with_incremental_crc_replay(IncrementalReplay::Unlimited)
+            .build(engine.as_ref())?
+            .write_checksum(engine.as_ref())?;
+    }
+    if let Some(v) = checkpoint_version {
+        Snapshot::builder_for(&table_path)
+            .at_version(v)
+            .build(engine.as_ref())?
+            .checkpoint(engine.as_ref(), None)?;
+    }
+
+    // ===== WHEN: incrementally update the base snapshot to the latest version =====
+    let updated_snapshot = Snapshot::builder_from(base_snapshot)
+        .with_incremental_crc_replay(IncrementalReplay::Unlimited)
+        .build(engine.as_ref())?;
+
+    // ===== THEN: an in-memory CRC is loaded exactly when expected; when loaded it sits at the
+    //             snapshot version and reflects all five files =====
+    assert_eq!(updated_snapshot.version(), 5);
+    match expected_num_files {
+        Some(num_files) => {
+            let crc = updated_snapshot.crc().expect("expected an in-memory CRC");
+            assert_eq!(crc.version, updated_snapshot.version());
+            let stats = updated_snapshot.get_file_stats_if_present().unwrap();
+            assert_eq!(stats.num_files(), num_files);
+        }
+        None => {
+            assert!(updated_snapshot.crc().is_none());
+            assert!(updated_snapshot.get_file_stats_if_present().is_none());
+        }
+    }
+
+    Ok(())
+}
+
 // An unreadable CRC at the snapshot version must not break loading: the snapshot falls back
 // to log replay for P&M and exposes no CRC.
 #[tokio::test]
@@ -575,8 +658,8 @@ async fn test_incremental_snapshot_preserves_loaded_crc() -> DeltaResult<()> {
 }
 
 // Incremental update where only the old segment has a CRC file (no new CRC written).
-// The old segment's CRC file is preserved on the combined segment, but since it is at v0
-// while the snapshot is at v1, it is not stored on the snapshot.
+// The old segment's CRC file is preserved on the combined segment, but with the default
+// (disabled) replay budget the v0 CRC is not advanced to v1, so the snapshot carries no CRC.
 #[tokio::test]
 async fn test_incremental_snapshot_old_crc_no_new_crc() -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
@@ -613,10 +696,11 @@ async fn test_incremental_snapshot_old_crc_no_new_crc() -> DeltaResult<()> {
     let incremental_v1 = Snapshot::builder_from(fresh_v0).build(engine.as_ref())?;
     assert_eq!(incremental_v1.version(), 1);
 
-    // The CRC is at v0, not v1, so it is not stored on the v1 snapshot.
+    // builder_from defaults to IncrementalReplay::Disabled, so the v0 CRC is not advanced to
+    // v1 and the snapshot carries no CRC. (With Unlimited it would advance to v1.)
     assert!(
         incremental_v1.crc().is_none(),
-        "CRC at v0 should not be stored on the v1 snapshot (version mismatch)"
+        "CRC at v0 should not be stored on the v1 snapshot (replay disabled)"
     );
 
     Ok(())


### PR DESCRIPTION
## What changes are proposed in this pull request?

Allows incremental snapshot builders (given a Snapshot A, try and construct a newer Snapshot B) to be able to take advantage of incremental CRC reconstruction.

This covers several cases:

- Imagine we had a Snapshot A at v10 with some in-memory CRC
  - It doesn't matter if there was a 10.crc or a 5.crc and Snapshot A derived v10.crc via incremental CRC replay
- Then a connector wants to build a new Snapshot from A
- **Case 1**: That connector sees: 11-20.json -> it builds a Snapshot B at v20 with in-memory CRC using the base from A
- **Case 2**: That connector sees 11-20.json with 15.crc -> it builders a Snapshot B at v20 with in-memory CRC using the 15.crc base

Resolves #2674.

## Expected Performance Impact

Test Setup: Write to a UC managed table always using a previous Snapshot at N-4 as the "build_from" Snapshot, which **did** have a CRC. 100 parquet files per commit.

| Phase | incremental (Unlimited) | master (Disabled) | incremental / master |
|---|---|---|---|
| snapshot build (build_from) | 60.8 ms | 54.5 ms | 1.12x |
| txn build (.transaction()) | 0.0136 ms | 78.0 ms | ~5,700x faster |
| txn commit (.commit()) | 25.8 ms | 77.4 ms | 0.33x (3x faster) |
| per-commit total | ~87 ms | ~210 ms | ~2.4x faster |

## How was this change tested?

New UTs.
