### PR TITLE
feat: add a public history_manager::get_earliest_commit

### DIFF
--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -770,6 +770,17 @@ fn get_earliest_recreatable_commit(
     }))
 }
 
+/// Select which commit type to return in the get_earliest_commit query.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommitType {
+    /// A file-system commit or a catalog commit present in the table's _delta_log/ .
+    /// The commit does not gurantee that the table can be reconstructed from the commit's version.
+    Published,
+    /// A commit that table can be reconstructed from that version and replay forward to the latest
+    /// version.
+    Recreatable,
+}
+
 /// Returns the earliest table version available on the file system at `log_root`. The returned
 /// version is not guaranteed to exist by the time the caller acts on it: a concurrent log-cleanup
 /// operation may delete the underlying file.
@@ -796,12 +807,18 @@ pub fn get_earliest_commit(
     engine: &dyn Engine,
     log_root: &Url,
     earliest_ratified_commit_version: Option<Version>,
-    must_be_recreatable: bool,
+    commit_type: CommitType,
 ) -> DeltaResult<Version> {
-    if must_be_recreatable {
-        get_earliest_recreatable_commit(engine, log_root, earliest_ratified_commit_version)
-    } else {
-        get_earliest_published_commit_version(engine, log_root, earliest_ratified_commit_version)
+    match commit_type {
+        CommitType::Published => get_earliest_published_commit_version(
+            engine,
+            log_root,
+            earliest_ratified_commit_version,
+        ),
+
+        CommitType::Recreatable => {
+            get_earliest_recreatable_commit(engine, log_root, earliest_ratified_commit_version)
+        }
     }
 }
 

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -770,14 +770,14 @@ fn get_earliest_recreatable_commit(
     }))
 }
 
-/// Select which commit type to return in the get_earliest_commit query.
+/// Selects which commit the [`get_earliest_commit`] query returns.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CommitType {
-    /// A file-system commit or a catalog commit present in the table's _delta_log/ .
-    /// The commit does not gurantee that the table can be reconstructed from the commit's version.
+pub enum HistoryCommitType {
+    /// A filesystem or catalog commit present in the table's `_delta_log/`. Its presence does not
+    /// guarantee that the table can be reconstructed at that commit's version.
     Published,
-    /// A commit that table can be reconstructed from that version and replay forward to the latest
-    /// version.
+    /// A commit whose version the table state can be fully reconstructed at and replayed forward
+    /// from to the latest version.
     Recreatable,
 }
 
@@ -790,16 +790,18 @@ pub enum CommitType {
 /// - `log_root`: URL of the table's `_delta_log/` directory (must end with `/`).
 /// - `earliest_ratified_commit_version`: For catalog-managed tables, the earliest version the
 ///   catalog has ratified a commit at. Pass `None` for filesystem-only tables.
-/// - `must_be_recreatable`: When `true`, return the earliest version whose state can be fully
-///   reconstructed (commit 0 or the earliest complete checkpoint). When `false`, return the
-///   lowest-numbered published commit.
+/// - `commit_type`: selects the query. [`HistoryCommitType::Published`] returns the lowest-numbered
+///   published commit; [`HistoryCommitType::Recreatable`] returns the earliest version whose state
+///   can be fully reconstructed (commit 0 or the earliest complete checkpoint).
 ///
 /// # Errors
 /// - Propagates any error from listing the log directory.
-/// - [`LogHistoryError::NoCommitsFound`] when the log directory contains no commits.
-/// - [`LogHistoryError::NoRecreatableCommit`] when `must_be_recreatable` is `true`, commits exist,
-///   but neither `00...00.json` nor a checkpoint anchoring the smallest commit is present.
-/// - [`DeltaError::Generic`] when there is no published filesystem commit and
+/// - [`LogHistoryError::NoCommitsFound`] when the log directory contains no commits and
+///   `earliest_ratified_commit_version` is not `Some(0)`.
+/// - [`LogHistoryError::NoRecreatableCommit`] when `commit_type` is
+///   [`HistoryCommitType::Recreatable`], commits exist, but neither `00...00.json` nor a checkpoint
+///   anchoring the smallest commit is present.
+/// - [`DeltaError::Generic`] when the listing yields no commits and
 ///   `earliest_ratified_commit_version` is `Some(0)`, flagging a broken catalog-managed invariant
 ///   (ratified commit 0 with no published filesystem commit).
 #[tracing::instrument(skip(engine), err, ret)]
@@ -807,16 +809,16 @@ pub fn get_earliest_commit(
     engine: &dyn Engine,
     log_root: &Url,
     earliest_ratified_commit_version: Option<Version>,
-    commit_type: CommitType,
+    commit_type: HistoryCommitType,
 ) -> DeltaResult<Version> {
     match commit_type {
-        CommitType::Published => get_earliest_published_commit_version(
+        HistoryCommitType::Published => get_earliest_published_commit_version(
             engine,
             log_root,
             earliest_ratified_commit_version,
         ),
 
-        CommitType::Recreatable => {
+        HistoryCommitType::Recreatable => {
             get_earliest_recreatable_commit(engine, log_root, earliest_ratified_commit_version)
         }
     }

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -645,10 +645,7 @@ pub fn timestamp_range_to_versions(
 ///   before the catalog exposes the table. Otherwise a filesystem-only client could list an empty
 ///   `_delta_log/` and "create" a table at the same location. An empty listing here therefore
 ///   indicates a broken invariant rather than a normal missing version.
-// TODO: remove the `#[allow(unused)]` once the public earliest-commit-version API that calls
-// this helper lands.
-#[allow(unused)]
-#[tracing::instrument(skip(engine), ret)]
+#[tracing::instrument(skip(engine), ret, err)]
 fn get_earliest_published_commit_version(
     engine: &dyn Engine,
     log_root: &Url,
@@ -692,9 +689,6 @@ fn get_earliest_published_commit_version(
 /// broken CCv2 invariant (ratified commit 0 with no published filesystem commit).
 /// - [`LogHistoryError::NoRecreatableCommit`] if commits exist but neither
 /// `00...00.json` nor a complete checkpoint that anchors the smallest commit is present.
-// TODO: remove the `#[allow(unused)]` once the public earliest-commit-version API that calls
-// this helper lands.
-#[allow(unused)]
 #[tracing::instrument(skip(engine), err, ret)]
 fn get_earliest_recreatable_commit(
     engine: &dyn Engine,
@@ -797,6 +791,7 @@ fn get_earliest_recreatable_commit(
 /// - [`DeltaError::Generic`] when there is no published filesystem commit and
 ///   `earliest_ratified_commit_version` is `Some(0)`, flagging a broken catalog-managed invariant
 ///   (ratified commit 0 with no published filesystem commit).
+#[tracing::instrument(skip(engine), err, ret)]
 pub fn get_earliest_commit(
     engine: &dyn Engine,
     log_root: &Url,

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -776,6 +776,40 @@ fn get_earliest_recreatable_commit(
     }))
 }
 
+/// Returns the earliest table version available on the file system at `log_root`. The returned
+/// version is not guaranteed to exist by the time the caller acts on it: a concurrent log-cleanup
+/// operation may delete the underlying file.
+///
+/// # Parameters
+/// - `engine`: kernel engine used to list `log_root`.
+/// - `log_root`: URL of the table's `_delta_log/` directory (must end with `/`).
+/// - `earliest_ratified_commit_version`: For catalog-managed tables, the earliest version the
+///   catalog has ratified a commit at. Pass `None` for filesystem-only tables.
+/// - `must_be_recreatable`: When `true`, return the earliest version whose state can be fully
+///   reconstructed (commit 0 or the earliest complete checkpoint). When `false`, return the
+///   lowest-numbered published commit.
+///
+/// # Errors
+/// - Propagates any error from listing the log directory.
+/// - [`LogHistoryError::NoCommitsFound`] when the log directory contains no commits.
+/// - [`LogHistoryError::NoRecreatableCommit`] when `must_be_recreatable` is `true`, commits exist,
+///   but neither `00...00.json` nor a checkpoint anchoring the smallest commit is present.
+/// - [`DeltaError::Generic`] when there is no published filesystem commit and
+///   `earliest_ratified_commit_version` is `Some(0)`, flagging a broken catalog-managed invariant
+///   (ratified commit 0 with no published filesystem commit).
+pub fn get_earliest_commit(
+    engine: &dyn Engine,
+    log_root: &Url,
+    earliest_ratified_commit_version: Option<Version>,
+    must_be_recreatable: bool,
+) -> DeltaResult<Version> {
+    if must_be_recreatable {
+        get_earliest_recreatable_commit(engine, log_root, earliest_ratified_commit_version)
+    } else {
+        get_earliest_published_commit_version(engine, log_root, earliest_ratified_commit_version)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;

--- a/kernel/tests/integration/log/history_manager.rs
+++ b/kernel/tests/integration/log/history_manager.rs
@@ -5,7 +5,12 @@ use std::ops::RangeInclusive;
 use delta_kernel::engine::default::DefaultEngineBuilder;
 use delta_kernel::history_manager::{get_earliest_commit, HistoryCommitType};
 use delta_kernel::object_store::path::Path;
-use delta_kernel::object_store::{ObjectStore, ObjectStoreExt as _};
+use delta_kernel::object_store::ObjectStore;
+// `ObjectStoreExt` is needed for `store.get()` etc. in arrow-58 mode where these methods moved
+// off the `ObjectStore` trait. In arrow-57 mode the compat shim makes the import a no-op, so
+// silence the resulting unused-import warning.
+#[allow(unused_imports)]
+use delta_kernel::object_store::ObjectStoreExt as _;
 use delta_kernel::Version;
 use rstest::rstest;
 use test_utils::table_builder::{LogState, TestTableBuilder};

--- a/kernel/tests/integration/log/history_manager.rs
+++ b/kernel/tests/integration/log/history_manager.rs
@@ -1,98 +1,50 @@
-//! Integration tests for the public `history_manager` earliest-commit API.
-//!
-//! These exercise `get_earliest_commit` end-to-end against real kernel-written logs (commit
-//! JSON written via the transaction path, plus a real checkpoint parquet written by
-//! `Snapshot::checkpoint`), simulating log cleanup by deleting commit files on disk. The
-//! internal helpers it dispatches to are unit-tested exhaustively against synthetic listings;
-//! the goal here is to prove the public surface works on real tables and that the
-//! `must_be_recreatable` switch routes correctly after realistic cleanup.
+//! Integration tests for the public `history_manager` API.
 
-use std::collections::HashMap;
 use std::ops::RangeInclusive;
-use std::sync::Arc;
 
-use delta_kernel::engine::default::executor::tokio::TokioMultiThreadExecutor;
-use delta_kernel::engine::default::DefaultEngine;
-use delta_kernel::history_manager::{get_earliest_commit, CommitType};
+use delta_kernel::engine::default::DefaultEngineBuilder;
+use delta_kernel::history_manager::{get_earliest_commit, HistoryCommitType};
+use delta_kernel::object_store::path::Path;
+use delta_kernel::object_store::{ObjectStore, ObjectStoreExt as _};
 use delta_kernel::Version;
 use rstest::rstest;
-use test_utils::{create_table_and_load_snapshot, test_table_setup_mt, write_batch_to_table};
+use test_utils::table_builder::{LogState, TestTableBuilder};
 use url::Url;
 
-use crate::common::write_utils::{get_simple_schema, simple_id_batch};
-
-type TestEngine = DefaultEngine<TokioMultiThreadExecutor>;
-
-/// Builds a table with commits v0..=v8 and a checkpoint at v5. Returns the temp dir (keeps the
-/// on-disk table alive), the table URL, and the engine.
-async fn build_table(
-) -> Result<(tempfile::TempDir, Url, Arc<TestEngine>), Box<dyn std::error::Error>> {
-    let schema = get_simple_schema();
-    let (tmp_dir, table_path, engine) = test_table_setup_mt()?;
-    let table_url = Url::from_directory_path(&table_path)
-        .map_err(|_| "table_path should be a valid file URL")?;
-
-    let mut snapshot =
-        create_table_and_load_snapshot(&table_path, schema.clone(), engine.as_ref(), &[])?;
-
-    for version in 1..=8 {
-        snapshot = write_batch_to_table(
-            &snapshot,
-            engine.as_ref(),
-            simple_id_batch(&schema, vec![version]),
-            HashMap::new(),
-        )
-        .await?;
-        if version == 5 {
-            (_, snapshot) = snapshot.checkpoint(engine.as_ref(), None)?;
-        }
-    }
-
-    Ok((tmp_dir, table_url, engine))
-}
-
-/// Deletes the published commit JSON files for `versions`, simulating log cleanup.
-fn remove_commits(table_url: &Url, versions: RangeInclusive<Version>) {
-    let log_dir = table_url
-        .join("_delta_log/")
-        .unwrap()
-        .to_file_path()
-        .unwrap();
+async fn remove_commits(store: &dyn ObjectStore, versions: RangeInclusive<Version>) {
     for version in versions {
-        std::fs::remove_file(log_dir.join(format!("{version:020}.json"))).unwrap();
+        let path = Path::from(format!("_delta_log/{version:020}.json"));
+        store.delete(&path).await.unwrap();
     }
 }
 
-// Table for all cases: commits v0..=v8 with a checkpoint at v5.
-//   - no cleanup: v0 present, so both modes anchor at 0
-//   - cleanup v0..=v5 (commit at checkpoint version gone): recreatable falls back to the checkpoint
-//     (5), published reports the lowest surviving JSON commit (6)
-//   - cleanup v0..=v4 (commit at checkpoint version survives): both report 5
-//   - earliest_ratified_commit_version is plumbed through but irrelevant while commits exist
 #[rstest]
-#[case::recreatable_v0_present(None, None, CommitType::Recreatable, 0)]
-#[case::published_v0_present(None, None, CommitType::Published, 0)]
-#[case::recreatable_checkpoint_anchors(Some(0..=5), None, CommitType::Recreatable, 5)]
-#[case::published_lowest_surviving_json(Some(0..=5), None, CommitType::Published, 6)]
-#[case::recreatable_commit_at_checkpoint_survives(Some(0..=4), None, CommitType::Recreatable, 5)]
-#[case::published_commit_at_checkpoint_survives(Some(0..=4), None, CommitType::Published, 5)]
-#[case::recreatable_ratified_zero_passthrough(None, Some(0), CommitType::Recreatable, 0)]
-#[case::published_ratified_zero_passthrough(None, Some(0), CommitType::Published, 0)]
+#[case::recreatable_v0_present(None, None, HistoryCommitType::Recreatable, 0)]
+#[case::published_v0_present(None, None, HistoryCommitType::Published, 0)]
+#[case::recreatable_checkpoint_anchors(Some(0..=5), None, HistoryCommitType::Recreatable, 5)]
+#[case::published_lowest_surviving_json(Some(0..=5), None, HistoryCommitType::Published, 6)]
+#[case::recreatable_commit_at_checkpoint_survives(Some(0..=4), Some(9), HistoryCommitType::Recreatable, 5)]
+#[case::published_commit_at_checkpoint_survives(Some(0..=4), Some(9), HistoryCommitType::Published, 5)]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_earliest_commit(
     #[case] cleanup: Option<RangeInclusive<Version>>,
     #[case] earliest_ratified_commit_version: Option<Version>,
-    #[case] commit_type: CommitType,
+    #[case] commit_type: HistoryCommitType,
     #[case] expected_version: Version,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let (_tmp_dir, table_url, engine) = build_table().await?;
+    let table = TestTableBuilder::new()
+        .with_log_state(LogState::with_latest_version(8).with_checkpoint_at([5]))
+        .build()?;
+    let store = table.store().clone();
+    let engine = DefaultEngineBuilder::new(store.clone()).build();
+    let log_root = Url::parse(table.table_root())?.join("_delta_log/")?;
+
     if let Some(versions) = cleanup {
-        remove_commits(&table_url, versions);
+        remove_commits(store.as_ref(), versions).await;
     }
-    let log_root = table_url.join("_delta_log/")?;
 
     let earliest = get_earliest_commit(
-        engine.as_ref(),
+        &engine,
         &log_root,
         earliest_ratified_commit_version,
         commit_type,

--- a/kernel/tests/integration/log/history_manager.rs
+++ b/kernel/tests/integration/log/history_manager.rs
@@ -2,7 +2,6 @@
 
 use std::ops::RangeInclusive;
 
-use delta_kernel::engine::default::DefaultEngineBuilder;
 use delta_kernel::history_manager::{get_earliest_commit, HistoryCommitType};
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::ObjectStore;
@@ -13,6 +12,7 @@ use delta_kernel::object_store::ObjectStore;
 use delta_kernel::object_store::ObjectStoreExt as _;
 use delta_kernel::Version;
 use rstest::rstest;
+use test_utils::delta_kernel_default_engine::DefaultEngineBuilder;
 use test_utils::table_builder::{LogState, TestTableBuilder};
 use url::Url;
 

--- a/kernel/tests/integration/log/history_manager.rs
+++ b/kernel/tests/integration/log/history_manager.rs
@@ -1,0 +1,102 @@
+//! Integration tests for the public `history_manager` earliest-commit API.
+//!
+//! These exercise `get_earliest_commit` end-to-end against real kernel-written logs (commit
+//! JSON written via the transaction path, plus a real checkpoint parquet written by
+//! `Snapshot::checkpoint`), simulating log cleanup by deleting commit files on disk. The
+//! internal helpers it dispatches to are unit-tested exhaustively against synthetic listings;
+//! the goal here is to prove the public surface works on real tables and that the
+//! `must_be_recreatable` switch routes correctly after realistic cleanup.
+
+use std::collections::HashMap;
+use std::ops::RangeInclusive;
+use std::sync::Arc;
+
+use delta_kernel::engine::default::executor::tokio::TokioMultiThreadExecutor;
+use delta_kernel::engine::default::DefaultEngine;
+use delta_kernel::history_manager::get_earliest_commit;
+use delta_kernel::Version;
+use rstest::rstest;
+use test_utils::{create_table_and_load_snapshot, test_table_setup_mt, write_batch_to_table};
+use url::Url;
+
+use crate::common::write_utils::{get_simple_schema, simple_id_batch};
+
+type TestEngine = DefaultEngine<TokioMultiThreadExecutor>;
+
+/// Builds a table with commits v0..=v8 and a checkpoint at v5. Returns the temp dir (keeps the
+/// on-disk table alive), the table URL, and the engine.
+async fn build_table(
+) -> Result<(tempfile::TempDir, Url, Arc<TestEngine>), Box<dyn std::error::Error>> {
+    let schema = get_simple_schema();
+    let (tmp_dir, table_path, engine) = test_table_setup_mt()?;
+    let table_url = Url::from_directory_path(&table_path)
+        .map_err(|_| "table_path should be a valid file URL")?;
+
+    let mut snapshot =
+        create_table_and_load_snapshot(&table_path, schema.clone(), engine.as_ref(), &[])?;
+
+    for version in 1..=8 {
+        snapshot = write_batch_to_table(
+            &snapshot,
+            engine.as_ref(),
+            simple_id_batch(&schema, vec![version]),
+            HashMap::new(),
+        )
+        .await?;
+        if version == 5 {
+            (_, snapshot) = snapshot.checkpoint(engine.as_ref(), None)?;
+        }
+    }
+
+    Ok((tmp_dir, table_url, engine))
+}
+
+/// Deletes the published commit JSON files for `versions`, simulating log cleanup.
+fn remove_commits(table_url: &Url, versions: RangeInclusive<Version>) {
+    let log_dir = table_url
+        .join("_delta_log/")
+        .unwrap()
+        .to_file_path()
+        .unwrap();
+    for version in versions {
+        std::fs::remove_file(log_dir.join(format!("{version:020}.json"))).unwrap();
+    }
+}
+
+// Table for all cases: commits v0..=v8 with a checkpoint at v5.
+//   - no cleanup: v0 present, so both modes anchor at 0
+//   - cleanup v0..=v5 (commit at checkpoint version gone): recreatable falls back to the checkpoint
+//     (5), published reports the lowest surviving JSON commit (6)
+//   - cleanup v0..=v4 (commit at checkpoint version survives): both report 5
+//   - earliest_ratified_commit_version is plumbed through but irrelevant while commits exist
+#[rstest]
+#[case::recreatable_v0_present(None, None, true, 0)]
+#[case::published_v0_present(None, None, false, 0)]
+#[case::recreatable_checkpoint_anchors(Some(0..=5), None, true, 5)]
+#[case::published_lowest_surviving_json(Some(0..=5), None, false, 6)]
+#[case::recreatable_commit_at_checkpoint_survives(Some(0..=4), None, true, 5)]
+#[case::published_commit_at_checkpoint_survives(Some(0..=4), None, false, 5)]
+#[case::recreatable_ratified_zero_passthrough(None, Some(0), true, 0)]
+#[case::published_ratified_zero_passthrough(None, Some(0), false, 0)]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_earliest_commit(
+    #[case] cleanup: Option<RangeInclusive<Version>>,
+    #[case] earliest_ratified_commit_version: Option<Version>,
+    #[case] must_be_recreatable: bool,
+    #[case] expected_version: Version,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_tmp_dir, table_url, engine) = build_table().await?;
+    if let Some(versions) = cleanup {
+        remove_commits(&table_url, versions);
+    }
+    let log_root = table_url.join("_delta_log/")?;
+
+    let earliest = get_earliest_commit(
+        engine.as_ref(),
+        &log_root,
+        earliest_ratified_commit_version,
+        must_be_recreatable,
+    )?;
+    assert_eq!(earliest, expected_version);
+    Ok(())
+}

--- a/kernel/tests/integration/log/history_manager.rs
+++ b/kernel/tests/integration/log/history_manager.rs
@@ -26,7 +26,7 @@ async fn remove_commits(store: &dyn ObjectStore, versions: RangeInclusive<Versio
 #[rstest]
 #[case::recreatable_v0_present(None, None, HistoryCommitType::Recreatable, 0)]
 #[case::published_v0_present(None, None, HistoryCommitType::Published, 0)]
-#[case::recreatable_checkpoint_anchors(Some(0..=5), None, HistoryCommitType::Recreatable, 5)]
+#[case::recreatable_checkpoint_anchors(Some(0..=4), None, HistoryCommitType::Recreatable, 5)]
 #[case::published_lowest_surviving_json(Some(0..=5), None, HistoryCommitType::Published, 6)]
 #[case::recreatable_commit_at_checkpoint_survives(Some(0..=4), Some(9), HistoryCommitType::Recreatable, 5)]
 #[case::published_commit_at_checkpoint_survives(Some(0..=4), Some(9), HistoryCommitType::Published, 5)]

--- a/kernel/tests/integration/log/history_manager.rs
+++ b/kernel/tests/integration/log/history_manager.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 
 use delta_kernel::engine::default::executor::tokio::TokioMultiThreadExecutor;
 use delta_kernel::engine::default::DefaultEngine;
-use delta_kernel::history_manager::get_earliest_commit;
+use delta_kernel::history_manager::{get_earliest_commit, CommitType};
 use delta_kernel::Version;
 use rstest::rstest;
 use test_utils::{create_table_and_load_snapshot, test_table_setup_mt, write_batch_to_table};
@@ -70,19 +70,19 @@ fn remove_commits(table_url: &Url, versions: RangeInclusive<Version>) {
 //   - cleanup v0..=v4 (commit at checkpoint version survives): both report 5
 //   - earliest_ratified_commit_version is plumbed through but irrelevant while commits exist
 #[rstest]
-#[case::recreatable_v0_present(None, None, true, 0)]
-#[case::published_v0_present(None, None, false, 0)]
-#[case::recreatable_checkpoint_anchors(Some(0..=5), None, true, 5)]
-#[case::published_lowest_surviving_json(Some(0..=5), None, false, 6)]
-#[case::recreatable_commit_at_checkpoint_survives(Some(0..=4), None, true, 5)]
-#[case::published_commit_at_checkpoint_survives(Some(0..=4), None, false, 5)]
-#[case::recreatable_ratified_zero_passthrough(None, Some(0), true, 0)]
-#[case::published_ratified_zero_passthrough(None, Some(0), false, 0)]
+#[case::recreatable_v0_present(None, None, CommitType::Recreatable, 0)]
+#[case::published_v0_present(None, None, CommitType::Published, 0)]
+#[case::recreatable_checkpoint_anchors(Some(0..=5), None, CommitType::Recreatable, 5)]
+#[case::published_lowest_surviving_json(Some(0..=5), None, CommitType::Published, 6)]
+#[case::recreatable_commit_at_checkpoint_survives(Some(0..=4), None, CommitType::Recreatable, 5)]
+#[case::published_commit_at_checkpoint_survives(Some(0..=4), None, CommitType::Published, 5)]
+#[case::recreatable_ratified_zero_passthrough(None, Some(0), CommitType::Recreatable, 0)]
+#[case::published_ratified_zero_passthrough(None, Some(0), CommitType::Published, 0)]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_earliest_commit(
     #[case] cleanup: Option<RangeInclusive<Version>>,
     #[case] earliest_ratified_commit_version: Option<Version>,
-    #[case] must_be_recreatable: bool,
+    #[case] commit_type: CommitType,
     #[case] expected_version: Version,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let (_tmp_dir, table_url, engine) = build_table().await?;
@@ -95,7 +95,7 @@ async fn test_get_earliest_commit(
         engine.as_ref(),
         &log_root,
         earliest_ratified_commit_version,
-        must_be_recreatable,
+        commit_type,
     )?;
     assert_eq!(earliest, expected_version);
     Ok(())

--- a/kernel/tests/integration/log/mod.rs
+++ b/kernel/tests/integration/log/mod.rs
@@ -3,6 +3,7 @@
 mod checkpoint_transform;
 mod crc;
 mod empty_log_files;
+mod history_manager;
 mod log_compaction;
 mod log_tail;
 mod v2_checkpoints;


### PR DESCRIPTION
Please [use this change](https://github.com/delta-io/delta-kernel-rs/pull/2713/changes/4d61ba853e124e4e4f8bc52c7c18cc13566c287a..7e0f180021191d6b5f5bf07f07eb52d81a29662f) to review the PR. 

## What changes are proposed in this pull request?

This PR added a new public API in history_manager mod, the `get_earliest_commit`. The function allow user to get the earliest available file-system commit in the `_delta_log/` of the table. Furthermore, user can query for the earliest available version (`HistoryCommitType::Published`) or the earliest version that the table can be reconstructed and replay forward from (`HistoryCommitType::Recreatable`) .

This PR depend on: #2675

## How was this change tested?

New integration test was added to verify the public API. The integration test construct a table with 8 commits, checkpoint at version 5 and various log clean up simulation scenario to test the return value based on the `HistoryCommitType` and the log cleanup.