### PR TITLE
ci: fix flaky metrics deadlock test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,8 +229,8 @@ jobs:
         shell: bash
         run: |
           output=$(cargo run --profile test --example metrics-tester)
-          echo "$output" | grep -q 'invalid_field'
-          echo "$output" | grep -q 'Invalid uuid'
+          grep -q 'invalid_field' <<< "$output"
+          grep -q 'Invalid uuid' <<< "$output"
 
   ffi_test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes a flaky failure in the `metrics deadlock test` CI step (e.g.
https://github.com/delta-io/delta-kernel-rs/actions/runs/27173481108/job/80217380098?pr=2665).

**Problem:** the step pipes the example's output into `grep -q`:

```bash
echo "$output" | grep -q 'invalid_field'
```

`grep -q` exits as soon as it matches, closing the pipe. Both matched strings sit near the end of a large (~159 KB) output, so by then `echo` may still have bytes pending and its write fails with `EPIPE`. Under `bash -eo pipefail` (the
`shell: bash` default) that broken-pipe exit becomes the pipeline's status and fails the step. It's a race, hence the flakiness. The failing run shows exactly this:

```
shell: /opt/homebrew/bin/bash --noprofile --norc -e -o pipefail {0}
...
.../6fbb8cb3-...sh: line 3: echo: write error: Broken pipe
##[error]Process completed with exit code 1.
```

**Fix:** drop the pipe and feed `grep` a here-string. `grep` reads a complete buffer, so matching early can't break a pipe.

```bash
grep -q 'invalid_field' <<< "$output"
```

## How was this change tested?

CI.
