### PR TITLE
feat!: add `Transaction::commit` metric events

### DIFF
--- a/kernel/src/crc/delta.rs
+++ b/kernel/src/crc/delta.rs
@@ -243,13 +243,23 @@ mod tests {
         HashMap::from([dm_entry("keep", "old"), dm_entry("drop", "x")])
     }
 
-    fn write_delta(net_files: i64, net_bytes: i64) -> CrcDelta {
+    fn add_files_delta(add_files: u64, add_bytes: u64) -> CrcDelta {
         CrcDelta {
             file_stats: FileStatsDelta {
-                gross_add_files: net_files.max(0) as u64,
-                gross_remove_files: (-net_files).max(0) as u64,
-                gross_add_bytes: net_bytes.max(0) as u64,
-                gross_remove_bytes: (-net_bytes).max(0) as u64,
+                gross_add_files: add_files,
+                gross_add_bytes: add_bytes,
+                ..Default::default()
+            },
+            is_incremental_safe: true,
+            ..Default::default()
+        }
+    }
+
+    fn remove_files_delta(remove_files: u64, remove_bytes: u64) -> CrcDelta {
+        CrcDelta {
+            file_stats: FileStatsDelta {
+                gross_remove_files: remove_files,
+                gross_remove_bytes: remove_bytes,
                 ..Default::default()
             },
             is_incremental_safe: true,
@@ -301,7 +311,7 @@ mod tests {
 
     #[test]
     fn test_apply_updates_file_stats() {
-        let crc = base_crc().apply(write_delta(3, 600), 1);
+        let crc = base_crc().apply(add_files_delta(3, 600), 1);
         let stats = crc.file_stats().unwrap();
         assert_eq!(stats.num_files(), 13); // 10 + 3
         assert_eq!(stats.table_size_bytes(), 1600); // 1000 + 600
@@ -313,8 +323,8 @@ mod tests {
     #[test]
     fn test_apply_multiple_deltas() {
         let crc = base_crc()
-            .apply(write_delta(3, 600), 1)
-            .apply(write_delta(-2, -400), 2);
+            .apply(add_files_delta(3, 600), 1)
+            .apply(remove_files_delta(2, 400), 2);
         let stats = crc.file_stats().unwrap();
         assert_eq!(stats.num_files(), 11); // 10 + 3 - 2
         assert_eq!(stats.table_size_bytes(), 1200); // 1000 + 600 - 400
@@ -326,7 +336,7 @@ mod tests {
     fn test_apply_not_incremental_safe_transitions_to_indeterminate() {
         let unsafe_change = CrcDelta {
             is_incremental_safe: false,
-            ..write_delta(1, 100)
+            ..add_files_delta(1, 100)
         };
         let crc = base_crc().apply(unsafe_change, 1);
         assert!(crc.file_stats_state.is_indeterminate());
@@ -336,13 +346,13 @@ mod tests {
     fn test_indeterminate_stays_indeterminate() {
         let unsafe_change = CrcDelta {
             is_incremental_safe: false,
-            ..write_delta(1, 100)
+            ..add_files_delta(1, 100)
         };
         let crc = base_crc().apply(unsafe_change, 1);
         assert!(crc.file_stats_state.is_indeterminate());
 
         // Subsequent safe op doesn't recover the state. Version still advances.
-        let crc = crc.apply(write_delta(5, 500), 2);
+        let crc = crc.apply(add_files_delta(5, 500), 2);
         assert!(crc.file_stats_state.is_indeterminate());
         assert_eq!(crc.version, 2);
     }
@@ -360,7 +370,7 @@ mod tests {
         .unwrap();
         let delta = CrcDelta {
             protocol: Some(new_protocol.clone()),
-            ..write_delta(0, 0)
+            ..add_files_delta(0, 0)
         };
         let crc = base_crc().apply(delta, 1);
         assert_eq!(crc.protocol, new_protocol);
@@ -381,7 +391,7 @@ mod tests {
                 dm_entry("add", "y"),
                 dm_remove_entry("drop", "x"),
             ]),
-            ..write_delta(0, 0)
+            ..add_files_delta(0, 0)
         };
         let crc = Crc {
             domain_metadata_state: base,
@@ -405,7 +415,7 @@ mod tests {
     fn test_apply_replaces_in_commit_timestamp() {
         let delta = CrcDelta {
             in_commit_timestamp: Some(9999),
-            ..write_delta(0, 0)
+            ..add_files_delta(0, 0)
         };
         let crc = base_crc().apply(delta, 1);
         assert_eq!(crc.in_commit_timestamp_opt, Some(9999));
@@ -415,7 +425,7 @@ mod tests {
     fn test_apply_clears_in_commit_timestamp_when_delta_is_none() {
         let delta = CrcDelta {
             in_commit_timestamp: None,
-            ..write_delta(0, 0)
+            ..add_files_delta(0, 0)
         };
         let crc = Crc {
             in_commit_timestamp_opt: Some(1000),
@@ -444,7 +454,7 @@ mod tests {
         let delta = CrcDelta {
             protocol: Some(protocol.clone()),
             metadata: Some(metadata.clone()),
-            ..write_delta(5, 1000)
+            ..add_files_delta(5, 1000)
         };
         let crc = delta.into_crc_for_version_zero().unwrap();
         let stats = crc.file_stats().unwrap();
@@ -469,7 +479,7 @@ mod tests {
     fn test_into_crc_for_version_zero_returns_none_without_protocol() {
         let delta = CrcDelta {
             metadata: Some(Metadata::default()),
-            ..write_delta(5, 1000)
+            ..add_files_delta(5, 1000)
         };
         assert!(delta.into_crc_for_version_zero().is_none());
     }
@@ -478,7 +488,7 @@ mod tests {
     fn test_into_crc_for_version_zero_returns_none_without_metadata() {
         let delta = CrcDelta {
             protocol: Some(test_protocol()),
-            ..write_delta(5, 1000)
+            ..add_files_delta(5, 1000)
         };
         assert!(delta.into_crc_for_version_zero().is_none());
     }
@@ -490,7 +500,7 @@ mod tests {
             protocol: Some(test_protocol()),
             metadata: Some(Metadata::default()),
             domain_metadata: HashMap::from([("my.domain".to_string(), dm)]),
-            ..write_delta(0, 0)
+            ..add_files_delta(0, 0)
         };
         let crc = delta.into_crc_for_version_zero().unwrap();
         let map = crc.domain_metadata_state.expect_complete();
@@ -504,7 +514,7 @@ mod tests {
             protocol: Some(test_protocol()),
             metadata: Some(Metadata::default()),
             in_commit_timestamp: Some(12345),
-            ..write_delta(0, 0)
+            ..add_files_delta(0, 0)
         };
         let crc = delta.into_crc_for_version_zero().unwrap();
         assert_eq!(crc.in_commit_timestamp_opt, Some(12345));
@@ -529,7 +539,7 @@ mod tests {
                 txn_entry("existing", 2, Some(2000)),
                 txn_entry("new", 1, Some(1500)),
             ]),
-            ..write_delta(0, 0)
+            ..add_files_delta(0, 0)
         };
         let crc = Crc {
             set_transaction_state: base,
@@ -557,7 +567,7 @@ mod tests {
             protocol: Some(test_protocol()),
             metadata: Some(Metadata::default()),
             set_transactions: HashMap::from([("my-app".to_string(), txn)]),
-            ..write_delta(0, 0)
+            ..add_files_delta(0, 0)
         };
         let crc = delta.into_crc_for_version_zero().unwrap();
         let map = crc.set_transaction_state.expect_complete();
@@ -681,7 +691,7 @@ mod tests {
     fn apply_drops_histogram_on_indeterminate() {
         let unsafe_delta = CrcDelta {
             is_incremental_safe: false,
-            ..write_delta(1, 100)
+            ..add_files_delta(1, 100)
         };
         let crc = base_crc_with_histogram(&[100, 200]).apply(unsafe_delta, 1);
         // Indeterminate has no histogram field; the histogram data is gone.
@@ -713,12 +723,12 @@ mod tests {
 
     #[test]
     fn into_crc_for_version_zero_without_histogram() {
-        // write_delta() produces a CrcDelta with no histogram delta, so
+        // add_files_delta() produces a CrcDelta with no histogram delta, so
         // into_crc_for_version_zero cannot construct a file size histogram.
         let delta = CrcDelta {
             protocol: Some(test_protocol()),
             metadata: Some(Metadata::default()),
-            ..write_delta(0, 0)
+            ..add_files_delta(0, 0)
         };
         let crc = delta.into_crc_for_version_zero().unwrap();
         let stats = crc.file_stats().unwrap();

--- a/kernel/src/crc/delta.rs
+++ b/kernel/src/crc/delta.rs
@@ -57,23 +57,22 @@ impl CrcDelta {
         );
         // CREATE TABLE starts with a known-complete set of transactions (possibly empty).
         let set_transaction_state = SetTransactionState::Complete(self.set_transactions);
-        // For version zero the delta IS the full table histogram. Validate that all bins
-        // are non-negative (a real table can't have negative file counts). If validation
-        // fails, drop the histogram.
-        let initial_histogram = self.file_stats.net_histogram.and_then(|delta| {
-            delta
-                .check_non_negative()
-                .inspect_err(|e| {
-                    warn!("Non-negative file count check failed, dropping file size histogram for version zero: {e}");
-                })
-                .ok()
-        });
         Some(Crc {
             version: 0,
             file_stats_state: FileStatsState::Complete(FileStats {
-                num_files: self.file_stats.net_files,
-                table_size_bytes: self.file_stats.net_bytes,
-                file_size_histogram: initial_histogram,
+                num_files: self.file_stats.net_files(),
+                table_size_bytes: self.file_stats.net_bytes(),
+                // For version zero the delta IS the full table histogram. Validate that all bins
+                // are non-negative (a real table can't have negative file counts). If validation
+                // fails, drop the histogram.
+                file_size_histogram: self.file_stats.net_histogram.and_then(|delta| {
+                    delta
+                        .check_non_negative()
+                        .inspect_err(|e| {
+                            warn!("Non-negative file count check failed, dropping file size histogram for version zero: {e}");
+                        })
+                        .ok()
+                }),
             }),
             protocol,
             metadata,
@@ -164,8 +163,8 @@ fn transition_file_stats(
         _ if !is_incremental_safe => FileStatsState::Indeterminate,
         FileStatsState::Complete(stats) => FileStatsState::Complete(FileStats {
             // Counts and bytes have no non-negative check.
-            num_files: stats.num_files + delta.net_files,
-            table_size_bytes: stats.table_size_bytes + delta.net_bytes,
+            num_files: stats.num_files + delta.net_files(),
+            table_size_bytes: stats.table_size_bytes + delta.net_bytes(),
             // Histogram: per-bin merge; drop on failure. See `merge_histogram`.
             file_size_histogram: merge_histogram(
                 stats.file_size_histogram.as_ref(),
@@ -247,8 +246,10 @@ mod tests {
     fn write_delta(net_files: i64, net_bytes: i64) -> CrcDelta {
         CrcDelta {
             file_stats: FileStatsDelta {
-                net_files,
-                net_bytes,
+                gross_add_files: net_files.max(0) as u64,
+                gross_remove_files: (-net_files).max(0) as u64,
+                gross_add_bytes: net_bytes.max(0) as u64,
+                gross_remove_bytes: (-net_bytes).max(0) as u64,
                 ..Default::default()
             },
             is_incremental_safe: true,
@@ -598,12 +599,12 @@ mod tests {
         for &s in remove_sizes {
             hist.remove(s).unwrap();
         }
-        let net_files = add_sizes.len() as i64 - remove_sizes.len() as i64;
-        let net_bytes: i64 = add_sizes.iter().sum::<i64>() - remove_sizes.iter().sum::<i64>();
         CrcDelta {
             file_stats: FileStatsDelta {
-                net_files,
-                net_bytes,
+                gross_add_files: add_sizes.len() as u64,
+                gross_remove_files: remove_sizes.len() as u64,
+                gross_add_bytes: add_sizes.iter().sum::<i64>() as u64,
+                gross_remove_bytes: remove_sizes.iter().sum::<i64>() as u64,
                 net_histogram: Some(hist),
             },
             is_incremental_safe: true,
@@ -660,9 +661,10 @@ mod tests {
         };
         let delta = CrcDelta {
             file_stats: FileStatsDelta {
-                net_files: 1,
-                net_bytes: 100,
+                gross_add_files: 1,
+                gross_add_bytes: 100,
                 net_histogram: None,
+                ..Default::default()
             },
             is_incremental_safe: true,
             ..Default::default()
@@ -694,9 +696,10 @@ mod tests {
             protocol: Some(test_protocol()),
             metadata: Some(Metadata::default()),
             file_stats: FileStatsDelta {
-                net_files: 2,
-                net_bytes: 1500,
+                gross_add_files: 2,
+                gross_add_bytes: 1500,
                 net_histogram: Some(delta_hist),
+                ..Default::default()
             },
             is_incremental_safe: true,
             ..Default::default()
@@ -749,8 +752,10 @@ mod tests {
 
         let delta = CrcDelta {
             file_stats: FileStatsDelta {
-                net_files: 1,    // +2 - 1
-                net_bytes: 1450, // (100 + 1500) - 150
+                gross_add_files: 2,
+                gross_remove_files: 1,
+                gross_add_bytes: 1600,
+                gross_remove_bytes: 150,
                 net_histogram: Some(delta_hist),
             },
             is_incremental_safe: true,

--- a/kernel/src/crc/file_stats.rs
+++ b/kernel/src/crc/file_stats.rs
@@ -54,13 +54,13 @@ impl FileStats {
     }
 }
 
-/// Net file count and size changes from a single commit, with an optional net histogram.
+/// Gross file-change totals from a single commit, plus an optional net file-size histogram.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct FileStatsDelta {
-    /// Net change in file count (files added minus files removed).
-    pub(crate) net_files: i64,
-    /// Net change in total bytes (bytes added minus bytes removed).
-    pub(crate) net_bytes: i64,
+    pub(crate) gross_add_files: u64,
+    pub(crate) gross_remove_files: u64,
+    pub(crate) gross_add_bytes: u64,
+    pub(crate) gross_remove_bytes: u64,
     /// Net change in file size histogram (adds minus removes per bin). May contain negative
     /// values in bins where more files were removed than added. `None` when the delta source
     /// does not provide histogram data.
@@ -91,6 +91,16 @@ pub(crate) fn is_incremental_safe_operation(operation: &str) -> bool {
 }
 
 impl FileStatsDelta {
+    /// Net change in file count (added minus removed).
+    pub(crate) fn net_files(&self) -> i64 {
+        self.gross_add_files as i64 - self.gross_remove_files as i64
+    }
+
+    /// Net change in total bytes (added minus removed).
+    pub(crate) fn net_bytes(&self) -> i64 {
+        self.gross_add_bytes as i64 - self.gross_remove_bytes as i64
+    }
+
     /// Compute file stats and a delta histogram from a transaction's staged add and remove
     /// metadata.
     ///
@@ -116,15 +126,17 @@ impl FileStatsDelta {
             Some(b) => FileSizeHistogram::create_empty_with_boundaries(b.to_vec())?,
             None => FileSizeHistogram::create_default(),
         };
-        let mut net_files = 0i64;
-        let mut net_bytes = 0i64;
+        let mut gross_add_files = 0u64;
+        let mut gross_remove_files = 0u64;
+        let mut gross_add_bytes = 0u64;
+        let mut gross_remove_bytes = 0u64;
 
         // Visit add files (insert into histogram). Every row is a file being added.
         for batch in add_files_metadata {
             let mut visitor = FileStatsVisitor::new(None, false, &mut histogram);
             visitor.visit_rows_of(batch.as_ref())?;
-            net_files += visitor.count;
-            net_bytes += visitor.total_size;
+            gross_add_files += visitor.count.unsigned_abs();
+            gross_add_bytes += visitor.total_size.unsigned_abs();
         }
 
         // Visit remove files (remove from histogram). Each FilteredEngineData has its own
@@ -134,13 +146,15 @@ impl FileStatsDelta {
             let sv_opt = if sv.is_empty() { None } else { Some(sv) };
             let mut visitor = FileStatsVisitor::new(sv_opt, true, &mut histogram);
             visitor.visit_rows_of(filtered_batch.data())?;
-            net_files += visitor.count;
-            net_bytes += visitor.total_size;
+            gross_remove_files += visitor.count.unsigned_abs();
+            gross_remove_bytes += visitor.total_size.unsigned_abs();
         }
 
         Ok(FileStatsDelta {
-            net_files,
-            net_bytes,
+            gross_add_files,
+            gross_remove_files,
+            gross_add_bytes,
+            gross_remove_bytes,
             net_histogram: Some(histogram),
         })
     }
@@ -285,8 +299,8 @@ mod tests {
             .map(|sizes| FilteredEngineData::with_all_rows_selected(size_batch(sizes)))
             .collect();
         let stats = FileStatsDelta::try_compute_for_txn(&adds, &removes, None).unwrap();
-        assert_eq!(stats.net_files, case.expected_net_files);
-        assert_eq!(stats.net_bytes, case.expected_net_bytes);
+        assert_eq!(stats.net_files(), case.expected_net_files);
+        assert_eq!(stats.net_bytes(), case.expected_net_bytes);
     }
 
     #[test]
@@ -303,8 +317,12 @@ mod tests {
         let stats = FileStatsDelta::try_compute_for_txn(&adds, &removes, None).unwrap();
         // adds: 3 files, 600 bytes (100 + 200 + 300)
         // removes: 4 files, 2400 bytes (400 + 500 + 700 + 800)
-        assert_eq!(stats.net_files, -1); // 3 - 4
-        assert_eq!(stats.net_bytes, -1800); // 600 - 2400
+        assert_eq!(stats.net_files(), -1); // 3 - 4
+        assert_eq!(stats.net_bytes(), -1800); // 600 - 2400
+        assert_eq!(stats.gross_add_files, 3);
+        assert_eq!(stats.gross_remove_files, 4);
+        assert_eq!(stats.gross_add_bytes, 600);
+        assert_eq!(stats.gross_remove_bytes, 2400);
     }
 
     #[test]

--- a/kernel/src/crc/file_stats.rs
+++ b/kernel/src/crc/file_stats.rs
@@ -135,8 +135,8 @@ impl FileStatsDelta {
         for batch in add_files_metadata {
             let mut visitor = FileStatsVisitor::new(None, false, &mut histogram);
             visitor.visit_rows_of(batch.as_ref())?;
-            gross_add_files += visitor.count.unsigned_abs();
-            gross_add_bytes += visitor.total_size.unsigned_abs();
+            gross_add_files += visitor.count;
+            gross_add_bytes += visitor.total_size;
         }
 
         // Visit remove files (remove from histogram). Each FilteredEngineData has its own
@@ -146,8 +146,8 @@ impl FileStatsDelta {
             let sv_opt = if sv.is_empty() { None } else { Some(sv) };
             let mut visitor = FileStatsVisitor::new(sv_opt, true, &mut histogram);
             visitor.visit_rows_of(filtered_batch.data())?;
-            gross_remove_files += visitor.count.unsigned_abs();
-            gross_remove_bytes += visitor.total_size.unsigned_abs();
+            gross_remove_files += visitor.count;
+            gross_remove_bytes += visitor.total_size;
         }
 
         Ok(FileStatsDelta {
@@ -160,11 +160,18 @@ impl FileStatsDelta {
     }
 }
 
+/// Read a file `size` (a non-negative byte count stored as `i64`) as `u64`, erroring on a
+/// negative size (corrupt input).
+pub(crate) fn size_to_u64(size: i64) -> DeltaResult<u64> {
+    u64::try_from(size)
+        .map_err(|_| Error::internal_error(format!("File size must be non-negative, got {size}")))
+}
+
 /// Visitor that extracts the `size` column from file metadata and updates a shared histogram.
 ///
-/// When `is_remove` is false (add files), each visited row increments the histogram bin's count
-/// and bytes. When true (remove files), each row decrements them. This builds a single delta
-/// histogram directly without needing separate add/remove histograms.
+/// `is_remove` selects whether each visited row is inserted into (add) or removed from (remove)
+/// the shared delta histogram. `count`/`total_size` always accumulate gross magnitude; the
+/// add/remove direction is the caller's to track.
 ///
 /// Accepts an optional selection vector to filter which rows are visited. AddFiles pass `None`
 /// (count every row); RemoveFiles may pass `Some(sv)` from [`FilteredEngineData`] to skip rows
@@ -175,12 +182,12 @@ struct FileStatsVisitor<'sv, 'h> {
     selection_vector: Option<&'sv [bool]>,
     /// Offset into the selection vector, tracking position across multiple visit calls.
     offset: usize,
-    /// Whether this visitor is processing remove files (decrements) vs add files (increments).
+    /// Whether visited rows are removed from (vs added to) the histogram.
     is_remove: bool,
-    /// Net file count contribution from this visitor. Negative for remove visitors.
-    count: i64,
-    /// Net byte size contribution from this visitor. Negative for remove visitors.
-    total_size: i64,
+    /// Count of files visited.
+    count: u64,
+    /// Total bytes of files visited.
+    total_size: u64,
     /// Shared histogram that all visitors (add and remove) write to.
     histogram: &'h mut FileSizeHistogram,
 }
@@ -224,13 +231,11 @@ impl RowVisitor for FileStatsVisitor<'_, '_> {
             };
             if selected {
                 let size: i64 = getters[0].get(i, "size")?;
+                self.count += 1;
+                self.total_size += size_to_u64(size)?;
                 if self.is_remove {
-                    self.count -= 1;
-                    self.total_size -= size;
                     self.histogram.remove(size)?;
                 } else {
-                    self.count += 1;
-                    self.total_size += size;
                     self.histogram.insert(size)?;
                 }
             }

--- a/kernel/src/crc/mod.rs
+++ b/kernel/src/crc/mod.rs
@@ -30,7 +30,7 @@ pub(crate) use delta::CrcDelta;
 pub use file_size_histogram::FileSizeHistogram;
 pub use file_stats::FileStats;
 #[allow(unused)]
-pub(crate) use file_stats::{is_incremental_safe_operation, FileStatsDelta};
+pub(crate) use file_stats::{is_incremental_safe_operation, size_to_u64, FileStatsDelta};
 pub(crate) use reader::read_crc_file_or_none;
 #[cfg(test)]
 pub(crate) use reader::try_read_crc_file;

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -281,14 +281,14 @@ impl CrcReplayAccumulator {
     fn on_add(&mut self, size: i64) -> DeltaResult<()> {
         self.current_commit_saw_file_action = true;
         // Once the delta is no longer incremental-safe, [`Crc::apply`] will transition the
-        // file-stats state to `Indeterminate` and discard `net_files`/`net_bytes`/histogram.
-        // Stop accumulating; further math is wasted work.
+        // file-stats state to `Indeterminate` and discard the accumulated file stats and
+        // histogram. Stop accumulating; further math is wasted work.
         if !self.delta.is_incremental_safe {
             return Ok(());
         }
         let fs = &mut self.delta.file_stats;
-        fs.net_files += 1;
-        fs.net_bytes += size;
+        fs.gross_add_files += 1;
+        fs.gross_add_bytes += size.max(0) as u64;
         if let Some(hist) = fs.net_histogram.as_mut() {
             // TODO(#2676): a negative size errors here and fails the snapshot load; degrade to
             //              Indeterminate instead, like a missing remove size.
@@ -302,16 +302,16 @@ impl CrcReplayAccumulator {
     fn on_remove(&mut self, path: &str, size: Option<i64>) -> DeltaResult<()> {
         self.current_commit_saw_file_action = true;
         // Once the delta is no longer incremental-safe, [`Crc::apply`] will transition the
-        // file-stats state to `Indeterminate` and discard `net_files`/`net_bytes`/histogram.
-        // Stop accumulating; further math is wasted work.
+        // file-stats state to `Indeterminate` and discard the accumulated file stats and
+        // histogram. Stop accumulating; further math is wasted work.
         if !self.delta.is_incremental_safe {
             return Ok(());
         }
         match size {
             Some(s) => {
                 let fs = &mut self.delta.file_stats;
-                fs.net_files -= 1;
-                fs.net_bytes -= s;
+                fs.gross_remove_files += 1;
+                fs.gross_remove_bytes += s.max(0) as u64;
                 if let Some(hist) = fs.net_histogram.as_mut() {
                     hist.remove(s)?;
                 }
@@ -540,8 +540,8 @@ mod tests {
         let mut acc = CrcReplayAccumulator::new(None);
         acc.on_add(100).unwrap();
         acc.on_add(200).unwrap();
-        assert_eq!(acc.delta.file_stats.net_files, 2);
-        assert_eq!(acc.delta.file_stats.net_bytes, 300);
+        assert_eq!(acc.delta.file_stats.net_files(), 2);
+        assert_eq!(acc.delta.file_stats.net_bytes(), 300);
         assert!(acc.delta.is_incremental_safe);
     }
 
@@ -551,8 +551,8 @@ mod tests {
     fn on_remove_with_size_decrements_files_and_bytes() {
         let mut acc = CrcReplayAccumulator::new(None);
         acc.on_remove("p", Some(50)).unwrap();
-        assert_eq!(acc.delta.file_stats.net_files, -1);
-        assert_eq!(acc.delta.file_stats.net_bytes, -50);
+        assert_eq!(acc.delta.file_stats.net_files(), -1);
+        assert_eq!(acc.delta.file_stats.net_bytes(), -50);
         assert!(acc.delta.is_incremental_safe);
     }
 
@@ -617,8 +617,8 @@ mod tests {
         let mut acc = CrcReplayAccumulator::new(None);
         acc.on_add(42).unwrap();
         let delta = acc.into_crc_delta();
-        assert_eq!(delta.file_stats.net_files, 1);
-        assert_eq!(delta.file_stats.net_bytes, 42);
+        assert_eq!(delta.file_stats.net_files(), 1);
+        assert_eq!(delta.file_stats.net_bytes(), 42);
     }
 
     #[test]

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -20,8 +20,8 @@ use crate::actions::{
     DOMAIN_METADATA_NAME, METADATA_NAME, PROTOCOL_NAME, REMOVE_NAME, SET_TRANSACTION_NAME,
 };
 use crate::crc::{
-    is_incremental_safe_operation, read_crc_file_or_none, Crc, CrcDelta, FileSizeHistogram,
-    FileStatsDelta,
+    is_incremental_safe_operation, read_crc_file_or_none, size_to_u64, Crc, CrcDelta,
+    FileSizeHistogram, FileStatsDelta,
 };
 use crate::engine_data::{GetData, TypedGetData as _};
 use crate::schema::{
@@ -288,10 +288,10 @@ impl CrcReplayAccumulator {
         }
         let fs = &mut self.delta.file_stats;
         fs.gross_add_files += 1;
-        fs.gross_add_bytes += size.max(0) as u64;
+        // TODO(#2676): a negative size errors here and fails the snapshot load; degrade to
+        //              Indeterminate instead, like a missing remove size.
+        fs.gross_add_bytes += size_to_u64(size)?;
         if let Some(hist) = fs.net_histogram.as_mut() {
-            // TODO(#2676): a negative size errors here and fails the snapshot load; degrade to
-            //              Indeterminate instead, like a missing remove size.
             hist.insert(size)?;
         }
         Ok(())
@@ -311,7 +311,7 @@ impl CrcReplayAccumulator {
             Some(s) => {
                 let fs = &mut self.delta.file_stats;
                 fs.gross_remove_files += 1;
-                fs.gross_remove_bytes += s.max(0) as u64;
+                fs.gross_remove_bytes += size_to_u64(s)?;
                 if let Some(hist) = fs.net_histogram.as_mut() {
                     hist.remove(s)?;
                 }

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -9,6 +9,7 @@ use std::fmt;
 use std::str::FromStr as _;
 use std::time::Duration;
 
+use strum::{AsRefStr, Display as StrumDisplay, EnumString};
 use tracing::field::{Field, Visit};
 use tracing::span::Attributes;
 use tracing::warn;
@@ -191,7 +192,7 @@ impl MetricEvent {
                 let operation_id = e.operation_id;
                 *self = Self::TransactionCommitFailure(TransactionCommitFailure {
                     operation_id,
-                    reason: CommitFailureReason::parse(value),
+                    reason: value.parse().unwrap_or(CommitFailureReason::Error),
                 });
             }
             return Ok(());
@@ -617,7 +618,11 @@ impl fmt::Display for TransactionCommitSuccess {
 }
 
 /// Why a transaction commit did not succeed.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// Serializes to its `snake_case` name for the `failure_reason` span field (e.g.
+/// `RetryableIo` -> `"retryable_io"`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumString, StrumDisplay, AsRefStr)]
+#[strum(serialize_all = "snake_case")]
 pub enum CommitFailureReason {
     /// The commit conflicted with a concurrently committed version.
     Conflict,
@@ -625,32 +630,6 @@ pub enum CommitFailureReason {
     RetryableIo,
     /// A terminal (non-retryable) error occurred.
     Error,
-}
-
-impl CommitFailureReason {
-    /// The `failure_reason` span-field string for this reason. Producer and parser share this.
-    pub(crate) fn as_str(self) -> &'static str {
-        match self {
-            Self::Conflict => "conflict",
-            Self::RetryableIo => "retryable_io",
-            Self::Error => "error",
-        }
-    }
-
-    /// Parse the value of the `failure_reason` span field. Unknown values map to `Error`.
-    fn parse(s: &str) -> Self {
-        match s {
-            _ if s == Self::Conflict.as_str() => Self::Conflict,
-            _ if s == Self::RetryableIo.as_str() => Self::RetryableIo,
-            _ => Self::Error,
-        }
-    }
-}
-
-impl fmt::Display for CommitFailureReason {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
-    }
 }
 
 /// A transaction commit did not succeed; `reason` distinguishes conflict, retryable IO, and
@@ -1349,6 +1328,8 @@ pub(crate) fn emit_scan_metadata_completed(e: &ScanMetadataCompleted) {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
 
     fn commit_success(operation_id: MetricId) -> TransactionCommitSuccess {
@@ -1368,32 +1349,23 @@ mod tests {
         }
     }
 
-    #[test]
-    fn commit_failure_reason_parse_round_trips_and_defaults_unknown_to_error() {
-        for reason in [
-            CommitFailureReason::Conflict,
-            CommitFailureReason::RetryableIo,
-            CommitFailureReason::Error,
-        ] {
-            assert_eq!(CommitFailureReason::parse(reason.as_str()), reason);
-        }
-        assert_eq!(
-            CommitFailureReason::parse("nope"),
-            CommitFailureReason::Error
-        );
-        assert_eq!(CommitFailureReason::parse(""), CommitFailureReason::Error);
-    }
-
-    #[test]
-    fn record_str_failure_reason_flips_success_to_failure_preserving_id() {
+    #[rstest]
+    #[case::conflict("conflict", CommitFailureReason::Conflict)]
+    #[case::retryable_io("retryable_io", CommitFailureReason::RetryableIo)]
+    #[case::error("error", CommitFailureReason::Error)]
+    #[case::unknown_defaults_to_error("totally_unknown", CommitFailureReason::Error)]
+    fn record_str_failure_reason_flips_to_expected_reason(
+        #[case] value: &str,
+        #[case] expected: CommitFailureReason,
+    ) {
         let id = MetricId::new();
         let mut event = MetricEvent::TransactionCommitSuccess(commit_success(id));
-        event.record_str("failure_reason", "retryable_io").unwrap();
+        event.record_str("failure_reason", value).unwrap();
         let MetricEvent::TransactionCommitFailure(failure) = event else {
             panic!("expected TransactionCommitFailure");
         };
         assert_eq!(failure.operation_id, id);
-        assert_eq!(failure.reason, CommitFailureReason::RetryableIo);
+        assert_eq!(failure.reason, expected);
     }
 
     #[test]

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -78,6 +78,8 @@ pub enum MetricEvent {
     ProtocolMetadataLoadFailure(ProtocolMetadataLoadFailure),
     SnapshotBuildSuccess(SnapshotBuildSuccess),
     SnapshotBuildFailure(SnapshotBuildFailure),
+    TransactionCommitSuccess(TransactionCommitSuccess),
+    TransactionCommitFailure(TransactionCommitFailure),
     DomainMetadataLoadSuccess(DomainMetadataLoadSuccess),
     DomainMetadataLoadFailure,
     SetTransactionLoadSuccess(SetTransactionLoadSuccess),
@@ -100,6 +102,7 @@ impl MetricEvent {
             Self::LogSegmentLoadSuccess(e) => e.set_duration(d),
             Self::ProtocolMetadataLoadSuccess(e) => e.set_duration(d),
             Self::SnapshotBuildSuccess(e) => e.set_duration(d),
+            Self::TransactionCommitSuccess(e) => e.set_duration(d),
             Self::DomainMetadataLoadSuccess(e) => e.set_duration(d),
             Self::SetTransactionLoadSuccess(e) => e.set_duration(d),
             Self::CrcReadSuccess(e) => e.set_duration(d),
@@ -109,6 +112,7 @@ impl MetricEvent {
             Self::LogSegmentLoadFailure(_)
             | Self::ProtocolMetadataLoadFailure(_)
             | Self::SnapshotBuildFailure(_)
+            | Self::TransactionCommitFailure(_)
             | Self::DomainMetadataLoadFailure
             | Self::SetTransactionLoadFailure
             | Self::CrcReadFailure
@@ -126,6 +130,7 @@ impl MetricEvent {
             // Variants with u64 fields set during span lifetime.
             Self::LogSegmentLoadSuccess(e) => e.record_u64(name, value),
             Self::SnapshotBuildSuccess(e) => e.record_u64(name, value),
+            Self::TransactionCommitSuccess(e) => e.record_u64(name, value),
             Self::DomainMetadataLoadSuccess(e) => e.record_u64(name, value),
             Self::CrcReadSuccess(e) => e.record_u64(name, value),
 
@@ -143,6 +148,7 @@ impl MetricEvent {
             Self::LogSegmentLoadFailure(_) => Err(LogSegmentLoadSuccess::SPAN_NAME),
             Self::ProtocolMetadataLoadFailure(_) => Err(ProtocolMetadataLoadSuccess::SPAN_NAME),
             Self::SnapshotBuildFailure(_) => Err(SnapshotBuildSuccess::SPAN_NAME),
+            Self::TransactionCommitFailure(_) => Err(TransactionCommitSuccess::SPAN_NAME),
             Self::DomainMetadataLoadFailure => Err(DomainMetadataLoadSuccess::SPAN_NAME),
             Self::SetTransactionLoadFailure => Err(SetTransactionLoadSuccess::SPAN_NAME),
             Self::CrcReadFailure => Err(CrcReadSuccess::SPAN_NAME),
@@ -153,6 +159,7 @@ impl MetricEvent {
         match self {
             // Variants with bool fields set during span lifetime.
             Self::LogSegmentLoadSuccess(e) => e.record_bool(name, value),
+            Self::TransactionCommitSuccess(e) => e.record_bool(name, value),
             Self::DomainMetadataLoadSuccess(e) => e.record_bool(name, value),
             Self::SetTransactionLoadSuccess(e) => e.record_bool(name, value),
 
@@ -171,9 +178,29 @@ impl MetricEvent {
             Self::LogSegmentLoadFailure(_) => Err(LogSegmentLoadSuccess::SPAN_NAME),
             Self::ProtocolMetadataLoadFailure(_) => Err(ProtocolMetadataLoadSuccess::SPAN_NAME),
             Self::SnapshotBuildFailure(_) => Err(SnapshotBuildSuccess::SPAN_NAME),
+            Self::TransactionCommitFailure(_) => Err(TransactionCommitSuccess::SPAN_NAME),
             Self::DomainMetadataLoadFailure => Err(DomainMetadataLoadSuccess::SPAN_NAME),
             Self::SetTransactionLoadFailure => Err(SetTransactionLoadSuccess::SPAN_NAME),
             Self::CrcReadFailure => Err(CrcReadSuccess::SPAN_NAME),
+        }
+    }
+
+    pub(crate) fn record_str(&mut self, name: &str, value: &str) -> Result<(), &'static str> {
+        if name == "failure_reason" {
+            if let Self::TransactionCommitSuccess(e) = self {
+                let operation_id = e.operation_id;
+                *self = Self::TransactionCommitFailure(TransactionCommitFailure {
+                    operation_id,
+                    reason: CommitFailureReason::parse(value),
+                });
+            }
+            return Ok(());
+        }
+        // Only TransactionCommitSuccess records string fields today. If other events need them,
+        // dispatch per-variant like `record_u64`/`record_bool` above instead of this catch-all.
+        match self {
+            Self::TransactionCommitSuccess(e) => e.record_str(name, value),
+            _ => Ok(()),
         }
     }
 
@@ -191,6 +218,12 @@ impl MetricEvent {
             Self::SnapshotBuildSuccess(e) => Self::SnapshotBuildFailure(SnapshotBuildFailure {
                 operation_id: e.operation_id,
             }),
+            Self::TransactionCommitSuccess(e) => {
+                Self::TransactionCommitFailure(TransactionCommitFailure {
+                    operation_id: e.operation_id,
+                    reason: CommitFailureReason::Error,
+                })
+            }
             Self::DomainMetadataLoadSuccess(_) => Self::DomainMetadataLoadFailure,
             Self::SetTransactionLoadSuccess(_) => Self::SetTransactionLoadFailure,
             Self::CrcReadSuccess(_) => Self::CrcReadFailure,
@@ -200,6 +233,7 @@ impl MetricEvent {
             e @ (Self::LogSegmentLoadFailure(_)
             | Self::ProtocolMetadataLoadFailure(_)
             | Self::SnapshotBuildFailure(_)
+            | Self::TransactionCommitFailure(_)
             | Self::DomainMetadataLoadFailure
             | Self::SetTransactionLoadFailure
             | Self::CrcReadFailure
@@ -222,6 +256,8 @@ impl fmt::Display for MetricEvent {
             Self::ProtocolMetadataLoadFailure(e) => e.fmt(f),
             Self::SnapshotBuildSuccess(e) => e.fmt(f),
             Self::SnapshotBuildFailure(e) => e.fmt(f),
+            Self::TransactionCommitSuccess(e) => e.fmt(f),
+            Self::TransactionCommitFailure(e) => e.fmt(f),
             Self::DomainMetadataLoadSuccess(e) => e.fmt(f),
             Self::DomainMetadataLoadFailure => f.write_str("DomainMetadataLoadFailure"),
             Self::SetTransactionLoadSuccess(e) => e.fmt(f),
@@ -464,6 +500,193 @@ impl fmt::Display for SnapshotBuildFailure {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SnapshotBuildFailure(id={})", self.operation_id)
     }
+}
+
+// ====================================================================
+// TransactionCommit
+// ====================================================================
+
+pub(crate) const TRANSACTION_COMMIT_SPAN: &str = "txn.commit";
+
+/// A transaction was committed successfully.
+#[derive(Debug, Clone)]
+pub struct TransactionCommitSuccess {
+    // === Set on span creation ===
+    pub operation_id: MetricId,
+    pub commit_version: u64,
+
+    // === Set during span lifetime ===
+    pub num_add_files: u64,
+    pub num_remove_files: u64,
+    pub add_files_bytes: u64,
+    pub remove_files_bytes: u64,
+    pub is_blind_append: bool,
+    pub data_change: bool,
+    pub operation: Option<String>,
+    /// Time assembling and validating the commit, before the committer call.
+    pub prepare_duration: Duration,
+    /// Time in the committer's `commit()` call.
+    pub committer_duration: Duration,
+
+    // === Set on span close ===
+    pub duration: Duration,
+}
+
+impl TransactionCommitSuccess {
+    pub(crate) const SPAN_NAME: &'static str = TRANSACTION_COMMIT_SPAN;
+
+    pub(crate) fn from_attrs(attrs: &Attributes<'_>) -> Self {
+        let mut v = TransactionCommitAttrs::default();
+        attrs.record(&mut v);
+        Self {
+            operation_id: MetricId::from_attrs(attrs),
+            commit_version: v.commit_version,
+            num_add_files: 0,
+            num_remove_files: 0,
+            add_files_bytes: 0,
+            remove_files_bytes: 0,
+            is_blind_append: false,
+            data_change: false,
+            operation: None,
+            prepare_duration: Duration::default(),
+            committer_duration: Duration::default(),
+            duration: Duration::default(),
+        }
+    }
+
+    pub(crate) fn record_u64(&mut self, name: &str, value: u64) -> Result<(), &'static str> {
+        match name {
+            "num_add_files" => self.num_add_files = value,
+            "num_remove_files" => self.num_remove_files = value,
+            "add_files_bytes" => self.add_files_bytes = value,
+            "remove_files_bytes" => self.remove_files_bytes = value,
+            "prepare_duration_ns" => self.prepare_duration = Duration::from_nanos(value),
+            "committer_duration_ns" => self.committer_duration = Duration::from_nanos(value),
+            _ => return Err(Self::SPAN_NAME),
+        }
+        Ok(())
+    }
+
+    pub(crate) fn record_bool(&mut self, name: &str, value: bool) -> Result<(), &'static str> {
+        match name {
+            "is_blind_append" => self.is_blind_append = value,
+            "data_change" => self.data_change = value,
+            _ => return Err(Self::SPAN_NAME),
+        }
+        Ok(())
+    }
+
+    pub(crate) fn record_str(&mut self, name: &str, value: &str) -> Result<(), &'static str> {
+        match name {
+            "operation" => self.operation = Some(value.to_string()),
+            _ => return Err(Self::SPAN_NAME),
+        }
+        Ok(())
+    }
+
+    pub(crate) fn set_duration(&mut self, d: Duration) {
+        self.duration = d;
+    }
+}
+
+impl fmt::Display for TransactionCommitSuccess {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            operation_id,
+            commit_version,
+            num_add_files,
+            num_remove_files,
+            add_files_bytes,
+            remove_files_bytes,
+            is_blind_append,
+            data_change,
+            operation,
+            prepare_duration,
+            committer_duration,
+            duration,
+        } = self;
+        write!(
+            f,
+            "TransactionCommitSuccess(id={operation_id}, version={commit_version}, \
+             duration={duration:?}, prepare={prepare_duration:?}, committer={committer_duration:?}, \
+             add_files={num_add_files}, remove_files={num_remove_files}, \
+             add_bytes={add_files_bytes}, remove_bytes={remove_files_bytes}, \
+             is_blind_append={is_blind_append}, data_change={data_change}, operation={operation:?})"
+        )
+    }
+}
+
+/// Why a transaction commit did not succeed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommitFailureReason {
+    /// The commit conflicted with a concurrently committed version.
+    Conflict,
+    /// A retryable IO error occurred during the commit.
+    RetryableIo,
+    /// A terminal (non-retryable) error occurred.
+    Error,
+}
+
+impl CommitFailureReason {
+    /// The `failure_reason` span-field string for this reason. Producer and parser share this.
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Conflict => "conflict",
+            Self::RetryableIo => "retryable_io",
+            Self::Error => "error",
+        }
+    }
+
+    /// Parse the value of the `failure_reason` span field. Unknown values map to `Error`.
+    fn parse(s: &str) -> Self {
+        match s {
+            _ if s == Self::Conflict.as_str() => Self::Conflict,
+            _ if s == Self::RetryableIo.as_str() => Self::RetryableIo,
+            _ => Self::Error,
+        }
+    }
+}
+
+impl fmt::Display for CommitFailureReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A transaction commit did not succeed; `reason` distinguishes conflict, retryable IO, and
+/// terminal errors.
+#[derive(Debug, Clone)]
+pub struct TransactionCommitFailure {
+    pub operation_id: MetricId,
+    pub reason: CommitFailureReason,
+}
+
+impl fmt::Display for TransactionCommitFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            operation_id,
+            reason,
+        } = self;
+        write!(
+            f,
+            "TransactionCommitFailure(id={operation_id}, reason={reason})"
+        )
+    }
+}
+
+#[derive(Default)]
+struct TransactionCommitAttrs {
+    commit_version: u64,
+}
+
+impl Visit for TransactionCommitAttrs {
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        if field.name() == "commit_version" {
+            self.commit_version = value;
+        }
+    }
+
+    fn record_debug(&mut self, _field: &Field, _value: &dyn fmt::Debug) {}
 }
 
 // ====================================================================
@@ -1122,4 +1345,75 @@ pub(crate) fn emit_scan_metadata_completed(e: &ScanMetadataCompleted) {
         dedup_visitor_time_ms = e.dedup_visitor_time_ms,
         predicate_eval_time_ms = e.predicate_eval_time_ms,
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn commit_success(operation_id: MetricId) -> TransactionCommitSuccess {
+        TransactionCommitSuccess {
+            operation_id,
+            commit_version: 1,
+            num_add_files: 0,
+            num_remove_files: 0,
+            add_files_bytes: 0,
+            remove_files_bytes: 0,
+            is_blind_append: false,
+            data_change: false,
+            operation: None,
+            prepare_duration: Duration::default(),
+            committer_duration: Duration::default(),
+            duration: Duration::default(),
+        }
+    }
+
+    #[test]
+    fn commit_failure_reason_parse_round_trips_and_defaults_unknown_to_error() {
+        for reason in [
+            CommitFailureReason::Conflict,
+            CommitFailureReason::RetryableIo,
+            CommitFailureReason::Error,
+        ] {
+            assert_eq!(CommitFailureReason::parse(reason.as_str()), reason);
+        }
+        assert_eq!(
+            CommitFailureReason::parse("nope"),
+            CommitFailureReason::Error
+        );
+        assert_eq!(CommitFailureReason::parse(""), CommitFailureReason::Error);
+    }
+
+    #[test]
+    fn record_str_failure_reason_flips_success_to_failure_preserving_id() {
+        let id = MetricId::new();
+        let mut event = MetricEvent::TransactionCommitSuccess(commit_success(id));
+        event.record_str("failure_reason", "retryable_io").unwrap();
+        let MetricEvent::TransactionCommitFailure(failure) = event else {
+            panic!("expected TransactionCommitFailure");
+        };
+        assert_eq!(failure.operation_id, id);
+        assert_eq!(failure.reason, CommitFailureReason::RetryableIo);
+    }
+
+    #[test]
+    fn record_str_operation_sets_field_without_flipping() {
+        let mut event = MetricEvent::TransactionCommitSuccess(commit_success(MetricId::new()));
+        event.record_str("operation", "WRITE").unwrap();
+        let MetricEvent::TransactionCommitSuccess(success) = event else {
+            panic!("expected TransactionCommitSuccess");
+        };
+        assert_eq!(success.operation.as_deref(), Some("WRITE"));
+    }
+
+    #[test]
+    fn into_failure_maps_commit_success_to_error_reason() {
+        let id = MetricId::new();
+        let failure = MetricEvent::TransactionCommitSuccess(commit_success(id)).into_failure();
+        let MetricEvent::TransactionCommitFailure(failure) = failure else {
+            panic!("expected TransactionCommitFailure");
+        };
+        assert_eq!(failure.operation_id, id);
+        assert_eq!(failure.reason, CommitFailureReason::Error);
+    }
 }

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -529,7 +529,7 @@ pub struct TransactionCommitSuccess {
     pub committer_duration: Duration,
 
     // === Set on span close ===
-    pub duration: Duration,
+    pub total_duration: Duration,
 }
 
 impl TransactionCommitSuccess {
@@ -550,7 +550,7 @@ impl TransactionCommitSuccess {
             operation: None,
             prepare_duration: Duration::default(),
             committer_duration: Duration::default(),
-            duration: Duration::default(),
+            total_duration: Duration::default(),
         }
     }
 
@@ -585,7 +585,7 @@ impl TransactionCommitSuccess {
     }
 
     pub(crate) fn set_duration(&mut self, d: Duration) {
-        self.duration = d;
+        self.total_duration = d;
     }
 }
 
@@ -603,12 +603,12 @@ impl fmt::Display for TransactionCommitSuccess {
             operation,
             prepare_duration,
             committer_duration,
-            duration,
+            total_duration,
         } = self;
         write!(
             f,
             "TransactionCommitSuccess(id={operation_id}, version={commit_version}, \
-             duration={duration:?}, prepare={prepare_duration:?}, committer={committer_duration:?}, \
+             total_duration={total_duration:?}, prepare={prepare_duration:?}, committer={committer_duration:?}, \
              add_files={num_add_files}, remove_files={num_remove_files}, \
              add_bytes={add_files_bytes}, remove_bytes={remove_files_bytes}, \
              is_blind_append={is_blind_append}, data_change={data_change}, operation={operation:?})"
@@ -1364,7 +1364,7 @@ mod tests {
             operation: None,
             prepare_duration: Duration::default(),
             committer_duration: Duration::default(),
-            duration: Duration::default(),
+            total_duration: Duration::default(),
         }
     }
 

--- a/kernel/src/metrics/mod.rs
+++ b/kernel/src/metrics/mod.rs
@@ -84,12 +84,12 @@ mod streaming_metrics_iterator;
 use std::sync::Arc;
 
 pub use events::{
-    emit_json_read_completed, emit_parquet_read_completed, CrcReadSuccess,
+    emit_json_read_completed, emit_parquet_read_completed, CommitFailureReason, CrcReadSuccess,
     DomainMetadataLoadSuccess, JsonReadCompleted, LogSegmentLoadFailure, LogSegmentLoadSuccess,
     MetricEvent, MetricId, ParquetReadCompleted, ProtocolMetadataLoadFailure,
     ProtocolMetadataLoadSuccess, ScanMetadataCompleted, ScanType, SetTransactionLoadSuccess,
     SnapshotBuildFailure, SnapshotBuildSuccess, StorageCopyCompleted, StorageListCompleted,
-    StorageReadCompleted,
+    StorageReadCompleted, TransactionCommitFailure, TransactionCommitSuccess,
 };
 pub use metered_engine::MeteredDeltaEngine;
 pub use metered_json::MeteredJsonHandler;

--- a/kernel/src/metrics/reporter.rs
+++ b/kernel/src/metrics/reporter.rs
@@ -12,7 +12,8 @@ use tracing_subscriber::Layer;
 use super::events::{
     storage_metric_from_attrs, CrcReadSuccess, DomainMetadataLoadSuccess, JsonReadCompleted,
     LogSegmentLoadSuccess, MetricEvent, ParquetReadCompleted, ProtocolMetadataLoadSuccess,
-    ScanMetadataCompleted, SetTransactionLoadSuccess, SnapshotBuildSuccess, STORAGE_SPAN,
+    ScanMetadataCompleted, SetTransactionLoadSuccess, SnapshotBuildSuccess,
+    TransactionCommitSuccess, STORAGE_SPAN,
 };
 
 // ====================================================================
@@ -115,6 +116,9 @@ where
             }
             SnapshotBuildSuccess::SPAN_NAME => Some(MetricEvent::SnapshotBuildSuccess(
                 SnapshotBuildSuccess::from_attrs(attrs),
+            )),
+            TransactionCommitSuccess::SPAN_NAME => Some(MetricEvent::TransactionCommitSuccess(
+                TransactionCommitSuccess::from_attrs(attrs),
             )),
             DomainMetadataLoadSuccess::SPAN_NAME => Some(MetricEvent::DomainMetadataLoadSuccess(
                 DomainMetadataLoadSuccess::from_attrs(attrs),
@@ -239,6 +243,15 @@ impl Visit for EventVisitor {
             return;
         };
         if let Err(span_name) = event.record_bool(field.name(), value) {
+            self.warn_invalid(field, span_name);
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        let Some(event) = self.event.as_mut() else {
+            return;
+        };
+        if let Err(span_name) = event.record_str(field.name(), value) {
             self.warn_invalid(field, span_name);
         }
     }

--- a/kernel/src/transaction/alter_table.rs
+++ b/kernel/src/transaction/alter_table.rs
@@ -9,6 +9,7 @@
 use std::marker::PhantomData;
 
 use crate::committer::Committer;
+use crate::metrics::MetricId;
 use crate::snapshot::SnapshotRef;
 use crate::table_configuration::TableConfiguration;
 use crate::transaction::{AlterTable, Transaction};
@@ -47,6 +48,7 @@ impl AlterTableTransaction {
 
         Ok(Transaction {
             span,
+            operation_id: MetricId::new(),
             read_snapshot_opt: Some(read_snapshot),
             effective_table_config,
             should_emit_protocol: false,

--- a/kernel/src/transaction/create_table.rs
+++ b/kernel/src/transaction/create_table.rs
@@ -38,6 +38,7 @@ pub use super::builder::create_table::CreateTableTransactionBuilder;
 use crate::actions::DomainMetadata;
 use crate::committer::Committer;
 use crate::expressions::ColumnName;
+use crate::metrics::MetricId;
 use crate::schema::SchemaRef;
 use crate::table_configuration::TableConfiguration;
 use crate::transaction::{CreateTable, Transaction};
@@ -150,6 +151,7 @@ impl CreateTableTransaction {
         );
         Ok(Transaction {
             span,
+            operation_id: MetricId::new(),
             read_snapshot_opt: None,
             effective_table_config,
             should_emit_protocol: true,

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -536,13 +536,10 @@ impl<S> Transaction<S> {
                     self.into_committed(file_meta, crc_delta)?,
                 ))
             }
-            // The conflict and retryable arms both return Ok (the retryable arm converts the
-            // committer's IOError into Ok(RetryableTransaction)), so `#[instrument(err)]` does not
-            // flip the metric event. Each records its `failure_reason` to flip success -> failure.
-            // Only the terminal Err arm flips via `err`.
             Ok(CommitResponse::Conflict { version }) => {
+                // Flips the metric event from success -> failure.
                 tracing::Span::current()
-                    .record("failure_reason", CommitFailureReason::Conflict.as_str());
+                    .record("failure_reason", CommitFailureReason::Conflict.as_ref());
                 Ok(CommitResult::ConflictedTransaction(
                     self.into_conflicted(version),
                 ))
@@ -550,8 +547,9 @@ impl<S> Transaction<S> {
             // TODO: we may want to be more or less selective about what is retryable (this is tied
             // to the idea of "what kind of Errors should write_json_file return?")
             Err(e @ Error::IOError(_)) => {
+                // Flips the metric event from success -> failure.
                 tracing::Span::current()
-                    .record("failure_reason", CommitFailureReason::RetryableIo.as_str());
+                    .record("failure_reason", CommitFailureReason::RetryableIo.as_ref());
                 Ok(CommitResult::RetryableTransaction(self.into_retryable(e)))
             }
             Err(e) => Err(e),
@@ -1693,6 +1691,7 @@ mod tests {
     use crate::engine::arrow_expression::ArrowEvaluationHandler;
     use crate::engine::sync::SyncEngine;
     use crate::expressions::{MapData, Scalar, StructData};
+    use crate::metrics::MetricEvent;
     use crate::object_store::memory::InMemory;
     use crate::object_store::path::Path;
     use crate::object_store::ObjectStoreExt as _;
@@ -1700,8 +1699,9 @@ mod tests {
     use crate::table_features::ColumnMappingMode;
     use crate::transaction::create_table::create_table;
     use crate::utils::test_utils::{
-        load_test_table, string_array_to_engine_data, test_schema_flat, test_schema_nested,
-        test_schema_with_array, test_schema_with_map,
+        install_thread_local_metrics_reporter, load_test_table, string_array_to_engine_data,
+        test_schema_flat, test_schema_nested, test_schema_with_array, test_schema_with_map,
+        CapturingReporter,
     };
     use crate::{DeltaResultIterator, EvaluationHandler, Snapshot};
 
@@ -3066,11 +3066,9 @@ mod tests {
 
     // ===== Commit failure-metric tests =====
 
-    fn commit_failure_reason(
-        reporter: &crate::utils::test_utils::CapturingReporter,
-    ) -> Option<CommitFailureReason> {
+    fn commit_failure_reason(reporter: &CapturingReporter) -> Option<CommitFailureReason> {
         reporter.events().into_iter().find_map(|event| match event {
-            crate::metrics::MetricEvent::TransactionCommitFailure(f) => Some(f.reason),
+            MetricEvent::TransactionCommitFailure(f) => Some(f.reason),
             _ => None,
         })
     }
@@ -3078,9 +3076,8 @@ mod tests {
     #[test]
     fn test_commit_io_error_emits_retryable_io_failure_metric() -> DeltaResult<()> {
         let (engine, snapshot, _tempdir) = load_test_table("table-without-dv-small")?;
-        let reporter = Arc::new(crate::utils::test_utils::CapturingReporter::default());
-        let _guard =
-            crate::utils::test_utils::install_thread_local_metrics_reporter(reporter.clone());
+        let reporter = Arc::new(CapturingReporter::default());
+        let _guard = install_thread_local_metrics_reporter(reporter.clone());
         let mut txn = snapshot.transaction(Box::new(IoErrorCommitter), engine.as_ref())?;
         add_dummy_file(&mut txn);
         let result = txn.commit(engine.as_ref())?;
@@ -3095,9 +3092,8 @@ mod tests {
     #[test]
     fn test_commit_terminal_error_emits_error_failure_metric() -> DeltaResult<()> {
         let (engine, snapshot, _tempdir) = load_test_table("table-without-dv-small")?;
-        let reporter = Arc::new(crate::utils::test_utils::CapturingReporter::default());
-        let _guard =
-            crate::utils::test_utils::install_thread_local_metrics_reporter(reporter.clone());
+        let reporter = Arc::new(CapturingReporter::default());
+        let _guard = install_thread_local_metrics_reporter(reporter.clone());
         let mut txn = snapshot.transaction(Box::new(GenericErrorCommitter), engine.as_ref())?;
         add_dummy_file(&mut txn);
         assert!(txn.commit(engine.as_ref()).is_err());

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -3,6 +3,7 @@ use std::iter;
 use std::marker::PhantomData;
 use std::ops::Deref;
 use std::sync::{Arc, LazyLock};
+use std::time::{Duration, Instant};
 
 use delta_kernel_derive::internal_api;
 use tracing::{info, instrument};
@@ -21,6 +22,8 @@ use crate::error::Error;
 use crate::expressions::UnaryExpressionOp::ToJson;
 use crate::expressions::{ArrayData, ColumnName, ExpressionStructPatch, Scalar};
 use crate::log_segment::LogSegment;
+use crate::metrics::events::TRANSACTION_COMMIT_SPAN;
+use crate::metrics::{CommitFailureReason, MetricId};
 use crate::partition::serialization::serialize_partition_value;
 use crate::partition::validation::validate_partition_values;
 use crate::path::{LogRoot, ParsedLogPath};
@@ -221,6 +224,8 @@ impl SupportsDataFiles for CreateTable {}
 /// ```
 pub struct Transaction<S = ExistingTable> {
     span: tracing::Span,
+    // Correlates all metric events emitted by this transaction.
+    operation_id: MetricId,
     // The snapshot this transaction is based on. None for CREATE TABLE (no pre-existing table).
     // Use `read_snapshot()` to access; it returns an error if None.
     read_snapshot_opt: Option<SnapshotRef>,
@@ -334,14 +339,27 @@ impl<S> Transaction<S> {
     /// - Err(Error) indicates a non-retryable error (e.g. logic/validation error).
     #[instrument(
         parent = &self.span,
-        name = "txn.commit",
+        name = TRANSACTION_COMMIT_SPAN,
         skip_all,
         fields(
+            report,
+            operation_id = %self.operation_id,
             commit_version = self.get_commit_version(),
+            num_add_files,
+            num_remove_files,
+            add_files_bytes,
+            remove_files_bytes,
+            is_blind_append,
+            data_change,
+            operation,
+            prepare_duration_ns,
+            committer_duration_ns,
+            failure_reason,
         ),
         err
     )]
     pub fn commit(self, engine: &dyn Engine) -> DeltaResult<CommitResult<S>> {
+        let commit_start = Instant::now();
         info!(
             num_add_files = self.add_files_metadata.len(),
             num_remove_files = self.remove_files_metadata.len(),
@@ -486,36 +504,81 @@ impl<S> Transaction<S> {
             metadata,
             dm_changes.clone(),
         )?;
-        match self
-            .committer
-            .commit(engine, Box::new(filtered_actions), commit_metadata)
-        {
+        let prepare_duration = commit_start.elapsed();
+        let committer_start = Instant::now();
+        let commit_response =
+            self.committer
+                .commit(engine, Box::new(filtered_actions), commit_metadata);
+        let committer_duration = committer_start.elapsed();
+        match commit_response {
             Ok(CommitResponse::Committed { file_meta }) => {
+                // TODO(#2717): the commit already succeeded atomically; the post-commit `?`
+                //              below must not fail the txn (and must not mislabel the metric).
                 let bin_boundaries = self
                     .read_snapshot_opt
                     .as_ref()
                     .and_then(|snap| snap.get_file_stats_if_present())
                     .and_then(|s| s.file_size_histogram)
                     .map(|h| h.sorted_bin_boundaries);
-                let crc_delta = self.build_crc_delta(
-                    in_commit_timestamp,
-                    dm_changes,
+                let file_stats = FileStatsDelta::try_compute_for_txn(
+                    &self.add_files_metadata,
+                    &self.remove_files_metadata,
                     bin_boundaries.as_deref(),
                 )?;
+                self.record_commit_success_metrics(
+                    &file_stats,
+                    prepare_duration,
+                    committer_duration,
+                );
+                let crc_delta =
+                    self.build_crc_delta(file_stats, in_commit_timestamp, dm_changes)?;
                 Ok(CommitResult::CommittedTransaction(
                     self.into_committed(file_meta, crc_delta)?,
                 ))
             }
-            Ok(CommitResponse::Conflict { version }) => Ok(CommitResult::ConflictedTransaction(
-                self.into_conflicted(version),
-            )),
+            // The conflict and retryable arms both return Ok (the retryable arm converts the
+            // committer's IOError into Ok(RetryableTransaction)), so `#[instrument(err)]` does not
+            // flip the metric event. Each records its `failure_reason` to flip success -> failure.
+            // Only the terminal Err arm flips via `err`.
+            Ok(CommitResponse::Conflict { version }) => {
+                tracing::Span::current()
+                    .record("failure_reason", CommitFailureReason::Conflict.as_str());
+                Ok(CommitResult::ConflictedTransaction(
+                    self.into_conflicted(version),
+                ))
+            }
             // TODO: we may want to be more or less selective about what is retryable (this is tied
             // to the idea of "what kind of Errors should write_json_file return?")
             Err(e @ Error::IOError(_)) => {
+                tracing::Span::current()
+                    .record("failure_reason", CommitFailureReason::RetryableIo.as_str());
                 Ok(CommitResult::RetryableTransaction(self.into_retryable(e)))
             }
             Err(e) => Err(e),
         }
+    }
+
+    fn record_commit_success_metrics(
+        &self,
+        file_stats: &FileStatsDelta,
+        prepare_duration: Duration,
+        committer_duration: Duration,
+    ) {
+        let span = tracing::Span::current();
+        span.record("num_add_files", file_stats.gross_add_files);
+        span.record("num_remove_files", file_stats.gross_remove_files);
+        span.record("add_files_bytes", file_stats.gross_add_bytes);
+        span.record("remove_files_bytes", file_stats.gross_remove_bytes);
+        span.record("is_blind_append", self.is_blind_append);
+        span.record("data_change", self.data_change);
+        if let Some(operation) = self.operation.as_deref() {
+            span.record("operation", operation);
+        }
+        span.record("prepare_duration_ns", prepare_duration.as_nanos() as u64);
+        span.record(
+            "committer_duration_ns",
+            committer_duration.as_nanos() as u64,
+        );
     }
 
     /// Set the data change flag.
@@ -1260,18 +1323,14 @@ impl<S> Transaction<S> {
         })
     }
 
-    /// Build a [`CrcDelta`] from the transaction's staged file metadata and commit state.
+    /// Build a [`CrcDelta`] from the transaction's commit state and a precomputed
+    /// [`FileStatsDelta`].
     fn build_crc_delta(
         &self,
+        file_stats: FileStatsDelta,
         in_commit_timestamp: Option<i64>,
         dm_changes: Vec<DomainMetadata>,
-        bin_boundaries: Option<&[i64]>,
     ) -> DeltaResult<CrcDelta> {
-        let file_stats = FileStatsDelta::try_compute_for_txn(
-            &self.add_files_metadata,
-            &self.remove_files_metadata,
-            bin_boundaries,
-        )?;
         // TODO: drop these conversions by migrating the upstream chain
         //       (`CommitMetadata.domain_metadata_changes`, `Transaction.set_transactions`)
         //       to `HashMap<String, _>`, lifting protocol-mandated uniqueness from runtime
@@ -1666,6 +1725,31 @@ mod tests {
             _commit_metadata: CommitMetadata,
         ) -> DeltaResult<CommitResponse> {
             Err(Error::IOError(std::io::Error::other("simulated IO error")))
+        }
+        fn is_catalog_committer(&self) -> bool {
+            false
+        }
+        fn publish(
+            &self,
+            _engine: &dyn Engine,
+            _publish_metadata: PublishMetadata,
+        ) -> DeltaResult<()> {
+            Ok(())
+        }
+    }
+
+    /// A mock committer that always returns a non-retryable (non-IO) error, used to test the
+    /// terminal error path.
+    struct GenericErrorCommitter;
+
+    impl Committer for GenericErrorCommitter {
+        fn commit(
+            &self,
+            _engine: &dyn Engine,
+            _actions: DeltaResultIterator<'_, FilteredEngineData>,
+            _commit_metadata: CommitMetadata,
+        ) -> DeltaResult<CommitResponse> {
+            Err(Error::generic("simulated commit error"))
         }
         fn is_catalog_committer(&self) -> bool {
             false
@@ -2976,6 +3060,50 @@ mod tests {
             future_ict + 1,
             "CommitMetadata.in_commit_timestamp should be the computed ICT (prev_ict + 1), \
              not the wall-clock time"
+        );
+        Ok(())
+    }
+
+    // ===== Commit failure-metric tests =====
+
+    fn commit_failure_reason(
+        reporter: &crate::utils::test_utils::CapturingReporter,
+    ) -> Option<CommitFailureReason> {
+        reporter.events().into_iter().find_map(|event| match event {
+            crate::metrics::MetricEvent::TransactionCommitFailure(f) => Some(f.reason),
+            _ => None,
+        })
+    }
+
+    #[test]
+    fn test_commit_io_error_emits_retryable_io_failure_metric() -> DeltaResult<()> {
+        let (engine, snapshot, _tempdir) = load_test_table("table-without-dv-small")?;
+        let reporter = Arc::new(crate::utils::test_utils::CapturingReporter::default());
+        let _guard =
+            crate::utils::test_utils::install_thread_local_metrics_reporter(reporter.clone());
+        let mut txn = snapshot.transaction(Box::new(IoErrorCommitter), engine.as_ref())?;
+        add_dummy_file(&mut txn);
+        let result = txn.commit(engine.as_ref())?;
+        assert!(matches!(result, CommitResult::RetryableTransaction(_)));
+        assert_eq!(
+            commit_failure_reason(&reporter),
+            Some(CommitFailureReason::RetryableIo)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_commit_terminal_error_emits_error_failure_metric() -> DeltaResult<()> {
+        let (engine, snapshot, _tempdir) = load_test_table("table-without-dv-small")?;
+        let reporter = Arc::new(crate::utils::test_utils::CapturingReporter::default());
+        let _guard =
+            crate::utils::test_utils::install_thread_local_metrics_reporter(reporter.clone());
+        let mut txn = snapshot.transaction(Box::new(GenericErrorCommitter), engine.as_ref())?;
+        add_dummy_file(&mut txn);
+        assert!(txn.commit(engine.as_ref()).is_err());
+        assert_eq!(
+            commit_failure_reason(&reporter),
+            Some(CommitFailureReason::Error)
         );
         Ok(())
     }

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -27,6 +27,7 @@ use crate::error::Error;
 use crate::expressions::{
     column_name, ArrayData, ColumnName, ExpressionStructPatch, Scalar, StructData,
 };
+use crate::metrics::MetricId;
 use crate::scan::data_skipping::stats_schema::schema_with_all_fields_nullable;
 use crate::scan::log_replay::get_scan_metadata_transform_expr;
 use crate::scan::{restored_add_schema, scan_row_schema};
@@ -77,6 +78,7 @@ impl Transaction {
 
         Ok(Transaction {
             span,
+            operation_id: MetricId::new(),
             read_snapshot_opt: Some(read_snapshot),
             effective_table_config,
             should_emit_protocol: false,

--- a/kernel/tests/integration/metrics/commit.rs
+++ b/kernel/tests/integration/metrics/commit.rs
@@ -18,6 +18,7 @@ use url::Url;
 
 use super::{measuring_engine, simple_schema};
 
+/// Reporter that keeps the last `TransactionCommitSuccess` for field-level assertions.
 #[derive(Debug, Default)]
 struct LastCommitSuccess(Mutex<Option<TransactionCommitSuccess>>);
 
@@ -42,63 +43,11 @@ fn setup_empty_table() -> DeltaResult<(tempfile::TempDir, Url)> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn commit_append_emits_success_metrics() -> DeltaResult<()> {
     let (_temp_dir, table_url) = setup_empty_table()?;
-    let (engine, reporter, _guard) = measuring_engine(Arc::new(LocalFileSystem::new()));
-    let engine = Arc::new(engine);
-    let snap = Snapshot::builder_for(table_url).build(engine.as_ref())?;
-
-    reporter.reset();
-    let committed = insert_data(
-        snap,
-        &engine,
-        vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
-    )
-    .await?
-    .unwrap_committed();
-
-    assert_eq!(committed.commit_version(), 1);
-    assert_eq!(reporter.transaction_commits.get(), 1);
-    assert_eq!(reporter.commit_add_files.get(), 1);
-    assert!(reporter.commit_add_bytes.get() > 0);
-    assert_eq!(reporter.commit_remove_files.get(), 0);
-    assert_eq!(reporter.commit_remove_bytes.get(), 0);
-    assert_eq!(reporter.commit_conflicts.get(), 0);
-    assert_eq!(reporter.commit_errors.get(), 0);
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn commit_conflict_emits_conflict_metric() -> DeltaResult<()> {
-    let (_temp_dir, table_url) = setup_empty_table()?;
-    let (engine, reporter, _guard) = measuring_engine(Arc::new(LocalFileSystem::new()));
-    let engine = Arc::new(engine);
-    let snap = Snapshot::builder_for(table_url).build(engine.as_ref())?;
-
-    reporter.reset();
-    insert_data(
-        snap.clone(),
-        &engine,
-        vec![Arc::new(Int32Array::from(vec![1]))],
-    )
-    .await?
-    .unwrap_committed();
-    // Both transactions are built from the same base snapshot, so the second targets a version
-    // the first already wrote, forcing a conflict.
-    let result = insert_data(snap, &engine, vec![Arc::new(Int32Array::from(vec![2]))]).await?;
-
-    assert!(matches!(result, CommitResult::ConflictedTransaction(_)));
-    assert_eq!(reporter.transaction_commits.get(), 1);
-    assert_eq!(reporter.commit_conflicts.get(), 1);
-    assert_eq!(reporter.commit_errors.get(), 0);
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn commit_success_event_carries_operation_and_flags() -> DeltaResult<()> {
-    let (_temp_dir, table_url) = setup_empty_table()?;
     let reporter = Arc::new(LastCommitSuccess::default());
     let engine = Arc::new(DefaultEngineBuilder::new(Arc::new(LocalFileSystem::new())).build());
     let _guard = install_thread_local_metrics_reporter(reporter.clone());
     let snap = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+
     insert_data(
         snap,
         &engine,
@@ -113,9 +62,42 @@ async fn commit_success_event_carries_operation_and_flags() -> DeltaResult<()> {
         .unwrap()
         .clone()
         .expect("commit success event");
+    assert_eq!(success.commit_version, 1);
+    assert_eq!(success.num_add_files, 1);
+    assert!(success.add_files_bytes > 0);
+    assert_eq!(success.num_remove_files, 0);
+    assert_eq!(success.remove_files_bytes, 0);
     assert_eq!(success.operation.as_deref(), Some("WRITE"));
     assert!(success.data_change);
     assert!(!success.is_blind_append);
-    assert_eq!(success.num_add_files, 1);
+    assert!(success.total_duration >= success.prepare_duration + success.committer_duration);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn commit_conflict_emits_conflict_metric() -> DeltaResult<()> {
+    // GIVEN a table at v0 (00.json) and a snapshot pinned to it.
+    let (_temp_dir, table_url) = setup_empty_table()?;
+    let (engine, reporter, _guard) = measuring_engine(Arc::new(LocalFileSystem::new()));
+    let engine = Arc::new(engine);
+    let snap = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+
+    reporter.reset();
+    // WHEN a first append commits against that snapshot, advancing the table to v1 (01.json).
+    insert_data(
+        snap.clone(),
+        &engine,
+        vec![Arc::new(Int32Array::from(vec![1]))],
+    )
+    .await?
+    .unwrap_committed();
+    // AND a second append reuses the SAME v0 snapshot, so it also targets v1 (already written).
+    let result = insert_data(snap, &engine, vec![Arc::new(Int32Array::from(vec![2]))]).await?;
+
+    // THEN the second commit conflicts and emits exactly one conflict metric.
+    assert!(matches!(result, CommitResult::ConflictedTransaction(_)));
+    assert_eq!(reporter.transaction_commits.get(), 1);
+    assert_eq!(reporter.commit_conflicts.get(), 1);
+    assert_eq!(reporter.commit_errors.get(), 0);
     Ok(())
 }

--- a/kernel/tests/integration/metrics/commit.rs
+++ b/kernel/tests/integration/metrics/commit.rs
@@ -12,8 +12,11 @@ use delta_kernel::object_store::local::LocalFileSystem;
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::CommitResult;
 use delta_kernel::{DeltaResult, Snapshot};
+use rstest::rstest;
 use test_utils::delta_kernel_default_engine::DefaultEngineBuilder;
-use test_utils::{insert_data, install_thread_local_metrics_reporter, test_table_setup_mt};
+use test_utils::{
+    insert_data, insert_data_with, install_thread_local_metrics_reporter, test_table_setup_mt,
+};
 use url::Url;
 
 use super::{measuring_engine, simple_schema};
@@ -40,18 +43,29 @@ fn setup_empty_table() -> DeltaResult<(tempfile::TempDir, Url)> {
     Ok((temp_dir, table_url))
 }
 
+#[rstest]
+#[case::write_append("WRITE", true, false)]
+#[case::blind_append("WRITE", true, true)]
+#[case::optimize_no_data_change("OPTIMIZE", false, false)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn commit_append_emits_success_metrics() -> DeltaResult<()> {
+async fn commit_append_emits_success_metrics(
+    #[case] operation: &str,
+    #[case] data_change: bool,
+    #[case] is_blind_append: bool,
+) -> DeltaResult<()> {
     let (_temp_dir, table_url) = setup_empty_table()?;
     let reporter = Arc::new(LastCommitSuccess::default());
     let engine = Arc::new(DefaultEngineBuilder::new(Arc::new(LocalFileSystem::new())).build());
     let _guard = install_thread_local_metrics_reporter(reporter.clone());
     let snap = Snapshot::builder_for(table_url).build(engine.as_ref())?;
 
-    insert_data(
+    insert_data_with(
         snap,
         &engine,
         vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        operation,
+        data_change,
+        is_blind_append,
     )
     .await?
     .unwrap_committed();
@@ -67,9 +81,9 @@ async fn commit_append_emits_success_metrics() -> DeltaResult<()> {
     assert!(success.add_files_bytes > 0);
     assert_eq!(success.num_remove_files, 0);
     assert_eq!(success.remove_files_bytes, 0);
-    assert_eq!(success.operation.as_deref(), Some("WRITE"));
-    assert!(success.data_change);
-    assert!(!success.is_blind_append);
+    assert_eq!(success.operation.as_deref(), Some(operation));
+    assert_eq!(success.data_change, data_change);
+    assert_eq!(success.is_blind_append, is_blind_append);
     assert!(success.total_duration >= success.prepare_duration + success.committer_duration);
     Ok(())
 }

--- a/kernel/tests/integration/metrics/commit.rs
+++ b/kernel/tests/integration/metrics/commit.rs
@@ -1,0 +1,121 @@
+//! Metrics tests for `Transaction::commit`.
+//!
+//! Each test builds a table, attaches a metrics reporter, runs a commit, and asserts the
+//! commit metrics a real connector would observe.
+
+use std::sync::{Arc, Mutex};
+
+use delta_kernel::arrow::array::Int32Array;
+use delta_kernel::committer::FileSystemCommitter;
+use delta_kernel::metrics::{MetricEvent, MetricsReporter, TransactionCommitSuccess};
+use delta_kernel::object_store::local::LocalFileSystem;
+use delta_kernel::transaction::create_table::create_table;
+use delta_kernel::transaction::CommitResult;
+use delta_kernel::{DeltaResult, Snapshot};
+use test_utils::delta_kernel_default_engine::DefaultEngineBuilder;
+use test_utils::{insert_data, install_thread_local_metrics_reporter, test_table_setup_mt};
+use url::Url;
+
+use super::{measuring_engine, simple_schema};
+
+#[derive(Debug, Default)]
+struct LastCommitSuccess(Mutex<Option<TransactionCommitSuccess>>);
+
+impl MetricsReporter for LastCommitSuccess {
+    fn report(&self, event: MetricEvent) {
+        if let MetricEvent::TransactionCommitSuccess(success) = event {
+            *self.0.lock().unwrap() = Some(success);
+        }
+    }
+}
+
+fn setup_empty_table() -> DeltaResult<(tempfile::TempDir, Url)> {
+    let (temp_dir, table_path, setup_engine) = test_table_setup_mt()?;
+    let table_url = delta_kernel::try_parse_uri(&table_path)?;
+    create_table(&table_path, simple_schema(), "Test/1.0")
+        .build(setup_engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(setup_engine.as_ref())?
+        .unwrap_committed();
+    Ok((temp_dir, table_url))
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn commit_append_emits_success_metrics() -> DeltaResult<()> {
+    let (_temp_dir, table_url) = setup_empty_table()?;
+    let (engine, reporter, _guard) = measuring_engine(Arc::new(LocalFileSystem::new()));
+    let engine = Arc::new(engine);
+    let snap = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+
+    reporter.reset();
+    let committed = insert_data(
+        snap,
+        &engine,
+        vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+    )
+    .await?
+    .unwrap_committed();
+
+    assert_eq!(committed.commit_version(), 1);
+    assert_eq!(reporter.transaction_commits.get(), 1);
+    assert_eq!(reporter.commit_add_files.get(), 1);
+    assert!(reporter.commit_add_bytes.get() > 0);
+    assert_eq!(reporter.commit_remove_files.get(), 0);
+    assert_eq!(reporter.commit_remove_bytes.get(), 0);
+    assert_eq!(reporter.commit_conflicts.get(), 0);
+    assert_eq!(reporter.commit_errors.get(), 0);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn commit_conflict_emits_conflict_metric() -> DeltaResult<()> {
+    let (_temp_dir, table_url) = setup_empty_table()?;
+    let (engine, reporter, _guard) = measuring_engine(Arc::new(LocalFileSystem::new()));
+    let engine = Arc::new(engine);
+    let snap = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+
+    reporter.reset();
+    insert_data(
+        snap.clone(),
+        &engine,
+        vec![Arc::new(Int32Array::from(vec![1]))],
+    )
+    .await?
+    .unwrap_committed();
+    // Both transactions are built from the same base snapshot, so the second targets a version
+    // the first already wrote, forcing a conflict.
+    let result = insert_data(snap, &engine, vec![Arc::new(Int32Array::from(vec![2]))]).await?;
+
+    assert!(matches!(result, CommitResult::ConflictedTransaction(_)));
+    assert_eq!(reporter.transaction_commits.get(), 1);
+    assert_eq!(reporter.commit_conflicts.get(), 1);
+    assert_eq!(reporter.commit_errors.get(), 0);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn commit_success_event_carries_operation_and_flags() -> DeltaResult<()> {
+    let (_temp_dir, table_url) = setup_empty_table()?;
+    let reporter = Arc::new(LastCommitSuccess::default());
+    let engine = Arc::new(DefaultEngineBuilder::new(Arc::new(LocalFileSystem::new())).build());
+    let _guard = install_thread_local_metrics_reporter(reporter.clone());
+    let snap = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+    insert_data(
+        snap,
+        &engine,
+        vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+    )
+    .await?
+    .unwrap_committed();
+
+    let success = reporter
+        .0
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("commit success event");
+    assert_eq!(success.operation.as_deref(), Some("WRITE"));
+    assert!(success.data_change);
+    assert!(!success.is_blind_append);
+    assert_eq!(success.num_add_files, 1);
+    Ok(())
+}

--- a/kernel/tests/integration/metrics/mod.rs
+++ b/kernel/tests/integration/metrics/mod.rs
@@ -29,6 +29,7 @@ use test_utils::{
 };
 use url::Url;
 
+mod commit;
 mod scan;
 mod snapshot_load;
 

--- a/kernel/tests/integration/metrics/mod.rs
+++ b/kernel/tests/integration/metrics/mod.rs
@@ -9,6 +9,7 @@
 //! - [`snapshot_load`]: snapshot-loading scenarios (delta-only, checkpoint, compaction, CRC, and
 //!   on-demand API calls like `get_domain_metadata`)
 //! - [`scan`]: scan execution scenarios (`scan.execute()` parquet data-file reads)
+//! - [`commit`]: `Transaction::commit()` success / conflict metrics
 //!
 //! Where possible, tests use [`TestTableBuilder`] for table setup. Tests that need
 //! checkpoint, CRC, or log compaction features still use manual helpers until those

--- a/test-utils/src/counting_reporter.rs
+++ b/test-utils/src/counting_reporter.rs
@@ -7,7 +7,9 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 
-use delta_kernel::metrics::{MetricEvent, MetricsReporter, WithMetricsReporterLayer as _};
+use delta_kernel::metrics::{
+    CommitFailureReason, MetricEvent, MetricsReporter, WithMetricsReporterLayer as _,
+};
 use tracing::subscriber::DefaultGuard;
 use tracing_subscriber::util::SubscriberInitExt as _;
 
@@ -188,6 +190,16 @@ pub struct CountingReporter {
     pub set_transaction_load_failures: RelaxedCounter,
     pub set_transaction_cache_hits: RelaxedCounter,
     pub set_transaction_found: RelaxedCounter,
+
+    // Transaction commit counters (Transaction::commit)
+    pub transaction_commits: RelaxedCounter,
+    pub commit_conflicts: RelaxedCounter,
+    pub commit_retryable_failures: RelaxedCounter,
+    pub commit_errors: RelaxedCounter,
+    pub commit_add_files: RelaxedCounter,
+    pub commit_remove_files: RelaxedCounter,
+    pub commit_add_bytes: RelaxedCounter,
+    pub commit_remove_bytes: RelaxedCounter,
 }
 
 impl CountingReporter {
@@ -228,6 +240,14 @@ impl CountingReporter {
         self.set_transaction_load_failures.reset();
         self.set_transaction_cache_hits.reset();
         self.set_transaction_found.reset();
+        self.transaction_commits.reset();
+        self.commit_conflicts.reset();
+        self.commit_retryable_failures.reset();
+        self.commit_errors.reset();
+        self.commit_add_files.reset();
+        self.commit_remove_files.reset();
+        self.commit_add_bytes.reset();
+        self.commit_remove_bytes.reset();
     }
 
     /// Print a human-readable IO and operation summary.
@@ -328,6 +348,18 @@ impl MetricsReporter for CountingReporter {
             MetricEvent::SetTransactionLoadFailure => {
                 self.set_transaction_load_failures.inc();
             }
+            MetricEvent::TransactionCommitSuccess(e) => {
+                self.transaction_commits.inc();
+                self.commit_add_files.add(e.num_add_files);
+                self.commit_remove_files.add(e.num_remove_files);
+                self.commit_add_bytes.add(e.add_files_bytes);
+                self.commit_remove_bytes.add(e.remove_files_bytes);
+            }
+            MetricEvent::TransactionCommitFailure(e) => match e.reason {
+                CommitFailureReason::Conflict => self.commit_conflicts.inc(),
+                CommitFailureReason::RetryableIo => self.commit_retryable_failures.inc(),
+                CommitFailureReason::Error => self.commit_errors.inc(),
+            },
             // Intentionally not tracked. Add counters if needed.
             MetricEvent::ProtocolMetadataLoadSuccess(_)
             | MetricEvent::ProtocolMetadataLoadFailure(_)
@@ -348,6 +380,7 @@ mod tests {
         CrcReadSuccess, DomainMetadataLoadSuccess, LogSegmentLoadSuccess, MetricId,
         ProtocolMetadataLoadSuccess, SetTransactionLoadSuccess, SnapshotBuildFailure,
         SnapshotBuildSuccess, StorageCopyCompleted, StorageListCompleted, StorageReadCompleted,
+        TransactionCommitFailure, TransactionCommitSuccess,
     };
 
     use super::*;
@@ -494,6 +527,53 @@ mod tests {
         assert_eq!(reporter.set_transaction_loads.get(), 2);
         assert_eq!(reporter.set_transaction_cache_hits.get(), 1);
         assert_eq!(reporter.set_transaction_found.get(), 1);
+    }
+
+    #[test]
+    fn report_transaction_commit_success_accumulates_files_and_bytes() {
+        let reporter = CountingReporter::new();
+        reporter.report(MetricEvent::TransactionCommitSuccess(
+            TransactionCommitSuccess {
+                operation_id: MetricId::new(),
+                commit_version: 1,
+                num_add_files: 3,
+                num_remove_files: 2,
+                add_files_bytes: 600,
+                remove_files_bytes: 150,
+                is_blind_append: false,
+                data_change: true,
+                operation: Some("WRITE".to_string()),
+                prepare_duration: dur(),
+                committer_duration: dur(),
+                duration: dur(),
+            },
+        ));
+        assert_eq!(reporter.transaction_commits.get(), 1);
+        assert_eq!(reporter.commit_add_files.get(), 3);
+        assert_eq!(reporter.commit_remove_files.get(), 2);
+        assert_eq!(reporter.commit_add_bytes.get(), 600);
+        assert_eq!(reporter.commit_remove_bytes.get(), 150);
+    }
+
+    #[test]
+    fn report_transaction_commit_failure_increments_matching_reason_counter() {
+        let reporter = CountingReporter::new();
+        for reason in [
+            CommitFailureReason::Conflict,
+            CommitFailureReason::RetryableIo,
+            CommitFailureReason::Error,
+        ] {
+            reporter.report(MetricEvent::TransactionCommitFailure(
+                TransactionCommitFailure {
+                    operation_id: MetricId::new(),
+                    reason,
+                },
+            ));
+        }
+        assert_eq!(reporter.commit_conflicts.get(), 1);
+        assert_eq!(reporter.commit_retryable_failures.get(), 1);
+        assert_eq!(reporter.commit_errors.get(), 1);
+        assert_eq!(reporter.transaction_commits.get(), 0);
     }
 
     #[test]

--- a/test-utils/src/counting_reporter.rs
+++ b/test-utils/src/counting_reporter.rs
@@ -545,7 +545,7 @@ mod tests {
                 operation: Some("WRITE".to_string()),
                 prepare_duration: dur(),
                 committer_duration: dur(),
-                duration: dur(),
+                total_duration: dur(),
             },
         ));
         assert_eq!(reporter.transaction_commits.get(), 1);

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -820,12 +820,28 @@ pub async fn insert_data<E: TaskExecutor>(
     engine: &Arc<DefaultEngine<E>>,
     columns: Vec<ArrayRef>,
 ) -> DeltaResult<CommitResult> {
+    insert_data_with(snapshot, engine, columns, "WRITE", true, false).await
+}
+
+/// Like [`insert_data`] but with the commit's `operation`, `data_change`, and blind-append flag
+/// configurable.
+pub async fn insert_data_with<E: TaskExecutor>(
+    snapshot: Arc<Snapshot>,
+    engine: &Arc<DefaultEngine<E>>,
+    columns: Vec<ArrayRef>,
+    operation: &str,
+    data_change: bool,
+    is_blind_append: bool,
+) -> DeltaResult<CommitResult> {
     let arrow_schema = TryFromKernel::try_from_kernel(snapshot.schema().as_ref())?;
     let batch = RecordBatch::try_new(Arc::new(arrow_schema), columns)
         .map_err(|e| delta_kernel::Error::generic(e.to_string()))?;
     let mut txn = begin_transaction(snapshot, engine.as_ref())?
-        .with_operation("WRITE".to_string())
-        .with_data_change(true);
+        .with_operation(operation.to_string())
+        .with_data_change(data_change);
+    if is_blind_append {
+        txn = txn.with_blind_append();
+    }
 
     let write_context = txn.unpartitioned_write_context()?;
     let add_files_metadata = engine


### PR DESCRIPTION
TODO: depending on which is merged first, bring in the table_type metric label from https://github.com/delta-io/delta-kernel-rs/pull/2721

## What changes are proposed in this pull request?

Emit `TransactionCommitSuccess` and `TransactionCommitFailure` metric events.

## How was this change tested?

New UTs.
