### PR TITLE
feat!: add `table_type` to snapshot-load and scan metric events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,6 +1256,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "test_utils",
  "tokio",
  "tracing",
  "unity-catalog-delta-client-api",

--- a/delta-kernel-unity-catalog/Cargo.toml
+++ b/delta-kernel-unity-catalog/Cargo.toml
@@ -35,4 +35,5 @@ delta_kernel = { path = "../kernel", features = ["default-engine-base", "test-ut
 delta_kernel_default_engine = { path = "../default-engine", features = ["rustls"] }
 unity-catalog-delta-rest-client = { path = "../unity-catalog-delta-rest-client", features = ["test-utils"] }
 unity-catalog-delta-client-api = { path = "../unity-catalog-delta-client-api" }
+test_utils = { path = "../test-utils" }
 tempfile = "3"

--- a/delta-kernel-unity-catalog/src/utils/create_table.rs
+++ b/delta-kernel-unity-catalog/src/utils/create_table.rs
@@ -119,41 +119,15 @@ pub fn get_final_required_properties_for_uc(
 mod tests {
     use std::sync::Arc;
 
-    use delta_kernel::committer::{CommitMetadata, CommitResponse, Committer, PublishMetadata};
     use delta_kernel::object_store::memory::InMemory;
     use delta_kernel::schema::{DataType, StructField, StructType};
     use delta_kernel::snapshot::Snapshot;
     use delta_kernel::transaction::create_table::create_table;
     use delta_kernel::transaction::data_layout::DataLayout;
-    use delta_kernel::{DeltaResult, DeltaResultIterator, Engine, FileMeta, FilteredEngineData};
     use delta_kernel_default_engine::DefaultEngineBuilder;
+    use test_utils::TestCatalogCommitter;
 
     use super::*;
-
-    /// A mock catalog committer that writes directly to the published path.
-    struct MockCatalogCommitter;
-    impl Committer for MockCatalogCommitter {
-        fn commit(
-            &self,
-            engine: &dyn Engine,
-            actions: DeltaResultIterator<'_, FilteredEngineData>,
-            commit_metadata: CommitMetadata,
-        ) -> DeltaResult<CommitResponse> {
-            let path = commit_metadata.published_commit_path()?;
-            engine
-                .json_handler()
-                .write_json_file(&path, Box::new(actions), false)?;
-            Ok(CommitResponse::Committed {
-                file_meta: FileMeta::new(path, commit_metadata.in_commit_timestamp(), 0),
-            })
-        }
-        fn is_catalog_committer(&self) -> bool {
-            true
-        }
-        fn publish(&self, _: &dyn Engine, _: PublishMetadata) -> DeltaResult<()> {
-            Ok(())
-        }
-    }
 
     #[test]
     fn test_get_required_properties_for_disk() {
@@ -182,7 +156,7 @@ mod tests {
         let _ = create_table(table_path, schema, "Test/1.0")
             .with_table_properties(disk_props)
             .with_data_layout(DataLayout::clustered(["region"]))
-            .build(&engine, Box::new(MockCatalogCommitter))
+            .build(&engine, Box::new(TestCatalogCommitter))
             .unwrap()
             .commit(&engine)
             .unwrap();
@@ -250,7 +224,7 @@ mod tests {
                     ColumnName::new(["address", "city"]),
                 ],
             })
-            .build(&engine, Box::new(MockCatalogCommitter))
+            .build(&engine, Box::new(TestCatalogCommitter))
             .unwrap()
             .commit(&engine)
             .unwrap();
@@ -285,7 +259,7 @@ mod tests {
         let disk_props = get_required_properties_for_disk("test-table-id");
         let _ = create_table(table_path, schema, "Test/1.0")
             .with_table_properties(disk_props)
-            .build(&engine, Box::new(MockCatalogCommitter))
+            .build(&engine, Box::new(TestCatalogCommitter))
             .unwrap()
             .commit(&engine)
             .unwrap();
@@ -294,7 +268,7 @@ mod tests {
             .build(&engine)
             .unwrap();
         let result = v0_snapshot
-            .transaction(Box::new(MockCatalogCommitter), &engine)
+            .transaction(Box::new(TestCatalogCommitter), &engine)
             .unwrap()
             .commit(&engine)
             .unwrap();

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -21,7 +21,7 @@ use crate::log_replay::ActionsBatch;
 #[internal_api]
 use crate::log_segment_files::LogSegmentFiles;
 use crate::metrics::events::LOG_SEGMENT_LOADED_SPAN;
-use crate::metrics::MetricId;
+use crate::metrics::SnapshotLoadMetricContext;
 use crate::path::LogPathFileType::*;
 use crate::path::{LogPathFileType, ParsedLogPath};
 use crate::schema::compare::SchemaComparison;
@@ -318,7 +318,7 @@ impl LogSegment {
         name = LOG_SEGMENT_LOADED_SPAN,
         err,
         skip(storage, time_travel_version),
-        fields(report, operation_id = %operation_id, num_commit_files, num_checkpoint_files, num_compaction_files, has_latest_crc_file)
+        fields(report, operation_id = %metric_context.operation_id, is_catalog_managed = metric_context.is_catalog_managed, num_commit_files, num_checkpoint_files, num_compaction_files, has_latest_crc_file)
     )]
     #[internal_api]
     pub(crate) fn for_snapshot(
@@ -326,7 +326,7 @@ impl LogSegment {
         log_root: Url,
         log_tail: Vec<ParsedLogPath>,
         time_travel_version: impl Into<Option<Version>>,
-        operation_id: MetricId,
+        metric_context: SnapshotLoadMetricContext,
     ) -> DeltaResult<Self> {
         let time_travel_version = time_travel_version.into();
         let checkpoint_hint = LastCheckpointHint::try_read(storage, &log_root)?;

--- a/kernel/src/log_segment/protocol_metadata_replay.rs
+++ b/kernel/src/log_segment/protocol_metadata_replay.rs
@@ -12,7 +12,7 @@ use crate::actions::{get_commit_schema, Metadata, Protocol, METADATA_NAME, PROTO
 use crate::crc::Crc;
 use crate::log_replay::ActionsBatch;
 use crate::metrics::events::PROTOCOL_METADATA_LOADED_SPAN;
-use crate::metrics::MetricId;
+use crate::metrics::SnapshotLoadMetricContext;
 use crate::{DeltaResult, Engine, Error};
 
 impl LogSegment {
@@ -23,12 +23,12 @@ impl LogSegment {
     /// snapshot creation where both Protocol and Metadata must exist.
     ///
     /// Reports metrics: `ProtocolMetadataLoadSuccess` or `ProtocolMetadataLoadFailure`.
-    #[instrument(name = PROTOCOL_METADATA_LOADED_SPAN, err, fields(report, operation_id = %operation_id), skip(engine, crc))]
+    #[instrument(name = PROTOCOL_METADATA_LOADED_SPAN, err, fields(report, operation_id = %metric_context.operation_id, is_catalog_managed = metric_context.is_catalog_managed), skip(engine, crc))]
     pub(crate) fn read_protocol_metadata(
         &self,
         engine: &dyn Engine,
         crc: Option<&Arc<Crc>>,
-        operation_id: MetricId,
+        metric_context: SnapshotLoadMetricContext,
     ) -> DeltaResult<(Metadata, Protocol)> {
         match self.read_protocol_metadata_opt(engine, crc)? {
             (Some(m), Some(p)) => Ok((m, p)),

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -2543,7 +2543,7 @@ async fn test_latest_commit_file_field_is_captured() {
         log_root.clone(),
         vec![],
         None,
-        MetricId::default(),
+        SnapshotLoadMetricContext::default(),
     )
     .unwrap();
 
@@ -2576,7 +2576,7 @@ async fn test_latest_commit_file_with_checkpoint_filtering() {
         log_root.clone(),
         vec![],
         None,
-        MetricId::default(),
+        SnapshotLoadMetricContext::default(),
     )
     .unwrap();
 
@@ -2603,7 +2603,7 @@ async fn test_latest_commit_file_with_no_commits() {
         log_root.clone(),
         vec![],
         None,
-        MetricId::default(),
+        SnapshotLoadMetricContext::default(),
     )
     .unwrap();
 
@@ -2633,7 +2633,7 @@ async fn test_latest_commit_file_with_checkpoint_at_same_version() {
         log_root.clone(),
         vec![],
         None,
-        MetricId::default(),
+        SnapshotLoadMetricContext::default(),
     )
     .unwrap();
 
@@ -2665,7 +2665,7 @@ async fn test_latest_commit_file_edge_case_commit_before_checkpoint() {
         log_root.clone(),
         vec![],
         None,
-        MetricId::default(),
+        SnapshotLoadMetricContext::default(),
     )
     .unwrap();
 

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -9,6 +9,7 @@ use std::fmt;
 use std::str::FromStr as _;
 use std::time::Duration;
 
+use delta_kernel_derive::internal_api;
 use strum::{AsRefStr, Display as StrumDisplay, EnumString};
 use tracing::field::{Field, Visit};
 use tracing::span::Attributes;
@@ -190,8 +191,10 @@ impl MetricEvent {
         if name == "failure_reason" {
             if let Self::TransactionCommitSuccess(e) = self {
                 let operation_id = e.operation_id;
+                let table_type = e.table_type;
                 *self = Self::TransactionCommitFailure(TransactionCommitFailure {
                     operation_id,
+                    table_type,
                     reason: value.parse().unwrap_or(CommitFailureReason::Error),
                 });
             }
@@ -210,18 +213,22 @@ impl MetricEvent {
         match self {
             Self::LogSegmentLoadSuccess(e) => Self::LogSegmentLoadFailure(LogSegmentLoadFailure {
                 operation_id: e.operation_id,
+                table_type: e.table_type,
             }),
             Self::ProtocolMetadataLoadSuccess(e) => {
                 Self::ProtocolMetadataLoadFailure(ProtocolMetadataLoadFailure {
                     operation_id: e.operation_id,
+                    table_type: e.table_type,
                 })
             }
             Self::SnapshotBuildSuccess(e) => Self::SnapshotBuildFailure(SnapshotBuildFailure {
                 operation_id: e.operation_id,
+                table_type: e.table_type,
             }),
             Self::TransactionCommitSuccess(e) => {
                 Self::TransactionCommitFailure(TransactionCommitFailure {
                     operation_id: e.operation_id,
+                    table_type: e.table_type,
                     reason: CommitFailureReason::Error,
                 })
             }
@@ -291,6 +298,7 @@ pub(crate) const LOG_SEGMENT_LOADED_SPAN: &str = "segment.for_snapshot";
 pub struct LogSegmentLoadSuccess {
     // === Set on span creation ===
     pub operation_id: MetricId,
+    pub table_type: TableType,
 
     // === Set during span lifetime ===
     pub num_commit_files: u64,
@@ -310,6 +318,7 @@ impl LogSegmentLoadSuccess {
     pub(crate) fn from_attrs(attrs: &Attributes<'_>) -> Self {
         Self {
             operation_id: MetricId::from_attrs(attrs),
+            table_type: TableType::from_catalog_managed(read_is_catalog_managed(attrs)),
             num_commit_files: 0,
             num_checkpoint_files: 0,
             num_compaction_files: 0,
@@ -347,6 +356,7 @@ impl fmt::Display for LogSegmentLoadSuccess {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self {
             operation_id,
+            table_type,
             duration,
             num_commit_files,
             num_checkpoint_files,
@@ -355,9 +365,10 @@ impl fmt::Display for LogSegmentLoadSuccess {
         } = self;
         write!(
             f,
-            "LogSegmentLoadSuccess(id={operation_id}, duration={duration:?}, \
-             commits={num_commit_files}, checkpoints={num_checkpoint_files}, \
-             compactions={num_compaction_files}, has_latest_crc={has_latest_crc_file})"
+            "LogSegmentLoadSuccess(id={operation_id}, table_type={table_type}, \
+             duration={duration:?}, commits={num_commit_files}, \
+             checkpoints={num_checkpoint_files}, compactions={num_compaction_files}, \
+             has_latest_crc={has_latest_crc_file})"
         )
     }
 }
@@ -366,11 +377,16 @@ impl fmt::Display for LogSegmentLoadSuccess {
 #[derive(Debug, Clone)]
 pub struct LogSegmentLoadFailure {
     pub operation_id: MetricId,
+    pub table_type: TableType,
 }
 
 impl fmt::Display for LogSegmentLoadFailure {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "LogSegmentLoadFailure(id={})", self.operation_id)
+        write!(
+            f,
+            "LogSegmentLoadFailure(id={}, table_type={})",
+            self.operation_id, self.table_type
+        )
     }
 }
 
@@ -385,6 +401,7 @@ pub(crate) const PROTOCOL_METADATA_LOADED_SPAN: &str = "segment.read_metadata";
 pub struct ProtocolMetadataLoadSuccess {
     // === Set on span creation ===
     pub operation_id: MetricId,
+    pub table_type: TableType,
 
     // === Set on span close ===
     pub duration: Duration,
@@ -396,6 +413,7 @@ impl ProtocolMetadataLoadSuccess {
     pub(crate) fn from_attrs(attrs: &Attributes<'_>) -> Self {
         Self {
             operation_id: MetricId::from_attrs(attrs),
+            table_type: TableType::from_catalog_managed(read_is_catalog_managed(attrs)),
             duration: Duration::default(),
         }
     }
@@ -409,11 +427,12 @@ impl fmt::Display for ProtocolMetadataLoadSuccess {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self {
             operation_id,
+            table_type,
             duration,
         } = self;
         write!(
             f,
-            "ProtocolMetadataLoadSuccess(id={operation_id}, duration={duration:?})"
+            "ProtocolMetadataLoadSuccess(id={operation_id}, table_type={table_type}, duration={duration:?})"
         )
     }
 }
@@ -422,11 +441,16 @@ impl fmt::Display for ProtocolMetadataLoadSuccess {
 #[derive(Debug, Clone)]
 pub struct ProtocolMetadataLoadFailure {
     pub operation_id: MetricId,
+    pub table_type: TableType,
 }
 
 impl fmt::Display for ProtocolMetadataLoadFailure {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "ProtocolMetadataLoadFailure(id={})", self.operation_id)
+        write!(
+            f,
+            "ProtocolMetadataLoadFailure(id={}, table_type={})",
+            self.operation_id, self.table_type
+        )
     }
 }
 
@@ -441,6 +465,7 @@ pub(crate) const SNAPSHOT_COMPLETED_SPAN: &str = "snap.build";
 pub struct SnapshotBuildSuccess {
     // === Set on span creation ===
     pub operation_id: MetricId,
+    pub table_type: TableType,
 
     // === Set during span lifetime ===
     pub version: u64,
@@ -455,6 +480,7 @@ impl SnapshotBuildSuccess {
     pub(crate) fn from_attrs(attrs: &Attributes<'_>) -> Self {
         Self {
             operation_id: MetricId::from_attrs(attrs),
+            table_type: TableType::from_catalog_managed(read_is_catalog_managed(attrs)),
             version: 0,
             duration: Duration::default(),
         }
@@ -477,12 +503,13 @@ impl fmt::Display for SnapshotBuildSuccess {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self {
             operation_id,
+            table_type,
             version,
             duration,
         } = self;
         write!(
             f,
-            "SnapshotBuildSuccess(id={operation_id}, version={version}, duration={duration:?})"
+            "SnapshotBuildSuccess(id={operation_id}, table_type={table_type}, version={version}, duration={duration:?})"
         )
     }
 }
@@ -495,11 +522,16 @@ impl fmt::Display for SnapshotBuildSuccess {
 #[derive(Debug, Clone)]
 pub struct SnapshotBuildFailure {
     pub operation_id: MetricId,
+    pub table_type: TableType,
 }
 
 impl fmt::Display for SnapshotBuildFailure {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "SnapshotBuildFailure(id={})", self.operation_id)
+        write!(
+            f,
+            "SnapshotBuildFailure(id={}, table_type={})",
+            self.operation_id, self.table_type
+        )
     }
 }
 
@@ -514,6 +546,7 @@ pub(crate) const TRANSACTION_COMMIT_SPAN: &str = "txn.commit";
 pub struct TransactionCommitSuccess {
     // === Set on span creation ===
     pub operation_id: MetricId,
+    pub table_type: TableType,
     pub commit_version: u64,
 
     // === Set during span lifetime ===
@@ -541,6 +574,7 @@ impl TransactionCommitSuccess {
         attrs.record(&mut v);
         Self {
             operation_id: MetricId::from_attrs(attrs),
+            table_type: TableType::from_catalog_managed(read_is_catalog_managed(attrs)),
             commit_version: v.commit_version,
             num_add_files: 0,
             num_remove_files: 0,
@@ -594,6 +628,7 @@ impl fmt::Display for TransactionCommitSuccess {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self {
             operation_id,
+            table_type,
             commit_version,
             num_add_files,
             num_remove_files,
@@ -608,7 +643,7 @@ impl fmt::Display for TransactionCommitSuccess {
         } = self;
         write!(
             f,
-            "TransactionCommitSuccess(id={operation_id}, version={commit_version}, \
+            "TransactionCommitSuccess(id={operation_id}, table_type={table_type}, version={commit_version}, \
              total_duration={total_duration:?}, prepare={prepare_duration:?}, committer={committer_duration:?}, \
              add_files={num_add_files}, remove_files={num_remove_files}, \
              add_bytes={add_files_bytes}, remove_bytes={remove_files_bytes}, \
@@ -637,6 +672,7 @@ pub enum CommitFailureReason {
 #[derive(Debug, Clone)]
 pub struct TransactionCommitFailure {
     pub operation_id: MetricId,
+    pub table_type: TableType,
     pub reason: CommitFailureReason,
 }
 
@@ -644,11 +680,12 @@ impl fmt::Display for TransactionCommitFailure {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self {
             operation_id,
+            table_type,
             reason,
         } = self;
         write!(
             f,
-            "TransactionCommitFailure(id={operation_id}, reason={reason})"
+            "TransactionCommitFailure(id={operation_id}, table_type={table_type}, reason={reason})"
         )
     }
 }
@@ -978,6 +1015,72 @@ impl fmt::Display for ScanType {
     }
 }
 
+// ====================================================================
+// SnapshotLoadMetricContext and shared span fields
+// ====================================================================
+
+/// The `is_catalog_managed` bool span field carried by every event that records it. It is the
+/// confirmed protocol value, except on snapshot-load events, which use the requested mode because
+/// the on-disk protocol is not known that early (see `SnapshotBuilder::build`).
+pub(crate) const IS_CATALOG_MANAGED_FIELD: &str = "is_catalog_managed";
+
+/// Whether a table is path-based or catalog-managed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+pub enum TableType {
+    /// Loaded without catalog involvement; commits live directly in the Delta log.
+    #[default]
+    PathBased,
+    /// Backed by a managing catalog.
+    CatalogManaged,
+}
+
+impl TableType {
+    #[internal_api]
+    pub(crate) fn from_catalog_managed(is_catalog_managed: bool) -> Self {
+        if is_catalog_managed {
+            Self::CatalogManaged
+        } else {
+            Self::PathBased
+        }
+    }
+
+    pub(crate) fn is_catalog_managed(self) -> bool {
+        self == Self::CatalogManaged
+    }
+}
+
+impl fmt::Display for TableType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::PathBased => "path_based",
+            Self::CatalogManaged => "catalog_managed",
+        })
+    }
+}
+
+/// Operation-scoped values threaded through the snapshot-load chain to label its metric events.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SnapshotLoadMetricContext {
+    pub(crate) operation_id: MetricId,
+    pub(crate) is_catalog_managed: bool,
+}
+
+pub(crate) fn read_is_catalog_managed(attrs: &Attributes<'_>) -> bool {
+    #[derive(Default)]
+    struct V(bool);
+    impl Visit for V {
+        fn record_bool(&mut self, field: &Field, value: bool) {
+            if field.name() == IS_CATALOG_MANAGED_FIELD {
+                self.0 = value;
+            }
+        }
+        fn record_debug(&mut self, _field: &Field, _value: &dyn fmt::Debug) {}
+    }
+    let mut v = V::default();
+    attrs.record(&mut v);
+    v.0
+}
+
 /// A `parallel_scan_metadata` scan emits **two** events (one per phase) sharing the same
 /// `operation_id`; `scan_metadata` emits one event with [`ScanType::Full`].
 #[derive(Debug, Clone)]
@@ -985,6 +1088,8 @@ pub struct ScanMetadataCompleted {
     // === Set on span creation ===
     /// Unique ID to correlate this scan with other events.
     pub operation_id: MetricId,
+    /// Whether the scanned table is path-based or catalog-managed.
+    pub table_type: TableType,
     /// Which scan execution path produced this event.
     pub scan_type: ScanType,
     /// Wall-clock time from scan start to iterator exhaustion.
@@ -1017,6 +1122,7 @@ impl ScanMetadataCompleted {
         attrs.record(&mut v);
         Self {
             operation_id: MetricId(v.operation_id),
+            table_type: TableType::from_catalog_managed(v.is_catalog_managed),
             scan_type: ScanType::parse(&v.scan_type),
             duration: Duration::from_nanos(v.duration_ns),
             num_add_files_seen: v.num_add_files_seen,
@@ -1036,6 +1142,7 @@ impl fmt::Display for ScanMetadataCompleted {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self {
             operation_id,
+            table_type,
             scan_type,
             duration,
             num_add_files_seen,
@@ -1050,7 +1157,7 @@ impl fmt::Display for ScanMetadataCompleted {
         } = self;
         write!(
             f,
-            "ScanMetadataCompleted(id={operation_id}, scan_type={scan_type}, duration={duration:?}, \
+            "ScanMetadataCompleted(id={operation_id}, table_type={table_type}, scan_type={scan_type}, duration={duration:?}, \
              add_files_seen={num_add_files_seen}, active_add_files={num_active_add_files}, \
              active_add_files_bytes={active_add_files_bytes}, \
              remove_files_seen={num_remove_files_seen}, non_file_actions={num_non_file_actions}, \
@@ -1063,6 +1170,7 @@ impl fmt::Display for ScanMetadataCompleted {
 #[derive(Default)]
 struct ScanMetadataCompletedAttrs {
     operation_id: Uuid,
+    is_catalog_managed: bool,
     scan_type: String,
     duration_ns: u64,
     num_add_files_seen: u64,
@@ -1077,6 +1185,12 @@ struct ScanMetadataCompletedAttrs {
 }
 
 impl Visit for ScanMetadataCompletedAttrs {
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        if field.name() == IS_CATALOG_MANAGED_FIELD {
+            self.is_catalog_managed = value;
+        }
+    }
+
     fn record_u64(&mut self, field: &Field, value: u64) {
         match field.name() {
             "duration_ns" => self.duration_ns = value,
@@ -1312,6 +1426,7 @@ pub(crate) fn emit_scan_metadata_completed(e: &ScanMetadataCompleted) {
         ScanMetadataCompleted::SPAN_NAME,
         report = tracing::field::Empty,
         operation_id = %e.operation_id,
+        is_catalog_managed = e.table_type.is_catalog_managed(),
         scan_type = %e.scan_type,
         duration_ns = e.duration.as_nanos() as u64,
         num_add_files_seen = e.num_add_files_seen,
@@ -1335,6 +1450,7 @@ mod tests {
     fn commit_success(operation_id: MetricId) -> TransactionCommitSuccess {
         TransactionCommitSuccess {
             operation_id,
+            table_type: TableType::PathBased,
             commit_version: 1,
             num_add_files: 0,
             num_remove_files: 0,

--- a/kernel/src/metrics/mod.rs
+++ b/kernel/src/metrics/mod.rs
@@ -85,10 +85,10 @@ use std::sync::Arc;
 
 pub use events::{
     emit_json_read_completed, emit_parquet_read_completed, CommitFailureReason, CrcReadSuccess,
-    SnapshotLoadMetricContext, DomainMetadataLoadSuccess, JsonReadCompleted, LogSegmentLoadFailure,
-    LogSegmentLoadSuccess, MetricEvent, MetricId, ParquetReadCompleted,
-    ProtocolMetadataLoadFailure, ProtocolMetadataLoadSuccess, ScanMetadataCompleted, ScanType,
-    SetTransactionLoadSuccess, SnapshotBuildFailure, SnapshotBuildSuccess, StorageCopyCompleted,
+    DomainMetadataLoadSuccess, JsonReadCompleted, LogSegmentLoadFailure, LogSegmentLoadSuccess,
+    MetricEvent, MetricId, ParquetReadCompleted, ProtocolMetadataLoadFailure,
+    ProtocolMetadataLoadSuccess, ScanMetadataCompleted, ScanType, SetTransactionLoadSuccess,
+    SnapshotBuildFailure, SnapshotBuildSuccess, SnapshotLoadMetricContext, StorageCopyCompleted,
     StorageListCompleted, StorageReadCompleted, TableType, TransactionCommitFailure,
     TransactionCommitSuccess,
 };

--- a/kernel/src/metrics/mod.rs
+++ b/kernel/src/metrics/mod.rs
@@ -85,11 +85,12 @@ use std::sync::Arc;
 
 pub use events::{
     emit_json_read_completed, emit_parquet_read_completed, CommitFailureReason, CrcReadSuccess,
-    DomainMetadataLoadSuccess, JsonReadCompleted, LogSegmentLoadFailure, LogSegmentLoadSuccess,
-    MetricEvent, MetricId, ParquetReadCompleted, ProtocolMetadataLoadFailure,
-    ProtocolMetadataLoadSuccess, ScanMetadataCompleted, ScanType, SetTransactionLoadSuccess,
-    SnapshotBuildFailure, SnapshotBuildSuccess, StorageCopyCompleted, StorageListCompleted,
-    StorageReadCompleted, TransactionCommitFailure, TransactionCommitSuccess,
+    SnapshotLoadMetricContext, DomainMetadataLoadSuccess, JsonReadCompleted, LogSegmentLoadFailure,
+    LogSegmentLoadSuccess, MetricEvent, MetricId, ParquetReadCompleted,
+    ProtocolMetadataLoadFailure, ProtocolMetadataLoadSuccess, ScanMetadataCompleted, ScanType,
+    SetTransactionLoadSuccess, SnapshotBuildFailure, SnapshotBuildSuccess, StorageCopyCompleted,
+    StorageListCompleted, StorageReadCompleted, TableType, TransactionCommitFailure,
+    TransactionCommitSuccess,
 };
 pub use metered_engine::MeteredDeltaEngine;
 pub use metered_json::MeteredJsonHandler;

--- a/kernel/src/parallel/parallel_scan_metadata.rs
+++ b/kernel/src/parallel/parallel_scan_metadata.rs
@@ -58,6 +58,7 @@ impl SequentialScanMetadata {
             AfterSequential::Done(processor) => {
                 let event = processor.get_metrics().to_event(
                     self.operation_id,
+                    processor.table_type(),
                     ScanType::SequentialPhase,
                     self.start.elapsed(),
                 );
@@ -70,6 +71,7 @@ impl SequentialScanMetadata {
             AfterSequential::Parallel { processor, files } => {
                 let event = processor.get_metrics().to_event(
                     self.operation_id,
+                    processor.table_type(),
                     ScanType::SequentialPhase,
                     self.start.elapsed(),
                 );
@@ -145,6 +147,7 @@ impl ParallelState {
     pub fn log_metrics(&self) {
         let event = self.inner.get_metrics().to_event(
             self.operation_id,
+            self.inner.table_type(),
             ScanType::ParallelPhase,
             self.parallel_start.elapsed(),
         );
@@ -262,5 +265,67 @@ impl Iterator for ParallelScanMetadata {
     fn next(&mut self) -> Option<Self::Item> {
         let _guard = self.span.enter();
         self.processor.next()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::sync::Arc;
+
+    use super::ParallelState;
+    use crate::engine::sync::SyncEngine;
+    use crate::log_segment::CheckpointReadInfo;
+    use crate::metrics::{MetricEvent, ScanType, TableType};
+    use crate::scan::log_replay::{ScanLogReplayProcessor, ScanStatsOptions};
+    use crate::scan::state_info::StateInfo;
+    use crate::scan::PhysicalPredicate;
+    use crate::schema::{DataType, SchemaRef, StructField, StructType};
+    use crate::table_features::ColumnMappingMode;
+    use crate::utils::test_utils::{install_thread_local_metrics_reporter, CapturingReporter};
+
+    #[test]
+    fn test_parallel_state_log_metrics_carries_round_tripped_table_type() {
+        let engine = SyncEngine::new();
+        let schema: SchemaRef = Arc::new(StructType::new_unchecked([StructField::new(
+            "id",
+            DataType::INTEGER,
+            true,
+        )]));
+        let state_info = Arc::new(StateInfo {
+            logical_schema: schema.clone(),
+            physical_schema: schema,
+            physical_predicate: PhysicalPredicate::None,
+            transform_spec: None,
+            column_mapping_mode: ColumnMappingMode::None,
+            physical_stats_schema: None,
+            physical_partition_schema: None,
+            physical_stats_columns: HashSet::new(),
+            table_type: TableType::CatalogManaged,
+        });
+        let processor = ScanLogReplayProcessor::new(
+            &engine,
+            state_info,
+            CheckpointReadInfo::without_stats_parsed(),
+            ScanStatsOptions::default(),
+        )
+        .unwrap();
+        let serialized = processor.into_serializable_state().unwrap();
+        let state = ParallelState::from_serializable_state(&engine, serialized).unwrap();
+
+        let reporter = Arc::new(CapturingReporter::default());
+        let _guard = install_thread_local_metrics_reporter(reporter.clone());
+        state.log_metrics();
+
+        let event = reporter
+            .events()
+            .into_iter()
+            .find_map(|e| match e {
+                MetricEvent::ScanMetadataCompleted(c) => Some(c),
+                _ => None,
+            })
+            .expect("ScanMetadataCompleted emitted");
+        assert_eq!(event.table_type, TableType::CatalogManaged);
+        assert_eq!(event.scan_type, ScanType::ParallelPhase);
     }
 }

--- a/kernel/src/parallel/parallel_scan_metadata.rs
+++ b/kernel/src/parallel/parallel_scan_metadata.rs
@@ -58,7 +58,7 @@ impl SequentialScanMetadata {
             AfterSequential::Done(processor) => {
                 let event = processor.get_metrics().to_event(
                     self.operation_id,
-                    processor.table_type(),
+                    processor.is_catalog_managed(),
                     ScanType::SequentialPhase,
                     self.start.elapsed(),
                 );
@@ -71,7 +71,7 @@ impl SequentialScanMetadata {
             AfterSequential::Parallel { processor, files } => {
                 let event = processor.get_metrics().to_event(
                     self.operation_id,
-                    processor.table_type(),
+                    processor.is_catalog_managed(),
                     ScanType::SequentialPhase,
                     self.start.elapsed(),
                 );
@@ -147,7 +147,7 @@ impl ParallelState {
     pub fn log_metrics(&self) {
         let event = self.inner.get_metrics().to_event(
             self.operation_id,
-            self.inner.table_type(),
+            self.inner.is_catalog_managed(),
             ScanType::ParallelPhase,
             self.parallel_start.elapsed(),
         );
@@ -301,7 +301,7 @@ mod tests {
             physical_stats_schema: None,
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
-            table_type: TableType::CatalogManaged,
+            is_catalog_managed: true,
         });
         let processor = ScanLogReplayProcessor::new(
             &engine,

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -21,7 +21,6 @@ use crate::log_replay::{
     ParallelLogReplayProcessor,
 };
 use crate::log_segment::CheckpointReadInfo;
-use crate::metrics::TableType;
 use crate::scan::transform_spec::{get_transform_expr, parse_partition_values, TransformSpec};
 use crate::scan::Scalar;
 use crate::schema::{
@@ -78,7 +77,7 @@ struct InternalScanState {
     #[serde(default)]
     physical_stats_columns: HashSet<ColumnName>,
     #[serde(default)]
-    table_type: TableType,
+    is_catalog_managed: bool,
 }
 
 /// Serializable processor state for distributed processing. This can be serialized using the
@@ -312,8 +311,8 @@ impl ScanLogReplayProcessor {
         self.metrics.as_ref()
     }
 
-    pub(crate) fn table_type(&self) -> TableType {
-        self.state_info.table_type
+    pub(crate) fn is_catalog_managed(&self) -> bool {
+        self.state_info.is_catalog_managed
     }
 
     /// Serialize the processor state for distributed processing.
@@ -341,7 +340,7 @@ impl ScanLogReplayProcessor {
             physical_stats_schema,
             physical_partition_schema,
             physical_stats_columns,
-            table_type,
+            is_catalog_managed,
         } = self.state_info.as_ref().clone();
 
         // Extract predicate from PhysicalPredicate
@@ -361,7 +360,7 @@ impl ScanLogReplayProcessor {
             stats_options: self.stats_options,
             physical_partition_schema,
             physical_stats_columns,
-            table_type,
+            is_catalog_managed,
         };
         let internal_state_blob = serde_json::to_vec(&internal_state)
             .map_err(|e| Error::generic(format!("Failed to serialize internal state: {e}")))?;
@@ -419,7 +418,7 @@ impl ScanLogReplayProcessor {
             physical_stats_schema: internal_state.physical_stats_schema,
             physical_partition_schema: internal_state.physical_partition_schema,
             physical_stats_columns: internal_state.physical_stats_columns,
-            table_type: internal_state.table_type,
+            is_catalog_managed: internal_state.is_catalog_managed,
         });
 
         Self::new_with_seen_files(
@@ -982,7 +981,7 @@ mod tests {
 
     use super::{
         get_add_transform_expr, scan_action_iter, InternalScanState, ScanLogReplayProcessor,
-        ScanStatsOptions, SerializableScanState, TableType,
+        ScanStatsOptions, SerializableScanState,
     };
     use crate::actions::get_commit_schema;
     use crate::engine::sync::SyncEngine;
@@ -1107,7 +1106,7 @@ mod tests {
             physical_stats_schema: None,
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
-            table_type: TableType::PathBased,
+            is_catalog_managed: false,
         });
         let (iter, _metrics) = scan_action_iter(
             &SyncEngine::new(),
@@ -1438,7 +1437,7 @@ mod tests {
                 physical_stats_schema: None,
                 physical_partition_schema: None,
                 physical_stats_columns: HashSet::new(),
-                table_type: TableType::PathBased,
+                is_catalog_managed: false,
             });
             let checkpoint_info = test_checkpoint_info();
             let processor = ScanLogReplayProcessor::new(
@@ -1476,7 +1475,7 @@ mod tests {
             physical_stats_schema: None,
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
-            table_type: TableType::PathBased,
+            is_catalog_managed: false,
         });
         let processor = ScanLogReplayProcessor::new(
             &engine,
@@ -1494,7 +1493,7 @@ mod tests {
     }
 
     #[test]
-    fn test_serialization_round_trips_table_type() {
+    fn test_serialization_round_trips_is_catalog_managed() {
         let engine = SyncEngine::new();
         let schema: SchemaRef = Arc::new(StructType::new_unchecked([StructField::new(
             "id",
@@ -1510,7 +1509,7 @@ mod tests {
             physical_stats_schema: None,
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
-            table_type: TableType::CatalogManaged,
+            is_catalog_managed: true,
         });
         let processor = ScanLogReplayProcessor::new(
             &engine,
@@ -1522,7 +1521,7 @@ mod tests {
         let serialized = processor.into_serializable_state().unwrap();
         let deserialized =
             ScanLogReplayProcessor::from_serializable_state(&engine, serialized).unwrap();
-        assert_eq!(deserialized.table_type(), TableType::CatalogManaged);
+        assert!(deserialized.is_catalog_managed());
     }
 
     #[test]
@@ -1559,7 +1558,7 @@ mod tests {
             stats_options: ScanStatsOptions::default(),
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
-            table_type: TableType::PathBased,
+            is_catalog_managed: false,
         };
         let predicate = Arc::new(crate::expressions::Predicate::column(["id"]));
         let invalid_blob = serde_json::to_vec(&invalid_internal_state).unwrap();
@@ -1593,7 +1592,7 @@ mod tests {
             stats_options: ScanStatsOptions::default(),
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
-            table_type: TableType::PathBased,
+            is_catalog_managed: false,
         };
         let blob = serde_json::to_string(&invalid_internal_state).unwrap();
         let mut obj: serde_json::Value = serde_json::from_str(&blob).unwrap();

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -21,6 +21,7 @@ use crate::log_replay::{
     ParallelLogReplayProcessor,
 };
 use crate::log_segment::CheckpointReadInfo;
+use crate::metrics::TableType;
 use crate::scan::transform_spec::{get_transform_expr, parse_partition_values, TransformSpec};
 use crate::scan::Scalar;
 use crate::schema::{
@@ -76,6 +77,8 @@ struct InternalScanState {
     /// still correct.
     #[serde(default)]
     physical_stats_columns: HashSet<ColumnName>,
+    #[serde(default)]
+    table_type: TableType,
 }
 
 /// Serializable processor state for distributed processing. This can be serialized using the
@@ -309,6 +312,10 @@ impl ScanLogReplayProcessor {
         self.metrics.as_ref()
     }
 
+    pub(crate) fn table_type(&self) -> TableType {
+        self.state_info.table_type
+    }
+
     /// Serialize the processor state for distributed processing.
     ///
     /// Consumes the processor and returns a `SerializableScanState` containing:
@@ -334,6 +341,7 @@ impl ScanLogReplayProcessor {
             physical_stats_schema,
             physical_partition_schema,
             physical_stats_columns,
+            table_type,
         } = self.state_info.as_ref().clone();
 
         // Extract predicate from PhysicalPredicate
@@ -353,6 +361,7 @@ impl ScanLogReplayProcessor {
             stats_options: self.stats_options,
             physical_partition_schema,
             physical_stats_columns,
+            table_type,
         };
         let internal_state_blob = serde_json::to_vec(&internal_state)
             .map_err(|e| Error::generic(format!("Failed to serialize internal state: {e}")))?;
@@ -410,6 +419,7 @@ impl ScanLogReplayProcessor {
             physical_stats_schema: internal_state.physical_stats_schema,
             physical_partition_schema: internal_state.physical_partition_schema,
             physical_stats_columns: internal_state.physical_stats_columns,
+            table_type: internal_state.table_type,
         });
 
         Self::new_with_seen_files(
@@ -972,7 +982,7 @@ mod tests {
 
     use super::{
         get_add_transform_expr, scan_action_iter, InternalScanState, ScanLogReplayProcessor,
-        ScanStatsOptions, SerializableScanState,
+        ScanStatsOptions, SerializableScanState, TableType,
     };
     use crate::actions::get_commit_schema;
     use crate::engine::sync::SyncEngine;
@@ -1097,6 +1107,7 @@ mod tests {
             physical_stats_schema: None,
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
+            table_type: TableType::PathBased,
         });
         let (iter, _metrics) = scan_action_iter(
             &SyncEngine::new(),
@@ -1427,6 +1438,7 @@ mod tests {
                 physical_stats_schema: None,
                 physical_partition_schema: None,
                 physical_stats_columns: HashSet::new(),
+                table_type: TableType::PathBased,
             });
             let checkpoint_info = test_checkpoint_info();
             let processor = ScanLogReplayProcessor::new(
@@ -1464,6 +1476,7 @@ mod tests {
             physical_stats_schema: None,
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
+            table_type: TableType::PathBased,
         });
         let processor = ScanLogReplayProcessor::new(
             &engine,
@@ -1478,6 +1491,38 @@ mod tests {
             ScanLogReplayProcessor::from_serializable_state(&engine, serialized).unwrap();
         assert_eq!(deserialized.seen_file_keys.len(), 0);
         assert!(deserialized.state_info.transform_spec.is_none());
+    }
+
+    #[test]
+    fn test_serialization_round_trips_table_type() {
+        let engine = SyncEngine::new();
+        let schema: SchemaRef = Arc::new(StructType::new_unchecked([StructField::new(
+            "id",
+            DataType::INTEGER,
+            true,
+        )]));
+        let state_info = Arc::new(StateInfo {
+            logical_schema: schema.clone(),
+            physical_schema: schema,
+            physical_predicate: PhysicalPredicate::None,
+            transform_spec: None,
+            column_mapping_mode: ColumnMappingMode::None,
+            physical_stats_schema: None,
+            physical_partition_schema: None,
+            physical_stats_columns: HashSet::new(),
+            table_type: TableType::CatalogManaged,
+        });
+        let processor = ScanLogReplayProcessor::new(
+            &engine,
+            state_info,
+            test_checkpoint_info(),
+            ScanStatsOptions::default(),
+        )
+        .unwrap();
+        let serialized = processor.into_serializable_state().unwrap();
+        let deserialized =
+            ScanLogReplayProcessor::from_serializable_state(&engine, serialized).unwrap();
+        assert_eq!(deserialized.table_type(), TableType::CatalogManaged);
     }
 
     #[test]
@@ -1514,6 +1559,7 @@ mod tests {
             stats_options: ScanStatsOptions::default(),
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
+            table_type: TableType::PathBased,
         };
         let predicate = Arc::new(crate::expressions::Predicate::column(["id"]));
         let invalid_blob = serde_json::to_vec(&invalid_internal_state).unwrap();
@@ -1547,6 +1593,7 @@ mod tests {
             stats_options: ScanStatsOptions::default(),
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
+            table_type: TableType::PathBased,
         };
         let blob = serde_json::to_string(&invalid_internal_state).unwrap();
         let mut obj: serde_json::Value = serde_json::from_str(&blob).unwrap();

--- a/kernel/src/scan/metrics.rs
+++ b/kernel/src/scan/metrics.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use tracing::info;
 
-use crate::metrics::{MetricId, ScanMetadataCompleted, ScanType};
+use crate::metrics::{MetricId, ScanMetadataCompleted, ScanType, TableType};
 
 /// Metrics collected during scan log replay. Metrics are updated and read using relaxed ordering
 /// to keep updates fast across parallel executing threads.
@@ -110,11 +110,13 @@ impl ScanMetrics {
     pub(crate) fn to_event(
         &self,
         operation_id: MetricId,
+        table_type: TableType,
         scan_type: ScanType,
         duration: Duration,
     ) -> ScanMetadataCompleted {
         ScanMetadataCompleted {
             operation_id,
+            table_type,
             scan_type,
             duration,
             num_add_files_seen: self.num_add_files_seen.load(Ordering::Relaxed),

--- a/kernel/src/scan/metrics.rs
+++ b/kernel/src/scan/metrics.rs
@@ -110,13 +110,13 @@ impl ScanMetrics {
     pub(crate) fn to_event(
         &self,
         operation_id: MetricId,
-        table_type: TableType,
+        is_catalog_managed: bool,
         scan_type: ScanType,
         duration: Duration,
     ) -> ScanMetadataCompleted {
         ScanMetadataCompleted {
             operation_id,
-            table_type,
+            table_type: TableType::from_catalog_managed(is_catalog_managed),
             scan_type,
             duration,
             num_add_files_seen: self.num_add_files_seen.load(Ordering::Relaxed),

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -834,6 +834,7 @@ impl Scan {
     ) -> DeltaResult<impl Iterator<Item = DeltaResult<ScanMetadata>>> {
         let start = Instant::now();
         let operation_id = MetricId::new();
+        let table_type = self.snapshot.table_configuration().table_type();
 
         let (iter, metrics) = match self.state_info.physical_predicate {
             PhysicalPredicate::StaticSkipAll => {
@@ -853,7 +854,7 @@ impl Scan {
         };
 
         let on_complete = move || {
-            let event = metrics.to_event(operation_id, ScanType::Full, start.elapsed());
+            let event = metrics.to_event(operation_id, table_type, ScanType::Full, start.elapsed());
             info!(%event);
             emit_scan_metadata_completed(&event);
         };

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -834,7 +834,7 @@ impl Scan {
     ) -> DeltaResult<impl Iterator<Item = DeltaResult<ScanMetadata>>> {
         let start = Instant::now();
         let operation_id = MetricId::new();
-        let table_type = self.snapshot.table_configuration().table_type();
+        let is_catalog_managed = self.snapshot.table_configuration().is_catalog_managed();
 
         let (iter, metrics) = match self.state_info.physical_predicate {
             PhysicalPredicate::StaticSkipAll => {
@@ -854,7 +854,12 @@ impl Scan {
         };
 
         let on_complete = move || {
-            let event = metrics.to_event(operation_id, table_type, ScanType::Full, start.elapsed());
+            let event = metrics.to_event(
+                operation_id,
+                is_catalog_managed,
+                ScanType::Full,
+                start.elapsed(),
+            );
             info!(%event);
             emit_scan_metadata_completed(&event);
         };

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -8,6 +8,7 @@ use tracing::{debug, enabled, warn, Level};
 
 use crate::actions::NULL_COUNT;
 use crate::expressions::ColumnName;
+use crate::metrics::TableType;
 use crate::scan::field_classifiers::TransformFieldClassifier;
 use crate::scan::transform_spec::{FieldTransformSpec, TransformSpec};
 use crate::scan::{PhysicalPredicate, StatsOptions, StructStats};
@@ -44,6 +45,7 @@ pub(crate) struct StateInfo {
     ///
     /// Read-path mirror of `SharedWriteState.stats_columns`.
     pub(crate) physical_stats_columns: HashSet<ColumnName>,
+    pub(crate) table_type: TableType,
 }
 
 /// Validating the metadata columns also extracts information needed to properly construct the full
@@ -421,6 +423,7 @@ impl StateInfo {
             physical_stats_schema,
             physical_partition_schema,
             physical_stats_columns,
+            table_type: table_configuration.table_type(),
         })
     }
 

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -8,7 +8,6 @@ use tracing::{debug, enabled, warn, Level};
 
 use crate::actions::NULL_COUNT;
 use crate::expressions::ColumnName;
-use crate::metrics::TableType;
 use crate::scan::field_classifiers::TransformFieldClassifier;
 use crate::scan::transform_spec::{FieldTransformSpec, TransformSpec};
 use crate::scan::{PhysicalPredicate, StatsOptions, StructStats};
@@ -45,7 +44,9 @@ pub(crate) struct StateInfo {
     ///
     /// Read-path mirror of `SharedWriteState.stats_columns`.
     pub(crate) physical_stats_columns: HashSet<ColumnName>,
-    pub(crate) table_type: TableType,
+    /// Whether the table is catalog-managed, used to label scan metric events. Converted to a
+    /// [`TableType`](crate::metrics::TableType) at event construction.
+    pub(crate) is_catalog_managed: bool,
 }
 
 /// Validating the metadata columns also extracts information needed to properly construct the full
@@ -423,7 +424,7 @@ impl StateInfo {
             physical_stats_schema,
             physical_partition_schema,
             physical_stats_columns,
-            table_type: table_configuration.table_type(),
+            is_catalog_managed: table_configuration.is_catalog_managed(),
         })
     }
 

--- a/kernel/src/scan/test_utils.rs
+++ b/kernel/src/scan/test_utils.rs
@@ -12,7 +12,6 @@ use crate::engine::sync::json::SyncJsonHandler;
 use crate::engine::sync::SyncEngine;
 use crate::log_replay::ActionsBatch;
 use crate::log_segment::CheckpointReadInfo;
-use crate::metrics::TableType;
 use crate::scan::log_replay::{scan_action_iter, ScanStatsOptions};
 use crate::scan::state_info::StateInfo;
 use crate::scan::transform_spec::TransformSpec;
@@ -168,7 +167,7 @@ pub(crate) fn run_with_validate_callback<T: Clone>(
         physical_stats_schema: None,
         physical_partition_schema: None,
         physical_stats_columns: HashSet::new(),
-        table_type: TableType::PathBased,
+        is_catalog_managed: false,
     });
     let checkpoint_info = CheckpointReadInfo::without_stats_parsed();
     let (iter, _metrics) = scan_action_iter(

--- a/kernel/src/scan/test_utils.rs
+++ b/kernel/src/scan/test_utils.rs
@@ -12,6 +12,7 @@ use crate::engine::sync::json::SyncJsonHandler;
 use crate::engine::sync::SyncEngine;
 use crate::log_replay::ActionsBatch;
 use crate::log_segment::CheckpointReadInfo;
+use crate::metrics::TableType;
 use crate::scan::log_replay::{scan_action_iter, ScanStatsOptions};
 use crate::scan::state_info::StateInfo;
 use crate::scan::transform_spec::TransformSpec;
@@ -167,6 +168,7 @@ pub(crate) fn run_with_validate_callback<T: Clone>(
         physical_stats_schema: None,
         physical_partition_schema: None,
         physical_stats_columns: HashSet::new(),
+        table_type: TableType::PathBased,
     });
     let checkpoint_info = CheckpointReadInfo::without_stats_parsed();
     let (iter, _metrics) = scan_action_iter(

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -5,7 +5,7 @@ use tracing::{info, instrument};
 use crate::log_path::LogPath;
 use crate::log_segment::LogSegment;
 use crate::metrics::events::SNAPSHOT_COMPLETED_SPAN;
-use crate::metrics::{SnapshotLoadMetricContext, MetricId};
+use crate::metrics::{MetricId, SnapshotLoadMetricContext};
 use crate::path::LogPathFileType;
 use crate::snapshot::SnapshotRef;
 use crate::utils::{require, try_parse_uri};
@@ -41,6 +41,8 @@ pub struct SnapshotBuilder {
     log_tail: Vec<LogPath>,
     max_catalog_version: Option<Version>,
     incremental_replay: IncrementalReplay,
+    /// Kernel-minted id correlating this build's metric events with its child events.
+    operation_id: MetricId,
 }
 
 /// Controls whether kernel replays commits to advance a stale base CRC (the existing snapshot's
@@ -100,6 +102,7 @@ impl SnapshotBuilder {
             log_tail: Vec::new(),
             max_catalog_version: None,
             incremental_replay: IncrementalReplay::default(),
+            operation_id: MetricId::new(),
         }
     }
 
@@ -111,6 +114,7 @@ impl SnapshotBuilder {
             log_tail: Vec::new(),
             max_catalog_version: None,
             incremental_replay: IncrementalReplay::default(),
+            operation_id: MetricId::new(),
         }
     }
 
@@ -190,27 +194,15 @@ impl SnapshotBuilder {
     ///
     /// [`MetricEvent::SnapshotBuildSuccess`]: crate::metrics::MetricEvent::SnapshotBuildSuccess
     /// [`MetricEvent::SnapshotBuildFailure`]: crate::metrics::MetricEvent::SnapshotBuildFailure
-    pub fn build(self, engine: &dyn Engine) -> DeltaResult<SnapshotRef> {
-        let metric_context = SnapshotLoadMetricContext {
-            operation_id: MetricId::new(),
-            is_catalog_managed: self.max_catalog_version.is_some(),
-        };
-        self.build_inner(engine, metric_context)
-    }
-
-    // `metric_context.is_catalog_managed` is the requested load mode, not the confirmed protocol
+    // `is_catalog_managed` is the requested load mode, not the confirmed protocol
     // (see `IS_CATALOG_MANAGED_FIELD`).
     #[instrument(
         name = SNAPSHOT_COMPLETED_SPAN,
         skip_all,
-        fields(path = %self.table_path(), report, version = tracing::field::Empty, operation_id = %metric_context.operation_id, is_catalog_managed = metric_context.is_catalog_managed),
+        fields(path = %self.table_path(), report, version = tracing::field::Empty, operation_id = %self.operation_id, is_catalog_managed = self.max_catalog_version.is_some()),
         err
     )]
-    fn build_inner(
-        self,
-        engine: &dyn Engine,
-        metric_context: SnapshotLoadMetricContext,
-    ) -> DeltaResult<SnapshotRef> {
+    pub fn build(self, engine: &dyn Engine) -> DeltaResult<SnapshotRef> {
         info!(
             target = self.target_version_str(),
             from_version = ?self.existing_snapshot.as_ref().map(|s| s.version()),
@@ -227,7 +219,13 @@ impl SnapshotBuilder {
             log_tail,
             max_catalog_version,
             incremental_replay,
+            operation_id,
         } = self;
+
+        let metric_context = SnapshotLoadMetricContext {
+            operation_id,
+            is_catalog_managed: max_catalog_version.is_some(),
+        };
 
         let log_tail: Vec<_> = log_tail.into_iter().map(Into::into).collect();
 

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -5,7 +5,7 @@ use tracing::{info, instrument};
 use crate::log_path::LogPath;
 use crate::log_segment::LogSegment;
 use crate::metrics::events::SNAPSHOT_COMPLETED_SPAN;
-use crate::metrics::MetricId;
+use crate::metrics::{SnapshotLoadMetricContext, MetricId};
 use crate::path::LogPathFileType;
 use crate::snapshot::SnapshotRef;
 use crate::utils::{require, try_parse_uri};
@@ -190,13 +190,27 @@ impl SnapshotBuilder {
     ///
     /// [`MetricEvent::SnapshotBuildSuccess`]: crate::metrics::MetricEvent::SnapshotBuildSuccess
     /// [`MetricEvent::SnapshotBuildFailure`]: crate::metrics::MetricEvent::SnapshotBuildFailure
+    pub fn build(self, engine: &dyn Engine) -> DeltaResult<SnapshotRef> {
+        let metric_context = SnapshotLoadMetricContext {
+            operation_id: MetricId::new(),
+            is_catalog_managed: self.max_catalog_version.is_some(),
+        };
+        self.build_inner(engine, metric_context)
+    }
+
+    // `metric_context.is_catalog_managed` is the requested load mode, not the confirmed protocol
+    // (see `IS_CATALOG_MANAGED_FIELD`).
     #[instrument(
         name = SNAPSHOT_COMPLETED_SPAN,
         skip_all,
-        fields(path = %self.table_path(), report, version = tracing::field::Empty, operation_id = tracing::field::Empty),
+        fields(path = %self.table_path(), report, version = tracing::field::Empty, operation_id = %metric_context.operation_id, is_catalog_managed = metric_context.is_catalog_managed),
         err
     )]
-    pub fn build(self, engine: &dyn Engine) -> DeltaResult<SnapshotRef> {
+    fn build_inner(
+        self,
+        engine: &dyn Engine,
+        metric_context: SnapshotLoadMetricContext,
+    ) -> DeltaResult<SnapshotRef> {
         info!(
             target = self.target_version_str(),
             from_version = ?self.existing_snapshot.as_ref().map(|s| s.version()),
@@ -216,11 +230,6 @@ impl SnapshotBuilder {
         } = self;
 
         let log_tail: Vec<_> = log_tail.into_iter().map(Into::into).collect();
-        let operation_id = MetricId::new();
-        // TODO(#2605): this late `record` is silently dropped by the metrics layer, so every
-        //              `SnapshotBuildSuccess` event carries a nil operation_id. Bind eagerly via a
-        //              `build_inner(self, engine, operation_id)` helper instead.
-        tracing::Span::current().record("operation_id", tracing::field::display(operation_id));
 
         // Pre-build validations for catalog-managed tables
         Self::validate_catalog_managed_build_inputs(version, max_catalog_version, &log_tail)?;
@@ -237,13 +246,13 @@ impl SnapshotBuilder {
                     table_url.join("_delta_log/")?,
                     log_tail,
                     effective_version,
-                    operation_id,
+                    metric_context,
                 )?;
                 Snapshot::try_new_from_log_segment(
                     table_url,
                     log_segment,
                     engine,
-                    operation_id,
+                    metric_context,
                     incremental_replay,
                 )
                 .map(Into::into)
@@ -261,7 +270,7 @@ impl SnapshotBuilder {
                         log_tail,
                         engine,
                         effective_version,
-                        operation_id,
+                        metric_context,
                         incremental_replay,
                     )
                 })

--- a/kernel/src/snapshot/incremental.rs
+++ b/kernel/src/snapshot/incremental.rs
@@ -10,7 +10,7 @@ use tracing::instrument;
 use super::{IncrementalReplay, Snapshot};
 use crate::log_segment::LogSegment;
 use crate::log_segment_files::LogSegmentFiles;
-use crate::metrics::MetricId;
+use crate::metrics::SnapshotLoadMetricContext;
 use crate::path::ParsedLogPath;
 use crate::table_configuration::TableConfiguration;
 use crate::{DeltaResult, Engine, Error, Version};
@@ -82,13 +82,13 @@ impl Snapshot {
     ///
     /// [`SnapshotBuilder::at_version`]: crate::snapshot::SnapshotBuilder::at_version
     /// [`SnapshotBuilder::with_max_catalog_version`]: crate::snapshot::SnapshotBuilder::with_max_catalog_version
-    #[instrument(err, fields(version, operation_id = %operation_id), skip(engine, target_version))]
+    #[instrument(err, fields(version, operation_id = %metric_context.operation_id), skip(engine, target_version))]
     pub(super) fn try_new_from(
         existing_snapshot: Arc<Snapshot>,
         log_tail: Vec<ParsedLogPath>,
         engine: &dyn Engine,
         target_version: impl Into<Option<Version>>,
-        operation_id: MetricId,
+        metric_context: SnapshotLoadMetricContext,
         incremental_replay: IncrementalReplay,
     ) -> DeltaResult<Arc<Self>> {
         let existing_log_segment = &existing_snapshot.log_segment;
@@ -181,7 +181,7 @@ impl Snapshot {
                     existing_snapshot.table_root().clone(),
                     new_log_segment,
                     engine,
-                    operation_id,
+                    metric_context,
                     incremental_replay,
                 );
                 return Ok(Arc::new(snapshot?));
@@ -550,7 +550,7 @@ mod tests {
             vec![],
             &engine,
             None,
-            MetricId::default(),
+            SnapshotLoadMetricContext::default(),
             IncrementalReplay::Disabled,
         )?;
         assert_eq!(result, base_snapshot);
@@ -627,7 +627,7 @@ mod tests {
             log_tail,
             &engine,
             Some(2),
-            MetricId::default(),
+            SnapshotLoadMetricContext::default(),
             IncrementalReplay::Disabled,
         )?;
 
@@ -685,7 +685,7 @@ mod tests {
             vec![],
             &engine,
             Some(1),
-            MetricId::default(),
+            SnapshotLoadMetricContext::default(),
             IncrementalReplay::Disabled,
         )?;
         assert!(Arc::ptr_eq(&same_version, &base_snapshot));
@@ -696,7 +696,7 @@ mod tests {
             vec![],
             &engine,
             Some(0),
-            MetricId::default(),
+            SnapshotLoadMetricContext::default(),
             IncrementalReplay::Disabled,
         );
         assert!(matches!(

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -23,7 +23,7 @@ use crate::expressions::ColumnName;
 use crate::incremental_scan::IncrementalScanBuilder;
 use crate::log_segment::{DomainMetadataMap, LogSegment};
 use crate::metrics::events::{DOMAIN_METADATA_LOADED_SPAN, SET_TRANSACTION_LOADED_SPAN};
-use crate::metrics::MetricId;
+use crate::metrics::SnapshotLoadMetricContext;
 use crate::path::ParsedLogPath;
 use crate::scan::ScanBuilder;
 use crate::schema::SchemaRef;
@@ -174,12 +174,12 @@ impl Snapshot {
     /// from the latest on-disk CRC, advanced to the segment's end version when `incremental_replay`
     /// permits, or used to root Protocol and Metadata log replay otherwise. Falls back to full log
     /// replay when no CRC is present.
-    #[instrument(err, fields(version, operation_id = %operation_id), skip(engine))]
+    #[instrument(err, fields(version, operation_id = %metric_context.operation_id), skip(engine))]
     fn try_new_from_log_segment(
         location: Url,
         log_segment: LogSegment,
         engine: &dyn Engine,
-        operation_id: MetricId,
+        metric_context: SnapshotLoadMetricContext,
         incremental_replay: IncrementalReplay,
     ) -> DeltaResult<Self> {
         // Step 1: read the latest on-disk CRC and, if usable, advance it to the end version
@@ -197,7 +197,9 @@ impl Snapshot {
         //              `ProtocolMetadataLoaded` span only fires on the replay branch below.
         let (metadata, protocol) = match crc_at_version.as_deref() {
             Some(c) => (c.metadata.clone(), c.protocol.clone()),
-            None => log_segment.read_protocol_metadata(engine, base_crc.as_ref(), operation_id)?,
+            None => {
+                log_segment.read_protocol_metadata(engine, base_crc.as_ref(), metric_context)?
+            }
         };
 
         let table_configuration =

--- a/kernel/src/table_changes/physical_to_logical.rs
+++ b/kernel/src/table_changes/physical_to_logical.rs
@@ -132,7 +132,6 @@ mod tests {
 
     use super::*;
     use crate::expressions::Expression;
-    use crate::metrics::TableType;
     use crate::scan::state::DvInfo;
     use crate::scan::state_info::StateInfo;
     use crate::scan::transform_spec::FieldTransformSpec;
@@ -190,7 +189,7 @@ mod tests {
             physical_stats_schema: None,
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
-            table_type: TableType::PathBased,
+            is_catalog_managed: false,
         }
     }
 
@@ -413,7 +412,7 @@ mod tests {
             physical_stats_schema: None,
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
-            table_type: TableType::PathBased,
+            is_catalog_managed: false,
         };
 
         let result = get_cdf_transform_expr(&scan_file, &state_info, &physical_schema);

--- a/kernel/src/table_changes/physical_to_logical.rs
+++ b/kernel/src/table_changes/physical_to_logical.rs
@@ -132,6 +132,7 @@ mod tests {
 
     use super::*;
     use crate::expressions::Expression;
+    use crate::metrics::TableType;
     use crate::scan::state::DvInfo;
     use crate::scan::state_info::StateInfo;
     use crate::scan::transform_spec::FieldTransformSpec;
@@ -189,6 +190,7 @@ mod tests {
             physical_stats_schema: None,
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
+            table_type: TableType::PathBased,
         }
     }
 
@@ -411,6 +413,7 @@ mod tests {
             physical_stats_schema: None,
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
+            table_type: TableType::PathBased,
         };
 
         let result = get_cdf_transform_expr(&scan_file, &state_info, &physical_schema);

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -18,6 +18,7 @@ use url::Url;
 
 use crate::actions::{Metadata, Protocol};
 use crate::expressions::ColumnName;
+use crate::metrics::TableType;
 use crate::scan::data_skipping::stats_schema::{
     expected_stats_schema, stats_column_names, StatsConfig, StripFieldMetadataTransform,
 };
@@ -502,6 +503,11 @@ impl TableConfiguration {
     pub(crate) fn is_catalog_managed(&self) -> bool {
         self.is_feature_supported(&TableFeature::CatalogManaged)
             || self.is_feature_supported(&TableFeature::CatalogOwnedPreview)
+    }
+
+    #[internal_api]
+    pub(crate) fn table_type(&self) -> TableType {
+        TableType::from_catalog_managed(self.is_catalog_managed())
     }
 
     /// The [`ColumnMappingMode`] for this table at this version.

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -18,7 +18,6 @@ use url::Url;
 
 use crate::actions::{Metadata, Protocol};
 use crate::expressions::ColumnName;
-use crate::metrics::TableType;
 use crate::scan::data_skipping::stats_schema::{
     expected_stats_schema, stats_column_names, StatsConfig, StripFieldMetadataTransform,
 };
@@ -503,11 +502,6 @@ impl TableConfiguration {
     pub(crate) fn is_catalog_managed(&self) -> bool {
         self.is_feature_supported(&TableFeature::CatalogManaged)
             || self.is_feature_supported(&TableFeature::CatalogOwnedPreview)
-    }
-
-    #[internal_api]
-    pub(crate) fn table_type(&self) -> TableType {
-        TableType::from_catalog_managed(self.is_catalog_managed())
     }
 
     /// The [`ColumnMappingMode`] for this table at this version.

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -343,6 +343,7 @@ impl<S> Transaction<S> {
         fields(
             report,
             operation_id = %self.operation_id,
+            is_catalog_managed = self.effective_table_config.is_catalog_managed(),
             commit_version = self.get_commit_version(),
             num_add_files,
             num_remove_files,
@@ -1677,7 +1678,7 @@ mod tests {
     use crate::engine::arrow_expression::ArrowEvaluationHandler;
     use crate::engine::sync::SyncEngine;
     use crate::expressions::{MapData, Scalar, StructData};
-    use crate::metrics::MetricEvent;
+    use crate::metrics::{MetricEvent, TableType, TransactionCommitFailure};
     use crate::object_store::memory::InMemory;
     use crate::object_store::path::Path;
     use crate::object_store::ObjectStoreExt as _;
@@ -3052,9 +3053,9 @@ mod tests {
 
     // ===== Commit failure-metric tests =====
 
-    fn commit_failure_reason(reporter: &CapturingReporter) -> Option<CommitFailureReason> {
+    fn commit_failure_event(reporter: &CapturingReporter) -> Option<TransactionCommitFailure> {
         reporter.events().into_iter().find_map(|event| match event {
-            MetricEvent::TransactionCommitFailure(f) => Some(f.reason),
+            MetricEvent::TransactionCommitFailure(f) => Some(f),
             _ => None,
         })
     }
@@ -3068,10 +3069,9 @@ mod tests {
         add_dummy_file(&mut txn);
         let result = txn.commit(engine.as_ref())?;
         assert!(matches!(result, CommitResult::RetryableTransaction(_)));
-        assert_eq!(
-            commit_failure_reason(&reporter),
-            Some(CommitFailureReason::RetryableIo)
-        );
+        let failure = commit_failure_event(&reporter).expect("commit failure event");
+        assert_eq!(failure.reason, CommitFailureReason::RetryableIo);
+        assert_eq!(failure.table_type, TableType::PathBased);
         Ok(())
     }
 
@@ -3083,10 +3083,9 @@ mod tests {
         let mut txn = snapshot.transaction(Box::new(GenericErrorCommitter), engine.as_ref())?;
         add_dummy_file(&mut txn);
         assert!(txn.commit(engine.as_ref()).is_err());
-        assert_eq!(
-            commit_failure_reason(&reporter),
-            Some(CommitFailureReason::Error)
-        );
+        let failure = commit_failure_event(&reporter).expect("commit failure event");
+        assert_eq!(failure.reason, CommitFailureReason::Error);
+        assert_eq!(failure.table_type, TableType::PathBased);
         Ok(())
     }
 }

--- a/kernel/tests/integration/metrics/commit.rs
+++ b/kernel/tests/integration/metrics/commit.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex};
 
 use delta_kernel::arrow::array::Int32Array;
 use delta_kernel::committer::FileSystemCommitter;
-use delta_kernel::metrics::{MetricEvent, MetricsReporter, TransactionCommitSuccess};
+use delta_kernel::metrics::{MetricEvent, MetricsReporter, TableType, TransactionCommitSuccess};
 use delta_kernel::object_store::local::LocalFileSystem;
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::CommitResult;
@@ -19,6 +19,7 @@ use test_utils::{
 };
 use url::Url;
 
+use super::table_type::{create_simple_table, make_committer};
 use super::{measuring_engine, simple_schema};
 
 /// Reporter that keeps the last `TransactionCommitSuccess` for field-level assertions.
@@ -63,6 +64,7 @@ async fn commit_append_emits_success_metrics(
         snap,
         &engine,
         vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        Box::new(FileSystemCommitter::new()),
         operation,
         data_change,
         is_blind_append,
@@ -76,6 +78,7 @@ async fn commit_append_emits_success_metrics(
         .unwrap()
         .clone()
         .expect("commit success event");
+    assert_eq!(success.table_type, TableType::PathBased);
     assert_eq!(success.commit_version, 1);
     assert_eq!(success.num_add_files, 1);
     assert!(success.add_files_bytes > 0);
@@ -113,5 +116,49 @@ async fn commit_conflict_emits_conflict_metric() -> DeltaResult<()> {
     assert_eq!(reporter.transaction_commits.get(), 1);
     assert_eq!(reporter.commit_conflicts.get(), 1);
     assert_eq!(reporter.commit_errors.get(), 0);
+    Ok(())
+}
+
+#[rstest]
+#[case::path_based(false)]
+#[case::catalog_managed(true)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn commit_success_carries_table_type(#[case] catalog_managed: bool) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+    let table_url = delta_kernel::try_parse_uri(&table_path)?;
+    create_simple_table(engine.as_ref(), &table_path, catalog_managed)?;
+
+    let reporter = Arc::new(LastCommitSuccess::default());
+    let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
+    let builder = Snapshot::builder_for(table_url);
+    let builder = if catalog_managed {
+        builder.with_max_catalog_version(0)
+    } else {
+        builder
+    };
+    let snapshot = builder.build(engine.as_ref())?;
+    insert_data_with(
+        snapshot,
+        &engine,
+        vec![Arc::new(Int32Array::from(vec![1]))],
+        make_committer(catalog_managed),
+        "WRITE",
+        /* data_change */ true,
+        /* is_blind_append */ false,
+    )
+    .await?
+    .unwrap_committed();
+
+    let success = reporter
+        .0
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("commit success event");
+    assert_eq!(
+        success.table_type,
+        TableType::from_catalog_managed(catalog_managed)
+    );
     Ok(())
 }

--- a/kernel/tests/integration/metrics/mod.rs
+++ b/kernel/tests/integration/metrics/mod.rs
@@ -31,8 +31,10 @@ use test_utils::{
 use url::Url;
 
 mod commit;
+mod parallel_scan;
 mod scan;
 mod snapshot_load;
+mod table_type;
 
 /// Build a `DefaultEngine` + `CountingReporter` backed by `store`, for use in the
 /// *measurement* phase (building a snapshot and asserting metric counters).

--- a/kernel/tests/integration/metrics/parallel_scan.rs
+++ b/kernel/tests/integration/metrics/parallel_scan.rs
@@ -1,0 +1,79 @@
+//! Verifies that the parallel scan-metadata path (`parallel_scan_metadata`) emits
+//! `ScanMetadataCompleted` events carrying the correct [`TableType`], exercising the live
+//! `StateInfo` -> phase-event wiring (a different source than the full-scan path).
+
+use std::sync::Arc;
+
+use delta_kernel::arrow::array::Int32Array;
+use delta_kernel::metrics::TableType;
+use delta_kernel::scan::{AfterSequentialScanMetadata, ParallelScanMetadata};
+use delta_kernel::{DeltaResult, Engine, Snapshot};
+use rstest::rstest;
+use test_utils::{
+    insert_data_with, install_thread_local_metrics_reporter, test_table_setup_mt, CapturingReporter,
+};
+
+use super::table_type::{assert_table_types, create_simple_table, make_committer};
+
+#[rstest]
+#[case::path_based(false)]
+#[case::catalog_managed(true)]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_parallel_scan_metadata_events_carry_table_type(
+    #[case] catalog_managed: bool,
+) -> DeltaResult<()> {
+    let (_tmp, table_path, engine) = test_table_setup_mt()?;
+    let table_url = delta_kernel::try_parse_uri(&table_path)?;
+    let build_snapshot = |version: u64| -> DeltaResult<Arc<Snapshot>> {
+        let builder = Snapshot::builder_for(table_url.clone());
+        let builder = if catalog_managed {
+            builder.with_max_catalog_version(version)
+        } else {
+            builder
+        };
+        builder.build(engine.as_ref())
+    };
+
+    // Given: a table with one appended row.
+    create_simple_table(engine.as_ref(), &table_path, catalog_managed)?;
+    insert_data_with(
+        build_snapshot(0)?,
+        &engine,
+        vec![Arc::new(Int32Array::from(vec![1]))],
+        make_committer(catalog_managed),
+        "WRITE",
+        /* data_change */ true,
+        /* is_blind_append */ false,
+    )
+    .await?
+    .unwrap_committed();
+
+    // When: the table is scanned via the parallel (sequential + optional distributed) path.
+    let reporter = Arc::new(CapturingReporter::default());
+    let _guard = install_thread_local_metrics_reporter(reporter.clone());
+    let scan = build_snapshot(1)?.scan_builder().build()?;
+    let engine_dyn: Arc<dyn Engine> = engine.clone();
+    let mut sequential = scan.parallel_scan_metadata(engine_dyn.clone())?;
+    for result in sequential.by_ref() {
+        result?;
+    }
+    if let AfterSequentialScanMetadata::Parallel { state, files } = sequential.finish()? {
+        let state = Arc::new(*state);
+        for file in files {
+            let parallel =
+                ParallelScanMetadata::try_new(engine_dyn.clone(), state.clone(), vec![file])?;
+            for result in parallel {
+                result?;
+            }
+        }
+        state.log_metrics();
+    }
+
+    // Then: the emitted scan-metadata event(s) carry the expected table_type.
+    assert_table_types(
+        &reporter.events(),
+        &["ScanMetadataCompleted"],
+        TableType::from_catalog_managed(catalog_managed),
+    );
+    Ok(())
+}

--- a/kernel/tests/integration/metrics/table_type.rs
+++ b/kernel/tests/integration/metrics/table_type.rs
@@ -1,0 +1,233 @@
+//! Verifies that snapshot-load and scan metric events carry the correct [`TableType`] for both
+//! path-based and catalog-managed tables, exercised end-to-end through public APIs
+//! (`create_table`, `Transaction`, `Scan`).
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use delta_kernel::arrow::array::Int32Array;
+use delta_kernel::committer::{Committer, FileSystemCommitter};
+use delta_kernel::metrics::{MetricEvent, TableType};
+use delta_kernel::transaction::create_table::create_table;
+use delta_kernel::{DeltaResult, Engine, Snapshot};
+use rstest::rstest;
+use test_utils::{
+    add_commit, engine_store_setup, insert_data_with, install_thread_local_metrics_reporter,
+    test_table_setup_mt, CapturingReporter, TestCatalogCommitter,
+};
+
+use super::simple_schema;
+
+#[rstest]
+#[case::path_based(false)]
+#[case::catalog_managed(true)]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_metric_events_carry_table_type(#[case] catalog_managed: bool) -> DeltaResult<()> {
+    let (_tmp, table_path, engine) = test_table_setup_mt()?;
+    let table_url = delta_kernel::try_parse_uri(&table_path)?;
+
+    let build_snapshot = |max_catalog_version: u64| -> DeltaResult<Arc<Snapshot>> {
+        let builder = Snapshot::builder_for(table_url.clone());
+        let builder = if catalog_managed {
+            builder.with_max_catalog_version(max_catalog_version)
+        } else {
+            builder
+        };
+        builder.build(engine.as_ref())
+    };
+
+    // Given: a table (path-based or catalog-managed) with one appended row.
+    create_simple_table(engine.as_ref(), &table_path, catalog_managed)?;
+    insert_data_with(
+        build_snapshot(0)?,
+        &engine,
+        vec![Arc::new(Int32Array::from(vec![1]))],
+        make_committer(catalog_managed),
+        "WRITE",
+        /* data_change */ true,
+        /* is_blind_append */ false,
+    )
+    .await?
+    .unwrap_committed();
+
+    // When: a fresh snapshot is built and scanned with a metrics reporter installed.
+    let reporter = Arc::new(CapturingReporter::default());
+    let _guard = install_thread_local_metrics_reporter(reporter.clone());
+    let snapshot = build_snapshot(1)?;
+    let scan = snapshot.scan_builder().build()?;
+    for batch in scan.scan_metadata(engine.as_ref())? {
+        batch?;
+    }
+
+    // Then: every snapshot-load and scan event carries the expected table_type.
+    let expected = TableType::from_catalog_managed(catalog_managed);
+    assert_table_types(
+        &reporter.events(),
+        &[
+            "LogSegmentLoadSuccess",
+            "ProtocolMetadataLoadSuccess",
+            "SnapshotBuildSuccess",
+            "ScanMetadataCompleted",
+        ],
+        expected,
+    );
+    Ok(())
+}
+
+#[rstest]
+#[case::path_based(false)]
+#[case::catalog_managed(true)]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_snapshot_failure_events_carry_table_type(#[case] catalog_managed: bool) {
+    let (_tmp, table_path, engine) = test_table_setup_mt().unwrap();
+    let table_url = delta_kernel::try_parse_uri(&table_path).unwrap();
+
+    let reporter = Arc::new(CapturingReporter::default());
+    let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
+    let builder = Snapshot::builder_for(table_url);
+    let builder = if catalog_managed {
+        builder.with_max_catalog_version(0)
+    } else {
+        builder
+    };
+    assert!(builder.build(engine.as_ref()).is_err());
+
+    let expected = TableType::from_catalog_managed(catalog_managed);
+    assert_table_types(
+        &reporter.events(),
+        &["LogSegmentLoadFailure", "SnapshotBuildFailure"],
+        expected,
+    );
+}
+
+#[rstest]
+#[case::path_based(false)]
+#[case::catalog_managed(true)]
+#[tokio::test]
+async fn test_protocol_metadata_load_failure_carries_table_type(#[case] catalog_managed: bool) {
+    let (store, engine, table_url) = engine_store_setup("pm_failure", None);
+    // An Add-only commit (no Protocol/Metadata) makes the protocol+metadata replay fail.
+    let add_only = r#"{"add":{"path":"f.parquet","partitionValues":{},"size":1,"modificationTime":1,"dataChange":true}}"#;
+    add_commit(table_url.as_str(), store.as_ref(), 0, add_only.to_string())
+        .await
+        .unwrap();
+
+    let reporter = Arc::new(CapturingReporter::default());
+    let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
+    let builder = Snapshot::builder_for(table_url);
+    let builder = if catalog_managed {
+        builder.with_max_catalog_version(0)
+    } else {
+        builder
+    };
+    assert!(builder.build(&engine).is_err());
+
+    let expected = TableType::from_catalog_managed(catalog_managed);
+    assert_table_types(
+        &reporter.events(),
+        &["ProtocolMetadataLoadFailure", "SnapshotBuildFailure"],
+        expected,
+    );
+}
+
+/// Validation fails after the protocol read succeeds, so events carry the requested mode (the
+/// documented best guess), not the protocol truth.
+#[rstest]
+#[case::catalog_version_on_path_based(false, true, TableType::CatalogManaged)]
+#[case::no_catalog_version_on_catalog_managed(true, false, TableType::PathBased)]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_build_validation_mismatch_events_carry_requested_table_type(
+    #[case] create_catalog_managed: bool,
+    #[case] request_catalog_version: bool,
+    #[case] expected: TableType,
+) -> DeltaResult<()> {
+    let (_tmp, table_path, engine) = test_table_setup_mt()?;
+    let table_url = delta_kernel::try_parse_uri(&table_path)?;
+
+    create_simple_table(engine.as_ref(), &table_path, create_catalog_managed)?;
+
+    let reporter = Arc::new(CapturingReporter::default());
+    let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
+    let builder = Snapshot::builder_for(table_url);
+    let builder = if request_catalog_version {
+        builder.with_max_catalog_version(0)
+    } else {
+        builder
+    };
+    assert!(builder.build(engine.as_ref()).is_err());
+
+    assert_table_types(
+        &reporter.events(),
+        &["ProtocolMetadataLoadSuccess", "SnapshotBuildFailure"],
+        expected,
+    );
+    Ok(())
+}
+
+pub(super) fn make_committer(catalog_managed: bool) -> Box<dyn Committer> {
+    if catalog_managed {
+        Box::new(TestCatalogCommitter)
+    } else {
+        Box::new(FileSystemCommitter::new())
+    }
+}
+
+pub(super) fn create_simple_table(
+    engine: &dyn Engine,
+    table_path: &str,
+    catalog_managed: bool,
+) -> DeltaResult<()> {
+    let builder = create_table(table_path, simple_schema(), "Test/1.0");
+    let builder = if catalog_managed {
+        builder.with_table_properties([
+            ("delta.feature.catalogManaged", "supported"),
+            ("delta.feature.vacuumProtocolCheck", "supported"),
+            ("io.unitycatalog.tableId", "metrics-table-type-test"),
+        ])
+    } else {
+        builder
+    };
+    builder
+        .build(engine, make_committer(catalog_managed))?
+        .commit(engine)?
+        .unwrap_committed();
+    Ok(())
+}
+
+fn table_types(events: &[MetricEvent]) -> Vec<(&'static str, TableType)> {
+    events
+        .iter()
+        .filter_map(|e| match e {
+            MetricEvent::LogSegmentLoadSuccess(e) => Some(("LogSegmentLoadSuccess", e.table_type)),
+            MetricEvent::LogSegmentLoadFailure(e) => Some(("LogSegmentLoadFailure", e.table_type)),
+            MetricEvent::ProtocolMetadataLoadSuccess(e) => {
+                Some(("ProtocolMetadataLoadSuccess", e.table_type))
+            }
+            MetricEvent::ProtocolMetadataLoadFailure(e) => {
+                Some(("ProtocolMetadataLoadFailure", e.table_type))
+            }
+            MetricEvent::SnapshotBuildSuccess(e) => Some(("SnapshotBuildSuccess", e.table_type)),
+            MetricEvent::SnapshotBuildFailure(e) => Some(("SnapshotBuildFailure", e.table_type)),
+            MetricEvent::ScanMetadataCompleted(e) => Some(("ScanMetadataCompleted", e.table_type)),
+            _ => None,
+        })
+        .collect()
+}
+
+#[track_caller]
+pub(super) fn assert_table_types(events: &[MetricEvent], required: &[&str], expected: TableType) {
+    let observed = table_types(events);
+    let kinds: HashSet<&str> = observed.iter().map(|(kind, _)| *kind).collect();
+    for required in required {
+        assert!(
+            kinds.contains(required),
+            "missing {required} event; saw {kinds:?}"
+        );
+    }
+    for (kind, table_type) in observed {
+        assert_eq!(table_type, expected, "{kind} carried the wrong table_type");
+    }
+}

--- a/test-utils/src/counting_reporter.rs
+++ b/test-utils/src/counting_reporter.rs
@@ -5,7 +5,7 @@
 //! inspect the counters or call [`CountingReporter::print_summary`].
 
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use delta_kernel::metrics::{
     CommitFailureReason, MetricEvent, MetricsReporter, WithMetricsReporterLayer as _,
@@ -371,6 +371,26 @@ impl MetricsReporter for CountingReporter {
     }
 }
 
+/// A [`MetricsReporter`] that retains every [`MetricEvent`] for inspection, for tests that need
+/// to assert on event payloads (not just counts, which [`CountingReporter`] handles).
+#[derive(Debug, Default)]
+pub struct CapturingReporter {
+    events: Mutex<Vec<MetricEvent>>,
+}
+
+impl MetricsReporter for CapturingReporter {
+    fn report(&self, event: MetricEvent) {
+        self.events.lock().unwrap().push(event);
+    }
+}
+
+impl CapturingReporter {
+    /// All events captured so far, in report order.
+    pub fn events(&self) -> Vec<MetricEvent> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -380,7 +400,7 @@ mod tests {
         CrcReadSuccess, DomainMetadataLoadSuccess, LogSegmentLoadSuccess, MetricId,
         ProtocolMetadataLoadSuccess, SetTransactionLoadSuccess, SnapshotBuildFailure,
         SnapshotBuildSuccess, StorageCopyCompleted, StorageListCompleted, StorageReadCompleted,
-        TransactionCommitFailure, TransactionCommitSuccess,
+        TableType, TransactionCommitFailure, TransactionCommitSuccess,
     };
 
     use super::*;
@@ -431,6 +451,7 @@ mod tests {
         let reporter = CountingReporter::new();
         reporter.report(MetricEvent::SnapshotBuildSuccess(SnapshotBuildSuccess {
             operation_id: MetricId::new(),
+            table_type: TableType::PathBased,
             version: 0,
             duration: dur(),
         }));
@@ -442,6 +463,7 @@ mod tests {
         let reporter = CountingReporter::new();
         reporter.report(MetricEvent::LogSegmentLoadSuccess(LogSegmentLoadSuccess {
             operation_id: MetricId::new(),
+            table_type: TableType::PathBased,
             duration: dur(),
             num_commit_files: 7,
             num_checkpoint_files: 2,
@@ -460,6 +482,7 @@ mod tests {
         let reporter = CountingReporter::new();
         reporter.report(MetricEvent::LogSegmentLoadSuccess(LogSegmentLoadSuccess {
             operation_id: MetricId::new(),
+            table_type: TableType::PathBased,
             duration: dur(),
             num_commit_files: 3,
             num_checkpoint_files: 1,
@@ -535,6 +558,7 @@ mod tests {
         reporter.report(MetricEvent::TransactionCommitSuccess(
             TransactionCommitSuccess {
                 operation_id: MetricId::new(),
+                table_type: TableType::PathBased,
                 commit_version: 1,
                 num_add_files: 3,
                 num_remove_files: 2,
@@ -566,6 +590,7 @@ mod tests {
             reporter.report(MetricEvent::TransactionCommitFailure(
                 TransactionCommitFailure {
                     operation_id: MetricId::new(),
+                    table_type: TableType::PathBased,
                     reason,
                 },
             ));
@@ -582,11 +607,13 @@ mod tests {
         reporter.report(MetricEvent::ProtocolMetadataLoadSuccess(
             ProtocolMetadataLoadSuccess {
                 operation_id: MetricId::new(),
+                table_type: TableType::PathBased,
                 duration: dur(),
             },
         ));
         reporter.report(MetricEvent::SnapshotBuildFailure(SnapshotBuildFailure {
             operation_id: MetricId::new(),
+            table_type: TableType::PathBased,
         }));
         assert_eq!(reporter.snapshot_completions.get(), 0);
     }
@@ -608,6 +635,7 @@ mod tests {
         }));
         reporter.report(MetricEvent::LogSegmentLoadSuccess(LogSegmentLoadSuccess {
             operation_id: MetricId::new(),
+            table_type: TableType::PathBased,
             duration: dur(),
             num_commit_files: 7,
             num_checkpoint_files: 2,

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -146,7 +146,7 @@ use std::sync::{Arc, Mutex};
 
 pub use counting_reporter::{
     ensure_metrics_compatible_global_subscriber, install_thread_local_metrics_reporter,
-    CountingReporter, RelaxedCounter,
+    CapturingReporter, CountingReporter, RelaxedCounter,
 };
 use delta_kernel::actions::{
     get_log_add_schema, MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS, TIGHT_BOUNDS,
@@ -159,7 +159,9 @@ use delta_kernel::arrow::buffer::OffsetBuffer;
 use delta_kernel::arrow::datatypes::{DataType as ArrowDataType, Field, Schema as ArrowSchema};
 use delta_kernel::arrow::error::ArrowError;
 use delta_kernel::arrow::util::pretty::pretty_format_batches;
-use delta_kernel::committer::FileSystemCommitter;
+use delta_kernel::committer::{
+    CommitMetadata, CommitResponse, Committer, FileSystemCommitter, PublishMetadata,
+};
 use delta_kernel::engine::arrow_conversion::TryFromKernel;
 use delta_kernel::engine::arrow_data::{ArrowEngineData, EngineDataArrowExt};
 use delta_kernel::expressions::Scalar;
@@ -172,7 +174,10 @@ use delta_kernel::parquet::file::properties::WriterProperties;
 use delta_kernel::scan::Scan;
 use delta_kernel::schema::{DataType, SchemaRef, StructField, StructType};
 use delta_kernel::transaction::{CommitResult, Transaction};
-use delta_kernel::{try_parse_uri, DeltaResult, Engine, EngineData, FileMeta, LogPath, Snapshot};
+use delta_kernel::{
+    try_parse_uri, DeltaResult, DeltaResultIterator, Engine, EngineData, FileMeta,
+    FilteredEngineData, LogPath, Snapshot,
+};
 // Re-export `delta_kernel_default_engine` so kernel's integration tests can access it without
 // taking a direct dev-dep on the new crate (which would create a cycle via this crate).
 pub use delta_kernel_default_engine;
@@ -820,15 +825,26 @@ pub async fn insert_data<E: TaskExecutor>(
     engine: &Arc<DefaultEngine<E>>,
     columns: Vec<ArrayRef>,
 ) -> DeltaResult<CommitResult> {
-    insert_data_with(snapshot, engine, columns, "WRITE", true, false).await
+    insert_data_with(
+        snapshot,
+        engine,
+        columns,
+        Box::new(FileSystemCommitter::new()),
+        "WRITE",
+        /* data_change */ true,
+        /* is_blind_append */ false,
+    )
+    .await
 }
 
-/// Like [`insert_data`] but with the commit's `operation`, `data_change`, and blind-append flag
-/// configurable.
+/// Like [`insert_data`] but with the `committer` and the commit's `operation`, `data_change`, and
+/// blind-append flag configurable. Pass [`TestCatalogCommitter`] for catalog-managed tables.
+#[allow(clippy::too_many_arguments)]
 pub async fn insert_data_with<E: TaskExecutor>(
     snapshot: Arc<Snapshot>,
     engine: &Arc<DefaultEngine<E>>,
     columns: Vec<ArrayRef>,
+    committer: Box<dyn Committer>,
     operation: &str,
     data_change: bool,
     is_blind_append: bool,
@@ -836,7 +852,8 @@ pub async fn insert_data_with<E: TaskExecutor>(
     let arrow_schema = TryFromKernel::try_from_kernel(snapshot.schema().as_ref())?;
     let batch = RecordBatch::try_new(Arc::new(arrow_schema), columns)
         .map_err(|e| delta_kernel::Error::generic(e.to_string()))?;
-    let mut txn = begin_transaction(snapshot, engine.as_ref())?
+    let mut txn = snapshot
+        .transaction(committer, engine.as_ref())?
         .with_operation(operation.to_string())
         .with_data_change(data_change);
     if is_blind_append {
@@ -855,6 +872,35 @@ pub async fn insert_data_with<E: TaskExecutor>(
 /// Starts a transaction using the passed snapshot using a [`FileSystemCommitter`].
 pub fn begin_transaction(snapshot: Arc<Snapshot>, engine: &dyn Engine) -> DeltaResult<Transaction> {
     snapshot.transaction(Box::new(FileSystemCommitter::new()), engine)
+}
+
+/// A catalog [`Committer`] for tests: writes every commit directly to the published Delta log
+/// path, so catalog-managed tables can be created and appended to without a real catalog.
+pub struct TestCatalogCommitter;
+
+impl Committer for TestCatalogCommitter {
+    fn commit(
+        &self,
+        engine: &dyn Engine,
+        actions: DeltaResultIterator<'_, FilteredEngineData>,
+        commit_metadata: CommitMetadata,
+    ) -> DeltaResult<CommitResponse> {
+        let path = commit_metadata.published_commit_path()?;
+        engine
+            .json_handler()
+            .write_json_file(&path, Box::new(actions), false)?;
+        Ok(CommitResponse::Committed {
+            file_meta: FileMeta::new(path, commit_metadata.in_commit_timestamp(), 0),
+        })
+    }
+
+    fn is_catalog_committer(&self) -> bool {
+        true
+    }
+
+    fn publish(&self, _: &dyn Engine, _: PublishMetadata) -> DeltaResult<()> {
+        Ok(())
+    }
 }
 
 /// Load latest snapshot from `table_url` and start a transaction using a [`FileSystemCommitter`].


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add a `TableType { PathBased, CatalogManaged }` dimension to the snapshot-load (`LogSegmentLoad`, `ProtocolMetadataLoad`, `SnapshotBuild` success + failure), `ScanMetadataCompleted`, and `TransactionCommit` metric events.

Resolves #2605: `SnapshotBuilder::build` now binds `operation_id` eagerly via a private `build_inner`, so snapshot-load events carry a real id instead of nil.

## How was this change tested?

New UTs. 
