### PR TITLE
ci: interleave benchmark rounds and report noise-aware comparison

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,8 +8,8 @@
 # Benchmarks run on four triggers:
 #   - pull_request: every push to a non-draft PR auto-runs with BENCH_TAGS=base
 #   - push (main only): warms the rust-cache so PR runs restore a warm target/
-#   - issue_comment: a /bench [--tags ...] [--filter ...] comment runs with
-#                    the supplied flags (including on draft PRs)
+#   - issue_comment: a /bench comment runs with the supplied flags (including
+#                    on draft PRs); see benchmarks/README.md for the syntax
 #   - merge_group: declared so this workflow can be added to branch protection
 #                  as a required status check later. Currently a no-op.
 # Comment posting lives in a separate workflow_run-triggered workflow at

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -112,14 +112,20 @@ same comment that the auto-trigger uses.
 To trigger benchmarks on a pull request manually, post a comment using the following syntax:
 
 ```
-/bench [--tags <comma separated list of tags>] [--filter <regex>]
+/bench [--tags <comma separated list of tags>] [--filter <regex>] [--rounds <n>]
+       [--sample-size <n>] [--measurement-time <secs>] [--warm-up-time <secs>]
 ```
 
 - `--tags` sets `BENCH_TAGS` (comma-separated), controlling which table groupings run.
 - `--filter` is a single-token Criterion regex matched against benchmark names.
-- Both flags are optional and independent; they can be given in any order.
-- When both are specified, they apply as AND: only benchmarks from tables that match the tag filter AND whose name matches the regex are run.
-- Running just `/bench` (with no flags) defaults to `BENCH_TAGS=base`. If neither flag is parsed, the same default applies.
+- `--rounds` sets how many alternating base/PR measurement rounds run (1 to 5, default 2).
+- `--sample-size`, `--measurement-time`, and `--warm-up-time` are passed through to Criterion,
+  trading per-pass cost against per-pass precision.
+- All flags are optional and independent; they can be given in any order.
+- When both `--tags` and `--filter` are specified, they apply as AND: only benchmarks from
+  tables that match the tag filter AND whose name matches the regex are run.
+- Running just `/bench` (with no flags) defaults to `BENCH_TAGS=base`. If neither `--tags`
+  nor `--filter` is parsed, the same default applies.
 
 Examples:
 ```
@@ -131,7 +137,14 @@ Examples:
 ```
 
 See [By tag (`BENCH_TAGS`)](#by-tag-bench_tags) for how tags work and [By benchmark name](#by-benchmark-name) for regex pattern examples. Results are posted automatically as a PR comment, comparing the PR branch against the base branch.
-CI timings are noisy and tend to run higher than on dedicated hardware, but proportional differences between branches are a rough signal for performance changes.
+
+CI timings are noisy and tend to run higher than on dedicated hardware. To keep that noise
+out of the comparison, the CI run compiles one bench binary per branch and executes them in
+alternating rounds (base, PR, base, PR, ...), so machine-state drift spreads over both sides
+instead of biasing one. The posted comment compares the best time per side across rounds,
+flags a change only when it exceeds a noise band and the combined error bars, and reports the
+round-to-round spread of identical code as the run's measured noise floor. Treat wall-clock
+results on shared runners as advisory; rerun locally before acting on a small difference.
 
 ## Workload data layout
 

--- a/benchmarks/ci/parse_critcmp.py
+++ b/benchmarks/ci/parse_critcmp.py
@@ -1,36 +1,42 @@
 #!/usr/bin/env python3
 """
-Parse critcmp output and format it as a GitHub-flavoured Markdown comment.
+Parse per-round critcmp output and format it as a GitHub-flavoured Markdown
+comment.
 
-Reads the output of `critcmp base changes` from stdin and writes:
-  1. A summary block listing the largest slowdown, the fastest speedup,
-     and the count of significant slowdowns/speedups.
-  2. A `<details>` block (closed by default) containing the full
-     per-benchmark table with columns: Test | Base | PR | Change.
+Each input file holds the output of `critcmp base<r> changes<r>` for one
+alternating measurement round (see benchmarks/ci/run-benchmarks.sh). Writes:
+  1. A summary block: counts of changes beyond the noise band, the largest
+     such slowdown and speedup, and the measured noise floor (round-to-round
+     spread of identical code).
+  2. A `<details>` block with the per-benchmark table comparing the best
+     (lowest) time per side across rounds.
+  3. A `<details>` block with the raw per-round times.
 
-A change is "significant" when it is at least 2x in either direction
-(ratio >= 2.0 for slowdown, ratio <= 0.5 for speedup). The summary includes
-every slowdown and speedup; significant ones get a 🐌/🚀 marker in the
-Change cell.
+A change is reported only when the ratio between the best times is at least
+NOISE_BAND away from 1.0 AND the absolute difference exceeds the two sides'
+combined error bars; everything else renders unmarked, as within noise.
+Ratios of at least SIGNIFICANCE_THRESHOLD get the strong marker.
 
 Usage:
-    critcmp base changes | python3 benchmarks/ci/parse_critcmp.py
+    python3 benchmarks/ci/parse_critcmp.py round1.txt [round2.txt ...]
 """
 import re
+import statistics
 import sys
 
-# Significance threshold for slowdowns/speedups (2x in either direction).
+# Minimum relative change that counts as beyond noise; wall clock on shared CI
+# runners routinely jitters a few percent. The error bars must also separate.
+NOISE_BAND = 0.05
+
+# Ratios at least this far from 1.0 in either direction get the strong marker.
 SIGNIFICANCE_THRESHOLD = 2.0
 
-# Ratios within this of 1.0 count as no change: rendered "1.00x" with no marker
-# and excluded from the summary's slowdown/speedup counts.
-NEUTRAL_THRESHOLD = 1e-3
-
-# Emoji markers for the Change cell, by side and severity.
+# Emoji markers for the Change cell, by side and severity. Rows within the
+# noise band carry no marker.
 SIGNIFICANT_SLOWDOWN = '🐌'  # ratio >= SIGNIFICANCE_THRESHOLD
-SLIGHT_SLOWDOWN = '🚧'  # 1.0 < ratio < SIGNIFICANCE_THRESHOLD
-SLIGHT_SPEEDUP = '✅'  # 1.0 / SIGNIFICANCE_THRESHOLD < ratio < 1.0
-SIGNIFICANT_SPEEDUP = '🚀'  # ratio <= 1.0 / SIGNIFICANCE_THRESHOLD
+SLOWDOWN = '🚧'  # beyond noise, below SIGNIFICANCE_THRESHOLD
+SPEEDUP = '✅'  # beyond noise, below SIGNIFICANCE_THRESHOLD
+SIGNIFICANT_SPEEDUP = '🚀'  # ratio <= 1 / SIGNIFICANCE_THRESHOLD
 
 def to_ms(value, units):
     """Convert a critcmp duration to milliseconds.
@@ -51,23 +57,32 @@ def to_ms(value, units):
         return value / 1e6
     raise ValueError(f'unrecognized critcmp time unit: {units!r}')
 
-def parse_duration(s):
-    m = re.match(r'([0-9.]+)±([0-9.]+)(.+)', s.strip())
+def parse_measurement(dur_str):
+    """Parse a critcmp duration cell like '26.8±0.45ms'.
+
+    Returns a dict with `ms` (point estimate), `err_ms` (error bar), and
+    `display` (the original string), or None when the cell is missing or
+    unparseable.
+    """
+    if not dur_str:
+        return None
+    m = re.match(r'([0-9.]+)±([0-9.]+)(.+)', dur_str.strip())
     if not m:
         return None
-    return float(m.group(1)), float(m.group(2)), m.group(3).strip()
+    unit = m.group(3).strip()
+    return {
+        'ms': to_ms(float(m.group(1)), unit),
+        'err_ms': to_ms(float(m.group(2)), unit),
+        'display': dur_str.strip(),
+    }
 
-def parse_rows(lines):
-    """Parse critcmp stdout into a list of row dicts.
+def parse_round(lines):
+    """Parse one critcmp output into {benchmark name: {'base': m, 'changes': m}}.
 
-    Each row dict contains:
-      name:         sanitized benchmark name (no backticks/pipes), unwrapped
-      base_display: base duration string or 'N/A'
-      chg_display:  changes duration string or 'N/A'
-      ratio:        chg_ms / base_ms, or None if either side is missing/zero
-      significant:  bool, False if ratio is None
+    Measurement values are None when a benchmark only exists in one of the two
+    baselines (added or removed benchmarks).
     """
-    rows = []
+    out = {}
     for line in lines[2:]:  # skip critcmp header rows
         if not line.strip():
             continue
@@ -79,42 +94,71 @@ def parse_rows(lines):
         fields = re.split(r'  +', line)
         name = fields[0].strip() if fields else ''
         dur_fields = [f.strip() for f in fields[1:] if '±' in f]
-        base_dur_str = dur_fields[0] if len(dur_fields) > 0 else None
-        chg_dur_str  = dur_fields[1] if len(dur_fields) > 1 else None
-
-        if not name and not base_dur_str and not chg_dur_str:
+        if not name and not dur_fields:
             continue
+        out[name] = {
+            'base': parse_measurement(dur_fields[0] if len(dur_fields) > 0 else None),
+            'changes': parse_measurement(dur_fields[1] if len(dur_fields) > 1 else None),
+        }
+    return out
 
-        # N/A when a benchmark only exists in one of the two runs (added or removed).
-        base_display = base_dur_str or 'N/A'
-        chg_display  = chg_dur_str  or 'N/A'
+def best(measurements):
+    """Lowest-time measurement, or None when the list is empty.
+
+    The minimum is the standard combiner for wall-clock rounds: scheduler and
+    neighbor interference only ever add time, so the lowest observation is the
+    closest to the machine's true speed.
+    """
+    return min(measurements, key=lambda m: m['ms']) if measurements else None
+
+def spread(measurements):
+    """Round-to-round relative spread (max/min - 1) for one side of one
+    benchmark, or None with fewer than two rounds."""
+    if len(measurements) < 2:
+        return None
+    lo = min(m['ms'] for m in measurements)
+    hi = max(m['ms'] for m in measurements)
+    return hi / lo - 1.0 if lo > 0 else None
+
+def combine_rounds(rounds):
+    """Combine per-round parses into one row per benchmark.
+
+    Each row carries the best measurement per side, the ratio between them,
+    whether the change clears the noise band and the combined error bars, the
+    per-side round-to-round spreads, and the raw per-round measurements.
+    """
+    names = {}
+    for rnd in rounds:
+        for name in rnd:
+            names.setdefault(name, None)
+
+    rows = []
+    for name in names:
+        base_all = [r[name]['base'] for r in rounds if name in r and r[name]['base']]
+        chg_all = [r[name]['changes'] for r in rounds if name in r and r[name]['changes']]
+        b = best(base_all)
+        c = best(chg_all)
+
         ratio = None
-        significant = False
+        beyond_noise = False
+        if b and c and b['ms'] > 0 and c['ms'] > 0:
+            ratio = c['ms'] / b['ms']
+            in_band = 1.0 / (1.0 + NOISE_BAND) < ratio < 1.0 + NOISE_BAND
+            separated = abs(c['ms'] - b['ms']) > (b['err_ms'] + c['err_ms'])
+            beyond_noise = not in_band and separated
 
-        if base_dur_str and chg_dur_str:
-            base_p = parse_duration(base_dur_str)
-            chg_p  = parse_duration(chg_dur_str)
-            if base_p and chg_p:
-                base_ms = to_ms(base_p[0], base_p[2])
-                chg_ms  = to_ms(chg_p[0],  chg_p[2])
-
-                # Float-equality on zero is safe here: to_ms only multiplies/divides
-                # by powers of ten, so a zero output strictly implies a zero input.
-                # Do NOT replace with an epsilon -- that would tag legitimately fast
-                # benches (sub-nanosecond rounding) as N/A.
-                if base_ms != 0 and chg_ms != 0:
-                    ratio = chg_ms / base_ms
-                    significant = (
-                        ratio >= SIGNIFICANCE_THRESHOLD
-                        or ratio <= 1.0 / SIGNIFICANCE_THRESHOLD
-                    )
-
+        spreads = [s for s in (spread(base_all), spread(chg_all)) if s is not None]
         rows.append({
             'name': name,
-            'base_display': base_display,
-            'chg_display': chg_display,
+            'base': b,
+            'chg': c,
             'ratio': ratio,
-            'significant': significant,
+            'beyond_noise': beyond_noise,
+            'spreads': spreads,
+            'per_round': [
+                (r.get(name, {}).get('base'), r.get(name, {}).get('changes'))
+                for r in rounds
+            ],
         })
     return rows
 
@@ -122,91 +166,127 @@ def format_difference(ratio):
     """Render a ratio as e.g. '1.00x', '1.50x slower', or '2.00x faster'."""
     if ratio is None:
         return 'N/A'
-    if abs(ratio - 1.0) < NEUTRAL_THRESHOLD:
+    shown = ratio if ratio >= 1.0 else 1.0 / ratio
+    if f'{shown:.2f}' == '1.00':
         return '1.00x'
-    if ratio > 1:
-        return f'{ratio:.2f}x slower'
-    return f'{1.0 / ratio:.2f}x faster'
+    side = 'slower' if ratio > 1.0 else 'faster'
+    return f'{shown:.2f}x {side}'
 
-def change_emoji(ratio, significant):
-    """Pick an emoji indicator for the Change cell.
-
-    See the module-level emoji constants for the marker assignments. Returns
-    an empty string for ratios near 1.0 or N/A rows.
-    """
-    if ratio is None or abs(ratio - 1.0) < NEUTRAL_THRESHOLD:
+def change_emoji(row):
+    """Pick the Change-cell marker; rows within the noise band get none."""
+    if not row['beyond_noise']:
         return ''
-    if ratio > 1.0:
-        return SIGNIFICANT_SLOWDOWN if significant else SLIGHT_SLOWDOWN
-    return SIGNIFICANT_SPEEDUP if significant else SLIGHT_SPEEDUP
+    if row['ratio'] > 1.0:
+        return SIGNIFICANT_SLOWDOWN if row['ratio'] >= SIGNIFICANCE_THRESHOLD else SLOWDOWN
+    return SIGNIFICANT_SPEEDUP if row['ratio'] <= 1.0 / SIGNIFICANCE_THRESHOLD else SPEEDUP
 
 def render_summary(rows):
-    """Render the summary block. The counts and the largest-slowdown/fastest-speedup
-    lines include every slowdown and speedup regardless of the 2x significance
-    threshold; the per-row emoji marker is what distinguishes significant from
-    slight changes.
+    """Render the summary block: beyond-noise counts with the largest change on
+    each side, the within-noise count, and the measured noise floor."""
+    slow = [r for r in rows if r['beyond_noise'] and r['ratio'] > 1.0]
+    fast = [r for r in rows if r['beyond_noise'] and r['ratio'] < 1.0]
+    measured = [r for r in rows if r['ratio'] is not None]
+    within = len(measured) - len(slow) - len(fast)
 
-    Rows within NEUTRAL_THRESHOLD of 1.0 are excluded since they are neither slowdowns
-    nor speedups. N/A rows (ratio is None) are excluded for the same reason.
-    """
-    slow = [r for r in rows if r['ratio'] is not None and r['ratio'] - 1.0 >= NEUTRAL_THRESHOLD]
-    fast = [r for r in rows if r['ratio'] is not None and 1.0 - r['ratio'] >= NEUTRAL_THRESHOLD]
-
+    slow_line = f'- Slowdowns beyond noise: {len(slow)}'
     if slow:
         worst = max(slow, key=lambda r: r['ratio'])
-        largest_slowdown = f"`{worst['name']}` ({format_difference(worst['ratio'])})"
-    else:
-        largest_slowdown = "no benchmarks slowed down"
-
+        slow_line += f" (largest: `{worst['name']}`, {format_difference(worst['ratio'])})"
+    fast_line = f'- Speedups beyond noise: {len(fast)}'
     if fast:
-        best = min(fast, key=lambda r: r['ratio'])
-        fastest_speedup = f"`{best['name']}` ({format_difference(best['ratio'])})"
-    else:
-        fastest_speedup = "no benchmarks sped up"
+        best_row = min(fast, key=lambda r: r['ratio'])
+        fast_line += f" (largest: `{best_row['name']}`, {format_difference(best_row['ratio'])})"
 
-    lines = [
-        "**Summary**",
-        "",
-        f"- Largest slowdown: {largest_slowdown}",
-        f"- Fastest speedup: {fastest_speedup}",
-        f"- Benchmarks slowed down: {len(slow)}",
-        f"- Benchmarks sped up: {len(fast)}",
-    ]
-    return "\n".join(lines)
+    all_spreads = [s for r in rows for s in r['spreads']]
+    if all_spreads:
+        floor_line = (
+            f'- Measured noise floor (identical code, round-to-round): '
+            f'median {statistics.median(all_spreads):.1%}, max {max(all_spreads):.1%}'
+        )
+    else:
+        floor_line = '- Measured noise floor: n/a (single round)'
+
+    return '\n'.join([
+        '**Summary**',
+        '',
+        slow_line,
+        fast_line,
+        f'- Within noise: {within}',
+        floor_line,
+    ])
+
+def nbsp(text):
+    """Join with non-breaking spaces so a table cell renders on one line."""
+    return text.strip().replace(' ', '&nbsp;')
 
 def render_table(rows):
-    """Render the per-benchmark table wrapped in a closed-by-default <details> block."""
+    """Render the per-benchmark comparison wrapped in a closed `<details>` block."""
     out = []
-    out.append("<details>")
-    out.append(f"<summary>Per-benchmark results ({len(rows)} rows)</summary>")
-    out.append("")
+    out.append('<details>')
+    out.append(f'<summary>Per-benchmark results ({len(rows)} rows)</summary>')
+    out.append('')
     out.append(
-        f"**Legend:** {SIGNIFICANT_SLOWDOWN} ≥ 2x slower &nbsp;·&nbsp;"
-        f"{SLIGHT_SLOWDOWN} < 2x slower &nbsp;·&nbsp;"
-        f"{SLIGHT_SPEEDUP} < 2x faster &nbsp;·&nbsp;"
-        f"{SIGNIFICANT_SPEEDUP} ≥ 2x faster"
+        f'**Legend:** {SIGNIFICANT_SLOWDOWN} ≥ 2x slower &nbsp;·&nbsp;'
+        f'{SLOWDOWN} beyond noise, slower &nbsp;·&nbsp;'
+        f'{SPEEDUP} beyond noise, faster &nbsp;·&nbsp;'
+        f'{SIGNIFICANT_SPEEDUP} ≥ 2x faster &nbsp;·&nbsp;'
+        'unmarked: within noise. '
+        'Base and PR cells show the best time across rounds; self-noise is the '
+        'worst per-side spread between rounds of identical code.'
     )
-    out.append("")
-    out.append("| Test | Base         | PR               | Change |")
-    out.append("|------|--------------|------------------|--------|")
+    out.append('')
+    out.append('| Test | Base | PR | Change | Self-noise |')
+    out.append('|------|------|----|--------|------------|')
     for r in rows:
         name_cell = f"`{r['name']}`" if r['name'] else ''
-        difference = format_difference(r['ratio'])
-        emoji = change_emoji(r['ratio'], r['significant'])
-        # Non-breaking spaces keep the marker and ratio on one line so the
-        # Change cell renders without wrapping.
-        change_cell = f"{emoji} {difference}".strip().replace(" ", "&nbsp;")
-        out.append(f"| {name_cell} | {r['base_display']} | {r['chg_display']} | {change_cell} |")
-    out.append("")
-    out.append("</details>")
-    return "\n".join(out)
+        base_cell = r['base']['display'] if r['base'] else 'N/A'
+        chg_cell = r['chg']['display'] if r['chg'] else 'N/A'
+        change_cell = nbsp(f"{change_emoji(r)} {format_difference(r['ratio'])}")
+        noise_cell = f"±{max(r['spreads']):.1%}" if r['spreads'] else ''
+        out.append(f'| {name_cell} | {base_cell} | {chg_cell} | {change_cell} | {noise_cell} |')
+    out.append('')
+    out.append('</details>')
+    return '\n'.join(out)
+
+def render_rounds_table(rows, num_rounds):
+    """Render the raw per-round times wrapped in a closed `<details>` block."""
+    out = []
+    out.append('<details>')
+    out.append('<summary>Per-round raw times</summary>')
+    out.append('')
+    header = '| Test |'
+    divider = '|------|'
+    for round_idx in range(1, num_rounds + 1):
+        header += f' Base r{round_idx} | PR r{round_idx} |'
+        divider += '------|------|'
+    out.append(header)
+    out.append(divider)
+    for r in rows:
+        cells = [f"`{r['name']}`" if r['name'] else '']
+        for base_m, chg_m in r['per_round']:
+            cells.append(base_m['display'] if base_m else 'N/A')
+            cells.append(chg_m['display'] if chg_m else 'N/A')
+        out.append('| ' + ' | '.join(cells) + ' |')
+    out.append('')
+    out.append('</details>')
+    return '\n'.join(out)
 
 def main():
-    lines = sys.stdin.read().splitlines()
-    rows = parse_rows(lines)
+    paths = sys.argv[1:]
+    if not paths:
+        print('usage: parse_critcmp.py <critcmp-round-output>...', file=sys.stderr)
+        sys.exit(2)
+    rounds = []
+    for path in paths:
+        with open(path, encoding='utf-8') as f:
+            rounds.append(parse_round(f.read().splitlines()))
+    rows = combine_rounds(rounds)
     print(render_summary(rows))
-    print("")
+    print('')
     print(render_table(rows))
+    if len(rounds) > 1:
+        print('')
+        print(render_rounds_table(rows, len(rounds)))
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/benchmarks/ci/run-benchmarks.sh
+++ b/benchmarks/ci/run-benchmarks.sh
@@ -6,6 +6,15 @@
 # to /tmp/bench-comment.md; the companion benchmark-post-comment.yml workflow
 # downloads it as an artifact and posts the PR comment in base-branch context.
 #
+# Methodology: the bench harness is compiled once per branch, then the two
+# binaries are executed in alternating rounds (base, PR, base, PR, ...). With
+# a single pass per side, slow machine-state drift (noisy neighbors, frequency
+# scaling) lands entirely on one side and reads as a direction-consistent bias
+# across every benchmark; alternating rounds spread the drift over both sides.
+# parse_critcmp.py compares the best time per side across rounds, reports a
+# change only when it clears a noise band, and reports the round-to-round
+# spread of identical code as the run's measured noise floor.
+#
 # Expects the following environment variables:
 #
 #   BASE_REF   - base branch ref (e.g. "main")
@@ -21,11 +30,18 @@ shopt -s extglob
 
 # ---------------------------------------------------------------------------
 # 1. Parse the /bench comment
-#    Syntax: /bench [--tags <csv>] [--filter <regex>]
+#    Syntax: /bench [--tags <csv>] [--filter <regex>] [--rounds <n>]
+#                   [--sample-size <n>] [--measurement-time <secs>]
+#                   [--warm-up-time <secs>]
 #      --tags    sets BENCH_TAGS (comma-separated tag list); defaults to "base"
 #                when the comment is just /bench (or COMMENT is unset, i.e.
 #                the auto-trigger path)
-#      --filter  Criterion name regex passed as a positional arg to cargo bench
+#      --filter  Criterion name regex passed as a positional arg to the bench
+#                binary
+#      --rounds  number of alternating base/PR measurement rounds (1 to 5)
+#      --sample-size, --measurement-time, --warm-up-time
+#                passed through to Criterion to trade per-pass cost against
+#                per-pass precision
 # ---------------------------------------------------------------------------
 
 # Auto-trigger path leaves COMMENT unset; treat that the same as a bare /bench.
@@ -36,6 +52,10 @@ ARGS="${ARGS##+( )}"
 
 TAGS=""
 FILTER=""
+ROUNDS="2"
+SAMPLE_SIZE=""
+MEASUREMENT_TIME=""
+WARM_UP_TIME=""
 
 if [[ -z "$ARGS" ]]; then
   # Bare /bench with no args: default to the "base" tag
@@ -51,68 +71,145 @@ else
   i=0
   while [[ $i -lt ${#TOKENS[@]} ]]; do
     case "${TOKENS[$i]}" in
-      --tags)   i=$((i + 1)); TAGS="${TOKENS[$i]:-}"   ;;
-      --filter) i=$((i + 1)); FILTER="${TOKENS[$i]:-}" ;;
+      --tags)             i=$((i + 1)); TAGS="${TOKENS[$i]:-}"             ;;
+      --filter)           i=$((i + 1)); FILTER="${TOKENS[$i]:-}"           ;;
+      --rounds)           i=$((i + 1)); ROUNDS="${TOKENS[$i]:-}"           ;;
+      --sample-size)      i=$((i + 1)); SAMPLE_SIZE="${TOKENS[$i]:-}"      ;;
+      --measurement-time) i=$((i + 1)); MEASUREMENT_TIME="${TOKENS[$i]:-}" ;;
+      --warm-up-time)     i=$((i + 1)); WARM_UP_TIME="${TOKENS[$i]:-}"     ;;
       *)        echo "Unknown token: '${TOKENS[$i]}'" >&2; exit 1 ;;
     esac
     i=$((i + 1))
   done
 fi
 
-# Default: if nothing was parsed, run with BENCH_TAGS=base
+# Default: if no workload selection was parsed, run with BENCH_TAGS=base
 if [[ -z "$TAGS" && -z "$FILTER" ]]; then
   TAGS="base"
 fi
 
+# Validate numeric arguments. ROUNDS is capped to keep a /bench comment from
+# requesting an arbitrarily long CI run; the Criterion knobs are validated as
+# plain numbers and any range enforcement is left to Criterion itself.
+[[ "$ROUNDS" =~ ^[1-5]$ ]] \
+  || { echo "Invalid --rounds (expected 1 to 5): $ROUNDS" >&2; exit 1; }
+[[ -z "$SAMPLE_SIZE" || "$SAMPLE_SIZE" =~ ^[0-9]+$ ]] \
+  || { echo "Invalid --sample-size: $SAMPLE_SIZE" >&2; exit 1; }
+[[ -z "$MEASUREMENT_TIME" || "$MEASUREMENT_TIME" =~ ^[0-9]+([.][0-9]+)?$ ]] \
+  || { echo "Invalid --measurement-time: $MEASUREMENT_TIME" >&2; exit 1; }
+[[ -z "$WARM_UP_TIME" || "$WARM_UP_TIME" =~ ^[0-9]+([.][0-9]+)?$ ]] \
+  || { echo "Invalid --warm-up-time: $WARM_UP_TIME" >&2; exit 1; }
+
+CRIT_ARGS=()
+[[ -n "$SAMPLE_SIZE" ]]      && CRIT_ARGS+=(--sample-size "$SAMPLE_SIZE")
+[[ -n "$MEASUREMENT_TIME" ]] && CRIT_ARGS+=(--measurement-time "$MEASUREMENT_TIME")
+[[ -n "$WARM_UP_TIME" ]]     && CRIT_ARGS+=(--warm-up-time "$WARM_UP_TIME")
+
 echo "Parsed tags:   ${TAGS:-<none>}"
 echo "Parsed filter: ${FILTER:-<none>}"
+echo "Rounds:        ${ROUNDS}"
+echo "Criterion args: ${CRIT_ARGS[*]:-<defaults>}"
 
 [[ -n "$TAGS" ]] && export BENCH_TAGS="$TAGS"
 
 # ---------------------------------------------------------------------------
-# 2. Benchmark the PR branch (already checked out by the workflow)
+# 2. Log the runner environment
+#    GitHub-hosted runners draw from a heterogeneous pool (different CPU
+#    models, cache sizes, and neighbor load). Recording the hardware and load
+#    alongside each run lets a reader correlate noisy comparisons with the
+#    machine they ran on.
 # ---------------------------------------------------------------------------
-(cd benchmarks && cargo bench --locked --bench workload_bench -- --save-baseline changes "$FILTER")
+echo "=== Runner environment ==="
+lscpu | grep -E '^(Model name|CPU\(s\)|Thread|CPU( max| min)? MHz|L[123][a-z]* cache)' || true
+echo "loadavg: $(cat /proc/loadavg)"
+echo "mem: $(free -m | awk '/^Mem:/ {print $2 " MB total, " $7 " MB available"}')"
+echo "==========================="
 
 # ---------------------------------------------------------------------------
-# 3. Switch to the base branch and benchmark it
-#    The benchmarks/target/ directory is not tracked by git, so the
-#    "changes" baseline files are preserved across the branch switch.
+# 3. Compile one bench binary per branch
+#    Compiling once and stashing the binaries lets the measurement rounds
+#    alternate between branches without recompiling on every switch.
+#    CRITERION_HOME pins where the binaries store baselines no matter which
+#    tree is checked out when they run; critcmp reads the same location via
+#    --target-dir below.
 # ---------------------------------------------------------------------------
+TARGET_DIR=$( (cd benchmarks && cargo metadata --format-version 1 --no-deps --locked) | jq -r .target_directory)
+export CRITERION_HOME="$TARGET_DIR/criterion"
+echo "Criterion home: $CRITERION_HOME"
+
+# Compiles the bench harness for the currently checked-out tree and echoes the
+# binary path.
+compile_bench_binary() {
+  (cd benchmarks && cargo bench --locked --bench workload_bench --no-run --message-format=json) \
+    | jq -r 'select(.reason == "compiler-artifact" and .target.name == "workload_bench") | .executable // empty' \
+    | tail -n 1
+}
+
+echo "Compiling PR bench binary"
+PR_BIN=$(compile_bench_binary)
+[[ -n "$PR_BIN" ]] || { echo "Failed to locate PR bench binary" >&2; exit 1; }
+cp "$PR_BIN" /tmp/bench-bin-changes
+
 git fetch origin -- "$BASE_REF"
 git checkout FETCH_HEAD
-(cd benchmarks && cargo bench --locked --bench workload_bench -- --save-baseline base "$FILTER")
+echo "Compiling base bench binary"
+BASE_BIN=$(compile_bench_binary)
+[[ -n "$BASE_BIN" ]] || { echo "Failed to locate base bench binary" >&2; exit 1; }
+cp "$BASE_BIN" /tmp/bench-bin-base
+
+# Restore the PR-head tree: the rounds below execute the stashed binaries, and
+# the comment is formatted by the PR's own parse_critcmp.py (a formatter change
+# is then exercised on the PR that introduces it).
+git checkout "$HEAD_SHA"
 
 # ---------------------------------------------------------------------------
-# 4. Compare baselines with critcmp and format as a markdown comment
-#    (summary block + collapsed per-benchmark table; see
-#    benchmarks/ci/parse_critcmp.py for the format and significance rules).
-#      - Parses actual duration values (not rank factors) to compute a ratio
+# 4. Run alternating measurement rounds
+#    Each round measures base then PR, saving baselines named base<round> and
+#    changes<round>.
 # ---------------------------------------------------------------------------
-# Step 3 left the working tree on the base branch, so parse_critcmp.py on disk
-# is the base version. Restore the PR-head tree so the comment is formatted by
-# the PR's own formatter (a formatter change is then exercised on the PR that
-# introduces it). Only tracked sources move; the `base`/`changes` criterion
-# baselines live in gitignored benchmarks/target/ and survive the checkout.
-git checkout "$HEAD_SHA"
-# Use `critcmp` to compare the criterion output for `base` and `changes`. We use `critcmp` instead of manually
+for (( round=1; round<=ROUNDS; round++ )); do
+  for side in base changes; do
+    echo "=== Round ${round}/${ROUNDS}: ${side} ==="
+    "/tmp/bench-bin-${side}" --bench --save-baseline "${side}${round}" "${CRIT_ARGS[@]}" "$FILTER"
+  done
+done
+
+# ---------------------------------------------------------------------------
+# 5. Compare baselines with critcmp and format as a markdown comment
+#    (summary block + collapsed per-benchmark tables; see
+#    benchmarks/ci/parse_critcmp.py for the format and significance rules).
+# ---------------------------------------------------------------------------
+# Use `critcmp` to compare the criterion output for each round. We use `critcmp` instead of manually
 # parsing criterion outputs because criterion may update its output format. By using `critcmp`, we inherit all
 # updated criterion output parsing.
-COMPARISON=$((cd benchmarks && critcmp base changes) | python3 benchmarks/ci/parse_critcmp.py)
+ROUND_FILES=()
+for (( round=1; round<=ROUNDS; round++ )); do
+  OUT="/tmp/critcmp-round-${round}.txt"
+  critcmp --target-dir "$TARGET_DIR" "base${round}" "changes${round}" > "$OUT"
+  echo "=== critcmp round ${round} ==="
+  cat "$OUT"
+  ROUND_FILES+=("$OUT")
+done
+COMPARISON=$(python3 benchmarks/ci/parse_critcmp.py "${ROUND_FILES[@]}")
 
 # ---------------------------------------------------------------------------
-# 5. Write results to /tmp/bench-comment.md
+# 6. Write results to /tmp/bench-comment.md
 #    benchmark.yml uploads this as an artifact; benchmark-post-comment.yml
 #    downloads it and posts the PR comment in base-branch context.
 # ---------------------------------------------------------------------------
 SHORT_SHA="${HEAD_SHA:0:7}"
 
-# Metadata line shows commit + what fired this run + the active tags/filter so
-# a reviewer can tell at a glance which configuration produced the displayed
-# numbers (the same comment is reused across auto-trigger and /bench runs).
+# Metadata line shows commit + what fired this run + the active configuration
+# and runner hardware so a reviewer can tell at a glance which setup produced
+# the displayed numbers (the same comment is reused across auto-trigger and
+# /bench runs).
 SUMMARY="Commit: \`${SHORT_SHA}\` &middot; Trigger: ${TRIGGER:-auto-push}"
 [[ -n "$TAGS" ]]   && SUMMARY+=" &middot; Tags: \`${TAGS}\`"
 [[ -n "$FILTER" ]] && SUMMARY+=" &middot; Filter: \`${FILTER}\`"
+SUMMARY+=" &middot; Rounds: ${ROUNDS}"
+[[ ${#CRIT_ARGS[@]} -gt 0 ]] && SUMMARY+=" &middot; Criterion: \`${CRIT_ARGS[*]}\`"
+CPU_MODEL=$(lscpu | sed -n 's/^Model name:[[:space:]]*//p' | head -n 1)
+[[ -n "$CPU_MODEL" ]] && SUMMARY+=" &middot; Runner: ${CPU_MODEL}"
 
 # Leading marker is an HTML comment, invisible to readers; the post-comment
 # job uses it as a stable identifier for find-and-update so each push reuses


### PR DESCRIPTION
## What changes are proposed in this pull request?

The benchmark comparison previously measured each branch in one sequential
pass (all of PR, then all of base) and counted any ratio more than 0.1%
from 1.0 as a slowdown or speedup. On shared GitHub runners, wall clock
jitters by several percent and machine-state drift between the two passes
biases every benchmark in the same direction, so comments routinely
reported ten-plus sub-7% "slowdowns" that were pure noise.

Methodology changes:
- Compile one bench binary per branch, then execute them in alternating
  rounds (base, PR, base, PR, ...) so drift spreads over both sides.
  CRITERION_HOME pins baseline storage; critcmp reads it via --target-dir.
- Compare the best (lowest) time per side across rounds; interference only
  ever adds time, so the minimum is closest to the machine's true speed.
- Flag a change only when the ratio clears a 5% noise band AND the
  difference exceeds the two sides' combined error bars; everything else
  renders unmarked as within noise.
- Report the round-to-round spread of identical code as the run's measured
  noise floor, plus a raw per-round table for diagnosis.
- Log the runner hardware and load, and name the CPU model in the comment.

/bench gains passthrough flags: --rounds (1 to 5, default 2) plus Criterion
knobs --sample-size, --measurement-time, and --warm-up-time, so measurement
cost and precision can be tuned per run without a new push.

## How was this change tested?
