### PR TITLE
refactor!: Checkpoint writer eagerly creates output schema

### DIFF
--- a/docs/user-guide/src/connector/overview.md
+++ b/docs/user-guide/src/connector/overview.md
@@ -92,7 +92,7 @@ From a snapshot, you can:
 | Get schema and metadata | `snapshot.schema()`, `snapshot.table_properties()` | Table schema discovery |
 | Read data | `snapshot.scan_builder()` | Scan / PartitionReader |
 | Write data | `snapshot.transaction(committer, &engine)` | Writer / Committer |
-| Checkpoint | `snapshot.create_checkpoint_writer()` | Maintenance task |
+| Checkpoint | `snapshot.create_checkpoint_writer(&engine)` | Maintenance task |
 
 ## What your connector does vs. what Kernel does
 

--- a/docs/user-guide/src/maintenance/checkpointing.md
+++ b/docs/user-guide/src/maintenance/checkpointing.md
@@ -68,16 +68,16 @@ if let Some(snapshot) = committed.post_commit_snapshot() {
 > [!WARNING]
 > For catalog-managed tables, you must
 > [publish](../catalog_managed/writing.md) the commit before checkpointing.
-> `create_checkpoint_writer()` returns an error if the snapshot is not published.
+> `create_checkpoint_writer(&engine)` returns an error if the snapshot is not published.
 
 ## The custom path: `CheckpointWriter`
 
 If you need control over how the checkpoint file is written, use the lower-level
-`CheckpointWriter` API. `create_checkpoint_writer()` consumes an `Arc<Snapshot>`:
+`CheckpointWriter` API. `create_checkpoint_writer(&engine)` consumes an `Arc<Snapshot>`:
 
 ```rust,ignore
 // 1. Create a CheckpointWriter from a snapshot (consumes the Arc<Snapshot>)
-let writer = snapshot.create_checkpoint_writer()?;
+let writer = snapshot.create_checkpoint_writer(&engine)?;
 
 // 2. Get the path where the checkpoint should be written
 let checkpoint_path = writer.checkpoint_path()?;

--- a/kernel/examples/checkpoint-table/src/main.rs
+++ b/kernel/examples/checkpoint-table/src/main.rs
@@ -79,7 +79,7 @@ async fn try_main() -> DeltaResult<()> {
         println!("Table checkpointed");
     } else {
         // first we create a checkpoint writer
-        let writer = snapshot.create_checkpoint_writer()?;
+        let writer = snapshot.create_checkpoint_writer(&engine)?;
 
         // this tells us the path where we should write the checkpoint file
         let checkpoint_path = writer.checkpoint_path()?;

--- a/kernel/src/checkpoint/checkpoint_transform.rs
+++ b/kernel/src/checkpoint/checkpoint_transform.rs
@@ -41,6 +41,23 @@ impl StatsTransformConfig {
     }
 }
 
+/// Builds the checkpoint output schema and transform expression together.
+pub(crate) fn build_checkpoint_transform(
+    config: &StatsTransformConfig,
+    base_schema: &StructType,
+    stats_schema: &SchemaRef,
+    partition_schema: Option<&SchemaRef>,
+) -> DeltaResult<(SchemaRef, ExpressionRef)> {
+    let output_schema = build_checkpoint_output_schema(
+        config,
+        base_schema,
+        stats_schema.as_ref(),
+        partition_schema.map(AsRef::as_ref),
+    )?;
+    let transform_expr = build_checkpoint_transform_expr(config, stats_schema, partition_schema);
+    Ok((output_schema, transform_expr))
+}
+
 /// Builds a transform for the Add action to populate and/or drop stats and partition fields.
 ///
 /// The transform handles statistics based on table properties:
@@ -77,7 +94,7 @@ impl StatsTransformConfig {
 ///   non-partitioned tables.
 ///
 /// [`expected_stats_schema`]: crate::scan::data_skipping::stats_schema::expected_stats_schema
-pub(crate) fn build_checkpoint_transform(
+fn build_checkpoint_transform_expr(
     config: &StatsTransformConfig,
     stats_schema: &SchemaRef,
     partition_schema: Option<&SchemaRef>,
@@ -180,7 +197,7 @@ pub(crate) fn build_checkpoint_read_schema(
 /// # Errors
 ///
 /// Returns an error if the `add` field is not found or is not a struct type.
-pub(crate) fn build_checkpoint_output_schema(
+fn build_checkpoint_output_schema(
     config: &StatsTransformConfig,
     base_schema: &StructType,
     stats_schema: &StructType,
@@ -317,8 +334,11 @@ fn build_add_output_schema(
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
     use crate::actions::NUM_RECORDS;
+    use crate::schema::MapType;
 
     #[test]
     fn test_config_defaults() {
@@ -396,6 +416,51 @@ mod tests {
             .get(field)
             .map(|ft| ft.is_replace && ft.exprs.len() == 1)
             .unwrap_or(false)
+    }
+
+    fn build_checkpoint_transform(
+        config: &StatsTransformConfig,
+        stats_schema: &SchemaRef,
+        partition_schema: Option<&SchemaRef>,
+    ) -> ExpressionRef {
+        let fields = [
+            Some(StructField::not_null("path", DataType::STRING)),
+            partition_schema.is_some().then(|| {
+                let partition_values = MapType::new(DataType::STRING, DataType::STRING, true);
+                StructField::nullable(PARTITION_VALUES_FIELD, partition_values)
+            }),
+            Some(StructField::nullable(STATS_FIELD, DataType::STRING)),
+        ];
+        let base_schema = StructType::new_unchecked([StructField::nullable(
+            ADD_NAME,
+            StructType::new_unchecked(fields.into_iter().flatten()),
+        )]);
+        let (_, transform_expr) =
+            super::build_checkpoint_transform(config, &base_schema, stats_schema, partition_schema)
+                .expect("build checkpoint transform should produce a valid schema and expression");
+        transform_expr
+    }
+
+    fn build_add_output_schema(
+        config: &StatsTransformConfig,
+        add_schema: StructType,
+        stats_schema: StructType,
+        partition_schema: Option<StructType>,
+    ) -> StructType {
+        let (output_schema, _) = super::build_checkpoint_transform(
+            config,
+            &StructType::new_unchecked([StructField::nullable(ADD_NAME, add_schema)]),
+            &Arc::new(stats_schema),
+            partition_schema.map(Arc::new).as_ref(),
+        )
+        .expect("build checkpoint transform should produce a valid schema and expression");
+        let add_field = output_schema
+            .field(ADD_NAME)
+            .expect("output schema should contain add field");
+        let DataType::Struct(add_schema) = add_field.data_type() else {
+            panic!("output add field should be a struct");
+        };
+        add_schema.as_ref().clone()
     }
 
     #[test]
@@ -584,138 +649,58 @@ mod tests {
         assert_eq!(field_names, vec!["path", "stats", "stats_parsed", "tags"]);
     }
 
-    #[test]
-    fn test_build_add_output_schema_json_only() {
+    #[rstest]
+    #[case::json_only(true, false, false, &["path", "stats"])]
+    #[case::struct_only(false, true, false, &["path", "stats_parsed"])]
+    #[case::json_and_struct(true, true, false, &["path", "stats", "stats_parsed"])]
+    #[case::with_partition_values(
+        true,
+        true,
+        true,
+        &["path", "partitionValues", "partitionValues_parsed", "stats", "stats_parsed"])]
+    #[case::partition_values_struct_disabled(
+        true,
+        false,
+        true,
+        &["path", "partitionValues", "stats"])]
+    fn test_build_add_output_schema(
+        #[case] write_stats_as_json: bool,
+        #[case] write_stats_as_struct: bool,
+        #[case] with_partition_schema: bool,
+        #[case] expected_names: &[&str],
+    ) {
         let config = StatsTransformConfig {
-            write_stats_as_json: true,
-            write_stats_as_struct: false,
+            write_stats_as_json,
+            write_stats_as_struct,
         };
-
-        let add_schema = StructType::new_unchecked([
+        let mut fields = vec![
             StructField::not_null("path", DataType::STRING),
             StructField::nullable("stats", DataType::STRING),
-        ]);
-
-        let stats_schema = StructType::new_unchecked([]);
-
-        let result = build_add_output_schema(&config, &add_schema, &stats_schema, None)
-            .expect("build add output schema should produce a valid schema");
-
-        // Should have path and stats, no stats_parsed
-        let field_names: Vec<&str> = result.fields().map(|f| f.name.as_str()).collect();
-        assert_eq!(field_names, vec!["path", "stats"]);
-    }
-
-    #[test]
-    fn test_build_add_output_schema_struct_only() {
-        let config = StatsTransformConfig {
-            write_stats_as_json: false,
-            write_stats_as_struct: true,
+        ];
+        if with_partition_schema {
+            fields.insert(
+                1,
+                StructField::nullable(
+                    PARTITION_VALUES_FIELD,
+                    crate::schema::MapType::new(DataType::STRING, DataType::STRING, true),
+                ),
+            );
+        }
+        let add_schema = StructType::new_unchecked(fields);
+        let stats_schema = if write_stats_as_struct {
+            StructType::new_unchecked([StructField::nullable(NUM_RECORDS, DataType::LONG)])
+        } else {
+            StructType::new_unchecked([])
         };
+        let pv_schema = with_partition_schema.then(|| {
+            StructType::new_unchecked([
+                StructField::nullable("year", DataType::INTEGER),
+                StructField::nullable("month", DataType::INTEGER),
+            ])
+        });
 
-        let add_schema = StructType::new_unchecked([
-            StructField::not_null("path", DataType::STRING),
-            StructField::nullable("stats", DataType::STRING),
-        ]);
-
-        let stats_schema =
-            StructType::new_unchecked([StructField::nullable(NUM_RECORDS, DataType::LONG)]);
-
-        let result = build_add_output_schema(&config, &add_schema, &stats_schema, None)
-            .expect("build add output schema should produce a valid schema");
-
-        // Should have path and stats_parsed (stats dropped)
+        let result = build_add_output_schema(&config, add_schema, stats_schema, pv_schema);
         let field_names: Vec<&str> = result.fields().map(|f| f.name.as_str()).collect();
-        assert_eq!(field_names, vec!["path", "stats_parsed"]);
-    }
-
-    #[test]
-    fn test_build_add_output_schema_both() {
-        let config = StatsTransformConfig {
-            write_stats_as_json: true,
-            write_stats_as_struct: true,
-        };
-
-        let add_schema = StructType::new_unchecked([
-            StructField::not_null("path", DataType::STRING),
-            StructField::nullable("stats", DataType::STRING),
-        ]);
-
-        let stats_schema =
-            StructType::new_unchecked([StructField::nullable(NUM_RECORDS, DataType::LONG)]);
-
-        let result = build_add_output_schema(&config, &add_schema, &stats_schema, None)
-            .expect("build add output schema should produce a valid schema");
-
-        // Should have path, stats, and stats_parsed
-        let field_names: Vec<&str> = result.fields().map(|f| f.name.as_str()).collect();
-        assert_eq!(field_names, vec!["path", "stats", "stats_parsed"]);
-    }
-
-    #[test]
-    fn test_build_add_output_schema_with_partition_values() {
-        let config = StatsTransformConfig {
-            write_stats_as_json: true,
-            write_stats_as_struct: true,
-        };
-
-        let add_schema = StructType::new_unchecked([
-            StructField::not_null("path", DataType::STRING),
-            StructField::nullable(
-                "partitionValues",
-                crate::schema::MapType::new(DataType::STRING, DataType::STRING, true),
-            ),
-            StructField::nullable("stats", DataType::STRING),
-        ]);
-
-        let stats_schema =
-            StructType::new_unchecked([StructField::nullable(NUM_RECORDS, DataType::LONG)]);
-        let pv_schema = StructType::new_unchecked([
-            StructField::nullable("year", DataType::INTEGER),
-            StructField::nullable("month", DataType::INTEGER),
-        ]);
-
-        let result = build_add_output_schema(&config, &add_schema, &stats_schema, Some(&pv_schema))
-            .expect("build add output schema should produce a valid schema");
-
-        let field_names: Vec<&str> = result.fields().map(|f| f.name.as_str()).collect();
-        assert_eq!(
-            field_names,
-            vec![
-                "path",
-                "partitionValues",
-                "partitionValues_parsed",
-                "stats",
-                "stats_parsed"
-            ]
-        );
-    }
-
-    #[test]
-    fn test_build_add_output_schema_no_partition_values_when_struct_disabled() {
-        let config = StatsTransformConfig {
-            write_stats_as_json: true,
-            write_stats_as_struct: false,
-        };
-
-        let add_schema = StructType::new_unchecked([
-            StructField::not_null("path", DataType::STRING),
-            StructField::nullable(
-                "partitionValues",
-                crate::schema::MapType::new(DataType::STRING, DataType::STRING, true),
-            ),
-            StructField::nullable("stats", DataType::STRING),
-        ]);
-
-        let stats_schema = StructType::new_unchecked([]);
-        let pv_schema =
-            StructType::new_unchecked([StructField::nullable("year", DataType::INTEGER)]);
-
-        let result = build_add_output_schema(&config, &add_schema, &stats_schema, Some(&pv_schema))
-            .expect("build add output schema should produce a valid schema");
-
-        let field_names: Vec<&str> = result.fields().map(|f| f.name.as_str()).collect();
-        // partitionValues_parsed should NOT be present when writeStatsAsStruct=false
-        assert_eq!(field_names, vec!["path", "partitionValues", "stats"]);
+        assert_eq!(field_names, expected_names);
     }
 }

--- a/kernel/src/checkpoint/checkpoint_transform.rs
+++ b/kernel/src/checkpoint/checkpoint_transform.rs
@@ -404,17 +404,9 @@ mod tests {
         stats_schema: &SchemaRef,
         partition_schema: Option<&SchemaRef>,
     ) -> ExpressionRef {
-        let fields = [
-            Some(StructField::not_null("path", DataType::STRING)),
-            partition_schema.is_some().then(|| {
-                let partition_values = MapType::new(DataType::STRING, DataType::STRING, true);
-                StructField::nullable(PARTITION_VALUES_FIELD, partition_values)
-            }),
-            Some(StructField::nullable(STATS_FIELD, DataType::STRING)),
-        ];
         let base_schema = StructType::new_unchecked([StructField::nullable(
             ADD_NAME,
-            StructType::new_unchecked(fields.into_iter().flatten()),
+            add_schema(partition_schema.is_some()),
         )]);
         let (_, transform_expr) =
             super::build_checkpoint_transform(config, &base_schema, stats_schema, partition_schema)
@@ -422,26 +414,16 @@ mod tests {
         transform_expr
     }
 
-    fn build_add_output_schema(
-        config: &StatsTransformConfig,
-        add_schema: StructType,
-        stats_schema: StructType,
-        partition_schema: Option<StructType>,
-    ) -> StructType {
-        let (output_schema, _) = super::build_checkpoint_transform(
-            config,
-            &StructType::new_unchecked([StructField::nullable(ADD_NAME, add_schema)]),
-            &Arc::new(stats_schema),
-            partition_schema.map(Arc::new).as_ref(),
-        )
-        .expect("build checkpoint transform should produce a valid schema and expression");
-        let add_field = output_schema
-            .field(ADD_NAME)
-            .expect("output schema should contain add field");
-        let DataType::Struct(add_schema) = add_field.data_type() else {
-            panic!("output add field should be a struct");
-        };
-        add_schema.as_ref().clone()
+    fn add_schema(with_partition_schema: bool) -> StructType {
+        let fields = [
+            Some(StructField::not_null("path", DataType::STRING)),
+            with_partition_schema.then(|| {
+                let partition_values = MapType::new(DataType::STRING, DataType::STRING, true);
+                StructField::nullable(PARTITION_VALUES_FIELD, partition_values)
+            }),
+            Some(StructField::nullable(STATS_FIELD, DataType::STRING)),
+        ];
+        StructType::new_unchecked(fields.into_iter().flatten())
     }
 
     #[test]
@@ -605,32 +587,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_schema_patch_inserts_field_after_anchor() {
-        let add_schema = StructType::new_unchecked([
-            StructField::not_null("path", DataType::STRING),
-            StructField::nullable("stats", DataType::STRING),
-            StructField::nullable("tags", DataType::STRING),
-        ]);
-
-        let injected_schema =
-            StructType::new_unchecked([StructField::nullable(NUM_RECORDS, DataType::LONG)]);
-
-        let result = SchemaStructPatchBuilder::new()
-            .insert_after(
-                STATS_FIELD,
-                StructField::nullable(STATS_PARSED_FIELD, injected_schema),
-            )
-            .build(&add_schema)
-            .expect("inserting stats_parsed should succeed");
-
-        // Should have 4 fields: path, stats, stats_parsed, tags
-        assert_eq!(result.fields().count(), 4);
-
-        let field_names: Vec<&str> = result.fields().map(|f| f.name.as_str()).collect();
-        assert_eq!(field_names, vec!["path", "stats", "stats_parsed", "tags"]);
-    }
-
     #[rstest]
     #[case::json_only(true, false, false, &["path", "stats"])]
     #[case::struct_only(false, true, false, &["path", "stats_parsed"])]
@@ -655,25 +611,9 @@ mod tests {
             write_stats_as_json,
             write_stats_as_struct,
         };
-        let mut fields = vec![
-            StructField::not_null("path", DataType::STRING),
-            StructField::nullable("stats", DataType::STRING),
-        ];
-        if with_partition_schema {
-            fields.insert(
-                1,
-                StructField::nullable(
-                    PARTITION_VALUES_FIELD,
-                    crate::schema::MapType::new(DataType::STRING, DataType::STRING, true),
-                ),
-            );
-        }
-        let add_schema = StructType::new_unchecked(fields);
-        let stats_schema = if write_stats_as_struct {
-            StructType::new_unchecked([StructField::nullable(NUM_RECORDS, DataType::LONG)])
-        } else {
-            StructType::new_unchecked([])
-        };
+        let add_schema = add_schema(with_partition_schema);
+        let stats_schema =
+            StructType::new_unchecked([StructField::nullable(NUM_RECORDS, DataType::LONG)]);
         let pv_schema = with_partition_schema.then(|| {
             StructType::new_unchecked([
                 StructField::nullable("year", DataType::INTEGER),
@@ -681,7 +621,9 @@ mod tests {
             ])
         });
 
-        let result = build_add_output_schema(&config, add_schema, stats_schema, pv_schema);
+        let result =
+            super::build_add_output_schema(&config, &add_schema, &stats_schema, pv_schema.as_ref())
+                .expect("build add output schema should produce a valid schema");
         let field_names: Vec<&str> = result.fields().map(|f| f.name.as_str()).collect();
         assert_eq!(field_names, expected_names);
     }

--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -54,7 +54,7 @@
 //! let snapshot = Snapshot::builder_for(url).build(engine)?;
 //!
 //! // Create a checkpoint writer from the snapshot
-//! let writer = snapshot.create_checkpoint_writer()?;
+//! let writer = snapshot.create_checkpoint_writer(engine)?;
 //!
 //! // Get the checkpoint path and data
 //! let checkpoint_path = writer.checkpoint_path()?;
@@ -99,7 +99,7 @@
 //! [`LastCheckpointHint`]: crate::last_checkpoint_hint::LastCheckpointHint
 //! [`Snapshot::checkpoint`]: crate::Snapshot::checkpoint
 //! [`Snapshot::create_checkpoint_writer`]: crate::Snapshot::create_checkpoint_writer
-use std::sync::{Arc, LazyLock, Mutex, OnceLock};
+use std::sync::{Arc, LazyLock, Mutex};
 
 use tracing::info;
 use url::Url;
@@ -116,7 +116,7 @@ use crate::actions::{
     SET_TRANSACTION_NAME, SIDECAR_NAME,
 };
 use crate::engine_data::FilteredEngineData;
-use crate::expressions::{Expression, ExpressionStructPatch, Scalar, StructData};
+use crate::expressions::{Expression, ExpressionRef, ExpressionStructPatch, Scalar, StructData};
 use crate::last_checkpoint_hint::LastCheckpointHint;
 use crate::log_replay::LogReplayProcessor;
 use crate::path::{self, ParsedLogPath};
@@ -133,8 +133,7 @@ mod checkpoint_transform;
 mod sidecar;
 
 use checkpoint_transform::{
-    build_checkpoint_output_schema, build_checkpoint_read_schema, build_checkpoint_transform,
-    StatsTransformConfig,
+    build_checkpoint_read_schema, build_checkpoint_transform, StatsTransformConfig,
 };
 use sidecar::{create_sidecar_action_batch, SidecarSplitter, SingleSidecarDataIterator};
 #[cfg(test)]
@@ -364,8 +363,10 @@ pub struct CheckpointWriter {
     /// field here to avoid multiple type conversions.
     version: i64,
 
-    /// Cached checkpoint output schema.
-    checkpoint_output_schema: OnceLock<SchemaRef>,
+    is_v2: bool,
+    read_schema: SchemaRef,
+    output_schema: SchemaRef,
+    transform_expr: ExpressionRef,
 }
 
 impl RetentionCalculator for CheckpointWriter {
@@ -376,7 +377,7 @@ impl RetentionCalculator for CheckpointWriter {
 
 impl CheckpointWriter {
     /// Creates a new [`CheckpointWriter`] for the given snapshot.
-    pub(crate) fn try_new(snapshot: SnapshotRef) -> DeltaResult<Self> {
+    pub(crate) fn try_new(snapshot: SnapshotRef, engine: &dyn Engine) -> DeltaResult<Self> {
         let version = i64::try_from(snapshot.version()).map_err(|e| {
             Error::CheckpointWrite(format!(
                 "Failed to convert checkpoint version from u64 {} to i64: {}",
@@ -389,29 +390,27 @@ impl CheckpointWriter {
         // create gaps in the version history, thereby breaking old readers.
         snapshot.log_segment().validate_published()?;
 
+        let schema_context = Self::checkpoint_schema_context(&snapshot, engine)?;
+        let read_schema = build_checkpoint_read_schema(
+            &schema_context.checkpoint_base_schema,
+            &schema_context.stats_schema,
+            schema_context.partition_schema.as_deref(),
+        )?;
+        let (output_schema, transform_expr) = build_checkpoint_transform(
+            &schema_context.stats_config,
+            &schema_context.checkpoint_base_schema,
+            &schema_context.stats_schema,
+            schema_context.partition_schema.as_ref(),
+        )?;
+
         Ok(Self {
             snapshot,
             version,
-            checkpoint_output_schema: OnceLock::new(),
+            is_v2: schema_context.is_v2,
+            read_schema,
+            output_schema,
+            transform_expr,
         })
-    }
-    /// Returns the cached output schema, initializing it with `f` on first call.
-    ///
-    /// `OnceLock::get_or_try_init` is unstable, so we use a custom implementation.
-    /// (tracking issue: <https://github.com/rust-lang/rust/issues/109737>).
-    fn get_or_init_output_schema(
-        &self,
-        f: impl FnOnce() -> DeltaResult<SchemaRef>,
-    ) -> DeltaResult<SchemaRef> {
-        if let Some(schema) = self.checkpoint_output_schema.get() {
-            return Ok(schema.clone());
-        }
-        let schema = f()?;
-        let _ = self.checkpoint_output_schema.set(schema);
-        self.checkpoint_output_schema
-            .get()
-            .cloned()
-            .ok_or_else(|| Error::internal_error("OnceLock should be initialized"))
     }
 
     /// Returns the URL where the checkpoint file should be written.
@@ -469,29 +468,11 @@ impl CheckpointWriter {
         &self,
         engine: &dyn Engine,
     ) -> DeltaResult<ActionReconciliationIterator> {
-        let schema_context = self.checkpoint_schema_context(engine)?;
-
-        // The read schema and output schema differ because the transform needs access to
-        // both stats formats as input, but may only write one format as output.
-        //
-        // read_schema: Always includes both `stats` and `stats_parsed` fields in the Add
-        // action, so COALESCE expressions can read from either source. For commit files,
-        // `stats_parsed` doesn't exist and is read as nulls. For partitioned tables,
-        // `partitionValues_parsed` is also included.
-        //
-        // output_schema: Only includes the stats fields that the table config requests
-        // (e.g., only `stats` if writeStatsAsJson=true and writeStatsAsStruct=false).
-        let read_schema = build_checkpoint_read_schema(
-            &schema_context.checkpoint_base_schema,
-            &schema_context.stats_schema,
-            schema_context.partition_schema.as_deref(),
-        )?;
-
         // Read actions from log segment
         let actions = self
             .snapshot
             .log_segment()
-            .read_actions(engine, read_schema.clone())?;
+            .read_actions(engine, self.read_schema.clone())?;
 
         // Process actions through reconciliation
         let checkpoint_data = ActionReconciliationProcessor::new(
@@ -500,26 +481,12 @@ impl CheckpointWriter {
         )
         .process_actions_iter(actions);
 
-        let output_schema = self.get_or_init_output_schema(|| {
-            build_checkpoint_output_schema(
-                &schema_context.stats_config,
-                &schema_context.checkpoint_base_schema,
-                &schema_context.stats_schema,
-                schema_context.partition_schema.as_deref(),
-            )
-        })?;
-
-        // Build transform expression and create expression evaluator.
+        // Create the expression evaluator for the checkpoint transform.
         // The transform is applied to reconciled action batches only (not checkpoint metadata).
-        let transform_expr = build_checkpoint_transform(
-            &schema_context.stats_config,
-            &schema_context.stats_schema,
-            schema_context.partition_schema.as_ref(),
-        );
         let evaluator = engine.evaluation_handler().new_expression_evaluator(
-            read_schema,
-            transform_expr,
-            output_schema.clone().into(),
+            self.read_schema.clone(),
+            self.transform_expr.clone(),
+            self.output_schema.clone().into(),
         )?;
 
         // Apply stats transform to each reconciled batch
@@ -537,9 +504,9 @@ impl CheckpointWriter {
         // For V2 checkpoints, chain the checkpoint metadata batch after the transformed
         // action stream. The metadata batch is created with the output schema directly,
         // bypassing the stats transform (it has no add actions to transform).
-        let checkpoint_metadata = schema_context
+        let checkpoint_metadata = self
             .is_v2
-            .then(|| self.create_checkpoint_metadata_batch(engine, &output_schema));
+            .then(|| self.create_checkpoint_metadata_batch(engine, &self.output_schema));
 
         Ok(ActionReconciliationIterator::new(Box::new(
             transformed.chain(checkpoint_metadata),
@@ -607,22 +574,13 @@ impl CheckpointWriter {
         engine: &dyn Engine,
         file_actions_per_sidecar_hint: usize,
     ) -> DeltaResult<WrittenCheckpointInfo> {
-        let output_schema = self.get_or_init_output_schema(|| {
-            let ctx = self.checkpoint_schema_context(engine)?;
-            build_checkpoint_output_schema(
-                &ctx.stats_config,
-                &ctx.checkpoint_base_schema,
-                &ctx.stats_schema,
-                ctx.partition_schema.as_deref(),
-            )
-        })?;
         let data_iter = self.checkpoint_data(engine)?;
         let iter_state = data_iter.state();
 
         let splitter = SidecarSplitter::new_mut_shared(
             data_iter,
             engine.evaluation_handler().as_ref(),
-            output_schema.clone(),
+            self.output_schema.clone(),
         )?;
 
         // Write sidecar files
@@ -659,7 +617,8 @@ impl CheckpointWriter {
         // the `sidecar` column, e.g. `sidecar: { path: "<sidecar_filename>.parquet", sizeInBytes:
         // <size>, modificationTime: <time>, tags: null }`, with all other action columns
         // left null.
-        let sidecar_batch = create_sidecar_action_batch(engine, &output_schema, &sidecar_metas)?;
+        let sidecar_batch =
+            create_sidecar_action_batch(engine, &self.output_schema, &sidecar_metas)?;
 
         // Write main checkpoint file: non-file actions + sidecar references
         let checkpoint_path = self.checkpoint_path()?;
@@ -766,11 +725,11 @@ impl CheckpointWriter {
 
     /// Helper for computing the checkpoint schema context from the snapshot and engine.
     fn checkpoint_schema_context(
-        &self,
+        snapshot: &SnapshotRef,
         engine: &dyn Engine,
     ) -> DeltaResult<CheckpointSchemaContext> {
-        let tc = self.snapshot.table_configuration();
-        let config = StatsTransformConfig::from_table_properties(self.snapshot.table_properties());
+        let tc = snapshot.table_configuration();
+        let config = StatsTransformConfig::from_table_properties(snapshot.table_properties());
 
         // Select schema based on V2 checkpoint support
         let is_v2 = tc.is_feature_supported(&TableFeature::V2Checkpoint);
@@ -781,7 +740,7 @@ impl CheckpointWriter {
         };
 
         // Get clustering columns so they are always included in stats per the Delta protocol.
-        let physical_clustering_columns = self.snapshot.get_physical_clustering_columns(engine)?;
+        let physical_clustering_columns = snapshot.get_physical_clustering_columns(engine)?;
 
         // Get stats schema from table configuration.
         // This already excludes partition columns and applies column mapping.

--- a/kernel/src/checkpoint/sidecar/tests.rs
+++ b/kernel/src/checkpoint/sidecar/tests.rs
@@ -45,11 +45,7 @@ fn generate_checkpoint_parts(
 ) -> DeltaResult<CheckpointParts> {
     let data_iter = writer.checkpoint_data(engine)?;
     let iter_state = data_iter.state();
-    let output_schema = writer
-        .checkpoint_output_schema
-        .get()
-        .cloned()
-        .expect("checkpoint_output_schema should be set by checkpoint_data");
+    let output_schema = writer.output_schema.clone();
 
     let splitter = SidecarSplitter::new_mut_shared(
         data_iter,
@@ -311,7 +307,7 @@ async fn test_generate_sidecars_single_sidecar() -> DeltaResult<()> {
 
     let table_root = Url::parse("memory:///")?;
     let snapshot = Snapshot::builder_for(table_root).build(&engine)?;
-    let writer = snapshot.create_checkpoint_writer()?;
+    let writer = snapshot.create_checkpoint_writer(&engine)?;
 
     let result = generate_checkpoint_parts(&writer, &engine, usize::MAX)?;
 
@@ -389,7 +385,7 @@ async fn test_generate_sidecars_multiple_chunks() -> DeltaResult<()> {
 
     let table_root = Url::parse("memory:///")?;
     let snapshot = Snapshot::builder_for(table_root).build(&engine)?;
-    let writer = snapshot.create_checkpoint_writer()?;
+    let writer = snapshot.create_checkpoint_writer(&engine)?;
 
     // hint=3: with DefaultEngine, each commit is one batch. Reconciliation replays
     // in reverse: commit 3 (1 add), commit 2 (2 adds + 1 remove = 3 file rows),
@@ -491,7 +487,7 @@ async fn test_generate_sidecars_hint_one_per_batch() -> DeltaResult<()> {
 
     let table_root = Url::parse("memory:///")?;
     let snapshot = Snapshot::builder_for(table_root).build(&engine)?;
-    let writer = snapshot.create_checkpoint_writer()?;
+    let writer = snapshot.create_checkpoint_writer(&engine)?;
 
     // hint=1: each batch exceeds the hint, so each gets its own sidecar.
     let result = generate_checkpoint_parts(&writer, &engine, 1)?;
@@ -559,7 +555,7 @@ async fn test_generate_sidecars_stats_and_partition_values() -> DeltaResult<()> 
 
     let table_root = Url::parse("memory:///")?;
     let snapshot = Snapshot::builder_for(table_root).build(&engine)?;
-    let writer = snapshot.create_checkpoint_writer()?;
+    let writer = snapshot.create_checkpoint_writer(&engine)?;
 
     let data_iter = writer.checkpoint_data(&engine)?;
     let mut all_batches = Vec::new();
@@ -570,10 +566,7 @@ async fn test_generate_sidecars_stats_and_partition_values() -> DeltaResult<()> 
     }
 
     // Validate the checkpoint data schema
-    let schema = writer
-        .checkpoint_output_schema
-        .get()
-        .expect("should be cached after checkpoint_data");
+    let schema = &writer.output_schema;
     let add_field = schema.field(ADD_NAME).expect("schema should have 'add'");
     if let DataType::Struct(ref add_struct) = add_field.data_type {
         assert!(
@@ -656,14 +649,10 @@ async fn test_splitter_no_file_actions() -> DeltaResult<()> {
 
     let table_root = Url::parse("memory:///")?;
     let snapshot = Snapshot::builder_for(table_root).build(&engine)?;
-    let writer = snapshot.create_checkpoint_writer()?;
+    let writer = snapshot.create_checkpoint_writer(&engine)?;
 
     let data_iter = writer.checkpoint_data(&engine)?;
-    let output_schema = writer
-        .checkpoint_output_schema
-        .get()
-        .cloned()
-        .expect("checkpoint_output_schema should be set by checkpoint_data");
+    let output_schema = writer.output_schema.clone();
 
     let splitter = SidecarSplitter::new_mut_shared(
         data_iter,

--- a/kernel/src/checkpoint/tests.rs
+++ b/kernel/src/checkpoint/tests.rs
@@ -70,7 +70,7 @@ async fn test_create_checkpoint_metadata_batch() -> DeltaResult<()> {
 
     let table_root = Url::parse("memory:///")?;
     let snapshot = Snapshot::builder_for(table_root).build(&engine)?;
-    let writer = snapshot.create_checkpoint_writer()?;
+    let writer = snapshot.create_checkpoint_writer(&engine)?;
 
     // Use V2 schema for the checkpoint metadata batch
     let checkpoint_batch =
@@ -331,7 +331,7 @@ async fn test_v1_checkpoint_latest_version_by_default() -> DeltaResult<()> {
 
     let table_root = Url::parse("memory:///")?;
     let snapshot = Snapshot::builder_for(table_root).build(&engine)?;
-    let writer = snapshot.create_checkpoint_writer()?;
+    let writer = snapshot.create_checkpoint_writer(&engine)?;
 
     // Verify the checkpoint file path is the latest version by default.
     assert_eq!(
@@ -404,7 +404,7 @@ async fn test_v1_checkpoint_specific_version() -> DeltaResult<()> {
     let snapshot = Snapshot::builder_for(table_root)
         .at_version(0)
         .build(&engine)?;
-    let writer = snapshot.create_checkpoint_writer()?;
+    let writer = snapshot.create_checkpoint_writer(&engine)?;
 
     // Verify the checkpoint file path is the specified version.
     assert_eq!(
@@ -456,7 +456,7 @@ async fn test_finalize_errors_if_checkpoint_data_iterator_is_not_exhausted() -> 
     let snapshot = Snapshot::builder_for(table_root)
         .at_version(0)
         .build(&engine)?;
-    let writer = snapshot.create_checkpoint_writer()?;
+    let writer = snapshot.create_checkpoint_writer(&engine)?;
     let data_iter = writer.checkpoint_data(&engine)?;
 
     /* The returned data iterator has batches that we do not consume */
@@ -559,7 +559,7 @@ async fn test_v2_checkpoint_supported_table() -> DeltaResult<()> {
 
     let table_root = Url::parse("memory:///")?;
     let snapshot = Snapshot::builder_for(table_root).build(&engine)?;
-    let writer = snapshot.create_checkpoint_writer()?;
+    let writer = snapshot.create_checkpoint_writer(&engine)?;
 
     // Verify the checkpoint file path is the latest version by default.
     assert_eq!(
@@ -648,7 +648,7 @@ async fn test_no_checkpoint_on_unpublished_snapshot() -> DeltaResult<()> {
         .build(&engine)?;
 
     assert!(matches!(
-        snapshot.create_checkpoint_writer().unwrap_err(),
+        snapshot.create_checkpoint_writer(&engine).unwrap_err(),
         crate::Error::Generic(e) if e == "Log segment is not published"
     ));
     Ok(())
@@ -1126,7 +1126,7 @@ async fn test_stats_config_round_trip(
     // The add action for file1.parquet comes from checkpoint 1, so the COALESCE
     // expressions must recover stats across format changes.
     let snapshot2 = Snapshot::builder_for(table_root).build(&engine)?;
-    let writer2 = snapshot2.create_checkpoint_writer()?;
+    let writer2 = snapshot2.create_checkpoint_writer(&engine)?;
     let mut result2 = writer2.checkpoint_data(&engine)?;
 
     // Verify checkpoint 2 schema matches new settings
@@ -1204,7 +1204,7 @@ async fn test_stats_config_round_trip_partitioned(
 
     // Build snapshot that reads from checkpoint 1 + commit 2
     let snapshot2 = Snapshot::builder_for(table_root).build(&engine)?;
-    let writer2 = snapshot2.create_checkpoint_writer()?;
+    let writer2 = snapshot2.create_checkpoint_writer(&engine)?;
     let result2 = writer2.checkpoint_data(&engine)?;
 
     // Collect all checkpoint batches

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -788,8 +788,11 @@ impl Snapshot {
     ///
     /// See the [`crate::checkpoint`] module documentation for more details on checkpoint types
     /// and the overall checkpoint process.
-    pub fn create_checkpoint_writer(self: Arc<Self>) -> DeltaResult<CheckpointWriter> {
-        CheckpointWriter::try_new(self)
+    pub fn create_checkpoint_writer(
+        self: Arc<Self>,
+        engine: &dyn Engine,
+    ) -> DeltaResult<CheckpointWriter> {
+        CheckpointWriter::try_new(self, engine)
     }
 
     /// Creates a [`LogCompactionWriter`] for generating a log compaction file.
@@ -976,7 +979,7 @@ impl Snapshot {
             _ => {}
         }
 
-        let writer = Arc::clone(self).create_checkpoint_writer()?;
+        let writer = Arc::clone(self).create_checkpoint_writer(engine)?;
 
         let write_result = match spec {
             Some(CheckpointSpec::V2(V2CheckpointConfig::WithSidecar {


### PR DESCRIPTION
## What changes are proposed in this pull request?

`CheckpointWriter` had an awkward choreography for creating its output schema along any of several code paths that could trigger its owning `OnceLock`. This lazy/indirect approach complicates the control flow for no good reason -- any caller who bothered to create a checkpoint writer intends to write and will eventually need the output schema. Just compute it directly in the constructor.

While we're at it, simplify several checkpoint writer tests with rstest.

## This PR affects the following public APIs

`Snapshot::create_checkpoint_writer` now takes an `Engine` instance because it may need a domain metadata log replay to get clustering columns.

## How was this change tested?

Existing unit tests cover the code path.