### PR TITLE
fix: specify selection-vector contracts at the engine boundary

### DIFF
--- a/docs/user-guide/src/connector/engine_data.md
+++ b/docs/user-guide/src/connector/engine_data.md
@@ -208,7 +208,7 @@ Key methods:
 | `with_all_rows_selected(data)` | Wrap data with an empty selection vector (all rows kept) |
 | `data()` | Access the underlying `EngineData` |
 | `selection_vector()` | Get the boolean selection vector as `&[bool]` |
-| `apply_selection_vector()` | Applies the filter, removing unselected rows and consuming self |
+| `apply_selection_vector()` | Applies the filter, keeping only selected rows and consuming self |
 | `into_parts()` | Decompose into `(Box<dyn EngineData>, Vec<bool>)`. |
 
 > [!WARNING]

--- a/kernel/src/engine/arrow_data.rs
+++ b/kernel/src/engine/arrow_data.rs
@@ -22,6 +22,7 @@ pub use crate::engine::arrow_utils::fix_nested_null_masks;
 use crate::engine_data::{EngineData, GetData, RowVisitor, StringArrayAccessor};
 use crate::expressions::ArrayData;
 use crate::schema::{ColumnName, DataType, PrimitiveType, SchemaRef};
+use crate::utils::require;
 use crate::{DeltaResult, Error};
 
 /// ArrowEngineData holds an Arrow `RecordBatch`, implements `EngineData` so the kernel can extract
@@ -292,6 +293,14 @@ impl EngineData for ArrowEngineData {
         self: Box<Self>,
         mut selection_vector: Vec<bool>,
     ) -> DeltaResult<Box<dyn EngineData>> {
+        require!(
+            selection_vector.len() <= self.len(),
+            Error::InvalidSelectionVector(format!(
+                "Selection vector is larger than data length: {} > {}",
+                selection_vector.len(),
+                self.len()
+            ))
+        );
         selection_vector.resize(self.len(), true);
         let filtered = filter_record_batch(&self.data, &selection_vector.into())?;
         Ok(Box::new(Self::new(filtered)))
@@ -1767,5 +1776,23 @@ mod tests {
             ]
         );
         Ok(())
+    }
+
+    #[test]
+    fn test_apply_selection_vector_shorter_than_data_keeps_trailing_rows() -> DeltaResult<()> {
+        let data = string_array_to_engine_data(StringArray::from(vec!["a", "b", "c"]));
+        let filtered = data.apply_selection_vector(vec![false])?;
+        let batch = extract_record_batch(filtered.as_ref())?;
+        let column = batch.column(0).as_string::<i32>();
+        let values: Vec<_> = column.iter().flatten().collect();
+        assert_eq!(values, ["b", "c"]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_apply_selection_vector_longer_than_data_returns_error() {
+        let data = string_array_to_engine_data(StringArray::from(vec!["a", "b"]));
+        let result = data.apply_selection_vector(vec![true, true, true]);
+        assert_result_error_with_message(result, "Selection vector is larger than data length");
     }
 }

--- a/kernel/src/engine_data.rs
+++ b/kernel/src/engine_data.rs
@@ -70,11 +70,10 @@ impl FilteredEngineData {
         }
     }
 
-    /// Apply the contained selection vector and return an engine data with only the valid rows
-    /// included. This consumes the `FilteredEngineData`
+    /// Apply the contained selection vector and return an engine data with only the selected rows
+    /// included. This consumes the `FilteredEngineData`.
     pub fn apply_selection_vector(self) -> DeltaResult<Box<dyn EngineData>> {
-        self.data
-            .apply_selection_vector(self.selection_vector.clone())
+        self.data.apply_selection_vector(self.selection_vector)
     }
 }
 
@@ -503,7 +502,7 @@ pub trait RowVisitor {
 ///     todo!() // convert `SchemaRef` and `ArrayData` into local representation and append them
 ///   }
 ///   fn apply_selection_vector(self: Box<Self>, selection_vector: Vec<bool>) -> DeltaResult<Box<dyn EngineData>> {
-///     todo!() // filter out unselected rows and return the new set of data
+///     todo!() // filter out unselected rows; rows beyond the selection vector's end are selected
 ///   }
 ///   fn has_field(&self, name: &ColumnName) -> bool {
 ///     todo!() // determine whether the field exists in the data
@@ -555,9 +554,14 @@ pub trait EngineData: AsAny {
         columns: Vec<ArrayData>,
     ) -> DeltaResult<Box<dyn EngineData>>;
 
-    /// Apply a selection vector to the data and return a data where only the valid rows are
+    /// Apply a selection vector to the data and return a data where only the selected rows are
     /// included. This consumes the EngineData, allowing engines to implement this "in place" if
-    /// desired
+    /// desired.
+    ///
+    /// The selection vector may be shorter than the data; rows beyond its end are selected and
+    /// must be retained (see [`FilteredEngineData`]). An empty selection vector selects all rows.
+    /// A selection vector longer than the data is invalid and must be rejected, e.g. with
+    /// [`Error::InvalidSelectionVector`].
     fn apply_selection_vector(
         self: Box<Self>,
         selection_vector: Vec<bool>,

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -672,9 +672,13 @@ pub trait JsonHandler: AsAny {
         predicate: Option<PredicateRef>,
     ) -> DeltaResult<FileDataReadResultIterator>;
 
-    /// Atomically (!) write a single JSON file. Each row of the input data should be written as a
-    /// new JSON object appended to the file. this write must:
-    /// (1) serialize the data to newline-delimited json (each row is a json object literal)
+    /// Atomically (!) write a single JSON file. Each selected row of the input data must be
+    /// written as a new JSON object appended to the file; rows not selected by a batch's
+    /// selection vector (see [`FilteredEngineData`]) must not be written.
+    /// [`FilteredEngineData::apply_selection_vector`] produces the selected-rows view for
+    /// implementations that do not filter during serialization. This write must:
+    /// (1) serialize the selected rows to newline-delimited json (each row is a json object
+    ///     literal)
     /// (2) write the data to storage atomically (i.e. if the file already exists, fail unless the
     ///     overwrite flag is set)
     ///
@@ -689,9 +693,7 @@ pub trait JsonHandler: AsAny {
     /// # Parameters
     ///
     /// - `path` - URL specifying the location to write the JSON file
-    /// - `data` - Iterator of EngineData to write to the JSON file. Each row should be written as a
-    ///   new JSON object appended to the file. (that is, the file is newline-delimited JSON, and
-    ///   each row is a JSON object on a single line)
+    /// - `data` - Iterator of [`FilteredEngineData`] to write to the JSON file
     /// - `overwrite` - If true, overwrite the file if it exists. If false, the call must fail if
     ///   the file exists.
     fn write_json_file(


### PR DESCRIPTION
## What changes are proposed in this pull request?

Documents the selection-vector contracts at the engine boundary:

- `JsonHandler::write_json_file`: only rows selected by `FilteredEngineData`'s selection vector may be written.
- `EngineData::apply_selection_vector`: a short vector leaves trailing rows selected, an empty vector selects all rows, an over-long vector must be rejected.

Also, `ArrowEngineData::apply_selection_vector` now errors on over-long vectors instead of silently truncating, and `FilteredEngineData::apply_selection_vector` no longer clones the vector.

### This PR affects the following public APIs

`ArrowEngineData::apply_selection_vector` errors on a selection vector longer than the data. Doc-only otherwise.

## How was this change tested?

Unit tests for both sides of the length contract.